### PR TITLE
A number of fixes for Windows platform

### DIFF
--- a/src/ffmpeg.imageio/CMakeLists.txt
+++ b/src/ffmpeg.imageio/CMakeLists.txt
@@ -2,8 +2,10 @@
 # marked m_format_context->streams[i]->codec as deprecated.
 # FIXME -- at some point, come back and figure out how to fix for real
 # before the field disappears entirely.
-set_source_files_properties (ffmpeginput.cpp
+if (NOT MSVC)
+    set_source_files_properties (ffmpeginput.cpp
                              PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations")
+endif()
 
 if (USE_FFMPEG AND FFMPEG_FOUND)
     add_oiio_plugin (ffmpeginput.cpp ffmpegoutput.cpp

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -2467,7 +2467,7 @@ template<int i> OIIO_FORCEINLINE bool8 shuffle (const bool8& a) {
 
 template<int i>
 OIIO_FORCEINLINE bool extract (const bool8& a) {
-#if OIIO_SIMD_AVX
+#if OIIO_SIMD_AVX && !_WIN32
     return _mm256_extract_epi32(_mm256_castps_si256(a.simd()), i);  // SSE4.1 only
 #else
     return a[i];
@@ -2476,7 +2476,7 @@ OIIO_FORCEINLINE bool extract (const bool8& a) {
 
 template<int i>
 OIIO_FORCEINLINE bool8 insert (const bool8& a, bool val) {
-#if OIIO_SIMD_AVX
+#if OIIO_SIMD_AVX && !_WIN32
     int ival = -int(val);
     return _mm256_castsi256_ps (_mm256_insert_epi32 (_mm256_castps_si256(a.simd()), ival, i));
 #else
@@ -3654,7 +3654,7 @@ template<int i> OIIO_FORCEINLINE int8 shuffle (const int8& a) {
 
 template<int i>
 OIIO_FORCEINLINE int extract (const int8& v) {
-#if OIIO_SIMD_AVX
+#if OIIO_SIMD_AVX && !_WIN32
     return _mm256_extract_epi32(v.simd(), i);
 #else
     return v[i];
@@ -3664,7 +3664,7 @@ OIIO_FORCEINLINE int extract (const int8& v) {
 
 template<int i>
 OIIO_FORCEINLINE int8 insert (const int8& a, int val) {
-#if OIIO_SIMD_AVX
+#if OIIO_SIMD_AVX && !_WIN32
     return _mm256_insert_epi32 (a.simd(), val, i);
 #else
     int8 tmp = a;

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -23,8 +23,10 @@ endif()
 # marked m_format_context->streams[i]->codec as deprecated.
 # FIXME -- at some point, come back and figure out how to fix for real
 # before the field disappears entirely.
-set_source_files_properties (../ffmpeg.imageio/ffmpeginput.cpp
+if (NOT MSVC)
+    set_source_files_properties (../ffmpeg.imageio/ffmpeginput.cpp
                              PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations")
+endif()
 
 list (APPEND libOpenImageIO_srcs
                           deepdata.cpp exif.cpp formatspec.cpp imagebuf.cpp

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -142,6 +142,7 @@ if (USE_EXTERNAL_PUGIXML)
 endif ()
 
 target_link_libraries (OpenImageIO ${ILMBASE_LIBRARIES})
+target_link_libraries (OpenImageIO ${OPENEXR_LIBRARIES})
 target_link_libraries (OpenImageIO ${ZLIB_LIBRARIES})
 
 if (VERBOSE)

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -248,7 +248,11 @@ Filesystem::get_directory_entries (const std::string &dirname,
              s != boost::filesystem::recursive_directory_iterator();  ++s) {
             std::string file = s->path().string();
             if (!filter_regex.size() || boost::regex_search (file, re))
+#ifdef _WIN32
+                filenames.push_back (Strutil::utf16_to_utf8(s->path().native()));
+#else
                 filenames.push_back (file);
+#endif
         }
     } else {
 #ifdef _WIN32
@@ -260,7 +264,11 @@ Filesystem::get_directory_entries (const std::string &dirname,
              s != boost::filesystem::directory_iterator();  ++s) {
             std::string file = s->path().string();
             if (!filter_regex.size() || boost::regex_search (file, re))
+#ifdef _WIN32
+                filenames.push_back (Strutil::utf16_to_utf8(s->path().native()));
+#else
                 filenames.push_back (file);
+#endif
         }
     }
     return true;


### PR DESCRIPTION
## Description

The first three commits are needed to compile OIIO on Windows. I have checked the unavailability of the intrinsics in `<immintrin.h>`
The fourth commit fixes a bug on Windows where OIIO is unable to load its plugins. The reason is that `directory_iterator.path().string()` does not return a suitable path but must be first converted back to utf8. I haven't checked but the `regex `part looks also suspicious in this respect; Using a `wregex` looks more consistent.

## Tests

Tested by loading various images with iv

It would be nice to have those changes backported to 1.7

