### PR TITLE
Add veq, vneq, ... etc, component-wise comparisons to float4, int4, mask4

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -384,6 +384,31 @@ public:
     }
 
     /// Equality comparison, component by component
+    friend OIIO_FORCEINLINE const mask4 veq (mask4 a, mask4 b) {
+#if defined(OIIO_SIMD_SSE)
+        return _mm_castsi128_ps (_mm_cmpeq_epi32 (_mm_castps_si128 (a.m_vec), _mm_castps_si128(b.m_vec)));
+#else
+        return mask4 (a[0] == b[0],
+                      a[1] == b[1],
+                      a[2] == b[2],
+                      a[3] == b[3]);
+#endif
+    }
+
+    /// Inequality comparison, component by component
+    friend OIIO_FORCEINLINE const mask4 vne (mask4 a, mask4 b) {
+#if defined(OIIO_SIMD_SSE)
+        return _mm_xor_ps (a.m_vec, b.m_vec);
+#else
+        return mask4 (a[0] != b[0],
+                      a[1] != b[1],
+                      a[2] != b[2],
+                      a[3] != b[3]);
+#endif
+    }
+
+#if 1
+    /// Equality comparison, component by component
     friend OIIO_FORCEINLINE const mask4 operator== (mask4 a, mask4 b) {
 #if defined(OIIO_SIMD_SSE)
         return _mm_castsi128_ps (_mm_cmpeq_epi32 (_mm_castps_si128 (a.m_vec), _mm_castps_si128(b.m_vec)));
@@ -406,6 +431,7 @@ public:
                       a[3] != b[3]);
 #endif
     }
+#endif
 
     /// Stream output
     friend inline std::ostream& operator<< (std::ostream& cout, mask4 a) {
@@ -900,6 +926,43 @@ public:
     }
 
 
+    friend OIIO_FORCEINLINE mask4 veq (int4 a, int4 b) {
+#if defined(OIIO_SIMD_SSE)
+        return _mm_castsi128_ps(_mm_cmpeq_epi32 (a.m_vec, b.m_vec));
+#else
+        return mask4 (a[0] == b[0], a[1] == b[1], a[2] == b[2], a[3] == b[3]);
+#endif
+    }
+  
+    friend OIIO_FORCEINLINE mask4 vne (int4 a, int4 b) {
+        return ! veq(a,b);
+    }
+  
+    friend OIIO_FORCEINLINE mask4 vlt (int4 a, int4 b) {
+#if defined(OIIO_SIMD_SSE)
+        return _mm_castsi128_ps(_mm_cmplt_epi32 (a.m_vec, b.m_vec));
+#else
+        return mask4 (a[0] < b[0], a[1] < b[1], a[2] < b[2], a[3] < b[3]);
+#endif
+    }
+  
+    friend OIIO_FORCEINLINE mask4 vgt (int4 a, int4 b) {
+#if defined(OIIO_SIMD_SSE)
+        return _mm_castsi128_ps(_mm_cmpgt_epi32 (a.m_vec, b.m_vec));
+#else
+        return mask4 (a[0] > b[0], a[1] > b[1], a[2] > b[2], a[3] > b[3]);
+#endif
+    }
+
+    friend OIIO_FORCEINLINE mask4 vge (int4 a, int4 b) {
+        return !vlt(a,b);
+    }
+
+    friend OIIO_FORCEINLINE mask4 vle (int4 a, int4 b) {
+        return !vgt(a,b);
+    }
+
+#if 1
     friend OIIO_FORCEINLINE mask4 operator== (int4 a, int4 b) {
 #if defined(OIIO_SIMD_SSE)
         return _mm_castsi128_ps(_mm_cmpeq_epi32 (a.m_vec, b.m_vec));
@@ -911,7 +974,9 @@ public:
     friend OIIO_FORCEINLINE mask4 operator!= (int4 a, int4 b) {
         return ! (a == b);
     }
-  
+#endif
+
+#if 1
     friend OIIO_FORCEINLINE mask4 operator< (int4 a, int4 b) {
 #if defined(OIIO_SIMD_SSE)
         return _mm_castsi128_ps(_mm_cmplt_epi32 (a.m_vec, b.m_vec));
@@ -935,6 +1000,7 @@ public:
     friend OIIO_FORCEINLINE mask4 operator<= (int4 a, int4 b) {
         return !(a > b);
     }
+#endif
 
     /// Stream output
     friend inline std::ostream& operator<< (std::ostream& cout, int4 val) {
@@ -1434,6 +1500,55 @@ public:
     }
 
 
+    friend OIIO_FORCEINLINE mask4 veq (float4 a, float4 b) {
+#if defined(OIIO_SIMD_SSE)
+        return _mm_cmpeq_ps (a.m_vec, b.m_vec);
+#else
+        return mask4 (a[0] == b[0], a[1] == b[1], a[2] == b[2], a[3] == b[3]);
+#endif
+    }
+  
+    friend OIIO_FORCEINLINE mask4 vne (float4 a, float4 b) {
+#if defined(OIIO_SIMD_SSE)
+        return _mm_cmpneq_ps (a.m_vec, b.m_vec);
+#else
+        return mask4 (a[0] != b[0], a[1] != b[1], a[2] != b[2], a[3] != b[3]);
+#endif
+    }
+  
+    friend OIIO_FORCEINLINE mask4 vlt (float4 a, float4 b) {
+#if defined(OIIO_SIMD_SSE)
+        return _mm_cmplt_ps (a.m_vec, b.m_vec);
+#else
+        return mask4 (a[0] < b[0], a[1] < b[1], a[2] < b[2], a[3] < b[3]);
+#endif
+    }
+  
+    friend OIIO_FORCEINLINE mask4 vgt  (float4 a, float4 b) {
+#if defined(OIIO_SIMD_SSE)
+        return _mm_cmpgt_ps (a.m_vec, b.m_vec);
+#else
+        return mask4 (a[0] > b[0], a[1] > b[1], a[2] > b[2], a[3] > b[3]);
+#endif
+    }
+
+    friend OIIO_FORCEINLINE mask4 vge (float4 a, float4 b) {
+#if defined(OIIO_SIMD_SSE)
+        return _mm_cmpge_ps (a.m_vec, b.m_vec);
+#else
+        return mask4 (a[0] >= b[0], a[1] >= b[1], a[2] >= b[2], a[3] >= b[3]);
+#endif
+    }
+
+    friend OIIO_FORCEINLINE mask4 vle (float4 a, float4 b) {
+#if defined(OIIO_SIMD_SSE)
+        return _mm_cmple_ps (a.m_vec, b.m_vec);
+#else
+        return mask4 (a[0] <= b[0], a[1] <= b[1], a[2] <= b[2], a[3] <= b[3]);
+#endif
+    }
+
+#if 1
     friend OIIO_FORCEINLINE mask4 operator== (float4 a, float4 b) {
 #if defined(OIIO_SIMD_SSE)
         return _mm_cmpeq_ps (a.m_vec, b.m_vec);
@@ -1449,7 +1564,9 @@ public:
         return mask4 (a[0] != b[0], a[1] != b[1], a[2] != b[2], a[3] != b[3]);
 #endif
     }
-  
+#endif
+
+#if 1
     friend OIIO_FORCEINLINE mask4 operator< (float4 a, float4 b) {
 #if defined(OIIO_SIMD_SSE)
         return _mm_cmplt_ps (a.m_vec, b.m_vec);
@@ -1481,6 +1598,7 @@ public:
         return mask4 (a[0] <= b[0], a[1] <= b[1], a[2] <= b[2], a[3] <= b[3]);
 #endif
     }
+#endif
 
     /// Stream output
     friend inline std::ostream& operator<< (std::ostream& cout, float4 val) {


### PR DESCRIPTION
I have come to believe it was a mistake to define ==, !=, <, etc., as
component-wise, in conflict with the understood semantics of the
operators for all other numeric types (which return a bool).

I think the better approach is to define explicit per-component vector
ops veq, vne, vlt, vgt, vge, vle, and then change == and != to return
bools.  Probably the comparison ops should be undefined for vector
types, since there is no canonical ordering and people are probably
going to be confused about whether va < vb means "all components are
less" or "any components are less" or "first component is less"...

OK, so this patch is phase 1: define the vector per-component comparisons.
Phase 2 is going to be replacing any existing use of the old operators,
both in OIIO as well as OSL. After that has settled down, then I'll
return here and remove the deprecated ops and change == and != to return
bools. I'm just afraid that if I do it all in one step, there will be
the opportunity to have subtle bugs if I miss a spot that needs to change
(say, a == that should be veq).
