### PR TITLE
Make all the non-tiled formats emulate tiled files by buffering the image.

### DIFF
--- a/src/bmp.imageio/bmp_pvt.h
+++ b/src/bmp.imageio/bmp_pvt.h
@@ -175,6 +175,9 @@ class BmpOutput : public ImageOutput {
     virtual bool close (void);
     virtual bool write_scanline (int y, int z, TypeDesc format,
                                  const void *data, stride_t xstride);
+    virtual bool write_tile (int x, int y, int z, TypeDesc format,
+                             const void *data, stride_t xstride,
+                             stride_t ystride, stride_t zstride);
  private:
     int m_scanline_size;
     FILE *m_fd;
@@ -183,6 +186,7 @@ class BmpOutput : public ImageOutput {
     bmp_pvt::DibInformationHeader m_dib_header;
     fpos_t m_image_start;
     unsigned int m_dither;
+    std::vector<unsigned char> m_tilebuffer;
 
     void init (void) {
         m_scanline_size = 0;

--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -82,6 +82,11 @@ BmpOutput::open (const std::string &name, const ImageSpec &spec,
     m_spec.set_format (TypeDesc::UINT8);
     m_dither = m_spec.get_int_attribute ("oiio:dither", 0);
 
+    // If user asked for tiles -- which this format doesn't support, emulate
+    // it by buffering the whole image.
+    if (m_spec.tile_width && m_spec.tile_height)
+        m_tilebuffer.resize (m_spec.image_bytes());
+
     return true;
 }
 
@@ -120,13 +125,34 @@ BmpOutput::write_scanline (int y, int z, TypeDesc format, const void *data,
 
 
 bool
+BmpOutput::write_tile (int x, int y, int z, TypeDesc format,
+                       const void *data, stride_t xstride,
+                       stride_t ystride, stride_t zstride)
+{
+    // Emulate tiles by buffering the whole image
+    return copy_tile_to_image_buffer (x, y, z, format, data, xstride,
+                                      ystride, zstride, &m_tilebuffer[0]);
+}
+
+
+
+bool
 BmpOutput::close (void)
 {
+    bool ok = true;
+    if (m_spec.tile_width) {
+        // We've been emulating tiles; now dump as scanlines.
+        ASSERT (m_tilebuffer.size());
+        ok &= write_scanlines (m_spec.y, m_spec.y+m_spec.height, 0,
+                               m_spec.format, &m_tilebuffer[0]);
+        std::vector<unsigned char>().swap (m_tilebuffer);
+    }
+
     if (m_fd) {
         fclose (m_fd);
         m_fd = NULL;
     }
-    return true;
+    return ok;
 }
 
 

--- a/src/dds.imageio/ddsoutput.cpp
+++ b/src/dds.imageio/ddsoutput.cpp
@@ -105,20 +105,6 @@ bool
 DDSOutput::open (const std::string &name, const ImageSpec &userspec,
                  OpenMode mode)
 {
-    if (mode != Create) {
-        error ("%s does not support subimages or MIP levels", format_name());
-        return false;
-    }
-
-    close ();  // Close any already-opened file
-    m_spec = userspec;  // Stash the spec
-
-    m_file = Filesystem::fopen (name, "wb");
-    if (! m_file) {
-        error ("Could not open file \"%s\"", name.c_str());
-        return false;
-    }
-
     error ("DDS writing is not supported yet, please poke Leszek in the "
         "mailing list");
     return false;
@@ -129,15 +115,7 @@ DDSOutput::open (const std::string &name, const ImageSpec &userspec,
 bool
 DDSOutput::close ()
 {
-    if (m_file) {
-        // close the stream
-        fclose (m_file);
-        m_file = NULL;
-    }
-
-    init ();      // re-initialize
-    return true;  // How can we fail?
-                  // Epicly. -- IneQuation
+    return false;
 }
 
 
@@ -146,7 +124,7 @@ bool
 DDSOutput::write_scanline (int y, int z, TypeDesc format,
                             const void *data, stride_t xstride)
 {
-    return true;
+    return false;
 }
 
 OIIO_PLUGIN_NAMESPACE_END

--- a/src/doc/writingplugins.tex
+++ b/src/doc/writingplugins.tex
@@ -287,6 +287,14 @@ real-world example of writing a JPEG/JFIF plug-in.
       ``deep'' data images.
   \end{enumerate}
 
+  It is not strictly required, but certainly appreciated, if a file format
+  does not support tiles, to nonetheless accept an \ImageSpec that specifies
+  tile sizes by allocating a full-image buffer in {\cf open()}, providing an
+  implementation of {\cf write_tile()} that copies the tile of data to the
+  right spots in the buffer, and having {\cf close()} then call 
+  {\cf write_scanlines} to process the buffer now that the image has been
+  fully sent.
+
   Here is how the class definition looks for our JPEG example.  Note
   that the JPEG/JFIF file format does not support multiple subimages
   or tiled images.

--- a/src/fits.imageio/fits_pvt.h
+++ b/src/fits.imageio/fits_pvt.h
@@ -143,6 +143,9 @@ class FitsOutput : public ImageOutput {
     virtual bool close (void);
     virtual bool write_scanline (int y, int z, TypeDesc format,
                                  const void *data, stride_t xstride);
+    virtual bool write_tile (int x, int y, int z, TypeDesc format,
+                             const void *data, stride_t xstride,
+                             stride_t ystride, stride_t zstride);
 
  private:
     FILE *m_fd;
@@ -152,6 +155,8 @@ class FitsOutput : public ImageOutput {
     bool m_simple; // does the header with SIMPLE key was written?
     std::vector<unsigned char> m_scratch;
     std::string m_sep;
+    std::vector<unsigned char> m_tilebuffer;
+
     void init (void) {
         m_fd = NULL;
         m_filename.clear ();

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -51,11 +51,15 @@ class HdrOutput : public ImageOutput {
                        OpenMode mode);
     virtual bool write_scanline (int y, int z, TypeDesc format,
                                  const void *data, stride_t xstride);
-    bool close ();
+    virtual bool write_tile (int x, int y, int z, TypeDesc format,
+                             const void *data, stride_t xstride,
+                             stride_t ystride, stride_t zstride);
+    virtual bool close ();
  private:
     FILE *m_fd;
     std::vector<unsigned char> scratch;
     char rgbe_error[1024];        ///< Buffer for RGBE library error msgs
+    std::vector<unsigned char> m_tilebuffer;
 
     void init (void) { m_fd = NULL; }
 };
@@ -134,6 +138,11 @@ HdrOutput::open (const std::string &name, const ImageSpec &newspec,
     if (r != RGBE_RETURN_SUCCESS)
         error ("%s", rgbe_error);
 
+    // If user asked for tiles -- which this format doesn't support, emulate
+    // it by buffering the whole image.
+    if (m_spec.tile_width && m_spec.tile_height)
+        m_tilebuffer.resize (m_spec.image_bytes());
+
     return true;
 }
 
@@ -153,15 +162,36 @@ HdrOutput::write_scanline (int y, int z, TypeDesc format,
 
 
 bool
+HdrOutput::write_tile (int x, int y, int z, TypeDesc format,
+                       const void *data, stride_t xstride,
+                       stride_t ystride, stride_t zstride)
+{
+    // Emulate tiles by buffering the whole image
+    return copy_tile_to_image_buffer (x, y, z, format, data, xstride,
+                                      ystride, zstride, &m_tilebuffer[0]);
+}
+
+
+
+bool
 HdrOutput::close ()
 {
+    bool ok = true;
+    if (m_spec.tile_width) {
+        // We've been emulating tiles; now dump as scanlines.
+        ASSERT (m_tilebuffer.size());
+        ok &= write_scanlines (m_spec.y, m_spec.y+m_spec.height, 0,
+                               m_spec.format, &m_tilebuffer[0]);
+        std::vector<unsigned char>().swap (m_tilebuffer);
+    }
+
     if (m_fd != NULL) {
         fclose (m_fd);
         m_fd = NULL;
     }
     init();
 
-    return true;
+    return ok;
 }
 
 OIIO_PLUGIN_NAMESPACE_END

--- a/src/include/imageio.h
+++ b/src/include/imageio.h
@@ -1096,6 +1096,11 @@ protected:
                                      std::vector<unsigned char> &scratch,
                                      unsigned int dither=0,
                                      int xorigin=0, int yorigin=0, int zorigin=0);
+    /// Helper function to copy a tile of data into an image-sized buffer.
+    bool copy_tile_to_image_buffer (int x, int y, int z, TypeDesc format,
+                                    const void *data, stride_t xstride,
+                                    stride_t ystride, stride_t zstride,
+                                    void *image_buffer);
 
 protected:
     ImageSpec m_spec;           ///< format spec of the currently open image

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -49,12 +49,16 @@ class Jpeg2000Output : public ImageOutput {
     virtual bool close ();
     virtual bool write_scanline (int y, int z, TypeDesc format,
                                  const void *data, stride_t xstride);
+    virtual bool write_tile (int x, int y, int z, TypeDesc format,
+                             const void *data, stride_t xstride,
+                             stride_t ystride, stride_t zstride);
  private:
     std::string m_filename;
     FILE *m_file;
     opj_cparameters_t m_compression_parameters;
     opj_image_t *m_image;
     unsigned int m_dither;
+    std::vector<unsigned char> m_tilebuffer;
 
     void init (void)
     {
@@ -121,6 +125,11 @@ Jpeg2000Output::open (const std::string &name, const ImageSpec &spec,
         return false;
     }
 
+    // If user asked for tiles -- which this format doesn't support, emulate
+    // it by buffering the whole image.
+    if (m_spec.tile_width && m_spec.tile_height)
+        m_tilebuffer.resize (m_spec.image_bytes());
+
     m_image = create_jpeg2000_image();
     return true;
 }
@@ -152,9 +161,31 @@ Jpeg2000Output::write_scanline (int y, int z, TypeDesc format,
 }
 
 
+
+bool
+Jpeg2000Output::write_tile (int x, int y, int z, TypeDesc format,
+                       const void *data, stride_t xstride,
+                       stride_t ystride, stride_t zstride)
+{
+    // Emulate tiles by buffering the whole image
+    return copy_tile_to_image_buffer (x, y, z, format, data, xstride,
+                                      ystride, zstride, &m_tilebuffer[0]);
+}
+
+
+
 bool
 Jpeg2000Output::close ()
 {
+    bool ok = true;
+    if (m_spec.tile_width) {
+        // We've been emulating tiles; now dump as scanlines.
+        ASSERT (m_tilebuffer.size());
+        ok &= write_scanlines (m_spec.y, m_spec.y+m_spec.height, 0,
+                               m_spec.format, &m_tilebuffer[0]);
+        std::vector<unsigned char>().swap (m_tilebuffer);
+    }
+
     if (m_file) {
         fclose(m_file);
         m_file = NULL;
@@ -163,7 +194,7 @@ Jpeg2000Output::close ()
         opj_image_destroy(m_image);
         m_image = NULL;
     }
-    return true;
+    return ok;
 }
 
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -108,6 +108,7 @@ Oiiotool::clear_options ()
     output_autocrop = true;
     output_autotrim = false;
     output_dither = false;
+    output_force_tiles = false;
     diff_warnthresh = 1.0e-6f;
     diff_warnpercent = 0;
     diff_hardwarn = std::numeric_limits<float>::max();
@@ -477,7 +478,7 @@ output_file (int argc, const char *argv[])
         return 0;
     }
     bool supports_displaywindow = out->supports ("displaywindow");
-    bool supports_tiles = out->supports ("tiles");
+    bool supports_tiles = out->supports ("tiles") || ot.output_force_tiles;
     ot.read ();
     ImageRecRef saveimg = ot.curimg;
     ImageRecRef ir (ot.curimg);
@@ -3281,6 +3282,7 @@ getargs (int argc, char *argv[])
                 "--scanline", &ot.output_scanline, "Output scanline images",
                 "--tile %@ %d %d", output_tiles, &ot.output_tilewidth, &ot.output_tileheight,
                     "Output tiled images (tilewidth, tileheight)",
+                "--force-tiles", &ot.output_force_tiles, "", // undocumented
                 "--compression %s", &ot.output_compression, "Set the compression method",
                 "--quality %d", &ot.output_quality, "Set the compression quality, 1-100",
                 "--dither", &ot.output_dither, "Add dither to 8-bit output",

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -76,6 +76,7 @@ public:
     bool output_autocrop;
     bool output_autotrim;
     bool output_dither;
+    bool output_force_tiles; // for debugging
 
     // Options for --diff
     float diff_warnthresh;

--- a/src/sgi.imageio/sgi_pvt.h
+++ b/src/sgi.imageio/sgi_pvt.h
@@ -147,11 +147,15 @@ class SgiOutput : public ImageOutput {
     virtual bool close (void);
     virtual bool write_scanline (int y, int z, TypeDesc format, const void *data,
                                  stride_t xstride);
+    virtual bool write_tile (int x, int y, int z, TypeDesc format,
+                             const void *data, stride_t xstride,
+                             stride_t ystride, stride_t zstride);
  private:
     FILE *m_fd;
     std::string m_filename;
     std::vector<unsigned char> m_scratch;
     unsigned int m_dither;
+    std::vector<unsigned char> m_tilebuffer;
 
     void init () {
         m_fd = NULL;


### PR DESCRIPTION
Some apps may only know how to output tiles, but some formats only support
scanline oriented data.  This patch makes this situation work (albeit not
especially efficiently) by:
1. Upon open() with a tiled spec and a non-tile-supporting format, will
   allocate a buffer large enough to hold the full image (I told you it
   wouldn't be efficient).
2. write_tile() marshalls the tile of data into the right spots in the
   image buffer.
3. close() calls write_scanlines(), thereby outputting all those scanlines
   now that it has the full buffer ready.  And frees the buffer.

I don't recommend using this as a first choice. Best is for the app to
send scanlines to files for formats that don't support("tiles"). But if
you had an app that naturally generated data in tiles, and almost always
used the tiled formats, but every once in a while might want to save in
one of those scanline-only formats (but this is not the important case
for high performance), at least this lets the app knowingly make the
memory-for-flexibility trade-off, without needing to handle the
buffering logic on the app side or have a secondary scanline-oriented
code path.
