### PR TITLE
ImageInput/ImageOutput API change to allow thread policy per file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project (OpenImageIO)
 # Release version of the library
 set (OIIO_VERSION_MAJOR 1)
 set (OIIO_VERSION_MINOR 6)
-set (OIIO_VERSION_PATCH 5)
+set (OIIO_VERSION_PATCH 6)
 set (OIIO_VERSION_RELEASE_TYPE "dev")   # "dev", "betaX", "RCY", ""
 
 cmake_minimum_required (VERSION 2.6)

--- a/src/doc/imagebuf.tex
+++ b/src/doc/imagebuf.tex
@@ -437,6 +437,21 @@ have correct knowledge of its pixel memory layout.  USE WITH EXTREME
 CAUTION.
 \apiend
 
+\apiitem{void {\ce threads} (int n) \\
+int {\ce threads} () const}
+\index{threads}
+\NEW % 1.6
+Get or set the threading policy for this \ImageBuf, controlling the
+maximum amount of parallelizing thread ``fan-out'' that might occur during
+expensive operations. The default of 0 means that the global
+{\cf attribute("threads")} value should be used (which itself defaults to
+using as many threads as cores; see Section~\ref{sec:attribute:threads}).
+
+The main reason to change this value is to set it to 1 to indicate that the
+calling thread should do all the work rather than spawning new threads. That
+is probably the desired behavior in situations where the calling application
+has already spawned multiple worker threads.
+\apiend
 
 
 \section{Copying \ImageBuf's and blocks of pixels}

--- a/src/doc/imageinput.tex
+++ b/src/doc/imageinput.tex
@@ -1171,6 +1171,22 @@ General message passing between client and image input server.
 This is currently undefined and is reserved for future use.
 \apiend
 
+\apiitem{void {\ce threads} (int n) \\
+int {\ce threads} () const}
+\index{threads}
+\NEW % 1.6
+Get or set the threading policy for this \ImageInput, controlling the
+maximum amount of parallelizing thread ``fan-out'' that might occur during
+large read operations. The default of 0 means that the global
+{\cf attribute("threads")} value should be used (which itself defaults to
+using as many threads as cores; see Section~\ref{sec:attribute:threads}).
+
+The main reason to change this value is to set it to 1 to indicate that the
+calling thread should do all the work rather than spawning new threads. That
+is probably the desired behavior in situations where the calling application
+has already spawned multiple worker threads.
+\apiend
+
 \apiitem{std::string {\ce geterror} () const}
 \index{error checking}
 Returns the current error string describing what went wrong if
@@ -1178,8 +1194,6 @@ any of the public methods returned {\kw false} indicating an error.
 (Hopefully the implementation plugin called {\kw error()} with a
 helpful error message.)
 \apiend
-
-
 
 \index{Image I/O API|)}
 

--- a/src/doc/imageoutput.tex
+++ b/src/doc/imageoutput.tex
@@ -1645,6 +1645,22 @@ General message passing between client and image output server.
 This is currently undefined and is reserved for future use.
 \apiend
 
+\apiitem{void {\ce threads} (int n) \\
+int {\ce threads} () const}
+\index{threads}
+\NEW % 1.6
+Get or set the threading policy for this \ImageOutput, controlling the
+maximum amount of parallelizing thread ``fan-out'' that might occur during
+large write operations. The default of 0 means that the global
+{\cf attribute("threads")} value should be used (which itself defaults to
+using as many threads as cores; see Section~\ref{sec:attribute:threads}).
+
+The main reason to change this value is to set it to 1 to indicate that the
+calling thread should do all the work rather than spawning new threads. That
+is probably the desired behavior in situations where the calling application
+has already spawned multiple worker threads.
+\apiend
+
 \apiitem{std::string {\ce geterror} ()}
 \index{error checking}
 Returns the current error string describing what went wrong if

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -684,6 +684,15 @@ public:
     DeepData *deepdata ();
     const DeepData *deepdata () const;
 
+    /// Set the current thread-spawning policy: the maximum number of
+    /// threads that may be spawned by ImagBuf internals. A value of 1
+    /// means all work will be done by the calling thread; 0 means to use
+    /// the global OIIO::attribute("threads") value.
+    void threads (int n) const;
+
+    /// Retrieve the current thread-spawning policy of this ImageBuf.
+    int threads () const;
+
     friend class IteratorBase;
 
     class IteratorBase {

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -506,8 +506,8 @@ public:
     /// should be safe.
     static void destroy (ImageInput *x);
 
-    ImageInput () { }
-    virtual ~ImageInput () { }
+    ImageInput ();
+    virtual ~ImageInput ();
 
     /// Return the name of the format implemented by this class.
     ///
@@ -874,11 +874,21 @@ public:
     TINYFORMAT_WRAP_FORMAT (void, error, const,
         std::ostringstream msg;, msg, append_error(msg.str());)
 
+    /// Set the current thread-spawning policy: the maximum number of
+    /// threads that may be spawned by ImageInput internals. A value of 1
+    /// means all work will be done by the calling thread; 0 means to use
+    /// the global OIIO::attribute("threads") value.
+    void threads (int n) { m_threads = n; }
+
+    /// Retrieve the current thread-spawning policy.
+    int threads () const { return m_threads; }
+
 protected:
     ImageSpec m_spec;  // format spec of the current open subimage/MIPlevel
 
 private:
     mutable std::string m_errmessage;  // private storage of error message
+    int m_threads;    // Thread policy
     void append_error (const std::string& message) const; // add to m_errmessage
     static ImageInput *create (const std::string &filename, bool do_open,
                                const std::string &plugin_searchpath);
@@ -907,8 +917,8 @@ public:
     /// create() may be unusafe, but passing it to destroy() should be safe.
     static void destroy (ImageOutput *x);
 
-    ImageOutput () { }
-    virtual ~ImageOutput () { }
+    ImageOutput ();
+    virtual ~ImageOutput ();
 
     /// Return the name of the format implemented by this class.
     ///
@@ -1195,6 +1205,15 @@ public:
     TINYFORMAT_WRAP_FORMAT (void, error, const,
         std::ostringstream msg;, msg, append_error(msg.str());)
 
+    /// Set the current thread-spawning policy: the maximum number of
+    /// threads that may be spawned by ImageOutput internals. A value of 1
+    /// means all work will be done by the calling thread; 0 means to use
+    /// the global OIIO::attribute("threads") value.
+    void threads (int n) { m_threads = n; }
+
+    /// Retrieve the current thread-spawning policy.
+    int threads () const { return m_threads; }
+
 protected:
     /// Helper routines used by write_* implementations: convert data (in
     /// the given format and stride) to the "native" format of the file
@@ -1257,6 +1276,7 @@ protected:
 private:
     void append_error (const std::string& message) const; // add to m_errmessage
     mutable std::string m_errmessage;   ///< private storage of error message
+    int m_threads;    // Thread policy
 };
 
 

--- a/src/include/OpenImageIO/oiioversion.h.in
+++ b/src/include/OpenImageIO/oiioversion.h.in
@@ -105,8 +105,9 @@ namespace OIIO = OIIO_NAMESPACE::OIIO_VERSION_NS;
 ///     from firstchan,nchans to chbegin,chend.
 /// Version 17 changed to int supports(string_view) rather than
 ///     bool supports(const std::string&)). (OIIO 1.6)
+/// Version 18 changed to add an m_threads member to ImageInput/Output.
 
-#define OIIO_PLUGIN_VERSION 17
+#define OIIO_PLUGIN_VERSION 18
 
 #define OIIO_PLUGIN_NAMESPACE_BEGIN OIIO_NAMESPACE_BEGIN
 #define OIIO_PLUGIN_NAMESPACE_END OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -48,6 +48,19 @@ OIIO_NAMESPACE_BEGIN
 
 
 
+ImageInput::ImageInput ()
+    : m_threads(0)
+{
+}
+
+
+
+ImageInput::~ImageInput ()
+{
+}
+
+
+
 // Default implementation of valid_file: try to do a full open.  If it
 // succeeds, it's the right kind of file.  We assume that most plugins
 // will override this with something smarter and much less expensive,
@@ -220,7 +233,8 @@ ImageInput::read_scanlines (int ybegin, int yend, int z,
             } else {
                 ok = parallel_convert_image (nchans, m_spec.width, nscanlines, 1, 
                                     &buf[0], m_spec.format, AutoStride, AutoStride, AutoStride,
-                                    data, format, xstride, ystride, zstride);
+                                    data, format, xstride, ystride, zstride,
+                                    -1 /*alpha*/, -1 /*z*/, threads());
             }
         } else {
             // Per-channel formats -- have to convert/copy channels individually

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -51,6 +51,21 @@
 OIIO_NAMESPACE_BEGIN
     using namespace pvt;
 
+
+
+ImageOutput::ImageOutput ()
+    : m_threads(0)
+{
+}
+
+
+
+ImageOutput::~ImageOutput ()
+{
+}
+
+
+
 bool
 ImageOutput::write_scanline (int y, int z, TypeDesc format,
                              const void *data, stride_t xstride)


### PR DESCRIPTION
Please see also #1258, this is an alternate proposal for the same basic issue. I think this one is far less intrusive to the APIs, and am leaning toward this if nobody strongly prefers the other.

----


This allows control over thread spawning for any ImageInput or
ImageOutput internals that may have the opportunity to parallelize work,
similar to the parameter on the various ImageBufAlgo functions. A value
of 0 means to use the global OIIO::attribute("nthreads") value (which in
turn defaults to have a thread fan-out equal to the hardware
concurrency). For a sole thread of execution, you want a big fan-out for
tasks that can be parallelized, whereas when the calling function is one
of many concurrent threads already underway, you just want the work done
directly by the calling thread, without spawning additional threads that
will oversubscribe the hardware.

The reason that we want per-ImageInput (or ImageOutput) overrides rather
than relying solely on the global "nthreads" attribute is that OIIO may
be used by multiple parts of an application (or multiple dependent
libraries or plugins, each unaware of the others), and so it is not
particularly safe under those circumstances to set the global value and
assume that it will stay that way.