### PR TITLE
Better error handling for oiiotool --diff.

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -376,10 +376,6 @@ output_file (int argc, const char *argv[])
 {
     ASSERT (argc == 2 && !strcmp(argv[0],"-o"));
 
-    // Don't produce output if we've had a fatal error
-    if (ot.return_value == EXIT_FAILURE)
-        return 0;
-
     Timer timer (ot.enable_function_timing);
     ot.total_writetime.start();
     std::string filename = argv[1];
@@ -1237,6 +1233,10 @@ action_diff (int argc, const char *argv[])
     int ret = do_action_diff (*ot.image_stack.back(), *ot.curimg, ot);
     if (ret != DiffErrOK && ret != DiffErrWarn)
         ot.return_value = EXIT_FAILURE;
+
+    if (ret != DiffErrOK && ret != DiffErrWarn && ret != DiffErrFail)
+        ot.error ("Error doing --diff");
+
     ot.function_times["diff"] += timer();
     return 0;
 }

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -140,7 +140,7 @@ public:
 
     ImageRecRef top () { return curimg; }
 
-    void error (const std::string &command, const std::string &explanation);
+    void error (const std::string &command, const std::string &explanation="");
 
 private:
     CallbackFunction m_pending_callback;


### PR DESCRIPTION
Botched the last error handling patch -- this is what I wanted.
The difference is that we want a "failed to match" to output the difference
image, if that is requested.  But a "failed to diff" (e.g. images have
differing number of channels) should be a real failure and abort.
