### PR TITLE
iv: fix bug where 'reload' would lose track of the image.

### DIFF
--- a/src/iv/ivimage.cpp
+++ b/src/iv/ivimage.cpp
@@ -397,7 +397,7 @@ void
 IvImage::invalidate ()
 {
     ustring filename (name());
-    clear ();
+    reset (filename.string());
     m_thumbnail_valid = false;
     m_image_valid = false;
     if (imagecache())


### PR DESCRIPTION
(This bug was introduced recently by the ImageBuf PIMPL overhaul.)
