### PR TITLE
Allow use of custom ocio configuration files

### DIFF
--- a/src/doc/imagebufalgo.tex
+++ b/src/doc/imagebufalgo.tex
@@ -1812,7 +1812,8 @@ higher-contrast edges.
 
 \apiitem{bool {\ce colorconvert} (ImageBuf \&dst, const ImageBuf \&src, \\
   \bigspc\spc string_view from, string_view to, bool unpremult=false, \\
-  \bigspc\spc  ROI roi=ROI::All(), int nthreads=0) \\
+  \bigspc\spc ColorConfig *colorconfig=NULL, \\
+  \bigspc\spc ROI roi=ROI::All(), int nthreads=0) \\
 bool {\ce colorconvert} (ImageBuf \&dst, const ImageBuf \&src, \\
   \bigspc\spc const ColorProcessor *processor, bool unpremult=false, \\
   \bigspc\spc  ROI roi=ROI::All(), int nthreads=0)}
@@ -1826,11 +1827,14 @@ If {\cf unpremult} is {\cf true}, unpremultiply before color conversion,
 then premultiply again after the color conversion.  You may want to use
 this flag if your image contains an alpha channel.
 
-The first form of this function specifies the ``from''
-and ``to'' color spaces by name.
-The second form is passed a {\cf ColorProcessor},
-which is is a special object created by a
-{\cf ColorConfig} (see {\cf OpenImageIO/color.h} for details).
+The first form of this function specifies the ``from'' and ``to'' color
+spaces by name. An optional {\cf ColorConfig} is specified, but {\cf NULL}
+is passed, the default OCIO color configuration found by examining the {\cf
+\$OCIO} environment variable will be used instead.
+
+The second form is directly passed a {\cf ColorProcessor}, which is is a
+special object created by a {\cf ColorConfig} (see {\cf OpenImageIO/color.h}
+for details).
 
 If OIIO was built with OpenColorIO support enabled, then the transformation
 may be between any two spaces supported by the active OCIO configuration, or
@@ -1865,6 +1869,7 @@ to \qkw{linear} and vice versa.
   \bigspc\spc string_view looks, string_view from, string_view to, \\
   \bigspc\spc bool inverse=false, bool unpremult=false, \\
   \bigspc\spc string_view key="", string_view value="", \\
+  \bigspc\spc ColorConfig *colorconfig=NULL, \\
   \bigspc\spc ROI roi=ROI::All(), int nthreads=0)}
 \index{ImageBufAlgo!ociolook} \indexapi{ociolook}
 Copy pixels from {\cf src} to {\cf dst} (within the ROI), while
@@ -1879,6 +1884,10 @@ and look application.
 If {\cf unpremult} is {\cf true}, unpremultiply before color conversion,
 then premultiply again after the color conversion.  You may want to use
 this flag if your image contains an alpha channel.
+
+An optional {\cf ColorConfig} is specified, but {\cf NULL} is passed, the
+default OCIO color configuration found by examining the {\cf \$OCIO}
+environment variable will be used instead.
 
 \smallskip
 \noindent Examples:
@@ -1896,6 +1905,7 @@ this flag if your image contains an alpha channel.
   \bigspc\spc string_view from="", string_view looks="",\\
   \bigspc\spc bool unpremult=false, \\
   \bigspc\spc string_view key="", string_view value="", \\
+  \bigspc\spc ColorConfig *colorconfig=NULL, \\
   \bigspc\spc ROI roi=ROI::All(), int nthreads=0)}
 \index{ImageBufAlgo!ociodisplay} \indexapi{ociodisplay}
 Copy pixels from {\cf src} to {\cf dst} (within the ROI), while
@@ -1913,6 +1923,10 @@ and look application.
 If {\cf unpremult} is {\cf true}, unpremultiply before color conversion,
 then premultiply again after the color conversion.  You may want to use
 this flag if your image contains an alpha channel.
+
+An optional {\cf ColorConfig} is specified, but {\cf NULL} is passed, the
+default OCIO color configuration found by examining the {\cf \$OCIO}
+environment variable will be used instead.
 
 \smallskip
 \noindent Examples:

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -2292,6 +2292,23 @@ identical on different platforms supported by \product.
 
 \section{\oiiotool commands for color management}
 
+Many of the color management commands depend on an installation of
+OpenColorIO ({\cf http://opencolorio.org/}).
+
+If OIIO has been compiled with OpenColorIO support and the environment
+variable {\cf \$OCIO} is set to point to a valid OpenColorIO configuration
+file, you will have access to all the color spaces that are known by that
+OCIO configuration.  Alternately, you can use the {\cf --colorconfig} option
+to explicitly point to a configuration file. If no  valid configuration file
+is found (either in {\cf \$OCIO} or specified by {\cf --colorconfig}) or
+OIIO was not compiled with OCIO support, then the only color space
+transformats available are {\cf linear} to {\cf Rec709} (and vice versa) and
+{\cf linear} to {\cf sRGB} (and vice versa).
+
+If you ask for \oiiotool help ({\cf oiiotool --help}), at the very bottom
+you will see the list of all color spaces, looks, and displays that
+\oiiotool knows about.
+
 \apiitem{\ce --iscolorspace {\rm \emph{colorspace}}}
 Alter the metadata of the current image so that it thinks its pixels
 are in the named color space.  This does not alter the pixels of the
@@ -2299,24 +2316,18 @@ image, it only changes \oiiotool's understanding of what color
 space those those pixels are in.
 \apiend
 
+\apiitem{\ce --colorconfig {\rm \emph{filename}}}
+\NEW % 1.6
+Instruct \oiiotool to read an OCIO configuration from a custom location.
+Without this, the default is to use the {\cf \$OCIO} environment variable
+as a guide for the location of the configuration file.
+\apiend
+
 \apiitem{\ce --colorconvert {\rm \emph{fromspace tospace}}}
 Replace the current image with a new image whose pixels are transformed
 from the named \emph{fromspace} color space into the named
 \emph{tospace} (disregarding any notion it may have previously had 
 about the color space of the current image).  
-
-If OIIO has been compiled with OpenColorIO support and the environment
-variable {\cf \$OCIO} is set to point to a valid OpenColorIO
-configuration file, you will have access to all the color spaces that
-are known by that OCIO configuration.  If {\cf \$OCIO} does not point to
-a valid configuration file or OIIO was not compiled with OCIO support,
-then the only color space transformats available are {\cf linear} to
-{\cf Rec709} (and vice versa) and {\cf linear} to {\cf sRGB} (and vice
-versa).
-
-If you ask for \oiiotool help ({\cf oiiotool --help}), at the very
-bottom you will see the list of all color spaces that \oiiotool knows
-about.
 \apiend
 
 \apiitem{\ce --tocolorspace {\rm \emph{tospace}}}

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -94,7 +94,7 @@
 }
 \date{{\large 
 %Editor: Larry Gritz \\[2ex]
-Date: 19 Apr 2015
+Date: 27 Apr 2015
 % \\ (with corrections, 7 Jan 2015)
 }}
 

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -61,21 +61,24 @@ class OIIO_API ColorProcessor;
 class OIIO_API ColorConfig
 {
 public:
-    /// If OpenColorIO is enabled at build time, initialize with the current
-    /// color configuration. ($OCIO)
-    /// If OpenColorIO is not enabled, this does nothing.
+    /// Construct a ColorConfig using the named OCIO configuration file,
+    /// or if filename is empty, to the current color configuration
+    /// specified by env variable $OCIO.
     ///
-    /// Multiple calls to this are inexpensive.
-    ColorConfig();
-    
-    /// If OpenColorIO is enabled at build time, initialize with the 
-    /// specified color configuration (.ocio) file
-    /// If OpenColorIO is not enabled, this will result in an error.
-    /// 
-    /// Multiple calls to this are potentially expensive.
-    ColorConfig(string_view filename);
+    /// Multiple calls to this are potentially expensive. A ColorConfig
+    /// should usually be shared by an app for its entire runtime.
+    ColorConfig (string_view filename = "");
     
     ~ColorConfig();
+
+    /// Reset the config to the named OCIO configuration file, or if
+    /// filename is empty, to the current color configuration specified
+    /// by env variable $OCIO. Return true for success, false if there
+    /// was an error.
+    ///
+    /// Multiple calls to this are potentially expensive. A ColorConfig
+    /// should usually be shared by an app for its entire runtime.
+    bool reset (string_view filename = "");
     
     /// Has an error string occurred?
     /// (This will not affect the error state.)

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -897,50 +897,12 @@ bool OIIO_API rangeexpand (ImageBuf &dst, const ImageBuf &src,
 bool OIIO_API colorconvert (ImageBuf &dst, const ImageBuf &src,
                             string_view from, string_view to,
                             bool unpremult=false,
+                            ColorConfig *colorconfig=NULL,
                             ROI roi=ROI::All(), int nthreads=0);
-
-/// Copy pixels within the ROI from src to dst, applying an OpenColorIO
-/// "look" transform. In-place operations (dst == src) are supported.
-///
-/// If dst is not yet initialized, it will be allocated to the same
-/// size as specified by roi.  If roi is not defined it will be all
-/// of dst, if dst is defined, or all of src, if dst is not yet defined.
-///
-/// If unpremult is true, unpremultiply before color conversion, then
-/// premultiply after the color conversion.  You may want to use this
-/// flag if your image contains an alpha channel.
-///
-/// Return true on success, false on error (with an appropriate error
-/// message set in dst).
-bool OIIO_API ociolook (ImageBuf &dst, const ImageBuf &src,
-                        string_view looks, string_view from, string_view to,
-                        bool unpremult=false, bool inverse=false,
-                        string_view key="", string_view value="",
-                        ROI roi=ROI::All(), int nthreads=0);
-
-/// Copy pixels within the ROI from src to dst, applying an OpenColorIO
-/// "display" transform.  If from or looks are NULL, it will not
-/// override the look or source color space (subtly different than
-/// passing "", the empty string, which means to use no look or source
-/// space).
-///
-/// If dst is not yet initialized, it will be allocated to the same
-/// size as specified by roi.  If roi is not defined it will be all
-/// of dst, if dst is defined, or all of src, if dst is not yet defined.
-/// In-place operations (dst == src) are supported.
-///
-/// If unpremult is true, unpremultiply before color conversion, then
-/// premultiply after the color conversion.  You may want to use this
-/// flag if your image contains an alpha channel.
-///
-/// Return true on success, false on error (with an appropriate error
-/// message set in dst).
-bool OIIO_API ociodisplay (ImageBuf &dst, const ImageBuf &src,
-                        string_view display, string_view view,
-                        string_view from="", string_view looks="",
-                        bool unpremult=false,
-                        string_view key="", string_view value="",
-                        ROI roi=ROI::All(), int nthreads=0);
+// DEPRECATED (1.6)
+bool OIIO_API colorconvert (ImageBuf &dst, const ImageBuf &src,
+                            string_view from, string_view to,
+                            bool unpremult, ROI roi, int nthreads=0);
 
 /// Copy pixels within the ROI from src to dst, applying a color transform.
 /// In-place operations (dst == src) are supported.
@@ -969,6 +931,64 @@ bool OIIO_API colorconvert (ImageBuf &dst, const ImageBuf &src,
 /// flag if your image contains an alpha channel.
 bool OIIO_API colorconvert (float *color, int nchannels,
                             const ColorProcessor *processor, bool unpremult);
+
+
+/// Copy pixels within the ROI from src to dst, applying an OpenColorIO
+/// "look" transform. In-place operations (dst == src) are supported.
+///
+/// If dst is not yet initialized, it will be allocated to the same
+/// size as specified by roi.  If roi is not defined it will be all
+/// of dst, if dst is defined, or all of src, if dst is not yet defined.
+///
+/// If unpremult is true, unpremultiply before color conversion, then
+/// premultiply after the color conversion.  You may want to use this
+/// flag if your image contains an alpha channel.
+///
+/// Return true on success, false on error (with an appropriate error
+/// message set in dst).
+bool OIIO_API ociolook (ImageBuf &dst, const ImageBuf &src,
+                        string_view looks, string_view from, string_view to,
+                        bool unpremult=false, bool inverse=false,
+                        string_view key="", string_view value="",
+                        ColorConfig *colorconfig=NULL,
+                        ROI roi=ROI::All(), int nthreads=0);
+// DEPRECATED (1.6)
+bool OIIO_API ociolook (ImageBuf &dst, const ImageBuf &src,
+                        string_view looks, string_view from, string_view to,
+                        bool unpremult, bool inverse,
+                        string_view key, string_view value,
+                        ROI roi, int nthreads=0);
+
+/// Copy pixels within the ROI from src to dst, applying an OpenColorIO
+/// "display" transform.  If from or looks are NULL, it will not
+/// override the look or source color space (subtly different than
+/// passing "", the empty string, which means to use no look or source
+/// space).
+///
+/// If dst is not yet initialized, it will be allocated to the same
+/// size as specified by roi.  If roi is not defined it will be all
+/// of dst, if dst is defined, or all of src, if dst is not yet defined.
+/// In-place operations (dst == src) are supported.
+///
+/// If unpremult is true, unpremultiply before color conversion, then
+/// premultiply after the color conversion.  You may want to use this
+/// flag if your image contains an alpha channel.
+///
+/// Return true on success, false on error (with an appropriate error
+/// message set in dst).
+bool OIIO_API ociodisplay (ImageBuf &dst, const ImageBuf &src,
+                        string_view display, string_view view,
+                        string_view from="", string_view looks="",
+                        bool unpremult=false,
+                        string_view key="", string_view value="",
+                        ColorConfig *colorconfig=NULL,
+                        ROI roi=ROI::All(), int nthreads=0);
+// DEPRECATED (1.6)
+bool OIIO_API ociodisplay (ImageBuf &dst, const ImageBuf &src,
+                        string_view display, string_view view,
+                        string_view from, string_view looks,
+                        bool unpremult, string_view key, string_view value,
+                        ROI roi, int nthreads=0);
 
 
 /// Copy pixels from dst to src, and in the process divide all color

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1400,6 +1400,16 @@ set_full_to_pixels (int argc, const char *argv[])
 
 
 static int
+set_colorconfig (int argc, const char *argv[])
+{
+    ASSERT (argc == 2);
+    ot.colorconfig.reset (argv[1]);
+    return 0;
+}
+
+
+
+static int
 set_colorspace (int argc, const char *argv[])
 {
     ASSERT (argc == 2);
@@ -1445,7 +1455,8 @@ action_colorconvert (int argc, const char *argv[])
     for (int s = 0, send = ot.curimg->subimages();  s < send;  ++s) {
         for (int m = 0, mend = ot.curimg->miplevels(s);  m < mend;  ++m) {
             bool ok = ImageBufAlgo::colorconvert ((*ot.curimg)(s,m), (*A)(s,m),
-                                 fromspace.c_str(), tospace.c_str(), false);
+                                   fromspace.c_str(), tospace.c_str(), false,
+                                   &ot.colorconfig);
             if (! ok)
                 ot.error (command, (*ot.curimg)(s,m).geterror());
         }
@@ -1516,7 +1527,7 @@ action_ociolook (int argc, const char *argv[])
                 (*ot.curimg)(s,m), (*A)(s,m),
                 lookname.c_str(), fromspace.c_str(), tospace.c_str(),
                 false, inverse,
-                contextkey.c_str(), contextvalue.c_str());
+                contextkey.c_str(), contextvalue.c_str(), &ot.colorconfig);
             if (! ok)
                 ot.error (command, (*ot.curimg)(s,m).geterror());
         }
@@ -1572,7 +1583,7 @@ action_ociodisplay (int argc, const char *argv[])
                     displayname.c_str(), viewname.c_str(),
                     fromspace.c_str(), 
                     override_looks ? options["looks"].c_str() : 0, false,
-                    contextkey.c_str(), contextvalue.c_str());
+                    contextkey.c_str(), contextvalue.c_str(), &ot.colorconfig);
             if (! ok)
                 ot.error (command, (*ot.curimg)(s,m).geterror());
         }
@@ -4699,6 +4710,8 @@ getargs (int argc, char *argv[])
                 "--label %@ %s", action_label, NULL,
                     "Label the top image",
                 "<SEPARATOR>", "Color management:",
+                "--colorconfig %@ %s", set_colorconfig, NULL,
+                    "Explicitly specify an OCIO configuration file",
                 "--iscolorspace %@ %s", set_colorspace, NULL,
                     "Set the assumed color space (without altering pixels)",
                 "--tocolorspace %@ %s", action_tocolorspace, NULL,


### PR DESCRIPTION
* Change ColorConfig wrapper to allow a reset() to point the color config to a new/custom OCIO configuration. (Also simplify the constructors by implementing in terms of reset.)

* IBA colorconvert, ociodisplay, and ociolook get new varieties that accept an optional ColorConfig, rather than having no choice but to construct a new one internally.

* oiiotool passes its colorconfig to the IBA functions so it will reuse the one stored in ot.colorconfig.

* New oiiotool --colorconfig lets you direct oiiotool to use a custom location of an OCIO configuration (rather than strictly relying on the $OCIO environment variable). This is especially handy in certain testing situations.