### PR TITLE
oiiotool: --fullsize followed by --attrib could lose the fullsize

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1440,6 +1440,13 @@ set_fullsize (int argc, const char *argv[])
         spec.full_y = y;
         spec.full_width = w;
         spec.full_height = h;
+        // That updated the private spec of the ImageRec. In this case
+        // we really need to update the underlying IB as well.
+        ImageSpec &ibspec = (*A)(0,0).specmod();
+        ibspec.full_x = x;
+        ibspec.full_y = y;
+        ibspec.full_width = w;
+        ibspec.full_height = h;
         A->metadata_modified (true);
     }
     ot.function_times[command] += timer();


### PR DESCRIPTION
The --fullsize wasn't updating the spec properly in both places, and the
subsequent --attrib that re-copies some items from the underlying
ImageBuf's spec into the ImageRec's copy of the spec would overwrite the
previous changes of --fullsize. The --origin code path got it
right. Easy to adjust.