### PR TITLE
Review: OpenCV interoperability

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ set (USE_PYTHON ON CACHE BOOL "Build the Python bindings")
 set (USE_FIELD3D ON CACHE BOOL "Use Field3D if found")
 set (USE_OPENJPEG ON CACHE BOOL "Use OpenJpeg if found")
 set (USE_OCIO ON CACHE BOOL "Use OpenColorIO for color management if found")
+set (USE_OPENCV ON CACHE BOOL "Use OpenCV if found")
 set (NOTHREADS OFF CACHE BOOL "Compile with no threads or locking")
 set (PYTHON_VERSION 2.6)
 set (USE_EXTERNAL_PUGIXML OFF CACHE BOOL

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -338,4 +338,47 @@ if (USE_EXTERNAL_PUGIXML)
     include_directories (BEFORE ${PUGIXML_INCLUDE_DIR})
 endif()
 
+
+###########################################################################
+# OpenCV setup
+
+if (USE_OPENCV)
+    find_path (OpenCV_INCLUDE_DIR opencv/cv.h
+               ${THIRD_PARTY_TOOLS}/include
+               ${PROJECT_SOURCE_DIR}/include  
+               ${OpenCV_HOME}/include
+               /usr/local/include
+               /opt/local/include
+               )
+    find_library (OpenCV_LIBS
+                  NAMES opencv_core
+                  PATHS ${THIRD_PARTY_TOOLS_HOME}/lib/
+                        ${PROJECT_SOURCE_DIR}/lib
+                        ${OpenCV_HOME}/lib
+                        /usr/local/lib
+                        /opt/local/lib
+                 )
+    find_library (OpenCV_LIBS_highgui
+                  NAMES opencv_highgui
+                  PATHS ${THIRD_PARTY_TOOLS_HOME}/lib/
+                        ${PROJECT_SOURCE_DIR}/lib
+                        ${OpenCV_HOME}/lib
+                        /usr/local/lib
+                        /opt/local/lib
+                 )
+    set (OpenCV_LIBS "${OpenCV_LIBS} ${OpenCV_LIBS_highgui}")
+    if (OpenCV_INCLUDE_DIR AND OpenCV_LIBS)
+        set (OpenCV_FOUND TRUE)
+        add_definitions ("-DUSE_OPENCV")
+        message (STATUS "OpenCV includes = ${OpenCV_INCLUDE_DIR} ")
+        message (STATUS "OpenCV libs = ${OpenCV_LIBS} ")
+    else ()
+        set (OpenCV_FOUND FALSE)
+        message (STATUS "OpenCV library not found")
+    endif ()
+else ()
+    message (STATUS "Not using OpenCV")
+endif ()
+
+# end OpenCV setup
 ###########################################################################

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -31,6 +31,23 @@ the alteration), or in some cases will pull more than one image off the
 stack (such as the current image and the next item on the stack) and
 then push a new image.
 
+Some commands stand completely on their own (like {\cf --flip}), others
+take one or more arguments (like {\cf --resize} or {\cf -o}):
+
+\smallskip
+\hspace{0.25in} {\cf oiiotool foo.jpg --flip --resize 640x480 -o out.tif}
+\smallskip
+
+A few commands take optional modifiers for options that are so
+rarely-used or confusing that they should not be required arguments.
+In these cases, they are appended to the command name, after a colon
+(``{\cf :}''), and with a \emph{name}{\cf =}\emph{value} format.  As
+an example:
+
+\smallskip
+\hspace{0.25in} {\cf oiiotool --capture:camera=1 -o out.tif}
+\smallskip
+
 
 
 
@@ -532,6 +549,25 @@ If the offset is omitted, it will be $x=0,y=0$.
 \end{tabular}
 \apiend
 
+\apiitem{--capture}
+
+Capture a frame from a camera device, pushing it onto the image stack
+and making it the new current image.  Optional appended arguments
+include:
+
+\begin{tabular}{p{10pt} p{1in} p{3.5in}}
+  & {\cf camera=}\emph{num} & Select which camera number to capture
+  (default: 0).
+\end{tabular}
+
+\noindent Examples:
+
+\begin{tabular}{p{2in} p{4in}}
+    {\cf --capture}  &      Capture from the default camera. \\
+    {\cf --capture:camera=1}  & Capture from camera 2. \\
+\end{tabular}
+\apiend
+
 \apiitem{--unmip}
 If the current image is MIP-mapped, discard all but the top level
 (i.e., replacing the current image with a new image consisting of only the
@@ -610,6 +646,14 @@ Replace the current image with a new image that is resized to the
 given pixel data resolution.  The size is in the form 
 \\ \spc\spc \emph{width}\,{\cf x}\,\emph{height}
 \\ or~~~~ \spc \emph{scale}{\verb|%|} \\
+
+Optional appended arguments include:
+
+\begin{tabular}{p{10pt} p{1in} p{3.75in}}
+ & {\cf filter=}\emph{name} & Filter name. The default is {\cf
+  blackman-harris} when increasing resolution, {\cf lanczos3} when
+decreasing resolution. \\
+\end{tabular}
 
 \noindent Examples: 
 

--- a/src/include/imagebuf.h
+++ b/src/include/imagebuf.h
@@ -360,6 +360,27 @@ public:
     bool localpixels () const { return m_localpixels; }
     ImageCache *imagecache () const { return m_imagecache; }
 
+    /// Return the address where pixel (x,y) is stored in the image buffer.
+    /// Use with extreme caution!  Will return NULL if the pixel values
+    /// aren't local.
+    const void *pixeladdr (int x, int y) const { return pixeladdr (x, y, 0); }
+
+    /// Return the address where pixel (x,y,z) is stored in the image buffer.
+    /// Use with extreme caution!  Will return NULL if the pixel values
+    /// aren't local.
+    const void *pixeladdr (int x, int y, int z) const;
+
+    /// Return the address where pixel (x,y) is stored in the image buffer.
+    /// Use with extreme caution!  Will return NULL if the pixel values
+    /// aren't local.
+    void *pixeladdr (int x, int y) { return pixeladdr (x, y, 0); }
+
+    /// Return the address where pixel (x,y,z) is stored in the image buffer.
+    /// Use with extreme caution!  Will return NULL if the pixel values
+    /// aren't local.
+    void *pixeladdr (int x, int y, int z);
+
+
     /// Templated class for referring to an individual pixel in an
     /// ImageBuf, iterating over the pixels of an ImageBuf, or iterating
     /// over the pixels of a specified region of the ImageBuf
@@ -922,22 +943,6 @@ protected:
     TypeDesc m_cachedpixeltype;  ///< Data type stored in the cache
 
     void realloc ();
-
-    // Return the address where pixel (x,y) is stored in the image buffer.
-    // Use with extreme caution!
-    const void *pixeladdr (int x, int y) const { return pixeladdr (x, y, 0); }
-
-    // Return the address where pixel (x,y,z) is stored in the image buffer.
-    // Use with extreme caution!
-    const void *pixeladdr (int x, int y, int z) const;
-
-    // Return the address where pixel (x,y) is stored in the image buffer.
-    // Use with extreme caution!
-    void *pixeladdr (int x, int y) { return pixeladdr (x, y, 0); }
-
-    // Return the address where pixel (x,y,z) is stored in the image buffer.
-    // Use with extreme caution!
-    void *pixeladdr (int x, int y, int z);
 
     // Reset the ImageCache::Tile * to reserve and point to the correct
     // tile for the given pixel, and return the ptr to the actual pixel

--- a/src/include/imagebufalgo.h
+++ b/src/include/imagebufalgo.h
@@ -43,6 +43,13 @@
 #include "fmath.h"
 #include "color.h"
 
+
+#ifndef __OPENCV_CORE_TYPES_H__
+struct IplImage;  // Forward declaration; used by Intel Image lib & OpenCV
+#endif
+
+
+
 OIIO_NAMESPACE_ENTER
 {
 
@@ -270,6 +277,32 @@ enum DLLPUBLIC NonFiniteFixMode
 bool DLLPUBLIC fixNonFinite(ImageBuf &dst, const ImageBuf &src,
                             NonFiniteFixMode mode=NONFINITE_BOX3,
                             int * pixelsFixed=NULL);
+
+
+/// Convert an IplImage, used by OpenCV and Intel's Image Libray, and
+/// set ImageBuf dst to be the same image (copying the pixels).  If
+/// convert is not set to UNKNOWN, try to establish dst as holding that
+/// data type and convert the IplImage data.  Return true if ok, false
+/// if it couldn't figure out how to make the conversion from IplImage
+/// to ImageBuf.  If OpenImageIO was compiled without OpenCV support,
+/// this function will return false without modifying dst.
+bool DLLPUBLIC from_IplImage (ImageBuf &dst, const IplImage *ipl,
+                              TypeDesc convert=TypeDesc::UNKNOWN);
+
+/// Construct an IplImage*, used by OpenCV and Intel's Image Library,
+/// that is equivalent to the ImageBuf src.  If it is not possible, or
+/// if OpenImageIO was compiled without OpenCV support, then return
+/// NULL.  The ownership of the IplImage is fully transferred to the
+/// calling application.
+IplImage* DLLPUBLIC to_IplImage (const ImageBuf &src);
+
+/// Capture a still image from a designated camera.  If able to do so,
+/// store the image in dst and return true.  If there is no such device,
+/// or support for camera capture is not available (such as if OpenCV
+/// support was not enabled at compile time), return false and do not
+/// alter dst.
+bool DLLPUBLIC capture_image (ImageBuf &dst, int cameranum = 0,
+                              TypeDesc convert=TypeDesc::UNKNOWN);
 
 
 };  // end namespace ImageBufAlgo

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -31,11 +31,11 @@ if (NOT USE_EXTERNAL_PUGIXML)
 endif()
 
 set (libOpenImageIO_srcs exif.cpp formatspec.cpp imagebuf.cpp
-                         imagebufalgo.cpp imagebufalgo_orient.cpp
-                         imagebufalgo_yee.cpp
                           imageinput.cpp imageio.cpp imageioplugin.cpp
                           imageoutput.cpp iptc.cpp xmp.cpp
                           color_ocio.cpp
+                          imagebufalgo.cpp imagebufalgo_orient.cpp
+                          imagebufalgo_yee.cpp imagebufalgo_opencv.cpp
                           ../libutil/argparse.cpp
                           ../libutil/errorhandler.cpp 
                           ../libutil/filesystem.cpp 
@@ -207,6 +207,12 @@ if (USE_OCIO AND OCIO_FOUND)
     target_link_libraries (OpenImageIO ${OCIO_LIBRARIES})
 endif ()
 
+
+# Include OpenCV if using it
+if (OpenCV_FOUND)
+    include_directories (${OpenCV_INCLUDE_DIR})
+    target_link_libraries (OpenImageIO opencv_core opencv_highgui)
+endif ()
 
 
 

--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -1,0 +1,203 @@
+/*
+  Copyright 2011 Larry Gritz and the other authors and contributors.
+  All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the software's owners nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  (This is the Modified BSD License)
+*/
+
+
+/// \file
+/// Implementation of ImageBufAlgo algorithms related to OpenCV.
+/// These are nonfunctional if OpenCV is not found at build time.
+
+#ifdef USE_OPENCV
+#include <opencv2/core/core_c.h>
+#include <opencv2/highgui/highgui_c.h>
+#endif
+
+#include <iostream>
+#include <map>
+
+#include "imagebuf.h"
+#include "imagebufalgo.h"
+#include "dassert.h"
+#include "thread.h"
+
+
+
+OIIO_NAMESPACE_ENTER
+{
+
+
+
+bool
+ImageBufAlgo::from_IplImage (ImageBuf &dst, const IplImage *ipl,
+                             TypeDesc convert)
+{
+    if (! ipl) {
+        DASSERT (0 && "ImageBufAlgo::fromIplImage called with NULL ipl");
+        return false;
+    }
+#ifdef USE_OPENCV
+    TypeDesc srcformat;
+    switch (ipl->depth) {
+    case IPL_DEPTH_8U :
+        srcformat = TypeDesc::UINT8;  break;
+    case IPL_DEPTH_8S :
+        srcformat = TypeDesc::INT8;  break;
+    case IPL_DEPTH_16U :
+        srcformat = TypeDesc::UINT16;  break;
+    case IPL_DEPTH_16S :
+        srcformat = TypeDesc::INT16;  break;
+    case IPL_DEPTH_32F :
+        srcformat = TypeDesc::FLOAT;  break;
+    case IPL_DEPTH_64F :
+        srcformat = TypeDesc::DOUBLE;  break;
+    default:
+        DASSERT (0 && "unknown IplImage type");
+        return false;
+    }
+
+    TypeDesc dstformat = (convert != TypeDesc::UNKNOWN) ? convert : srcformat;
+    ImageSpec spec (ipl->width, ipl->height, ipl->nChannels, dstformat);
+    // N.B. The OpenCV headers say that ipl->alphaChannel,
+    // ipl->colorModel, and ipl->channelSeq are ignored by OpenCV.
+
+    if (ipl->dataOrder != IPL_DATA_ORDER_PIXEL) {
+        // We don't handle separate color channels, and OpenCV doesn't either
+        return false;
+    }
+    
+    dst.reset (dst.name(), spec);
+    size_t pixelsize = srcformat.size()*spec.nchannels;
+    // Account for the origin in the line step size, to end up with the
+    // standard OIIO origin-at-upper-left:
+    size_t linestep = ipl->origin ? -ipl->widthStep : ipl->widthStep;
+    // Block copy and convert
+    convert_image (spec.nchannels, spec.width, spec.height, 1,
+                   ipl->imageData, srcformat,
+                   pixelsize, linestep, 0, 
+                   dst.pixeladdr(0,0), dstformat,
+                   spec.pixel_bytes(), spec.scanline_bytes(), 0);
+    // FIXME - honor dataOrder.  I'm not sure if it is ever used by
+    // OpenCV.  Fix when it becomes a problem.
+
+    // OpenCV uses BGR ordering
+    // FIXME: what do they do with alpha?
+    if (spec.nchannels >= 3) {
+        float pixel[4];
+        for (int y = 0;  y < spec.height;  ++y) {
+            for (int x = 0;  x < spec.width;  ++x) {
+                dst.getpixel (x, y, pixel, 4);
+                float tmp = pixel[0];  pixel[0] = pixel[2]; pixel[2] = tmp;
+                dst.setpixel (x, y, pixel, 4);
+            }
+        }
+    }
+    // FIXME -- the copy and channel swap should happen all as one loop,
+    // probably templated by type.
+
+    return true;
+#else
+    return false;
+#endif
+}
+
+
+
+IplImage *
+ImageBufAlgo::to_IplImage (const ImageBuf &src)
+{
+#ifdef USE_OPENCV
+    return NULL;
+#else
+    return NULL;
+#endif
+}
+
+
+
+namespace {
+
+static mutex opencv_mutex;
+
+#ifdef USE_OPENCV
+class CameraHolder {
+public:
+    CameraHolder () { }
+    // Destructor frees all cameras
+    ~CameraHolder () {
+        for (camera_map::iterator i = m_cvcaps.begin();  i != m_cvcaps.end();  ++i)
+            cvReleaseCapture (&(i->second));
+    }
+    // Get the capture device, creating a new one if necessary.
+    CvCapture * operator[] (int cameranum) {
+        camera_map::iterator i = m_cvcaps.find (cameranum);
+        if (i != m_cvcaps.end())
+            return i->second;
+        CvCapture *cvcam = cvCreateCameraCapture (cameranum);
+        m_cvcaps[cameranum] = cvcam;
+        return cvcam;
+    }
+private:
+    typedef std::map<int,CvCapture*> camera_map;
+    camera_map m_cvcaps;
+};
+
+static CameraHolder cameras;
+#endif
+
+};
+
+
+bool
+ImageBufAlgo::capture_image (ImageBuf &dst, int cameranum, TypeDesc convert)
+{
+#ifdef USE_OPENCV
+    IplImage *frame = NULL;
+    {
+        // This block is mutex-protected
+        lock_guard lock (opencv_mutex);
+        CvCapture *cvcam = cameras[cameranum];
+        if (! cvcam) {
+            return false;  // failed somehow
+        }
+        frame = cvQueryFrame (cvcam);
+        if (! frame) {
+            return false;  // failed somehow
+        }
+    }
+    bool ok = ImageBufAlgo::from_IplImage (dst, frame, convert);
+    // cvReleaseImage (&frame);   // unnecessary?
+    return ok;
+#else
+    return false;
+#endif
+}
+
+
+}
+OIIO_NAMESPACE_EXIT

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1176,9 +1176,31 @@ action_pattern (int argc, const char *argv[])
     } else {
         ImageBufAlgo::zero (ib);
     }
-    if (ot.curimg)
-        ot.image_stack.push_back (ot.curimg);
-    ot.curimg = img;
+    ot.push (img);
+    return 0;
+}
+
+
+
+static int
+action_capture (int argc, const char *argv[])
+{
+    ASSERT (argc == 1);
+    int camera = 0;
+
+    std::string cmd = argv[0];
+    size_t pos;
+    while ((pos = cmd.find_first_of(":")) != std::string::npos) {
+        cmd = cmd.substr (pos+1, std::string::npos);
+        if (istarts_with(cmd,"camera="))
+            camera = atoi(cmd.c_str()+7);
+    }
+
+    ImageBuf ib;
+    ImageBufAlgo::capture_image (ib, camera, TypeDesc::FLOAT);
+    ImageRecRef img (new ImageRec ("capture", ib.spec(), ot.imagecache));
+    (*img)() = ib;
+    ot.push (img);
     return 0;
 }
 
@@ -1416,6 +1438,8 @@ getargs (int argc, char *argv[])
                         "Create a blank image (args: geom, channels)",
                 "--pattern %@ %s %s %d", action_pattern, NULL, NULL, NULL,
                         "Create a patterned image (args: pattern, geom, channels)",
+                "--capture %@", action_capture, NULL,
+                        "Capture an image (args: camera=%%d)",
                 "--unmip %@", action_unmip, &dummybool, "Discard all but the top level of a MIPmap",
                 "--selectmip %@ %d", action_selectmip, &dummyint,
                     "Select just one MIP level (0 = highest res)",


### PR DESCRIPTION
This is actually something I did last summer and forgot about.  But it's very useful, so I dusted it off and updated it in the new world of oiiotool.

The intent of all this is to let applications that use OpenCV freely use OpenImageIO as well, with easy conversion and handoff between the packages.  Currently, this consists of:
- Basic conversion if IplImage (used by OpenCV and Intel's Image Library) to ImageBuf.  And a stub for the other direction, but not yet implemented.
- ImageBufAlgo::capture_image will capture an image from a webcam or other device, using OpenCV underneath.
- oiiotool --capture grabs a frame, which can subsequently be processed in all the usual oiiotool ways.

The compile-time detection of OpenCV is automatic, and if not found by CMake, the above functionality will not be built.
