### PR TITLE
Modify oiiotool --zover to take optional "zeroisinf=%d" argument.

### DIFF
--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -738,7 +738,15 @@ Porter/Duff ``over'' composite, but each pixel individually will choose
 which of the two images is the foreground and which background, depending on
 the ``Z'' channel values for that pixel (larger Z means farther away).
 Both input images must have the same number and order of channels
-and must contain both depth/Z and alpha channels.
+and must contain both depth/Z and alpha channels. Optional appended arguments
+include:
+
+\begin{tabular}{p{10pt} p{1in} p{3.5in}}
+  & {\cf zeroisinf=}\emph{num} & If nonzero, indicates that $z=0$ pixels
+  should be treated as if they were infinitely far away. (The default is
+  0, meaning that ``zero means zero.'').
+\end{tabular}
+
 \apiend
 
 \apiitem{--flip}

--- a/src/include/imagebufalgo.h
+++ b/src/include/imagebufalgo.h
@@ -368,9 +368,15 @@ bool OIIO_API over (ImageBuf &R, const ImageBuf &A, const ImageBuf &B,
 /// Just like ImageBufAlgo::over(), but inputs A and B must have
 /// designated 'z' channels, and on a pixel-by-pixel basis, the z values
 /// will determine which of A or B will be considered the foreground or
-/// background (lower z is foreground).
+/// background (lower z is foreground).  If z_zeroisinf is true, then
+/// z=0 values will be treated as if they are infinitely far away.
 bool OIIO_API zover (ImageBuf &R, const ImageBuf &A, const ImageBuf &B,
+                     bool z_zeroisinf = false,
                      ROI roi = ROI(), int threads = 0);
+
+/// DEPRECATED -- preserved for link compatibility, but will be removed.
+bool OIIO_API zover (ImageBuf &R, const ImageBuf &A, const ImageBuf &B,
+                     ROI roi, int threads = 0);
 
 
 /// Render a text string into image R, essentially doing an "over" of

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1641,6 +1641,16 @@ action_zover (int argc, const char *argv[])
     if (ot.postpone_callback (2, action_over, argc, argv))
         return 0;
 
+    // Get optional flags
+    bool z_zeroisinf = false;
+    std::string cmd = argv[0];
+    size_t pos;
+    while ((pos = cmd.find_first_of(":")) != std::string::npos) {
+        cmd = cmd.substr (pos+1, std::string::npos);
+        if (Strutil::istarts_with(cmd,"zeroisinf="))
+            z_zeroisinf = (atoi(cmd.c_str()+10) != 0);
+    }
+
     ImageRecRef B (ot.pop());
     ImageRecRef A (ot.pop());
     ot.read (A);
@@ -1657,7 +1667,7 @@ action_zover (int argc, const char *argv[])
     ot.push (new ImageRec ("zover", specR, ot.imagecache));
     ImageBuf &Rib ((*ot.curimg)());
 
-    bool ok = ImageBufAlgo::zover (Rib, Aib, Bib);
+    bool ok = ImageBufAlgo::zover (Rib, Aib, Bib, z_zeroisinf);
     if (! ok)
         ot.error (argv[0], Rib.geterror());
     return 0;
@@ -1937,18 +1947,18 @@ getargs (int argc, char *argv[])
                 "--hardwarn %g", &ot.diff_hardwarn, "Warn if any one pixel difference exceeds this error (infinity)",
                 "<SEPARATOR>", "Actions:",
                 "--create %@ %s %d", action_create, NULL, NULL,
-                        "Create a blank image (args: geom, channels)",
+                        "Create a blank image (optional args: geom, channels)",
                 "--pattern %@ %s %s %d", action_pattern, NULL, NULL, NULL,
-                        "Create a patterned image (args: pattern, geom, channels)",
+                        "Create a patterned image (optional args: pattern, geom, channels)",
                 "--capture %@", action_capture, NULL,
-                        "Capture an image (args: camera=%%d)",
+                        "Capture an image (optional args: camera=%d)",
                 "--diff %@", action_diff, NULL, "Print report on the difference of two images (modified by --fail, --failpercent, --hardfail, --warn, --warnpercent --hardwarn)",
                 "--add %@", action_add, NULL, "Add two images",
                 "--sub %@", action_sub, NULL, "Subtract two images",
                 "--abs %@", action_abs, NULL, "Take the absolute value of the image pixels",
                 "--over %@", action_over, NULL, "'Over' composite of two images",
-                "--zover %@", action_zover, NULL, "Depth composite two images with Z channels",
-                "--histogram %@ %s %d", action_histogram, NULL, NULL, "Histogram one channel (args: cumulative=0)",
+                "--zover %@", action_zover, NULL, "Depth composite two images with Z channels (optional args: zeroisinf=%d)",
+                "--histogram %@ %s %d", action_histogram, NULL, NULL, "Histogram one channel (optional args: cumulative=0)",
                 "--flip %@", action_flip, NULL, "Flip the image vertically (top<->bottom)",
                 "--flop %@", action_flop, NULL, "Flop the image horizontally (left<->right)",
                 "--flipflop %@", action_flipflop, NULL, "Flip and flop the image (180 degree rotation)",


### PR DESCRIPTION
Modify oiiotool --zover to take optional "zeroisinf=%d" argument.
Also change the underlying ImageBufAlgo::zover in the corresponding way.
When nonzero, this will interpret z=0 values as actually infinitely far
away.  Why some apps use z=0 for tmpty pixels instead of a HUGE value
for this, I don't know.  I'm talking to you, Maya.
