### PR TITLE
Allow reset_stats of IC and TS

### DIFF
--- a/src/doc/imagecache.tex
+++ b/src/doc/imagecache.tex
@@ -530,6 +530,7 @@ modification times have been changed since they were first opened.
 \subsection{Errors and statistics}
 \label{sec:imagecache:api:geterror}
 \label{sec:imagecache:api:getstats}
+\label{sec:imagecache:api:resetstats}
 
 \apiitem{std::string {\ce geterror} ()}
 If any other API routines return {\cf false}, indicating that an error
@@ -544,6 +545,14 @@ operations, suitable for saving to a file or outputting to the terminal.
 The {\cf level} indicates the amount of detail in the statistics,
 with higher numbers (up to a maximum of 5) yielding more and more
 esoteric information.
+\apiend
+
+\apiitem{void {\ce reset_stats} ()}
+Reset most statistics to be as they were with a fresh
+\TextureSystem.  Caveat emptor: this does not flush the cache
+itelf, so the resulting statistics from the next set of texture
+requests will not match the number of tile reads, etc., that
+would have resulted from a new \TextureSystem.
 \apiend
 
 

--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -1265,6 +1265,7 @@ applied.
 \subsection{Miscellaneous -- Statistics, errors, flushing the cache}
 \label{sec:texturesys:api:geterror}
 \label{sec:texturesys:api:getstats}
+\label{sec:texturesys:api:resetstats}
 \label{sec:texturesys:api:invalidate}
 
 \apiitem{std::string {\ce geterror} ()}
@@ -1282,6 +1283,14 @@ with higher numbers (up to a maximum of 5) yielding more and more
 esoteric information.  If {\cf icstats} is true, the returned string
 will also contain all the statistics of the underlying \ImageCache,
 but if false will only contain texture-specific statistics.
+\apiend
+
+\apiitem{void {\ce reset_stats} ()}
+Reset most statistics to be as they were with a fresh
+\ImageCache.  Caveat emptor: this does not flush the cache
+itelf, so the resulting statistics from the next set of texture
+requests will not match the number of tile reads, etc., that
+would have resulted from a new \ImageCache.
 \apiend
 
 \apiitem{void {\ce invalidate} (ustring filename)}

--- a/src/include/imagecache.h
+++ b/src/include/imagecache.h
@@ -205,6 +205,13 @@ public:
     ///
     virtual std::string getstats (int level=1) const = 0;
 
+    /// Reset most statistics to be as they were with a fresh
+    /// ImageCache.  Caveat emptor: this does not flush the cache itelf,
+    /// so the resulting statistics from the next set of texture
+    /// requests will not match the number of tile reads, etc., that
+    /// would have resulted from a new ImageCache.
+    virtual void reset_stats () = 0;
+
     /// Invalidate any loaded tiles or open file handles associated with
     /// the filename, so that any subsequent queries will be forced to
     /// re-open the file or re-load any tiles (even those that were

--- a/src/include/texture.h
+++ b/src/include/texture.h
@@ -601,6 +601,13 @@ public:
     /// they were first opened.
     virtual void invalidate_all (bool force=false) = 0;
 
+    /// Reset most statistics to be as they were with a fresh
+    /// TextureSystem.  Caveat emptor: this does not flush the cache
+    /// itelf, so the resulting statistics from the next set of texture
+    /// requests will not match the number of tile reads, etc., that
+    /// would have resulted from a new TextureSystem.
+    virtual void reset_stats () = 0;
+
 private:
     // Make delete private and unimplemented in order to prevent apps
     // from calling it.  Instead, they should call TextureSystem::destroy().

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1529,6 +1529,29 @@ ImageCacheImpl::printstats () const
 
 
 
+void
+ImageCacheImpl::reset_stats ()
+{
+    {
+        lock_guard lock (m_perthread_info_mutex);
+        for (size_t i = 0;  i < m_all_perthread_info.size();  ++i)
+            m_all_perthread_info[i]->m_stats.init ();
+    }
+
+    {
+        ic_read_lock fileguard (m_filemutex);
+        for (FilenameMap::const_iterator f = m_files.begin(); f != m_files.end(); ++f) {
+            const ImageCacheFileRef &file (f->second);
+            file->m_timesopened = 0;
+            file->m_tilesread = 0;
+            file->m_bytesread = 0;
+            file->m_iotime = 0;
+        }
+    }
+}
+
+
+
 bool
 ImageCacheImpl::attribute (const std::string &name, TypeDesc type,
                            const void *val)

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -749,6 +749,7 @@ public:
 
     virtual std::string geterror () const;
     virtual std::string getstats (int level=1) const;
+    virtual void reset_stats ();
     virtual void invalidate (ustring filename);
     virtual void invalidate_all (bool force=false);
 

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -256,6 +256,7 @@ public:
 
     virtual std::string geterror () const;
     virtual std::string getstats (int level=1, bool icstats=true) const;
+    virtual void reset_stats ();
 
     virtual void invalidate (ustring filename);
     virtual void invalidate_all (bool force=false);

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -299,6 +299,15 @@ TextureSystemImpl::printstats () const
 
 
 
+void
+TextureSystemImpl::reset_stats ()
+{
+    ASSERT (m_imagecache);
+    m_imagecache->reset_stats ();
+}
+
+
+
 bool
 TextureSystemImpl::attribute (const std::string &name, TypeDesc type,
                               const void *val)

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -77,6 +77,7 @@ static Imath::V3f offset (0,0,0);
 static bool nountiled = false;
 static bool nounmipped = false;
 static bool gray_to_rgb = false;
+static bool resetstats = false;
 void *dummyptr;
 
 
@@ -125,6 +126,7 @@ getargs (int argc, const char *argv[])
                   "--offset %f %f %f", &offset[0], &offset[1], &offset[2], "Offset texture coordinates",
                   "--scalest %f %f", &sscale, &tscale, "Scale texture lookups (s, t)",
                   "--graytorgb", &gray_to_rgb, "Convert gratscale textures to RGB",
+                  "--resetstats", &resetstats, "Print and reset statistics on each iteration",
                   NULL);
     if (ap.parse (argc, argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
@@ -366,6 +368,11 @@ test_plain_texture ()
                     }
                 }
             }
+        }
+
+        if (resetstats) {
+            std::cout << texsys->getstats(2) << "\n";
+            texsys->reset_stats ();
         }
     }
     


### PR DESCRIPTION
By popular demand, add a simple method to ImageCache and TextureSystem that allows the statistics to get reset to zero.  Be careful of doing this -- stats you get after reset can be subtly misleading because they do not reflect the reads and whatnot that got tiles into the cache in the first place.  (Resetting the stats does NOT invalidate and flush the cache.)
