### PR TITLE
Review: New ImageInput methods that read a subset of channels

### DIFF
--- a/src/doc/imageinput.tex
+++ b/src/doc/imageinput.tex
@@ -808,6 +808,9 @@ float pixels.
 
 \apiitem{bool {\ce read_scanlines} (int ybegin, int yend, int z,\\
   \bigspc TypeDesc format, void *data,\\
+  \bigspc stride_t xstride=AutoStride, stride_t ystride=AutoStride) \\
+bool {\ce read_scanlines} (int ybegin, int yend, int z,\\
+  \bigspc int firstchan, int nchans, TypeDesc format, void *data,\\
   \bigspc                      stride_t xstride=AutoStride, stride_t ystride=AutoStride)}
 
 Read all the scanlines that include pixels $(*,y,z)$, where
@@ -815,7 +818,11 @@ $\mathit{ybegin} \le y < \mathit{yend}$, into {\kw data}.  This is
 essentially identical to \readscanline, except that can read more than
 one scanline at a time, which may be more efficient for certain image
 format readers.
+
+The version that specifies a channel range will read only
+channels $[${\cf firstchan},{\cf firstchan+nchans}$)$ into the buffer.
 \apiend
+
 
 \apiitem{bool {\ce read_tile} (int x, int y, int z, TypeDesc format,
                             void *data, \\ \bigspc stride_t xstride=AutoStride,
@@ -857,7 +864,12 @@ Simple version of {\kw read_tile} that reads to contiguous float pixels.
   yend, \\ \bigspc int zbegin, int zend, TypeDesc format,
                             void *data, \\ \bigspc stride_t xstride=AutoStride,
                             stride_t ystride=AutoStride, \\ \bigspc stride_t
-                            zstride=AutoStride)}
+                            zstride=AutoStride) \\
+bool {\ce read_tiles} (int xbegin, int xend, int ybegin, int yend, \\
+ \bigspc int zbegin, int zend, int firstchan, int nchans,\\
+ \bigspc TypeDesc format, void *data, \\ 
+ \bigspc stride_t xstride=AutoStride, stride_t ystride=AutoStride, \\
+ \bigspc stride_t zstride=AutoStride)}
 Read the tiles bounded by {\kw xbegin} $\le x <$ {\kw xend},
 {\kw ybegin} $\le y <$ {\kw yend}, {\kw zbegin} $\le z <$ {\kw zend}
 into {\kw data}
@@ -884,6 +896,9 @@ otherwise {\cf false} for a failure.
 The call will fail if the image is not tiled, or if the pixel ranges
 do not fall along tile (or image) boundaries, or if it is not a valid
 tile range.
+
+The version that specifies a channel range will read only
+channels $[${\cf firstchan},{\cf firstchan+nchans}$)$ into the buffer.
 \apiend
 
 
@@ -945,6 +960,16 @@ override this method if there is a way to achieve higher performance by
 reading multiple scanlines at once.
 \apiend
 
+\apiitem{bool {\ce read_native_scanlines} (int ybegin, int yend, int z,
+\\ \bigspc  int firstchan, int nchans, void *data)}
+A variant of {\cf read_native_scanlines} that reads only a subset of 
+channels \\ $[${\cf firstchan},{\cf firstchan+nchans}$)$.  
+If a format reader subclass does
+not override this method, the default implementation will simply
+call the all-channel version of {\cf read_native_scanlines} into a
+temporary buffer and copy the subset of channels.
+\apiend
+
 \apiitem{bool {\ce read_native_tile} (int x, int y, int z, void *data)}
 The {\kw read_native_tile()} function is just like {\kw read_tile()}, 
 except that it keeps the data in the native format of the disk file and
@@ -952,6 +977,26 @@ always read into contiguous memory (no strides).  It's up to the user to
 have enough space allocated and know what to do with the data.  IT IS
 EXPECTED THAT EACH FORMAT PLUGIN WILL OVERRIDE THIS METHOD IF IT
 SUPPORTS TILED IMAGES.
+\apiend
+
+\apiitem{bool {\ce read_native_tiles} (int xbegin, int xend, int ybegin,
+  int yend, \\ \bigspc int zbegin, int zend, void *data)}
+The {\kw read_native_tiles()} function is just like {\kw read_tiles()}, 
+except that it keeps the data in the native format of the disk file and
+always read into contiguous memory (no strides).  
+If a format reader does not override this method, the default
+implementation it will simply be a loop calling read_native_tile
+for each tile in the block.
+\apiend
+
+\apiitem{bool {\ce read_native_tiles} (int xbegin, int xend, int ybegin,
+  int yend, \\ \bigspc int zbegin, int zend, int firstchan, int nchans, void *data)}
+A variant of {\kw read_native_tiles()} that reads only a subset of 
+channels \\ $[${\cf firstchan},{\cf firstchan+nchans}$)$.  
+If a format reader subclass does
+not override this method, the default implementation will simply
+call the all-channel version of {\cf read_native_tiles} into a
+temporary buffer and copy the subset of channels.
 \apiend
 
 \apiitem{int {\ce send_to_input} (const char *format, ...)}

--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -326,12 +326,31 @@ Returns the number of bytes comprising each channel of each pixel (i.e.,
 the size of a single value of the type described by the {\cf format} field).
 \apiend
 
+\apiitem{size_t {\ce channel_bytes} (int chan, bool native=false) const}
+Returns the number of bytes needed for the single specified
+channel.  If native is {\cf false} (default), compute the size of one
+channel of {\cf this->format}, but if native is {\cf true}, compute the size
+of the channel in terms of the ``native'' data format of that
+channel as stored in the file.
+\apiend
+
 \apiitem{size_t {\ce pixel_bytes} (bool native=false) const}
 Returns the number of bytes comprising each pixel (i.e. the number of
 channels multiplied by the channel size).
 
 If {\cf native} is true, this will be the sum of all the per-channel
 formats in {\cf channelformats}.  If {\cf native} is false (the
+default), or if all channels use the same format, this will simply be
+the number of channels multiplied by the width (in bytes) of the {\cf format}.
+\apiend
+
+\apiitem{size_t {\ce pixel_bytes} (int firstchan, int nchans, bool native=false) const}
+Returns the number of bytes comprising the range of channels 
+  $[${\cf firstchan}, {\cf firstchan+nchans}$)$ for each pixel.
+
+If {\cf native} is true, this will be the sum of the per-channel
+formats in {\cf channelformats} (for the given range of channels).  
+If {\cf native} is false (the
 default), or if all channels use the same format, this will simply be
 the number of channels multiplied by the width (in bytes) of the {\cf format}.
 \apiend

--- a/src/doc/writingplugins.tex
+++ b/src/doc/writingplugins.tex
@@ -109,17 +109,24 @@ real-world example of writing a JPEG/JFIF plug-in.
   \begin{enumerate}
     \item[(f)] {\cf seek_subimage()}, only if your format supports
       reading multiple subimages within a single file.
-    \item[(g)] {\cf read_scanlines()}, only if your format has a speed
+    \item[(g)] {\cf read_native_scanlines()}, only if your format has a speed
       advantage when reading multiple scanlines at once.  If you do not
       supply this function, the default implementation will simply call
       {\cf read_scanline()} for each scanline in the range.
-    \item[(g)] {\cf read_native_tile()}, only if your format supports
+    \item[(h)] {\cf read_native_tile()}, only if your format supports
       reading tiled images.
-    \item[(g)] {\cf read_native_tiles()}, only if your format supports
+    \item[(i)] {\cf read_native_tiles()}, only if your format supports
       reading tiled images and there is a speed advantage when reading
       multiple tiles at once.  If you do not supply this function, the
       default implementation will simply call {\cf read_native_tile()} for each
       tile in the range.
+    \item[(j)] ``Channel subset'' versions of {\cf read_native_scanlines()}
+      and/or {\cf read_native_tiles()}, only if your format has a more
+      efficient means of reading a subset of channels.  If you do not
+      supply these methods, the default implementation will simply use
+      {\cf read_native_scanlines()} or {\cf read_native_tiles()} to read
+      into a temporary all-channel buffer and then copy the channel
+      subset into the user's buffer.
   \end{enumerate}
 
   Here is how the class definition looks for our JPEG example.  Note

--- a/src/include/imageio.h
+++ b/src/include/imageio.h
@@ -185,9 +185,16 @@ public:
     static TypeDesc format_from_quantize (int quant_black, int quant_white,
                                           int quant_min, int quant_max);
 
-    ///
-    /// Return the number of bytes for each channel datum
+    /// Return the number of bytes for each channel datum, assuming they
+    /// are all stored using the data format given by this->format.
     size_t channel_bytes() const { return format.size(); }
+
+    /// Return the number of bytes needed for the single specified
+    /// channel.  If native is false (default), compute the size of one
+    /// channel of this->format, but if native is true, compute the size
+    /// of the channel in terms of the "native" data format of that
+    /// channel as stored in the file.
+    size_t channel_bytes (int chan, bool native=false) const;
 
     /// Return the number of bytes for each pixel (counting all channels).
     /// If native is false (default), assume all channels are in 
@@ -197,6 +204,16 @@ public:
     /// This will return std::numeric_limits<size_t>::max() in the
     /// event of an overflow where it's not representable in a size_t.
     size_t pixel_bytes (bool native=false) const;
+
+    /// Return the number of bytes for just the subset of channels in
+    /// each pixel described by [firstchan,firstchan+nchans).
+    /// If native is false (default), assume all channels are in 
+    /// this->format, but if native is true, compute the size of a pixel
+    /// in the "native" data format of the file (these may differ in
+    /// the case of per-channel formats).
+    /// This will return std::numeric_limits<size_t>::max() in the
+    /// event of an overflow where it's not representable in a size_t.
+    size_t pixel_bytes (int firstchan, int nchans, bool native=false) const;
 
     /// Return the number of bytes for each scanline.  This will return
     /// std::numeric_limits<imagesize_t>::max() in the event of an
@@ -499,11 +516,29 @@ public:
     }
 
     /// Read multiple scanlines that include pixels (*,y,z) for all
-    /// ybegin <= y < yend, into data.  This is analogous to
-    /// read_scanline except that it may be used to read more than one
-    /// scanline at a time (which, for some formats, may be able to
-    /// be done much more efficiently or in parallel).
+    /// ybegin <= y < yend, into data, using the strides given and
+    /// converting to the requested data format (unless format is
+    /// TypeDesc::UNKNOWN, in which case pixels will be copied in the
+    /// native data layout, including per-channel data formats).  This
+    /// is analogous to read_scanline except that it may be used to read
+    /// more than one scanline at a time (which, for some formats, may
+    /// be able to be done much more efficiently or in parallel).
     virtual bool read_scanlines (int ybegin, int yend, int z,
+                                 TypeDesc format, void *data,
+                                 stride_t xstride=AutoStride,
+                                 stride_t ystride=AutoStride);
+
+    /// Read multiple scanlines that include pixels (*,y,z) for all
+    /// ybegin <= y < yend, into data, using the strides given and
+    /// converting to the requested data format (unless format is
+    /// TypeDesc::UNKNOWN, in which case pixels will be copied in the
+    /// native data layout, including per-channel data formats).  Only
+    /// channels [firstchan,firstchan+nchans) will be read/copied
+    /// (firstchan=0, nchans=spec.nchannels reads all scanlines,
+    /// yielding equivalent behavior to the simpler variant of
+    /// read_scanlines).
+    virtual bool read_scanlines (int ybegin, int yend, int z,
+                                 int firstchan, int nchans,
                                  TypeDesc format, void *data,
                                  stride_t xstride=AutoStride,
                                  stride_t ystride=AutoStride);
@@ -540,19 +575,38 @@ public:
     }
 
     /// Read the block of multiple tiles that include all pixels in
-    /// [xbegin,xend) X [ybegin,yend) X [zbegin,zend).  This is
-    /// analogous to read_tile except that it may be used to read more
-    /// than one tile at a time (which, for some formats, may be able to
-    /// be done much more efficiently or in parallel).
-    /// The begin/end pairs must correctly delineate tile boundaries,
-    /// with the exception that it may also be the end of the image data
-    /// if the image resolution is not a whole multiple of the tile size.
+    /// [xbegin,xend) X [ybegin,yend) X [zbegin,zend), into data, using
+    /// the strides given and converting to the requested data format
+    /// (unless format is TypeDesc::UNKNOWN, in which case pixels will
+    /// be copied in the native data layout, including per-channel data
+    /// formats).  This is analogous to read_tile except that it may be
+    /// used to read more than one tile at a time (which, for some
+    /// formats, may be able to be done much more efficiently or in
+    /// parallel).  The begin/end pairs must correctly delineate tile
+    /// boundaries, with the exception that it may also be the end of
+    /// the image data if the image resolution is not a whole multiple
+    /// of the tile size.
     virtual bool read_tiles (int xbegin, int xend, int ybegin, int yend,
                              int zbegin, int zend, TypeDesc format,
                              void *data, stride_t xstride=AutoStride,
                              stride_t ystride=AutoStride,
                              stride_t zstride=AutoStride);
 
+    /// Read the block of multiple tiles that include all pixels in
+    /// [xbegin,xend) X [ybegin,yend) X [zbegin,zend), into data, using
+    /// the strides given and converting to the requested data format
+    /// (unless format is TypeDesc::UNKNOWN, in which case pixels will
+    /// be copied in the native data layout, including per-channel data
+    /// formats).  Only channels [firstchan,firstchan+nchans) will be
+    /// read/copied (firstchan=0, nchans=spec.nchannels reads all
+    /// scanlines, yielding equivalent behavior to the simpler variant
+    /// of read_tiles).
+    virtual bool read_tiles (int xbegin, int xend, int ybegin, int yend,
+                             int zbegin, int zend, 
+                             int firstchan, int nchans, TypeDesc format,
+                             void *data, stride_t xstride=AutoStride,
+                             stride_t ystride=AutoStride,
+                             stride_t zstride=AutoStride);
 
     /// Read the entire image of spec.width x spec.height x spec.depth
     /// pixels into data (which must already be sized large enough for
@@ -593,10 +647,19 @@ public:
     /// it keeps the data in the native format of the disk file and
     /// always reads into contiguous memory (no strides).  It's up to
     /// the user to have enough space allocated and know what to do with
-    /// the data.  If a format does not override this method, the
-    /// default implementation it will simply be a loop calling
-    /// read_native_scanline for each scanline.
+    /// the data.  If a format reader subclass does not override this
+    /// method, the default implementation it will simply be a loop
+    /// calling read_native_scanline for each scanline.
     virtual bool read_native_scanlines (int ybegin, int yend, int z,
+                                        void *data);
+
+    /// A variant of read_native_scanlines that reads only channels
+    /// [firstchan,firstchan+nchans).  If a format reader subclass does
+    /// not override this method, the default implementation will simply
+    /// call the all-channel version of read_native_scanlines into a
+    /// temporary buffer and copy the subset of channels.
+    virtual bool read_native_scanlines (int ybegin, int yend, int z,
+                                        int firstchan, int nchans,
                                         void *data);
 
     /// read_native_tile is just like read_tile, except that it
@@ -607,15 +670,24 @@ public:
     /// IF IT SUPPORTS TILED IMAGES.
     virtual bool read_native_tile (int x, int y, int z, void *data);
 
-    /// read_native_tiles is just like read_tile, except that it keeps
+    /// read_native_tiles is just like read_tiles, except that it keeps
     /// the data in the native format of the disk file and always reads
     /// into contiguous memory (no strides).  It's up to the caller to
     /// have enough space allocated and know what to do with the data.
-    /// If a format does not override this method, the default
+    /// If a format reader does not override this method, the default
     /// implementation it will simply be a loop calling read_native_tile
     /// for each tile in the block.
     virtual bool read_native_tiles (int xbegin, int xend, int ybegin, int yend,
                                     int zbegin, int zend, void *data);
+
+    /// A variant of read_native_tiles that reads only channels
+    /// [firstchan,firstchan+nchans).  If a format reader subclass does
+    /// not override this method, the default implementation will simply
+    /// call the all-channel version of read_native_tiles into a
+    /// temporary buffer and copy the subset of channels.
+    virtual bool read_native_tiles (int xbegin, int xend, int ybegin, int yend,
+                                    int zbegin, int zend,
+                                    int firstchan, int nchans, void *data);
 
     /// General message passing between client and image input server
     ///
@@ -942,14 +1014,16 @@ inline float exposure (float value, float gain, float invgamma)
 
 /// Helper function: convert contiguous arbitrary data between two
 /// arbitrary types (specified by TypeDesc's).  Return true if ok, false
-/// if it didn't know how to do the conversion.
+/// if it didn't know how to do the conversion.  If dst_type is UNKNWON,
+/// it will be assumed to be the same as src_type.
 DLLPUBLIC bool convert_types (TypeDesc src_type, const void *src,
                               TypeDesc dst_type, void *to, int n);
 
 /// Helper function: convert contiguous arbitrary data between two
 /// arbitrary types (specified by TypeDesc's), with optional transfer
 /// function. Return true if ok, false if it didn't know how to do the
-/// conversion.
+/// conversion.  If dst_type is UNKNWON, it will be assumed to be the
+/// same as src_type.
 DLLPUBLIC bool convert_types (TypeDesc src_type, const void *src,
                               TypeDesc dst_type, void *to, int n,
                               ColorTransfer *tfunc,

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -260,6 +260,19 @@ ImageSpec::default_channel_names ()
 
 
 size_t
+ImageSpec::channel_bytes (int chan, bool native) const
+{
+    if (chan >= nchannels)
+        return 0;
+    if (!native || channelformats.empty())
+        return format.size();
+    else
+        return channelformats[chan].size();
+}
+
+
+
+size_t
 ImageSpec::pixel_bytes (bool native) const
 {
     if (nchannels < 0)
@@ -269,6 +282,24 @@ ImageSpec::pixel_bytes (bool native) const
     else {
         size_t sum = 0;
         for (int i = 0;  i < nchannels;  ++i)
+            sum += channelformats[i].size();
+        return sum;
+    }
+}
+
+
+
+size_t
+ImageSpec::pixel_bytes (int firstchan, int nchans, bool native) const
+{
+    nchans = std::min (nchans, nchannels-firstchan);
+    if (nchans < 0 || firstchan < 0)
+        return 0;
+    if (!native || channelformats.empty())
+        return clamped_mult32 ((size_t)nchans, channel_bytes());
+    else {
+        size_t sum = 0;
+        for (int i = firstchan, e = firstchan+nchans;  i < e;  ++i)
             sum += channelformats[i].size();
         return sum;
     }

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -323,7 +323,8 @@ convert_types (TypeDesc src_type, const void *src,
                int alpha_channel, int z_channel)
 {
     // If no conversion is necessary, just memcpy
-    if (src_type == dst_type && tfunc == NULL) {
+    if ((src_type == dst_type || dst_type.basetype == TypeDesc::UNKNOWN)
+          && tfunc == NULL) {
         memcpy (dst, src, n * src_type.size());
         return true;
     }
@@ -378,7 +379,7 @@ convert_types (TypeDesc src_type, const void *src,
     case TypeDesc::INT64 :  convert_type (buf, (long long *)dst, n);  break;
     case TypeDesc::UINT64 : convert_type (buf, (unsigned long long *)dst, n);  break;
     case TypeDesc::DOUBLE : convert_type (buf, (double *)dst, n); break;
-    default:         return false;  // unknown format
+        default:            return false;  // unknown format
     }
 
     return true;

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -72,9 +72,14 @@ public:
     virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec);
     virtual bool read_native_scanline (int y, int z, void *data);
     virtual bool read_native_scanlines (int ybegin, int yend, int z, void *data);
+    virtual bool read_native_scanlines (int ybegin, int yend, int z,
+                                        int firstchan, int nchans, void *data);
     virtual bool read_native_tile (int x, int y, int z, void *data);
     virtual bool read_native_tiles (int xbegin, int xend, int ybegin, int yend,
                                     int zbegin, int zend, void *data);
+    virtual bool read_native_tiles (int xbegin, int xend, int ybegin, int yend,
+                                    int zbegin, int zend,
+                                    int firstchan, int nchans, void *data);
 
 private:
     const Imf::Header *m_header;          ///< Ptr to image header
@@ -535,7 +540,7 @@ OpenEXRInput::close ()
 bool
 OpenEXRInput::read_native_scanline (int y, int z, void *data)
 {
-    return read_native_scanlines (y, y+1, z, data);
+    return read_native_scanlines (y, y+1, z, 0, m_spec.nchannels, data);
 }
 
 
@@ -543,16 +548,27 @@ OpenEXRInput::read_native_scanline (int y, int z, void *data)
 bool
 OpenEXRInput::read_native_scanlines (int ybegin, int yend, int z, void *data)
 {
-//    std::cerr << "rns " << ybegin << ' ' << yend << "\n";
-    ASSERT (m_input_scanline != NULL);
+    return read_native_scanlines (ybegin, yend, z, 0, m_spec.nchannels, data);
+}
+
+
+
+bool
+OpenEXRInput::read_native_scanlines (int ybegin, int yend, int z,
+                                     int firstchan, int nchans, void *data)
+{
+//    std::cerr << "openexr rns " << ybegin << ' ' << yend << ", channels "
+//              << firstchan << "-" << (firstchan+nchans-1) << "\n";
+    if (m_input_scanline == NULL)
+        return false;
 
     // Compute where OpenEXR needs to think the full buffers starts.
     // OpenImageIO requires that 'data' points to where the client wants
     // to put the pixels being read, but OpenEXR's frameBuffer.insert()
     // wants where the address of the "virtual framebuffer" for the
     // whole image.
-    size_t pixelbytes = m_spec.pixel_bytes (true);
-    size_t scanlinebytes = m_spec.scanline_bytes (true);
+    size_t pixelbytes = m_spec.pixel_bytes (firstchan, nchans, true);
+    size_t scanlinebytes = (size_t)m_spec.width * pixelbytes;
     char *buf = (char *)data
               - m_spec.x * pixelbytes
               - ybegin * scanlinebytes;
@@ -560,12 +576,12 @@ OpenEXRInput::read_native_scanlines (int ybegin, int yend, int z, void *data)
     try {
         Imf::FrameBuffer frameBuffer;
         size_t chanoffset = 0;
-        for (int c = 0;  c < m_spec.nchannels;  ++c) {
+        for (int c = 0;  c < nchans;  ++c) {
             size_t chanbytes = m_spec.channelformats.size() 
-                                  ? m_spec.channelformats[c].size() 
+                                  ? m_spec.channelformats[c+firstchan].size() 
                                   : m_spec.format.size();
-            frameBuffer.insert (m_spec.channelnames[c].c_str(),
-                                Imf::Slice (m_pixeltype[c],
+            frameBuffer.insert (m_spec.channelnames[c+firstchan].c_str(),
+                                Imf::Slice (m_pixeltype[c+firstchan],
                                             buf + chanoffset,
                                             pixelbytes, scanlinebytes));
             chanoffset += chanbytes;
@@ -586,7 +602,8 @@ bool
 OpenEXRInput::read_native_tile (int x, int y, int z, void *data)
 {
     return read_native_tiles (x, x+m_spec.tile_width, y, y+m_spec.tile_height,
-                              z, z+m_spec.tile_depth, data);
+                              z, z+m_spec.tile_depth,
+                              0, m_spec.nchannels, data);
 }
 
 
@@ -595,7 +612,22 @@ bool
 OpenEXRInput::read_native_tiles (int xbegin, int xend, int ybegin, int yend,
                                  int zbegin, int zend, void *data)
 {
-    // std::cerr << "openexr rnt " << xbegin << ' ' << xend << ' ' << ybegin << ' ' << yend << "\n";
+    return read_native_tiles (xbegin, xend, ybegin, yend, zbegin, zend,
+                              0, m_spec.nchannels, data);
+}
+
+
+
+bool
+OpenEXRInput::read_native_tiles (int xbegin, int xend, int ybegin, int yend,
+                                 int zbegin, int zend, 
+                                 int firstchan, int nchans, void *data)
+{
+#if 0
+    std::cerr << "openexr rnt " << xbegin << ' ' << xend << ' ' << ybegin 
+              << ' ' << yend << ", chans " << firstchan 
+              << "-" << (firstchan+nchans-1) << "\n";
+#endif
     if (! m_input_tiled ||
         ! m_spec.valid_tile_range (xbegin, xend, ybegin, yend, zbegin, zend))
         return false;
@@ -605,7 +637,7 @@ OpenEXRInput::read_native_tiles (int xbegin, int xend, int ybegin, int yend,
     // to put the pixels being read, but OpenEXR's frameBuffer.insert()
     // wants where the address of the "virtual framebuffer" for the
     // whole image.
-    size_t pixelbytes = m_spec.pixel_bytes (true);
+    size_t pixelbytes = m_spec.pixel_bytes (firstchan, nchans, true);
     int firstxtile = (xbegin-m_spec.x) / m_spec.tile_width;
     int firstytile = (ybegin-m_spec.y) / m_spec.tile_height;
     // clamp to the image edge
@@ -632,11 +664,11 @@ OpenEXRInput::read_native_tiles (int xbegin, int xend, int ybegin, int yend,
     try {
         Imf::FrameBuffer frameBuffer;
         size_t chanoffset = 0;
-        for (int c = 0;  c < m_spec.nchannels;  ++c) {
+        for (int c = 0;  c < nchans;  ++c) {
             size_t chanbytes = m_spec.channelformats.size() 
-                                  ? m_spec.channelformats[c].size() 
+                                  ? m_spec.channelformats[c+firstchan].size()
                                   : m_spec.format.size();
-            frameBuffer.insert (m_spec.channelnames[c].c_str(),
+            frameBuffer.insert (m_spec.channelnames[c+firstchan].c_str(),
                                 Imf::Slice (m_pixeltype[c],
                                             buf + chanoffset, pixelbytes,
                                             pixelbytes*m_spec.tile_width*nxtiles));

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -654,7 +654,6 @@ OpenEXROutput::write_scanlines (int ybegin, int yend, int z,
             m_output_scanline->writePixels (nscanlines);
         }
         catch (const std::exception &e) {
-            std::cerr << "except " << e.what() << "\n";
             error ("Failed OpenEXR write: %s", e.what());
             return false;
         }

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -76,6 +76,31 @@ stride_t ImageSpec_auto_stride_2(const TypeDesc& format, int nchannels)
     return x;
 }
 
+
+stride_t ImageSpec_channel_bytes_1(ImageSpec& spec)
+{
+    return spec.channel_bytes ();
+}
+
+stride_t ImageSpec_channel_bytes_2(ImageSpec& spec, int chan, bool native)
+{
+    return spec.channel_bytes (chan, native);
+}
+
+
+
+stride_t ImageSpec_pixel_bytes_1(ImageSpec& spec, bool native)
+{
+    return spec.pixel_bytes (native);
+}
+
+stride_t ImageSpec_pixel_bytes_2(ImageSpec& spec, int firstchan, int nchans, bool native)
+{
+    return spec.pixel_bytes (firstchan, nchans, native);
+}
+
+
+
 void declare_imagespec()
 {
     class_<ImageSpec>("ImageSpec")
@@ -112,8 +137,10 @@ void declare_imagespec()
         .def("default_channel_names",   &ImageSpec::default_channel_names)
         .def("format_from_quantize",    &ImageSpec::format_from_quantize)
         .staticmethod("format_from_quantize")
-        .def("channel_bytes",           &ImageSpec::channel_bytes)
-        .def("pixel_bytes",             &ImageSpec::pixel_bytes)
+        .def("channel_bytes",           &ImageSpec_channel_bytes_1)
+        .def("channel_bytes",           &ImageSpec_channel_bytes_2)
+        .def("pixel_bytes",             &ImageSpec_pixel_bytes_1)
+        .def("pixel_bytes",             &ImageSpec_pixel_bytes_2)
         .def("scanline_bytes",          &ImageSpec::scanline_bytes)
         .def("tile_pixels",             &ImageSpec::tile_pixels)
         .def("tile_bytes",              &ImageSpec::tile_bytes)


### PR DESCRIPTION
Add two new methods to ImageInput, new varieties of read_scanlines and read_tiles that allow firstchan/nchans to specify a contiguous subrange of channels to read.  The default implementation just calls regular (all-channels) read_scanlines/read_tiles into a temporary buffer then copies out the selected range, but format readers may optionally override for something more efficient (thus far, I have only done so for OpenEXR, I'm not yet sure which others stand to benefit).  Presumably this allows a many-channel EXR file to be more efficiently read if an application knows for sure that it only needs a few contiguous channels (which is not an uncommon case).

I did not add channel-subset varieties of the simpler read_scanline/read_tile/read_image, I think it's not needed for the simple one, only necessary for the "full-service" routines for advanced users.  I also did not add analogous channel-subset ImageOutput routines, since it's not clear to me that it's possible to do for any of the formats we support.

This is an API change, back compatible for source, but changes linkage.  It's for the master trunk only, it will not be back-ported to any branch.  (Though we'll likely make a 0.11 branch soon to incorporate this and other recent changes.)  The only other pre-1.0 core API changes still planned but not yet implemented are the integration of OCIO support, but those will probably only be to utility code, not the core ImageInput/Output APIs.
