### PR TITLE
Add maketx option to sharpen as we create MIP levels.

### DIFF
--- a/src/doc/imagebufalgo.tex
+++ b/src/doc/imagebufalgo.tex
@@ -1537,6 +1537,7 @@ preserving the sharpness of long edges.
   \bigspc\spc float contrast = 1.0f, float threshold = 0.0f, \\
   \bigspc\spc  ROI roi=ROI::All(), int nthreads=0)}
 \index{ImageBufAlgo!unsharp_mask} \indexapi{unsharp_mask}
+\label{sec:IBA_unsharp_mask}
 
 Replace the given ROI of {\cf dst} with a sharpened version of the
 corresponding region of {\cf src} using the ``unsharp mask'' technique.

--- a/src/doc/maketx.tex
+++ b/src/doc/maketx.tex
@@ -160,6 +160,23 @@ non-negative.  This can result in some loss of energy, but often this is
 a preferable alternative to ringing artifacts in your upper MIP levels.
 \apiend
 
+\apiitem{--sharpen {\rm \emph{contrast}}}
+\NEW  % 1.5
+EXPERIMENTAL: USE AT YOUR OWN RISK!
+
+This option will run an additional sharpening filter
+when creating the successive MIP-map levels. It uses an unsharp mask
+(much like in Section~{sec:IBA_unsharp_mask}) to emphasize high-frequency
+details to make features ``pop'' visually even at high MIP-map levels.
+The \emph{contrast} controls the degree to which it does this. Probably
+a good value to enhance detail but not go overboard is 0.5 or even 0.25.
+A value of 1.0 may make strage artifacts at high MIP-map levels. Also, if
+you simultaneously use {\cf --filter unsharp-median}, a slightly different
+variant of unsharp masking will be used that employs a median filter to
+separate out the low-frequencies, this may tend to help emphasize small
+features while not over-emphasizing large edges. 
+\apiend
+
 \apiitem{--nomipmap}
 Causes the output to \emph{not} be MIP-mapped, i.e., only will have
 the highest-resolution level.

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -1802,6 +1802,10 @@ enum OIIO_API MakeTextureMode {
 ///                              values to zero. This reduces ringing when
 ///                              using filters with negative lobes on HDR
 ///                              images.
+///    maketx:sharpen (float) If nonzero, sharpens details when creating
+///                              MIPmap levels. The amount is the contrast
+///                              matric. The default is 0, meaning no
+///                              sharpening.
 ///    maketx:nchannels (int) If nonzero, will specify how many channels
 ///                              the output texture should have, padding with
 ///                              0 values or dropping channels, if it doesn't

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -210,6 +210,7 @@ getargs (int argc, char *argv[], ImageSpec &configspec)
     bool ignore_unassoc = false;  // ignore unassociated alpha tags
     bool unpremult = false;
     bool sansattrib = false;
+    float sharpen = 0.0f;
     std::string incolorspace;
     std::string outcolorspace;
     std::string channelnames;
@@ -246,6 +247,7 @@ getargs (int argc, char *argv[], ImageSpec &configspec)
                   "--filter %s", &filtername, filter_help_string().c_str(),
                   "--hicomp", &do_highlight_compensation,
                           "Compress HDR range before resize, expand after.",
+                  "--sharpen %f", &sharpen, "Sharpen MIP levels (default = 0.0 = no)",
                   "--nomipmap", &nomipmap, "Do not make multiple MIP-map levels",
                   "--checknan", &checknan, "Check for NaN/Inf values (abort if found)",
                   "--fixnan %s", &fixnan, "Attempt to fix NaN/Inf values in the image (options: none, black, box3)",
@@ -373,6 +375,7 @@ getargs (int argc, char *argv[], ImageSpec &configspec)
     configspec.attribute ("maketx:fixnan", fixnan);
     configspec.attribute ("maketx:set_full_to_pixels", set_full_to_pixels);
     configspec.attribute ("maketx:highlightcomp", (int)do_highlight_compensation);
+    configspec.attribute ("maketx:sharpen", sharpen);
     if (filtername.size())
         configspec.attribute ("maketx:filtername", filtername);
     configspec.attribute ("maketx:nchannels", nchannels);


### PR DESCRIPTION
I know this might be contentious (and wrong in so many ways), but bear with me.

The idea is that production sometimes thinks the filtered textures look a little too blurry and washed out (even though we know that they're filtered almost exactly right). So with this, we optionally do a sharpening step (via unsharp_mask) as we create MIP levels. This gooses the high-frequency detail just a bit.  Example command line:

```
maketx input.exr -sharpen 0.5 -filter unsharp-median -o texture.exr
```

Play with the sharpening amount (I like somewhere between 0.25 and 0.5) and with whether you use the unsharp-median or (by leaving out the -filter or setting it to an ordinary name like "lanczos3") whether you use the usual Gaussian-based unsharp mask

This is all experimental! Use at your own risk.

I'm not ready to advocate using this yet... it's going in for experimental purposes, but we'll let you know if our productions like it and you can make up your own minds.
