### PR TITLE
Several oiiotool enhancements for big images

### DIFF
--- a/src/doc/imagecache.tex
+++ b/src/doc/imagecache.tex
@@ -283,6 +283,7 @@ not found in OIIO's ``lib'' directory.)
 
 \apiitem{int autotile \\
 int autoscanline}
+\label{imagecacheattr:autotile}
 These attributes control how the image cache deals with images that
 are not ``tiled'' (i.e., are stored as scanlines). 
 

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -932,6 +932,19 @@ native format (if it's not a format that can use the ImageCache without a
 loss of precision).
 \apiend
 
+\apiitem{\ce --cache {\rm \emph{size}}}
+\NEW % 1.7
+Set the underlying \ImageCache size (in MB). See Section~\ref{imagecacheattr:autotile}.
+\apiend
+
+\apiitem{\ce --autotile {\rm \emph{tilesize}}}
+\NEW % 1.7
+For the underlying \ImageCache, turn on auto-tiling with the given tile
+size. Setting \emph{tilesize} to 0 turns off auto-tiling. If auto-tile
+is turned on, The \ImageCache \qkw{autoscanline} feature will also be enabled.
+See Section~\ref{imagecacheattr:autotile} for details.
+\apiend
+
 \newpage
 \subsection*{Writing images}
 

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -916,20 +916,28 @@ names and use automatic conversion:
 \apiend
 
 \apiitem{\ce --native}
-Normally, all image reads into an \ImageBuf will be performed via an
-underlying \ImageCache. But since an \ImageCache does not support all
-possible data formats, some lesser-used formats may be auto-converted upon
-being read into the cache, and therefore lose precision or range compared to
-what the equivalent {\cf ImageInput::read_image} is capable of. (An example
-would be a rare file of {\cf uint32} or {\cf double} pixels, which would
-lose data when read into an \ImageCache whose ``biggest'' data type is
-{\cf float}.)
+Normally, all images read by \oiiotool are read into an \ImageBuf backed by
+an underlying \ImageCache, and are automatically converted to {\cf float}
+pixels for internal storage (because any subsequent image processing is
+usually much faster and more accurate when done on floating-point values).
 
-The {\cf --native} option is used for the small set of cases where this is
-problematic in practice. It causes subsequent image loads to bypass the
-\ImageCache and instead do an immediate read of the file that preserves its
-native format (if it's not a format that can use the ImageCache without a
-loss of precision).
+This option causes (1) input images to be stored internally in their native
+pixel data type rather than converted to float, and (2) to bypass the
+\ImageCache (reading directly into an \ImageBuf) if the pixel data type is
+not one of the types that is supported internally to \ImageCache ({\cf uint8},
+{\cf uint16}, {\cf half}, and {\cf float}).
+
+images whose pixels are comprised of data types that
+are not natively representable exactly in the \ImageCache to bypass the
+\ImageCache and be read directly into an \ImageBuf.
+
+The typical use case for this is when you know you are dealing with unusual
+pixel data types that might lose precision if converted to {\cf float} (for
+example, if you have images with {\cf uint32} or {\cf double} pixels).
+Another use case is if you are using \oiiotool merely for file format or
+data format conversion, with no actual image processing math performed on
+the pixel values -- in that case, you might save time and memory by
+bypassing the conversion to {\cf float}.
 \apiend
 
 \apiitem{\ce --cache {\rm \emph{size}}}

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -94,7 +94,7 @@
  \bigskip \\
 }
 \date{{\large 
-Date: 9 Feb 2016
+Date: 18 Mar 2016
 %\\ (with corrections, 25 Aug 2015)
 }}
 

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -258,10 +258,17 @@ ImageRec::read (bool force_native_read)
             bool forceread = (s == 0 && m == 0 &&
                               m_imagecache->imagespec(uname,s,m)->image_bytes() < 50*1024*1024);
             ImageBuf *ib = new ImageBuf (name(), m_imagecache);
-            TypeDesc convert = TypeDesc::FLOAT;
+            TypeDesc convert = TypeDesc::UNKNOWN;
             if (force_native_read) {
-                forceread = true;
                 convert = ib->nativespec().format;
+                if (convert != TypeDesc::UINT8 && convert != TypeDesc::UINT16 &&
+                    convert != TypeDesc::HALF &&  convert != TypeDesc::FLOAT) {
+                    // It can't be represented natively in the IC
+                    convert = TypeDesc::FLOAT;
+                    forceread = true;
+                }
+            } else {
+                convert = TypeDesc::FLOAT;
             }
             bool ok = ib->read (s, m, forceread, convert);
             if (!ok)

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -365,6 +365,17 @@ set_autotile (int argc, const char *argv[])
 
 
 static int
+set_native (int argc, const char *argv[])
+{
+    ASSERT (argc == 1);
+    ot.nativeread = true;
+    ot.imagecache->attribute ("forcefloat", 0);
+    return 0;
+}
+
+
+
+static int
 set_dumpdata (int argc, const char *argv[])
 {
     ASSERT (argc == 1);
@@ -4319,7 +4330,7 @@ getargs (int argc, char *argv[])
                 "--auto-orient", &ot.autoorient, "", // symonym for --autoorient
                 "--autocc", &ot.autocc, "Automatically color convert based on filename",
                 "--noautocc %!", &ot.autocc, "Turn off automatic color conversion",
-                "--native", &ot.nativeread, "Force native data type reads if cache would lose precision",
+                "--native %@", set_native, &ot.nativeread, "Keep native pixel data type (bypass cache if necessary)",
                 "--cache %@ %d", set_cachesize, &ot.cachesize, "ImageCache size (in MB: default=4096)",
                 "--autotile %@ %d", set_autotile, &ot.autotile, "Autotile size for cached images (default=4096)",
                 "<SEPARATOR>", "Commands that write images:",
@@ -4751,7 +4762,7 @@ main (int argc, char *argv[])
         ot.check_peak_memory ();
         std::cout << "  Peak memory:    " << Strutil::memformat(ot.peak_memory) << "\n";
         std::cout << "  Current memory: " << Strutil::memformat(Sysutil::memory_used()) << "\n";
-        std::cout << "\n" << ot.imagecache->getstats() << "\n";
+        std::cout << "\n" << ot.imagecache->getstats(2) << "\n";
     }
 
     return ot.return_value;

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -65,6 +65,8 @@ public:
     bool autoorient;
     bool autocc;                      // automatically color correct
     bool nativeread;                  // force native data type reads
+    int cachesize;
+    int autotile;
     std::string full_command_line;
     std::string printinfo_metamatch;
     std::string printinfo_nometamatch;

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -34,6 +34,7 @@
 #include "OpenImageIO/imagebuf.h"
 #include "OpenImageIO/refcnt.h"
 #include "OpenImageIO/timer.h"
+#include "OpenImageIO/sysutil.h"
 
 
 OIIO_NAMESPACE_BEGIN
@@ -105,6 +106,7 @@ public:
     typedef std::map<std::string, double> TimingMap;
     TimingMap function_times;
     bool enable_function_timing;
+    size_t peak_memory;
 
     Oiiotool ();
 
@@ -188,6 +190,12 @@ public:
 
     void error (string_view command, string_view explanation="");
     void warning (string_view command, string_view explanation="");
+
+    size_t check_peak_memory () {
+        size_t mem = Sysutil::memory_used();
+        peak_memory = std::max (peak_memory, mem);
+        return mem;
+    }
 
 private:
     CallbackFunction m_pending_callback;
@@ -549,6 +557,9 @@ public:
             if (img[i]->has_error())
                 ot.error (opname(), img[i]->geterror());
         }
+
+        if (ot.debug || ot.runstats)
+            ot.check_peak_memory();
 
         // Optional cleanup after processing all the subimages
         cleanup ();


### PR DESCRIPTION
Thematically related but orthogonal changes:

* oiiotool --runstats tracks and reports max memory usage.

* oiiotool new options --cache and --autotile can explicitly set the ImageCache size and autotile settings.

* oiiotool --native behavior is adjusted so that it still uses the cache if the pixel data type is one that the cache supports natively (and it turns off "forcefloat" on the cache). This is actually closer to the way --native was described in the docs.

* ImageBuf::write (used by oiiotool) has been modified to be more memory efficient for very large files -- when IC-backed (not in memory), it will write scanlines or tiles in strips rather than force the whole input image to be read fully into RAM. This doesn't help when using oiiotool for "image processing", which will tend to create intermediate result images that are entirely in memory, but when using oiiotool just to copy images (say, with file format or data format conversions, or adjusting metadata or compression) it really is a case of going straight from IC-backed input to an output, so this can greatly reduce the memory footprint in those cases.
