### PR TITLE
Enable TIFF write of 'half' pixels, if "tiff:half" attribute is nonzero.

### DIFF
--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -982,10 +982,10 @@ options are supported:
 
 \vspace{.125in}
 
-\noindent\begin{tabular}{p{2.0in}|p{0.5in}|p{2.75in}}
+\noindent\begin{tabular}{p{1.8in}|p{0.5in}|p{2.95in}}
 Configuration attribute & Type & Meaning \\
 \hline
-\qkw{oiio:UnassociatedAlpha} & int & If nonzero, will leave alpha unassociated
+\qkws{oiio:UnassociatedAlpha} & int & If nonzero, will leave alpha unassociated
                                      (versus the default of premultiplying
                                      color channels by alpha if the alpha channel
                                      is unassociated). \\
@@ -998,23 +998,27 @@ aspects of the writing itself:
 
 \vspace{.125in}
 
-\noindent\begin{tabular}{p{2.0in}|p{0.5in}|p{2.75in}}
+\noindent\begin{tabular}{p{1.8in}|p{0.5in}|p{2.95in}}
 Output attribute & Type & Meaning \\
 \hline
-\qkw{oiio:UnassociatedAlpha} & int & If nonzero, any alpha channel is
+\qkws{oiio:UnassociatedAlpha} & int & If nonzero, any alpha channel is
                                 understood do be unassociated, and the
                                 EXTRASAMPLES tag in the TIFF file will be
                                 set to reflect this). \\
 \qkw{tiff:write_exif} & int & If zero, will not write any Exif data to the
                             TIFF file. (The default is 1.) \\
-
+\qkw{tiff:half} & int & If nonzero, allow writing TIFF files with `half'
+                (16 bit float) pixels. The default of 0 will automatically
+                translate to float pixels, since most non-OIIO applications
+                will not properly read half TIFF files despite their
+                being legal. \\
 \qkws{tiff:ColorSpace} & string & Requests that the file be
                         saved with a non-RGB color spaces.
                         Choices are \qkw{RGB}, \qkw{CMYK}.
                         % , \qkw{YCbCr}, \qkw{CIELAB}, \qkw{ICCLAB}, \qkw{ITULAB}
 \end{tabular}
 
-
+\newpage
 \subsubsection*{TIFF compression modes}
 
 \noindent The full list of possible TIFF compression mode values are as

--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -915,12 +915,31 @@ For example, the following are equivalent to the example above for the
 general (pointer) form of {\cf getattribute()}:
 
 \begin{code}
-      int maxfiles;
-      ts->getattribute ("max_open_files", &maxfiles);
-      const char *path;
-      ts->getattribute ("plugin_searchpath", &path);
+      int threads;
+      OIIO::getattribute ("threads", &threads);
+      std::string path;
+      OIIO::getattribute ("plugin_searchpath", &path);
 \end{code}
+\apiend
 
+\apiitem{int {\ce get_int_attribute} (string_view name, int defaultvalue=0) \\
+float {\ce get_float_attribute} (string_view name, float defaultvalue=0) \\
+string_view {\ce get_string_attribute} (string_view name, \\
+\bigspc\bigspc\bigspc  string_view defaultvalue="")}
+\indexapi{get_int_attribute} \indexapi{get_float_attribute}
+\indexapi{get_string_attribute}
+\NEW % 1.7
+Specialized versions of {\cf getattribute()} for common types, in which the
+data is returned directly, and a supplied default value is returned if the
+attribute was not found.
+
+For example, the following are equivalent to the example above for the
+general (pointer) form of {\cf getattribute()}:
+
+\begin{code}
+      int threads = OIIO::getattribute ("threads", 0);
+      string_view path = OIIO::getattribute ("plugin_searchpath");
+\end{code}
 \apiend
 
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1344,8 +1344,7 @@ inline bool attribute (string_view name, string_view val) {
 /// otherwise return false and do not modify the contents of *val.  It
 /// is up to the caller to ensure that val points to the right kind and
 /// size of storage for the given type.
-OIIO_API bool getattribute (string_view name, TypeDesc type,
-                             void *val);
+OIIO_API bool getattribute (string_view name, TypeDesc type, void *val);
 // Shortcuts for common types
 inline bool getattribute (string_view name, int &val) {
     return getattribute (name, TypeDesc::TypeInt, &val);
@@ -1362,6 +1361,19 @@ inline bool getattribute (string_view name, std::string &val) {
     if (ok)
         val = s.string();
     return ok;
+}
+inline int get_int_attribute (string_view name, int defaultval=0) {
+    int val;
+    return getattribute (name, TypeDesc::TypeInt, &val) ? val : defaultval;
+}
+inline float get_float_attribute (string_view name, float defaultval=0) {
+    float val;
+    return getattribute (name, TypeDesc::TypeFloat, &val) ? val : defaultval;
+}
+inline string_view get_string_attribute (string_view name,
+                                 string_view defaultval = string_view()) {
+    ustring val;
+    return getattribute (name, TypeDesc::TypeString, &val) ? string_view(val) : defaultval;
 }
 
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1326,6 +1326,11 @@ OIIO_API std::string geterror ();
 ///             The default is 0 for release builds, 1 for DEBUG builds,
 ///             but also may be overridden by the OPENIMAGEIO_DEBUG env
 ///             variable.
+///     int tiff:half
+///             When nonzero, allows TIFF to write 'half' pixel data.
+///             N.B. Most apps may not read these correctly, but OIIO will.
+///             That's why the default is not to support it.
+///
 OIIO_API bool attribute (string_view name, TypeDesc type, const void *val);
 // Shortcuts for common types
 inline bool attribute (string_view name, int val) {

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -56,6 +56,7 @@ recursive_mutex imageio_mutex;
 atomic_int oiio_threads (Sysutil::physical_concurrency());
 atomic_int oiio_exr_threads (Sysutil::physical_concurrency());
 atomic_int oiio_read_chunk (256);
+int tiff_half (0);
 ustring plugin_searchpath (OIIO_DEFAULT_PLUGIN_SEARCHPATH);
 std::string format_list;   // comma-separated list of all formats
 std::string extension_list;   // list of all extensions for all formats
@@ -161,6 +162,10 @@ attribute (string_view name, TypeDesc type, const void *val)
         oiio_exr_threads = Imath::clamp (*(const int *)val, 0, maxthreads);
         return true;
     }
+    if (name == "tiff:half" && type == TypeDesc::TypeInt) {
+        tiff_half = *(const int *)val;
+        return true;
+    }
     if (name == "debug" && type == TypeDesc::TypeInt) {
         print_debug = *(const int *)val;
         return true;
@@ -200,6 +205,10 @@ getattribute (string_view name, TypeDesc type, void *val)
     }
     if (name == "exr_threads" && type == TypeDesc::TypeInt) {
         *(int *)val = oiio_exr_threads;
+        return true;
+    }
+    if (name == "tiff:half" && type == TypeDesc::TypeInt) {
+        *(int *)val = tiff_half;
         return true;
     }
     if (name == "debug" && type == TypeDesc::TypeInt) {

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -339,18 +339,23 @@ TIFFOutput::open (const std::string &name, const ImageSpec &userspec,
         sampformat = SAMPLEFORMAT_UINT;
         break;
     case TypeDesc::HALF:
-#if 0
         // Adobe extension, see http://chriscox.org/TIFFTN3d1.pdf
         // Unfortunately, Nuke 9.0, and probably many other apps we care
         // about, cannot read 16 bit float TIFFs correctly. Revisit this
         // again in future releases. (comment added Feb 2015)
-        m_bitspersample = 16;
+        // For now, the default is to NOT write this (instead writing float)
+        // unless the "tiff:half" attribute is nonzero -- use the global
+        // OIIO attribute, but override with a specific attribute for this
+        // file.
+        if (m_spec.get_int_attribute("tiff:half", OIIO::get_int_attribute("tiff:half"))) {
+            m_bitspersample = 16;
+        } else {
+            // Silently change requests for unsupported 'half' to 'float'
+            m_bitspersample = 32;
+            m_spec.set_format (TypeDesc::FLOAT);
+        }
         sampformat = SAMPLEFORMAT_IEEEFP;
         break;
-#else
-        // Silently change requests for unsupported 'half' to 'float'
-        m_spec.set_format (TypeDesc::FLOAT);
-#endif
     case TypeDesc::FLOAT:
         m_bitspersample = 32;
         sampformat = SAMPLEFORMAT_IEEEFP;


### PR DESCRIPTION
Enable TIFF write of 'half' pixels, if "tiff:half" attribute is nonzero.

Set up a global OIIO attribute "tiff:half" that sets the default globally,    and also have the ImageOutput for TIFF recognize a per-file "tiff:half"    override. The default in both cases is 0, meaning that requests for    half pixel float files in the absence this attribute nonzero will be    automatically be upgraded to float, which is more widely read.

The reason for this is that nearly every non-OIIO-based reader fails to    correctly recognize half-valued pixels in TIFF files, including    PhotoShop and Nuke 9. So you are urged not to write half tiff, unless    you are sure that the only consumer of those files uses OIIO (which can    read them properly), or have verified that other consumers in your    pipeline get it right.

Here is the Adobe tech report describing this TIFF extension:     http://chriscox.org/TIFFTN3d1.pdf

A typical OIIO use of this would be to create a half TIFF texture file:

        maketx in.tif -attrib tiff:half 1 -d half -o half.tx

Why would you do this? Because in my benchmarks, texture access of    a half TIFF texture file is nearly twice the raw read performance of    the equivalent OpenEXR half texture.

Along the way, I added the missing get_int_attribute, get_float_attribute, and get_string_attribute equivalents to the global OIIO::getattribute, to match how we have done it for the versions that are methods of ImageSpec, TextureSystem, and a number of other classes.
