### PR TITLE
Python: finally implemented ImageBuf.get_pixels()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -102,6 +102,8 @@ Fixes, minor enhancements, and performance improvements:
   wrong memory. (#868) (1.5.0/1.4.9)
 * Better exception safety in Filesystem::scan_for_matching_filenames().
   #902 (1.5.1/1.4.11)
+* Python: ImageBuf.get_pixels() is now implemented, was previously omitted.
+  (1.5.2)
 
 Build/test system improvements:
 * Fix several compiler warnings and build breakages for a variety of

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -1405,6 +1405,19 @@ Sets pixel $(x,y,z)$ to be the {\cf pixel_value}, expressed as a tuple of
 \end{code}
 \apiend
 
+\apiitem{array ImageBuf.{\ce get_pixels} (format=OpenImageIO.UNKNOWN, roi=ROI.All)}
+\NEW % 1.5
+Retrieves the rectangle of pixels (and channels) specified by {\cf roi} from
+the image and returns them as an array of values with type specified by
+{\cf format}.
+
+\noindent Example:
+\begin{code}
+    buf = ImageBuf ("tahoe.jpg")
+    pixels = buf.get_pixels (oiio.FLOAT)  # no ROI means the whole image
+\end{code}
+\apiend
+
 \apiitem{bool ImageBuf.{\ce has_error} \\
 str ImageBuf.{\ce geterror} ()}
 The {\cf ImageBuf.has_error} field will be {\cf True} if an error has

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -28,6 +28,8 @@
   (This is the Modified BSD License)
 */
 
+#include <boost/scoped_array.hpp>
+
 #include "py_oiio.h"
 #include "OpenImageIO/sysutil.h"
 
@@ -233,6 +235,41 @@ ImageBuf_setpixel1 (ImageBuf &buf, int i, tuple p)
 
 
 
+object
+ImageBuf_get_pixels (const ImageBuf &buf, TypeDesc format, ROI roi=ROI::All())
+{
+    // Allocate our own temp buffer and try to read the image into it.
+    // If the read fails, return None.
+    if (! roi.defined())
+        roi = buf.roi();
+    roi.chend = std::min (roi.chend, buf.nchannels()+1);
+
+    size_t size = (size_t) roi.npixels() * roi.nchannels() * format.size();
+    boost::scoped_array<char> data (new char [size]);
+    if (! buf.get_pixel_channels (roi.xbegin, roi.xend, roi.ybegin, roi.yend,
+                                  roi.zbegin, roi.zend, roi.chbegin, roi.chend,
+                                  format, &data[0])) {
+        return object(handle<>(Py_None));
+    }
+
+    return C_array_to_Python_array (data.get(), format, size);
+}
+
+BOOST_PYTHON_FUNCTION_OVERLOADS(ImageBuf_get_pixels_overloads,
+                                ImageBuf_get_pixels, 2, 3)
+
+object
+ImageBuf_get_pixels_bt (const ImageBuf &buf, TypeDesc::BASETYPE format,
+                        ROI roi=ROI::All())
+{
+    return ImageBuf_get_pixels (buf, TypeDesc(format), roi);
+}
+
+BOOST_PYTHON_FUNCTION_OVERLOADS(ImageBuf_get_pixels_bt_overloads,
+                                ImageBuf_get_pixels_bt, 2, 3)
+
+
+
 void declare_imagebuf()
 {
     enum_<ImageBuf::WrapMode>("WrapMode")
@@ -330,7 +367,8 @@ void declare_imagebuf()
         .def("setpixel", &ImageBuf_setpixel)
         .def("setpixel", &ImageBuf_setpixel2)
         .def("setpixel", &ImageBuf_setpixel1)
-        // FIXME - get_pixels, get_pixel_channels
+        .def("get_pixels", &ImageBuf_get_pixels, ImageBuf_get_pixels_overloads())
+        .def("get_pixels", &ImageBuf_get_pixels_bt, ImageBuf_get_pixels_bt_overloads())
 
         // FIXME -- do we want to provide pixel iterators?
     ;

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -64,6 +64,8 @@ void declare_paramvalue();
 void declare_global();
 
 bool PyProgressCallback(void*, float);
+object C_array_to_Python_array (const char *data, TypeDesc type, size_t size);
+
 
 
 // Suck up one or more presumed T values into a vector<T>

--- a/testsuite/python-imagebuf/ref/out.txt
+++ b/testsuite/python-imagebuf/ref/out.txt
@@ -85,7 +85,7 @@ Resetting to a different MIP level:
   IPTC:OriginatingProgram = "maketx g.tif -o grid.tx"
   tiff:PageNumber = "0"
 
-Making 2x2 RGBK image:
+Making 2x2 RGB image:
   resolution 2x2+0+0
   untiled
   3 channels: ('R', 'G', 'B')
@@ -98,6 +98,7 @@ Pixel 1,0 is (0.0, 1.0, 0.0)
 Pixel 0,1 is (0.0, 0.0, 1.0)
 Interpolating 1,0.5 -> (0.5, 0.5, 0.0)
 Interpolating NDC 0.25,0.5 -> (0.5, 0.0, 0.5)
+The whole image is:  array('f', [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
 
 Saving file...
 Done.

--- a/testsuite/python-imagebuf/test_imagebuf.py
+++ b/testsuite/python-imagebuf/test_imagebuf.py
@@ -80,7 +80,7 @@ try:
     print ""
 
     # Create a small buffer, do various pixel reads and writes
-    print "Making 2x2 RGBK image:"
+    print "Making 2x2 RGB image:"
     b = oiio.ImageBuf (oiio.ImageSpec(2,2,3,oiio.UINT8))
     print_imagespec (b.spec())
     b.setpixel (0, 0, 0, (1.0, 0.0, 0.0))
@@ -92,6 +92,7 @@ try:
     print "Pixel 0,1 is", b.getpixel(0,1)
     print "Interpolating 1,0.5 ->", b.interppixel(1,0.5)
     print "Interpolating NDC 0.25,0.5 ->", b.interppixel_NDC(0.25,0.5)
+    print "The whole image is: ", b.get_pixels(oiio.TypeDesc.TypeFloat)
     print ""
     print "Saving file..."
     b.write ("out.tif")


### PR DESCRIPTION
It was omitted when we did the ImageBuf Python bindings, for no good reason.
