### PR TITLE
Support for Nuke-style %V and %v wildcards in oiiotool

### DIFF
--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -106,6 +106,34 @@ Alternately, you can use the {\cf printf} notation, such as
     oiiotool --frames 3,4,10-20x2 blah.%03d.tif
 \end{code}
 
+\subsubsection*{Stereo wildcards}
+
+\oiiotool can also handle image sequences with separate left and right
+images per frame using {\cf views}. The {\cf \%V} wildcard will match
+the full name of all views and {\cf \%v} will match the first character
+of each view. View names default to ``left'' and ``right'', but may
+be overridden using the {\cf --views} option.
+For example,
+\begin{code}
+    oiiotool --frames 1-5 blah_%V.#.tif
+\end{code}
+\noindent would match {\cf blah_left.0001.tif}, {\cf blah_right.0001.tif},
+{\cf blah_left.0002.tif}, {\cf blah_right.0002.tif}, {\cf blah_left.0003.tif},
+{\cf blah_right.0003.tif}, {\cf blah_left.0004.tif}, 
+{\cf blah_right.0004.tif}, {\cf blah_left.0005.tif}, 
+{\cf blah_right.0005.tif}, and
+\begin{code}
+    oiiotool --frames 1-5 blah_%v.#.tif
+\end{code}
+\noindent would match {\cf blah_l.0001.tif}, {\cf blah_r.0001.tif},
+{\cf blah_l.0002.tif}, {\cf blah_r.0002.tif}, {\cf blah_l.0003.tif},
+{\cf blah_r.0003.tif}, {\cf blah_l.0004.tif}, {\cf blah_r.0004.tif}, 
+{\cf blah_l.0005.tif}, {\cf blah_r.0005.tif}, but
+\begin{code}
+    oiiotool --views left --frames 1-5 blah_%v.#.tif
+\end{code}
+\noindent would only match {\cf blah_l.0001.tif}, {\cf blah_l.0002.tif},
+{\cf blah_l.0003.tif}, {\cf blah_l.0004.tif}, {\cf blah_l.0005.tif}.
 
 \section{\oiiotool Tutorial / Recipes}
 

--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -209,6 +209,31 @@ OIIO_API bool enumerate_file_sequence (const std::string &pattern,
                                        const std::vector<int> &numbers,
                                        std::vector<std::string> &filenames);
 
+/// Given a normalized pattern (such as "foo_%V.%04d.tif") and a list of frame
+/// numbers, generate a list of filenames. "views" is list of per-frame
+/// views, or empty. In each frame filename, "%V" is replaced with the view,
+/// and "%v" is replaced with the first character of the view.
+///
+/// Return true upon success, false if the description was too malformed
+/// to generate a sequence.
+OIIO_API bool enumerate_file_sequence (const std::string &pattern,
+                                       const std::vector<int> &numbers,
+                                       const std::vector<string_ref> &views,
+                                       std::vector<std::string> &filenames);
+
+/// Given a normalized pattern (such as "/path/to/foo.%04d.tif") scan the
+/// containing directory (/path/to) for matching frame numbers, views and files.
+/// "%V" in the pattern matches views, while "%v" matches the first character
+/// of each entry in views.
+///
+/// Return true upon success, false if the directory doesn't exist or the
+/// pattern can't be parsed.
+OIIO_API bool scan_for_matching_filenames (const std::string &pattern,
+                                           const std::vector<string_ref> &views,
+                                           std::vector<int> &frame_numbers,
+                                           std::vector<string_ref> &frame_views,
+                                           std::vector<std::string> &filenames);
+
 /// Given a normalized pattern (such as "/path/to/foo.%04d.tif") scan the
 /// containing directory (/path/to) for matching frame numbers and files.
 ///

--- a/src/include/OpenImageIO/string_ref.h
+++ b/src/include/OpenImageIO/string_ref.h
@@ -148,6 +148,7 @@ public:
     size_type length() const { return m_len; }
     size_type max_size() const { return m_len; }
     bool empty() const { return m_len == 0; }
+    bool null() const { return m_chars == 0; }
 
     // element access
     const charT& operator[] (size_type pos) const { return m_chars[pos]; }

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -457,6 +457,12 @@ Filesystem::parse_pattern (const char *pattern_,
     boost::match_results<std::string::const_iterator> range_match;
     if (! boost::regex_search (pattern, range_match, sequence_re)) {
         // Not a range
+        static boost::regex all_views_re ("%[Vv]");
+        if (boost::regex_search (pattern, all_views_re)) {
+            normalized_pattern = pattern;
+            return true;
+        }
+
         return false;
     }
 
@@ -513,6 +519,105 @@ Filesystem::enumerate_file_sequence (const std::string &pattern,
 
 
 bool
+Filesystem::enumerate_file_sequence (const std::string &pattern,
+                                     const std::vector<int> &numbers,
+                                     const std::vector<string_ref> &views,
+                                     std::vector<std::string> &filenames)
+{
+    DASSERT (views.size() == 0 || views.size() == numbers.size());
+
+    static boost::regex view_re ("%V"), short_view_re ("%v");
+
+    for (size_t i = 0, e = numbers.size(); i < e; ++i) {
+        std::string f = pattern;
+        if (views.size() > 0 && ! views[i].null()) {
+            f = boost::regex_replace (f, view_re, views[i]);
+            f = boost::regex_replace (f, short_view_re, views[i].substr(0, 1));
+        }
+        f = Strutil::format (f.c_str(), numbers[i]);
+        filenames.push_back (f);
+    }
+
+    return true;
+}
+
+
+
+bool
+Filesystem::scan_for_matching_filenames(const std::string &pattern,
+                                        const std::vector<string_ref> &views,
+                                        std::vector<int> &frame_numbers,
+                                        std::vector<string_ref> &frame_views,
+                                        std::vector<std::string> &filenames)
+{
+    static boost::regex format_re ("%0([0-9]+)d");
+    static boost::regex all_views_re ("%[Vv]"), view_re ("%V"), short_view_re ("%v");
+
+    if (boost::regex_search (pattern, all_views_re)) {
+        if (boost::regex_search (pattern, format_re)) {
+            // case 1: pattern has format and view
+            std::vector< std::pair< std::pair< int, string_ref>, std::string> > matches;
+            for (int i = 0, e = views.size(); i < e; ++i) {
+                if (views[i].null())
+                    continue;
+
+                const string_ref short_view = views[i].substr (0, 1);
+                std::vector<int> view_numbers;
+                std::vector<std::string> view_filenames;
+
+                std::string view_pattern = pattern;
+                view_pattern = boost::regex_replace (view_pattern, view_re, views[i]);
+                view_pattern = boost::regex_replace (view_pattern, short_view_re, short_view);
+
+                if (! scan_for_matching_filenames (view_pattern, view_numbers, view_filenames))
+                    continue;
+
+                for (int j = 0, f = view_numbers.size(); j < f; ++j) {
+                    matches.push_back (std::make_pair (std::make_pair (view_numbers[j], views[i]), view_filenames[j]));
+                }
+            }
+
+            std::sort (matches.begin(), matches.end());
+
+            for (int i = 0, e = matches.size(); i < e; ++i) {
+                frame_numbers.push_back (matches[i].first.first);
+                frame_views.push_back (matches[i].first.second);
+                filenames.push_back (matches[i].second);
+            }
+
+        } else {
+            // case 2: pattern has view, but no format
+            std::vector< std::pair<string_ref, std::string> > matches;
+            for (int i = 0, e = views.size(); i < e; ++i) {
+                const string_ref &view = views[i];
+                const string_ref short_view = view.substr (0, 1);
+
+                std::string view_pattern = pattern;
+                view_pattern = boost::regex_replace (view_pattern, view_re, view);
+                view_pattern = boost::regex_replace (view_pattern, short_view_re, short_view);
+
+                if (boost::filesystem::exists (view_pattern))
+                    matches.push_back (std::make_pair (view, view_pattern));
+            }
+
+            std::sort (matches.begin(), matches.end());
+            for (int i = 0, e = matches.size(); i < e; ++i) {
+                frame_views.push_back (matches[i].first);
+                filenames.push_back (matches[i].second);
+            }
+
+        }
+        return true;
+
+    } else {
+        // case 3: pattern has format, but no view
+        return scan_for_matching_filenames(pattern, frame_numbers, filenames);
+    }
+
+    return true;
+}
+
+bool
 Filesystem::scan_for_matching_filenames(const std::string &pattern_,
                                         std::vector<int> &numbers,
                                         std::vector<std::string> &filenames)
@@ -534,7 +639,7 @@ Filesystem::scan_for_matching_filenames(const std::string &pattern_,
         return false;
 
     // build a regex that matches the pattern
-    boost::regex format_re ("%0([0-9]+)d");
+    static boost::regex format_re ("%0([0-9]+)d");
     boost::match_results<std::string::const_iterator> format_match;
     if (! boost::regex_search (pattern, format_match, format_re))
         return false;
@@ -571,7 +676,7 @@ Filesystem::scan_for_matching_filenames(const std::string &pattern_,
     // filesystem order is undefined, so return sorted sequences
     std::sort (matches.begin(), matches.end());
 
-    for (size_t i = 0; i < matches.size(); ++i) {
+    for (size_t i = 0, e = matches.size(); i < e; ++i) {
         numbers.push_back (matches[i].first);
         filenames.push_back (matches[i].second);
     }

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -3347,6 +3347,7 @@ getargs (int argc, char *argv[])
                 "--threads %@ %d", set_threads, &ot.threads, "Number of threads (default 0 == #cores)",
                 "--frames %s", NULL, "Frame range for '#' or printf-style wildcards",
                 "--framepadding %d", NULL, "Frame number padding digits (ignored when using printf-style wildcards)",
+                "--views %s", NULL, "Views for %V/%v wildcards (comma-separated, defaults to left,right)",
                 "<SEPARATOR>", "Commands that write images:",
                 "-o %@ %s", output_file, NULL, "Output the current image to the named file",
                 "<SEPARATOR>", "Options that affect subsequent image output:",
@@ -3571,15 +3572,21 @@ handle_sequence (int argc, const char **argv)
 {
     Timer totaltime;
 
-    // First, scan the original command line arguments for '#', '@' or '%0Nd'
-    // characters.  Any found indicate that there are numeric range or
-    // wildcards to deal with.  Also look for --frames and --framepadding
-    // options.
+    // First, scan the original command line arguments for '#', '@', '%0Nd',
+    // '%v' or '%V' characters.  Any found indicate that there are numeric
+    // range or wildcards to deal with.  Also look for --frames,
+    // --framepadding and --views options.
 #define ONERANGE_SPEC "[0-9]+(-[0-9]+((x|y)-?[0-9]+)?)?"
 #define MANYRANGE_SPEC ONERANGE_SPEC "(," ONERANGE_SPEC ")*"
-#define SEQUENCE_SPEC "(" MANYRANGE_SPEC ")?" "((#|@)+|(%[0-9]*d))"
+#define VIEW_SPEC "%[Vv]"
+#define SEQUENCE_SPEC "((" MANYRANGE_SPEC ")?" "((#|@)+|(%[0-9]*d)))" "|" "(" VIEW_SPEC ")"
     static boost::regex sequence_re (SEQUENCE_SPEC);
     std::string framespec = "";
+
+    static const char *default_views = "left,right";
+    std::vector<string_ref> views;
+    Strutil::split (default_views, views, ",");
+
     int framepadding = 0;
     std::vector<int> sequence_args;  // Args with sequence numbers
     std::vector<bool> sequence_is_output;
@@ -3605,6 +3612,9 @@ handle_sequence (int argc, const char **argv)
             if (f >= 1 && f < 10)
                 framepadding = f;
         }
+        else if (! strcmp (argv[a], "--views") && a < argc-1) {
+            Strutil::split (argv[++a], views, ",");
+        }
     }
 
     // No ranges or wildcards?
@@ -3619,8 +3629,9 @@ handle_sequence (int argc, const char **argv)
     // sequences without explicit frame ranges inherit the frame numbers of
     // the first input sequence. It's an error if the sequences are not all
     // of the same length.
-    std::vector< std::vector<std::string> > filenames (argc+1); 
+    std::vector< std::vector<std::string> > filenames (argc+1);
     std::vector< std::vector<int> > frame_numbers (argc+1);
+    std::vector< std::vector<string_ref> > frame_views (argc+1);
     std::string normalized_pattern, sequence_framespec;
     size_t nfilenames = 0;
     bool result;
@@ -3645,15 +3656,19 @@ handle_sequence (int argc, const char **argv)
                                             frame_numbers[a]);
             Filesystem::enumerate_file_sequence (normalized_pattern,
                                                  frame_numbers[a],
+                                                 views,
                                                  filenames[a]);
         } else if (sequence_is_output[i]) {
             // use frame numbers from first sequence
             Filesystem::enumerate_file_sequence (normalized_pattern,
                                                  frame_numbers[sequence_args[0]],
+                                                 frame_views[sequence_args[0]],
                                                  filenames[a]);
         } else if (! sequence_is_output[i]) {
             result = Filesystem::scan_for_matching_filenames (normalized_pattern,
+                                                              views,
                                                               frame_numbers[a],
+                                                              frame_views[a],
                                                               filenames[a]);
             if (! result) {
                 ot.error (Strutil::format("No filenames found matching pattern: %s",


### PR DESCRIPTION
aka stereo support.

Examples:
`oiiotool foo_%V.%04d.exr` will match `foo_left.%04d.exr` or `foo_right.%04d.exr`.
`oiiotool foo_%v.%04d.exr` will match `foo_l.%04d.exr` or `foo_r.%04d.exr`.

The default views matched by %V are left and right, and the first character of each is used for %v. These may be overridden with the new `--views` option, for example `oiiotool --views LEFT,RIGHT ...`. The syntax is compatible with both Nuke and RV.

For this first pass, I only added to the public interface of the Filesystem namespace, so the non-view-supporting enumerate_file_sequence function is still present but unused. I dunno if this is used elsewhere, so I didn't want to remove it completely. But it should probably be deprecated, or just dropped.

The original scan_for_matching_filenames function is used by the newer view-supporting version, so it remains unchanged. It could go static, though, and keep the Filesystem namespace clean.

I added a few unit tests (all good) and also updated the docs.

This patch has been in production for a couple weeks now with no problems.

cheers,
-Mark
