### PR TITLE
TIFF: allow writing of half (fp16) pixels.

### DIFF
--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -271,8 +271,10 @@ TIFFOutput::open (const std::string &name, const ImageSpec &userspec,
         sampformat = SAMPLEFORMAT_UINT;
         break;
     case TypeDesc::HALF:
-        // Silently change requests for unsupported 'half' to 'float'
-        m_spec.set_format (TypeDesc::FLOAT);
+        // Adobe extension, see http://chriscox.org/TIFFTN3d1.pdf
+        bps = 16;
+        sampformat = SAMPLEFORMAT_IEEEFP;
+        break;
     case TypeDesc::FLOAT:
         bps = 32;
         sampformat = SAMPLEFORMAT_IEEEFP;


### PR DESCRIPTION
Floating point pixels are designated in TIFF files by a combination of the sampleformat being SAMPLEFORMAT_IEEEFP, and the bitspersample being either 32 or 64, giving what we would interpret as float or double pixels.

A 2005 whitepaper by Adobe extended the TIFF standard to handle the combination of SAMPLEFORMAT_IEEEFP and 16 bits per sample to mean the obvious interpretation of 'half' pixels (like are used by OpenEXR and GPUs). For some time now, we have read this kind of file with no trouble, but our TIFF writer has always silently converted half pixels to float for TIFF output, on the theory that there are probably lots of TIFF-reading programs out there that don't know about this and would therefore get it wrong.

This patch enables the outputs of half-valued TIFF files.

Honestly, I'm not 100% sure this is good. But 10 years after it was supposedly added to the standard, let's hope it's well supported by readers. If reports start coming back from the field that this is causing OIIO to create files that aren't widely readable, then we can revisit the decision.

Though, if anybody objects now, please do say so, I'm not wedded to this idea. It would be nice to support this, but not at the expense of making unreadable TIFF files. (Though it's also easy enough to avoid the issue by simply not requesting 'half' TIFF output.)

