### PR TITLE
Review: Add Filesystem::filename

### DIFF
--- a/src/include/filesystem.h
+++ b/src/include/filesystem.h
@@ -60,8 +60,16 @@ OIIO_NAMESPACE_ENTER
 
 namespace Filesystem {
 
+/// Return the filename (excluding any directories, but including the
+/// file extension, if any) of a filepath.
+DLLPUBLIC std::string filename (const std::string &filepath);
+
+/// Return the file extension (including the last '.') of a filename or
+/// filepath.
+DLLPUBLIC std::string extension (const std::string &filepath);
+
 /// Return the file extension (just the part after the last '.') of a
-/// filename.
+/// filename or filepath.  DEPRECATED.
 DLLPUBLIC std::string file_extension (const std::string &filepath);
 
 /// Turn a searchpath (multiple directory paths separated by ':' or ';')

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -700,12 +700,8 @@ ImageViewer::updateRecentFilesMenu ()
 {
     for (size_t i = 0;  i < MaxRecentFiles;  ++i) {
         if (i < m_recent_files.size()) {
-            boost::filesystem::path fn (m_recent_files[i]);
-#if (BOOST_FILESYSTEM_VERSION == 3) && defined (BOOST_WINDOWS_API)
-            openRecentAct[i]->setText (QString::fromStdString (fn.filename().string()));
-#else
-            openRecentAct[i]->setText (fn.filename().c_str());
-#endif
+            std::string name = Filesystem::filename (m_recent_files[i]);
+            openRecentAct[i]->setText (QString::fromStdString (name));
             openRecentAct[i]->setData (m_recent_files[i].c_str());
             openRecentAct[i]->setVisible (true);
         } else {
@@ -1355,14 +1351,8 @@ ImageViewer::slideNoLoop ()
 static bool
 compName (IvImage *first, IvImage *second)
 {
-#if BOOST_FILESYSTEM_VERSION == 3
-    std::string firstFile = boost::filesystem3::path (first->name()).filename().string();
-    std::string secondFile = boost::filesystem3::path (second->name()).filename().string();
-#else
-    std::string firstFile = boost::filesystem::path (first->name()).filename();
-    std::string secondFile = boost::filesystem::path (second->name()).filename();
-#endif
-    
+    std::string firstFile = Filesystem::filename (first->name());
+    std::string secondFile = Filesystem::filename (second->name());
     return (firstFile.compare(secondFile) < 0);
 }
 

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -269,3 +269,7 @@ add_test (unit_strutil ${CMAKE_BINARY_DIR}/libOpenImageIO/strutil_test)
 add_executable (fmath_test fmath_test.cpp)
 target_link_libraries (fmath_test OpenImageIO ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
 add_test (unit_fmath ${CMAKE_BINARY_DIR}/libOpenImageIO/fmath_test)
+
+add_executable (filesystem_test filesystem_test.cpp)
+target_link_libraries (filesystem_test OpenImageIO ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+add_test (unit_filesystem ${CMAKE_BINARY_DIR}/libOpenImageIO/filesystem_test)

--- a/src/libOpenImageIO/filesystem_test.cpp
+++ b/src/libOpenImageIO/filesystem_test.cpp
@@ -1,0 +1,62 @@
+/*
+  Copyright 2011 Larry Gritz and the other authors and contributors.
+  All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the software's owners nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  (This is the Modified BSD License)
+*/
+
+#include "imageio.h"
+#include "filesystem.h"
+#include "unittest.h"
+
+OIIO_NAMESPACE_USING;
+
+
+void test_filename_decomposition ()
+{
+    std::cout << "filename(\"/directory/filename.ext\") = "
+              << Filesystem::filename("/directory/filename.ext") << "\n";
+    OIIO_CHECK_EQUAL (Filesystem::filename("/directory/filename.ext"),
+                      "filename.ext");
+
+    std::cout << "extension(\"/directory/filename.ext\") = "
+              << Filesystem::extension("/directory/filename.ext") << "\n";
+    OIIO_CHECK_EQUAL (Filesystem::extension("/directory/filename.ext"),
+                      ".ext");
+    OIIO_CHECK_EQUAL (Filesystem::extension("/directory/filename"),
+                      "");
+    OIIO_CHECK_EQUAL (Filesystem::extension("/directory/filename."),
+                      ".");
+}
+
+
+
+int main (int argc, char *argv[])
+{
+    test_filename_decomposition ();
+
+    return unit_test_failures;
+}

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -285,11 +285,7 @@ catalog_all_plugins (std::string searchpath)
         for (boost::filesystem::directory_iterator itr (dir);
               itr != end_itr;  ++itr) {
             std::string full_filename = itr->path().string();
-#if BOOST_FILESYSTEM_VERSION == 3
-            std::string leaf = itr->path().filename().string();
-#else
-            std::string leaf = itr->path().filename();
-#endif
+            std::string leaf = Filesystem::filename (full_filename);
             size_t found = leaf.find (pattern);
             if (found != std::string::npos &&
                 (found == leaf.length() - patlen)) {

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -45,34 +45,33 @@
 OIIO_NAMESPACE_ENTER
 {
 
-#if 0
 
-// Return just the leaf file name (excluding directories) of a
-// potentially full file path name.
 std::string
-Filesystem::file_leafname (const std::string &filepath)
+Filesystem::filename (const std::string &filepath)
 {
-    const char *lastslash = strrchr (filepath.c_str(), '/');
-    return lastslash ? (lastslash+1) : "";
-}
-
-
-
-// Return just the directory part of the filepath.
-//
-std::string
-Filesystem::file_directory (const std::string &filepath)
-{
-}
-
-
+    // To simplify dealing with platform-specific separators and whatnot,
+    // just use the Boost routines:
+#if BOOST_FILESYSTEM_VERSION == 3
+    return boost::filesystem::path(filepath).filename().string();
+#else
+    return boost::filesystem::path(filepath).filename();
 #endif
+}
 
 
 
+std::string
+Filesystem::extension (const std::string &filepath)
+{
+#if BOOST_FILESYSTEM_VERSION == 3
+    return boost::filesystem::path(filepath).extension().string();
+#else
+    return boost::filesystem::path(filepath).extension();
+#endif
+}
 
-/// Return the file extension (just the part after the last '.') of a 
-/// filename.
+
+
 std::string
 Filesystem::file_extension (const std::string &filepath)
 {


### PR DESCRIPTION
Add Filesystem::filename, and use it in place of a few tricky boost ifdefs.  Also add Filesystem::extension that is like file_extension but includes the dot (and thus is compatible with boost).
