### PR TITLE
Fix warnings on clang 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,10 @@ if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_APPLECLANG)
         APPLECLANG_VERSION_STRING VERSION_GREATER 6.1)
         add_definitions ("-Wno-unused-local-typedefs")
     endif ()
+    if (CLANG_VERSION_STRING VERSION_EQUAL 3.9 OR CLANG_VERSION_STRING VERSION_GREATER 3.9)
+        # Don't warn about using unknown preprocessor symbols in #if'set
+        add_definitions ("-Wno-expansion-to-defined")
+    endif ()
 endif ()
 
 # gcc specific options


### PR DESCRIPTION
I guess we extensively use constructs like this:

    #if SOMETIMES_DEFINED > 3

as shorthand for

    #if defined(SOMETIMES_DEFINED) && SOMETIMES_DEFINED > 3

I was never 100% sure that the former was legal, but the compilers didn't
complain and I preferred it over the more verbose equivalent.

But apparently, it's just lax compilers, and in the latest Clang 3.9,
doing this (assuming "expansion to defined") is a warning, and of course
we usually treat warnings as errors.

It's going to be a lot of work to track all of these down and fix them,
especially before clang 3.9 has a Homebrew package (without it, I'm
operating blind, both on my laptop and on the TravisCI builds). So for
now, we'll settle for just disabling that warning, and slowly fix up the
guards later.
