### PR TITLE
Smarter channel_append channel renaming: use subimage name if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,7 +563,7 @@ oiio_add_tests (
                 oiiotool-pattern oiiotool-readerror
                 oiiotool-subimage oiiotool-text
                 maketx oiiotool-maketx
-                dither
+                dither dup-channels
                 dpx ico iff png psd rla sgi
                 python-typedesc python-imagespec python-roi python-deep
                 python-imageinput python-imageoutput

--- a/testsuite/dup-channels/ref/out.txt
+++ b/testsuite/dup-channels/ref/out.txt
@@ -1,0 +1,21 @@
+Reading out.exr
+out.exr              :   64 x   64, 6 channel, half openexr
+    SHA-1: 6FECD5769C727E137B7580AE3B1823B06EE6F9D9
+    channel list: R, G, B, channel3, channel4, channel5
+    oiio:ColorSpace: "Linear"
+    compression: "zip"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0 0
+    screenWindowWidth: 1
+Reading out2.exr
+out2.exr             :   64 x   64, 6 channel, half openexr
+    SHA-1: 6FECD5769C727E137B7580AE3B1823B06EE6F9D9
+    channel list: R, G, B, Bimg.R, Bimg.G, Bimg.B
+    oiio:ColorSpace: "Linear"
+    compression: "zip"
+    name: "Aimg"
+    openexr:chunkCount: 4
+    PixelAspectRatio: 1
+    screenWindowCenter: 0 0
+    screenWindowWidth: 1
+    oiio:subimagename: "Aimg"

--- a/testsuite/dup-channels/run.py
+++ b/testsuite/dup-channels/run.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+# Test that appending channels fixes duplicate channel names
+
+
+# Test 1: Make two images, both with R,G,B channel names, so duplicated.
+# When mashing them together, they should end up with channels
+# R, G, B, channel3, channel4, channel5.
+command += oiiotool ("--create 64x64 3 -d uint8 -o a.exr")
+command += oiiotool ("--create 64x64 3 -d uint8 -o b.exr")
+command += oiiotool ("a.exr b.exr -chappend -o out.exr")
+command += info_command ("out.exr", safematch=True)
+
+
+# Test 2: Start with a multi-image file with different subimage names,
+# then split subimages and append channels (convert multi-image file to
+# single image / many-channel). The new channel names should be
+# de-duplicated by using the subimage names. The resulting image should
+# have channels R, G, B, Bimg.R, Bimg.G, Bimg.B.
+command += oiiotool ("a.exr --attrib oiio:subimagename Aimg " +
+                     "b.exr --attrib oiio:subimagename Bimg " +
+                     "--siappend -o multi.exr")
+command += oiiotool ("multi.exr -sisplit --chappend -o out2.exr")
+command += info_command ("out2.exr", safematch=True)

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -134,7 +134,7 @@ def oiio_app (app):
 # Construct a command that will print info for an image, appending output to
 # the file "out.txt".  If 'safematch' is nonzero, it will exclude printing
 # of fields that tend to change from run to run or release to release.
-def info_command (file, extraargs="", safematch=0, hash=True) :
+def info_command (file, extraargs="", safematch=False, hash=True) :
     if safematch :
         extraargs += " --no-metamatch \"DateTime|Software|OriginatingProgram|ImageHistory\""
     if hash :


### PR DESCRIPTION
For OpenEXR, channel names are not merely informational -- channel names *must* be unique within an image part, or else the ones with duplicate names will be dropped silently when the file is outout.

IBA::channel_append (and therefore `oiiotool --chappend`) tried to protect against that by renaming duplicate channels "channelN". (As would happen if you chappend'ed two images that each were R,G,B.)

There's a special case to consider: taking a multi-subimage (or multi-part, in EXR lingo) and turning into a many-channel image. Like you'd do with this command:

    oiiotool manyparts.exr -sisplit -chappend -o manychannels.exr

Having channels named R, G, B, channel3, channel4, ... isn't the best we can do.

This patch modifies the renaming of duplicate channel names within channel_append so that if the image had a "oiio:subimagename" metadata, it uses that as a prefix to try to create a unique name.

So, as an example, suppose manyparts.exr had two parts, both with channels named R, G, and B, and the second part of the image had the name "specular", then the image resulting from the above command would end up with channels named R, G, B, specular.R, specular.G, specular.B.

This is likely to be a lot more useful to people. If this *still* results in a duplicate channel name somehow, then it will fall back on the old strategy of just calling it "channelN".

While I was messing with that part of the code, I also lifted the restriction on IBA::channel_append that required the destination image to be float. Now, although the two input images must match data type, the output image can be any desired type.