### PR TITLE
Add support for WebP file format

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -199,6 +199,10 @@ oiio_add_tests (fits
     IMAGEDIR fits-images
     URL http://www.cv.nrao.edu/fits/data/tests/)
 
+oiio_add_tests (webp
+    IMAGEDIR webp-images
+    URL http://code.google.com/speed/webp/gallery.html)
+
 #########################################################################
 # Packaging
 set (CPACK_PACKAGE_VERSION_MAJOR ${OIIO_VERSION_MAJOR})

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -237,3 +237,25 @@ endif ()
 # end Field3d setup
 ###########################################################################
 
+###########################################################################
+# WebP setup
+    message (STATUS "WEBP_HOME=${WEBP_HOME}")
+    find_path (WEBP_INCLUDE_DIR webp/encode.h
+               ${THIRD_PARTY_TOOLS}/include
+               ${PROJECT_SOURCE_DIR}/include  
+               ${WEBP_HOME}/)
+    find_library (WEBP_LIBRARY
+                  NAMES webp
+                  PATHS ${THIRD_PARTY_TOOLS_HOME}/lib/
+                  ${WEBP_HOME}/
+                 )
+    if (WEBP_INCLUDE_DIR AND WEBP_LIBRARY)
+        set (WEBP_FOUND TRUE)
+        message (STATUS "WEBP includes = ${WEBP_INCLUDE_DIR} ")
+        message (STATUS "WEBP library = ${WEBP_LIBRARY} ")
+    else()
+        set (WEBP_FOUND FALSE)
+        message (STATUS "WebP library not found")
+    endif()
+# end Webp setup
+###########################################################################

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -152,6 +152,18 @@ if (EMBEDPLUGINS)
         set (FIELD3D_LIBRARY "")
         set (HDF5_LIBRARIES "")
     endif ()
+
+    if (WEBP_FOUND)
+        set (libOpenImageIO_srcs ${libOpenImageIO_srcs}
+             ../webp.imageio/webpinput.cpp
+             ../webp.imageio/webpoutput.cpp
+            )
+        include_directories (${WEBP_INCLUDE_DIR})
+        add_definitions ("-DUSE_WEBP=1")
+    else ()
+        message (STATUS "WebP plugin will not be built")
+        set (WEBP_LIBRARY "")
+    endif ()
 endif ()
 
 if (BUILDSTATIC)
@@ -171,6 +183,7 @@ if (EMBEDPLUGINS)
                                ${JASPER_LIBRARY}
                                ${FIELD3D_LIBRARY}
                                ${HDF5_LIBRARIES}
+                               ${WEBP_LIBRARY}
                           )
     link_openexr (OpenImageIO)
 endif ()

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -199,6 +199,7 @@ catalog_plugin (const std::string &format_name,
     PLUGENTRY (softimage);
     PLUGENTRY (tiff);
     PLUGENTRY (targa);
+    PLUGENTRY (webp);
     PLUGENTRY (zfile);
 
 
@@ -249,6 +250,9 @@ catalog_builtin_plugins ()
     DECLAREPLUG (softimage);
     DECLAREPLUG (tiff);
     DECLAREPLUG (targa);
+#ifdef USE_WEBP
+    DECLAREPLUG (webp);
+#endif
     DECLAREPLUG (zfile);
 #endif
 }

--- a/src/webp.imageio/CMakeLists.txt
+++ b/src/webp.imageio/CMakeLists.txt
@@ -1,0 +1,5 @@
+if (WEBP_FOUND)
+    add_oiio_plugin (webpinput.cpp jwebpoutput.cpp LINK_LIBRARIES ${WEBP_LIBRARY})
+endif()
+
+

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -1,0 +1,150 @@
+/*
+  Copyright 2011 Larry Gritz and the other authors and contributors.
+  All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the software's owners nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  (This is the Modified BSD License)
+*/
+#include <cstdio>
+#include <webp/decode.h>
+#include "imageio.h"
+#include "fmath.h"
+
+OIIO_PLUGIN_NAMESPACE_BEGIN
+
+namespace webp_pvt {
+
+
+class WebpInput : public ImageInput
+{
+ public:
+    WebpInput() { init(); }
+    virtual ~WebpInput() { close(); }
+    virtual const char* format_name() const { return "webp"; }
+    virtual bool open (const std::string &name, ImageSpec &spec);
+    virtual bool read_native_scanline (int y, int z, void *data);
+    virtual bool close ();
+
+ private:
+    std::string m_filename;
+    uint8_t *m_decoded_image;
+    long int m_image_size;
+    long int m_scanline_size;
+    FILE *m_file;
+
+    void init()
+    {
+        m_image_size = m_scanline_size = 0;
+        m_decoded_image = NULL;
+        m_file = NULL;
+    }
+};
+
+
+bool
+WebpInput::open (const std::string &name, ImageSpec &spec)
+{
+    m_filename = name;
+
+    m_file = fopen(m_filename.c_str(), "rb");
+    if (!m_file)
+    {
+        error ("Could not open file \"%s\"", m_filename.c_str());
+        return false;
+    }
+
+    fseek (m_file, 0, SEEK_END);
+    m_image_size = ftell(m_file);
+    fseek (m_file, 0, SEEK_SET);
+
+    std::vector<uint8_t> encoded_image;
+    encoded_image.resize(m_image_size, 0);
+    fread(&encoded_image[0], sizeof(uint8_t), encoded_image.size(), m_file);
+
+    int width = 0, height = 0;
+    if(!WebPGetInfo(&encoded_image[0], encoded_image.size(), &width, &height))
+    {
+        error ("%s is not a WebP image file", m_filename.c_str());
+        close();
+        return false;
+    }
+
+    const int CHANNEL_NUM = 4;
+    m_scanline_size = width * CHANNEL_NUM;
+    m_spec = ImageSpec(width, height, CHANNEL_NUM, TypeDesc::UINT8);
+    spec = m_spec;
+
+    if (!(m_decoded_image = WebPDecodeRGBA(&encoded_image[0], encoded_image.size(), &m_spec.width, &m_spec.height)))
+    {
+        error ("Couldn't decode %s", m_filename.c_str());
+        close();
+        return false;
+    }
+    return true;
+}
+
+
+bool
+WebpInput::read_native_scanline (int y, int z, void *data)
+{
+    if (y < 0 || y >= m_spec.width)   // out of range scanline
+        return false;
+    memcpy(data, &m_decoded_image[y*m_scanline_size], m_scanline_size);
+    return true;    
+}
+
+
+bool
+WebpInput::close()
+{
+    if (m_file)
+    {
+        fclose(m_file);
+        m_file = NULL;
+    }
+    if (m_decoded_image)
+    {
+        free(m_decoded_image); // this was allocated by WebPDecodeRGB and should be fread by free
+        m_decoded_image = NULL;
+    }
+    return true;
+}
+
+} // namespace webp_pvt
+
+// Obligatory material to make this a recognizeable imageio plugin
+OIIO_PLUGIN_EXPORTS_BEGIN
+
+    DLLEXPORT int webp_imageio_version = OIIO_PLUGIN_VERSION;
+    DLLEXPORT ImageInput *webp_input_imageio_create () {
+        return new webp_pvt::WebpInput;
+    }
+    DLLEXPORT const char *webp_input_extensions[] = {
+        "webp", NULL
+    };
+
+OIIO_PLUGIN_EXPORTS_END
+
+OIIO_PLUGIN_NAMESPACE_END

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -1,0 +1,197 @@
+/*
+  Copyright 2011 Larry Gritz and the other authors and contributors.
+  All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the software's owners nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  (This is the Modified BSD License)
+*/
+#include <cstdio>
+#include <webp/encode.h>
+#include "imageio.h"
+
+OIIO_PLUGIN_NAMESPACE_BEGIN
+
+namespace webp_pvt {
+
+
+class WebpOutput : public ImageOutput
+{
+ public:
+    WebpOutput(){ init(); }
+    virtual ~WebpOutput(){ close(); }
+    virtual const char* format_name () const { return "webp"; }
+    virtual bool open (const std::string &name, const ImageSpec &spec,
+                       OpenMode mode=Create);
+    virtual bool supports (const std::string &property) const { return false; }
+    virtual bool write_scanline (int y, int z, TypeDesc format,
+                                 const void *data, stride_t xstride);
+    virtual bool close();
+
+ private:
+    WebPPicture m_webp_picture;
+    WebPConfig m_webp_config;
+    std::string m_filename;
+    FILE *m_file;
+    int m_scanline_size;
+    std::vector<uint8_t> m_uncompressed_image;
+
+    void init()
+    {
+        m_scanline_size = 0;
+        m_file = NULL;
+    }
+};
+
+
+static int WebpImageWriter(const uint8_t* img_data, size_t data_size,
+                           const WebPPicture* const webp_img)
+{
+    FILE *out_file = (FILE*)webp_img->custom_ptr;
+    fwrite (img_data, data_size, sizeof(uint8_t), out_file);
+    return 1;
+}
+
+
+
+bool
+WebpOutput::open (const std::string &name, const ImageSpec &spec,
+                 OpenMode mode)
+{
+    if (mode != Create) {
+        error ("%s does not support subimages or MIP levels", format_name());
+        return false;
+    }
+
+    // saving 'name' and 'spec' for later use
+    m_filename = name;
+    m_spec = spec;
+
+    m_file = fopen (m_filename.c_str (), "wb");
+    if (!m_file) {
+        error ("Unable to open file \"%s\"", m_filename.c_str ());
+        return false;
+    }
+
+    if (!WebPPictureInit(&m_webp_picture))
+    {
+        error("Couldn't initialize WebPPicture\n");
+        close();
+        return false;
+    }
+
+    m_webp_picture.width = m_spec.width;
+    m_webp_picture.height = m_spec.height;
+    m_webp_picture.writer = WebpImageWriter;
+    m_webp_picture.custom_ptr = (void*)m_file;
+
+    if (!WebPConfigInit(&m_webp_config))
+    {
+        error("Couldn't initialize WebPPicture\n");
+        close();
+        return false;
+    }
+
+    m_webp_config.method = 6;
+    int compression_quality = 100;
+    const ImageIOParameter *qual = m_spec.find_attribute ("CompressionQuality",
+                                                          TypeDesc::INT);
+    if (qual)
+    {
+        compression_quality = *static_cast<const int*>(qual->data());
+    }
+    m_webp_config.quality = compression_quality;
+    
+    // forcing UINT8 format
+    m_spec.set_format (TypeDesc::UINT8);
+
+    m_scanline_size = m_spec.width * m_spec.nchannels;
+    const int image_buffer = m_spec.height * m_scanline_size;
+    m_uncompressed_image.resize(image_buffer, 0);
+    return true;
+}
+
+
+bool
+WebpOutput::write_scanline (int y, int z, TypeDesc format,
+                            const void *data, stride_t xstride)
+{
+    if (y > m_spec.height)
+    {
+        error ("Attempt to write too many scanlines to %s", m_filename.c_str());
+        close ();
+        return false;
+    }
+    std::vector<uint8_t> scratch;
+    data = to_native_scanline (format, data, xstride, scratch);
+    memcpy(&m_uncompressed_image[y*m_scanline_size], data, m_scanline_size);
+
+    if (y == m_spec.height - 1)
+    {
+        if (m_spec.nchannels == 4)
+        {
+            WebPPictureImportRGBA(&m_webp_picture, &m_uncompressed_image[0], m_scanline_size);
+        }
+        else
+        {
+            WebPPictureImportRGB(&m_webp_picture, &m_uncompressed_image[0], m_scanline_size);
+        }
+        if (!WebPEncode(&m_webp_config, &m_webp_picture))
+        {
+            error ("Failed to encode %s as WebP image", m_filename.c_str());
+            close();
+            return false;
+        }
+    }
+    return true;    
+}
+
+
+bool
+WebpOutput::close()
+{
+    if (m_file)
+    {
+        WebPPictureFree(&m_webp_picture);
+        fclose(m_file);
+        m_file = NULL;
+    }
+    return true;
+}
+
+} // namespace webp_pvt
+
+
+OIIO_PLUGIN_EXPORTS_BEGIN
+
+    DLLEXPORT ImageOutput *webp_output_imageio_create () {
+        return new webp_pvt::WebpOutput;
+    }
+    DLLEXPORT const char *webp_output_extensions[] = {
+        "webp", NULL
+    };
+
+OIIO_PLUGIN_EXPORTS_END
+
+OIIO_PLUGIN_NAMESPACE_END

--- a/testsuite/webp/ref/out.txt
+++ b/testsuite/webp/ref/out.txt
@@ -1,0 +1,10 @@
+../../../webp-images/1.webp :  550 x  368, 4 channel, uint8 webp
+    channel list: R, G, B, A
+../../../webp-images/2.webp :  550 x  404, 4 channel, uint8 webp
+    channel list: R, G, B, A
+../../../webp-images/3.webp : 1280 x  720, 4 channel, uint8 webp
+    channel list: R, G, B, A
+../../../webp-images/4.webp : 1024 x  772, 4 channel, uint8 webp
+    channel list: R, G, B, A
+../../../webp-images/5.webp : 1024 x  752, 4 channel, uint8 webp
+    channel list: R, G, B, A

--- a/testsuite/webp/run.py
+++ b/testsuite/webp/run.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python 
+
+import os
+import sys
+
+path = ""
+command = ""
+if len(sys.argv) > 2 :
+    os.chdir (sys.argv[1])
+    path = sys.argv[2] + "/"
+
+sys.path = [".."] + sys.path
+import runtest
+
+# A command to run
+command = path + runtest.oiio_app("iinfo") + " -v ../../../webp-images/1.webp > out.txt;"
+command += path + runtest.oiio_app("iinfo") + " -v ../../../webp-images/2.webp >> out.txt;"
+command += path + runtest.oiio_app("iinfo") + " -v ../../../webp-images/3.webp >> out.txt;"
+command += path + runtest.oiio_app("iinfo") + " -v ../../../webp-images/4.webp >> out.txt;"
+command += path + runtest.oiio_app("iinfo") + " -v ../../../webp-images/5.webp >> out.txt;"
+
+# Outputs to check against references
+outputs = [ "out.txt" ]
+
+# Files that need to be cleaned up, IN ADDITION to outputs
+cleanfiles = [ ]
+
+
+# boilerplate
+ret = runtest.runtest (command, outputs, cleanfiles)
+sys.exit (ret)


### PR DESCRIPTION
Here's a simple WebP reader/writer that uses Google libwebp library. For now the plugin is very naive: before decompressing an image it waits till all data will be read from file. The same with writing: before compressing an image it waits till receive all image data, then compress the image and write it to the file.
