### PR TITLE
Fix errors in mitchell and gaussian default width. Fixes #835.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -131,6 +131,11 @@ Fixes, minor enhancements, and performance improvements:
   and copy construction. (#829) (1.4.5/1.3.13)
 * Fix ImageBufAlgo::circular_shift (and oiiotool --cshift) that did not
   wrap correctly for negative shifts. (#832) (1.4.5/1.3.13)
+* The "gaussian" flter incorrectly had default width 2 (correct = 3),
+  and the "mitchell" filter incorrect had default width 3 (correct = 4).
+  These were bugs/typos, the new way is correct. If you were using those
+  filters in ways that used the default width value, appearance may change
+  slightly. (1.4.6)
 
 Build/test system improvements:
 * libOpenImageIO_Util is now built that only has the utility functions

--- a/src/libutil/filter.cpp
+++ b/src/libutil/filter.cpp
@@ -543,13 +543,13 @@ FilterDesc filter1d_list[] = {
     // name             dim width fixedwidth scalable separable
     { "box",             1,   1,    false,    true,     true },
     { "triangle",        1,   2,    false,    true,     true },
-    { "gaussian",        1,   2,    false,    true,     true },
+    { "gaussian",        1,   3,    false,    true,     true },
     { "sharp-gaussian",  1,   2,    false,    true,     true },
     { "catrom",          1,   4,    true,     false,    true },
     { "blackman-harris", 1,   3,    false,    true,     true },
     { "sinc",            1,   4,    false,    true,     true },
     { "lanczos3",        1,   6,    true,     false,    true },
-    { "mitchell",        1,   3,    false,    true,     true },
+    { "mitchell",        1,   4,    false,    true,     true },
     { "bspline",         1,   4,    false,    true,     true }
 };
 }
@@ -613,14 +613,14 @@ static FilterDesc filter2d_list[] = {
     // name             dim width fixedwidth scalable separable
     { "box",             2,   1,    false,    true,     true  },
     { "triangle",        2,   2,    false,    true,     true  },
-    { "gaussian",        2,   2,    false,    true,     true  },
+    { "gaussian",        2,   3,    false,    true,     true  },
     { "sharp-gaussian",  2,   2,    false,    true,     true  },
     { "catrom",          2,   4,    true,     false,    true  },
     { "blackman-harris", 2,   3,    false,    true,     true  },
     { "sinc",            2,   4,    false,    true,     true  },
     { "lanczos3",        2,   6,    true,     false,    true  },
     { "radial-lanczos3", 2,   6,    true,     false,    false },
-    { "mitchell",        2,   3,    false,    true,     true  },
+    { "mitchell",        2,   4,    false,    true,     true  },
     { "bspline",         2,   4,    false,    true,     true  },
     { "disk",            2,   1,    false,    true,     false }
 };


### PR DESCRIPTION
Mitchell should be 4, was incorrectly 3. Gaussian should be 3, was 2.
Note that there has always been "sharp-gaussian", which is 2 by design.
The fact that "gaussian" was also 2 is clearly a typo, there's no reason
for us to have intentionally made "gaussian" and "sharp-gaussian" identical.
