### PR TITLE
Fix compile errors on MSVS2013.

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -402,12 +402,12 @@ template<typename T> struct is_same<T,T> { static const bool value = true; };
 
 
 
-template <typename IN, typename OUT>
-inline OUT bit_cast (const IN in) {
+template <typename IN_TYPE, typename OUT_TYPE>
+inline OUT_TYPE bit_cast (const IN_TYPE in) {
     // NOTE: this is the only standards compliant way of doing this type of casting,
     // luckily the compilers we care about know how to optimize away this idiom.
-    OUT out;
-    memcpy (&out, &in, sizeof(IN));
+    OUT_TYPE out;
+    memcpy (&out, &in, sizeof(IN_TYPE));
     return out;
 }
 


### PR DESCRIPTION
Our working theory is that one of the MSVS headers has a #define of IN or
OUT. So we change the names of the types in our template, and people report
that it compiles.

Fixes #974
