### PR TITLE
Added NO_DEFAULT_PATH to find_path() and find_library() for FindIlmBase.cmake and FindOpenEXR.cmake

### DIFF
--- a/src/cmake/modules/FindIlmBase.cmake
+++ b/src/cmake/modules/FindIlmBase.cmake
@@ -42,6 +42,7 @@ macro (PREFIX_FIND_INCLUDE_DIR prefix includefile libpath_var)
   find_path(${tmp_varname} ${includefile}
     PATHS ${${libpath_var}}
     PATH_SUFFIXES include
+    NO_DEFAULT_PATH
   )
   if (${tmp_varname})
     mark_as_advanced (${tmp_varname})
@@ -58,11 +59,13 @@ macro (PREFIX_FIND_LIB prefix libname libpath_var liblist_var cachelist_var)
     NAMES ${libname}
     PATHS ${${libpath_var}}
     PATH_SUFFIXES lib
+    NO_DEFAULT_PATH
   )
   find_library(${tmp_prefix}_LIBRARY_DEBUG
     NAMES ${libname}d ${libname}_d ${libname}debug ${libname}_debug
     PATHS ${${libpath_var}}
     PATH_SUFFIXES lib
+    NO_DEFAULT_PATH
   )
   # Properly define ${tmp_prefix}_LIBRARY (cached) and ${tmp_prefix}_LIBRARIES
   select_library_configurations (${tmp_prefix})

--- a/src/cmake/modules/FindOpenEXR.cmake
+++ b/src/cmake/modules/FindOpenEXR.cmake
@@ -40,6 +40,7 @@ macro (PREFIX_FIND_INCLUDE_DIR prefix includefile libpath_var)
   find_path(${tmp_varname} ${includefile}
     PATHS ${${libpath_var}}
     PATH_SUFFIXES include
+    NO_DEFAULT_PATH
   )
   if (${tmp_varname})
     mark_as_advanced (${tmp_varname})
@@ -56,11 +57,13 @@ macro (PREFIX_FIND_LIB prefix libname libpath_var liblist_var cachelist_var)
     NAMES ${libname}
     PATHS ${${libpath_var}}
     PATH_SUFFIXES lib
+    NO_DEFAULT_PATH
   )
   find_library(${tmp_prefix}_LIBRARY_DEBUG
     NAMES ${libname}d ${libname}_d ${libname}debug ${libname}_debug
     PATHS ${${libpath_var}}
     PATH_SUFFIXES lib
+    NO_DEFAULT_PATH
   )
   # Properly define ${tmp_prefix}_LIBRARY (cached) and ${tmp_prefix}_LIBRARIES
   select_library_configurations (${tmp_prefix})


### PR DESCRIPTION
This will now respect ILMBASE_HOME and OPENEXR_HOME as advertised on machines which also have ilmbase and openexr installed locally. ie. With out this we always find things in /usr/include first
