### PR TITLE
Deal more gracefully with out-of-range subimages.

### DIFF
--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -398,14 +398,15 @@ DDSInput::internal_seek_subimage (int cubeface, int miplevel, unsigned int& w,
 bool
 DDSInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
 {
+    if (subimage != 0)
+        return false;
+
     // early out
     if (subimage == current_subimage() && miplevel == current_miplevel()) {
         newspec = m_spec;
         return true;
     }
 
-    if (subimage != 0)
-        return false;
     // don't seek if the image doesn't contain mipmaps, isn't 3D or a cube map,
     // and don't seek out of bounds
     if (miplevel < 0 || (!(m_dds.caps.flags1 & DDS_CAPS1_COMPLEX) && miplevel != 0)

--- a/src/ico.imageio/icoinput.cpp
+++ b/src/ico.imageio/icoinput.cpp
@@ -156,16 +156,13 @@ ICOInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
 {
     /*std::cerr << "[ico] seeking subimage " << index << " (current "
               << m_subimage << ") out of " << m_ico.count << "\n";*/
-    if (miplevel != 0)
+    if (miplevel != 0 || subimage < 0 || subimage >= m_ico.count)
         return false;
 
     if (subimage == m_subimage) {
         newspec = spec();
         return true;
     }
-
-    if (subimage < 0 || subimage >= m_ico.count)
-        return false;
 
     // clear the buffer of previous data
     m_buf.clear ();

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1603,10 +1603,19 @@ action_select_subimage (int argc, const char *argv[])
     Timer timer (ot.enable_function_timing);
 
     ot.read ();
+
+    int subimage = atoi(argv[1]);
+    if (subimage < 0 || subimage >= ot.curimg->subimages()) {
+        ot.error ("-subimage",
+                 Strutil::format ("Invalid -subimage (%d): %s has %d subimage%s",
+                                  subimage, ot.curimg->name(), ot.curimg->subimages(),
+                                  ot.curimg->subimages() == 1 ? "" : "s"));
+        return 0;
+    }
+
     if (ot.curimg->subimages() == 1)
         return 0;    // --subimage on a single-image file is a no-op
     
-    int subimage = std::min (atoi(argv[1]), ot.curimg->subimages());
     ImageRecRef A = ot.pop();
     ot.push (new ImageRec (*A, subimage));
     ot.function_times["subimage"] += timer();


### PR DESCRIPTION
oiiotool -subimage : better error detection and reporting of requests
for nonexistant subimages.

Fix the one or two spots in image readers that weren't fully robust for
this (especially for negative subimages). In the vast majority of readers,
it was already catching it properly.
