### PR TITLE
maketx --mipimage lets you specify custom or doctored individual MIP levels.

### DIFF
--- a/src/doc/maketx.tex
+++ b/src/doc/maketx.tex
@@ -222,6 +222,18 @@ Specifically, this is the equivalent to using \\
 \apiend
 
 
+\apiitem{--mipimage {\rm \emph{filename}}}
+Specifies the name of an image file to use as a custom MIP-map level, 
+instead of simply downsizing the last one.  This option may be used
+multiple times to specify multiple levels.  For example:
+\begin{code}
+    maketx 256.tif --miplevel 128.tif --miplevel 64.tif -o out.tx
+\end{code}
+This will make a texture with the first MIP level taken from {\cf 256.tif},
+the second level from {\cf 128.tif}, the third from {\cf 64.tif}, and
+then subsequent levels will be the usual downsizings of {\cf 64.tif}.
+\apiend
+
 % --shadow --shadcube
 % --volshad --envlatl --envcube --lightprobe --latl2envcube --vertcross
 % --fov


### PR DESCRIPTION
Like this:

```
maketx 256.tif --mipimage 128.tif --mipimage 64.tif -o out.tx
```

This makes the first there mip levels 256.tif, 128.tif, and 64.tif.  Levels thereafter will continue to downsample the last one specified (64.tif, in this case).
