### PR TITLE
Fix for UDIM channels query

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -2501,20 +2501,17 @@ ImageCacheImpl::get_image_info (ImageCacheFile *file,
         // if different panels of the same UDIM scheme have different
         // numbers of channels! Search the 10x100 files for a match, give
         // up if not found.
-        ImageCacheFile *concretefile = NULL;
-        for (int j = 0; j < 100 && !concretefile; ++j) {
+        for (int j = 0; j < 100; ++j) {
             for (int i = 0; i < 10; ++i) {
                 float s = i + 0.5f, t = j + 0.5f;
-                if (ImageCacheFile *c = resolve_udim (file, s, t)) {
-                    concretefile = c;
-                    break;
+                ImageCacheFile *concretefile = resolve_udim (file, s, t);
+                concretefile = verify_file (concretefile, thread_info, true);
+                if (concretefile && !concretefile->broken()) {
+                    // Recurse to try again with the concrete file
+                    return get_image_info (concretefile, thread_info, subimage,
+                                           miplevel, dataname, datatype, data);
                 }
             }
-        }
-        if (concretefile) {
-            // Recurse to try again with the concrete file
-            return get_image_info (concretefile, thread_info, subimage,
-                                   miplevel, dataname, datatype, data);
         }
     }
 


### PR DESCRIPTION
Logic was botched, it was still getting errors if the first file was not
present. Needed to verify the file and check that it wasn't broken,
because only in verify is it actually opened. Just checking for a
non-NULL result from resolve_udim() isn't enough.