### PR TITLE
Change coefficients for the rangecompress/expand transformation.

### DIFF
--- a/src/doc/imagebufalgo.tex
+++ b/src/doc/imagebufalgo.tex
@@ -628,9 +628,9 @@ performed, and if {\cf max} is \NULL, no maximum clamping is performed.
 \apiend
 
 
-\apiitem{bool {\ce rangecompress} (ImageBuf \&dst, bool useluma = true, \\
+\apiitem{bool {\ce rangecompress} (ImageBuf \&dst, bool useluma = false, \\
         \bigspc\bigspc  ROI roi=ROI::All(), nthreads=0) \\
-bool {\ce rangeexpand} (ImageBuf \&dst, bool useluma = true, \\
+bool {\ce rangeexpand} (ImageBuf \&dst, bool useluma = false, \\
         \bigspc\bigspc  ROI roi=ROI::All(), nthreads=0)}
 \index{ImageBufAlgo!rangecompress} \indexapi{rangecompress}
 \index{ImageBufAlgo!rangeexpand} \indexapi{rangeexpand}
@@ -639,20 +639,18 @@ Some image operations (such as resizing with a ``good'' filter that
 contains negative lobes) can have objectionable artifacts when applied
 to images with very high-contrast regions involving extra bright pixels
 (such as highlights in HDR captured or rendered images).  One way to
-address this is by compressing the range of super-hot $>1$ pixels, then
+address this is by compressing the range of pixel values, then
 performing the operation (such as a resize), then re-expanding the range
 of the result again.  This approach can yield results that are much more
 pleasing (even if not exactly mathematically correct).
 
 The {\cf rangecompress} operation does the following: For all pixels and
 color channels of {\cf dst} within region {\cf roi} (defaulting to all
-the defined pixels of {\cf dst}), alter their values in place to rescale
-their range in the following way: values $< 1$ are unchanged, excess
-value $> 1$ is remapped to be logarithmically-encoded, with a smooth
-transition between them.  Alpha and z channels are not transformed.
+the defined pixels of {\cf dst}), apply a logarithmic transformation on
+their values.  Alpha and z channels are not transformed.
 
 The {\cf rangeexpand} operation is the opposite of {\cf rangecompress}:
-it rescales the color channel values that are $> 1$ back to a linear
+it rescales the logarithmic color channel values back to a linear
 response.
 
 If {\cf useluma} is true, the luma of the first three channels (presumed
@@ -672,7 +670,7 @@ and {\cf rangeexpand}).
     // 1. Read the original image
     ImageBuf Src ("tahoeHDR.exr");  Src.read();
 
-    // 2. Range compress
+    // 2. Range compress to a logarithmic scale
     ImageBuf Compressed;
     Compressed.copy (Src);
     ImageBufAlgo::rangecompress (Compressed);

--- a/src/doc/maketx.tex
+++ b/src/doc/maketx.tex
@@ -151,7 +151,8 @@ highlights is turned into a MIP-mapped texture using a high-quality
 filter with negative lobes (such as {\cf lanczos3}), objectionable
 ringing could appear near very high-contrast regions with pixel values
 $>1$. This option improves those areas by using range compression
-(transforming HDR excess values $> 1$ to be log-encoded) prior to each
+(transforming values from a linear to a logarithmic scale that greatly
+compresses the values $> 1$) prior to each
 image filtered-resize step, and then expanded back to a linear format
 after the resize, and also clamping resulting pixel values to be
 non-negative.  This can result in some loss of energy, but often this is

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -1329,19 +1329,17 @@ corresponding channel should not be clamped.
 \apiitem{--rangecompress \\
 --rangeexpand}
 \NEW
-Range compression re-maps input values so that values $\le 1$ are
-unchanged, and values $> 1$ are encoded on a logarithmic scale, with a
-smooth transition between them.  Range expansion is the inverse
-mapping.  Range compression and expansion only applies to color
+Range compression re-maps input values to a logarithmic scale.
+Range expansion is the inverse mapping back to a linear scale.
+Range compression and expansion only applies to color
 channels; alpha or z channels will not be modified.
 
-If the image has at least 3 channels and the first three channels are
+By default, this transformation will happen to each color channel 
+independently.  But if the optional {\cf luma} argument is nonzero and
+the image has at least 3 channels and the first three channels are
 not alpha or depth, they will be assumed to be RGB and the pixel scaling
 will be done using the luminance and applied equally to all color
-channels. This helps to preserve color even when remapping intensity.
-If these conditions are not met, or if this behavior is explicitly
-turned off with the optional {\cf luma=0} modifier, the remapping will
-happen to each color channel independently.
+channels. This can help to preserve color even when remapping intensity.
 
 Optional appended arguments include:
 

--- a/src/include/imagebufalgo.h
+++ b/src/include/imagebufalgo.h
@@ -576,42 +576,36 @@ bool OIIO_API channel_sum (ImageBuf &dst, const ImageBuf &src,
                            const float *weights=NULL, ROI roi=ROI::All(),
                            int nthreads=0);
 
-/// For all pixels and color channels of dst within region roi
-/// (defaulting to all the defined pixels of dst), rescale their range
-/// in the following way: values < 1 are unchanged, excess value > 1 is
-/// remapped to be logarithmically-encoded, with a smooth transition
-/// between them.  Alpha and z channels are not transformed.
+/// For all pixels and color channels of dst within region roi (defaulting
+/// to all the defined pixels of dst), rescale their range with a
+/// logarithmic transformation. Alpha and z channels are not transformed.
 ///
 /// If useluma is true, the luma of channels [roi.chbegin..roi.chbegin+2]
 /// (presumed to be R, G, and B) are used to compute a single scale
 /// factor for all color channels, rather than scaling all channels
-/// individually (which could result in a big color shift).
+/// individually (which could result in a color shift).
 ///
 /// Some image operations (such as resizing with a "good" filter that
 /// contains negative lobes) can have objectionable artifacts when applied
-/// to images with very high-contrast regions involving extra bright
-/// pixels (such as highlights in HDR captured or rendered images).  By
-/// compressing the range of super-hot >1 pixels, then performing the
-/// operation, then expanding the range of the result again, the result
-/// can be much more pleasing (even if not exactly correct).
+/// to images with very high-contrast regions involving extra bright pixels
+/// (such as highlights in HDR captured or rendered images).  By compressing
+/// the range pixel values, then performing the operation, then expanding
+/// the range of the result again, the result can be much more pleasing
+/// (even if not exactly correct).
 ///
 /// The nthreads parameter specifies how many threads (potentially) may
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
 ///
-/// Works for all pixel types, although it's a trivial no-op for
-/// integer formats since they cannot encode values > 1.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
-bool OIIO_API rangecompress (ImageBuf &dst, bool useluma = true,
+bool OIIO_API rangecompress (ImageBuf &dst, bool useluma = false,
                              ROI roi = ROI::All(), int nthreads=0);
 
 /// rangeexpand is the opposite operation of rangecompress -- rescales
-/// the color channel values of an image whose super-white vaues were
-/// range compressed, back to a linear response.
-bool OIIO_API rangeexpand (ImageBuf &dst, bool useluma = true,
+/// the logarithmic color channel values back to a linear response.
+bool OIIO_API rangeexpand (ImageBuf &dst, bool useluma = false,
                            ROI roi = ROI::All(), int nthreads=0);
 
 
@@ -1357,7 +1351,8 @@ enum OIIO_API MakeTextureMode {
 ///                              range compression and expansion around
 ///                              the resize, plus clamping negative plxel
 ///                              values to zero. This reduces ringing when
-///                              using filters with negative lobes.
+///                              using filters with negative lobes on HDR
+///                              images.
 ///    maketx:nchannels (int) If nonzero, will specify how many channels
 ///                              the output texture should have, padding with
 ///                              0 values or dropping channels, if it doesn't

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -2945,15 +2945,10 @@ action_rangecompress (int argc, const char *argv[])
         return 0;
     Timer timer (ot.enable_function_timing);
 
-    std::vector<std::string> addstrings;
-    Strutil::split (std::string(argv[1]), addstrings, ",");
-    if (addstrings.size() < 1)
-        return 0;   // Implicit addition by 0 if we can't figure it out
-
     std::map<std::string,std::string> options;
     extract_options (options, argv[0]);
     std::string useluma_str = options["luma"];
-    bool useluma = useluma_str.size() ? atoi(useluma_str.c_str()) != 0 : true;
+    bool useluma = useluma_str.size() && atoi(useluma_str.c_str()) != 0;
 
     ImageRecRef A = ot.pop();
     ImageRecRef R (new ImageRec (*A, ot.allsubimages ? -1 : 0,
@@ -2982,15 +2977,10 @@ action_rangeexpand (int argc, const char *argv[])
         return 0;
     Timer timer (ot.enable_function_timing);
 
-    std::vector<std::string> addstrings;
-    Strutil::split (std::string(argv[1]), addstrings, ",");
-    if (addstrings.size() < 1)
-        return 0;   // Implicit addition by 0 if we can't figure it out
-
     std::map<std::string,std::string> options;
     extract_options (options, argv[0]);
     std::string useluma_str = options["luma"];
-    bool useluma = useluma_str.size() ? atoi(useluma_str.c_str()) != 0 : true;
+    bool useluma = useluma_str.size() && atoi(useluma_str.c_str()) != 0;
 
     ImageRecRef A = ot.pop();
     ImageRecRef R (new ImageRec (*A, ot.allsubimages ? -1 : 0,


### PR DESCRIPTION
Modifications to range compression/expansion.

The coefficients we use to do range compression turn out not to work well in practice, nor does it match the old tool we use at SPI that oiiotool is replacing.  Actually, I was unintentionally given sub-optimal values when I first implemented it in OIIO, when better ones were being used elsewhere but we didn't realize there were two sets floating around, oops.

An intersting consequence is that the old coefficients did not alter values <= 1, so a LDR image would by definition not need the transformation applied.  The better coefficients, unfortunately, do compress the range even for values < 1, which is unfortunate, but at the end of the day the new coefficients do a better job of the intended purpose.

This patch:
- Alters the coefficients used for the logarithmic<->linear transformation used by IBA::rangecompress / rangeexpand.  These work better in practice.
- The docs have been altered to no longer say explicitly that values < 1 are unchanged, nor that it's a no-op for LDR image formats.
- Remove various code shortcuts that avoided the transformation for LDR images or values < 1.  Gotta do it all the time for results to match correctly.
- Changes the default for rangecompress/expand to transform each color channel independently, rather than use the luma.  The option is still there, we're just changing the default to the one that years of experience at SPI was preferred.  This applies both to the IBA functions themselves, as well as the commands in oiiotool.

Please note that this also applies to the behavior of maketx when the --hicomp option.
