### PR TITLE
Overhaul of metadata printing.

### DIFF
--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -662,6 +662,19 @@ values) for certain known metadata.
 \apiend
 
 
+\apiitem{std::string {\ce serialize} (SerialFormat format, SerialVerbose verbose) const}
+\NEW % 1.8
+Returns, as a string, a serialized version of the \ImageSpec.
+The {\cf format} may be either {\cf ImageSpec::SerialText} or
+{\cf ImageSpec::SerialXML}.
+The {\cf verbose} argument may be one of: {\cf ImageSpec::SerialBrief} (just
+resolution and other vital statistics, one line for {\cf SerialText},
+{\cf ImageSpec::SerialDetailed} (contains all metadata in orginal form), or
+{\cf ImageSpec::SerialDetailedHuman} (contains all metadata, in many cases
+with human-readable explanation).
+
+\apiend
+
 \apiitem{std::string {\ce to_xml} () const}
 Saves the contents of the \ImageSpec as XML, returning it as a string.
 \apiend

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -248,6 +248,12 @@ To print the name, format, resolution, and data type of an image
     oiiotool --info -v *.tif
 \end{code}
 
+\noindent or
+
+\begin{code}
+    oiiotool --info:verbose=1 *.tif
+\end{code}
+
 \noindent To print info about all subimages and/or MIP-map levels of each
 input image, use the {\cf -a} flag:
 
@@ -679,6 +685,16 @@ Prints information about each input image as it is read.  If verbose mode
 is turned on ({\cf -v}), all the metadata for the image is printed.
 If verbose mode is not turned on, only the resolution and data format
 are printed.
+
+\noindent Optional appended arguments include:
+
+\begin{tabular}{p{10pt} p{0.75in} p{3.75in}}
+  & {\cf format=}\emph{name} & The format may be one of: {\cf text} (default)
+      for readable text, or {\cf xml} for an XML description of the image
+      metadata. \\
+  & {\cf verbose=}\emph{1} & If nonzero, the information will contain all
+      metadata, not just the minimal amount.
+\end{tabular}
 \apiend
 
 \apiitem{{\ce --metamatch} {\rm \emph{regex}} \\
@@ -884,6 +900,9 @@ options that control the reading of just that one file.
 {\cf info=}\emph{int} & Print info about this file (even if the global
      {\cf --info} was not used) if nonzero. If the value is 2, print full
      verbose info (like {\cf --info -v}). \\
+{\cf format=}\emph{name} & When printing info, the format may be one of:
+      {\cf text} (default) for readable text, or {\cf xml} for an XML
+      description of the image metadata. \\
 \end{tabular}
 \apiend
 
@@ -2891,6 +2910,13 @@ Print to the console detailed information about the values in every pixel.
 
 \apiitem{\ce --info}
 Prints information about each input image as it is read.
+
+\noindent Optional appended arguments include:
+
+\begin{tabular}{p{10pt} p{0.75in} p{3.75in}}
+  & {\cf format=}\emph{fmt} & The format of the information printed, which
+  may be {\cf text} (the default) or {\cf xml}.
+\end{tabular}
 \apiend
 
 \apiitem{\ce --trim}

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -94,7 +94,7 @@
  \bigskip \\
 }
 \date{{\large
-Date: 22 Sep 2016
+Date: 25 Sep 2016
 %\\ (with corrections, 5 Sep 2016)
 }}
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -355,6 +355,13 @@ public:
     static std::string metadata_val (const ImageIOParameter &p,
                               bool human=false);
 
+    enum SerialFormat  { SerialText, SerialXML };
+    enum SerialVerbose { SerialBrief, SerialDetailed, SerialDetailedHuman };
+
+    /// Convert ImageSpec class into a serialized string.
+    std::string serialize (SerialFormat format,
+                           SerialVerbose verbose = SerialDetailed) const;
+
     /// Convert ImageSpec class into XML string.
     ///
     std::string to_xml () const;

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -549,7 +549,8 @@ format_raw_metadata (const ImageIOParameter &p, int maxsize=16)
     if (element.basetype == TypeDesc::STRING) {
         for (int i = 0;  i < n;  ++i) {
             const char *s = ((const char **)p.data())[i];
-            out += Strutil::format ("%s\"%s\"", (i ? ", " : ""), s ? s : "");
+            out += Strutil::format ("%s\"%s\"", (i ? ", " : ""),
+                                    s ? Strutil::escape_chars(s) : std::string());
         }
     } else if (element.basetype == TypeDesc::FLOAT) {
         formatType< float >(p, n, element, "%s%g", out);
@@ -863,22 +864,23 @@ namespace { // Helper functions for from_xml () and to_xml () methods.
 
 using namespace pugi;
 
-static void
-add_node (xml_node &node, const std::string &node_name, const char *val)
+static xml_node
+add_node (xml_node &node, string_view node_name, const char *val)
 {
     xml_node newnode = node.append_child();
     newnode.set_name (node_name.c_str ());
     newnode.append_child (node_pcdata).set_value (val);
+    return newnode;
 }
 
 
 
-static void
-add_node (xml_node &node, const std::string &node_name, const int val)
+static xml_node
+add_node (xml_node &node, string_view node_name, const int val)
 {
     char buf[64];
     sprintf (buf, "%d", val);
-    add_node (node, node_name, buf);
+    return add_node (node, node_name, buf);
 }
 
 
@@ -888,7 +890,7 @@ add_channelnames_node (xml_document &doc, const std::vector<std::string> &channe
 {
     xml_node channel_node = doc.child ("ImageSpec").append_child();
     channel_node.set_name ("channelnames");
-    BOOST_FOREACH (std::string name, channelnames) {
+    BOOST_FOREACH (const std::string &name, channelnames) {
         add_node (channel_node, "channelname", name.c_str ());
     }
 }
@@ -910,8 +912,43 @@ get_channelnames (const xml_node &n, std::vector<std::string> &channelnames)
 
 
 
-std::string
-ImageSpec::to_xml () const
+static const char *
+extended_format_name (TypeDesc type, int bits)
+{
+    if (bits && bits < (int)type.size()*8) {
+        // The "oiio:BitsPerSample" betrays a different bit depth in the
+        // file than the data type we are passing.
+        if (type == TypeDesc::UINT8 || type == TypeDesc::UINT16 ||
+            type == TypeDesc::UINT32 || type == TypeDesc::UINT64)
+            return ustring::format("uint%d", bits).c_str();
+        if (type == TypeDesc::INT8 || type == TypeDesc::INT16 ||
+            type == TypeDesc::INT32 || type == TypeDesc::INT64)
+            return ustring::format("int%d", bits).c_str();
+    }
+    return type.c_str();  // use the name implied by type
+}
+
+
+
+inline std::string
+format_res (const ImageSpec &spec, int w, int h, int d)
+{
+    using Strutil::format;
+    return (spec.depth > 1) ? format("%d x %d x %d", w, h, d) : format("%d x %d", w, h);
+}
+
+
+inline std::string
+format_offset (const ImageSpec &spec, int x, int y, int z)
+{
+    using Strutil::format;
+    return (spec.depth > 1) ? format("%d, %d, %d", x, y, z) : format("%d, %d", x, y);
+}
+
+
+
+static std::string
+spec_to_xml (const ImageSpec &spec, ImageSpec::SerialVerbose verbose)
 {
     xml_document doc;
 
@@ -919,33 +956,141 @@ ImageSpec::to_xml () const
     doc.child ("ImageSpec").append_attribute ("version") = OIIO_PLUGIN_VERSION;
     xml_node node = doc.child ("ImageSpec");
 
-    add_node (node, "x", x);
-    add_node (node, "y", y);
-    add_node (node, "z", z);
-    add_node (node, "width", width);
-    add_node (node, "height", height);
-    add_node (node, "depth", depth);
-    add_node (node, "full_x", full_x);
-    add_node (node, "full_y", full_y);
-    add_node (node, "full_z", full_z);
-    add_node (node, "full_width", full_width);
-    add_node (node, "full_height", full_height);
-    add_node (node, "full_depth", full_depth);
-    add_node (node, "tile_width", tile_width);
-    add_node (node, "tile_height", tile_height);
-    add_node (node, "tile_depth", tile_depth);
-    add_node (node, "format", format.c_str ());
-    add_node (node, "nchannels", nchannels);
-    add_channelnames_node (doc, channelnames);
-    add_node (node, "alpha_channel", alpha_channel);
-    add_node (node, "z_channel", z_channel);
-    add_node (node, "deep", int(deep));
-    
-    // FIXME: What about extra attributes?
-    
+    add_node (node, "x", spec.x);
+    add_node (node, "y", spec.y);
+    add_node (node, "z", spec.z);
+    add_node (node, "width", spec.width);
+    add_node (node, "height", spec.height);
+    add_node (node, "depth", spec.depth);
+    add_node (node, "full_x", spec.full_x);
+    add_node (node, "full_y", spec.full_y);
+    add_node (node, "full_z", spec.full_z);
+    add_node (node, "full_width", spec.full_width);
+    add_node (node, "full_height", spec.full_height);
+    add_node (node, "full_depth", spec.full_depth);
+    add_node (node, "tile_width", spec.tile_width);
+    add_node (node, "tile_height", spec.tile_height);
+    add_node (node, "tile_depth", spec.tile_depth);
+    add_node (node, "format", spec.format.c_str ());
+    add_node (node, "nchannels", spec.nchannels);
+    add_channelnames_node (doc, spec.channelnames);
+    add_node (node, "alpha_channel", spec.alpha_channel);
+    add_node (node, "z_channel", spec.z_channel);
+    add_node (node, "deep", int(spec.deep));
+
+    if (verbose > ImageSpec::SerialBrief) {
+        BOOST_FOREACH (const ImageIOParameter &p, spec.extra_attribs) {
+            std::string s = spec.metadata_val (p, false);  // raw data
+            if (s == "1.#INF")
+                s ="inf";
+            if (p.type() == TypeDesc::STRING) {
+                if (s.size() >= 2 && s[0] == '\"' && s[s.size()-1] == '\"')
+                    s = s.substr (1, s.size()-2);
+            }
+            std::string desc;
+            for (int e = 0;  explanation[e].oiioname;  ++e) {
+                if (! strcmp (explanation[e].oiioname, p.name().c_str()) &&
+                    explanation[e].explainer) {
+                    desc = explanation[e].explainer (p, explanation[e].extradata);
+                    break;
+                }
+            }
+            if (p.type() == TypeDesc::TypeTimeCode) {
+                Imf::TimeCode tc = *reinterpret_cast<const Imf::TimeCode *>(p.data());
+                desc = Strutil::format ("%02d:%02d:%02d:%02d", tc.hours(),
+                                        tc.minutes(), tc.seconds(), tc.frame());
+            }
+            xml_node n = add_node (node, "attrib", s.c_str());
+            n.append_attribute("name").set_value (p.name().c_str());
+            n.append_attribute("type").set_value (p.type().c_str());
+            if (! desc.empty())
+                n.append_attribute("description").set_value (desc.c_str());
+        }
+    }
+
     std::ostringstream result;
     doc.print (result, "");
     return result.str();
+}
+
+
+
+
+std::string
+ImageSpec::serialize (SerialFormat fmt, SerialVerbose verbose) const
+{
+    if (fmt == SerialXML)
+        return spec_to_xml (*this, verbose);
+
+    // Text case:
+    //
+
+    using Strutil::format;
+    std::stringstream out;
+
+    out << ((depth > 1) ? format("%4d x %4d x %4d", width, height, depth)
+                        : format("%4d x %4d", width, height));
+    out << format (", %d channel, %s%s", nchannels,
+                   deep ? "deep " : "", depth > 1 ? "volume " : "");
+    if (channelformats.size()) {
+        for (size_t c = 0;  c < channelformats.size();  ++c)
+            out << format ("%s%s", c ? "/" : "", channelformats[c]);
+    } else {
+        int bits = get_int_attribute ("oiio:BitsPerSample", 0);
+        out << extended_format_name (this->format, bits);
+    }
+    out << '\n';
+
+    if (verbose >= SerialDetailed) {
+        out << format ("    channel list: ");
+        for (int i = 0;  i < nchannels;  ++i) {
+            if (i < (int)channelnames.size())
+                out << channelnames[i];
+            else
+                out << "unknown";
+            if (i < (int)channelformats.size())
+                out << format (" (%s)", channelformats[i]);
+            if (i < nchannels-1)
+                out << ", ";
+        }
+        out << '\n';
+        if (x || y || z) {
+            out << "    pixel data origin: "
+                << ((depth > 1) ? format("x=%d, y=%d, z=%d", x, y, z)
+                                : format("x=%d, y=%d", x, y)) << '\n';
+        }
+        if (full_x || full_y || full_z ||
+              (full_width != width && full_width != 0) ||
+              (full_height != height && full_height != 0) ||
+              (full_depth != depth && full_depth != 0)) {
+            out << "    full/display size: "
+                << format_res (*this, full_width, full_height, full_depth) << '\n';
+            out << "    full/display origin: "
+                << format_offset (*this, full_x, full_y, full_z) << '\n';
+        }
+        if (tile_width) {
+            out << "    tile size: "
+                << format_res (*this, tile_width, tile_height, tile_depth) << '\n';
+        }
+
+        BOOST_FOREACH (const ImageIOParameter &p, extra_attribs) {
+            out << format ("    %s: ", p.name());
+            std::string s = metadata_val (p, verbose == SerialDetailedHuman);
+            if (s == "1.#INF")
+                s ="inf";
+            out << s << '\n';
+        }
+    }
+
+    return out.str();
+}
+
+
+
+std::string
+ImageSpec::to_xml () const
+{
+    return spec_to_xml (*this, SerialDetailedHuman);
 }
 
 

--- a/src/libOpenImageIO/imagespec_test.cpp
+++ b/src/libOpenImageIO/imagespec_test.cpp
@@ -126,11 +126,11 @@ void test_imagespec_metadata_val ()
 
     const char* smatrix[] = {"this is \"a test\"", "this is another test"};
     metadata_val_test (smatrix, 1, TypeDesc::TypeString, ret);
-    OIIO_CHECK_EQUAL (ret, "\"this is \"a test\"\"");
+    OIIO_CHECK_EQUAL (ret, "\"this is \\\"a test\\\"\"");
     OIIO_CHECK_NE (ret, smatrix[0]);
     OIIO_CHECK_NE (ret, "\"this is \"a test\"\",");
     metadata_val_test (smatrix, sizeof (smatrix) / sizeof (char *), TypeDesc::TypeString, ret);
-    OIIO_CHECK_EQUAL (ret, "\"this is \"a test\"\", \"this is another test\"");
+    OIIO_CHECK_EQUAL (ret, "\"this is \\\"a test\\\"\", \"this is another test\"");
 
     float matrix16[2][16] = {{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
                         {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25}};

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -84,6 +84,8 @@ public:
     std::string full_command_line;
     std::string printinfo_metamatch;
     std::string printinfo_nometamatch;
+    std::string printinfo_format;
+    bool printinfo_verbose;
     ImageSpec input_config;           // configuration options for reading
     bool input_config_set;
 
@@ -126,6 +128,7 @@ public:
     bool enable_function_timing;
     size_t peak_memory;
     int num_outputs;                         // Count of outputs written
+    bool printed_info;                       // printed info at some point
 
     Oiiotool ();
 
@@ -436,6 +439,7 @@ struct print_info_options {
     bool dumpdata_showempty;
     std::string metamatch;
     std::string nometamatch;
+    std::string infoformat;
     size_t namefieldlength;
 
     print_info_options ()


### PR DESCRIPTION
Airplane project from last weekend. This is for you, @danwexler 

* ImageSpec::to_xml() improvement: output contents of extra_attrib.
* ImageSpec::serialize() serializes the spec, as text or xml. Leaves
  room for other formats in the future. (JSON? YAML?)
* 'oiiotool -info:format=xml' prints metadata as xml

A bunch of refactoring to support this.