### PR TITLE
Back out bad thread.h change from a few weeks back

### DIFF
--- a/src/include/thread.h
+++ b/src/include/thread.h
@@ -110,9 +110,9 @@ InterlockedExchangeAdd64 (volatile long long *Addend, long long Value)
 #endif
 
 #if defined(__GNUC__) && (defined(_GLIBCXX_ATOMIC_BUILTINS) || (__GNUC__ * 100 + __GNUC_MINOR__ >= 401))
-# if !USE_TBB
-# define USE_GCC_ATOMICS 1
-# endif
+#if !defined(__FreeBSD__) || defined(__x86_64__)
+#define USE_GCC_ATOMICS
+#endif
 #endif
 
 OIIO_NAMESPACE_ENTER


### PR DESCRIPTION
Back out thread.h changes from a while back -- they had unintentional
performance degredation.  It was incorrect to force only one of
USE_GCC_ATOMICS and USE_TBB to be true; there were some places (such
as atomic_compare_and_exchange where the gcc intrinsics were used if
available, even if TBB was being used, and apparently the gcc intrinsics
were much faster.

This was very very subtle.  Most benchmarks were fine.  In fact, we only
noticed this when an app that uses OIIO's TextureSystem had a huge
performance regression in a situation with extreme texture thrashing.  Seems
that you'd never see the perf problem unless you were in the highest possible
contention situation for those atomics.  I still don't have a fully coherent theory
for why the TBB version of atomic_compare_and_exchange is slower, or for
why, even if it is, that should have such a big performance implication (especially
because it was manifesting as a huge number of extra tiles read from disk).
But nonetheless, making this one little change returns performance to its old
self.  Here be dragons.  Never doubt my extreme reluctance to change anything
in thread.h without an extremely compelling reason.  

I will also immediately backport to 1.1, which also unfortunately had the bad
change a few weeks ago, and issue a new release.
