### PR TITLE
[Mingw] Bug fix in Filesystem

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -61,7 +61,7 @@
 OIIO_NAMESPACE_BEGIN
 
 #if FILESYSTEM_USE_STDIO_FILEBUF
-typedef __gnu__cxx::stdio_filebuf<char> stdio_filebuf;
+typedef __gnu_cxx::stdio_filebuf<char> stdio_filebuf;
 #else
 typedef std::basic_filebuf<char> stdio_filebuf;
 #endif

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -560,7 +560,7 @@ open_fstream_impl(string_view path,
                    STREAM** stream,
                    stdio_filebuf** buffer)
 {
-    if (!stream || buffer) {
+    if (!stream || !buffer) {
         return false;
     }
     std::wstring wpath = Strutil::utf8_to_utf16(path);
@@ -568,7 +568,9 @@ open_fstream_impl(string_view path,
     int oflag = ios_open_mode_to_oflag(mode);
     errno_t errcode = _wsopen_s(&fd, wpath.c_str(), oflag, _SH_DENYNO, _S_IREAD | _S_IWRITE);
     if (errcode != 0) {
-        return 0;
+		*buffer = 0;
+		*stream = 0;
+        return false;
     }
     *buffer = new OIIO_NAMESPACE::stdio_filebuf(fd, mode, 1);
     if (!*buffer) {

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -507,8 +507,8 @@ Strutil::utf8_to_utf16 (string_view str)
 {
     std::wstring native;
     
-    native.resize(MultiByteToWideChar (CP_UTF8, 0, str.c_str(), -1, NULL, 0));
-    MultiByteToWideChar (CP_UTF8, 0, str.c_str(), -1, &native[0], (int)native.size());
+    native.resize(MultiByteToWideChar (CP_UTF8, 0, str.c_str(), -1, NULL, 0) - 1);
+    MultiByteToWideChar (CP_UTF8, 0, str.c_str(), str.size(), &native[0], (int)native.size());
 
     return native;
 }

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -87,7 +87,6 @@
 #include "OpenImageIO/deepdata.h"
 
 #include <boost/scoped_array.hpp>
-#include <boost/scoped_ptr.hpp>
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
@@ -101,13 +100,9 @@ public:
     OpenEXRInputStream (const char *filename) : Imf::IStream (filename) {
         // The reason we have this class is for this line, so that we
         // can correctly handle UTF-8 file paths on Windows
-        {
-            std::istream* ifsraw;
-            Filesystem::open (&ifsraw, filename, std::ios_base::binary);
-            if (ifsraw) {
-                ifs.reset(ifsraw);
-            }
-        }
+
+        Filesystem::open (&ifs, filename, std::ios_base::binary);
+        
         if (!ifs)
             Iex::throwErrnoExc ();
     }
@@ -143,7 +138,7 @@ private:
         }
         return true;
     }
-    boost::scoped_ptr<std::istream> ifs;
+    Filesystem::IStreamWrapper ifs;
 };
 
 

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -87,8 +87,6 @@
 #include "OpenImageIO/sysutil.h"
 #include "OpenImageIO/fmath.h"
 
-#include <boost/scoped_ptr.hpp>
-
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
 
@@ -102,13 +100,7 @@ public:
     OpenEXROutputStream (const char *filename) : Imf::OStream(filename) {
         // The reason we have this class is for this line, so that we
         // can correctly handle UTF-8 file paths on Windows
-        {
-            std::ostream* rawhandle;
-            Filesystem::open (&rawhandle, filename, std::ios_base::binary);
-            if (rawhandle) {
-                ofs.reset(rawhandle);
-            }
-        }
+        Filesystem::open (&ofs, filename, std::ios_base::binary);
         if (!ofs)
             Iex::throwErrnoExc ();
     }
@@ -139,7 +131,7 @@ private:
             throw Iex::ErrnoExc ("File output failed.");
         }
     }
-    boost::scoped_ptr<std::ostream> ofs;
+    Filesystem::OStreamWrapper ofs;
 };
 
 

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -32,8 +32,6 @@
 #include <fstream>
 #include <cstdlib>
 
-#include <boost/scoped_ptr.hpp>
-
 #include "OpenImageIO/filesystem.h"
 #include "OpenImageIO/fmath.h"
 #include "OpenImageIO/imageio.h"
@@ -55,7 +53,7 @@ private:
       P1, P2, P3, P4, P5, P6, Pf, PF
     };
 
-    boost::scoped_ptr<std::istream> m_file;
+    Filesystem::IStreamWrapper m_file;
     std::streampos m_header_end_pos; // file position after the header
     std::string m_current_line; ///< Buffer the image pixels
     const char * m_pos;
@@ -450,13 +448,8 @@ PNMInput::open (const std::string &name, ImageSpec &newspec)
 {
     close(); //close previously opened file
     
-    std::istream* rawfile;
-    Filesystem::open (&rawfile, name, std::ios::in|std::ios::binary);
-    if (rawfile) {
-        m_file.reset(rawfile);
-    }
-    
-    
+    Filesystem::open (&m_file, name, std::ios::in|std::ios::binary);
+ 
     m_current_line = "";
     m_pos = m_current_line.c_str();
 

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -30,8 +30,6 @@
 
 #include <fstream>
 
-#include <boost/scoped_ptr.hpp>
-
 #include "OpenImageIO/filesystem.h"
 #include "OpenImageIO/imageio.h"
 
@@ -53,7 +51,7 @@ public:
 
 private:
     std::string m_filename;           ///< Stash the filename
-    boost::scoped_ptr<std::ostream> m_file;
+    Filesystem::OStreamWrapper m_file;
     unsigned int m_max_val, m_pnm_type;
     unsigned int m_dither;
     std::vector<unsigned char> m_scratch;
@@ -188,21 +186,12 @@ PNMOutput::open (const std::string &name, const ImageSpec &userspec,
     if (!m_spec.get_int_attribute ("pnm:binary", 1)) 
     {
         m_pnm_type -= 3;
-        {
-            std::ostream* raw;
-            Filesystem::open (&raw, name);
-            if (raw) {
-                m_file.reset(raw);
-            }
-        }
+        Filesystem::open (&m_file, name);
+        
     }
     else {
-        std::ostream* raw;
-        Filesystem::open (&raw, name, std::ios::out|std::ios::binary);
-        if (raw) {
-            m_file.reset(raw);
-        }
-        
+        Filesystem::open (&m_file, name, std::ios::out|std::ios::binary);
+ 
     }
     
     if (!m_file)

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -36,7 +36,6 @@
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/foreach.hpp>
-#include <boost/scoped_ptr.hpp>
 
 #include "psd_pvt.h"
 #include "jpeg_memory_src.h"
@@ -197,7 +196,7 @@ private:
     };
 
     std::string m_filename;
-    boost::scoped_ptr<std::istream> m_file;
+    Filesystem::IStreamWrapper m_file;
     //Current subimage
     int m_subimage;
     //Subimage count (1 + layer count)
@@ -544,13 +543,9 @@ bool
 PSDInput::open (const std::string &name, ImageSpec &newspec)
 {
     m_filename = name;
-    {
-        std::istream* raw;
-        Filesystem::open (&raw, name, std::ios::binary);
-        if (raw) {
-            m_file.reset(raw);
-        }
-    }
+
+    Filesystem::open (&m_file, name, std::ios::binary);
+  
     if (!m_file) {
         error ("\"%s\": failed to open file", name.c_str());
         return false;


### PR DESCRIPTION
Fix recent changes to Filesystem::open where internal buffers of istream/ostream would never get deleted on MINGW.