### PR TITLE
Use fingerprint instead of filename to delete fingerprint in invalidate

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -2427,6 +2427,8 @@ ImageCacheImpl::invalidate (ustring filename)
         tilemutex_holder (NULL);
     }
 
+    ustring fingerprint = file->fingerprint();
+
     {
         ic_write_lock fileguard (m_filemutex);
         file->invalidate ();
@@ -2435,7 +2437,7 @@ ImageCacheImpl::invalidate (ustring filename)
     // Remove the fingerprint corresponding to this file
     {
         spin_lock lock (m_fingerprints_mutex);
-        FilenameMap::iterator f = m_fingerprints.find (filename);
+        FilenameMap::iterator f = m_fingerprints.find (fingerprint);
         if (f != m_fingerprints.end())
             m_fingerprints.erase (f);
     }


### PR DESCRIPTION
Commit 378d4e5 optimizes how OIIO deals with fingerprints when a file is invalidated, but it searches for elements to delete in the fingerprint vector using the file's name, not its fingerprint. So no fingerprints are actually deleted.

This results in fingerprints that point to invalidated files in the fingerprint vector.

This pull request fixes the issue (related to SA Arnold ticket #3261)
