### PR TITLE
Fixes for OpenBSD compilation. Fixes #826, as suggested by pstumpf.

### DIFF
--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -216,8 +216,8 @@ bool
 TextureSystemImpl::texture3d_lookup_nomip (TextureFile &texturefile,
                             PerThreadInfo *thread_info, 
                             TextureOpt &options,
-                            const Imath::V3f &_P, const Imath::V3f &_dPdx,
-                            const Imath::V3f &_dPdy, const Imath::V3f &_dPdz,
+                            const Imath::V3f &P, const Imath::V3f &dPdx,
+                            const Imath::V3f &dPdy, const Imath::V3f &dPdz,
                             float *result)
 {
     // Initialize results to 0.  We'll add from here on as we sample.
@@ -249,7 +249,7 @@ TextureSystemImpl::texture3d_lookup_nomip (TextureFile &texturefile,
         &TextureSystemImpl::accum3d_sample_bilinear,
     };
     accum3d_prototype accumer = accum_functions[(int)options.interpmode];
-    bool ok = (this->*accumer) (_P, 0, texturefile, thread_info, options,
+    bool ok = (this->*accumer) (P, 0, texturefile, thread_info, options,
                                 1.0f, result, dresultds, dresultdt, dresultdr);
 
     // Update stats

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -358,14 +358,14 @@ private:
     typedef bool (TextureSystemImpl::*texture3d_lookup_prototype)
             (TextureFile &texfile, PerThreadInfo *thread_info,
              TextureOpt &options,
-             const Imath::V3f &_P, const Imath::V3f &_dPdx,
-             const Imath::V3f &_dPdy, const Imath::V3f &_dPdz,
+             const Imath::V3f &P, const Imath::V3f &dPdx,
+             const Imath::V3f &dPdy, const Imath::V3f &dPdz,
              float *result);
     bool texture3d_lookup_nomip (TextureFile &texfile,
                                  PerThreadInfo *thread_info, 
                                  TextureOpt &options,
-                                 const Imath::V3f &_P, const Imath::V3f &_dPdx,
-                                 const Imath::V3f &_dPdy, const Imath::V3f &_dPdz,
+                                 const Imath::V3f &P, const Imath::V3f &dPdx,
+                                 const Imath::V3f &dPdy, const Imath::V3f &dPdz,
                                  float *result);
     typedef bool (TextureSystemImpl::*accum3d_prototype)
                         (const Imath::V3f &P, int level,

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -244,7 +244,7 @@ Sysutil::this_program_path ()
     size_t cb = sizeof(filename);
     int r=1;
     sysctl(mib, 4, filename, &cb, NULL, 0);
-#elif defined(__GNU__)
+#elif defined(__GNU__) || defined(__OpenBSD__)
     int r = 0;
 #else
     // No idea what platform this is

--- a/src/ptex.imageio/ptex/PtexPlatform.h
+++ b/src/ptex.imageio/ptex/PtexPlatform.h
@@ -60,7 +60,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 // linux/unix/posix
 #include <stdlib.h>
-#ifndef __FreeBSD__
+#if !defined(__FreeBSD__) && !defined(__OpenBSD__)
 #include <alloca.h>
 #endif
 #include <string.h>


### PR DESCRIPTION
Fixes #826.

Solution is the same as what was suggested there, except that instead of '#undef _P', I just changed the "_P" declarations to "P", with no adverse consequences.
