### PR TITLE
Minor adjustments to make failed tests print their output and .txt files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,16 +349,18 @@ endif
 # 'make dist' is just a synonym for 'make cmakeinstall'
 dist : cmakeinstall
 
+TEST_FLAGS += --force-new-ctest-process --output-on-failure
+
 # 'make test' does a full build and then runs all tests
 test: cmake
 	${CMAKE} -E cmake_echo_color --switch=$(COLOR) --cyan "Running tests ${TEST_FLAGS}..."
-	( cd ${build_dir} ; PYTHONPATH=${PWD}/${build_dir}/src/python ctest --force-new-ctest-process ${TEST_FLAGS} -E broken )
+	( cd ${build_dir} ; PYTHONPATH=${PWD}/${build_dir}/src/python ctest  ${TEST_FLAGS} -E broken )
 
 # 'make testall' does a full build and then runs all tests (even the ones
 # that are expected to fail on some platforms)
 testall: cmake
 	${CMAKE} -E cmake_echo_color --switch=$(COLOR) --cyan "Running all tests ${TEST_FLAGS}..."
-	( cd ${build_dir} ; PYTHONPATH=${PWD}/${build_dir}/src/python ctest --force-new-ctest-process ${TEST_FLAGS} )
+	( cd ${build_dir} ; PYTHONPATH=${PWD}/${build_dir}/src/python ctest ${TEST_FLAGS} )
 
 # 'make clean' clears out the build directory for this platform
 clean:

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -259,6 +259,9 @@ def runtest (command, outputs, failureok=0) :
             err = 1
             print ("NO MATCH for " + out)
             print ("FAIL " + out)
+            if extension == ".txt" :
+                print ("-----" + out + "----->")
+                print (open(out,'r').read() + "<----------")
 
     return (err)
 


### PR DESCRIPTION
Among other things, this makes things a lot easier when inspecting failed Travis builds -- the travis log will show the test output and any text file comparisons that fail.