### PR TITLE
ignoring backup files (ending with '~')

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 build/
 dist/
 testsuite/tiff-suite/cramps-tile.tif


### PR DESCRIPTION
I'm using an editor that save backup files every time I modify the file. It would be great if those files doesn't show when I type "git status".
