### PR TITLE
Bug fix for oiiotool frame sequences -- passed wrong variable

### DIFF
--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -678,7 +678,7 @@ Filesystem::enumerate_file_sequence (const std::string &pattern,
                                      const std::vector<string_view> &views,
                                      std::vector<std::string> &filenames)
 {
-    DASSERT (views.size() == 0 || views.size() == numbers.size());
+    ASSERT (views.size() == 0 || views.size() == numbers.size());
 
     static boost::regex view_re ("%V"), short_view_re ("%v");
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4316,7 +4316,7 @@ handle_sequence (int argc, const char **argv)
                                             frame_numbers[a]);
             Filesystem::enumerate_file_sequence (normalized_pattern,
                                                  frame_numbers[a],
-                                                 views,
+                                                 frame_views[a],
                                                  filenames[a]);
         } else if (sequence_is_output[i]) {
             // use frame numbers from first sequence


### PR DESCRIPTION
As reported on the mail list, an occasional crash with file sequences appears to boil down to this.

If I change the 'DASSERT' to 'ASSERT', the old code hits it, so that was certainly wrong. New code is fine. I'm keeping the assert, it keeps us honest.
