### PR TITLE
Clamp ImageCache max_open_files below the system limit

### DIFF
--- a/src/include/OpenImageIO/sysutil.h
+++ b/src/include/OpenImageIO/sysutil.h
@@ -108,6 +108,9 @@ OIIO_API unsigned int hardware_concurrency ();
 /// platforms will return the number of virtual cores.
 OIIO_API unsigned int physical_concurrency ();
 
+/// Get the maximum number of open file handles allowed on this system.
+OIIO_API size_t max_open_files ();
+
 }  // namespace Sysutils
 
 OIIO_NAMESPACE_END

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -784,6 +784,9 @@ public:
 
     virtual std::string resolve_filename (const std::string &filename) const;
 
+    // Set m_max_open_files, with logic to try to clamp reasonably.
+    void set_max_open_files (int m);
+
     /// Get information about the given image.
     ///
     virtual bool get_image_info (ustring filename, int subimage, int miplevel,

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -64,6 +64,7 @@
 # define WIN32_LEAN_AND_MEAN
 # include <windows.h>
 # include <Psapi.h>
+# include <cstdio>
 #else
 # include <sys/resource.h>
 #endif
@@ -377,5 +378,19 @@ Sysutil::physical_concurrency ()
 #endif
 }
 
+
+
+size_t
+Sysutil::max_open_files ()
+{
+#if defined(_WIN32)
+    return size_t(_getmaxstdio());
+#else
+    struct rlimit rl;
+    if (getrlimit(RLIMIT_NOFILE, &rl) == 0)
+        return rl.rlim_cur;
+#endif
+    return size_t(-1); // Couldn't figure out, so return effectively infinity
+}
 
 OIIO_NAMESPACE_END


### PR DESCRIPTION
There is trouble if the user tries to set ImageCache's "max_open_files" below the limit of open file handles. Clamp it somewhat below that number.

