### PR TITLE
Filesystem improvements

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -155,6 +155,14 @@ inline bool copy (string_view from, string_view to) {
     return copy (from, to, err);
 }
 
+/// Rename (or move) a file, directory, or link.  Return true upon success,
+/// false upon failure and place an error message in err.
+OIIO_API bool rename (string_view from, string_view to, std::string &err);
+inline bool rename (string_view from, string_view to) {
+    std::string err;
+    return rename (from, to, err);
+}
+
 /// Remove the file or directory. Return true for success, false for
 /// failure and place an error message in err.
 OIIO_API bool remove (string_view path, std::string &err);

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -322,7 +322,31 @@ Filesystem::copy (string_view from, string_view to, std::string &err)
 # else
     boost::filesystem::copy (from.str(), to.str(), ec);
 # endif
-    if (ec) {
+    if (! ec) {
+        err.clear();
+        return true;
+    } else {
+        err = ec.message();
+        return false;
+    }
+#else
+    return false; // I'm too lazy to figure this out.
+#endif
+}
+
+
+
+bool
+Filesystem::rename (string_view from, string_view to, std::string &err)
+{
+#if BOOST_FILESYSTEM_VERSION >= 3
+    boost::system::error_code ec;
+# if BOOST_VERSION < 105000
+    boost::filesystem3::rename (from.str(), to.str(), ec);
+# else
+    boost::filesystem::rename (from.str(), to.str(), ec);
+# endif
+    if (! ec) {
         err.clear();
         return true;
     } else {

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -199,7 +199,12 @@ Filesystem::get_directory_entries (const std::string &dirname,
     if (dirname.size() && ! is_directory(dirname))
         return false;
     boost::filesystem::path dirpath (dirname.size() ? dirname : std::string("."));
-    boost::regex re (filter_regex);
+    boost::regex re;
+    try {
+        re = boost::regex(filter_regex);
+    } catch (...) {
+        return false;
+    }
 
     if (recursive) {
         for (boost::filesystem::recursive_directory_iterator s (dirpath);


### PR DESCRIPTION
1. From Max Liani: improve exception safety of Filesystem::get_directory_entries. 

2. From LG: add Filesystem::rename(), and fix Filesystem::copy() which got the sense of the error code backwards.
