### PR TITLE
Minor hash.h fixes for C++11 compatibility

### DIFF
--- a/src/include/OpenImageIO/hash.h
+++ b/src/include/OpenImageIO/hash.h
@@ -51,7 +51,7 @@
 #include "string_view.h"
 #include "array_view.h"
 
-#if OIIO_CPLUSPLUS_VERSION >= 11
+#if OIIO_CPLUSPLUS_VERSION >= 11 || OIIO_MSVS_AT_LEAST_2013
 #  include <unordered_map>
 #else /* FIXME(C++11): remove this after making C++11 the baseline */
 #  include <boost/unordered_map.hpp>
@@ -60,11 +60,13 @@
 
 OIIO_NAMESPACE_BEGIN
 
-// Define OIIO::unordered_map as either std or boost.
-#if OIIO_CPLUSPLUS_VERSION >= 11
+// Define OIIO::unordered_map and OIIO::hash as either std or boost.
+#if OIIO_CPLUSPLUS_VERSION >= 11 || OIIO_MSVS_AT_LEAST_2013
 using std::unordered_map;
+using std::hash;
 #else /* FIXME(C++11): remove this after making C++11 the baseline */
 using boost::unordered_map;
+using boost::hash;
 #endif
 
 


### PR DESCRIPTION
* Use std::unordered_map for MSVS 2013+ as well as C++11.
* Define OIIO::hash<> template (either as std::hash or boost::hash).