### PR TITLE
Sysutil::physical_memory

### DIFF
--- a/src/include/sysutil.h
+++ b/src/include/sysutil.h
@@ -112,6 +112,9 @@ namespace Sysutil {
 /// thread).
 OIIO_API size_t memory_used (bool resident=true);
 
+/// The amount of physical RAM on this machine, in bytes.
+/// If it can't figure it out, it will return 0.
+OIIO_API size_t physical_memory ();
 
 /// Convert calendar time pointed by 'time' into local time and save it in
 /// 'converted_time' variable


### PR DESCRIPTION
Trying to make a portable Sysutil utility to report total physical memory.  One imagines that this could inform heuristics about cache size or something.  We don't use it yet, but I wanted to add it because I wrote it a while back while experimenting, don't want to accidentally lose it forever, and it seems to go along with the other stuff in systutil.
