### PR TITLE
maketx bug in fix_latl_edges -- apparent cut/paste error summed incorrectly

### DIFF
--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -310,8 +310,6 @@ fix_latl_edges (ImageBuf &buf)
                 left[c] += right[c];
         }
         for (int c = 0;  c < n;  ++c)
-            left[c] += right[c];
-        for (int c = 0;  c < n;  ++c)
             left[c] *= wscale;
         for (int x = buf.xbegin();  x < buf.xend();  ++x)
             buf.setpixel (x, y, left);

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -624,8 +624,6 @@ fix_latl_edges (ImageBuf &buf)
                 left[c] += right[c];
         }
         for (int c = 0;  c < n;  ++c)
-            left[c] += right[c];
-        for (int c = 0;  c < n;  ++c)
             left[c] *= wscale;
         for (int x = buf.xbegin();  x < buf.xend();  ++x)
             buf.setpixel (x, y, left);

--- a/testsuite/maketx/ref/out.txt
+++ b/testsuite/maketx/ref/out.txt
@@ -349,3 +349,37 @@ small.tx             :   64 x   64, 3 channel, uint8 tiff
     compression: "zip"
     IPTC:Caption: "foo bar SHA-1=FFB354CFB97E56225E1FDA9484B8DE1B04470DAE ConstantColor=[1,0,0]"
     tiff:RowsPerStrip: "32"
+whiteenv.exr         :    4 x    2, 3 channel, half openexr (+mipmap)
+    MIP 0 of 3 (4 x 2):
+      Stats Min: 1.000000 1.000000 1.000000 (float)
+      Stats Max: 1.000000 1.000000 1.000000 (float)
+      Stats Avg: 1.000000 1.000000 1.000000 (float)
+      Stats StdDev: 0.000000 0.000000 0.000000 (float)
+      Stats NanCount: 0 0 0 
+      Stats InfCount: 0 0 0 
+      Stats FiniteCount: 8 8 8 
+      Constant: Yes
+      Constant Color: 1.000000 1.000000 1.000000 (float)
+      Monochrome: Yes
+    MIP 1 of 3 (2 x 1):
+      Stats Min: 1.000000 1.000000 1.000000 (float)
+      Stats Max: 1.000000 1.000000 1.000000 (float)
+      Stats Avg: 1.000000 1.000000 1.000000 (float)
+      Stats StdDev: 0.000000 0.000000 0.000000 (float)
+      Stats NanCount: 0 0 0 
+      Stats InfCount: 0 0 0 
+      Stats FiniteCount: 2 2 2 
+      Constant: Yes
+      Constant Color: 1.000000 1.000000 1.000000 (float)
+      Monochrome: Yes
+    MIP 2 of 3 (1 x 1):
+      Stats Min: 1.000000 1.000000 1.000000 (float)
+      Stats Max: 1.000000 1.000000 1.000000 (float)
+      Stats Avg: 1.000000 1.000000 1.000000 (float)
+      Stats StdDev: 0.000000 0.000000 0.000000 (float)
+      Stats NanCount: 0 0 0 
+      Stats InfCount: 0 0 0 
+      Stats FiniteCount: 1 1 1 
+      Constant: Yes
+      Constant Color: 1.000000 1.000000 1.000000 (float)
+      Monochrome: Yes

--- a/testsuite/maketx/run.py
+++ b/testsuite/maketx/run.py
@@ -90,6 +90,16 @@ command += info_command ("small.tif", safematch=1);
 command += maketx_command ("small.tif", "small.tx",
                            "--oiio --constant-color-detect", showinfo=True)
 
+# Regression test -- at one point, we had a bug where we were botching
+# the poles of OpenEXR env maps, adding energy.  Check it by creating an
+# all-white image, turning it into an env map, and calculating its
+# statistics (should be 1.0 everywhere).
+command += (oiio_app("oiiotool") + " --pattern constant:color=1,1,1 4x2 3 "
+            + " -d half -o " + oiio_relpath("white.exr") + " >> out.txt;\n")
+command += maketx_command ("white.exr", "whiteenv.exr",
+                           "--envlatl")
+command += (oiio_app("oiiotool") + "--stats whiteenv.exr"
+            + " >> out.txt;\n")
 
 outputs = [ "out.txt" ]
 


### PR DESCRIPTION
maketx bug in fix_latl_edges -- apparent cut/paste error summed incorrectly

This is the special routine that patches up the poles, only comes into play for OpenEXR environment maps.  The top and/or bottom rows are supposed to be averaged, which happens by summing, then dividing by the number of pixels summed.  Somehow, one extra pixel got added, I can only imagine that it was a cut-and-paste error.  But the result is that OpenEXR environment maps had just a teensy bit too much energy at the poles.  But this compounds at each MIP level, so for extremely blurry environment lookups, it could look much brighter than it should have.

It was clearly wrong before, right now.  But beware -- if you re-convert an environment map, this could change its appearance.  (Only if it's an OpenEXR env map, it did not affect ordinary texture, nor TIFF environment maps.)

Apologies -- this seems to have been a bug that's been in effect for a long, long time.
