### PR TITLE
oiiotool --fixnan for deep files

### DIFF
--- a/src/doc/imagebufalgo.tex
+++ b/src/doc/imagebufalgo.tex
@@ -2486,6 +2486,14 @@ Add, subtract, multiply, or divide a deep image {\cf A} by per-channel
 values {\cf B[]}, storing the result in deep image {\cf dst}.
 \apiend
 
+\apiitem{bool {\ce fixNonFinite} (ImageBuf \&dst, const ImageBuf \&src, \\
+  \bigspc\spc NonFiniteFixMode mode = NONFINITE_BOX3, \\
+  \bigspc\spc int *pixelsFixed = NULL, \\
+  \bigspc\spc  ROI roi=ROI::All(), int nthreads=0)}
+\index{ImageBufAlgo!fixNonFinite} \indexapi{fixNonFinite}
+\NEW % 1.7
+Repair nonfinite ({\cf NaN} or {\cf Inf}) values, setting them to 0.0.
+\apiend
 
 
 \begin{comment}

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -2802,6 +2802,13 @@ Prints detailed statistical information about each input image as it is
 read.
 \apiend
 
+\apiitem{\ce --fixnan {\rm \emph{streategy}}}
+\NEW % 1.7
+Replace the top image with a copy in which any pixels that contained {\cf
+NaN} or {\cf Inf} values (hereafter referred to collectively as
+``nonfinite'') are repaired.  The \emph{strategy} may be either {\cf black}
+or {\cf error}.
+\apiend
 
 
 \chapwidthend


### PR DESCRIPTION
Make IBA::fixNonFinite (and oiiotool -fixnan) work with deep images.

Also speed them up (for the non-deep case) by fixing a bug where, even
though it split the image for threads, each thread examined the whole
image instead of just its part. Oops.

Also modify oiiotool --stats for deep files to print locations of nonfinites.

