### PR TITLE
Improve oiiotool error messages when files can't be read.

### DIFF
--- a/testsuite/oiiotool-readerror/ref/out.err-alt.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err-alt.txt
@@ -1,1 +1,1 @@
-oiiotool ERROR: read incomplete.exr (Failed OpenEXR read: Error reading pixel data from image file "incomplete.exr". Unexpected end of file.)
+oiiotool ERROR: read incomplete.exr : Failed OpenEXR read: Error reading pixel data from image file "incomplete.exr". Unexpected end of file.

--- a/testsuite/oiiotool-readerror/ref/out.err.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err.txt
@@ -1,1 +1,1 @@
-oiiotool ERROR: read incomplete.exr (Failed OpenEXR read: Error reading pixel data from image file "incomplete.exr". Scan line 126 is missing.)
+oiiotool ERROR: read incomplete.exr : Failed OpenEXR read: Error reading pixel data from image file "incomplete.exr". Scan line 126 is missing.


### PR DESCRIPTION
Before, all read errors gave the same generic "Could not open file" message.  Now, it is more nuanced, as shown in the following examples:

    $ oiiotool noexist.jpg
     oiiotool ERROR: read : File does not exist: "noexist.jpg"
    
    $ oiiotool empty.jpg
     oiiotool ERROR: read : OpenImageIO could not open "empty.jpg" as jpg: Empty file "empty.jpg"
    
    $ oiiotool corrupt.jpg
     oiiotool ERROR: read : OpenImageIO could not open "corrupt.jpg" as jpg: "corrupt.jpg" is not a JPEG file, magic number doesn't match (was 0x6173)
