### PR TITLE
Strutil::safe_strcpy -- like strncpy, but copies terminating 0 char.

### DIFF
--- a/src/cineon.imageio/libcineon/CineonHeader.cpp
+++ b/src/cineon.imageio/libcineon/CineonHeader.cpp
@@ -41,6 +41,7 @@
 #include <ctime>
 #include <limits>
 
+#include "strutil.h"
 
 #include "CineonHeader.h"
 #include "EndianSwap.h"
@@ -84,7 +85,7 @@ void cineon::GenericHeader::Reset()
 	this->magicNumber = MAGIC_COOKIE;
 	this->imageOffset = ~0;
 	EmptyString(this->version);
-	::strcpy(this->version, SPEC_VERSION);
+	OIIO::Strutil::safe_strcpy(this->version, SPEC_VERSION, sizeof(this->version));
 	fileSize = sizeof(cineon::Header);
 
 	// genericSize is the size of the file/image/orientation headers

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -366,7 +366,7 @@ DPXInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
         // libdpx's date/time format is pretty close to OIIO's (libdpx uses
         // %Y:%m:%d:%H:%M:%S%Z)
         char date[24];
-        strcpy(date, m_dpx.header.creationTimeDate);
+        Strutil::safe_strcpy(date, m_dpx.header.creationTimeDate, sizeof(date));
         date[10] = ' ';
         date[19] = 0;
         m_spec.attribute ("DateTime", date);
@@ -492,7 +492,7 @@ DPXInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
         // libdpx's date/time format is pretty close to OIIO's (libdpx uses
         // %Y:%m:%d:%H:%M:%S%Z)
         char date[24];
-        strcpy(date, m_dpx.header.sourceTimeDate);
+        Strutil::safe_strcpy(date, m_dpx.header.sourceTimeDate, sizeof(date));
         date[10] = ' ';
         date[19] = 0;
         m_spec.attribute ("dpx:SourceDateTime", date);

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -39,6 +39,7 @@
 #include "typedesc.h"
 #include "imageio.h"
 #include "fmath.h"
+#include "strutil.h"
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
@@ -714,19 +715,19 @@ DPXOutput::set_keycode_values (int *array)
     int &perfsPerCount = array[6];
 
     if (perfsPerFrame == 15 && perfsPerCount == 120) {
-        strcpy(m_dpx.header.format, "8kimax");
+        Strutil::safe_strcpy(m_dpx.header.format, "8kimax", sizeof(m_dpx.header.format));
     }
     else if (perfsPerFrame == 8 && perfsPerCount == 64) {
-        strcpy(m_dpx.header.format, "VistaVision");
+        Strutil::safe_strcpy(m_dpx.header.format, "VistaVision", sizeof(m_dpx.header.format));
     }
     else if (perfsPerFrame == 4 && perfsPerCount == 64) {
-        strcpy(m_dpx.header.format, "Full Aperture");
+        Strutil::safe_strcpy(m_dpx.header.format, "Full Aperture", sizeof(m_dpx.header.format));
     }
     else if (perfsPerFrame == 3 && perfsPerCount == 64) {
-        strcpy(m_dpx.header.format, "3perf");
+        Strutil::safe_strcpy(m_dpx.header.format, "3perf", sizeof(m_dpx.header.format));
     }
     else {
-        strcpy(m_dpx.header.format, "Unknown");
+        Strutil::safe_strcpy(m_dpx.header.format, "Unknown", sizeof(m_dpx.header.format));
     }
 }
 

--- a/src/dpx.imageio/libdpx/DPXHeader.cpp
+++ b/src/dpx.imageio/libdpx/DPXHeader.cpp
@@ -79,8 +79,8 @@ void dpx::GenericHeader::Reset()
 	// File Information
 	this->magicNumber = MAGIC_COOKIE;
 	this->imageOffset = ~0;
-	EmptyString(this->version, 8);
-	::strcpy(this->version, SMPTE_VERSION);
+	EmptyString(this->version, sizeof(this->version));
+	OIIO::Strutil::safe_strcpy(this->version, SMPTE_VERSION, sizeof(this->version));
 	fileSize = sizeof(dpx::Header);
 	this->dittoKey = 1;									// new
 
@@ -99,32 +99,32 @@ void dpx::GenericHeader::Reset()
 	this->industrySize = 256 + 128;
 
 	this->userSize = 0;
-	EmptyString(this->fileName, 100);
-	EmptyString(this->creationTimeDate, 24);
-	EmptyString(this->creator, 100);
-	EmptyString(this->project, 200);
-	EmptyString(this->copyright, 200);
+	EmptyString(this->fileName, sizeof(this->fileName));
+	EmptyString(this->creationTimeDate, sizeof(this->creationTimeDate));
+	EmptyString(this->creator, sizeof(this->creator));
+	EmptyString(this->project, sizeof(this->project));
+	EmptyString(this->copyright, sizeof(this->copyright));
 	this->encryptKey = 0xffffffff;
-	EmptyString(this->reserved1, 104);
+	EmptyString(this->reserved1, sizeof(this->reserved1));
 
 	// Image Information
 	this->imageOrientation = kUndefinedOrientation;
 	this->numberOfElements = 0xffff;
 	this->pixelsPerLine = this->linesPerElement = 0xffffffff;
-	EmptyString(this->reserved2, 52);
+	EmptyString(this->reserved2, sizeof(this->reserved2));
 
 	// Image Orientation
 	this->xOffset = this->yOffset = 0xffffffff;
 	this->xCenter = this->yCenter = std::numeric_limits<float>::quiet_NaN();
 	this->xOriginalSize = this->yOriginalSize = 0xffffffff;
-	EmptyString(this->sourceImageFileName, 100);
-	EmptyString(this->sourceTimeDate, 24);
-	EmptyString(this->inputDevice, 32);
-	EmptyString(this->inputDeviceSerialNumber, 32);
+	EmptyString(this->sourceImageFileName, sizeof(this->sourceImageFileName));
+	EmptyString(this->sourceTimeDate, sizeof(this->sourceTimeDate));
+	EmptyString(this->inputDevice, sizeof(this->inputDevice));
+	EmptyString(this->inputDeviceSerialNumber, sizeof(this->inputDeviceSerialNumber));
 	this->border[0] = this->border[1] = this->border[2] = this->border[3] = 0xffff;
 	this->aspectRatio[0] = this->aspectRatio[1] = 0xffffffff;
 	this->xScannedSize = this->yScannedSize = std::numeric_limits<float>::quiet_NaN();
-	EmptyString(this->reserved3, 28);
+	EmptyString(this->reserved3, sizeof(this->reserved3));
 }
 
 
@@ -137,17 +137,17 @@ dpx::IndustryHeader::IndustryHeader()
 void dpx::IndustryHeader::Reset()
 {
 	// Motion Picture Industry Specific
-	EmptyString(this->filmManufacturingIdCode, 2);
-	EmptyString(this->filmType, 2);
-	EmptyString(this->perfsOffset, 2);
-	EmptyString(this->prefix, 6);
-	EmptyString(this->count, 4);
-	EmptyString(this->format, 32);
+	EmptyString(this->filmManufacturingIdCode, sizeof(this->filmManufacturingIdCode));
+	EmptyString(this->filmType, sizeof(this->filmType));
+	EmptyString(this->perfsOffset, sizeof(this->perfsOffset));
+	EmptyString(this->prefix, sizeof(this->prefix));
+	EmptyString(this->count, sizeof(this->count));
+	EmptyString(this->format, sizeof(this->format));
 	this->framePosition = this->sequenceLength = this->heldCount = 0xffffffff;
 	this->frameRate = this->shutterAngle = std::numeric_limits<float>::quiet_NaN();
-	EmptyString(this->frameId, 32);
-	EmptyString(this->slateInfo, 200);
-	EmptyString(this->reserved4, 56);
+	EmptyString(this->frameId, sizeof(this->frameId));
+	EmptyString(this->slateInfo, sizeof(this->slateInfo));
+	EmptyString(this->reserved4, sizeof(this->reserved4));
 
 	// Television Industry Specific
 	this->timeCode = this->userBits = 0xffffffff;
@@ -158,7 +158,7 @@ void dpx::IndustryHeader::Reset()
 	this->timeOffset = this->gamma = std::numeric_limits<float>::quiet_NaN();
 	this->blackLevel = this->blackGain = std::numeric_limits<float>::quiet_NaN();
 	this->breakPoint = this->whiteLevel = this->integrationTimes = std::numeric_limits<float>::quiet_NaN();
-	EmptyString(this->reserved5, 76);
+	EmptyString(this->reserved5, sizeof(this->reserved5));
 }
 
 
@@ -175,7 +175,7 @@ dpx::ImageElement::ImageElement()
 	this->bitDepth = 0xff;
 	this->packing = this->encoding = 0xffff;
 	this->dataOffset = this->endOfLinePadding = this->endOfImagePadding = 0xffffffff;
-	EmptyString(this->description, 32);
+	EmptyString(this->description, sizeof(this->description));
 }
 
 

--- a/src/dpx.imageio/libdpx/DPXHeader.h
+++ b/src/dpx.imageio/libdpx/DPXHeader.h
@@ -42,7 +42,7 @@
 #define _DPX_DPXHEADER_H 1
 
 #include <cstring>
-
+#include "strutil.h"
 #include "DPXStream.h"
 
 
@@ -1532,13 +1532,13 @@ namespace dpx
 	
 	inline void GenericHeader::Version(char *v) const
 	{
-		::strncpy(v, this->version, sizeof(this->version));
+		OIIO::Strutil::safe_strcpy(v, this->version, sizeof(this->version));
 		v[8] = '\0';
 	}
 	
 	inline void GenericHeader::SetVersion(const char * v)
 	{
-		::strncpy(this->version, v, sizeof(this->version));
+		OIIO::Strutil::safe_strcpy(this->version, v, sizeof(this->version));
 	}
 	
 	inline U32 GenericHeader::FileSize() const

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -36,6 +36,7 @@
 #include "imageio.h"
 #include "filesystem.h"
 #include "fmath.h"
+#include "strutil.h"
 #include "rgbe.h"
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
@@ -117,7 +118,7 @@ HdrOutput::open (const std::string &name, const ImageSpec &newspec,
     // Most readers seem to think that rgbe files are valid only if they
     // identify themselves as from "RADIANCE".
     h.valid |= RGBE_VALID_PROGRAMTYPE;
-    strcpy (h.programtype, "RADIANCE");
+    Strutil::safe_strcpy (h.programtype, "RADIANCE", sizeof(h.programtype));
 
     ImageIOParameter *p;
     p = m_spec.find_attribute ("Orientation", TypeDesc::INT);

--- a/src/include/strutil.h
+++ b/src/include/strutil.h
@@ -341,6 +341,16 @@ std::wstring OIIO_API utf8_to_utf16(const std::string& utf8str);
 std::string OIIO_API utf16_to_utf8(const std::wstring& utf16str);
 #endif
 
+
+/// Safe C string copy.  Basically strncpy but ensuring that there's a
+/// terminating 0 character at the end of the resulting string.
+char * OIIO_API safe_strcpy (char *dst, const char *src, size_t size);
+
+inline char * safe_strcpy (char *dst, const std::string &src, size_t size) {
+    return safe_strcpy (dst, src.length() ? src.c_str() : NULL, size);
+}
+
+
 }  // namespace Strutil
 
 }

--- a/src/libOpenImageIO/strutil_test.cpp
+++ b/src/libOpenImageIO/strutil_test.cpp
@@ -163,6 +163,44 @@ void test_strip ()
 
 
 
+void test_safe_strcpy ()
+{
+    { // test in-bounds copy
+        char result[4] = { '0', '1', '2', '3' };
+        Strutil::safe_strcpy (result, "A", 3);
+        OIIO_CHECK_EQUAL (result[0], 'A');
+        OIIO_CHECK_EQUAL (result[1],  0);
+        OIIO_CHECK_EQUAL (result[2], '2'); // should not overwrite
+        OIIO_CHECK_EQUAL (result[3], '3'); // should not overwrite
+    }
+    { // test over-bounds copy
+        char result[4] = { '0', '1', '2', '3' };
+        Strutil::safe_strcpy (result, "ABC", 3);
+        OIIO_CHECK_EQUAL (result[0], 'A');
+        OIIO_CHECK_EQUAL (result[1], 'B');
+        OIIO_CHECK_EQUAL (result[2],  0);
+        OIIO_CHECK_EQUAL (result[3], '3'); // should not overwrite
+    }
+    { // test empty string copy
+        char result[4] = { '0', '1', '2', '3' };
+        Strutil::safe_strcpy (result, "", 3);
+        OIIO_CHECK_EQUAL (result[0], 0);
+        OIIO_CHECK_EQUAL (result[1], '1'); // should not overwrite
+        OIIO_CHECK_EQUAL (result[2], '2'); // should not overwrite
+        OIIO_CHECK_EQUAL (result[3], '3'); // should not overwrite
+    }
+    { // test NULL case
+        char result[4] = { '0', '1', '2', '3' };
+        Strutil::safe_strcpy (result, NULL, 3);
+        OIIO_CHECK_EQUAL (result[0], 0);
+        OIIO_CHECK_EQUAL (result[1], '1'); // should not overwrite
+        OIIO_CHECK_EQUAL (result[2], '2'); // should not overwrite
+        OIIO_CHECK_EQUAL (result[3], '3'); // should not overwrite
+    }
+}
+
+
+
 int main (int argc, char *argv[])
 {
     test_format ();
@@ -171,6 +209,7 @@ int main (int argc, char *argv[])
     test_get_rest_arguments ();
     test_escape_sequences ();
     test_strip ();
+    test_safe_strcpy ();
 
     return unit_test_failures;
 }

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -493,5 +493,24 @@ Strutil::utf16_to_utf8 (const std::wstring& str)
 #endif
 
 
+
+char *
+Strutil::safe_strcpy (char *dst, const char *src, size_t size)
+{
+    if (src) {
+        for (size_t i = 0;  i < size;  ++i) {
+            if (! (dst[i] = src[i]))
+                return dst;   // finished, and copied the 0 character
+        }
+        // If we got here, we have gotten to the maximum length, and still
+        // no terminating 0, so add it!
+        dst[size-1] = 0;
+    } else {
+        dst[0] = 0;
+    }
+    return dst;
+}
+
+
 }
 OIIO_NAMESPACE_EXIT

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -284,7 +284,7 @@ RLAOutput::open (const std::string &name, const ImageSpec &userspec,
     
     std::string s = m_spec.get_string_attribute ("oiio:ColorSpace", "Unknown");
     if (Strutil::iequals(s, "Linear"))
-        strcpy (m_rla.Gamma, "1.0");
+        Strutil::safe_strcpy (m_rla.Gamma, "1.0", sizeof(m_rla.Gamma));
     else if (Strutil::iequals(s, "GammaCorrected"))
         snprintf (m_rla.Gamma, sizeof(m_rla.Gamma), "%.10f",
             m_spec.get_float_attribute ("oiio:Gamma", 1.f));
@@ -347,8 +347,8 @@ RLAOutput::open (const std::string &name, const ImageSpec &userspec,
 
     snprintf (m_rla.AspectRatio, sizeof(m_rla.AspectRatio), "%.10f",
         m_spec.get_float_attribute ("PixelAspectRatio", 1.f));
-    strcpy (m_rla.ColorChannel, m_spec.get_string_attribute ("rla:ColorChannel",
-        "rgb").c_str ());
+    Strutil::safe_strcpy (m_rla.ColorChannel, m_spec.get_string_attribute ("rla:ColorChannel",
+        "rgb"), sizeof(m_rla.ColorChannel));
     m_rla.FieldRendered = m_spec.get_int_attribute ("rla:FieldRendered", 0);
 
     STRING_FIELD (Time, "rla:Time");
@@ -386,7 +386,7 @@ RLAOutput::set_chromaticity (const ImageIOParameter *p, char *dst,
                 break;
         }
     } else
-        strcpy (dst, default_val);
+        Strutil::safe_strcpy (dst, default_val, field_size);
 }
 
 


### PR DESCRIPTION
And fix several places where strcpy might be unsafe or have buffer overrun.
