### PR TITLE
oiiotool: rename -cadd, -csub, -cmul, -cpow to -addc, -subc, -mulc, -powc

### DIFF
--- a/src/doc/makefigures.bash
+++ b/src/doc/makefigures.bash
@@ -11,8 +11,8 @@ echo "Using OIIOTOOL=${OIIOTOOL}"
 #${OIIOTOOL} ../../../../oiio-images/tahoe-gps.jpg --colorconvert sRGB linear --resize 320x240 --colorconvert linear sRGB -o tahoe-small.jpg
 #${OIIOTOOL} ../../../../oiio-images/grid.tif --resize 256x256 --colorconvert linear sRGB -o grid-small.jpg
 
-${OIIOTOOL} tahoe-small.jpg --tocolorspace linear --cadd 0.2 --tocolorspace sRGB -o cadd.jpg
-${OIIOTOOL} tahoe-small.jpg --tocolorspace linear --cmul 0.5 --tocolorspace sRGB -o cmul.jpg
+${OIIOTOOL} tahoe-small.jpg --tocolorspace linear --addc 0.2 --tocolorspace sRGB -o addc.jpg
+${OIIOTOOL} tahoe-small.jpg --tocolorspace linear --mulc 0.5 --tocolorspace sRGB -o mulc.jpg
 ${OIIOTOOL} tahoe-small.jpg --tocolorspace linear --chsum:weight=.2126,.7152,.0722 --ch 0,0,0 --tocolorspace sRGB -o luma.jpg
 ${OIIOTOOL} grid-small.jpg --flip -o flip.jpg
 ${OIIOTOOL} grid-small.jpg --flop -o flop.jpg

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -356,7 +356,7 @@ Reduce the brightness of the R, G, and B channels by 10\%,
 but leave the A channel at its original value:
 
 \begin{code}
-    oiiotool original.exr --cmul 0.9,0.9,0.9,1.0 -o out.exr
+    oiiotool original.exr --mulc 0.9,0.9,0.9,1.0 -o out.exr
 \end{code}
 
 \subsection*{Remove gamma-correction from an image}
@@ -364,7 +364,7 @@ but leave the A channel at its original value:
 Convert a gamma-corrected image (with gamma = 2.2) to linear values.
 
 \begin{code}
-    oiiotool corrected.exr --cpow 2.2,2.2,2.2,1.0 -o linear.exr
+    oiiotool corrected.exr --powc 2.2,2.2,2.2,1.0 -o linear.exr
 \end{code}
 
 \subsection*{Resize an image}
@@ -491,7 +491,7 @@ and naming it ``Z'' so it will be recognized as a depth channel:
 \noindent Fade 30\% of the way from A to B:
 
 \begin{code}
-    oiiotool A.exr --cmul 0.7 B.exr --cmul 0.3 --add -o fade.exr
+    oiiotool A.exr --mulc 0.7 B.exr --mulc 0.3 --add -o fade.exr
 \end{code}
 
 
@@ -1292,8 +1292,8 @@ different multiplier for each channel in the image, respectively.
 Division by zero is defined as resulting in 0.
 \apiend
 
-\apiitem{--cadd {\rm \emph{value}} \\
---cadd {\rm \emph{value0,value1,value2...}}}
+\apiitem{--addc {\rm \emph{value}} \\
+--addc {\rm \emph{value0,value1,value2...}}}
 Add a constant value to all the pixels in the current image.  If a
 single constant value is given, it will be added to all color channels.
 Alternatively, a series of comma-separated constant values (with no
@@ -1302,15 +1302,25 @@ channel in the image, respectively.
 
 \noindent Example:
 \begin{code}
-    oiiotool tahoe.jpg --cadd 0.5 -o cadd.jpg
+    oiiotool tahoe.jpg --addc 0.5 -o addc.jpg
 \end{code}
 \spc \includegraphics[width=1.25in]{figures/tahoe-small.jpg} 
 ~ {\Huge $\rightarrow$} ~
-\includegraphics[width=1.25in]{figures/cadd.jpg} \\
+\includegraphics[width=1.25in]{figures/addc.jpg} \\
 \apiend
 
-\apiitem{--cmul {\rm \emph{value}} \\
---cmul {\rm \emph{value0,value1,value2...}}}
+\apiitem{--subc {\rm \emph{value}} \\
+--subc {\rm \emph{value0,value1,value2...}}}
+\NEW %1.6
+Subtrace a constant value from all the pixels in the current image.  If a
+single constant value is given, it will be subtracted from all color channels.
+Alternatively, a series of comma-separated constant values (with no
+spaces!) may be used to specifiy a different value to subtract from each
+channel in the image, respectively.
+\apiend
+
+\apiitem{--mulc {\rm \emph{value}} \\
+--mulc {\rm \emph{value0,value1,value2...}}}
 Multiply all the pixel values in the top image by a constant value.
 If a single constant value is given, all color channels will have their values
 multiplied by the same value.  Alternatively, a series of
@@ -1319,15 +1329,15 @@ different multiplier for each channel in the image, respectively.
 
 \noindent Example:
 \begin{code}
-    oiiotool tahoe.jpg --cmul 0.2 -o cmul.jpg
+    oiiotool tahoe.jpg --mulc 0.2 -o mulc.jpg
 \end{code}
 \spc \includegraphics[width=1.25in]{figures/tahoe-small.jpg} 
 ~ {\Huge $\rightarrow$} ~
-\includegraphics[width=1.25in]{figures/cmul.jpg} \\
+\includegraphics[width=1.25in]{figures/mulc.jpg} \\
 \apiend
 
-\apiitem{--cpow {\rm \emph{value}} \\
---cpow {\rm \emph{value0,value1,value2...}}}
+\apiitem{--powc {\rm \emph{value}} \\
+--powc {\rm \emph{value0,value1,value2...}}}
 Raise all the pixel values in the top image to a constant power value.
 If a single constant value is given, all color channels will have their values
 raised to this power.  Alternatively, a series of

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1916,9 +1916,9 @@ action_sub (int argc, const char *argv[])
 
 
 static int
-action_csub (int argc, const char *argv[])
+action_subc (int argc, const char *argv[])
 {
-    if (ot.postpone_callback (1, action_csub, argc, argv))
+    if (ot.postpone_callback (1, action_subc, argc, argv))
         return 0;
     Timer timer (ot.enable_function_timing);
 
@@ -1937,11 +1937,11 @@ action_csub (int argc, const char *argv[])
         val.resize (nchans, val.size() == 1 ? val.back() : 0.0f);
         for (int m = 0, miplevels = ot.curimg->miplevels(s);  m < miplevels;  ++m) {
             if (! ImageBufAlgo::sub ((*R)(s,m), (*R)(s,m), &val[0]))
-                ot.error ("csub", (*R)(s,m).geterror());
+                ot.error ("subc", (*R)(s,m).geterror());
         }
     }
 
-    ot.function_times["csub"] += timer();
+    ot.function_times["subc"] += timer();
     return 0;
 }
 
@@ -2072,9 +2072,9 @@ action_mul (int argc, const char *argv[])
 
 
 static int
-action_cmul (int argc, const char *argv[])
+action_mulc (int argc, const char *argv[])
 {
-    if (ot.postpone_callback (1, action_cmul, argc, argv))
+    if (ot.postpone_callback (1, action_mulc, argc, argv))
         return 0;
     Timer timer (ot.enable_function_timing);
 
@@ -2107,11 +2107,11 @@ action_cmul (int argc, const char *argv[])
         for (int m = 0, miplevels = ot.curimg->miplevels(s); m < miplevels; ++m) {
             bool ok = ImageBufAlgo::mul ((*R)(s,m), (*R)(s,m), &scale[0]);
             if (! ok)
-                ot.error ("cmul", (*R)(s,m).geterror());
+                ot.error ("mulc", (*R)(s,m).geterror());
         }
     }
 
-    ot.function_times["cmul"] += timer();
+    ot.function_times["mulc"] += timer();
     return 0;
 }
 
@@ -2178,9 +2178,9 @@ action_divc (int argc, const char *argv[])
 
 
 static int
-action_cadd (int argc, const char *argv[])
+action_addc (int argc, const char *argv[])
 {
-    if (ot.postpone_callback (1, action_cadd, argc, argv))
+    if (ot.postpone_callback (1, action_addc, argc, argv))
         return 0;
     Timer timer (ot.enable_function_timing);
 
@@ -2213,20 +2213,20 @@ action_cadd (int argc, const char *argv[])
         for (int m = 0, miplevels = ot.curimg->miplevels(s);  m < miplevels;  ++m) {
             bool ok = ImageBufAlgo::add ((*R)(s,m), (*R)(s,m), &val[0]);
             if (! ok)
-                ot.error ("cadd", (*R)(s,m).geterror());
+                ot.error ("addc", (*R)(s,m).geterror());
         }
     }
 
-    ot.function_times["cadd"] += timer();
+    ot.function_times["addc"] += timer();
     return 0;
 }
 
 
 
 static int
-action_cpow (int argc, const char *argv[])
+action_powc (int argc, const char *argv[])
 {
-    if (ot.postpone_callback (1, action_cpow, argc, argv))
+    if (ot.postpone_callback (1, action_powc, argc, argv))
         return 0;
     Timer timer (ot.enable_function_timing);
 
@@ -2259,11 +2259,11 @@ action_cpow (int argc, const char *argv[])
         for (int m = 0, miplevels = ot.curimg->miplevels(s); m < miplevels; ++m) {
             bool ok = ImageBufAlgo::pow ((*R)(s,m), (*R)(s,m), &scale[0]);
             if (! ok)
-                ot.error ("cpow", (*R)(s,m).geterror());
+                ot.error ("powc", (*R)(s,m).geterror());
         }
     }
 
-    ot.function_times["cpow"] += timer();
+    ot.function_times["powc"] += timer();
     return 0;
 }
 
@@ -4003,17 +4003,21 @@ getargs (int argc, char *argv[])
                 "--diff %@", action_diff, NULL, "Print report on the difference of two images (modified by --fail, --failpercent, --hardfail, --warn, --warnpercent --hardwarn)",
                 "--pdiff %@", action_pdiff, NULL, "Print report on the perceptual difference of two images (modified by --fail, --failpercent, --hardfail, --warn, --warnpercent --hardwarn)",
                 "--add %@", action_add, NULL, "Add two images",
+                "--addc %s %@", action_addc, NULL, "Add to all channels a scalar or per-channel constants (e.g.: 0.5 or 1,1.25,0.5)",
+                "--cadd %s %@", action_addc, NULL, "", // Deprecated synonym
                 "--sub %@", action_sub, NULL, "Subtract two images",
-                "--abs %@", action_abs, NULL, "Take the absolute value of the image pixels",
-                "--absdiff %@", action_absdiff, NULL, "Absolute difference between two images",
+                "--subc %s %@", action_subc, NULL, "Subtract from all channels a scalar or per-channel constants (e.g.: 0.5 or 1,1.25,0.5)",
+                "--csub %s %@", action_subc, NULL, "", // Deprecated synonym
                 "--mul %@", action_mul, NULL, "Multiply two images",
+                "--mulc %s %@", action_mulc, NULL, "Multiply the image values by a scalar or per-channel constants (e.g.: 0.5 or 1,1.25,0.5)",
+                "--cmul %s %@", action_mulc, NULL, "", // Deprecated synonym
                 "--div %@", action_div, NULL, "Divide first image by second image",
                 "--divc %s %@", action_divc, NULL, "Divide the image values by a scalar or per-channel constants (e.g.: 0.5 or 1,1.25,0.5)",
-                "--cadd %s %@", action_cadd, NULL, "Add to all channels a scalar or per-channel constants (e.g.: 0.5 or 1,1.25,0.5)",
-                "--csub %s %@", action_csub, NULL, "Subtract from all channels a scalar or per-channel constants (e.g.: 0.5 or 1,1.25,0.5)",
+                "--abs %@", action_abs, NULL, "Take the absolute value of the image pixels",
+                "--absdiff %@", action_absdiff, NULL, "Absolute difference between two images",
                 "--absdiffc %s %@", action_absdiffc, NULL, "Absolute difference versus a scalar or per-channel constant (e.g.: 0.5 or 1,1.25,0.5)",
-                "--cmul %s %@", action_cmul, NULL, "Multiply the image values by a scalar or per-channel constants (e.g.: 0.5 or 1,1.25,0.5)",
-                "--cpow %s %@", action_cpow, NULL, "Raise the image values to a scalar or per-channel power (e.g.: 2.2 or 2.2,2.2,2.2,1.0)",
+                "--powc %s %@", action_powc, NULL, "Raise the image values to a scalar or per-channel power (e.g.: 2.2 or 2.2,2.2,2.2,1.0)",
+                "--cpow %s %@", action_powc, NULL, "", // Depcrcated synonym
                 "--chsum %@", action_chsum, NULL,
                     "Turn into 1-channel image by summing channels (options: weight=r,g,...)",
                 "--crop %@ %s", action_crop, NULL, "Set pixel data resolution and offset, cropping or padding if necessary (WxH+X+Y or xmin,ymin,xmax,ymax)",

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -51,13 +51,13 @@ command += oiiotool ("resize.tif --rotate 45 --rotate 90 --rotate 90 --rotate 90
 # test warp
 command += oiiotool ("resize.tif --warp 0.7071068,0.7071068,0,-0.7071068,0.7071068,0,128,-53.01933,1 -o warped.tif")
 
-# test --cmul
+# test --mulc
 # First, make a small gray swatch
 command += oiiotool ("--pattern constant:color=0.5,0.5,0.5 128x128 3 -d half -o cmul-input.exr")
-# Test --cmul val (multiply all channels by the same scalar)
-command += oiiotool ("cmul-input.exr --cmul 1.5 -o cmul1.exr")
-# Test --cmul val,val,val... (multiply per-channel scalars)
-command += oiiotool ("cmul-input.exr --cmul 1.5,1,0.5 -o cmul2.exr")
+# Test --mulc val (multiply all channels by the same scalar)
+command += oiiotool ("cmul-input.exr --mulc 1.5 -o cmul1.exr")
+# Test --mulc val,val,val... (multiply per-channel scalars)
+command += oiiotool ("cmul-input.exr --mulc 1.5,1,0.5 -o cmul2.exr")
 
 # Test --divc val (divide all channels by the same scalar)
 command += oiiotool ("--pattern constant:color=0.5,0.5,0.5 64x64 3 "
@@ -70,26 +70,26 @@ command += oiiotool ("--pattern constant:color=0.5,0.5,0.5 64x64 3 "
                      "--pattern constant:color=2.0,1,0.5 64x64 3 "
                      "--div -d half -o div.exr")
 
-# Test --cadd val (add to all channels the same scalar)
-command += oiiotool ("cmul-input.exr --cadd 0.25 -o cadd1.exr")
-# Test --cadd val,val,val... (add per-channel scalars)
-command += oiiotool ("cmul-input.exr --cadd 0,0.25,-0.25 -o cadd2.exr")
+# Test --addc val (add to all channels the same scalar)
+command += oiiotool ("cmul-input.exr --addc 0.25 -o cadd1.exr")
+# Test --addc val,val,val... (add per-channel scalars)
+command += oiiotool ("cmul-input.exr --addc 0,0.25,-0.25 -o cadd2.exr")
 
-# Test --cpow val (raise all channels by the same power)
-command += oiiotool ("cmul-input.exr --cpow 2 -o cpow1.exr")
-# Test --cpow val,val,val... (per-channel powers)
-command += oiiotool ("cmul-input.exr --cpow 2,2,1 -o cpow2.exr")
+# Test --powc val (raise all channels by the same power)
+command += oiiotool ("cmul-input.exr --powc 2 -o cpow1.exr")
+# Test --powc val,val,val... (per-channel powers)
+command += oiiotool ("cmul-input.exr --powc 2,2,1 -o cpow2.exr")
 
 # Test --add
 command += oiiotool ("--pattern constant:color=.1,.2,.3 64x64+0+0 3 "
             + " --pattern constant:color=.1,.1,.1 64x64+20+20 3 "
             + " --add -d half -o add.exr")
-# Test --sub, csub
+# Test --sub, subc
 command += oiiotool ("--pattern constant:color=.1,.2,.3 64x64+0+0 3 "
             + " --pattern constant:color=.1,.1,.1 64x64+20+20 3 "
             + " --sub -d half -o sub.exr")
 command += oiiotool ("--pattern constant:color=.1,.2,.3 64x64+0+0 3 "
-            + " --csub 0.1,0.1,0.1 -d half -o subc.exr")
+            + " --subc 0.1,0.1,0.1 -d half -o subc.exr")
 
 # Test --abs, --absdiff, --absdiffc
 # First, make a test image that's 0.5 on the left, -0.5 on the right


### PR DESCRIPTION
I just like the new names better, and by being alphabetical neighbors to their image-wise counterparts, the documentation is easier to read and find what you want.

The old ones are left in as aliases, will keep working for a couple major releases, maybe indefinitely.

This is only about command-line arguments to oiiotool. Nothing changes about the C++ or Python APIs (which used function overloading all along, didn't have this naming problem).

Reminder: --add adds two images pixel-by-pixel, --addc (nee --cadd) adds a constant color to all pixels of an image.

