### PR TITLE
simd exp, log, pow (exact and approximate/fast versions), and speed up sRGB<->linear

### DIFF
--- a/src/include/OpenImageIO/timer.h
+++ b/src/include/OpenImageIO/timer.h
@@ -272,7 +272,7 @@ template <class T>
 inline void __attribute__((__optnone__))
 DoNotOptimize (T const &val) { }
 
-#elif (OIIO_GNUC_VERSION || OIIO_CLANG_VERSION >= 30500 || OIIO_APPLE_CLANG_VERSION >= 60000 || defined(__INTEL_COMPILER)) && (defined(__x86_64__) || defined(__i386__))
+#elif ((OIIO_GNUC_VERSION && NDEBUG) || OIIO_CLANG_VERSION >= 30500 || OIIO_APPLE_CLANG_VERSION >= 70000 || defined(__INTEL_COMPILER)) && (defined(__x86_64__) || defined(__i386__))
 
 // Major non-MS compilers on x86/x86_64: use asm trick to indicate that
 // the value is needed.
@@ -300,7 +300,7 @@ template <class T> inline void DoNotOptimize (T const &val) { }
 /// fools the compiler into thinking that potentially any part of memory
 /// has been modified, and thus serves as a barrier where the optimizer
 /// won't assume anything about the state of memory preceding it.
-#if (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)) && (defined(__x86_64__) || defined(__i386__))
+#if ((OIIO_GNUC_VERSION && NDEBUG) || OIIO_CLANG_VERSION >= 30500 || OIIO_APPLE_CLANG_VERSION >= 70000 || defined(__INTEL_COMPILER)) && (defined(__x86_64__) || defined(__i386__))
 
 // Special trick for x86/x86_64 and gcc-like compilers
 inline void clobber_all_memory() {

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -399,11 +399,23 @@ public:
     {
         if (channels > 3)
             channels = 3;
-        for (int y = 0;  y < height;  ++y) {
-            char *d = (char *)data + y*ystride;
-            for (int x = 0;  x < width;  ++x, d += xstride)
-                for (int c = 0;  c < channels;  ++c)
-                    ((float *)d)[c] = sRGB_to_linear (((float *)d)[c]);
+        if (channels == 3) {
+            for (int y = 0;  y < height;  ++y) {
+                char *d = (char *)data + y*ystride;
+                for (int x = 0;  x < width;  ++x, d += xstride) {
+                    simd::float4 r;
+                    r.load ((float *)d, 3);
+                    r = sRGB_to_linear (simd::float4((float *)d));
+                    r.store ((float *)d, 3);
+                }
+            }
+        } else {
+            for (int y = 0;  y < height;  ++y) {
+                char *d = (char *)data + y*ystride;
+                for (int x = 0;  x < width;  ++x, d += xstride)
+                    for (int c = 0;  c < channels;  ++c)
+                        ((float *)d)[c] = sRGB_to_linear (((float *)d)[c]);
+            }
         }
     }
 };
@@ -421,11 +433,23 @@ public:
     {
         if (channels > 3)
             channels = 3;
-        for (int y = 0;  y < height;  ++y) {
-            char *d = (char *)data + y*ystride;
-            for (int x = 0;  x < width;  ++x, d += xstride)
-                for (int c = 0;  c < channels;  ++c)
-                    ((float *)d)[c] = linear_to_sRGB (((float *)d)[c]);
+        if (channels == 3) {
+            for (int y = 0;  y < height;  ++y) {
+                char *d = (char *)data + y*ystride;
+                for (int x = 0;  x < width;  ++x, d += xstride) {
+                    simd::float4 r;
+                    r.load ((float *)d, 3);
+                    r = linear_to_sRGB (simd::float4((float *)d));
+                    r.store ((float *)d, 3);
+                }
+            }
+        } else {
+            for (int y = 0;  y < height;  ++y) {
+                char *d = (char *)data + y*ystride;
+                for (int x = 0;  x < width;  ++x, d += xstride)
+                    for (int c = 0;  c < channels;  ++c)
+                        ((float *)d)[c] = linear_to_sRGB (((float *)d)[c]);
+            }
         }
     }
 };


### PR DESCRIPTION
simd exp, log, pow (exact and approximate/fast versions)

Also add code to simd_test to not only verify that they work, but also
benchmark them.
