### PR TITLE
Remove deprecated header

### DIFF
--- a/src/include/OpenImageIO/string_ref.h
+++ b/src/include/OpenImageIO/string_ref.h
@@ -1,7 +1,0 @@
-// Back-compatible temporary inclusion of string_view.h
-
-#pragma once
-
-#include "string_view.h"
-
-


### PR DESCRIPTION
We renamed string_ref to be string_view a while back and, for the sake of not breaking anybody immediately, made this back-compatible header. I propose that we remove it now in master.
