### PR TITLE
init() missing?

### DIFF
--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -101,6 +101,7 @@ OIIO_PLUGIN_EXPORTS_END
 bool
 HdrInput::open (const std::string &name, ImageSpec &newspec)
 {
+    init();
     m_filename = name;
     return seek_subimage (0, 0, newspec);
 }


### PR DESCRIPTION
Was the member variable initialization missed here?
