### PR TITLE
Retrieve additional IC/TS statistics with getattribute & get_image_info()

### DIFF
--- a/src/doc/imagecache.tex
+++ b/src/doc/imagecache.tex
@@ -393,6 +393,83 @@ settings of named options.  For example,
 \end{code}
 \apiend
 
+\apiitem{int max_open_files}
+The maximum number of file handles that the image cache will
+hold open simultaneously.  (Default = 100)
+\apiend
+
+\apiitem{int total_files {\rm ~(read only)}}
+The total number of unique file names referenced by calls to the \ImageCache.
+\apiend
+
+\apiitem{string[] all_filenames {\rm ~(read only)}}
+An array that will be filled with the list of the names of all files
+referenced by calls to the \ImageCache. (The array is of {\cf ustring}s or
+{\cf char*}'s.)
+\apiend
+
+\apiitem{int64 stat:cache_memory_used {\rm ~(read only)}}
+Total bytes used by tile cache.
+\apiend
+
+\apiitem{int stat:tiles_created {\rm ~(read only)} \\
+int stat:tiles_current {\rm ~(read only)} \\
+int stat:tiles_peak {\rm ~(read only)}}
+Total times created, still allocated (at the time of the query), and the
+peak number of tiles in memory at any time.
+\apiend
+
+\apiitem{int stat:open_files_created {\rm ~(read only)} \\
+int stat:open_files_current {\rm ~(read only)} \\
+int stat:open_files_peak {\rm ~(read only)}}
+Total number of times a file was opened, number still opened (at the time of
+the query), and the peak number of files opened at any time.
+\apiend
+
+\apiitem{int stat:find_tile_calls {\rm ~(read only)}}
+Number of times a filename was looked up in the file cache.
+\apiend
+
+\apiitem{int64 stat:files_totalsize {\rm ~(read only)}}
+Total size (uncompressed bytes of pixel data) of all files referenced.
+\apiend
+
+\apiitem{int64 stat:bytes_read {\rm ~(read only)}}
+Total size (uncompressed bytes of pixel data) read.
+\apiend
+
+\apiitem{int stat:unique_files {\rm ~(read only)}}
+Number of unique files opened.
+\apiend
+
+\apiitem{float stat:fileio_time {\rm ~(read only)}}
+Total I/O-related time (seconds).
+\apiend
+
+\apiitem{float stat:fileopen_time {\rm ~(read only)}}
+I/O time related to opening and reading headers (but not pixel I/O).
+\apiend
+
+\apiitem{float stat:file_locking_time {\rm ~(read only)}}
+Total time (across all threads) that threads blocked waiting for access to
+the file data structures.
+\apiend
+
+\apiitem{float stat:tile_locking_time {\rm ~(read only)}}
+Total time (across all threads) that threads blocked waiting for access to
+the tile cache data structures.
+\apiend
+
+\apiitem{float stat:find_file_time {\rm ~(read only)}}
+Total time (across all threads) that threads spent looking up files by name.
+\apiend
+
+\apiitem{float stat:find_tile_time {\rm ~(read only)}}
+Total time (across all threads) that threads spent looking up individual tiles.
+\apiend
+
+
+
 \bigskip
 
 \subsection{Opaque data for performance lookups}
@@ -479,11 +556,15 @@ Supported {\cf dataname} values include:
 \item[\spc] \spc
 \vspace{-12pt} 
 
-\item[\rm \kw{exists}] Stores the value 1 (as an {\cf int} if the file
+\item[\rm \kw{exists}] Stores the value 1 (as an {\cf int}) if the file
 exists and is an image format that \product can read, or 0 if the file
 does not exist, or could not be properly read as an image. Note that
 unlike all other queries, this query will ``succeed'' (return {\cf true})
 even if the file does not exist.
+
+\item[\rm \kw{udim}] Stores the value 1 (as an {\cf int}) if the file
+is a ``virtual UDIM'' or texture atlas file (as described in
+Section~\ref{sec:texturesys:udim}) or 0 otherwise.
 
 \item[\rm \kw{subimages}] The number of subimages in the file, as an integer.
 
@@ -543,6 +624,50 @@ matrix (an {\cf Imath::M44f}, described as {\cf TypeDesc(FLOAT,MATRIX)}),
 giving the matrix that projected points from world space into a 2D screen
 coordinate system where $x$ and $y$ range from $-1$ to $+1$.  Generally,
 only rendered images will have this.
+
+\item[\rm \kw{averagecolor}] If available in the metadata (generally only
+for files that have been processed by {\cf maketx}), this will return the
+average color of the texture (into an array of floats).
+
+\item[\rm \kw{averagealpha}] If available in the metadata (generally only
+for files that have been processed by {\cf maketx}), this will return the
+average alpha value of the texture (into a float).
+
+\item[\rm \kw{constantcolor}] If the metadata (generally only for files that
+have been processed by {\cf maketx}) indicates that the texture has the same
+values for all pixels in the texture, this will retrieve the constant color
+of the texture (into an array of floats). A non-constant image (or one that
+does not have the special metadata tag identifying it as a constant texture)
+will fail this query (return false).
+
+\item[\rm \kw{constantalpha}] If the metadata indicates that the texture has
+the same values for all pixels in the texture, this will retrieve the
+constant alpha value of the texture (into a float). A non-constant image (or
+one that does not have the special metadata tag identifying it as a constant
+texture) will fail this query (return false).
+
+\item[\rm \kw{stat:tilesread}] Number of tiles read from this file ({\cf int64}).
+
+\item[\rm \kw{stat:bytesread}] Number of bytes of uncompressed pixel data read
+from this file ({cf int64}).
+
+\item[\rm \kw{stat:redundant_tiles}] Number of times a tile was read, where
+the same tile had been rad before. ({\cf int64}).
+
+\item[\rm \kw{stat:redundant_bytesread}] Number of bytes (of uncompressed pixel
+data) in tiles that were read redundantly. ({\cf int64}).
+
+\item[\rm \kw{stat:redundant_bytesread}] Number of tiles read from this file ({\cf int}).
+
+\item[\rm \kw{stat:timesopened}] Number of times this file was opened ({\cf int}).
+
+\item[\rm \kw{stat:iotime}] Time (in seconds) spent on all I/O for this file ({\cf float}).
+
+\item[\rm \kw{stat:mipsused}] Stores 1 if any MIP levels beyond the highest
+resolution were accesed, otherwise 0. ({\cf int})
+
+\item[\rm \kw{stat:is_duplicate}] Stores 1 if this file was a duplicate of
+another image, otherwise 0. ({\cf int})
 
 \item[Anything else] -- For all other data names, the
 the metadata of the image file will be searched for an item that

--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -1180,7 +1180,7 @@ does not exist, or could not be properly read as a texture. Note that
 unlike all other queries, this query will ``succeed'' (return {\cf true})
 even if the file does not exist.
 
-\item[\rm \kw{udim}] Stores the value 1 (as an {\cf int} if the file
+\item[\rm \kw{udim}] Stores the value 1 (as an {\cf int}) if the file
 is a ``virtual UDIM'' or texture atlas file (as described in
 Section~\ref{sec:texturesys:udim}) or 0 otherwise.
 
@@ -1213,6 +1213,16 @@ all accessible through the same API calls.
 
 \item[\rm \kw{channels}] The number of color channels in the file 
 (an integer).
+
+\item[\rm \kw{format}] The native data format of the pixels in the
+  file (an integer, giving the {\cf TypeDesc::BASETYPE} of the data).
+  Note that this is not necessarily the same as the data format stored
+  in the image cache.
+
+\item[\rm \kw{cachedformat}] The native data format of the pixels as
+  stored in the image cache (an integer, giving the {\cf
+    TypeDesc::BASETYPE} of the data).  Note that this is not necessarily
+  the same as the native data format of the file.
 
 \item[\rm \kw{datawindow}] 
 Returns the pixel data window of the image, which is either an array of 4
@@ -1257,6 +1267,29 @@ the same values for all pixels in the texture, this will retrieve the
 constant alpha value of the texture (into a float). A non-constant image (or
 one that does not have the special metadata tag identifying it as a constant
 texture) will fail this query (return false).
+
+\item[\rm \kw{stat:tilesread}] Number of tiles read from this file ({\cf int64}).
+
+\item[\rm \kw{stat:bytesread}] Number of bytes of uncompressed pixel data read
+from this file ({cf int64}).
+
+\item[\rm \kw{stat:redundant_tiles}] Number of times a tile was read, where
+the same tile had been rad before. ({\cf int64}).
+
+\item[\rm \kw{stat:redundant_bytesread}] Number of bytes (of uncompressed pixel
+data) in tiles that were read redundantly. ({\cf int64}).
+
+\item[\rm \kw{stat:redundant_bytesread}] Number of tiles read from this file ({\cf int}).
+
+\item[\rm \kw{stat:timesopened}] Number of times this file was opened ({\cf int}).
+
+\item[\rm \kw{stat:iotime}] Time (in seconds) spent on all I/O for this file ({\cf float}).
+
+\item[\rm \kw{stat:mipsused}] Stores 1 if any MIP levels beyond the highest
+resolution were accesed, otherwise 0. ({\cf int})
+
+\item[\rm \kw{stat:is_duplicate}] Stores 1 if this file was a duplicate of
+another image, otherwise 0. ({\cf int})
 
 \item[Anything else] -- For all other data names, the
 the metadata of the image file will be searched for an item that

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -112,7 +112,19 @@ public:
     virtual bool attribute (string_view name, double val) = 0;
     virtual bool attribute (string_view name, string_view val) = 0;
 
-    /// Get the named attribute, store it in value.
+    /// Get the named attribute, store it in *val. All of the attributes
+    /// that may be set with the attribute() call may also be queried with
+    /// getattribute().
+    ///
+    /// Additionally, there are some read-only attributes that can be
+    /// queried with getattribute():
+    ///     int total_files : the total number of unique files referenced by
+    ///             calls to the ImageCache.
+    ///     string[] all_filenames : an array that will be filled with the
+    ///             list of the names of all files referenced by calls to
+    ///             the ImageCache. (The array is of ustrings or char*'s.)
+    ///     stat:* : a variety of statistics (see full docs for details).
+    ///
     virtual bool getattribute (string_view name, TypeDesc type,
                                void *val) const = 0;
     // Shortcuts for common types

--- a/src/include/OpenImageIO/unordered_map_concurrent.h
+++ b/src/include/OpenImageIO/unordered_map_concurrent.h
@@ -353,6 +353,9 @@ public:
     /// Return true if the entire map is empty.
     bool empty() { return m_size == 0; }
 
+    /// Return the total number of entries in the map.
+    size_t size () { return size_t(m_size); }
+
     /// Expliticly lock the bin that will contain the key (regardless of
     /// whether there is such an entry in the map), and return its bin
     /// number.


### PR DESCRIPTION
Additional IC-wide (and TS-wide) queries for getattribute():

    total_files
    all_filenames

And now a variety of per-file statistics may be retrieved via
get_image_info():

    broken
    stat:tilesread
    stat:bytesread
    stat:redundant_tiles
    stat:redundant_bytesread
    stat:timesopened
    stat:iotime
    stat:mipused
    stat:is_duplicate