### PR TITLE
JPEG bug fix: misdeclared supports()

### DIFF
--- a/src/doc/imageoutput.tex
+++ b/src/doc/imageoutput.tex
@@ -1316,7 +1316,7 @@ Returns the canonical name of the format that this \ImageOutput
 instance is capable of writing.
 \apiend
 
-\apiitem{int {\ce supports} (string_view feature)}
+\apiitem{int {\ce supports} (string_view feature) const}
 \label{sec:supportsfeaturelist}
 Given the name of a \emph{feature}, tells if this \ImageOutput  instance
 supports that feature.  Most queries will simply return 0 for ``doesn't

--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -74,7 +74,7 @@ class JpgInput : public ImageInput {
     JpgInput () { init(); }
     virtual ~JpgInput () { close(); }
     virtual const char * format_name (void) const { return "jpeg"; }
-    virtual int supports (string_view feature) {
+    virtual int supports (string_view feature) const {
         return (feature == "exif"
              || feature == "iptc");
     }

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -52,7 +52,7 @@ class JpgOutput : public ImageOutput {
     JpgOutput () { init(); }
     virtual ~JpgOutput () { close(); }
     virtual const char * format_name (void) const { return "jpeg"; }
-    virtual int supports (string_view feature) {
+    virtual int supports (string_view feature) const {
         return (feature == "exif"
              || feature == "iptc");
     }


### PR DESCRIPTION
I noticed that the JPEG reader mis-declared "supports", not having the const label, and so wasn't properly overriding the base class. Similar fix in the docs.
