### PR TITLE
Make IB iterators return valid black pixel data for missing tiles.

### DIFF
--- a/src/include/imagebuf.h
+++ b/src/include/imagebuf.h
@@ -944,7 +944,7 @@ public:
                 m_proxydata = NULL;
             } else {
                 // Cached image
-                if (e && m_x < m_tilexend)
+                if (e && m_x < m_tilexend && m_tile)
                     // Haven't crossed a tile boundary, don't retile!
                     m_proxydata += m_pixel_bytes;
                 else {

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1949,8 +1949,10 @@ ImageBufImpl::retile (int x, int y, int z, ImageCache::Tile* &tile,
         tilexend = tilexbegin + tw;
         tile = m_imagecache->get_tile (m_name, m_current_subimage,
                                        m_current_miplevel, x, y, z);
-        if (! tile)
-            return NULL;
+        if (! tile) {
+            // Even though tile is NULL, ensure valid black pixel data
+            return &m_blackpixel[0];
+        }
     }
 
     size_t offset = ((z - tilezbegin) * (size_t) th + (y - tileybegin)) * (size_t) tw


### PR DESCRIPTION
It's a lot better than crashing when you dereference a NULL pointer!
