### PR TITLE
Fix unused function 'convert_wchar_endian_swap' compilation error on Mac Os X 10.7.5.

### DIFF
--- a/src/libutil/pugixml.cpp
+++ b/src/libutil/pugixml.cpp
@@ -920,10 +920,10 @@ namespace
 		for (size_t i = 0; i < length; ++i) result[i] = endian_swap(data[i]);
 	}
 
-	inline void convert_wchar_endian_swap(wchar_t* result, const wchar_t* data, size_t length)
+	/*inline void convert_wchar_endian_swap(wchar_t* result, const wchar_t* data, size_t length)
 	{
 		for (size_t i = 0; i < length; ++i) result[i] = static_cast<wchar_t>(endian_swap(static_cast<wchar_selector<sizeof(wchar_t)>::type>(data[i])));
-	}
+	}*/
 }
 
 namespace


### PR DESCRIPTION
Closes OpenImageIO/oiio/#617.
