### PR TITLE
Remove memcmp as it can cause false positive warnings from Valgrind

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1761,7 +1761,7 @@ ImageCacheImpl::find_tile_main_cache (const TileID &id, ImageCacheTileRef &tile,
     tile = new ImageCacheTile (id, thread_info, m_read_before_insert);
     // N.B. the ImageCacheTile ctr starts the tile out as 'used'
     DASSERT (tile);
-    DASSERT (id == tile->id() && !memcmp(&id, &tile->id(), sizeof(TileID)));
+    DASSERT (id == tile->id());
     double readtime = timer();
     stats.fileio_time += readtime;
     id.file().iotime() += readtime;


### PR DESCRIPTION
This happens because the TileID struct contains padding on 64 bit
architectures which Valgrind will detect as un-initialized memory
