### PR TITLE
Eliminate spurious cache invalidation.

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3043,8 +3043,6 @@ ImageCache::create (bool shared)
         spin_lock guard (shared_image_cache_mutex);
         if (! shared_image_cache.get())
             shared_image_cache.reset (new ImageCacheImpl);
-        else
-            shared_image_cache->invalidate_all ();
 
 #if 0
         std::cerr << " shared ImageCache is "

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -116,11 +116,9 @@ TextureSystem::create (bool shared)
         spin_lock guard (shared_texturesys_mutex);
         if (! shared_texturesys)
             shared_texturesys = new TextureSystemImpl(ImageCache::create(true));
-        else
-            shared_texturesys->invalidate_all ();
 #if 0
         std::cerr << " shared TextureSystem is "
-                  << (void *)shared_texturesys.get() << "\n";
+                  << (void *)shared_texturesys << "\n";
 #endif
         return shared_texturesys;
     }


### PR DESCRIPTION
There's no need to invalidate the cache just because somebody asks for
another copy of the shared cache.
