### PR TITLE
Allow ImageCache/TextureSystem to store partial channel sets in cache.

### DIFF
--- a/src/doc/imagecache.tex
+++ b/src/doc/imagecache.tex
@@ -634,13 +634,15 @@ image file will be filled with zero values.
          \bigspc\spc int xbegin, int xend, int ybegin, int yend, \\
          \bigspc\spc int zbegin, int zend, int chbegin, int chend,\\
          \bigspc\spc TypeDesc format, void *result, \\
-         \bigspc\spc stride_t xstride, stride_t ystride, stride_t zstride) \\
+         \bigspc\spc stride_t xstride, stride_t ystride, stride_t zstride,\\
+         \bitspc\spc int cache_chbegin=0, int cache_chend=-1) \\
 bool {\ce get\_pixels} (ImageHandle *file, Perthread *thread_info, \\
          \bigspc\spc int subimage, int miplevel, \\
          \bigspc\spc int xbegin, int xend, int ybegin, int yend, \\
          \bigspc\spc int zbegin, int zend, int chbegin, int chend,\\
          \bigspc\spc TypeDesc format, void *result, \\
-         \bigspc\spc stride_t xstride, stride_t ystride, stride_t zstride)}
+         \bigspc\spc stride_t xstride, stride_t ystride, stride_t zstride,\\
+         \bitspc\spc int cache_chbegin=0, int cache_chend=-1)}
 For an image specified by either name or handle,
 retrieve the rectangle of pixels and subset of channels
 of the designated {\cf subimage} and {\cf miplevel}, storing the pixel values
@@ -656,7 +658,10 @@ The rectangular region and channel set to be retrieved includes
 {\cf begin} but does not
 include {\cf end} (much like STL begin/end usage).
 Requested pixels that are not part of the valid pixel data region of the
-image file will be filled with zero values.
+image file will be filled with zero values. The optional parameters
+{\cf cache_chbegin} and {\cf cache_chend} can be used to tell the
+\ImageCache to read and cache a subset of channels (if not specified,
+all the channels of the file will be stored in the cached tile).
 \apiend
 
 

--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -551,6 +551,15 @@ The default value of zero means that all missing channels will get
 the ``fill'' color.
 \apiend
 
+\apiitem{int max_tile_channels}
+\NEW % 1.6
+Sets the maximum number of color channels in a texture file for which all
+channels will be loaded as cached tiles. Files with more than this number
+of color channels will have only the requested subset loaded, in order
+to save cache space (but at the possible wasted expense of separate tiles
+that overlap their channel ranges). The default is 5.
+\apiend
+
 \apiitem{string latlong_up}
 Sets the default ``up'' direction for latlong environment maps (only
 applies if the map itself doesn't specify a format or is in a format

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -334,6 +334,7 @@ public:
     ///     int failure_retries : how many times to retry a read failure
     ///     int deduplicate : if nonzero, detect duplicate textures (default=1)
     ///     int gray_to_rgb : make 1-channel images fill RGB lookups
+    ///     int max_tile_channels : max channels to store all chans in a tile
     ///     string latlong_up : default "up" direction for latlong ("y")
     ///
     virtual bool attribute (string_view name, TypeDesc type, const void *val) = 0;

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1543,6 +1543,28 @@ ImageCacheImpl::getstats (int level) const
                 out << (void *)this;
         }
         out << ") ver " << OIIO_VERSION_STRING << "\n";
+
+        std::string opt;
+#define BOOLOPT(name) if (m_##name) opt += #name " "
+#define INTOPT(name) opt += Strutil::format(#name "=%d ", m_##name)
+#define STROPT(name) if (m_##name.size()) opt += Strutil::format(#name "=\"%s\" ", m_##name)
+        opt += Strutil::format("max_memory_MB=%0.1f ", m_max_memory_bytes/(1024.0*1024.0));
+        INTOPT(max_open_files);
+        INTOPT(autotile);
+        INTOPT(autoscanline);
+        INTOPT(automip);
+        INTOPT(forcefloat);
+        INTOPT(accept_untiled);
+        INTOPT(accept_unmipped);
+        INTOPT(read_before_insert);
+        INTOPT(deduplicate);
+        INTOPT(unassociatedalpha);
+        INTOPT(failure_retries);
+#undef BOOLOPT
+#undef INTOPT
+#undef STROPT
+        out << "  Options:  " << Strutil::wordwrap(opt,75,12) << "\n";
+
         if (stats.unique_files) {
             out << "  Images : " << stats.unique_files << " unique\n";
             out << "    ImageInputs : " << m_stat_open_files_created << " created, " << m_stat_open_files_current << " current, " << m_stat_open_files_peak << " peak\n";

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -523,6 +523,8 @@ private:
     Imath::M44f m_Mw2c;          ///< world-to-"common" matrix
     Imath::M44f m_Mc2w;          ///< common-to-world matrix
     bool m_gray_to_rgb;          ///< automatically copy gray to rgb channels?
+    int m_max_tile_channels;     ///< narrow tile ID channel range when
+                                 ///<   the file has more channels
     /// Saved error string, per-thread
     ///
     mutable thread_specific_ptr< std::string > m_errormessage;

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -381,6 +381,17 @@ TextureSystemImpl::getstats (int level, bool icstats) const
                        stats.shadow_queries + stats.environment_queries);
     if (level > 0 && anytexture) {
         out << "OpenImageIO Texture statistics\n";
+
+        std::string opt;
+#define BOOLOPT(name) if (m_##name) opt += #name " "
+#define INTOPT(name) opt += Strutil::format(#name "=%d ", m_##name)
+#define STROPT(name) if (m_##name.size()) opt += Strutil::format(#name "=\"%s\" ", m_##name)
+        INTOPT(gray_to_rgb);
+#undef BOOLOPT
+#undef INTOPT
+#undef STROPT
+        out << "  Options:  " << Strutil::wordwrap(opt,75,12) << "\n";
+
         out << "  Queries/batches : \n";
         out << "    texture     :  " << stats.texture_queries
             << " queries in " << stats.texture_batches << " batches\n";


### PR DESCRIPTION
Allow ImageCache/TextureSystem to store partial channel sets in cache.

ImageCache's original design would read all channels into a tile,    because (1) most files have only a few channels, (2) most uses (for    example, texture) tend to use most or all of the channels in the file,    in close temporal proximity if not in the same lookup, (3) most file    formats don't have a way to read a channel subset that's any more    efficient than reading all of them.

However, for the rare case that there are MANY channels, only a few of    which are needed (for example, looking up 3 channels of textures from a    40 channel file), this is very wasteful of texture space, and MAY    (depending on the format) also be wasteful of I/O.

So this patch:

* Modifies ImageCache so that a tile can store any contiguous subset      of channels. This means the TileID stores a chbegin/chend range,      the hashes consider this, and certain ImageCache public API calls      now have varieties that take chbegin/chend parameters.

* ImageCache will create cache tiles that store exactly the channel      range requested. The default is all channels in the tile. Use subsets      wisely -- if you have a 4-channel file and you separately look up      channel ranges [0,1) and [0,3), it will redundantly read and store      the overlapping channels!

* TextureSystem is modified to ask for all channels when there are only      a few channels in the file, but when there are more than      max_tile_channels (a new settable attribute of the TS) channels in      the file, it will ask the IC for only the channels it needs for the      texture lookup. The max_tile_channels is set by default to 5, which      means for the vast majority of files (R, RGB, RGBA, RGBAZ) it will      read all channels and behave as before. But if you have a mega-channel      file, it will try to read and cache only the subset of channels you      requested with the texture call. If you don't want the new behavior,      just set max_tile_channels to something bigger.

The bottom line is that if your app uses IC with the old API calls, or    if you use TS with texture files having 5 or fewer channels (which is    almost always the case), you should see no change in behavior or    performance. But for those of you who for some reason deal with files of    many many channels, accessing a small subset of them via texture or IC    should result much more efficient cache behavior because the IC won't be    caching channels you aren't accessing.
