### PR TITLE
Bug fixes to deep tiled exr input/output

### DIFF
--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -1244,14 +1244,21 @@ OpenEXRInput::read_native_deep_tiles (int xbegin, int xend,
         int xtiles = round_to_multiple (xend-xbegin, m_spec.tile_width) / m_spec.tile_width;
         int ytiles = round_to_multiple (yend-ybegin, m_spec.tile_height) / m_spec.tile_height;
 
+        int firstxtile = (xbegin - m_spec.x) / m_spec.tile_width;
+        int firstytile = (ybegin - m_spec.y) / m_spec.tile_height;
+
         // Get the sample counts for each pixel and compute the total
         // number of samples and resize the data area appropriately.
-        m_deep_tiled_input_part->readPixelSampleCounts (0, xtiles-1, 0, ytiles-1);
+        m_deep_tiled_input_part->readPixelSampleCounts (
+                firstxtile, firstxtile+xtiles-1,
+                firstytile, firstytile+ytiles-1);
         deepdata.alloc ();
 
         // Read the pixels
-        m_deep_tiled_input_part->readTiles (0, xtiles-1, 0, ytiles-1,
-                                            m_miplevel, m_miplevel);
+        m_deep_tiled_input_part->readTiles (
+                firstxtile, firstxtile+xtiles-1,
+                firstytile, firstytile+ytiles-1,
+                m_miplevel, m_miplevel);
     } catch (const std::exception &e) {
         error ("Failed OpenEXR read: %s", e.what());
         return false;

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -695,6 +695,9 @@ OpenEXROutput::spec_to_header (ImageSpec &spec, int subimage, Imf::Header &heade
         header.insert ("envmap", Imf::EnvmapAttribute(Imf::ENVMAP_LATLONG));
     }
 
+    // We must setTileDescription here before the put_parameter calls below,
+    // since put_parameter will check the header to ensure this is a tiled
+    // image before setting lineOrder to randomY.
     if (spec.tile_width)
         header.setTileDescription (
             Imf::TileDescription (spec.tile_width, spec.tile_height,
@@ -837,7 +840,7 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
         header.lineOrder() = Imf::INCREASING_Y;   // Default
         if (str) {
             if (Strutil::iequals (str, "randomY")
-                  && m_spec.tile_width /* randomY is only for tiled files */)
+                  && header.hasTileDescription() /* randomY is only for tiled files */)
                 header.lineOrder() = Imf::RANDOM_Y;
             else if (Strutil::iequals (str, "decreasingY"))
                 header.lineOrder() = Imf::DECREASING_Y;


### PR DESCRIPTION
Input: Tiles were always being read starting at 0,0 rather than the requested offset.  I matched variable names with similar existing logic in the deep tile output.

Output: Within spec_to_header, the call to put_parameter does a sanity check to make sure the image is tiled if setting lineOrder to randomY.  The problem in the case of deep exrs (any multipart exr, really) is that the sanity check was being done with m_spec before it was initialized.  This change instead gets the tile info from the header that is currently being built, with a comment to ensure that the tile description is set *before* the call to put_parameter.