### PR TITLE
Review: Move mutex out of imagebuf definition

### DIFF
--- a/src/include/imagebuf.h
+++ b/src/include/imagebuf.h
@@ -47,7 +47,6 @@
 #include "fmath.h"
 #include "imagecache.h"
 #include "dassert.h"
-#include "thread.h"
 
 
 OIIO_NAMESPACE_ENTER
@@ -1101,7 +1100,6 @@ protected:
     bool m_pixels_valid;         ///< Image is valid
     bool m_badfile;              ///< File not found
     mutable std::string m_err;   ///< Last error message
-    spin_mutex m_err_mutex;      ///< Protect m_err
     int m_orientation;           ///< Orientation of the image
     float m_pixelaspect;         ///< Pixel aspect ratio of the image
     ImageCache *m_imagecache;    ///< ImageCache to use

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -256,10 +256,13 @@ ImageBuf::operator= (const ImageBuf &src)
 
 
 
+static spin_mutex err_mutex;      ///< Protect m_err fields
+
+
 bool
 ImageBuf::has_error () const
 {
-    spin_lock lock (*(spin_mutex *)&m_err_mutex);
+    spin_lock lock (err_mutex);
     return ! m_err.empty();
 }
 
@@ -268,7 +271,7 @@ ImageBuf::has_error () const
 std::string
 ImageBuf::geterror (void) const
 {
-    spin_lock lock (*(spin_mutex *)&m_err_mutex);
+    spin_lock lock (err_mutex);
     std::string e = m_err;
     m_err.clear();
     return e;
@@ -279,7 +282,7 @@ ImageBuf::geterror (void) const
 void
 ImageBuf::append_error (const std::string &message) const
 {
-    spin_lock lock (*(spin_mutex *)&m_err_mutex);
+    spin_lock lock (err_mutex);
     ASSERT (m_err.size() < 1024*1024*16 &&
             "Accumulated error messages > 16MB. Try checking return codes!");
     if (m_err.size() && m_err[m_err.size()-1] != '\n')


### PR DESCRIPTION
Change recent ImageBuf addition -- I don't like spin_mutex being in the public
definition of ImageBuf.  Move the mutex to be static in imagebuf.cpp, not in
the header.  That also eliminates the need for imagebuf.h to include thread.h.
