### PR TITLE
Review: Minor build fixes for OCIO detection

### DIFF
--- a/site/spi/Makefile-bits-arnold
+++ b/site/spi/Makefile-bits-arnold
@@ -20,6 +20,7 @@ endif
 ifeq ($(SP_ARCH), spinux1_x86_64)
     platform=spinux1
     COMPILER=gcc44m64
+    INSTALL_SPCOMP2_LOCATION = /shots/spi/home/lib/SpComp2
     # At SPI, we have two "flavors" of spinux.  One is based on Foresight, which
     # uses a special libGL (below).  The other is based on Fedora which uses
     # the standard libGL.  This attempts to detect which libGL to use.
@@ -30,6 +31,9 @@ ifeq ($(SP_ARCH), spinux1_x86_64)
 	  -DILMBASE_CUSTOM_LIBRARIES="SpiImath SpiHalf SpiIlmThread SpiIex" \
 	  -DOPENEXR_CUSTOM=1 \
 	  -DOPENEXR_CUSTOM_LIBRARY="SpiIlmImf"
+    ifeq (${OCIO_PATH},)
+        MY_CMAKE_FLAGS += -DOCIO_PATH="${INSTALL_SPCOMP2_LOCATION}/OpenColorIO/${platform}-${COMPILER}/current"
+    endif
 endif  # endif spinux1_x86_64
 
 

--- a/site/spi/Makefile-bits-spcomp2
+++ b/site/spi/Makefile-bits-spcomp2
@@ -23,6 +23,7 @@ OPENIMAGEIO_SPCOMP2_VERSION=30
 NAMESPACE ?= 'OpenImageIO_SPI'
 SOVERSION ?= ${OPENIMAGEIO_SPCOMP2_VERSION}
 SPCOMP2_RPATH ?= ""
+INSTALL_SPCOMP2_LOCATION = /shots/spi/home/lib/SpComp2
 
 ## Spinux (current)
 ifeq ($(SP_ARCH), spinux1_x86_64)
@@ -38,6 +39,9 @@ ifeq ($(SP_ARCH), spinux1_x86_64)
      -DILMBASE_CUSTOM_LIBRARIES="SpiImath SpiHalf SpiIlmThread SpiIex" \
      -DOPENEXR_CUSTOM=1 \
      -DOPENEXR_CUSTOM_LIBRARY="SpiIlmImf"
+    ifeq (${OCIO_PATH},)
+        MY_CMAKE_FLAGS += -DOCIO_PATH="${INSTALL_SPCOMP2_LOCATION}/OpenColorIO/${platform}-${COMPILER}/current"
+    endif
 endif  # endif spinux1_x86_64
 
 
@@ -49,7 +53,6 @@ comma:= ,
 empty:=
 space:= $(empty) $(empty)
 
-INSTALL_SPCOMP2_LOCATION = /shots/spi/home/lib/SpComp2
 INSTALL_BIN_LOCATION = /shots/spi/home/bin/$(ARCHITECTURE)
 INSTALL_SPCOMP2_CURRENT = $(INSTALL_SPCOMP2_LOCATION)/OpenImageIO/$(ARCHITECTURE)-$(COMPILER)/v$(OPENIMAGEIO_SPCOMP2_VERSION)
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -178,9 +178,32 @@ message (STATUS "OPENGL_FOUND=${OPENGL_FOUND} USE_OPENGL=${USE_OPENGL}")
 
 ###########################################################################
 # OpenColorIO Setup
+
 if (USE_OCIO)
+    # If 'OCIO_PATH' not set, use the env variable of that name if available
+    if (NOT OCIO_PATH)
+        if (NOT $ENV{OCIO_PATH} STREQUAL "")
+            set (OCIO_PATH $ENV{OCIO_PATH})
+        endif ()
+    endif()
+
     find_package (OpenColorIO)
+    FindOpenColorIO ()
+
+    if (OCIO_FOUND)
+        message (STATUS "OpenColorIO enabled")
+        message(STATUS "OCIO_INCLUDES: ${OCIO_INCLUDES}")
+        include_directories (${OCIO_INCLUDES})
+        add_definitions ("-DUSE_OCIO=1")
+    else ()
+        message (STATUS "Skipping OpenColorIO support")
+    endif ()
+else ()
+    message (STATUS "OpenColorIO disabled")
 endif ()
+
+# end OpenColorIO setup
+###########################################################################
 
 
 ###########################################################################

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -65,21 +65,6 @@ if (USE_TBB)
     set (libOpenImageIO_srcs ${libOpenImageIO_srcs} ../libutil/tbb_misc.cpp)
 endif ()
 
-# Include OpenColorIO if using it
-if (USE_OCIO)
-    FindOpenColorIO()
-    if (OCIO_FOUND)
-        message (STATUS "OpenColorIO enabled")
-        message(STATUS "OCIO_INCLUDES: ${OCIO_INCLUDES}")
-        include_directories (${OCIO_INCLUDES})
-        add_definitions ("-DUSE_OCIO=1")
-    else ()
-        message (STATUS "Skipping OpenColorIO support")
-    endif ()
-else ()
-    message (STATUS "OpenColorIO disabled")
-endif ()
-
 # If the 'EMBEDPLUGINS' option is set, we want to compile the source for
 # all the plugins into libOpenImageIO.
 if (EMBEDPLUGINS)


### PR DESCRIPTION
Make it so that environment variable "OCIO_PATH" is used for the default CMake OCIO_PATH, if present.  

Also some minor SPI-specific fixes to find OCIO.
