### PR TITLE
Make sure ImageSpec::set_format clears any per-channel formats

### DIFF
--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -486,7 +486,8 @@ it exists) is assumed to be alpha, and values are assumed to be linear.
 \apiend
 
 \apiitem{void {\ce set_format} (TypeDesc fmt)}
-Sets the format as described.
+Sets the format as described, and clears any per-channel format information
+in {\cf channelformats}.
 \apiend
 
 \apiitem{void {\ce default_channel_names} ()}

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -360,8 +360,7 @@ image, of {\cf False} if it is an ordinary image.
 \apiitem{ImageSpec.{\ce set_format} (basetype) \\
 ImageSpec.{\ce set_format} (typedesc)}
 Given a {\cf BASETYPE} or a \TypeDesc, sets the {\cf format} field and
-also sets all the {\cf quantize} fields to the defaults for the given
-data format.
+clear any per-channel formats in {\cf channelformats}.
 
 \noindent Example:
 \begin{code}

--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -187,12 +187,12 @@ adjust_spec (ImageInput *in, ImageOutput *out,
     bool nocopy = no_copy_image;
 
     // Copy the spec, with possible change in format
-    outspec.set_format (inspec.format);
+    outspec.format = inspec.format;
     if (inspec.channelformats.size()) {
         // Input file has mixed channels
         if (out->supports("channelformats")) {
             // Output supports mixed formats -- so request it
-            outspec.set_format (TypeDesc::UNKNOWN);
+            outspec.format = TypeDesc::UNKNOWN;
         } else {
             // Input had mixed formats, output did not, so just use a fixed
             // format and forget the per-channel formats for output.

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -124,7 +124,6 @@ ImageSpec::ImageSpec (TypeDesc format)
       nchannels(0), format(format), alpha_channel(-1), z_channel(-1),
       deep(false)
 {
-    set_format (format);
 }
 
 
@@ -137,7 +136,6 @@ ImageSpec::ImageSpec (int xres, int yres, int nchans, TypeDesc format)
       nchannels(nchans), format(format), alpha_channel(-1), z_channel(-1),
       deep(false)
 {
-    set_format (format);
     default_channel_names ();
 }
 
@@ -147,6 +145,7 @@ void
 ImageSpec::set_format (TypeDesc fmt)
 {
     format = fmt;
+    channelformats.clear ();
 }
 
 
@@ -990,4 +989,3 @@ ImageSpec::from_xml (const char *xml)
 
 
 OIIO_NAMESPACE_END
-

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -493,7 +493,7 @@ adjust_output_options (string_view filename,
         if (type == TypeDesc::UNKNOWN)
             type = ot.output_dataformat;
         if (type != TypeDesc::UNKNOWN)
-            spec.set_format (ot.output_dataformat);
+            spec.format = ot.output_dataformat;
         int bits = get_value_override (fileoptions["bits"], ot.output_bitspersample);
         if (bits)
             spec.attribute ("oiio:BitsPerSample", ot.output_bitspersample);


### PR DESCRIPTION
It seems to me that a call to set_format() should really completely overwrite the format, including per-channel information that may have been previously set.

There were a handful of places where we called set_format and specifically wanted to preserve channelformats. In those cases, we just changed it to `format = ...`.

