### PR TITLE
Make IBA::channels() take an 'nthreads' parameter

### DIFF
--- a/src/doc/imagebufalgo.tex
+++ b/src/doc/imagebufalgo.tex
@@ -273,8 +273,8 @@ identical on different platforms supported by \product.
 
 \apiitem{bool {\ce channels} (ImageBuf \&dst, const ImageBuf \&src, int nchannels, \\
         \bigspc  const int *channelorder,  const float *channelvalues=NULL, \\
-        \bigspc                 const std::string *newchannelnames=NULL, \\
-        \bigspc                 bool shuffle_channel_names=false)}
+        \bigspc  const std::string *newchannelnames=NULL, \\
+        \bigspc  bool shuffle_channel_names=false, int nthreads=0)}
 \index{ImageBufAlgo!channels} \indexapi{channels} \label{sec:iba:channels}
 
 Generic channel shuffling: copy {\cf src} to {\cf dst}, but with channels in

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -1733,7 +1733,7 @@ is a tuple giving the per-channel colors.
 \label{sec:iba:py:transforms}
 
 \apiitem{bool ImageBufAlgo.{\ce channels} (dst, src, channelorder, newchannelnames=(), \\
-        \bigspc\bigspc shuffle_channel_names=False)}
+        \bigspc\bigspc shuffle_channel_names=False, nthreads=0)}
 \index{ImageBufAlgo!channels} \indexapi{channels}
 
 Copy {\cf src} to {\cf dst}, but with channels in

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -223,6 +223,11 @@ bool OIIO_API noise (ImageBuf &dst, string_view noisetype,
 /// shuffling both channel ordering and their names could result in no
 /// semantic change at all, if you catch the drift.
 ///
+/// The nthreads parameter specifies how many threads (potentially) may
+/// be used, but it's not a guarantee.  If nthreads == 0, it will use
+/// the global OIIO attribute "nthreads".  If nthreads == 1, it
+/// guarantees that it will not launch any new threads.
+///
 /// N.B. If you are merely interested in extending the number of channels
 /// or truncating channels at the end (but leaving the other channels
 /// intact), then you should call this as:
@@ -231,7 +236,7 @@ bool OIIO_API channels (ImageBuf &dst, const ImageBuf &src,
                         int nchannels, const int *channelorder,
                         const float *channelvalues=NULL,
                         const std::string *newchannelnames=NULL,
-                        bool shuffle_channel_names=false);
+                        bool shuffle_channel_names=false, int nthreads=0);
 
 
 /// Append the channels of A and B together into dst over the region of

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -160,7 +160,7 @@ IBA_noise (ImageBuf &dst, std::string type, float A, float B, bool mono, int see
 bool
 IBA_channels (ImageBuf &dst, const ImageBuf &src,
               tuple channelorder_, tuple newchannelnames_,
-              bool shuffle_channel_names)
+              bool shuffle_channel_names, int nthreads)
 {
     size_t nchannels = (size_t) len(channelorder_);
     if (nchannels < 1) {
@@ -199,7 +199,7 @@ IBA_channels (ImageBuf &dst, const ImageBuf &src,
     return ImageBufAlgo::channels (dst, src, (int)nchannels, &channelorder[0],
                          channelvalues.size() ? &channelvalues[0] : NULL,
                          newchannelnames.size() ? &newchannelnames[0] : NULL,
-                         shuffle_channel_names);
+                         shuffle_channel_names, nthreads);
 }
 
 
@@ -1232,7 +1232,7 @@ void declare_imagebufalgo()
         .def("channels", &IBA_channels,
              (arg("dst"), arg("src"), arg("channelorder"),
               arg("newchannelnames")=tuple(),
-              arg("shuffle_channel_names")=false))
+              arg("shuffle_channel_names")=false, arg("nthreads")=0) )
         .staticmethod("channels")
 
         .def("channel_append", IBA_channel_append,


### PR DESCRIPTION
For reasons I no longer remember, IBA::channels() didn't take an 'nthreads' parameter and didn't try to parallelize itself for large images.

Now it does.
