### PR TITLE
Review: Make ImageCache/ImageBuf able to report native file spec

### DIFF
--- a/src/doc/imagecache.tex
+++ b/src/doc/imagecache.tex
@@ -416,7 +416,7 @@ matches both the name and data type.
 \apiend
 
 \apiitem{bool {\ce get_imagespec} (ustring filename, ImageSpec \&spec,\\
-\bigspc  int subimage=0, int miplevel=0)}
+\bigspc  int subimage=0, int miplevel=0, bool native=false)}
 
 If the named image (and the specific subimage and MIP level) is found and able to be opened by an available
 image format plugin, and the designated subimage exists, this function copies
@@ -426,10 +426,16 @@ is not of a format readable by any plugin that could be found, or
 the designated subimage did not exist in the file, the return value is
 {\cf false} and {\cf spec} will not be modified.
 
+If {\cf native} is {\cf false} (the default), then the spec retrieved
+will accurately describe the image stored internally in the cache,
+whereas if {\cf native} is {\cf true}, the spec retrieved will reflect
+the original file.  These may differ due to use of certain \ImageCache
+settings such as \qkw{forcefloat} or \qkw{autotile}.
+
 \apiend
 
 \apiitem{const ImageSpec * {\ce imagespec} (ustring filename, int
-  subimage=0, int miplevel=0)}
+  subimage=0, int miplevel=0, bool native=false)}
 
 If the named image is found and able to be opened by an available
 image format plugin, and the designated subimage exists, this function
@@ -437,6 +443,12 @@ returns a pointer to an \ImageSpec that describes it.  Otherwise, if the
 file is not found, could not be opened, is not of a format readable by
 any plugin that could be find, or the designated subimage did
 not exist in the file, the return value is NULL.
+
+If {\cf native} is {\cf false} (the default), then the spec retrieved
+will accurately describe the image stored internally in the cache,
+whereas if {\cf native} is {\cf true}, the spec retrieved will reflect
+the original file.  These may differ due to use of certain \ImageCache
+settings such as \qkw{forcefloat} or \qkw{autotile}.
 
 This method is much more efficient than {\cf get_imagespec()}, since it
 just returns a pointer to the spec held internally by the \ImageCache

--- a/src/include/imagebuf.h
+++ b/src/include/imagebuf.h
@@ -135,9 +135,16 @@ public:
     ///
     std::string error_message () const { return geterror (); }
 
-    /// Return a read-only (const) reference to the image spec.
-    ///
+    /// Return a read-only (const) reference to the image spec that
+    /// describes the buffer.
     const ImageSpec & spec () const { return m_spec; }
+
+    /// Return a read-only (const) reference to the "native" image spec
+    /// (that describes the file, which may be slightly different than
+    /// the spec of the ImageBuf, particularly if the IB is backed by an
+    /// ImageCache that is imposing some particular data format or tile
+    /// size).
+    const ImageSpec & nativespec () const { return m_nativespec; }
 
     /// Return the name of this image.
     ///
@@ -882,6 +889,7 @@ protected:
     int m_current_miplevel;      ///< Current miplevel we're viewing
     int m_nmiplevels;            ///< # of MIP levels in the current subimage
     ImageSpec m_spec;            ///< Describes the image (size, etc)
+    ImageSpec m_nativespec;      ///< Describes the true native image
     std::vector<char> m_pixels;  ///< Pixel data
     bool m_localpixels;          ///< Pixels are local, in m_pixels
     bool m_spec_valid;           ///< Is the spec valid

--- a/src/include/imagecache.h
+++ b/src/include/imagecache.h
@@ -137,7 +137,8 @@ public:
     /// return true.  Return false if the file was not found or could
     /// not be opened as an image file by any available ImageIO plugin.
     virtual bool get_imagespec (ustring filename, ImageSpec &spec,
-                                int subimage=0, int miplevel=0) = 0;
+                                int subimage=0, int miplevel=0,
+                                bool native=false) = 0;
 
     /// Return a pointer to an ImageSpec associated with the named image
     /// (the first subimage & miplevel by default, or as set by
@@ -151,7 +152,7 @@ public:
     /// as long as nobody (even other threads) calls invalidate() on the
     /// file, or invalidate_all(), or destroys the ImageCache.
     virtual const ImageSpec *imagespec (ustring filename, int subimage=0,
-                                        int miplevel=0) = 0;
+                                        int miplevel=0, bool native=false) = 0;
 
     /// Retrieve the rectangle of pixels spanning [xbegin..xend) X
     /// [ybegin..yend) X [zbegin..zend), with "exclusive end" a la STL,

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -92,6 +92,7 @@ ImageBuf::clear ()
     m_current_subimage = -1;
     m_current_miplevel = -1;
     m_spec = ImageSpec ();
+    m_nativespec = ImageSpec ();
     {
         std::vector<char> tmp;
         std::swap (m_pixels, tmp);  // clear it with deallocation
@@ -153,6 +154,7 @@ void
 ImageBuf::alloc (const ImageSpec &spec)
 {
     m_spec = spec;
+    m_nativespec = spec;
     m_spec_valid = true;
     realloc ();
 }
@@ -180,6 +182,7 @@ ImageBuf::init_spec (const std::string &filename, int subimage, int miplevel)
     m_imagecache->get_image_info (m_name, subimage, miplevel, s_miplevels,
                                   TypeDesc::TypeInt, &m_nmiplevels);
     m_imagecache->get_imagespec (m_name, m_spec, subimage, miplevel);
+    m_imagecache->get_imagespec (m_name, m_nativespec, subimage, miplevel, true);
     if (m_nsubimages) {
         m_badfile = false;
         m_spec_valid = true;
@@ -217,7 +220,8 @@ ImageBuf::read (int subimage, int miplevel, bool force, TypeDesc convert,
     }
 
     // Set our current spec to the requested subimage
-    if (! m_imagecache->get_imagespec (m_name, m_spec, subimage, miplevel)) {
+    if (! m_imagecache->get_imagespec (m_name, m_spec, subimage, miplevel) ||
+        ! m_imagecache->get_imagespec (m_name, m_nativespec, subimage, miplevel, true)) {
         m_err = m_imagecache->geterror ();
         return false;
     }

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -254,8 +254,9 @@ ImageCacheStatistics::merge (const ImageCacheStatistics &s)
 
 
 
-ImageCacheFile::LevelInfo::LevelInfo (const ImageSpec &spec_)
-    : spec(spec_)
+ImageCacheFile::LevelInfo::LevelInfo (const ImageSpec &spec_,
+                                      const ImageSpec &nativespec_)
+    : spec(spec_), nativespec(nativespec_)
 {
     full_pixel_range = (spec.x == spec.full_x && spec.y == spec.full_y &&
                         spec.z == spec.full_z &&
@@ -318,12 +319,13 @@ ImageCacheFile::open (ImageCachePerThreadInfo *thread_info)
         return false;
     }
 
-    ImageSpec tempspec;
+    ImageSpec nativespec, tempspec;
     m_broken = false;
     bool ok = true;
     for (int tries = 0; tries <= imagecache().failure_retries(); ++tries) {
-        ok = m_input->open (m_filename.c_str(), tempspec);
+        ok = m_input->open (m_filename.c_str(), nativespec);
         if (ok) {
+            tempspec = nativespec;
             if (tries)   // succeeded, but only after a failure!
                 ++thread_info->m_stats.file_retry_success;
             (void) m_input->geterror ();  // Eat the errors
@@ -356,9 +358,10 @@ ImageCacheFile::open (ImageCachePerThreadInfo *thread_info)
     do {
         m_subimages.resize (nsubimages+1);
         SubimageInfo &si (subimageinfo(nsubimages));
-        si.volume = (tempspec.depth > 1 || tempspec.full_depth > 1);
+        si.volume = (nativespec.depth > 1 || nativespec.full_depth > 1);
         int nmip = 0;
         do {
+            tempspec = nativespec;
             if (tempspec.tile_width == 0 || tempspec.tile_height == 0) {
                 si.untiled = true;
                 if (imagecache().autotile()) {
@@ -371,9 +374,9 @@ ImageCacheFile::open (ImageCachePerThreadInfo *thread_info)
                         tempspec.tile_depth = 1;
                 } else {
                     // Don't auto-tile -- which really means, make it look like
-                    // a single tile that's as big as the whole image
-                    // FIXME -- is there a good reason to round up pow 2 here?
-                    // Or does that just end up wasting space?
+                    // a single tile that's as big as the whole image.
+                    // We round to a power of 2 because the texture system
+                    // currently requires power of 2 tile sizes.
                     tempspec.tile_width = pow2roundup (tempspec.width);
                     tempspec.tile_height = pow2roundup (tempspec.height);
                     tempspec.tile_depth = pow2roundup(tempspec.depth);
@@ -389,10 +392,10 @@ ImageCacheFile::open (ImageCachePerThreadInfo *thread_info)
                 invalidate_spec ();
                 return false;
             }
-            LevelInfo levelinfo (tempspec);
+            LevelInfo levelinfo (tempspec, nativespec);
             si.levels.push_back (levelinfo);
             ++nmip;
-        } while (m_input->seek_subimage (nsubimages, nmip, tempspec));
+        } while (m_input->seek_subimage (nsubimages, nmip, nativespec));
 
         // Special work for non-MIPmapped images -- but only if "automip"
         // is on, it's a non-mipmapped image, and it doesn't have a
@@ -432,7 +435,7 @@ ImageCacheFile::open (ImageCachePerThreadInfo *thread_info)
                 s.tile_height = pow2roundup (s.tile_height);
                 s.tile_depth = pow2roundup (s.tile_depth);
                 ++nmip;
-                LevelInfo levelinfo (s);
+                LevelInfo levelinfo (s, s);
                 si.levels.push_back (levelinfo);
             }
         }
@@ -454,7 +457,7 @@ ImageCacheFile::open (ImageCachePerThreadInfo *thread_info)
         }
 
         ++nsubimages;
-    } while (m_input->seek_subimage (nsubimages, 0, tempspec));
+    } while (m_input->seek_subimage (nsubimages, 0, nativespec));
     ASSERT ((size_t)nsubimages == m_subimages.size());
 
     const ImageSpec &spec (this->spec(0,0));
@@ -1996,9 +1999,9 @@ ImageCacheImpl::get_image_info (ustring filename, int subimage, int miplevel,
 
 bool
 ImageCacheImpl::get_imagespec (ustring filename, ImageSpec &spec,
-                               int subimage, int miplevel)
+                               int subimage, int miplevel, bool native)
 {
-    const ImageSpec *specptr = imagespec (filename, subimage, miplevel);
+    const ImageSpec *specptr = imagespec (filename, subimage, miplevel, native);
     if (specptr) {
         spec = *specptr;
         return true;
@@ -2010,7 +2013,8 @@ ImageCacheImpl::get_imagespec (ustring filename, ImageSpec &spec,
 
 
 const ImageSpec *
-ImageCacheImpl::imagespec (ustring filename, int subimage, int miplevel)
+ImageCacheImpl::imagespec (ustring filename, int subimage, int miplevel,
+                           bool native)
 {
     ImageCachePerThreadInfo *thread_info = get_perthread_info ();
     ImageCacheFile *file = find_file (filename, thread_info);

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -141,6 +141,9 @@ public:
     ImageSpec & spec (int subimage, int miplevel) {
         return levelinfo(subimage,miplevel).spec;
     }
+    const ImageSpec & nativespec (int subimage, int miplevel) const {
+        return levelinfo(subimage,miplevel).nativespec;
+    }
     ustring filename (void) const { return m_filename; }
     ustring fileformat (void) const { return m_fileformat; }
     TexFormat textureformat () const { return m_texformat; }
@@ -187,12 +190,13 @@ public:
     /// precompute.
     struct LevelInfo {
         ImageSpec spec;             ///< ImageSpec for the mip level
+        ImageSpec nativespec;       ///< Native ImageSpec for the mip level
         bool full_pixel_range;      ///< pixel data window matches image window
         bool zero_origin;           ///< pixel data origin is (0,0)
         bool onetile;               ///< Whole level fits on one tile
         mutable bool polecolorcomputed;     ///< Pole color was computed
         mutable std::vector<float> polecolor;///< Pole colors
-        LevelInfo (const ImageSpec &spec);  ///< Initialize based on spec
+        LevelInfo (const ImageSpec &spec, const ImageSpec &nativespec);  ///< Initialize based on spec
     };
 
     /// Info for each subimage
@@ -205,6 +209,7 @@ public:
         SubimageInfo () : untiled(false), unmipped(false) { }
         ImageSpec &spec (int m) { return levels[m].spec; }
         const ImageSpec &spec (int m) const { return levels[m].spec; }
+        const ImageSpec &nativespec (int m) const { return levels[m].nativespec; }
     };
 
     const SubimageInfo &subimageinfo (int subimage) const {
@@ -656,10 +661,11 @@ public:
     /// the file was not found or could not be opened as an image file
     /// by any available ImageIO plugin.
     virtual bool get_imagespec (ustring filename, ImageSpec &spec,
-                                int subimage=0, int miplevel=0);
+                                int subimage=0, int miplevel=0,
+                                bool native=false);
 
     virtual const ImageSpec *imagespec (ustring filename, int subimage=0,
-                                        int miplevel=0);
+                                        int miplevel=0, bool native=false);
 
     // Retrieve a rectangle of raw unfiltered pixels.
     virtual bool get_pixels (ustring filename, int subimage, int miplevel,

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -225,7 +225,7 @@ output_file (int argc, const char *argv[])
     ImageOutput::OpenMode mode = ImageOutput::Create;  // initial open
     for (int s = 0, send = ir.subimages();  s < send;  ++s) {
         for (int m = 0, mend = ir.miplevels(s);  m < mend;  ++m) {
-            ImageSpec spec = *ir.spec(s,m);
+            ImageSpec spec = ir(s,m).nativespec();
             adjust_output_options (spec, ot);
             if (! out->open (filename, spec, mode)) {
                 std::cerr << "oiiotool ERROR: " << out->geterror() << "\n";


### PR DESCRIPTION
Fix IC/IB not able to report what was in the original file, used to solve a "bug" wherein oiiotool would always output float images instead of the original format.

When ImageBuf is backed by an ImageCache that has had "autotile" or "forcefloat" turned on, the ImageSpec for the buf would look like it was tiled and/or float regardless of the original file (by design).  But the unintended consequence was that if you called ib.save(), it would write it out as a tile/float, which is probably not what you want by default.  

The solution, not especially elegant but nicely back-compatible, is for the IC's entry and the ImageBuf to separately track both the spec that describes the buffer as well as the spec that describes the file it came from (the "native" spec), and augment a few of the "retrieve spec" methods with choices to get the native one.  We then use these in the right spots in ImageBuf::save and oiiotool to make output files have the tiling and data format used by their source images.
