### PR TITLE
Fix Filesystem::searchpath_find on Windows

### DIFF
--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -524,8 +524,8 @@ Strutil::utf8_to_utf16 (string_view str)
 {
     std::wstring native;
     
-    native.resize(MultiByteToWideChar (CP_UTF8, 0, str.c_str(), -1, NULL, 0));
-    MultiByteToWideChar (CP_UTF8, 0, str.c_str(), -1, &native[0], (int)native.size());
+    native.resize(MultiByteToWideChar (CP_UTF8, 0, str.data(), str.length(), NULL, 0));
+    MultiByteToWideChar (CP_UTF8, 0, str.data(), str.length(), &native[0], (int)native.size());
 
     return native;
 }
@@ -537,8 +537,8 @@ Strutil::utf16_to_utf8 (const std::wstring& str)
 {
     std::string utf8;
 
-    utf8.resize(WideCharToMultiByte (CP_UTF8, 0, str.c_str(), -1, NULL, 0, NULL, NULL));
-    WideCharToMultiByte (CP_UTF8, 0, str.c_str(), -1, &utf8[0], (int)utf8.size(), NULL, NULL);
+    utf8.resize(WideCharToMultiByte (CP_UTF8, 0, str.data(), str.length(), NULL, 0, NULL, NULL));
+    WideCharToMultiByte (CP_UTF8, 0, str.data(), str.length(), &utf8[0], (int)utf8.size(), NULL, NULL);
 
     return utf8;
 }


### PR DESCRIPTION
Both `Strutil::utf8_to_utf16` and `Strutil::utf16_to_utf8` had a bug in which the converted string would include the trailing `'\0'`, e.g., `"foo"` (len 3) would become `L"foo\0"` (len 4). This caused an infinite recursion on `Filesystem::searchpath_find` during recursive searches.

Also reduce the implicit conversions in `Filesystem::searchpath_find` happening when calling the helper oiio functions. Instead, keep explicit `boost::filesystem::path` objects for as long as possible and call the `boost::filesystem` methods directly.