### PR TITLE
DPX bug fixes

### DIFF
--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -183,9 +183,9 @@ DPXInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
 
     m_spec.x = m_dpx.header.xOffset;
     m_spec.y = m_dpx.header.yOffset;
-    if (m_dpx.header.xOriginalSize)
+    if ((int)m_dpx.header.xOriginalSize > 0)
         m_spec.full_width = m_dpx.header.xOriginalSize;
-    if (m_dpx.header.yOriginalSize)
+    if ((int)m_dpx.header.yOriginalSize > 0)
         m_spec.full_height = m_dpx.header.yOriginalSize;
 
     // fill channel names
@@ -578,7 +578,7 @@ DPXInput::close ()
 bool
 DPXInput::read_native_scanline (int y, int z, void *data)
 {
-    dpx::Block block(0, y, m_dpx.header.Width () - 1, y);
+    dpx::Block block(0, y-m_spec.y, m_dpx.header.Width () - 1, y-m_spec.y);
 
     if (m_wantRaw) {
         // fast path - just read the scanline in

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1927,6 +1927,8 @@ ImageBufImpl::retile (int x, int y, int z, ImageCache::Tile* &tile,
         tilexend = tilexbegin + tw;
         tile = m_imagecache->get_tile (m_name, m_current_subimage,
                                        m_current_miplevel, x, y, z);
+        if (! tile)
+            return NULL;
     }
 
     size_t offset = ((z - tilezbegin) * (size_t) th + (y - tileybegin)) * (size_t) tw


### PR DESCRIPTION
- Was not handling nonzero image origins properly in DPX read_native_scanline.
- Apparently, some files have 0xffffffff in the 'originalSize' fields
  to indicate that they aren't used.
