### PR TITLE
Review: invalidate_all shouldn't close unconditionally

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -2191,7 +2191,6 @@ ImageCacheImpl::invalidate_all (bool force)
             ImageCacheFileRef &f (fileit->second);
             ustring name = f->filename();
             recursive_lock_guard guard (f->m_input_mutex);
-            f->close ();
             if (f->broken() || ! boost::filesystem::exists(name.string())) {
                 all_files.push_back (name);
                 continue;


### PR DESCRIPTION
Only the actually invalidated files should be closed, not all of them.  
I think.  Please pipe up if you can remember a reason why we always closed.
