### PR TITLE
ImageCache: Zero out the SIMD padding in tile allocations!!!

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1249,8 +1249,11 @@ void
 ImageCacheTile::read (ImageCachePerThreadInfo *thread_info)
 {
     size_t size = memsize_needed ();
-    ASSERT (memsize() == 0 && size > 0);
+    ASSERT (memsize() == 0 && size > OIIO_SIMD_MAX_SIZE_BYTES);
     m_pixels.reset (new char [m_pixels_size = size]);
+    // Clear the end pad values so there aren't NaNs sucked up by simd loads
+    memset (m_pixels.get() + size - OIIO_SIMD_MAX_SIZE_BYTES,
+            0, OIIO_SIMD_MAX_SIZE_BYTES);
     ImageCacheFile &file (m_id.file());
     m_valid = file.read_tile (thread_info, m_id.subimage(), m_id.miplevel(),
                               m_id.x(), m_id.y(), m_id.z(),


### PR DESCRIPTION
The texture system tries to use SIMD (SSE) ops. It wants work on four
floats at a time. If there aren't four channels, that's ok, because
we'll zero out "past the end" channels by multiplying with a float mask
that will be 0.  We also pad the end of the allocation for a tile, so if
we retrieve four values (for a texture with < 4 channels) from the last
pixel in the tile, we don't want to run off the end of the allocation
and segfault.

OK, but if it turns out that this padded but uninitialized memory past
the last pixel of the tile happens to have the bit pattern that
corresponds to NaN, then even though it will get multiplied by a mask
such as (1.0, 1.0, 1.0, 0.0), 0_NaN = NaN, *not_ 0! (For any non-NaN
value, the float multiply mask trick would work fine.) So this was
allowing NaNs to creap into the texture results. Oops.

The solution is really simple, which is just to use memset to make sure
the padding at the end of the tile allocation is filled with zero
values.
