### PR TITLE
Now supports writing image buffers that have differing data and display windows to image formats that do not support differing data and display windows.

### DIFF
--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -63,7 +63,7 @@ BmpOutput::open (const std::string &name, const ImageSpec &spec,
 
     // saving 'name' and 'spec' for later use
     m_filename = name;
-    m_spec = spec;
+    stash_spec(spec);
 
     // TODO: Figure out what to do with nchannels.
 

--- a/src/dds.imageio/ddsoutput.cpp
+++ b/src/dds.imageio/ddsoutput.cpp
@@ -111,7 +111,7 @@ DDSOutput::open (const std::string &name, const ImageSpec &userspec,
     }
 
     close ();  // Close any already-opened file
-    m_spec = userspec;  // Stash the spec
+    stash_spec(userspec);
 
     m_file = fopen (name.c_str(), "wb");
     if (! m_file) {

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -135,7 +135,7 @@ DPXOutput::open (const std::string &name, const ImageSpec &userspec,
         return false;
     }
 
-    m_spec = userspec;  // Stash the spec
+    stash_spec(userspec);
 
     // open the image
     m_stream = new OutStream();

--- a/src/fits.imageio/fitsoutput.cpp
+++ b/src/fits.imageio/fitsoutput.cpp
@@ -61,7 +61,7 @@ FitsOutput::open (const std::string &name, const ImageSpec &spec,
 
     // saving 'name' and 'spec' for later use
     m_filename = name;
-    m_spec = spec;
+    stash_spec(spec);
 
     // checking if the file exists and can be opened in WRITE mode
     m_fd = fopen (m_filename.c_str (), mode == AppendSubimage ? "r+b" : "wb");

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -81,7 +81,7 @@ HdrOutput::open (const std::string &name, const ImageSpec &newspec,
     }
 
     // Save spec for later use
-    m_spec = newspec;
+    stash_spec(newspec);
 
     // Check for things HDR can't support
     if (m_spec.nchannels != 3) {

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -145,7 +145,7 @@ ICOOutput::open (const std::string &name, const ImageSpec &userspec,
     }
 
     close ();  // Close any already-opened file
-    m_spec = userspec;  // Stash the spec
+    stash_spec(userspec);
 
     // Check for things this format doesn't support
     if (m_spec.width < 1 || m_spec.height < 1) {

--- a/src/iff.imageio/iffoutput.cpp
+++ b/src/iff.imageio/iffoutput.cpp
@@ -95,7 +95,7 @@ IffOutput::open (const std::string &name, const ImageSpec &spec,
     close ();  // Close any already-opened file
     // saving 'name' and 'spec' for later use
     m_filename = name;
-    m_spec = spec;
+    stash_spec(spec);
 
     // tiles
     m_spec.tile_width = tile_width();

--- a/src/include/imageio.h
+++ b/src/include/imageio.h
@@ -768,6 +768,8 @@ public:
     ///                       indicate that the entire data block is zero?
     ///    "channelformats" Does the plugin/format support per-channel
     ///                       data formats?
+    ///    "datawindow"     Does the plugin/format support data windows that
+    ///                       differ from their display window?
     ///
     /// Note that main advantage of this approach, versus having
     /// separate individual supports_foo() methods, is that this allows
@@ -948,6 +950,8 @@ protected:
     /// Error reporting for the plugin implementation: call this with
     /// printf-like arguments.
     void error (const char *format, ...) OPENIMAGEIO_PRINTF_ARGS(2,3);
+    
+    void stash_spec(ImageSpec newspec);
 
     /// Helper routines used by write_* implementations: convert data (in
     /// the given format and stride) to the "native" format of the file

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -110,7 +110,7 @@ JpgOutput::open (const std::string &name, const ImageSpec &newspec,
 
     // Save name and spec for later use
     m_filename = name;
-    m_spec = newspec;
+    stash_spec(newspec);
 
     // Check for things this format doesn't support
     if (m_spec.width < 1 || m_spec.height < 1) {

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -86,7 +86,7 @@ Jpeg2000Output::open (const std::string &name, const ImageSpec &spec,
     }
 
     // saving 'name' and 'spec' for later use
-    m_spec = spec;
+    stash_spec(spec);
     m_filename = name;
 
     // check for things that this format doesn't support

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -41,6 +41,7 @@
 
 #include "imageio.h"
 #include "imagebuf.h"
+#include "imagebufalgo.h"
 #include "imagecache.h"
 #include "dassert.h"
 #include "strutil.h"
@@ -276,8 +277,31 @@ ImageBuf::write (ImageOutput *out,
                  ProgressCallback progress_callback,
                  void *progress_callback_data) const
 {
-    stride_t as = AutoStride;
     bool ok = true;
+    
+    // If ImageOutput does not support data windows, then a new image buffer
+    // should be created here that has m_spec's full_width/height and that should
+    // be passed through.
+    if (!out->supports ("datawindow") &&
+            (m_spec.x != m_spec.full_x ||
+             m_spec.y != m_spec.full_y ||
+             m_spec.z != m_spec.full_z ||
+             m_spec.width != m_spec.full_width ||
+             m_spec.height != m_spec.full_height ||
+             m_spec.depth != m_spec.full_depth)) {
+        ImageBuf newBuf;
+
+        ok = ImageBufAlgo::crop(newBuf, *this, 0, m_spec.full_width, 0, m_spec.full_height, ImageBufAlgo::CROP_CUT);
+        if (! ok)
+            return ok;
+        
+        ok = newBuf.write(out, progress_callback, progress_callback_data);
+        if (! ok)
+            m_err = newBuf.geterror();
+        return ok;
+    }
+
+    stride_t as = AutoStride;
     if (m_localpixels) {
         ok = out->write_image (m_spec.format, &m_pixels[0], as, as, as,
                                progress_callback, progress_callback_data);

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -327,6 +327,20 @@ ImageOutput::to_native_rectangle (int xbegin, int xend, int ybegin, int yend,
                        m_spec.format);
 }
 
+void
+ImageOutput::stash_spec(ImageSpec newspec)
+{
+    m_spec = newspec;
+
+    if ( !supports("datawindow")) {
+        m_spec.width = m_spec.full_width;
+        m_spec.height = m_spec.full_height;
+        m_spec.depth = m_spec.full_depth;
+        m_spec.x = m_spec.full_x;
+        m_spec.y = m_spec.full_y;
+        m_spec.z = m_spec.full_z;
+    }
+}
 
 
 bool

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -174,6 +174,8 @@ OpenEXROutput::supports (const std::string &feature) const
         return true;
     if (feature == "channelformats")
         return true;
+    if (feature == "datawindow")
+        return true;
 
     // EXR supports random write order iff lineOrder is set to 'random Y'
     if (feature == "random_access") {
@@ -221,7 +223,7 @@ OpenEXROutput::open (const std::string &name, const ImageSpec &userspec,
         }
     }
 
-    m_spec = userspec;  // Stash the spec
+    stash_spec(userspec);
 
     if (m_spec.width < 1 || m_spec.height < 1) {
         error ("Image resolution must be at least 1x1, you asked for %d x %d",

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -128,7 +128,7 @@ PNGOutput::open (const std::string &name, const ImageSpec &userspec,
     }
 
     close ();  // Close any already-opened file
-    m_spec = userspec;  // Stash the spec
+    stash_spec(userspec);
 
     m_file = fopen (name.c_str(), "wb");
     if (! m_file) {

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -162,7 +162,7 @@ PNMOutput::open (const std::string &name, const ImageSpec &userspec,
     }
 
     close ();  // Close any already-opened file
-    m_spec = userspec;  // Stash the spec
+    stash_spec(userspec);
 
     int bits_per_sample = m_spec.get_int_attribute ("oiio:BitsPerSample", 8);
 

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -57,10 +57,7 @@ public:
     RLAOutput ();
     virtual ~RLAOutput ();
     virtual const char * format_name (void) const { return "rla"; }
-    virtual bool supports (const std::string &feature) const {
-        // Support nothing nonstandard
-        return false;
-    }
+    virtual bool supports (const std::string &feature) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close ();
@@ -130,6 +127,16 @@ RLAOutput::~RLAOutput ()
 }
 
 
+bool
+RLAOutput::supports (const std::string &feature) const
+{
+    if (feature == "datawindow")
+        return true;
+
+    return false;
+}
+
+
 
 bool
 RLAOutput::open (const std::string &name, const ImageSpec &userspec,
@@ -141,7 +148,7 @@ RLAOutput::open (const std::string &name, const ImageSpec &userspec,
     }
 
     close ();  // Close any already-opened file
-    m_spec = userspec;  // Stash the spec
+    stash_spec(userspec);
 
     m_file = fopen (name.c_str(), "wb");
     if (! m_file) {

--- a/src/sgi.imageio/sgioutput.cpp
+++ b/src/sgi.imageio/sgioutput.cpp
@@ -59,7 +59,7 @@ SgiOutput::open (const std::string &name, const ImageSpec &spec,
     close ();  // Close any already-opened file
     // saving 'name' and 'spec' for later use
     m_filename = name;
-    m_spec = spec;
+    stash_spec(spec);
 
     m_fd = fopen (m_filename.c_str (), "wb");
     if (!m_fd) {

--- a/src/socket.imageio/socket_pvt.h
+++ b/src/socket.imageio/socket_pvt.h
@@ -64,7 +64,7 @@ class SocketOutput : public ImageOutput {
     SocketOutput ();
     virtual ~SocketOutput () { close(); }
     virtual const char * format_name (void) const { return "socket"; }
-    virtual bool supports (const std::string &property) const { return false; }
+    virtual bool supports (const std::string &property) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool write_scanline (int y, int z, TypeDesc format,

--- a/src/socket.imageio/socketoutput.cpp
+++ b/src/socket.imageio/socketoutput.cpp
@@ -67,7 +67,7 @@ SocketOutput::open (const std::string &name, const ImageSpec &newspec,
     }
 
     m_next_scanline = 0;
-    m_spec = newspec;
+    stash_spec(newspec);
 
     return true;
 }
@@ -185,6 +185,15 @@ SocketOutput::connect_to_server (const std::string &name)
     }
 
     return true;
+}
+
+bool
+SocketOutput::supports (const std::string &feature) const
+{
+    if (feature == "datawindow")
+        return true;
+    
+    return false;
 }
 
 OIIO_PLUGIN_NAMESPACE_END

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -126,7 +126,7 @@ TGAOutput::open (const std::string &name, const ImageSpec &userspec,
     }
 
     close ();  // Close any already-opened file
-    m_spec = userspec;  // Stash the spec
+    stash_spec(userspec);
 
     m_file = fopen (name.c_str(), "wb");
     if (! m_file) {

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -135,6 +135,8 @@ TIFFOutput::supports (const std::string &feature) const
         return true;
     if (feature == "multiimage")
         return true;
+    if (feature == "datawindow")
+        return true;
 
     // FIXME: we could support "volumes" and "empty"
 
@@ -154,7 +156,7 @@ TIFFOutput::open (const std::string &name, const ImageSpec &userspec,
     }
 
     close ();  // Close any already-opened file
-    m_spec = userspec;  // Stash the spec
+    stash_spec(userspec);
 
     // Check for things this format doesn't support
     if (m_spec.width < 1 || m_spec.height < 1) {

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -86,7 +86,7 @@ WebpOutput::open (const std::string &name, const ImageSpec &spec,
 
     // saving 'name' and 'spec' for later use
     m_filename = name;
-    m_spec = spec;
+    stash_spec(spec);
 
     m_file = fopen (m_filename.c_str (), "wb");
     if (!m_file) {


### PR DESCRIPTION
Oiio had an issue when passing an ImageBuf through to an ImageOutput where the ImageBuf had differing data and display windows. The resulting image (DPX, in my tests) would be the shape and resolution of the data window, and not of the display window.

This pull request fixes this. Each image format now can specify in supports() whether it supports a 'datawindow'. If it does, then the behaviour is unchanged.

If it doesn't, however, then, just before writing the image data, ImageBuf will call ImageBufAlgo::crop, to ensure that there is data to fill the entire display window. (and crop off any data that is outside it)

Alongside this, when m_spec is stored in the open() function of each format's Output class, it is now done through a stash_spec() function. This checks support('datawindow'), and, again, if it is false, it sets m_spec.width/height/etc to the same thing as m_spec.full_width/full_height/etc.
