### PR TITLE
Review: global attribute()/getattribute for OIIO-wide options and thread control

### DIFF
--- a/src/doc/iconvert.tex
+++ b/src/doc/iconvert.tex
@@ -158,6 +158,12 @@ Prints usage information to the terminal.
 Verbose status messages.
 \apiend
 
+\apiitem{--threads \emph{n}}
+Use \emph{n} execution threads if it helps to speed up image operations.
+The default (also if $n=0$) is to use as many threads as there are cores
+present in the hardware.
+\apiend
+
 \apiitem{--inplace}
 Causes the output to \emph{replace} the input file, rather than create a
 new file with a different name.

--- a/src/doc/imagecache.tex
+++ b/src/doc/imagecache.tex
@@ -569,6 +569,7 @@ modification times have been changed since they were first opened.
 \label{sec:imagecache:api:resetstats}
 
 \apiitem{std::string {\ce geterror} ()}
+\index{error checking}
 If any other API routines return {\cf false}, indicating that an error
 has occurred, this routine will retrieve the error and clear the error
 status.  If no error has occurred since the last time {\cf geterror()}

--- a/src/doc/imageinput.tex
+++ b/src/doc/imageinput.tex
@@ -636,6 +636,7 @@ Here is an example:
 
 \subsection{Error checking}
 \label{sec:imageinput:errors}
+\index{error checking}
 
 Nearly every \ImageInput API function returns a {\cf bool} indicating
 whether the operation succeeded ({\cf true}) or failed ({\cf false}).
@@ -1010,6 +1011,7 @@ This is currently undefined and is reserved for future use.
 \apiend
 
 \apiitem{std::string {\ce geterror} () const}
+\index{error checking}
 Returns the current error string describing what went wrong if
 any of the public methods returned {\kw false} indicating an error.
 (Hopefully the implementation plugin called {\kw error()} with a

--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -227,10 +227,10 @@ The number of \emph{channels} (color values) present in each pixel of
 the image.  For example, an RGB image has 3 channels.
 \apiend
 
-\newpage
+%\newpage
 %\vspace{24pt}  % make some space
 
-\apiitem{TypeDesc format \\
+\apiitem{TypeDesc format \\[0.5ex]
 std::vector<TypeDesc> channelformats}
 Describes the native format of the pixel data values themselves, as a
 \TypeDesc (see \ref{sec:TypeDesc}).  Typical values would be 
@@ -465,6 +465,113 @@ format the value nicely as a string.  If {\cf human} is true, use
 especially human-readable explanations (units, or decoding of
 values) for certain known metadata.
 \apiend
+
+
+
+\subsection{Miscellaneous Utilities}
+
+These helper functions are not part of any other \OpenImageIO class,
+they just exist in the {\cf OpenImageIO} namespace as general utilities.
+
+\apiitem{int {\ce openimageio_version} ()}
+\index{version}
+\indexapi{openimageio_version}
+Returns a numeric value for the version of \product, 10000 for each
+major version, 100 for each minor version, 1 for each patch.  For
+example, \product 1.2.3 would return a value of 10203.
+\apiend
+
+\apiitem{std::string {\ce geterror} ()}
+\index{error checking}
+\indexapi{geterror}
+Returns any error string describing what went wrong if 
+{\cf ImageInput::create()} or {\cf ImageOutput::create()} failed
+(since in such cases, the \ImageInput or \ImageOutput itself does 
+not exist to have its own {\cf geterror()} function called).
+\apiend
+
+
+\apiitem{bool {\ce attribute} (const std::string \&name, TypeDesc type,
+  const void *val)}
+\indexapi{attribute}
+
+Sets an global attribute (i.e., a property or option) of \product.
+The {\cf name} designates the name of the attribute, {\cf type}
+describes the type of data, and {\cf val} is a pointer to memory 
+containing the new value for the attribute.
+
+If the name is known, valid attribute that matches the type specified,
+the attribute will be set to the new value and {\cf attribute()} will
+return {\cf true}.  If {\cf name} is not recognized, or if the types do
+not match (e.g., {\cf type} is {\cf TypeDesc::TypeFloat} but the named
+attribute is a string), the attribute will not be modified, and {\cf
+  attribute()} will return {\cf false}.
+
+\noindent The following are the recognized attributes:
+
+\apiitem{int threads}
+\vspace{10pt}
+\index{threads}
+Some \product operations can be accelerated if allowed to spawn multiple
+threads to parallelize the task.  (Examples: decompressing multiple
+simultaneously-read OpenEXR scanlines, or many \ImageBuf operations.)
+This attribute sets the maximum number of threads that will be spawned.
+The default is 1.  If set to 0, it means that it should use as many
+threads as there are hardware cores present on the system.
+\apiend
+
+\apiend
+
+\apiitem{bool {\ce attribute} (const std::string \&name, int val) \\
+bool {\ce attribute} (const std::string \&name, float val) \\
+bool {\ce attribute} (const std::string \&name, const char *val) \\
+bool {\ce attribute} (const std::string \&name, const std::string \& val)}
+Specialized versions of {\cf attribute()} in which the data type is
+implied by the type of the argument.
+\apiend
+
+
+
+\apiitem{bool {\ce getattribute} (const std::string \&name, TypeDesc type,
+  void *val)}
+\indexapi{getattribute}
+
+Gets the current value of a global attribute.  The {\cf name} designates
+the name of the attribute, {\cf type} describes the type of data, and
+{\cf val} is a pointer to memory where the user would like the value
+placed.
+
+If the attribute name is valid and matches the type specified, the
+attribute value will be stored at address {\cf val} and {\cf
+  attribute()} will return {\cf true}.  If {\cf name} is not recognized
+as a valid attribute name, or if the types do not match (e.g., {\cf
+  type} is {\cf TypeDesc::TypeFloat} but the named attribute is a
+string), no data will be written to {\cf val}, and {\cf attribute()}
+will return {\cf false}.
+
+The complete list of attributes can be found above, in the description
+of the {\cf attribute()} function.
+\apiend
+
+\apiitem{bool {\ce getattribute} (const std::string \&name, int \&val) \\
+bool {\ce getattribute} (const std::string \&name, float \&val) \\
+bool {\ce getattribute} (const std::string \&name, char **val) \\
+bool {\ce getattribute} (const std::string \&name, std::string \& val)}
+Specialized versions of {\cf getattribute()} in which the data type is
+implied by the type of the argument.
+
+For example, the following are equivalent to the example above for the
+general (pointer) form of {\cf getattribute()}:
+
+\begin{code}
+      int maxfiles;
+      ts->getattribute ("max_open_files", &maxfiles);
+      const char *path;
+      ts->getattribute ("searchpath", &path);
+\end{code}
+
+\apiend
+
 
 
 \index{Image I/O API|)}

--- a/src/doc/imageoutput.tex
+++ b/src/doc/imageoutput.tex
@@ -1019,6 +1019,7 @@ the order that the directories are listed.  Here is an example:
 
 \subsection{Error checking}
 \label{sec:imageoutput:errors}
+\index{error checking}
 
 Nearly every \ImageOutput API function returns a {\cf bool} indicating
 whether the operation succeeded ({\cf true}) or failed ({\cf false}).
@@ -1354,6 +1355,7 @@ This is currently undefined and is reserved for future use.
 \apiend
 
 \apiitem{std::string {\ce geterror} ()}
+\index{error checking}
 Returns the current error string describing what went wrong if
 any of the public methods returned {\kw false} indicating an error.
 (Hopefully the implementation plugin called {\kw error()} with a

--- a/src/doc/maketx.tex
+++ b/src/doc/maketx.tex
@@ -41,6 +41,12 @@ Verbose status messages, including runtime statistics and timing.
 Sets the name of the output texture.
 \apiend
 
+\apiitem{--threads \emph{n}}
+Use \emph{n} execution threads if it helps to speed up image operations.
+The default (also if $n=0$) is to use as many threads as there are cores
+present in the hardware.
+\apiend
+
 \apiitem{--format {\rm \emph{formatname}}}
 Specifies the image format of the output file (e.g., ``tiff'',
 ``OpenEXR'', etc.).  If {\cf --format} is not used, \maketx will 

--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -1280,6 +1280,7 @@ applied.
 \label{sec:texturesys:api:invalidate}
 
 \apiitem{std::string {\ce geterror} ()}
+\index{error checking}
 If any other API routines return {\cf false}, indicating that an
 error has occurred, this routine will retrieve the error and clear
 the error status.  If no error has occurred since the last time

--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -55,6 +55,7 @@ static std::string dataformatname = "";
 static float gammaval = 1.0f;
 //static bool depth = false;
 static bool verbose = false;
+static int nthreads = 0;    // default: use #cores threads if available
 static std::vector<std::string> filenames;
 static int tile[3] = { 0, 0, 1 };
 static bool scanline = false;
@@ -99,6 +100,7 @@ getargs (int argc, char *argv[])
                 "%*", parse_files, "",
                 "--help", &help, "Print help message",
                 "-v", &verbose, "Verbose status messages",
+                "--threads %d", &nthreads, "Number of threads (default 0 = #cores)",
                 "-d %s", &dataformatname, "Set the output data format to one of:"
                         "uint8, sint8, uint10, uint12, uint16, sint16, half, float, double",
                 "-g %f", &gammaval, "Set gamma correction (default = 1)",
@@ -501,6 +503,8 @@ int
 main (int argc, char *argv[])
 {
     getargs (argc, argv);
+
+    OIIO_NAMESPACE::attribute ("threads", nthreads);
 
     bool ok = true;
 

--- a/src/include/imageio.h
+++ b/src/include/imageio.h
@@ -999,6 +999,56 @@ DLLPUBLIC int openimageio_version ();
 /// which call obj->geterror().
 DLLPUBLIC std::string geterror ();
 
+/// Set a global attribute controlling OpenImageIO.  Return true
+/// if the name and type were recognized and the attribute was set.
+///
+/// Documented attributes:
+///     int threads : how many threads to use for operations that can
+///                   be sped up by spawning threads (default=1;
+///                   note that 0 means "as many threads as cores").
+DLLPUBLIC bool attribute (const std::string &name, TypeDesc type,
+                          const void *val);
+// Shortcuts for common types
+inline bool attribute (const std::string &name, int val) {
+    return attribute (name, TypeDesc::TypeInt, &val);
+}
+inline bool attribute (const std::string &name, float val) {
+    return attribute (name, TypeDesc::TypeFloat, &val);
+}
+inline bool attribute (const std::string &name, const char *val) {
+    return attribute (name, TypeDesc::TypeString, &val);
+}
+inline bool attribute (const std::string &name, const std::string &val) {
+    const char *s = val.c_str();
+    return attribute (name, TypeDesc::TypeString, &s);
+}
+
+/// Get the named global attribute of OpenImageIO, store it in *val.
+/// Return true if found and it was compatible with the type specified,
+/// otherwise return false and do not modify the contents of *val.  It
+/// is up to the caller to ensure that val points to the right kind and
+/// size of storage for the given type.
+DLLPUBLIC bool getattribute (const std::string &name, TypeDesc type,
+                             void *val);
+// Shortcuts for common types
+inline bool getattribute (const std::string &name, int &val) {
+    return getattribute (name, TypeDesc::TypeInt, &val);
+}
+inline bool getattribute (const std::string &name, float &val) {
+    return getattribute (name, TypeDesc::TypeFloat, &val);
+}
+inline bool getattribute (const std::string &name, char **val) {
+    return getattribute (name, TypeDesc::TypeString, val);
+}
+inline bool getattribute (const std::string &name, std::string &val) {
+    const char *s = NULL;
+    bool ok = getattribute (name, TypeDesc::TypeString, &s);
+    if (ok)
+        val = s;
+    return ok;
+}
+
+
 /// Deprecated
 ///
 inline std::string error_message () { return geterror (); }

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -71,7 +71,7 @@ static std::vector<std::string> mipimages;
 //static float ingamma = 1.0f, outgamma = 1.0f;
 static bool verbose = false;
 static bool stats = false;
-static int nthreads = 0;
+static int nthreads = 0;    // default: use #cores threads if available
 static int tile[3] = { 64, 64, 1 };
 static std::string channellist;
 static bool updatemode = false;
@@ -228,7 +228,7 @@ getargs (int argc, char *argv[])
                   "--help", &help, "Print help message",
                   "-v", &verbose, "Verbose status messages",
                   "-o %s", &outputfilename, "Output filename",
-                  "-t %d", &nthreads, "Number of threads (default: #cores)",
+                  "--threads %d", &nthreads, "Number of threads (default: #cores)",
                   "-u", &updatemode, "Update mode",
                   "--format %s", &fileformatname, "Specify output file format (default: guess from extension)",
                   "--nchannels %d", &nchannels, "Specify the number of output image channels.",
@@ -1261,6 +1261,7 @@ main (int argc, char *argv[])
     Timer alltimer;
     getargs (argc, argv);
 
+    OIIO_NAMESPACE::attribute ("threads", nthreads);
     if (stats) {
         ImageCache *ic = ImageCache::create ();  // get the shared one
         ic->attribute ("forcefloat", 1);   // Force float upon read

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -137,6 +137,15 @@ Oiiotool::process_pending ()
 
 
 static int
+set_threads (int argc, const char *argv[])
+{
+    ASSERT (argc == 1);
+    OIIO_NAMESPACE::attribute ("threads", atoi(argv[0]));
+}
+
+
+
+static int
 input_file (int argc, const char *argv[])
 {
     for (int i = 0;  i < argc;  i++) {
@@ -1127,7 +1136,7 @@ getargs (int argc, char *argv[])
 //                "-u", &ot.updatemode, "Update mode: skip outputs when the file exists and is newer than all inputs",
                 "--no-clobber", &ot.noclobber, "Do not overwrite existing files",
                 "--noclobber", &ot.noclobber, "", // synonym
-                "--threads %d", &ot.threads, "Number of threads to use (0 == #cores)",
+                "--threads %@ %d", set_threads, &ot.threads, "Number of threads (default 0 == #cores)",
                 "<SEPARATOR>", "Commands that write images:",
                 "-o %@ %s", output_file, &dummystr, "Output the current image to the named file",
                 "<SEPARATOR>", "Options that affect subsequent image output:",


### PR DESCRIPTION
Add global attribute()/getattribute for OIIO-wide options. First one: "threads"

set number of threads for things that can spawn threads to parallelize
(such as certain ImageBuf algorithms and OpenEXR multi-tile encode/decode).
Set this in the appropriate command-line utilities and also standardize on
--threads as the command line argument across all the utils.

The impetus from this was a suggest from Chris Kulla that we should not
automatically instruct OpenEXR to use many threads.  But I didn't want
to lose this ability entirely, and the ability to set a nmber of threads
to be spawned pops up in many places, and generalizes to many potential
future cases of wanting to set various global options, for which we did
not previously have an API call.  Now we do, in the form of attribute()
and getattribute(), syntax lifted directly from TextureSystem,
ImageCache, and OSL.  But these global ones are not part of any class
(and do not take the place of class-specific ones such as
TextureSystem::attribute()), but rather are in the outer OIIO_NAMESPACE.
