### PR TITLE
Added autoscanline option to make autotiles as wide as the whole image.

### DIFF
--- a/src/include/imagecache.h
+++ b/src/include/imagecache.h
@@ -85,6 +85,7 @@ public:
     ///     float max_memory_MB : maximum tile cache size, in MB
     ///     string searchpath : colon-separated search path for images
     ///     int autotile : if >0, tile size to emulate for non-tiled images
+    ///     int autoscanline : autotile using full width tiles
     ///     int automip : if nonzero, emulate mipmap on the fly
     ///     int accept_untiled : if nonzero, accept untiled images, but
     ///                          if zero, reject untiled images (default=1)

--- a/src/include/texture.h
+++ b/src/include/texture.h
@@ -332,6 +332,7 @@ public:
     ///     matrix44 worldtocommon : the world-to-common transformation
     ///     matrix44 commontoworld : the common-to-world transformation
     ///     int autotile : if >0, tile size to emulate for non-tiled images
+    ///     int autoscanline : autotile using full width tiles
     ///     int automip : if nonzero, emulate mipmap on the fly
     ///     int accept_untiled : if nonzero, accept untiled images
     ///     int accept_unmipped : if nonzero, accept unmipped images

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -366,7 +366,11 @@ ImageCacheFile::open (ImageCachePerThreadInfo *thread_info)
                 si.untiled = true;
                 if (imagecache().autotile()) {
                     // Automatically make it appear as if it's tiled
-                    tempspec.tile_width = imagecache().autotile();
+                    if (imagecache().autoscanline()) {
+                        tempspec.tile_width = pow2roundup (tempspec.width);
+                    } else {
+                        tempspec.tile_width = imagecache().autotile();
+                    }
                     tempspec.tile_height = imagecache().autotile();
                     if (tempspec.depth > 1)
                         tempspec.tile_depth = imagecache().autotile();
@@ -422,7 +426,11 @@ ImageCacheFile::open (ImageCachePerThreadInfo *thread_info)
                 s.full_height = h;
                 s.full_depth = d;
                 if (imagecache().autotile()) {
-                    s.tile_width = std::min (imagecache().autotile(), w);
+                    if (imagecache().autoscanline()) {
+                       s.tile_width = w;
+                    } else {
+                       s.tile_width = std::min (imagecache().autotile(), w);
+                    }
                     s.tile_height = std::min (imagecache().autotile(), h);
                     s.tile_depth = std::min (imagecache().autotile(), d);
                 } else {
@@ -1236,6 +1244,7 @@ ImageCacheImpl::init ()
     m_max_open_files = 100;
     m_max_memory_bytes = 256 * 1024 * 1024;   // 256 MB default cache size
     m_autotile = 0;
+    m_autoscanline = false;
     m_automip = false;
     m_forcefloat = false;
     m_accept_untiled = true;
@@ -1608,6 +1617,13 @@ ImageCacheImpl::attribute (const std::string &name, TypeDesc type,
             do_invalidate = true;
         }
     }
+    else if (name == "autoscanline" && type == TypeDesc::INT) {
+        int a = *(const int *)val;
+        if (a != m_autoscanline) {
+            m_autoscanline = a;
+            do_invalidate = true;
+        }
+    }
     else if (name == "automip" && type == TypeDesc::INT) {
         int a = *(const int *)val;
         if (a != m_automip) {
@@ -1679,6 +1695,7 @@ ImageCacheImpl::getattribute (const std::string &name, TypeDesc type,
     ATTR_DECODE ("max_memory_MB", int, m_max_memory_bytes/(1024*1024));
     ATTR_DECODE ("statistics:level", int, m_statslevel);
     ATTR_DECODE ("autotile", int, m_autotile);
+    ATTR_DECODE ("autoscanline", int, m_autoscanline);
     ATTR_DECODE ("automip", int, m_automip);
     ATTR_DECODE ("forcefloat", int, m_forcefloat);
     ATTR_DECODE ("accept_untiled", int, m_accept_untiled);

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -638,6 +638,7 @@ public:
     int max_open_files () const { return m_max_open_files; }
     const std::string &searchpath () const { return m_searchpath; }
     int autotile () const { return m_autotile; }
+    bool autoscanline () const { return m_autoscanline; }
     bool automip () const { return m_automip; }
     bool forcefloat () const { return m_forcefloat; }
     bool accept_untiled () const { return m_accept_untiled; }
@@ -906,6 +907,7 @@ private:
     std::string m_searchpath;    ///< Colon-separated directory list
     std::vector<std::string> m_searchdirs; ///< Searchpath split into dirs
     int m_autotile;              ///< if nonzero, pretend tiles of this size
+    bool m_autoscanline;          ///< autotile using full width tiles
     bool m_automip;              ///< auto-mipmap on demand?
     bool m_forcefloat;           ///< force all cache tiles to be float
     bool m_accept_untiled;       ///< Accept untiled images?


### PR DESCRIPTION
If autoscanline is off, to load a 64x64 tile that has been purged you need to read in again the whole 4096x64 scanlines. 

With it on, auto-tiles are set, for example, to 4096x64. This forces the cache to work with batches of 64 scanlines.

This corresponds better with the loading costs of untiled images and
improves cache performance, specially when more threads are accessing the same image.
