### PR TITLE
Review: minor fixes for clang warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,14 @@ if (NOT WIN32)
     add_definitions ("-Wall")
 endif()
 
+# Disable some warnings for Clang, it's a little too picky with boost
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+    add_definitions ("-Wno-parentheses")
+    add_definitions ("-Wno-char-subscripts")
+    add_definitions ("-Wno-unused-function")
+    add_definitions ("-Wno-overloaded-virtual")
+endif ()
+
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_definitions ("-DDEBUG=1")
 endif ()

--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -54,8 +54,8 @@ class JpgInput : public ImageInput {
     virtual bool open (const std::string &name, ImageSpec &spec);
     virtual bool open (const std::string &name, ImageSpec &spec,
                        const ImageSpec &config);
-    virtual bool seek_subimage (int index, ImageSpec &newspec) {
-        return (index == 0);   // JPEG has only one subimage
+    virtual bool seek_subimage (int index, int miplevel, ImageSpec &newspec) {
+        return (index == 0 && miplevel == 0);   // JPEG has only one subimage
     }
     virtual bool read_native_scanline (int y, int z, void *data);
     virtual bool close ();

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -241,7 +241,7 @@ JpgInput::read_native_scanline (int y, int z, void *data)
         int subimage = current_subimage();
         if (! close ()  ||
             ! open (m_filename, dummyspec)  ||
-            ! seek_subimage (subimage, dummyspec))
+            ! seek_subimage (subimage, 0, dummyspec))
             return false;    // Somehow, the re-open failed
         assert (m_next_scanline == 0 && current_subimage() == subimage);
     }

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -7,6 +7,11 @@ if (APPLE)
 #    set (PYTHON_LIBRARIES /opt/local/lib)
 endif ()
 
+# Disable some warnings for Clang, it's a little too picky with boost
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+    add_definitions ("-Wno-array-bounds")
+endif ()
+
 if ( BOOST_CUSTOM OR Boost_FOUND AND PYTHONLIBS_FOUND)
 
     set (python_srcs py_imageinput.cpp py_imageoutput.cpp

--- a/src/softimage.imageio/softimageinput.cpp
+++ b/src/softimage.imageio/softimageinput.cpp
@@ -63,7 +63,7 @@ private:
     void init ();
     /// Read a scanline from m_fd.
     ///
-    bool read_scanline (void * data);
+    bool read_next_scanline (void * data);
     /// Read uncompressed pixel data from m_fd.
     ///
     bool read_pixels_uncompressed (const softimage_pvt::ChannelPacket & curPacket,
@@ -187,7 +187,7 @@ SoftimageInput::read_native_scanline (int y, int z, void* data)
     bool result = false;
     if (y == (int)m_scanline_markers.size() - 1) {
         // we're up to this scanline
-        result = read_scanline(data);
+        result = read_next_scanline(data);
         
         // save the marker for the next scanline if we haven't got the who images
         if (m_scanline_markers.size() < m_pic_header.height) {
@@ -200,14 +200,14 @@ SoftimageInput::read_native_scanline (int y, int z, void* data)
         fpos_t curPos;
         // Store the ones before this without pulling the pixels
         do {
-            if (!read_scanline(NULL))
+            if (!read_next_scanline(NULL))
                 return false;
             
             fgetpos(m_fd, &curPos);
             m_scanline_markers.push_back(curPos);
         } while ((int)m_scanline_markers.size() <= y);
         
-        result = read_scanline(data);
+        result = read_next_scanline(data);
         fgetpos(m_fd, &curPos);
         m_scanline_markers.push_back(curPos);
     } else {
@@ -220,7 +220,7 @@ SoftimageInput::read_native_scanline (int y, int z, void* data)
             return false;
         }
 
-        result = read_scanline(data);
+        result = read_next_scanline(data);
 
         // If the index isn't complete let's shift the file pointer back to the latest readline
         if (m_scanline_markers.size() < m_pic_header.height) {
@@ -252,7 +252,7 @@ SoftimageInput::close()
 
 
 inline bool
-SoftimageInput::read_scanline (void * data)
+SoftimageInput::read_next_scanline (void * data)
 {
     // Each scanline is stored using one or more channel packets.
     // We go through each of those to pull the data


### PR DESCRIPTION
Fix or suppress warnings that clang prints but gcc never did.
Almost all the ones we suppress are warnings in Boost headers, so we can't fix it on our own.
