### PR TITLE
OIIO::debugmsg() preferred over raw debugging output to stderr or stdout.

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1281,8 +1281,11 @@ OIIO_API std::string geterror ();
 /// Documented attributes:
 ///     int threads
 ///             How many threads to use for operations that can be sped
-///             by spawning threads (default=1; note that 0 means "as
-///             many threads as cores").
+///             by spawning threads (default=0, meaning to use the full
+///             available hardware concurrency detected).
+///     int exr_threads
+///             The size of the internal OpenEXR thread pool. The default
+///             is to use the full available hardware concurrency detected.
 ///     string plugin_searchpath
 ///             Colon-separated list of directories to search for 
 ///             dynamically-loaded format plugins.
@@ -1295,6 +1298,14 @@ OIIO_API std::string geterror ();
 ///             are presumed to be used for that format.  Semicolons
 ///             separate the lists for formats.  For example,
 ///                "tiff:tif;jpeg:jpg,jpeg;openexr:exr"
+///     int read_chunk
+///             The number of scanlines that will be attempted to read at
+///             once for read_image calls (default: 256).
+///     int debug
+///             When nonzero, various debug messages may be printed.
+///             The default is 0 for release builds, 1 for DEBUG builds,
+///             but also may be overridden by the OPENIMAGEIO_DEBUG env
+///             variable.
 OIIO_API bool attribute (string_view name, TypeDesc type, const void *val);
 // Shortcuts for common types
 inline bool attribute (string_view name, int val) {
@@ -1487,6 +1498,20 @@ OIIO_API bool wrap_mirror (int &coord, int origin, int width);
 
 // Typedef for the function signature of a wrap implementation.
 typedef bool (*wrap_impl) (int &coord, int origin, int width);
+
+
+namespace pvt {
+// For internal use - use debugmsg() below for a nicer interface.
+void debugmsg_ (string_view message);
+};
+
+/// debugmsg(format, ...) prints debugging message when attribute "debug" is
+/// nonzero, which it is by default for DEBUG compiles or when the
+/// environment variable OPENIMAGEIO_DEBUG is set. This is preferred to raw
+/// output to stderr for debugging statements.
+///   void debugmsg (const char *format, ...);
+TINYFORMAT_WRAP_FORMAT (void, debugmsg, /**/,
+                        std::ostringstream msg;, msg, pvt::debugmsg_(msg.str());)
 
 
 // to force correct linkage on some systems

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -58,15 +58,15 @@ extern std::string extension_list;
 // For internal use - use error() below for a nicer interface.
 void seterror (const std::string& message);
 
-// Make sure all plugins are inventoried.  Should only be called while
-// imageio_mutex is held.  For internal use only.
-void catalog_all_plugins (std::string searchpath);
-
 /// Use error() privately only.  Protoype is conceptually printf-like, but
 /// also fully typesafe:
 /// void error (const char *format, ...);
 TINYFORMAT_WRAP_FORMAT (void, error, /**/,
     std::ostringstream msg;, msg, seterror(msg.str());)
+
+// Make sure all plugins are inventoried.  Should only be called while
+// imageio_mutex is held.  For internal use only.
+void catalog_all_plugins (std::string searchpath);
 
 /// Given the format, set the default quantization range.
 void get_default_quantize (TypeDesc format,

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -148,14 +148,10 @@ catalog_plugin (const std::string &format_name,
             // It's ok if they're both the same file; just skip it.
             return;
         }
-        // if (verbosity > 1)
-#ifndef NDEBUG
-        std::cerr << "OpenImageIO WARNING: " << format_name << " had multiple plugins:\n"
-                  << "\t\"" << found_path->second << "\"\n"
-                  << "    as well as\n"
-                  << "\t\"" << plugin_fullpath << "\"\n"
-                  << "    Ignoring all but the first one.\n";
-#endif
+        OIIO::debugmsg ("OpenImageIO WARNING: %s had multiple plugins:\n"
+                        "\t\"%s\"\n    as well as\n\t\"%s\"\n"
+                        "    Ignoring all but the first one.\n",
+                        format_name, found_path->second, plugin_fullpath);
         return;
     }
 

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -957,10 +957,8 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
     // Now if we still don't match a specific type OpenEXR is looking for,
     // skip it.
     if (exrtype != TypeDesc::UNKNOWN && ! exrtype.equivalent(type)) {
-#ifndef NDEBUG
-        std::cerr << "OpenEXR output metadata type mismatch: expected "
-                  << exrtype << ", got " << type << "\n";
-#endif
+        OIIO::debugmsg ("OpenEXR output metadata type mismatch: expected %s, got %s\n",
+                        exrtype, type);
         return false;
     }
 
@@ -1153,19 +1151,12 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
 #endif
     }
     } catch (const std::exception &e) {
-#ifndef NDEBUG
-        std::cout << "Caught OpenEXR exception: " << e.what() << "\n";
-#endif
+        OIIO::debugmsg ("Caught OpenEXR exception: %s\n", e.what());
     } catch (...) {  // catch-all for edge cases or compiler bugs
-#ifndef NDEBUG
-        std::cout << "Caught unknown OpenEXR exception\n";
-#endif
+        OIIO::debugmsg ("Caught unknown OpenEXR exception\n");
     }
 
-#ifndef NDEBUG
-    std::cerr << "Don't know what to do with " << type.c_str() << ' ' << xname << "\n";
-#endif
-
+    OIIO::debugmsg ("Don't know what to do with %s %s\n", type, xname);
     return false;
 }
 


### PR DESCRIPTION
It's echoed to stderr if global attribute("debug") is nonzero.
It defaults to 0 for ordinary runs, 1 for DEBUG, and the default is
overridden by he value of environment variable OPENIMAGEIO_DEBUG, if
present.

Suggested in #1242 

It is preferred that OIIO-internal code that's tempted to echo anything to stderr or stdout for debugging purposes (for example, selectively only when not NDEBUG) use this instead.

I have done this in a couple spots, but have not comprehensively scoured the code looking for examples. We can do it lazily, as we are visiting other parts of the code base.

