### PR TITLE
ParamValueList tweaks

### DIFF
--- a/src/include/paramlist.h
+++ b/src/include/paramlist.h
@@ -129,12 +129,12 @@ private:
     ustring m_name;           ///< data name
     TypeDesc m_type;          ///< data type, which may itself be an array
     int m_nvalues;            ///< number of values of the given type
+    unsigned char m_interp;   ///< Interpolation type
+    bool m_copy, m_nonlocal;
     union {
         ptrdiff_t localval;
         const void *ptr;
     } m_data;             ///< Our data, either a pointer or small local value
-    unsigned char m_interp;   ///< Interpolation type
-    bool m_copy, m_nonlocal;
 
     void init_noclear (ustring _name, TypeDesc _type,
                        int _nvalues, const void *_value, bool _copy=true);


### PR DESCRIPTION
1. Allow get/set of the internal ParamValue::m_interp field.
2. ParamValueList::push_back() should take a const ParamValue&, not a non-const.
3. Rearranging data members of ParamValueList compresses the struct from 40 to 32 bytes (on architectures with 64 bit pointers).

I'd like to backport all three changes to 1.3 (the third one changes the ABI because the structure layout internals change, but 1.3 is still technically a beta, so minor ABI changes are still allowed).

I'd like to backport 1 & 2 (which do not change non-inlined APIs and do not change ABIs) to 1.2 as well. This should not break either link or source compatibility.
