### PR TITLE
Python read_scanlines did not honor channel subset, leading to chaos.

### DIFF
--- a/src/python/py_imageinput.cpp
+++ b/src/python/py_imageinput.cpp
@@ -262,7 +262,7 @@ ImageInputWrap::read_scanlines (int ybegin, int yend, int z,
     int nchans = chend - chbegin;
     size_t size = (size_t) spec.width * (yend-ybegin) * nchans * format.size();
     char *data = new char[size];
-    if (!m_input->read_scanlines (ybegin, yend, z, format, data)) {
+    if (!m_input->read_scanlines (ybegin, yend, z, chbegin, chend, format, data)) {
         delete [] data;  // never mind
         return object(handle<>(Py_None));
     }

--- a/testsuite/python-imageinput/ref/out.txt
+++ b/testsuite/python-imageinput/ref/out.txt
@@ -103,6 +103,11 @@ Opened "../../../../../oiio-images/tahoe-gps.jpg" as a jpeg
 @ (2047, 1535) = array('f', [0.15294118225574493, 0.21568627655506134, 0.3490196168422699])
 @ (1024, 768) = array('f', [0.5333333611488342, 0.7176470756530762, 0.9215686321258545])
 
+Opened "../../../../../oiio-images/tahoe-gps.jpg" as a jpeg
+@ (0, 0) = array('B', [40])
+@ (2047, 1535) = array('B', [39])
+@ (1024, 768) = array('B', [136])
+
 Testing read_scanline:
 Opened "../../../../../oiio-images/tahoe-gps.jpg" as a jpeg
 @ (0, 0) = array('B', [40, 35, 57])

--- a/testsuite/python-imageinput/test_imageinput.py
+++ b/testsuite/python-imageinput/test_imageinput.py
@@ -68,9 +68,11 @@ def poor_mans_iinfo (filename) :
 
 # Read the whole image (using either read_image, read_scanlines, or
 # read_tiles, depending on the 'method' argument) and print a few 
-# pixel values ot prove that we have the right data.
+# pixel values ot prove that we have the right data. Read nchannels
+# channels, if nonzero, otherwise read the full channel range in the
+# file.
 def test_readimage (filename, sub=0, mip=0, type=oiio.UNKNOWN,
-                    method="image") :
+                    method="image", nchannels=0) :
     input = oiio.ImageInput.open (filename)
     if not input :
         print 'Could not open "' + filename + '"'
@@ -80,18 +82,20 @@ def test_readimage (filename, sub=0, mip=0, type=oiio.UNKNOWN,
     print 'Opened "' + filename + '" as a ' + input.format_name()
     input.seek_subimage (sub, mip)
     spec = input.spec ()
+    if nchannels == 0 or method == "image" :
+        nchannels = spec.nchannels
     if type == oiio.UNKNOWN :
         type = spec.format.basetype
     if method == "image" :
         data = input.read_image (type)
     elif method == "scanlines" :
         data = input.read_scanlines (spec.y, spec.y+spec.height, spec.z,
-                                     0, spec.nchannels, type)
+                                     0, nchannels, type)
     elif method == "tiles" :
         data = input.read_tiles (spec.x, spec.x+spec.width,
                                  spec.y, spec.y+spec.height,
                                  spec.z, spec.z+spec.depth,
-                                 0, spec.nchannels, type)
+                                 0, nchannels, type)
     else :
         print "Unknown method:", method
         return
@@ -100,14 +104,14 @@ def test_readimage (filename, sub=0, mip=0, type=oiio.UNKNOWN,
         return
     # print the first, last, and middle pixel values
     (x,y) = (spec.x, spec.y)
-    i = ((y-spec.y)*spec.width + (x-spec.x)) * spec.nchannels
-    print "@", (x,y), "=", data[i:i+spec.nchannels]
+    i = ((y-spec.y)*spec.width + (x-spec.x)) * nchannels
+    print "@", (x,y), "=", data[i:i+nchannels]
     (x,y) = (spec.x+spec.width-1, spec.y+spec.height-1)
-    i = ((y-spec.y)*spec.width + (x-spec.x)) * spec.nchannels
-    print "@", (x,y), "=", data[i:i+spec.nchannels]
+    i = ((y-spec.y)*spec.width + (x-spec.x)) * nchannels
+    print "@", (x,y), "=", data[i:i+nchannels]
     (x,y) = (spec.x+spec.width/2, spec.y+spec.height/2)
-    i = ((y-spec.y)*spec.width + (x-spec.x)) * spec.nchannels
-    print "@", (x,y), "=", data[i:i+spec.nchannels]
+    i = ((y-spec.y)*spec.width + (x-spec.x)) * nchannels
+    print "@", (x,y), "=", data[i:i+nchannels]
     input.close ()
     print
 
@@ -195,6 +199,9 @@ try:
     # again, force a float buffer
     test_readimage ("../../../../../oiio-images/tahoe-gps.jpg",
                     type=oiio.FLOAT)
+    # Test read of partial channels
+    test_readimage ("../../../../../oiio-images/tahoe-gps.jpg",
+                    method="scanlines", nchannels=1)
 
     # test readscanline
     print "Testing read_scanline:"


### PR DESCRIPTION
It's a one-line fix. The rest is all just making sure it's tested by the testsuite.
