### PR TITLE
Save space in ImageCacheFile by eliminating unused shadow matrix fields.

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -295,10 +295,12 @@ ImageCacheFile::ImageCacheFile (ImageCacheImpl &imagecache,
     m_filename = imagecache.resolve_filename (m_filename_original.string());
     // N.B. the file is not opened, the ImageInput is NULL.  This is
     // reflected by the fact that m_validspec is false.
+#if USE_SHADOW_MATRICES
     m_Mlocal.makeIdentity();
     m_Mproj.makeIdentity();
     m_Mtex.makeIdentity();
     m_Mras.makeIdentity();
+#endif
 }
 
 
@@ -644,6 +646,7 @@ ImageCacheFile::init_from_spec ()
             m_envlayout = LayoutTexture;
     }
 
+#if USE_SHADOW_MATRICES
     Imath::M44f c2w;
     m_imagecache.get_commontoworld (c2w);
     if ((p = spec.find_attribute ("worldtocamera", TypeDesc::TypeMatrix))) {
@@ -655,6 +658,7 @@ ImageCacheFile::init_from_spec ()
         m_Mproj = c2w * (*m);
     }
     // FIXME -- compute Mtex, Mras
+#endif
 
     // See if there's a SHA-1 hash in the image description
     std::string fing = spec.get_string_attribute ("oiio:SHA-1");

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -64,6 +64,10 @@ namespace pvt {
 
 #define IMAGECACHE_USE_RW_MUTEX 1
 
+// Should we compute and store shadow matrices? Not if we don't support
+// shadow maps!
+#define USE_SHADOW_MATRICES 0
+
 
 using boost::thread_specific_ptr;
 
@@ -309,10 +313,12 @@ private:
     TextureOpt::Wrap m_swrap;       ///< Default wrap modes
     TextureOpt::Wrap m_twrap;       ///< Default wrap modes
     TextureOpt::Wrap m_rwrap;       ///< Default wrap modes
+#if USE_SHADOW_MATRICES
     Imath::M44f m_Mlocal;           ///< shadows: world-to-local (light) matrix
     Imath::M44f m_Mproj;            ///< shadows: world-to-pseudo-NDC
     Imath::M44f m_Mtex;             ///< shadows: world-to-pNDC with camera z
     Imath::M44f m_Mras;             ///< shadows: world-to-raster with camera z
+#endif
     EnvLayout m_envlayout;          ///< env map: which layout?
     bool m_y_up;                    ///< latlong: is y "up"? (else z is up)
     bool m_sample_border;           ///< are edge samples exactly on the border?


### PR DESCRIPTION
I put these fields here in the very early days of IC development,
anticipating that I would fully elaborate the shadow() lookup functions,
for which these matrices are needed. But it was never a priority, so
they are effectively unused, yet take up a lot of space (64 bytes * 4,
per ImageCacheFile).

I'm not quite brave enough to remove them entirely, out of superstition
that either somebody else is using a modified OIIO that implements
shadow maps, or that the very minute I remove them, some situation will
come up where they are important. So for now I will #ifdef them out.