### PR TITLE
Minor fixes for Over

### DIFF
--- a/src/include/imagebuf.h
+++ b/src/include/imagebuf.h
@@ -818,7 +818,7 @@ public:
         }
         /// Construct read-only clamped valid iteration region
         /// from ImageBuf and ROI.
-        ConstIterator (ImageBuf &ib, const ROI &roi)
+        ConstIterator (const ImageBuf &ib, const ROI &roi)
             : m_ib(&ib), m_tile(NULL)
         {
             init_ib ();

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -1225,6 +1225,13 @@ ImageBufAlgo::over (ImageBuf &R, const ImageBuf &A, const ImageBuf &B, ROI roi,
     int non_alpha_B = has_alpha_B ? (channels_B - 1) : 3;
     bool B_not_34 = channels_B != 3 && channels_B != 4;
 
+    // At present, this operation only supports ImageBuf's containing
+    // float pixel data.
+    if (R.spec().format != TypeDesc::TypeFloat ||
+        A.spec().format != TypeDesc::TypeFloat ||
+        B.spec().format != TypeDesc::TypeFloat)
+        return false;
+
     // Fail if the input images have a Z channel.
     if (specA.z_channel >= 0 || specB.z_channel >= 0)
         return false;
@@ -1275,14 +1282,7 @@ ImageBufAlgo::over (ImageBuf &R, const ImageBuf &A, const ImageBuf &B, ROI roi,
     // Specified ROI -> use it. Unspecified ROI -> initialize from R.
     if (! roi.defined) {
         roi = get_roi (R.spec());
-    }
-
-    // At present, this operation only supports ImageBuf's containing
-    // float pixel data.
-    if (R.spec().format != TypeDesc::TypeFloat ||
-        A.spec().format != TypeDesc::TypeFloat ||
-        B.spec().format != TypeDesc::TypeFloat)
-        return false;
+    }    
 
     parallel_image (boost::bind (over_impl<float,float,float>, boost::ref(R),
                                  boost::cref(A), boost::cref(B), _1),


### PR DESCRIPTION
Two fixes:
1. In imagebuf.h the const iterator
   was taking non-const ImageBuf so I fixed that.
2. I moved the type checking code in ImageBufAlgo::over
   at the top of the function, no need to come at the
   end of the function to realize types are wrong.
