### PR TITLE
Small fix in IFF documentation

### DIFF
--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -390,7 +390,7 @@ OIIO Attribute & Type & DPX header data or explanation \\
 \qkw{Artist} & string & The IFF ``author'' \\
 \qkw{DateTime} & string & Creation date/time \\
 \qkw{compression} & string & The compression type \\
-\qkw{oiio:BitsPerSample} & int & the true bits per sample of the DPX file. \\
+\qkw{oiio:BitsPerSample} & int & the true bits per sample of the IFF file. \\
 \end{tabular} 
 
 


### PR DESCRIPTION
Changed oiio:BitsPerSample description, DPX should be IFF.
