### PR TITLE
Refactor the OIIO_DISPATCH macros.

### DIFF
--- a/src/doc/imagebuf.tex
+++ b/src/doc/imagebuf.tex
@@ -874,8 +874,10 @@ static bool make_black_impl (ImageBuf &buf, ROI region)
 
 bool make_black (ImageBuf &buf, ROI region)
 {
-    OIIO_DISPATCH_COMMON_TYPES ("make_black", make_black_impl,
+    bool ok;
+    OIIO_DISPATCH_COMMON_TYPES (ok, "make_black", make_black_impl,
                                  buf.spec().format, buf, region);
+    return ok;
 }
 \end{code}
 

--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -120,182 +120,203 @@ enum IBAprep_flags {
 
 
 // Macro to call a type-specialzed version func<type>(R,...)
-#define OIIO_DISPATCH_TYPES(name,func,type,R,...)                       \
+#define OIIO_DISPATCH_TYPES(ret,name,func,type,R,...)                   \
     switch (type.basetype) {                                            \
     case TypeDesc::FLOAT :                                              \
-        return func<float> (R, __VA_ARGS__); break;                     \
+        ret = func<float> (R, __VA_ARGS__); break;                      \
     case TypeDesc::UINT8 :                                              \
-        return func<unsigned char> (R, __VA_ARGS__); break;             \
+        ret = func<unsigned char> (R, __VA_ARGS__); break;              \
     case TypeDesc::HALF  :                                              \
-        return func<half> (R, __VA_ARGS__); break;                      \
+        ret = func<half> (R, __VA_ARGS__); break;                       \
     case TypeDesc::UINT16:                                              \
-        return func<unsigned short> (R, __VA_ARGS__); break;            \
+        ret = func<unsigned short> (R, __VA_ARGS__); break;             \
     case TypeDesc::INT8  :                                              \
-        return func<char> (R, __VA_ARGS__); break;                      \
+        ret = func<char> (R, __VA_ARGS__); break;                       \
     case TypeDesc::INT16 :                                              \
-        return func<short> (R, __VA_ARGS__); break;                     \
+        ret = func<short> (R, __VA_ARGS__); break;                      \
     case TypeDesc::UINT  :                                              \
-        return func<unsigned int> (R, __VA_ARGS__); break;              \
+        ret = func<unsigned int> (R, __VA_ARGS__); break;               \
     case TypeDesc::INT   :                                              \
-        return func<int> (R, __VA_ARGS__); break;                       \
+        ret = func<int> (R, __VA_ARGS__); break;                        \
     case TypeDesc::DOUBLE:                                              \
-        return func<double> (R, __VA_ARGS__); break;                    \
+        ret = func<double> (R, __VA_ARGS__); break;                     \
     default:                                                            \
         (R).error ("%s: Unsupported pixel data format '%s'", name, type); \
-        return false;                                                   \
+        ret = false;                                                    \
     }
 
 // Helper, do not call from the outside world.
-#define OIIO_DISPATCH_TYPES2_HELP(name,func,Atype,Btype,R,...)   \
+#define OIIO_DISPATCH_TYPES2_HELP(ret,name,func,Atype,Btype,R,...)      \
     switch (Btype.basetype) {                                           \
     case TypeDesc::FLOAT :                                              \
-        return func<Atype,float> (R, __VA_ARGS__); break;               \
+        ret = func<Atype,float> (R, __VA_ARGS__); break;                \
     case TypeDesc::UINT8 :                                              \
-        return func<Atype,unsigned char> (R, __VA_ARGS__); break;       \
+        ret = func<Atype,unsigned char> (R, __VA_ARGS__); break;        \
     case TypeDesc::HALF  :                                              \
-        return func<Atype,half> (R, __VA_ARGS__); break;                \
+        ret = func<Atype,half> (R, __VA_ARGS__); break;                 \
     case TypeDesc::UINT16:                                              \
-        return func<Atype,unsigned short> (R, __VA_ARGS__); break;      \
+        ret = func<Atype,unsigned short> (R, __VA_ARGS__); break;       \
     case TypeDesc::INT8 :                                               \
-        return func<Atype,char> (R, __VA_ARGS__); break;                \
+        ret = func<Atype,char> (R, __VA_ARGS__); break;                 \
     case TypeDesc::INT16 :                                              \
-        return func<Atype,short> (R, __VA_ARGS__); break;               \
+        ret = func<Atype,short> (R, __VA_ARGS__); break;                \
     case TypeDesc::UINT :                                               \
-        return func<Atype,unsigned int> (R, __VA_ARGS__); break;        \
+        ret = func<Atype,unsigned int> (R, __VA_ARGS__); break;         \
     case TypeDesc::INT :                                                \
-        return func<Atype,int> (R, __VA_ARGS__); break;                 \
+        ret = func<Atype,int> (R, __VA_ARGS__); break;                  \
     case TypeDesc::DOUBLE :                                             \
-        return func<Atype,double> (R, __VA_ARGS__); break;              \
+        ret = func<Atype,double> (R, __VA_ARGS__); break;               \
     default:                                                            \
         (R).error ("%s: Unsupported pixel data format '%s'", name, Btype); \
-        return false;                                                   \
+        ret = false;                                                    \
     }
 
 // Macro to call a type-specialzed version func<Atype,Btype>(R,...).
-#define OIIO_DISPATCH_TYPES2(name,func,Atype,Btype,R,...)               \
+#define OIIO_DISPATCH_TYPES2(ret,name,func,Atype,Btype,R,...)           \
     switch (Atype.basetype) {                                           \
     case TypeDesc::FLOAT :                                              \
-        OIIO_DISPATCH_TYPES2_HELP(name,func,float,Btype,R,__VA_ARGS__); \
+        OIIO_DISPATCH_TYPES2_HELP(ret,name,func,float,Btype,R,__VA_ARGS__); \
+        break;                                                          \
     case TypeDesc::UINT8 :                                              \
-        OIIO_DISPATCH_TYPES2_HELP(name,func,unsigned char,Btype,R,__VA_ARGS__); \
+        OIIO_DISPATCH_TYPES2_HELP(ret,name,func,unsigned char,Btype,R,__VA_ARGS__); \
+        break;                                                          \
     case TypeDesc::HALF  :                                              \
-        OIIO_DISPATCH_TYPES2_HELP(name,func,half,Btype,R,__VA_ARGS__);  \
+        OIIO_DISPATCH_TYPES2_HELP(ret,name,func,half,Btype,R,__VA_ARGS__);  \
+        break;                                                          \
     case TypeDesc::UINT16:                                              \
-        OIIO_DISPATCH_TYPES2_HELP(name,func,unsigned short,Btype,R,__VA_ARGS__); \
+        OIIO_DISPATCH_TYPES2_HELP(ret,name,func,unsigned short,Btype,R,__VA_ARGS__); \
+        break;                                                          \
     case TypeDesc::INT8:                                                \
-        OIIO_DISPATCH_TYPES2_HELP(name,func,char,Btype,R,__VA_ARGS__);  \
+        OIIO_DISPATCH_TYPES2_HELP(ret,name,func,char,Btype,R,__VA_ARGS__);  \
+        break;                                                          \
     case TypeDesc::INT16:                                               \
-        OIIO_DISPATCH_TYPES2_HELP(name,func,short,Btype,R,__VA_ARGS__); \
+        OIIO_DISPATCH_TYPES2_HELP(ret,name,func,short,Btype,R,__VA_ARGS__); \
+        break;                                                          \
     case TypeDesc::UINT:                                                \
-        OIIO_DISPATCH_TYPES2_HELP(name,func,unsigned int,Btype,R,__VA_ARGS__); \
+        OIIO_DISPATCH_TYPES2_HELP(ret,name,func,unsigned int,Btype,R,__VA_ARGS__); \
+        break;                                                          \
     case TypeDesc::INT:                                                 \
-        OIIO_DISPATCH_TYPES2_HELP(name,func,int,Btype,R,__VA_ARGS__);   \
+        OIIO_DISPATCH_TYPES2_HELP(ret,name,func,int,Btype,R,__VA_ARGS__); \
+        break;                                                          \
     case TypeDesc::DOUBLE:                                              \
-        OIIO_DISPATCH_TYPES2_HELP(name,func,double,Btype,R,__VA_ARGS__);\
+        OIIO_DISPATCH_TYPES2_HELP(ret,name,func,double,Btype,R,__VA_ARGS__);\
+        break;                                                          \
     default:                                                            \
         (R).error ("%s: Unsupported pixel data format '%s'", name, Atype); \
-        return false;                                                   \
+        ret = false;                                                    \
     }
 
 
 // Macro to call a type-specialzed version func<type>(R,...) for
 // the most common types, fail for anything else.
-#define OIIO_DISPATCH_COMMON_TYPES(name,func,type,R,...)                \
+#define OIIO_DISPATCH_COMMON_TYPES(ret,name,func,type,R,...)            \
     switch (type.basetype) {                                            \
     case TypeDesc::FLOAT :                                              \
-        return func<float> (R, __VA_ARGS__); break;                     \
+        ret = func<float> (R, __VA_ARGS__); break;                      \
     case TypeDesc::UINT8 :                                              \
-        return func<unsigned char> (R, __VA_ARGS__); break;             \
+        ret = func<unsigned char> (R, __VA_ARGS__); break;              \
     case TypeDesc::HALF  :                                              \
-        return func<half> (R, __VA_ARGS__); break;                      \
+        ret = func<half> (R, __VA_ARGS__); break;                       \
     case TypeDesc::UINT16:                                              \
-        return func<unsigned short> (R, __VA_ARGS__); break;            \
+        ret = func<unsigned short> (R, __VA_ARGS__); break;             \
     default:                                                            \
         (R).error ("%s: Unsupported pixel data format '%s'", name, type); \
-        return false;                                                   \
+        ret = false;                                                    \
     }
 
 // Helper, do not call from the outside world.
-#define OIIO_DISPATCH_COMMON_TYPES2_HELP(name,func,Atype,Btype,R,...)   \
+#define OIIO_DISPATCH_COMMON_TYPES2_HELP(ret,name,func,Atype,Btype,R,...) \
     switch (Btype.basetype) {                                           \
     case TypeDesc::FLOAT :                                              \
-        return func<Atype,float> (R, __VA_ARGS__); break;               \
+        ret = func<Atype,float> (R, __VA_ARGS__); break;                \
     case TypeDesc::UINT8 :                                              \
-        return func<Atype,unsigned char> (R, __VA_ARGS__); break;       \
+        ret = func<Atype,unsigned char> (R, __VA_ARGS__); break;        \
     case TypeDesc::HALF  :                                              \
-        return func<Atype,half> (R, __VA_ARGS__); break;                \
+        ret = func<Atype,half> (R, __VA_ARGS__); break;                 \
     case TypeDesc::UINT16:                                              \
-        return func<Atype,unsigned short> (R, __VA_ARGS__); break;      \
+        ret = func<Atype,unsigned short> (R, __VA_ARGS__); break;       \
     default:                                                            \
         (R).error ("%s: Unsupported pixel data format '%s'", name, Btype); \
-        return false;                                                   \
+        ret = false;                                                    \
     }
 
 // Macro to call a type-specialzed version func<Atype,Btype>(R,...) for
 // the most common types, fail for anything else.
-#define OIIO_DISPATCH_COMMON_TYPES2(name,func,Atype,Btype,R,...)        \
+#define OIIO_DISPATCH_COMMON_TYPES2(ret,name,func,Atype,Btype,R,...)    \
     switch (Atype.basetype) {                                           \
     case TypeDesc::FLOAT :                                              \
-        OIIO_DISPATCH_COMMON_TYPES2_HELP(name,func,float,Btype,R,__VA_ARGS__); \
+        OIIO_DISPATCH_COMMON_TYPES2_HELP(ret,name,func,float,Btype,R,__VA_ARGS__); \
+        break;                                                          \
     case TypeDesc::UINT8 :                                              \
-        OIIO_DISPATCH_COMMON_TYPES2_HELP(name,func,unsigned char,Btype,R,__VA_ARGS__); \
+        OIIO_DISPATCH_COMMON_TYPES2_HELP(ret,name,func,unsigned char,Btype,R,__VA_ARGS__); \
+        break;                                                          \
     case TypeDesc::HALF  :                                              \
-        OIIO_DISPATCH_COMMON_TYPES2_HELP(name,func,half,Btype,R,__VA_ARGS__); \
+        OIIO_DISPATCH_COMMON_TYPES2_HELP(ret,name,func,half,Btype,R,__VA_ARGS__); \
+        break;                                                          \
     case TypeDesc::UINT16:                                              \
-        OIIO_DISPATCH_COMMON_TYPES2_HELP(name,func,unsigned short,Btype,R,__VA_ARGS__); \
+        OIIO_DISPATCH_COMMON_TYPES2_HELP(ret,name,func,unsigned short,Btype,R,__VA_ARGS__); \
+        break;                                                          \
     default:                                                            \
         (R).error ("%s: Unsupported pixel data format '%s'", name, Atype); \
-        return false;                                                   \
+        ret = false;                                                    \
     }
 
 
 // Helper, do not call from the outside world.
-#define OIIO_DISPATCH_COMMON_TYPES3_HELP2(name,func,Rtype,Atype,Btype,R,...) \
+#define OIIO_DISPATCH_COMMON_TYPES3_HELP2(ret,name,func,Rtype,Atype,Btype,R,...) \
     switch (Rtype.basetype) {                                           \
     case TypeDesc::FLOAT :                                              \
-        return func<float,Atype,Btype> (R, __VA_ARGS__); break;         \
+        ret = func<float,Atype,Btype> (R, __VA_ARGS__); break;          \
     case TypeDesc::UINT8 :                                              \
-        return func<unsigned char,Atype,Btype> (R, __VA_ARGS__); break; \
+        ret = func<unsigned char,Atype,Btype> (R, __VA_ARGS__); break;  \
     case TypeDesc::HALF  :                                              \
-        return func<half,Atype,Btype> (R, __VA_ARGS__); break;          \
+        ret = func<half,Atype,Btype> (R, __VA_ARGS__); break;           \
     case TypeDesc::UINT16:                                              \
-        return func<unsigned short,Atype,Btype> (R, __VA_ARGS__); break; \
+        ret = func<unsigned short,Atype,Btype> (R, __VA_ARGS__); break;  \
     default:                                                            \
         (R).error ("%s: Unsupported pixel data format '%s'", name, Rtype); \
-        return false;                                                   \
+        ret = false;                                                    \
     }
 
 // Helper, do not call from the outside world.
-#define OIIO_DISPATCH_COMMON_TYPES3_HELP(name,func,Rtype,Atype,Btype,R,...) \
+#define OIIO_DISPATCH_COMMON_TYPES3_HELP(ret,name,func,Rtype,Atype,Btype,R,...) \
     switch (Btype.basetype) {                                           \
     case TypeDesc::FLOAT :                                              \
-        OIIO_DISPATCH_COMMON_TYPES3_HELP2(name,func,Rtype,Atype,float,R,__VA_ARGS__); \
+        OIIO_DISPATCH_COMMON_TYPES3_HELP2(ret,name,func,Rtype,Atype,float,R,__VA_ARGS__); \
+        break;                                                          \
     case TypeDesc::UINT8 :                                              \
-        OIIO_DISPATCH_COMMON_TYPES3_HELP2(name,func,Rtype,Atype,unsigned char,R,__VA_ARGS__); \
+        OIIO_DISPATCH_COMMON_TYPES3_HELP2(ret,name,func,Rtype,Atype,unsigned char,R,__VA_ARGS__); \
+        break;                                                          \
     case TypeDesc::HALF :                                               \
-        OIIO_DISPATCH_COMMON_TYPES3_HELP2(name,func,Rtype,Atype,half,R,__VA_ARGS__); \
+        OIIO_DISPATCH_COMMON_TYPES3_HELP2(ret,name,func,Rtype,Atype,half,R,__VA_ARGS__); \
+        break;                                                          \
     case TypeDesc::UINT16 :                                             \
-        OIIO_DISPATCH_COMMON_TYPES3_HELP2(name,func,Rtype,Atype,unsigned short,R,__VA_ARGS__); \
+        OIIO_DISPATCH_COMMON_TYPES3_HELP2(ret,name,func,Rtype,Atype,unsigned short,R,__VA_ARGS__); \
+        break;                                                          \
     default:                                                            \
         (R).error ("%s: Unsupported pixel data format '%s'", name, Btype); \
-        return false;                                                   \
+        ret = false;                                                    \
     }
 
 // Macro to call a type-specialzed version func<Rtype,Atype,Btype>(R,...)
 // for the most common types, fail for anything else.
-#define OIIO_DISPATCH_COMMON_TYPES3(name,func,Rtype,Atype,Btype,R,...)  \
+#define OIIO_DISPATCH_COMMON_TYPES3(ret,name,func,Rtype,Atype,Btype,R,...)  \
     switch (Atype.basetype) {                                           \
     case TypeDesc::FLOAT :                                              \
-        OIIO_DISPATCH_COMMON_TYPES3_HELP(name,func,Rtype,float,Btype,R,__VA_ARGS__); \
+        OIIO_DISPATCH_COMMON_TYPES3_HELP(ret,name,func,Rtype,float,Btype,R,__VA_ARGS__); \
+        break;                                                          \
     case TypeDesc::UINT8 :                                              \
-        OIIO_DISPATCH_COMMON_TYPES3_HELP(name,func,Rtype,unsigned char,Btype,R,__VA_ARGS__); \
+        OIIO_DISPATCH_COMMON_TYPES3_HELP(ret,name,func,Rtype,unsigned char,Btype,R,__VA_ARGS__); \
+        break;                                                          \
     case TypeDesc::HALF  :                                              \
-        OIIO_DISPATCH_COMMON_TYPES3_HELP(name,func,Rtype,half,Btype,R,__VA_ARGS__); \
+        OIIO_DISPATCH_COMMON_TYPES3_HELP(ret,name,func,Rtype,half,Btype,R,__VA_ARGS__); \
+        break;                                                          \
     case TypeDesc::UINT16:                                              \
-        OIIO_DISPATCH_COMMON_TYPES3_HELP(name,func,Rtype,unsigned short,Btype,R,__VA_ARGS__); \
+        OIIO_DISPATCH_COMMON_TYPES3_HELP(ret,name,func,Rtype,unsigned short,Btype,R,__VA_ARGS__); \
+        break;                                                          \
     default:                                                            \
         (R).error ("%s: Unsupported pixel data format '%s'", name, Atype); \
-        return false;                                                   \
+        ret = false;                                                    \
     }
 
 

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1229,9 +1229,10 @@ ImageBuf::copy_pixels (const ImageBuf &src)
     if (roi != myroi)
         ImageBufAlgo::zero (*this);
 
-    OIIO_DISPATCH_TYPES2 ("copy_pixels", copy_pixels_2,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "copy_pixels", copy_pixels_2,
                           spec().format, src.spec().format, *this, src, roi);
-    return true;
+    return ok;
 }
 
 
@@ -1267,8 +1268,10 @@ ImageBuf::getchannel (int x, int y, int z, int c, WrapMode wrap) const
 {
     if (c < 0 || c >= spec().nchannels)
         return 0.0f;
-    OIIO_DISPATCH_TYPES ("getchannel", getchannel_, spec().format,
+    float ret;
+    OIIO_DISPATCH_TYPES (ret, "getchannel", getchannel_, spec().format,
                          *this, x, y, z, c, wrap);
+    return ret;
 }
 
 
@@ -1290,8 +1293,10 @@ inline bool
 getpixel_wrapper (int x, int y, int z, float *pixel, int nchans,
                   ImageBuf::WrapMode wrap, const ImageBuf &ib)
 {
-    OIIO_DISPATCH_TYPES ("getpixel", getpixel_, ib.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES (ok, "getpixel", getpixel_, ib.spec().format,
                          ib, x, y, z, pixel, nchans, wrap);
+    return ok;
 }
 
 
@@ -1335,8 +1340,10 @@ inline bool
 interppixel_wrapper (float x, float y, float *pixel,
                      ImageBuf::WrapMode wrap, const ImageBuf &img)
 {
-    OIIO_DISPATCH_TYPES ("interppixel", interppixel_, img.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES (ok, "interppixel", interppixel_, img.spec().format,
                          img, x, y, pixel, wrap);
+    return ok;
 }
 
 
@@ -1417,7 +1424,7 @@ ImageBuf::setpixel (int i, const float *pixel, int maxchannels)
 
 
 template<typename D, typename S>
-static inline bool 
+static bool
 get_pixel_channels_ (const ImageBuf &buf, int xbegin, int xend,
                      int ybegin, int yend, int zbegin, int zend, 
                      int chbegin, int chend, void *r_,
@@ -1448,10 +1455,12 @@ ImageBuf::get_pixel_channels (int xbegin, int xend, int ybegin, int yend,
                               stride_t xstride, stride_t ystride,
                               stride_t zstride) const
 {
-    OIIO_DISPATCH_TYPES2_HELP ("get_pixel_channels", get_pixel_channels_,
+    bool ok;
+    OIIO_DISPATCH_TYPES2_HELP (ok, "get_pixel_channels", get_pixel_channels_,
                                D, spec().format, *this,
                                xbegin, xend, ybegin, yend, zbegin, zend,
                                chbegin, chend, r, xstride, ystride, zstride);
+    return ok;
 }
 
 
@@ -1463,10 +1472,12 @@ ImageBuf::get_pixel_channels (int xbegin, int xend, int ybegin, int yend,
                               stride_t xstride, stride_t ystride,
                               stride_t zstride) const
 {
-    OIIO_DISPATCH_TYPES2 ("get_pixel_channels", get_pixel_channels_,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "get_pixel_channels", get_pixel_channels_,
                           format, spec().format, *this,
                           xbegin, xend, ybegin, yend, zbegin, zend,
                           chbegin, chend, result, xstride, ystride, zstride);
+    return ok;
 }
 
 

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -249,9 +249,10 @@ ImageBufAlgo::fill (ImageBuf &dst, const float *pixel, ROI roi, int nthreads)
     ASSERT (pixel && "fill must have a non-NULL pixel value pointer");
     if (! IBAprep (roi, &dst))
         return false;
-    OIIO_DISPATCH_TYPES ("fill", fill_, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES (ok, "fill", fill_, dst.spec().format,
                          dst, pixel, roi, nthreads);
-    return true;
+    return ok;
 }
 
 
@@ -310,10 +311,11 @@ ImageBufAlgo::checker (ImageBuf &dst, int width, int height, int depth,
 {
     if (! IBAprep (roi, &dst))
         return false;
-    OIIO_DISPATCH_TYPES ("checker", checker_, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES (ok, "checker", checker_, dst.spec().format,
                          dst, Dim3(width, height, depth), color1, color2,
                          Dim3(xoffset, yoffset, zoffset), roi, nthreads);
-    return true;
+    return ok;
 }
 
 
@@ -539,11 +541,11 @@ ImageBufAlgo::resize (ImageBuf &dst, const ImageBuf &src,
         filterptr.reset (filter);
     }
 
-    OIIO_DISPATCH_TYPES2 ("resize", resize_,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "resize", resize_,
                           dst.spec().format, src.spec().format,
                           dst, src, filter, roi, nthreads);
-
-    return false;
+    return ok;
 }
 
 
@@ -597,11 +599,11 @@ ImageBufAlgo::resize (ImageBuf &dst, const ImageBuf &src,
         return false;
     }
 
-    OIIO_DISPATCH_TYPES2 ("resize", resize_,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "resize", resize_,
                           dstspec.format, srcspec.format,
                           dst, src, filter.get(), roi, nthreads);
-
-    return false;
+    return ok;
 }
 
 
@@ -690,10 +692,11 @@ ImageBufAlgo::resample (ImageBuf &dst, const ImageBuf &src,
         dst.error ("ImageBufAlgo::resample does not support volume images");
         return false;
     }
-    OIIO_DISPATCH_TYPES2 ("resample", resample_,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "resample", resample_,
                           dst.spec().format, src.spec().format,
                           dst, src, interpolate, roi, nthreads);
-    return false;
+    return ok;
 }
 
 
@@ -760,10 +763,11 @@ ImageBufAlgo::convolve (ImageBuf &dst, const ImageBuf &src,
                    dst.spec().nchannels, src.spec().nchannels);
         return false;
     }
-    OIIO_DISPATCH_TYPES2 ("convolve", convolve_,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "convolve", convolve_,
                           dst.spec().format, src.spec().format,
                           dst, src, kernel, normalize, roi, nthreads);
-    return false;
+    return ok;
 }
 
 
@@ -1163,9 +1167,11 @@ ImageBufAlgo::polar_to_complex (ImageBuf &dst, const ImageBuf &src,
         dst.error ("polar_to_complex can only be done on 2-channel");
         return false;
     }
-    OIIO_DISPATCH_COMMON_TYPES2 ("polar_to_complex", polar_to_complex_impl, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "polar_to_complex",
+                                 polar_to_complex_impl, dst.spec().format,
                                  src.spec().format, dst, src, roi, nthreads);
-    return true;
+    return ok;
 }
 
 
@@ -1186,9 +1192,11 @@ ImageBufAlgo::complex_to_polar (ImageBuf &dst, const ImageBuf &src,
         dst.error ("complex_to_polar can only be done on 2-channel");
         return false;
     }
-    OIIO_DISPATCH_COMMON_TYPES2 ("complex_to_polar", complex_to_polar_impl, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "complex_to_polar",
+                                 complex_to_polar_impl, dst.spec().format,
                                  src.spec().format, dst, src, roi, nthreads);
-    return true;
+    return ok;
 }
 
 

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -223,9 +223,10 @@ ImageBufAlgo::computePixelStats (PixelStats &stats, const ImageBuf &src,
         return false;
     }
 
-    OIIO_DISPATCH_TYPES ("computePixelStats", computePixelStats_,
+    bool ok;
+    OIIO_DISPATCH_TYPES (ok, "computePixelStats", computePixelStats_,
                          src.spec().format, src, stats, roi, nthreads);
-    return false;
+    return ok;
 }
 
 
@@ -337,14 +338,15 @@ ImageBufAlgo::compare (const ImageBuf &A, const ImageBuf &B,
     if (B.deep() != A.deep())
         return false;
 
-    OIIO_DISPATCH_TYPES2 ("compare", compare_,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "compare", compare_,
                           A.spec().format, B.spec().format,
                           A, B, failthresh, warnthresh, result,
                           roi, nthreads);
     // FIXME - The nthreads argument is for symmetry with the rest of
     // ImageBufAlgo and for future expansion. But for right now, we
     // don't actually split by threads.  Maybe later.
-    return false;
+    return ok;
 }
 
 
@@ -394,8 +396,10 @@ ImageBufAlgo::isConstantColor (const ImageBuf &src, float *color,
     if (roi.nchannels() == 0)
         return true;
     
-    OIIO_DISPATCH_TYPES ("isConstantColor", isConstantColor_,
+    bool ok;
+    OIIO_DISPATCH_TYPES (ok, "isConstantColor", isConstantColor_,
                          src.spec().format, src, color, roi, nthreads);
+    return ok;
     // FIXME -  The nthreads argument is for symmetry with the rest of
     // ImageBufAlgo and for future expansion. But for right now, we
     // don't actually split by threads.  Maybe later.
@@ -428,8 +432,10 @@ ImageBufAlgo::isConstantChannel (const ImageBuf &src, int channel, float val,
     if (channel < 0 || channel >= src.nchannels())
         return false;  // that channel doesn't exist in the image
 
-    OIIO_DISPATCH_TYPES ("isConstantChannel", isConstantChannel_,
+    bool ok;
+    OIIO_DISPATCH_TYPES (ok, "isConstantChannel", isConstantChannel_,
                          src.spec().format, src, channel, val, roi, nthreads);
+    return ok;
     // FIXME -  The nthreads argument is for symmetry with the rest of
     // ImageBufAlgo and for future expansion. But for right now, we
     // don't actually split by threads.  Maybe later.
@@ -466,8 +472,10 @@ ImageBufAlgo::isMonochrome (const ImageBuf &src, ROI roi, int nthreads)
     if (roi.nchannels() < 2)
         return true;  // 1 or fewer channels are always "monochrome"
 
-    OIIO_DISPATCH_TYPES ("isMonochrome", isMonochrome_, src.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES (ok, "isMonochrome", isMonochrome_, src.spec().format,
                          src, roi, nthreads);
+    return ok;
     // FIXME -  The nthreads argument is for symmetry with the rest of
     // ImageBufAlgo and for future expansion. But for right now, we
     // don't actually split by threads.  Maybe later.
@@ -537,9 +545,11 @@ ImageBufAlgo::color_count (const ImageBuf &src, imagesize_t *count,
 
     for (int col = 0;  col < ncolors;  ++col)
         count[col] = 0;
-    OIIO_DISPATCH_TYPES ("color_count", color_count_, src.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES (ok, "color_count", color_count_, src.spec().format,
                          src, (atomic_ll *)count, ncolors, color, eps,
                          roi, nthreads);
+    return ok;
 }
 
 
@@ -607,11 +617,13 @@ ImageBufAlgo::color_range_check (const ImageBuf &src, imagesize_t *lowcount,
         *highcount = 0;
     if (inrangecount)
         *inrangecount = 0;
-    OIIO_DISPATCH_TYPES ("color_range_check", color_range_check_,
+    bool ok;
+    OIIO_DISPATCH_TYPES (ok, "color_range_check", color_range_check_,
                          src.spec().format,
                          src, (atomic_ll *)lowcount, 
                          (atomic_ll *)highcount, (atomic_ll *)inrangecount,
                          low, high, roi, nthreads);
+    return ok;
 }
 
 

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -97,9 +97,10 @@ ImageBufAlgo::paste (ImageBuf &dst, int xbegin, int ybegin,
     IBAprep (dstroi, &dst);
 
     // do the actual copying
-    OIIO_DISPATCH_TYPES2 ("paste", paste_, dst.spec().format, src.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "paste", paste_, dst.spec().format, src.spec().format,
                           dst, dstroi_save, src, srcroi, nthreads);
-    return false;
+    return ok;
 }
 
 
@@ -138,9 +139,10 @@ ImageBufAlgo::crop (ImageBuf &dst, const ImageBuf &src,
     dst.clear ();
     roi.chend = std::min (roi.chend, src.nchannels());
     IBAprep (roi, &dst, &src);
-    OIIO_DISPATCH_TYPES2 ("crop", crop_, dst.spec().format, src.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "crop", crop_, dst.spec().format, src.spec().format,
                           dst, src, roi, nthreads);
-    return false;
+    return ok;
 }
 
 
@@ -184,10 +186,11 @@ bool
 ImageBufAlgo::flip(ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
 {
     IBAprep (roi, &dst, &src);
-    OIIO_DISPATCH_TYPES2 ("flip", flip_,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "flip", flip_,
                           dst.spec().format, src.spec().format, dst, src,
                           roi, nthreads);
-    return false;
+    return ok;
 }
 
 
@@ -211,10 +214,11 @@ bool
 ImageBufAlgo::flop (ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
 {
     IBAprep (roi, &dst, &src);
-    OIIO_DISPATCH_TYPES2 ("flop", flop_,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "flop", flop_,
                           dst.spec().format, src.spec().format, dst, src,
                           roi, nthreads);
-    return false;
+    return ok;
 }
 
 
@@ -241,10 +245,11 @@ ImageBufAlgo::flipflop (ImageBuf &dst, const ImageBuf &src,
                         ROI roi, int nthreads)
 {
     IBAprep (roi, &dst, &src);
-    OIIO_DISPATCH_TYPES2 ("flipflop", flipflop_,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "flipflop", flipflop_,
                           dst.spec().format, src.spec().format, dst, src,
                           roi, nthreads);
-    return false;
+    return ok;
 }
 
 
@@ -289,9 +294,10 @@ ImageBufAlgo::transpose (ImageBuf &dst, const ImageBuf &src,
     ROI dst_roi (roi.ybegin, roi.yend, roi.xbegin, roi.xend,
                  roi.zbegin, roi.zend, roi.chbegin, roi.chend);
     IBAprep (dst_roi, &dst);
-    OIIO_DISPATCH_TYPES2 ("transpose", transpose_, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "transpose", transpose_, dst.spec().format,
                           src.spec().format, dst, src, roi, nthreads);
-    return false;
+    return ok;
 }
 
 
@@ -338,10 +344,11 @@ ImageBufAlgo::circular_shift (ImageBuf &dst, const ImageBuf &src,
                               ROI roi, int nthreads)
 {
     IBAprep (roi, &dst, &src);
-    OIIO_DISPATCH_TYPES2 ("circular_shift", circular_shift_,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "circular_shift", circular_shift_,
                           dst.spec().format, src.spec().format, dst, src,
                           xshift, yshift, zshift, roi, roi, nthreads);
-    return false;
+    return ok;
 }
 
 
@@ -522,9 +529,10 @@ ImageBufAlgo::channel_append (ImageBuf &dst, const ImageBuf &A,
         return false;
     }
 
-    OIIO_DISPATCH_TYPES ("channel_append", channel_append_impl,
+    bool ok;
+    OIIO_DISPATCH_TYPES (ok, "channel_append", channel_append_impl,
                          A.spec().format, dst, A, B, roi, nthreads);
-    return true;
+    return ok;
 }
 
 

--- a/src/libOpenImageIO/imagebufalgo_deep.cpp
+++ b/src/libOpenImageIO/imagebufalgo_deep.cpp
@@ -181,9 +181,10 @@ ImageBufAlgo::flatten (ImageBuf &dst, const ImageBuf &src,
         return false;
     }
 
-    OIIO_DISPATCH_TYPES ("flatten", flatten_, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES (ok, "flatten", flatten_, dst.spec().format,
                          dst, src, roi, nthreads);
-    return false;
+    return ok;
 }
 
 

--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -101,10 +101,11 @@ ImageBufAlgo::clamp (ImageBuf &dst, const ImageBuf &src,
         maxvec.resize (dst.nchannels(), std::numeric_limits<float>::max());
         max = &maxvec[0];
     }
-    OIIO_DISPATCH_TYPES2 ("clamp", clamp_, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "clamp", clamp_, dst.spec().format,
                           src.spec().format, dst, src,
                           min, max, clampalpha01, roi, nthreads);
-    return false;
+    return ok;
 }
 
 
@@ -198,10 +199,11 @@ ImageBufAlgo::add (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
 {
     if (! IBAprep (roi, &dst, &A, &B))
         return false;
-    OIIO_DISPATCH_COMMON_TYPES3 ("add", add_impl, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_COMMON_TYPES3 (ok, "add", add_impl, dst.spec().format,
                                  A.spec().format, B.spec().format,
                                  dst, A, B, roi, nthreads);
-    return true;
+    return ok;
 }
 
 
@@ -212,9 +214,10 @@ ImageBufAlgo::add (ImageBuf &dst, const ImageBuf &A, const float *b,
 {
     if (! IBAprep (roi, &dst, &A))
         return false;
-    OIIO_DISPATCH_TYPES2 ("add", add_impl, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "add", add_impl, dst.spec().format,
                           A.spec().format, dst, A, b, roi, nthreads);
-    return true;
+    return ok;
 }
 
 
@@ -229,8 +232,10 @@ ImageBufAlgo::add (ImageBuf &dst, const ImageBuf &A, float b,
     float *vals = ALLOCA (float, nc);
     for (int c = 0;  c < nc;  ++c)
         vals[c] = b;
-    OIIO_DISPATCH_TYPES2 ("add", add_impl, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "add", add_impl, dst.spec().format,
                           A.spec().format, dst, A, vals, roi, nthreads);
+    return ok;
 }
 
 
@@ -285,10 +290,11 @@ ImageBufAlgo::sub (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
 {
     if (! IBAprep (roi, &dst, &A, &B))
         return false;
-    OIIO_DISPATCH_COMMON_TYPES3 ("sub", sub_impl, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_COMMON_TYPES3 (ok, "sub", sub_impl, dst.spec().format,
                                  A.spec().format, B.spec().format,
                                  dst, A, B, roi, nthreads);
-    return true;
+    return ok;
 }
 
 
@@ -303,9 +309,10 @@ ImageBufAlgo::sub (ImageBuf &dst, const ImageBuf &A, const float *b,
     float *vals = ALLOCA (float, nc);
     for (int c = 0;  c < nc;  ++c)
         vals[c] = -b[c];
-    OIIO_DISPATCH_TYPES2 ("sub", add_impl, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "sub", add_impl, dst.spec().format,
                           A.spec().format, dst, A, vals, roi, nthreads);
-    return true;
+    return ok;
 }
 
 
@@ -320,8 +327,10 @@ ImageBufAlgo::sub (ImageBuf &dst, const ImageBuf &A, float b,
     float *vals = ALLOCA (float, nc);
     for (int c = 0;  c < nc;  ++c)
         vals[c] = -b;
-    OIIO_DISPATCH_TYPES2 ("sub", add_impl, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "sub", add_impl, dst.spec().format,
                           A.spec().format, dst, A, vals, roi, nthreads);
+    return ok;
 }
 
 
@@ -359,10 +368,11 @@ ImageBufAlgo::mul (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
 {
     if (! IBAprep (roi, &dst, &A, &B))
         return false;
-    OIIO_DISPATCH_COMMON_TYPES3 ("mul", mul_impl, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_COMMON_TYPES3 (ok, "mul", mul_impl, dst.spec().format,
                                  A.spec().format, B.spec().format,
                                  dst, A, B, roi, nthreads);
-    return true;
+    return ok;
 }
 
 
@@ -395,9 +405,10 @@ ImageBufAlgo::mul (ImageBuf &dst, const ImageBuf &A, const float *b,
 {
     if (! IBAprep (roi, &dst, &A))
         return false;
-    OIIO_DISPATCH_TYPES2 ("mul", mul_impl, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "mul", mul_impl, dst.spec().format,
                           A.spec().format, dst, A, b, roi, nthreads);
-    return true;
+    return ok;
 }
 
 
@@ -412,8 +423,10 @@ ImageBufAlgo::mul (ImageBuf &dst, const ImageBuf &A, float b,
     float *vals = ALLOCA (float, nc);
     for (int c = 0;  c < nc;  ++c)
         vals[c] = b;
-    OIIO_DISPATCH_TYPES2 ("mul", mul_impl, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "mul", mul_impl, dst.spec().format,
                           A.spec().format, dst, A, vals, roi, nthreads);
+    return ok;
 }
 
 
@@ -463,9 +476,10 @@ ImageBufAlgo::pow (ImageBuf &dst, const ImageBuf &A, const float *b,
 {
     if (! IBAprep (roi, &dst, &A))
         return false;
-    OIIO_DISPATCH_TYPES2 ("pow", pow_impl, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "pow", pow_impl, dst.spec().format,
                           A.spec().format, dst, A, b, roi, nthreads);
-    return true;
+    return ok;
 }
 
 
@@ -480,8 +494,10 @@ ImageBufAlgo::pow (ImageBuf &dst, const ImageBuf &A, float b,
     float *vals = ALLOCA (float, nc);
     for (int c = 0;  c < nc;  ++c)
         vals[c] = b;
-    OIIO_DISPATCH_TYPES2 ("pow", pow_impl, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "pow", pow_impl, dst.spec().format,
                           A.spec().format, dst, A, vals, roi, nthreads);
+    return ok;
 }
 
 
@@ -535,10 +551,11 @@ ImageBufAlgo::channel_sum (ImageBuf &dst, const ImageBuf &src,
         weights = &local_weights[0];
     }
 
-    OIIO_DISPATCH_TYPES2 ("channel_sum", channel_sum_,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "channel_sum", channel_sum_,
                           dst.spec().format, src.spec().format,
                           dst, src, weights, roi, nthreads);
-    return false;
+    return ok;
 }
 
 
@@ -739,10 +756,11 @@ ImageBufAlgo::rangecompress (ImageBuf &dst, const ImageBuf &src,
     }
     if (! IBAprep (roi, &dst, &src))
         return false;
-    OIIO_DISPATCH_TYPES2 ("rangecompress", rangecompress_,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "rangecompress", rangecompress_,
                           dst.spec().format, src.spec().format,
                           dst, src, useluma, roi, nthreads);
-    return true;
+    return ok;
 }
 
 
@@ -757,10 +775,11 @@ ImageBufAlgo::rangeexpand (ImageBuf &dst, const ImageBuf &src,
     }
     if (! IBAprep (roi, &dst))
         return false;
-    OIIO_DISPATCH_TYPES2 ("rangeexpand", rangeexpand_,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "rangeexpand", rangeexpand_,
                           dst.spec().format, src.spec().format,
                           dst, src, useluma, roi, nthreads);
-    return true;
+    return ok;
 }
 
 
@@ -841,9 +860,10 @@ ImageBufAlgo::unpremult (ImageBuf &dst, const ImageBuf &src,
                           roi.chbegin, src, roi, nthreads);
         return true;
     }
-    OIIO_DISPATCH_TYPES2 ("unpremult", unpremult_, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "unpremult", unpremult_, dst.spec().format,
                           src.spec().format, dst, src, roi, nthreads);
-    return true;
+    return ok;
 }
 
 
@@ -909,9 +929,10 @@ ImageBufAlgo::premult (ImageBuf &dst, const ImageBuf &src,
                           roi.chbegin, src, roi, nthreads);
         return true;
     }
-    OIIO_DISPATCH_TYPES2 ("premult", premult_, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_TYPES2 (ok, "premult", premult_, dst.spec().format,
                           src.spec().format, dst, src, roi, nthreads);
-    return true;
+    return ok;
 }
 
 
@@ -1172,7 +1193,8 @@ ImageBufAlgo::over (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
     if (! IBAprep (roi, &dst, &A, &B, NULL,
                    IBAprep_REQUIRE_ALPHA | IBAprep_REQUIRE_SAME_NCHANNELS))
         return false;
-    OIIO_DISPATCH_COMMON_TYPES3 ("over", over_impl, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_COMMON_TYPES3 (ok, "over", over_impl, dst.spec().format,
                                  A.spec().format, B.spec().format,
                                  dst, A, B, false, false, roi, nthreads);
     return ! dst.has_error();
@@ -1188,7 +1210,8 @@ ImageBufAlgo::zover (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
                    IBAprep_REQUIRE_ALPHA | IBAprep_REQUIRE_Z |
                    IBAprep_REQUIRE_SAME_NCHANNELS))
         return false;
-    OIIO_DISPATCH_COMMON_TYPES3 ("zover", over_impl, dst.spec().format,
+    bool ok;
+    OIIO_DISPATCH_COMMON_TYPES3 (ok, "zover", over_impl, dst.spec().format,
                                  A.spec().format, B.spec().format,
                                  dst, A, B, true, z_zeroisinf, roi, nthreads);
     return ! dst.has_error();


### PR DESCRIPTION
Previously, they cause a return. Now they set a variable with the return
value. This is helpful for functions that want to dispatch, and then
do more work without a forced return.

This makes use of these macros a bit more flexible.

This is all internal to OIIO, by the way. This isn't a public API.
