### PR TITLE
Review: Bug fix when reading vector Field3D files.

### DIFF
--- a/src/field3d.imageio/field3dinput.cpp
+++ b/src/field3d.imageio/field3dinput.cpp
@@ -355,8 +355,8 @@ void Field3DInput::read_layers (TypeDesc datatype)
                 lay.fieldtype = MAC;
             else
                 ASSERT (0 && "unknown field type");
-            read_one_layer (*i, lay, datatype, layernum);
             lay.vecfield = true;
+            read_one_layer (*i, lay, datatype, layernum);
         }
     }
 }


### PR DESCRIPTION
read_one_layer would net set up the channels correctly if lay.vecfield=true
was not set up before its call.

Minor buglet for reading certain f3d files.
