### PR TITLE
Fix ill-formed default output name for maketx

### DIFF
--- a/src/include/filesystem.h
+++ b/src/include/filesystem.h
@@ -72,6 +72,11 @@ DLLPUBLIC std::string extension (const std::string &filepath);
 /// filename or filepath.  DEPRECATED.
 DLLPUBLIC std::string file_extension (const std::string &filepath);
 
+/// Change the file extension of a filename or filepath. Does not
+/// alter filepath, just returns a new string
+DLLPUBLIC std::string change_extension (const std::string &filepath, 
+                                        const std::string &new_extension);
+
 /// Turn a searchpath (multiple directory paths separated by ':' or ';')
 /// into a vector<string> containing each individual directory.  If
 /// validonly is true, only existing and readable directories will end

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -96,6 +96,14 @@ Filesystem::file_extension (const std::string &filepath)
 
 
 
+std::string
+Filesystem::change_extension (const std::string &filepath, const std::string &new_extension)
+{
+	return boost::filesystem::path(filepath).replace_extension(new_extension).string();
+}
+
+
+
 void
 Filesystem::searchpath_split (const std::string &searchpath,
                               std::vector<std::string> &dirs,

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -675,13 +675,8 @@ make_texturemap (const char *maptypename = "texture map")
         std::cerr << "maketx ERROR: \"" << filenames[0] << "\" does not exist\n";
         exit (EXIT_FAILURE);
     }
-    if (outputfilename.empty()) {
-        const std::string ext = Filesystem::file_extension (filenames[0]);
-        int notextlen = (int) filenames[0].length() - (int) ext.length();
-        outputfilename = std::string (filenames[0].begin(),
-                                      filenames[0].begin() + notextlen);
-        outputfilename += ".tx";
-    }
+    if (outputfilename.empty()) 
+		outputfilename = Filesystem::change_extension (filenames[0], ".tx");
 
     // When was the input file last modified?
     std::time_t in_time = boost::filesystem::last_write_time (filenames[0]);


### PR DESCRIPTION
Filesystem::file_extension() does not return the '.' in the extension string whereas boost::file_system::extension() does. This little difference went unnoticed in a previous commit. The result is that "maketx foo.tif" builds a "foo..tx" file. The proposed change greatly simplifies the code and does the right thing.

Notes for Larry:
- The filesystem.{cpp,h} changes compile with boost::filesystem v2 and v3. 
- The replace_extension() method used by the wrapper is available in Boost 1.40 (and in prior versions)
