### PR TITLE
oiiotool: Add support for writing out mixed channel bitdepths

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -839,6 +839,7 @@ ImageBufImpl::read (int subimage, int miplevel, bool force, TypeDesc convert,
         m_spec.format = convert;
     else
         m_spec.format = m_nativespec.format;
+    m_spec.channelformats = m_nativespec.channelformats;
     m_pixelaspect = m_spec.get_float_attribute ("pixelaspectratio", 1.0f);
     realloc ();
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4282,6 +4282,8 @@ output_file (int argc, const char *argv[])
             // For deep files, must copy the native deep channelformats
             if (spec.deep)
                 spec.channelformats = (*ir)(s,0).nativespec().channelformats;
+            else
+                spec.channelformats = (*ir)(s,0).spec().channelformats;
             // If it's not tiled and MIP-mapped, remove any "textureformat"
             if (! spec.tile_pixels() || ir->miplevels(s) <= 1)
                 spec.erase_attribute ("textureformat");


### PR DESCRIPTION
## Description

Currently when oiio reads in an image with channels that have different bitdepths, all channels get converted to the bitdepth of the image. This fixes that by retaining the format of each channel when reading in the image.

oiiotool would also ignore mixed channel bitdepth information, so now it retains the information and writes out the channels at whatever their bitdepth is in the image buffer.

Fixes #1445 

## Tests

I can't provide the test data that I have and I can't generate some test data either. If someone is able to supply some test data then I'd be happy to write the tests.