### PR TITLE
Win32 fixes

### DIFF
--- a/src/include/OpenImageIO/missing_math.h
+++ b/src/include/OpenImageIO/missing_math.h
@@ -166,6 +166,11 @@ cbrtf (float val) {
 }
 
 
+inline float
+rintf (float val) {
+    return val + copysignf(0.5f, val);
+}
+
 #elif _MSC_VER >= 1800 && __cplusplus <= 201103L
 // Prior to c++11, these were implementation defined, and on msvc, were not in the
 // std namespace

--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -39,6 +39,11 @@
 
 #include <csetjmp>
 
+#ifdef WIN32
+#undef FAR
+#define XMD_H
+#endif
+
 extern "C" {
 #include "jpeglib.h"
 }

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -33,10 +33,6 @@
 #include <cstdio>
 #include <algorithm>
 
-extern "C" {
-#include "jpeglib.h"
-}
-
 #include "OpenImageIO/imageio.h"
 #include "OpenImageIO/filesystem.h"
 #include "OpenImageIO/fmath.h"

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -29,14 +29,9 @@
   (This is the Modified BSD License)
 */
 
-
 #include <cassert>
 #include <cstdio>
 #include <vector>
-
-extern "C" {
-#include "jpeglib.h"
-}
 
 #include "OpenImageIO/imageio.h"
 #include "OpenImageIO/filesystem.h"

--- a/src/psd.imageio/jpeg_memory_src.cpp
+++ b/src/psd.imageio/jpeg_memory_src.cpp
@@ -32,10 +32,8 @@
 
 #include "OpenImageIO/imageio.h"
 
-extern "C" {
-#include <jpeglib.h>
-#include <jerror.h>
-}
+#include "jpeg_memory_src.h"
+#include "jerror.h"
 
 namespace {
 

--- a/src/psd.imageio/jpeg_memory_src.h
+++ b/src/psd.imageio/jpeg_memory_src.h
@@ -31,6 +31,11 @@
 #ifndef OPENIMAGEIO_PSD_JPEG_MEMORY_SRC_H
 #define OPENIMAGEIO_PSD_JPEG_MEMORY_SRC_H
 
+#ifdef WIN32
+//#undef FAR
+#define XMD_H
+#endif
+
 extern "C" {
 #include "jpeglib.h"
 }


### PR DESCRIPTION
`rintf` is not part of Visual Studio 2010 libraries. The first commit provides a default implementation.

The second commit is more controversial. Currently, `psd` & `jpeg` plugins do not compile on Windows for master and RB1.5 because `jpeg` headers define stuff that conflicts with `<windows.h>`. The patch attempts to prevent this in a simple manner but it is quite ugly.

The real issue here is that `<windows.h>` is included with each and every OIIO file: IMHO, it should not because this header is only really needed when using `Win32 API` (timers, threads, locks, ...).

I think a better patch would be to restore `osdep.h` usage in a few selected places and to remove `<windows.h>` from `platform.h`. I can certainly do this if you will.