### PR TITLE
Python bindings: revise ImageOutput

### DIFF
--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -974,12 +974,10 @@ Closes an open output.
 Retrieves the \ImageSpec of the currently-open output image.
 \apiend
 
-\apiitem{bool ImageOutput.{\ce write_image} (typedesc, pixels, xstride=AutoStride, \\
-\bigspc\bigspc\spc ystride=AutoStride, zstride=AutoStride)}
+\apiitem{bool ImageOutput.{\ce write_image} (typedesc, pixels)}
 Write the currently opened image all at once.  The {\cf pixels} parameter
-should be an {\cf array} containing data elements of the type described by
-the \TypeDesc.  Optional strides describe data layout in the array (the
-default values of {\cf AutoStride} are used if the data are contiguous).
+should be an {\cf array} containing data elements. The data type is
+deduced from the contents of the array itself.
 Returns {\cf True} upon success, {\cf False} upon failure.
 
 \noindent Example:
@@ -997,15 +995,13 @@ Returns {\cf True} upon success, {\cf False} upon failure.
         spec.tile_width = 64
         spec.tile_height = 64
         output.open (filename, spec, oiio.Create)
-        output.write_image (oiio.FLOAT, pixels)
+        output.write_image (pixels)
         output.close ()
 \end{code}
 \apiend
 
-\apiitem{bool ImageOutput.{\ce write_scanline} (y, z, typesdesc, pixels, \\
-\bigspc\bigspc xstride=AutoStride) \\
-bool ImageOutput.{\ce write_scanlines} (ybegin, yend, z, typesdesc, pixels, \\
-\bigspc\bigspc xstride=AutoStride)}
+\apiitem{bool ImageOutput.{\ce write_scanline} (y, z, pixels) \\
+bool ImageOutput.{\ce write_scanlines} (ybegin, yend, z, pixels)}
 
 Write one or many scanlines to the currently open file.
 
@@ -1019,7 +1015,7 @@ Write one or many scanlines to the currently open file.
     for z in range(spec.z, spec.z+spec.depth) :
         for y in range(spec.y, spec.y+spec.height) :
             pixels = input.read_scanline (y, z, oiio.FLOAT)
-            output.write_scanline (y, z, oiio.FLOAT, pixels)
+            output.write_scanline (y, z, pixels)
     output.close ()
     input.close ()
 
@@ -1028,18 +1024,13 @@ Write one or many scanlines to the currently open file.
     for z in range(spec.z, spec.z+spec.depth) :
         pixels = input.read_scanlines (spec.y, spec.y+spec.height,
                                        z, oiio.FLOAT)
-        output.write_scanlines (spec.y, spec.y+spec.height,
-                                z, oiio.FLOAT, pixels)
+        output.write_scanlines (spec.y, spec.y+spec.height, z, pixels)
     ...
 \end{code}
 \apiend
 
-\apiitem{bool ImageOutput.{\ce write_tile} (x, y, z, typesdesc, pixels, \\
-\bigspc\bigspc\spc xstride=AutoStride, ystride=AutoStride, \\
-\bigspc\bigspc\spc zstride=AutoStride) \\
-bool ImageOutput.{\ce write_tiles} (xbegin, xend, ybegin, yend, zbegin, zend, \\
-\bigspc\bigspc\spc  xstride=AutoStride, ystride=AutoStride, \\
-\bigspc\bigspc\spc  zstride=AutoStride)}
+\apiitem{bool ImageOutput.{\ce write_tile} (x, y, z, pixels) \\
+bool ImageOutput.{\ce write_tiles} (xbegin, xend, ybegin, yend, zbegin, zend)}
 
 Write one or many tiles to the currently open file.
 
@@ -1053,7 +1044,7 @@ Write one or many tiles to the currently open file.
         for y in range(spec.y, spec.y+spec.height, spec.tile_height) :
             for x in range(spec.x, spec.x+spec.width, spec.tile_width) :
                 pixels = input.read_tile (x, y, z, oiio.FLOAT)
-                output.write_tile (x, y, z, oiio.FLOAT, pixels)
+                output.write_tile (x, y, z, pixels)
     output.close ()
     input.close ()
 
@@ -1065,8 +1056,7 @@ Write one or many tiles to the currently open file.
                                        y, y+tile_width,
                                        z, z+tile_width, oiio.FLOAT)
             output.write_tiles (spec.x, spec.x+spec.width,
-                               y, y+tile_width, z, z+tile_width,
-                               oiio.FLOAT, pixels)
+                                y, y+tile_width, z, z+tile_width, pixels)
     ...
 \end{code}
 \apiend
@@ -1114,7 +1104,7 @@ file.
         ok = output.open (filename, spec, oiio.Create)
         if not ok :
             print "Open error:", output.geterror()
-        ok = output.write_image (oiio.FLOAT, pixels)
+        ok = output.write_image (pixels)
         if not ok :
             print "Write error:", output.geterror()
         output.close ()

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -819,9 +819,9 @@ a subset of channels.
 \end{code}
 \apiend
 
-\apiitem{DeepData ImageOutput.{\ce read_native_deep_scanlines} (ybegin, yend, z, chbegin, chend) \\
-DeepData ImageOutput.{\ce read_native_deep_tiles} (xbegin, xend, ybegin, yend, zbegin, zend, chbegin, chend) \\
-DeepData ImageOutput.{\ce read_native_deep_image} (chbegin, chend)}
+\apiitem{DeepData ImageInput.{\ce read_native_deep_scanlines} (ybegin, yend, z, chbegin, chend) \\
+DeepData ImageInput.{\ce read_native_deep_tiles} (xbegin, xend, ybegin, yend, zbegin, zend, chbegin, chend) \\
+DeepData ImageInput.{\ce read_native_deep_image} (chbegin, chend)}
 \NEW % 1.6
 Read a collection of scanlines, tiles, or an entire image of ``deep'' pixel
 data. The begin/end coordinates are all integer values. The value returned
@@ -1053,7 +1053,7 @@ Write one or many tiles to the currently open file.
         for y in range(spec.y, spec.y+spec.height, spec.tile_height) :
             for x in range(spec.x, spec.x+spec.width, spec.tile_width) :
                 pixels = input.read_tile (x, y, z, oiio.FLOAT)
-                output.read_tile (x, y, z, oiio.FLOAT, pixels)
+                output.write_tile (x, y, z, oiio.FLOAT, pixels)
     output.close ()
     input.close ()
 
@@ -1064,9 +1064,9 @@ Write one or many tiles to the currently open file.
             pixels = input.read_tiles (spec.x, spec.x+spec.width,
                                        y, y+tile_width,
                                        z, z+tile_width, oiio.FLOAT)
-            output.read_tile (spec.x, spec.x+spec.width,
-                              y, y+tile_width, z, z+tile_width,
-                              oiio.FLOAT, pixels)
+            output.write_tiles (spec.x, spec.x+spec.width,
+                               y, y+tile_width, z, z+tile_width,
+                               oiio.FLOAT, pixels)
     ...
 \end{code}
 \apiend

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -854,7 +854,6 @@ public:
     /// the caller, who is responsible for deleting it when done with it.
     typedef ImageInput* (*Creator)();
 
-protected:
     /// Error reporting for the plugin implementation: call this with
     /// printf-like arguments.  Note however that this is fully typesafe!
     // void error (const char *format, ...) const;
@@ -1176,13 +1175,13 @@ public:
     /// the caller, who is responsible for deleting it when done with it.
     typedef ImageOutput* (*Creator)();
 
-protected:
     /// Error reporting for the plugin implementation: call this with
     /// printf-like arguments.  Note however that this is fully typesafe!
     /// void error (const char *format, ...)
     TINYFORMAT_WRAP_FORMAT (void, error, const,
         std::ostringstream msg;, msg, append_error(msg.str());)
 
+protected:
     /// Helper routines used by write_* implementations: convert data (in
     /// the given format and stride) to the "native" format of the file
     /// (described by the 'spec' member variable), in contiguous order. This

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -356,20 +356,12 @@ ImageBuf_set_pixels_array (ImageBuf &buf, ROI roi, numeric::array data)
     if (size == 0)
         return true;   // done
 
-    // Figure out the type of the array
-    object tcobj = data.attr("typecode");
-    extract<char> tce (tcobj);
-    char typecode = tce.check() ? (char)tce : 0;
-    TypeDesc type = typedesc_from_python_array_code (typecode);
-
-    const void *addr = NULL;
-    Py_ssize_t pylen = 0;
-    int success = PyObject_AsReadBuffer(data.ptr(), &addr, &pylen);
-    if (success != 0)
-        throw_error_already_set();
-
-    if (type == TypeDesc::UNKNOWN || size*type.size() > (size_t)pylen)
+    TypeDesc type;
+    size_t pylen = 0;
+    const void *addr = python_array_address (data, type, pylen);
+    if (!addr || size > pylen)
         return false;   // Not enough data to fill our ROI
+
     buf.set_pixels (roi, type, addr);
     return true;
 }

--- a/src/python/py_imageoutput.cpp
+++ b/src/python/py_imageoutput.cpp
@@ -112,6 +112,25 @@ ImageOutputWrap::make_read_buffer (object &buffer, imagesize_t size)
 
 
 bool
+ImageOutputWrap::write_scanline_array (int y, int z, numeric::array &buffer)
+{
+    TypeDesc format;
+    size_t numelements = 0;
+    const void *array = python_array_address (buffer, format, numelements);
+    if (numelements < spec().width*spec().nchannels) {
+        m_output->error ("write_scanline was not passed a long enough array");
+        return false;
+    }
+    if (! array) {
+        return false;
+    }
+    ScopedGILRelease gil;
+    return m_output->write_scanline (y, z, format, array);
+}
+
+
+// DEPRECATED (1.6)
+bool
 ImageOutputWrap::write_scanline (int y, int z, TypeDesc format, object &buffer,
                                  stride_t xstride)
 {
@@ -124,6 +143,7 @@ ImageOutputWrap::write_scanline (int y, int z, TypeDesc format, object &buffer,
 }
 
 
+// DEPRECATED (1.6)
 bool
 ImageOutputWrap::write_scanline_bt (int y, int z, TypeDesc::BASETYPE format,
                                     object &buffer, stride_t xstride)
@@ -132,6 +152,26 @@ ImageOutputWrap::write_scanline_bt (int y, int z, TypeDesc::BASETYPE format,
 }
 
 
+bool
+ImageOutputWrap::write_scanlines_array (int ybegin, int yend, int z,
+                                        numeric::array &buffer)
+{
+    TypeDesc format;
+    size_t numelements = 0;
+    const void *array = python_array_address (buffer, format, numelements);
+    if (numelements < spec().width*spec().nchannels*(yend-ybegin)) {
+        m_output->error ("write_scanlines was not passed a long enough array");
+        return false;
+    }
+    if (! array) {
+        return false;
+    }
+    ScopedGILRelease gil;
+    return m_output->write_scanlines (ybegin, yend, z, format, array);
+}
+
+
+// DEPRECATED (1.6)
 bool
 ImageOutputWrap::write_scanlines (int ybegin, int yend, int z,
                                   TypeDesc format, object &buffer,
@@ -146,6 +186,7 @@ ImageOutputWrap::write_scanlines (int ybegin, int yend, int z,
 }
 
 
+// DEPRECATED (1.6)
 bool
 ImageOutputWrap::write_scanlines_bt (int ybegin, int yend, int z,
                                      TypeDesc::BASETYPE format,
@@ -156,6 +197,25 @@ ImageOutputWrap::write_scanlines_bt (int ybegin, int yend, int z,
 
 
 
+bool
+ImageOutputWrap::write_tile_array (int x, int y, int z,
+                                   numeric::array &buffer)
+{
+    TypeDesc format;
+    size_t numelements = 0;
+    const void *array = python_array_address (buffer, format, numelements);
+    if (numelements < spec().tile_pixels()*spec().nchannels) {
+        m_output->error ("write_tile was not passed a long enough array");
+        return false;
+    }
+    if (! array) {
+        return false;
+    }
+    ScopedGILRelease gil;
+    return m_output->write_tile (x, y, z, format, array);
+}
+
+// DEPRECATED (1.6)
 bool
 ImageOutputWrap::write_tile (int x, int y, int z, TypeDesc format,
                              object &buffer, stride_t xstride,
@@ -169,6 +229,7 @@ ImageOutputWrap::write_tile (int x, int y, int z, TypeDesc format,
     return m_output->write_tile(x, y, z, format, array, xstride, ystride, zstride);    
 }
 
+// DEPRECATED (1.6)
 bool
 ImageOutputWrap::write_tile_bt (int x, int y, int z, TypeDesc::BASETYPE format,
                                 object &buffer, stride_t xstride,
@@ -179,6 +240,27 @@ ImageOutputWrap::write_tile_bt (int x, int y, int z, TypeDesc::BASETYPE format,
 
 
 
+bool
+ImageOutputWrap::write_tiles_array (int xbegin, int xend, int ybegin, int yend,
+                                    int zbegin, int zend,
+                                    numeric::array &buffer)
+{
+    TypeDesc format;
+    size_t numelements = 0;
+    const void *array = python_array_address (buffer, format, numelements);
+    if (numelements < (xend-xbegin)*(yend-ybegin)*(zend-zbegin)*spec().nchannels) {
+        m_output->error ("write_tiles was not passed a long enough array");
+        return false;
+    }
+    if (! array) {
+        return false;
+    }
+    ScopedGILRelease gil;
+    return m_output->write_tiles (xbegin, xend, ybegin, yend, zbegin, zend,
+                                  format, array);
+}
+
+// DEPRECATED (1.6)
 bool
 ImageOutputWrap::write_tiles (int xbegin, int xend, int ybegin, int yend,
                               int zbegin, int zend, TypeDesc format,
@@ -194,6 +276,7 @@ ImageOutputWrap::write_tiles (int xbegin, int xend, int ybegin, int yend,
                                   format, array, xstride, ystride, zstride);    
 }
 
+// DEPRECATED (1.6)
 bool
 ImageOutputWrap::write_tiles_bt (int xbegin, int xend, int ybegin, int yend,
                                  int zbegin, int zend, TypeDesc::BASETYPE format,
@@ -206,6 +289,25 @@ ImageOutputWrap::write_tiles_bt (int xbegin, int xend, int ybegin, int yend,
 
 
 
+bool
+ImageOutputWrap::write_image_array (numeric::array &buffer)
+{
+    TypeDesc format;
+    size_t numelements = 0;
+    const void *array = python_array_address (buffer, format, numelements);
+    if (numelements < spec().image_pixels()*spec().nchannels) {
+        m_output->error ("write_image was not passed a long enough array");
+        return false;
+    }
+    if (! array) {
+        return false;
+    }
+    ScopedGILRelease gil;
+    return m_output->write_image (format, array);
+}
+
+
+// DEPRECATED (1.6)
 bool
 ImageOutputWrap::write_image (TypeDesc format, object &buffer,
                               stride_t xstride, stride_t ystride,
@@ -222,6 +324,7 @@ ImageOutputWrap::write_image (TypeDesc format, object &buffer,
 }
 
 
+// DEPRECATED (1.6)
 bool
 ImageOutputWrap::write_image_bt (TypeDesc::BASETYPE format, object &data,
                                  stride_t xstride, stride_t ystride,
@@ -325,22 +428,27 @@ void declare_imageoutput()
              ImageOutputWrap_write_image_overloads())
         .def("write_image",     &ImageOutputWrap::write_image_bt,
              ImageOutputWrap_write_image_bt_overloads())
+        .def("write_image",     &ImageOutputWrap::write_image_array)
         .def("write_scanline",  &ImageOutputWrap::write_scanline,
              ImageOutputWrap_write_scanline_overloads())
         .def("write_scanline",  &ImageOutputWrap::write_scanline_bt,
              ImageOutputWrap_write_scanline_bt_overloads())
+        .def("write_scanline",  &ImageOutputWrap::write_scanline_array)
         .def("write_scanlines",  &ImageOutputWrap::write_scanlines,
              ImageOutputWrap_write_scanlines_overloads())
         .def("write_scanlines",  &ImageOutputWrap::write_scanlines_bt,
              ImageOutputWrap_write_scanlines_bt_overloads())
+        .def("write_scanlines",  &ImageOutputWrap::write_scanlines_array)
         .def("write_tile",      &ImageOutputWrap::write_tile,
              ImageOutputWrap_write_tile_overloads())
         .def("write_tile",      &ImageOutputWrap::write_tile_bt,
              ImageOutputWrap_write_tile_bt_overloads())
+        .def("write_tile",       &ImageOutputWrap::write_tile_array)
         .def("write_tiles",      &ImageOutputWrap::write_tiles,
              ImageOutputWrap_write_tiles_overloads())
         .def("write_tiles",      &ImageOutputWrap::write_tiles_bt,
              ImageOutputWrap_write_tiles_bt_overloads())
+        .def("write_tiles",      &ImageOutputWrap::write_tiles_array)
         .def("write_deep_scanlines", &ImageOutputWrap::write_deep_scanlines)
         .def("write_deep_tiles", &ImageOutputWrap::write_deep_tiles)
         .def("write_deep_image", &ImageOutputWrap::write_deep_image)

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -70,6 +70,13 @@ const char * python_array_code (TypeDesc format);
 TypeDesc typedesc_from_python_array_code (char code);
 
 
+// Given python array 'data', figure out its element type and number of
+// elements, and return the memory address of its contents.  Return NULL as
+// the address for an error.
+const void * python_array_address (numeric::array &data, TypeDesc &elementtype,
+                                   size_t &numelements);
+
+
 
 // Suck up one or more presumed T values into a vector<T>
 template<typename T>
@@ -205,10 +212,12 @@ public:
                          stride_t xstride=AutoStride);
     bool write_scanline_bt (int, int, TypeDesc::BASETYPE,
                             boost::python::object&, stride_t xstride=AutoStride);
+    bool write_scanline_array (int, int, numeric::array&);
     bool write_scanlines (int, int, int, TypeDesc, boost::python::object&,
                          stride_t xstride=AutoStride);
     bool write_scanlines_bt (int, int, int, TypeDesc::BASETYPE,
                             boost::python::object&, stride_t xstride=AutoStride);
+    bool write_scanlines_array (int, int, int, numeric::array&);
     bool write_tile (int, int, int, TypeDesc, boost::python::object&,
                      stride_t xstride=AutoStride, stride_t ystride=AutoStride,
                      stride_t zstride=AutoStride);
@@ -216,6 +225,7 @@ public:
                         boost::python::object&, stride_t xstride=AutoStride,
                         stride_t ystride=AutoStride,
                         stride_t zstride=AutoStride);
+    bool write_tile_array (int, int, int, numeric::array&);
     bool write_tiles (int, int, int, int, int, int,
                       TypeDesc, boost::python::object&,
                       stride_t xstride=AutoStride, stride_t ystride=AutoStride,
@@ -225,6 +235,7 @@ public:
                          stride_t xstride=AutoStride,
                          stride_t ystride=AutoStride,
                          stride_t zstride=AutoStride);
+    bool write_tiles_array (int, int, int, int, int, int, numeric::array&);
     bool write_image (TypeDesc format, object &buffer,
                       stride_t xstride=AutoStride,
                       stride_t ystride=AutoStride,
@@ -233,6 +244,7 @@ public:
                          stride_t xstride=AutoStride,
                          stride_t ystride=AutoStride,
                          stride_t zstride=AutoStride);
+    bool write_image_array (numeric::array &buffer);
     bool write_deep_scanlines (int ybegin, int yend, int z,
                                const DeepData &deepdata);
     bool write_deep_tiles (int xbegin, int xend, int ybegin, int yend,

--- a/testsuite/python-imageoutput/test_imageoutput.py
+++ b/testsuite/python-imageoutput/test_imageoutput.py
@@ -15,14 +15,14 @@ def copy_subimage (input, output, method="image",
         if not pixels :
             print "Error reading input pixels in", in_filename
             return False
-        output.write_image (memformat, pixels)
+        output.write_image (pixels)
     elif method == "scanlines" and spec.tile_width == 0 :
         pixels = input.read_image (memformat)
         if not pixels :
             print "Error reading input pixels in", in_filename
             return False
         output.write_scanlines (spec.y, spec.y+spec.height, spec.z,
-                                memformat, pixels)
+                                pixels)
     elif method == "scanline" and spec.tile_width == 0 :
         for z in range(spec.z, spec.z+spec.depth) :
             for y in range(spec.y, spec.y+spec.height) :
@@ -30,7 +30,7 @@ def copy_subimage (input, output, method="image",
                 if not pixels :
                     print "Error reading input pixels in", in_filename
                     return False
-                output.write_scanline (y, z, memformat, pixels)
+                output.write_scanline (y, z, pixels)
     elif method == "tiles" and spec.tile_width != 0 :
         pixels = input.read_image (memformat)
         if not pixels :
@@ -39,7 +39,7 @@ def copy_subimage (input, output, method="image",
         output.write_tiles (spec.x, spec.x+spec.width,
                             spec.y, spec.y+spec.height,
                             spec.z, spec.z+spec.depth,
-                            memformat, pixels)
+                            pixels)
     elif method == "tile" and spec.tile_width != 0 :
         for z in range(spec.z, spec.z+spec.depth, spec.tile_depth) :
             for y in range(spec.y, spec.y+spec.height, spec.tile_height) :
@@ -48,7 +48,7 @@ def copy_subimage (input, output, method="image",
                     if not pixels :
                         print "Error reading input pixels in", in_filename
                         return False
-                    output.write_tile (x, y, z, memformat, pixels)
+                    output.write_tile (x, y, z, pixels)
     else :
         print "Unknown method:", method
         return False


### PR DESCRIPTION
Change Python ImageOutput bindings to simplify the write_* methods.

They, oddly, took both an array and a TypeDesc describing the array. Nix the TypeDesc and just figure out the array type. If they didn't match, it would only have been trouble. Also, get rid of the stride parameters, they make sense in a C++ context, but are just confusing to Python.