### PR TITLE
Minor patch to iv/imageviewer.cpp - hyperlinking the URL in the About messagebox.

### DIFF
--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -2000,7 +2000,7 @@ ImageViewer::about()
     QMessageBox::about(this, tr("About iv"),
             tr("<p><b>iv</b> is the image viewer for OpenImageIO.</p>"
                "<p>(c) Copyright 2008 Larry Gritz et al.  All Rights Reserved.</p>"
-               "<p>See http://openimageio.org for details.</p>"));
+               "<p>See <a href='http://openimageio.org'>http://openimageio.org</a> for details.</p>"));
 }
 
 


### PR DESCRIPTION
I was just getting started with the imageviewer GUI, with an interest to apply for GSOC with OIIO. 
I have hyperlinked the URL in the 'About' message box to the OIIO homepage.
This was my first ever patch submitted and hence a tiny one. I shall try to look up Issues list and come up with more bug fixes.
