### PR TITLE
Refine ccache logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,10 +60,12 @@ before_install:
 
 install:
     - if [ "$CXX" == "g++" ]; then export CXX="g++-${WHICHGCC}" ; fi
+    - export USE_CCACHE=1
+    - export CCACHE_CPP2=1
     - if [ $TRAVIS_OS_NAME == osx ] ; then
           src/build-scripts/install_homebrew_deps.bash ;
       elif [ $TRAVIS_OS_NAME == linux ] ; then
-          CXX="ccache $CXX" CCACHE_CPP2=1 src/build-scripts/build_openexr.bash ;
+          CXX="ccache $CXX" src/build-scripts/build_openexr.bash ;
           export ILMBASE_HOME=$PWD/openexr-install ;
           export OPENEXR_HOME=$PWD/openexr-install ;
       fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,13 +156,6 @@ if (EXISTS "/usr/lib/libc++.dylib")
     set (OSL_SYSTEM_HAS_LIBCPP ON)
 endif ()
 
-# Use ccache if found
-find_program (CCACHE_FOUND ccache)
-if (CCACHE_FOUND)
-    set_property (GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-    set_property (GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-endif ()
-
 
 set (VERBOSE OFF CACHE BOOL "Print lots of messages while compiling")
 set (EMBEDPLUGINS ON CACHE BOOL "Embed format plugins in libOpenImageIO")
@@ -209,6 +202,19 @@ set (OIIO_BUILD_CPP14 OFF CACHE BOOL "Compile in C++14 mode")
 set (OIIO_BUILD_LIBCPLUSPLUS OFF CACHE BOOL "Compile with clang libc++")
 set (EXTRA_CPP_ARGS "" CACHE STRING "Extra C++ command line definitions")
 set (USE_SIMD "" CACHE STRING "Use SIMD directives (0, sse2, sse3, ssse3, sse4.1, sse4.2)")
+set (USE_CCACHE ON CACHE BOOL "Use ccache if found")
+
+# Use ccache if found
+find_program (CCACHE_FOUND ccache)
+if (CCACHE_FOUND AND USE_CCACHE)
+    if (CMAKE_COMPILER_IS_CLANG AND USE_QT AND (NOT DEFINED ENV{CCACHE_CPP2}))
+        message (STATUS "Ignoring ccache because clang + Qt + env CCACHE_CPP2 is not set")
+    else ()
+        set_property (GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+        set_property (GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+    endif ()
+endif ()
+
 
 if (BUILDSTATIC AND ${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     # On Linux, the lack of -fPIC when building static libraries seems

--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,10 @@ ifneq (${TEST},)
 TEST_FLAGS += -R ${TEST}
 endif
 
+ifneq (${USE_CCACHE},)
+MY_CMAKE_FLAGS += -DUSE_CCACHE:BOOL=${USE_CCACHE}
+endif
+
 ifeq (${USE_NINJA},1)
 MY_CMAKE_FLAGS += -G Ninja
 BUILDSENTINEL := build.ninja
@@ -403,6 +407,7 @@ help:
 	@echo "      USE_LIBCPLUSPLUS=1       Use clang libc++"
 	@echo "      EXTRA_CPP_ARGS=          Additional args to the C++ command"
 	@echo "      USE_NINJA=1              Set up Ninja build (instead of make)"
+	@echo "      USE_CCACHE=0             Disable ccache (even if available)"
 	@echo "  Linking and libraries:"
 	@echo "      HIDE_SYMBOLS=1           Hide symbols not in the public API"
 	@echo "      SOVERSION=nn             Include the specifed major version number "


### PR DESCRIPTION
* Top-level USE_CCACHE=0 can turn it off no matter what
* Avoid ccache if we're using clang and compiling Qt headers and the
  $CCACHE_CPP2 env var is not set -- this leads to problems.