### PR TITLE
UDIM get_image_info query for "channels" should succeed.

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -2495,6 +2495,26 @@ ImageCacheImpl::get_image_info (ImageCacheFile *file,
         *(int *)data = file->is_udim();
         return true;
     }
+    if (file->is_udim() && dataname == s_channels) {
+        // Special case -- it's ok to ask for a UDIM's channels. It'll
+        // search for a concrete file. Beware, this will cause trouble
+        // if different panels of the same UDIM scheme have different
+        // numbers of channels! Search the 10x100 files for a match, give
+        // up if not found.
+        ImageCacheFile *concretefile = NULL;
+        for (int j = 0; j < 100 && !concretefile; ++j) {
+            for (int i = 0; i < 10; ++i) {
+                float s = i + 0.5f, t = j + 0.5f;
+                if (ImageCacheFile *c = resolve_udim (file, s, t)) {
+                    concretefile = c;
+                    break;
+                }
+            }
+        }
+        if (concretefile)
+            file = verify_file (concretefile, thread_info, true);
+    }
+
     if (file->is_udim()) {
         return false;     // UDIM-like files fail all other queries
     }


### PR DESCRIPTION
In general, ImageCache::get_image_info (or the TextureSystem equivalent, get_texture_info) fails for UDIM texture patterns, for all but the "UDIM" query (which means, "is this a UDIM file").

This is because the UDIM name is a pattern, not a concrete file. The specific file is not resolved until the texture() call itself, because the actual filename will depend on the st coordinates being looked up. The get_texture_info query is not for a particular coordinate.

But let's say that you are writing a shader and want different behavior or code paths depending on properties of the file, such as the number of channels. Those queries would fail.

So the purpose of this patch is to make the "channels" query to succeed. It will find the first file to match the pattern (the 0,0 corner may not exist -- the UDIM set is allowed to be sparse) and query that.  The big caveat is, this won't be helpful if the textures in the UDIM collection don't all have the same number of channels. So watch out for that if you want to throw caution to the wind and do queries on UDIM patterns.

To start with, since this is so inherently dangerous, "channels" is the only query we support this way. We may expand this set later, if there are other queries that (a) especially useful, and (b) make sense to constrain (or assume) to be identical for all individual textures in the same UDIM set.