### PR TITLE
Image Processing Operation: Invert

### DIFF
--- a/src/include/imagebuf.h
+++ b/src/include/imagebuf.h
@@ -52,6 +52,66 @@
 OIIO_NAMESPACE_ENTER
 {
 
+class ImageBuf;
+
+
+
+class ROI {
+public:
+    int xbegin, xend, ybegin, yend, zbegin, zend;
+    bool defined;
+
+    // Undefined region.
+    ROI () : defined(false) { }
+
+    // Region explicitly defined.
+    ROI (int xbegin, int xend, int ybegin, int yend, int zbegin, int zend)
+        : xbegin(xbegin), xend(xend), ybegin(ybegin), yend(yend),
+          zbegin(zbegin), zend(zend), defined(true)
+    { }
+
+    // Region dimensions.
+    int width () const { return xend - xbegin; }
+    int height () const { return yend - ybegin; }
+    int depth () const { return zend - zbegin; }
+
+    // Region operations.
+    friend ROI roi_union (const ROI &A, const ROI &B);
+    friend ROI roi_intersection (const ROI &A, const ROI &B);
+};
+
+
+
+/// Union of two regions, the smallest region containing both.
+ROI roi_union (const ROI &A, const ROI &B);
+
+
+
+/// Intersection of two regions.
+ROI roi_intersection (const ROI &A, const ROI &B);
+
+
+
+/// Return pixel data window for this ImageSpec as a ROI.
+ROI get_roi (const ImageSpec &spec);
+
+
+
+/// Return full/display window for this ImageSpec as a ROI.
+ROI get_roi_full (const ImageSpec &spec);
+
+
+
+/// Set pixel data window for this ImageSpec to a ROI.
+void set_roi (ImageSpec &spec, const ROI &newroi);
+
+
+
+/// Set full/display window for this ImageSpec to a ROI.
+void set_roi_full (ImageSpec &spec, const ROI &newroi);
+
+
+
 /// An ImageBuf is a simple in-memory representation of a 2D image.  It
 /// uses ImageInput and ImageOutput underneath for its file I/O, and has
 /// simple routines for setting and getting individual pixels, that
@@ -424,6 +484,8 @@ public:
     /// aren't local.
     void *pixeladdr (int x, int y, int z);
 
+    /// Is this ImageBuf object initialized?
+    bool initialized () const { return m_spec_valid || m_pixels_valid; }
 
     /// Templated class for referring to an individual pixel in an
     /// ImageBuf, iterating over the pixels of an ImageBuf, or iterating
@@ -478,6 +540,20 @@ public:
             m_rng_yend   = std::min (yend,   m_img_yend);
             m_rng_zbegin = std::max (zbegin, m_img_zbegin);
             m_rng_zend   = std::min (zend,   m_img_zend);
+            pos (m_rng_xbegin, m_rng_ybegin, m_rng_zbegin);
+        }
+        /// Construct read-write clamped valid iteration region from
+        /// ImageBuf and ROI.
+        Iterator (ImageBuf &ib, const ROI &roi)
+            : m_ib(&ib), m_tile(NULL)
+        {
+            init_ib ();
+            m_rng_xbegin = std::max (roi.xbegin, m_img_xbegin);
+            m_rng_xend   = std::min (roi.xend,   m_img_xend);
+            m_rng_ybegin = std::max (roi.ybegin, m_img_ybegin);
+            m_rng_yend   = std::min (roi.yend,   m_img_yend);
+            m_rng_zbegin = std::max (roi.zbegin, m_img_zbegin);
+            m_rng_zend   = std::min (roi.zend,   m_img_zend);
             pos (m_rng_xbegin, m_rng_ybegin, m_rng_zbegin);
         }
         /// Construct from an ImageBuf and designated region -- iterate
@@ -743,6 +819,20 @@ public:
             m_rng_yend   = std::min (yend,   m_img_yend);
             m_rng_zbegin = std::max (zbegin, m_img_zbegin);
             m_rng_zend   = std::min (zend,   m_img_zend);
+            pos (m_rng_xbegin, m_rng_ybegin, m_rng_zbegin);
+        }
+        /// Construct read-only clamped valid iteration region
+        /// from ImageBuf and ROI.
+        ConstIterator (ImageBuf &ib, const ROI &roi)
+            : m_ib(&ib), m_tile(NULL)
+        {
+            init_ib ();
+            m_rng_xbegin = std::max (roi.xbegin, m_img_xbegin);
+            m_rng_xend   = std::min (roi.xend,   m_img_xend);
+            m_rng_ybegin = std::max (roi.ybegin, m_img_ybegin);
+            m_rng_yend   = std::min (roi.yend,   m_img_yend);
+            m_rng_zbegin = std::max (roi.zbegin, m_img_zbegin);
+            m_rng_zend   = std::min (roi.zend,   m_img_zend);
             pos (m_rng_xbegin, m_rng_ybegin, m_rng_zbegin);
         }
         /// Construct from an ImageBuf and designated region -- iterate

--- a/src/include/imagebufalgo.h
+++ b/src/include/imagebufalgo.h
@@ -305,6 +305,13 @@ bool DLLPUBLIC capture_image (ImageBuf &dst, int cameranum = 0,
                               TypeDesc convert=TypeDesc::UNKNOWN);
 
 
+
+bool DLLPUBLIC invert (ImageBuf &R, const ImageBuf &A,
+                        bool* channels_mask = NULL, ROI roi = ROI(),
+                        int nthreads = -1);
+
+
+
 };  // end namespace ImageBufAlgo
 
 

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -50,6 +50,68 @@
 OIIO_NAMESPACE_ENTER
 {
 
+
+
+ROI get_roi (const ImageSpec &spec)
+{
+    return ROI (spec.x, spec.x + spec.width,
+                spec.y, spec.y + spec.height,
+                spec.z, spec.z + spec.depth);
+}
+
+
+
+ROI get_roi_full (const ImageSpec &spec)
+{
+    return ROI (spec.full_x, spec.full_x + spec.full_width,
+                spec.full_y, spec.full_y + spec.full_height,
+                spec.full_z, spec.full_z + spec.full_depth);
+}
+
+
+
+void set_roi (ImageSpec &spec, const ROI &newroi)
+{
+    spec.x = newroi.xbegin;
+    spec.y = newroi.ybegin;
+    spec.z = newroi.zbegin;
+    spec.width = newroi.width();
+    spec.height = newroi.height();
+    spec.depth = newroi.depth();
+}
+
+
+
+void set_roi_full (ImageSpec &spec, const ROI &newroi)
+{
+    spec.full_x = newroi.xbegin;
+    spec.full_y = newroi.ybegin;
+    spec.full_z = newroi.zbegin;
+    spec.full_width = newroi.width();
+    spec.full_height = newroi.height();
+    spec.full_depth = newroi.depth();
+}
+
+
+
+ROI roi_union (const ROI &A, const ROI &B)
+{
+    return ROI (std::min (A.xbegin, B.xbegin), std::max (A.xend, B.xend),
+                std::min (A.ybegin, B.ybegin), std::max (A.yend, B.yend),
+                std::min (A.zbegin, B.zbegin), std::max (A.zend, B.zend));
+}
+
+
+
+ROI roi_intersection (const ROI &A, const ROI &B)
+{
+    return ROI (std::max (A.xbegin, B.xbegin), std::min (A.xend, B.xend),
+                std::max (A.ybegin, B.ybegin), std::min (A.yend, B.yend),
+                std::max (A.zbegin, B.zbegin), std::min (A.zend, B.zend));
+}
+
+
+
 ImageBuf::ImageBuf (const std::string &filename,
                     ImageCache *imagecache)
     : m_name(filename), m_nsubimages(0),

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1396,6 +1396,46 @@ action_fixnan (int argc, const char *argv[])
 
 
 
+bool*
+channels_mask_from_string (std::string channels_mask_string)
+{
+    int size = channels_mask_string.size();
+    bool* channels_mask = new bool[size];
+    for (int i = 0; i < size; ++i) {
+        channels_mask[i] = (channels_mask_string[i] == '1') ? true : false;
+    }
+    return channels_mask;
+}
+
+
+
+static int
+action_invert (int argc, const char *argv[])
+{
+    if (ot.postpone_callback (1, action_invert, argc, argv)) { return 0; }
+
+    // Get input image A.
+    ot.read ();
+    ImageRecRef A = ot.pop();
+    const ImageBuf &Aib ((*A)());
+    const ImageSpec &specA = Aib.spec();
+
+    // Get output image R.
+    ot.push (new ImageRec ("irec", specA, ot.imagecache));
+    ImageBuf &Rib ((*ot.curimg)());
+
+    // Get arguments from command line.
+    std::string channels_mask_string = argv[1];
+    bool* channels_mask = channels_mask_from_string (channels_mask_string);
+
+    ImageBufAlgo::invert (Rib, Aib, channels_mask);
+
+    delete channels_mask;
+    return 0;
+}
+
+
+
 static void
 getargs (int argc, char *argv[])
 {
@@ -1488,6 +1528,7 @@ getargs (int argc, char *argv[])
                     "Convert the current image's pixels to a named color space",
                 "--colorconvert %@ %s %s", action_colorconvert, NULL, NULL,
                     "Convert pixels from 'src' to 'dst' color space (without regard to its previous interpretation)",
+                "--invert %@ %s", action_invert, NULL, "Invert the image",
                 NULL);
 
     if (ap.parse(argc, (const char**)argv) < 0) {


### PR DESCRIPTION
The code is similar to previous operations.

Please ignore the common code like the ROI class and parallel_image.

I had to copy common code like this, to keep it simple for now, both
in terms of branches organization and compile time.

So you can ignore imagebuf.h and imagebuf.cpp, nothing new there.
