### PR TITLE
Review: Revert recent change with TIFFdOpen -- it breaks subimage appending.

### DIFF
--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -170,12 +170,30 @@ TIFFOutput::open (const std::string &name, const ImageSpec &userspec,
         m_spec.depth = 1;
 
     // Open the file
-    const char *fmode = (mode == AppendSubimage ? "a" : "w");
-    FILE *fd = Filesystem::fopen (name, fmode);
-    m_tif = (fd) ? TIFFFdOpen (fileno (fd), name.c_str(), fmode) : NULL;
+#if 1
+    m_tif = TIFFOpen (name.c_str(), mode == AppendSubimage ? "a" : "w");
+#else
+    // The following code was proposed by Brecht Van Lommel, going through
+    // Filesystem::fopen in order to take advantage of correct handling of
+    // UTF-8 filenames in Windows (which TIFFOpen doesn't do).  
+    // Looked good on paper, but for some reason, the code below does NOT
+    // correctly handle "a" append mode, which means that writing multiple
+    // subimages breaks, which in turn renders 'maketx' useless!  Though
+    // since it doesn't return an error code, you don't know that until your
+    // texturing looks bad and you realize it's because there's only one
+    // level of the MIPmap output.  Ugh!
+    // I (lg) played with it for a while and couldn't find a solution.
+    // Our bug?  Bug in libtiff?  Who knows?  Back in your court, Brecht.
+    // When you find a solution, we can re-enable this code.  Easy to test
+    // by simply doing 'maketx input.tif -o output.tif' and then
+    // 'iinfo -v output.tif' to verify whether MIP levels are present.
+    FILE *fd = Filesystem::fopen (name, mode == AppendSubimage ? "a+b" : "wb");
+    m_tif = (fd) ? TIFFFdOpen (fileno (fd), name.c_str(),
+                               mode == AppendSubimage ? "a" : "w") : NULL;
+    if (! m_tif && fd)
+        fclose (fd);
+#endif
     if (! m_tif) {
-        if (fd)
-            fclose(fd);
         error ("Can't open \"%s\" for output.", name.c_str());
         return false;
     }


### PR DESCRIPTION
Brecht's recent changes to support Windows UTF-8 filenames broke maketx by somehow breaking TIFF output append mode, and thus not outputting subimage (MIP levels!) correctly.

This restores that critical section to the old way, until Brecht can find a solution -- I tried for a while, failed, and don't have time to pursue it further at this moment.

Here's a comment I added to the code that explains the situation.

```
// The following code was proposed by Brecht Van Lommel, going through
// Filesystem::fopen in order to take advantage of correct handling of
// UTF-8 filenames in Windows (which TIFFOpen doesn't do).  
// Looked good on paper, but for some reason, the code below does NOT
// correctly handle "a" append mode, which means that writing multiple
// subimages breaks, which in turn renders 'maketx' useless!  Though
// since it doesn't return an error code, you don't know that until your
// texturing looks bad and you realize it's because there's only one
// level of the MIPmap output.  Ugh!
// I (lg) played with it for a while and couldn't find a solution.
// Our bug?  Bug in libtiff?  Who knows?  Back in your court, Brecht.
// When you find a solution, we can re-enable this code.  Easy to test
// by simply doing 'maketx input.tif -o output.tif' and then
// 'iinfo -v output.tif' to verify whether MIP levels are present.
```
