### PR TITLE
oiiotool: gracefully handle impossible requests to save too many channels.

### DIFF
--- a/src/bmp.imageio/bmp_pvt.h
+++ b/src/bmp.imageio/bmp_pvt.h
@@ -169,7 +169,7 @@ class BmpOutput : public ImageOutput {
     BmpOutput () { init (); }
     virtual ~BmpOutput () { close (); }
     virtual const char *format_name (void) const { return "bmp"; }
-    virtual bool supports (const std::string &feature) const {return false;}
+    virtual bool supports (const std::string &feature) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode);
     virtual bool close (void);

--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -51,6 +51,14 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 bool
+BmpOutput::supports (const std::string &feature) const
+{
+    return (feature == "alpha");
+}
+
+
+
+bool
 BmpOutput::open (const std::string &name, const ImageSpec &spec,
                  OpenMode mode)
 {
@@ -63,7 +71,11 @@ BmpOutput::open (const std::string &name, const ImageSpec &spec,
     m_filename = name;
     m_spec = spec;
 
-    // TODO: Figure out what to do with nchannels.
+    if (m_spec.nchannels != 3 && m_spec.nchannels != 4) {
+        error ("%s does not support %d-channel images\n",
+               format_name(), m_spec.nchannels);
+        return false;
+    }
 
     m_fd = Filesystem::fopen (m_filename, "wb");
     if (! m_fd) {

--- a/src/doc/imageoutput.tex
+++ b/src/doc/imageoutput.tex
@@ -66,6 +66,42 @@ to a file:
   \end{code}
 \end{itemize}
 
+\subsection*{What happens when the file format doesn't support the spec?}
+
+The {\cf open()} call will fail (return {\cf false} and set an appropriate
+error message) if the output format cannot accommodate what is requested by
+the \ImageSpec. This includes:
+\begin{itemize}
+\item Dimensions (width, height, or number of channels) exceeding the limits
+  supported by the file format.\footnote{One exception to the rule about
+  number of channels is that a file format that supports only RGB, but not
+  alpha, is permitted to silently drop the alpha channel without considering
+  that to be an error.}
+\item Volumetric (depth $> 1$) if the format does not support volumetric
+  data.
+\item Tile size $>1$ if the format does not support tiles.
+\item Multiple subimages or MIP levels if not supported by the format.
+\end{itemize}
+
+
+However, several other mismatches between requested \ImageSpec and file
+format capabilities will be silently ignored, allowing {\cf open()} to
+succeed:
+
+\begin{itemize}
+\item If the pixel data format is not supported (for example, a request for
+  {\cf half} pixels when writing a JPEG/JFIF file), the format writer
+  may substitute another data format (generally, whichever commonly-used
+  data format supported by the file type will result in the least reduction
+  of precision or range).
+\item If the \ImageSpec requests different per-channel data formats, but
+  the format supports only a single format for all channels, it may just
+  choose the most precise format requested and use it for all channels.
+\item If the file format does not support arbitrarily-named channels, the
+  channel names may be lost when saving the file.
+\item Any other metadata in the \ImageSpec may be summarily dropped if not
+  supported by the file format.
+\end{itemize}
 
 
 \section{Advanced Image Output}
@@ -1332,6 +1368,9 @@ by this query:
   image/subimage (MIP-map levels)?
 \item[\rm \qkw{volumes}] Does this format support ``3D'' pixel arrays
   (a.k.a.\ volume images)?
+\item[\rm \qkw{alpha}] Does this format support an alpha channel?
+\item[\rm \qkw{nchannels}] Does this format support an arbitrary number
+  of channels (beyond RGBA)?
 \item[\rm \qkw{rewrite}] Does this plugin allow the same scanline or
   tile to be sent more than once?  Generally this is true for plugins
   that implement some sort of interactive display, rather than a saved

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -92,7 +92,7 @@
 }
 \date{{\large 
 %Editor: Larry Gritz \\[2ex]
-Date: 29 Jan 2015
+Date: 9 Feb 2015
 % \\ (with corrections, 7 Jan 2015)
 }}
 

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -55,6 +55,8 @@ public:
     virtual const char * format_name (void) const { return "dpx"; }
     virtual bool supports (const std::string &feature) const {
         if (feature == "multiimage"
+            || feature == "alpha"
+            || feature == "nchannels"
             || feature == "random_access"
             || feature == "rewrite"
             || feature == "displaywindow"

--- a/src/field3d.imageio/field3doutput.cpp
+++ b/src/field3d.imageio/field3doutput.cpp
@@ -71,7 +71,6 @@ private:
     int m_subimage;       ///< What subimage/field are we writing now
     int m_nsubimages;     ///< How many subimages will be in the file?
     bool m_writepending;  ///< Is there an unwritten current layer?
-    std::vector<layerrecord> Xm_layers;
     std::vector<ImageSpec> m_specs;
     std::vector<unsigned char> m_scratch; ///< Scratch space for us to use
     FieldRes::Ptr m_field;
@@ -82,7 +81,6 @@ private:
         m_output = NULL;
         m_subimage = -1;
         m_nsubimages = 0;
-        // m_layers.clear ();
         m_specs.clear ();
         m_writepending = false;
     }

--- a/src/fits.imageio/fits_pvt.h
+++ b/src/fits.imageio/fits_pvt.h
@@ -141,13 +141,7 @@ class FitsOutput : public ImageOutput {
     FitsOutput () { init (); }
     virtual ~FitsOutput () { close (); }
     virtual const char *format_name (void) const { return "fits"; }
-    virtual bool supports (const std::string &feature) const {
-        return (feature == "multiimage"
-             || feature == "random_access"
-             || feature == "arbitrary_metadata"
-             || feature == "exif"   // Because of arbitrary_metadata
-             || feature == "iptc"); // Because of arbitrary_metadata
-    }
+    virtual bool supports (const std::string &feature) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close (void);

--- a/src/fits.imageio/fitsoutput.cpp
+++ b/src/fits.imageio/fitsoutput.cpp
@@ -51,6 +51,20 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 bool
+FitsOutput::supports (const std::string &feature) const
+{
+    return (feature == "multiimage"
+         || feature == "alpha"
+         || feature == "nchannels"
+         || feature == "random_access"
+         || feature == "arbitrary_metadata"
+         || feature == "exif"   // Because of arbitrary_metadata
+         || feature == "iptc"); // Because of arbitrary_metadata
+}
+
+
+
+bool
 FitsOutput::open (const std::string &name, const ImageSpec &spec,
                   OpenMode mode)
 {

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -417,6 +417,8 @@ ICOOutput::supports (const std::string &feature) const
     // advertise our support for subimages
     if (Strutil::iequals (feature, "multiimage"))
         return true;
+    if (Strutil::iequals (feature, "alpha"))
+        return true;
     return false;
 }
 

--- a/src/iff.imageio/iffoutput.cpp
+++ b/src/iff.imageio/iffoutput.cpp
@@ -52,11 +52,10 @@ OIIO_PLUGIN_EXPORTS_END
 bool
 IffOutput::supports (const std::string &feature) const
 {
-    if (feature == "tiles")
-        return true;
-
-    // Everything else, we either don't support or don't know about
-    return false;
+    return (feature == "tiles"
+         || feature == "alpha"
+         || feature == "nchannels"
+        );
 }
 
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -847,6 +847,9 @@ public:
     ///    "mipmap"         Does this format support multiple resolutions
     ///                       for an image/subimage?
     ///    "volumes"        Does this format support "3D" pixel arrays?
+    ///    "alpha"          Can this format support an alpha channel?
+    ///    "nchannels"      Can this format support arbitrary number of
+    ///                        channels (beyond RGBA)?
     ///    "rewrite"        May the same scanline or tile be sent more than
     ///                       once?  (Generally, this will be true for
     ///                       plugins that implement interactive display.)
@@ -872,7 +875,7 @@ public:
     /// future expansion of the set of possible queries without changing
     /// the API, adding new entry points, or breaking linkage
     /// compatibility.
-    virtual bool supports (const std::string & /*feature*/) const { return false; }
+    virtual bool supports (const std::string &feature) const { return false; }
 
     enum OpenMode { Create, AppendSubimage, AppendMIPLevel };
 

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -143,7 +143,7 @@ JpgOutput::open (const std::string &name, const ImageSpec &newspec,
 
     if (m_spec.nchannels != 1 && m_spec.nchannels != 3 &&
             m_spec.nchannels != 4) {
-        error ("%s does not support %d-channel images\n",
+        error ("%s does not support %d-channel images",
                format_name(), m_spec.nchannels);
         return false;
     }

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -494,6 +494,8 @@ void test_parse ()
     OIIO_CHECK_ASSERT (ss == "foo" && s == ";bar blow");
     s = "foo;bar blow"; ss = parse_until (s, "\t ");
     OIIO_CHECK_ASSERT (ss == "foo;bar" && s == " blow");
+    s = "foo;bar blow"; ss = parse_until (s, "/");
+    OIIO_CHECK_ASSERT (ss == "foo;bar blow" && s == "");
 }
 
 

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -284,6 +284,10 @@ OpenEXROutput::supports (const std::string &feature) const
         return true;
     if (feature == "mipmap")
         return true;
+    if (feature == "alpha")
+        return true;
+    if (feature == "nchannels")
+        return true;
     if (feature == "channelformats")
         return true;
     if (feature == "displaywindow")

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -49,8 +49,7 @@ public:
     virtual ~PNGOutput ();
     virtual const char * format_name (void) const { return "png"; }
     virtual bool supports (const std::string &feature) const {
-        // Support nothing nonstandard
-        return false;
+        return (feature == "alpha");
     }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -175,6 +175,12 @@ PNMOutput::open (const std::string &name, const ImageSpec &userspec,
     m_dither = (m_spec.format == TypeDesc::UINT8) ?
                     m_spec.get_int_attribute ("oiio:dither", 0) : 0;
 
+    if (m_spec.nchannels != 1 && m_spec.nchannels != 3) {
+        error ("%s does not support %d-channel images\n",
+               format_name(), m_spec.nchannels);
+        return false;
+    }
+
     if (bits_per_sample == 1)
         m_pnm_type = 4;
     else if (m_spec.nchannels == 1)

--- a/src/psd.imageio/psdoutput.cpp
+++ b/src/psd.imageio/psdoutput.cpp
@@ -41,8 +41,7 @@ public:
     virtual ~PSDOutput ();
     virtual const char * format_name (void) const { return "psd"; }
     virtual bool supports (const std::string &feature) const {
-        // Support nothing nonstandard
-        return false;
+        return (feature == "alpha");
     }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);

--- a/src/ptex.imageio/ptexoutput.cpp
+++ b/src/ptex.imageio/ptexoutput.cpp
@@ -95,6 +95,8 @@ PtexOutput::supports (const std::string &feature) const
     return (feature == "tiles"
          || feature == "multiimage"
          || feature == "mipmap"
+         || feature == "alpha"
+         || feature == "nchannels"
          || feature == "arbitrary_metadata"
          || feature == "exif"   // Because of arbitrary_metadata
          || feature == "iptc"); // Because of arbitrary_metadata

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -161,6 +161,10 @@ RLAOutput::supports (const std::string &feature) const
         return true;
     if (feature == "negativeorigin")
         return true;
+    if (feature == "alpha")
+        return true;
+    if (feature == "nchannels")
+        return true;
     // Support nothing else nonstandard
     return false;
 }

--- a/src/sgi.imageio/sgi_pvt.h
+++ b/src/sgi.imageio/sgi_pvt.h
@@ -141,7 +141,7 @@ class SgiOutput : public ImageOutput {
     SgiOutput () : m_fd(NULL) { }
     virtual ~SgiOutput () { close(); }
     virtual const char *format_name (void) const { return "sgi"; }
-    virtual bool supports (const std::string &feature) const { return false; }
+    virtual bool supports (const std::string &feature) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close (void);

--- a/src/sgi.imageio/sgioutput.cpp
+++ b/src/sgi.imageio/sgioutput.cpp
@@ -48,6 +48,15 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 bool
+SgiOutput::supports (const std::string &feature) const
+{
+    return (feature == "alpha"
+         || feature == "nchannels");
+}
+
+
+
+bool
 SgiOutput::open (const std::string &name, const ImageSpec &spec,
                  OpenMode mode)
 {

--- a/src/socket.imageio/socket_pvt.h
+++ b/src/socket.imageio/socket_pvt.h
@@ -64,7 +64,7 @@ class SocketOutput : public ImageOutput {
     SocketOutput ();
     virtual ~SocketOutput () { close(); }
     virtual const char * format_name (void) const { return "socket"; }
-    virtual bool supports (const std::string &property) const { return false; }
+    virtual bool supports (const std::string &property) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool write_scanline (int y, int z, TypeDesc format,

--- a/src/socket.imageio/socketoutput.cpp
+++ b/src/socket.imageio/socketoutput.cpp
@@ -59,6 +59,15 @@ SocketOutput::SocketOutput()
 
 
 bool
+SocketOutput::supports (const std::string &property) const
+{
+    return (property == "alpha" ||
+            property == "nchannels");
+}
+
+
+
+bool
 SocketOutput::open (const std::string &name, const ImageSpec &newspec,
                     OpenMode mode)
 {

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -51,8 +51,7 @@ public:
     virtual ~TGAOutput ();
     virtual const char * format_name (void) const { return "targa"; }
     virtual bool supports (const std::string &feature) const {
-        // Support nothing nonstandard
-        return false;
+        return (feature == "alpha");
     }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -155,6 +155,10 @@ TIFFOutput::supports (const std::string &feature) const
         return true;
     if (feature == "appendsubimage")
         return true;
+    if (feature == "alpha")
+        return true;
+    if (feature == "nchannels")
+        return true;
     if (feature == "displaywindow")
         return true;
     if (feature == "origin")

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -45,7 +45,7 @@ class WebpOutput : public ImageOutput
     virtual const char* format_name () const { return "webp"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
-    virtual bool supports (const std::string &property) const { return false; }
+    virtual bool supports (const std::string &property) const;
     virtual bool write_scanline (int y, int z, TypeDesc format,
                                  const void *data, stride_t xstride);
     virtual bool write_tile (int x, int y, int z, TypeDesc format,
@@ -68,6 +68,15 @@ class WebpOutput : public ImageOutput
         m_file = NULL;
     }
 };
+
+
+
+bool
+WebpOutput::supports (const std::string &property) const
+{
+    return (property == "alpha");
+}
+
 
 
 static int WebpImageWriter(const uint8_t* img_data, size_t data_size,
@@ -96,6 +105,12 @@ WebpOutput::open (const std::string &name, const ImageSpec &spec,
     // saving 'name' and 'spec' for later use
     m_filename = name;
     m_spec = spec;
+
+    if (m_spec.nchannels != 3 && m_spec.nchannels != 4) {
+        error ("%s does not support %d-channel images\n",
+               format_name(), m_spec.nchannels);
+        return false;
+    }
 
     m_file = Filesystem::fopen (m_filename, "wb");
     if (!m_file) {


### PR DESCRIPTION
Before saving and encountering an error, check that the output file type supports the number of channels in the image being saved. If not, don't consider it an error, but rather just give a warning, and then do the best we can. What we try to do is: (a) if "R", "G", and "B" (and also "A", if the format supports it) are all in the list of channel names for the image that is being saved, save just those channels; (b) if those names are not found, just punt and save the first three channels (or 4, if the output supports alpha).

In order to facilitate this, we add two new tokens to ImageOutput::supports(): supports("alpha") if the file format supports saving an alpha channel, and supports("nchannels") if the file format supports saving an arbitrary number of channels. (We assume that ALL formats we care about can save a minimum of 3 channels, for RGB.)

As an example, we go from this:

    $ oiiotool fivechannels.exr -o out.jpg
    oiiotool ERROR: output (jpeg does not support 5-channel images)

and no output saved, to this:

    $ oiiotool fivechannels.exr -o out.jpg
    oiiotool WARNING: output (Can't save 5 channels to jpeg... saving only R,G,B)

and with a JPEG file saved (albeit with only the R,G,B channels of the original).

