### PR TITLE
Fix iv broken on Mavericks and other platforms where GLU is deprecated.

### DIFF
--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -59,10 +59,25 @@ using boost::algorithm::iequals;
 #include "timer.h"
 
 
+static const char *
+gl_err_to_string (GLenum err)
+{  // Thanks, Dan Wexler, for this function
+    switch (err) {
+    case GL_NO_ERROR: return "No error";
+    case GL_INVALID_ENUM: return "Invalid enum";
+    case GL_INVALID_OPERATION: return "Invalid operation";
+    case GL_INVALID_VALUE: return "Invalid value";
+    case GL_OUT_OF_MEMORY: return "Out of memory";
+    case GL_INVALID_FRAMEBUFFER_OPERATION:
+        return "Invalid framebuffer operation";
+    default: return "Unknown";
+    }
+}
+
 
 #define GLERRPRINT(msg)                                           \
     for (GLenum err = glGetError();  err != GL_NO_ERROR;  err = glGetError()) \
-        std::cerr << "GL error " << msg << " " << (int)err <<  " - " << (const char *)gluErrorString(err) << "\n";      \
+        std::cerr << "GL error " << msg << " " << (int)err <<  " - " << gl_err_to_string(err) << "\n";      \
 
 
 


### PR DESCRIPTION
GLU (there was only one call we ever made) is apparently deprecated in OpenGL 3.x, that's probably old news, but in Mac OS 10.9, they give it some teeth.
