### PR TITLE
Support separate ilmbase installation and other OpenEXR fixes

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -70,7 +70,11 @@ if (NOT OPENEXR_FOUND)
     find_package (OpenEXR REQUIRED)
 endif ()
 
-include_directories ("${OPENEXR_INCLUDE_DIR}")
+#OpenEXR 2.2 still has problems with importing ImathInt64.h unqualified
+#thus need for ilmbase/OpenEXR
+include_directories ("${OPENEXR_INCLUDE_DIR}"
+                     "${ILMBASE_INCLUDE_DIR}"
+                     "${ILMBASE_INCLUDE_DIR}/OpenEXR")
 
 if (${OPENEXR_VERSION} VERSION_LESS 2.0.0)
     # OpenEXR 1.x had weird #include dirctives, this is also necessary:

--- a/src/cmake/modules/FindOpenEXR.cmake
+++ b/src/cmake/modules/FindOpenEXR.cmake
@@ -23,9 +23,12 @@ find_package (ZLIB REQUIRED)
 
 # List of likely places to find the headers -- note priority override of
 # OPENEXR_CUSTOM_INCLUDE_DIR and ${OPENEXR_HOME}/include.
-set (GENERIC_INCLUDE_PATHS 
+# ILMBASE is needed in case ilmbase an openexr are installed in separate
+# directories, like NixOS does
+set (GENERIC_INCLUDE_PATHS
     ${OPENEXR_CUSTOM_INCLUDE_DIR}
     ${OPENEXR_HOME}/include
+    ${ILMBASE_HOME}/include
     /usr/include
     /usr/include/${CMAKE_LIBRARY_ARCHITECTURE}
     /usr/local/include
@@ -37,6 +40,7 @@ set (GENERIC_INCLUDE_PATHS
 set (GENERIC_LIBRARY_PATHS 
     ${OPENEXR_CUSTOM_LIB_DIR}
     ${OPENEXR_HOME}/lib
+    ${ILMBASE_HOME}/lib
     /usr/lib
     /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}
     /usr/local/lib
@@ -77,6 +81,12 @@ foreach (COMPONENT ${_openexr_components})
                   PATHS ${GENERIC_LIBRARY_PATHS} NO_DEFAULT_PATH)
     find_library (OPENEXR_${UPPERCOMPONENT}_LIBRARY ${FULL_COMPONENT_NAME})
 endforeach ()
+
+#Half usually has no suffix
+find_library (OPENEXR_HALF_LIBRARY ${OPENEXR_CUSTOM_LIB_PREFIX}Half
+              PATHS ${GENERIC_LIBRARY_PATHS} NO_DEFAULT_PATH)
+find_library (OPENEXR_HALF_LIBRARY ${OPENEXR_CUSTOM_LIB_PREFIX}Half)
+
 
 # Set the FOUND, INCLUDE_DIR, and LIBRARIES variables.
 if (ILMBASE_INCLUDE_PATH AND OPENEXR_INCLUDE_PATH AND


### PR DESCRIPTION
Restore usage of separate ILMBASE_ROOT, since some package managers and
OSes install ilbase and OpenEXR into different paths.

On some versions of OpenEXR ImfInt64.h includes ImathInt64.h directly,

libHalf is often installed without suffix, cmake should try to find it.