### PR TITLE
IBA::over/zover: Remove float-only restrictions, simplify implementation

### DIFF
--- a/src/include/imagebufalgo_util.h
+++ b/src/include/imagebufalgo_util.h
@@ -101,10 +101,19 @@ parallel_image (Func f, ROI roi, int nthreads=0)
 /// dst is uninitialized and  force_spec is not NULL, use *force_spec as
 /// dst's new spec rather than using A's.  Also, if A or B inputs are
 /// specified but not initialized or broken, it's an error so return false.
-/// If all is ok, return true.
+/// If all is ok, return true.  Some additional checks and behaviors may be
+/// specified by the 'prepflags', which is a bit field defined by
+/// IBAprep_flags.
 bool OIIO_API IBAprep (ROI &roi, ImageBuf *dst,
                        const ImageBuf *A=NULL, const ImageBuf *B=NULL,
-                       ImageSpec *force_spec=NULL);
+                       ImageSpec *force_spec=NULL, int prepflags=0);
+
+enum IBAprep_flags {
+    IBAprep_DEFAULT = 0,
+    IBAprep_REQUIRE_ALPHA = 1,
+    IBAprep_REQUIRE_Z = 2,
+    IBAprep_REQUIRE_SAME_NCHANNELS = 4
+};
 
 
 

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -104,7 +104,7 @@ struct Dim3 {
 bool
 ImageBufAlgo::IBAprep (ROI &roi, ImageBuf *dst,
                        const ImageBuf *A, const ImageBuf *B,
-                       ImageSpec *force_spec)
+                       ImageSpec *force_spec, int prepflags)
 {
     if ((A && !A->initialized()) || (B && !B->initialized())) {
         if (dst)
@@ -177,6 +177,31 @@ ImageBufAlgo::IBAprep (ROI &roi, ImageBuf *dst,
             set_roi_full (spec, roi);
         dst->alloc (spec);
     }
+    if (prepflags & IBAprep_REQUIRE_ALPHA) {
+        if (dst->spec().alpha_channel < 0 ||
+              (A && A->spec().alpha_channel < 0) ||
+              (B && B->spec().alpha_channel < 0)) {
+            dst->error ("images must have alpha channels");
+            return false;
+        }
+    }
+    if (prepflags & IBAprep_REQUIRE_Z) {
+        if (dst->spec().z_channel < 0 ||
+              (A && A->spec().z_channel < 0) ||
+              (B && B->spec().z_channel < 0)) {
+            dst->error ("images must have depth channels");
+            return false;
+        }
+    }
+    if (prepflags & IBAprep_REQUIRE_SAME_NCHANNELS) {
+        int n = dst->spec().nchannels;
+        if ((A && A->spec().nchannels != n) ||
+            (B && B->spec().nchannels != n)) {
+            dst->error ("images must have the same number of channels");
+            return false;
+        }
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Somehow over & zover escaped part of the recent overhaul of ImageBufAlgo and still contained an odd restriction to only working on float images.  This modernizes the implementation and lifts that restriction.

This includes beefing up IBAPrep to let it perform additional optional checks.
