### PR TITLE
Fix EXR tile logic for OpenEXR 1.x

### DIFF
--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -479,8 +479,11 @@ OpenEXRInput::PartInfo::parse_header (const Imf::Header *header)
     spec.full_depth = 1;
     spec.tile_depth = 1;
 
-    if (Strutil::icontains(header->type(), "tile")
-          && header->hasTileDescription()) {
+    if (header->hasTileDescription()
+#if USE_OPENEXR_VERSION2
+        && Strutil::icontains(header->type(), "tile")
+#endif
+        ) {
         const Imf::TileDescription &td (header->tileDescription());
         spec.tile_width = td.xSize;
         spec.tile_height = td.ySize;


### PR DESCRIPTION
Recent change #1441 ("More robust detection of whether OpenEXR is tiled")
inadvertently used a call that is only available for OpenEXR >= 2.x.
Use the more robust test for OpenEXR 2.x, the old naive one for 1.x.

Fixes #1447