### PR TITLE
Fix IFF output so that it accepts write_scanline, even though IFF is tile only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,7 +350,7 @@ endif()
 oiio_add_tests (gpsread misnamed-file nonwhole-tiles
                 oiiotool oiiotool-composite oiiotool-fixnan 
                 perchannel dither
-                dpx ico png psd rla sgi
+                dpx ico iff png psd rla sgi
                 python-typedesc python-imagespec python-roi
                 python-imageinput python-imageoutput
                 python-imagebuf python-imagebufalgo

--- a/src/iff.imageio/iff_pvt.h
+++ b/src/iff.imageio/iff_pvt.h
@@ -167,9 +167,7 @@ private:
     bool readimg (void);
     
     // helper to uncompress a rle channel
-    size_t uncompress_rle_channel(
-        const uint8_t * in, uint8_t * out, int size
-    );
+    size_t uncompress_rle_channel(const uint8_t *in, uint8_t * out, int size);
 };
 
 
@@ -194,26 +192,21 @@ private:
     iff_pvt::IffFileHeader m_iff_header;
     std::vector<uint8_t> m_buf;
     unsigned int m_dither;
-    
+    std::vector<uint8_t> scratch;    
+
     void init (void) {
         m_fd = NULL;
         m_filename.clear ();
     }
     
     // helper to compress verbatim
-    void compress_verbatim (
-        const uint8_t *& in, uint8_t *& out, int size
-    );
+    void compress_verbatim (const uint8_t *& in, uint8_t *& out, int size);
       
     // helper to compress duplicate
-    void compress_duplicate (
-        const uint8_t *&in, uint8_t *& out, int size
-    );
+    void compress_duplicate (const uint8_t *&in, uint8_t *& out, int size);
       
     // helper to compress a rle channel
-    size_t compress_rle_channel (
-        const uint8_t *in, uint8_t *out, int size
-    );
+    size_t compress_rle_channel (const uint8_t *in, uint8_t *out, int size);
 };
 
 OIIO_PLUGIN_NAMESPACE_END

--- a/src/iff.imageio/iffoutput.cpp
+++ b/src/iff.imageio/iffoutput.cpp
@@ -100,6 +100,7 @@ IffOutput::open (const std::string &name, const ImageSpec &spec,
     // tiles
     m_spec.tile_width = tile_width();
     m_spec.tile_height = tile_height();
+    m_spec.tile_depth = 1;
     
     m_fd = Filesystem::fopen (m_filename, "wb");
     if (!m_fd) {
@@ -139,6 +140,8 @@ IffOutput::open (const std::string &name, const ImageSpec &spec,
         return false;
     }
 
+    m_buf.resize (m_spec.image_bytes());
+
     return true;
 }
 
@@ -149,6 +152,14 @@ IffOutput::write_scanline (int y, int z, TypeDesc format, const void *data,
                            stride_t xstride)
 {
     // scanline not used for Maya IFF, uses tiles instead.
+    // Emulate by copying the scanline to the buffer we're accumulating.
+    std::vector<unsigned char> scratch;
+    data = to_native_scanline (format, data, xstride, scratch,
+                               m_dither, y, z);
+    size_t scanlinesize = spec().scanline_bytes(true);
+    size_t offset = scanlinesize * (y-spec().y) +
+                    scanlinesize * spec().height * (z-spec().z);
+    memcpy (&m_buf[offset], data, scanlinesize);
     return false;
 }
 
@@ -159,16 +170,11 @@ IffOutput::write_tile (int x, int y, int z,
                        TypeDesc format, const void *data,
                        stride_t xstride, stride_t ystride, stride_t zstride)
 {
-    if (m_buf.empty ())
-        // resize buffer
-        m_buf.resize (m_spec.image_bytes());
-  
     // auto stride
     m_spec.auto_stride (xstride, ystride, zstride, format, spec().nchannels,
                         spec().tile_width, spec().tile_height);
     
     // native tile
-    std::vector<uint8_t> scratch;    
     data = to_native_tile (format, data, xstride, ystride, zstride, scratch,
                            m_dither, x, y, z);   
                         

--- a/testsuite/iff/ref/out.txt
+++ b/testsuite/iff/ref/out.txt
@@ -1,0 +1,2 @@
+Comparing "../../../../../oiio-images/grid.tif" and "grid.iff"
+PASS

--- a/testsuite/iff/run.py
+++ b/testsuite/iff/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+imagedir = parent + "/oiio-images"
+command += oiiotool (imagedir+"/grid.tif --scanline -o grid.iff")
+command += diff_command (imagedir+"/grid.tif", "grid.iff")


### PR DESCRIPTION
Fixes #794

This is in a similar spirit as #800, where we made the scanline-only file format writers accept API input _as if_ it were tiled, but it just buffers until the image is complete and then output scanlines.

In this case, we have ONE format -- it's the only one I know of -- that is tile only, so this change makes it accept write_scanline calls, buffering the output, then writing the tiles at the end. 

This makes the IFF output a lot less finicky (not that IFF is especially needed these days, but...).

There is some minor reformatting in here, too, for things I saw that were outside our usual style.
