### PR TITLE
Fix unhelpful ASSERT(0) calls.

### DIFF
--- a/src/field3d.imageio/field3doutput.cpp
+++ b/src/field3d.imageio/field3doutput.cpp
@@ -364,7 +364,7 @@ Field3DOutput::write_scanline (int y, int z, TypeDesc format,
         else
             return write_scanline_specialized(y, z, (const FIELD3D_VEC3_T<FIELD3D_NS::half> *)data);
     } else {
-        ASSERT (0);
+        ASSERT (0 && "Unsupported data format for field3d");
     }
 
     return false;
@@ -435,7 +435,7 @@ Field3DOutput::write_tile (int x, int y, int z,
         else
             return write_tile_specialized (x, y, z, (const FIELD3D_VEC3_T<FIELD3D_NS::half> *)data);
     } else {
-        ASSERT (0);
+        ASSERT (0 && "Unsupported data format for field3d");
     }
 
     return false;
@@ -543,7 +543,7 @@ Field3DOutput::prep_subimage ()
         else
             prep_subimage_specialized<FIELD3D_VEC3_T<FIELD3D_NS::half> >();
     } else {
-        ASSERT (0);
+        ASSERT (0 && "Unsupported data format for field3d");
     }
 
     m_writepending = true;

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -570,7 +570,8 @@ DeepData::deep_value (int pixel, int channel, int sample) const
     case TypeDesc::INT64 :
         return ConstDataArrayProxy<long long,float>((const long long *)ptr)[0];
     default:
-        ASSERT (0);
+        ASSERT_MSG (0, "Unknown/unsupported data type %d",
+                    channeltype(channel).basetype);
         return 0.0f;
     }
 }
@@ -605,7 +606,8 @@ DeepData::deep_value_uint (int pixel, int channel, int sample) const
     case TypeDesc::INT64 :
         return ConstDataArrayProxy<long long,uint32_t>((const long long *)ptr)[0];
     default:
-        ASSERT (0);
+        ASSERT_MSG (0, "Unknown/unsupported data type %d",
+                    channeltype(channel).basetype);
         return 0;
     }
 }
@@ -640,7 +642,8 @@ DeepData::set_deep_value (int pixel, int channel, int sample, float value)
     case TypeDesc::INT64 :
         DataArrayProxy<int64_t,float>((int64_t *)ptr)[0] = value; break;
     default:
-        ASSERT (0);
+        ASSERT_MSG (0, "Unknown/unsupported data type %d",
+                    channeltype(channel).basetype);
     }
 }
 
@@ -674,7 +677,8 @@ DeepData::set_deep_value (int pixel, int channel, int sample, uint32_t value)
     case TypeDesc::INT64 :
         DataArrayProxy<int64_t,uint32_t>((int64_t *)ptr)[0] = value; break;
     default:
-        ASSERT (0);
+        ASSERT_MSG (0, "Unknown/unsupported data type %d",
+                    channeltype(channel).basetype);
     }
 }
 
@@ -754,7 +758,7 @@ DeepData::copy_deep_pixel (int pixel, const DeepData &src, int srcpixel)
 {
     if (pixel < 0 || pixel >= pixels()) {
         // std::cout << "dst pixel was " << pixel << "\n";
-        ASSERT(0);
+        DASSERT (0 && "Out of range pixel index");
         return false;
     }
     if (srcpixel < 0 || srcpixel >= src.pixels()) {
@@ -765,7 +769,7 @@ DeepData::copy_deep_pixel (int pixel, const DeepData &src, int srcpixel)
     }
     int nchans = channels();
     if (nchans != src.channels()) {
-        ASSERT(0);
+        DASSERT (0 && "Number of channels don't match.");
         return false;
     }
     int nsamples = src.samples(srcpixel);

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -110,7 +110,7 @@ pvt::get_default_quantize (TypeDesc format,
     case TypeDesc::DOUBLE:
         get_default_quantize_ <double> (quant_min, quant_max);
         break;
-    default: ASSERT(0);
+    default: ASSERT_MSG (0, "Unknown data format %d", format.basetype);
     }
 }
 

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1652,7 +1652,7 @@ ImageBuf::setpixel (int x, int y, int z, const float *pixel, int maxchannels)
     case TypeDesc::UINT64: setpixel_<unsigned long long> (*this, x, y, z, pixel, n); break;
     case TypeDesc::INT64 : setpixel_<long long> (*this, x, y, z, pixel, n); break;
     default:
-        ASSERT (0);
+        ASSERTMSG (0, "Unknown/unsupported data type %d", spec().format.basetype);
     }
 }
 

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -255,7 +255,7 @@ Sysutil::this_program_path ()
     int r = 0;
 #else
     // No idea what platform this is
-    ASSERT (0);
+    OIIO_STATIC_ASSERT_MSG (0, "this_program_path() unimplemented on this platform");
 #endif
 
     if (r > 0)

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -735,7 +735,7 @@ TypeDesc_from_ImfPixelType (Imf::PixelType ptype)
     case Imf::UINT  : return TypeDesc::UINT;  break;
     case Imf::HALF  : return TypeDesc::HALF;  break;
     case Imf::FLOAT : return TypeDesc::FLOAT; break;
-    default: ASSERT (0);
+    default: ASSERT_MSG (0, "Unknown Imf::PixelType %d", int(ptype));
     }
 }
 
@@ -886,7 +886,6 @@ OpenEXRInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
             m_tiled_input_part = NULL;
             m_deep_scanline_input_part = NULL;
             m_deep_tiled_input_part = NULL;
-            ASSERT(0);
             return false;
         } catch (...) {   // catch-all for edge cases or compiler bugs
             error ("OpenEXR exception: unknown");
@@ -894,7 +893,6 @@ OpenEXRInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
             m_tiled_input_part = NULL;
             m_deep_scanline_input_part = NULL;
             m_deep_tiled_input_part = NULL;
-            ASSERT(0);
             return false;
         }
     }
@@ -930,7 +928,7 @@ OpenEXRInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
     } else if (part.levelmode == Imf::RIPMAP_LEVELS) {
         // FIXME
     } else {
-        ASSERT(0);
+        ASSERT_MSG (0, "Unknown levelmode %d", int(part.levelmode));
     }
 
     m_spec.width = w;
@@ -1040,7 +1038,8 @@ OpenEXRInput::read_native_scanlines (int ybegin, int yend, int z,
             m_scanline_input_part->readPixels (ybegin, yend-1);
 #endif
         } else {
-            ASSERT (0);
+            error ("Attempted to read scanline from a non-scanline file.");
+            return false;
         }
     } catch (const std::exception &e) {
         error ("Failed OpenEXR read: %s", e.what());
@@ -1146,7 +1145,8 @@ OpenEXRInput::read_native_tiles (int xbegin, int xend, int ybegin, int yend,
                                            m_miplevel, m_miplevel);
 #endif
         } else {
-            ASSERT (0);
+            error ("Attempted to read tiles from a non-tiled file");
+            return false;
         }
         if (data != origdata) {
             stride_t user_scanline_bytes = (xend-xbegin) * pixelbytes;

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -417,7 +417,8 @@ OpenEXROutput::open (const std::string &name, const ImageSpec &userspec,
                 delete m_deep_scanline_output_part;
                 m_deep_scanline_output_part = new Imf::DeepScanLineOutputPart (*m_output_multipart, m_subimage);
             } else {
-                ASSERT (0);
+                error ("Called open with AppendSubimage mode, but no appropriate part is found. Application bug?");
+                return false;
             }
         } catch (const std::exception &e) {
             error ("OpenEXR exception: %s", e.what());
@@ -472,7 +473,7 @@ OpenEXROutput::open (const std::string &name, const ImageSpec &userspec,
         }
     }
 
-    ASSERTMSG (0, "Unknown open mode %d", int(mode));
+    error ("Unknown open mode %d", int(mode));
     return false;
 }
 
@@ -1321,7 +1322,8 @@ OpenEXROutput::write_scanline (int y, int z, TypeDesc format,
             m_scanline_output_part->writePixels (1);
 #endif
         } else {
-            ASSERT (0);
+            error ("Attempt to write scanline to a non-scanline file.");
+            return false;
         }
     } catch (const std::exception &e) {
         error ("Failed OpenEXR write: %s", e.what());
@@ -1398,7 +1400,8 @@ OpenEXROutput::write_scanlines (int ybegin, int yend, int z,
                 m_scanline_output_part->writePixels (nscanlines);
 #endif
             } else {
-                ASSERT (0);
+                error ("Attempt to write scanlines to a non-scanline file.");
+                return false;
             }
         } catch (const std::exception &e) {
             error ("Failed OpenEXR write: %s", e.what());
@@ -1528,7 +1531,8 @@ OpenEXROutput::write_tiles (int xbegin, int xend, int ybegin, int yend,
                                              m_miplevel, m_miplevel);
 #endif
         } else {
-            ASSERT (0);
+            error ("Attempt to write tiles for a non-tiled file.");
+            return false;
         }
     } catch (const std::exception &e) {
         error ("Failed OpenEXR write: %s", e.what());


### PR DESCRIPTION
Some should be errors, not assertions.

Others should at least have messages to make them more apparent why
they are asserting.

A few should occur only when compiled in DEBUG mode.

Reminder: assertions are not intended to handle error conditions (and
especially NEVER supposed to be hit because of "bad input"). They are
meant to catch "impossible situations" that indicate an error in program
logic from which no meaningful recovery can be made at runtime.