### PR TITLE
Ensure that all ImageOutputs calling close() twice is safe.

### DIFF
--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -139,19 +139,22 @@ BmpOutput::write_tile (int x, int y, int z, TypeDesc format,
 bool
 BmpOutput::close (void)
 {
+    if (! m_fd) {   // already closed
+        init ();
+        return true;
+    }
+
     bool ok = true;
     if (m_spec.tile_width) {
-        // We've been emulating tiles; now dump as scanlines.
+        // Handle tile emulation -- output the buffered pixels
         ASSERT (m_tilebuffer.size());
         ok &= write_scanlines (m_spec.y, m_spec.y+m_spec.height, 0,
                                m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap (m_tilebuffer);
     }
 
-    if (m_fd) {
-        fclose (m_fd);
-        m_fd = NULL;
-    }
+    fclose (m_fd);
+    m_fd = NULL;
     return ok;
 }
 

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -546,20 +546,22 @@ DPXOutput::write_buffer ()
 bool
 DPXOutput::close ()
 {
+    if (! m_stream) {   // already closed
+        init ();
+        return true;
+    }
+
     bool ok = true;
     if (m_spec.tile_width) {
-        // We've been emulating tiles; now dump as scanlines.
+        // Handle tile emulation -- output the buffered pixels
         ASSERT (m_tilebuffer.size());
         ok &= write_scanlines (m_spec.y, m_spec.y+m_spec.height, 0,
                                m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap (m_tilebuffer);
     }
 
-    if (m_stream) {
-        ok &= write_buffer ();
-        m_dpx.Finish ();
-    }
-
+    ok &= write_buffer ();
+    m_dpx.Finish ();
     init();  // Reset to initial state
     return ok;
 }

--- a/src/fits.imageio/fitsoutput.cpp
+++ b/src/fits.imageio/fitsoutput.cpp
@@ -164,17 +164,21 @@ FitsOutput::supports (const std::string &feature) const
 bool
 FitsOutput::close (void)
 {
+    if (! m_fd) {   // already closed
+        init ();
+        return true;
+    }
+
     bool ok = true;
     if (m_spec.tile_width) {
-        // We've been emulating tiles; now dump as scanlines.
+        // Handle tile emulation -- output the buffered pixels
         ASSERT (m_tilebuffer.size());
         ok &= write_scanlines (m_spec.y, m_spec.y+m_spec.height, 0,
                                m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap (m_tilebuffer);
     }
 
-    if (m_fd)
-        fclose (m_fd);
+    fclose (m_fd);
     init ();
     return ok;
 }

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -176,6 +176,11 @@ HdrOutput::write_tile (int x, int y, int z, TypeDesc format,
 bool
 HdrOutput::close ()
 {
+    if (! m_fd) {   // already closed
+        init ();
+        return true;
+    }
+
     bool ok = true;
     if (m_spec.tile_width) {
         // We've been emulating tiles; now dump as scanlines.
@@ -185,10 +190,8 @@ HdrOutput::close ()
         std::vector<unsigned char>().swap (m_tilebuffer);
     }
 
-    if (m_fd != NULL) {
-        fclose (m_fd);
-        m_fd = NULL;
-    }
+    fclose (m_fd);
+    m_fd = NULL;
     init();
 
     return ok;

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -425,9 +425,14 @@ ICOOutput::supports (const std::string &feature) const
 bool
 ICOOutput::close ()
 {
+    if (! m_file) {   // already closed
+        init ();
+        return true;
+    }
+
     bool ok = true;
     if (m_spec.tile_width) {
-        // We've been emulating tiles; now dump as scanlines.
+        // Handle tile emulation -- output the buffered pixels
         ASSERT (m_tilebuffer.size());
         ok &= write_scanlines (m_spec.y, m_spec.y+m_spec.height, 0,
                                m_spec.format, &m_tilebuffer[0]);
@@ -438,11 +443,8 @@ ICOOutput::close ()
         PNG_pvt::finish_image (m_png);
         PNG_pvt::destroy_write_struct (m_png, m_info);
     }
-    if (m_file) {
-        fclose (m_file);
-        m_file = NULL;
-    }
-
+    fclose (m_file);
+    m_file = NULL;
     init ();      // re-initialize
     return ok;
 }

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -303,8 +303,11 @@ JpgOutput::write_tile (int x, int y, int z, TypeDesc format,
 bool
 JpgOutput::close ()
 {
-    if (! m_fd)          // Already closed
+    if (! m_fd) {         // Already closed
         return true;
+        init();
+    }
+
     bool ok = true;
 
     if (m_spec.tile_width) {

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -177,6 +177,11 @@ Jpeg2000Output::write_tile (int x, int y, int z, TypeDesc format,
 bool
 Jpeg2000Output::close ()
 {
+    if (! m_file) {         // Already closed
+        return true;
+        init();
+    }
+
     bool ok = true;
     if (m_spec.tile_width) {
         // We've been emulating tiles; now dump as scanlines.
@@ -186,10 +191,8 @@ Jpeg2000Output::close ()
         std::vector<unsigned char>().swap (m_tilebuffer);
     }
 
-    if (m_file) {
-        fclose(m_file);
-        m_file = NULL;
-    }
+    fclose(m_file);
+    m_file = NULL;
     if (m_image) {
         opj_image_destroy(m_image);
         m_image = NULL;

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -198,9 +198,14 @@ PNGOutput::open (const std::string &name, const ImageSpec &userspec,
 bool
 PNGOutput::close ()
 {
+    if (! m_file) {   // already closed
+        init ();
+        return true;
+    }
+
     bool ok = true;
     if (m_spec.tile_width) {
-        // We've been emulating tiles; now dump as scanlines.
+        // Handle tile emulation -- output the buffered pixels
         ASSERT (m_tilebuffer.size());
         ok &= write_scanlines (m_spec.y, m_spec.y+m_spec.height, 0,
                                m_spec.format, &m_tilebuffer[0]);
@@ -211,10 +216,8 @@ PNGOutput::close ()
         PNG_pvt::finish_image (m_png);
     PNG_pvt::destroy_write_struct (m_png, m_info);
 
-    if (m_file) {
-        fclose (m_file);
-        m_file = NULL;
-    }
+    fclose (m_file);
+    m_file = NULL;
 
     init ();      // re-initialize
     return ok;

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -212,17 +212,20 @@ PNMOutput::open (const std::string &name, const ImageSpec &userspec,
 bool
 PNMOutput::close ()
 {
+    if (! m_file.is_open()) {   // already closed
+        return true;
+    }
+
     bool ok = true;
     if (m_spec.tile_width) {
-        // We've been emulating tiles; now dump as scanlines.
+        // Handle tile emulation -- output the buffered pixels
         ASSERT (m_tilebuffer.size());
         ok &= write_scanlines (m_spec.y, m_spec.y+m_spec.height, 0,
                                m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap (m_tilebuffer);
     }
 
-    if (m_file.is_open())
-        m_file.close();
+    m_file.close();
     return true;  
 }
 

--- a/src/sgi.imageio/sgioutput.cpp
+++ b/src/sgi.imageio/sgioutput.cpp
@@ -143,17 +143,21 @@ SgiOutput::write_tile (int x, int y, int z, TypeDesc format,
 bool
 SgiOutput::close ()
 {
+    if (! m_fd) {   // already closed
+        init ();
+        return true;
+    }
+
     bool ok = true;
     if (m_spec.tile_width) {
-        // We've been emulating tiles; now dump as scanlines.
+        // Handle tile emulation -- output the buffered pixels
         ASSERT (m_tilebuffer.size());
         ok &= write_scanlines (m_spec.y, m_spec.y+m_spec.height, 0,
                                m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap (m_tilebuffer);
     }
 
-    if (m_fd)
-        fclose (m_fd);
+    fclose (m_fd);
     init ();
     return ok;
 }

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -449,21 +449,23 @@ TGAOutput::write_tga20_data_fields ()
 bool
 TGAOutput::close ()
 {
+    if (! m_file) {   // already closed
+        init ();
+        return true;
+    }
+
     bool ok = true;
     if (m_spec.tile_width) {
-        // We've been emulating tiles; now dump as scanlines.
+        // Handle tile emulation -- output the buffered pixels
         ASSERT (m_tilebuffer.size());
         ok &= write_scanlines (m_spec.y, m_spec.y+m_spec.height, 0,
                                m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap (m_tilebuffer);
     }
 
-    if (m_file) {
-        ok &= write_tga20_data_fields ();
-        // close the stream
-        fclose (m_file);
-        m_file = NULL;
-    }
+    ok &= write_tga20_data_fields ();
+    fclose (m_file);  // close the stream
+    m_file = NULL;
 
     init ();      // re-initialize
     return ok;

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -195,6 +195,9 @@ WebpOutput::write_tile (int x, int y, int z, TypeDesc format,
 bool
 WebpOutput::close()
 {
+    if (! m_file)
+        return true;   // already closed
+
     bool ok = true;
     if (m_spec.tile_width) {
         // We've been emulating tiles; now dump as scanlines.
@@ -204,11 +207,9 @@ WebpOutput::close()
         std::vector<uint8_t>().swap (m_uncompressed_image);
     }
 
-    if (m_file) {
-        WebPPictureFree(&m_webp_picture);
-        fclose(m_file);
-        m_file = NULL;
-    }
+    WebPPictureFree(&m_webp_picture);
+    fclose(m_file);
+    m_file = NULL;
     return true;
 }
 


### PR DESCRIPTION
It could be broken after the recent "tile emulation" change.
