### PR TITLE
fixed link to reference images for j2k plugin

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -243,7 +243,7 @@ oiio_add_tests (openexr-suite openexr-multires openexr-chroma
 
 oiio_add_tests (jpeg2000
     IMAGEDIR j2kp4files_v1_5
-    URL http://www.crc.ricoh.com/~gormish/jpeg2000conformance/)
+    URL http://www.itu.int/net/ITU-T/sigdb/speimage/ImageForm-s.aspx?val=10100803)
 
 oiio_add_tests (targa-tgautils
     IMAGEDIR TGAUTILS


### PR DESCRIPTION
It looks like images from previous link were deleted. Now, we can point to images on ITU-T site (those are the same as on previous site)
