### PR TITLE
Review: Fix allocation and stride bugs in ImageInput::read_tiles.

### DIFF
--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -232,8 +232,8 @@ ImageInput::read_scanlines (int ybegin, int yend, int z,
                 TypeDesc chanformat = m_spec.channelformats[c+firstchan];
                 ok = convert_image (1 /* channels */, m_spec.width, nscanlines, 1, 
                                     &buf[offset], chanformat, 
-                                    pixel_bytes, AutoStride, AutoStride,
-                                    (char *)data + c*m_spec.format.size(),
+                                    native_pixel_bytes, native_scanline_bytes, 0,
+                                    (char *)data + c*format.size(),
                                     format, xstride, ystride, zstride);
                 offset += chanformat.size ();
             }

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -415,6 +415,8 @@ ImageCacheFile::open (ImageCachePerThreadInfo *thread_info)
                 invalidate_spec ();
                 return false;
             }
+            // ImageCache can't store differing formats per channel
+            tempspec.channelformats.clear();
             LevelInfo levelinfo (tempspec, nativespec);
             si.levels.push_back (levelinfo);
             ++nmip;

--- a/testsuite/openexr-suite/ref/out.txt
+++ b/testsuite/openexr-suite/ref/out.txt
@@ -66,7 +66,7 @@ Comparing "../../../../../openexr-images-1.5.0/ScanLines/Tree.exr" and "Tree.exr
 PASS
 Reading ../../../../../openexr-images-1.5.0/ScanLines/Blobbies.exr
 ../../../../../openexr-images-1.5.0/ScanLines/Blobbies.exr : 1040 x 1040, 5 channel, half/half/half/half/float openexr
-    SHA-1: 1D3D059692BB2074264393AA2B04D3E60DC52BDC
+    SHA-1: 64C3C765E0D40AA92E066F6EC9198A8053BF1179
     channel list: R (half), G (half), B (half), A (half), Z (float)
     pixel data origin: x=-20, y=-20
     full/display size: 1000 x 1000


### PR DESCRIPTION
When reading tiled images, where the image is not a whole number of tiles,
this bug could misallocate and run off the end of the buffer while dealing
with the partial tiles on the right or bottom edge of the image.
