### PR TITLE
Support printf-style frame wildcards (e.g. file.%04d.exr).

### DIFF
--- a/src/libOpenImageIO/filesystem_test.cpp
+++ b/src/libOpenImageIO/filesystem_test.cpp
@@ -119,8 +119,6 @@ test_file_seq (const char *pattern, const char *override,
     OIIO_CHECK_EQUAL (joined, expected);
 }
 
-
-
 void test_frame_sequences ()
 {
     std::cout << "Testing frame number sequences:\n";
@@ -143,6 +141,11 @@ void test_frame_sequences ()
 
     test_file_seq ("foo.1-3@@.exr", NULL, "foo.01.exr foo.02.exr foo.03.exr");
     test_file_seq ("foo.1-3@#.exr", NULL, "foo.00001.exr foo.00002.exr foo.00003.exr");
+
+    test_file_seq ("foo.1-5%04d.exr", NULL, "foo.0001.exr foo.0002.exr foo.0003.exr foo.0004.exr foo.0005.exr");
+    test_file_seq ("foo.%04d.exr", "1-5", "foo.0001.exr foo.0002.exr foo.0003.exr foo.0004.exr foo.0005.exr");
+    test_file_seq ("foo.%4d.exr", "1-5", "foo.   1.exr foo.   2.exr foo.   3.exr foo.   4.exr foo.   5.exr");
+    test_file_seq ("foo.%d.exr", "1-5", "foo.1.exr foo.2.exr foo.3.exr foo.4.exr foo.5.exr");
     std::cout << "\n";
 }
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -3108,8 +3108,8 @@ getargs (int argc, char *argv[])
                 "--no-clobber", &ot.noclobber, "Do not overwrite existing files",
                 "--noclobber", &ot.noclobber, "", // synonym
                 "--threads %@ %d", set_threads, &ot.threads, "Number of threads (default 0 == #cores)",
-                "--frames %s", NULL, "Frame range for '#' wildcards",
-                "--framepadding %d", NULL, "Frame number padding digits",
+                "--frames %s", NULL, "Frame range for '#' or printf-style wildcards",
+                "--framepadding %d", NULL, "Frame number padding digits (ignored when using printf-style wildcards)",
                 "<SEPARATOR>", "Commands that write images:",
                 "-o %@ %s", output_file, NULL, "Output the current image to the named file",
                 "<SEPARATOR>", "Options that affect subsequent image output:",
@@ -3292,7 +3292,7 @@ handle_sequence (int argc, const char **argv)
 {
     Timer totaltime;
 
-    // First, scan the original command line arguments for '#' or '@'
+    // First, scan the original command line arguments for '#', '@' or '%0Nd'
     // characters.  Any found indicate that there are numeric range or
     // wildcards to deal with.  Also look for --frames and --framepadding
     // options.
@@ -3301,7 +3301,7 @@ handle_sequence (int argc, const char **argv)
     std::vector<int> sequence_args;  // Args with sequence numbers
     bool is_sequence = false;
     for (int a = 1;  a < argc;  ++a) {
-        if (strchr (argv[a], '#') || strchr (argv[a], '@')) {
+        if (strchr (argv[a], '#') || strchr (argv[a], '@') || strchr (argv[a], '%')) {
             is_sequence = true;
             sequence_args.push_back (a);
         }


### PR DESCRIPTION
Hi, this branch adds support for printf-style frame wildcards. See issue #701.
