### PR TITLE
Bring certain filtering trunk fixes to 0.10.x

### DIFF
--- a/src/include/fmath.h
+++ b/src/include/fmath.h
@@ -1030,6 +1030,12 @@ safe_acosf (float x) {
 
 
 
+inline float
+safe_sqrtf (float x) {
+    return (x > 0.0f) ? sqrtf(x) : 0.0f;
+}
+
+
 
 /// Solve for the x for which func(x) == y on the interval [xmin,xmax].
 /// Use a maximum of maxiter iterations, and stop any time the remaining


### PR DESCRIPTION
This is a patch as concise as possible to bring into 0.10.x some fixes from the main line.

Specifically those in pull requests 417 and 422 that have to do with using the major ellipse axis for sampling, and some additional changes to improve numerical stability.
