### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/include/OpenImageIO/deepdata.h
+++ b/src/include/OpenImageIO/deepdata.h
@@ -123,8 +123,7 @@ public:
 
     /// Fill in the vector with pointers to the start of the first
     /// channel for each pixel.
-    void get_pointers (std::vector<void*> &pointers);
-    void get_pointers (std::vector<const void*> &pointers) const;
+    void get_pointers (std::vector<void*> &pointers) const;
 
 private:
     class Impl;

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -501,30 +501,17 @@ DeepData::all_data () const
 
 
 void
-DeepData::get_pointers (std::vector<void*> &pointers)
+DeepData::get_pointers (std::vector<void*> &pointers) const
 {
     ASSERT (m_impl);
     m_impl->alloc (m_npixels);
     pointers.resize (pixels()*channels());
     for (int i = 0;  i < m_npixels;  ++i) {
         for (int c = 0;  c < m_nchannels;  ++c)
-            pointers[i*m_nchannels+c] = m_impl->data_ptr (i, c, 0);
+            pointers[i*m_nchannels+c] = (void *)m_impl->data_ptr (i, c, 0);
     }
 }
 
-
-
-void
-DeepData::get_pointers (std::vector<const void*> &pointers) const
-{
-    ASSERT (m_impl);
-    m_impl->alloc (m_npixels);
-    pointers.resize (pixels()*channels());
-    for (int i = 0;  i < m_npixels;  ++i) {
-        for (int c = 0;  c < m_nchannels;  ++c)
-            pointers[i*m_nchannels+c] = m_impl->data_ptr (i, c, 0);
-    }
-}
 
 
 OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -81,7 +81,7 @@ public:
     }
 
     size_t data_offset (int pixel, int channel, int sample) {
-        DASSERT (m_cumsamples.size() > pixel);
+        DASSERT (int(m_cumsamples.size()) > pixel);
         return (m_cumsamples[pixel] + sample) * m_samplesize
              + m_channeloffsets[channel];
     }

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -1521,7 +1521,7 @@ OpenEXROutput::write_deep_scanlines (int ybegin, int yend, int z,
                                sizeof(unsigned int),
                                sizeof(unsigned int) * m_spec.width);
         frameBuffer.insertSampleCountSlice (countslice);
-        std::vector<const void*> pointerbuf;
+        std::vector<void*> pointerbuf;
         deepdata.get_pointers (pointerbuf);
         for (int c = 0;  c < nchans;  ++c) {
             Imf::DeepSlice slice (m_pixeltype[c],
@@ -1584,7 +1584,7 @@ OpenEXROutput::write_deep_tiles (int xbegin, int xend, int ybegin, int yend,
                                sizeof(unsigned int),
                                sizeof(unsigned int) * width);
         frameBuffer.insertSampleCountSlice (countslice);
-        std::vector<const void*> pointerbuf;
+        std::vector<void*> pointerbuf;
         deepdata.get_pointers (pointerbuf);
         for (int c = 0;  c < nchans;  ++c) {
             Imf::DeepSlice slice (m_pixeltype[c],


### PR DESCRIPTION
The trickiest issue involved DeepData::get_pointers (std::vector<const void*>&). Some compilers won't eat a vector of a const type. Others seem fine.    Sidestep the problem by removing this variety of DeepData::get_pointers,    it's not necessary with the right casting inside the non-const version.