### PR TITLE
GIF input plug: Fix build with giflib>=5.1

### DIFF
--- a/src/gif.imageio/gifinput.cpp
+++ b/src/gif.imageio/gifinput.cpp
@@ -437,7 +437,11 @@ inline bool
 GIFInput::close (void)
 {
     if (m_gif_file) {
+#if GIFLIB_MAJOR > 5 || (GIFLIB_MAJOR == 5 && GIFLIB_MINOR >= 1)
+        if (DGifCloseFile (m_gif_file, NULL) == GIF_ERROR) {
+#else
         if (DGifCloseFile (m_gif_file) == GIF_ERROR) {
+#endif
             error ("Error trying to close the file.");
             return false;
         }


### PR DESCRIPTION
From giflib-5.1.0's NEWS:
"A small change to the API: DGifClose() and EGifClose() now take a
pointer-to-int second argument (like the corresponding openers)
where a diagnostic code will be deposited when they return
GIF_ERROR."
