### PR TITLE
Review: Use reader/writer spin locks for ustring table.

### DIFF
--- a/src/libutil/ustring.cpp
+++ b/src/libutil/ustring.cpp
@@ -54,11 +54,16 @@ typedef unique_lock ustring_write_lock_t;
 typedef mutex ustring_mutex_t;
 typedef lock_guard ustring_read_lock_t;
 typedef lock_guard ustring_write_lock_t;
-#elif 1
+#elif 0
 // Use spin locks
 typedef spin_mutex ustring_mutex_t;
 typedef spin_lock ustring_read_lock_t;
 typedef spin_lock ustring_write_lock_t;
+#elif 1
+// Use rw spin locks
+typedef spin_rw_mutex ustring_mutex_t;
+typedef spin_rw_read_lock ustring_read_lock_t;
+typedef spin_rw_write_lock ustring_write_lock_t;
 #else
 // Use null locks
 typedef null_mutex ustring_mutex_t;


### PR DESCRIPTION
I wrote a reader/writer spin lock, used it for the ustring table, and it produces another significant improvement when there's heavy contention in ustring creation.  In particular, with this patch the ustring performance continues to improve all the way up to the number of threads greater than the number of cores, whereas previously it "leveled off" earlier, with at some point additional HT cores not providing any additional benefit.  Now, more cores always benefit.  (For just a few cores, performance is the same as before.)

Now that this class is written, we could possibly improve performance by finding other places where a good spin rw lock is appropriate that's currently a purely exclusive lock.
