### PR TITLE
Additional DISPATCH_TYPES macro improvements

### DIFF
--- a/src/include/imagebuf.h
+++ b/src/include/imagebuf.h
@@ -106,6 +106,21 @@ struct ROI {
     /// Doesn't that make it abundantly clear?
     static ROI All () { return ROI(); }
 
+    /// Test equality of two ROIs
+    friend bool operator== (const ROI &a, const ROI &b) {
+        return (a.xbegin == b.xbegin && a.xend == b.xend &&
+                a.ybegin == b.ybegin && a.yend == b.yend &&
+                a.zbegin == b.zbegin && a.zend == b.zend &&
+                a.chbegin == b.chbegin && a.chend == b.chend);
+    }
+    /// Test inequality of two ROIs
+    friend bool operator!= (const ROI &a, const ROI &b) {
+        return (a.xbegin != b.xbegin || a.xend != b.xend ||
+                a.ybegin != b.ybegin || a.yend != b.yend ||
+                a.zbegin != b.zbegin || a.zend != b.zend ||
+                a.chbegin != b.chbegin || a.chend != b.chend);
+    }
+
     /// Stream output of the range
     friend std::ostream & operator<< (std::ostream &out, const ROI &roi) {
         out << roi.xbegin << ' ' << roi.xend << ' ' << roi.ybegin << ' '


### PR DESCRIPTION
Last night's project. :-)

Additional DISPATCH_TYPES macro improvements:

OIIO_DISPATCH_TYPES2 does two-level dispatching (i.e. specializes on two different types), dispatching to function<type1,type2> blah (...).

OIIO_DISPATCH_COMMON_TYPES and OIIO_DISPATCH_COMMON_TYPES2 are like the others, but only support float, uint8, half, and uint16, and failing for other types, thus generating far fewer code variants, but still effectively covering all the cases we're ever likely to see in the real world.  This is especially handy for 2-level dispatch to very complex functions, for which the full 9x9 set of specializations is just too much code to generate.

I also eliminated support for UINT64 and INT64 from even the "non-common" macros -- I don't think there are any image file formats that support this data type, so it seems pointless to generate code for it.

I think the guideline should be that for fairly trivial utility functions (for example, copying pixels from one image to another), use the full-type-selection macros -- there's no reason to fail for any type.  But for functions doing non-trivial work (compositing, say), use the COMMON macros to generate code only for cases that we plausibly may see.

You can also see lots of functions that are simplified by using the macros.
