### PR TITLE
Prevent bad memory access when reading specific Jpeg files

### DIFF
--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -281,7 +281,7 @@ JpgInput::open (const std::string &name, ImageSpec &newspec)
         else if (m->marker == JPEG_COM) {
             if (! m_spec.find_attribute ("ImageDescription", TypeDesc::STRING))
                 m_spec.attribute ("ImageDescription",
-                                  std::string ((const char *)m->data));
+                                  std::string ((const char *)m->data, m->data_length));
         }
     }
 


### PR DESCRIPTION
## Description

The issue was caused by some applications not putting a proper
NULL-terminator to the comment marker when saving an image.
This will cause std::string to access memory past the marker's
data when calculating string length.

Now we pass length of string stored in the marker explicitly, so
there's no need to call strlen() on a random memory.

While it's arguably that applications should put null-terminator
to the comment, there are enough textures in online libraries
which doesn't have null-terminator in the comment string and there's
need to crash on those at all.

## Tests

The issue was already discussed there http://lists.openimageio.org/pipermail/oiio-dev-openimageio.org/2013-April/006002.html but seems no conclusion were done there. File from that message will demonstrate the issue. Very much easy to notice the issue when using address sanitizer.