### PR TITLE
IC/TS: add create_thread_info() and destroy_thread_info() methods

### DIFF
--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -122,12 +122,22 @@ public:
 
     /// Define an opaque data type that allows us to have a pointer
     /// to certain per-thread information that the ImageCache maintains.
+    /// Any given one of these should NEVER be shared between running
+    /// threads.
     typedef pvt::ImageCachePerThreadInfo Perthread;
 
-    /// Retrieve an opaque handle for per-thread info, to be used for
-    /// get_texture_handle and the texture routines that take handles
-    /// directly.
+    /// Retrieve a Perthread, unique to the calling thread. This is a
+    /// thread-specific pointer that will always return the Perthread for a
+    /// thread, which will also be automatically destroyed when the thread
+    /// terminates.
     virtual Perthread * get_perthread_info () = 0;
+
+    /// Create a new Perthread. It is the caller's responsibility to
+    /// eventually destroy it using destroy_thread_info().
+    virtual Perthread * create_thread_info () = 0;
+
+    /// Destroy a Perthread that was allocated by create_thread_info().
+    virtual void destroy_thread_info (Perthread *threadinfo) = 0;
 
     /// Define an opaque data type that allows us to have a handle to an
     /// image (already having its name resolved) but without exposing

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -355,12 +355,22 @@ public:
 
     /// Define an opaque data type that allows us to have a pointer
     /// to certain per-thread information that the TextureSystem maintains.
+    /// Any given one of these should NEVER be shared between running
+    /// threads.
     class Perthread;
 
-    /// Retrieve an opaque handle for per-thread info, to be used for
-    /// get_texture_handle and the texture routines that take handles
-    /// directly.
+    /// Retrieve a Perthread, unique to the calling thread. This is a
+    /// thread-specific pointer that will always return the Perthread for a
+    /// thread, which will also be automatically destroyed when the thread
+    /// terminates.
     virtual Perthread * get_perthread_info () = 0;
+
+    /// Create a new Perthread. It is the caller's responsibility to
+    /// eventually destroy it using destroy_thread_info().
+    virtual Perthread * create_thread_info () = 0;
+
+    /// Destroy a Perthread that was allocated by create_thread_info().
+    virtual void destroy_thread_info (Perthread *threadinfo) = 0;
 
     /// Define an opaque data type that allows us to have a handle to a
     /// texture (already having its name resolved) but without exposing

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -603,9 +603,14 @@ public:
     ImageCachePerThreadInfo ()
         : next_last_file(0), shared(false)
     {
+        // std::cout << "Creating PerThreadInfo " << (void*)this << "\n";
         for (int i = 0;  i < nlastfile;  ++i)
             last_file[i] = NULL;
         purge = 0;
+    }
+
+    ~ImageCachePerThreadInfo () {
+        // std::cout << "Destroying PerThreadInfo " << (void*)this << "\n";
     }
 
     // Add a new filename/fileptr pair to our microcache
@@ -888,9 +893,9 @@ public:
     /// Append a string to the current error message
     void append_error (const std::string& message) const;
 
-    /// Get a pointer to the caller's thread's per-thread info, or create
-    /// one in the first place if there isn't one already.
-    virtual ImageCachePerThreadInfo *get_perthread_info ();
+    virtual Perthread * get_perthread_info ();
+    virtual Perthread * create_thread_info ();
+    virtual void destroy_thread_info (Perthread *threadinfo);
 
     /// Called when the IC is destroyed.  We have a list of all the 
     /// perthread pointers -- go through and delete the ones for which we
@@ -949,7 +954,7 @@ private:
 
     thread_specific_ptr< ImageCachePerThreadInfo > m_perthread_info;
     std::vector<ImageCachePerThreadInfo *> m_all_perthread_info;
-    static mutex m_perthread_info_mutex; ///< Thread safety for perthread
+    static spin_mutex m_perthread_info_mutex; ///< Thread safety for perthread
     int m_max_open_files;
     atomic_ll m_max_memory_bytes;
     std::string m_searchpath;    ///< Colon-separated image directory list

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -116,8 +116,16 @@ public:
         result = m_Mc2w;
     }
 
-    virtual Perthread *get_perthread_info (void) {
+    virtual Perthread *get_perthread_info () {
         return (Perthread *)m_imagecache->get_perthread_info ();
+    }
+    virtual Perthread *create_thread_info () {
+        ASSERT (m_imagecache);
+        return (Perthread *)m_imagecache->create_thread_info ();
+    }
+    virtual void destroy_thread_info (Perthread *threadinfo) {
+        ASSERT (m_imagecache);
+        m_imagecache->destroy_thread_info ((ImageCachePerThreadInfo *)threadinfo);
     }
 
     virtual TextureHandle *get_texture_handle (ustring filename,


### PR DESCRIPTION
ImageCache/TextureSystem: add create_thread_info() and destroy_thread_info() methods that let an app explicitly create an IC/TS per-thread info that the app can completely manage (and is responsible for destroying).

This augments the existing get_perthread_info(), which retrieves a unique Perthread* from a thread-specific pointer (whose storage and lifetime is controlled by the library, not the app).

The addition of the explicit create/destroy allows very savvy apps to pre-allocate PerThreadInfo that can persist even as threads come and go, and avoid the thread-specific-pointer retrieval. But beware -- it is up to the app to ensure that any created Perthread info (a) is eventually destroyed, and (b) under no circumstances may be shared by more than one thread at the same time. Bad things will happen. Don't cross the streams.
