### PR TITLE
Adjustments to color transformations for under-specified OCIO cases.

### DIFF
--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -90,16 +90,22 @@ ColorConfig::Impl::inventory ()
 {
 #ifdef USE_OCIO
     if (config_) {
-        for (int i = 0, e = config_->getNumColorSpaces();  i < e;  ++i) {
-            std::string name = config_->getColorSpaceNameByIndex(i);
-            add (name, i);
+        bool nonraw = false;
+        for (int i = 0, e = config_->getNumColorSpaces();  i < e;  ++i)
+            nonraw |= ! Strutil::iequals(config_->getColorSpaceNameByIndex(i), "raw");
+        if (nonraw) {
+            for (int i = 0, e = config_->getNumColorSpaces();  i < e;  ++i)
+                add (config_->getColorSpaceNameByIndex(i), i);
+            OCIO::ConstColorSpaceRcPtr lin = config_->getColorSpace ("scene_linear");
+            if (lin)
+                linear_alias = lin->getName();
+            return;   // If any non-"raw" spaces were defined, we're done
         }
-        OCIO::ConstColorSpaceRcPtr lin = config_->getColorSpace ("scene_linear");
-        if (lin)
-            linear_alias = lin->getName();
     }
-    if (colorspaces.size())
-        return;   // If any were defined, we're done
+    // If we had some kind of bogus configuration that seemed to define
+    // only a "raw" color space and nothing else, that's useless, so
+    // figure out our own way to move forward.
+    config_.reset();
 #endif
 
     // If there was no configuration, or we didn't compile with OCIO
@@ -505,18 +511,24 @@ ColorProcessor*
 ColorConfig::createColorProcessor (string_view inputColorSpace,
                                    string_view outputColorSpace) const
 {
+    string_view inputrole, outputrole;
 #ifdef USE_OCIO
     // Ask OCIO to make a Processor that can handle the requested
     // transformation.
+    OCIO::ConstProcessorRcPtr p;
     if (getImpl()->config_) {
         // If the names are roles, convert them to color space names
         string_view name;
         name = getColorSpaceNameByRole (inputColorSpace);
-        if (! name.empty())
+        if (! name.empty()) {
+            inputrole = inputColorSpace;
             inputColorSpace = name;
+        }
         name = getColorSpaceNameByRole (outputColorSpace);
-        if (! name.empty())
+        if (! name.empty()) {
+            outputrole = outputColorSpace;
             outputColorSpace = name;
+        }
         OCIO::ConstProcessorRcPtr p;
         try {
             // Get the processor corresponding to this transform.
@@ -533,30 +545,44 @@ ColorConfig::createColorProcessor (string_view inputColorSpace,
         }
     
         getImpl()->error_ = "";
-        return new ColorProcessor_OCIO(p);
+        if (p && ! p->isNoOp()) {
+            // If we got a valid processor that does something useful,
+            // return it now. If it boils down to a no-op, give a second
+            // chance below to recognize it as a special case.
+            return new ColorProcessor_OCIO(p);
+        }
     }
 #endif
 
     // Either not compiled with OCIO support, or no OCIO configuration
     // was found at all.  There are a few color conversions we know
     // about even in such dire conditions.
-    if (Strutil::iequals(inputColorSpace,"linear") &&
-        Strutil::iequals(outputColorSpace,"sRGB")) {
+    using namespace Strutil;
+    if ((iequals(inputColorSpace,"linear") || iequals(inputrole,"linear")) &&
+        iequals(outputColorSpace,"sRGB")) {
         return new ColorProcessor_linear_to_sRGB;
     }
-    if (Strutil::iequals(inputColorSpace,"sRGB") &&
-        Strutil::iequals(outputColorSpace,"linear")) {
+    if (iequals(inputColorSpace,"sRGB") &&
+        (iequals(outputColorSpace,"linear") || iequals(outputrole,"linear"))) {
         return new ColorProcessor_sRGB_to_linear;
     }
-    if (Strutil::iequals(inputColorSpace,"linear") &&
-        Strutil::iequals(outputColorSpace,"Rec709")) {
+    if ((iequals(inputColorSpace,"linear") || iequals(inputrole,"linear")) &&
+        iequals(outputColorSpace,"Rec709")) {
         return new ColorProcessor_linear_to_Rec709;
     }
-    if (Strutil::iequals(inputColorSpace,"Rec709") &&
-        Strutil::iequals(outputColorSpace,"linear")) {
+    if (iequals(inputColorSpace,"Rec709") &&
+        (iequals(outputColorSpace,"linear") || iequals(outputrole,"linear"))) {
         // No OCIO, or the OCIO config doesn't know linear->sRGB
         return new ColorProcessor_Rec709_to_linear;
     }
+
+#ifdef USE_OCIO
+    if (p) {
+        // If we found a procesor from OCIO, even if it was a NoOp, and we
+        // still don't have a better idea, return it.
+        return new ColorProcessor_OCIO(p);
+    }
+#endif
 
     return NULL;    // if we get this far, we've failed
 }
@@ -721,11 +747,11 @@ string_view
 ColorConfig::parseColorSpaceFromString (string_view str) const
 {
 #ifdef USE_OCIO
-    string_view result (getImpl()->config_->parseColorSpaceFromString (str.c_str()));
-    return result;
-#else
-    return "";
+    if (getImpl() && getImpl()->config_) {
+        return getImpl()->config_->parseColorSpaceFromString (str.c_str());
+    }
 #endif
+    return "";
 }
 
 


### PR DESCRIPTION
* Be a little more forgiving about the color space name being "linear"
  versus the color role name being "linear" when determining if we can
  fall back on our best guess conversions between linear, sRGB, and
  Rec709.

* If OCIO is present and then best it can do when asked for a color
  processor is give a NoOp, go ahead and see if the space names
  nevertheless are ones for which we have a fallback (linear, sRGB, and
  Rec709). We strive to let OCIO handle color transformations if
  present, but on the other hand, we know damn well that linear and sRGB
  aren't the same, so if OCIO gives us a NoOp to convert between them,
  I think it's fair for us to not believe it and try ourselves.

* Address bogusly minimal OCIO configuration in which all known color
  spaces are simply marked as "raw" -- it's useless, so forget the OCIO
  stuff in that case.

* No OCIO configuration -- a couple fixes to prevent problems when $OCIO
  points nowhere useful.