### PR TITLE
Add an optimized (and sign accurate) version of log1p

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -1447,6 +1447,15 @@ inline float fast_logb (float x) {
     return float (int(bits >> 23) - 127);
 }
 
+inline float fast_log1p (float x) {
+    if (fabsf(x) < 0.01f) {
+        float y = 1.0f - (1.0f - x); // crush denormals
+        return copysignf(madd(-0.5f, y * y, y), x);
+    } else {
+        return fast_log(x + 1);
+    }
+}
+
 inline float fast_exp2 (float x) {
     // clamp to safe range for final addition
     if (x < -126.0f) x = -126.0f;
@@ -1527,7 +1536,7 @@ inline float fast_exp10 (float x) {
 }
 
 inline float fast_expm1 (float x) {
-    if (fabsf(x) < 1e-5f) {
+    if (fabsf(x) < 0.03f) {
         float y = 1.0f - (1.0f - x); // crush denormals
         return copysignf(madd(0.5f, y * y, y), x);
     } else


### PR DESCRIPTION
`log1p` is the natural companion to `expm1` and we were missing a fast version of it.

Just like in `expm1`, care is taken to get the sign bit right for small arguments (which simply calling `fast_log(1+x)` gets wrong for roughly 50% of inputs between -1 and 1).

After more careful measurement, I also found I could relax the threshold for small angles in `expm1` without changing the maximum error. This makes it slightly faster.