### PR TITLE
added missing CMakeLists.txt file for sgi plugin

### DIFF
--- a/src/sgi.imageio/CMakeLists.txt
+++ b/src/sgi.imageio/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_oiio_plugin (sgiinput.cpp sgioutput.cpp)


### PR DESCRIPTION
There was no CMakeLists.txt file for sgi plugin. This was harmless, but produced warning when building projects with EMBEDPLUGINS off
