### PR TITLE
Fix for compilation with Boost 1.60 -- major Python ImageCache overhaul

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -118,7 +118,7 @@ if (NOT Boost_FIND_QUIETLY)
 endif ()
 
 if (NOT DEFINED Boost_ADDITIONAL_VERSIONS)
-  set (Boost_ADDITIONAL_VERSIONS "1.57" "1.56"
+  set (Boost_ADDITIONAL_VERSIONS "1.60" "1.59" "1.58" "1.57" "1.56"
                                  "1.55" "1.54" "1.53" "1.52" "1.51" "1.50"
                                  "1.49" "1.48" "1.47" "1.46" "1.45" "1.44"
                                  "1.43" "1.43.0" "1.42" "1.42.0")

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -113,13 +113,13 @@ public:
 
     /// Get the named attribute, store it in value.
     virtual bool getattribute (string_view name, TypeDesc type,
-                               void *val) = 0;
+                               void *val) const = 0;
     // Shortcuts for common types
-    virtual bool getattribute (string_view name, int &val) = 0;
-    virtual bool getattribute (string_view name, float &val) = 0;
-    virtual bool getattribute (string_view name, double &val) = 0;
-    virtual bool getattribute (string_view name, char **val) = 0;
-    virtual bool getattribute (string_view name, std::string &val) = 0;
+    virtual bool getattribute (string_view name, int &val) const = 0;
+    virtual bool getattribute (string_view name, float &val) const = 0;
+    virtual bool getattribute (string_view name, double &val) const = 0;
+    virtual bool getattribute (string_view name, char **val) const = 0;
+    virtual bool getattribute (string_view name, std::string &val) const = 0;
 
     /// Define an opaque data type that allows us to have a pointer
     /// to certain per-thread information that the ImageCache maintains.

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -345,13 +345,14 @@ public:
     virtual bool attribute (string_view name, string_view val) = 0;
 
     /// Get the named attribute, store it in value.
-    virtual bool getattribute (string_view name, TypeDesc type, void *val) = 0;
+    virtual bool getattribute (string_view name,
+                               TypeDesc type, void *val) const = 0;
     // Shortcuts for common types
-    virtual bool getattribute (string_view name, int &val) = 0;
-    virtual bool getattribute (string_view name, float &val) = 0;
-    virtual bool getattribute (string_view name, double &val) = 0;
-    virtual bool getattribute (string_view name, char **val) = 0;
-    virtual bool getattribute (string_view name, std::string &val) = 0;
+    virtual bool getattribute (string_view name, int &val) const = 0;
+    virtual bool getattribute (string_view name, float &val) const = 0;
+    virtual bool getattribute (string_view name, double &val) const = 0;
+    virtual bool getattribute (string_view name, char **val) const = 0;
+    virtual bool getattribute (string_view name, std::string &val) const = 0;
 
     /// Define an opaque data type that allows us to have a pointer
     /// to certain per-thread information that the TextureSystem maintains.

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1922,7 +1922,7 @@ ImageCacheImpl::attribute (string_view name, TypeDesc type,
 
 bool
 ImageCacheImpl::getattribute (string_view name, TypeDesc type,
-                              void *val)
+                              void *val) const
 {
 #define ATTR_DECODE(_name,_ctype,_src)                                  \
     if (name == _name && type == BaseTypeFromC<_ctype>::value) {        \

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -703,24 +703,24 @@ public:
         return attribute (name, TypeDesc::STRING, &s);
     }
 
-    virtual bool getattribute (string_view name, TypeDesc type, void *val);
-    virtual bool getattribute (string_view name, int &val) {
+    virtual bool getattribute (string_view name, TypeDesc type, void *val) const;
+    virtual bool getattribute (string_view name, int &val) const {
         return getattribute (name, TypeDesc::INT, &val);
     }
-    virtual bool getattribute (string_view name, float &val) {
+    virtual bool getattribute (string_view name, float &val) const {
         return getattribute (name, TypeDesc::FLOAT, &val);
     }
-    virtual bool getattribute (string_view name, double &val) {
+    virtual bool getattribute (string_view name, double &val) const {
         float f;
         bool ok = getattribute (name, TypeDesc::FLOAT, &f);
         if (ok)
             val = f;
         return ok;
     }
-    virtual bool getattribute (string_view name, char **val) {
+    virtual bool getattribute (string_view name, char **val) const {
         return getattribute (name, TypeDesc::STRING, val);
     }
-    virtual bool getattribute (string_view name, std::string &val) {
+    virtual bool getattribute (string_view name, std::string &val) const {
         ustring s;
         bool ok = getattribute (name, TypeDesc::STRING, &s);
         if (ok)

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -82,24 +82,24 @@ public:
         return attribute (name, TypeDesc::STRING, &s);
     }
 
-    virtual bool getattribute (string_view name, TypeDesc type, void *val);
-    virtual bool getattribute (string_view name, int &val) {
+    virtual bool getattribute (string_view name, TypeDesc type, void *val) const;
+    virtual bool getattribute (string_view name, int &val) const {
         return getattribute (name, TypeDesc::INT, &val);
     }
-    virtual bool getattribute (string_view name, float &val) {
+    virtual bool getattribute (string_view name, float &val) const {
         return getattribute (name, TypeDesc::FLOAT, &val);
     }
-    virtual bool getattribute (string_view name, double &val) {
+    virtual bool getattribute (string_view name, double &val) const {
         float f;
         bool ok = getattribute (name, TypeDesc::FLOAT, &f);
         if (ok)
             val = f;
         return ok;
     }
-    virtual bool getattribute (string_view name, char **val) {
+    virtual bool getattribute (string_view name, char **val) const {
         return getattribute (name, TypeDesc::STRING, val);
     }
-    virtual bool getattribute (string_view name, std::string &val) {
+    virtual bool getattribute (string_view name, std::string &val) const {
         const char *s;
         bool ok = getattribute (name, TypeDesc::STRING, &s);
         if (ok)

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -484,7 +484,7 @@ TextureSystemImpl::attribute (string_view name, TypeDesc type,
 
 bool
 TextureSystemImpl::getattribute (string_view name, TypeDesc type,
-                                 void *val)
+                                 void *val) const
 {
     if (name == "worldtocommon" && (type == TypeDesc::TypeMatrix ||
                                     type == TypeDesc(TypeDesc::FLOAT,16))) {

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -214,31 +214,7 @@ static void
 ImageSpec_attribute_typed (ImageSpec& spec, const std::string &name,
                            TypeDesc type, object &obj)
 {
-    if (type.basetype == TypeDesc::INT) {
-        std::vector<int> vals;
-        py_to_stdvector (vals, obj);
-        if (vals.size() == type.numelements()*type.aggregate)
-            spec.attribute (name, type, &vals[0]);
-        return;
-    }
-    if (type.basetype == TypeDesc::FLOAT) {
-        std::vector<float> vals;
-        py_to_stdvector (vals, obj);
-        if (vals.size() == type.numelements()*type.aggregate)
-            spec.attribute (name, type, &vals[0]);
-        return;
-    }
-    if (type.basetype == TypeDesc::STRING) {
-        std::vector<std::string> vals;
-        py_to_stdvector (vals, obj);
-        if (vals.size() == type.numelements()*type.aggregate) {
-            std::vector<ustring> u;
-            for (size_t i = 0, e = vals.size(); i < e; ++i)
-                u.push_back (ustring(vals[i]));
-            spec.attribute (name, type, &u[0]);
-        }
-        return;
-    }
+    attribute_typed (spec, name, type, obj);
 }
 
 
@@ -247,31 +223,7 @@ static void
 ImageSpec_attribute_tuple_typed (ImageSpec& spec, const std::string &name,
                            TypeDesc type, tuple &obj)
 {
-    if (type.basetype == TypeDesc::INT) {
-        std::vector<int> vals;
-        py_to_stdvector (vals, obj);
-        if (vals.size() == type.numelements()*type.aggregate)
-            spec.attribute (name, type, &vals[0]);
-        return;
-    }
-    if (type.basetype == TypeDesc::FLOAT) {
-        std::vector<float> vals;
-        py_to_stdvector (vals, obj);
-        if (vals.size() == type.numelements()*type.aggregate)
-            spec.attribute (name, type, &vals[0]);
-        return;
-    }
-    if (type.basetype == TypeDesc::STRING) {
-        std::vector<std::string> vals;
-        py_to_stdvector (vals, obj);
-        if (vals.size() == type.numelements()*type.aggregate) {
-            std::vector<ustring> u;
-            for (size_t i = 0, e = vals.size(); i < e; ++i)
-                u.push_back (ustring(vals[i]));
-            spec.attribute (name, type, &u[0]);
-        }
-        return;
-    }
+    attribute_tuple_typed (spec, name, type, obj);
 }
 
 


### PR DESCRIPTION
Fixes #1299 

I don't know why it worked before or why it's broken now, but the    just-release Boost 1.60 refused to build OIIO, and all the problems    were in the ImageCache bindings. And they were weird, and in retrospect    some of the calls would probably not ever have worked. So after a big    refactor, we are building against Boost 1.60 and passing all tests. Luckily, the Python bindings for ImageCache are all but undocumented, and I suspect unused, so this late-stage overhaul should probably not hurt anyone. And I assure you, what we have before was very, very broken.

Along the way I noticed that ImageCache and TextureSystem both have their getattribute() methods curiously not marked as const! Sorry, that needs to be fixed. I need to backport all this to 1.6, and this would ordinarily break the "don't change API in a release branch", but in this case I think it needs to be done, and since 1.6 was only just considered released, I think the number of people inconvenienced will be minimal.

