### PR TITLE
forgotten #include <iomanip>

### DIFF
--- a/src/oiiotool/diff.cpp
+++ b/src/oiiotool/diff.cpp
@@ -36,6 +36,7 @@
 #include <iterator>
 #include <vector>
 #include <string>
+#include <iomanip>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/tokenizer.hpp>


### PR DESCRIPTION
OIIO fails to build on my linux system due to this forgotten include.
