### PR TITLE
Replace runtime array size (incompatible with some old compilers) with vector

### DIFF
--- a/src/dpx.imageio/libdpx/Writer.cpp
+++ b/src/dpx.imageio/libdpx/Writer.cpp
@@ -183,10 +183,9 @@ dpx::Writer::WritePadData(const int alignment)
 {
     int imageoffset = ((this->fileLoc + alignment - 1)/alignment)*alignment;
     int padsize = imageoffset - this->fileLoc;
-    if (padsize > 0){
-        dpx::U8 pad[padsize];
-        memset(pad, 0XFF, padsize);
-        this->fileLoc += this->fd->Write(pad, padsize);
+    if (padsize > 0) {
+        std::vector<dpx::U8> pad (padsize, 0xff);
+        this->fileLoc += this->fd->Write (&pad[0], padsize);
         if (this->fileLoc != imageoffset)
             return false;
     }


### PR DESCRIPTION
In addition to working with old compilers (MSVC 9, I'm looking at you), the new way is safe against stack overflows if the padding amount is for some reason very large. It's generally once per subimage in a DPX file, there's no appreciable penalty for allocating it on the heap and being totally safe with it.
