### PR TITLE
Separate global "threads" and "exr_threads" attributes.

### DIFF
--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -805,11 +805,31 @@ attribute is a string), the attribute will not be modified, and {\cf
 \vspace{10pt}
 \index{threads} \label{sec:attribute:threads}
 Some \product operations can be accelerated if allowed to spawn multiple
-threads to parallelize the task.  (Examples: decompressing multiple
-simultaneously-read OpenEXR scanlines, or many \ImageBuf operations.)
-This attribute sets the maximum number of threads that will be spawned.
-The default is 1.  If set to 0, it means that it should use as many
+threads to parallelize the task.  (Examples: simultaneous format conversions
+of multiple scanlines read together, or many \ImageBufAlgo operations.)
+This attribute sets the default number of threads that will be spawned
+for these operations (the ``fan out'').
+The default is 0, which means that it should spawn as many
 threads as there are hardware cores present on the system.
+
+Situations where the main application logic is essentially single threaded
+(i.e., one top-level call into OIIO at a time) should leave this at the
+default value, or some reasonable number of cores, thus allowing lots of
+threads to fill the cores when OIIO has big tasks to complete. But
+situations where you have many threads at the application level, each of
+which is expected to be making separate OIIO calls simultaneously, should
+set this to 1, thus having each calling thread do its own work inside of
+OIIO rather than spawning new threads with a high overall ``fan out.''
+\apiend
+
+\apiitem{int exr_threads}
+\vspace{10pt}
+\index{exr_threads}
+\NEW % 1.6
+Sets the internal OpenEXR thread pool size. The default is to use as many
+threads as the amount of hardware concurrency detected.
+Note that this is separate from the OIIO
+\qkw{threads} attribute.
 \apiend
 
 \apiitem{string plugin_searchpath}

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -328,7 +328,9 @@ static int
 set_threads (int argc, const char *argv[])
 {
     ASSERT (argc == 2);
-    OIIO::attribute ("threads", atoi(argv[1]));
+    int nthreads = atoi(argv[1]);
+    OIIO::attribute ("threads", nthreads);
+    OIIO::attribute ("exr_threads", nthreads);
     return 0;
 }
 

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -316,12 +316,12 @@ void set_exr_threads ()
     static spin_mutex exr_threads_mutex;  
 
     int oiio_threads = 1;
-    OIIO::getattribute ("threads", oiio_threads);
+    OIIO::getattribute ("exr_threads", oiio_threads);
 
     spin_lock lock (exr_threads_mutex);
     if (exr_threads != oiio_threads) {
         exr_threads = oiio_threads;
-        Imf::setGlobalThreadCount (exr_threads == 1 ? 0 : exr_threads);
+        Imf::setGlobalThreadCount (exr_threads);
     }
 }
 


### PR DESCRIPTION
The global OIIO "threads" attribute controls the default "fan out" of
spawned threads when an OIIO call has work that can be parallelized
(like for ImageBufAlgo functions). Apps with essentially single logic
thread leave this at 0, which means to spawn #cores threads, whereas
apps with lots of app-side threads set it to 1 to prevent OIIO from
internally spawning many threads for each app calling thread.

Unfortunately, we were using the same attribute value to set the size of
OpenEXR's thread pool size. In an app where we set "threads" to 1 to
prevent OIIO fan-out, this was unfortunately also limiting OpenEXR's
worker thread pool to 1, which means the various threads would block
against each other.

It seems like the best solution is to break this apart into separate
attributes: "threads" to control the OIIO fan-out, and "exr_threads"
to control the size of OpenEXR's thread pool. Most apps need not mess
with either of these.