### PR TITLE
don't link Python framework on OS X

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -84,7 +84,12 @@ if (BOOST_CUSTOM OR Boost_FOUND AND PYTHONLIBS_FOUND)
 
     include_directories (${PYTHON_INCLUDE_PATH} ${Boost_INCLUDE_DIRS})
     add_library (${target_name} MODULE ${python_srcs})
-    target_link_libraries (${target_name} OpenImageIO ${Boost_LIBRARIES} ${Boost_PYTHON_LIBRARIES} ${PYTHON_LIBRARIES} ${CMAKE_DL_LIBS})
+    if (APPLE)
+        target_link_libraries (${target_name} OpenImageIO ${Boost_LIBRARIES} ${Boost_PYTHON_LIBRARIES} ${CMAKE_DL_LIBS})
+        set_target_properties (${target_name} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+    else ()
+        target_link_libraries (${target_name} OpenImageIO ${Boost_LIBRARIES} ${Boost_PYTHON_LIBRARIES} ${PYTHON_LIBRARIES} ${CMAKE_DL_LIBS})
+    endif ()
 
     # Exclude the 'lib' prefix from the name
     if(NOT PYLIB_LIB_PREFIX)


### PR DESCRIPTION
Instead of explicitly linking to a Python framework, use -undefined
dynamic_lookup so that Python symbols are resolved at module load time
and not at build time. Without this change, importing the module from a
different Python than to which the module is linked segfaults the Python
interpreter.