### PR TITLE
C++11 use boost alternatives (mainly std)

### DIFF
--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -41,7 +41,6 @@ extern "C" { // ffmpeg is a C api
 #define av_frame_free   avcodec_free_frame
 #endif
 
-#include <boost/shared_ptr.hpp>
 #include <boost/thread/once.hpp>
 
 #include "OpenImageIO/imageio.h"

--- a/src/iv/ivimage.cpp
+++ b/src/iv/ivimage.cpp
@@ -32,7 +32,6 @@
 #include <iostream>
 
 #include <boost/foreach.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <OpenEXR/half.h>
 
 #include "imageviewer.h"

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -32,13 +32,13 @@
 #include <vector>
 #include <string>
 
-#include <boost/shared_ptr.hpp>
 #include <OpenEXR/half.h>
 
 #include "OpenImageIO/strutil.h"
 #include "OpenImageIO/color.h"
 #include "OpenImageIO/imagebufalgo.h"
 #include "OpenImageIO/imagebufalgo_util.h"
+#include "OpenImageIO/refcnt.h"
 
 #ifdef USE_OCIO
 #include <OpenColorIO/OpenColorIO.h>
@@ -719,7 +719,7 @@ ColorConfig::deleteColorProcessor (ColorProcessor * processor)
 // Image Processing Implementations
 
 
-static boost::shared_ptr<ColorConfig> default_colorconfig;  // default color config
+static OIIO::shared_ptr<ColorConfig> default_colorconfig;  // default color config
 static spin_mutex colorconfig_mutex;
 
 

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -32,6 +32,7 @@
 #include <vector>
 #include <string>
 
+#include <boost/shared_ptr.hpp>
 #include <OpenEXR/half.h>
 
 #include "OpenImageIO/strutil.h"
@@ -783,8 +784,8 @@ colorconvert_impl (ImageBuf &R, const ImageBuf &A,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(colorconvert_impl<Rtype,Atype>,
-                        boost::ref(R), boost::cref(A), processor, unpremult,
+            OIIO::bind(colorconvert_impl<Rtype,Atype>,
+                        OIIO::ref(R), OIIO::cref(A), processor, unpremult,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1599,7 +1599,7 @@ get_pixels_ (const ImageBuf &buf, ROI whole_roi, ROI roi, void *r_,
     if (nthreads != 1 && roi.npixels() >= 64*1024) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(get_pixels_<D,S>, boost::ref(buf),
+            OIIO::bind(get_pixels_<D,S>, OIIO::ref(buf),
                         whole_roi,  _1 /*roi*/, r_,
                         xstride, ystride, zstride, 1 /*nthreads*/),
             roi, nthreads);

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -28,7 +28,6 @@
   (This is the Modified BSD License)
 */
 
-#include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/regex.hpp>
 
@@ -287,8 +286,8 @@ convolve_ (ImageBuf &dst, const ImageBuf &src, const ImageBuf &kernel,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind(convolve_<DSTTYPE,SRCTYPE>, boost::ref(dst),
-                        boost::cref(src), boost::cref(kernel), normalize,
+            OIIO::bind(convolve_<DSTTYPE,SRCTYPE>, OIIO::ref(dst),
+                        OIIO::cref(src), OIIO::cref(kernel), normalize,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -437,7 +436,7 @@ threshold_to_zero (ImageBuf &dst, float threshold,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind(threshold_to_zero, boost::ref(dst), threshold,
+            OIIO::bind(threshold_to_zero, OIIO::ref(dst), threshold,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -516,8 +515,8 @@ median_filter_impl (ImageBuf &R, const ImageBuf &A, int width, int height,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(median_filter_impl<Rtype,Atype>,
-                        boost::ref(R), boost::cref(A),
+            OIIO::bind(median_filter_impl<Rtype,Atype>,
+                        OIIO::ref(R), OIIO::cref(A),
                         width, height, _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -599,7 +598,7 @@ hfft_ (ImageBuf &dst, const ImageBuf &src, bool inverse, bool unitary,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind (hfft_, boost::ref(dst), boost::cref(src),
+            OIIO::bind (hfft_, OIIO::ref(dst), OIIO::cref(src),
                          inverse, unitary,
                          _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
@@ -765,7 +764,7 @@ polar_to_complex_impl (ImageBuf &R, const ImageBuf &A, ROI roi, int nthreads)
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(polar_to_complex_impl<Rtype,Atype>, boost::ref(R), boost::cref(A),
+            OIIO::bind(polar_to_complex_impl<Rtype,Atype>, OIIO::ref(R), OIIO::cref(A),
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -792,7 +791,7 @@ complex_to_polar_impl (ImageBuf &R, const ImageBuf &A, ROI roi, int nthreads)
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(complex_to_polar_impl<Rtype,Atype>, boost::ref(R), boost::cref(A),
+            OIIO::bind(complex_to_polar_impl<Rtype,Atype>, OIIO::ref(R), OIIO::cref(A),
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -871,7 +870,7 @@ divide_by_alpha (ImageBuf &dst, ROI roi, int nthreads)
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind(divide_by_alpha, boost::ref(dst),
+            OIIO::bind(divide_by_alpha, OIIO::ref(dst),
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -28,7 +28,6 @@
   (This is the Modified BSD License)
 */
 
-#include <boost/shared_ptr.hpp>
 #include <boost/regex.hpp>
 
 #include <OpenEXR/half.h>
@@ -42,6 +41,7 @@
 #include "OpenImageIO/platform.h"
 #include "OpenImageIO/filter.h"
 #include "OpenImageIO/thread.h"
+#include "OpenImageIO/refcnt.h"
 #include "kissfft.hh"
 
 
@@ -918,7 +918,7 @@ ImageBufAlgo::fillholes_pushpull (ImageBuf &dst, const ImageBuf &src,
     // We generate a bunch of temp images to form an image pyramid.
     // These give us a place to stash them and make sure they are
     // auto-deleted when the function exits.
-    std::vector<boost::shared_ptr<ImageBuf> > pyramid;
+    std::vector<OIIO::shared_ptr<ImageBuf> > pyramid;
 
     // First, make a writeable copy of the original image (converting
     // to float as a convenience) as the top level of the pyramid.
@@ -926,7 +926,7 @@ ImageBufAlgo::fillholes_pushpull (ImageBuf &dst, const ImageBuf &src,
     topspec.set_format (TypeDesc::FLOAT);
     ImageBuf *top = new ImageBuf (topspec);
     paste (*top, topspec.x, topspec.y, topspec.z, 0, src);
-    pyramid.push_back (boost::shared_ptr<ImageBuf>(top));
+    pyramid.push_back (OIIO::shared_ptr<ImageBuf>(top));
 
     // Construct the rest of the pyramid by successive x/2 resizing and
     // then dividing nonzero alpha pixels by their alpha (this "spreads
@@ -939,7 +939,7 @@ ImageBufAlgo::fillholes_pushpull (ImageBuf &dst, const ImageBuf &src,
         ImageBuf *small = new ImageBuf (smallspec);
         ImageBufAlgo::resize (*small, *pyramid.back(), "triangle");
         divide_by_alpha (*small, get_roi(smallspec), nthreads);
-        pyramid.push_back (boost::shared_ptr<ImageBuf>(small));
+        pyramid.push_back (OIIO::shared_ptr<ImageBuf>(small));
         //debug small->save();
     }
 

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -32,14 +32,6 @@
 /// Implementation of ImageBufAlgo algorithms that analize or compare
 /// images.
 
-/* This header has to be included before boost/regex.hpp header
-   If it is included after, there is an error
-   "undefined reference to CSHA1::Update (unsigned char const*, unsigned long)"
-*/
-#include "OpenImageIO/SHA1.h"
-
-#include <boost/bind.hpp>
-
 #include <OpenEXR/half.h>
 
 #include <cmath>
@@ -50,6 +42,7 @@
 #include "OpenImageIO/imagebufalgo.h"
 #include "OpenImageIO/imagebufalgo_util.h"
 #include "OpenImageIO/dassert.h"
+#include "OpenImageIO/SHA1.h"
 
 #ifdef USE_OPENSSL
 #ifdef __APPLE__
@@ -506,7 +499,7 @@ color_count_ (const ImageBuf &src, atomic_ll *count,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind(color_count_<T>, boost::ref(src),
+            OIIO::bind(color_count_<T>, OIIO::ref(src),
                         count, ncolors, color, eps,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
@@ -578,7 +571,7 @@ color_range_check_ (const ImageBuf &src, atomic_ll *lowcount,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind(color_range_check_<T>, boost::ref(src),
+            OIIO::bind(color_range_check_<T>, OIIO::ref(src),
                         lowcount, highcount, inrangecount, low, high,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
@@ -849,7 +842,7 @@ ImageBufAlgo::computePixelHashSHA1 (const ImageBuf &src,
         sha1_hasher (&src, roi, blocksize, &results[0], 0);
     } else {
         // parallel case
-        boost::thread_group threads;
+        OIIO::thread_group threads;
         int blocks_per_thread = (nblocks+nthreads-1) / nthreads;
         ROI broi = roi;
         for (int b = 0, t = 0;  b < nblocks;  b += blocks_per_thread, ++t) {
@@ -858,7 +851,7 @@ ImageBufAlgo::computePixelHashSHA1 (const ImageBuf &src,
                 break;
             broi.ybegin = y;
             broi.yend = std::min (y+blocksize*blocks_per_thread, roi.yend);
-            threads.add_thread (new boost::thread (sha1_hasher, &src, broi,
+            threads.add_thread (new OIIO::thread (sha1_hasher, &src, broi,
                                                    blocksize, &results[0], b));
         }
         threads.join_all ();

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -33,8 +33,6 @@
 /// or channels between images without altering their values.
 
 
-#include <boost/bind.hpp>
-
 #include <OpenEXR/half.h>
 
 #include <cmath>
@@ -113,7 +111,7 @@ crop_ (ImageBuf &dst, const ImageBuf &src,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind(crop_<D,S>, boost::ref(dst), boost::cref(src),
+            OIIO::bind(crop_<D,S>, OIIO::ref(dst), OIIO::cref(src),
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -529,8 +527,8 @@ transpose_ (ImageBuf &dst, const ImageBuf &src,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(transpose_<DSTTYPE,SRCTYPE>,
-                        boost::ref(dst), boost::cref(src),
+            OIIO::bind(transpose_<DSTTYPE,SRCTYPE>,
+                        OIIO::ref(dst), OIIO::cref(src),
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -585,8 +583,8 @@ circular_shift_ (ImageBuf &dst, const ImageBuf &src,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(circular_shift_<DSTTYPE,SRCTYPE>,
-                        boost::ref(dst), boost::cref(src),
+            OIIO::bind(circular_shift_<DSTTYPE,SRCTYPE>,
+                        OIIO::ref(dst), OIIO::cref(src),
                         xshift, yshift, zshift,
                         dstroi, _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
@@ -636,8 +634,8 @@ channels_ (ImageBuf &dst, const ImageBuf &src,
     if (nthreads != 1 && roi.npixels() >= 64*1024) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(channels_<DSTTYPE>, boost::ref(dst),
-                        boost::cref(src), channelorder, channelvalues,
+            OIIO::bind(channels_<DSTTYPE>, OIIO::ref(dst),
+                        OIIO::cref(src), channelorder, channelvalues,
                         _1 /*roi*/, 1 /*ntheads*/),
             roi, nthreads);
         return true;
@@ -811,8 +809,8 @@ channel_append_impl (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
     } else {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind (channel_append_impl<ABtype>, boost::ref(dst),
-                         boost::cref(A), boost::cref(B), _1, 1),
+            OIIO::bind (channel_append_impl<ABtype>, OIIO::ref(dst),
+                         OIIO::cref(A), OIIO::cref(B), _1, 1),
             roi, nthreads);
     }
     return true;

--- a/src/libOpenImageIO/imagebufalgo_deep.cpp
+++ b/src/libOpenImageIO/imagebufalgo_deep.cpp
@@ -29,7 +29,6 @@
 */
 
 
-#include <boost/bind.hpp>
 #include <OpenEXR/half.h>
 
 #include <cmath>
@@ -87,7 +86,7 @@ flatten_ (ImageBuf &dst, const ImageBuf &src,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(flatten_<DSTTYPE>, boost::ref(dst), boost::cref(src),
+            OIIO::bind(flatten_<DSTTYPE>, OIIO::ref(dst), OIIO::cref(src),
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -28,10 +28,6 @@
   (This is the Modified BSD License)
 */
 
-#include <boost/bind.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/regex.hpp>
-
 #include <OpenEXR/half.h>
 
 #include <cmath>
@@ -57,12 +53,12 @@ OIIO_NAMESPACE_BEGIN
 
 template<typename T>
 static bool
-fill_ (ImageBuf &dst, const float *values, ROI roi=ROI(), int nthreads=1)
+fill_const_ (ImageBuf &dst, const float *values, ROI roi=ROI(), int nthreads=1)
 {
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind(fill_<T>, boost::ref(dst), values,
+            OIIO::bind(fill_const_<T>, OIIO::ref(dst), values,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -78,13 +74,13 @@ fill_ (ImageBuf &dst, const float *values, ROI roi=ROI(), int nthreads=1)
 
 template<typename T>
 static bool
-fill_ (ImageBuf &dst, const float *top, const float *bottom,
+fill_tb_ (ImageBuf &dst, const float *top, const float *bottom,
        ROI origroi, ROI roi=ROI(), int nthreads=1)
 {
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind(fill_<T>, boost::ref(dst), top, bottom,
+            OIIO::bind(fill_tb_<T>, OIIO::ref(dst), top, bottom,
                         origroi, _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -103,14 +99,14 @@ fill_ (ImageBuf &dst, const float *top, const float *bottom,
 
 template<typename T>
 static bool
-fill_ (ImageBuf &dst, const float *topleft, const float *topright,
+fill_corners_ (ImageBuf &dst, const float *topleft, const float *topright,
        const float *bottomleft, const float *bottomright,
        ROI origroi, ROI roi=ROI(), int nthreads=1)
 {
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind(fill_<T>, boost::ref(dst), topleft, topright,
+            OIIO::bind(fill_corners_<T>, OIIO::ref(dst), topleft, topright,
                         bottomleft, bottomright,
                         origroi, _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
@@ -138,7 +134,7 @@ ImageBufAlgo::fill (ImageBuf &dst, const float *pixel, ROI roi, int nthreads)
     if (! IBAprep (roi, &dst))
         return false;
     bool ok;
-    OIIO_DISPATCH_TYPES (ok, "fill", fill_, dst.spec().format,
+    OIIO_DISPATCH_TYPES (ok, "fill", fill_const_, dst.spec().format,
                          dst, pixel, roi, nthreads);
     return ok;
 }
@@ -152,7 +148,7 @@ ImageBufAlgo::fill (ImageBuf &dst, const float *top, const float *bottom,
     if (! IBAprep (roi, &dst))
         return false;
     bool ok;
-    OIIO_DISPATCH_TYPES (ok, "fill", fill_, dst.spec().format,
+    OIIO_DISPATCH_TYPES (ok, "fill", fill_tb_, dst.spec().format,
                          dst, top, bottom, roi, roi, nthreads);
     return ok;
 }
@@ -168,7 +164,7 @@ ImageBufAlgo::fill (ImageBuf &dst, const float *topleft, const float *topright,
     if (! IBAprep (roi, &dst))
         return false;
     bool ok;
-    OIIO_DISPATCH_TYPES (ok, "fill", fill_, dst.spec().format,
+    OIIO_DISPATCH_TYPES (ok, "fill", fill_corners_, dst.spec().format,
                          dst, topleft, topright, bottomleft, bottomright,
                          roi, roi, nthreads);
     return ok;
@@ -205,7 +201,7 @@ checker_ (ImageBuf &dst, Dim3 size,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind(checker_<T>, boost::ref(dst),
+            OIIO::bind(checker_<T>, OIIO::ref(dst),
                         size, color1, color2, offset,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
@@ -288,7 +284,7 @@ noise_uniform_ (ImageBuf &dst, float min, float max, bool mono,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind(noise_uniform_<T>, boost::ref(dst),
+            OIIO::bind(noise_uniform_<T>, OIIO::ref(dst),
                         min, max, mono, seed,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
@@ -318,7 +314,7 @@ noise_gaussian_ (ImageBuf &dst, float mean, float stddev, bool mono,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind(noise_gaussian_<T>, boost::ref(dst),
+            OIIO::bind(noise_gaussian_<T>, OIIO::ref(dst),
                         mean, stddev, mono, seed,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
@@ -348,7 +344,7 @@ noise_salt_ (ImageBuf &dst, float saltval, float saltportion, bool mono,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind(noise_salt_<T>, boost::ref(dst),
+            OIIO::bind(noise_salt_<T>, OIIO::ref(dst),
                         saltval, saltportion, mono, seed,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);

--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -32,8 +32,6 @@
 /// Implementation of ImageBufAlgo algorithms that do math on 
 /// single pixels at a time.
 
-#include <boost/bind.hpp>
-
 #include <OpenEXR/half.h>
 
 #include <cmath>
@@ -59,7 +57,7 @@ clamp_ (ImageBuf &dst, const ImageBuf &src,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind(clamp_<D,S>, boost::ref(dst), boost::cref(src),
+            OIIO::bind(clamp_<D,S>, OIIO::ref(dst), OIIO::cref(src),
                         min, max, clampalpha01,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
@@ -127,8 +125,8 @@ add_impl (ImageBuf &R, const ImageBuf &A, const ImageBuf &B,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(add_impl<Rtype,Atype,Btype>,
-                        boost::ref(R), boost::cref(A), boost::cref(B),
+            OIIO::bind(add_impl<Rtype,Atype,Btype>,
+                        OIIO::ref(R), OIIO::cref(A), OIIO::cref(B),
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -154,8 +152,8 @@ add_impl (ImageBuf &R, const ImageBuf &A, const float *b,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(add_impl<Rtype,Atype>,
-                        boost::ref(R), boost::cref(A), b,
+            OIIO::bind(add_impl<Rtype,Atype>,
+                        OIIO::ref(R), OIIO::cref(A), b,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -228,8 +226,8 @@ sub_impl (ImageBuf &R, const ImageBuf &A, const ImageBuf &B,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(sub_impl<Rtype,Atype,Btype>,
-                        boost::ref(R), boost::cref(A), boost::cref(B),
+            OIIO::bind(sub_impl<Rtype,Atype,Btype>,
+                        OIIO::ref(R), OIIO::cref(A), OIIO::cref(B),
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -306,8 +304,8 @@ absdiff_impl (ImageBuf &R, const ImageBuf &A, const ImageBuf &B,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(absdiff_impl<Rtype,Atype,Btype>,
-                        boost::ref(R), boost::cref(A), boost::cref(B),
+            OIIO::bind(absdiff_impl<Rtype,Atype,Btype>,
+                        OIIO::ref(R), OIIO::cref(A), OIIO::cref(B),
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -332,8 +330,8 @@ absdiff_impl (ImageBuf &R, const ImageBuf &A, const float *b,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(absdiff_impl<Rtype,Atype>,
-                        boost::ref(R), boost::cref(A), b,
+            OIIO::bind(absdiff_impl<Rtype,Atype>,
+                        OIIO::ref(R), OIIO::cref(A), b,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -416,8 +414,8 @@ mul_impl (ImageBuf &R, const ImageBuf &A, const ImageBuf &B,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(mul_impl<Rtype,Atype,Btype>,
-                        boost::ref(R), boost::cref(A), boost::cref(B),
+            OIIO::bind(mul_impl<Rtype,Atype,Btype>,
+                        OIIO::ref(R), OIIO::cref(A), OIIO::cref(B),
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -458,7 +456,7 @@ mul_impl (ImageBuf &R, const ImageBuf &A, const float *b,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(mul_impl<Rtype,Atype>, boost::ref(R), boost::cref(A), b,
+            OIIO::bind(mul_impl<Rtype,Atype>, OIIO::ref(R), OIIO::cref(A), b,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -513,8 +511,8 @@ div_impl (ImageBuf &R, const ImageBuf &A, const ImageBuf &B,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(div_impl<Rtype,Atype,Btype>,
-                        boost::ref(R), boost::cref(A), boost::cref(B),
+            OIIO::bind(div_impl<Rtype,Atype,Btype>,
+                        OIIO::ref(R), OIIO::cref(A), OIIO::cref(B),
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -594,8 +592,8 @@ mad_impl (ImageBuf &R, const ImageBuf &A, const ImageBuf &B, const ImageBuf &C,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(mad_impl<Rtype,ABCtype>, boost::ref(R),
-                        boost::cref(A), boost::cref(B), boost::cref(C),
+            OIIO::bind(mad_impl<Rtype,ABCtype>, OIIO::ref(R),
+                        OIIO::cref(A), OIIO::cref(B), OIIO::cref(C),
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -622,8 +620,8 @@ mad_implf (ImageBuf &R, const ImageBuf &A, const float *b, const float *c,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(mad_implf<Rtype,Atype>, boost::ref(R),
-                        boost::cref(A), b, c,
+            OIIO::bind(mad_implf<Rtype,Atype>, OIIO::ref(R),
+                        OIIO::cref(A), b, c,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -738,7 +736,7 @@ pow_impl (ImageBuf &R, const ImageBuf &A, const float *b,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(pow_impl<Rtype,Atype>, boost::ref(R), boost::cref(A), b,
+            OIIO::bind(pow_impl<Rtype,Atype>, OIIO::ref(R), OIIO::cref(A), b,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -794,7 +792,7 @@ channel_sum_ (ImageBuf &dst, const ImageBuf &src,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(channel_sum_<D,S>, boost::ref(dst), boost::cref(src),
+            OIIO::bind(channel_sum_<D,S>, OIIO::ref(dst), OIIO::cref(src),
                         weights, _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -896,8 +894,8 @@ rangecompress_ (ImageBuf &R, const ImageBuf &A,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(rangecompress_<Rtype,Atype>, boost::ref(R),
-                        boost::cref(A), useluma,
+            OIIO::bind(rangecompress_<Rtype,Atype>, OIIO::ref(R),
+                        OIIO::cref(A), useluma,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -966,8 +964,8 @@ rangeexpand_ (ImageBuf &R, const ImageBuf &A,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(rangeexpand_<Rtype,Atype>, boost::ref(R), 
-                        boost::cref(A), useluma,
+            OIIO::bind(rangeexpand_<Rtype,Atype>, OIIO::ref(R), 
+                        OIIO::cref(A), useluma,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -1065,7 +1063,7 @@ unpremult_ (ImageBuf &R, const ImageBuf &A, ROI roi, int nthreads)
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(unpremult_<Rtype,Atype>, boost::ref(R), boost::cref(A),
+            OIIO::bind(unpremult_<Rtype,Atype>, OIIO::ref(R), OIIO::cref(A),
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -1131,7 +1129,7 @@ premult_ (ImageBuf &R, const ImageBuf &A, ROI roi, int nthreads)
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(premult_<Rtype,Atype>, boost::ref(R), boost::cref(A),
+            OIIO::bind(premult_<Rtype,Atype>, OIIO::ref(R), OIIO::cref(A),
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -1200,7 +1198,7 @@ bool fixNonFinite_ (ImageBuf &dst, ImageBufAlgo::NonFiniteFixMode mode,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind(fixNonFinite_<T>, boost::ref(dst), mode, pixelsFixed,
+            OIIO::bind(fixNonFinite_<T>, OIIO::ref(dst), mode, pixelsFixed,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -1363,8 +1361,8 @@ over_impl (ImageBuf &R, const ImageBuf &A, const ImageBuf &B,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(over_impl<Rtype,Atype,Btype>,
-                        boost::ref(R), boost::cref(A), boost::cref(B),
+            OIIO::bind(over_impl<Rtype,Atype,Btype>,
+                        OIIO::ref(R), OIIO::cref(A), OIIO::cref(B),
                         zcomp, z_zeroisinf, _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -32,7 +32,6 @@
 /// ImageBufAlgo functions for filtered transformations
 
 
-#include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 
 #include <OpenEXR/half.h>
@@ -190,8 +189,8 @@ resize_ (ImageBuf &dst, const ImageBuf &src,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind(resize_<DSTTYPE,SRCTYPE>, boost::ref(dst),
-                        boost::cref(src), filter,
+            OIIO::bind(resize_<DSTTYPE,SRCTYPE>, OIIO::ref(dst),
+                        OIIO::cref(src), filter,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -466,8 +465,8 @@ resample_ (ImageBuf &dst, const ImageBuf &src, bool interpolate,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind(resample_<DSTTYPE,SRCTYPE>, boost::ref(dst),
-                        boost::cref(src), interpolate,
+            OIIO::bind(resample_<DSTTYPE,SRCTYPE>, OIIO::ref(dst),
+                        OIIO::cref(src), interpolate,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -553,8 +552,8 @@ affine_resample_ (ImageBuf &dst, const ImageBuf &src, const Imath::M33f &Minv,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(affine_resample_<DSTTYPE,SRCTYPE>,
-                        boost::ref(dst), boost::cref(src), Minv,
+            OIIO::bind(affine_resample_<DSTTYPE,SRCTYPE>,
+                        OIIO::ref(dst), OIIO::cref(src), Minv,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -585,8 +584,8 @@ warp_ (ImageBuf &dst, const ImageBuf &src, const Imath::M33f &M,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
         ImageBufAlgo::parallel_image (
-            boost::bind(warp_<DSTTYPE,SRCTYPE>,
-                        boost::ref(dst), boost::cref(src), M,
+            OIIO::bind(warp_<DSTTYPE,SRCTYPE>,
+                        OIIO::ref(dst), OIIO::cref(src), M,
                         filter, wrap, _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -32,8 +32,6 @@
 /// ImageBufAlgo functions for filtered transformations
 
 
-#include <boost/shared_ptr.hpp>
-
 #include <OpenEXR/half.h>
 #include <OpenEXR/ImathMatrix.h>
 #include <OpenEXR/ImathBox.h>
@@ -46,6 +44,7 @@
 #include "OpenImageIO/dassert.h"
 #include "OpenImageIO/filter.h"
 #include "OpenImageIO/thread.h"
+#include "OpenImageIO/refcnt.h"
 
 OIIO_NAMESPACE_BEGIN
 
@@ -383,7 +382,7 @@ ImageBufAlgo::resize (ImageBuf &dst, const ImageBuf &src,
 
     // Set up a shared pointer with custom deleter to make sure any
     // filter we allocate here is properly destroyed.
-    boost::shared_ptr<Filter2D> filterptr ((Filter2D*)NULL, Filter2D::destroy);
+    OIIO::shared_ptr<Filter2D> filterptr ((Filter2D*)NULL, Filter2D::destroy);
     bool allocfilter = (filter == NULL);
     if (allocfilter) {
         // If no filter was provided, punt and just linearly interpolate.
@@ -424,7 +423,7 @@ ImageBufAlgo::resize (ImageBuf &dst, const ImageBuf &src,
 
     // Set up a shared pointer with custom deleter to make sure any
     // filter we allocate here is properly destroyed.
-    boost::shared_ptr<Filter2D> filter ((Filter2D*)NULL, Filter2D::destroy);
+    OIIO::shared_ptr<Filter2D> filter ((Filter2D*)NULL, Filter2D::destroy);
     std::string filtername = filtername_;
     if (filtername.empty()) {
         // No filter name supplied -- pick a good default
@@ -637,7 +636,7 @@ ImageBufAlgo::warp (ImageBuf &dst, const ImageBuf &src,
 
     // Set up a shared pointer with custom deleter to make sure any
     // filter we allocate here is properly destroyed.
-    boost::shared_ptr<Filter2D> filterptr ((Filter2D*)NULL, Filter2D::destroy);
+    OIIO::shared_ptr<Filter2D> filterptr ((Filter2D*)NULL, Filter2D::destroy);
     if (filter == NULL) {
         // If no filter was provided, punt and just linearly interpolate.
         filterptr.reset (Filter2D::create ("lanczos3", 6.0f, 6.0f));
@@ -662,7 +661,7 @@ ImageBufAlgo::warp (ImageBuf &dst, const ImageBuf &src,
 {
     // Set up a shared pointer with custom deleter to make sure any
     // filter we allocate here is properly destroyed.
-    boost::shared_ptr<Filter2D> filter ((Filter2D*)NULL, Filter2D::destroy);
+    OIIO::shared_ptr<Filter2D> filter ((Filter2D*)NULL, Filter2D::destroy);
     std::string filtername = filtername_.size() ? filtername_ : "lanczos3";
     for (int i = 0, e = Filter2D::num_filters();  i < e;  ++i) {
         FilterDesc fd;

--- a/src/libOpenImageIO/imagebufalgo_yee.cpp
+++ b/src/libOpenImageIO/imagebufalgo_yee.cpp
@@ -105,7 +105,7 @@ private:
 // Adobe RGB (1998) with reference white D65 -> XYZ
 // matrix is from http://www.brucelindbloom.com/
 inline Color3f
-AdobeRGBToXYZ (const Color3f &rgb)
+AdobeRGBToXYZ_color (const Color3f &rgb)
 {
     return Color3f (rgb[0] * 0.576700f  + rgb[1] * 0.185556f  + rgb[2] * 0.188212f,
                     rgb[0] * 0.297361f  + rgb[1] * 0.627355f  + rgb[2] * 0.0752847f,
@@ -119,7 +119,7 @@ AdobeRGBToXYZ (ImageBuf &A, ROI roi, int nthreads)
 {
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
-        ImageBufAlgo::parallel_image (boost::bind(AdobeRGBToXYZ, boost::ref(A),
+        ImageBufAlgo::parallel_image (OIIO::bind(AdobeRGBToXYZ, OIIO::ref(A),
                                                   _1 /*roi*/, 1 /*nthreads*/),
                                       roi, nthreads);
         return true;
@@ -128,7 +128,7 @@ AdobeRGBToXYZ (ImageBuf &A, ROI roi, int nthreads)
     // Serial case
     for (ImageBuf::Iterator<float> a (A, roi);  !a.done();  ++a) {
         Color3f rgb (a[0], a[1], a[2]);
-        Color3f XYZ = AdobeRGBToXYZ (rgb);
+        Color3f XYZ = AdobeRGBToXYZ_color (rgb);
         a[0] = XYZ[0];
         a[1] = XYZ[1];
         a[2] = XYZ[2];
@@ -141,7 +141,7 @@ AdobeRGBToXYZ (ImageBuf &A, ROI roi, int nthreads)
 /// Convert a color in XYZ space to LAB space.
 ///
 static Color3f
-XYZToLAB (const Color3f xyz)
+XYZToLAB_color (const Color3f xyz)
 {
     // Reference white point
     static const Color3f white (0.576700f + 0.185556f + 0.188212f,
@@ -170,7 +170,7 @@ XYZToLAB (ImageBuf &A, ROI roi, int nthreads)
 {
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Possible multiple thread case -- recurse via parallel_image
-        ImageBufAlgo::parallel_image (boost::bind(XYZToLAB, boost::ref(A),
+        ImageBufAlgo::parallel_image (OIIO::bind(XYZToLAB, OIIO::ref(A),
                                                   _1 /*roi*/, 1 /*nthreads*/),
                                       roi, nthreads);
         return true;
@@ -179,7 +179,7 @@ XYZToLAB (ImageBuf &A, ROI roi, int nthreads)
     // Serial case
     for (ImageBuf::Iterator<float> a (A, roi);  !a.done();  ++a) {
         Color3f XYZ (a[0], a[1], a[2]);
-        Color3f LAB = XYZToLAB (XYZ);
+        Color3f LAB = XYZToLAB_color (XYZ);
         a[0] = LAB[0];
         a[1] = LAB[1];
         a[2] = LAB[2];

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -35,6 +35,7 @@
 #include <OpenEXR/ImathFun.h>
 
 #include <boost/scoped_array.hpp>
+#include <boost/thread/tss.hpp>
 
 #include "OpenImageIO/dassert.h"
 #include "OpenImageIO/typedesc.h"
@@ -86,7 +87,7 @@ openimageio_version ()
 
 // To avoid thread oddities, we have the storage area buffering error
 // messages for seterror()/geterror() be thread-specific.
-static thread_specific_ptr<std::string> thread_error_msg;
+static boost::thread_specific_ptr<std::string> thread_error_msg;
 
 // Return a reference to the string for this thread's error messages,
 // creating it if none exists for this thread thus far.
@@ -109,7 +110,6 @@ error_msg ()
 void
 pvt::seterror (const std::string& message)
 {
-    recursive_lock_guard lock (pvt::imageio_mutex);
     error_msg() = message;
 }
 
@@ -118,7 +118,6 @@ pvt::seterror (const std::string& message)
 std::string
 geterror ()
 {
-    recursive_lock_guard lock (pvt::imageio_mutex);
     std::string e = error_msg();
     error_msg().clear ();
     return e;

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -35,6 +35,7 @@
 #include <OpenEXR/ImathFun.h>
 
 #include <boost/scoped_array.hpp>
+#include <boost/thread.hpp>
 #include <boost/thread/tss.hpp>
 
 #include "OpenImageIO/dassert.h"

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -435,8 +435,8 @@ lightprobe_to_envlatl (ImageBuf &dst, const ImageBuf &src, bool y_is_up,
     if (nthreads != 1 && roi.npixels() >= 1000) {
         // Lots of pixels and request for multi threads? Parallelize.
         ImageBufAlgo::parallel_image (
-            boost::bind(lightprobe_to_envlatl, boost::ref(dst),
-                        boost::cref(src), y_is_up,
+            OIIO::bind(lightprobe_to_envlatl, OIIO::ref(dst),
+                        OIIO::cref(src), y_is_up,
                         _1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
@@ -690,7 +690,7 @@ write_mipmap (ImageBufAlgo::MakeTextureMode mode,
                                img->yend(), img->zbegin(), img->zend());
 
                 if (filtername == "box" && !orig_was_overscan && sharpen <= 0.0f) {
-                    ImageBufAlgo::parallel_image (boost::bind(resize_block, boost::ref(*small), boost::cref(*img), _1, envlatlmode, allow_shift),
+                    ImageBufAlgo::parallel_image (OIIO::bind(resize_block, OIIO::ref(*small), OIIO::cref(*img), _1, envlatlmode, allow_shift),
                                                   OIIO::get_roi(small->spec()));
                 } else {
                     Filter2D *filter = setup_filter (small->spec(), img->spec(), filtername);
@@ -1219,7 +1219,7 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
                      srcspec.format.basetype == TypeDesc::HALF ||
                      srcspec.format.basetype == TypeDesc::DOUBLE)) {
         int found_nonfinite = 0;
-        ImageBufAlgo::parallel_image (boost::bind(check_nan_block, boost::ref(*src), _1, boost::ref(found_nonfinite)),
+        ImageBufAlgo::parallel_image (OIIO::bind(check_nan_block, OIIO::ref(*src), _1, OIIO::ref(found_nonfinite)),
                                       OIIO::get_roi(srcspec));
         if (found_nonfinite) {
             if (found_nonfinite > 3)
@@ -1354,7 +1354,7 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
     } else  if (! do_resize) {
         // Need format conversion, but no resize -- just copy the pixels
         toplevel.reset (new ImageBuf (dstspec));
-        ImageBufAlgo::parallel_image (boost::bind(copy_block,boost::ref(*toplevel),boost::cref(*src),_1),
+        ImageBufAlgo::parallel_image (OIIO::bind(copy_block,OIIO::ref(*toplevel),OIIO::cref(*src),_1),
                                       OIIO::get_roi(dstspec));
     } else {
         // Resize
@@ -1367,7 +1367,7 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
         toplevel.reset (new ImageBuf (dstspec));
         if ((resize_filter == "box" || resize_filter == "triangle")
             && !orig_was_overscan) {
-            ImageBufAlgo::parallel_image (boost::bind(resize_block, boost::ref(*toplevel), boost::cref(*src), _1, envlatlmode, allow_shift),
+            ImageBufAlgo::parallel_image (OIIO::bind(resize_block, OIIO::ref(*toplevel), OIIO::cref(*src), _1, envlatlmode, allow_shift),
                                           OIIO::get_roi(dstspec));
         } else {
             Filter2D *filter = setup_filter (toplevel->spec(), src->spec(), resize_filter);

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -44,6 +44,7 @@
 
 #include <boost/scoped_ptr.hpp>
 #include <boost/scoped_array.hpp>
+#include <boost/thread/tss.hpp>
 
 #include <OpenEXR/half.h>
 
@@ -69,6 +70,8 @@ namespace pvt {
 
 #define IMAGECACHE_USE_RW_MUTEX 1
 
+
+using boost::thread_specific_ptr;
 
 class ImageCacheImpl;
 class ImageCachePerThreadInfo;

--- a/src/libtexture/texoptions.cpp
+++ b/src/libtexture/texoptions.cpp
@@ -29,7 +29,6 @@
 */
 
 #include <string>
-#include <boost/scoped_ptr.hpp>
 
 #include "OpenImageIO/dassert.h"
 #include "OpenImageIO/typedesc.h"

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -129,7 +129,7 @@ public:
 
     virtual TextureHandle *get_texture_handle (ustring filename,
                                                Perthread *thread) {
-        PerThreadInfo *thread_info = thread ? (PerThreadInfo *)thread
+        PerThreadInfo *thread_info = thread ? ((PerThreadInfo *)thread)
                                        : m_imagecache->get_perthread_info ();
         return (TextureHandle *) find_texturefile (filename, thread_info);
     }

--- a/src/libutil/optparser_test.cpp
+++ b/src/libutil/optparser_test.cpp
@@ -31,11 +31,10 @@
 
 #include <iostream>
 #include <string>
+#include <cstdlib>
+#include <cstring>
 
-#include "OpenImageIO/thread.h"
-
-#include <boost/thread/thread.hpp>
-
+#include "OpenImageIO/platform.h"
 #include "OpenImageIO/optparser.h"
 #include "OpenImageIO/unittest.h"
 

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -41,6 +41,8 @@
 
 #include "OpenImageIO/unittest.h"
 
+#include <boost/thread.hpp>
+  
 
 OIIO_NAMESPACE_USING;
 

--- a/src/socket.imageio/socket_pvt.h
+++ b/src/socket.imageio/socket_pvt.h
@@ -38,6 +38,7 @@
 #define OPENIMAGEIO_SOCKET_PVT_H
 
 #include "OpenImageIO/imageio.h"
+#include "OpenImageIO/refcnt.h"
 
 #include <map>
 
@@ -50,7 +51,6 @@
 #endif
 
 #include <boost/asio.hpp>
-#include <boost/shared_ptr.hpp>
 
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
@@ -104,7 +104,7 @@ class SocketInput : public ImageInput {
     int m_next_scanline;      // Which scanline is the next to read?
     io_service io;
     ip::tcp::socket socket;
-    boost::shared_ptr <ip::tcp::acceptor> acceptor;
+    OIIO::shared_ptr <ip::tcp::acceptor> acceptor;
     
     bool accept_connection (const std::string &name);
     bool get_spec_from_client (ImageSpec &spec);

--- a/src/socket.imageio/socketinput.cpp
+++ b/src/socket.imageio/socketinput.cpp
@@ -167,7 +167,7 @@ SocketInput::accept_connection(const std::string &name)
     int port = atoi (rest_args["port"].c_str ());
 
     try {
-        acceptor = boost::shared_ptr <ip::tcp::acceptor>
+        acceptor = OIIO::shared_ptr <ip::tcp::acceptor>
             (new ip::tcp::acceptor (io, ip::tcp::endpoint (ip::tcp::v4(), port)));
         acceptor->accept (socket);
     } catch (boost::system::system_error &err) {

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -41,8 +41,6 @@
 #include <OpenEXR/ImathVec.h>
 #include <OpenEXR/half.h>
 
-#include <boost/bind.hpp>
-
 #include "OpenImageIO/argparse.h"
 #include "OpenImageIO/imageio.h"
 #include "OpenImageIO/ustring.h"
@@ -58,6 +56,10 @@
 #include "../libtexture/imagecache_pvt.h"
 
 OIIO_NAMESPACE_USING
+
+#if OIIO_CPLUSPLUS_VERSION >= 11
+using OIIO::_1;
+#endif
 
 static std::vector<ustring> filenames;
 static std::string output_filename = "out.exr";
@@ -567,7 +569,7 @@ test_plain_texture (Mapping2D mapping)
             std::cout << "iter " << iter << " file " << filename << "\n";
         }
 
-        ImageBufAlgo::parallel_image (boost::bind(plain_tex_region, boost::ref(image), filename, mapping,
+        ImageBufAlgo::parallel_image (OIIO::bind(plain_tex_region, OIIO::ref(image), filename, mapping,
                                                   test_derivs ? &image_ds : NULL,
                                                   test_derivs ? &image_dt : NULL, _1),
                                       get_roi(image.spec()), nthreads);
@@ -649,7 +651,7 @@ test_texture3d (ustring filename, Mapping3D mapping)
         if (iter && filenames.size() > 1)
             filename = filenames[1];
 
-        ImageBufAlgo::parallel_image (boost::bind(tex3d_region, boost::ref(image), filename, mapping, _1),
+        ImageBufAlgo::parallel_image (OIIO::bind(tex3d_region, OIIO::ref(image), filename, mapping, _1),
                                       get_roi(image.spec()), nthreads);
     }
     
@@ -952,9 +954,9 @@ void
 launch_tex_threads (int numthreads, int iterations)
 {
     texsys->invalidate_all (true);
-    boost::thread_group threads;
+    OIIO::thread_group threads;
     for (int i = 0;  i < numthreads;  ++i) {
-        threads.create_thread (boost::bind(do_tex_thread_workout,iterations,i));
+        threads.create_thread (OIIO::bind(do_tex_thread_workout,iterations,i));
     }
     ASSERT ((int)threads.size() == numthreads);
     threads.join_all ();
@@ -1158,7 +1160,7 @@ main (int argc, const char *argv[])
             int nt = wedge ? threadcounts[i] : nthreads;
             int its = iters>1 ? (std::max (1, iters/nt)) : iterations; // / nt;
             double range;
-            double t = time_trial (boost::bind(launch_tex_threads,nt,its),
+            double t = time_trial (OIIO::bind(launch_tex_threads,nt,its),
                                    ntrials, &range);
             if (nt == 1)
                 single_thread_time = (float)t;

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -34,6 +34,7 @@
 #include <cmath>
 
 #include <boost/regex.hpp>
+#include <boost/thread/tss.hpp>
 
 #include <tiffio.h>
 
@@ -302,7 +303,7 @@ OIIO_PLUGIN_EXPORTS_END
 // Someplace to store an error message from the TIFF error handler
 // To avoid thread oddities, we have the storage area buffering error
 // messages for seterror()/geterror() be thread-specific.
-static thread_specific_ptr<std::string> thread_error_msg;
+static boost::thread_specific_ptr<std::string> thread_error_msg;
 static atomic_int handler_set;
 static spin_mutex handler_mutex;
 


### PR DESCRIPTION
A series of changes with the aim of using only std, no boost, in public headers. For the most part, these only come into play with compiling with USE_CPP11=1. C++03 compiles still fall back to the boost versions.

There were three main sets of changes:

* thread.h: use std::mutex, recursive_mutex, lock_guard, thread, and make a simple thread_group, all to take the place of boost components of the same names. Also remove mention of thread_specific_ptr from thread.h, use the boost one directly from the couple of specific places in internals where we need it.

* refcnt.h handles all the reference-counted pointers -- use std::shared_ptr instead of boost, and make our own intrusive_ptr.

* imagebufalgo_util.h now uses the OIIO-namespaced thread_group, bind, ref, cref (which are std or our own for C++11, boost for C++03).

I believe that this gets us to a state where, when using C++11, there are NO references to boost headers or types in OIIO's public headers, and thus no need to expose them in client application code that uses OIIO. We still use some boost internally at OIIO build time, and that's fine. Yet more of that will go away once we eventually move to C++11 as a baseline (after our next major release branch).

None of this is resulting from any antipathy toward boost. Like I said, there are uses of boost in our internals that we have no particular intent to remove (and no obvious replacements). But there is a benefit to keeping it out of the public APIs, primarily to avoid versionitis issues in apps that may require multiple dependent libraries that each use or expect different Boost versions. We strive for OIIO to not add to those headaches, unless there is no alternative. With C++11, a whole lot of alternatives crop up, as a sizeable portion of the bits of boost we use have migrated to be part of the standard library.
 
