### PR TITLE
oiiotool --wildcardoff / --wildcardon turn off and on numeric wildcard expansion

### DIFF
--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -51,6 +51,8 @@ an example:
 \smallskip
 
 \subsubsection*{Frame sequences}
+\index{frame sequences}\index{wildcard}
+\index{numeric frame sequence wildcards}
 
 It is also possible to have \oiiotool operate on numbered sequences of
 images.  In effect, this will execute the \oiiotool command several
@@ -105,6 +107,23 @@ Alternately, you can use the {\cf printf} notation, such as
 \begin{code}
     oiiotool --frames 3,4,10-20x2 blah.%03d.tif
 \end{code}
+
+\NEW % 1.5
+Two special command line arguments can be used to disable numeric wildcard
+expansion: {\cf --wildcardoff} disables numeric wildcard expansion for
+subsequent command line arguments, until {\cf --wildcardon} re-enables
+it for subsequent command line arguments. Turning wildcard expansion off
+for selected arguments can be helpful if you have arguments that must 
+contain the wildcard characters themselves. For example:
+
+\begin{code}
+    oiiotool input.@@@.tif --wildcardoff --sattrib Caption "lg@openimageio.org" \
+        --wildcardon -o output.@@@.tif
+\end{code}
+
+\noindent In this example, the `{\cf @}' characters in the filenames should
+be expanded into numeric file sequence wildcards, but the `{\cf @}' in the
+caption (denoting an email address) should not.
 
 \subsubsection*{Stereo wildcards}
 
@@ -673,6 +692,19 @@ For example,
 {\cf blah.010.tif}, {\cf blah.012.tif}, 
 {\cf blah.014.tif}, {\cf blah.016.tif}, {\cf blah.018.tif}, 
 {\cf blah.020.tif}.
+\apiend
+
+\apiitem{--views \emph{name1,name2,...}}
+Supplies a comma-separated list of view names (substituted for {\cf \%V}
+and {\cf \%v}). If not supplied, the view list will be {\cf left,right}.
+\apiend
+
+\apiitem{--wildcardoff \\
+--wildcardon}
+\NEW % 1.5
+Turns off (or on) numeric wildcard expansion for subsequent command
+line arguments. This can be useful in selectively disabling numeric wildcard
+expansion for a subset of the command line.
 \apiend
 
 \begin{comment}

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -3461,6 +3461,8 @@ getargs (int argc, char *argv[])
                 "--frames %s", NULL, "Frame range for '#' or printf-style wildcards",
                 "--framepadding %d", NULL, "Frame number padding digits (ignored when using printf-style wildcards)",
                 "--views %s", NULL, "Views for %V/%v wildcards (comma-separated, defaults to left,right)",
+                "--wildcardoff", NULL, "Disable numeric wildcard expansion for subsequent command line arguments",
+                "--wildcardon", NULL, "Enable numeric wildcard expansion for subsequent command line arguments",
                 "<SEPARATOR>", "Commands that write images:",
                 "-o %@ %s", output_file, NULL, "Output the current image to the named file",
                 "<SEPARATOR>", "Options that affect subsequent image output:",
@@ -3709,6 +3711,7 @@ handle_sequence (int argc, const char **argv)
     std::vector<int> sequence_args;  // Args with sequence numbers
     std::vector<bool> sequence_is_output;
     bool is_sequence = false;
+    bool wildcard_on = true;
     for (int a = 1;  a < argc;  ++a) {
         bool is_output = false;
         if (! strcmp (argv[a], "-o") && a < argc-1) {
@@ -3717,21 +3720,29 @@ handle_sequence (int argc, const char **argv)
         }
         std::string strarg (argv[a]);
         boost::match_results<std::string::const_iterator> range_match;
-        if (boost::regex_search (strarg, range_match, sequence_re)) {
-            is_sequence = true;
-            sequence_args.push_back (a);
-            sequence_is_output.push_back (is_output);
-        }
-        if (! strcmp (argv[a], "--frames") && a < argc-1) {
+        if ((strarg == "--frames" || strarg == "-frames") && a < argc-1) {
             framespec = argv[++a];
         }
-        else if (! strcmp (argv[a], "--framepadding") && a < argc-1) {
+        else if ((strarg == "--framepadding" || strarg == "-framepadding")
+                 && a < argc-1) {
             int f = atoi (argv[++a]);
             if (f >= 1 && f < 10)
                 framepadding = f;
         }
-        else if (! strcmp (argv[a], "--views") && a < argc-1) {
+        else if ((strarg == "--views" || strarg == "-views") && a < argc-1) {
             Strutil::split (argv[++a], views, ",");
+        }
+        else if (strarg == "--wildcardoff" || strarg == "-wildcardoff") {
+            wildcard_on = false;
+        }
+        else if (strarg == "--wildcardon" || strarg == "-wildcardon") {
+            wildcard_on = true;
+        }
+        else if (wildcard_on &&
+                 boost::regex_search (strarg, range_match, sequence_re)) {
+            is_sequence = true;
+            sequence_args.push_back (a);
+            sequence_is_output.push_back (is_output);
         }
     }
 


### PR DESCRIPTION
oiiotool --wildcardoff / --wildcardon turn off and on numeric wildcard expansion for subsequent command line arguments. You can have multiple on/off commands sprinkled among the arguments. The purpose is to be able to specify command line arguments with wildcard characters that are NOT expanded, for example if you are seeing a metadata attribute to contain an email address (whose '@' would ordinarily be recognized as a numeric wildcard).
