### PR TITLE
maketx: added --fixnan option

### DIFF
--- a/src/include/imagebufalgo.h
+++ b/src/include/imagebufalgo.h
@@ -267,9 +267,9 @@ enum DLLPUBLIC NonFiniteFixMode
 };
 
 /// Fix all non-finite pixels (nan/inf) using the specified approach
-bool DLLPUBLIC fixNonFinite(int * pixelsFixed,
-                            ImageBuf &dst, const ImageBuf &src,
-                            NonFiniteFixMode mode);
+bool DLLPUBLIC fixNonFinite(ImageBuf &dst, const ImageBuf &src,
+                            NonFiniteFixMode mode=NONFINITE_BOX3,
+                            int * pixelsFixed=NULL);
 
 
 };  // end namespace ImageBufAlgo

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -250,11 +250,8 @@ getargs (int argc, char *argv[])
                   "--noresize %!", &doresize, "Do not resize textures to power of 2 (deprecated)",
                   "--filter %s", &filtername, filter_help_string().c_str(),
                   "--nomipmap", &nomipmap, "Do not make multiple MIP-map levels",
-                  "--checknan", &checknan, "Check for NaN and Inf values (abort if found)",
-                  "--fixnan %s", &fixnan, "Attempt to cleanup NaN/Inf(s) in the image using the specified approach. (default: none)\n"
-                          "\t\t\t\t  none: do nothing\n"
-                          "\t\t\t\t  black: replace NaN/Inf(s) with black\n"
-                          "\t\t\t\t  box3: Fill nan values with 3x3 window average, replace remaining NaN/Inf(s) with black",
+                  "--checknan", &checknan, "Check for NaN/Inf values (abort if found)",
+                  "--fixnan %s", &fixnan, "Attempt to fix NaN/Inf values in the image (options: none, black, box3)",
                   "--Mcamera %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f",
                           &Mcam[0][0], &Mcam[0][1], &Mcam[0][2], &Mcam[0][3], 
                           &Mcam[1][0], &Mcam[1][1], &Mcam[1][2], &Mcam[1][3], 
@@ -981,7 +978,7 @@ make_texturemap (const char *maptypename = "texture map")
     }
     
     int pixelsFixed = 0;
-    if (!ImageBufAlgo::fixNonFinite (&pixelsFixed, src, src, fixmode)) {
+    if (!ImageBufAlgo::fixNonFinite (src, src, fixmode, &pixelsFixed)) {
         std::cerr << "maketx ERROR: Error fixing nans/infs.\n";
         exit (EXIT_FAILURE);
     }


### PR DESCRIPTION
maketx gets an option to fix nan/infs in the image.  (defaults to off)
