### PR TITLE
Allow more slop in the timer_test (tolerance of 1/100s instead of 1/1000s)

### DIFF
--- a/src/libOpenImageIO/timer_test.cpp
+++ b/src/libOpenImageIO/timer_test.cpp
@@ -95,7 +95,7 @@ main (int argc, char **argv)
     }
 
     const int interval = 100000;  // 1/10 sec
-    const double eps = 1e-3;   // slop we allow in our timings
+    const double eps = 1e-2;   // slop we allow in our timings
 
     // Verify that Timer(false) doesn't start
     Timer all(true);


### PR DESCRIPTION
For some reason, this test fails on OS 10.9 Mavericks, seemingly because
there's a bit more slop in how long a usleep() really takes to wake you
up again.  It used to be within 1/1000s, but sometimes it's a bit more
on this OS.  Changing the tolerance to 1/100s makes the tests pass, and
I don't see any problem with it.

I've read that one of Mavericks' major design goals was to improve
power use, and apparently the process scheduler tries very hard
to juggle time slices around to make slices abut (to amortize the power
efficiency of the Intel chips, which have to ramp up and down a bit when
there's processor activity).  It wouldn't surprise me if this ends up
making usleep just a bit less consistent in precisely how long it will
be before the process wakes up again.  How's that for a hypothesis?
