### PR TITLE
Add missing include to fix compilation error.

### DIFF
--- a/src/include/string_ref.h
+++ b/src/include/string_ref.h
@@ -32,6 +32,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <cstring>
 #include <stdexcept>


### PR DESCRIPTION
Error message:

```
[  0%] Building CXX object src/libutil/CMakeFiles/OpenImageIO_Util.dir/argparse.cpp.o
In file included from /home/mariusz/myrepos/oiio/src/include/strutil.h:53:0,
                 from /home/mariusz/myrepos/oiio/src/libutil/argparse.cpp:43:
/home/mariusz/myrepos/oiio/src/include/string_ref.h:63:13: error: ‘ptrdiff_t’ does not name a type
     typedef ptrdiff_t difference_type;
             ^
src/libutil/CMakeFiles/OpenImageIO_Util.dir/build.make:57: recipe for target 'src/libutil/CMakeFiles/OpenImageIO_Util.dir/argparse.cpp.o' failed
```
