### PR TITLE
IBA colorconvert & ociolook additions

### DIFF
--- a/src/doc/imagebufalgo.tex
+++ b/src/doc/imagebufalgo.tex
@@ -1290,9 +1290,12 @@ higher-contrast edges.
 \label{sec:iba:color}
 
 \apiitem{bool {\ce colorconvert} (ImageBuf \&dst, const ImageBuf \&src, \\
-  \bigspc\spc const ColorProcessor *processor, bool unpremult, \\
-  \bigspc\spc  ROI roi=ROI::All(), nthreads=0)}
-\index{ImageBufAlgo!colorconvert} \indexapi{colorconverr}
+  \bigspc\spc const char *from, const char *to, bool unpremult=false, \\
+  \bigspc\spc  ROI roi=ROI::All(), int nthreads=0) \\
+bool {\ce colorconvert} (ImageBuf \&dst, const ImageBuf \&src, \\
+  \bigspc\spc const ColorProcessor *processor, bool unpremult=false, \\
+  \bigspc\spc  ROI roi=ROI::All(), int nthreads=0)}
+\index{ImageBufAlgo!colorconvert} \indexapi{colorconvert}
 Copy pixels from {\cf src} to {\cf dst} (within the ROI), while
 applying a color transform to the pixel values.
 In-place operations ({\cf dst} and {\cf src} being the same image)
@@ -1302,14 +1305,18 @@ If {\cf unpremult} is {\cf true}, unpremultiply before color conversion,
 then premultiply again after the color conversion.  You may want to use
 this flag if your image contains an alpha channel.
 
-The {\cf ColorProcessor} is a special object created by a 
-{\cf ColorConfig} (see {\cf OpenImageIO/color.h} for details).  If OIIO
-was built with OpenColorIO support enabled, then the {\cf ColorProcessor}
-may transform among any two spaces supported by the active OCIO
-configuration, or may be a ``look'' transformation created by
-{\cf ColorConfig::createLookTransform}.  If OIIO was not built with
-OpenColorIO support enabled, then the only transformations available
-are from \qkw{sRGB} to \qkw{linear} and vice versa.
+The first form of this function specifies the ``from''
+and ``to'' color spaces by name.
+The second form is passed a {\cf ColorProcessor},
+which is is a special object created by a
+{\cf ColorConfig} (see {\cf OpenImageIO/color.h} for details).
+
+If OIIO was built with OpenColorIO support enabled, then the transformation
+may be between any two spaces supported by the active OCIO configuration, or
+may be a ``look'' transformation created by {\cf
+ColorConfig::createLookTransform}.  If OIIO was not built with OpenColorIO
+support enabled, then the only transformations available are from \qkw{sRGB}
+to \qkw{linear} and vice versa.
 
 \smallskip
 \noindent Examples:
@@ -1321,9 +1328,43 @@ are from \qkw{sRGB} to \qkw{linear} and vice versa.
     ImageBuf Src ("tahoe.jpg");
     ImageBuf Dst;
     ColorConfig cc;
-    ColorProcessor *processor = cc.createColorProcessor ("sRGB", "linear");
+    ColorProcessor *processor = cc.createColorProcessor ("vd8", "lnf");
     ImageBufAlgo::colorconvert (Dst, Src, processor, true);
     ColorProcessor::deleteColorProcessor (processor);
+
+    // Equivalent, though possibly less efficient if you will be
+    // converting many images using the same transformation:
+    ImageBuf Src ("tahoe.jpg");
+    ImageBuf Dst;
+    ImageBufAlgo::colorconvert (Dst, Src, "vd8", "lnf", true);
+\end{code}
+\apiend
+
+\apiitem{bool {\ce ociolook} (ImageBuf \&dst, const ImageBuf \&src, \\
+  \bigspc\spc const char *looks, const char *from, const char *to, \\
+  \bigspc\spc bool inverse=false, bool unpremult=false, \\
+  \bigspc\spc const char *key, const char *value, \\
+  \bigspc\spc ROI roi=ROI::All(), nthreads=0)}
+\index{ImageBufAlgo!ociolook} \indexapi{ociolook}
+Copy pixels from {\cf src} to {\cf dst} (within the ROI), while
+applying an OpenColorIO ``look'' transform to the pixel values.
+In-place operations ({\cf dst} and {\cf src} being the same image)
+are supported.
+
+If {\cf inverse} is {\cf true}, it will reverse the color transformation
+and look application.
+
+If {\cf unpremult} is {\cf true}, unpremultiply before color conversion,
+then premultiply again after the color conversion.  You may want to use
+this flag if your image contains an alpha channel.
+
+\smallskip
+\noindent Examples:
+\begin{code}
+    ImageBuf Src ("tahoe.jpg");
+    ImageBuf Dst;
+    ImageBufAlgo::ociolook (Dst, Src, "look", "vd8", "lnf", false, false,
+                            "key", "value");
 \end{code}
 \apiend
 

--- a/src/include/imagebufalgo.h
+++ b/src/include/imagebufalgo.h
@@ -609,7 +609,51 @@ bool OIIO_API rangeexpand (ImageBuf &dst, bool useluma = false,
                            ROI roi = ROI::All(), int nthreads=0);
 
 
-/// Apply a color transform to the pixel values within the ROI.
+/// Copy pixels within the ROI from src to dst, applying a color transform.
+///
+/// If dst is not yet initialized, it will be allocated to the same
+/// size as specified by roi.  If roi is not defined it will be all
+/// of dst, if dst is defined, or all of src, if dst is not yet defined.
+///
+/// In-place operations (dst == src) are supported.
+///
+/// If unpremult is true, unpremultiply before color conversion, then
+/// premultiply after the color conversion.  You may want to use this
+/// flag if your image contains an alpha channel.
+///
+/// Works with all data types.
+///
+/// Return true on success, false on error (with an appropriate error
+/// message set in dst).
+bool OIIO_API colorconvert (ImageBuf &dst, const ImageBuf &src,
+                            const char *from, const char *to,
+                            bool unpremult=false,
+                            ROI roi=ROI::All(), int nthreads=0);
+
+/// Copy pixels within the ROI from src to dst, applying an OpenColorIO
+/// "look" transform.
+///
+/// If dst is not yet initialized, it will be allocated to the same
+/// size as specified by roi.  If roi is not defined it will be all
+/// of dst, if dst is defined, or all of src, if dst is not yet defined.
+///
+/// In-place operations (dst == src) are supported.
+///
+/// If unpremult is true, unpremultiply before color conversion, then
+/// premultiply after the color conversion.  You may want to use this
+/// flag if your image contains an alpha channel.
+///
+/// Works with all data types.
+///
+/// Return true on success, false on error (with an appropriate error
+/// message set in dst).
+bool OIIO_API ociolook (ImageBuf &dst, const ImageBuf &src,
+                        const char *looks, const char *from, const char *to,
+                        bool unpremult=false, bool inverse=false,
+                        const char *key=NULL, const char *value=NULL,
+                        ROI roi=ROI::All(), int nthreads=0);
+
+/// Copy pixels within the ROI from src to dst, applying a color transform.
 ///
 /// If dst is not yet initialized, it will be allocated to the same
 /// size as specified by roi.  If roi is not defined it will be all

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -997,30 +997,14 @@ action_colorconvert (int argc, const char *argv[])
     ot.push (new ImageRec (*A, ot.allsubimages ? -1 : 0,
                            ot.allsubimages ? -1 : 0, true, false));
 
-    if (fromspace == "current")
-        fromspace = A->spec(0,0)->get_string_attribute ("oiio:Colorspace", "Linear");
-
-    ColorProcessor *processor =
-        ot.colorconfig.createColorProcessor (fromspace.c_str(), tospace.c_str());
-    if (! processor) {
-        if (ot.colorconfig.error())
-            ot.error ("colorconvert", ot.colorconfig.geterror());
-        else
-            ot.error ("colorconvert", "Could not construct the color transform");
-        return 1;
-    }
-
     for (int s = 0, send = A->subimages();  s < send;  ++s) {
         for (int m = 0, mend = A->miplevels(s);  m < mend;  ++m) {
-            bool ok = ImageBufAlgo::colorconvert ((*ot.curimg)(s,m), (*A)(s,m), processor, false);
+            bool ok = ImageBufAlgo::colorconvert ((*ot.curimg)(s,m), (*A)(s,m),
+                                 fromspace.c_str(), tospace.c_str(), false);
             if (! ok)
                 ot.error (argv[0], (*ot.curimg)(s,m).geterror());
-            ot.curimg->spec(s,m)->attribute ("oiio:Colorspace", tospace);
-//        ot.curimg->metadata_modified (true);
         }
     }
-
-    ot.colorconfig.deleteColorProcessor (processor);
 
     ot.function_times["colorconvert"] += timer();
     return 1;


### PR DESCRIPTION
- Add a variety of IBA::colorconvert that takes the color space names rather than a ColorProcessor
- Add ImageBufAlgo::ociolook() (encapsulates what oiiotool --ociolook does)
