### PR TITLE
Consistency improvement for iinfo and oiiotool --info

### DIFF
--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -445,8 +445,8 @@ print_info_subimage (int current_subimage, int max_subimages, ImageSpec &spec,
         int bits = spec.get_int_attribute ("oiio:BitsPerSample", 0);
         printf (", %d channel, %s%s%s", spec.nchannels,
                 spec.deep ? "deep " : "",
-                extended_format_name(spec.format, bits),
-                spec.depth > 1 ? " volume" : "");
+                spec.depth > 1 ? "volume " : "",
+                extended_format_name(spec.format, bits));
         printf (" %s", input->format_name());
         printf ("\n");
     }
@@ -535,9 +535,9 @@ print_info (const std::string &filename, size_t namefieldlength,
                 spec.width, spec.height);
         if (spec.depth > 1)
             printf (" x %4d", spec.depth);
-        printf (", %d channel, ", spec.nchannels);
-        if (spec.deep)
-            printf ("deep ");
+        printf (", %d channel, %s%s", spec.nchannels,
+                spec.deep ? "deep " : "",
+                spec.depth > 1 ? "volume " : "");
         if (spec.channelformats.size()) {
             for (size_t c = 0;  c < spec.channelformats.size();  ++c)
                 printf ("%s%s", c ? "/" : "",
@@ -546,8 +546,6 @@ print_info (const std::string &filename, size_t namefieldlength,
             int bits = spec.get_int_attribute ("oiio:BitsPerSample", 0);
             printf ("%s", extended_format_name(spec.format, bits));
         }
-        if (spec.depth > 1)
-            printf (" volume");
         printf (" %s", input->format_name());
         if (sum) {
             imagesize_t imagebytes = spec.image_bytes (true);

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -564,10 +564,17 @@ print_info_subimage (int current_subimage, int max_subimages, ImageSpec &spec,
         printf ("%4d x %4d", spec.width, spec.height);
         if (spec.depth > 1)
             printf (" x %4d", spec.depth);
-        int bits = spec.get_int_attribute ("oiio:BitsPerSample", 0);
         printf (", %d channel, %s%s", spec.nchannels,
-                extended_format_name(spec.format, bits),
-                spec.depth > 1 ? " volume" : "");
+                spec.deep ? "deep " : "",
+                spec.depth > 1 ? "volume " : "");
+        if (spec.channelformats.size()) {
+            for (size_t c = 0;  c < spec.channelformats.size();  ++c)
+                printf ("%s%s", c ? "/" : "",
+                        spec.channelformats[c].c_str());
+        } else {
+            int bits = spec.get_int_attribute ("oiio:BitsPerSample", 0);
+            printf ("%s", extended_format_name(spec.format, bits));
+        }
         printf (" %s", input->format_name());
         printf ("\n");
     }
@@ -696,7 +703,9 @@ OiioTool::print_info (const std::string &filename,
                 spec.width, spec.height);
         if (spec.depth > 1)
             printf (" x %4d", spec.depth);
-        printf (", %d channel, ", spec.nchannels);
+        printf (", %d channel, %s%s", spec.nchannels,
+                spec.deep ? "deep " : "",
+                spec.depth > 1 ? "volume " : "");
         if (spec.channelformats.size()) {
             for (size_t c = 0;  c < spec.channelformats.size();  ++c)
                 printf ("%s%s", c ? "/" : "",
@@ -705,8 +714,6 @@ OiioTool::print_info (const std::string &filename,
             int bits = spec.get_int_attribute ("oiio:BitsPerSample", 0);
             printf ("%s", extended_format_name(spec.format, bits));
         }
-        if (spec.depth > 1)
-            printf (" volume");
         printf (" %s", input->format_name());
         if (opt.sum) {
             imagesize_t imagebytes = spec.image_bytes (true);

--- a/testsuite/field3d/ref/out.txt
+++ b/testsuite/field3d/ref/out.txt
@@ -1,5 +1,5 @@
 Reading ../texture-field3d/dense_float.f3d
-../texture-field3d/dense_float.f3d :   64 x   64 x   64, 1 channel, float volume field3d
+../texture-field3d/dense_float.f3d :   64 x   64 x   64, 1 channel, volume float field3d
     SHA-1: 776F6CFF0B2C6834785A6EABA740C0DC7F1C78A2
     channel list: density
     tile size: 64 x 64 x 64
@@ -16,7 +16,7 @@ Reading ../texture-field3d/dense_float.f3d
 Comparing "../texture-field3d/dense_float.f3d" and "dense_float.f3d"
 PASS
 Reading ../texture-field3d/sparse_float.f3d
-../texture-field3d/sparse_float.f3d :   64 x   64 x   64, 1 channel, float volume field3d
+../texture-field3d/sparse_float.f3d :   64 x   64 x   64, 1 channel, volume float field3d
     SHA-1: 776F6CFF0B2C6834785A6EABA740C0DC7F1C78A2
     channel list: density
     tile size: 16 x 16 x 16
@@ -33,7 +33,7 @@ Reading ../texture-field3d/sparse_float.f3d
 Comparing "../texture-field3d/sparse_float.f3d" and "sparse_float.f3d"
 PASS
 Reading ../texture-field3d/dense_half.f3d
-../texture-field3d/dense_half.f3d :   64 x   64 x   64, 1 channel, half volume field3d
+../texture-field3d/dense_half.f3d :   64 x   64 x   64, 1 channel, volume half field3d
     SHA-1: E5F0EC2FDFB1C6D093F3FDDA6E72EE77B86514D5
     channel list: density
     tile size: 64 x 64 x 64
@@ -50,7 +50,7 @@ Reading ../texture-field3d/dense_half.f3d
 Comparing "../texture-field3d/dense_half.f3d" and "dense_half.f3d"
 PASS
 Reading ../texture-field3d/sparse_half.f3d
-../texture-field3d/sparse_half.f3d :   64 x   64 x   64, 1 channel, half volume field3d
+../texture-field3d/sparse_half.f3d :   64 x   64 x   64, 1 channel, volume half field3d
     SHA-1: E5F0EC2FDFB1C6D093F3FDDA6E72EE77B86514D5
     channel list: density
     tile size: 16 x 16 x 16

--- a/testsuite/openexr-v2/ref/out.txt
+++ b/testsuite/openexr-v2/ref/out.txt
@@ -79,9 +79,9 @@ Reading ../../../../../openexr-images/v2/Stereo/composited.exr
 Comparing "../../../../../openexr-images/v2/Stereo/composited.exr" and "composited.exr"
 PASS
 Reading ../../../../../openexr-images/v2/Stereo/Balls.exr
-../../../../../openexr-images/v2/Stereo/Balls.exr : 1431 x  761, 5 channel, half/half/half/half/float openexr
+../../../../../openexr-images/v2/Stereo/Balls.exr : 1431 x  761, 5 channel, deep half/half/half/half/float openexr
     2 subimages: 1431x761 1452x761 
- subimage  0: 1431 x  761, 5 channel, float openexr
+ subimage  0: 1431 x  761, 5 channel, deep half/half/half/half/float openexr
     SHA-1: CB3E54294B268B6C2764410710267D0AF809A3C4
     channel list: R (half), G (half), B (half), A (half), Z (float)
     pixel data origin: x=247, y=319
@@ -98,7 +98,7 @@ Reading ../../../../../openexr-images/v2/Stereo/Balls.exr
     openexr:version: 1
     view: "left"
     oiio:subimagename: "rgba.left"
- subimage  1: 1452 x  761, 5 channel, float openexr
+ subimage  1: 1452 x  761, 5 channel, deep half/half/half/half/float openexr
     SHA-1: 4318FB751F2C30955AC745FFFCF47E8BB932C8D1
     channel list: R (half), G (half), B (half), A (half), Z (float)
     pixel data origin: x=389, y=319
@@ -115,7 +115,7 @@ Reading ../../../../../openexr-images/v2/Stereo/Balls.exr
     openexr:version: 1
     view: "right"
     oiio:subimagename: "rgba.right"
-../../../../../openexr-images/v2/Stereo/Balls.exr : 1431 x  761, 5 channel, half/half/half/half/float openexr (2 subimages)
+../../../../../openexr-images/v2/Stereo/Balls.exr : 1431 x  761, 5 channel, deep half/half/half/half/float openexr (2 subimages)
     Stats Min: 0.000169 0.000083 0.000092 0.015625 127.872681 (float)
     Stats Max: 0.622070 0.265625 0.267822 1.000000 738.560669 (float)
     Stats Avg: 0.106414 0.010251 0.011385 0.896199 242.031235 (float)
@@ -135,9 +135,9 @@ Reading ../../../../../openexr-images/v2/Stereo/Balls.exr
 Comparing "../../../../../openexr-images/v2/Stereo/Balls.exr" and "Balls.exr"
 PASS
 Reading ../../../../../openexr-images/v2/Stereo/Leaves.exr
-../../../../../openexr-images/v2/Stereo/Leaves.exr : 1920 x 1080, 5 channel, half/half/half/half/float openexr
+../../../../../openexr-images/v2/Stereo/Leaves.exr : 1920 x 1080, 5 channel, deep half/half/half/half/float openexr
     2 subimages: 1920x1080 1920x1080 
- subimage  0: 1920 x 1080, 5 channel, float openexr
+ subimage  0: 1920 x 1080, 5 channel, deep half/half/half/half/float openexr
     SHA-1: ED7BBA99CE96DF98AC784F50B54EF976DB17AF26
     channel list: R (half), G (half), B (half), A (half), Z (float)
     oiio:ColorSpace: "Linear"
@@ -151,7 +151,7 @@ Reading ../../../../../openexr-images/v2/Stereo/Leaves.exr
     openexr:version: 1
     view: "left"
     oiio:subimagename: "rgba.left"
- subimage  1: 1920 x 1080, 5 channel, float openexr
+ subimage  1: 1920 x 1080, 5 channel, deep half/half/half/half/float openexr
     SHA-1: 11F6FB62B0F1080F78DBA6464FCC92C30D3162AF
     channel list: R (half), G (half), B (half), A (half), Z (float)
     oiio:ColorSpace: "Linear"
@@ -165,7 +165,7 @@ Reading ../../../../../openexr-images/v2/Stereo/Leaves.exr
     openexr:version: 1
     view: "right"
     oiio:subimagename: "rgba.right"
-../../../../../openexr-images/v2/Stereo/Leaves.exr : 1920 x 1080, 5 channel, half/half/half/half/float openexr (2 subimages)
+../../../../../openexr-images/v2/Stereo/Leaves.exr : 1920 x 1080, 5 channel, deep half/half/half/half/float openexr (2 subimages)
     Stats Min: 0.000099 0.000341 0.000152 0.015625 72.493698 (float)
     Stats Max: 0.403564 0.593262 0.345215 1.000000 954.392700 (float)
     Stats Avg: 0.071147 0.155779 0.047921 0.949514 208.998001 (float)


### PR DESCRIPTION
iinfo and oiiotool (and for each, the whole image versus subimages)
didn't all match the order and nomenclature for their presentation of
volume, deep, and per-channel data formats. This makes them all match,
and in particular fixes the fact that oiiotool didn't say that deep
files were deep (but iinfo did).
