### PR TITLE
libdpx accumulated line offset fix (aka RGBA support)

### DIFF
--- a/src/dpx.imageio/libdpx/ReaderInternal.h
+++ b/src/dpx.imageio/libdpx/ReaderInternal.h
@@ -141,12 +141,12 @@ namespace dpx
 			int actline = line + block.y1;
 
 			// first get line offset
-			long offset = (actline) * dpxHeader.Width() * numberOfComponents;
+			long offset = actline * datums;
 			
 			// add in the accumulated round-up offset - the following magical formula is
 			// just an unrolling of a loop that does the same work in constant time:
-			// for (int i = 1; i <= (line + block.y1); ++i)
-			//     offset += (i * dpxHeader.Width() * numberOfComponents) % 3;
+			// for (int i = 1; i <= actline; ++i)
+			//     offset += (i * datums) % 3;
 			offset += datums % 3 * ((actline + 2) / 3) + (3 - datums % 3) % 3 * ((actline + 1) / 3);
 			
 			// round up to the 32-bit boundary


### PR DESCRIPTION
Addressing #29. Also replaced the previously introduced loop with a constant-time expression.
