### PR TITLE
iinfo/oiiotool -info : more clearly print subimage formats

### DIFF
--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -421,6 +421,27 @@ extended_format_name (TypeDesc type, int bits)
 
 
 
+static const char *
+brief_format_name (TypeDesc type, int bits=0)
+{
+    if (! bits)
+        bits = (int)type.size()*8;
+    if (type.is_floating_point()) {
+        if (type.basetype == TypeDesc::FLOAT)
+            return "f";
+        if (type.basetype == TypeDesc::HALF)
+            return "h";
+        return ustring::format("f%d", bits).c_str();
+    } else if (type.is_signed()) {
+        return ustring::format("i%d", bits).c_str();
+    } else {
+        return ustring::format("u%d", bits).c_str();
+    }
+    return type.c_str();  // use the name implied by type
+}
+
+
+
 // prints basic info (resolution, width, height, depth, channels, data format,
 // and format name) about given subimage.
 static void
@@ -571,10 +592,19 @@ print_info (const std::string &filename, size_t namefieldlength,
         printf ("    %d subimages: ", num_of_subimages);
         for (int i = 0; i < num_of_subimages; ++i) {
             input->seek_subimage (i, 0, spec);
+            int bits = spec.get_int_attribute ("oiio:BitsPerSample",
+                                               spec.format.size()*8);
+            if (i)
+                printf (", ");
             if (spec.depth > 1)
                 printf ("%dx%dx%d ", spec.width, spec.height, spec.depth);
             else
                 printf ("%dx%d ", spec.width, spec.height);
+            // printf ("[");
+            for (int c = 0; c < spec.nchannels; ++c)
+                printf ("%c%s", c ? ',' : '[',
+                        brief_format_name(spec.channelformat(c), bits));
+            printf ("]");
             if (movie)
                 break;
         }

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -217,6 +217,9 @@ struct OIIO_API TypeDesc {
     /// integral type or something else like a string).
     bool is_floating_point () const;
 
+    /// True if it's a signed type that allows for negative values.
+    bool is_signed () const;
+
     /// Set *this to the type described in the string.  Return the
     /// length of the part of the string that describes the type.  If
     /// no valid type could be assembled, return 0 and do not modify

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -111,6 +111,33 @@ TypeDesc::is_floating_point () const
 
 
 
+bool
+TypeDesc::is_signed () const
+{
+    static bool issigned[] = {
+        0, // UNKNOWN
+        0, // VOID
+        0, // UCHAR
+        1, // CHAR
+        0, // USHORT
+        1, // SHORT
+        0, // UINT
+        1, // INT
+        0, // ULONGLONG
+        1, // LONGLONG
+        1, // HALF
+        1, // FLOAT
+        1, // DOUBLE
+        0, // STRING
+        0  // PTR
+    };
+    DASSERT (sizeof(issigned)/sizeof(issigned[0]) == TypeDesc::LASTBASE);
+    DASSERT (basetype < TypeDesc::LASTBASE);
+    return issigned[basetype];
+}
+
+
+
 namespace {
 
 static const char * basetype_name[] = {

--- a/testsuite/dpx/ref/out.txt
+++ b/testsuite/dpx/ref/out.txt
@@ -84,7 +84,7 @@ Comparing "input_rgb_mattes.tif" and "output_rgb_mattes.dpx"
 PASS
 Reading stereo.dpx
 stereo.dpx           :   80 x   60, 3 channel, uint10 dpx
-    2 subimages: 80x60 80x60 
+    2 subimages: 80x60 [u10,u10,u10], 80x60 [u10,u10,u10]
  subimage  0:   80 x   60, 3 channel, uint10 dpx
     channel list: R, G, B
     oiio:BitsPerSample: 10

--- a/testsuite/gif/ref/out.txt
+++ b/testsuite/gif/ref/out.txt
@@ -1,6 +1,6 @@
 Reading ../../../../../oiio-images/gif_animation.gif
 ../../../../../oiio-images/gif_animation.gif :   30 x   30, 4 channel, uint8 gif
-    3 subimages: 30x30 
+    3 subimages: 30x30 [u8,u8,u8,u8]
  subimage  0:   30 x   30, 4 channel, uint8 gif
     SHA-1: DDECBD8686D4C2BCB43C2AA05F75C5BDB1CAF54B
     channel list: R, G, B, A
@@ -61,7 +61,7 @@ Reading ../../../../../oiio-images/gif_triangle_interlaced.gif
     gif:Interlacing: 1
 Reading ../../../../../oiio-images/gif_test_disposal_method.gif
 ../../../../../oiio-images/gif_test_disposal_method.gif :   50 x   50, 4 channel, uint8 gif
-    4 subimages: 50x50 50x50 50x50 50x50 
+    4 subimages: 50x50 [u8,u8,u8,u8], 50x50 [u8,u8,u8,u8], 50x50 [u8,u8,u8,u8], 50x50 [u8,u8,u8,u8]
  subimage  0:   50 x   50, 4 channel, uint8 gif
     SHA-1: 30839F361083DA6893F6A29B4F4628DCFBF9F1B5
     channel list: R, G, B, A

--- a/testsuite/ico/ref/out.txt
+++ b/testsuite/ico/ref/out.txt
@@ -1,6 +1,6 @@
 Reading ../../../../../oiio-images/oiio.ico
 ../../../../../oiio-images/oiio.ico :   16 x   16, 4 channel, uint1 ico
-    10 subimages: 16x16 32x32 16x16 48x48 32x32 16x16 256x256 48x48 32x32 16x16 
+    10 subimages: 16x16 [u1,u1,u1,u1], 32x32 [u2,u2,u2,u2], 16x16 [u2,u2,u2,u2], 48x48 [u3,u3,u3,u3], 32x32 [u3,u3,u3,u3], 16x16 [u3,u3,u3,u3], 256x256 [u2,u2,u2,u2], 48x48 [u8,u8,u8,u8], 32x32 [u8,u8,u8,u8], 16x16 [u8,u8,u8,u8]
  subimage  0:   16 x   16, 4 channel, uint1 ico
     SHA-1: 563F978D0860CB8791716CA694AB94EEA83E6E03
     channel list: R, G, B, A

--- a/testsuite/openexr-v2/ref/out.txt
+++ b/testsuite/openexr-v2/ref/out.txt
@@ -1,6 +1,6 @@
 Reading ../../../../../openexr-images/v2/Stereo/composited.exr
 ../../../../../openexr-images/v2/Stereo/composited.exr : 1918 x 1078, 4 channel, half openexr
-    4 subimages: 1918x1078 1918x1078 1918x1078 1918x1078 
+    4 subimages: 1918x1078 [h,h,h,h], 1918x1078 [h], 1918x1078 [h,h,h,h], 1918x1078 [h]
  subimage  0: 1918 x 1078, 4 channel, half openexr
     SHA-1: 95EDAC421BCDE17EFB4DA1078E13DCC322D56608
     channel list: R, G, B, A
@@ -80,7 +80,7 @@ Comparing "../../../../../openexr-images/v2/Stereo/composited.exr" and "composit
 PASS
 Reading ../../../../../openexr-images/v2/Stereo/Balls.exr
 ../../../../../openexr-images/v2/Stereo/Balls.exr : 1431 x  761, 5 channel, deep half/half/half/half/float openexr
-    2 subimages: 1431x761 1452x761 
+    2 subimages: 1431x761 [h,h,h,h,f], 1452x761 [h,h,h,h,f]
  subimage  0: 1431 x  761, 5 channel, deep half/half/half/half/float openexr
     SHA-1: C68EB6A304F07B78F480E6FCDBA07BF9028E3305
     channel list: R (half), G (half), B (half), A (half), Z (float)
@@ -140,7 +140,7 @@ Comparing "../../../../../openexr-images/v2/Stereo/Balls.exr" and "Balls.exr"
 PASS
 Reading ../../../../../openexr-images/v2/Stereo/Leaves.exr
 ../../../../../openexr-images/v2/Stereo/Leaves.exr : 1920 x 1080, 5 channel, deep half/half/half/half/float openexr
-    2 subimages: 1920x1080 1920x1080 
+    2 subimages: 1920x1080 [h,h,h,h,f], 1920x1080 [h,h,h,h,f]
  subimage  0: 1920 x 1080, 5 channel, deep half/half/half/half/float openexr
     SHA-1: 63932A1F4D607129054D80A4361176BA54955E90
     channel list: R (half), G (half), B (half), A (half), Z (float)

--- a/testsuite/psd/ref/out-alt.txt
+++ b/testsuite/psd/ref/out-alt.txt
@@ -1,6 +1,6 @@
 Reading ../../../../../oiio-images/psd_123.psd
 ../../../../../oiio-images/psd_123.psd :  257 x  126, 4 channel, uint8 psd
-    4 subimages: 257x126 33x98 63x100 61x102 
+    4 subimages: 257x126 [u8,u8,u8,u8], 33x98 [u8,u8,u8,u8], 63x100 [u8,u8,u8,u8], 61x102 [u8,u8,u8,u8]
  subimage  0:  257 x  126, 4 channel, uint8 psd
     SHA-1: F7A1BCAC9115D886FC6D6C23639529955D74DD58
     channel list: R, G, B, A
@@ -119,7 +119,7 @@ Reading ../../../../../oiio-images/psd_123.psd
     PixelAspectRatio: 1
 Reading ../../../../../oiio-images/psd_123_nomaxcompat.psd
 ../../../../../oiio-images/psd_123_nomaxcompat.psd :  257 x  126, 3 channel, uint8 psd
-    4 subimages: 257x126 33x98 63x100 61x102 
+    4 subimages: 257x126 [u8,u8,u8], 33x98 [u8,u8,u8,u8], 63x100 [u8,u8,u8,u8], 61x102 [u8,u8,u8,u8]
  subimage  0:  257 x  126, 3 channel, uint8 psd
     SHA-1: 5A7BDC7A11A9E4BDCBEC968375EE466DE74D0481
     channel list: R, G, B
@@ -604,7 +604,7 @@ Reading ../../../../../oiio-images/psd_rgb_32.psd
     PixelAspectRatio: 1
 Reading ../../../../../oiio-images/psd_rgba_8.psd
 ../../../../../oiio-images/psd_rgba_8.psd :  320 x  240, 4 channel, uint8 psd
-    2 subimages: 320x240 320x240 
+    2 subimages: 320x240 [u8,u8,u8,u8], 320x240 [u8,u8,u8,u8]
  subimage  0:  320 x  240, 4 channel, uint8 psd
     SHA-1: 9519DFB5CDF4D8BAC10A20EAE6433A9216885F9D
     channel list: R, G, B, A

--- a/testsuite/psd/ref/out.txt
+++ b/testsuite/psd/ref/out.txt
@@ -1,6 +1,6 @@
 Reading ../../../../../oiio-images/psd_123.psd
 ../../../../../oiio-images/psd_123.psd :  257 x  126, 4 channel, uint8 psd
-    4 subimages: 257x126 33x98 63x100 61x102 
+    4 subimages: 257x126 [u8,u8,u8,u8], 33x98 [u8,u8,u8,u8], 63x100 [u8,u8,u8,u8], 61x102 [u8,u8,u8,u8]
  subimage  0:  257 x  126, 4 channel, uint8 psd
     SHA-1: F7A1BCAC9115D886FC6D6C23639529955D74DD58
     channel list: R, G, B, A
@@ -119,7 +119,7 @@ Reading ../../../../../oiio-images/psd_123.psd
     PixelAspectRatio: 1
 Reading ../../../../../oiio-images/psd_123_nomaxcompat.psd
 ../../../../../oiio-images/psd_123_nomaxcompat.psd :  257 x  126, 3 channel, uint8 psd
-    4 subimages: 257x126 33x98 63x100 61x102 
+    4 subimages: 257x126 [u8,u8,u8], 33x98 [u8,u8,u8,u8], 63x100 [u8,u8,u8,u8], 61x102 [u8,u8,u8,u8]
  subimage  0:  257 x  126, 3 channel, uint8 psd
     SHA-1: 5A7BDC7A11A9E4BDCBEC968375EE466DE74D0481
     channel list: R, G, B
@@ -604,7 +604,7 @@ Reading ../../../../../oiio-images/psd_rgb_32.psd
     PixelAspectRatio: 1
 Reading ../../../../../oiio-images/psd_rgba_8.psd
 ../../../../../oiio-images/psd_rgba_8.psd :  320 x  240, 4 channel, uint8 psd
-    2 subimages: 320x240 320x240 
+    2 subimages: 320x240 [u8,u8,u8,u8], 320x240 [u8,u8,u8,u8]
  subimage  0:  320 x  240, 4 channel, uint8 psd
     SHA-1: 9519DFB5CDF4D8BAC10A20EAE6433A9216885F9D
     channel list: R, G, B, A

--- a/testsuite/ptex/ref/out.txt
+++ b/testsuite/ptex/ref/out.txt
@@ -1,6 +1,6 @@
 Reading src/triangle.ptx
 src/triangle.ptx     :    4 x    4, 3 channel, float ptex
-    9 subimages: 4x4 4x4 4x4 4x4 4x4 4x4 4x4 4x4 4x4 
+    9 subimages: 4x4 [f,f,f], 4x4 [f,f,f], 4x4 [f,f,f], 4x4 [f,f,f], 4x4 [f,f,f], 4x4 [f,f,f], 4x4 [f,f,f], 4x4 [f,f,f], 4x4 [f,f,f]
  subimage  0:    4 x    4, 3 channel, float ptex
     MIP-map levels: 4x4 2x2 1x1
     SHA-1: 7BC2F942597DAEB92D3E51C8C72EA9C957F5A891

--- a/testsuite/tiff-suite/ref/out-alt.txt
+++ b/testsuite/tiff-suite/ref/out-alt.txt
@@ -33,7 +33,7 @@ Comparing "../../../../../libtiffpic/cramps-tile.tif" and "../../../../../libtif
 PASS
 Reading ../../../../../libtiffpic/dscf0013.tif
 ../../../../../libtiffpic/dscf0013.tif :  640 x  480, 3 channel, uint8 tiff
-    2 subimages: 640x480 160x120 
+    2 subimages: 640x480 [u8,u8,u8], 160x120 [u8,u8,u8]
  subimage  0:  640 x  480, 3 channel, uint8 tiff
     SHA-1: 5A28EA8AB0FD8E03EA11BF008E842CFEB42A9716
     channel list: R, G, B

--- a/testsuite/tiff-suite/ref/out.txt
+++ b/testsuite/tiff-suite/ref/out.txt
@@ -33,7 +33,7 @@ Comparing "../../../../../libtiffpic/cramps-tile.tif" and "../../../../../libtif
 PASS
 Reading ../../../../../libtiffpic/dscf0013.tif
 ../../../../../libtiffpic/dscf0013.tif :  640 x  480, 3 channel, uint8 tiff
-    2 subimages: 640x480 160x120 
+    2 subimages: 640x480 [u8,u8,u8], 160x120 [u8,u8,u8]
  subimage  0:  640 x  480, 3 channel, uint8 tiff
     SHA-1: 5A28EA8AB0FD8E03EA11BF008E842CFEB42A9716
     channel list: R, G, B


### PR DESCRIPTION
Something I fixed up during recent debugging -- more clear printing of the number of channels and formats, when summarizing the different subimages.