### PR TITLE
Move rotl32 and rotl64 from hash.h to fmath.h (where other bit-twiddles live)

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -178,6 +178,18 @@ clamped_mult64 (uint64_t a, uint64_t b)
 }
 
 
+
+/// Bitwise circular rotation left by k bits (for 32 bit unsigned integers)
+OIIO_FORCEINLINE uint32_t rotl32 (uint32_t x, int k) {
+    return (x<<k) | (x>>(32-k));
+}
+
+/// Bitwise circular rotation left by k bits (for 64 bit unsigned integers)
+OIIO_FORCEINLINE uint64_t rotl64 (uint64_t x, int k) {
+    return (x<<k) | (x>>(64-k));
+}
+
+
 // (end of integer helper functions)
 ////////////////////////////////////////////////////////////////////////////
 

--- a/src/include/OpenImageIO/hash.h
+++ b/src/include/OpenImageIO/hash.h
@@ -76,9 +76,6 @@ namespace bjhash {
 // Bob Jenkins "lookup3" hashes:  http://burtleburtle.net/bob/c/lookup3.c
 // It's in the public domain.
 
-inline uint32_t rotl32 (uint32_t x, int k) { return (x<<k) | (x>>(32-k)); }
-inline uint64_t rotl64 (uint64_t x, int k) { return (x<<k) | (x>>(64-k)); }
-
 // Mix up the bits of a, b, and c (changing their values in place).
 inline void bjmix (uint32_t &a, uint32_t &b, uint32_t &c)
 {

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -1182,6 +1182,13 @@ OIIO_FORCEINLINE int4 max (const int4& a, const int4& b)
 }
 
 
+// Circular bit rotate by k bits, for 4 values at once.
+OIIO_FORCEINLINE int4 rotl32 (const int4& x, const unsigned int k)
+{
+    return (x<<k) | srl(x,32-k);
+}
+
+
 
 
 /// Floating point 4-vector, accelerated by SIMD instructions when


### PR DESCRIPTION
Move rotl32 and rotl64 from hash.h to fmath.h (where other bit-twiddles live)
Also add a SIMD version of rotl to simd.h.