### PR TITLE
OpenEXR 2.2 support, esp. for the new DWAA/DWAB compression modes.

### DIFF
--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -435,6 +435,7 @@ anywhere near the acceptance of the original JPEG/JFIF format.
 \qkw{Orientation} & int & the image orientation \\[2ex]
 \qkw{XResolution}, \qkw{YResolution},
 \qkw{ResolutionUnit} & & The resolution and units from the Exif header \\[2ex]
+\qkw{CompressionQuality} & int & Quality of compression (1-100) \\[2ex]
 \qkw{ICCProfile} & uint8[] & The ICC color profile \\
 & & \\
 Exif, IPTC, XMP, GPS & & Extensive Exif, IPTC, XMP, and GPS data are supported by the
@@ -523,9 +524,11 @@ The official OpenEXR site is \url{http://www.openexr.com/}.
 \qkw{ExposureTime} & float & expTime \\
 \qkw{FNumber} & float & aperture \\
 \qkw{compression} & string & one of: \qkw{none}, \qkw{rle},
-  \qkw{zip}, \qkw{piz}, \qkw{pxr24}, \qkw{b44}, or \qkw{b44a}.  If the
+  \qkw{zip}, \qkw{piz}, \qkw{pxr24}, \qkw{b44}, \qkw{b44a},
+  \qkw{dwaa}, or \qkw{dwab}.  If the
   writer receives a request for a compression type it does not
-  recognize, it will use \qkw{zip} by default. \\
+  recognize or is not supported by the version of OpenEXR on the system,
+  it will use \qkw{zip} by default. \\
 \qkw{textureformat} & string & set to \qkw{Plain Texture} for
   MIP-mapped OpenEXR files, \qkw{CubeFace Environment} or \qkw{Latlong
     Environment} for OpenEXR environment maps.  Non-environment
@@ -546,6 +549,8 @@ The official OpenEXR site is \url{http://www.openexr.com/}.
  \\
 \qkws{openexr:roundingmode} & int & the MIPmap rounding mode of the
   file. \\[2ex]
+\qkws{openexr:dwaCompressionLevel} & float & compression level for
+   dwaa or dwab compression (default: 45.0). \\
 \emph{other} & & All other attributes will be added to the \ImageSpec by their
   name and apparent type.
 \end{tabular}

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -273,6 +273,7 @@ private:
         m_map["version"] = "openexr:version";
         m_map["chunkCount"] = "openexr:chunkCount";
         m_map["maxSamplesPerPixel"] = "openexr:maxSamplesPerPixel";
+        m_map["dwaCompressionLevel"] = "openexr:dwaCompressionLevel";
         // Ones to skip because we handle specially
         m_map["channels"] = "";
         m_map["compression"] = "";
@@ -520,6 +521,11 @@ OpenEXRInput::PartInfo::parse_header (const Imf::Header *header)
             // the newer version.
         case Imf::B44_COMPRESSION   : comp = "b44"; break;
         case Imf::B44A_COMPRESSION  : comp = "b44a"; break;
+#endif
+#if defined(OPENEXR_VERSION_MAJOR) && \
+    (OPENEXR_VERSION_MAJOR*10000+OPENEXR_VERSION_MINOR*100+OPENEXR_VERSION_PATCH) >= 20200
+        case Imf::DWAA_COMPRESSION  : comp = "dwaa"; break;
+        case Imf::DWAB_COMPRESSION  : comp = "dwab"; break;
 #endif
         default:
             break;

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -238,7 +238,6 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 static std::string format_string ("openexr");
-static std::string format_prefix ("openexr_");
 
 
 namespace pvt {
@@ -763,8 +762,8 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
         xname = "aperture";
     else if (Strutil::iequals(xname, "name"))
         xname = "oiio::subimagename";
-    else if (Strutil::istarts_with (xname, format_prefix))
-        xname = std::string (xname.begin()+format_prefix.size(), xname.end());
+    else if (Strutil::iequals(xname, "openexr:dwaCompressionLevel"))
+        xname = "dwaCompressionLevel";
 
 //    std::cerr << "exr put '" << name << "' -> '" << xname << "'\n";
 
@@ -794,6 +793,13 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
                 header.compression() = Imf::B44_COMPRESSION;
             else if (Strutil::iequals (str, "b44a"))
                 header.compression() = Imf::B44A_COMPRESSION;
+#endif
+#if defined(OPENEXR_VERSION_MAJOR) && \
+    (OPENEXR_VERSION_MAJOR*10000+OPENEXR_VERSION_MINOR*100+OPENEXR_VERSION_PATCH) >= 20200
+            else if (Strutil::iequals (str, "dwaa"))
+                header.compression() = Imf::DWAA_COMPRESSION;
+            else if (Strutil::iequals (str, "dwab"))
+                header.compression() = Imf::DWAB_COMPRESSION;
 #endif
         }
         return true;


### PR DESCRIPTION
When compiled against OpenEXR 2.2, the "dwaa" and "dwab" compression are available. Also respects the "openexr:dwaCompressionLevel" float attribute to set the compression level.

For those not up on it, OpenEXR 2.2 was recently released, and it contains two new compression methods contributed by DreamWorks Animation, which are extremely good at compressing HDR images. It's lossy, but has very high visual fidelity with impressive compression ratios.
