### PR TITLE
Different fix to make TIFF work with UTF-8 on Windows

### DIFF
--- a/src/include/filesystem.h
+++ b/src/include/filesystem.h
@@ -151,6 +151,16 @@ DLLPUBLIC void last_write_time (const std::string& path, std::time_t time);
 ///
 DLLPUBLIC void convert_native_arguments (int argc, const char *argv[]);
 
+#ifdef _WIN32
+// Conversion to windows native wide char file path
+//
+DLLPUBLIC std::wstring path_to_windows_native (const std::string& path);
+
+// Conversion from windows native wide char file path
+//
+DLLPUBLIC std::string path_from_windows_native (const std::wstring& wpath);
+#endif
+
 };  // namespace Filesystem
 
 }

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -239,8 +239,8 @@ Filesystem::is_regular (const std::string &path)
 
 
 #ifdef _WIN32
-static std::wstring
-string_utf8_to_windows_native (const std::string& str)
+std::wstring
+Filesystem::path_to_windows_native (const std::string& str)
 {
     std::wstring native;
     
@@ -252,8 +252,8 @@ string_utf8_to_windows_native (const std::string& str)
 
 
 
-static std::string
-string_windows_native_to_utf8 (const std::wstring& str)
+std::string
+Filesystem::path_from_windows_native (const std::wstring& str)
 {
     std::string utf8;
 
@@ -271,8 +271,8 @@ Filesystem::fopen (const std::string &path, const std::string &mode)
 {
 #ifdef _WIN32
     // on Windows fopen does not accept UTF-8 paths, so we convert to wide char
-    std::wstring wpath = string_utf8_to_windows_native (path);
-    std::wstring wmode = string_utf8_to_windows_native (mode);
+    std::wstring wpath = path_to_windows_native (path);
+    std::wstring wmode = path_to_windows_native (mode);
 
     return ::_wfopen (wpath.c_str(), wmode.c_str());
 #else
@@ -290,7 +290,7 @@ Filesystem::open (std::ifstream &stream,
 {
 #ifdef _WIN32
     // Windows std::ifstream accepts non-standard wchar_t* 
-    std::wstring wpath = string_utf8_to_windows_native(path);
+    std::wstring wpath = path_to_windows_native(path);
     stream.open (wpath.c_str(), mode);
 #else
     stream.open (path.c_str(), mode);
@@ -306,7 +306,7 @@ Filesystem::open (std::ofstream &stream,
 {
 #ifdef _WIN32
     // Windows std::ofstream accepts non-standard wchar_t*
-    std::wstring wpath = string_utf8_to_windows_native (path);
+    std::wstring wpath = path_to_windows_native (path);
     stream.open (wpath.c_str(), mode);
 #else
     stream.open (path.c_str(), mode);
@@ -317,7 +317,7 @@ std::time_t
 Filesystem::last_write_time (const std::string& path)
 {
 #ifdef _WIN32
-    std::wstring wpath = string_utf8_to_windows_native (path);
+    std::wstring wpath = path_to_windows_native (path);
     return boost::filesystem::last_write_time (wpath);
 #else
     return boost::filesystem::last_write_time (path);
@@ -330,7 +330,7 @@ void
 Filesystem::last_write_time (const std::string& path, std::time_t time)
 {
 #ifdef _WIN32
-    std::wstring wpath = string_utf8_to_windows_native (path);
+    std::wstring wpath = path_to_windows_native (path);
     boost::filesystem::last_write_time (wpath, time);
 #else
     boost::filesystem::last_write_time (path, time);
@@ -355,7 +355,7 @@ Filesystem::convert_native_arguments (int argc, const char *argv[])
         return;
 
     for (int i = 0; i < argc; i++) {
-        std::string utf8_arg = string_windows_native_to_utf8 (native_argv[i]);
+        std::string utf8_arg = path_from_windows_native (native_argv[i]);
         argv[i] = ustring (utf8_arg).c_str();
     }
 #endif

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -361,11 +361,13 @@ TIFFInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
     }
 
     if (! m_tif) {
-        FILE *fd = Filesystem::fopen (m_filename, "rm");
-        m_tif = (fd) ? TIFFFdOpen (fileno (fd), m_filename.c_str(), "rm") : NULL;
+#ifdef _WIN32
+        std::wstring wfilename = Filesystem::path_to_windows_native (m_filename);
+        m_tif = TIFFOpenW (wfilename.c_str(), "rm");
+#else
+        m_tif = TIFFOpen (m_filename.c_str(), "rm");
+#endif
         if (m_tif == NULL) {
-            if (fd)
-                fclose (fd);
             error ("Could not open file: %s",
                    lasterr.length() ? lasterr.c_str() : m_filename.c_str());
             return false;
@@ -758,8 +760,12 @@ TIFFInput::readspec (bool read_meta)
         // I'm not sure what state TIFFReadEXIFDirectory leaves us.
         // So to be safe, close and re-seek.
         TIFFClose (m_tif);
-        FILE *fd = Filesystem::fopen (m_filename, "rm");
-        m_tif = (fd) ? TIFFFdOpen (fileno (fd), m_filename.c_str(), "rm"): NULL;
+#ifdef _WIN32
+        std::wstring wfilename = Filesystem::path_to_windows_native (m_filename);
+        m_tif = TIFFOpenW (wfilename.c_str(), "rm");
+#else
+        m_tif = TIFFOpen (m_filename.c_str(), "rm");
+#endif
         TIFFSetDirectory (m_tif, m_subimage);
 
         // A few tidbits to look for


### PR DESCRIPTION
This moves platform specific code outside of the filesystem module and into the tiff plugin code, which I had tried to avoid, but it should be safer than trying to obtain the right file handle.
