### PR TITLE
Make ustring implementation safe for libc++

### DIFF
--- a/src/libutil/ustring.cpp
+++ b/src/libutil/ustring.cpp
@@ -114,7 +114,7 @@ ustring::TableRep::TableRep (const char *s, size_t len)
     dummy_capacity = len;
     dummy_refcount = 1;   // so it never frees
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(_LIBCPP_VERSION)
     // We don't want the internal 'string str' to redundantly store the
     // chars, along with our own allocation.  So we use our knowledge of
     // the internal structure of gcc strings to make it point to our chars!
@@ -148,7 +148,7 @@ ustring::TableRep::TableRep (const char *s, size_t len)
 
 ustring::TableRep::~TableRep ()
 {
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(_LIBCPP_VERSION)
     // Doctor the string to be empty again before destroying.
     ASSERT (str.c_str() == c_str());
     std::string empty;
@@ -209,7 +209,7 @@ ustring::make_unique (const char *str)
             table[result] = rep;
             ++ustring_stats_unique;
             ustring_stats_memory += size;
-#ifndef __GNUC__
+#if ! (defined(__GNUC__) && !defined(_LIBCPP_VERSION))
             ustring_stats_memory += len+1;  // non-GNU replicates the chars
 #endif
             return result;


### PR DESCRIPTION
ustring internally stores the characters for the string and also a std::string representation (so it can return a std::string of the ustring without doing any allocation or construction of it).  In order to not allocate the characters twice (once for the C string and once for the std::string), it cleverly doctors the std::string representation to make it point to the same characters.  But it's only a trick that (currently) works for gcc's headers, since it's so specific to the std::string internals.

The new libc++ (part of llvm's family of packages) uses a different representation of std::string, but ustring fails to notice because it keys off the definition of **GNUC**.  This change excludes the special sauce if __LIBCPP_VERSION is defined.

Note that this is wasteful, in that when building against libc++, every ustring will allocate the characters twice. We should go back and fix that, but it's more work because we have to be super sure it works correctly, and I can't do that easily at the moment because I'm not using a system that uses libc++ (though I use clang, we use gcc's headers).
