### PR TITLE
exr_threads: 0 means hardware_concurrency, -1 means no thread-pool

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1239,6 +1239,9 @@ OIIO_API std::string geterror ();
 ///     int exr_threads
 ///             The size of the internal OpenEXR thread pool. The default
 ///             is to use the full available hardware concurrency detected.
+///             Default is 0 meaning to use full available hardware
+///             concurrency detected, -1 means to disable usage of the OpenEXR
+///             thread pool and execute everything in the caller thread.
 ///     string plugin_searchpath
 ///             Colon-separated list of directories to search for 
 ///             dynamically-loaded format plugins.

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -320,8 +320,13 @@ void set_exr_threads ()
 
     int oiio_threads = 1;
     OIIO::getattribute ("exr_threads", oiio_threads);
+    
+    // 0 means all threads in OIIO, but single-threaded in OpenEXR
+    // -1 means single-threaded in OIIO
     if (oiio_threads == 0) {
         oiio_threads = Sysutil::hardware_concurrency();
+    } else if (oiio_threads == -1) {
+        oiio_threads = 0;
     }
     spin_lock lock (exr_threads_mutex);
     if (exr_threads != oiio_threads) {


### PR DESCRIPTION
**exr_threads**: use -1 to disable usage of OpenEXR thread-pool (and to clean its threads)

See my comment in https://github.com/OpenImageIO/oiio/issues/1375
