### PR TITLE
Minor platform.h related fixes

### DIFF
--- a/src/include/OpenImageIO/dassert.h
+++ b/src/include/OpenImageIO/dassert.h
@@ -35,6 +35,8 @@
 #include <cstdio>
 #include <cstdlib>
 
+#include "platform.h"
+
 
 /// \file
 ///
@@ -68,7 +70,7 @@
 
 #ifndef ASSERT
 # define ASSERT(x)                                              \
-    ((x) ? ((void)0)                                            \
+    (OIIO_LIKELY(x) ? ((void)0)                                 \
          : (fprintf (stderr, "%s:%u: failed assertion '%s'\n",  \
                      __FILE__, __LINE__, #x), abort()))
 #endif
@@ -77,7 +79,7 @@
 /// formatted output (a la printf) to the failure message.
 #ifndef ASSERT_MSG
 # define ASSERT_MSG(x,msg,...)                                      \
-    ((x) ? ((void)0)                                                \
+    (OIIO_LIKELY(x) ? ((void)0)                                     \
          : (fprintf (stderr, "%s:%u: failed assertion '%s': " msg "\n", \
                     __FILE__, __LINE__, #x,  __VA_ARGS__), abort()))
 #endif

--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -45,16 +45,6 @@
 #include "platform.h"
 
 
-// defining NOMINMAX to prevent problems with std::min/std::max
-// and std::numeric_limits<type>::min()/std::numeric_limits<type>::max()
-// when boost include windows.h
-#ifdef _MSC_VER
-# define WIN32_LEAN_AND_MEAN
-# define VC_EXTRALEAN
-# ifndef NOMINMAX
-#   define NOMINMAX
-# endif
-#endif
 
 #if OIIO_CPLUSPLUS_VERSION >= 11
 # include <thread>
@@ -78,8 +68,7 @@
 
 
 #if defined(_MSC_VER)
-#  include <windows.h>
-#  include <winbase.h>
+   // N.B. including platform.h also included <windows.h>
 #  pragma intrinsic (_InterlockedExchangeAdd)
 #  pragma intrinsic (_InterlockedCompareExchange)
 #  pragma intrinsic (_InterlockedCompareExchange64)

--- a/src/libutil/hashes.cpp
+++ b/src/libutil/hashes.cpp
@@ -7,15 +7,7 @@
 # include <endian.h>    /* attempt to define endianness */
 #endif
 
-#if defined(_MSC_VER) && _MSC_VER < 1600
-  typedef __int8            int8_t;
-  typedef __int16           int16_t;
-  typedef __int32           int32_t;
-  typedef __int64           int64_t;
-#else
-# include <stdint.h>
-#endif
-
+#include "OpenImageIO/platform.h"
 #include "OpenImageIO/fmath.h"
 #include "OpenImageIO/hash.h"
 


### PR DESCRIPTION
(Note: I just found this lurking in my tree, something I did many weeks ago and never submitted.)

* Make sure LIKELY/UNLIKELY are defined for clang and Intel.

* More straightforward way to generate bools for LIKELY/UNLIKELY.

* Use OIIO_UNLIKELY in the ASSERT macros, since by definition we
  aren't expecting the condition to usually be true.

* Feature-testing macro definitions for compilers that lack them
  (and use them).

* More robust test for including windows.h.

* Remove redundant definitions from thread.h and hashes.cpp.