### PR TITLE
Review: Fix or suppress warnings with clang (redux)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,8 +85,7 @@ endif()
 
 # Disable some warnings for Clang, it's a little too picky with boost
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    add_definitions ("-Wno-parentheses")
-    add_definitions ("-Wno-char-subscripts")
+    set (CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")
     add_definitions ("-Wno-unused-function")
     add_definitions ("-Wno-overloaded-virtual")
 endif ()

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -82,11 +82,9 @@ endmacro ()
 
 message (STATUS "BOOST_ROOT ${BOOST_ROOT}")
 
-set (Boost_ADDITIONAL_VERSIONS "1.45" "1.44" 
+set (Boost_ADDITIONAL_VERSIONS "1.49" "1.48" "1.47" "1.46" "1.45" "1.44" 
                                "1.43" "1.43.0" "1.42" "1.42.0" 
-                               "1.41" "1.41.0" "1.40" "1.40.0"
-                               "1.39" "1.39.0" "1.38" "1.38.0"
-                               "1.37" "1.37.0" "1.34.1" "1_34_1")
+                               "1.41" "1.41.0" "1.40" "1.40.0")
 if (LINKSTATIC)
     set (Boost_USE_STATIC_LIBS   ON)
 endif ()
@@ -96,7 +94,7 @@ if (BOOST_CUSTOM)
     # N.B. For a custom version, the caller had better set up the variables
     # Boost_VERSION, Boost_INCLUDE_DIRS, Boost_LIBRARY_DIRS, Boost_LIBRARIES.
 else ()
-    find_package (Boost 1.34 REQUIRED 
+    find_package (Boost 1.40 REQUIRED 
                   COMPONENTS filesystem regex system thread
                  )
     # Try to figure out if this boost distro has Boost::python.  If we
@@ -158,8 +156,12 @@ if (NOT oiio_boost_PYTHON_FOUND)
     set (PYTHONLIBS_FOUND OFF)
 endif ()
 
-include_directories ("${Boost_INCLUDE_DIRS}")
+include_directories (SYSTEM "${Boost_INCLUDE_DIRS}")
 link_directories ("${Boost_LIBRARY_DIRS}")
+
+#if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+#    add_definitions ("-Wno-parentheses")
+#endif ()
 
 # end Boost setup
 ###########################################################################

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -261,7 +261,7 @@ Jpeg2000Input::create_decompressor()
     int magic[3];
     if (::fread (&magic, 4, 3, m_file) != 3) {
         error ("Empty file \"%s\"", m_filename.c_str());
-        return false;
+        return NULL;
     }
     opj_dinfo_t* dinfo = NULL;
     if (isJp2File(magic))

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -41,8 +41,8 @@ ImageBufWrap::ImageBufWrap (const std::string &name,
     m_buf = new ImageBuf(name, spec);
 }
 
-ImageBufWrap::ImageBufWrap (const std::string &name = std::string(), 
-                ImageCacheWrap *icw = NULL) {
+ImageBufWrap::ImageBufWrap (const std::string &name,
+                            ImageCacheWrap *icw) {
     // TODO: this isn't done properly. It should not take NULL as 
     // 2nd argument, the proper way would be icw->Cache
     // It's like this just for the initial tests.

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -170,7 +170,8 @@ private:
     ImageBuf *m_buf;
 public:
 
-    ImageBufWrap (const std::string&, ImageCacheWrap*);
+    ImageBufWrap (const std::string&name = std::string(),
+                  ImageCacheWrap*icw = NULL);
     ImageBufWrap (const std::string&, const ImageSpec&) ;  
     void clear ();
     void reset_to_new_image (const std::string&, ImageCache*);


### PR DESCRIPTION
New version of "fix or suppress warnings with clang."  Fewer warnings suppressed, better way of telling clang to ignore warnings in boost.
