### PR TITLE
oiiotool --iconfig NAME VALUE lets you set input configurations.

### DIFF
--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -975,6 +975,30 @@ is turned on, The \ImageCache \qkw{autoscanline} feature will also be enabled.
 See Section~\ref{imagecacheattr:autotile} for details.
 \apiend
 
+\apiitem{\ce --iconfig {\rm \emph{name value}}}
+\NEW % 1.7
+Sets configuration metadata that will apply to the next input file read.
+
+\noindent Optional appended arguments include:
+
+\begin{tabular}{p{10pt} p{1in} p{3.5in}}
+  & {\cf type=}\emph{typename} & Specify the metadata type.
+\end{tabular}
+
+If the optional {\cf type=} specifier is used, that provides an
+explicit type for the metadata. If not provided,
+it will try to infer the type of the metadata from the value: if the
+value contains only numerals (with optional leading minus sign), it will
+be saved as {\cf int} metadata; if it also contains a decimal point, it
+will be saved as {\cf float} metadata; otherwise, it will be saved as
+a {\cf string} metadata.
+
+\noindent Examples:
+\begin{code}
+    oiiotool --iconfig "oiio:UnassociatedAlpha" 1 in.png -o out.tif
+\end{code}
+\apiend
+
 \newpage
 \subsection*{Writing images}
 

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -94,7 +94,7 @@
  \bigskip \\
 }
 \date{{\large 
-Date: 20 Jun 2016
+Date: 28 Jun 2016
 %\\ (with corrections, 25 Aug 2015)
 }}
 

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -84,6 +84,8 @@ public:
     std::string full_command_line;
     std::string printinfo_metamatch;
     std::string printinfo_nometamatch;
+    ImageSpec input_config;           // configuration options for reading
+    bool input_config_set;
 
     // Output options
     TypeDesc output_dataformat;

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -724,7 +724,8 @@ OiioTool::print_info (Oiiotool &ot,
                       std::string &error)
 {
     error.clear();
-    ImageInput *input = ImageInput::open (filename.c_str());
+    ImageSpec *config = ot.input_config_set ? &ot.input_config : NULL;
+    ImageInput *input = ImageInput::open (filename.c_str(), config);
     if (! input) {
         error = geterror();
         if (error.empty())

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -53,6 +53,8 @@ copyA.0007.jpg       :  360 x  240, 3 channel, uint8 jpeg
 copyA.0008.jpg       :  360 x  240, 3 channel, uint8 jpeg
 copyA.0009.jpg       :  360 x  240, 3 channel, uint8 jpeg
 copyA.0010.jpg       :  360 x  240, 3 channel, uint8 jpeg
+Reading black.tif
+    oiio:DebugOpenConfig!: 42
 Comparing "filled.tif" and "ref/filled.tif"
 PASS
 Comparing "autotrim.tif" and "ref/autotrim.tif"

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -278,6 +278,9 @@ command += oiiotool ("src/tahoe-small.tif -o exprstrcat{TOP.compression}.tif")
 # test --no-autopremult on a TGA file thet needs it.
 command += oiiotool ("--no-autopremult src/rgba.tga --ch R,G,B -o rgbfromtga.png")
 
+# test --iconfig
+command += oiiotool ("--info -v -metamatch Debug --iconfig oiio:DebugOpenConfig! 1 black.tif")
+
 # To add more tests, just append more lines like the above and also add
 # the new 'feature.tif' (or whatever you call it) to the outputs list,
 # below.


### PR DESCRIPTION
Very occasionally, you want to do an "open with config" where a configuration ImageSpec is supplied to the ImageInput::open() and contains metadata that gives special instructions (invariably they are format-specific).

It was awkward to do so for images read by oiiotool.

This command lets you set config metadata that will apply to the NEXT image read by referencing its name on the command line (after which the configuration metadata will be cleared).

Example:

    oiiotool -iconfig "oiio:UnassociatedAlpha" 1 input.png -o out.exr

    # The PNG input recognizes oiio:UnassociatedAlpha configuration
    # metadata, when nonzero, to cause it to NOT leave PNG's unassociated
    # (not "pre-multiplied" by alpha) color values intact, rather than
    # applying the automatic conversion to associated alpha.
