### PR TITLE
Fix TIFF loss of precision when auto-premultiplying unassociated alpha images

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -128,6 +128,9 @@ Fixes, minor enhancements, and performance improvements:
    * Read and write ICC profiles as attribute "ICCProfile". (#911)
    * Graceful handling of output of images with negative data window
      origin. (1.5.3)
+   * Improved precision when auto-premultiplying 8 bit unassociated alpha
+     images (if the user is reading them into a higher-precision buffer).
+     #960, #962 (1.6.2)
 * RAW: Fix for portrait-orientation image reads. (#878) (1.5.1/1.4.10)
 * RLA: Fix bug that caused RLA output to not respect requests for 10 bit
   output (would force it to 16 in that case). #899 (1.5.1)
@@ -211,6 +214,9 @@ Developer goodies / internals:
   functions that are approximations that may differ slightly several
   decimal places in but are much faster than the full precision libm/IEEE
   versions. #953, #956 (1.5.5)
+* New utility function: premult(), which can premultiply non-alpha, non-z
+  channels by alpha, for a whole buffer (with strides, any data type).
+  #962 (1.6.2)
 
 
 

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -449,7 +449,8 @@ swap_endian (T *f, int len=1)
 /// (presumed to be integer).  This is just a helper for the convert_type
 /// templates, it probably has no other use.
 template<typename S, typename D, typename F>
-D scaled_conversion (const S &src, F scale, F min, F max)
+inline D
+scaled_conversion (const S &src, F scale, F min, F max)
 {
     if (std::numeric_limits<S>::is_signed) {
         F s = src * scale;
@@ -545,7 +546,8 @@ void convert_type (const S *src, D *dst, size_t n, D _zero=0, D _one=1,
 /// types.  Take a copy shortcut if both types are the same and no
 /// conversion is necessary.
 template<typename S, typename D>
-D convert_type (const S &src)
+inline D
+convert_type (const S &src)
 {
     if (is_same<S,D>::value) {
         // They must be the same type.  Just return it.

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1256,6 +1256,14 @@ OIIO_API void add_dither (int nchannels, int width, int height, int depth,
                           int chorigin=0, int xorigin=0,
                           int yorigin=0, int zorigin=0);
 
+/// Convert unassociated to associated alpha by premultiplying all color
+/// (non-alpha, non-z) channels by alpha.
+OIIO_API void premult (int nchannels, int width, int height, int depth,
+                       int chbegin, int chend,
+                       TypeDesc datatype, void *data, stride_t xstride,
+                       stride_t ystride, stride_t zstride,
+                       int alpha_channel = -1, int z_channel = -1);
+
 /// Helper routine for data conversion: Copy an image of nchannels x
 /// width x height x depth from src to dst.  The src and dst may have
 /// different data layouts, but must have the same data type.  Clever


### PR DESCRIPTION
Frédéric Devernay points out in GH issue #960 that we auto-premultiply unassociated alpha TIFF images BEFORE converting from native data type. So if the native data is uint8, we do a premultiply from uint8 -> uint8, thereby losing precision, even if the call ultimately asks us to convert to the a higher-precision (e.g., float) data type in the caller's buffer.

The root of the evil is that we do the auto-premultiply inside read_native_scanline (and tile), which operates entirely in native data type and is unaware of what buffer data type the user has supplied. Ugh.

The solution is:
1. Add a premult() utility function in imageio.h/imageio.cpp (for easy reuse elsewhere).
2. Do NOT do the multiply in the 'native' functions.
3. Add TIFFInput::read_scanline(s)/read_tile(s) functions, which call the base class version first, and then (if requested) do the un-premultiplication. Seems to work! It's a little roundabout, but necessary because the base class read_blah functions do not have the TIFF-specific knowledge of whether or not the premultiplication is desired. Those methods are already virtual and it's always been legal to override them on a format-specific basis, though we've never had a reason to do so before.

Note that this only helps if the user specifies a higher-precision buffer. I think that's a fine limitation. If they read an 8 bit file into a supplied 8 bit buffer, and don't specifically ask for unassociated values to be preserved, I think this is the best they can hope for anyway.

Fixes #960 
