### PR TITLE
Correction to fill_channels when a monochrome image with alpha is read into an RGBA buffer

### DIFF
--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -499,7 +499,7 @@ TextureSystemImpl::environment (TextureHandle *texture_handle_,
     ++stats.aniso_queries;
 
     if (actualchannels < options.nchannels)
-        fill_channels (spec.nchannels, options, result);
+        fill_channels (spec, options, result);
 
     return ok;
 }

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -186,7 +186,7 @@ TextureSystemImpl::texture3d (TextureHandle *texture_handle_,
     bool ok = (this->*lookup) (*texturefile, thread_info, options,
                                Plocal, dPdx, dPdy, dPdz, result);
     if (actualchannels < options.nchannels)
-        fill_channels (spec.nchannels, options, result);
+        fill_channels (spec, options, result);
     return ok;
 
 

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -414,7 +414,7 @@ private:
 
     /// Correctly fill in channels that were requested but not present
     /// in the file.
-    void fill_channels (int nfilechannels, TextureOpt &options, float *result);
+    void fill_channels (const ImageSpec &spec, TextureOpt &options, float *result);
 
     typedef bool (*wrap_impl) (int &coord, int origin, int width);
     static bool wrap_black (int &coord, int origin, int width);

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -597,17 +597,42 @@ TextureSystemImpl::missing_texture (TextureOpt &options, float *result)
 
 
 void
-TextureSystemImpl::fill_channels (int nfilechannels, TextureOpt &options,
+TextureSystemImpl::fill_channels (const ImageSpec &spec, TextureOpt &options,
                                   float *result)
 {
     // Starting channel to deal with is the first beyond what we actually
     // got from the texture lookup.
     int c = options.actualchannels;
 
-    // Special case: multi-channel texture reads from single channel
-    // files propagate their grayscale value to G and B.
-    if (nfilechannels == 1 && m_gray_to_rgb && 
-            options.firstchannel == 0 && options.nchannels >= 3) {
+    bool save_alpha = false;
+
+    // Multi-channel texture reads from single channel files will
+    // propagate their grayscale value to G and B (no alpha)
+    bool propagate = (spec.nchannels == 1 &&
+                      m_gray_to_rgb &&
+                      options.firstchannel == 0 && options.nchannels >= 3);
+
+    // When reading monochrome images with alpha into a 4
+    // channel result, move the alpha to the last position (CCCA)
+    if (spec.nchannels == 2 && spec.alpha_channel == 1 &&
+        m_gray_to_rgb &&
+        options.firstchannel == 0 && options.nchannels == 4) {
+        // Save alpha
+        result[3] = result[1];
+        if (options.dresultds)
+            options.dresultds[3] = options.dresultds[1];
+        if (options.dresultdt)
+            options.dresultdt[3] = options.dresultdt[1];
+        if (options.dresultdr)
+            options.dresultdr[3] = options.dresultdr[1];
+        // And we will propagate monochrome to G and B
+        propagate = true;
+        // And save the alpha
+        save_alpha = true;
+    }
+
+    // Propagate to G and B if needed
+    if (propagate) {
         result[1] = result[0];
         result[2] = result[0];
         if (options.dresultds) {
@@ -622,7 +647,7 @@ TextureSystemImpl::fill_channels (int nfilechannels, TextureOpt &options,
             options.dresultdr[1] = options.dresultdr[0];
             options.dresultdr[2] = options.dresultdr[0];
         }
-        c = 3; // we're done with channels 0-2, work on 3 next
+        c = 3 + save_alpha;
     }
 
     // Fill in the remaining files with the fill color
@@ -721,7 +746,7 @@ TextureSystemImpl::texture (TextureHandle *texture_handle_,
     bool ok = (this->*lookup) (*texturefile, thread_info, options,
                                s, t, dsdx, dtdx, dsdy, dtdy, result);
     if (actualchannels < options.nchannels)
-        fill_channels (spec.nchannels, options, result);
+        fill_channels (spec, options, result);
     return ok;
 }
 


### PR DESCRIPTION
(Please check arnold trac #2627 for sample cases)

Some Arnold users trying to use monochrome images with alpha were getting colors into their renders.

When reading a monochrome image into a 4 channel RGBA buffer, fill_channels would correctly return CCCF (where C is the original gray channel and F is options.fill value)

But when reading a monochrome image with alpha, it was turning a CA image into CAFF (where A is the original alpha)

This proposed fix conforms a CA image into CCCA when CA is read into an RGBA buffer. 

Note it also changes the method signature to be able to determine if the read file had alpha or not.
