### PR TITLE
DeepData refactor

### DIFF
--- a/src/doc/imagebuf.tex
+++ b/src/doc/imagebuf.tex
@@ -624,20 +624,53 @@ are no deep samples for that pixel (including if the pixel coordinates
 are outside the data area).  For non-deep images, it will always return 0.
 \apiend
 
-\apiitem{const void *{\ce deep_pixel_ptr} (int x, int y, int z, int c) const}
-Returns a pointer to the raw array of deep samples for channel {\cf c}
-of pixel {\cf (x,y,z)}.  This will return {\cf NULL} if the pixel
-coordinates or channel number are out of range, if the pixel/channel has
-no deep samples, or if the image is not deep.
+\apiitem{void {\ce set_deep_samples} (int x, int y, int z, int nsamples)}
+Set the number of samples for pixel {\cf (x,y,z)}. If data has already been
+allocated, this is equivalent to inserting or erasing samples.
 \apiend
 
+\apiitem{void {\ce deep_insert_samples} (int x, int y, int z, int samplepos, int nsamples)}
+\NEW % 1.7
+Insert {\cf nsamples} new samples, starting at position {\cf samplepos} of
+pixel {\cf (x,y,z)}.
+\apiend
 
-\apiitem{float {\ce deep_value} (int x, int y, int z, int c, int s) const}
-Return the value (as a {\cf float}) of sample {\cf s} of channel {\cf c}
-of pixel {\cf (x,y,z)}.  Return {\cf 0.0} if not a deep image or if the
+\apiitem{void {\ce deep_erase_samples} (int x, int y, int z, int samplepos, int nsamples)}
+\NEW % 1.7
+Remove {\cf nsamples} new samples, starting at position {\cf samplepos} of
+pixel {\cf (x,y,z)}.
+\apiend
+
+\apiitem{float {\ce deep_value} (int x, int y, int z, int c, int s) const \\
+uint32_t {\ce deep_value_uint} (int x, int y, int z, int c, int s) const}
+Return the value of sample {\cf s} of channel {\cf c}
+of pixel {\cf (x,y,z)}.  Return {\cf 0} if not a deep image or if the
 pixel coordinates, channel number, or sample number are out of range, or
-if it has no deep samples.
+if it has no deep samples.  You are expected to call the {\cf float} or
+{\cf uint32_t} version based on the data type of channel {\cf c}.
 \apiend
+
+\apiitem{void {\ce set_deep_value} (int x, int y, int z, int c, int s, float value) const \\
+void {\ce set_deep_value} (int x, int y, int z, int c, int s, uint32_t value) const}
+Set the value of sample {\cf s} of channel {\cf c}
+of pixel {\cf (x,y,z)}. It is expected that you choose the {\cf float}
+or {\cf uint32_t} variety of the call based on the data type of channel {\cf c}.
+\apiend
+
+\apiitem{const void *{\ce deep_pixel_ptr} (int x, int y, int z, int c, int s=0) const}
+Returns a pointer to the raw pixel data pixel {\cf (x,y,z)}, channel {\cf c},
+sample {\cf s}.  This will return {\cf NULL} if the pixel
+coordinates or channel number are out of range, if the pixel/channel has
+no deep samples, or if the image is not deep. Use with caution --- these
+pointers may be invalidated by calls that adjust the number of samples in
+any pixel.
+\apiend
+
+\apiitem{DeepData\& {\ce deepdata} () \\
+const DeepData\& {\ce deepdata} () const}
+Returns a reference to the underlying {\cf DeepData} for a deep image.
+\apiend
+
 
 \section{Miscellaneous}
 
@@ -799,7 +832,8 @@ samples for the current pixel. This only is useful if the \ImageBuf has
 not yet had the {\cf deep_alloc()} method called.
 \apiend
 
-\apiitem{USERT Iterator::deep_value (int c, int s) const}
+\apiitem{USERT Iterator::deep_value (int c, int s) const \\
+uint32_t Iterator::deep_value_int (int c, int s) const}
 For deep images only, returns the value of channel {\cf c}, sample
 number {\cf s}, at the current pixel.
 \apiend

--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -723,14 +723,20 @@ Retrieve the number of samples for the given pixel index.
 \apiend
 
 \apiitem{void {\ce set_samples} (int pixel, int samps)}
-Set the number of samples for the given pixel index. This method should
-be called after {\cf init()}, for each pixel with $>0$ samples, \emph{before}
-calling {\cf init()}.
+Set the number of samples for the given pixel index.
 \apiend
 
-\apiitem{void {\ce alloc} ()}
-For an initialized \DeepData, given the number of samples specified for each
-pixel (via {\cf set_samples}), allocate the space for the pixel data itself.
+\apiitem{void {\ce insert_samples} (int pixel, int samplepos, int n=1)}
+\NEW % 1.7
+Insert {\cf n} samples of the specified pixel, betinning at the sample
+position index. After insertion, the new samples will have uninitialized
+values.
+\apiend
+
+\apiitem{void {\ce erase_samples} (int pixel, int samplepos, int n=1)}
+\NEW % 1.7
+Remove {\cf n} samples of the specified pixel, betinning at the sample
+position index.
 \apiend
 
 \apiitem{float {\ce deep_value} (int pixel, int channel, int sample) const \\
@@ -744,13 +750,6 @@ void {\ce set_deep_value} (int pixel, int channel, int sample, uint32_t value)}
 Set the value of the given pixel, channel, and sample indices, for
 floating point or unsigned integer channel types, respectively.
 \apiend
-
-\apiitem{void* {\ce channel_ptr} (int pixel, int channel) \\
-const void* {\ce channel_ptr} (int pixel, int channel) const}
-Retrieve a raw pointer to the first sample of the given pixel and channel,
-or NULL if there are no samples for that pixel.
-\apiend
-
 
 
 

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -94,7 +94,7 @@
  \bigskip \\
 }
 \date{{\large 
-Date: 1 Dec 2015
+Date: 12 Dec 2015
 %\\ (with corrections, 25 Aug 2015)
 }}
 

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -609,19 +609,22 @@ collection of deep data.
 This {\cf int} field constains the number of channels.
 \apiend
 
-\apiitem{DeepData.{\ce set_nsamples} (pixel, nsamples) \\
-int DeepData.{\ce get_nsamples} (pixel)}
+\apiitem{DeepData.{\ce set_samples} (pixel, nsamples) \\
+int DeepData.{\ce samples} (pixel)}
 Set or get the number of samples for a given pixel (specified by integer
 index).
 \apiend
 
-\apiitem{DeepData.{\ce alloc()}}
-After {\cf set_nsamples} has been called for each pixel, {\cf alloc()}
-is called to allocate the sample data.
+\apiitem{DeepData.{\ce insert_samples} (pixel, samplepos, n) \\
+int DeepData.{\ce erase_samples} (pixel, samplepos, n)}
+\NEW % 1.7
+Insert or erase \emph{n} samples starting at the given position of an
+indexed pixel.
 \apiend
 
-\apiitem{DeepData.{\ce set_deep_value} (pixel, channel, sample, value)}
-Set specific float value of a given pixel, channel, and
+\apiitem{DeepData.{\ce set_deep_value} (pixel, channel, sample, value) \\
+DeepData.{\ce set_deep_value_uint} (pixel, channel, sample, value)}
+Set specific float or unsigned int value of a given pixel, channel, and
 sample index.
 \apiend
 
@@ -1560,6 +1563,13 @@ Return the number of deep samples for pixel (x,y,z).
 Set the number of deep samples for pixel (x,y,z).
 \apiend
 
+\apiitem{ImageBuf.{\ce deep_insert_samples} (x, y, z, samplepos, nsamples) \\
+int ImageBuf.{\ce deep_erase_samples} (x, y, z, samplepos, nsamples)}
+\NEW % 1.7
+Insert or erase \emph{nsamples} samples starting at the given position of
+pixel {\cf (x,y,z)}.
+\apiend
+
 \apiitem{float ImageBuf.{\ce deep_value} (x, y, z, channel, sample) \\
 uint ImageBuf.{\ce deep_value_uint} (x, y, z, channel, sample)}
 Return the value of the given deep sample (particular pixel, channel, and
@@ -1576,11 +1586,6 @@ respectively.
 
 \apiitem{DeepData ImageBuf.{\ce deepdata}}
 Returns a reference to the underlying {\cf DeepData} of the image.
-\apiend
-
-\apiitem{ImageBuf.{\ce deep_alloc} ()}
-Allocate the space for all samples (assuming you have already properly
-called {\cf deepdata().init()}).
 \apiend
 
 

--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -79,8 +79,8 @@ print_sha1 (ImageInput *input)
             return;
         }
         // Hash both the sample counds and the data block
-        sha.appendvec (dd.nsamples);
-        sha.appendvec (dd.data);
+        sha.append (dd.all_nsamples());
+        sha.append (dd.all_data());
     } else {
         imagesize_t size = input->spec().image_bytes (true /*native*/);
         if (size >= std::numeric_limits<size_t>::max()) {
@@ -256,11 +256,11 @@ print_stats (const std::string &filename,
 
     if (input.deep()) {
         const DeepData *dd (input.deepdata());
-        size_t npixels = dd->nsamples.size();
+        size_t npixels = dd->pixels();
         size_t totalsamples = 0, emptypixels = 0;
         size_t maxsamples = 0, minsamples = std::numeric_limits<size_t>::max();
         for (size_t p = 0;  p < npixels;  ++p) {
-            size_t c = dd->nsamples[p];
+            size_t c = dd->samples(p);
             totalsamples += c;
             if (c > maxsamples)
                 maxsamples = c;

--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -45,6 +45,7 @@
 #include "OpenImageIO/imageio.h"
 #include "OpenImageIO/imagebuf.h"
 #include "OpenImageIO/imagebufalgo.h"
+#include "OpenImageIO/deepdata.h"
 #include "OpenImageIO/hash.h"
 #include "OpenImageIO/filesystem.h"
 

--- a/src/include/OpenImageIO/deepdata.h
+++ b/src/include/OpenImageIO/deepdata.h
@@ -1,0 +1,130 @@
+/*
+Copyright 2015 Larry Gritz and the other authors and contributors.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of the software's owners nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+(This is the Modified BSD License)
+*/
+
+
+#pragma once 
+
+#ifndef OPENIMAGEIO_DEEPDATA_H
+#define OPENIMAGEIO_DEEPDATA_H
+
+#include "export.h"
+#include "oiioversion.h"
+#include "array_view.h"
+
+OIIO_NAMESPACE_BEGIN
+
+
+struct TypeDesc;
+class ImageSpec;
+
+
+
+/// Structure to hold "deep" data -- multiple samples per pixel.
+class OIIO_API DeepData {
+public:
+    /// Construct an empty DeepData.
+    DeepData ();
+
+    /// Construct and init from an ImageSpec.
+    DeepData (const ImageSpec &spec);
+
+    /// Copy constructor
+    DeepData (const DeepData &d);
+
+    ~DeepData ();
+
+    /// Copy assignment
+    const DeepData& operator= (const DeepData &d);
+
+    /// Clear the vectors and reset size to 0.
+    void clear ();
+    /// Deallocate all space in the vectors
+    void free ();
+
+    /// Initialize size and allocate nsamples, pointers. It is important to
+    /// completely fill in nsamples after init() but before alling alloc().
+    void init (int npix, int nchan, array_view<const TypeDesc> channeltypes);
+
+    /// Initialize size and allocate nsamples, pointers based on the number
+    /// of pixels, channels, and channel types in the ImageSpec. It is
+    /// important to completely fill in nsamples after init() but before
+    /// alling alloc().
+    void init (const ImageSpec &spec);
+
+    /// Retrieve the total number of pixels.
+    int pixels () const;
+    /// Retrieve the number of channels.
+    int channels () const;
+    /// Retrieve the channel type of channel c.
+    TypeDesc channeltype (int c) const;
+
+    /// Retrieve the number of samples for the given pixel index.
+    int samples (int pixel) const;
+
+    /// Set the number of samples for the given pixel. This must be called
+    /// after init(), but before alloc().
+    void set_samples (int pixel, int samps);
+
+    /// After set_samples() has been set for all pixels, call alloc() to
+    /// allocate enough scratch space for data and set up all the pointers.
+    void alloc ();
+
+    /// Retrieve deep sample value within a pixel, cast to a float.
+    float deep_value (int pixel, int channel, int sample) const;
+    /// Retrieve deep sample value within a pixel, as an untigned int.
+    uint32_t deep_value_uint (int pixel, int channel, int sample) const;
+
+    /// Set deep sample value within a pixel, as a float.
+    /// It will automatically call alloc() if it has not yet been called.
+    void set_deep_value (int pixel, int channel, int sample, float value);
+    /// Set deep sample value within a pixel, as a uint32.
+    /// It will automatically call alloc() if it has not yet been called.
+    void set_deep_value (int pixel, int channel, int sample, uint32_t value);
+
+    /// Retrieve the pointer to the first sample of the given pixel and
+    /// channel. Return NULL if there are no samples for that pixel.
+    /// Use with care.
+    void *channel_ptr (int pixel, int channel);
+    const void *channel_ptr (int pixel, int channel) const;
+
+    array_view<const unsigned int> all_nsamples () const;
+    array_view<const char> all_data () const;
+    void * const * all_pointers () const;  // Caution: expect deprecation
+
+private:
+    class Impl;
+    Impl *m_impl;  // holds all the nontrivial stuff
+    int m_npixels, m_nchannels;
+};
+
+
+
+OIIO_NAMESPACE_END
+
+#endif  // OPENIMAGEIO_DEEPDATA_H

--- a/src/include/OpenImageIO/hash.h
+++ b/src/include/OpenImageIO/hash.h
@@ -48,7 +48,8 @@
 #include "export.h"
 #include "oiioversion.h"
 #include "fmath.h"   /* for endian */
-#include "string_view.h"   /* for endian */
+#include "string_view.h"
+#include "array_view.h"
 
 
 OIIO_NAMESPACE_BEGIN
@@ -476,9 +477,13 @@ public:
 
     /// Append more data
     void append (const void *data, size_t size);
-    /// Append more data from a vector, without thinking about sizes.
-    template<class T> void appendvec (const std::vector<T> &v) {
-        append (&v[0], v.size()*sizeof(T));
+    /// Append more data from an array_view, without thinking about sizes.
+    template<class T> void append (array_view<T> v) {
+        append (v.data(), v.size()*sizeof(T));
+    }
+    // DEPRECATED(1.6): appendvec is the old name
+    template<class T> void appendvec (array_view<T> v) {
+        append (v.data(), v.size()*sizeof(T));
     }
 
     /// Type for storing the raw bits of the hash

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -653,11 +653,11 @@ public:
     /// range or has no deep samples.
     int deep_samples (int x, int y, int z=0) const;
 
-    /// Return a pointer to the raw array of deep data samples for
-    /// channel c of pixel (x,y,z).  Return NULL if the pixel
-    /// coordinates or channel number are out of range, if the
-    /// pixel/channel has no deep samples, or if the image is not deep.
-    const void *deep_pixel_ptr (int x, int y, int z, int c) const;
+    /// Return a pointer to the raw data of pixel (x,y,z), channel c, sample
+    /// s. Return NULL if the pixel coordinates or channel number are out of
+    /// range, if the pixel/channel has no deep samples, or if the image is
+    /// not deep.
+    const void *deep_pixel_ptr (int x, int y, int z, int c, int s=0) const;
 
     /// Return the value (as a float) of sample s of channel c of pixel
     /// (x,y,z).  Return 0.0 if not a deep image or if the pixel
@@ -671,11 +671,21 @@ public:
     /// Set the number of deep samples for a particular pixel.
     void set_deep_samples (int x, int y, int z, int nsamples);
 
+    /// Set the number of deep samples for a particular pixel.
+    void deep_insert_samples (int x, int y, int z, int samplepos, int nsamples);
+
+    /// Set the number of deep samples for a particular pixel.
+    void deep_erase_samples (int x, int y, int z, int samplepos, int nsamples);
+
     /// Set deep sample value within a pixel, as a float.
     void set_deep_value (int x, int y, int z, int c, int s, float value);
     /// Set deep sample value within a pixel, as a uint32.
+    void set_deep_value (int x, int y, int z, int c, int s, uint32_t value);
+
+    // DEPRECATED (1.7): old name
     void set_deep_value_uint (int x, int y, int z, int c, int s, uint32_t value);
 
+    /// DEPRECATED (1.7): no longer necessary
     /// Allocate all the deep samples, called after deepdata()->nsamples
     /// is set.
     void deep_alloc ();
@@ -1141,6 +1151,9 @@ public:
         USERT deep_value (int c, int s) const {
             return convert_type<float,USERT>(m_ib->deep_value (m_x, m_y, m_z, c, s));
         }
+        uint32_t deep_value_uint (int c, int s) const {
+            return m_ib->deep_value_uint (m_x, m_y, m_z, c, s);
+        }
 
         /// Set the deep data value of sample s of channel c. (Only use this
         /// if deep_alloc() has been called.)
@@ -1235,6 +1248,9 @@ public:
         /// Retrieve the deep data value of sample s of channel c.
         USERT deep_value (int c, int s) const {
             return convert_type<float,USERT>(m_ib->deep_value (m_x, m_y, m_z, c, s));
+        }
+        uint32_t deep_value_uint (int c, int s) const {
+            return m_ib->deep_value_uint (m_x, m_y, m_z, c, s);
         }
     };
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -63,6 +63,9 @@
 
 OIIO_NAMESPACE_BEGIN
 
+class DeepData;
+
+
 /// Type we use for stride lengths.  This is only used to designate
 /// pixel, scanline, tile, or image plane sizes in user-allocated memory,
 /// so it doesn't need to represent sizes larger than can be malloced,
@@ -389,86 +392,6 @@ public:
         if ((int)formats.size() < nchannels)
             formats.resize (nchannels, format);
     }
-};
-
-
-
-/// Structure to hold "deep" data -- multiple samples per pixel.
-struct OIIO_API DeepData {
-public:
-    /// Construct an empty DeepData.
-    DeepData ();
-
-    /// Construct and init from an ImageSpec.
-    DeepData (const ImageSpec &spec);
-
-    /// Copy constructor
-    DeepData (const DeepData &d);
-
-    ~DeepData ();
-
-    /// Copy assignment
-    const DeepData& operator= (const DeepData &d);
-
-    /// Clear the vectors and reset size to 0.
-    void clear ();
-    /// Deallocate all space in the vectors
-    void free ();
-
-    /// Initialize size and allocate nsamples, pointers. It is important to
-    /// completely fill in nsamples after init() but before alling alloc().
-    void init (int npix, int nchan, array_view<const TypeDesc> channeltypes);
-
-    /// Initialize size and allocate nsamples, pointers based on the number
-    /// of pixels, channels, and channel types in the ImageSpec. It is
-    /// important to completely fill in nsamples after init() but before
-    /// alling alloc().
-    void init (const ImageSpec &spec);
-
-    /// Retrieve the total number of pixels.
-    int pixels () const;
-    /// Retrieve the number of channels.
-    int channels () const;
-    /// Retrieve the channel type of channel c.
-    TypeDesc channeltype (int c) const;
-
-    /// Retrieve the number of samples for the given pixel index.
-    int samples (int pixel) const;
-
-    /// Set the number of samples for the given pixel. This must be called
-    /// after init(), but before alloc().
-    void set_samples (int pixel, int samps);
-
-    /// After set_samples() has been set for all pixels, call alloc() to
-    /// allocate enough scratch space for data and set up all the pointers.
-    void alloc ();
-
-    /// Retrieve deep sample value within a pixel, cast to a float.
-    float deep_value (int pixel, int channel, int sample) const;
-    /// Retrieve deep sample value within a pixel, as an untigned int.
-    uint32_t deep_value_uint (int pixel, int channel, int sample) const;
-
-    /// Set deep sample value within a pixel, as a float.
-    /// It will automatically call alloc() if it has not yet been called.
-    void set_deep_value (int pixel, int channel, int sample, float value);
-    /// Set deep sample value within a pixel, as a uint32.
-    /// It will automatically call alloc() if it has not yet been called.
-    void set_deep_value (int pixel, int channel, int sample, uint32_t value);
-
-    /// Retrieve the pointer to the first sample of the given pixel and
-    /// channel. Return NULL if there are no samples for that pixel.
-    /// Use with care.
-    void *channel_ptr (int pixel, int channel);
-    const void *channel_ptr (int pixel, int channel) const;
-
-    array_view<const unsigned int> all_nsamples () const;
-    array_view<const char> all_data () const;
-    void * const * all_pointers () const;  // Caution: expect deprecation
-
-private:
-    class Impl;
-    Impl *m_impl;  // holds all the nontrivial stuff
-    int m_npixels, m_nchannels;
 };
 
 

--- a/src/include/OpenImageIO/oiioversion.h.in
+++ b/src/include/OpenImageIO/oiioversion.h.in
@@ -106,8 +106,9 @@ namespace OIIO = OIIO_NAMESPACE::OIIO_VERSION_NS;
 /// Version 17 changed to int supports(string_view) rather than
 ///     bool supports(const std::string&)). (OIIO 1.6)
 /// Version 18 changed to add an m_threads member to ImageInput/Output.
+/// Version 19 changed the definition of DeepData.
 
-#define OIIO_PLUGIN_VERSION 18
+#define OIIO_PLUGIN_VERSION 19
 
 #define OIIO_PLUGIN_NAMESPACE_BEGIN OIIO_NAMESPACE_BEGIN
 #define OIIO_PLUGIN_NAMESPACE_END OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -34,8 +34,8 @@
 #include <OpenEXR/half.h>
 
 #include "OpenImageIO/dassert.h"
-#include "OpenImageIO/typedesc.h"
 #include "OpenImageIO/imageio.h"
+#include "OpenImageIO/deepdata.h"
 
 OIIO_NAMESPACE_BEGIN
 
@@ -122,9 +122,10 @@ int DeepData::channels () const
 
 
 
-TypeDesc DeepData::channeltype (int c) const
+TypeDesc
+DeepData::channeltype (int c) const
 {
-    ASSERT (m_impl);
+    DASSERT (m_impl && c >= 0 && c < m_nchannels);
     return m_impl->m_channeltypes[c];
 }
 

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -30,6 +30,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <numeric>
 
 #include <OpenEXR/half.h>
 
@@ -44,16 +45,53 @@ OIIO_NAMESPACE_BEGIN
 class DeepData::Impl {  // holds all the nontrivial stuff
 public:
     std::vector<TypeDesc> m_channeltypes;  // for each channel [c]
-    std::vector<unsigned int> m_nsamples;// for each pixel [z][y][x]
-    std::vector<void *> m_pointers;    // for each channel per pixel [z][y][x][c]
-    std::vector<char> m_data;          // for each sample [z][y][x][c][s]
+    std::vector<size_t> m_channelsizes;    // for each channel [c]
+    std::vector<size_t> m_channeloffsets;  // for each channel [c]
+    std::vector<unsigned int> m_nsamples;  // for each pixel [p]
+    std::vector<size_t> m_cumsamples;      // cumulative samples before pixel [p]
+    std::vector<char> m_data;              // for each sample [p][s][c]
+    size_t m_samplesize;
+    bool m_allocated;
+
+    Impl () : m_allocated(false) {}
 
     void clear () {
         m_channeltypes.clear();
+        m_channelsizes.clear();
+        m_channeloffsets.clear();
         m_nsamples.clear();
-        m_pointers.clear();
+        m_cumsamples.clear();
         m_data.clear();
+        m_samplesize = 0;
+        m_allocated = false;
     }
+
+    // If not already done, allocate data and cumsamples
+    void alloc (size_t npixels) {
+        if (! m_allocated) {
+            m_cumsamples.resize (npixels);
+            size_t totalsamples = 0;
+            for (size_t i = 0; i < npixels; ++i) {
+                m_cumsamples[i] = totalsamples;
+                totalsamples += m_nsamples[i];
+            }
+            m_data.resize (totalsamples * m_samplesize);
+            m_allocated = true;
+        }
+    }
+
+    size_t data_offset (int pixel, int channel, int sample) {
+        DASSERT (m_cumsamples.size() > pixel);
+        return (m_cumsamples[pixel] + sample) * m_samplesize
+             + m_channeloffsets[channel];
+    }
+
+    void * data_ptr (int pixel, int channel, int sample) {
+        size_t offset = data_offset (pixel, channel, sample);
+        DASSERT (offset < m_data.size());
+        return &m_data[offset];
+    }
+
 };
 
 
@@ -131,6 +169,23 @@ DeepData::channeltype (int c) const
 
 
 
+size_t
+DeepData::channelsize (int c) const
+{
+    DASSERT (m_impl && c >= 0 && c < m_nchannels);
+    return m_impl->m_channelsizes[c];
+}
+
+
+
+size_t
+DeepData::samplesize () const
+{
+    return m_impl->m_samplesize;
+}
+
+
+
 void
 DeepData::init (int npix, int nchan,
                 array_view<const TypeDesc> channeltypes)
@@ -147,8 +202,16 @@ DeepData::init (int npix, int nchan,
     } else {
         m_impl->m_channeltypes.assign (channeltypes.data(), channeltypes.data()+channeltypes.size());
     }
+    m_impl->m_channelsizes.resize (m_nchannels);
+    m_impl->m_channeloffsets.resize (m_nchannels);
+    m_impl->m_samplesize = 0;
+    for (int i = 0; i < m_nchannels; ++i) {
+        size_t size = m_impl->m_channeltypes[i].size();
+        m_impl->m_channelsizes[i] = size;
+        m_impl->m_channeloffsets[i] = m_impl->m_samplesize;
+        m_impl->m_samplesize += size;
+    }
     m_impl->m_nsamples.resize (m_npixels, 0);
-    m_impl->m_pointers.resize (size_t(m_npixels)*size_t(m_nchannels), NULL);
 }
 
 
@@ -160,40 +223,6 @@ DeepData::init (const ImageSpec &spec)
         init ((int) spec.image_pixels(), spec.nchannels, spec.channelformats);
     else
         init ((int) spec.image_pixels(), spec.nchannels, spec.format);
-}
-
-
-
-void
-DeepData::alloc ()
-{
-    ASSERT (m_impl);
-    // Calculate the total size we need, align each channel to 4 byte boundary
-    size_t totalsamples = 0, totalbytes = 0;
-    for (int i = 0;  i < m_npixels;  ++i) {
-        if (int s = m_impl->m_nsamples[i]) {
-            totalsamples += s;
-            for (int c = 0;  c < m_nchannels;  ++c)
-                totalbytes += round_to_multiple (channeltype(c).size() * s, 4);
-        }
-    }
-
-    // Allocate a minimum of 4 bytes so that we can tell if alloc() was
-    // called by whether m_impl->m_data.size() > 0.
-    totalbytes = std::max (totalbytes, size_t(4));
-
-    // Set all the data pointers to the right offsets within the
-    // data block.  Leave the pointes NULL for pixels with no samples.
-    m_impl->m_data.resize (totalbytes);
-    char *p = &m_impl->m_data[0];
-    for (int i = 0;  i < m_npixels;  ++i) {
-        if (int s = m_impl->m_nsamples[i]) {
-            for (int c = 0;  c < m_nchannels;  ++c) {
-                m_impl->m_pointers[i*m_nchannels+c] = p;
-                p += round_to_multiple (channeltype(c).size()*s, 4);
-            }
-        }
-    }
 }
 
 
@@ -233,32 +262,83 @@ DeepData::samples (int pixel) const
 void
 DeepData::set_samples (int pixel, int samps)
 {
-    ASSERT (pixel >= 0 && pixel < m_npixels && "invalid pixel index");
+    if (pixel < 0 || pixel >= m_npixels)
+        return;
     ASSERT (m_impl);
-    ASSERT (m_impl->m_data.size() == 0 && "set_samples may not be called after alloc()");
-    m_impl->m_nsamples[pixel] = samps;
+    if (m_impl->m_allocated) {
+        // Data already allocated. Turn it into an insert or delete
+        int n = (int)samples(pixel);
+        int diff = abs (samps - n);
+        if (samps < n)
+            insert_samples (pixel, n, diff);
+        else
+            erase_samples (pixel, n-diff, diff);
+    } else {
+        m_impl->m_nsamples[pixel] = samps;
+    }
+}
+
+
+
+void
+DeepData::insert_samples (int pixel, int samplepos, int n)
+{
+    if (m_impl->m_allocated) {
+        // Move the data
+        size_t offset = m_impl->data_offset (pixel, 0, samplepos);
+        m_impl->m_data.insert (m_impl->m_data.begin() + offset,
+                               n*samplesize(), 0);
+        // Adjust the cumulative prefix sum of samples for subsequent pixels
+        for (int p = pixel+1; p < m_npixels; ++p)
+            m_impl->m_cumsamples[p] += size_t(n);
+    }
+    // Add to this pixel's sample count
+    m_impl->m_nsamples[pixel] += n;
+}
+
+
+
+void
+DeepData::erase_samples (int pixel, int samplepos, int n)
+{
+    n = std::min (n, int(m_impl->m_nsamples[pixel]));
+    if (m_impl->m_allocated) {
+        // Move the data
+        size_t offset = m_impl->data_offset (pixel, 0, samplepos);
+        m_impl->m_data.erase (m_impl->m_data.begin() + offset,
+                              m_impl->m_data.begin() + offset + n*samplesize());
+        // Adjust the cumulative prefix sum of samples for subsequent pixels
+        for (int p = pixel+1; p < m_npixels; ++p)
+            m_impl->m_cumsamples[p] -= size_t(n);
+    }
+    // Subtract from this pixel's sample count
+    m_impl->m_nsamples[pixel] -= n;
 }
 
 
 
 void *
-DeepData::channel_ptr (int pixel, int channel)
+DeepData::data_ptr (int pixel, int channel, int sample)
 {
+    m_impl->alloc (m_npixels);
     if (pixel < 0 || pixel >= m_npixels ||
-          channel < 0 || channel >= m_nchannels || !m_impl)
+          channel < 0 || channel >= m_nchannels || !m_impl ||
+          sample < 0 || sample >= int(m_impl->m_nsamples[pixel]))
         return NULL;
-    return m_impl->m_pointers[pixel*m_nchannels + channel];
+    return m_impl->data_ptr (pixel, channel, sample);
 }
 
 
 
 const void *
-DeepData::channel_ptr (int pixel, int channel) const
+DeepData::data_ptr (int pixel, int channel, int sample) const
 {
     if (pixel < 0 || pixel >= m_npixels ||
-            channel < 0 || channel >= m_nchannels || !m_impl)
+            channel < 0 || channel >= m_nchannels ||
+            !m_impl || !m_impl->m_data.size() ||
+            sample < 0 || sample >= int(m_impl->m_nsamples[pixel]))
         return NULL;
-    return m_impl->m_pointers[pixel*m_nchannels + channel];
+    return m_impl->data_ptr (pixel, channel, sample);
 }
 
 
@@ -266,36 +346,30 @@ DeepData::channel_ptr (int pixel, int channel) const
 float
 DeepData::deep_value (int pixel, int channel, int sample) const
 {
-    if (pixel < 0 || pixel >= m_npixels || channel < 0 ||
-            channel >= m_nchannels || !m_impl)
-        return 0.0f;
-    int nsamps = m_impl->m_nsamples[pixel];
-    if (nsamps == 0 || sample < 0 || sample >= nsamps)
-        return 0.0f;
-    const void *ptr = m_impl->m_pointers[pixel*m_nchannels + channel];
+    const void *ptr = data_ptr (pixel, channel, sample);
     if (! ptr)
         return 0.0f;
     switch (channeltype(channel).basetype) {
     case TypeDesc::FLOAT :
-        return ((const float *)ptr)[sample];
+        return ((const float *)ptr)[0];
     case TypeDesc::HALF  :
-        return ((const half *)ptr)[sample];
-    case TypeDesc::UINT8 :
-        return ConstDataArrayProxy<unsigned char,float>((const unsigned char *)ptr)[sample];
-    case TypeDesc::INT8  :
-        return ConstDataArrayProxy<char,float>((const char *)ptr)[sample];
-    case TypeDesc::UINT16:
-        return ConstDataArrayProxy<unsigned short,float>((const unsigned short *)ptr)[sample];
-    case TypeDesc::INT16 :
-        return ConstDataArrayProxy<short,float>((const short *)ptr)[sample];
+        return ((const half *)ptr)[0];
     case TypeDesc::UINT  :
-        return ConstDataArrayProxy<unsigned int,float>((const unsigned int *)ptr)[sample];
+        return ConstDataArrayProxy<unsigned int,float>((const unsigned int *)ptr)[0];
+    case TypeDesc::UINT8 :
+        return ConstDataArrayProxy<unsigned char,float>((const unsigned char *)ptr)[0];
+    case TypeDesc::INT8  :
+        return ConstDataArrayProxy<char,float>((const char *)ptr)[0];
+    case TypeDesc::UINT16:
+        return ConstDataArrayProxy<unsigned short,float>((const unsigned short *)ptr)[0];
+    case TypeDesc::INT16 :
+        return ConstDataArrayProxy<short,float>((const short *)ptr)[0];
     case TypeDesc::INT   :
-        return ConstDataArrayProxy<int,float>((const int *)ptr)[sample];
+        return ConstDataArrayProxy<int,float>((const int *)ptr)[0];
     case TypeDesc::UINT64:
-        return ConstDataArrayProxy<unsigned long long,float>((const unsigned long long *)ptr)[sample];
+        return ConstDataArrayProxy<unsigned long long,float>((const unsigned long long *)ptr)[0];
     case TypeDesc::INT64 :
-        return ConstDataArrayProxy<long long,float>((const long long *)ptr)[sample];
+        return ConstDataArrayProxy<long long,float>((const long long *)ptr)[0];
     default:
         ASSERT (0);
         return 0.0f;
@@ -307,39 +381,33 @@ DeepData::deep_value (int pixel, int channel, int sample) const
 uint32_t
 DeepData::deep_value_uint (int pixel, int channel, int sample) const
 {
-    if (pixel < 0 || pixel >= m_npixels || channel < 0 ||
-            channel >= m_nchannels || !m_impl)
-        return 0.0f;
-    int nsamps = m_impl->m_nsamples[pixel];
-    if (nsamps == 0 || sample < 0 || sample >= nsamps)
-        return 0.0f;
-    const void *ptr = m_impl->m_pointers[pixel*m_nchannels + channel];
+    const void *ptr = data_ptr (pixel, channel, sample);
     if (! ptr)
-        return 0.0f;
+        return 0;
     switch (channeltype(channel).basetype) {
-    case TypeDesc::FLOAT :
-        return ConstDataArrayProxy<float,uint32_t>((const float *)ptr)[sample];
-    case TypeDesc::HALF  :
-        return ConstDataArrayProxy<half,uint32_t>((const half *)ptr)[sample];
-    case TypeDesc::UINT8 :
-        return ConstDataArrayProxy<unsigned char,uint32_t>((const unsigned char *)ptr)[sample];
-    case TypeDesc::INT8  :
-        return ConstDataArrayProxy<char,uint32_t>((const char *)ptr)[sample];
-    case TypeDesc::UINT16:
-        return ConstDataArrayProxy<unsigned short,uint32_t>((const unsigned short *)ptr)[sample];
-    case TypeDesc::INT16 :
-        return ConstDataArrayProxy<short,uint32_t>((const short *)ptr)[sample];
     case TypeDesc::UINT  :
-        return ((const unsigned int *)ptr)[sample];
+        return ((const unsigned int *)ptr)[0];
+    case TypeDesc::FLOAT :
+        return ConstDataArrayProxy<float,uint32_t>((const float *)ptr)[0];
+    case TypeDesc::HALF  :
+        return ConstDataArrayProxy<half,uint32_t>((const half *)ptr)[0];
+    case TypeDesc::UINT8 :
+        return ConstDataArrayProxy<unsigned char,uint32_t>((const unsigned char *)ptr)[0];
+    case TypeDesc::INT8  :
+        return ConstDataArrayProxy<char,uint32_t>((const char *)ptr)[0];
+    case TypeDesc::UINT16:
+        return ConstDataArrayProxy<unsigned short,uint32_t>((const unsigned short *)ptr)[0];
+    case TypeDesc::INT16 :
+        return ConstDataArrayProxy<short,uint32_t>((const short *)ptr)[0];
     case TypeDesc::INT   :
-        return ConstDataArrayProxy<int,uint32_t>((const int *)ptr)[sample];
+        return ConstDataArrayProxy<int,uint32_t>((const int *)ptr)[0];
     case TypeDesc::UINT64:
-        return ConstDataArrayProxy<unsigned long long,uint32_t>((const unsigned long long *)ptr)[sample];
+        return ConstDataArrayProxy<unsigned long long,uint32_t>((const unsigned long long *)ptr)[0];
     case TypeDesc::INT64 :
-        return ConstDataArrayProxy<long long,uint32_t>((const long long *)ptr)[sample];
+        return ConstDataArrayProxy<long long,uint32_t>((const long long *)ptr)[0];
     default:
         ASSERT (0);
-        return 0.0f;
+        return 0;
     }
 }
 
@@ -348,38 +416,30 @@ DeepData::deep_value_uint (int pixel, int channel, int sample) const
 void
 DeepData::set_deep_value (int pixel, int channel, int sample, float value)
 {
-    if (pixel < 0 || pixel >= m_npixels || channel < 0 ||
-            channel >= m_nchannels || !m_impl)
-        return;
-    int nsamps = m_impl->m_nsamples[pixel];
-    if (nsamps == 0 || sample < 0 || sample >= nsamps)
-        return;
-    if (! m_impl->m_data.size())
-        alloc();
-    void *ptr = m_impl->m_pointers[pixel*m_nchannels + channel];
+    void *ptr = data_ptr (pixel, channel, sample);
     if (! ptr)
         return;
     switch (channeltype(channel).basetype) {
     case TypeDesc::FLOAT :
-        DataArrayProxy<float,float>((float *)ptr)[sample] = value; break;
+        DataArrayProxy<float,float>((float *)ptr)[0] = value; break;
     case TypeDesc::HALF  :
-        DataArrayProxy<half,float>((half *)ptr)[sample] = value; break;
-    case TypeDesc::UINT8 :
-        DataArrayProxy<unsigned char,float>((unsigned char *)ptr)[sample] = value; break;
-    case TypeDesc::INT8  :
-        DataArrayProxy<char,float>((char *)ptr)[sample] = value; break;
-    case TypeDesc::UINT16:
-        DataArrayProxy<unsigned short,float>((unsigned short *)ptr)[sample] = value; break;
-    case TypeDesc::INT16 :
-        DataArrayProxy<short,float>((short *)ptr)[sample] = value; break;
+        DataArrayProxy<half,float>((half *)ptr)[0] = value; break;
     case TypeDesc::UINT  :
-        DataArrayProxy<uint32_t,float>((uint32_t *)ptr)[sample] = value; break;
+        DataArrayProxy<uint32_t,float>((uint32_t *)ptr)[0] = value; break;
+    case TypeDesc::UINT8 :
+        DataArrayProxy<unsigned char,float>((unsigned char *)ptr)[0] = value; break;
+    case TypeDesc::INT8  :
+        DataArrayProxy<char,float>((char *)ptr)[0] = value; break;
+    case TypeDesc::UINT16:
+        DataArrayProxy<unsigned short,float>((unsigned short *)ptr)[0] = value; break;
+    case TypeDesc::INT16 :
+        DataArrayProxy<short,float>((short *)ptr)[0] = value; break;
     case TypeDesc::INT   :
-        DataArrayProxy<int,float>((int *)ptr)[sample] = value; break;
+        DataArrayProxy<int,float>((int *)ptr)[0] = value; break;
     case TypeDesc::UINT64:
-        DataArrayProxy<uint64_t,float>((uint64_t *)ptr)[sample] = value; break;
+        DataArrayProxy<uint64_t,float>((uint64_t *)ptr)[0] = value; break;
     case TypeDesc::INT64 :
-        DataArrayProxy<int64_t,float>((int64_t *)ptr)[sample] = value; break;
+        DataArrayProxy<int64_t,float>((int64_t *)ptr)[0] = value; break;
     default:
         ASSERT (0);
     }
@@ -390,38 +450,30 @@ DeepData::set_deep_value (int pixel, int channel, int sample, float value)
 void
 DeepData::set_deep_value (int pixel, int channel, int sample, uint32_t value)
 {
-    if (pixel < 0 || pixel >= m_npixels || channel < 0 ||
-            channel >= m_nchannels || !m_impl)
-        return;
-    int nsamps = m_impl->m_nsamples[pixel];
-    if (nsamps == 0 || sample < 0 || sample >= nsamps)
-        return;
-    if (! m_impl->m_data.size())
-        alloc();
-    void *ptr = m_impl->m_pointers[pixel*m_nchannels + channel];
+    void *ptr = data_ptr (pixel, channel, sample);
     if (! ptr)
         return;
     switch (channeltype(channel).basetype) {
     case TypeDesc::FLOAT :
-        DataArrayProxy<float,uint32_t>((float *)ptr)[sample] = value; break;
+        DataArrayProxy<float,uint32_t>((float *)ptr)[0] = value; break;
     case TypeDesc::HALF  :
-        DataArrayProxy<half,uint32_t>((half *)ptr)[sample] = value; break;
+        DataArrayProxy<half,uint32_t>((half *)ptr)[0] = value; break;
     case TypeDesc::UINT8 :
-        DataArrayProxy<unsigned char,uint32_t>((unsigned char *)ptr)[sample] = value; break;
+        DataArrayProxy<unsigned char,uint32_t>((unsigned char *)ptr)[0] = value; break;
     case TypeDesc::INT8  :
-        DataArrayProxy<char,uint32_t>((char *)ptr)[sample] = value; break;
+        DataArrayProxy<char,uint32_t>((char *)ptr)[0] = value; break;
     case TypeDesc::UINT16:
-        DataArrayProxy<unsigned short,uint32_t>((unsigned short *)ptr)[sample] = value; break;
+        DataArrayProxy<unsigned short,uint32_t>((unsigned short *)ptr)[0] = value; break;
     case TypeDesc::INT16 :
-        DataArrayProxy<short,uint32_t>((short *)ptr)[sample] = value; break;
+        DataArrayProxy<short,uint32_t>((short *)ptr)[0] = value; break;
     case TypeDesc::UINT  :
-        DataArrayProxy<uint32_t,uint32_t>((uint32_t *)ptr)[sample] = value; break;
+        DataArrayProxy<uint32_t,uint32_t>((uint32_t *)ptr)[0] = value; break;
     case TypeDesc::INT   :
-        DataArrayProxy<int,uint32_t>((int *)ptr)[sample] = value; break;
+        DataArrayProxy<int,uint32_t>((int *)ptr)[0] = value; break;
     case TypeDesc::UINT64:
-        DataArrayProxy<uint64_t,uint32_t>((uint64_t *)ptr)[sample] = value; break;
+        DataArrayProxy<uint64_t,uint32_t>((uint64_t *)ptr)[0] = value; break;
     case TypeDesc::INT64 :
-        DataArrayProxy<int64_t,uint32_t>((int64_t *)ptr)[sample] = value; break;
+        DataArrayProxy<int64_t,uint32_t>((int64_t *)ptr)[0] = value; break;
     default:
         ASSERT (0);
     }
@@ -438,20 +490,40 @@ DeepData::all_nsamples () const
 
 
 
-void * const *
-DeepData::all_pointers () const
-{
-    ASSERT (m_impl);
-    return m_npixels ? &m_impl->m_pointers[0] : NULL;
-}
-
-
-
 array_view<const char>
 DeepData::all_data () const
 {
     ASSERT (m_impl);
+    m_impl->alloc (m_npixels);
     return m_impl->m_data;
+}
+
+
+
+void
+DeepData::get_pointers (std::vector<void*> &pointers)
+{
+    ASSERT (m_impl);
+    m_impl->alloc (m_npixels);
+    pointers.resize (pixels()*channels());
+    for (int i = 0;  i < m_npixels;  ++i) {
+        for (int c = 0;  c < m_nchannels;  ++c)
+            pointers[i*m_nchannels+c] = m_impl->data_ptr (i, c, 0);
+    }
+}
+
+
+
+void
+DeepData::get_pointers (std::vector<const void*> &pointers) const
+{
+    ASSERT (m_impl);
+    m_impl->alloc (m_npixels);
+    pointers.resize (pixels()*channels());
+    for (int i = 0;  i < m_npixels;  ++i) {
+        for (int c = 0;  c < m_nchannels;  ++c)
+            pointers[i*m_nchannels+c] = m_impl->data_ptr (i, c, 0);
+    }
 }
 
 

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -41,6 +41,7 @@
 #include <boost/scoped_array.hpp>
 
 #include "OpenImageIO/imageio.h"
+#include "OpenImageIO/deepdata.h"
 #include "OpenImageIO/imagebuf.h"
 #include "OpenImageIO/imagebufalgo.h"
 #include "OpenImageIO/imagebufalgo_util.h"

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1731,7 +1731,7 @@ ImageBuf::deep_samples (int x, int y, int z) const
 
 
 const void *
-ImageBuf::deep_pixel_ptr (int x, int y, int z, int c) const
+ImageBuf::deep_pixel_ptr (int x, int y, int z, int c, int s) const
 {
     impl()->validate_pixels();
     if (! deep())
@@ -1744,7 +1744,7 @@ ImageBuf::deep_pixel_ptr (int x, int y, int z, int c) const
         c < 0 || c >= m_spec.nchannels)
         return NULL;
     int p = (z * m_spec.height + y) * m_spec.width  + x;
-    return deepdata()->samples(p) ? deepdata()->channel_ptr (p, c) : NULL;
+    return (s < deepdata()->samples(p)) ? deepdata()->data_ptr (p, c, s) : NULL;
 }
 
 
@@ -1791,6 +1791,34 @@ ImageBuf::set_deep_samples (int x, int y, int z, int samps)
 
 
 void
+ImageBuf::deep_insert_samples (int x, int y, int z,
+                               int samplepos, int nsamples)
+{
+    if (! deep())
+        return ;
+    const ImageSpec &m_spec (spec());
+    x -= m_spec.x;  y -= m_spec.y;  z -= m_spec.z;
+    int p = (z * m_spec.height + y) * m_spec.width + x;
+    impl()->m_deepdata.insert_samples (p, samplepos, nsamples);
+}
+
+
+
+void
+ImageBuf::deep_erase_samples (int x, int y, int z,
+                              int samplepos, int nsamples)
+{
+    if (! deep())
+        return ;
+    const ImageSpec &m_spec (spec());
+    x -= m_spec.x;  y -= m_spec.y;  z -= m_spec.z;
+    int p = (z * m_spec.height + y) * m_spec.width + x;
+    impl()->m_deepdata.erase_samples (p, samplepos, nsamples);
+}
+
+
+
+void
 ImageBuf::set_deep_value (int x, int y, int z, int c, int s, float value)
 {
     impl()->validate_pixels();
@@ -1805,7 +1833,7 @@ ImageBuf::set_deep_value (int x, int y, int z, int c, int s, float value)
 
 
 void
-ImageBuf::set_deep_value_uint (int x, int y, int z, int c, int s, uint32_t value)
+ImageBuf::set_deep_value (int x, int y, int z, int c, int s, uint32_t value)
 {
     impl()->validate_pixels();
     if (! deep())
@@ -1818,11 +1846,20 @@ ImageBuf::set_deep_value_uint (int x, int y, int z, int c, int s, uint32_t value
 
 
 
+// DEPRECATED (1.7): old name
+void
+ImageBuf::set_deep_value_uint (int x, int y, int z, int c, int s, uint32_t value)
+{
+    return set_deep_value (x, y, z, c, s, value);
+}
+
+
+
+// DEPRECATED (1.7)
 void
 ImageBuf::deep_alloc ()
 {
-    deepdata()->alloc ();
-    m_impl->m_storage = ImageBuf::LOCALBUFFER;
+    ASSERT (m_impl->m_storage == ImageBuf::LOCALBUFFER);
 }
 
 

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -757,10 +757,6 @@ ImageBufAlgo::channels (ImageBuf &dst, const ImageBuf &src,
                     float val = channelvalues ? channelvalues[c] : 0.0f;
                     for (int s = 0, ns = dstdata.samples(p); s < ns; ++s)
                         dstdata.set_deep_value (p, c, s, val);
-                } else if (dstdata.channeltype(c) == srcdata.channeltype(csrc)) {
-                    // Same channel types -- copy all samples at once
-                    memcpy (dstdata.channel_ptr(p,c), srcdata.channel_ptr(p,csrc),
-                            dstdata.samples(p) * srcdata.channeltype(csrc).size());
                 } else {
                     if (dstdata.channeltype(c) == TypeDesc::UINT)
                         for (int s = 0, ns = dstdata.samples(p); s < ns; ++s)

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -41,6 +41,7 @@
 #include "OpenImageIO/imagebuf.h"
 #include "OpenImageIO/imagebufalgo.h"
 #include "OpenImageIO/imagebufalgo_util.h"
+#include "OpenImageIO/deepdata.h"
 #include "OpenImageIO/thread.h"
 
 

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -38,6 +38,7 @@
 #include "OpenImageIO/strutil.h"
 #include "OpenImageIO/fmath.h"
 #include "OpenImageIO/imageio.h"
+#include "OpenImageIO/deepdata.h"
 #include "imageio_pvt.h"
 
 #include <boost/scoped_array.hpp>

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -43,6 +43,7 @@
 #include "OpenImageIO/strutil.h"
 
 #include "OpenImageIO/imageio.h"
+#include "OpenImageIO/deepdata.h"
 #include "imageio_pvt.h"
 
 #include <boost/scoped_array.hpp>

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -47,6 +47,7 @@
 #include "OpenImageIO/imageio.h"
 #include "OpenImageIO/imagebuf.h"
 #include "OpenImageIO/imagebufalgo.h"
+#include "OpenImageIO/deepdata.h"
 #include "OpenImageIO/hash.h"
 #include "OpenImageIO/fmath.h"
 #include "OpenImageIO/array_view.h"

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -1176,11 +1176,11 @@ OpenEXRInput::read_native_deep_scanlines (int ybegin, int yend, int z,
         // Set up the count and pointers arrays and the Imf framebuffer
         std::vector<TypeDesc> channeltypes;
         m_spec.get_channelformats (channeltypes);
-        deepdata.init (npixels, nchans, &channeltypes[chbegin],
-                       &channeltypes[chend]);
+        deepdata.init (npixels, nchans,
+                       array_view<const TypeDesc>(&channeltypes[chbegin], chend-chbegin));
         Imf::DeepFrameBuffer frameBuffer;
         Imf::Slice countslice (Imf::UINT,
-                               (char *)(&deepdata.nsamples[0]
+                               (char *)(deepdata.all_nsamples().data()
                                         - m_spec.x
                                         - ybegin*m_spec.width),
                                sizeof(unsigned int),
@@ -1188,7 +1188,7 @@ OpenEXRInput::read_native_deep_scanlines (int ybegin, int yend, int z,
         frameBuffer.insertSampleCountSlice (countslice);
         for (int c = chbegin;  c < chend;  ++c) {
             Imf::DeepSlice slice (part.pixeltype[c],
-                                  (char *)(&deepdata.pointers[c-chbegin]
+                                  (char *)(deepdata.all_pointers()+(c-chbegin)
                                            - m_spec.x * nchans
                                            - ybegin*m_spec.width*nchans),
                                   sizeof(void*) * nchans, // xstride of pointer array
@@ -1245,11 +1245,11 @@ OpenEXRInput::read_native_deep_tiles (int xbegin, int xend,
         // Set up the count and pointers arrays and the Imf framebuffer
         std::vector<TypeDesc> channeltypes;
         m_spec.get_channelformats (channeltypes);
-        deepdata.init (npixels, nchans, &channeltypes[chbegin],
-                       &channeltypes[chend]);
+        deepdata.init (npixels, nchans,
+                       array_view<const TypeDesc>(&channeltypes[chbegin], chend-chbegin));
         Imf::DeepFrameBuffer frameBuffer;
         Imf::Slice countslice (Imf::UINT,
-                               (char *)(&deepdata.nsamples[0]
+                               (char *)(deepdata.all_nsamples().data()
                                         - xbegin
                                         - ybegin*width),
                                sizeof(unsigned int),
@@ -1257,7 +1257,7 @@ OpenEXRInput::read_native_deep_tiles (int xbegin, int xend,
         frameBuffer.insertSampleCountSlice (countslice);
         for (int c = chbegin;  c < chend;  ++c) {
             Imf::DeepSlice slice (part.pixeltype[c],
-                                  (char *)(&deepdata.pointers[c-chbegin]
+                                  (char *)(deepdata.all_pointers()+(c-chbegin)
                                            - xbegin*nchans
                                            - ybegin*width*nchans),
                                   sizeof(void*) * nchans, // xstride of pointer array

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -84,6 +84,7 @@
 #include "OpenImageIO/fmath.h"
 #include "OpenImageIO/filesystem.h"
 #include "OpenImageIO/imagebufalgo_util.h"
+#include "OpenImageIO/deepdata.h"
 
 #include <boost/scoped_array.hpp>
 

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -1521,15 +1521,16 @@ OpenEXROutput::write_deep_scanlines (int ybegin, int yend, int z,
                                sizeof(unsigned int),
                                sizeof(unsigned int) * m_spec.width);
         frameBuffer.insertSampleCountSlice (countslice);
+        std::vector<const void*> pointerbuf;
+        deepdata.get_pointers (pointerbuf);
         for (int c = 0;  c < nchans;  ++c) {
-            size_t chanbytes = deepdata.channeltype(c).size();
             Imf::DeepSlice slice (m_pixeltype[c],
-                                  (char *)(deepdata.all_pointers()+c
+                                  (char *)(&pointerbuf[c]
                                            - m_spec.x * nchans
                                            - ybegin*m_spec.width*nchans),
                                   sizeof(void*) * nchans, // xstride of pointer array
                                   sizeof(void*) * nchans*m_spec.width, // ystride of pointer array
-                                  chanbytes); // stride of data sample
+                                  deepdata.samplesize()); // stride of data sample
             frameBuffer.insert (m_spec.channelnames[c].c_str(), slice);
         }
         m_deep_scanline_output_part->setFrameBuffer (frameBuffer);
@@ -1583,15 +1584,16 @@ OpenEXROutput::write_deep_tiles (int xbegin, int xend, int ybegin, int yend,
                                sizeof(unsigned int),
                                sizeof(unsigned int) * width);
         frameBuffer.insertSampleCountSlice (countslice);
+        std::vector<const void*> pointerbuf;
+        deepdata.get_pointers (pointerbuf);
         for (int c = 0;  c < nchans;  ++c) {
-            size_t chanbytes = m_spec.channelformat(c).size();
             Imf::DeepSlice slice (m_pixeltype[c],
-                                  (char *)(deepdata.all_pointers()+c
+                                  (char *)(&pointerbuf[c]
                                            - xbegin*nchans
                                            - ybegin*width*nchans),
                                   sizeof(void*) * nchans, // xstride of pointer array
                                   sizeof(void*) * nchans*width, // ystride of pointer array
-                                  chanbytes); // stride of data sample
+                                  deepdata.samplesize()); // stride of data sample
             frameBuffer.insert (m_spec.channelnames[c].c_str(), slice);
         }
         m_deep_tiled_output_part->setFrameBuffer (frameBuffer);

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -1502,8 +1502,8 @@ OpenEXROutput::write_deep_scanlines (int ybegin, int yend, int z,
         error ("called OpenEXROutput::write_deep_scanlines without an open file");
         return false;
     }
-    if (m_spec.width*(yend-ybegin) != deepdata.npixels ||
-        m_spec.nchannels != deepdata.nchannels) {
+    if (m_spec.width*(yend-ybegin) != deepdata.pixels() ||
+        m_spec.nchannels != deepdata.channels()) {
         error ("called OpenEXROutput::write_deep_scanlines with non-matching DeepData size");
         return false;
     }
@@ -1514,16 +1514,16 @@ OpenEXROutput::write_deep_scanlines (int ybegin, int yend, int z,
         // Set up the count and pointers arrays and the Imf framebuffer
         Imf::DeepFrameBuffer frameBuffer;
         Imf::Slice countslice (Imf::UINT,
-                               (char *)(&deepdata.nsamples[0]
+                               (char *)(deepdata.all_nsamples().data()
                                         - m_spec.x
                                         - ybegin*m_spec.width),
                                sizeof(unsigned int),
                                sizeof(unsigned int) * m_spec.width);
         frameBuffer.insertSampleCountSlice (countslice);
         for (int c = 0;  c < nchans;  ++c) {
-            size_t chanbytes = deepdata.channeltypes[c].size();
+            size_t chanbytes = deepdata.channeltype(c).size();
             Imf::DeepSlice slice (m_pixeltype[c],
-                                  (char *)(&deepdata.pointers[c]
+                                  (char *)(deepdata.all_pointers()+c
                                            - m_spec.x * nchans
                                            - ybegin*m_spec.width*nchans),
                                   sizeof(void*) * nchans, // xstride of pointer array
@@ -1562,8 +1562,8 @@ OpenEXROutput::write_deep_tiles (int xbegin, int xend, int ybegin, int yend,
         error ("called OpenEXROutput::write_deep_tiles without an open file");
         return false;
     }
-    if ((xend-xbegin)*(yend-ybegin)*(zend-zbegin) != deepdata.npixels ||
-        m_spec.nchannels != deepdata.nchannels) {
+    if ((xend-xbegin)*(yend-ybegin)*(zend-zbegin) != deepdata.pixels() ||
+        m_spec.nchannels != deepdata.channels()) {
         error ("called OpenEXROutput::write_deep_tiles with non-matching DeepData size");
         return false;
     }
@@ -1576,7 +1576,7 @@ OpenEXROutput::write_deep_tiles (int xbegin, int xend, int ybegin, int yend,
         // Set up the count and pointers arrays and the Imf framebuffer
         Imf::DeepFrameBuffer frameBuffer;
         Imf::Slice countslice (Imf::UINT,
-                               (char *)(&deepdata.nsamples[0]
+                               (char *)(deepdata.all_nsamples().data()
                                         - xbegin
                                         - ybegin*width),
                                sizeof(unsigned int),
@@ -1585,7 +1585,7 @@ OpenEXROutput::write_deep_tiles (int xbegin, int xend, int ybegin, int yend,
         for (int c = 0;  c < nchans;  ++c) {
             size_t chanbytes = m_spec.channelformat(c).size();
             Imf::DeepSlice slice (m_pixeltype[c],
-                                  (char *)(&deepdata.pointers[c]
+                                  (char *)(deepdata.all_pointers()+c
                                            - xbegin*nchans
                                            - ybegin*width*nchans),
                                   sizeof(void*) * nchans, // xstride of pointer array

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -80,6 +80,7 @@
 
 #include "OpenImageIO/dassert.h"
 #include "OpenImageIO/imageio.h"
+#include "OpenImageIO/deepdata.h"
 #include "OpenImageIO/filesystem.h"
 #include "OpenImageIO/thread.h"
 #include "OpenImageIO/strutil.h"

--- a/src/python/py_deepdata.cpp
+++ b/src/python/py_deepdata.cpp
@@ -101,17 +101,26 @@ void declare_deepdata()
 
         .def("init",  &DeepData_init)
         .def("init",  &DeepData_init_spec)
-        .def("alloc", &DeepData::alloc)
         .def("clear", &DeepData::clear)
         .def("free",  &DeepData::free)
 
-        .def("samples",         &DeepData_get_samples)
-        .def("set_samples",     &DeepData::set_samples)
+        .def("samples",         &DeepData_get_samples,
+             (arg("pixel")))
+        .def("set_samples",     &DeepData::set_samples,
+             (arg("pixel"), arg("nsamples")))
+        .def("insert_samples",  &DeepData::insert_samples,
+             (arg("pixel"), arg("samplepos"), arg("nsamples")=1))
+        .def("erase_samples",   &DeepData::erase_samples,
+             (arg("pixel"), arg("samplepos"), arg("nsamples")=1))
         .def("channeltype",     &DeepData::channeltype)
-        .def("deep_value",      &DeepData::deep_value)
-        .def("deep_value_uint", &DeepData::deep_value_uint)
-        .def("set_deep_value",  &DeepData_set_deep_value_float)
-        .def("set_deep_value",  &DeepData_set_deep_value_uint)
+        .def("deep_value",      &DeepData::deep_value,
+             (arg("pixel"), arg("channel"), arg("sample")))
+        .def("deep_value_uint", &DeepData::deep_value_uint,
+             (arg("pixel"), arg("channel"), arg("sample")))
+        .def("set_deep_value",  &DeepData_set_deep_value_float,
+             (arg("pixel"), arg("channel"), arg("sample"), arg("value")))
+        .def("set_deep_value_uint", &DeepData_set_deep_value_uint,
+             (arg("pixel"), arg("channel"), arg("sample"), arg("value")))
     ;
 }
 

--- a/src/python/py_deepdata.cpp
+++ b/src/python/py_deepdata.cpp
@@ -43,7 +43,7 @@ DeepData_init (DeepData &dd, int npix, int nchan, tuple p)
     std::vector<TypeDesc> chantypes;
     py_to_stdvector (chantypes, p);
     ScopedGILRelease gil;
-    dd.init (npix, nchan, &(*chantypes.begin()), &(*chantypes.end()));
+    dd.init (npix, nchan, chantypes);
 }
 
 
@@ -94,11 +94,10 @@ DeepData_set_deep_value_uint (DeepData &dd, int pixel,
 void declare_deepdata()
 {
     class_<DeepData>("DeepData")
-        .def_readonly ("npixels",      &DeepData::npixels)
-        .def_readonly ("nchannels",    &DeepData::nchannels)
-        .def_readwrite("nsamples",     &DeepData::nsamples)
-        .def_readonly ("pixels",       &DeepData::npixels)
-        .def_readonly ("channels",     &DeepData::nchannels)
+        .def_readonly ("npixels",    &DeepData::pixels)   //DEPRECATED(1.7)
+        .def_readonly ("nchannels",  &DeepData::channels) //DEPRECATED(1.7)
+        .def_readonly ("pixels",     &DeepData::pixels)
+        .def_readonly ("channels",   &DeepData::channels)
 
         .def("init",  &DeepData_init)
         .def("init",  &DeepData_init_spec)

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -328,6 +328,23 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(ImageBuf_get_pixels_bt_overloads,
                                 ImageBuf_get_pixels_bt, 2, 3)
 
 
+
+void
+ImageBuf_set_deep_value (ImageBuf &buf, int x, int y, int z,
+                         int c, int s, float value)
+{
+    buf.set_deep_value (x, y, z, c, s, value);
+}
+
+void
+ImageBuf_set_deep_value_uint (ImageBuf &buf, int x, int y, int z,
+                         int c, int s, uint32_t value)
+{
+    buf.set_deep_value (x, y, z, c, s, value);
+}
+
+
+
 bool
 ImageBuf_set_pixels_tuple (ImageBuf &buf, ROI roi, tuple data)
 {
@@ -489,12 +506,23 @@ void declare_imagebuf()
         .add_property("deep", &ImageBuf::deep)
         .def("deep_samples", &ImageBuf::deep_samples,
              (arg("x"), arg("y"), arg("z")=0))
-        .def("set_deep_samples", &ImageBuf::set_deep_samples)
-        .def("deep_value", &ImageBuf::deep_value)
-        .def("deep_value_uint", &ImageBuf::deep_value_uint)
-        .def("set_deep_value", &ImageBuf::set_deep_value)
-        .def("set_deep_value_uint", &ImageBuf::set_deep_value_uint)
-        .def("deep_alloc", &ImageBuf::deep_alloc)
+        .def("set_deep_samples", &ImageBuf::set_deep_samples,
+             (arg("x"), arg("y"), arg("z")=0, arg("nsamples")=1))
+        .def("deep_insert_samples", &ImageBuf::deep_insert_samples,
+             (arg("x"), arg("y"), arg("z")=0, arg("samplepos"), arg("nsamples")=1))
+        .def("deep_erase_samples", &ImageBuf::deep_erase_samples,
+             (arg("x"), arg("y"), arg("z")=0, arg("samplepos"), arg("nsamples")=1))
+        .def("deep_value", &ImageBuf::deep_value,
+             (arg("x"), arg("y"), arg("z")=0, arg("channel"), arg("sample")))
+        .def("deep_value_uint", &ImageBuf::deep_value_uint,
+             (arg("x"), arg("y"), arg("z")=0, arg("channel"), arg("sample")))
+        .def("set_deep_value", &ImageBuf_set_deep_value,
+             (arg("x"), arg("y"), arg("z")=0, arg("channel"),
+              arg("sample"), arg("value")=0.0f))
+        .def("set_deep_value_uint", &ImageBuf_set_deep_value_uint,
+             (arg("x"), arg("y"), arg("z")=0, arg("channel"),
+              arg("sample"), arg("value")=0))
+        .def("deep_alloc", &ImageBuf::deep_alloc)  // DEPRECATED(1.7)
         .def("deepdata", &ImageBuf_deepdataref,
              return_value_policy<reference_existing_object>())
 

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -39,6 +39,7 @@
 #include "OpenImageIO/typedesc.h"
 #include "OpenImageIO/imagecache.h"
 #include "OpenImageIO/imagebuf.h"
+#include "OpenImageIO/deepdata.h"
 
 
 #if PY_MAJOR_VERSION < 2 || (PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION < 5)

--- a/testsuite/openexr-v2/ref/out.txt
+++ b/testsuite/openexr-v2/ref/out.txt
@@ -82,7 +82,7 @@ Reading ../../../../../openexr-images/v2/Stereo/Balls.exr
 ../../../../../openexr-images/v2/Stereo/Balls.exr : 1431 x  761, 5 channel, deep half/half/half/half/float openexr
     2 subimages: 1431x761 1452x761 
  subimage  0: 1431 x  761, 5 channel, deep half/half/half/half/float openexr
-    SHA-1: CB3E54294B268B6C2764410710267D0AF809A3C4
+    SHA-1: C68EB6A304F07B78F480E6FCDBA07BF9028E3305
     channel list: R (half), G (half), B (half), A (half), Z (float)
     pixel data origin: x=247, y=319
     full/display size: 1920 x 1080
@@ -99,7 +99,7 @@ Reading ../../../../../openexr-images/v2/Stereo/Balls.exr
     view: "left"
     oiio:subimagename: "rgba.left"
  subimage  1: 1452 x  761, 5 channel, deep half/half/half/half/float openexr
-    SHA-1: 4318FB751F2C30955AC745FFFCF47E8BB932C8D1
+    SHA-1: 23D591E3BE032257729B30F078D62F6A16D40377
     channel list: R (half), G (half), B (half), A (half), Z (float)
     pixel data origin: x=389, y=319
     full/display size: 1920 x 1080
@@ -142,7 +142,7 @@ Reading ../../../../../openexr-images/v2/Stereo/Leaves.exr
 ../../../../../openexr-images/v2/Stereo/Leaves.exr : 1920 x 1080, 5 channel, deep half/half/half/half/float openexr
     2 subimages: 1920x1080 1920x1080 
  subimage  0: 1920 x 1080, 5 channel, deep half/half/half/half/float openexr
-    SHA-1: ED7BBA99CE96DF98AC784F50B54EF976DB17AF26
+    SHA-1: 63932A1F4D607129054D80A4361176BA54955E90
     channel list: R (half), G (half), B (half), A (half), Z (float)
     oiio:ColorSpace: "Linear"
     compression: "zips"
@@ -156,7 +156,7 @@ Reading ../../../../../openexr-images/v2/Stereo/Leaves.exr
     view: "left"
     oiio:subimagename: "rgba.left"
  subimage  1: 1920 x 1080, 5 channel, deep half/half/half/half/float openexr
-    SHA-1: 11F6FB62B0F1080F78DBA6464FCC92C30D3162AF
+    SHA-1: B0B52A15E0E25796832E4C25BD835C3F3B970BC0
     channel list: R (half), G (half), B (half), A (half), Z (float)
     oiio:ColorSpace: "Linear"
     compression: "zips"

--- a/testsuite/python-deep/test_deep.py
+++ b/testsuite/python-deep/test_deep.py
@@ -14,28 +14,28 @@ print "test_chantypes ", str(test_chantypes[0]), str(test_chantypes[1]), str(tes
 def make_test_deep_image () :
     dd = oiio.DeepData()
     dd.init (test_xres*test_yres, test_nchannels, test_chantypes)
-    for p in range(dd.npixels) :
+    for p in range(dd.pixels) :
         if p&1 :
             dd.set_samples (p, p)
     dd.alloc()
-    for p in range(dd.npixels) :
+    for p in range(dd.pixels) :
         ns = dd.samples(p)
         for s in range(ns) :
-            for c in range(dd.nchannels) :
+            for c in range(dd.channels) :
                 dd.set_deep_value (p, c, s, c*10+s+p/10.0)
     return dd
 
 
 
 def print_deep_image (dd) :
-    print "After init, dd has", dd.npixels, "pixels,", dd.nchannels, "channels."
-    for p in range(dd.npixels) :
+    print "After init, dd has", dd.pixels, "pixels,", dd.channels, "channels."
+    for p in range(dd.pixels) :
         ns = dd.samples(p)
         if ns > 0 :
             print "  Nsamples[", p, "] =", ns, "samples:"
             for s in range(ns) :
                 print "  sample", s, ": ",
-                for c in range(dd.nchannels) :
+                for c in range(dd.channels) :
                     print "[%d] %.2f / " % (c, dd.deep_value (p, c, s)),
                 print
 

--- a/testsuite/python-deep/test_deep.py
+++ b/testsuite/python-deep/test_deep.py
@@ -17,7 +17,6 @@ def make_test_deep_image () :
     for p in range(dd.pixels) :
         if p&1 :
             dd.set_samples (p, p)
-    dd.alloc()
     for p in range(dd.pixels) :
         ns = dd.samples(p)
         for s in range(ns) :

--- a/testsuite/python-imagebuf/ref/out-alt.txt
+++ b/testsuite/python-imagebuf/ref/out-alt.txt
@@ -113,19 +113,25 @@ Saving file...
 Writing deep buffer...
 
 Reading back deep buffer:
-Pixel 0 1 had 2 samples
+Pixel 0 1 had 3 samples
 Sample 0
-	c 0 : 0.419999986887
-	c 1 : 0.0
-	c 2 : 0.0
-	c 3 : 0.0
-	c 4 : 42.0
+	c 0 : 0.420
+	c 1 : 0.000
+	c 2 : 0.000
+	c 3 : 0.000
+	c 4 : 42.000
 Sample 1
-	c 0 : 0.469999998808
-	c 1 : 0.0
-	c 2 : 0.0
-	c 3 : 0.0
-	c 4 : 43.0
+	c 0 : 0.100
+	c 1 : 0.200
+	c 2 : 0.300
+	c 3 : 42.500
+	c 4 : 0.000
+Sample 2
+	c 0 : 0.470
+	c 1 : 0.000
+	c 2 : 0.000
+	c 3 : 0.000
+	c 4 : 43.000
 
 Done.
 Comparing "out.tif" and "ref/out.tif"

--- a/testsuite/python-imagebuf/ref/out.txt
+++ b/testsuite/python-imagebuf/ref/out.txt
@@ -109,19 +109,25 @@ Saving file...
 Writing deep buffer...
 
 Reading back deep buffer:
-Pixel 0 1 had 2 samples
+Pixel 0 1 had 3 samples
 Sample 0
-	c 0 : 0.419999986887
-	c 1 : 0.0
-	c 2 : 0.0
-	c 3 : 0.0
-	c 4 : 42.0
+	c 0 : 0.420
+	c 1 : 0.000
+	c 2 : 0.000
+	c 3 : 0.000
+	c 4 : 42.000
 Sample 1
-	c 0 : 0.469999998808
-	c 1 : 0.0
-	c 2 : 0.0
-	c 3 : 0.0
-	c 4 : 43.0
+	c 0 : 0.100
+	c 1 : 0.200
+	c 2 : 0.300
+	c 3 : 42.500
+	c 4 : 0.000
+Sample 2
+	c 0 : 0.470
+	c 1 : 0.000
+	c 2 : 0.000
+	c 3 : 0.000
+	c 4 : 43.000
 
 Done.
 Comparing "out.tif" and "ref/out.tif"

--- a/testsuite/python-imagebuf/test_imagebuf.py
+++ b/testsuite/python-imagebuf/test_imagebuf.py
@@ -147,7 +147,7 @@ try:
             print "Pixel", p/deepbufin_spec.width, p%deepbufin_spec.width, "had", ns, "samples"
             for s in range(ns) :
                 print "Sample", s
-                for c in range(dd.nchannels) :
+                for c in range(dd.channels) :
                     print "\tc", c, ":", dd.deep_value(p,c,s)
 
     print "\nDone."

--- a/testsuite/python-imagebuf/test_imagebuf.py
+++ b/testsuite/python-imagebuf/test_imagebuf.py
@@ -130,11 +130,26 @@ try:
     deepbufout_spec.channelnames = ("R", "G", "B", "A", "Z")
     deepbufout_spec.deep = True
     deepbufout = oiio.ImageBuf(deepbufout_spec)
-    deepbufout.deepdata().set_samples (1, 2)
-    deepbufout.deepdata().set_deep_value (1, 0, 0, 0.42)
-    deepbufout.deepdata().set_deep_value (1, 4, 0, 42.0)
-    deepbufout.deepdata().set_deep_value (1, 0, 1, 0.47)
-    deepbufout.deepdata().set_deep_value (1, 4, 1, 43.0)
+    deepbufout.set_deep_samples (x=1, y=0, z=0, nsamples=2)
+    deepbufout.set_deep_value (x=1, y=0, z=0, channel=0, sample=0, value=0.42)
+    deepbufout.set_deep_value (x=1, y=0, z=0, channel=4, sample=0, value=42.0)
+    deepbufout.set_deep_value (x=1, y=0, z=0, channel=0, sample=1, value=0.47)
+    deepbufout.set_deep_value (x=1, y=0, z=0, channel=4, sample=1, value=43.0)
+    # Also insert some new samples
+    deepbufout.deep_insert_samples (x=1, y=0, z=0, samplepos=1, nsamples=2);
+    deepbufout.set_deep_value (x=1, y=0, z=0, channel=0, sample=1, value=1.1);
+    deepbufout.set_deep_value (x=1, y=0, z=0, channel=1, sample=1, value=2.2);
+    deepbufout.set_deep_value (x=1, y=0, z=0, channel=2, sample=1, value=2.3);
+    deepbufout.set_deep_value (x=1, y=0, z=0, channel=3, sample=1, value=1.0);
+    deepbufout.set_deep_value (x=1, y=0, z=0, channel=3, sample=1, value=42.25);
+    deepbufout.set_deep_value (x=1, y=0, z=0, channel=0, sample=2, value=0.1);
+    deepbufout.set_deep_value (x=1, y=0, z=0, channel=1, sample=2, value=0.2);
+    deepbufout.set_deep_value (x=1, y=0, z=0, channel=2, sample=2, value=0.3);
+    deepbufout.set_deep_value (x=1, y=0, z=0, channel=3, sample=2, value=1.0);
+    deepbufout.set_deep_value (x=1, y=0, z=0, channel=3, sample=2, value=42.5);
+    # But delete the first one
+    deepbufout.deep_erase_samples (x=1, y=0, z=0, samplepos=1, nsamples=1);
+    # Save
     deepbufout.write ("deepbuf.exr")
     # And read it back
     print "\nReading back deep buffer:"
@@ -148,7 +163,7 @@ try:
             for s in range(ns) :
                 print "Sample", s
                 for c in range(dd.channels) :
-                    print "\tc", c, ":", dd.deep_value(p,c,s)
+                    print "\tc {0} : {1:.3f}".format(c, dd.deep_value(p,c,s))
 
     print "\nDone."
 except Exception as detail:


### PR DESCRIPTION
DeepData is ok for simple passing of data in and out of the ImageInput/ImageOutput functions, but its internal layout is actually horrible for doing any actual work. (Exercise for the reader: try to imagine how to add or delete individual samples in a particular pixel of a DeepData.)

I have longer-term goals of overhauling its internals to make these operations natural and efficient. But as a first step, I need to properly hide the current internals so that I'm free to change them later.

This patch has hides the internals of DeepData -- everything is private now, and the nontrivial parts are hidden behind a PIMPL idiom. So "client" code is now forced to use the public methods. This is going to be slightly painful for apps that are used to reaching into the guts and manipulating the underlying vectors directly. Sorry about that. But once you switch to using the API, it will allow us to iterate on the internals to improve them, without any danger of further breakage of code that relies on using DeepData.

