### PR TITLE
Fix several Cineon warnings

### DIFF
--- a/src/cineon.imageio/libcineon/CineonHeader.h
+++ b/src/cineon.imageio/libcineon/CineonHeader.h
@@ -43,6 +43,7 @@
 
 #include <cstring>
 #include <stdint.h>
+#include <limits>
 
 #include "CineonStream.h"
 
@@ -1275,7 +1276,7 @@ namespace cineon
 	inline R32 GenericHeader::LowData(const int i) const
 	{
 		if (i < 0 || i >= MAX_ELEMENTS)
-			return 1.f / (1.f - 1.f);	// +infinity
+			return std::numeric_limits<R32>::infinity();
 		return this->chan[i].lowData;
 	}
 
@@ -1289,7 +1290,7 @@ namespace cineon
 	inline R32 GenericHeader::LowQuantity(const int i) const
 	{
 		if (i < 0 || i >= MAX_ELEMENTS)
-			return 0xffffffff;
+			return std::numeric_limits<R32>::max();
 		return this->chan[i].lowQuantity;
 	}
 
@@ -1303,7 +1304,7 @@ namespace cineon
 	inline R32 GenericHeader::HighData(const int i) const
 	{
 		if (i < 0 || i >= MAX_ELEMENTS)
-			return 0xffffffff;
+			return std::numeric_limits<R32>::max();
 		return this->chan[i].highData;
 	}
 
@@ -1317,7 +1318,7 @@ namespace cineon
 	inline R32 GenericHeader::HighQuantity(const int i) const
 	{
 		if (i < 0 || i >= MAX_ELEMENTS)
-			return 0xffffffff;
+			return std::numeric_limits<R32>::max();
 		return this->chan[i].highQuantity;
 	}
 

--- a/src/cineon.imageio/libcineon/Writer.cpp
+++ b/src/cineon.imageio/libcineon/Writer.cpp
@@ -290,9 +290,9 @@ bool cineon::Writer::WriteElement(const int element, void *data, const DataSize 
 
 		case 64:
 			if (size == cineon::kLongLong)
-				this->fileLoc += WriteBuffer<R64, 64, true>(this->fd, size, data, width, height, noc, packing, reverse, eolnPad, blank, status);
+				this->fileLoc += WriteBuffer<U64, 64, true>(this->fd, size, data, width, height, noc, packing, reverse, eolnPad, blank, status);
 			else
-				this->fileLoc += WriteBuffer<R64, 64, false>(this->fd, size, data, width, height, noc, packing, reverse, eolnPad, blank, status);
+				this->fileLoc += WriteBuffer<U64, 64, false>(this->fd, size, data, width, height, noc, packing, reverse, eolnPad, blank, status);
 			break;
 		}
 	}


### PR DESCRIPTION
Apparently, Patrick Palmer preferred to hack in his own +infinity instead of using std::numeric_limits.

This doesn't fix the negative bit shift warnings from the writer, however. I'm not sure it's worth trying to correct them, as without rewriting that code althogether, I could probably break more things than I'd fix, and we have a library switch in perspective.
