### PR TITLE
Several XMP & IPTC metadata handling fixes:

### DIFF
--- a/src/libOpenImageIO/xmp.cpp
+++ b/src/libOpenImageIO/xmp.cpp
@@ -122,6 +122,7 @@ static XMPtag xmptag [] = {
     { "dc:Rights", "Copyright", TypeDesc::STRING, TiffRedundant },
     { "dc:title", "IPTC:ObjectName", TypeDesc::STRING, 0 },
     { "dc:subject", "Keywords", TypeDesc::STRING, IsList },
+    { "dc:keywords", "Keywords", TypeDesc::STRING, IsList },
 
     { "Iptc4xmpCore:IntellectualGenre", "IPTC:IntellectualGenre", TypeDesc::STRING, 0 },
     { "Iptc4xmpCore:CountryCode", "IPTC:CountryCode", TypeDesc::STRING, 0 },
@@ -169,8 +170,10 @@ add_attrib (ImageSpec &spec, const char *xmlname, const char *xmlvalue)
                     bool dup = false;
                     if (p) {
                         Strutil::split (*(const char **)p->data(), items, ";");
-                        for (size_t i = 0;  i < items.size();  ++i)
-                            dup |= (items[i] == xmlvalue);
+                        for (size_t item = 0;  item < items.size();  ++item) {
+                            items[item] = Strutil::strip (items[item]);
+                            dup |= (items[item] == xmlvalue);
+                        }
                         dup |= (xmlvalue == std::string(*(const char **)p->data()));
                     }
                     if (! dup)


### PR DESCRIPTION
- Broken 'for' loop would add keywords under the wrong IPTC tags (stupidly
  used the same named iteration variable in two nested loops, leading to
  hilarity as usual).
- Accept XMP "dc:keywords" as synonym for the more standard "dc:subject".
- Strip spaces in some places where it needed to be done.
- Add semicolon where it was needed, oops a typo 'out + "; "' that should
  have been 'out += "; "', D'oh!
- Guard against IPTC data that is TOO large (it ends up encoding the length
  as a 16 bit int, so we truncate if it's bigger).

This is for you, Dan Wexler!
