### PR TITLE
Misc dpx enhancements

### DIFF
--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -31,7 +31,6 @@
 #include "libdpx/DPX.h"
 #include "libdpx/DPXColorConverter.h"
 
-#include "dassert.h"
 #include "typedesc.h"
 #include "imageio.h"
 #include "fmath.h"

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -36,7 +36,6 @@
 #include "libdpx/DPX.h"
 #include "libdpx/DPXColorConverter.h"
 
-#include "dassert.h"
 #include "typedesc.h"
 #include "imageio.h"
 #include "fmath.h"
@@ -231,7 +230,7 @@ DPXOutput::open (const std::string &name, const ImageSpec &userspec,
     // calculate target bit depth
     int bitDepth = m_spec.get_int_attribute ("oiio:BitsPerSample",
         m_spec.format.size () * 8);
-    if (bitDepth % 8 != 0 && bitDepth != 10 && bitDepth != 12) {
+    if (bitDepth % 8 != 0 && bitDepth != 10 && bitDepth != 12 && bitDepth != 16) {
         error ("Unsupported bit depth %d", bitDepth);
         return false;
     }

--- a/src/dpx.imageio/libdpx/DPXHeader.cpp
+++ b/src/dpx.imageio/libdpx/DPXHeader.cpp
@@ -473,6 +473,12 @@ int dpx::GenericHeader::ImageElementComponentCount(const int element) const
 
 int dpx::GenericHeader::ImageElementCount() const
 {
+	if(this->numberOfElements>0 && this->numberOfElements<=MAX_ELEMENTS)
+		return this->numberOfElements;
+	
+	// If the image header does not list a valid number of elements,
+	// count how many defined image descriptors we have...
+	
 	int i = 0;
 	
 	while (i < MAX_ELEMENTS )
@@ -488,6 +494,7 @@ int dpx::GenericHeader::ImageElementCount() const
 
 void dpx::GenericHeader::CalculateNumberOfElements()
 {
+	this->numberOfElements = 0xffff;
 	int i = this->ImageElementCount();
 	
 	if (i == 0)

--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -98,7 +98,7 @@ getargs (int argc, char *argv[])
                 "--help", &help, "Print help message",
                 "-v", &verbose, "Verbose status messages",
                 "-d %s", &dataformatname, "Set the output data format to one of:\n"
-                        "\t\t\tuint8, sint8, uint16, sint16, half, float, double",
+                        "\t\t\tuint8, sint8, uint10, uint12, uint16, sint16, half, float, double",
                 "-g %f", &gammaval, "Set gamma correction (default = 1)",
                 "--tile %d %d", &tile[0], &tile[1], "Output as a tiled image",
                 "--scanline", &scanline, "Output as a scanline image",
@@ -225,6 +225,14 @@ adjust_spec (ImageInput *in, ImageOutput *out,
             outspec.set_format (TypeDesc::UINT8);
         else if (dataformatname == "int8")
             outspec.set_format (TypeDesc::INT8);
+        else if (dataformatname == "uint10") {
+            outspec.attribute ("oiio:BitsPerSample", 10);
+            outspec.set_format (TypeDesc::UINT16);
+        }
+        else if (dataformatname == "uint12") {
+            outspec.attribute ("oiio:BitsPerSample", 12);
+            outspec.set_format (TypeDesc::UINT16);
+        }
         else if (dataformatname == "uint16")
             outspec.set_format (TypeDesc::UINT16);
         else if (dataformatname == "int16")


### PR DESCRIPTION
Fixed subtle dpx reading bug where wrong number of image elements were being identified.  Previously this manifested itself as assertion exceptions in debug builds.

iconvert can now specify 10 or 12 bit output types, useful in dpx conversions.
