### PR TITLE
Fix ill-formed default output name for maketx

### DIFF
--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -675,13 +675,8 @@ make_texturemap (const char *maptypename = "texture map")
         std::cerr << "maketx ERROR: \"" << filenames[0] << "\" does not exist\n";
         exit (EXIT_FAILURE);
     }
-    if (outputfilename.empty()) {
-        const std::string ext = Filesystem::file_extension (filenames[0]);
-        int notextlen = (int) filenames[0].length() - (int) ext.length();
-        outputfilename = std::string (filenames[0].begin(),
-                                      filenames[0].begin() + notextlen);
-        outputfilename += ".tx";
-    }
+    if (outputfilename.empty()) 
+		outputfilename = boost::filesystem::change_extension (filenames[0], ".tx").string ();
 
     // When was the input file last modified?
     std::time_t in_time = boost::filesystem::last_write_time (filenames[0]);


### PR DESCRIPTION
Filesystem::file_extension() does not return the '.' in the extension string whereas boost::file_system::extension() does. This little difference went unnoticed in a previous commit. The result is that "maketx foo.tif" buiilds a "foo..tx" file. The proposed change greatly simplifies the code and does the right thing.
