### PR TITLE
Change threads.h to set USE_TBB=0 if undefined.

### DIFF
--- a/src/include/thread.h
+++ b/src/include/thread.h
@@ -69,7 +69,7 @@
 #endif
 
 #ifndef USE_TBB
-#  define USE_TBB 1
+#  define USE_TBB 0
 #endif
 
 // Include files we need for atomic counters.


### PR DESCRIPTION
This doesn't actually change anything about the OIIO build -- the
CMakeLists.txt still defaults to USE_TBB=1.  But if thread.h is used
by another application, this will make it "safe" regardless of whether
OIIO was built with or without TBB (the other app will fall back to our
intrinsics, unless they explicitly set USE_TBB=1, which they should only
do if they are confident that OIIO was also compiled that way).

This just makes it easier for other apps to use our threads.h and be oblivious about TBB.
