### PR TITLE
fmath.h: Add 'safe' inversesqrt, log, log2, log10, logb

### DIFF
--- a/src/include/fmath.h
+++ b/src/include/fmath.h
@@ -889,7 +889,7 @@ roundf (float val) {
 #ifdef _MSC_VER
 template<class T>
 inline int isinf (T x) {
-    return (isfinite(x)||isnan(x)) ? 0 : static_cast<int>(copysign(1.0f, x));
+    return (isfinite(x)||isnan(x)) ? 0 : static_cast<int>(copysign(T(1.0), x));
 }
 #endif
 
@@ -977,7 +977,16 @@ truncf(float val)
     return (float)(int)val;
 }
 
-#endif
+using OIIO::roundf;
+using OIIO::truncf;
+using OIIO::expm1f;
+using OIIO::erff;
+using OIIO::erfcf;
+using OIIO::log2f;
+using OIIO::logbf;
+using OIIO::exp2f;
+
+#endif  /* _WIN32 */
 
 
 // Some systems have isnan, isinf and isfinite in the std namespace.
@@ -997,6 +1006,7 @@ log2f (float val) {
     return logf (val)/static_cast<float>(M_LN2);
 }
 
+using OIIO::log2f;
 #endif
 
 
@@ -1100,6 +1110,27 @@ inline float
 safe_sqrtf (float x)
 {
     return (x > 0.0f) ? sqrtf(x) : 0.0f;
+}
+
+/// Safe (clamping) inverse sqrt
+inline float safe_inversesqrt (float x) {
+    return (x > 0.0f) ? 1.0f/std::sqrt(x) : 0.0f;
+}
+
+inline float safe_log (float x) {
+    return (x > 0.0f) ? logf(x) : -std::numeric_limits<float>::max();
+}
+
+inline float safe_log2(float x) {
+    return (x > 0.0f) ? log2f(x) : -std::numeric_limits<float>::max();
+}
+
+inline float safe_log10(float x) {
+    return (x > 0.0f) ? log10f(x) : -std::numeric_limits<float>::max();
+}
+
+inline float safe_logb (float x) {
+    return (x != 0.0f) ? logbf(x) : -std::numeric_limits<float>::max();
 }
 
 


### PR DESCRIPTION
Gathering all the 'safe' (no NaN or Infs returned) versions in one place.
