### PR TITLE
Introduce a CMake option to specify a plugin search path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,7 @@ if (UNIX)
     set (MAN_INSTALL_DIR ${DEFAULT_MAN_INSTALL_DIR} CACHE STRING
          "Install location for manual pages (relative to CMAKE_INSTALL_PREFIX or absolute)")
 endif()
+set (PLUGIN_SEARCH_PATH "" CACHE STRING "Default plugin search path")
 
 set (INSTALL_DOCS ON CACHE BOOL "Install documentation")
 

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -1,3 +1,8 @@
+message (STATUS "Create imagio_pvt.h from imageio_pvt.h.in")
+file (TO_NATIVE_PATH "${PLUGIN_SEARCH_PATH}" PLUGIN_SEARCH_PATH_NATIVE)
+configure_file (imageio_pvt.h.in "${CMAKE_CURRENT_BINARY_DIR}/imageio_pvt.h" @ONLY)
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")
+
 file (GLOB libOpenImageIO_hdrs ../include/OpenImageIO/*.h)
 
 if (NOT USE_EXTERNAL_PUGIXML)

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -53,7 +53,7 @@ namespace pvt {
 recursive_mutex imageio_mutex;
 atomic_int oiio_threads (boost::thread::hardware_concurrency());
 atomic_int oiio_read_chunk (256);
-ustring plugin_searchpath;
+ustring plugin_searchpath (PVT_DEFAULT_PLUGIN_SEARCHPATH);
 std::string format_list;   // comma-separated list of all formats
 std::string extension_list;   // list of all extensions for all formats
 }

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -119,4 +119,7 @@ const void *parallel_convert_from_float (const float *src, void *dst,
 }
 OIIO_NAMESPACE_EXIT
 
+//Define a default plugin search path
+#define PVT_DEFAULT_PLUGIN_SEARCHPATH "@PLUGIN_SEARCH_PATH_NATIVE@"
+
 #endif // OPENIMAGEIO_IMAGEIO_PVT_H


### PR DESCRIPTION
The new PLUGIN_SEARCH_PATH option allows for specifying a default plugin
search path at build time. More precisely, the plugin_searchpath
attribute is assigned the value of PLUGIN_SEARCH_PATH by default.

This makes it possible for example to simple install custom plugins to
PLUGIN_SEARCH_PATH without having to fiddle around with environment
variables (i. e. OIIO_LIBRARY_PATH).