### PR TITLE
ImageCache/TextureSystem: collect stats on total size on disk.

### DIFF
--- a/src/doc/imagecache.tex
+++ b/src/doc/imagecache.tex
@@ -430,8 +430,15 @@ the query), and the peak number of files opened at any time.
 Number of times a filename was looked up in the file cache.
 \apiend
 
-\apiitem{int64 stat:files_totalsize {\rm ~(read only)}}
-Total size (uncompressed bytes of pixel data) of all files referenced.
+\apiitem{int64 stat:image_size {\rm ~(read only)}}
+Total size (uncompressed bytes of pixel data) of all images referenced
+by the \ImageCache. (Note: Prior to 1.7, this was called \qkw{stat:files_totalsize}.)
+\apiend
+
+\apiitem{int64 stat:file_size {\rm ~(read only)}}
+\NEW   % 1.7
+Total size of all files (as on disk, possibly compressed) of all images
+referenced by the \ImageCache.
 \apiend
 
 \apiitem{int64 stat:bytes_read {\rm ~(read only)}}
@@ -658,6 +665,12 @@ the same tile had been rad before. ({\cf int64}).
 data) in tiles that were read redundantly. ({\cf int64}).
 
 \item[\rm \kw{stat:redundant_bytesread}] Number of tiles read from this file ({\cf int}).
+
+\item[\rm \kw{stat:image_size}] Size of the uncompressed image pixel data
+of this image, in bytes ({\cf int64}).
+
+\item[\rm \kw{stat:file_size}] Size of the disk file (possibly compressed)
+for this image, in bytes ({\cf int64}).
 
 \item[\rm \kw{stat:timesopened}] Number of times this file was opened ({\cf int}).
 

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -100,6 +100,7 @@ struct ImageCacheStatistics {
     long long find_tile_microcache_misses;
     int find_tile_cache_misses;
     long long files_totalsize;
+    long long files_totalsize_ondisk;
     long long bytes_read;
     // These stats are hard to deal with on a per-thread basis, so for
     // now, they are still atomics shared by the whole IC.
@@ -357,6 +358,7 @@ private:
     ustring m_fingerprint;          ///< Optional cryptographic fingerprint
     ImageCacheFile *m_duplicate;    ///< Is this a duplicate?
     imagesize_t m_total_imagesize;  ///< Total size, uncompressed
+    imagesize_t m_total_imagesize_ondisk;  ///< Total size, compressed on disk
     ImageInput::Creator m_inputcreator; ///< Custom ImageInput-creator
     boost::scoped_ptr<ImageSpec> m_configspec; // Optional configuration hints
     UdimLookupMap m_udim_lookup;    ///< Used for decoding udim tiles

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -1232,16 +1232,23 @@ main (int argc, const char *argv[])
             int timesopened = 0;
             int64_t bytesread = 0;
             float iotime = 0.0f;
+            int64_t data_size = 0, file_size = 0;
             texsys->get_texture_info (all_filenames[i], 0, ustring("stat:timesopened"),
                                       TypeDesc::INT, &timesopened);
             texsys->get_texture_info (all_filenames[i], 0, ustring("stat:bytesread"),
                                       TypeDesc::INT64, &bytesread);
             texsys->get_texture_info (all_filenames[i], 0, ustring("stat:iotime"),
                                       TypeDesc::FLOAT, &iotime);
-            std::cout << Strutil::format ("  %d: %s  opens=%d, read=%s, time=%s\n",
+            texsys->get_texture_info (all_filenames[i], 0, ustring("stat:image_size"),
+                                      TypeDesc::INT64, &data_size);
+            texsys->get_texture_info (all_filenames[i], 0, ustring("stat:file_size"),
+                                      TypeDesc::INT64, &file_size);
+            std::cout << Strutil::format ("  %d: %s  opens=%d, read=%s, time=%s, data=%s, file=%s\n",
                                           i, all_filenames[i], timesopened,
                                           Strutil::memformat(bytesread),
-                                          Strutil::timeintervalformat(iotime,2));
+                                          Strutil::timeintervalformat(iotime,2),
+                                          Strutil::memformat(data_size),
+                                          Strutil::memformat(file_size));
         }
     }
 


### PR DESCRIPTION
The size statistics reported by IC/TS are the *data* size -- that is,
the size of all pixels of the image if they were read into memory, as
represented in the cache (uncompressed, and in one of the data types
supported by the cache).

But this doesn't accurately reflect the size of the images as they exist
on disk. The three main ways they differ are: (a) the image data doesn't
count the size of the headers, metadata, etc; (b) the pixel data on disk
is often compressed, making it much smaller stored on disk than the
in-cache size; (c) the data on disk may be in a format not directly
supported by the cache, and is "expanded" upon being read (for example,
10 bit per channel data would be expanded to 16 bits per channel in
the cache, palette images might be represented by one byte per pixel
on disk but 3 bytes of RGB per pixel in the cache, and so on).

This patch records the actual file size on disk for each file referenced
by the ImageCache.

Now the stats try to more clearly describe these two separate values:

    Total pixel data size of all images referenced : 120.0 MB
    Total actual file size of all images referenced : 6.6 MB

The stats also can be accessed through the IC or TS APIs, as totals for
all files via getattribute queries for "stat:image_size" and
"stat:file_size", and for individual files using get_image_info queries
of the same name (all are int64 values).