### PR TITLE
maketx : various updates

### DIFF
--- a/src/include/imagebufalgo.h
+++ b/src/include/imagebufalgo.h
@@ -179,6 +179,12 @@ bool DLLPUBLIC isMonochrome(const ImageBuf &src);
 /// (current subimage, and current mipmap level)
 std::string DLLPUBLIC computePixelHashSHA1(const ImageBuf &src);
 
+/// Compute the sha1 byte hash for all the pixels in the image.
+/// (current subimage, and current mipmap level)
+std::string DLLPUBLIC computePixelHashSHA1(const ImageBuf &src,
+                                           const std::string & extrainfo);
+
+
 
 /// Set dst, over the pixel range [xbegin,xend) x [ybegin,yend), to be a
 /// resized version of src (mapping such that the "full" image window of

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -650,12 +650,14 @@ ImageBufAlgo::isMonochrome(const ImageBuf &src)
 };
 
 std::string
-ImageBufAlgo::computePixelHashSHA1(const ImageBuf &src)
+ImageBufAlgo::computePixelHashSHA1(const ImageBuf &src,
+                                   const std::string & extrainfo)
 {
     std::string hash_digest;
     
     CSHA1 sha;
     sha.Reset ();
+    
     // Do one scanline at a time, to keep to < 2^32 bytes each
     imagesize_t scanline_bytes = src.spec().scanline_bytes();
     ASSERT (scanline_bytes < std::numeric_limits<unsigned int>::max());
@@ -665,10 +667,22 @@ ImageBufAlgo::computePixelHashSHA1(const ImageBuf &src)
                          src.spec().format, &tmp[0]);
         sha.Update (&tmp[0], (unsigned int) scanline_bytes);
     }
+    
+    // If extra info is specified, also include it in the sha computation
+    if(!extrainfo.empty()) {
+        sha.Update ((const unsigned char*) extrainfo.c_str(), extrainfo.size());
+    }
+    
     sha.Final ();
     sha.ReportHashStl (hash_digest, CSHA1::REPORT_HEX_SHORT);
     
     return hash_digest;
+}
+
+std::string
+ImageBufAlgo::computePixelHashSHA1(const ImageBuf &src)
+{
+    return computePixelHashSHA1 (src, "");
 }
 
 

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -873,7 +873,17 @@ make_texturemap (const char *maptypename = "texture map")
         desc = "";
     }
     
-    std::string hash_digest = ImageBufAlgo::computePixelHashSHA1 (*toplevel);
+    
+    // The hash is only computed for the top mipmap level of pixel data.
+    // Thus, any additional information that will effect the lower levels
+    // (such as filtering information) needs to be manually added into the
+    // hash.
+    std::ostringstream addlHashData;
+    addlHashData << filtername << " ";
+    addlHashData << filterwidth << " ";
+    
+    std::string hash_digest = ImageBufAlgo::computePixelHashSHA1 (*toplevel,
+        addlHashData.str());
     if (hash_digest.length()) {
         if (desc.length())
             desc += " ";


### PR DESCRIPTION
Various tweaks to maketx.

The --hash option is deprecated; the SHA-1 hash is now computed in all cases.
The SHA1 computation was also moved to later in the txmake process, so it also
takes into account upstream image changes, such as resizing.

constant color metadata is always emitted (though the image dimenstions are not
shrunk unless explicitly requested, such as with --oiio)
