### PR TITLE
Allow multiple key/value pairs in OCIO wrappers.

### DIFF
--- a/src/doc/imagebufalgo.tex
+++ b/src/doc/imagebufalgo.tex
@@ -2000,6 +2000,7 @@ higher-contrast edges.
 
 \apiitem{bool {\ce colorconvert} (ImageBuf \&dst, const ImageBuf \&src, \\
   \bigspc\spc string_view from, string_view to, bool unpremult=false, \\
+  \bigspc\spc string_view context_key="", string_view context_value="", \\
   \bigspc\spc ColorConfig *colorconfig=NULL, \\
   \bigspc\spc ROI roi=ROI::All(), int nthreads=0) \\
 bool {\ce colorconvert} (ImageBuf \&dst, const ImageBuf \&src, \\
@@ -2023,6 +2024,9 @@ is passed, the default OCIO color configuration found by examining the {\cf
 The second form is directly passed a {\cf ColorProcessor}, which is is a
 special object created by a {\cf ColorConfig} (see {\cf OpenImageIO/color.h}
 for details).
+
+The {\cf context_key} and {\cf context_value} may optionally be used
+to establish a context (for example, a shot-specific transform).
 
 If OIIO was built with OpenColorIO support enabled, then the transformation
 may be between any two spaces supported by the active OCIO configuration, or
@@ -2056,14 +2060,14 @@ to \qkw{linear} and vice versa.
 \apiitem{bool {\ce ociolook} (ImageBuf \&dst, const ImageBuf \&src, \\
   \bigspc\spc string_view looks, string_view from, string_view to, \\
   \bigspc\spc bool inverse=false, bool unpremult=false, \\
-  \bigspc\spc string_view key="", string_view value="", \\
+  \bigspc\spc string_view context_key="", string_view context_value="", \\
   \bigspc\spc ColorConfig *colorconfig=NULL, \\
   \bigspc\spc ROI roi=ROI::All(), int nthreads=0)}
 \index{ImageBufAlgo!ociolook} \indexapi{ociolook}
 Copy pixels from {\cf src} to {\cf dst} (within the ROI), while
 applying an OpenColorIO ``look'' transform to the pixel values.
 In-place operations ({\cf dst} and {\cf src} being the same image)
-are supported.  The {\cf key} and {\cf value} may optionally be used
+are supported.  The {\cf context_key} and {\cf context_value} may optionally be used
 to establish a context (for example, a shot-specific transform).
 
 If {\cf inverse} is {\cf true}, it will reverse the color transformation

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -2715,8 +2715,16 @@ as a guide for the location of the configuration file.
 \apiitem{\ce --colorconvert {\rm \emph{fromspace tospace}}}
 Replace the current image with a new image whose pixels are transformed
 from the named \emph{fromspace} color space into the named
-\emph{tospace} (disregarding any notion it may have previously had 
-about the color space of the current image).  
+\emph{tospace} (disregarding any notion it may have previously had
+about the color space of the current image). Optional appended
+arguments include:
+
+\begin{tabular}{p{10pt} p{1in} p{3.75in}}
+ & {\cf key=}\emph{name} & \\
+ & {\cf value=}\emph{str} & Adds a key/value pair to the ``context'' that
+  OpenColorIO will used when applying the look. Multiple key/value pairs
+  may be specified by making each one a comma-separated list. \\
+\end{tabular}
 \apiend
 
 \apiitem{\ce --tocolorspace {\rm \emph{tospace}}}

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -2743,7 +2743,8 @@ arguments include:
   color transformation and look application. \\
  & {\cf key=}\emph{name} & \\
  & {\cf value=}\emph{str} & Adds a key/value pair to the ``context'' that
-  OpenColorIO will used when applying the look. \\
+  OpenColorIO will used when applying the look. Multiple key/value pairs
+  may be specified by making each one a comma-separated list. \\
 \end{tabular}
 
 This command is only meaningful if OIIO was compiled with OCIO support
@@ -2772,7 +2773,8 @@ arguments include:
   directives. \\
  & {\cf key=}\emph{name} & \\
  & {\cf value=}\emph{str} & Adds a key/value pair to the ``context'' that
-  OpenColorIO will used when applying the look. \\
+  OpenColorIO will used when applying the display transform. Multiple key/value pairs
+  may be specified by making each one a comma-separated list. \\
 \end{tabular}
 
 This command is only meaningful if OIIO was compiled with OCIO support

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -2936,9 +2936,7 @@ corresponding region of {\cf src} using the ``unsharp mask'' technique.
 
 \apiitem{bool ImageBufAlgo.{\ce colorconvert} (dst, src, from, to,
   unpremult=False, \\
-  \bigspc\bigspc  roi=ROI.All, nthreads=0) \\
-bool ImageBufAlgo.{\ce colorconvert} (dst, src, from, to,
-  unpremult=False, \\
+  \bigspc\bigspc context_key="", context_value="", \\
   \bigspc\bigspc  colorconfig="", roi=ROI.All, nthreads=0) \\
 }
 \index{ImageBufAlgo!colorconvert} \indexapi{colorconvert}
@@ -2959,10 +2957,6 @@ are supported.
 
 \apiitem{bool ImageBufAlgo.{\ce ociolook} (dst, src, looks, from, to,  \\
   \bigspc\bigspc  inverse=False, unpremult=False, \\
-  \bigspc\bigspc context_key="", context_value="", \\
-  \bigspc\bigspc roi=ROI.All, nthreads=0) \\
- bool ImageBufAlgo.{\ce ociolook} (dst, src, looks, from, to, \\
-  \bigspc\bigspc inverse=False, unpremult=False, \\
   \bigspc\bigspc context_key="", context_value="", colorconfig="", \\
   \bigspc\bigspc roi=ROI.All, nthreads=0)}
 \index{ImageBufAlgo!ociolook} \indexapi{ociolook}
@@ -2983,10 +2977,6 @@ are supported.
 
 
 \apiitem{bool ImageBufAlgo.{\ce ociodisplay} (dst, src, display, view, \\
-  \bigspc\bigspc from=None, looks=None, unpremult=False, \\
-  \bigspc\bigspc context_key="", context_value="", \\
-  \bigspc\bigspc roi=ROI.All, nthreads=0) \\
-bool ImageBufAlgo.{\ce ociodisplay} (dst, src, display, view, \\
   \bigspc\bigspc from=None, looks=None, unpremult=False, \\
   \bigspc\bigspc context_key="", context_value="", colorconfig="", \\
   \bigspc\bigspc roi=ROI.All, nthreads=0)}

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -125,13 +125,13 @@ public:
     /// separately!
     ColorProcessor* createColorProcessor (string_view inputColorSpace,
                                           string_view outputColorSpace) const;
-    
-    /// Given the named look(s), input and output color spaces,
-    /// construct a color processor that applies an OCIO look
-    /// transformation.  If inverse==true, construct the inverse
-    /// transformation.  The context_key and context_value can
-    /// optionally be used to establish an extra token/value pair in the
-    /// OCIO context.
+
+    /// Given the named look(s), input and output color spaces, construct a
+    /// color processor that applies an OCIO look transformation.  If
+    /// inverse==true, construct the inverse transformation.  The
+    /// context_key and context_value can optionally be used to establish
+    /// extra key/value pairs in the OCIO context if they are comma-
+    /// separated lists of ontext keys and values, respectively.
     ///
     /// It is possible that this will return NULL, if one of the color
     /// spaces or the look itself doesnt exist or is not allowed.  When
@@ -176,8 +176,9 @@ public:
     /// forward/inverse transformation (and forward is assumed in the
     /// absence of either). It is possible to remove all looks from the
     /// display by passing an empty string. The context_key and context_value
-    /// can optionally be used to establish an extra token/value pair in the
-    /// OCIO context.
+    /// can optionally be used to establish extra key/value pair in the OCIO
+    /// context if they are comma-separated lists of context keys and
+    /// values, respectively.
     ///
     /// It is possible that this will return NULL, if one of the color
     /// spaces or the display or view doesn't exist or is not allowed.  When

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -124,6 +124,11 @@ public:
     /// (or multiple images), NOT for every scanline or pixel
     /// separately!
     ColorProcessor* createColorProcessor (string_view inputColorSpace,
+                                          string_view outputColorSpace,
+                                          string_view context_key /* ="" */,
+                                          string_view context_value="") const;
+    // DEPRECATED (1.7):
+    ColorProcessor* createColorProcessor (string_view inputColorSpace,
                                           string_view outputColorSpace) const;
 
     /// Given the named look(s), input and output color spaces, construct a

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -967,6 +967,14 @@ bool OIIO_API rangeexpand (ImageBuf &dst, const ImageBuf &src,
 bool OIIO_API colorconvert (ImageBuf &dst, const ImageBuf &src,
                             string_view from, string_view to,
                             bool unpremult=false,
+                            string_view context_key="",
+                            string_view context_value="",
+                            ColorConfig *colorconfig=NULL,
+                            ROI roi=ROI::All(), int nthreads=0);
+// DEPRECATED: [1.7]
+bool OIIO_API colorconvert (ImageBuf &dst, const ImageBuf &src,
+                            string_view from, string_view to,
+                            bool unpremult=false,
                             ColorConfig *colorconfig=NULL,
                             ROI roi=ROI::All(), int nthreads=0);
 OIIO_DEPRECATED("Use the version that takes a ColorConfig*. [1.6]")

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -594,7 +594,7 @@ ColorConfig::createLookTransform (string_view looks,
                                   string_view outputColorSpace,
                                   bool inverse,
                                   string_view context_key,
-                                  string_view context_val) const
+                                  string_view context_value) const
 {
 #ifdef USE_OCIO
     // Ask OCIO to make a Processor that can handle the requested
@@ -619,9 +619,13 @@ ColorConfig::createLookTransform (string_view looks,
             dir = OCIO::TRANSFORM_DIR_FORWARD;
         }
         OCIO::ConstContextRcPtr context = config->getCurrentContext();
-        if (context_key.size() && context_val.size()) {
+        std::vector<string_view> keys, values;
+        Strutil::split (context_key, keys, ",");
+        Strutil::split (context_value, values, ",");
+        if (keys.size() && values.size() && keys.size() == values.size()) {
             OCIO::ContextRcPtr ctx = context->createEditableCopy();
-            ctx->setStringVar (context_key.c_str(), context_val.c_str());
+            for (size_t i = 0; i < keys.size(); ++i)
+                ctx->setStringVar (keys[i].c_str(), values[i].c_str());
             context = ctx;
         }
 
@@ -673,9 +677,13 @@ ColorConfig::createDisplayTransform (string_view display,
             transform->setLooksOverrideEnabled(false);
         }
         OCIO::ConstContextRcPtr context = config->getCurrentContext();
-        if (context_key.size() && context_value.size()) {
+        std::vector<string_view> keys, values;
+        Strutil::split (context_key, keys, ",");
+        Strutil::split (context_value, values, ",");
+        if (keys.size() && values.size() && keys.size() == values.size()) {
             OCIO::ContextRcPtr ctx = context->createEditableCopy();
-            ctx->setStringVar (context_key.c_str(), context_value.c_str());
+            for (size_t i = 0; i < keys.size(); ++i)
+                ctx->setStringVar (keys[i].c_str(), values[i].c_str());
             context = ctx;
         }
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1636,8 +1636,11 @@ public:
         return true;
     }
     virtual int impl (ImageBuf **img) {
+        string_view contextkey = options["key"];
+        string_view contextvalue = options["value"];
         return ImageBufAlgo::colorconvert (*img[0], *img[1],
                                            fromspace, tospace, false,
+                                           contextkey, contextvalue,
                                            &ot.colorconfig);
     }
     string_view fromspace, tospace;
@@ -4838,7 +4841,7 @@ getargs (int argc, char *argv[])
                 "--tocolorspace %@ %s", action_tocolorspace, NULL,
                     "Convert the current image's pixels to a named color space",
                 "--colorconvert %@ %s %s", action_colorconvert, NULL, NULL,
-                    "Convert pixels from 'src' to 'dst' color space (without regard to its previous interpretation)",
+                    "Convert pixels from 'src' to 'dst' color space (options: key=, value=)",
                 "--ociolook %@ %s", action_ociolook, NULL,
                     "Apply the named OCIO look (options: from=, to=, inverse=, key=, value=)",
                 "--ociodisplay %@ %s %s", action_ociodisplay, NULL, NULL,

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -975,12 +975,16 @@ IBA_colorconvert (ImageBuf &dst, const ImageBuf &src,
 bool
 IBA_colorconvert_colorconfig (ImageBuf &dst, const ImageBuf &src,
                   const std::string &from, const std::string &to,
-                  bool unpremult = false, const std::string &colorconfig="",
+                  bool unpremult = false,
+                  const std::string &context_key="",
+                  const std::string &context_value="",
+                  const std::string &colorconfig="",
                   ROI roi = ROI::All(), int nthreads = 0)
 {
     ColorConfig config (colorconfig);
     ScopedGILRelease gil;
     return ImageBufAlgo::colorconvert (dst, src, from, to, unpremult,
+                                       context_key, context_value,
                                        &config, roi, nthreads);
 }
 
@@ -1520,8 +1524,10 @@ void declare_imagebufalgo()
               arg("roi")=ROI::All(), arg("nthreads")=0))
         .def("colorconvert", &IBA_colorconvert_colorconfig,
              (arg("dst"), arg("src"),
-              arg("from"), arg("to"), 
-              arg("unpremult")=false, arg("colorconfig")="",
+              arg("from"), arg("to"),
+              arg("unpremult")=false,
+              arg("context_key")="", arg("context_value")="",
+              arg("colorconfig")="",
               arg("roi")=ROI::All(), arg("nthreads")=0))
         .staticmethod("colorconvert")
 


### PR DESCRIPTION
Extend ColorConfig::createLookTransform & createDisplayTransform to
accept mutiple key/value pair, by allowing their context_key and
context_value paramters to each be comma-separated lists (which
obviously must both contain the same number of items).