### PR TITLE
oiiotool -stats on deep files now prints a histogram of samples/pixel.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -111,6 +111,8 @@ Fixes, minor enhancements, and performance improvements:
      long edges as the traditional unsharp mask often does. (1.5.4)
    * oiiotool's help message now says explicitly if it was compiled without
      any support for OpenColorIO. (1.5.5/1.4.15)
+   * oiiotool -stats, on deep files, now prints a histogram of the number
+     of samples per pixel. #992 (1.5.6)
 * maketx:
    * Fix case typo for LatLong env map creation when in 'prman' mode. #877.
      (1.5.1/1.4.10)


### PR DESCRIPTION
Also, for deep images that contain no depth file, skip erroneous printing
of min and maximum depth.
