### PR TITLE
Jpeg2000 read/write image fix

### DIFF
--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -215,7 +215,7 @@ Jpeg2000Input::open (const std::string &p_name, ImageSpec &p_spec)
 bool
 Jpeg2000Input::read_native_scanline (int y, int z, void *data)
 {
-    if (m_spec.format == TypeDesc::UINT8)
+    if (m_spec.format == TypeDesc::UINT8 || m_spec.format == TypeDesc::INT8)
         read_scanline<uint8_t>(y, z, data);
     else
         read_scanline<uint16_t>(y, z, data);

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -131,7 +131,7 @@ Jpeg2000Output::write_scanline (int y, int z, TypeDesc format,
 
     std::vector<uint8_t> scratch;
     data = to_native_scanline (format, data, xstride, scratch);
-    if (m_spec.format == TypeDesc::UINT8)
+    if (m_spec.format == TypeDesc::UINT8 || m_spec.format == TypeDesc::INT8)
         write_scanline<uint8_t>(y, z, data);
     else
         write_scanline<uint16_t>(y, z, data);


### PR DESCRIPTION
When TypeDesc is set to INT8 plugin should save 8-bit data to the file, not 16-bit (read_scanlin<T> write_scanline<T> should be typed to uint8_t).

Run the testsuite and this patch don't broke anything.
