### PR TITLE
Optimization of DeepData.

### DIFF
--- a/src/include/OpenImageIO/deepdata.h
+++ b/src/include/OpenImageIO/deepdata.h
@@ -101,6 +101,14 @@ public:
     /// required to match pixels().
     void set_all_samples (array_view<const unsigned int> samples);
 
+    /// Set the capacity of samples for the given pixel. This must be called
+    /// after init().
+    void set_capacity (int pixel, int samps);
+
+    /// Retrieve the capacity (number of allocated samples) for the given
+    /// pixel index.
+    int capacity (int pixel) const;
+
     /// Insert n samples at the given pixel, starting at the indexed
     /// position.
     void insert_samples (int pixel, int samplepos, int n=1);

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -299,28 +299,6 @@ bool OIIO_API flatten (ImageBuf &dst, const ImageBuf &src,
                        ROI roi = ROI::All(), int nthreads = 0);
 
 
-/// Merge the samples of deep image A into the existing samples of dst.
-/// If dst is not yet initialized, it will simply become a copy of A.
-/// If occlusion_cull is true, any samples occluded by an opaque
-/// sample will be deleted.
-///
-/// 'roi' specifies the region of A's pixels which will be merged;
-/// existing pixels of dst outside this range will not be altered.  If not
-/// specified, the default ROI value will be the pixel data window of src.
-///
-/// The nthreads parameter specifies how many threads (potentially) may
-/// be used, but it's not a guarantee.  If nthreads == 0, it will use
-/// the global OIIO attribute "nthreads".  If nthreads == 1, it
-/// guarantees that it will not launch any new threads.
-///
-/// Works on all pixel data types.
-///
-/// Return true on success, false on error (with an appropriate error
-/// message set in dst).
-bool OIIO_API deep_merge (ImageBuf &dst, const ImageBuf &A,
-                          bool occlusion_cull = true,
-                          ROI roi = ROI::All(), int nthreads = 0);
-
 /// Set dst to the deep merge of the samples of deep images A and B,
 /// overwriting any existing samples of dst in the ROI.
 /// If occlusion_cull is true, any samples occluded by an opaque

--- a/src/python/py_deepdata.cpp
+++ b/src/python/py_deepdata.cpp
@@ -61,6 +61,13 @@ DeepData_init_spec (DeepData &dd, const ImageSpec &spec)
 
 
 int
+DeepData_get_capacity (const DeepData &dd, int pixel)
+{
+    return int (dd.capacity(pixel));
+}
+
+
+int
 DeepData_get_samples (const DeepData &dd, int pixel)
 {
     return int (dd.samples(pixel));
@@ -129,6 +136,10 @@ void declare_deepdata()
         .def("samples",         &DeepData_get_samples,
              (arg("pixel")))
         .def("set_samples",     &DeepData::set_samples,
+             (arg("pixel"), arg("nsamples")))
+        .def("capacity",        &DeepData_get_capacity,
+             (arg("pixel")))
+        .def("set_capacity",    &DeepData::set_capacity,
              (arg("pixel"), arg("nsamples")))
         .def("insert_samples",  &DeepData::insert_samples,
              (arg("pixel"), arg("samplepos"), arg("nsamples")=1))

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -234,17 +234,7 @@ IBA_flatten (ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
 
 
 bool
-IBA_deep_merge (ImageBuf &dst, const ImageBuf &src, bool occlusion_cull,
-                ROI roi, int nthreads)
-{
-    ScopedGILRelease gil;
-    return ImageBufAlgo::deep_merge (dst, src, occlusion_cull, roi, nthreads);
-}
-
-
-
-bool
-IBA_deep_merge2 (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
+IBA_deep_merge (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
                  bool occlusion_cull, ROI roi, int nthreads)
 {
     ScopedGILRelease gil;
@@ -1314,9 +1304,6 @@ void declare_imagebufalgo()
         .staticmethod("flatten")
 
         .def("deep_merge", IBA_deep_merge,
-             (arg("dst"), arg("src"), arg("occlusion_cull")=true,
-              arg("roi")=ROI::All(), arg("nthreads")=0))
-        .def("deep_merge", IBA_deep_merge2,
              (arg("dst"), arg("A"), arg("B"), arg("occlusion_cull")=true,
               arg("roi")=ROI::All(), arg("nthreads")=0))
         .staticmethod("deep_merge")

--- a/testsuite/python-deep/ref/out.txt
+++ b/testsuite/python-deep/ref/out.txt
@@ -1,18 +1,18 @@
 test_chantypes  half half half half float float
 After init, dd has 9 pixels, 6 channels.
-  Nsamples[ 1 ] = 1 samples:
+  Nsamples[ 1 ] = 1  (capacity= 1 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 1.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
-  Nsamples[ 3 ] = 3 samples:
+  Nsamples[ 3 ] = 3  (capacity= 3 ) samples:
   sample 0 :  [0 R] 0.33 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.33 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.67 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.67 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
   sample 2 :  [0 R] 1.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
-  Nsamples[ 5 ] = 5 samples:
+  Nsamples[ 5 ] = 5  (capacity= 5 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.20 /  [3 A] 0.20 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.40 /  [3 A] 0.40 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
   sample 2 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.60 /  [3 A] 0.60 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
   sample 3 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.80 /  [3 A] 0.80 /  [4 Z] 13.00 /  [5 Zback] 13.50 / 
   sample 4 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 1.00 /  [3 A] 1.00 /  [4 Z] 14.00 /  [5 Zback] 14.50 / 
-  Nsamples[ 7 ] = 7 samples:
+  Nsamples[ 7 ] = 7  (capacity= 7 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.14 /  [2 B] 0.00 /  [3 A] 0.14 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.00 /  [1 G] 0.29 /  [2 B] 0.00 /  [3 A] 0.29 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
   sample 2 :  [0 R] 0.00 /  [1 G] 0.43 /  [2 B] 0.00 /  [3 A] 0.43 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
@@ -25,19 +25,19 @@ Writing image...
 
 Reading image...
 After init, dd has 9 pixels, 6 channels.
-  Nsamples[ 1 ] = 1 samples:
+  Nsamples[ 1 ] = 1  (capacity= 1 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 1.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
-  Nsamples[ 3 ] = 3 samples:
+  Nsamples[ 3 ] = 3  (capacity= 3 ) samples:
   sample 0 :  [0 R] 0.33 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.33 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.67 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.67 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
   sample 2 :  [0 R] 1.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
-  Nsamples[ 5 ] = 5 samples:
+  Nsamples[ 5 ] = 5  (capacity= 5 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.20 /  [3 A] 0.20 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.40 /  [3 A] 0.40 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
   sample 2 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.60 /  [3 A] 0.60 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
   sample 3 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.80 /  [3 A] 0.80 /  [4 Z] 13.00 /  [5 Zback] 13.50 / 
   sample 4 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 1.00 /  [3 A] 1.00 /  [4 Z] 14.00 /  [5 Zback] 14.50 / 
-  Nsamples[ 7 ] = 7 samples:
+  Nsamples[ 7 ] = 7  (capacity= 7 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.14 /  [2 B] 0.00 /  [3 A] 0.14 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.00 /  [1 G] 0.29 /  [2 B] 0.00 /  [3 A] 0.29 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
   sample 2 :  [0 R] 0.00 /  [1 G] 0.43 /  [2 B] 0.00 /  [3 A] 0.43 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
@@ -48,33 +48,33 @@ After init, dd has 9 pixels, 6 channels.
 
 Testing insert and erase...
 After setting one sample: dd has 3 pixels, 6 channels.
-  Nsamples[ 1 ] = 1 samples:
+  Nsamples[ 1 ] = 1  (capacity= 1 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.00 /  [4 Z] 10.00 /  [5 Zback] 0.00 / 
 After inserting before and after: dd has 3 pixels, 6 channels.
-  Nsamples[ 1 ] = 3 samples:
+  Nsamples[ 1 ] = 3  (capacity= 3 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.00 /  [4 Z] 9.00 /  [5 Zback] 0.00 / 
   sample 1 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.00 /  [4 Z] 10.00 /  [5 Zback] 0.00 / 
   sample 2 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.00 /  [4 Z] 11.00 /  [5 Zback] 0.00 / 
 After deleting the middle: dd has 3 pixels, 6 channels.
-  Nsamples[ 1 ] = 2 samples:
+  Nsamples[ 1 ] = 2  (capacity= 3 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.00 /  [4 Z] 9.00 /  [5 Zback] 0.00 / 
   sample 1 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.00 /  [4 Z] 11.00 /  [5 Zback] 0.00 / 
 
 Testing copy_deep_pixel...
 test_deep_copy: should swap pixels 3 and 5, dd has 9 pixels, 6 channels.
-  Nsamples[ 1 ] = 1 samples:
+  Nsamples[ 1 ] = 1  (capacity= 1 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 1.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
-  Nsamples[ 3 ] = 5 samples:
+  Nsamples[ 3 ] = 5  (capacity= 5 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.20 /  [3 A] 0.20 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.40 /  [3 A] 0.40 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
   sample 2 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.60 /  [3 A] 0.60 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
   sample 3 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.80 /  [3 A] 0.80 /  [4 Z] 13.00 /  [5 Zback] 13.50 / 
   sample 4 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 1.00 /  [3 A] 1.00 /  [4 Z] 14.00 /  [5 Zback] 14.50 / 
-  Nsamples[ 5 ] = 3 samples:
+  Nsamples[ 5 ] = 3  (capacity= 5 ) samples:
   sample 0 :  [0 R] 0.33 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.33 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.67 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.67 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
   sample 2 :  [0 R] 1.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
-  Nsamples[ 7 ] = 7 samples:
+  Nsamples[ 7 ] = 7  (capacity= 7 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.14 /  [2 B] 0.00 /  [3 A] 0.14 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.00 /  [1 G] 0.29 /  [2 B] 0.00 /  [3 A] 0.29 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
   sample 2 :  [0 R] 0.00 /  [1 G] 0.43 /  [2 B] 0.00 /  [3 A] 0.43 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
@@ -85,33 +85,33 @@ test_deep_copy: should swap pixels 3 and 5, dd has 9 pixels, 6 channels.
 
 Testing split...
 After split, dd has 2 pixels, 6 channels.
-  Nsamples[ 0 ] = 2 samples:
+  Nsamples[ 0 ] = 2  (capacity= 2 ) samples:
   sample 0 :  [0 R] 0.50 /  [1 G] 0.10 /  [2 B] 0.10 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 11.00 / 
   sample 1 :  [0 R] 0.10 /  [1 G] 0.50 /  [2 B] 0.10 /  [3 A] 0.50 /  [4 Z] 20.00 /  [5 Zback] 21.00 / 
-  Nsamples[ 1 ] = 3 samples:
+  Nsamples[ 1 ] = 3  (capacity= 3 ) samples:
   sample 0 :  [0 R] 0.50 /  [1 G] 0.10 /  [2 B] 0.10 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 11.00 / 
   sample 1 :  [0 R] 0.06 /  [1 G] 0.29 /  [2 B] 0.06 /  [3 A] 0.29 /  [4 Z] 20.00 /  [5 Zback] 20.50 / 
   sample 2 :  [0 R] 0.06 /  [1 G] 0.29 /  [2 B] 0.06 /  [3 A] 0.29 /  [4 Z] 20.50 /  [5 Zback] 21.00 / 
 
 Testing sort...
 Before z sort, dd has 2 pixels, 6 channels.
-  Nsamples[ 0 ] = 4 samples:
+  Nsamples[ 0 ] = 4  (capacity= 4 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 20.00 /  [5 Zback] 20.50 / 
   sample 1 :  [0 R] 0.10 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 19.00 /  [5 Zback] 19.50 / 
   sample 2 :  [0 R] 0.20 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 18.00 /  [5 Zback] 18.50 / 
   sample 3 :  [0 R] 0.30 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 17.00 /  [5 Zback] 17.50 / 
-  Nsamples[ 1 ] = 4 samples:
+  Nsamples[ 1 ] = 4  (capacity= 4 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 20.00 /  [5 Zback] 20.50 / 
   sample 1 :  [0 R] 0.10 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 19.00 /  [5 Zback] 19.50 / 
   sample 2 :  [0 R] 0.20 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 18.00 /  [5 Zback] 18.50 / 
   sample 3 :  [0 R] 0.30 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 17.00 /  [5 Zback] 17.50 / 
 After z sort of pixel 1, dd has 2 pixels, 6 channels.
-  Nsamples[ 0 ] = 4 samples:
+  Nsamples[ 0 ] = 4  (capacity= 4 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 20.00 /  [5 Zback] 20.50 / 
   sample 1 :  [0 R] 0.10 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 19.00 /  [5 Zback] 19.50 / 
   sample 2 :  [0 R] 0.20 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 18.00 /  [5 Zback] 18.50 / 
   sample 3 :  [0 R] 0.30 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 17.00 /  [5 Zback] 17.50 / 
-  Nsamples[ 1 ] = 4 samples:
+  Nsamples[ 1 ] = 4  (capacity= 4 ) samples:
   sample 0 :  [0 R] 0.30 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 17.00 /  [5 Zback] 17.50 / 
   sample 1 :  [0 R] 0.20 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 18.00 /  [5 Zback] 18.50 / 
   sample 2 :  [0 R] 0.10 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 19.00 /  [5 Zback] 19.50 / 
@@ -119,47 +119,47 @@ After z sort of pixel 1, dd has 2 pixels, 6 channels.
 
 Testing merge_overlaps...
 Before merge_overlaps, dd has 2 pixels, 6 channels.
-  Nsamples[ 0 ] = 4 samples:
+  Nsamples[ 0 ] = 4  (capacity= 4 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.10 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 2 :  [0 R] 0.20 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
   sample 3 :  [0 R] 0.30 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
-  Nsamples[ 1 ] = 4 samples:
+  Nsamples[ 1 ] = 4  (capacity= 4 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.10 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 2 :  [0 R] 0.20 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
   sample 3 :  [0 R] 0.30 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
 After merge_overlaps of pixel 1, dd has 2 pixels, 6 channels.
-  Nsamples[ 0 ] = 4 samples:
+  Nsamples[ 0 ] = 4  (capacity= 4 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.10 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 2 :  [0 R] 0.20 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
   sample 3 :  [0 R] 0.30 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
-  Nsamples[ 1 ] = 2 samples:
+  Nsamples[ 1 ] = 2  (capacity= 4 ) samples:
   sample 0 :  [0 R] 0.07 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.75 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.38 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.75 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
 
 Testing merge_deep_pixels...
 Before merge_deep_pixels, dd has 1 pixels, 6 channels.
-  Nsamples[ 0 ] = 1 samples:
+  Nsamples[ 0 ] = 1  (capacity= 1 ) samples:
   sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 12.00 / 
 And the other image, dd has 1 pixels, 6 channels.
-  Nsamples[ 0 ] = 1 samples:
+  Nsamples[ 0 ] = 1  (capacity= 1 ) samples:
   sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 11.00 /  [5 Zback] 13.00 / 
 After merge_deep_pixels, dd has 1 pixels, 6 channels.
-  Nsamples[ 0 ] = 3 samples:
+  Nsamples[ 0 ] = 3  (capacity= 4 ) samples:
   sample 0 :  [0 R] 0.29 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.29 /  [4 Z] 10.00 /  [5 Zback] 11.00 / 
   sample 1 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 11.00 /  [5 Zback] 12.00 / 
   sample 2 :  [0 R] 0.29 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.29 /  [4 Z] 12.00 /  [5 Zback] 13.00 / 
 
 Testing occlusion_cull...
 Before occlusion_cull, dd has 1 pixels, 6 channels.
-  Nsamples[ 0 ] = 3 samples:
+  Nsamples[ 0 ] = 3  (capacity= 3 ) samples:
   sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
   sample 2 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
 After occlusion_cull, dd has 1 pixels, 6 channels.
-  Nsamples[ 0 ] = 2 samples:
+  Nsamples[ 0 ] = 2  (capacity= 3 ) samples:
   sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
 

--- a/testsuite/python-deep/src/test_deep.py
+++ b/testsuite/python-deep/src/test_deep.py
@@ -44,8 +44,8 @@ def print_deep_image (dd, prefix="After init,") :
     print prefix, "dd has", dd.pixels, "pixels,", dd.channels, "channels."
     for p in range(dd.pixels) :
         ns = dd.samples(p)
-        if ns > 0 :
-            print "  Nsamples[", p, "] =", ns, "samples:"
+        if ns > 0 or dd.capacity(p) > 0 :
+            print "  Nsamples[", p, "] =", ns, " (capacity=", dd.capacity(p), ")", "samples:"
             for s in range(ns) :
                 print "  sample", s, ": ",
                 for c in range(dd.channels) :


### PR DESCRIPTION
The changes from last week that implemented deep merge were correct but
very inefficient. I realized that because every sample insertion or
deletion would have to insert or delete from the data vector, it was
essentially O(n^2) on the number of pixels.

As an alternate design, we try allowing each pixel to have a "capacity"
(allocated storage within the data array) in addition to "nsamples."
This lets three important things happen: (1) any algorithm that first
establishes the capacity for each pixel, even an approximate guess,
can essentially pre-allocate and apportion the storage without every
individual sample added later copying big portions of the array (much
like how it's helpful for a std::vector to reserve() before lots of
insertions); (2) erasing samples just shifts data in that pixel,
decreases nsamples for the pixel, but leaves its capacty alone (and
thus does no copying of the whole data); (3) inserting more samples after
erasures avoids reallocation or large-scale copying, at least until
the previous capacity is exceeded.

The scheme works! The net result is that doing a deep merge of three
1024x576 images (from the OpenEXR test images) using oiiotool went from
231 seconds to 0.8 seconds.