### PR TITLE
Fix build with USE_TBB off (on Windows)

### DIFF
--- a/src/include/thread.h
+++ b/src/include/thread.h
@@ -252,7 +252,7 @@ atomic_exchange_and_add (volatile int *at, int x)
 {
 #if defined(__GNUC__) && defined(_GLIBCXX_ATOMIC_BUILTINS)
     return __sync_fetch_and_add ((int *)at, x);
-#elif defined(USE_TBB)
+#elif USE_TBB
     atomic<int> *a = (atomic<int> *)at;
     return a->fetch_and_add (x);
 #elif defined(__APPLE__)
@@ -273,7 +273,7 @@ atomic_exchange_and_add (volatile long long *at, long long x)
 {
 #if defined(__GNUC__) && defined(_GLIBCXX_ATOMIC_BUILTINS)
     return __sync_fetch_and_add (at, x);
-#elif defined(USE_TBB)
+#elif USE_TBB
     atomic<long long> *a = (atomic<long long> *)at;
     return a->fetch_and_add (x);
 #elif defined(__APPLE__)
@@ -300,7 +300,7 @@ atomic_compare_and_exchange (volatile int *at, int compareval, int newval)
 {
 #if defined(__GNUC__) && defined(_GLIBCXX_ATOMIC_BUILTINS)
     return __sync_bool_compare_and_swap (at, compareval, newval);
-#elif defined(USE_TBB)
+#elif USE_TBB
     atomic<int> *a = (atomic<int> *)at;
     return a->compare_and_swap (newval, compareval) == newval;
 #elif defined(__APPLE__)
@@ -319,7 +319,7 @@ atomic_compare_and_exchange (volatile long long *at, long long compareval, long 
 {
 #if defined(__GNUC__) && defined(_GLIBCXX_ATOMIC_BUILTINS)
     return __sync_bool_compare_and_swap (at, compareval, newval);
-#elif defined(USE_TBB)
+#elif USE_TBB
     atomic<long long> *a = (atomic<long long> *)at;
     return a->compare_and_swap (newval, compareval) == newval;
 #elif defined(__APPLE__)


### PR DESCRIPTION
USE_TBB is set to 0 or 1, not undefined, so some of the tests in thread.h don't work correctly.
