### PR TITLE
Expand oiiotool geometry support for <float>%x<float>% syntax

### DIFF
--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -375,14 +375,21 @@ Convert a gamma-corrected image (with gamma = 2.2) to linear values.
     oiiotool original.tif --resize 1024x768 -o specific.tif
 \end{code}
 
-Resize by a known scale factor:
+\noindent Resize both dimensions by a known scale factor:
 
 \begin{code}
     oiiotool original.tif --resize 200% -o big.tif
     oiiotool original.tif --resize 25% -o small.tif
 \end{code}
 
-Resize to a known resolution in one dimension, with the other dimension
+\noindent Resize each dimension, independently, by known scale factors:
+
+\begin{code}
+    oiiotool original.tif --resize 300%x200% -o big.tif
+    oiiotool original.tif --resize 100%x25% -o small.tif
+\end{code}
+
+\noindent Resize to a known resolution in one dimension, with the other dimension
 automatically computed to preserve aspect ratio (just specify 0 as the
 resolution in the dimension to be automatically computed):
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -778,7 +778,8 @@ Oiiotool::adjust_geometry (string_view command,
                            int &w, int &h, int &x, int &y, const char *geom,
                            bool allow_scaling)
 {
-    float scale = 1.0f;
+    float scaleX = 1.0f;
+    float scaleY = 1.0f;
     int ww = w, hh = h;
     int xx = x, yy = y;
     int xmax, ymax;
@@ -803,21 +804,30 @@ Oiiotool::adjust_geometry (string_view command,
             hh = int (ww * float(h)/float(w) + 0.5f);
         w = ww;
         h = hh;
+    } else if (allow_scaling && sscanf (geom, "%f%%x%f%%", &scaleX, &scaleY) == 2) {
+        scaleX = std::max(0.0f, scaleX*0.01f);
+        scaleY = std::max(0.0f, scaleY*0.01f);
+        if (scaleX == 0 && scaleY != 0)
+            scaleX = scaleY;
+        if (scaleY == 0 && scaleX != 0)
+            scaleY = scaleX;
+        w = (int)(w * scaleX + 0.5f);
+        h = (int)(h * scaleY + 0.5f);
     } else if (sscanf (geom, "%d%d", &xx, &yy) == 2) {
         x = xx;
         y = yy;
-    } else if (allow_scaling && sscanf (geom, "%f%%", &scale) == 1) {
-        scale *= 0.01f;
-        w = (int)(w * scale + 0.5f);
-        h = (int)(h * scale + 0.5f);
-    } else if (allow_scaling && sscanf (geom, "%f", &scale) == 1) {
-        w = (int)(w * scale + 0.5f);
-        h = (int)(h * scale + 0.5f);
+    } else if (allow_scaling && sscanf (geom, "%f%%", &scaleX) == 1) {
+        scaleX *= 0.01f;
+        w = (int)(w * scaleX + 0.5f);
+        h = (int)(h * scaleX + 0.5f);
+    } else if (allow_scaling && sscanf (geom, "%f", &scaleX) == 1) {
+        w = (int)(w * scaleX + 0.5f);
+        h = (int)(h * scaleX + 0.5f);
     } else {
         error (command, Strutil::format ("Unrecognized geometry \"%s\"", geom));
         return false;
     }
-//    printf ("geom %dx%d, %+d%+d\n", w, h, x, y);
+    // printf ("geom %dx%d, %+d%+d\n", w, h, x, y);
     return true;
 }
 


### PR DESCRIPTION
As per discussions in the oiio-dev list, I have expanded the oiiotool adjust_geometry function to accept two float scale values, to independently scale each dimension. 
