### PR TITLE
resolves "error: comparison between signed and unsigned integer expressions"

### DIFF
--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -93,7 +93,7 @@ private:
     unsigned int m_dither;
     int m_compression;
     int m_photometric;
-    int m_bitspersample;  ///< Of the *file*, not the client's view
+    unsigned int m_bitspersample;  ///< Of the *file*, not the client's view
 
     // Initialize private members to pre-opened state
     void init (void) {


### PR DESCRIPTION
Hi, this patch fixes a compiler warning due to signed/unsigned comparison mismatch.

Unless there's a valid reason to have a negative number of bits per pixel that I'm not aware of?

cheers