### PR TITLE
Fix typo in Tiff plugin documentation

### DIFF
--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -1098,7 +1098,7 @@ aware of:
 \qkw{fovcot} & float & {\cf PIXAR_FOVCOT} \\
 \qkw{worldtocamera} & matrix & PIXAR\_MATRIX\_WORLDTOCAMERA \\
 \qkw{worldtoscreen} & matrix & PIXAR\_MATRIX\_WORLDTOSCREEN\\
-\qkw{comrpession} & string & based on TIFF Compression 
+\qkw{compression} & string & based on TIFF Compression
   (one of \qkw{none}, \qkw{lzw}, \qkw{zip}, or others listed above.).\\
 \qkw{tiff:compression} & int & the original integer code
   from the TIFF Compression tag.\\


### PR DESCRIPTION
I spotted a typo in the documentation for the Tiff plugin, so this fixes it...