### PR TITLE
Handle DPX with (likely) invalid X/Y offset values

### DIFF
--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -191,8 +191,12 @@ DPXInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
     m_spec = ImageSpec (m_dpx.header.Width(), m_dpx.header.Height(),
         m_dpx.header.ImageElementComponentCount(subimage), typedesc);
 
-    m_spec.x = m_dpx.header.xOffset;
-    m_spec.y = m_dpx.header.yOffset;
+    // xOffset/yOffset are defined as unsigned 32-bit integers, but m_spec.x/y are signed
+    // avoid casts that would result in negative values
+    if (m_dpx.header.xOffset <= (unsigned int)std::numeric_limits<int>::max())
+        m_spec.x = m_dpx.header.xOffset;
+    if (m_dpx.header.yOffset <= (unsigned int)std::numeric_limits<int>::max())
+        m_spec.y = m_dpx.header.yOffset;
     if ((int)m_dpx.header.xOriginalSize > 0)
         m_spec.full_width = m_dpx.header.xOriginalSize;
     if ((int)m_dpx.header.yOriginalSize > 0)


### PR DESCRIPTION
We recently hit an inconsistency in how oiio deals with (likely) bad X/Y offset values. All the DPX files we received from one client have their X/Y offset set to 4294967295. Probably-not-so-coincidentally, that's -1 when cast to a signed int, which is what happens at line 194 in dpxinput.cpp (line 194). However, when the same image is written back out in dpxoutput.cpp (line 348), negative x/y offsets are thrown out.

Rather than read these as -1, which isn't possible according to the DPX standard, I propose ignoring any X/Y offset > (max signed int).

(RV and Nuke both ignore the bad offset.)

Here's a patch. Please ignore the branch name, forgot to update it after I found the source of the problem. :-)

cheers,
-Mark
