### PR TITLE
Speedup of iinfo/oiiotool --hash

### DIFF
--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -38,6 +38,7 @@
 
 #include <boost/foreach.hpp>
 #include <boost/regex.hpp>
+#include <boost/scoped_array.hpp>
 
 #include "argparse.h"
 #include "strutil.h"
@@ -86,12 +87,12 @@ print_sha1 (ImageInput *input)
             printf ("    SHA-1: unable to compute, image is too big\n");
             return;
         }
-        std::vector<unsigned char> buf((size_t)size);
+        boost::scoped_array<char> buf (new char [size]);
         if (! input->read_image (TypeDesc::UNKNOWN /*native*/, &buf[0])) {
             printf ("    SHA-1: unable to compute, could not read image\n");
             return;
         }
-        sha.appendvec (buf);
+        sha.append (&buf[0], size);
     }
 
     printf ("    SHA-1: %s\n", sha.digest().c_str());

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -80,12 +80,12 @@ print_sha1 (ImageInput *input)
             return;
         }
         else if (size != 0) {
-            std::vector<unsigned char> buf((size_t)size);
+            boost::scoped_array<char> buf (new char [size]);
             if (! input->read_image (TypeDesc::UNKNOWN /*native*/, &buf[0])) {
                 printf ("    SHA-1: unable to compute, could not read image\n");
                 return;
             }
-            sha.appendvec (buf);
+            sha.append (&buf[0], size);
         }
     }
 


### PR DESCRIPTION
By changing a large vector<> allocation (which zeroes out the vector)
to a scoped_array<> (which does not needlessly initialize the allocation),
this speeds up a SHA-1 hash of an 8k image by about 20%.
