### PR TITLE
OpenEXR includes cleanup

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -38,7 +38,6 @@ endif ()
 find_package (IlmBase REQUIRED)
 
 include_directories ("${ILMBASE_INCLUDE_DIR}")
-include_directories ("${ILMBASE_INCLUDE_DIR}/OpenEXR")
 
 macro (LINK_ILMBASE target)
     target_link_libraries (${target} ${ILMBASE_LIBRARIES})
@@ -68,7 +67,6 @@ endif ()
 mark_as_advanced (OPENEXR_VERSION)
 
 include_directories ("${OPENEXR_INCLUDE_DIR}")
-include_directories ("${OPENEXR_INCLUDE_DIR}/OpenEXR")
 macro (LINK_OPENEXR target)
     target_link_libraries (${target} ${OPENEXR_LIBRARIES})
 endmacro ()

--- a/src/cmake/modules/FindIlmBase.cmake
+++ b/src/cmake/modules/FindIlmBase.cmake
@@ -145,12 +145,7 @@ list (APPEND IlmBase_library_paths ${IlmBase_generic_library_paths})
 PREFIX_FIND_INCLUDE_DIR (IlmBase
   OpenEXR/IlmBaseConfig.h IlmBase_include_paths)
 
-# If the headers were found, add its parent to the list of lib directories
 if (ILMBASE_INCLUDE_DIR)
-  get_filename_component (tmp_extra_dir "${ILMBASE_INCLUDE_DIR}/../" ABSOLUTE)
-  list (APPEND IlmBase_library_paths ${tmp_extra_dir})
-  unset (tmp_extra_dir)
-
   # Get the version from config file, if not already set.
   if (NOT ILMBASE_VERSION)
     FILE(STRINGS "${ILMBASE_INCLUDE_DIR}/OpenEXR/IlmBaseConfig.h" ILMBASE_BUILD_SPECIFICATION

--- a/src/cmake/modules/FindOpenEXR.cmake
+++ b/src/cmake/modules/FindOpenEXR.cmake
@@ -146,12 +146,7 @@ list (APPEND OpenEXR_library_paths ${OpenEXR_generic_library_paths})
 PREFIX_FIND_INCLUDE_DIR (OpenEXR
   OpenEXR/ImfArray.h OpenEXR_include_paths)
 
-# If the headers were found, add its parent to the list of lib directories
 if (OPENEXR_INCLUDE_DIR)
-  get_filename_component (tmp_extra_dir "${OPENEXR_INCLUDE_DIR}/../" ABSOLUTE)
-  list (APPEND OpenEXR_library_paths ${tmp_extra_dir})
-  unset (tmp_extra_dir)
-
   # Get the version from config file, if not already set.
   if (NOT OPENEXR_VERSION)
     FILE(STRINGS "${OPENEXR_INCLUDE_DIR}/OpenEXR/OpenEXRConfig.h" OPENEXR_BUILD_SPECIFICATION

--- a/src/iv/ivimage.cpp
+++ b/src/iv/ivimage.cpp
@@ -33,7 +33,7 @@
 
 #include <boost/foreach.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <half.h>
+#include <OpenEXR/half.h>
 
 #include "imageviewer.h"
 #include "strutil.h"

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -32,7 +32,7 @@
 #include <cstdlib>
 #include <sstream>
 
-#include <half.h>
+#include <OpenEXR/half.h>
 
 #include <boost/tokenizer.hpp>
 #include <boost/foreach.hpp>

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -33,8 +33,9 @@
 #include <cstdlib>
 #include <string>
 
+#include <OpenEXR/half.h>
+
 #include "dassert.h"
-#include "half.h"
 #include "ustring.h"
 #include "strutil.h"
 


### PR DESCRIPTION
Make sure we include all OpenEXR related headers with `<OpenEXR/foo.h>` and remove the addition of the OpenEXR sub-folder from system search paths.
