### PR TITLE
Review: "accept_unmipped" ImageCache/TextureSystem option

### DIFF
--- a/src/doc/imagecache.tex
+++ b/src/doc/imagecache.tex
@@ -318,6 +318,14 @@ This is sometimes helpful for applications that want to enforce use of
 tiled images only.
 \apiend
 
+\apiitem{int accept_unmipped}
+When nonzero (the default), \ImageCache accepts un-MIPmapped images as
+usual.  When set to zero, \ImageCache will reject un-MIPmapped images with
+an error condition, as if the file could not be properly read.
+This is sometimes helpful for applications that want to enforce use of
+MIP-mapped images only.
+\apiend
+
 \apiitem{int failure_retries}
 When an {\cf open()} or {\cf read_tile()} calls fails, pause and try
 again, up to {\cf failure_retries} times before truly returning a

--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -528,6 +528,7 @@ string searchpath \\
 int autotile \\
 int automip \\
 int accept_untiled \\
+int accept_unmipped \\
 int failure_retries}
 
 These attributes are all passed along to the underlying \ImageCache that

--- a/src/include/imagecache.h
+++ b/src/include/imagecache.h
@@ -88,6 +88,7 @@ public:
     ///     int automip : if nonzero, emulate mipmap on the fly
     ///     int accept_untiled : if nonzero, accept untiled images, but
     ///                          if zero, reject untiled images (default=1)
+    ///     int accept_unmipped : if nonzero, accept unmipped images (def=1)
     ///     int statistics:level : verbosity of statistics auto-printed.
     ///     int forcefloat : if nonzero, convert all to float.
     ///     int failure_retries : number of times to retry a read before fail.

--- a/src/include/texture.h
+++ b/src/include/texture.h
@@ -329,6 +329,9 @@ public:
     ///     matrix44 commontoworld : the common-to-world transformation
     ///     int autotile : if >0, tile size to emulate for non-tiled images
     ///     int automip : if nonzero, emulate mipmap on the fly
+    ///     int accept_untiled : if nonzero, accept untiled images
+    ///     int accept_unmipped : if nonzero, accept unmipped images
+    ///     int failure_retries : how many times to retry a read failure
     ///
     virtual bool attribute (const std::string &name, TypeDesc type, const void *val) = 0;
     // Shortcuts for common types

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -636,6 +636,7 @@ public:
     bool automip () const { return m_automip; }
     bool forcefloat () const { return m_forcefloat; }
     bool accept_untiled () const { return m_accept_untiled; }
+    bool accept_unmipped () const { return m_accept_unmipped; }
     int failure_retries () const { return m_failure_retries; }
     void get_commontoworld (Imath::M44f &result) const {
         result = m_Mc2w;
@@ -900,6 +901,7 @@ private:
     bool m_automip;              ///< auto-mipmap on demand?
     bool m_forcefloat;           ///< force all cache tiles to be float
     bool m_accept_untiled;       ///< Accept untiled images?
+    bool m_accept_unmipped;      ///< Accept unmipped images?
     bool m_read_before_insert;   ///< Read tiles before adding to cache?
     int m_failure_retries;       ///< Times to re-try disk failures
     Imath::M44f m_Mw2c;          ///< world-to-"common" matrix

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -74,6 +74,7 @@ static float scalefactor = 1.0f;
 static Imath::V3f offset (0,0,0);
 static float scalest = 1.0f;
 static bool nountiled = false;
+static bool nounmipped = false;
 void *dummyptr;
 
 
@@ -116,6 +117,7 @@ getargs (int argc, const char *argv[])
                   "--scale %f", &scalefactor, "Scale intensities",
                   "--maxfiles %d", &maxfiles, "Set maximum open files",
                   "--nountiled", &nountiled, "Reject untiled images",
+                  "--nounmipped", &nounmipped, "Reject unmipped images",
                   "--ctr", &test_construction, "Test TextureOpt construction time",
                   "--offset %f %f %f", &offset[0], &offset[1], &offset[2], "Offset texture coordinates",
                   "--scalest %f", &scalest, "Scale st coordinates",
@@ -558,6 +560,8 @@ main (int argc, const char *argv[])
         texsys->attribute ("searchpath", searchpath);
     if (nountiled)
         texsys->attribute ("accept_untiled", 0);
+    if (nounmipped)
+        texsys->attribute ("accept_unmipped", 0);
 
     if (test_construction) {
         Timer t;


### PR DESCRIPTION
ImageCache/TextureSystem attribute "accept_unmipped", when set to zero, will treat any un-MIPmapped file as an error (analogous to accept_untiled).
