### PR TITLE
Filesystem utility enhancements and fixes

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -192,6 +192,10 @@ OIIO_API std::string unique_path (string_view model="%%%%-%%%%-%%%%-%%%%");
 ///
 OIIO_API FILE *fopen (string_view path, string_view mode);
 
+/// Return the current (".") directory path.
+///
+OIIO_API std::string current_path ();
+
 /// Version of std::ifstream.open that can handle UTF-8 paths
 ///
 OIIO_API void open (std::ifstream &stream, string_view path,

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -716,6 +716,7 @@ Filesystem::enumerate_file_sequence (const std::string &pattern,
                                      const std::vector<int> &numbers,
                                      std::vector<std::string> &filenames)
 {
+    filenames.clear ();
     for (size_t i = 0, e = numbers.size(); i < e; ++i) {
         std::string f = Strutil::format (pattern.c_str(), numbers[i]);
         filenames.push_back (f);
@@ -732,9 +733,9 @@ Filesystem::enumerate_file_sequence (const std::string &pattern,
                                      std::vector<std::string> &filenames)
 {
     ASSERT (views.size() == 0 || views.size() == numbers.size());
-
     static boost::regex view_re ("%V"), short_view_re ("%v");
 
+    filenames.clear ();
     for (size_t i = 0, e = numbers.size(); i < e; ++i) {
         std::string f = pattern;
         if (views.size() > 0 && ! views[i].empty()) {
@@ -760,6 +761,9 @@ Filesystem::scan_for_matching_filenames(const std::string &pattern,
     static boost::regex format_re ("%0([0-9]+)d");
     static boost::regex all_views_re ("%[Vv]"), view_re ("%V"), short_view_re ("%v");
 
+    frame_numbers.clear ();
+    frame_views.clear ();
+    filenames.clear ();
     if (boost::regex_search (pattern, all_views_re)) {
         if (boost::regex_search (pattern, format_re)) {
             // case 1: pattern has format and view
@@ -829,8 +833,9 @@ Filesystem::scan_for_matching_filenames(const std::string &pattern_,
                                         std::vector<int> &numbers,
                                         std::vector<std::string> &filenames)
 {
+    numbers.clear ();
+    filenames.clear ();
     std::string pattern = pattern_;
-
     // Isolate the directory name (or '.' if none was specified)
     std::string directory = Filesystem::parent_path (pattern);
     if (directory.size() == 0) {

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -43,6 +43,9 @@
 #ifdef _WIN32
 #include <windows.h>
 #include <shellapi.h>
+#include <direct.h>
+#else
+#include <unistd.h>
 #endif
 
 #include "OpenImageIO/dassert.h"
@@ -440,6 +443,27 @@ Filesystem::unique_path (string_view model)
     char buf[L_tmpnam];
     char *result = tmpnam (buf);
     return result ? std::string(result) : std::string();
+#endif
+}
+
+
+
+std::string
+Filesystem::current_path()
+{
+#if BOOST_FILESYSTEM_VERSION >= 3
+    boost::system::error_code ec;
+    boost::filesystem::path p = boost::filesystem::current_path (ec);
+    return ec ? std::string() : p.string();
+#else
+    // Fallback if we don't have recent Boost
+    char path[FILENAME_MAX];
+#ifdef _WIN32
+    bool ok = _getcwd (path, sizeof(path));
+#else
+    bool ok = getcwd (path, sizeof(path));
+#endif
+    return ok ? std::string(path) : std::string();
 #endif
 }
 

--- a/src/libutil/filesystem_test.cpp
+++ b/src/libutil/filesystem_test.cpp
@@ -185,7 +185,9 @@ test_scan_file_seq (const char *pattern, const std::string &expected)
     // formed patterns.
     const char *weird = "{'cpu_model': 'Intel(R) Xeon(R) CPU E5-2630 @ 2.30GHz'}";
     Filesystem::parse_pattern (weird, 0, normalized_pattern, frame_range);
-    OIIO_CHECK_ASSERT (! Filesystem::scan_for_matching_filenames (normalized_pattern, numbers, names));
+    Filesystem::scan_for_matching_filenames (normalized_pattern, numbers, names);
+    OIIO_CHECK_EQUAL (names.size(), 0);
+    // If we didn't crash above, we're ok!
 }
 
 


### PR DESCRIPTION
1. Add Filesystem::current_path() as portable way to get current working directory path.

2. Fix a unit test that failed with newer Boost (1.57) due to Boost's exception behavior changing in a certain spot. Nothing wrong with our Filesystem code, only that our unit test was testing the wrong conditions (it was testing a specific return value, when all we cared is that the function didn't crash).

3. Fix the sequence enumeration functions to clear their results vectors when the start. The documentation never advertised that they were appending, so replacing the results (including clearing it if no match was found) seems like the best way to adhere to the Principle of Least Surprise.

