### PR TITLE
Define 'USING_OIIO_PUGI' when using the OIIO-internal version of PugiXML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,10 @@ ifneq (${USE_OPENSSL},)
 MY_CMAKE_FLAGS += -DUSE_OPENSSL:BOOL=${USE_OPENSSL}
 endif
 
+ifneq (${USE_EXTERNAL_PUGIXML},)
+MY_CMAKE_FLAGS += -DUSE_EXTERNAL_PUGIXML:BOOL=${USE_EXTERNAL_PUGIXML} -DPUGIXML_HOME=${PUGIXML_HOME}
+endif
+
 ifneq (${ILMBASE_HOME},)
 MY_CMAKE_FLAGS += -DILMBASE_HOME:STRING=${ILMBASE_HOME}
 endif
@@ -292,6 +296,7 @@ help:
 	@echo "  make USE_OPENJPEG=0 ...     Don't build the JPEG-2000 plugin"
 	@echo "  make USE_OCIO=0 ...         Don't use OpenColorIO even if found"
 	@echo "  make USE_OPENSSL=0 ...      Don't use OpenSSL even if found"
+	@echo "  make USE_EXTERNAL_PUGIXML=1 Use the system PugiXML, not the one in OIIO"
 	@echo "  make ILMBASE_HOME=path ...  Custom Ilmbase installation"
 	@echo "  make OPENEXR_HOME=path ...  Custom OpenEXR installation"
 	@echo "  make BUILDSTATIC=1 ...      Build static library instead of shared"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,6 +94,7 @@ set (NOTHREADS OFF CACHE BOOL "Compile with no threads or locking")
 set (PYTHON_VERSION 2.6)
 set (USE_EXTERNAL_PUGIXML OFF CACHE BOOL
      "Use an externally built shared library version of the pugixml library")
+set (PUGIXML_HOME "" CACHE STRING "Hint about where to find external PugiXML library")
 set (USE_EXTERNAL_TBB OFF CACHE BOOL
      "Use system TBB library instead of bundled.")
 

--- a/src/cmake/modules/FindPugiXML.cmake
+++ b/src/cmake/modules/FindPugiXML.cmake
@@ -6,8 +6,12 @@
 # PUGIXML_LIBRARIES - library to link against
 # PUGIXML_FOUND - true if pugixml was found.
 
-find_path (PUGIXML_INCLUDE_DIR pugixml.hpp)
-find_library (PUGIXML_LIBRARY NAMES pugixml)
+find_path (PUGIXML_INCLUDE_DIR
+           NAMES pugixml.hpp
+           PATHS ${PUGIXML_HOME}/include)
+find_library (PUGIXML_LIBRARY
+              NAMES pugixml
+              PATHS ${PUGIXML_HOME}/lib)
 
 # Support the REQUIRED and QUIET arguments, and set PUGIXML_FOUND if found.
 include (FindPackageHandleStandardArgs)
@@ -16,6 +20,10 @@ FIND_PACKAGE_HANDLE_STANDARD_ARGS (PugiXML DEFAULT_MSG PUGIXML_LIBRARY
 
 if (PUGIXML_FOUND)
     set (PUGIXML_LIBRARIES ${PUGIXML_LIBRARY})
+    message (STATUS "PugiXML include = ${PUGIXML_INCLUDE_DIR}")
+    message (STATUS "PugiXML library = ${PUGIXML_LIBRARY}")
+else ()
+    message (STATUS "No PugiXML found")
 endif()
 
 mark_as_advanced (PUGIXML_LIBRARY PUGIXML_INCLUDE_DIR)

--- a/src/include/pugixml.hpp
+++ b/src/include/pugixml.hpp
@@ -17,6 +17,11 @@
 #include "pugiconfig.hpp"
 #include "version.h"
 
+// Signify that we use Pugixml embedded in OIIO.  If OIIO is compiled with
+// the system Pugi, this will not be defined.
+#define USING_OIIO_PUGI 1
+
+
 #ifndef PUGIXML_NO_STL
 namespace std
 {

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -258,7 +258,6 @@ if (EMBEDPLUGINS)
                                ${HDF5_LIBRARIES}
                                ${OPENJPEG_LIBRARIES}
                                ${WEBP_LIBRARY}
-                               ${OPENJPEG_LIBRARIES}
                           )
     link_openexr (OpenImageIO)
 endif ()


### PR DESCRIPTION
This is going to help OSL builds for people who built OIIO using the system version of PugiXML and told the OIIO build system not to use the bundled one.
