### PR TITLE
Add "extension_list" attribute

### DIFF
--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -568,6 +568,20 @@ image format readers and writers.  (Note: can only be retrieved
 by {\cf getattribute()}, cannot be set by {\cf attribute()}.)
 \apiend
 
+\apiitem{string extension_list}
+\vspace{10pt}
+\index{extension_list}
+For each format, the format name, followed by a colon, followed by
+a comma-separated list of all extensions that are presumed to be used
+for that format.  Semicolons separate the lists for formats.  For
+example,
+\begin{code}
+     "tiff:tif;jpeg:jpg,jpeg;openexr:exr"
+\end{code}
+(Note: can only be retrieved
+by {\cf getattribute()}, cannot be set by {\cf attribute()}.)
+\apiend
+
 \apiend
 
 \apiitem{bool {\ce attribute} (const std::string \&name, int val) \\

--- a/src/include/imageio.h
+++ b/src/include/imageio.h
@@ -1134,6 +1134,12 @@ OIIO_API std::string geterror ();
 ///     string format_list     (for 'getattribute' only, cannot set)
 ///             Comma-separated list of all format names supported
 ///             or for which plugins could be found.
+///     string extension_list   (for 'getattribute' only, cannot set)
+///             For each format, the format name followed by a colon,
+///             followed by comma-separated list of all extensions that
+///             are presumed to be used for that format.  Semicolons
+///             separate the lists for formats.  For example,
+///                "tiff:tif;jpeg:jpg,jpeg;openexr:exr"
 OIIO_API bool attribute (const std::string &name, TypeDesc type,
                           const void *val);
 // Shortcuts for common types

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -53,6 +53,7 @@ recursive_mutex imageio_mutex;
 int oiio_threads = boost::thread::hardware_concurrency();
 ustring plugin_searchpath;
 std::string format_list;   // comma-separated list of all formats
+std::string extension_list;   // list of all extensions for all formats
 };
 
 
@@ -161,6 +162,12 @@ getattribute (const std::string &name, TypeDesc type, void *val)
         if (format_list.empty())
             pvt::catalog_all_plugins (plugin_searchpath.string());
         *(ustring *)val = ustring(format_list);
+        return true;
+    }
+    if (name == "extension_list" && type == TypeDesc::TypeString) {
+        if (extension_list.empty())
+            pvt::catalog_all_plugins (plugin_searchpath.string());
+        *(ustring *)val = ustring(extension_list);
         return true;
     }
     return false;

--- a/src/libOpenImageIO/imageio_pvt.h
+++ b/src/libOpenImageIO/imageio_pvt.h
@@ -56,6 +56,7 @@ extern recursive_mutex imageio_mutex;
 extern int oiio_threads;
 extern ustring plugin_searchpath;
 extern std::string format_list;
+extern std::string extension_list;
 
 
 // For internal use - use error() below for a nicer interface.

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -73,6 +73,16 @@ static std::map <std::string, std::string> plugin_filepaths;
 static std::string pattern = Strutil::format (".imageio.%s",
                                               Plugin::plugin_extension());
 
+
+inline void
+add_if_missing (std::vector<std::string> &vec, const std::string &val)
+{
+    if (std::find (vec.begin(), vec.end(), val) == vec.end())
+        vec.push_back (val);
+}
+
+
+
 /// Register the input and output 'create' routine and list of file
 /// extensions for a particular format.
 static void
@@ -80,6 +90,7 @@ declare_plugin (const std::string &format_name,
                 create_prototype input_creator, const char **input_extensions,
                 create_prototype output_creator, const char **output_extensions)
 {
+    std::vector<std::string> all_extensions;
     // Look for input creator and list of supported extensions
     if (input_creator) {
         if (input_formats.find(format_name) != input_formats.end())
@@ -88,8 +99,10 @@ declare_plugin (const std::string &format_name,
         for (const char **e = input_extensions; e && *e; ++e) {
             std::string ext (*e);
             Strutil::to_lower (ext);
-            if (input_formats.find(ext) == input_formats.end())
+            if (input_formats.find(ext) == input_formats.end()) {
                 input_formats[ext] = input_creator;
+                add_if_missing (all_extensions, ext);
+            }
         }
     }
 
@@ -100,16 +113,23 @@ declare_plugin (const std::string &format_name,
         for (const char **e = output_extensions; e && *e; ++e) {
             std::string ext (*e);
             Strutil::to_lower (ext);
-            if (output_formats.find(ext) == output_formats.end())
+            if (output_formats.find(ext) == output_formats.end()) {
                 output_formats[ext] = output_creator;
+                add_if_missing (all_extensions, ext);
+            }
         }
     }
 
-    // Add the name to the master list of format_names
+    // Add the name to the master list of format_names, and extensions to
+    // their master list.
     recursive_lock_guard lock (pvt::imageio_mutex);
     if (format_list.length())
         format_list += std::string(",");
     format_list += format_name;
+    if (extension_list.length())
+        extension_list += std::string(";");
+    extension_list += format_name + std::string(":");
+    extension_list += Strutil::join(all_extensions, ",");
 }
 
 


### PR DESCRIPTION
Just like getattribute("format_list") returns a comma-separated list of formats, this new "extension_list" attribute, when retrieves, lists all formats and for each format every extension that is presumed to correspond to the format.  For example:

```
"tiff:tif;jpeg:jpg,jpeg;openexr:exr"
```

This is for you, @slooper
