### PR TITLE
maketx: --oiio enables hash generation

### DIFF
--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -292,6 +292,9 @@ set_oiio_options(TypeDesc out_dataformat)
     // Enable constant color optimizations
     constant_color_detect = true;
     
+    // Always embed the image hash info
+    embed_hash = true;
+    
     // Force fixed tile-size across the board
     tile[0] = 64;
     tile[1] = 64;


### PR DESCRIPTION
As oiio's texture engine supports duplicate texture detection using the sha-1 hash,
it seems most appropriate for maketx in -oiio mode to enable this optimization by
default.  (I thought we had made this change weeks ago, actually. Not including
it was an oversight).

Appropriate for merging into 0.9 as well.
