### PR TITLE
Attribute for chunk in ImageInput

### DIFF
--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -620,22 +620,14 @@ ImageInput::read_image (TypeDesc format, void *data,
             }
         }
     } else {
-        // Scanline image -- rely on read_scanlines, in chunks of 256
-        static int chunk = 256;
-        int oiio_chunk;
-        if( OIIO::getattribute ("chunk", oiio_chunk) ) {
-            if( oiio_chunk ) {
-               if( chunk != oiio_chunk ) {
-                    chunk = oiio_chunk;
-               }
-            }
-            else {
-                chunk = m_spec.height;
-            }
-        };
+        // Scanline image -- rely on read_scanlines, in chunks of oiio_read_chunk
+        int read_chunk = oiio_read_chunk;
+        if (!read_chunk) {
+            read_chunk = m_spec.height;
+        }
         for (int z = 0;  z < m_spec.depth;  ++z)
-            for (int y = 0;  y < m_spec.height && ok;  y += chunk) {
-                int yend = std::min (y+m_spec.y+chunk, m_spec.y+m_spec.height);
+            for (int y = 0;  y < m_spec.height && ok;  y += read_chunk) {
+                int yend = std::min (y+m_spec.y+read_chunk, m_spec.y+m_spec.height);
                 ok &= read_scanlines (y+m_spec.y, yend, z+m_spec.z, format,
                                       (char *)data + z*zstride + y*ystride,
                                       xstride, ystride);

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -52,8 +52,8 @@ OIIO_NAMESPACE_ENTER
 namespace pvt {
 recursive_mutex imageio_mutex;
 atomic_int oiio_threads (boost::thread::hardware_concurrency());
+atomic_int oiio_read_chunk (256);
 ustring plugin_searchpath;
-atomic_int oiio_chunk (256);
 std::string format_list;   // comma-separated list of all formats
 std::string extension_list;   // list of all extensions for all formats
 }
@@ -139,12 +139,12 @@ attribute (string_view name, TypeDesc type, const void *val)
         return true;
     }
     spin_lock lock (attrib_mutex);
-    if (name == "plugin_searchpath" && type == TypeDesc::TypeString) {
-        plugin_searchpath = ustring (*(const char **)val);
+    if (name == "read_chunk" && type == TypeDesc::TypeInt) {
+        oiio_read_chunk = *(const int *)val;
         return true;
     }
-    if (name == "chunk" && type == TypeDesc::TypeInt) {
-        oiio_chunk = *(const int *)val;
+    if (name == "plugin_searchpath" && type == TypeDesc::TypeString) {
+        plugin_searchpath = ustring (*(const char **)val);
         return true;
     }
     return false;
@@ -160,12 +160,12 @@ getattribute (string_view name, TypeDesc type, void *val)
         return true;
     }
     spin_lock lock (attrib_mutex);
-    if (name == "plugin_searchpath" && type == TypeDesc::TypeString) {
-        *(ustring *)val = plugin_searchpath;
+    if (name == "read_chunk" && type == TypeDesc::TypeInt) {
+        *(int *)val = oiio_read_chunk;
         return true;
     }
-    if (name == "chunk" && type == TypeDesc::TypeInt) {
-        *(int *)val = oiio_chunk;
+    if (name == "plugin_searchpath" && type == TypeDesc::TypeString) {
+        *(ustring *)val = plugin_searchpath;
         return true;
     }
     if (name == "format_list" && type == TypeDesc::TypeString) {

--- a/src/libOpenImageIO/imageio_pvt.h
+++ b/src/libOpenImageIO/imageio_pvt.h
@@ -50,6 +50,7 @@ namespace pvt {
 ///
 extern recursive_mutex imageio_mutex;
 extern atomic_int oiio_threads;
+extern atomic_int oiio_read_chunk;
 extern ustring plugin_searchpath;
 extern std::string format_list;
 extern std::string extension_list;


### PR DESCRIPTION
Another one up for discussion, when reading lots of images for playback in multiple threads it's faster (on my test machines) to read scanline images with chunk = m_spec.height.

First results:

./test_stats: stat file: /Users/mikaelsundell/Desktop/test.exr
./test_stats: oiio ImageInput: /Users/mikaelsundell/Desktop/test.exr, elapsed time: 0.131, chunks: 256
read was not necessary -- using cache
going to have to read /Users/mikaelsundell/Desktop/test.exr: float vs unknown
./test_stats: oiio ImageBuf/ImageCache: /Users/mikaelsundell/Desktop/test.exr, elapsed time: 0.43, chunks: 256
./test_stats: core ImageLoader: /Users/mikaelsundell/Desktop/test.exr, elapsed time: 0.071, chunks: 256
./test_stats: core ImageLoader: /Users/mikaelsundell/Desktop/test.exr, elapsed time: 0.061, chunks: 0
./test_stats: exr RgbaInputFile: /Users/mikaelsundell/Desktop/test.exr, elapsed time: 0.215
./test_stats: exr framebuffer: /Users/mikaelsundell/Desktop/test.exr, elapsed time: 0.094

Sets oiio_chunk to 256 per default and a value of 0 means m_spec.height in ImageInput.
If not set the ImageInput scanline reader will fallback to 256, if set to zero the m_spec.height will be used.

core ImageLoader is class that only uses ImageInput::open/read_image without ImageCache.
