### PR TITLE
Sysutil::hardware_concurrency and physical_concurrency()

### DIFF
--- a/src/include/OpenImageIO/sysutil.h
+++ b/src/include/OpenImageIO/sysutil.h
@@ -94,6 +94,15 @@ OIIO_API int terminal_columns ();
 /// Return true if successful, false if it was unable to do so.
 OIIO_API bool put_in_background (int argc, char* argv[]);
 
+/// Number of virtual cores available on this platform (including
+/// hyperthreads).
+OIIO_API unsigned int hardware_concurrency ();
+
+/// Number of full hardware cores available on this platform (does not
+/// include hyperthreads). This is not always accurate and on some
+/// platforms will return the number of virtual cores.
+OIIO_API unsigned int physical_concurrency ();
+
 }  // namespace Sysutils
 
 OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -39,6 +39,7 @@
 #include "OpenImageIO/dassert.h"
 #include "OpenImageIO/typedesc.h"
 #include "OpenImageIO/strutil.h"
+#include "OpenImageIO/sysutil.h"
 #include "OpenImageIO/fmath.h"
 #include "OpenImageIO/thread.h"
 #include "OpenImageIO/hash.h"
@@ -50,8 +51,8 @@ OIIO_NAMESPACE_BEGIN
 // Global private data
 namespace pvt {
 recursive_mutex imageio_mutex;
-atomic_int oiio_threads (boost::thread::hardware_concurrency());
-atomic_int oiio_exr_threads (boost::thread::hardware_concurrency());
+atomic_int oiio_threads (Sysutil::physical_concurrency());
+atomic_int oiio_exr_threads (Sysutil::physical_concurrency());
 atomic_int oiio_read_chunk (256);
 ustring plugin_searchpath (OIIO_DEFAULT_PLUGIN_SEARCHPATH);
 std::string format_list;   // comma-separated list of all formats
@@ -143,7 +144,7 @@ attribute (string_view name, TypeDesc type, const void *val)
     if (name == "threads" && type == TypeDesc::TypeInt) {
         int ot = Imath::clamp (*(const int *)val, 0, maxthreads);
         if (ot == 0)
-            ot = boost::thread::hardware_concurrency();
+            ot = Sysutil::physical_concurrency();
         oiio_threads = ot;
         return true;
     }

--- a/src/libutil/atomic_test.cpp
+++ b/src/libutil/atomic_test.cpp
@@ -33,6 +33,7 @@
 
 #include "OpenImageIO/thread.h"
 #include "OpenImageIO/strutil.h"
+#include "OpenImageIO/sysutil.h"
 #include "OpenImageIO/timer.h"
 #include "OpenImageIO/argparse.h"
 #include "OpenImageIO/ustring.h"
@@ -178,7 +179,7 @@ int main (int argc, char *argv[])
 {
     getargs (argc, argv);
 
-    std::cout << "hw threads = " << boost::thread::hardware_concurrency() << "\n";
+    std::cout << "hw threads = " << Sysutil::hardware_concurrency() << "\n";
     std::cout << "threads\ttime (best of " << ntrials << ")\n";
     std::cout << "-------\t----------\n";
 

--- a/src/libutil/spin_rw_test.cpp
+++ b/src/libutil/spin_rw_test.cpp
@@ -33,6 +33,7 @@
 
 #include "OpenImageIO/thread.h"
 #include "OpenImageIO/strutil.h"
+#include "OpenImageIO/sysutil.h"
 #include "OpenImageIO/timer.h"
 #include "OpenImageIO/argparse.h"
 #include "OpenImageIO/ustring.h"
@@ -137,7 +138,7 @@ int main (int argc, char *argv[])
 {
     getargs (argc, argv);
 
-    std::cout << "hw threads = " << boost::thread::hardware_concurrency() << "\n";
+    std::cout << "hw threads = " << Sysutil::hardware_concurrency() << "\n";
     std::cout << "reader:writer ratio = " << read_write_ratio << ":1\n";
     std::cout << "threads\ttime (best of " << ntrials << ")\n";
     std::cout << "-------\t----------\n";

--- a/src/libutil/spinlock_test.cpp
+++ b/src/libutil/spinlock_test.cpp
@@ -33,6 +33,7 @@
 
 #include "OpenImageIO/thread.h"
 #include "OpenImageIO/strutil.h"
+#include "OpenImageIO/sysutil.h"
 #include "OpenImageIO/timer.h"
 #include "OpenImageIO/argparse.h"
 #include "OpenImageIO/ustring.h"
@@ -141,7 +142,7 @@ int main (int argc, char *argv[])
 {
     getargs (argc, argv);
 
-    std::cout << "hw threads = " << boost::thread::hardware_concurrency() << "\n";
+    std::cout << "hw threads = " << Sysutil::hardware_concurrency() << "\n";
     std::cout << "threads\ttime (best of " << ntrials << ")\n";
     std::cout << "-------\t----------\n";
 

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -74,6 +74,10 @@
 #include "OpenImageIO/dassert.h"
 #include "OpenImageIO/sysutil.h"
 
+#include <boost/version.hpp>
+#include <boost/thread.hpp>
+
+
 OIIO_NAMESPACE_BEGIN
 
 using namespace Sysutil;
@@ -336,6 +340,26 @@ Sysutil::put_in_background (int, char* [])
 
     // Otherwise, we don't know what to do
     return false;
+}
+
+
+
+unsigned int
+Sysutil::hardware_concurrency ()
+{
+    return boost::thread::hardware_concurrency();
+}
+
+
+
+unsigned int
+Sysutil::physical_concurrency ()
+{
+#if BOOST_VERSION >= 105600
+    return boost::thread::physical_concurrency();
+#else
+    return boost::thread::hardware_concurrency();
+#endif
 }
 
 

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -35,6 +35,7 @@
 #include "OpenImageIO/thread.h"
 #include "OpenImageIO/ustring.h"
 #include "OpenImageIO/strutil.h"
+#include "OpenImageIO/sysutil.h"
 #include "OpenImageIO/timer.h"
 #include "OpenImageIO/argparse.h"
 
@@ -124,7 +125,7 @@ int main (int argc, char *argv[])
     ustring foo ("foo");
     OIIO_CHECK_ASSERT (foo.string() == "foo");
 
-    std::cout << "hw threads = " << boost::thread::hardware_concurrency() << "\n";
+    std::cout << "hw threads = " << Sysutil::hardware_concurrency() << "\n";
     std::cout << "threads\ttime (best of " << ntrials << ")\n";
     std::cout << "-------\t----------\n";
 

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -1145,13 +1145,13 @@ main (int argc, const char *argv[])
         const int iterations = iters>1 ? iters : 2000000;
         std::cout << "Workload: " << workload_names[threadtimes] << "\n";
         std::cout << "texture cache size = " << cachesize << " MB\n";
-        std::cout << "hw threads = " << boost::thread::hardware_concurrency() << "\n";
+        std::cout << "hw threads = " << Sysutil::hardware_concurrency() << "\n";
         std::cout << "times are best of " << ntrials << " trials\n\n";
         std::cout << "threads  time (s) efficiency\n";
         std::cout << "-------- -------- ----------\n";
 
         if (nthreads == 0)
-            nthreads = boost::thread::hardware_concurrency();
+            nthreads = Sysutil::hardware_concurrency();
         static int threadcounts[] = { 1, 2, 4, 8, 12, 16, 24, 32, 64, 128, 1024, 1<<30 };
         float single_thread_time = 0.0f;
         for (int i = 0; threadcounts[i] <= nthreads; ++i) {


### PR DESCRIPTION
These are merely implemented in terms of boost::thread functions of the same name.
But by wrapping them in Sysutil, it's part of a plan to reduce the need to include boost thread.hpp, especially for C++11.

Also, change our default concurrency (OIIO attribute("threads")) to physical rather than virtual cores. On the more recent boost (1.56 and higher), physical_concurrency is a more accurate count of physical cores, rather than virtual/hyperthread cores, so let's default to that for our concurrency (hyperthread cores aren't all they're cracked up to be; I feel comfortable defaulting to number of physical cores and of course the user can overthread to take hyperthreading into consideration if they want).
