### PR TITLE
Fixes for windows compilation

### DIFF
--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -116,7 +116,7 @@
 // Caveat: Programmers are notoriously bad at guessing this, so it
 // should be used only with thorough benchmarking.
 #ifdef __GNUC__
-#define OIIO_LIKELY(x)   (__builtin_expect((x), 1))
+#define OIIO_LIKELY(x)   (__builtin_expect(!!(x), 1))
 #define OIIO_UNLIKELY(x) (__builtin_expect((x), 0))
 #else
 #define OIIO_LIKELY(x)   (x)

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -67,6 +67,18 @@
 #include <malloc.h> // for alloca
 #endif
 
+#ifdef _WIN32
+# ifndef WIN32_LEAN_AND_MEAN
+#   define WIN32_LEAN_AND_MEAN
+# endif
+# ifndef VC_EXTRALEAN
+#   define VC_EXTRALEAN
+# endif
+# ifndef NOMINMAX
+#   define NOMINMAX
+# endif
+# include <windows.h>
+#endif
 
 
 // Detect if we're C++11

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -122,6 +122,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "platform.h"
 #include "oiioversion.h"
 
+#include <algorithm>
+
 
 OIIO_NAMESPACE_ENTER {
 

--- a/src/include/OpenImageIO/timer.h
+++ b/src/include/OpenImageIO/timer.h
@@ -38,9 +38,10 @@
 
 #include "oiioversion.h"
 #include "export.h"
+#include "platform.h"    /* Must be before windows.h */
 
 #ifdef _WIN32
-# include "osdep.h"
+# include <windows.h>
 #elif defined(__APPLE__)
 # include <mach/mach_time.h>
 #else

--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -42,7 +42,7 @@
 #endif
 
 // included to remove std::min/std::max errors
-#include "OpenImageIO/osdep.h"
+#include "OpenImageIO/platform.h"
 
 #include <vector>
 

--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -42,7 +42,7 @@
 #endif
 
 // included to remove std::min/std::max errors
-#include "OpenImageIO/osdep.h"
+#include "OpenImageIO/platform.h"
 
 #include <vector>
 

--- a/src/libutil/farmhash.cpp
+++ b/src/libutil/farmhash.cpp
@@ -76,18 +76,6 @@
 #define STATIC_INLINE static inline
 #endif
 
-// FARMHASH PORTABILITY LAYER: LIKELY and UNLIKELY
-
-#if !defined(LIKELY)
-#if defined(FARMHASH_NO_BUILTIN_EXPECT) || (defined(FARMHASH_OPTIONAL_BUILTIN_EXPECT) && !defined(HAVE_BUILTIN_EXPECT))
-#define LIKELY(x) (x)
-#else
-#define LIKELY(x) (__builtin_expect(!!(x), 1))
-#endif
-#endif
-
-#undef UNLIKELY
-#define UNLIKELY(x) !LIKELY(!(x))
 
 // FARMHASH PORTABILITY LAYER: endianness and byteswapping functions
 
@@ -1846,7 +1834,7 @@ uint128_t CityHash128WithSeed(const char *s, size_t len, uint128_t seed) {
     std::swap(z, x);
     s += 64;
     len -= 128;
-  } while (LIKELY(len >= 128));
+  } while (OIIO_LIKELY(len >= 128));
   x += Rotate(v.first + z, 49) * k0;
   y = y * k0 + Rotate(w.second, 37);
   z = z * k0 + Rotate(w.first, 27);

--- a/src/libutil/plugin.cpp
+++ b/src/libutil/plugin.cpp
@@ -31,9 +31,9 @@
 #include <cstdlib>
 #include <string>
 
-#ifdef _WIN32
-# include "OpenImageIO/osdep.h"
-#else
+#include "OpenImageIO/platform.h"
+
+#ifndef _WIN32
 # include <dlfcn.h>
 #endif
 

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -58,8 +58,9 @@
 # include <sys/sysctl.h>
 #endif
 
+#include "OpenImageIO/platform.h"
+
 #ifdef _WIN32
-# include "OpenImageIO/osdep.h"
 # include <Psapi.h>
 #else
 # include <sys/resource.h>


### PR DESCRIPTION
* The recently-added farmhash uses a 'LIKELY' macro that conflicts with something in Windows land. Replace it with our OIIO_LIKELY defined in platform.h.

* To fix recurrent min/max conflicts, move the magic symbols that fix it into platform.h. In the process, noticed that osdep.h exists only to fix that problem, it predates platform.h and clearly that's where it should be. So change all other references to osdep.h to include platform.h. We will eventually remove osdep.h when we are confident that no user programs are likely to reference it.

* simd.h can, if not at sufficiently high level of SSE support, use std::min and std::max. So we need to include <algorithm> to ensure those are defined.

