### PR TITLE
Better handling of unexpected TIFF bitsperpixel/format combinations 

### DIFF
--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -508,14 +508,26 @@ TIFFInput::readspec ()
             m_spec.set_format (TypeDesc::UINT16);
         else if (sampleformat == SAMPLEFORMAT_INT)
             m_spec.set_format (TypeDesc::INT16);
+        else if (sampleformat == SAMPLEFORMAT_IEEEFP)
+            m_spec.set_format (TypeDesc::HALF); // not to spec, but why not?
+        else
+            m_spec.set_format (TypeDesc::UNKNOWN);
         break;
     case 32:
         if (sampleformat == SAMPLEFORMAT_IEEEFP)
             m_spec.set_format (TypeDesc::FLOAT);
+        else if (sampleformat == SAMPLEFORMAT_UINT)
+            m_spec.set_format (TypeDesc::UINT32);
+        else if (sampleformat == SAMPLEFORMAT_INT)
+            m_spec.set_format (TypeDesc::INT32);
+        else
+            m_spec.set_format (TypeDesc::UNKNOWN);
         break;
     case 64:
         if (sampleformat == SAMPLEFORMAT_IEEEFP)
             m_spec.set_format (TypeDesc::DOUBLE);
+        else
+            m_spec.set_format (TypeDesc::UNKNOWN);
         break;
     default:
         m_spec.set_format (TypeDesc::UNKNOWN);


### PR DESCRIPTION
For several bits/format combinations that we didn't account for, fail rather than crash.  And speculatively interpret IEEEFP/16bit as 'half', even though it's not in the TIFF spec.  Apparently, some recent versions of PhotoShop are outputting this.  In this review, I only support it for reading, not writing, since so few other TIFF-reading apps are likely to make any sense of it (we still auto-convert 'half' output to 'float' for TIFF output).
