### PR TITLE
Support JPEG files encoded as CMYK (by converting to RGB upon read).

### DIFF
--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -96,14 +96,17 @@ class JpgInput : public ImageInput {
     std::string m_filename;
     int m_next_scanline;      // Which scanline is the next to read?
     bool m_raw;               // Read raw coefficients, not scanlines
+    bool m_cmyk;              // The input file is cmyk
     bool m_fatalerr;          // JPEG reader hit a fatal error
     struct jpeg_decompress_struct m_cinfo;
     my_error_mgr m_jerr;
     jvirt_barray_ptr *m_coeffs;
+    std::vector<unsigned char> m_cmyk_buf; // For CMYK translation
 
     void init () {
         m_fd = NULL;
         m_raw = false;
+        m_cmyk = false;
         m_fatalerr = false;
         m_coeffs = NULL;
         m_jerr.jpginput = this;


### PR DESCRIPTION
So a CMYK or YCbCrK JPEG file will appear (to an OIIO client app) as an ordinary 3-channel sRGB file, silently converted by the plugin.

At present, writing CMYK is not supported. We will revisit in the future if this is a requirement for somebody.