### PR TITLE
CMake 3.0 compatibility:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,14 +40,14 @@ if (CMAKE_COMPILER_IS_GNUCC)
 endif ()
 message (STATUS "CMAKE_CXX_COMPILER is ${CMAKE_CXX_COMPILER}")
 message (STATUS "CMAKE_CXX_COMPILER_ID is ${CMAKE_CXX_COMPILER_ID}")
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set (CMAKE_COMPILER_IS_CLANG 1)
     message (STATUS "Using clang as the compiler")
 endif ()
 # Second try: for earlier versions of CMake, the CMAKE_CXX_COMPILER_ID
 # appears to be unreliable and may say "GNU" despite using clang, so
 # directly match against the compiler name.
-if ("${CMAKE_CXX_COMPILER}" MATCHES ".*clang.*")
+if (CMAKE_CXX_COMPILER MATCHES "[Cc]lang")
     set (CMAKE_COMPILER_IS_CLANG 1)
     message (STATUS "The compiler seems to be clang")
 endif ()

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -10,7 +10,7 @@ if (APPLE)
 endif ()
 
 # Disable some warnings for Clang, it's a little too picky with boost
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_definitions ("-Wno-array-bounds")
 endif ()
 


### PR DESCRIPTION
CMAKE_CXX_COMPILER_ID may be "AppleClang" rather than "Clang" if it's the
separately versioned Apple variety on OSX. Make the test robust to either
by using MATCHES instead of STREQUAL.
