### PR TITLE
Review: Improve reading of unassociated alpha

### DIFF
--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -764,8 +764,6 @@ metadata if present.
 \qkw{Model} & string & Model \\
 \qkw{DocumentName} & string & DocumentName \\
 \qkw{HostComputer} & string & HostComputer \\
-\qkw{oiio:BitsPerSample} & int & The actual bits per sample in the file (may
-  differ from {\cf ImageSpec::format}).\\
 \qkws{XResultion} \qkws{YResolution} & float & XResolution, YResolution \\
 \qkws{ResolutionUnit} & string & ResolutionUnit (\qkw{in} or
   \qkw{cm}). \\
@@ -786,10 +784,13 @@ metadata if present.
 \qkw{tiff:PageName} & string & PageName \\
 \qkw{tiff:PageNumber} & int & PageNumber \\
 \qkw{tiff:RowsPerStrip} & int & RowsPerStrip \\
-
 \qkw{tiff:subfiletype} & 1 & SubfileType \\
 \qkw{Exif:*} & & A wide variety of EXIF data are honored, and are all prefixed
   with \qkw{Exif:}.\\
+\qkw{oiio:BitsPerSample} & int & The actual bits per sample in the file (may
+  differ from {\cf ImageSpec::format}).\\
+\qkw{oiio:UnassociatedAlpha} & int & Nonzero if the alpha channel
+  contained ``unassociated'' alpha. \\
 \end{tabular}
 
 \subsubsection*{Limitations}

--- a/src/doc/stdmetadata.tex
+++ b/src/doc/stdmetadata.tex
@@ -109,6 +109,12 @@ be 4 but the {\cf format} field may be {\cf TypeDesc::UINT8} (because
 the \product APIs do not support fewer than 8 bits per sample).
 \apiend
 
+\apiitem{"oiio:UnassociatedAlpha" : int}
+Whether the data in the file stored alpha channels (if any) that were
+unassociated with the color (i.e., color not ``premultiplied'' by the
+alpha coverage value).
+\apiend
+
 \apiitem{"planarconfig" : string}
 \qkw{contig} indicates that the file has contiguous pixels (RGB RGB
 RGB...), whereas \qkw{separate} indicate that the file stores each

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -212,6 +212,9 @@ read_info (png_structp& sp, png_infop& ip, int& bit_depth, int& color_type,
 
     interlace_type = png_get_interlace_type (sp, ip);
 
+    // PNG files are always "unassociated alpha"
+    spec.attribute ("oiio:UnassociatedAlpha", (int)1);
+
     // FIXME -- look for an XMP packet in an iTXt chunk.
 }
 


### PR DESCRIPTION
Per discussions on oiio-dev, this patch by Carl Rand (with minor touchups by myself) establishes the convention that readers should now set "oiio:UnassociatedAlpha" to signal whether the file had unassociated alpha, and accept the same tag to 'open with config' where nonzero means to preserve the unassociated alpha value.  The TIFF and PNG readers have been modified in this way; I think they are the only two for which this issue applies at the moment.

At this time, I have not yet modified the writers to pass unassociated alpha through unaltered, there's a bit more to work out.  I thought maybe we'd commit the readers first.  I _think_ the right approach is that the writer ought to assume it's being passed an associated alpha buffer unless it sees the "oiio:UnassociatedAlpha" present and nonzero, which would mean that the user's buffer is unassociated.  The thing that makes this straightforward is that the reader sets it whether or not it corrects, which would make 'iconvert' not idempotent.  I think the solutions are one of: (1) writers always assume they are passed associated alpha, that's the only way we swing; (2) readers only set "oiio:UnassociatedAlpha" if they found unassociated alpha and DID NOT convert it to associated; or (3) differently named options for reading and writing.  Opinions wanted.  We essentially have #1 implemented now, and I'd support #2 + make the writers conform if that's what people want.
