### PR TITLE
Review: ImageCache bug fix -- "accept_untiled" wasn't registering properly

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1573,7 +1573,7 @@ ImageCacheImpl::attribute (const std::string &name, TypeDesc type,
     }
     else if (name == "accept_untiled" && type == TypeDesc::INT) {
         int a = *(const int *)val;
-        if (a == m_accept_untiled) {
+        if (a != m_accept_untiled) {
             m_accept_untiled = a;
             do_invalidate = true;
         }

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -72,6 +72,7 @@ static float missing[4] = {-1, 0, 0, 1};
 static float scalefactor = 1.0f;
 static Imath::V3f offset (0,0,0);
 static float scalest = 1.0f;
+static bool nountiled = false;
 void *dummyptr;
 
 
@@ -112,6 +113,7 @@ getargs (int argc, const char *argv[])
                   "--cachesize %f", &cachesize, "Set cache size, in MB",
                   "--scale %f", &scalefactor, "Scale intensities",
                   "--maxfiles %d", &maxfiles, "Set maximum open files",
+                  "--nountiled", &nountiled, "Reject untiled images",
                   "--ctr", &test_construction, "Test TextureOpt construction time",
                   "--offset %f %f %f", &offset[0], &offset[1], &offset[2], "Offset texture coordinates",
                   "--scalest %f", &scalest, "Scale st coordinates",
@@ -524,6 +526,8 @@ main (int argc, const char *argv[])
         texsys->attribute ("max_open_files", maxfiles);
     if (searchpath.length())
         texsys->attribute ("searchpath", searchpath);
+    if (nountiled)
+        texsys->attribute ("accept_untiled", 0);
 
     if (test_construction) {
         Timer t;


### PR DESCRIPTION
Typo caused "accept_untiled" not to be recognized.
