### PR TITLE
Add ICC color profile extraction to jpeg, tiff and png

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -47,7 +47,13 @@ Fixes, minor enhancements, and performance improvements:
      for OpenEXR output. #907 (1.5.1/1.4.11)
    * Improved ordering of channel names for OpenEXR files with many
      "layers".  #904 (1.5.1/1.4.11)
-* JPEG: Fix broken recognition of .jfi extension. (#876)
+* JPEG:
+   * Fix broken recognition of .jfi extension. (#876)
+   * Read and write ICC profiles as attribute "ICCProfile". (#911)
+* PNG:
+   * Read and write ICC profiles as attribute "ICCProfile". (#911)
+* TIFF:
+   * Read and write ICC profiles as attribute "ICCProfile". (#911)
 * RAW: Fix for portrait-orientation image reads. (#878) (1.5.1/1.4.10)
 * RLA: Fix bug that caused RLA output to not respect requests for 10 bit
   output (would force it to 16 in that case). #899 (1.5.1)

--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -434,8 +434,8 @@ anywhere near the acceptance of the original JPEG/JFIF format.
 \qkw{ImageDescription} & string & the JPEG Comment field \\
 \qkw{Orientation} & int & the image orientation \\[2ex]
 \qkw{XResolution}, \qkw{YResolution},
-\qkw{ResolutionUnit} & & The resolution and units from the Exif header
-\\
+\qkw{ResolutionUnit} & & The resolution and units from the Exif header \\[2ex]
+\qkw{ICCProfile} & uint8[] & The ICC color profile \\
 & & \\
 Exif, IPTC, XMP, GPS & & Extensive Exif, IPTC, XMP, and GPS data are supported by the
   reader/writer, and you should assume that nearly everything described
@@ -584,7 +584,8 @@ PNG files use the file extension {\cf .png}.
 \qkw{DateTime} & string & the timestamp in the PNG header \\
 \qkw{PixelAspectRatio} & float & pixel aspect ratio \\
 \qkw{XResolution} \qkw{YResolution}
-  \qkw{ResolutionUnit} & & resolution and units from the PNG header. 
+  \qkw{ResolutionUnit} & & resolution and units from the PNG header. \\
+\qkw{ICCProfile} & uint8[] & The ICC color profile \\
 \end{tabular}
 
 \subsubsection*{Limitations}
@@ -945,6 +946,7 @@ metadata if present.
 \qkws{ResolutionUnit} & string & ResolutionUnit (\qkw{in} or
   \qkw{cm}). \\
 \qkw{Orientation} & int & Orientation \\
+\qkw{ICCProfile} & uint8[] & The ICC color profile \\
 \qkw{textureformat} & string & {\cf PIXAR_TEXTUREFORMAT} \\
 \qkw{wrapmodes} & string & {\cf PIXAR_WRAPMODES} \\
 \qkw{fovcot} & float & {\cf PIXAR_FOVCOT} \\

--- a/src/doc/stdmetadata.tex
+++ b/src/doc/stdmetadata.tex
@@ -114,6 +114,12 @@ For example, the TIFF ImageIO plugin supports \qkw{none}, \qkw{in},
 and \qkw{cm}.
 \apiend
 
+\apiitem{"ICCProfile" : uint8[]}
+\NEW % 1.5
+The ICC color profile takes the form of an array of bytes (unsigned 8 bit
+chars). The length of the array is the length of the profile blob.
+\apiend
+
 \section{Disk file format info/hints}
 
 \apiitem{"oiio:BitsPerSample" : int}

--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -46,6 +46,13 @@ extern "C" {
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
+
+#define MAX_DATA_BYTES_IN_MARKER 65519L
+#define ICC_HEADER_SIZE 14
+#define ICC_PROFILE_ATTR "ICCProfile"
+
+
+
 class JpgInput : public ImageInput {
  public:
     JpgInput () { init(); }
@@ -59,7 +66,6 @@ class JpgInput : public ImageInput {
     virtual bool close ();
     const std::string &filename () const { return m_filename; }
     void * coeffs () const { return m_coeffs; }
-
     struct my_error_mgr {
         struct jpeg_error_mgr pub;    /* "public" fields */
         jmp_buf setjmp_buffer;        /* for return to caller */
@@ -94,6 +100,8 @@ class JpgInput : public ImageInput {
     // the form of an IIM (Information Interchange Model), which is actually
     // considered obsolete and is replaced by an XML scheme called XMP.
     void jpeg_decode_iptc (const unsigned char *buf);
+
+    bool read_icc_profile (j_decompress_ptr cinfo, ImageSpec& spec);
 
     void close_file () {
         if (m_fd)

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -538,6 +538,8 @@ static const TIFF_tag_info exif_tag_table[] = {
 };
 
 
+#define ICC_PROFILE_ATTR "ICCProfile"
+
 
 void
 TIFFInput::readspec (bool read_meta)
@@ -807,6 +809,13 @@ TIFFInput::readspec (bool read_meta)
     // MaxSampleValue MinSampleValue
     // NewSubfileType SubfileType(deprecated)
     // Colorimetry fields
+
+    /// read color profile
+    unsigned int icc_datasize = 0;
+    unsigned char *icc_buf = NULL;
+    TIFFGetField (m_tif, TIFFTAG_ICCPROFILE, &icc_datasize, &icc_buf);
+    if (icc_datasize && icc_buf)
+        m_spec.attribute (ICC_PROFILE_ATTR, TypeDesc(TypeDesc::UINT8, icc_datasize), icc_buf);
 
     // Search for an EXIF IFD in the TIFF file, and if found, rummage 
     // around for Exif fields.

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -168,6 +168,8 @@ TIFFOutput::supports (const std::string &feature) const
 }
 
 
+#define ICC_PROFILE_ATTR "ICCProfile"
+
 
 bool
 TIFFOutput::open (const std::string &name, const ImageSpec &userspec,
@@ -319,6 +321,15 @@ TIFFOutput::open (const std::string &name, const ImageSpec &userspec,
                                mytm.tm_year+1900, mytm.tm_mon+1, mytm.tm_mday,
                                mytm.tm_hour, mytm.tm_min, mytm.tm_sec);
         m_spec.attribute ("DateTime", date);
+    }
+
+    // Write ICC profile, if we have anything
+    const ImageIOParameter* icc_profile_parameter = m_spec.find_attribute(ICC_PROFILE_ATTR);
+    if (icc_profile_parameter != NULL) {
+        unsigned char *icc_profile = (unsigned char*)icc_profile_parameter->data();
+        uint32 length = icc_profile_parameter->type().size();
+        if (icc_profile && length)
+            TIFFSetField (m_tif, TIFFTAG_ICCPROFILE, length, icc_profile);
     }
 
     if (Strutil::iequals (m_spec.get_string_attribute ("oiio:ColorSpace"), "sRGB"))


### PR DESCRIPTION
This is my revised version of #911, squashing all the commits, with some reformatting and minor restructuring of the code, and documentation. Also, I changed the OIIO metadata name from "icc-profile" to "ICCProfile".

It does not need to be reviewed separately, I'm just posting it as a PR for @YangYangTL to be able to pull and test.
