### PR TITLE
Get rid of deprecated cruft. 

### DIFF
--- a/src/doc/macros.tex
+++ b/src/doc/macros.tex
@@ -60,19 +60,6 @@
 
 
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%
-% Defs of variables and functions that we frequently refer to in
-% text.
-%
-
-\def\ParamType{{\kw ParamType}\xspace}
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-
-
-
 %begin{latexonly}
 \newenvironment{apilist}{\begin{list}{}{\medskip \item[]}}{\end{list}}
 \newcommand{\apiitem}[1]{\vspace{12pt} \noindent {\bf\tt #1} \vspace{-10pt}\begin{apilist}\nopagebreak[4]}

--- a/src/include/typedesc.h
+++ b/src/include/typedesc.h
@@ -312,28 +312,6 @@ template<> struct CType<(int)TypeDesc::FLOAT> { typedef float type; };
 template<> struct CType<(int)TypeDesc::DOUBLE> { typedef double type; };
 
 
-
-// Deprecated!  Some back-compatibility with Gelato
-typedef TypeDesc ParamType;
-typedef TypeDesc ParamBaseType;
-#define PT_FLOAT TypeDesc::FLOAT
-#define PT_UINT8 TypeDesc::UCHAR
-#define PT_INT8 TypeDesc::CHAR
-#define PT_UINT16 TypeDesc::USHORT
-#define PT_INT16 TypeDesc::SHORT
-#define PT_UINT TypeDesc::UINT
-#define PT_INT TypeDesc::INT
-#define PT_FLOAT TypeDesc::FLOAT
-#define PT_DOUBLE TypeDesc::DOUBLE
-#define PT_HALF TypeDesc::HALF
-#define PT_MATRIX TypeDesc(TypeDesc::FLOAT,TypeDesc::MATRIX44)
-#define PT_STRING TypeDesc::STRING
-#define PT_UNKNOWN TypeDesc::UNKNOWN
-#define PT_COLOR TypeDesc(TypeDesc::FLOAT,TypeDesc::VEC3,TypeDesc::COLOR)
-#define PT_POINT TypeDesc(TypeDesc::FLOAT,TypeDesc::VEC3,TypeDesc::POINT)
-#define PT_VECTOR TypeDesc(TypeDesc::FLOAT,TypeDesc::VEC3,TypeDesc::VECTOR)
-#define PT_NORMAL TypeDesc(TypeDesc::FLOAT,TypeDesc::VEC3,TypeDesc::NORMAL)
-
 }
 OIIO_NAMESPACE_EXIT
 


### PR DESCRIPTION
In the very earliest days of OIIO, typedesc.h was one of the first files I wrote, and it was based on a similar concept (though different name) in an open source header that was part of Gelato. I added some #defines for compatibility (at least as much to satisfy my fingers' muscle memory as to help any actual Gelato users who might want OIIO), but whatever the original rationale, there is no reason after all these years to retain these macros. Let's finally excise them.
