### PR TITLE
Add ImageBuf::make_writeable()

### DIFF
--- a/src/doc/imagebuf.tex
+++ b/src/doc/imagebuf.tex
@@ -157,6 +157,20 @@ resolution, data type, metadata, etc.).  Optionally, you may name the
 \ImageBuf.
 \apiend
 
+\apiitem{bool make_writeable (bool keep_cache_type = false)}
+\NEW % 1.6
+Force the \ImageBuf to be writeable. That means that if it was previously
+backed by an \ImageCache (storage was {\cf IMAGECACHE}), it will force a
+full read so that the whole image is in local memory.
+This will invalidate any current iterators on the image. It has
+no effect if the image storage not {\cf IMAGECACHE}.  Return {\cf true} if
+it works (including if no read was necessary), {\cf false} if something went
+horribly wrong. If {\cf keep_cache_type} is true, it preserves any
+\ImageCache-forced data types (you might want to do this if it is critical
+that the apparent data type doesn't change, for example if you are calling
+make_writeable from within a type-specialized function).
+\apiend
+
 \subsection*{Constructing a readable \ImageBuf and reading from a file}
 
 Constructing a readable \ImageBuf that will hold an image to be read

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -1161,6 +1161,13 @@ will infer it from the extension of the file name).
 \end{code}
 \apiend
 
+\apiitem{bool ImageBuf.{\ce make_writeable} (keep_cache_type = false)}
+Force the \ImageBuf to be writeable. That means that if it was previously
+backed by an \ImageCache (storage was {\cf IMAGECACHE}), it will force a
+full read so that the whole image is in local memory.
+\apiend
+
+
 \apiitem{bool ImageBuf.{\ce set_write_format} (format=oiio.UNKNOWN) \\
 bool ImageBuf.{\ce set_write_tiles} (width=0, height=0, depth=0)}
 Override the data format or tile size in a subsequent call to {\cf write()}.

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1022,6 +1022,18 @@ ImageBuf::write (string_view _filename, string_view _fileformat,
 
 
 
+bool
+ImageBuf::make_writeable (bool keep_cache_type)
+{
+    if (storage() == IMAGECACHE) {
+        return read (subimage(), miplevel(), true /*force*/,
+                     keep_cache_type ? impl()->m_cachedpixeltype : TypeDesc());
+    }
+    return true;
+}
+
+
+
 void
 ImageBufImpl::copy_metadata (const ImageBufImpl &src)
 {

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -95,7 +95,7 @@ ImageBufAlgo::IBAprep (ROI &roi, ImageBuf *dst,
     }
     if (B && !B->initialized()) {
         if (dst)
-            dst->error ("Uninitialized destination image");
+            dst->error ("Uninitialized input image");
         return false;
     }
     if (dst->initialized()) {
@@ -110,10 +110,7 @@ ImageBufAlgo::IBAprep (ROI &roi, ImageBuf *dst,
         // If the dst is initialized but is a cached image, we'll need
         // to fully read it into allocated memory so that we're able
         // to write to it subsequently.
-        if (dst->storage() == ImageBuf::IMAGECACHE) {
-            dst->read (dst->subimage(), dst->miplevel(), true /*force*/);
-            ASSERT (dst->storage() == ImageBuf::LOCALBUFFER);
-        }
+        dst->make_writeable (true);
     } else {
         // Not an initialized destination image!
         ASSERT ((A || roi.defined()) &&

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -120,6 +120,15 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(ImageBuf_write_overloads,
                                 ImageBuf_write, 2, 3)
 
 
+bool
+ImageBuf_make_writeable (ImageBuf &buf, bool keep_cache_type)
+{
+    ScopedGILRelease gil;
+    return buf.make_writeable (keep_cache_type);
+}
+
+
+
 void
 ImageBuf_set_write_format (ImageBuf &buf, TypeDesc::BASETYPE format)
 {
@@ -326,6 +335,8 @@ void declare_imagebuf()
         .def("write", &ImageBuf_write,
              ImageBuf_write_overloads())
         // FIXME -- write(ImageOut&)
+        .def("make_writeable", &ImageBuf_make_writeable,
+             (arg("keep_cache_type")=false))
         .def("set_write_format", &ImageBuf_set_write_format)
         .def("set_write_tiles", &ImageBuf::set_write_tiles,
              (arg("width")=0, arg("height")=0, arg("depth")=0))


### PR DESCRIPTION
Add ImageBuf::make_writeable(), forces IC-backed read-only IB to force a full read into locally allocated pixels so they can be subsequently altered.

Make IB::Iterator constructors automatically do this, so that if somebody initializes an iterator to an IC-backed IB, it will automagically become safe to write. This does NOT happen for IB::const_iterator, which when used will keep IC-backed IB's using the IC rather than local storage.

Users shouldn't notice any difference, except for higher fault tolerance if they should try altering an ImageeCache-backed ImageBuf.
