### PR TITLE
Add destroy() methods to ImageInput and ImageOutput.

### DIFF
--- a/src/doc/imageinput.tex
+++ b/src/doc/imageinput.tex
@@ -25,7 +25,7 @@ out its resolution, and read the pixels (converting them into
         std::vector<unsigned char> pixels (xres*yres*channels);
         in->read_image (TypeDesc::UINT8, &pixels[0]);
         in->close ();
-        delete in;
+        ImageInput::destroy (in);
 \end{code}
 
 \noindent Here is a breakdown of what work this code is doing:
@@ -69,7 +69,7 @@ out its resolution, and read the pixels (converting them into
   the plugin.
   \begin{code}
         in->close ();
-        delete in;
+        ImageInput::destroy (in);
   \end{code}
 \end{itemize}
 
@@ -573,7 +573,7 @@ multi-image files:
         // to find a next MIP level.
 
         in->close ();
-        delete in;
+        ImageInput::destroy (in);
 \end{code}
 
 In this example, we have used \readimage, but of course \readscanline
@@ -716,7 +716,7 @@ a file and print all its values:
         }
     }
     in->close ();
-    delete in;
+    ImageInput::destroy (in);
 \end{code}
 
 
@@ -783,17 +783,17 @@ elaborated with error checking and reporting:
         if (! in->read_image (TypeDesc::UINT8, pixels)) {
             std::cerr << "Could not read pixels from " << filename 
                       << ", error = " << in->geterror() << "\n";
-            delete in;
+            ImageInput::destroy (in);
             return;
         }
 
         if (! in->close ()) {
             std::cerr << "Error closing " << filename 
                       << ", error = " << in->geterror() << "\n";
-            delete in;
+            ImageInput::destroy (in);
             return;
         }
-        delete in;
+        ImageInput::destroy (in);
 \end{code}
 
 
@@ -830,6 +830,17 @@ DSO/DLL's (not a searchpath for the image itself!).  This will
 actually just try every ImageIO plugin it can locate, until it
 finds one that's able to open the file without error.  This just
 creates the \ImageInput, it does not open the file.
+\apiend
+
+\apiitem{void {\ce destroy} (ImageInput *input)}
+\NEW  % 1.6
+
+Destroy an \ImageInput that was created by {\cf create()} or {\cf open()}.
+The {\cf destroy()} method is just a wrapper around operator {\cf delete},
+but by being implemented within the \product DLL, it can ensure that the
+memory deallocation is done in the same DLL arena as where it was originally
+allocated. This is considered safer than a bare {\cf delete} when
+used inside ``plug-ins,'' especially on Windows systems.
 \apiend
 
 \apiitem{const char * {\ce format_name} (void) const}

--- a/src/doc/imageoutput.tex
+++ b/src/doc/imageoutput.tex
@@ -27,7 +27,7 @@ to a file:
         out->open (filename, spec);
         out->write_image (TypeDesc::UINT8, pixels);
         out->close ();
-        delete out;
+        ImageOutput::destroy (out);
 \end{code}
 
 \noindent This little bit of code does a surprising amount of useful work:  
@@ -62,7 +62,7 @@ to a file:
   the plugin.
   \begin{code}
         out->close ();
-        delete out;
+        ImageOutput::destroy (out);
   \end{code}
 \end{itemize}
 
@@ -854,7 +854,7 @@ completed.  Here is an example:
         if (subimages > 1 &&  (! out->supports("multiimage") ||
                                ! out->supports("appendsubimage"))) {
             std::cerr << "Does not support appending of subimages\n";
-            delete out;
+            ImageOutput::destroy (out);
             return;
         }
 
@@ -869,7 +869,7 @@ completed.  Here is an example:
             appendmode = ImageOutput::AppendSubimage;
         }
         out->close ();
-        delete out;
+        ImageOutput::destroy (out);
 \end{code}
 
 
@@ -897,7 +897,7 @@ specification of the subimages at the time you first open the file.
         // Be sure we can support subimages
         if (subimages > 1 && ! out->supports ("multiimage")) {
             std::cerr << "Cannot write multiple subimages\n";
-            delete out;
+            ImageOutput::destroy (out);
             return;
         }
 
@@ -911,7 +911,7 @@ specification of the subimages at the time you first open the file.
             out->write_image (TypeDesc::UINT8, pixels[s]);
         }
         out->close ();
-        delete out;
+        ImageOutput::destroy (out);
 \end{code}
 
 In both of these examples, we have used \writeimage, but of course
@@ -959,7 +959,7 @@ used for texture mapping):
         // Be sure we can support either mipmaps or subimages
         if (! out->supports ("mipmap") && ! out->supports ("multiimage")) {
             std::cerr << "Cannot write a MIP-map\n";
-            delete out;
+            ImageOutput::destroy (out);
             return;
         }
         // Set up spec for the highest resolution
@@ -988,7 +988,7 @@ used for texture mapping):
                 appendmode = ImageOutput::AppendSubimage;
         }
         out->close ();
-        delete out;
+        ImageOutput::destroy (out);
 \end{code}
 
 In this example, we have used \writeimage, but of course \writescanline,
@@ -1028,7 +1028,7 @@ a Z channel in {\cf float}:
 
         // Double check that this format accepts per-channel formats
         if (! out->supports("channelformats")) {
-            delete out;
+            ImageOutput::destroy (out);
             return;
         }
 
@@ -1161,7 +1161,7 @@ deep data in a special {\cf DeepData} structure, defined in
     out->open (filename, spec);
     out->write_deep_image (deepdata);
     out->close ();
-    delete out;
+    ImageOutput::destroy (out);
 \end{code}
 
 
@@ -1214,9 +1214,9 @@ without alteration while modifying the image description metadata:
 
     // Clean up
     out->close ();
-    delete out;
+    ImageOutput::destroy (out);
     in->close ();
-    delete in;
+    ImageInput::destroy (in);
 \end{code}
 
 
@@ -1300,25 +1300,25 @@ elaborated with error checking and reporting:
         if (! out->open (filename, spec)) {
             std::cerr << "Could not open " << filename 
                       << ", error = " << out->geterror() << "\n";
-            delete out;
+            ImageOutput::destroy (out);
             return;
         }
 
         if (! out->write_image (TypeDesc::UINT8, pixels)) {
             std::cerr << "Could not write pixels to " << filename 
                       << ", error = " << out->geterror() << "\n";
-            delete out;
+            ImageOutput::destroy (out);
             return;
         }
 
         if (! out->close ()) {
             std::cerr << "Error closing " << filename 
                       << ", error = " << out->geterror() << "\n";
-            delete out;
+            ImageOutput::destroy (out);
             return;
         }
 
-        delete out;
+        ImageOutput::destroy (out);
 \end{code}
 
 
@@ -1335,7 +1335,16 @@ returned, and the plugin that contains its methods) is inferred from the
 extension of the file name.  The {\kw plugin_searchpath} parameter is a
 colon-separated list of directories to search for \product plugin
 DSO/DLL's.
+\apiend
 
+\apiitem{void {\ce destroy} (ImageOutput *Output)}
+\NEW  % 1.6
+Destroy an \ImageOutput that was created by {\cf create()}.
+The {\cf destroy()} method is just a wrapper around operator {\cf delete},
+but by being implemented within the \product DLL, it can ensure that the
+memory deallocation is done in the same DLL arena as where it was originally
+allocated. This is considered safer than a bare {\cf delete} when
+used inside ``plug-ins,'' especially on Windows systems.
 \apiend
 
 \apiitem{const char * {\ce format_name} ()}

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -93,7 +93,7 @@
 }
 \date{{\large 
 %Editor: Larry Gritz \\[2ex]
-Date: 28 Mar 2015
+Date: 31 Mar 2015
 % \\ (with corrections, 7 Jan 2015)
 }}
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -463,6 +463,14 @@ public:
     static ImageInput *create (const std::string &filename,
                                const std::string &plugin_searchpath="");
 
+    /// Destroy an ImageInput that was created using ImageInput::create() or
+    /// the static open(). For some systems (Windows, I'm looking at you),
+    /// it is not necessarily safe to allocate memory in one DLL and free it
+    /// in another, so directly calling 'delete' on an ImageInput allocated
+    /// by create() or open() may be unusafe, but passing it to destroy()
+    /// should be safe.
+    static void destroy (ImageInput *x);
+
     ImageInput () { }
     virtual ~ImageInput () { }
 
@@ -840,6 +848,13 @@ public:
     /// does not open the file.
     static ImageOutput *create (const std::string &filename,
                                 const std::string &plugin_searchpath="");
+
+    /// Destroy an ImageOutput that was created using ImageOutput::create().
+    /// For some systems (Windows, I'm looking at you), it is not
+    /// necessarily safe to allocate memory in one DLL and free it in
+    /// another, so directly calling 'delete' on an ImageOutput allocated by
+    /// create() may be unusafe, but passing it to destroy() should be safe.
+    static void destroy (ImageOutput *x);
 
     ImageOutput () { }
     virtual ~ImageOutput () { }

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -395,6 +395,14 @@ ImageOutput::create (const std::string &filename,
 
 
 
+void
+ImageOutput::destroy (ImageOutput *x)
+{
+    delete x;
+}
+
+
+
 ImageInput *
 ImageInput::create (const std::string &filename, 
                     const std::string &plugin_searchpath)
@@ -544,6 +552,15 @@ ImageInput::create (const std::string &filename,
 
     return (ImageInput *) create_function();
 }
+
+
+
+void
+ImageInput::destroy (ImageInput *x)
+{
+    delete x;
+}
+
 
 }
 OIIO_NAMESPACE_EXIT


### PR DESCRIPTION
This is helpful on Windows if OIIO is used within plugins (DLLs) that may be loaded and unloaded. It can be problematic to have memory allocated (as is done by ImageOutput::create()) on one side of a DLL boundary, and then freed on the other side of the DLL boundary (as would happen with an ordinary 'delete'). Instead, prefer to get rid of ImageInput*'s and ImageOutput*'s by calling destroy().

If this solves the problem, I think it's safe to backport to 1.5 without breaking compatibility, because it only adds static methods to these classes and doesn't change any previously existing API calls or class structure layout.

