### PR TITLE
nuke: Handle NULL Knob* in TxReaderFormat::setMipLabels

### DIFF
--- a/src/nuke/txReader/txReader.cpp
+++ b/src/nuke/txReader/txReader.cpp
@@ -53,7 +53,8 @@ public:
     inline int mipLevel() { return mipLevel_; }
 
     void setMipLabels(std::vector<std::string> items) {
-        mipLevelKnob_->enumerationKnob()->menu(items);
+        if (mipLevelKnob_)
+            mipLevelKnob_->enumerationKnob()->menu(items);
     }
 
     const char* help() { return "Tiled, mipmapped texture format"; }


### PR DESCRIPTION
Fixes a crash in the Nuke txReader when a .tx file is selected in the Nuke clip browser while the preview pane is open.

Issue: https://github.com/OpenImageIO/oiio/issues/1211