### PR TITLE
Fix unit test methodology regarding NULL pointers

### DIFF
--- a/src/libOpenImageIO/imagespec_test.cpp
+++ b/src/libOpenImageIO/imagespec_test.cpp
@@ -223,12 +223,12 @@ test_get_attribute ()
     OIIO_CHECK_EQUAL (spec.get_int_attribute("bar"), 0);
     OIIO_CHECK_EQUAL (spec.get_int_attribute("bar"), 0);
     OIIO_CHECK_EQUAL (spec.get_string_attribute("bar"), "barbarbar?");
-    OIIO_CHECK_NE    (spec.find_attribute("foo"), NULL);
-    OIIO_CHECK_NE    (spec.find_attribute("Foo"), NULL);
-    OIIO_CHECK_NE    (spec.find_attribute("Foo", TypeDesc::UNKNOWN, false), NULL);
-    OIIO_CHECK_EQUAL (spec.find_attribute("Foo", TypeDesc::UNKNOWN, true), NULL);
-    OIIO_CHECK_NE    (spec.find_attribute("foo", TypeDesc::INT), NULL);
-    OIIO_CHECK_EQUAL (spec.find_attribute("foo", TypeDesc::FLOAT), NULL);
+    OIIO_CHECK_ASSERT(spec.find_attribute("foo") != NULL);
+    OIIO_CHECK_ASSERT(spec.find_attribute("Foo") != NULL);
+    OIIO_CHECK_ASSERT(spec.find_attribute("Foo", TypeDesc::UNKNOWN, false) != NULL);
+    OIIO_CHECK_ASSERT(spec.find_attribute("Foo", TypeDesc::UNKNOWN, true) == NULL);
+    OIIO_CHECK_ASSERT(spec.find_attribute("foo", TypeDesc::INT) != NULL);
+    OIIO_CHECK_ASSERT(spec.find_attribute("foo", TypeDesc::FLOAT) == NULL);
 }
 
 


### PR DESCRIPTION
Use OIIO_CHECK_ASSERT(foo != NULL), not OIIO_CHECK_EQUAL(foo,NULL)
because the latter can try to print the NULL, which on some platforms
could be a problem depending on exactly how NULL is defined.