### PR TITLE
ImageBuf::pixelindex

### DIFF
--- a/src/doc/imagebuf.tex
+++ b/src/doc/imagebuf.tex
@@ -700,6 +700,12 @@ Use with extreme caution!  Will return NULL if the pixel values
 aren't local (for example, if backed by an \ImageCache).
 \apiend
 
+\apiitem{int {\ce pixelindex} (int x, int y, int z, bool check_range=false) const}
+\NEW %1.7
+Return the index of pixel (x,y,z). If {\cf check_range} is {\cf true},
+return -1 for an invalid coordinate that is not within the data window.
+\apiend
+
 
 
 \section{Iterators -- the fast way of accessing individual pixels}

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -1551,6 +1551,11 @@ retrieve the error message (and clear it afterwards).
 \end{code}
 \apiend
 
+\apiitem(int ImageBuf.{\ce pixelindex} (x, y, z, check_range=False))
+\NEW %1.7
+Return the index of pixel (x,y,z).
+\apiend
+
 \apiitem{bool ImageBuf.{\ce deep}}
 Will be {\cf True} if the file contains ``deep'' pixel data, or {\cf False}
 for an ordinary images.

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -649,6 +649,10 @@ public:
     /// aren't local.
     void *pixeladdr (int x, int y, int z);
 
+    /// Return the index of pixel (x,y,z). If check_range is true, return
+    /// -1 for an invalid coordinate that is not within the data window.
+    int pixelindex (int x, int y, int z, bool check_range=false) const;
+
     /// Does this ImageBuf store deep data?
     bool deep () const;
 

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -480,6 +480,8 @@ void declare_imagebuf()
         .add_property("has_error",   &ImageBuf::has_error)
         .def("geterror",    &ImageBuf::geterror)
 
+        .def("pixelindex", &ImageBuf::pixelindex,
+             (arg("x"), arg("y"), arg("z"), arg("check_range")=false))
         .def("copy_metadata", &ImageBuf::copy_metadata)
         .def("copy_pixels", &ImageBuf::copy_pixels)
         .def("copy",  &ImageBuf_copy,


### PR DESCRIPTION
Handy conversion from (x,y,z) to indexed pixel within the data window.
We can use this to eliminate some redundant boilerplate code.