### PR TITLE
pLinear default value changed to false

### DIFF
--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -618,7 +618,7 @@ OpenEXROutput::spec_to_header (ImageSpec &spec, int subimage, Imf::Header &heade
 
         // Note: This is not the same as data having come from a linear colorspace.
         // It is meant for data that is percieved by humans in a linear fashion
-        // e.g Cb & Cr componenta in YCbCr images
+        // e.g Cb & Cr components in YCbCr images
         //     a* & b* components in L*a*b* images
         //     H & S components in HLS images
         bool pLinear = false;


### PR DESCRIPTION
As most EXR channels are percieved in a logarithmic fashion by human vision, pLinear default value has been changed to false. This gives a greatly improved look to R,G,B,A channels when b44 compression is used.
