### PR TITLE
Fixed typos in icooutput.cpp and tgaoutput.cpp

### DIFF
--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -210,7 +210,7 @@ ICOOutput::open (const std::string &name, const ImageSpec &userspec,
                     + (4 - ((m_spec.width + 7) / 8) % 4) % 4; // padding
 
         // Force 8 bit integers
-        if (m_spec.format != TypeDesc::UINT16)
+        if (m_spec.format != TypeDesc::UINT8)
             m_spec.set_format (TypeDesc::UINT8);
     }
 

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -165,7 +165,7 @@ TGAOutput::open (const std::string &name, const ImageSpec &userspec,
     }
 
     // Force 8 bit integers
-    if (m_spec.format != TypeDesc::UINT16)
+    if (m_spec.format != TypeDesc::UINT8)
         m_spec.set_format (TypeDesc::UINT8);
 
     // check if the client wants the image to be run length encoded


### PR DESCRIPTION
fixed typo in icooutput.cpp and tgaoutput.cpp where they were set to change the format to UINT8 if they weren't UINT16, instead of UINT8
