### PR TITLE
Improved removal of SHA-1 hash upon reading in oiiotool and for IBA

### DIFF
--- a/src/include/imagebufalgo_util.h
+++ b/src/include/imagebufalgo_util.h
@@ -112,7 +112,9 @@ enum IBAprep_flags {
     IBAprep_DEFAULT = 0,
     IBAprep_REQUIRE_ALPHA = 1,
     IBAprep_REQUIRE_Z = 2,
-    IBAprep_REQUIRE_SAME_NCHANNELS = 4
+    IBAprep_REQUIRE_SAME_NCHANNELS = 4,
+    IBAprep_NO_COPY_METADATA = 256,     // N.B. default copies all metadata
+    IBAprep_COPY_ALL_METADATA = 512     // Even unsafe things
 };
 
 


### PR DESCRIPTION
This is a continuation of the recent checkin related to this.  When
reading in oiiotool, or when preparing destination IB's for IBA
functions, we had removed any actual "oiio:SHA-1" metadata.  But this
patch also ensures that any hashes embedded in the "ImageDescription"
are also removed.
