### PR TITLE
Make ustring::TableRep match allocation & deallocation (malloc / free).

### DIFF
--- a/src/libutil/ustring.cpp
+++ b/src/libutil/ustring.cpp
@@ -229,7 +229,8 @@ ustring::make_unique (const char *str)
     // new one!  Use the one in the table and disregard the one we
     // speculatively built.  Note that we've already released the lock
     // on the table at this point.
-    delete rep;
+    rep->~TableRep ();  // destructor
+    free (rep);         // because it was malloced
     return result;
 }
 


### PR DESCRIPTION
It was previously doing malloc / delete, a mismatch. Pointed out by Mark Leone.
