### PR TITLE
Fix for number of bytes copied in encode_exif()

### DIFF
--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -955,7 +955,7 @@ encode_exif (const ImageSpec &spec, std::vector<char> &blob)
         reoffset (exifdirs, exif_tagmap, datastart);
         unsigned short nd = exifdirs.size();
         data.insert (data.end(), (char *)&nd, (char *)&nd + sizeof(nd));
-        data.insert (data.end(), (char *)&exifdirs[0], (char *)&exifdirs[0] + exifdirs.size());
+        data.insert (data.end(), (char *)&exifdirs[0], (char *)(&exifdirs[0] + exifdirs.size()));
         data.insert (data.end(), (char *)&endmarker, (char *)&endmarker + sizeof(int));
     }
 
@@ -966,7 +966,7 @@ encode_exif (const ImageSpec &spec, std::vector<char> &blob)
         reoffset (gpsdirs, gps_tagmap, datastart);
         unsigned short nd = gpsdirs.size();
         data.insert (data.end(), (char *)&nd, (char *)&nd + sizeof(nd));
-        data.insert (data.end(), (char *)&gpsdirs[0], (char *)&gpsdirs[0] + gpsdirs.size());
+        data.insert (data.end(), (char *)&gpsdirs[0], (char *)(&gpsdirs[0] + gpsdirs.size()));
         data.insert (data.end(), (char *)&endmarker, (char *)&endmarker + sizeof(int));
     }
 


### PR DESCRIPTION
Currently the number of bytes copied is equal to the number of elements in the exifdirs vector (and likewise for gpsdirs), instead of number of elements \* sizeof(element). This should fix that!
