### PR TITLE
CMake: fixed how to find ocio header with OCIO_INCLUDE_PATH

### DIFF
--- a/src/cmake/modules/FindOpenColorIO.cmake
+++ b/src/cmake/modules/FindOpenColorIO.cmake
@@ -24,13 +24,16 @@ include (FindPackageMessage)
             message(STATUS "OCIO LIBRARY_PATH explicitly specified: ${OCIO_LIBRARY_PATH}")
         endif()
     endif ()
-    FIND_PATH( OCIO_INCLUDES OpenColorIO/OpenColorIO.h
+    FIND_PATH(OCIO_INCLUDES
+        OpenColorIO.h
+        PATHS
         ${OCIO_INCLUDE_PATH}
         ${OCIO_PATH}/include/
         /usr/include
         /usr/local/include
         /sw/include
         /opt/local/include
+        PATH_SUFFIXES OpenColorIO
         DOC "The directory where OpenColorIO/OpenColorIO.h resides")
     FIND_LIBRARY(OCIO_LIBRARIES
         NAMES OCIO OpenColorIO


### PR DESCRIPTION
## Description
Hello there! This change fixes an issue when we try to find the ocio header with __OCIO_INCLUDE_PATH__ defined (and not __OCIO_PATH__).

Example (with boost, python-2.7 and cmake installed on your system):
```bash
export OCIO_INCLUDE_PATH=/path/to/ocio/include
export OCIO_LIBRARY_PATH=/path/to/ocio/lib
cmake . -DVERBOSE=1
# should see:
# -- Found OCIO library...
# -- Found OCIO includes...
```
## Tests
Tested with CMake 3.4.3.