### PR TITLE
Review: Minor IFF metadata fixes

### DIFF
--- a/src/iff.imageio/iffinput.cpp
+++ b/src/iff.imageio/iffinput.cpp
@@ -127,12 +127,12 @@ IffInput::open (const std::string &name, ImageSpec &spec)
     
     // author
     if (m_iff_header.author.size()) {
-        m_spec.attribute ("author", m_iff_header.author);
+        m_spec.attribute ("Artist", m_iff_header.author);
     }
     
     // date
     if (m_iff_header.date.size()) {
-        m_spec.attribute ("date", m_iff_header.date);
+        m_spec.attribute ("DateTime", m_iff_header.date);
     }
     
     // file pointer is set to the beginning of tbmp data

--- a/src/iff.imageio/iffoutput.cpp
+++ b/src/iff.imageio/iffoutput.cpp
@@ -127,6 +127,8 @@ IffOutput::open (const std::string &name, const ImageSpec &spec,
     m_iff_header.tiles = tile_width_size (m_spec.width) * tile_height_size (m_spec.height);
     m_iff_header.pixel_bits = m_spec.format == TypeDesc::UINT8 ? 8 : 16;
     m_iff_header.pixel_channels = m_spec.nchannels;
+    m_iff_header.author = m_spec.get_string_attribute ("Artist");
+    m_iff_header.date = m_spec.get_string_attribute ("DateTime");
     
     if (!m_iff_header.write_header (m_fd)) {
         error ("\"%s\": could not write iff header", m_filename.c_str ());


### PR DESCRIPTION
While updating docs for upcoming 0.10 branching, I noticed a few minor IFF issues.  Here I regularize a the "author" and "data" to our usual "Artist" and "DateTime" names when reading, as well as remembering to use those values correctly when writing IFF files.
