### PR TITLE
Make maketx reject input images that have overscan.

### DIFF
--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1107,6 +1107,14 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
     }
 
     bool orig_was_overscan = (roi != roi_full);
+    // FIXME? For now, we don't have a strategy for making the MIPmaps in a
+    // sensible way for source image with overscan. Just reject them. Maybe
+    // someday we will return and do something smart, but for now a good way
+    // to deal with this case eludes us.
+    if (orig_was_overscan) {
+        outstream << "maketx ERROR: can't handle source images with overscan\n";
+        return false;
+    }
     if (orig_was_overscan) {
         configspec.attribute ("wrapmodes", "black,black");
     }

--- a/testsuite/texture-cropover/run.py
+++ b/testsuite/texture-cropover/run.py
@@ -2,6 +2,9 @@
 
 # Tests input image which is partial crop, partial overscan!
 
+# Skip this test. For now, we don't support overscan as texture input.
+exit ()
+
 command += oiiotool(parent + "/oiio-images/grid.tif " +
                     "--crop 500x1000+250+0 --fullsize 1000x800+0+100 -o grid-cropover.exr")
 command += maketx_command ("grid-cropover.exr",

--- a/testsuite/texture-overscan/run.py
+++ b/testsuite/texture-overscan/run.py
@@ -1,8 +1,31 @@
 #!/usr/bin/env python
 
+# FIXME: Overscan textures don't work right. It sounds fine conceptually
+# (just let texture extend past the 0-1 range), but once you start thinking
+# about how the MIP-map levels work, it gets really ugly. Because display
+# and pixel data windows (that is, image origins and resolutions) are
+# integers, once you start downsizing to generate MIP levels, you quickly
+# get into situations where whole numbers can't accurately represent the
+# sizes of the display and data windows (certainly not both at once). So
+# punt for now, skip this test, we don't expect it to work properly.
+exit ()
+
+
 command = (oiio_app("maketx") + " --filter lanczos3 "
            + parent + "/oiio-images/grid-overscan.exr"
            + " -o grid-overscan.exr ;\n")
 command = command + testtex_command ("grid-overscan.exr", "--wrap black")
 
 outputs = [ "out.exr" ]
+
+
+# FIXME: some day, remove grid-overscan.exr from oiio-images, and just
+# generate an overscan image on the fly, like shown below. But don't bother
+# for the moment, because overscan textures don't work right.
+#
+# command += (oiio_app("oiiotool") + parent+"/oiio-images/grid.tif"
+#             + " -resize 512x512 "
+#             + " -pattern checker:color1=1,0,0:color2=.25,0,0 640x640 3 "
+#             + "-origin -64-64 -paste +0+0 -o overscan-src.exr ;")
+# command += (oiio_app("maketx") + " --filter lanczos3 overscan-src.exr "
+#            + " -o grid-overscan.exr ;\n")


### PR DESCRIPTION
It's hard to know how to handle them sensibly. Because display and data window origins and sizes are integers (in all file formats we know of), there's no way to downsize them for MIP levels and preserve that property. This makes for misalignments or bleeding at edges or other undesirable behavior.  Rather than have people perplexed at the results, just have maketx reject overscan files.

Skip texture-overscan and maketx-cropover tests, we don't expect them to work.