### PR TITLE
ImageInput/ImageOutput: Add new supports() feature tags

### DIFF
--- a/src/doc/imageinput.tex
+++ b/src/doc/imageinput.tex
@@ -447,7 +447,7 @@ This can be accomplished using the technique of the following example:
                         f[8], f[9], f[10], f[11], f[12], f[13], f[14], f[15]);
             }
             else
-                printf ("<unknown data type>");
+                printf (" <unknown data type> ");
             printf ("\n");
         }
 \end{code}
@@ -843,8 +843,15 @@ instance supports that feature.  The following features are recognized
 by this query:
 \begin{description}
 \item[\spc] \spc
-\item[\rm ] No queries supported at this time.
-\end{description}
+\item[\rm \qkw{arbitrary_metadata}] Does the image file format allow
+  metadata with arbitrary names (and either arbitrary, or a reasonable set
+  of, data types)? (Versus the file format supporting only a fixed list of
+  specific metadata names/values?
+\item[\rm \qkw{exif}] Does the image file format support Exif camera data
+  (either specifically, or via arbitrary named metadata)?
+\item[\rm \qkw{iptc}] Does the image file format support IPTC data
+  (either specifically, or via arbitrary named metadata)?
+  \end{description}
 \apiend
 
 \apiitem{bool {\ce valid_file} (const std::string \&filename) const}

--- a/src/doc/imageoutput.tex
+++ b/src/doc/imageoutput.tex
@@ -1358,6 +1358,14 @@ by this query:
 \item[\rm \qkw{deepdata}] Does the image format allow ``deep'' data
   consisting of multiple values per pixel (and potentially a differing
   number of values from pixel to pixel)?
+\item[\rm \qkw{arbitrary_metadata}] Does the image file format allow
+  metadata with arbitrary names (and either arbitrary, or a reasonable set
+  of, data types)? (Versus the file format supporting only a fixed list of
+  specific metadata names/values?
+\item[\rm \qkw{exif}] Does the image file format support Exif camera data
+  (either specifically, or via arbitrary named metadata)?
+\item[\rm \qkw{iptc}] Does the image file format support IPTC data
+  (either specifically, or via arbitrary named metadata)?
 \end{description}
 
 \noindent This list of queries may be extended in future releases.

--- a/src/field3d.imageio/field3dinput.cpp
+++ b/src/field3d.imageio/field3dinput.cpp
@@ -61,6 +61,9 @@ public:
     Field3DInput () { init(); }
     virtual ~Field3DInput () { close(); }
     virtual const char * format_name (void) const { return "field3d"; }
+    virtual bool supports (const std::string &feature) const {
+        return (feature == "arbitrary_metadata");
+    }
     virtual bool valid_file (const std::string &filename) const;
     virtual bool open (const std::string &name, ImageSpec &newspec);
     virtual bool close ();

--- a/src/field3d.imageio/field3doutput.cpp
+++ b/src/field3d.imageio/field3doutput.cpp
@@ -153,17 +153,15 @@ Field3DOutput::~Field3DOutput ()
 bool
 Field3DOutput::supports (const std::string &feature) const
 {
-    if (feature == "tiles")
-        return true;
-    if (feature == "multiimage")
-        return true;
-    if (feature == "random_access")
-        return true;
+    return (feature == "tiles"
+         || feature == "multiimage"
+         || feature == "random_access"
+         || feature == "arbitrary_metadata"
+         || feature == "exif"   // Because of arbitrary_metadata
+         || feature == "iptc"); // Because of arbitrary_metadata
 
     // FIXME: we could support "empty"
-
-    // Everything else, we either don't support or don't know about
-    return false;
+    // FIXME: newer releases of Field3D support mipmap
 }
 
 

--- a/src/fits.imageio/fits_pvt.h
+++ b/src/fits.imageio/fits_pvt.h
@@ -69,6 +69,11 @@ class FitsInput : public ImageInput {
     FitsInput () { init (); }
     virtual ~FitsInput () { close (); }
     virtual const char *format_name (void) const { return "fits"; }
+    virtual bool supports (const std::string &feature) const {
+        return (feature == "arbitrary_metadata"
+             || feature == "exif"   // Because of arbitrary_metadata
+             || feature == "iptc"); // Because of arbitrary_metadata
+    }
     virtual bool valid_file (const std::string &filename) const;
     virtual bool open (const std::string &name, ImageSpec &spec);
     virtual bool close (void);
@@ -136,7 +141,13 @@ class FitsOutput : public ImageOutput {
     FitsOutput () { init (); }
     virtual ~FitsOutput () { close (); }
     virtual const char *format_name (void) const { return "fits"; }
-    virtual bool supports (const std::string &feature) const;
+    virtual bool supports (const std::string &feature) const {
+        return (feature == "multiimage"
+             || feature == "random_access"
+             || feature == "arbitrary_metadata"
+             || feature == "exif"   // Because of arbitrary_metadata
+             || feature == "iptc"); // Because of arbitrary_metadata
+    }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close (void);

--- a/src/fits.imageio/fitsoutput.cpp
+++ b/src/fits.imageio/fitsoutput.cpp
@@ -149,19 +149,6 @@ FitsOutput::write_tile (int x, int y, int z, TypeDesc format,
 
 
 bool
-FitsOutput::supports (const std::string &feature) const
-{
-    // for now we only supports IMAGE extensions
-    if (feature == "multiimage")
-        return true;
-    if (feature == "random_access")
-        return true;
-    return false;
-}
-
-
-
-bool
 FitsOutput::close (void)
 {
     if (! m_fd) {   // already closed

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -443,6 +443,22 @@ public:
     ///
     virtual const char *format_name (void) const = 0;
 
+    /// Given the name of a 'feature', return whether this ImageInput
+    /// supports input of images with the given properties.
+    /// Feature names that ImageIO plugins are expected to recognize
+    /// include:
+    ///    "arbitrary_metadata" Does this format allow metadata with
+    ///                        arbitrary names and types?
+    ///    "exif"           Can this format store Exif camera data?
+    ///    "iptc"           Can this format store IPTC data?
+    ///
+    /// Note that main advantage of this approach, versus having
+    /// separate individual supports_foo() methods, is that this allows
+    /// future expansion of the set of possible queries without changing
+    /// the API, adding new entry points, or breaking linkage
+    /// compatibility.
+    virtual bool supports (const std::string & /*feature*/) const { return false; }
+
     /// Return true if the named file is file of the type for this
     /// ImageInput.  The implementation will try to determine this as
     /// efficiently as possible, in most cases much less expensively
@@ -472,19 +488,6 @@ public:
     /// are invalid before open() or after close(), and may change with
     /// a call to seek_subimage().
     const ImageSpec &spec (void) const { return m_spec; }
-
-    /// Given the name of a 'feature', return whether this ImageInput
-    /// supports input of images with the given properties.
-    /// Feature names that ImageIO plugins are expected to recognize
-    /// include:
-    ///    none at this time
-    ///
-    /// Note that main advantage of this approach, versus having
-    /// separate individual supports_foo() methods, is that this allows
-    /// future expansion of the set of possible queries without changing
-    /// the API, adding new entry points, or breaking linkage
-    /// compatibility.
-    virtual bool supports (const std::string & /*feature*/) const { return false; }
 
     /// Close an image that we are totally done with.
     ///
@@ -844,6 +847,10 @@ public:
     ///    "negativeorigin" Does the format support negative x,y,z
     ///                        and full_{x,y,z} origin values?
     ///    "deepdata"       Deep (multi-sample per pixel) data
+    ///    "arbitrary_metadata" Does this format allow metadata with
+    ///                        arbitrary names and types?
+    ///    "exif"           Can this format store Exif camera data?
+    ///    "iptc"           Can this format store IPTC data?
     ///
     /// Note that main advantage of this approach, versus having
     /// separate individual supports_foo() methods, is that this allows

--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -69,6 +69,10 @@ class JpgInput : public ImageInput {
     JpgInput () { init(); }
     virtual ~JpgInput () { close(); }
     virtual const char * format_name (void) const { return "jpeg"; }
+    virtual bool supports (const std::string &feature) {
+        return (feature == "exif"
+             || feature == "iptc");
+    }
     virtual bool valid_file (const std::string &filename) const;
     virtual bool open (const std::string &name, ImageSpec &spec);
     virtual bool open (const std::string &name, ImageSpec &spec,

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -57,7 +57,10 @@ class JpgOutput : public ImageOutput {
     JpgOutput () { init(); }
     virtual ~JpgOutput () { close(); }
     virtual const char * format_name (void) const { return "jpeg"; }
-    virtual bool supports (const std::string &property) const { return false; }
+    virtual bool supports (const std::string &feature) {
+        return (feature == "exif"
+             || feature == "iptc");
+    }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool write_scanline (int y, int z, TypeDesc format,

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -47,6 +47,10 @@ class Jpeg2000Input : public ImageInput {
     Jpeg2000Input () { init (); }
     virtual ~Jpeg2000Input () { close (); }
     virtual const char *format_name (void) const { return "jpeg2000"; }
+    virtual bool supports (const std::string &feature) const {
+        return false;
+        // FIXME: we should support Exif/IPTC, but currently don't.
+    }
     virtual bool open (const std::string &name, ImageSpec &spec);
     virtual bool close (void);
     virtual bool read_native_scanline (int y, int z, void *data);

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -43,7 +43,10 @@ class Jpeg2000Output : public ImageOutput {
     Jpeg2000Output () { init (); }
     virtual ~Jpeg2000Output () { close (); }
     virtual const char *format_name (void) const { return "jpeg2000"; }
-    virtual bool supports (const std::string &feature) const { return false; }
+    virtual bool supports (const std::string &feature) const {
+        return false;
+        // FIXME: we should support Exif/IPTC, but currently don't.
+    }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close ();

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -140,6 +140,11 @@ public:
     OpenEXRInput ();
     virtual ~OpenEXRInput () { close(); }
     virtual const char * format_name (void) const { return "openexr"; }
+    virtual bool supports (const std::string &feature) const {
+        return (feature == "arbitrary_metadata"
+             || feature == "exif"   // Because of arbitrary_metadata
+             || feature == "iptc"); // Because of arbitrary_metadata
+    }
     virtual bool valid_file (const std::string &filename) const;
     virtual bool open (const std::string &name, ImageSpec &newspec);
     virtual bool close ();

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -292,6 +292,12 @@ OpenEXROutput::supports (const std::string &feature) const
         return true;
     if (feature == "negativeorigin")
         return true;
+    if (feature == "arbitrary_metadata")
+        return true;
+    if (feature == "exif")   // Because of arbitrary_metadata
+        return true;
+    if (feature == "iptc")   // Because of arbitrary_metadata
+        return true;
 #ifdef USE_OPENEXR_VERSION2
     if (feature == "multiimage")
         return true;  // N.B. But OpenEXR does not support "appendsubimage"

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -50,6 +50,10 @@ public:
     PSDInput ();
     virtual ~PSDInput () { close(); }
     virtual const char * format_name (void) const { return "psd"; }
+    virtual bool supports (const std::string &feature) const {
+        return (feature == "exif"
+             || feature == "iptc");
+    }
     virtual bool open (const std::string &name, ImageSpec &newspec);
     virtual bool open (const std::string &name, ImageSpec &newspec,
                        const ImageSpec &config);

--- a/src/ptex.imageio/ptexinput.cpp
+++ b/src/ptex.imageio/ptexinput.cpp
@@ -43,6 +43,11 @@ public:
     PtexInput () : m_ptex(NULL) { init(); }
     virtual ~PtexInput () { close(); }
     virtual const char * format_name (void) const { return "ptex"; }
+    virtual bool supports (const std::string &feature) const {
+        return (feature == "arbitrary_metadata"
+             || feature == "exif"   // Because of arbitrary_metadata
+             || feature == "iptc"); // Because of arbitrary_metadata
+    }
     virtual bool open (const std::string &name, ImageSpec &newspec);
     virtual bool close ();
     virtual int current_subimage (void) const { return m_subimage; }

--- a/src/ptex.imageio/ptexoutput.cpp
+++ b/src/ptex.imageio/ptexoutput.cpp
@@ -92,14 +92,12 @@ PtexOutput::~PtexOutput ()
 bool
 PtexOutput::supports (const std::string &feature) const
 {
-    // Support nothing nonstandard
-    if (feature == "tiles")
-        return true;
-    if (feature == "multiimage")
-        return true;
-    if (feature == "mipmap")
-        return false;   // N.B. because PtexWriters mipmaps automatically!
-    return false;
+    return (feature == "tiles"
+         || feature == "multiimage"
+         || feature == "mipmap"
+         || feature == "arbitrary_metadata"
+         || feature == "exif"   // Because of arbitrary_metadata
+         || feature == "iptc"); // Because of arbitrary_metadata
 }
 
 

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -47,6 +47,10 @@ public:
     RawInput () : m_process(true), m_image(NULL) {}
     virtual ~RawInput() { close(); }
     virtual const char * format_name (void) const { return "raw"; }
+    virtual bool supports (const std::string &feature) const {
+        return (feature == "exif"
+             /* not yet? || feature == "iptc"*/);
+    }
     virtual bool open (const std::string &name, ImageSpec &newspec);
     virtual bool open (const std::string &name, ImageSpec &newspec,
                        const ImageSpec &config);

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -94,6 +94,11 @@ public:
     virtual ~TIFFInput ();
     virtual const char * format_name (void) const { return "tiff"; }
     virtual bool valid_file (const std::string &filename) const;
+    virtual bool supports (const std::string &feature) const {
+        return (feature == "exif"
+             || feature == "iptc");
+        // N.B. No support for arbitrary metadata.
+    }
     virtual bool open (const std::string &name, ImageSpec &newspec);
     virtual bool open (const std::string &name, ImageSpec &newspec,
                        const ImageSpec &config);

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -160,6 +160,11 @@ TIFFOutput::supports (const std::string &feature) const
     if (feature == "origin")
         return true;
     // N.B. TIFF doesn't support "negativeorigin"
+    if (feature == "exif")
+        return true;
+    if (feature == "iptc")
+        return true;
+    // N.B. TIFF doesn't support arbitrary metadata.
 
     // FIXME: we could support "volumes" and "empty"
 


### PR DESCRIPTION
- "arbitrary_metadata" if the format has arbitrarily-named metadata.
- "exif" if the format can store camera Exif data
- "iptc" if the format can store IPTC metadata
