### PR TITLE
Better handling of timecodes, especially for OpenEXR

### DIFF
--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -384,6 +384,12 @@ Convert a scanline file to a tiled file with $16 \times 16$ tiles:
 \begin{code}
     oiiotool in.exr --attrib "FStop" 22.0 \
             --attrib "IPTC:City" "Berkeley" -o out.exr
+
+    oiiotool in.exr --attrib:type=timecode smpte:TimeCode "11:34:04:00" \
+            -o out.exr
+
+    oiiotool in.exr --attrib:type=int[4] FaceBBox "140,300,219,460" \
+            -o out.exr
 \end{code}
 
 
@@ -1217,6 +1223,9 @@ a {\cf string} metadata.
 
     oiiotool in.exr --attrib:type=matrix worldtocam \
             "1,0,0,0,0,1,0,0,0,0,1,0,2.3,2.1,0,1" -o out.exr
+
+    oiiotool in.exr --attrib:type=timecode smpte:TimeCode "11:34:04:00" \
+            -o out.exr
 \end{code}
 \apiend
 

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -94,7 +94,7 @@
  \bigskip \\
 }
 \date{{\large 
-Date: 31 Mar 2016
+Date: 18 May 2016
 %\\ (with corrections, 25 Aug 2015)
 }}
 

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -220,6 +220,9 @@ struct OIIO_API TypeDesc {
     /// True if it's a signed type that allows for negative values.
     bool is_signed () const;
 
+    /// Shortcut: is it UNKNOWN?
+    bool is_unknown () const { return (basetype == UNKNOWN); }
+
     /// Set *this to the type described in the string.  Return the
     /// length of the part of the string that describes the type.  If
     /// no valid type could be assembled, return 0 and do not modify

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -33,6 +33,7 @@
 #include <sstream>
 
 #include <OpenEXR/half.h>
+#include <OpenEXR/ImfTimeCode.h>
 
 #include <boost/foreach.hpp>
 
@@ -855,6 +856,11 @@ ImageSpec::metadata_val (const ImageIOParameter &p, bool human)
                 nice = explanation[e].explainer (p, explanation[e].extradata);
                 break;
             }
+        }
+        if (p.type() == TypeDesc::TypeTimeCode) {
+            Imf::TimeCode tc = *reinterpret_cast<const Imf::TimeCode *>(p.data());
+            nice = Strutil::format ("%02d:%02d:%02d:%02d", tc.hours(),
+                                    tc.minutes(), tc.seconds(), tc.frame());
         }
         if (nice.length())
             out = out + " (" + nice + ")";

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -299,6 +299,8 @@ TypeDesc::fromstring (string_view typestring)
         t = TypeMatrix33;
     else if (type == "matrix" || type == "matrix44")
         t = TypeMatrix44;
+    else if (type == "timecode")
+        t = TypeTimeCode;
     else {
         return 0;  // unknown
     }

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -304,7 +304,6 @@ private:
         // utcOffset
         // longitude latitude altitude
         // focus isoSpeed
-        // keyCode timeCode framesPerSecond
     }
 };
 

--- a/testsuite/dpx/ref/out.txt
+++ b/testsuite/dpx/ref/out.txt
@@ -33,7 +33,7 @@ Reading ../../../../../oiio-images/dpx_nuke_10bits_rgb.dpx
     dpx:WhiteLevel: 0
     dpx:IntegrationTimes: 0
     dpx:Packing: "Filled, method A"
-    smpte:TimeCode: 0, 0
+    smpte:TimeCode: 0, 0 (00:00:00:00)
     dpx:TimeCode: "00:00:00:00"
     dpx:UserBits: 0
     dpx:Signal: "Undefined"
@@ -74,7 +74,7 @@ Reading ../../../../../oiio-images/dpx_nuke_16bits_rgba.dpx
     dpx:WhiteLevel: 0
     dpx:IntegrationTimes: 0
     dpx:Packing: "Filled, method A"
-    smpte:TimeCode: 0, 0
+    smpte:TimeCode: 0, 0 (00:00:00:00)
     dpx:TimeCode: "00:00:00:00"
     dpx:UserBits: 0
     dpx:Signal: "Undefined"


### PR DESCRIPTION
SMPTE timecodes are expressed as uint32[2], with various bit field
encodings (see OpenEXR's ImfTimeCode.h for details). This is really
hard for humans to understand and specify, so we take some extra steps:

* Have 'oiiotool -info -v' and 'iinfo -v' print a more human-readable
  rendition ("hh:mm:ss:ff") via ImageSpec::metadata_val recognizing this
  special case.

* Have oiiotool recognize and encode human-writeable timecode metadata,
  as long as the type is specified to be a timecode.

For example:

    $ oiiotool in.exr -attrib:type=timecode TimeCode 11:34:03:00' -o out.exr

    $ oiiotool -v -info out.exr
    Reading out.exr
    out.exr              :   64 x   64, 3 channel, float openexr
    ...
    smpte:TimeCode: 287572736, 0 (11:24:03:00)