### PR TITLE
allow non power of two tiles, and correct code for all filters

### DIFF
--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -1274,10 +1274,8 @@ TextureSystemImpl::accum_sample_closest (float s, float t, int miplevel,
         return true;
     }
 
-    int tilewidthmask  = spec.tile_width  - 1;  // e.g. 63
-    int tileheightmask = spec.tile_height - 1;
-    int tile_s = (stex - spec.x) & tilewidthmask;
-    int tile_t = (ttex - spec.y) & tileheightmask;
+    int tile_s = (stex - spec.x) % spec.tile_width;
+    int tile_t = (ttex - spec.y) % spec.tile_height;
     TileID id (texturefile, options.subimage, miplevel,
                stex - tile_s, ttex - tile_t, 0);
     bool ok = find_tile (id, thread_info);
@@ -1354,8 +1352,8 @@ TextureSystemImpl::accum_sample_bilinear (float s, float t, int miplevel,
     const unsigned char *texel[2][2];
     TileRef savetile[2][2];
     static float black[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
-    int tile_s = (stex[0] - spec.x) & tilewidthmask;
-    int tile_t = (ttex[0] - spec.y) & tileheightmask;
+    int tile_s = (stex[0] - spec.x) % spec.tile_width;
+    int tile_t = (ttex[0] - spec.y) % spec.tile_height;
     bool s_onetile = (tile_s != tilewidthmask) & (stex[0]+1 == stex[1]);
     bool t_onetile = (tile_t != tileheightmask) & (ttex[0]+1 == ttex[1]);
     bool onetile = (s_onetile & t_onetile);
@@ -1398,8 +1396,8 @@ TextureSystemImpl::accum_sample_bilinear (float s, float t, int miplevel,
                     texel[j][i] = (unsigned char *)black;
                     continue;
                 }
-                tile_s = (stex[i] - spec.x) & tilewidthmask;
-                tile_t = (ttex[j] - spec.y) & tileheightmask;
+                tile_s = (stex[i] - spec.x) % spec.tile_width;
+                tile_t = (ttex[j] - spec.y) % spec.tile_height;
                 TileID id (texturefile, options.subimage, miplevel,
                            stex[i] - tile_s, ttex[j] - tile_t, 0);
                 bool ok = find_tile (id, thread_info);
@@ -1567,8 +1565,9 @@ TextureSystemImpl::accum_sample_bicubic (float s, float t, int miplevel,
     static float black[4] = { 0, 0, 0, 0 };
     int tilewidthmask  = spec.tile_width  - 1;  // e.g. 63
     int tileheightmask = spec.tile_height - 1;
-    int tile_s = (stex[0] - spec.x) & tilewidthmask;
-    int tile_t = (ttex[0] - spec.y) & tileheightmask;
+    int tile_s = (stex[0] - spec.x) % spec.tile_width;
+    int tile_t = (ttex[0] - spec.y) % spec.tile_height;
+
     bool s_onetile = (tile_s <= tilewidthmask-3);
     bool t_onetile = (tile_t <= tileheightmask-3);
     if (s_onetile && t_onetile) {
@@ -1607,8 +1606,8 @@ TextureSystemImpl::accum_sample_bicubic (float s, float t, int miplevel,
                     continue;
                 }
                 int stex_i = stex[i];
-                tile_s = (stex_i - spec.x) & tilewidthmask;
-                tile_t = (ttex[j] - spec.y) & tileheightmask;
+                tile_s = (stex_i - spec.x) % spec.tile_width;
+                tile_t = (ttex[j] - spec.y) % spec.tile_height;
                 TileID id (texturefile, options.subimage, miplevel,
                            stex_i - tile_s, ttex[j] - tile_t, 0);
                 bool ok = find_tile (id, thread_info);


### PR DESCRIPTION
Could we backport this to the 0.10.x line? Fixes ticket #2853 in the Arnold trac.

This is part of commit a35fdcda2de "TextureSystem: allow subimages specified by name, and alllow tile sizes to be non-pow2."

IMPORTANT NOTE! this has an additional fix for nearest_filter that is missing from master!
