### PR TITLE
Be more careful about building iv man page

### DIFF
--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(PythonInterp)
 if (UNIX AND TXT2MAN AND PYTHONINTERP_FOUND)
     message (STATUS "Unix man page documentation will be generated")
     set (cli_tools oiiotool iinfo maketx idiff igrep iconvert)
-    if (USE_QT)
+    if (IV_BUILT)
         list (APPEND cli_tools iv)
     endif()
 

--- a/src/iv/CMakeLists.txt
+++ b/src/iv/CMakeLists.txt
@@ -24,6 +24,7 @@ if (QT4_FOUND AND OPENGL_FOUND AND GLEW_FOUND)
                                ${Boost_LIBRARIES} ${CMAKE_DL_LIBS}
                                ${GLEW_LIBRARIES})
     oiio_install_targets (iv)
+    set (IV_BUILT 1)
 
 else ()
     message (STATUS "\n\n   WARNING: Qt, OpenGL, or GLEW not found -- 'iv' will not be built!\n")


### PR DESCRIPTION
On Unix systems if txt2man is found, we automatically build man pages from our command-line binaries. It was smart enough to skip doing so for iv if USE_QT was 0 (that is, if the build was set up to purposely exclude anything using QT). But if USE_QT was not set to 0 but iv was skipped anyway (perhaps Qt or other iv-specific dependencies weren't found at build time), it would fail in trying to make the man page for iv, since the iv program itself could not be executed.

This logic fix instead predicates it on whether iv actually got built, regardless of whether its failure to build was due to explicitly skipping it, dependencies not found, or whatever.

Fixes #1509 (I think)
