### PR TITLE
Make IB iterator constructors with 0-size ranges look "done".

### DIFF
--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -1003,6 +1003,14 @@ public:
             }
         }
 
+        // Set to the "done" position
+        void pos_done () {
+            m_valid = false;
+            m_x = m_rng_xbegin;
+            m_y = m_rng_ybegin;
+            m_z = m_rng_zend;
+        }
+
         // Make sure it's writeable. Use with caution!
         void make_writeable () {
             if (! m_localpixels) {
@@ -1043,6 +1051,9 @@ public:
         {
             make_writeable ();
             pos (m_rng_xbegin,m_rng_ybegin,m_rng_zbegin);
+            if (m_rng_xbegin == m_rng_xend || m_rng_ybegin == m_rng_yend
+                  || m_rng_zbegin == m_rng_zend)
+                pos_done();  // make empty range look "done"
         }
         /// Construct from an ImageBuf and a specific pixel index.
         /// The iteration range is the full image.
@@ -1059,6 +1070,9 @@ public:
         {
             make_writeable ();
             pos (m_rng_xbegin, m_rng_ybegin, m_rng_zbegin);
+            if (m_rng_xbegin == m_rng_xend || m_rng_ybegin == m_rng_yend
+                  || m_rng_zbegin == m_rng_zend)
+                pos_done();  // make empty range look "done"
         }
         /// Construct from an ImageBuf and designated region -- iterate
         /// over region, starting with the upper left pixel.
@@ -1069,6 +1083,9 @@ public:
         {
             make_writeable ();
             pos (m_rng_xbegin, m_rng_ybegin, m_rng_zbegin);
+            if (m_rng_xbegin == m_rng_xend || m_rng_ybegin == m_rng_yend
+                  || m_rng_zbegin == m_rng_zend)
+                pos_done();  // make empty range look "done"
         }
         /// Copy constructor.
         ///
@@ -1146,6 +1163,9 @@ public:
             : IteratorBase(ib,wrap)
         {
             pos (m_rng_xbegin,m_rng_ybegin,m_rng_zbegin);
+            if (m_rng_xbegin == m_rng_xend || m_rng_ybegin == m_rng_yend
+                  || m_rng_zbegin == m_rng_zend)
+                pos_done();  // make empty range look "done"
         }
         /// Construct from an ImageBuf and a specific pixel index.
         /// The iteration range is the full image.
@@ -1161,6 +1181,9 @@ public:
             : IteratorBase (ib, roi, wrap)
         {
             pos (m_rng_xbegin, m_rng_ybegin, m_rng_zbegin);
+            if (m_rng_xbegin == m_rng_xend || m_rng_ybegin == m_rng_yend
+                  || m_rng_zbegin == m_rng_zend)
+                pos_done();  // make empty range look "done"
         }
         /// Construct from an ImageBuf and designated region -- iterate
         /// over region, starting with the upper left pixel.
@@ -1170,6 +1193,9 @@ public:
             : IteratorBase(ib, xbegin, xend, ybegin, yend, zbegin, zend, wrap)
         {
             pos (m_rng_xbegin, m_rng_ybegin, m_rng_zbegin);
+            if (m_rng_xbegin == m_rng_xend || m_rng_ybegin == m_rng_yend
+                  || m_rng_zbegin == m_rng_zend)
+                pos_done();  // make empty range look "done"
         }
         /// Copy constructor.
         ///

--- a/src/libOpenImageIO/imagebuf_test.cpp
+++ b/src/libOpenImageIO/imagebuf_test.cpp
@@ -275,12 +275,27 @@ void test_open_with_config ()
 
 
 
+void test_empty_iterator ()
+{
+    // Ensure that ImageBuf iterators over empty ROIs immediately appear
+    // done
+    ImageBuf A (ImageSpec (64, 64, 3, TypeDesc::FLOAT));
+    ROI roi (10, 10, 20, 40, 0, 1);
+    for (ImageBuf::Iterator<float> p (A, roi);  ! p.done();  ++p) {
+        std::cout << "p is " << p.x() << ' ' << p.y() << ' ' << p.z() << "\n";
+        OIIO_CHECK_ASSERT (0 && "should never execute this loop body");
+    }
+}
+
+
+
 int
 main (int argc, char **argv)
 {
     test_wrapmodes ();
 
     // Lots of tests related to ImageBuf::Iterator
+    test_empty_iterator ();
     iterator_read_test<ImageBuf::ConstIterator<float> > ();
     iterator_read_test<ImageBuf::Iterator<float> > ();
 


### PR DESCRIPTION
Otherwise, you set up your iterator that should loop over 0 pixels, and it
visits pixels incorrectly.

Fixes #1139. Note that the problem could crop up for things other than fill(). I think this solution would solve it for all IBA functions.
