### PR TITLE
Targa fixes

### DIFF
--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -475,34 +475,16 @@ TGAInput::decode_pixel (unsigned char *in, unsigned char *out,
     switch (m_tga.type) {
     case TYPE_PALETTED:
     case TYPE_PALETTED_RLE:
-        switch (bytespp) {
-        case 1:
-            k = in[0];
-            break;
-        case 2:
-            k = *((unsigned int *)in) & 0x0000FFFF;
-            if (bigendian())
-                swap_endian (&k);
-            break;
-        case 3:
-            k = *((unsigned int *)in) & 0x00FFFFFF;
-            if (bigendian())
-                swap_endian (&k);
-            break;
-        case 4:
-            k = *((unsigned int *)in);
-            if (bigendian())
-                swap_endian (&k);
-            break;
-        }
+        for (int i = 0;  i < bytespp;  ++i)
+            k |= in[i] << (8*i);  // Assemble it in little endian order
         k = (m_tga.cmap_first + k) * palbytespp;
         switch (palbytespp) {
         case 2:
             // see the comment for 16bpp RGB below for an explanation of this
-            out[2] = bit_range_convert<5, 8> ((palette[k + 1] & 0x7C) >> 2);
+            out[0] = bit_range_convert<5, 8> ((palette[k + 1] & 0x7C) >> 2);
             out[1] = bit_range_convert<5, 8> (((palette[k + 0] & 0xE0) >> 5)
                                             | ((palette[k + 1] & 0x03) << 3));
-            out[0] = bit_range_convert<5, 8> (palette[k + 0] & 0x1F);
+            out[2] = bit_range_convert<5, 8> (palette[k + 0] & 0x1F);
             break;
         case 3:
             out[0] = palette[k + 2];

--- a/testsuite/targa-tgautils/ref/out.txt
+++ b/testsuite/targa-tgautils/ref/out.txt
@@ -18,7 +18,7 @@ Comparing "../../../../../TGAUTILS/CBW8.TGA" and "CBW8.TGA"
 PASS
 Reading ../../../../../TGAUTILS/CCM8.TGA
 ../../../../../TGAUTILS/CCM8.TGA :  128 x  128, 3 channel, uint2 targa
-    SHA-1: 1CA776B45486FB52A5A8953F9BAE94975933334D
+    SHA-1: C3CFE6424C5A9D88BB212BFE230F5B9875F434C4
     channel list: R, G, B
     oiio:BitsPerSample: 2
     compression: "rle"
@@ -107,7 +107,7 @@ Comparing "../../../../../TGAUTILS/UBW8.TGA" and "UBW8.TGA"
 PASS
 Reading ../../../../../TGAUTILS/UCM8.TGA
 ../../../../../TGAUTILS/UCM8.TGA :  128 x  128, 3 channel, uint2 targa
-    SHA-1: 1CA776B45486FB52A5A8953F9BAE94975933334D
+    SHA-1: C3CFE6424C5A9D88BB212BFE230F5B9875F434C4
     channel list: R, G, B
     oiio:BitsPerSample: 2
     targa:ImageID: "Truevision(R) Sample Image"


### PR DESCRIPTION
1. From Michel Lerenard, a more robust check for presence of alpha. The previous check could fail for certain alpha flag, incorrectly thinking it was a 2-channel image instead of 1, or 4 channel instead of 3.
2. In the process of checking this result against various test cases, LG also noticed that we were incorrectly decoding 16 bit palette images by swapping the R and B channels, and there's a fairly obvious fix for that (also a slight simplification of code nearby).
