### PR TITLE
Fix OpenEXR input and output of chromaticities

### DIFF
--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -57,6 +57,7 @@
 #include <OpenEXR/ImfKeyCodeAttribute.h>
 #include <OpenEXR/ImfEnvmapAttribute.h>
 #include <OpenEXR/ImfCompressionAttribute.h>
+#include <OpenEXR/ImfChromaticitiesAttribute.h>
 #include <OpenEXR/IexBaseExc.h>
 #include <OpenEXR/IexThrowErrnoExc.h>
 #ifdef USE_OPENEXR_VERSION2
@@ -299,7 +300,7 @@ private:
         // FIXME: Things to consider in the future:
         // preview
         // screenWindowCenter
-        // chromaticities whiteLuminance adoptedNeutral
+        // adoptedNeutral
         // renderingTransform, lookModTransform
         // utcOffset
         // longitude latitude altitude
@@ -576,6 +577,7 @@ OpenEXRInput::PartInfo::parse_header (const Imf::Header *header)
         const Imf::Box2fAttribute *b2fattr;
         const Imf::TimeCodeAttribute *tattr;
         const Imf::KeyCodeAttribute *kcattr;
+        const Imf::ChromaticitiesAttribute *crattr;
 #ifdef USE_OPENEXR_VERSION2
         const Imf::StringVectorAttribute *svattr;
         const Imf::DoubleAttribute *dattr;
@@ -698,6 +700,11 @@ OpenEXRInput::PartInfo::parse_header (const Imf::Header *header)
             if (oname == "keyCode")
                 oname = "smpte:KeyCode";
             spec.attribute(oname, TypeDesc::TypeKeyCode, keycode);
+        } else if (type == "chromaticities" &&
+                   (crattr = header->findTypedAttribute<Imf::ChromaticitiesAttribute> (name))) {
+            const Imf::Chromaticities *chroma = &crattr->value();
+            spec.attribute (oname, TypeDesc(TypeDesc::FLOAT,8),
+                            (const float *)chroma);
         }
         else {
 #if 0

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -56,6 +56,7 @@
 #include <OpenEXR/ImfBoxAttribute.h>
 #include <OpenEXR/ImfEnvmapAttribute.h>
 #include <OpenEXR/ImfCompressionAttribute.h>
+#include <OpenEXR/ImfChromaticitiesAttribute.h>
 #include <OpenEXR/ImfCRgbaFile.h>  // JUST to get symbols to figure out version!
 #include <OpenEXR/IexBaseExc.h>
 #include <OpenEXR/IexThrowErrnoExc.h>
@@ -1204,6 +1205,14 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
                     return true;
 #endif
             }
+        }
+        if (type.basetype == TypeDesc::FLOAT && type.aggregate * type.arraylen == 8
+            && Strutil::iequals (xname, "chromaticities")) {
+            const float *f = (const float *)data;
+            Imf::Chromaticities c (Imath::V2f(f[0], f[1]), Imath::V2f(f[2], f[3]),
+                                   Imath::V2f(f[4], f[5]), Imath::V2f(f[6], f[7]));
+            header.insert ("chromaticities", Imf::ChromaticitiesAttribute (c));
+            return true;
         }
 #ifdef USE_OPENEXR_VERSION2
         // String Vector

--- a/testsuite/openexr-suite/ref/out.txt
+++ b/testsuite/openexr-suite/ref/out.txt
@@ -60,6 +60,7 @@ Reading ../../../../../openexr-images/ScanLines/Tree.exr
     oiio:ColorSpace: "Linear"
     compression: "piz"
     DateTime: "2002:06:23 15:00:00"
+    chromaticities: 0.62955, 0.341, 0.2867, 0.6108, 0.1489, 0.07125, 0.3155, 0.33165
     focus: 3.5
     Copyright: "Copyright 2002 Industrial Light & Magic"
     PixelAspectRatio: 1
@@ -79,6 +80,7 @@ Reading ../../../../../openexr-images/ScanLines/Blobbies.exr
     oiio:ColorSpace: "Linear"
     compression: "zip"
     DateTime: "2004:01:19 12:55:33"
+    chromaticities: 0.62955, 0.341, 0.2867, 0.6108, 0.1489, 0.07125, 0.3155, 0.33165
     Copyright: "Copyright 2004 Industrial Light & Magic"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
@@ -181,6 +183,7 @@ Reading ../../../../../openexr-images/TestImages/WideColorGamut.exr
     channel list: R, G, B
     oiio:ColorSpace: "Linear"
     compression: "zip"
+    chromaticities: 0.64, 0.33, 0.3, 0.6, 0.15, 0.06, 0.3127, 0.329
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
@@ -233,4 +236,24 @@ Reading ../../../../../openexr-images/Tiles/Ocean.exr
     screenWindowCenter: 0 0
     screenWindowWidth: 1
 Comparing "../../../../../openexr-images/Tiles/Ocean.exr" and "Ocean.exr"
+PASS
+Reading ../../../../../openexr-images/Tiles/Spirals.exr
+../../../../../openexr-images/Tiles/Spirals.exr : 1040 x 1040, 5 channel, half/half/half/half/float openexr
+    SHA-1: C8FE122F0C0E0A81D5DD84C1BFA70ABFC2FA401A
+    channel list: R (half), G (half), B (half), A (half), Z (float)
+    pixel data origin: x=-20, y=-20
+    full/display size: 1000 x 1000
+    full/display origin: 0, 0
+    tile size: 287 x 126
+    oiio:ColorSpace: "Linear"
+    compression: "pxr24"
+    DateTime: "2004:01:19 10:25:14"
+    chromaticities: 0.62955, 0.341, 0.2867, 0.6108, 0.1489, 0.07125, 0.3155, 0.33165
+    Copyright: "Copyright 2004 Industrial Light & Magic"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0 0
+    screenWindowWidth: 1
+    utcOffset: 28800
+    whiteLuminance: 90
+Comparing "../../../../../openexr-images/Tiles/Spirals.exr" and "Spirals.exr"
 PASS

--- a/testsuite/openexr-suite/run.py
+++ b/testsuite/openexr-suite/run.py
@@ -18,7 +18,7 @@ files = [ "StillLife.exr", "Tree.exr", "Blobbies.exr" ]
 for f in files:
     command += rw_command (imagedir, f)
 # Cannon must be instructed to use lossless compression
-# FIXME - on all: chromaticies, screenWindowCenter, preview?
+# FIXME - on all: screenWindowCenter, preview?
 
 # ../openexr-images/TestImages:
 # AllHalfValues.exr        GrayRampsDiagonal.exr    SquaresSwirls.exr
@@ -36,7 +36,6 @@ for f in files:
 # ../openexr-images/Tiles:
 # GoldenGate.exr  Ocean.exr       Spirals.exr
 imagedir = parent + "/openexr-images/Tiles"
-files = [ "GoldenGate.exr", "Ocean.exr" ]
+files = [ "GoldenGate.exr", "Ocean.exr", "Spirals.exr" ]
 for f in files:
     command += rw_command (imagedir, f)
-# FIXME - Spirals: per-channel formats, iv >4 chans, chromaticities


### PR DESCRIPTION
"Chromaticites" has a custom attribute type to OpenEXR, so need a bit of special handling to get it right.

