### PR TITLE
fix in some Find*.cmake scripts for compatibility with external svn repo

### DIFF
--- a/src/cmake/modules/FindIlmBase.cmake
+++ b/src/cmake/modules/FindIlmBase.cmake
@@ -125,7 +125,8 @@ if (ILMBASE_HOME)
       ${ILMBASE_HOME}/ilmbase-${ILMBASE_VERSION}/include
       ${ILMBASE_HOME}/include/ilmbase-${ILMBASE_VERSION})
     set (IlmBase_library_paths
-      ${ILMBASE_HOME}/ilmbase-${ILMBASE_VERSION}/lib)
+      ${ILMBASE_HOME}/ilmbase-${ILMBASE_VERSION}/lib
+      ${ILMBASE_HOME}/lib/ilmbase-${ILMBASE_VERSION})
   endif()
   list (APPEND IlmBase_include_paths ${ILMBASE_HOME}/include)
   set (IlmBase_library_paths

--- a/src/cmake/modules/FindOpenEXR.cmake
+++ b/src/cmake/modules/FindOpenEXR.cmake
@@ -121,9 +121,11 @@ if (OPENEXR_HOME)
     ${OPENEXR_HOME}/lib64)
   if (OPENEXR_VERSION)
     set (OpenEXR_include_paths
-      ${OPENEXR_HOME}/openexr-${OPENEXR_VERSION}/include)
+      ${OPENEXR_HOME}/openexr-${OPENEXR_VERSION}/include
+      ${OPENEXR_HOME}/include/openexr-${OPENEXR_VERSION})
     list (APPEND OpenEXR_library_paths
-      ${OPENEXR_HOME}/openexr-${OPENEXR_VERSION}/lib)
+      ${OPENEXR_HOME}/openexr-${OPENEXR_VERSION}/lib
+      ${OPENEXR_HOME}/lib/openexr-${OPENEXR_VERSION})
   endif()
   list (APPEND OpenEXR_include_paths ${OPENEXR_HOME}/include)
   if (OPENEXR_LIB_AREA)


### PR DESCRIPTION
latest version of external svn repo puts output for ilmbase / openexr in, ie, ${ILMBASE_HOME}/lib/ilmbase-1.0.1 and ${ILMBASE_HOME}/include/ilmbase-1.0.1

This commit modifies src/cmake/modules/FindIlmBase.cmake / FindOpenExr.cmake so that they can find these modules in the build output of the latest external repo.
