### PR TITLE
Export pugixml symbols from Windows DLL

### DIFF
--- a/src/include/pugiconfig.hpp
+++ b/src/include/pugiconfig.hpp
@@ -34,6 +34,10 @@
 // #define PUGIXML_FUNCTION __fastcall // to set calling conventions to all public functions to fastcall
 // In absence of PUGIXML_CLASS/PUGIXML_FUNCTION definitions PUGIXML_API is used instead
 
+// OIIO: use already defined DLLPUBLIC
+#include "export.h"
+#define PUGIXML_API DLLPUBLIC
+
 #endif
 
 /**


### PR DESCRIPTION
This patch exports pugixml symbols, needed to build OSL on Windows.
