### PR TITLE
Fix bug in recently modified UDIM code

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -2511,8 +2511,11 @@ ImageCacheImpl::get_image_info (ImageCacheFile *file,
                 }
             }
         }
-        if (concretefile)
-            file = verify_file (concretefile, thread_info, true);
+        if (concretefile) {
+            // Recurse to try again with the concrete file
+            return get_image_info (concretefile, thread_info, subimage,
+                                   miplevel, dataname, datatype, data);
+        }
     }
 
     if (file->is_udim()) {


### PR DESCRIPTION
Forgot to recheck for broken file after changing UDIM name pattern into
a concrete file. A better solution is to fully recurse (just one level)
to perform all the initial checks on the concrete file.