### PR TITLE
DeepData::get_pointers - Fix pointer botch for 0-sample pixels

### DIFF
--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -539,8 +539,12 @@ DeepData::get_pointers (std::vector<void*> &pointers) const
     m_impl->alloc (m_npixels);
     pointers.resize (pixels()*channels());
     for (int i = 0;  i < m_npixels;  ++i) {
-        for (int c = 0;  c < m_nchannels;  ++c)
-            pointers[i*m_nchannels+c] = (void *)m_impl->data_ptr (i, c, 0);
+        if (m_impl->m_nsamples[i])
+            for (int c = 0;  c < m_nchannels;  ++c)
+                pointers[i*m_nchannels+c] = (void *)m_impl->data_ptr (i, c, 0);
+        else
+            for (int c = 0;  c < m_nchannels;  ++c)
+                pointers[i*m_nchannels+c] = NULL;
     }
 }
 


### PR DESCRIPTION
When there are no samples for a pixel, the pointer to a particular sample (which should not be used) will compute something meaningless, which triggered the assertion.
