### PR TITLE
Fix bug in multi-point environment call -- wasn't incrementing result pointer

### DIFF
--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -250,11 +250,17 @@ TextureSystemImpl::environment (ustring filename, TextureOptions &options,
                                 VaryingRef<Imath::V3f> dRdy,
                                 float *result)
 {
+    Perthread *thread_info = get_perthread_info();
+    TextureHandle *texture_handle = get_texture_handle (filename, thread_info);
+    if (! texture_handle)
+        return false;
     bool ok = true;
     for (int i = beginactive;  i < endactive;  ++i) {
         if (runflags[i]) {
             TextureOpt opt (options, i);
-            ok &= environment (filename, opt, R[i], dRdx[i], dRdy[i], result);
+            ok &= environment (texture_handle, thread_info,
+                               opt, R[i], dRdx[i], dRdy[i],
+                               result+i*options.nchannels);
         }
     }
     return ok;

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -685,11 +685,16 @@ TextureSystemImpl::texture (ustring filename, TextureOptions &options,
                             VaryingRef<float> dsdy, VaryingRef<float> dtdy,
                             float *result)
 {
+    Perthread *thread_info = get_perthread_info();
+    TextureHandle *texture_handle = get_texture_handle (filename, thread_info);
+    if (! texture_handle)
+        return false;
     bool ok = true;
     for (int i = beginactive;  i < endactive;  ++i) {
         if (runflags[i]) {
             TextureOpt opt (options, i);
-            ok &= texture (filename, opt, s[i], t[i], dsdx[i], dtdx[i],
+            ok &= texture (texture_handle, thread_info,
+                           opt, s[i], t[i], dsdx[i], dtdx[i],
                            dsdy[i], dtdy[i], result+i*options.nchannels);
         }
     }


### PR DESCRIPTION
Fix bug in multi-point environment call -- wasn't incrementing result pointer

Also modify the multi-point texture and environment calls to use
get_perthread_info and get_texture_handle to do those expensive operations
just once per grid, rather than per point.
