### PR TITLE
Review: Build cleanups and clang fixes (especially for Linux)

### DIFF
--- a/site/spi/Makefile-bits-arnold
+++ b/site/spi/Makefile-bits-arnold
@@ -37,8 +37,8 @@ ifeq ($(SP_ARCH), spinux1_x86_64)
 	  -DILMBASE_CUSTOM_LIBRARIES="SpiImath SpiHalf SpiIlmThread SpiIex" \
 	  -DOPENEXR_CUSTOM=1 \
 	  -DOPENEXR_CUSTOM_LIBRARY="SpiIlmImf" \
-	  -DOCIO_PATH="${OCIO_PATH}" \
-	  -DFIELD3D_HOME="${FIELD3D_HOME}" \
+	  -DOCIO_PATH=${OCIO_PATH} \
+	  -DFIELD3D_HOME=${FIELD3D_HOME} \
           -DHDF5_CUSTOM=1 \
 	  -DHDF5_INCLUDE_DIRS=/usr/include \
 	  -DHDF5_LIBRARIES=/usr/lib64/libhdf5.so \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,6 @@
 project (OpenImageIO)
+
+# Release version of the library
 set (OIIO_VERSION_MAJOR 1)
 set (OIIO_VERSION_MINOR 1)
 set (OIIO_VERSION_PATCH 0)
@@ -7,6 +9,7 @@ cmake_minimum_required (VERSION 2.6)
 if (NOT CMAKE_VERSION VERSION_LESS 2.8.4)
     cmake_policy (SET CMP0017 NEW)
 endif ()
+set (CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS TRUE)
 message (STATUS "Project source dir = ${PROJECT_SOURCE_DIR}")
 message (STATUS "Project build dir = ${CMAKE_BINARY_DIR}")
 
@@ -14,10 +17,53 @@ if (${PROJECT_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
     message (FATAL_ERROR "Not allowed to run in-source build!")
 endif ()
 
-
 if (NOT CMAKE_BUILD_TYPE) 
     set (CMAKE_BUILD_TYPE "Release") 
 endif ()
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_definitions ("-DDEBUG=1")
+    set (DEBUGMODE ON)
+endif ()
+
+
+# Figure out which compiler we're using
+if (CMAKE_COMPILER_IS_GNUCC)
+    execute_process (COMMAND ${CMAKE_C_COMPILER} -dumpversion
+                     OUTPUT_VARIABLE GCC_VERSION
+                     OUTPUT_STRIP_TRAILING_WHITESPACE)
+    message (STATUS "Using gcc ${GCC_VERSION} as the compiler")
+endif ()
+if (NOT CMAKE_COMPILER_IS_CLANG)
+    message (STATUS "CMAKE_CXX_COMPILER is ${CMAKE_CXX_COMPILER}")
+    string (REGEX MATCH clang CMAKE_COMPILER_IS_CLANG ${CMAKE_CXX_COMPILER})
+    message (STATUS "CMAKE_COMPILER_IS_CLANG is '${CMAKE_COMPILER_IS_CLANG}'")
+    if (CMAKE_COMPILER_IS_CLANG)
+        set (CMAKE_COMPILER_IS_CLANG 1)
+        message (STATUS "Using clang as the compiler")
+    endif ()
+endif ()
+
+# Strict warnings
+if (NOT MSVC)
+    add_definitions ("-Wall")
+endif()
+
+if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_GNUCC)
+    # CMake doesn't automatically know what do do with
+    # include_directories(SYSTEM...) when using clang or gcc.
+    set (CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")
+endif ()
+
+if (CMAKE_COMPILER_IS_CLANG)
+    # Disable some warnings for Clang, for some things that are too awkward
+    # to change just for the sake of having no warnings.
+    add_definitions ("-Wno-unused-function")
+    add_definitions ("-Wno-overloaded-virtual")
+    # disable warning about unused command line arguments
+    add_definitions ("-Qunused-arguments")
+endif ()
+
+
 
 set (EMBEDPLUGINS ON CACHE BOOL "Embed format plugins in libOpenImageIO")
 set (BUILDSTATIC OFF CACHE BOOL "Build static library instead of shared")
@@ -78,24 +124,6 @@ include_directories(
     ${CMAKE_BINARY_DIR}/include/
 )
 
-# Strict warnings
-if (NOT MSVC)
-    add_definitions ("-Wall")
-endif()
-
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    # CMake doesn't automatically know what do do with
-    # include_directories(SYSTEM...) when using clang.
-    set (CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")
-    # Disable some warnings for Clang, for some things that are too awkward
-    # to change just for the sake of having no warnings.
-    add_definitions ("-Wno-unused-function")
-    add_definitions ("-Wno-overloaded-virtual")
-endif ()
-
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    add_definitions ("-DDEBUG=1")
-endif ()
 
 ###########################################################################
 # Paths for install tree customization.  Note that relative paths are relative


### PR DESCRIPTION
I was having trouble on our work Linux boxes getting the CMake build scripts to properly recognize clang.  The slightly different ways of recognizing clang that I'd used in OSL's CMake files worked better, so I reconciled the two packages by porting that, and a few other bits and pieces, over to OIIO.  Most of the changes are just rearrangements to make the two packages' very similar files do things in the same order so they are easier to compare in the future.  A couple other very minor cleanups as well (removed some double quoting in the site/spi/Makefile-bits-arnold file).
