### PR TITLE
Deal with texture inputs with unassociated alpha without conversion

### DIFF
--- a/src/include/imagecache.h
+++ b/src/include/imagecache.h
@@ -95,6 +95,7 @@ public:
     ///     int forcefloat : if nonzero, convert all to float.
     ///     int failure_retries : number of times to retry a read before fail.
     ///     int deduplicate : if nonzero, detect duplicate textures (default=1)
+    ///     int unassociatedalpha : if nonzero, keep unassociated alpha images
     ///
     virtual bool attribute (const std::string &name, TypeDesc type,
                             const void *val) = 0;

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -299,11 +299,15 @@ ImageCacheFile::open (ImageCachePerThreadInfo *thread_info)
         return false;
     }
 
+    ImageSpec configspec;
+    if (imagecache().unassociatedalpha())
+        configspec.attribute ("oiio:UnassociatedAlpha", 1);
+
     ImageSpec nativespec, tempspec;
     m_broken = false;
     bool ok = true;
     for (int tries = 0; tries <= imagecache().failure_retries(); ++tries) {
-        ok = m_input->open (m_filename.c_str(), nativespec);
+        ok = m_input->open (m_filename.c_str(), nativespec, configspec);
         if (ok) {
             tempspec = nativespec;
             if (tries)   // succeeded, but only after a failure!
@@ -1250,6 +1254,7 @@ ImageCacheImpl::init ()
     m_accept_unmipped = true;
     m_read_before_insert = false;
     m_deduplicate = true;
+    m_unassociatedalpha = false;
     m_failure_retries = 0;
     m_latlong_y_up_default = true;
     m_Mw2c.makeIdentity();
@@ -1677,6 +1682,13 @@ ImageCacheImpl::attribute (const std::string &name, TypeDesc type,
             do_invalidate = true;
         }
     }
+    else if (name == "unassociatedalpha" && type == TypeDesc::INT) {
+        int r = *(const int *)val;
+        if (r != m_unassociatedalpha) {
+            m_unassociatedalpha = r;
+            do_invalidate = true;
+        }
+    }
     else if (name == "failure_retries" && type == TypeDesc::INT) {
         m_failure_retries = *(const int *)val;
     }
@@ -1723,6 +1735,7 @@ ImageCacheImpl::getattribute (const std::string &name, TypeDesc type,
     ATTR_DECODE ("accept_unmipped", int, m_accept_unmipped);
     ATTR_DECODE ("read_before_insert", int, m_read_before_insert);
     ATTR_DECODE ("deduplicate", int, m_deduplicate);
+    ATTR_DECODE ("unassociatedalpha", int, m_unassociatedalpha);
     ATTR_DECODE ("failure_retries", int, m_failure_retries);
 
     // The cases that don't fit in the simple ATTR_DECODE scheme

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -639,6 +639,7 @@ public:
     bool forcefloat () const { return m_forcefloat; }
     bool accept_untiled () const { return m_accept_untiled; }
     bool accept_unmipped () const { return m_accept_unmipped; }
+    bool unassociatedalpha () const { return m_unassociatedalpha; }
     int failure_retries () const { return m_failure_retries; }
     bool latlong_y_up_default () const { return m_latlong_y_up_default; }
     void get_commontoworld (Imath::M44f &result) const {
@@ -927,6 +928,7 @@ private:
     bool m_accept_unmipped;      ///< Accept unmipped images?
     bool m_read_before_insert;   ///< Read tiles before adding to cache?
     bool m_deduplicate;          ///< Detect duplicate files?
+    bool m_unassociatedalpha;    ///< Keep unassociated alpha files as they are?
     int m_failure_retries;       ///< Times to re-try disk failures
     bool m_latlong_y_up_default; ///< Is +y the default "up" for latlong?
     Imath::M44f m_Mw2c;          ///< world-to-"common" matrix

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -115,6 +115,7 @@ static int nchannels = -1;
 static bool prman = false;
 static bool oiio = false;
 static bool src_samples_border = false; // are src edge samples on the border?
+static bool ignore_unassoc = false;  // ignore unassociated alpha tags
 
 static bool unpremult = false;
 static std::string incolorspace;
@@ -266,6 +267,7 @@ getargs (int argc, char *argv[])
                   "--constant-color-detect", &constant_color_detect, "Create 1-tile textures from constant color inputs",
                   "--monochrome-detect", &monochrome_detect, "Create 1-channel textures from monochrome inputs",
                   "--opaque-detect", &opaque_detect, "Drop alpha channel that is always 1.0",
+                  "--ignore-unassoc", &ignore_unassoc, "Ignore unassociated alpha tags in input (don't autoconvert)",
                   "--stats", &stats, "Print runtime statistics",
                   "--mipimage %L", &mipimages, "Specify an individual MIP level",
 //FIXME           "-c %s", &channellist, "Restrict/shuffle channels",
@@ -878,6 +880,9 @@ make_texturemap (const char *maptypename = "texture map")
     // Maybe a bug in libtiff zip compression for tiles?  So let's
     // stick to the default compression.
 
+    if (ignore_unassoc)
+        dstspec.erase_attribute ("oiio:UnassociatedAlpha");
+
     // Put a DateTime in the out file, either now, or matching the date
     // stamp of the input file (if update mode).
     time_t date;
@@ -1350,6 +1355,7 @@ main (int argc, char *argv[])
     ImageCache *ic = ImageCache::create ();  // get the shared one
     ic->attribute ("forcefloat", 1);   // Force float upon read
     ic->attribute ("max_memory_MB", 1024.0);  // 1 GB cache
+    ic->attribute ("unassociatedalpha", (int)ignore_unassoc);
 
     if (mipmapmode) {
         make_texturemap ("texture map");


### PR DESCRIPTION
Deal with texture inputs with unassociated alpha without conversion including
texture inputs are associated but incorrectly are tagged as unassociated alpha.

This comes in two parts:
1. A new ImageCache attribute "unassociatedalpha", which when set to 1 will
   cause image files to be opened with the special configuration option
   "oiio:UnassociatedAlpha", which is recognized by the image reader as
   an instruction to leave unassociated alpha as it is, rather than converting
   to associated alpha upon input.
2. A maketx option --keepunassoc, which when used will set this option for
   the ImageCache.

The net result is that 'maketx --keepunassoc' will not scale the color
channels by alpha, even if the file appears to have unassociated alpha.

The main reason this is coming up is that Mari appears to have a bug wherein
its TIFF output is tagged as having unassociated alpha, even though it does not.
Therefore maketx was inappropriately and automatically scaling the color
channels when this was not desired.  The bug will eventually be fixed, but in
the mean time, this will get users unstuck.
