### PR TITLE
simd.h needs cstring header to get declaration of memcmp

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -56,6 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenEXR/ImathVec.h>
 #include <OpenEXR/ImathMatrix.h>
 #include <algorithm>
+#include <cstring>
 
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
@danwexler Does this help?
