### PR TITLE
Fix uninitialized memory in Sysutil::this_program_path

### DIFF
--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -152,6 +152,8 @@ Sysutil::this_program_path ()
 
 #if defined(__linux__)
     int r = readlink ("/proc/self/exe", filename, size);
+    ASSERT(r < int(size)); // user won't get the right answer if the filename is too long to store
+    if (r > 0) filename[r] = 0; // readlink does not fill in the 0 byte
 #elif defined(__APPLE__)
     // For info:  'man 3 dyld'
     int r = _NSGetExecutablePath (filename, &size);


### PR DESCRIPTION
`readlink` does not write a trailing 0 into the buffer it fills
