### PR TITLE
Make temporary texture filename unique to avoid classes on shared drives

### DIFF
--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -828,8 +828,11 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
     // chance a crash during texture conversion will leave behind a
     // partially formed tx with incomplete mipmaps levels which happesn to
     // be extremely slow to use in a raytracer.
+    // We also force a unique filename to protect against multiple maketx
+    // processes running at the same time on the same file.
     std::string extension = Filesystem::extension(outputfilename);
-    std::string tmpfilename = Filesystem::replace_extension (outputfilename, ".temp"+extension);
+    std::string tmpfilename = Filesystem::replace_extension (outputfilename, ".%%%%%%%%.temp"+extension);
+    tmpfilename = Filesystem::unique_path(tmpfilename);
 
     // When was the input file last modified?
     // This is only used when we're reading from a filename


### PR DESCRIPTION
maketx (and IBA::make_texture underneath) writes its results to a temporary file to avoid overwriting an existing file and leaving an invalid file there if the command should be terminated before it's done. After it's done being written, the temp file is "moved" to the final destination, replacing it atomically.

But as Ramon points out, if multiple processes are running on the same shared disk partition and might try to maketx the same texture at the same time, they could clobber each other by both writing to identically named temp files. So the solution is to ask the OS to make a unique name for that temporary file, using Filesystem::unique_path().