### PR TITLE
Change 'bool supports(const std::string&)' to 'int supports(string_view)'

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -72,6 +72,9 @@ Public API changes:
    #1063 (1.6.1)
  * Python bindings:
     * Added previously-M.I.A. ImageSpec::erase_attribute(). #1063 (1.6.1)
+ * ImageInput and ImageOutput supports() method has been changed to accept
+   a string_view (rather than a const std::string&), and return an int
+   (rather than a bool). (1.6.1)
 
 Fixes, minor enhancements, and performance improvements:
  * oiiotool

--- a/src/bmp.imageio/bmp_pvt.h
+++ b/src/bmp.imageio/bmp_pvt.h
@@ -169,7 +169,7 @@ class BmpOutput : public ImageOutput {
     BmpOutput () { init (); }
     virtual ~BmpOutput () { close (); }
     virtual const char *format_name (void) const { return "bmp"; }
-    virtual bool supports (const std::string &feature) const;
+    virtual int supports (string_view feature) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode);
     virtual bool close (void);

--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -50,8 +50,8 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 
-bool
-BmpOutput::supports (const std::string &feature) const
+int
+BmpOutput::supports (string_view feature) const
 {
     return (feature == "alpha");
 }

--- a/src/cineon.imageio/cineonoutput.cpp
+++ b/src/cineon.imageio/cineonoutput.cpp
@@ -44,10 +44,6 @@ public:
     CineonOutput ();
     virtual ~CineonOutput ();
     virtual const char * format_name (void) const { return "cineon"; }
-    virtual bool supports (const std::string &feature) const {
-        // Support nothing nonstandard
-        return false;
-    }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        ImageOutput::OpenMode mode);
     virtual bool close ();

--- a/src/dds.imageio/ddsoutput.cpp
+++ b/src/dds.imageio/ddsoutput.cpp
@@ -47,10 +47,6 @@ public:
     DDSOutput ();
     virtual ~DDSOutput ();
     virtual const char * format_name (void) const { return "dds"; }
-    virtual bool supports (const std::string &feature) const {
-        // Support nothing nonstandard
-        return false;
-    }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode);
     virtual bool close ();

--- a/src/doc/imageinput.tex
+++ b/src/doc/imageinput.tex
@@ -836,11 +836,14 @@ creates the \ImageInput, it does not open the file.
 Return the name of the format implemented by this class.
 \apiend
 
-\apiitem{bool {\ce supports} (const std::string \&feature)}
+\apiitem{int {\ce supports} (string_view feature)}
 \label{sec:inputsupportsfeaturelist}
-Given the name of a \emph{feature}, tells if this \ImageInput 
-instance supports that feature.  The following features are recognized
-by this query:
+Given the name of a \emph{feature}, tells if this \ImageInput  instance
+supports that feature. Most queries will simply return 0 for ``doesn't
+support the feature'' and nonzero for ``supports the feature,'' but it is
+acceptable to have queries return other nonzero integers to indicate varying
+degrees of support or limits (but those queries should be clearly documented
+as such). The following features are recognized by this query:
 \begin{description}
 \item[\spc] \spc
 \item[\rm \qkw{arbitrary_metadata}] Does the image file format allow

--- a/src/doc/imageoutput.tex
+++ b/src/doc/imageoutput.tex
@@ -1343,11 +1343,14 @@ Returns the canonical name of the format that this \ImageOutput
 instance is capable of writing.
 \apiend
 
-\apiitem{bool {\ce supports} (const std::string \&feature)}
+\apiitem{int {\ce supports} (string_view feature)}
 \label{sec:supportsfeaturelist}
-Given the name of a \emph{feature}, tells if this \ImageOutput 
-instance supports that feature.  The following features are recognized
-by this query:
+Given the name of a \emph{feature}, tells if this \ImageOutput  instance
+supports that feature.  Most queries will simply return 0 for ``doesn't
+support the feature'' and nonzero for ``supports the feature,'' but it is
+acceptable to have queries return other nonzero integers to indicate varying
+degrees of support or limits (but those queries should be clearly documented
+as such). The following features are recognized by this query:
 \begin{description}
 \item[\spc] \spc 
 \item[\rm \qkw{tiles}] Is this plugin able to write tiled images?

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -92,7 +92,7 @@
 }
 \date{{\large 
 %Editor: Larry Gritz \\[2ex]
-Date: 15 Feb 2015
+Date: 18 Feb 2015
 % \\ (with corrections, 7 Jan 2015)
 }}
 

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -854,7 +854,7 @@ The file format name of a created \ImageOutput.
 \end{code}
 \apiend
 
-\apiitem{bool ImageOutput.{\ce supports} (feature)}
+\apiitem{int ImageOutput.{\ce supports} (feature)}
 For a created \ImageOutput, returns {\cf True} if the file format supports
 the named feature (such as \qkw{tiles}, \qkw{mipmap}, etc., see
 Section~\ref{sec:supportsfeaturelist} for the full list), or {\cf False}

--- a/src/doc/writingplugins.tex
+++ b/src/doc/writingplugins.tex
@@ -305,7 +305,7 @@ real-world example of writing a JPEG/JFIF plug-in.
         JpgOutput () { init(); }
         virtual ~JpgOutput () { close(); }
         virtual const char * format_name (void) const { return "jpeg"; }
-        virtual bool supports (const std::string &property) const { return false; }
+        virtual int supports (string_view property) const { return false; }
         virtual bool open (const std::string &name, const ImageSpec &spec,
                            bool append=false);
         virtual bool write_scanline (int y, int z, TypeDesc format,

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -53,7 +53,7 @@ public:
     DPXOutput ();
     virtual ~DPXOutput ();
     virtual const char * format_name (void) const { return "dpx"; }
-    virtual bool supports (const std::string &feature) const {
+    virtual int supports (string_view feature) const {
         if (feature == "multiimage"
             || feature == "alpha"
             || feature == "nchannels"

--- a/src/ffmpeg.imageio/ffmpegoutput.cpp
+++ b/src/ffmpeg.imageio/ffmpegoutput.cpp
@@ -37,7 +37,7 @@ public:
     FFmpegOutput () { init (); }
     virtual ~FFmpegOutput () { close (); }
     virtual const char *format_name (void) const { return "mov"; }
-    virtual bool supports (const std::string &feature) const;
+    virtual int supports (string_view feature) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode);
     virtual bool close (void);
@@ -68,8 +68,8 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 
-bool
-FFmpegOutput::supports (const std::string &feature) const
+int
+FFmpegOutput::supports (string_view feature) const
 {
     // Everything else, we either don't support or don't know about
     return false;

--- a/src/field3d.imageio/field3dinput.cpp
+++ b/src/field3d.imageio/field3dinput.cpp
@@ -61,7 +61,7 @@ public:
     Field3DInput () { init(); }
     virtual ~Field3DInput () { close(); }
     virtual const char * format_name (void) const { return "field3d"; }
-    virtual bool supports (const std::string &feature) const {
+    virtual int supports (string_view feature) const {
         return (feature == "arbitrary_metadata");
     }
     virtual bool valid_file (const std::string &filename) const;

--- a/src/field3d.imageio/field3doutput.cpp
+++ b/src/field3d.imageio/field3doutput.cpp
@@ -53,7 +53,7 @@ public:
     Field3DOutput ();
     virtual ~Field3DOutput ();
     virtual const char * format_name (void) const { return "field3d"; }
-    virtual bool supports (const std::string &feature) const;
+    virtual int supports (string_view feature) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode);
     virtual bool open (const std::string &name, int subimages,
@@ -148,8 +148,8 @@ Field3DOutput::~Field3DOutput ()
 
 
 
-bool
-Field3DOutput::supports (const std::string &feature) const
+int
+Field3DOutput::supports (string_view feature) const
 {
     return (feature == "tiles"
          || feature == "multiimage"

--- a/src/fits.imageio/fits_pvt.h
+++ b/src/fits.imageio/fits_pvt.h
@@ -69,7 +69,7 @@ class FitsInput : public ImageInput {
     FitsInput () { init (); }
     virtual ~FitsInput () { close (); }
     virtual const char *format_name (void) const { return "fits"; }
-    virtual bool supports (const std::string &feature) const {
+    virtual int supports (string_view feature) const {
         return (feature == "arbitrary_metadata"
              || feature == "exif"   // Because of arbitrary_metadata
              || feature == "iptc"); // Because of arbitrary_metadata
@@ -141,7 +141,7 @@ class FitsOutput : public ImageOutput {
     FitsOutput () { init (); }
     virtual ~FitsOutput () { close (); }
     virtual const char *format_name (void) const { return "fits"; }
-    virtual bool supports (const std::string &feature) const;
+    virtual int supports (string_view feature) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close (void);

--- a/src/fits.imageio/fitsoutput.cpp
+++ b/src/fits.imageio/fitsoutput.cpp
@@ -50,8 +50,8 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 
-bool
-FitsOutput::supports (const std::string &feature) const
+int
+FitsOutput::supports (string_view feature) const
 {
     return (feature == "multiimage"
          || feature == "alpha"

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -46,7 +46,6 @@ class HdrOutput : public ImageOutput {
     HdrOutput () { init(); }
     virtual ~HdrOutput () { close(); }
     virtual const char * format_name (void) const { return "hdr"; }
-    virtual bool supports (const std::string &property) const { return false; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode);
     virtual bool write_scanline (int y, int z, TypeDesc format,

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -52,7 +52,7 @@ public:
     ICOOutput ();
     virtual ~ICOOutput ();
     virtual const char * format_name (void) const { return "ico"; }
-    virtual bool supports (const std::string &feature) const;
+    virtual int supports (string_view feature) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close ();
@@ -411,8 +411,8 @@ ICOOutput::open (const std::string &name, const ImageSpec &userspec,
 
 
 
-bool
-ICOOutput::supports (const std::string &feature) const
+int
+ICOOutput::supports (string_view feature) const
 {
     // advertise our support for subimages
     if (Strutil::iequals (feature, "multiimage"))

--- a/src/iff.imageio/iff_pvt.h
+++ b/src/iff.imageio/iff_pvt.h
@@ -177,7 +177,7 @@ public:
     IffOutput () { init (); }
     virtual ~IffOutput () { close (); }
     virtual const char *format_name (void) const { return "iff"; }
-    virtual bool supports (const std::string &feature) const;
+    virtual int supports (string_view feature) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode);
     virtual bool close (void);

--- a/src/iff.imageio/iffoutput.cpp
+++ b/src/iff.imageio/iffoutput.cpp
@@ -49,8 +49,8 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 
-bool
-IffOutput::supports (const std::string &feature) const
+int
+IffOutput::supports (string_view feature) const
 {
     return (feature == "tiles"
          || feature == "alpha"

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -471,7 +471,12 @@ public:
     virtual const char *format_name (void) const = 0;
 
     /// Given the name of a 'feature', return whether this ImageInput
-    /// supports input of images with the given properties.
+    /// supports input of images with the given properties. Most queries
+    /// will simply return 0 for "doesn't support" and nonzero for "supports
+    /// it", but it is acceptable to have queries return other nonzero
+    /// integers to indicate varying degrees of support or limits (but
+    /// should be clearly documented as such).
+    ///
     /// Feature names that ImageIO plugins are expected to recognize
     /// include:
     ///    "arbitrary_metadata" Does this format allow metadata with
@@ -484,7 +489,7 @@ public:
     /// future expansion of the set of possible queries without changing
     /// the API, adding new entry points, or breaking linkage
     /// compatibility.
-    virtual bool supports (const std::string & /*feature*/) const { return false; }
+    virtual int supports (string_view feature) const { return false; }
 
     /// Return true if the named file is file of the type for this
     /// ImageInput.  The implementation will try to determine this as
@@ -847,7 +852,12 @@ public:
     // to inform the client which formats are supported
 
     /// Given the name of a 'feature', return whether this ImageOutput
-    /// supports output of images with the given properties.
+    /// supports output of images with the given properties. Most queries
+    /// will simply return 0 for "doesn't support" and nonzero for "supports
+    /// it", but it is acceptable to have queries return other nonzero
+    /// integers to indicate varying degrees of support or limits (but
+    /// should be clearly documented as such).
+    ///
     /// Feature names that ImageIO plugins are expected to recognize
     /// include:
     ///    "tiles"          Is this format able to write tiled images?
@@ -894,7 +904,7 @@ public:
     /// future expansion of the set of possible queries without changing
     /// the API, adding new entry points, or breaking linkage
     /// compatibility.
-    virtual bool supports (const std::string &feature) const { return false; }
+    virtual int supports (string_view feature) const { return false; }
 
     enum OpenMode { Create, AppendSubimage, AppendMIPLevel };
 

--- a/src/include/OpenImageIO/oiioversion.h.in
+++ b/src/include/OpenImageIO/oiioversion.h.in
@@ -91,8 +91,10 @@ namespace OIIO = OIIO_NAMESPACE::OIIO_VERSION_NS;
 ///     ImageInput, ImageOutput).
 /// Version 16 changed the ImageInput functions taking channel ranges
 ///     from firstchan,nchans to chbegin,chend.
+/// Version 17 changed to int supports(string_view) rather than
+///     bool supports(const std::string&)). (OIIO 1.6)
 
-#define OIIO_PLUGIN_VERSION 16
+#define OIIO_PLUGIN_VERSION 17
 
 #define OIIO_PLUGIN_NAMESPACE_BEGIN OIIO_NAMESPACE_ENTER {
 #define OIIO_PLUGIN_NAMESPACE_END } OIIO_NAMESPACE_EXIT

--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -69,7 +69,7 @@ class JpgInput : public ImageInput {
     JpgInput () { init(); }
     virtual ~JpgInput () { close(); }
     virtual const char * format_name (void) const { return "jpeg"; }
-    virtual bool supports (const std::string &feature) {
+    virtual int supports (string_view feature) {
         return (feature == "exif"
              || feature == "iptc");
     }

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -57,7 +57,7 @@ class JpgOutput : public ImageOutput {
     JpgOutput () { init(); }
     virtual ~JpgOutput () { close(); }
     virtual const char * format_name (void) const { return "jpeg"; }
-    virtual bool supports (const std::string &feature) {
+    virtual int supports (string_view feature) {
         return (feature == "exif"
              || feature == "iptc");
     }

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -47,7 +47,7 @@ class Jpeg2000Input : public ImageInput {
     Jpeg2000Input () { init (); }
     virtual ~Jpeg2000Input () { close (); }
     virtual const char *format_name (void) const { return "jpeg2000"; }
-    virtual bool supports (const std::string &feature) const {
+    virtual int supports (string_view feature) const {
         return false;
         // FIXME: we should support Exif/IPTC, but currently don't.
     }

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -43,7 +43,7 @@ class Jpeg2000Output : public ImageOutput {
     Jpeg2000Output () { init (); }
     virtual ~Jpeg2000Output () { close (); }
     virtual const char *format_name (void) const { return "jpeg2000"; }
-    virtual bool supports (const std::string &feature) const {
+    virtual int supports (string_view feature) const {
         return (feature == "alpha");
         // FIXME: we should support Exif/IPTC, but currently don't.
     }

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -140,7 +140,7 @@ public:
     OpenEXRInput ();
     virtual ~OpenEXRInput () { close(); }
     virtual const char * format_name (void) const { return "openexr"; }
-    virtual bool supports (const std::string &feature) const {
+    virtual int supports (string_view feature) const {
         return (feature == "arbitrary_metadata"
              || feature == "exif"   // Because of arbitrary_metadata
              || feature == "iptc"); // Because of arbitrary_metadata

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -134,7 +134,7 @@ public:
     OpenEXROutput ();
     virtual ~OpenEXROutput ();
     virtual const char * format_name (void) const { return "openexr"; }
-    virtual bool supports (const std::string &feature) const;
+    virtual int supports (string_view feature) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool open (const std::string &name, int subimages,
@@ -277,8 +277,8 @@ OpenEXROutput::~OpenEXROutput ()
 
 
 
-bool
-OpenEXROutput::supports (const std::string &feature) const
+int
+OpenEXROutput::supports (string_view feature) const
 {
     if (feature == "tiles")
         return true;

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -48,7 +48,7 @@ public:
     PNGOutput ();
     virtual ~PNGOutput ();
     virtual const char * format_name (void) const { return "png"; }
-    virtual bool supports (const std::string &feature) const {
+    virtual int supports (string_view feature) const {
         return (feature == "alpha");
     }
     virtual bool open (const std::string &name, const ImageSpec &spec,

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -40,10 +40,6 @@ class PNMOutput : public ImageOutput {
 public:
     virtual ~PNMOutput ();
     virtual const char * format_name (void) const { return "pnm"; }
-    virtual bool supports (const std::string &feature) const {
-        // Support nothing nonstandard
-        return false;
-    }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close ();

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -50,7 +50,7 @@ public:
     PSDInput ();
     virtual ~PSDInput () { close(); }
     virtual const char * format_name (void) const { return "psd"; }
-    virtual bool supports (const std::string &feature) const {
+    virtual int supports (string_view feature) const {
         return (feature == "exif"
              || feature == "iptc");
     }

--- a/src/psd.imageio/psdoutput.cpp
+++ b/src/psd.imageio/psdoutput.cpp
@@ -40,7 +40,7 @@ public:
     PSDOutput ();
     virtual ~PSDOutput ();
     virtual const char * format_name (void) const { return "psd"; }
-    virtual bool supports (const std::string &feature) const {
+    virtual int supports (string_view feature) const {
         return (feature == "alpha");
     }
     virtual bool open (const std::string &name, const ImageSpec &spec,

--- a/src/ptex.imageio/ptexinput.cpp
+++ b/src/ptex.imageio/ptexinput.cpp
@@ -43,7 +43,7 @@ public:
     PtexInput () : m_ptex(NULL) { init(); }
     virtual ~PtexInput () { close(); }
     virtual const char * format_name (void) const { return "ptex"; }
-    virtual bool supports (const std::string &feature) const {
+    virtual int supports (string_view feature) const {
         return (feature == "arbitrary_metadata"
              || feature == "exif"   // Because of arbitrary_metadata
              || feature == "iptc"); // Because of arbitrary_metadata

--- a/src/ptex.imageio/ptexoutput.cpp
+++ b/src/ptex.imageio/ptexoutput.cpp
@@ -42,7 +42,7 @@ public:
     PtexOutput ();
     virtual ~PtexOutput ();
     virtual const char * format_name (void) const { return "ptex"; }
-    virtual bool supports (const std::string &feature) const;
+    virtual int supports (string_view feature) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        ImageOutput::OpenMode mode);
     virtual bool close ();
@@ -89,8 +89,8 @@ PtexOutput::~PtexOutput ()
 
 
 
-bool
-PtexOutput::supports (const std::string &feature) const
+int
+PtexOutput::supports (string_view feature) const
 {
     return (feature == "tiles"
          || feature == "multiimage"

--- a/src/python/py_imageinput.cpp
+++ b/src/python/py_imageinput.cpp
@@ -118,7 +118,7 @@ const ImageSpec& ImageInputWrap::spec() const
     return m_input->spec();
 }
 
-bool ImageInputWrap::supports (const std::string &feature) const
+int ImageInputWrap::supports (const std::string &feature) const
 {
     return m_input->supports (feature);
 }

--- a/src/python/py_imageoutput.cpp
+++ b/src/python/py_imageoutput.cpp
@@ -269,7 +269,7 @@ const char* ImageOutputWrap::format_name (void) const
 }
 
 
-bool ImageOutputWrap::supports (const std::string &feature) const
+int ImageOutputWrap::supports (const std::string &feature) const
 {
     return m_output->supports(feature);
 }

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -154,7 +154,7 @@ public:
     bool open_regular (const std::string &name);
     bool open_with_config(const std::string &name, const ImageSpec &config);
     const ImageSpec &spec() const;
-    bool supports (const std::string &feature) const;
+    int supports (const std::string &feature) const;
     bool close();
     int current_subimage() const;
     int current_miplevel() const;
@@ -217,7 +217,7 @@ public:
                          stride_t zstride=AutoStride);
     bool copy_image (ImageInputWrap *iiw);
     const char *format_name () const;
-    bool supports (const std::string&) const;
+    int supports (const std::string&) const;
     std::string geterror()const;
 };
 

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -47,7 +47,7 @@ public:
     RawInput () : m_process(true), m_image(NULL) {}
     virtual ~RawInput() { close(); }
     virtual const char * format_name (void) const { return "raw"; }
-    virtual bool supports (const std::string &feature) const {
+    virtual int supports (string_view feature) const {
         return (feature == "exif"
              /* not yet? || feature == "iptc"*/);
     }

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -58,7 +58,7 @@ public:
     RLAOutput ();
     virtual ~RLAOutput ();
     virtual const char * format_name (void) const { return "rla"; }
-    virtual bool supports (const std::string &feature) const;
+    virtual int supports (string_view feature) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close ();
@@ -150,8 +150,8 @@ RLAOutput::~RLAOutput ()
 
 
 
-bool
-RLAOutput::supports (const std::string &feature) const
+int
+RLAOutput::supports (string_view feature) const
 {
     if (feature == "random_access")
         return true;

--- a/src/sgi.imageio/sgi_pvt.h
+++ b/src/sgi.imageio/sgi_pvt.h
@@ -141,7 +141,7 @@ class SgiOutput : public ImageOutput {
     SgiOutput () : m_fd(NULL) { }
     virtual ~SgiOutput () { close(); }
     virtual const char *format_name (void) const { return "sgi"; }
-    virtual bool supports (const std::string &feature) const;
+    virtual int supports (string_view feature) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close (void);

--- a/src/sgi.imageio/sgioutput.cpp
+++ b/src/sgi.imageio/sgioutput.cpp
@@ -47,8 +47,8 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 
-bool
-SgiOutput::supports (const std::string &feature) const
+int
+SgiOutput::supports (string_view feature) const
 {
     return (feature == "alpha"
          || feature == "nchannels");

--- a/src/socket.imageio/socket_pvt.h
+++ b/src/socket.imageio/socket_pvt.h
@@ -64,7 +64,7 @@ class SocketOutput : public ImageOutput {
     SocketOutput ();
     virtual ~SocketOutput () { close(); }
     virtual const char * format_name (void) const { return "socket"; }
-    virtual bool supports (const std::string &property) const;
+    virtual int supports (string_view property) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool write_scanline (int y, int z, TypeDesc format,

--- a/src/socket.imageio/socketoutput.cpp
+++ b/src/socket.imageio/socketoutput.cpp
@@ -58,11 +58,11 @@ SocketOutput::SocketOutput()
 
 
 
-bool
-SocketOutput::supports (const std::string &property) const
+int
+SocketOutput::supports (string_view feature) const
 {
-    return (property == "alpha" ||
-            property == "nchannels");
+    return (feature == "alpha" ||
+            feature == "nchannels");
 }
 
 

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -50,7 +50,7 @@ public:
     TGAOutput ();
     virtual ~TGAOutput ();
     virtual const char * format_name (void) const { return "targa"; }
-    virtual bool supports (const std::string &feature) const {
+    virtual int supports (string_view feature) const {
         return (feature == "alpha");
     }
     virtual bool open (const std::string &name, const ImageSpec &spec,

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -96,7 +96,7 @@ public:
     virtual ~TIFFInput ();
     virtual const char * format_name (void) const { return "tiff"; }
     virtual bool valid_file (const std::string &filename) const;
-    virtual bool supports (const std::string &feature) const {
+    virtual int supports (string_view feature) const {
         return (feature == "exif"
              || feature == "iptc");
         // N.B. No support for arbitrary metadata.

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -74,7 +74,7 @@ public:
     TIFFOutput ();
     virtual ~TIFFOutput ();
     virtual const char * format_name (void) const { return "tiff"; }
-    virtual bool supports (const std::string &feature) const;
+    virtual int supports (string_view feature) const;
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close ();
@@ -146,8 +146,8 @@ TIFFOutput::~TIFFOutput ()
 
 
 
-bool
-TIFFOutput::supports (const std::string &feature) const
+int
+TIFFOutput::supports (string_view feature) const
 {
     if (feature == "tiles")
         return true;

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -45,7 +45,7 @@ class WebpOutput : public ImageOutput
     virtual const char* format_name () const { return "webp"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
-    virtual bool supports (const std::string &property) const;
+    virtual int supports (string_view feature) const;
     virtual bool write_scanline (int y, int z, TypeDesc format,
                                  const void *data, stride_t xstride);
     virtual bool write_tile (int x, int y, int z, TypeDesc format,
@@ -71,10 +71,10 @@ class WebpOutput : public ImageOutput
 
 
 
-bool
-WebpOutput::supports (const std::string &property) const
+int
+WebpOutput::supports (string_view feature) const
 {
-    return (property == "alpha");
+    return (feature == "alpha");
 }
 
 

--- a/src/zfile.imageio/zfile.cpp
+++ b/src/zfile.imageio/zfile.cpp
@@ -93,7 +93,6 @@ public:
     ZfileOutput () { init(); }
     virtual ~ZfileOutput () { close(); }
     virtual const char * format_name (void) const { return "zfile"; }
-    virtual bool supports (const std::string &feature) const { return false; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
                        OpenMode mode=Create);
     virtual bool close ();


### PR DESCRIPTION
By changing to int, we allow future queries to return more information than just a bool (for example, perhaps a supports("maxchannels") would return the maximum number of channels allowed by the format). By changing the argument to a string_view, we make the call less expensive by no longer requiring a temporary string be constructed in many cases.

This should not require any changes to client-side source code, since all existing queries just return true or false (1 or 0), and the string_view can accept either a char* or a std::string (or for that matter, a ustring).

However, if you have written any custom ImageInput or ImageOutput plugins, you will need to change the signature of any supports() methods in your
subclasses.

I have bumped the OIIO_PLUGIN_VERSION, and after merging will also bump the OIIO release version.