### PR TITLE
Fix include order at the suggestion of Rob Pieke.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,7 @@ include (externalpackages)
 
 
 include_directories (
+    BEFORE
     "${CMAKE_SOURCE_DIR}/src/include"
     "${CMAKE_BINARY_DIR}/include/OpenImageIO"
   )


### PR DESCRIPTION
This ensures that the local include directories are considered before
any system directories, which avoids confusion if there are conflicting
versions of OIIO installed elsewhere.

Fixes #1522