### PR TITLE
Review: Make plugin.h public, and add a flag to Plugin::open that changes he dlopen mode

### DIFF
--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -1,7 +1,7 @@
 set (public_headers argparse.h dassert.h errorhandler.h export.h 
                     filesystem.h filter.h fmath.h hash.h
                     imagebuf.h imagebufalgo.h 
-                    imagecache.h imageio.h osdep.h paramlist.h
+                    imagecache.h imageio.h osdep.h paramlist.h plugin.h
                     refcnt.h strutil.h sysutil.h texture.h thread.h timer.h
                     typedesc.h ustring.h varyingref.h
                     colortransfer.h pugixml.hpp pugiconfig.hpp

--- a/src/include/plugin.h
+++ b/src/include/plugin.h
@@ -41,6 +41,8 @@
 #ifndef OPENIMAGEIO_PLUGIN_H
 #define OPENIMAGEIO_PLUGIN_H
 
+#include <string>
+
 #include "export.h"
 #include "version.h"
 
@@ -58,13 +60,15 @@ DLLPUBLIC const char *plugin_extension (void);
 
 /// Open the named plugin, return its handle.  If it could not be
 /// opened, return 0 and the next call to geterror() will contain
-/// an explanatory message.
-DLLPUBLIC Handle open (const char *plugin_filename);
+/// an explanatory message.  If the 'global' parameter is true, all
+/// symbols from the plugin will be available to the app (on Unix-like
+/// platforms; this has no effect on Windows).
+DLLPUBLIC Handle open (const char *plugin_filename, bool global=true);
 
 inline Handle
-open (const std::string &plugin_filename)
+open (const std::string &plugin_filename, bool global=true)
 {
-    return open (plugin_filename.c_str());
+    return open (plugin_filename.c_str(), global);
 }
 
 /// Close the open plugin with the given handle and return true upon

--- a/src/libutil/plugin.cpp
+++ b/src/libutil/plugin.cpp
@@ -73,14 +73,17 @@ Plugin::plugin_extension (void)
 
 
 Handle
-Plugin::open (const char *plugin_filename)
+Plugin::open (const char *plugin_filename, bool global)
 {
     lock_guard guard (plugin_mutex);
     last_error.clear ();
 #if defined(_WIN32)
     return LoadLibrary (plugin_filename);
 #else
-    Handle h = dlopen (plugin_filename, RTLD_LAZY | RTLD_GLOBAL);
+    int mode = RTLD_LAZY;
+    if (global)
+        mode |= RTLD_GLOBAL;
+    Handle h = dlopen (plugin_filename, mode);
     if (!h)
         last_error = dlerror();
     return h;


### PR DESCRIPTION
Make plugin.h public, and add a flag to Plugin::open that allows the caller to force the underlying dlopen to not use the RTLD_GLOBAL mode.  (By default, it works as it always did.)

(This was very helpful in debugging something in OSL.)
