### PR TITLE
adjust OpenEXR cmake module to find newer versions of library

### DIFF
--- a/src/cmake/modules/FindOpenEXR.cmake
+++ b/src/cmake/modules/FindOpenEXR.cmake
@@ -141,7 +141,7 @@ list (APPEND OpenEXR_library_paths ${OpenEXR_generic_library_paths})
 
 # Locate the header files
 PREFIX_FIND_INCLUDE_DIR (OpenEXR
-  OpenEXR/OpenEXRConfig.h OpenEXR_include_paths)
+  OpenEXR/ImfArray.h OpenEXR_include_paths)
 
 # If the headers were found, add its parent to the list of lib directories
 if (OPENEXR_INCLUDE_DIR)

--- a/src/cmake/util_macros.cmake
+++ b/src/cmake/util_macros.cmake
@@ -67,11 +67,9 @@ macro (setup_string name defaultval explanation)
         # If there's an environment variable of the same name that's
         # nonempty, use the env variable.  Otherwise, use the default.
         if (NOT $ENV{${name}} STREQUAL "")
-            set (${name} $ENV{${name}})
-                  # CACHE STRING ${explanation})
+            set (${name} $ENV{${name}} CACHE STRING ${explanation})
         else ()
-            set (${name} ${defaultval})
-                  # CACHE STRING ${explanation})
+            set (${name} ${defaultval} CACHE STRING ${explanation})
         endif ()
     endif ()
     message (STATUS "${name} = ${${name}}")


### PR DESCRIPTION
make OPENEXR_VERSION and ILMBASE_VERSION available in cmake-gui to allow input of newer OpenEXR versions (like 1.7.1 and potentially 2.0)
change FindOpenEXR.cmake so it would also find the includes with newer versions of OpenEXR - OpenEXRConfig.h is not included in newer OpenEXR deployments

Changes tested with Windows 7 x64 and CentOS 6.2 x86.
