### PR TITLE
Fix for quantize

### DIFF
--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -164,7 +164,7 @@ inline int
 quantize (float value, float quant_black, float quant_white,
           int quant_min, int quant_max)
 {
-    value = Imath::lerp (quant_black, quant_white, value);
+    value = Imath::lerp ((float)quant_black, (float)quant_white, value);
     return Imath::clamp ((int)(value + 0.5f), quant_min, quant_max);
 }
 


### PR DESCRIPTION
Some Arnold users had noticed problems when resizing textures with maketx. This showed as quantization errors where instead of an expected constant field of 255s, some 254s would be sprinkled in.

The problem was coming from quantize. Quantize was calling int Imath::lerp(int, int, float), returning a truncated integer, instead of a float. for instance, 0.999999 would lerp to 254

Changing that call to float Imath::lerp(float, float, float) preserves precision before the final quantization step.

r
