### PR TITLE
maketx fixes -- fix making textures from source images that are crop windows

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -865,7 +865,7 @@ static inline void
 getpixel_ (const ImageBuf &buf, int x, int y, int z, float *result, int chans)
 {
     ImageBuf::ConstIterator<T> pixel (buf, x, y, z);
-    if (pixel.valid()) {
+    if (pixel.exists()) {
         for (int i = 0;  i < chans;  ++i)
             result[i] = pixel[i];
     } else {
@@ -927,7 +927,7 @@ static inline void
 setpixel_ (ImageBuf &buf, int x, int y, int z, const float *data, int chans)
 {
     ImageBuf::Iterator<T> pixel (buf, x, y, z);
-    if (pixel.valid()) {
+    if (pixel.exists()) {
         for (int i = 0;  i < chans;  ++i)
             pixel[i] = data[i];
     }


### PR DESCRIPTION
Crop windows should be handled by considering them black outside the crop region, not clamping.  This was leading to strange artifacts.

Also fix imagebuf.cpp getpixel/setpixel internals -- subtle difference between Iterator::exists() [data exists for the pixel] versus valid() [pixel coordinates is outside the iteration range].

I'll need to backport this to 1.1 as well.
