### PR TITLE
Fix roundf: identifier not found

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -46,6 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <OpenImageIO/dassert.h>
+#include <OpenImageIO/missing_math.h>
 #include <OpenImageIO/platform.h>
 #include <OpenEXR/ImathVec.h>
 


### PR DESCRIPTION
## Description

Got this error while compiling with "Visual Studio 11 2012 Win64":
```
~\src\include\OpenImageIO/simd.h(2318): error C3861: 'roundf': identifier not found [~\build\src\libutil\simd_test.vcxproj]
```

This fixes the build for me but I'm not sure if this is the correct way to fix it.

------

Fixes `~\src\include\OpenImageIO/simd.h(2318): error C3861: 'roundf': identifier not found [~\build\src\libutil\simd_test.vcxproj]`