### PR TITLE
Review: maketx --alpha1-detect

### DIFF
--- a/src/doc/maketx.tex
+++ b/src/doc/maketx.tex
@@ -178,6 +178,19 @@ if the ``client'' application will attempt to access those other
 channels that will no longer exist.
 \apiend
 
+\apiitem{--opaque-detect}
+Detects images that have a designated alpha channel for which the alpha value
+for all pixels is 1.0 (fully opaque), and omits the alpha channel from
+the output texture.  So, for example, an RGBA input texture where A=1
+for all pixels will be output just as RGB.  The purpose is to save disk
+space, texture I/O bandwidth, and texturing time for those textures
+where alpha was present in the input, but clearly not necessary.
+
+Use with caution!  This is a great optimization only if your use of such
+textures will assume that missing alpha channels are equivalent to
+textures whose alpha is 1.0 everywhere.
+\apiend
+
 \apiitem{--prman}
 PRMan is will crash in strange ways if given textures that don't have
 its quirky set of tile sizes and other specific metadata.  If you want

--- a/src/include/imagebufalgo.h
+++ b/src/include/imagebufalgo.h
@@ -196,9 +196,14 @@ bool DLLPUBLIC compare (const ImageBuf &A, const ImageBuf &B,
 int DLLPUBLIC compare_Yee (const ImageBuf &img0, const ImageBuf &img1,
                            float luminance = 100, float fov = 45);
 
-/// You can optionally query the constantvalue'd color
-/// (current subimage, and current mipmap level)
+/// Do all pixels for the entire image have the same channel values?  If
+/// color is not NULL, that constant value will be stored in
+/// color[0..nchannels-1].
 bool DLLPUBLIC isConstantColor (const ImageBuf &src, float *color = NULL);
+
+/// Does the requested channel have a given value over the entire image?
+///
+bool DLLPUBLIC isConstantChannel (const ImageBuf &src, int channel, float val);
 
 /// Is the image monochrome? (i.e., are all channels the same value?)
 /// zero and one channel images always return true


### PR DESCRIPTION
maketx --alpha1-detect will omit alpha from textures whose input images had designated alpha channels that were 1.0 for all pixels.  Somewhat similar in operation to --monochrome-detect and --constant-detect.

Also adds ImageBufAlgo::isConstantChannel() utility and does some minor cleanup/simplification to isConstantColor.

(Yes, this is because we have textures with pointless alpha=1 everywhere, and it's easier to fix in image-to-texture conversion than it is to actually fix the problem upstream.)
