### PR TITLE
Bring boost floor to 1.50

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ Release 1.8 (in progress) -- compared to 1.7.x
 ----------------------------------------------
 New minimum dependencies:
  * **C++11** (gcc 4.8.2, clang 3.3, or MSVS 2013)
+ * Boost >= 1.50
 
 Major new features and improvements:
 * New oiiotool commands:

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -116,10 +116,9 @@ if (NOT Boost_FIND_QUIETLY)
 endif ()
 
 if (NOT DEFINED Boost_ADDITIONAL_VERSIONS)
-  set (Boost_ADDITIONAL_VERSIONS "1.60" "1.59" "1.58" "1.57" "1.56"
-                                 "1.55" "1.54" "1.53" "1.52" "1.51" "1.50"
-                                 "1.49" "1.48" "1.47" "1.46" "1.45" "1.44"
-                                 "1.43" "1.43.0" "1.42" "1.42.0")
+  set (Boost_ADDITIONAL_VERSIONS "1.62" "1.61" "1.60"
+                                 "1.59" "1.58" "1.57" "1.56"
+                                 "1.55" "1.54" "1.53" "1.52" "1.51" "1.50")
 endif ()
 if (LINKSTATIC)
     set (Boost_USE_STATIC_LIBS   ON)
@@ -131,7 +130,7 @@ if (BOOST_CUSTOM)
     # Boost_VERSION, Boost_INCLUDE_DIRS, Boost_LIBRARY_DIRS, Boost_LIBRARIES.
 else ()
     set (Boost_COMPONENTS filesystem regex system thread)
-    find_package (Boost 1.42 REQUIRED
+    find_package (Boost 1.50 REQUIRED
                   COMPONENTS ${Boost_COMPONENTS}
                  )
 

--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -55,16 +55,7 @@
 #else   /* prior to C++11... */
   // Use Boost mutexes & guards when C++11 is not available
 # include <boost/version.hpp>
-# if defined(__GNUC__) && (BOOST_VERSION == 104500)
-   // gcc reports errors inside some of the boost headers with boost 1.45
-   // See: https://svn.boost.org/trac/boost/ticket/4818
-#  pragma GCC diagnostic ignored "-Wunused-variable"
-# endif
 # include <boost/thread.hpp>
-# if defined(__GNUC__) && (BOOST_VERSION == 104500)
-   // can't restore via push/pop in all versions of gcc (warning push/pop implemented for 4.6+ only)
-#  pragma GCC diagnostic error "-Wunused-variable"
-# endif
 #endif
 
 

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -40,9 +40,7 @@
 #include <boost/scoped_ptr.hpp>
 #include <boost/scoped_array.hpp>
 #include <boost/thread/tss.hpp>
-#if BOOST_VERSION >= 104900
-# include <boost/container/flat_map.hpp>
-#endif
+#include <boost/container/flat_map.hpp>
 
 #include <OpenEXR/half.h>
 

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -36,7 +36,6 @@
 
 #include <boost/version.hpp>
 #include <boost/tokenizer.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
 #include <boost/regex.hpp>
 
@@ -54,13 +53,18 @@
 # include <unistd.h>
 #endif
 
+#include <boost/filesystem.hpp>
+namespace filesystem = boost::filesystem;
+// FIXME: use std::filesystem when available
+
+
 
 OIIO_NAMESPACE_BEGIN
 
 #ifdef _MSC_VER
     // fix for https://svn.boost.org/trac/boost/ticket/6320
     const std::string dummy_path = "../dummy_path.txt";
-    const std::string dummy_extension = boost::filesystem::path(dummy_path).extension().string();
+    const std::string dummy_extension = filesystem::path(dummy_path).extension().string();
 #endif
 
 std::string
@@ -68,11 +72,7 @@ Filesystem::filename (const std::string &filepath)
 {
     // To simplify dealing with platform-specific separators and whatnot,
     // just use the Boost routines:
-#if BOOST_FILESYSTEM_VERSION == 3
-    return boost::filesystem::path(filepath).filename().string();
-#else
-    return boost::filesystem::path(filepath).filename();
-#endif
+    return filesystem::path(filepath).filename().string();
 }
 
 
@@ -80,12 +80,7 @@ Filesystem::filename (const std::string &filepath)
 std::string
 Filesystem::extension (const std::string &filepath, bool include_dot)
 {
-    std::string s;
-#if BOOST_FILESYSTEM_VERSION == 3
-    s = boost::filesystem::path(filepath).extension().string();
-#else
-    s = boost::filesystem::path(filepath).extension();
-#endif
+    std::string s = filesystem::path(filepath).extension().string();
     if (! include_dot && !s.empty() && s[0] == '.')
         s.erase (0, 1);  // erase the first character
     return s;
@@ -96,7 +91,7 @@ Filesystem::extension (const std::string &filepath, bool include_dot)
 std::string
 Filesystem::parent_path (const std::string &filepath)
 {
-    return boost::filesystem::path(filepath).parent_path().string();
+    return filesystem::path(filepath).parent_path().string();
 }
 
 
@@ -105,7 +100,7 @@ std::string
 Filesystem::replace_extension (const std::string &filepath,
                                const std::string &new_extension)
 {
-    return boost::filesystem::path(filepath).replace_extension(new_extension).string();
+    return filesystem::path(filepath).replace_extension(new_extension).string();
 }
 
 
@@ -163,20 +158,16 @@ Filesystem::searchpath_find (const std::string &filename_utf8,
                              bool testcwd, bool recursive)
 {
 #ifdef _WIN32
-    const boost::filesystem::path filename (Strutil::utf8_to_utf16 (filename_utf8));
+    const filesystem::path filename (Strutil::utf8_to_utf16 (filename_utf8));
 #else
-    const boost::filesystem::path filename (filename_utf8);
+    const filesystem::path filename (filename_utf8);
 #endif
-#if BOOST_FILESYSTEM_VERSION == 3
     bool abs = filename.is_absolute();
-#else
-    bool abs = path_is_absolute (filename.string());
-#endif
 
     // If it's an absolute filename, or if we want to check "." first,
     // then start by checking filename outright.
     if (testcwd || abs) {
-        if (boost::filesystem::is_regular_file (filename))
+        if (filesystem::is_regular_file (filename))
             return filename_utf8;
     }
 
@@ -184,13 +175,13 @@ Filesystem::searchpath_find (const std::string &filename_utf8,
     BOOST_FOREACH (const std::string &d_utf8, dirs) {
         // std::cerr << "\tPath = '" << d << "'\n";
 #ifdef _WIN32
-        const boost::filesystem::path d(Strutil::utf8_to_utf16 (d_utf8));
+        const filesystem::path d(Strutil::utf8_to_utf16 (d_utf8));
 #else
-        const boost::filesystem::path d(d_utf8);
+        const filesystem::path d(d_utf8);
 #endif
-        boost::filesystem::path f = d / filename;
+        filesystem::path f = d / filename;
         // std::cerr << "\tTesting '" << f.string() << "'\n";
-        if (boost::filesystem::is_regular_file (f)) {
+        if (filesystem::is_regular_file (f)) {
             // std::cerr << "Found '" << f.string() << "'\n";
 #ifdef _WIN32
             return Strutil::utf16_to_utf8 (f.native());
@@ -199,11 +190,11 @@ Filesystem::searchpath_find (const std::string &filename_utf8,
 #endif
         }
 
-        if (recursive && boost::filesystem::is_directory (d)) {
+        if (recursive && filesystem::is_directory (d)) {
             std::vector<std::string> subdirs;
-            boost::filesystem::directory_iterator end_iter;
-            for (boost::filesystem::directory_iterator s(d); s != end_iter; ++s) {
-                if (boost::filesystem::is_directory (s->status())) {
+            filesystem::directory_iterator end_iter;
+            for (filesystem::directory_iterator s(d); s != end_iter; ++s) {
+                if (filesystem::is_directory (s->status())) {
 #ifdef _WIN32
                     subdirs.push_back (Strutil::utf16_to_utf8 (s->path().native()));
 #else
@@ -230,7 +221,7 @@ Filesystem::get_directory_entries (const std::string &dirname,
     filenames.clear ();
     if (dirname.size() && ! is_directory(dirname))
         return false;
-    boost::filesystem::path dirpath (dirname.size() ? dirname : std::string("."));
+    filesystem::path dirpath (dirname.size() ? dirname : std::string("."));
     boost::regex re;
     try {
         re = boost::regex(filter_regex);
@@ -241,11 +232,11 @@ Filesystem::get_directory_entries (const std::string &dirname,
     if (recursive) {
 #ifdef _WIN32
         std::wstring wdirpath = Strutil::utf8_to_utf16 (dirpath.string());
-        for (boost::filesystem::recursive_directory_iterator s (wdirpath);
+        for (filesystem::recursive_directory_iterator s (wdirpath);
 #else
-        for (boost::filesystem::recursive_directory_iterator s (dirpath);
+        for (filesystem::recursive_directory_iterator s (dirpath);
 #endif
-             s != boost::filesystem::recursive_directory_iterator();  ++s) {
+             s != filesystem::recursive_directory_iterator();  ++s) {
             std::string file = s->path().string();
             if (!filter_regex.size() || boost::regex_search (file, re))
 #ifdef _WIN32
@@ -257,11 +248,11 @@ Filesystem::get_directory_entries (const std::string &dirname,
     } else {
 #ifdef _WIN32
         std::wstring wdirpath = Strutil::utf8_to_utf16 (dirpath.string());
-        for (boost::filesystem::directory_iterator s (wdirpath);
+        for (filesystem::directory_iterator s (wdirpath);
 #else
-        for (boost::filesystem::directory_iterator s (dirpath);
+        for (filesystem::directory_iterator s (dirpath);
 #endif
-             s != boost::filesystem::directory_iterator();  ++s) {
+             s != filesystem::directory_iterator();  ++s) {
             std::string file = s->path().string();
             if (!filter_regex.size() || boost::regex_search (file, re))
 #ifdef _WIN32
@@ -306,12 +297,12 @@ Filesystem::exists (const std::string &path)
 #if defined(_WIN32)
         // boost internally doesn't use MultiByteToWideChar (CP_UTF8,...
         // to convert char* to wchar_t* because they do not know the encoding
-        // See boost::filesystem::path.hpp 
+        // See boost/filesystem/path.hpp
         // The only correct way to do this is to do the conversion ourselves
         std::wstring wpath = Strutil::utf8_to_utf16(path);
-        r = boost::filesystem::exists (wpath);
+        r = filesystem::exists (wpath);
 #else
-        r = boost::filesystem::exists (path);
+        r = filesystem::exists (path);
 #endif
     } catch (...) {
         r = false;
@@ -329,12 +320,12 @@ Filesystem::is_directory (const std::string &path)
 #if defined(_WIN32)
         // boost internally doesn't use MultiByteToWideChar (CP_UTF8,...
         // to convert char* to wchar_t* because they do not know the encoding
-        // See boost::filesystem::path.hpp 
+        // See boost/filesystem/path.hpp
         // The only correct way to do this is to do the conversion ourselves
         std::wstring wpath = Strutil::utf8_to_utf16(path);
-        r = boost::filesystem::is_directory (wpath);
+        r = filesystem::is_directory (wpath);
 #else
-        r = boost::filesystem::is_directory (path);
+        r = filesystem::is_directory (path);
 #endif
     } catch (...) {
         r = false;
@@ -352,12 +343,12 @@ Filesystem::is_regular (const std::string &path)
 #if defined(_WIN32)
         // boost internally doesn't use MultiByteToWideChar (CP_UTF8,...
         // to convert char* to wchar_t* because they do not know the encoding
-        // See boost::filesystem::path.hpp 
+        // See boost/filesystem/path.hpp
         // The only correct way to do this is to do the conversion ourselves
         std::wstring wpath = Strutil::utf8_to_utf16(path);
-        r = boost::filesystem::is_regular_file (wpath);
+        r = filesystem::is_regular_file (wpath);
 #else
-        r = boost::filesystem::is_regular_file (path);
+        r = filesystem::is_regular_file (path);
 #endif
     } catch (...) {
         r = false;
@@ -374,29 +365,20 @@ Filesystem::create_directory (string_view path, std::string &err)
 #if defined(_WIN32)
 	// boost internally doesn't use MultiByteToWideChar (CP_UTF8,...
 	// to convert char* to wchar_t* because they do not know the encoding
-	// See boost::filesystem::path.hpp 
+	// See boost/filesystem/path.hpp
 	// The only correct way to do this is to do the conversion ourselves
 	std::wstring pathStr = Strutil::utf8_to_utf16(path);
 #else
 	std::string pathStr = path.str();
 #endif
 
-#if BOOST_FILESYSTEM_VERSION >= 3
     boost::system::error_code ec;
-	bool ok = boost::filesystem::create_directory (pathStr, ec);
+	bool ok = filesystem::create_directory (pathStr, ec);
     if (ok)
         err.clear();
     else
         err = ec.message();
     return ok;
-#else
-    bool ok = boost::filesystem::create_directory (pathStr);
-    if (ok)
-        err.clear();
-    else
-        err = "Could not make directory";
-    return ok;
-#endif
 }
 
 
@@ -406,7 +388,7 @@ Filesystem::copy (string_view from, string_view to, std::string &err)
 #if defined(_WIN32)
 	// boost internally doesn't use MultiByteToWideChar (CP_UTF8,...
 	// to convert char* to wchar_t* because they do not know the encoding
-	// See boost::filesystem::path.hpp 
+	// See boost/filesystem/path.hpp
 	// The only correct way to do this is to do the conversion ourselves
 	std::wstring fromStr = Strutil::utf8_to_utf16(from);
 	std::wstring toStr = Strutil::utf8_to_utf16(to);
@@ -415,13 +397,8 @@ Filesystem::copy (string_view from, string_view to, std::string &err)
 	std::string toStr = to.str();
 #endif
 
-#if BOOST_FILESYSTEM_VERSION >= 3
     boost::system::error_code ec;
-# if BOOST_VERSION < 105000
-    boost::filesystem3::copy (fromStr, toStr, ec);
-# else
-    boost::filesystem::copy (fromStr, toStr, ec);
-# endif
+    filesystem::copy (fromStr, toStr, ec);
     if (! ec) {
         err.clear();
         return true;
@@ -429,9 +406,6 @@ Filesystem::copy (string_view from, string_view to, std::string &err)
         err = ec.message();
         return false;
     }
-#else
-    return false; // I'm too lazy to figure this out.
-#endif
 }
 
 
@@ -442,7 +416,7 @@ Filesystem::rename (string_view from, string_view to, std::string &err)
 #if defined(_WIN32)
 	// boost internally doesn't use MultiByteToWideChar (CP_UTF8,...
 	// to convert char* to wchar_t* because they do not know the encoding
-	// See boost::filesystem::path.hpp 
+	// See boost/filesystem/path.hpp
 	// The only correct way to do this is to do the conversion ourselves
 	std::wstring fromStr = Strutil::utf8_to_utf16(from);
 	std::wstring toStr = Strutil::utf8_to_utf16(to);
@@ -450,13 +424,8 @@ Filesystem::rename (string_view from, string_view to, std::string &err)
 	std::string fromStr = from.str();
 	std::string toStr = to.str();
 #endif
-#if BOOST_FILESYSTEM_VERSION >= 3
     boost::system::error_code ec;
-# if BOOST_VERSION < 105000
-    boost::filesystem3::rename (fromStr, toStr, ec);
-# else
-    boost::filesystem::rename (fromStr, toStr, ec);
-# endif
+    filesystem::rename (fromStr, toStr, ec);
     if (! ec) {
         err.clear();
         return true;
@@ -464,9 +433,6 @@ Filesystem::rename (string_view from, string_view to, std::string &err)
         err = ec.message();
         return false;
     }
-#else
-    return false; // I'm too lazy to figure this out.
-#endif
 }
 
 
@@ -477,28 +443,19 @@ Filesystem::remove (string_view path, std::string &err)
 #if defined(_WIN32)
 	// boost internally doesn't use MultiByteToWideChar (CP_UTF8,...
 	// to convert char* to wchar_t* because they do not know the encoding
-	// See boost::filesystem::path.hpp 
+	// See boost/filesystem/path.hpp
 	// The only correct way to do this is to do the conversion ourselves
 	std::wstring pathStr = Strutil::utf8_to_utf16(path);
 #else
 	std::string pathStr = path.str();
 #endif
-#if BOOST_FILESYSTEM_VERSION >= 3
     boost::system::error_code ec;
-    bool ok = boost::filesystem::remove (pathStr, ec);
+    bool ok = filesystem::remove (pathStr, ec);
     if (ok)
         err.clear();
     else
         err = ec.message();
     return ok;
-#else
-    bool ok = boost::filesystem::remove (pathStr);
-    if (ok)
-        err.clear();
-    else
-        err = "Could not remove file";
-    return ok;
-#endif
 }
 
 
@@ -509,25 +466,19 @@ Filesystem::remove_all (string_view path, std::string &err)
 #if defined(_WIN32)
 	// boost internally doesn't use MultiByteToWideChar (CP_UTF8,...
 	// to convert char* to wchar_t* because they do not know the encoding
-	// See boost::filesystem::path.hpp 
+	// See boost/filesystem/path.hpp
 	// The only correct way to do this is to do the conversion ourselves
 	std::wstring pathStr = Strutil::utf8_to_utf16(path);
 #else
 	std::string pathStr = path.str();
 #endif
-#if BOOST_FILESYSTEM_VERSION >= 3
     boost::system::error_code ec;
-    unsigned long long n = boost::filesystem::remove_all (pathStr, ec);
+    unsigned long long n = filesystem::remove_all (pathStr, ec);
     if (!ec)
         err.clear();
     else
         err = ec.message();
     return n;
-#else
-    unsigned long long n = boost::filesystem::remove_all (pathStr);
-    err.clear();
-    return n;
-#endif
 }
 
 
@@ -535,21 +486,9 @@ Filesystem::remove_all (string_view path, std::string &err)
 std::string
 Filesystem::temp_directory_path()
 {
-#if BOOST_FILESYSTEM_VERSION >= 3
     boost::system::error_code ec;
-    boost::filesystem::path p = boost::filesystem::temp_directory_path (ec);
+    filesystem::path p = filesystem::temp_directory_path (ec);
     return ec ? std::string() : p.string();
-#else
-    const char *tmpdir = getenv("TMPDIR");
-    if (! tmpdir)
-        tmpdir = getenv("TMP");
-    if (! tmpdir)
-        tmpdir = "/var/tmp";
-    if (exists (tmpdir))
-        return tmpdir;
-    // punt and hope for the best
-    return ".";
-#endif
 }
 
 
@@ -560,25 +499,15 @@ Filesystem::unique_path (string_view model)
 #if defined(_WIN32)
 	// boost internally doesn't use MultiByteToWideChar (CP_UTF8,...
 	// to convert char* to wchar_t* because they do not know the encoding
-	// See boost::filesystem::path.hpp 
+	// See boost/filesystem/path.hpp
 	// The only correct way to do this is to do the conversion ourselves
 	std::wstring modelStr = Strutil::utf8_to_utf16(model);
 #else
 	std::string modelStr = model.str();
 #endif
-#if BOOST_FILESYSTEM_VERSION >= 3
     boost::system::error_code ec;
-    boost::filesystem::path p = boost::filesystem::unique_path (modelStr, ec);
+    filesystem::path p = filesystem::unique_path (modelStr, ec);
     return ec ? std::string() : p.string();
-#elif _MSC_VER
-    char buf[TMP_MAX];
-    char *result = tmpnam (buf);
-    return result ? std::string(result) : std::string();
-#else
-    char buf[L_tmpnam];
-    char *result = tmpnam (buf);
-    return result ? std::string(result) : std::string();
-#endif
 }
 
 
@@ -586,20 +515,9 @@ Filesystem::unique_path (string_view model)
 std::string
 Filesystem::current_path()
 {
-#if BOOST_FILESYSTEM_VERSION >= 3
     boost::system::error_code ec;
-    boost::filesystem::path p = boost::filesystem::current_path (ec);
+    filesystem::path p = filesystem::current_path (ec);
     return ec ? std::string() : p.string();
-#else
-    // Fallback if we don't have recent Boost
-    char path[FILENAME_MAX];
-#ifdef _WIN32
-    bool ok = _getcwd (path, sizeof(path));
-#else
-    bool ok = getcwd (path, sizeof(path));
-#endif
-    return ok ? std::string(path) : std::string();
-#endif
 }
 
 
@@ -701,9 +619,9 @@ Filesystem::last_write_time (const std::string& path)
     try {
 #ifdef _WIN32
         std::wstring wpath = Strutil::utf8_to_utf16 (path);
-        return boost::filesystem::last_write_time (wpath);
+        return filesystem::last_write_time (wpath);
 #else
-        return boost::filesystem::last_write_time (path);
+        return filesystem::last_write_time (path);
 #endif
     } catch (...) {
         // File doesn't exist
@@ -719,9 +637,9 @@ Filesystem::last_write_time (const std::string& path, std::time_t time)
     try {
 #ifdef _WIN32
         std::wstring wpath = Strutil::utf8_to_utf16 (path);
-        boost::filesystem::last_write_time (wpath, time);
+        filesystem::last_write_time (wpath, time);
 #else
-        boost::filesystem::last_write_time (path, time);
+        filesystem::last_write_time (path, time);
 #endif
     } catch (...) {
         // File doesn't exist
@@ -736,9 +654,9 @@ Filesystem::file_size (string_view path)
     try {
 #ifdef _WIN32
         std::wstring wpath = Strutil::utf8_to_utf16 (path);
-        return boost::filesystem::file_size (wpath);
+        return filesystem::file_size (wpath);
 #else
-        return boost::filesystem::file_size (path.str());
+        return filesystem::file_size (path.str());
 #endif
     } catch (...) {
         // File doesn't exist
@@ -1043,14 +961,14 @@ Filesystem::scan_for_matching_filenames(const std::string &pattern_,
 
     boost::regex pattern_re (pattern_re_str);
 
-    boost::filesystem::directory_iterator end_it;
+    filesystem::directory_iterator end_it;
 #ifdef _WIN32
     std::wstring wdirectory = Strutil::utf8_to_utf16 (directory);
-    for (boost::filesystem::directory_iterator it(wdirectory); it != end_it; ++it) {
+    for (filesystem::directory_iterator it(wdirectory); it != end_it; ++it) {
 #else
-    for (boost::filesystem::directory_iterator it(directory); it != end_it; ++it) {
+    for (filesystem::directory_iterator it(directory); it != end_it; ++it) {
 #endif
-        if (boost::filesystem::is_regular_file(it->status())) {
+        if (filesystem::is_regular_file(it->status())) {
             const std::string f = it->path().string();
             boost::match_results<std::string::const_iterator> frame_match;
             if (boost::regex_match (f, frame_match, pattern_re)) {


### PR DESCRIPTION
VFX platform dictates 1.55, but I think we can be more flexible, as there is nothing we use that was introduced between 1.50 and 1.55. But by definitively excluding 1.4x, we can clean up some conditional compilation guards. In filesystem.cpp in particular, we no longer have to worry about boost::filesystem prior to v3 (which is the one that will form the basis of C++17 filesystem).

