### PR TITLE
Review: TIFF - fix lots of odd-bit-depth and contig/separate bugs

### DIFF
--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -260,8 +260,14 @@ TIFFOutput::open (const std::string &name, const ImageSpec &userspec,
     if ((param = m_spec.find_attribute("planarconfig", TypeDesc::STRING)) ||
         (param = m_spec.find_attribute("tiff:planarconfig", TypeDesc::STRING))) {
         str = *(char **)param->data();
-        if (str && iequals (str, "separate"))
+        if (str && iequals (str, "separate")) {
             m_planarconfig = PLANARCONFIG_SEPARATE;
+            if (! m_spec.tile_width) {
+                // I can only seem to make separate planarconfig work when
+                // rowsperstrip is 1.
+                TIFFSetField (m_tif, TIFFTAG_ROWSPERSTRIP, 1);
+            }
+        }
     }
     TIFFSetField (m_tif, TIFFTAG_PLANARCONFIG, m_planarconfig);
 
@@ -391,13 +397,17 @@ TIFFOutput::put_parameter (const std::string &name, TypeDesc type,
         TIFFSetField (m_tif, TIFFTAG_RESOLUTIONUNIT, *(unsigned int *)data);
         return true;
     }
-    if (iequals(name, "tiff:RowsPerStrip")) {
+    if (iequals(name, "tiff:RowsPerStrip")
+          && ! m_spec.tile_width /* don't set rps for tiled files */
+          && m_planarconfig == PLANARCONFIG_CONTIG /* only for contig */) {
         if (type == TypeDesc::INT) {
-            TIFFSetField (m_tif, TIFFTAG_ROWSPERSTRIP, *(int*)data);
+            TIFFSetField (m_tif, TIFFTAG_ROWSPERSTRIP,
+                          std::min (*(int*)data, m_spec.height));
             return true;
         } else if (type == TypeDesc::STRING) {
             // Back-compatibility with Entropy and PRMan
-            TIFFSetField (m_tif, TIFFTAG_ROWSPERSTRIP, atoi(*(char **)data));
+            TIFFSetField (m_tif, TIFFTAG_ROWSPERSTRIP,
+                          std::min (atoi(*(char **)data), m_spec.height));
             return true;
         }
     }
@@ -480,11 +490,18 @@ TIFFOutput::write_scanline (int y, int z, TypeDesc format,
     data = to_native_scanline (format, data, xstride, m_scratch);
 
     y -= m_spec.y;
-    if (m_planarconfig == PLANARCONFIG_SEPARATE && m_spec.nchannels > 1) {
+    if (m_planarconfig == PLANARCONFIG_SEPARATE) {
         // Convert from contiguous (RGBRGBRGB) to separate (RRRGGGBBB)
+        int plane_bytes = m_spec.width * m_spec.format.size();
+        std::vector<unsigned char> scratch2 (m_spec.scanline_bytes());
+        std::swap (m_scratch, scratch2);
         m_scratch.resize (m_spec.scanline_bytes());
         contig_to_separate (m_spec.width, (const unsigned char *)data, &m_scratch[0]);
-        TIFFWriteScanline (m_tif, &m_scratch[0], y);
+        for (int c = 0;  c < m_spec.nchannels;  ++c) {
+            int r = TIFFWriteScanline (m_tif, (tdata_t)&m_scratch[plane_bytes*c], y, c);
+            if (r < 0)
+                return false;
+        }
     } else {
         // No contig->separate is necessary.  But we still use scratch
         // space since TIFFWriteScanline is destructive when
@@ -497,7 +514,8 @@ TIFFOutput::write_scanline (int y, int z, TypeDesc format,
         TIFFWriteScanline (m_tif, (tdata_t)data, y);
     }
     
-    // Should we checkpoint? Only if we have enough scanlines and enough time has passed
+    // Should we checkpoint? Only if we have enough scanlines and enough
+    // time has passed
     if (m_checkpointTimer() > DEFAULT_CHECKPOINT_INTERVAL_SECONDS && 
         m_checkpointItems >= MIN_SCANLINES_OR_TILES_PER_CHECKPOINT) {
         TIFFCheckpointDirectory (m_tif);
@@ -528,10 +546,9 @@ TIFFOutput::write_tile (int x, int y, int z,
     data = to_native_tile (format, data, xstride, ystride, zstride, m_scratch);
     if (m_planarconfig == PLANARCONFIG_SEPARATE && m_spec.nchannels > 1) {
         // Convert from contiguous (RGBRGBRGB) to separate (RRRGGGBBB)
-        int tile_pixels = m_spec.tile_width * m_spec.tile_height 
-                            * std::max (m_spec.tile_depth, 1);
-        int plane_bytes = tile_pixels * m_spec.format.size();
-        DASSERT (imagesize_t(plane_bytes*m_spec.nchannels) == m_spec.tile_bytes());
+        imagesize_t tile_pixels = m_spec.tile_pixels();
+        imagesize_t plane_bytes = tile_pixels * m_spec.format.size();
+        DASSERT (plane_bytes*m_spec.nchannels == m_spec.tile_bytes());
         m_scratch.resize (m_spec.tile_bytes());
         contig_to_separate (tile_pixels, (const unsigned char *)data, &m_scratch[0]);
         for (int c = 0;  c < m_spec.nchannels;  ++c)

--- a/testsuite/tiff-depths/ref/out.txt
+++ b/testsuite/tiff-depths/ref/out.txt
@@ -51,6 +51,32 @@ Subimage 0: 73 x 43, 1 channel
   0 pixels (0%) over 1e-06
   0 pixels (0%) over 1e-06
 PASS
+../../../libtiffpic/depth/flower-minisblack-06.tif :   73 x   43, 1 channel, uint8 tiff
+    SHA-1: AE809BFEF36E3E0047343655231200A916D83492
+    channel list: A
+    oiio:BitsPerSample: 6
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-minisblack-06.tif"
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    planarconfig: "contig"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 148
+Converting ../../../libtiffpic/depth/flower-minisblack-06.tif to flower-minisblack-06.tif
+Comparing "../../../libtiffpic/depth/flower-minisblack-06.tif" and "flower-minisblack-06.tif"
+Subimage 0: 73 x 43, 1 channel
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = inf
+  Max error  = 0
+  0 pixels (0%) over 1e-06
+  0 pixels (0%) over 1e-06
+PASS
 ../../../libtiffpic/depth/flower-minisblack-08.tif :   73 x   43, 1 channel, uint8 tiff
     SHA-1: 1A909C8E70CC479D8A35BAA9BFEDDCBF4BF46FDC
     channel list: A
@@ -69,6 +95,84 @@ PASS
     tiff:RowsPerStrip: 112
 Converting ../../../libtiffpic/depth/flower-minisblack-08.tif to flower-minisblack-08.tif
 Comparing "../../../libtiffpic/depth/flower-minisblack-08.tif" and "flower-minisblack-08.tif"
+Subimage 0: 73 x 43, 1 channel
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = inf
+  Max error  = 0
+  0 pixels (0%) over 1e-06
+  0 pixels (0%) over 1e-06
+PASS
+../../../libtiffpic/depth/flower-minisblack-10.tif :   73 x   43, 1 channel, uint16 tiff
+    SHA-1: E9240FEF19CC8EF5EBBF2EE4A10EDF25E51C67B4
+    channel list: A
+    oiio:BitsPerSample: 10
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-minisblack-10.tif"
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    planarconfig: "contig"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 89
+Converting ../../../libtiffpic/depth/flower-minisblack-10.tif to flower-minisblack-10.tif
+Comparing "../../../libtiffpic/depth/flower-minisblack-10.tif" and "flower-minisblack-10.tif"
+Subimage 0: 73 x 43, 1 channel
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = inf
+  Max error  = 0
+  0 pixels (0%) over 1e-06
+  0 pixels (0%) over 1e-06
+PASS
+../../../libtiffpic/depth/flower-minisblack-12.tif :   73 x   43, 1 channel, uint16 tiff
+    SHA-1: AAE977957ED6AAC647967192A74E4AD55FF75811
+    channel list: A
+    oiio:BitsPerSample: 12
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-minisblack-12.tif"
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    planarconfig: "contig"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 74
+Converting ../../../libtiffpic/depth/flower-minisblack-12.tif to flower-minisblack-12.tif
+Comparing "../../../libtiffpic/depth/flower-minisblack-12.tif" and "flower-minisblack-12.tif"
+Subimage 0: 73 x 43, 1 channel
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = inf
+  Max error  = 0
+  0 pixels (0%) over 1e-06
+  0 pixels (0%) over 1e-06
+PASS
+../../../libtiffpic/depth/flower-minisblack-14.tif :   73 x   43, 1 channel, uint16 tiff
+    SHA-1: C1B9CA21C227EF11626EF0C58BD49769EEF48363
+    channel list: A
+    oiio:BitsPerSample: 14
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-minisblack-14.tif"
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    planarconfig: "contig"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 64
+Converting ../../../libtiffpic/depth/flower-minisblack-14.tif to flower-minisblack-14.tif
+Comparing "../../../libtiffpic/depth/flower-minisblack-14.tif" and "flower-minisblack-14.tif"
 Subimage 0: 73 x 43, 1 channel
   Mean error = 0
   RMS error = 0
@@ -181,6 +285,58 @@ Subimage 0: 73 x 43, 3 channel
   0 pixels (0%) over 1e-06
   0 pixels (0%) over 1e-06
 PASS
+../../../libtiffpic/depth/flower-rgb-contig-02.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
+    channel list: R, G, B
+    oiio:BitsPerSample: 2
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-rgb-contig-02.tif"
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    planarconfig: "contig"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 148
+Converting ../../../libtiffpic/depth/flower-rgb-contig-02.tif to flower-rgb-contig-02.tif
+Comparing "../../../libtiffpic/depth/flower-rgb-contig-02.tif" and "flower-rgb-contig-02.tif"
+Subimage 0: 73 x 43, 3 channel
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = inf
+  Max error  = 0
+  0 pixels (0%) over 1e-06
+  0 pixels (0%) over 1e-06
+PASS
+../../../libtiffpic/depth/flower-rgb-contig-04.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
+    channel list: R, G, B
+    oiio:BitsPerSample: 4
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-rgb-contig-04.tif"
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    planarconfig: "contig"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 74
+Converting ../../../libtiffpic/depth/flower-rgb-contig-04.tif to flower-rgb-contig-04.tif
+Comparing "../../../libtiffpic/depth/flower-rgb-contig-04.tif" and "flower-rgb-contig-04.tif"
+Subimage 0: 73 x 43, 3 channel
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = inf
+  Max error  = 0
+  0 pixels (0%) over 1e-06
+  0 pixels (0%) over 1e-06
+PASS
 ../../../libtiffpic/depth/flower-rgb-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
     SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
     channel list: R, G, B
@@ -207,6 +363,84 @@ Subimage 0: 73 x 43, 3 channel
   0 pixels (0%) over 1e-06
   0 pixels (0%) over 1e-06
 PASS
+../../../libtiffpic/depth/flower-rgb-contig-10.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
+    channel list: R, G, B
+    oiio:BitsPerSample: 10
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-rgb-contig-10.tif"
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    planarconfig: "contig"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 29
+Converting ../../../libtiffpic/depth/flower-rgb-contig-10.tif to flower-rgb-contig-10.tif
+Comparing "../../../libtiffpic/depth/flower-rgb-contig-10.tif" and "flower-rgb-contig-10.tif"
+Subimage 0: 73 x 43, 3 channel
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = inf
+  Max error  = 0
+  0 pixels (0%) over 1e-06
+  0 pixels (0%) over 1e-06
+PASS
+../../../libtiffpic/depth/flower-rgb-contig-12.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: E61083B50548C7D304A45735452FD05C1814677B
+    channel list: R, G, B
+    oiio:BitsPerSample: 12
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-rgb-contig-12.tif"
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    planarconfig: "contig"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 24
+Converting ../../../libtiffpic/depth/flower-rgb-contig-12.tif to flower-rgb-contig-12.tif
+Comparing "../../../libtiffpic/depth/flower-rgb-contig-12.tif" and "flower-rgb-contig-12.tif"
+Subimage 0: 73 x 43, 3 channel
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = inf
+  Max error  = 0
+  0 pixels (0%) over 1e-06
+  0 pixels (0%) over 1e-06
+PASS
+../../../libtiffpic/depth/flower-rgb-contig-14.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
+    channel list: R, G, B
+    oiio:BitsPerSample: 14
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-rgb-contig-14.tif"
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    planarconfig: "contig"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 21
+Converting ../../../libtiffpic/depth/flower-rgb-contig-14.tif to flower-rgb-contig-14.tif
+Comparing "../../../libtiffpic/depth/flower-rgb-contig-14.tif" and "flower-rgb-contig-14.tif"
+Subimage 0: 73 x 43, 3 channel
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = inf
+  Max error  = 0
+  0 pixels (0%) over 1e-06
+  0 pixels (0%) over 1e-06
+PASS
 ../../../libtiffpic/depth/flower-rgb-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
     SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
     channel list: R, G, B
@@ -225,6 +459,188 @@ PASS
     tiff:RowsPerStrip: 18
 Converting ../../../libtiffpic/depth/flower-rgb-contig-16.tif to flower-rgb-contig-16.tif
 Comparing "../../../libtiffpic/depth/flower-rgb-contig-16.tif" and "flower-rgb-contig-16.tif"
+Subimage 0: 73 x 43, 3 channel
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = inf
+  Max error  = 0
+  0 pixels (0%) over 1e-06
+  0 pixels (0%) over 1e-06
+PASS
+../../../libtiffpic/depth/flower-rgb-planar-02.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
+    channel list: R, G, B
+    oiio:BitsPerSample: 2
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-rgb-planar-02.tif"
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    planarconfig: "separate"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 431
+Converting ../../../libtiffpic/depth/flower-rgb-planar-02.tif to flower-rgb-planar-02.tif
+Comparing "../../../libtiffpic/depth/flower-rgb-planar-02.tif" and "flower-rgb-planar-02.tif"
+Subimage 0: 73 x 43, 3 channel
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = inf
+  Max error  = 0
+  0 pixels (0%) over 1e-06
+  0 pixels (0%) over 1e-06
+PASS
+../../../libtiffpic/depth/flower-rgb-planar-04.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
+    channel list: R, G, B
+    oiio:BitsPerSample: 4
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-rgb-planar-04.tif"
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    planarconfig: "separate"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 221
+Converting ../../../libtiffpic/depth/flower-rgb-planar-04.tif to flower-rgb-planar-04.tif
+Comparing "../../../libtiffpic/depth/flower-rgb-planar-04.tif" and "flower-rgb-planar-04.tif"
+Subimage 0: 73 x 43, 3 channel
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = inf
+  Max error  = 0
+  0 pixels (0%) over 1e-06
+  0 pixels (0%) over 1e-06
+PASS
+../../../libtiffpic/depth/flower-rgb-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
+    channel list: R, G, B
+    oiio:BitsPerSample: 8
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-rgb-planar-08.tif"
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    planarconfig: "separate"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 112
+Converting ../../../libtiffpic/depth/flower-rgb-planar-08.tif to flower-rgb-planar-08.tif
+Comparing "../../../libtiffpic/depth/flower-rgb-planar-08.tif" and "flower-rgb-planar-08.tif"
+Subimage 0: 73 x 43, 3 channel
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = inf
+  Max error  = 0
+  0 pixels (0%) over 1e-06
+  0 pixels (0%) over 1e-06
+PASS
+../../../libtiffpic/depth/flower-rgb-planar-10.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
+    channel list: R, G, B
+    oiio:BitsPerSample: 10
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-rgb-planar-10.tif"
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    planarconfig: "separate"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 89
+Converting ../../../libtiffpic/depth/flower-rgb-planar-10.tif to flower-rgb-planar-10.tif
+Comparing "../../../libtiffpic/depth/flower-rgb-planar-10.tif" and "flower-rgb-planar-10.tif"
+Subimage 0: 73 x 43, 3 channel
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = inf
+  Max error  = 0
+  0 pixels (0%) over 1e-06
+  0 pixels (0%) over 1e-06
+PASS
+../../../libtiffpic/depth/flower-rgb-planar-12.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: E61083B50548C7D304A45735452FD05C1814677B
+    channel list: R, G, B
+    oiio:BitsPerSample: 12
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-rgb-planar-12.tif"
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    planarconfig: "separate"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 74
+Converting ../../../libtiffpic/depth/flower-rgb-planar-12.tif to flower-rgb-planar-12.tif
+Comparing "../../../libtiffpic/depth/flower-rgb-planar-12.tif" and "flower-rgb-planar-12.tif"
+Subimage 0: 73 x 43, 3 channel
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = inf
+  Max error  = 0
+  0 pixels (0%) over 1e-06
+  0 pixels (0%) over 1e-06
+PASS
+../../../libtiffpic/depth/flower-rgb-planar-14.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
+    channel list: R, G, B
+    oiio:BitsPerSample: 14
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-rgb-planar-14.tif"
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    planarconfig: "separate"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 64
+Converting ../../../libtiffpic/depth/flower-rgb-planar-14.tif to flower-rgb-planar-14.tif
+Comparing "../../../libtiffpic/depth/flower-rgb-planar-14.tif" and "flower-rgb-planar-14.tif"
+Subimage 0: 73 x 43, 3 channel
+  Mean error = 0
+  RMS error = 0
+  Peak SNR = inf
+  Max error  = 0
+  0 pixels (0%) over 1e-06
+  0 pixels (0%) over 1e-06
+PASS
+../../../libtiffpic/depth/flower-rgb-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
+    channel list: R, G, B
+    oiio:BitsPerSample: 16
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-rgb-planar-16.tif"
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    planarconfig: "separate"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 56
+Converting ../../../libtiffpic/depth/flower-rgb-planar-16.tif to flower-rgb-planar-16.tif
+Comparing "../../../libtiffpic/depth/flower-rgb-planar-16.tif" and "flower-rgb-planar-16.tif"
 Subimage 0: 73 x 43, 3 channel
   Mean error = 0
   RMS error = 0

--- a/testsuite/tiff-depths/run.py
+++ b/testsuite/tiff-depths/run.py
@@ -26,11 +26,15 @@ command = command + "; " + runtest.rw_command (imagedir, "flower-minisblack-02.t
 # flower-minisblack-04.tif        73x43 4-bit minisblack gray image
 command = command + "; " + runtest.rw_command (imagedir, "flower-minisblack-04.tif", path)
 # flower-minisblack-06.tif        73x43 6-bit minisblack gray image
+command = command + "; " + runtest.rw_command (imagedir, "flower-minisblack-06.tif", path)
 # flower-minisblack-08.tif        73x43 8-bit minisblack gray image
 command = command + "; " + runtest.rw_command (imagedir, "flower-minisblack-08.tif", path)
 # flower-minisblack-10.tif        73x43 10-bit minisblack gray image
+command = command + "; " + runtest.rw_command (imagedir, "flower-minisblack-10.tif", path)
 # flower-minisblack-12.tif        73x43 12-bit minisblack gray image
+command = command + "; " + runtest.rw_command (imagedir, "flower-minisblack-12.tif", path)
 # flower-minisblack-14.tif        73x43 14-bit minisblack gray image
+command = command + "; " + runtest.rw_command (imagedir, "flower-minisblack-14.tif", path)
 # flower-minisblack-16.tif        73x43 16-bit minisblack gray image
 command = command + "; " + runtest.rw_command (imagedir, "flower-minisblack-16.tif", path)
 # flower-minisblack-24.tif        73x43 24-bit minisblack gray image
@@ -45,24 +49,35 @@ command = command + "; " + runtest.rw_command (imagedir, "flower-palette-08.tif"
 # flower-palette-16.tif   73x43 65536-entry colormapped image
 #   FIXME - broken
 # flower-rgb-contig-02.tif        73x43 2-bit contiguous RGB image
+command = command + "; " + runtest.rw_command (imagedir, "flower-rgb-contig-02.tif", path)
 # flower-rgb-contig-04.tif        73x43 4-bit contiguous RGB image
+command = command + "; " + runtest.rw_command (imagedir, "flower-rgb-contig-04.tif", path)
 # flower-rgb-contig-08.tif        73x43 8-bit contiguous RGB image
 command = command + "; " + runtest.rw_command (imagedir, "flower-rgb-contig-08.tif", path)
 # flower-rgb-contig-10.tif        73x43 10-bit contiguous RGB image
+command = command + "; " + runtest.rw_command (imagedir, "flower-rgb-contig-10.tif", path)
 # flower-rgb-contig-12.tif        73x43 12-bit contiguous RGB image
+command = command + "; " + runtest.rw_command (imagedir, "flower-rgb-contig-12.tif", path)
 # flower-rgb-contig-14.tif        73x43 14-bit contiguous RGB image
+command = command + "; " + runtest.rw_command (imagedir, "flower-rgb-contig-14.tif", path)
 # flower-rgb-contig-16.tif        73x43 16-bit contiguous RGB image
 command = command + "; " + runtest.rw_command (imagedir, "flower-rgb-contig-16.tif", path)
 # flower-rgb-contig-24.tif        73x43 24-bit contiguous RGB image
 # flower-rgb-contig-32.tif        73x43 32-bit contiguous RGB image
 # flower-rgb-planar-02.tif        73x43 2-bit seperated RGB image
+command = command + "; " + runtest.rw_command (imagedir, "flower-rgb-planar-02.tif", path)
 # flower-rgb-planar-04.tif        73x43 4-bit seperated RGB image
+command = command + "; " + runtest.rw_command (imagedir, "flower-rgb-planar-04.tif", path)
 # flower-rgb-planar-08.tif        73x43 8-bit seperated RGB image
-#command = command + "; " + runtest.rw_command (imagedir, "flower-rgb-planar-08.tif", path)
+command = command + "; " + runtest.rw_command (imagedir, "flower-rgb-planar-08.tif", path)
 # flower-rgb-planar-10.tif        73x43 10-bit seperated RGB image
+command = command + "; " + runtest.rw_command (imagedir, "flower-rgb-planar-10.tif", path)
 # flower-rgb-planar-12.tif        73x43 12-bit seperated RGB image
+command = command + "; " + runtest.rw_command (imagedir, "flower-rgb-planar-12.tif", path)
 # flower-rgb-planar-14.tif        73x43 14-bit seperated RGB image
+command = command + "; " + runtest.rw_command (imagedir, "flower-rgb-planar-14.tif", path)
 # flower-rgb-planar-16.tif        73x43 16-bit seperated RGB image
+command = command + "; " + runtest.rw_command (imagedir, "flower-rgb-planar-16.tif", path)
 # flower-rgb-planar-24.tif        73x43 24-bit seperated RGB image
 # flower-rgb-planar-32.tif        73x43 32-bit seperated RGB image
 # flower-separated-contig-08.tif  73x43 8-bit contiguous CMYK image
@@ -76,7 +91,33 @@ command = command + "; " + runtest.rw_command (imagedir, "flower-rgb-contig-16.t
 outputs = [ "out.txt" ]
 
 # Files that need to be cleaned up, IN ADDITION to outputs
-cleanfiles = [ ]
+cleanfiles = [
+    "flower-minisblack-02.tif", 
+    "flower-minisblack-04.tif", 
+    "flower-minisblack-06.tif", 
+    "flower-minisblack-08.tif", 
+    "flower-minisblack-10.tif", 
+    "flower-minisblack-12.tif", 
+    "flower-minisblack-14.tif", 
+    "flower-minisblack-16.tif",
+    "flower-palette-02.tif",
+    "flower-palette-04.tif",
+    "flower-palette-08.tif",
+    "flower-rgb-contig-02.tif", 
+    "flower-rgb-contig-04.tif", 
+    "flower-rgb-contig-08.tif", 
+    "flower-rgb-contig-10.tif", 
+    "flower-rgb-contig-12.tif", 
+    "flower-rgb-contig-14.tif", 
+    "flower-rgb-contig-16.tif",
+    "flower-rgb-planar-02.tif", 
+    "flower-rgb-planar-04.tif", 
+    "flower-rgb-planar-08.tif", 
+    "flower-rgb-planar-10.tif", 
+    "flower-rgb-planar-12.tif", 
+    "flower-rgb-planar-14.tif", 
+    "flower-rgb-planar-16.tif"
+]
 
 
 # boilerplate

--- a/testsuite/tiff-suite/run.py
+++ b/testsuite/tiff-suite/run.py
@@ -92,7 +92,6 @@ command = command + "; " + runtest.rw_command (imagedir, "strike.tif", path)
 #   considered a deprecated format, not supported by libtiff
 
 # oxford.tif	601x81 8-bit RGB (lzw) screendump off oxford
-#  FIXME -- we read this ok, but something goes wrong on the iconvert!
 command = command + "; " + runtest.rw_command (imagedir, "oxford.tif", path, 0)
 
 # The other images are from Hewlett Packard and exemplify the use of the


### PR DESCRIPTION
This started off as a fix for issue #165 (https://github.com/OpenImageIO/oiio/issues/165) -- not reading 10 and 12 bit TIFF files correctly.

But as I dug, I saw that in addition to some bit depths (6, 10, 12, 14) not being supported in the reader, we also lacked them in the writer and additionally had a very incomplete and buggy support for writing "separate" planatconfig files of any bit depth (especially when tiled).

So it turned into a rather large refactor of TIFF where uncommon bit depths and/or separate planarconfig are concerned.  But as you can see from the modified testsuite run.py file, this greatly expands the number of obscure TIFF varieties that we support.

TIFF support is pretty fundamental, this is a big and risky change, so certainly this is destined for the trunk (0.11) only and will not be backported to 0.10.
