### PR TITLE
Added Orient ImageBufAlgo + iprocess command

### DIFF
--- a/src/include/imagebufalgo.h
+++ b/src/include/imagebufalgo.h
@@ -70,6 +70,28 @@ bool DLLPUBLIC fill (ImageBuf &dst,
                      int ybegin, int yend,
                      int zbegin, int zend);
 
+/// Enum describing options to be passed to transform
+
+enum DLLPUBLIC AlignedTransform
+{
+    TRANSFORM_NONE = 0,
+    TRANSFORM_FLIP,        // Upside-down
+    TRANSFORM_FLOP,        // Left/Right Mirrored
+    TRANSFORM_FLIPFLOP,    // Upside-down + Mirrored (Same as 180 degree rotation)
+//  TRANSFORM_ROT90,       // Rotate 90 degrees clockwise. Image remains in positive quadrant.
+//  TRANSFORM_ROT180,      // Rotate 180 degrees clockwise. Image remains in positive quadrant. (Same as FlipFlop)
+//  TRANSFORM_ROT270,      // Rotate 270 degrees clockwise. Image remains in positive quadrant.
+};
+
+/// Transform the image, as specified in the options. All transforms are done
+/// with respect the display winow (full_size / full_origin), though data
+/// outside this area (overscan) is preserved.  This operation does not
+///.filter pixel values; all operations are pixel aligned. In-place operation
+/// (dst == src) is not supported.
+/// return true on success.
+
+bool DLLPUBLIC transform (ImageBuf &dst, const ImageBuf &src, AlignedTransform t);
+
 
 /// Change the number of channels in the specified imagebuf.
 /// This is done by either dropping them, or synthesizing additional ones.

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -25,7 +25,8 @@ set (libOpenImageIO_hdrs ../include/argparse.h
                          ../include/varyingref.h    
                          )
 
-set (libOpenImageIO_srcs formatspec.cpp imagebuf.cpp imagebufalgo.cpp
+set (libOpenImageIO_srcs formatspec.cpp imagebuf.cpp
+                         imagebufalgo.cpp imagebufalgo_orient.cpp
                           imageinput.cpp imageio.cpp imageioplugin.cpp
                           imageoutput.cpp iptc.cpp xmp.cpp 
                           ../libutil/argparse.cpp

--- a/src/libOpenImageIO/imagebufalgo_orient.cpp
+++ b/src/libOpenImageIO/imagebufalgo_orient.cpp
@@ -1,0 +1,178 @@
+/*
+  Copyright 2008 Larry Gritz and the other authors and contributors.
+  All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the software's owners nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  (This is the Modified BSD License)
+*/
+
+#include <OpenEXR/ImathFun.h>
+#include <OpenEXR/half.h>
+
+#include <iostream>
+#include <limits>
+
+#include "imagebuf.h"
+#include "imagebufalgo.h"
+#include "dassert.h"
+#include <stdexcept>
+
+OIIO_NAMESPACE_ENTER
+{
+namespace
+{
+
+bool
+TransformImageSpec(ImageSpec & spec, ImageBufAlgo::AlignedTransform t)
+{
+    
+    if (t == ImageBufAlgo::TRANSFORM_NONE) {
+        return true;
+    }
+    else if (t == ImageBufAlgo::TRANSFORM_FLIP) {
+        spec.y = spec.full_y + spec.full_height - spec.y - spec.height;
+    }
+    else if (t == ImageBufAlgo::TRANSFORM_FLOP) {
+        spec.x = spec.full_x + spec.full_width - spec.x - spec.width;
+    }
+    else if (t == ImageBufAlgo::TRANSFORM_FLIPFLOP) {
+        spec.x = spec.full_x + spec.full_width - spec.x - spec.width;
+        spec.y = spec.full_y + spec.full_height - spec.y - spec.height;
+    }
+    else {
+        return false;
+    }
+    
+    return true;
+}
+
+// FIXME: Reorganize these to use iterators, at the native bit type.
+// This does a needless conversion to float and back (per pixel)
+
+// FIXME: These works for non-zero data windows, but
+// does it work for non-origin display windows?
+
+void
+FlipImageData (ImageBuf &dst, const ImageBuf &src)
+{
+    const ImageSpec & spec = dst.spec();
+    const int c0 = spec.full_y + spec.full_height - 1;
+    
+    std::vector<float> pixel (dst.spec().nchannels, 0.0f);
+    
+    // Walk though the output data window...
+    for (int k = spec.z; k < spec.z+spec.depth; k++) {
+        for (int j = spec.y; j < spec.y+spec.height; j++) {
+            int jIn = c0 - j;
+            
+            for (int i = spec.x; i < spec.x+spec.width ; i++) {
+                src.getpixel (i, jIn, k, &pixel[0]);
+                dst.setpixel (i, j, k, &pixel[0]);
+            }
+        }
+    }
+}
+
+void
+FlopImageData (ImageBuf &dst, const ImageBuf &src)
+{
+    const ImageSpec & spec = dst.spec();
+    const int c1 = spec.full_x + spec.full_width - 1;
+    
+    std::vector<float> pixel (dst.spec().nchannels, 0.0f);
+    
+    // Walk though the output data window...
+    for (int k = spec.z; k < spec.z+spec.depth; k++) {
+        for (int j = spec.y; j < spec.y+spec.height; j++) {
+            for (int i = spec.x; i < spec.x+spec.width ; i++) {
+                int iIn = c1 - i;
+                src.getpixel (iIn, j, k, &pixel[0]);
+                dst.setpixel (i, j, k, &pixel[0]);
+            }
+        }
+    }
+}
+
+void
+FlipFlopImageData (ImageBuf &dst, const ImageBuf &src)
+{
+    const ImageSpec & spec = dst.spec();
+    const int c0 = spec.full_y + spec.full_height - 1;
+    const int c1 = spec.full_x + spec.full_width - 1;
+    
+    std::vector<float> pixel (dst.spec().nchannels, 0.0f);
+    
+    // Walk though the output data window...
+    for (int k = spec.z; k < spec.z+spec.depth; k++) {
+        for (int j = spec.y; j < spec.y+spec.height; j++) {
+            int jIn = c0 - j;
+            for (int i = spec.x; i < spec.x+spec.width ; i++) {
+                int iIn = c1 - i;
+                src.getpixel (iIn, jIn, k, &pixel[0]);
+                dst.setpixel (i, j, k, &pixel[0]);
+            }
+        }
+    }
+}
+
+} // Anonymous Namespace
+
+
+
+bool
+ImageBufAlgo::transform (ImageBuf &dst, const ImageBuf &src, AlignedTransform t)
+{
+    if (t == TRANSFORM_NONE) {
+        dst = src;
+        return true;
+    }
+    
+    ImageSpec dst_spec (src.spec());
+    if(!TransformImageSpec(dst_spec, t)) {
+        return false;
+    }
+    
+    // Update the image (realloc with the new spec)
+    dst.alloc (dst_spec);
+    
+    if (t == TRANSFORM_FLIP) {
+        FlipImageData (dst, src);
+        return true;
+    }
+    else if (t == TRANSFORM_FLOP) {
+        FlopImageData (dst, src);
+        return true;
+    }
+    else if (t == TRANSFORM_FLIPFLOP) {
+        FlipFlopImageData (dst, src);
+        return true;
+    }
+    
+    return false;
+}
+
+
+}
+OIIO_NAMESPACE_EXIT


### PR DESCRIPTION
We have the need to batch re-orient a bunch of images, and iprocess seems like a good fit. This commit also adds the orient command to ImageBufAlgo.

Known issues:
- I have not validated this on images with display windows not at the origin. We do not use such images at SPI, so I need to find a way to create an example + reference answer. I _have_ validated this working with crop windows + overscan, that works great.
- rotations are left unimplemented for now, I hope to get to these soon.

This also raises the issue of iprocess vs. iconvert.  I'd expect openimageio to have some sort of command-line utility that can perform a chain of processing operations.  I.e., color convert + crop + orient, etc.  But neither tool appears to support this.  What's the long term plan for both of these? Which should we put the love into?

iconvert appears to already have an orientation support, but it looks like this is just some sort of jpg metadata thing.  Am I correct, or is all this work duplicated?  I'd probably like to demote the orientation metadata command in iconvert to an alternate name, and make this the native orient processing.
