### PR TITLE
PFM file read: scanline order of pfm is bottom-to-top

### DIFF
--- a/testsuite/pnm/ref/out.txt
+++ b/testsuite/pnm/ref/out.txt
@@ -1,15 +1,15 @@
 Reading ../../../../../oiio-images/pnm/test-1.pfm
 ../../../../../oiio-images/pnm/test-1.pfm :   64 x   64, 3 channel, float pnm
-    SHA-1: D2F9B71115C1F07D8C8AFE38ABCBC427B7ACEEA3
+    SHA-1: ACEB5CA4B88F78E3344D79E7C8E16200FF434085
     channel list: R, G, B
     pnm:bigendian: 0
 Reading ../../../../../oiio-images/pnm/test-2.pfm
 ../../../../../oiio-images/pnm/test-2.pfm :  240 x  240, 3 channel, float pnm
-    SHA-1: 08E7F34368081D220FFFFD9CBB1EE75B1E90C560
+    SHA-1: 312B084985EF1B9C20D35A9D7A5DC8E8EAEB25A0
     channel list: R, G, B
     pnm:bigendian: 0
 Reading ../../../../../oiio-images/pnm/test-3.pfm
 ../../../../../oiio-images/pnm/test-3.pfm :  240 x  240, 3 channel, float pnm
-    SHA-1: 74310451E1248850977FC2946168F45D0011ABC4
+    SHA-1: 613A9639725F51ADC8B6F8F5A38DB5EFF0B3A628
     channel list: R, G, B
     pnm:bigendian: 1


### PR DESCRIPTION
Since PFM is uncompressed, we merely remember the file position right after the header ends, and when we need a scanline, seek to the right spot.

Fixes #1170