### PR TITLE
Re-enable the Cineon plugin

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -183,11 +183,10 @@ add_subdirectory (maketx)
 add_subdirectory (oiiotool)
 add_subdirectory (testtex)
 add_subdirectory (iv)
-
 # Add IO plugin directories
 if (NOT EMBEDPLUGINS)
     add_subdirectory (bmp.imageio)
-#    add_subdirectory (cineon.imageio)
+    add_subdirectory (cineon.imageio)
     add_subdirectory (dds.imageio)
     add_subdirectory (dpx.imageio)
     add_subdirectory (field3d.imageio)

--- a/src/cineon.imageio/cineoninput.cpp
+++ b/src/cineon.imageio/cineoninput.cpp
@@ -35,6 +35,8 @@
 #include "imageio.h"
 #include "fmath.h"
 
+using namespace cineon;
+
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
 
@@ -210,20 +212,18 @@ CineonInput::open (const std::string &name, ImageSpec &newspec)
         case cineon::kRec709Red:
         case cineon::kRec709Green:
         case cineon::kRec709Blue:
-            m_spec.linearity = ImageSpec::Rec709;
+            m_spec.attribute ("oiio:ColorSpace", "Rec709");
         default:
             // either grayscale or printing density
             if (!isinf (m_cin.header.Gamma ()))
                 // actual gamma value is read later on
-                m_spec.linearity = ImageSpec::GammaCorrected;
-            else
-                m_spec.linearity = ImageSpec::UnknownLinearity;
+                m_spec.attribute ("oiio:ColorSpace", "GammaCorrected");
             break;
     }
 
     // gamma exponent
     if (!isinf (m_cin.header.Gamma ()))
-        m_spec.gamma = m_cin.header.Gamma ();
+        m_spec.attribute ("oiio:Gamma", (float) m_cin.header.Gamma ());
 
     // general metadata
     // some non-compliant writers will dump a field filled with 0xFF rather

--- a/src/cineon.imageio/cineonoutput.cpp
+++ b/src/cineon.imageio/cineonoutput.cpp
@@ -34,6 +34,8 @@
 #include "imageio.h"
 #include "fmath.h"
 
+using namespace cineon;
+
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
 

--- a/src/cineon.imageio/libcineon/CineonHeader.cpp
+++ b/src/cineon.imageio/libcineon/CineonHeader.cpp
@@ -54,7 +54,7 @@
 						EmptyFloat((x)[1]))
 
 
-
+namespace cineon {
 
 char Hex(char x)
 {
@@ -632,5 +632,5 @@ cineon::U32 cineon::Header::Width() const
 	return w;
 }
 
-
+}
 

--- a/src/cineon.imageio/libcineon/CineonHeader.h
+++ b/src/cineon.imageio/libcineon/CineonHeader.h
@@ -883,12 +883,6 @@ namespace cineon
 		 */
 		void CalculateNumberOfElements();
 
-				/*!
-		 * \brief Number of components for the element
-		 * \return number of components
-		 */
-		int ImageElementComponentCount(const int element) const;
-
 		/*!
 		 * \brief DataSize required for individual image element components
 		 * \return datasize of element

--- a/src/cineon.imageio/libcineon/CineonStream.h
+++ b/src/cineon.imageio/libcineon/CineonStream.h
@@ -41,7 +41,7 @@
 
 #include <cstdio>
 
-
+namespace cineon {
 
 /*!
  * \class InStream
@@ -196,7 +196,7 @@ class OutStream
 	FILE *fp;
 };
 
-
+}
 
 
 

--- a/src/cineon.imageio/libcineon/InStream.cpp
+++ b/src/cineon.imageio/libcineon/InStream.cpp
@@ -38,6 +38,7 @@
 
 #include "CineonStream.h"
 
+namespace cineon {
 
 InStream::InStream() : fp(0)
 {
@@ -121,7 +122,7 @@ bool InStream::EndOfFile() const
 	return ::feof(this->fp);
 }
 
-
+}
 
 
 

--- a/src/cineon.imageio/libcineon/Writer.cpp
+++ b/src/cineon.imageio/libcineon/Writer.cpp
@@ -214,7 +214,7 @@ bool cineon::Writer::WriteElement(const int element, void *data, const DataSize 
 	const U8 bitDepth = this->header.BitDepth(element);
 	const U32 width = this->header.Width();
 	const U32 height = this->header.Height();
-	const int noc = this->header.ImageElementComponentCount(element);
+	const int noc = this->header.NumberOfElements();
 	const Packing packing = this->header.ImagePacking();
 
 	// check width & height, just in case

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -75,11 +75,11 @@ if (EMBEDPLUGINS)
     set (libOpenImageIO_srcs ${libOpenImageIO_srcs}
         ../bmp.imageio/bmpinput.cpp ../bmp.imageio/bmpoutput.cpp
         ../bmp.imageio/bmp_pvt.cpp
-#        ../cineon.imageio/cineoninput.cpp ../cineon.imageio/cineonoutput.cpp
-#          ../cineon.imageio/libcineon/Cineon.cpp 
-#          ../cineon.imageio/libcineon/Codec.cpp ../cineon.imageio/libcineon/Reader.cpp
-#          ../cineon.imageio/libcineon/Writer.cpp ../cineon.imageio/libcineon/CineonHeader.cpp
-#          ../cineon.imageio/libcineon/ElementReadStream.cpp ../cineon.imageio/libcineon/InStream.cpp
+        ../cineon.imageio/cineoninput.cpp ../cineon.imageio/cineonoutput.cpp
+          ../cineon.imageio/libcineon/Cineon.cpp 
+          ../cineon.imageio/libcineon/Codec.cpp ../cineon.imageio/libcineon/Reader.cpp
+          ../cineon.imageio/libcineon/Writer.cpp ../cineon.imageio/libcineon/CineonHeader.cpp
+          ../cineon.imageio/libcineon/ElementReadStream.cpp ../cineon.imageio/libcineon/InStream.cpp
         ../dds.imageio/ddsinput.cpp ../dds.imageio/ddsoutput.cpp
           ../dds.imageio/squish/alpha.cpp ../dds.imageio/squish/clusterfit.cpp
           ../dds.imageio/squish/colourblock.cpp ../dds.imageio/squish/colourfit.cpp

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -180,7 +180,7 @@ catalog_plugin (const std::string &format_name,
     extern const char *name ## _input_extensions[];
 
     PLUGENTRY (bmp);
-//    PLUGENTRY (cineon);
+    PLUGENTRY (cineon);
     PLUGENTRY (dds);
     PLUGENTRY (dpx);
     PLUGENTRY (field3d);
@@ -225,7 +225,7 @@ catalog_builtin_plugins ()
                     name ## _output_extensions)
 
     DECLAREPLUG (bmp);
-//    DECLAREPLUG (cineon);
+    DECLAREPLUG (cineon);
     DECLAREPLUG (dds);
     DECLAREPLUG (dpx);
 #ifdef USE_FIELD3D


### PR DESCRIPTION
I've hacked my last year's work to compile and link without errors (even with EMBEDPLUGINS=1) so that we have a Cineon reader at all until Jonathan Gibbs provides us with his promised library.

The writer is still missing, but the reader works, just like it did last summer.
