### PR TITLE
Bugfix: PNG alpha + gamma lost all precision.  Also tentative fix to gamma in iv

### DIFF
--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -215,20 +215,21 @@ associateAlpha (T * data, int size, int channels, int alpha_channel, float gamma
     }
     else { //With gamma correction
         float inv_max = 1.0 / max;
-        for (int x = 0;  x < size;  ++x, data += channels)
-            for (int c = 0;  c < channels;  c++) {
-                // We need to do the association of alpha in linear space.  If
-                // D = data[c], we want
-                //
-                // D' = max * ( (D/max)^(1/gamma) * (alpha/max) ) ^ gamma
-                //
-                // which simplifies to:
-                //
-                // D' = D * (alpha/max)^gamma
-                float nonlin_alpha = pow(data[alpha_channel]*inv_max, gamma);
+        for (int x = 0;  x < size;  ++x, data += channels) {
+            float alpha_associate = pow(data[alpha_channel]*inv_max, gamma);
+            // We need to transform to linear space, associate the alpha, and
+            // then transform back.  That is, if D = data[c], we want
+            //
+            // D' = max * ( (D/max)^(1/gamma) * (alpha/max) ) ^ gamma
+            //
+            // This happens to simplify to something which looks like
+            // multiplying by a nonlinear alpha:
+            //
+            // D' = D * (alpha/max)^gamma
+            for (int c = 0;  c < channels;  c++)
                 if (c != alpha_channel)
-                    data[c] = static_cast<T>(data[c] * nonlin_alpha);
-            }
+                    data[c] = static_cast<T>(data[c] * alpha_associate);
+        }
     }
 }
 

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -188,16 +188,16 @@ deassociateAlpha (T * data, int size, int channels, int alpha_channel, float gam
                     }
     }
     else {
-        float inv_gamma=1/gamma;
         for (int x = 0;  x < size;  ++x, data += channels)
-            if (data[alpha_channel])
+            if (data[alpha_channel]) {
+                // See associateAlpha() for an explanation.
+                float alpha_deassociate = pow((float)max / data[alpha_channel],
+                                              gamma);
                 for (int c = 0;  c < channels;  c++)
-                    if (c != alpha_channel) {
-                        //FIXME: Would it be worthwhile to do some caching on pow values??
-                        float f = pow(data[c]/max, inv_gamma); //Linearize
-                        f = (f / (data[alpha_channel]/max));
-                        data[c] = (T) std::min (max, (unsigned int)(max * pow(f, gamma)));
-                    }
+                    if (c != alpha_channel)
+                        data[c] = static_cast<T> (std::min (max,
+                                (unsigned int)(data[c] * alpha_deassociate)));
+            }
     }
 }
 


### PR DESCRIPTION
The first patch here fixes github issue #160.  Integer division was accidentally used in converting to channel data to the range [0.0, 1.0], resulting in complete loss of precision when multiplying back by the appropriate integer max value.  The transfer function has been slightly written to avoid unnecessary invocations of pow().

The second patch attempts to address display of the kind of image linked from issue #160 in iv.  All the other image programs I tried showed the image much lighter than iv so something funny may be going on.  It seems that this is due to two things: (1) the gamma isn't getting from the image files into IvImage, and (2) the gamma stored in png files is really 1/oiio_gamma (??)  Actually I'm not at all certain about this second conclusion, but it does fix the image display.  Advice gladly welcomed!
