### PR TITLE
Fixes to texture handle changes

### DIFF
--- a/src/doc/imagecache.tex
+++ b/src/doc/imagecache.tex
@@ -389,16 +389,41 @@ settings of named options.  For example,
 \subsection{Opaque data for performance lookups}
 \label{sec:imagecache:api:opaque}
 
-\apiitem{Perthread * {\ce get_perthread_info} ()}
+\apiitem{Perthread * {\ce get_perthread_info} (Perthread *thread_info=NULL) \\
+Perthread * {\ce create_perthread_info} () \\
+void {\ce destroy_perthread_info} (Perthread *thread_info)}
 \indexapi{get_perthread_info}
+\indexapi{create_perthread_info} \indexapi{destroy_perthread_info}
 \NEW % 1.6
-Retrieves an opaque handle for per-thread info, to be used for
-{\cf get_image_handle()} and the \ImageCache methods that take handles
-directly.
+
+The \ImageCache implementation needs to maintain certain per-thread
+state, and some \ImageCache methods take an opaque {\cf Perthread} pointer
+to this record. There are three options for how to deal with it:
+
+1. Don't worry about it at all: don't use the methods that want {\cf
+Perthread} pointers, or always pass {\cf NULL} for any {\cf Perthread*}
+arguments, and \ImageCache will do thread-specific-pointer retrieval as
+necessary (though at some small cost).
+
+2. If your app already stores per-thread information of its own, you may
+call {\cf get_perthread_info(NULL)} to retrieve it for that thread, and then
+pass it into the functions that allow it (thus sparing them the need and
+expense of retrieving the thread-specific pointer). However, it is crucial
+that this pointer not be shared between multiple threads. In this case,
+the \ImageCache manages the storage, which will automatically be released
+when the thread terminates.
+
+3. If your app also wants to manage the storage of the {\cf Perthread},
+it can explicitly create one with {\cf create_perthread_info}, pass it around,
+and eventually be responsible for destroying it with {\cf destroy_perthread_info}.
+When managing the storage, the app may reuse the {\cf Perthread} for another
+thread after the first is terminated, but still may not use the same
+{\cf Perthread} for two threads running concurrently.
 \apiend
 
+
 \apiitem{ImageHandle * {\ce get_image_handle} (ustring filename,\\
-\bigspc\bigspc\bigspc  Perthread *thread_info=NULL)}
+\bigspc\bigspc\spc\spc  Perthread *thread_info=NULL)}
 \indexapi{get_image_handle}
 \NEW % 1.6
 Retrieve an opaque handle for fast \ImageCache lookups.  The optional opaque
@@ -423,7 +448,8 @@ Return true if the image handle (previously returned by
 \apiitem{bool {\ce get_image_info} (ustring filename, int subimage, int
   miplevel, \\
   \bigspc\bigspc ustring dataname, TypeDesc datatype, void *data) \\
-bool {\ce get_image_info} (ImageHandle *file, int subimage, int miplevel, \\
+bool {\ce get_image_info} (ImageHandle *file, Perthread *thread_info,\\
+  \bigspc\bigspc int subimage, int miplevel, \\
   \bigspc\bigspc ustring dataname, TypeDesc datatype, void *data)}
 Retrieves information about the image named by {\cf filename} (or specified
 by the opaque image handle).
@@ -521,8 +547,9 @@ matches both the name and data type.
 
 \apiitem{bool {\ce get_imagespec} (ustring filename, ImageSpec \&spec,\\
 \bigspc\spc\spc  int subimage=0, int miplevel=0, bool native=false)\\
-bool {\ce get_imagespec} (ImageHandle *file, ImageSpec \&spec,\\
-\bigspc\spc\spc  int subimage=0, int miplevel=0, bool native=false)}
+bool {\ce get_imagespec} (ImageHandle *file,  Perthread *thread_info,\\
+  \bigspc\bigspc ImageSpec \&spec, int subimage=0, \\
+  \bigspc\bigspc int miplevel=0, bool native=false)}
 
 If the image (and the specific subimage and MIP level) is found and able to
 be opened by an available
@@ -546,8 +573,8 @@ settings such as \qkw{forcefloat} or \qkw{autotile}.
 \apiitem{const ImageSpec * {\ce imagespec} (ustring filename, int
   subimage=0, \\
       \bigspc\bigspc\spc int miplevel=0, bool native=false) \\
-const ImageSpec * {\ce imagespec} (ImageHandle *file, int subimage=0, \\
-      \bigspc\bigspc\spc int miplevel=0, bool native=false)}
+const ImageSpec * {\ce imagespec} (ImageHandle *file, Perthread *thread_info,\\
+  \bigspc\bigspc int subimage=0, int miplevel=0, bool native=false)}
 
 If the image is found and able to be opened by an available
 image format plugin, and the designated subimage exists, this function

--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -571,13 +571,38 @@ settings of named options.  For example,
 \subsection{Opaque data for performance lookups}
 \label{sec:texturesys:api:opaque}
 
-\apiitem{Perthread * {\ce get_perthread_info} ()}
+\apiitem{Perthread * {\ce get_perthread_info} (Perthread *thread_info=NULL) \\
+Perthread * {\ce create_perthread_info} () \\
+void {\ce destroy_perthread_info} (Perthread *thread_info)}
 \indexapi{get_perthread_info}
+\indexapi{create_perthread_info} \indexapi{destroy_perthread_info}
+\NEW % 1.6
 
-Retrieves an opaque handle for per-thread info, to be used for
-{\cf get_texture_handle()} and the texture routines that take handles
-directly.
+The \TextureSystem implementation needs to maintain certain per-thread
+state, and some \TextureSystem methods take an opaque {\cf Perthread} pointer
+to this record. There are three options for how to deal with it:
+
+1. Don't worry about it at all: don't use the methods that want {\cf
+Perthread} pointers, or always pass {\cf NULL} for any {\cf Perthread*}
+arguments, and \TextureSystem will do thread-specific-pointer retrieval as
+necessary (though at some small cost).
+
+2. If your app already stores per-thread information of its own, you may
+call {\cf get_perthread_info(NULL)} to retrieve it for that thread, and then
+pass it into the functions that allow it (thus sparing them the need and
+expense of retrieving the thread-specific pointer). However, it is crucial
+that this pointer not be shared between multiple threads. In this case,
+the \TextureSystem manages the storage, which will automatically be released
+when the thread terminates.
+
+3. If your app also wants to manage the storage of the {\cf Perthread},
+it can explicitly create one with {\cf create_perthread_info}, pass it around,
+and eventually be responsible for destroying it with {\cf destroy_perthread_info}.
+When managing the storage, the app may reuse the {\cf Perthread} for another
+thread after the first is terminated, but still may not use the same
+{\cf Perthread} for two threads running concurrently.
 \apiend
+
 
 \apiitem{TextureHandle * {\ce get_texture_handle} (ustring filename,\\
 \bigspc\bigspc\bigspc  Perthread *thread_info=NULL)}
@@ -1111,7 +1136,8 @@ plugin.
 
 \apiitem{bool {\ce get_texture_info} (ustring filename, int subimage, \\
 \bigspc\spc\spc ustring dataname, TypeDesc datatype, void *data) \\
-bool {\ce get_texture_info} (TextureHandle *texture_handle, int subimage, \\
+bool {\ce get_texture_info} (TextureHandle *texture_handle, \\
+\bigspc\spc\spc Perthread *thread_info, int subimage, \\
 \bigspc\spc\spc ustring dataname, TypeDesc datatype, void *data)}
 
 Retrieves information about the texture, either named by {\cf filename} or
@@ -1223,7 +1249,8 @@ matches both the name and data type.
 \apiend
 
 \apiitem{bool {\ce get_imagespec} (ustring filename, int subimage, ImageSpec \&spec) \\
-bool {\ce get_imagespec} (TextureHandle *texture_handle, int subimage, ImageSpec \&spec)}
+bool {\ce get_imagespec} (TextureHandle *texture_handle, Perthread *thread_info,\\
+  \bigspc\bigspc int subimage, ImageSpec \&spec)}
 
 If the image (specified by either name or handle)
 is found and able to be opened by an available
@@ -1235,7 +1262,8 @@ plugin that could be found, the return value is {\cf false}.
 
 
 \apiitem{const ImageSpec * {\ce imagespec} (ustring filename, int subimage) \\
-const ImageSpec * {\ce imagespec} (TextureHandle *texture_handle, int subimage)}
+const ImageSpec * {\ce imagespec} (TextureHandle *texture_handle, \\
+\bigspc\bigspc Perthread *thread_info, int subimage)}
 
 If the named image is found and able to be opened by an available
 image format plugin, and the designated subimage exists, this function
@@ -1257,7 +1285,7 @@ caller must beware that the pointer is only valid as long as nobody
 \bigspc                       int zbegin, int zend, int chbegin, int chend,\\
 \bigspc                       TypeDesc format, void *result) \\
 bool {\ce get_texels} (TextureHandle *texture_handle, PerThread *thread_info, \\
-\bigspc                       TextureOpt \&options, int miplevel, \\
+\bigspc                       Perthread *thread_info, TextureOpt \&options, int miplevel, \\
 \bigspc                       int xbegin, int xend, int ybegin, int yend,\\
 \bigspc                       int zbegin, int zend, int chbegin, int chend,\\
 \bigspc                       TypeDesc format, void *result)}

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -165,7 +165,8 @@ public:
     /// doesn't match the type requested. or some other failure.
     virtual bool get_image_info (ustring filename, int subimage, int miplevel,
                          ustring dataname, TypeDesc datatype, void *data) = 0;
-    virtual bool get_image_info (ImageHandle *file, int subimage, int miplevel,
+    virtual bool get_image_info (ImageHandle *file, Perthread *thread_info,
+                         int subimage, int miplevel,
                          ustring dataname, TypeDesc datatype, void *data) = 0;
 
     /// Get the ImageSpec associated with the named image (the first
@@ -177,7 +178,8 @@ public:
     virtual bool get_imagespec (ustring filename, ImageSpec &spec,
                                 int subimage=0, int miplevel=0,
                                 bool native=false) = 0;
-    virtual bool get_imagespec (ImageHandle *file, ImageSpec &spec,
+    virtual bool get_imagespec (ImageHandle *file, Perthread *thread_info,
+                                ImageSpec &spec,
                                 int subimage=0, int miplevel=0,
                                 bool native=false) = 0;
 
@@ -194,8 +196,10 @@ public:
     /// file, or invalidate_all(), or destroys the ImageCache.
     virtual const ImageSpec *imagespec (ustring filename, int subimage=0,
                                         int miplevel=0, bool native=false) = 0;
-    virtual const ImageSpec *imagespec (ImageHandle *file, int subimage=0,
-                                        int miplevel=0, bool native=false) = 0;
+    virtual const ImageSpec *imagespec (ImageHandle *file,
+                                        Perthread *thread_info,
+                                        int subimage=0, int miplevel=0,
+                                        bool native=false) = 0;
 
     /// Retrieve the rectangle of pixels spanning [xbegin..xend) X
     /// [ybegin..yend) X [zbegin..zend), with "exclusive end" a la STL,

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -130,14 +130,20 @@ public:
     /// thread-specific pointer that will always return the Perthread for a
     /// thread, which will also be automatically destroyed when the thread
     /// terminates.
-    virtual Perthread * get_perthread_info () = 0;
+    ///
+    /// Applications that want to manage their own Perthread pointers (with
+    /// create_thread_info and destroy_thread_info) should still call this,
+    /// but passing in their managed pointer. If the passed-in threadinfo is
+    /// not NULL, it won't create a new one or retrieve a TSP, but it will
+    /// do other necessary housekeeping on the Perthread information.
+    virtual Perthread * get_perthread_info (Perthread *thread_info = NULL) = 0;
 
     /// Create a new Perthread. It is the caller's responsibility to
     /// eventually destroy it using destroy_thread_info().
     virtual Perthread * create_thread_info () = 0;
 
     /// Destroy a Perthread that was allocated by create_thread_info().
-    virtual void destroy_thread_info (Perthread *threadinfo) = 0;
+    virtual void destroy_thread_info (Perthread *thread_info) = 0;
 
     /// Define an opaque data type that allows us to have a handle to an
     /// image (already having its name resolved) but without exposing

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -133,9 +133,9 @@ public:
     ///
     /// Applications that want to manage their own Perthread pointers (with
     /// create_thread_info and destroy_thread_info) should still call this,
-    /// but passing in their managed pointer. If the passed-in threadinfo is
-    /// not NULL, it won't create a new one or retrieve a TSP, but it will
-    /// do other necessary housekeeping on the Perthread information.
+    /// but passing in their managed pointer. If the passed-in thread_info
+    /// is not NULL, it won't create a new one or retrieve a TSP, but it
+    /// will do other necessary housekeeping on the Perthread information.
     virtual Perthread * get_perthread_info (Perthread *thread_info = NULL) = 0;
 
     /// Create a new Perthread. It is the caller's responsibility to

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -363,7 +363,13 @@ public:
     /// thread-specific pointer that will always return the Perthread for a
     /// thread, which will also be automatically destroyed when the thread
     /// terminates.
-    virtual Perthread * get_perthread_info () = 0;
+    ///
+    /// Applications that want to manage their own Perthread pointers (with
+    /// create_thread_info and destroy_thread_info) should still call this,
+    /// but passing in their managed pointer. If the passed-in threadinfo is
+    /// not NULL, it won't create a new one or retrieve a TSP, but it will
+    /// do other necessary housekeeping on the Perthread information.
+    virtual Perthread * get_perthread_info (Perthread *thread_info=NULL) = 0;
 
     /// Create a new Perthread. It is the caller's responsibility to
     /// eventually destroy it using destroy_thread_info().

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -577,6 +577,10 @@ public:
     /// doesn't match the type requested. or some other failure.
     virtual bool get_texture_info (ustring filename, int subimage,
                           ustring dataname, TypeDesc datatype, void *data) = 0;
+    virtual bool get_texture_info (TextureHandle *texture_handle,
+                          Perthread *thread_info, int subimage,
+                          ustring dataname, TypeDesc datatype, void *data) = 0;
+    /// DEPRECATED (1.6.2)
     virtual bool get_texture_info (TextureHandle *texture_handle, int subimage,
                           ustring dataname, TypeDesc datatype, void *data) = 0;
 
@@ -588,7 +592,8 @@ public:
     /// available ImageIO plugin.
     virtual bool get_imagespec (ustring filename, int subimage,
                                 ImageSpec &spec) = 0;
-    virtual bool get_imagespec (TextureHandle *texture_handle, int subimage,
+    virtual bool get_imagespec (TextureHandle *texture_handle,
+                                Perthread *thread_info, int subimage,
                                 ImageSpec &spec) = 0;
 
     /// Return a pointer to an ImageSpec associated with the named
@@ -605,6 +610,7 @@ public:
     /// the TextureSystem.
     virtual const ImageSpec *imagespec (ustring filename, int subimage=0) = 0;
     virtual const ImageSpec *imagespec (TextureHandle *texture_handle,
+                                        Perthread *thread_info = NULL,
                                         int subimage=0) = 0;
 
     /// Retrieve the rectangle of raw unfiltered texels spanning

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -363,7 +363,7 @@ TextureSystemImpl::environment (TextureHandle *texture_handle_,
     }
 
     PerThreadInfo *thread_info = (PerThreadInfo *)thread_info_;
-    TextureFile *texturefile = (TextureFile *)texture_handle_;
+    TextureFile *texturefile = verify_texturefile ((TextureFile *)texture_handle_, thread_info);
     ImageCacheStatistics &stats (thread_info->m_stats);
     ++stats.environment_batches;
     ++stats.environment_queries;

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -362,7 +362,7 @@ TextureSystemImpl::environment (TextureHandle *texture_handle_,
         return true;
     }
 
-    PerThreadInfo *thread_info = (PerThreadInfo *)thread_info_;
+    PerThreadInfo *thread_info = m_imagecache->get_perthread_info((PerThreadInfo *)thread_info_);
     TextureFile *texturefile = verify_texturefile ((TextureFile *)texture_handle_, thread_info);
     ImageCacheStatistics &stats (thread_info->m_stats);
     ++stats.environment_batches;

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -2907,9 +2907,10 @@ ImageCacheImpl::destroy_thread_info (ImageCachePerThreadInfo *thread_info)
 
 
 ImageCachePerThreadInfo *
-ImageCacheImpl::get_perthread_info ()
+ImageCacheImpl::get_perthread_info (ImageCachePerThreadInfo *p)
 {
-    ImageCachePerThreadInfo *p = m_perthread_info.get();
+    if (!p)
+        p = m_perthread_info.get();
     if (! p) {
         p = new ImageCachePerThreadInfo;
         m_perthread_info.reset (p);

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1034,7 +1034,7 @@ ImageCacheImpl::find_file (ustring filename,
     // expensive lock on the shared file cache.
     ImageCacheFile *tf = thread_info->find_file (filename);
 
-    // Part 1 - make sure the ImageCacheFile entry exists and is in the
+    // Make sure the ImageCacheFile entry exists and is in the
     // file cache.  For this part, we need to lock the file cache.
     bool newfile = false;
     if (! tf) {  // was not found in microcache
@@ -1054,19 +1054,39 @@ ImageCacheImpl::find_file (ustring filename,
         }
         m_files.unlock_bin (bin);
 
-        if (newfile)
+        if (newfile) {
             check_max_files (thread_info);
+            if (! tf->duplicate())
+                ++thread_info->m_stats.unique_files;
+        }
         thread_info->filename (filename, tf);  // add to the microcache
 #if IMAGECACHE_TIME_STATS
         thread_info->m_stats.find_file_time += timer();
 #endif
     }
 
-    // Part 2 - open the file if it's never been opened before.
+    // Ensure that it's open and do other important housekeeping.
+//    tf = verify_file (tf, thread_info, header_only);
+    return tf;
+}
+
+
+
+ImageCacheFile *
+ImageCacheImpl::verify_file (ImageCacheFile *tf,
+                             ImageCachePerThreadInfo *thread_info,
+                             bool header_only)
+{
+    if (! tf)
+        return NULL;
+
+    // Open the file if it's never been opened before.
     // No need to have the file cache locked for this, though we lock
     // the tf->m_input_mutex if we need to open it.
     if (! tf->validspec()) {
         Timer timer;
+        if (! thread_info)
+            thread_info = get_perthread_info ();
         recursive_lock_guard guard (tf->m_input_mutex);
         if (! tf->validspec()) {
             tf->open (thread_info);
@@ -1114,21 +1134,15 @@ ImageCacheImpl::find_file (ustring filename,
         }
     }
 
-    // if this is a duplicate texture, switch to the canonical copy
-    if (tf->duplicate()) {
-        if (! header_only)
-            tf = tf->duplicate();
+    if (! header_only) {
+        // if this is a duplicate texture, switch to the canonical copy
         // N.B. If looking up header info (i.e., get_image_info, rather
         // than getting pixels, use the original not the duplicate, since
         // metadata may differ even if pixels are identical).
-    } else {
-        // not a duplicate -- if opening the first time, count as unique
-        if (newfile)
-            ++thread_info->m_stats.unique_files;
-    }
-
-    if (! header_only)
+        if (tf->duplicate())
+            tf = tf->duplicate();
         tf->use ();  // Mark it as recently used
+    }
     return tf;
 }
 
@@ -2178,7 +2192,7 @@ ImageCacheImpl::get_image_info (ustring filename, int subimage, int miplevel,
         error ("Invalid image file \"%s\"", filename);
         return false;
     }
-    return get_image_info (file, /* thread_info,*/ subimage, miplevel,
+    return get_image_info (file, thread_info, subimage, miplevel,
                            dataname, datatype, data);
 }
 
@@ -2186,11 +2200,12 @@ ImageCacheImpl::get_image_info (ustring filename, int subimage, int miplevel,
 
 bool
 ImageCacheImpl::get_image_info (ImageCacheFile *file,
-                                // ImageCachePerThreadInfo *thread_info,
+                                ImageCachePerThreadInfo *thread_info,
                                 int subimage, int miplevel,
                                 ustring dataname,
                                 TypeDesc datatype, void *data)
 {
+    file = verify_file (file, thread_info, true);
     if (dataname == s_exists && datatype == TypeDesc::TypeInt) {
         // Just check for existence.  Need to do this before the invalid
         // file error below, since in this one case, it's not an error
@@ -2363,10 +2378,11 @@ ImageCacheImpl::get_imagespec (ustring filename, ImageSpec &spec,
 
 bool
 ImageCacheImpl::get_imagespec (ImageCacheFile *file,
+                               ImageCachePerThreadInfo *thread_info,
                                ImageSpec &spec,
                                int subimage, int miplevel, bool native)
 {
-    const ImageSpec *specptr = imagespec (file, subimage, miplevel, native);
+    const ImageSpec *specptr = imagespec (file, thread_info, subimage, miplevel, native);
     if (specptr) {
         spec = *specptr;
         return true;
@@ -2387,19 +2403,23 @@ ImageCacheImpl::imagespec (ustring filename, int subimage, int miplevel,
         error ("Image file \"%s\" not found", filename.c_str());
         return NULL;
     }
-    return imagespec (file, subimage, miplevel, native);
+    return imagespec (file, thread_info, subimage, miplevel, native);
 }
 
 
 
 const ImageSpec *
 ImageCacheImpl::imagespec (ImageCacheFile *file,
+                           ImageCachePerThreadInfo *thread_info,
                            int subimage, int miplevel, bool native)
 {
     if (! file) {
         error ("Image file handle was NULL");
         return NULL;
     }
+    if (! thread_info)
+        thread_info = get_perthread_info ();
+    file = verify_file (file, thread_info, true);
     if (file->broken()) {
         error ("Invalid image file \"%s\"", file->filename());
         return NULL;
@@ -2491,6 +2511,9 @@ ImageCacheImpl::get_pixels (ImageCacheFile *file,
                             TypeDesc format, void *result,
                             stride_t xstride, stride_t ystride, stride_t zstride)
 {
+    if (! thread_info)
+        thread_info = get_perthread_info ();
+    file = verify_file (file, thread_info);
     if (file->broken()) {
         error ("Invalid image file \"%s\"", file->filename());
         return false;
@@ -2644,6 +2667,7 @@ ImageCacheImpl::get_tile (ImageHandle *file, Perthread *thread_info,
 {
     if (! thread_info)
         thread_info = get_perthread_info ();
+    file = verify_file (file, thread_info);
     if (! file || file->broken())
         return NULL;
     const ImageSpec &spec (file->spec(subimage,miplevel));
@@ -2698,6 +2722,7 @@ ImageCacheImpl::add_file (ustring filename, ImageInput::Creator creator,
     ImageCachePerThreadInfo *thread_info = get_perthread_info ();
     ImageCacheFile *file = find_file (filename, thread_info, creator,
                                       false, config);
+    file = verify_file (file, thread_info);
     if (!file || file->broken())
         return false;
     return true;
@@ -2713,6 +2738,7 @@ ImageCacheImpl::add_tile (ustring filename, int subimage, int miplevel,
 {
     ImageCachePerThreadInfo *thread_info = get_perthread_info ();
     ImageCacheFile *file = find_file (filename, thread_info);
+    file = verify_file (file, thread_info);
     if (! file || file->broken()) {
         error ("Cannot add_tile for an image file that was not set up with add_file()");
         return false;

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -913,9 +913,9 @@ public:
     /// Append a string to the current error message
     void append_error (const std::string& message) const;
 
-    virtual Perthread * get_perthread_info ();
+    virtual Perthread * get_perthread_info (Perthread *thread_info = NULL);
     virtual Perthread * create_thread_info ();
-    virtual void destroy_thread_info (Perthread *threadinfo);
+    virtual void destroy_thread_info (Perthread *thread_info);
 
     /// Called when the IC is destroyed.  We have a list of all the 
     /// perthread pointers -- go through and delete the ones for which we
@@ -928,7 +928,7 @@ public:
     /// clear its tile microcache), so don't delete the perthread info
     /// (it will be owned thereafter by the IC).  If there is no IC still
     /// depending on it (signalled by m_imagecache == NULL), delete it.
-    static void cleanup_perthread_info (ImageCachePerThreadInfo *p);
+    static void cleanup_perthread_info (Perthread *thread_info);
 
     /// Ensure that the max_memory_bytes is at least newsize bytes.
     /// Override the previous value if necessary, with thread-safety.

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -138,7 +138,7 @@ TextureSystemImpl::texture3d (TextureHandle *texture_handle_,
     texture3d_lookup_prototype lookup = &TextureSystemImpl::texture3d_lookup_nomip;
 #endif
 
-    PerThreadInfo *thread_info = (PerThreadInfo *)thread_info_;
+    PerThreadInfo *thread_info = m_imagecache->get_perthread_info((PerThreadInfo *)thread_info_);
     TextureFile *texturefile = verify_texturefile ((TextureFile *)texture_handle_, thread_info);
     ImageCacheStatistics &stats (thread_info->m_stats);
     ++stats.texture3d_batches;

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -139,7 +139,7 @@ TextureSystemImpl::texture3d (TextureHandle *texture_handle_,
 #endif
 
     PerThreadInfo *thread_info = (PerThreadInfo *)thread_info_;
-    TextureFile *texturefile = (TextureFile *)texture_handle_;
+    TextureFile *texturefile = verify_texturefile ((TextureFile *)texture_handle_, thread_info);
     ImageCacheStatistics &stats (thread_info->m_stats);
     ++stats.texture3d_batches;
     ++stats.texture3d_queries;

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -116,8 +116,8 @@ public:
         result = m_Mc2w;
     }
 
-    virtual Perthread *get_perthread_info () {
-        return (Perthread *)m_imagecache->get_perthread_info ();
+    virtual Perthread *get_perthread_info (Perthread *thread_info = NULL) {
+        return (Perthread *)m_imagecache->get_perthread_info ((ImageCachePerThreadInfo *)thread_info);
     }
     virtual Perthread *create_thread_info () {
         ASSERT (m_imagecache);

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -263,16 +263,24 @@ public:
 
     virtual bool get_texture_info (ustring filename, int subimage,
                            ustring dataname, TypeDesc datatype, void *data);
+    virtual bool get_texture_info (TextureHandle *texture_handle,
+                           Perthread *thread_info, int subimage,
+                           ustring dataname, TypeDesc datatype, void *data);
     virtual bool get_texture_info (TextureHandle *texture_handle, int subimage,
-                          ustring dataname, TypeDesc datatype, void *data);
+                           ustring dataname, TypeDesc datatype, void *data) {
+        return get_texture_info (texture_handle, NULL, subimage,
+                                 dataname, datatype, data);
+    }
 
     virtual bool get_imagespec (ustring filename, int subimage,
                                 ImageSpec &spec);
-    virtual bool get_imagespec (TextureHandle *texture_handle, int subimage,
+    virtual bool get_imagespec (TextureHandle *texture_handle,
+                                Perthread *thread_info, int subimage,
                                 ImageSpec &spec);
 
     virtual const ImageSpec *imagespec (ustring filename, int subimage=0);
     virtual const ImageSpec *imagespec (TextureHandle *texture_handle,
+                                        Perthread *thread_info=NULL,
                                         int subimage=0);
 
     virtual bool get_texels (ustring filename, TextureOpt &options,
@@ -307,9 +315,15 @@ private:
     /// Find the TextureFile record for the named texture, or NULL if no
     /// such file can be found.
     TextureFile *find_texturefile (ustring filename, PerThreadInfo *thread_info) {
-        TextureFile *texturefile = m_imagecache->find_file (filename, thread_info);
-        if (!texturefile || texturefile->broken())
-            error ("%s", m_imagecache->geterror().c_str());
+        return m_imagecache->find_file (filename, thread_info);
+    }
+    TextureFile *verify_texturefile (TextureFile *texturefile,
+                                     PerThreadInfo *thread_info) {
+        texturefile = m_imagecache->verify_file (texturefile, thread_info);
+        if (!texturefile || texturefile->broken()) {
+            std::string err = m_imagecache->geterror();
+            error ("%s", err.size() ? err.c_str() : "(unknown error)");
+        }
         return texturefile;
     }
 

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -470,11 +470,14 @@ TextureSystemImpl::get_texture_info (ustring filename, int subimage,
 
 
 bool
-TextureSystemImpl::get_texture_info (TextureHandle *texture_handle, int subimage,
+TextureSystemImpl::get_texture_info (TextureHandle *texture_handle,
+                             Perthread *thread_info, int subimage,
                              ustring dataname, TypeDesc datatype, void *data)
 {
     bool ok = m_imagecache->get_image_info ((ImageCache::ImageHandle *)texture_handle,
-                                    subimage, 0, dataname, datatype, data);
+                                            (ImageCache::Perthread *)thread_info,
+                                            subimage, 0,
+                                            dataname, datatype, data);
     if (! ok)
         error ("%s", m_imagecache->geterror());
     return ok;
@@ -495,10 +498,12 @@ TextureSystemImpl::get_imagespec (ustring filename, int subimage,
 
 
 bool
-TextureSystemImpl::get_imagespec (TextureHandle *texture_handle, int subimage,
+TextureSystemImpl::get_imagespec (TextureHandle *texture_handle,
+                                  Perthread *thread_info, int subimage,
                                   ImageSpec &spec)
 {
     bool ok = m_imagecache->get_imagespec ((ImageCache::ImageHandle *)texture_handle,
+                                           (ImageCache::Perthread *)thread_info,
                                            spec, subimage);
     if (! ok)
         error ("%s", m_imagecache->geterror());
@@ -519,11 +524,12 @@ TextureSystemImpl::imagespec (ustring filename, int subimage)
 
 
 const ImageSpec *
-TextureSystemImpl::imagespec (TextureHandle *texture_handle, int subimage)
+TextureSystemImpl::imagespec (TextureHandle *texture_handle,
+                              Perthread *thread_info, int subimage)
 {
     const ImageSpec *spec =
         m_imagecache->imagespec ((ImageCache::ImageHandle *)texture_handle,
-                                 subimage);
+                                 (ImageCache::Perthread *)thread_info, subimage);
     if (! spec)
         error ("%s", m_imagecache->geterror());
     return spec;
@@ -561,7 +567,7 @@ TextureSystemImpl::get_texels (TextureHandle *texture_handle_,
 {
     PerThreadInfo *thread_info = thread_info_ ? (PerThreadInfo *)thread_info_
                                               : m_imagecache->get_perthread_info();
-    TextureFile *texfile = (TextureFile *)texture_handle_;
+    TextureFile *texfile = verify_texturefile ((TextureFile *)texture_handle_, thread_info);
     if (! texfile) {
         error ("Invalid texture handle NULL");
         return false;
@@ -864,7 +870,7 @@ TextureSystemImpl::texture (TextureHandle *texture_handle_,
     texture_lookup_prototype lookup = lookup_functions[(int)options.mipmode];
 
     PerThreadInfo *thread_info = (PerThreadInfo *)thread_info_;
-    TextureFile *texturefile = (TextureFile *)texture_handle_;
+    TextureFile *texturefile = verify_texturefile ((TextureFile *)texture_handle_, thread_info);
     ImageCacheStatistics &stats (thread_info->m_stats);
     ++stats.texture_batches;
     ++stats.texture_queries;

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -565,8 +565,7 @@ TextureSystemImpl::get_texels (TextureHandle *texture_handle_,
                                int chbegin, int chend,
                                TypeDesc format, void *result)
 {
-    PerThreadInfo *thread_info = thread_info_ ? (PerThreadInfo *)thread_info_
-                                              : m_imagecache->get_perthread_info();
+    PerThreadInfo *thread_info = m_imagecache->get_perthread_info((PerThreadInfo *)thread_info_);
     TextureFile *texfile = verify_texturefile ((TextureFile *)texture_handle_, thread_info);
     if (! texfile) {
         error ("Invalid texture handle NULL");
@@ -869,7 +868,7 @@ TextureSystemImpl::texture (TextureHandle *texture_handle_,
     };
     texture_lookup_prototype lookup = lookup_functions[(int)options.mipmode];
 
-    PerThreadInfo *thread_info = (PerThreadInfo *)thread_info_;
+    PerThreadInfo *thread_info = m_imagecache->get_perthread_info((PerThreadInfo *)thread_info_);
     TextureFile *texturefile = verify_texturefile ((TextureFile *)texture_handle_, thread_info);
     ImageCacheStatistics &stats (thread_info->m_stats);
     ++stats.texture_batches;


### PR DESCRIPTION
Ugh, I did it wrong. The find_file methods that did the name to IC handle lookups did more than just that -- that's also where the ImageInputs were opened (if not yet opened), duplicates found, 'used' flags updated, errors reported, etc.

It wasn't symptomatic until we started messing around with invalidating the files in the cache, which doesn't invalidate the handles themselves (and shouldn't), but at that point the files would be closed, and the re-opening wouldn't happen properly without the call to find_file, which of course wouldn't happen at all since the handle was already retrieved.

The solution is to split into separate "find" (just convert name to file cache handle, creating if necessary), and "verify" (open and other housekeeping and error checking). It's mostly just splitting the existing find_file in half, then cleaning up the many many consequent changes that make use of that properly. The name-based functions just call find, and then pass to the handle-based functions. The handle-based functions need to call "verify" on the handle it has, to ensure that the handle is ready for use. Once this split was done, it also became clear that a thread_info pointer needed to be passed to some routines where we didn't pass it before. There shouldn't be any performance hit from this, it's just re-apportioning the same amount of work across two functions.

Pulling on this piece of yarn unraveled much of the sweater, but I think I've got it put back together correctly now.