### PR TITLE
Make sure the sign bit of expm1 is correct for small arguments

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -1528,8 +1528,8 @@ inline float fast_exp10 (float x) {
 
 inline float fast_expm1 (float x) {
     if (fabsf(x) < 1e-5f) {
-        x = 1.0f - (1.0f - x); // crush denormals
-        return madd(0.5f, x * x, x);
+        float y = 1.0f - (1.0f - x); // crush denormals
+        return copysignf(madd(0.5f, y * y, y), x);
     } else
         return fast_exp(x) - 1.0f;
 }


### PR DESCRIPTION
The sign bit of expm1 could be wrong (due to the "denormals crush" technique we use to speed things up).

Since expm1 is a strictly increasing function passing through 0, we can just force in the sign bit we want from the argument.