### PR TITLE
Fix build with freetype>=2.5.4

### DIFF
--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -1312,9 +1312,9 @@ ImageBufAlgo::render_text (ImageBuf &R, int x, int y, const std::string &text,
         if (error)
             continue;  // ignore errors
         // now, draw to our target surface
-        for (int j = 0;  j < slot->bitmap.rows; ++j) {
+        for (int j = 0;  j < static_cast<int>(slot->bitmap.rows); ++j) {
             int ry = y + j - slot->bitmap_top;
-            for (int i = 0;  i < slot->bitmap.width; ++i) {
+            for (int i = 0;  i < static_cast<int>(slot->bitmap.width); ++i) {
                 int rx = x + i + slot->bitmap_left;
                 float b = slot->bitmap.buffer[slot->bitmap.pitch*j+i] / 255.0f;
                 R.getpixel (rx, ry, pixelcolor);


### PR DESCRIPTION
From CHANGES BETWEEN 2.5.3 and 2.5.4:
"Some fields in the `FT_Bitmap' structure have been changed from
signed to unsigned type, which better reflects the actual usage. It
is also an additional means to protect against malformed input. This
change doesn't break the ABI; however, it might cause compiler
warnings."
