### PR TITLE
fixes OIIO issue 518, extra_attribs properly responds to iterator calls

### DIFF
--- a/src/python/py_paramvalue.cpp
+++ b/src/python/py_paramvalue.cpp
@@ -127,6 +127,7 @@ void declare_paramvalue()
     class_<ParamValueList>("ParamValueList")
         .def("__getitem__", &ParamValueList_getitem,
             return_internal_reference<>())
+        .def("__iter__", boost::python::iterator<ParamValueList>())
         .def("__len__",     &ParamValueList::size)
         .def("grow",        &ParamValueList::grow,
             return_internal_reference<>())


### PR DESCRIPTION
Previously when iterating on extra_attribs there was a segfault once it got to iter::end, by adding the **iter**  and the proper iter call, python can handle the end of the iteration gracefully.
