### PR TITLE
More careful with texture de-duplication.

### DIFF
--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -727,9 +727,12 @@ public:
     /// no such file can be found.  This returns a plain old pointer,
     /// which is ok because the file hash table has ref-counted pointers
     /// and those won't be freed until the texture system is destroyed.
+    /// If header_only is true, we are finding the file only for the sake
+    /// of header information (e.g., called by get_image_info).
     ImageCacheFile *find_file (ustring filename,
                                ImageCachePerThreadInfo *thread_info,
-                               ImageInput::Creator creator=NULL);
+                               ImageInput::Creator creator=NULL,
+                               bool header_only=false);
 
     /// Is the tile specified by the TileID already in the cache?
     bool tile_in_cache (const TileID &id,

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -274,17 +274,10 @@ private:
     /// Find the TextureFile record for the named texture, or NULL if no
     /// such file can be found.
     TextureFile *find_texturefile (ustring filename, PerThreadInfo *thread_info) {
-        // Per-thread microcache that prevents locking of the file mutex
-        TextureFile *texturefile = thread_info->find_file (filename);
-        if (! texturefile) {
-            // Fall back on the master cache
-            texturefile = m_imagecache->find_file (filename, thread_info);
-            if (!texturefile || texturefile->broken())
-                error ("%s", m_imagecache->geterror().c_str());
-            thread_info->filename (filename, texturefile);
-        }
+        TextureFile *texturefile = m_imagecache->find_file (filename, thread_info);
+        if (!texturefile || texturefile->broken())
+            error ("%s", m_imagecache->geterror().c_str());
         return texturefile;
-
     }
 
     /// Find the tile specified by id.  If found, return true and place


### PR DESCRIPTION
The hash only compares input pixel values. We check a few other items in
the metadata (such as default wrap mode), but had neglected to consider
the role of the projection matrices in the metadata.  And in fact, we
had a site that routinely used EXR files for the sole purpose of having
a queryable transformation matrix (the rationale for this is more sound
than you might guess), and the deduplication was kicking in and "losing"
the different matrices because the pixels happened to be identical (all
black). And in general, we now realize that it's a little funny for the
deduplication to give us the "wrong" metadata for get_texture_info
queries. All sorts of metadata may be different despite the pixels of
the two images being identical and therefore wanting to avoid redundant
loading of tiles.

This patch does some refactoring, wherein find_tile takes a new
parameter that allows explicit "do not redirect duplicates" control,
which is used by get_imagespec and get_image_info/get_texture_info, so
that metadata queries will always return the correct results for the
named file, rather than any earlier-loaded duplicate (of pixel values).
The functions that access pixels rather than metadata (get_pixels,
texture lookups, etc.)  continue to do duplication redirects, so it
should be as efficient with duplicates as before.

Along the way, I also noticed that the per-thread "microcache" of
name-vs-texture lookups was only used when accessing via the
TextureSystem, and bypassed for apps calling ImageCache directly, nor
was it used for get_texture_info calls.  I rectified that by moving the
micro-cache check into ImageCache::find_file itself, and then making
TextureSystem::find_file (where the check previously resided) a more
simple and direct mapping of IC::find_file.  This might yield a slight
speedup for certain apps that directly use the ImageCache APIs, or
that tend to make lots of get_texture_info/get_image_info calls.
