### PR TITLE
ColorConfig bug fix -- failed to find ColorProcessor for NoOp transformation

### DIFF
--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -529,7 +529,6 @@ ColorConfig::createColorProcessor (string_view inputColorSpace,
             outputrole = outputColorSpace;
             outputColorSpace = name;
         }
-        OCIO::ConstProcessorRcPtr p;
         try {
             // Get the processor corresponding to this transform.
             p = getImpl()->config_->getProcessor(inputColorSpace.c_str(),


### PR DESCRIPTION
Just a bad variable declaration, inner scope masked outer scope. Led to maketx refusing to do a certain color transform.
