### PR TITLE
ImageInput close/dtr leaving files open fixes

### DIFF
--- a/src/iff.imageio/iff_pvt.h
+++ b/src/iff.imageio/iff_pvt.h
@@ -142,7 +142,7 @@ namespace iff_pvt {
 class IffInput : public ImageInput {
 public:
     IffInput () { init(); }
-    virtual ~IffInput () { }
+    virtual ~IffInput () { close(); }
     virtual const char *format_name (void) const { return "iff"; }
     virtual bool open (const std::string &name, ImageSpec &spec);
     virtual bool close (void);

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -40,6 +40,8 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 
 class PNMInput : public ImageInput {
 public:
+    PNMInput() { }
+    virtual ~PNMInput() { close(); }
     virtual const char* format_name (void) const { return "pnm"; }
     virtual bool open (const std::string &name, ImageSpec &newspec);
     virtual bool close ();
@@ -349,8 +351,7 @@ PNMInput::read_file_header ()
 bool
 PNMInput::open (const std::string &name, ImageSpec &newspec)
 {
-    if (m_file.is_open()) //close previously opened file
-        m_file.close();
+    close(); //close previously opened file
 
     Filesystem::open (m_file, name, std::ios::in|std::ios::binary);
 
@@ -369,7 +370,8 @@ PNMInput::open (const std::string &name, ImageSpec &newspec)
 bool
 PNMInput::close ()
 {
-    m_file.close();
+    if (m_file.is_open())
+        m_file.close();
     return true;
 }
 

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -200,7 +200,8 @@ PNMOutput::open (const std::string &name, const ImageSpec &userspec,
 bool
 PNMOutput::close ()
 {
-    m_file.close();
+    if (m_file.is_open())
+        m_file.close();
     return true;  
 }
 

--- a/src/sgi.imageio/sgi_pvt.h
+++ b/src/sgi.imageio/sgi_pvt.h
@@ -90,7 +90,7 @@ namespace sgi_pvt {
 class SgiInput : public ImageInput {
  public:
     SgiInput () { init(); }
-    virtual ~SgiInput () { }
+    virtual ~SgiInput () { close(); }
     virtual const char *format_name (void) const { return "sgi"; }
     virtual bool valid_file (const std::string &filename) const;
     virtual bool open (const std::string &name, ImageSpec &spec);
@@ -139,7 +139,7 @@ class SgiInput : public ImageInput {
 class SgiOutput : public ImageOutput {
  public:
     SgiOutput () : m_fd(NULL) { }
-    virtual ~SgiOutput () { }
+    virtual ~SgiOutput () { close(); }
     virtual const char *format_name (void) const { return "sgi"; }
     virtual bool supports (const std::string &feature) const { return false; }
     virtual bool open (const std::string &name, const ImageSpec &spec,


### PR DESCRIPTION
- For a couple formats, the ImageInput dtr didn't automatcially close() the
  file if it was still open.
- For a couple formats, a redundant call to close() might have strange
  effects because it didn't double check that the file was open.

I'm pretty sure that the docs don't say anything that would guarantee that the ImageInput dtr will close a file if still opened (without an explicit call to close by the app). But almost all of them did call close automatically upon destruction.  This just fixes the few that did not.
