### PR TITLE
oiiotool --pdiff is perceptual diff equivalent to idiff -p

### DIFF
--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -443,6 +443,14 @@ many pixels differed, the maximum amount, etc.).  This command does not
 alter the image stack.
 \apiend
 
+\NEW % 1.4
+\apiitem{--pdiff}
+This command computes the difference of the current image and the next
+image on the stack using a perceptual metric, and prints whether or not they
+match according to that metric.  This command does not
+alter the image stack.
+\apiend
+
 \apiitem{--colorcount \emph{r1,g1,b1,...:r2,g2,b2,...:...}}
 Given a list of colors separated by colons or semicolons, where each
 color is a list of comma-separated values (for each channel), examine

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1684,6 +1684,26 @@ action_diff (int argc, const char *argv[])
 
 
 static int
+action_pdiff (int argc, const char *argv[])
+{
+    if (ot.postpone_callback (2, action_pdiff, argc, argv))
+        return 0;
+    Timer timer (ot.enable_function_timing);
+
+    int ret = do_action_diff (*ot.image_stack.back(), *ot.curimg, ot, 1);
+    if (ret != DiffErrOK && ret != DiffErrWarn)
+        ot.return_value = EXIT_FAILURE;
+
+    if (ret != DiffErrOK && ret != DiffErrWarn && ret != DiffErrFail)
+        ot.error ("Error doing %s", argv[0]);
+
+    ot.function_times["pdiff"] += timer();
+    return 0;
+}
+
+
+
+static int
 action_add (int argc, const char *argv[])
 {
     if (ot.postpone_callback (2, action_add, argc, argv))
@@ -3366,6 +3386,7 @@ getargs (int argc, char *argv[])
                 "--capture %@", action_capture, NULL,
                         "Capture an image (options: camera=%d)",
                 "--diff %@", action_diff, NULL, "Print report on the difference of two images (modified by --fail, --failpercent, --hardfail, --warn, --warnpercent --hardwarn)",
+                "--pdiff %@", action_pdiff, NULL, "Print report on the perceptual difference of two images (modified by --fail, --failpercent, --hardfail, --warn, --warnpercent --hardwarn)",
                 "--add %@", action_add, NULL, "Add two images",
                 "--sub %@", action_sub, NULL, "Subtract two images",
                 "--abs %@", action_abs, NULL, "Take the absolute value of the image pixels",

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -377,7 +377,8 @@ enum DiffErrors {
     DiffErrLast
 };
 
-int do_action_diff (ImageRec &ir0, ImageRec &ir1, Oiiotool &options);
+int do_action_diff (ImageRec &ir0, ImageRec &ir1, Oiiotool &options,
+                    int perceptual = 0);
 
 
 


### PR DESCRIPTION
Not especially purposely, oiiotool --diff did not fully replicate the original functionality of 'idiff'. In particular, there was no prevision for a perceptual diff. Added now as --pdiff.

Also rigged it so that either --diff or --pdiff, when images fail to match closely enough, will set the oiiotool run status code to be nonzero.
