### PR TITLE
Review: ImageCache attribute "deduplicate" 

### DIFF
--- a/src/doc/imagecache.tex
+++ b/src/doc/imagecache.tex
@@ -350,6 +350,15 @@ default is zero, meaning that failures of open or tile reading will
 immediately return as a failure.
 \apiend
 
+\apiitem{int deduplicate}
+When nonzero, the \ImageCache will notice duplicate images under
+different names if their headers contain a SHA-1 fingerprint (as is done
+with \maketx-produced textures) and handle them more efficiently by
+avoiding redundant reads.  The default is 1 (de-duplication turned on).
+The only reason to set it to 0 is if you specifically want to disable the
+de-duplication optimization.
+\apiend
+
 \apiitem{string options}
 This catch-all is simply a comma-separated list of {\cf name=value}
 settings of named options.  For example,

--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -536,7 +536,8 @@ int autoscanline \\
 int automip \\
 int accept_untiled \\
 int accept_unmipped \\
-int failure_retries}
+int failure_retries \\
+int deduplicate}
 
 These attributes are all passed along to the underlying \ImageCache that
 is used internally by the \TextureSystem.  Please consult the

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -221,6 +221,9 @@ main (int argc, char *argv[])
 #ifdef DEBUG
     imagecache->attribute ("statistics:level", 2);
 #endif
+    // force a full diff, even for files tagged with the same
+    // fingerprint, just in case some mistake has been made.
+    imagecache->attribute ("deduplicate", 0);
 
     ImageBuf img0, img1;
     if (! read_input (filenames[0], img0, imagecache) ||

--- a/src/include/imagecache.h
+++ b/src/include/imagecache.h
@@ -94,6 +94,7 @@ public:
     ///     int statistics:level : verbosity of statistics auto-printed.
     ///     int forcefloat : if nonzero, convert all to float.
     ///     int failure_retries : number of times to retry a read before fail.
+    ///     int deduplicate : if nonzero, detect duplicate textures (default=1)
     ///
     virtual bool attribute (const std::string &name, TypeDesc type,
                             const void *val) = 0;

--- a/src/include/texture.h
+++ b/src/include/texture.h
@@ -338,6 +338,7 @@ public:
     ///     int accept_untiled : if nonzero, accept untiled images
     ///     int accept_unmipped : if nonzero, accept unmipped images
     ///     int failure_retries : how many times to retry a read failure
+    ///     int deduplicate : if nonzero, detect duplicate textures (default=1)
     ///     int gray_to_rgb : make 1-channel images fill RGB lookups
     ///     string latlong_up : default "up" direction for latlong ("y")
     ///

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -920,6 +920,7 @@ private:
     bool m_accept_untiled;       ///< Accept untiled images?
     bool m_accept_unmipped;      ///< Accept unmipped images?
     bool m_read_before_insert;   ///< Read tiles before adding to cache?
+    bool m_deduplicate;          ///< Detect duplicate files?
     int m_failure_retries;       ///< Times to re-try disk failures
     bool m_latlong_y_up_default; ///< Is +y the default "up" for latlong?
     Imath::M44f m_Mw2c;          ///< world-to-"common" matrix

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -1134,6 +1134,7 @@ make_texturemap (const char *maptypename = "texture map")
         if (verbose)
             std::cout << "  SHA-1: " << hash_digest << std::endl;
         updatedDesc = true;
+        dstspec.attribute ("oiio:SHA-1", hash_digest);
     }
     
     if (isConstantColor) {
@@ -1152,6 +1153,7 @@ make_texturemap (const char *maptypename = "texture map")
         if (verbose)
             std::cout << "  ConstantColor: " << os.str() << std::endl;
         updatedDesc = true;
+        dstspec.attribute ("oiio:ConstantColor", os.str());
     }
     
     if (updatedDesc) {


### PR DESCRIPTION
Add ImageCache attribute "deduplicate" that controls whether the identical-image-deduplication is enabled. (It is enabled by default.)

Disable it for idiff, to be extra super sure we are diffing the actual pixels even if there is a SHA-1 botch.
Also, in maketx, store the SHA-1 in metadata "oiio:SHA-1" and the constant color info in "oiio:ConstantColor", in addition to stashing it in the ImageDescription.
