### PR TITLE
Fix Cineon building on Windows

### DIFF
--- a/src/cineon.imageio/libcineon/CineonHeader.h
+++ b/src/cineon.imageio/libcineon/CineonHeader.h
@@ -42,8 +42,16 @@
 #define _CINEON_CINEONHEADER_H 1
 
 #include <cstring>
-#include <stdint.h>
 #include <limits>
+
+#if defined(_MSC_VER) && _MSC_VER < 1600
+   typedef __int32 int32_t;
+   typedef unsigned __int32 uint32_t;
+   typedef __int64 int64_t;
+   typedef unsigned __int64 uint64_t;
+#else
+# include <stdint.h>
+#endif
 
 #include "CineonStream.h"
 


### PR DESCRIPTION
On Windows stdint.h header is present only in Visual Studio 10. Older version of VS don't have it. This patch fix the problem by typedefing used types
