### PR TITLE
Fix error due to using SSSE3 _mm_abs_epi32 when compiling for SSE2

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -1054,7 +1054,7 @@ OIIO_FORCEINLINE int4 blend0 (int4 a, mask4 mask)
 /// Per-element absolute value.
 OIIO_FORCEINLINE int4 abs (int4 a)
 {
-#if defined(OIIO_SIMD_SSE)
+#if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 3
     return _mm_abs_epi32(a.simd());
 #else
     return int4 (std::abs(a[0]), std::abs(a[1]), std::abs(a[2]), std::abs(a[3]));


### PR DESCRIPTION
This `abs` function doesn't seem to be used in the OIIO texture sampling or OSL noise code so this change should not slow them down.

I also noticed that there is no distinction made between SSE3 and (the unfortunately named) SSSE3. So someone with a SSE3 CPU and compiling with USE_SIMD=sse3 may not be able to run the binary if the CPU does not support SSSE3, which could be confusing.
