### PR TITLE
Fix missing Python bindings for OIIO::getattribute

### DIFF
--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -785,6 +785,7 @@ other's global error messages.
 \apiitem{bool {\ce attribute} (string_view name, TypeDesc type,
   const void *val)}
 \index{globalattribute}
+\label{sec:globalattribute}
 \indexapi{attribute}
 
 Sets an global attribute (i.e., a property or option) of \product.

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -434,17 +434,17 @@ data (for aggregate types or arrays, pass multiple values as a tuple).
 \end{code}
 \apiend
 
-\apiitem{ImageSpec.{\ce get_attribute} (name) \\
-ImageSpec.{\ce get_attribute} (name, typedesc)}
+\apiitem{ImageSpec.{\ce getattribute} (name) \\
+ImageSpec.{\ce getattribute} (name, typedesc)}
 Retrieves a named metadata value from {\cf extra_attribs}.  The generic
-{\cf get_attribute()} function returns it regardless of type, or {\cf None}
+{\cf getattribute()} function returns it regardless of type, or {\cf None}
 if the attribute does not exist.  The typed variety will only succeed
 if the attribute is actually of that type specified.
 
 \noindent Example:
 \begin{code}
-    foo = s.get_attribute ("foo")   # None if not found
-    foo = s.get_attribute ("foo", oiio.FLOAT)  # None if not found AND float
+    foo = s.getattribute ("foo")   # None if not found
+    foo = s.getattribute ("foo", oiio.FLOAT)  # None if not found AND float
 \end{code}
 \apiend
 
@@ -2952,6 +2952,25 @@ recognized attribute.
     oiio.attribute ("threads", 0)
 \end{code}
 \apiend
+
+\apiitem{{\ce getattribute} (name, typedesc) \\
+{\ce get_int_attribute} (name, defaultval=0) \\
+{\ce get_float_attribute} (name, defaultval=0.0) \\
+{\ce get_string_attribute} (name, defaultval="")}
+\NEW % 1.7
+Retrieves an attribute value from the named set of global OIIO options. (See
+Section~\ref{sec:globalattribute}.) The {\cf getattribute()} function
+returns the value regardless of type, or {\cf None} if the attribute does
+not exist.  The typed variety will only succeed if the attribute is actually
+of that type specified. Type varity with the type in the name also takes a
+default value.
+
+\noindent Example:
+\begin{code}
+    formats = oiio.get_string_attribute ("format_list")
+\end{code}
+\apiend
+
 
 
 \section{Python Recipes}

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -437,8 +437,10 @@ void declare_imagespec()
         .def("get_float_attribute", &ImageSpec_get_float_attribute_d)
         .def("get_string_attribute", &ImageSpec_get_string_attribute)
         .def("get_string_attribute", &ImageSpec_get_string_attribute_d)
-        .def("get_attribute", &ImageSpec_get_attribute_typed)
-        .def("get_attribute", &ImageSpec_get_attribute_untyped)
+        .def("getattribute",  &ImageSpec_get_attribute_typed)
+        .def("getattribute",  &ImageSpec_get_attribute_untyped)
+        .def("get_attribute", &ImageSpec_get_attribute_typed) // DEPRECATED(1.7)
+        .def("get_attribute", &ImageSpec_get_attribute_untyped) // DEPRECATED(1.7)
         .def("erase_attribute", &ImageSpec_erase_attribute,
              (arg("name")="", arg("type")=TypeDesc(TypeDesc::UNKNOWN),
               arg("casesensitive")=false))

--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -230,6 +230,80 @@ oiio_attribute_tuple_typed (const std::string &name,
 
 
 
+static object
+oiio_getattribute_typed (const std::string &name, TypeDesc type)
+{
+    if (type == TypeDesc::UNKNOWN)
+        return object();
+    char *data = OIIO_ALLOCA(char, type.size());
+    if (OIIO::getattribute (name, type, data)) {
+        if (type.basetype == TypeDesc::INT) {
+#if PY_MAJOR_VERSION >= 3
+            return C_to_val_or_tuple ((const int *)data, type, PyLong_FromLong);
+#else
+            return C_to_val_or_tuple ((const int *)data, type, PyInt_FromLong);
+#endif
+        }
+        if (type.basetype == TypeDesc::FLOAT) {
+            return C_to_val_or_tuple ((const float *)data, type, PyFloat_FromDouble);
+        }
+        if (type.basetype == TypeDesc::STRING) {
+#if PY_MAJOR_VERSION >= 3
+            return C_to_val_or_tuple ((const char **)data, type, PyUnicode_FromString);
+#else
+            return C_to_val_or_tuple ((const char **)data, type, PyString_FromString);
+#endif
+        }
+    }
+    return object();
+}
+
+
+static int
+oiio_get_int_attribute (const char *name)
+{
+    return OIIO::get_int_attribute (name);
+}
+
+
+static int
+oiio_get_int_attribute_d (const char *name, int defaultval)
+{
+    return OIIO::get_int_attribute (name, defaultval);
+}
+
+
+static float
+oiio_get_float_attribute (const char *name)
+{
+    return OIIO::get_float_attribute (name);
+}
+
+
+static float
+oiio_get_float_attribute_d (const char *name, float defaultval)
+{
+    return OIIO::get_float_attribute (name, defaultval);
+}
+
+
+static std::string
+oiio_get_string_attribute (const char *name)
+{
+    return OIIO::get_string_attribute (name);
+}
+
+
+static std::string
+oiio_get_string_attribute_d (const char *name, const char *defaultval)
+{
+    return OIIO::get_string_attribute (name, defaultval);
+}
+
+
+
+
+
 const void *
 python_array_address (numeric::array &data, TypeDesc &elementtype,
                       size_t &numelements)
@@ -291,12 +365,19 @@ OIIO_DECLARE_PYMODULE(OIIO_PYMODULE_NAME) {
     declare_imagebufalgo();
     
     // Global (OpenImageIO scope) functiona and symbols
+    def("geterror",     &OIIO::geterror);
     def("attribute",    &oiio_attribute_float);
     def("attribute",    &oiio_attribute_int);
     def("attribute",    &oiio_attribute_string);
     def("attribute",    &oiio_attribute_typed);
     def("attribute",    &oiio_attribute_tuple_typed);
-    def("geterror",     &OIIO::geterror);
+    def("get_int_attribute",    &oiio_get_int_attribute);
+    def("get_int_attribute",    &oiio_get_int_attribute_d);
+    def("get_float_attribute",  &oiio_get_float_attribute);
+    def("get_float_attribute",  &oiio_get_float_attribute_d);
+    def("get_string_attribute", &oiio_get_string_attribute);
+    def("get_string_attribute", &oiio_get_string_attribute_d);
+    def("getattribute",         &oiio_getattribute_typed);
     scope().attr("AutoStride") = AutoStride;
     scope().attr("openimageio_version") = OIIO_VERSION;
     scope().attr("VERSION") = OIIO_VERSION;

--- a/testsuite/python-imagespec/ref/out.txt
+++ b/testsuite/python-imagespec/ref/out.txt
@@ -75,12 +75,12 @@ get_string_attribute('foo_str') retrieves blah
 get_string_attribute('foo_str_no') retrieves 
 get_string_attribute('foo_str_no','xx') retrieves xx
 
-get_attribute('foo_int') retrieves 14
-get_attribute('foo_float') retrieves 3.1400001049
-get_attribute('foo_str') retrieves blah
-get_attribute('foo_vector') retrieves (1.0, 0.0, 11.0)
-get_attribute('foo_matrix') retrieves (1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0, 1.0)
-get_attribute('foo_no') retrieves None
+getattribute('foo_int') retrieves 14
+getattribute('foo_float') retrieves 3.1400001049
+getattribute('foo_str') retrieves blah
+getattribute('foo_vector') retrieves (1.0, 0.0, 11.0)
+getattribute('foo_matrix') retrieves (1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0, 1.0)
+getattribute('foo_no') retrieves None
 
 extra_attribs size is 5
 0 foo_str string blah
@@ -94,4 +94,11 @@ extra_attribs size is 5
 4 foo_matrix matrix (1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0, 1.0)
 1 0 0 0 0 2 0 0 0 0 1 0 1 2 3 1
 
+
+Testing global attribute store/retrieve:
+get_string_attribute plugin_searchpath :  perfect
+get_int_attribute plugin_searchpath :  0
+getattribute TypeString plugin_searchpath :  perfect
+getattribute TypeFloat plugin_searchpath :  None
+getattribute TypeString blahblah :  None
 Done.

--- a/testsuite/python-imagespec/test_imagespec.py
+++ b/testsuite/python-imagespec/test_imagespec.py
@@ -92,12 +92,12 @@ try:
     print "get_string_attribute('foo_str_no') retrieves", s.get_string_attribute ("foo_str_no")
     print "get_string_attribute('foo_str_no','xx') retrieves", s.get_string_attribute ("foo_str_no", "xx")
     print
-    print "get_attribute('foo_int') retrieves", s.get_attribute("foo_int")
-    print "get_attribute('foo_float') retrieves", s.get_attribute("foo_float")
-    print "get_attribute('foo_str') retrieves", s.get_attribute("foo_str")
-    print "get_attribute('foo_vector') retrieves", s.get_attribute("foo_vector")
-    print "get_attribute('foo_matrix') retrieves", s.get_attribute("foo_matrix")
-    print "get_attribute('foo_no') retrieves", s.get_attribute("foo_no")
+    print "getattribute('foo_int') retrieves", s.getattribute("foo_int")
+    print "getattribute('foo_float') retrieves", s.getattribute("foo_float")
+    print "getattribute('foo_str') retrieves", s.getattribute("foo_str")
+    print "getattribute('foo_vector') retrieves", s.getattribute("foo_vector")
+    print "getattribute('foo_matrix') retrieves", s.getattribute("foo_matrix")
+    print "getattribute('foo_no') retrieves", s.getattribute("foo_no")
     print
 
     print "extra_attribs size is", len(s.extra_attribs)
@@ -105,6 +105,15 @@ try:
         print i, s.extra_attribs[i].name, s.extra_attribs[i].type, s.extra_attribs[i].value
         print s.metadata_val (s.extra_attribs[i], True)
     print
+
+    # Also test global OIIO functions here
+    print "\nTesting global attribute store/retrieve:"
+    oiio.attribute ("plugin_searchpath", "perfect")
+    print "get_string_attribute plugin_searchpath : ", oiio.get_string_attribute ("plugin_searchpath", "bad")
+    print "get_int_attribute plugin_searchpath : ", oiio.get_int_attribute ("plugin_searchpath", 0)
+    print "getattribute TypeString plugin_searchpath : ", oiio.getattribute ("plugin_searchpath", oiio.TypeDesc.TypeString)
+    print "getattribute TypeFloat plugin_searchpath : ", oiio.getattribute ("plugin_searchpath", oiio.TypeDesc.TypeFloat)
+    print "getattribute TypeString blahblah : ", oiio.getattribute ("blahblah", oiio.TypeDesc.TypeString)
 
     print "Done."
 except Exception as detail:


### PR DESCRIPTION
This is embarrassing: somehow we never added the global getattribute() calls to the Python bindings.

Also notice that the Python bindings for ImageSpec::getattribute were incorrectly bound to "get_attribute". So add "getattribute" and consider "get_attribute" a deprecated synonym.

I will backport this to 1.6, despite being at RC stage, since this is an obvious bug.
