### PR TITLE
Fix typo: was getting XResolution metadata when YResolution was intended

### DIFF
--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -726,7 +726,7 @@ OpenEXROutput::spec_to_header (ImageSpec &spec, int subimage, Imf::Header &heade
     // Fix up density and aspect to be consistent
     float aspect = spec.get_float_attribute ("PixelAspectRatio", 0.0f);
     float xdensity = spec.get_float_attribute ("XResolution", 0.0f);
-    float ydensity = spec.get_float_attribute ("XResolution", 0.0f);
+    float ydensity = spec.get_float_attribute ("YResolution", 0.0f);
     if (! aspect && xdensity && ydensity) {
         // No aspect ratio. Compute it from density, if supplied.
         spec.attribute ("PixelAspectRatio", xdensity / ydensity);


### PR DESCRIPTION
Fixes #1214

Thanks, Thiago, for spotting this, and I'm a real dunce for not only doing
it in the first place, but for so badly misunderstanding the point of your
issue that I let it go unaddressed for months.