### PR TITLE
Fix simd.h typo that implemented >>= incorrectly

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -918,7 +918,7 @@ public:
     }
 
     OIIO_FORCEINLINE const int4 & operator>>= (const unsigned int bits) {
-        return *this = *this << bits;
+        return *this = *this >> bits;
     }
 
     // Shift right logical -- unsigned shift. This differs from operator>>

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -266,6 +266,13 @@ void test_shift ()
                                              unsigned(c)>>4, unsigned(d)>>4));
     std::cout << Strutil::format ("  [%x] >>  4 == [%x]\n", hard, hard>>4);
     std::cout << Strutil::format ("  [%x] srl 4 == [%x]\n", hard, srl(hard,4));
+
+    i = int4(1,2,4,8);
+    i <<= 1;
+    OIIO_CHECK_SIMD_EQUAL (i, int4(2,4,8,16));
+    i = int4(1,2,4,8);
+    i >>= 1;
+    OIIO_CHECK_SIMD_EQUAL (i, int4(0,1,2,4));
 }
 
 


### PR DESCRIPTION
Was glancing through code and spotted this embarrassing typo. Added the unit tests I always should have had, that would have found this.

"Untested code is broken code."
