### PR TITLE
Important bug fix to recent 'wrap mode' chanage

### DIFF
--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -961,6 +961,8 @@ TextureSystemImpl::texture_lookup_trilinear_mipmap (TextureFile &texturefile,
                             float *result)
 {
     // Initialize results to 0.  We'll add from here on as we sample.
+    for (int c = 0;  c < options.nchannels;  ++c)
+        result[c] = 0;
     float* dresultds = options.dresultds;
     float* dresultdt = options.dresultdt;
     if (dresultds)


### PR DESCRIPTION
Somehow in the wrap mode checkin from a couple days ago, I either failed to copy, or inadvertently deleted, a couple lines that zero out a texture result. Apparently, it passed tests for me because that uninitialized memory happened to be zero, but that surely wasn't reliable.
