### PR TITLE
Add ANSI terminal support to Windows platform

### DIFF
--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -377,7 +377,7 @@ bool enableVTMode()
     return true;
 }
 #else
-bool enableVTMode() {}
+bool enableVTMode() { return true; }
 #endif
 
 


### PR DESCRIPTION
## Description

Windows 10 supports VT100 escape sequences since the Anniversary Edition. Except for the define, this patch uses APIs that have been present for quite some time, so it should fail gracefully on older versions of Windows
## Tests

Test  with simd_test. It looks much better !

------

