### PR TITLE
Modify ustring_test to give it thread wedging benchmark abilities

### DIFF
--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -35,6 +35,8 @@
 #include "OpenImageIO/thread.h"
 #include "OpenImageIO/ustring.h"
 #include "OpenImageIO/strutil.h"
+#include "OpenImageIO/timer.h"
+#include "OpenImageIO/argparse.h"
 
 #include "OpenImageIO/unittest.h"
 
@@ -45,13 +47,24 @@ OIIO_NAMESPACE_USING;
 // threads simultaneously.  Hopefully something will crash if the 
 // internal table is not being locked properly.
 
+static int iterations = 1000000;
+static int numthreads = 16;
+static int ntrials = 1;
+static bool verbose = false;
+static bool wedge = false;
+static spin_mutex print_mutex;  // make the prints not clobber each other
+
+
+
 static void
-create_lotso_ustrings ()
+create_lotso_ustrings (int iterations)
 {
-    std::cout << "thread " << boost::this_thread::get_id() << "\n";
-    char buf[20];
-    const int iterations = 1000000;
+    if (verbose) {
+        spin_lock lock(print_mutex);
+        std::cout << "thread " << boost::this_thread::get_id() << "\n";
+    }
     for (int i = 0;  i < iterations;  ++i) {
+        char buf[20];
         sprintf (buf, "%d", i);
         ustring s (buf);
     }
@@ -59,26 +72,74 @@ create_lotso_ustrings ()
 
 
 
-void test_ustring_lock ()
+void test_ustring_lock (int numthreads, int iterations)
 {
-    std::cout << "hw threads = " << boost::thread::hardware_concurrency() << "\n";
-
-    const int numthreads = 16;
     boost::thread_group threads;
     for (int i = 0;  i < numthreads;  ++i) {
-        threads.create_thread (&create_lotso_ustrings);
+        threads.create_thread (boost::bind (create_lotso_ustrings, iterations));
     }
-    std::cout << "Created " << threads.size() << " threads\n";
     threads.join_all ();
-    std::cout << "\n" << ustring::getstats() << "\n";
     OIIO_CHECK_ASSERT (true);  // If we make it here without crashing, pass
+}
+
+
+
+static void
+getargs (int argc, char *argv[])
+{
+    bool help = false;
+    ArgParse ap;
+    ap.options ("ustring_test\n"
+                OIIO_INTRO_STRING "\n"
+                "Usage:  ustring_test [options]",
+                // "%*", parse_files, "",
+                "--help", &help, "Print help message",
+                "-v", &verbose, "Verbose mode",
+                "--threads %d", &numthreads, 
+                    ustring::format("Number of threads (default: %d)", numthreads).c_str(),
+                "--iters %d", &iterations,
+                    ustring::format("Number of iterations (default: %d)", iterations).c_str(),
+                "--trials %d", &ntrials, "Number of trials",
+                "--wedge", &wedge, "Do a wedge test",
+                NULL);
+    if (ap.parse (argc, (const char**)argv) < 0) {
+        std::cerr << ap.geterror() << std::endl;
+        ap.usage ();
+        exit (EXIT_FAILURE);
+    }
+    if (help) {
+        ap.usage ();
+        exit (EXIT_FAILURE);
+    }
 }
 
 
 
 int main (int argc, char *argv[])
 {
-    test_ustring_lock ();
+    getargs (argc, argv);
+
+    std::cout << "hw threads = " << boost::thread::hardware_concurrency() << "\n";
+    std::cout << "threads\ttime (best of " << ntrials << ")\n";
+    std::cout << "-------\t----------\n";
+
+    static int threadcounts[] = { 1, 2, 4, 8, 12, 16, 20, 24, 28, 32, 64, 128, 1024, 1<<30 };
+    for (int i = 0; threadcounts[i] <= numthreads; ++i) {
+        int nt = wedge ? threadcounts[i] : numthreads;
+        int its = iterations/nt;
+
+        double range;
+        double t = time_trial (boost::bind(test_ustring_lock,nt,its),
+                               ntrials, &range);
+
+        std::cout << Strutil::format ("%2d\t%5.1f   range %.2f\t(%d iters/thread)\n",
+                                      nt, t, range, its);
+        if (! wedge)
+            break;    // don't loop if we're not wedging
+    }
+
+    if (verbose)
+        std::cout << "\n" << ustring::getstats() << "\n";
 
     return unit_test_failures;
 }


### PR DESCRIPTION
Modify ustring_test to give it thread wedging benchmark abilities
(modeled after spinlock_test)

To benchmark its thread performance, you'd use it like this (hint for Chris):

    build/spinux1/src/libutil/ustring_test -wedge -trials 5 -iters 10000000 -threads 32

