### PR TITLE
ArgParse: new briefusage() method prints briefer help message.

### DIFF
--- a/src/include/OpenImageIO/argparse.h
+++ b/src/include/OpenImageIO/argparse.h
@@ -170,6 +170,11 @@ public:
     /// description arguments passed to parse().
     void usage () const;
 
+    /// Print a brief usage message to stdout.  The usage message is
+    /// generated and formatted automatically based on the command and
+    /// description arguments passed to parse().
+    void briefusage () const;
+
     /// Return the entire command-line as one string.
     ///
     std::string command_line () const;
@@ -189,6 +194,12 @@ private:
 
     int found (const char *option);      // number of times option was parsed
 };
+
+
+
+// Define symbols that let client applications determine if newly added
+// features are supported.
+#define OIIO_ARGPARSE_SUPPORTS_BRIEFUSAGE 1
 
 
 OIIO_NAMESPACE_END

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -298,9 +298,14 @@ getargs (int argc, char *argv[], ImageSpec &configspec)
         ap.usage ();
         exit (EXIT_FAILURE);
     }
-    if (help || filenames.empty()) {
+    if (help) {
         ap.usage ();
         exit (EXIT_FAILURE);
+    }
+    if (filenames.empty()) {
+        ap.briefusage ();
+        std::cout << "\nFor detailed help: maketx --help\n";
+        exit (EXIT_SUCCESS);
     }
 
     int optionsum = ((int)shadowmode + (int)envlatlmode + (int)envcubemode +
@@ -308,7 +313,6 @@ getargs (int argc, char *argv[], ImageSpec &configspec)
     if (optionsum > 1) {
         std::cerr << "maketx ERROR: At most one of the following options may be set:\n"
                   << "\t--shadow --envlatl --envcube --lightprobe\n";
-        ap.usage ();
         exit (EXIT_FAILURE);
     }
     if (optionsum == 0)
@@ -318,7 +322,6 @@ getargs (int argc, char *argv[], ImageSpec &configspec)
         std::cerr << "maketx ERROR: '--prman' compatibility, and '--oiio' optimizations are mutually exclusive.\n";
         std::cerr << "\tIf you'd like both prman and oiio compatibility, you should choose --prman\n";
         std::cerr << "\t(at the expense of oiio-specific optimizations)\n";
-        ap.usage ();
         exit (EXIT_FAILURE);
     }
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4136,8 +4136,13 @@ getargs (int argc, char *argv[])
         print_help (ap);
         exit (EXIT_SUCCESS);
     }
-    if (help || argc <= 1) {
+    if (help) {
         print_help (ap);
+        exit (EXIT_SUCCESS);
+    }
+    if (argc <= 1) {
+        ap.briefusage ();
+        std::cout << "\nFor detailed help: oiiotool --help\n";
         exit (EXIT_SUCCESS);
     }
 }


### PR DESCRIPTION
This is really helpful for programs with many command line options.  The briefusage can be used by default, quickly listing all commands, while --help (or some other trigger) can call the very long usage() with full explanations of every command, its arguments, and description.

Used this new feature for oiiotool and maketx.

As an example, here is the original output from running "maketx" with no arguments, as well as when you use --help:

    $ maketx --help
    maketx -- convert images to tiled, MIP-mapped textures
    OpenImageIO 1.6.5dev http://www.openimageio.org
    Usage:  maketx [options] file...
        --help                   Print help message
        -v                       Verbose status messages
        -o %s                    Output filename
        --old                    Old mode
        --threads %d             Number of threads (default: #cores)
        -u                       Update mode
        --format %s              Specify output file format (default: guess
                                   from extension)
        --nchannels %d           Specify the number of output image channels.
        --chnames %s             Rename channels (comma-separated)
        -d %s                    Set the output data format to one of: uint8,
                                   sint8, uint16, sint16, half, float
        --tile %d %d             Specify tile size
        --separate               Use planarconfig separate (default: contiguous)
        --compression %s         Set the compression method (default = zip, if
                                   possible)
        --fovcot %f              Override the frame aspect ratio. Default is
                                   width/height.
        --wrap %s                Specify wrap mode (black, clamp, periodic,
                                   mirror)
        --swrap %s               Specific s wrap mode separately
        --twrap %s               Specific t wrap mode separately
        --resize                 Resize textures to power of 2 (default: no)
        --noresize               Do not resize textures to power of 2
                                   (deprecated)
        --filter %s              Select filter for resizing (choices: box
                                   triangle gaussian sharp-gaussian catrom
                                   blackman-harris sinc lanczos3 radial-lanczos3
                                   mitchell bspline disk cubic keys simon rifman,
                                   default=box)
        --hicomp                 Compress HDR range before resize, expand after.
        --sharpen %f             Sharpen MIP levels (default = 0.0 = no)
        --nomipmap               Do not make multiple MIP-map levels
        --checknan               Check for NaN/Inf values (abort if found)
        --fixnan %s              Attempt to fix NaN/Inf values in the image
                                   (options: none, black, box3)
        --fullpixels             Set the 'full' image range to be the pixel
                                   data window
        --Mcamera %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f
                                 Set the camera matrix
        --Mscreen %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f
                                 Set the screen matrix
        --prman-metadata         Add prman specific metadata
        --attrib %s %s           Sets metadata attribute (name, value)
        --sattrib %s %s          Sets string metadata attribute (name, value)
        --sansattrib             Write command line into Software &
                                   ImageHistory but remove --sattrib and --attrib
                                   options
        --constant-color-detect  Create 1-tile textures from constant color
                                   inputs
        --monochrome-detect      Create 1-channel textures from monochrome
                                   inputs
        --opaque-detect          Drop alpha channel that is always 1.0
        --no-compute-average     Don't compute and store average color
        --ignore-unassoc         Ignore unassociated alpha tags in input (don't
                                   autoconvert)
        --runstats               Print runtime statistics
        --mipimage %s            Specify an individual MIP level
    Basic modes (default is plain texture):
        --shadow                 Create shadow map
        --envlatl                Create lat/long environment map
        --lightprobe             Create lat/long environment map from a light
                                   probe
    Color Management Options (OpenColorIO enabled)
        --colorconvert %s %s     Apply a color space conversion to the image.
                                   If the output color space is not the same bit
                                   depth as input color space, it is your
                                   responsibility to set the data format to the
                                   proper bit depth using the -d option.
                                   (choices: raw)
        --unpremult              Unpremultiply before color conversion, then
                                   premultiply after the color conversion.
                                   You'll probably want to use this flag if your
                                   image contains an alpha channel.
    Configuration Presets
        --prman                  Use PRMan-safe settings for tile size,
                                   planarconfig, and metadata.
        --oiio                   Use OIIO-optimized settings for tile size,

That's great when you need a detailed explanation of a command and its arguments. But if you know what you want to do but can't quite remember the command, and need just a brief reminder without having to page through several screenfuls of detail, it's not helpful.

But with this patch, `maketx --help` will continue to print the fully detailed help, but simply `maketx` (no arguments) will print the pleasingly brief:


    $ maketx
    maketx -- convert images to tiled, MIP-mapped textures
    OpenImageIO 1.6.5dev http://www.openimageio.org
    Usage:  maketx [options] file...
        --help -v -o --old --threads -u --format --nchannels --chnames -d --tile
        --separate --compression --fovcot --wrap --swrap --twrap --resize
        --noresize --filter --hicomp --sharpen --nomipmap --checknan --fixnan
        --fullpixels --Mcamera --Mscreen --prman-metadata --attrib --sattrib
        --sansattrib --constant-color-detect --monochrome-detect --opaque-detect
        --no-compute-average --ignore-unassoc --runstats --mipimage
    Basic modes (default is plain texture):
        --shadow --envlatl --lightprobe
    Color Management Options (OpenColorIO enabled)
        --colorconvert --unpremult
    Configuration Presets
        --prman --oiio
    
    For detailed help: maketx --help
