### PR TITLE
Don't do StringVectorAttribute stuff for older OpenEXR versions

### DIFF
--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -54,7 +54,6 @@
 #include <OpenEXR/ImfVecAttribute.h>
 #include <OpenEXR/ImfBoxAttribute.h>
 #include <OpenEXR/ImfStringAttribute.h>
-#include <OpenEXR/ImfStringVectorAttribute.h>
 #include <OpenEXR/ImfTimeCodeAttribute.h>
 #include <OpenEXR/ImfKeyCodeAttribute.h>
 #include <OpenEXR/ImfEnvmapAttribute.h>
@@ -62,6 +61,7 @@
 #include <OpenEXR/IexBaseExc.h>
 #include <OpenEXR/IexThrowErrnoExc.h>
 #ifdef USE_OPENEXR_VERSION2
+#include <OpenEXR/ImfStringVectorAttribute.h>
 #include <OpenEXR/ImfPartType.h>
 #include <OpenEXR/ImfMultiPartInputFile.h>
 #include <OpenEXR/ImfInputPart.h>
@@ -537,11 +537,13 @@ OpenEXRInput::PartInfo::parse_header (const Imf::Header *header)
         const Imf::V3iAttribute *v3iattr;
         const Imf::V2fAttribute *v2fattr;
         const Imf::V2iAttribute *v2iattr;
-        const Imf::StringVectorAttribute *svattr;
         const Imf::Box2iAttribute *b2iattr;
         const Imf::Box2fAttribute *b2fattr;
         const Imf::TimeCodeAttribute *tattr;
         const Imf::KeyCodeAttribute *kcattr;
+#ifdef USE_OPENEXR_VERSION2
+        const Imf::StringVectorAttribute *svattr;
+#endif
         const char *name = hit.name();
         std::string oname = exr_tag_to_ooio_std[name];
         if (oname.empty())   // Empty string means skip this attrib
@@ -580,6 +582,7 @@ OpenEXRInput::PartInfo::parse_header (const Imf::Header *header)
             TypeDesc v2 (TypeDesc::INT,TypeDesc::VEC2);
             spec.attribute (oname, v2, &(v2iattr->value()));
         }
+#ifdef USE_OPENEXR_VERSION2
         else if (type == "stringvector" &&
             (svattr = header->findTypedAttribute<Imf::StringVectorAttribute> (name))) {
             std::vector<std::string> strvec = svattr->value();
@@ -589,6 +592,7 @@ OpenEXRInput::PartInfo::parse_header (const Imf::Header *header)
             TypeDesc sv (TypeDesc::STRING, ustrvec.size());
             spec.attribute(oname, sv, &ustrvec[0]);
         }
+#endif
         else if (type == "box2i" &&
                  (b2iattr = header->findTypedAttribute<Imf::Box2iAttribute> (name))) {
             TypeDesc bx (TypeDesc::INT, TypeDesc::VEC2, 2);

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -51,7 +51,6 @@
 #include <OpenEXR/ImfMatrixAttribute.h>
 #include <OpenEXR/ImfVecAttribute.h>
 #include <OpenEXR/ImfStringAttribute.h>
-#include <OpenEXR/ImfStringVectorAttribute.h>
 #include <OpenEXR/ImfTimeCodeAttribute.h>
 #include <OpenEXR/ImfKeyCodeAttribute.h>
 #include <OpenEXR/ImfBoxAttribute.h>
@@ -69,6 +68,7 @@
 #define OPENEXR_VERSION_IS_1_6_OR_LATER
 #endif
 #ifdef USE_OPENEXR_VERSION2
+#include <OpenEXR/ImfStringVectorAttribute.h>
 #include <OpenEXR/ImfMultiPartOutputFile.h>
 #include <OpenEXR/ImfPartType.h>
 #include <OpenEXR/ImfOutputPart.h>
@@ -892,6 +892,7 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
                 case TypeDesc::FLOAT:
                     header.insert (xname.c_str(), Imf::V2fAttribute (*(Imath::V2f*)data));
                     return true;
+#ifdef USE_OPENEXR_VERSION2
                 case TypeDesc::DOUBLE:
                     header.insert (xname.c_str(), Imf::V2dAttribute (*(Imath::V2d*)data));
                     return true;
@@ -901,6 +902,7 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
                     v.push_back(((std::string*)data)[1]);
                     header.insert (xname.c_str(), Imf::StringVectorAttribute (v));
                     return true;
+#endif
             }
         }
         if (type.aggregate == TypeDesc::VEC3) {
@@ -913,6 +915,7 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
                 case TypeDesc::FLOAT:
                     header.insert (xname.c_str(), Imf::V3fAttribute (*(Imath::V3f*)data));
                     return true;
+#ifdef USE_OPENEXR_VERSION2
                 case TypeDesc::DOUBLE:
                     header.insert (xname.c_str(), Imf::V3dAttribute (*(Imath::V3d*)data));
                     return true;
@@ -923,6 +926,7 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
                     v.push_back(((std::string*)data)[2]);
                     header.insert (xname.c_str(), Imf::StringVectorAttribute (v));
                     return true;
+#endif
             }
         }
         if (type.aggregate == TypeDesc::MATRIX44) {
@@ -930,9 +934,11 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
                 case TypeDesc::FLOAT:
                     header.insert (xname.c_str(), Imf::M44fAttribute (*(Imath::M44f*)data));
                     return true;
+#ifdef USE_OPENEXR_VERSION2
                 case TypeDesc::DOUBLE:
                     header.insert (xname.c_str(), Imf::M44dAttribute (*(Imath::M44d*)data));
                     return true;
+#endif
             }
         }
     }
@@ -981,6 +987,7 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
                 case TypeDesc::FLOAT:
                     header.insert (xname.c_str(), Imf::V2fAttribute (*(Imath::V2f*)data));
                     return true;
+#ifdef USE_OPENEXR_VERSION2
                 case TypeDesc::DOUBLE:
                     header.insert (xname.c_str(), Imf::V2dAttribute (*(Imath::V2d*)data));
                     return true;
@@ -990,6 +997,7 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
                     v.push_back(((std::string*)data)[1]);
                     header.insert (xname.c_str(), Imf::StringVectorAttribute (v));
                     return true;
+#endif
             }
         }
         // Vec3
@@ -1003,6 +1011,7 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
                 case TypeDesc::FLOAT:
                     header.insert (xname.c_str(), Imf::V3fAttribute (*(Imath::V3f*)data));
                     return true;
+#ifdef USE_OPENEXR_VERSION2
                 case TypeDesc::DOUBLE:
                     header.insert (xname.c_str(), Imf::V3dAttribute (*(Imath::V3d*)data));
                     return true;
@@ -1013,6 +1022,7 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
                     v.push_back(((std::string*)data)[2]);
                     header.insert (xname.c_str(), Imf::StringVectorAttribute (v));
                     return true;
+#endif
             }
         }
         // Matrix
@@ -1021,11 +1031,14 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
                 case TypeDesc::FLOAT:
                     header.insert (xname.c_str(), Imf::M44fAttribute (*(Imath::M44f*)data));
                     return true;
+#ifdef USE_OPENEXR_VERSION2
                 case TypeDesc::DOUBLE:
                     header.insert (xname.c_str(), Imf::M44dAttribute (*(Imath::M44d*)data));
                     return true;
+#endif
             }
         }
+#ifdef USE_OPENEXR_VERSION2
         // String Vector
         else if (type.basetype == TypeDesc::STRING) {
             Imf::StringVector v;
@@ -1035,6 +1048,7 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
             header.insert (xname.c_str(), Imf::StringVectorAttribute (v));
             return true;
         }
+#endif
     }
 
 


### PR DESCRIPTION
Solves build breaks for people with older OpenEXR.

OK, technically, OpenEXR 1.7 (but not older) supported StringVectorAttribute. But this code was very recently added, so I don't think it'll break any of those 1.7 users to disable it, and it's a LOT easier to identify when we're using >= 2.0. So I'm going to be lazy rather than tie myself in knots to distinguish between 1.6 and 1.7.
