### PR TITLE
Alternative to #1265 openexr 3x3 matrix

### DIFF
--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -89,6 +89,7 @@ by the enumerated type {\cf AGGREGATE}:
 {\cf VEC2} & two values representing a 2D vector. \\
 {\cf VEC3} & three values representing a 3D vector. \\
 {\cf VEC4} & four values representing a 4D vector. \\
+{\cf MATRIX33} & nine values representing a $3 \times 3$ matrix. \\
 {\cf MATRIX44} & sixteen values representing a $4 \times 4$ matrix.
 \end{tabular}
 \medskip

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -64,6 +64,7 @@
 \def\ParamValue{{\codefont ParamValue}\xspace}
 \def\ParamValueList{{\codefont ParamValueList}\xspace}
 \def\ImageBuf{{\codefont ImageBuf}\xspace}
+\def\ImageBufAlgo{{\codefont ImageBufAlgo}\xspace}
 \def\ImageCache{{\codefont ImageCache}\xspace}
 \def\TextureSystem{{\codefont TextureSystem}\xspace}
 \def\ROI{{\codefont ROI}\xspace}
@@ -94,7 +95,7 @@
 }
 \date{{\large 
 %Editor: Larry Gritz \\[2ex]
-Date: 22 Oct 2015
+Date: 18 Nov 2015
 %\\ (with corrections, 25 Aug 2015)
 }}
 

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -43,7 +43,7 @@ These names are also exported to the {\cf OpenImageIO} namespace.
 \apiitem{AGGREGATE}
 The {\cf AGGREGATE} enum corresponds to the C++ {\cf TypeDesc::AGGREGATE} and
 contains the following values: \\
-{\cf SCALAR VEC2 VEC3 VEC4 MATRIX44} \\
+{\cf SCALAR VEC2 VEC3 VEC4 MATRIX33 MATRIX44} \\
 These names are also exported to the {\cf OpenImageIO} namespace.
 \apiend
 
@@ -95,6 +95,7 @@ TypeDesc.TypePoint() \\
 TypeDesc.TypeVector() \\
 TypeDesc.TypeNormal() \\
 TypeDesc.TypeMatrix() \\
+TypeDesc.TypeMatrix33() \\
 TypeDesc.TypeTimeCode() \\
 TypeDesc.TypeKeyCode() \\
 TypeDesc.TypeFloat4()}

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -85,7 +85,7 @@ struct OIIO_API TypeDesc {
                     HALF, FLOAT, DOUBLE, STRING, PTR, LASTBASE };
     /// AGGREGATE describes whether our type is a simple scalar of
     /// one of the BASETYPE's, or one of several simple aggregates.
-    enum AGGREGATE { SCALAR=1, VEC2=2, VEC3=3, VEC4=4, MATRIX44=16 };
+    enum AGGREGATE { SCALAR=1, VEC2=2, VEC3=3, VEC4=4, MATRIX33=9, MATRIX44=16 };
     /// VECSEMANTICS gives hints about what the data represent (for
     /// example, if a spatial vector, whether it should transform as
     /// a point, direction vector, or surface normal).
@@ -295,6 +295,8 @@ struct OIIO_API TypeDesc {
     static const TypeDesc TypeVector;
     static const TypeDesc TypeNormal;
     static const TypeDesc TypeMatrix;
+    static const TypeDesc TypeMatrix33;
+    static const TypeDesc TypeMatrix44;
     static const TypeDesc TypeTimeCode;
     static const TypeDesc TypeKeyCode;
     static const TypeDesc TypeFloat4;

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -177,6 +177,8 @@ TypeDesc::c_str () const
         result = basetype_name[basetype];
     else if (aggregate == MATRIX44 && basetype == FLOAT)
         result = "matrix";
+    else if (aggregate == MATRIX33 && basetype == FLOAT)
+        result = "matrix33";
     else if (aggregate == VEC4 && basetype == FLOAT && vecsemantics == NOXFORM)
         result = "float4";
     else if (vecsemantics == NOXFORM) {
@@ -185,7 +187,8 @@ TypeDesc::c_str () const
         case VEC2 : agg = "vec2"; break;
         case VEC3 : agg = "vec3"; break;
         case VEC4 : agg = "vec4"; break;
-        case MATRIX44 : agg = "matrix44"; break;
+        case MATRIX33 : agg = "matrix33"; break;
+        case MATRIX44 : agg = "matrix"; break;
         }
         result = std::string (agg) + basetype_code[basetype];
     } else {
@@ -202,7 +205,8 @@ TypeDesc::c_str () const
         switch (aggregate) {
         case VEC2 : agg = "2"; break;
         case VEC4 : agg = "4"; break;
-        case MATRIX44 : agg = "matrix"; break;
+        case MATRIX33 : agg = "matrix33"; break;
+        case MATRIX44 : agg = "matrix44"; break;
         }
         result = std::string (vec) + std::string (agg);
         if (basetype != FLOAT)
@@ -281,8 +285,10 @@ TypeDesc::fromstring (string_view typestring)
         t = TypeVector;
     else if (type == "normal")
         t = TypeNormal;
-    else if (type == "matrix")
-        t = TypeMatrix;
+    else if (type == "matrix33")
+        t = TypeMatrix33;
+    else if (type == "matrix" || type == "matrix44")
+        t = TypeMatrix44;
     else {
         return 0;  // unknown
     }
@@ -409,7 +415,9 @@ const TypeDesc TypeDesc::TypeColor (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::C
 const TypeDesc TypeDesc::TypePoint (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::POINT);
 const TypeDesc TypeDesc::TypeVector (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::VECTOR);
 const TypeDesc TypeDesc::TypeNormal (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::NORMAL);
-const TypeDesc TypeDesc::TypeMatrix (TypeDesc::FLOAT,TypeDesc::MATRIX44);
+const TypeDesc TypeDesc::TypeMatrix33 (TypeDesc::FLOAT,TypeDesc::MATRIX33);
+const TypeDesc TypeDesc::TypeMatrix44 (TypeDesc::FLOAT,TypeDesc::MATRIX44);
+const TypeDesc TypeDesc::TypeMatrix = TypeDesc::TypeMatrix44;
 const TypeDesc TypeDesc::TypeString (TypeDesc::STRING);
 const TypeDesc TypeDesc::TypeInt (TypeDesc::INT);
 const TypeDesc TypeDesc::TypeHalf (TypeDesc::HALF);

--- a/src/python/py_typedesc.cpp
+++ b/src/python/py_typedesc.cpp
@@ -99,6 +99,7 @@ void declare_typedesc() {
         .value("VEC2",      TypeDesc::VEC2)
         .value("VEC3",      TypeDesc::VEC3)
         .value("VEC4",      TypeDesc::VEC4)
+        .value("MATRIX33",  TypeDesc::MATRIX33)
         .value("MATRIX44",  TypeDesc::MATRIX44)
         .export_values()
     ;
@@ -168,6 +169,8 @@ void declare_typedesc() {
         .def_readonly("TypeVector",   &TypeDesc::TypeVector)
         .def_readonly("TypeNormal",   &TypeDesc::TypeNormal)
         .def_readonly("TypeMatrix",   &TypeDesc::TypeMatrix)
+        .def_readonly("TypeMatrix33", &TypeDesc::TypeMatrix33)
+        .def_readonly("TypeMatrix44", &TypeDesc::TypeMatrix44)
         .def_readonly("TypeTimeCode", &TypeDesc::TypeTimeCode)
         .def_readonly("TypeKeyCode",  &TypeDesc::TypeKeyCode)
         .def_readonly("TypeFloat4",   &TypeDesc::TypeFloat4)

--- a/testsuite/python-typedesc/ref/out.txt
+++ b/testsuite/python-typedesc/ref/out.txt
@@ -128,6 +128,10 @@ type 'TypeNormal'
     c_str "normal"
 type 'TypeMatrix'
     c_str "matrix"
+type 'TypeMatrix33'
+    c_str "matrix33"
+type 'TypeMatrix44'
+    c_str "matrix"
 type 'TypeTimeCode'
     c_str "timecode"
 type 'TypeKeyCode'

--- a/testsuite/python-typedesc/test_typedesc.py
+++ b/testsuite/python-typedesc/test_typedesc.py
@@ -43,6 +43,7 @@ def aggregate_enum_test():
         oiio.VEC2
         oiio.VEC3
         oiio.VEC4
+        oiio.MATRIX33
         oiio.MATRIX44
         oiio.TIMECODE
         oiio.KEYCODE
@@ -135,6 +136,8 @@ try:
     breakdown_test (oiio.TypeDesc.TypeVector,   "TypeVector",   verbose=False)
     breakdown_test (oiio.TypeDesc.TypeNormal,   "TypeNormal",   verbose=False)
     breakdown_test (oiio.TypeDesc.TypeMatrix,   "TypeMatrix",   verbose=False)
+    breakdown_test (oiio.TypeDesc.TypeMatrix33, "TypeMatrix33", verbose=False)
+    breakdown_test (oiio.TypeDesc.TypeMatrix44, "TypeMatrix44", verbose=False)
     breakdown_test (oiio.TypeDesc.TypeTimeCode, "TypeTimeCode", verbose=False)
     breakdown_test (oiio.TypeDesc.TypeKeyCode,  "TypeKeyCode",  verbose=False)
     breakdown_test (oiio.TypeDesc.TypeFloat4,   "TypeFloat4",   verbose=False)


### PR DESCRIPTION
Please see #1265. GitHub doesn't let me propose changes on the same ticket, grr. This is 99% the same as @shootfast's proposal, but I have

1. Added the Python binding changes he forgot.

2. Modified the docs appropriately.

3. Reverted a tiny bit so that the string representation of 4x4 matrices remains "matrix" rather than changing it to "matrix44". I'm proposing that we use "matrix33" is for 3x3, but stay with plain "matrix" for the usual common CG case of 4x4, for the same reason that "point" is the common CG case without needing to be called "point3"; and this way, we don't introduce any compatibility breaks for apps that expect the current behavior (especially for OSL).

If everybody is ok with this, before merging I will squash it down to just two commits: (a) all the changes to TypeDesc, together; and (b) the changes to OpenEXR. But for review purposes, it may be clearer to be able to see exactly what changes I made atop Mark's original proposal.
