### PR TITLE
FindOpenColorIO.cmake: Fix for location of OCIO headers

### DIFF
--- a/src/cmake/modules/FindOpenColorIO.cmake
+++ b/src/cmake/modules/FindOpenColorIO.cmake
@@ -25,7 +25,7 @@ include (FindPackageMessage)
         endif()
     endif ()
     FIND_PATH(OCIO_INCLUDES
-        OpenColorIO.h
+        OpenColorIO/OpenColorIO.h
         PATHS
         ${OCIO_INCLUDE_PATH}
         ${OCIO_PATH}/include/
@@ -33,7 +33,6 @@ include (FindPackageMessage)
         /usr/local/include
         /sw/include
         /opt/local/include
-        PATH_SUFFIXES OpenColorIO
         DOC "The directory where OpenColorIO/OpenColorIO.h resides")
     FIND_LIBRARY(OCIO_LIBRARIES
         NAMES OCIO OpenColorIO


### PR DESCRIPTION
## Description

Fixes the search for the OpenColorIO headers by removing the trailing `OpenColorIO` subdirectory from the `OCIO_INCLUDES` result, since the includes in `color_ocio.cpp` are already qualified.

Confirmed working on RB-1.6.