### PR TITLE
templatize round_to_multiple so it works with other types (like size_t)

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -137,12 +137,12 @@ pow2rounddown (int x)
 
 
 
-/// Round up to the next whole multiple of m.
-///
-inline int
-round_to_multiple (int x, int m)
+/// Round value up to the next whole multiple.
+/// For example, round_to_multiple(7,10) returns 10.
+template <typename V, typename M>
+inline V round_to_multiple (V value, M multiple)
 {
-    return ((x + m - 1) / m) * m;
+    return V (((value + V(multiple) - 1) / V(multiple)) * V(multiple));
 }
 
 

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -994,7 +994,7 @@ ImageBuf::write (ImageOutput *out,
         } else {
             // Big scanline image: break up into scanline strips
             imagesize_t slsize = bufspec.scanline_bytes();
-            int chunk = clamp (round_to_multiple(budget/slsize, 64), 1, 1024);
+            int chunk = clamp (round_to_multiple(int(budget/slsize), 64), 1, 1024);
             std::unique_ptr<char[]> tmp (new char [chunk*slsize]);
             for (int z = 0;  z < outspec.depth;  ++z) {
                 for (int y = 0;  y < outspec.height && ok;  y += chunk) {

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -122,6 +122,8 @@ test_int_helpers ()
     OIIO_CHECK_EQUAL (round_to_multiple(4, 5), 5);
     OIIO_CHECK_EQUAL (round_to_multiple(5, 5), 5);
     OIIO_CHECK_EQUAL (round_to_multiple(6, 5), 10);
+    OIIO_CHECK_EQUAL (round_to_multiple(size_t(5), 5), 5);
+    OIIO_CHECK_EQUAL (round_to_multiple(size_t(6), 5), 10);
 
     // round_to_multiple_of_pow2
     OIIO_CHECK_EQUAL (round_to_multiple_of_pow2(int(1), 4), 4);


### PR DESCRIPTION
Caused me to also modify the template to clamp to prevent a cascade of type errors.