### PR TITLE
Fix fault in python ImageOutput.write_* functions

### DIFF
--- a/src/python/py_imageoutput.cpp
+++ b/src/python/py_imageoutput.cpp
@@ -115,7 +115,10 @@ bool
 ImageOutputWrap::write_scanline (int y, int z, TypeDesc format, object &buffer,
                                  stride_t xstride)
 {
-    const void *array = make_read_buffer (buffer, m_output->spec().scanline_bytes());
+    bool native = (format == TypeDesc::UNKNOWN);
+    imagesize_t size = native ? m_output->spec().scanline_bytes (native)
+                                  : format.size() * m_output->spec().nchannels * m_output->spec().width;
+    const void *array = make_read_buffer (buffer, size);
     ScopedGILRelease gil;
     return m_output->write_scanline(y, z, format, array, xstride);
 }
@@ -134,7 +137,10 @@ ImageOutputWrap::write_scanlines (int ybegin, int yend, int z,
                                   TypeDesc format, object &buffer,
                                   stride_t xstride)
 {
-    const void *array = make_read_buffer (buffer, m_output->spec().scanline_bytes());
+    bool native = (format == TypeDesc::UNKNOWN);
+    imagesize_t size = native ? m_output->spec().scanline_bytes (native)
+                                  : format.size() * m_output->spec().nchannels * m_output->spec().width;
+    const void *array = make_read_buffer (buffer, size);
     ScopedGILRelease gil;
     return m_output->write_scanlines(ybegin, yend, z, format, array, xstride);
 }
@@ -155,7 +161,9 @@ ImageOutputWrap::write_tile (int x, int y, int z, TypeDesc format,
                              object &buffer, stride_t xstride,
                              stride_t ystride, stride_t zstride)
 {
-    imagesize_t size = m_output->spec().tile_bytes();
+    bool native = (format == TypeDesc::UNKNOWN);
+    imagesize_t size = native ? m_output->spec().tile_bytes (native)
+                                  : format.size() * m_output->spec().nchannels * m_output->spec().tile_pixels();
     const void *array = make_read_buffer(buffer, size);
     ScopedGILRelease gil;
     return m_output->write_tile(x, y, z, format, array, xstride, ystride, zstride);    
@@ -177,7 +185,9 @@ ImageOutputWrap::write_tiles (int xbegin, int xend, int ybegin, int yend,
                               object &buffer, stride_t xstride,
                               stride_t ystride, stride_t zstride)
 {
-    imagesize_t size = m_output->spec().tile_bytes();
+    bool native = (format == TypeDesc::UNKNOWN);
+    imagesize_t size = native ? m_output->spec().tile_bytes (native)
+                                  : format.size() * m_output->spec().nchannels * m_output->spec().tile_pixels();
     const void *array = make_read_buffer(buffer, size);
     ScopedGILRelease gil;
     return m_output->write_tiles (xbegin, xend, ybegin, yend, zbegin, zend,
@@ -201,7 +211,9 @@ ImageOutputWrap::write_image (TypeDesc format, object &buffer,
                               stride_t xstride, stride_t ystride,
                               stride_t zstride)
 {
-    imagesize_t size = m_output->spec().image_bytes();
+    bool native = (format == TypeDesc::UNKNOWN);
+    imagesize_t size = native ? m_output->spec().image_bytes (native)
+                                  : format.size() * m_output->spec().nchannels * m_output->spec().image_pixels();
     const void *array = make_read_buffer (buffer, size);
     ScopedGILRelease gil;
     if (array)


### PR DESCRIPTION
The buffer to be written was assumed to be of the same format as
specified in the ImageOutput's spec, which in generally is not true and
leads to a wrong calculation of the buffer size.

This commit makes the python write_\* functions do something similar to
the C++ ImageOutput::write_image function to calculate the buffer size.

It works for me. I hope I didn't overlook anything.
