### PR TITLE
ustring fixes for new gcc (5.1+) std::string ABI

### DIFF
--- a/src/libutil/ustring.cpp
+++ b/src/libutil/ustring.cpp
@@ -318,7 +318,12 @@ ustring::TableRep::TableRep (string_view strref, size_t hash)
     // the std::string to make it point to our chars!  In such a case, the
     // destructor will be careful not to allow a deallocation.
 
-#if defined(__GNUC__) && !defined(_LIBCPP_VERSION)
+#if defined(__GNUC__) && !defined(_LIBCPP_VERSION) && defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI
+    // NEW gcc ABI
+    // FIXME -- do something smart with this.
+
+#elif defined(__GNUC__) && !defined(_LIBCPP_VERSION)
+    // OLD gcc ABI
     // It turns out that the first field of a gcc std::string is a pointer
     // to the characters within the basic_string::_Rep.  We merely redirect
     // that pointer, though for std::string to function properly, the chars

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -121,6 +121,8 @@ int main (int argc, char *argv[])
 
     OIIO_CHECK_ASSERT(ustring("foo") == ustring("foo"));
     OIIO_CHECK_ASSERT(ustring("bar") != ustring("foo"));
+    ustring foo ("foo");
+    OIIO_CHECK_ASSERT (foo.string() == "foo");
 
     std::cout << "hw threads = " << boost::thread::hardware_concurrency() << "\n";
     std::cout << "threads\ttime (best of " << ntrials << ")\n";


### PR DESCRIPTION
This makes it work (and adds a test).

We still need to return and do something more clever for that case. I'll need to install gcc 5.1 first to see how the internals work. But in the mean time, at least this will unbreak things for people already on gcc 5.1.

Fixes #1174