### PR TITLE
if texture derivatives are colinear, then orthogonalize them

### DIFF
--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -813,6 +813,11 @@ adjust_width_blur (float &dsdx, float &dtdx, float &dsdy, float &dtdy,
     if (fabsf(dtdy) < eps)
         dtdy = copysignf (eps, dtdy);
 
+    // If the derivatives are colinear then force them to be orthogonal
+    if (dsdx * dtdy - dsdy * dtdx == 0.0f) {
+       dtdy = -dtdy;
+    }
+
     if (sblur+tblur != 0.0f /* avoid the work when blur is zero */) {
         // Carefully add blur to the right derivative components in the
         // right proportions -- meerely adding the same amount of blur


### PR DESCRIPTION
If we perform a texture lookup where dsdx,dsdy..dtdy=0, then the options.sblur parameter won't get applied.  

This is because adjust_width_blur will produce colinear derivative components (dsdx=dtdx=dsdy=dtdy) which then produces numerical problems with the ellipse axes and effectively results in point-lookups.

This fix just "orthogonalizes" the texture derivatives and the blur seems to get applied correctly.
