### PR TITLE
Fix include for gcc 4.7.

### DIFF
--- a/src/include/strutil.h
+++ b/src/include/strutil.h
@@ -44,6 +44,7 @@
 #include <string>
 #include <cstring>
 #include <map>
+#include <unistd.h>
 
 #include "export.h"
 #include "version.h"


### PR DESCRIPTION
It looks like "off_t" is no longer gotten for free so unistd.h must be explicitly included.
