### PR TITLE
TS/IC: Add a separate plugin_searchpath to distinguish from the image searchpath.

### DIFF
--- a/src/doc/imagecache.tex
+++ b/src/doc/imagecache.tex
@@ -272,6 +272,13 @@ directories that will be searched in order for any image name
 that is not specified as an absolute path. (Default: no search path.)
 \apiend
 
+\apiitem{string plugin_searchpath}
+The search path for plugins: a colon-separated list of
+directories that will be searched in order for any OIIO plugins, if
+not found in OIIO's ``lib'' directory.)
+(Default: no additional search path.)
+\apiend
+
 \apiitem{int autotile \\
 int autoscanline}
 These attributes control how the image cache deals with images that

--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -530,6 +530,7 @@ Recognized attributes include the following:
 \apiitem{int max_open_files \\
 float max_memory_MB \\
 string searchpath \\
+string plugin_searchpath \\
 int autotile \\
 int autoscanline \\
 int automip \\

--- a/src/include/imagecache.h
+++ b/src/include/imagecache.h
@@ -84,6 +84,7 @@ public:
     ///     int max_open_files : maximum number of file handles held open
     ///     float max_memory_MB : maximum tile cache size, in MB
     ///     string searchpath : colon-separated search path for images
+    ///     string plugin_searchpath : colon-separated search path for plugins
     ///     int autotile : if >0, tile size to emulate for non-tiled images
     ///     int autoscanline : autotile using full width tiles
     ///     int automip : if nonzero, emulate mipmap on the fly

--- a/src/include/texture.h
+++ b/src/include/texture.h
@@ -329,6 +329,7 @@ public:
     ///     int max_open_files : maximum number of file handles held open
     ///     float max_memory_MB : maximum tile cache size, in MB
     ///     string searchpath : colon-separated search path for texture files
+    ///     string plugin_searchpath : colon-separated search path for plugins
     ///     matrix44 worldtocommon : the world-to-common transformation
     ///     matrix44 commontoworld : the common-to-world transformation
     ///     int autotile : if >0, tile size to emulate for non-tiled images

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -312,7 +312,7 @@ ImageCacheFile::open (ImageCachePerThreadInfo *thread_info)
         return false;
 
     m_input.reset (ImageInput::create (m_filename.c_str(),
-                                       m_imagecache.searchpath().c_str()));
+                                       m_imagecache.plugin_searchpath().c_str()));
     if (! m_input) {
         imagecache().error ("%s", OIIO_NAMESPACE::geterror().c_str());
         m_broken = true;
@@ -1609,6 +1609,9 @@ ImageCacheImpl::attribute (const std::string &name, TypeDesc type,
             force_invalidate = true;
         }
     }
+    else if (name == "plugin_searchpath" && type == TypeDesc::STRING) {
+        m_plugin_searchpath = std::string (*(const char **)val);
+    }
     else if (name == "statistics:level" && type == TypeDesc::INT) {
         m_statslevel = *(const int *)val;
     }
@@ -1715,6 +1718,10 @@ ImageCacheImpl::getattribute (const std::string &name, TypeDesc type,
     // The cases that don't fit in the simple ATTR_DECODE scheme
     if (name == "searchpath" && type == TypeDesc::STRING) {
         *(ustring *)val = m_searchpath;
+        return true;
+    }
+    if (name == "plugin_searchpath" && type == TypeDesc::STRING) {
+        *(ustring *)val = m_plugin_searchpath;
         return true;
     }
     if (name == "worldtocommon" && (type == TypeDesc::TypeMatrix ||

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -637,6 +637,7 @@ public:
     // Retrieve options
     int max_open_files () const { return m_max_open_files; }
     const std::string &searchpath () const { return m_searchpath; }
+    const std::string &plugin_searchpath () const { return m_plugin_searchpath; }
     int autotile () const { return m_autotile; }
     bool autoscanline () const { return m_autoscanline; }
     bool automip () const { return m_automip; }
@@ -904,10 +905,11 @@ private:
     static mutex m_perthread_info_mutex; ///< Thread safety for perthread
     int m_max_open_files;
     atomic_ll m_max_memory_bytes;
-    std::string m_searchpath;    ///< Colon-separated directory list
+    std::string m_searchpath;    ///< Colon-separated image directory list
     std::vector<std::string> m_searchdirs; ///< Searchpath split into dirs
+    std::string m_plugin_searchpath; ///< Colon-separated plugin directory list
     int m_autotile;              ///< if nonzero, pretend tiles of this size
-    bool m_autoscanline;          ///< autotile using full width tiles
+    bool m_autoscanline;         ///< autotile using full width tiles
     bool m_automip;              ///< auto-mipmap on demand?
     bool m_forcefloat;           ///< force all cache tiles to be float
     bool m_accept_untiled;       ///< Accept untiled images?


### PR DESCRIPTION
We were previously using the one "searchpath" (documented as being for images) for the plugins as well.
