### PR TITLE
Update test suite to point to new test image repo

### DIFF
--- a/testsuite/gpsread/run.py
+++ b/testsuite/gpsread/run.py
@@ -13,7 +13,7 @@ sys.path = [".."] + sys.path
 import runtest
 
 # A command to run
-command = path + runtest.oiio_app("iinfo") + " -v ../../../oiio-testimages/tahoe-gps.jpg > out.txt"
+command = path + runtest.oiio_app("iinfo") + " -v ../../../oiio-images/tahoe-gps.jpg > out.txt"
 
 # Outputs to check against references
 outputs = [ "out.txt" ]

--- a/testsuite/ico/run.py
+++ b/testsuite/ico/run.py
@@ -16,7 +16,7 @@ import runtest
 # Start off
 command = "echo hi> out.txt"
 
-imagedir = "../../../oiio-testimages"
+imagedir = "../../../oiio-images"
 
 # Run the tests
 command = command + "; " + runtest.rw_command (imagedir, "oiio.ico", path)

--- a/testsuite/imagecache-files/run.py
+++ b/testsuite/imagecache-files/run.py
@@ -16,7 +16,7 @@ import runtest
 # Files that need to be cleaned up, IN ADDITION to outputs
 cleanfiles = [ "out.txt" "out.exr" ]
 
-texfile = "../../../oiio-testimages/grid.tx"
+texfile = "../../../oiio-images/grid.tx"
 
 # Make 10 copies of the grid texture, to different names to force
 # lots of filse in the cache.

--- a/testsuite/run-template.py
+++ b/testsuite/run-template.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python 
 
 # A command to run
-command = "iinfo -v ../../../../oiio-testimages/tahoe-gps.jpg > out.txt"
+command = "iinfo -v ../../../../oiio-images/tahoe-gps.jpg > out.txt"
 
 # Outputs to check against references
 outputs = [ "out.txt" ]

--- a/testsuite/texture-grid/run.py
+++ b/testsuite/texture-grid/run.py
@@ -13,7 +13,7 @@ sys.path = [".."] + sys.path
 import runtest
 
 # A command to run
-command = path + runtest.oiio_app("testtex") + " ../../../oiio-testimages/grid.tx ; "
+command = path + runtest.oiio_app("testtex") + " ../../../oiio-images/grid.tx ; "
 command = command + path + runtest.oiio_app("idiff") + " out.exr ref/out.exr > out.txt"
 # Outputs to check against references
 outputs = [  ]

--- a/testsuite/texture-pointsample/run.py
+++ b/testsuite/texture-pointsample/run.py
@@ -13,7 +13,7 @@ sys.path = [".."] + sys.path
 import runtest
 
 # A command to run
-command = path + runtest.oiio_app("testtex") + " -width 0 ../../../oiio-testimages/grid.tx ; "
+command = path + runtest.oiio_app("testtex") + " -width 0 ../../../oiio-images/grid.tx ; "
 command = command + path + runtest.oiio_app("idiff") + " out.exr ref/out.exr > out.txt"
 # Outputs to check against references
 outputs = [  ]

--- a/testsuite/texture-res/run.py
+++ b/testsuite/texture-res/run.py
@@ -13,7 +13,7 @@ sys.path = [".."] + sys.path
 import runtest
 
 # A command to run
-command = path + runtest.oiio_app ("testtex") + " -res 256 256 --nowarp ../../../oiio-testimages/miplevels.tx -o out.tif; "
+command = path + runtest.oiio_app ("testtex") + " -res 256 256 --nowarp ../../../oiio-images/miplevels.tx -o out.tif; "
 command = command + path + runtest.oiio_app ("idiff") + " --fail 0.0005 --warn 0.0005 out.tif ref/out.tif > out.txt"
 
 # Outputs to check against references


### PR DESCRIPTION
Since the move to git, the repo is called "oiio-images" instead of "oiio-testimages".
