### PR TITLE
New IC/TS attribute: "one_error_per_file"

### DIFF
--- a/src/doc/imagecache.tex
+++ b/src/doc/imagecache.tex
@@ -374,6 +374,15 @@ converting to associated alpha upon reading the pixels.  The default is
 0, meaning that the automatic conversion will take place.
 \apiend
 
+\apiitem{int one_error_per_file}
+When nonzero, only one ``Invalid file'' or ``Could not open file''
+error message will be issued for each broken file.  Any subsequent 
+method call that fails will still return {\cf false}, but it just
+will have an empty error message string.  The default is
+0, meaning that a new error message will be generated for every time
+each broken file is accessed.
+\apiend
+
 \apiitem{string options}
 This catch-all is simply a comma-separated list of {\cf name=value}
 settings of named options.  For example,

--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -543,7 +543,10 @@ int accept_untiled \\
 int accept_unmipped \\
 int failure_retries \\
 int deduplicate \\
-string substitute_image}
+string substitute_image \\
+int unassociatedalpha \\
+int one_error_per_file
+}
 
 These attributes are all passed along to the underlying \ImageCache that
 is used internally by the \TextureSystem.  Please consult the

--- a/src/include/imagecache.h
+++ b/src/include/imagecache.h
@@ -98,6 +98,8 @@ public:
     ///     string substitute_image : uses the named image in place of all
     ///                               texture and image references.
     ///     int unassociatedalpha : if nonzero, keep unassociated alpha images
+    ///     string latlong_up : default "up" direction for latlong ("y")
+    ///     int one_error_per_file : only issue one error for each broken file
     ///
     virtual bool attribute (const std::string &name, TypeDesc type,
                             const void *val) = 0;

--- a/src/include/texture.h
+++ b/src/include/texture.h
@@ -327,22 +327,28 @@ public:
 
     /// Set an attribute controlling the texture system.  Return true
     /// if the name and type were recognized and the attrib was set.
-    /// Documented attributes:
+    /// Documented attributes specific to the TextureSystem:
+    ///     matrix44 worldtocommon : the world-to-common transformation
+    ///     matrix44 commontoworld : the common-to-world transformation
+    ///     int gray_to_rgb : make 1-channel images fill RGB lookups
+    ///     string latlong_up : default "up" direction for latlong ("y")
+    /// And attributes that are passed along to the underling ImageCache:
     ///     int max_open_files : maximum number of file handles held open
     ///     float max_memory_MB : maximum tile cache size, in MB
     ///     string searchpath : colon-separated search path for texture files
     ///     string plugin_searchpath : colon-separated search path for plugins
-    ///     matrix44 worldtocommon : the world-to-common transformation
-    ///     matrix44 commontoworld : the common-to-world transformation
     ///     int autotile : if >0, tile size to emulate for non-tiled images
     ///     int autoscanline : autotile using full width tiles
     ///     int automip : if nonzero, emulate mipmap on the fly
     ///     int accept_untiled : if nonzero, accept untiled images
     ///     int accept_unmipped : if nonzero, accept unmipped images
+    ///     int statistics:level : verbosity of statistics auto-printed.
     ///     int failure_retries : how many times to retry a read failure
     ///     int deduplicate : if nonzero, detect duplicate textures (default=1)
-    ///     int gray_to_rgb : make 1-channel images fill RGB lookups
-    ///     string latlong_up : default "up" direction for latlong ("y")
+    ///     string substitute_image : uses the named image in place of all
+    ///                               texture and image references.
+    ///     int unassociatedalpha : if nonzero, keep unassociated alpha images
+    ///     int one_error_per_file : only issue one error for each broken file
     ///
     virtual bool attribute (const std::string &name, TypeDesc type, const void *val) = 0;
     // Shortcuts for common types

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -291,6 +291,7 @@ private:
     std::time_t m_mod_time;         ///< Time file was last updated
     ustring m_fingerprint;          ///< Optional cryptographic fingerprint
     ImageCacheFile *m_duplicate;    ///< Is this a duplicate?
+    atomic_int m_printed_error;     ///< has already printed an error
 
     /// We will need to read pixels from the file, so be sure it's
     /// currently opened.  Return true if ok, false if error.
@@ -650,6 +651,7 @@ public:
     bool unassociatedalpha () const { return m_unassociatedalpha; }
     int failure_retries () const { return m_failure_retries; }
     bool latlong_y_up_default () const { return m_latlong_y_up_default; }
+    bool one_error_per_file () const { return m_one_error_per_file; }
     void get_commontoworld (Imath::M44f &result) const {
         result = m_Mc2w;
     }
@@ -948,6 +950,7 @@ private:
     bool m_unassociatedalpha;    ///< Keep unassociated alpha files as they are?
     int m_failure_retries;       ///< Times to re-try disk failures
     bool m_latlong_y_up_default; ///< Is +y the default "up" for latlong?
+    bool m_one_error_per_file;   ///< Issue just one err msg per broken file?
     Imath::M44f m_Mw2c;          ///< world-to-"common" matrix
     Imath::M44f m_Mc2w;          ///< common-to-world matrix
     ustring m_substitute_image;  ///< Substitute this image for all others


### PR DESCRIPTION
When set to nonzero, only ONE "Invalid file" or "Could not open file"
error message will be issued for each broken file.  Of course, calls that
fail will still return false, they just will have empty error messages.
This turns out to be helpful if you have an app that might make millions
of calls before it discovers a problem, and happens to be echoing non-empty
error messages.  The default is 0 (the old behavior; an error message every time).
