### PR TITLE
oiiotool --dumpdata improvements for non-deep

### DIFF
--- a/src/cmake/modules/FindOpenEXR.cmake
+++ b/src/cmake/modules/FindOpenEXR.cmake
@@ -7,6 +7,13 @@
 #   ILMBASE_LIBRARIES      libraries just IlmBase
 #   OPENEXR_VERSION        OpenEXR version (accurate for >= 2.0.0,
 #                              otherwise will just guess 1.6.1)
+#
+# Special inputs:
+#   OPENEXR_CUSTOM_INCLUDE_DIR - custom location of headers
+#   OPENEXR_CUSTOM_LIB_DIR - custom location of libraries
+#   OPENEXR_CUSTOM_LIB_PREFIX - special snowflake library prefix
+#   OPENEXR_CUSTOM_LIB_SUFFIX - special snowflake library suffix
+#
 
 # Other standarnd issue macros
 include (FindPackageHandleStandardArgs)
@@ -65,9 +72,10 @@ endif ()
 set (_openexr_components IlmThread IlmImf Imath Iex Half)
 foreach (COMPONENT ${_openexr_components})
     string (TOUPPER ${COMPONENT} UPPERCOMPONENT)
-    find_library (OPENEXR_${UPPERCOMPONENT}_LIBRARY ${COMPONENT}
+    set (FULL_COMPONENT_NAME ${OPENEXR_CUSTOM_LIB_PREFIX}${COMPONENT}${OPENEXR_CUSTOM_LIB_SUFFIX})
+    find_library (OPENEXR_${UPPERCOMPONENT}_LIBRARY ${FULL_COMPONENT_NAME}
                   PATHS ${GENERIC_LIBRARY_PATHS} NO_DEFAULT_PATH)
-    find_library (OPENEXR_${UPPERCOMPONENT}_LIBRARY ${COMPONENT})
+    find_library (OPENEXR_${UPPERCOMPONENT}_LIBRARY ${FULL_COMPONENT_NAME})
 endforeach ()
 
 # Set the FOUND, INCLUDE_DIR, and LIBRARIES variables.

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -2615,7 +2615,10 @@ Print to the console detailed information about the values in every pixel.
 
 \begin{tabular}{p{10pt} p{0.75in} p{3.75in}}
   & {\cf empty=}{\verb&0|1&} & If 0, will cause deep images to skip printing
-                            of information about pixels with no samples.
+                            of information about pixels with no samples, and
+                            cause non-deep images to skip printing information
+                            about pixels that are entirely 0.0 value in all
+                            channels.
 \end{tabular}
 \apiend
 

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -150,6 +150,15 @@ dump_data (ImageInput *input, const print_info_options &opt)
         for (int z = 0;  z < spec.depth;  ++z) {
             for (int y = 0;  y < spec.height;  ++y) {
                 for (int x = 0;  x < spec.width;  ++x) {
+                    if (! opt.dumpdata_showempty) {
+                        bool allzero = true;
+                        for (int c = 0; c < spec.nchannels && allzero; ++c)
+                            allzero &= (ptr[c] == 0.0f);
+                        if (allzero) {
+                            ptr += spec.nchannels;
+                            continue;
+                        }
+                    }
                     if (spec.depth > 1 || spec.z != 0)
                         std::cout << Strutil::format("    Pixel (%d, %d, %d):",
                                              x+spec.x, y+spec.y, z+spec.z);

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -142,7 +142,7 @@ dump_data (ImageInput *input, const print_info_options &opt)
 
     } else {
         std::vector<float> buf(spec.image_pixels() * spec.nchannels);
-        if (! input->read_image (TypeDesc::UNKNOWN /*native*/, &buf[0])) {
+        if (! input->read_image (TypeDesc::FLOAT, &buf[0])) {
             printf ("    dump data: could not read image\n");
             return;
         }


### PR DESCRIPTION
I guess I'd only used the `--dumpdata` on deep files?

1. Make sure for non-deep, that it works correctly! It was reading native, then walking through it as if it were float. Instead, read and convert to float properly.

2. For deep, the `--dumpdata:empty=0` option skipped the printing of values of pixels with no samples. For non-deep, make it also do something useful -- skip the printing of values of pixels where all channel values are 0.
