### PR TITLE
Review: Fix aniso footprint estimation for very-small-deriv case.

### DIFF
--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -398,6 +398,9 @@ private:
     float anisotropic_aspect (float &majorlength, float &minorlength,
                               TextureOpt& options, float &trueaspect);
 
+    int ellipse_axes (float dsdx, float dtdx, float dsdy, float dtdy,
+                      float &majorlength, float &minorlength);
+
     /// Convert texture coordinates (s,t), which range on 0-1 for the
     /// "full" image boundary, to texel coordinates (i+ifrac,j+jfrac)
     /// where (i,j) is the texel to the immediate upper left of the
@@ -453,6 +456,9 @@ private:
     Imath::M44f m_Mw2c;          ///< world-to-"common" matrix
     Imath::M44f m_Mc2w;          ///< common-to-world matrix
     bool m_gray_to_rgb;          ///< automatically copy gray to rgb channels?
+    float m_aniso_F_threshold;   ///< Threshold for ellipse_axes F test
+    int m_aniso_smallderiv_strategy; ///< Small deriv strategy in ellipse_axes
+
     /// Saved error string, per-thread
     ///
     mutable thread_specific_ptr< std::string > m_errormessage;


### PR DESCRIPTION
Fix aniso footprint estimation for very-small-deriv case.

Because the more correct estimate for the filter footprint goes awry if
F is very small (caused by extremely tiny derivatives), we tested this
and if true, set the major axis to the bigger of the two derivative
estimates, and the minor axis to be 1e-8.

The problem is that that the mip level is determined by the minor axis,
so this means that all texture lookups falling into this case end up
sampling the highest-res MIPmap level.  That's bad for cache coherence,
and to add insult to injury, even with small derivs, small x 1e-8 makes
for a very anisotropic footprint, so it tended to take the maximum
number of sample probes, yielding very pad performance.  Furthermore, in
many scenes you can see a "seam" between where things were humming along
reasonably with normal F, and where F dips below the threshold and thus
switches to a radically different MIPmap level.  In any case, we had
thought this case of very small F was rare, but turns out to pop up more
frequently than we thought.

This patch changes the strategy to make the minoraxis be the smaller of
the x and y derivative, clamped at a minimum of 1e-8, but not set
unconditionally to 1e-8.  It definitely gets rid of the visual seam I'd
been tracking, and I'm pretty sure will help with the performance cases
that others have seen.
