### PR TITLE
Speed up IBA::mad, and compute speed tests

### DIFF
--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -614,6 +614,10 @@ public:
     /// Does NOT change the channels of the spec, regardless of newroi.
     void set_roi_full (const ROI &newroi);
 
+    /// Is the specified roi completely contained in the data window of
+    /// this ImageBuf?
+    bool contains_roi (ROI roi) const;
+
     bool pixels_valid (void) const;
 
     TypeDesc pixeltype () const;

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -371,4 +371,10 @@ if (OIIO_BUILD_TESTS)
     link_ilmbase (imagespeed_test)
     #add_test (imagespeed_test imagespeed_test)
 
+    add_executable (compute_test compute_test.cpp)
+    set_target_properties (compute_test PROPERTIES FOLDER "Unit Tests")
+    target_link_libraries (compute_test OpenImageIO ${Boost_LIBRARIES}
+                           ${CMAKE_DL_LIBS})
+    add_test (unit_compute compute_test)
+
 endif (OIIO_BUILD_TESTS)

--- a/src/libOpenImageIO/compute_test.cpp
+++ b/src/libOpenImageIO/compute_test.cpp
@@ -1,0 +1,329 @@
+/*
+  Copyright 2016 Larry Gritz and the other authors and contributors.
+  All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the software's owners nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  (This is the Modified BSD License)
+*/
+
+
+//
+// Task: take "images" A and B, and compute R = A*A + B.
+//
+// Do this a whole bunch of different ways and benchmark.
+//
+
+
+#include <iostream>
+
+#include <OpenImageIO/imageio.h>
+#include <OpenImageIO/imagebuf.h>
+#include <OpenImageIO/imagebufalgo.h>
+#include <OpenImageIO/imagebufalgo_util.h>
+#include <OpenImageIO/thread.h>
+#include <OpenImageIO/strutil.h>
+#include <OpenImageIO/sysutil.h>
+#include <OpenImageIO/timer.h>
+#include <OpenImageIO/argparse.h>
+#include <OpenImageIO/simd.h>
+#include <OpenImageIO/unittest.h>
+
+OIIO_NAMESPACE_USING;
+
+static int iterations = 100;
+static int numthreads = Sysutil::physical_concurrency();
+static int ntrials = 5;
+static bool verbose = false;
+static bool wedge = false;
+static bool allgpus = false;
+
+static spin_mutex print_mutex;  // make the prints not clobber each other
+
+static int xres = 1920, yres = 1080, channels = 3;
+static int npixels = xres * yres;
+static int size = npixels * channels;
+static ImageBuf imgA, imgB, imgR;
+
+
+
+static void
+test_arrays (ROI roi)
+{
+    const float *a = (const float *)imgA.localpixels(); ASSERT(a);
+    const float *b = (const float *)imgB.localpixels(); ASSERT(b);
+    float *r = (float *)imgR.localpixels(); ASSERT(r);
+    for (int x = 0; x < size; ++x)
+        r[x] = a[x] * a[x] + b[x];
+}
+
+
+
+static void
+test_arrays_like_image (ROI roi)
+{
+    const float *a = (const float *)imgA.localpixels(); ASSERT(a);
+    const float *b = (const float *)imgB.localpixels(); ASSERT(b);
+    float *r = (float *)imgR.localpixels(); ASSERT(r);
+    int nchannels = imgA.nchannels();
+    for (int y = 0; y < yres; ++y) {
+        for (int x = 0; x < xres; ++x) {
+            int i = (y*xres + x) * nchannels;
+            for (int c = 0; c < nchannels; ++c)
+                r[i+c] = a[i+c] * a[i+c] + b[i+c];
+        }
+    }
+}
+
+
+static void
+test_arrays_like_image_multithread (ROI roi)
+{
+    const float *a = (const float *)imgA.localpixels(); ASSERT(a);
+    const float *b = (const float *)imgB.localpixels(); ASSERT(b);
+    float *r = (float *)imgR.localpixels(); ASSERT(r);
+    int nchannels = imgA.nchannels();
+    for (int y = roi.ybegin; y < roi.yend; ++y) {
+        for (int x = roi.xbegin; x < roi.xend; ++x) {
+            int i = (y*xres + x) * nchannels;
+            for (int c = 0; c < nchannels; ++c)
+                r[i+c] = a[i+c] * a[i+c] + b[i+c];
+        }
+    }
+}
+
+static void
+test_arrays_like_image_multithread_wrapper (ROI roi)
+{
+    ImageBufAlgo::parallel_image (test_arrays_like_image_multithread, roi, numthreads);
+}
+
+
+
+static void
+test_arrays_simd4 (ROI roi)
+{
+    const float *a = (const float *)imgA.localpixels(); ASSERT(a);
+    const float *b = (const float *)imgB.localpixels(); ASSERT(b);
+    float *r = (float *)imgR.localpixels(); ASSERT(r);
+    int x, end4 = size - (size&3);
+    for (x = 0; x < end4; x += 4, a += 4, b += 4, r += 4) {
+        simd::float4 a_simd(a), b_simd(b);
+        *(simd::float4 *)r = a_simd * a_simd + b_simd;
+    }
+    for ( ; x < size; ++x, ++a, ++b, ++r) {
+        *r = a[0]*a[0] + b[0];
+    }
+}
+
+
+
+static void
+test_arrays_like_image_simd (ROI roi)
+{
+    const float *a = (const float *)imgA.localpixels(); ASSERT(a);
+    const float *b = (const float *)imgB.localpixels(); ASSERT(b);
+    float *r = (float *)imgR.localpixels(); ASSERT(r);
+    int nchannels = imgA.nchannels();
+    for (int y = 0; y < yres; ++y) {
+        for (int x = 0; x < xres; ++x) {
+            int i = (y*xres + x) * nchannels;
+            simd::float4 a_simd, b_simd, r_simd;
+            a_simd.load (a+i, 3);
+            b_simd.load (b+i, 3);
+            r_simd = a_simd * a_simd + b_simd;
+            r_simd.store (r+i, 3);
+        }
+    }
+}
+
+
+static void
+test_arrays_like_image_simd_multithread (ROI roi)
+{
+    const float *a = (const float *)imgA.localpixels(); ASSERT(a);
+    const float *b = (const float *)imgB.localpixels(); ASSERT(b);
+    float *r = (float *)imgR.localpixels(); ASSERT(r);
+    int nchannels = imgA.nchannels();
+    for (int y = roi.ybegin; y < roi.yend; ++y) {
+        for (int x = roi.xbegin; x < roi.xend; ++x) {
+            int i = (y*xres + x) * nchannels;
+            simd::float4 a_simd, b_simd, r_simd;
+            a_simd.load (a+i, 3);
+            b_simd.load (b+i, 3);
+            r_simd = a_simd * a_simd + b_simd;
+            r_simd.store (r+i, 3);
+        }
+    }
+}
+
+
+static void
+test_arrays_like_image_simd_multithread_wrapper (ROI roi)
+{
+    ImageBufAlgo::parallel_image (test_arrays_like_image_simd_multithread, roi, 0);
+}
+
+
+
+static void
+test_IBA (ROI roi, int threads)
+{
+    ImageBufAlgo::mad (imgR, imgA, imgA, imgB, roi, threads);
+}
+
+
+
+
+
+void
+test_compute ()
+{
+    double time;
+
+    ROI roi (0, xres, 0, yres, 0, 1, 0, channels);
+
+    std::cout << "Test straightforward as 1D array of float: ";
+    ImageBufAlgo::zero (imgR);
+    time = time_trial (OIIO::bind (test_arrays, roi), ntrials, iterations) / iterations;
+    std::cout << Strutil::format ("%.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,0), 0.25, 0.001);
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,1), 0.25, 0.001);
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,2), 0.50, 0.001);
+    // imgR.write ("ref.exr");
+
+    std::cout << "Test array iterated like an image: ";
+    ImageBufAlgo::zero (imgR);
+    time = time_trial (OIIO::bind (test_arrays_like_image, roi), ntrials, iterations) / iterations;
+    std::cout << Strutil::format ("%.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,0), 0.25, 0.001);
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,1), 0.25, 0.001);
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,2), 0.50, 0.001);
+
+    std::cout << "Test array iterated like an image, multithreaded: ";
+    ImageBufAlgo::zero (imgR);
+    time = time_trial (OIIO::bind (test_arrays_like_image_multithread_wrapper, roi), ntrials, iterations) / iterations;
+    std::cout << Strutil::format ("%.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,0), 0.25, 0.001);
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,1), 0.25, 0.001);
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,2), 0.50, 0.001);
+
+    std::cout << "Test array as 1D, using SIMD: ";
+    ImageBufAlgo::zero (imgR);
+    time = time_trial (OIIO::bind (test_arrays_simd4, roi), ntrials, iterations) / iterations;
+    std::cout << Strutil::format ("%.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,0), 0.25, 0.001);
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,1), 0.25, 0.001);
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,2), 0.50, 0.001);
+
+    std::cout << "Test array iterated like an image, using SIMD: ";
+    ImageBufAlgo::zero (imgR);
+    time = time_trial (OIIO::bind (test_arrays_like_image_simd, roi), ntrials, iterations) / iterations;
+    std::cout << Strutil::format ("%.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,0), 0.25, 0.001);
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,1), 0.25, 0.001);
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,2), 0.50, 0.001);
+
+    std::cout << "Test array iterated like an image, using SIMD, multithreaded: ";
+    ImageBufAlgo::zero (imgR);
+    time = time_trial (OIIO::bind (test_arrays_like_image_simd_multithread_wrapper, roi), ntrials, iterations) / iterations;
+    std::cout << Strutil::format ("%.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,0), 0.25, 0.001);
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,1), 0.25, 0.001);
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,2), 0.50, 0.001);
+
+    std::cout << "Test ImageBufAlgo::mad 1 thread: ";
+    ImageBufAlgo::zero (imgR);
+    time = time_trial (OIIO::bind (test_IBA, roi, 1),
+                       ntrials, iterations) / iterations;
+    std::cout << Strutil::format ("%.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,0), 0.25, 0.001);
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,1), 0.25, 0.001);
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,2), 0.50, 0.001);
+
+    std::cout << "Test ImageBufAlgo::mad multi-thread " << numthreads << ": ";
+    ImageBufAlgo::zero (imgR);
+    time = time_trial (OIIO::bind (test_IBA, roi, numthreads),
+                       ntrials, iterations) / iterations;
+    std::cout << Strutil::format ("%.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,0), 0.25, 0.001);
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,1), 0.25, 0.001);
+    OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,2), 0.50, 0.001);
+}
+
+
+
+static void
+getargs (int argc, char *argv[])
+{
+    bool help = false;
+    ArgParse ap;
+    ap.options ("atomic_test\n"
+                OIIO_INTRO_STRING "\n"
+                "Usage:  atomic_test [options]",
+                // "%*", parse_files, "",
+                "--help", &help, "Print help message",
+                "-v", &verbose, "Verbose mode",
+                "--threads %d", &numthreads,
+                    ustring::format("Number of threads (default: %d)", numthreads).c_str(),
+                "--iterations %d", &iterations,
+                    ustring::format("Number of iterations (default: %d)", iterations).c_str(),
+                "--trials %d", &ntrials, "Number of trials",
+                "--allgpus", &allgpus, "Run OpenCL tests on all devices, not just default",
+                "--wedge", &wedge, "Do a wedge test",
+                NULL);
+    if (ap.parse (argc, (const char**)argv) < 0) {
+        std::cerr << ap.geterror() << std::endl;
+        ap.usage ();
+        exit (EXIT_FAILURE);
+    }
+    if (help) {
+        ap.usage ();
+        exit (EXIT_FAILURE);
+    }
+}
+
+
+
+int main (int argc, char *argv[])
+{
+    getargs (argc, argv);
+
+    // Initialize
+    imgA.reset (ImageSpec (xres, yres, channels, TypeDesc::FLOAT));
+    imgB.reset (ImageSpec (xres, yres, channels, TypeDesc::FLOAT));
+    imgR.reset (ImageSpec (xres, yres, channels, TypeDesc::FLOAT));
+    float red[3]  = { 1, 0, 0 };
+    float green[3] = { 0, 1, 0 };
+    float blue[3]  = { 0, 0, 1 };
+    float black[3] = { 0, 0, 0 };
+    ImageBufAlgo::fill (imgA, red, green, red, green);
+    ImageBufAlgo::fill (imgB, blue, blue, black, black);
+    // imgA.write ("A.exr");
+    // imgB.write ("B.exr");
+
+    test_compute ();
+
+    return unit_test_failures;
+}

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -2075,6 +2075,19 @@ ImageBuf::set_roi_full (const ROI &newroi)
 
 
 
+bool
+ImageBuf::contains_roi (ROI roi) const
+{
+    ROI myroi = roi;
+    return (roi.defined() && myroi.defined() &&
+            roi.xbegin >= myroi.xbegin && roi.xend <= myroi.xend &&
+            roi.ybegin >= myroi.ybegin && roi.yend <= myroi.yend &&
+            roi.zbegin >= myroi.zbegin && roi.zend <= myroi.zend &&
+            roi.chbegin >= myroi.chbegin && roi.chend <= myroi.chend);
+}
+
+
+
 const void *
 ImageBufImpl::pixeladdr (int x, int y, int z) const
 {

--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -43,6 +43,7 @@
 #include "OpenImageIO/imagebufalgo_util.h"
 #include "OpenImageIO/deepdata.h"
 #include "OpenImageIO/dassert.h"
+#include "OpenImageIO/simd.h"
 
 
 
@@ -664,15 +665,55 @@ mad_impl (ImageBuf &R, const ImageBuf &A, const ImageBuf &B, const ImageBuf &C,
             roi, nthreads);
         return true;
     }
-
     // Serial case
-    ImageBuf::Iterator<Rtype> r (R, roi);
-    ImageBuf::ConstIterator<ABCtype> a (A, roi);
-    ImageBuf::ConstIterator<ABCtype> b (B, roi);
-    ImageBuf::ConstIterator<ABCtype> c (C, roi);
-    for ( ;  !r.done();  ++r, ++a, ++b, ++c)
-        for (int ch = roi.chbegin;  ch < roi.chend;  ++ch)
-            r[ch] = a[ch] * b[ch] + c[ch];
+
+    if (   (is_same<Rtype,float>::value || is_same<Rtype,half>::value)
+        && (is_same<ABCtype,float>::value || is_same<ABCtype,half>::value)
+        // && R.localpixels() // has to be, because it's writeable
+        && A.localpixels() && B.localpixels() && C.localpixels()
+        // && R.contains_roi(roi)  // has to be, because IBAPrep
+        && A.contains_roi(roi) && B.contains_roi(roi) && C.contains_roi(roi)
+        && roi.chbegin == 0 && roi.chend == R.nchannels()
+        && roi.chend == A.nchannels() && roi.chend == B.nchannels()
+        && roi.chend == C.nchannels()) {
+        // Special case when all inputs are either float or half, with in-
+        // memory contiguous data and we're operating on the full channel
+        // range: skip iterators: For these circumstances, we can operate on
+        // the raw memory very efficiently. Otherwise, we will need the
+        // magic of the the Iterators (and pay the price).
+        int nxvalues = roi.width() * R.nchannels();
+        for (int z = roi.zbegin; z < roi.zend; ++z)
+            for (int y = roi.ybegin; y < roi.yend; ++y) {
+                Rtype         *rraw =         (Rtype *) R.pixeladdr (roi.xbegin, y, z);
+                const ABCtype *araw = (const ABCtype *) A.pixeladdr (roi.xbegin, y, z);
+                const ABCtype *braw = (const ABCtype *) B.pixeladdr (roi.xbegin, y, z);
+                const ABCtype *craw = (const ABCtype *) C.pixeladdr (roi.xbegin, y, z);
+                DASSERT (araw && braw && craw);
+                // The straightforward loop auto-vectorizes very well,
+                // there's no benefit to using explicit SIMD here.
+                for (int x = 0; x < nxvalues; ++x)
+                    rraw[x] = araw[x] * braw[x] + craw[x];
+                // But if you did want to explicitly vectorize, this is
+                // how it would look:
+                // int simdend = nxvalues & (~3); // how many float4's?
+                // for (int x = 0; x < simdend; x += 4) {
+                //     simd::float4 a_simd(araw+x), b_simd(braw+x), c_simd(craw+x);
+                //     simd::float4 r_simd = a_simd * b_simd + c_simd;
+                //     r_simd.store (rraw+x);
+                // }
+                // for (int x = simdend; x < nxvalues; ++x)
+                //     rraw[x] = araw[x] * braw[x] + craw[x];
+            }
+    } else {
+        ImageBuf::Iterator<Rtype> r (R, roi);
+        ImageBuf::ConstIterator<ABCtype> a (A, roi);
+        ImageBuf::ConstIterator<ABCtype> b (B, roi);
+        ImageBuf::ConstIterator<ABCtype> c (C, roi);
+        for ( ;  !r.done();  ++r, ++a, ++b, ++c) {
+            for (int ch = roi.chbegin;  ch < roi.chend;  ++ch)
+                r[ch] = a[ch] * b[ch] + c[ch];
+        }
+    }
     return true;
 }
 


### PR DESCRIPTION
More fun from winter break...

I constructed a compute_test that benchmarks a number of ways of traversing an ImageBuf to do some math (in this case, R = A*A+B, three HD-res float images, RGB). Many ways to do it, how fast are they? Sample output like this:

```
Test straightforward as 1D array of float: 1658.6 Mvals/sec
Test array iterated like an image: 581.8 Mvals/sec
Test array iterated like an image, multithreaded: 2132.8 Mvals/sec
Test array as 1D, using SIMD: 1675.9 Mvals/sec
Test array iterated like an image, using SIMD: 1514.3 Mvals/sec
Test array iterated like an image, using SIMD, multithreaded: 3333.2 Mvals/sec
Test ImageBufAlgo::mad 1 thread: 352.6 Mvals/sec
Test ImageBufAlgo::mad multi-thread 4: 1245.9 Mvals/sec
```

There are some interesting observations here.

* Just looping float*'s over the images as a single linear array and doing the math is "speed of light" for a single core -- around 1650M pixels/sec.

* When I fully loop over y, x, and channel, and do the math, I get 581M/sec. That's leads me to believe that for the 1D case, the compiler is auto-vectorizing, whereas when I loop over individual color channels it's defeating the SIMD auto-vectorization.

* Also, when I loop by 4's and explicitly use float4 SIMD math, I get the same speed as the 1D case, also confirming that the dumb 1D case is auto-vectorizing. (Lesson: explicit SIMD only helps for cases where the compiler can't figure out how to auto-vectorize.)

* When I loop over pixels (x,y) but use my own SIMD ops to process all 3 channels in one shot, I get 1514M/sec, very nearly 3x the performance of the scalar case (as we'd hope) and quite close to the ideal 1D auto-vectorized case. (We lose just a bit of performance with the double loop, and the unused SIMD slot.)

* **IBA::mad() is 5x slower**. This is the price we pay for the full generality of handling any combination of data types, any number of channels, potentially overlapping or wrapping image edge conditions, crop windows or channel subsets, in-core as well as ImageCache-based data, and so on.

But at least as far as use in oiiotool is concerned, mad() almost always is dealing with float-only images that are kept in memory (not cached) and are invoked with images that exactly overlap and are operating on all the channels. So I tried special-casing that one situation (which as I said is almost always what will happen in practice), in which we know that each "scanline" will be a contiguous area of memory and can be treated like a 1D array. And it improves:

```
Test ImageBufAlgo::mad 1 thread: 1614.7 Mvals/sec
Test ImageBufAlgo::mad multi-thread 4: 3204.3 Mvals/sec
```

In fact, it improves almost all the way to the "speed of light" case, meaning that calling mad() for the usual case (whole, in-memory, float images, applied to all channels) is almost indistinguishable in speed compared to the "plain 1D arrays, autovectorized" case that knows nothing about ImageBuf's but just does pure math.

Therefore, I think this kind of special case is the approach we should take to speeding up any IBA function that is profiled to be a bottleneck for any operation that people care about.



