### PR TITLE
Rethink default channel naming, just use R, G, B, A.

### DIFF
--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -155,37 +155,26 @@ void
 ImageSpec::default_channel_names ()
 {
     channelnames.clear();
+    channelnames.reserve (nchannels);
     alpha_channel = -1;
     z_channel = -1;
-    switch (nchannels) {
-    case 1:
-        channelnames.push_back ("A");
-        break;
-    case 2:
-        channelnames.push_back ("I");
-        channelnames.push_back ("A");
-        alpha_channel = 1;
-        break;
-    case 3:
-        channelnames.push_back ("R");
-        channelnames.push_back ("G");
-        channelnames.push_back ("B");
-        break;
-    default:
-        if (nchannels >= 1)
-            channelnames.push_back ("R");
-        if (nchannels >= 2)
-            channelnames.push_back ("G");
-        if (nchannels >= 3)
-            channelnames.push_back ("B");
-        if (nchannels >= 4) {
-            channelnames.push_back ("A");
-            alpha_channel = 3;
-        }
-        for (int c = 4;  c < nchannels;  ++c)
-            channelnames.push_back (Strutil::format("channel%d", c));
-        break;
+    if (nchannels == 1) {   // Special case: 1-channel is named "Y"
+        channelnames.push_back ("Y");
+        return;
     }
+    // General case: name channels R, G, B, A, channel4, channel5, ...
+    if (nchannels >= 1)
+        channelnames.push_back ("R");
+    if (nchannels >= 2)
+        channelnames.push_back ("G");
+    if (nchannels >= 3)
+        channelnames.push_back ("B");
+    if (nchannels >= 4) {
+        channelnames.push_back ("A");
+        alpha_channel = 3;
+    }
+    for (int c = 4;  c < nchannels;  ++c)
+        channelnames.push_back (Strutil::format("channel%d", c));
 }
 
 

--- a/testsuite/fits/ref/out.txt
+++ b/testsuite/fits/ref/out.txt
@@ -1,7 +1,7 @@
 Reading ../../../../../fits-images/pg93/tst0001.fits
 ../../../../../fits-images/pg93/tst0001.fits :  123 x  321, 1 channel, uint8 fits
     SHA-1: FC4F635D410B219477B709E4D6F993E9AA42C7B3
-    channel list: A
+    channel list: Y
     Extend: "T"
     Blocked: "T"
     Cdelt1: -2.3
@@ -22,7 +22,7 @@ PASS
 Reading ../../../../../fits-images/pg93/tst0002.fits
 ../../../../../fits-images/pg93/tst0002.fits :   73 x   31, 1 channel, uint16 fits
     SHA-1: 4FCD0E343956DEA4E792786138651F9D8C81F615
-    channel list: A
+    channel list: Y
     Cdelt1: -2.3
     Crval1: -73.5
     Crpix1: 12.1
@@ -44,7 +44,7 @@ PASS
 Reading ../../../../../fits-images/pg93/tst0003.fits
 ../../../../../fits-images/pg93/tst0003.fits :  137 x  271, 1 channel, uint fits
     SHA-1: 9D2DEE3C1411AB38B5DBAD0532F3679B797B2374
-    channel list: A
+    channel list: Y
     Extend: "T"
     Blocked: "T"
     Cdelt1: -0.12321
@@ -67,7 +67,7 @@ PASS
 Reading ../../../../../fits-images/pg93/tst0005.fits
 ../../../../../fits-images/pg93/tst0005.fits :  102 x  109, 1 channel, float fits
     SHA-1: 763996BCEADB93234A73AD0D714C3E9D874014CE
-    channel list: A
+    channel list: Y
     Extend: "T"
     Blocked: "T"
     Cdelt1: 3.1
@@ -86,7 +86,7 @@ PASS
 Reading ../../../../../fits-images/pg93/tst0006.fits
 ../../../../../fits-images/pg93/tst0006.fits :   77 x  173, 1 channel, double fits
     SHA-1: B043726D3F76840AAC84713C1A6C323D85CADC74
-    channel list: A
+    channel list: Y
     Extend: "T"
     Blocked: "T"
     Cdelt1: -0.25
@@ -105,7 +105,7 @@ PASS
 Reading ../../../../../fits-images/pg93/tst0007.fits
 ../../../../../fits-images/pg93/tst0007.fits :   38 x    1, 1 channel, float fits
     SHA-1: 32FB2E046F09E6DC814A6040B03706174EAE7229
-    channel list: A
+    channel list: Y
     Object: "IEEE 32-bit test"
     Origin: "ESO"
     DateTime: "1992:08:20 00:00:00"
@@ -161,7 +161,7 @@ PASS
 Reading ../../../../../fits-images/pg93/tst0008.fits
 ../../../../../fits-images/pg93/tst0008.fits :   38 x    1, 1 channel, double fits
     SHA-1: 5C21742E65AF385B106DE98BE7004190C6F2E2BC
-    channel list: A
+    channel list: Y
     Object: "IEEE 64-bit test"
     Origin: "ESO"
     DateTime: "1992:08:20 00:00:00"
@@ -216,7 +216,7 @@ PASS
 Reading ../../../../../fits-images/pg93/tst0013.fits
 ../../../../../fits-images/pg93/tst0013.fits :  128 x  128, 1 channel, float fits
     SHA-1: 2DAE86283E1BCB155774A83F88C75B045FB9B28C
-    channel list: A
+    channel list: Y
     Blocked: "T"
     Origin: "BASIC-UX-LA SILLA"
     Object: "Test data"
@@ -273,7 +273,7 @@ PASS
 Reading ../../../../../fits-images/ftt4b/file001.fits
 ../../../../../fits-images/ftt4b/file001.fits :    0 x    0, 1 channel, uint8 fits
     SHA-1: DA39A3EE5E6B4B0D3255BFEF95601890AFD80709
-    channel list: A
+    channel list: Y
     Extend: "T"
     Origin: "ESO"
     Object: "SNG - CAT."
@@ -283,7 +283,7 @@ PASS
 Reading ../../../../../fits-images/ftt4b/file002.fits
 ../../../../../fits-images/ftt4b/file002.fits :    0 x    0, 1 channel, uint8 fits
     SHA-1: DA39A3EE5E6B4B0D3255BFEF95601890AFD80709
-    channel list: A
+    channel list: Y
     Extend: "T"
     Origin: "ESO"
     Object: "PGSNC - SN.CAT."
@@ -293,7 +293,7 @@ PASS
 Reading ../../../../../fits-images/ftt4b/file003.fits
 ../../../../../fits-images/ftt4b/file003.fits :  512 x  512, 1 channel, uint16 fits
     SHA-1: 5CC4340F5D8AB2B776D2E12BFE946CA5CAFA38C6
-    channel list: A
+    channel list: Y
     Extend: "T"
     Object: 3
     Observer: "LISZ"
@@ -506,7 +506,7 @@ PASS
 Reading ../../../../../fits-images/ftt4b/file009.fits
 ../../../../../fits-images/ftt4b/file009.fits :    0 x    0, 1 channel, uint16 fits
     SHA-1: DA39A3EE5E6B4B0D3255BFEF95601890AFD80709
-    channel list: A
+    channel list: Y
     Groups: "T"
     Pcount: 5
     Gcount: 631
@@ -588,7 +588,7 @@ PASS
 Reading ../../../../../fits-images/ftt4b/file012.fits
 ../../../../../fits-images/ftt4b/file012.fits :  513 x  513, 1 channel, uint16 fits
     SHA-1: 844CE9474D5C9E91154E41D7ED417173DE57286D
-    channel list: A
+    channel list: Y
     Tables: 1
     Object: "M84"
     Observer: "LAIN"

--- a/testsuite/jpeg2000/ref/out-spinux.txt
+++ b/testsuite/jpeg2000/ref/out-spinux.txt
@@ -71,9 +71,9 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file8.jp2
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file8.jp2" and "file8.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file9.jp2
-../../../../../j2kp4files_v1_5/testfiles_jp2/file9.jp2 :  768 x  512, 3 channel, uint8 jpeg2000
-    SHA-1: 501807547A6F9B8FA61EF7A4FD9AB7B369E7800C
-    channel list: R, G, B
+../../../../../j2kp4files_v1_5/testfiles_jp2/file9.jp2 :  768 x  512, 1 channel, uint8 jpeg2000
+    SHA-1: 9784D248E95A47CDB3D0B260C7FBFFE2A4A2D492
+    channel list: Y
     oiio:BitsPerSample: 8
     oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"

--- a/testsuite/jpeg2000/ref/out.txt
+++ b/testsuite/jpeg2000/ref/out.txt
@@ -28,7 +28,7 @@ PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file4.jp2
 ../../../../../j2kp4files_v1_5/testfiles_jp2/file4.jp2 :  768 x  512, 1 channel, uint8 jpeg2000
     SHA-1: A45171430806BA3E74705675C855A781FC04BE44
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 8
     oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
@@ -47,7 +47,7 @@ PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file6.jp2
 ../../../../../j2kp4files_v1_5/testfiles_jp2/file6.jp2 :  768 x  512, 1 channel, uint12 jpeg2000
     SHA-1: 3A29DFAD0AA3F910AA2D37007989A4CC6E7BDE2A
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 12
     oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
@@ -66,7 +66,7 @@ PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file8.jp2
 ../../../../../j2kp4files_v1_5/testfiles_jp2/file8.jp2 :  700 x  400, 1 channel, uint8 jpeg2000
     SHA-1: 593D82DE9935FC3F7963CABAAD5ACB7F8134E39A
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 8
     oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"

--- a/testsuite/maketx/ref/out-alt-tiff4-2.txt
+++ b/testsuite/maketx/ref/out-alt-tiff4-2.txt
@@ -66,7 +66,7 @@ Reading checker-1chan.tx
 checker-1chan.tx     :  128 x  128, 1 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: F7DAC8772B7C6BFABDA884D61ABC84844C949AF1
-    channel list: A
+    channel list: Y
     tile size: 64 x 64
     oiio:BitsPerSample: 8
     Orientation: 1 (normal)
@@ -211,7 +211,7 @@ Reading gray-mono.tx
 gray-mono.tx         :  256 x  256, 1 channel, uint8 tiff
     MIP-map levels: 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: F5C1F9FA963006D501B14542F5E941AEDB4C5907
-    channel list: A
+    channel list: Y
     tile size: 64 x 64
     oiio:BitsPerSample: 8
     Orientation: 1 (normal)

--- a/testsuite/maketx/ref/out-alt-tiff4.txt
+++ b/testsuite/maketx/ref/out-alt-tiff4.txt
@@ -66,7 +66,7 @@ Reading checker-1chan.tx
 checker-1chan.tx     :  128 x  128, 1 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: F7DAC8772B7C6BFABDA884D61ABC84844C949AF1
-    channel list: A
+    channel list: Y
     tile size: 64 x 64
     oiio:BitsPerSample: 8
     Orientation: 1 (normal)
@@ -211,7 +211,7 @@ Reading gray-mono.tx
 gray-mono.tx         :  256 x  256, 1 channel, uint8 tiff
     MIP-map levels: 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: F5C1F9FA963006D501B14542F5E941AEDB4C5907
-    channel list: A
+    channel list: Y
     tile size: 64 x 64
     oiio:BitsPerSample: 8
     Orientation: 1 (normal)

--- a/testsuite/maketx/ref/out.txt
+++ b/testsuite/maketx/ref/out.txt
@@ -69,7 +69,7 @@ Reading checker-1chan.tx
 checker-1chan.tx     :  128 x  128, 1 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: F7DAC8772B7C6BFABDA884D61ABC84844C949AF1
-    channel list: A
+    channel list: Y
     tile size: 64 x 64
     oiio:BitsPerSample: 8
     Orientation: 1 (normal)
@@ -222,7 +222,7 @@ Reading gray-mono.tx
 gray-mono.tx         :  256 x  256, 1 channel, uint8 tiff
     MIP-map levels: 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: F5C1F9FA963006D501B14542F5E941AEDB4C5907
-    channel list: A
+    channel list: Y
     tile size: 64 x 64
     oiio:BitsPerSample: 8
     Orientation: 1 (normal)

--- a/testsuite/oiiotool-maketx/ref/out.txt
+++ b/testsuite/oiiotool-maketx/ref/out.txt
@@ -66,7 +66,7 @@ Reading checker-1chan.tx
 checker-1chan.tx     :  128 x  128, 1 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: F7DAC8772B7C6BFABDA884D61ABC84844C949AF1
-    channel list: A
+    channel list: Y
     tile size: 64 x 64
     oiio:BitsPerSample: 8
     Orientation: 1 (normal)
@@ -211,7 +211,7 @@ Reading gray-mono.tx
 gray-mono.tx         :  256 x  256, 1 channel, uint8 tiff
     MIP-map levels: 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: F5C1F9FA963006D501B14542F5E941AEDB4C5907
-    channel list: A
+    channel list: Y
     tile size: 64 x 64
     oiio:BitsPerSample: 8
     Orientation: 1 (normal)

--- a/testsuite/targa-tgautils/ref/out.txt
+++ b/testsuite/targa-tgautils/ref/out.txt
@@ -1,7 +1,7 @@
 Reading ../../../../../TGAUTILS/CBW8.TGA
 ../../../../../TGAUTILS/CBW8.TGA :  128 x  128, 1 channel, uint8 targa
     SHA-1: E157488A1D82536C6CC5F38CA2BF3CAA397BE69A
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 8
     compression: "rle"
     targa:ImageID: "Truevision(R) Sample Image"
@@ -91,7 +91,7 @@ PASS
 Reading ../../../../../TGAUTILS/UBW8.TGA
 ../../../../../TGAUTILS/UBW8.TGA :  128 x  128, 1 channel, uint8 targa
     SHA-1: E157488A1D82536C6CC5F38CA2BF3CAA397BE69A
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 8
     targa:ImageID: "Truevision(R) Sample Image"
     Artist: "Ricky True"

--- a/testsuite/tiff-depths/ref/out.txt
+++ b/testsuite/tiff-depths/ref/out.txt
@@ -1,7 +1,7 @@
 Reading ../../../../../libtiffpic/depth/flower-minisblack-02.tif
 ../../../../../libtiffpic/depth/flower-minisblack-02.tif :   73 x   43, 1 channel, uint2 tiff
     SHA-1: F6BD9D10FB0DD8E9AC62DEBBB743A78FC48D3C9B
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 2
     Orientation: 1 (normal)
     XResolution: 72
@@ -21,7 +21,7 @@ PASS
 Reading ../../../../../libtiffpic/depth/flower-minisblack-04.tif
 ../../../../../libtiffpic/depth/flower-minisblack-04.tif :   73 x   43, 1 channel, uint4 tiff
     SHA-1: 8C0CF14B3B585F4B1F249C681BEDEA4CB63E3EDD
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 4
     Orientation: 1 (normal)
     XResolution: 72
@@ -41,7 +41,7 @@ PASS
 Reading ../../../../../libtiffpic/depth/flower-minisblack-06.tif
 ../../../../../libtiffpic/depth/flower-minisblack-06.tif :   73 x   43, 1 channel, uint6 tiff
     SHA-1: AE809BFEF36E3E0047343655231200A916D83492
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 6
     Orientation: 1 (normal)
     XResolution: 72
@@ -61,7 +61,7 @@ PASS
 Reading ../../../../../libtiffpic/depth/flower-minisblack-08.tif
 ../../../../../libtiffpic/depth/flower-minisblack-08.tif :   73 x   43, 1 channel, uint8 tiff
     SHA-1: 1A909C8E70CC479D8A35BAA9BFEDDCBF4BF46FDC
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 8
     Orientation: 1 (normal)
     XResolution: 72
@@ -81,7 +81,7 @@ PASS
 Reading ../../../../../libtiffpic/depth/flower-minisblack-10.tif
 ../../../../../libtiffpic/depth/flower-minisblack-10.tif :   73 x   43, 1 channel, uint10 tiff
     SHA-1: E9240FEF19CC8EF5EBBF2EE4A10EDF25E51C67B4
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 10
     Orientation: 1 (normal)
     XResolution: 72
@@ -101,7 +101,7 @@ PASS
 Reading ../../../../../libtiffpic/depth/flower-minisblack-12.tif
 ../../../../../libtiffpic/depth/flower-minisblack-12.tif :   73 x   43, 1 channel, uint12 tiff
     SHA-1: AAE977957ED6AAC647967192A74E4AD55FF75811
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 12
     Orientation: 1 (normal)
     XResolution: 72
@@ -121,7 +121,7 @@ PASS
 Reading ../../../../../libtiffpic/depth/flower-minisblack-14.tif
 ../../../../../libtiffpic/depth/flower-minisblack-14.tif :   73 x   43, 1 channel, uint14 tiff
     SHA-1: C1B9CA21C227EF11626EF0C58BD49769EEF48363
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 14
     Orientation: 1 (normal)
     XResolution: 72
@@ -141,7 +141,7 @@ PASS
 Reading ../../../../../libtiffpic/depth/flower-minisblack-16.tif
 ../../../../../libtiffpic/depth/flower-minisblack-16.tif :   73 x   43, 1 channel, uint16 tiff
     SHA-1: 7EBB74E46C869CA0D6D091183732214B6A75173A
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 16
     Orientation: 1 (normal)
     XResolution: 72
@@ -161,7 +161,7 @@ PASS
 Reading ../../../../../libtiffpic/depth/flower-minisblack-32.tif
 ../../../../../libtiffpic/depth/flower-minisblack-32.tif :   73 x   43, 1 channel, uint tiff
     SHA-1: C98FB1125C7210E380E3F86DFCAEFF49A16742E0
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 32
     Orientation: 1 (normal)
     XResolution: 72

--- a/testsuite/tiff-suite/ref/out-alt.txt
+++ b/testsuite/tiff-suite/ref/out-alt.txt
@@ -1,7 +1,7 @@
 Reading ../../../../../libtiffpic/cramps.tif
 ../../../../../libtiffpic/cramps.tif :  800 x  607, 1 channel, uint8 tiff
     SHA-1: A1CA337CBB22D84410BBE710BB31D5D6646CF839
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 8
     Orientation: 1 (normal)
     XResolution: 72
@@ -18,7 +18,7 @@ PASS
 Reading ../../../../../libtiffpic/cramps-tile.tif
 ../../../../../libtiffpic/cramps-tile.tif :  800 x  607, 1 channel, uint8 tiff
     SHA-1: A1CA337CBB22D84410BBE710BB31D5D6646CF839
-    channel list: A
+    channel list: Y
     tile size: 256 x 256
     oiio:BitsPerSample: 8
     Orientation: 1 (normal)
@@ -95,7 +95,7 @@ PASS
 Reading ../../../../../libtiffpic/fax2d.tif
 ../../../../../libtiffpic/fax2d.tif : 1728 x 1082, 1 channel, uint1 tiff
     SHA-1: A57ECEDA78607AE81ABA344E4456EDB1E34A6CB0
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 1
     Orientation: 1 (normal)
     XResolution: 204
@@ -114,7 +114,7 @@ PASS
 Reading ../../../../../libtiffpic/g3test.tif
 ../../../../../libtiffpic/g3test.tif : 1728 x 1103, 1 channel, uint1 tiff
     SHA-1: D674B2BB7707525F8DD678E81CAF50EE3A15D1E8
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 1
     Orientation: 1 (normal)
     XResolution: 204
@@ -148,7 +148,7 @@ PASS
 Reading ../../../../../libtiffpic/off_l16.tif
 ../../../../../libtiffpic/off_l16.tif :  333 x  225, 1 channel, uint8 tiff
     SHA-1: 430C2B645099A186CC7AE28C5DA697297E40A4D5
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 16
     Orientation: 1 (normal)
     XResolution: 72

--- a/testsuite/tiff-suite/ref/out.txt
+++ b/testsuite/tiff-suite/ref/out.txt
@@ -1,7 +1,7 @@
 Reading ../../../../../libtiffpic/cramps.tif
 ../../../../../libtiffpic/cramps.tif :  800 x  607, 1 channel, uint8 tiff
     SHA-1: A1CA337CBB22D84410BBE710BB31D5D6646CF839
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 8
     Orientation: 1 (normal)
     XResolution: 72
@@ -18,7 +18,7 @@ PASS
 Reading ../../../../../libtiffpic/cramps-tile.tif
 ../../../../../libtiffpic/cramps-tile.tif :  800 x  607, 1 channel, uint8 tiff
     SHA-1: A1CA337CBB22D84410BBE710BB31D5D6646CF839
-    channel list: A
+    channel list: Y
     tile size: 256 x 256
     oiio:BitsPerSample: 8
     Orientation: 1 (normal)
@@ -95,7 +95,7 @@ PASS
 Reading ../../../../../libtiffpic/fax2d.tif
 ../../../../../libtiffpic/fax2d.tif : 1728 x 1082, 1 channel, uint1 tiff
     SHA-1: A57ECEDA78607AE81ABA344E4456EDB1E34A6CB0
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 1
     Orientation: 1 (normal)
     XResolution: 204
@@ -114,7 +114,7 @@ PASS
 Reading ../../../../../libtiffpic/g3test.tif
 ../../../../../libtiffpic/g3test.tif : 1728 x 1103, 1 channel, uint1 tiff
     SHA-1: D674B2BB7707525F8DD678E81CAF50EE3A15D1E8
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 1
     Orientation: 1 (normal)
     XResolution: 204
@@ -148,7 +148,7 @@ PASS
 Reading ../../../../../libtiffpic/off_l16.tif
 ../../../../../libtiffpic/off_l16.tif :  333 x  225, 1 channel, uint8 tiff
     SHA-1: 430C2B645099A186CC7AE28C5DA697297E40A4D5
-    channel list: A
+    channel list: Y
     oiio:BitsPerSample: 16
     Orientation: 1 (normal)
     XResolution: 72


### PR DESCRIPTION
In particular, 1-channel images (from formats without channel naming) will now get R, 2-channel images get R, G.

It's not perfect, because it's probably not really "red" and "green." But before, we were setting the default names to "A" and "I","A".  Which is probably much much worse, because "A" means alpha, and lots of operations treat alpha as special (such as PNG output dividing all the non-alpha channels by the alpha value!).

This is just for formats that don't actually store channel names in the files. Which is most formats.