### PR TITLE
Filter

### DIFF
--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -200,6 +200,12 @@ getargs (int argc, char *argv[])
                   "<SEPARATOR>", "Configuration Presets",
                   "--prman", &prman, "Use PRMan-safe settings for tile size, planarconfig, and metadata.",
                   "--oiio", &oiio, "Use OIIO-optimized settings for tile size, planarconfig, metadata, and constant-color optimizations.",
+                  
+                  "<SEPARATOR>", "Filter Types:\n"
+                  "\tbox, triangle, gaussian, catmull-rom, catrom,\n"
+                  "\tblackman-harris, sinc, lanczos3 / lanczos,\n"
+                  "\tradial-lanczos3 / radial-lanczos, mitchell, \n"
+                  "\tb-spline / bspline, disk",
                   NULL);
     if (ap.parse (argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;


### PR DESCRIPTION
This branch is for development on cleaning up the use of the maketx --filter option.

The intent is to remove the use specification of filter size, only the filter kernel type will be specified.  The rationale is that for any kernel type there is only a single 'optimized' setting (where the image is not being overly blurred, or overly aliased) so it only makes usage more difficult to require the user to provide this value.   Other command-line image processing tools do not typically require this either.
