### PR TITLE
Update INSTALL to add libpng requirement

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -22,7 +22,7 @@ Building OpenImageIO on Linux or OS X
 -------------------------------------
 
 The following dependencies must be installed to build the core of
-OpenImageIO: Boost, libjpeg, libtiff and OpenEXR.  These can be installed
+OpenImageIO: Boost, libjpeg, libtiff, libpng and OpenEXR.  These can be installed
 using the standard package managers on your system.  Optionally, 
 to build the image viewing tools, you will need Qt, OpenGL, and GLEW.
 


### PR DESCRIPTION
I'm trying to get up and running with OSL and OIIO on a fresh  Ubuntu Lucid VM, and was unable to compile without libpng.
