### PR TITLE
Misc WIN32 and VS2010 fixes

### DIFF
--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -134,7 +134,7 @@ enum IBAprep_flags {
 
 /// Given data types a and b, return a type that is a best guess for one
 /// that can handle both without any loss of range or precision.
-TypeDesc::BASETYPE type_merge (TypeDesc::BASETYPE a, TypeDesc::BASETYPE b);
+TypeDesc::BASETYPE OIIO_API type_merge (TypeDesc::BASETYPE a, TypeDesc::BASETYPE b);
 
 inline TypeDesc::BASETYPE
 type_merge (TypeDesc::BASETYPE a, TypeDesc::BASETYPE b, TypeDesc::BASETYPE c)

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -80,6 +80,10 @@
 # include <windows.h>
 #endif
 
+# ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
 #include "oiioversion.h"
 
 // Detect if we're C++11

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -40,6 +40,10 @@
 #include <boost/foreach.hpp>
 #include <boost/regex.hpp>
 
+#include "OpenImageIO/dassert.h"
+#include "OpenImageIO/ustring.h"
+#include "OpenImageIO/filesystem.h"
+
 #ifdef _WIN32
 #include <windows.h>
 #include <shellapi.h>
@@ -47,10 +51,6 @@
 #else
 #include <unistd.h>
 #endif
-
-#include "OpenImageIO/dassert.h"
-#include "OpenImageIO/ustring.h"
-#include "OpenImageIO/filesystem.h"
 
 
 OIIO_NAMESPACE_ENTER

--- a/src/python/py_paramvalue.cpp
+++ b/src/python/py_paramvalue.cpp
@@ -32,7 +32,7 @@
 
 namespace PyOpenImageIO
 {
-using namespace boost::python;
+using boost::python::make_tuple;
 using namespace std;
 
 template <typename BaseType>


### PR DESCRIPTION
CHANGES:
* imagebufalgo_util.h: export type_merge symbol
* platform.h : declare __cpuidex function
* filesystem.cpp : include `<windows.h>` after `"OpenImageIO/platform.h"`. Otherwise, NOMINMAX gets defined too late.
* py_paramvalue.cpp : make sure code uses make_tuple from boost::python and not make_tuple
from std::tr1. VS2010 gets confused with the current code.

Except for the second, all changes should be backported to RB 1.5