### PR TITLE
Patch addressing Hotkeys feature.

### DIFF
--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -1696,6 +1696,14 @@ ImageViewer::keyPressEvent (QKeyEvent *event)
     case Qt::Key_Escape :
         if (m_fullscreen)
             fullScreenToggle();
+        else
+            close();        
+        return;
+    case Qt::Key_F11 :
+        fullScreenToggle();
+        return;
+    case Qt::Key_F4 :
+        fitImageToWindowAct->trigger();
         return;
     case Qt::Key_Minus :
     case Qt::Key_Underscore :


### PR DESCRIPTION
This patch addresses issue #309 and makes the following additions:
1. Esc key exits full-screen mode, if it is not in full-screen mode, closes iv.
2. F11 toggles full-screen mode. (F2 was suggested in the issue. I felt F11 was a more 'popular' alternative.)
3. F4 toggles fit to window.
