### PR TITLE
Added filter.h to public headers

### DIFF
--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -1,5 +1,5 @@
 set (public_headers argparse.h dassert.h errorhandler.h export.h 
-                    filesystem.h fmath.h hash.h
+                    filesystem.h filter.h fmath.h hash.h
                     imagebuf.h imagebufalgo.h 
                     imagecache.h imageio.h osdep.h paramlist.h
                     refcnt.h strutil.h sysutil.h texture.h thread.h timer.h


### PR DESCRIPTION
Other apps which want to replicate the functionality of maketx externally, couldn't, because filter.h was private. This fixes it.
