### PR TITLE
Review: back off of tinyformat just a bit

### DIFF
--- a/src/include/strutil.h
+++ b/src/include/strutil.h
@@ -89,8 +89,17 @@ namespace Strutil {
 TINYFORMAT_WRAP_FORMAT (std::string, format, /**/,
     std::ostringstream msg;, msg, return msg.str();)
 
+/// Return a std::string formatted from printf-like arguments.  Like the
+/// real sprintf, this is not guaranteed type-safe and is not extensible
+/// like format().  You would only want to use this instead of the safe
+/// format() in rare situations where you really need to use obscure
+/// printf features that aren't supported by tinyformat.
+std::string DLLPUBLIC format_raw (const char *fmt, ...)
+                                         OPENIMAGEIO_PRINTF_ARGS(1,2);
+
 /// Return a std::string formatted from printf-like arguments -- passed
-/// already as a va_list.
+/// already as a va_list.  Like vsprintf, this is not guaranteed
+/// type-safe and is not extensible like format().
 std::string DLLPUBLIC vformat (const char *fmt, va_list ap)
                                          OPENIMAGEIO_PRINTF_ARGS(1,0);
 

--- a/src/libOpenImageIO/strutil_test.cpp
+++ b/src/libOpenImageIO/strutil_test.cpp
@@ -28,10 +28,35 @@
   (This is the Modified BSD License)
 */
 
-#include "imageio.h"
+#include "strutil.h"
 #include "unittest.h"
 
 OIIO_NAMESPACE_USING;
+
+
+
+void test_memformat ()
+{
+    OIIO_CHECK_EQUAL (Strutil::memformat (15), "15 B");
+    OIIO_CHECK_EQUAL (Strutil::memformat (15LL*1024), "15 KB");
+    OIIO_CHECK_EQUAL (Strutil::memformat (15LL*1024*1024), "15.0 MB");
+    OIIO_CHECK_EQUAL (Strutil::memformat (15LL*1024*1024*1024), "15.0 GB");
+    OIIO_CHECK_EQUAL (Strutil::memformat (15LL*1024*1024+200000), "15.2 MB");
+    OIIO_CHECK_EQUAL (Strutil::memformat (15LL*1024*1024+200000, 3), "15.191 MB");
+}
+
+
+
+void test_timeintervalformat ()
+{
+    OIIO_CHECK_EQUAL (Strutil::timeintervalformat (15.321), "15.3s");
+    OIIO_CHECK_EQUAL (Strutil::timeintervalformat (150.321), "2m 30.3s");
+    OIIO_CHECK_EQUAL (Strutil::timeintervalformat (15000.321), "4h 10m 0.3s");
+    OIIO_CHECK_EQUAL (Strutil::timeintervalformat (150000.321), "1d 17h 40m 0.3s");
+    OIIO_CHECK_EQUAL (Strutil::timeintervalformat (150.321, 2), "2m 30.32s");
+}
+
+
 
 void test_get_rest_arguments ()
 {
@@ -111,6 +136,8 @@ void test_escape_sequences ()
 
 int main (int argc, char *argv[])
 {
+    test_memformat ();
+    test_timeintervalformat ();
     test_get_rest_arguments ();
     test_escape_sequences ();
 


### PR DESCRIPTION
Restore old-fashioned unsafe format() as "format_raw()", for those rare
times when you must have every last feature of printf, including those
that tinyformat doesn't handle (and are willing to trade type safety and
expandability to do it).

What do you know, we need this for Strutil::memformat and Strutil::timeintervalformat!

Which we didn't notice because we had no unit tests for them, which I also have
now added.
