### PR TITLE
IBA::resize() - double the performance

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -408,6 +408,17 @@ bicubic_interp (const T **val, T s, T t, int n, T *result)
 
 
 
+/// Return floor(x) as an int, as efficiently as possible.
+inline int
+ifloor (float x)
+{
+    // Find the greatest whole number <= x.  This cast is faster than
+    // calling floorf.
+    return (int) x - (x < 0.0f ? 1 : 0);
+}
+
+
+
 /// Return (x-floor(x)) and put (int)floor(x) in *xint.  This is similar
 /// to the built-in modf, but returns a true int, always rounds down
 /// (compared to modf which rounds toward 0), and always returns
@@ -415,9 +426,7 @@ bicubic_interp (const T **val, T s, T t, int n, T *result)
 inline float
 floorfrac (float x, int *xint)
 {
-    // Find the greatest whole number <= x.  This cast is faster than
-    // calling floorf.
-    int i = (int) x - (x < 0.0f ? 1 : 0);
+    int i = ifloor(x);
     *xint = i;
     return x - static_cast<float>(i);   // Return the fraction left over
 }


### PR DESCRIPTION
IBA::resize() : speed up by approximately 2x

* Most of the heavy lifting is done by calculating the horizontal filter    taps for separable filters just once for each pixel column, rather than    for every pixel. (We already had a similar speedup for the vertical    taps, computing them just once per scanline.)

* Refactor a bit to break apart the separable and non-separable cases a    bit more coarsely, to reduce the number of conditionals inside the loop.

* Use Iterator::rerange rather than creating new iterators for each filter.