### PR TITLE
ImageBufAlgo::compare and idiff improvements.

### DIFF
--- a/src/include/imagebufalgo.h
+++ b/src/include/imagebufalgo.h
@@ -221,7 +221,7 @@ bool DLLPUBLIC computePixelStats (PixelStats &stats, const ImageBuf &src);
 struct CompareResults {
     double meanerror, rms_error, PSNR, maxerror;
     int maxx, maxy, maxz, maxc;
-    int nwarn, nfail;
+    imagesize_t nwarn, nfail;
 };
 
 /// Numerically compare two images.  The images must be the same size

--- a/src/include/unittest.h
+++ b/src/include/unittest.h
@@ -53,6 +53,14 @@ static int unit_test_failures = 0;
              << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
             (void)++unit_test_failures))
 
+#define OIIO_CHECK_EQUAL_THRESH(x,y,eps)                                \
+    ((std::abs((x)-(y)) <= eps) ? ((void)0)                             \
+         : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
+             << "FAILED: " << #x << " == " << #y << "\n"                \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'"     \
+             << ", diff was " << std::abs((x)-(y)) << "\n"),            \
+            (void)++unit_test_failures))
+
 #define OIIO_CHECK_NE(x,y)                                              \
     (((x) != (y)) ? ((void)0)                                           \
          : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -593,6 +593,11 @@ ImageBufAlgo::compare (const ImageBuf &A, const ImageBuf &B,
                        float failthresh, float warnthresh,
                        ImageBufAlgo::CompareResults &result)
 {
+    if (A.spec().format != TypeDesc::FLOAT &&
+        B.spec().format != TypeDesc::FLOAT) {
+        A.error ("ImageBufAlgo::compare only works on 'float' images.");
+        return false;
+    }
     int npels = A.spec().width * A.spec().height * A.spec().depth;
     int nvals = npels * A.spec().nchannels;
 
@@ -604,8 +609,6 @@ ImageBufAlgo::compare (const ImageBuf &A, const ImageBuf &B,
     result.maxx=0, result.maxy=0, result.maxz=0, result.maxc=0;
     result.nfail = 0, result.nwarn = 0;
     float maxval = 1.0;  // max possible value
-    ASSERT (A.spec().format == TypeDesc::FLOAT &&
-            B.spec().format == TypeDesc::FLOAT);
     ImageBuf::ConstIterator<float,float> a (A);
     ImageBuf::ConstIterator<float,float> b (B);
     // Break up into batches to reduce cancelation errors as the error

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -45,7 +45,7 @@ OIIO_NAMESPACE_USING;
 
 
 // Test ImageBuf::zero and ImageBuf::fill
-void ImageBuf_zero_fill ()
+void test_zero_fill ()
 {
     const int WIDTH = 8;
     const int HEIGHT = 6;
@@ -150,7 +150,7 @@ void test_crop ()
 
 
 // Tests ImageBufAlgo::add
-void ImageBuf_add ()
+void test_add ()
 {
     const int WIDTH = 8;
     const int HEIGHT = 8;
@@ -181,10 +181,47 @@ void ImageBuf_add ()
 
 
 
-// check if two float values match
-inline bool
-is_equal (float x, float y) {
-    return std::abs(x - y) <= 1e-05 * std::abs(x); // 1e-05
+// Tests ImageBufAlgo::compare
+void test_compare ()
+{
+    // Construct two identical 50% grey images
+    const int WIDTH = 10, HEIGHT = 10, CHANNELS = 3;
+    ImageSpec spec (WIDTH, HEIGHT, CHANNELS, TypeDesc::FLOAT);
+    ImageBuf A ("A", spec);
+    ImageBuf B ("B", spec);
+    const float grey[CHANNELS] = { 0.5, 0.5, 0.5 };
+    ImageBufAlgo::fill (A, grey);
+    ImageBufAlgo::fill (B, grey);
+
+    // Introduce some minor differences
+    const int NDIFFS = 10;
+    ImageBuf::Iterator<float> a (A);
+    for (int i = 0;  i < NDIFFS && a.valid();  ++i, ++a) {
+        for (int c = 0;  c < CHANNELS;  ++c)
+            a[c] = a[c] + 0.01f * i;
+    }
+    // We expect the differences to be { 0, 0.01, 0.02, 0.03, 0.04, 0.05,
+    // 0.06, 0.07, 0.08, 0.09, 0, 0, ...}.
+    const float failthresh = 0.05;
+    const float warnthresh = 0.025;
+    ImageBufAlgo::CompareResults comp;
+    ImageBufAlgo::compare (A, B, failthresh, warnthresh, comp);
+    // We expect 5 pixels to exceed the fail threshold, 7 pixels to
+    // exceed the warn threshold, the maximum difference to be 0.09,
+    // and the maximally different pixel to be (9,0).
+    // The total error should be 3 chans * sum{0.01,...,0.09} / (pixels*chans)
+    //   = 3 * 0.45 / (100*3) = 0.0045
+    std::cout << "Testing comparison: " << comp.nfail << " failed, "
+              << comp.nwarn << " warned, max diff = " << comp.maxerror
+              << " @ (" << comp.maxx << ',' << comp.maxy << ")\n";
+    std::cout << "   mean err " << comp.meanerror << ", RMS err " 
+              << comp.rms_error << ", PSNR = " << comp.PSNR <<  "\n";
+    OIIO_CHECK_EQUAL (comp.nfail, 5);
+    OIIO_CHECK_EQUAL (comp.nwarn, 7);
+    OIIO_CHECK_EQUAL_THRESH (comp.maxerror, 0.09, 1e-6);
+    OIIO_CHECK_EQUAL (comp.maxx, 9);
+    OIIO_CHECK_EQUAL (comp.maxy, 0);
+    OIIO_CHECK_EQUAL_THRESH (comp.meanerror, 0.0045, 1.0e-8);
 }
 
 
@@ -192,9 +229,10 @@ is_equal (float x, float y) {
 int
 main (int argc, char **argv)
 {
-    ImageBuf_zero_fill ();
+    test_zero_fill ();
     test_crop ();
-    ImageBuf_add ();
+    test_add ();
+    test_compare ();
     
     return unit_test_failures;
 }


### PR DESCRIPTION
Change the IBA::CompareResults failure and warning counts to imagesize_t so
they can't overflow int for very large images.

Have IBA::compare() give a sensible error (rather than an ASSERT) if the
images aren't float.

Add a careful unit test for IBA::compare() to imagebufalgo_test.cpp.
