### PR TITLE
Clean up for tinyformat version 1.2

### DIFF
--- a/src/include/tinyformat.h
+++ b/src/include/tinyformat.h
@@ -717,7 +717,7 @@ inline void format(FormatIterator& fmtIter)
 
 // Define N-argument format function.
 //
-// There's two cases here: c++0x and c++98.
+// There's two cases here: C++11 and C++98.
 #ifdef TINYFORMAT_USE_VARIADIC_TEMPLATES
 
 // First, the simple definition for C++11:

--- a/src/libOpenImageIO/strutil_test.cpp
+++ b/src/libOpenImageIO/strutil_test.cpp
@@ -46,8 +46,7 @@ void test_format ()
                       "'  3' '003' '3  '");
 
     // Test '+' format modifier
-// FIXME -- this fails at the moment, due to tinyformat error
-//    OIIO_CHECK_EQUAL (Strutil::format ("%+d%+d%+d", 3, -3, 0), "+3-3+0");
+    OIIO_CHECK_EQUAL (Strutil::format ("%+d%+d%+d", 3, -3, 0), "+3-3+0");
 
     // FIXME -- we should make comprehensive tests here
 }

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -121,17 +121,7 @@ Oiiotool::clear_options ()
 std::string
 format_resolution (int w, int h, int x, int y)
 {
-#if 0
-    // This should work...
     return Strutil::format ("%dx%d%+d%+d", w, h, x, y);
-    // ... but tinyformat doesn't print the sign for '0' values!  It
-    // appears to be a bug with iostream use of 'showpos' format flag,
-    // specific to certain gcc libs, perhaps only on OSX.  Workaround:
-#else
-    return Strutil::format ("%dx%d%c%d%c%d", w, h,
-                            x >= 0 ? '+' : '-', abs(x),
-                            y >= 0 ? '+' : '-', abs(y));
-#endif
 }
 
 
@@ -139,18 +129,7 @@ format_resolution (int w, int h, int x, int y)
 std::string
 format_resolution (int w, int h, int d, int x, int y, int z)
 {
-#if 0
-    // This should work...
     return Strutil::format ("%dx%dx%d%+d%+d%+d", w, h, d, x, y, z);
-    // ... but tinyformat doesn't print the sign for '0' values!  It
-    // appears to be a bug with iostream use of 'showpos' format flag,
-    // specific to certain gcc libs, perhaps only on OSX.  Workaround:
-#else
-    return Strutil::format ("%dx%dx%d%c%d%c%d%c%d", w, h, d,
-                            x >= 0 ? '+' : '-', abs(x),
-                            y >= 0 ? '+' : '-', abs(y),
-                            z >= 0 ? '+' : '-', abs(z));
-#endif
 }
 
 


### PR DESCRIPTION
This is just to remove the workarounds that had to be added before this bug was fixed on the tinyformat end.

Commit message:

The new version of tinyformat should fix the "%+d" issue on OSX, so
re-enabled the test just to be sure, and remove old workaround code in
oiiotool.  Also a tiny change to align with tagged 1.2 version of
tinyformat.
