### PR TITLE
Massive overhaul of simd.h leading to full support of AVX and AVX2.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -322,7 +322,9 @@ Developer goodies / internals:
    and add ~ for int4. #1331 (1.7.2); madd, msub, nmadd, nmsub, rint,
    andnot #1377 (1.7.2); exp, log #1384 (1.7.2); simd::float3 is like float4,
    but only loads and stores 3 components, it's a good Vec3f replacement (but
-   padded) #1473 (1.7.5); matrix44 4x4 matrix class #1473 (1.7.5).
+   padded) #1473 (1.7.5); matrix44 4x4 matrix class #1473 (1.7.5);
+   mask4 renamed to bool4, and addition of float8, int8, bool8 classes
+   for 8-wide AVX/AVX2 SIMD #1484 (1.7.5).
  * fmath.h: convert_types has new special cases that vastly speed up
    float <-> uint16, uint8, and half buffer conversions #1305 (1.7.0);
    ifloor (1.7.2); SIMD versions of fast_log2, fast_log, fast_exp2,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,7 @@ set (USE_CPP11 ON CACHE BOOL "Compile in C++11 mode")
 set (USE_CPP14 OFF CACHE BOOL "Compile in C++14 mode")
 set (USE_LIBCPLUSPLUS OFF CACHE BOOL "Compile with clang libc++")
 set (EXTRA_CPP_ARGS "" CACHE STRING "Extra C++ command line definitions")
-set (USE_SIMD "" CACHE STRING "Use SIMD directives (0, sse2, sse3, ssse3, sse4.1, sse4.2)")
+set (USE_SIMD "" CACHE STRING "Use SIMD directives (0, sse2, sse3, ssse3, sse4.1, sse4.2, avx, avx2, avx512f, f16c)")
 set (USE_CCACHE ON CACHE BOOL "Use ccache if found")
 set (CODECOV OFF CACHE BOOL "Build code coverage tests")
 

--- a/Makefile
+++ b/Makefile
@@ -485,7 +485,7 @@ help:
 	@echo "      OIIO_BUILD_TESTS=0       Skip building the unit tests"
 	@echo "      BUILD_OIIOUTIL_ONLY=1    Build *only* libOpenImageIO_Util"
 	@echo "      USE_SIMD=arch            Build with SIMD support (choices: 0, sse2, sse3,"
-	@echo "                                  ssse3, sse4.1, sse4.2, f16c,"
+	@echo "                                  ssse3, sse4.1, sse4.2, f16c, avx, avx2"
 	@echo "                                  comma-separated ok)"
 	@echo "  make test, extra options:"
 	@echo "      TEST=regex               Run only tests matching the regex"

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -223,9 +223,14 @@ clamp (T a, T low, T high)
 
 
 // Specialization of clamp for float4
-template<>
-inline simd::float4
+template<> inline simd::float4
 clamp (simd::float4 a, simd::float4 low, simd::float4 high)
+{
+    return simd::min (high, simd::max (low, a));
+}
+
+template<> inline simd::float8
+clamp (simd::float8 a, simd::float8 low, simd::float8 high)
 {
     return simd::min (high, simd::max (low, a));
 }
@@ -233,97 +238,36 @@ clamp (simd::float4 a, simd::float4 low, simd::float4 high)
 
 
 /// Fused multiply and add: (a*b + c)
-template <typename T>
-inline T madd (const T& a, const T& b, const T& c) {
+inline float madd (float a, float b, float c) {
 #if OIIO_FMA_ENABLED && (OIIO_CPLUSPLUS_VERSION >= 11)
     // C++11 defines std::fma, which we assume is implemented using an
     // intrinsic.
-    if (is_same<T,float>::value || is_same<T,double>::value)
-        return std::fma (a, b, c);
-#endif
+    return std::fma (a, b, c);
+#else
     // NOTE: GCC/ICC will turn this (for float) into a FMA unless
     // explicitly asked not to, clang will do so if -ffp-contract=fast.
     return a * b + c;
-}
-
-#if OIIO_FMA_ENABLED
-template <>
-inline float madd (const float& a, const float& b, const float& c) {
-    return _mm_cvtss_f32 (_mm_fmadd_ss (_mm_set_ss(a), _mm_set_ss(b), _mm_set_ss(c)));
-}
 #endif
-
-template <>
-inline simd::float4 madd (const simd::float4& a, const simd::float4& b,
-                          const simd::float4& c) {
-    // Implement float4 madd in terms of the one defined in simd.h.
-    return simd::madd (a, b, c);
 }
-
 
 
 /// Fused multiply and subtract: -(a*b - c)
-template <typename T>
-inline T msub (const T& a, const T& b, const T& c) {
+inline float msub (float a, float b, float c) {
     return a * b - c; // Hope for the best
-}
-
-#if OIIO_FMA_ENABLED
-template <>
-inline float msub (const float& a, const float& b, const float& c) {
-    return _mm_cvtss_f32 (_mm_fmsub_ss (_mm_set_ss(a), _mm_set_ss(b), _mm_set_ss(c)));
-}
-#endif
-
-template <>
-inline simd::float4 msub (const simd::float4& a, const simd::float4& b,
-                           const simd::float4& c) {
-    // Implement float4 msub in terms of the one defined in simd.h.
-    return simd::msub (a, b, c);
 }
 
 
 
 /// Fused negative multiply and add: -(a*b) + c
-template <typename T>
-inline T nmadd (const T& a, const T& b, const T& c) {
+inline float nmadd (float a, float b, float c) {
     return c - (a * b); // Hope for the best
-}
-
-#if OIIO_FMA_ENABLED
-template <>
-inline float nmadd (const float& a, const float& b, const float& c) {
-    return _mm_cvtss_f32 (_mm_fnmadd_ss (_mm_set_ss(a), _mm_set_ss(b), _mm_set_ss(c)));
-}
-#endif
-
-template <>
-inline simd::float4 nmadd (const simd::float4& a, const simd::float4& b,
-                           const simd::float4& c) {
-    // Implement float4 nmadd in terms of the one defined in simd.h.
-    return simd::nmadd (a, b, c);
 }
 
 
 
 /// Negative fused multiply and subtract: -(a*b) - c
-template <typename T>
-inline T nmsub (const T& a, const T& b, const T& c) {
+inline float nmsub (float a, float b, float c) {
     return -(a * b) - c; // Hope for the best
-}
-
-#if OIIO_FMA_ENABLED
-template <>
-inline float nmsub (const float& a, const float& b, const float& c) {
-    return _mm_cvtss_f32 (_mm_fnmsub_ss (_mm_set_ss(a), _mm_set_ss(b), _mm_set_ss(c)));
-}
-#endif
-
-template <>
-inline simd::float4 nmsub (const simd::float4& a, const simd::float4& b,
-                           const simd::float4& c) {
-    // Implement float4 nmsub in terms of the one defined in simd.h.
-    return simd::nmsub (a, b, c);
 }
 
 
@@ -578,6 +522,10 @@ inline OUT_TYPE bit_cast (const IN_TYPE in) {
     memcpy (&out, &in, sizeof(IN_TYPE));
     return out;
 }
+
+
+inline int bitcast_to_int (float x) { return bit_cast<float,int>(x); }
+inline int bitcast_to_float (int x) { return bit_cast<int,float>(x); }
 
 
 
@@ -1376,10 +1324,31 @@ inline float fast_atan2 (float y, float x) {
     return copysignf(r, y);
 }
 
-static inline float fast_log2 (float x) {
+template<typename T>
+inline T fast_log2 (const T& xval) {
+    using namespace simd;
+    typedef typename T::int_t intN;
+    // See float fast_log2 for explanations
+    T x = clamp (xval, T(std::numeric_limits<float>::min()), T(std::numeric_limits<float>::max()));
+    intN bits = bitcast_to_int(x);
+    intN exponent = srl (bits, 23) - intN(127);
+    T f = bitcast_to_float ((bits & intN(0x007FFFFF)) | intN(0x3f800000)) - T(1.0f);
+    T f2 = f * f;
+    T f4 = f2 * f2;
+    T hi = madd(f, T(-0.00931049621349f), T( 0.05206469089414f));
+    T lo = madd(f, T( 0.47868480909345f), T(-0.72116591947498f));
+    hi = madd(f, hi, T(-0.13753123777116f));
+    hi = madd(f, hi, T( 0.24187369696082f));
+    hi = madd(f, hi, T(-0.34730547155299f));
+    lo = madd(f, lo, T( 1.442689881667200f));
+    return ((f4 * hi) + (f * lo)) + T(exponent);
+}
+
+
+template<>
+inline float fast_log2 (const float& xval) {
     // NOTE: clamp to avoid special cases and make result "safe" from large negative values/nans
-    if (x < std::numeric_limits<float>::min()) x = std::numeric_limits<float>::min();
-    if (x > std::numeric_limits<float>::max()) x = std::numeric_limits<float>::max();
+    float x = clamp (xval, std::numeric_limits<float>::min(), std::numeric_limits<float>::max());
     // based on https://github.com/LiraNuna/glsl-sse2/blob/master/source/vec4.h
     unsigned bits = bit_cast<float, unsigned>(x);
     int exponent = int(bits >> 23) - 127;
@@ -1400,42 +1369,19 @@ static inline float fast_log2 (float x) {
     return ((f4 * hi) + (f * lo)) + exponent;
 }
 
-inline simd::float4 fast_log2 (const simd::float4& xval) {
-    using namespace simd;
-#if OIIO_SIMD_SSE
-    // See float fast_log2 for explanations
-    OIIO_SIMD_FLOAT4_CONST (log2_hi, std::numeric_limits<float>::max());
-    OIIO_SIMD_FLOAT4_CONST (log2_lo, std::numeric_limits<float>::min());
-    float4 x = clamp (xval, float4(log2_lo), float4(log2_hi));
-    int4 bits = bitcast_to_int4(x);
-    int4 exponent = srl (bits, 23) - int4(127);
-    float4 f = bitcast_to_float4 ((bits & int4(0x007FFFFF)) | int4(0x3f800000)) - float4(1.0f);
-    float4 f2 = f * f;
-    float4 f4 = f2 * f2;
-    float4 hi = madd(f, float4(-0.00931049621349f), float4( 0.05206469089414f));
-    float4 lo = madd(f, float4( 0.47868480909345f), float4(-0.72116591947498f));
-    hi = madd(f, hi, float4(-0.13753123777116f));
-    hi = madd(f, hi, float4( 0.24187369696082f));
-    hi = madd(f, hi, float4(-0.34730547155299f));
-    lo = madd(f, lo, float4( 1.442689881667200f));
-    return ((f4 * hi) + (f * lo)) + float4(exponent);
-#else
-    return float4 (fast_log2(xval[0]), fast_log2(xval[1]), fast_log2(xval[2]), fast_log2(xval[3]));
-#endif
-}
 
-inline float fast_log (float x) {
+
+template<typename T>
+inline T fast_log (const T& x) {
     // Examined 2130706432 values of logf on [1.17549435e-38,3.40282347e+38]: 0.313865375 avg ulp diff, 5148137 max ulp, 7.62939e-06 max error
-    return fast_log2(x) * float(M_LN2);
+    return fast_log2(x) * T(M_LN2);
 }
 
-inline simd::float4 fast_log (const simd::float4& x) {
-    return fast_log2(x) * float(M_LN2);
-}
 
-inline float fast_log10 (float x) {
+template<typename T>
+inline T fast_log10 (const T& x) {
     // Examined 2130706432 values of log10f on [1.17549435e-38,3.40282347e+38]: 0.631237033 avg ulp diff, 4471615 max ulp, 3.8147e-06 max error
-    return fast_log2(x) * float(M_LN2 / M_LN10);
+    return fast_log2(x) * T(M_LN2 / M_LN10);
 }
 
 inline float fast_logb (float x) {
@@ -1456,10 +1402,45 @@ inline float fast_log1p (float x) {
     }
 }
 
-inline float fast_exp2 (float x) {
+
+
+template<typename T>
+inline T fast_exp2 (const T& xval) {
+    using namespace simd;
+    typedef typename T::int_t intN;
+#if OIIO_SIMD_SSE
+    // See float specialization for explanations
+    T x = clamp (xval, T(-126.0f), T(126.0f));
+    intN m (x); x -= T(m);
+    T one (1.0f);
+    x = one - (one - x); // crush denormals (does not affect max ulps!)
+    const T kA (1.33336498402e-3f);
+    const T kB (9.810352697968e-3f);
+    const T kC (5.551834031939e-2f);
+    const T kD (0.2401793301105f);
+    const T kE (0.693144857883f);
+    T r (kA);
+    r = madd(x, r, kB);
+    r = madd(x, r, kC);
+    r = madd(x, r, kD);
+    r = madd(x, r, kE);
+    r = madd(x, r, one);
+    return bitcast_to_float (bitcast_to_int(r) + (m << 23));
+#else
+    T r;
+    for (int i = 0; i < r.elements; ++i)
+        r[i] = fast_exp2(xval[i]);
+    for (int i = r.elements; i < r.paddedelements; ++i)
+        r[i] = 0.0f;
+    return r;
+#endif
+}
+
+
+template<>
+inline float fast_exp2 (const float& xval) {
     // clamp to safe range for final addition
-    if (x < -126.0f) x = -126.0f;
-    if (x >  126.0f) x =  126.0f;
+    float x = clamp (xval, -126.0f, 126.0f);
     // range reduction
     int m = int(x); x -= m;
     x = 1.0f - (1.0f - x); // crush denormals (does not affect max ulps!)
@@ -1479,42 +1460,15 @@ inline float fast_exp2 (float x) {
     return bit_cast<unsigned, float>(bit_cast<float, unsigned>(r) + (unsigned(m) << 23));
 }
 
-inline simd::float4 fast_exp2 (const simd::float4& xval) {
-    using namespace simd;
-#if OIIO_SIMD_SSE
-    // See float fast_exp2 for explanations
-    OIIO_SIMD_FLOAT4_CONST (exp_hi,  126.0f);
-    OIIO_SIMD_FLOAT4_CONST (exp_lo, -126.0f);
-    float4 x = clamp (xval, float4(exp_lo), float4(exp_hi));
-    int4 m (x); x -= float4(m);
-    OIIO_SIMD_FLOAT4_CONST (kone, 1.0f);
-    float4 one (kone);
-    x = one - (one - x); // crush denormals (does not affect max ulps!)
-    OIIO_SIMD_FLOAT4_CONST (kA, 1.33336498402e-3f);
-    OIIO_SIMD_FLOAT4_CONST (kB, 9.810352697968e-3f);
-    OIIO_SIMD_FLOAT4_CONST (kC, 5.551834031939e-2f);
-    OIIO_SIMD_FLOAT4_CONST (kD, 0.2401793301105f);
-    OIIO_SIMD_FLOAT4_CONST (kE, 0.693144857883f);
-    float4 r (kA);
-    r = madd(x, r, float4(kB));
-    r = madd(x, r, float4(kC));
-    r = madd(x, r, float4(kD));
-    r = madd(x, r, float4(kE));
-    r = madd(x, r, one);
-    return bitcast_to_float4 (bitcast_to_int4(r) + (m << 23));
-#else
-    return float4 (fast_exp2(xval[0]), fast_exp2(xval[1]), fast_exp2(xval[2]), fast_exp2(xval[3]));
-#endif
-}
 
-inline float fast_exp (float x) {
+
+
+template <typename T>
+inline T fast_exp (const T& x) {
     // Examined 2237485550 values of exp on [-87.3300018,87.3300018]: 2.6666452 avg ulp diff, 230 max ulp
-    return fast_exp2(x * float(1 / M_LN2));
+    return fast_exp2(x * T(1 / M_LN2));
 }
 
-inline simd::float4 fast_exp (const simd::float4& x) {
-    return fast_exp2(x * float(1 / M_LN2));
-}
 
 
 /// Faster float exp than is in libm, but still 100% accurate
@@ -1607,7 +1561,8 @@ inline float fast_safe_pow (float x, float y) {
 
 
 // Fast simd pow that only needs to work for positive x
-inline simd::float4 fast_pow_pos (const simd::float4& x, const simd::float4& y) {
+template<typename T, typename U>
+inline T fast_pow_pos (const T& x, const U& y) {
     return fast_exp2(y * fast_log2(x));
 }
 


### PR DESCRIPTION
The quick summary is that it adds float8, int8, bool8 classes that are analogous to the 4-way versions. The existing float4, int4, bool4 classes are more or less the way they were before.

So much changed and moved around within simd.h, it's not worth bothering to understand the diff. Read the new file if you care about the details.

They are quite speedy on AVX/AVX2, but fall back on a mixture of SSE (4-wide) and scalar if AVX is not available. Note that the float classes are generally fully performant on AVX, but it takes AVX2 for most of the 8-wide instructions for integers. In many cases, we get pretty close by doing it in 4-way chunks rather than falling back to fully scalar. If there are particular methods that need to be faster on AVX 1.0 (or SSE), I'm happy to give them a closer look, but I'm going forward under the assumption that the people who care most about performance are on, or soon moving to, AVX2.

Renamed "mask4" to "bool4" to avoid confusion with "masks" that will be coming soon when we add support for AVX-512. The old "mask4" is typedefed to be bool4 for now, for compatibility.

The simd_test is also massively overhauled, not just to test the new classes, but also significantly beefing up tests of the 4-way SIMD classes, and doing time trials of nearly every bit of functionality.