### PR TITLE
Add an ImageInput::read_image() variant that reads a subset of channels.

### DIFF
--- a/src/doc/imageinput.tex
+++ b/src/doc/imageinput.tex
@@ -1043,6 +1043,13 @@ channels $[${\cf chbegin},{\cf chend}$)$ into the buffer.
                              stride_t ystride=AutoStride, \\
                              \bigspc stride_t zstride=AutoStride, \\
                              \bigspc ProgressCallback progress_callback=NULL,\\
+                             \bigspc void *progress_callback_data=NULL) \\
+bool {\ce read_image} (int chbegin, int chend, \\
+                             \bigspc TypeDesc format, void *data, \\
+                             \bigspc stride_t xstride=AutoStride,
+                             stride_t ystride=AutoStride, \\
+                             \bigspc stride_t zstride=AutoStride, \\
+                             \bigspc ProgressCallback progress_callback=NULL,\\
                              \bigspc void *progress_callback_data=NULL)}
 
 Read the entire image of {\kw spec.width * spec.height * spec.depth}
@@ -1062,6 +1069,9 @@ data, i.e., \\
 The function will internally either call {\kw read_scanlines} or 
 {\kw read_tiles}, depending on whether the file is scanline- or
 tile-oriented.
+
+The version that specifies a channel range will read only
+channels $[${\cf chbegin},{\cf chend}$)$ into the buffer.
 
 Because this may be an expensive operation, a progress callback may be passed.
 Periodically, it will be called as follows:\\

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -724,14 +724,15 @@ specified subimage or MIP level).
 \end{code}
 \apiend
 
-\apiitem{array ImageInput.{\ce read_image} (type=OpenImageIO.UNKNOWN)}
+\apiitem{array ImageInput.{\ce read_image} (type=OpenImageIO.UNKNOWN) \\
+array ImageInput.{\ce read_image} (chbegin, chend, type=OpenImageIO.UNKNOWN)}
 Read the entire image and return the pixels as an array of
 $\mathit{width} \times \mathit{height} \times \mathit{depth} \times \mathit{nchannels}$
 values (or {\cf None} if an error occurred).  The array will be of the type
 specified by the {\cf TypeDesc} or {\cf BASETYPE} argument, or  if the
 argument is missing or is {\cf TypeDesc(oiio.UNKNOWN)}, it will choose an
 appropriate data type that is the ``smallest'' type that can hold the actual
-types in the file.
+types in the file. The call may optionally specify a subset of channels.
 
 \noindent Example:
 \begin{code}

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -751,6 +751,21 @@ public:
                              ProgressCallback progress_callback=NULL,
                              void *progress_callback_data=NULL);
 
+    /// Read the entire image of spec.width x spec.height x spec.depth
+    /// pixels into data (which must already be sized large enough for
+    /// the entire image) with the given strides and in the desired
+    /// format.  Read tiles or scanlines automatically. Only channels
+    /// [chbegin,chend) will be read/copied (chbegin=0, chend=spec.nchannels
+    /// reads all channels, yielding equivalent behavior to the simpler
+    /// variant of read_image).
+    virtual bool read_image (int chbegin, int chend,
+                             TypeDesc format, void *data,
+                             stride_t xstride=AutoStride,
+                             stride_t ystride=AutoStride,
+                             stride_t zstride=AutoStride,
+                             ProgressCallback progress_callback=NULL,
+                             void *progress_callback_data=NULL);
+
     ///
     /// Simple read_image reads to contiguous float pixels.
     bool read_image (float *data) {

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -179,7 +179,7 @@ public:
     int current_subimage() const;
     int current_miplevel() const;
     bool seek_subimage (int, int);
-    object read_image (TypeDesc);
+    object read_image (int chbegin, int chend, TypeDesc);
     object read_scanline (int y, int z, TypeDesc format);
     object read_scanlines (int ybegin, int yend, int z,
                            int chbegin, int chend, TypeDesc format);


### PR DESCRIPTION
Did this a few days back, related to something else I'm working on.

We have variants of read_scanlines and read_tiles that let you specify a contiguous subset of channels (for some formats, may be more efficient than reading all channels when you only need some). But we lacked a version of read_image that let you specify a channel range, so this just makes it symmetric to the others.

