### PR TITLE
Remove references to boost filesystem and tokenizer.

### DIFF
--- a/src/igrep/igrep.cpp
+++ b/src/igrep/igrep.cpp
@@ -39,8 +39,6 @@
 #include <boost/scoped_ptr.hpp>
 #include <boost/foreach.hpp>
 #include <boost/regex.hpp>
-#include <boost/filesystem.hpp>
-using namespace boost::filesystem;
 
 #include "OpenImageIO/argparse.h"
 #include "OpenImageIO/strutil.h"
@@ -80,12 +78,10 @@ grep_file (const std::string &filename, boost::regex &re,
             std::cout.flush();
         }
         bool r = false;
-        boost::filesystem::path path (filename);
-        boost::filesystem::directory_iterator end_itr;  // default is past-end
-        for (boost::filesystem::directory_iterator itr(path);  itr != end_itr;  ++itr) {
-            // std::cout << "  rec " << itr->path() << "\n";
-            r |= grep_file (itr->path().string(), re, true);
-        }
+        std::vector<std::string> directory_entries;
+        Filesystem::get_directory_entries (filename, directory_entries);
+        for (size_t i = 0, e = directory_entries.size(); i < e; ++i)
+            r |= grep_file (directory_entries[i], re, true);
         return r;
     }
 

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -34,7 +34,6 @@
 
 #include <OpenEXR/half.h>
 
-#include <boost/tokenizer.hpp>
 #include <boost/foreach.hpp>
 
 #include "OpenImageIO/dassert.h"

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -34,7 +34,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
 
 #include "OpenImageIO/dassert.h"
@@ -344,11 +343,10 @@ pvt::catalog_all_plugins (std::string searchpath)
     size_t patlen = pattern.length();
     std::vector<std::string> dirs;
     Filesystem::searchpath_split (searchpath, dirs, true);
-    BOOST_FOREACH (std::string &dir, dirs) {
-        boost::filesystem::directory_iterator end_itr; // default construction yields past-the-end
-        for (boost::filesystem::directory_iterator itr (dir);
-              itr != end_itr;  ++itr) {
-            std::string full_filename = itr->path().string();
+    BOOST_FOREACH (const std::string &dir, dirs) {
+        std::vector<std::string> dir_entries;
+        Filesystem::get_directory_entries (dir, dir_entries);
+        BOOST_FOREACH (const std::string &full_filename, dir_entries) {
             std::string leaf = Filesystem::filename (full_filename);
             size_t found = leaf.find (pattern);
             if (found != std::string::npos &&

--- a/src/libOpenImageIO/iptc.cpp
+++ b/src/libOpenImageIO/iptc.cpp
@@ -31,8 +31,6 @@
 
 #include <iostream>
 
-#include <boost/tokenizer.hpp>
-
 #include "OpenImageIO/imageio.h"
 
 #define DEBUG_IPTC_READ  0

--- a/src/libOpenImageIO/xmp.cpp
+++ b/src/libOpenImageIO/xmp.cpp
@@ -32,7 +32,6 @@
 #include <iostream>
 
 #include <boost/regex.hpp>
-#include <boost/tokenizer.hpp>
 
 #include "OpenImageIO/thread.h"
 #include "OpenImageIO/strutil.h"

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -36,7 +36,6 @@
 #include <cmath>
 #include <sstream>
 #include <limits>
-#include <boost/tokenizer.hpp>
 #include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
 
@@ -205,11 +204,10 @@ Strutil::get_rest_arguments (const std::string &str, std::string &base,
     }
 
     base = str.substr (0, mark_pos);
-
-    boost::char_separator<char> sep ("&");
     std::string rest = str.substr (mark_pos + 1);
-    boost::tokenizer<boost::char_separator<char> > rest_tokens (rest, sep);
-    BOOST_FOREACH (std::string keyval, rest_tokens) {
+    std::vector<std::string> rest_tokens;
+    Strutil::split (rest, rest_tokens, "&");
+    BOOST_FOREACH (const std::string &keyval, rest_tokens) {
         mark_pos = keyval.find_first_of ("=");
         if (mark_pos == std::string::npos)
             return false;

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -265,6 +265,10 @@ void test_split ()
     OIIO_CHECK_EQUAL (splits.size(), 2);
     OIIO_CHECK_EQUAL (splits[0], "Now\nis");
     OIIO_CHECK_EQUAL (splits[1], "the  time!");
+
+    Strutil::split ("blah", splits, "!");
+    OIIO_CHECK_EQUAL (splits.size(), 1);
+    OIIO_CHECK_EQUAL (splits[0], "blah");
 }
 
 

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -36,9 +36,6 @@
 #include <limits>
 #include <sstream>
 
-#include <boost/version.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/regex.hpp>
 #include <OpenEXR/ImathMatrix.h>
 
 #include "OpenImageIO/argparse.h"

--- a/src/oiiotool/diff.cpp
+++ b/src/oiiotool/diff.cpp
@@ -38,14 +38,6 @@
 #include <string>
 #include <iomanip>
 
-#include <boost/algorithm/string.hpp>
-#include <boost/tokenizer.hpp>
-#include <boost/foreach.hpp>
-#include <boost/filesystem.hpp>
-
-using boost::algorithm::iequals;
-
-
 #include "OpenImageIO/argparse.h"
 #include "OpenImageIO/imageio.h"
 #include "OpenImageIO/imagebuf.h"
@@ -56,8 +48,6 @@ using boost::algorithm::iequals;
 
 OIIO_NAMESPACE_USING
 using namespace OiioTool;
-
-
 using namespace ImageBufAlgo;
 
 

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -39,9 +39,7 @@
 #include <utility>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/tokenizer.hpp>
 #include <boost/foreach.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/regex.hpp>
 
 using boost::algorithm::iequals;

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -42,7 +42,6 @@
 #include <ctype.h>
 #include <map>
 
-#include <boost/tokenizer.hpp>
 #include <boost/foreach.hpp>
 #include <boost/regex.hpp>
 

--- a/src/socket.imageio/socket_pvt.cpp
+++ b/src/socket.imageio/socket_pvt.cpp
@@ -35,11 +35,6 @@
 
 
 
-#include <map>
-
-#include <boost/foreach.hpp>
-#include <boost/tokenizer.hpp>
-
 #include "socket_pvt.h"
 
 OIIO_PLUGIN_NAMESPACE_BEGIN


### PR DESCRIPTION
Remove the last of the "bare" boost::filesystem references, EXCEPT the ones that are necessary inside the implementation of our Filesystem wrappers.

Remove references to boost::tokenizer, in favor of our Strutil::split.
