### PR TITLE
Overhaul OIIO_DISPATCH_COMMON macros

### DIFF
--- a/src/doc/imagebuf.tex
+++ b/src/doc/imagebuf.tex
@@ -441,8 +441,11 @@ CAUTION.
 
 \section{Copying \ImageBuf's and blocks of pixels}
 
-\apiitem{bool copy (const ImageBuf \&src)}
+\apiitem{bool {\ce copy} (const ImageBuf \&src) \\
+bool {\ce copy} (const ImageBuf \&src, TypeDesc format)}
 Copies {\cf src} to {\cf this} -- both pixel values and all metadata.
+If a {\cf format} is provided, {\cf this} will get the specified pixel
+data type rather than using the same pixel format as {\cf src}.
 \apiend
 
 \apiitem{void copy_metadata (const ImageBuf \&src)}

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -1315,15 +1315,23 @@ Replace the pixels in this \ImageBuf with the values from the other
 \ImageBuf.
 \apiend
 
-\apiitem{ImageBuf.{\ce copy} (other_imagebuf)}
+\apiitem{ImageBuf.{\ce copy} (other_imagebuf) \\
+ImageBuf.{\ce copy} (other_imagebuf, format)}
 Make this \ImageBuf a complete copy of the other \ImageBuf.
+If a {\cf format} is provided, {\cf this} will get the specified pixel
+data type rather than using the same pixel format as the source \ImageBuf.
 
 \noindent Example:
 \begin{code}
-    A = ImageBuf()
-    B = ImageBuf("B.tif")
-    A.copy (B)
-    # Now A is a separate, duplicate copy of "B.tif"
+    A = ImageBuf("A.tif")
+
+    # Make a separate, duplicate copy of A
+    B = ImageBuf()
+    B.copy (A)
+
+    # Make another copy of A, but converting to float pixels
+    C = ImageBuf()
+    C.copy (A, OIIO.FLOAT)
 \end{code}
 \apiend
 

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -338,6 +338,9 @@ public:
     /// converted automatically to the data type of the app buffer.
     bool copy (const ImageBuf &src);
 
+    /// copy(src), but with optional override of pixel data type
+    bool copy (const ImageBuf &src, TypeDesc format /*= TypeDesc::UNKNOWN*/);
+
     /// Swap with another ImageBuf
     void swap (ImageBuf &other) { std::swap (m_impl, other.m_impl); }
 

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -106,8 +106,6 @@ namespace ImageBufAlgo {
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
 ///
-/// Works on all pixel data types.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API zero (ImageBuf &dst, ROI roi=ROI::All(), int nthreads=0);
@@ -134,8 +132,6 @@ bool OIIO_API zero (ImageBuf &dst, ROI roi=ROI::All(), int nthreads=0);
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works on all pixel data types.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -165,8 +161,6 @@ bool OIIO_API fill (ImageBuf &dst, const float *topleft, const float *topright,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works on all pixel data types.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -203,8 +197,6 @@ bool OIIO_API checker (ImageBuf &dst, int width, int height, int depth,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works on all pixel data types.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -269,8 +261,6 @@ bool OIIO_API channel_append (ImageBuf &dst, const ImageBuf &A,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works on all pixel data types.
 bool OIIO_API flatten (ImageBuf &dst, const ImageBuf &src,
                        ROI roi = ROI::All(), int nthreads = 0);
 
@@ -281,8 +271,6 @@ bool OIIO_API flatten (ImageBuf &dst, const ImageBuf &src,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works on all pixel data types.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -299,8 +287,6 @@ bool OIIO_API crop (ImageBuf &dst, const ImageBuf &src,
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
 ///
-/// Works on all pixel data types.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API cut (ImageBuf &dst, const ImageBuf &src,
@@ -316,8 +302,6 @@ bool OIIO_API cut (ImageBuf &dst, const ImageBuf &src,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works on all pixel data types.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -344,8 +328,6 @@ bool OIIO_API paste (ImageBuf &dst, int xbegin, int ybegin,
 /// global OIIO attribute "nthreads".  If nthreads == 1, it guarantees that
 /// it will not launch any new threads.
 ///
-/// Works on all pixel data types.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API rotate90 (ImageBuf &dst, const ImageBuf &src,
@@ -367,8 +349,6 @@ bool OIIO_API rotate90 (ImageBuf &dst, const ImageBuf &src,
 /// used, but it's not a guarantee.  If nthreads == 0, it will use the
 /// global OIIO attribute "nthreads".  If nthreads == 1, it guarantees that
 /// it will not launch any new threads.
-///
-/// Works on all pixel data types.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -395,8 +375,6 @@ bool OIIO_API flipflop (ImageBuf &dst, const ImageBuf &src,
 /// global OIIO attribute "nthreads".  If nthreads == 1, it guarantees that
 /// it will not launch any new threads.
 ///
-/// Works on all pixel data types.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API rotate270 (ImageBuf &dst, const ImageBuf &src,
@@ -418,8 +396,6 @@ bool OIIO_API rotate270 (ImageBuf &dst, const ImageBuf &src,
 /// used, but it's not a guarantee.  If nthreads == 0, it will use the
 /// global OIIO attribute "nthreads".  If nthreads == 1, it guarantees that
 /// it will not launch any new threads.
-///
-/// Works on all pixel data types.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -443,8 +419,6 @@ bool OIIO_API flip (ImageBuf &dst, const ImageBuf &src,
 /// global OIIO attribute "nthreads".  If nthreads == 1, it guarantees that
 /// it will not launch any new threads.
 ///
-/// Works on all pixel data types.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API flop (ImageBuf &dst, const ImageBuf &src,
@@ -459,8 +433,6 @@ bool OIIO_API flop (ImageBuf &dst, const ImageBuf &src,
 /// used, but it's not a guarantee.  If nthreads == 0, it will use the
 /// global OIIO attribute "nthreads".  If nthreads == 1, it guarantees that
 /// it will not launch any new threads.
-///
-/// Works on all pixel data types.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -484,8 +456,6 @@ bool OIIO_API reorient (ImageBuf &dst, const ImageBuf &src,
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
 ///
-/// Works on all pixel data types.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API transpose (ImageBuf &dst, const ImageBuf &src,
@@ -506,8 +476,6 @@ bool OIIO_API transpose (ImageBuf &dst, const ImageBuf &src,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works on all pixel data types.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -530,8 +498,6 @@ bool OIIO_API circular_shift (ImageBuf &dst, const ImageBuf &src,
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
 ///
-/// Works on all pixel data types.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API clamp (ImageBuf &dst, const ImageBuf &src,
@@ -550,8 +516,6 @@ bool OIIO_API clamp (ImageBuf &dst, const ImageBuf &src,
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
 ///
-/// Works on all pixel data types.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API clamp (ImageBuf &dst, const ImageBuf &src,
@@ -562,7 +526,7 @@ bool OIIO_API clamp (ImageBuf &dst, const ImageBuf &src,
 
 
 /// For all pixels within the designated region, set dst = A + B.
-/// All three images must have the same number of channels.
+/// It is permitted for any of dst, A, or B to be the same image.
 ///
 /// If roi is not initialized, it will be set to the union of the pixel
 /// regions of A and B.  If dst is not initialized, it will be sized
@@ -573,16 +537,14 @@ bool OIIO_API clamp (ImageBuf &dst, const ImageBuf &src,
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
 ///
-/// Works only for pixel types float, half, uint8, uint16.
-/// It is permitted for dst and A to be the same image.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API add (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
                    ROI roi=ROI::All(), int nthreads=0);
 
-/// For all pixels and channels of dst within the designated region, set 
-/// dst = A + B.  (B must point to nchannels floats.)
+/// For all pixels and channels of dst within the designated region, set
+/// dst = A + B.  (B must point to nchannels floats.) It is permitted for
+/// dst and A to be the same image.
 ///
 /// If roi is not initialized, it will be set to the pixel region of A.
 /// If dst is not initialized, it will be sized based on roi.
@@ -591,9 +553,6 @@ bool OIIO_API add (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works for all pixel types. It is permitted for dst and A to be the
-/// same image.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -602,6 +561,7 @@ bool OIIO_API add (ImageBuf &dst, const ImageBuf &A, const float *B,
 
 /// For all pixels and channels of dst within the designated region, set 
 /// dst = A + B.  (B is a single float that is added to all channels.)
+/// It is permitted for dst and A to be the same image.
 ///
 /// If roi is not initialized, it will be set to the pixel region of A.
 /// If dst is not initialized, it will be sized based on roi.
@@ -611,9 +571,6 @@ bool OIIO_API add (ImageBuf &dst, const ImageBuf &A, const float *B,
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
 ///
-/// Works for all pixel types. It is permitted for dst and A to be the
-/// same image.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API add (ImageBuf &dst, const ImageBuf &A, float B,
@@ -621,7 +578,7 @@ bool OIIO_API add (ImageBuf &dst, const ImageBuf &A, float B,
 
 
 /// For all pixels within the designated ROI, compute dst = A - B.
-/// All three images must have the same number of channels.
+/// It is permitted for any of dst, A, or B to be the same image.
 ///
 /// If roi is not initialized, it will be set to the union of the pixel
 /// regions of A and B.  If dst is not initialized, it will be sized
@@ -632,9 +589,6 @@ bool OIIO_API add (ImageBuf &dst, const ImageBuf &A, float B,
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
 ///
-/// Works only for pixel types float, half, uint8, uint16.
-/// It is permitted for dst and A to be the same image.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API sub (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
@@ -642,6 +596,7 @@ bool OIIO_API sub (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
 
 /// For all pixels and channels of dst within the designated region, set 
 /// dst = A - B.  (B must point to nchannels floats.)
+/// It is permitted for dst and A to be the same image.
 ///
 /// If roi is not initialized, it will be set to the pixel region of A.
 /// If dst is not initialized, it will be sized based on roi.
@@ -650,9 +605,6 @@ bool OIIO_API sub (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works for all pixel types. It is permitted for dst and A to be the
-/// same image.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -661,6 +613,7 @@ bool OIIO_API sub (ImageBuf &dst, const ImageBuf &A, const float *B,
 
 /// For all pixels and channels of dst within the designated region, set 
 /// dst = A - B.  (B is a single float that is added to all channels.)
+/// It is permitted for dst and A to be the same image.
 ///
 /// If roi is not initialized, it will be set to the pixel region of A.
 /// If dst is not initialized, it will be sized based on roi.
@@ -670,9 +623,6 @@ bool OIIO_API sub (ImageBuf &dst, const ImageBuf &A, const float *B,
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
 ///
-/// Works for all pixel types. It is permitted for dst and A to be the
-/// same image.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API sub (ImageBuf &dst, const ImageBuf &A, float B,
@@ -680,6 +630,7 @@ bool OIIO_API sub (ImageBuf &dst, const ImageBuf &A, float B,
 
 
 /// For all pixels within the designated ROI, compute dst = abs(A - B).
+/// It is permitted for any of dst, A, or B to be the same image.
 ///
 /// A is an ImageBuf. B may be an ImageBuf (with the same number of channels
 /// as A), or an array of floats (one per channel, for each channel of A),
@@ -694,9 +645,6 @@ bool OIIO_API sub (ImageBuf &dst, const ImageBuf &A, float B,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works only for pixel types float, half, uint8, uint16.
-/// It is permitted for dst and A to be the same image.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -709,6 +657,7 @@ bool OIIO_API absdiff (ImageBuf &dst, const ImageBuf &A, float B,
 
 
 /// For all pixels within the designated ROI, compute dst = abs(A).
+/// It is permitted for dst and A to be the same image.
 ///
 /// If roi is not initialized, it will be set to the pixel data region of A.
 /// If dst is not initialized, it will be sized based on roi. If dst is
@@ -719,9 +668,6 @@ bool OIIO_API absdiff (ImageBuf &dst, const ImageBuf &A, float B,
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
 ///
-/// Works only for pixel types float, half, uint8, uint16.
-/// It is permitted for dst and A to be the same image.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API abs (ImageBuf &dst, const ImageBuf &A,
@@ -730,6 +676,7 @@ bool OIIO_API abs (ImageBuf &dst, const ImageBuf &A,
 
 /// For all pixels within the designated ROI, compute dst = A * B.
 /// All three images must have the same number of channels.
+/// It is permitted for dst and A to be the same image.
 ///
 /// If roi is not initialized, it will be set to the union of the pixel
 /// regions of A and B.  If dst is not initialized, it will be sized
@@ -740,8 +687,6 @@ bool OIIO_API abs (ImageBuf &dst, const ImageBuf &A,
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
 ///
-/// Works only for pixel types float, half, uint8, uint16.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API mul (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
@@ -750,14 +695,12 @@ bool OIIO_API mul (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
 
 /// For all pixels and channels of dst within region roi (defaulting to
 /// all the defined pixels of dst), set dst = A * B.
+/// It is permitted for dst and A to be the same image.
 ///
 /// The nthreads parameter specifies how many threads (potentially) may
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works for all pixel types.  It is permissible for dst and A to be
-/// the same image.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -766,14 +709,12 @@ bool OIIO_API mul (ImageBuf &dst, const ImageBuf &A, float B,
 
 /// For all pixels and channels of dst within region roi (defaulting to
 /// all the defined pixels of dst), set dst = A * B.
+/// It is permitted for dst and A to be the same image.
 ///
 /// The nthreads parameter specifies how many threads (potentially) may
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works for all pixel types.  It is permissible for dst and A to be
-/// the same image.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -783,6 +724,7 @@ bool OIIO_API mul (ImageBuf &dst, const ImageBuf &A, const float *B,
 
 /// For all pixels within the designated ROI, compute dst = A / B.
 /// We define division-by-zero to result in 0.
+/// It is permitted for any of dst, A, or B to be the same image.
 ///
 /// A is an ImageBuf. B may be an ImageBuf (with the same number of channels
 /// as A), or an array of floats (one per channel, for each channel of A),
@@ -797,9 +739,6 @@ bool OIIO_API mul (ImageBuf &dst, const ImageBuf &A, const float *B,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works only for pixel types float, half, uint8, uint16.
-/// It is permitted for dst and A to be the same image.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -813,33 +752,18 @@ bool OIIO_API div (ImageBuf &dst, const ImageBuf &A, float B,
 
 /// For all pixels and channels of dst within region roi (defaulting to
 /// all the defined pixels of dst), set dst = A ^ b. (raise to power)
+/// B may be either a single float (for all channels), or a float* pointing
+/// to one value per channel of A.
 ///
 /// The nthreads parameter specifies how many threads (potentially) may
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works for all pixel types.  It is permissible for dst and A to be
-/// the same image.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API pow (ImageBuf &dst, const ImageBuf &A, float B,
                    ROI roi=ROI::All(), int nthreads=0);
-
-/// For all pixels and channels of dst within region roi (defaulting to
-/// all the defined pixels of R), set R = A ^ b. (raise to power)
-///
-/// The nthreads parameter specifies how many threads (potentially) may
-/// be used, but it's not a guarantee.  If nthreads == 0, it will use
-/// the global OIIO attribute "nthreads".  If nthreads == 1, it
-/// guarantees that it will not launch any new threads.
-///
-/// Works for all pixel types.  It is permissible for dst and A to be
-/// the same image.
-///
-/// Return true on success, false on error (with an appropriate error
-/// message set in dst).
 bool OIIO_API pow (ImageBuf &dst, const ImageBuf &A, const float *B,
                    ROI roi=ROI::All(), int nthreads=0);
 
@@ -855,8 +779,6 @@ bool OIIO_API pow (ImageBuf &dst, const ImageBuf &A, const float *B,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works for all pixel types.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -902,18 +824,15 @@ bool OIIO_API rangeexpand (ImageBuf &dst, const ImageBuf &src,
 
 
 /// Copy pixels within the ROI from src to dst, applying a color transform.
+/// In-place operations (dst == src) are supported.
 ///
 /// If dst is not yet initialized, it will be allocated to the same
 /// size as specified by roi.  If roi is not defined it will be all
 /// of dst, if dst is defined, or all of src, if dst is not yet defined.
 ///
-/// In-place operations (dst == src) are supported.
-///
 /// If unpremult is true, unpremultiply before color conversion, then
 /// premultiply after the color conversion.  You may want to use this
 /// flag if your image contains an alpha channel.
-///
-/// Works with all data types.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -923,19 +842,15 @@ bool OIIO_API colorconvert (ImageBuf &dst, const ImageBuf &src,
                             ROI roi=ROI::All(), int nthreads=0);
 
 /// Copy pixels within the ROI from src to dst, applying an OpenColorIO
-/// "look" transform.
+/// "look" transform. In-place operations (dst == src) are supported.
 ///
 /// If dst is not yet initialized, it will be allocated to the same
 /// size as specified by roi.  If roi is not defined it will be all
 /// of dst, if dst is defined, or all of src, if dst is not yet defined.
 ///
-/// In-place operations (dst == src) are supported.
-///
 /// If unpremult is true, unpremultiply before color conversion, then
 /// premultiply after the color conversion.  You may want to use this
 /// flag if your image contains an alpha channel.
-///
-/// Works with all data types.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -960,8 +875,6 @@ bool OIIO_API ociolook (ImageBuf &dst, const ImageBuf &src,
 /// premultiply after the color conversion.  You may want to use this
 /// flag if your image contains an alpha channel.
 ///
-/// Works with all data types.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API ociodisplay (ImageBuf &dst, const ImageBuf &src,
@@ -972,18 +885,15 @@ bool OIIO_API ociodisplay (ImageBuf &dst, const ImageBuf &src,
                         ROI roi=ROI::All(), int nthreads=0);
 
 /// Copy pixels within the ROI from src to dst, applying a color transform.
+/// In-place operations (dst == src) are supported.
 ///
 /// If dst is not yet initialized, it will be allocated to the same
 /// size as specified by roi.  If roi is not defined it will be all
 /// of dst, if dst is defined, or all of src, if dst is not yet defined.
 ///
-/// In-place operations (dst == src) are supported.
-///
 /// If unpremult is true, unpremultiply before color conversion, then
 /// premultiply after the color conversion.  You may want to use this
 /// flag if your image contains an alpha channel.
-///
-/// Works with all data types.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -1013,8 +923,6 @@ bool OIIO_API colorconvert (float *color, int nchannels,
 /// identified alpha channel (and a no-op if dst and src are the same
 /// image).
 ///
-/// Works with all data types.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API unpremult (ImageBuf &dst, const ImageBuf &src,
@@ -1033,8 +941,6 @@ bool OIIO_API unpremult (ImageBuf &dst, const ImageBuf &src,
 /// For all dst pixels and channels within the ROI, divide all color
 /// channels (those not alpha or z) by the alpha, to "un-premultiply"
 /// them.
-///
-/// Works with all data types.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -1062,8 +968,6 @@ struct OIIO_API PixelStats {
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works for all pixel types.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -1095,8 +999,6 @@ struct CompareResults {
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works for all pixel types.
 ///
 /// Return true on success, false on error.
 bool OIIO_API compare (const ImageBuf &A, const ImageBuf &B,
@@ -1140,8 +1042,6 @@ int OIIO_API compare_Yee (const ImageBuf &A, const ImageBuf &B,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works for all pixel types.
 bool OIIO_API isConstantColor (const ImageBuf &src, float *color = NULL,
                                ROI roi = ROI::All(), int nthreads=0);
 
@@ -1155,8 +1055,6 @@ bool OIIO_API isConstantColor (const ImageBuf &src, float *color = NULL,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works for all pixel types.
 bool OIIO_API isConstantChannel (const ImageBuf &src, int channel, float val,
                                  ROI roi = ROI::All(), int nthreads = 0);
 
@@ -1169,8 +1067,6 @@ bool OIIO_API isConstantChannel (const ImageBuf &src, int channel, float val,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works for all pixel types.
 bool OIIO_API isMonochrome (const ImageBuf &src,
                             ROI roi = ROI::All(), int nthreads = 0);
 
@@ -1191,8 +1087,6 @@ bool OIIO_API isMonochrome (const ImageBuf &src,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works for all pixel types.
 ///
 /// Upon success, return true and store the number of pixels that
 /// matched each color count[..ncolors-1].  If there is an error,
@@ -1219,8 +1113,6 @@ bool OIIO_API color_count (const ImageBuf &src,
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
 ///
-/// Works for all pixel types.
-///
 /// Return true if the operation can be performed, false if there is
 /// some sort of error (and sets an appropriate error message in src).
 bool OIIO_API color_range_check (const ImageBuf &src,
@@ -1240,8 +1132,6 @@ bool OIIO_API color_range_check (const ImageBuf &src,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works for all pixel types.
 OIIO_API ROI nonzero_region (const ImageBuf &src,
                              ROI roi=ROI::All(), int nthreads=0);
 
@@ -1282,8 +1172,6 @@ std::string OIIO_API computePixelHashSHA1 (const ImageBuf &src,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works on all pixel data types.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -1327,8 +1215,6 @@ bool OIIO_API warp (ImageBuf &dst, const ImageBuf &src,
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
 ///
-/// Works on all pixel data types.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API rotate (ImageBuf &dst, const ImageBuf &src, float angle,
@@ -1369,8 +1255,6 @@ bool OIIO_API rotate (ImageBuf &dst, const ImageBuf &src,
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
 ///
-/// Works on all pixel data types.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API resize (ImageBuf &dst, const ImageBuf &src,
@@ -1393,8 +1277,6 @@ bool OIIO_API resize (ImageBuf &dst, const ImageBuf &src,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works on all pixel data types.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -1419,8 +1301,6 @@ bool OIIO_API resize (ImageBuf &dst, const ImageBuf &src,
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
 ///
-/// Works on all pixel data types.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API resample (ImageBuf &dst, const ImageBuf &src,
@@ -1438,9 +1318,6 @@ bool OIIO_API resample (ImageBuf &dst, const ImageBuf &src,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works on any pixel data type for dst and src, but kernel MUST be
-/// a float image.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -1494,8 +1371,6 @@ bool OIIO_API make_kernel (ImageBuf &dst, string_view name,
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
 ///
-/// Works on all pixel data types.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API unsharp_mask (ImageBuf &dst, const ImageBuf &src,
@@ -1521,8 +1396,6 @@ bool OIIO_API unsharp_mask (ImageBuf &dst, const ImageBuf &src,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works on all pixel data types.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -1659,8 +1532,6 @@ bool OIIO_API fixNonFinite (ImageBuf &dst, const ImageBuf &src,
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
 ///
-/// Works on all pixel data types.
-///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
 bool OIIO_API fillholes_pushpull (ImageBuf &dst, const ImageBuf &src,
@@ -1727,8 +1598,6 @@ bool OIIO_API capture_image (ImageBuf &dst, int cameranum = 0,
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use
 /// the global OIIO attribute "nthreads".  If nthreads == 1, it
 /// guarantees that it will not launch any new threads.
-///
-/// Works on all pixel data types.
 bool OIIO_API over (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
                     ROI roi = ROI::All(), int nthreads = 0);
 

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1307,7 +1307,7 @@ ImageBuf::copy_pixels (const ImageBuf &src)
 
 
 bool
-ImageBuf::copy (const ImageBuf &src)
+ImageBuf::copy (const ImageBuf &src, TypeDesc format)
 {
     src.impl()->validate_pixels ();
     if (this == &src)     // self-assignment
@@ -1316,8 +1316,23 @@ ImageBuf::copy (const ImageBuf &src)
         clear();
         return true;
     }
-    reset (src.name(), src.spec());
+    if (format.basetype == TypeDesc::UNKNOWN)
+        reset (src.name(), src.spec());
+    else {
+        ImageSpec newspec (src.spec());
+        newspec.set_format (format);
+        newspec.channelformats.clear ();
+        reset (src.name(), newspec);
+    }
     return this->copy_pixels (src);
+}
+
+
+
+bool
+ImageBuf::copy (const ImageBuf &src)
+{
+    return copy (src, TypeDesc::UNKNOWN);
 }
 
 

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -291,7 +291,7 @@ ImageBufAlgo::convolve (ImageBuf &dst, const ImageBuf &src,
         Ktmp.copy (kernel, TypeDesc::FLOAT);
         K = &Ktmp;
     }
-    OIIO_DISPATCH_TYPES2 (ok, "convolve", convolve_,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "convolve", convolve_,
                           dst.spec().format, src.spec().format,
                           dst, src, kernel, normalize, roi, nthreads);
     return ok;

--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -195,7 +195,7 @@ ImageBufAlgo::add (ImageBuf &dst, const ImageBuf &A, const float *b,
     if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "add", add_impl, dst.spec().format,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "add", add_impl, dst.spec().format,
                           A.spec().format, dst, A, b, roi, nthreads);
     return ok;
 }
@@ -213,7 +213,7 @@ ImageBufAlgo::add (ImageBuf &dst, const ImageBuf &A, float b,
     for (int c = 0;  c < nc;  ++c)
         vals[c] = b;
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "add", add_impl, dst.spec().format,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "add", add_impl, dst.spec().format,
                           A.spec().format, dst, A, vals, roi, nthreads);
     return ok;
 }
@@ -274,7 +274,7 @@ ImageBufAlgo::sub (ImageBuf &dst, const ImageBuf &A, const float *b,
     for (int c = 0;  c < nc;  ++c)
         vals[c] = -b[c];
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "sub", add_impl, dst.spec().format,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "sub", add_impl, dst.spec().format,
                           A.spec().format, dst, A, vals, roi, nthreads);
     return ok;
 }
@@ -292,7 +292,7 @@ ImageBufAlgo::sub (ImageBuf &dst, const ImageBuf &A, float b,
     for (int c = 0;  c < nc;  ++c)
         vals[c] = -b;
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "sub", add_impl, dst.spec().format,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "sub", add_impl, dst.spec().format,
                           A.spec().format, dst, A, vals, roi, nthreads);
     return ok;
 }
@@ -374,7 +374,7 @@ ImageBufAlgo::absdiff (ImageBuf &dst, const ImageBuf &A, const float *b,
     if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "absdiff", absdiff_impl, dst.spec().format,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "absdiff", absdiff_impl, dst.spec().format,
                           A.spec().format, dst, A, b, roi, nthreads);
     return ok;
 }
@@ -392,7 +392,7 @@ ImageBufAlgo::absdiff (ImageBuf &dst, const ImageBuf &A, float b,
     for (int c = 0;  c < nc;  ++c)
         vals[c] = b;
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "absdiff", absdiff_impl, dst.spec().format,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "absdiff", absdiff_impl, dst.spec().format,
                           A.spec().format, dst, A, vals, roi, nthreads);
     return ok;
 }
@@ -480,7 +480,7 @@ ImageBufAlgo::mul (ImageBuf &dst, const ImageBuf &A, const float *b,
     if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "mul", mul_impl, dst.spec().format,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "mul", mul_impl, dst.spec().format,
                           A.spec().format, dst, A, b, roi, nthreads);
     return ok;
 }
@@ -498,7 +498,7 @@ ImageBufAlgo::mul (ImageBuf &dst, const ImageBuf &A, float b,
     for (int c = 0;  c < nc;  ++c)
         vals[c] = b;
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "mul", mul_impl, dst.spec().format,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "mul", mul_impl, dst.spec().format,
                           A.spec().format, dst, A, vals, roi, nthreads);
     return ok;
 }
@@ -561,7 +561,7 @@ ImageBufAlgo::div (ImageBuf &dst, const ImageBuf &A, const float *b,
     for (int c = 0; c < nc; ++c)
         binv[c] = (b[c] == 0.0f) ? 1.0f : 1.0f/b[c];
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "div", mul_impl, dst.spec().format,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "div", mul_impl, dst.spec().format,
                           A.spec().format, dst, A, binv, roi, nthreads);
     return ok;
 }
@@ -580,7 +580,7 @@ ImageBufAlgo::div (ImageBuf &dst, const ImageBuf &A, float b,
     for (int c = 0;  c < nc;  ++c)
         binv[c] = b;
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "div", mul_impl, dst.spec().format,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "div", mul_impl, dst.spec().format,
                           A.spec().format, dst, A, binv, roi, nthreads);
     return ok;
 }
@@ -616,7 +616,7 @@ ImageBufAlgo::pow (ImageBuf &dst, const ImageBuf &A, const float *b,
     if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "pow", pow_impl, dst.spec().format,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "pow", pow_impl, dst.spec().format,
                           A.spec().format, dst, A, b, roi, nthreads);
     return ok;
 }
@@ -634,7 +634,7 @@ ImageBufAlgo::pow (ImageBuf &dst, const ImageBuf &A, float b,
     for (int c = 0;  c < nc;  ++c)
         vals[c] = b;
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "pow", pow_impl, dst.spec().format,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "pow", pow_impl, dst.spec().format,
                           A.spec().format, dst, A, vals, roi, nthreads);
     return ok;
 }
@@ -896,7 +896,7 @@ ImageBufAlgo::rangecompress (ImageBuf &dst, const ImageBuf &src,
     if (! IBAprep (roi, &dst, &src, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "rangecompress", rangecompress_,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "rangecompress", rangecompress_,
                           dst.spec().format, src.spec().format,
                           dst, src, useluma, roi, nthreads);
     return ok;
@@ -915,7 +915,7 @@ ImageBufAlgo::rangeexpand (ImageBuf &dst, const ImageBuf &src,
     if (! IBAprep (roi, &dst, &src, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "rangeexpand", rangeexpand_,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "rangeexpand", rangeexpand_,
                           dst.spec().format, src.spec().format,
                           dst, src, useluma, roi, nthreads);
     return ok;
@@ -982,7 +982,7 @@ ImageBufAlgo::unpremult (ImageBuf &dst, const ImageBuf &src,
         return true;
     }
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "unpremult", unpremult_, dst.spec().format,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "unpremult", unpremult_, dst.spec().format,
                           src.spec().format, dst, src, roi, nthreads);
     return ok;
 }
@@ -1043,7 +1043,7 @@ ImageBufAlgo::premult (ImageBuf &dst, const ImageBuf &src,
         return true;
     }
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "premult", premult_, dst.spec().format,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "premult", premult_, dst.spec().format,
                           src.spec().format, dst, src, roi, nthreads);
     return ok;
 }

--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -177,7 +177,7 @@ bool
 ImageBufAlgo::add (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
                    ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &A, &B))
+    if (! IBAprep (roi, &dst, &A, &B, NULL, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
     OIIO_DISPATCH_COMMON_TYPES3 (ok, "add", add_impl, dst.spec().format,
@@ -192,7 +192,7 @@ bool
 ImageBufAlgo::add (ImageBuf &dst, const ImageBuf &A, const float *b,
                    ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &A))
+    if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
     OIIO_DISPATCH_TYPES2 (ok, "add", add_impl, dst.spec().format,
@@ -206,7 +206,7 @@ bool
 ImageBufAlgo::add (ImageBuf &dst, const ImageBuf &A, float b,
                    ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &A))
+    if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     int nc = A.nchannels();
     float *vals = ALLOCA (float, nc);
@@ -252,7 +252,7 @@ bool
 ImageBufAlgo::sub (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
                    ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &A, &B))
+    if (! IBAprep (roi, &dst, &A, &B, NULL, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
     OIIO_DISPATCH_COMMON_TYPES3 (ok, "sub", sub_impl, dst.spec().format,
@@ -267,7 +267,7 @@ bool
 ImageBufAlgo::sub (ImageBuf &dst, const ImageBuf &A, const float *b,
                    ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &A))
+    if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     int nc = A.nchannels();
     float *vals = ALLOCA (float, nc);
@@ -285,7 +285,7 @@ bool
 ImageBufAlgo::sub (ImageBuf &dst, const ImageBuf &A, float b,
                    ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &A))
+    if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     int nc = A.nchannels();
     float *vals = ALLOCA (float, nc);
@@ -356,7 +356,7 @@ bool
 ImageBufAlgo::absdiff (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
                        ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &A, &B))
+    if (! IBAprep (roi, &dst, &A, &B, NULL, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
     OIIO_DISPATCH_COMMON_TYPES3 (ok, "absdiff", absdiff_impl, dst.spec().format,
@@ -371,7 +371,7 @@ bool
 ImageBufAlgo::absdiff (ImageBuf &dst, const ImageBuf &A, const float *b,
                        ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &A))
+    if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
     OIIO_DISPATCH_TYPES2 (ok, "absdiff", absdiff_impl, dst.spec().format,
@@ -385,7 +385,7 @@ bool
 ImageBufAlgo::absdiff (ImageBuf &dst, const ImageBuf &A, float b,
                        ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &A))
+    if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     int nc = A.nchannels();
     float *vals = ALLOCA (float, nc);
@@ -440,7 +440,7 @@ bool
 ImageBufAlgo::mul (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
                    ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &A, &B))
+    if (! IBAprep (roi, &dst, &A, &B, NULL, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
     OIIO_DISPATCH_COMMON_TYPES3 (ok, "mul", mul_impl, dst.spec().format,
@@ -477,7 +477,7 @@ bool
 ImageBufAlgo::mul (ImageBuf &dst, const ImageBuf &A, const float *b,
                    ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &A))
+    if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
     OIIO_DISPATCH_TYPES2 (ok, "mul", mul_impl, dst.spec().format,
@@ -491,7 +491,7 @@ bool
 ImageBufAlgo::mul (ImageBuf &dst, const ImageBuf &A, float b,
                    ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &A))
+    if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     int nc = A.nchannels();
     float *vals = ALLOCA (float, nc);
@@ -539,7 +539,7 @@ bool
 ImageBufAlgo::div (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
                    ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &A, &B))
+    if (! IBAprep (roi, &dst, &A, &B, NULL, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
     OIIO_DISPATCH_COMMON_TYPES3 (ok, "div", div_impl, dst.spec().format,
@@ -554,7 +554,7 @@ bool
 ImageBufAlgo::div (ImageBuf &dst, const ImageBuf &A, const float *b,
                    ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &A))
+    if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     int nc = dst.nchannels();
     float *binv = OIIO_ALLOCA (float, nc);
@@ -572,7 +572,7 @@ bool
 ImageBufAlgo::div (ImageBuf &dst, const ImageBuf &A, float b,
                    ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &A))
+    if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     b = (b == 0.0f) ? 1.0f : 1.0f/b;
     int nc = dst.nchannels();
@@ -613,7 +613,7 @@ bool
 ImageBufAlgo::pow (ImageBuf &dst, const ImageBuf &A, const float *b,
                    ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &A))
+    if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
     OIIO_DISPATCH_TYPES2 (ok, "pow", pow_impl, dst.spec().format,
@@ -627,7 +627,7 @@ bool
 ImageBufAlgo::pow (ImageBuf &dst, const ImageBuf &A, float b,
                    ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &A))
+    if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     int nc = A.nchannels();
     float *vals = ALLOCA (float, nc);
@@ -893,7 +893,7 @@ ImageBufAlgo::rangecompress (ImageBuf &dst, const ImageBuf &src,
         dst.error ("in-place rangecompress requires the ImageBuf to be initialized");
         return false;
     }
-    if (! IBAprep (roi, &dst, &src))
+    if (! IBAprep (roi, &dst, &src, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
     OIIO_DISPATCH_TYPES2 (ok, "rangecompress", rangecompress_,
@@ -912,7 +912,7 @@ ImageBufAlgo::rangeexpand (ImageBuf &dst, const ImageBuf &src,
         dst.error ("in-place rangeexpand requires the ImageBuf to be initialized");
         return false;
     }
-    if (! IBAprep (roi, &dst))
+    if (! IBAprep (roi, &dst, &src, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
     OIIO_DISPATCH_TYPES2 (ok, "rangeexpand", rangeexpand_,
@@ -973,7 +973,7 @@ bool
 ImageBufAlgo::unpremult (ImageBuf &dst, const ImageBuf &src,
                          ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &src))
+    if (! IBAprep (roi, &dst, &src, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     if (src.spec().alpha_channel < 0) {
         if (&dst != &src)
@@ -1034,7 +1034,7 @@ bool
 ImageBufAlgo::premult (ImageBuf &dst, const ImageBuf &src,
                        ROI roi, int nthreads)
 {
-    if (! IBAprep (roi, &dst, &src))
+    if (! IBAprep (roi, &dst, &src, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     if (src.spec().alpha_channel < 0) {
         if (&dst != &src)

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -397,7 +397,7 @@ ImageBufAlgo::resize (ImageBuf &dst, const ImageBuf &src,
     }
 
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "resize", resize_,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "resize", resize_,
                           dst.spec().format, src.spec().format,
                           dst, src, filter, roi, nthreads);
     return ok;
@@ -448,7 +448,7 @@ ImageBufAlgo::resize (ImageBuf &dst, const ImageBuf &src,
     }
 
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "resize", resize_,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "resize", resize_,
                           dstspec.format, srcspec.format,
                           dst, src, filter.get(), roi, nthreads);
     return ok;
@@ -534,7 +534,7 @@ ImageBufAlgo::resample (ImageBuf &dst, const ImageBuf &src,
             IBAprep_NO_COPY_ROI_FULL))
         return false;
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "resample", resample_,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "resample", resample_,
                           dst.spec().format, src.spec().format,
                           dst, src, interpolate, roi, nthreads);
     return ok;
@@ -644,7 +644,7 @@ ImageBufAlgo::warp (ImageBuf &dst, const ImageBuf &src,
     }
 
     bool ok;
-    OIIO_DISPATCH_TYPES2 (ok, "warp", warp_,
+    OIIO_DISPATCH_COMMON_TYPES2 (ok, "warp", warp_,
                           dst.spec().format, src.spec().format,
                           dst, src, M, filter, wrap, dst_roi, nthreads);
     return ok;

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -137,6 +137,31 @@ ImageBuf_set_write_format (ImageBuf &buf, TypeDesc::BASETYPE format)
 
 
 
+bool
+ImageBuf_copy (ImageBuf &buf, const ImageBuf &src,
+               TypeDesc format = TypeDesc::UNKNOWN)
+{
+    ScopedGILRelease gil;
+    return buf.copy (src, format);
+}
+
+
+bool
+ImageBuf_copy2 (ImageBuf &buf, const ImageBuf &src,
+                TypeDesc::BASETYPE format = TypeDesc::UNKNOWN)
+{
+    ScopedGILRelease gil;
+    return buf.copy (src, format);
+}
+
+
+BOOST_PYTHON_FUNCTION_OVERLOADS(ImageBuf_copy_overloads,
+                                ImageBuf_copy, 2, 3)
+BOOST_PYTHON_FUNCTION_OVERLOADS(ImageBuf_copy2_overloads,
+                                ImageBuf_copy2, 2, 3)
+
+
+
 void
 ImageBuf_set_full (ImageBuf &buf, int xbegin, int xend, int ybegin, int yend,
                    int zbegin, int zend)
@@ -389,7 +414,10 @@ void declare_imagebuf()
 
         .def("copy_metadata", &ImageBuf::copy_metadata)
         .def("copy_pixels", &ImageBuf::copy_pixels)
-        .def("copy", &ImageBuf::copy)
+        .def("copy",  &ImageBuf_copy,
+             ImageBuf_copy_overloads())
+        .def("copy",  &ImageBuf_copy2,
+             ImageBuf_copy2_overloads())
         .def("swap", &ImageBuf::swap)
 
         .def("getchannel", &ImageBuf_getchannel,


### PR DESCRIPTION
Something I was working on a couple weekends ago.

Basically, rewrite the OIIO_DISPATCH_COMMON_TYPES macros (used internally by ImageBufAlgo to specialize for the various combinations of pixel data types when combining images) so that instead of failing when they get uncommon types, they silently auto-convert to a supported type. Thus, these functions may have lower performance when not using one of the preferred types, but now they will never fail for that reason.
