### PR TITLE
Separate test for SSE3 and SSSE3

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -52,8 +52,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if (defined(__SSE2__) || (_MSC_VER >= 1300 && !_M_CEE_PURE)) && !defined(OIIO_NO_SSE)
 #  include <xmmintrin.h>
 #  include <emmintrin.h>
-#  if defined(__SSE3__) || defined(__SSSE3__)
+#  if defined(__SSE3__)
 #    include <pmmintrin.h>
+#  endif
+#  if defined(__SSSE3__)
 #    include <tmmintrin.h>
 #  endif
 #  if (defined(__SSE4_1__) || defined(__SSE4_2__))


### PR DESCRIPTION
nocona cpu's have SSE3 without SSSE3 which breaks by including tmmintrin.h

clang 3.3 - 3.7 and gcc 4.2 4.6 and 4.8 all seem to force this to be an error.

```/usr/include/clang/3.4.1/tmmintrin.h:28:2: error: "SSSE3 instruction set not enabled"```

While nocona cpu's are getting old, when a user has set nocona as the target arch the SSSE3 header comes in and breaks the build.
