### PR TITLE
Tweaks to the cmake build system (mostly for SPI):

### DIFF
--- a/site/spi/Makefile-bits-arnold
+++ b/site/spi/Makefile-bits-arnold
@@ -36,7 +36,7 @@ ifeq ($(SP_OS), spinux1)
         OCIO_PATH="${INSTALL_SPCOMP2_LOCATION}/OpenColorIO/${SP_OS}-${SPCOMP2_COMPILER}/v2"
     endif
     ifeq (${FIELD3D_HOME},)
-        FIELD3D_HOME="${INSTALL_SPCOMP2_LOCATION}/Field3D/${SP_OS}-${SPCOMP2_COMPILER}/v227"
+        FIELD3D_HOME="${INSTALL_SPCOMP2_LOCATION}/Field3D/${SP_OS}-${SPCOMP2_COMPILER}-boost151/v401"
     endif
 
     ## custom compiler: clang
@@ -60,18 +60,44 @@ ifeq ($(SP_OS), spinux1)
          -DCMAKE_CXX_COMPILER=/net/soft_scratch/apps/arnold/tools/gcc-4.7.0-test/bin/g++
     endif
 
-
-    MY_CMAKE_FLAGS += \
+    ifneq (,$(wildcard /usr/include/OpenEXR2))
+        MY_CMAKE_FLAGS += \
 	  -DILMBASE_CUSTOM=1 \
+	  -DILMBASE_CUSTOM_INCLUDE_DIR=/usr/include/OpenEXR2 \
+          -DILMBASE_CUSTOM_LIB_DIR=/usr/lib64/OpenEXR2 \
+	  -DILMBASE_CUSTOM_LIBRARIES="Imath Half IlmThread Iex" \
+	  -DOPENEXR_CUSTOM=1 \
+	  -DOPENEXR_CUSTOM_INCLUDE_DIR=/usr/include/OpenEXR2 \
+          -DOPENEXR_CUSTOM_LIB_DIR=/usr/lib64/OpenEXR2 \
+	  -DOPENEXR_CUSTOM_LIBRARY="IlmImf"
+    else
+        MY_CMAKE_FLAGS += \
+	  -DILMBASE_CUSTOM=1 \
+          -DILMBASE_CUSTOM_LIB_DIR=/usr/lib64 \
 	  -DILMBASE_CUSTOM_LIBRARIES="SpiImath SpiHalf SpiIlmThread SpiIex" \
 	  -DOPENEXR_CUSTOM=1 \
-	  -DOPENEXR_CUSTOM_LIBRARY="SpiIlmImf" \
+          -DOPENEXR_CUSTOM_LIB_DIR=/usr/lib64 \
+	  -DOPENEXR_CUSTOM_LIBRARY="SpiIlmImf"
+    endif
+    MY_CMAKE_FLAGS += \
 	  -DOCIO_PATH=${OCIO_PATH} \
 	  -DFIELD3D_HOME=${FIELD3D_HOME} \
           -DHDF5_CUSTOM=1 \
 	  -DHDF5_INCLUDE_DIRS=/usr/include \
 	  -DHDF5_LIBRARIES=/usr/lib64/libhdf5.so \
 	  -DHDF5_LIBRARY_DIRS=/usr/lib64
+
+    ifneq (${SPCOMP2_USE_BOOSTVERS}, 1)
+	BOOSTVERS=1.51
+    endif ()
+    BOOSTVERS_SUFFIX = -${shell echo ${BOOSTVERS} | sed "s/\\./_/"}
+    MY_CMAKE_FLAGS += \
+	-DBOOST_CUSTOM=1 \
+	-DBoost_INCLUDE_DIRS=/usr/include/boost_${BOOSTVERS} \
+	-DBoost_LIBRARY_DIRS=/usr/lib64/boost_${BOOSTVERS} \
+	-DBoost_python_FOUND=1 -Doiio_boost_PYTHON_FOUND=1 \
+	-DBoost_LIBRARIES:STRING="/usr/lib64/boost_${BOOSTVERS}/libboost_python-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_regex-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_system-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_thread-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/libpython2.6.so"
+
 endif  # endif spinux1
 
 

--- a/site/spi/Makefile-bits-spcomp2
+++ b/site/spi/Makefile-bits-spcomp2
@@ -50,11 +50,25 @@ ifeq ($(SP_OS), spinux1)
     # the standard libGL.  This attempts to detect which libGL to use.
     SPINUX_GL_LIB = /usr/lib64/xorg.nvidia.3d/libGL.so
     MY_CMAKE_FLAGS += $(if $(wildcard ${SPINUX_GL_LIB}), -DOPENGL_gl_LIBRARY=${SPINUX_GL_LIB})
-    MY_CMAKE_FLAGS += \
-     -DILMBASE_CUSTOM=1 \
-     -DILMBASE_CUSTOM_LIBRARIES="SpiImath SpiHalf SpiIlmThread SpiIex" \
-     -DOPENEXR_CUSTOM=1 \
-     -DOPENEXR_CUSTOM_LIBRARY="SpiIlmImf"
+    ifneq (,$(wildcard /usr/include/OpenEXR2))
+        MY_CMAKE_FLAGS += \
+	  -DILMBASE_CUSTOM=1 \
+	  -DILMBASE_CUSTOM_INCLUDE_DIR=/usr/include/OpenEXR2 \
+          -DILMBASE_CUSTOM_LIB_DIR=/usr/lib64/OpenEXR2 \
+	  -DILMBASE_CUSTOM_LIBRARIES="Imath Half IlmThread Iex" \
+	  -DOPENEXR_CUSTOM=1 \
+	  -DOPENEXR_CUSTOM_INCLUDE_DIR=/usr/include/OpenEXR2 \
+          -DOPENEXR_CUSTOM_LIB_DIR=/usr/lib64/OpenEXR2 \
+	  -DOPENEXR_CUSTOM_LIBRARY="IlmImf"
+    else
+        MY_CMAKE_FLAGS += \
+	  -DILMBASE_CUSTOM=1 \
+          -DILMBASE_CUSTOM_LIB_DIR=/usr/lib64 \
+	  -DILMBASE_CUSTOM_LIBRARIES="SpiImath SpiHalf SpiIlmThread SpiIex" \
+	  -DOPENEXR_CUSTOM=1 \
+          -DOPENEXR_CUSTOM_LIB_DIR=/usr/lib64 \
+	  -DOPENEXR_CUSTOM_LIBRARY="SpiIlmImf"
+    endif
     MY_CMAKE_FLAGS += -DOCIO_PATH="${OCIO_PATH}"
 else ifeq ($(SP_OS), lion)
     COMPILER=clang
@@ -92,6 +106,16 @@ else ifeq ($(SP_OS), lion)
       -DPYTHON_LIBRARY=${MACPORTS_PREFIX}/Library/Frameworks/Python.framework/Versions/2.7/Python \
       -DTHIRD_PARTY_TOOLS_HOME=${MACPORTS_PREFIX} \
       -DZLIB_ROOT=${MACPORTS_PREFIX}
+
+    ifeq (${SPCOMP2_USE_BOOSTVERS}, 1)
+    BOOSTVERS_UNDERSCORE = ${shell echo ${BOOSTVERS} | sed "s/\\./_/"}
+    MY_CMAKE_FLAGS += \
+        -DBOOST_CUSTOM=1 \
+        -DBoost_INCLUDE_DIRS=/usr/include/boost_${BOOSTVERS} \
+        -DBoost_LIBRARY_DIRS=/usr/lib64/boost_${BOOSTVERS} \
+        -DBoost_LIBRARIES=optimized;/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt-${BOOSTVERS_UNDERSCORE}.so;optimized;/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt-${BOOSTVERS_UNDERSCORE}.so;optimized;/usr/lib64/boost_${BOOSTVERS}/libboost_regex-gcc44-mt-${BOOSTVERS_UNDERSCORE}.so;optimized;/usr/lib64/boost_${BOOSTVERS}/libboost_system-gcc44-mt-${BOOSTVERS_UNDERSCORE}.so;optimized;/usr/lib64/boost_${BOOSTVERS}/libboost_thread-gcc44-mt-${BOOSTVERS_UNDERSCORE}.so
+    endif
+
 else
 # Not sure how to obtain the correct GCC version but this returns the
 # version of GCC in the path.

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -33,16 +33,7 @@ endif ()
 
 
 ###########################################################################
-# IlmBase and OpenEXR setup
-
-# example of using setup_var instead:
-#setup_var (ILMBASE_VERSION 1.0.1 "Version of the ILMBase library")
-setup_string (ILMBASE_VERSION 1.0.1
-              "Version of the ILMBase library")
-mark_as_advanced (ILMBASE_VERSION)
-setup_path (ILMBASE_HOME "${THIRD_PARTY_TOOLS_HOME}"
-            "Location of the ILMBase library install")
-mark_as_advanced (ILMBASE_HOME)
+# IlmBase setup
 
 find_package (IlmBase REQUIRED)
 
@@ -53,10 +44,12 @@ macro (LINK_ILMBASE target)
     target_link_libraries (${target} ${ILMBASE_LIBRARIES})
 endmacro ()
 
+# end IlmBase setup
+###########################################################################
 
-setup_path (OPENEXR_HOME "${THIRD_PARTY_TOOLS_HOME}"
-            "Location of the OpenEXR library install")
-mark_as_advanced (OPENEXR_HOME)
+
+###########################################################################
+# OpenEXR setup
 
 find_package (OpenEXR REQUIRED)
 
@@ -65,8 +58,6 @@ if (EXISTS ${OPENEXR_INCLUDE_DIR}/OpenEXR/ImfMultiPartInputFile.h)
     setup_string (OPENEXR_VERSION 2.0.0 "OpenEXR version number")
     if (VERBOSE)
         message (STATUS "OpenEXR version 2.x")
-    endif ()
-    if (VERBOSE)
     endif ()
 else ()
     setup_string (OPENEXR_VERSION 1.6.1 "OpenEXR version number")
@@ -82,9 +73,9 @@ macro (LINK_OPENEXR target)
     target_link_libraries (${target} ${OPENEXR_LIBRARIES})
 endmacro ()
 
-
-# end IlmBase and OpenEXR setup
+# OpenEXR setup
 ###########################################################################
+
 
 ###########################################################################
 # Boost setup
@@ -92,9 +83,9 @@ endmacro ()
 message (STATUS "BOOST_ROOT ${BOOST_ROOT}")
 
 if (NOT DEFINED Boost_ADDITIONAL_VERSIONS)
-  set (Boost_ADDITIONAL_VERSIONS "1.49" "1.48" "1.47" "1.46" "1.45" "1.44" 
-                                 "1.43" "1.43.0" "1.42" "1.42.0"
-                                 "1.41" "1.41.0" "1.40" "1.40.0")
+  set (Boost_ADDITIONAL_VERSIONS "1.54" "1.53" "1.52" "1.51" "1.50"
+                                 "1.49" "1.48" "1.47" "1.46" "1.45" "1.44" 
+                                 "1.43" "1.43.0" "1.42" "1.42.0")
 endif ()
 if (LINKSTATIC)
     set (Boost_USE_STATIC_LIBS   ON)
@@ -105,8 +96,9 @@ if (BOOST_CUSTOM)
     # N.B. For a custom version, the caller had better set up the variables
     # Boost_VERSION, Boost_INCLUDE_DIRS, Boost_LIBRARY_DIRS, Boost_LIBRARIES.
 else ()
-    find_package (Boost 1.40 REQUIRED 
-                  COMPONENTS filesystem regex system thread
+    set (Boost_COMPONENTS filesystem regex system thread)
+    find_package (Boost 1.42 REQUIRED 
+                  COMPONENTS ${Boost_COMPONENTS}
                  )
     # Try to figure out if this boost distro has Boost::python.  If we
     # include python in the component list above, cmake will abort if
@@ -152,6 +144,7 @@ else ()
 endif ()
 
 if (VERBOSE)
+    message (STATUS "BOOST_ROOT ${BOOST_ROOT}")
     message (STATUS "Boost found ${Boost_FOUND} ")
     message (STATUS "Boost version      ${Boost_VERSION}")
     message (STATUS "Boost include dirs ${Boost_INCLUDE_DIRS}")
@@ -171,10 +164,6 @@ endif ()
 
 include_directories (SYSTEM "${Boost_INCLUDE_DIRS}")
 link_directories ("${Boost_LIBRARY_DIRS}")
-
-#if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-#    add_definitions ("-Wno-parentheses")
-#endif ()
 
 # end Boost setup
 ###########################################################################

--- a/src/cmake/modules/FindIlmBase.cmake
+++ b/src/cmake/modules/FindIlmBase.cmake
@@ -9,6 +9,10 @@
 #   - Set the variable ILMBASE_CUSTOM to True
 #   - Set the variable ILMBASE_CUSTOM_LIBRARIES to a list of the libraries to
 #     use, e.g. "SpiImath SpiHalf SpiIlmThread SpiIex"
+#   - Optionally set the variable ILMBASE_CUSTOM_INCLUDE_DIR to any
+#     particularly weird place that the OpenEXR/*.h files may be found
+#   - Optionally set the variable ILMBASE_CUSTOM_LIB_DIR to any
+#     particularly weird place that the libraries files may be found
 #
 # This module defines the following variables:
 #
@@ -112,11 +116,13 @@ endif ()
 
 # Generic search paths
 set (IlmBase_generic_include_paths
+  ${ILMBASE_CUSTOM_INCLUDE_DIR}
   /usr/include
   /usr/local/include
   /sw/include
   /opt/local/include)
 set (IlmBase_generic_library_paths
+  ${ILMBASE_CUSTOM_LIB_DIR}
   /usr/lib
   /usr/local/lib
   /sw/lib

--- a/src/cmake/modules/FindOpenEXR.cmake
+++ b/src/cmake/modules/FindOpenEXR.cmake
@@ -9,6 +9,10 @@
 #   - Set the variable OPENEXR_CUSTOM to True
 #   - Set the variable OPENEXR_CUSTOM_LIBRARY to the name of the library to
 #     use, e.g. "SpiIlmImf"
+#   - Optionally set the variable OPENEXR_CUSTOM_INCLUDE_DIR to any
+#     particularly weird place that the OpenEXR/*.h files may be found
+#   - Optionally set the variable OPENEXR_CUSTOM_LIB_DIR to any
+#     particularly weird place that the libraries files may be found
 #
 # This module defines the following variables:
 #
@@ -108,11 +112,13 @@ endif ()
 
 # Generic search paths
 set (OpenEXR_generic_include_paths
+  ${OPENEXR_CUSTOM_INCLUDE_DIR}
   /usr/include
   /usr/local/include
   /sw/include
   /opt/local/include)
 set (OpenEXR_generic_library_paths
+  ${OPENEXR_CUSTOM_LIB_DIR}
   /usr/lib
   /usr/local/lib
   /sw/lib

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,6 +1,8 @@
 if (NOT BOOST_CUSTOM)
     find_package (PythonLibs ${PYTHON_VERSION} REQUIRED)
-    find_package (Boost 1.34 REQUIRED COMPONENTS python)
+    find_package (Boost 1.42 REQUIRED COMPONENTS python)
+else ()
+    find_package (PythonLibs ${PYTHON_VERSION} REQUIRED)
 endif ()
 
 if (APPLE)


### PR DESCRIPTION
- At SPI, build against OpenEXR 2.0 if available
- At SPI, update which internal Field3D build we use.
- At SPI, build against Boost 1.51
- New cmake variables that let you specify a custom OpenEXR & Ilmbase location.
- Some other cruft removal in the build system
