### PR TITLE
Review: TS/IC::attribute ("options", "foo=a,bar=b,...")

### DIFF
--- a/src/doc/imagecache.tex
+++ b/src/doc/imagecache.tex
@@ -343,6 +343,14 @@ default is zero, meaning that failures of open or tile reading will
 immediately return as a failure.
 \apiend
 
+\apiitem{string options}
+This catch-all is simply a comma-separated list of {\cf name=value}
+settings of named options.  For example,
+\begin{code}
+        ic->attribute ("options", "max_memory_MB=512.0,autotile=1");
+\end{code}
+\apiend
+
 \bigskip
 
 \subsection{Getting information about images}

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -85,7 +85,7 @@
 \date{{\large 
 %Editor: Larry Gritz \\[2ex]
 Date: 9 June, 2011
-\\ (with corrections, 5 Nov 2011)
+\\ (with corrections, 11 Nov 2011)
 }}
 
 

--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -579,6 +579,15 @@ that explicitly requires a particular orientation).  The default is
 \qkw{y}.  (Currently any other value will result in $z$ being ``up.'')
 \apiend
 
+\apiitem{string options}
+This catch-all is simply a comma-separated list of {\cf name=value}
+settings of named options.  For example,
+\begin{code}
+        ic->attribute ("options", "max_memory_MB=512.0,autotile=1");
+\end{code}
+\apiend
+
+
 
 \subsection{Opaque data for performance lookups}
 \label{sec:texturesys:api:opaque}

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -1,7 +1,8 @@
 set (public_headers argparse.h dassert.h errorhandler.h export.h 
                     filesystem.h filter.h fmath.h hash.h
                     imagebuf.h imagebufalgo.h 
-                    imagecache.h imageio.h osdep.h paramlist.h plugin.h
+                    imagecache.h imageio.h
+                    optparser.h osdep.h paramlist.h plugin.h
                     refcnt.h strutil.h sysutil.h texture.h thread.h timer.h
                     typedesc.h ustring.h varyingref.h
                     colortransfer.h

--- a/src/include/optparser.h
+++ b/src/include/optparser.h
@@ -1,0 +1,127 @@
+/*
+  Copyright 2011 Larry Gritz and the other authors and contributors.
+  All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the software's owners nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  (This is the Modified BSD License)
+*/
+
+
+/////////////////////////////////////////////////////////////////////////
+/// @file  optparser.h
+///
+/// @brief Option parser template
+/////////////////////////////////////////////////////////////////////////
+
+
+#ifndef OPENIMAGEIO_OPTPARSER_H
+#define OPENIMAGEIO_OPTPARSER_H
+
+
+OIIO_NAMESPACE_ENTER
+{
+
+
+/// Parse a string of the form "name=value" and then call
+/// system.attribute (name, value), with appropriate type conversions.
+template<class C>
+inline bool
+optparse1 (C &system, const std::string &opt)
+{
+    std::string::size_type eq_pos = opt.find_first_of ("=");
+    if (eq_pos == std::string::npos) {
+        // malformed option
+        return false;
+    }
+    std::string name (opt, 0, eq_pos);
+    // trim the name
+    while (name.size() && name[0] == ' ')
+        name.erase (0);
+    while (name.size() && name[name.size()-1] == ' ')
+        name.erase (name.size()-1);
+    std::string value (opt, eq_pos+1, std::string::npos);
+    if (name.empty())
+        return false;
+    char v = value.size() ? value[0] : ' ';
+    if ((v >= '0' && v <= '9') || v == '+' || v == '-') {  // numeric
+        if (strchr (value.c_str(), '.'))  // float
+            return system.attribute (name.c_str(), (float)atof(value.c_str()));
+        else  // int
+            return system.attribute (name.c_str(), (int)atoi(value.c_str()));
+    } else { // treat it as a string
+        // trim surrounding double quotes
+        if (value.size() >= 2 &&
+                value[0] == '\"' && value[value.size()-1] == '\"')
+            value = std::string (value, 1, value.size()-2);
+        return system.attribute (name.c_str(), value.c_str());
+    }
+}
+
+
+
+/// Parse a string with comma-separated name=value directives, calling
+/// system.attribute(name,value) for each one, with appropriate type
+/// conversions.  Examples:
+///    optparser(texturesystem, "verbose=1");
+///    optparser(texturesystem, "max_memory_MB=32.0");
+///    optparser(texturesystem, "a=1,b=2,c=3.14,d=\"a string\"");
+template<class C>
+inline bool
+optparser (C &system, const std::string &optstring)
+{
+    bool ok = true;
+    size_t len = optstring.length();
+    size_t pos = 0;
+    while (pos < len) {
+        std::string opt;
+        bool inquote = false;
+        while (pos < len) {
+            unsigned char c = optstring[pos];
+            if (c == '\"') {
+                // Hit a double quote -- toggle "inquote" and add the quote
+                inquote = !inquote;
+                opt += c;
+                ++pos;
+            } else if (c == ',' && !inquote) {
+                // Hit a comma and not inside a quote -- we have an option
+                ++pos;  // skip the comma
+                break;  // done with option
+            } else {
+                // Anything else: add to the option
+                opt += c;
+                ++pos;
+            }
+        }
+        // At this point, opt holds an option
+        ok &= optparse1 (system, opt);
+    }
+    return ok;
+}
+
+
+}
+OIIO_NAMESPACE_EXIT
+
+#endif // OPENIMAGEIO_OPTPARSER_H

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -273,3 +273,7 @@ add_test (unit_fmath ${CMAKE_BINARY_DIR}/libOpenImageIO/fmath_test)
 add_executable (filesystem_test filesystem_test.cpp)
 target_link_libraries (filesystem_test OpenImageIO ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
 add_test (unit_filesystem ${CMAKE_BINARY_DIR}/libOpenImageIO/filesystem_test)
+
+add_executable (optparser_test optparser_test.cpp)
+target_link_libraries (optparser_test OpenImageIO ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+add_test (unit_optparser ${CMAKE_BINARY_DIR}/libOpenImageIO/optparser_test)

--- a/src/libOpenImageIO/optparser_test.cpp
+++ b/src/libOpenImageIO/optparser_test.cpp
@@ -1,0 +1,114 @@
+/*
+  Copyright 2011 Larry Gritz and the other authors and contributors.
+  All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the software's owners nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  (This is the Modified BSD License)
+*/
+
+
+#include <iostream>
+#include <string>
+
+#include "thread.h"
+
+#include <boost/thread/thread.hpp>
+
+#include "optparser.h"
+#include "unittest.h"
+
+
+OIIO_NAMESPACE_USING;
+
+
+class MySystem {
+public:
+    MySystem() : i(0), f(0) { }
+
+    bool attribute (const std::string &name, int value) {
+        std::cout << "iattribute '" << name << "' = " << value << "\n";
+        if (name == "i") {
+            i = value;
+            return true;
+        }
+        return false;
+    }
+    bool attribute (const std::string &name, float value) {
+        std::cout << "fattribute '" << name << "' = " << value << "\n";
+        if (name == "f") {
+            f = value;
+            return true;
+        }
+        return false;
+    }
+    bool attribute (const std::string &name, const std::string &value) {
+        std::cout << "sattribute '" << name << "' = '" << value << "'\n";
+        if (name == "s") {
+            s = value;  return true;
+        }
+        return false;
+    }
+
+    int i;
+    float f;
+    std::string s;
+};
+
+
+
+void test_optparser ()
+{
+    MySystem sys;
+    optparser (sys, "i=14");
+    OIIO_CHECK_EQUAL (sys.i, 14);
+    optparser (sys, "i=-28");
+    OIIO_CHECK_EQUAL (sys.i, -28);
+
+    optparser (sys, "f=6.28");
+    OIIO_CHECK_EQUAL (sys.f, 6.28f);
+    optparser (sys, "f=-56.0");
+    OIIO_CHECK_EQUAL (sys.f, -56.0f);
+    optparser (sys, "f=-1.");
+    OIIO_CHECK_EQUAL (sys.f, -1.0f);
+
+    optparser (sys, "s=foo");
+    OIIO_CHECK_EQUAL (sys.s, "foo");
+    optparser (sys, "s=\"foo, bar\"");
+    OIIO_CHECK_EQUAL (sys.s, "foo, bar");
+
+    optparser (sys, "f=256.29,s=\"phone call\",i=100");
+    OIIO_CHECK_EQUAL (sys.i, 100);
+    OIIO_CHECK_EQUAL (sys.f, 256.29f);
+    OIIO_CHECK_EQUAL (sys.s, "phone call");
+}
+
+
+
+int main (int argc, char *argv[])
+{
+    test_optparser ();
+
+    return unit_test_failures;
+}

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -51,6 +51,7 @@ using namespace std::tr1;
 #include "strutil.h"
 #include "sysutil.h"
 #include "timer.h"
+#include "optparser.h"
 #include "imageio.h"
 #include "imagebuf.h"
 #include "imagecache.h"
@@ -1263,6 +1264,11 @@ ImageCacheImpl::init ()
     m_stat_open_files_peak = 0;
     m_tilemutex_holder = NULL;
     m_filemutex_holder = NULL;
+
+    // Allow environment variable to override default options
+    const char *options = getenv ("OPENIMAGEIO_IMAGECACHE_OPTIONS");
+    if (options)
+        attribute ("options", options);
 }
 
 
@@ -1570,6 +1576,9 @@ ImageCacheImpl::attribute (const std::string &name, TypeDesc type,
 {
     bool do_invalidate = false;
     bool force_invalidate = false;
+    if (name == "options" && type == TypeDesc::STRING) {
+        return optparser (*this, *(const char **)val);
+    }
     if (name == "max_open_files" && type == TypeDesc::INT) {
         m_max_open_files = *(const int *)val;
     }

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -47,6 +47,7 @@ using namespace std::tr1;
 #include "thread.h"
 #include "fmath.h"
 #include "filter.h"
+#include "optparser.h"
 #include "imageio.h"
 
 #include "texture.h"
@@ -232,6 +233,11 @@ TextureSystemImpl::init ()
     delete hq_filter;
     hq_filter = Filter1D::create ("b-spline", 4);
     m_statslevel = 0;
+
+    // Allow environment variable to override default options
+    const char *options = getenv ("OPENIMAGEIO_TEXTURE_OPTIONS");
+    if (options)
+        attribute ("options", options);
 }
 
 
@@ -312,6 +318,9 @@ bool
 TextureSystemImpl::attribute (const std::string &name, TypeDesc type,
                               const void *val)
 {
+    if (name == "options" && type == TypeDesc::STRING) {
+        return optparser (*this, *(const char **)val);
+    }
     if (name == "worldtocommon" && (type == TypeDesc::TypeMatrix ||
                                     type == TypeDesc(TypeDesc::FLOAT,16))) {
         m_Mw2c = *(const Imath::M44f *)val;


### PR DESCRIPTION
Have TS and IC accept attribute "options", that is a comma-separated list of 
name=value settings (e.g., "max_memory_MB=256,max_files=1000") that
will be parsed and used to set the individual attributes of those names.
This is helpful if you want an app that can just pass such a string through,
including setting new or experimental IC/TS options, without the app needing
to be modified for each new/experimental OIIO option.  Furthermore, IC/TS
upon startup will check for OPENIMAGEIO_IMAGECACHE_OPTIONS and
OPENIMAGEIO_TEXTURE_OPTIONS environment variables and seed options using
those.
Also expose the helper template optparser, in case other apps want to use it.
