### PR TITLE
Fix Parameter neglect of its m_interp field when copying.

### DIFF
--- a/src/include/OpenImageIO/paramlist.h
+++ b/src/include/OpenImageIO/paramlist.h
@@ -59,7 +59,7 @@ OIIO_NAMESPACE_ENTER
 ///
 /// Nomenclature: if you have an array of 4 colors for each of 15 points...
 ///  - There are 15 VALUES
-///  - Each value has an array of 4 ELEMENTS, ecah of which is a color
+///  - Each value has an array of 4 ELEMENTS, each of which is a color
 ///  - A color has 3 COMPONENTS (R, G, B)
 ///
 class OIIO_API ParamValue {
@@ -82,25 +82,41 @@ public:
                 int _nvalues, const void *_value, bool _copy=true) {
         init_noclear (_name, _type, _nvalues, _value, _copy);
     }
+    ParamValue (const ustring &_name, TypeDesc _type, int _nvalues,
+                Interp _interp, const void *_value, bool _copy=true) {
+        init_noclear (_name, _type, _nvalues, _interp, _value, _copy);
+    }
     ParamValue (string_ref _name, TypeDesc _type,
                 int _nvalues, const void *_value, bool _copy=true) {
         init_noclear (ustring(_name), _type, _nvalues, _value, _copy);
     }
+    ParamValue (string_ref _name, TypeDesc _type, int _nvalues,
+                Interp _interp, const void *_value, bool _copy=true) {
+        init_noclear (ustring(_name), _type, _nvalues, _interp, _value, _copy);
+    }
     ParamValue (const ParamValue &p, bool _copy=true) {
-        init_noclear (p.name(), p.type(), p.nvalues(), p.data(), _copy);
+        init_noclear (p.name(), p.type(), p.nvalues(), p.interp(), p.data(), _copy);
     }
     ~ParamValue () { clear_value(); }
+    void init (ustring _name, TypeDesc _type, int _nvalues,
+               Interp _interp, const void *_value, bool _copy=true) {
+        clear_value ();
+        init_noclear (_name, _type, _nvalues, _interp, _value, _copy);
+    }
     void init (ustring _name, TypeDesc _type,
                int _nvalues, const void *_value, bool _copy=true) {
-        clear_value ();
-        init_noclear (_name, _type, _nvalues, _value, _copy);
+        init (_name, _type, _nvalues, INTERP_CONSTANT, _value, _copy);
     }
     void init (string_ref _name, TypeDesc _type,
                int _nvalues, const void *_value, bool _copy=true) {
         init (ustring(_name), _type, _nvalues, _value, _copy);
     }
+    void init (string_ref _name, TypeDesc _type, int _nvalues,
+               Interp _interp, const void *_value, bool _copy=true) {
+        init (ustring(_name), _type, _nvalues, _interp, _value, _copy);
+    }
     const ParamValue& operator= (const ParamValue &p) {
-        init (p.name(), p.type(), p.nvalues(), p.data(), p.m_copy);
+        init (p.name(), p.type(), p.nvalues(), p.interp(), p.data(), p.m_copy);
         return *this;
     }
 
@@ -120,6 +136,7 @@ public:
         std::swap (a.m_name,     b.m_name);
         std::swap (a.m_type,     b.m_type);
         std::swap (a.m_nvalues,  b.m_nvalues);
+        std::swap (a.m_interp,   b.m_interp);
         std::swap (a.m_data.ptr, b.m_data.ptr);
         std::swap (a.m_copy,     b.m_copy);
         std::swap (a.m_nonlocal, b.m_nonlocal);
@@ -138,6 +155,9 @@ private:
 
     void init_noclear (ustring _name, TypeDesc _type,
                        int _nvalues, const void *_value, bool _copy=true);
+    void init_noclear (ustring _name, TypeDesc _type,int _nvalues,
+                       Interp _interp, const void *_value,
+                       bool _copy=true);
     void clear_value();
 };
 

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -44,10 +44,19 @@ void
 ParamValue::init_noclear (ustring _name, TypeDesc _type,
                           int _nvalues, const void *_value, bool _copy)
 {
+    init_noclear (_name, _type, _nvalues, INTERP_CONSTANT, _value, _copy);
+}
+
+
+
+void
+ParamValue::init_noclear (ustring _name, TypeDesc _type, int _nvalues,
+                          Interp _interp, const void *_value, bool _copy)
+{
     m_name = _name;
     m_type = _type;
     m_nvalues = _nvalues;
-    m_interp = INTERP_CONSTANT;
+    m_interp = _interp;
     size_t n = (size_t) (m_nvalues * m_type.numelements());
     size_t size = (size_t) (m_nvalues * m_type.size());
     bool small = (size <= sizeof(m_data));


### PR DESCRIPTION
The long-unused m_interp field of Parameter was not properly copied
during copy-construction or assignment (nor was there any ctr variety
that directly set it -- you'd need to construct with the default
INTERP_CONSTANT, then set it manually).

This was problematic if you had a std::vector<Parameter> (such as a
ParamValueList!) because when it resizes as the vector grows, it will
copy elements to reallocated memory and in the process botch the
m_interp field if anybody has set it to something other than the
default. Which OSL does! Oops.

So we're careful about this in the copy ctr and assignemnt now, and made
varieties of the init() and ctr's that take an interp. We only _added_
inline and non-virtual methods, so it should be both source and link
compatible with apps that used Parameter before. That being the case, I
intend to backport to 1.3, in case anybody is using OSL with the release
branch of OIIO. (OSL is the only situation in which the interp field is
used, as far as I'm aware.)
