### PR TITLE
Add an option to link against static ilmbase and openexr libraries

### DIFF
--- a/src/cmake/modules/FindIlmBase.cmake
+++ b/src/cmake/modules/FindIlmBase.cmake
@@ -26,6 +26,15 @@ include (FindPackageMessage)
 include (SelectLibraryConfigurations)
 
 
+if( ILMBASE_USE_STATIC_LIBS )
+  set( _ilmbase_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  if(WIN32)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .lib .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  else()
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a )
+  endif()
+endif()
+
 # Macro to assemble a helper state variable
 macro (SET_STATE_VAR varname)
   set (tmp_ilmbaselibs ${ILMBASE_CUSTOM_LIBRARIES})
@@ -232,6 +241,11 @@ if (ILMBASE_FOUND)
       )
   endif ()
 endif ()
+
+# Restore the original find library ordering
+if( ILMBASE_USE_STATIC_LIBS )
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${_ilmbase_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+endif()
 
 # Unset the helper variables to avoid pollution
 unset (ILMBASE_CURRENT_STATE)

--- a/src/cmake/modules/FindOpenEXR.cmake
+++ b/src/cmake/modules/FindOpenEXR.cmake
@@ -26,6 +26,14 @@
 include (FindPackageHandleStandardArgs)
 include (FindPackageMessage)
 
+if( OPENEXR_USE_STATIC_LIBS )
+  set( _openexr_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  if(WIN32)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .lib .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  else()
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a )
+  endif()
+endif()
 
 # Macro to assemble a helper state variable
 macro (SET_STATE_VAR varname)
@@ -217,6 +225,11 @@ if (OPENEXR_FOUND)
       )
   endif ()
 endif ()
+
+# Restore the original find library ordering
+if( OPENEXR_USE_STATIC_LIBS )
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${_openexr_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+endif()
 
 # Unset the helper variables to avoid pollution
 unset (OPENEXR_CURRENT_STATE)

--- a/src/dpx.imageio/CMakeLists.txt
+++ b/src/dpx.imageio/CMakeLists.txt
@@ -2,5 +2,5 @@ add_oiio_plugin (dpxinput.cpp dpxoutput.cpp
   libdpx/DPX.cpp libdpx/OutStream.cpp libdpx/RunLengthEncoding.cpp
   libdpx/Codec.cpp libdpx/Reader.cpp libdpx/Writer.cpp libdpx/DPXHeader.cpp
   libdpx/ElementReadStream.cpp libdpx/InStream.cpp libdpx/DPXColorConverter.cpp)
-link_ilmbase (dpx.imageio)
 link_openexr (dpx.imageio)
+link_ilmbase (dpx.imageio)

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -228,7 +228,7 @@ endif ()
 if (WIN32)
     target_link_libraries (OpenImageIO psapi.lib)
 endif ()
-link_ilmbase (OpenImageIO)
+
 add_dependencies (OpenImageIO "${CMAKE_CURRENT_SOURCE_DIR}/libOpenImageIO.map")
 
 if (EMBEDPLUGINS)
@@ -248,6 +248,8 @@ if (EMBEDPLUGINS)
         target_link_libraries (OpenImageIO ${LibRaw_r_LIBRARIES})
     endif ()
 endif ()
+
+link_ilmbase (OpenImageIO)
 
 if (USE_EXTERNAL_PUGIXML)
     target_link_libraries (OpenImageIO ${PUGIXML_LIBRARIES})

--- a/src/openexr.imageio/CMakeLists.txt
+++ b/src/openexr.imageio/CMakeLists.txt
@@ -3,6 +3,6 @@
 
 add_oiio_plugin (exrinput.cpp exroutput.cpp)
 
-link_ilmbase (openexr.imageio)
 link_openexr (openexr.imageio)
+link_ilmbase (openexr.imageio)
 


### PR DESCRIPTION
This adds new cmake variables `ILMBASE_USE_STATIC_LIBS` and `OPENEXR_USE_STATIC_LIBS` which do what they sound like.  The mechanism for preferring static over dynamic libs is taken from `FindBoost.cmake`. 

This also addresses linking order for static libraries:  IlmImf must come before IlmThread in the list of linked libraries or else IlmThread symbols will remain undefined in the resulting libOpenImageIO.so. 
