### PR TITLE
Review: PNG gamma fixes

### DIFF
--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -149,14 +149,15 @@ read_info (png_structp& sp, png_infop& ip, int& bit_depth, int& color_type,
 
     spec.default_channel_names ();
 
-    double gamma;
-    if (png_get_gAMA (sp, ip, &gamma)) {
-        spec.attribute ("oiio:Gamma", (float) gamma);
-        spec.attribute ("oiio:ColorSpace", (gamma == 1) ? "Linear" : "GammaCorrected");
-    }
     int srgb_intent;
     if (png_get_sRGB (sp, ip, &srgb_intent)) {
         spec.attribute ("oiio:ColorSpace", "sRGB");
+    } else {
+        double gamma;
+        if (png_get_gAMA (sp, ip, &gamma)) {
+            spec.attribute ("oiio:Gamma", (float)(1.0f/gamma));
+            spec.attribute ("oiio:ColorSpace", (gamma == 1) ? "Linear" : "GammaCorrected");
+        }
     }
     png_timep mod_time;
     if (png_get_tIME (sp, ip, &mod_time)) {
@@ -439,7 +440,7 @@ write_info (png_structp& sp, png_infop& ip, int& color_type,
     }
     else if (Strutil::iequals (colorspace, "GammaCorrected")) {
         float gamma = spec.get_float_attribute ("oiio:Gamma", 1.0);
-        png_set_gAMA (sp, ip, gamma);
+        png_set_gAMA (sp, ip, 1.0f/gamma);
     }
     else if (Strutil::iequals (colorspace, "sRGB")) {
         png_set_sRGB_gAMA_and_cHRM (sp, ip, PNG_sRGB_INTENT_ABSOLUTE);

--- a/testsuite/png/ref/out.txt
+++ b/testsuite/png/ref/out.txt
@@ -2,7 +2,6 @@ Reading ../../../../../oiio-images/oiio-logo-no-alpha.png
 ../../../../../oiio-images/oiio-logo-no-alpha.png :  135 x  135, 4 channel, uint8 png
     SHA-1: 75ED9B183E083ECF0A4881EEE0B553457B698CF4
     channel list: R, G, B, A
-    oiio:Gamma: 0.45455
     oiio:ColorSpace: "sRGB"
     DateTime: "2009:03:26 17:19:47"
     Comment: "Created with GIMP"
@@ -16,7 +15,6 @@ Reading ../../../../../oiio-images/oiio-logo-with-alpha.png
 ../../../../../oiio-images/oiio-logo-with-alpha.png :  135 x  135, 4 channel, uint8 png
     SHA-1: 8AED04DCCE8F83B068C537DC0982A42EFBE431B6
     channel list: R, G, B, A
-    oiio:Gamma: 0.45455
     oiio:ColorSpace: "sRGB"
     DateTime: "2009:03:26 18:44:26"
     Comment: "Created with GIMP"


### PR DESCRIPTION
PNG: if sRGB is detected, don't set oiio:Gamma metadata.  Furthermore, it seems our notion of gamma is 1/ PNG's way of expressing it.
