### PR TITLE
Fixing 'variable may be used uninitialized'

### DIFF
--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -667,7 +667,7 @@ DDSInput::read_native_tile (int x, int y, int z, void *data)
         lastx = x;
         lasty = y;
         lastz = z;
-        unsigned int w, h, d;
+        unsigned int w = 0, h = 0, d = 0;
 #ifdef DDS_3X2_CUBE_MAP_LAYOUT
         internal_seek_subimage (((x / m_spec.tile_width) << 1)
                                 + y / m_spec.tile_height,


### PR DESCRIPTION
ddsinput.cpp:679:9: error: ‘w’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
         if (!w && !h && !d)
         ^

same for h and d
