### PR TITLE
C++11 cleanup

### DIFF
--- a/src/include/OpenImageIO/array_view.h
+++ b/src/include/OpenImageIO/array_view.h
@@ -35,24 +35,24 @@
 #include <stdexcept>
 #include <iostream>
 
+#if OIIO_CPLUSPLUS_VERSION >= 11
+# include <initializer_list>
+# include <type_traits>
+#else /* FIXME(C++11): this case can go away when C++11 is our minimum */
+# include <boost/type_traits.hpp>
+#endif
+
 #include "oiioversion.h"
 #include "platform.h"
 #include "dassert.h"
 #include "coordinate.h"
-
-#if OIIO_CPLUSPLUS_VERSION >= 11
-# include <initializer_list>
-# include <type_traits>
-#else
-# include <boost/type_traits.hpp>
-#endif
 
 OIIO_NAMESPACE_BEGIN
 
 #if OIIO_CPLUSPLUS_VERSION >= 11
 using std::remove_const;
 using std::is_array;
-#else
+#else /* FIXME(C++11): this case can go away when C++11 is our minimum */
 using boost::remove_const;
 using boost::is_array;
 #endif

--- a/src/include/OpenImageIO/coordinate.h
+++ b/src/include/OpenImageIO/coordinate.h
@@ -41,9 +41,6 @@
 
 #if OIIO_CPLUSPLUS_VERSION >= 11
 # include <initializer_list>
-// # include <type_traits>
-#else
-// # include <boost/type_traits.hpp>
 #endif
 
 OIIO_NAMESPACE_BEGIN

--- a/src/include/OpenImageIO/dassert.h
+++ b/src/include/OpenImageIO/dassert.h
@@ -121,7 +121,7 @@
 #elif (__cplusplus >= 201103L)
 #  define OIIO_STATIC_ASSERT(cond)         static_assert(cond,"")
 #  define OIIO_STATIC_ASSERT_MSG(cond,msg) static_assert(cond,msg)
-#else /* fall back on Boost static assert */
+#else /* FIXME(C++11): this case can go away when C++11 is our minimum */
 #  include <boost/static_assert.hpp>
 #  define OIIO_STATIC_ASSERT(cond)         BOOST_STATIC_ASSERT(cond)
 #  define OIIO_STATIC_ASSERT_MSG(cond,msg) BOOST_STATIC_ASSERT_MSG(cond,msg)

--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -31,9 +31,7 @@
 
 /// @file  filesystem.h
 ///
-/// @brief Utilities for dealing with file names and files.  We use
-/// boost::filesystem anywhere we can, but that doesn't cover everything
-/// we want to do.
+/// @brief Utilities for dealing with file names and files portably.
 ///
 /// Some helpful nomenclature:
 ///  -  "filename" - a file or directory name, relative or absolute

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -42,7 +42,6 @@
 #include "imagebuf.h"
 #include "fmath.h"
 #include "color.h"
-#include "thread.h"
 
 #include <OpenEXR/ImathMatrix.h>       /* because we need M33f */
 

--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -32,7 +32,8 @@
 #ifndef OPENIMAGEIO_IMAGEBUFALGO_UTIL_H
 #define OPENIMAGEIO_IMAGEBUFALGO_UTIL_H
 
-#include "imagebufalgo.h"
+#include <OpenImageIO/imagebufalgo.h>
+#include <OpenImageIO/thread.h>
 
 
 OIIO_NAMESPACE_BEGIN

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -285,7 +285,7 @@ int extract_from_list_string (std::vector<T> &vals,
 /// StringEqual, to build an efficient hash map for char*'s or
 /// std::string's is as follows:
 /// \code
-///    boost::unordered_map <const char *, Key, Strutil::StringHash, Strutil::StringEqual>
+///    unordered_map <const char *, Key, Strutil::StringHash, Strutil::StringEqual>
 /// \endcode
 class StringHash {
 public:

--- a/src/include/OpenImageIO/unordered_map_concurrent.h
+++ b/src/include/OpenImageIO/unordered_map_concurrent.h
@@ -34,12 +34,25 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef OPENIMAGEIO_UNORDERED_MAP_CONCURRENT_H
 #define OPENIMAGEIO_UNORDERED_MAP_CONCURRENT_H
 
-#include <boost/unordered_map.hpp>
-#include "thread.h"    // from OIIO
-#include "hash.h"      // from OIIO
-#include "dassert.h"   // from OIIO
+#include <OpenImageIO/thread.h>
+#include <OpenImageIO/hash.h>
+#include <OpenImageIO/dassert.h>
+
+#if OIIO_CPLUSPLUS_VERSION >= 11
+#  include <unordered_map>
+#else /* FIXME(C++11): remove this after making C++11 the baseline */
+#  include <boost/unordered_map.hpp>
+#endif
 
 OIIO_NAMESPACE_BEGIN
+
+
+// Define OIIO::unordered_map as either std or boost.
+#if OIIO_CPLUSPLUS_VERSION >= 11
+using std::unordered_map;
+#else /* FIXME(C++11): remove this after making C++11 the baseline */
+using boost::unordered_map;
+#endif
 
 
 /// unordered_map_concurrent provides an unordered_map replacement that
@@ -76,7 +89,7 @@ OIIO_NAMESPACE_BEGIN
 
 template<class KEY, class VALUE, class HASH=boost::hash<KEY>,
          class PRED=std::equal_to<KEY>, size_t BINS=16,
-         class BINMAP=boost::unordered_map<KEY,VALUE,HASH,PRED> >
+         class BINMAP=unordered_map<KEY,VALUE,HASH,PRED> >
 class unordered_map_concurrent {
 public:
     typedef BINMAP BinMap_t;

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -36,7 +36,12 @@
 #ifndef OPENIMAGEIO_IMAGECACHE_PVT_H
 #define OPENIMAGEIO_IMAGECACHE_PVT_H
 
-#include <boost/unordered_map.hpp>
+#if OIIO_CPLUSPLUS_VERSION >= 11
+#  include <unordered_map>
+#else /* FIXME(C++11): remove this after making C++11 the baseline */
+#  include <boost/unordered_map.hpp>
+#endif
+
 #include <boost/scoped_ptr.hpp>
 #include <boost/scoped_array.hpp>
 
@@ -376,9 +381,12 @@ typedef intrusive_ptr<ImageCacheFile> ImageCacheFileRef;
 
 
 /// Map file names to file references
-///
 typedef unordered_map_concurrent<ustring,ImageCacheFileRef,ustringHash,std::equal_to<ustring>, 8> FilenameMap;
+#if OIIO_CPLUSPLUS_VERSION >= 11
+typedef std::unordered_map<ustring,ImageCacheFileRef,ustringHash> FingerprintMap;
+#else /* FIXME(C++11): remove this after making C++11 the baseline */
 typedef boost::unordered_map<ustring,ImageCacheFileRef,ustringHash> FingerprintMap;
+#endif
 
 
 


### PR DESCRIPTION
Some C++11 related cleanup.

The most important item is that when C++11 is detected, std::unordered_map will always be used rather than boost::unordered_map.

The rest is mostly changes to comments or minor rearrangements of headers.
