### PR TITLE
Replace vector with scoped_array for better performance (no needless fill)

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -904,7 +904,7 @@ ImageBuf::write (ImageOutput *out,
         ok = out->write_deep_image (impl->m_deepdata);
     } else {
         // Backed by ImageCache
-        std::vector<char> tmp (m_spec.image_bytes());
+        boost::scoped_array<char> tmp (new char [m_spec.image_bytes()]);
         get_pixels (xbegin(), xend(), ybegin(), yend(), zbegin(), zend(),
                     m_spec.format, &tmp[0]);
         ok = out->write_image (m_spec.format, &tmp[0], as, as, as,

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -113,7 +113,7 @@ bool ImageOutput::write_tiles (int xbegin, int xend, int ybegin, int yend,
 
     bool ok = true;
     stride_t pixelsize = format.size() * m_spec.nchannels;
-    std::vector<char> buf;
+    boost::scoped_array<char> buf;
     for (int z = zbegin;  z < zend;  z += std::max(1,m_spec.tile_depth)) {
         int zd = std::min (zend-z, m_spec.tile_depth);
         for (int y = ybegin;  y < yend;  y += m_spec.tile_height) {
@@ -130,7 +130,8 @@ bool ImageOutput::write_tiles (int xbegin, int xend, int ybegin, int yend,
                     ok &= write_tile (x, y, z, format, tilestart,
                                      xstride, ystride, zstride);
                 } else {
-                    buf.resize (pixelsize * m_spec.tile_pixels());
+                    if (! buf.get())
+                        buf.reset (new char [pixelsize * m_spec.tile_pixels()]);
                     OIIO::copy_image (m_spec.nchannels, xw, yh, zd,
                                 tilestart, pixelsize, xstride, ystride, zstride,
                                 &buf[0], pixelsize, pixelsize*m_spec.tile_width,


### PR DESCRIPTION
std::vector is helpful if you need to dynamically change size, but if you expect to only allocate once, it has a serious problem -- it fills the array right after allocation. If the very next things you're gonna do is copy something into it, that's just needless touching of memory. In such cases, it's really better to use a scoped_array, if the only point is to hold the one allocation and ensure that it's automatically deleted when it exits scope.
