### PR TITLE
Fix bug in fft -- was not zeroing out imaginary channel

### DIFF
--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -327,7 +327,8 @@ bool OIIO_API cut (ImageBuf &dst, const ImageBuf &src,
 /// Copy into dst, beginning at (xbegin,ybegin,zbegin), the pixels of
 /// src described by srcroi.  If srcroi is ROI::All(), the entirety of src
 /// will be used.  It will copy into channels [chbegin...], as many
-/// channels as are described by srcroi.
+/// channels as are described by srcroi. Pixels or channels of dst outside
+/// the range of roi will not be altered.
 ///
 /// The nthreads parameter specifies how many threads (potentially) may
 /// be used, but it's not a guarantee.  If nthreads == 0, it will use

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -659,7 +659,13 @@ ImageBufAlgo::fft (ImageBuf &dst, const ImageBuf &src,
     dst.reset (dst.name(), spec);
 
     // Copy src to a 2-channel (for "complex") float buffer
-    ImageBuf A (spec);   // zeros it out automatically
+    ImageBuf A (spec);
+    if (src.nchannels() < 2) {
+        // If we're pasting fewer than 2 channels, zero out channel 1.
+        ROI r = roi;
+        r.chbegin = 1; r.chend = 2;
+        zero (A, r);
+    }
     if (! ImageBufAlgo::paste (A, 0, 0, 0, 0, src, roi, nthreads)) {
         dst.error ("%s", A.geterror());
         return false;


### PR DESCRIPTION
Fix bug in fft -- was not zeroing out imaginary channel when copying from a real-only image. Just creating a buffer does NOT zero it out, as was assumed (and commented) in this code.

This bug has been there for a while, usually is not symptomatic, depends what was lying around in the buffer. But the python-imagebufalgo test would tickle it with some regularity, It was keeping me from having clean testsuite runs, so I finally tried to figure out why, and this was it.
