### PR TITLE
IC: Detailed per-file stats track number of tile reads per MIPmap level.

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -335,6 +335,10 @@ ImageCacheFile::open (ImageCachePerThreadInfo *thread_info)
     // of the ImageCacheFile.
     m_subimages.clear ();
     int nsubimages = 0;
+
+    // Since each subimage can potentially have its own mipmap levels,
+    // keep track of the highest level discovered
+    int maxmip = 0;
     do {
         m_subimages.resize (nsubimages+1);
         SubimageInfo &si (subimageinfo(nsubimages));
@@ -400,6 +404,7 @@ ImageCacheFile::open (ImageCachePerThreadInfo *thread_info)
             LevelInfo levelinfo (tempspec, nativespec);
             si.levels.push_back (levelinfo);
             ++nmip;
+            maxmip = std::max (nmip, maxmip);
         } while (m_input->seek_subimage (nsubimages, nmip, nativespec));
 
         // Special work for non-MIPmapped images -- but only if "automip"
@@ -444,6 +449,7 @@ ImageCacheFile::open (ImageCachePerThreadInfo *thread_info)
                 s.tile_height = pow2roundup (s.tile_height);
                 s.tile_depth = pow2roundup (s.tile_depth);
                 ++nmip;
+                maxmip = std::max (nmip, maxmip);
                 LevelInfo levelinfo (s, s);
                 si.levels.push_back (levelinfo);
             }
@@ -572,6 +578,9 @@ ImageCacheFile::open (ImageCachePerThreadInfo *thread_info)
     m_eightbit = (m_datatype == TypeDesc::UINT8);
     m_mod_time = Filesystem::last_write_time (m_filename.string());
 
+    // Set all mipmap level read counts to zero
+    m_mipreadcount.resize(maxmip, 0);
+
     DASSERT (! m_broken);
     m_validspec = true;
     return true;
@@ -608,6 +617,9 @@ ImageCacheFile::read_tile (ImageCachePerThreadInfo *thread_info,
     // Mark if we ever use a mip level that's not the first
     if (miplevel > 0)
         m_mipused = true;
+
+    // count how many times this mipmap level was read
+    m_mipreadcount[miplevel]++;
 
     SubimageInfo &subinfo (subimageinfo(subimage));
 
@@ -1354,6 +1366,13 @@ ImageCacheImpl::onefile_stat_line (const ImageCacheFileRef &file,
                 out << " MIP-UNUSED";
                 break;
             }
+    }
+    if (! file->mipreadcount().empty()) {
+        out << " MIP COUNT [";
+        int nmip = (int) file->mipreadcount().size();
+        for (int c = 0; c < nmip; c++)
+            out << (c ? "," : "") << file->mipreadcount()[c];
+        out << "]";
     }
 
     return out.str ();

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -177,6 +177,7 @@ public:
     size_t pixelsize () const { return m_pixelsize; }
     bool eightbit (void) const { return m_eightbit; }
     bool mipused (void) const { return m_mipused; }
+    const std::vector<size_t> &mipreadcount (void) const { return m_mipreadcount; }
 
     void invalidate ();
 
@@ -279,6 +280,7 @@ private:
     size_t m_timesopened;           ///< Separate times we opened this file
     double m_iotime;                ///< I/O time for this file
     bool m_mipused;                 ///< MIP level >0 accessed
+    std::vector<size_t> m_mipreadcount; ///< Tile reads per mip level
     volatile bool m_validspec;      ///< If false, reread spec upon open
     ImageCacheImpl &m_imagecache;   ///< Back pointer for ImageCache
     mutable recursive_mutex m_input_mutex; ///< Mutex protecting the ImageInput


### PR DESCRIPTION
IC: Detailed per-file stats track number of tile reads per MIPmap level.
This can help track down unusual MIPmap access patterns.
The idea and most of the code came from Thiago Ize at Solid Angle.
