### PR TITLE
Add _STDC_CONSTANT_MACROS for FFmpeg(2.8.1) plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
     set (CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")
     # Ensure this macro is set for stdint.h
     add_definitions ("-D__STDC_LIMIT_MACROS")
+    add_definitions ("-D__STDC_CONSTANT_MACROS")
     # this allows native instructions to be used for sqrtf instead of a function call
     add_definitions ("-fno-math-errno")
     if (HIDE_SYMBOLS AND NOT DEBUGMODE)


### PR DESCRIPTION
I must add this to compile using gcc 4.8.3 with FFmpeg 2.8.1
