### PR TITLE
Fix build error in float4.xyz0() with SSE version < 4

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -1656,7 +1656,7 @@ public:
         return _mm_insert_ps (m_vec, _mm_set_ss(0.0f), 3<<4);
 #else
         float4 tmp = m_vec;
-        tmp[3] = val;
+        tmp[3] = 0.0f;
         return tmp;
 #endif
     }


### PR DESCRIPTION
Please backport to RB-1.5, since the same issue exists there.