### PR TITLE
SPI only: make COMPILER=clang or =gcc use the default clang or gcc in execution path

### DIFF
--- a/site/spi/Makefile-bits-arnold
+++ b/site/spi/Makefile-bits-arnold
@@ -57,18 +57,35 @@ ifeq ($(SP_OS), spinux1)
         FIELD3D_HOME="${INSTALL_SPCOMP2_LOCATION}/Field3D/${SP_OS}-${SPCOMP2_COMPILER}-boost151/v401"
     endif
 
-    ## custom compiler: clang
+    ## If not overridden, here is our preferred LLVM installation
+    ## (may be changed as new versions are rolled out to the facility)
     ifeq (${LLVM_DIRECTORY},)
         LLVM_DIRECTORY := /shots/spi/home/lib/arnold/spinux1/llvm_3.4.1
     endif
 
-    ## default compiler is clang
+    # default compiler is clang, taken from the LLVM directory
     ifeq (${COMPILER},)
         MY_CMAKE_FLAGS += \
            -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang \
            -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
     endif
 
+    # requesting 'clang' or 'gcc' (no version) means the first clang or
+    # gcc in your path
+    ifeq (${COMPILER},clang)
+        MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+    endif
+    ifeq (${COMPILER},gcc)
+        MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+    endif
+
+    # A variety of tags can be used to try specific versions of gcc or
+    # clang from the site-specific places we have installed them.
+    ifeq (${COMPILER}, clang341)
+        MY_CMAKE_FLAGS += \
+           -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/spinux1/llvm_3.4.1/bin/clang \
+           -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/spinux1/llvm_3.4.1/bin/clang++
+    endif
     ifeq (${COMPILER}, gcc463)
       MY_CMAKE_FLAGS += \
          -DCMAKE_C_COMPILER=/net/soft_scratch/apps/arnold/tools/gcc-4.6.3-test/bin/gcc \


### PR DESCRIPTION
This won't affect anybody outside of SPI.

