### PR TITLE
Field3d - add helpful metadata

### DIFF
--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -200,15 +200,24 @@ Otherwise, the tile size will be the size of the entire volume.
 %\subsubsection*{Attributes}
 \vspace{.125in}
 
-\noindent\begin{tabular}{p{1.6in}|p{0.6in}|p{3.0in}}
+\noindent\begin{tabular}{p{1.8in}|p{0.6in}|p{2.8in}}
 \ImageSpec Attribute & Type & Field3d header data or explanation \\
 \hline
 \qkw{ImageDescription} & string & layer name + ``.'' + attribute name \\
 \qkw{field3d:name} & string & the layer name \\
 \qkw{field3d:attribute} & string & the layer attribute name \\
 \qkw{field3d:fieldtype} & string & field type, one of:
-   \qkw{dense}, \qkw{sparse}, or \qkw{MAC} \\
+   \qkw{DenseField}, \qkw{SparseField}, or \qkw{MACField} \\
+\qkw{field3d:fielddatatype} & string & native data type of the field, as
+   a string, one of: \qkw{half}, \qkw{float}, \qkw{double}. \\
 \qkw{field3d:mapping} & string & the coordinate mapping type \\
+{\small \qkw{field3d:sparseregions}} & float[] & If it's a sparse field, will be
+    a float array of length $6 r$, where $r$ is the number of sparse
+    regions, and each {\cf b[6*i...6*i+5]} contains the bounding box
+    of sparse region $i$ (min x, y, z; max x, y, z), expressed in
+    local coordinates (i.e., 0--1 corresponds to the field extents). \\
+\qkw{field3d:fieldresptr} & pointer & A raw pointer to the FieldRes ---
+    use with extreme caution, if at all! \\
 \qkws{field3d:localtoworld} & matrix of doubles & if a
   matrixMapping, the local-to-world transformation matrix \\
 \qkw{worldtocamera} & matrix & if a matrixMapping, the

--- a/src/doc/imageoutput.tex
+++ b/src/doc/imageoutput.tex
@@ -730,8 +730,7 @@ quantization.
 \smallskip
 \begin{tabular}{|l|r|r|r|r|r|}
 \hline
-{\bf Data Format} & {\bf black} & {\bf white} & {\bf min} & {\bf max}
-} \\
+{\bf Data Format} & {\bf black} & {\bf white} & {\bf min} & {\bf max} \\
 \hline
 {\cf UINT8}  & 0 &        255 &     0 & 255 & 0.5 \\
 {\cf INT8}   & 0 &        127 &  -128 & 127 & 0.5 \\

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -85,7 +85,7 @@
 \date{{\large 
 %Editor: Larry Gritz \\[2ex]
 Date: 29 Dec, 2010
-%\\ (with corrections, 20 Apr, 2010)
+\\ (with corrections, 9 Feb 2010)
 }}
 
 

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -578,6 +578,10 @@ format_raw_metadata (const ImageIOParameter &p)
                 out += ", ";
             for (int c = 0;  c < (int)element.aggregate;  ++c, ++f)
                 out += Strutil::format ("%s%g", (c ? " " : ""), f[0]);
+            if (i >= 15 && n > 1024) {
+                out += Strutil::format (", ...%d more values...", n-i-1);
+                break;
+            }
         }
     } else if (element.basetype == TypeDesc::DOUBLE) {
         const double *f = (const double *)p.data();
@@ -586,6 +590,10 @@ format_raw_metadata (const ImageIOParameter &p)
                 out += ", ";
             for (int c = 0;  c < (int)element.aggregate;  ++c, ++f)
                 out += Strutil::format ("%s%g", (c ? " " : ""), f[0]);
+            if (i >= 15 && n > 1024) {
+                out += Strutil::format (", ...%d more values...", n-i-1);
+                break;
+            }
         }
     } else if (element.basetype == TypeDesc::HALF) {
         const half *f = (const half *)p.data();
@@ -594,25 +602,64 @@ format_raw_metadata (const ImageIOParameter &p)
                 out += ", ";
             for (int c = 0;  c < (int)element.aggregate;  ++c, ++f)
                 out += Strutil::format ("%s%g", (c ? " " : ""), (float)f[0]);
+            if (i >= 15 && n > 1024) {
+                out += Strutil::format (", ...%d more values...", n-i-1);
+                break;
+            }
         }
     } else if (element == TypeDesc::INT) {
-        for (int i = 0;  i < n;  ++i)
+        for (int i = 0;  i < n;  ++i) {
             out += Strutil::format ("%s%d", (i ? ", " : ""), ((const int *)p.data())[i]);
+            if (i >= 15 && n > 1024) {
+                out += Strutil::format (", ...%d more values...", n-i-1);
+                break;
+            }
+        }
     } else if (element == TypeDesc::UINT) {
-        for (int i = 0;  i < n;  ++i)
+        for (int i = 0;  i < n;  ++i) {
             out += Strutil::format ("%s%d", (i ? ", " : ""), ((const unsigned int *)p.data())[i]);
+            if (i >= 15 && n > 1024) {
+                out += Strutil::format (", ...%d more values...", n-i-1);
+                break;
+            }
+        }
     } else if (element == TypeDesc::UINT16) {
-        for (int i = 0;  i < n;  ++i)
+        for (int i = 0;  i < n;  ++i) {
             out += Strutil::format ("%s%u", (i ? ", " : ""), ((const unsigned short *)p.data())[i]);
+            if (i >= 15 && n > 1024) {
+                out += Strutil::format (", ...%d more values...", n-i-1);
+                break;
+            }
+        }
     } else if (element == TypeDesc::INT16) {
-        for (int i = 0;  i < n;  ++i)
+        for (int i = 0;  i < n;  ++i) {
             out += Strutil::format ("%s%d", (i ? ", " : ""), ((const short *)p.data())[i]);
+            if (i >= 15 && n > 1024) {
+                out += Strutil::format (", ...%d more values...", n-i-1);
+                break;
+            }
+        }
     } else if (element == TypeDesc::UINT64) {
-        for (int i = 0;  i < n;  ++i)
+        for (int i = 0;  i < n;  ++i) {
             out += Strutil::format ("%s%llu", (i ? ", " : ""), ((const unsigned long long *)p.data())[i]);
+            if (i >= 15 && n > 1024) {
+                out += Strutil::format (", ...%d more values...", n-i-1);
+                break;
+            }
+        }
     } else if (element == TypeDesc::INT64) {
-        for (int i = 0;  i < n;  ++i)
+        for (int i = 0;  i < n;  ++i) {
             out += Strutil::format ("%s%lld", (i ? ", " : ""), ((const long long *)p.data())[i]);
+            if (i >= 15 && n > 1024) {
+                out += Strutil::format (", ...%d more values...", n-i-1);
+                break;
+            }
+        }
+    } else if (element == TypeDesc::PTR) {
+        for (int i = 0;  i < n;  ++i) {
+            const void *ptr = ((const void **)p.data())[i];
+            out += Strutil::format ("%s%p", (i ? ", " : ""), ptr);
+        }
     } else {
         out += Strutil::format ("<unknown data type> (base %d, agg %d vec %d)",
                 p.type().basetype, p.type().aggregate,


### PR DESCRIPTION
When reading Field3d files, add metadata in the image spec giving the raw FieldRes pointer (use with extreme caution!), the field data type, and the complete lists of SparseField blocks.

Also some minor changes to ImageSpec::format_raw_metadata that allows more graceful printing of pointers and long arrays.  (Helpful when doing something like "iinfo -v foo.f3d" now that this metadata is present.)
