### PR TITLE
Add compression level and compression strategy attribute to pngoutput

### DIFF
--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -153,7 +153,10 @@ PNGOutput::open (const std::string &name, const ImageSpec &userspec,
     png_set_compression_level (m_png, std::max (std::min (m_spec.get_int_attribute ("png:compressionLevel", 6/* medium speed vs size tradeoff */), Z_BEST_COMPRESSION), Z_NO_COMPRESSION));
     std::string compression = m_spec.get_string_attribute ("compression");
     if (compression.empty ()) {
-        png_set_compression_strategy(m_png, Z_RLE);
+        png_set_compression_strategy(m_png, Z_DEFAULT_STRATEGY);
+    }
+    else if (Strutil::iequals (compression, "default")) {
+        png_set_compression_strategy(m_png, Z_DEFAULT_STRATEGY);
     }
     else if (Strutil::iequals (compression, "filtered")) {
         png_set_compression_strategy(m_png, Z_FILTERED);
@@ -168,7 +171,7 @@ PNGOutput::open (const std::string &name, const ImageSpec &userspec,
         png_set_compression_strategy(m_png, Z_FIXED);
     }
     else {
-        png_set_compression_strategy(m_png, Z_RLE); /* Z_RLE is designed to be almost as fast as Z_HUFFMAN_ONLY, but give better compression for PNG image data. */
+        png_set_compression_strategy(m_png, Z_DEFAULT_STRATEGY);
     }
 
 


### PR DESCRIPTION
As title, I add the attribute to adjust compression level and compress strategy.
For compression level, it is an integer between Z_NO_COMPRESSION(0) to Z_BEST_COMPRESSION(9).
For compression strategy, it one of the string in "default", "filtered", "huffman", "rle", or "fixed" that zlib support.
But I am confuse use which mode to be default mode, even there is a mode call default, but the zlib document says that rle is designed for png image.

From http://www.zlib.net/manual.html
"Z_RLE is designed to be almost as fast as Z_HUFFMAN_ONLY, but give better compression for PNG image data."
