### PR TITLE
Remove deprecated functions

### DIFF
--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -402,7 +402,7 @@ convert_file (const std::string &in_filename, const std::string &out_filename)
         ImageCache *imagecache = ImageCache::create ();
         int nsubimages = 0;
         ustring ufilename (in_filename);
-        imagecache->get_image_info (ufilename, ustring("subimages"),
+        imagecache->get_image_info (ufilename, 0, 0, ustring("subimages"),
                                     TypeDesc::TypeInt, &nsubimages);
         if (nsubimages > 1) {
             subimagespecs.resize (nsubimages);

--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -74,11 +74,6 @@ OIIO_API std::string filename (const std::string &filepath);
 OIIO_API std::string extension (const std::string &filepath,
                                  bool include_dot=true);
 
-/// DEPRECATED.
-inline std::string file_extension (const std::string &filepath) {
-    return extension (filepath, false);
-}
-
 /// Return all but the last part of the path, for example,
 /// parent_path("foo/bar") returns "foo", and parent_path("foo")
 /// returns "".

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -1362,7 +1362,7 @@ T invert (Func &func, T y, T xmin=0.0, T xmax=1.0,
 ////////////////////////////////////////////////////////////////////////////
 
 
-// DEPRECATED - Some back-compatibility, will remove soon
+// DEPRECATED(1.5) - Some back-compatibility, will remove soon
 inline float safe_sqrtf (float x) { return safe_sqrt(x); }
 inline float safe_acosf (float x) { return safe_acos(x); }
 inline float fast_expf (float x) { return fast_exp(x); }

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -244,15 +244,6 @@ public:
     /// image of the given name and dimensions.
     void reset (string_view name, const ImageSpec &spec);
 
-    /// Copy spec to *this, and then allocate enough space the right
-    /// size for an image described by the format spec.  If the ImageBuf
-    /// already has allocated pixels, their values will not be preserved
-    /// if the new spec does not describe an image of the same size and
-    /// data type as it used to be.
-    /// DEPRECATED (1.3) -- I don't see any reason why this should be
-    /// favored over reset(spec).
-    void alloc (const ImageSpec &spec);
-
     /// Which type of storage is being used for the pixels?
     IBStorage storage () const;
 
@@ -291,13 +282,6 @@ public:
     /// Inform the ImageBuf what tile size (or no tiling, for 0) for
     /// any subsequent write().
     void set_write_tiles (int width=0, int height=0, int depth=0);
-
-    /// DEPRECATED (1.3) synonym for write().  Kept for now for backward
-    /// compatibility.
-    bool save (string_view filename = string_view(),
-               string_view fileformat = string_view(),
-               ProgressCallback progress_callback=NULL,
-               void *progress_callback_data=NULL) const;
 
     /// Write the image to the open ImageOutput 'out'.  Return true if
     /// all went ok, false if there were errors writing.  It does NOT
@@ -595,14 +579,6 @@ public:
     /// [ybegin,yend) x [zbegin,zend).
     void set_full (int xbegin, int xend, int ybegin, int yend,
                    int zbegin, int zend);
-
-    /// Set the "full" (a.k.a. display) window to [xbegin,xend) x
-    /// [ybegin,yend) x [zbegin,zend).  If bordercolor is not NULL, also
-    /// set the spec's "oiio:bordercolor" attribute.
-    /// DEPRECATED (1.3) -- we don't use the 'bordercolor' parameter, and
-    /// it seems strange, so let's phase it out.
-    void set_full (int xbegin, int xend, int ybegin, int yend,
-                   int zbegin, int zend, const float *bordercolor);
 
     /// Return pixel data window for this ImageBuf as a ROI.
     ROI roi () const;

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -514,18 +514,6 @@ bool OIIO_API clamp (ImageBuf &dst, const ImageBuf &src,
                      bool clampalpha01 = false,
                      ROI roi = ROI::All(), int nthreads = 0);
 
-/// DEPRECATED (1.3) in-place version
-bool OIIO_API clamp (ImageBuf &dst, 
-                     const float *min=NULL, const float *max=NULL,
-                     bool clampalpha01 = false,
-                     ROI roi = ROI::All(), int nthreads = 0);
-
-/// DEPRECATED (1.3) in-place version
-bool OIIO_API clamp (ImageBuf &dst, 
-                     float min=-std::numeric_limits<float>::max(),
-                     float max=std::numeric_limits<float>::max(),
-                     bool clampalpha01 = false,
-                     ROI roi = ROI::All(), int nthreads = 0);
 
 /// For all pixels within the designated region, set dst = A + B.
 /// All three images must have the same number of channels.
@@ -583,13 +571,6 @@ bool OIIO_API add (ImageBuf &dst, const ImageBuf &A, const float *B,
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API add (ImageBuf &dst, const ImageBuf &A, float B,
-                   ROI roi=ROI::All(), int nthreads=0);
-
-/// DEPRECATED as of 1.3 -- in-place add
-bool OIIO_API add (ImageBuf &dst, float val,
-                   ROI roi=ROI::All(), int nthreads=0);
-/// DEPRECATED as of 1.3 -- in-place add
-bool OIIO_API add (ImageBuf &dst, const float *val,
                    ROI roi=ROI::All(), int nthreads=0);
 
 
@@ -688,10 +669,6 @@ bool OIIO_API mul (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
 bool OIIO_API mul (ImageBuf &dst, const ImageBuf &A, float B,
                    ROI roi=ROI::All(), int nthreads=0);
 
-/// DEPRECATED in-place version. (1.3)
-bool OIIO_API mul (ImageBuf &dst, float val,
-                   ROI roi=ROI::All(), int nthreads=0);
-
 /// For all pixels and channels of dst within region roi (defaulting to
 /// all the defined pixels of dst), set dst = A * B.
 ///
@@ -706,10 +683,6 @@ bool OIIO_API mul (ImageBuf &dst, float val,
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API mul (ImageBuf &dst, const ImageBuf &A, const float *B,
-                   ROI roi=ROI::All(), int nthreads=0);
-
-/// DEPRECATED in-place version. (1.3)
-bool OIIO_API mul (ImageBuf &dst, const float *val,
                    ROI roi=ROI::All(), int nthreads=0);
 
 
@@ -800,14 +773,6 @@ bool OIIO_API rangecompress (ImageBuf &dst, const ImageBuf &src,
 /// the logarithmic color channel values back to a linear response.
 bool OIIO_API rangeexpand (ImageBuf &dst, const ImageBuf &src,
                            bool useluma = false,
-                           ROI roi = ROI::All(), int nthreads=0);
-
-/// DEPRECATED in-place version (1.3)
-bool OIIO_API rangecompress (ImageBuf &dst, bool useluma = false,
-                             ROI roi = ROI::All(), int nthreads=0);
-
-/// DEPRECATED in-place version (1.3)
-bool OIIO_API rangeexpand (ImageBuf &dst, bool useluma = false,
                            ROI roi = ROI::All(), int nthreads=0);
 
 
@@ -930,9 +895,6 @@ bool OIIO_API colorconvert (float *color, int nchannels,
 bool OIIO_API unpremult (ImageBuf &dst, const ImageBuf &src,
                          ROI roi = ROI::All(), int nthreads = 0);
 
-/// DEPRECATED (1.3) in-place version
-bool OIIO_API unpremult (ImageBuf &dst, ROI roi = ROI::All(), int nthreads = 0);
-
 /// Copy pixels from dst to src, and in the process multiply all color
 /// channels (those not alpha or z) by the alpha value, to "-premultiply"
 /// them.  This presumes that the image starts off as "unassociated alpha"
@@ -953,9 +915,6 @@ bool OIIO_API unpremult (ImageBuf &dst, ROI roi = ROI::All(), int nthreads = 0);
 /// message set in dst).
 bool OIIO_API premult (ImageBuf &dst, const ImageBuf &src,
                        ROI roi = ROI::All(), int nthreads = 0);
-
-/// DEPRECATED (1.3) in-place version
-bool OIIO_API premult (ImageBuf &dst, ROI roi = ROI::All(), int nthreads = 0);
 
 
 
@@ -1560,11 +1519,6 @@ enum OIIO_API NonFiniteFixMode
 /// message set in dst).
 bool OIIO_API fixNonFinite (ImageBuf &dst, const ImageBuf &src,
                             NonFiniteFixMode mode=NONFINITE_BOX3,
-                            int *pixelsFixed = NULL,
-                            ROI roi = ROI::All(), int nthreads = 0);
-
-/// DEPRECATED (1.3) in-place version
-bool OIIO_API fixNonFinite (ImageBuf &dst, NonFiniteFixMode mode=NONFINITE_BOX3,
                             int *pixelsFixed = NULL,
                             ROI roi = ROI::All(), int nthreads = 0);
 

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -129,12 +129,6 @@ public:
     virtual bool get_image_info (ustring filename, int subimage, int miplevel,
                          ustring dataname, TypeDesc datatype, void *data) = 0;
 
-    /// Back-compatible version of get_image_info -- DEPRECATED
-    bool get_image_info (ustring filename, ustring dataname,
-                         TypeDesc datatype, void *data) {
-        return get_image_info (filename, 0, 0, dataname, datatype, data);
-    }
-
     /// Get the ImageSpec associated with the named image (the first
     /// subimage & miplevel by default, or as set by 'subimage' and
     /// 'miplevel').  If the file is found and is an image format that

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1213,7 +1213,7 @@ OIIO_API void declare_imageio_format (const std::string &format_name,
 OIIO_API bool convert_types (TypeDesc src_type, const void *src,
                               TypeDesc dst_type, void *dst, int n);
 
-/// DEPRECATED -- for some reason we had a convert_types that took
+/// DEPRECATED(1.4) -- for some reason we had a convert_types that took
 /// alpha_channel and z_channel parameters, but never did anything
 /// with them.
 OIIO_API bool convert_types (TypeDesc src_type, const void *src,

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -401,9 +401,9 @@ ImageBuf::ImageBuf (string_view filename, ImageCache *imagecache)
 
 
 ImageBuf::ImageBuf (const ImageSpec &spec)
-    : m_impl (new ImageBufImpl (std::string(), 0, 0, NULL, &spec))
+    : m_impl (new ImageBufImpl ("", 0, 0, NULL, &spec))
 {
-    alloc (spec);
+    m_impl->alloc (spec);
 }
 
 
@@ -411,7 +411,7 @@ ImageBuf::ImageBuf (const ImageSpec &spec)
 ImageBuf::ImageBuf (string_view filename, const ImageSpec &spec)
     : m_impl (new ImageBufImpl (filename, 0, 0, NULL, &spec))
 {
-    alloc (spec);
+    m_impl->alloc (spec);
 }
 
 
@@ -425,7 +425,7 @@ ImageBuf::ImageBuf (string_view filename, const ImageSpec &spec,
 
 
 ImageBuf::ImageBuf (const ImageSpec &spec, void *buffer)
-    : m_impl (new ImageBufImpl (std::string(), 0, 0, NULL, &spec, buffer))
+    : m_impl (new ImageBufImpl ("", 0, 0, NULL, &spec, buffer))
 {
 }
 
@@ -597,7 +597,7 @@ ImageBuf::reset (string_view filename, const ImageSpec &spec)
 void
 ImageBuf::reset (const ImageSpec &spec)
 {
-    impl()->reset (std::string(), spec);
+    impl()->reset ("", spec);
 }
 
 
@@ -639,14 +639,6 @@ ImageBufImpl::alloc (const ImageSpec &spec)
     m_nativespec = spec;
     realloc ();
     m_spec_valid = true;
-}
-
-
-
-void
-ImageBuf::alloc (const ImageSpec &spec)
-{
-    impl()->alloc (spec);
 }
 
 
@@ -952,17 +944,6 @@ ImageBuf::write (ImageOutput *out,
     if (! ok)
         error ("%s", out->geterror ());
     return ok;
-}
-
-
-
-bool
-ImageBuf::save (string_view filename, string_view fileformat,
-                ProgressCallback progress_callback,
-                void *progress_callback_data) const
-{
-    return write (filename, fileformat,
-                  progress_callback, progress_callback_data);
 }
 
 
@@ -1781,25 +1762,6 @@ ImageBuf::set_full (int xbegin, int xend, int ybegin, int yend,
     m_spec.full_width  = xend - xbegin;
     m_spec.full_height = yend - ybegin;
     m_spec.full_depth  = zend - zbegin;
-}
-
-
-
-void
-ImageBuf::set_full (int xbegin, int xend, int ybegin, int yend,
-                    int zbegin, int zend, const float *bordercolor)
-{
-    ImageSpec &m_spec (impl()->specmod());
-    m_spec.full_x = xbegin;
-    m_spec.full_y = ybegin;
-    m_spec.full_z = zbegin;
-    m_spec.full_width  = xend - xbegin;
-    m_spec.full_height = yend - ybegin;
-    m_spec.full_depth  = zend - zbegin;
-    if (bordercolor)
-        m_spec.attribute ("oiio:bordercolor",
-                          TypeDesc(TypeDesc::FLOAT,m_spec.nchannels),
-                          bordercolor);
 }
 
 

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -183,7 +183,7 @@ ImageBufAlgo::IBAprep (ROI &roi, ImageBuf *dst,
                                 boost::regex_replace (desc, regex_sha, ""));
         }
 
-        dst->alloc (spec);
+        dst->reset (spec);
     }
     if (prepflags & IBAprep_REQUIRE_ALPHA) {
         if (dst->spec().alpha_channel < 0 ||
@@ -423,7 +423,7 @@ ImageBufAlgo::make_kernel (ImageBuf &dst, string_view name,
     spec.full_width = spec.width;
     spec.full_height = spec.height;
     spec.full_depth = spec.depth;
-    dst.alloc (spec);
+    dst.reset (spec);
 
     if (Filter2D *filter = Filter2D::create (name, width, height)) {
         // Named continuous filter from filter.h
@@ -534,7 +534,7 @@ ImageBufAlgo::unsharp_mask (ImageBuf &dst, const ImageBuf &src,
 
     // Scale the difference image by the contrast
     if (ok)
-        ok = mul (Diff, contrast, roi, nthreads);
+        ok = mul (Diff, Diff, contrast, roi, nthreads);
     if (! ok) {
         dst.error ("%s", Diff.geterror());
         return false;

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -672,7 +672,7 @@ ImageBufAlgo::channels (ImageBuf &dst, const ImageBuf &src,
     }
 
     // Update the image (realloc with the new spec)
-    dst.alloc (newspec);
+    dst.reset (newspec);
 
     // Copy the channels individually
     stride_t dstxstride = AutoStride, dstystride = AutoStride, dstzstride = AutoStride;

--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -109,15 +109,6 @@ ImageBufAlgo::clamp (ImageBuf &dst, const ImageBuf &src,
 
 
 bool
-ImageBufAlgo::clamp (ImageBuf &dst, const float *min, const float *max,
-                     bool clampalpha01, ROI roi, int nthreads)
-{
-    return clamp (dst, dst, min, max, clampalpha01, roi, nthreads);
-}
-
-
-
-bool
 ImageBufAlgo::clamp (ImageBuf &dst, const ImageBuf &src,
                      float min, float max,
                      bool clampalpha01, ROI roi, int nthreads)
@@ -125,15 +116,6 @@ ImageBufAlgo::clamp (ImageBuf &dst, const ImageBuf &src,
     std::vector<float> minvec (src.nchannels(), min);
     std::vector<float> maxvec (src.nchannels(), max);
     return clamp (dst, src, &minvec[0], &maxvec[0], clampalpha01, roi, nthreads);
-}
-
-
-
-bool
-ImageBufAlgo::clamp (ImageBuf &dst, float min, float max,
-                     bool clampalpha01, ROI roi, int nthreads)
-{
-    return clamp (dst, dst, min, max, clampalpha01, roi, nthreads);
 }
 
 
@@ -234,22 +216,6 @@ ImageBufAlgo::add (ImageBuf &dst, const ImageBuf &A, float b,
     OIIO_DISPATCH_TYPES2 (ok, "add", add_impl, dst.spec().format,
                           A.spec().format, dst, A, vals, roi, nthreads);
     return ok;
-}
-
-
-
-bool
-ImageBufAlgo::add (ImageBuf &dst, const float *val, ROI roi, int nthreads)
-{
-    return add (dst, dst, val, roi, nthreads);
-}
-
-
-
-bool
-ImageBufAlgo::add (ImageBuf &R, float val, ROI roi, int nthreads)
-{
-    return add (R, R, val, roi, nthreads);
 }
 
 
@@ -427,22 +393,6 @@ ImageBufAlgo::mul (ImageBuf &dst, const ImageBuf &A, float b,
     return ok;
 }
 
-
-
-
-bool
-ImageBufAlgo::mul (ImageBuf &dst, const float *val, ROI roi, int nthreads)
-{
-    return mul (dst, dst, val, roi, nthreads);
-}
-
-
-
-bool
-ImageBufAlgo::mul (ImageBuf &dst, float val, ROI roi, int nthreads)
-{
-    return mul (dst, dst, val, roi, nthreads);
-}
 
 
 
@@ -782,24 +732,6 @@ ImageBufAlgo::rangeexpand (ImageBuf &dst, const ImageBuf &src,
 
 
 
-bool
-ImageBufAlgo::rangecompress (ImageBuf &dst, bool useluma,
-                             ROI roi, int nthreads)
-{
-    return rangecompress (dst, dst, useluma, roi, nthreads);
-}
-
-
-
-bool
-ImageBufAlgo::rangeexpand (ImageBuf &dst, bool useluma,
-                           ROI roi, int nthreads)
-{
-    return rangeexpand (dst, dst, useluma, roi, nthreads);
-}
-
-
-
 template<class Rtype, class Atype>
 static bool
 unpremult_ (ImageBuf &R, const ImageBuf &A, ROI roi, int nthreads)
@@ -866,14 +798,6 @@ ImageBufAlgo::unpremult (ImageBuf &dst, const ImageBuf &src,
 
 
 
-bool
-ImageBufAlgo::unpremult (ImageBuf &dst, ROI roi, int nthreads)
-{
-    return unpremult (dst, dst, roi, nthreads);
-}
-
-
-
 template<class Rtype, class Atype>
 static bool
 premult_ (ImageBuf &R, const ImageBuf &A, ROI roi, int nthreads)
@@ -931,13 +855,6 @@ ImageBufAlgo::premult (ImageBuf &dst, const ImageBuf &src,
     OIIO_DISPATCH_TYPES2 (ok, "premult", premult_, dst.spec().format,
                           src.spec().format, dst, src, roi, nthreads);
     return ok;
-}
-
-
-bool
-ImageBufAlgo::premult (ImageBuf &dst, ROI roi, int nthreads)
-{
-    return premult (dst, dst, roi, nthreads);
 }
 
 
@@ -1074,17 +991,6 @@ ImageBufAlgo::fixNonFinite (ImageBuf &dst, const ImageBuf &src,
         // pixel values, so the copy was enough.
         return true;
     }
-}
-
-
-
-// DEPRECATED (1.3)
-bool
-ImageBufAlgo::fixNonFinite (ImageBuf &dst,
-                            NonFiniteFixMode mode, int *pixelsFixed,
-                            ROI roi, int nthreads)
-{
-    return fixNonFinite (dst, dst, mode, pixelsFixed, roi, nthreads);
 }
 
 

--- a/src/libOpenImageIO/imagebufalgo_yee.cpp
+++ b/src/libOpenImageIO/imagebufalgo_yee.cpp
@@ -272,7 +272,7 @@ ImageBufAlgo::compare_Yee (const ImageBuf &img0, const ImageBuf &img1,
     ImageBuf aLum;
     int channelorder[] = { 1 };  // channel to copy
     ImageBufAlgo::channels (aLum, aLAB, 1, channelorder);
-    ImageBufAlgo::mul (aLum, luminance, ROI::All(), nthreads);
+    ImageBufAlgo::mul (aLum, aLum, luminance, ROI::All(), nthreads);
     XYZToLAB (aLAB, ROI::All(), nthreads);  // now it's LAB
 
     // Same thing for img1/bLAB/bLum
@@ -281,7 +281,7 @@ ImageBufAlgo::compare_Yee (const ImageBuf &img0, const ImageBuf &img1,
     AdobeRGBToXYZ (bLAB, ROI::All(), nthreads);  // contains XYZ now
     ImageBuf bLum;
     ImageBufAlgo::channels (bLum, bLAB, 1, channelorder);
-    ImageBufAlgo::mul (bLum, luminance, ROI::All(), nthreads);
+    ImageBufAlgo::mul (bLum, bLum, luminance, ROI::All(), nthreads);
     XYZToLAB (bLAB, ROI::All(), nthreads);  // now it's LAB
 
     // Construct Gaussian pyramids (not really pyramids, because they all

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -685,7 +685,7 @@ write_mipmap (ImageBufAlgo::MakeTextureMode mode,
                 smallspec.y = 0;
                 smallspec.full_x = 0;
                 smallspec.full_y = 0;
-                small->alloc (smallspec);  // Realocate with new size
+                small->reset (smallspec);  // Realocate with new size
                 img->set_full (img->xbegin(), img->xend(), img->ybegin(),
                                img->yend(), img->zbegin(), img->zend());
 

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -710,7 +710,7 @@ write_mipmap (ImageBufAlgo::MakeTextureMode mode,
                         outstream << "\n";
                     }
                     if (do_highlight_compensation)
-                        ImageBufAlgo::rangecompress (*img);
+                        ImageBufAlgo::rangecompress (*img, *img);
                     if (sharpen > 0.0f && sharpen_first) {
                         boost::shared_ptr<ImageBuf> sharp (new ImageBuf);
                         bool uok = ImageBufAlgo::unsharp_mask (*sharp, *img,
@@ -729,8 +729,9 @@ write_mipmap (ImageBufAlgo::MakeTextureMode mode,
                         std::swap (small, sharp);
                     }
                     if (do_highlight_compensation) {
-                        ImageBufAlgo::rangeexpand (*small);
-                        ImageBufAlgo::clamp (*small, 0.0f, std::numeric_limits<float>::max(), true);
+                        ImageBufAlgo::rangeexpand (*small, *small);
+                        ImageBufAlgo::clamp (*small, *small, 0.0f,
+                                    std::numeric_limits<float>::max(), true);
                     }
                     Filter2D::destroy (filter);
                 }
@@ -1191,7 +1192,7 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
         (srcspec.format.basetype == TypeDesc::FLOAT ||
          srcspec.format.basetype == TypeDesc::HALF ||
          srcspec.format.basetype == TypeDesc::DOUBLE) &&
-        ! ImageBufAlgo::fixNonFinite (*src, fixmode, &pixelsFixed)) {
+        ! ImageBufAlgo::fixNonFinite (*src, *src, fixmode, &pixelsFixed)) {
         outstream << "maketx ERROR: Error fixing nans/infs.\n";
         return false;
     }

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1299,7 +1299,7 @@ action_unpremult (int argc, const char *argv[])
 
     for (int s = 0, subimages = R->subimages();  s < subimages;  ++s)
         for (int m = 0, miplevels = R->miplevels(s);  m < miplevels;  ++m)
-            ImageBufAlgo::unpremult ((*R)(s,m));
+            ImageBufAlgo::unpremult ((*R)(s,m), (*R)(s,m));
 
     ot.function_times["unpremult"] += timer();
     return 0;
@@ -1323,7 +1323,7 @@ action_premult (int argc, const char *argv[])
 
     for (int s = 0, subimages = R->subimages();  s < subimages;  ++s)
         for (int m = 0, miplevels = R->miplevels(s);  m < miplevels;  ++m)
-            ImageBufAlgo::premult ((*R)(s,m));
+            ImageBufAlgo::premult ((*R)(s,m), (*R)(s,m));
 
     ot.function_times["premult"] += timer();
     return 0;

--- a/src/python/py_imagecache.cpp
+++ b/src/python/py_imagecache.cpp
@@ -121,11 +121,20 @@ std::string ImageCacheWrap::resolve_filename (const std::string &val) {
     return m_cache->resolve_filename(val);
 }
 
-bool ImageCacheWrap::get_image_info (ustring filename, ustring dataname,
+bool ImageCacheWrap::get_image_info (ustring filename, int subimage,
+                                     int miplevel, ustring dataname,
+                                     TypeDesc datatype, void *data)
+{
+    ScopedGILRelease gil;
+    return m_cache->get_image_info(filename, subimage, miplevel,
+                                   dataname, datatype, data);
+}
+
+bool ImageCacheWrap::get_image_info_old (ustring filename, ustring dataname,
                         TypeDesc datatype, void *data)
 {
     ScopedGILRelease gil;
-    return m_cache->get_image_info(filename, dataname, datatype, data);
+    return m_cache->get_image_info(filename, 0, 0, dataname, datatype, data);
 }   
 
 bool ImageCacheWrap::get_imagespec(ustring filename, ImageSpec &spec, int subimage=0)
@@ -204,6 +213,7 @@ void declare_imagecache()
         .def("getattribute", &ImageCacheWrap::getattribute_string)
         .def("resolve_filename", &ImageCacheWrap::resolve_filename)
         .def("get_image_info", &ImageCacheWrap::get_image_info)
+        .def("get_image_info", &ImageCacheWrap::get_image_info_old)
         .def("get_imagespec", &ImageCacheWrap::get_imagespec)
         .def("get_pixels", &ImageCacheWrap::get_pixels)
 //      .def("get_tile", &ImageCacheWrap::get_tile)

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -243,7 +243,8 @@ public:
     bool getattribute_char(const std::string&, char**);    
     bool getattribute_string(const std::string&, std::string&);
     std::string resolve_filename (const std::string&);
-    bool get_image_info (ustring, ustring, TypeDesc, void*);
+    bool get_image_info_old (ustring, ustring, TypeDesc, void*);
+    bool get_image_info (ustring, int, int, ustring, TypeDesc, void*);
     bool get_imagespec(ustring, ImageSpec&, int);
     bool get_pixels (ustring, int, int, int, int, int, int, 
                      int, int, TypeDesc, void*);


### PR DESCRIPTION
These are all things that have been deprecated since 1.3 was in development (around 2 years ago). Everybody has had the full lifetime of 1.3 and 1.4 to stop using them. Proposing to remove them completely in time to branch for release 1.5.
