### PR TITLE
Fixes offset overflow in retile

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1654,7 +1654,7 @@ ImageBufImpl::retile (int x, int y, int z, ImageCache::Tile* &tile,
                                        m_current_miplevel, x, y, z);
     }
 
-    size_t offset = ((z - tilezbegin) * th + (y - tileybegin)) * tw
+    size_t offset = ((z - tilezbegin) * (size_t) th + (y - tileybegin)) * (size_t) tw
                     + (x - tilexbegin);
     offset *= m_spec.pixel_bytes();
     DASSERTMSG (m_spec.pixel_bytes() == m_pixel_bytes,


### PR DESCRIPTION
The offset computation here can overflow since x,y,z, tile*begin, tw, th are all ints. So computation happens in ints and that is then cast to size_t.
That causes maketx to crash for textures bigger than 32k x 32k. I have verified that in 0.1, and 1.1
Could this be backported to the older branches too?
Thanks!
r
