### PR TITLE
Rename clobber() -> clobber_all_memory().

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -159,7 +159,7 @@ Developer goodies / internals:
    direction; raised minimum chunk size to prevent thread fan-out for
    images too small to benefit; uses the calling thread as part of the
    pool. #1303 (1.7.0)
- * timer.h: DoNotOptimize() and clobber() help to disable certain
+ * timer.h: DoNotOptimize() and clobber_all_memory() help to disable certain
    optimizations that would interfere with micro-benchmarks. #1305 (1.7.0)
  * simd.h improvements: select(); round(); float4::store(half*),
    int4::store(unsigned short*), int4::store(unsigned char*). #1305 (1.7.0)

--- a/src/include/OpenImageIO/timer.h
+++ b/src/include/OpenImageIO/timer.h
@@ -303,14 +303,14 @@ template <class T> inline void DoNotOptimize (T const &val) { }
 #if (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)) && (defined(__x86_64__) || defined(__i386__))
 
 // Special trick for x86/x86_64 and gcc-like compilers
-inline void clobber() {
+inline void clobber_all_memory() {
     asm volatile ("" : : : "memory");
 }
 
 #else
 
 // No fallback for other CPUs or compilers. Suggestions?
-inline void clobber() { }
+inline void clobber_all_memory() { }
 
 #endif
 
@@ -329,7 +329,7 @@ time_trial (FUNC func, int ntrials=1, int nrepeats = 1, double *range=NULL)
         Timer timer;
         for (int i = 0; i < nrepeats; ++i) {
             // Be sure that the repeated calls to func aren't optimzed away:
-            clobber ();
+            clobber_all_memory();
             func ();
         }
         double t = timer();


### PR DESCRIPTION
More descriptive, and judging by the comments, the name I originally intended.