### PR TITLE
oiiotool --dumpdata:empty=0

### DIFF
--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -436,6 +436,17 @@ read.
 Print the SHA-1 hash of the pixels of each input image.
 \apiend
 
+\apiitem{--dumpdata}
+Print to the console detailed information about the values in every pixel.
+
+\noindent Optional appended arguments include:
+
+\begin{tabular}{p{10pt} p{0.75in} p{3.75in}}
+  & {\cf empty=}{\verb&0|1&} & If 0, will cause deep images to skip printing
+                            of information about pixels with no samples.
+\end{tabular}
+\apiend
+
 \apiitem{--diff}
 This command computes the difference of the current image and the next
 image on the stack, and prints a report of those differences (how

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -89,6 +89,7 @@ Oiiotool::clear_options ()
     printinfo = false;
     printstats = false;
     dumpdata = false;
+    dumpdata_showempty = true;
     hash = false;
     updatemode = false;
     threads = 0;
@@ -266,6 +267,20 @@ set_threads (int argc, const char *argv[])
 
 
 static int
+set_dumpdata (int argc, const char *argv[])
+{
+    ASSERT (argc == 1);
+    ot.dumpdata = true;
+    std::map<std::string,std::string> options;
+    options["empty"] = "1";
+    extract_options (options, argv[0]);
+    ot.dumpdata_showempty = Strutil::from_string<int> (options["empty"]);
+    return 0;
+}
+
+
+
+static int
 input_file (int argc, const char *argv[])
 {
     for (int i = 0;  i < argc;  i++) {
@@ -295,6 +310,7 @@ input_file (int argc, const char *argv[])
             pio.subimages = ot.allsubimages;
             pio.compute_stats = ot.printstats;
             pio.dumpdata = ot.dumpdata;
+            pio.dumpdata_showempty = ot.dumpdata_showempty;
             pio.compute_sha1 = ot.hash;
             pio.metamatch = ot.printinfo_metamatch;
             pio.nometamatch = ot.printinfo_nometamatch;
@@ -3319,7 +3335,7 @@ getargs (int argc, char *argv[])
                 "--no-metamatch %s", &ot.printinfo_nometamatch,
                     "Regex: which metadata is excluded with -info -v",
                 "--stats", &ot.printstats, "Print pixel statistics on all inputs",
-                "--dumpdata", &ot.dumpdata, "Print all pixel data values",
+                "--dumpdata %@", set_dumpdata, NULL, "Print all pixel data values (options: empty=0)",
                 "--hash", &ot.hash, "Print SHA-1 hash of each input image",
                 "--colorcount %@ %s", action_colorcount, NULL,
                     "Count of how many pixels have the given color (argument: color;color;...) (optional args: eps=color)",

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -56,6 +56,7 @@ public:
     bool printinfo;
     bool printstats;
     bool dumpdata;
+    bool dumpdata_showempty;
     bool hash;
     bool updatemode;
     int threads;
@@ -321,6 +322,7 @@ struct print_info_options {
     bool compute_sha1;
     bool compute_stats;
     bool dumpdata;
+    bool dumpdata_showempty;
     std::string metamatch;
     std::string nometamatch;
     size_t namefieldlength;
@@ -328,7 +330,7 @@ struct print_info_options {
     print_info_options ()
         : verbose(false), filenameprefix(false), sum(false), subimages(false),
           compute_sha1(false), compute_stats(false), dumpdata(false),
-          namefieldlength(20)
+          dumpdata_showempty(true), namefieldlength(20)
     {}
 };
 

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -95,7 +95,7 @@ print_sha1 (ImageInput *input)
 
 
 static void
-dump_data (ImageInput *input)
+dump_data (ImageInput *input, const print_info_options &opt)
 {
     const ImageSpec &spec (input->spec());
     if (spec.deep) {
@@ -110,6 +110,8 @@ dump_data (ImageInput *input)
             for (int y = 0;  y < spec.height;  ++y) {
                 for (int x = 0;  x < spec.width;  ++x, ++pixel) {
                     int nsamples = dd.nsamples[pixel];
+                    if (nsamples == 0 && ! opt.dumpdata_showempty)
+                        continue;
                     std::cout << "    Pixel (";
                     if (spec.depth > 1 || spec.z != 0)
                         std::cout << Strutil::format("%d, %d, %d",
@@ -596,7 +598,7 @@ print_info_subimage (int current_subimage, int max_subimages, ImageSpec &spec,
     if (opt.dumpdata) {
         ImageSpec tmp;
         input->seek_subimage (current_subimage, 0, tmp);
-        dump_data (input);
+        dump_data (input, opt);
     }
 
     if (opt.compute_stats && (opt.metamatch.empty() ||


### PR DESCRIPTION
This option causes --dumpdata to skip empty pixels in a deep image.
Whew, makes output a lot easier to deal with when debugging with deep
file data dumps.
