### PR TITLE
Use find_tile in get_tile so that tile microcache is properly updated

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -2346,10 +2346,9 @@ ImageCacheImpl::get_tile (ustring filename, int subimage, int miplevel,
     y = spec.y + ytile * spec.tile_height;
     z = spec.z + ztile * spec.tile_depth;
     TileID id (*file, subimage, miplevel, x, y, z);
-    ImageCacheTileRef tile;
-    if (find_tile_main_cache (id, tile, thread_info)) {
+    if (find_tile(id, thread_info)) {
+        ImageCacheTileRef tile(thread_info->tile);
         tile->_incref();   // Fake an extra reference count
-        tile->use ();
         return (ImageCache::Tile *) tile.get();
     } else {
         return NULL;


### PR DESCRIPTION
There is only one place in the code where find_tile_main_cache is called instead of calling find_tile. Not calling find_tile means that get_tile will not update the microcache.

This small change fixes that issue. Note that this does not really cause any problems besides a slightly stale microcache when get_tile is used.

Removed tile->use() too following Larry's indication.
