### PR TITLE
Fix trilinear mipmap texture lookup giving an invalid alpha fill

### DIFF
--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -1264,16 +1264,16 @@ TextureSystemImpl::texture_lookup_trilinear_mipmap (TextureFile &texturefile,
         if (! levelweight[level])  // No contribution from this level, skip it
             continue;
         float4 r, drds, drdt;
-        weight[0] = levelweight[level];
         ok &= (this->*sampler) (1, sval, tval, miplevel[level],
                                 texturefile, thread_info, options,
                                 nchannels_result, actualchannels, weight,
                                 &r, dresultds ? &drds : NULL, dresultds ? &drdt : NULL);
         ++npointson;
-        *(simd::float4 *)(result) += r;
+        float lw = levelweight[level];
+        *(simd::float4 *)(result) += lw * r;
         if (dresultds) {
-            *(simd::float4 *)(dresultds) += drds;
-            *(simd::float4 *)(dresultdt) += drdt;
+            *(simd::float4 *)(dresultds) += lw * drds;
+            *(simd::float4 *)(dresultdt) += lw * drdt;
         }
     }
 


### PR DESCRIPTION
When using trilinear mipmap texture lookup, alpha values of 2.0 are returned when using an RGB image without an alpha channel.

This happens because the `sampler` functions are implemented in such a way that the fill code assumes the `weight` values to add up to 1. This fix makes `texture_lookup_trilinear_mipmap()` apply the level weights in the same way as `texture_lookup()`, by multiplying it afterwards instead of passing it in the `weight` argument.