### PR TITLE
Fixes incorrect imagespec in JPEG reader

### DIFF
--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -55,9 +55,6 @@ class JpgInput : public ImageInput {
     virtual bool open (const std::string &name, ImageSpec &spec);
     virtual bool open (const std::string &name, ImageSpec &spec,
                        const ImageSpec &config);
-    virtual bool seek_subimage (int index, int miplevel, ImageSpec &newspec) {
-        return (index == 0 && miplevel == 0);   // JPEG has only one subimage
-    }
     virtual bool read_native_scanline (int y, int z, void *data);
     virtual bool close ();
     const std::string &filename () const { return m_filename; }


### PR DESCRIPTION
Removed seek_subimage, it returns an incorrect imagespec should fallback to base ImageInput::seek_subimage
