### PR TITLE
OpenEXR fix writing of subimage name.

### DIFF
--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -760,8 +760,8 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
         xname = "expTime";
     else if (Strutil::iequals(xname, "FNumber"))
         xname = "aperture";
-    else if (Strutil::iequals(xname, "name"))
-        xname = "oiio::subimagename";
+    else if (Strutil::iequals(xname, "oiio:subimagename"))
+        xname = "name";
     else if (Strutil::iequals(xname, "openexr:dwaCompressionLevel"))
         xname = "dwaCompressionLevel";
 


### PR DESCRIPTION
(Got attribute name translation backwards.)
