### PR TITLE
Catch all exceptions with catch(...)

### DIFF
--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -249,7 +249,7 @@ Filesystem::exists (const std::string &path)
     bool r = false;
     try {
         r = boost::filesystem::exists (path);
-    } catch (const std::exception &) {
+    } catch (...) {
         r = false;
     }
     return r;
@@ -263,7 +263,7 @@ Filesystem::is_directory (const std::string &path)
     bool r = false;
     try {
         r = boost::filesystem::is_directory (path);
-    } catch (const std::exception &) {
+    } catch (...) {
         r = false;
     }
     return r;
@@ -277,7 +277,7 @@ Filesystem::is_regular (const std::string &path)
     bool r = false;
     try {
         r = boost::filesystem::is_regular_file (path);
-    } catch (const std::exception &) {
+    } catch (...) {
         r = false;
     }
     return r;
@@ -496,7 +496,7 @@ Filesystem::last_write_time (const std::string& path)
 #else
         return boost::filesystem::last_write_time (path);
 #endif
-    } catch (const std::exception &) {
+    } catch (...) {
         // File doesn't exist
         return 0;
     }
@@ -514,7 +514,7 @@ Filesystem::last_write_time (const std::string& path, std::time_t time)
 #else
         boost::filesystem::last_write_time (path, time);
 #endif
-    } catch (const std::exception &) {
+    } catch (...) {
         // File doesn't exist
     }
 }
@@ -829,7 +829,7 @@ Filesystem::scan_for_matching_filenames(const std::string &pattern_,
         }
     }
 
-    } catch (std::exception &e) {
+    } catch (...) {
         // Botched regex. Just fail.
         return false;
     }

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -364,21 +364,27 @@ OpenEXRInput::open (const std::string &name, ImageSpec &newspec)
     
     try {
         m_input_stream = new OpenEXRInputStream (name.c_str());
-    }
-    catch (const std::exception &e) {
+    } catch (const std::exception &e) {
         m_input_stream = NULL;
         error ("OpenEXR exception: %s", e.what());
+        return false;
+    } catch (...) {   // catch-all for edge cases or compiler bugs
+        m_input_stream = NULL;
+        error ("OpenEXR exception: unknown");
         return false;
     }
 
 #ifdef USE_OPENEXR_VERSION2
     try {
         m_input_multipart = new Imf::MultiPartInputFile (*m_input_stream);
-    }
-    catch (const std::exception &e) {
+    } catch (const std::exception &e) {
         delete m_input_stream;
         m_input_stream = NULL;
         error ("OpenEXR exception: %s", e.what());
+        return false;
+    } catch (...) {   // catch-all for edge cases or compiler bugs
+        m_input_stream = NULL;
+        error ("OpenEXR exception: unknown");
         return false;
     }
 
@@ -391,11 +397,14 @@ OpenEXRInput::open (const std::string &name, ImageSpec &newspec)
         } else {
             m_input_scanline = new Imf::InputFile (*m_input_stream);
         }
-    }
-    catch (const std::exception &e) {
+    } catch (const std::exception &e) {
         delete m_input_stream;
         m_input_stream = NULL;
         error ("OpenEXR exception: %s", e.what());
+        return false;
+    } catch (...) {   // catch-all for edge cases or compiler bugs
+        m_input_stream = NULL;
+        error ("OpenEXR exception: unknown");
         return false;
     }
 
@@ -832,9 +841,16 @@ OpenEXRInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
                 else
                     m_scanline_input_part = new Imf::InputPart (*m_input_multipart, subimage);
             }
-        }
-        catch (const std::exception &e) {
+        } catch (const std::exception &e) {
             error ("OpenEXR exception: %s", e.what());
+            m_scanline_input_part = NULL;
+            m_tiled_input_part = NULL;
+            m_deep_scanline_input_part = NULL;
+            m_deep_tiled_input_part = NULL;
+            ASSERT(0);
+            return false;
+        } catch (...) {   // catch-all for edge cases or compiler bugs
+            error ("OpenEXR exception: unknown");
             m_scanline_input_part = NULL;
             m_tiled_input_part = NULL;
             m_deep_scanline_input_part = NULL;
@@ -987,9 +1003,11 @@ OpenEXRInput::read_native_scanlines (int ybegin, int yend, int z,
         } else {
             ASSERT (0);
         }
-    }
-    catch (const std::exception &e) {
+    } catch (const std::exception &e) {
         error ("Failed OpenEXR read: %s", e.what());
+        return false;
+    } catch (...) {   // catch-all for edge cases or compiler bugs
+        error ("Failed OpenEXR read: unknown exception");
         return false;
     }
     return true;
@@ -1099,9 +1117,11 @@ OpenEXRInput::read_native_tiles (int xbegin, int xend, int ybegin, int yend,
                         (char *)data+(y-ybegin)*scanline_stride,
                         user_scanline_bytes);
         }
-    }
-    catch (const std::exception &e) {
+    } catch (const std::exception &e) {
         error ("Failed OpenEXR read: %s", e.what());
+        return false;
+    } catch (...) {   // catch-all for edge cases or compiler bugs
+        error ("Failed OpenEXR read: unknown exception");
         return false;
     }
 
@@ -1159,9 +1179,11 @@ OpenEXRInput::read_native_deep_scanlines (int ybegin, int yend, int z,
 
         // Read the pixels
         m_deep_scanline_input_part->readPixels (ybegin, yend-1);
-    }
-    catch (const std::exception &e) {
+    } catch (const std::exception &e) {
         error ("Failed OpenEXR read: %s", e.what());
+        return false;
+    } catch (...) {   // catch-all for edge cases or compiler bugs
+        error ("Failed OpenEXR read: unknown exception");
         return false;
     }
 
@@ -1230,9 +1252,11 @@ OpenEXRInput::read_native_deep_tiles (int xbegin, int xend,
         // Read the pixels
         m_deep_tiled_input_part->readTiles (0, xtiles-1, 0, ytiles-1,
                                             m_miplevel, m_miplevel);
-    }
-    catch (const std::exception &e) {
+    } catch (const std::exception &e) {
         error ("Failed OpenEXR read: %s", e.what());
+        return false;
+    } catch (...) {   // catch-all for edge cases or compiler bugs
+        error ("Failed OpenEXR read: unknown exception");
         return false;
     }
 

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -345,9 +345,13 @@ OpenEXROutput::open (const std::string &name, const ImageSpec &userspec,
                 m_output_scanline = new Imf::OutputFile (*m_output_stream,
                                                          m_headers[m_subimage]);
             }
-        }
-        catch (const std::exception &e) {
+        } catch (const std::exception &e) {
             error ("OpenEXR exception: %s", e.what());
+            m_output_scanline = NULL;
+            m_output_tiled = NULL;
+            return false;
+        } catch (...) {   // catch-all for edge cases or compiler bugs
+            error ("OpenEXR exception: unknown");
             m_output_scanline = NULL;
             m_output_tiled = NULL;
             return false;
@@ -391,9 +395,15 @@ OpenEXROutput::open (const std::string &name, const ImageSpec &userspec,
             } else {
                 ASSERT (0);
             }
-        }
-        catch (const std::exception &e) {
+        } catch (const std::exception &e) {
             error ("OpenEXR exception: %s", e.what());
+            m_scanline_output_part = NULL;
+            m_tiled_output_part = NULL;
+            m_deep_scanline_output_part = NULL;
+            m_deep_tiled_output_part = NULL;
+            return false;
+        } catch (...) {   // catch-all for edge cases or compiler bugs
+            error ("OpenEXR exception: unknown exception");
             m_scanline_output_part = NULL;
             m_tiled_output_part = NULL;
             m_deep_scanline_output_part = NULL;
@@ -496,11 +506,15 @@ OpenEXROutput::open (const std::string &name, int subimages,
         // do this quite yet.
         m_output_multipart = new Imf::MultiPartOutputFile (name.c_str(),
                                                  &m_headers[0], subimages);
-    }
-    catch (const std::exception &e) {
+    } catch (const std::exception &e) {
         delete m_output_stream;
         m_output_stream = NULL;
         error ("OpenEXR exception: %s", e.what());
+        return false;
+    } catch (...) {   // catch-all for edge cases or compiler bugs
+        delete m_output_stream;
+        m_output_stream = NULL;
+        error ("OpenEXR exception: unknown exception");
         return false;
     }
     try {
@@ -517,9 +531,16 @@ OpenEXROutput::open (const std::string &name, int subimages,
                 m_scanline_output_part = new Imf::OutputPart (*m_output_multipart, 0);
             }
         }
-    }
-    catch (const std::exception &e) {
+    } catch (const std::exception &e) {
         error ("OpenEXR exception: %s", e.what());
+        delete m_output_stream;  m_output_stream = NULL;
+        m_scanline_output_part = NULL;
+        m_tiled_output_part = NULL;
+        m_deep_scanline_output_part = NULL;
+        m_deep_tiled_output_part = NULL;
+        return false;
+    } catch (...) {  // catch-all for edge cases or compiler bugs
+        error ("OpenEXR exception: unknown exception");
         delete m_output_stream;  m_output_stream = NULL;
         m_scanline_output_part = NULL;
         m_tiled_output_part = NULL;
@@ -1069,6 +1090,10 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
 #ifndef NDEBUG
         std::cout << "Caught OpenEXR exception: " << e.what() << "\n";
 #endif
+    } catch (...) {  // catch-all for edge cases or compiler bugs
+#ifndef NDEBUG
+        std::cout << "Caught unknown OpenEXR exception\n";
+#endif
     }
 
 #ifndef NDEBUG
@@ -1155,9 +1180,11 @@ OpenEXROutput::write_scanline (int y, int z, TypeDesc format,
         } else {
             ASSERT (0);
         }
-    }
-    catch (const std::exception &e) {
+    } catch (const std::exception &e) {
         error ("Failed OpenEXR write: %s", e.what());
+        return false;
+    } catch (...) {  // catch-all for edge cases or compiler bugs
+        error ("Failed OpenEXR write: unknown exception");
         return false;
     }
 
@@ -1230,9 +1257,11 @@ OpenEXROutput::write_scanlines (int ybegin, int yend, int z,
             } else {
                 ASSERT (0);
             }
-        }
-        catch (const std::exception &e) {
+        } catch (const std::exception &e) {
             error ("Failed OpenEXR write: %s", e.what());
+            return false;
+        } catch (...) {  // catch-all for edge cases or compiler bugs
+            error ("Failed OpenEXR write: unknown exception");
             return false;
         }
 
@@ -1353,9 +1382,11 @@ OpenEXROutput::write_tiles (int xbegin, int xend, int ybegin, int yend,
         } else {
             ASSERT (0);
         }
-    }
-    catch (const std::exception &e) {
+    } catch (const std::exception &e) {
         error ("Failed OpenEXR write: %s", e.what());
+        return false;
+    } catch (...) {  // catch-all for edge cases or compiler bugs
+        error ("Failed OpenEXR write: unknown exception");
         return false;
     }
 
@@ -1405,9 +1436,11 @@ OpenEXROutput::write_deep_scanlines (int ybegin, int yend, int z,
 
         // Write the pixels
         m_deep_scanline_output_part->writePixels (yend-ybegin);
-    }
-    catch (const std::exception &e) {
+    } catch (const std::exception &e) {
         error ("Failed OpenEXR write: %s", e.what());
+        return false;
+    } catch (...) {  // catch-all for edge cases or compiler bugs
+        error ("Failed OpenEXR write: unknown exception");
         return false;
     }
 
@@ -1472,9 +1505,11 @@ OpenEXROutput::write_deep_tiles (int xbegin, int xend, int ybegin, int yend,
         m_deep_tiled_output_part->writeTiles (firstxtile, firstxtile+xtiles-1,
                                               firstytile, firstytile+ytiles-1,
                                               m_miplevel, m_miplevel);
-    }
-    catch (const std::exception &e) {
+    } catch (const std::exception &e) {
         error ("Failed OpenEXR write: %s", e.what());
+        return false;
+    } catch (...) {  // catch-all for edge cases or compiler bugs
+        error ("Failed OpenEXR write: unknown exception");
         return false;
     }
 

--- a/src/socket.imageio/socketinput.cpp
+++ b/src/socket.imageio/socketinput.cpp
@@ -113,6 +113,9 @@ SocketInput::read_native_scanline (int y, int z, void *data)
     } catch (boost::system::system_error &err) {
         error ("Error while reading: %s", err.what ());
         return false;
+    } catch (...) {
+        error ("Error while reading: unknown exception");
+        return false;
     }
 
     return true;
@@ -128,6 +131,9 @@ SocketInput::read_native_tile (int x, int y, int z, void *data)
                 m_spec.tile_bytes ()));
     } catch (boost::system::system_error &err) {
         error ("Error while reading: %s", err.what ());
+        return false;
+    } catch (...) {
+        error ("Error while reading: unknown exception");
         return false;
     }
 
@@ -167,6 +173,9 @@ SocketInput::accept_connection(const std::string &name)
     } catch (boost::system::system_error &err) {
         error ("Error while accepting: %s", err.what ());
         return false;
+    } catch (...) {
+        error ("Error while accepting: unknown exception");
+        return false;
     }
 
     return true;
@@ -189,7 +198,10 @@ SocketInput::get_spec_from_client (ImageSpec &spec)
         spec.from_xml (spec_xml);
         delete [] spec_xml;
     } catch (boost::system::system_error &err) {
-        error ("Error while reading: %s", err.what ());
+        error ("Error while get_spec_from_client: %s", err.what ());
+        return false;
+    } catch (...) {
+        error ("Error while get_spec_from_client: unknown exception");
         return false;
     }
 

--- a/src/socket.imageio/socketoutput.cpp
+++ b/src/socket.imageio/socketoutput.cpp
@@ -85,7 +85,10 @@ SocketOutput::write_scanline (int y, int z, TypeDesc format,
     try {
         socket_pvt::socket_write (socket, format, data, m_spec.scanline_bytes ());
     } catch (boost::system::system_error &err) {
-        error ("Error while reading: %s", err.what ());
+        error ("Error while writing: %s", err.what ());
+        return false;
+    } catch (...) {
+        error ("Error while writing: unknown exception");
         return false;
     }
 
@@ -106,7 +109,10 @@ SocketOutput::write_tile (int x, int y, int z,
     try {
         socket_pvt::socket_write (socket, format, data, m_spec.tile_bytes ());
     } catch (boost::system::system_error &err) {
-        error ("Error while reading: %s", err.what ());
+        error ("Error while writing: %s", err.what ());
+        return false;
+    } catch (...) {
+        error ("Error while writing: unknown exception");
         return false;
     }
 
@@ -143,7 +149,10 @@ SocketOutput::send_spec_to_server(const ImageSpec& spec)
                 sizeof (boost::uint32_t)));
         boost::asio::write (socket, buffer (spec_xml.c_str (), spec_xml.length ()));
     } catch (boost::system::system_error &err) {
-        error ("Error while writing: %s", err.what ());
+        error ("Error while send_spec_to_server: %s", err.what ());
+        return false;
+    } catch (...) {
+        error ("Error while send_spec_to_server: unknown exception");
         return false;
     }
 
@@ -183,6 +192,9 @@ SocketOutput::connect_to_server (const std::string &name)
         }
     } catch (boost::system::system_error &err) {
         error ("Error while connecting: %s", err.what ());
+        return false;
+    } catch (...) {
+        error ("Error while connecting: unknown exception");
         return false;
     }
 


### PR DESCRIPTION
Some places -- notably, the parts of OIIO that deal with field3d and OpenColorIO -- already put a catch(...) even after catches of other specific exceptions. But others, including OIIO::Filesystem wrappers and the places where we deal with OpenEXR, tried to catch specific exceptions, even std::exception&, which we would have thought would catch anything. But apparently not. At the very least, some versions of clang on Apple, when -fno-rtti is used for static linkage, have a bug that can still let through exceptions. Now we really, absolutely, catch everything, dammit.

Fixes #1025