### PR TITLE
More cleanup of bogus channel name edge cases

### DIFF
--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -230,7 +230,7 @@ command += oiiotool ("src/tahoe-tiny.tif --laplacian -d uint8 -o tahoe-laplacian
 
 # test fft, ifft
 command += oiiotool ("src/tahoe-tiny.tif --ch 2 --fft -d float -o fft.exr")
-command += oiiotool ("fft.exr --ifft --ch 0,0,0 -d float -o ifft.exr")
+command += oiiotool ("fft.exr --ifft --ch 0 -d float -o ifft.exr")
 
 # test --polar, --unpolar
 # note that fft.exr that we built above is in complex form

--- a/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
+++ b/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
@@ -372,7 +372,7 @@ try:
     inv = ImageBuf()
     ImageBufAlgo.ifft (inv, fft)
     b = ImageBuf()
-    ImageBufAlgo.channels (b, inv, (0,0,0))
+    ImageBufAlgo.channels (b, inv, (0,))
     write (b, "ifft.exr", oiio.FLOAT)
     inv.clear()
     fft.clear()


### PR DESCRIPTION
* PNG

The PNG spec is quite particular that a 2-channel image is gray+alpha,    so make sure that we name channels Y,A and designate channel 1 as alpha.

Also, since writing PNG involves automatically un-premultiplying the    color channels by alpha, enforce the fact that for PNG, alpha can ONLY    be the last channel of a 2 or 4 channel image. This prevents an app that    has set channel names or spec.alpha_channel stupidly from messing up the    values in the file (we wouldn't want to un-premultiply by a channel that    can't, by definition, be alpha).

*  OpenEXR write -- watch out for duplicate channel names.

MOST of the time, the channel names in an ImageSpec are merely     "informational." But one of those times when it makes a real difference    is writing OpenEXR files -- if there are multiple channels with the same    name, libIlmImf will silently DROP the duplicates! And it's not too hard    if you shuffle or replicate channels and aren't careful with the naming,    to do this. So this patch checks the exr output channel names, and    rewrites any duplicate ones to "channelN" (N is the index). It's    probably not "right", but it's probably better than channels    disappearing from the output entirely; it's easier to change a channel    name later than to discover that you've lost all the pixels for a    channel.