### PR TITLE
oiiotool: new -o option: -o:all=n <pattern>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -119,6 +119,14 @@ Fixes, minor enhancements, and performance improvements:
       union of all nonzero pixels in all subimages. #1440 (1.7.3)
     * --help now prints all of the dependent libraries for individual
       formats. #1458 (1.7.5)
+    * -o:all=n will output all images currently on the stack, and the
+      filename argument will be assumed to be a pattern containing a %d,
+      which will be substituted with the index of the image (beginning with
+      n). For example, to take a multi-image TIFF and extract all the
+      subimages separately,
+          oiiotool multi.tif -sisplit -o:all=1 sub%04d.tif
+      will output the subimges as sub0001.tif, sub0002.tif, and so on.
+      #1494 (1.7.6)
  * ImageBuf:
     * ImageBuf::iterator performance is improved -- roughly cutting in half
       the overhead of iterating over pixels. #1308 (1.7.1/1.6.10)

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -623,6 +623,16 @@ of time, and will always put the text 30 pixels from the bottom of the image
 without requiring you to know the resolution.
 
 
+\subsection{Split a multi-image file into separate files}
+\noindent Take a multi-image TIFF file, split into its constituent subimages
+and output each one to a different file, with names \qkw{sub0001.tif},
+\qkw{sub0002.tif}, etc.
+
+\begin{code}
+    oiiotool multi.tif -sisplit -o:all=1 sub%04d.tif
+\end{code}
+
+
 \newpage
 \section{\oiiotool commands: general and image information}
 
@@ -1029,7 +1039,24 @@ current image from the image stack, it merely saves a copy of it.
     for this output. \\
 {\cf\small fileformatname=}\emph{string} & Specify the desired output file
   format, overriding any guess based on file name extension. \\
+{\cf all=}\emph{n} & Output all images currently on the stack using a
+      pattern. See further explanation below.
 \end{tabular}
+
+The {\cf all=}\emph{n} option causes \emph{all} images on the image stack
+to be output, with the
+filename argument used as a pattern assumed to contain a {\cf \%d},
+which will be substituted with the index of the image (beginning with
+\emph{n}). For example, to take a multi-image TIFF and extract all the
+subimages and save them as separate files,
+\NEW % 1.7
+
+\begin{code}
+    oiiotool multi.tif -sisplit -o:all=1 sub%04d.tif
+\end{code}
+\vspace{-12pt}
+\noindent This will output the subimges as separate files \qkw{sub0001.tif},
+\qkw{sub0002.tif}, and so on.
 
 \apiend
 

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -94,7 +94,7 @@
  \bigskip \\
 }
 \date{{\large
-Date: 10 Sep 2016
+Date: 22 Sep 2016
 %\\ (with corrections, 5 Sep 2016)
 }}
 

--- a/testsuite/oiiotool-subimage/run.py
+++ b/testsuite/oiiotool-subimage/run.py
@@ -15,8 +15,7 @@ command += oiiotool ("--pattern constant:color=0.5,0.0,0.0 64x64 3 --text A -att
                      "--siappendall -d half -o subimages-4.exr")
 command += oiiotool ("subimages-4.exr --subimage 3 -o subimageD3.exr")
 command += oiiotool ("subimages-4.exr --subimage layerB -o subimageB1.exr")
-command += oiiotool ("subimages-2.exr --sisplit -o subimage2.exr " +
-                     "--pop -o subimage1.exr")
+command += oiiotool ("subimages-2.exr --sisplit -o:all=1 subimage%d.exr")
 
 
 # Outputs to check against references


### PR DESCRIPTION
This causes all images on the stack to be output (not just the top), using
the filename pattern (assumed to have an integer substitution '%d'). The
number substituted will be index of the image (starting with the bottom
of the stack, beginning with number n).

Example of how this is useful:

    oiiotool multiimage.tif -sisplit -o:all=1 subimage%04d.tif

Splits multiimage.tif into individual subimages and saves them all
as separate images with names subimage0001.tif, subimage0002.tif, etc.