### PR TITLE
Deal with older version of libopenjpeg not having icc fields.

### DIFF
--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -278,9 +278,15 @@ Jpeg2000Input::open (const std::string &p_name, ImageSpec &p_spec)
     m_spec.attribute ("oiio:BitsPerSample", maxPrecision);
     m_spec.attribute ("oiio:Orientation", 1);
     m_spec.attribute ("oiio:ColorSpace", "sRGB");
+#ifndef OPENJPEG_VERSION
+    // Sigh... openjpeg.h doesn't seem to have a clear version #define.
+    // OPENJPEG_VERSION only seems to exist in 1.3, which doesn't have
+    // the ICC fields. So assume its absence in the newer one (at least,
+    // 1.5) means the field is valid.
     if (m_image->icc_profile_len && m_image->icc_profile_buf)
         m_spec.attribute ("ICCProfile", TypeDesc(TypeDesc::UINT8,m_image->icc_profile_len),
                           m_image->icc_profile_buf);
+#endif
 
     p_spec = m_spec;
     return true;

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -335,11 +335,17 @@ Jpeg2000Output::create_jpeg2000_image()
     m_image->x1 = m_compression_parameters.image_offset_x0 + (m_spec.width - 1) * m_compression_parameters.subsampling_dx + 1;
     m_image->y1 = m_compression_parameters.image_offset_y0 + (m_spec.height - 1) * m_compression_parameters.subsampling_dy + 1;
 
+#ifndef OPENJPEG_VERSION
+    // Sigh... openjpeg.h doesn't seem to have a clear version #define.
+    // OPENJPEG_VERSION only seems to exist in 1.3, which doesn't have
+    // the ICC fields. So assume its absence in the newer one (at least,
+    // 1.5) means the field is valid.
     const ImageIOParameter *icc = m_spec.find_attribute ("ICCProfile");
     if (icc && icc->type().basetype == TypeDesc::UINT8 && icc->type().arraylen > 0) {
         m_image->icc_profile_len = icc->type().arraylen;
         m_image->icc_profile_buf = (unsigned char *) icc->data();
     }
+#endif
 
     return m_image;
 }


### PR DESCRIPTION
And having no principled way to detect the version from the header.