### PR TITLE
DPX bug fixes for cropped images

### DIFF
--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -180,6 +180,14 @@ DPXInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
     }
     m_spec = ImageSpec (m_dpx.header.Width(), m_dpx.header.Height(),
         m_dpx.header.ImageElementComponentCount(subimage), typedesc);
+
+    m_spec.x = m_dpx.header.xOffset;
+    m_spec.y = m_dpx.header.yOffset;
+    if (m_dpx.header.xOriginalSize)
+        m_spec.full_width = m_dpx.header.xOriginalSize;
+    if (m_dpx.header.yOriginalSize)
+        m_spec.full_height = m_dpx.header.yOriginalSize;
+
     // fill channel names
     m_spec.channelnames.clear ();
     switch (m_dpx.header.ImageDescriptor(subimage)) {

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -52,7 +52,6 @@ public:
     virtual ~DPXOutput ();
     virtual const char * format_name (void) const { return "dpx"; }
     virtual bool supports (const std::string &feature) const {
-        // Support nothing nonstandard
         if (feature == "multiimage"
             || feature == "random_access"
             || feature == "rewrite"
@@ -538,7 +537,7 @@ DPXOutput::write_scanline (int y, int z, TypeDesc format,
                           data = &m_scratch[0];
     }
 
-    unsigned char *dst = &m_buf[y * m_bytes];
+    unsigned char *dst = &m_buf[(y-m_spec.y) * m_bytes];
     if (m_wantRaw)
         // fast path - just dump the scanline into the buffer
         memcpy (dst, data, m_spec.scanline_bytes ());


### PR DESCRIPTION
DPX bug fixes
1. incorrect addressing when writing crop images could cause a crash
2. incorrect reading of crop image offsets
