### PR TITLE
Bug fix in wrap_periodic_sharedborder (used by environment call with exr maps)

### DIFF
--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -161,16 +161,17 @@ bool
 TextureSystemImpl::wrap_periodic_sharedborder (int &coord, int origin, int width)
 {
     // Like periodic, but knowing that the first column and last are
-    // actually the same position, so we essentially skip the first
-    // column in the next cycle.  We only need this to work for one wrap
-    // in each direction since it's only used for latlong maps.
-    coord -= origin;
-    if (coord >= width) {
-        coord = coord - width + 1;
-    } else if (coord < 0) {
-        coord = coord + width - 1;
+    // actually the same position, so we essentially skip the last
+    // column in the next cycle.
+    if (width <= 2) {
+        coord = origin;  // special case -- just 1 pixel wide
+    } else {
+        coord -= origin;
+        coord %= (width-1);
+        if (coord < 0)       // Fix negative values
+            coord += width;
+        coord += origin;
     }
-    coord += origin;
     return true;
 }
 


### PR DESCRIPTION
The math here made an assumption that the amount of periodic wrapping could
be no more than 1 cycle.  But it could!  If using a bicubic lookup (needs 4
samples) at a MIP level with resolution <= 2 (very blurry), you could
mis-calculate the wrap and end up with a coordinate out of the range of
valid pixels.
