### PR TITLE
Remove renaming of "name" parameter

### DIFF
--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -760,8 +760,6 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
         xname = "expTime";
     else if (Strutil::iequals(xname, "FNumber"))
         xname = "aperture";
-    else if (Strutil::iequals(xname, "name"))
-        xname = "oiio::subimagename";
     else if (Strutil::iequals(xname, "openexr:dwaCompressionLevel"))
         xname = "dwaCompressionLevel";
 


### PR DESCRIPTION
Seems like there is no way to pass a name to each subimage's header when writing multipart exrs.
The name attribute of each ImageSpec seems a good place to pull that from, but it's currently being remapped to "oiio::subimagename" when writing to the subimage's header.
Each subimage then defaults to being named "subimagexx".

Is there a practical reason for this? Or a different way to set the header's name that I'm missing?

Thanks
