### PR TITLE
Marked string_ref and timer as exported classes

### DIFF
--- a/src/include/OpenImageIO/string_ref.h
+++ b/src/include/OpenImageIO/string_ref.h
@@ -83,7 +83,7 @@ OIIO_NAMESPACE_ENTER {
 ///
 
 
-class string_ref {
+class OIIO_API string_ref {
 public:
     typedef char charT;
     typedef charT value_type;

--- a/src/include/OpenImageIO/timer.h
+++ b/src/include/OpenImageIO/timer.h
@@ -37,6 +37,7 @@
 #define OPENIMAGEIO_TIMER_H
 
 #include "oiioversion.h"
+#include "export.h"
 
 #ifdef _WIN32
 # include "osdep.h"
@@ -77,7 +78,7 @@ OIIO_NAMESPACE_ENTER
 /// (b) calling it millions of times could make your program appreciably
 /// more expensive due to the timers themselves.
 ///
-class Timer {
+class OIIO_API Timer {
 public:
     typedef unsigned long long value_t;
 


### PR DESCRIPTION
This is a small change but it does fix a link error on Windows.
