### PR TITLE
Review: Remove uses of the deprecated Filesystem:file_extension

### DIFF
--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -365,8 +365,8 @@ convert_file (const std::string &in_filename, const std::string &out_filename)
 
     std::string tempname = out_filename;
     if (tempname == in_filename) {
-        tempname = out_filename + ".tmp."
-                    + Filesystem::file_extension (out_filename);
+        tempname = out_filename + ".tmp"
+                    + Filesystem::extension (out_filename);
     }
 
     // Find an ImageIO plugin that can open the input file, and open it.

--- a/src/include/filesystem.h
+++ b/src/include/filesystem.h
@@ -64,13 +64,15 @@ namespace Filesystem {
 /// file extension, if any) of a filepath.
 DLLPUBLIC std::string filename (const std::string &filepath);
 
-/// Return the file extension (including the last '.') of a filename or
-/// filepath.
-DLLPUBLIC std::string extension (const std::string &filepath);
+/// Return the file extension (including the last '.' if
+/// include_dot=true) of a filename or filepath.
+DLLPUBLIC std::string extension (const std::string &filepath,
+                                 bool include_dot=true);
 
-/// Return the file extension (just the part after the last '.') of a
-/// filename or filepath.  DEPRECATED.
-DLLPUBLIC std::string file_extension (const std::string &filepath);
+/// DEPRECATED.
+inline std::string file_extension (const std::string &filepath) {
+    return extension (filepath, false);
+}
 
 /// Replace the file extension of a filename or filepath. Does not
 /// alter filepath, just returns a new string

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -238,11 +238,11 @@ Jpeg2000Output::init_components(opj_image_cmptparm_t *components, int precision)
 opj_cinfo_t*
 Jpeg2000Output::create_compressor()
 {
-    std::string ext = Filesystem::file_extension(m_filename);
+    std::string ext = Filesystem::extension(m_filename);
     opj_cinfo_t *compressor = NULL;
-    if (ext == "j2k")
+    if (ext == ".j2k")
         compressor = opj_create_compress(CODEC_J2K);
-    else if (ext == "jp2")
+    else if (ext == ".jp2")
         compressor = opj_create_compress(CODEC_JP2);
 
     return compressor;

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -308,7 +308,7 @@ ImageOutput::create (const std::string &filename,
     }
 
     // Extract the file extension from the filename (without the leading dot)
-    std::string format = Filesystem::file_extension (filename);
+    std::string format = Filesystem::extension (filename, false);
     if (format.empty()) {
         // If the file had no extension, maybe it was itself the format name
         format = filename;
@@ -365,7 +365,7 @@ ImageInput::create (const std::string &filename,
     }
 
     // Extract the file extension from the filename (without the leading dot)
-    std::string format = Filesystem::file_extension (filename);
+    std::string format = Filesystem::extension (filename, false);
     if (format.empty()) {
         // If the file had no extension, maybe it was itself the format name
         format = filename;

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -61,37 +61,17 @@ Filesystem::filename (const std::string &filepath)
 
 
 std::string
-Filesystem::extension (const std::string &filepath)
+Filesystem::extension (const std::string &filepath, bool include_dot)
 {
+    std::string s;
 #if BOOST_FILESYSTEM_VERSION == 3
-    return boost::filesystem::path(filepath).extension().string();
+    s = boost::filesystem::path(filepath).extension().string();
 #else
-    return boost::filesystem::path(filepath).extension();
+    s = boost::filesystem::path(filepath).extension();
 #endif
-}
-
-
-
-std::string
-Filesystem::file_extension (const std::string &filepath)
-{
-    // Search for the LAST dot in the filepath
-    const char *ext = strrchr (filepath.c_str(), '.');
-
-    // If there was no dot at all, or if it was the last character, there's
-    // no file extension, so just return "".
-    if (! ext || !ext[1])
-        return "";
-
-    ++ext;  // Advance to the char AFTER the dot
-
-    // But if there's a slash after the last dot, then the dot was part
-    // of the directory, not the leaf name.
-    if (strchr (ext, '/'))
-        return "";
-
-    // The extension starts AFTER the period!
-    return ext;
+    if (! include_dot && !s.empty() && s[0] == '.')
+        s.erase (0, 1);  // erase the first character
+    return s;
 }
 
 
@@ -100,7 +80,7 @@ std::string
 Filesystem::replace_extension (const std::string &filepath,
                                const std::string &new_extension)
 {
-	return boost::filesystem::path(filepath).replace_extension(new_extension).string();
+    return boost::filesystem::path(filepath).replace_extension(new_extension).string();
 }
 
 


### PR DESCRIPTION
Remove uses of the deprecated Filesystem:file_extension, and extend the preferred extension() to handle the missing functionality.
