### PR TITLE
TIFF support a wider range of compression and photometric modes.

### DIFF
--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -1010,6 +1010,40 @@ Output attribute & Type & Meaning \\
 \end{tabular}
 
 
+\subsubsection*{TIFF compression modes}
+
+\noindent The full list of possible TIFF compression mode values are as
+follows ($ ^*$ indicates that \product can write that format, and is not
+part of the format name): \\
+    {\kw none}$ ^*$  ~
+    {\kw lzw}$ ^*$  ~
+    {\kw zip}$ ^*$  ~ \\
+    {\kw ccitt_t4}  ~
+    {\kw ccitt_t6}  ~
+    {\kw ccittfax3}  ~
+    {\kw ccittfax4}  ~
+    {\kw ccittrle2}  ~
+    {\kw ccittrle}$ ^*$  ~
+    {\kw dcs}  ~
+    {\kw isojbig}  ~
+    {\kw IT8BL}  ~
+    {\kw IT8CTPAD}  ~
+    {\kw IT8LW}  ~
+    {\kw IT8MP}  ~
+    {\kw jp2000}  ~
+    {\kw jpeg}$ ^*$  ~
+    {\kw lzma}  ~
+    {\kw next}  ~
+    {\kw ojpeg}  ~
+    {\kw packbits}$ ^*$  ~
+    {\kw pixarfilm}  ~
+    {\kw pixarlog}  ~
+    {\kw sgilog24}  ~
+    {\kw sgilog}  ~
+    {\kw T43}  ~
+    {\kw T85}  ~
+    {\kw thunderscan}  ~
+
 \subsubsection*{Limitations}
 
 \product's TIFF reader and writer have some limitations you should be
@@ -1022,6 +1056,7 @@ aware of:
   by OIIO as 8 bit images; 12 bits per pixel will be reported as 16,
   etc.  But the \qkw{oiio:BitsPerSample} attribute in the \ImageSpec
   will correctly report the original bit depth of the file.
+\item JPEG compression is limited to 8-bit per channel, 3-channel files.
 \end{itemize}
 
 
@@ -1055,7 +1090,7 @@ aware of:
 \qkw{worldtocamera} & matrix & PIXAR\_MATRIX\_WORLDTOCAMERA \\
 \qkw{worldtoscreen} & matrix & PIXAR\_MATRIX\_WORLDTOSCREEN\\
 \qkw{comrpession} & string & based on TIFF Compression 
-  (one of \qkw{none}, \qkw{lzw}, \qkw{ccittrle}, \qkw{zip}, \qkw{packbits}).\\
+  (one of \qkw{none}, \qkw{lzw}, \qkw{zip}, or others listed above.).\\
 \qkw{tiff:compression} & int & the original integer code
   from the TIFF Compression tag.\\
 \qkw{tiff:planarconfig} & string & PlanarConfiguration (\qkw{separate} or

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -95,7 +95,7 @@
 \date{{\large 
 %Editor: Larry Gritz \\[2ex]
 Date: 29 Jul 2015
-% \\ (with corrections, 7 Jan 2015)
+\\ (with corrections, 25 Aug 2015)
 }}
 
 

--- a/testsuite/tiff-suite/ref/out-alt.txt
+++ b/testsuite/tiff-suite/ref/out-alt.txt
@@ -272,7 +272,7 @@ Comparing "../../../../../libtiffpic/quad-tile.tif" and "../../../../../libtiffp
 PASS
 Reading ../../../../../libtiffpic/quad-jpeg.tif
 ../../../../../libtiffpic/quad-jpeg.tif :  512 x  384, 3 channel, uint8 tiff
-    SHA-1: F035DB0C05B1AC8E0301F41D27C1FF604EFA65E3
+    SHA-1: 3EF052D81D73F129B65F2199DFDD74E0A8E6356B
     channel list: R, G, B
     oiio:BitsPerSample: 8
     tiff:PhotometricInterpretation: 6

--- a/testsuite/tiff-suite/run.py
+++ b/testsuite/tiff-suite/run.py
@@ -11,14 +11,13 @@ imagedir = parent + "/libtiffpic"
 #    This tests 1-bit images, and packbits compression
 # cramps-tile.tif	256x256 tiled version of cramps.tif (no compression)
 #    Tests tiled images (especially tiled 1-bit) -- compare it to cramps
+# dscf0013.tif  640x480 YCbCr digital camera image which lacks Reference
+#       Black/White values. Contains EXIF SubIFD. No compression.
 command += rw_command (imagedir, "cramps.tif")
 command += rw_command (imagedir, "cramps-tile.tif")
 command += diff_command (imagedir+"/cramps-tile.tif",
                                           imagedir+"/cramps.tif")
-
-# dscf0013.tif	640x480 YCbCr digital camera image which lacks Reference
-# 		Black/White values. Contains EXIF SubIFD. No compression.
-# FIXME - we don't support YCbCr yet.  
+command += rw_command (imagedir, "dscf0013.tif")
 
 # fax2d.tif	1728x1082 1-bit b&w (G3/2D) facsimile
 # FIXME - we read the pixel data fine, but we fail to recognize that
@@ -40,7 +39,9 @@ command += rw_command (imagedir, "jello.tif")
 # off_l16.tif	333x225 8-bit CIE LogL (SGILog) office from Greg Larson
 # off_luv24.tif	333x225 8-bit CIE LogLuv (SGILog24) office from " "
 # off_luv32.tif	333x225	8-bit CIE LogLuv (SGILog) office from " "
-#  FIXME -- we just don't handle LogL or LogLuv yet
+command += rw_command (imagedir, "off_l16.tif")
+command += rw_command (imagedir, "off_luv24.tif")
+command += rw_command (imagedir, "off_luv32.tif")
 
 # pc260001.tif	640x480 8-bit RGB digital camera image. Contains EXIF SubIFD.
 # 		No compression.
@@ -48,16 +49,15 @@ command += rw_command (imagedir, "jello.tif")
 #    'Maker Note', which includes GainControl
 command += rw_command (imagedir, "pc260001.tif")
 
-# quad-jpeg.tif	512x384 8-bit YCbCr (jpeg) version of quad-lzw.tif
-#  FIXME -- we don't handle this (YCbCr? jpeg?)
-#  NOTE -- OSX preview doesn't handle this either (but ImageMagick does)
-
 # quad-lzw.tif	512x384 8-bit RGB (lzw) "quadric surfaces"
 # quad-tile.tif	512x384 tiled version of quad-lzw.tif (lzw)
+# quad-jpeg.tif 512x384 8-bit YCbCr (jpeg) version of quad-lzw.tif
 command += rw_command (imagedir, "quad-lzw.tif")
 command += rw_command (imagedir, "quad-tile.tif")
 command += diff_command (imagedir+"/quad-tile.tif",
                                           imagedir+"/quad-lzw.tif")
+command += rw_command (imagedir, "quad-jpeg.tif",
+                       extraargs="-compression zip")
 
 # strike.tif	256x200 8-bit RGBA (lzw) "bowling pins" from Pixar
 command += rw_command (imagedir, "strike.tif")
@@ -66,11 +66,13 @@ command += rw_command (imagedir, "strike.tif")
 #  FIXME -- we don't get this right
 
 # ycbcr-cat.tif	250x325 8-bit YCbCr (lzw) "kitty" created by rgb2ycbcr
-#  FIXME -- we don't get this right
+command += rw_command (imagedir, "ycbcr-cat.tif")
 
 # smallliz.tif	160x160 8-bit YCbCr (OLD jpeg) lizard from HP**
+command += rw_command (imagedir, "smallliz.tif", 0)
 # zackthecat.tif 234x213 8-bit YCbCr (OLD jpeg) tiled "ZackTheCat" from NeXT**
 #   considered a deprecated format, not supported by libtiff
+command += rw_command (imagedir, "zackthecat.tif", 0)
 
 # oxford.tif	601x81 8-bit RGB (lzw) screendump off oxford
 command += rw_command (imagedir, "oxford.tif", 0)


### PR DESCRIPTION
The TIFF reader now correctly notices and reports the full range of possible compression modes supported by libtiff. The writer still only supports a subset of them, primarily because nobody needs them and I don't want to bother carefully testing their correctness.

Enable (previously-broken) reading of JPEG-compressed TIFF and YCrCb encoded images (even when the chroma is subsampled), as well as LAB and LOG encodings. For these rare edge cases we fall back on libtiff's "ReadRGBAImage". This makes some compromises (such as forcing uint8 and buffering the whole image), but I think it's well worth supporting these in a low-performance and low-precision way rather than not at all, yet not worth the immense effort to get fully performant support for these varieties that are extremely rare.

Modify the testsuite/tiff-suite test to include several more libtiff example images, for the new modes that we handle ok now.

This patch also adds some half-baked support for writing JPEG-encoded TIFF, but as of this checkin it is disabled because I still don't have it working correctly.