### PR TITLE
Texture wrapmodes are always ignored

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -502,7 +502,7 @@ ImageCacheFile::open (ImageCachePerThreadInfo *thread_info)
     }
 
     if ((p = spec.find_attribute ("wrapmodes", TypeDesc::STRING))) {
-        const char *wrapmodes = (const char *)p->data();
+        const char *wrapmodes = *(const char **)p->data();
         TextureOpt::parse_wrapmodes (wrapmodes, m_swrap, m_twrap);
         m_rwrap = m_swrap;
         // FIXME(volume) -- rwrap


### PR DESCRIPTION
This fixes a problem where the string for wrapmodes in texture attributes is not properly returned (and cannot be parsed). When wrap options are set to default, this prevents the wrap mode in the texture attributes to be used. Instead, we always get 'black' behaviour.
