### PR TITLE
Add Filesystem::exists and is_directory to wrap the boost versions

### DIFF
--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -44,6 +44,7 @@
 #include "argparse.h"
 #include "imageio.h"
 #include "sysutil.h"
+#include "filesystem.h"
 
 
 OIIO_NAMESPACE_USING;
@@ -347,7 +348,7 @@ adjust_spec (ImageInput *in, ImageOutput *out,
 static bool
 convert_file (const std::string &in_filename, const std::string &out_filename)
 {
-    if (noclobber && boost::filesystem::exists(out_filename)) {
+    if (noclobber && Filesystem::exists(out_filename)) {
         std::cerr << "iconvert ERROR: Output file already exists \""
                   << out_filename << "\"\n";
         return false;

--- a/src/igrep/igrep.cpp
+++ b/src/igrep/igrep.cpp
@@ -44,6 +44,7 @@ using namespace boost::filesystem;
 
 #include "argparse.h"
 #include "strutil.h"
+#include "filesystem.h"
 #include "imageio.h"
 
 OIIO_NAMESPACE_USING;
@@ -66,20 +67,20 @@ static bool
 grep_file (const std::string &filename, boost::regex &re,
            bool ignore_nonimage_files=false)
 {
-    boost::filesystem::path path (filename);
-    if (! boost::filesystem::exists (path)) {
+    if (! Filesystem::exists (filename)) {
         std::cerr << "igrep: " << filename << ": No such file or directory\n";
         return false;
     }
 
-    if (boost::filesystem::is_directory (path)) {
+    if (Filesystem::is_directory (filename)) {
         if (! recursive)
             return false;
         if (print_dirs) {
-            std::cout << "(" << path << "/)\n";
+            std::cout << "(" << filename << "/)\n";
             std::cout.flush();
         }
         bool r = false;
+        boost::filesystem::path path (filename);
         boost::filesystem::directory_iterator end_itr;  // default is past-end
         for (boost::filesystem::directory_iterator itr(path);  itr != end_itr;  ++itr) {
             // std::cout << "  rec " << itr->path() << "\n";

--- a/src/include/filesystem.h
+++ b/src/include/filesystem.h
@@ -90,6 +90,15 @@ DLLPUBLIC bool path_is_absolute (const std::string &path,
                                  bool dot_is_absolute=false);
 
 
+/// Return true if the file exists.
+///
+DLLPUBLIC bool exists (const std::string &path);
+
+
+/// Return true if the file exists and is a directory.
+///
+DLLPUBLIC bool is_directory (const std::string &path);
+
 };  // namespace Filesystem
 
 }

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -50,6 +50,8 @@ using boost::algorithm::iequals;
 #include "timer.h"
 #include "fmath.h"
 #include "sysutil.h"
+#include "filesystem.h"
+
 
 namespace
 {
@@ -1432,7 +1434,7 @@ compImageDate (IvImage *first, IvImage *second)
         if (first->init_spec (first->name(), 0, 0)) {
             metadatatime = first->spec ().get_string_attribute ("DateTime");
             if (metadatatime.empty()){
-                if (! boost::filesystem::exists (first->name ()))
+                if (! Filesystem::exists (first->name ()))
                     return false;
                 firstFile = boost::filesystem::last_write_time (first->name ());
             }
@@ -1446,7 +1448,7 @@ compImageDate (IvImage *first, IvImage *second)
         if (second->init_spec(second->name(), 0, 0)) {
             metadatatime = second->spec ().get_string_attribute ("DateTime");
             if (metadatatime.empty()){
-                if (! boost::filesystem::exists (second->name ()))
+                if (! Filesystem::exists (second->name ()))
                     return true;
                 secondFile = boost::filesystem::last_write_time (second->name());
             }
@@ -1482,10 +1484,10 @@ compFileDate (IvImage *first, IvImage *second)
 {
     std::time_t firstFile, secondFile;
     double diff;
-    if (! boost::filesystem::exists (first->name ()))
+    if (! Filesystem::exists (first->name ()))
         return false;
     firstFile = boost::filesystem::last_write_time (first->name ());
-    if (! boost::filesystem::exists (second->name ()))
+    if (! Filesystem::exists (second->name ()))
         return true;
     secondFile = boost::filesystem::last_write_time (second->name ());
     diff = difftime(firstFile, secondFile);

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -406,7 +406,7 @@ ImageInput::create (const std::string &filename, const std::string &plugin_searc
             fprintf (stderr, "%s", msg);
             pvt::error ("%s", msg);
         }
-        else if (boost::filesystem::exists (filename))
+        else if (Filesystem::exists (filename))
             pvt::error ("OpenImageIO could not find a format reader for \"%s\". "
                         "Is it a file format that OpenImageIO doesn't know about?\n",
                          filename.c_str());

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -2253,7 +2253,7 @@ ImageCacheImpl::invalidate_all (bool force)
             ImageCacheFileRef &f (fileit->second);
             ustring name = f->filename();
             recursive_lock_guard guard (f->m_input_mutex);
-            if (f->broken() || ! boost::filesystem::exists(name.string())) {
+            if (f->broken() || ! Filesystem::exists(name.string())) {
                 all_files.push_back (name);
                 continue;
             }

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -131,7 +131,7 @@ Filesystem::searchpath_split (const std::string &searchpath,
             path.erase (--len);
         // If it's a valid directory, or if validonly is false, add it
         // to the list
-        if (!validonly || boost::filesystem::is_directory (path))
+        if (!validonly || Filesystem::is_directory (path))
             dirs.push_back (path);
     }
 #if 0
@@ -200,6 +200,35 @@ Filesystem::path_is_absolute (const std::string &path, bool dot_is_absolute)
 #endif
         ;
 }
+
+
+
+bool
+Filesystem::exists (const std::string &path)
+{
+    bool r = false;
+    try {
+        r = boost::filesystem::exists (path);
+    } catch (const std::exception &e) {
+        r = false;
+    }
+    return r;
+}
+
+
+
+bool
+Filesystem::is_directory (const std::string &path)
+{
+    bool r = false;
+    try {
+        r = boost::filesystem::is_directory (path);
+    } catch (const std::exception &e) {
+        r = false;
+    }
+    return r;
+}
+
 
 }
 OIIO_NAMESPACE_EXIT

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -555,7 +555,7 @@ make_texturemap (const char *maptypename = "texture map")
         exit (EXIT_FAILURE);
     }
 
-    if (! boost::filesystem::exists (filenames[0])) {
+    if (! Filesystem::exists (filenames[0])) {
         std::cerr << "maketx ERROR: \"" << filenames[0] << "\" does not exist\n";
         exit (EXIT_FAILURE);
     }
@@ -572,7 +572,7 @@ make_texturemap (const char *maptypename = "texture map")
 
     // When in update mode, skip making the texture if the output already
     // exists and has the same file modification time as the input file.
-    if (updatemode && boost::filesystem::exists (outputfilename) &&
+    if (updatemode && Filesystem::exists (outputfilename) &&
         (in_time == boost::filesystem::last_write_time (outputfilename))) {
         std::cout << "maketx: no update required for \"" 
                   << outputfilename << "\"\n";


### PR DESCRIPTION
Add Filesystem::exists and is_directory to wrap the boost versions and catch exceptions.

There's some anecdotal evidence that these Boost routines can throw exceptions, so we add wrappers to catch (as well as insulate our apps from direct boost calls, in case we prefer to implement this in a different way in the future or on other platforms).
