### PR TITLE
Sysutil additions: Simple terminal output with ANSI text formatting codes.

### DIFF
--- a/src/include/OpenImageIO/sysutil.h
+++ b/src/include/OpenImageIO/sysutil.h
@@ -88,11 +88,6 @@ OIIO_API string_view getenv (string_view name);
 ///
 OIIO_API void usleep (unsigned long useconds);
 
-/// Try to figure out how many columns wide the terminal window is.
-/// May not be correct all all systems, will default to 80 if it can't
-/// figure it out.
-OIIO_API int terminal_columns ();
-
 /// Try to put the process into the background so it doesn't continue to
 /// tie up any shell that it was launched from.  The arguments are the
 /// argc/argv that describe the program and its command line arguments.
@@ -110,6 +105,55 @@ OIIO_API unsigned int physical_concurrency ();
 
 /// Get the maximum number of open file handles allowed on this system.
 OIIO_API size_t max_open_files ();
+
+/// Try to figure out how many columns wide the terminal window is. May not
+/// be correct on all systems, will default to 80 if it can't figure it out.
+OIIO_API int terminal_columns ();
+
+/// Try to figure out how many rows tall the terminal window is. May not be
+/// correct on all systems, will default to 24 if it can't figure it out.
+OIIO_API int terminal_rows ();
+
+
+/// Term object encapsulates information about terminal output for the sake
+/// of constructing ANSI escape sequences.
+class OIIO_API Term {
+public:
+    /// Default ctr: assume ANSI escape sequences are ok.
+    Term () : m_is_console(true) { }
+    /// Construct from a FILE*: ANSI codes ok if the file describes a
+    /// live console, otherwise they will be supressed.
+    Term (FILE *file);
+    /// Construct from a stream: ANSI codes ok if the file describes a
+    /// live console, otherwise they will be supressed.
+    Term (const std::ostream &stream);
+
+    /// ansi("appearance") returns the ANSI escape sequence for the named
+    /// command (if ANSI codes are ok, otherwise it will return the empty
+    /// string). Accepted commands include: "default", "bold", "underscore",
+    /// "blink", "reverse", "concealed", "black", "red", "green", "yellow",
+    /// "blue", "magenta", "cyan", "white", "black_bg", "red_bg",
+    /// "green_bg", "yellow_bg", "blue_bg", "magenta_bg", "cyan_bg",
+    /// "white_bg". Commands may be combined with "," for example:
+    /// "bold,green,white_bg".
+    std::string ansi (string_view command) const;
+
+    /// ansi("appearance", "text") returns the text, with the formatting
+    /// command, then the text, then the formatting command to return to
+    /// default appearance.
+    std::string ansi (string_view command, string_view text) const {
+        return std::string(ansi(command)) + std::string(text) + ansi("default");
+    }
+
+    /// Extended color control: take RGB values from 0-255
+    std::string ansi_fgcolor (int r, int g, int b);
+    std::string ansi_bgcolor (int r, int g, int b);
+
+    bool is_console () const { return m_is_console; }
+private:
+    bool m_is_console;
+};
+
 
 }  // namespace Sysutils
 

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -30,6 +30,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <cstdio>
 #include <string>
 #include <iostream>
 #include <ctime>
@@ -65,6 +66,7 @@
 # include <windows.h>
 # include <Psapi.h>
 # include <cstdio>
+# include <io.h>
 #else
 # include <sys/resource.h>
 #endif
@@ -74,8 +76,9 @@
 # include <sys/ioctl.h>
 #endif
 
-#include "OpenImageIO/dassert.h"
-#include "OpenImageIO/sysutil.h"
+#include <OpenImageIO/dassert.h>
+#include <OpenImageIO/sysutil.h>
+#include <OpenImageIO/strutil.h>
 
 #include <boost/version.hpp>
 #include <boost/thread.hpp>
@@ -304,6 +307,131 @@ Sysutil::terminal_columns ()
 #endif
 
     return columns;
+}
+
+
+
+int
+Sysutil::terminal_rows ()
+{
+    int rows = 24;   // a decent guess, if we have nothing more to go on
+
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__GNU__)
+    struct winsize w;
+    ioctl (0, TIOCGWINSZ, &w);
+    rows = w.ws_row;
+#elif defined(_WIN32)
+    HANDLE h = GetStdHandle (STD_OUTPUT_HANDLE);
+    if (h != INVALID_HANDLE_VALUE) {
+        CONSOLE_SCREEN_BUFFER_INFO csbi = { { 0 } };
+        GetConsoleScreenBufferInfo (h, &csbi);
+        rows = csbi.dwSize.Y;
+    }
+#endif
+
+    return rows;
+}
+
+
+
+#ifdef _WIN32
+int isatty(int fd) { return _isatty(fd); }
+#endif
+
+
+Term::Term (FILE *file)
+{
+    m_is_console = isatty (fileno((file)));
+}
+
+
+
+Term::Term (const std::ostream &stream)
+{
+    m_is_console = (&stream == &std::cout && isatty(fileno(stdout)))
+                || (&stream == &std::cerr && isatty(fileno(stderr)))
+                || (&stream == &std::clog && isatty(fileno(stderr)));
+}
+
+
+
+std::string
+Term::ansi (string_view command) const
+{
+    static const char *codes[] = {
+        "default",    "0",
+        "normal",     "0",
+        "reset",      "0",
+        "bold",       "1",
+        "italic",     "3",       // Not widely supported, sometimes inverse
+        "underscore", "4",
+        "underline",  "4",
+        "blink",      "5",
+        "reverse",    "7",
+        "concealed",  "8",
+        "strike",     "9",       // Not widely supported
+        "black",      "30",
+        "red",        "31",
+        "green",      "32",
+        "yellow",     "33",
+        "blue",       "34",
+        "magenta",    "35",
+        "cyan",       "36",
+        "white",      "37",
+        "black_bg",   "40",
+        "red_bg",     "41",
+        "green_bg",   "42",
+        "yellow_bg",  "43",
+        "blue_bg",    "44",
+        "magenta_bg", "45",
+        "cyan_bg",    "46",
+        "white_bg",   "47",
+        NULL
+    };
+    std::string ret;
+    if (is_console()) {
+        std::vector<string_view> cmds;
+        Strutil::split (command, cmds, ",");
+        for (size_t c = 0; c < cmds.size(); ++c) {
+            for (size_t i = 0; codes[i]; i += 2)
+                if (codes[i] == cmds[c]) {
+                    ret += c ? ";" : "\033[";
+                    ret += codes[i+1];
+                }
+        }
+        ret += "m";
+    }
+    return ret;
+}
+
+
+
+std::string
+Term::ansi_fgcolor (int r, int g, int b)
+{
+    std::string ret;
+    if (is_console()) {
+        r = std::max (0, std::min (255, r));
+        g = std::max (0, std::min (255, g));
+        b = std::max (0, std::min (255, b));
+        ret = Strutil::format ("\033[38;2;%d;%d;%dm", r, g, b);
+    }
+    return ret;
+}
+
+
+
+std::string
+Term::ansi_bgcolor (int r, int g, int b)
+{
+    std::string ret;
+    if (is_console()) {
+        r = std::max (0, std::min (255, r));
+        g = std::max (0, std::min (255, g));
+        b = std::max (0, std::min (255, b));
+        ret = Strutil::format ("\033[48;2;%d;%d;%dm", r, g, b);
+    }
+    return ret;
 }
 
 


### PR DESCRIPTION
Example-as-documentation:

    // Make a Term object that understands whether the intended output
    // channel is a live terminal (pass a stream, or a FILE*, or the
    // default ctr just assumes ANSI codes are ok).
    Sysutil::Term term(std::cout);

    // Term.ansi("command") produces the code for the given attribute
    // (such as "bold" or "red", and you can combine them with commas),
    // IF the term supports ANSI codes, otherwise returns a safe empty
    // string.
    std::cout << "Normal " << term.ansi("bold") << "bold stuff"
              << term.ansi("default") << "\n";

    // Term.ansi ("command", "string") returns the string that turns on
    // the attribute, then has the string, then goes back to the default
    // appearance.
    std::cout << "Normal "
              << term.ansi("bold", "bold") << " "
              << term.ansi("underscore", "underscore") << " "
              << term.ansi("reverse", "reverse") << " "
              << term.ansi("red", "red") << " "
              << term.ansi("bold,green,blue_bg", "bold,green,blue_bg") << " "
              << "normal\n";

    // We can even set r,g,b values with fg_color and bg_color!
    std::cout << term.fg_color (128, 15, 255)
              << "wowza! << term.ansi("default") << "\n";