### PR TITLE
Make TIFF output support 2, 4, 10, and 12 bits unsigned per sample.

### DIFF
--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -1052,10 +1052,14 @@ aware of:
 \item No separate per-channel data formats (not supported by {\cf
   libtiff}).
 \item Only multiples of 8 bits per pixel may be passed through
-  \product's APIs, e.g., 1-, 2-, and 4-bits per pixel will be reported
-  by OIIO as 8 bit images; 12 bits per pixel will be reported as 16,
+  \product's APIs, e.g., 1-, 2-, and 4-bits per pixel will be passed
+  by OIIO as 8 bit images; 12 bits per pixel will be passed as 16,
   etc.  But the \qkw{oiio:BitsPerSample} attribute in the \ImageSpec
-  will correctly report the original bit depth of the file.
+  will correctly report the original bit depth of the file. Similarly
+  for output, you must pass 8 or 16 bit output, but \qkw{oiio:BitsPerSample}
+  gives a hint about how you want it to be when written to the file, and
+  it will try to accommodate the request (for signed integers,
+  TIFF output can accommodate 2, 4, 8, 10, 12, and 16 bits).
 \item JPEG compression is limited to 8-bit per channel, 3-channel files.
 \end{itemize}
 

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -767,6 +767,15 @@ TIFFInput::readspec (bool read_meta)
         // Palette TIFF images are always 3 channels (to the client)
         m_spec.nchannels = 3;
         m_spec.default_channel_names ();
+        if (m_bitspersample != m_spec.format.size()*8) {
+            // For palette images with unusual bits per sample, set
+            // oiio:BitsPerSample to the "full" version, to avoid problems
+            // when copying the file back to a TIFF file (we don't write
+            // palette images), but do leave "tiff:BitsPerSample" to reflect
+            // the original file.
+            m_spec.attribute ("tiff:BitsPerSample", (int)m_bitspersample);
+            m_spec.attribute ("oiio:BitsPerSample", (int)m_spec.format.size()*8);
+        }
         // FIXME - what about palette + extra (alpha?) channels?  Is that
         // allowed?  And if so, ever encountered in the wild?
     }

--- a/testsuite/tiff-depths/ref/out.txt
+++ b/testsuite/tiff-depths/ref/out.txt
@@ -159,10 +159,10 @@ Reading ../../../../../libtiffpic/depth/flower-minisblack-16.tif
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-16.tif" and "flower-minisblack-16.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-palette-02.tif
-../../../../../libtiffpic/depth/flower-palette-02.tif :   73 x   43, 3 channel, uint2 tiff
+../../../../../libtiffpic/depth/flower-palette-02.tif :   73 x   43, 3 channel, uint8 tiff
     SHA-1: 52B3033465AA01129BAE149FF96CBB49877DAB7C
     channel list: R, G, B
-    oiio:BitsPerSample: 2
+    oiio:BitsPerSample: 8
     Orientation: 1 (normal)
     XResolution: 72
     YResolution: 72
@@ -170,6 +170,7 @@ Reading ../../../../../libtiffpic/depth/flower-palette-02.tif
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
     DocumentName: "flower-palette-02.tif"
     tiff:PhotometricInterpretation: 3
+    tiff:BitsPerSample: 2
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 1
@@ -179,10 +180,10 @@ Reading ../../../../../libtiffpic/depth/flower-palette-02.tif
 Comparing "../../../../../libtiffpic/depth/flower-palette-02.tif" and "flower-palette-02.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-palette-04.tif
-../../../../../libtiffpic/depth/flower-palette-04.tif :   73 x   43, 3 channel, uint4 tiff
+../../../../../libtiffpic/depth/flower-palette-04.tif :   73 x   43, 3 channel, uint8 tiff
     SHA-1: C6E40A3D134F1A29E153FE15459D8DE657CB7F9C
     channel list: R, G, B
-    oiio:BitsPerSample: 4
+    oiio:BitsPerSample: 8
     Orientation: 1 (normal)
     XResolution: 72
     YResolution: 72
@@ -190,6 +191,7 @@ Reading ../../../../../libtiffpic/depth/flower-palette-04.tif
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
     DocumentName: "flower-palette-04.tif"
     tiff:PhotometricInterpretation: 3
+    tiff:BitsPerSample: 4
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 1


### PR DESCRIPTION
We always read all these oddball bit depths, just didn't write them,
instead we would round to uint8 or uint16.