### PR TITLE
Have TIFF output recognize special "tiff:write_exif" metadata.

### DIFF
--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -973,6 +973,42 @@ photometric mode (will convert to ``minisblack'').
 The TIFF plugin attempts to support all the standard Exif, IPTC, and XMP
 metadata if present.
 
+\subsubsection*{Configuration settings for TIFF input}
+
+When opening an \ImageInput with a \emph{configuration} (see
+Section~\ref{sec:inputwithconfig}), the following special configuration
+options are supported:
+
+\vspace{.125in}
+
+\noindent\begin{tabular}{p{2.0in}|p{0.5in}|p{2.75in}}
+Configuration attribute & Type & Meaning \\
+\hline
+\qkw{oiio:UnassociatedAlpha} & int & If nonzero, will leave alpha unassociated
+                                     (versus the default of premultiplying
+                                     color channels by alpha if the alpha channel
+                                     is unassociated). \\
+\end{tabular}
+
+\subsubsection*{Configuration settings for TIFF output}
+
+When opening an \ImageOutput, the following special metadata tokens control
+aspects of the writing itself:
+
+\vspace{.125in}
+
+\noindent\begin{tabular}{p{2.0in}|p{0.5in}|p{2.75in}}
+Output attribute & Type & Meaning \\
+\hline
+\qkw{oiio:UnassociatedAlpha} & int & If nonzero, any alpha channel is
+                                understood do be unassociated, and the
+                                EXTRASAMPLES tag in the TIFF file will be
+                                set to reflect this). \\
+\qkw{tiff:write_exif} & int & If zero, will not write any Exif data to the
+                            TIFF file. (The default is 1.) \\
+\end{tabular}
+
+
 \subsubsection*{Limitations}
 
 \product's TIFF reader and writer have some limitations you should be
@@ -989,8 +1025,7 @@ aware of:
 
 
 \newpage 
-%\subsubsection*{Attributes}
-\vspace{.125in}
+\subsubsection*{TIFF Attributes}
 
 \noindent\begin{tabular}{p{2.0in}|p{0.5in}|p{2.75in}}
 \ImageSpec Attribute & Type & TIFF header data or explanation \\
@@ -1037,6 +1072,9 @@ aware of:
 \qkw{oiio:UnassociatedAlpha} & int & Nonzero if the alpha channel
   contained ``unassociated'' alpha. \\
 \end{tabular}
+
+\vspace{.25in}
+
 
 
 

--- a/src/doc/imageinput.tex
+++ b/src/doc/imageinput.tex
@@ -866,6 +866,7 @@ otherwise {\kw false}.
 
 \apiitem{bool {\ce open} (const std::string \&name, ImageSpec \&newspec,\\
 \bigspc  const ImageSpec \&config)}
+\label{sec:inputwithconfig}
 
 Opens the file with given name, similarly to {\cf open(name, newspec)}.
 However, in this version, any non-default fields of {\cf config},

--- a/src/doc/maketx.tex
+++ b/src/doc/maketx.tex
@@ -328,7 +328,9 @@ Specifically, this option sets the tile size (to 64x64 for 8 bit,
 uses ``separate'' planar configuration ({\cf --separate}), and sets
 PRMan-specific metadata ({\cf --prman-metadata}).  It also outputs 
 sint16 textures if uint16 is requested (because PRMan for some reason
-does not accept true uint16 textures).
+does not accept true uint16 textures), and in the case of TIFF files will
+omit the Exif directory block which will not be recognized by the older
+version of libtiff used by PRMan.
 
 \OpenImageIO will happily accept textures that conform to PRMan's
 expectations, but not vice versa.  But \OpenImageIO's \TextureSystem

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1179,6 +1179,11 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
         if (prman_metadata)
             dstspec.attribute ("PixarTextureFormat", "Plain Texture");
     }
+    if (prman_metadata) {
+        // Suppress writing of exif directory in the TIFF file to not
+        // confuse the older libtiff that PRMan uses.
+        dstspec.attribute ("tiff:write_exif", 0);
+    }
 
     // FIXME -- should we allow tile sizes to reduce if the image is
     // smaller than the tile size?  And when we do, should we also try

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -545,6 +545,15 @@ TIFFOutput::write_exif_data ()
 #if defined(TIFF_VERSION_BIG) && TIFFLIB_VERSION >= 20120922
     // Older versions of libtiff do not support writing Exif directories
 
+    if (m_spec.get_int_attribute ("tiff:write_exif", 1) == 0) {
+        // The special metadata "tiff:write_exif", if present and set to 0
+        // (the default is 1), will cause us to skip outputting Exif data.
+        // This is useful in cases where we think the TIFF file will need to
+        // be read by an app that links against an old version of libtiff
+        // that will have trouble reading the Exif directory.
+        return true;
+    }
+
     // First, see if we have any Exif data at all
     bool any_exif = false;
     for (size_t i = 0, e = m_spec.extra_attribs.size(); i < e; ++i) {


### PR DESCRIPTION
If present and set to 0, will not write an Exif tag directory to the file, even if Exif metadata is otherwise present. This can be useful when writing a TIFF file intended to be read by an application that links to a version of libtiff that is too old to properly read the Exif data and don't want it confused.

Note in particular that PRMan may fall into that category. Therefore, if you are using 'maketx' to prepare texture files for use with PRMan, you may find it prudent to set this special metadata like this:

    maketx input.tif -prman -attrib "tiff:write_exif" 0 -o output.tx