### PR TITLE
Strutil & Sysutil odds and ends

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -475,7 +475,7 @@ string_view OIIO_API parse_nested (string_view &str, bool eat=true);
 /// vector, but C++11 support is not yet stabilized across compilers.
 /// We will eventually add that and deprecate this one, after everybody
 /// is caught up to C++11.
-void OIIO_API utf8_to_unicode (string_view &str, std::vector<uint32_t> &uvec);
+void OIIO_API utf8_to_unicode (string_view str, std::vector<uint32_t> &uvec);
 
 }  // namespace Strutil
 

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -477,6 +477,10 @@ string_view OIIO_API parse_nested (string_view &str, bool eat=true);
 /// is caught up to C++11.
 void OIIO_API utf8_to_unicode (string_view str, std::vector<uint32_t> &uvec);
 
+/// Encode the string in base64.
+/// https://en.wikipedia.org/wiki/Base64
+std::string OIIO_API base64_encode (string_view str);
+
 }  // namespace Strutil
 
 OIIO_NAMESPACE_END

--- a/src/include/OpenImageIO/sysutil.h
+++ b/src/include/OpenImageIO/sysutil.h
@@ -49,6 +49,7 @@
 #include "export.h"
 #include "oiioversion.h"
 #include "platform.h"
+#include "string_view.h"
 
 
 OIIO_NAMESPACE_BEGIN
@@ -78,6 +79,10 @@ OIIO_API void get_local_time (const time_t *time, struct tm *converted_time);
 /// Return the full path of the currently-running executable program.
 ///
 OIIO_API std::string this_program_path ();
+
+/// Return the value of an environment variable (or the empty string_view
+/// if it is not found in the environment.)
+OIIO_API string_view getenv (string_view name);
 
 /// Sleep for the given number of microseconds.
 ///

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -881,7 +881,7 @@ decode(uint32_t* state, uint32_t* codep, uint32_t byte)
 }
 
 void
-Strutil::utf8_to_unicode (string_view &str, std::vector<uint32_t> &uvec)
+Strutil::utf8_to_unicode (string_view str, std::vector<uint32_t> &uvec)
 {
     const char* begin = str.begin();
     const char* end = str.end();

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -893,4 +893,66 @@ Strutil::utf8_to_unicode (string_view str, std::vector<uint32_t> &uvec)
     }
 }
 
+
+
+/* base64 code is based upon: http://www.adp-gmbh.ch/cpp/common/base64.html
+   Copyright (C) 2004-2008 René Nyffenegger
+
+   This source code is provided 'as-is', without any express or implied
+   warranty. In no event will the author be held liable for any damages
+   arising from the use of this software.
+
+   Permission is granted to anyone to use this software for any purpose,
+   including commercial applications, and to alter it and redistribute it
+   freely, subject to the following restrictions:
+
+   1. The origin of this source code must not be misrepresented; you must not
+      claim that you wrote the original source code. If you use this source code
+      in a product, an acknowledgment in the product documentation would be
+      appreciated but is not required.
+   2. Altered source versions must be plainly marked as such, and must not be
+      misrepresented as being the original source code.
+   3. This notice may not be removed or altered from any source distribution.
+
+   René Nyffenegger rene.nyffenegger@adp-gmbh.ch
+*/
+std::string
+Strutil::base64_encode (string_view str)
+{
+    static const char *base64_chars =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    std::string ret;
+    ret.reserve ((str.size() * 4 + 2)/ 3);
+    int i = 0;
+    unsigned char char_array_3[3];
+    unsigned char char_array_4[4];
+    while (str.size()) {
+        char_array_3[i++] = str.front();
+        str.remove_prefix (1);
+        if (i == 3) {
+            char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
+            char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
+            char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
+            char_array_4[3] = char_array_3[2] & 0x3f;
+            for (int j = 0; j < 4; j++)
+                ret += base64_chars[char_array_4[j]];
+            i = 0;
+        }
+    }
+    if (i) {
+        for (int j = i; j < 3; j++)
+            char_array_3[j] = '\0';
+        char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
+        char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
+        char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
+        char_array_4[3] = char_array_3[2] & 0x3f;
+        for (int j = 0; j < i + 1; j++)
+            ret += base64_chars[char_array_4[j]];
+        while (i++ < 3)
+            ret += '=';
+    }
+    return ret;
+}
+
+
 OIIO_NAMESPACE_END

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -262,6 +262,14 @@ Sysutil::this_program_path ()
 
 
 
+string_view
+Sysutil::getenv (string_view name)
+{
+    return string_view (::getenv (name.c_str()));
+}
+
+
+
 void
 Sysutil::usleep (unsigned long useconds)
 {


### PR DESCRIPTION
Some minor changes to Strutil & Sysutil that I did a while back but hadn't committed.

* Change declaration of utf_to_unicode from taking a string_view& to a string_view. This was probably just a typo in the original code.
* Strutil::base64_encode -- does what it says.
* Sysutil::getenv -- wraps getenv in a nice string_view wrapper, which means you can directly compare it rather than needing to separately see if a raw getenv call returns NULL before strcmp'ing it.
