### PR TITLE
Qt migration WIP

### DIFF
--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -28,9 +28,6 @@
   (This is the Modified BSD License)
 */
 
-#include "imageviewer.h"
-#include "ivgl.h"
-
 #include <iostream>
 #include <cmath>
 #ifndef WIN32
@@ -38,21 +35,24 @@
 #endif
 #include <vector>
 
-#include <QtCore/QSettings>
-#include <QtCore/QTimer>
-#include <QtGui/QApplication>
-#include <QtGui/QComboBox>
-#include <QtGui/QDesktopWidget>
-#include <QtGui/QFileDialog>
-#include <QtGui/QKeyEvent>
-#include <QtGui/QLabel>
-#include <QtGui/QMenu>
-#include <QtGui/QMenuBar>
-#include <QtGui/QMessageBox>
-#include <QtGui/QProgressBar>
-#include <QtGui/QResizeEvent>
-#include <QtGui/QSpinBox>
-#include <QtGui/QStatusBar>
+#include "imageviewer.h"
+#include "ivgl.h"
+
+#include <QSettings>
+#include <QTimer>
+#include <QApplication>
+#include <QComboBox>
+#include <QDesktopWidget>
+#include <QFileDialog>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QMenu>
+#include <QMenuBar>
+#include <QMessageBox>
+#include <QProgressBar>
+#include <QResizeEvent>
+#include <QSpinBox>
+#include <QStatusBar>
 
 #include <OpenEXR/ImathFun.h>
 

--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -46,16 +46,15 @@
 
 #include <vector>
 
-// This needs to be included before GL.h
 #include <glew.h>
-
-#include <QtGui/QAction>
-#include <QtGui/QCheckBox>
-#include <QtGui/QDialog>
-#include <QtGui/QMainWindow>
+#include <QGLWidget>
+#include <QAction>
+#include <QCheckBox>
+#include <QDialog>
+#include <QMainWindow>
 
 #ifndef QT_NO_PRINTER
-#include <QtGui/QPrinter>
+// #include <QPrinter>
 #endif
 
 #include "OpenImageIO/imageio.h"
@@ -333,7 +332,7 @@ private:
     IvPreferenceWindow *preferenceWindow;
 
 #ifndef QT_NO_PRINTER
-    QPrinter printer;
+    // QPrinter printer;
 #endif
 
     QAction *openAct, *reloadAct, *closeImgAct;

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -33,18 +33,14 @@
 
 #include <iostream>
 
-// This needs to be included before GL.h
-// (which is included by QtOpenGL and QGLFormat)
-#include <glew.h>
-
 #include <OpenEXR/half.h>
 #include <OpenEXR/ImathFun.h>
 
-#include <QtGui/QComboBox>
-#include <QtGui/QLabel>
-#include <QtGui/QMouseEvent>
-#include <QtGui/QProgressBar>
-#include <QtOpenGL/QGLFormat>
+#include <QComboBox>
+#include <QLabel>
+#include <QMouseEvent>
+#include <QProgressBar>
+#include <QGLFormat>
 
 #include "ivutils.h"
 #include "OpenImageIO/strutil.h"

--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -46,10 +46,7 @@
 
 #include <vector>
 
-// This needs to be included before GL.h
-#include <glew.h>
-
-#include <QtOpenGL/QGLWidget>
+#include <QGLWidget>
 
 #include "OpenImageIO/imageio.h"
 #include "OpenImageIO/imagebuf.h"

--- a/src/iv/ivinfowin.cpp
+++ b/src/iv/ivinfowin.cpp
@@ -31,11 +31,11 @@
 
 #include <iostream>
 
-#include <QtGui/QKeyEvent>
-#include <QtGui/QLabel>
-#include <QtGui/QPushButton>
-#include <QtGui/QScrollArea>
-#include <QtGui/QVBoxLayout>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QPushButton>
+#include <QScrollArea>
+#include <QVBoxLayout>
 
 #include "imageviewer.h"
 #include "OpenImageIO/dassert.h"

--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -44,7 +44,7 @@
 #include <iostream>
 #include <iterator>
 
-#include <QtGui/QApplication>
+#include <QApplication>
 
 #include "imageviewer.h"
 #include "OpenImageIO/timer.h"

--- a/src/iv/ivpref.cpp
+++ b/src/iv/ivpref.cpp
@@ -31,11 +31,11 @@
 
 #include <iostream>
 
-#include <QtGui/QKeyEvent>
-#include <QtGui/QLabel>
-#include <QtGui/QPushButton>
-#include <QtGui/QSpinBox>
-#include <QtGui/QVBoxLayout>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QVBoxLayout>
 
 #include "imageviewer.h"
 #include "OpenImageIO/dassert.h"


### PR DESCRIPTION
* strip directories from #includes of Qt headers.
* Reorder OpenGL-related headers.

This is preliminary work towards eventual migration to Qt5.

The original header locations are incompatible with Qt5, but if we
eliminate the directories, they will mostly work for both Qt4 and Qt5.