### PR TITLE
ImageBufAlgo::color_count() and oiiotool --colorcount

### DIFF
--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -466,6 +466,26 @@ it effectively ensures that alpha will not be considered in the matching
 of pixels to the color value.
 \apiend
 
+\apiitem{--rangecheck \emph{Rlow,Glow,Blow,...}  \emph{Rhi,Bhi,Ghi,...}}
+\NEW
+Given a two colors (each a comma-separated list of values for each
+channel), print a count of the number of pixels in the image that has
+channel values outside the [low,hi] range.  Any channels not
+specified will assume a low of 0.0 and high of 1.0.
+
+\noindent Example:
+
+\begin{code}
+    oiiotool test.exr --rangecheck 0,0,0 1,1,1
+\end{code}
+\noindent might produce the following output:
+\begin{code}
+     0  < 0,0,0
+   221  > 1,1,1
+ 65315  within range
+\end{code}
+\apiend
+
 \apiitem{--no-clobber}
 Sets ``no clobber'' mode, in which existing images on disk will never be 
 overridden, even if the {\cf -o} command specifies that file.

--- a/src/include/imagebufalgo.h
+++ b/src/include/imagebufalgo.h
@@ -845,6 +845,31 @@ bool OIIO_API color_count (const ImageBuf &src,
                            const float *eps=NULL,
                            ROI roi=ROI::All(), int nthreads=0);
 
+/// Count how many pixels in the ROI are outside the value range.
+/// low[0..nchans-1] and high[0..nchans-1] are the low and high
+/// acceptable values for each color channel.  The number of pixels
+/// containing values that fall below the lower bound will be stored in
+/// *lowcount, the number of pixels containing values that fall above
+/// the upper bound will be stored in *highcount, and the number of
+/// pixels for which all channels fell within the bounds will be stored
+/// in *inrangecount.
+///
+/// The nthreads parameter specifies how many threads (potentially) may
+/// be used, but it's not a guarantee.  If nthreads == 0, it will use
+/// the global OIIO attribute "nthreads".  If nthreads == 1, it
+/// guarantees that it will not launch any new threads.
+///
+/// Works for all pixel types.
+///
+/// Return true if the operation can be performed, false if there is
+/// some sort of error (and sets an appropriate error message in src).
+bool OIIO_API color_range_check (const ImageBuf &src,
+                                 imagesize_t *lowcount,
+                                 imagesize_t *highcount,
+                                 imagesize_t *inrangecount,
+                                 const float *low, const float *high,
+                                 ROI roi=ROI::All(), int nthreads=0);
+
 /// Compute the SHA-1 byte hash for all the pixels in the specifed
 /// region of the image.  If blocksize > 0, the function will compute
 /// separate SHA-1 hashes of each 'blocksize' batch of scanlines, then

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -23,6 +23,9 @@ constant.tif         :  320 x  240, 4 channel, float tiff
        0  0,0,0
    59136  1,.5,.5
     6400  0,1,0
+       0  < 0,0,0
+    6400  > 1,0.9,1
+   59136  within range
 Reading chname.exr
 chname.exr           :   38 x   38, 5 channel, float openexr
     SHA-1: 6EB25E53358BF3ECDFECD04F662D335DE647A1A6

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -20,6 +20,10 @@ command += (oiio_app("oiiotool")
 command += (oiio_app("oiiotool")
             + " filled.tif --colorcount:eps=.1,.1,.1 0,0,0:1,.5,.5:0,1,0 >> out.txt ;\n")
 
+# test --rangecheck  (using the results of the --fill test)
+command += (oiio_app("oiiotool")
+            + " filled.tif --rangecheck 0,0,0 1,0.9,1 >> out.txt ;\n")
+
 # test resample
 command += (oiio_app ("oiiotool") + " " 
             + parent + "/oiio-images/grid.tif"


### PR DESCRIPTION
Both can be used to count how many pixels match a given color or colors.

The oiiotool version works like this:

```
oiiotool rgb.tif --colorcount 1,0,0:0.18,0.18,0.18
```

would count how many pixels in the image are red, and how many are 18% gray.  It might produce output like:

```
 1830   1,0,0
20495   0.18,0.18,0.18
```

This was requested by a production user, it actually does have a purpose.
