### PR TITLE
Fix support for UTF-8 filenames on MingW

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -45,6 +45,7 @@
 #include <cstdio>
 #include <ctime>
 #include <fstream>
+#include <cassert>
 #include <string>
 #include <vector>
 
@@ -52,8 +53,24 @@
 #include "oiioversion.h"
 #include "string_view.h"
 
+#if defined(_WIN32) && defined(__GLIBCXX__)
+#define FILESYSTEM_USE_STDIO_FILEBUF 1
+#include "fstream_mingw.h"
+#endif
 
 OIIO_NAMESPACE_BEGIN
+
+#if FILESYSTEM_USE_STDIO_FILEBUF
+// MingW uses GCC to build, but does not support having a wchar_t* passed as argument
+// of ifstream::open or ofstream::open. To properly support UTF-8 encoding on MingW we must
+// use the __gnu_cxx::stdio_filebuf GNU extension that can be used with _wfsopen and returned
+// into a istream which share the same API as ifsteam. The same reasoning holds for ofstream.
+typedef basic_ifstream<char> ifstream;
+typedef basic_ofstream<char> ofstream;
+#else
+typedef std::ifstream ifstream;
+typedef std::ofstream ofstream;
+#endif
 
 /// @namespace Filesystem
 ///
@@ -193,52 +210,16 @@ OIIO_API FILE *fopen (string_view path, string_view mode);
 ///
 OIIO_API std::string current_path ();
 
-/// Deprecated: Will not work correctly on GCC with MingW, prefer
-/// the version below taking a ofstream**
 /// Version of std::ifstream.open that can handle UTF-8 paths
 ///
-OIIO_API void open (std::ifstream &stream, string_view path,
+OIIO_API void open (OIIO_NAMESPACE::ifstream &stream, string_view path,
                     std::ios_base::openmode mode = std::ios_base::in);
 
-/// Deprecated: Will not work correctly on GCC with MingW, prefer
-/// the version below taking a ofstream**
 /// Version of std::ofstream.open that can handle UTF-8 paths
 ///
-OIIO_API void open (std::ofstream &stream, string_view path,
+OIIO_API void open (OIIO_NAMESPACE::ofstream &stream, string_view path,
                     std::ios_base::openmode mode = std::ios_base::out);
     
-    
-/// Version of std::ifstream.open that can handle UTF-8 paths
-/// Open the file for reading with the given mode and set the stream
-/// accordingly. Upon failure, stream is set to NULL.
-/// Caller is responsible for calling delete on the returned stream
-/// when done.
-/// Usage:
-///     std::ifstream* stream;
-///     Filesystem::open(&stream, path);
-///     if (stream) ...
-///     delete stream;
-/// To avoid memory leaks, the returned stream should be enclosed
-/// as soon as possible in a RAII style structure, such as a smart ptr.
-///
-OIIO_API void open (std::istream** stream, string_view path,
-                    std::ios_base::openmode mode  = std::ios_base::in);
-    
-/// Version of std::ofstream.open that can handle UTF-8 paths
-/// Open the file for reading with the given mode and set the stream
-/// accordingly. Upon failure, stream is set to NULL.
-/// Caller is responsible for calling delete on the returned stream
-/// when done.
-/// Usage:
-///     std::ofstream* stream;
-///     Filesystem::open(&stream, path);
-///     if (stream) ...
-///     delete stream;
-/// To avoid memory leaks, the returned stream should be enclosed
-/// as soon as possible in a RAII style structure, such as a smart ptr.
-///
-OIIO_API void open (std::ostream** stream, string_view path,
-                    std::ios_base::openmode mode  = std::ios_base::out);
 
 
 /// Read the entire contents of the named text file and place it in str,

--- a/src/include/OpenImageIO/fstream_mingw.h
+++ b/src/include/OpenImageIO/fstream_mingw.h
@@ -1,0 +1,352 @@
+/*
+  Copyright 2008 Larry Gritz and the other authors and contributors.
+  All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the software's owners nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  (This is the Modified BSD License)
+*/
+
+
+/// @file  fstream_mingw.h
+///
+/// @brief Utilities for dealing with fstream on MingW.
+/// Basically accepting wchar_t* filenames in the std::ifstream::open function
+/// is a Windows MSVC extension and does not work on MingW. This file implements
+/// ifstream and ofstream so that they work with UTF-16 filenames.
+
+
+#ifndef OPENIMAGEIO_FSTREAM_MINGW_H
+#define OPENIMAGEIO_FSTREAM_MINGW_H
+
+#include <cassert>
+#include <istream>
+#include <ostream>
+
+#if defined(_WIN32) && defined(__GLIBCXX__)
+#include <ext/stdio_filebuf.h> // __gnu_cxx::stdio_filebuf
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <Share.h>
+
+
+OIIO_NAMESPACE_BEGIN
+
+
+template <class _CharT, class _Traits = std::char_traits<_CharT> >
+class basic_ifstream
+: public std::basic_istream<_CharT, _Traits>
+{
+public:
+    typedef _CharT                         char_type;
+    typedef _Traits                        traits_type;
+    typedef typename traits_type::int_type int_type;
+    typedef typename traits_type::pos_type pos_type;
+    typedef typename traits_type::off_type off_type;
+    
+    typedef typename __gnu_cxx::stdio_filebuf<char_type, traits_type> stdio_filebuf;
+
+    
+    basic_ifstream();
+    explicit basic_ifstream(const std::wstring& path, std::ios_base::openmode __mode = std::ios_base::in);
+    
+    virtual ~basic_ifstream();
+    
+    stdio_filebuf* rdbuf() const;
+    bool is_open() const;
+    void open(const std::wstring& path, std::ios_base::openmode __mode = std::ios_base::in);
+    void close();
+    
+private:
+    
+    void open_internal(const std::wstring& path, std::ios_base::openmode mode);
+    
+    stdio_filebuf* __sb_;
+};
+
+template <class _CharT, class _Traits>
+inline
+basic_ifstream<_CharT, _Traits>::basic_ifstream()
+: std::basic_istream<char_type, traits_type>(0)
+, __sb_(0)
+{
+}
+
+
+template <class _CharT, class _Traits>
+inline
+basic_ifstream<_CharT, _Traits>::basic_ifstream(const std::wstring& path, std::ios_base::openmode __mode)
+: std::basic_istream<char_type, traits_type>(0)
+, __sb_(0)
+{
+    open_internal(path, __mode | std::ios_base::in);
+}
+
+template <class _CharT, class _Traits>
+inline
+basic_ifstream<_CharT, _Traits>::~basic_ifstream()
+{
+    delete __sb_;
+}
+
+
+inline int
+ios_open_mode_to_oflag(std::ios_base::openmode mode)
+{
+    int f = 0;
+    if (mode & std::ios_base::in) {
+        f |= _O_RDONLY;
+    }
+    if (mode & std::ios_base::out) {
+        f |= _O_WRONLY;
+        f |= _O_CREAT;
+        if (mode & std::ios_base::app) {
+            f |= _O_APPEND;
+        }
+        if (mode & std::ios_base::trunc) {
+            f |= _O_TRUNC;
+        }
+    }
+    if (mode & std::ios_base::binary) {
+        f |= _O_BINARY;
+    } else {
+        f |= _O_TEXT;
+    }
+    return f;
+}
+
+template <class _CharT, class _Traits>
+inline
+void
+basic_ifstream<_CharT, _Traits>::open_internal(const std::wstring& path, std::ios_base::openmode mode)
+{
+	if (is_open()) {
+		// if the stream is already associated with a file (i.e., it is already open), calling this function fails.
+		this->setstate(std::ios_base::failbit);
+        return;
+	}
+    int fd;
+    int oflag = ios_open_mode_to_oflag(mode);
+    errno_t errcode = _wsopen_s(&fd, path.c_str(), oflag, _SH_DENYNO, _S_IREAD | _S_IWRITE);
+    if (errcode != 0) {
+        this->setstate(std::ios_base::failbit);
+        return;
+    }
+    __sb_ = new stdio_filebuf(fd, mode, 1);
+    if (__sb_ == 0) {
+        this->setstate(std::ios_base::failbit);
+        return;
+    }
+	// 409. Closing an fstream should clear error state
+    this->clear();
+	assert(__sb_);
+	
+	// In init() the rdstate() is set to badbit if __sb_ is NULL and
+	// goodbit otherwise. The assert afterwards ensures this.
+    this->init(__sb_);
+	assert(this->good() && !this->fail());
+}
+
+template <class _CharT, class _Traits>
+inline
+typename basic_ifstream<_CharT, _Traits>::stdio_filebuf*
+basic_ifstream<_CharT, _Traits>::rdbuf() const
+{
+    return const_cast<stdio_filebuf*>(__sb_);
+}
+
+
+template <class _CharT, class _Traits>
+inline
+bool
+basic_ifstream<_CharT, _Traits>::is_open() const
+{
+    return __sb_ && __sb_->is_open();
+}
+
+
+template <class _CharT, class _Traits>
+void
+basic_ifstream<_CharT, _Traits>::open(const std::wstring& path, std::ios_base::openmode __mode)
+{
+    open_internal(path, __mode | std::ios_base::in);
+}
+
+template <class _CharT, class _Traits>
+inline
+void
+basic_ifstream<_CharT, _Traits>::close()
+{
+    if (!__sb_) {
+        return;
+    }
+    if (__sb_->close() == 0)
+        this->setstate(std::ios_base::failbit);
+    
+    delete __sb_;
+	__sb_= 0;
+
+}
+
+
+
+template <class _CharT, class _Traits = std::char_traits<_CharT> >
+class basic_ofstream
+: public std::basic_ostream<_CharT, _Traits>
+{
+public:
+    typedef _CharT                         char_type;
+    typedef _Traits                        traits_type;
+    typedef typename traits_type::int_type int_type;
+    typedef typename traits_type::pos_type pos_type;
+    typedef typename traits_type::off_type off_type;
+    
+    typedef typename __gnu_cxx::stdio_filebuf<char_type, traits_type> stdio_filebuf;
+    
+    
+    basic_ofstream();
+    explicit basic_ofstream(const std::wstring& path, std::ios_base::openmode __mode = std::ios_base::out);
+    
+    virtual ~basic_ofstream();
+    
+    stdio_filebuf* rdbuf() const;
+    bool is_open() const;
+    void open(const std::wstring& path, std::ios_base::openmode __mode = std::ios_base::out);
+    void close();
+    
+private:
+    
+    void open_internal(const std::wstring& path, std::ios_base::openmode mode);
+    
+    stdio_filebuf* __sb_;
+};
+
+template <class _CharT, class _Traits>
+inline
+basic_ofstream<_CharT, _Traits>::basic_ofstream()
+: std::basic_ostream<char_type, traits_type>(0)
+, __sb_(0)
+{
+}
+
+
+template <class _CharT, class _Traits>
+inline
+basic_ofstream<_CharT, _Traits>::basic_ofstream(const std::wstring& path, std::ios_base::openmode __mode)
+: std::basic_ostream<char_type, traits_type>(0)
+, __sb_(0)
+{
+    open_internal(path, __mode  | std::ios_base::out);
+}
+
+template <class _CharT, class _Traits>
+inline
+basic_ofstream<_CharT, _Traits>::~basic_ofstream()
+{
+    delete __sb_;
+}
+
+
+template <class _CharT, class _Traits>
+inline
+void
+basic_ofstream<_CharT, _Traits>::open_internal(const std::wstring& path, std::ios_base::openmode mode)
+{
+	if (is_open()) {
+		// if the stream is already associated with a file (i.e., it is already open), calling this function fails.
+		this->setstate(std::ios_base::failbit);
+        return;
+	}
+    int fd;
+    int oflag = ios_open_mode_to_oflag(mode);
+    errno_t errcode = _wsopen_s(&fd, path.c_str(), oflag, _SH_DENYNO, _S_IREAD | _S_IWRITE);
+    if (errcode != 0) {
+        this->setstate(std::ios_base::failbit);
+        return;
+    }
+    __sb_ = new stdio_filebuf(fd, mode, 1);
+    if (__sb_ == 0) {
+        this->setstate(std::ios_base::failbit);
+        return;
+    }
+	// 409. Closing an fstream should clear error state
+    this->clear();
+	assert(__sb_);
+	
+	// In init() the rdstate() is set to badbit if __sb_ is NULL and
+	// goodbit otherwise. The assert afterwards ensures this.
+    this->init(__sb_);
+	assert(this->good() && !this->fail());
+}
+
+
+template <class _CharT, class _Traits>
+inline
+typename basic_ofstream<_CharT, _Traits>::stdio_filebuf*
+basic_ofstream<_CharT, _Traits>::rdbuf() const
+{
+    return const_cast<stdio_filebuf*>(__sb_);
+}
+
+
+
+template <class _CharT, class _Traits>
+inline
+bool
+basic_ofstream<_CharT, _Traits>::is_open() const
+{
+    return __sb_ && __sb_->is_open();
+}
+
+
+template <class _CharT, class _Traits>
+void
+basic_ofstream<_CharT, _Traits>::open(const std::wstring& path, std::ios_base::openmode __mode)
+{
+    open_internal(path, __mode | std::ios_base::out);
+}
+
+template <class _CharT, class _Traits>
+inline 
+void
+basic_ofstream<_CharT, _Traits>::close()
+{
+    if (!__sb_) {
+        return;
+    }
+    if (__sb_->close() == 0)
+        this->setstate(std::ios_base::failbit);
+    
+    delete __sb_;
+	__sb_= 0;
+}
+// basic_fstream
+
+OIIO_NAMESPACE_END
+
+
+#endif // #if defined(_WIN32) && defined(__GLIBCXX__)
+
+
+#endif // OPENIMAGEIO_FSTREAM_MINGW_H

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -49,12 +49,6 @@
 #include <windows.h>
 #include <shellapi.h>
 #include <direct.h>
-#include <fcntl.h>
-#include <sys/stat.h>
-#include <Share.h>
-#ifdef __GLIBCXX__
-#include <ext/stdio_filebuf.h> // __gnu_cxx::stdio_filebuf
-#endif
 #else
 #include <unistd.h>
 #endif
@@ -262,7 +256,16 @@ Filesystem::exists (const std::string &path)
 {
     bool r = false;
     try {
+#if defined(_WIN32)
+		// boost internally doesn't use MultiByteToWideChar (CP_UTF8,...
+		// to convert char* to wchar_t* because they do not know the encoding
+		// See boost::filesystem::path.hpp 
+		// The only correct way to do this is to do the conversion ourselves
+		std::wstring wpath = Strutil::utf8_to_utf16(path);
+		r = boost::filesystem::exists (wpath);
+#else
         r = boost::filesystem::exists (path);
+#endif
     } catch (...) {
         r = false;
     }
@@ -276,7 +279,16 @@ Filesystem::is_directory (const std::string &path)
 {
     bool r = false;
     try {
-        r = boost::filesystem::is_directory (path);
+#if defined(_WIN32)
+		// boost internally doesn't use MultiByteToWideChar (CP_UTF8,...
+		// to convert char* to wchar_t* because they do not know the encoding
+		// See boost::filesystem::path.hpp 
+		// The only correct way to do this is to do the conversion ourselves
+		std::wstring wpath = Strutil::utf8_to_utf16(path);
+        r = boost::filesystem::is_directory (wpath);
+#else
+		r = boost::filesystem::is_directory (path);
+#endif
     } catch (...) {
         r = false;
     }
@@ -290,7 +302,16 @@ Filesystem::is_regular (const std::string &path)
 {
     bool r = false;
     try {
+#if defined(_WIN32)
+		// boost internally doesn't use MultiByteToWideChar (CP_UTF8,...
+		// to convert char* to wchar_t* because they do not know the encoding
+		// See boost::filesystem::path.hpp 
+		// The only correct way to do this is to do the conversion ourselves
+		std::wstring wpath = Strutil::utf8_to_utf16(path);
+		r = boost::filesystem::is_regular_file (wpath);
+#else
         r = boost::filesystem::is_regular_file (path);
+#endif
     } catch (...) {
         r = false;
     }
@@ -302,16 +323,27 @@ Filesystem::is_regular (const std::string &path)
 bool
 Filesystem::create_directory (string_view path, std::string &err)
 {
+
+#if defined(_WIN32)
+	// boost internally doesn't use MultiByteToWideChar (CP_UTF8,...
+	// to convert char* to wchar_t* because they do not know the encoding
+	// See boost::filesystem::path.hpp 
+	// The only correct way to do this is to do the conversion ourselves
+	std::wstring pathStr = Strutil::utf8_to_utf16(path);
+#else
+	std::string pathStr = path.str();
+#endif
+
 #if BOOST_FILESYSTEM_VERSION >= 3
     boost::system::error_code ec;
-    bool ok = boost::filesystem::create_directory (path.str(), ec);
+	bool ok = boost::filesystem::create_directory (pathStr, ec);
     if (ok)
         err.clear();
     else
         err = ec.message();
     return ok;
 #else
-    bool ok = boost::filesystem::create_directory (path.str());
+    bool ok = boost::filesystem::create_directory (pathStr);
     if (ok)
         err.clear();
     else
@@ -324,12 +356,24 @@ Filesystem::create_directory (string_view path, std::string &err)
 bool
 Filesystem::copy (string_view from, string_view to, std::string &err)
 {
+#if defined(_WIN32)
+	// boost internally doesn't use MultiByteToWideChar (CP_UTF8,...
+	// to convert char* to wchar_t* because they do not know the encoding
+	// See boost::filesystem::path.hpp 
+	// The only correct way to do this is to do the conversion ourselves
+	std::wstring fromStr = Strutil::utf8_to_utf16(from);
+	std::wstring toStr = Strutil::utf8_to_utf16(to);
+#else
+	std::string fromStr = from.str();
+	std::string toStr = to.str();
+#endif
+
 #if BOOST_FILESYSTEM_VERSION >= 3
     boost::system::error_code ec;
 # if BOOST_VERSION < 105000
-    boost::filesystem3::copy (from.str(), to.str(), ec);
+    boost::filesystem3::copy (fromStr, toStr, ec);
 # else
-    boost::filesystem::copy (from.str(), to.str(), ec);
+    boost::filesystem::copy (fromStr, toStr, ec);
 # endif
     if (! ec) {
         err.clear();
@@ -348,12 +392,23 @@ Filesystem::copy (string_view from, string_view to, std::string &err)
 bool
 Filesystem::rename (string_view from, string_view to, std::string &err)
 {
+#if defined(_WIN32)
+	// boost internally doesn't use MultiByteToWideChar (CP_UTF8,...
+	// to convert char* to wchar_t* because they do not know the encoding
+	// See boost::filesystem::path.hpp 
+	// The only correct way to do this is to do the conversion ourselves
+	std::wstring fromStr = Strutil::utf8_to_utf16(from);
+	std::wstring toStr = Strutil::utf8_to_utf16(to);
+#else
+	std::string fromStr = from.str();
+	std::string toStr = to.str();
+#endif
 #if BOOST_FILESYSTEM_VERSION >= 3
     boost::system::error_code ec;
 # if BOOST_VERSION < 105000
-    boost::filesystem3::rename (from.str(), to.str(), ec);
+    boost::filesystem3::rename (fromStr, toStr, ec);
 # else
-    boost::filesystem::rename (from.str(), to.str(), ec);
+    boost::filesystem::rename (fromStr, toStr, ec);
 # endif
     if (! ec) {
         err.clear();
@@ -372,16 +427,25 @@ Filesystem::rename (string_view from, string_view to, std::string &err)
 bool
 Filesystem::remove (string_view path, std::string &err)
 {
+#if defined(_WIN32)
+	// boost internally doesn't use MultiByteToWideChar (CP_UTF8,...
+	// to convert char* to wchar_t* because they do not know the encoding
+	// See boost::filesystem::path.hpp 
+	// The only correct way to do this is to do the conversion ourselves
+	std::wstring pathStr = Strutil::utf8_to_utf16(path);
+#else
+	std::string pathStr = path.str();
+#endif
 #if BOOST_FILESYSTEM_VERSION >= 3
     boost::system::error_code ec;
-    bool ok = boost::filesystem::remove (path.str(), ec);
+    bool ok = boost::filesystem::remove (pathStr, ec);
     if (ok)
         err.clear();
     else
         err = ec.message();
     return ok;
 #else
-    bool ok = boost::filesystem::remove (path.str());
+    bool ok = boost::filesystem::remove (pathStr);
     if (ok)
         err.clear();
     else
@@ -395,16 +459,25 @@ Filesystem::remove (string_view path, std::string &err)
 unsigned long long
 Filesystem::remove_all (string_view path, std::string &err)
 {
+#if defined(_WIN32)
+	// boost internally doesn't use MultiByteToWideChar (CP_UTF8,...
+	// to convert char* to wchar_t* because they do not know the encoding
+	// See boost::filesystem::path.hpp 
+	// The only correct way to do this is to do the conversion ourselves
+	std::wstring pathStr = Strutil::utf8_to_utf16(path);
+#else
+	std::string pathStr = path.str();
+#endif
 #if BOOST_FILESYSTEM_VERSION >= 3
     boost::system::error_code ec;
-    unsigned long long n = boost::filesystem::remove_all (path.str(), ec);
+    unsigned long long n = boost::filesystem::remove_all (pathStr, ec);
     if (!ec)
         err.clear();
     else
         err = ec.message();
     return n;
 #else
-    unsigned long long n = boost::filesystem::remove_all (path.str());
+    unsigned long long n = boost::filesystem::remove_all (pathStr);
     err.clear();
     return n;
 #endif
@@ -437,9 +510,18 @@ Filesystem::temp_directory_path()
 std::string
 Filesystem::unique_path (string_view model)
 {
+#if defined(_WIN32)
+	// boost internally doesn't use MultiByteToWideChar (CP_UTF8,...
+	// to convert char* to wchar_t* because they do not know the encoding
+	// See boost::filesystem::path.hpp 
+	// The only correct way to do this is to do the conversion ourselves
+	std::wstring modelStr = Strutil::utf8_to_utf16(model);
+#else
+	std::string modelStr = model.str();
+#endif
 #if BOOST_FILESYSTEM_VERSION >= 3
     boost::system::error_code ec;
-    boost::filesystem::path p = boost::filesystem::unique_path (model.str(), ec);
+    boost::filesystem::path p = boost::filesystem::unique_path (modelStr, ec);
     return ec ? std::string() : p.string();
 #elif _MSC_VER
     char buf[TMP_MAX];
@@ -493,12 +575,12 @@ Filesystem::fopen (string_view path, string_view mode)
 
 
 void
-Filesystem::open (std::ifstream &stream, string_view path,
+Filesystem::open (OIIO_NAMESPACE::ifstream &stream, string_view path,
                   std::ios_base::openmode mode)
 {
 #ifdef _WIN32
-    // This will not work correctly on GCC with MingW
     // Windows std::ifstream accepts non-standard wchar_t* 
+	// On MingW, we use our own OIIO_NAMESPACE::ifstream
     std::wstring wpath = Strutil::utf8_to_utf16(path);
     stream.open (wpath.c_str(), mode);
     stream.seekg (0, std::ios_base::beg); // force seek, otherwise broken
@@ -510,211 +592,18 @@ Filesystem::open (std::ifstream &stream, string_view path,
 
 
 void
-Filesystem::open (std::ofstream &stream, string_view path,
+Filesystem::open (OIIO_NAMESPACE::ofstream &stream, string_view path,
                   std::ios_base::openmode mode)
 {
-#ifdef _WIN32
-    // This will not work correctly on GCC with MingW
+#ifdef _WIN32 
     // Windows std::ofstream accepts non-standard wchar_t*
+	// On MingW, we use our own OIIO_NAMESPACE::ofstream
     std::wstring wpath = Strutil::utf8_to_utf16 (path);
     stream.open (wpath.c_str(), mode);
 #else
     stream.open (path.c_str(), mode);
 #endif
 }
-
-
-
-#if defined(_WIN32) && defined(__GLIBCXX__)
-// MingW uses GCC to build, but does not support having a wchar_t* passed as argument
-// of ifstream::open or ofstream::open. To properly support UTF-8 encoding on MingW we must
-// use the __gnu_cxx::stdio_filebuf GNU extension that can be used with _wfsopen and returned
-// into a istream which share the same API as ifsteam. The same reasoning holds for ofstream.
-
-static int
-ios_open_mode_to_oflag (std::ios_base::openmode mode)
-{
-    int f = 0;
-    if (mode & std::ios_base::in) {
-        f |= _O_RDONLY;
-    }
-    if (mode & std::ios_base::out) {
-        f |= _O_WRONLY;
-        f |= _O_CREAT;
-        if (mode & std::ios_base::app) {
-            f |= _O_APPEND;
-        }
-        if (mode & std::ios_base::trunc) {
-            f |= _O_TRUNC;
-        }
-    }
-    if (mode & std::ios_base::binary) {
-        f |= _O_BINARY;
-    } else {
-        f |= _O_TEXT;
-    }
-    return f;
-}
-
-static std::istream*
-open_ifstream_impl (string_view path,
-                    std::ios_base::openmode mode)
-{
-    std::wstring wpath = Strutil::utf8_to_utf16(path);
-    int fd;
-    int oflag = ios_open_mode_to_oflag(mode);
-    errno_t errcode = _wsopen_s (&fd, wpath.c_str(), oflag,
-                                 _SH_DENYNO, _S_IREAD | _S_IWRITE);
-    if (errcode != 0) {
-        return 0;
-    }
-    __gnu_cxx::stdio_filebuf<char>* buffer = new __gnu_cxx::stdio_filebuf<char>(fd, mode, 1);
-    if (!buffer) {
-        return 0;
-    }
-    return new std::istream(buffer);
-}
-
-static std::ostream*
-open_ofstream_impl (string_view path,
-                    std::ios_base::openmode mode)
-{
-    
-    std::wstring wpath = Strutil::utf8_to_utf16(path);
-    int fd;
-    int oflag = ios_open_mode_to_oflag(mode);
-    errno_t errcode = _wsopen_s (&fd, wpath.c_str(), oflag,
-                                 _SH_DENYNO, _S_IREAD | _S_IWRITE);
-    if (errcode != 0) {
-        return 0;
-    }
-    __gnu_cxx::stdio_filebuf<char>* buffer = new __gnu_cxx::stdio_filebuf<char>(fd, mode, 1);
-    if (!buffer) {
-        return 0;
-    }
-    return new std::ostream(buffer);
-}
-
-#else // MSVC or Unix
-
-#ifdef _WIN32
-#  ifndef _MSC_VER_
-#    error "open_ifstream_impl only supports GCC or MSVC"
-#  endif
-#endif
-
-static std::ifstream*
-open_ifstream_impl (string_view path,  std::ios_base::openmode  mode)
-{
-    
-#ifdef _WIN32
-    std::wstring wpath = Strutil::utf8_to_utf16(path);
-#endif
-    std::ifstream *ret = new std::ifstream();
-    if (!ret) {
-        return 0;
-    }
-    try {
-#ifdef _WIN32
-        ret->open (wpath.c_str(), mode);
-#else
-        ret->open (path.c_str(), mode);
-#endif
-    } catch (const std::exception & e) {
-        delete ret;
-        return 0;
-    }
-
-    if (!*ret) {
-        delete ret;
-        return 0;
-    }
-
-    return ret;
-} // open_ifstream_impl
-
-
-static std::ofstream*
-open_ofstream_impl (string_view path, std::ios_base::openmode mode)
-{
-#ifdef _WIN32
-    std::wstring wpath = Strutil::utf8_to_utf16(path);
-#endif
-    std::ofstream *ret = new std::ofstream();
-    if (!ret) {
-        return 0;
-    }
-    try {
-#ifdef _WIN32
-        ret->open (wpath.c_str(), mode);
-#else
-        ret->open (path.c_str(), mode);
-#endif
-    } catch (const std::exception & e) {
-        delete ret;
-        return 0;
-    }
-    
-    if (!*ret) {
-        delete ret;
-        return 0;
-    }
-    
-    return ret;
-}
-
-#endif //#if defined(_WIN32) &&  defined(__GLIBCXX__)
-
-
-
-void
-Filesystem::open (std::istream** stream,
-                  string_view path,
-                  std::ios_base::openmode mode)
-{
-    if (!stream) {
-        return;
-    }
-    *stream = open_ifstream_impl(path, mode | std::ios_base::in);
-    if (!*stream) {
-        return;
-    }
-    if (mode & std::ios_base::ate) {
-        (*stream)->seekg (0, std::ios_base::end);
-    } else {
-        (*stream)->seekg (0, std::ios_base::beg); // force seek, otherwise broken
-    }
-    if ((*stream)->fail()) {
-        delete *stream;
-        *stream = 0;
-    }
-}
-
-
-
-void
-Filesystem::open (std::ostream** stream,
-                  string_view path,
-                  std::ios_base::openmode mode)
-{
-    
-    if (!stream) {
-        return;
-    }
-    *stream = open_ofstream_impl(path, mode | std::ios_base::out);
-    if (!*stream) {
-        return;
-    }
-    if ((mode & std::ios_base::app) == 0) {
-        (*stream)->seekp (0, std::ios_base::end);  // force seek, otherwise broken
-    }
-    if ((*stream)->fail()) {
-        delete *stream;
-        *stream = 0;
-    }
-}
-
-
 
 
 /// Read the entire contents of the named file and place it in str,
@@ -724,14 +613,13 @@ Filesystem::read_text_file (string_view filename, std::string &str)
 {
     // For info on why this is the fastest method:
     // http://insanecoding.blogspot.com/2011/11/how-to-read-in-file-in-c.html
-    std::istream* inraw;
-    Filesystem::open (&inraw, filename);
-    shared_ptr<std::istream> in(inraw);
+    OIIO_NAMESPACE::ifstream in;
+    Filesystem::open (in, filename);
 
     // N.B. for binary read: open(in, filename, std::ios::in|std::ios::binary);
     if (in) {
         std::ostringstream contents;
-        contents << in->rdbuf();
+        contents << in.rdbuf();
         str = contents.str();
         return true;
     }

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -87,7 +87,6 @@
 #include "OpenImageIO/deepdata.h"
 
 #include <boost/scoped_array.hpp>
-#include <boost/scoped_ptr.hpp>
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
@@ -101,49 +100,40 @@ public:
     OpenEXRInputStream (const char *filename) : Imf::IStream (filename) {
         // The reason we have this class is for this line, so that we
         // can correctly handle UTF-8 file paths on Windows
-        {
-            std::istream* ifsraw;
-            Filesystem::open (&ifsraw, filename, std::ios_base::binary);
-            if (ifsraw) {
-                ifs.reset(ifsraw);
-            }
-        }
-        if (!ifs)
+        Filesystem::open (ifs, filename, std::ios_base::binary);
+        if (!ifs) 
             Iex::throwErrnoExc ();
     }
     virtual bool read (char c[], int n) {
-        if (!ifs)
+        if (!ifs) 
             throw Iex::InputExc ("Unexpected end of file.");
+		
         errno = 0;
-        ifs->read (c, n);
+        ifs.read (c, n);
         return check_error ();
     }
     virtual Imath::Int64 tellg () {
-        return ifs ? std::streamoff (ifs->tellg ()) : 0;
+        return std::streamoff (ifs.tellg ());
     }
     virtual void seekg (Imath::Int64 pos) {
-        if (!ifs) {
-            Iex::throwErrnoExc ();
-        }
-        ifs->seekg (pos);
+        ifs.seekg (pos);
         check_error ();
     }
     virtual void clear () {
-        if (ifs) {
-            ifs->clear ();
-        }
+        ifs.clear ();
     }
 
 private:
     bool check_error () {
         if (!ifs) {
-            if (errno)
+            if (errno) 
                 Iex::throwErrnoExc ();
+			
             return false;
         }
         return true;
     }
-    boost::scoped_ptr<std::istream> ifs;
+    OIIO_NAMESPACE::ifstream ifs;
 };
 
 

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -87,8 +87,6 @@
 #include "OpenImageIO/sysutil.h"
 #include "OpenImageIO/fmath.h"
 
-#include <boost/scoped_ptr.hpp>
-
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
 
@@ -102,32 +100,20 @@ public:
     OpenEXROutputStream (const char *filename) : Imf::OStream(filename) {
         // The reason we have this class is for this line, so that we
         // can correctly handle UTF-8 file paths on Windows
-        {
-            std::ostream* rawhandle;
-            Filesystem::open (&rawhandle, filename, std::ios_base::binary);
-            if (rawhandle) {
-                ofs.reset(rawhandle);
-            }
-        }
-        if (!ofs)
+        Filesystem::open (ofs, filename, std::ios_base::binary);
+        if (!ofs) 	
             Iex::throwErrnoExc ();
     }
     virtual void write (const char c[], int n) {
-        if (!ofs) {
-            Iex::throwErrnoExc ();
-        }
         errno = 0;
-        ofs->write (c, n);
+        ofs.write (c, n);
         check_error ();
     }
     virtual Imath::Int64 tellp () {
-        return ofs ? std::streamoff (ofs->tellp ()) : 0;
+        return std::streamoff (ofs.tellp ());
     }
     virtual void seekp (Imath::Int64 pos) {
-        if (!ofs) {
-            Iex::throwErrnoExc ();
-        }
-        ofs->seekp (pos);
+        ofs.seekp (pos);
         check_error ();
     }
 
@@ -139,7 +125,7 @@ private:
             throw Iex::ErrnoExc ("File output failed.");
         }
     }
-    boost::scoped_ptr<std::ostream> ofs;
+    OIIO_NAMESPACE::ofstream ofs;
 };
 
 

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -32,8 +32,6 @@
 #include <fstream>
 #include <cstdlib>
 
-#include <boost/scoped_ptr.hpp>
-
 #include "OpenImageIO/filesystem.h"
 #include "OpenImageIO/fmath.h"
 #include "OpenImageIO/imageio.h"
@@ -55,7 +53,7 @@ private:
       P1, P2, P3, P4, P5, P6, Pf, PF
     };
 
-    boost::scoped_ptr<std::istream> m_file;
+    OIIO_NAMESPACE::ifstream m_file;
     std::streampos m_header_end_pos; // file position after the header
     std::string m_current_line; ///< Buffer the image pixels
     const char * m_pos;
@@ -258,7 +256,7 @@ PNMInput::read_file_scanline (void * data, int y)
     if (m_pnm_type == PF || m_pnm_type == Pf) {
         int file_scanline = m_spec.height - 1 - (y-m_spec.y);
         std::streampos offset = file_scanline * m_spec.scanline_bytes();
-        m_file->seekg (m_header_end_pos + offset, std::ios_base::beg);
+        m_file.seekg (m_header_end_pos + offset, std::ios_base::beg);
     }
 
     if ((m_pnm_type >= P4 && m_pnm_type <= P6) || m_pnm_type == PF || m_pnm_type == Pf){
@@ -270,25 +268,25 @@ PNMInput::read_file_scanline (void * data, int y)
         else
             numbytes = m_spec.scanline_bytes();
         buf.resize (numbytes);
-        m_file->read ((char*)&buf[0], numbytes);
-        if (!m_file->good())
+        m_file.read ((char*)&buf[0], numbytes);
+        if (!m_file.good())
             return false;
     }
 
     switch (m_pnm_type) {
         //Ascii 
         case P1:
-            good &= ascii_to_raw (*m_file, m_current_line, m_pos, (unsigned char *) data,
+            good &= ascii_to_raw (m_file, m_current_line, m_pos, (unsigned char *) data,
                                   nsamples, (unsigned char)m_max_val);
             invert ((unsigned char *)data, (unsigned char *)data, nsamples); 
             break;
         case P2:
         case P3:
             if (m_max_val > std::numeric_limits<unsigned char>::max())
-                good &= ascii_to_raw (*m_file, m_current_line, m_pos, (unsigned short *) data,
+                good &= ascii_to_raw (m_file, m_current_line, m_pos, (unsigned short *) data,
                                       nsamples, (unsigned short)m_max_val);
             else 
-                good &= ascii_to_raw (*m_file, m_current_line, m_pos, (unsigned char *) data,
+                good &= ascii_to_raw (m_file, m_current_line, m_pos, (unsigned char *) data,
                                       nsamples, (unsigned char)m_max_val);
             break;
         //Raw
@@ -337,11 +335,11 @@ PNMInput::read_file_header ()
         return false;
   
     //MagicNumber
-    *m_file >> c;
+    m_file >> c;
     if (c != 'P')
         return false;
     
-    *m_file >> c;
+    m_file >> c;
     switch(c) {
       case '1':
         m_pnm_type = P1;
@@ -372,23 +370,23 @@ PNMInput::read_file_header ()
     }
     
     //Size
-    if (!read_int (*m_file, width))
+    if (!read_int (m_file, width))
         return false; 
-    if (!read_int (*m_file, height))
+    if (!read_int (m_file, height))
         return false; 
 
     if(m_pnm_type != PF && m_pnm_type != Pf) {
         //Max Val
         if (m_pnm_type != P1 && m_pnm_type != P4) {
-            if (!read_int (*m_file, m_max_val))
+            if (!read_int (m_file, m_max_val))
                 return false;
         } else
             m_max_val = 1;
         
         //Space before content
-        if (!(isspace (m_file->get()) && m_file->good()))
+        if (!(isspace (m_file.get()) && m_file.good()))
             return false;
-        m_header_end_pos = m_file->tellg ();   // remember file pos
+        m_header_end_pos = m_file.tellg ();   // remember file pos
 
         if (m_pnm_type == P3 || m_pnm_type == P6)
             m_spec =  ImageSpec (width, height, 3, 
@@ -411,14 +409,14 @@ PNMInput::read_file_header ()
         return true;
     } else {
         //Read scaling factor
-        if(!read_int(*m_file, m_scaling_factor)) {
+        if(!read_int(m_file, m_scaling_factor)) {
             return false;
         }
         
         //Space before content
-        if (!(isspace (m_file->get()) && m_file->good()))
+        if (!(isspace (m_file.get()) && m_file.good()))
             return false;
-        m_header_end_pos = m_file->tellg ();   // remember file pos
+        m_header_end_pos = m_file.tellg ();   // remember file pos
 
         if(m_pnm_type == PF) {
             m_spec = ImageSpec(width, height, 3, TypeDesc::FLOAT);
@@ -450,13 +448,8 @@ PNMInput::open (const std::string &name, ImageSpec &newspec)
 {
     close(); //close previously opened file
     
-    std::istream* rawfile;
-    Filesystem::open (&rawfile, name, std::ios::in|std::ios::binary);
-    if (rawfile) {
-        m_file.reset(rawfile);
-    }
-    
-    
+    Filesystem::open (m_file, name, std::ios::in|std::ios::binary);
+ 
     m_current_line = "";
     m_pos = m_current_line.c_str();
 
@@ -472,8 +465,7 @@ PNMInput::open (const std::string &name, ImageSpec &newspec)
 bool
 PNMInput::close ()
 {
-    if (m_file)
-        m_file.reset();
+    m_file.close();
     return true;
 }
 

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -30,8 +30,6 @@
 
 #include <fstream>
 
-#include <boost/scoped_ptr.hpp>
-
 #include "OpenImageIO/filesystem.h"
 #include "OpenImageIO/imageio.h"
 
@@ -53,7 +51,7 @@ public:
 
 private:
     std::string m_filename;           ///< Stash the filename
-    boost::scoped_ptr<std::ostream> m_file;
+    OIIO_NAMESPACE::ofstream m_file;
     unsigned int m_max_val, m_pnm_type;
     unsigned int m_dither;
     std::vector<unsigned char> m_scratch;
@@ -188,21 +186,12 @@ PNMOutput::open (const std::string &name, const ImageSpec &userspec,
     if (!m_spec.get_int_attribute ("pnm:binary", 1)) 
     {
         m_pnm_type -= 3;
-        {
-            std::ostream* raw;
-            Filesystem::open (&raw, name);
-            if (raw) {
-                m_file.reset(raw);
-            }
-        }
+        Filesystem::open (m_file, name);
+        
     }
     else {
-        std::ostream* raw;
-        Filesystem::open (&raw, name, std::ios::out|std::ios::binary);
-        if (raw) {
-            m_file.reset(raw);
-        }
-        
+        Filesystem::open (m_file, name, std::ios::out|std::ios::binary);
+ 
     }
     
     if (!m_file)
@@ -210,17 +199,17 @@ PNMOutput::open (const std::string &name, const ImageSpec &userspec,
 
     m_max_val = (1 << bits_per_sample) - 1;
     // Write header
-    *m_file << "P" << m_pnm_type << std::endl;
-    *m_file << m_spec.width << " " << m_spec.height << std::endl;
+    m_file << "P" << m_pnm_type << std::endl;
+    m_file << m_spec.width << " " << m_spec.height << std::endl;
     if (m_pnm_type != 1 && m_pnm_type != 4)  // only non-monochrome 
-        *m_file << m_max_val << std::endl;
+        m_file << m_max_val << std::endl;
 
     // If user asked for tiles -- which this format doesn't support, emulate
     // it by buffering the whole image.
     if (m_spec.tile_width && m_spec.tile_height)
         m_tilebuffer.resize (m_spec.image_bytes());
 
-    return m_file->good();
+    return m_file.good();
 }
 
 
@@ -241,7 +230,7 @@ PNMOutput::close ()
         std::vector<unsigned char>().swap (m_tilebuffer);
     }
 
-    m_file.reset();
+    m_file.close();
     return true;  
 }
 
@@ -265,30 +254,30 @@ PNMOutput::write_scanline (int y, int z, TypeDesc format,
 
     switch (m_pnm_type){
         case 1:
-            write_ascii_binary (*m_file, (unsigned char *) data, xstride, m_spec);
+            write_ascii_binary (m_file, (unsigned char *) data, xstride, m_spec);
             break;
         case 2:
         case 3:
             if (m_max_val > std::numeric_limits<unsigned char>::max())
-                write_ascii (*m_file, (unsigned short *) data, xstride, m_spec, m_max_val);
+                write_ascii (m_file, (unsigned short *) data, xstride, m_spec, m_max_val);
             else 
-                write_ascii (*m_file, (unsigned char *) data, xstride, m_spec, m_max_val);
+                write_ascii (m_file, (unsigned char *) data, xstride, m_spec, m_max_val);
             break;
         case 4:
-            write_raw_binary (*m_file, (unsigned char *) data, xstride, m_spec);
+            write_raw_binary (m_file, (unsigned char *) data, xstride, m_spec);
             break;
         case 5:
         case 6:
             if (m_max_val > std::numeric_limits<unsigned char>::max())
-                write_raw (*m_file, (unsigned short *) data, xstride, m_spec, m_max_val);
+                write_raw (m_file, (unsigned short *) data, xstride, m_spec, m_max_val);
             else 
-                write_raw (*m_file, (unsigned char *) data, xstride, m_spec, m_max_val);
+                write_raw (m_file, (unsigned char *) data, xstride, m_spec, m_max_val);
             break;
         default:
             return false;
     } 
 
-    return m_file->good();
+    return m_file.good();
 }
 
 

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -36,7 +36,6 @@
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/foreach.hpp>
-#include <boost/scoped_ptr.hpp>
 
 #include "psd_pvt.h"
 #include "jpeg_memory_src.h"
@@ -197,7 +196,7 @@ private:
     };
 
     std::string m_filename;
-    boost::scoped_ptr<std::istream> m_file;
+    OIIO_NAMESPACE::ifstream m_file;
     //Current subimage
     int m_subimage;
     //Subimage count (1 + layer count)
@@ -387,14 +386,14 @@ private:
     bool read_bige (TVariable &value)
     {
         TStorage buffer;
-        m_file->read ((char *)&buffer, sizeof(buffer));
+        m_file.read ((char *)&buffer, sizeof(buffer));
         if (!bigendian ())
             swap_endian (&buffer);
 
         // For debugging, numeric_cast will throw if precision is lost:
         // value = boost::numeric_cast<TVariable>(buffer);
         value = buffer;
-        return m_file->good();
+        return m_file.good();
     }
 
     int read_pascal_string (std::string &s, uint16_t mod_padding);
@@ -544,13 +543,9 @@ bool
 PSDInput::open (const std::string &name, ImageSpec &newspec)
 {
     m_filename = name;
-    {
-        std::istream* raw;
-        Filesystem::open (&raw, name, std::ios::binary);
-        if (raw) {
-            m_file.reset(raw);
-        }
-    }
+
+    Filesystem::open (m_file, name, std::ios::binary);
+  
     if (!m_file) {
         error ("\"%s\": failed to open file", name.c_str());
         return false;
@@ -766,7 +761,7 @@ void
 PSDInput::init ()
 {
     m_filename.clear ();
-    m_file.reset();
+    m_file.close();
     m_subimage = -1;
     m_subimage_count = 0;
     m_specs.clear ();
@@ -802,9 +797,9 @@ PSDInput::load_header ()
 bool
 PSDInput::read_header ()
 {
-    m_file->read (m_header.signature, 4);
+    m_file.read (m_header.signature, 4);
     read_bige<uint16_t> (m_header.version);
-    m_file->seekg(6, std::ios::cur);
+    m_file.seekg(6, std::ios::cur);
     read_bige<uint16_t> (m_header.channel_count);
     read_bige<uint32_t> (m_header.height);
     read_bige<uint32_t> (m_header.width);
@@ -899,7 +894,7 @@ PSDInput::load_color_data ()
 
     if (m_color_data.length) {
         m_color_data.data.resize (m_color_data.length);
-        m_file->read (&m_color_data.data[0], m_color_data.length);
+        m_file.read (&m_color_data.data[0], m_color_data.length);
     }
     return check_io ();
 }
@@ -933,9 +928,9 @@ PSDInput::load_resources ()
 
     ImageResourceBlock block;
     ImageResourceMap resources;
-    std::streampos begin = m_file->tellg ();
+    std::streampos begin = m_file.tellg ();
     std::streampos end = begin + (std::streampos)length;
-    while (m_file && m_file->tellg () < end) {
+    while (m_file && m_file.tellg () < end) {
         if (!read_resource (block) || !validate_resource (block))
             return false;
 
@@ -947,7 +942,7 @@ PSDInput::load_resources ()
     if (!handle_resources (resources))
         return false;
 
-    m_file->seekg (end);
+    m_file.seekg (end);
     return check_io ();
 }
 
@@ -956,18 +951,18 @@ PSDInput::load_resources ()
 bool
 PSDInput::read_resource (ImageResourceBlock &block)
 {
-    m_file->read (block.signature, 4);
+    m_file.read (block.signature, 4);
     read_bige<uint16_t> (block.id);
     read_pascal_string (block.name, 2);
     read_bige<uint32_t> (block.length);
     // Save the file position of the image resource data
-    block.pos = m_file->tellg();
+    block.pos = m_file.tellg();
     // Skip the image resource data
-    m_file->seekg (block.length, std::ios::cur);
+    m_file.seekg (block.length, std::ios::cur);
     // Image resource blocks are supposed to be padded to an even size.
     // I'm not sure if the padding is included in the length field
     if (block.length % 2 != 0)
-        m_file->seekg(1, std::ios::cur);
+        m_file.seekg(1, std::ios::cur);
 
     return check_io ();
 }
@@ -995,7 +990,7 @@ PSDInput::handle_resources (ImageResourceMap &resources)
         ImageResourceMap::const_iterator it (resources.find (loader.resource_id));
         // If a resource with that ID exists in the file, call the loader
         if (it != end) {
-            m_file->seekg (it->second.pos);
+            m_file.seekg (it->second.pos);
             if (!check_io ())
                 return false;
 
@@ -1122,7 +1117,7 @@ bool
 PSDInput::load_resource_1058 (uint32_t length)
 {
     std::string data (length, 0);
-    if (!m_file->read (&data[0], length))
+    if (!m_file.read (&data[0], length))
         return false;
 
     if (!decode_exif (&data[0], length, m_composite_attribs) ||
@@ -1148,7 +1143,7 @@ bool
 PSDInput::load_resource_1060 (uint32_t length)
 {
     std::string data (length, 0);
-    if (!m_file->read (&data[0], length))
+    if (!m_file.read (&data[0], length))
         return false;
 
     // Store the XMP data for the composite and all other subimages
@@ -1230,7 +1225,7 @@ PSDInput::load_resource_thumbnail (uint32_t length, bool isBGR)
         return false;
     }
     std::string jpeg_data (jpeg_length, '\0');
-    if (!m_file->read (&jpeg_data[0], jpeg_length))
+    if (!m_file.read (&jpeg_data[0], jpeg_length))
         return false;
 
     jpeg_create_decompress (&cinfo);
@@ -1289,7 +1284,7 @@ PSDInput::load_layers ()
     else
         read_bige<uint64_t> (m_layer_mask_info.length);
 
-    m_layer_mask_info.begin = m_file->tellg ();
+    m_layer_mask_info.begin = m_file.tellg ();
     m_layer_mask_info.end = m_layer_mask_info.begin
                           + (std::streampos)m_layer_mask_info.length;
     if (!check_io ())
@@ -1304,7 +1299,7 @@ PSDInput::load_layers ()
     else
         read_bige<uint64_t> (layer_info.length);
 
-    layer_info.begin = m_file->tellg ();
+    layer_info.begin = m_file.tellg ();
     layer_info.end = layer_info.begin + (std::streampos)layer_info.length;
     if (!check_io ())
         return false;
@@ -1358,7 +1353,7 @@ PSDInput::load_layer (Layer &layer)
         layer.channel_id_map[channel_info.channel_id] = &channel_info;
     }
     char bm_signature[4];
-    m_file->read (bm_signature, 4);
+    m_file.read (bm_signature, 4);
     if (!check_io ())
         return false;
 
@@ -1366,12 +1361,12 @@ PSDInput::load_layer (Layer &layer)
         error ("[Layer Record] Invalid blend mode signature");
         return false;
     }
-    m_file->read (layer.bm_key, 4);
+    m_file.read (layer.bm_key, 4);
     read_bige<uint8_t> (layer.opacity);
     read_bige<uint8_t> (layer.clipping);
     read_bige<uint8_t> (layer.flags);
     // skip filler
-    m_file->seekg(1, std::ios::cur);
+    m_file.seekg(1, std::ios::cur);
     read_bige<uint32_t> (layer.extra_length);
     uint32_t extra_remaining = layer.extra_length;
     // layer mask data length
@@ -1391,12 +1386,12 @@ PSDInput::load_layer (Layer &layer)
             read_bige<uint8_t> (layer.mask_data.default_color);
             read_bige<uint8_t> (layer.mask_data.flags);
             // skip padding
-            m_file->seekg(2, std::ios::cur);
+            m_file.seekg(2, std::ios::cur);
             break;
         case 36:
             // In this case, we skip the above (lmd_length == 20) fields
             // to read the "real" fields.
-            m_file->seekg (18, std::ios::cur);
+            m_file.seekg (18, std::ios::cur);
             read_bige<uint8_t> (layer.mask_data.flags);
             read_bige<uint8_t> (layer.mask_data.default_color);
             read_bige<uint32_t> (layer.mask_data.top);
@@ -1416,7 +1411,7 @@ PSDInput::load_layer (Layer &layer)
     uint32_t lbr_length;
     read_bige<uint32_t> (lbr_length);
     // skip block
-    m_file->seekg (lbr_length, std::ios::cur);
+    m_file.seekg (lbr_length, std::ios::cur);
     extra_remaining -= (lbr_length + 4);
     if (!check_io ())
         return false;
@@ -1427,8 +1422,8 @@ PSDInput::load_layer (Layer &layer)
         Layer::AdditionalInfo &info = layer.additional_info.back();
 
         char signature[4];
-        m_file->read (signature, 4);
-        m_file->read (info.key, 4);
+        m_file.read (signature, 4);
+        m_file.read (info.key, 4);
         if (std::memcmp (signature, "8BIM", 4) != 0
               && std::memcmp (signature, "8B64", 4) != 0) {
             error ("[Additional Layer Info] invalid signature");
@@ -1442,7 +1437,7 @@ PSDInput::load_layer (Layer &layer)
             read_bige<uint32_t> (info.length);
             extra_remaining -= 4;
         }
-        m_file->seekg (info.length, std::ios::cur);
+        m_file.seekg (info.length, std::ios::cur);
         extra_remaining -= info.length;
     }
     return check_io ();
@@ -1466,7 +1461,7 @@ PSDInput::load_layer_channels (Layer &layer)
 bool
 PSDInput::load_layer_channel (Layer &layer, ChannelInfo &channel_info)
 {
-    std::streampos start_pos = m_file->tellg ();
+    std::streampos start_pos = m_file.tellg ();
     if (channel_info.data_length >= 2) {
         read_bige<uint16_t> (channel_info.compression);
         if (!check_io ())
@@ -1476,7 +1471,7 @@ PSDInput::load_layer_channel (Layer &layer, ChannelInfo &channel_info)
     if (channel_info.data_length <= 2)
         return true;
 
-    channel_info.data_pos = m_file->tellg ();
+    channel_info.data_pos = m_file.tellg ();
     channel_info.row_pos.resize (layer.height);
     channel_info.row_length = (layer.width * m_header.depth + 7) / 8;
     switch (channel_info.compression) {
@@ -1494,7 +1489,7 @@ PSDInput::load_layer_channel (Layer &layer, ChannelInfo &channel_info)
                 return false;
 
             // channel data is located after the RLE lengths
-            channel_info.data_pos = m_file->tellg ();
+            channel_info.data_pos = m_file.tellg ();
             // subtract the RLE lengths read above
             channel_info.data_length = channel_info.data_length - (channel_info.data_pos - start_pos);
             if (layer.height) {
@@ -1514,7 +1509,7 @@ PSDInput::load_layer_channel (Layer &layer, ChannelInfo &channel_info)
             return false;
 ;
     }
-    m_file->seekg (channel_info.data_length, std::ios::cur);
+    m_file.seekg (channel_info.data_length, std::ios::cur);
     return check_io ();
 
 }
@@ -1542,19 +1537,19 @@ PSDInput::load_global_mask_info ()
     if (!m_layer_mask_info.length)
         return true;
 
-    m_file->seekg (m_layer_mask_info.layer_info.end);
-    uint64_t remaining = m_layer_mask_info.end - m_file->tellg();
+    m_file.seekg (m_layer_mask_info.layer_info.end);
+    uint64_t remaining = m_layer_mask_info.end - m_file.tellg();
     uint32_t length;
 
     // This section should be at least 17 bytes, but some files lack
     // global mask info and additional layer info, not convered in the spec
     if (remaining < 17) {
-        m_file->seekg(m_layer_mask_info.end);
+        m_file.seekg(m_layer_mask_info.end);
         return true;
     }
 
     read_bige<uint32_t> (length);
-    std::streampos start = m_file->tellg ();
+    std::streampos start = m_file.tellg ();
     std::streampos end = start + (std::streampos)length;
     if (!check_io ())
         return false;
@@ -1569,7 +1564,7 @@ PSDInput::load_global_mask_info ()
 
     read_bige<uint16_t> (m_global_mask_info.opacity);
     read_bige<int16_t> (m_global_mask_info.kind);
-    m_file->seekg (end);
+    m_file.seekg (end);
     return check_io ();
 }
 
@@ -1584,9 +1579,9 @@ PSDInput::load_global_additional ()
     char signature[4];
     char key[4];
     uint64_t length;
-    uint64_t remaining = m_layer_mask_info.length - (m_file->tellg() - m_layer_mask_info.begin);
+    uint64_t remaining = m_layer_mask_info.length - (m_file.tellg() - m_layer_mask_info.begin);
     while (m_file && remaining >= 12) {
-        m_file->read (signature, 4);
+        m_file.read (signature, 4);
         if (!check_io ())
             return false;
 
@@ -1595,7 +1590,7 @@ PSDInput::load_global_additional ()
             error ("[Global Additional Layer Info] invalid signature");
             return false;
         }
-        m_file->read (key, 4);
+        m_file.read (key, 4);
         if (!check_io ())
             return false;
 
@@ -1614,10 +1609,10 @@ PSDInput::load_global_additional ()
         length = (length + 3) & ~3;
         remaining -= length;
         // skip it for now
-        m_file->seekg (length, std::ios::cur);
+        m_file.seekg (length, std::ios::cur);
     }
     // finished with the layer and mask information section, seek to the end
-    m_file->seekg (m_layer_mask_info.end);
+    m_file.seekg (m_layer_mask_info.end);
     return check_io ();
 }
 
@@ -1651,7 +1646,7 @@ PSDInput::load_image_data ()
     }
     BOOST_FOREACH (ChannelInfo &channel_info, m_image_data.channel_info) {
         channel_info.row_pos.resize (m_header.height);
-        channel_info.data_pos = m_file->tellg ();
+        channel_info.data_pos = m_file.tellg ();
         channel_info.row_length = (m_header.width * m_header.depth + 7) / 8;
         switch (compression) {
             case Compression_Raw:
@@ -1659,14 +1654,14 @@ PSDInput::load_image_data ()
                 for (uint32_t i = 1; i < m_header.height; ++i)
                     channel_info.row_pos[i] = channel_info.row_pos[i - 1] + (std::streampos)row_length;
 
-                m_file->seekg (channel_info.row_pos.back () + (std::streampos)row_length);
+                m_file.seekg (channel_info.row_pos.back () + (std::streampos)row_length);
                 break;
             case Compression_RLE:
                 channel_info.row_pos[0] = channel_info.data_pos;
                 for (uint32_t i = 1; i < m_header.height; ++i)
                     channel_info.row_pos[i] = channel_info.row_pos[i - 1] + (std::streampos)channel_info.rle_lengths[i - 1];
 
-                m_file->seekg (channel_info.row_pos.back () + (std::streampos)channel_info.rle_lengths.back ());
+                m_file.seekg (channel_info.row_pos.back () + (std::streampos)channel_info.rle_lengths.back ());
                 break;
         }
     }
@@ -1755,17 +1750,17 @@ PSDInput::read_channel_row (const ChannelInfo &channel_info, uint32_t row, char 
 
     uint32_t rle_length;
     channel_info.row_pos[row];
-    m_file->seekg (channel_info.row_pos[row]);
+    m_file.seekg (channel_info.row_pos[row]);
     switch (channel_info.compression) {
         case Compression_Raw:
-            m_file->read (data, channel_info.row_length);
+            m_file.read (data, channel_info.row_length);
             break;
         case Compression_RLE:
             rle_length = channel_info.rle_lengths[row];
             if (m_rle_buffer.size () < rle_length)
                 m_rle_buffer.resize (rle_length);
 
-            m_file->read (&m_rle_buffer[0], rle_length);
+            m_file.read (&m_rle_buffer[0], rle_length);
             if (!check_io ())
                 return false;
 
@@ -1914,18 +1909,18 @@ PSDInput::read_pascal_string (std::string &s, uint16_t mod_padding)
     s.clear();
     uint8_t length;
     int bytes = 0;
-    if (m_file->read ((char *)&length, 1)) {
+    if (m_file.read ((char *)&length, 1)) {
         bytes = 1;
         if (length == 0) {
-            if (m_file->seekg (mod_padding - 1, std::ios::cur))
+            if (m_file.seekg (mod_padding - 1, std::ios::cur))
                 bytes += mod_padding - 1;
         } else {
             s.resize (length);
-            if (m_file->read (&s[0], length)) {
+            if (m_file.read (&s[0], length)) {
                 bytes += length;
                 if (mod_padding > 0) {
                     for (int padded_length = length + 1; padded_length % mod_padding != 0; padded_length++) {
-                        if (!m_file->seekg(1, std::ios::cur))
+                        if (!m_file.seekg(1, std::ios::cur))
                             break;
 
                         bytes++;


### PR DESCRIPTION
See original pull-request: #1366

Less intrusive implementation which only requires user to use OIIO_NAMESPACE::ifstream / OIIO_NAMESPACE::ofstream instead of the original fix proposed in the pull request #1366.

This is cleaned-up in a single commit with other compilation fixes stripped-off 