### PR TITLE
allow e.g. %04d to match more than 4 digits, e.g. 10000

### DIFF
--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -831,7 +831,7 @@ Filesystem::scan_for_matching_filenames(const std::string &pattern_,
     std::string prefix (format_match.prefix().first, format_match.prefix().second);
     std::string suffix (format_match.suffix().first, format_match.suffix().second);
 
-    std::string pattern_re_str = prefix + "([0-9]{" + thepadding + "})" + suffix;
+    std::string pattern_re_str = prefix + "([0-9]{" + thepadding + ",})" + suffix;
     std::vector< std::pair< int, std::string > > matches;
 
     // There are some corner cases regex that could be constructed here that


### PR DESCRIPTION
A tiny patch (1 character!) that allows %0Nd to match more than N digits. For example, if a sequence overflows 4 digits, frame 10000 should still be matched. 

This behavior is consistent with Nuke and RV.

cheers,
-Mark