### PR TITLE
build fixes for SPI's new fedora distribution

### DIFF
--- a/site/spi/Makefile-bits-arnold
+++ b/site/spi/Makefile-bits-arnold
@@ -20,8 +20,8 @@ endif
 ifeq ($(SP_ARCH), spinux1_x86_64)
     platform=spinux1
     COMPILER=gcc44m64
+    MY_CMAKE_FLAGS += $(if $(wildcard /usr/lib64/xorg.nvidia.3d/libGL.so), -DOPENGL_gl_LIBRARY=/usr/lib64/xorg.nvidia.3d/libGL.so)
     MY_CMAKE_FLAGS += \
-     -DOPENGL_gl_LIBRARY=/usr/lib64/xorg.nvidia.3d/libGL.so \
 	  -DILMBASE_CUSTOM=1 \
 	  -DILMBASE_CUSTOM_LIBRARIES="SpiImath SpiHalf SpiIlmThread SpiIex" \
 	  -DOPENEXR_CUSTOM=1 \

--- a/site/spi/Makefile-bits-spcomp2
+++ b/site/spi/Makefile-bits-spcomp2
@@ -28,8 +28,8 @@ SPCOMP2_RPATH ?= ""
 ifeq ($(SP_ARCH), spinux1_x86_64)
     platform=spinux1
     COMPILER=gcc44m64
+    MY_CMAKE_FLAGS += $(if $(wildcard /usr/lib64/xorg.nvidia.3d/libGL.so), -DOPENGL_gl_LIBRARY=/usr/lib64/xorg.nvidia.3d/libGL.so)
     MY_CMAKE_FLAGS += \
-     -DOPENGL_gl_LIBRARY=/usr/lib64/xorg.nvidia.3d/libGL.so \
      -DILMBASE_CUSTOM=1 \
      -DILMBASE_CUSTOM_LIBRARIES="SpiImath SpiHalf SpiIlmThread SpiIex" \
      -DOPENEXR_CUSTOM=1 \


### PR DESCRIPTION
This is a minor tweak I needed to make to get 'iv' to build properly on SPI's new fedora distribution (which is also called "spinux1').
