### PR TITLE
Fix IB::copy() and oiiotool --ch for deep

### DIFF
--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -1245,12 +1245,6 @@ protected:
     ImageBufImpl * impl () { return m_impl; }
     const ImageBufImpl * impl () const { return m_impl; }
 
-    // Copy src's pixels into *this.  Pixels must already be local
-    // (either owned or wrapped) and the resolution and number of
-    // channels must match src.  Data type is allowed to be different,
-    // however, with automatic conversion upon copy.
-    void copy_from (const ImageBuf &src);
-
     // Reset the ImageCache::Tile * to reserve and point to the correct
     // tile for the given pixel, and return the ptr to the actual pixel
     // within the tile.

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -669,31 +669,6 @@ ImageBufImpl::alloc (const ImageSpec &spec)
 
 
 
-void
-ImageBuf::copy_from (const ImageBuf &src)
-{
-    if (this == &src)
-        return;
-    const ImageBufImpl *srcimpl (src.impl());
-    srcimpl->validate_pixels ();
-    const ImageSpec &srcspec (srcimpl->spec());
-    ImageBufImpl *impl (this->impl());
-    const ImageSpec &spec (impl->spec());
-    ASSERT (spec.width == srcspec.width &&
-            spec.height == srcspec.height &&
-            spec.depth == srcspec.depth &&
-            spec.nchannels == srcspec.nchannels);
-    impl->realloc ();
-    if (spec.deep)
-        impl->m_deepdata = srcimpl->m_deepdata;
-    else
-        src.get_pixels (src.xbegin(), src.xend(), src.ybegin(), src.yend(),
-                        src.zbegin(), src.zend(), spec.format,
-                        impl->m_localpixels);
-}
-
-
-
 bool
 ImageBufImpl::init_spec (string_view filename, int subimage, int miplevel)
 {

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1311,6 +1311,9 @@ ImageBuf::copy_pixels (const ImageBuf &src)
     if (this == &src)
         return true;
 
+    if (deep() || src.deep())
+        return false;   // This operation is not supported for deep images
+
     // compute overlap
     ROI myroi = get_roi(spec());
     ROI roi = roi_intersection (myroi, get_roi(src.spec()));
@@ -1337,7 +1340,12 @@ ImageBuf::copy (const ImageBuf &src, TypeDesc format)
         clear();
         return true;
     }
-    if (format.basetype == TypeDesc::UNKNOWN)
+    if (src.deep()) {
+        reset (src.name(), src.spec());
+        impl()->m_deepdata = src.impl()->m_deepdata;
+        return true;
+    }
+    if (format.basetype == TypeDesc::UNKNOWN || src.deep())
         reset (src.name(), src.spec());
     else {
         ImageSpec newspec (src.spec());


### PR DESCRIPTION
Fixes #1282 -- oiiotool --ch was noticed to fail for deep images when the --ch didn't actually change or reorder the channels.

Some investigation showed that this "straight copy" fell back on the simpler ImageBuf::copy(), which in turn was not deep-safe. This patch fixes that.

Also noticed along the way the existence of a closely related but subtly incompatible method copy_from(), which also was both not public and never used! So remove it.
