### PR TITLE
ociofiletransform

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -50,6 +50,8 @@ Major new features and improvements:
       -v which just makes more verbose (non-debugging) output. #1134 (1.6.3)
     * --pixelaspect rescales the image to have the given pixel aspect
       ratio. #1146 (1.6.5)
+    * --ociofiletransform() implements OpenColorIO "file" transforms.
+      #1213 (1.6.5)
  * New ImageBufAlgo functions:
     * absdiff() computes the absolute difference (abs(A-B)) of two images,
       or between an image and a constant color. #1029 (1.6.0)
@@ -66,6 +68,8 @@ Major new features and improvements:
     * invert() computes 1-val. #1125 (1.6.3)
     * deepen() turns a flat RGBA (and optional Z) image into a "deep"
       image. #1130 (1.6.3)
+    * ociofiletransform() implements OpenColorIO "file" transforms.
+      #1213 (1.6.5)
 * Some open source fonts are now distributed with OIIO (DroidSans,
    DroidSans-Bold, DroidSerif, DroidSerif-Bold, DroidSerif-Italic,
    DroidSerif-BoldItalic, and DroidSansMono), and so those are always

--- a/src/doc/imagebufalgo.tex
+++ b/src/doc/imagebufalgo.tex
@@ -1929,6 +1929,36 @@ environment variable will be used instead.
 \apiend
 
 
+\apiitem{bool {\ce ociofiletransform} (ImageBuf \&dst, const ImageBuf \&src, \\
+  \bigspc\spc string_view name, bool inverse=false, bool unpremult=false, \\
+  \bigspc\spc ColorConfig *colorconfig=NULL, \\
+  \bigspc\spc ROI roi=ROI::All(), int nthreads=0)}
+\index{ImageBufAlgo!ociofiletransform} \indexapi{ociofiletransform}
+\NEW % 1.6
+Copy pixels from {\cf src} to {\cf dst} (within the ROI), while applying an
+OpenColorIO ``file'' transform to the pixel values. If {\cf inverse} is {\cf
+true}, it will reverse the color transformation and look application. In-
+place operations ({\cf dst} and {\cf src} being the same image) are
+supported.
+
+If {\cf unpremult} is {\cf true}, unpremultiply before color conversion,
+then premultiply again after the color conversion.  You may want to use
+this flag if your image contains an alpha channel.
+
+An optional {\cf ColorConfig} is specified, but {\cf NULL} is passed, the
+default OCIO color configuration found by examining the {\cf \$OCIO}
+environment variable will be used instead.
+
+\smallskip
+\noindent Examples:
+\begin{code}
+    ImageBuf Src ("tahoe.jpg");
+    ImageBuf Dst;
+    ImageBufAlgo::ociofiletransform (Dst, Src, "footransform.csp");
+\end{code}
+\apiend
+
+
 \apiitem{bool {\ce unpremult} (ImageBuf \&dst, const ImageBuf \&src,\\
   \bigspc ROI roi=ROI::All(), int nthreads=0)}
 \index{ImageBufAlgo!unpremult} \indexapi{unpremult}

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -2468,6 +2468,30 @@ looks that \oiiotool knows about.
 
 \apiend
 
+\apiitem{\ce --ociofiletransform {\rm \emph{name}}}
+\NEW % 1.6
+Replace the current image with a new image whose pixels are transformed
+using the named OpenColorIO file transform.  Optional appended
+arguments include:
+
+\begin{tabular}{p{10pt} p{1in} p{3.75in}}
+ & {\cf inverse=}\emph{val} & If \emph{val} is nonzero, inverts the 
+  color transformation. \\
+\end{tabular}
+
+This command is only meaningful if OIIO was compiled with OCIO support
+and the environment variable {\cf \$OCIO} is set to point to a valid
+OpenColorIO configuration file.  If you ask for \oiiotool help 
+({\cf oiiotool --help}), at the very bottom you will see the list of all
+looks that \oiiotool knows about.
+
+\noindent Examples:
+\begin{tinycode}
+  oiiotool in.jpg --ociofiletransform footransform.csp -o out.jpg
+\end{tinycode}
+
+\apiend
+
 \apiitem{\ce --unpremult}
 Divide all color channels (those not alpha or z) of the current image by
 the alpha value, to ``un-premultiply'' them.  This presumes that the

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -195,6 +195,22 @@ public:
                                             string_view context_key="",
                                             string_view context_value="") const;
 
+    /// Construct a processor to perform color transforms determined by an
+    /// OpenColorIO FileTransform.
+    ///
+    /// It is possible that this will return NULL, if the FileTransform
+    /// doesn't exist or is not allowed.  When the user is finished with a
+    /// ColorProcess, deleteColorProcessor should be called.
+    /// ColorProcessor(s) remain valid even if the ColorConfig that created
+    /// them no longer exists.
+    ///
+    /// Multiple calls to this are potentially expensive, so you should
+    /// call once to create a ColorProcessor to use on an entire image
+    /// (or multiple images), NOT for every scanline or pixel
+    /// separately!
+    ColorProcessor* createFileTransform (string_view name,
+                                         bool inverse=false) const;
+
     /// Given a string (like a filename), look for the longest, right-most
     /// colorspace substring that appears. Returns "" if no such color space
     /// is found. (This is just a wrapper around OCIO's

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -973,7 +973,8 @@ bool OIIO_API colorconvert (float *color, int nchannels,
 ///
 /// If unpremult is true, unpremultiply before color conversion, then
 /// premultiply after the color conversion.  You may want to use this
-/// flag if your image contains an alpha channel.
+/// flag if your image contains an alpha channel. If inverse is true, it
+/// will reverse the color transformation.
 ///
 /// Return true on success, false on error (with an appropriate error
 /// message set in dst).
@@ -1021,6 +1022,25 @@ bool OIIO_API ociodisplay (ImageBuf &dst, const ImageBuf &src,
                         bool unpremult, string_view key, string_view value,
                         ROI roi, int nthreads=0);
 
+/// Copy pixels within the ROI from src to dst, applying an OpenColorIO
+/// "file" transform.  If inverse is true, it will reverse the color
+/// transformation. In-place operations (dst == src) are supported.
+///
+/// If dst is not yet initialized, it will be allocated to the same
+/// size as specified by roi.  If roi is not defined it will be all
+/// of dst, if dst is defined, or all of src, if dst is not yet defined.
+///
+/// If unpremult is true, unpremultiply before color conversion, then
+/// premultiply after the color conversion.  You may want to use this
+/// flag if your image contains an alpha channel. 
+///
+/// Return true on success, false on error (with an appropriate error
+/// message set in dst).
+bool OIIO_API ociofiletransform (ImageBuf &dst, const ImageBuf &src,
+                                 string_view name,
+                                 bool unpremult=false, bool inverse=false,
+                                 ColorConfig *colorconfig=NULL,
+                                 ROI roi=ROI::All(), int nthreads=0);
 
 /// Copy pixels from dst to src, and in the process divide all color
 /// channels (those not alpha or z) by the alpha value, to "un-premultiply"

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1417,6 +1417,23 @@ OP_CUSTOMCLASS (ociodisplay, OpOcioDisplay, 1);
 
 
 
+class OpOcioFileTransform : public OiiotoolOp {
+public:
+    OpOcioFileTransform (Oiiotool &ot, string_view opname, int argc, const char *argv[])
+        : OiiotoolOp (ot, opname, argc, argv, 1) { }
+    virtual void option_defaults () { }
+    virtual int impl (ImageBuf **img) {
+        string_view name = args[1];
+        bool inverse = Strutil::from_string<int> (options["inverse"]);
+        return ImageBufAlgo::ociofiletransform (*img[0], *img[1], name,
+                                       false, inverse, &ot.colorconfig);
+    }
+};
+
+OP_CUSTOMCLASS (ociofiletransform, OpOcioFileTransform, 1);
+
+
+
 static int
 output_tiles (int /*argc*/, const char *argv[])
 {
@@ -4126,6 +4143,8 @@ getargs (int argc, char *argv[])
                     "Apply the named OCIO look (options: from=, to=, inverse=, key=, value=)",
                 "--ociodisplay %@ %s %s", action_ociodisplay, NULL, NULL,
                     "Apply the named OCIO display and view (options: from=, looks=, key=, value=)",
+                "--ociofiletransform %@ %s", action_ociofiletransform, NULL,
+                    "Apply the named OCIO filetransform (options: inverse=)",
                 "--unpremult %@", action_unpremult, NULL,
                     "Divide all color channels of the current image by the alpha to \"un-premultiply\"",
                 "--premult %@", action_premult, NULL,

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -3510,6 +3510,7 @@ input_file (int argc, const char *argv[])
                 std::cout << "  From " << filename << ", we deduce color space \""
                           << colorspace << "\"\n";
             if (colorspace.empty()) {
+                ot.read ();
                 colorspace = ot.curimg->spec()->get_string_attribute ("oiio:ColorSpace");
                 if (ot.debug)
                     std::cout << "  Metadata of " << filename << " indicates color space \""

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -1032,6 +1032,36 @@ IBA_ociodisplay_colorconfig (ImageBuf &dst, const ImageBuf &src,
 
 
 
+bool
+IBA_ociofiletransform (ImageBuf &dst, const ImageBuf &src,
+                       const std::string &name,
+                       bool inverse, bool unpremult,
+                       ROI roi = ROI::All(), int nthreads = 0)
+{
+    ScopedGILRelease gil;
+    return ImageBufAlgo::ociofiletransform (dst, src, name,
+                                            inverse, unpremult, NULL,
+                                            roi, nthreads);
+}
+
+
+
+bool
+IBA_ociofiletransform_colorconfig (ImageBuf &dst, const ImageBuf &src,
+                                   const std::string &name,
+                                   bool inverse, bool unpremult,
+                                   const std::string &colorconfig="",
+                                   ROI roi = ROI::All(), int nthreads = 0)
+{
+    ColorConfig config (colorconfig);
+    ScopedGILRelease gil;
+    return ImageBufAlgo::ociofiletransform (dst, src, name,
+                                            inverse, unpremult, &config,
+                                            roi, nthreads);
+}
+
+
+
 object
 IBA_isConstantColor (const ImageBuf &src,
                      ROI roi = ROI::All(), int nthreads = 0)
@@ -1448,6 +1478,17 @@ void declare_imagebufalgo()
               arg("colorconfig")="",
               arg("roi")=ROI::All(), arg("nthreads")=0))
         .staticmethod("ociodisplay")
+
+        .def("ociofiletransform", &IBA_ociofiletransform,
+             (arg("dst"), arg("src"), arg("name"),
+              arg("unpremult")=false, arg("invert")=false,
+              arg("roi")=ROI::All(), arg("nthreads")=0))
+        .def("ociofiletransform", &IBA_ociofiletransform_colorconfig,
+             (arg("dst"), arg("src"), arg("name"),
+              arg("unpremult")=false, arg("invert")=false,
+              arg("colorconfig")="",
+              arg("roi")=ROI::All(), arg("nthreads")=0))
+        .staticmethod("ociofiletransform")
 
         // computePixelStats, 
 

--- a/testsuite/oiiotool-spi/run.py
+++ b/testsuite/oiiotool-spi/run.py
@@ -36,6 +36,24 @@ command += oiiotool_and_test ("ep0400_bg1_v101_3kalxog_alogc16.1001.dpx",
                               "ep0400_bg1_v101_1kalxog_vd8.1001.jpg",
                               precommand = "--colorconfig " + imagedir + "pxl.ocio/config.ocio")
 
+# Test ociofiletransform
+command += oiiotool_and_test ("os0225_110_lightingfix_v002.0101.dpx",
+                              "--ociofiletransform srgb_look.csp",
+                              "os0225_110_lightingfix_v002.0101.png",
+                              precommand = "--colorconfig " + imagedir + "os4.ocio/config.ocio")
+command += oiiotool_and_test ("os0225_110_lightingfix_v002.0170.dpx",
+                              "--ociofiletransform srgb_look.csp",
+                              "os0225_110_lightingfix_v002.0170.png",
+                              precommand = "--colorconfig " + imagedir + "os4.ocio/config.ocio")
+command += oiiotool_and_test ("os0525_120_lighting_v008.0101.dpx",
+                              "--ociofiletransform srgb_look.csp",
+                              "os0525_120_lighting_v008.0101.png",
+                              precommand = "--colorconfig " + imagedir + "os4.ocio/config.ocio")
+command += oiiotool_and_test ("os0525_120_lighting_v008.0132.dpx",
+                              "--ociofiletransform srgb_look.csp",
+                              "os0525_120_lighting_v008.0132.png",
+                              precommand = "--colorconfig " + imagedir + "os4.ocio/config.ocio")
+
 
 
 # Regression test on dealing with DPX with overscan


### PR DESCRIPTION
In ImageBufAlgo (C++ and Python) and via oiiotool command line, we exposed OpenColorIO color conversion, look transforms, and display transforms.

There's something called a "filetransform" in OCIO which we didn't expose and now somebody needs it. This patch does it.

Also fix a minor bug in oiiotool (oiiotool.cpp:3530) using --autocc that will crash if the color space isn't found in the filename, because it checks for metadata before the file has been read, and falls off a NULL pointer when looking for the ImageSpec. A simple call to read the file in that case fixes.

