### PR TITLE
imageinput: added read_native_channels, fixed bug in multipart exrs

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -751,6 +751,16 @@ public:
                              ProgressCallback progress_callback=NULL,
                              void *progress_callback_data=NULL);
 
+    // Read the specified channels of the original image into data
+    // (which must be large enough to accept it in memory). Since
+    // no format is specified, data is read back in its original format.
+    // All channels requested are automatically interleaved together
+    // into a contiguous block in the order specified by channelorder.
+    // This implies out of order access to channels, but relies on
+    // read_native_scanlines to pull image data from the current ImageInput.
+    virtual bool read_native_channels (void *data, const int *channelorder,
+                                       const int nchannels);
+
     ///
     /// Simple read_image reads to contiguous float pixels.
     bool read_image (float *data) {

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -588,6 +588,53 @@ ImageInput::read_native_tiles (int xbegin, int xend, int ybegin, int yend,
 
 
 bool
+ImageInput::read_native_channels(void *data, const int *channelorder, const int nchannels)
+{
+    std::vector<int> channelSizes(nchannels);
+    std::vector<uint8_t> buffer;
+
+    int pixelSize = 0;
+    for (int c = 0; c < nchannels ;++c){
+            int currentSize = 0;
+            if (m_spec.channelformats.size() < 1){
+                // non-per channel format case
+                // we assume all the channels match the overall format
+                currentSize = m_spec.format.size();
+            } else {
+                currentSize = m_spec.channelformats[channelorder[c]].size();
+            }
+            channelSizes[c] = currentSize;
+            pixelSize += currentSize;
+    }
+
+    int pixelStart = 0;
+    for (int c = 0; c < nchannels; ++c){
+            buffer.resize(channelSizes[c] * m_spec.height * m_spec.width);
+
+            if (!read_native_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
+                                       channelorder[c], channelorder[c]+1, buffer.data())) {
+                return false;
+            }
+            uint8_t* channelOffset = buffer.data();
+            int currentChannelSize = channelSizes[c];
+            uint8_t* pixelOffset = static_cast<uint8_t*>(data) + pixelStart;
+
+            for (int y = 0; y < m_spec.height; ++y){
+                for (int x = 0; x < m_spec.width; ++x, channelOffset += currentChannelSize, pixelOffset += pixelSize) {
+                    // Fill the output buffer based on scanline width and pixel stride
+                    memcpy(pixelOffset, channelOffset, currentChannelSize);
+                }
+            }
+            pixelStart += currentChannelSize;
+
+    }
+    return true;
+
+}
+
+
+
+bool
 ImageInput::read_image (TypeDesc format, void *data,
                         stride_t xstride, stride_t ystride, stride_t zstride,
                         ProgressCallback progress_callback,

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -415,6 +415,10 @@ OpenEXROutput::open (const std::string &name, const ImageSpec &userspec,
             return false;
         }
         m_spec = m_subimagespecs[m_subimage];
+        // We have to reset the m_pixeltype var as well. So just rebuild it from the spec for now
+        if (! spec_to_header(m_subimagespecs[m_subimage],m_subimage,m_headers[m_subimage])){
+            return false;
+        }
         return true;
 #else
         // OpenEXR 1.x does not support subimages (multi-part)
@@ -500,6 +504,15 @@ OpenEXROutput::open (const std::string &name, int subimages,
 
     m_spec = m_subimagespecs[0];
 
+    // We have to reset the m_pixeltype as well. So just rebuild it from the header/spec for now
+    if (! spec_to_header(m_subimagespecs[0],0,m_headers[0])){
+        return false;
+    }else{
+        bool tiled = m_subimagespecs[0].tile_width;
+        // Need to reset type as well otherwise it will fail
+        m_headers[0].setType (deep ? (tiled ? Imf::DEEPTILE   : Imf::DEEPSCANLINE)
+                                   : (tiled ? Imf::TILEDIMAGE : Imf::SCANLINEIMAGE));
+    }
     // Create an ImfMultiPartOutputFile
     try {
         // m_output_stream = new OpenEXROutputStream (name.c_str());

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -181,6 +181,9 @@ public:
     bool seek_subimage (int, int);
     object read_image (TypeDesc);
     object read_scanline (int y, int z, TypeDesc format);
+    object read_native_scanlines(int ybegin, int yend, int z,
+                                 int chbegin, int chend, int pixel_bytes);
+    object read_native_channels(tuple channelorder);
     object read_scanlines (int ybegin, int yend, int z,
                            int chbegin, int chend, TypeDesc format);
     object read_tile (int x, int y, int z, TypeDesc format);


### PR DESCRIPTION
Added a new method read_native_channels to imageinput and python wrappers for read_native_scanlines and read_native_channels. Fixed a bug for multi-part exrs, was setting m_pixel type incorrectly
