### PR TITLE
Make TextureSystem::create(shared=true) truly create a shared TS.

### DIFF
--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -299,8 +299,8 @@ public:
     /// freed by passing it to TextureSystem::destroy()!
     ///
     /// If shared==true, it's intended to be shared with other like-minded
-    /// owners in the same process who also ask for a shared cache.  If
-    /// false, a private image cache will be created.
+    /// owners in the same process who also ask for a shared texture system.
+    /// If false, a private texture system and cache will be created.
     static TextureSystem *create (bool shared=true);
 
     /// Destroy a TextureSystem that was created using


### PR DESCRIPTION
It had been creating a separate TS for every create call, but with a
shared ImageCache (if requested).  That's not good enough. If two spots
in an app each request a shared TS, They probably want it to actually be
the same one, including any attributes already set in it.