### PR TITLE
Add IBAPrep flag DST_FLOAT_PIXELS

### DIFF
--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -138,16 +138,17 @@ inline bool IBAprep (ROI &roi, ImageBuf *dst,
 
 enum IBAprep_flags {
     IBAprep_DEFAULT = 0,
-    IBAprep_REQUIRE_ALPHA = 1,
-    IBAprep_REQUIRE_Z = 2,
-    IBAprep_REQUIRE_SAME_NCHANNELS = 4,
-    IBAprep_NO_COPY_ROI_FULL = 8,       // Don't copy the src's roi_full
-    IBAprep_NO_SUPPORT_VOLUME = 16,     // Don't know how to do volumes
-    IBAprep_NO_COPY_METADATA = 256,     // N.B. default copies all metadata
-    IBAprep_COPY_ALL_METADATA = 512,    // Even unsafe things
+    IBAprep_REQUIRE_ALPHA = 1<<0,
+    IBAprep_REQUIRE_Z = 1<<1,
+    IBAprep_REQUIRE_SAME_NCHANNELS = 1<<2,
+    IBAprep_NO_COPY_ROI_FULL = 1<<3,    // Don't copy the src's roi_full
+    IBAprep_NO_SUPPORT_VOLUME = 1<<4,   // Don't know how to do volumes
+    IBAprep_NO_COPY_METADATA = 1<<8,    // N.B. default copies all metadata
+    IBAprep_COPY_ALL_METADATA = 1<<9,   // Even unsafe things
     IBAprep_CLAMP_MUTUAL_NCHANNELS = 1<<10, // Clamp roi.chend to max of inputs
     IBAprep_SUPPORT_DEEP = 1<<11,       // Operation allows deep images
     IBAprep_DEEP_MIXED = 1<<12,         // Allow deep & non-deep combinations
+    IBAprep_DST_FLOAT_PIXELS = 1<<13    // If dst is uninit, make it float
 };
 
 

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -154,7 +154,8 @@ ImageBufAlgo::IBAprep (ROI &roi, ImageBuf *dst, const ImageBuf *A,
             // For multiple inputs, if they aren't the same data type, punt and
             // allocate a float buffer. If the user wanted something else,
             // they should have pre-allocated dst with their desired format.
-            if (B && A->spec().format != B->spec().format)
+            if ((B && A->spec().format != B->spec().format)
+                    || (prepflags & IBAprep_DST_FLOAT_PIXELS))
                 spec.set_format (TypeDesc::FLOAT);
             if (C && (A->spec().format != C->spec().format ||
                       B->spec().format != C->spec().format))


### PR DESCRIPTION
This new flag causes an uninitialized destination image to be initialized with FLOAT pixels, rather
than the same type as the input image. Can be handy.