### PR TITLE
Fix compilation error on FreeBSD/kFreeBSD systems (usleep)

### DIFF
--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -45,6 +45,7 @@
 # include <sys/sysctl.h>
 # include <sys/wait.h>
 # include <sys/ioctl.h>
+# include <unistd.h>
 #endif
 
 #ifdef __APPLE__


### PR DESCRIPTION
We didn't included <unistd.h> header file on FreeBSD/kFreeBSD systems - this caused compilation errors. This pull request fix that.
