### PR TITLE
oiiotool add warnings for common noob mistakes

### DIFF
--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -223,6 +223,9 @@ struct OIIO_API TypeDesc {
     /// Shortcut: is it UNKNOWN?
     bool is_unknown () const { return (basetype == UNKNOWN); }
 
+    /// if (typespec) is the same as asking whether it's not UNKNOWN.
+    operator bool () const { return (basetype != UNKNOWN); }
+
     /// Set *this to the type described in the string.  Return the
     /// length of the part of the string that describes the type.  If
     /// no valid type could be assembled, return 0 and do not modify

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -64,6 +64,7 @@ ImageRec::ImageRec (const std::string &name, int nsubimages,
                     const int *miplevels, const ImageSpec *specs)
     : m_name(name), m_elaborated(true),
       m_metadata_modified(false), m_pixels_modified(true),
+      m_was_output(false),
       m_imagecache(NULL)
 {
     int specnum = 0;
@@ -89,6 +90,7 @@ ImageRec::ImageRec (ImageRec &img, int subimage_to_copy,
                     int miplevel_to_copy, bool writable, bool copy_pixels)
     : m_name(img.name()), m_elaborated(true),
       m_metadata_modified(false), m_pixels_modified(false),
+      m_was_output(false),
       m_imagecache(img.m_imagecache)
 {
     img.read ();
@@ -131,6 +133,7 @@ ImageRec::ImageRec (ImageRec &A, ImageRec &B, int subimage_to_copy,
                     TypeDesc pixeltype)
     : m_name(A.name()), m_elaborated(true),
       m_metadata_modified(false), m_pixels_modified(false),
+      m_was_output(false),
       m_imagecache(A.m_imagecache)
 {
     A.read ();
@@ -188,6 +191,7 @@ ImageRec::ImageRec (ImageRec &A, ImageRec &B, int subimage_to_copy,
 ImageRec::ImageRec (ImageBufRef img, bool copy_pixels)
     : m_name(img->name()), m_elaborated(true),
       m_metadata_modified(false), m_pixels_modified(false),
+      m_was_output(false),
       m_imagecache(img->imagecache())
 {
     m_subimages.resize (1);
@@ -206,6 +210,7 @@ ImageRec::ImageRec (const std::string &name, const ImageSpec &spec,
                     ImageCache *imagecache)
     : m_name(name), m_elaborated(true),
       m_metadata_modified(false), m_pixels_modified(true),
+      m_was_output(false),
       m_imagecache(imagecache)
 {
     int subimages = 1;

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -123,6 +123,7 @@ public:
     TimingMap function_times;
     bool enable_function_timing;
     size_t peak_memory;
+    int num_outputs;                         // Count of outputs written
 
     Oiiotool ();
 
@@ -358,10 +359,20 @@ public:
         return subimg < subimages() ? m_subimages[subimg].spec(mip) : NULL;
     }
 
+    bool was_output () const { return m_was_output; }
+    void was_output (bool val) { m_was_output = val; }
     bool metadata_modified () const { return m_metadata_modified; }
-    void metadata_modified (bool mod) { m_metadata_modified = mod; }
+    void metadata_modified (bool mod) {
+        m_metadata_modified = mod;
+        if (mod)
+            was_output(false);
+    }
     bool pixels_modified () const { return m_pixels_modified; }
-    void pixels_modified (bool mod) { m_pixels_modified = mod; }
+    void pixels_modified (bool mod) {
+        m_pixels_modified = mod;
+        if (mod)
+            was_output(false);
+    }
 
     std::time_t time() const { return m_time; }
 
@@ -370,7 +381,7 @@ public:
     // update the outer copy held by the SubimageRec.
     void update_spec_from_imagebuf (int subimg=0, int mip=0) {
         *m_subimages[subimg].spec(mip) = m_subimages[subimg][mip]->spec();
-        metadata_modified();
+        metadata_modified (true);
     }
 
     /// Error reporting for ImageRec: call this with printf-like arguments.
@@ -393,6 +404,7 @@ private:
     bool m_elaborated;
     bool m_metadata_modified;
     bool m_pixels_modified;
+    bool m_was_output;
     std::vector<SubimageRec> m_subimages;
     std::time_t m_time;  //< Modification time of the input file
     ImageCache *m_imagecache;


### PR DESCRIPTION
* When no output is specified (and also no -info, etc, are used). This
  usually indicates that the user forgot "-o" entirely.

* When an image is modified but not output. This indicates either a
  forgotten -o, or even more insidious, using -o and then subsequenty
  making more modifications (by users who don't realize that the -o
  applies to the *current* top of stack in the sequence of commands,
  and does not automatically get moved to the end).

* When -autocc causes output to be of a data format that overrides a
  previous -d directive (when the OCIO color space name dictates a data
  format or bit depth that contradicts -d).