### PR TITLE
oiiotool -n and --debug

### DIFF
--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -620,6 +620,20 @@ Quet mode --- print out less information about what \oiiotool is doing
 (only errors).
 \apiend
 
+\apiitem{\ce -n}
+\NEW % 1.6
+No saved output --- do not save any image files. This is helpful for certain
+kinds of tests, or in combination with {\cf --runstats} or {\cf --debug},
+for getting detailed information about what a command sequence will do and
+what it costs, but without producing any saved output files.
+\apiend
+
+\apiitem{\ce --debug}
+\NEW % 1.6
+Debug mode --- print lots of information about what operations are being
+performed.
+\apiend
+
 \apiitem{\ce --runstats}
 Print timing and memory statistics about the work done by \oiiotool.
 \apiend

--- a/src/oiiotool/diff.cpp
+++ b/src/oiiotool/diff.cpp
@@ -154,7 +154,7 @@ OiioTool::do_action_diff (ImageRec &ir0, ImageRec &ir1,
 
             // Print the report
             //
-            if (ot.verbose || ret != DiffErrOK) {
+            if (ot.verbose || ot.debug || ret != DiffErrOK) {
                 if (ot.allsubimages)
                     print_subimage (ir0, subimage, m);
                 std::cout << "  Mean error = ";

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -50,6 +50,8 @@ class Oiiotool {
 public:
     // General options
     bool verbose;
+    bool debug;
+    bool dryrun;
     bool runstats;
     bool noclobber;
     bool allsubimages;
@@ -487,6 +489,14 @@ public:
         // Set up a timer to automatically record how much time is spent in
         // every class of operation.
         Timer timer (ot.enable_function_timing);
+        if (ot.debug) {
+            std::cout << "Performing '" << opname() << "'";
+            if (nargs() > 1)
+                std::cout << " with args: ";
+            for (int i = 0; i < nargs(); ++i)
+                std::cout << (i > 0 ? ", \"" : " \"") << args[i] << "\"";
+            std::cout << "\n";
+        }
 
         // Read all input images, and reserve (and push) the output image.
         int subimages = compute_subimages();


### PR DESCRIPTION
-n : "no saved output" performs all the calculations (including timing
and stats) but does not write any output files to disk. This is helpful
for debugging, for testing an oiiotool command line syntax or behavior
without wanting to accidentally write files with a malformed command,
and for performance testing of computation where you don't really care
about timing of I/O to write the tiles.

--debug : Previously the "-v" (verbose) performed two somewhat unrelated
tasks -- it increased the verbosity of essential output, but it alto
triggered certain debugging status messages. Now we have separate
controls for these two options.