### PR TITLE
oiiotool --ch : if channel names don't match exactly, try case-insensitive.

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1377,6 +1377,13 @@ decode_channel_set (const ImageSpec &spec, std::string chanlist,
                 ch = i;
                 break;
             }
+        if (ch < 0) { // Didn't find a match? Try case-insensitive.
+            for (int i = 0;  i < spec.nchannels;  ++i)
+                if (Strutil::iequals (spec.channelnames[i], onechan)) {
+                    ch = i;
+                    break;
+                }
+        }
         if (ch < 0 && onechan.length() &&
                 (isdigit(onechan[0]) || onechan[0] == '-'))
             ch = atoi (onechan.c_str());  // numeric channel index


### PR DESCRIPTION
This alleviates unexpected behavior for, as an example, a file with
channels R,G,B where the user tries

```
oiiotool in.exr --ch r,g,b -o out.exr
```

Old behavior is, perplexingly, a black image, because no channel names
matched. New behavior is copying R,G,B. We first check for
case-sensitive match, so that if there is a file with mutiple channels
that differ only in case, it will find the exact match. Only when an
exact match is not found does it fall back on case-insensitive search
for the channel name.
