### PR TITLE
maketx --fullpixels

### DIFF
--- a/src/doc/maketx.tex
+++ b/src/doc/maketx.tex
@@ -150,6 +150,14 @@ be replaced by the average of all the finite values within a $3 \times 3$
 region surrounding the pixel.
 \apiend
 
+\apiitem{--fullpixels}
+\NEW
+Resets the ``full'' (or ``display'') pixel range to be the ``data''
+range.  This is used to deal with input images that appear, in their
+headers, to be crop windows or overscanned images, but you want to treat
+them as full 0--1 range images over just their defined pixel data.
+\apiend
+
 %\apiitem{--ingamma {\rm \emph{value}} \\
 %--outgamma {\rm \emph{value}}}
 %Not currently implemented

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -80,6 +80,7 @@ static double stat_miptime = 0;
 static double stat_colorconverttime = 0;
 static bool checknan = false;
 static std::string fixnan = "none"; // none, black, box3
+static bool set_full_to_pixels = false;
 static int found_nonfinite = 0;
 static spin_mutex maketx_mutex;   // for anything that needs locking
 static std::string filtername = "box";
@@ -249,6 +250,7 @@ getargs (int argc, char *argv[])
                   "--nomipmap", &nomipmap, "Do not make multiple MIP-map levels",
                   "--checknan", &checknan, "Check for NaN/Inf values (abort if found)",
                   "--fixnan %s", &fixnan, "Attempt to fix NaN/Inf values in the image (options: none, black, box3)",
+                  "--fullpixels", &set_full_to_pixels, "Set the 'full' image range to be the pixel data window",
                   "--Mcamera %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f",
                           &Mcam[0][0], &Mcam[0][1], &Mcam[0][2], &Mcam[0][3], 
                           &Mcam[1][0], &Mcam[1][1], &Mcam[1][2], &Mcam[1][3], 
@@ -834,6 +836,18 @@ make_texturemap (const char *maptypename = "texture map")
               out_dataformat != TypeDesc::HALF &&
               out_dataformat != TypeDesc::DOUBLE)
             out_dataformat = TypeDesc::FLOAT;
+    }
+
+    if (set_full_to_pixels) {
+        // User requested that we treat the image as uncropped or not
+        // overscan
+        ImageSpec &spec (src.specmod());
+        spec.full_x = spec.x = 0;
+        spec.full_y = spec.y = 0;
+        spec.full_z = spec.z = 0;
+        spec.full_width = spec.width;
+        spec.full_height = spec.height;
+        spec.full_depth = spec.depth;
     }
 
     // Copy the input spec


### PR DESCRIPTION
When given this command, maketx will consider the pixel data window of
the input image to be the full 0-1 texture range, ignoring any origin or
differenly specified full/display window (i.e. pretending that the image
is not, as its header may state, a crop of overscan image).  This is
primarily to counteract weird or buggy behavior in certain paint program
that inexplicably save images that look like crops even when they are
not intended to be.
