### PR TITLE
Remove Sysutil::this_program_path

### DIFF
--- a/src/include/sysutil.h
+++ b/src/include/sysutil.h
@@ -65,10 +65,6 @@ DLLPUBLIC size_t memory_used (bool resident=false);
 /// 'converted_time' variable
 DLLPUBLIC void get_local_time (const time_t *time, struct tm *converted_time);
 
-/// Return the full path of the currently-running executable program.
-///
-DLLPUBLIC std::string this_program_path ();
-
 /// Sleep for the given number of microseconds.
 ///
 DLLPUBLIC void usleep (unsigned long useconds);

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -137,46 +137,6 @@ Sysutil::get_local_time (const time_t *time, struct tm *converted_time)
 }
 
 
-
-std::string
-Sysutil::this_program_path ()
-{
-    char filename[10240];
-    filename[0] = 0;
-    unsigned int size = sizeof(filename);
-
-#if defined(__linux__)
-    int r = readlink ("/proc/self/exe", filename, size);
-#elif defined(__APPLE__)
-    // For info:  'man 3 dyld'
-    int r = _NSGetExecutablePath (filename, &size);
-    if (r == 0)
-        r = size;
-#elif defined(_WIN32)
-    // According to MSDN...
-    int r = GetModuleFileName (NULL, filename, size);
-#elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
-    int mib[4];
-    mib[0] = CTL_KERN;
-    mib[1] = KERN_PROC;
-    mib[2] = KERN_PROC_PATHNAME;
-    mib[3] = -1;
-//  char filename[1024];
-    size_t cb = sizeof(filename);
-    int r=1;
-    sysctl(mib, 4, filename, &cb, NULL, 0);
-#else
-    // No idea what platform this is
-    ASSERT (0);
-#endif
-
-    if (r > 0)
-        return std::string (filename);
-    return std::string();   // Couldn't figure it out
-}
-
-
-
 void
 Sysutil::usleep (unsigned long useconds)
 {


### PR DESCRIPTION
When dealing with GNU/Hurd compilation fixes I noticed that Sysutil::this_program_path is not used in liboiio and liboiio tools source code. I also can't find any good reason to keep this method and expose it to OIIO clients.

Any reason to keep it in oiio source or can I safely remove it?
