### PR TITLE
Travis -- clean up, and use ccache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
     - if [ $TRAVIS_OS_NAME == osx ] ; then
           src/build-scripts/install_homebrew_deps.bash ;
       elif [ $TRAVIS_OS_NAME == linux ] ; then
-          src/build-scripts/build_openexr.bash ;
+          CXX="ccache $CXX" CCACHE_CPP2=1 src/build-scripts/build_openexr.bash ;
           export ILMBASE_HOME=$PWD/openexr-install ;
           export OPENEXR_HOME=$PWD/openexr-install ;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,17 +49,24 @@ cache:
     - $HOME/lgritz/libtiffpic
 
 before_install:
-    - if [ $TRAVIS_OS_NAME == osx ] ; then export PLATFORM=macosx ; fi
-    - if [ $TRAVIS_OS_NAME == linux ] ; then export PLATFORM=linux64 ; fi
+    - if [ $TRAVIS_OS_NAME == osx ] ; then
+          export PLATFORM=macosx ;
+          sysctl machdep.cpu.features ;
+      elif [ $TRAVIS_OS_NAME == linux ] ; then
+          export PLATFORM=linux64 ;
+          cat /proc/cpuinfo ;
+      fi
     - echo "Build platform name is $PLATFORM"
-    - if [ $TRAVIS_OS_NAME == osx ] ; then sysctl machdep.cpu.features ; fi
-    - if [ $TRAVIS_OS_NAME == linux ] ; then cat /proc/cpuinfo ; fi
 
 install:
     - if [ "$CXX" == "g++" ]; then export CXX="g++-${WHICHGCC}" ; fi
-    - if [ $TRAVIS_OS_NAME == osx ] ; then src/build-scripts/install_homebrew_deps.bash ; fi
-    - if [ $TRAVIS_OS_NAME == linux ] ; then src/build-scripts/build_openexr.bash ; fi
-    - if [ $TRAVIS_OS_NAME == linux ] ; then export ILMBASE_HOME=${PWD}/openexr-install ; export OPENEXR_HOME=${PWD}/openexr-install ; fi
+    - if [ $TRAVIS_OS_NAME == osx ] ; then
+          src/build-scripts/install_homebrew_deps.bash ;
+      elif [ $TRAVIS_OS_NAME == linux ] ; then
+          src/build-scripts/build_openexr.bash ;
+          export ILMBASE_HOME=$PWD/openexr-install ;
+          export OPENEXR_HOME=$PWD/openexr-install ;
+      fi
     - src/build-scripts/install_test_images.bash
 
 # before_script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,13 @@ if (EXISTS "/usr/lib/libc++.dylib")
     set (OSL_SYSTEM_HAS_LIBCPP ON)
 endif ()
 
+# Use ccache if found
+find_program (CCACHE_FOUND ccache)
+if (CCACHE_FOUND)
+    set_property (GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    set_property (GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+endif ()
+
 
 set (VERBOSE OFF CACHE BOOL "Print lots of messages while compiling")
 set (EMBEDPLUGINS ON CACHE BOOL "Embed format plugins in libOpenImageIO")

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -19,6 +19,7 @@ brew update >/dev/null
 echo ""
 echo "Before my brew installs:"
 brew list --versions
+brew install ccache
 brew install ilmbase openexr
 brew install boost-python
 brew install opencolorio


### PR DESCRIPTION
Last night's web surfing discovery: 5 lines added to CMakeLists.txt that causes it to use ccache if it's installed on the system. 

This cuts the Travis build time in half, and also will speed up OIIO builds for anybody else with ccache on their system but haven't taken any steps on their own to use it. I can't think of any down-sides to this, can you?

Also some cleanup and reformatting after discovering that in the .travis.yml file I can split commands over several lines, makes it more readable.
