### PR TITLE
TIFF read_scanlines of images with unassociated alpha didn't honor stride

### DIFF
--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1462,7 +1462,7 @@ bool TIFFInput::read_scanlines (int ybegin, int yend, int z,
         // read_native_blah.
         OIIO::premult (m_spec.nchannels, m_spec.width, yend-ybegin, 1,
                        chbegin, chend, format, data,
-                       xstride, AutoStride, AutoStride,
+                       xstride, ystride, AutoStride,
                        m_spec.alpha_channel, m_spec.z_channel);
     }
     return ok;


### PR DESCRIPTION
This could run off the end of a buffer when reading images with
unassociated alpha, if the calling app passed an unusual ystride (or,
in the case I found, using a negative stride to flip the process
in the process of reading it).