### PR TITLE
Remove useless IC/TS clear() methods.

### DIFF
--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -78,9 +78,8 @@ public:
     ImageCache (void) { }
     virtual ~ImageCache () { }
 
-    /// Close everything, free resources, start from scratch.
-    ///
-    virtual void clear () = 0;
+    OIIO_DEPRECATED("clear() was never implemented. Don't bother calling it. [1.7]")
+    virtual void clear () { }
 
     /// Set an attribute controlling the image cache.  Return true
     /// if the name and type were recognized and the attrib was set.

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -313,9 +313,8 @@ public:
     TextureSystem (void) { }
     virtual ~TextureSystem () { }
 
-    /// Close everything, free resources, start from scratch.
-    ///
-    virtual void clear () = 0;
+    OIIO_DEPRECATED("clear() was never implemented. Don't bother calling it. [1.7]")
+    virtual void clear () { }
 
     /// Set an attribute controlling the texture system.  Return true
     /// if the name and type were recognized and the attrib was set.

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -764,10 +764,6 @@ public:
     }
 
 
-    /// Close everything, free resources, start from scratch.
-    ///
-    virtual void clear () { }
-
     // Retrieve options
     int max_open_files () const { return m_max_open_files; }
     const std::string &searchpath () const { return m_searchpath; }

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -108,8 +108,6 @@ public:
     }
 
 
-    virtual void clear () { }
-
     // Retrieve options
     void get_commontoworld (Imath::M44f &result) const {
         result = m_Mc2w;

--- a/src/python/py_imagecache.cpp
+++ b/src/python/py_imagecache.cpp
@@ -49,12 +49,6 @@ void ImageCacheWrap::destroy (ImageCacheWrap *x)
     ImageCache::destroy(x->m_cache);
 }
 
-void ImageCacheWrap::clear ()
-{
-    m_cache->clear();
-}
-
-
 std::string ImageCacheWrap::resolve_filename (const std::string &val)
 {
     ScopedGILRelease gil;
@@ -199,7 +193,6 @@ void declare_imagecache()
         .staticmethod("create")
         .def("destroy", &ImageCacheWrap::destroy)
         .staticmethod("destroy")
-        .def("clear", &ImageCacheWrap::clear)
         .def("attribute", &ImageCacheWrap::attribute_float)
         .def("attribute", &ImageCacheWrap::attribute_int)
         .def("attribute", &ImageCacheWrap::attribute_string)
@@ -227,4 +220,3 @@ void declare_imagecache()
 }
 
 } // namespace PyOpenImageIO
-

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -364,7 +364,6 @@ private:
 public:
     static ImageCacheWrap *create (bool);
     static void destroy (ImageCacheWrap*);
-    void clear ();     
     void attribute_int    (const std::string&, int );
     void attribute_float  (const std::string&, float);
     void attribute_string (const std::string&, const std::string&);


### PR DESCRIPTION
It's not used, is empty, isn't even documented. So remove it.

I think this was put in within the first few minutes of laying out these
classes, but in the end was not needed; as the concepts got more refined,
we ended up with invalidate() and its variants.