### PR TITLE
WIP Support random access writes to subimages/MIPmaps.

### DIFF
--- a/src/doc/imageoutput.tex
+++ b/src/doc/imageoutput.tex
@@ -811,6 +811,18 @@ queried using:
             ...
 \end{code}
 
+Generally, a subimage and/or MIP-map level is written to completion before
+the next {\cf open()} call designates the start of the next subimage or MIP
+level (assuming that the file format supports those concepts in the first
+place). For some file formats, their \ImageOutput may support truly random
+write access across subimages or MIP levels via a variants of {\cf
+write_scanlines()} and {\cf write_tiles()} that take scanline and MIP
+level indices. Support for these calls may be detected by:
+
+\begin{code}
+        if (out->supports ("random_subimage_access"))
+\end{code}
+
 
 \subsection{Multi-image files}
 \label{sec:imageoutput:multiimage}
@@ -1331,8 +1343,14 @@ as such). The following features are recognized by this query:
   pixels must be transmitted via \writescanline (if
   scanline-oriented) or \writetile (if tile-oriented, and only if
   {\kw supports("tiles")} returns true).
-\item[\rm \qkw{random_access}] May tiles or scanlines be written in any
+\item[\rm \qkw{random_access}] May tiles or scanlines (of the current
+  subimage and MIP level) be written in any
   order?  False indicates that they must be in successive order.
+\item[\rm \qkw{random_subimage_access}] May tiles or scanlines be written
+  to subimages or MIP levels in any order on a scanline-by-scanline or
+  tile-by-tile or  basis?  False indicates that each scanline or MIP level
+  must be written to completion, followed by a call to {\cf open()} to
+  explicitly move to the next MIP level or subimage.
 \item[\rm \qkw{multiimage}] Does this format support multiple subimages
   within a single file?
 \item[\rm \qkw{appendsubimage}] Does this format support multiple
@@ -1459,6 +1477,10 @@ access.
 \apiitem{bool {\ce write_scanlines} (int ybegin, int yend, int z, \\
 \bigspc TypeDesc format,
      const void *data, \\
+\bigspc stride_t xstride=AutoStride, stride_t ystride=AutoStride) \\
+bool {\ce write_scanlines} (int ybegin, int yend, int z, \\
+\bigspc int subimage, int miplevel, \\
+\bigspc TypeDesc format, const void *data, \\
 \bigspc stride_t xstride=AutoStride, stride_t ystride=AutoStride)}
 
 Write a block of scanlines that include pixels $(*,y,z)$,
@@ -1482,6 +1504,12 @@ Return {\kw true} for success, {\kw false} for failure.
 It is a failure to call \writescanline with an
 out-of-order scanline if this format driver does not support random
 access.
+
+Note that the second variety of the call, which takes indices for the
+subimage and MIP level to provide truly random access writes across the
+whole collection of images in the file, is only functional for \ImageOutput
+implementations for which {\cf supports("random_subimage_access")} returns
+{\cf true}.
 \apiend
 
 \apiitem{bool {\ce write_tile} (int x, int y, int z, TypeDesc format,
@@ -1515,6 +1543,11 @@ actually a tile boundary.
 \apiitem{bool {\ce write_tiles} (int xbegin, int xend, int ybegin, int yend,\\
 \bigspc int zbegin, int zend, TypeDesc format, const void *data, \\
 \bigspc stride_t xstride=AutoStride, stride_t ystride=AutoStride, \\
+\bigspc stride_t zstride=AutoStride) \\
+bool {\ce write_tiles} (int xbegin, int xend, int ybegin, int yend,\\
+\bigspc int zbegin, int zend, int subimage, int miplevel,\\
+\bigspc TypeDesc format, const void *data,\\
+\bigspc stride_t xstride=AutoStride, stride_t ystride=AutoStride, \\
 \bigspc stride_t zstride=AutoStride)}
 
 Write the tiles that include pixels {\kw xbegin} $\le x <$ {\kw xend},
@@ -1540,6 +1573,12 @@ otherwise {\cf false} for a failure.
 The call will fail if the image is not tiled, or if the pixel ranges
 do not fall along tile (or image) boundaries, or if it is not a valid
 tile range.
+
+Note that the second variety of the call, which takes indices for the
+subimage and MIP level to provide truly random access writes across the
+whole collection of images in the file, is only functional for \ImageOutput
+implementations for which {\cf supports("random_subimage_access")} returns
+{\cf true}.
 \apiend
 
 \apiitem{bool {\ce write_rectangle} ({\small int xbegin, int xend, int ybegin, int yend, \\ \bigspc

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -1064,8 +1064,9 @@ Returns {\cf True} upon success, {\cf False} upon failure.
 \end{code}
 \apiend
 
-\apiitem{bool ImageOutput.{\ce write_scanline} (y, z, pixels) \\
-bool ImageOutput.{\ce write_scanlines} (ybegin, yend, z, pixels)}
+\apiitem{bool ImageOutput.{\ce write_scanline} (y, z, data) \\
+bool ImageOutput.{\ce write_scanlines} (ybegin, yend, z, data) \\
+bool ImageOutput.{\ce write_scanlines} (ybegin, yend, z, subimage, miplevel, data)}
 
 Write one or many scanlines to the currently open file.
 
@@ -1093,8 +1094,10 @@ Write one or many scanlines to the currently open file.
 \end{code}
 \apiend
 
-\apiitem{bool ImageOutput.{\ce write_tile} (x, y, z, pixels) \\
-bool ImageOutput.{\ce write_tiles} (xbegin, xend, ybegin, yend, zbegin, zend)}
+\apiitem{bool ImageOutput.{\ce write_tile} (x, y, z, data) \\
+bool ImageOutput.{\ce write_tiles} (xbegin, xend, ybegin, yend, zbegin, zend, data) \\
+bool ImageOutput.{\ce write_tiles} (xbegin, xend, ybegin, yend, zbegin, zend,\\
+\bigspc\bigspc subimage, miplevel, data)}
 
 Write one or many tiles to the currently open file.
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -873,9 +873,13 @@ public:
     ///    "rectangles"     Does this plugin accept arbitrary rectangular
     ///                       pixel regions, not necessarily aligned to
     ///                       scanlines or tiles?
-    ///    "random_access"  May tiles or scanlines be written in
-    ///                       any order (false indicates that they MUST
-    ///                       be in successive order).
+    ///    "random_access"  May tiles or scanlines (within the current
+    ///                       subimage and MIP level) be written in any
+    ///                       order (false indicates that they MUST be in
+    ///                       successive order).
+    ///    "random_subimage_access"  May tiles or scanlines be written in
+    ///                       written in any order to any subimage or MIP
+    ///                       level?
     ///    "multiimage"     Does this format support multiple subimages
     ///                       within a file?
     ///    "appendsubimage" Does this format support adding subimages one at
@@ -986,12 +990,21 @@ public:
                                   stride_t xstride=AutoStride,
                                   stride_t ystride=AutoStride);
 
+    /// This variety of write_scanlines takes subimge and MIP level indices.
+    /// It is expected that this is only called (and only implemented) for
+    /// ImageOutput subclasses for which supports("random_subimage_access")
+    /// is true.
+    virtual bool write_scanlines (int ybegin, int yend, int z,
+                                  int subimage, int miplevel,
+                                  TypeDesc format, const void *data,
+                                  stride_t xstride=AutoStride,
+                                  stride_t ystride=AutoStride);
+
     /// Write the tile with (x,y,z) as the upper left corner.  (z is
     /// ignored for 2D non-volume images.)  The three stride values give
     /// the distance (in bytes) between successive pixels, scanlines,
     /// and volumetric slices, respectively.  Strides set to AutoStride
     /// imply 'contiguous' data in the shape of a full tile, i.e.,
-
     ///     xstride == spec.nchannels*format.size()
     ///     ystride == xstride*spec.tile_width
     ///     zstride == ystride*spec.tile_height
@@ -1025,6 +1038,17 @@ public:
     ///     zstride == ystride * (yend-ybegin)
     virtual bool write_tiles (int xbegin, int xend, int ybegin, int yend,
                               int zbegin, int zend, TypeDesc format,
+                              const void *data, stride_t xstride=AutoStride,
+                              stride_t ystride=AutoStride,
+                              stride_t zstride=AutoStride);
+
+    /// This variety of write_tiles takes subimge and MIP level indices.
+    /// It is expected that this is only called (and only implemented) for
+    /// ImageOutput subclasses for which supports("random_subimage_access")
+    /// is true.
+    virtual bool write_tiles (int xbegin, int xend, int ybegin, int yend,
+                              int zbegin, int zend,
+                              int subimage, int miplevel, TypeDesc format,
                               const void *data, stride_t xstride=AutoStride,
                               stride_t ystride=AutoStride,
                               stride_t zstride=AutoStride);

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -100,6 +100,20 @@ ImageOutput::write_scanlines (int ybegin, int yend, int z,
 
 
 bool
+ImageOutput::write_scanlines (int ybegin, int yend, int z,
+                              int subimage, int miplevel,
+                              TypeDesc format, const void *data,
+                              stride_t xstride, stride_t ystride)
+{
+    // Overridden for subclasses of ImageOutput that support
+    // random_subimage_access. The default implementation is to ignore
+    // the subimage and miplevel.
+    return write_scanlines (ybegin, yend, z, format, data, xstride, ystride);
+}
+
+
+
+bool
 ImageOutput::write_tile (int x, int y, int z, TypeDesc format,
                          const void *data, stride_t xstride,
                          stride_t ystride,
@@ -160,6 +174,21 @@ bool ImageOutput::write_tiles (int xbegin, int xend, int ybegin, int yend,
         }
     }
     return ok;
+}
+
+
+
+bool ImageOutput::write_tiles (int xbegin, int xend, int ybegin, int yend,
+                               int zbegin, int zend,
+                               int subimage, int miplevel, TypeDesc format,
+                               const void *data, stride_t xstride,
+                               stride_t ystride, stride_t zstride)
+{
+    // Overridden for subclasses of ImageOutput that support
+    // random_subimage_access. The default implementation is to ignore
+    // the subimage and miplevel.
+    return write_tiles (xbegin, xend, ybegin, yend, zbegin, zend,
+                        format, data, xstride, ystride, zstride);
 }
 
 

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -319,6 +319,7 @@ public:
     bool write_scanlines_bt (int, int, int, TypeDesc::BASETYPE,
                             boost::python::object&, stride_t xstride=AutoStride);
     bool write_scanlines_array (int, int, int, numeric::array&);
+    bool write_scanlines_random_array (int, int, int, int, int, numeric::array&);
     bool write_tile (int, int, int, TypeDesc, boost::python::object&,
                      stride_t xstride=AutoStride, stride_t ystride=AutoStride,
                      stride_t zstride=AutoStride);
@@ -337,6 +338,7 @@ public:
                          stride_t ystride=AutoStride,
                          stride_t zstride=AutoStride);
     bool write_tiles_array (int, int, int, int, int, int, numeric::array&);
+    bool write_tiles_random_array (int, int, int, int, int, int, int, int, numeric::array&);
     bool write_image (TypeDesc format, object &buffer,
                       stride_t xstride=AutoStride,
                       stride_t ystride=AutoStride,


### PR DESCRIPTION
DESIGN REVIEW

This adds to ImageOutput a new version of write_scanlines() and
write_tiles() that takes subimage and miplevel designations for formats
that support true random access to subimages/miplevels without the need
to write a subimage or miplevel to completion before moving on to another.

We use supports("random_subimage_access") to designate ImageOutput
plugins that support this.

The presumed use case is for a renderer that is generating many AOVs
simultaneously, each one to a separate subimage in the same file (in
OpenEXR parlance, to different "parts") and as it renders scanlines or
buckets (tiles), wants to write all the AOVs for the current bucket to
their respective subimage, without needing to buffer all the AOVs for
the entire image.

Most ImageOutput implementations are not expected to support this
feature.  In fact, the only format I'm aware of that is capable of
supporting it is OpenEXR.

As of this checkin, the OpenEXR support as not yet been added. This is
just a conceptual prototype for review of the API.
