### PR TITLE
ImageBuf::roi() and roi_full() should be const

### DIFF
--- a/src/include/imagebuf.h
+++ b/src/include/imagebuf.h
@@ -599,10 +599,10 @@ public:
                    int zbegin, int zend, const float *bordercolor);
 
     /// Return pixel data window for this ImageBuf as a ROI.
-    ROI roi ();
+    ROI roi () const;
 
     /// Return full/display window for this ImageBuf as a ROI.
-    ROI roi_full ();
+    ROI roi_full () const;
 
     /// Set full/display window for this ImageBuf to a ROI.
     /// Does NOT change the channels of the spec, regardless of newroi.

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1778,14 +1778,14 @@ ImageBuf::set_full (int xbegin, int xend, int ybegin, int yend,
 
 
 ROI
-ImageBuf::roi ()
+ImageBuf::roi () const
 {
     return get_roi(spec());
 }
 
 
 ROI
-ImageBuf::roi_full ()
+ImageBuf::roi_full () const
 {
     return get_roi_full(spec());
 }


### PR DESCRIPTION
How come the compiler doesn't warn you if you declare a method non-const, but it doesn't alter anything in the class?
