### PR TITLE
OpenEXR write_tile with AutoStride calculated the wrong strides.

### DIFF
--- a/src/doc/imageinput.tex
+++ b/src/doc/imageinput.tex
@@ -981,7 +981,8 @@ in its native format (including per-channel formats, if applicable).
 The stride values
 give the data spacing of adjacent pixels, scanlines, and volumetric
 slices, respectively (measured in bytes).  Strides set to the special
-value of {\kw AutoStride} imply contiguous data, i.e., \\
+value of {\kw AutoStride} imply contiguous data in the shape of a full tile,
+i.e., \\
 \spc {\kw xstride} $=$ {\kw spec.nchannels * spec.pixel_size()} \\
 \spc {\kw ystride} $=$ {\kw xstride * spec.tile_width} \\
 \spc {\kw zstride} $=$ {\kw ystride * spec.tile_height} \\
@@ -1024,10 +1025,11 @@ in its native format (including per-channel formats, if applicable).
 The stride values
 give the data spacing of adjacent pixels, scanlines, and volumetric
 slices, respectively (measured in bytes).  Strides set to the special
-value of {\kw AutoStride} imply contiguous data, i.e., \\
+value of {\kw AutoStride} imply contiguous data in the shape of
+the region specified, i.e., \\
 \spc {\kw xstride} $=$ {\kw spec.nchannels * spec.pixel_size()} \\
-\spc {\kw ystride} $=$ {\kw xstride * spec.tile_width} \\
-\spc {\kw zstride} $=$ {\kw ystride * spec.tile_height} \\
+\spc {\kw ystride} $=$ {\kw xstride * (xend - xbegin)} \\
+\spc {\kw zstride} $=$ {\kw ystride * (yend - ybegin)} \\
 The \ImageInput is expected to give the appearance of random access
 --- in other words, if it can't randomly seek to the given tile, it
 should transparently close, reopen, and sequentially read through prior

--- a/src/doc/imageoutput.tex
+++ b/src/doc/imageoutput.tex
@@ -1478,10 +1478,10 @@ Write the tile with $(x,y,z)$ as the upper left corner.  For 2D
 non-volume images, $z$ is ignored.  The three stride values give the
 distance (in bytes) between successive pixels, scanlines, and volumetric
 slices, respectively.  Strides set to the special value {\kw AutoStride}
-imply contiguous data, i.e., \\
-\spc {\kw xstride} $=$ {\kw spec.nchannels*format.size()} \\
-\spc {\kw ystride} $=$ {\kw xstride*spec.tile_width} \\
-\spc {\kw zstride} $=$ {\kw ystride*spec.tile_height} \\
+imply contiguous data in the shape of a full tile, i.e., \\
+\spc {\kw xstride} $=$ {\kw spec.nchannels * format.size()} \\
+\spc {\kw ystride} $=$ {\kw xstride * spec.tile_width} \\
+\spc {\kw zstride} $=$ {\kw ystride * spec.tile_height} \\
 This method automatically converts the
 data from the specified {\kw format} to the actual output format of the
 file. 
@@ -1513,10 +1513,11 @@ to already be in the native format (including per-channel formats, if applicable
 The stride values
 give the data spacing of adjacent pixels, scanlines, and volumetric
 slices, respectively (measured in bytes).  Strides set to the special
-value of {\kw AutoStride} imply contiguous data, i.e., \\
+value of {\kw AutoStride} imply contiguous data in the shape of the
+region specified, i.e., \\
 \spc {\kw xstride} $=$ {\kw spec.nchannels * spec.pixel_size()} \\
-\spc {\kw ystride} $=$ {\kw xstride * (xend-xbegin)} \\
-\spc {\kw zstride} $=$ {\kw ystride * (yend-ybegin)} \\
+\spc {\kw ystride} $=$ {\kw xstride * (xend - xbegin)} \\
+\spc {\kw zstride} $=$ {\kw ystride * (yend - ybegin)} \\
 The data for those tiles is assumed to be in the usual image order, as if
 it were just one big tile, and not ``paded'' to a whole multiple of the tile size.
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -591,10 +591,10 @@ public:
 
     /// Read the tile whose upper-left origin is (x,y,z) into data,
     /// converting if necessary from the native data format of the file
-    /// into the 'format' specified.  (z==0 for non-volume images.)  The
-    /// stride values give the data spacing of adjacent pixels,
-    /// scanlines, and volumetric slices (measured in bytes).  Strides
-    /// set to AutoStride imply 'contiguous' data, i.e.,
+    /// into the 'format' specified. (z==0 for non-volume images.) The
+    /// stride values give the data spacing of adjacent pixels, scanlines,
+    /// and volumetric slices (measured in bytes). Strides set to AutoStride
+    /// imply 'contiguous' data in the shape of a full tile, i.e.,
     ///     xstride == spec.nchannels*format.size()
     ///     ystride == xstride*spec.tile_width
     ///     zstride == ystride*spec.tile_height
@@ -632,6 +632,13 @@ public:
     /// boundaries, with the exception that it may also be the end of
     /// the image data if the image resolution is not a whole multiple
     /// of the tile size.
+    /// The stride values give the data spacing of adjacent pixels,
+    /// scanlines, and volumetric slices (measured in bytes). Strides set to
+    /// AutoStride imply 'contiguous' data in the shape of the [begin,end)
+    /// region, i.e.,
+    ///     xstride == spec.nchannels*format.size()
+    ///     ystride == xstride * (xend-xbegin)
+    ///     zstride == ystride * (yend-ybegin)
     virtual bool read_tiles (int xbegin, int xend, int ybegin, int yend,
                              int zbegin, int zend, TypeDesc format,
                              void *data, stride_t xstride=AutoStride,
@@ -942,7 +949,8 @@ public:
     /// ignored for 2D non-volume images.)  The three stride values give
     /// the distance (in bytes) between successive pixels, scanlines,
     /// and volumetric slices, respectively.  Strides set to AutoStride
-    /// imply 'contiguous' data, i.e.,
+    /// imply 'contiguous' data in the shape of a full tile, i.e.,
+
     ///     xstride == spec.nchannels*format.size()
     ///     ystride == xstride*spec.tile_width
     ///     zstride == ystride*spec.tile_height
@@ -960,13 +968,20 @@ public:
                              stride_t zstride=AutoStride);
 
     /// Write the block of multiple tiles that include all pixels in
-    /// [xbegin,xend) X [ybegin,yend) X [zbegin,zend).  This is
-    /// analogous to write_tile except that it may be used to write more
-    /// than one tile at a time (which, for some formats, may be able to
-    /// be done much more efficiently or in parallel).
-    /// The begin/end pairs must correctly delineate tile boundaries,
-    /// with the exception that it may also be the end of the image data
-    /// if the image resolution is not a whole multiple of the tile size.
+    /// [xbegin,xend) X [ybegin,yend) X [zbegin,zend).  This is analogous to
+    /// write_tile except that it may be used to write more than one tile at
+    /// a time (which, for some formats, may be able to be done much more
+    /// efficiently or in parallel).
+    /// The begin/end pairs must correctly delineate tile boundaries, with
+    /// the exception that it may also be the end of the image data if the
+    /// image resolution is not a whole multiple of the tile size.
+    /// The stride values give the data spacing of adjacent pixels,
+    /// scanlines, and volumetric slices (measured in bytes). Strides set to
+    /// AutoStride imply 'contiguous' data in the shape of the [begin,end)
+    /// region, i.e.,
+    ///     xstride == spec.nchannels*format.size()
+    ///     ystride == xstride * (xend-xbegin)
+    ///     zstride == ystride * (yend-ybegin)
     virtual bool write_tiles (int xbegin, int xend, int ybegin, int yend,
                               int zbegin, int zend, TypeDesc format,
                               const void *data, stride_t xstride=AutoStride,
@@ -975,13 +990,13 @@ public:
 
     /// Write a rectangle of pixels given by the range
     ///   [xbegin,xend) X [ybegin,yend) X [zbegin,zend)
-    /// The three stride values give the distance (in bytes) between
-    /// successive pixels, scanlines, and volumetric slices,
-    /// respectively.  Strides set to AutoStride imply 'contiguous'
-    /// data, i.e.,
+    /// The stride values give the data spacing of adjacent pixels,
+    /// scanlines, and volumetric slices (measured in bytes). Strides set to
+    /// AutoStride imply 'contiguous' data in the shape of the [begin,end)
+    /// region, i.e.,
     ///     xstride == spec.nchannels*format.size()
-    ///     ystride == xstride * (xmax-xmin+1)
-    ///     zstride == ystride * (ymax-ymin+1)
+    ///     ystride == xstride * (xend-xbegin)
+    ///     zstride == ystride * (yend-ybegin)
     /// The data are automatically converted from 'format' to the actual
     /// output format (as specified to open()) by this method.  If
     /// format is TypeDesc::UNKNOWN, it will just copy pixels assuming

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -1311,6 +1311,11 @@ OpenEXROutput::write_tile (int x, int y, int z,
                            TypeDesc format, const void *data,
                            stride_t xstride, stride_t ystride, stride_t zstride)
 {
+    bool native = (format == TypeDesc::UNKNOWN);
+    if (native && xstride == AutoStride)
+        xstride = (stride_t) m_spec.pixel_bytes (native);
+    m_spec.auto_stride (xstride, ystride, zstride, format, spec().nchannels,
+                        m_spec.tile_width, m_spec.tile_height);
     return write_tiles (x, std::min (x+m_spec.tile_width, m_spec.x+m_spec.width),
                         y, std::min (y+m_spec.tile_height, m_spec.y+m_spec.height),
                         z, std::min (z+m_spec.tile_depth, m_spec.z+m_spec.depth),


### PR DESCRIPTION
When strides are automatically computed rather than explicitly supplied,
it should have assumed data layout of a "full tile", even if it was the
last tile in a row in an image whose width was not an integral multiple
of the tile width. Instead, it was clamping the width and height by the
size of the remaining data. That didn't match the behavior of read_tile
(which assumed full-tile-size layout, even for edge tiles), nor the
behavior of write_tile for other tiled formats such as TIFF.

Used the occasion to tighten up the imageio.h comments and OIIO
documention on this matter, spelling out more carefully what happens
with AutoStride in write_tile versus write_tiles.