### PR TITLE
Change default to USE_CPP11=1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,12 @@ os:
 #osx_image: xcode7
 dist: trusty
 
-# Do a default build (C++03, sse2), an sse4.2 build, and a C++11 build.
-# Also try with both gcc 4.8 and 4.9 (on Linux; on OSX these will be
-# excluded).
 env:
     matrix:
-      - WHICHGCC=4.8 BUILD_FLAGS="USE_CPP11=0"
-      - WHICHGCC=4.8 BUILD_FLAGS="USE_CPP11=1 USE_SIMD=sse4.2"
-      - WHICHGCC=4.8 BUILD_FLAGS="USE_CPP11=1"
-      - WHICHGCC=4.9 BUILD_FLAGS="USE_CPP11=1"
-      - WHICHGCC=5 BUILD_FLAGS="USE_CPP11=1"
-      - WHICHGCC=4.8 BUILD_FLAGS="USE_CPP11=0" DEBUG=1
+      - BUILD_FLAGS="USE_CPP11=0"
+      - BUILD_FLAGS="USE_CPP11=1"
+      - BUILD_FLAGS="USE_CPP11=1" DEBUG=1
+      - BUILD_FLAGS="USE_CPP11=1 USE_SIMD=sse4.2"
 
 # Add-ons: specify apt packages for Linux
 addons:
@@ -32,8 +27,6 @@ addons:
    packages:
       - gcc-4.8
       - g++-4.8
-      - gcc-4.9
-      - g++-4.9
       - gcc-5
       - g++-5
       - libboost1.55-all-dev
@@ -53,6 +46,7 @@ cache:
     - $HOME/lgritz/libtiffpic
 
 before_install:
+    - if [ "$WHICHGCC" == "" ]; then export WHICHGCC="4.8" ; fi
     - if [ $TRAVIS_OS_NAME == osx ] ; then
           export PLATFORM=macosx ;
           sysctl machdep.cpu.features ;
@@ -105,14 +99,9 @@ matrix:
         compiler: gcc
       - os: linux
         compiler: clang
-      - os: osx
-        compiler: clang
-        env: WHICHGCC=4.9
-      - os: osx
-        compiler: clang
-        env: WHICHGCC=4.9 BUILD_FLAGS="USE_CPP11=1"
-      - os: osx
-        compiler: clang
+    include:
+      - os: linux
+        compiler: gcc
         env: WHICHGCC=5 BUILD_FLAGS="USE_CPP11=1"
     include:
       - os: linux
@@ -120,7 +109,7 @@ matrix:
         env: WHICHGCC=5 BUILD_FLAGS="USE_CPP11=1 USE_SIMD=avx,f16c"
       - os: linux
         compiler: gcc
-        env: WHICHGCC=4.8 BUILD_FLAGS="USE_CPP11=1 USE_SIMD=0"
+        env: BUILD_FLAGS="USE_CPP11=1 USE_SIMD=0"
 
 notifications:
     email:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,7 @@ set (SOVERSION ${OIIO_VERSION_MAJOR}.${OIIO_VERSION_MINOR}
 set (PYLIB_INCLUDE_SONAME OFF CACHE BOOL "If ON, soname/soversion will be set for Python module library")
 set (PYLIB_LIB_PREFIX OFF CACHE BOOL "If ON, prefix the Python module with 'lib'")
 set (BUILD_OIIOUTIL_ONLY OFF CACHE BOOL "If ON, will build *only* libOpenImageIO_Util")
-set (OIIO_BUILD_CPP11 OFF CACHE BOOL "Compile in C++11 mode")
+set (OIIO_BUILD_CPP11 ON CACHE BOOL "Compile in C++11 mode")
 set (OIIO_BUILD_CPP14 OFF CACHE BOOL "Compile in C++14 mode")
 set (OIIO_BUILD_LIBCPLUSPLUS OFF CACHE BOOL "Compile with clang libc++")
 set (EXTRA_CPP_ARGS "" CACHE STRING "Extra C++ command line definitions")

--- a/Makefile
+++ b/Makefile
@@ -404,7 +404,7 @@ help:
 	@echo "      STOP_ON_WARNING=0        Do not stop building if compiler warns"
 	@echo "      OPENIMAGEIO_SITE=xx      Use custom site build mods"
 	@echo "      MYCC=xx MYCXX=yy         Use custom compilers"
-	@echo "      USE_CPP11=1              Compile in C++11 mode"
+	@echo "      USE_CPP11=0              Compile in C++11 mode (=0 means use CPP03!)"
 	@echo "      USE_CPP14=1              Compile in C++14 mode"
 	@echo "      USE_LIBCPLUSPLUS=1       Use clang libc++"
 	@echo "      EXTRA_CPP_ARGS=          Additional args to the C++ command"

--- a/site/spi/Makefile-bits-arnold
+++ b/site/spi/Makefile-bits-arnold
@@ -129,6 +129,7 @@ ifeq ($(SP_OS), rhel7)
 
 ## Spinux (current)
 else ifeq ($(SP_OS), spinux1)
+    USE_CPP11 ?= 0
     USE_SIMD = sse4.1
     USE_NINJA := 1
     NINJA := /net/soft_scratch/apps/arnold/tools/spinux1/bin/ninja
@@ -230,6 +231,7 @@ else ifeq ($(SP_OS), spinux1)
 
 ## Official OS X build machines with special conventions
 else ifeq ($(SP_OS), lion)
+    USE_CPP11 ?= 0
     USE_SIMD = sse4.2
     MACPORTS_PREFIX=/opt/local-10.7-2012-08
     OCIO_PATH ?= "${SPCOMP2_SHOTTREE_LOCATION}/OpenColorIO/${SP_OS}-${SPCOMP2_COMPILER}/v${OCIO_SPCOMP_VERSION}"

--- a/site/spi/Makefile-bits-spcomp2
+++ b/site/spi/Makefile-bits-spcomp2
@@ -162,6 +162,7 @@ ifeq ($(SP_OS), rhel7)
 
 ## Spinux (current)
 else ifeq ($(SP_OS), spinux1)
+    USE_CPP11 ?= 0
     USE_SIMD = sse4.1
 #    USE_NINJA := 1
 #    NINJA := /net/soft_scratch/apps/arnold/tools/spinux1/bin/ninja
@@ -258,6 +259,7 @@ else ifeq ($(SP_OS), spinux1)
 
 ## Official OS X build machines with special conventions
 else ifeq ($(SP_OS), lion)
+    USE_CPP11 ?= 0
     USE_SIMD = sse4.2
     MACPORTS_PREFIX=/opt/local-10.7-2012-08
     OCIO_PATH ?= ${SPCOMP2_SHOTTREE_LOCATION}/OpenColorIO/${SP_OS}-${SPCOMP2_COMPILER}/v${OCIO_SPCOMP_VERSION}


### PR DESCRIPTION
This does NOT make the codebase C++11-only. Although that will happen
sooner or later, almost certainly during the course of 1.7 development.
But for now, this just means that it defaults to C++11, and you need to
proactively use 'make USE_CPP11=0' (or 'cmake -DOIIO_BUILD_CPP11=0') to
stay on C++03 compatibility. This is to ensure that nobody is surprised
when the C++11 switch eventually comes, by requiring them to have
continued awareness that they are living on borrowed time.