### PR TITLE
ImageSpec minor additions & fixes

### DIFF
--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -588,10 +588,10 @@ function for when you know you are just looking for a simple string value.
 \apiend
 
 
-\apiitem{std::string {\ce metadata_val} (const ImageIOParamaeter \&p,
+\apiitem{static std::string {\ce metadata_val} (const ImageIOParamaeter \&p,
   bool human=true) const}
-For a given parameter (in this \ImageSpec's {\cf extra_attribs} field),
-format the value nicely as a string.  If {\cf human} is true, use
+For a given parameter {\cf p}, format the value nicely as a string.
+If {\cf human} is true, use
 especially human-readable explanations (units, or decoding of
 values) for certain known metadata.
 \apiend

--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -564,8 +564,20 @@ The name comparison will be exact if {\cf casesensitive} is true, otherwise
 in a case-insensitive manner if {\cf caseinsensitive} is false.
 \apiend
 
-\apiitem{int {\ce get_int_attribute} (string_view name, int
-  defaultval=0) const}
+\apiitem{const ImageIOParameter * {\ce find_attribute} (string_view name,\\
+\bigspc\bigspc\bigspc\spc                     ImageIOParameter \&tmpparam,\\
+\bigspc\bigspc\bigspc\spc                     TypeDesc searchtype=UNKNOWN,\\
+\bigspc\bigspc\bigspc\spc                     bool casesensitive=false) const}
+Search for the named attribute and return the pointer to its
+{\cf ImageIOParameter} record, or {\cf NULL} if not found.  This variety of
+{\cf find_attribute(}) can retrieve items such as \qkw{width}, which are
+part of the \ImageSpec, but not in {\cf extra_attribs}. The {\cf tmpparam}
+is a temporary storage area owned by the caller, which is used as temporary
+buffer in cases where the information does not correspond to an actual
+{\cf extra_attribs} (in this case, the return value will be {\cf \&tmpparam}).
+\apiend
+
+\apiitem{int {\ce get_int_attribute} (string_view name, int defaultval=0) const}
 Gets an integer metadata attribute (silently converting to {\cf int}
 even if if the data is really int8, uint8, int16, uint16, or uint32),
 and simply substituting the supplied default value if no such metadata

--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -537,21 +537,30 @@ Shortcuts for passing attributes comprised of a single integer,
 floating-point value, or string.
 \apiend
 
+\apiitem{void {\ce erase_attribute} (string_view name,\\
+\bigspc\bigspc                   TypeDesc searchtype=UNKNOWN,\\
+\bigspc\bigspc                   bool casesensitive=false)}
+
+Searches {\cf extra_attribs} for an attribute matching {\cf name},
+and if it exists, remove it entirely from {\cf extra_attribs}.
+If {\cf searchtype} is anything other than {\cf TypeDesc::UNKNOWN},
+matches will be restricted only to attributes with the given type.
+The name comparison will be exact if {\cf casesensitive} is true, otherwise
+in a case-insensitive manner if {\cf caseinsensitive} is false.
+\apiend
+
 \apiitem{ImageIOParameter * {\ce find_attribute} (string_view name,\\
-\bigspc\bigspc\spc                           TypeDesc searchtype=UNKNOWN,\\
-\bigspc\bigspc\spc                           bool casesensitive=false)\\
+\bigspc\bigspc\bigspc                        TypeDesc searchtype=UNKNOWN,\\
+\bigspc\bigspc\bigspc                        bool casesensitive=false)\\
 const ImageIOParameter * {\ce find_attribute} (string_view name,\\
-\bigspc\bigspc\spc                           TypeDesc searchtype=UNKNOWN,\\
-\bigspc\bigspc\spc                           bool casesensitive=false) const
-\\
-}
+\bigspc\bigspc\bigspc\spc                     TypeDesc searchtype=UNKNOWN,\\
+\bigspc\bigspc\bigspc\spc                     bool casesensitive=false) const}
 
 Searches {\cf extra_attribs} for an attribute matching {\cf name},
 returning a pointer to the attribute record, or NULL if there was no
-match.  If {\cf searchtype} is {\cf TypeDesc::UNKNOWN}, the search will be made
-regardless of the data type, whereas other values of {\cf searchtype}
-will reject a matching name if the data type does not also match.  The
-name comparison will be exact if {\cf casesensitive} is true, otherwise
+match.  If {\cf searchtype} is anything other than {\cf TypeDesc::UNKNOWN},
+matches will be restricted only to attributes with the given type.
+The name comparison will be exact if {\cf casesensitive} is true, otherwise
 in a case-insensitive manner if {\cf caseinsensitive} is false.
 \apiend
 
@@ -564,8 +573,7 @@ exists.  This is a convenience function for when you know you are just
 looking for a simple integer value.
 \apiend
 
-\apiitem{float {\ce get_float_attribute} (string_view name,\\
-\bigspc\bigspc float defaultval=0) const}
+\apiitem{float {\ce get_float_attribute} (string_view name, float defaultval=0) const}
 Gets a float metadata attribute (silently converting to {\cf float} even
 if the data is really half or double), simply substituting the supplied
 default value if no such metadata exists.  This is a convenience
@@ -573,7 +581,7 @@ function for when you know you are just looking for a simple float value.
 \apiend
 
 \apiitem{string_view {\ce get_string_attribute} (string_view name, \\
-\bigspc\bigspc  string_view defaultval = string_view()) const}
+\bigspc\bigspc\bigspc  string_view defaultval = "") const}
 Gets a string metadata attribute, simply substituting the supplied
 default value if no such metadata exists.  This is a convenience
 function for when you know you are just looking for a simple string value.

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -405,6 +405,12 @@ Returns the number of pixels in a tile or the full image, respectively
 Section~\ref{sec:ImageSpecMemberFuncs} for details.)
 \apiend
 
+\apiitem{ImageSpec.{\ce erase_attribute} (name, searchtype=TypeDesc(TypeDesc.UNKNOWN),\\
+\bigspc\bigspc\spc casesensitive=False)}
+Remove the specified attribute from the list of extra_attribs. If not found,
+do nothing.
+\apiend
+
 \apiitem{ImageSpec.{\ce attribute} (name, int) \\
 ImageSpec.{\ce attribute} (name, float) \\
 ImageSpec.{\ce attribute} (name, string) \\

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -296,14 +296,21 @@ public:
         attribute (name, TypeDesc::STRING, &s);
     }
 
-    /// Remove the specified attribute from the list of extra
-    /// attributes. If not found, do nothing.
+    /// Remove the specified attribute from the list of extra_attribs. If
+    /// not found, do nothing.  If searchtype is anything but UNKNOWN,
+    /// restrict matches to only those of the given type. If casesensitive
+    /// is true, the name search will be case-sensitive, otherwise the name
+    /// search will be performed without regard to case (this is the
+    /// default).
     void erase_attribute (string_view name,
                           TypeDesc searchtype=TypeDesc::UNKNOWN,
                           bool casesensitive=false);
 
-    /// Search for a attribute of the given name in the list of extra
-    /// attributes.
+    /// Search for an attribute of the given name in the list of
+    /// extra_attribs. If searchtype is anything but UNKNOWN, restrict
+    /// matches to only those of the given type. If casesensitive is true,
+    /// the name search will be case-sensitive, otherwise the name search
+    /// will be performed without regard to case (this is the default).
     ImageIOParameter * find_attribute (string_view name,
                                        TypeDesc searchtype=TypeDesc::UNKNOWN,
                                        bool casesensitive=false);

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -318,6 +318,19 @@ public:
                                             TypeDesc searchtype=TypeDesc::UNKNOWN,
                                             bool casesensitive=false) const;
 
+    /// Search for the named attribute and return a pointer to an
+    /// ImageIOParameter record, or NULL if not found.  This variety of
+    /// find_attribute() can retrieve items such as "width", which are part
+    /// of the ImageSpec, but not in extra_attribs. The tmpparam is a
+    /// temporary storage area owned by the caller, which is used as
+    /// temporary buffer in cases where the information does not correspond
+    /// to an actual extra_attribs (in this case, the return value will be
+    /// &tmpparam).
+    const ImageIOParameter * find_attribute (string_view name,
+                         ImageIOParameter &tmpparam,
+                         TypeDesc searchtype=TypeDesc::UNKNOWN,
+                         bool casesensitive=false) const;
+
     /// Simple way to get an integer attribute, with default provided.
     /// Automatically will return an int even if the data is really
     /// unsigned, short, or byte.

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -333,12 +333,11 @@ public:
     string_view get_string_attribute (string_view name,
                            string_view defaultval = string_view()) const;
 
-    /// For a given parameter (in this ImageSpec's extra_attribs),
-    /// format the value nicely as a string.  If 'human' is true, use
-    /// especially human-readable explanations (units, or decoding of
-    /// values) for certain known metadata.
-    std::string metadata_val (const ImageIOParameter &p,
-                              bool human=false) const;
+    /// For a given parameter p, format the value nicely as a string.  If
+    /// 'human' is true, use especially human-readable explanations (units,
+    /// or decoding of values) for certain known metadata.
+    static std::string metadata_val (const ImageIOParameter &p,
+                              bool human=false);
 
     /// Convert ImageSpec class into XML string.
     ///

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -797,7 +797,7 @@ static ExplanationTableEntry explanation[] = {
 
 
 std::string
-ImageSpec::metadata_val (const ImageIOParameter &p, bool human) const
+ImageSpec::metadata_val (const ImageIOParameter &p, bool human)
 {
     std::string out = format_raw_metadata (p, human ? 16 : 1024);
 

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -402,10 +402,70 @@ ImageSpec::find_attribute (string_view name, TypeDesc searchtype,
 
 
 
+const ImageIOParameter *
+ImageSpec::find_attribute (string_view name, ImageIOParameter &tmpparam,
+                           TypeDesc searchtype, bool casesensitive) const
+{
+    ImageIOParameterList::const_iterator iter =
+        extra_attribs.find (name, searchtype, casesensitive);
+    if (iter != extra_attribs.end())
+        return &(*iter);
+    // Check named items in the ImageSpec structs, not in extra_attrubs
+#define MATCH(n,t) (((!casesensitive && Strutil::iequals(name,n)) || \
+                     ( casesensitive && name == n)) && \
+                    (searchtype == TypeDesc::UNKNOWN || searchtype == t))
+#define GETINT(n) if (MATCH(#n,TypeDesc::TypeInt)) { \
+                      tmpparam.init (#n, TypeDesc::TypeInt, 1, &this->n); \
+                      return &tmpparam; \
+                  }
+    GETINT(nchannels);
+    GETINT(width);
+    GETINT(height);
+    GETINT(depth);
+    GETINT(x);
+    GETINT(y);
+    GETINT(z);
+    GETINT(full_width);
+    GETINT(full_height);
+    GETINT(full_depth);
+    GETINT(full_x);
+    GETINT(full_y);
+    GETINT(full_z);
+    GETINT(tile_width);
+    GETINT(tile_height);
+    GETINT(tile_depth);
+    GETINT(alpha_channel);
+    GETINT(z_channel);
+    // some special cases
+    if (MATCH("geom", TypeDesc::TypeString)) {
+        ustring s = (depth <= 1 && full_depth <= 1)
+                    ? ustring::format ("%dx%d%+d%+d", width, height, x, y)
+                    : ustring::format ("%dx%dx%d%+d%+d%+d", width, height, depth, x, y, z);
+        tmpparam.init ("geom", TypeDesc::TypeString, 1, &s);
+        return &tmpparam;
+    }
+    if (MATCH("full_geom", TypeDesc::TypeString)) {
+        ustring s = (depth <= 1 && full_depth <= 1)
+                    ? ustring::format ("%dx%d%+d%+d",
+                                       full_width, full_height, full_x, full_y)
+                    : ustring::format ("%dx%dx%d%+d%+d%+d",
+                                       full_width, full_height, full_depth,
+                                       full_x, full_y, full_z);
+        tmpparam.init ("full_geom", TypeDesc::TypeString, 1, &s);
+        return &tmpparam;
+    }
+#undef GETINT
+#undef MATCH
+    return NULL;
+}
+
+
+
 int
 ImageSpec::get_int_attribute (string_view name, int val) const
 {
-    const ImageIOParameter *p = find_attribute (name);
+    ImageIOParameter tmpparam;
+    const ImageIOParameter *p = find_attribute (name, tmpparam);
     if (p) {
         if (p->type() == TypeDesc::INT)
             val = *(const int *)p->data();
@@ -432,7 +492,8 @@ ImageSpec::get_int_attribute (string_view name, int val) const
 float
 ImageSpec::get_float_attribute (string_view name, float val) const
 {
-    const ImageIOParameter *p = find_attribute (name);
+    ImageIOParameter tmpparam;
+    const ImageIOParameter *p = find_attribute (name, tmpparam);
     if (p) {
         if (p->type() == TypeDesc::FLOAT)
             val = *(const float *)p->data();
@@ -465,7 +526,8 @@ ImageSpec::get_float_attribute (string_view name, float val) const
 string_view
 ImageSpec::get_string_attribute (string_view name, string_view val) const
 {
-    const ImageIOParameter *p = find_attribute (name, TypeDesc::STRING);
+    ImageIOParameter tmpparam;
+    const ImageIOParameter *p = find_attribute (name, tmpparam, TypeDesc::STRING);
     if (p)
         return *(ustring *)p->data();
     else return val;

--- a/src/libOpenImageIO/imagespec_test.cpp
+++ b/src/libOpenImageIO/imagespec_test.cpp
@@ -38,6 +38,7 @@ OIIO_NAMESPACE_USING;
 
 void test_imagespec_pixels ()
 {
+    std::cout << "test_imagespec_pixels\n";
     // images with dimensions > 2^16 (65536) on a side have > 2^32 pixels
     const long long WIDTH = 456789;
     const long long HEIGHT = 345678;
@@ -97,6 +98,7 @@ metadata_val_test (void *data, int num_elements, TypeDesc type, std::string& val
 
 void test_imagespec_metadata_val ()
 {
+    std::cout << "test_imagespec_metadata_val\n";
     std::string ret;
 
     int imatrix[] = {100, 200, 300, 400};
@@ -153,6 +155,7 @@ attribute_test (const std::string &data, TypeDesc type, std::string &ret)
 
 void test_imagespec_attribute_from_string ()
 {
+    std::cout << "test_imagespec_attribute_from_string\n";
     TypeDesc type = TypeDesc::TypeInt;
     std::string ret, data, invalid_data;
 
@@ -188,12 +191,54 @@ void test_imagespec_attribute_from_string ()
 
 
 
+static void
+test_get_attribute ()
+{
+    std::cout << "test_get_attribute\n";
+    ImageSpec spec (640, 480, 4, TypeDesc::FLOAT);
+    spec.x = 10; spec.y = 12;
+    spec.full_x = -5; spec.full_y = -8;
+    spec.full_width = 1024; spec.full_height = 800;
+    spec.tile_width = 64; spec.tile_height = 32;
+    spec.attribute ("foo", int(42));
+    spec.attribute ("pi", float(M_PI));
+    spec.attribute ("bar", "barbarbar?");
+
+    OIIO_CHECK_EQUAL (spec.get_int_attribute("width"), 640);
+    OIIO_CHECK_EQUAL (spec.get_int_attribute("height"), 480);
+    OIIO_CHECK_EQUAL (spec.get_int_attribute("nchannels"), 4);
+    OIIO_CHECK_EQUAL (spec.get_int_attribute("x"), 10);
+    OIIO_CHECK_EQUAL (spec.get_int_attribute("y"), 12);
+    OIIO_CHECK_EQUAL (spec.get_int_attribute("full_x"), -5);
+    OIIO_CHECK_EQUAL (spec.get_int_attribute("full_y"), -8);
+    OIIO_CHECK_EQUAL (spec.get_int_attribute("full_width"), 1024);
+    OIIO_CHECK_EQUAL (spec.get_int_attribute("full_height"), 800);
+    OIIO_CHECK_EQUAL (spec.get_int_attribute("tile_width"), 64);
+    OIIO_CHECK_EQUAL (spec.get_int_attribute("tile_height"), 32);
+    OIIO_CHECK_EQUAL (spec.get_string_attribute("geom"), "640x480+10+12");
+    OIIO_CHECK_EQUAL (spec.get_string_attribute("full_geom"), "1024x800-5-8");
+    OIIO_CHECK_EQUAL (spec.get_int_attribute("foo"), 42);
+    OIIO_CHECK_EQUAL (spec.get_int_attribute("pi",4), 4);  // should fail int
+    OIIO_CHECK_EQUAL (spec.get_float_attribute("pi"), float(M_PI));
+    OIIO_CHECK_EQUAL (spec.get_int_attribute("bar"), 0);
+    OIIO_CHECK_EQUAL (spec.get_int_attribute("bar"), 0);
+    OIIO_CHECK_EQUAL (spec.get_string_attribute("bar"), "barbarbar?");
+    OIIO_CHECK_NE    (spec.find_attribute("foo"), NULL);
+    OIIO_CHECK_NE    (spec.find_attribute("Foo"), NULL);
+    OIIO_CHECK_NE    (spec.find_attribute("Foo", TypeDesc::UNKNOWN, false), NULL);
+    OIIO_CHECK_EQUAL (spec.find_attribute("Foo", TypeDesc::UNKNOWN, true), NULL);
+    OIIO_CHECK_NE    (spec.find_attribute("foo", TypeDesc::INT), NULL);
+    OIIO_CHECK_EQUAL (spec.find_attribute("foo", TypeDesc::FLOAT), NULL);
+}
+
+
 
 int main (int argc, char *argv[])
 {
     test_imagespec_pixels ();
     test_imagespec_metadata_val ();
     test_imagespec_attribute_from_string ();
+    test_get_attribute ();
 
     return unit_test_failures;
 }

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -436,6 +436,7 @@ void declare_imagespec()
               arg("casesensitive")=false))
 
         .def("metadata_val", &ImageSpec::metadata_val)
+        .staticmethod("metadata_val")
     ;          
 }
 

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -273,7 +273,8 @@ static object
 ImageSpec_get_attribute_typed (const ImageSpec& spec,
                                const std::string &name, TypeDesc type)
 {
-    const ImageIOParameter *p = spec.find_attribute (name, type);
+    ImageIOParameter tmpparam;
+    const ImageIOParameter *p = spec.find_attribute (name, tmpparam, type);
     if (!p)
         return object();   // None
     type = p->type();

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -172,6 +172,15 @@ ImageSpec_set_format_2(ImageSpec& spec, TypeDesc::BASETYPE basetype)
 
 
 static void
+ImageSpec_erase_attribute (ImageSpec& spec, const std::string &name,
+                           TypeDesc searchtype=TypeDesc::UNKNOWN,
+                           bool casesensitive=false)
+{
+    spec.erase_attribute (name, searchtype, casesensitive);
+}
+
+
+static void
 ImageSpec_attribute_int (ImageSpec& spec, const std::string &name, int val)
 {
     spec.attribute (name, val);
@@ -422,6 +431,9 @@ void declare_imagespec()
         .def("get_string_attribute", &ImageSpec_get_string_attribute_d)
         .def("get_attribute", &ImageSpec_get_attribute_typed)
         .def("get_attribute", &ImageSpec_get_attribute_untyped)
+        .def("erase_attribute", &ImageSpec_erase_attribute,
+             (arg("name")="", arg("type")=TypeDesc(TypeDesc::UNKNOWN),
+              arg("casesensitive")=false))
 
         .def("metadata_val", &ImageSpec::metadata_val)
     ;          


### PR DESCRIPTION
* Add ImageSpec::find_attribute() that works for fixed fields in the spec like "width" (in addition to named metadata in extra_attribs).  But needs to be passed a temporary ImageIOParameter as scratch. By using this, we make get_int_attribute, get_float_attribute, and get_string_attribute also able to retrieve those fields. For example, imagespec.get_int_attribute("nchannels") might return 3, or imagespec.get_string_attribute("geom") might return "640x480+0+0".

* ImageSpec::metadata_val should be static (not merely const), since it doesn't need 'this' at all.

* ImageSpec::erase_attribute() fixups:
    1. Document it (had somehow gone undocumented in the PDF)
    2. Set up Python bindings for it (was missing)
    3. Minor touch-ups in describing the workings of find_attribute.
