### PR TITLE
fix signed / unsigned comparison error

### DIFF
--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -368,7 +368,7 @@ ImageBuf_set_pixels_array (ImageBuf &buf, ROI roi, numeric::array data)
     if (success != 0)
         throw_error_already_set();
 
-    if (type == TypeDesc::UNKNOWN || size*type.size() > pylen)
+    if (type == TypeDesc::UNKNOWN || size*type.size() > (size_t)pylen)
         return false;   // Not enough data to fill our ROI
     buf.set_pixels (roi, type, addr);
     return true;


### PR DESCRIPTION
On my machine, building with warning treated as errors (the default I presume) results in the following error message regarding a comparison between signed and unsigned integer types. This PR fixes the issue using an appropriate cast.

```
In function ‘bool PyOpenImageIO::ImageBuf_set_pixels_array(OpenImageIO::v1_6::ImageBuf&, OpenImageIO::v1_6::ROI, boost::python::numeric::array)’:
/home/ghislain/workspace/oiio/src/python/py_imagebuf.cpp:371:55: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
     if (type == TypeDesc::UNKNOWN || size*type.size() > pylen)
```

EDIT: added error message