### PR TITLE
2 simple GUI improvements for iv

### DIFF
--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -238,8 +238,6 @@ public:
         return darkPaletteBox ? darkPaletteBox->isChecked() : m_darkPalette;
     }
 
-    QPalette palette (void) const { return m_palette; }
-
 private slots:
     void open();                        ///< Dialog to open new image from file
     void reload();                      ///< Reread current image from disk
@@ -296,6 +294,7 @@ private slots:
     void showInfoWindow();              ///< View extended info on image
     void showPixelviewWindow();         ///< View closeup pixel view
     void editPreferences();             ///< Edit viewer preferences
+    void changePalette (int darkPaletteBoxState); ///< Sets the application's palette
 private:
     void createActions ();
     void createMenus ();
@@ -382,7 +381,6 @@ private:
     bool m_fullscreen;                ///< Full screen mode
     std::vector<std::string> m_recent_files;  ///< Recently opened files
     float m_default_gamma;            ///< Default gamma of the display
-    QPalette m_palette;               ///< Custom palette
     bool m_darkPalette;               ///< Use dark palette?
 
     static const int m_default_width = 640; ///< The default width of the window.


### PR DESCRIPTION
1. Now at start the main window appears in the center of the desktop. I don't know whether this is useful, but it looks better.
2. When clicking "Dark palette" in the preferences window, the application changes its palette dynamically. No restart required. (For this purpose it was necessary: to add a new public slot changePalette() to the ImageViewer class and to remove unnecessary field "QPalette m_palette;" from this class.) Also there was a FIXME which said that palette setting didn't work. Now it works. But by default changing a palette works only for the components which are not using system styles. Therefore for some elements it was required to change stylesheet instead of palette.
