### PR TITLE
TextureSystem: add a 'texsharp' attribute to let people globally scale texture sharpness

### DIFF
--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -560,6 +560,17 @@ separately; just setting either one will implicitly set the other, since
 each is the inverse of the other.
 \apiend
 
+\apiitem{float texsharp}
+Multiplies all texture derivative estimates by this global sharpness 
+value --- as if all texture lookups had their {\cf swidth} and {\cf twidth} 
+options multipled by {\cf texsharp}.  Thus, setting this to 0.75, say,
+would slightly sharpen all texture lookups (though it might visibly
+alias slightly, compared to the ``correct'' filter sizes, as well
+as hurt performance by requiring slightly higher-resolution MIP
+levels for all texture lookups).
+The default value of {\cf texsharp} is 1.0.  
+\apiend
+
 \apiitem{int gray_to_rgb}
 If set to nonzero, texture lookups of single-channel (grayscale) 
 images will replicate the sole channel's values into the next two

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -354,8 +354,8 @@ TextureSystemImpl::environment (TextureHandle *texture_handle_,
     // N.B. naturalres formulated for latlong
 
     // Account for width and blur
-    float xfilt = xfilt_noblur * options.swidth + options.sblur;
-    float yfilt = yfilt_noblur * options.twidth + options.tblur;
+    float xfilt = xfilt_noblur * options.swidth * m_texsharp + options.sblur;
+    float yfilt = yfilt_noblur * options.twidth * m_texsharp + options.tblur;
 
     // Figure out major versus minor, and aspect ratio
     Imath::V3f Rmajor;   // major axis

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -451,6 +451,7 @@ private:
     ImageCacheImpl *m_imagecache;
     Imath::M44f m_Mw2c;          ///< world-to-"common" matrix
     Imath::M44f m_Mc2w;          ///< common-to-world matrix
+    float m_texsharp;            ///< texture sharpness factor
     bool m_gray_to_rgb;          ///< automatically copy gray to rgb channels?
     /// Saved error string, per-thread
     ///


### PR DESCRIPTION
TextureSystem: add a 'texsharp' attribute to let people globally scale the filter size estimates.

Sometimes people wish our (I believe correctly-calculated) texture filters were just a bit sharper.  This global adjustment allows that, at the obvious expense of (1) possible slight aliasing, and (2) possible performance hit to the texture cache due to all texture lookups needing slightly higher-res MIPmap levels.
