### PR TITLE
Bug fix: oiiotool color conversion botched inputs with MIP levels.

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1109,8 +1109,8 @@ action_colorconvert (int argc, const char *argv[])
     ot.push (new ImageRec (*A, ot.allsubimages ? -1 : 0,
                            ot.allsubimages ? -1 : 0, true, false));
 
-    for (int s = 0, send = A->subimages();  s < send;  ++s) {
-        for (int m = 0, mend = A->miplevels(s);  m < mend;  ++m) {
+    for (int s = 0, send = ot.curimg->subimages();  s < send;  ++s) {
+        for (int m = 0, mend = ot.curimg->miplevels(s);  m < mend;  ++m) {
             bool ok = ImageBufAlgo::colorconvert ((*ot.curimg)(s,m), (*A)(s,m),
                                  fromspace.c_str(), tospace.c_str(), false);
             if (! ok)
@@ -1173,8 +1173,8 @@ action_ociolook (int argc, const char *argv[])
     if (tospace == "current" || tospace == "")
         tospace = A->spec(0,0)->get_string_attribute ("oiio:Colorspace", "Linear");
 
-    for (int s = 0, send = A->subimages();  s < send;  ++s) {
-        for (int m = 0, mend = A->miplevels(s);  m < mend;  ++m) {
+    for (int s = 0, send = ot.curimg->subimages();  s < send;  ++s) {
+        for (int m = 0, mend = ot.curimg->miplevels(s);  m < mend;  ++m) {
             bool ok = ImageBufAlgo::ociolook (
                 (*ot.curimg)(s,m), (*A)(s,m),
                 lookname.c_str(), fromspace.c_str(), tospace.c_str(),
@@ -1227,8 +1227,8 @@ action_ociodisplay (int argc, const char *argv[])
     if (fromspace == "current" || fromspace == "")
         fromspace = A->spec(0,0)->get_string_attribute ("oiio:Colorspace", "Linear");
 
-    for (int s = 0, send = A->subimages();  s < send;  ++s) {
-        for (int m = 0, mend = A->miplevels(s);  m < mend;  ++m) {
+    for (int s = 0, send = ot.curimg->subimages();  s < send;  ++s) {
+        for (int m = 0, mend = ot.curimg->miplevels(s);  m < mend;  ++m) {
             bool ok = ImageBufAlgo::ociodisplay (
                     (*ot.curimg)(s,m), (*A)(s,m),
                     displayname.c_str(), viewname.c_str(),


### PR DESCRIPTION
It should have been looping over the number of subimages and mip levels in the destination image, not the source image, because if the -a flag is not used, the dst image will be constructed with fewer mip levels (i.e. 1) than the source. Looping over the source's count will run off the end of the list.

You can see how I cut-and-pasted the guts of colorconvert (including this bug) to form ociolook and ociodisplay. Oops.

The bug is only symptomatic if the input image is multi-image or MIP-mapped. So was discovered upon color converting a texture. I guess that hasn't come up before, usually color conversion is done before making the texture map as the last step.
