### PR TITLE
SIMD additions

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -267,10 +267,29 @@ public:
     }
 
     /// Return a mask4 the is 'false' for all values
-    static OIIO_FORCEINLINE const mask4 False () { return mask4(false); }
+    static OIIO_FORCEINLINE const mask4 False () {
+#if defined(OIIO_SIMD_SSE)
+        return _mm_setzero_ps();
+#else
+        return mask4(false);
+#endif
+    }
 
     /// Return a mask4 the is 'true' for all values
-    static OIIO_FORCEINLINE const mask4 True () { return mask4(true); }
+    static OIIO_FORCEINLINE const mask4 True () {
+#if defined(OIIO_SIMD_SSE)
+        // Fastest way to fill an __m128 with all 1 bits is to cmpeq_epi8
+        // any value to itself.
+# if defined(OIIO_SIMD_AVX)
+        __m128i anyval = _mm_castps_si128 (_mm_undefined_si128());
+# else
+        __m128i anyval = _mm_castps_si128 (_mm_setzero_ps());
+# endif
+        return _mm_castsi128_ps (_mm_cmpeq_epi8 (anyval, anyval));
+#else
+        return mask4(true);
+#endif
+    }
 
     /// Assign one value to all components
     OIIO_FORCEINLINE const mask4 & operator= (bool a) { load(a); return *this; }
@@ -389,6 +408,40 @@ public:
     }
     OIIO_FORCEINLINE const mask4& operator|= (const mask4 & a) {
         return *this = *this | a;
+    }
+
+    friend OIIO_FORCEINLINE mask4 operator^ (const mask4& a, const mask4& b) {
+#if defined(OIIO_SIMD_SSE)
+        return _mm_xor_ps (a.m_vec, b.m_vec);
+#else
+        return mask4 (a.m_val[0] ^ b.m_val[0],
+                      a.m_val[1] ^ b.m_val[1],
+                      a.m_val[2] ^ b.m_val[2],
+                      a.m_val[3] ^ b.m_val[3]);
+#endif
+    }
+    OIIO_FORCEINLINE const mask4 & operator^= (const mask4& a) {
+        return *this = *this ^ a;
+    }
+
+    OIIO_FORCEINLINE mask4 operator~ () {
+#if defined(OIIO_SIMD_SSE)
+        // Fastest way to bit-complement in SSE is to xor with 0xffffffff.
+        // Fastest way to fill an __m128 with all 1 bits is to cmpeq_epi8
+        // any value to itself.
+# if defined(OIIO_SIMD_AVX)
+        __m128i anyval = _mm_undefined_si128(); // AVX only, sigh
+# else
+        __m128i anyval = _mm_castps_si128 (m_vec);
+# endif
+        __m128 all_one_bits = _mm_castsi128_ps (_mm_cmpeq_epi8 (anyval, anyval));
+        return _mm_xor_ps (m_vec, all_one_bits);
+#else
+        return mask4 (~(m_val[0]),
+                      ~(m_val[1]),
+                      ~(m_val[2]),
+                      ~(m_val[3]));
+#endif
     }
 
     /// Equality comparison, component by component
@@ -594,6 +647,22 @@ public:
 
     /// Return an int4 with all components set to 1
     static OIIO_FORCEINLINE const int4 One () { return int4(1); }
+
+    /// Return an int4 with all components set to -1 (aka 0xffffffff)
+    static OIIO_FORCEINLINE const int4 NegOne () {
+#if defined(OIIO_SIMD_SSE)
+        // Fastest way to fill an __m128 with all 1 bits is to cmpeq_epi8
+        // any value to itself.
+# if defined(OIIO_SIMD_AVX)
+        __m128i anyval = _mm_castps_si128 (_mm_undefined_si128());
+# else
+        __m128i anyval = _mm_castps_si128 (_mm_setzero_ps());
+# endif
+        return _mm_cmpeq_epi8 (anyval, anyval);
+#else
+        return int4(-1);
+#endif
+    }
 
     /// Return an int4 with incremented components (e.g., 0,1,2,3).
     /// Optional argument can give a non-zero starting point.
@@ -984,6 +1053,26 @@ public:
     }
     OIIO_FORCEINLINE const int4 & operator^= (const int4& a) {
         return *this = *this ^ a;
+    }
+
+    OIIO_FORCEINLINE int4 operator~ () {
+#if defined(OIIO_SIMD_SSE)
+        // Fastest way to bit-complement in SSE is to xor with 0xffffffff.
+        // Fastest way to fill an __m128 with all 1 bits is to cmpeq_epi8
+        // any value to itself.
+# if defined(OIIO_SIMD_AVX)
+        __m128i anyval = _mm_undefined_si128(); // AVX only, sigh
+        __m128i all_one_bits = _mm_cmpeq_epi8 (anyval, anyval);
+# else
+        __m128i all_one_bits = _mm_cmpeq_epi8 (m_vec, m_vec);
+# endif
+        return _mm_xor_si128 (m_vec, all_one_bits);
+#else
+        return int4 (~(m_val[0]),
+                     ~(m_val[1]),
+                     ~(m_val[2]),
+                     ~(m_val[3]));
+#endif
     }
 
     OIIO_FORCEINLINE int4 operator<< (const unsigned int bits) const {

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -210,6 +210,37 @@ void test_arithmetic ()
 
 
 
+void test_bitwise_int4 ()
+{
+    typedef int4 VEC;
+    typedef int ELEM;
+    std::cout << "test_bitwise " << VEC::type_name() << "\n";
+
+    OIIO_CHECK_SIMD_EQUAL (VEC(0x12341234) & VEC(0x11111111), VEC(0x10101010));
+    OIIO_CHECK_SIMD_EQUAL (VEC(0x12341234) | VEC(0x11111111), VEC(0x13351335));
+    OIIO_CHECK_SIMD_EQUAL (VEC(0x12341234) ^ VEC(0x11111111), VEC(0x03250325));
+    OIIO_CHECK_SIMD_EQUAL (~(VEC(0x12341234)), VEC(0xedcbedcb));
+}
+
+
+
+void test_bitwise_mask4 ()
+{
+    typedef mask4 VEC;
+    typedef int ELEM;
+    std::cout << "test_bitwise " << VEC::type_name() << "\n";
+
+    OIIO_CHECK_SIMD_EQUAL (VEC(true, true, false, false) & VEC(true, false, true, false),
+                           VEC(true, false, false, false));
+    OIIO_CHECK_SIMD_EQUAL (VEC(true, true, false, false) | VEC(true, false, true, false),
+                           VEC(true, true, true, false));
+    OIIO_CHECK_SIMD_EQUAL (VEC(true, true, false, false) ^ VEC(true, false, true, false),
+                           VEC(false, true, true, false));
+    OIIO_CHECK_SIMD_EQUAL (~(VEC(true, true, false, false)), VEC(false, false, true, true));
+}
+
+
+
 template<typename VEC>
 void test_comparisons ()
 {
@@ -353,6 +384,23 @@ void test_vectorops ()
 
 
 
+void test_constants ()
+{
+    std::cout << "test_constants\n";
+
+    OIIO_CHECK_SIMD_EQUAL (mask4::False(), mask4(false));
+    OIIO_CHECK_SIMD_EQUAL (mask4::True(), mask4(true));
+
+    OIIO_CHECK_SIMD_EQUAL (int4::Zero(), int4(0));
+    OIIO_CHECK_SIMD_EQUAL (int4::One(), int4(1));
+    OIIO_CHECK_SIMD_EQUAL (int4::NegOne(), int4(-1));
+
+    OIIO_CHECK_SIMD_EQUAL (float4::Zero(), float4(0.0f));
+    OIIO_CHECK_SIMD_EQUAL (float4::One(), float4(1.0f));
+}
+
+
+
 // Miscellaneous one-off stuff not caught by other tests
 void test_special ()
 {
@@ -404,6 +452,7 @@ main (int argc, char *argv[])
     test_loadstore<int4> ();
     test_component_access<int4> ();
     test_arithmetic<int4> ();
+    test_bitwise_int4 ();
     test_comparisons<int4> ();
     test_shuffle<int4> ();
     test_swizzle<float4> ();
@@ -414,7 +463,9 @@ main (int argc, char *argv[])
     std::cout << "\n";
     test_shuffle<mask4> ();
     test_component_access<mask4> ();
+    test_bitwise_mask4 ();
 
+    test_constants();
     test_special();
 
     return unit_test_failures;

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -168,6 +168,30 @@ void test_component_access ()
 
 
 
+template<>
+void test_component_access<mask4> ()
+{
+    typedef mask4 VEC;
+    typedef typename VEC::value_t ELEM;
+    std::cout << "test_component_access " << VEC::type_name() << "\n";
+
+    VEC a (false, true, true, true);
+    OIIO_CHECK_EQUAL (bool(a[0]), false);
+    OIIO_CHECK_EQUAL (bool(a[1]), true);
+    OIIO_CHECK_EQUAL (bool(a[2]), true);
+    OIIO_CHECK_EQUAL (bool(a[3]), true);
+    OIIO_CHECK_EQUAL (extract<0>(a), false);
+    OIIO_CHECK_EQUAL (extract<1>(a), true);
+    OIIO_CHECK_EQUAL (extract<2>(a), true);
+    OIIO_CHECK_EQUAL (extract<3>(a), true);
+    OIIO_CHECK_SIMD_EQUAL (insert<0>(a, ELEM(true)), VEC(true,true,true,true));
+    OIIO_CHECK_SIMD_EQUAL (insert<1>(a, ELEM(false)), VEC(false,false,true,true));
+    OIIO_CHECK_SIMD_EQUAL (insert<2>(a, ELEM(false)), VEC(false,true,false,true));
+    OIIO_CHECK_SIMD_EQUAL (insert<3>(a, ELEM(false)), VEC(false,true,true,false));
+}
+
+
+
 template<typename VEC>
 void test_arithmetic ()
 {
@@ -389,6 +413,7 @@ main (int argc, char *argv[])
 
     std::cout << "\n";
     test_shuffle<mask4> ();
+    test_component_access<mask4> ();
 
     test_special();
 


### PR DESCRIPTION
Define insert and extract for mask4 (already existed for float4 & int4).

Add xor for mask4 (int4 already had it).

Add bitwise complement for int4 and mask4.

Efficient int4::NegOne()

