### PR TITLE
Fix case typo for LatLong env map creation in "prman mode".

### DIFF
--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1114,7 +1114,7 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
         dstspec.attribute ("textureformat", "LatLong Environment");
         configspec.attribute ("wrapmodes", "periodic,clamp");
         if (prman_metadata)
-            dstspec.attribute ("PixarTextureFormat", "Latlong Environment");
+            dstspec.attribute ("PixarTextureFormat", "LatLong Environment");
     } else {
         dstspec.attribute ("textureformat", "Plain Texture");
         if (prman_metadata)

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -506,7 +506,7 @@ ImageCacheFile::init_from_spec ()
     if ((p = spec.find_attribute ("textureformat", TypeDesc::STRING))) {
         const char *textureformat = *(const char **)p->data();
         for (int i = 0;  i < TexFormatLast;  ++i)
-            if (! strcmp (textureformat, texture_format_name((TexFormat)i))) {
+            if (Strutil::iequals (textureformat, texture_format_name((TexFormat)i))) {
                 m_texformat = (TexFormat) i;
                 break;
             }


### PR DESCRIPTION
Also make the comparison on the other end case insensitive just to be safe.
Fixes #877
