### PR TITLE
Free memory used by UstringTable on exit

### DIFF
--- a/src/libutil/ustring.cpp
+++ b/src/libutil/ustring.cpp
@@ -83,11 +83,21 @@ typedef null_lock<null_mutex> ustring_write_lock_t;
 #define USE_CONCURRENT_MAP 1
 #endif
 
+class UstringTable : public
 #if USE_CONCURRENT_MAP
-typedef unordered_map_concurrent <string_view, ustring::TableRep *, Strutil::StringHash, Strutil::StringEqual, 8> UstringTable;
+    unordered_map_concurrent <string_view, ustring::TableRep *, Strutil::StringHash, Strutil::StringEqual, 8>
 #else
-typedef boost::unordered_map <string_view, ustring::TableRep *, Strutil::StringHash, Strutil::StringEqual> UstringTable;
+    boost::unordered_map <string_view, ustring::TableRep *, Strutil::StringHash, Strutil::StringEqual>
 #endif
+{
+ public:
+   ~UstringTable() {
+       for (UstringTable::iterator it = begin(); it != end(); ++it) {
+           ustring::TableRep *rep = it->second;
+           free(rep);
+       }
+   }
+};
 
 std::string ustring::empty_std_string ("");
 


### PR DESCRIPTION
Previously values of this map were only allocated in make_unique()
and never freed afterwards. This isn't harmful, but makes it much
more difficult to troubleshoot possible leaks in software which
uses OpenImageIO,

Added a destructor to UstringTable now which frees memory used
by map values.
