### PR TITLE
Revisions to the new Filesystem functions

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -169,10 +169,10 @@ inline bool remove (string_view path) {
 }
 
 /// Remove the file or directory, including any children (recursively).
-/// Return true for success, false for failure and place an error message in
-/// err.
-OIIO_API bool remove_all (string_view path, std::string &err);
-inline bool remove_all (string_view path) {
+/// Return the number of files removed.  Place an error message (if
+/// applicable in err.
+OIIO_API unsigned long long remove_all (string_view path, std::string &err);
+inline unsigned long long remove_all (string_view path) {
     std::string err;
     return remove_all (path, err);
 }


### PR DESCRIPTION
1. I hadn't realized that the underlying boost::filesystem::remove_all
   (and C++1y std::filesystem::remove_all) returns the number of files
   removed, not a bool. So I changed our functions to conform.
2. I also didn't realize that in some cases I was using functions that
   are only in boost::filesystem v3.  I think this will affect the few
   users with boost versions older than 1.45 (that was 4 years ago), but
   nevertheless I have now put #if clauses to compile cleanly, and in most
   cases do something reasonable if only boost::filesystem v2 is available.
