### PR TITLE
oiiotool should suppress output of the "textureformat" metadata

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -3700,6 +3700,9 @@ output_file (int argc, const char *argv[])
         // For deep files, must copy the native deep channelformats
         if (spec.deep)
             spec.channelformats = (*ir)(s,0).nativespec().channelformats;
+        // If it's not tiled and MIP-mapped, remove any "textureformat"
+        if (! spec.tile_pixels() || ir->miplevels(s) <= 1)
+            spec.erase_attribute ("textureformat");
         subimagespecs[s] = spec;
     }
 


### PR DESCRIPTION
oiiotool should suppress output of the "textureformat" metadata it inherited from any input, if it's not plausibly still a valid texture (in particular, if it's no longer tiled and MIPmapped).

