### PR TITLE
oiiotool: -i 

### DIFF
--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -847,10 +847,26 @@ or control the way that subsequent images will be written upon output.
 
 \subsection*{Reading images}
 
-\apiitem{\ce \rm \emph{filename}}
+\apiitem{\ce \rm \emph{filename} \\
+\ce -i \rm \emph{filename}}
+\label{sec:oiiotool:i}
 If a command-line option is the name of an image file, that file will
 be read and will become the new \emph{current image}, with the previous
 current image pushed onto the image stack.
+
+The {\cf -i} command may be used, which allows additional
+options that control the reading of just that one file.
+\noindent Optional appended arguments include:
+
+\noindent \begin{tabular}{p{1.25in} p{3.75in}}
+{\cf now=}\emph{int} & If 1, read the image now, before proceding to the
+     next command. \\
+{\cf autocc=}\emph{int} & Enable or disable {\cf --autocc} for
+     this input image. \\
+{\cf info=}\emph{int} & Print info about this file (even if the global
+     {\cf --info} was not used) if nonzero. If the value is 2, print full
+     verbose info (like {\cf --info -v}). \\
+\end{tabular}
 \apiend
 
 \apiitem{\ce --no-autopremult \\
@@ -979,7 +995,7 @@ current image from the image stack, it merely saves a copy of it.
 {\cf separate=}\emph{int} & \\
 {\cf contig=}\emph{int} & Set separate or contiguous planar configuration
     for this output. \\
-& {\cf\small fileformatname=}\emph{string} & Specify the desired output file
+{\cf\small fileformatname=}\emph{string} & Specify the desired output file
   format, overriding any guess based on file name extension. \\
 \end{tabular}
 

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -239,7 +239,6 @@ ImageRec::read (bool force_native_read)
         return false;  // Image not found
     }
     m_subimages.resize (subimages);
-
     bool allok = true;
     for (int s = 0;  s < subimages;  ++s) {
         int miplevels = 0;

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -225,7 +225,7 @@ ImageRec::ImageRec (const std::string &name, const ImageSpec &spec,
 
 
 bool
-ImageRec::read (bool force_native_read)
+ImageRec::read (ReadPolicy readpolicy)
 {
     if (elaborated())
         return true;
@@ -257,18 +257,22 @@ ImageRec::read (bool force_native_read)
             bool forceread = (s == 0 && m == 0 &&
                               m_imagecache->imagespec(uname,s,m)->image_bytes() < 50*1024*1024);
             ImageBuf *ib = new ImageBuf (name(), m_imagecache);
-            TypeDesc convert = TypeDesc::UNKNOWN;
-            if (force_native_read) {
-                convert = ib->nativespec().format;
-                if (convert != TypeDesc::UINT8 && convert != TypeDesc::UINT16 &&
-                    convert != TypeDesc::HALF &&  convert != TypeDesc::FLOAT) {
-                    // It can't be represented natively in the IC
-                    convert = TypeDesc::FLOAT;
-                    forceread = true;
-                }
-            } else {
-                convert = TypeDesc::FLOAT;
+
+            // If we were requested to bypass the cache, force a full read.
+            if (readpolicy & ReadNoCache)
+                forceread = true;
+
+            // Convert to float unless asked to keep native.
+            TypeDesc convert = (readpolicy & ReadNative)
+                             ? ib->nativespec().format : TypeDesc::FLOAT;
+            if (! forceread &&
+                convert != TypeDesc::UINT8 && convert != TypeDesc::UINT16 &&
+                convert != TypeDesc::HALF &&  convert != TypeDesc::FLOAT) {
+                // If we're still trying to use the cache but it doesn't
+                // support the native type, force a full read.
+                forceread = true;
             }
+
             bool ok = ib->read (s, m, forceread, convert);
             if (!ok)
                 error ("%s", ib->geterror());

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -201,7 +201,7 @@ format_resolution (int w, int h, int d, int x, int y, int z)
 
 
 bool
-Oiiotool::read (ImageRecRef img)
+Oiiotool::read (ImageRecRef img, ReadPolicy readpolicy)
 {
     // If the image is already elaborated, take an early out, both to
     // save time, but also because we only want to do the format and
@@ -214,7 +214,9 @@ Oiiotool::read (ImageRecRef img)
     float pre_ic_time, post_ic_time;
     imagecache->getattribute ("stat:fileio_time", pre_ic_time);
     total_readtime.start ();
-    bool ok = img->read (ot.nativeread);
+    if (ot.nativeread)
+        readpolicy = ReadPolicy (readpolicy | ReadNative);
+    bool ok = img->read (readpolicy);
     total_readtime.stop ();
     imagecache->getattribute ("stat:fileio_time", post_ic_time);
     total_imagecache_readtime += post_ic_time - pre_ic_time;
@@ -3786,7 +3788,7 @@ input_file (int argc, const char *argv[])
             std::cout << "Reading " << filename << "\n";
         ot.push (ImageRecRef (new ImageRec (filename, ot.imagecache)));
         if (readnow) {
-            ot.curimg->read ();
+            ot.curimg->read (ReadNoCache);
         }
         if (printinfo || ot.printstats || ot.dumpdata || ot.hash) {
             OiioTool::print_info_options pio;

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -46,6 +46,20 @@ class ImageRec;
 typedef shared_ptr<ImageRec> ImageRecRef;
 
 
+/// Polycy hints for reading images
+enum ReadPolicy {
+    ReadDefault = 0,       //< Default: use cache, maybe convert to float.
+                           //<   For "small" files, may bypass cache.
+    ReadNative  = 1,       //< Keep in native type, use cache if it supports
+                           //<   the native type, bypass if not. May still
+                           //<   bypass cache for "small" images.
+    ReadNoCache = 2,       //< Bypass the cache regardless of size (beware!),
+                           //<   but still subject to format conversion.
+    ReadNativeNoCache = 3, //< No cache, no conversion. Do it all now.
+                           //<   You better know what you're doing.
+};
+
+
 
 class Oiiotool {
 public:
@@ -117,11 +131,11 @@ public:
     /// Force img to be read at this point.  Use this wrapper, don't directly
     /// call img->read(), because there's extra work done here specific to
     /// oiiotool.
-    bool read (ImageRecRef img);
+    bool read (ImageRecRef img, ReadPolicy readpolicy = ReadDefault);
     // Read the current image
-    bool read () {
+    bool read (ReadPolicy readpolicy = ReadDefault) {
         if (curimg)
-            return read (curimg);
+            return read (curimg, readpolicy);
         return true;
     }
 
@@ -325,7 +339,7 @@ public:
     // it's lazily kept as name only, without reading the file.)
     bool elaborated () const { return m_elaborated; }
 
-    bool read (bool force_native_read=false);
+    bool read (ReadPolicy readpolicy = ReadDefault);
 
     // ir(subimg,mip) references a specific MIP level of a subimage
     // ir(subimg) references the first MIP level of a subimage


### PR DESCRIPTION
Add -i command to input file. By default it's the same as just giving the filename, but it can take optional arguments, too.

The optional argument of particular interest to me to day is `-i:now=1` which causes the file to be read immediately, bypassing the cache. (There's also a bunch of other refactoring to make this cleaner.)

The reason this is helpful is for benchmarking, to more cleanly account for time of file reading, without it being spread into other operations, which is what would happen ordinarily for files backed by ImageCache.
