### PR TITLE
array_view fixes and docs

### DIFF
--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -157,6 +157,47 @@ Sections~\ref{sec:imageoutput:metadata}, \ref{sec:imageinput:metadata},
 and the documentation of individual ImageIO plugins for details).
 
 
+\section{Efficient unique strings: {\cf ustring}}
+\label{sec:ustring}
+\indexapi{ustring}
+
+A \ustring is an alternative to {\cf char*} or {\cf std::string} for storing
+strings, in which the character sequence is stored uniquely.  If there are
+many copies of the same \ustring, they all point to the same canonical
+characters, which themselves are stored only once. This allows \ustring's to
+be assigned to one another with only the copy of a pointer assignment (not
+allocation or copying of characters), and for {\cf ==} and {\cf !=}
+comparisons of two \ustring values for only the cost of comparing the
+pointers (not examining the characters).
+
+\OpenImageIO uses \ustring in a few select places, where string
+assignment/copy and equality/inequality are the dominant string operation
+and we want them to be the same low cost as a simple pointer assignment or
+comparison.  (This primarily comes into play for the \ImageCache and
+\TextureSystem, where we refer to images by their filenames and want
+very fast lookups.)
+
+Please consult the public header {\cf ustring.h} for details, especially if
+you want to use \ustring extensively in your own code. But here are the most
+important details to know if you are calling the \OpenImageIO functions that
+take \ustring parameters:
+
+\apiitem{{\ce ustring} (const char *chars) \\
+{\ce ustring} (const char *chars, size_t length) \\
+{\ce ustring} (const std::string \&str) \\
+{\ce ustring} (string\_view sref)}
+Constructs a \ustring from a C string ({\cf char*}), C++ {\cf std::string},
+or a \stringview.
+\apiend
+
+\apiitem{const char* ustring::{\ce c_str} () \\
+const std::string\& ustring::{\ce string()} \\
+string\_view ustring::{\ce operator string\_view}()}
+Convert a \ustring to a 0-terminated C string, a C++ {\cf std::string}, or
+a {\cf string_view}.  All of these are extremely inexpensive.
+\apiend
+
+
 \section{Non-owning string views: {\cf string_view}}
 \label{sec:stringview}
 \indexapi{string_view}
@@ -238,45 +279,55 @@ header file for full details, if you wish to use \stringview in your own
 code.
 
 
-\section{Efficient unique strings: {\cf ustring}}
-\label{sec:ustring}
-\indexapi{ustring}
+\section{Non-owning array views: {\cf array_view}}
+\label{sec:arrayview}
+\indexapi{array_view}
 
-A \ustring is an alternative to {\cf char*} or {\cf std::string} for storing
-strings, in which the character sequence is stored uniquely.  If there are
-many copies of the same \ustring, they all point to the same canonical
-characters, which themselves are stored only once. This allows \ustring's to
-be assigned to one another with only the copy of a pointer assignment (not
-allocation or copying of characters), and for {\cf ==} and {\cf !=}
-comparisons of two \ustring values for only the cost of comparing the
-pointers (not examining the characters).
+A {\cf template array\_view<typename T>} is a non-owning, non-copying, non-
+allocating reference to an array.  It encapsulates both a pointer and a
+length, and thus is a safer way of passing pointers around (because the
+function called knows how long the array is). A function that might
+ordinarily take a {\cf T*} and a length could instead just take an {\cf
+array\_view<T>}.
 
-\OpenImageIO uses \ustring in a few select places, where string
-assignment/copy and equality/inequality are the dominant string operation
-and we want them to be the same low cost as a simple pointer assignment or
-comparison.  (This primarily comes into play for the \ImageCache and
-\TextureSystem, where we refer to images by their filenames and want
-very fast lookups.)
+An \arrayview may be initialized explicitly from a pointer and length, by
+initializing with a {\cf std::vector<T>}, or by initalizing with a constant
+(treated as an array of length 1). For all of these cases, no extra
+allocations are performed, and no extra copies of the array contents are
+made.
 
-Please consult the public header {\cf ustring.h} for details, especially if
-you want to use \ustring extensively in your own code. But here are the most
-important details to know if you are calling the \OpenImageIO functions that
-take \ustring parameters:
+Important caveat: The \arrayview merely refers to items owned by another
+array, so the \arrayview should not be used outside the lifetime of the
+array it refers to. Thus, \arrayview is great for parameter passing, but
+it's not a good idea to use a \arrayview to store strings in a data
+structure (unless you are really sure you know what you're doing).
 
-\apiitem{{\ce ustring} (const char *chars) \\
-{\ce ustring} (const char *chars, size_t length) \\
-{\ce ustring} (const std::string \&str) \\
-{\ce ustring} (string\_view sref)}
-Constructs a \ustring from a C string ({\cf char*}), C++ {\cf std::string},
-or a \stringview.
+\noindent Commonly used \arrayview methods include:
+
+\apiitem{{\ce array_view<T>} (T *data, size_t len) \\
+{\ce array_view<T>} (T \&data) \\
+{\ce array_view<T>} (T *begin, T *end) \\
+{\ce array_view<T>} (std::vector<T> \&vec)}
+Constructs a \arrayview.  The \arrayview doesn't have its own copy of the
+array elements, so don't use the \arrayview after the original array has been
+destroyed or altered.
 \apiend
 
-\apiitem{const char* ustring::{\ce c_str} () \\
-const std::string\& ustring::{\ce string()} \\
-string\_view ustring::{\ce operator string\_view}()}
-Convert a \ustring to a 0-terminated C string, a C++ {\cf std::string}, or
-a {\cf string_view}.  All of these are extremely inexpensive.
+\apiitem{T* array_view<T>::{\ce data} () \\
+size_t array_view<T>::{\ce size} ()}
+The raw pointer to the array, and its length.
 \apiend
+
+\apiitem{T\& array_view<T>::operator{\ce []} (size_t pos)}
+References a single element of the \arrayview.
+\apiend
+
+\smallskip
+\noindent Please consult the public {\cf array_view.h}
+header file for full details, if you wish to use \arrayview in your own
+code.
+
+
 
 
 \section{Image Specification: {\cf ImageSpec}}

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -77,6 +77,7 @@
 \def\readscanline{{\codefont read\_scanline()}\xspace}
 \def\readtile{{\codefont read\_tile()}\xspace}
 \def\AutoStride{{\codefont AutoStride}\xspace}
+\def\arrayview{{\codefont array\_view}\xspace}
 \def\stringview{{\codefont string\_view}\xspace}
 \def\ustring{{\codefont ustring}\xspace}
 
@@ -92,7 +93,7 @@
 }
 \date{{\large 
 %Editor: Larry Gritz \\[2ex]
-Date: 18 Feb 2015
+Date: 1 Mar 2015
 % \\ (with corrections, 7 Jan 2015)
 }}
 

--- a/src/include/OpenImageIO/array_view.h
+++ b/src/include/OpenImageIO/array_view.h
@@ -37,9 +37,23 @@
 
 #include "oiioversion.h"
 #include "strided_ptr.h"
+#include "platform.h"
+
+#if OIIO_CPLUSPLUS11
+#include <type_traits>
+#else
+#include <boost/type_traits.hpp>
+#endif
 
 
 OIIO_NAMESPACE_ENTER {
+
+#if OIIO_CPLUSPLUS11
+using std::remove_const;
+#else
+using boost::remove_const;
+#endif
+
 
 
 /// array_view : a non-owning reference to a contiguous array with known
@@ -102,6 +116,12 @@ public:
     array_view (std::vector<T> &v)
         : m_data(v.size() ? &v[0] : NULL), m_len(v.size()) {}
 
+    /// Construct from const std::vector<T>.
+    /// This turns const std::vector<T> into an array_view<const T> (the
+    /// array_view isn't const, but the data it points to will be).
+    array_view (const std::vector<typename remove_const<T>::type> &v)
+        : m_data(v.size() ? &v[0] : NULL), m_len(v.size()) {}
+
     // assignments
     array_view& operator= (const array_view &copy) {
         m_data = copy.data();
@@ -149,7 +169,7 @@ public:
 
     array_view slice (size_type pos, size_type n=npos) const {
         if (pos > size())
-            throw (std::out_of_range ("OIIO::array_view::slice"));
+            throw (std::out_of_range ("OpenImageIO::array_view::slice"));
         if (n == npos || pos + n > size())
             n = size() - pos;
         return array_view (data() + pos, n);
@@ -242,6 +262,12 @@ public:
     array_view_strided (std::vector<T> &v)
         : m_data(v.size() ? &v[0] : NULL), m_len(v.size()), m_stride(sizeof(T)) {}
 
+    /// Construct from const std::vector<T>.
+    /// This turns const std::vector<T> into an array_view<const T> (the
+    /// array_view isn't const, but the data it points to will be).
+    array_view_strided (const std::vector<typename remove_const<T>::type> &v)
+        : m_data(v.size() ? &v[0] : NULL), m_len(v.size()), m_stride(sizeof(T)) {}
+
     // assignments
     array_view_strided& operator= (const array_view_strided &copy) {
         m_data = copy.data();
@@ -279,7 +305,7 @@ public:
 
     array_view_strided slice (size_type pos, size_type n=npos) const {
         if (pos > size())
-            throw (std::out_of_range ("OIIO::array_view_strided::slice"));
+            throw (std::out_of_range ("OpenImageIO::array_view_strided::slice"));
         if (n == npos || pos + n > size())
             n = size() - pos;
         return array_view_strided (getptr(pos), n, m_stride);


### PR DESCRIPTION
The most important fix is to do some tricks to allow a array_view<const float> to be constructed from a const std::vector<float>&.

Also added documentation of array_view to the PDF. (The changes you see to ustring docs aren't new, they just shifted position around.)

