### PR TITLE
deal with vs 2015 being pedantic about alignment issues.

### DIFF
--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -245,7 +245,7 @@ inline float sRGB_to_linear (float x)
                            : powf ((x + 0.055f) * (1.0f / 1.055f), 2.4f);
 }
 
-inline simd::float4 sRGB_to_linear (simd::float4 x)
+inline simd::float4 sRGB_to_linear (const simd::float4& x)
 {
     return simd::select (x <= 0.04045f, x * (1.0f/12.92f),
                          fast_pow_pos (madd (x, (1.0f / 1.055f), 0.055f*(1.0f/1.055f)), 2.4f));
@@ -260,7 +260,7 @@ inline float linear_to_sRGB (float x)
 
 
 /// Utility -- convert linear value to sRGB
-inline simd::float4 linear_to_sRGB (simd::float4 x)
+inline simd::float4 linear_to_sRGB (const simd::float4& x)
 {
     // x = simd::max (x, simd::float4::Zero());
     return simd::select (x <= 0.0031308f, 12.92f * x,

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -216,7 +216,7 @@ OIIO_FORCEINLINE uint64_t rotl64 (uint64_t x, int k) {
 /// clamp a to bounds [low,high].
 template <class T>
 inline T
-clamp (T a, T low, T high)
+clamp (const T& a, const T& low, const T& high)
 {
     return (a < low) ? low : ((a > high) ? high : a);
 }
@@ -225,7 +225,7 @@ clamp (T a, T low, T high)
 // Specialization of clamp for float4
 template<>
 inline simd::float4
-clamp (simd::float4 a, simd::float4 low, simd::float4 high)
+clamp (const simd::float4& a, const simd::float4& low, const simd::float4& high)
 {
     return simd::min (high, simd::max (low, a));
 }
@@ -277,7 +277,7 @@ inline float msub (const float& a, const float& b, const float& c) {
 
 template <>
 inline simd::float4 msub (const simd::float4& a, const simd::float4& b,
-                           const simd::float4& c) {
+                          const simd::float4& c) {
     // Implement float4 msub in terms of the one defined in simd.h.
     return simd::msub (a, b, c);
 }

--- a/src/include/OpenImageIO/tinyformat.h
+++ b/src/include/OpenImageIO/tinyformat.h
@@ -192,7 +192,7 @@ template<int n> struct is_wchar<wchar_t[n]> {};
 
 // Format the value by casting to type fmtT.  This default implementation
 // should never be called.
-template<typename T, typename fmtT, bool convertible = is_convertible<T, fmtT>::value>
+template<typename T, typename fmtT, bool convertible = is_convertible<const T&, fmtT>::value>
 struct formatValueAsType
 {
     static void invoke(std::ostream& /*out*/, const T& /*value*/) { assert(0); }
@@ -229,7 +229,7 @@ struct formatZeroIntegerWorkaround<T,true>
 
 // Convert an arbitrary type to integer.  The version with convertible=false
 // throws an error.
-template<typename T, bool convertible = is_convertible<T,int>::value>
+template<typename T, bool convertible = is_convertible<const T&, int>::value>
 struct convertToInt
 {
     static int invoke(const T& /*value*/)
@@ -241,7 +241,7 @@ struct convertToInt
 };
 // Specialization for convertToInt when conversion is possible
 template<typename T>
-struct convertToInt<T,true>
+struct convertToInt<const T&,true>
 {
     static int invoke(const T& value) { return static_cast<int>(value); }
 };
@@ -278,8 +278,8 @@ inline void formatValue(std::ostream& out, const char* /*fmtBegin*/,
     // void* respectively and format that instead of the value itself.  For the
     // %p conversion it's important to avoid dereferencing the pointer, which
     // could otherwise lead to a crash when printing a dangling (const char*).
-    const bool canConvertToChar = detail::is_convertible<T,char>::value;
-    const bool canConvertToVoidPtr = detail::is_convertible<T, const void*>::value;
+    const bool canConvertToChar = detail::is_convertible<const T&,char>::value;
+    const bool canConvertToVoidPtr = detail::is_convertible<const T&, const void*>::value;
     if(canConvertToChar && *(fmtEnd-1) == 'c')
         detail::formatValueAsType<T, char>::invoke(out, value);
     else if(canConvertToVoidPtr && *(fmtEnd-1) == 'p')


### PR DESCRIPTION
It still breaks compiling  tryConvert(...) as it wasnt to call tryConvert(T) rathern than tryConvert(const T&)
```
s:\storage\git\oiio.git\src\include\openimageio\tinyformat.h(178): error C2718: 'const OpenImageIO::v1_7::simd::int4': actual parameter with requested alignment of 16 won't be aligned
s:\storage\git\oiio.git\src\include\openimageio\tinyformat.h(600): note: see reference to class template instantiation 'tinyformat::detail::is_convertible<const T &,int>' being compiled
        with
        [
            T=OpenImageIO::v1_7::simd::int4
        ]
s:\storage\git\oiio.git\src\include\openimageio\tinyformat.h(883): note: see reference to function template instantiation 'void tinyformat::detail::FormatIterator::accept<T1>(const T &)' being compiled
        with
        [
            T1=OpenImageIO::v1_7::simd::int4,
            T=OpenImageIO::v1_7::simd::int4
        ]
s:\storage\git\oiio.git\src\include\openimageio\tinyformat.h(944): note: see reference to function template instantiation 'void tinyformat::detail::format<T1,T2>(tinyformat::detail::FormatIterator &,const T1 &,const T2 &)' being compiled
        with
        [
            T1=OpenImageIO::v1_7::simd::int4,
            T2=OpenImageIO::v1_7::simd::int4
        ]
S:\storage\git\oiio.git\src\include\OpenImageIO/strutil.h(91): note: see reference to function template instantiation 'void tinyformat::format<T1,T2>(std::ostream &,const char *,const T1 &,const T2 &)' being compiled
        with
        [
            T1=OpenImageIO::v1_7::simd::int4,
            T2=OpenImageIO::v1_7::simd::int4
        ]
S:\storage\git\oiio.git\src\libutil\simd_test.cpp(420): note: see reference to function template instantiation 'std::string OpenImageIO::v1_7::Strutil::format<OpenImageIO::v1_7::simd::int4,OpenImageIO::v1_7::simd::int4>(const char *,const T1 &,const T2 &)' being compiled
        with
        [
            T1=OpenImageIO::v1_7::simd::int4,
            T2=OpenImageIO::v1_7::simd::int4
        ]
```