### PR TITLE
More efficient subpixel filtering

### DIFF
--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -1073,6 +1073,13 @@ TextureSystemImpl::texture_lookup (TextureFile &texturefile,
         miplevel[0] = 0;
         miplevel[1] = 0;
         levelblend = 0;
+        // It's possible that minorlength is degenerate, giving an aspect
+        // ratio that implies a huge nsamples, which is pointless if those
+        // samples are too close.  So if minorlength is less than 1/2 texel
+        // at the finest resolution, clamp it and recalculate aspect.
+        int r = std::max (subinfo.spec(0).full_width, subinfo.spec(0).full_height);
+        if (minorlength*r < 0.5f)
+            aspect = Imath::clamp (majorlength * r * 2.0f, 1.0f, float(options.anisotropic));
     }
     if (options.mipmode == TextureOpt::MipModeOneLevel) {
         miplevel[0] = miplevel[1];


### PR DESCRIPTION
Alternate proposal to https://github.com/OpenImageIO/oiio/pull/196
I think this is equivalent but is a bit less mysterious.
The idea here is that the filtering ellipse can be so thin that the minorlength is significantly subpixel sized, even at the finest MIP level, which will lead to a high nsamples pointlessly -- the samples will be too close together.  So this detects that case and clamps minorlength to be at least 1/2 texel wide, and readjusts aspect, which in turn will end up leading to a sane number of samples along the ellipse axis.
