### PR TITLE
ImageBufAlgo API overhaul for uniformity.

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -132,7 +132,7 @@ void test_crop ()
     ImageBufAlgo::fill (A, arbitrary1);
 
     // Test CUT crop
-    ImageBufAlgo::crop (B, A, xbegin, xend, ybegin, yend);
+    ImageBufAlgo::crop (B, A, ROI(xbegin, xend, ybegin, yend));
 
     // Should have changed the data window (origin and width/height)
     OIIO_CHECK_EQUAL (B.spec().x, xbegin);

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -583,7 +583,8 @@ write_mipmap (ImageBufAlgo::MakeTextureMode mode,
                     outstream << "WARNING: Custom mip level \"" << mipimages[0]
                               << " had the wrong number of channels.\n";
                     boost::shared_ptr<ImageBuf> t (new ImageBuf (mipimages[0], smallspec));
-                    ImageBufAlgo::setNumChannels(*t, *small, outspec.nchannels);
+                    ImageBufAlgo::channels(*t, *small, outspec.nchannels,
+                                           NULL, NULL, NULL, true);
                     std::swap (t, small);
                 }
                 smallspec.tile_width = outspec.tile_width;
@@ -879,7 +880,8 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
         if (verbose)
             outstream << "  Alpha==1 image detected. Dropping the alpha channel.\n";
         boost::shared_ptr<ImageBuf> newsrc (new ImageBuf(src->name() + ".noalpha", src->spec()));
-        ImageBufAlgo::setNumChannels (*newsrc, *src, src->nchannels()-1);
+        ImageBufAlgo::channels (*newsrc, *src, src->nchannels()-1,
+                                NULL, NULL, NULL, true);
         std::swap (src, newsrc);   // N.B. the old src will delete
     }
 
@@ -891,7 +893,7 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
         if (verbose)
             outstream << "  Monochrome image detected. Converting to single channel texture.\n";
         boost::shared_ptr<ImageBuf> newsrc (new ImageBuf(src->name() + ".monochrome", src->spec()));
-        ImageBufAlgo::setNumChannels (*newsrc, *src, 1);
+        ImageBufAlgo::channels (*newsrc, *src, 1, NULL, NULL, NULL, true);
         std::swap (src, newsrc);
     }
 
@@ -901,7 +903,7 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
         if (verbose)
             outstream << "  Overriding number of channels to " << nchannels << "\n";
         boost::shared_ptr<ImageBuf> newsrc (new ImageBuf(src->name() + ".channels", src->spec()));
-        ImageBufAlgo::setNumChannels (*newsrc, *src, nchannels);
+        ImageBufAlgo::channels (*newsrc, *src, nchannels, NULL, NULL, NULL, true);
         std::swap (src, newsrc);
     }
     

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -795,7 +795,8 @@ make_texturemap (const char *maptypename = "texture map")
           nchannels < 0 &&
           ImageBufAlgo::isConstantChannel(src,src.spec().alpha_channel,1.0f)) {
         ImageBuf newsrc(src.name() + ".noalpha", src.spec());
-        ImageBufAlgo::setNumChannels (newsrc, src, src.nchannels()-1);
+        ImageBufAlgo::channels (newsrc, src, src.nchannels()-1,
+                                NULL, NULL, NULL, true);
         src.copy (newsrc);
         if (verbose) {
             std::cout << "  Alpha==1 image detected. Dropping the alpha channel.\n";
@@ -807,7 +808,7 @@ make_texturemap (const char *maptypename = "texture map")
           src.nchannels() == 3 && src.spec().alpha_channel < 0 &&  // RGB only
           ImageBufAlgo::isMonochrome(src)) {
         ImageBuf newsrc(src.name() + ".monochrome", src.spec());
-        ImageBufAlgo::setNumChannels (newsrc, src, 1);
+        ImageBufAlgo::channels (newsrc, src, 1, NULL, NULL, NULL, true);
         src.copy (newsrc);
         if (verbose) {
             std::cout << "  Monochrome image detected. Converting to single channel texture.\n";
@@ -818,7 +819,7 @@ make_texturemap (const char *maptypename = "texture map")
     // specific number of channels, do it.
     if ((nchannels > 0) && (nchannels != src.nchannels())) {
         ImageBuf newsrc(src.name() + ".channels", src.spec());
-        ImageBufAlgo::setNumChannels (newsrc, src, nchannels);
+        ImageBufAlgo::channels (newsrc, src, nchannels, NULL, NULL, NULL, true);
         src.copy (newsrc);
         if (verbose) {
             std::cout << "  Overriding number of channels to " << nchannels << "\n";
@@ -1290,7 +1291,8 @@ write_mipmap (ImageBuf &img, const ImageSpec &outspec_template,
                     std::cout << "WARNING: Custom mip level \"" << mipimages[0]
                               << " had the wrong number of channels.\n";
                     ImageBuf *t = new ImageBuf (mipimages[0], smallspec);
-                    ImageBufAlgo::setNumChannels(*t, *small, outspec.nchannels);
+                    ImageBufAlgo::channels (*t, *small, outspec.nchannels,
+                                            NULL, NULL, NULL, true);
                     std::swap (t, small);
                     delete t;
                 }

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1583,13 +1583,12 @@ action_pattern (int argc, const char *argv[])
             pattern = pattern.substr (pos+1, std::string::npos);
             if (Strutil::istarts_with(pattern,"width="))
                 width = atoi (pattern.substr(6, std::string::npos).c_str());
+            // FIXME: allow full 3-D size and offset to be specified
         }
         std::vector<float> color1 (nchans, 0.0f);
         std::vector<float> color2 (nchans, 1.0f);
-        bool ok = ImageBufAlgo::checker (ib, width, &color1[0], &color2[0],
-                                         ib.xbegin(), ib.xend(),
-                                         ib.ybegin(), ib.yend(),
-                                         ib.zbegin(), ib.zend());
+        bool ok = ImageBufAlgo::checker (ib, width, width, width,
+                                         &color1[0], &color2[0], 0, 0, 0);
         if (! ok)
             ot.error (argv[0], ib.geterror());
     } else {
@@ -1648,8 +1647,7 @@ action_crop (int argc, const char *argv[])
         ot.push (new ImageRec (A->name(), newspec, ot.imagecache));
         const ImageBuf &Aib ((*A)(0,0));
         ImageBuf &Rib ((*ot.curimg)(0,0));
-        bool ok = ImageBufAlgo::crop (Rib, Aib, newspec.x, newspec.x+newspec.width,
-                                      newspec.y, newspec.y+newspec.height);
+        bool ok = ImageBufAlgo::crop (Rib, Aib, get_roi(newspec));
         if (! ok)
             ot.error (argv[0], Rib.geterror());
     } else if (newspec.x != Aspec.x || newspec.y != Aspec.y) {


### PR DESCRIPTION
Make all the ImageBufAlgo functions conform to the new conventions:
- Take ROI rather than xbegin/xend (or in some cases not taking any
  region specification).
- Use the DISPATCH macros to make work with all types where practical,
  common types otherwise, and document which types it works with.
- Use Iterator, not getpixel/setpixel.
- Multithread when operating on enough pixels.
- Make 3-D where applicable.
- More care in uniformly handling uninitialized destination image or
  undefined ROI.
- More clear documentation overall.

In this commit, we tackle zero, fill, channels, crop, paste.
More than enough to review, save the rest for later.
