### PR TITLE
Added inplace version of colorconvert. Fixed two argument version.

### DIFF
--- a/src/include/imagebufalgo.h
+++ b/src/include/imagebufalgo.h
@@ -613,7 +613,22 @@ bool OIIO_API rangecompress (ImageBuf &dst, bool useluma = true,
 /// range compressed, back to a linear response.
 bool OIIO_API rangeexpand (ImageBuf &dst, bool useluma = true,
                            ROI roi = ROI::All(), int nthreads=0);
-
+/// Apply a color transform to the pixel values within the ROI, inplace.
+///
+/// If roi is not defined it will be all src
+///
+/// If unpremult is true, unpremultiply before color conversion, then
+/// premultiply after the color conversion.  You may want to use this
+/// flag if your image contains an alpha channel.
+///
+/// Works with all data types.
+///
+/// Return true on success, false on error (with an appropriate error
+/// message set in src).
+bool OIIO_API colorconvert (ImageBuf &src,
+                            const ColorProcessor *processor,
+                            bool unpremult,
+                            ROI roi=ROI::All(), int nthreads=0);
 
 /// Apply a color transform to the pixel values within the ROI.
 ///


### PR DESCRIPTION
The version of colorconvert that takes two image arguments, was assuming that the contents of the src and dst images were the same, when the ColorProcessor::isNoOp returns true. I think this is confusing, as it's not a natural  requirement of the function and it's not documented. 
There's a bug related to this in maketx, when the color conversion is NoOp and half to float promotion is needed, maketx calls colorconvert with an allocated but uninitialized dst image and colorconvert exits early, leaving 
dst still uninitialized and generating an incorrect mipmap.

I modified the two arguments version of the function to just copy the pixels if the color processor is a no op and 
I also added an explicit inplace version of the function that can early exit if the color conversion is not needed.
