### PR TITLE
to_native_rectangle -- handle case with native data but non-contiguous strides

### DIFF
--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -299,6 +299,10 @@ ImageOutput::to_native_rectangle (int xbegin, int xend, int ybegin, int yend,
     // native_data is true if the user is passing data in the native format
     bool native_data = (format == TypeDesc::UNKNOWN ||
                         (format == m_spec.format && !perchanfile));
+    // If user is passing native data and it's all one type, go ahead and
+    // set format correctly.
+    if (format == TypeDesc::UNKNOWN && !perchanfile)
+        format = m_spec.format;
     // If the user is passing native data and they've left xstride set
     // to Auto, then we know it's the native pixel size.
     if (native_data && xstride == AutoStride)


### PR DESCRIPTION
This function is used as a helper by various ImageOutput implementations.

If you passed data to write_scanline or write_tile with UNKNOWN format (indicating "native" data) but the data were noncontiguous (the strides didn't match fully packed sizes), you would previously hit an assertion in some circumstances.
