### PR TITLE
TIFF CMYK support

### DIFF
--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -1007,6 +1007,11 @@ Output attribute & Type & Meaning \\
                                 set to reflect this). \\
 \qkw{tiff:write_exif} & int & If zero, will not write any Exif data to the
                             TIFF file. (The default is 1.) \\
+
+\qkws{tiff:ColorSpace} & string & Requests that the file be
+                        saved with a non-RGB color spaces.
+                        Choices are \qkw{RGB}, \qkw{CMYK}.
+                        % , \qkw{YCbCr}, \qkw{CIELAB}, \qkw{ICCLAB}, \qkw{ITULAB}
 \end{tabular}
 
 

--- a/testsuite/tiff-depths/ref/out.txt
+++ b/testsuite/tiff-depths/ref/out.txt
@@ -158,6 +158,26 @@ Reading ../../../../../libtiffpic/depth/flower-minisblack-16.tif
     PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-16.tif" and "flower-minisblack-16.tif"
 PASS
+Reading ../../../../../libtiffpic/depth/flower-minisblack-32.tif
+../../../../../libtiffpic/depth/flower-minisblack-32.tif :   73 x   43, 1 channel, uint tiff
+    SHA-1: C98FB1125C7210E380E3F86DFCAEFF49A16742E0
+    channel list: A
+    oiio:BitsPerSample: 32
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-minisblack-32.tif"
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    planarconfig: "contig"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 28
+    PixelAspectRatio: 1
+Comparing "../../../../../libtiffpic/depth/flower-minisblack-32.tif" and "flower-minisblack-32.tif"
+PASS
 Reading ../../../../../libtiffpic/depth/flower-palette-02.tif
 ../../../../../libtiffpic/depth/flower-palette-02.tif :   73 x   43, 3 channel, uint8 tiff
     SHA-1: 52B3033465AA01129BAE149FF96CBB49877DAB7C
@@ -170,6 +190,7 @@ Reading ../../../../../libtiffpic/depth/flower-palette-02.tif
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
     DocumentName: "flower-palette-02.tif"
     tiff:PhotometricInterpretation: 3
+    tiff:ColorSpace: "palette"
     tiff:BitsPerSample: 2
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
@@ -191,6 +212,7 @@ Reading ../../../../../libtiffpic/depth/flower-palette-04.tif
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
     DocumentName: "flower-palette-04.tif"
     tiff:PhotometricInterpretation: 3
+    tiff:ColorSpace: "palette"
     tiff:BitsPerSample: 4
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
@@ -212,6 +234,7 @@ Reading ../../../../../libtiffpic/depth/flower-palette-08.tif
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
     DocumentName: "flower-palette-08.tif"
     tiff:PhotometricInterpretation: 3
+    tiff:ColorSpace: "palette"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 1
@@ -360,6 +383,26 @@ Reading ../../../../../libtiffpic/depth/flower-rgb-contig-16.tif
     PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-16.tif" and "flower-rgb-contig-16.tif"
 PASS
+Reading ../../../../../libtiffpic/depth/flower-rgb-contig-32.tif
+../../../../../libtiffpic/depth/flower-rgb-contig-32.tif :   73 x   43, 3 channel, uint tiff
+    SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
+    channel list: R, G, B
+    oiio:BitsPerSample: 32
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-rgb-contig-32.tif"
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    planarconfig: "contig"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 9
+    PixelAspectRatio: 1
+Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-32.tif" and "flower-rgb-contig-32.tif"
+PASS
 Reading ../../../../../libtiffpic/depth/flower-rgb-planar-02.tif
 ../../../../../libtiffpic/depth/flower-rgb-planar-02.tif :   73 x   43, 3 channel, uint2 tiff
     SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
@@ -499,4 +542,88 @@ Reading ../../../../../libtiffpic/depth/flower-rgb-planar-16.tif
     tiff:RowsPerStrip: 56
     PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-rgb-planar-16.tif" and "flower-rgb-planar-16.tif"
+PASS
+Reading ../../../../../libtiffpic/depth/flower-separated-contig-08.tif
+../../../../../libtiffpic/depth/flower-separated-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
+    channel list: R, G, B
+    oiio:BitsPerSample: 8
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-separated-contig-08.tif"
+    tiff:PhotometricInterpretation: 5
+    tiff:ColorSpace: "CMYK"
+    tiff:PlanarConfiguration: 1
+    planarconfig: "contig"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 28
+    PixelAspectRatio: 1
+Comparing "../../../../../libtiffpic/depth/flower-separated-contig-08.tif" and "flower-separated-contig-08.tif"
+PASS
+Reading ../../../../../libtiffpic/depth/flower-separated-contig-16.tif
+../../../../../libtiffpic/depth/flower-separated-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 11EDBB53957F64BDDD05F0BF4121505763956CA9
+    channel list: R, G, B
+    oiio:BitsPerSample: 16
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-separated-contig-16.tif"
+    tiff:PhotometricInterpretation: 5
+    tiff:ColorSpace: "CMYK"
+    tiff:PlanarConfiguration: 1
+    planarconfig: "contig"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 14
+    PixelAspectRatio: 1
+Comparing "../../../../../libtiffpic/depth/flower-separated-contig-16.tif" and "flower-separated-contig-16.tif"
+PASS
+Reading ../../../../../libtiffpic/depth/flower-separated-planar-08.tif
+../../../../../libtiffpic/depth/flower-separated-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
+    channel list: R, G, B
+    oiio:BitsPerSample: 8
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-separated-planar-08.tif"
+    tiff:PhotometricInterpretation: 5
+    tiff:ColorSpace: "CMYK"
+    tiff:PlanarConfiguration: 2
+    planarconfig: "separate"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 112
+    PixelAspectRatio: 1
+Comparing "../../../../../libtiffpic/depth/flower-separated-planar-08.tif" and "flower-separated-planar-08.tif"
+PASS
+Reading ../../../../../libtiffpic/depth/flower-separated-planar-16.tif
+../../../../../libtiffpic/depth/flower-separated-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 11EDBB53957F64BDDD05F0BF4121505763956CA9
+    channel list: R, G, B
+    oiio:BitsPerSample: 16
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    DocumentName: "flower-separated-planar-16.tif"
+    tiff:PhotometricInterpretation: 5
+    tiff:ColorSpace: "CMYK"
+    tiff:PlanarConfiguration: 2
+    planarconfig: "separate"
+    tiff:Compression: 1
+    compression: "none"
+    tiff:RowsPerStrip: 56
+    PixelAspectRatio: 1
+Comparing "../../../../../libtiffpic/depth/flower-separated-planar-16.tif" and "flower-separated-planar-16.tif"
 PASS

--- a/testsuite/tiff-depths/run.py
+++ b/testsuite/tiff-depths/run.py
@@ -13,7 +13,7 @@ files = [
     "flower-minisblack-14.tif",   #  73x43 14-bit minisblack gray image
     "flower-minisblack-16.tif",   # 73x43 16-bit minisblack gray image
     #FIXME "flower-minisblack-24.tif",   #  73x43 24-bit minisblack gray image
-    #FIXME "flower-minisblack-32.tif",   #  73x43 32-bit minisblack gray image
+    "flower-minisblack-32.tif",   #  73x43 32-bit minisblack gray image
     "flower-palette-02.tif",   #73x43 4-entry colormapped image
     "flower-palette-04.tif",   #73x43 16-entry colormapped image
     "flower-palette-08.tif",   #73x43 256-entry colormapped image
@@ -26,20 +26,20 @@ files = [
     "flower-rgb-contig-14.tif",   #  73x43 14-bit contiguous RGB image
     "flower-rgb-contig-16.tif",   #  73x43 16-bit contiguous RGB image
     #FIXME "flower-rgb-contig-24.tif",   #  73x43 24-bit contiguous RGB image
-    #FIXME "flower-rgb-contig-32.tif",   #  73x43 32-bit contiguous RGB image
+    "flower-rgb-contig-32.tif",   #  73x43 32-bit contiguous RGB image
     "flower-rgb-planar-02.tif",   #  73x43 2-bit seperated RGB image
     "flower-rgb-planar-04.tif",   #  73x43 4-bit seperated RGB image
     "flower-rgb-planar-08.tif",   #  73x43 8-bit seperated RGB image
     "flower-rgb-planar-10.tif",   #  73x43 10-bit seperated RGB image
     "flower-rgb-planar-12.tif",   #  73x43 12-bit seperated RGB image
     "flower-rgb-planar-14.tif",   #  73x43 14-bit seperated RGB image
-    "flower-rgb-planar-16.tif"    #  73x43 16-bit seperated RGB image
+    "flower-rgb-planar-16.tif",   #  73x43 16-bit seperated RGB image
     #FIXME "flower-rgb-planar-24.tif",   #  73x43 24-bit seperated RGB image
     #FIXME "flower-rgb-planar-32.tif",   #  73x43 32-bit seperated RGB image
-    #FIXME "flower-separated-contig-08.tif",  # 73x43 8-bit contiguous CMYK image
-    #FIXME "flower-separated-contig-16.tif",  # 73x43 16-bit contiguous CMYK image
-    #FIXME "flower-separated-planar-08.tif",  # 73x43 8-bit separated CMYK image
-    #FIXME "flower-separated-planar-16.tif",  # 73x43 16-bit separated CMYK image
+    "flower-separated-contig-08.tif",  # 73x43 8-bit contiguous CMYK image
+    "flower-separated-contig-16.tif",  # 73x43 16-bit contiguous CMYK image
+    "flower-separated-planar-08.tif",  # 73x43 8-bit separated CMYK image
+    "flower-separated-planar-16.tif",  # 73x43 16-bit separated CMYK image
     ]
 
 for f in files:

--- a/testsuite/tiff-suite/ref/out-alt.txt
+++ b/testsuite/tiff-suite/ref/out-alt.txt
@@ -48,6 +48,7 @@ Reading ../../../../../libtiffpic/dscf0013.tif
     Copyright: "          "
     DateTime: "2004:11:10 00:00:31"
     tiff:PhotometricInterpretation: 6
+    tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 1
@@ -82,6 +83,7 @@ Reading ../../../../../libtiffpic/dscf0013.tif
     YResolution: 72
     ResolutionUnit: "in"
     tiff:PhotometricInterpretation: 6
+    tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 1
@@ -135,6 +137,7 @@ Reading ../../../../../libtiffpic/jello.tif
     oiio:BitsPerSample: 8
     Orientation: 1 (normal)
     tiff:PhotometricInterpretation: 3
+    tiff:ColorSpace: "palette"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 32773
@@ -152,6 +155,7 @@ Reading ../../../../../libtiffpic/off_l16.tif
     YResolution: 72
     ResolutionUnit: "in"
     tiff:PhotometricInterpretation: 32844
+    tiff:ColorSpace: "LOGL"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 34676
@@ -170,6 +174,7 @@ Reading ../../../../../libtiffpic/off_luv24.tif
     YResolution: 72
     ResolutionUnit: "in"
     tiff:PhotometricInterpretation: 32845
+    tiff:ColorSpace: "LOGLUV"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 34677
@@ -188,6 +193,7 @@ Reading ../../../../../libtiffpic/off_luv32.tif
     YResolution: 72
     ResolutionUnit: "in"
     tiff:PhotometricInterpretation: 32845
+    tiff:ColorSpace: "LOGLUV"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 34676
@@ -276,6 +282,7 @@ Reading ../../../../../libtiffpic/quad-jpeg.tif
     channel list: R, G, B
     oiio:BitsPerSample: 8
     tiff:PhotometricInterpretation: 6
+    tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 7
@@ -308,6 +315,7 @@ Reading ../../../../../libtiffpic/ycbcr-cat.tif
     ImageDescription: "YCbCr conversion of cat.tif"
     Orientation: 1 (normal)
     tiff:PhotometricInterpretation: 6
+    tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 5
@@ -325,6 +333,7 @@ Reading ../../../../../libtiffpic/smallliz.tif
     ResolutionUnit: "in"
     Software: "HP IL v1.1"
     tiff:PhotometricInterpretation: 6
+    tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 6
@@ -342,6 +351,7 @@ Reading ../../../../../libtiffpic/zackthecat.tif
     YResolution: 75
     ResolutionUnit: "in"
     tiff:PhotometricInterpretation: 6
+    tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 6

--- a/testsuite/tiff-suite/ref/out.txt
+++ b/testsuite/tiff-suite/ref/out.txt
@@ -48,6 +48,7 @@ Reading ../../../../../libtiffpic/dscf0013.tif
     Copyright: "          "
     DateTime: "2004:11:10 00:00:31"
     tiff:PhotometricInterpretation: 6
+    tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 1
@@ -82,6 +83,7 @@ Reading ../../../../../libtiffpic/dscf0013.tif
     YResolution: 72
     ResolutionUnit: "in"
     tiff:PhotometricInterpretation: 6
+    tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 1
@@ -135,6 +137,7 @@ Reading ../../../../../libtiffpic/jello.tif
     oiio:BitsPerSample: 8
     Orientation: 1 (normal)
     tiff:PhotometricInterpretation: 3
+    tiff:ColorSpace: "palette"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 32773
@@ -152,6 +155,7 @@ Reading ../../../../../libtiffpic/off_l16.tif
     YResolution: 72
     ResolutionUnit: "in"
     tiff:PhotometricInterpretation: 32844
+    tiff:ColorSpace: "LOGL"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 34676
@@ -170,6 +174,7 @@ Reading ../../../../../libtiffpic/off_luv24.tif
     YResolution: 72
     ResolutionUnit: "in"
     tiff:PhotometricInterpretation: 32845
+    tiff:ColorSpace: "LOGLUV"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 34677
@@ -188,6 +193,7 @@ Reading ../../../../../libtiffpic/off_luv32.tif
     YResolution: 72
     ResolutionUnit: "in"
     tiff:PhotometricInterpretation: 32845
+    tiff:ColorSpace: "LOGLUV"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 34676
@@ -276,6 +282,7 @@ Reading ../../../../../libtiffpic/quad-jpeg.tif
     channel list: R, G, B
     oiio:BitsPerSample: 8
     tiff:PhotometricInterpretation: 6
+    tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 7
@@ -308,6 +315,7 @@ Reading ../../../../../libtiffpic/ycbcr-cat.tif
     ImageDescription: "YCbCr conversion of cat.tif"
     Orientation: 1 (normal)
     tiff:PhotometricInterpretation: 6
+    tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 5
@@ -325,6 +333,7 @@ Reading ../../../../../libtiffpic/smallliz.tif
     ResolutionUnit: "in"
     Software: "HP IL v1.1"
     tiff:PhotometricInterpretation: 6
+    tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 6
@@ -342,6 +351,7 @@ Reading ../../../../../libtiffpic/zackthecat.tif
     YResolution: 75
     ResolutionUnit: "in"
     tiff:PhotometricInterpretation: 6
+    tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
     tiff:Compression: 6


### PR DESCRIPTION
Needed at my place so that our usual oiiotool-based color correction pipeline can deliver certain marketing assets that need to be CMYK for some reason. 

The refactor of the TIFF code to make all this work was a little more involved than I'd hoped. It's not conceptually hard, but some code got shuffled around.