### PR TITLE
file path encoded fixed

### DIFF
--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -1349,13 +1349,13 @@ ImageViewer::slideNoLoop ()
 static bool
 compName (IvImage *first, IvImage *second)
 {
-    #if BOOST_FILESYSTEM_VERSION == 3
-        std::string firstFile = boost::filesystem3::path(first->name()).leaf().string();
-        std::string secondFile = boost::filesystem3::path(second->name()).leaf().string();
-    #else
-        std::string firstFile = boost::filesystem::path(first->name()).leaf();
-        std::string secondFile = boost::filesystem::path(second->name()).leaf();
-    #endif
+#if BOOST_FILESYSTEM_VERSION == 3
+    std::string firstFile = boost::filesystem3::path(first->name()).leaf().string();
+    std::string secondFile = boost::filesystem3::path(second->name()).leaf().string();
+#else
+    std::string firstFile = boost::filesystem::path(first->name()).leaf();
+    std::string secondFile = boost::filesystem::path(second->name()).leaf();
+#endif
     
     return (firstFile.compare(secondFile) < 0);
 }
@@ -1985,7 +1985,7 @@ void ImageViewer::fullScreenToggle()
     } else {
         menuBar()->hide ();
         statusBar()->hide ();
-        showFullScreen ();   
+        showFullScreen ();
         m_fullscreen = true;
         fitImageToWindow ();
     }


### PR DESCRIPTION
If in the file path there are not latin symbol, that's file couldn't be opened. Now it's fixed.
