### PR TITLE
Review: environment API call

### DIFF
--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -810,7 +810,7 @@ plugin.
 \subsection{Shadow Lookups}
 \label{sec:texturesys:api:shadow}
 
-\apiitem{bool {\ce shadow} (ustring filename, TextureOptions \&opt,\\
+\apiitem{bool {\ce shadow} (ustring filename, TextureOpt \&opt,\\
 \bigspc                         const Imath::V3f \&P,\\
 \bigspc                         const Imath::V3f \&dPdx,\\
 \bigspc                         const Imath::V3f \&dPdy,\\

--- a/src/include/texture.h
+++ b/src/include/texture.h
@@ -418,7 +418,7 @@ public:
     ///
     /// Return true if the file is found and could be opened by an
     /// available ImageIO plugin, otherwise return false.
-    virtual bool shadow (ustring filename, TextureOptions &options,
+    virtual bool shadow (ustring filename, TextureOpt &options,
                          const Imath::V3f &P, const Imath::V3f &dPdx,
                          const Imath::V3f &dPdy, float *result) = 0;
 
@@ -437,7 +437,7 @@ public:
     ///
     /// Return true if the file is found and could be opened by an
     /// available ImageIO plugin, otherwise return false.
-    virtual bool environment (ustring filename, TextureOptions &options,
+    virtual bool environment (ustring filename, TextureOpt &options,
                               const Imath::V3f &R, const Imath::V3f &dRdx,
                               const Imath::V3f &dRdy, float *result) = 0;
 

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -165,7 +165,7 @@ public:
 
     /// Retrieve a shadow lookup for a single position P.
     ///
-    virtual bool shadow (ustring filename, TextureOptions &options,
+    virtual bool shadow (ustring filename, TextureOpt &options,
                          const Imath::V3f &P, const Imath::V3f &dPdx,
                          const Imath::V3f &dPdy, float *result) {
         return false;
@@ -184,7 +184,7 @@ public:
 
     /// Retrieve an environment map lookup for direction R.
     ///
-    virtual bool environment (ustring filename, TextureOptions &opt,
+    virtual bool environment (ustring filename, TextureOpt &opt,
                               const Imath::V3f &R, const Imath::V3f &dRdx,
                               const Imath::V3f &dRdy, float *result) {
         return false;


### PR DESCRIPTION
I'm working on finally implementing environment().  No meat to review yet, here's just the API change, I missed switching environment of one point to the new TextureOpt struct, as I did for texture() and texture3d() a while back.
