### PR TITLE
Move shared_ptr and intrusive_ptr from the global to the OIIO namespace

### DIFF
--- a/src/include/refcnt.h
+++ b/src/include/refcnt.h
@@ -44,13 +44,15 @@
 
 // Use Boost for shared pointers
 #include <boost/shared_ptr.hpp>
-using boost::shared_ptr;
 #include <boost/intrusive_ptr.hpp>
-using boost::intrusive_ptr;
 
 
 OIIO_NAMESPACE_ENTER
 {
+
+using boost::shared_ptr;
+using boost::intrusive_ptr;
+
 
 /// Mix-in class that adds a reference count, implemented as an atomic
 /// counter.


### PR DESCRIPTION
This avoids conflicts when another package already defines them, in particular this OSL issue:
https://github.com/imageworks/OpenShadingLanguage/issues/242
