### PR TITLE
Bug fix: frame sequences incorrectly overridden with --frames

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -3904,10 +3904,8 @@ handle_sequence (int argc, const char **argv)
             return true;
         }
 
-        // --frames overrides sequence framespec
-        if (! framespec.empty())
+        if (sequence_framespec.empty())
             sequence_framespec = framespec;
-
         if (! sequence_framespec.empty()) {
             Filesystem::enumerate_sequence (sequence_framespec.c_str(),
                                             frame_numbers[a]);


### PR DESCRIPTION
When oiiotool --frames was used, it overrode ALL frame sequence wildcards.
That's not correct; the argument to --frames should only override sequence
wildcards that don't explicitly spell out the sequences.

Example:   oiiotool --frames 1-5 a.#.exr -o b.1001-1005#.exr
This should copy a.0001.exr to b.1001.exr, NOT b.0001.exr. The --frames 1-5
should only apply to the "#" free sequence wildcard, not the 1001-1005# explicitly
ranged sequence wildcard.