### PR TITLE
texture: average and constant color handling

### DIFF
--- a/src/doc/stdmetadata.tex
+++ b/src/doc/stdmetadata.tex
@@ -247,6 +247,26 @@ row/column of pixels lie exactly at the $s$ or $t = 0$ or $1$
 boundaries, i.e., $s = i/(\mathit{xres}-1)$ and $t = j/(\mathit{yres}-1)$.
 \apiend
 
+\apiitem{"oiio:ConstantColor" : string}
+If present, is a hint that the texture has the same value in all pixels,
+and the metadata value is a string containing the channel values as
+a comma-separated list (no spaces, for example: \qkw{0.73,0.9,0.11,1.0}).
+\apiend
+
+\apiitem{"oiio:AverageColor" : string}
+If present, is a hint giving the \emph{average} value of all pixels in the
+texture, as a string containing a comma-separated list of the channel values
+(no spaces, for example: \qkw{0.73,0.9,0.11,1.0}).
+\apiend
+
+\apiitem{"oiio:SHA-1" : string}
+If present, is a 40-byte SHA-1 hash of the input image (possibly salted with
+various maketx options) that can serve to quickly compare two separate
+textures to know if they contain the same pixels. While it's not, technically,
+100\% guaranteed that no separate textures will match, it's so astronomically
+unlikely that we discount the possibility (you'd be rendering movies for
+centuries before finding a single match).
+\apiend
 
 \section{Exif metadata}
 \label{sec:metadata:exif}

--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -1176,6 +1176,27 @@ $4 \times 4$ matrix (an {\cf Imath::M44f}, described as {\cf
 $4 \times 4$ matrix (an {\cf Imath::M44f}, described as {\cf
   TypeDesc(FLOAT,MATRIX)}).
 
+\item[\rm \kw{averagecolor}] If available in the metadata (generally only
+for files that have been processed by {\cf maketx}), this will return the
+average color of the texture (into an array of floats).  \NEW
+
+\item[\rm \kw{averagealpha}] If available in the metadata (generally only
+for files that have been processed by {\cf maketx}), this will return the
+average alpha value of the texture (into a float).
+
+\item[\rm \kw{constantcolor}] If the metadata (generally only for files that
+have been processed by {\cf maketx}) indicates that the texture has the same
+values for all pixels in the texture, this will retrieve the constant color
+of the texture (into an array of floats). A non-constant image (or one that
+does not have the special metadata tag identifying it as a constant texture)
+will fail this query (return false). \NEW
+
+\item[\rm \kw{constantalpha}] If the metadata indicates that the texture has
+the same values for all pixels in the texture, this will retrieve the
+constant alpha value of the texture (into a float). A non-constant image (or
+one that does not have the special metadata tag identifying it as a constant
+texture) will fail this query (return false).
+
 \item[Anything else] -- For all other data names, the
 the metadata of the image file will be searched for an item that
 matches both the name and data type.

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -1774,6 +1774,9 @@ enum OIIO_API MakeTextureMode {
 ///    maketx:opaque_detect (int)
 ///                           If nonzero, drop the alpha channel if alpha
 ///                              is 1.0 in all pixels (default: 0).
+///    maketx:compute_average (int)
+///                           If nonzero, compute and store the average
+///                              color of the texture (default: 1).
 ///    maketx:unpremult (int) If nonzero, unpremultiply color by alpha before
 ///                              color conversion, then multiply by alpha
 ///                              after color conversion (default: 0).

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -199,6 +199,10 @@ public:
     void duplicate (ImageCacheFile *dup) { m_duplicate = dup;}
     ImageCacheFile *duplicate () const { return m_duplicate; }
 
+    // Retrieve the average color, or try to compute it. Return true on
+    // success, false on failure.
+    bool get_average_color (float *avg, int subimage, int chbegin, int chend);
+
     /// Info for each MIP level that isn't in the ImageSpec, or that we
     /// precompute.
     struct LevelInfo {
@@ -223,6 +227,10 @@ public:
         bool volume;                    ///< It's a volume image
         bool full_pixel_range;          ///< pixel data window matches image window
         bool eightbit;                  ///< Eight bit?  (or float)
+        bool is_constant_image;         ///< Is the image a constant color?
+        bool has_average_color;         ///< We have an average color
+        std::vector<float> average_color; ///< Average color
+        spin_mutex average_color_mutex; ///< protect average_color
 
         // The scale/offset accounts for crops or overscans, converting
         // 0-1 texture space relative to the "display/full window" into 
@@ -234,6 +242,7 @@ public:
                           channelsize(0), pixelsize(0),
                           untiled(false), unmipped(false), volume(false),
                           full_pixel_range(false), eightbit(false),
+                          is_constant_image(false), has_average_color(false),
                           sscale(1.0f), soffset(0.0f),
                           tscale(1.0f), toffset(0.0f) { }
         void init (const ImageSpec &spec, bool forcefloat);

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -204,6 +204,7 @@ getargs (int argc, char *argv[], ImageSpec &configspec)
     bool constant_color_detect = false;
     bool monochrome_detect = false;
     bool opaque_detect = false;
+    bool compute_average = true;
     int nchannels = -1;
     bool prman = false;
     bool oiio = false;
@@ -272,6 +273,7 @@ getargs (int argc, char *argv[], ImageSpec &configspec)
                   "--constant-color-detect", &constant_color_detect, "Create 1-tile textures from constant color inputs",
                   "--monochrome-detect", &monochrome_detect, "Create 1-channel textures from monochrome inputs",
                   "--opaque-detect", &opaque_detect, "Drop alpha channel that is always 1.0",
+                  "--no-compute-average %!", &compute_average, "Don't compute and store average color",
                   "--ignore-unassoc", &ignore_unassoc, "Ignore unassociated alpha tags in input (don't autoconvert)",
                   "--stats", &stats, "Print runtime statistics",
                   "--mipimage %L", &mipimages, "Specify an individual MIP level",
@@ -368,6 +370,7 @@ getargs (int argc, char *argv[], ImageSpec &configspec)
     configspec.attribute ("maketx:constant_color_detect", constant_color_detect);
     configspec.attribute ("maketx:monochrome_detect", monochrome_detect);
     configspec.attribute ("maketx:opaque_detect", opaque_detect);
+    configspec.attribute ("maketx:compute_average", compute_average);
     configspec.attribute ("maketx:unpremult", unpremult);
     configspec.attribute ("maketx:incolorspace", incolorspace);
     configspec.attribute ("maketx:outcolorspace", outcolorspace);

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -486,9 +486,11 @@ adjust_output_options (string_view filename,
         spec.attribute ("oiio:dither", h);
     }
 
-    // Make sure we kill any pixel value hash that may have been in the
-    // input.
+    // Make sure we kill any special hints that maketx adds and that will
+    // no longer be valid after whatever oiiotool operations we've done.
     spec.erase_attribute ("oiio:SHA-1");
+    spec.erase_attribute ("oiio:ConstantColor");
+    spec.erase_attribute ("oiio:AverageColor");
 }
 
 

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -836,8 +836,15 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
 
     // Special handling of any remaining "oiio:*" metadata.
     if (Strutil::istarts_with (xname, "oiio:")) {
-        // None currently supported
-        return false;
+        if (Strutil::iequals (xname, "oiio:ConstantColor") ||
+            Strutil::iequals (xname, "oiio:AverageColor") ||
+            Strutil::iequals (xname, "oiio:SHA-1")) {
+            // let these fall through and get stored as metadata
+        } else {
+            // Other than the listed exceptions, suppress any other custom
+            // oiio: directives.
+            return false;
+        }
     }
 
     // Before handling general named metadata, suppress non-openexr

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -257,6 +257,25 @@ test_gettextureinfo (ustring filename)
     std::cout << "Result of get_texture_info datetime = " << ok << ' '
               << (datetime ? datetime : "") << "\n";
 
+    float avg[4];
+    ok = texsys->get_texture_info (filename, 0, ustring("averagecolor"),
+                                   TypeDesc(TypeDesc::FLOAT,4), avg);
+    std::cout << "Result of get_texture_info averagecolor = " << (ok?"yes":"no\n");
+    if (ok)
+        std::cout << " " << avg[0] << ' ' << avg[1] << ' '
+                  << avg[2] << ' ' << avg[3] << "\n";
+    ok = texsys->get_texture_info (filename, 0, ustring("averagealpha"),
+                                   TypeDesc::TypeFloat, avg);
+    std::cout << "Result of get_texture_info averagealpha = " << (ok?"yes":"no\n");
+    if (ok)
+        std::cout << " " << avg[0] << "\n";
+    ok = texsys->get_texture_info (filename, 0, ustring("constantcolor"),
+                                   TypeDesc(TypeDesc::FLOAT,4), avg);
+    std::cout << "Result of get_texture_info constantcolor = " << (ok?"yes":"no\n");
+    if (ok)
+        std::cout << " " << avg[0] << ' ' << avg[1] << ' '
+                  << avg[2] << ' ' << avg[3] << "\n";
+
     const char *texturetype = NULL;
     ok = texsys->get_texture_info (filename, 0, ustring("textureformat"),
                                    TypeDesc::STRING, &texturetype);

--- a/testsuite/maketx/ref/out-alt-tiff4.txt
+++ b/testsuite/maketx/ref/out-alt-tiff4.txt
@@ -5,7 +5,6 @@ grid.tx              : 1000 x 1000, 4 channel, uint8 tiff
     channel list: R, G, B, A
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=9CA964417213269190944948273FB1F00A4A8393"
     Orientation: 1 (normal)
     XResolution: 72
     YResolution: 72
@@ -19,6 +18,8 @@ grid.tx              : 1000 x 1000, 4 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
+    oiio:AverageColor: "0.608983,0.608434,0.608728,1"
+    oiio:SHA-1: "9CA964417213269190944948273FB1F00A4A8393"
 Reading grid-resize.tx
 grid-resize.tx       : 1024 x 1024, 4 channel, uint8 tiff
     MIP-map levels: 1024x1024 512x512 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -26,7 +27,6 @@ grid-resize.tx       : 1024 x 1024, 4 channel, uint8 tiff
     channel list: R, G, B, A
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=C4BE40DC3B3534F30ACB906602F2FF80A246C01E"
     Orientation: 1 (normal)
     XResolution: 72
     YResolution: 72
@@ -40,6 +40,8 @@ grid-resize.tx       : 1024 x 1024, 4 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
+    oiio:AverageColor: "0.608983,0.608434,0.608728,1"
+    oiio:SHA-1: "C4BE40DC3B3534F30ACB906602F2FF80A246C01E"
 Reading checker-uint16.tx
 checker-uint16.tx    :  128 x  128, 4 channel, uint16 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -47,7 +49,6 @@ checker-uint16.tx    :  128 x  128, 4 channel, uint16 tiff
     channel list: R, G, B, A
     tile size: 64 x 64
     oiio:BitsPerSample: 16
-    ImageDescription: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -57,6 +58,8 @@ checker-uint16.tx    :  128 x  128, 4 channel, uint16 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-1chan.tx
 checker-1chan.tx     :  128 x  128, 1 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -64,7 +67,6 @@ checker-1chan.tx     :  128 x  128, 1 channel, uint8 tiff
     channel list: A
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=1D0A2254373A69C054C08672041FC7DE3BAE5179"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -74,6 +76,8 @@ checker-1chan.tx     :  128 x  128, 1 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
+    oiio:AverageColor: "0.5"
+    oiio:SHA-1: "1D0A2254373A69C054C08672041FC7DE3BAE5179"
 Reading checker-16x32tile.tx
 checker-16x32tile.tx :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -81,7 +85,6 @@ checker-16x32tile.tx :  128 x  128, 4 channel, uint8 tiff
     channel list: R, G, B, A
     tile size: 16 x 32
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -91,6 +94,8 @@ checker-16x32tile.tx :  128 x  128, 4 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-seplzw.tx
 checker-seplzw.tx    :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -98,7 +103,6 @@ checker-seplzw.tx    :  128 x  128, 4 channel, uint8 tiff
     channel list: R, G, B, A
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -108,6 +112,8 @@ checker-seplzw.tx    :  128 x  128, 4 channel, uint8 tiff
     planarconfig: "separate"
     tiff:Compression: 5
     compression: "lzw"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-clamp.tx
 checker-clamp.tx     :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -115,7 +121,6 @@ checker-clamp.tx     :  128 x  128, 4 channel, uint8 tiff
     channel list: R, G, B, A
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "clamp,clamp"
@@ -125,6 +130,8 @@ checker-clamp.tx     :  128 x  128, 4 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-permir.tx
 checker-permir.tx    :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -132,7 +139,6 @@ checker-permir.tx    :  128 x  128, 4 channel, uint8 tiff
     channel list: R, G, B, A
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "periodic,mirror"
@@ -142,13 +148,14 @@ checker-permir.tx    :  128 x  128, 4 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-nomip.tx
 checker-nomip.tx     :  128 x  128, 4 channel, uint8 tiff
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -158,6 +165,8 @@ checker-nomip.tx     :  128 x  128, 4 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-camera.tx
 checker-camera.tx    :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -165,7 +174,6 @@ checker-camera.tx    :  128 x  128, 4 channel, uint8 tiff
     channel list: R, G, B, A
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -177,6 +185,8 @@ checker-camera.tx    :  128 x  128, 4 channel, uint8 tiff
     compression: "zip"
     worldtocamera: 1 0 0 0 0 2 0 0 0 0 1 0 0 0 0 1
     worldtoscreen: 3 0 0 0 0 3 0 0 0 0 3 0 1 2 3 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-opaque.tx
 checker-opaque.tx    :  128 x  128, 3 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -184,7 +194,6 @@ checker-opaque.tx    :  128 x  128, 3 channel, uint8 tiff
     channel list: R, G, B
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=2BE3743A64D4309645F94CA7B37D0CD08AF0B38E"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -194,6 +203,8 @@ checker-opaque.tx    :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
+    oiio:AverageColor: "0.5,0.5,0.5"
+    oiio:SHA-1: "2BE3743A64D4309645F94CA7B37D0CD08AF0B38E"
 Reading gray-mono.tx
 gray-mono.tx         :  256 x  256, 1 channel, uint8 tiff
     MIP-map levels: 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -201,7 +212,6 @@ gray-mono.tx         :  256 x  256, 1 channel, uint8 tiff
     channel list: A
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=24049CDF337F17E162291C7B626E0588A9D71160"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -211,6 +221,9 @@ gray-mono.tx         :  256 x  256, 1 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
+    oiio:ConstantColor: "0.25098"
+    oiio:AverageColor: "0.25098"
+    oiio:SHA-1: "24049CDF337F17E162291C7B626E0588A9D71160"
 Reading pink-mono.tx
 pink-mono.tx         :  256 x  256, 3 channel, uint8 tiff
     MIP-map levels: 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -218,7 +231,6 @@ pink-mono.tx         :  256 x  256, 3 channel, uint8 tiff
     channel list: R, G, B
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=D5F1500992EFBDA77B89E946A9F53F89D332B6F4"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -228,6 +240,9 @@ pink-mono.tx         :  256 x  256, 3 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
+    oiio:ConstantColor: "0.25098,0.2,0.14902"
+    oiio:AverageColor: "0.25098,0.2,0.14902"
+    oiio:SHA-1: "D5F1500992EFBDA77B89E946A9F53F89D332B6F4"
 Reading checker-prman.tx
 checker-prman.tx     :  128 x  128, 4 channel, int16 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -235,7 +250,6 @@ checker-prman.tx     :  128 x  128, 4 channel, int16 tiff
     channel list: R, G, B, A
     tile size: 64 x 32
     oiio:BitsPerSample: 16
-    ImageDescription: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -245,6 +259,8 @@ checker-prman.tx     :  128 x  128, 4 channel, int16 tiff
     planarconfig: "separate"
     tiff:Compression: 8
     compression: "zip"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading nan.exr
 nan.exr              :   64 x   64, 3 channel, half openexr
     SHA-1: 47A8E8F3E8B2C3B6B032FCC8C39D3C5FC1AAA390
@@ -252,8 +268,9 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     tile size: 64 x 64
     oiio:ColorSpace: "Linear"
     compression: "zip"
-    ImageDescription: "SHA-1=44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5"
+    oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     openexr:levelmode: 0
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
@@ -280,8 +297,9 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     textureformat: "Plain Texture"
     compression: "zip"
     Orientation: 1 (normal)
-    ImageDescription: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
     fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
@@ -291,7 +309,7 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     SHA-1: BE1D5EA24E907A4C4B3FB3C28EAC872A20F5B414
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    ImageDescription: "foo SHA-1=1234abcd ConstantColor=[0.0,0,-0.0] bar"
+    ImageDescription: "foo ConstantColor=[0.0,0,-0.0] bar"
     Orientation: 1 (normal)
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -299,6 +317,7 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     tiff:Compression: 8
     compression: "zip"
     tiff:RowsPerStrip: 32
+    oiio:SHA-1: "1234abcd ConstantColor=[0.0,0,-0.0] bar"
 Reading small.tx
 small.tx             :   64 x   64, 3 channel, uint8 tiff
     MIP-map levels: 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -306,7 +325,7 @@ small.tx             :   64 x   64, 3 channel, uint8 tiff
     channel list: R, G, B
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "foo bar SHA-1=1DD1CB3C76F9A491B115F85A6DAC1B1A8DD2D3CB ConstantColor=[1,0,0]"
+    ImageDescription: "foo bar "
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -316,6 +335,9 @@ small.tx             :   64 x   64, 3 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
+    oiio:ConstantColor: "1,0,0"
+    oiio:AverageColor: "1,0,0"
+    oiio:SHA-1: "1DD1CB3C76F9A491B115F85A6DAC1B1A8DD2D3CB"
 whiteenv.exr         :    4 x    2, 3 channel, half openexr (+mipmap)
     MIP 0 of 3 (4 x 2):
       Stats Min: 1.000000 1.000000 1.000000 (float)

--- a/testsuite/maketx/ref/out.txt
+++ b/testsuite/maketx/ref/out.txt
@@ -5,7 +5,6 @@ grid.tx              : 1000 x 1000, 4 channel, uint8 tiff
     channel list: R, G, B, A
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=9CA964417213269190944948273FB1F00A4A8393"
     Orientation: 1 (normal)
     XResolution: 72
     YResolution: 72
@@ -19,7 +18,9 @@ grid.tx              : 1000 x 1000, 4 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
-    IPTC:Caption: "SHA-1=9CA964417213269190944948273FB1F00A4A8393"
+    IPTC:Caption: "oiio:SHA-1=9CA964417213269190944948273FB1F00A4A8393 oiio:AverageColor=0.608983,0.608434,0.608728,1"
+    oiio:AverageColor: "0.608983,0.608434,0.608728,1"
+    oiio:SHA-1: "9CA964417213269190944948273FB1F00A4A8393"
 Reading grid-resize.tx
 grid-resize.tx       : 1024 x 1024, 4 channel, uint8 tiff
     MIP-map levels: 1024x1024 512x512 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -27,7 +28,6 @@ grid-resize.tx       : 1024 x 1024, 4 channel, uint8 tiff
     channel list: R, G, B, A
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=C4BE40DC3B3534F30ACB906602F2FF80A246C01E"
     Orientation: 1 (normal)
     XResolution: 72
     YResolution: 72
@@ -41,7 +41,9 @@ grid-resize.tx       : 1024 x 1024, 4 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
-    IPTC:Caption: "SHA-1=C4BE40DC3B3534F30ACB906602F2FF80A246C01E"
+    IPTC:Caption: "oiio:SHA-1=C4BE40DC3B3534F30ACB906602F2FF80A246C01E oiio:AverageColor=0.608983,0.608434,0.608728,1"
+    oiio:AverageColor: "0.608983,0.608434,0.608728,1"
+    oiio:SHA-1: "C4BE40DC3B3534F30ACB906602F2FF80A246C01E"
 Reading checker-uint16.tx
 checker-uint16.tx    :  128 x  128, 4 channel, uint16 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -49,7 +51,6 @@ checker-uint16.tx    :  128 x  128, 4 channel, uint16 tiff
     channel list: R, G, B, A
     tile size: 64 x 64
     oiio:BitsPerSample: 16
-    ImageDescription: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -59,7 +60,9 @@ checker-uint16.tx    :  128 x  128, 4 channel, uint16 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
-    IPTC:Caption: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
+    IPTC:Caption: "oiio:SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765 oiio:AverageColor=0.5,0.5,0.5,1"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-1chan.tx
 checker-1chan.tx     :  128 x  128, 1 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -67,7 +70,6 @@ checker-1chan.tx     :  128 x  128, 1 channel, uint8 tiff
     channel list: A
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=1D0A2254373A69C054C08672041FC7DE3BAE5179"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -77,7 +79,9 @@ checker-1chan.tx     :  128 x  128, 1 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
-    IPTC:Caption: "SHA-1=1D0A2254373A69C054C08672041FC7DE3BAE5179"
+    IPTC:Caption: "oiio:SHA-1=1D0A2254373A69C054C08672041FC7DE3BAE5179 oiio:AverageColor=0.5"
+    oiio:AverageColor: "0.5"
+    oiio:SHA-1: "1D0A2254373A69C054C08672041FC7DE3BAE5179"
 Reading checker-16x32tile.tx
 checker-16x32tile.tx :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -85,7 +89,6 @@ checker-16x32tile.tx :  128 x  128, 4 channel, uint8 tiff
     channel list: R, G, B, A
     tile size: 16 x 32
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -95,7 +98,9 @@ checker-16x32tile.tx :  128 x  128, 4 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
-    IPTC:Caption: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
+    IPTC:Caption: "oiio:SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765 oiio:AverageColor=0.5,0.5,0.5,1"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-seplzw.tx
 checker-seplzw.tx    :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -103,7 +108,6 @@ checker-seplzw.tx    :  128 x  128, 4 channel, uint8 tiff
     channel list: R, G, B, A
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -113,7 +117,9 @@ checker-seplzw.tx    :  128 x  128, 4 channel, uint8 tiff
     planarconfig: "separate"
     tiff:Compression: 5
     compression: "lzw"
-    IPTC:Caption: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
+    IPTC:Caption: "oiio:SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765 oiio:AverageColor=0.5,0.5,0.5,1"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-clamp.tx
 checker-clamp.tx     :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -121,7 +127,6 @@ checker-clamp.tx     :  128 x  128, 4 channel, uint8 tiff
     channel list: R, G, B, A
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "clamp,clamp"
@@ -131,7 +136,9 @@ checker-clamp.tx     :  128 x  128, 4 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
-    IPTC:Caption: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
+    IPTC:Caption: "oiio:SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765 oiio:AverageColor=0.5,0.5,0.5,1"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-permir.tx
 checker-permir.tx    :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -139,7 +146,6 @@ checker-permir.tx    :  128 x  128, 4 channel, uint8 tiff
     channel list: R, G, B, A
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "periodic,mirror"
@@ -149,14 +155,15 @@ checker-permir.tx    :  128 x  128, 4 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
-    IPTC:Caption: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
+    IPTC:Caption: "oiio:SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765 oiio:AverageColor=0.5,0.5,0.5,1"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-nomip.tx
 checker-nomip.tx     :  128 x  128, 4 channel, uint8 tiff
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -166,7 +173,9 @@ checker-nomip.tx     :  128 x  128, 4 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
-    IPTC:Caption: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
+    IPTC:Caption: "oiio:SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765 oiio:AverageColor=0.5,0.5,0.5,1"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-camera.tx
 checker-camera.tx    :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -174,7 +183,6 @@ checker-camera.tx    :  128 x  128, 4 channel, uint8 tiff
     channel list: R, G, B, A
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -186,7 +194,9 @@ checker-camera.tx    :  128 x  128, 4 channel, uint8 tiff
     compression: "zip"
     worldtocamera: 1 0 0 0 0 2 0 0 0 0 1 0 0 0 0 1
     worldtoscreen: 3 0 0 0 0 3 0 0 0 0 3 0 1 2 3 1
-    IPTC:Caption: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
+    IPTC:Caption: "oiio:SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765 oiio:AverageColor=0.5,0.5,0.5,1"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-opaque.tx
 checker-opaque.tx    :  128 x  128, 3 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -194,7 +204,6 @@ checker-opaque.tx    :  128 x  128, 3 channel, uint8 tiff
     channel list: R, G, B
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=2BE3743A64D4309645F94CA7B37D0CD08AF0B38E"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -204,7 +213,9 @@ checker-opaque.tx    :  128 x  128, 3 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
-    IPTC:Caption: "SHA-1=2BE3743A64D4309645F94CA7B37D0CD08AF0B38E"
+    IPTC:Caption: "oiio:SHA-1=2BE3743A64D4309645F94CA7B37D0CD08AF0B38E oiio:AverageColor=0.5,0.5,0.5"
+    oiio:AverageColor: "0.5,0.5,0.5"
+    oiio:SHA-1: "2BE3743A64D4309645F94CA7B37D0CD08AF0B38E"
 Reading gray-mono.tx
 gray-mono.tx         :  256 x  256, 1 channel, uint8 tiff
     MIP-map levels: 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -212,7 +223,6 @@ gray-mono.tx         :  256 x  256, 1 channel, uint8 tiff
     channel list: A
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=24049CDF337F17E162291C7B626E0588A9D71160"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -222,7 +232,10 @@ gray-mono.tx         :  256 x  256, 1 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
-    IPTC:Caption: "SHA-1=24049CDF337F17E162291C7B626E0588A9D71160"
+    IPTC:Caption: "oiio:SHA-1=24049CDF337F17E162291C7B626E0588A9D71160 oiio:ConstantColor=0.25098 oiio:AverageColor=0.25098"
+    oiio:ConstantColor: "0.25098"
+    oiio:AverageColor: "0.25098"
+    oiio:SHA-1: "24049CDF337F17E162291C7B626E0588A9D71160"
 Reading pink-mono.tx
 pink-mono.tx         :  256 x  256, 3 channel, uint8 tiff
     MIP-map levels: 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -230,7 +243,6 @@ pink-mono.tx         :  256 x  256, 3 channel, uint8 tiff
     channel list: R, G, B
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "SHA-1=D5F1500992EFBDA77B89E946A9F53F89D332B6F4"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -240,7 +252,10 @@ pink-mono.tx         :  256 x  256, 3 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
-    IPTC:Caption: "SHA-1=D5F1500992EFBDA77B89E946A9F53F89D332B6F4"
+    IPTC:Caption: "oiio:SHA-1=D5F1500992EFBDA77B89E946A9F53F89D332B6F4 oiio:ConstantColor=0.25098,0.2,0.14902 oiio:AverageColor=0.25098,0.2,0.14902"
+    oiio:ConstantColor: "0.25098,0.2,0.14902"
+    oiio:AverageColor: "0.25098,0.2,0.14902"
+    oiio:SHA-1: "D5F1500992EFBDA77B89E946A9F53F89D332B6F4"
 Reading checker-prman.tx
 checker-prman.tx     :  128 x  128, 4 channel, int16 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -248,7 +263,6 @@ checker-prman.tx     :  128 x  128, 4 channel, int16 tiff
     channel list: R, G, B, A
     tile size: 64 x 32
     oiio:BitsPerSample: 16
-    ImageDescription: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -258,7 +272,9 @@ checker-prman.tx     :  128 x  128, 4 channel, int16 tiff
     planarconfig: "separate"
     tiff:Compression: 8
     compression: "zip"
-    IPTC:Caption: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
+    IPTC:Caption: "oiio:SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765 oiio:AverageColor=0.5,0.5,0.5,1"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading nan.exr
 nan.exr              :   64 x   64, 3 channel, half openexr
     SHA-1: 47A8E8F3E8B2C3B6B032FCC8C39D3C5FC1AAA390
@@ -266,8 +282,9 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     tile size: 64 x 64
     oiio:ColorSpace: "Linear"
     compression: "zip"
-    ImageDescription: "SHA-1=44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5"
+    oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
     openexr:levelmode: 0
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
@@ -294,8 +311,9 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     textureformat: "Plain Texture"
     compression: "zip"
     Orientation: 1 (normal)
-    ImageDescription: "SHA-1=D924CA144A02479D1507F5910F5FC8F51EF78765"
     fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
@@ -305,7 +323,7 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     SHA-1: BE1D5EA24E907A4C4B3FB3C28EAC872A20F5B414
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    ImageDescription: "foo SHA-1=1234abcd ConstantColor=[0.0,0,-0.0] bar"
+    ImageDescription: "foo ConstantColor=[0.0,0,-0.0] bar"
     Orientation: 1 (normal)
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
@@ -314,6 +332,7 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     compression: "zip"
     tiff:RowsPerStrip: 32
     IPTC:Caption: "foo SHA-1=1234abcd ConstantColor=[0.0,0,-0.0] bar"
+    oiio:SHA-1: "1234abcd ConstantColor=[0.0,0,-0.0] bar"
 Reading small.tx
 small.tx             :   64 x   64, 3 channel, uint8 tiff
     MIP-map levels: 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -321,7 +340,7 @@ small.tx             :   64 x   64, 3 channel, uint8 tiff
     channel list: R, G, B
     tile size: 64 x 64
     oiio:BitsPerSample: 8
-    ImageDescription: "foo bar SHA-1=1DD1CB3C76F9A491B115F85A6DAC1B1A8DD2D3CB ConstantColor=[1,0,0]"
+    ImageDescription: "foo bar "
     Orientation: 1 (normal)
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -331,7 +350,10 @@ small.tx             :   64 x   64, 3 channel, uint8 tiff
     planarconfig: "contig"
     tiff:Compression: 8
     compression: "zip"
-    IPTC:Caption: "foo bar SHA-1=1DD1CB3C76F9A491B115F85A6DAC1B1A8DD2D3CB ConstantColor=[1,0,0]"
+    IPTC:Caption: "foo bar oiio:SHA-1=1DD1CB3C76F9A491B115F85A6DAC1B1A8DD2D3CB oiio:ConstantColor=1,0,0 oiio:AverageColor=1,0,0"
+    oiio:ConstantColor: "1,0,0"
+    oiio:AverageColor: "1,0,0"
+    oiio:SHA-1: "1DD1CB3C76F9A491B115F85A6DAC1B1A8DD2D3CB"
 whiteenv.exr         :    4 x    2, 3 channel, half openexr (+mipmap)
     MIP 0 of 3 (4 x 2):
       Stats Min: 1.000000 1.000000 1.000000 (float)

--- a/testsuite/python-imagebuf/ref/out.txt
+++ b/testsuite/python-imagebuf/ref/out.txt
@@ -40,7 +40,6 @@ Printing the whole spec to be sure:
   z channel =  -1
   deep =  False
   oiio:BitsPerSample = 8
-  ImageDescription = "oiio:SHA-1=233A1D3412A54A5F49814AB7BFFD04F56F46D3D7 oiio:AverageColor=0.608983,0.608434,0.608728,1"
   Orientation = 1
   XResolution = 72.0
   YResolution = 72.0
@@ -56,6 +55,8 @@ Printing the whole spec to be sure:
   planarconfig = "contig"
   tiff:Compression = 8
   compression = "zip"
+  oiio:AverageColor = "0.608983,0.608434,0.608728,1"
+  oiio:SHA-1 = "233A1D3412A54A5F49814AB7BFFD04F56F46D3D7"
 
 Resetting to a different MIP level:
   resolution 256x256+0+0
@@ -66,7 +67,6 @@ Resetting to a different MIP level:
   z channel =  -1
   deep =  False
   oiio:BitsPerSample = 8
-  ImageDescription = "oiio:SHA-1=233A1D3412A54A5F49814AB7BFFD04F56F46D3D7 oiio:AverageColor=0.608983,0.608434,0.608728,1"
   Orientation = 1
   XResolution = 72.0
   YResolution = 72.0
@@ -82,6 +82,8 @@ Resetting to a different MIP level:
   planarconfig = "contig"
   tiff:Compression = 8
   compression = "zip"
+  oiio:AverageColor = "0.608983,0.608434,0.608728,1"
+  oiio:SHA-1 = "233A1D3412A54A5F49814AB7BFFD04F56F46D3D7"
 
 Making 2x2 RGB image:
   resolution 2x2+0+0

--- a/testsuite/python-imageinput/ref/out-alt.txt
+++ b/testsuite/python-imageinput/ref/out-alt.txt
@@ -44,7 +44,6 @@ Opened "../common/textures/grid.tx" as a tiff
   z channel =  -1
   deep =  False
   oiio:BitsPerSample = 8
-  ImageDescription = "oiio:SHA-1=233A1D3412A54A5F49814AB7BFFD04F56F46D3D7 oiio:AverageColor=0.608983,0.608434,0.608728,1"
   Orientation = 1
   XResolution = 72.0
   YResolution = 72.0
@@ -60,6 +59,10 @@ Opened "../common/textures/grid.tx" as a tiff
   planarconfig = "contig"
   tiff:Compression = 8
   compression = "zip"
+  IPTC:OriginatingProgram = "OpenImageIO 1.5.7dev : maketx -filter lanczos3 --resize grid.tif -o grid.tx"
+  IPTC:Caption = "oiio:SHA-1=233A1D3412A54A5F49814AB7BFFD04F56F46D3D7 oiio:AverageColor=0.608983,0.608434,0.608728,1"
+  oiio:AverageColor = "0.608983,0.608434,0.608728,1"
+  oiio:SHA-1 = "233A1D3412A54A5F49814AB7BFFD04F56F46D3D7"
 Subimage 0 MIP level 1 :
   resolution 512x512+0+0
   tile size  64x64x1
@@ -113,8 +116,8 @@ Opened "../../../../../oiio-images/tahoe-gps.jpg" as a jpeg
 @ (0, 1535) = array('B', [82, 94, 136])
 
 Testing read_tile:
-Opened "../../../../../oiio-images/grid.tx" as a tiff
-@ (32, 32) = array('B', [0, 0, 0, 255])
+Opened "../common/textures/grid.tx" as a tiff
+@ (32, 32) = array('B', [1, 1, 1, 255])
 @ (160, 160) = array('B', [255, 127, 127, 255])
 
 Testing read_scanlines:

--- a/testsuite/python-imageinput/ref/out.txt
+++ b/testsuite/python-imageinput/ref/out.txt
@@ -44,7 +44,6 @@ Opened "../common/textures/grid.tx" as a tiff
   z channel =  -1
   deep =  False
   oiio:BitsPerSample = 8
-  ImageDescription = "oiio:SHA-1=233A1D3412A54A5F49814AB7BFFD04F56F46D3D7 oiio:AverageColor=0.608983,0.608434,0.608728,1"
   Orientation = 1
   XResolution = 72.0
   YResolution = 72.0
@@ -60,6 +59,8 @@ Opened "../common/textures/grid.tx" as a tiff
   planarconfig = "contig"
   tiff:Compression = 8
   compression = "zip"
+  oiio:AverageColor = "0.608983,0.608434,0.608728,1"
+  oiio:SHA-1 = "233A1D3412A54A5F49814AB7BFFD04F56F46D3D7"
 Subimage 0 MIP level 1 :
   resolution 512x512+0+0
   tile size  64x64x1


### PR DESCRIPTION
New get_texture_info queries:
- "averagecolor", "averagealpha" -- retrieve the average color/alpha of a texture. (Fail the query if there was no metadata giving this information -- we do NOT compute an expensive average of the whole texture on the fly. It happens at maketx time or not at all.)
- "constantcolor", "constantalpha" -- retrieve the value of color/alpha if it's a texture with the same value in all pixels, fail the query if it's not known to be a constant-valued texture.

maketx is modified to compute the average color and store it in the metadata, also minor tweaks to the existing functionality where it stores whether/if it's a constant-valued texture. There is some refinement and refactoring of how these metadata are stored and retrieved.

If average color is requested by get_texture_info, it's trivial if the texture was created by the new maketx that embeds the metadata. If not (if it's an "old" texture), it will lazily retrieve the 1x1 MIPmap level and use the value of that single pixel (which should be a reasonably accurate average of the whole original input texture) to initialize the average. If it neither has the metadata nor is a MIPmap with a 1x1 level, then the query will fail.

We also modify texture calls to take a significant shortcut if doing texture lookups on a constant-valued texture (as long as the wrap mode is not black!), and this turns out to speed up texture lookups on constant-valued textures by a factor of 10!

New stat to say how many textures were constant.
