### PR TITLE
Small patch to allow compiling on systems without log2

### DIFF
--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -66,7 +66,7 @@
 #include "sysutil.h"
 #include "filesystem.h"
 
-#if !defined(log2f)
+#if (defined(__FreeBSD__) && (__FreeBSD_version < 803000))
 
 inline float log2f(float x) {return logf(x)*(float)1.4426950408889634;}
 

--- a/src/ptex.imageio/ptex/Ptexture.h
+++ b/src/ptex.imageio/ptex/Ptexture.h
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 #include <math.h>
 
-#if !defined(log2)
+#if (defined(__FreeBSD__) && (__FreeBSD_version < 803000))
 
 inline double log2(double x) {return log(x)*(double)1.4426950408889634;}
 


### PR DESCRIPTION
When creating the freebsd port for oiio I found I needed to add log2 functions to two files for freebsd 8.2 and earlier. Rather than make it freebsd specific I opted to check for log2 being defined so it can be more universal.
