### PR TITLE
Review: Make IBA::over() support only float buffers -- faster compilation and simpler source

### DIFF
--- a/src/include/imagebufalgo.h
+++ b/src/include/imagebufalgo.h
@@ -309,7 +309,8 @@ bool DLLPUBLIC capture_image (ImageBuf &dst, int cameranum = 0,
 
 /// Set R to the composite of A over B using the Porter/Duff definition
 /// of "over", returning true upon success and false for any of a
-/// variety of failures (as described below).
+/// variety of failures (as described below).  All three buffers must
+/// have 'float' pixel data type.
 ///
 /// A and B must have valid alpha channels identified by their ImageSpec
 /// alpha_channel field, with the following two exceptions: (a) a


### PR DESCRIPTION
Make IBA::over() support only float buffers -- faster compilation and simpler source.

But internally, there is still a type-specialized template supplying the
guts of the algorithm, so in the future, we could expose it if there's demand,
or of course anybody may copy that template to their app if they are allergic
to float ImageBuf's.

I'm aware that Jeremy thinks we shouldn't do the template at all, but I think I
like it better this way, it will pay off many times over if anybody ever really
wishes the functions worked on other buffer types for some application, all they
would have to do is copy the template to their app.

I will eventually scrub the rest of ImageBufAlgo to make the rest of the functions
conform to this idiom.  But there's no particular rush, I'll get to it when I have some
free time.
