### PR TITLE
Support for ImageOutput classes to know what data formats they support, and be able to tell oiiotool what they consider their default data format to be

### DIFF
--- a/src/bmp.imageio/bmp_pvt.h
+++ b/src/bmp.imageio/bmp_pvt.h
@@ -168,6 +168,8 @@ class BmpOutput : public ImageOutput {
     virtual ~BmpOutput () { close (); }
     virtual const char *format_name (void) const { return "bmp"; }
     virtual bool supports (const std::string &feature) const {return false;}
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return "uint8"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode);
     virtual bool close (void);

--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -51,6 +51,16 @@ OIIO_PLUGIN_EXPORTS_BEGIN
 OIIO_PLUGIN_EXPORTS_END
 
 
+bool
+BmpOutput::supports_data_format (const std::string &format) const
+{
+    if (format == "uint8")
+        return true;
+
+    return false;
+}
+
+
 
 bool
 BmpOutput::open (const std::string &name, const ImageSpec &spec,

--- a/src/cineon.imageio/cineonoutput.cpp
+++ b/src/cineon.imageio/cineonoutput.cpp
@@ -48,6 +48,8 @@ public:
         // Support nothing nonstandard
         return false;
     }
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return "uint10"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        ImageOutput::OpenMode mode);
     virtual bool close ();
@@ -92,6 +94,21 @@ CineonOutput::~CineonOutput ()
     close ();
 }
 
+
+bool
+CineonOutput::supports_data_format (const std::string &format) const
+{
+    if (format == "uint8")
+        return true;
+    else if (format == "uint10")
+        return true;
+    else if (format == "uint12")
+        return true;
+    else if (format == "uint16")
+        return true;
+
+    return false;
+}
 
 
 bool

--- a/src/dds.imageio/ddsoutput.cpp
+++ b/src/dds.imageio/ddsoutput.cpp
@@ -51,6 +51,7 @@ public:
         // Support nothing nonstandard
         return false;
     }
+    virtual bool supports_data_format (const std::string &format) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode);
     virtual bool close ();
@@ -99,6 +100,11 @@ DDSOutput::~DDSOutput ()
     close ();
 }
 
+bool
+DDSOutput::supports_data_format (const std::string &format) const
+{
+    return false;
+}
 
 
 bool

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -55,6 +55,8 @@ public:
         // Support nothing nonstandard
         return false;
     }
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return "uint10"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close ();
@@ -122,6 +124,21 @@ DPXOutput::~DPXOutput ()
     close ();
 }
 
+
+bool
+DPXOutput::supports_data_format (const std::string &format) const
+{
+    if (format == "uint8")
+        return true;
+    else if (format == "uint10")
+        return true;
+    else if (format == "uint12")
+        return true;
+    else if (format == "uint16")
+        return true;
+
+    return false;
+}
 
 
 bool

--- a/src/field3d.imageio/field3doutput.cpp
+++ b/src/field3d.imageio/field3doutput.cpp
@@ -50,6 +50,7 @@ public:
     virtual ~Field3DOutput ();
     virtual const char * format_name (void) const { return "field3d"; }
     virtual bool supports (const std::string &feature) const;
+    virtual bool supports_data_format (const std::string &format) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode);
     virtual bool close ();
@@ -127,6 +128,12 @@ Field3DOutput::supports (const std::string &feature) const
     return false;
 }
 
+
+bool
+Field3DOutput::supports_data_format (const std::string &format) const
+{
+    return false;
+}
 
 
 bool

--- a/src/fits.imageio/fits_pvt.h
+++ b/src/fits.imageio/fits_pvt.h
@@ -136,6 +136,8 @@ class FitsOutput : public ImageOutput {
     virtual ~FitsOutput () { close (); }
     virtual const char *format_name (void) const { return "fits"; }
     virtual bool supports (const std::string &feature) const;
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return "float"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close (void);

--- a/src/fits.imageio/fitsoutput.cpp
+++ b/src/fits.imageio/fitsoutput.cpp
@@ -79,6 +79,31 @@ FitsOutput::open (const std::string &name, const ImageSpec &spec,
 }
 
 
+bool
+FitsOutput::supports_data_format (const std::string &format) const
+{
+    if (format == "int8")
+        return true;
+    else if (format == "uint8")
+        return true;
+    else if (format == "int16")
+        return true;
+    else if (format == "uint16")
+        return true;
+    else if (format == "int32")
+        return true;
+    else if (format == "uint32")
+        return true;
+    else if (format == "half")
+        return true;
+    else if (format == "float")
+        return true;
+    else if (format == "double")
+        return true;
+
+    return false;
+}
+
 
 bool
 FitsOutput::write_scanline (int y, int z, TypeDesc format, const void *data,

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -45,6 +45,8 @@ class HdrOutput : public ImageOutput {
     virtual ~HdrOutput () { close(); }
     virtual const char * format_name (void) const { return "hdr"; }
     virtual bool supports (const std::string &property) const { return false; }
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return "float"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode);
     virtual bool write_scanline (int y, int z, TypeDesc format,
@@ -69,6 +71,16 @@ OIIO_PLUGIN_EXPORTS_BEGIN
     };
 
 OIIO_PLUGIN_EXPORTS_END
+
+
+bool
+HdrOutput::supports_data_format (const std::string &format) const
+{
+    if (format == "float")
+        return true;
+
+    return false;
+}
 
 
 bool

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -56,6 +56,8 @@ public:
     virtual ~ICOOutput ();
     virtual const char * format_name (void) const { return "ico"; }
     virtual bool supports (const std::string &feature) const;
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return "uint8"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close ();
@@ -133,6 +135,15 @@ ICOOutput::~ICOOutput ()
     close ();
 }
 
+
+bool
+ICOOutput::supports_data_format (const std::string &format) const
+{
+    if (format == "uint8")
+        return true;
+
+    return false;
+}
 
 
 bool

--- a/src/iff.imageio/iff_pvt.h
+++ b/src/iff.imageio/iff_pvt.h
@@ -179,6 +179,8 @@ public:
     virtual ~IffOutput () { close (); }
     virtual const char *format_name (void) const { return "iff"; }
     virtual bool supports (const std::string &feature) const;
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return "uint16"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode);
     virtual bool close (void);

--- a/src/iff.imageio/iffoutput.cpp
+++ b/src/iff.imageio/iffoutput.cpp
@@ -60,6 +60,17 @@ IffOutput::supports (const std::string &feature) const
 }
 
 
+bool
+IffOutput::supports_data_format (const std::string &format) const
+{
+    if (format == "uint8")
+        return true;
+    else if (format == "uint16")
+        return true;
+
+    return false;
+}
+
 
 bool 
 IffOutput::open (const std::string &name, const ImageSpec &spec,

--- a/src/include/imageio.h
+++ b/src/include/imageio.h
@@ -175,6 +175,10 @@ public:
     /// Set the data format, and as a side effect set quantize
     /// to good defaults for that format
     void set_format (TypeDesc fmt);
+    
+    /// Get the format as a string, representing both the format, and any
+    /// bitsPerSample attribute
+    std::string get_format_name();
 
     /// Set the channelnames to reasonable defaults ("R", "G", "B", "A"),
     /// and alpha_channel, based on the number of channels.
@@ -775,6 +779,16 @@ public:
     /// the API, adding new entry points, or breaking linkage
     /// compatibility.
     virtual bool supports (const std::string & /*feature*/) const { return false; }
+
+    /// Override this function to specify which data formats are supported by the
+    /// plugin/format supports
+    
+    // Defaults to returning true to provide backward compatibility
+    virtual bool supports_data_format (const std::string &format) const { return true; }
+    
+    // Returns the default data format for the plugin/format, to be used if
+    // the input one is not supported
+    virtual std::string get_default_data_format() const { return ""; }
 
     enum OpenMode { Create, AppendSubimage, AppendMIPLevel };
 

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -60,6 +60,8 @@ class JpgOutput : public ImageOutput {
     virtual ~JpgOutput () { close(); }
     virtual const char * format_name (void) const { return "jpeg"; }
     virtual bool supports (const std::string &property) const { return false; }
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return "uint8"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool write_scanline (int y, int z, TypeDesc format,
@@ -97,6 +99,15 @@ OIIO_PLUGIN_EXPORTS_BEGIN
 
 OIIO_PLUGIN_EXPORTS_END
 
+
+bool
+JpgOutput::supports_data_format (const std::string &format) const
+{
+    if (format == "uint8")
+        return true;
+
+    return false;
+}
 
 
 bool

--- a/src/jpeg2000.imageio/jpeg2000_pvt.h
+++ b/src/jpeg2000.imageio/jpeg2000_pvt.h
@@ -99,6 +99,8 @@ class Jpeg2000Output : public ImageOutput {
     virtual ~Jpeg2000Output () { close (); }
     virtual const char *format_name (void) const { return "jpeg2000"; }
     virtual bool supports (const std::string &feature) const { return false; }
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return "uint8"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close ();

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -75,6 +75,15 @@ Jpeg2000Output::component_struct_init (jas_image_cmptparm_t *cmpt) {
 }
 
 
+bool
+Jpeg2000Output::supports_data_format (const std::string &format) const
+{
+    if (format == "uint8")
+        return true;
+
+    return false;
+}
+
 
 bool
 Jpeg2000Output::open (const std::string &name, const ImageSpec &spec,

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -182,7 +182,33 @@ ImageSpec::set_format (TypeDesc fmt)
                           quant_min, quant_max);
 }
 
-
+std::string
+ImageSpec::get_format_name ()
+{
+    if (format == TypeDesc::UINT8)
+        return "uint8";
+    else if (format == TypeDesc::INT8)
+        return "int8";
+    else if (format == TypeDesc::UINT16) {
+        int bitsPerSample = get_int_attribute("oiio:BitsPerSample");
+        if (bitsPerSample == 10)
+            return "uint10";
+        else if (bitsPerSample == 12)
+            return "uint12";
+        else
+            return "uint16";
+    }
+    else if (format == TypeDesc::INT16)
+        return "int16";
+    else if (format == TypeDesc::HALF)
+        return "half";
+    else if (format == TypeDesc::FLOAT)
+        return "float";
+    else if (format == TypeDesc::DOUBLE)
+        return "double";
+    
+    return "";
+}
 
 TypeDesc
 ImageSpec::format_from_quantize (int quant_black, int quant_white,

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -122,32 +122,20 @@ input_file (int argc, const char *argv[])
 
 
 
-static void
-adjust_output_options (ImageSpec &spec, const Oiiotool &ot)
+static bool
+adjust_output_options (ImageSpec &spec, const Oiiotool &ot, ImageOutput *out)
 {
-    if (! ot.output_dataformatname.empty()) {
-        if (ot.output_dataformatname == "uint8")
-            spec.set_format (TypeDesc::UINT8);
-        else if (ot.output_dataformatname == "int8")
-            spec.set_format (TypeDesc::INT8);
-        else if (ot.output_dataformatname == "uint10") {
-            spec.attribute ("oiio:BitsPerSample", 10);
-            spec.set_format (TypeDesc::UINT16);
-        }
-        else if (ot.output_dataformatname == "uint12") {
-            spec.attribute ("oiio:BitsPerSample", 12);
-            spec.set_format (TypeDesc::UINT16);
-        }
-        else if (ot.output_dataformatname == "uint16")
-            spec.set_format (TypeDesc::UINT16);
-        else if (ot.output_dataformatname == "int16")
-            spec.set_format (TypeDesc::INT16);
-        else if (ot.output_dataformatname == "half")
-            spec.set_format (TypeDesc::HALF);
-        else if (ot.output_dataformatname == "float")
-            spec.set_format (TypeDesc::FLOAT);
-        else if (ot.output_dataformatname == "double")
-            spec.set_format (TypeDesc::DOUBLE);
+    std::string dataformatname;
+
+    if (ot.output_dataformatname.empty()) {
+        if (out->supports_data_format(spec.get_format_name()))
+            dataformatname = spec.get_format_name();
+        else
+            dataformatname = out->get_default_data_format();
+    }
+    else {
+        dataformatname = ot.output_dataformatname;
+    
 #if 0
         // FIXME -- eventually restore this for "copy" functionality
 //        if (spec.format != inspec.format || inspec.channelformats.size())
@@ -155,6 +143,46 @@ adjust_output_options (ImageSpec &spec, const Oiiotool &ot)
 #endif
         spec.channelformats.clear ();
     }
+    
+    if (dataformatname.empty()) {
+        std::cerr << "oiiotool ERROR: '" << out->format_name() << "' does not support the input data type (" << spec.get_format_name() << ") and does not specify a default format" << std::endl;
+        return false;
+    }
+    else if (! out->supports_data_format(dataformatname)) {
+        std::cerr << "oiiotool ERROR: '" << dataformatname << "' format not supported by '" << out->format_name() << "'" << std::endl;
+        return false;
+    }
+
+    if (dataformatname == "uint8")
+        spec.set_format (TypeDesc::UINT8);
+    else if (dataformatname == "int8")
+        spec.set_format (TypeDesc::INT8);
+    else if (dataformatname == "uint10") {
+        spec.attribute ("oiio:BitsPerSample", 10);
+        spec.set_format (TypeDesc::UINT16);
+    }
+    else if (dataformatname == "uint12") {
+        spec.attribute ("oiio:BitsPerSample", 12);
+        spec.set_format (TypeDesc::UINT16);
+    }
+    else if (dataformatname == "uint16")
+        spec.set_format (TypeDesc::UINT16);
+    else if (dataformatname == "int16")
+        spec.set_format (TypeDesc::INT16);
+    else if (dataformatname == "uint32")
+        spec.set_format (TypeDesc::UINT32);
+    else if (dataformatname == "int32")
+        spec.set_format (TypeDesc::INT32);
+    else if (dataformatname == "uint64")
+        spec.set_format (TypeDesc::UINT64);
+    else if (dataformatname == "int64")
+        spec.set_format (TypeDesc::INT64);
+    else if (dataformatname == "half")
+        spec.set_format (TypeDesc::HALF);
+    else if (dataformatname == "float")
+        spec.set_format (TypeDesc::FLOAT);
+    else if (dataformatname == "double")
+        spec.set_format (TypeDesc::DOUBLE);
 
     if (ot.output_scanline)
         spec.tile_width = spec.tile_height = 0;
@@ -171,6 +199,8 @@ adjust_output_options (ImageSpec &spec, const Oiiotool &ot)
     if (ot.output_planarconfig == "contig" ||
         ot.output_planarconfig == "separate")
         spec.attribute ("planarconfig", ot.output_planarconfig);
+    
+    return true;
 }
 
 
@@ -226,7 +256,8 @@ output_file (int argc, const char *argv[])
     for (int s = 0, send = ir.subimages();  s < send;  ++s) {
         for (int m = 0, mend = ir.miplevels(s);  m < mend;  ++m) {
             ImageSpec spec = *ir.spec(s,m);
-            adjust_output_options (spec, ot);
+            if (! adjust_output_options (spec, ot, out))
+                return 0;
             if (! out->open (filename, spec, mode)) {
                 std::cerr << "oiiotool ERROR: " << out->geterror() << "\n";
                 return 0;

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -70,6 +70,8 @@ public:
     virtual ~OpenEXROutput ();
     virtual const char * format_name (void) const { return "openexr"; }
     virtual bool supports (const std::string &feature) const;
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return "half"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close ();
@@ -188,6 +190,18 @@ OpenEXROutput::supports (const std::string &feature) const
     return false;
 }
 
+bool
+OpenEXROutput::supports_data_format (const std::string &format) const
+{
+    if (format == "half")
+        return true;
+    else if (format == "float")
+        return true;
+    else if (format == "uint32")
+        return true;
+
+    return false;
+}
 
 
 bool

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -55,6 +55,8 @@ public:
         // Support nothing nonstandard
         return false;
     }
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return "uint8"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close ();
@@ -116,6 +118,17 @@ PNGOutput::~PNGOutput ()
     close ();
 }
 
+
+bool
+PNGOutput::supports_data_format (const std::string &format) const
+{
+    if (format == "uint8")
+        return true;
+    else if (format == "uint16")
+        return true;
+
+    return false;
+}
 
 
 bool

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -43,6 +43,8 @@ public:
         // Support nothing nonstandard
         return false;
     }
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return "uint8"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close ();
@@ -150,6 +152,15 @@ PNMOutput::~PNMOutput ()
     close ();
 }
 
+
+bool
+PNMOutput::supports_data_format (const std::string &format) const
+{
+    if (format == "uint8")
+        return true;
+
+    return false;
+}
 
 
 bool

--- a/src/psd.imageio/psdoutput.cpp
+++ b/src/psd.imageio/psdoutput.cpp
@@ -44,6 +44,8 @@ public:
         // Support nothing nonstandard
         return false;
     }
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return ""; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close ();
@@ -86,6 +88,12 @@ PSDOutput::~PSDOutput ()
     close ();
 }
 
+
+bool
+PSDOutput::supports_data_format (const std::string &format) const
+{
+    return false;
+}
 
 
 bool

--- a/src/ptex.imageio/ptexoutput.cpp
+++ b/src/ptex.imageio/ptexoutput.cpp
@@ -43,6 +43,8 @@ public:
     virtual ~PtexOutput ();
     virtual const char * format_name (void) const { return "ptex"; }
     virtual bool supports (const std::string &feature) const;
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return ""; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        ImageOutput::OpenMode mode);
     virtual bool close ();
@@ -102,6 +104,12 @@ PtexOutput::supports (const std::string &feature) const
     return false;
 }
 
+
+bool
+PtexOutput::supports_data_format (const std::string &format) const
+{
+    return false;
+}
 
 
 bool

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -61,6 +61,8 @@ public:
         // Support nothing nonstandard
         return false;
     }
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return "uint8"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close ();
@@ -129,6 +131,19 @@ RLAOutput::~RLAOutput ()
     close ();
 }
 
+
+bool
+RLAOutput::supports_data_format (const std::string &format) const
+{
+    if (format == "uint8")
+        return true;
+    else if (format == "uint16")
+        return true;
+    else if (format == "float")
+        return true;
+
+    return false;
+}
 
 
 bool

--- a/src/sgi.imageio/sgi_pvt.h
+++ b/src/sgi.imageio/sgi_pvt.h
@@ -140,6 +140,8 @@ class SgiOutput : public ImageOutput {
     virtual ~SgiOutput () { }
     virtual const char *format_name (void) const { return "sgi"; }
     virtual bool supports (const std::string &feature) const { return false; }
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return "uint8"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close (void);

--- a/src/sgi.imageio/sgioutput.cpp
+++ b/src/sgi.imageio/sgioutput.cpp
@@ -46,6 +46,17 @@ OIIO_PLUGIN_EXPORTS_BEGIN
 OIIO_PLUGIN_EXPORTS_END
 
 
+bool
+SgiOutput::supports_data_format (const std::string &format) const
+{
+    if (format == "uint8")
+        return true;
+    else if (format == "uint16")
+        return true;
+
+    return false;
+}
+
 
 bool
 SgiOutput::open (const std::string &name, const ImageSpec &spec,

--- a/src/socket.imageio/socket_pvt.h
+++ b/src/socket.imageio/socket_pvt.h
@@ -65,6 +65,8 @@ class SocketOutput : public ImageOutput {
     virtual ~SocketOutput () { close(); }
     virtual const char * format_name (void) const { return "socket"; }
     virtual bool supports (const std::string &property) const { return false; }
+    virtual bool supports_data_format (const std::string &format) const { return true; }
+    virtual std::string get_default_data_format () const { return "uint16"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool write_scanline (int y, int z, TypeDesc format,

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -56,6 +56,8 @@ public:
         // Support nothing nonstandard
         return false;
     }
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return "uint8"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close ();
@@ -114,6 +116,15 @@ TGAOutput::~TGAOutput ()
     close ();
 }
 
+
+bool
+TGAOutput::supports_data_format (const std::string &format) const
+{
+    if (format == "uint8")
+        return true;
+
+    return false;
+}
 
 
 bool

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -65,6 +65,8 @@ public:
     virtual ~TIFFOutput ();
     virtual const char * format_name (void) const { return "tiff"; }
     virtual bool supports (const std::string &feature) const;
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return "float"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close ();
@@ -142,6 +144,27 @@ TIFFOutput::supports (const std::string &feature) const
     return false;
 }
 
+
+bool
+TIFFOutput::supports_data_format (const std::string &format) const
+{
+    if (format == "int8")
+        return true;
+    else if (format == "uint8")
+        return true;
+    else if (format == "int16")
+        return true;
+    else if (format == "uint16")
+        return true;
+    else if (format == "half")
+        return true;
+    else if (format == "float")
+        return true;
+    else if (format == "double")
+        return true;
+
+    return false;
+}
 
 
 bool

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -45,6 +45,8 @@ class WebpOutput : public ImageOutput
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool supports (const std::string &property) const { return false; }
+    virtual bool supports_data_format (const std::string &format) const;
+    virtual std::string get_default_data_format () const { return "uint8"; }
     virtual bool write_scanline (int y, int z, TypeDesc format,
                                  const void *data, stride_t xstride);
     virtual bool close();
@@ -73,6 +75,15 @@ static int WebpImageWriter(const uint8_t* img_data, size_t data_size,
     return 1;
 }
 
+
+bool
+WebpOutput::supports_data_format (const std::string &format) const
+{
+    if (format == "uint8")
+        return true;
+
+    return false;
+}
 
 
 bool


### PR DESCRIPTION
ImageOutput now has two extra functions:

```
virtual bool supports_data_format (const std::string &format) const;
virtual std::string get_default_data_format () const;
```

supports_data_format() is passed a string representation of the data format, and should be overridden for every image format subclass. It should return true for every supported data format.

get_default_data_format() should return the default data format for the Output class.

Data formats are passed around as strings rather than TypeDesc enums to allow the support of uint10/12, etc. These both have types of TypeDesc::UINT16, but have differing 'oiio:BitsPerSample' attributes.

This change allows commands like the following:

```
oiiotool foo.exr -o bar.dpx
```

Which will automatically convert the image data to the default data format for DPXOutput. It also means that oiiotool can error if an invalid data format is requested.

This still suffers from the same crash that is mentioned in Issue #178, but works fine when merged with the pull request mentioned in Issue #179
