### PR TITLE
Refactor simd.h to separate declarations from implementations.

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -47,16 +47,21 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #pragma once
+#ifndef OIIO_SIMD_H
+#define OIIO_SIMD_H 1
 
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/missing_math.h>
 #include <OpenImageIO/platform.h>
 #include <OpenEXR/ImathVec.h>
 #include <OpenEXR/ImathMatrix.h>
-
-#if defined(_MSC_VER)
 #include <algorithm>
-#endif
+
+
+//////////////////////////////////////////////////////////////////////////
+// Sort out which SIMD capabilities we have and set definitions
+// appropriately.
+//
 
 #if (defined(__SSE2__) || (_MSC_VER >= 1300 && !_M_CEE_PURE)) && !defined(OIIO_NO_SSE)
 #  include <immintrin.h>
@@ -127,12 +132,25 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #  define OIIO_SIMD_MAX_SIZE_BYTES 16
 #endif
 
-#include <algorithm>
 
 
 OIIO_NAMESPACE_BEGIN
 
 namespace simd {
+
+//////////////////////////////////////////////////////////////////////////
+// Forward declarations of our main SIMD classes
+
+class int4;
+class float4;
+class mask4;
+class float3;
+class matrix44;
+
+
+//////////////////////////////////////////////////////////////////////////
+// Template magic to determine the raw SIMD types involved, and other
+// things helpful for metaprogramming.
 
 template <typename T, int N> struct simd_raw_t { struct type { T val[N]; }; };
 template <int N> struct simd_bool_t { struct type { int val[N]; }; };
@@ -161,11 +179,32 @@ template<> struct simd_raw_t<float,4> { typedef float32x4_t type; };
 template<> struct simd_bool_t<4> { typedef int32x4 type; };
 #endif
 
-class int4;
-class float4;
-class mask4;
-class float3;
 
+/// Template to retrieve the vector type from the scalar. For example,
+/// simd::VecType<int,4> will be float4.
+template<typename T,int elements> struct VecType {};
+template<> struct VecType<int,4>   { typedef int4 type; };
+template<> struct VecType<float,4> { typedef float4 type; };
+template<> struct VecType<float,3> { typedef float3 type; };
+template<> struct VecType<bool,4>  { typedef mask4 type; };
+
+/// Template to retrieve the SIMD size of a SIMD type. Rigged to be 1 for
+/// anything but our SIMD types.
+template<typename T> struct SimdSize { static const int size = 1; };
+template<> struct SimdSize<int4>     { static const int size = 4; };
+template<> struct SimdSize<float4>   { static const int size = 4; };
+template<> struct SimdSize<float3>   { static const int size = 4; };
+template<> struct SimdSize<mask4>    { static const int size = 4; };
+
+/// Template to retrieve the number of elements size of a SIMD type. Rigged
+/// to be 1 for anything but our SIMD types.
+template<typename T> struct SimdElements { static const int size = SimdSize<T>::size; };
+template<> struct SimdElements<float3>   { static const int size = 3; };
+
+
+
+//////////////////////////////////////////////////////////////////////////
+// Macros helpful for making static constants in code.
 
 # define OIIO_SIMD_FLOAT4_CONST(name,val) \
     static const OIIO_SIMD4_ALIGN float name[4] = { (val), (val), (val), (val) }
@@ -180,6 +219,12 @@ class float3;
 # define OIIO_SIMD_UINT4_CONST4(name,v0,v1,v2,v3) \
     static const OIIO_SIMD4_ALIGN uint32_t name[4] = { (v0), (v1), (v2), (v3) }
 
+
+
+//////////////////////////////////////////////////////////////////////////
+// Some macros just for use in this file (#undef-ed at the end) making
+// it more succinct to express per-element operations.
+
 #define SIMD_DO(x) for (int i = 0; i < elements; ++i) x
 #define SIMD_CONSTRUCT(x) for (int i = 0; i < elements; ++i) m_val[i] = (x)
 #define SIMD_CONSTRUCT_PAD(x) for (int i = 0; i < elements; ++i) m_val[i] = (x); \
@@ -187,70 +232,23 @@ class float3;
 #define SIMD_RETURN(T,x) T r; for (int i = 0; i < r.elements; ++i) r[i] = (x); return r
 
 
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+// The public declarations of the main SIMD classes follow: maskN, intN,
+// floatN, matrix44.
 //
-// Additional private intrinsic wrappers
+// These class declarations are intended to be brief and self-documenting,
+// and give all the information that users or client applications need to
+// know to use these classes.
 //
-#if defined(OIIO_SIMD_SSE)
-
-// Shamelessly lifted from Syrah which lifted from Manta which lifted it
-// from intel.com
-OIIO_FORCEINLINE __m128i mm_mul_epi32 (__m128i a, __m128i b) {
-#if OIIO_SIMD_SSE >= 4  /* SSE >= 4.1 */
-    return _mm_mullo_epi32(a, b);
-#else
-    // Prior to SSE 4.1, there is no _mm_mullo_epi32 instruction, so we have
-    // to fake it.
-    __m128i t0;
-    __m128i t1;
-    t0 = _mm_mul_epu32 (a, b);
-    t1 = _mm_mul_epu32 (_mm_shuffle_epi32 (a, 0xB1),
-                        _mm_shuffle_epi32 (b, 0xB1));
-    t0 = _mm_shuffle_epi32 (t0, 0xD8);
-    t1 = _mm_shuffle_epi32 (t1, 0xD8);
-    return _mm_unpacklo_epi32 (t0, t1);
-#endif
-}
-
-
-// Shuffling. Use like this:  x = shuffle<3,2,1,0>(b)
-template<int i0, int i1, int i2, int i3>
-OIIO_FORCEINLINE __m128i shuffle_sse (__m128i v) {
-    return _mm_shuffle_epi32(v, _MM_SHUFFLE(i3, i2, i1, i0));
-}
-
-#if OIIO_SIMD_SSE >= 3
-// SSE3 has intrinsics for a few special cases
-template<> OIIO_FORCEINLINE __m128i shuffle_sse<0, 0, 2, 2> (__m128i a) {
-    return _mm_castps_si128(_mm_moveldup_ps(_mm_castsi128_ps(a)));
-}
-template<> OIIO_FORCEINLINE __m128i shuffle_sse<1, 1, 3, 3> (__m128i a) {
-    return _mm_castps_si128(_mm_movehdup_ps(_mm_castsi128_ps(a)));
-}
-template<> OIIO_FORCEINLINE __m128i shuffle_sse<0, 1, 0, 1> (__m128i a) {
-    return _mm_castpd_si128(_mm_movedup_pd(_mm_castsi128_pd(a)));
-}
-#endif
-
-template<int i0, int i1, int i2, int i3>
-OIIO_FORCEINLINE __m128 shuffle_sse (__m128 a) {
-    return _mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(a), _MM_SHUFFLE(i3, i2, i1, i0)));
-}
-
-#if OIIO_SIMD_SSE >= 3
-// SSE3 has intrinsics for a few special cases
-template<> OIIO_FORCEINLINE __m128 shuffle_sse<0, 0, 2, 2> (__m128 a) {
-    return _mm_moveldup_ps(a);
-}
-template<> OIIO_FORCEINLINE __m128 shuffle_sse<1, 1, 3, 3> (__m128 a) {
-    return _mm_movehdup_ps(a);
-}
-template<> OIIO_FORCEINLINE __m128 shuffle_sse<0, 1, 0, 1> (__m128 a) {
-    return _mm_castpd_ps(_mm_movedup_pd(_mm_castps_pd(a)));
-}
-#endif
-
-#endif
-
+// No implementations are given inline except for the briefest, completely
+// generic methods that don't have any architecture-specific overloads.
+// After the class defintions, there will be an immense pile of full
+// implementation definitions, which casual users are not expected to
+// understand.
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
 
 
 /// mask4: A mask 4-vector, whose elements act mostly like bools,
@@ -267,226 +265,82 @@ public:
     typedef simd_bool_t<4>::type simd_t;  ///< the native SIMD type used
 
     /// Default constructor (contents undefined)
-    OIIO_FORCEINLINE mask4 () { }
+    mask4 () { }
 
     /// Destructor
-    OIIO_FORCEINLINE ~mask4 () { }
+    ~mask4 () { }
 
     /// Construct from a single value (store it in all slots)
-    OIIO_FORCEINLINE mask4 (bool a) { load(a); }
+    mask4 (bool a) { load(a); }
 
     /// Construct from 4 values
-    OIIO_FORCEINLINE mask4 (bool a, bool b, bool c, bool d) { load(a,b,c,d); }
+    mask4 (bool a, bool b, bool c, bool d) { load(a,b,c,d); }
 
     /// Copy construct from another mask4
-    OIIO_FORCEINLINE mask4 (const mask4 &other) { m_vec = other.m_vec; }
+    mask4 (const mask4 &other) { m_vec = other.m_vec; }
 
     /// Construct from an int4 (is each element nonzero?)
-    OIIO_FORCEINLINE mask4 (const int4 &i);
+    mask4 (const int4 &i);
 
     /// Construct from the underlying SIMD type
-    OIIO_FORCEINLINE mask4 (const simd_t& m) : m_vec(m) { }
+    mask4 (const simd_t& m) : m_vec(m) { }
 
     /// Return the raw SIMD type
-    OIIO_FORCEINLINE operator simd_t () const { return m_vec; }
-    OIIO_FORCEINLINE simd_t simd () const { return m_vec; }
+    operator simd_t () const { return m_vec; }
+    simd_t simd () const { return m_vec; }
 
     /// Set all components to false
-    OIIO_FORCEINLINE void clear () {
-#if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_setzero_ps();
-#else
-        *this = false;
-#endif
-    }
+    void clear ();
 
     /// Return a mask4 the is 'false' for all values
-    static OIIO_FORCEINLINE const mask4 False () {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_setzero_ps();
-#else
-        return mask4(false);
-#endif
-    }
+    static const mask4 False ();
 
     /// Return a mask4 the is 'true' for all values
-    static OIIO_FORCEINLINE const mask4 True () {
-#if defined(OIIO_SIMD_SSE)
-        // Fastest way to fill an __m128 with all 1 bits is to cmpeq_epi8
-        // any value to itself.
-# if defined(OIIO_SIMD_AVX) && (OIIO_GNUC_VERSION > 50000)
-        __m128i anyval = _mm_undefined_si128();
-# else
-        __m128i anyval = _mm_castps_si128 (_mm_setzero_ps());
-# endif
-        return _mm_castsi128_ps (_mm_cmpeq_epi8 (anyval, anyval));
-#else
-        return mask4(true);
-#endif
-    }
+    static const mask4 True ();
 
     /// Assign one value to all components
-    OIIO_FORCEINLINE const mask4 & operator= (bool a) { load(a); return *this; }
+    const mask4 & operator= (bool a);
 
     /// Assignment of another mask4
-    OIIO_FORCEINLINE const mask4 & operator= (const mask4 & other) {
-#if defined(OIIO_SIMD_SSE)
-        m_vec = other.m_vec;
-#else
-        SIMD_CONSTRUCT (other.m_val[i]);
-#endif
-        return *this;
-    }
+    const mask4 & operator= (const mask4 & other);
 
     /// Component access (get)
-    OIIO_FORCEINLINE bool operator[] (int i) const {
-        DASSERT(i >= 0 && i < 4);
-#if defined(OIIO_SIMD_SSE)
-        return (_mm_movemask_ps(m_vec) >> i) & 1;
-#else
-        return bool(m_val[i]);
-#endif
-    }
+    bool operator[] (int i) const ;
 
     /// Component access (set).
     /// NOTE: use with caution. The implementation sets the integer
     /// value, which may not have the same bit pattern as the bool returned
     /// by operator[]const.
-    OIIO_FORCEINLINE int& operator[] (int i) {
-        DASSERT(i >= 0 && i < 4);
-        return m_val[i];
-    }
+    int& operator[] (int i);
 
     /// Helper: load a single value into all components.
-    OIIO_FORCEINLINE void load (bool a) {
-#if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_castsi128_ps(_mm_set1_epi32(a ? -1 : 0));
-#else
-        int val = a ? -1 : 0;
-        SIMD_CONSTRUCT (val);
-#endif
-    }
+    void load (bool a);
 
     /// Helper: load separate values into each component.
-    OIIO_FORCEINLINE void load (bool a, bool b, bool c, bool d) {
-#if defined(OIIO_SIMD_SSE)
-        // N.B. -- we need to reverse the order because of our convention
-        // of storing a,b,c,d in the same order in memory.
-        m_vec = _mm_castsi128_ps(_mm_set_epi32(d ? -1 : 0,
-                                               c ? -1 : 0,
-                                               b ? -1 : 0,
-                                               a ? -1 : 0));
-#else
-        m_val[0] = a ? -1 : 0;
-        m_val[1] = b ? -1 : 0;
-        m_val[2] = c ? -1 : 0;
-        m_val[3] = d ? -1 : 0;
-#endif
-    }
+    void load (bool a, bool b, bool c, bool d);
 
     /// Helper: store the values into memory as bools.
-    OIIO_FORCEINLINE void store (bool *values) const {
-#if 0 && defined(OIIO_SIMD_SSE)
-        // FIXME: is there a more efficient way to do this?
-#else
-        SIMD_DO (values[i] = m_val[i] ? true : false);
-#endif
-    }
+    void store (bool *values) const;
 
     /// Store the first n values into memory.
-    OIIO_FORCEINLINE void store (bool *values, int n) const {
-        DASSERT (n >= 0 && n <= elements);
-        for (int i = 0; i < n; ++i)
-            values[i] = m_val[i] ? true : false;
-    }
+    void store (bool *values, int n) const;
 
-    /// Logical "not", component-by-component
-    friend OIIO_FORCEINLINE mask4 operator! (const mask4 & a) {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_xor_ps (a.m_vec, True());
-#else
-        SIMD_RETURN (mask4, a.m_val[i] ^ (-1));
-#endif
-    }
+    /// Logical/bitwise operators, component-by-component
+    friend mask4 operator! (const mask4 & a);
+    friend mask4 operator& (const mask4 & a, const mask4 & b);
+    const mask4& operator&= (const mask4 & b);
+    friend mask4 operator| (const mask4 & a, const mask4 & b);
+    const mask4& operator|= (const mask4 & a);
+    friend mask4 operator^ (const mask4& a, const mask4& b);
+    const mask4 & operator^= (const mask4& a);
+    mask4 operator~ ();
 
-    /// Logical "and", component-by-component
-    friend OIIO_FORCEINLINE mask4 operator& (const mask4 & a, const mask4 & b) {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_and_ps (a.m_vec, b.m_vec);
-#else
-        SIMD_RETURN (mask4, a.m_val[i] & b.m_val[i]);
-#endif
-    }
-    OIIO_FORCEINLINE const mask4& operator&= (const mask4 & b) {
-        return *this = *this & b;
-    }
-
-
-    /// Logical "or" component-by-component
-    friend OIIO_FORCEINLINE mask4 operator| (const mask4 & a, const mask4 & b) {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_or_ps (a.m_vec, b.m_vec);
-#else
-        SIMD_RETURN (mask4, a.m_val[i] | b.m_val[i]);
-#endif
-    }
-    OIIO_FORCEINLINE const mask4& operator|= (const mask4 & a) {
-        return *this = *this | a;
-    }
-
-    friend OIIO_FORCEINLINE mask4 operator^ (const mask4& a, const mask4& b) {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_xor_ps (a.m_vec, b.m_vec);
-#else
-        SIMD_RETURN (mask4, a.m_val[i] ^ b.m_val[i]);
-#endif
-    }
-    OIIO_FORCEINLINE const mask4 & operator^= (const mask4& a) {
-        return *this = *this ^ a;
-    }
-
-    OIIO_FORCEINLINE mask4 operator~ () {
-#if defined(OIIO_SIMD_SSE)
-        // Fastest way to bit-complement in SSE is to xor with 0xffffffff.
-        // Fastest way to fill an __m128 with all 1 bits is to cmpeq_epi8
-        // any value to itself.
-# if defined(OIIO_SIMD_AVX) && (OIIO_GNUC_VERSION > 50000)
-        __m128i anyval = _mm_undefined_si128(); // AVX only, sigh
-# else
-        __m128i anyval = _mm_castps_si128 (m_vec);
-# endif
-        __m128 all_one_bits = _mm_castsi128_ps (_mm_cmpeq_epi8 (anyval, anyval));
-        return _mm_xor_ps (m_vec, all_one_bits);
-#else
-        SIMD_RETURN (mask4, ~m_val[i]);
-#endif
-    }
-
-    /// Equality comparison, component by component
-    friend OIIO_FORCEINLINE const mask4 operator== (const mask4 & a, const mask4 & b) {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_castsi128_ps (_mm_cmpeq_epi32 (_mm_castps_si128 (a.m_vec), _mm_castps_si128(b.m_vec)));
-#else
-        SIMD_RETURN (mask4, a.m_val[i] == b.m_val[i] ? -1 : 0);
-#endif
-    }
-
-    /// Inequality comparison, component by component
-    friend OIIO_FORCEINLINE const mask4 operator!= (const mask4 & a, const mask4 & b) {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_xor_ps (a.m_vec, b.m_vec);
-#else
-        SIMD_RETURN (mask4, a.m_val[i] != b.m_val[i] ? -1 : 0);
-#endif
-    }
+    /// Comparison operators, component by component
+    friend const mask4 operator== (const mask4 & a, const mask4 & b);
+    friend const mask4 operator!= (const mask4 & a, const mask4 & b);
 
     /// Stream output
-    friend inline std::ostream& operator<< (std::ostream& cout, const mask4 & a) {
-        cout << a[0];
-        for (int i = 1; i < elements; ++i)
-            cout << ' ' << a[i];
-        return cout;
-    }
+    friend inline std::ostream& operator<< (std::ostream& cout, const mask4 & a);
 
 private:
     // The actual data representation
@@ -497,6 +351,1102 @@ private:
 };
 
 
+
+/// Helper: shuffle/swizzle with constant (templated) indices.
+/// Example: shuffle<1,1,2,2>(mask4(a,b,c,d)) returns (b,b,c,c)
+template<int i0, int i1, int i2, int i3> mask4 shuffle (const mask4& a);
+
+/// shuffle<i>(a) is the same as shuffle<i,i,i,i>(a)
+template<int i> mask4 shuffle (const mask4& a);
+
+/// Helper: as rapid as possible extraction of one component, when the
+/// index is fixed.
+template<int i> bool extract (const mask4& a);
+
+/// Helper: substitute val for a[i]
+template<int i> mask4 insert (const mask4& a, bool val);
+
+/// Logical "and" reduction, i.e., 'and' all components together, resulting
+/// in a single bool.
+bool reduce_and (const mask4& v);
+
+/// Logical "or" reduction, i.e., 'or' all components together, resulting
+/// in a single bool.
+bool reduce_or (const mask4& v);
+
+/// Are all components true?
+OIIO_FORCEINLINE bool all  (const mask4& v) { return reduce_and(v) == true; }
+
+/// Are any components true?
+OIIO_FORCEINLINE bool any  (const mask4& v) { return reduce_or(v) == true; }
+
+/// Are all components false:
+OIIO_FORCEINLINE bool none (const mask4& v) { return reduce_or(v) == false; }
+
+
+
+
+
+/// Integer 4-vector, accelerated by SIMD instructions when available.
+class int4 {
+public:
+    static const char* type_name() { return "int4"; }
+    typedef int value_t;      ///< Underlying equivalent scalar value type
+    enum { elements = 4 };    ///< Number of scalar elements
+    enum { paddedelements = 4 }; ///< Number of scalar elements for full pad
+    enum { bits = 128 };      ///< Total number of bits
+    typedef simd_raw_t<int,4>::type simd_t;  ///< the native SIMD type used
+
+    /// Default constructor (contents undefined)
+    int4 () { }
+
+    /// Destructor
+    ~int4 () { }
+
+    /// Construct from a single value (store it in all slots)
+    int4 (int a) { load(a); }
+
+    /// Construct from 2 values -- (a,a,b,b)
+    int4 (int a, int b) { load(a,a,b,b); }
+
+    /// Construct from 4 values
+    int4 (int a, int b, int c, int d) { load(a,b,c,d); }
+
+    /// Construct from a pointer to 4 values
+    int4 (const int *vals) { load (vals); }
+
+    /// Construct from a pointer to 4 unsigned short values
+    explicit int4 (const unsigned short *vals) { load(vals); }
+
+    /// Construct from a pointer to 4 signed short values
+    explicit int4 (const short *vals) { load(vals); }
+
+    /// Construct from a pointer to 4 unsigned char values (0 - 255)
+    explicit int4 (const unsigned char *vals) { load(vals); }
+
+    /// Construct from a pointer to 4 signed char values (-128 - 127)
+    explicit int4 (const char *vals) { load(vals); }
+
+    /// Copy construct from another int4
+    int4 (const int4 & other) { m_vec = other.m_vec; }
+
+    /// Convert a float4 to an int4. Equivalent to i = (int)f;
+    explicit int4 (const float4& f); // implementation below
+
+    /// Construct from the underlying SIMD type
+    int4 (const simd_t& m) : m_vec(m) { }
+
+    /// Return the raw SIMD type
+    operator simd_t () const { return m_vec; }
+    simd_t simd () const { return m_vec; }
+
+    /// Sset all components to 0
+    void clear () ;
+
+    /// Return an int4 with all components set to 0
+    static const int4 Zero ();
+
+    /// Return an int4 with all components set to 1
+    static const int4 One ();
+
+    /// Return an int4 with all components set to -1 (aka 0xffffffff)
+    static const int4 NegOne ();
+
+    /// Return an int4 with incremented components (e.g., 0,1,2,3).
+    /// Optional argument can give a non-zero starting point.
+    static const int4 Iota (int value=0);
+
+    /// Assign one value to all components.
+    const int4 & operator= (int a);
+
+    /// Assignment from another int4
+    const int4 & operator= (int4 other) ;
+
+    /// Component access (set)
+    int& operator[] (int i) ;
+
+    /// Component access (get)
+    int operator[] (int i) const;
+
+    value_t x () const;
+    value_t y () const;
+    value_t z () const;
+    value_t w () const;
+    void set_x (value_t val);
+    void set_y (value_t val);
+    void set_z (value_t val);
+    void set_w (value_t val);
+
+    /// Helper: load a single int into all components
+    void load (int a);
+
+    /// Helper: load separate values into each component.
+    void load (int a, int b, int c, int d);
+
+    /// Load from an array of 4 values
+    void load (const int *values);
+
+    void load (const int *values, int n) ;
+
+    /// Load from an array of 4 unsigned short values, convert to int4
+    void load (const unsigned short *values) ;
+
+    /// Load from an array of 4 unsigned short values, convert to int4
+    void load (const short *values);
+
+    /// Load from an array of 4 unsigned char values, convert to int4
+    void load (const unsigned char *values);
+
+    /// Load from an array of 4 unsigned char values, convert to int4
+    void load (const char *values);
+
+    /// Store the values into memory
+    void store (int *values) const;
+
+    /// Store the first n values into memory
+    void store (int *values, int n) const;
+
+    /// Store the least significant 16 bits of each element into adjacent
+    /// unsigned shorts.
+    void store (unsigned short *values) const;
+
+    /// Store the least significant 8 bits of each element into adjacent
+    /// unsigned chars.
+    void store (unsigned char *values) const;
+
+    // Arithmetic operators (component-by-component)
+    friend int4 operator+ (const int4& a, const int4& b);
+    const int4 & operator+= (const int4& a);
+    int4 operator- () const ;
+    friend int4 operator- (const int4& a, const int4& b);
+    const int4 & operator-= (const int4& a) ;
+    friend int4 operator* (const int4& a, const int4& b);
+    const int4 & operator*= (const int4& a);
+    const int4 & operator*= (int val);
+    friend int4 operator/ (const int4& a, const int4& b);
+    const int4 & operator/= (const int4& a);
+    const int4 & operator/= (int val);
+    friend int4 operator% (const int4& a, const int4& b);
+    const int4 & operator%= (const int4& a);
+    friend int4 operator% (const int4& a, int w);
+    const int4 & operator%= (int a);
+    friend int4 operator% (int a, const int4& b);
+
+    // Bitwise operators (component-by-component)
+    friend int4 operator& (const int4& a, const int4& b);
+    const int4 & operator&= (const int4& a);
+    friend int4 operator| (const int4& a, const int4& b);
+    const int4 & operator|= (const int4& a);
+    friend int4 operator^ (const int4& a, const int4& b);
+    const int4 & operator^= (const int4& a);
+    int4 operator~ ();
+    int4 operator<< (const unsigned int bits) const;
+    const int4 & operator<<= (const unsigned int bits);
+    int4 operator>> (const unsigned int bits);
+    const int4 & operator>>= (const unsigned int bits);
+
+    // Shift right logical -- unsigned shift. This differs from operator>>
+    // in how it handles the sign bit.  (1<<31) >> 1 == (1<<31), but
+    // srl((1<<31),1) == 1<<30.
+    friend int4 srl (const int4& val, const unsigned int bits);
+
+    // Comparison operators (component-by-component)
+    friend mask4 operator== (const int4& a, const int4& b);
+    friend mask4 operator!= (const int4& a, const int4& b);
+    friend mask4 operator< (const int4& a, const int4& b);
+    friend mask4 operator>  (const int4& a, const int4& b);
+    friend mask4 operator>= (const int4& a, const int4& b);
+    friend mask4 operator<= (const int4& a, const int4& b);
+
+    /// Stream output
+    friend inline std::ostream& operator<< (std::ostream& cout, const int4& val);
+
+private:
+    // The actual data representation
+    union {
+        simd_t  m_vec;
+        value_t m_val[4];
+    };
+};
+
+
+
+/// Helper: shuffle/swizzle with constant (templated) indices.
+/// Example: shuffle<1,1,2,2>(mask4(a,b,c,d)) returns (b,b,c,c)
+template<int i0, int i1, int i2, int i3> int4 shuffle (const int4& a);
+
+/// shuffle<i>(a) is the same as shuffle<i,i,i,i>(a)
+template<int i> int4 shuffle (const int4& a);
+
+/// Helper: as rapid as possible extraction of one component, when the
+/// index is fixed.
+template<int i> int extract (const int4& v);
+
+/// Helper: substitute val for a[i]
+template<int i> int4 insert (const int4& a, int val);
+
+/// The sum of all components, returned in all components.
+int4 vreduce_add (const int4& v);
+
+/// The sum of all components, returned as a scalar.
+int reduce_add (const int4& v);
+
+/// Bitwise "and" of all components.
+int reduce_and (const int4& v);
+
+/// Bitwise "or" of all components.
+int reduce_or (const int4& v);
+
+/// Use a mask to select between components of a (if mask[i] is false) and
+/// b (if mask[i] is true).
+int4 blend (const int4& a, const int4& b, const mask4& mask);
+
+/// Use a mask to select between components of a (if mask[i] is true) or
+/// 0 (if mask[i] is true).
+int4 blend0 (const int4& a, const mask4& mask);
+
+/// Use a mask to select between components of a (if mask[i] is FALSE) or
+/// 0 (if mask[i] is TRUE).
+int4 blend0not (const int4& a, const mask4& mask);
+
+/// Select 'a' where mask is true, 'b' where mask is false. Sure, it's a
+/// synonym for blend with arguments rearranged, but this is more clear
+/// because the arguments are symmetric to scalar (cond ? a : b).
+int4 select (const mask4& mask, const int4& a, const int4& b);
+
+/// Per-element absolute value.
+int4 abs (const int4& a);
+
+/// Per-element min
+int4 min (const int4& a, const int4& b);
+
+/// Per-element max
+int4 max (const int4& a, const int4& b);
+
+// Circular bit rotate by k bits, for 4 values at once.
+int4 rotl32 (const int4& x, const unsigned int k);
+
+/// andnot(a,b) returns ((~a) & b)
+int4 andnot (const int4& a, const int4& b);
+
+/// Bitcast back and forth int4 (not a convert -- move the bits!)
+int4 bitcast_to_int4 (const mask4& x);
+int4 bitcast_to_int4 (const float4& x);
+float4 bitcast_to_float4 (const int4& x);
+
+void transpose (int4 &a, int4 &b, int4 &c, int4 &d);
+void transpose (const int4& a, const int4& b, const int4& c, const int4& d,
+                int4 &r0, int4 &r1, int4 &r2, int4 &r3);
+
+int4 AxBxCxDx (const int4& a, const int4& b, const int4& c, const int4& d);
+
+
+
+
+/// Floating point 4-vector, accelerated by SIMD instructions when
+/// available.
+class float4 {
+public:
+    static const char* type_name() { return "float4"; }
+    typedef float value_t;    ///< Underlying equivalent scalar value type
+    typedef mask4 mask_t;     ///< SIMD mask type
+    enum { elements = 4 };    ///< Number of scalar elements
+    enum { paddedelements = 4 }; ///< Number of scalar elements for full pad
+    enum { bits = 128 };      ///< Total number of bits
+    typedef simd_raw_t<float,4>::type simd_t;  ///< the native SIMD type used
+
+    /// Default constructor (contents undefined)
+    float4 () { }
+
+    /// Destructor
+    ~float4 () { }
+
+    /// Construct from a single value (store it in all slots)
+    float4 (float a) { load(a); }
+
+    /// Construct from 3 or 4 values
+    float4 (float a, float b, float c, float d=0.0f) { load(a,b,c,d); }
+
+    /// Construct from a pointer to 4 values
+    float4 (const float *f) { load (f); }
+
+    /// Copy construct from another float4
+    float4 (const float4 &other) { m_vec = other.m_vec; }
+
+    /// Construct from an int4 (promoting all components to float)
+    explicit float4 (const int4& ival);
+
+    /// Construct from the underlying SIMD type
+    float4 (const simd_t& m) : m_vec(m) { }
+
+    /// Return the raw SIMD type
+    operator simd_t () const { return m_vec; }
+    simd_t simd () const { return m_vec; }
+
+    /// Construct from a Imath::V3f
+    float4 (const Imath::V3f &v) { load (v[0], v[1], v[2]); }
+
+    /// Cast to a Imath::V3f
+    const Imath::V3f& V3f () const { return *(const Imath::V3f*)this; }
+
+#if defined(ILMBASE_VERSION_MAJOR) && ILMBASE_VERSION_MAJOR >= 2
+    // V4f is not defined for older Ilmbase. It's certainly safe for 2.x.
+
+    /// Construct from a Imath::V4f
+    float4 (const Imath::V4f &v) { load ((const float *)&v); }
+
+    /// Cast to a Imath::V4f
+    const Imath::V4f& V4f () const { return *(const Imath::V4f*)this; }
+#endif
+
+    /// Construct from a pointer to 4 unsigned short values
+    explicit float4 (const unsigned short *vals) { load(vals); }
+
+    /// Construct from a pointer to 4 short values
+    explicit float4 (const short *vals) { load(vals); }
+
+    /// Construct from a pointer to 4 unsigned char values
+    explicit float4 (const unsigned char *vals) { load(vals); }
+
+    /// Construct from a pointer to 4 char values
+    explicit float4 (const char *vals) { load(vals); }
+
+#ifdef _HALF_H_
+    /// Construct from a pointer to 4 half (16 bit float) values
+    explicit float4 (const half *vals) { load(vals); }
+#endif
+
+    /// Assign a single value to all components
+    const float4 & operator= (float a) { load(a); return *this; }
+
+    /// Assign a float4
+    const float4 & operator= (float4 other) {
+        m_vec = other.m_vec;
+        return *this;
+    }
+
+    /// Return a float4 with all components set to 0.0
+    static const float4 Zero ();
+
+    /// Return a float4 with all components set to 1.0
+    static const float4 One ();
+
+    /// Return a float4 with incremented components (e.g., 0.0,1.0,2.0,3.0).
+    /// Optional argument can give a non-zero starting point.
+    static const float4 Iota (float value=0.0f);
+    /// Set all components to 0.0
+    void clear ();
+
+#if defined(ILMBASE_VERSION_MAJOR) && ILMBASE_VERSION_MAJOR >= 2
+    /// Assign from a Imath::V4f
+    const float4 & operator= (const Imath::V4f &v);
+#endif
+
+    /// Assign from a Imath::V3f
+    const float4 & operator= (const Imath::V3f &v);
+
+    /// Component access (set)
+    float& operator[] (int i);
+    /// Component access (get)
+    float operator[] (int i) const;
+
+    value_t x () const;
+    value_t y () const;
+    value_t z () const;
+    value_t w () const;
+    void set_x (value_t val);
+    void set_y (value_t val);
+    void set_z (value_t val);
+    void set_w (value_t val);
+
+    /// Helper: load a single value into all components
+    void load (float val);
+
+    /// Helper: load 3 or 4 values. (If 3 are supplied, the 4th will be 0.)
+    void load (float a, float b, float c, float d=0.0f);
+
+    /// Load from an array of 4 values
+    void load (const float *values);
+
+    /// Load from a partial array of <=4 values. Unassigned values are
+    /// undefined.
+    void load (const float *values, int n);
+
+    /// Load from an array of 4 unsigned short values, convert to float
+    void load (const unsigned short *values);
+
+    /// Load from an array of 4 short values, convert to float
+    void load (const short *values);
+
+    /// Load from an array of 4 unsigned char values, convert to float
+    void load (const unsigned char *values);
+
+    /// Load from an array of 4 char values, convert to float
+    void load (const char *values);
+
+#ifdef _HALF_H_
+    /// Load from an array of 4 half values, convert to float
+    void load (const half *values);
+#endif /* _HALF_H_ */
+
+    void store (float *values) const;
+
+    /// Store the first n values into memory
+    void store (float *values, int n) const;
+
+#ifdef _HALF_H_
+    void store (half *values) const;
+#endif
+
+    // Arithmetic operators
+    friend float4 operator+ (const float4& a, const float4& b);
+    const float4 & operator+= (const float4& a);
+    float4 operator- () const;
+    friend float4 operator- (const float4& a, const float4& b);
+    const float4 & operator-= (const float4& a);
+    friend float4 operator* (const float4& a, const float4& b);
+    const float4 & operator*= (const float4& a);
+    const float4 & operator*= (float val);
+    friend float4 operator/ (const float4& a, const float4& b);
+    const float4 & operator/= (const float4& a);
+    const float4 & operator/= (float val);
+
+    // Comparison operations
+    friend mask_t operator== (const float4& a, const float4& b);
+    friend mask_t operator!= (const float4& a, const float4& b);
+    friend mask_t operator< (const float4& a, const float4& b);
+    friend mask_t operator>  (const float4& a, const float4& b);
+    friend mask_t operator>= (const float4& a, const float4& b);
+    friend mask_t operator<= (const float4& a, const float4& b);
+
+    // Some oddball items that are handy
+
+    /// Combine the first two components of A with the first two components
+    /// of B.
+    friend float4 AxyBxy (const float4& a, const float4& b);
+
+    /// Combine the first two components of A with the first two components
+    /// of B, but interleaved.
+    friend float4 AxBxAyBy (const float4& a, const float4& b);
+
+    /// Return xyz components, plus 0 for w
+    float4 xyz0 () const;
+
+    /// Return xyz components, plus 1 for w
+    float4 xyz1 () const;
+
+    /// Stream output
+    friend inline std::ostream& operator<< (std::ostream& cout, const float4& val);
+
+protected:
+    // The actual data representation
+    union {
+        simd_t  m_vec;
+        value_t m_val[paddedelements];
+    };
+};
+
+
+/// Helper: shuffle/swizzle with constant (templated) indices.
+/// Example: shuffle<1,1,2,2>(mask4(a,b,c,d)) returns (b,b,c,c)
+template<int i0, int i1, int i2, int i3> float4 shuffle (const float4& a);
+
+/// shuffle<i>(a) is the same as shuffle<i,i,i,i>(a)
+template<int i> float4 shuffle (const float4& a);
+
+/// Helper: as rapid as possible extraction of one component, when the
+/// index is fixed.
+template<int i> float extract (const float4& a);
+
+/// Helper: substitute val for a[i]
+template<int i> float4 insert (const float4& a, float val);
+
+
+/// The sum of all components, returned in all components.
+float4 vreduce_add (const float4& v);
+
+/// The sum of all components, returned as a scalar.
+float reduce_add (const float4& v);
+
+/// Return the float dot (inner) product of a and b in every component.
+float4 vdot (const float4 &a, const float4 &b);
+
+/// Return the float dot (inner) product of a and b.
+float dot (const float4 &a, const float4 &b);
+
+/// Return the float 3-component dot (inner) product of a and b in
+/// all components.
+float4 vdot3 (const float4 &a, const float4 &b);
+
+/// Return the float 3-component dot (inner) product of a and b.
+float dot3 (const float4 &a, const float4 &b);
+
+/// Use a mask to select between components of a (if mask[i] is false) and
+/// b (if mask[i] is true).
+float4 blend (const float4& a, const float4& b, const mask4& mask);
+
+/// Use a mask to select between components of a (if mask[i] is true) or
+/// 0 (if mask[i] is true).
+float4 blend0 (const float4& a, const mask4& mask);
+
+/// Use a mask to select between components of a (if mask[i] is FALSE) or
+/// 0 (if mask[i] is TRUE).
+float4 blend0not (const float4& a, const mask4& mask);
+
+/// "Safe" divide of float4/float4 -- for any component of the divisor
+/// that is 0, return 0 rather than Inf.
+float4 safe_div (const float4 &a, const float4 &b);
+
+/// Homogeneous divide to turn a float4 into a float3.
+float3 hdiv (const float4 &a);
+
+/// Select 'a' where mask is true, 'b' where mask is false. Sure, it's a
+/// synonym for blend with arguments rearranged, but this is more clear
+/// because the arguments are symmetric to scalar (cond ? a : b).
+float4 select (const mask4& mask, const float4& a, const float4& b);
+
+// Per-element math
+float4 abs (const float4& a);    ///< absolute value (float)
+float4 sign (const float4& a);   ///< 1.0 when value >= 0, -1 when negative
+float4 ceil (const float4& a);
+float4 floor (const float4& a);
+int4 floori (const float4& a);    ///< (int)floor
+
+/// Per-element round to nearest integer (rounding away from 0 in cases
+/// that are exactly half way).
+float4 round (const float4& a);
+
+/// Per-element round to nearest integer (rounding away from 0 in cases
+/// that are exactly half way).
+int4 rint (const float4& a);
+
+float4 sqrt (const float4 &a);
+float4 rsqrt (const float4 &a);   ///< Fully accurate 1/sqrt
+float4 rsqrt_fast (const float4 &a);  ///< Fast, approximate 1/sqrt
+float4 exp (const float4& v);
+float4 log (const float4& v);
+float4 min (const float4& a, const float4& b); ///< Per-element min
+float4 max (const float4& a, const float4& b); ///< Per-element max
+
+/// andnot(a,b) returns ((~a) & b)
+float4 andnot (const float4& a, const float4& b);
+
+// Fused multiply and add (or subtract):
+float4 madd (const float4& a, const float4& b, const float4& c); // a*b + c
+float4 msub (const float4& a, const float4& b, const float4& c); // a*b - c
+float4 nmadd (const float4& a, const float4& b, const float4& c); // -a*b + c
+float4 nmsub (const float4& a, const float4& b, const float4& c); // -a*b - c
+
+/// Transpose the rows and columns of the 4x4 matrix [a b c d].
+/// In the end, a will have the original (a[0], b[0], c[0], d[0]),
+/// b will have the original (a[1], b[1], c[1], d[1]), and so on.
+void transpose (float4 &a, float4 &b, float4 &c, float4 &d);
+void transpose (const float4& a, const float4& b, const float4& c, const float4& d,
+                float4 &r0, float4 &r1, float4 &r2, float4 &r3);
+
+/// Make a float4 consisting of the first element of each of 4 float4's.
+float4 AxBxCxDx (const float4& a, const float4& b,
+                 const float4& c, const float4& d);
+
+
+
+/// Floating point 3-vector, aligned to be internally identical to a float4.
+/// The way it differs from float4 is that all of he load functions only
+/// load three values, and all the stores only store 3 values. The vast
+/// majority of ops just fall back to the float4 version, and so will
+/// operate on the 4th component, but we won't care about that results.
+class float3 : public float4 {
+public:
+    static const char* type_name() { return "float3"; }
+    enum { elements = 3 };    ///< Number of scalar elements
+    enum { paddedelements = 4 }; ///< Number of scalar elements for full pad
+
+    /// Default constructor (contents undefined)
+    float3 () { }
+
+    /// Destructor
+    ~float3 () { }
+
+    /// Construct from a single value (store it in all slots)
+    float3 (float a) { load(a); }
+
+    /// Construct from 3 or 4 values
+    float3 (float a, float b, float c) { float4::load(a,b,c); }
+
+    /// Construct from a pointer to 4 values
+    float3 (const float *f) { load (f); }
+
+    /// Copy construct from another float3
+    float3 (const float3 &other);
+
+    explicit float3 (const float4 &other);
+
+#if OIIO_SIMD
+    /// Construct from the underlying SIMD type
+    explicit float3 (const simd_t& m) : float4(m) { }
+#endif
+
+    /// Construct from a Imath::V3f
+    float3 (const Imath::V3f &v) : float4(v) { }
+
+    /// Cast to a Imath::V3f
+    const Imath::V3f& V3f () const { return *(const Imath::V3f*)this; }
+
+    /// Construct from a pointer to 4 unsigned short values
+    explicit float3 (const unsigned short *vals) { load(vals); }
+
+    /// Construct from a pointer to 4 short values
+    explicit float3 (const short *vals) { load(vals); }
+
+    /// Construct from a pointer to 4 unsigned char values
+    explicit float3 (const unsigned char *vals) { load(vals); }
+
+    /// Construct from a pointer to 4 char values
+    explicit float3 (const char *vals) { load(vals); }
+
+#ifdef _HALF_H_
+    /// Construct from a pointer to 4 half (16 bit float) values
+    explicit float3 (const half *vals) { load(vals); }
+#endif
+
+    /// Assign a single value to all components
+    const float3 & operator= (float a) { load(a); return *this; }
+
+    /// Return a float3 with all components set to 0.0
+    static const float3 Zero ();
+
+    /// Return a float3 with all components set to 1.0
+    static const float3 One ();
+
+    /// Return a float3 with incremented components (e.g., 0.0,1.0,2.0,3.0).
+    /// Optional argument can give a non-zero starting point.
+    static const float3 Iota (float value=0.0f);
+
+    /// Helper: load a single value into all components
+    void load (float val);
+
+    /// Load from an array of 4 values
+    void load (const float *values);
+
+    /// Load from an array of 4 values
+    void load (const float *values, int n);
+
+    /// Load from an array of 4 unsigned short values, convert to float
+    void load (const unsigned short *values);
+
+    /// Load from an array of 4 short values, convert to float
+    void load (const short *values);
+
+    /// Load from an array of 4 unsigned char values, convert to float
+    void load (const unsigned char *values);
+
+    /// Load from an array of 4 char values, convert to float
+    void load (const char *values);
+
+#ifdef _HALF_H_
+    /// Load from an array of 4 half values, convert to float
+    void load (const half *values);
+#endif /* _HALF_H_ */
+
+    void store (float *values) const;
+
+    void store (float *values, int n) const;
+
+#ifdef _HALF_H_
+    void store (half *values) const;
+#endif
+
+    /// Store into an Imath::V3f reference.
+    void store (Imath::V3f &vec) const;
+
+    // Math operators -- define in terms of float3.
+    friend float3 operator+ (const float3& a, const float3& b);
+    const float3 & operator+= (const float3& a);
+    float3 operator- () const;
+    friend float3 operator- (const float3& a, const float3& b);
+    const float3 & operator-= (const float3& a);
+    friend float3 operator* (const float3& a, const float3& b);
+    const float3 & operator*= (const float3& a);
+    const float3 & operator*= (float a);
+    friend float3 operator/ (const float3& a, const float3& b);
+    const float3 & operator/= (const float3& a);
+    const float3 & operator/= (float a);
+
+    float3 normalized () const;
+    float3 normalized_fast () const;
+
+    /// Stream output
+    friend inline std::ostream& operator<< (std::ostream& cout, const float3& val);
+};
+
+
+
+
+/// SIMD-based 4x4 matrix. This is guaranteed to have memory layout (when
+/// not in registers) isomorphic to Imath::M44f.
+class matrix44 {
+public:
+    // Uninitialized
+    OIIO_FORCEINLINE matrix44 ()
+#ifndef OIIO_SIMD_SSE
+        : m_mat(Imath::UNINITIALIZED)
+#endif
+    { }
+
+    /// Construct from a reference to an Imath::M44f
+    OIIO_FORCEINLINE matrix44 (const Imath::M44f &M) {
+#if OIIO_SIMD_SSE
+        m_row[0].load (M[0]);
+        m_row[1].load (M[1]);
+        m_row[2].load (M[2]);
+        m_row[3].load (M[3]);
+#else
+        m_mat = M;
+#endif
+    }
+
+    /// Construct from a float array
+    OIIO_FORCEINLINE explicit matrix44 (const float *f) {
+#if OIIO_SIMD_SSE
+        m_row[0].load (f+0);
+        m_row[1].load (f+4);
+        m_row[2].load (f+8);
+        m_row[3].load (f+12);
+#else
+        memcpy (&m_mat, f, 16*sizeof(float));
+#endif
+    }
+
+    /// Construct from 4 float4 rows
+    OIIO_FORCEINLINE explicit matrix44 (const float4& a, const float4& b,
+                                        const float4& c, const float4& d) {
+#if OIIO_SIMD_SSE
+        m_row[0] = a; m_row[1] = b; m_row[2] = c; m_row[3] = d;
+#else
+        a.store (m_mat[0]);
+        b.store (m_mat[1]);
+        c.store (m_mat[2]);
+        d.store (m_mat[3]);
+#endif
+    }
+    /// Construct from 4 float[4] rows
+    OIIO_FORCEINLINE explicit matrix44 (const float *a, const float *b,
+                                        const float *c, const float *d) {
+#if OIIO_SIMD_SSE
+        m_row[0].load(a); m_row[1].load(b); m_row[2].load(c); m_row[3].load(d);
+#else
+        memcpy (m_mat[0], a, 4*sizeof(float));
+        memcpy (m_mat[1], b, 4*sizeof(float));
+        memcpy (m_mat[2], c, 4*sizeof(float));
+        memcpy (m_mat[3], d, 4*sizeof(float));
+#endif
+    }
+
+    /// Present as an Imath::M44f
+    const Imath::M44f& M44f() const;
+
+    /// Return one row
+    float4 operator[] (int i) const;
+
+    /// Return the transposed matrix
+    matrix44 transposed () const;
+
+    /// Transform 3-point V by 4x4 matrix M.
+    float3 transformp (const float3 &V) const;
+
+    /// Transform 3-vector V by 4x4 matrix M.
+    float3 transformv (const float3 &V) const;
+
+    /// Transform 3-vector V by the transpose of 4x4 matrix M.
+    float3 transformvT (const float3 &V) const;
+
+    bool operator== (const matrix44& m) const;
+
+    bool operator== (const Imath::M44f& m) const ;
+    friend bool operator== (const Imath::M44f& a, const matrix44 &b);
+
+    bool operator!= (const matrix44& m) const;
+
+    bool operator!= (const Imath::M44f& m) const;
+    friend bool operator!= (const Imath::M44f& a, const matrix44 &b);
+
+    /// Return the inverse of the matrix.
+    matrix44 inverse() const;
+
+    /// Stream output
+    friend inline std::ostream& operator<< (std::ostream& cout, const matrix44 &M);
+
+private:
+#if OIIO_SIMD_SSE
+    float4 m_row[4];
+#else
+    Imath::M44f m_mat;
+#endif
+};
+
+/// Transform 3-point V by 4x4 matrix M.
+float3 transformp (const matrix44 &M, const float3 &V);
+float3 transformp (const Imath::M44f &M, const float3 &V);
+
+/// Transform 3-vector V by 4x4 matrix M.
+float3 transformv (const matrix44 &M, const float3 &V);
+float3 transformv (const Imath::M44f &M, const float3 &V);
+
+// Transform 3-vector by the transpose of 4x4 matrix M.
+float3 transformvT (const matrix44 &M, const float3 &V);
+float3 transformvT (const Imath::M44f &M, const float3 &V);
+
+
+
+
+
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+//
+// Gory implementation details follow.
+//
+// ^^^ All declarations and documention is above ^^^
+//
+// vvv Below is the implementation, often considerably cluttered with
+//     #if's for each architeture, and unapologitic use of intrinsics and
+//     every manner of dirty trick we can think of to make things fast.
+//     Some of this isn't pretty. We won't recapitulate comments or
+//     documentation of what the functions are supposed to do, please
+//     consult the declarations above for that.
+//
+//     Here be dragons.
+//
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+
+
+//////////////////////////////////////////////////////////////////////
+// mask4 implementation
+
+
+OIIO_FORCEINLINE void mask4::clear () {
+#if defined(OIIO_SIMD_SSE)
+    m_vec = _mm_setzero_ps();
+#else
+    *this = false;
+#endif
+}
+
+OIIO_FORCEINLINE const mask4 mask4::False () {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_setzero_ps();
+#else
+    return mask4(false);
+#endif
+}
+
+OIIO_FORCEINLINE const mask4 mask4::True () {
+#if defined(OIIO_SIMD_SSE)
+    // Fastest way to fill an __m128 with all 1 bits is to cmpeq_epi8
+    // any value to itself.
+# if defined(OIIO_SIMD_AVX) && (OIIO_GNUC_VERSION > 50000)
+    __m128i anyval = _mm_undefined_si128();
+# else
+    __m128i anyval = _mm_castps_si128 (_mm_setzero_ps());
+# endif
+    return _mm_castsi128_ps (_mm_cmpeq_epi8 (anyval, anyval));
+#else
+    return mask4(true);
+#endif
+}
+
+OIIO_FORCEINLINE const mask4 & mask4::operator= (bool a) { load(a); return *this; }
+
+OIIO_FORCEINLINE const mask4 & mask4::operator= (const mask4 & other) {
+#if defined(OIIO_SIMD_SSE)
+    m_vec = other.m_vec;
+#else
+    SIMD_CONSTRUCT (other.m_val[i]);
+#endif
+    return *this;
+}
+
+OIIO_FORCEINLINE bool mask4::operator[] (int i) const {
+    DASSERT(i >= 0 && i < 4);
+#if defined(OIIO_SIMD_SSE)
+    return (_mm_movemask_ps(m_vec) >> i) & 1;
+#else
+    return bool(m_val[i]);
+#endif
+}
+
+OIIO_FORCEINLINE int& mask4::operator[] (int i) {
+    DASSERT(i >= 0 && i < 4);
+    return m_val[i];
+}
+
+OIIO_FORCEINLINE void mask4::load (bool a) {
+#if defined(OIIO_SIMD_SSE)
+    m_vec = _mm_castsi128_ps(_mm_set1_epi32(a ? -1 : 0));
+#else
+    int val = a ? -1 : 0;
+    SIMD_CONSTRUCT (val);
+#endif
+}
+
+OIIO_FORCEINLINE void mask4::load (bool a, bool b, bool c, bool d) {
+#if defined(OIIO_SIMD_SSE)
+    // N.B. -- we need to reverse the order because of our convention
+    // of storing a,b,c,d in the same order in memory.
+    m_vec = _mm_castsi128_ps(_mm_set_epi32(d ? -1 : 0,
+                                           c ? -1 : 0,
+                                           b ? -1 : 0,
+                                           a ? -1 : 0));
+#else
+    m_val[0] = a ? -1 : 0;
+    m_val[1] = b ? -1 : 0;
+    m_val[2] = c ? -1 : 0;
+    m_val[3] = d ? -1 : 0;
+#endif
+}
+
+OIIO_FORCEINLINE void mask4::store (bool *values) const {
+#if 0 && defined(OIIO_SIMD_SSE)
+    // FIXME: is there a more efficient way to do this?
+#else
+    SIMD_DO (values[i] = m_val[i] ? true : false);
+#endif
+}
+
+OIIO_FORCEINLINE void mask4::store (bool *values, int n) const {
+    DASSERT (n >= 0 && n <= elements);
+    for (int i = 0; i < n; ++i)
+        values[i] = m_val[i] ? true : false;
+}
+
+OIIO_FORCEINLINE mask4 operator! (const mask4 & a) {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_xor_ps (a.m_vec, mask4::True());
+#else
+    SIMD_RETURN (mask4, a.m_val[i] ^ (-1));
+#endif
+}
+
+OIIO_FORCEINLINE mask4 operator& (const mask4 & a, const mask4 & b) {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_and_ps (a.m_vec, b.m_vec);
+#else
+    SIMD_RETURN (mask4, a.m_val[i] & b.m_val[i]);
+#endif
+}
+
+OIIO_FORCEINLINE const mask4& mask4::operator&= (const mask4 & b) {
+    return *this = *this & b;
+}
+
+OIIO_FORCEINLINE mask4 operator| (const mask4 & a, const mask4 & b) {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_or_ps (a.m_vec, b.m_vec);
+#else
+    SIMD_RETURN (mask4, a.m_val[i] | b.m_val[i]);
+#endif
+}
+
+OIIO_FORCEINLINE const mask4& mask4::operator|= (const mask4 & a) {
+    return *this = *this | a;
+}
+
+OIIO_FORCEINLINE mask4 operator^ (const mask4& a, const mask4& b) {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_xor_ps (a.m_vec, b.m_vec);
+#else
+    SIMD_RETURN (mask4, a.m_val[i] ^ b.m_val[i]);
+#endif
+}
+
+OIIO_FORCEINLINE const mask4 & mask4::operator^= (const mask4& a) {
+    return *this = *this ^ a;
+}
+
+OIIO_FORCEINLINE mask4 mask4::operator~ () {
+#if defined(OIIO_SIMD_SSE)
+    // Fastest way to bit-complement in SSE is to xor with 0xffffffff.
+    // Fastest way to fill an __m128 with all 1 bits is to cmpeq_epi8
+    // any value to itself.
+# if defined(OIIO_SIMD_AVX) && (OIIO_GNUC_VERSION > 50000)
+    __m128i anyval = _mm_undefined_si128(); // AVX only, sigh
+# else
+    __m128i anyval = _mm_castps_si128 (m_vec);
+# endif
+    __m128 all_one_bits = _mm_castsi128_ps (_mm_cmpeq_epi8 (anyval, anyval));
+    return _mm_xor_ps (m_vec, all_one_bits);
+#else
+    SIMD_RETURN (mask4, ~m_val[i]);
+#endif
+}
+
+OIIO_FORCEINLINE const mask4 operator== (const mask4 & a, const mask4 & b) {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_castsi128_ps (_mm_cmpeq_epi32 (_mm_castps_si128 (a.m_vec), _mm_castps_si128(b.m_vec)));
+#else
+    SIMD_RETURN (mask4, a.m_val[i] == b.m_val[i] ? -1 : 0);
+#endif
+}
+
+OIIO_FORCEINLINE const mask4 operator!= (const mask4 & a, const mask4 & b) {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_xor_ps (a.m_vec, b.m_vec);
+#else
+    SIMD_RETURN (mask4, a.m_val[i] != b.m_val[i] ? -1 : 0);
+#endif
+}
+
+inline std::ostream& operator<< (std::ostream& cout, const mask4 & a) {
+    cout << a[0];
+    for (int i = 1; i < a.elements; ++i)
+        cout << ' ' << a[i];
+    return cout;
+}
+
+
+
+#if defined(OIIO_SIMD_SSE)
+// Shuffling. Use like this:  x = shuffle<3,2,1,0>(b)
+template<int i0, int i1, int i2, int i3>
+OIIO_FORCEINLINE __m128i shuffle_sse (__m128i v) {
+    return _mm_shuffle_epi32(v, _MM_SHUFFLE(i3, i2, i1, i0));
+}
+#endif
+
+#if OIIO_SIMD_SSE >= 3
+// SSE3 has intrinsics for a few special cases
+template<> OIIO_FORCEINLINE __m128i shuffle_sse<0, 0, 2, 2> (__m128i a) {
+    return _mm_castps_si128(_mm_moveldup_ps(_mm_castsi128_ps(a)));
+}
+template<> OIIO_FORCEINLINE __m128i shuffle_sse<1, 1, 3, 3> (__m128i a) {
+    return _mm_castps_si128(_mm_movehdup_ps(_mm_castsi128_ps(a)));
+}
+template<> OIIO_FORCEINLINE __m128i shuffle_sse<0, 1, 0, 1> (__m128i a) {
+    return _mm_castpd_si128(_mm_movedup_pd(_mm_castsi128_pd(a)));
+}
+#endif
+
+#if defined(OIIO_SIMD_SSE)
+template<int i0, int i1, int i2, int i3>
+OIIO_FORCEINLINE __m128 shuffle_sse (__m128 a) {
+    return _mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(a), _MM_SHUFFLE(i3, i2, i1, i0)));
+}
+#endif
+
+#if OIIO_SIMD_SSE >= 3
+// SSE3 has intrinsics for a few special cases
+template<> OIIO_FORCEINLINE __m128 shuffle_sse<0, 0, 2, 2> (__m128 a) {
+    return _mm_moveldup_ps(a);
+}
+template<> OIIO_FORCEINLINE __m128 shuffle_sse<1, 1, 3, 3> (__m128 a) {
+    return _mm_movehdup_ps(a);
+}
+template<> OIIO_FORCEINLINE __m128 shuffle_sse<0, 1, 0, 1> (__m128 a) {
+    return _mm_castpd_ps(_mm_movedup_pd(_mm_castps_pd(a)));
+}
+#endif
 
 
 /// Helper: shuffle/swizzle with constant (templated) indices.
@@ -539,8 +1489,6 @@ OIIO_FORCEINLINE mask4 insert (const mask4& a, bool val) {
 }
 
 
-/// Logical "and" reduction, i.e., 'and' all components together, resulting
-/// in a single bool.
 OIIO_FORCEINLINE bool reduce_and (const mask4& v) {
 #if defined(OIIO_SIMD_SSE)
     return _mm_movemask_ps(v.simd()) == 0xf;
@@ -550,8 +1498,6 @@ OIIO_FORCEINLINE bool reduce_and (const mask4& v) {
 }
 
 
-/// Logical "or" reduction, i.e., 'or' all components together, resulting
-/// in a single bool.
 OIIO_FORCEINLINE bool reduce_or (const mask4& v) {
 #if defined(OIIO_SIMD_SSE)
     return _mm_movemask_ps(v) != 0;
@@ -561,568 +1507,490 @@ OIIO_FORCEINLINE bool reduce_or (const mask4& v) {
 }
 
 
-/// Are all components true?
-OIIO_FORCEINLINE bool all  (const mask4& v) { return reduce_and(v) == true; }
 
-/// Are any components true?
-OIIO_FORCEINLINE bool any  (const mask4& v) { return reduce_or(v) == true; }
-
-/// Are all components false:
-OIIO_FORCEINLINE bool none (const mask4& v) { return reduce_or(v) == false; }
+//////////////////////////////////////////////////////////////////////
+// int4 implementation
 
 
-
-
-
-/// Integer 4-vector, accelerated by SIMD instructions when available.
-class int4 {
-public:
-    static const char* type_name() { return "int4"; }
-    typedef int value_t;      ///< Underlying equivalent scalar value type
-    enum { elements = 4 };    ///< Number of scalar elements
-    enum { paddedelements = 4 }; ///< Number of scalar elements for full pad
-    enum { bits = 128 };      ///< Total number of bits
-    typedef simd_raw_t<int,4>::type simd_t;  ///< the native SIMD type used
-
-    /// Default constructor (contents undefined)
-    OIIO_FORCEINLINE int4 () { }
-
-    /// Destructor
-    OIIO_FORCEINLINE ~int4 () { }
-
-    /// Construct from a single value (store it in all slots)
-    OIIO_FORCEINLINE int4 (int a) { load(a); }
-
-    /// Construct from 2 values -- (a,a,b,b)
-    OIIO_FORCEINLINE int4 (int a, int b) { load(a,a,b,b); }
-
-    /// Construct from 4 values
-    OIIO_FORCEINLINE int4 (int a, int b, int c, int d) { load(a,b,c,d); }
-
-    /// Construct from a pointer to 4 values
-    OIIO_FORCEINLINE int4 (const int *vals) { load (vals); }
-
-    /// Construct from a pointer to 4 unsigned short values
-    OIIO_FORCEINLINE explicit int4 (const unsigned short *vals) { load(vals); }
-
-    /// Construct from a pointer to 4 signed short values
-    OIIO_FORCEINLINE explicit int4 (const short *vals) { load(vals); }
-
-    /// Construct from a pointer to 4 unsigned char values (0 - 255)
-    OIIO_FORCEINLINE explicit int4 (const unsigned char *vals) { load(vals); }
-
-    /// Construct from a pointer to 4 signed char values (-128 - 127)
-    OIIO_FORCEINLINE explicit int4 (const char *vals) { load(vals); }
-
-    /// Copy construct from another int4
-    OIIO_FORCEINLINE int4 (const int4 & other) { m_vec = other.m_vec; }
-
-    /// Convert a float4 to an int4. Equivalent to i = (int)f;
-    OIIO_FORCEINLINE explicit int4 (const float4& f); // implementation below
-
-    /// Construct from the underlying SIMD type
-    OIIO_FORCEINLINE int4 (const simd_t& m) : m_vec(m) { }
-
-    /// Return the raw SIMD type
-    OIIO_FORCEINLINE operator simd_t () const { return m_vec; }
-    OIIO_FORCEINLINE simd_t simd () const { return m_vec; }
-
-    /// Sset all components to 0
-    OIIO_FORCEINLINE void clear () {
+OIIO_FORCEINLINE void int4::clear () {
 #if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_setzero_si128();
+    m_vec = _mm_setzero_si128();
 #else
-        *this = 0.0f;
+    *this = 0.0f;
 #endif
-    }
+}
 
-    /// Return an int4 with all components set to 0
-    static OIIO_FORCEINLINE const int4 Zero () {
+OIIO_FORCEINLINE const int4 int4::Zero () {
 #if defined(OIIO_SIMD_SSE)
-        return _mm_setzero_si128();
+    return _mm_setzero_si128();
 #else
-        return int4(0);
+    return int4(0);
 #endif
-    }
+}
 
-    /// Return an int4 with all components set to 1
-    static OIIO_FORCEINLINE const int4 One () { return int4(1); }
+OIIO_FORCEINLINE const int4 int4::One () { return int4(1); }
 
-    /// Return an int4 with all components set to -1 (aka 0xffffffff)
-    static OIIO_FORCEINLINE const int4 NegOne () {
+OIIO_FORCEINLINE const int4 int4::NegOne () {
 #if defined(OIIO_SIMD_SSE)
-        // Fastest way to fill an __m128 with all 1 bits is to cmpeq_epi8
-        // any value to itself.
+    // Fastest way to fill an __m128 with all 1 bits is to cmpeq_epi8
+    // any value to itself.
 # if defined(OIIO_SIMD_AVX) && (OIIO_GNUC_VERSION > 50000)
-        __m128i anyval = _mm_undefined_si128();
+    __m128i anyval = _mm_undefined_si128();
 # else
-        __m128i anyval = _mm_castps_si128 (_mm_setzero_ps());
+    __m128i anyval = _mm_castps_si128 (_mm_setzero_ps());
 # endif
-        return _mm_cmpeq_epi8 (anyval, anyval);
+    return _mm_cmpeq_epi8 (anyval, anyval);
 #else
-        return int4(-1);
+    return int4(-1);
 #endif
-    }
+}
 
-    /// Return an int4 with incremented components (e.g., 0,1,2,3).
-    /// Optional argument can give a non-zero starting point.
-    static OIIO_FORCEINLINE const int4 Iota (int value=0) {
-        return int4(value,value+1,value+2,value+3);
-    }
+OIIO_FORCEINLINE const int4 int4::Iota (int value) {
+    return int4(value,value+1,value+2,value+3);
+}
 
-    /// Assign one value to all components.
-    OIIO_FORCEINLINE const int4 & operator= (int a) { load(a); return *this; }
+OIIO_FORCEINLINE const int4 & int4::operator= (int a) { load(a); return *this; }
 
-    /// Assignment from another int4
-    OIIO_FORCEINLINE const int4 & operator= (int4 other) {
-        m_vec = other.m_vec;
-        return *this;
-    }
+OIIO_FORCEINLINE const int4 & int4::operator= (int4 other) {
+    m_vec = other.m_vec;
+    return *this;
+}
 
-    /// Component access (set)
-    OIIO_FORCEINLINE int& operator[] (int i) {
-        DASSERT(i<elements);
-        return m_val[i];
-    }
+OIIO_FORCEINLINE int& int4::operator[] (int i) {
+    DASSERT(i<elements);
+    return m_val[i];
+}
 
-    /// Component access (get)
-    OIIO_FORCEINLINE int operator[] (int i) const {
-        DASSERT(i<elements);
-        return m_val[i];
-    }
+OIIO_FORCEINLINE int int4::operator[] (int i) const {
+    DASSERT(i<elements);
+    return m_val[i];
+}
 
-    OIIO_FORCEINLINE value_t x () const;
-    OIIO_FORCEINLINE value_t y () const;
-    OIIO_FORCEINLINE value_t z () const;
-    OIIO_FORCEINLINE value_t w () const;
-    OIIO_FORCEINLINE void set_x (value_t val);
-    OIIO_FORCEINLINE void set_y (value_t val);
-    OIIO_FORCEINLINE void set_z (value_t val);
-    OIIO_FORCEINLINE void set_w (value_t val);
 
-    /// Helper: load a single int into all components
-    OIIO_FORCEINLINE void load (int a) {
+OIIO_FORCEINLINE void int4::load (int a) {
 #if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_set1_epi32 (a);
+    m_vec = _mm_set1_epi32 (a);
 #else
-        SIMD_CONSTRUCT (a);
+    SIMD_CONSTRUCT (a);
 #endif
-    }
+}
 
-    /// Helper: load separate values into each component.
-    OIIO_FORCEINLINE void load (int a, int b, int c, int d) {
+OIIO_FORCEINLINE void int4::load (int a, int b, int c, int d) {
 #if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_set_epi32 (d, c, b, a);
+    m_vec = _mm_set_epi32 (d, c, b, a);
 #else
-        m_val[0] = a;
-        m_val[1] = b;
-        m_val[2] = c;
-        m_val[3] = d;
+    m_val[0] = a;
+    m_val[1] = b;
+    m_val[2] = c;
+    m_val[3] = d;
 #endif
-    }
+}
 
-    /// Load from an array of 4 values
-    OIIO_FORCEINLINE void load (const int *values) {
+OIIO_FORCEINLINE void int4::load (const int *values) {
 #if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_loadu_si128 ((const simd_t *)values);
+    m_vec = _mm_loadu_si128 ((const simd_t *)values);
 #else
-        SIMD_CONSTRUCT (values[i]);
+    SIMD_CONSTRUCT (values[i]);
 #endif
-    }
+}
 
-    OIIO_FORCEINLINE void load (const int *values, int n) {
+OIIO_FORCEINLINE void int4::load (const int *values, int n)
+{
 #if defined(OIIO_SIMD_SSE)
-        switch (n) {
-        case 1:
-            m_vec = _mm_castps_si128 (_mm_load_ss ((const float *)values));
-            break;
-        case 2:
+    switch (n) {
+    case 1:
+        m_vec = _mm_castps_si128 (_mm_load_ss ((const float *)values));
+        break;
+    case 2:
             // Trickery: load one double worth of bits!
-            m_vec = _mm_castpd_si128 (_mm_load_sd ((const double*)values));
-            break;
-        case 3:
-            // Trickery: load one double worth of bits, then a float,
-            // and combine, casting to ints.
-            m_vec = _mm_castps_si128 (
-                        _mm_movelh_ps(_mm_castpd_ps(_mm_load_sd((const double*)values)),
-                                      _mm_load_ss ((const float *)values + 2)));
-            break;
-        case 4:
-            m_vec = _mm_loadu_si128 ((const simd_t *)values);
-            break;
-        default:
-            break;
-        }
-#endif
-        for (int i = 0; i < n; ++i)
-            m_val[i] = values[i];
-        for (int i = n; i < elements; ++i)
-            m_val[i] = 0;
+        m_vec = _mm_castpd_si128 (_mm_load_sd ((const double*)values));
+        break;
+    case 3:
+        // Trickery: load one double worth of bits, then a float,
+        // and combine, casting to ints.
+        m_vec = _mm_castps_si128 (_mm_movelh_ps(_mm_castpd_ps(_mm_load_sd((const double*)values)),
+                                                _mm_load_ss ((const float *)values + 2)));
+        break;
+    case 4:
+        m_vec = _mm_loadu_si128 ((const simd_t *)values);
+        break;
+    default:
+        break;
     }
+#endif
+    for (int i = 0; i < n; ++i)
+        m_val[i] = values[i];
+    for (int i = n; i < elements; ++i)
+        m_val[i] = 0;
+}
 
-    /// Load from an array of 4 unsigned short values, convert to int4
-    OIIO_FORCEINLINE void load (const unsigned short *values) {
+OIIO_FORCEINLINE void int4::load (const unsigned short *values) {
 #if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 4
-        // Trickery: load one double worth of bits = 4 uint16's!
-        simd_t a = _mm_castpd_si128 (_mm_load_sd ((const double *)values));
-        m_vec = _mm_cvtepu16_epi32 (a);
+    // Trickery: load one double worth of bits = 4 uint16's!
+    simd_t a = _mm_castpd_si128 (_mm_load_sd ((const double *)values));
+    m_vec = _mm_cvtepu16_epi32 (a);
 #else
-        SIMD_CONSTRUCT (values[i]);
+    SIMD_CONSTRUCT (values[i]);
 #endif
-    }
+}
 
-    /// Load from an array of 4 unsigned short values, convert to int4
-    OIIO_FORCEINLINE void load (const short *values) {
+OIIO_FORCEINLINE void int4::load (const short *values) {
 #if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 4
-        // Trickery: load one double worth of bits = 4 int16's!
-        simd_t a = _mm_castpd_si128 (_mm_load_sd ((const double *)values));
-        m_vec = _mm_cvtepi16_epi32 (a);
+    // Trickery: load one double worth of bits = 4 int16's!
+    simd_t a = _mm_castpd_si128 (_mm_load_sd ((const double *)values));
+    m_vec = _mm_cvtepi16_epi32 (a);
 #else
-        SIMD_CONSTRUCT (values[i]);
+    SIMD_CONSTRUCT (values[i]);
 #endif
-    }
+}
 
-    /// Load from an array of 4 unsigned char values, convert to int4
-    OIIO_FORCEINLINE void load (const unsigned char *values) {
+OIIO_FORCEINLINE void int4::load (const unsigned char *values) {
 #if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 4
-        // Trickery: load one float worth of bits = 4 uint8's!
-        simd_t a = _mm_castps_si128 (_mm_load_ss ((const float *)values));
-        m_vec = _mm_cvtepu8_epi32 (a);
+    // Trickery: load one float worth of bits = 4 uint8's!
+    simd_t a = _mm_castps_si128 (_mm_load_ss ((const float *)values));
+    m_vec = _mm_cvtepu8_epi32 (a);
 #else
-        SIMD_CONSTRUCT (values[i]);
+    SIMD_CONSTRUCT (values[i]);
 #endif
-    }
+}
 
-    /// Load from an array of 4 unsigned char values, convert to int4
-    OIIO_FORCEINLINE void load (const char *values) {
+OIIO_FORCEINLINE void int4::load (const char *values) {
 #if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 4
-        // Trickery: load one float worth of bits = 4 uint8's!
-        simd_t a = _mm_castps_si128 (_mm_load_ss ((const float *)values));
-        m_vec = _mm_cvtepi8_epi32 (a);
+    // Trickery: load one float worth of bits = 4 uint8's!
+    simd_t a = _mm_castps_si128 (_mm_load_ss ((const float *)values));
+    m_vec = _mm_cvtepi8_epi32 (a);
 #else
-        SIMD_CONSTRUCT (values[i]);
+    SIMD_CONSTRUCT (values[i]);
 #endif
-    }
+}
 
-    /// Store the values into memory
-    OIIO_FORCEINLINE void store (int *values) const {
+OIIO_FORCEINLINE void int4::store (int *values) const {
 #if defined(OIIO_SIMD_SSE)
-        // Use an unaligned store -- it's just as fast when the memory turns
-        // out to be aligned, nearly as fast even when unaligned. Not worth
-        // the headache of using stores that require alignment.
-        _mm_storeu_si128 ((simd_t *)values, m_vec);
+    // Use an unaligned store -- it's just as fast when the memory turns
+    // out to be aligned, nearly as fast even when unaligned. Not worth
+    // the headache of using stores that require alignment.
+    _mm_storeu_si128 ((simd_t *)values, m_vec);
 #else
-        SIMD_DO (values[i] = m_val[i]);
+    SIMD_DO (values[i] = m_val[i]);
 #endif
-    }
+}
 
-    /// Store the first n values into memory
-    OIIO_FORCEINLINE void store (int *values, int n) const {
-        DASSERT (n >= 0 && n <= elements);
+OIIO_FORCEINLINE void int4::store (int *values, int n) const {
+    DASSERT (n >= 0 && n <= elements);
 #if defined(OIIO_SIMD)
-        // For full SIMD, there is a speed advantage to storing all components.
-        if (n == elements)
-            store (values);
-        else
+    // For full SIMD, there is a speed advantage to storing all components.
+    if (n == elements)
+        store (values);
+    else
 #endif
         for (int i = 0; i < n; ++i)
             values[i] = m_val[i];
-    }
+}
 
-    /// Store the least significant 16 bits of each element into adjacent
-    /// unsigned shorts.
-    OIIO_FORCEINLINE void store (unsigned short *values) const {
+OIIO_FORCEINLINE void int4::store (unsigned short *values) const {
 #if defined(OIIO_SIMD_SSE)
-        // Expressed as half-words and considering little endianness, we
-        // currently have xAxBxCxD (the 'x' means don't care).
-        int4 clamped = m_val & int4(0xffff);   // A0B0C0D0
-        int4 low = _mm_shufflelo_epi16 (clamped, (0<<0) | (2<<2) | (1<<4) | (1<<6));
+    // Expressed as half-words and considering little endianness, we
+    // currently have xAxBxCxD (the 'x' means don't care).
+    int4 clamped = m_val & int4(0xffff);   // A0B0C0D0
+    int4 low = _mm_shufflelo_epi16 (clamped, (0<<0) | (2<<2) | (1<<4) | (1<<6));
                     // low = AB00xxxx
-        int4 high = _mm_shufflehi_epi16 (clamped, (1<<0) | (1<<2) | (0<<4) | (2<<6));
+    int4 high = _mm_shufflehi_epi16 (clamped, (1<<0) | (1<<2) | (0<<4) | (2<<6));
                     // high = xxxx00CD
-        int4 highswapped = shuffle_sse<2,3,0,1>(high);  // 00CDxxxx
-        int4 result = low | highswapped;   // ABCDxxxx
-        _mm_storel_pd ((double *)values, _mm_castsi128_pd(result));
-        // At this point, values[] should hold A,B,C,D
+    int4 highswapped = shuffle_sse<2,3,0,1>(high);  // 00CDxxxx
+    int4 result = low | highswapped;   // ABCDxxxx
+    _mm_storel_pd ((double *)values, _mm_castsi128_pd(result));
+    // At this point, values[] should hold A,B,C,D
 #else
-        SIMD_DO (values[i] = m_val[i]);
+    SIMD_DO (values[i] = m_val[i]);
 #endif
-    }
+}
 
-    /// Store the least significant 8 bits of each element into adjacent
-    /// unsigned chars.
-    OIIO_FORCEINLINE void store (unsigned char *values) const {
+OIIO_FORCEINLINE void int4::store (unsigned char *values) const {
 #if defined(OIIO_SIMD_SSE)
-        // Expressed as bytes and considering little endianness, we
-        // currently have xAxBxCxD (the 'x' means don't care).
-        int4 clamped = m_val & int4(0xff);            // A000 B000 C000 D000
-        int4 swapped = shuffle_sse<1,0,3,2>(clamped); // B000 A000 D000 C000
-        int4 shifted = swapped << 8;                  // 0B00 0A00 0D00 0C00
-        int4 merged = clamped | shifted;              // AB00 xxxx CD00 xxxx
-        int4 merged2 = shuffle_sse<2,2,2,2>(merged);  // CD00 ...
-        int4 shifted2 = merged2 << 16;                // 00CD ...
-        int4 result = merged | shifted2;              // ABCD ...
-        *(int*)values = result[0]; //extract<0>(result);
-        // At this point, values[] should hold A,B,C,D
+    // Expressed as bytes and considering little endianness, we
+    // currently have xAxBxCxD (the 'x' means don't care).
+    int4 clamped = m_val & int4(0xff);            // A000 B000 C000 D000
+    int4 swapped = shuffle_sse<1,0,3,2>(clamped); // B000 A000 D000 C000
+    int4 shifted = swapped << 8;                  // 0B00 0A00 0D00 0C00
+    int4 merged = clamped | shifted;              // AB00 xxxx CD00 xxxx
+    int4 merged2 = shuffle_sse<2,2,2,2>(merged);  // CD00 ...
+    int4 shifted2 = merged2 << 16;                // 00CD ...
+    int4 result = merged | shifted2;              // ABCD ...
+    *(int*)values = result[0]; //extract<0>(result);
+    // At this point, values[] should hold A,B,C,D
 #else
-        SIMD_DO (values[i] = m_val[i]);
+    SIMD_DO (values[i] = m_val[i]);
 #endif
-    }
+}
 
-    friend OIIO_FORCEINLINE int4 operator+ (const int4& a, const int4& b) {
+OIIO_FORCEINLINE int4 operator+ (const int4& a, const int4& b) {
 #if defined(OIIO_SIMD_SSE)
-        return _mm_add_epi32 (a.m_vec, b.m_vec);
+    return _mm_add_epi32 (a.m_vec, b.m_vec);
 #else
-        SIMD_RETURN (int4, a[i] + b[i]);
+    SIMD_RETURN (int4, a[i] + b[i]);
 #endif
-    }
+}
 
-    OIIO_FORCEINLINE const int4 & operator+= (const int4& a) {
+OIIO_FORCEINLINE const int4 & int4::operator+= (const int4& a) {
 #if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_add_epi32 (m_vec, a.m_vec);
+    m_vec = _mm_add_epi32 (m_vec, a.m_vec);
 #else
-        SIMD_DO (m_val[i] += a[i]);
+    SIMD_DO (m_val[i] += a[i]);
 #endif
-        return *this;
-    }
+    return *this;
+}
 
-    OIIO_FORCEINLINE int4 operator- () const {
+OIIO_FORCEINLINE int4 int4::operator- () const {
 #if defined(OIIO_SIMD_SSE)
-        return _mm_sub_epi32 (_mm_setzero_si128(), m_vec);
+    return _mm_sub_epi32 (_mm_setzero_si128(), m_vec);
 #else
-        SIMD_RETURN (int4, -m_val[i]);
+    SIMD_RETURN (int4, -m_val[i]);
 #endif
-    }
+}
 
-    friend OIIO_FORCEINLINE int4 operator- (const int4& a, const int4& b) {
+OIIO_FORCEINLINE int4 operator- (const int4& a, const int4& b) {
 #if defined(OIIO_SIMD_SSE)
-        return _mm_sub_epi32 (a.m_vec, b.m_vec);
+    return _mm_sub_epi32 (a.m_vec, b.m_vec);
 #else
-        SIMD_RETURN (int4, a[i] - b[i]);
+    SIMD_RETURN (int4, a[i] - b[i]);
 #endif
-    }
+}
 
-    OIIO_FORCEINLINE const int4 & operator-= (const int4& a) {
+OIIO_FORCEINLINE const int4 & int4::operator-= (const int4& a) {
 #if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_sub_epi32 (m_vec, a.m_vec);
+    m_vec = _mm_sub_epi32 (m_vec, a.m_vec);
 #else
-        SIMD_DO (m_val[i] -= a[i]);
+    SIMD_DO (m_val[i] -= a[i]);
 #endif
         return *this;
-    }
+}
 
-    friend OIIO_FORCEINLINE int4 operator* (const int4& a, const int4& b) {
+
 #if defined(OIIO_SIMD_SSE)
-        return mm_mul_epi32 (a.m_vec, b.m_vec);
+// Shamelessly lifted from Syrah which lifted from Manta which lifted it
+// from intel.com
+OIIO_FORCEINLINE __m128i mm_mul_epi32 (__m128i a, __m128i b) {
+#if OIIO_SIMD_SSE >= 4  /* SSE >= 4.1 */
+    return _mm_mullo_epi32(a, b);
 #else
-        SIMD_RETURN (int4, a[i] * b[i]);
+    // Prior to SSE 4.1, there is no _mm_mullo_epi32 instruction, so we have
+    // to fake it.
+    __m128i t0;
+    __m128i t1;
+    t0 = _mm_mul_epu32 (a, b);
+    t1 = _mm_mul_epu32 (_mm_shuffle_epi32 (a, 0xB1),
+                        _mm_shuffle_epi32 (b, 0xB1));
+    t0 = _mm_shuffle_epi32 (t0, 0xD8);
+    t1 = _mm_shuffle_epi32 (t1, 0xD8);
+    return _mm_unpacklo_epi32 (t0, t1);
 #endif
-    }
+}
+#endif
 
-    OIIO_FORCEINLINE const int4 & operator*= (const int4& a) {
+
+OIIO_FORCEINLINE int4 operator* (const int4& a, const int4& b) {
 #if defined(OIIO_SIMD_SSE)
-        m_vec = mm_mul_epi32 (m_vec, a.m_vec);
+    return mm_mul_epi32 (a.m_vec, b.m_vec);
 #else
-        SIMD_DO (m_val[i] *= a[i]);
+    SIMD_RETURN (int4, a[i] * b[i]);
 #endif
-        return *this;
-    }
+}
 
-    OIIO_FORCEINLINE const int4 & operator*= (int val) {
+OIIO_FORCEINLINE const int4 & int4::operator*= (const int4& a) {
 #if defined(OIIO_SIMD_SSE)
-        m_vec = mm_mul_epi32 (m_vec, _mm_set1_epi32(val));
+    m_vec = mm_mul_epi32 (m_vec, a.m_vec);
 #else
-        SIMD_DO (m_val[i] *= val);
+    SIMD_DO (m_val[i] *= a[i]);
 #endif
-        return *this;
-    }
+    return *this;
+}
 
-    friend OIIO_FORCEINLINE int4 operator/ (const int4& a, const int4& b) {
-        // NO INTEGER DIVISION IN SSE!
-        SIMD_RETURN (int4, a[i] / b[i]);
-    }
-
-    OIIO_FORCEINLINE const int4 & operator/= (const int4& a) {
-        // NO INTEGER DIVISION IN SSE!
-        SIMD_DO (m_val[i] /= a[i]);
-        return *this;
-    }
-
-    OIIO_FORCEINLINE const int4 & operator/= (int val) {
-        // NO INTEGER DIVISION IN SSE!
-        SIMD_DO (m_val[i] /= val);
-        return *this;
-    }
-
-    friend OIIO_FORCEINLINE int4 operator% (const int4& a, const int4& b) {
-        // NO INTEGER MODULUS in SSE!
-        SIMD_RETURN (int4, a[i] % b[i]);
-    }
-    OIIO_FORCEINLINE const int4 & operator%= (const int4& a) {
-        // NO INTEGER MODULUS in SSE!
-        SIMD_DO (m_val[i] %= a[i]);
-        return *this;
-    }
-    friend OIIO_FORCEINLINE int4 operator% (const int4& a, int w) {
-        // NO INTEGER MODULUS in SSE!
-        SIMD_RETURN (int4, a[i] % w);
-    }
-    OIIO_FORCEINLINE const int4 & operator%= (int a) {
-        // NO INTEGER MODULUS IN SSE!
-        SIMD_DO (m_val[i] %= a);
-        return *this;
-    }
-    friend OIIO_FORCEINLINE int4 operator% (int a, const int4& b) {
-        // NO INTEGER MODULUS in SSE!
-        SIMD_RETURN (int4, a % b[i]);
-    }
-
-
-    friend OIIO_FORCEINLINE int4 operator& (const int4& a, const int4& b) {
+OIIO_FORCEINLINE const int4 & int4::operator*= (int val) {
 #if defined(OIIO_SIMD_SSE)
-        return _mm_and_si128 (a.m_vec, b.m_vec);
+    m_vec = mm_mul_epi32 (m_vec, _mm_set1_epi32(val));
 #else
-        SIMD_RETURN (int4, a[i] & b[i]);
+    SIMD_DO (m_val[i] *= val);
 #endif
-    }
-    OIIO_FORCEINLINE const int4 & operator&= (const int4& a) {
-        return *this = *this & a;
+    return *this;
+}
+
+OIIO_FORCEINLINE int4 operator/ (const int4& a, const int4& b) {
+    // NO INTEGER DIVISION IN SSE!
+    SIMD_RETURN (int4, a[i] / b[i]);
+}
+
+OIIO_FORCEINLINE const int4 & int4::operator/= (const int4& a) {
+    // NO INTEGER DIVISION IN SSE!
+    SIMD_DO (m_val[i] /= a[i]);
+    return *this;
+}
+
+OIIO_FORCEINLINE const int4 & int4::operator/= (int val) {
+    // NO INTEGER DIVISION IN SSE!
+    SIMD_DO (m_val[i] /= val);
+    return *this;
+}
+
+OIIO_FORCEINLINE int4 operator% (const int4& a, const int4& b) {
+    // NO INTEGER MODULUS in SSE!
+    SIMD_RETURN (int4, a[i] % b[i]);
     }
 
+OIIO_FORCEINLINE const int4 & int4::operator%= (const int4& a) {
+    // NO INTEGER MODULUS in SSE!
+    SIMD_DO (m_val[i] %= a[i]);
+    return *this;
+}
 
-    friend OIIO_FORCEINLINE int4 operator| (const int4& a, const int4& b) {
+OIIO_FORCEINLINE int4 operator% (const int4& a, int w) {
+    // NO INTEGER MODULUS in SSE!
+    SIMD_RETURN (int4, a[i] % w);
+}
+
+OIIO_FORCEINLINE const int4 & int4::operator%= (int a) {
+    // NO INTEGER MODULUS IN SSE!
+    SIMD_DO (m_val[i] %= a);
+    return *this;
+}
+
+OIIO_FORCEINLINE int4 operator% (int a, const int4& b) {
+    // NO INTEGER MODULUS in SSE!
+    SIMD_RETURN (int4, a % b[i]);
+}
+
+
+OIIO_FORCEINLINE int4 operator& (const int4& a, const int4& b) {
 #if defined(OIIO_SIMD_SSE)
-        return _mm_or_si128 (a.m_vec, b.m_vec);
+    return _mm_and_si128 (a.m_vec, b.m_vec);
 #else
-        SIMD_RETURN (int4, a[i] | b[i]);
+    SIMD_RETURN (int4, a[i] & b[i]);
 #endif
-    }
-    OIIO_FORCEINLINE const int4 & operator|= (const int4& a) {
-        return *this = *this | a;
-    }
+}
 
-    friend OIIO_FORCEINLINE int4 operator^ (const int4& a, const int4& b) {
+OIIO_FORCEINLINE const int4 & int4::operator&= (const int4& a) {
+    return *this = *this & a;
+}
+
+
+OIIO_FORCEINLINE int4 operator| (const int4& a, const int4& b) {
 #if defined(OIIO_SIMD_SSE)
-        return _mm_xor_si128 (a.m_vec, b.m_vec);
+    return _mm_or_si128 (a.m_vec, b.m_vec);
 #else
-        SIMD_RETURN (int4, a[i] ^ b[i]);
+    SIMD_RETURN (int4, a[i] | b[i]);
 #endif
-    }
-    OIIO_FORCEINLINE const int4 & operator^= (const int4& a) {
-        return *this = *this ^ a;
-    }
+}
 
-    OIIO_FORCEINLINE int4 operator~ () {
+OIIO_FORCEINLINE const int4 & int4::operator|= (const int4& a) {
+    return *this = *this | a;
+}
+
+OIIO_FORCEINLINE int4 operator^ (const int4& a, const int4& b) {
 #if defined(OIIO_SIMD_SSE)
-        // Fastest way to bit-complement in SSE is to xor with 0xffffffff.
-        // Fastest way to fill an __m128 with all 1 bits is to cmpeq_epi8
-        // any value to itself.
+    return _mm_xor_si128 (a.m_vec, b.m_vec);
+#else
+    SIMD_RETURN (int4, a[i] ^ b[i]);
+#endif
+}
+
+OIIO_FORCEINLINE const int4 & int4::operator^= (const int4& a) {
+    return *this = *this ^ a;
+}
+
+OIIO_FORCEINLINE int4 int4::operator~ () {
+#if defined(OIIO_SIMD_SSE)
+    // Fastest way to bit-complement in SSE is to xor with 0xffffffff.
+    // Fastest way to fill an __m128 with all 1 bits is to cmpeq_epi8
+    // any value to itself.
 # if defined(OIIO_SIMD_AVX) && (OIIO_GNUC_VERSION > 50000)
-        __m128i anyval = _mm_undefined_si128(); // AVX only, sigh
-        __m128i all_one_bits = _mm_cmpeq_epi8 (anyval, anyval);
+    __m128i anyval = _mm_undefined_si128(); // AVX only, sigh
+    __m128i all_one_bits = _mm_cmpeq_epi8 (anyval, anyval);
 # else
-        __m128i all_one_bits = _mm_cmpeq_epi8 (m_vec, m_vec);
+    __m128i all_one_bits = _mm_cmpeq_epi8 (m_vec, m_vec);
 # endif
-        return _mm_xor_si128 (m_vec, all_one_bits);
+    return _mm_xor_si128 (m_vec, all_one_bits);
 #else
-        SIMD_RETURN (int4, ~m_val[i]);
+    SIMD_RETURN (int4, ~m_val[i]);
 #endif
-    }
+}
 
-    OIIO_FORCEINLINE int4 operator<< (const unsigned int bits) const {
+OIIO_FORCEINLINE int4 int4::operator<< (const unsigned int bits) const {
 #if defined(OIIO_SIMD_SSE)
-        return _mm_slli_epi32 (m_vec, bits);
+    return _mm_slli_epi32 (m_vec, bits);
 #else
-        SIMD_RETURN (int4, m_val[i] << bits);
+    SIMD_RETURN (int4, m_val[i] << bits);
 #endif
-    }
+}
 
-    OIIO_FORCEINLINE const int4 & operator<<= (const unsigned int bits) {
-        return *this = *this << bits;
-    }
+OIIO_FORCEINLINE const int4 & int4::operator<<= (const unsigned int bits) {
+    return *this = *this << bits;
+}
 
-    // Arithmetic shift right (matches int>>, in that it preserves the
-    // sign bit).
-    OIIO_FORCEINLINE int4 operator>> (const unsigned int bits) {
+OIIO_FORCEINLINE int4 int4::operator>> (const unsigned int bits) {
 #if defined(OIIO_SIMD_SSE)
-        return _mm_srai_epi32 (m_vec, bits);
+    return _mm_srai_epi32 (m_vec, bits);
 #else
-        SIMD_RETURN (int4, m_val[i] >> bits);
+    SIMD_RETURN (int4, m_val[i] >> bits);
 #endif
-    }
+}
 
-    OIIO_FORCEINLINE const int4 & operator>>= (const unsigned int bits) {
-        return *this = *this >> bits;
-    }
+OIIO_FORCEINLINE const int4 & int4::operator>>= (const unsigned int bits) {
+    return *this = *this >> bits;
+}
 
-    // Shift right logical -- unsigned shift. This differs from operator>>
-    // in how it handles the sign bit.  (1<<31) >> 1 == (1<<31), but
-    // srl((1<<31),1) == 1<<30.
-    OIIO_FORCEINLINE friend int4 srl (const int4& val, const unsigned int bits) {
+OIIO_FORCEINLINE int4 srl (const int4& val, const unsigned int bits) {
 #if defined(OIIO_SIMD_SSE)
-        return _mm_srli_epi32 (val.m_vec, bits);
+    return _mm_srli_epi32 (val.m_vec, bits);
 #else
-        SIMD_RETURN (int4, int ((unsigned int)(val[i]) >> bits));
+    SIMD_RETURN (int4, int ((unsigned int)(val[i]) >> bits));
 #endif
-    }
+}
 
 
-    friend OIIO_FORCEINLINE mask4 operator== (const int4& a, const int4& b) {
+OIIO_FORCEINLINE mask4 operator== (const int4& a, const int4& b) {
 #if defined(OIIO_SIMD_SSE)
-        return _mm_castsi128_ps(_mm_cmpeq_epi32 (a.m_vec, b.m_vec));
+    return _mm_castsi128_ps(_mm_cmpeq_epi32 (a.m_vec, b.m_vec));
 #else
-        SIMD_RETURN (mask4, a[i] == b[i] ? -1 : 0);
+    SIMD_RETURN (mask4, a[i] == b[i] ? -1 : 0);
 #endif
-    }
+}
 
-    friend OIIO_FORCEINLINE mask4 operator!= (const int4& a, const int4& b) {
+OIIO_FORCEINLINE mask4 operator!= (const int4& a, const int4& b) {
         return ! (a == b);
-    }
+}
 
-    friend OIIO_FORCEINLINE mask4 operator< (const int4& a, const int4& b) {
+OIIO_FORCEINLINE mask4 operator< (const int4& a, const int4& b) {
 #if defined(OIIO_SIMD_SSE)
-        return _mm_castsi128_ps(_mm_cmplt_epi32 (a.m_vec, b.m_vec));
+    return _mm_castsi128_ps(_mm_cmplt_epi32 (a.m_vec, b.m_vec));
 #else
-        SIMD_RETURN (mask4, a[i] < b[i] ? -1 : 0);
+    SIMD_RETURN (mask4, a[i] < b[i] ? -1 : 0);
 #endif
-    }
+}
 
-    friend OIIO_FORCEINLINE mask4 operator>  (const int4& a, const int4& b) {
+OIIO_FORCEINLINE mask4 operator>  (const int4& a, const int4& b) {
 #if defined(OIIO_SIMD_SSE)
-        return _mm_castsi128_ps(_mm_cmpgt_epi32 (a.m_vec, b.m_vec));
+    return _mm_castsi128_ps(_mm_cmpgt_epi32 (a.m_vec, b.m_vec));
 #else
-        SIMD_RETURN (mask4, a[i] > b[i] ? -1 : 0);
+    SIMD_RETURN (mask4, a[i] > b[i] ? -1 : 0);
 #endif
-    }
+}
 
-    friend OIIO_FORCEINLINE mask4 operator>= (const int4& a, const int4& b) {
-        return !(a < b);
-    }
+OIIO_FORCEINLINE mask4 operator>= (const int4& a, const int4& b) {
+    return !(a < b);
+}
 
-    friend OIIO_FORCEINLINE mask4 operator<= (const int4& a, const int4& b) {
-        return !(a > b);
-    }
+OIIO_FORCEINLINE mask4 operator<= (const int4& a, const int4& b) {
+    return !(a > b);
+}
 
-    /// Stream output
-    friend inline std::ostream& operator<< (std::ostream& cout, const int4& val) {
-        cout << val[0];
-        for (int i = 1; i < elements; ++i)
-            cout << ' ' << val[i];
-        return cout;
-    }
-
-private:
-    // The actual data representation
-    union {
-        simd_t  m_vec;
-        value_t m_val[4];
-    };
-};
+inline std::ostream& operator<< (std::ostream& cout, const int4& val) {
+    cout << val[0];
+    for (int i = 1; i < val.elements; ++i)
+        cout << ' ' << val[i];
+    return cout;
+}
 
 
 
-/// Helper: shuffle/swizzle with constant (templated) indices.
-/// Example: shuffle<1,1,2,2>(mask4(a,b,c,d)) returns (b,b,c,c)
 template<int i0, int i1, int i2, int i3>
 OIIO_FORCEINLINE int4 shuffle (const int4& a) {
 #if defined(OIIO_SIMD_SSE)
@@ -1132,12 +2000,9 @@ OIIO_FORCEINLINE int4 shuffle (const int4& a) {
 #endif
 }
 
-/// shuffle<i>(a) is the same as shuffle<i,i,i,i>(a)
 template<int i> OIIO_FORCEINLINE int4 shuffle (const int4& a) { return shuffle<i,i,i,i>(a); }
 
 
-/// Helper: as rapid as possible extraction of one component, when the
-/// index is fixed.
 template<int i>
 OIIO_FORCEINLINE int extract (const int4& v) {
 #if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 4
@@ -1148,7 +2013,6 @@ OIIO_FORCEINLINE int extract (const int4& v) {
 }
 
 
-/// Helper: substitute val for a[i]
 template<int i>
 OIIO_FORCEINLINE int4 insert (const int4& a, int val) {
 #if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 4
@@ -1172,7 +2036,16 @@ OIIO_FORCEINLINE void int4::set_z (int val) { *this = insert<2>(*this, val); }
 OIIO_FORCEINLINE void int4::set_w (int val) { *this = insert<3>(*this, val); }
 
 
-/// The sum of all components, returned in all components.
+OIIO_FORCEINLINE int4 bitcast_to_int4 (const mask4& x)
+{
+#if defined(OIIO_SIMD_SSE)
+    return _mm_castps_si128 (x.simd());
+#else
+    return *(int4 *)&x;
+#endif
+}
+
+
 OIIO_FORCEINLINE int4 vreduce_add (const int4& v) {
 #if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 3
     // People seem to agree that SSE3 does add reduction best with 2
@@ -1199,7 +2072,6 @@ OIIO_FORCEINLINE int4 vreduce_add (const int4& v) {
 }
 
 
-/// The sum of all components, returned as a scalar.
 OIIO_FORCEINLINE int reduce_add (const int4& v) {
 #if defined(OIIO_SIMD_SSE)
     return _mm_cvtsi128_si32(vreduce_add(v));
@@ -1209,7 +2081,6 @@ OIIO_FORCEINLINE int reduce_add (const int4& v) {
 }
 
 
-/// Bitwise "and" of all components.
 OIIO_FORCEINLINE int reduce_and (const int4& v) {
 #if defined(OIIO_SIMD_SSE)
     // I think this is the best we can do for SSE, and I'm still not sure
@@ -1223,7 +2094,6 @@ OIIO_FORCEINLINE int reduce_and (const int4& v) {
 }
 
 
-/// Bitwise "or" of all components.
 OIIO_FORCEINLINE int reduce_or (const int4& v) {
 #if defined(OIIO_SIMD_SSE)
     // I think this is the best we can do for SSE, and I'm still not sure
@@ -1236,8 +2106,6 @@ OIIO_FORCEINLINE int reduce_or (const int4& v) {
 #endif
 }
 
-/// Use a mask to select between components of a (if mask[i] is false) and
-/// b (if mask[i] is true).
 OIIO_FORCEINLINE int4 blend (const int4& a, const int4& b, const mask4& mask)
 {
 #if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 4 /* SSE >= 4.1 */
@@ -1252,8 +2120,6 @@ OIIO_FORCEINLINE int4 blend (const int4& a, const int4& b, const mask4& mask)
 
 
 
-/// Use a mask to select between components of a (if mask[i] is true) or
-/// 0 (if mask[i] is true).
 OIIO_FORCEINLINE int4 blend0 (const int4& a, const mask4& mask)
 {
 #if defined(OIIO_SIMD_SSE)
@@ -1265,8 +2131,6 @@ OIIO_FORCEINLINE int4 blend0 (const int4& a, const mask4& mask)
 
 
 
-/// Use a mask to select between components of a (if mask[i] is FALSE) or
-/// 0 (if mask[i] is TRUE).
 OIIO_FORCEINLINE int4 blend0not (const int4& a, const mask4& mask)
 {
 #if defined(OIIO_SIMD_SSE)
@@ -1277,10 +2141,6 @@ OIIO_FORCEINLINE int4 blend0not (const int4& a, const mask4& mask)
 }
 
 
-
-/// Select 'a' where mask is true, 'b' where mask is false. Sure, it's a
-/// synonym for blend with arguments rearranged, but this is more clear
-/// because the arguments are symmetric to scalar (cond ? a : b).
 OIIO_FORCEINLINE int4 select (const mask4& mask, const int4& a, const int4& b)
 {
     return blend (b, a, mask);
@@ -1288,7 +2148,6 @@ OIIO_FORCEINLINE int4 select (const mask4& mask, const int4& a, const int4& b)
 
 
 
-/// Per-element absolute value.
 OIIO_FORCEINLINE int4 abs (const int4& a)
 {
 #if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 3
@@ -1298,7 +2157,6 @@ OIIO_FORCEINLINE int4 abs (const int4& a)
 #endif
 }
 
-/// Per-element min
 OIIO_FORCEINLINE int4 min (const int4& a, const int4& b)
 {
 #if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 4 /* SSE >= 4.1 */
@@ -1308,7 +2166,6 @@ OIIO_FORCEINLINE int4 min (const int4& a, const int4& b)
 #endif
 }
 
-/// Per-element max
 OIIO_FORCEINLINE int4 max (const int4& a, const int4& b)
 {
 #if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 4 /* SSE >= 4.1 */
@@ -1319,7 +2176,6 @@ OIIO_FORCEINLINE int4 max (const int4& a, const int4& b)
 }
 
 
-// Circular bit rotate by k bits, for 4 values at once.
 OIIO_FORCEINLINE int4 rotl32 (const int4& x, const unsigned int k)
 {
     return (x<<k) | srl(x,32-k);
@@ -1327,7 +2183,6 @@ OIIO_FORCEINLINE int4 rotl32 (const int4& x, const unsigned int k)
 
 
 
-/// andnot(a,b) returns ((~a) & b)
 OIIO_FORCEINLINE int4 andnot (const int4& a, const int4& b) {
 #if defined(OIIO_SIMD_SSE)
     return _mm_andnot_si128 (a.simd(), b.simd());
@@ -1335,804 +2190,6 @@ OIIO_FORCEINLINE int4 andnot (const int4& a, const int4& b) {
     SIMD_RETURN (int4, ~(a[i]) & b[i]);
 #endif
 }
-
-
-
-template<int i> OIIO_FORCEINLINE float4 insert (const float4& a, float val);
-
-
-
-
-/// Floating point 4-vector, accelerated by SIMD instructions when
-/// available.
-class float4 {
-public:
-    static const char* type_name() { return "float4"; }
-    typedef float value_t;    ///< Underlying equivalent scalar value type
-    typedef mask4 mask_t;     ///< SIMD mask type
-    enum { elements = 4 };    ///< Number of scalar elements
-    enum { paddedelements = 4 }; ///< Number of scalar elements for full pad
-    enum { bits = 128 };      ///< Total number of bits
-    typedef simd_raw_t<float,4>::type simd_t;  ///< the native SIMD type used
-
-    /// Default constructor (contents undefined)
-    OIIO_FORCEINLINE float4 () { }
-
-    /// Destructor
-    OIIO_FORCEINLINE ~float4 () { }
-
-    /// Construct from a single value (store it in all slots)
-    OIIO_FORCEINLINE float4 (float a) { load(a); }
-
-    /// Construct from 3 or 4 values
-    OIIO_FORCEINLINE float4 (float a, float b, float c, float d=0.0f) { load(a,b,c,d); }
-
-    /// Construct from a pointer to 4 values
-    OIIO_FORCEINLINE float4 (const float *f) { load (f); }
-
-    /// Copy construct from another float4
-    OIIO_FORCEINLINE float4 (const float4 &other) {
-#if defined(OIIO_SIMD_SSE) || defined(OIIO_SIMD_NEON)
-        m_vec = other.m_vec;
-#else
-        SIMD_CONSTRUCT (other[i]);
-#endif
-    }
-
-    /// Construct from an int4 (promoting all components to float)
-    OIIO_FORCEINLINE explicit float4 (const int4& ival) {
-#if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_cvtepi32_ps (ival.simd());
-#else
-        SIMD_CONSTRUCT (float(ival[i]));
-#endif
-    }
-
-    /// Construct from the underlying SIMD type
-    OIIO_FORCEINLINE float4 (const simd_t& m) : m_vec(m) { }
-
-    /// Return the raw SIMD type
-    OIIO_FORCEINLINE operator simd_t () const { return m_vec; }
-    OIIO_FORCEINLINE simd_t simd () const { return m_vec; }
-
-    /// Construct from a Imath::V3f
-    OIIO_FORCEINLINE float4 (const Imath::V3f &v) { load (v[0], v[1], v[2]); }
-
-    /// Cast to a Imath::V3f
-    OIIO_FORCEINLINE const Imath::V3f& V3f () const { return *(const Imath::V3f*)this; }
-
-#if defined(ILMBASE_VERSION_MAJOR) && ILMBASE_VERSION_MAJOR >= 2
-    // V4f is not defined for older Ilmbase. It's certainly safe for 2.x.
-
-    /// Construct from a Imath::V4f
-    OIIO_FORCEINLINE float4 (const Imath::V4f &v) { load ((const float *)&v); }
-
-    /// Cast to a Imath::V4f
-    OIIO_FORCEINLINE const Imath::V4f& V4f () const { return *(const Imath::V4f*)this; }
-#endif
-
-    /// Construct from a pointer to 4 unsigned short values
-    OIIO_FORCEINLINE explicit float4 (const unsigned short *vals) { load(vals); }
-
-    /// Construct from a pointer to 4 short values
-    OIIO_FORCEINLINE explicit float4 (const short *vals) { load(vals); }
-
-    /// Construct from a pointer to 4 unsigned char values
-    OIIO_FORCEINLINE explicit float4 (const unsigned char *vals) { load(vals); }
-
-    /// Construct from a pointer to 4 char values
-    OIIO_FORCEINLINE explicit float4 (const char *vals) { load(vals); }
-
-#ifdef _HALF_H_
-    /// Construct from a pointer to 4 half (16 bit float) values
-    OIIO_FORCEINLINE explicit float4 (const half *vals) { load(vals); }
-#endif
-
-    /// Assign a single value to all components
-    OIIO_FORCEINLINE const float4 & operator= (float a) { load(a); return *this; }
-
-    /// Assign a float4
-    OIIO_FORCEINLINE const float4 & operator= (float4 other) {
-#if defined(OIIO_SIMD_SSE) || defined(OIIO_SIMD_NEON)
-        m_vec = other.m_vec;
-#else
-        SIMD_CONSTRUCT (other[i]);
-#endif
-        return *this;
-    }
-
-    /// Return a float4 with all components set to 0.0
-    static OIIO_FORCEINLINE const float4 Zero () {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_setzero_ps();
-#else
-        return float4(0.0f);
-#endif
-    }
-
-    /// Return a float4 with all components set to 1.0
-    static OIIO_FORCEINLINE const float4 One () { return float4(1.0f); }
-
-    /// Return a float4 with incremented components (e.g., 0.0,1.0,2.0,3.0).
-    /// Optional argument can give a non-zero starting point.
-    static OIIO_FORCEINLINE const float4 Iota (float value=0.0f) {
-        return float4(value,value+1.0f,value+2.0f,value+3.0f);
-    }
-
-    /// Set all components to 0.0
-    OIIO_FORCEINLINE void clear () {
-#if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_setzero_ps();
-#else
-        load (0.0f);
-#endif
-    }
-
-#if defined(ILMBASE_VERSION_MAJOR) && ILMBASE_VERSION_MAJOR >= 2
-    /// Assign from a Imath::V4f
-    OIIO_FORCEINLINE const float4 & operator= (const Imath::V4f &v) {
-        load ((const float *)&v);
-        return *this;
-    }
-#endif
-
-    /// Assign from a Imath::V3f
-    OIIO_FORCEINLINE const float4 & operator= (const Imath::V3f &v) {
-        load (v[0], v[1], v[2], 0.0f);
-        return *this;
-    }
-
-    /// Component access (set)
-    OIIO_FORCEINLINE float& operator[] (int i) {
-        DASSERT(i<elements);
-        return m_val[i];
-    }
-    /// Component access (get)
-    OIIO_FORCEINLINE float operator[] (int i) const {
-        DASSERT(i<elements);
-        return m_val[i];
-    }
-
-    OIIO_FORCEINLINE value_t x () const;
-    OIIO_FORCEINLINE value_t y () const;
-    OIIO_FORCEINLINE value_t z () const;
-    OIIO_FORCEINLINE value_t w () const;
-    OIIO_FORCEINLINE void set_x (value_t val);
-    OIIO_FORCEINLINE void set_y (value_t val);
-    OIIO_FORCEINLINE void set_z (value_t val);
-    OIIO_FORCEINLINE void set_w (value_t val);
-
-    /// Helper: load a single value into all components
-    OIIO_FORCEINLINE void load (float val) {
-#if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_set1_ps (val);
-#elif defined(OIIO_SIMD_NEON)
-        m_vec = vdupq_n_f32 (val);
-#else
-        SIMD_CONSTRUCT (val);
-#endif
-    }
-
-    /// Helper: load 3 or 4 values. (If 3 are supplied, the 4th will be 0.)
-    OIIO_FORCEINLINE void load (float a, float b, float c, float d=0.0f) {
-#if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_set_ps (d, c, b, a);
-#elif defined(OIIO_SIMD_NEON)
-        float values[4] = { a, b, c, d };
-        m_vec = vld1q_f32 (values);
-#else
-        m_val[0] = a;
-        m_val[1] = b;
-        m_val[2] = c;
-        m_val[3] = d;
-#endif
-    }
-
-    /// Load from an array of 4 values
-    OIIO_FORCEINLINE void load (const float *values) {
-#if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_loadu_ps (values);
-#elif defined(OIIO_SIMD_NEON)
-        m_vec = vld1q_f32 (values);
-#else
-        SIMD_CONSTRUCT (values[i]);
-#endif
-    }
-
-    /// Load from a partial array of <=4 values. Unassigned values are
-    /// undefined.
-    OIIO_FORCEINLINE void load (const float *values, int n) {
-#if defined(OIIO_SIMD_SSE)
-        switch (n) {
-        case 1:
-            m_vec = _mm_load_ss (values);
-            break;
-        case 2:
-            // Trickery: load one double worth of bits!
-            m_vec = _mm_castpd_ps (_mm_load_sd ((const double*)values));
-            break;
-        case 3:
-            m_vec = _mm_setr_ps (values[0], values[1], values[2], 0.0f);
-            // This looks wasteful, but benchmarks show that it's the
-            // fastest way to set 3 values with the 4th getting zero.
-            // Actually, gcc and clang both turn it into something more
-            // efficient than _mm_setr_ps. The version below looks smart,
-            // but was much more expensive as the _mm_setr_ps!
-            //   __m128 xy = _mm_castsi128_ps(_mm_loadl_epi64((const __m128i*)values));
-            //   m_vec = _mm_movelh_ps(xy, _mm_load_ss (values + 2));
-            break;
-        case 4:
-            m_vec = _mm_loadu_ps (values);
-            break;
-        default:
-            break;
-        }
-#elif defined(OIIO_SIMD_NEON)
-        switch (n) {
-        case 1: m_vec = vdupq_n_f32 (val);                    break;
-        case 2: load (values[0], values[1], 0.0f, 0.0f);      break;
-        case 3: load (values[0], values[1], values[2], 0.0f); break;
-        case 4: m_vec = vld1q_f32 (values);                   break;
-        default: break;
-        }
-#else
-        for (int i = 0; i < n; ++i)
-            m_val[i] = values[i];
-        for (int i = n; i < paddedelements; ++i)
-            m_val[i] = 0;
-#endif
-    }
-
-    /// Load from an array of 4 unsigned short values, convert to float
-    OIIO_FORCEINLINE void load (const unsigned short *values) {
-#if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 2
-        m_vec = _mm_cvtepi32_ps (int4(values).simd());
-        // You might guess that the following is faster, but it's NOT:
-        //   NO!  m_vec = _mm_cvtpu16_ps (*(__m64*)values);
-#else
-        SIMD_CONSTRUCT (values[i]);
-#endif
-    }
-
-    /// Load from an array of 4 short values, convert to float
-    OIIO_FORCEINLINE void load (const short *values) {
-#if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 2
-        m_vec = _mm_cvtepi32_ps (int4(values).simd());
-#else
-        SIMD_CONSTRUCT (values[i]);
-#endif
-    }
-
-    /// Load from an array of 4 unsigned char values, convert to float
-    OIIO_FORCEINLINE void load (const unsigned char *values) {
-#if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 2
-        m_vec = _mm_cvtepi32_ps (int4(values).simd());
-#else
-        SIMD_CONSTRUCT (values[i]);
-#endif
-    }
-
-    /// Load from an array of 4 char values, convert to float
-    OIIO_FORCEINLINE void load (const char *values) {
-#if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 2
-        m_vec = _mm_cvtepi32_ps (int4(values).simd());
-#else
-        SIMD_CONSTRUCT (values[i]);
-#endif
-    }
-
-#ifdef _HALF_H_
-    /// Load from an array of 4 half values, convert to float
-    OIIO_FORCEINLINE void load (const half *values) {
-#if defined(__F16C__) && defined(OIIO_SIMD_SSE)
-        /* Enabled 16 bit float instructions! */
-        __m128i a = _mm_castpd_si128 (_mm_load_sd ((const double *)values));
-        m_vec = _mm_cvtph_ps (a);
-#elif defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 2
-        // SSE half-to-float by Fabian "ryg" Giesen. Public domain.
-        // https://gist.github.com/rygorous/2144712
-        int4 h ((const unsigned short *)values);
-# define CONSTI(name) *(const __m128i *)&name
-# define CONSTF(name) *(const __m128 *)&name
-        OIIO_SIMD_UINT4_CONST(mask_nosign, 0x7fff);
-        OIIO_SIMD_UINT4_CONST(magic,       (254 - 15) << 23);
-        OIIO_SIMD_UINT4_CONST(was_infnan,  0x7bff);
-        OIIO_SIMD_UINT4_CONST(exp_infnan,  255 << 23);
-        __m128i mnosign     = CONSTI(mask_nosign);
-        __m128i expmant     = _mm_and_si128(mnosign, h);
-        __m128i justsign    = _mm_xor_si128(h, expmant);
-        __m128i expmant2    = expmant; // copy (just here for counting purposes)
-        __m128i shifted     = _mm_slli_epi32(expmant, 13);
-        __m128  scaled      = _mm_mul_ps(_mm_castsi128_ps(shifted), *(const __m128 *)&magic);
-        __m128i b_wasinfnan = _mm_cmpgt_epi32(expmant2, CONSTI(was_infnan));
-        __m128i sign        = _mm_slli_epi32(justsign, 16);
-        __m128  infnanexp   = _mm_and_ps(_mm_castsi128_ps(b_wasinfnan), CONSTF(exp_infnan));
-        __m128  sign_inf    = _mm_or_ps(_mm_castsi128_ps(sign), infnanexp);
-        __m128  final       = _mm_or_ps(scaled, sign_inf);
-        // ~11 SSE2 ops.
-        m_vec = final;
-# undef CONSTI
-# undef CONSTF
-#else /* No SIMD defined: */
-        SIMD_CONSTRUCT (values[i]);
-#endif
-    }
-#endif /* _HALF_H_ */
-
-    OIIO_FORCEINLINE void store (float *values) const {
-#if defined(OIIO_SIMD_SSE)
-        // Use an unaligned store -- it's just as fast when the memory turns
-        // out to be aligned, nearly as fast even when unaligned. Not worth
-        // the headache of using stores that require alignment.
-        _mm_storeu_ps (values, m_vec);
-#elif defined(OIIO_SIMD_NEON)
-        vst1q_f32 (values, m_vec);
-#else
-        SIMD_DO (values[i] = m_val[i]);
-#endif
-    }
-
-    /// Store the first n values into memory
-    OIIO_FORCEINLINE void store (float *values, int n) const {
-        DASSERT (n >= 0 && n <= 4);
-#if defined(OIIO_SIMD_SSE)
-        switch (n) {
-        case 1:
-            _mm_store_ss (values, m_vec);
-            break;
-        case 2:
-            // Trickery: store two floats as a double worth of bits
-            _mm_store_sd ((double*)values, _mm_castps_pd(m_vec));
-            break;
-        case 3:
-            values[0] = m_val[0];
-            values[1] = m_val[1];
-            values[2] = m_val[2];
-            // This looks wasteful, but benchmarks show that it's the
-            // fastest way to store 3 values, in benchmarks was faster than
-            // this, below:
-            //   _mm_store_sd ((double*)values, _mm_castps_pd(m_vec));
-            //   _mm_store_ss (values + 2, _mm_movehl_ps(m_vec,m_vec));
-            break;
-        case 4:
-            store (values);
-            break;
-        default:
-            break;
-        }
-#elif defined(OIIO_SIMD_NEON)
-        switch (n) {
-        case 1:
-            vst1q_lane_f32 (values, m_vec, 0);
-            break;
-        case 2:
-            vst1q_lane_f32 (values++, m_vec, 0);
-            vst1q_lane_f32 (values, m_vec, 1);
-            break;
-        case 3:
-            vst1q_lane_f32 (values++, m_vec, 0);
-            vst1q_lane_f32 (values++, m_vec, 1);
-            vst1q_lane_f32 (values, m_vec, 2);
-            break;
-        case 4:
-            vst1q_f32 (values, m_vec); break;
-        default:
-            break;
-        }
-#else
-        for (int i = 0; i < n; ++i)
-            values[i] = m_val[i];
-#endif
-    }
-
-#ifdef _HALF_H_
-    OIIO_FORCEINLINE void store (half *values) const {
-#if defined(__F16C__) && defined(OIIO_SIMD_SSE)
-        __m128i h = _mm_cvtps_ph (m_vec, (_MM_FROUND_TO_NEAREST_INT |_MM_FROUND_NO_EXC));
-        _mm_store_sd ((double *)values, _mm_castsi128_pd(h));
-#else
-        SIMD_DO (values[i] = m_val[i]);
-#endif
-    }
-#endif
-
-    friend OIIO_FORCEINLINE float4 operator+ (const float4& a, const float4& b) {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_add_ps (a.m_vec, b.m_vec);
-#elif defined(OIIO_SIMD_NEON)
-        return vaddq_f32 (a.m_vec, b.m_vec);
-#else
-        SIMD_RETURN (float4, a[i] + b[i]);
-#endif
-    }
-
-    OIIO_FORCEINLINE const float4 & operator+= (const float4& a) {
-#if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_add_ps (m_vec, a.m_vec);
-#elif defined(OIIO_SIMD_NEON)
-        m_vec = vaddq_f32 (m_vec, a.m_vec);
-#else
-        SIMD_DO (m_val[i] += a[i]);
-#endif
-        return *this;
-    }
-
-    OIIO_FORCEINLINE float4 operator- () const {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_sub_ps (_mm_setzero_ps(), m_vec);
-#elif defined(OIIO_SIMD_NEON)
-        return vsubq_f32 (Zero(), m_vec);
-#else
-        SIMD_RETURN (float4, -m_val[i]);
-#endif
-    }
-
-    friend OIIO_FORCEINLINE float4 operator- (const float4& a, const float4& b) {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_sub_ps (a.m_vec, b.m_vec);
-#elif defined(OIIO_SIMD_NEON)
-        return vsubq_f32 (a.m_vec, b.m_vec);
-#else
-        SIMD_RETURN (float4, a[i] - b[i]);
-#endif
-    }
-
-    OIIO_FORCEINLINE const float4 & operator-= (const float4& a) {
-#if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_sub_ps (m_vec, a.m_vec);
-#elif defined(OIIO_SIMD_NEON)
-        m_vec = vsubq_f32 (m_vec, a.m_vec);
-#else
-        SIMD_DO (m_val[i] -= a[i]);
-#endif
-        return *this;
-    }
-
-    friend OIIO_FORCEINLINE float4 operator* (const float4& a, const float4& b) {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_mul_ps (a.m_vec, b.m_vec);
-#elif defined(OIIO_SIMD_NEON)
-        return vmulq_f32 (a.m_vec, b.m_vec);
-#else
-        SIMD_RETURN (float4, a[i] * b[i]);
-#endif
-    }
-
-    OIIO_FORCEINLINE const float4 & operator*= (const float4& a) {
-#if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_mul_ps (m_vec, a.m_vec);
-#elif defined(OIIO_SIMD_NEON)
-        m_vec = vmulq_f32 (m_vec, a.m_vec);
-#else
-        SIMD_DO (m_val[i] *= a[i]);
-#endif
-        return *this;
-    }
-    OIIO_FORCEINLINE const float4 & operator*= (float val) {
-#if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_mul_ps (m_vec, _mm_set1_ps(val));
-#elif defined(OIIO_SIMD_NEON)
-        m_vec = vmulq_f32 (m_vec, vdupq_n_f32(val));
-#else
-        SIMD_DO (m_val[i] *= val);
-#endif
-        return *this;
-    }
-
-    friend OIIO_FORCEINLINE float4 operator/ (const float4& a, const float4& b) {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_div_ps (a.m_vec, b.m_vec);
-#else
-        SIMD_RETURN (float4, a[i] / b[i]);
-#endif
-    }
-    OIIO_FORCEINLINE const float4 & operator/= (const float4& a) {
-#if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_div_ps (m_vec, a.m_vec);
-#else
-        SIMD_DO (m_val[i] /= a[i]);
-#endif
-        return *this;
-    }
-    OIIO_FORCEINLINE const float4 & operator/= (float val) {
-#if defined(OIIO_SIMD_SSE)
-        m_vec = _mm_div_ps (m_vec, _mm_set1_ps(val));
-#else
-        SIMD_DO (m_val[i] /= val);
-#endif
-        return *this;
-    }
-
-    friend OIIO_FORCEINLINE mask_t operator== (const float4& a, const float4& b) {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_cmpeq_ps (a.m_vec, b.m_vec);
-#else
-        SIMD_RETURN (mask_t, a[i] == b[i] ? -1 : 0);
-#endif
-    }
-
-    friend OIIO_FORCEINLINE mask_t operator!= (const float4& a, const float4& b) {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_cmpneq_ps (a.m_vec, b.m_vec);
-#else
-        SIMD_RETURN (mask_t, a[i] != b[i] ? -1 : 0);
-#endif
-    }
-
-    friend OIIO_FORCEINLINE mask_t operator< (const float4& a, const float4& b) {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_cmplt_ps (a.m_vec, b.m_vec);
-#else
-        SIMD_RETURN (mask_t, a[i] < b[i] ? -1 : 0);
-#endif
-    }
-
-    friend OIIO_FORCEINLINE mask_t operator>  (const float4& a, const float4& b) {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_cmpgt_ps (a.m_vec, b.m_vec);
-#else
-        SIMD_RETURN (mask_t, a[i] > b[i] ? -1 : 0);
-#endif
-    }
-
-    friend OIIO_FORCEINLINE mask_t operator>= (const float4& a, const float4& b) {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_cmpge_ps (a.m_vec, b.m_vec);
-#else
-        SIMD_RETURN (mask_t, a[i] >= b[i] ? -1 : 0);
-#endif
-    }
-
-    friend OIIO_FORCEINLINE mask_t operator<= (const float4& a, const float4& b) {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_cmple_ps (a.m_vec, b.m_vec);
-#else
-        SIMD_RETURN (mask_t, a[i] <= b[i] ? -1 : 0);
-#endif
-    }
-
-    // Some oddball items that are handy
-
-    /// Combine the first two components of A with the first two components
-    /// of B.
-    friend OIIO_FORCEINLINE float4 AxyBxy (const float4& a, const float4& b) {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_movelh_ps (a.m_vec, b.m_vec);
-#else
-        return float4 (a[0], a[1], b[0], b[1]);
-#endif
-    }
-
-    /// Combine the first two components of A with the first two components
-    /// of B, but interleaved.
-    friend OIIO_FORCEINLINE float4 AxBxAyBy (const float4& a, const float4& b) {
-#if defined(OIIO_SIMD_SSE)
-        return _mm_unpacklo_ps (a.m_vec, b.m_vec);
-#else
-        return float4 (a[0], b[0], a[1], b[1]);
-#endif
-    }
-
-    /// Return xyz components, plus 0 for w
-    float4 xyz0 () const {
-        return insert<3>(*this, 0.0f);
-    }
-
-    /// Return xyz components, plus 1 for w
-    float4 xyz1 () const {
-        return insert<3>(*this, 1.0f);
-    }
-
-    /// Stream output
-    friend inline std::ostream& operator<< (std::ostream& cout, const float4& val) {
-        cout << val[0];
-        for (int i = 1; i < elements; ++i)
-            cout << ' ' << val[i];
-        return cout;
-    }
-
-protected:
-    // The actual data representation
-    union {
-        simd_t  m_vec;
-        value_t m_val[paddedelements];
-    };
-};
-
-
-
-
-/// Floating point 3-vector, aligned to be internally identical to a float4.
-/// The way it differs from float4 is that all of he load functions only
-/// load three values, and all the stores only store 3 values. The vast
-/// majority of ops just fall back to the float4 version, and so will
-/// operate on the 4th component, but we won't care about that results.
-class float3 : public float4 {
-public:
-    static const char* type_name() { return "float3"; }
-    enum { elements = 3 };    ///< Number of scalar elements
-    enum { paddedelements = 4 }; ///< Number of scalar elements for full pad
-
-    /// Default constructor (contents undefined)
-    OIIO_FORCEINLINE float3 () { }
-
-    /// Destructor
-    OIIO_FORCEINLINE ~float3 () { }
-
-    /// Construct from a single value (store it in all slots)
-    OIIO_FORCEINLINE float3 (float a) { load(a); }
-
-    /// Construct from 3 or 4 values
-    OIIO_FORCEINLINE float3 (float a, float b, float c) { float4::load(a,b,c); }
-
-    /// Construct from a pointer to 4 values
-    OIIO_FORCEINLINE float3 (const float *f) { load (f); }
-
-    /// Copy construct from another float3
-    OIIO_FORCEINLINE float3 (const float3 &other) {
-#if defined(OIIO_SIMD_SSE) || defined(OIIO_SIMD_NEON)
-        m_vec = other.m_vec;
-#else
-        SIMD_CONSTRUCT_PAD (other[i]);
-#endif
-    }
-
-    OIIO_FORCEINLINE explicit float3 (const float4 &other) {
-#if defined(OIIO_SIMD_SSE) || defined(OIIO_SIMD_NEON)
-        m_vec = other.simd();
-#else
-        SIMD_CONSTRUCT_PAD (other[i]);
-        m_val[3] = 0.0f;
-#endif
-    }
-
-#if OIIO_SIMD
-    /// Construct from the underlying SIMD type
-    OIIO_FORCEINLINE explicit float3 (const simd_t& m) : float4(m) { }
-#endif
-
-    /// Construct from a Imath::V3f
-    OIIO_FORCEINLINE float3 (const Imath::V3f &v) : float4(v) { }
-
-    /// Cast to a Imath::V3f
-    OIIO_FORCEINLINE const Imath::V3f& V3f () const { return *(const Imath::V3f*)this; }
-
-    /// Construct from a pointer to 4 unsigned short values
-    OIIO_FORCEINLINE explicit float3 (const unsigned short *vals) { load(vals); }
-
-    /// Construct from a pointer to 4 short values
-    OIIO_FORCEINLINE explicit float3 (const short *vals) { load(vals); }
-
-    /// Construct from a pointer to 4 unsigned char values
-    OIIO_FORCEINLINE explicit float3 (const unsigned char *vals) { load(vals); }
-
-    /// Construct from a pointer to 4 char values
-    OIIO_FORCEINLINE explicit float3 (const char *vals) { load(vals); }
-
-#ifdef _HALF_H_
-    /// Construct from a pointer to 4 half (16 bit float) values
-    OIIO_FORCEINLINE explicit float3 (const half *vals) { load(vals); }
-#endif
-
-    /// Assign a single value to all components
-    OIIO_FORCEINLINE const float3 & operator= (float a) { load(a); return *this; }
-
-    /// Return a float3 with all components set to 0.0
-    static OIIO_FORCEINLINE const float3 Zero () { return float3(float4::Zero()); }
-
-    /// Return a float3 with all components set to 1.0
-    static OIIO_FORCEINLINE const float3 One () { return float3(1.0f); }
-
-    /// Return a float3 with incremented components (e.g., 0.0,1.0,2.0,3.0).
-    /// Optional argument can give a non-zero starting point.
-    static OIIO_FORCEINLINE const float3 Iota (float value=0.0f) {
-        return float3(value,value+1.0f,value+2.0f);
-    }
-
-
-    /// Helper: load a single value into all components
-    OIIO_FORCEINLINE void load (float val) { float4::load (val, val, val, 0.0f); }
-
-    /// Load from an array of 4 values
-    OIIO_FORCEINLINE void load (const float *values) { float4::load (values, 3); }
-
-    /// Load from an array of 4 values
-    OIIO_FORCEINLINE void load (const float *values, int n) {
-        float4::load (values, n);
-    }
-
-    /// Load from an array of 4 unsigned short values, convert to float
-    OIIO_FORCEINLINE void load (const unsigned short *values) {
-        float4::load (float(values[0]), float(values[1]), float(values[2]));
-    }
-
-    /// Load from an array of 4 short values, convert to float
-    OIIO_FORCEINLINE void load (const short *values) {
-        float4::load (float(values[0]), float(values[1]), float(values[2]));
-    }
-
-    /// Load from an array of 4 unsigned char values, convert to float
-    OIIO_FORCEINLINE void load (const unsigned char *values) {
-        float4::load (float(values[0]), float(values[1]), float(values[2]));
-    }
-
-    /// Load from an array of 4 char values, convert to float
-    OIIO_FORCEINLINE void load (const char *values) {
-        float4::load (float(values[0]), float(values[1]), float(values[2]));
-    }
-
-#ifdef _HALF_H_
-    /// Load from an array of 4 half values, convert to float
-    OIIO_FORCEINLINE void load (const half *values) {
-        float4::load (float(values[0]), float(values[1]), float(values[2]));
-    }
-#endif /* _HALF_H_ */
-
-    OIIO_FORCEINLINE void store (float *values) const {
-        float4::store (values, 3);
-    }
-
-    OIIO_FORCEINLINE void store (float *values, int n) const {
-        float4::store (values, n);
-    }
-
-#ifdef _HALF_H_
-    OIIO_FORCEINLINE void store (half *values) const {
-        SIMD_DO (values[i] = m_val[i]);
-    }
-#endif
-
-    /// Store into an Imath::V3f reference.
-    OIIO_FORCEINLINE void store (Imath::V3f &vec) const {
-        store ((float *)&vec);
-    }
-
-    // Math operators -- define in terms of float3.
-    friend OIIO_FORCEINLINE float3 operator+ (const float3& a, const float3& b) {
-        return float3 (float4(a) + float4(b));
-    }
-    OIIO_FORCEINLINE const float3 & operator+= (const float3& a) {
-        *this = *this + a; return *this;
-    }
-    OIIO_FORCEINLINE float3 operator- () const { return float3 (-float4(*this)); }
-    friend OIIO_FORCEINLINE float3 operator- (const float3& a, const float3& b) {
-        return float3 (float4(a) - float4(b));
-    }
-    OIIO_FORCEINLINE const float3 & operator-= (const float3& a) {
-        *this = *this - a; return *this;
-    }
-    friend OIIO_FORCEINLINE float3 operator* (const float3& a, const float3& b) {
-        return float3 (float4(a) * float4(b));
-    }
-    OIIO_FORCEINLINE const float3 & operator*= (const float3& a) {
-        *this = *this * a; return *this;
-    }
-    OIIO_FORCEINLINE const float3 & operator*= (float a) {
-        *this = *this * a; return *this;
-    }
-    friend OIIO_FORCEINLINE float3 operator/ (const float3& a, const float3& b) {
-        return float3 (float4(a) / b.xyz1()); // Avoid divide by zero!
-    }
-    OIIO_FORCEINLINE const float3 & operator/= (const float3& a) {
-        *this = *this / a; return *this;
-    }
-    OIIO_FORCEINLINE const float3 & operator/= (float a) {
-        *this = *this / a; return *this;
-    }
-
-    OIIO_FORCEINLINE float3 normalized () const;
-    OIIO_FORCEINLINE float3 normalized_fast () const;
-
-    /// Stream output
-    friend inline std::ostream& operator<< (std::ostream& cout, const float3& val) {
-        cout << val[0];
-        for (int i = 1; i < elements; ++i)
-            cout << ' ' << val[i];
-        return cout;
-    }
-};
-
-
 
 
 // Implementation had to be after the definition of int4.
@@ -2143,6 +2200,489 @@ OIIO_FORCEINLINE mask4::mask4 (const int4& ival)
 #else
     SIMD_CONSTRUCT (ival[i] ? -1 : 0);
 #endif
+}
+
+
+
+
+//////////////////////////////////////////////////////////////////////
+// float4 implementation
+
+
+OIIO_FORCEINLINE float4::float4 (const int4& ival) {
+#if defined(OIIO_SIMD_SSE)
+    m_vec = _mm_cvtepi32_ps (ival.simd());
+#else
+    SIMD_CONSTRUCT (float(ival[i]));
+#endif
+}
+
+
+OIIO_FORCEINLINE const float4 float4::Zero () {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_setzero_ps();
+#else
+    return float4(0.0f);
+#endif
+}
+
+OIIO_FORCEINLINE const float4 float4::One () {
+    return float4(1.0f);
+}
+
+OIIO_FORCEINLINE const float4 float4::Iota (float value) {
+    return float4(value,value+1.0f,value+2.0f,value+3.0f);
+}
+
+    /// Set all components to 0.0
+OIIO_FORCEINLINE void float4::clear () {
+#if defined(OIIO_SIMD_SSE)
+    m_vec = _mm_setzero_ps();
+#else
+    load (0.0f);
+#endif
+}
+
+#if defined(ILMBASE_VERSION_MAJOR) && ILMBASE_VERSION_MAJOR >= 2
+OIIO_FORCEINLINE const float4 & float4::operator= (const Imath::V4f &v) {
+    load ((const float *)&v);
+    return *this;
+}
+#endif
+
+OIIO_FORCEINLINE const float4 & float4::operator= (const Imath::V3f &v) {
+    load (v[0], v[1], v[2], 0.0f);
+    return *this;
+}
+
+OIIO_FORCEINLINE float& float4::operator[] (int i) {
+    DASSERT(i<elements);
+    return m_val[i];
+}
+
+OIIO_FORCEINLINE float float4::operator[] (int i) const {
+    DASSERT(i<elements);
+    return m_val[i];
+}
+
+
+OIIO_FORCEINLINE void float4::load (float val) {
+#if defined(OIIO_SIMD_SSE)
+    m_vec = _mm_set1_ps (val);
+#elif defined(OIIO_SIMD_NEON)
+    m_vec = vdupq_n_f32 (val);
+#else
+    SIMD_CONSTRUCT (val);
+#endif
+}
+
+OIIO_FORCEINLINE void float4::load (float a, float b, float c, float d) {
+#if defined(OIIO_SIMD_SSE)
+    m_vec = _mm_set_ps (d, c, b, a);
+#elif defined(OIIO_SIMD_NEON)
+    float values[4] = { a, b, c, d };
+    m_vec = vld1q_f32 (values);
+#else
+    m_val[0] = a;
+    m_val[1] = b;
+    m_val[2] = c;
+    m_val[3] = d;
+#endif
+}
+
+    /// Load from an array of 4 values
+OIIO_FORCEINLINE void float4::load (const float *values) {
+#if defined(OIIO_SIMD_SSE)
+    m_vec = _mm_loadu_ps (values);
+#elif defined(OIIO_SIMD_NEON)
+    m_vec = vld1q_f32 (values);
+#else
+    SIMD_CONSTRUCT (values[i]);
+#endif
+}
+
+    /// Load from a partial array of <=4 values. Unassigned values are
+    /// undefined.
+OIIO_FORCEINLINE void float4::load (const float *values, int n) {
+#if defined(OIIO_SIMD_SSE)
+    switch (n) {
+    case 1:
+        m_vec = _mm_load_ss (values);
+        break;
+    case 2:
+        // Trickery: load one double worth of bits!
+        m_vec = _mm_castpd_ps (_mm_load_sd ((const double*)values));
+        break;
+    case 3:
+        m_vec = _mm_setr_ps (values[0], values[1], values[2], 0.0f);
+        // This looks wasteful, but benchmarks show that it's the
+        // fastest way to set 3 values with the 4th getting zero.
+        // Actually, gcc and clang both turn it into something more
+        // efficient than _mm_setr_ps. The version below looks smart,
+        // but was much more expensive as the _mm_setr_ps!
+        //   __m128 xy = _mm_castsi128_ps(_mm_loadl_epi64((const __m128i*)values));
+        //   m_vec = _mm_movelh_ps(xy, _mm_load_ss (values + 2));
+        break;
+    case 4:
+        m_vec = _mm_loadu_ps (values);
+        break;
+    default:
+        break;
+    }
+#elif defined(OIIO_SIMD_NEON)
+    switch (n) {
+    case 1: m_vec = vdupq_n_f32 (val);                    break;
+    case 2: load (values[0], values[1], 0.0f, 0.0f);      break;
+    case 3: load (values[0], values[1], values[2], 0.0f); break;
+    case 4: m_vec = vld1q_f32 (values);                   break;
+    default: break;
+    }
+#else
+    for (int i = 0; i < n; ++i)
+        m_val[i] = values[i];
+    for (int i = n; i < paddedelements; ++i)
+        m_val[i] = 0;
+#endif
+}
+
+    /// Load from an array of 4 unsigned short values, convert to float
+OIIO_FORCEINLINE void float4::load (const unsigned short *values) {
+#if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 2
+    m_vec = _mm_cvtepi32_ps (int4(values).simd());
+    // You might guess that the following is faster, but it's NOT:
+    //   NO!  m_vec = _mm_cvtpu16_ps (*(__m64*)values);
+#else
+    SIMD_CONSTRUCT (values[i]);
+#endif
+}
+
+    /// Load from an array of 4 short values, convert to float
+OIIO_FORCEINLINE void float4::load (const short *values) {
+#if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 2
+    m_vec = _mm_cvtepi32_ps (int4(values).simd());
+#else
+    SIMD_CONSTRUCT (values[i]);
+#endif
+}
+
+    /// Load from an array of 4 unsigned char values, convert to float
+OIIO_FORCEINLINE void float4::load (const unsigned char *values) {
+#if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 2
+    m_vec = _mm_cvtepi32_ps (int4(values).simd());
+#else
+    SIMD_CONSTRUCT (values[i]);
+#endif
+}
+
+    /// Load from an array of 4 char values, convert to float
+OIIO_FORCEINLINE void float4::load (const char *values) {
+#if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 2
+    m_vec = _mm_cvtepi32_ps (int4(values).simd());
+#else
+    SIMD_CONSTRUCT (values[i]);
+#endif
+}
+
+#ifdef _HALF_H_
+OIIO_FORCEINLINE void float4::load (const half *values) {
+#if defined(__F16C__) && defined(OIIO_SIMD_SSE)
+    /* Enabled 16 bit float instructions! */
+    __m128i a = _mm_castpd_si128 (_mm_load_sd ((const double *)values));
+    m_vec = _mm_cvtph_ps (a);
+#elif defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 2
+    // SSE half-to-float by Fabian "ryg" Giesen. Public domain.
+    // https://gist.github.com/rygorous/2144712
+    int4 h ((const unsigned short *)values);
+# define CONSTI(name) *(const __m128i *)&name
+# define CONSTF(name) *(const __m128 *)&name
+    OIIO_SIMD_UINT4_CONST(mask_nosign, 0x7fff);
+    OIIO_SIMD_UINT4_CONST(magic,       (254 - 15) << 23);
+    OIIO_SIMD_UINT4_CONST(was_infnan,  0x7bff);
+    OIIO_SIMD_UINT4_CONST(exp_infnan,  255 << 23);
+    __m128i mnosign     = CONSTI(mask_nosign);
+    __m128i expmant     = _mm_and_si128(mnosign, h);
+    __m128i justsign    = _mm_xor_si128(h, expmant);
+    __m128i expmant2    = expmant; // copy (just here for counting purposes)
+    __m128i shifted     = _mm_slli_epi32(expmant, 13);
+    __m128  scaled      = _mm_mul_ps(_mm_castsi128_ps(shifted), *(const __m128 *)&magic);
+    __m128i b_wasinfnan = _mm_cmpgt_epi32(expmant2, CONSTI(was_infnan));
+    __m128i sign        = _mm_slli_epi32(justsign, 16);
+    __m128  infnanexp   = _mm_and_ps(_mm_castsi128_ps(b_wasinfnan), CONSTF(exp_infnan));
+    __m128  sign_inf    = _mm_or_ps(_mm_castsi128_ps(sign), infnanexp);
+    __m128  final       = _mm_or_ps(scaled, sign_inf);
+    // ~11 SSE2 ops.
+    m_vec = final;
+# undef CONSTI
+# undef CONSTF
+#else /* No SIMD defined: */
+    SIMD_CONSTRUCT (values[i]);
+#endif
+}
+#endif /* _HALF_H_ */
+
+OIIO_FORCEINLINE void float4::store (float *values) const {
+#if defined(OIIO_SIMD_SSE)
+    // Use an unaligned store -- it's just as fast when the memory turns
+    // out to be aligned, nearly as fast even when unaligned. Not worth
+    // the headache of using stores that require alignment.
+    _mm_storeu_ps (values, m_vec);
+#elif defined(OIIO_SIMD_NEON)
+    vst1q_f32 (values, m_vec);
+#else
+    SIMD_DO (values[i] = m_val[i]);
+#endif
+}
+
+OIIO_FORCEINLINE void float4::store (float *values, int n) const {
+    DASSERT (n >= 0 && n <= 4);
+#if defined(OIIO_SIMD_SSE)
+    switch (n) {
+        case 1:
+        _mm_store_ss (values, m_vec);
+        break;
+    case 2:
+        // Trickery: store two floats as a double worth of bits
+        _mm_store_sd ((double*)values, _mm_castps_pd(m_vec));
+        break;
+    case 3:
+        values[0] = m_val[0];
+        values[1] = m_val[1];
+        values[2] = m_val[2];
+        // This looks wasteful, but benchmarks show that it's the
+        // fastest way to store 3 values, in benchmarks was faster than
+        // this, below:
+        //   _mm_store_sd ((double*)values, _mm_castps_pd(m_vec));
+        //   _mm_store_ss (values + 2, _mm_movehl_ps(m_vec,m_vec));
+        break;
+    case 4:
+        store (values);
+        break;
+    default:
+        break;
+    }
+#elif defined(OIIO_SIMD_NEON)
+    switch (n) {
+    case 1:
+        vst1q_lane_f32 (values, m_vec, 0);
+        break;
+    case 2:
+        vst1q_lane_f32 (values++, m_vec, 0);
+        vst1q_lane_f32 (values, m_vec, 1);
+        break;
+    case 3:
+        vst1q_lane_f32 (values++, m_vec, 0);
+        vst1q_lane_f32 (values++, m_vec, 1);
+        vst1q_lane_f32 (values, m_vec, 2);
+        break;
+    case 4:
+        vst1q_f32 (values, m_vec); break;
+    default:
+        break;
+    }
+#else
+    for (int i = 0; i < n; ++i)
+        values[i] = m_val[i];
+#endif
+}
+
+#ifdef _HALF_H_
+OIIO_FORCEINLINE void float4::store (half *values) const {
+#if defined(__F16C__) && defined(OIIO_SIMD_SSE)
+    __m128i h = _mm_cvtps_ph (m_vec, (_MM_FROUND_TO_NEAREST_INT |_MM_FROUND_NO_EXC));
+    _mm_store_sd ((double *)values, _mm_castsi128_pd(h));
+    #else
+    SIMD_DO (values[i] = m_val[i]);
+#endif
+}
+#endif
+
+OIIO_FORCEINLINE float4 operator+ (const float4& a, const float4& b) {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_add_ps (a.m_vec, b.m_vec);
+#elif defined(OIIO_SIMD_NEON)
+    return vaddq_f32 (a.m_vec, b.m_vec);
+#else
+    SIMD_RETURN (float4, a[i] + b[i]);
+#endif
+}
+
+OIIO_FORCEINLINE const float4 & float4::operator+= (const float4& a) {
+#if defined(OIIO_SIMD_SSE)
+    m_vec = _mm_add_ps (m_vec, a.m_vec);
+#elif defined(OIIO_SIMD_NEON)
+    m_vec = vaddq_f32 (m_vec, a.m_vec);
+#else
+    SIMD_DO (m_val[i] += a[i]);
+#endif
+    return *this;
+    }
+
+OIIO_FORCEINLINE float4 float4::operator- () const {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_sub_ps (_mm_setzero_ps(), m_vec);
+#elif defined(OIIO_SIMD_NEON)
+    return vsubq_f32 (Zero(), m_vec);
+#else
+    SIMD_RETURN (float4, -m_val[i]);
+#endif
+}
+
+OIIO_FORCEINLINE float4 operator- (const float4& a, const float4& b) {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_sub_ps (a.m_vec, b.m_vec);
+#elif defined(OIIO_SIMD_NEON)
+    return vsubq_f32 (a.m_vec, b.m_vec);
+#else
+    SIMD_RETURN (float4, a[i] - b[i]);
+#endif
+}
+
+OIIO_FORCEINLINE const float4 & float4::operator-= (const float4& a) {
+#if defined(OIIO_SIMD_SSE)
+    m_vec = _mm_sub_ps (m_vec, a.m_vec);
+#elif defined(OIIO_SIMD_NEON)
+    m_vec = vsubq_f32 (m_vec, a.m_vec);
+#else
+    SIMD_DO (m_val[i] -= a[i]);
+#endif
+    return *this;
+}
+
+OIIO_FORCEINLINE float4 operator* (const float4& a, const float4& b) {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_mul_ps (a.m_vec, b.m_vec);
+#elif defined(OIIO_SIMD_NEON)
+    return vmulq_f32 (a.m_vec, b.m_vec);
+#else
+    SIMD_RETURN (float4, a[i] * b[i]);
+#endif
+}
+
+OIIO_FORCEINLINE const float4 & float4::operator*= (const float4& a) {
+#if defined(OIIO_SIMD_SSE)
+    m_vec = _mm_mul_ps (m_vec, a.m_vec);
+#elif defined(OIIO_SIMD_NEON)
+    m_vec = vmulq_f32 (m_vec, a.m_vec);
+#else
+    SIMD_DO (m_val[i] *= a[i]);
+#endif
+    return *this;
+}
+
+OIIO_FORCEINLINE const float4 & float4::operator*= (float val) {
+#if defined(OIIO_SIMD_SSE)
+    m_vec = _mm_mul_ps (m_vec, _mm_set1_ps(val));
+#elif defined(OIIO_SIMD_NEON)
+    m_vec = vmulq_f32 (m_vec, vdupq_n_f32(val));
+#else
+    SIMD_DO (m_val[i] *= val);
+#endif
+    return *this;
+}
+
+OIIO_FORCEINLINE float4 operator/ (const float4& a, const float4& b) {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_div_ps (a.m_vec, b.m_vec);
+#else
+    SIMD_RETURN (float4, a[i] / b[i]);
+#endif
+}
+
+OIIO_FORCEINLINE const float4 & float4::operator/= (const float4& a) {
+#if defined(OIIO_SIMD_SSE)
+    m_vec = _mm_div_ps (m_vec, a.m_vec);
+#else
+    SIMD_DO (m_val[i] /= a[i]);
+#endif
+    return *this;
+}
+
+OIIO_FORCEINLINE const float4 & float4::operator/= (float val) {
+#if defined(OIIO_SIMD_SSE)
+    m_vec = _mm_div_ps (m_vec, _mm_set1_ps(val));
+#else
+    SIMD_DO (m_val[i] /= val);
+#endif
+    return *this;
+}
+
+OIIO_FORCEINLINE mask4 operator== (const float4& a, const float4& b) {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_cmpeq_ps (a.m_vec, b.m_vec);
+#else
+    SIMD_RETURN (mask4, a[i] == b[i] ? -1 : 0);
+#endif
+}
+
+OIIO_FORCEINLINE mask4 operator!= (const float4& a, const float4& b) {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_cmpneq_ps (a.m_vec, b.m_vec);
+#else
+    SIMD_RETURN (mask4, a[i] != b[i] ? -1 : 0);
+#endif
+}
+
+OIIO_FORCEINLINE mask4 operator< (const float4& a, const float4& b) {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_cmplt_ps (a.m_vec, b.m_vec);
+#else
+    SIMD_RETURN (mask4, a[i] < b[i] ? -1 : 0);
+#endif
+}
+
+OIIO_FORCEINLINE mask4 operator>  (const float4& a, const float4& b) {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_cmpgt_ps (a.m_vec, b.m_vec);
+#else
+    SIMD_RETURN (mask4, a[i] > b[i] ? -1 : 0);
+#endif
+}
+
+OIIO_FORCEINLINE mask4 operator>= (const float4& a, const float4& b) {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_cmpge_ps (a.m_vec, b.m_vec);
+#else
+    SIMD_RETURN (mask4, a[i] >= b[i] ? -1 : 0);
+#endif
+}
+
+OIIO_FORCEINLINE mask4 operator<= (const float4& a, const float4& b) {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_cmple_ps (a.m_vec, b.m_vec);
+#else
+    SIMD_RETURN (mask4, a[i] <= b[i] ? -1 : 0);
+#endif
+}
+
+OIIO_FORCEINLINE float4 AxyBxy (const float4& a, const float4& b) {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_movelh_ps (a.m_vec, b.m_vec);
+#else
+    return float4 (a[0], a[1], b[0], b[1]);
+#endif
+}
+
+OIIO_FORCEINLINE float4 AxBxAyBy (const float4& a, const float4& b) {
+#if defined(OIIO_SIMD_SSE)
+    return _mm_unpacklo_ps (a.m_vec, b.m_vec);
+#else
+    return float4 (a[0], b[0], a[1], b[1]);
+#endif
+}
+
+OIIO_FORCEINLINE float4 float4::xyz0 () const {
+    return insert<3>(*this, 0.0f);
+}
+
+OIIO_FORCEINLINE float4 float4::xyz1 () const {
+    return insert<3>(*this, 1.0f);
+}
+
+inline std::ostream& operator<< (std::ostream& cout, const float4& val) {
+    cout << val[0];
+    for (int i = 1; i < val.elements; ++i)
+        cout << ' ' << val[i];
+    return cout;
 }
 
 
@@ -2157,8 +2697,7 @@ OIIO_FORCEINLINE int4::int4 (const float4& f)
 }
 
 
-/// Helper: shuffle/swizzle with constant (templated) indices.
-/// Example: shuffle<1,1,2,2>(mask4(a,b,c,d)) returns (b,b,c,c)
+
 template<int i0, int i1, int i2, int i3>
 OIIO_FORCEINLINE float4 shuffle (const float4& a) {
 #if defined(OIIO_SIMD_SSE)
@@ -2168,7 +2707,6 @@ OIIO_FORCEINLINE float4 shuffle (const float4& a) {
 #endif
 }
 
-/// shuffle<i>(a) is the same as shuffle<i,i,i,i>(a)
 template<int i> OIIO_FORCEINLINE float4 shuffle (const float4& a) { return shuffle<i,i,i,i>(a); }
 
 #if defined(OIIO_SIMD_NEON)
@@ -2236,15 +2774,6 @@ OIIO_FORCEINLINE void float4::set_z (float val) { *this = insert<2>(*this, val);
 OIIO_FORCEINLINE void float4::set_w (float val) { *this = insert<3>(*this, val); }
 
 
-OIIO_FORCEINLINE int4 bitcast_to_int4 (const mask4& x)
-{
-#if defined(OIIO_SIMD_SSE)
-    return _mm_castps_si128 (x.simd());
-#else
-    return *(int4 *)&x;
-#endif
-}
-
 OIIO_FORCEINLINE int4 bitcast_to_int4 (const float4& x)
 {
 #if defined(OIIO_SIMD_SSE)
@@ -2264,7 +2793,6 @@ OIIO_FORCEINLINE float4 bitcast_to_float4 (const int4& x)
 }
 
 
-/// The sum of all components, returned in all components.
 OIIO_FORCEINLINE float4 vreduce_add (const float4& v) {
 #if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 3
     // People seem to agree that SSE3 does add reduction best with 2
@@ -2291,7 +2819,6 @@ OIIO_FORCEINLINE float4 vreduce_add (const float4& v) {
 }
 
 
-/// The sum of all components, returned as a scalar.
 OIIO_FORCEINLINE float reduce_add (const float4& v) {
 #if defined(OIIO_SIMD_SSE)
     return _mm_cvtss_f32(vreduce_add (v));
@@ -2300,19 +2827,6 @@ OIIO_FORCEINLINE float reduce_add (const float4& v) {
 #endif
 }
 
-
-
-/// The sum of all components, returned in all components.
-OIIO_FORCEINLINE float3 vreduce_add (const float3& v) {
-#if defined(OIIO_SIMD_SSE)
-    return float3 ((vreduce_add(float4(v))).xyz0());
-#else
-    return float3 (v[0] + v[1] + v[2]);
-#endif
-}
-
-
-/// Return the float dot (inner) product of a and b in every component.
 OIIO_FORCEINLINE float4 vdot (const float4 &a, const float4 &b) {
 #if OIIO_SIMD_SSE >= 4
     return _mm_dp_ps (a.simd(), b.simd(), 0xff);
@@ -2325,8 +2839,6 @@ OIIO_FORCEINLINE float4 vdot (const float4 &a, const float4 &b) {
 #endif
 }
 
-
-/// Return the float dot (inner) product of a and b.
 OIIO_FORCEINLINE float dot (const float4 &a, const float4 &b) {
 #if OIIO_SIMD_SSE >= 4
     return _mm_cvtss_f32 (_mm_dp_ps (a.simd(), b.simd(), 0xff));
@@ -2335,29 +2847,6 @@ OIIO_FORCEINLINE float dot (const float4 &a, const float4 &b) {
 #endif
 }
 
-
-/// Return the float dot (inner) product of a and b in every component.
-OIIO_FORCEINLINE float3 vdot (const float3 &a, const float3 &b) {
-#if OIIO_SIMD_SSE >= 4
-    return float3(_mm_dp_ps (a.simd(), b.simd(), 0x77));
-#else
-    return vreduce_add (a*b);
-#endif
-}
-
-
-/// Return the float dot (inner) product of a and b.
-OIIO_FORCEINLINE float dot (const float3 &a, const float3 &b) {
-#if OIIO_SIMD_SSE >= 4
-    return _mm_cvtss_f32 (_mm_dp_ps (a.simd(), b.simd(), 0x77));
-#else
-    return reduce_add (a*b);
-#endif
-}
-
-
-/// Return the float 3-component dot (inner) product of a and b in
-/// all components.
 OIIO_FORCEINLINE float4 vdot3 (const float4 &a, const float4 &b) {
 #if OIIO_SIMD_SSE >= 4
     return _mm_dp_ps (a.simd(), b.simd(), 0x7f);
@@ -2366,17 +2855,6 @@ OIIO_FORCEINLINE float4 vdot3 (const float4 &a, const float4 &b) {
 #endif
 }
 
-/// Return the float 3-component dot (inner) product of a and b in
-/// all components.
-OIIO_FORCEINLINE float3 vdot3 (const float3 &a, const float3 &b) {
-#if OIIO_SIMD_SSE >= 4
-    return float3(_mm_dp_ps (a.simd(), b.simd(), 0x77));
-#else
-    return float3 (vreduce_add((a*b).xyz0()).xyz0());
-#endif
-}
-
-/// Return the float 3-component dot (inner) product of a and b.
 OIIO_FORCEINLINE float dot3 (const float4 &a, const float4 &b) {
 #if OIIO_SIMD_SSE >= 4
     return _mm_cvtss_f32 (_mm_dp_ps (a.simd(), b.simd(), 0x77));
@@ -2386,9 +2864,6 @@ OIIO_FORCEINLINE float dot3 (const float4 &a, const float4 &b) {
 }
 
 
-
-/// Use a mask to select between components of a (if mask[i] is false) and
-/// b (if mask[i] is true).
 OIIO_FORCEINLINE float4 blend (const float4& a, const float4& b, const mask4& mask)
 {
 #if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 4
@@ -2407,8 +2882,6 @@ OIIO_FORCEINLINE float4 blend (const float4& a, const float4& b, const mask4& ma
 }
 
 
-/// Use a mask to select between components of a (if mask[i] is true) or
-/// 0 (if mask[i] is true).
 OIIO_FORCEINLINE float4 blend0 (const float4& a, const mask4& mask)
 {
 #if defined(OIIO_SIMD_SSE)
@@ -2422,9 +2895,6 @@ OIIO_FORCEINLINE float4 blend0 (const float4& a, const mask4& mask)
 }
 
 
-
-/// Use a mask to select between components of a (if mask[i] is FALSE) or
-/// 0 (if mask[i] is TRUE).
 OIIO_FORCEINLINE float4 blend0not (const float4& a, const mask4& mask)
 {
 #if defined(OIIO_SIMD_SSE)
@@ -2438,9 +2908,6 @@ OIIO_FORCEINLINE float4 blend0not (const float4& a, const mask4& mask)
 }
 
 
-
-/// "Safe" divide of float4/float4 -- for any component of the divisor
-/// that is 0, return 0 rather than Inf.
 OIIO_FORCEINLINE float4 safe_div (const float4 &a, const float4 &b) {
 #if defined(OIIO_SIMD_SSE)
     return blend0not (a/b, b == float4::Zero());
@@ -2453,8 +2920,6 @@ OIIO_FORCEINLINE float4 safe_div (const float4 &a, const float4 &b) {
 }
 
 
-
-/// Homogeneous divide to turn a float4 into a float3.
 OIIO_FORCEINLINE float3 hdiv (const float4 &a)
 {
 #if defined(OIIO_SIMD_SSE)
@@ -2467,17 +2932,12 @@ OIIO_FORCEINLINE float3 hdiv (const float4 &a)
 
 
 
-/// Select 'a' where mask is true, 'b' where mask is false. Sure, it's a
-/// synonym for blend with arguments rearranged, but this is more clear
-/// because the arguments are symmetric to scalar (cond ? a : b).
 OIIO_FORCEINLINE float4 select (const mask4& mask, const float4& a, const float4& b)
 {
     return blend (b, a, mask);
 }
 
 
-
-/// Per-element absolute value.
 OIIO_FORCEINLINE float4 abs (const float4& a)
 {
 #if defined(OIIO_SIMD_SSE)
@@ -2489,8 +2949,6 @@ OIIO_FORCEINLINE float4 abs (const float4& a)
 }
 
 
-
-/// Return 1.0 for each component >= 0, -1.0 for each negative component.
 OIIO_FORCEINLINE float4 sign (const float4& a)
 {
     float4 one(1.0f);
@@ -2498,8 +2956,6 @@ OIIO_FORCEINLINE float4 sign (const float4& a)
 }
 
 
-
-/// Per-element ceil.
 OIIO_FORCEINLINE float4 ceil (const float4& a)
 {
 #if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 4  /* SSE >= 4.1 */
@@ -2509,7 +2965,6 @@ OIIO_FORCEINLINE float4 ceil (const float4& a)
 #endif
 }
 
-/// Per-element floor.
 OIIO_FORCEINLINE float4 floor (const float4& a)
 {
 #if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 4  /* SSE >= 4.1 */
@@ -2519,8 +2974,6 @@ OIIO_FORCEINLINE float4 floor (const float4& a)
 #endif
 }
 
-/// Per-element round to nearest integer (rounding away from 0 in cases
-/// that are exactly half way).
 OIIO_FORCEINLINE float4 round (const float4& a)
 {
 #if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 4  /* SSE >= 4.1 */
@@ -2530,7 +2983,6 @@ OIIO_FORCEINLINE float4 round (const float4& a)
 #endif
 }
 
-/// Per-element (int)floor.
 OIIO_FORCEINLINE int4 floori (const float4& a)
 {
 #if defined(OIIO_SIMD_SSE) && OIIO_SIMD_SSE >= 4  /* SSE >= 4.1 */
@@ -2548,8 +3000,7 @@ OIIO_FORCEINLINE int4 floori (const float4& a)
 #endif
 }
 
-/// Per-element round to nearest integer (rounding away from 0 in cases
-/// that are exactly half way).
+
 OIIO_FORCEINLINE int4 rint (const float4& a)
 {
     return int4 (round(a));
@@ -2557,7 +3008,6 @@ OIIO_FORCEINLINE int4 rint (const float4& a)
 
 
 
-/// Compute the per-component sqrt.
 OIIO_FORCEINLINE float4 sqrt (const float4 &a)
 {
 #if OIIO_SIMD_SSE
@@ -2569,7 +3019,6 @@ OIIO_FORCEINLINE float4 sqrt (const float4 &a)
 
 
 
-/// Compute the per-component sqrt, fully accurate.
 OIIO_FORCEINLINE float4 rsqrt (const float4 &a)
 {
 #if OIIO_SIMD_SSE
@@ -2582,7 +3031,6 @@ OIIO_FORCEINLINE float4 rsqrt (const float4 &a)
 
 
 
-/// Compute the per-component approximate reciprocal sqrt.
 OIIO_FORCEINLINE float4 rsqrt_fast (const float4 &a)
 {
 #if OIIO_SIMD_SSE
@@ -2595,34 +3043,6 @@ OIIO_FORCEINLINE float4 rsqrt_fast (const float4 &a)
 
 
 
-OIIO_FORCEINLINE float3 float3::normalized () const
-{
-#if OIIO_SIMD
-    float3 len2 = vdot3 (*this, *this);
-    return float3 (safe_div (*this, sqrt(len2)));
-#else
-    float len2 = dot (*this, *this);
-    return len2 > 0.0f ? (*this) / sqrtf(len2) : float3::Zero();
-#endif
-}
-
-
-
-OIIO_FORCEINLINE float3 float3::normalized_fast () const
-{
-#if OIIO_SIMD
-    float3 len2 = vdot3 (*this, *this);
-    float4 invlen = blend0not (rsqrt_fast (len2), len2 == float4::Zero());
-    return float3 ((*this) * invlen);
-#else
-    float len2 = dot (*this, *this);
-    return len2 > 0.0f ? (*this) / sqrtf(len2) : float3::Zero();
-#endif
-}
-
-
-
-/// Per-element min
 OIIO_FORCEINLINE float4 min (const float4& a, const float4& b)
 {
 #if defined(OIIO_SIMD_SSE)
@@ -2635,7 +3055,6 @@ OIIO_FORCEINLINE float4 min (const float4& a, const float4& b)
 #endif
 }
 
-/// Per-element max
 OIIO_FORCEINLINE float4 max (const float4& a, const float4& b)
 {
 #if defined(OIIO_SIMD_SSE)
@@ -2650,7 +3069,6 @@ OIIO_FORCEINLINE float4 max (const float4& a, const float4& b)
 
 
 
-/// andnot(a,b) returns ((~a) & b)
 OIIO_FORCEINLINE float4 andnot (const float4& a, const float4& b) {
 #if defined(OIIO_SIMD_SSE)
     return _mm_andnot_ps (a.simd(), b.simd());
@@ -2666,7 +3084,6 @@ OIIO_FORCEINLINE float4 andnot (const float4& a, const float4& b) {
 
 
 
-/// Fused multiply and add: (a*b + c)
 OIIO_FORCEINLINE float4 madd (const simd::float4& a, const simd::float4& b,
                               const simd::float4& c)
 {
@@ -2685,7 +3102,6 @@ OIIO_FORCEINLINE float4 madd (const simd::float4& a, const simd::float4& b,
 }
 
 
-/// Fused multiply and subtract: (a*b - c)
 OIIO_FORCEINLINE float4 msub (const simd::float4& a, const simd::float4& b,
                               const simd::float4& c)
 {
@@ -2705,7 +3121,6 @@ OIIO_FORCEINLINE float4 msub (const simd::float4& a, const simd::float4& b,
 
 
 
-/// Fused negative multiply and add: -(a*b) + c
 OIIO_FORCEINLINE float4 nmadd (const simd::float4& a, const simd::float4& b,
                                const simd::float4& c)
 {
@@ -2725,7 +3140,6 @@ OIIO_FORCEINLINE float4 nmadd (const simd::float4& a, const simd::float4& b,
 
 
 
-/// Fused negative multiply and subtract: -(a*b) - c
 OIIO_FORCEINLINE float4 nmsub (const simd::float4& a, const simd::float4& b,
                                const simd::float4& c)
 {
@@ -2864,9 +3278,6 @@ OIIO_FORCEINLINE float4 log (const float4& v)
 
 
 
-/// Transpose the rows and columns of the 4x4 matrix [a b c d].
-/// In the end, a will have the original (a[0], b[0], c[0], d[0]),
-/// b will have the original (a[1], b[1], c[1], d[1]), and so on.
 OIIO_FORCEINLINE void transpose (float4 &a, float4 &b, float4 &c, float4 &d)
 {
 #if defined(OIIO_SIMD_SSE)
@@ -2879,7 +3290,6 @@ OIIO_FORCEINLINE void transpose (float4 &a, float4 &b, float4 &c, float4 &d)
     a = A;  b = B;  c = C;  d = D;
 #endif
 }
-
 
 
 OIIO_FORCEINLINE void transpose (const float4& a, const float4& b, const float4& c, const float4& d,
@@ -2904,9 +3314,6 @@ OIIO_FORCEINLINE void transpose (const float4& a, const float4& b, const float4&
 }
 
 
-/// Transpose the rows and columns of the 4x4 matrix [a b c d].
-/// In the end, a will have the original (a[0], b[0], c[0], d[0]),
-/// b will have the original (a[1], b[1], c[1], d[1]), and so on.
 OIIO_FORCEINLINE void transpose (int4 &a, int4 &b, int4 &c, int4 &d)
 {
 #if defined(OIIO_SIMD_SSE)
@@ -2951,8 +3358,6 @@ OIIO_FORCEINLINE void transpose (const int4& a, const int4& b, const int4& c, co
 }
 
 
-
-/// Make a float4 consisting of the first element of each of 4 float4's.
 OIIO_FORCEINLINE float4 AxBxCxDx (const float4& a, const float4& b,
                                   const float4& c, const float4& d)
 {
@@ -2966,7 +3371,6 @@ OIIO_FORCEINLINE float4 AxBxCxDx (const float4& a, const float4& b,
 }
 
 
-/// Make an int4 consisting of the first element of each of 4 int4's.
 OIIO_FORCEINLINE int4 AxBxCxDx (const int4& a, const int4& b,
                                 const int4& c, const int4& d)
 {
@@ -2981,270 +3385,397 @@ OIIO_FORCEINLINE int4 AxBxCxDx (const int4& a, const int4& b,
 
 
 
-/// SIMD-based 4x4 matrix. This is guaranteed to have memory layout (when
-/// not in registers) isomorphic to Imath::M44f.
-class matrix44 {
-public:
-    // Uninitialized
-    matrix44 ()
-    #ifndef OIIO_SIMD_SSE
-        : m_mat(Imath::UNINITIALIZED)
-    #endif
-     { }
+//////////////////////////////////////////////////////////////////////
+// float3 implementation
 
-    /// Construct from a reference to an Imath::M44f
-    matrix44 (const Imath::M44f &M) {
-    #if OIIO_SIMD_SSE
-        m_row[0].load (M[0]);
-        m_row[1].load (M[1]);
-        m_row[2].load (M[2]);
-        m_row[3].load (M[3]);
-    #else
-        m_mat = M;
-    #endif
-    }
-
-    /// Construct from a float array
-    explicit matrix44 (const float *f) {
-    #if OIIO_SIMD_SSE
-        m_row[0].load (f+0);
-        m_row[1].load (f+4);
-        m_row[2].load (f+8);
-        m_row[3].load (f+12);
-    #else
-        memcpy (&m_mat, f, 16*sizeof(float));
-    #endif
-    }
-
-    /// Construct from 4 float4 rows
-    explicit matrix44 (float4 a, float4 b, float4 c, float4 d) {
-    #if OIIO_SIMD_SSE
-        m_row[0] = a; m_row[1] = b; m_row[2] = c; m_row[3] = d;
-    #else
-        a.store (m_mat[0]);
-        b.store (m_mat[1]);
-        c.store (m_mat[2]);
-        d.store (m_mat[3]);
-    #endif
-    }
-
-    /// Construct from 4 float[4] rows
-    explicit matrix44 (const float *a, const float *b,
-                       const float *c, const float *d) {
-    #if OIIO_SIMD_SSE
-        m_row[0].load(a); m_row[1].load(b); m_row[2].load(c); m_row[3].load(d);
-    #else
-        memcpy (m_mat[0], a, 4*sizeof(float));
-        memcpy (m_mat[1], b, 4*sizeof(float));
-        memcpy (m_mat[2], c, 4*sizeof(float));
-        memcpy (m_mat[3], d, 4*sizeof(float));
-    #endif
-    }
-
-    /// Present as an Imath::M44f
-    const Imath::M44f& M44f() const { return *(Imath::M44f*)this; }
-
-    /// Return one row
-    float4 operator[] (int i) const {
-    #if OIIO_SIMD_SSE
-        return m_row[i];
-    #else
-        return float4 (m_mat[i]);
-    #endif
-    }
-
-    /// Return the transposed matrix
-    OIIO_FORCEINLINE matrix44 transposed () const {
-        matrix44 T;
-    #if OIIO_SIMD_SSE
-        simd::transpose (m_row[0], m_row[1], m_row[2], m_row[3],
-                         T.m_row[0], T.m_row[1], T.m_row[2], T.m_row[3]);
-    #else
-        T = m_mat.transposed();
-    #endif
-        return T;
-    }
-
-    /// Transform 3-point V by 4x4 matrix M.
-    OIIO_FORCEINLINE float3 transformp (const float3 &V) const {
-    #if OIIO_SIMD_SSE
-        float4 R = shuffle<0>(V) * m_row[0] + shuffle<1>(V) * m_row[1] +
-                   shuffle<2>(V) * m_row[2] + m_row[3];
-        R = R / shuffle<3>(R);
-        return float3 (R.xyz0());
-    #else
-        Imath::V3f R;
-        m_mat.multVecMatrix (*(Imath::V3f *)&V, R);
-        return float3(R);
-    #endif
-    }
-
-    /// Transform 3-vector V by 4x4 matrix M.
-    OIIO_FORCEINLINE float3 transformv (const float3 &V) const {
-    #if OIIO_SIMD_SSE
-        float4 R = shuffle<0>(V) * m_row[0] + shuffle<1>(V) * m_row[1] +
-                   shuffle<2>(V) * m_row[2];
-        return float3 (R.xyz0());
-    #else
-        Imath::V3f R;
-        m_mat.multDirMatrix (*(Imath::V3f *)&V, R);
-        return float3(R);
-    #endif
-    }
-
-    /// Transform 3-vector V by the transpose of 4x4 matrix M.
-    OIIO_FORCEINLINE float3 transformvT (const float3 &V) const {
-    #if OIIO_SIMD_SSE
-        matrix44 T = transposed();
-        float4 R = shuffle<0>(V) * T[0] + shuffle<1>(V) * T[1] +
-                   shuffle<2>(V) * T[2];
-        return float3 (R.xyz0());
-    #else
-        Imath::V3f R;
-        m_mat.transposed().multDirMatrix (*(Imath::V3f *)&V, R);
-        return float3(R);
-    #endif
-    }
-
-    OIIO_FORCEINLINE bool operator== (const matrix44& m) const {
-    #if OIIO_SIMD_SSE
-        mask4 b0 = (m_row[0] == m[0]);
-        mask4 b1 = (m_row[1] == m[1]);
-        mask4 b2 = (m_row[2] == m[2]);
-        mask4 b3 = (m_row[3] == m[3]);
-        return simd::all (b0 & b1 & b2 & b3);
-    #else
-        return memcmp(this, &m, 16*sizeof(float)) == 0;
-    #endif
-    }
-
-    OIIO_FORCEINLINE bool operator== (const Imath::M44f& m) const {
-        return memcmp(this, &m, 16*sizeof(float)) == 0;
-    }
-    friend OIIO_FORCEINLINE bool operator== (const Imath::M44f& a, const matrix44 &b) {
-        return (b == a);
-    }
-
-    OIIO_FORCEINLINE bool operator!= (const matrix44& m) const {
-    #if OIIO_SIMD_SSE
-        mask4 b0 = (m_row[0] != m[0]);
-        mask4 b1 = (m_row[1] != m[1]);
-        mask4 b2 = (m_row[2] != m[2]);
-        mask4 b3 = (m_row[3] != m[3]);
-        return simd::any (b0 | b1 | b2 | b3);
-    #else
-        return memcmp(this, &m, 16*sizeof(float)) != 0;
-    #endif
-    }
-
-    OIIO_FORCEINLINE bool operator!= (const Imath::M44f& m) const {
-        return memcmp(this, &m, 16*sizeof(float)) != 0;
-    }
-    friend OIIO_FORCEINLINE bool operator!= (const Imath::M44f& a, const matrix44 &b) {
-        return (b != a);
-    }
-
-    OIIO_FORCEINLINE matrix44 inverse() const {
-    #if OIIO_SIMD_SSE
-        // Adapted from this code from Intel:
-        // ftp://download.intel.com/design/pentiumiii/sml/24504301.pdf
-        float4 minor0, minor1, minor2, minor3;
-        float4 row0, row1, row2, row3;
-        float4 det, tmp1;
-        const float *src = (const float *)this;
-        float4 zero = float4::Zero();
-        tmp1 = _mm_loadh_pi(_mm_loadl_pi(zero, (__m64*)(src)), (__m64*)(src+ 4));
-        row1 = _mm_loadh_pi(_mm_loadl_pi(zero, (__m64*)(src+8)), (__m64*)(src+12));
-        row0 = _mm_shuffle_ps(tmp1, row1, 0x88);
-        row1 = _mm_shuffle_ps(row1, tmp1, 0xDD);
-        tmp1 = _mm_loadh_pi(_mm_loadl_pi(tmp1, (__m64*)(src+ 2)), (__m64*)(src+ 6));
-        row3 = _mm_loadh_pi(_mm_loadl_pi(zero, (__m64*)(src+10)), (__m64*)(src+14));
-        row2 = _mm_shuffle_ps(tmp1, row3, 0x88);
-        row3 = _mm_shuffle_ps(row3, tmp1, 0xDD);
-        // -----------------------------------------------
-        tmp1 = row2 * row3;
-        tmp1 = shuffle<1,0,3,2>(tmp1);
-        minor0 = row1 * tmp1;
-        minor1 = row0 * tmp1;
-        tmp1 = shuffle<2,3,0,1>(tmp1);
-        minor0 = (row1 * tmp1) - minor0;
-        minor1 = (row0 * tmp1) - minor1;
-        minor1 = shuffle<2,3,0,1>(minor1);
-        // -----------------------------------------------
-        tmp1 = row1 * row2;
-        tmp1 = shuffle<1,0,3,2>(tmp1);
-        minor0 = (row3 * tmp1) + minor0;
-        minor3 = row0 * tmp1;
-        tmp1 = shuffle<2,3,0,1>(tmp1);
-        minor0 = minor0 - (row3 * tmp1);
-        minor3 = (row0 * tmp1) - minor3;
-        minor3 = shuffle<2,3,0,1>(minor3);
-        // -----------------------------------------------
-        tmp1 = shuffle<2,3,0,1>(row1) * row3;
-        tmp1 = shuffle<1,0,3,2>(tmp1);
-        row2 = shuffle<2,3,0,1>(row2);
-        minor0 = (row2 * tmp1) + minor0;
-        minor2 = row0 * tmp1;
-        tmp1 = shuffle<2,3,0,1>(tmp1);
-        minor0 = minor0 - (row2 * tmp1);
-        minor2 = (row0 * tmp1) - minor2;
-        minor2 = shuffle<2,3,0,1>(minor2);
-        // -----------------------------------------------
-        tmp1 = row0 * row1;
-        tmp1 = shuffle<1,0,3,2>(tmp1);
-        minor2 = (row3 * tmp1) + minor2;
-        minor3 = (row2 * tmp1) - minor3;
-        tmp1 = shuffle<2,3,0,1>(tmp1);
-        minor2 = (row3 * tmp1) - minor2;
-        minor3 = minor3 - (row2 * tmp1);
-        // -----------------------------------------------
-        tmp1 = row0 * row3;
-        tmp1 = shuffle<1,0,3,2>(tmp1);
-        minor1 = minor1 - (row2 * tmp1);
-        minor2 = (row1 * tmp1) + minor2;
-        tmp1 = shuffle<2,3,0,1>(tmp1);
-        minor1 = (row2 * tmp1) + minor1;
-        minor2 = minor2 - (row1 * tmp1);
-        // -----------------------------------------------
-        tmp1 = row0 * row2;
-        tmp1 = shuffle<1,0,3,2>(tmp1);
-        minor1 = (row3 * tmp1) + minor1;
-        minor3 = minor3 - (row1 * tmp1);
-        tmp1 = shuffle<2,3,0,1>(tmp1);
-        minor1 = minor1 - (row3 * tmp1);
-        minor3 = (row1 * tmp1) + minor3;
-        // -----------------------------------------------
-        det = row0 * minor0;
-        det = shuffle<2,3,0,1>(det) + det;
-        det = _mm_add_ss(shuffle<1,0,3,2>(det), det);
-        tmp1 = _mm_rcp_ss(det);
-        det = _mm_sub_ss(_mm_add_ss(tmp1, tmp1), _mm_mul_ss(det, _mm_mul_ss(tmp1, tmp1)));
-        det = shuffle<0>(det);
-        return matrix44 (det*minor0, det*minor1, det*minor2, det*minor3);
-    #else
-        return m_mat.inverse();
-    #endif
-    }
-    /// Stream output
-    friend inline std::ostream& operator<< (std::ostream& cout, const matrix44 &M) {
-        const float *m = (const float *)&M;
-        cout << m[0];
-        for (int i = 1; i < 16; ++i)
-            cout << ' ' << m[i];
-        return cout;
-    }
-
-private:
-#if OIIO_SIMD_SSE
-    float4 m_row[4];
+OIIO_FORCEINLINE float3::float3 (const float3 &other) {
+#if defined(OIIO_SIMD_SSE) || defined(OIIO_SIMD_NEON)
+    m_vec = other.m_vec;
 #else
-    Imath::M44f m_mat;
+    SIMD_CONSTRUCT_PAD (other[i]);
 #endif
-};
+}
+
+OIIO_FORCEINLINE float3::float3 (const float4 &other) {
+#if defined(OIIO_SIMD_SSE) || defined(OIIO_SIMD_NEON)
+    m_vec = other.simd();
+#else
+    SIMD_CONSTRUCT_PAD (other[i]);
+    m_val[3] = 0.0f;
+#endif
+}
+
+OIIO_FORCEINLINE const float3 float3::Zero () { return float3(float4::Zero()); }
+
+OIIO_FORCEINLINE const float3 float3::One () { return float3(1.0f); }
+
+OIIO_FORCEINLINE const float3 float3::Iota (float value) {
+    return float3(value,value+1.0f,value+2.0f);
+}
+
+
+OIIO_FORCEINLINE void float3::load (float val) { float4::load (val, val, val, 0.0f); }
+
+OIIO_FORCEINLINE void float3::load (const float *values) { float4::load (values, 3); }
+
+OIIO_FORCEINLINE void float3::load (const float *values, int n) {
+    float4::load (values, n);
+}
+
+OIIO_FORCEINLINE void float3::load (const unsigned short *values) {
+    float4::load (float(values[0]), float(values[1]), float(values[2]));
+}
+
+OIIO_FORCEINLINE void float3::load (const short *values) {
+    float4::load (float(values[0]), float(values[1]), float(values[2]));
+}
+
+OIIO_FORCEINLINE void float3::load (const unsigned char *values) {
+    float4::load (float(values[0]), float(values[1]), float(values[2]));
+}
+
+OIIO_FORCEINLINE void float3::load (const char *values) {
+    float4::load (float(values[0]), float(values[1]), float(values[2]));
+}
+
+#ifdef _HALF_H_
+OIIO_FORCEINLINE void float3::load (const half *values) {
+    float4::load (float(values[0]), float(values[1]), float(values[2]));
+}
+#endif /* _HALF_H_ */
+
+OIIO_FORCEINLINE void float3::store (float *values) const {
+    float4::store (values, 3);
+}
+
+OIIO_FORCEINLINE void float3::store (float *values, int n) const {
+    float4::store (values, n);
+}
+
+#ifdef _HALF_H_
+OIIO_FORCEINLINE void float3::store (half *values) const {
+    SIMD_DO (values[i] = m_val[i]);
+}
+#endif
+
+OIIO_FORCEINLINE void float3::store (Imath::V3f &vec) const {
+    store ((float *)&vec);
+}
+
+OIIO_FORCEINLINE float3 operator+ (const float3& a, const float3& b) {
+    return float3 (float4(a) + float4(b));
+}
+
+OIIO_FORCEINLINE const float3 & float3::operator+= (const float3& a) {
+    *this = *this + a; return *this;
+}
+
+OIIO_FORCEINLINE float3 float3::operator- () const {
+    return float3 (-float4(*this));
+}
+
+OIIO_FORCEINLINE float3 operator- (const float3& a, const float3& b) {
+    return float3 (float4(a) - float4(b));
+}
+
+OIIO_FORCEINLINE const float3 & float3::operator-= (const float3& a) {
+    *this = *this - a; return *this;
+}
+
+OIIO_FORCEINLINE float3 operator* (const float3& a, const float3& b) {
+    return float3 (float4(a) * float4(b));
+}
+
+OIIO_FORCEINLINE const float3 & float3::operator*= (const float3& a) {
+    *this = *this * a; return *this;
+}
+
+OIIO_FORCEINLINE const float3 & float3::operator*= (float a) {
+    *this = *this * a; return *this;
+}
+
+OIIO_FORCEINLINE float3 operator/ (const float3& a, const float3& b) {
+    return float3 (float4(a) / b.xyz1()); // Avoid divide by zero!
+}
+
+OIIO_FORCEINLINE const float3 & float3::operator/= (const float3& a) {
+    *this = *this / a; return *this;
+}
+
+OIIO_FORCEINLINE const float3 & float3::operator/= (float a) {
+    *this = *this / a; return *this;
+}
+
+
+inline std::ostream& operator<< (std::ostream& cout, const float3& val) {
+    cout << val[0];
+    for (int i = 1; i < val.elements; ++i)
+        cout << ' ' << val[i];
+    return cout;
+}
+
+
+OIIO_FORCEINLINE float3 vreduce_add (const float3& v) {
+#if defined(OIIO_SIMD_SSE)
+    return float3 ((vreduce_add(float4(v))).xyz0());
+#else
+    return float3 (v[0] + v[1] + v[2]);
+#endif
+}
+
+
+OIIO_FORCEINLINE float3 vdot (const float3 &a, const float3 &b) {
+#if OIIO_SIMD_SSE >= 4
+    return float3(_mm_dp_ps (a.simd(), b.simd(), 0x77));
+#else
+    return vreduce_add (a*b);
+#endif
+}
+
+
+OIIO_FORCEINLINE float dot (const float3 &a, const float3 &b) {
+#if OIIO_SIMD_SSE >= 4
+    return _mm_cvtss_f32 (_mm_dp_ps (a.simd(), b.simd(), 0x77));
+#else
+    return reduce_add (a*b);
+#endif
+}
+
+
+OIIO_FORCEINLINE float3 vdot3 (const float3 &a, const float3 &b) {
+#if OIIO_SIMD_SSE >= 4
+    return float3(_mm_dp_ps (a.simd(), b.simd(), 0x77));
+#else
+    return float3 (vreduce_add((a*b).xyz0()).xyz0());
+#endif
+}
+
+OIIO_FORCEINLINE float3 float3::normalized () const
+{
+#if OIIO_SIMD
+    float3 len2 = vdot3 (*this, *this);
+    return float3 (safe_div (*this, sqrt(len2)));
+#else
+    float len2 = dot (*this, *this);
+    return len2 > 0.0f ? (*this) / sqrtf(len2) : float3::Zero();
+#endif
+}
+
+
+OIIO_FORCEINLINE float3 float3::normalized_fast () const
+{
+#if OIIO_SIMD
+    float3 len2 = vdot3 (*this, *this);
+    float4 invlen = blend0not (rsqrt_fast (len2), len2 == float4::Zero());
+    return float3 ((*this) * invlen);
+#else
+    float len2 = dot (*this, *this);
+    return len2 > 0.0f ? (*this) / sqrtf(len2) : float3::Zero();
+#endif
+}
 
 
 
-/// Transform 3-point V by 4x4 matrix M.
+//////////////////////////////////////////////////////////////////////
+// matrix44 implementation
+
+
+OIIO_FORCEINLINE const Imath::M44f& matrix44::M44f() const {
+    return *(Imath::M44f*)this;
+}
+
+
+OIIO_FORCEINLINE float4 matrix44::operator[] (int i) const {
+#if OIIO_SIMD_SSE
+    return m_row[i];
+#else
+    return float4 (m_mat[i]);
+#endif
+}
+
+
+OIIO_FORCEINLINE matrix44 matrix44::transposed () const {
+    matrix44 T;
+#if OIIO_SIMD_SSE
+    simd::transpose (m_row[0], m_row[1], m_row[2], m_row[3],
+                     T.m_row[0], T.m_row[1], T.m_row[2], T.m_row[3]);
+#else
+    T = m_mat.transposed();
+#endif
+    return T;
+}
+
+OIIO_FORCEINLINE float3 matrix44::transformp (const float3 &V) const {
+#if OIIO_SIMD_SSE
+    float4 R = shuffle<0>(V) * m_row[0] + shuffle<1>(V) * m_row[1] +
+               shuffle<2>(V) * m_row[2] + m_row[3];
+    R = R / shuffle<3>(R);
+    return float3 (R.xyz0());
+#else
+    Imath::V3f R;
+    m_mat.multVecMatrix (*(Imath::V3f *)&V, R);
+    return float3(R);
+#endif
+}
+
+OIIO_FORCEINLINE float3 matrix44::transformv (const float3 &V) const {
+#if OIIO_SIMD_SSE
+    float4 R = shuffle<0>(V) * m_row[0] + shuffle<1>(V) * m_row[1] +
+               shuffle<2>(V) * m_row[2];
+    return float3 (R.xyz0());
+#else
+    Imath::V3f R;
+    m_mat.multDirMatrix (*(Imath::V3f *)&V, R);
+    return float3(R);
+#endif
+}
+
+OIIO_FORCEINLINE float3 matrix44::transformvT (const float3 &V) const {
+#if OIIO_SIMD_SSE
+    matrix44 T = transposed();
+    float4 R = shuffle<0>(V) * T[0] + shuffle<1>(V) * T[1] +
+               shuffle<2>(V) * T[2];
+    return float3 (R.xyz0());
+#else
+    Imath::V3f R;
+    m_mat.transposed().multDirMatrix (*(Imath::V3f *)&V, R);
+    return float3(R);
+#endif
+}
+
+OIIO_FORCEINLINE bool matrix44::operator== (const matrix44& m) const {
+#if OIIO_SIMD_SSE
+    mask4 b0 = (m_row[0] == m[0]);
+    mask4 b1 = (m_row[1] == m[1]);
+    mask4 b2 = (m_row[2] == m[2]);
+    mask4 b3 = (m_row[3] == m[3]);
+    return simd::all (b0 & b1 & b2 & b3);
+#else
+    return memcmp(this, &m, 16*sizeof(float)) == 0;
+#endif
+}
+
+OIIO_FORCEINLINE bool matrix44::operator== (const Imath::M44f& m) const {
+    return memcmp(this, &m, 16*sizeof(float)) == 0;
+}
+
+OIIO_FORCEINLINE bool operator== (const Imath::M44f& a, const matrix44 &b) {
+    return (b == a);
+}
+
+OIIO_FORCEINLINE bool matrix44::operator!= (const matrix44& m) const {
+#if OIIO_SIMD_SSE
+    mask4 b0 = (m_row[0] != m[0]);
+    mask4 b1 = (m_row[1] != m[1]);
+    mask4 b2 = (m_row[2] != m[2]);
+    mask4 b3 = (m_row[3] != m[3]);
+    return simd::any (b0 | b1 | b2 | b3);
+#else
+    return memcmp(this, &m, 16*sizeof(float)) != 0;
+#endif
+}
+
+OIIO_FORCEINLINE bool matrix44::operator!= (const Imath::M44f& m) const {
+    return memcmp(this, &m, 16*sizeof(float)) != 0;
+}
+
+OIIO_FORCEINLINE bool operator!= (const Imath::M44f& a, const matrix44 &b) {
+    return (b != a);
+}
+
+OIIO_FORCEINLINE matrix44 matrix44::inverse() const {
+#if OIIO_SIMD_SSE
+    // Adapted from this code from Intel:
+    // ftp://download.intel.com/design/pentiumiii/sml/24504301.pdf
+    float4 minor0, minor1, minor2, minor3;
+    float4 row0, row1, row2, row3;
+    float4 det, tmp1;
+    const float *src = (const float *)this;
+    float4 zero = float4::Zero();
+    tmp1 = _mm_loadh_pi(_mm_loadl_pi(zero, (__m64*)(src)), (__m64*)(src+ 4));
+    row1 = _mm_loadh_pi(_mm_loadl_pi(zero, (__m64*)(src+8)), (__m64*)(src+12));
+    row0 = _mm_shuffle_ps(tmp1, row1, 0x88);
+    row1 = _mm_shuffle_ps(row1, tmp1, 0xDD);
+    tmp1 = _mm_loadh_pi(_mm_loadl_pi(tmp1, (__m64*)(src+ 2)), (__m64*)(src+ 6));
+    row3 = _mm_loadh_pi(_mm_loadl_pi(zero, (__m64*)(src+10)), (__m64*)(src+14));
+    row2 = _mm_shuffle_ps(tmp1, row3, 0x88);
+    row3 = _mm_shuffle_ps(row3, tmp1, 0xDD);
+    // -----------------------------------------------
+    tmp1 = row2 * row3;
+    tmp1 = shuffle<1,0,3,2>(tmp1);
+    minor0 = row1 * tmp1;
+    minor1 = row0 * tmp1;
+    tmp1 = shuffle<2,3,0,1>(tmp1);
+    minor0 = (row1 * tmp1) - minor0;
+    minor1 = (row0 * tmp1) - minor1;
+    minor1 = shuffle<2,3,0,1>(minor1);
+    // -----------------------------------------------
+    tmp1 = row1 * row2;
+    tmp1 = shuffle<1,0,3,2>(tmp1);
+    minor0 = (row3 * tmp1) + minor0;
+    minor3 = row0 * tmp1;
+    tmp1 = shuffle<2,3,0,1>(tmp1);
+    minor0 = minor0 - (row3 * tmp1);
+    minor3 = (row0 * tmp1) - minor3;
+    minor3 = shuffle<2,3,0,1>(minor3);
+    // -----------------------------------------------
+    tmp1 = shuffle<2,3,0,1>(row1) * row3;
+    tmp1 = shuffle<1,0,3,2>(tmp1);
+    row2 = shuffle<2,3,0,1>(row2);
+    minor0 = (row2 * tmp1) + minor0;
+    minor2 = row0 * tmp1;
+    tmp1 = shuffle<2,3,0,1>(tmp1);
+    minor0 = minor0 - (row2 * tmp1);
+    minor2 = (row0 * tmp1) - minor2;
+    minor2 = shuffle<2,3,0,1>(minor2);
+    // -----------------------------------------------
+    tmp1 = row0 * row1;
+    tmp1 = shuffle<1,0,3,2>(tmp1);
+    minor2 = (row3 * tmp1) + minor2;
+    minor3 = (row2 * tmp1) - minor3;
+    tmp1 = shuffle<2,3,0,1>(tmp1);
+    minor2 = (row3 * tmp1) - minor2;
+    minor3 = minor3 - (row2 * tmp1);
+    // -----------------------------------------------
+    tmp1 = row0 * row3;
+    tmp1 = shuffle<1,0,3,2>(tmp1);
+    minor1 = minor1 - (row2 * tmp1);
+    minor2 = (row1 * tmp1) + minor2;
+    tmp1 = shuffle<2,3,0,1>(tmp1);
+    minor1 = (row2 * tmp1) + minor1;
+    minor2 = minor2 - (row1 * tmp1);
+    // -----------------------------------------------
+    tmp1 = row0 * row2;
+    tmp1 = shuffle<1,0,3,2>(tmp1);
+    minor1 = (row3 * tmp1) + minor1;
+    minor3 = minor3 - (row1 * tmp1);
+    tmp1 = shuffle<2,3,0,1>(tmp1);
+    minor1 = minor1 - (row3 * tmp1);
+    minor3 = (row1 * tmp1) + minor3;
+    // -----------------------------------------------
+    det = row0 * minor0;
+    det = shuffle<2,3,0,1>(det) + det;
+    det = _mm_add_ss(shuffle<1,0,3,2>(det), det);
+    tmp1 = _mm_rcp_ss(det);
+    det = _mm_sub_ss(_mm_add_ss(tmp1, tmp1), _mm_mul_ss(det, _mm_mul_ss(tmp1, tmp1)));
+    det = shuffle<0>(det);
+    return matrix44 (det*minor0, det*minor1, det*minor2, det*minor3);
+#else
+    return m_mat.inverse();
+#endif
+}
+
+
+inline std::ostream& operator<< (std::ostream& cout, const matrix44 &M) {
+    const float *m = (const float *)&M;
+    cout << m[0];
+    for (int i = 1; i < 16; ++i)
+        cout << ' ' << m[i];
+    return cout;
+}
+
+
+
 OIIO_FORCEINLINE float3 transformp (const matrix44 &M, const float3 &V) {
     return M.transformp (V);
 }
@@ -3261,7 +3792,6 @@ OIIO_FORCEINLINE float3 transformp (const Imath::M44f &M, const float3 &V)
 }
 
 
-/// Transform 3-vector V by 4x4 matrix M.
 OIIO_FORCEINLINE float3 transformv (const matrix44 &M, const float3 &V) {
     return M.transformv (V);
 }
@@ -3292,29 +3822,8 @@ OIIO_FORCEINLINE float3 transformvT (const Imath::M44f &M, const float3 &V)
 }
 
 
-/// Template to retrieve the vector type from the scalar. For example,
-/// simd::VecType<int,4> will be float4.
-template<typename T,int elements> struct VecType {};
-template<> struct VecType<int,4>   { typedef int4 type; };
-template<> struct VecType<float,4> { typedef float4 type; };
-template<> struct VecType<float,3> { typedef float3 type; };
-template<> struct VecType<bool,4>  { typedef mask4 type; };
 
-/// Template to retrieve the SIMD size of a SIMD type. Rigged to be 1 for
-/// anything but our SIMD types.
-template<typename T> struct SimdSize { static const int size = 1; };
-template<> struct SimdSize<int4>     { static const int size = 4; };
-template<> struct SimdSize<float4>   { static const int size = 4; };
-template<> struct SimdSize<float3>   { static const int size = 4; };
-template<> struct SimdSize<mask4>    { static const int size = 4; };
-
-/// Template to retrieve the number of elements size of a SIMD type. Rigged
-/// to be 1 for anything but our SIMD types.
-template<typename T> struct SimdElements { static const int size = SimdSize<T>::size; };
-template<> struct SimdElements<float3>   { static const int size = 3; };
-
-
-} // end namespace
+} // end namespace simd
 
 OIIO_NAMESPACE_END
 
@@ -3323,3 +3832,5 @@ OIIO_NAMESPACE_END
 #undef SIMD_CONSTRUCT
 #undef SIMD_CONSTRUCT_PAD
 #undef SIMD_RETURN
+
+#endif /* OIIO_SIMD_H */


### PR DESCRIPTION
This doesn't introduce any new functionality, just moves code around within simd.h MASSIVELY. The net effect is to reorganize the header file so that it has the important class and functions declared and documented very cleanly in the first section of the file, and then all the gory details and architecture-specific implementation following that.  This makes it so that users of the simd.h functionality can more easily read the relevant parts of the header to understand the classes, and never need to poke around the ugly implementation.

We could, in the future, move the implementation details to one or more secondary files included from here, perhaps split by class or by architecture.  No need for that now, but this refactor makes it easier. 

It also makes it easier to block-copy-and-paste the existing classes to make new ones, such as I'm planning to do shortly to make 8-wide and 16-wide versions.

**NOTE** It looks like the changes are too extensive for GitHub to show the diffs, which is fine because they are so radical that they won't make sense as a diff anyway. Just click "view" to see the whole file in its new proposed form, and know that it's all just shuffled around but no functionality or actual implementation code has changed, it's just all reorganizing this file. Let the major comment sections be your guide.
