### PR TITLE
Smarter unassociated alpha handling.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -95,8 +95,12 @@ Fixes, minor enhancements, and performance improvements:
     DPX spec which states they are unsigned. (#813) (1.4.4)
   - Fix improper handling of unsupported pixel data types. (#818) (1.4.5)
   - Accept pixel ratio (x/0) to mean 1.0, not NaN. (#834) (1.4.5/1.3.13)
-* PNG: add "png:compressionlevel" and "compression" strategy attributes.
-  (1.3.12/1.4.2)
+* PNG:
+  - add "png:compressionlevel" and "compression" strategy attributes.
+    (1.3.12/1.4.2)
+  - output properly responds to "oiio:UnassociatedAlpha"=1 to indicate
+    that the buffer is unassociated (not premultiplied) and therefore it
+    should not automatically unpremultiply it. (1.4.5)
 * Make ImageBuf iterators return valid black pixel data for missing
   tiles. (1.3.12/1.4.2)
 * Make the ImageOutput implementations for all non-tiled file formats

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -185,6 +185,9 @@ PNGOutput::open (const std::string &name, const ImageSpec &userspec,
     m_dither = (m_spec.format == TypeDesc::UINT8) ?
                     m_spec.get_int_attribute ("oiio:dither", 0) : 0;
 
+    m_convert_alpha = m_spec.alpha_channel != -1 &&
+                      !m_spec.get_int_attribute("oiio:UnassociatedAlpha", 0);
+
     // If user asked for tiles -- which this format doesn't support, emulate
     // it by buffering the whole image.
     if (m_spec.tile_width && m_spec.tile_height)

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -235,7 +235,7 @@ def runtest (command, outputs, failureok=0) :
         # variants for different platforms, etc.
         for testfile in (["ref/"+out] + glob.glob (os.path.join ("ref", "*"+extension))) :
             # print ("comparing " + out + " to " + testfile)
-            if extension == ".tif" or extension == ".exr" or extension == ".jpg":
+            if extension == ".tif" or extension == ".exr" or extension == ".jpg" or extension == ".png":
                 # images -- use idiff
                 cmpcommand = diff_command (out, testfile, concat=False)
                 # print ("cmpcommand = " + cmpcommand)


### PR DESCRIPTION
1. Make IBA premult/unpremult (and oiiotool --premult/--unpremult) mark the IB's
   metadata "oiio:UnassociatedAlpha" as dictated.
2. Make PNG output receiving a non-premultiplied buffer NOT preemptively unpremult.
   (This makes it match Targa's behavior.)

This makes it somewhat harder to inadvertently double-unpremult, such as if you did:

```
oiiotool in.exr --unpremult -o out.png
```
