### PR TITLE
Review: Change write_rectangle and to_native_rectangle to use begin/end

### DIFF
--- a/src/doc/imageoutput.tex
+++ b/src/doc/imageoutput.tex
@@ -1173,21 +1173,34 @@ and frees any memory or resources associated with it.
      const void *data, \\
 \bigspc stride_t xstride=AutoStride)}
 
-Write a full scanline that includes pixels $(*,y,z)$.  For 2D non-volume
+Write a block of scanlines that include pixels $(*,y,z)$, where
+$\mathit{ybegin} \le y < \mathit{yend}$.  This is 
+essentially identical to \writescanline, except that can write more than
+one scanline at a time, which may be more efficient for certain image
+format writers.
+\apiend
+
+\apiitem{bool {\ce write_scanlines} (int ybegin, int yend, int z, TypeDesc format,
+     const void *data, \\
+\bigspc stride_t xstride=AutoStride, stride_t ystride=AutoStride)}
+
+Write a block of scanlines scanline that includes pixels $(*,y,z)$,
+where ${\mathit ybegin} \le y < {\mathit yend}$.  For 2D non-volume
 images, $z$ is ignored.  The {\kw xstride} value gives the distance
-between successive pixels (in bytes).  Strides set to the special value
+between successive pixels (in bytes), and {\kw ystride} gives the 
+distance between successive scanlines.  Strides set to the special value
 {\kw AutoStride} imply contiguous data, i.e., \\ \spc {\kw xstride} $=$
-{\kw spec.nchannels*format.size()} \\ This method
-automatically converts the data from the specified {\kw format} to the
-actual output format of the file.  
+{\kw spec.nchannels*format.size()}, {\kw ystride} $=$ {\kw spec.width*xstride}.\\
+
+This method automatically converts the data from the specified {\kw format}
+to the actual output format of the file.  
 If {\cf format} is {\cf TypeDesc::UNKNOWN}, the data is assumed to
 already be in the file's native format (including per-channel formats, 
 as specified in the \ImageSpec's {\cf channelformats} field, if applicable).
-Return {\kw true} for success, {\kw
-  false} for failure.  It is a failure to call \writescanline with an
+Return {\kw true} for success, {\kw false} for failure.  
+It is a failure to call \writescanline with an
 out-of-order scanline if this format driver does not support random
 access.
-
 \apiend
 
 \apiitem{bool {\ce write_tile} (int x, int y, int z, TypeDesc format,
@@ -1214,15 +1227,39 @@ format driver does not support random access.
 
 \apiend
 
-\apiitem{bool {\ce write_rectangle} ({\small int xmin, int xmax, int ymin, int ymax,
-                                  int zmin, int zmax,} \\ \bigspc TypeDesc format,
+\apiitem{bool {\ce write_tiles} (int xbegin, int xend, int ybegin, int yend,\\
+\bigspc int zbegin, int zend, TypeDesc format, const void *data, \\
+\bigspc stride_t xstride=AutoStride, stride_t ystride=AutoStride, \\
+\bigspc stride_t zstride=AutoStride)}
+
+Write the tiles that include pixels {\kw xbegin} $\le x <$ {\kw xend},
+{\kw ybegin} $\le y <$ {\kw yend}, {\kw zbegin} $\le z <$ {\kw zend}
+from {\kw data}
+($z=0$ for non-volume images),
+converting if necessary from {\kw format} specified into the file's
+native data format.
+If {\cf format} is {\cf TypeDesc::UNKNOWN}, the data will be assumed
+to already be in the native format (including per-channel formats, if applicable).
+The stride values
+give the data spacing of adjacent pixels, scanlines, and volumetric
+slices, respectively (measured in bytes).  Strides set to the special
+value of {\kw AutoStride} imply contiguous data, i.e., \\
+\spc {\kw xstride} $=$ {\kw spec.nchannels * spec.pixel_size()} \\
+\spc {\kw ystride} $=$ {\kw xstride * (xend-xbegin)} \\
+\spc {\kw zstride} $=$ {\kw ystride * (yend-ybegin)} \\
+The data for those tiles is assumed to be in the usual image order, as if
+it were just one big tile, and not ``paded'' to a whole multiple of the tile size.
+\apiend
+
+\apiitem{bool {\ce write_rectangle} ({\small int xbegin, int xend, int ybegin, int yend,
+                                  int zbegin, int zend,} \\ \bigspc TypeDesc format,
                                   const void *data, \\ \bigspc stride_t xstride=AutoStride,
                                   stride_t ystride=AutoStride, \\
                                   \bigspc stride_t zstride=AutoStride)}
 
-Write pixels whose $x$ coords range over {\kw xmin}...{\kw xmax}
-(inclusive), $y$ coords over {\kw ymin}...{\kw ymax}, and $z$ coords
-over {\kw zmin}...{\kw zmax}.  The three stride values give the distance
+Write pixels covering the range that includes pixels {\kw xbegin} $\le x <$ {\kw xend},
+{\kw ybegin} $\le y <$ {\kw yend}, {\kw zbegin} $\le z <$ {\kw zend}.
+The three stride values give the distance
 (in bytes) between successive pixels, scanlines, and volumetric slices,
 respectively.  Strides set to the special value {\kw AutoStride} imply
 contiguous data, i.e.,\\

--- a/src/doc/writingplugins.tex
+++ b/src/doc/writingplugins.tex
@@ -239,11 +239,21 @@ real-world example of writing a JPEG/JFIF plug-in.
   behavior is not appropriate for your plugin:
 
   \begin{enumerate}
-    \item[(g)] {\cf write_tile()}, only if your format supports
+    \item[(g)] {\cf write_scanlines()}, only if your format supports
+      writing scanlines and you can get a performance improvement when
+      outputting multiple scanlines at once.  If you don't supply
+      {\cf write_scanlines()}, the default implementation will simply
+      call {\cf write_scanline()} repeatedly.
+    \item[(h)] {\cf write_tile()}, only if your format supports
       writing tiled images.
-    \item[(h)] {\cf write_rectangle()}, only if your format supports
+    \item[(i)] {\cf write_tiles()}, only if your format supports
+      writing tiled images and you can get a performance improvement
+      when outputting multiple tiles at once.  If you don't supply
+      {\cf write_tiles()}, the default implementation will simply
+      call {\cf write_tile()} repeatedly.
+    \item[(j)] {\cf write_rectangle()}, only if your format supports
       writing arbitrary rectangles.
-    \item[(i)] {\cf write_image()}, only if you have a more clever
+    \item[(k)] {\cf write_image()}, only if you have a more clever
       method of doing so than the default implementation that calls
       {\cf write_scanline()} or {\cf write_tile()} repeatedly.
   \end{enumerate}
@@ -323,9 +333,8 @@ allocated memory (other than eventually destroying the scratch vector).
 
 \apiend
 
-\apiitem{const void * {\ce to_native_rectangle} (int xmin, int xmax, int
-  ymin, int ymax, \\ \bigspc
-                                     int zmin, int zmax, 
+\apiitem{const void * {\ce to_native_rectangle} (int xbegin, int xend, int ybegin, int yend, \\ \bigspc
+                                     int zbegin, int zend, 
                                      TypeDesc format, const void
                                      *data, \\ \bigspc
                                      stride_t xstride, stride_t ystride,

--- a/src/include/imageio.h
+++ b/src/include/imageio.h
@@ -768,10 +768,9 @@ public:
                               stride_t ystride=AutoStride,
                               stride_t zstride=AutoStride);
 
-
-    /// Write pixels whose x coords range over xmin..xmax (inclusive), y
-    /// coords over ymin..ymax, and z coords over zmin...zmax.  The
-    /// three stride values give the distance (in bytes) between
+    /// Write a rectangle of pixels given by the range
+    ///   [xbegin,xend) X [ybegin,yend) X [zbegin,zend)
+    /// The three stride values give the distance (in bytes) between
     /// successive pixels, scanlines, and volumetric slices,
     /// respectively.  Strides set to AutoStride imply 'contiguous'
     /// data, i.e.,
@@ -779,15 +778,16 @@ public:
     ///     ystride == xstride * (xmax-xmin+1)
     ///     zstride == ystride * (ymax-ymin+1)
     /// The data are automatically converted from 'format' to the actual
-    /// output format (as specified to open()) by this method.  
-    /// If format is TypeDesc::UNKNOWN, then rather than converting from
-    /// format, it will just copy pixels in the file's native data layout
-    /// (including, possibly, per-channel data formats).
+    /// output format (as specified to open()) by this method.  If
+    /// format is TypeDesc::UNKNOWN, it will just copy pixels assuming
+    /// they are already in the file's native data layout (including,
+    /// possibly, per-channel data formats).
+    ///
     /// Return true for success, false for failure.  It is a failure to
     /// call write_rectangle for a format plugin that does not return
     /// true for supports("rectangles").
-    virtual bool write_rectangle (int xmin, int xmax, int ymin, int ymax,
-                                  int zmin, int zmax, TypeDesc format,
+    virtual bool write_rectangle (int xbegin, int xend, int ybegin, int yend,
+                                  int zbegin, int zend, TypeDesc format,
                                   const void *data, stride_t xstride=AutoStride,
                                   stride_t ystride=AutoStride,
                                   stride_t zstride=AutoStride);
@@ -872,8 +872,8 @@ protected:
                                 stride_t xstride, stride_t ystride,
                                 stride_t zstride,
                                 std::vector<unsigned char> &scratch);
-    const void *to_native_rectangle (int xmin, int xmax, int ymin, int ymax,
-                                     int zmin, int zmax,
+    const void *to_native_rectangle (int xbegin, int xend, int ybegin, int yend,
+                                     int zbegin, int zend,
                                      TypeDesc format, const void *data,
                                      stride_t xstride, stride_t ystride,
                                      stride_t zstride,

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -624,9 +624,8 @@ OpenEXROutput::write_scanlines (int ybegin, int yend, int z,
     for ( ;  ok && ybegin < yend;  ybegin += chunk) {
         int y1 = std::min (ybegin+chunk, yend);
         int nscanlines = y1 - ybegin;
-        
-        const void *d = to_native_rectangle (m_spec.x, m_spec.x+m_spec.width-1,
-                                             ybegin, y1-1, z, z, format, data,
+        const void *d = to_native_rectangle (m_spec.x, m_spec.x+m_spec.width,
+                                             ybegin, y1, z, z+1, format, data,
                                              xstride, ystride, zstride,
                                              m_scratch);
 
@@ -710,10 +709,7 @@ OpenEXROutput::write_tiles (int xbegin, int xend, int ybegin, int yend,
         xstride = (stride_t) user_pixelbytes;
     m_spec.auto_stride (xstride, ystride, zstride, format, spec().nchannels,
                         (xend-xbegin), (yend-ybegin));
-
-    // FIXME -- to_native_rectangle really needs to use begin/end notation,
-    // rather than min/max.
-    data = to_native_rectangle (xbegin, xend-1, ybegin, yend-1, zbegin, zend-1,
+    data = to_native_rectangle (xbegin, xend, ybegin, yend, zbegin, zend,
                                 format, data, xstride, ystride, zstride,
                                 m_scratch);
 

--- a/src/python/py_imageoutput.cpp
+++ b/src/python/py_imageoutput.cpp
@@ -103,15 +103,15 @@ bool ImageOutputWrap::write_tile(int x, int y, int z, TypeDesc format, object &b
 }
 
 // TESTME
-bool ImageOutputWrap::write_rectangle(int xmin, int xmax, int ymin, int ymax, 
-                                    int zmin, int zmax, TypeDesc format, 
+bool ImageOutputWrap::write_rectangle(int xbegin, int xend, int ybegin, int yend,
+                                     int zbegin, int zend, TypeDesc format, 
                                     object &buffer, stride_t xstride=AutoStride,
                                     stride_t ystride=AutoStride,
                                     stride_t zstride=AutoStride)
 {
     const void *array = make_read_buffer(buffer);
-    return m_output->write_rectangle(xmin, xmax, ymin, ymax, zmin, zmax, format,
-                                array, xstride, ystride, zstride);
+    return m_output->write_rectangle(xbegin, xend, ybegin, yend, zbegin, zend,
+                                     format, array, xstride, ystride, zstride);
 }
 
 // The write_image method is a bit different from the c++ interface. 


### PR DESCRIPTION
Change write_rectangle and to_native_rectangle, the last two API functions to use min/max pixel ranges, to use begin/end ranges like everybody else.  Also include more docs accidentally left out of the scanlines/tiles change.

In the ancient past, we specified ranges as min/max.  A year or two ago, we systematically changed them all to be [begin,end) a la STL.  There were two places we missed.

I regret to say that this is not a backward-compatible change, it truly changes the semantics of two existing methods.  But one is private, only called from one place, and the other public one I bet is totally unused, since it is at the moment not directly supported by any of our shipping formats.  So hopefully nobody will get bitten by this change.
