### PR TITLE
Review: TextureSystem option 'latlong_up'

### DIFF
--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -571,6 +571,13 @@ The default value of zero means that all missing channels will get
 the ``fill'' color.
 \apiend
 
+\apiitem{string latlong_up}
+Sets the default ``up'' direction for latlong environment maps (only
+applies if the map itself doesn't specify a format or is in a format
+that explicitly requires a particular orientation).  The default is
+\qkw{y}.  (Currently any other value will result in $z$ being ``up.'')
+\apiend
+
 
 \subsection{Opaque data for performance lookups}
 \label{sec:texturesys:api:opaque}

--- a/src/include/texture.h
+++ b/src/include/texture.h
@@ -333,6 +333,7 @@ public:
     ///     int accept_unmipped : if nonzero, accept unmipped images
     ///     int failure_retries : how many times to retry a read failure
     ///     int gray_to_rgb : make 1-channel images fill RGB lookups
+    ///     string latlong_up : default "up" direction for latlong ("y")
     ///
     virtual bool attribute (const std::string &name, TypeDesc type, const void *val) = 0;
     // Shortcuts for common types

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -638,6 +638,7 @@ public:
     bool accept_untiled () const { return m_accept_untiled; }
     bool accept_unmipped () const { return m_accept_unmipped; }
     int failure_retries () const { return m_failure_retries; }
+    bool latlong_y_up_default () const { return m_latlong_y_up_default; }
     void get_commontoworld (Imath::M44f &result) const {
         result = m_Mc2w;
     }
@@ -904,6 +905,7 @@ private:
     bool m_accept_unmipped;      ///< Accept unmipped images?
     bool m_read_before_insert;   ///< Read tiles before adding to cache?
     int m_failure_retries;       ///< Times to re-try disk failures
+    bool m_latlong_y_up_default; ///< Is +y the default "up" for latlong?
     Imath::M44f m_Mw2c;          ///< world-to-"common" matrix
     Imath::M44f m_Mc2w;          ///< common-to-world matrix
 


### PR DESCRIPTION
Previous behavior was that OpenEXR latlong maps and any others that explicitly knew that y should be "up" behaved as such, but the default was for +z to be "up" for latlong lookups.

This patch makes the default settable by an option ("latlong_up") and also changes its default to "y", so that unless overriden, all maps are assumed to have the same orientation as OpenEXR environment maps (which we think is the common convention anyway). 
