### PR TITLE
More portable definition of stride_t and AutoStride for array_view

### DIFF
--- a/src/include/OpenImageIO/image_view.h
+++ b/src/include/OpenImageIO/image_view.h
@@ -32,6 +32,10 @@
 
 #pragma once
 
+#ifndef __STDC_LIMIT_MACROS
+# define __STDC_LIMIT_MACROS  /* needed for some defs in stdint.h */
+#endif
+
 #include <vector>
 #include <stdexcept>
 #include <stdint.h>
@@ -54,8 +58,8 @@ public:
     typedef T value_type;
     typedef T& reference;
     typedef const T& const_reference;
-    typedef ptrdiff_t stride_t;
-    static const stride_t AutoStride = PTRDIFF_MIN;
+    typedef int64_t stride_t;
+    static const stride_t AutoStride = INT64_MIN;
 
     /// Default ctr -- points to nothing
     image_view () { init(); }


### PR DESCRIPTION
PTRDIFF_MIN isn't there for everybody. 

I'm hoping that int64_t and INT64_MIN is. Let me know if this breaks anybody.
