### PR TITLE
IBA: More control over result nchannels when inputs don't agree.

### DIFF
--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -181,7 +181,8 @@ enum IBAprep_flags {
     IBAprep_CLAMP_MUTUAL_NCHANNELS = 1<<10, // Clamp roi.chend to max of inputs
     IBAprep_SUPPORT_DEEP = 1<<11,       // Operation allows deep images
     IBAprep_DEEP_MIXED = 1<<12,         // Allow deep & non-deep combinations
-    IBAprep_DST_FLOAT_PIXELS = 1<<13    // If dst is uninit, make it float
+    IBAprep_DST_FLOAT_PIXELS = 1<<13,   // If dst is uninit, make it float
+    IBAprep_MINIMIZE_NCHANNELS = 1<<14, // Multi-inputs get min(nchannels)
 };
 
 


### PR DESCRIPTION
Previously, when computing functions that had multiple inputs that did not have the same number of channels, ImageBufAlgo functions relied on logic in IBAprep() that would make the result have the number of channels of the FIRST input, but then usually restrict the ROI channel range to the lesser of the inputs. This was strange, having it so that reordering the inputs (for a supposedly commutative operation such as +) would change the channel range of the result.

This set of changes tightens up this logic:

* IBAprep now always chooses a result that's the maximum of the input   image channels by default (though passing the flag   IBAprep_MINIMIZE_NCHANNELS will instead choose the the minimum).

* IBAprep still restricts the ROI to the minimum (i.e. overlapping   channel set), and non-overlapping channels are cleared to 0 value by   default.

* add, sub, and absdiff try to do the "correct" thing (treating missing   channels in the inputs as if they were 0-valued).
