### PR TITLE
TIFF: Tighten up logic for non-zero origin of "full" size (aka display window)

### DIFF
--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -293,11 +293,17 @@ TIFFOutput::open (const std::string &name, const ImageSpec &userspec,
 
     TIFFSetField (m_tif, TIFFTAG_IMAGEWIDTH, m_spec.width);
     TIFFSetField (m_tif, TIFFTAG_IMAGELENGTH, m_spec.height);
+
+    // Handle display window or "full" size. Note that TIFF can't represent
+    // nonzero offsets of the full size, so we may need to expand the
+    // display window to encompass the origin.
     if ((m_spec.full_width != 0 || m_spec.full_height != 0) &&
-        (m_spec.full_width != m_spec.width || m_spec.full_height != m_spec.height)) {
-        TIFFSetField (m_tif, TIFFTAG_PIXAR_IMAGEFULLWIDTH, m_spec.full_width);
-        TIFFSetField (m_tif, TIFFTAG_PIXAR_IMAGEFULLLENGTH, m_spec.full_height);
+        (m_spec.full_width != m_spec.width || m_spec.full_height != m_spec.height ||
+         m_spec.full_x != 0 || m_spec.full_y != 0)) {
+        TIFFSetField (m_tif, TIFFTAG_PIXAR_IMAGEFULLWIDTH, m_spec.full_width+m_spec.full_x);
+        TIFFSetField (m_tif, TIFFTAG_PIXAR_IMAGEFULLLENGTH, m_spec.full_height+m_spec.full_y);
     }
+
     if (m_spec.tile_width) {
         TIFFSetField (m_tif, TIFFTAG_TILEWIDTH, m_spec.tile_width);
         TIFFSetField (m_tif, TIFFTAG_TILELENGTH, m_spec.tile_height);


### PR DESCRIPTION
TIFF is incapable of representing non-(0,0) origin "full" (or display) window. So there are some edge cases we need to handle more deftly:

* When writing to TIFF, if the ImageSpec says the full/display window is   nonzero origin, set it to 0 origin and expand the width&height   accordingly.  That's the best we can do, it's all TIFF can represent.

* When reading TIFF that does not say anything about the full window   at all, assume it should be interpreted as equal to the data window.