### PR TITLE
ImageCache fix for when searchpath is changed.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -61,6 +61,7 @@ Other contributors (alphabetically):
     Deepak Gopinath
     John Haddon
     Changlin Hsieh
+    Thiago Ize
     Puneet Jain
     Saket Jalan
     Pavel Karneliuk

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -247,7 +247,8 @@ ImageCacheFile::ImageCacheFile (ImageCacheImpl &imagecache,
       m_total_imagesize(0),
       m_inputcreator(creator)
 {
-    m_filename = imagecache.resolve_filename (m_filename.string());
+    m_filename_original = m_filename;
+    m_filename = imagecache.resolve_filename (m_filename_original.string());
     // N.B. the file is not opened, the ImageInput is NULL.  This is
     // reflected by the fact that m_validspec is false.
     m_Mlocal.makeIdentity();
@@ -937,6 +938,8 @@ ImageCacheFile::invalidate ()
     m_broken = false;
     m_fingerprint.clear ();
     duplicate (NULL);
+
+    m_filename = m_imagecache.resolve_filename (m_filename_original.string());
 
     // Eat any errors that occurred in the open/close
     while (! imagecache().geterror().empty())

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -272,6 +272,7 @@ public:
     }
     
 private:
+    ustring m_filename_original;    ///< original filename before search path
     ustring m_filename;             ///< Filename
     bool m_used;                    ///< Recently used (in the LRU sense)
     bool m_broken;                  ///< has errors; can't be used properly


### PR DESCRIPTION
(This comes from Thiago Ize, I'm just posting the pull request on his behalf.)

If textures aren't found in the searchpath (thus making "broken" records
for those files), then the searchpath is changed to include the directory
where they really were stored, the filenames were never updated.

The solution is to make invalidate() clear the searchpath-augmented
filename so that any altered searchpath is re-applied next time the file
is re-opened.
