### PR TITLE
fixed brokem build when EMBEDPLUGINS was off

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,7 +134,7 @@ add_subdirectory (iv)
 # Add IO plugin directories
 if (NOT EMBEDPLUGINS)
     add_subdirectory (bmp.imageio)
-    add_subdirectory (cineon.imageio)
+#    add_subdirectory (cineon.imageio)
     add_subdirectory (dds.imageio)
     add_subdirectory (dpx.imageio)
     add_subdirectory (field3d.imageio)


### PR DESCRIPTION
It looks like building OIIO with EMBEDPLUGINS off fails because of broken cineon plugin. I understand that someone (Leszek?) is working on it but for now we should exclude it from build.
