### PR TITLE
ROI improvement -- make instersection/union robust to uninitialized arguments

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -110,10 +110,13 @@ set_roi_full (ImageSpec &spec, const ROI &newroi)
 ROI
 roi_union (const ROI &A, const ROI &B)
 {
-    return ROI (std::min (A.xbegin, B.xbegin), std::max (A.xend, B.xend),
-                std::min (A.ybegin, B.ybegin), std::max (A.yend, B.yend),
-                std::min (A.zbegin, B.zbegin), std::max (A.zend, B.zend),
-                std::min (A.chbegin, B.chbegin), std::max (A.chend, B.chend));
+    ROI R (A.defined() ? A : B);
+    if (A.defined() && B.defined())
+        R = ROI (std::min (R.xbegin,  B.xbegin),  std::max (R.xend,  B.xend),
+                 std::min (R.ybegin,  B.ybegin),  std::max (R.yend,  B.yend),
+                 std::min (R.zbegin,  B.zbegin),  std::max (R.zend,  B.zend),
+                 std::min (R.chbegin, B.chbegin), std::max (R.chend, B.chend));
+    return R;
 }
 
 
@@ -121,10 +124,13 @@ roi_union (const ROI &A, const ROI &B)
 ROI
 roi_intersection (const ROI &A, const ROI &B)
 {
-    return ROI (std::max (A.xbegin, B.xbegin), std::min (A.xend, B.xend),
-                std::max (A.ybegin, B.ybegin), std::min (A.yend, B.yend),
-                std::max (A.zbegin, B.zbegin), std::min (A.zend, B.zend),
-                std::max (A.chbegin, B.chbegin), std::min (A.chend, B.chend));
+    ROI R (A.defined() ? A : B);
+    if (A.defined() && B.defined())
+        R = ROI (std::max (R.xbegin,  B.xbegin),  std::min (R.xend,  B.xend),
+                 std::max (R.ybegin,  B.ybegin),  std::min (R.yend,  B.yend),
+                 std::max (R.zbegin,  B.zbegin),  std::min (R.zend,  B.zend),
+                 std::max (R.chbegin, B.chbegin), std::min (R.chend, B.chend));
+    return R;
 }
 
 


### PR DESCRIPTION
This ensures that an "undefined" ROI intersected or unioned with a valid one produces the expected result (i.e., returning the valid one).
