### PR TITLE
IC & TS: allow complete destruction of the shared ImageCache.

### DIFF
--- a/src/doc/imagecache.tex
+++ b/src/doc/imagecache.tex
@@ -110,7 +110,7 @@ will be created and returned.
 
 \apiend
 
-\apiitem{static void ImageCache::{\ce destroy} (ImageCache *x)}
+\apiitem{static void ImageCache::{\ce destroy} (ImageCache *x, bool teardown=false)}
 Destroys an allocated \ImageCache, including freeing all system
 resources that it holds.
 
@@ -123,7 +123,10 @@ allocator than the main program).
 It is safe to destroy even a shared \ImageCache, as the implementation
 of {\cf destroy()} will recognize a shared one and only truly release
 its resources if it has been requested to be destroyed as many times as
-shared \ImageCache's were created.
+shared \ImageCache's were created.  For a shared \ImageCache, if the
+{\cf teardown} parameter is {\cf true}, it will try to truly destroy the
+shared cache if nobody else is still holding a reference (otherwise,
+it will leave it intact).
 \apiend
 
 \subsection{Setting options and limits for the image cache}

--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -390,16 +390,20 @@ completely unique \ImageCache will be created that is private to this
 particular \TextureSystem.
 \apiend
 
-\apiitem{static void TextureSystem::{\ce destroy} (TextureSystem *x)}
+\apiitem{static void TextureSystem::{\ce destroy} (TextureSystem *x, \\
+\bigspc\bigspc bool teardown_imagecache=false)}
 Destroys an allocated \TextureSystem, including freeing all system
-resources that it holds.
+resources that it holds (such as its underlying \ImageCache).
 
 This is necessary to ensure that the memory is freed in a way that
 matches the way it was allocated within the library.  Note that simply
 using {\cf delete} on the pointer will not always work (at least,
 not on some platforms in which a DSO/DLL can end up using a different
 allocator than the main program).
-\apiend
+
+If {\cf teardown_imagecache} is {\cf true}, and the \TextureSystem's
+underlying \ImageCache is the \emph{shared} one, then that \ImageCache will
+be thoroughly destroyed, not merely releasing the reference. \apiend
 
 \subsection{Setting options and limits for the texture system}
 \label{sec:texturesys:api:options}

--- a/src/include/imagecache.h
+++ b/src/include/imagecache.h
@@ -68,8 +68,10 @@ public:
     static ImageCache *create (bool shared=true);
 
     /// Destroy a ImageCache that was created using ImageCache::create().
-    ///
+    /// The variety that takes a 'teardown' parameter, when set to true,
+    /// will fully destroy even a "shared" ImageCache.
     static void destroy (ImageCache * x);
+    static void destroy (ImageCache * x, bool teardown);
 
     ImageCache (void) { }
     virtual ~ImageCache () { }

--- a/src/include/texture.h
+++ b/src/include/texture.h
@@ -315,8 +315,12 @@ public:
     static TextureSystem *create (bool shared=true);
 
     /// Destroy a TextureSystem that was created using
-    /// TextureSystem::create().
+    /// TextureSystem::create().  For the variety that takes a
+    /// teardown_imagecache parameter, if set to true it will cause the
+    /// underlying ImageCache to be fully destroyed, even if it's the
+    /// "shared" ImageCache.
     static void destroy (TextureSystem *x);
+    static void destroy (TextureSystem *x, bool teardown_imagecache);
 
     TextureSystem (void) { }
     virtual ~TextureSystem () { }

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -2567,36 +2567,68 @@ ImageCacheImpl::invalidate (ustring filename)
 void
 ImageCacheImpl::invalidate_all (bool force)
 {
+    // Special case: invalidate EVERYTHING -- we can take some shortcuts
+    // to do it all in one shot.
+    if (force) {
+        // Clear the whole tile cache
+        std::vector<TileID> tiles_to_delete;
+        for (TileCache::iterator t = m_tilecache.begin(), e = m_tilecache.end();
+             t != e;  ++t) {
+            tiles_to_delete.push_back (t->second->id());
+        }
+        BOOST_FOREACH (const TileID &id, tiles_to_delete) {
+            m_tilecache.erase (id);
+        }
+        // Invalidate (close and clear spec) all individual files
+        for (FilenameMap::iterator fileit = m_files.begin(), e = m_files.end();
+                 fileit != e;  ++fileit) {
+            fileit->second->invalidate ();
+        }
+        // Clear fingerprints list
+        clear_fingerprints ();
+        // Mark the per-thread microcaches as invalid
+        purge_perthread_microcaches ();
+        return;
+    }
+
+    // Not forced... we need to look for particular files that seem
+    // to need invalidation.
+
     // Make a list of all files that need to be invalidated
     std::vector<ustring> all_files;
-
     for (FilenameMap::iterator fileit = m_files.begin(), e = m_files.end();
              fileit != e;  ++fileit) {
         ImageCacheFileRef &f (fileit->second);
         ustring name = f->filename();
         recursive_lock_guard guard (f->m_input_mutex);
+        // If the file was broken when we opened it, or if it no longer
+        // exists, definitely invalidate it.
         if (f->broken() || ! Filesystem::exists(name.string())) {
             all_files.push_back (name);
             continue;
         }
-        std::time_t t = Filesystem::last_write_time (name.string());
         // Invalidate the file if it has been modified since it was
-        // last opened, or if 'force' is true.
-        bool inval = force || (t != f->mod_time());
-        for (int s = 0;  !inval && s < f->subimages();  ++s) {
+        // last opened.
+        std::time_t t = Filesystem::last_write_time (name.string());
+        if (t != f->mod_time()) {
+            all_files.push_back (name);
+            continue;
+        }
+        // Invalidate if any unmipped subimage...
+        // ... didn't automip, but automip is now on
+        // ... did automip, but automip is now off
+        for (int s = 0;  s < f->subimages();  ++s) {
             ImageCacheFile::SubimageInfo &sub (f->subimageinfo(s));
-            // Invalidate if any unmipped subimage:
-            // ... didn't automip, but automip is now on
-            // ... did automip, but automip is now off
             if (sub.unmipped &&
                 ((m_automip && f->miplevels(s) <= 1) ||
-                 (!m_automip && f->miplevels(s) > 1)))
-                inval = true;
+                 (!m_automip && f->miplevels(s) > 1))) {
+                all_files.push_back (name);
+                break;
+            }
         }
-        if (inval)
-            all_files.push_back (name);
     }
 
+    // Now, invalidate all the files in our "needs invalidation" list
     BOOST_FOREACH (ustring f, all_files) {
         // fprintf (stderr, "Invalidating %s\n", f.c_str());
         invalidate (f);
@@ -2757,22 +2789,32 @@ ImageCache::create (bool shared)
 
 
 void
-ImageCache::destroy (ImageCache *x)
+ImageCache::destroy (ImageCache *x, bool teardown)
 {
-    // If this is not a shared cache, delete it for real.  But if it is
-    // the same as the shared cache, don't really delete it, since others
-    // may be using it now, or may request a shared cache some time in
-    // the future.  Don't worry that it will leak; because shared_image_cache
-    // is itself a shared_ptr, when the process ends it will properly
-    // destroy the shared cache.
+    if (! x)
+        return;
     spin_lock guard (shared_image_cache_mutex);
     if (x == shared_image_cache.get()) {
-        // Don't destroy the shared cache, but do invalidate and close the files.
-        ((ImageCacheImpl *)x)->invalidate_all ();
+        // This is the shared cache, so don't really delete it. Invalidate
+        // it fully, closing the files and throwing out any tiles that 
+        // nobody is currently holding references to.  But only delete the
+        // IC fully if 'teardown' is true, and even then, it won't destroy
+        // until nobody else is still holding a shared_ptr to it.
+        ((ImageCacheImpl *)x)->invalidate_all (teardown);
+        if (teardown)
+            shared_image_cache.reset ();
     } else {
         // Not a shared cache, we are the only owner, so truly destroy it.
         delete (ImageCacheImpl *) x;
     }
+}
+
+
+
+void
+ImageCache::destroy (ImageCache *x)
+{
+    destroy (x, false);
 }
 
 }

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -457,8 +457,7 @@ private:
     mutable thread_specific_ptr< std::string > m_errormessage;
     Filter1D *hq_filter;         ///< Better filter for magnification
     int m_statslevel;
-    friend class ImageCacheFile;
-    friend class ImageCacheTile;
+    friend class TextureSystem;
 };
 
 


### PR DESCRIPTION
Previously, destroy() would fully delete a non-shared IC but in the case of the global "shared" IC would just do a cursory invalidate of the files.

This patch adds a parameter to the destroy() methods that, if true, will do an even more thorough destruction of the underlying IC -- a full invalidate_all(true) followed by releasing the shared pointer and (when nobody else is still holding it) fully destroying the IC.

Default behavior doesn't change, but you can use this parameter to force a full destruction of the underlying IC, even if it's the "shared" one, for apps that want to be completely sure that they fully reclaim the memory and all other resources held by the IC.
