### PR TITLE
force pixel aspect ratio to 1.0 if denominator == 0 to avoid PAR of NaN

### DIFF
--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -381,8 +381,9 @@ DPXInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
     m_dpx.header.Description (subimage, buf);
     if (buf[0] && buf[0] != char(-1))
         m_spec.attribute ("ImageDescription", buf);
-    m_spec.attribute ("PixelAspectRatio", m_dpx.header.AspectRatio(0)
-         / (float)m_dpx.header.AspectRatio(1));
+    m_spec.attribute ("PixelAspectRatio",
+        m_dpx.header.AspectRatio(1) ? (m_dpx.header.AspectRatio(0) /
+                (float)m_dpx.header.AspectRatio(1)) : 1.0f);
 
     // DPX-specific metadata
     m_spec.attribute ("dpx:ImageDescriptor",


### PR DESCRIPTION
We received a bunch of dpx plates with pixel aspect ratio specified in the header as 0:0... which oiio dutifully turns into NaN. This patch checks for a non-zero denominator before dividing and defaults the PAR to 1.0 otherwise.
