### PR TITLE
Clean up ImageOutput handling of unknown or mismatched data formats

### DIFF
--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -170,7 +170,7 @@ DPXOutput::open (const std::string &name, const ImageSpec &userspec,
         m_datasize = dpx::kDouble;
     else {
         // use 16-bit unsigned integers as a failsafe
-        m_spec.format = TypeDesc::UINT16;
+        m_spec.set_format (TypeDesc::UINT16);
         m_datasize = dpx::kWord;
     }
 

--- a/src/fits.imageio/fitsoutput.cpp
+++ b/src/fits.imageio/fitsoutput.cpp
@@ -62,6 +62,8 @@ FitsOutput::open (const std::string &name, const ImageSpec &spec,
     // saving 'name' and 'spec' for later use
     m_filename = name;
     m_spec = spec;
+    if (m_spec.format == TypeDesc::UNKNOWN)  // if unknown, default to float
+        m_spec.set_format (TypeDesc::FLOAT);
 
     // checking if the file exists and can be opened in WRITE mode
     m_fd = Filesystem::fopen (m_filename, mode == AppendSubimage ? "r+b" : "wb");
@@ -249,8 +251,10 @@ FitsOutput::create_basic_header (std::string &header)
             m_bitpix = -32;
             break;
         case TypeDesc::DOUBLE:
-        default:
             m_bitpix = -64;
+            break;
+        default:
+            m_bitpix = -32;  // punt: default to 32 bit float
             break;
     }
     header += create_card ("BITPIX", num2str (m_bitpix));

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -83,6 +83,8 @@ HdrOutput::open (const std::string &name, const ImageSpec &newspec,
 
     // Save spec for later use
     m_spec = newspec;
+    // HDR always behaves like floating point
+    m_spec.set_format (TypeDesc::FLOAT);
 
     // Check for things HDR can't support
     if (m_spec.nchannels != 3) {

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -154,6 +154,8 @@ ICOOutput::open (const std::string &name, const ImageSpec &userspec,
 
     close ();  // Close any already-opened file
     m_spec = userspec;  // Stash the spec
+    if (m_spec.format == TypeDesc::UNKNOWN)  // if unknown, default to 8 bits
+        m_spec.set_format (TypeDesc::UINT8);
 
     // Check for things this format doesn't support
     if (m_spec.width < 1 || m_spec.height < 1) {

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -104,8 +104,12 @@ Jpeg2000Output::open (const std::string &name, const ImageSpec &spec,
         return false;
     }
 
-    m_spec = spec;
     m_filename = name;
+    m_spec = spec;
+
+    // If not uint8 or uint16, default to uint8
+    if (m_spec.format != TypeDesc::UINT8 && m_spec.format != TypeDesc::UINT16)
+        m_spec.set_format (TypeDesc::UINT8);
 
     m_file = Filesystem::fopen (m_filename, "wb");
     if (m_file == NULL) {

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -127,6 +127,10 @@ PNGOutput::open (const std::string &name, const ImageSpec &userspec,
     close ();  // Close any already-opened file
     m_spec = userspec;  // Stash the spec
 
+    // If not uint8 or uint16, default to uint8
+    if (m_spec.format != TypeDesc::UINT8 && m_spec.format != TypeDesc::UINT16)
+        m_spec.set_format (TypeDesc::UINT8);
+
     m_file = Filesystem::fopen (name, "wb");
     if (! m_file) {
         error ("Could not open file \"%s\"", name.c_str());

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -175,6 +175,8 @@ RLAOutput::open (const std::string &name, const ImageSpec &userspec,
 
     close ();  // Close any already-opened file
     m_spec = userspec;  // Stash the spec
+    if (m_spec.format == TypeDesc::UNKNOWN)
+        m_spec.format = TypeDesc::UINT8;  // Default to uint8 if unknown
 
     m_file = Filesystem::fopen (name, "wb");
     if (! m_file) {

--- a/src/socket.imageio/socketoutput.cpp
+++ b/src/socket.imageio/socketoutput.cpp
@@ -68,6 +68,8 @@ SocketOutput::open (const std::string &name, const ImageSpec &newspec,
 
     m_next_scanline = 0;
     m_spec = newspec;
+    if (m_spec.format == TypeDesc::UNKNOWN)
+        m_spec.set_format (TypeDesc::UINT8);  // Default to 8 bit channels
 
     return true;
 }

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -165,6 +165,7 @@ TGAOutput::open (const std::string &name, const ImageSpec &userspec,
 
     close ();  // Close any already-opened file
     m_spec = userspec;  // Stash the spec
+    m_spec.set_format (TypeDesc::UINT8);  // TARGA only supports 8 bits
 
     // Check for things this format doesn't support
     if (m_spec.width < 1 || m_spec.height < 1) {
@@ -506,9 +507,6 @@ TGAOutput::write_scanline (int y, int z, TypeDesc format,
                           (unsigned char *)data+m_spec.scanline_bytes());
         data = &m_scratch[0];
     }
-    ASSERT (m_spec.format == TypeDesc::UINT8 &&
-            "Targa only supports 8 bit channels");
-    //std::cerr << "[tga] writing scanline #" << y << "\n";
 
     unsigned char *bdata = (unsigned char *)data;
 

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -233,10 +233,11 @@ TIFFOutput::open (const std::string &name, const ImageSpec &userspec,
         sampformat = SAMPLEFORMAT_IEEEFP;
         break;
     default:
-        error ("TIFF doesn't support %s images (\"%s\")",
-               m_spec.format.c_str(), name.c_str());
-        close();
-        return false;
+        // Everything else, including UNKNOWN -- default to 8 bit
+        bps = 8;
+        sampformat = SAMPLEFORMAT_UINT;
+        m_spec.set_format (TypeDesc::UINT8);
+        break;
     }
     TIFFSetField (m_tif, TIFFTAG_BITSPERSAMPLE, bps);
     TIFFSetField (m_tif, TIFFTAG_SAMPLEFORMAT, sampformat);


### PR DESCRIPTION
Implement new rule for ImageOutput: if the spec passed to open() has
spec.format == UNKNOWN, then select a default data format for the output
file that is "most likely to be able to be read."  Also,
ImageOuput::open() will never fail because a requested data format is
unavailable; a reasonable default will always be chosen.

Along the way, fixed a few buggy behaviors in some of the plugins for
certain format combinations.
