### PR TITLE
Improve Python image input behavior for native data

### DIFF
--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -727,15 +727,15 @@ specified subimage or MIP level).
 \end{code}
 \apiend
 
-\apiitem{array ImageInput.{\ce read_image} (type=OpenImageIO.UNKNOWN) \\
-array ImageInput.{\ce read_image} (chbegin, chend, type=OpenImageIO.UNKNOWN)}
+\apiitem{array ImageInput.{\ce read_image} (type=OpenImageIO.FLOAT) \\
+array ImageInput.{\ce read_image} (chbegin, chend, type=OpenImageIO.FLOAT)}
 Read the entire image and return the pixels as an array of
 $\mathit{width} \times \mathit{height} \times \mathit{depth} \times \mathit{nchannels}$
-values (or {\cf None} if an error occurred).  The array will be of the type
-specified by the {\cf TypeDesc} or {\cf BASETYPE} argument, or  if the
-argument is missing or is {\cf TypeDesc(oiio.UNKNOWN)}, it will choose an
-appropriate data type that is the ``smallest'' type that can hold the actual
-types in the file. The call may optionally specify a subset of channels.
+values (or {\cf None} if an error occurred). The array will be of the type
+specified by the {\cf TypeDesc} or {\cf BASETYPE} argument (by default,
+{\cf FLOAT}). If {\cf type} is {\cf OpenImageIO.UNKNOWN}, an
+array of {\cf unsigned char} will be returned containing the raw data in
+its native format. The call may optionally specify a subset of channels.
 
 \noindent Example:
 \begin{code}
@@ -748,13 +748,14 @@ types in the file. The call may optionally specify a subset of channels.
 \end{code}
 \apiend
 
-\apiitem{array ImageInput.{\ce read_scanline} (y, z, type=OpenImageIO.UNKNOWN)}
+\apiitem{array ImageInput.{\ce read_scanline} (y, z, type=OpenImageIO.FLOAT)}
 Read scanline number {\cf y} from depth plane {\cf z} from the open file,
 returning it as an array of $\mathit{width} \times \mathit{nchannels}$
 values (or {\cf None} if an error occurred). The array will be of the type
-specified by the {\cf TypeDesc} or {\cf BASETYPE} argument, or if the
-argument is missing or is {\cf TypeDesc(oiio.UNKNOWN)}, it will choose an
-appropriate data type.
+specified by the {\cf TypeDesc} or {\cf BASETYPE} argument (by default,
+{\cf FLOAT}). If {\cf type} is {\cf OpenImageIO.UNKNOWN}, an
+array of {\cf unsigned char} will be returned containing the raw data in
+its native format.
 
 \noindent Example:
 \begin{code}
@@ -770,14 +771,15 @@ appropriate data type.
 \end{code}
 \apiend
 
-\apiitem{array ImageInput.{\ce read_tile} (x, y, z, type=OpenImageIO.UNKNOWN)}
+\apiitem{array ImageInput.{\ce read_tile} (x, y, z, type=OpenImageIO.FLOAT)}
 Read the tile whose upper left corner is pixel {\cf (x,y,z)} from the open
 file, returning it as an array of
 $\mathit{width} \times \mathit{height} \times \mathit{depth} \times \mathit{nchannels}$
 values (or {\cf None} if an error occurred). The array will be of the type
-specified by the {\cf TypeDesc} or {\cf BASETYPE} argument, or if the
-argument is missing or {\cf TypeDesc(oiio.UNKNOWN)}, it will choose an
-appropriate data type.
+specified by the {\cf TypeDesc} or {\cf BASETYPE} argument (by default,
+{\cf FLOAT}). If {\cf type} is {\cf OpenImageIO.UNKNOWN}, an
+array of {\cf unsigned char} will be returned containing the raw data in
+its native format.
 
 \noindent Example:
 \begin{code}
@@ -796,9 +798,9 @@ appropriate data type.
 \apiend
 
 \apiitem{array ImageInput.{\ce read_scanlines} (ybegin, yend, z, chbegin, chend, \\
-\bigspc\bigspc\spc type=OpenImageIO.UNKNOWN) \\
+\bigspc\bigspc\spc type=OpenImageIO.FLOAT) \\
 array ImageInput.{\ce read_tiles} (xbegin, xend, ybegin, yend, zbegin, zend, \\
-    \bigspc\bigspc\spc chbegin, chend, type=OpenImageIO.UNKNOWN)}
+    \bigspc\bigspc\spc chbegin, chend, type=OpenImageIO.FLOAT)}
 Similar to the C++ routines, these functions read multiple scanlines or 
 tiles at once, which in some cases may be more efficient than reading
 each scanline or tile separately.  Additionally, they allow you to read only

--- a/testsuite/python-imageinput/ref/out-alt.txt
+++ b/testsuite/python-imageinput/ref/out-alt.txt
@@ -130,4 +130,24 @@ Opened "grid.tx" as a tiff
 @ (1023, 1023) = array('B', [0, 0, 0, 255])
 @ (512, 512) = array('B', [0, 0, 0, 255])
 
+Test read_image native u16:
+Opened "testu16.tif" as a tiff
+Read array typecode B  [ 24576 ]
+
+Test read_scanlines native u16:
+Opened "testu16.tif" as a tiff
+Read array typecode B  [ 24576 ]
+
+Test read_tiles native half:
+Opened "testf16.exr" as a openexr
+Read array typecode B  [ 24576 ]
+
+Test read_image into half:
+Opened "testu16.tif" as a tiff
+Read array typecode H  [ 12288 ]
+
+Test read_image into FLOAT:
+Opened "testu16.tif" as a tiff
+Read array typecode f  [ 12288 ]
+
 Done.

--- a/testsuite/python-imageinput/ref/out-rhel7.txt
+++ b/testsuite/python-imageinput/ref/out-rhel7.txt
@@ -130,4 +130,24 @@ Opened "grid.tx" as a tiff
 @ (1023, 1023) = array('B', [0, 0, 0, 255])
 @ (512, 512) = array('B', [0, 0, 0, 255])
 
+Test read_image native u16:
+Opened "testu16.tif" as a tiff
+Read array typecode B  [ 24576 ]
+
+Test read_scanlines native u16:
+Opened "testu16.tif" as a tiff
+Read array typecode B  [ 24576 ]
+
+Test read_tiles native half:
+Opened "testf16.exr" as a openexr
+Read array typecode B  [ 24576 ]
+
+Test read_image into half:
+Opened "testu16.tif" as a tiff
+Read array typecode H  [ 12288 ]
+
+Test read_image into FLOAT:
+Opened "testu16.tif" as a tiff
+Read array typecode f  [ 12288 ]
+
 Done.

--- a/testsuite/python-imageinput/ref/out-travis.txt
+++ b/testsuite/python-imageinput/ref/out-travis.txt
@@ -130,4 +130,24 @@ Opened "grid.tx" as a tiff
 @ (1023, 1023) = array('B', [0, 0, 0, 255])
 @ (512, 512) = array('B', [0, 0, 0, 255])
 
+Test read_image native u16:
+Opened "testu16.tif" as a tiff
+Read array typecode B  [ 24576 ]
+
+Test read_scanlines native u16:
+Opened "testu16.tif" as a tiff
+Read array typecode B  [ 24576 ]
+
+Test read_tiles native half:
+Opened "testf16.exr" as a openexr
+Read array typecode B  [ 24576 ]
+
+Test read_image into half:
+Opened "testu16.tif" as a tiff
+Read array typecode H  [ 12288 ]
+
+Test read_image into FLOAT:
+Opened "testu16.tif" as a tiff
+Read array typecode f  [ 12288 ]
+
 Done.

--- a/testsuite/python-imageinput/ref/out.txt
+++ b/testsuite/python-imageinput/ref/out.txt
@@ -130,4 +130,24 @@ Opened "grid.tx" as a tiff
 @ (1023, 1023) = array('B', [0, 0, 0, 255])
 @ (512, 512) = array('B', [0, 0, 0, 255])
 
+Test read_image native u16:
+Opened "testu16.tif" as a tiff
+Read array typecode B  [ 24576 ]
+
+Test read_scanlines native u16:
+Opened "testu16.tif" as a tiff
+Read array typecode B  [ 24576 ]
+
+Test read_tiles native half:
+Opened "testf16.exr" as a openexr
+Read array typecode B  [ 24576 ]
+
+Test read_image into half:
+Opened "testu16.tif" as a tiff
+Read array typecode H  [ 12288 ]
+
+Test read_image into FLOAT:
+Opened "testu16.tif" as a tiff
+Read array typecode f  [ 12288 ]
+
 Done.

--- a/testsuite/python-imageinput/src/test_imageinput.py
+++ b/testsuite/python-imageinput/src/test_imageinput.py
@@ -71,7 +71,8 @@ def poor_mans_iinfo (filename) :
 # channels, if nonzero, otherwise read the full channel range in the
 # file.
 def test_readimage (filename, sub=0, mip=0, type=oiio.UNKNOWN,
-                    method="image", nchannels=0) :
+                    method="image", nchannels=0,
+                    print_pixels = True, keep_unknown=False) :
     input = oiio.ImageInput.open (filename)
     if not input :
         print 'Could not open "' + filename + '"'
@@ -83,7 +84,7 @@ def test_readimage (filename, sub=0, mip=0, type=oiio.UNKNOWN,
     spec = input.spec ()
     if nchannels == 0 or method == "image" :
         nchannels = spec.nchannels
-    if type == oiio.UNKNOWN :
+    if type == oiio.UNKNOWN and not keep_unknown :
         type = spec.format.basetype
     if method == "image" :
         data = input.read_image (type)
@@ -101,16 +102,19 @@ def test_readimage (filename, sub=0, mip=0, type=oiio.UNKNOWN,
     if data == None :
         print "read returned None"
         return
-    # print the first, last, and middle pixel values
-    (x,y) = (spec.x, spec.y)
-    i = ((y-spec.y)*spec.width + (x-spec.x)) * nchannels
-    print "@", (x,y), "=", data[i:i+nchannels]
-    (x,y) = (spec.x+spec.width-1, spec.y+spec.height-1)
-    i = ((y-spec.y)*spec.width + (x-spec.x)) * nchannels
-    print "@", (x,y), "=", data[i:i+nchannels]
-    (x,y) = (spec.x+spec.width/2, spec.y+spec.height/2)
-    i = ((y-spec.y)*spec.width + (x-spec.x)) * nchannels
-    print "@", (x,y), "=", data[i:i+nchannels]
+    if print_pixels :
+        # print the first, last, and middle pixel values
+        (x,y) = (spec.x, spec.y)
+        i = ((y-spec.y)*spec.width + (x-spec.x)) * nchannels
+        print "@", (x,y), "=", data[i:i+nchannels]
+        (x,y) = (spec.x+spec.width-1, spec.y+spec.height-1)
+        i = ((y-spec.y)*spec.width + (x-spec.x)) * nchannels
+        print "@", (x,y), "=", data[i:i+nchannels]
+        (x,y) = (spec.x+spec.width/2, spec.y+spec.height/2)
+        i = ((y-spec.y)*spec.width + (x-spec.x)) * nchannels
+        print "@", (x,y), "=", data[i:i+nchannels]
+    else :
+        print "Read array typecode", data.typecode, " [", len(data), "]"
     input.close ()
     print
 
@@ -182,6 +186,13 @@ def test_readtile (filename, sub=0, mip=0, type=oiio.UNKNOWN) :
     print
 
 
+def write (image, filename, format=oiio.UNKNOWN) :
+    if not image.has_error :
+        image.set_write_format (format)
+        image.write (filename)
+    if image.has_error :
+        print "Error writing", filename, ":", image.geterror()
+
 
 ######################################################################
 # main test starts here
@@ -219,6 +230,29 @@ try:
     print "Testing read_tiles:"
     test_readimage ("grid.tx",
                     method="tiles")
+
+    # test reading a raw buffer in native format, we should get back
+    # an unsigned byte array.
+    b = oiio.ImageBuf (oiio.ImageSpec(64, 64, 3, oiio.UINT16))
+    oiio.ImageBufAlgo.fill (b, (1,0,0), (0,1,0), (0,0,1), (1,1,1))
+    write (b, "testu16.tif", oiio.UINT16)
+    b.set_write_tiles (32, 32)
+    write (b, "testf16.exr", oiio.HALF)
+    print "Test read_image native u16:"
+    test_readimage ("testu16.tif", method="image", type=oiio.UNKNOWN,
+                    keep_unknown=True, print_pixels=False)
+    print "Test read_scanlines native u16:"
+    test_readimage ("testu16.tif", method="scanlines", type=oiio.UNKNOWN,
+                    keep_unknown=True, print_pixels=False)
+    print "Test read_tiles native half:"
+    test_readimage ("testf16.exr", method="tiles", type=oiio.UNKNOWN,
+                    keep_unknown=True, print_pixels=False)
+    print "Test read_image into half:"
+    test_readimage ("testu16.tif", method="image", type=oiio.HALF,
+                    keep_unknown=True, print_pixels=False)
+    print "Test read_image into FLOAT:"
+    test_readimage ("testu16.tif", method="image", type=oiio.FLOAT,
+                    keep_unknown=True, print_pixels=False)
 
     print "Done."
 except Exception as detail:


### PR DESCRIPTION
Python bindings of ImageInout.read_image, read_scanline, read_scanlines,
read_tile, read_tiles:

* If you ask for HALF, since there is no half in Python, return the half
  values packed into an 'unsigned short' array. (Old behavior was buggy
  and confusing: it packed the half values into a float array of half
  the expected size.)

* If you ask for UNKNOWN, like in C++ it means to give the raw/native
  data, packed into an 'unsigned char' array. (Old behavior was that
  UNKNOWN signified to return data in the type specified by spec.format.
  Now, if you want spec.format, pass spec.format.)

* Let the default be type=FLOAT, generate a float array. (Old default was
  UNKNOWN spec.format.)