### PR TITLE
Scan for matching frames if no explicit framespec is provided.

### DIFF
--- a/src/include/filesystem.h
+++ b/src/include/filesystem.h
@@ -187,28 +187,38 @@ OIIO_API void convert_native_arguments (int argc, const char *argv[]);
 OIIO_API bool enumerate_sequence (const char *desc,
                                   std::vector<int> &numbers);
 
-/// Given a pattern (such as "foo.#.tif" or "bar.1-10#.exr"), expand the
-/// wildcard to the list of frame numbers and filenames.  The wildcard
-/// consists of a numeric specification that follows the description of
-/// Filesystem::enumerate_sequence, followed by a combination of '#' and
-/// '@' characters.  The '#' and '@' specify padding of 4 and 1 digits,
-/// respectively, and may be combined.  For example, "1-3#" will expand
-/// to "0001", "0002", "003"; "1-3@@" will expand to "01", "02", "03";
-/// "1-3#@" expands to "00001", "00002", "00003".
+/// Given a pattern (such as "foo.#.tif" or "bar.1-10#.exr"), return a
+/// normalized pattern in printf format (such as "foo.%04d.tif") and a
+/// framespec (such as "1-10").
 ///
-/// If sequence_override is non-NULL and non-empty, it overrides any
-/// numeric sequence notation in the overall pattern.  If
-/// framepadding_override is > 0, it overrides any specific padding
-/// amount in the original pattern.
+/// If framepadding_override is > 0, it overrides any specific padding amount
+/// in the original pattern.
 ///
-/// Retrn true upon success, false if the description was too malformed
+/// Return true upon success, false if the description was too malformed
 /// to generate a sequence.
-OIIO_API bool enumerate_file_sequence (const char *pattern,
-                                       const char *sequence_override,
-                                       int framepadding_override,
-                                       std::vector<int> &numbers,
+OIIO_API bool parse_pattern (const char *pattern,
+                             int framepadding_override,
+                             std::string &normalized_pattern,
+                             std::string &framespec);
+
+
+/// Given a normalized pattern (such as "foo.%04d.tif") and a list of frame
+/// numbers, generate a list of filenames.
+///
+/// Return true upon success, false if the description was too malformed
+/// to generate a sequence.
+OIIO_API bool enumerate_file_sequence (const std::string &pattern,
+                                       const std::vector<int> &numbers,
                                        std::vector<std::string> &filenames);
 
+/// Given a normalized pattern (such as "/path/to/foo.%04d.tif") scan the
+/// containing directory (/path/to) for matching frame numbers and files.
+///
+/// Return true upon success, false if the directory doesn't exist or the
+/// pattern can't be parsed.
+OIIO_API bool scan_for_matching_filenames (const std::string &pattern,
+                                           std::vector<int> &numbers,
+                                           std::vector<std::string> &filenames);
 
 };  // namespace Filesystem
 

--- a/src/libOpenImageIO/filesystem_test.cpp
+++ b/src/libOpenImageIO/filesystem_test.cpp
@@ -29,6 +29,8 @@
 */
 
 #include <sstream>
+//#include <iostream>
+#include <fstream>
 
 #include "imageio.h"
 #include "filesystem.h"
@@ -109,12 +111,34 @@ test_file_seq (const char *pattern, const char *override,
 {
     std::vector<int> numbers;
     std::vector<std::string> names;
+    std::string normalized_pattern;
+    std::string frame_range;
 
-    Filesystem::enumerate_file_sequence (pattern, override, 0, numbers, names);
+    Filesystem::parse_pattern(pattern, 0, normalized_pattern, frame_range);
+    if (override && strlen(override) > 0)
+        frame_range = override;
+    Filesystem::enumerate_sequence(frame_range.c_str(), numbers);
+    Filesystem::enumerate_file_sequence (normalized_pattern, numbers, names);
     std::string joined = Strutil::join(names, " ");
     std::cout << "  " << pattern;
     if (override)
         std::cout << " + " << override;
+    std::cout << " -> " << joined << "\n";
+    OIIO_CHECK_EQUAL (joined, expected);
+}
+
+static void
+test_scan_file_seq (const char *pattern, const std::string &expected)
+{
+    std::vector<int> numbers;
+    std::vector<std::string> names;
+    std::string normalized_pattern;
+    std::string frame_range;
+
+    Filesystem::parse_pattern(pattern, 0, normalized_pattern, frame_range);
+    Filesystem::scan_for_matching_filenames (normalized_pattern, numbers, names);
+    std::string joined = Strutil::join(names, " ");
+    std::cout << "  " << pattern;
     std::cout << " -> " << joined << "\n";
     OIIO_CHECK_EQUAL (joined, expected);
 }
@@ -149,13 +173,28 @@ void test_frame_sequences ()
     std::cout << "\n";
 }
 
+void test_scan_sequences ()
+{
+    std::cout << "Testing frame sequence scanning:\n";
 
+    std::vector< std::string > filenames;
+
+    for (size_t i = 1; i <= 5; i++) {
+        std::string fn = Strutil::format ("foo.%04d.exr", i);
+        filenames.push_back (fn);
+        std::ofstream f(fn.c_str());
+        f.close();
+    }
+
+    test_scan_file_seq ("foo.#.exr", "foo.0001.exr foo.0002.exr foo.0003.exr foo.0004.exr foo.0005.exr");
+}
 
 int main (int argc, char *argv[])
 {
     test_filename_decomposition ();
     test_filename_searchpath_find ();
     test_frame_sequences ();
+    test_scan_sequences ();
 
     return unit_test_failures;
 }


### PR DESCRIPTION
Fixes #713.

This is a useful feature that scratches an itch. Basically the ability to do:

```
$ oiiotool foo.#.exr -o bar.#.exr
```

in a directory containing:

```
foo.0001.exr foo.0002.exr foo.0003.exr foo.0004.exr foo.0005.exr
```

results in the sequence:

```
bar.0001.exr bar.0002.exr bar.0003.exr bar.0004.exr bar.0005.exr
```

Any time framespecs are explicitly provided they are used. If they are not used, then inputs are scanned for matching frames. 

If no framespec is provided for an output, the frame numbers from the first input are used.

This is backwards-compatible (at least, I think it is) with current oiiotool behavior except for one edge case: currently (I mean in oiio master), if no framespec is provided for any sequence, it defaults to "0".
