### PR TITLE
Overhaul of oiiotool.cpp -- express operations as OiiotoolOp subclasses.

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -1033,10 +1033,6 @@ bool
 ImageBufAlgo::rangecompress (ImageBuf &dst, const ImageBuf &src,
                              bool useluma, ROI roi, int nthreads)
 {
-    if (! dst.initialized()) {
-        dst.error ("in-place rangecompress requires the ImageBuf to be initialized");
-        return false;
-    }
     if (! IBAprep (roi, &dst, &src, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
@@ -1052,10 +1048,6 @@ bool
 ImageBufAlgo::rangeexpand (ImageBuf &dst, const ImageBuf &src,
                            bool useluma, ROI roi, int nthreads)
 {
-    if (! dst.initialized()) {
-        dst.error ("in-place rangeexpand requires the ImageBuf to be initialized");
-        return false;
-    }
     if (! IBAprep (roi, &dst, &src, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;


### PR DESCRIPTION
It's been bugging me for a while that all the operations in oiiotool (add, mul, etc.) are enormously repetitive, lots of similar boilerplate in all the ops: pop images off the stack, create a destination image, decode arguments and options, loop over subimages, time the whole thing. etc.

And sometimes the repetition is inexact -- either plain old errors, or else that because oiiotool has grown in pieces, improvements to methodology get incorporated into newly added functions but not old ones.

So I've been contemplating a big refactor for some time, and this past weekend I got the chance to experiment, and I think I like it. The gist is that I define an OiiotoolOp base class that contains all the common boilerplate code. Then the individual operations subclass, overriding just the tiniest bits that tend to differ from op to op. This greatly reduces the amount of repeated code, I hope tends to make the code clearer by boiling down each op to "do the standard thing except with THIS one line in the loop", and also makes it much easier for new ideas or changes in methodology to get applied to nearly all ops with one change.

I'm sorry to say, though, that the overhaul is so extensive that 'diff' just doesn't line anything up for oiiotool.cpp, you can't easily see the difference side by side. You'll just have to look at the file in its new form and try to understand what it's doing. Github doesn't even attempt to show a diff, ugh. As an example, though, I'll present 'invert' done the old way:

    static int
    action_invert (int argc, const char *argv[])
    {
        if (ot.postpone_callback (1, action_invert, argc, argv))
            return 0;
        Timer timer (ot.enable_function_timing);
        string_view command = ot.express (argv[0]);
    
        ot.read ();
        ImageRecRef A = ot.pop();
        ot.push (new ImageRec (*A, ot.allsubimages ? -1 : 0,
                               ot.allsubimages ? -1 : 0, true, true/* copy pixels*/));
    
        for (int s = 0, subimages = ot.curimg->subimages(); s < subimages; ++s) {
            for (int m = 0, miplevels = ot.curimg->miplevels(s); m < miplevels; ++m) {
                ImageBuf &Rib ((*ot.curimg)(s,m));
                // invert the first three channels only, spare alpha
                ROI roi = Rib.roi();
                roi.chend = std::min (3, Rib.spec().nchannels);
                bool ok = ImageBufAlgo::invert (Rib, Rib, roi);
                if (! ok)
                    ot.error (command, Rib.geterror());
            }
        }
    
        ot.function_times[command] += timer();
        return 0;
    }

and the new way for the same functionality:

    class OpInvert : public OiiotoolOp {
    public:
        OpInvert (Oiiotool &ot, string_view opname, int argc, const char *argv[])
            : OiiotoolOp (ot, opname, argc, argv, 1) {}
        virtual int impl (ImageBuf **img) {
            // invert the first three channels only, spare alpha
            ROI roi = img[1]->roi();
            roi.chend = std::min (3, roi.chend);
            return ImageBufAlgo::invert (*img[0], *img[1], roi, 0);
        }
    };
    
    OP_CUSTOMCLASS (invert, OpInvert, 1);