### PR TITLE
Add DEBUG build & test to Travis-CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
       - WHICHGCC=4.8 BUILD_FLAGS="USE_CPP11=1"
       - WHICHGCC=4.9 BUILD_FLAGS="USE_CPP11=1"
       - WHICHGCC=5 BUILD_FLAGS="USE_CPP11=1"
+      - WHICHGCC=4.8 BUILD_FLAGS="USE_CPP11=0" DEBUG=1
 
 # Add-ons: specify apt packages for Linux
 addons:
@@ -59,6 +60,7 @@ before_install:
           export PLATFORM=linux64 ;
           cat /proc/cpuinfo ;
       fi
+    - if [ $DEBUG == 1 ] ; then export PLATFORM=${PLATFORM}.debug ; fi
     - echo "Build platform name is $PLATFORM"
 
 install:

--- a/src/include/OpenImageIO/array_view.h
+++ b/src/include/OpenImageIO/array_view.h
@@ -161,10 +161,10 @@ public:
         return m_bounds.size();
     }
     OIIO_CONSTEXPR14 offset_type stride() const OIIO_NOEXCEPT {
-        offset_type offset(1);
-        if (Rank == 1)
-            return offset;
-        else {
+        if (Rank == 1) {
+            return offset_type(1);
+        } else {
+            offset_type offset;
             offset[Rank-1] = 1;
             for (int i = int(Rank)-2; i >= 0; --i)
                 offset[i] = offset[i+1] * m_bounds[i+1];

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -2038,7 +2038,7 @@ TextureSystemImpl::sample_bilinear (int nsamples, const float *s_,
                     int pixelsize = tile->pixelsize();
                     int offset = pixelsize * (tile_t * spec.tile_width + tile_s);
                     offset += (firstchannel - id.chbegin()) * channelsize;
-                    DASSERT ((size_t)offset < spec.tile_width*spec.tile_height*spec.tile_depth*pixelsize);
+                    DASSERT (offset < spec.tile_width*spec.tile_height*spec.tile_depth*pixelsize);
                     if (pixeltype == TypeDesc::UINT8)
                         texel_simd[j][i] = uchar2float4 ((const unsigned char *)(tile->bytedata() + offset));
                     else if (pixeltype == TypeDesc::UINT16)

--- a/testsuite/oiiotool-readerror/ref/out.err-debug.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err-debug.txt
@@ -1,0 +1,3 @@
+read was not necessary -- using cache
+going to have to read incomplete.exr: float vs float
+oiiotool ERROR: read incomplete.exr : Failed OpenEXR read: Error reading pixel data from image file "incomplete.exr". Scan line 126 is missing.

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -50,7 +50,10 @@ failthresh = 0.004
 hardfail = 0.01
 failpercent = 0.02
 
-if "TRAVIS" in os.environ and os.environ["TRAVIS"] :
+# Allow a little more slop for slight pixel differences when in DEBUG
+# mode or when running on remote Travis-CI machines.
+if (("TRAVIS" in os.environ and os.environ["TRAVIS"]) or
+    ("DEBUG" in os.environ and os.environ["DEBUG"])) :
     failthresh *= 2.0
     hardfail *= 2.0
     failpercent *= 2.0


### PR DESCRIPTION
Make sure Travis CI includes a DEBUG build so we will never again check something in that works for optimize builds but breaks a debug build. Fix the few minor warnings and test failures that show up for DEBUG builds.
