### PR TITLE
filters updated: sinc, blackman-harris, gaussian

### DIFF
--- a/src/libutil/filter.cpp
+++ b/src/libutil/filter.cpp
@@ -41,7 +41,7 @@
 // sinc: oiio, prman match.  Katana is slighly softer. imagemagick is much softer
 // blackman harris:  all differ. In order of decreasing sharpness... imagemagick, oiio, prman
 // catrom: oiio, imagemagick, prman match
-// gaussian: oiio, prman, katana roughly match.  imgmagick is sharper
+// gaussian: prman, katana match (gaussian3).  imgmagick, oiio are sharper (gaussian2)
 
 
 
@@ -271,7 +271,7 @@ private:
 
 class FilterSinc1D : public Filter1D {
 public:
-    FilterSinc1D (float width) : Filter1D(4.0f), m_rad(2.0f) { }
+    FilterSinc1D (float width) : Filter1D(width), m_rad(width/2.0f) { }
     ~FilterSinc1D (void) { }
     float operator() (float x) const { return sinc1d (x, m_rad); }
     const std::string name (void) const { return "sinc"; }
@@ -292,8 +292,8 @@ private:
 class FilterSinc2D : public Filter2D {
 public:
     FilterSinc2D (float width, float height)
-        : Filter2D(4.0f,4.0f),
-          m_wrad(2.0f), m_hrad(2.0f) { }
+        : Filter2D(width,height),
+          m_wrad(width/2.0f), m_hrad(height/2.0f) { }
     ~FilterSinc2D (void) { }
     float operator() (float x, float y) const {
         return FilterSinc1D::sinc1d(x,m_wrad) * FilterSinc1D::sinc1d(y,m_hrad);
@@ -495,10 +495,10 @@ FilterDesc filter1d_list[] = {
     // name             dim width fixedwidth scalable separable
     { "box",             1,   1,    false,    true,     true },
     { "triangle",        1,   2,    false,    true,     true },
-    { "gaussian",        1,   3,    false,    true,     true },
+    { "gaussian",        1,   2,    false,    true,     true },
     { "catrom",          1,   4,    false,    false,    true },
     { "blackman-harris", 1,   3,    false,    true,     true },
-    { "sinc",            1,   4,    false,    false,    true },
+    { "sinc",            1,   4,    false,    true,     true },
     { "lanczos3",        1,   6,    false,    false,    true },
     { "mitchell",        1,   3,    false,    true,     true },
     { "bspline",         1,   4,    false,    true,     true }
@@ -562,10 +562,10 @@ static FilterDesc filter2d_list[] = {
     // name             dim width fixedwidth scalable separable
     { "box",             2,   1,    false,    true,     true  },
     { "triangle",        2,   2,    false,    true,     true  },
-    { "gaussian",        3,   3,    false,    true,     true  },
+    { "gaussian",        3,   2,    false,    true,     true  },
     { "catrom",          2,   4,    true,     false,    true  },
     { "blackman-harris", 2,   3,    false,    true,     true  },
-    { "sinc",            2,   4,    true,    false,    true  },
+    { "sinc",            2,   4,    false,    true,     true  },
     { "lanczos3",        2,   6,    true,     false,    true  },
     { "radial-lanczos3", 2,   6,    true,     false,    false },
     { "mitchell",        2,   3,    false,    true,     true  },


### PR DESCRIPTION
The math and filter radii have been updated for a bunch of filters to better
match existing performance in other common applications. (The biggest change
being sinc, which is now much sharper.)

Filter results comparison:
    pow2 downres (4K -> 128 tested)
    - katana 2.7.12
    - ImageMagick 6.3.6
    - prman 16.0 txmake

box: oiio, prman, katana, imagemagick match
lanczos3: oiio, katana, imagemagick match.  prman is far sharper (perhaps lanczos2?)
sinc: oiio, prman match.  Katana is slighly softer. imagemagick is much softer
blackman harris:  all differ. In order of decreasing sharpness... imagemagick, oiio, prman
catrom: oiio, imagemagick, prman match
gaussian: oiio, prman, katana roughly match.  imgmagick is sharper
