### PR TITLE
TIFF: Recognize Exif tags in the regular directory, not special Exif dir.

### DIFF
--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -746,6 +746,9 @@ TIFFInput::readspec (bool read_meta)
         for (int i = 0;  tiff_tag_table[i].name;  ++i)
             find_tag (tiff_tag_table[i].tifftag,
                       tiff_tag_table[i].tifftype, tiff_tag_table[i].name);
+        for (int i = 0;  tiff_tag_table[i].name;  ++i)
+            find_tag (exif_tag_table[i].tifftag,
+                      exif_tag_table[i].tifftype, exif_tag_table[i].name);
     }
 
     // Now we need to get fields "by hand" for anything else that is less


### PR DESCRIPTION
I came across some documents that made me think that there may be TIFF files that directly have these tags in the main directory. So may as well recognize them.


