### PR TITLE
oiiotool: make sure to propagate channel formats of input to output

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -241,6 +241,12 @@ Oiiotool::read (ImageRecRef img, ReadPolicy readpolicy)
         if (! output_bitspersample)
             output_bitspersample = nspec.get_int_attribute ("oiio:BitsPerSample");
     }
+    if (output_channelformats.empty() && nspec.channelformats.size()) {
+        for (int c = 0; c < nspec.nchannels; ++c) {
+            std::string chname = nspec.channelnames[c];
+            output_channelformats[chname] = std::string(nspec.channelformat(c).c_str());
+        }
+    }
 
     if (! ok) {
         error ("read "+img->name(), img->geterror());


### PR DESCRIPTION
Oiiotool took care to remember the data format of the first input file
it reads, and proagate that to the outputs (if not explicitly set by
-d).  And the -d could handle specifying per-channel data types. But we
didn't handle the case of remembering per-channel data types from the
input and propagating to the output.

Example:

    oiiotool -create 64x64 3 -d R=half,G=float,B=half -o test.exr

properly makes a half/float/half mixed file. But then subsequently,

    oiiotool test.exr -o out.exr

lost that info, saving it entirely as float/float/float.

With this patch, this works properly, and out.exr will correcly end up
as half/float/half.

I believe this fixes #1445 
