### PR TITLE
RAW reader: turn off some auto-adjustments

### DIFF
--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -698,10 +698,10 @@ It's not a smart choice unless you are sending your images back to the
 \noindent\begin{tabular}{p{1.3in}|p{0.5in}|p{3.50in}}
 \ImageSpec Attribute & Type & PNG header data or explanation \\
 \hline
-\qkw{oiio:BitsPerSample} & int & the true bits per sample of the file
+\qkws{oiio:BitsPerSample} & int & the true bits per sample of the file
   (1 for true PBM files, even though OIIO will report the {\cf format}
   as UINT8). \\
-\qkw{pnm:binary} & int & nonzero if the file itself used the PNM
+\qkws{pnm:binary} & int & nonzero if the file itself used the PNM
   binary format, 0 if it used ASCII.  The PNM writer honors this
   attribute in the \ImageSpec to determine whether to write an ASCII
   or binary file.
@@ -753,6 +753,66 @@ write Ptex files at all.
 
 \vspace{.25in}
 
+\section{RAW digital camera files}
+\label{sec:bundledplugins:raw}
+\index{RAW digital camera files}
+
+A variety of digital camera ``raw'' formats are supported via this
+plugin that is based on the LibRaw library ({\cf http://www.libraw.org/}).
+
+
+% FIXME - fill in more docs here
+
+\begin{comment}
+%\subsubsection*{Attributes}
+\vspace{.125in}
+
+\noindent\begin{tabular}{p{1.75in}|p{0.5in}|p{3.0in}}
+\ImageSpec Attribute & Type & RAW header data or explanation \\
+\hline
+\qkw{ImageDescription} & string & comment \\
+\qkw{oiio:BitsPerSample} & int & the true bits per sample in the RAW file.
+\end{tabular}
+\end{comment}
+
+\subsubsection*{Configuration settings for RAW input}
+
+When opening an \ImageInput with a \emph{configuration} (see
+Section~\ref{sec:inputwithconfig}), the following special configuration
+options are supported:
+
+\vspace{.125in}
+
+\noindent\begin{tabular}{p{1.8in}|p{0.5in}|p{2.95in}}
+Configuration attribute & Type & Meaning \\
+\hline
+\qkws{raw:auto_bright} & int & If nonzero, will use libraw's exposure
+                               correction. (Default: 0) \\
+\qkws{raw:use_camera_wb} & int & If 1, use libraw's camera white
+                               balance adjustment. (Default: 1) \\
+\qkws{raw:use_camera_matrix} & int & If 1, use libraw's camera matrix
+                               balance adjustment. (Default: 0) \\
+\qkws{raw:adjust_maximum_thr} & float & If nonzero, auto-adjusting maximum
+                                    value. (Default:0.0) \\
+\qkws{raw:ColorSpace} & string & Which color primaries to use: \qkw{raw},
+                                \qkw{sRGB}, \qkw{Adobe}, \qkw{Wide},
+                                \qkw{ProPhoto}, \qkw{XYZ}.
+                                (Default: \qkw{sRGB}) \\
+\qkws{raw:Exposure} & float & Amount of exposure before de-mosaicing, from
+                                0.25 (2 stop darken) to 8 (3 stop brighten).
+                                (Default: 0, meaning no correction.) \\
+\qkws{raw:Demosaic} & string & Force a demosaicing algorithm: \qkw{linear},
+                                \qkw{VNG}, \qkw{PPG}, \qkw{AHD} (default),
+                                \qkw{DCB}, \qkw{Modified AHD}, \qkw{AFD},
+                                \qkw{VCD}, \qkw{Mixed}, \qkw{LMMSE},
+                                \qkw{AMaZE}. \\
+\end{tabular}
+
+
+\vspace{.25in}
+\newpage
+
+
 \section{RLA}
 \label{sec:bundledplugins:rla}
 \index{RLA}
@@ -764,42 +824,42 @@ developed at Wavefront.  RLA files commonly use the file extension {\cf .rla}.
 %\subsubsection*{Attributes}
 \vspace{.125in}
 
-\noindent\begin{tabular}{p{1.75in}|p{0.5in}|p{3.0in}}
+\noindent\begin{tabular}{p{1.65in}|p{0.85in}|p{2.8in}}
 \ImageSpec Attribute & Type & RLA header data or explanation \\
 \hline
-{\cf width}, {\cf height}, {\cf x}, {\cf y} & & RLA ``active/viewable'' window. \\
+{\cf width}, {\cf height}, {\cf x}, {\cf y} & {\kw int} & RLA ``active/viewable'' window. \\
 & & \\
 {\cf\small full_width}, {\cf\small full_height}, {\cf\small full_x}, 
-  {\cf\small full_y} & & RLA ``full'' window.  \\
+  {\cf\small full_y} & {\kw int} & RLA ``full'' window.  \\
 & & \\
-\qkw{rla:FrameNumber} & int & frame sequence number. \\
-\qkw{rla:Revision} & int & file format revision number, currently
+\qkws{rla:FrameNumber} & int & frame sequence number. \\
+\qkws{rla:Revision} & int & file format revision number, currently
   \qkw{0xFFFE}. \\
-\qkw{rla:JobNumber} & int & job number ID of the file. \\
-\qkw{rla:FieldRendered} & int & whether the image is a field-rendered
+\qkws{rla:JobNumber} & int & job number ID of the file. \\
+\qkws{rla:FieldRendered} & int & whether the image is a field-rendered
   (interlaced) one (\qkw{0} for false, non-zero for true). \\
-\qkw{rla:FileName} & string & name under which the file was orignally saved. \\
+\qkws{rla:FileName} & string & name under which the file was orignally saved. \\
 \qkw{ImageDescription} & string & RLA ``Description'' of the image. \\
 \qkw{Software} & string & name of software used to save the image. \\
 \qkw{HostComputer} & string & name of machine used to save the image. \\
 \qkw{Artist} & string & RLA ``UserName'': logon name of user who saved the image. \\
-\qkw{rla:Aspect} & string & aspect format description string. \\
-\qkw{rla:ColorChannel} & string & textual description of color channel data
+\qkws{rla:Aspect} & string & aspect format description string. \\
+\qkws{rla:ColorChannel} & string & textual description of color channel data
   format (usually \qkw{rgb}). \\
-\qkw{rla:Time} & string & description (format not standardized) of amount of
+\qkws{rla:Time} & string & description (format not standardized) of amount of
   time spent on creating the image. \\
-\qkw{rla:Filter} & string & name of post-processing filter applied to the
+\qkws{rla:Filter} & string & name of post-processing filter applied to the
   image. \\
-\qkw{rla:AuxData} & string & textual description of auxiliary channel data
+\qkws{rla:AuxData} & string & textual description of auxiliary channel data
   format. \\
-\qkw{rla:AspectRatio} & float & image aspect ratio. \\
-\qkw{rla:RedChroma} & vec2 or vec3 of floats & red point XY (vec2) or XYZ
+\qkws{rla:AspectRatio} & float & image aspect ratio. \\
+\qkws{rla:RedChroma} & vec2 or vec3 of floats & red point XY (vec2) or XYZ
   (vec3) coordinates. \\
-\qkw{rla:GreenChroma} & vec2 or vec3 of floats & green point XY (vec2) or XYZ
+\qkws{rla:GreenChroma} & vec2 or vec3 of floats & green point XY (vec2) or XYZ
   (vec3) coordinates. \\
-\qkw{rla:BlueChroma} & vec2 or vec3 of floats & blue point XY (vec2) or XYZ
+\qkws{rla:BlueChroma} & vec2 or vec3 of floats & blue point XY (vec2) or XYZ
   (vec3) coordinates. \\
-\qkw{rla:WhitePoint} & vec2 or vec3 of floats & white point XY (vec2) or XYZ
+\qkws{rla:WhitePoint} & vec2 or vec3 of floats & white point XY (vec2) or XYZ
   (vec3) coordinates. \\
 \end{tabular}
 
@@ -863,31 +923,6 @@ files and is unable to write them.
 \qkw{oiio:BitsPerSample} & int & the true bits per sample in the PIC file.
 \end{tabular}
 
-
-
-\vspace{.25in}
-
-\section{RAW digital camera files}
-\label{sec:bundledplugins:raw}
-\index{RAW digital camera files}
-
-A variety of digital camera ``raw'' formats are supported via this
-plugin that is based on the LibRaw library ({\cf http://www.libraw.org/}).
-
-
-% FIXME - fill in more docs here
-
-\begin{comment}
-%\subsubsection*{Attributes}
-\vspace{.125in}
-
-\noindent\begin{tabular}{p{1.75in}|p{0.5in}|p{3.0in}}
-\ImageSpec Attribute & Type & PIC header data or explanation \\
-\hline
-\qkw{ImageDescription} & string & comment \\
-\qkw{oiio:BitsPerSample} & int & the true bits per sample in the PIC file.
-\end{tabular}
-\end{comment}
 
 
 \vspace{.25in}
@@ -1036,7 +1071,6 @@ Output attribute & Type & Meaning \\
         what the setting.
 \end{tabular}
 
-\newpage
 \subsubsection*{TIFF compression modes}
 
 \noindent The full list of possible TIFF compression mode values are as

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -135,6 +135,21 @@ RawInput::open (const std::string &name, ImageSpec &newspec,
     m_processor.imgdata.params.gamm[0] = 1.0;
     m_processor.imgdata.params.gamm[1] = 1.0;
 
+    // Disable exposure correction (unless config "raw:auto_bright" == 1)
+    m_processor.imgdata.params.no_auto_bright =
+        ! config.get_int_attribute("raw:auto_bright", 0);
+    // Use camera white balance if "raw:use_camera_wb" is not 0
+    m_processor.imgdata.params.use_camera_wb =
+        config.get_int_attribute("raw:use_camera_wb", 1);
+    // Turn off maximum threshold value (unless set to non-zero)
+    m_processor.imgdata.params.adjust_maximum_thr =
+        config.get_float_attribute("raw:adjust_maximum_thr", 0.0f);
+
+    // Use camera matrix (if config "raw:use_camera_matrix" is not 0)
+    m_processor.imgdata.params.use_camera_matrix =
+        config.get_int_attribute("raw:use_camera_matrix", 0);
+
+
     // Check to see if the user has explicitly set the output colorspace primaries
     std::string cs = config.get_string_attribute ("raw:ColorSpace", "sRGB");
     if (cs.size()) {


### PR DESCRIPTION
Per discussion on oiio-dev, the consensus seems to be:

* Turn off auto-bright adjustment
* turn on camera whie balance
* set maximum thresholding to 0

Add "config" overrides for all of these, for anybody who doesn't like
the default.

Also, document these, and the other existing-but-undocumented configuration
settings.