### PR TITLE
Fix OpenEXR brittleness with malformed metadata.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -77,6 +77,7 @@ Fixes, minor enhancements, and performance improvements:
     channels (#822) (1.4.5).
   - Adhere to the misunderstood limitation that OpenEXR library doesn't
     allow random writes to scanline files. (1.4.6)
+  - More robust with certain malformed metadata. (#841) (1.4.6)
 * TIFF: Give a more explicit error message for unsupported tile sizes (1.4.4)
 * GIF: Fixes to subimage gneeration; GIF frames are treated as sequential
   windows to be drawn on canvas rather than as independent images; respect

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -280,6 +280,7 @@ private:
         m_map["displayWindow"] = "";
         m_map["envmap"] = "";
         m_map["tiledesc"] = "";
+        m_map["tiles"] = "";
         m_map["openexr:lineOrder"] = "";
         m_map["type"] = "";
         // Ones to skip because we consider them irrelevant

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -846,6 +846,7 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
     // the library, don't mess it up by inadvertently copying it wrong from
     // the user or from a file we read.
     if (Strutil::iequals(xname, "type") ||
+        Strutil::iequals(xname, "tiles") ||
         Strutil::iequals(xname, "version") ||
         Strutil::iequals(xname, "chunkCount") ||
         Strutil::iequals(xname, "maxSamplesPerPixel")) {
@@ -853,6 +854,7 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
     }
 
     // General handling of attributes
+    try {
 
     // Scalar
     if (type.arraylen == 0) {
@@ -1052,7 +1054,11 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
         }
 #endif
     }
-
+    } catch (const std::exception &e) {
+#ifndef NDEBUG
+        std::cout << "Caught OpenEXR exception: " << e.what() << "\n";
+#endif
+    }
 
 #ifndef NDEBUG
     std::cerr << "Don't know what to do with " << type.c_str() << ' ' << xname << "\n";


### PR DESCRIPTION
Our particular case was a string called "tiles" -- triggers an exception inside libIlmImf.

I suppress this particular case by name, but also to avoid this kind of problem in the future, I enclose a whole section of put_parameter in a try/catch block, to deal with other unanticipated OpenEXR exceptions when setting attributes.
