### PR TITLE
Fixed compilation issue on Win64 build

### DIFF
--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -359,8 +359,13 @@ convert_file (const std::string &in_filename, const std::string &out_filename)
     std::string tempname = out_filename;
     if (tempname == in_filename) {
 #if (BOOST_VERSION >= 103700)
+#ifdef WIN32
+        tempname = out_filename + ".tmp" 
+                    + boost::filesystem::path(out_filename).extension().string();
+#else
         tempname = out_filename + ".tmp" 
                     + boost::filesystem::path(out_filename).extension();
+#endif // WIN32
 #else
         tempname = out_filename + ".tmp" 
                     + boost::filesystem::extension(out_filename);


### PR DESCRIPTION
Boost path on WIN32 needs string() method to obtain a string representation of the extension() return value
