### PR TITLE
Fixed oiio:ColorSpace typo

### DIFF
--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -960,7 +960,7 @@ TIFFInput::readspec (bool read_meta)
             // Exif spec says that anything other than 0xffff==uncalibrated
             // should be interpreted to be sRGB.
             if (*(const int *)p->data() != 0xffff)
-                m_spec.attribute ("oiio::ColorSpace", "sRGB");
+                m_spec.attribute ("oiio:ColorSpace", "sRGB");
         }
     }
 #endif


### PR DESCRIPTION
The `oiio:ColorSpace` metadata attribute is misnamed, not sure what implications fixing this has.