### PR TITLE
Fix to TIFF handling of certain unusual tags, which also affected raw files

### DIFF
--- a/testsuite/misnamed-file/ref/out.txt
+++ b/testsuite/misnamed-file/ref/out.txt
@@ -9,7 +9,6 @@ misnamed.exr         : 1000 x 1000, 4 channel, uint8 tiff
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.3.6 2009-07-25 Q8 http://www.GraphicsMagick.org/"
     DocumentName: "g.tif"
-    tiff:PageNumber: 0
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"

--- a/testsuite/tiff-suite/ref/out-alt.txt
+++ b/testsuite/tiff-suite/ref/out-alt.txt
@@ -57,7 +57,6 @@ Reading ../../../../../libtiffpic/dscf0013.tif
     PixelAspectRatio: 1
     FNumber: 3.4
     Exif:ExposureProgram: 2 (normal program)
-    Exif:ISOSpeedRatings: 1
     Exif:DateTimeOriginal: "2004:11:10 00:00:31"
     Exif:DateTimeDigitized: "2004:11:10 00:00:31"
     Exif:ShutterSpeedValue: 6.5 (1/90 s)
@@ -102,7 +101,6 @@ Reading ../../../../../libtiffpic/fax2d.tif
     YResolution: 98
     ResolutionUnit: "in"
     Software: "fax2tiff"
-    tiff:PageNumber: 1
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
@@ -121,7 +119,6 @@ Reading ../../../../../libtiffpic/g3test.tif
     YResolution: 98
     ResolutionUnit: "in"
     Software: "fax2tiff"
-    tiff:PageNumber: 1
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
@@ -226,7 +223,6 @@ Reading ../../../../../libtiffpic/pc260001.tif
     ExposureTime: 0.0125
     FNumber: 5.6
     Exif:ExposureProgram: 2 (normal program)
-    Exif:ISOSpeedRatings: 1
     Exif:DateTimeOriginal: "2005:12:26 17:09:35"
     Exif:DateTimeDigitized: "2005:12:26 17:09:35"
     Exif:ExposureBiasValue: 0

--- a/testsuite/tiff-suite/ref/out.txt
+++ b/testsuite/tiff-suite/ref/out.txt
@@ -57,7 +57,6 @@ Reading ../../../../../libtiffpic/dscf0013.tif
     PixelAspectRatio: 1
     FNumber: 3.4
     Exif:ExposureProgram: 2 (normal program)
-    Exif:ISOSpeedRatings: 1
     Exif:DateTimeOriginal: "2004:11:10 00:00:31"
     Exif:DateTimeDigitized: "2004:11:10 00:00:31"
     Exif:ShutterSpeedValue: 6.5 (1/90 s)
@@ -102,7 +101,6 @@ Reading ../../../../../libtiffpic/fax2d.tif
     YResolution: 98
     ResolutionUnit: "in"
     Software: "fax2tiff"
-    tiff:PageNumber: 1
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
@@ -121,7 +119,6 @@ Reading ../../../../../libtiffpic/g3test.tif
     YResolution: 98
     ResolutionUnit: "in"
     Software: "fax2tiff"
-    tiff:PageNumber: 1
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
     planarconfig: "contig"
@@ -226,7 +223,6 @@ Reading ../../../../../libtiffpic/pc260001.tif
     ExposureTime: 0.0125
     FNumber: 5.6
     Exif:ExposureProgram: 2 (normal program)
-    Exif:ISOSpeedRatings: 1
     Exif:DateTimeOriginal: "2005:12:26 17:09:35"
     Exif:DateTimeDigitized: "2005:12:26 17:09:35"
     Exif:ExposureBiasValue: 0


### PR DESCRIPTION
Many RAW files are really structured like TIFF underneath, and we
forcefully open them as a TIFF file to read their metadata, which is not
read as well by libraw. OK, but they also contain some of these oddball
tags, and that could lead to crashes. This patch makes it more robust to
some of these odd cases.