### PR TITLE
Fixed a compilation error on Windows

### DIFF
--- a/src/libutil/timer.cpp
+++ b/src/libutil/timer.cpp
@@ -45,7 +45,7 @@ public:
     TimerSetupOnce () {
 #ifdef _WIN32
         // From MSDN web site
-        value_t freq;
+        LARGE_INTEGER freq;
         QueryPerformanceFrequency (&freq);
         Timer::seconds_per_tick = 1.0 / (double)freq.QuadPart;
 #elif defined(__APPLE__)


### PR DESCRIPTION
QueryPerformanceFrequency() takes a a pointer to LARGE_INTEGER as argument, not value_t
