### PR TITLE
Add a new include search path for OpenJPEG 1.5.

### DIFF
--- a/src/cmake/modules/FindOpenJpeg.cmake
+++ b/src/cmake/modules/FindOpenJpeg.cmake
@@ -60,6 +60,7 @@ set (OpenJpeg_include_paths
      /usr/local/include/openjpeg
      /usr/local/include
      /usr/include/openjpeg
+     /usr/include/openjpeg-1.5
      /usr/include
      /opt/local/include)
 


### PR DESCRIPTION
The OpenJPEG library places its header file in a new directory causing build scripts to not find it. 

[Relevant discussion on the ffmpeg mailing list](http://ffmpeg.org/pipermail/ffmpeg-devel/2012-December/135800.html)
