### PR TITLE
FIX windows build and few minor cmake configure improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,7 @@ endif ()
 
 
 if (MSVC)
+    add_definitions (-DNOMINMAX)
     add_definitions (-D_CRT_SECURE_NO_DEPRECATE)
     add_definitions (-D_CRT_SECURE_NO_WARNINGS)
     add_definitions (-D_CRT_NONSTDC_NO_WARNINGS)

--- a/src/cmake/modules/FindIlmBase.cmake
+++ b/src/cmake/modules/FindIlmBase.cmake
@@ -25,7 +25,7 @@ include (FindPackageHandleStandardArgs)
 include (FindPackageMessage)
 include (SelectLibraryConfigurations)
 
-
+option(ILMBASE_USE_STATIC_LIBS OFF "shared lib built mean specific export config uner windows")
 if( ILMBASE_USE_STATIC_LIBS )
   set( _ilmbase_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
   if(WIN32)
@@ -33,6 +33,8 @@ if( ILMBASE_USE_STATIC_LIBS )
   else()
     set(CMAKE_FIND_LIBRARY_SUFFIXES .a )
   endif()
+else()
+  add_definitions(-DOPENEXR_DLL)
 endif()
 
 # Macro to assemble a helper state variable
@@ -73,11 +75,16 @@ endmacro ()
 macro (PREFIX_FIND_LIB prefix libname libpath_var liblist_var cachelist_var)
   string (TOUPPER ${prefix}_${libname} tmp_prefix)
   # Handle new library names for OpenEXR 2.1 build via cmake
-  string(REPLACE "." "_" _ILMBASE_VERSION ${ILMBASE_VERSION})
-  string(SUBSTRING ${_ILMBASE_VERSION} 0 3 _ILMBASE_VERSION )
-  
+  if(ILMBASE_VERSION)
+    string(REPLACE "." "_" _ILMBASE_VERSION ${ILMBASE_VERSION})
+    string(SUBSTRING ${_ILMBASE_VERSION} 0 3 _ILMBASE_VERSION )
+    set(libnameVersion ${libname}-${_ILMBASE_VERSION})
+  else()
+    message(WARNING "Cannot extract ILMBASE version since ILMBASE_VERSION is empty!")
+    set(libnameVersion ${libname})
+  endif()
   find_library(${tmp_prefix}_LIBRARY_RELEASE
-    NAMES ${libname} ${libname}-${_ILMBASE_VERSION}
+    NAMES ${libname} ${libnameVersion}
     HINTS ${${libpath_var}}
     PATH_SUFFIXES lib
     ${ILMBASE_FIND_OPTIONS}

--- a/src/cmake/modules/FindLibRaw.cmake
+++ b/src/cmake/modules/FindLibRaw.cmake
@@ -24,7 +24,7 @@ IF(PKG_CONFIG_FOUND AND NOT LIBRAW_PATH)
    SET(LibRaw_r_DEFINITIONS ${PC_LIBRAW_R_CFLAGS_OTHER})   
 ENDIF()
 
-FIND_PATH(LibRaw_INCLUDE_DIR libraw.h
+FIND_PATH(LibRaw_INCLUDE_DIR libraw/libraw.h
           HINTS
           ${PC_LIBRAW_INCLUDEDIR}
           ${PC_LibRaw_INCLUDE_DIRS}
@@ -44,7 +44,7 @@ FIND_LIBRARY(LibRaw_r_LIBRARIES NAMES raw_r
             )
 
 IF(LibRaw_INCLUDE_DIR)
-   FILE(READ ${LibRaw_INCLUDE_DIR}/libraw_version.h _libraw_version_content)
+   FILE(READ ${LibRaw_INCLUDE_DIR}/libraw/libraw_version.h _libraw_version_content)
    
    STRING(REGEX MATCH "#define LIBRAW_MAJOR_VERSION[ \t]*([0-9]*)\n" _version_major_match ${_libraw_version_content})
    SET(_libraw_version_major "${CMAKE_MATCH_1}")
@@ -59,7 +59,7 @@ IF(LibRaw_INCLUDE_DIR)
       SET(LibRaw_VERSION_STRING "${_libraw_version_major}.${_libraw_version_minor}.${_libraw_version_patch}")
    ELSE()
       IF(NOT LibRaw_FIND_QUIETLY)
-         MESSAGE(STATUS "Failed to get version information from ${LibRaw_INCLUDE_DIR}/libraw_version.h")
+         MESSAGE(STATUS "Failed to get version information from ${LibRaw_INCLUDE_DIR}/libraw/libraw_version.h")
       ENDIF()
    ENDIF()
 ENDIF()

--- a/src/cmake/modules/FindOpenColorIO.cmake
+++ b/src/cmake/modules/FindOpenColorIO.cmake
@@ -13,7 +13,6 @@
 include (FindPackageHandleStandardArgs)
 include (FindPackageMessage)
 
-MACRO(FindOpenColorIO)
     if (VERBOSE)
         if (OCIO_PATH)
             message(STATUS "OCIO path explicitly specified: ${OCIO_PATH}")
@@ -45,7 +44,18 @@ MACRO(FindOpenColorIO)
         /sw/lib
         /opt/local/lib
         DOC "The OCIO library")
-
+    option(OCIO_STATIC OFF "Use STATIC lib mean use specific config for use")
+    if(OCIO_STATIC)
+        add_definitions(-DOpenColorIO_STATIC)
+    endif()
+    option(OCIO_TINYXML_STATIC OFF "Use STATIC lib mean use specific config for use")
+    if(OCIO_TINYXML_STATIC)
+        add_definitions(-DTIXML_USE_STL)
+    endif()
+    option(OCIO_YAML_STATIC OFF "How yaml was build to use specific export config under windows")
+    if(NOT OCIO_YAML_STATIC)
+        add_definitions(-DYAML_CPP_DLL)
+    endif()
     if(OCIO_INCLUDES AND OCIO_LIBRARIES)
         set(OCIO_FOUND TRUE)
         if (VERBOSE)
@@ -56,5 +66,4 @@ MACRO(FindOpenColorIO)
         set(OCIO_FOUND FALSE)
         message(STATUS "OCIO not found. Specify OCIO_PATH to locate it")
     endif()
-ENDMACRO()
 

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -33,15 +33,13 @@
 #include <cstdio>
 #include <algorithm>
 
-extern "C" {
-#include "jpeglib.h"
-}
-
 #include "OpenImageIO/imageio.h"
 #include "OpenImageIO/filesystem.h"
 #include "OpenImageIO/fmath.h"
 #include "OpenImageIO/color.h"
-#include "jpeg_pvt.h"
+
+// have to be the last include to avoid preprocessor redefinition errors (INT32 from basetsd.h under windows fro example)
+#include "jpeg_pvt.h" // will include "jpeglib.h"
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -34,14 +34,12 @@
 #include <cstdio>
 #include <vector>
 
-extern "C" {
-#include "jpeglib.h"
-}
-
 #include "OpenImageIO/imageio.h"
 #include "OpenImageIO/filesystem.h"
 #include "OpenImageIO/fmath.h"
-#include "jpeg_pvt.h"
+
+// have to be the last include to avoid preprocessor redefinition errors (INT32 from basetsd.h under windows fro example)
+#include "jpeg_pvt.h" // will include jpeglib.h
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 


### PR DESCRIPTION
Hello,
Thanks for sharing this great project.
I managed to build your project under windows 8.1 within MSVC11 but without your binaries you provided from the wiki (it cause to failed the build).
I rebuilt most of the images projects dependencies under MSVC11 x64 and use your THIRD_PARTY_TOOLS_HOME and append some minor things to make build your project.
3rdParty folder structure like this : 
+---oiio
|   ---3rdParty
|       ---windows
|           +---glew-1.5.1
|           |   +---include
|           |   ---lib
|           +---gtest-1.3.0
|           |   +---include
|           |   ---lib
|           +---ilmbase-2.2.0
|           |   +---include
|           |   +---lib
|           +---jasper-1.900.1
|           |   +---include
|           |   ---lib
|           +---jpeg-8d
|           |   +---include
|           |   +---lib
|           +---libpng-1.7.0.b54
|           |   +---bin
|           |   +---include
|           |   +---lib
|           +---LibRaw-0.17.0-Alpha1
|           |   +---include
|           |   +---lib
|           +---openexr-2.2.0
|           |   +---include
|           |   +---lib
|           |   +---share
|           +---openjpeg-1.3
|           |   +---include
|           |   ---lib
|           +---tbb-21_20090511oss
|           |   ---lib
|           +---tiff-3.8.2
|           |   +---include
|           |   +---lib
|           ---zlib-1.2.8
|               +---bin
|               +---include
|               +---lib
|               +---share
