### PR TITLE
Review: More testsuite improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ $(info INSTALLDIR = ${INSTALLDIR})
 VERBOSE := ${SHOWCOMMANDS}
 ifneq (${VERBOSE},)
 MY_MAKE_FLAGS += VERBOSE=${VERBOSE}
+TEST_FLAGS += -V
 endif
 
 ifneq (${EMBEDPLUGINS},)
@@ -129,6 +130,10 @@ ifneq (${MYCXX},)
 MY_CMAKE_FLAGS += -DCMAKE_CXX_COMPILER:STRING=${MYCXX}
 endif
 
+ifneq (${TEST},)
+TEST_FLAGS += -R ${TEST}
+endif
+
 #$(info MY_CMAKE_FLAGS = ${MY_CMAKE_FLAGS})
 #$(info MY_MAKE_FLAGS = ${MY_MAKE_FLAGS})
 
@@ -177,7 +182,14 @@ dist : cmakeinstall
 
 # 'make test' does a full build and then runs all tests
 test: cmake
-	( cd ${build_dir} ; ${MAKE} ${MY_MAKE_FLAGS} test )
+	cmake -E cmake_echo_color --switch=$(COLOR) --cyan "Running tests ${TEST_FLAGS}..."
+	( cd ${build_dir} ; ctest --force-new-ctest-process ${TEST_FLAGS} -E broken )
+
+# 'make testall' does a full build and then runs all tests (even the ones
+# that are expected to fail on some platforms)
+testall: cmake
+	cmake -E cmake_echo_color --switch=$(COLOR) --cyan "Running all tests ${TEST_FLAGS}..."
+	( cd ${build_dir} ; ctest --force-new-ctest-process ${TEST_FLAGS} )
 
 # 'make package' builds everything and then makes an installable package 
 # (platform dependent -- may be .tar.gz, .sh, .dmg, .rpm, .deb. .exe)
@@ -206,14 +218,6 @@ nuke:
 doxygen:
 	doxygen src/doc/Doxyfile
 
-#testclean : ${all_tests}
-#	@ for f in ${all_tests} ; do \
-#	    ( cd $$f ; \
-#	      echo "Cleaning test $$f " ; \
-#	      ./run.py -c ; \
-#	    ) \
-#	done
-
 #########################################################################
 
 
@@ -230,7 +234,8 @@ help:
 	@echo "  make clean        Remove the temporary files in ${build_dir}"
 	@echo "  make realclean    Remove both ${build_dir} AND ${dist_dir}"
 	@echo "  make nuke         Remove ALL of build and dist (not just ${platform})"
-	@echo "  make test         Run all tests"
+	@echo "  make test         Run tests"
+	@echo "  make testall      Run all tests, even broken ones"
 	@echo "  make doxygen      Build the Doxygen docs in ${top_build_dir}/doxygen"
 	@echo ""
 	@echo "Helpful modifiers:"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -229,6 +229,22 @@ add_subdirectory (doc)
 
 #########################################################################
 # Testing
+# 
+# Just call oiio_add_tests(testname...) for each test.  Additional
+# optional arguments include:
+#     FOUNDVAR   specifies the name of a CMAKE variable; if not defined,
+#                    the test will not be added for 'make test' (helpful
+#                    for excluding tests for libraries not found).
+#     IMAGEDIR   specifies a directory for test images, one level higher
+#                    than where the oiio top level source lives -- a 
+#                    message will be printed if not found.
+#     URL        URL where the test images can be found, will be 
+#                    incorporated into the error message if the test
+#                    image directory is not found.
+#     LABEL      If set to "broken", will designate the test as one
+#                    that is known to be broken, so will only be run
+#                    for "make testall", but not "make test".
+#
 
 # Make a copy of the testsuite into the build area
 if (DEFINED CMAKE_VERSION AND NOT CMAKE_VERSION VERSION_LESS 2.8)
@@ -262,6 +278,7 @@ oiio_add_tests (openexr-suite openexr-multires openexr-chroma
     URL http://www.openexr.com/downloads.html)
 
 oiio_add_tests (jpeg2000
+    FOUNDVAR OPENJPEG_FOUND
     IMAGEDIR j2kp4files_v1_5
     URL http://www.itu.int/net/ITU-T/sigdb/speimage/ImageForm-s.aspx?val=10100803)
 
@@ -274,6 +291,7 @@ oiio_add_tests (fits
     URL http://www.cv.nrao.edu/fits/data/tests/)
 
 oiio_add_tests (webp
+    FOUNDVAR WEBP_FOUND
     IMAGEDIR webp-images
     URL http://code.google.com/speed/webp/gallery.html)
 

--- a/src/cmake/oiio_macros.cmake
+++ b/src/cmake/oiio_macros.cmake
@@ -77,8 +77,13 @@ endmacro ()
 # the user where to find such tests.
 #
 macro (oiio_add_tests)
-    parse_arguments (_ats "URL;IMAGEDIR" "" ${ARGN})
+    parse_arguments (_ats "URL;IMAGEDIR;LABEL;FOUNDVAR" "" ${ARGN})
     set (_ats_testdir "${PROJECT_SOURCE_DIR}/../../${_ats_IMAGEDIR}")
+    # If there was a FOUNDVAR param specified and that variable name is
+    # not defined, mark the test as broken.
+    if (_ats_FOUNDVAR AND NOT ${_ats_FOUNDVAR})
+        set (_ats_LABEL "broken")
+    endif ()
     if (_ats_IMAGEDIR AND NOT EXISTS ${_ats_testdir})
         # If the directory containig reference data (images) for the test
         # isn't found, point the user at the URL.
@@ -92,6 +97,9 @@ macro (oiio_add_tests)
         endif ()
         foreach (_testname ${_ats_DEFAULT_ARGS})
             set (_testdir "${CMAKE_BINARY_DIR}/testsuite/${_testname}")
+            if (_ats_LABEL MATCHES "broken")
+                set (_testname "${_testname}-broken")
+            endif ()
             if (_has_generator_expr)
                 set (_add_test_args NAME ${_testname} 
 #                                    WORKING_DIRECTORY ${_testdir}

--- a/testsuite/ico/run.py
+++ b/testsuite/ico/run.py
@@ -2,4 +2,3 @@
 
 imagedir = parent + "/oiio-images"
 command = rw_command (imagedir, "oiio.ico")
-outputs = [ "out.txt" ]

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -109,8 +109,6 @@ def runtest (command, outputs, failureok=0) :
     parser = OptionParser()
     parser.add_option("-p", "--path", help="add to executable path",
                       action="store", type="string", dest="path", default="")
-    parser.add_option("-c", "--clean", help="clean up",
-                      action="store_true", dest="clean", default=False)
     parser.add_option("--devenv-config", help="use a MS Visual Studio configuration",
                       action="store", type="string", dest="devenv_config", default="")
     parser.add_option("--solution-path", help="MS Visual Studio solution path",
@@ -183,7 +181,6 @@ def runtest (command, outputs, failureok=0) :
 # Read the individual run.py file for this test, which will define 
 # command and outputs.
 #
-#sys.path = [srcdir, ".", "testsuite"] + sys.path
 execfile ("run.py")
 
 # Run the test and check the outputs


### PR DESCRIPTION
Review: More testsuite improvements: (1) allow individual tests to run with
"make test TEST=foo".  Also works for regular expressions! (2) mark
tests that require optional libraries which aren't found as "broken",
also able to designate particular known failures as broken, and have
separate "make test" that skips broken tests and "make testall", which
runs all tests.
