### PR TITLE
Fix build errors on Windows when making Unicode builds

### DIFF
--- a/src/include/OpenImageIO/SHA1.h
+++ b/src/include/OpenImageIO/SHA1.h
@@ -121,27 +121,10 @@
 #define SHA1_WIPE_VARIABLES
 #endif
 
-#if defined(SHA1_HAS_TCHAR)
-#include <tchar.h>
-#else
 #ifdef _MSC_VER
-#include <tchar.h>
+#define _sntprintf _snprintf
 #else
-#ifndef TCHAR
-#define TCHAR char
-#endif
-#ifndef _T
-#define _T(__x) (__x)
-#define _tmain main
-#define _tprintf printf
-#define _getts gets
-#define _tcslen strlen
-#define _tfopen fopen
-#define _tcscpy strcpy
-#define _tcscat strcat
 #define _sntprintf snprintf
-#endif
-#endif
 #endif
 
 // Fallback, if no 64-bit support
@@ -203,18 +186,18 @@ public:
 
 #ifdef SHA1_UTILITY_FUNCTIONS
 	// Hash in file contents
-	bool HashFile(const TCHAR* tszFileName);
+	bool HashFile(const char* szFileName);
 #endif
 
 	// Finalize hash, call before using ReportHash(Stl)
 	void Final();
 
 #ifdef SHA1_UTILITY_FUNCTIONS
-	bool ReportHash(TCHAR* tszReport, REPORT_TYPE rtReportType = REPORT_HEX) const;
+	bool ReportHash(char* szReport, REPORT_TYPE rtReportType = REPORT_HEX) const;
 #endif
 
 #ifdef SHA1_STL_FUNCTIONS
-	bool ReportHashStl(std::basic_string<TCHAR>& strOut, REPORT_TYPE rtReportType =
+	bool ReportHashStl(std::string& strOut, REPORT_TYPE rtReportType =
 		REPORT_HEX) const;
 #endif
 

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -124,6 +124,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <algorithm>
 
+#include "missing_math.h"
+
 
 OIIO_NAMESPACE_BEGIN
 

--- a/src/libutil/SHA1.cpp
+++ b/src/libutil/SHA1.cpp
@@ -11,6 +11,7 @@
 #include "OpenImageIO/SHA1.h"
 #include "OpenImageIO/hash.h"
 #include "OpenImageIO/dassert.h"
+#include "OpenImageIO/strutil.h"
 
 #ifdef SHA1_UTILITY_FUNCTIONS
 #define SHA1_MAX_FILE_BUFFER 8000
@@ -186,11 +187,16 @@ void CSHA1::Update(const UINT_8* pbData, UINT_32 uLen)
 
 #ifdef SHA1_UTILITY_FUNCTIONS
 // Hash in file contents
-bool CSHA1::HashFile(const TCHAR* tszFileName)
+bool CSHA1::HashFile(const char* szFileName)
 {
-	if(tszFileName == NULL) return false;
+	if(szFileName == NULL) return false;
 
-	FILE* fpIn = _tfopen(tszFileName, _T("rb"));
+#ifdef _WIN32
+    std::wstring wf = Strutil::utf8_to_utf16(szFileName);
+    FILE* fpIn = _wfopen(wf.c_str(), L"rb");
+#else
+	FILE* fpIn = fopen(szFileName, "rb");
+#endif
 	if(fpIn == NULL) return false;
 
 	_fseeki64(fpIn, 0, SEEK_END);
@@ -254,33 +260,33 @@ void CSHA1::Final()
 
 #ifdef SHA1_UTILITY_FUNCTIONS
 // Get the final hash as a pre-formatted string
-bool CSHA1::ReportHash(TCHAR* tszReport, REPORT_TYPE rtReportType) const
+bool CSHA1::ReportHash(char* szReport, REPORT_TYPE rtReportType) const
 {
-	if(tszReport == NULL) return false;
+	if(szReport == NULL) return false;
 
-	TCHAR tszTemp[16];
+	char szTemp[16];
 
 	if((rtReportType == REPORT_HEX) || (rtReportType == REPORT_HEX_SHORT))
 	{
-		_sntprintf(tszTemp, 15, _T("%02X"), m_digest[0]);
-		_tcscpy(tszReport, tszTemp);
+		_sntprintf(szTemp, 15, "%02X", m_digest[0]);
+		strcpy(szReport, szTemp);
 
-		const TCHAR* lpFmt = ((rtReportType == REPORT_HEX) ? _T(" %02X") : _T("%02X"));
+		const char* lpFmt = ((rtReportType == REPORT_HEX) ? " %02X" : "%02X");
 		for(size_t i = 1; i < 20; ++i)
 		{
-			_sntprintf(tszTemp, 15, lpFmt, m_digest[i]);
-			_tcscat(tszReport, tszTemp);
+			_sntprintf(szTemp, 15, lpFmt, m_digest[i]);
+			strcat(szReport, szTemp);
 		}
 	}
 	else if(rtReportType == REPORT_DIGIT)
 	{
-		_sntprintf(tszTemp, 15, _T("%u"), m_digest[0]);
-		_tcscpy(tszReport, tszTemp);
+		_sntprintf(szTemp, 15, "%u", m_digest[0]);
+		strcpy(szReport, szTemp);
 
 		for(size_t i = 1; i < 20; ++i)
 		{
-			_sntprintf(tszTemp, 15, _T(" %u"), m_digest[i]);
-			_tcscat(tszReport, tszTemp);
+			_sntprintf(szTemp, 15, " %u", m_digest[i]);
+			strcat(szReport, szTemp);
 		}
 	}
 	else return false;
@@ -290,11 +296,11 @@ bool CSHA1::ReportHash(TCHAR* tszReport, REPORT_TYPE rtReportType) const
 #endif
 
 #ifdef SHA1_STL_FUNCTIONS
-bool CSHA1::ReportHashStl(std::basic_string<TCHAR>& strOut, REPORT_TYPE rtReportType) const
+bool CSHA1::ReportHashStl(std::string& strOut, REPORT_TYPE rtReportType) const
 {
-	TCHAR tszOut[84];
-	const bool bResult = ReportHash(tszOut, rtReportType);
-	if(bResult) strOut = tszOut;
+	char szOut[84];
+	const bool bResult = ReportHash(szOut, rtReportType);
+	if(bResult) strOut = szOut;
 	return bResult;
 }
 #endif

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -189,7 +189,7 @@ void benchmark_convert_type ()
     std::cout << Strutil::format("Benchmark conversion of %6s -> %6s : ",
                                  TypeDesc(BaseTypeFromC<S>::value),
                                  TypeDesc(BaseTypeFromC<D>::value));
-    float time = time_trial (bind (do_convert_type<S,D>, OIIO::cref(svec), OIIO::ref(dvec)),
+    float time = time_trial (boost::bind (do_convert_type<S,D>, OIIO::cref(svec), OIIO::ref(dvec)),
                              ntrials, iterations) / iterations;
     std::cout << Strutil::format ("%7.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
     D r = convert_type<S,D>(testval);

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -189,7 +189,7 @@ void benchmark_convert_type ()
     std::cout << Strutil::format("Benchmark conversion of %6s -> %6s : ",
                                  TypeDesc(BaseTypeFromC<S>::value),
                                  TypeDesc(BaseTypeFromC<D>::value));
-    float time = time_trial (boost::bind (do_convert_type<S,D>, OIIO::cref(svec), OIIO::ref(dvec)),
+    float time = time_trial (bind (do_convert_type<S,D>, OIIO::cref(svec), OIIO::ref(dvec)),
                              ntrials, iterations) / iterations;
     std::cout << Strutil::format ("%7.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
     D r = convert_type<S,D>(testval);

--- a/src/libutil/plugin.cpp
+++ b/src/libutil/plugin.cpp
@@ -39,6 +39,7 @@
 
 #include "OpenImageIO/thread.h"
 #include "OpenImageIO/plugin.h"
+#include "OpenImageIO/strutil.h"
 
 
 OIIO_NAMESPACE_BEGIN
@@ -75,7 +76,8 @@ Plugin::plugin_extension (void)
 Handle
 dlopen (const char *plugin_filename, int)
 {
-    return LoadLibrary (plugin_filename);
+    std::wstring w = Strutil::utf8_to_utf16(plugin_filename);
+    return LoadLibraryW(w.c_str());
 }
 
 

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -59,6 +59,7 @@
 #endif
 
 #include "OpenImageIO/platform.h"
+#include "OpenImageIO/strutil.h"
 
 #ifdef _WIN32
 # include <Psapi.h>
@@ -221,6 +222,14 @@ Sysutil::get_local_time (const time_t *time, struct tm *converted_time)
 std::string
 Sysutil::this_program_path ()
 {
+#if defined(_WIN32)
+    // According to MSDN...
+    WCHAR filename[10240];
+    int r = GetModuleFileNameW(NULL, filename, 10240);
+    if (r > 0)
+        return Strutil::utf16_to_utf8(filename);
+    return std::string();
+#else
     char filename[10240];
     filename[0] = 0;
 
@@ -235,10 +244,6 @@ Sysutil::this_program_path ()
     int r = _NSGetExecutablePath (filename, &size);
     if (r == 0)
         r = size;
-#elif defined(_WIN32)
-    // According to MSDN...
-    unsigned int size = sizeof(filename);
-    int r = GetModuleFileName (NULL, filename, size);
 #elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
     int mib[4];
     mib[0] = CTL_KERN;
@@ -258,6 +263,7 @@ Sysutil::this_program_path ()
     if (r > 0)
         return std::string (filename);
     return std::string();   // Couldn't figure it out
+#endif
 }
 
 


### PR DESCRIPTION
## Description

Fixes build errors on windows when using the _Unicode Character Set_ (which any serious project should be using these days). Practically this means that `TCHAR` is defined as a `WCHAR`, which is a 16-bit integral type. A `TCHAR[]` is encoded as UTF-16. There are a few places in the source code which assume a `TCHAR` is equal to a char (or alternatively, a `TCHAR*` can be converted to a `std::string`, this assumption is false.

Since the rest of the OpenImageIO project assumes strings are encoded using UTF-8 (?), I have removed the dependency on the `<tchar.h>` and any calls to win32 API functions explicitly use the wide versions (with the `W` suffix). The input / result is converted immediately before / after the API call (an approach inspired by http://utf8everywhere.org/)

Also `simd.h` depends on `missing_math.h` for the `roundf` function.

**Note:** on MSVC 2013 and older, `snprintf` is named `_snprintf`, I'm not sure what your preference is to deal with that.
## Tests

I think these changes are covered by existing tests, if any.
