### PR TITLE
Turn off openssl-related warnings on OSX.

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -53,6 +53,11 @@
 #include "thread.h"
 
 #ifdef USE_OPENSSL
+#ifdef __APPLE__
+// Newer OSX releaes mark OpenSSL functions as deprecated, in favor of
+// CDSA.  Make the warnings stop.
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations" 
+#endif
 #include <openssl/sha.h>
 #endif
 


### PR DESCRIPTION
On newer OSX releases, Apple has marked the functions in openssl/sha.h
as deprecated.

Fixes #615
