### PR TITLE
Tighten up error reporting

### DIFF
--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -477,6 +477,8 @@ ImageInput::read_tiles (int xbegin, int xend, int ybegin, int yend,
                     // per-tile data format conversion.
                     ok &= read_tile (x, y, z, format, tilestart,
                                      xstride, ystride, zstride);
+                    if (! ok)
+                        return false;
                 } else {
                     buf.resize (full_tilebytes);
                     ok &= read_tile (x, y, z, 

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -544,6 +544,12 @@ public:
             ir[0]->update_spec_from_imagebuf (s);
         }
 
+        // Make sure to forward any errors missed by the impl
+        for (int i = 0; i < nimages(); ++i) {
+            if (img[i]->has_error())
+                ot.error (opname(), img[i]->geterror());
+        }
+
         // Optional cleanup after processing all the subimages
         cleanup ();
 

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -263,10 +263,11 @@ print_stats (Oiiotool &ot,
         ot.error ("stats", input.geterror());
         return;
     }
-    
     PixelStats stats;
     if (! computePixelStats (stats, input)) {
-        ot.error ("stats", "unable to compute");
+        std::string err = input.geterror();
+        ot.error ("stats", Strutil::format ("unable to compute: %s",
+                                            err.empty() ? "unspecified error" : err.c_str()));
         return;
     }
     


### PR DESCRIPTION
A cascade of things we noticed when reading exr files with missing tile errors...

* For EXR read_tiles, neglecting to take an early out when the read fails (as we did for read_tile, read_scanline, read_scanlines) caused a confusing error message on the wrong topic to be printed.

* Error propagation is tricky in ImageBufAlgo functions when the ImageBuf's they are operating on are backed by ImageCache. A tile or scanline read error doesn't happen up front, it can happen as you iterate (when you pass from a valid tile to one that can't be read). But we don't want to slow things down by checking for read errors at every pixel, so instead use a generic way of checking after the IBA operation for any read errors accumulated along the way.

* Make sure that oiotool --stats passes along meaningful error messages.

* Speed up oiiotool --stats by, just like with regular oiiotool operations, do a forced direct read of files that aren't too big, rather than falling back on the ImageCache which is a bit slower.

