### PR TITLE
Added MATRIX33 aggregate to TypeDesc. Used in OpenEXR input/output

### DIFF
--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -85,7 +85,7 @@ struct OIIO_API TypeDesc {
                     HALF, FLOAT, DOUBLE, STRING, PTR, LASTBASE };
     /// AGGREGATE describes whether our type is a simple scalar of
     /// one of the BASETYPE's, or one of several simple aggregates.
-    enum AGGREGATE { SCALAR=1, VEC2=2, VEC3=3, VEC4=4, MATRIX44=16 };
+    enum AGGREGATE { SCALAR=1, VEC2=2, VEC3=3, VEC4=4, MATRIX33=9, MATRIX44=16 };
     /// VECSEMANTICS gives hints about what the data represent (for
     /// example, if a spatial vector, whether it should transform as
     /// a point, direction vector, or surface normal).
@@ -295,6 +295,8 @@ struct OIIO_API TypeDesc {
     static const TypeDesc TypeVector;
     static const TypeDesc TypeNormal;
     static const TypeDesc TypeMatrix;
+    static const TypeDesc TypeMatrix33;
+    static const TypeDesc TypeMatrix44;
     static const TypeDesc TypeTimeCode;
     static const TypeDesc TypeKeyCode;
     static const TypeDesc TypeFloat4;

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -175,8 +175,6 @@ TypeDesc::c_str () const
     std::string result;
     if (aggregate == SCALAR)
         result = basetype_name[basetype];
-    else if (aggregate == MATRIX44 && basetype == FLOAT)
-        result = "matrix";
     else if (aggregate == VEC4 && basetype == FLOAT && vecsemantics == NOXFORM)
         result = "float4";
     else if (vecsemantics == NOXFORM) {
@@ -185,6 +183,7 @@ TypeDesc::c_str () const
         case VEC2 : agg = "vec2"; break;
         case VEC3 : agg = "vec3"; break;
         case VEC4 : agg = "vec4"; break;
+        case MATRIX33 : agg = "matrix33"; break;
         case MATRIX44 : agg = "matrix44"; break;
         }
         result = std::string (agg) + basetype_code[basetype];
@@ -202,7 +201,8 @@ TypeDesc::c_str () const
         switch (aggregate) {
         case VEC2 : agg = "2"; break;
         case VEC4 : agg = "4"; break;
-        case MATRIX44 : agg = "matrix"; break;
+        case MATRIX33 : agg = "matrix33"; break;
+        case MATRIX44 : agg = "matrix44"; break;
         }
         result = std::string (vec) + std::string (agg);
         if (basetype != FLOAT)
@@ -281,8 +281,10 @@ TypeDesc::fromstring (string_view typestring)
         t = TypeVector;
     else if (type == "normal")
         t = TypeNormal;
-    else if (type == "matrix")
-        t = TypeMatrix;
+    else if (type == "matrix33")
+        t = TypeMatrix33;
+    else if (type == "matrix" || type == "matrix44")
+        t = TypeMatrix44;
     else {
         return 0;  // unknown
     }
@@ -409,7 +411,9 @@ const TypeDesc TypeDesc::TypeColor (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::C
 const TypeDesc TypeDesc::TypePoint (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::POINT);
 const TypeDesc TypeDesc::TypeVector (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::VECTOR);
 const TypeDesc TypeDesc::TypeNormal (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::NORMAL);
-const TypeDesc TypeDesc::TypeMatrix (TypeDesc::FLOAT,TypeDesc::MATRIX44);
+const TypeDesc TypeDesc::TypeMatrix33 (TypeDesc::FLOAT,TypeDesc::MATRIX33);
+const TypeDesc TypeDesc::TypeMatrix44 (TypeDesc::FLOAT,TypeDesc::MATRIX44);
+const TypeDesc TypeDesc::TypeMatrix = TypeDesc::TypeMatrix44;
 const TypeDesc TypeDesc::TypeString (TypeDesc::STRING);
 const TypeDesc TypeDesc::TypeInt (TypeDesc::INT);
 const TypeDesc TypeDesc::TypeHalf (TypeDesc::HALF);


### PR DESCRIPTION
Added a new `MATRIX33` to `TypeDesc`, and made the existing `TypeMatrix` an alias for `TypeMatrix44`.

Also changed the c_str representation of matrix to always return the explicit `matrix33` or `matrix44`, though left the fromstring behaviour the same.