### PR TITLE
TextureOpt: Add ustring-aware versions of the decode_wrapmode utility

### DIFF
--- a/src/include/texture.h
+++ b/src/include/texture.h
@@ -170,6 +170,7 @@ public:
     /// Utility: Return the Wrap enum corresponding to a wrap name:
     /// "default", "black", "clamp", "periodic", "mirror".
     static Wrap decode_wrapmode (const char *name);
+    static Wrap decode_wrapmode (ustring name);
 
     /// Utility: Parse a single wrap mode (e.g., "periodic") or a
     /// comma-separated wrap modes string (e.g., "black,clamp") into
@@ -267,6 +268,9 @@ public:
     /// Utility: Return the Wrap enum corresponding to a wrap name:
     /// "default", "black", "clamp", "periodic", "mirror".
     static Wrap decode_wrapmode (const char *name) {
+        return (Wrap)TextureOpt::decode_wrapmode (name);
+    }
+    static Wrap decode_wrapmode (ustring name) {
         return (Wrap)TextureOpt::decode_wrapmode (name);
     }
 

--- a/src/libtexture/texoptions.cpp
+++ b/src/libtexture/texoptions.cpp
@@ -58,10 +58,11 @@ static float default_bias = 0;
 static float default_fill = 0;
 static int   default_samples = 1;
 
-static const char * wrap_type_name[] = {
+static const ustring wrap_type_name[] = {
     // MUST match the order of TextureOptions::Wrap
-    "default", "black", "clamp", "periodic", "mirror",
-    ""
+    ustring("default"), ustring("black"), ustring("clamp"),
+    ustring("periodic"), ustring("mirror"),
+    ustring()
 };
 
 };  // end anonymous namespace
@@ -148,7 +149,18 @@ TextureOpt::Wrap
 TextureOpt::decode_wrapmode (const char *name)
 {
     for (int i = 0;  i < (int)WrapLast;  ++i)
-        if (! strcmp (name, wrap_type_name[i]))
+        if (! strcmp (name, wrap_type_name[i].c_str()))
+            return (Wrap) i;
+    return TextureOpt::WrapDefault;
+}
+
+
+
+TextureOpt::Wrap
+TextureOpt::decode_wrapmode (ustring name)
+{
+    for (int i = 0;  i < (int)WrapLast;  ++i)
+        if (name == wrap_type_name[i])
             return (Wrap) i;
     return TextureOpt::WrapDefault;
 }


### PR DESCRIPTION
For apps that already have the ustring version of the wrap name and want this to avoid the strcmps.
