### PR TITLE
Imagecache: do not abort/crash when too many error messages are accumulated

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -2745,12 +2745,20 @@ ImageCacheImpl::append_error (const std::string& message) const
         errptr = new std::string;
         m_errormessage.reset (errptr);
     }
+
     ASSERT (errptr != NULL);
-    ASSERT (errptr->size() < 1024*1024*16 &&
-            "Accumulated error messages > 16MB. Try checking return codes!");
+
+    size_t maxsize = 1024*1024*16;
+
+    if (errptr->size() > maxsize)
+        return;
+
     if (errptr->size())
         *errptr += '\n';
     *errptr += message;
+
+    if (errptr->size() > maxsize)
+        fprintf(stderr, "Accumulated error messages > 16MB. Try checking return codes!");
 }
 
 


### PR DESCRIPTION
I suspect this is not the proper solution, submitting this mostly to get advice.

I got a bug report with an OSL shader like this.

```
shader test(string Texture = "/some/file/that/does/not/exist.png", output color Color = 0)
{
    int resolution[2];

    if(gettextureinfo(Texture, "resolution", resolution)){
        float aspectratio = (float)resolution[1]/(float)resolution[0];
        Color = texture(Texture, P[0]*aspectratio, P[1]);
    }
}
```

This will call `TextureSystem::get_texture_info` many times, which leads to many errors reported due to the missing files, the error mesasages will exceed 16MB, and it will abort/crash. I think that there should be no crash at least, even if the user should be calling `gettextureinfo(Texture, "exists", exists)`?
