### PR TITLE
Fix DPX handling of unsupported pixel data types

### DIFF
--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -464,6 +464,23 @@ DPXOutput::prep_subimage (int s, bool allocate)
     else
         m_packing = dpx::kFilledMethodA;
 
+    switch (m_spec.format.basetype) {
+    case TypeDesc::UINT8 :
+    case TypeDesc::UINT16 :
+    case TypeDesc::FLOAT :
+    case TypeDesc::DOUBLE :
+        // supported, fine
+        break;
+    case TypeDesc::HALF :
+        // Turn half into float
+        m_spec.format.basetype = TypeDesc::FLOAT;
+        break;
+    default:
+        // Turn everything else into UINT16
+        m_spec.format.basetype = TypeDesc::UINT16;
+        break;
+    }
+
     // calculate target bit depth
     m_bitdepth = m_spec.format.size () * 8;
     if (m_spec.format == TypeDesc::UINT16) {


### PR DESCRIPTION
The general rule is that if a file type doesn't support the data type requested, it silently substitutes a supported data type (usually one that loses as little precision or range as possible).

DPX somehow lacked this logic, and we didn't notice until recently. In particular, something like

```
oiiotool in.dpx -d half -o out.dpx
```

Would result in garbage in the pixel, since it was not properly converting types or substituting one actually supported by DPX.

The true supported types of DPX are uint8, uint16 (including 10 and 12 bit variants), float, and double. Now half will be output as float, and all other unsupported types will be output as uint16.  
