### PR TITLE
Design review: ImageInput: Add nthreads parameter

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -639,10 +639,16 @@ public:
     /// is analogous to read_scanline except that it may be used to read
     /// more than one scanline at a time (which, for some formats, may
     /// be able to be done much more efficiently or in parallel).
+    ///
+    /// The optional nthreads parameter determines how many threads will
+    /// potentially be launched to help speed up the task: a specific
+    /// maximum, or 1 to guarantee that no new threads will be launched, or
+    /// the default of 0 to use global OIIO attribute "nthreads"
     virtual bool read_scanlines (int ybegin, int yend, int z,
                                  TypeDesc format, void *data,
                                  stride_t xstride=AutoStride,
-                                 stride_t ystride=AutoStride);
+                                 stride_t ystride=AutoStride,
+                                 int nthreads=0);
 
     /// Read multiple scanlines that include pixels (*,y,z) for all
     /// ybegin <= y < yend, into data, using the strides given and
@@ -652,11 +658,17 @@ public:
     /// channels [chbegin,chend) will be read/copied (chbegin=0,
     /// chend=spec.nchannels reads all channels, yielding equivalent
     /// behavior to the simpler variant of read_scanlines).
+    ///
+    /// The optional nthreads parameter determines how many threads will
+    /// potentially be launched to help speed up the task: a specific
+    /// maximum, or 1 to guarantee that no new threads will be launched, or
+    /// the default of 0 to use global OIIO attribute "nthreads"
     virtual bool read_scanlines (int ybegin, int yend, int z,
                                  int chbegin, int chend,
                                  TypeDesc format, void *data,
                                  stride_t xstride=AutoStride,
-                                 stride_t ystride=AutoStride);
+                                 stride_t ystride=AutoStride,
+                                 int nthreads=0);
 
     /// Read the tile whose upper-left origin is (x,y,z) into data,
     /// converting if necessary from the native data format of the file
@@ -708,11 +720,16 @@ public:
     ///     xstride == spec.nchannels*format.size()
     ///     ystride == xstride * (xend-xbegin)
     ///     zstride == ystride * (yend-ybegin)
+    /// The optional nthreads parameter determines how many threads will
+    /// potentially be launched to help speed up the task: a specific
+    /// maximum, or 1 to guarantee that no new threads will be launched, or
+    /// the default of 0 to use global OIIO attribute "nthreads"
     virtual bool read_tiles (int xbegin, int xend, int ybegin, int yend,
                              int zbegin, int zend, TypeDesc format,
                              void *data, stride_t xstride=AutoStride,
                              stride_t ystride=AutoStride,
-                             stride_t zstride=AutoStride);
+                             stride_t zstride=AutoStride,
+                             int nthreads=0);
 
     /// Read the block of multiple tiles that include all pixels in
     /// [xbegin,xend) X [ybegin,yend) X [zbegin,zend), into data, using
@@ -722,12 +739,18 @@ public:
     /// formats).  Only channels [chbegin,chend) will be read/copied
     /// (chbegin=0, chend=spec.nchannels reads all channels, yielding
     /// equivalent behavior to the simpler variant of read_tiles).
+    ///
+    /// The optional nthreads parameter determines how many threads will
+    /// potentially be launched to help speed up the task: a specific
+    /// maximum, or 1 to guarantee that no new threads will be launched, or
+    /// the default of 0 to use global OIIO attribute "nthreads"
     virtual bool read_tiles (int xbegin, int xend, int ybegin, int yend,
                              int zbegin, int zend, 
                              int chbegin, int chend, TypeDesc format,
                              void *data, stride_t xstride=AutoStride,
                              stride_t ystride=AutoStride,
-                             stride_t zstride=AutoStride);
+                             stride_t zstride=AutoStride,
+                             int nthreads=0);
 
     /// Read the entire image of spec.width x spec.height x spec.depth
     /// pixels into data (which must already be sized large enough for
@@ -744,12 +767,18 @@ public:
     /// may be passed.  Periodically, it will be called as follows:
     ///     progress_callback (progress_callback_data, float done)
     /// where 'done' gives the portion of the image
+    ///
+    /// The optional nthreads parameter determines how many threads will
+    /// potentially be launched to help speed up the task: a specific
+    /// maximum, or 1 to guarantee that no new threads will be launched, or
+    /// the default of 0 to use global OIIO attribute "nthreads"
     virtual bool read_image (TypeDesc format, void *data,
                              stride_t xstride=AutoStride,
                              stride_t ystride=AutoStride,
                              stride_t zstride=AutoStride,
                              ProgressCallback progress_callback=NULL,
-                             void *progress_callback_data=NULL);
+                             void *progress_callback_data=NULL,
+                             int nthreads=0);
 
     /// Read the entire image of spec.width x spec.height x spec.depth
     /// pixels into data (which must already be sized large enough for
@@ -758,13 +787,19 @@ public:
     /// [chbegin,chend) will be read/copied (chbegin=0, chend=spec.nchannels
     /// reads all channels, yielding equivalent behavior to the simpler
     /// variant of read_image).
+    ///
+    /// The optional nthreads parameter determines how many threads will
+    /// potentially be launched to help speed up the task: a specific
+    /// maximum, or 1 to guarantee that no new threads will be launched, or
+    /// the default of 0 to use global OIIO attribute "nthreads"
     virtual bool read_image (int chbegin, int chend,
                              TypeDesc format, void *data,
                              stride_t xstride=AutoStride,
                              stride_t ystride=AutoStride,
                              stride_t zstride=AutoStride,
                              ProgressCallback progress_callback=NULL,
-                             void *progress_callback_data=NULL);
+                             void *progress_callback_data=NULL,
+                             int nthreads=0);
 
     ///
     /// Simple read_image reads to contiguous float pixels.

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -121,13 +121,15 @@ public:
     virtual bool read_scanlines (int ybegin, int yend, int z,
                                  int chbegin, int chend,
                                  TypeDesc format, void *data,
-                                 stride_t xstride, stride_t ystride);
+                                 stride_t xstride, stride_t ystride,
+                                 int nthreads=0);
     virtual bool read_tile (int x, int y, int z, TypeDesc format, void *data,
                             stride_t xstride, stride_t ystride, stride_t zstride);
     virtual bool read_tiles (int xbegin, int xend, int ybegin, int yend,
                              int zbegin, int zend, int chbegin, int chend,
                              TypeDesc format, void *data,
-                             stride_t xstride, stride_t ystride, stride_t zstride);
+                             stride_t xstride, stride_t ystride, stride_t zstride,
+                             int nthreads=0);
 
 private:
     TIFF *m_tif;                     ///< libtiff handle
@@ -1448,10 +1450,11 @@ bool TIFFInput::read_scanline (int y, int z, TypeDesc format, void *data,
 bool TIFFInput::read_scanlines (int ybegin, int yend, int z,
                                 int chbegin, int chend,
                                 TypeDesc format, void *data,
-                                stride_t xstride, stride_t ystride)
+                                stride_t xstride, stride_t ystride,
+                                int nthreads)
 {
     bool ok = ImageInput::read_scanlines (ybegin, yend, z, chbegin, chend,
-                                          format, data, xstride, ystride);
+                                          format, data, xstride, ystride, nthreads);
     if (ok && m_convert_alpha) {
         // If alpha is unassociated and we aren't requested to keep it that
         // way, multiply the colors by alpha per the usual OIIO conventions
@@ -1496,11 +1499,12 @@ bool TIFFInput::read_tiles (int xbegin, int xend, int ybegin, int yend,
                             int zbegin, int zend,
                             int chbegin, int chend,
                             TypeDesc format, void *data,
-                            stride_t xstride, stride_t ystride, stride_t zstride)
+                            stride_t xstride, stride_t ystride,
+                            stride_t zstride, int nthreads)
 {
     bool ok = ImageInput::read_tiles (xbegin, xend, ybegin, yend, zbegin, zend,
                                       chbegin, chend, format, data,
-                                      xstride, ystride, zstride);
+                                      xstride, ystride, zstride, nthreads);
     if (ok && m_convert_alpha) {
         // If alpha is unassociated and we aren't requested to keep it that
         // way, multiply the colors by alpha per the usual OIIO conventions


### PR DESCRIPTION
I'm not committed to this yet, just testing the waters and looking for feedback.

ImageInput: Add nthreads parameter to read_image, read_scanlines, read_tiles.

This allows control over thread spawning, similar to the parameter on the various ImageBufAlgo functions. A value of 0 means to use the global OIIO::attribute("nthreads") value (which in turn defaults to have a thread fan-out equal to the hardware concurrency). For a sole thread of execution, you want a big fan-out for tasks that can be parallelized, whereas when the calling function is one of many concurrent threads already underway, you just want the work done directly by the calling thread, without spawning additional threads that will oversubscribe the hardware.

There are currently only a couple spots where ImageInput might spawn threads. So this is primarily for future expansion, so that we might add more multithreading and give appropriate control to the calling application.

The reason that we want per-call overrides rather than relying solely on the global "nthreads" attribute is that OIIO may be used by multiple parts of an application (or multiple dependent libraries or plugins, each unaware of the others), and so it is not particularly safe under those circumstances to set the global value and assume that it will stay that way.

This is a preliminary effort for design review. Obvious extensions, if people like the way this is going, would be to add the nthreads parameter to the "native" versions (read_native_tiles, read_native_scanlines), the "deep" versions, and and corresponding routines in ImageOutput. Also we should add a method to ImageBuf that can set an "nthreads" paremeter for any underlying ImageInput or other operations done internal to the IB.

It is worth discussing alternatives. I admit that the idea of scattering "nthreads" parameters widely through the APIs is one that does give me some pause. But it has worked well for IBA, and at the moment I don't have a better idea for ImageInput/ImageOutput. Feedback appreciated.

Additional question: should the default be 0 (use the global "nthreads"), or should the default be 1 (just do the work with the calling thread)?
