### PR TITLE
gcc6 missleading indentation

### DIFF
--- a/src/dpx.imageio/libdpx/Writer.cpp
+++ b/src/dpx.imageio/libdpx/Writer.cpp
@@ -204,9 +204,9 @@ bool dpx::Writer::WriteElement(const int element, void *data, const long count)
 	if (this->header.ImageDescriptor(element) == kUndefinedDescriptor)
 		return false;
 
-    // The DPX spec recommends that the image data starts on a 8K boundry.
-    if (! this->WritePadData(0x2000))
-        return false;
+	// The DPX spec recommends that the image data starts on a 8K boundry.
+	if (! this->WritePadData(0x2000))
+		return false;
 
 	// update file ptr
 	this->header.SetDataOffset(element, this->fileLoc);
@@ -243,9 +243,9 @@ bool dpx::Writer::WriteElement(const int element, void *data, const DataSize siz
 	if (this->header.ImageDescriptor(element) == kUndefinedDescriptor)
 		return false;
 
-    // The DPX spec recommends that the image data starts on a 8K boundry.
-    if (! this->WritePadData(0x2000))
-        return false;
+	// The DPX spec recommends that the image data starts on a 8K boundry.
+	if (! this->WritePadData(0x2000))
+		return false;
 
 	// mark location in headers
 	if (element == 0)


### PR DESCRIPTION
gcc6 sets by default -Werror=misleading-indentation
That detects bad indentation in
src/dpx.imageio/libdpx/Writer.cpp