### PR TITLE
Make simd.h safe for older Ilmbase.h.

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -1198,12 +1198,6 @@ public:
 #endif
     }
 
-    /// Construct from a Imath::V4f
-    OIIO_FORCEINLINE float4 (const Imath::V4f &v) { load ((const float *)&v); }
-
-    /// Construct from a Imath::V3f
-    OIIO_FORCEINLINE float4 (const Imath::V3f &v) { load (v[0], v[1], v[2], 0.0f); }
-
 #if OIIO_SIMD
     /// Construct from the underlying SIMD type
     OIIO_FORCEINLINE float4 (const simd_t m) : m_vec(m) { }
@@ -1213,11 +1207,21 @@ public:
     OIIO_FORCEINLINE simd_t simd () const { return m_vec; }
 #endif
 
+    /// Construct from a Imath::V3f
+    OIIO_FORCEINLINE float4 (const Imath::V3f &v) { load (v[0], v[1], v[2], 0.0f); }
+
     /// Cast to a Imath::V3f
     OIIO_FORCEINLINE const Imath::V3f& V3f () const { return *(const Imath::V3f*)this; }
 
+#if defined(ILMBASE_VERSION_MAJOR) && ILMBASE_VERSION_MAJOR >= 2
+    // V4f is not defined for older Ilmbase. It's certainly safe for 2.x.
+
+    /// Construct from a Imath::V4f
+    OIIO_FORCEINLINE float4 (const Imath::V4f &v) { load ((const float *)&v); }
+
     /// Cast to a Imath::V4f
     OIIO_FORCEINLINE const Imath::V4f& V4f () const { return *(const Imath::V4f*)this; }
+#endif
 
     /// Assign a single value to all components
     OIIO_FORCEINLINE const float4 & operator= (float a) { load(a); return *this; }
@@ -1262,11 +1266,13 @@ public:
 #endif
     }
 
+#if defined(ILMBASE_VERSION_MAJOR) && ILMBASE_VERSION_MAJOR >= 2
     /// Assign from a Imath::V4f
     OIIO_FORCEINLINE const float4 & operator= (const Imath::V4f &v) {
         load ((const float *)&v);
         return *this;
     }
+#endif
 
     /// Assign from a Imath::V3f
     OIIO_FORCEINLINE const float4 & operator= (const Imath::V3f &v) {


### PR DESCRIPTION
We have simd::float4 conversions from and to Imath::V4f. Turns out that
prior to OpenEXR 1.7-ish, there was no V4f. To make things extra fun,
back then OpenEXR/IlmBase did not have any handy #defines to let you
conditionally compile based on the Ilmbase version. Now it does.  So we
punt and only define the (rarely used?) V4f conversions when Ilmbase is
safely >= 2.0, which seems safe moving forward, but this header will
still compile without errors for somebody stuck with Ilmbase 1.0.1
(albeit without the ability to convert to and from V4f, which is moot
anyway for those without such a definition).