### PR TITLE
Review: testsuite refactor: make tests directly run runtest.py

### DIFF
--- a/src/cmake/oiio_macros.cmake
+++ b/src/cmake/oiio_macros.cmake
@@ -107,9 +107,10 @@ macro (oiio_add_tests)
                 set (_add_test_args ${_testname} python)
                 set (_extra_test_args "")
             endif ()
-            message (STATUS "TEST ${_testname}: ${_testdir}/run.py ${_testdir} ${CMAKE_BINARY_DIR} ${_extra_test_args}")
+            message (STATUS "TEST ${_testname}: ${CMAKE_BINARY_DIR}/testsuite/runtest.py ${_testdir} ${_extra_test_args}")
             add_test (${_add_test_args}
-                      "${_testdir}/run.py" "${_testdir}"
+                      ${CMAKE_BINARY_DIR}/testsuite/runtest.py
+                      ${_testdir}
                       ${_extra_test_args})
         endforeach ()
     endif ()

--- a/testsuite/bmp/run.py
+++ b/testsuite/bmp/run.py
@@ -1,22 +1,7 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-
-# bmpsuite:
-imagedir = runtest.parent + "/bmpsuite"
-command =           runtest.rw_command (imagedir, "g01bg.bmp")
-command = command + runtest.rw_command (imagedir, "g04.bmp")
-command = command + runtest.rw_command (imagedir, "g08.bmp")
-command = command + runtest.rw_command (imagedir, "g16bf555.bmp")
-command = command + runtest.rw_command (imagedir, "g24.bmp")
-command = command + runtest.rw_command (imagedir, "g32bf.bmp")
-
-# Outputs to check against references
-outputs = [ "out.txt" ]
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)
+imagedir = parent + "/bmpsuite"
+files = [ "g01bg.bmp", "g04.bmp", "g08.bmp",
+          "g16bf555.bmp", "g24.bmp", "g32bf.bmp" ]
+for f in files :
+    command += rw_command (imagedir, f)

--- a/testsuite/dpx/run.py
+++ b/testsuite/dpx/run.py
@@ -1,21 +1,6 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# List of images to test
-imagedir = runtest.parent + "/oiio-images"
+imagedir = parent + "/oiio-images"
 files = [ "dpx_nuke_10bits_rgb.dpx", "dpx_nuke_16bits_rgba.dpx" ]
-
-# Run the tests
-command = ""
 for f in files:
-    command = command + " ;\n" + runtest.rw_command (imagedir, f)
-
-# Outputs to check against references
-outputs = [ "out.txt" ]
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)
+    command += rw_command (imagedir, f)

--- a/testsuite/fits/run.py
+++ b/testsuite/fits/run.py
@@ -1,35 +1,18 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# Start off
-command = ""
-
 # ../fits-image/pg93:
 # tst0001.fits to tst0014.fits
-imagedir = runtest.parent + "/fits-images/pg93"
-command = command + ";\n" + runtest.rw_command (imagedir, "tst0001.fits")
-command = command + ";\n" + runtest.rw_command (imagedir, "tst0002.fits")
-command = command + ";\n" + runtest.rw_command (imagedir, "tst0003.fits")
-command = command + ";\n" + runtest.rw_command (imagedir, "tst0005.fits")
-command = command + ";\n" + runtest.rw_command (imagedir, "tst0006.fits")
-command = command + ";\n" + runtest.rw_command (imagedir, "tst0007.fits")
-command = command + ";\n" + runtest.rw_command (imagedir, "tst0008.fits")
-#command = command + ";\n" + runtest.rw_command (imagedir, "tst0009.fits")
-command = command + ";\n" + runtest.rw_command (imagedir, "tst0013.fits")
+imagedir = parent + "/fits-images/pg93"
+files = [ "tst0001.fits", "tst0002.fits", "tst0003.fits",
+           "tst0005.fits", "tst0006.fits", "tst0007.fits",  "tst0008.fits",
+           #FIXME? "tst0009.fits",
+          "tst0013.fits"
+        ]
+for f in files :
+    command += rw_command (imagedir, f)
 
-imagedir = runtest.parent + "/fits-images/ftt4b"
-command = command + ";\n" + runtest.rw_command (imagedir, "file001.fits")
-command = command + ";\n" + runtest.rw_command (imagedir, "file002.fits")
-command = command + ";\n" + runtest.rw_command (imagedir, "file003.fits")
-command = command + ";\n" + runtest.rw_command (imagedir, "file009.fits")
-command = command + ";\n" + runtest.rw_command (imagedir, "file012.fits")
-
-# Outputs to check against references
-outputs = [ "out.txt" ]
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)
+imagedir = parent + "/fits-images/ftt4b"
+files = [ "file001.fits", "file002.fits", "file003.fits",
+          "file009.fits", "file012.fits" ]
+for f in files :
+    command += rw_command (imagedir, f)

--- a/testsuite/gpsread/run.py
+++ b/testsuite/gpsread/run.py
@@ -1,15 +1,3 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# A command to run
-command = runtest.info_command (runtest.parent + "/oiio-images/tahoe-gps.jpg")
-
-# Outputs to check against references
-outputs = [ "out.txt" ]
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)
+command = info_command (parent + "/oiio-images/tahoe-gps.jpg")

--- a/testsuite/ico/run.py
+++ b/testsuite/ico/run.py
@@ -1,18 +1,5 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# Start off
-imagedir = runtest.parent + "/oiio-images"
-
-# Run the tests
-command = runtest.rw_command (imagedir, "oiio.ico")
-
-# Outputs to check against references
+imagedir = parent + "/oiio-images"
+command = rw_command (imagedir, "oiio.ico")
 outputs = [ "out.txt" ]
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)

--- a/testsuite/jpeg2000/run.py
+++ b/testsuite/jpeg2000/run.py
@@ -1,29 +1,9 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# Start off
-command = ""
-
 # ../j2kp4files_v1_5/codestreams_profile0:
-# p0_01.j2k to p_0_02.j2k images
-imagedir = runtest.parent + "/j2kp4files_v1_5/codestreams_profile0"
-command = command + runtest.rw_command (imagedir, "p0_01.j2k")
-command = command + runtest.rw_command (imagedir, "p0_02.j2k")
-command = command + runtest.rw_command (imagedir, "p0_03.j2k")
-command = command + runtest.rw_command (imagedir, "p0_04.j2k")
-command = command + runtest.rw_command (imagedir, "p0_05.j2k")
-command = command + runtest.rw_command (imagedir, "p0_06.j2k")
-command = command + runtest.rw_command (imagedir, "p0_10.j2k")
-command = command + runtest.rw_command (imagedir, "p0_11.j2k")
-command = command + runtest.rw_command (imagedir, "p0_12.j2k")
-command = command + runtest.rw_command (imagedir, "p0_14.j2k")
-
-# Outputs to check against references
-outputs = [ "out.txt" ]
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)
+imagedir = parent + "/j2kp4files_v1_5/codestreams_profile0"
+files = [ "p0_01.j2k", "p0_02.j2k", "p0_03.j2k", "p0_04.j2k",
+          "p0_05.j2k", "p0_06.j2k", "p0_10.j2k", "p0_11.j2k",
+          "p0_12.j2k", "p0_14.j2k" ]
+for f in files:
+    command += rw_command (imagedir, f)

--- a/testsuite/oiiotool-fixnan/run.py
+++ b/testsuite/oiiotool-fixnan/run.py
@@ -1,24 +1,12 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# A command to run
-command = ""
-command = command + (runtest.oiio_app ("oiiotool") + 
+command += (oiio_app ("oiiotool") + 
                      " bad.exr --fixnan black -o black.exr >> out.txt ;\n")
-command = command + (runtest.oiio_app ("oiiotool") + 
+command += (oiio_app ("oiiotool") + 
                      " bad.exr --fixnan box3 -o box3.exr >> out.txt ;\n")
-command = command + runtest.info_command ("bad.exr", "--stats")
-command = command + runtest.info_command ("black.exr", "--stats")
-command = command + runtest.info_command ("box3.exr", "--stats")
+command += info_command ("bad.exr", "--stats")
+command += info_command ("black.exr", "--stats")
+command += info_command ("box3.exr", "--stats")
 
 # Outputs to check against references
 outputs = [ "black.exr", "box3.exr", "out.txt" ]
-
-print "Running this command:\n" + command + "\n"
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -1,14 +1,8 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# A command to run
-command = ""
-command = command + (runtest.oiio_app ("oiiotool") + " " 
-                     + runtest.parent + "/oiio-images/grid.tif"
-                     + " --resize 256x256 -o resize.tif >> out.txt ;\n")
+command = (oiio_app ("oiiotool") + " " 
+           + parent + "/oiio-images/grid.tif"
+           + " --resize 256x256 -o resize.tif >> out.txt ;\n")
 
 # To add more tests, just append more lines like the above and also add
 # the new 'feature.tif' (or whatever you call it) to the outputs list,
@@ -19,7 +13,3 @@ command = command + (runtest.oiio_app ("oiiotool") + " "
 outputs = [ "resize.tif" ]
 
 #print "Running this command:\n" + command + "\n"
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)

--- a/testsuite/openexr-chroma/run.py
+++ b/testsuite/openexr-chroma/run.py
@@ -1,34 +1,18 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# Start off
-command = ""
-
-
 # ../openexr-images-1.5.0/Chromaticities:
 # README         Rec709.exr     Rec709_YC.exr  XYZ.exr        XYZ_YC.exr
-imagedir = runtest.parent + "/openexr-images-1.5.0/Chromaciticies"
+imagedir = parent + "/openexr-images-1.5.0/Chromaciticies"
 # FIXME - we don't currently understand chromaticities
 
 # ../openexr-images-1.5.0/LuminanceChroma:
 # CrissyField.exr  Garden.exr       StarField.exr
 # Flowers.exr      MtTamNorth.exr
-imagedir = runtest.parent + "/openexr-images-1.5.0/LuminanceChroma"
-#command = command + runtest.rw_command (imagedir, "CrissyField.exr", extraargs="--compression zip")
-#command = command + runtest.rw_command (imagedir, "Flowers.exr", extraargs="--compression zip")
-command = command + runtest.rw_command (imagedir, "Garden.exr")
-#command = command + runtest.rw_command (imagedir, "MtTamNorth.exr")
-#command = command + runtest.rw_command (imagedir, "StarField.exr")
+imagedir = parent + "/openexr-images-1.5.0/LuminanceChroma"
+#command += rw_command (imagedir, "CrissyField.exr", extraargs="--compression zip")
+#command += rw_command (imagedir, "Flowers.exr", extraargs="--compression zip")
+command += rw_command (imagedir, "Garden.exr")
+#command += rw_command (imagedir, "MtTamNorth.exr")
+#command += rw_command (imagedir, "StarField.exr")
 # FIXME -- most of these are broken, we don't read LuminanceChroma images,
 #     nor do we currently support subsampled channels
-
-
-# Outputs to check against references
-outputs = [ "out.txt" ]
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)

--- a/testsuite/openexr-multires/run.py
+++ b/testsuite/openexr-multires/run.py
@@ -1,38 +1,18 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
 # ../openexr-images-1.5.0/MultiResolution:
 # Bonita.exr              MirrorPattern.exr       StageEnvCube.exr
 # ColorCodedLevels.exr    OrientationCube.exr     StageEnvLatLong.exr
 # Kapaa.exr               OrientationLatLong.exr  WavyLinesCube.exr
 # KernerEnvCube.exr       PeriodicPattern.exr     WavyLinesLatLong.exr
 # KernerEnvLatLong.exr    README                  WavyLinesSphere.exr
-imagedir = runtest.parent + "/openexr-images-1.5.0/MultiResolution"
-command = ""
-command = command + runtest.rw_command (imagedir, "Bonita.exr")
-command = command + runtest.rw_command (imagedir, "ColorCodedLevels.exr")
-#command = command + runtest.rw_command (imagedir, "Kapaa.exr")
-command = command + runtest.rw_command (imagedir, "KernerEnvCube.exr")
-command = command + runtest.rw_command (imagedir, "KernerEnvLatLong.exr")
-command = command + runtest.rw_command (imagedir, "MirrorPattern.exr")
-command = command + runtest.rw_command (imagedir, "OrientationCube.exr")
-command = command + runtest.rw_command (imagedir, "OrientationLatLong.exr")
-command = command + runtest.rw_command (imagedir, "PeriodicPattern.exr")
-command = command + runtest.rw_command (imagedir, "StageEnvCube.exr")
-command = command + runtest.rw_command (imagedir, "StageEnvLatLong.exr")
-command = command + runtest.rw_command (imagedir, "WavyLinesCube.exr")
-command = command + runtest.rw_command (imagedir, "WavyLinesLatLong.exr")
-command = command + runtest.rw_command (imagedir, "WavyLinesSphere.exr")
-# FIXME -- we don't know how to deal with RIP-maps -- Kapaa, 
+imagedir = parent + "/openexr-images-1.5.0/MultiResolution"
+files = [ "Bonita.exr", "ColorCodedLevels.exr",
+          # FIXME -- we don't know how to deal with RIP-maps -- Kapaa, 
+          "KernerEnvCube.exr", "KernerEnvLatLong.exr", "MirrorPattern.exr",
+          "OrientationCube.exr", "OrientationLatLong.exr",
+          "PeriodicPattern.exr", "StageEnvCube.exr", "StageEnvLatLong.exr",
+          "WavyLinesCube.exr", "WavyLinesLatLong.exr", "WavyLinesSphere.exr" ]
 
-
-
-# Outputs to check against references
-outputs = [ "out.txt" ]
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)
+for f in files:
+    command += rw_command (imagedir, f)

--- a/testsuite/openexr-suite/run.py
+++ b/testsuite/openexr-suite/run.py
@@ -1,29 +1,22 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# Start off
-command = ""
-
 # ../openexr-images-1.5.0/DisplayWindow:
 # README   t03.exr  t06.exr  t09.exr  t12.exr  t15.exr
 # t01.exr  t04.exr  t07.exr  t10.exr  t13.exr  t16.exr
 # t02.exr  t05.exr  t08.exr  t11.exr  t14.exr
-imagedir = runtest.parent + "/openexr-images-1.5.0/DisplayWindow"
+imagedir = parent + "/openexr-images-1.5.0/DisplayWindow"
 
 # ../openexr-images-1.5.0/ScanLines:
 # Blobbies.exr   Desk.exr       StillLife.exr
 # Cannon.exr     MtTamWest.exr  Tree.exr
-imagedir = runtest.parent + "/openexr-images-1.5.0/ScanLines"
+imagedir = parent + "/openexr-images-1.5.0/ScanLines"
 files = [ "Desk.exr", "MtTamWest.exr" ]
 for f in files:
-    command = command + runtest.rw_command (imagedir, f)
-command = command + runtest.rw_command (imagedir, "Cannon.exr", extraargs="--compression zip")
+    command += rw_command (imagedir, f)
+command = command + rw_command (imagedir, "Cannon.exr", extraargs="--compression zip")
 files = [ "StillLife.exr", "Tree.exr", "Blobbies.exr" ]
 for f in files:
-    command = command + runtest.rw_command (imagedir, f)
+    command += rw_command (imagedir, f)
 # Cannon must be instructed to use lossless compression
 # FIXME - on all: chromaticies, screenWindowCenter, preview?
 
@@ -32,22 +25,18 @@ for f in files:
 # BrightRings.exr          GrayRampsHorizontal.exr  WideColorGamut.exr
 # BrightRingsNanInf.exr    README                   WideFloatRange.exr
 # GammaChart.exr           RgbRampsDiagonal.exr
-imagedir = runtest.parent + "/openexr-images-1.5.0/TestImages"
+imagedir = parent + "/openexr-images-1.5.0/TestImages"
 files = [ "AllHalfValues.exr", "BrightRings.exr", "BrightRingsNanInf.exr",
           "GammaChart.exr", "GrayRampsDiagonal.exr",
           "GrayRampsHorizontal.exr", "RgbRampsDiagonal.exr",
           "SquaresSwirls.exr", "WideColorGamut.exr", "WideFloatRange.exr" ]
 for f in files:
-    command = command + runtest.rw_command (imagedir, f)
+    command += rw_command (imagedir, f)
 
 # ../openexr-images-1.5.0/Tiles:
 # GoldenGate.exr  Ocean.exr       Spirals.exr
-imagedir = runtest.parent + "/openexr-images-1.5.0/Tiles"
+imagedir = parent + "/openexr-images-1.5.0/Tiles"
 files = [ "GoldenGate.exr", "Ocean.exr" ]
 for f in files:
-    command = command + runtest.rw_command (imagedir, f)
+    command += rw_command (imagedir, f)
 # FIXME - Spirals: per-channel formats, iv >4 chans, chromaticities
-
-
-ret = runtest.runtest (command)
-sys.exit (ret)

--- a/testsuite/psd/run.py
+++ b/testsuite/psd/run.py
@@ -1,17 +1,8 @@
 #!/usr/bin/python
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-imagedir = runtest.parent + "/oiio-images/"
-files = [ "psd_123.psd", "psd_123_nomaxcompat.psd", "psd_bitmap.psd", \
-          "psd_indexed_trans.psd", "psd_rgb_8.psd", "psd_rgb_16.psd", \
+imagedir = parent + "/oiio-images/"
+files = [ "psd_123.psd", "psd_123_nomaxcompat.psd", "psd_bitmap.psd",
+          "psd_indexed_trans.psd", "psd_rgb_8.psd", "psd_rgb_16.psd",
           "psd_rgb_32.psd", "psd_rgba_8.psd" ]
-command = ""
 for f in files:
-    command = command + runtest.info_command (imagedir + f)
-
-# boilerplate
-ret = runtest.runtest (command)
-sys.exit (ret)
+    command += info_command (imagedir + f)

--- a/testsuite/rla/run.py
+++ b/testsuite/rla/run.py
@@ -1,19 +1,10 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-imagedir = runtest.parent + "/oiio-images"
-files = [ "ginsu_a_nc10.rla", "ginsu_a_ncf.rla", "ginsu_rgba_nc8.rla", \
-          "ginsu_rgb_nc16.rla", "imgmake_rgba_nc10.rla", "ginsu_a_nc16.rla", \
-          "ginsu_rgba_nc10.rla", "ginsu_rgba_ncf.rla", "ginsu_rgb_nc8.rla", \
-          "imgmake_rgba_nc16.rla", "ginsu_a_nc8.rla", "ginsu_rgba_nc16.rla", \
+imagedir = parent + "/oiio-images"
+files = [ "ginsu_a_nc10.rla", "ginsu_a_ncf.rla", "ginsu_rgba_nc8.rla",
+          "ginsu_rgb_nc16.rla", "imgmake_rgba_nc10.rla", "ginsu_a_nc16.rla",
+          "ginsu_rgba_nc10.rla", "ginsu_rgba_ncf.rla", "ginsu_rgb_nc8.rla",
+          "imgmake_rgba_nc16.rla", "ginsu_a_nc8.rla", "ginsu_rgba_nc16.rla",
           "ginsu_rgb_nc10.rla", "ginsu_rgb_ncf.rla", "imgmake_rgba_nc8.rla" ]
-command = ""
 for f in files:
-    command = command + runtest.rw_command (imagedir, f)
-
-# boilerplate
-ret = runtest.runtest (command)
-sys.exit (ret)
+    command += rw_command (imagedir, f)

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -29,7 +29,8 @@ tmpdir = os.path.abspath (tmpdir)
 refdir = "ref/"
 parent = "../../../../../"
 
-default_outputs = [ "out.txt" ]
+command = ""
+outputs = [ "out.txt" ]    # default
 
 #print ("srcdir = " + srcdir)
 #print ("tmpdir = " + tmpdir)
@@ -38,6 +39,7 @@ default_outputs = [ "out.txt" ]
 
 
 
+# Handy functions...
 
 def oiio_app (app):
     # when we use Visual Studio, built applications are stored
@@ -103,7 +105,7 @@ def testtex_command (file, extraargs="") :
 # in 'ref/'.  If all outputs match their reference copies, return 0
 # to pass.  If any outputs do not match their references return 1 to
 # fail.
-def runtest (command, outputs=default_outputs, failureok=0) :
+def runtest (command, outputs, failureok=0) :
     parser = OptionParser()
     parser.add_option("-p", "--path", help="add to executable path",
                       action="store", type="string", dest="path", default="")
@@ -175,3 +177,15 @@ def runtest (command, outputs=default_outputs, failureok=0) :
 
 
 
+
+
+#
+# Read the individual run.py file for this test, which will define 
+# command and outputs.
+#
+#sys.path = [srcdir, ".", "testsuite"] + sys.path
+execfile ("run.py")
+
+# Run the test and check the outputs
+ret = runtest (command, outputs)
+sys.exit (ret)

--- a/testsuite/sgi/run.py
+++ b/testsuite/sgi/run.py
@@ -1,14 +1,6 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
 imagedir = "ref/"
 files = [ "norle-8.sgi", "rle-8.sgi", "norle-16.sgi", "rle-16.sgi" ]
-command = ""
 for f in files:
-    command = command + runtest.rw_command (imagedir, f)
-
-ret = runtest.runtest (command)
-sys.exit (ret)
+    command = command + rw_command (imagedir, f)

--- a/testsuite/targa-tgautils/run.py
+++ b/testsuite/targa-tgautils/run.py
@@ -1,18 +1,7 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# Start off
-command = ""
-
-imagedir = runtest.parent + "/TGAUTILS"
+imagedir = parent + "/TGAUTILS"
 files = [ "CBW8.TGA", "CCM8.TGA", "CTC16.TGA", "CTC24.TGA", "CTC32.TGA",
           "UBW8.TGA", "UCM8.TGA", "UTC16.TGA", "UTC24.TGA", "UTC32.TGA" ]
-command = ""
 for f in files:
-    command = command + runtest.rw_command (imagedir, f)
-
-ret = runtest.runtest (command)
-sys.exit (ret)
+    command += rw_command (imagedir, f)

--- a/testsuite/texture-fat/run.py
+++ b/testsuite/texture-fat/run.py
@@ -1,15 +1,4 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# A command to run
-command = runtest.testtex_command ("horizgrid.tx", " --scalest 1 4")
-
-# Outputs to check against references
+command = testtex_command ("horizgrid.tx", " --scalest 1 4")
 outputs = [ "out.exr" ]
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)

--- a/testsuite/texture-field3d/run.py
+++ b/testsuite/texture-field3d/run.py
@@ -1,14 +1,4 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# A command to run
-command = runtest.oiio_app("testtex") + " --nowarp --offset -1 -1 -1 --scalest 2 2 " + os.path.relpath("sparse_half.f3d",runtest.tmpdir)
-
+command = oiio_app("testtex") + " --nowarp --offset -1 -1 -1 --scalest 2 2 sparse_half.f3d"
 outputs = [ "out.exr" ]
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)

--- a/testsuite/texture-fill/run.py
+++ b/testsuite/texture-fill/run.py
@@ -1,15 +1,4 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# A command to run
-command = runtest.testtex_command ("gray.png", "-fill 0.05 --res 128 128 --nowarp")
-
-# Outputs to check against references
+command = testtex_command ("gray.png", "-fill 0.05 --res 128 128 --nowarp")
 outputs = [ "out.exr" ]
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)

--- a/testsuite/texture-gray/run.py
+++ b/testsuite/texture-gray/run.py
@@ -1,15 +1,4 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# A command to run
-command = runtest.testtex_command ("gray.png", " -fill 0.05 --graytorgb --res 128 128 --nowarp ")
-
-# Outputs to check against references
+command = testtex_command ("gray.png", " -fill 0.05 --graytorgb --res 128 128 --nowarp ")
 outputs = [ "out.exr" ]
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)

--- a/testsuite/texture-grid/run.py
+++ b/testsuite/texture-grid/run.py
@@ -1,15 +1,4 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# A command to run
-command = runtest.testtex_command (runtest.parent + "/oiio-images/grid.tx")
-
-# Outputs to check against references
+command = testtex_command (parent + "/oiio-images/grid.tx")
 outputs = [ "out.exr" ]
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)

--- a/testsuite/texture-missing/run.py
+++ b/testsuite/texture-missing/run.py
@@ -1,15 +1,4 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# A command to run
-command = runtest.testtex_command ("missing.tx", "--missing 1 0 0 --res 8 8 missing.tx")
-
-# Outputs to check against references
+command = testtex_command ("missing.tx", "--missing 1 0 0 --res 8 8 missing.tx")
 outputs = [ "out.exr" ]
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)

--- a/testsuite/texture-overscan/run.py
+++ b/testsuite/texture-overscan/run.py
@@ -1,18 +1,8 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# A command to run
-command = (runtest.oiio_app("maketx") + " --filter lanczos3 "
-           + runtest.parent + "/oiio-images/grid-overscan.exr"
+command = (oiio_app("maketx") + " --filter lanczos3 "
+           + parent + "/oiio-images/grid-overscan.exr"
            + " -o grid-overscan.exr ;\n")
-command = command + runtest.testtex_command ("grid-overscan.exr", "--wrap black")
+command = command + testtex_command ("grid-overscan.exr", "--wrap black")
 
-# Outputs to check against references
 outputs = [ "out.exr" ]
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)

--- a/testsuite/texture-pointsample/run.py
+++ b/testsuite/texture-pointsample/run.py
@@ -1,15 +1,4 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# A command to run
-command = runtest.testtex_command (runtest.parent + "/oiio-images/grid.tx", " -width 0")
-
-# Outputs to check against references
+command = testtex_command (parent + "/oiio-images/grid.tx", " -width 0")
 outputs = [ "out.exr" ]
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)

--- a/testsuite/texture-res/run.py
+++ b/testsuite/texture-res/run.py
@@ -1,20 +1,8 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# A command to run
-command = (runtest.oiio_app ("testtex") + " -res 256 256 --nowarp "
-           + runtest.parent + "/oiio-images/miplevels.tx"
+command = (oiio_app("testtex") + " -res 256 256 --nowarp "
+           + parent + "/oiio-images/miplevels.tx"
            + " -o out.tif ;\n")
-command = command + runtest.diff_command ("out.tif", "ref/out.tif",
-                                          "--fail 0.0005 --warn 0.0005")
+command += diff_command ("out.tif", "ref/out.tif", "--fail 0.0005 --warn 0.0005")
 
-# Outputs to check against references
 outputs = [ ]
-
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)

--- a/testsuite/texture-skinny/run.py
+++ b/testsuite/texture-skinny/run.py
@@ -1,15 +1,4 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-# A command to run
-command = runtest.testtex_command ("vertgrid.tx", " --scalest 4 1 ")
-
-# Outputs to check against references
+command = testtex_command ("vertgrid.tx", " --scalest 4 1 ")
 outputs = [ "out.exr" ]
-
-# boilerplate
-ret = runtest.runtest (command, outputs)
-sys.exit (ret)

--- a/testsuite/tiff-depths/run.py
+++ b/testsuite/tiff-depths/run.py
@@ -1,79 +1,48 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-
 # FIXME -- eventually, we want more (all?) of these to work
 
-imagedir = runtest.parent + "/libtiffpic/depth"
-command = ""
-# flower-minisblack-02.tif        73x43 2-bit minisblack gray image
-command = command + runtest.rw_command (imagedir, "flower-minisblack-02.tif")
-# flower-minisblack-04.tif        73x43 4-bit minisblack gray image
-command = command + runtest.rw_command (imagedir, "flower-minisblack-04.tif")
-# flower-minisblack-06.tif        73x43 6-bit minisblack gray image
-command = command + runtest.rw_command (imagedir, "flower-minisblack-06.tif")
-# flower-minisblack-08.tif        73x43 8-bit minisblack gray image
-command = command + runtest.rw_command (imagedir, "flower-minisblack-08.tif")
-# flower-minisblack-10.tif        73x43 10-bit minisblack gray image
-command = command + runtest.rw_command (imagedir, "flower-minisblack-10.tif")
-# flower-minisblack-12.tif        73x43 12-bit minisblack gray image
-command = command + runtest.rw_command (imagedir, "flower-minisblack-12.tif")
-# flower-minisblack-14.tif        73x43 14-bit minisblack gray image
-command = command + runtest.rw_command (imagedir, "flower-minisblack-14.tif")
-# flower-minisblack-16.tif        73x43 16-bit minisblack gray image
-command = command + runtest.rw_command (imagedir, "flower-minisblack-16.tif")
-# flower-minisblack-24.tif        73x43 24-bit minisblack gray image
-# flower-minisblack-32.tif        73x43 32-bit minisblack gray image
-#  FIXME - I'd like this one to work
-# flower-palette-02.tif   73x43 4-entry colormapped image
-command = command + runtest.rw_command (imagedir, "flower-palette-02.tif")
-# flower-palette-04.tif   73x43 16-entry colormapped image
-command = command + runtest.rw_command (imagedir, "flower-palette-04.tif")
-# flower-palette-08.tif   73x43 256-entry colormapped image
-command = command + runtest.rw_command (imagedir, "flower-palette-08.tif")
-# flower-palette-16.tif   73x43 65536-entry colormapped image
-#   FIXME - broken
-# flower-rgb-contig-02.tif        73x43 2-bit contiguous RGB image
-command = command + runtest.rw_command (imagedir, "flower-rgb-contig-02.tif")
-# flower-rgb-contig-04.tif        73x43 4-bit contiguous RGB image
-command = command + runtest.rw_command (imagedir, "flower-rgb-contig-04.tif")
-# flower-rgb-contig-08.tif        73x43 8-bit contiguous RGB image
-command = command + runtest.rw_command (imagedir, "flower-rgb-contig-08.tif")
-# flower-rgb-contig-10.tif        73x43 10-bit contiguous RGB image
-command = command + runtest.rw_command (imagedir, "flower-rgb-contig-10.tif")
-# flower-rgb-contig-12.tif        73x43 12-bit contiguous RGB image
-command = command + runtest.rw_command (imagedir, "flower-rgb-contig-12.tif")
-# flower-rgb-contig-14.tif        73x43 14-bit contiguous RGB image
-command = command + runtest.rw_command (imagedir, "flower-rgb-contig-14.tif")
-# flower-rgb-contig-16.tif        73x43 16-bit contiguous RGB image
-command = command + runtest.rw_command (imagedir, "flower-rgb-contig-16.tif")
-# flower-rgb-contig-24.tif        73x43 24-bit contiguous RGB image
-# flower-rgb-contig-32.tif        73x43 32-bit contiguous RGB image
-# flower-rgb-planar-02.tif        73x43 2-bit seperated RGB image
-command = command + runtest.rw_command (imagedir, "flower-rgb-planar-02.tif")
-# flower-rgb-planar-04.tif        73x43 4-bit seperated RGB image
-command = command + runtest.rw_command (imagedir, "flower-rgb-planar-04.tif")
-# flower-rgb-planar-08.tif        73x43 8-bit seperated RGB image
-command = command + runtest.rw_command (imagedir, "flower-rgb-planar-08.tif")
-# flower-rgb-planar-10.tif        73x43 10-bit seperated RGB image
-command = command + runtest.rw_command (imagedir, "flower-rgb-planar-10.tif")
-# flower-rgb-planar-12.tif        73x43 12-bit seperated RGB image
-command = command + runtest.rw_command (imagedir, "flower-rgb-planar-12.tif")
-# flower-rgb-planar-14.tif        73x43 14-bit seperated RGB image
-command = command + runtest.rw_command (imagedir, "flower-rgb-planar-14.tif")
-# flower-rgb-planar-16.tif        73x43 16-bit seperated RGB image
-command = command + runtest.rw_command (imagedir, "flower-rgb-planar-16.tif")
-# flower-rgb-planar-24.tif        73x43 24-bit seperated RGB image
-# flower-rgb-planar-32.tif        73x43 32-bit seperated RGB image
-# flower-separated-contig-08.tif  73x43 8-bit contiguous CMYK image
-# flower-separated-contig-16.tif  73x43 16-bit contiguous CMYK image
-# flower-separated-planar-08.tif  73x43 8-bit separated CMYK image
-# flower-separated-planar-16.tif  73x43 16-bit separated CMYK image
+imagedir = parent + "/libtiffpic/depth"
+files = [
+    "flower-minisblack-02.tif",   #  73x43 2-bit minisblack gray image
+    "flower-minisblack-04.tif",   #  73x43 4-bit minisblack gray image
+    "flower-minisblack-06.tif",   #  73x43 6-bit minisblack gray image
+    "flower-minisblack-08.tif",   #  73x43 8-bit minisblack gray image
+    "flower-minisblack-10.tif",   #  73x43 10-bit minisblack gray image
+    "flower-minisblack-12.tif",   #  73x43 12-bit minisblack gray image
+    "flower-minisblack-14.tif",   #  73x43 14-bit minisblack gray image
+    "flower-minisblack-16.tif",   # 73x43 16-bit minisblack gray image
+    #FIXME "flower-minisblack-24.tif",   #  73x43 24-bit minisblack gray image
+    #FIXME "flower-minisblack-32.tif",   #  73x43 32-bit minisblack gray image
+    "flower-palette-02.tif",   #73x43 4-entry colormapped image
+    "flower-palette-04.tif",   #73x43 16-entry colormapped image
+    "flower-palette-08.tif",   #73x43 256-entry colormapped image
+    #FIXME "flower-palette-16.tif",   # 73x43 65536-entry colormapped image
+    "flower-rgb-contig-02.tif",   #  73x43 2-bit contiguous RGB image
+    "flower-rgb-contig-04.tif",   #  73x43 4-bit contiguous RGB image
+    "flower-rgb-contig-08.tif",   #  73x43 8-bit contiguous RGB image
+    "flower-rgb-contig-10.tif",   #  73x43 10-bit contiguous RGB image
+    "flower-rgb-contig-12.tif",   #  73x43 12-bit contiguous RGB image
+    "flower-rgb-contig-14.tif",   #  73x43 14-bit contiguous RGB image
+    "flower-rgb-contig-16.tif",   #  73x43 16-bit contiguous RGB image
+    #FIXME "flower-rgb-contig-24.tif",   #  73x43 24-bit contiguous RGB image
+    #FIXME "flower-rgb-contig-32.tif",   #  73x43 32-bit contiguous RGB image
+    "flower-rgb-planar-02.tif",   #  73x43 2-bit seperated RGB image
+    "flower-rgb-planar-04.tif",   #  73x43 4-bit seperated RGB image
+    "flower-rgb-planar-08.tif",   #  73x43 8-bit seperated RGB image
+    "flower-rgb-planar-10.tif",   #  73x43 10-bit seperated RGB image
+    "flower-rgb-planar-12.tif",   #  73x43 12-bit seperated RGB image
+    "flower-rgb-planar-14.tif",   #  73x43 14-bit seperated RGB image
+    "flower-rgb-planar-16.tif"    #  73x43 16-bit seperated RGB image
+    #FIXME "flower-rgb-planar-24.tif",   #  73x43 24-bit seperated RGB image
+    #FIXME "flower-rgb-planar-32.tif",   #  73x43 32-bit seperated RGB image
+    #FIXME "flower-separated-contig-08.tif",  # 73x43 8-bit contiguous CMYK image
+    #FIXME "flower-separated-contig-16.tif",  # 73x43 16-bit contiguous CMYK image
+    #FIXME "flower-separated-planar-08.tif",  # 73x43 8-bit separated CMYK image
+    #FIXME "flower-separated-planar-16.tif",  # 73x43 16-bit separated CMYK image
+    ]
+
+for f in files:
+    command += rw_command (imagedir, f)
 
 print ("COMMAND= " + command)
-
-ret = runtest.runtest (command)
-sys.exit (ret)

--- a/testsuite/tiff-suite/run.py
+++ b/testsuite/tiff-suite/run.py
@@ -1,12 +1,6 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-command = ""
-
-imagedir = runtest.parent + "/libtiffpic"
+imagedir = parent + "/libtiffpic"
 
 # caspian.tif	279x220 64-bit floating point (deflate) Caspian Sea from space
 #   I can't get this to work with OIIO, but I can't get it to read with 
@@ -17,9 +11,9 @@ imagedir = runtest.parent + "/libtiffpic"
 #    This tests 1-bit images, and packbits compression
 # cramps-tile.tif	256x256 tiled version of cramps.tif (no compression)
 #    Tests tiled images (especially tiled 1-bit) -- compare it to cramps
-command = command + runtest.rw_command (imagedir, "cramps.tif")
-command = command + runtest.rw_command (imagedir, "cramps-tile.tif")
-command = command + runtest.diff_command (imagedir+"/cramps-tile.tif",
+command += rw_command (imagedir, "cramps.tif")
+command += rw_command (imagedir, "cramps-tile.tif")
+command += diff_command (imagedir+"/cramps-tile.tif",
                                           imagedir+"/cramps.tif")
 
 # dscf0013.tif	640x480 YCbCr digital camera image which lacks Reference
@@ -30,14 +24,14 @@ command = command + runtest.diff_command (imagedir+"/cramps-tile.tif",
 # FIXME - we read the pixel data fine, but we fail to recognize that
 #   differing XResolution and YResolution imply a non-square pixel
 #   aspect ratio, and iv fails to display it well for this reason.
-command = command + runtest.rw_command (imagedir, "fax2d.tif")
+command += rw_command (imagedir, "fax2d.tif")
 
 # g3test.tif	TIFF equivalent of g3test.g3 created by fax2tiff
-command = command + runtest.rw_command (imagedir, "g3test.tif")
+command += rw_command (imagedir, "g3test.tif")
 # FIXME - same aspect ratio issue as fax2d.tif
 
 # jello.tif	256x192 8-bit RGB (packbits palette) Paul Heckbert "jello"
-command = command + runtest.rw_command (imagedir, "jello.tif")
+command += rw_command (imagedir, "jello.tif")
 
 # ladoga.tif	158x118 16-bit unsigned, single band, deflate
 # NOTE -- I have no idea if we read this correctly.  Neither ImageMagick
@@ -52,7 +46,7 @@ command = command + runtest.rw_command (imagedir, "jello.tif")
 # 		No compression.
 # FIXME? - we don't seem to recognize additional Exif data that's in the
 #    'Maker Note', which includes GainControl
-command = command + runtest.rw_command (imagedir, "pc260001.tif")
+command += rw_command (imagedir, "pc260001.tif")
 
 # quad-jpeg.tif	512x384 8-bit YCbCr (jpeg) version of quad-lzw.tif
 #  FIXME -- we don't handle this (YCbCr? jpeg?)
@@ -60,13 +54,13 @@ command = command + runtest.rw_command (imagedir, "pc260001.tif")
 
 # quad-lzw.tif	512x384 8-bit RGB (lzw) "quadric surfaces"
 # quad-tile.tif	512x384 tiled version of quad-lzw.tif (lzw)
-command = command + runtest.rw_command (imagedir, "quad-lzw.tif")
-command = command + runtest.rw_command (imagedir, "quad-tile.tif")
-command = command + runtest.diff_command (imagedir+"/quad-tile.tif",
+command += rw_command (imagedir, "quad-lzw.tif")
+command += rw_command (imagedir, "quad-tile.tif")
+command += diff_command (imagedir+"/quad-tile.tif",
                                           imagedir+"/quad-lzw.tif")
 
 # strike.tif	256x200 8-bit RGBA (lzw) "bowling pins" from Pixar
-command = command + runtest.rw_command (imagedir, "strike.tif")
+command += rw_command (imagedir, "strike.tif")
 
 # text.tif	1512x359 4-bit b&w (thunderscan) am-express credit card
 #  FIXME -- we don't get this right
@@ -79,7 +73,7 @@ command = command + runtest.rw_command (imagedir, "strike.tif")
 #   considered a deprecated format, not supported by libtiff
 
 # oxford.tif	601x81 8-bit RGB (lzw) screendump off oxford
-command = command + runtest.rw_command (imagedir, "oxford.tif", 0)
+command += rw_command (imagedir, "oxford.tif", 0)
 
 # The other images are from Hewlett Packard and exemplify the use of the
 # HalftoneHints tag (in their words):
@@ -94,9 +88,3 @@ command = command + runtest.rw_command (imagedir, "oxford.tif", 0)
 #
 # NOTE -- OIIO appears to read this fine, but I'm really not sure how to
 #    judge if it's "correct"
-
-
-
-# boilerplate
-ret = runtest.runtest (command)
-sys.exit (ret)

--- a/testsuite/webp/run.py
+++ b/testsuite/webp/run.py
@@ -1,15 +1,6 @@
 #!/usr/bin/python 
 
-import sys
-sys.path = ["..", "testsuite"] + sys.path
-import runtest
-
-
-imagedir = runtest.parent + "/webp-images/"
+imagedir = parent + "/webp-images/"
 files = [ "1.webp", "2.webp", "3.webp", "4.webp" ]
-command = ""
 for f in files:
-    command = command + runtest.info_command (imagedir + f)
-
-ret = runtest.runtest (command)
-sys.exit (ret)
+    command = command + info_command (imagedir + f)


### PR DESCRIPTION
testsuite refactor: make tests directly run runtest.py, now the individual run.py are called from there and can now be extremely minimal.

Thanks for the suggestion, Chris Kulla.  I think it's a huge improvement.
