### PR TITLE
GCC 4.8 warning fix.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,11 +76,6 @@ if (CMAKE_COMPILER_IS_CLANG)
     add_definitions ("-Qunused-arguments")
 endif ()
 
-if (CMAKE_COMPILER_IS_GNUCC)
-    # Disable warning to prevent gcc 4.8 from failing.
-    add_definitions ("-Wno-unused-local-typedefs")
-endif ()
-
 
 set (VERBOSE OFF CACHE BOOL "Print lots of messages while compiling")
 set (EMBEDPLUGINS ON CACHE BOOL "Embed format plugins in libOpenImageIO")

--- a/src/include/tinyformat.h
+++ b/src/include/tinyformat.h
@@ -259,6 +259,7 @@ inline void formatValue(std::ostream& out, const char* /*fmtBegin*/,
     // Since we don't support printing of wchar_t using "%ls", make it fail at
     // compile time in preference to printing as a void* at runtime.
     typedef typename detail::is_wchar<T>::tinyformat_wchar_is_not_supported DummyType;
+    (void) DummyType();
 #endif
     // The mess here is to support the %c and %p conversions: if these
     // conversions are active we try to convert the type to a char or const


### PR DESCRIPTION
Changes introduced with commit c16d3d6 cause gcc 4.8 to fail:

```
[  0%] Building CXX object libOpenImageIO/CMakeFiles/OpenImageIO.dir/exif.cpp.o
In file included from /home/mariusz/repos/oiio/src/include/strutil.h:53:0,
                 from /home/mariusz/repos/oiio/src/include/ustring.h:137,
                 from /home/mariusz/repos/oiio/src/include/paramlist.h:52,
                 from /home/mariusz/repos/oiio/src/include/imageio.h:59,
                 from /home/mariusz/repos/oiio/src/libOpenImageIO/exif.cpp:74:
/home/mariusz/repos/oiio/src/include/tinyformat.h: In function ‘void tinyformat::formatValue(std::ostream&, const char*, const char*, const T&)’:
/home/mariusz/repos/oiio/src/include/tinyformat.h:261:77: error: typedef ‘DummyType’ locally defined but not used [-Werror=unused-local-typedefs]
     typedef typename detail::is_wchar<T>::tinyformat_wchar_is_not_supported DummyType;
                                                                             ^
cc1plus: all warnings being treated as errors
make[3]: *** [libOpenImageIO/CMakeFiles/OpenImageIO.dir/exif.cpp.o] Error 1
```

[Relevant Chromium issue](https://codereview.chromium.org/10449006/)
