### PR TITLE
Fixes for OpenJpeg/Jpeg2000

### DIFF
--- a/src/cmake/modules/FindOpenJpeg.cmake
+++ b/src/cmake/modules/FindOpenJpeg.cmake
@@ -67,6 +67,7 @@ set (OpenJpeg_include_paths
 
 set (OpenJpeg_library_paths
   /usr/lib
+  /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}
   /usr/local/lib
   /sw/lib
   /opt/local/lib)


### PR DESCRIPTION
There are couple of things here:

First of all, make OIIO look for j2k libraries in the multiarch folder on linux

Second of all, it seems alpha wasn't handled totally correct as we believe. This in fact was already submitted and some initial discussion started in #943 but while preparing other patches i needed to update master branch, which closed the original pull request. Not sure i can point existing pull-request to a different branch, so made a new pull-request from a dedicated branch.

Would be cool to nail down what's the proper way to deal with alpha in j2k :)