### PR TITLE
c++11 fixes on gcc-491, glibc-2.12-1.132.el6

### DIFF
--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -164,9 +164,9 @@ read_input (const std::string &filename, ImageBuf &img,
 inline void
 safe_double_print (double val)
 {
-    if (isnan (val))
+    if (OIIO::isnan (val))
         std::cout << "nan";
-    else if (isinf (val))
+    else if (OIIO::isinf (val))
         std::cout << "inf";
     else
         std::cout << val;

--- a/src/include/OpenImageIO/missing_math.h
+++ b/src/include/OpenImageIO/missing_math.h
@@ -246,9 +246,13 @@ erfcf (float val)
 #endif  /* _WIN32 */
 
 
-#ifndef _MSC_VER
- // Some systems have isnan, isinf and isfinite in the std namespace.
- // FIXME: remove these later
+#if defined(_MSC_VER) && __cplusplus <= 201103L
+// Prior to c++11, these were implementation defined, and on msvc, were not in the
+// std namespace
+ using ::isnan;
+ using ::isinf;
+ using ::isfinite;
+#else
  using std::isnan;
  using std::isinf;
  using std::isfinite;
@@ -268,39 +272,5 @@ log2f (float val) {
 
 
 } OIIO_NAMESPACE_EXIT
-
-
-// For certain platforms, direct them to use OIIO's implementations.
-
-#ifdef _WIN32
- using OIIO::truncf;
- using OIIO::log2f;
- using OIIO::exp2f;
-# if defined(_MSC_VER) && _MSC_VER < 1800 /* Needed for MSVS prior to 2013 */
-  using OIIO::isnan;
-  using OIIO::isfinite;
-  using OIIO::isinf;
-  using OIIO::round;
-  using OIIO::roundf;
-  using OIIO::logbf;
-  using OIIO::expm1;
-  using OIIO::expm1f;
-  using OIIO::erf;
-  using OIIO::erff;
-  using OIIO::erfc;
-  using OIIO::erfcf;
-# endif /* MSVS < 2013 */
-#endif  /* _WIN32 */
-
-#ifndef _MSC_VER
- // Some systems have isnan, isinf and isfinite in the std namespace.
- using std::isnan;
- using std::isinf;
- using std::isfinite;
-#endif
-
-#if (defined(__FreeBSD__) && (__FreeBSD_version < 803000))
- using OIIO::log2f;
-#endif
 
 

--- a/src/libutil/hashes.cpp
+++ b/src/libutil/hashes.cpp
@@ -68,8 +68,9 @@ namespace xxhash {
 #define inline __forceinline // Visual is not C99, but supports some kind of inline
 #endif
 
-// GCC does not support _rotl outside of Windows
-#if !defined(_WIN32)
+// Check for support of _rotl 
+// Not required for GCC 4.9x with -std=c++11
+#ifndef _rotl
 #define _rotl(x,r) ((x << r) | (x >> (32 - r)))
 #endif
 

--- a/src/oiiotool/diff.cpp
+++ b/src/oiiotool/diff.cpp
@@ -69,9 +69,9 @@ using namespace ImageBufAlgo;
 inline void
 safe_double_print (double val)
 {
-    if (isnan (val))
+    if (OIIO::isnan (val))
         std::cout << "nan";
-    else if (isinf (val))
+    else if (OIIO::isinf (val))
         std::cout << "inf";
     else
         std::cout << val;


### PR DESCRIPTION
Hi Larry, 

Just a few fixes I had to make in order to compile under -std=c++11 on GCC 4.9.1 - Centos 6.5.

The using declarations inside of `missing_math.h` were particularly nasty, as they leak out into the public interface. I don't have any way to test this on Windows, but the declarations I removed seemed to already exist in the OIIO namespace, so maybe we should just patch the places where it fails to compile with the relevant OIIO namespace.

I've already changed some of the calls in idiff and oiiotool to use OIIO::isnan / OIIO::isinf respectively. 

Cheers,
Mark
