### PR TITLE
Fix to recent warning patch

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4209,11 +4209,11 @@ output_file (int argc, const char *argv[])
         Filesystem::last_write_time (filename, in_time);
     }
 
-    ir->was_output (true);
     ot.check_peak_memory();
     ot.curimg = saveimg;
     ot.output_dataformat = saved_output_dataformat;
     ot.output_bitspersample = saved_bitspersample;
+    ot.curimg->was_output (true);
     ot.total_writetime.stop();
     ot.function_times[command] += timer();
     ot.num_outputs += 1;


### PR DESCRIPTION
Amends #1419

Slight error failed to mark files as "written" in some output cases where
a temporary image has to be made during output (the temp was marked as
written, rather than the original). This resulted in an incorrect warning
about "modified images without outputting them. Did you forget -o" when
clearly there was a -o.