### PR TITLE
Fix warnings on some 32 bit platforms

### DIFF
--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -2477,6 +2477,13 @@ TextureSystemImpl::sample_bicubic (int nsamples, const float *s_,
         } else {
             wx = evalBSplineWeights (float4(sfrac));
             wy = evalBSplineWeights (float4(tfrac));
+#if defined(__i386__) && !defined(__x86_64__)
+            // gcc on some 32 bit platforms complains here about these being
+            // uninitialized, so initialize them. Don't waste the cycles
+            // for 64 bit platforms that don't seem to have that error.
+            dwx = float4::Zero();
+            dwy = float4::Zero();
+#endif
         }
 
         // figure out lerp weights so we can turn the filter into a sequence of lerp's


### PR DESCRIPTION
For some reason, certain 32 bit platforms have gcc errors about this spot leading to uninitialized variables (they don't! but gcc can't seem to figure that out). The 64 bit platforms figure it out just fine, so just eat the cost of a couple useless assigns on the platforms where it's a problem.