### PR TITLE
jpeg.imageio error handling memory leak

### DIFF
--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -158,21 +158,13 @@ JpgInput::open (const std::string &name, ImageSpec &newspec)
     m_jerr.pub.output_message = my_output_message;
     if (setjmp (m_jerr.setjmp_buffer)) {
         // Jump to here if there's a libjpeg internal error
-        // don't jpeg_destroy_decompress, because we haven't initialized it
-        close_file ();
-        return false;
-    }
-
-    jpeg_create_decompress (&m_cinfo);          // initialize decompressor
-
-    // Now that we initialized the decompressor, re-jigger our setjmp
-    if (setjmp (m_jerr.setjmp_buffer)) {
-        // Jump to here if there's a libjpeg internal error
+        // Prevent memory leaks, see example.c in jpeg distribution
         jpeg_destroy_decompress (&m_cinfo);
         close_file ();
         return false;
     }
 
+    jpeg_create_decompress (&m_cinfo);          // initialize decompressor
     jpeg_stdio_src (&m_cinfo, m_fd);            // specify the data source
 
     // Request saving of EXIF and other special tags for later spelunking


### PR DESCRIPTION
Believe it or not, this is correct.
setjmp/longjmp make it look wrong because the flow of execution isn't what we normally expect.
The comment "don't jpeg_destroy_decompress, because we haven't initialized it" is incorrect.
Think of it like this:
setjmp is just setting up an error handler. It should be done before any jpeg lib code because if an error occurs, it will call my_error_exit which will longjmp back up to the setjmp block.
In effect, setjmp returns twice when there's an error (when longjmp is called).
See example.c in the jpeg distribution for confirmation on what is correct here.
