### PR TITLE
oiiotool --over should set output display window to union, not fg

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -2999,6 +2999,7 @@ action_over (int argc, const char *argv[])
     // Create output image specification.
     ImageSpec specR = specA;
     set_roi (specR, roi_union (get_roi(specA), get_roi(specB)));
+    set_roi_full (specR, roi_union (get_roi_full(specA), get_roi_full(specB)));
 
     ot.push (new ImageRec ("over", specR, ot.imagecache));
     ImageBuf &Rib ((*ot.curimg)());
@@ -3041,6 +3042,7 @@ action_zover (int argc, const char *argv[])
     // Create output image specification.
     ImageSpec specR = specA;
     set_roi (specR, roi_union (get_roi(specA), get_roi(specB)));
+    set_roi_full (specR, roi_union (get_roi_full(specA), get_roi_full(specB)));
 
     ot.push (new ImageRec ("zover", specR, ot.imagecache));
     ImageBuf &Rib ((*ot.curimg)());


### PR DESCRIPTION
I hadn't noticed a problem before because fg and bg are usually the same
size. But if they differ, it seems likely that it's a small element
being put overtop a fixed background, so setting the output's display
("full") window to the fg is not what you want.
