### PR TITLE
oiiotool --frames and --framepadding give more wildcard flexibility.

### DIFF
--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -54,11 +54,13 @@ an example:
 
 \NEW
 It is also possible to have \oiiotool operate on numbered sequences of
-images.  Image sequences are specified by having filename arguments to
+images.  In effect, this will execute the \oiiotool command several
+times, making substitutions to the sequence arguments in turn.
+
+Image sequences are specified by having filename arguments to
 oiiotool use either a numeric wildcard (designated by ``{\cf \#}'') or an
-explicit numeric range (designated such as ``{\cf 1-10\#}'').  In effect,
-this will execute the \oiiotool command several times, making
-substitutions to the sequence arguments in turn.  For example:
+explicit numeric range (designated such as ``{\cf 1-10\#}''), or
+spelling out a more complex pattern with {\cf --frames}.  For example:
 
 \begin{code}
     oiiotool big.#.tif --resize 100x100 -o small.#.tif
@@ -79,6 +81,22 @@ sequence of commands:
 \begin{code}
     oiiotool big.1-3#.tif --resize 100x100 -o small.1-3#.tif
 \end{code}
+
+You can also explicitly use the {\cf --frames} to specify a frame
+sequence very flexibly as a sequence of comma-separated subsequences,
+where each subsequence is a single frame (e.g., {\cf 100}), a range of
+frames ({\cf 100-150}), or a frame range with step size ({\cf 100-150x4}).
+An optional {\cf --framepadding} can be used to change the default number
+of digits (with leading zeroes applied) that the frame numbers should
+have.  It defaults to 4.
+For example,
+\begin{code}
+    oiiotool --framepadding 3 --frames 3,4,10-20x2 blah.#.tif
+\end{code}
+\noindent would match {\cf blah.003.tif}, {\cf blah.004.tif},
+{\cf blah.010.tif}, {\cf blah.012.tif}, 
+{\cf blah.014.tif}, {\cf blah.016.tif}, {\cf blah.018.tif}, 
+{\cf blah.020.tif}.
 
 
 \section{\oiiotool Tutorial / Recipes}
@@ -322,6 +340,11 @@ series of files with frame numbers in their names:
     oiiotool fg.1-50#.exr bg.1-50#.exr --over -o comp.1-50#.exr
 \end{code}
 
+\noindent Or,
+\begin{code}
+    oiiotool --frames 1-50 fg.#.exr bg.#.exr --over -o comp.#.exr
+\end{code}
+
 
 \newpage
 \section{\oiiotool commands: general}
@@ -390,6 +413,27 @@ overridden, even if the {\cf -o} command specifies that file.
 Use \emph{n} execution threads if it helps to speed up image operations.
 The default (also if $n=0$) is to use as many threads as there are cores
 present in the hardware.
+\apiend
+
+\apiitem{--frames \emph{seq}\\
+--framepadding \emph{n}}
+\NEW
+Describes the frame range to substitute for the {\cf \#} wildcard.  The
+sequence is a comma-separated list of subsequences; each subsequence
+is a single frame (e.g., {\cf 100}), a range of frames ({\cf 100-150}),
+or a frame range with step ({\cf 100-150x4} means {\cf  100,104,108,...}).
+
+The frame padding is the number of digits (with leading zeroes applied)
+that the frame numbers should have.  It defaults to 4.
+
+For example,
+\begin{code}
+    oiiotool --framepadding 3 --frames 3,4,10-20x2 blah.#.tif
+\end{code}
+\noindent would match {\cf blah.003.tif}, {\cf blah.004.tif},
+{\cf blah.010.tif}, {\cf blah.012.tif}, 
+{\cf blah.014.tif}, {\cf blah.016.tif}, {\cf blah.018.tif}, 
+{\cf blah.020.tif}.
 \apiend
 
 \begin{comment}

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -2221,6 +2221,8 @@ getargs (int argc, char *argv[])
                 "--no-clobber", &ot.noclobber, "Do not overwrite existing files",
                 "--noclobber", &ot.noclobber, "", // synonym
                 "--threads %@ %d", set_threads, &ot.threads, "Number of threads (default 0 == #cores)",
+                "--frames %s", NULL, "Frame range for '#' wildcards",
+                "--framepadding %d", NULL, "Frame number padding digits",
                 "<SEPARATOR>", "Commands that write images:",
                 "-o %@ %s", output_file, NULL, "Output the current image to the named file",
                 "<SEPARATOR>", "Options that affect subsequent image output:",
@@ -2342,11 +2344,44 @@ getargs (int argc, char *argv[])
 
 
 
+// Given a sequence description, generate numbers.
+static void
+generate_sequence (std::string seqdesc, int framepadding,
+                   std::vector<std::string> &numbers)
+{
+    numbers.clear ();
+    std::string format = Strutil::format ("%%0%dd", framepadding);
+
+    // Split the sequence description into comma-separated subranges.
+    std::vector<std::string> sequences;
+    Strutil::split (seqdesc, sequences, ",");
+
+    // For each subrange...
+    BOOST_FOREACH (std::string s, sequences) {
+        // It's START, START-END, or START-ENDxSTEP
+        std::vector<std::string> range;
+        Strutil::split (s, range, "-");
+        int first = strtol (range[0].c_str(), NULL, 10);
+        int last = first;
+        int step = 1;
+        if (range.size() > 1) {
+            last = strtol (range[1].c_str(), NULL, 10);
+            if (const char *x = strchr (range[1].c_str(), 'x'))
+                step = std::max (1, (int) strtol (x+1, NULL, 10));
+        }
+        for (int i = first; i <= last; i += step)
+            numbers.push_back (Strutil::format (format.c_str(), i));
+    }
+    // std::cout << "Sequence " << Strutil::join(numbers, " ") << "\n";
+}
+
+
+
 // Given a pattern (such as "foo.#.tif" or "bar.1-10#.exr"), produce a
 // list of matching filenames.  Explicit ranges enumerate the range,
 // whereas full numeric wildcards search for existing files.
 static bool
-deduce_sequence (std::string pattern,
+deduce_sequence (std::string pattern, int framepadding,
                  std::vector<std::string> &filenames,
                  std::vector<std::string> &numbers)
 {
@@ -2381,11 +2416,10 @@ deduce_sequence (std::string pattern,
         // Check the first one and assume it's the same for all.
         for (int r = rangefirst; r <= rangelast; ++r) {
             // Try up to 4 leading zeroes
-            static const char *formats[] = { "%01d", "%02d", "%03d", "%04d",
-                                             NULL };
             std::string f, num;
-            for (int i = 0; formats[i]; ++i) {
-                std::string num = Strutil::format (formats[i], r);
+            for (int i = 1; i <= framepadding; ++i) {
+                std::string fmt = Strutil::format ("%%0%dd", i);
+                std::string num = Strutil::format (fmt.c_str(), r);
                 f = prefix + num + suffix;
                 if (Filesystem::exists (f))
                     break;  // found it
@@ -2442,7 +2476,10 @@ handle_sequence (int argc, const char **argv)
 {
     // First, scan the original command line arguments for '#'
     // characters.  Any found indicate that there are numeric rnage or
-    // wildcards to deal with.
+    // wildcards to deal with.  Also look for --frames and --framepadding
+    // options.
+    std::string framenumbers_string;
+    int framepadding = 4;
     std::vector<int> sequence_args;  // Args with sequence numbers
     bool is_sequence = false;
     for (int a = 1;  a < argc;  ++a) {
@@ -2450,22 +2487,35 @@ handle_sequence (int argc, const char **argv)
             is_sequence = true;
             sequence_args.push_back (a);
         }
+        if (! strcmp (argv[a], "--frames") && a < argc-1) {
+            framenumbers_string = argv[++a];
+        }
+        else if (! strcmp (argv[a], "--framepadding") && a < argc-1) {
+            int f = atoi (argv[++a]);
+            if (f >= 1 && f < 10)
+                framepadding = f;
+        }
     }
 
     // No ranges or wildcards?
     if (! is_sequence)
         return false;
 
+    std::vector<std::string> numbers;
+
+    // If an explicit frame sequence was given, elaborate it.
+    if (framenumbers_string.size())
+        generate_sequence (framenumbers_string, framepadding, numbers);
+
     // For each of the arguments that contains a wildcard, use
     // deduce_sequence to fully elaborate all the filenames in the
     // sequence.  It's an error if the sequences are not all of the
     // same length.
     std::vector< std::vector<std::string> > filenames (argc+1);
-    std::vector<std::string> numbers;
     size_t nfilenames = 0;
     for (size_t i = 0;  i < sequence_args.size();  ++i) {
         int a = sequence_args[i];
-        deduce_sequence (argv[a], filenames[a], numbers);
+        deduce_sequence (argv[a], framepadding, filenames[a], numbers);
         if (i == 0) {
             nfilenames = filenames[a].size();
         } else if (nfilenames != filenames[a].size()) {


### PR DESCRIPTION
When using oiiotool with numeric wildcards ("foo.#.exr"), rather than rely strictly on matching exiting filenames, the --frames option allows for explicit flexible frame sequence specification, and --framepadding overrides the default number of digits (with leading zeroes) for frame numbers. Examples of frame sequences now supported:

```
10,11,13,14       Commas separate subsequences
10-14             Range
10-14x2           Range with step (matches 10, 12, 14)
```

Putting it all together, you can have a command like

```
oiiotool --info --frames 10,18,20-30x5 --framepadding 3 foo.#.exr
```

would match foo.010.exr, foo.018.exr, foo.020.exr, foo.025.exr, foo.030.exr
