### PR TITLE
Fix occasional NaNs in alpha channel with 3 channel images.

### DIFF
--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -75,12 +75,12 @@ simd::float4 uchar2float4 (const unsigned char *c) {
 }
 
 
-static const OIIO_SIMD4_ALIGN float channel_masks[5][4] = {
-    { 0.0f, 0.0f, 0.0f, 0.0f },
-    { 1.0f, 0.0f, 0.0f, 0.0f },
-    { 1.0f, 1.0f, 0.0f, 0.0f },
-    { 1.0f, 1.0f, 1.0f, 0.0f },
-    { 1.0f, 1.0f, 1.0f, 1.0f }
+static const OIIO_SIMD4_ALIGN mask4 channel_masks[5] = {
+    mask4(false, false, false, false),
+    mask4(true,  false, false, false),
+    mask4(true,  true,  false, false),
+    mask4(true,  true,  true,  false),
+    mask4(true,  true,  true,  true),
 };
 
 }  // end anonymous namespace
@@ -1678,11 +1678,11 @@ TextureSystemImpl::sample_closest (int nsamples, const float *s_,
         accum += weight * texel_simd;
     }
 
-    simd::float4 channel_mask = *(simd::float4 *)(channel_masks[actualchannels]);
-    accum *= channel_mask;
+    simd::mask4 channel_mask = channel_masks[actualchannels];
+    accum = blend0(accum, channel_mask);
     if (nonfill < 1.0f && nchannels_result > actualchannels && options.fill) {
         // Add the weighted fill color
-        accum += ((1.0f - nonfill) * options.fill) * (simd::float4::One() - channel_mask);
+        accum += blend0not(float4((1.0f - nonfill) * options.fill), channel_mask);
     }
 
     *accum_ = accum;
@@ -1953,11 +1953,11 @@ TextureSystemImpl::sample_bilinear (int nsamples, const float *s_,
         }
     }
 
-    simd::float4 channel_mask = *(simd::float4 *)(channel_masks[actualchannels]);
-    accum *= channel_mask;
+    simd::mask4 channel_mask = channel_masks[actualchannels];
+    accum = blend0(accum, channel_mask);
     if (use_fill) {
         // Add the weighted fill color
-        accum += ((1.0f - nonfill) * options.fill) * (simd::float4::One() - channel_mask);
+        accum += blend0not(float4((1.0f - nonfill) * options.fill), channel_mask);
     }
 
     *accum_ = accum;
@@ -2340,11 +2340,11 @@ TextureSystemImpl::sample_bicubic (int nsamples, const float *s_,
         }
     }
 
-    float4 channel_mask = *(simd::float4 *)(channel_masks[actualchannels]);
-    accum *= channel_mask;
+    simd::mask4 channel_mask = channel_masks[actualchannels];
+    accum = blend0(accum, channel_mask);
     if (use_fill) {
         // Add the weighted fill color
-        accum += ((1.0f - nonfill) * options.fill) * (simd::float4::One() - channel_mask);
+        accum += blend0not(float4((1.0f - nonfill) * options.fill), channel_mask);
     }
 
     *accum_ = accum;


### PR DESCRIPTION
We found an issue on Windows where the SIMD texture filtering code would sometimes generate NaNs in the alpha channel for 3 channel images.

What happens is that when doing an SIMD load of 4 floats, the 4th alpha channel value uses uninitialized memory. Note the pixel buffer is made big enough in `ImageCacheTile::memsize_needed()` to avoid reading past the end of the array so that's fine, the problem is uninitialized memory.

When the image size is not a multiple of the tile size, then tiles near the edge contain uninitialized values. Sometimes these are NaN. I don't know if the fact that these are uninitialized is a bug, if so then that should be fixed instead, but I'm not sure where exactly.

Here the fix is to use `blend0()` and `blend0not()` rather than multiplication with zero which doesn't filter out NaNs.

If you want to reliably reproduce this bug, you can apply this patch:
https://github.com/brechtvl/oiio/commit/51119ae23144b688d261f71303bd23dd960aa1f2

And run `testtex` with this image file:
https://github.com/brechtvl/oiio/raw/51119ae23144b688d261f71303bd23dd960aa1f2/green_exr.tex