### PR TITLE
OpenEXR 1.x build fix -- include file directory issues.

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -67,6 +67,9 @@ endif ()
 mark_as_advanced (OPENEXR_VERSION)
 
 include_directories ("${OPENEXR_INCLUDE_DIR}")
+# OpenEXR 1.x had weird #include dirctives, this is also necessary:
+include_directories ("${OPENEXR_INCLUDE_DIR}/OpenEXR")
+
 macro (LINK_OPENEXR target)
     target_link_libraries (${target} ${OPENEXR_LIBRARIES})
 endmacro ()


### PR DESCRIPTION
OpenEXR 2.0 has this working smoother, with `include <OpenEXR/blah.h>`. but 1.x has `#include <blah.h>` which will get confused if the OpenEXR subdirectory is not explicitly listed.
