### PR TITLE
Fix oiiotool # wildcard for frame numbers not working on Windows

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -3241,7 +3241,11 @@ deduce_sequence (std::string pattern, int framepadding,
     std::string directory = Filesystem::parent_path (pattern);
     if (directory.size() == 0) {
         directory = ".";
+#ifdef _WIN32
+        pattern = ".\\\\" + pattern;
+#else
         pattern = "./" + pattern;
+#endif
     }
 
     // The pattern is either a range (e.g., "1-15#"), or just a 


### PR DESCRIPTION
It needs a backslash instead of forward slash.

Maybe it is better to fix Filesystem::get_directory_entries so it doesn't require ./ in the regular expression, though strictly speaking that's breaking compatibility in a public API.
