### PR TITLE
SPI customizations

### DIFF
--- a/site/spi/Makefile-bits-arnold
+++ b/site/spi/Makefile-bits-arnold
@@ -8,6 +8,8 @@ $(info Including spi/Makefile-bits-arnold)
 
 # Default namespace
 NAMESPACE ?= 'OpenImageIO_Arnold'
+PYVER ?= 2.6
+PYVERNOSPACE=${shell echo ${PYVER} | sed "s/\\.//"}
 
 ## Official OS X build machines with special conventions
 ifeq (${SP_OS}, lion)
@@ -110,8 +112,10 @@ ifeq ($(SP_OS), spinux1)
 	-DBOOST_CUSTOM=1 \
 	-DBoost_INCLUDE_DIRS=/usr/include/boost_${BOOSTVERS} \
 	-DBoost_LIBRARY_DIRS=/usr/lib64/boost_${BOOSTVERS} \
-	-DBoost_python_FOUND=1 -Doiio_boost_PYTHON_FOUND=1 \
-	-DBoost_LIBRARIES:STRING="/usr/lib64/boost_${BOOSTVERS}/libboost_python-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_regex-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_system-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_thread-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/libpython2.6.so"
+	-DBoost_python_FOUND=1 -Doiio_boost_PYTHON_FOUND=1 -DPYTHONLIBS_FOUND=1 \
+    -DBoost_LIBRARIES:STRING="/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_regex-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_system-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_thread-gcc44-mt${BOOSTVERS_SUFFIX}.so" \
+    -DBoost_Python_LIBRARIES:STRING="/usr/lib64/boost_${BOOSTVERS}/libboost_python-gcc44-mt${BOOSTVERS_SUFFIX}.so" \
+    -DPYTHON_LIBRARIES:STRING="/usr/lib64/libpython${PYVER}.so"
 
 endif  # endif spinux1
 

--- a/site/spi/Makefile-bits-spcomp2
+++ b/site/spi/Makefile-bits-spcomp2
@@ -76,7 +76,10 @@ ifeq ($(SP_OS), spinux1)
 				-DBoost_INCLUDE_DIRS=/usr/include/boost_${BOOSTVERS} \
 				-DBoost_LIBRARY_DIRS=/usr/lib64/boost_${BOOSTVERS} \
 				-DBoost_python_FOUND=1 -Doiio_boost_PYTHON_FOUND=1 \
-				-DBoost_LIBRARIES:STRING="/usr/lib64/boost_${BOOSTVERS}/libboost_python-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_regex-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_system-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_thread-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/libpython2.6.so"
+                -DPYTHONLIBS_FOUND=1 \
+                -DBoost_LIBRARIES:STRING="/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_regex-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_system-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_thread-gcc44-mt${BOOSTVERS_SUFFIX}.so" \
+                -DBoost_Python_LIBRARIES:STRING="/usr/lib64/boost_${BOOSTVERS}/libboost_python-gcc44-mt${BOOSTVERS_SUFFIX}.so" \
+                -DPYTHON_LIBRARIES:STRING="/usr/lib64/libpython${PYVER}.so"
 		endif
 
 else ifeq ($(SP_OS), lion)
@@ -111,7 +114,7 @@ else ifeq ($(SP_OS), lion)
       -DOVERRIDE_SHARED_LIBRARY_SUFFIX=.so \
       -DPYTHON_EXECUTABLE=${MACPORTS_PREFIX}/bin/python${PYVER} \
       -DPYTHON_INCLUDE_DIR=${MACPORTS_PREFIX}/Library/Frameworks/Python.framework/Versions/2.7/Headers \
-      -DPYTHON_LIBRARY=${MACPORTS_PREFIX}/Library/Frameworks/Python.framework/Versions/2.7/Python \
+      -DPYTHON_LIBRARIES=${MACPORTS_PREFIX}/Library/Frameworks/Python.framework/Versions/2.7/Python \
       -DTHIRD_PARTY_TOOLS_HOME=${MACPORTS_PREFIX} \
       -DZLIB_ROOT=${MACPORTS_PREFIX}
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -81,7 +81,7 @@ endmacro ()
 message (STATUS "BOOST_ROOT ${BOOST_ROOT}")
 
 if (NOT DEFINED Boost_ADDITIONAL_VERSIONS)
-  set (Boost_ADDITIONAL_VERSIONS "1.54" "1.53" "1.52" "1.51" "1.50"
+  set (Boost_ADDITIONAL_VERSIONS "1.55" "1.54" "1.53" "1.52" "1.51" "1.50"
                                  "1.49" "1.48" "1.47" "1.46" "1.45" "1.44" 
                                  "1.43" "1.43.0" "1.42" "1.42.0")
 endif ()


### PR DESCRIPTION
Related to Python. Specifically, we were incorrectly linking the python libs to the main libOpenImageIO.so. Incorrect -- we only want to link against python for the python module python/OpenImageIO.so.  Fixed now, and some other SPI-specific python cleanup.

I don't really expect anybody to review this externally, and it shouldn't affect the build outside of SPI.
