### PR TITLE
"open with configuration" extended to ImageBuf, ImageCache

### DIFF
--- a/src/doc/imagebuf.tex
+++ b/src/doc/imagebuf.tex
@@ -163,7 +163,8 @@ Constructing a readable \ImageBuf that will hold an image to be read
 from disk.
 
 \apiitem{ImageBuf (string_view name, int subimage=0, int miplevel=0, \\
-\bigspc\bigspc ImageCache *imagecache=NULL)}
+\bigspc\bigspc ImageCache *imagecache = NULL, \\
+\bigspc\bigspc const ImageSpec *config = NULL)}
 Construct an \ImageBuf that will be used to read the named file (at the
 given subimage and MIP-level, defaulting to the first in the file).  But
 don't read it yet!  The image will actually be read when other methods
@@ -172,12 +173,19 @@ need to access the spec and/or pixels, or when an explicit call to
 If {\cf imagecache} is non-NULL, the custom
 \ImageCache will be used (if applicable); otherwise, a NULL imagecache
 indicates that the global/shared \ImageCache should be used.
+If {\cf config} is not NULL, it points to an \ImageSpec giving requests
+or special instructions to be passed on to the eventual
+{\cf ImageInput::open()} call.
 \apiend
 
 \apiitem{void reset (string_view name, int subimage=0, int miplevel=0, \\
-\bigspc\bigspc ImageCache *imagecache = NULL)}
+\bigspc\bigspc ImageCache *imagecache = NULL \\
+\bigspc\bigspc const ImageSpec *config = NULL)}
 Destroys any previous contents of the \ImageBuf and re-initializes it
 to read the named file (but doesn't actually read yet).
+If {\cf config} is not NULL, it points to an \ImageSpec giving requests
+or special instructions to be passed on to the eventual
+{\cf ImageInput::open()} call.
 \apiend
 
 \apiitem{bool read (int subimage=0, int miplevel=0, bool force=false, \\

--- a/src/doc/imagecache.tex
+++ b/src/doc/imagecache.tex
@@ -626,22 +626,38 @@ modification times have been changed since they were first opened.
 
 \subsection{Seeding the cache}
 \label{sec:imagecache:api:seeding}
-\apiitem{bool {\ce add_file} (ustring filename, ImageInput::Creator creator)}
-This creates a file entry in the cache that, instead of reading
-from disk, uses a custom \ImageInput to generate the image (note
-that it will have no effect if there's already an image by the
-same name in the cache).  The {\cf creator} is a factory that
-creates the custom \ImageInput and will be called like this:
+\apiitem{bool {\ce add_file} (ustring filename, \\
+    \bigspc ImageInput::Creator creator = NULL,\\
+    \bigspc const ImageSpec *config = NULL)}
+This method causes a file to be opened or added to the
+cache. There is no reason to use this method unless you are supplying
+a custom creator, or configuration, or both.
+
+If {\cf creator} is not NULL, it points to an {\cf ImageInput::Creator} that
+will be used rather than the default {\cf ImageInput::create()}, thus
+instead of reading from disk, creates and uses a custom ImageInput
+to generate the image. The {\cf creator} is a factory that creates the
+custom ImageInput and will be called like this:
 \begin{code}
     ImageInput *in = creator();
 \end{code}
+Once created, the \ImageCache owns the \ImageInput and is responsible
+for destroying it when done. Custom \ImageInput's allow ``procedural''
+images, among other things.  Also, this is the method you use to set
+up a ``writeable'' \ImageCache images (perhaps with a type of
+\ImageInput that's just a stub that does as little as possible).
 
-Once created, the \ImageCache owns
-the \ImageInput and is responsible for destroying it when done.
-Custom \ImageInput's allow ``procedural'' images, among other
-things.  Also, this is the method you use to set up a
-``writeable'' \ImageCache images (perhaps with a type of \ImageInput
-that's just a stub that does as little as possible).
+\NEW  % 1.5
+If {\cf config} is not NULL, it points to an \ImageSpec with configuration
+options/hints that will be passed to the underlying
+{\cf ImageInput::open()} call. Thus, this can be used to ensure that the
+\ImageCache opens a call with special configuration options.
+
+This call (including any custom creator or configuration hints) will
+have no effect if there's already an image by the same name in the
+cache. Custom creators or configurations only ``work'' the \emph{first} time
+a particular filename is referenced in the lifetime of the
+\ImageCache.
 \apiend
 
 \apiitem{bool {\ce add_tile} (ustring filename, int subimage, int miplevel,\\

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -91,7 +91,7 @@
 }
 \date{{\large 
 %Editor: Larry Gritz \\[2ex]
-Date: 2 Dec 2014
+Date: 23 Dec 2014
 % \\ (with corrections, 20 Nov 2014)
 }}
 

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -1089,15 +1089,18 @@ Return the \ImageBuf to its pristine, uninitialized state.
 
     # The following two commands are equivalent:
     buf = ImageBuf()     # 1 - assign a new blank ImageBuf
-    buf.clear()               # 2 - clear the existing ImageBuf
+    buf.clear()          # 2 - clear the existing ImageBuf
 \end{code}
 \apiend
 
-\apiitem{ImageBuf.{\ce reset} (filename) \\
-ImageBuf.{\ce reset} (filename, subimage, miplevel) \\
-ImageBuf.{\ce reset} (imagespec)}
-Restore the \ImageBuf to its newly-constructed state, either to read from
-a filename (optionally specifying a subimage and MIP level) or a writeable
+\apiitem{ImageBuf.{\ce reset} (filename, subimage=0, miplevel=0, config=ImageSpec())}
+Restore the \ImageBuf to a newly-constructed state, to read from
+a filename (optionally specifying a subimage, MIP level, and/or 
+a ``configuration'' \ImageSpec).
+\apiend
+
+\apiitem{ImageBuf.{\ce reset} (imagespec)}
+Restore the \ImageBuf to the newly-constructed state of a blank, writeable
 \ImageBuf specified by an \ImageSpec.
 \apiend
 

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -177,8 +177,12 @@ public:
     /// made, whichever comes first. If a non-NULL imagecache is supplied,
     /// it will specifiy a custom ImageCache to use; if otherwise, the
     /// global/shared ImageCache will be used.
-    explicit ImageBuf (string_view name, int subimage=0,
-                       int miplevel=0, ImageCache *imagecache = NULL);
+    /// If 'config' is not NULL, it points to an ImageSpec giving requests
+    /// or special instructions to be passed on to the eventual
+    /// ImageInput::open() call.
+    explicit ImageBuf (string_view name, int subimage=0, int miplevel=0,
+                       ImageCache *imagecache = NULL,
+                       const ImageSpec *config = NULL);
 
     /// Construct an ImageBuf to read the named image -- but don't actually
     /// read it yet!  The image will actually be read when other methods
@@ -229,8 +233,12 @@ public:
 
     /// Forget all previous info, reset this ImageBuf to a new image
     /// that is uninitialized (no pixel values, no size or spec).
+    /// If 'config' is not NULL, it points to an ImageSpec giving requests
+    /// or special instructions to be passed on to the eventual
+    /// ImageInput::open() call.
     void reset (string_view name, int subimage, int miplevel,
-                ImageCache *imagecache = NULL);
+                ImageCache *imagecache = NULL,
+                const ImageSpec *config = NULL);
 
     /// Forget all previous info, reset this ImageBuf to a new image
     /// that is uninitialized (no pixel values, no size or spec).

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -220,18 +220,34 @@ public:
     /// the data type of the pixels in the disk file).
     virtual const void * tile_pixels (Tile *tile, TypeDesc &format) const = 0;
 
-    /// This creates a file entry in the cache that, instead of reading
-    /// from disk, uses a custom ImageInput to generate the image (note
-    /// that it will have no effect if there's already an image by the
-    /// same name in the cache).  The 'creator' is a factory that
-    /// creates the custom ImageInput and will be called like this:
-    /// ImageInput *in = creator(); Once created, the ImageCache owns
-    /// the ImageInput and is responsible for destroying it when done.
-    /// Custom ImageInputs allow "procedural" images, among other
-    /// things.  Also, this is the method you use to set up a
-    /// "writeable" ImageCache images (perhaps with a type of ImageInput
-    /// that's just a stub that does as little as possible).
-    virtual bool add_file (ustring filename, ImageInput::Creator creator) = 0;
+    /// The add_file() call causes a file to be opened or added to the
+    /// cache. There is no reason to use this method unless you are
+    /// supplying a custom creator, or configuration, or both.
+    /// 
+    /// If creator is not NULL, it points to an ImageInput::Creator that
+    /// will be used rather than the default ImageInput::create(), thus
+    /// instead of reading from disk, creates and uses a custom ImageInput
+    /// to generate the image. The 'creator' is a factory that creates the
+    /// custom ImageInput and will be called like this:
+    ///      ImageInput *in = creator();
+    /// Once created, the ImageCache owns the ImageInput and is responsible
+    /// for destroying it when done. Custom ImageInputs allow "procedural"
+    /// images, among other things.  Also, this is the method you use to set
+    /// up a "writeable" ImageCache images (perhaps with a type of
+    /// ImageInput that's just a stub that does as little as possible).
+    /// 
+    /// If config is not NULL, it points to an ImageSpec with configuration
+    /// options/hints that will be passed to the underlying
+    /// ImageInput::open() call. Thus, this can be used to ensure that the
+    /// ImageCache opens a call with special configuration options.
+    /// 
+    /// This call (including any custom creator or configuration hints) will
+    /// have no effect if there's already an image by the same name in the
+    /// cache. Custom creators or configurations only "work" the FIRST time
+    /// a particular filename is referenced in the lifetime of the
+    /// ImageCache.
+    virtual bool add_file (ustring filename, ImageInput::Creator creator=NULL,
+                           const ImageSpec *config=NULL) = 0;
 
     /// Preemptively add a tile corresponding to the named image, at the
     /// given subimage and MIP level.  The tile added is the one whose

--- a/src/libOpenImageIO/imagebuf_test.cpp
+++ b/src/libOpenImageIO/imagebuf_test.cpp
@@ -261,6 +261,20 @@ void histogram_computation_test ()
 
 
 
+void test_open_with_config ()
+{
+    // N.B. This function must run after ImageBuf_test_appbuffer, which
+    // writes "A.tif".
+    ImageCache *ic = ImageCache::create(false);
+    ImageSpec config;
+    config.attribute ("oiio:DebugOpenConfig!", 1);
+    ImageBuf A ("A.tif", 0, 0, ic, &config);
+    OIIO_CHECK_EQUAL (A.spec().get_int_attribute("oiio:DebugOpenConfig!",0), 42);
+    ic->destroy (ic);
+}
+
+
+
 int
 main (int argc, char **argv)
 {
@@ -277,6 +291,7 @@ main (int argc, char **argv)
 
     ImageBuf_test_appbuffer ();
     histogram_computation_test ();
+    test_open_with_config ();
 
     return unit_test_failures;
 }

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -137,7 +137,8 @@ class OIIO_API ImageCacheFile : public RefCnt {
 public:
     ImageCacheFile (ImageCacheImpl &imagecache,
                     ImageCachePerThreadInfo *thread_info, ustring filename,
-                    ImageInput::Creator creator=NULL);
+                    ImageInput::Creator creator=NULL,
+                    const ImageSpec *config=NULL);
     ~ImageCacheFile ();
 
     bool broken () const { return m_broken; }
@@ -314,6 +315,7 @@ private:
     ImageCacheFile *m_duplicate;    ///< Is this a duplicate?
     imagesize_t m_total_imagesize;  ///< Total size, uncompressed
     ImageInput::Creator m_inputcreator; ///< Custom ImageInput-creator
+    boost::scoped_ptr<ImageSpec> m_configspec; // Optional configuration hints
 
     /// We will need to read pixels from the file, so be sure it's
     /// currently opened.  Return true if ok, false if error.
@@ -738,7 +740,8 @@ public:
     ImageCacheFile *find_file (ustring filename,
                                ImageCachePerThreadInfo *thread_info,
                                ImageInput::Creator creator=NULL,
-                               bool header_only=false);
+                               bool header_only=false,
+                               const ImageSpec *config=NULL);
 
     /// Is the tile specified by the TileID already in the cache?
     bool tile_in_cache (const TileID &id,
@@ -783,7 +786,8 @@ public:
                             int x, int y, int z);
     virtual void release_tile (Tile *tile) const;
     virtual const void * tile_pixels (Tile *tile, TypeDesc &format) const;
-    virtual bool add_file (ustring filename, ImageInput::Creator creator);
+    virtual bool add_file (ustring filename, ImageInput::Creator creator,
+                           const ImageSpec *config);
     virtual bool add_tile (ustring filename, int subimage, int miplevel,
                      int x, int y, int z, TypeDesc format, const void *buffer,
                      stride_t xstride, stride_t ystride, stride_t zstride);

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -68,6 +68,13 @@ ImageBuf_reset_name2 (ImageBuf &buf, const std::string &name,
 }
 
 void
+ImageBuf_reset_name_config (ImageBuf &buf, const std::string &name,
+                      int subimage, int miplevel, const ImageSpec &config)
+{
+    buf.reset (name, subimage, miplevel, NULL, &config);
+}
+
+void
 ImageBuf_reset_spec (ImageBuf &buf, const ImageSpec &spec)
 {
     buf.reset (spec);
@@ -291,6 +298,7 @@ void declare_imagebuf()
         .def("clear", &ImageBuf::clear)
         .def("reset", &ImageBuf_reset_name)
         .def("reset", &ImageBuf_reset_name2)
+        .def("reset", &ImageBuf_reset_name_config)
         .def("reset", &ImageBuf_reset_spec)
         .add_property ("initialized", &ImageBuf::initialized)
         .def("init_spec", &ImageBuf::init_spec)
@@ -301,7 +309,6 @@ void declare_imagebuf()
         .def("write", &ImageBuf_write,
              ImageBuf_write_overloads())
         // FIXME -- write(ImageOut&)
-//        .def("set_write_format", &ImageBuf::set_write_format)
         .def("set_write_format", &ImageBuf_set_write_format)
         .def("set_write_tiles", &ImageBuf::set_write_tiles,
              (arg("width")=0, arg("height")=0, arg("depth")=0))

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -141,6 +141,7 @@ private:
                                      ///  try to keep it that way!
     bool m_convert_alpha;            ///< Do we need to associate alpha?
     bool m_separate;                 ///< Separate planarconfig?
+    bool m_testopenconfig;           ///< Debug aid to test open-with-config
     unsigned short m_planarconfig;   ///< Planar config of the file
     unsigned short m_bitspersample;  ///< Of the *file*, not the client's view
     unsigned short m_photometric;    ///< Of the *file*, not the client's view
@@ -154,6 +155,7 @@ private:
         m_keep_unassociated_alpha = false;
         m_convert_alpha = false;
         m_separate = false;
+        m_testopenconfig = false;
         m_colormap.clear();
     }
 
@@ -387,6 +389,11 @@ TIFFInput::open (const std::string &name, ImageSpec &newspec,
     // Check 'config' for any special requests
     if (config.get_int_attribute("oiio:UnassociatedAlpha", 0) == 1)
         m_keep_unassociated_alpha = true;
+    // This configuration hint has no function other than as a debugging aid
+    // for testing whether configurations are received properly from other
+    // OIIO components.
+    if (config.get_int_attribute("oiio:DebugOpenConfig!", 0))
+        m_testopenconfig = true;
     return open (name, newspec);
 }
 
@@ -935,6 +942,9 @@ TIFFInput::readspec (bool read_meta)
         else
             m_spec.erase_attribute ("ImageDescription");
     }
+
+    if (m_testopenconfig)  // open-with-config debugging
+        m_spec.attribute ("oiio:DebugOpenConfig!", 42);
 }
 
 


### PR DESCRIPTION
This has never been a high priority, but it comes up as a request from time to time, so I thought I'd try to squeeze it in before we lock down the API for 1.5 release.

History: ImageInput has a variety of the open() method that takes an ImageSpec whose metadata can communicate special options or hints that a reader would need to know when the file is first opened. It's a rare case, but sometimes is used to solve tricky problems, allowing an app to talk to a particular format reader in custom ways that are not easily accommodated by the main ImageInput API. Occasionally people have noticed that this does not allow the same options to be passed to the readers when using the higher-level ImageBuf or ImageCache APIs, which don't directly expose the underlying ImageInput.

This patch tries to address this limitation by providing ways to pass the optional config ptr to ImageBuf ctr and reset(), and to ImageCache::add_file. It's not super elegant, but it fits, and it's rarely used in the vast majority of cases.

This preserves "source compatibility" but breaks link compatibility on the ImageBuf and ImageCache APIs, which I why I wanted to do it just prior to branching for a release, not within a locked release branch.
