### PR TITLE
IBA::channel_append() / oiiotool --chappend and oiitool --chnames

### DIFF
--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -606,6 +606,19 @@ unchanged.
 Set the full/display window range to exactly cover the pixel data window.
 \apiend
 
+\apiitem{--chnames {\rm \emph{name-list}}}
+Rename some or all of the channels of the top image to the given
+comma-separated list.  Any completely empty channel names in the
+list will not be changed.  For example,
+
+\begin{code}
+    oiiotool in.exr --chnames ",,,A,Z" -o out.exr
+\end{code}
+
+\noindent will rename channel 3 to be \qkw{A} and channel 4 to be
+\qkw{Z}, but will leave channels 0--3 with their old names.
+\apiend
+
 
 \section{\oiiotool commands that adjust the image stack}
 
@@ -636,6 +649,12 @@ by black channels.
 by a number is a \emph{literal value} that will be used to fill that
 channel.  If the \emph{channellist} is shorter than the number of
 channels in the source image, unspecified channels will be omitted.
+\apiend
+
+\apiitem{--chappend}
+\NEW
+Replaces the top two images on the stack with a new image comprised of
+the channels of both images appended together.
 \apiend
 
 \apiitem{--selectmip {\rm \emph{level}}}

--- a/src/include/imagebufalgo.h
+++ b/src/include/imagebufalgo.h
@@ -152,6 +152,16 @@ bool OIIO_API channels (ImageBuf &dst, const ImageBuf &src,
                          int nchannels, const int *channelorder,
                          bool shuffle_channel_names);
 
+/// Append the channels of A and B together into dst over the region of
+/// interest.  If the region passed is uninitialized (the default), it
+/// will be interpreted as being the union of the pixel windows of A and
+/// B (and all channels of both images).  If dst is not already
+/// initialized, it will be resized to be big enough for the region.
+bool OIIO_API channel_append (ImageBuf &dst, const ImageBuf &A,
+                              const ImageBuf &B, ROI roi=ROI(),
+                              int nthreads=0);
+
+
 /// Make dst be a cropped copy of src, but with the new pixel data
 /// window range [xbegin..xend) x [ybegin..yend).  Source pixel data
 /// falling outside this range will not be transferred to dst.  If

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -47,6 +47,7 @@ OIIO_NAMESPACE_USING;
 // Test ImageBuf::zero and ImageBuf::fill
 void test_zero_fill ()
 {
+    std::cout << "test zero_fill\n";
     const int WIDTH = 8;
     const int HEIGHT = 6;
     const int CHANNELS = 4;
@@ -113,6 +114,7 @@ void test_zero_fill ()
 // Test ImageBuf::crop
 void test_crop ()
 {
+    std::cout << "test crop\n";
     int WIDTH = 8, HEIGHT = 6, CHANNELS = 4;
     // Crop region we'll work with
     int xbegin = 3, xend = 5, ybegin = 0, yend = 4;
@@ -151,6 +153,7 @@ void test_crop ()
 
 void test_paste ()
 {
+    std::cout << "test paste\n";
     // Create the source image, make it a gradient
     ImageSpec Aspec (4, 4, 3, TypeDesc::FLOAT);
     ImageBuf A ("A", Aspec);
@@ -192,9 +195,33 @@ void test_paste ()
 
 
 
+void test_channel_append ()
+{
+    std::cout << "test channel_append\n";
+    ImageSpec spec (2, 2, 1, TypeDesc::FLOAT);
+    ImageBuf A ("A", spec);
+    ImageBuf B ("B", spec);
+    float Acolor = 0.1, Bcolor = 0.2;
+    ImageBufAlgo::fill (A, &Acolor);
+    ImageBufAlgo::fill (B, &Bcolor);
+
+    ImageBuf R ("R");
+    ImageBufAlgo::channel_append (R, A, B);
+    OIIO_CHECK_EQUAL (R.spec().width, spec.width);
+    OIIO_CHECK_EQUAL (R.spec().height, spec.height);
+    OIIO_CHECK_EQUAL (R.nchannels(), 2);
+    for (ImageBuf::ConstIterator<float> r(R); !r.done(); ++r) {
+        OIIO_CHECK_EQUAL (r[0], Acolor);
+        OIIO_CHECK_EQUAL (r[1], Bcolor);
+    }
+}
+
+
+
 // Tests ImageBufAlgo::add
 void test_add ()
 {
+    std::cout << "test add\n";
     const int WIDTH = 8;
     const int HEIGHT = 8;
     const int CHANNELS = 4;
@@ -227,6 +254,7 @@ void test_add ()
 // Tests ImageBufAlgo::compare
 void test_compare ()
 {
+    std::cout << "test compare\n";
     // Construct two identical 50% grey images
     const int WIDTH = 10, HEIGHT = 10, CHANNELS = 3;
     ImageSpec spec (WIDTH, HEIGHT, CHANNELS, TypeDesc::FLOAT);
@@ -275,6 +303,7 @@ main (int argc, char **argv)
     test_zero_fill ();
     test_crop ();
     test_paste ();
+    test_channel_append ();
     test_add ();
     test_compare ();
     

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -154,9 +154,11 @@ ImageRec::ImageRec (const std::string &name, int nsubimages,
         m_subimages[s].m_miplevels.resize (miplevels[s]);
         m_subimages[s].m_specs.resize (miplevels[s]);
         for (int m = 0;  m < miplevels[s];  ++m) {
-            ImageBuf *ib = new ImageBuf (name, specs[specnum]);
+            ImageBuf *ib = specs ? new ImageBuf (name, specs[specnum])
+                                 : new ImageBuf (name);
             m_subimages[s].m_miplevels[m].reset (ib);
-            m_subimages[s].m_specs[m] = specs[specnum];
+            if (specs)
+                m_subimages[s].m_specs[m] = specs[specnum];
             ++specnum;
         }
     }

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -218,8 +218,9 @@ public:
     // for each subimages is in miplevels[0..nsubimages-1], and specs[]
     // contains the specs for all the MIP levels of subimage 0, followed
     // by all the specs for the MIP levels of subimage 1, and so on.
+    // If spec == NULL, the IB's will not be fully allocated/initialized.
     ImageRec (const std::string &name, int nsubimages,
-              const int *miplevels, const ImageSpec *specs);
+              const int *miplevels, const ImageSpec *specs=NULL);
 
     // Number of subimages
     int subimages() const { return (int) m_subimages.size(); }


### PR DESCRIPTION
IBA::channel_append() (exposed as oiiotool --chappend) takes two input images and produces an output that is the channels of the two images appended to each other.

oiiotool --chnames lets you rename some or all of the channels of an image.

Here's an example of how this might be used to take an RGBA file and a separate Z file, and combine them into a single RGBAZ file (and make sure that the last channel is named "Z" regardless of what it was called in the image it came from):

```
oiiotool rgba.exr z.exr --chappend --chnames ",,,,Z" -o rgbaz.exr
```
