### PR TITLE
New ImageInput supports() query: "procedural" -- if it's not corresponding to a file

### DIFF
--- a/src/doc/imageinput.tex
+++ b/src/doc/imageinput.tex
@@ -838,6 +838,8 @@ as such). The following features are recognized by this query:
   (either specifically, or via arbitrary named metadata)?
 \item[\rm \qkw{iptc}] Does the image file format support IPTC data
   (either specifically, or via arbitrary named metadata)?
+\item[\rm \qkw{procedural}] Might the image ``file format'' generate pixels
+  procedurally, without the need for any disk file to be present?
   \end{description}
 \apiend
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -527,6 +527,8 @@ public:
     ///                        arbitrary names and types?
     ///    "exif"           Can this format store Exif camera data?
     ///    "iptc"           Can this format store IPTC data?
+    ///    "procedural"     Can this format create images without reading
+    ///                        from a disk file?
     ///
     /// Note that main advantage of this approach, versus having
     /// separate individual supports_foo() methods, is that this allows

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -2175,6 +2175,14 @@ ImageCacheImpl::check_max_mem (ImageCachePerThreadInfo *thread_info)
 std::string
 ImageCacheImpl::resolve_filename (const std::string &filename) const
 {
+    // Ask if the format can generate imagery procedurally. If so, don't
+    // go looking for a file.
+    ImageInput *input = ImageInput::create (filename);
+    bool procedural = input ? input->supports ("procedural") : false;
+    ImageInput::destroy (input);
+    if (procedural)
+        return filename;
+
     std::string s = Filesystem::searchpath_find (filename, m_searchdirs, true);
     return s.empty() ? filename : s;
 }


### PR DESCRIPTION
ImageCache should not fail resolve_filename if it's a procedural file.
