### PR TITLE
Harmonize the way all binaries use --stats versus --runstats

### DIFF
--- a/src/doc/maketx.tex
+++ b/src/doc/maketx.tex
@@ -37,6 +37,10 @@ Prints usage information to the terminal.
 Verbose status messages, including runtime statistics and timing.
 \apiend
 
+\apiitem{--runstats}
+Print runtime statistics and timing.
+\apiend
+
 \apiitem{-o {\rm \emph{outputname}}}
 Sets the name of the output texture.
 \apiend

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -1818,7 +1818,7 @@ enum OIIO_API MakeTextureMode {
 ///    worldtoscreen (matrix) World-to-screen space matrix of the view.
 ///    wrapmodes (string)     Default: "black,black"
 ///    maketx:verbose (int)   How much detail should go to outstream (0).
-///    maketx:stats (int)     If nonzero, print stats to outstream (0).
+///    maketx:runstats (int)  If nonzero, print run stats to outstream (0).
 ///    maketx:resize (int)    If nonzero, resize to power of 2. (0)
 ///    maketx:nomipmap (int)  If nonzero, only output the top MIP level (0).
 ///    maketx:updatemode (int) If nonzero, write new output only if the

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1511,7 +1511,8 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
     if (! ok)
         Filesystem::remove (tmpfilename);
 
-    if (verbose || configspec.get_int_attribute("maketx:stats")) {
+    if (verbose || configspec.get_int_attribute("maketx:runstats")
+                || configspec.get_int_attribute("maketx:stats")) {
         double all = alltime();
         outstream << Strutil::format ("maketx run time (seconds): %5.2f\n", all);;
 

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -63,7 +63,7 @@ static std::string full_command_line;
 static std::vector<std::string> filenames;
 static std::string outputfilename;
 static bool verbose = false;
-static bool stats = false;
+static bool runstats = false;
 static int nthreads = 0;    // default: use #cores threads if available
 
 // Conversion modes.  If none are true, we just make an ordinary texture.
@@ -275,7 +275,8 @@ getargs (int argc, char *argv[], ImageSpec &configspec)
                   "--opaque-detect", &opaque_detect, "Drop alpha channel that is always 1.0",
                   "--no-compute-average %!", &compute_average, "Don't compute and store average color",
                   "--ignore-unassoc", &ignore_unassoc, "Ignore unassociated alpha tags in input (don't autoconvert)",
-                  "--stats", &stats, "Print runtime statistics",
+                  "--runstats", &runstats, "Print runtime statistics",
+                  "--stats", &runstats, "", // DEPRECATED 1.6
                   "--mipimage %L", &mipimages, "Specify an individual MIP level",
                   "<SEPARATOR>", "Basic modes (default is plain texture):",
                   "--shadow", &shadowmode, "Create shadow map",
@@ -367,7 +368,7 @@ getargs (int argc, char *argv[], ImageSpec &configspec)
     configspec.attribute ("wrapmodes", wrapmodes);
 
     configspec.attribute ("maketx:verbose", verbose);
-    configspec.attribute ("maketx:stats", stats);
+    configspec.attribute ("maketx:runstats", runstats);
     configspec.attribute ("maketx:resize", doresize);
     configspec.attribute ("maketx:nomipmap", nomipmap);
     configspec.attribute ("maketx:updatemode", updatemode);
@@ -468,7 +469,7 @@ main (int argc, char *argv[])
     bool ok = ImageBufAlgo::make_texture (mode, filenames[0],
                                           outputfilename, configspec,
                                           &std::cout);
-    if (stats)
+    if (runstats)
         std::cout << "\n" << ic->getstats();
 
     return ok ? 0 : EXIT_FAILURE;


### PR DESCRIPTION
--stats if applicable, prints statistics about the program inputs.

--runstats prints runtime statistics about the operation of the program itself (timing, memory, etc.)

oiiotool already used this convention, but maketx used --stats to mean run stats.
