### PR TITLE
OpenEXR: allow dwaaCompressionLevel to be appended to compression name.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -221,6 +221,9 @@ Fixes, minor enhancements, and performance improvements:
       PixelAspectRatio based on the "XResolution" and "YResolution"
       attributes. #1453 (Fixes #1214) (1.7.4/1.6.16)
     * Fix setting "chromaticity" metadata in EXR files. #1487 (1.7.5)
+    * When writing OpenEXR, accept compression requests with quality numbers
+      appended to the compression algorithm name, such as "dwaa:200" to mean
+      dwaa compression with a dwaCompressionLevel set to 200. #1493 (1.7.6)
  * PNG:
     * Per the PNG spec, name 2-channel images Y,A. #1435 (1.7.3)
     * Enforce that alpha premultiplication on output MUST consider alpha

--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -576,7 +576,9 @@ The official OpenEXR site is \url{http://www.openexr.com/}.
   \qkw{dwaa}, or \qkw{dwab}.  If the
   writer receives a request for a compression type it does not
   recognize or is not supported by the version of OpenEXR on the system,
-  it will use \qkw{zip} by default. \\
+  it will use \qkw{zip} by default. For \qkw{dwaa} and \qkw{dwab}, the
+  dwaCompressionLevel may be optionally appended to the compression name
+  after a colon, like this: \qkw{dwaa:200}. \\
 \qkw{textureformat} & string & set to \qkw{Plain Texture} for
   MIP-mapped OpenEXR files, \qkw{CubeFace Environment} or \qkw{Latlong
     Environment} for OpenEXR environment maps.  Non-environment


### PR DESCRIPTION
For example, oiiotool in.exr -compression dwaa:200 -o out.exr

This is more convenient than separately needing to set the
"openexr:dwaCompressionLevel" metadata.

This came from discussion on a thread on oiio-dev mail list.
