### PR TITLE
More efficient subpixel filtering

### DIFF
--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -1074,6 +1074,8 @@ TextureSystemImpl::texture_lookup (TextureFile &texturefile,
         }
     }
 
+    int nsamples = std::max (1, (int) ceilf (aspect - 0.25f));
+   
     if (miplevel[1] < 0) {
         // We'd like to blur even more, but make due with the coarsest
         // MIP level.
@@ -1086,6 +1088,14 @@ TextureSystemImpl::texture_lookup (TextureFile &texturefile,
         miplevel[0] = 0;
         miplevel[1] = 0;
         levelblend = 0;
+        // We decrease the number of samples, since there is not enough
+        // resolution to justify sampling every minorlength distance
+        float filtwidth_ras = minorlength * std::min (subinfo.spec(0).full_width, subinfo.spec(0).full_height);
+        // We clamp sample distance to be no smaller than half a pixel
+        // Since we would never sample more than that on other mipmaps
+        if (filtwidth_ras < 0.5f ) {
+            nsamples = std::max(1,(int)(nsamples * filtwidth_ras * 2.f));
+        }
     }
     if (options.mipmode == TextureOpt::MipModeOneLevel) {
         miplevel[0] = miplevel[1];
@@ -1093,7 +1103,6 @@ TextureSystemImpl::texture_lookup (TextureFile &texturefile,
     }
     float levelweight[2] = { 1.0f - levelblend, levelblend };
 
-    int nsamples = std::max (1, (int) ceilf (aspect - 0.25f));
     float invsamples = 1.0f / nsamples;
 
     bool ok = true;


### PR DESCRIPTION
When filtering, oiio uses probes along the major ellipse axis, separated by the length of the minor axis. This works fine when the minor radius is always between .5 and 2 texels wide.

However at the highest resolution mipmap, oiio can end up sampling many times in a really small span since we are no longer guaranteed that the minor axis will be around a texel in length.

In the code I clamp the probe spacing to never be smaller than .5 texels when we are on the most detailed mipmap.

In some simple tests with renders zoomed on the texture the speedup is more than x10.

r
