### PR TITLE
OIIO_DEPRECATED

### DIFF
--- a/src/include/OpenImageIO/hash.h
+++ b/src/include/OpenImageIO/hash.h
@@ -59,11 +59,11 @@ namespace xxhash {
 // xxhash:  http://code.google.com/p/xxhash/
 // It's BSD licensed.
 
-// DEPRECATED
+OIIO_DEPRECATED("Use XXH32(). (Deprecated since 1.6.")
 unsigned int OIIO_API XXH_fast32 (const void* input, int len,
                                   unsigned int seed=1771);
 
-// DEPRECATED
+OIIO_DEPRECATED("Use XXH32(). (Deprecated since 1.6.")
 unsigned int OIIO_API XXH_strong32 (const void* input, int len,
                                     unsigned int seed=1771);
 
@@ -481,8 +481,9 @@ public:
     template<class T> void append (array_view<T> v) {
         append (v.data(), v.size()*sizeof(T));
     }
-    // DEPRECATED(1.6): appendvec is the old name
-    template<class T> void appendvec (array_view<T> v) {
+
+    template<class T> OIIO_DEPRECATED("Use append(). [1.6]")
+    void appendvec (array_view<T> v) {
         append (v.data(), v.size()*sizeof(T));
     }
 

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -503,7 +503,7 @@ public:
                      stride_t ystride=AutoStride,
                      stride_t zstride=AutoStride);
 
-    /// DEPRECATED (1.6) -- use get_pixels(ROI, ...) instead.
+    OIIO_DEPRECATED("Use get_pixels(ROI, ...) instead. [1.6]")
     bool get_pixel_channels (int xbegin, int xend, int ybegin, int yend,
                              int zbegin, int zend, int chbegin, int chend,
                              TypeDesc format, void *result,
@@ -511,7 +511,7 @@ public:
                              stride_t ystride=AutoStride,
                              stride_t zstride=AutoStride) const;
 
-    /// DEPRECATED (1.6) -- use get_pixels(ROI, ...) instead.
+    OIIO_DEPRECATED("Use get_pixels(ROI, ...) instead. [1.6]")
     bool get_pixels (int xbegin, int xend, int ybegin, int yend,
                      int zbegin, int zend,
                      TypeDesc format, void *result,
@@ -519,16 +519,16 @@ public:
                      stride_t ystride=AutoStride,
                      stride_t zstride=AutoStride) const;
 
-    /// DEPRECATED (1.6) -- use get_pixels(ROI, ...) instead.
     template<typename T>
+    OIIO_DEPRECATED("Use get_pixels(ROI, ...) instead. [1.6]")
     bool get_pixel_channels (int xbegin, int xend, int ybegin, int yend,
                              int zbegin, int zend, int chbegin, int chend,
                              T *result, stride_t xstride=AutoStride,
                              stride_t ystride=AutoStride,
                              stride_t zstride=AutoStride) const;
 
-    /// DEPRECATED (1.6) -- use get_pixels(ROI, ...) instead.
     template<typename T>
+    OIIO_DEPRECATED("Use get_pixels(ROI, ...) instead. [1.6]")
     bool get_pixels (int xbegin, int xend, int ybegin, int yend,
                      int zbegin, int zend, T *result,
                      stride_t xstride=AutoStride, stride_t ystride=AutoStride,
@@ -539,8 +539,8 @@ public:
                                    xstride, ystride, zstride);
     }
 
-    /// DEPRECATED (1.6) -- use get_pixels(ROI, ...) instead.
     template<typename T>
+    OIIO_DEPRECATED("Use get_pixels(ROI, ...) instead. [1.6]")
     bool get_pixels (int xbegin_, int xend_, int ybegin_, int yend_,
                       int zbegin_, int zend_,
                       std::vector<T> &result) const
@@ -682,12 +682,12 @@ public:
     /// Set deep sample value within a pixel, as a uint32.
     void set_deep_value (int x, int y, int z, int c, int s, uint32_t value);
 
-    // DEPRECATED (1.7): old name
+    OIIO_DEPRECATED("Use set_deep_value() [1.7]")
     void set_deep_value_uint (int x, int y, int z, int c, int s, uint32_t value);
 
-    /// DEPRECATED (1.7): no longer necessary
     /// Allocate all the deep samples, called after deepdata()->nsamples
     /// is set.
+    OIIO_DEPRECATED("No longer necessary to call deep_alloc [1.7]")
     void deep_alloc ();
 
     /// Retrieve the "deep" data.
@@ -1158,7 +1158,7 @@ public:
             return const_cast<ImageBuf*>(m_ib)->set_deep_value (m_x, m_y, m_z, c, s, value);
         }
         void set_deep_value (int c, int s, uint32_t value) {
-            return const_cast<ImageBuf*>(m_ib)->set_deep_value_uint (m_x, m_y, m_z, c, s, value);
+            return const_cast<ImageBuf*>(m_ib)->set_deep_value (m_x, m_y, m_z, c, s, value);
         }
 
     };

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -931,7 +931,7 @@ bool OIIO_API colorconvert (ImageBuf &dst, const ImageBuf &src,
                             bool unpremult=false,
                             ColorConfig *colorconfig=NULL,
                             ROI roi=ROI::All(), int nthreads=0);
-// DEPRECATED (1.6)
+OIIO_DEPRECATED("Use the version that takes a ColorConfig*. [1.6]")
 bool OIIO_API colorconvert (ImageBuf &dst, const ImageBuf &src,
                             string_view from, string_view to,
                             bool unpremult, ROI roi, int nthreads=0);
@@ -985,7 +985,7 @@ bool OIIO_API ociolook (ImageBuf &dst, const ImageBuf &src,
                         string_view key="", string_view value="",
                         ColorConfig *colorconfig=NULL,
                         ROI roi=ROI::All(), int nthreads=0);
-// DEPRECATED (1.6)
+OIIO_DEPRECATED("Use the version that takes a ColorConfig*. [1.6]")
 bool OIIO_API ociolook (ImageBuf &dst, const ImageBuf &src,
                         string_view looks, string_view from, string_view to,
                         bool unpremult, bool inverse,
@@ -1016,7 +1016,7 @@ bool OIIO_API ociodisplay (ImageBuf &dst, const ImageBuf &src,
                         string_view key="", string_view value="",
                         ColorConfig *colorconfig=NULL,
                         ROI roi=ROI::All(), int nthreads=0);
-// DEPRECATED (1.6)
+OIIO_DEPRECATED("Use the version that takes a ColorConfig*. [1.6]")
 bool OIIO_API ociodisplay (ImageBuf &dst, const ImageBuf &src,
                         string_view display, string_view view,
                         string_view from, string_view looks,

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -345,7 +345,8 @@ public:
                      TypeDesc format, const void *buffer,
                      stride_t xstride=AutoStride, stride_t ystride=AutoStride,
                      stride_t zstride=AutoStride) = 0;
-    // DEPRECATED(1.6) -- add a tile with all channels.
+
+    OIIO_DEPRECATED("Use the version of add_tile with channel range. [1.6]")
     virtual bool add_tile (ustring filename, int subimage, int miplevel,
                      int x, int y, int z, TypeDesc format, const void *buffer,
                      stride_t xstride=AutoStride, stride_t ystride=AutoStride,

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -282,6 +282,18 @@
 #endif
 
 
+#if OIIO_CPLUSPLUS_VERSION >= 14 || (OIIO_CPLUSPLUS_VERSION >= 11 && __has_attribute(deprecated))
+#  define OIIO_DEPRECATED(msg) [[deprecated(msg)]]
+#elif defined(__GNUC__) && OIIO_GNUC_VERSION >= 40600
+#  define OIIO_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#elif defined(__GNUC__) /* older gcc -- only the one with no message */
+#  define OIIO_DEPRECATED(msg) __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#  define OIIO_DEPRECATED(msg) __declspec(deprecated(msg))
+#else
+#  define OIIO_DEPRECATED(msg)
+#endif
+
 
 // Try to deduce endianness
 #if (defined(_WIN32) || defined(__i386__) || defined(__x86_64__))

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -587,7 +587,8 @@ public:
     virtual bool get_texture_info (TextureHandle *texture_handle,
                           Perthread *thread_info, int subimage,
                           ustring dataname, TypeDesc datatype, void *data) = 0;
-    /// DEPRECATED (1.6.2)
+
+    OIIO_DEPRECATED("Use get_texture_info variety that is passed a Perthread*. [1.6.2]")
     virtual bool get_texture_info (TextureHandle *texture_handle, int subimage,
                           ustring dataname, TypeDesc datatype, void *data) = 0;
 

--- a/src/include/OpenImageIO/timer.h
+++ b/src/include/OpenImageIO/timer.h
@@ -99,8 +99,8 @@ public:
             start();
     }
 
-    /// DEPRECATED Constructor -- reset at zero, and start timing unless
-    /// optional 'startnow' argument is false.
+    /// Constructor -- reset at zero, and start timing unless optional
+    /// 'startnow' argument is false.
     Timer (bool startnow)
         : m_ticking(false), m_printdtr(DontPrintDtr),
           m_starttime(0), m_elapsed_ticks(0),

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -144,7 +144,6 @@ struct OIIO_API TypeDesc {
     /// Construct from a string (e.g., "float[3]").  If no valid
     /// type could be assembled, set base to UNKNOWN.
     TypeDesc (string_view typestring);
-    TypeDesc (const char *typestring);   // DEPRECATED (1.6)
 
     /// Copy constructor.
     TypeDesc (const TypeDesc &t)
@@ -223,7 +222,6 @@ struct OIIO_API TypeDesc {
     /// no valid type could be assembled, return 0 and do not modify
     /// *this.
     size_t fromstring (string_view typestring);
-    size_t fromstring (const char *typestring);   // DEPRECATED (1.6)
 
     /// Compare two TypeDesc values for equality.
     ///

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -734,7 +734,8 @@ public:
     }
 };
 
-typedef ustringPtrIsLess ustringHashIsLess;   // DEPRECATED
+OIIO_DEPRECATED("Use ustringPtrIsLess [1.6]")
+typedef ustringPtrIsLess ustringHashIsLess;
 
 
 

--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -133,13 +133,11 @@ public:
     /// color space correction when indicated.
     void pixel_transform (bool srgb_to_linear, int color_mode, int channel);
 
-    bool get_pixels (int xbegin, int xend, int ybegin, int yend,
-                     TypeDesc format, void *result) {
-        if (m_corrected_image.localpixels ()) {
-            return m_corrected_image.get_pixels (xbegin, xend, ybegin, yend,
-                                                  0, 1, format, result);
-        }
-        return ImageBuf::get_pixels (xbegin, xend, ybegin, yend, 0, 1, format, result);
+    bool get_pixels (ROI roi, TypeDesc format, void *result) {
+        if (m_corrected_image.localpixels ())
+            return m_corrected_image.get_pixels (roi, format, result);
+        else
+            return ImageBuf::get_pixels (roi, format, result);
     }
 
     bool auto_subimage (void) const { return m_auto_subimage; }

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -827,14 +827,15 @@ IvGL::paint_pixelview ()
 
         void *zoombuffer = alloca ((xend-xbegin)*(yend-ybegin)*nchannels*spec.channel_bytes());
         if (! m_use_shaders) {
-            img->get_pixels (spec.x + xbegin, spec.x + xend,
-                             spec.y + ybegin, spec.y + yend,
+            img->get_pixels (ROI (spec.x + xbegin, spec.x + xend,
+                                  spec.y + ybegin, spec.y + yend),
                              spec.format, zoombuffer);
         } else {
-            img->get_pixel_channels (spec.x + xbegin, spec.x + xend,
-                    spec.y + ybegin, spec.y + yend, 0, 1,
-                    m_viewer.current_channel(), m_viewer.current_channel()+nchannels,
-                    spec.format, zoombuffer);
+            ROI roi (spec.x + xbegin, spec.x + xend,
+                     spec.y + ybegin, spec.y + yend,
+                     0, 1,
+                     m_viewer.current_channel(), m_viewer.current_channel()+nchannels);
+            img->get_pixels (roi, spec.format, zoombuffer);
         }
 
         GLenum glformat, gltype, glinternalformat;
@@ -1598,13 +1599,13 @@ IvGL::load_texture (int x, int y, int width, int height, float percent)
     // it safely since ImageBuf has a cache underneath and the whole image
     // may not be resident at once.
     if (! m_use_shaders) {
-        m_current_image->get_pixels (x, x + width, y, y + height,
+        m_current_image->get_pixels (ROI (x, x + width, y, y + height),
                                      spec.format, &m_tex_buffer[0]);
     } else {
-        m_current_image->get_pixel_channels (x, x+width, y, y+height, 0, 1,
-                                             m_viewer.current_channel(),
-                                             m_viewer.current_channel() + nchannels,
-                                             spec.format, &m_tex_buffer[0]);
+        m_current_image->get_pixels (ROI (x, x+width, y, y+height, 0, 1,
+                                          m_viewer.current_channel(),
+                                          m_viewer.current_channel() + nchannels),
+                                     spec.format, &m_tex_buffer[0]);
     }
     if (m_use_pbo) {
         glBindBufferARB (GL_PIXEL_UNPACK_BUFFER_ARB, 

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -941,8 +941,7 @@ ImageBuf::write (ImageOutput *out,
     } else {
         // Backed by ImageCache
         boost::scoped_array<char> tmp (new char [m_spec.image_bytes()]);
-        ok = get_pixels (xbegin(), xend(), ybegin(), yend(), zbegin(), zend(),
-                         m_spec.format, &tmp[0]);
+        ok = get_pixels (roi(), m_spec.format, &tmp[0]);
         ok &= out->write_image (m_spec.format, &tmp[0], as, as, as,
                                 progress_callback, progress_callback_data);
         // FIXME -- not good for huge images.  Instead, we should read

--- a/src/libOpenImageIO/imagebuf_test.cpp
+++ b/src/libOpenImageIO/imagebuf_test.cpp
@@ -319,7 +319,7 @@ test_set_get_pixels ()
     std::cout << " After set:\n";
     print (A);
     float retrieved[2*2*nchans] = { 9,9,9, 9,9,9, 9,9,9, 9,9,9 };
-    A.get_pixels (1, 3, 1, 3, 0, 1, TypeDesc::FLOAT, retrieved);
+    A.get_pixels (ROI(1, 3, 1, 3, 0, 1), TypeDesc::FLOAT, retrieved);
     OIIO_CHECK_ASSERT (0 == memcmp (retrieved, newdata, 2*2*nchans));
 }
 

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -748,7 +748,7 @@ simplePixelHashSHA1 (const ImageBuf &src,
                 SHA1_Update (&sha, src.pixeladdr (roi.xbegin, y, z),
                             (unsigned int) scanline_bytes*(y1-y));
             } else {
-                src.get_pixels (roi.xbegin, roi.xend, y, y1, z, z+1,
+                src.get_pixels (ROI (roi.xbegin, roi.xend, y, y1, z, z+1),
                                 src.spec().format, &tmp[0]);
                 SHA1_Update (&sha, &tmp[0], (unsigned int) scanline_bytes*(y1-y));
             }
@@ -779,7 +779,7 @@ simplePixelHashSHA1 (const ImageBuf &src,
                 sha.Update ((const unsigned char *)src.pixeladdr (roi.xbegin, y, z),
                             (unsigned int) scanline_bytes*(y1-y));
             } else {
-                src.get_pixels (roi.xbegin, roi.xend, y, y1, z, z+1,
+                src.get_pixels (ROI (roi.xbegin, roi.xend, y, y1, z, z+1),
                                 src.spec().format, &tmp[0]);
                 sha.Update (&tmp[0], (unsigned int) scanline_bytes*(y1-y));
             }

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -161,7 +161,6 @@ ImageBufAlgo::crop (ImageBuf &dst, const ImageBuf &src,
         ImageBuf::ConstIterator<float> s (src, roi);
         for (ImageBuf::Iterator<float> d (dst, roi);  !d.done();  ++d, ++s)
             d.set_deep_samples (s.deep_samples());
-        dst.deep_alloc ();
     }
 
     bool ok;
@@ -747,7 +746,6 @@ ImageBufAlgo::channels (ImageBuf &dst, const ImageBuf &src,
         // The earlier dst.alloc() already called dstdata.init()
         for (int p = 0, npels = (int)newspec.image_pixels(); p < npels; ++p)
             dstdata.set_samples (p, srcdata.samples(p));
-        dst.deep_alloc ();
         for (int p = 0, npels = (int)newspec.image_pixels(); p < npels; ++p) {
             if (! dstdata.samples(p))
                 continue;   // no samples for this pixel

--- a/src/libOpenImageIO/imagebufalgo_deep.cpp
+++ b/src/libOpenImageIO/imagebufalgo_deep.cpp
@@ -265,8 +265,6 @@ ImageBufAlgo::deepen (ImageBuf &dst, const ImageBuf &src, float zvalue,
             dst.set_deep_samples (x, y, z, 1);
     }
 
-    dst.deep_alloc ();
-
     // Now actually set the values
     for (int z = roi.zbegin; z < roi.zend; ++z)
     for (int y = roi.ybegin; y < roi.yend; ++y)

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -817,7 +817,7 @@ ImageCacheFile::read_unmipped (ImageCachePerThreadInfo *thread_info,
     }
 
     // Now convert and copy those values out to the caller's buffer
-    lores.get_pixels (0, tw, 0, th, 0, 1, format, data);
+    lores.get_pixels (ROI (0, tw, 0, th, 0, 1, chbegin, chend), format, data);
 
     // Restore the microcache to the way it was before.
     thread_info->tile = oldtile;

--- a/src/libutil/hash_test.cpp
+++ b/src/libutil/hash_test.cpp
@@ -113,17 +113,6 @@ test_bjhash_big_words ()
 
 
 size_t
-test_xxhash_fast32 (const void *ptr, size_t len)
-{
-    size_t a = 0;
-    for (int i = 0, e = iterations/len;  i < e;  ++i)
-        a += xxhash::XXH_fast32 (ptr, len);
-    return a;
-}
-
-
-
-size_t
 test_xxhash (const void *ptr, size_t len)
 {
     size_t a = 0;
@@ -260,16 +249,6 @@ int main (int argc, char *argv[])
               << Strutil::timeintervalformat(t, 2) << "\n";
     t = time_trial (boost::bind(test_farmhashchar, longstring.c_str()), ntrials);
     std::cout << "farmhash of long char*: "
-              << Strutil::timeintervalformat(t, 2) << "\n";
-
-    t = time_trial (boost::bind(test_xxhash_fast32, shortstring.c_str(), shortstring.length()), ntrials);
-    std::cout << "xxhash fast32 of short string: "
-              << Strutil::timeintervalformat(t, 2) << "\n";
-    t = time_trial (boost::bind(test_xxhash_fast32, medstring.c_str(), medstring.length()), ntrials);
-    std::cout << "xxhash fast32 of medium string: "
-              << Strutil::timeintervalformat(t, 2) << "\n";
-    t = time_trial (boost::bind(test_xxhash_fast32, longstring.c_str(), longstring.length()), ntrials);
-    std::cout << "xxhash fast32 of long string: "
               << Strutil::timeintervalformat(t, 2) << "\n";
 
     t = time_trial (boost::bind(test_xxhash, shortstring.c_str(), shortstring.length()), ntrials);

--- a/src/libutil/timer_test.cpp
+++ b/src/libutil/timer_test.cpp
@@ -118,8 +118,8 @@ main (int argc, char **argv)
 #endif
 
     // Verify that Timer(false) doesn't start
-    Timer all(true);
-    Timer selective(false);
+    Timer all (Timer::StartNow);
+    Timer selective (Timer::DontStartNow);
     Sysutil::usleep (interval);
     OIIO_CHECK_EQUAL_THRESH (selective(), 0.0, eps);
     OIIO_CHECK_EQUAL_THRESH (all(),       0.1, eps);

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -52,15 +52,6 @@ TypeDesc::TypeDesc (string_view typestring)
 
 
 
-TypeDesc::TypeDesc (const char *typestring)
-    : basetype(UNKNOWN), aggregate(SCALAR), vecsemantics(NOXFORM),
-      reserved(0), arraylen(0)
-{
-    fromstring (typestring);
-}
-
-
-
 namespace {
 
 static int basetype_size[] = {
@@ -240,14 +231,6 @@ copy_until (const char *src, const char *delim, char *dst, size_t maxlen)
     }
     dst[i] = 0;
     return i;
-}
-
-
-
-size_t
-TypeDesc::fromstring (const char *typestring)
-{
-    return fromstring (string_view(typestring));
 }
 
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -118,8 +118,8 @@ static Oiiotool ot;
 Oiiotool::Oiiotool ()
     : imagecache(NULL),
       return_value (EXIT_SUCCESS),
-      total_readtime (false /*don't start timer*/),
-      total_writetime (false /*don't start timer*/),
+      total_readtime (Timer::DontStartNow),
+      total_writetime (Timer::DontStartNow),
       total_imagecache_readtime (0.0),
       enable_function_timing(true)
 {

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -393,6 +393,13 @@ ImageBuf_deepdataref (ImageBuf *ib)
 
 
 
+static void
+ImageBuf_deep_alloc_dummy ()
+{
+}
+
+
+
 void declare_imagebuf()
 {
     enum_<ImageBuf::WrapMode>("WrapMode")
@@ -522,7 +529,7 @@ void declare_imagebuf()
         .def("set_deep_value_uint", &ImageBuf_set_deep_value_uint,
              (arg("x"), arg("y"), arg("z")=0, arg("channel"),
               arg("sample"), arg("value")=0))
-        .def("deep_alloc", &ImageBuf::deep_alloc)  // DEPRECATED(1.7)
+        .def("deep_alloc", &ImageBuf_deep_alloc_dummy)  // DEPRECATED(1.7)
         .def("deepdata", &ImageBuf_deepdataref,
              return_value_policy<reference_existing_object>())
 

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -917,8 +917,8 @@ IBA_colorconvert (ImageBuf &dst, const ImageBuf &src,
                   ROI roi = ROI::All(), int nthreads = 0)
 {
     ScopedGILRelease gil;
-    return ImageBufAlgo::colorconvert (dst, src, from.c_str(), to.c_str(),
-                                       unpremult, roi, nthreads);
+    return ImageBufAlgo::colorconvert (dst, src, from, to,
+                                       unpremult, NULL, roi, nthreads);
 }
 
 
@@ -931,8 +931,8 @@ IBA_colorconvert_colorconfig (ImageBuf &dst, const ImageBuf &src,
 {
     ColorConfig config (colorconfig);
     ScopedGILRelease gil;
-    return ImageBufAlgo::colorconvert (dst, src, from.c_str(), to.c_str(),
-                                       unpremult, &config, roi, nthreads);
+    return ImageBufAlgo::colorconvert (dst, src, from, to, unpremult,
+                                       &config, roi, nthreads);
 }
 
 
@@ -945,10 +945,9 @@ IBA_ociolook (ImageBuf &dst, const ImageBuf &src, const std::string &looks,
               ROI roi = ROI::All(), int nthreads = 0)
 {
     ScopedGILRelease gil;
-    return ImageBufAlgo::ociolook (dst, src, looks.c_str(),
-                                   from.c_str(), to.c_str(),
+    return ImageBufAlgo::ociolook (dst, src, looks, from, to,
                                    inverse, unpremult,
-                                   context_key.c_str(), context_value.c_str(),
+                                   context_key, context_value, NULL,
                                    roi, nthreads);
 }
 
@@ -964,10 +963,9 @@ IBA_ociolook_colorconfig (ImageBuf &dst, const ImageBuf &src, const std::string 
 {
     ColorConfig config (colorconfig);
     ScopedGILRelease gil;
-    return ImageBufAlgo::ociolook (dst, src, looks.c_str(),
-                                   from.c_str(), to.c_str(),
+    return ImageBufAlgo::ociolook (dst, src, looks, from, to,
                                    inverse, unpremult,
-                                   context_key.c_str(), context_value.c_str(),
+                                   context_key, context_value,
                                    &config, roi, nthreads);
 }
 
@@ -991,7 +989,7 @@ IBA_ociodisplay (ImageBuf &dst, const ImageBuf &src,
                                       from == object() ? NULL : from_str.c_str(),
                                       looks == object() ? NULL : looks_str.c_str(),
                                       unpremult,
-                                      context_key.c_str(), context_value.c_str(),
+                                      context_key, context_value, NULL,
                                       roi, nthreads);
 }
 
@@ -1016,8 +1014,7 @@ IBA_ociodisplay_colorconfig (ImageBuf &dst, const ImageBuf &src,
     return ImageBufAlgo::ociodisplay (dst, src, display.c_str(), view.c_str(),
                                       from == object() ? NULL : from_str.c_str(),
                                       looks == object() ? NULL : looks_str.c_str(),
-                                      unpremult,
-                                      context_key.c_str(), context_value.c_str(),
+                                      unpremult, context_key, context_value,
                                       &config, roi, nthreads);
 }
 

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -1058,7 +1058,8 @@ test_icwrite (int testicwrite)
                         tile[index+1] = float(yy)/spec.height;
                         tile[index+2] = (!(xx%10) || !(yy%10)) ? 1.0f : 0.0f;
                     }
-                bool ok = ic->add_tile (filename, 0, 0, tx, ty, 0, TypeDesc::FLOAT, &tile[0]);
+                bool ok = ic->add_tile (filename, 0, 0, tx, ty, 0, 0, -1,
+                                        TypeDesc::FLOAT, &tile[0]);
                 if (! ok)
                     std::cout << "ic->add_tile error: " << ic->geterror() << "\n";
                 ASSERT (ok);


### PR DESCRIPTION
Mimics this PR from OSL: https://github.com/imageworks/OpenShadingLanguage/pull/602

Start marking deprecated things in public APIs as OIIO_DEPRECATED, and then it will generate warnings (hopefully with helpful tips for what to use instead) when apps use the deprecated calls.
