### PR TITLE
Remove unused boost dependency from public header hash.h

### DIFF
--- a/src/include/OpenImageIO/hash.h
+++ b/src/include/OpenImageIO/hash.h
@@ -45,12 +45,6 @@
 #include <string.h>   // for memcpy and memset
 #include <utility>
 
-#include <boost/version.hpp>
-
-#define OIIO_HAVE_BOOST_UNORDERED_MAP
-#include <boost/unordered_map.hpp>
-#include <boost/unordered_set.hpp>
-
 #include "export.h"
 #include "oiioversion.h"
 #include "fmath.h"   /* for endian */

--- a/src/include/OpenImageIO/string_view.h
+++ b/src/include/OpenImageIO/string_view.h
@@ -36,6 +36,7 @@
 #include <cstring>
 #include <stdexcept>
 #include <algorithm>
+#include <ostream>
 
 #include "oiioversion.h"
 #include "export.h"


### PR DESCRIPTION
Had this small cleanup sitting locally for a while. These include lines are not used.