### PR TITLE
For deep files, fix some subtle problems with differing per-channel formats

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1306,7 +1306,7 @@ ImageBuf::deep_value (int x, int y, int z, int c, int s) const
     if (s >= nsamps)
         return 0.0f;
     const void *ptr = impl()->m_deepdata.pointers[p*m_spec.nchannels+c];
-    TypeDesc t = m_spec.channelformat(c);
+    TypeDesc t = impl()->m_deepdata.channeltypes[c];
     switch (t.basetype) {
     case TypeDesc::FLOAT :
         return ((const float *)ptr)[s];

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -464,6 +464,9 @@ output_file (int argc, const char *argv[])
     for (int s = 0;  s < ir->subimages();  ++s) {
         ImageSpec spec = *ir->spec(s,0);
         adjust_output_options (spec, ot, supports_tiles);
+        // For deep files, must copy the native deep channelformats
+        if (spec.deep)
+            spec.channelformats = (*ir)(s,0).nativespec().channelformats;
         subimagespecs[s] = spec;
     }
 

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -1174,7 +1174,7 @@ OpenEXROutput::write_deep_scanlines (int ybegin, int yend, int z,
                                sizeof(unsigned int) * m_spec.width);
         frameBuffer.insertSampleCountSlice (countslice);
         for (int c = 0;  c < nchans;  ++c) {
-            size_t chanbytes = m_spec.channelformat(c).size();
+            size_t chanbytes = deepdata.channeltypes[c].size();
             Imf::DeepSlice slice (m_pixeltype[c],
                                   (char *)(&deepdata.pointers[c]
                                            - m_spec.x * nchans


### PR DESCRIPTION
Was ok when all deep channels were the same data type, buggy for mixed types.
