### PR TITLE
Open PNM files in binary mode

### DIFF
--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -352,7 +352,7 @@ PNMInput::open (const std::string &name, ImageSpec &newspec)
     if (m_file.is_open()) //close previously opened file
         m_file.close();
 
-    Filesystem::open (m_file, name);
+    Filesystem::open (m_file, name, std::ios::in|std::ios::binary);
 
     m_current_line = "";
     m_pos = m_current_line.c_str();


### PR DESCRIPTION
In ascii mode, the "pnm.imageio" plugin sometimes fails to read binary
format PNM files (when it encounters an unsigned char of value EOF).
Conversely, reading ascii format PNM files in binary mode is OK.
