### PR TITLE
compile fixed with boost 1.46.0

### DIFF
--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -1746,6 +1746,8 @@ ImageViewer::closeImg()
     current_image (current_image() < (int)m_images.size() ? current_image() : 0);
 }
 
+
+
 void
 ImageViewer::print()
 {

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -275,13 +275,11 @@ catalog_all_plugins (std::string searchpath)
         for (boost::filesystem::directory_iterator itr (dir);
               itr != end_itr;  ++itr) {
             std::string full_filename = itr->path().string();
-            
-            #if BOOST_FILESYSTEM_VERSION == 3
-                std::string leaf = itr->path().leaf().string();
-            #else
-                std::string leaf = itr->path().leaf();
-            #endif
-                
+#if BOOST_FILESYSTEM_VERSION == 3
+    std::string leaf = itr->path().leaf().string();
+#else
+    std::string leaf = itr->path().leaf();
+#endif
             size_t found = leaf.find (pattern);
             if (found != std::string::npos &&
                 (found == leaf.length() - patlen)) {


### PR DESCRIPTION
Hello,

I want to take part in oio development in Google summer of code 2011 and not only. This is my first little patch (further there are will be greater :) ) 

This patch fix compiling with boost 1.46.0 Today i try to compile oio from source and get error:

/home/shk/OpenImageIO-oiio-82db2e5/src/libOpenImageIO/imageioplugin.cpp: In function ‘void OpenImageIO::v0::    <unnamed>::catalog_all_plugins(std::string)’:
make[2]: **\* [libOpenImageIO/CMakeFiles/OpenImageIO.dir/imageioplugin.cpp.o] Error 1

This patch fixed this trouble. 

Thank you.
