### PR TITLE
oiiotool --autocc

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -127,6 +127,8 @@ Fixes, minor enhancements, and performance improvements:
     * Bug fix: input file data format didn't always end up in the output.
       (1.6.3)
     * --channels bugs were fixed when dealing with "deep" images. (1.6.3)
+    * All the color space conversion operations run much faster now,
+      since the underlying IBA::colorconvert() has been parallelized. (1.6.3)
   * maketx & TextureSystem:
     * TextureSystem/IC now directly stores uint16 and half pixel data in
       the cache rather than converting internally to float for tile storage,
@@ -152,6 +154,8 @@ Fixes, minor enhancements, and performance improvements:
       image differences when the pixels that differed had NaN or NaN or
       Inf values! Now it is right. #1109 (1.6.3/1.5.13)
     * channels() bugs were fixed when dealing with "deep" images. (1.6.3)
+    * colorconvert() has been parallelized, and thus on most systems will
+      now run much faster. (1.6.3)
  * OpenEXR:
     * Improved handling of density and aspect ratio. #1042 (1.6.0)
     * Fix read_deep_tiles() error when not starting at the image origin.

--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,11 @@ Major new features and improvements:
       noise, or making "salt & pepper" noise. (1.6.2)
     * --trim crops the image to the minimal rectangle containing all
       the non-0 pixels. (1.6.3)
+    * --autocc : when turned on, automatic color conversion of input files
+      into a scene_linear space, and conversion to an appropriate space
+      and pixel type upon output. It infers the color spaces based on
+      metadata and filenames (looking for OCIO-recognized color space names
+      as substrings of the filenames). (1.6.3)
  * New ImageBufAlgo functions:
     * absdiff() computes the absolute difference (abs(A-B)) of two images,
       or between an image and a constant color. #1029 (1.6.0)

--- a/CHANGES
+++ b/CHANGES
@@ -99,6 +99,9 @@ Public API changes:
    IO objects are deleted on the same side of a DLL boundary as where they
    were created. (Helps with using OIIO from DLL-based plugins on Windows.)
    (1.6.3)
+ * The ColorConfig wrapper for OCIO functionality has been extended to
+   parse color names from filename strings, and to report the recommended
+   pixel data type for a color space. (1.6.3)
 
 Fixes, minor enhancements, and performance improvements:
  * oiiotool

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -841,6 +841,54 @@ to use if you are using oiiotool to combine images that may have different
 orientations.
 \apiend
 
+\apiitem{\ce --autocc}
+\NEW % 1.6
+
+Turns on automatic color conversion: Every input image file will be
+immediately converted to a scene-referred linear color space, and every file
+written will be first transformed to an appropriate output color space based
+on the filename or type.   Additionally, if the name of an output file
+contains a color space and that color space is associated with a particular
+data format, it will output that data format (akin to {\cf -d}).
+
+The rules for deducing color spaces are as follows, in order of priority:
+
+\begin{enumerate}
+\item[]
+\item If the filename (input or output) contains as a substring the name
+  of a color space from the current OpenColorIO configuration, that will
+  be assumed to be the color space of input data (or be the requested
+  color space for output).
+\item For input files, if the \ImageInput set the \qkw{oiio:ColorSpace}
+  metadata, it will be honored if the filename did not override it.
+\item When outputting to JPEG files, assume that sRGB is the desired
+  output color space (since JPEG requires sRGB), but still this only
+  occurs if the filename does not specify something different.
+\end{enumerate}
+
+\noindent Example:
+
+If the input file \qkw{in_lg10.dpx} is in the \qkw{lg10} color space,
+and you want to read it in, brighten the RGB uniformly by 10\% (in a linear
+space, of course), and then save it as a 16 bit integer TIFF file encoded
+in the {\cf vd16} color space, you could specifiy the conversions
+explicitly:
+
+\begin{code}
+  oiiotool in_lg10.dpx --colorconvert lg10 linear \
+                       --mulc 1.1,1.1,1.1,1.0 -colorconvert linear vd16 \
+                       -d uint16 -o out_vd16.tif
+\end{code}
+
+\noindent or rely on the naming convention matching the OCIO color space
+names and use automatic conversion:
+
+\begin{code}
+  oiiotool --autocc in_lg10.dpx --mulc 1.1 -o out_vd16.tif
+\end{code}
+
+\apiend
+
 \apiitem{\ce --native}
 Normally, all image reads into an \ImageBuf will be performed via an
 underlying \ImageCache. But since an \ImageCache does not support all

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -94,7 +94,7 @@
 }
 \date{{\large 
 %Editor: Larry Gritz \\[2ex]
-Date: 31 Mar 2015
+Date: 15 Apr 2015
 % \\ (with corrections, 7 Jan 2015)
 }}
 

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -186,6 +186,12 @@ public:
                                             string_view context_key="",
                                             string_view context_value="") const;
 
+    /// Given a string (like a filename), look for the longest, right-most
+    /// colorspace substring that appears. Returns "" if no such color space
+    /// is found. (This is just a wrapper around OCIO's
+    /// ColorConfig::parseColorSpaceFromString.)
+    string_view parseColorSpaceFromString (string_view str) const;
+
     /// Delete the specified ColorProcessor
     static void deleteColorProcessor(ColorProcessor * processor);
     

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -33,6 +33,8 @@
 
 #include "export.h"
 #include "oiioversion.h"
+#include "typedesc.h"
+
 
 OIIO_NAMESPACE_ENTER
 {
@@ -93,6 +95,11 @@ public:
     /// Get the name of the color space representing the named role,
     /// or NULL if none could be identified.
     const char * getColorSpaceNameByRole (string_view role) const;
+
+    /// Get the data type that OCIO thinks this color space is. The name
+    /// may be either a color space name or a role.
+    OIIO::TypeDesc getColorSpaceDataType (string_view name, int *bits) const;
+
     
     /// Get the number of Looks defined in this configuration
     int getNumLooks() const;

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -619,6 +619,20 @@ ColorConfig::createDisplayTransform (string_view display,
 }
 
 
+
+string_view
+ColorConfig::parseColorSpaceFromString (string_view str) const
+{
+#ifdef USE_OCIO
+    string_view result (getImpl()->config_->parseColorSpaceFromString (str.c_str()));
+    return result;
+#else
+    return "";
+#endif
+}
+
+
+
 void
 ColorConfig::deleteColorProcessor (ColorProcessor * processor)
 {

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -245,6 +245,31 @@ ColorConfig::getColorSpaceNameByRole (string_view role) const
 
 
 
+TypeDesc
+ColorConfig::getColorSpaceDataType (string_view name, int *bits) const
+{
+#ifdef USE_OCIO
+    OCIO::ConstColorSpaceRcPtr c = getImpl()->config_->getColorSpace (name.c_str());
+    if (c) {
+        OCIO::BitDepth b = c->getBitDepth();
+        switch (b) {
+        case OCIO::BIT_DEPTH_UNKNOWN : return TypeDesc::UNKNOWN;
+        case OCIO::BIT_DEPTH_UINT8   : *bits =  8; return TypeDesc::UINT8;
+        case OCIO::BIT_DEPTH_UINT10  : *bits = 10; return TypeDesc::UINT16;
+        case OCIO::BIT_DEPTH_UINT12  : *bits = 12; return TypeDesc::UINT16;
+        case OCIO::BIT_DEPTH_UINT14  : *bits = 14; return TypeDesc::UINT16;
+        case OCIO::BIT_DEPTH_UINT16  : *bits = 16; return TypeDesc::UINT16;
+        case OCIO::BIT_DEPTH_UINT32  : *bits = 32; return TypeDesc::UINT32;
+        case OCIO::BIT_DEPTH_F16     : *bits = 16; return TypeDesc::HALF;
+        case OCIO::BIT_DEPTH_F32     : *bits = 32; return TypeDesc::FLOAT;
+        }
+    }
+#endif
+    return TypeDesc::UNKNOWN;
+}
+
+
+
 int
 ColorConfig::getNumDisplays() const
 {

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -458,6 +458,14 @@ ColorConfig::createColorProcessor (string_view inputColorSpace,
     // Ask OCIO to make a Processor that can handle the requested
     // transformation.
     if (getImpl()->config_) {
+        // If the names are roles, convert them to color space names
+        string_view name;
+        name = getColorSpaceNameByRole (inputColorSpace);
+        if (! name.empty())
+            inputColorSpace = name;
+        name = getColorSpaceNameByRole (outputColorSpace);
+        if (! name.empty())
+            outputColorSpace = name;
         OCIO::ConstProcessorRcPtr p;
         try {
             // Get the processor corresponding to this transform.

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -60,6 +60,7 @@ public:
     bool hash;
     bool updatemode;
     bool autoorient;
+    bool autocc;                      // automatically color correct
     bool nativeread;                  // force native data type reads
     int threads;
     std::string full_command_line;


### PR DESCRIPTION
This set of changes adds an --autocc (auto color convert) option to oiiotool. When specified, it makes oiiotool:

* Examine any input and output filenames, looking to see if they contain substrings which are any of the known OpenColorIO color space names.

* If so, then it will assume that an input file contains data in that color space, and will automatically convert it to a scene-linear space upon input. If there is no such hint in the filename, it will then examine any "oiio:ColorSpace" metadata found in the file and do the conversion based upon that (this metadata is set by any ImageInput that can discern the color space of the input data, for example, it knows that JPEG data is always sRGB).

* Similarly, when requesting output (-o), it will interpret any color space names in the filename to be a request to convert to that color space as part of the output process. If no hint is found in the filename, but it appears to be a JPEG file (ending in .jpg or .jpeg), it will make sure the colors are converted to sRGB, as required by the JPEG standard.

* If a color space name is found embedded in the requested output filename and OCIO has a concrete idea of a specific pixel data type that is appropriate for the color space, it will also be used as a hint for a kind of automatic "-d" selecting output data format (e.g., color space "vd16" will try to output as uint16 pixels). 

Here's an example of how this all comes together. Let's say you have a DPX file in 10 bit log format (let's say, color space "lg10"), and you want to use oiiotool to brighten it by 10% in the R,G,B channels (but of course, 10% in a linear color space), and then save it as a TIFF in "vd8" color space (by our in-house convention, this is an video display color space, akin to sRGB, assumed to be 8 bits per channel). The old, fully explicit way is, assuming we follow our naming conventions rigorously:

    oiiotool in_lg10.dpx -colorconvert lg10 lnf -mulc 1.1,1.1,1.1,1.0 -colorconvert lnf vd8 -d uint8 -o out_vd8.tif

now, assuming you have the right color space names defined in your OCIO configuration, you can do the same operation in the more compact:

    oiiotool --autocc in_lg10.dpx -mulc 1.1,1.1,1.1,1.0 -o out_vd8.tif

So, everything will be converted to a canonical linear space upon input, any math oiiotool performs will then be correctly linear, and then convert to appropriate spaces for output, all determined by file naming conventions and the help of OCIO.

For anyone who cares, this roughly emulates the behavior of an old in-house image processing tool which has at this point been replaced by oiiotool.

One last thing... all this heavy use of color conversion reminded me that the underlying ImageBufAlgo::colorconvert() is not multithreaded, as is the rest of IBA. So I fixed that while I was at it. This speeds up oiiotool color conversion on my workstation by 8x!


