### PR TITLE
Review: one last env fix for shared border latlong

### DIFF
--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -324,7 +324,8 @@ TextureSystemImpl::environment (ustring filename, TextureOpt &options,
 
     const ImageSpec &spec (texturefile->spec(options.subimage, 0));
 
-    options.swrap_func = wrap_periodic;
+    options.swrap_func = texturefile->m_sample_border ?
+        wrap_periodic_sharedborder : wrap_periodic;
     options.twrap_func = wrap_clamp;
     options.envlayout = LayoutLatLong;
     int actualchannels = Imath::clamp (spec.nchannels - options.firstchannel,

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -369,6 +369,7 @@ private:
     static bool wrap_clamp (int &coord, int width);
     static bool wrap_periodic (int &coord, int width);
     static bool wrap_periodic2 (int &coord, int width);
+    static bool wrap_periodic_sharedborder (int &coord, int width);
     static bool wrap_mirror (int &coord, int width);
     static const wrap_impl wrap_functions[];
 

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -144,6 +144,21 @@ bool TextureSystemImpl::wrap_periodic2 (int &coord, int width)
 }
 
 
+bool TextureSystemImpl::wrap_periodic_sharedborder (int &coord, int width)
+{
+    // Like periodic, but knowing that the first column and last are
+    // actually the same position, so we essentially skip the first
+    // column in the next cycle.  We only need this to work for one wrap
+    // in each direction since it's only used for latlong maps.
+    if (coord >= width) {
+        coord = coord - width + 1;
+    } else if (coord < 0) {
+        coord = coord + width - 1;
+    }
+    return true;
+}
+
+
 bool TextureSystemImpl::wrap_mirror (int &coord, int width)
 {
     bool negative = (coord < 0);


### PR DESCRIPTION
Shared border latlong buglet -- when wrapping (as we do for bicubic filtering), you truly need to wrap PAST the shared pixel on the other side.
