### PR TITLE
Windows magic - __declspec can't be placed after pointer (*) sign

### DIFF
--- a/src/include/imagebufalgo.h
+++ b/src/include/imagebufalgo.h
@@ -294,7 +294,7 @@ bool DLLPUBLIC from_IplImage (ImageBuf &dst, const IplImage *ipl,
 /// if OpenImageIO was compiled without OpenCV support, then return
 /// NULL.  The ownership of the IplImage is fully transferred to the
 /// calling application.
-IplImage* DLLPUBLIC to_IplImage (const ImageBuf &src);
+DLLPUBLIC IplImage* to_IplImage (const ImageBuf &src);
 
 /// Capture a still image from a designated camera.  If able to do so,
 /// store the image in dst and return true.  If there is no such device,


### PR DESCRIPTION
For some reasons I don't quite understand You can't place __declspec declaration after pointer sign (*) - this issue a compilation error on VS 2010 Express. There is quick fix - just put the declaration before the return type.
