### PR TITLE
oiiotool -native forces native data format read.

### DIFF
--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -759,6 +759,25 @@ to use if you are using oiiotool to combine images that may have different
 orientations.
 \apiend
 
+\apiitem{--native}
+\NEW  % 1.5
+
+Normally, all image reads into an \ImageBuf will be performed via an
+underlying \ImageCache. But since an \ImageCache does not support all
+possible data formats, some lesser-used formats may be auto-converted upon
+being read into the cache, and therefore lose precision or range compared to
+what the equivalent {\cf ImageInput::read_image} is capable of. (An example
+would be a rare file of {\cf uint32} or {\cf double} pixels, which would
+lose data when read into an \ImageCache whose ``biggest'' data type is
+{\cf float}.)
+
+The {\cf --native} option is used for the small set of cases where this is
+problematic in practice. It causes subsequent image loads to bypass the
+\ImageCache and instead do an immediate read of the file that preserves its
+native format (if it's not a format that can use the ImageCache without a
+loss of precision).
+\apiend
+
 \apiitem{-o \rm \emph{filename}}
 Outputs the current image to the named file.  This does not remove the
 current image, it merely saves a copy of it.

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -227,7 +227,7 @@ ImageRec::ImageRec (const std::string &name, const ImageSpec &spec,
 
 
 bool
-ImageRec::read ()
+ImageRec::read (bool force_native_read)
 {
     if (elaborated())
         return true;
@@ -260,8 +260,12 @@ ImageRec::read ()
             bool forceread = (s == 0 && m == 0 &&
                               m_imagecache->imagespec(uname,s,m)->image_bytes() < 50*1024*1024);
             ImageBuf *ib = new ImageBuf (name(), m_imagecache);
-            bool ok = ib->read (s, m, forceread,
-                                TypeDesc::FLOAT /* force float */);
+            TypeDesc convert = TypeDesc::FLOAT;
+            if (force_native_read) {
+                forceread = true;
+                convert = ib->nativespec().format;
+            }
+            bool ok = ib->read (s, m, forceread, convert);
             if (!ok)
                 error ("%s", ib->geterror());
             allok &= ok;

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -93,6 +93,7 @@ Oiiotool::clear_options ()
     hash = false;
     updatemode = false;
     autoorient = false;
+    nativeread = false;
     threads = 0;
     full_command_line.clear ();
     printinfo_metamatch.clear ();
@@ -160,7 +161,7 @@ Oiiotool::read (ImageRecRef img)
     float pre_ic_time, post_ic_time;
     imagecache->getattribute ("stat:fileio_time", pre_ic_time);
     total_readtime.start ();
-    bool ok = img->read ();
+    bool ok = img->read (ot.nativeread);
     total_readtime.stop ();
     imagecache->getattribute ("stat:fileio_time", post_ic_time);
     total_imagecache_readtime += post_ic_time - pre_ic_time;
@@ -3747,6 +3748,7 @@ getargs (int argc, char *argv[])
                 "--autopremult %@", set_autopremult, NULL, "Turn on automatic premultiplication of images with unassociated alpha",
                 "--autoorient", &ot.autoorient, "Automatically --reorient all images upon input",
                 "--auto-orient", &ot.autoorient, "", // symonym for --autoorient
+                "--native", &ot.nativeread, "Force native data type reads if cache would lose precision",
                 "<SEPARATOR>", "Commands that write images:",
                 "-o %@ %s", output_file, NULL, "Output the current image to the named file",
                 "<SEPARATOR>", "Options that affect subsequent image output:",

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -60,6 +60,7 @@ public:
     bool hash;
     bool updatemode;
     bool autoorient;
+    bool nativeread;                  // force native data type reads
     int threads;
     std::string full_command_line;
     std::string printinfo_metamatch;
@@ -284,7 +285,7 @@ public:
     // it's lazily kept as name only, without reading the file.)
     bool elaborated () const { return m_elaborated; }
 
-    bool read ();
+    bool read (bool force_native_read=false);
 
     // ir(subimg,mip) references a specific MIP level of a subimage
     // ir(subimg) references the first MIP level of a subimage


### PR DESCRIPTION
Normally, all image reads into an ImageBuf will be performed via an underlying ImageCache. But since an ImageCache does not support all possible data formats, some lesser-used formats may be auto-converted upon being read into the cache, and therefore lose precision or range compared to what the equivalent ImageInput::read_image() is capable of. (An example would be a rare file of uint32 or double pixels, which would lose data when read into an ImageCache whose ``biggest'' data type is float.)

In this patch, IB::read is changed so that if you request a 'conversion' that would lose precision by going through the cache, it will bypass the ImageCache and instead do an immediate read of the file that preserves its native format (if it's not a format that can use the ImageCache without a loss of precision).

The oiiotool --native option then triggers this behavior, and should be used for the small set of cases where the default behavior is problematic in practice.
