### PR TITLE
Review: Move the put_in_background() function from iv private into sysutil.

### DIFF
--- a/src/include/sysutil.h
+++ b/src/include/sysutil.h
@@ -78,6 +78,13 @@ DLLPUBLIC void usleep (unsigned long useconds);
 /// figure it out.
 DLLPUBLIC int terminal_columns ();
 
+/// Try to put the process into the background so it doesn't continue to
+/// tie up any shell that it was launched from.  The arguments are the
+/// argc/argv that describe the program and its command line arguments.
+/// Return true if successful, false if it was unable to do so.
+DLLPUBLIC bool put_in_background (int argc, char* argv[]);
+
+
 };  // namespace Sysutils
 
 }

--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -101,92 +101,13 @@ getargs (int argc, char *argv[])
 
 
 
-/// Try to put the process into the background so it doesn't continue to
-/// tie up any shell that it was launched from.  Return true if successful,
-/// false if it was unable to do so.
-static bool
-#if !defined(_MSC_VER)
-put_in_background (int argc, char* argv[])
-#else
-put_in_background (int, char* [])
-#endif
-{
-    // You would think that this would be sufficient:
-    //   pid_t pid = fork ();
-    //   if (pid < 0)       // Some kind of error, we were unable to background
-    //      return false;
-    //   if (pid == 0)
-    //       return true;   // This is the child process, so continue with life
-    //   // Otherwise, this is the parent process, so terminate
-    //   exit (0); 
-    // But it's not.  On OS X, it's not safe to fork() if your app is linked
-    // against certain libraries or frameworks.  So the only thing that I
-    // think is safe is to exec a new process.
-    // Another solution is this:
-    //    daemon (1, 1);
-    // But it suffers from the same problem on OS X, and seems to just be
-    // a wrapper for fork.
-
-#if defined(__linux) || defined(__GLIBC__)
-    // Simplest case:
-    daemon (1, 1);
-    return true;
-#endif
-
-
-#ifdef __APPLE__
-#if 0
-    // Another solution -- But I can't seem to make this work!
-    std::vector<char *> newargs;
-    newargs.push_back ("-F");
-    for (int i = 0;  i < argc;  ++i)
-        newargs.push_back (argv[i]);
-    newargs.push_back (NULL);
-    if (fork())
-        exit (0);
-    execv ("/Users/lg/lg/proj/oiio/dist/macosx/bin/iv" /*argv[0]*/, &newargs[0]);
-    exit (0);
-#endif
-
-#if 1
-    // This one works -- just call system(), but we have to properly
-    // quote all the arguments in case filenames have spaces in them.
-    std::string newcmd = std::string(argv[0]) + " -F";
-    for (int i = 1;  i < argc;  ++i) {
-        newcmd += " \"";
-        newcmd += argv[i];
-        newcmd += "\"";
-    }
-    newcmd += " &";
-    if (system (newcmd.c_str()) != -1)
-        exit (0);
-    return true;
-#endif
-
-
-#endif
-
-#ifdef WIN32
-    // if we are not in DEBUG mode this code switch the IV to
-    // full windowed mode (no console and no need to define WinMain)
-    // FIXME: this should be done in CMakeLists.txt but first we have to
-    // fix Windows Debug build
-# ifndef DEBUG
-#  pragma comment(linker, "/subsystem:windows /entry:mainCRTStartup")
-# endif
-    return true;
-#endif
-}
-
-
-
 int
 main (int argc, char *argv[])
 {
     getargs (argc, argv);
 
     if (! foreground_mode)
-        put_in_background (argc, argv);
+        Sysutil::put_in_background (argc, argv);
 
     // LG
 //    Q_INIT_RESOURCE(iv);


### PR DESCRIPTION
Just moving code around.  Seems to me that this belongs in sysutil.h.
