### PR TITLE
Move CMakeLists.txt to the top level, per usual CMake convention

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,8 @@ if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     message (FATAL_ERROR "Not allowed to run in-source build!")
 endif ()
 
-if (NOT CMAKE_BUILD_TYPE) 
-    set (CMAKE_BUILD_TYPE "Release") 
+if (NOT CMAKE_BUILD_TYPE)
+    set (CMAKE_BUILD_TYPE "Release")
 endif ()
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     set (DEBUGMODE ON)
@@ -72,6 +72,20 @@ if (CMAKE_COMPILER_IS_CLANG)
     add_definitions ("-Qunused-arguments")
 endif ()
 
+if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_GNUCC)
+    if (HIDE_SYMBOLS AND NOT DEBUGMODE)
+        # Turn default symbol visibility to hidden
+        set (VISIBILITY_COMMAND "-fvisibility=hidden -fvisibility-inlines-hidden")
+        add_definitions (${VISIBILITY_COMMAND})
+        if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+            # Linux: also hide all the symbols of dependent libraries to
+            # prevent clashes if an app using OIIO is linked against
+            # other verions of our dependencies.
+            set (VISIBILITY_MAP_COMMAND "-Wl,--version-script=${PROJECT_SOURCE_DIR}/src/libOpenImageIO/libOpenImageIO.map")
+        endif ()
+    endif ()
+endif ()
+
 
 set (VERBOSE OFF CACHE BOOL "Print lots of messages while compiling")
 set (EMBEDPLUGINS ON CACHE BOOL "Embed format plugins in libOpenImageIO")
@@ -122,27 +136,13 @@ else ()
     message (STATUS "TBB will not be used")
 endif ()
 
-if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_GNUCC)
-    if (HIDE_SYMBOLS AND NOT DEBUGMODE)
-        # Turn default symbol visibility to hidden
-        set (VISIBILITY_COMMAND "-fvisibility=hidden -fvisibility-inlines-hidden")
-        add_definitions (${VISIBILITY_COMMAND})
-        if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-            # Linux: also hide all the symbols of dependent libraries to
-            # prevent clashes if an app using OIIO is linked against
-            # other verions of our dependencies.
-            set (VISIBILITY_MAP_COMMAND "-Wl,--version-script=${PROJECT_SOURCE_DIR}/libOpenImageIO/libOpenImageIO.map")
-        endif ()
-    endif ()
-endif ()
-
 if (EXTRA_CPP_DEFINITIONS)
     add_definitions ("${EXTRA_CPP_DEFINITIONS}")
 endif()
 
 set(CMAKE_MODULE_PATH
-    "${PROJECT_SOURCE_DIR}/cmake/modules"
-    "${PROJECT_SOURCE_DIR}/cmake")
+    "${PROJECT_SOURCE_DIR}/src/cmake/modules"
+    "${PROJECT_SOURCE_DIR}/src/cmake")
 
 # Set the default namespace
 if(NOT OIIO_NAMESPACE)
@@ -161,7 +161,7 @@ include (externalpackages)
 
 
 include_directories(
-    "${CMAKE_SOURCE_DIR}/include/"
+    "${CMAKE_SOURCE_DIR}/src/include/"
     "${CMAKE_BINARY_DIR}/include/"
 )
 
@@ -255,54 +255,54 @@ include (CTest)
 
 
 # Tell CMake to process the sub-directories
-add_subdirectory (libOpenImageIO)
+add_subdirectory (src/libOpenImageIO)
 
 if (OIIO_BUILD_TOOLS)
-  add_subdirectory (iconvert)
-  add_subdirectory (idiff)
-  add_subdirectory (igrep)
-  add_subdirectory (iinfo)
-  add_subdirectory (maketx)
-  add_subdirectory (oiiotool)
-  add_subdirectory (testtex)
-  add_subdirectory (iv)
+  add_subdirectory (src/iconvert)
+  add_subdirectory (src/idiff)
+  add_subdirectory (src/igrep)
+  add_subdirectory (src/iinfo)
+  add_subdirectory (src/maketx)
+  add_subdirectory (src/oiiotool)
+  add_subdirectory (src/testtex)
+  add_subdirectory (src/iv)
 endif ()
 
 # Add IO plugin directories
 if (NOT EMBEDPLUGINS)
-    add_subdirectory (bmp.imageio)
-    add_subdirectory (cineon.imageio)
-    add_subdirectory (dds.imageio)
-    add_subdirectory (dpx.imageio)
-    add_subdirectory (field3d.imageio)
-    add_subdirectory (fits.imageio)
-    add_subdirectory (gif.imageio)
-    add_subdirectory (hdr.imageio)
-    add_subdirectory (ico.imageio)
-    add_subdirectory (iff.imageio)
-    add_subdirectory (jpeg.imageio)
-    add_subdirectory (jpeg2000.imageio)
-    add_subdirectory (openexr.imageio)
-    add_subdirectory (png.imageio)
-    add_subdirectory (pnm.imageio)
-    add_subdirectory (psd.imageio)
-    add_subdirectory (ptex.imageio)
-    add_subdirectory (rla.imageio)
-    add_subdirectory (sgi.imageio)
-    add_subdirectory (socket.imageio)
-    add_subdirectory (softimage.imageio)
-    add_subdirectory (targa.imageio)
-    add_subdirectory (tiff.imageio)
-    add_subdirectory (webp.imageio)
-    add_subdirectory (zfile.imageio)
+    add_subdirectory (src/bmp.imageio)
+    add_subdirectory (src/cineon.imageio)
+    add_subdirectory (src/dds.imageio)
+    add_subdirectory (src/dpx.imageio)
+    add_subdirectory (src/field3d.imageio)
+    add_subdirectory (src/fits.imageio)
+    add_subdirectory (src/gif.imageio)
+    add_subdirectory (src/hdr.imageio)
+    add_subdirectory (src/ico.imageio)
+    add_subdirectory (src/iff.imageio)
+    add_subdirectory (src/jpeg.imageio)
+    add_subdirectory (src/jpeg2000.imageio)
+    add_subdirectory (src/openexr.imageio)
+    add_subdirectory (src/png.imageio)
+    add_subdirectory (src/pnm.imageio)
+    add_subdirectory (src/psd.imageio)
+    add_subdirectory (src/ptex.imageio)
+    add_subdirectory (src/rla.imageio)
+    add_subdirectory (src/sgi.imageio)
+    add_subdirectory (src/socket.imageio)
+    add_subdirectory (src/softimage.imageio)
+    add_subdirectory (src/targa.imageio)
+    add_subdirectory (src/tiff.imageio)
+    add_subdirectory (src/webp.imageio)
+    add_subdirectory (src/zfile.imageio)
 endif ()
 
 if (USE_PYTHON AND oiio_boost_PYTHON_FOUND)
-    add_subdirectory (python)
+    add_subdirectory (src/python)
 endif ()
 
-add_subdirectory (include)
-add_subdirectory (doc)
+add_subdirectory (src/include)
+add_subdirectory (src/doc)
 
 
 #########################################################################
@@ -326,7 +326,7 @@ add_subdirectory (doc)
 
 # Make a copy of the testsuite into the build area
 if (DEFINED CMAKE_VERSION AND NOT CMAKE_VERSION VERSION_LESS 2.8)
-    file (COPY "${PROJECT_SOURCE_DIR}/../testsuite"
+    file (COPY "${PROJECT_SOURCE_DIR}/testsuite"
           DESTINATION "${CMAKE_BINARY_DIR}")
 endif()
 
@@ -404,16 +404,16 @@ set (CPACK_PACKAGE_VERSION_PATCH ${OIIO_VERSION_PATCH})
 # the rest of the copyright notices say.
 set (CPACK_PACKAGE_VENDOR "Larry Gritz et al.")
 set (CPACK_PACKAGE_DESCRIPTION_SUMMARY "OpenImageIO is an open source library for reading and writing image file formats, a nice format-agnostic image viewer, and other image-related classes and utilities.")
-set (CPACK_PACKAGE_DESCRIPTION_FILE "${PROJECT_SOURCE_DIR}/doc/Description.txt")
+set (CPACK_PACKAGE_DESCRIPTION_FILE "${PROJECT_SOURCE_DIR}/src/doc/Description.txt")
 set (CPACK_PACKAGE_FILE_NAME OpenImageIO-${OIIO_VERSION_MAJOR}.${OIIO_VERSION_MINOR}.${OIIO_VERSION_PATCH}-${platform})
-#SET (CPACK_PACKAGE_INSTALL_DIRECTORY "${PROJECT_SOURCE_DIR}/..")
-file (COPY "${PROJECT_SOURCE_DIR}/../LICENSE" DESTINATION "${CMAKE_BINARY_DIR}")
+#SET (CPACK_PACKAGE_INSTALL_DIRECTORY "${PROJECT_SOURCE_DIR}")
+file (COPY "${PROJECT_SOURCE_DIR}/LICENSE" DESTINATION "${CMAKE_BINARY_DIR}")
 file (RENAME "${CMAKE_BINARY_DIR}/LICENSE" "${CMAKE_BINARY_DIR}/License.txt")
 set (CPACK_RESOURCE_FILE_LICENSE "${CMAKE_BINARY_DIR}/License.txt")
-file (COPY "${PROJECT_SOURCE_DIR}/../README.rst" DESTINATION "${CMAKE_BINARY_DIR}")
+file (COPY "${PROJECT_SOURCE_DIR}/README.rst" DESTINATION "${CMAKE_BINARY_DIR}")
 file (RENAME "${CMAKE_BINARY_DIR}/README.rst" "${CMAKE_BINARY_DIR}/Readme.rst")
 set (CPACK_RESOURCE_FILE_README "${CMAKE_BINARY_DIR}/Readme.rst")
-set (CPACK_RESOURCE_FILE_WELCOME "${PROJECT_SOURCE_DIR}/doc/Welcome.txt")
+set (CPACK_RESOURCE_FILE_WELCOME "${PROJECT_SOURCE_DIR}/src/doc/Welcome.txt")
 #SET (CPACK_STRIP_FILES Do we need this?)
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     set (CPACK_GENERATOR "TGZ;STGZ;RPM;DEB")

--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ cmakesetup:
 		cd ${build_dir} ; \
 		cmake -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/${dist_dir} \
 			${MY_CMAKE_FLAGS} -DBOOST_ROOT=${BOOST_HOME} \
-			../../src ; \
+			../.. ; \
 	 fi)
 
 # 'make cmake' does a basic build (after first setting it up)

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -2,7 +2,7 @@
 # Find libraries
 
 setup_path (THIRD_PARTY_TOOLS_HOME 
-#            "${PROJECT_SOURCE_DIR}/../../external/dist/${platform}"
+#            "${PROJECT_SOURCE_DIR}/../external/dist/${platform}"
             "unknown"
             "Location of third party libraries in the external project")
 
@@ -297,7 +297,7 @@ if (USE_FIELD3D AND HDF5_FOUND)
     else ()
         find_path (FIELD3D_INCLUDES Field3D/Field.h
                    "${THIRD_PARTY_TOOLS}/include"
-                   "${PROJECT_SOURCE_DIR}/include"
+                   "${PROJECT_SOURCE_DIR}/src/include"
                    "${FIELD3D_HOME}/include"
                   )
     endif ()
@@ -341,7 +341,7 @@ if (VERBOSE)
 endif ()
 find_path (WEBP_INCLUDE_DIR webp/encode.h
            "${THIRD_PARTY_TOOLS}/include"
-           "${PROJECT_SOURCE_DIR}/include"
+           "${PROJECT_SOURCE_DIR}/src/include"
            "${WEBP_HOME}")
 find_library (WEBP_LIBRARY
               NAMES webp

--- a/src/cmake/oiio_macros.cmake
+++ b/src/cmake/oiio_macros.cmake
@@ -78,7 +78,7 @@ endmacro ()
 #
 macro (oiio_add_tests)
     parse_arguments (_ats "URL;IMAGEDIR;LABEL;FOUNDVAR" "" ${ARGN})
-    set (_ats_testdir "${PROJECT_SOURCE_DIR}/../../${_ats_IMAGEDIR}")
+    set (_ats_testdir "${PROJECT_SOURCE_DIR}/../${_ats_IMAGEDIR}")
     # If there was a FOUNDVAR param specified and that variable name is
     # not defined, mark the test as broken.
     if (_ats_FOUNDVAR AND NOT ${_ats_FOUNDVAR})

--- a/src/dds.imageio/CMakeLists.txt
+++ b/src/dds.imageio/CMakeLists.txt
@@ -1,1 +1,4 @@
-add_oiio_plugin (ddsinput.cpp ddsoutput.cpp squish/alpha.cpp squish/clusterfit.cpp squish/colourblock.cpp squish/colourfit.cpp squish/colourset.cpp squish/maths.cpp squish/rangefit.cpp squish/singlecolourfit.cpp squish/squish.cpp)
+add_oiio_plugin (ddsinput.cpp ddsoutput.cpp squish/alpha.cpp squish/clusterfit.cpp
+                 squish/colourblock.cpp squish/colourfit.cpp squish/colourset.cpp
+                 squish/maths.cpp squish/rangefit.cpp squish/singlecolourfit.cpp
+                 squish/squish.cpp)

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -2,8 +2,8 @@ project(documentation)
 
 set (public_docs
      openimageio.pdf
-     "${OpenImageIO_SOURCE_DIR}/../LICENSE"
-     "${OpenImageIO_SOURCE_DIR}/../CHANGES"
+     "${OpenImageIO_SOURCE_DIR}/LICENSE"
+     "${OpenImageIO_SOURCE_DIR}/CHANGES"
 )
 
 if (INSTALL_DOCS)

--- a/src/iv/CMakeLists.txt
+++ b/src/iv/CMakeLists.txt
@@ -1,17 +1,17 @@
 if (QT4_FOUND AND OPENGL_FOUND AND GLEW_FOUND)
     include (${QT_USE_FILE})
     include_directories (${QT_INCLUDES} ${OPENGL_INCLUDE_DIR} ${GLEW_INCLUDES})
-    add_custom_command (OUTPUT "${CMAKE_BINARY_DIR}/iv/moc_imageviewer.cpp"
+    add_custom_command (OUTPUT "${CMAKE_BINARY_DIR}/src/iv/moc_imageviewer.cpp"
                         DEPENDS imageviewer.h imageviewer.cpp
                         COMMAND ${QT_MOC_EXECUTABLE}
-                        ARGS "${PROJECT_SOURCE_DIR}/iv/imageviewer.h"
-                           -o "${CMAKE_BINARY_DIR}/iv/moc_imageviewer.cpp"
+                        ARGS "${PROJECT_SOURCE_DIR}/src/iv/imageviewer.h"
+                           -o "${CMAKE_BINARY_DIR}/src/iv/moc_imageviewer.cpp"
                         )
-    add_custom_command (OUTPUT ${CMAKE_BINARY_DIR}/iv/moc_ivgl.cpp
+    add_custom_command (OUTPUT ${CMAKE_BINARY_DIR}/src/iv/moc_ivgl.cpp
                         DEPENDS ivgl.h ivgl.cpp
                         COMMAND ${QT_MOC_EXECUTABLE}
-                        ARGS "${PROJECT_SOURCE_DIR}/iv/ivgl.h"
-                           -o "${CMAKE_BINARY_DIR}/iv/moc_ivgl.cpp"
+                        ARGS "${PROJECT_SOURCE_DIR}/src/iv/ivgl.h"
+                           -o "${CMAKE_BINARY_DIR}/src/iv/moc_ivgl.cpp"
                         )
     set (iv_srcs imageviewer.cpp ivimage.cpp ivgl.cpp ivinfowin.cpp 
                  ivpref.cpp ivmain.cpp moc_imageviewer.cpp moc_ivgl.cpp)

--- a/src/libOpenImageIO/filesystem_test.cpp
+++ b/src/libOpenImageIO/filesystem_test.cpp
@@ -59,22 +59,22 @@ void test_filename_decomposition ()
 
 void test_filename_searchpath_find ()
 {
-    // This will be run via testsuite/unit_filesystem, from the
-    // build/ARCH/libOpenImageIO directory.  One level up will be
-    // build/ARCH.
-    std::vector<std::string> dirs;
-    dirs.push_back ("..");
-    std::string s;
-
 #if _WIN32
 # define SEPARATOR "\\"
 #else
 # define SEPARATOR "/"
 #endif
 
+    // This will be run via testsuite/unit_filesystem, from the
+    // build/ARCH/src/libOpenImageIO directory.  Two levels up will be
+    // build/ARCH.
+    std::vector<std::string> dirs;
+    dirs.push_back (".." SEPARATOR "..");
+    std::string s;
+
     // non-recursive search success
     s = Filesystem::searchpath_find ("License.txt", dirs, false, false);
-    OIIO_CHECK_EQUAL (s, ".." SEPARATOR "License.txt");
+    OIIO_CHECK_EQUAL (s, ".." SEPARATOR ".." SEPARATOR "License.txt");
 
     // non-recursive search failure (file is in a subdirectory)
     s = Filesystem::searchpath_find ("version.h", dirs, false, false);
@@ -82,7 +82,7 @@ void test_filename_searchpath_find ()
 
     // recursive search success (file is in a subdirectory)
     s = Filesystem::searchpath_find ("version.h", dirs, false, true);
-    OIIO_CHECK_EQUAL (s, ".." SEPARATOR "include" SEPARATOR "version.h");
+    OIIO_CHECK_EQUAL (s, ".." SEPARATOR ".." SEPARATOR "include" SEPARATOR "version.h");
 }
 
 

--- a/src/ptex.imageio/CMakeLists.txt
+++ b/src/ptex.imageio/CMakeLists.txt
@@ -1,11 +1,11 @@
 find_package (ZLIB)
 
 if (ZLIB_FOUND)
-	if (WIN32)
+    if (WIN32)
         add_definitions ("-DPTEX_EXPORTS")
-	endif()
+    endif()
     include_directories (${ZLIB_INCLUDE_DIR})
-	add_oiio_plugin (ptexinput.cpp ptexoutput.cpp
+    add_oiio_plugin (ptexinput.cpp ptexoutput.cpp
                  ptex/PtexCache.cpp
                  ptex/PtexFilters.cpp
                  ptex/PtexHalf.cpp

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -99,9 +99,9 @@ def oiio_app (app):
     # When we use Visual Studio, built applications are stored
     # in the app/$(OutDir)/ directory, e.g., Release or Debug.
     if (platform.system () != 'Windows' or options.devenv_config == ""):
-        return os.path.join (path, app, app) + " "
+        return os.path.join (path, "src", app, app) + " "
     else:
-        return os.path.join (path, app, options.devenv_config, app) + " "
+        return os.path.join (path, "src", app, options.devenv_config, app) + " "
 
 
 # Construct a command that will print info for an image, appending output to


### PR DESCRIPTION
This just moves the file around to the usual space and then fixes up all the paths that change.

In a few places, there's a tiny bit of other minor movement of code in the files, but no real changes.
