### PR TITLE
Review: multi-scanline/tile reading and writing

### DIFF
--- a/src/doc/imageinput.tex
+++ b/src/doc/imageinput.tex
@@ -107,7 +107,7 @@ and {\cf spec.tile_height} set to 0, whereas a tiled images will
 have nonzero values for the tile dimensions.
 
 
-\subsubsection{Reading individual scanlines}
+\subsubsection{Reading scanlines}
 
 Individual scanlines may be read using the \readscanline API
 call:
@@ -145,10 +145,17 @@ scanlines in strict order (starting with scanline 0, then 1, up to {\kw
 format and reader implementation, out-of-order scanline reads may be
 inefficient.
 
-The full description of the \readscanline function may be found
-in Section~\ref{sec:imageinput:reference}.
+There is also a {\cf read_scanlines()} function that operates similarly,
+except that it takes a {\cf ybegin} and {\cf yend} that specify a range,
+reading all scanlines {\cf ybegin} $\le y <$ {\cf yend}.  For most image
+format readers, this is implemented as a loop over individual scanlines,
+but some image format readers may be able to read a contiguous block of
+scanlines more efficiently than reading each one individually.
 
-\subsubsection{Reading individual tiles}
+The full descriptions of the \readscanline and {\cf read_scanlines()}
+functions may be found in Section~\ref{sec:imageinput:reference}.
+
+\subsubsection{Reading tiles}
 
 Once you {\kw open()} an image file, you can find out if it is a tiled
 image (and the tile size) by examining the \ImageSpec's {\cf
@@ -576,8 +583,9 @@ the following steps are necessary:
 \begin{enumerate}
 \item Check the \ImageSpec's {\cf channelformats} vector.  If non-empty,
   the channels in the file do not all have the same format.
-\item When calling {\cf read_scanline}, {\cf read_tile}, or {\cf
-  read_image}, pass a format of {\cf TypeDesc::UNKNOWN} to indicate that
+\item When calling {\cf read_scanline}, {\cf read_scanlines},
+  {\cf read_tile}, or {\cf read_image}, 
+  pass a format of {\cf TypeDesc::UNKNOWN} to indicate that
   you would like the raw data in native per-channel format of the file
   written to your {\cf data} buffer.
 \end{enumerate}
@@ -798,6 +806,17 @@ This simplified version of {\kw read_scanline()} reads to contiguous
 float pixels.
 \apiend
 
+\apiitem{bool {\ce read_scanlines} (int ybegin, int yend, int z,\\
+  \bigspc TypeDesc format, void *data,\\
+  \bigspc                      stride_t xstride=AutoStride, stride_t ystride=AutoStride)}
+
+Read all the scanlines that include pixels $(*,y,z)$, where
+$\mathit{ybegin} \le y < \mathit{yend}$, into {\kw data}.  This is 
+essentially identical to \readscanline, except that can read more than
+one scanline at a time, which may be more efficient for certain image
+format readers.
+\apiend
+
 \apiitem{bool {\ce read_tile} (int x, int y, int z, TypeDesc format,
                             void *data, \\ \bigspc stride_t xstride=AutoStride,
                             stride_t ystride=AutoStride, \\ \bigspc stride_t
@@ -873,6 +892,17 @@ of the disk file and always reads into contiguous memory (no strides).
 It's up to the user to have enough space allocated and know what to do
 with the data.  IT IS EXPECTED THAT EACH FORMAT PLUGIN WILL OVERRIDE
 THIS METHOD.
+\apiend
+
+\apiitem{bool {\ce read_native_scanlines} (int ybegin, int yend, int z, void *data)}
+The {\kw read_native_scanlines()} function is just like 
+{\cf read_native_scanline}, except that it reads
+a range of scanlines rather than only one scanline.  It is not necessary
+for format plugins to override this method --- a default implementation
+in the \ImageInput base class simply calls {\cf read_native_scanline}
+for each scanline in the range.  But format plugins may optionally
+override this method if there is a way to achieve higher performance by
+reading multiple scanlines at once.
 \apiend
 
 \apiitem{bool {\ce read_native_tile} (int x, int y, int z, void *data)}

--- a/src/include/fmath.h
+++ b/src/include/fmath.h
@@ -214,6 +214,16 @@ pow2rounddown (int x)
 
 
 
+/// Round up to the next even multiple of m.
+///
+inline int
+round_to_multiple (int x, int m)
+{
+    return ((x + m - 1) / m) * m;
+}
+
+
+
 /// Return true if the architecture we are running on is little endian
 ///
 inline bool littleendian (void)

--- a/src/include/version.h.in
+++ b/src/include/version.h.in
@@ -75,8 +75,9 @@
 /// with which we break backwards compatibility.
 /// Version 11 teased apart subimage versus miplevel specification in
 /// the APIs and per-channel formats (introduced in OIIO 0.9).
+/// Version 12 added read_scanlines() and supports() methods to ImageInput.
 
-#define OIIO_PLUGIN_VERSION 11
+#define OIIO_PLUGIN_VERSION 12
 
 #define OIIO_PLUGIN_NAMESPACE_BEGIN OIIO_NAMESPACE_ENTER {
 #define OIIO_PLUGIN_NAMESPACE_END } OIIO_NAMESPACE_EXIT

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -31,12 +31,12 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cmath>
-
-#include <boost/scoped_array.hpp>
+#include <vector>
 
 #include "dassert.h"
 #include "typedesc.h"
 #include "strutil.h"
+#include "fmath.h"
 
 #include "imageio.h"
 #include "imageio_pvt.h"
@@ -111,6 +111,100 @@ ImageInput::read_scanline (int y, int z, TypeDesc format, void *data,
 
 
 
+bool
+ImageInput::read_scanlines (int ybegin, int yend, int z,
+                            TypeDesc format, void *data,
+                            stride_t xstride, stride_t ystride)
+{
+    yend = std::min (yend, spec().y+spec().height);
+    size_t native_pixel_bytes = m_spec.pixel_bytes (true);
+    imagesize_t native_scanline_bytes = m_spec.scanline_bytes (true);
+    bool native = (format == TypeDesc::UNKNOWN);
+    size_t pixel_bytes = native ? m_spec.pixel_bytes (native)
+                                : (format.size()*m_spec.nchannels);
+    if (native && xstride == AutoStride)
+        xstride = pixel_bytes;
+    stride_t zstride = AutoStride;
+    m_spec.auto_stride (xstride, ystride, zstride, format, m_spec.nchannels,
+                        m_spec.width, m_spec.height);
+    bool contiguous = (xstride == (stride_t) native_pixel_bytes &&
+                       ystride == (stride_t) native_scanline_bytes);
+    // If user's format and strides are set up to accept the native data
+    // layout, read the scanlines directly into the user's buffer.
+    bool rightformat = (format == TypeDesc::UNKNOWN) ||
+        (format == m_spec.format && m_spec.channelformats.empty());
+    if (rightformat && contiguous)
+        return read_native_scanlines (ybegin, yend, z, data);
+
+    // No such luck.  Read scanlines in chunks.
+
+    const imagesize_t limit = 16*1024*1024;   // Allocate 16 MB, or 1 scanline
+    int chunk = std::max (1, int(limit / native_scanline_bytes));
+    unsigned char *buf = new unsigned char [chunk * native_scanline_bytes];
+
+    bool ok = true;
+    int scanline_values = m_spec.width * m_spec.nchannels;
+    for (;  ok && ybegin < yend;  ybegin += chunk) {
+        int y1 = std::min (ybegin+chunk, yend);
+        ok &= read_native_scanlines (ybegin, y1, z, data);
+        if (! ok)
+            break;
+
+        int nscanlines = y1 - ybegin;
+        int chunkvalues = scanline_values * nscanlines;
+        if (m_spec.channelformats.empty()) {
+            // No per-channel formats -- do the conversion in one shot
+            if (contiguous)
+                ok = convert_types (m_spec.format, buf, format, data, chunkvalues);
+            else {
+                ok = convert_image (m_spec.nchannels, m_spec.width, nscanlines, 1, 
+                                    buf, m_spec.format, AutoStride, AutoStride, AutoStride,
+                                    data, format, xstride, ystride, zstride);
+            }
+        } else {
+            // Per-channel formats -- have to convert/copy channels individually
+            size_t offset = 0;
+            for (size_t c = 0;  ok && c < m_spec.channelformats.size();  ++c) {
+                TypeDesc chanformat = m_spec.channelformats[c];
+                ok = convert_image (1 /* channels */, m_spec.width, nscanlines, 1, 
+                                    buf+offset, chanformat, 
+                                    native_pixel_bytes, AutoStride, AutoStride,
+                                    (char *)data + c*m_spec.format.size(),
+                                    format, xstride, ystride, zstride);
+                offset += chanformat.size ();
+            }
+        }
+        if (! ok)
+            error ("ImageInput::read_scanlines : no support for format %s",
+                   m_spec.format.c_str());
+        data = (char *)data + ystride*nscanlines;
+    }
+    delete [] buf;
+    return ok;
+}
+
+
+
+bool
+ImageInput::read_native_scanlines (int ybegin, int yend, int z, void *data)
+{
+    // Base class implementation of read_native_scanlines just repeatedly
+    // calls read_native_scanline, which is supplied by every plugin.
+    // Only the hardcore ones will overload read_native_scanlines with
+    // their own implementation.
+    size_t ystride = m_spec.scanline_bytes (true);
+    yend = std::min (yend, spec().y+spec().height);
+    for (int y = ybegin;  y < yend;  ++y) {
+        bool ok = read_native_scanline (y, z, data);
+        if (! ok)
+            return false;
+        data = (char *)data + ystride;
+    }
+    return true;
+}
+
+
+
 bool 
 ImageInput::read_tile (int x, int y, int z, TypeDesc format, void *data,
                        stride_t xstride, stride_t ystride, stride_t zstride)
@@ -139,10 +233,9 @@ ImageInput::read_tile (int x, int y, int z, TypeDesc format, void *data,
         return read_native_tile (x, y, z, data);  // Simple case
 
     // Complex case -- either changing data type or stride
-    int tile_values = m_spec.tile_width * m_spec.tile_height * 
-                      std::max(1,m_spec.tile_depth) * m_spec.nchannels;
+    size_t tile_values = (size_t)m_spec.tile_pixels() * m_spec.nchannels;
 
-    boost::scoped_array<char> buf (new char [m_spec.tile_bytes(true)]);
+    std::vector<char> buf (m_spec.tile_bytes(true));
     bool ok = read_native_tile (x, y, z, &buf[0]);
     if (! ok)
         return false;
@@ -181,6 +274,125 @@ ImageInput::read_tile (int x, int y, int z, TypeDesc format, void *data,
 
 
 
+bool 
+ImageInput::read_tiles (int xbegin, int xend, int ybegin, int yend,
+                        int zbegin, int zend, TypeDesc format, void *data,
+                        stride_t xstride, stride_t ystride, stride_t zstride)
+{
+    // native_pixel_bytes is the size of a pixel in the FILE, including
+    // the per-channel format.
+    stride_t native_pixel_bytes = (stride_t) m_spec.pixel_bytes (true);
+    // perchanfile is true if the file has different per-channel formats
+    bool perchanfile = m_spec.channelformats.size();
+    // native_data is true if the user asking for data in the native format
+    bool native_data = (format == TypeDesc::UNKNOWN ||
+                        (format == m_spec.format && !perchanfile));
+    if (format == TypeDesc::UNKNOWN && xstride == AutoStride)
+        xstride = native_pixel_bytes;
+    m_spec.auto_stride (xstride, ystride, zstride, format, m_spec.nchannels,
+                        xend-xbegin, yend-ybegin);
+    // Do the strides indicate that the data area is contiguous?
+    bool contiguous = (native_data && xstride == native_pixel_bytes) ||
+        (!native_data && xstride == (stride_t)m_spec.pixel_bytes(false));
+    contiguous &= (ystride == xstride*(xend-xbegin) &&
+                   (zstride == ystride*(yend-ybegin) || (zend-zbegin) <= 1));
+
+    int nxtiles = (xend - xbegin + m_spec.tile_width - 1) / m_spec.tile_width;
+    int nytiles = (yend - ybegin + m_spec.tile_height - 1) / m_spec.tile_height;
+    int nztiles = (zend - zbegin + m_spec.tile_depth - 1) / m_spec.tile_depth;
+
+    // If user's format and strides are set up to accept the native data
+    // layout, and we're asking for a whole number of tiles (no partial
+    // tiles at the edges), then read the tile directly into the user's
+    // buffer.
+    if (native_data && contiguous &&
+        (xend-xbegin) == nxtiles*m_spec.tile_width &&
+        (yend-ybegin) == nytiles*m_spec.tile_height &&
+        (zend-zbegin) == nztiles*m_spec.tile_depth) {
+        return read_native_tiles (xbegin, xend, ybegin, yend, zbegin, zend,
+                                  data);  // Simple case
+    }
+
+    // No such luck.  Just punt and read tiles individually.
+    bool ok = true;
+    stride_t pixelsize = native_data ? native_pixel_bytes
+                                     : (format.size() * m_spec.nchannels);
+    std::vector<char> buf;
+    for (int z = zbegin;  z < zend;  z += std::max(1,m_spec.tile_depth)) {
+        int zd = std::min (zend-z, m_spec.tile_depth);
+        for (int y = ybegin;  y < yend;  y += m_spec.tile_height) {
+            char *tilestart = ((char *)data + (z-zbegin)*zstride
+                               + (y-ybegin)*ystride);
+            int yh = std::min (yend-y, m_spec.tile_height);
+            for (int x = xbegin;  ok && x < xend;  x += m_spec.tile_width) {
+                int xw = std::min (xend-x, m_spec.tile_width);
+                // Full tiles are read directly into the user buffer, but
+                // partial tiles (such as at the image edge) are read into a
+                // buffer and then copied.
+                if (xw == m_spec.tile_width && yh == m_spec.tile_height &&
+                    zd == m_spec.tile_depth) {
+                    ok &= read_tile (x, y, z, format, tilestart,
+                                     xstride, ystride, zstride);
+                } else {
+                    buf.resize (pixelsize * m_spec.tile_pixels());
+                    ok &= read_tile (x, y, z, format, &buf[0],
+                                     pixelsize, pixelsize*m_spec.tile_width,
+                                     pixelsize*m_spec.tile_pixels());
+                    if (ok)
+                        copy_image (m_spec.nchannels, xw, yh, zd, &buf[0],
+                                    pixelsize, pixelsize,
+                                    pixelsize*m_spec.tile_width,
+                                    pixelsize*m_spec.tile_pixels(),
+                                    tilestart, xstride, ystride, zstride);
+                }
+                tilestart += m_spec.tile_width * xstride;
+            }
+        }
+    }
+
+    if (! ok)
+        error ("ImageInput::read_tiles : no support for format %s",
+               m_spec.format.c_str());
+    return ok;
+}
+
+
+
+bool
+ImageInput::read_native_tiles (int xbegin, int xend, int ybegin, int yend,
+                               int zbegin, int zend, void *data)
+{
+    // Base class implementation of read_native_tiles just repeatedly
+    // calls read_native_tile, which is supplied by every plugin that
+    // supports tiles.  Only the hardcore ones will overload
+    // read_native_tiles with their own implementation.
+    stride_t pixel_bytes = (stride_t) m_spec.pixel_bytes (true);
+    stride_t tileystride = pixel_bytes * m_spec.tile_width;
+    stride_t tilezstride = tileystride * m_spec.tile_height;
+    stride_t ystride = (xend-xbegin) * pixel_bytes;
+    stride_t zstride = (yend-ybegin) * ystride;
+    std::vector<char> pels (m_spec.tile_bytes(true));
+    for (int z = zbegin;  z < zend;  z += m_spec.tile_depth) {
+        for (int y = ybegin;  y < yend;  y += m_spec.tile_height) {
+            for (int x = xbegin;  x < xend;  x += m_spec.tile_width) {
+                bool ok = read_native_tile (x, y, z, &pels[0]);
+                if (! ok)
+                    return false;
+                copy_image (m_spec.nchannels, m_spec.tile_width,
+                            m_spec.tile_height, m_spec.tile_depth,
+                            &pels[0], size_t(pixel_bytes),
+                            pixel_bytes, tileystride, tilezstride,
+                            (char *)data+ (z-zbegin)*zstride + 
+                                (y-ybegin)*ystride + (x-xbegin)*pixel_bytes,
+                            pixel_bytes, ystride, zstride);
+            }
+        }
+    }
+    return true;
+}
+
+
+
 bool
 ImageInput::read_image (TypeDesc format, void *data,
                         stride_t xstride, stride_t ystride, stride_t zstride,
@@ -200,47 +412,28 @@ ImageInput::read_image (TypeDesc format, void *data,
             return ok;
     if (m_spec.tile_width) {
         // Tiled image
-
-        // Locally allocate a single tile to gracefully deal with image
-        // dimensions smaller than a tile, or if one of the tiles runs
-        // past the right or bottom edge.  Then we copy from our tile to
-        // the user data, only copying valid pixel ranges.
-        stride_t tilexstride = pixel_bytes;
-        stride_t tileystride = tilexstride * m_spec.tile_width;
-        stride_t tilezstride = tileystride * m_spec.tile_height;
-        imagesize_t tile_pixels = m_spec.tile_pixels();
-        std::vector<char> pels (tile_pixels * pixel_bytes);
-        for (int z = 0;  z < m_spec.depth;  z += m_spec.tile_depth)
+        for (int z = 0;  z < m_spec.depth;  z += m_spec.tile_depth) {
             for (int y = 0;  y < m_spec.height;  y += m_spec.tile_height) {
-                for (int x = 0;  x < m_spec.width && ok;  x += m_spec.tile_width) {
-                    ok &= read_tile (x+m_spec.x, y+m_spec.y, z+m_spec.z,
-                                     format, &pels[0]);
-                    // Now copy out the scanlines
-                    int ntz = std::min (z+m_spec.tile_depth, m_spec.depth) - z;
-                    int nty = std::min (y+m_spec.tile_height, m_spec.height) - y;
-                    int ntx = std::min (x+m_spec.tile_width, m_spec.width) - x;
-                    for (int tz = 0;  tz < ntz;  ++tz) {
-                        for (int ty = 0;  ty < nty;  ++ty) {
-                            // FIXME -- doesn't work for non-contiguous scanlines
-                            memcpy ((char *)data + x*xstride + (y+ty)*ystride + (z+tz)*zstride,
-                                    &pels[ty*tileystride+tz*tilezstride],
-                                    ntx*tilexstride);
-                        }
-                    }
-//                    return ok; // DEBUG -- just try very first tile
-                }
-                if (progress_callback)
-                    if (progress_callback (progress_callback_data, (float)y/m_spec.height))
-                        return ok;
+                ok &= read_tiles (m_spec.x, m_spec.x+m_spec.width,
+                                  y+m_spec.y, std::min (y+m_spec.y+m_spec.tile_height, m_spec.y+m_spec.height),
+                                  z+m_spec.z, std::min (z+m_spec.z+m_spec.tile_depth, m_spec.z+m_spec.depth),
+                                  format, (char *)data + z*zstride + y*ystride,
+                                  xstride, ystride, zstride);
+                if (progress_callback &&
+                    progress_callback (progress_callback_data, (float)y/m_spec.height))
+                    return ok;
             }
+        }
     } else {
-        // Scanline image
+        // Scanline image -- rely on read_scanlines, in chunks of 64
+        const int chunk = 256;
         for (int z = 0;  z < m_spec.depth;  ++z)
-            for (int y = 0;  y < m_spec.height && ok;  ++y) {
-                ok &= read_scanline (y+m_spec.y, z+m_spec.z, format,
-                                     (char *)data + z*zstride + y*ystride,
-                                     xstride);
-                if (progress_callback && !(y & 0x0f))
+            for (int y = 0;  y < m_spec.height && ok;  y += chunk) {
+                int yend = std::min (y+m_spec.y+chunk, m_spec.y+m_spec.height);
+                ok &= read_scanlines (y+m_spec.y, yend, z+m_spec.z, format,
+                                      (char *)data + z*zstride + y*ystride,
+                                      xstride, ystride);
+                if (progress_callback)
                     if (progress_callback (progress_callback_data, (float)y/m_spec.height))
                         return ok;
             }

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -406,12 +406,21 @@ convert_image (int nchannels, int width, int height, int depth,
                ColorTransfer *tfunc,
                int alpha_channel, int z_channel)
 {
+    // If no format conversion is taking place, use the simplified
+    // copy_image.
+    if (src_type == dst_type && tfunc == NULL)
+        return copy_image (nchannels, width, height, depth, src, 
+                           src_type.size()*nchannels,
+                           src_xstride, src_ystride, src_zstride,
+                           dst, dst_xstride, dst_ystride, dst_zstride);
+
     ImageSpec::auto_stride (src_xstride, src_ystride, src_zstride,
                             src_type, nchannels, width, height);
     ImageSpec::auto_stride (dst_xstride, dst_ystride, dst_zstride,
                             dst_type, nchannels, width, height);
     bool result = true;
-    bool contig = (src_xstride == dst_xstride && src_xstride == nchannels);
+    bool contig = (src_xstride == dst_xstride &&
+                   src_xstride == stride_t(nchannels*src_type.size()));
     for (int z = 0;  z < depth;  ++z) {
         for (int y = 0;  y < height;  ++y) {
             const char *f = (const char *)src + (z*src_zstride + y*src_ystride);
@@ -440,6 +449,45 @@ convert_image (int nchannels, int width, int height, int depth,
         }
     }
     return result;
+}
+
+
+
+bool
+copy_image (int nchannels, int width, int height, int depth,
+            const void *src, stride_t pixelsize, stride_t src_xstride,
+            stride_t src_ystride, stride_t src_zstride, void *dst, 
+            stride_t dst_xstride, stride_t dst_ystride, stride_t dst_zstride)
+{
+    stride_t channelsize = pixelsize / nchannels;
+    ImageSpec::auto_stride (src_xstride, src_ystride, src_zstride,
+                            channelsize, nchannels, width, height);
+    ImageSpec::auto_stride (dst_xstride, dst_ystride, dst_zstride,
+                            channelsize, nchannels, width, height);
+    bool contig = (src_xstride == dst_xstride &&
+                   src_xstride == (stride_t)pixelsize);
+    for (int z = 0;  z < depth;  ++z) {
+        for (int y = 0;  y < height;  ++y) {
+            const char *f = (const char *)src + (z*src_zstride + y*src_ystride);
+            char *t = (char *)dst + (z*dst_zstride + y*dst_ystride);
+            if (contig) {
+                // Special case: pixels within each row are contiguous
+                // in both src and dst and we're copying all channels.
+                // Be efficient by converting each scanline as a single
+                // unit.  (Note that within convert_types, a memcpy will
+                // be used if the formats are identical.)
+                memcpy (t, f, width*pixelsize);
+            } else {
+                // General case -- anything goes with strides.
+                for (int x = 0;  x < width;  ++x) {
+                    memcpy (t, f, pixelsize);
+                    f += src_xstride;
+                    t += dst_xstride;
+                }
+            }
+        }
+    }
+    return true;
 }
 
 }

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -423,8 +423,8 @@ print_info_subimage (int current_subimage, int max_subimages, ImageSpec &spec,
             if (nmip > 1 && (opt.subimages || m == 0)) {
                 printf ("    MIP %d of %d (%d x %d):\n",
                         m, nmip, mipspec.width, mipspec.height);
-                print_stats (filename, spec, current_subimage, m, nmip>1);
             }
+            print_stats (filename, spec, current_subimage, m, nmip>1);
         }
     }
 

--- a/testsuite/openexr-chroma/run.py
+++ b/testsuite/openexr-chroma/run.py
@@ -26,8 +26,8 @@ imagedir = "../../../openexr-images-1.5.0/Chromaciticies"
 # CrissyField.exr  Garden.exr       StarField.exr
 # Flowers.exr      MtTamNorth.exr
 imagedir = "../../../openexr-images-1.5.0/LuminanceChroma"
-#command = command + "; " + runtest.rw_command (imagedir, "CrissyField.exr", path)
-#command = command + "; " + runtest.rw_command (imagedir, "Flowers.exr", path)
+#command = command + "; " + runtest.rw_command (imagedir, "CrissyField.exr", path, extraargs="--compression zip")
+#command = command + "; " + runtest.rw_command (imagedir, "Flowers.exr", path, extraargs="--compression zip")
 command = command + "; " + runtest.rw_command (imagedir, "Garden.exr", path)
 #command = command + "; " + runtest.rw_command (imagedir, "MtTamNorth.exr", path)
 #command = command + "; " + runtest.rw_command (imagedir, "StarField.exr", path)

--- a/testsuite/openexr-suite/ref/out.txt
+++ b/testsuite/openexr-suite/ref/out.txt
@@ -2,7 +2,7 @@ hi
 ../../../openexr-images-1.5.0/ScanLines/Desk.exr :  644 x  874, 4 channel, half openexr
     SHA-1: CBFEA416A3CA23DF2B1599A0495EECE6FB009E5D
     channel list: R, G, B, A
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "piz"
     PixelAspectRatio: 1
     screenWindowWidth: 1
@@ -19,7 +19,7 @@ PASS
 ../../../openexr-images-1.5.0/ScanLines/Cannon.exr :  780 x  566, 3 channel, half openexr
     SHA-1: 8855671D158731258798358D78E90B2A62CF206D
     channel list: R, G, B
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "b44"
     Copyright: "Copyright 2006 Industrial Light & Magic"
     PixelAspectRatio: 1
@@ -37,7 +37,7 @@ PASS
 ../../../openexr-images-1.5.0/ScanLines/Desk.exr :  644 x  874, 4 channel, half openexr
     SHA-1: CBFEA416A3CA23DF2B1599A0495EECE6FB009E5D
     channel list: R, G, B, A
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "piz"
     PixelAspectRatio: 1
     screenWindowWidth: 1
@@ -54,7 +54,7 @@ PASS
 ../../../openexr-images-1.5.0/ScanLines/MtTamWest.exr : 1214 x  732, 4 channel, half openexr
     SHA-1: 0C7FC9D17BCF20EE043335F7D2DCFA2F19B3BA09
     channel list: R, G, B, A
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "piz"
     altitude: 716
     DateTime: "2002:06:23 16:00:00"
@@ -78,7 +78,7 @@ PASS
 ../../../openexr-images-1.5.0/ScanLines/StillLife.exr : 1240 x  846, 4 channel, half openexr
     SHA-1: F794B0D381CA2FDCE32BCAEC3734B2AB49579401
     channel list: R, G, B, A
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "piz"
     DateTime: "2002:06:23 21:30:10"
     Copyright: "Copyright 2002 Industrial Light & Magic"
@@ -98,7 +98,7 @@ PASS
 ../../../openexr-images-1.5.0/ScanLines/Tree.exr :  928 x  906, 4 channel, half openexr
     SHA-1: 75D2AAD6D04D8B8F520D391926767BC4A00E6A0F
     channel list: R, G, B, A
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "piz"
     DateTime: "2002:06:23 15:00:00"
     focus: 3.5
@@ -118,12 +118,12 @@ Subimage 0: 928 x 906, 4 channel
   0 pixels (0%) over 1e-06
 PASS
 ../../../openexr-images-1.5.0/ScanLines/Blobbies.exr : 1040 x 1040, 5 channel, half/half/half/half/float openexr
-    SHA-1: 64C3C765E0D40AA92E066F6EC9198A8053BF1179
+    SHA-1: EB3666BD3C1916A78974CE862F1BE06B600BEE56
     channel list: R (half), G (half), B (half), A (half), Z (float)
     pixel data origin: x=-20, y=-20
     full/display size: 1000 x 1000
     full/display origin: 0, 0
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "zip"
     DateTime: "2004:01:19 12:55:33"
     Copyright: "Copyright 2004 Industrial Light & Magic"
@@ -144,7 +144,7 @@ PASS
 ../../../openexr-images-1.5.0/TestImages/AllHalfValues.exr :  256 x  256, 3 channel, half openexr
     SHA-1: 4428F325F403515E6B3BF8E290FB7EDBF959ECF7
     channel list: R, G, B
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "piz"
     PixelAspectRatio: 1
     screenWindowWidth: 1
@@ -161,7 +161,7 @@ PASS
 ../../../openexr-images-1.5.0/TestImages/BrightRings.exr :  800 x  800, 3 channel, half openexr
     SHA-1: F6528D07E75DA1CE490DA6A93EB68573070FFB4B
     channel list: R, G, B
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "zip"
     PixelAspectRatio: 1
     screenWindowWidth: 1
@@ -178,7 +178,7 @@ PASS
 ../../../openexr-images-1.5.0/TestImages/BrightRingsNanInf.exr :  800 x  800, 3 channel, half openexr
     SHA-1: 73F0C53CFCE17B37DD873CF5FE4C9DF0DDB4D3DD
     channel list: R, G, B
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "zip"
     PixelAspectRatio: 1
     screenWindowWidth: 1
@@ -195,7 +195,7 @@ PASS
 ../../../openexr-images-1.5.0/TestImages/GammaChart.exr :  800 x  800, 3 channel, half openexr
     SHA-1: D21C1DC58FEC725E62D5A9F1503965CBD1A9BFD4
     channel list: R, G, B
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "pxr24"
     PixelAspectRatio: 1
     screenWindowWidth: 1
@@ -212,7 +212,7 @@ PASS
 ../../../openexr-images-1.5.0/TestImages/GrayRampsDiagonal.exr :  800 x  800, 1 channel, half openexr
     SHA-1: 4CC9922AFAD6CA706D66E466BEA9E93D9E813B39
     channel list: Y
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "pxr24"
     PixelAspectRatio: 1
     screenWindowWidth: 1
@@ -229,7 +229,7 @@ PASS
 ../../../openexr-images-1.5.0/TestImages/GrayRampsHorizontal.exr :  800 x  800, 1 channel, half openexr
     SHA-1: 1F0A6393B53BCA1AF072EA8B7795AE19FE2C8883
     channel list: Y
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "pxr24"
     PixelAspectRatio: 1
     screenWindowWidth: 1
@@ -246,7 +246,7 @@ PASS
 ../../../openexr-images-1.5.0/TestImages/RgbRampsDiagonal.exr :  800 x  800, 3 channel, half openexr
     SHA-1: 8C973B65215B6C1BC0D29376F1C49D6A9A6CFA19
     channel list: R, G, B
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "pxr24"
     PixelAspectRatio: 1
     screenWindowWidth: 1
@@ -263,7 +263,7 @@ PASS
 ../../../openexr-images-1.5.0/TestImages/SquaresSwirls.exr : 1000 x 1000, 3 channel, half openexr
     SHA-1: C0A591BDED4A83540BBEFC9FD0549FEEE499EB3A
     channel list: R, G, B
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "pxr24"
     PixelAspectRatio: 1
     screenWindowWidth: 1
@@ -280,7 +280,7 @@ PASS
 ../../../openexr-images-1.5.0/TestImages/WideColorGamut.exr :  800 x  800, 3 channel, half openexr
     SHA-1: B49406C6AA10E1E3CCA7AAF3BF68FDD3E5790643
     channel list: R, G, B
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "zip"
     PixelAspectRatio: 1
     screenWindowWidth: 1
@@ -297,7 +297,7 @@ PASS
 ../../../openexr-images-1.5.0/TestImages/WideFloatRange.exr :  500 x  500, 1 channel, float openexr
     SHA-1: 9009BE7DD8CC438F258A48243056E6D46E6147EB
     channel list: G
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "pxr24"
     PixelAspectRatio: 1
     screenWindowWidth: 1
@@ -315,7 +315,7 @@ PASS
     SHA-1: 828CD8188CC4A237C8025BA6634D1682A7F8C9BB
     channel list: R, G, B
     tile size: 128 x 128
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "piz"
     altitude: 274.5
     FNumber: 2.8
@@ -344,7 +344,7 @@ PASS
     SHA-1: 32BF0712FEABFFB448898D91F97E5C38BD351FD7
     channel list: R, G, B
     tile size: 128 x 128
-    Color space: unknown
+    oiio:ColorSpace: "Linear"
     compression: "zip"
     focus: inf
     Copyright: "Copyright 2004 Industrial Light & Magic"

--- a/testsuite/openexr-suite/run.py
+++ b/testsuite/openexr-suite/run.py
@@ -29,7 +29,7 @@ imagedir = "../../../openexr-images-1.5.0/DisplayWindow"
 imagedir = "../../../openexr-images-1.5.0/ScanLines"
 #command = command + "; " + runtest.rw_command (imagedir, "Blobbies.exr", path)
 command = command + "; " + runtest.rw_command (imagedir, "Desk.exr", path)
-command = command + "; " + runtest.rw_command (imagedir, "Cannon.exr", path)
+command = command + "; " + runtest.rw_command (imagedir, "Cannon.exr", path, extraargs="--compression zip")
 command = command + "; " + runtest.rw_command (imagedir, "Desk.exr", path)
 command = command + "; " + runtest.rw_command (imagedir, "MtTamWest.exr", path)
 command = command + "; " + runtest.rw_command (imagedir, "StillLife.exr", path)

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -118,11 +118,11 @@ def runtest (command, outputs, cleanfiles="", failureok=0) :
 # correctly).  If testwrite is nonzero, also iconvert the file to make a
 # copy (tests writing that format), and then idiff to make sure it
 # matches the original.
-def rw_command (dir, filename, cmdpath, testwrite=1) :
+def rw_command (dir, filename, cmdpath, testwrite=1, extraargs="") :
     cmd = cmdpath + oiio_app("iinfo") + " -v -a --hash " + dir + "/" + filename + " >> out.txt ; "
     print (cmd)
     if testwrite :
-        cmd = cmd + cmdpath + oiio_app("iconvert") + dir + "/" + filename + " " + filename + " >> out.txt ; "
+        cmd = cmd + cmdpath + oiio_app("iconvert") + dir + "/" + filename + " " + extraargs + " " + filename + " >> out.txt ; "
         cmd = cmd + cmdpath + oiio_app("idiff") + "-a " + dir + "/" + filename + " " + filename + " >> out.txt "
     return cmd
 


### PR DESCRIPTION
I've been working on this on and off for a long time, but I believe it's now complete.

This patch extends the ImageInput and ImageOutput APIs to have methods that are able to read and write multiple scanlines or tiles at once.  It's fully back-compatible in source (though obviously not in linkage).

The default implementation, for format plugins that don't supply {read,write}_{scanlines,tiles}, is to just loop over scanlines or tiles and call the 1-at-a-time version.

I've implemented the multi-line/tile versions of OpenEXR, one of the few formats libraries that supports it in a helpful way -- OpenEXR is nicely multithreaded when you are reading or writing more than one tile or scanline.  As an example, I see the following performance improvement in a maketx of a 4k x 4k texture on an 8-core machine:

before:

  total runtime:   23.47
  file read:        6.49
  file write:      14.12

after:

  total runtime:   10.62
  file read:        5.47
  file write:       2.53

The read times don't improve much because we're using the ImageCache, which is reading just one tile at a time.  But writing the mip-mapped output -- 5.5x improvement on 8 cores (mostly because the tiles can compress in parallel).

Scattered in the code are a few minor bug fixes I found along the way.  Also this incorporates the PNM and TypeDesc changes I submitted separate reviews for; just ignore those here, I will commit them separately as they pass review.

Please try to look at this, I think it will be an important performance improvement for the next major release.  Obviously, because it alters the API, it will not be back-ported to 0.10.

I just realized that I've only partially documented the new functions in the LaTeX manual; I will amend that later (hopefully today), but it should not stop you from reviewing the code.
