### PR TITLE
Workaround for USE_CONCURRENT_MAP seg fault on 32 bit systems with gcc 4.2

### DIFF
--- a/src/libutil/ustring.cpp
+++ b/src/libutil/ustring.cpp
@@ -68,7 +68,20 @@ typedef null_lock<null_mutex> ustring_write_lock_t;
 #endif
 
 
+#if defined(__i386__) && !defined(__clang__) && !defined(_MSC_VER)
+#if ((10000*__GNUC__ + 100*__GNUC_MINOR__ + __GNUC_PATCHLEVEL__) < 40300)
+// On a 32bit build using gcc4.2, make_unique() seg faults with the
+// concurrent map enabled, so turn it off. More recent gcc seems ok. That
+// old a gcc on 32 bit systems is a pretty rare combination, so we're not
+// going to sweat the lower performance of turning off the concurrent map
+// for that increasingly rare case.
+#define USE_CONCURRENT_MAP 0
+#endif
+#endif
+
+#ifndef USE_CONCURRENT_MAP
 #define USE_CONCURRENT_MAP 1
+#endif
 
 #if USE_CONCURRENT_MAP
 typedef unordered_map_concurrent <string_view, ustring::TableRep *, Strutil::StringHash, Strutil::StringEqual, 8> UstringTable;


### PR DESCRIPTION
Very few people are on 32 bit systems, let alone using a gcc so old, so don't sweat the lower perf of turning USE_CONCURRENT_MAP off in that case.  It's not even worth trying to track down exactly what's wrong.

Also note that all we know is that it core dumps with gcc 4.2, and is fine with gcc 4.6 and 4.8. It's possible that we'll need to adjust the test to also exclude other old gcc's, but we'll cross that bridge when we get to it.
