### PR TITLE
IFF fixes: didn't write metadata, didn't read properly, some cleanup, tests

### DIFF
--- a/src/iff.imageio/iff_pvt.h
+++ b/src/iff.imageio/iff_pvt.h
@@ -61,9 +61,6 @@ namespace iff_pvt {
         // reads information about IFF file
         bool read_header (FILE *fd);
         
-        // writes information about iff file to give file
-        bool write_header (FILE *fd);
-          
         // header information
         uint32_t x;
         uint32_t y;
@@ -133,8 +130,7 @@ namespace iff_pvt {
         uint32_t th = tile_height();
         return (height + th - 1) / th;
     }
-    
-    
+
 } // namespace iff_pvt
 
 
@@ -168,6 +164,43 @@ private:
     
     // helper to uncompress a rle channel
     size_t uncompress_rle_channel(const uint8_t *in, uint8_t * out, int size);
+
+    bool read_short (uint16_t& val) {
+        bool ok = fread (&val, sizeof(val), 1, m_fd);
+        if (littleendian())
+            swap_endian (&val);
+        return ok;
+    }
+
+    bool read_int (uint32_t& val) {
+        bool ok = fread (&val, sizeof(val), 1, m_fd);
+        if (littleendian())
+            swap_endian (&val);
+        return ok;
+    }
+
+    bool read_str (std::string &val, uint32_t len, uint32_t round = 4) {
+        const uint32_t big = 1024;
+        char strbuf[big];
+        len = std::min (len, big);
+        bool ok = fread (strbuf, len, 1, m_fd);
+        val.assign (strbuf, len);
+        for (uint32_t pad = len%round; pad; --pad)
+            fgetc (m_fd);
+        return ok;
+    }
+
+    bool read_type_len (std::string &type, uint32_t &len) {
+        return read_str (type, 4)
+            && read_int (len);
+    }
+
+    bool read_meta_string (std::string &name, std::string &val) {
+        uint32_t len = 0;
+        return read_type_len (name, len)
+            && read_str (val, len);
+    }
+
 };
 
 
@@ -198,7 +231,37 @@ private:
         m_fd = NULL;
         m_filename.clear ();
     }
-    
+
+    // writes information about iff file to give file
+    bool write_header (iff_pvt::IffFileHeader &header);
+
+    bool write_short (uint16_t val) {
+        if (littleendian())
+            swap_endian (&val);
+        return fwrite (&val, sizeof(val), 1, m_fd);
+    }
+    bool write_int (uint32_t val) {
+        if (littleendian())
+            swap_endian (&val);
+        return fwrite (&val, sizeof(val), 1, m_fd);
+    }
+
+    bool write_str (string_view val, size_t round = 4) {
+        bool ok = fwrite (val.data(), val.size(), 1, m_fd);
+        for (size_t i = val.size(); i < round_to_multiple(val.size(), round); ++i)
+            ok &= (fputc (' ', m_fd) != EOF);
+        return ok;
+    }
+
+    bool write_meta_string (string_view name, string_view val,
+                            bool write_if_empty = false) {
+        if (val.empty() && ! write_if_empty)
+            return true;
+        return write_str (name)
+            && write_int (int(val.size()))
+            && (val.size() == 0 || write_str (val));
+    }
+
     // helper to compress verbatim
     void compress_verbatim (const uint8_t *& in, uint8_t *& out, int size);
       

--- a/src/iff.imageio/iffoutput.cpp
+++ b/src/iff.imageio/iffoutput.cpp
@@ -133,7 +133,7 @@ IffOutput::open (const std::string &name, const ImageSpec &spec,
     m_iff_header.author = m_spec.get_string_attribute ("Artist");
     m_iff_header.date = m_spec.get_string_attribute ("DateTime");
     
-    if (!m_iff_header.write_header (m_fd)) {
+    if (!write_header (m_iff_header)) {
         error ("\"%s\": could not write iff header", m_filename.c_str ());
         close ();
         return false;

--- a/testsuite/iff/ref/out.txt
+++ b/testsuite/iff/ref/out.txt
@@ -1,2 +1,4 @@
-Comparing "../../../../../oiio-images/grid.tif" and "grid.iff"
+Comparing "../../../../../oiio-images/grid.tif" and "gridscanline.iff"
+PASS
+Comparing "../../../../../oiio-images/grid.tif" and "gridtile.iff"
 PASS

--- a/testsuite/iff/run.py
+++ b/testsuite/iff/run.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
 imagedir = parent + "/oiio-images"
-command += oiiotool (imagedir+"/grid.tif --scanline -o grid.iff")
-command += diff_command (imagedir+"/grid.tif", "grid.iff")
+command += oiiotool (imagedir+"/grid.tif --scanline -o gridscanline.iff")
+command += diff_command (imagedir+"/grid.tif", "gridscanline.iff")
+command += oiiotool (imagedir+"/grid.tif --tile 64 64 -o gridtile.iff")
+command += diff_command (imagedir+"/grid.tif", "gridtile.iff")

--- a/testsuite/oiiotool-spi/ref/out.txt
+++ b/testsuite/oiiotool-spi/ref/out.txt
@@ -1,10 +1,18 @@
+Reading iffout_vd8.1001.iff
+iffout_vd8.1001.iff  : 1998 x 1080, 4 channel, uint8 iff
+    SHA-1: 8DCC7F60EEA962A70ACE8E443BFA73D899123332
+    channel list: R, G, B, A
+    tile size: 64 x 64
+    compression: "rle"
+    Artist: "arturo on duck7105.spimageworks.com, Linux 3.10.0-327.22.2.el7.x86_64 x86_64"
+    DateTime: "Tue Oct 11 09:21:35 2016"
 Comparing "fit_lg10.dpx" and "../../../../../spi-oiio-tests/ref/fit_lg10.dpx"
 PASS
 Comparing "mkt019_comp_wayn_fullres_s3d_lf_v51_alpha_misc_vd16.1001.tif" and "../../../../../spi-oiio-tests/ref/mkt019_comp_wayn_fullres_s3d_lf_v51_alpha_misc_vd16.1001.tif"
 PASS
 Comparing "ffr0830_avid_ref_match_v3_2kdcip_ref8.1024.jpg" and "../../../../../spi-oiio-tests/ref/ffr0830_avid_ref_match_v3_2kdcip_ref8.1024.jpg"
 PASS
-Comparing "ep0400_bg1_v101_1kalxog_vd8.1001.jpg" and "../../../../../spi-oiio-tests/ref/ep0400_bg1_v101_1kalxog_vd8.1001.jpg"
+Comparing "ep0400-v2_bg1_v101_1kalxog_vd8.1001.jpg" and "../../../../../spi-oiio-tests/ref/ep0400-v2_bg1_v101_1kalxog_vd8.1001.jpg"
 PASS
 Comparing "os0225_110_lightingfix_v002.0101.png" and "../../../../../spi-oiio-tests/ref/os0225_110_lightingfix_v002.0101.png"
 PASS

--- a/testsuite/oiiotool-spi/run.py
+++ b/testsuite/oiiotool-spi/run.py
@@ -45,6 +45,11 @@ command += oiiotool_and_test ("os0225_110_lightingfix_v002.0101.dpx",
                               "os0225_110_lightingfix_v002.0101.png",
                               precommand = "--colorconfig " + imagedir + "os4.ocio/config.ocio")
 
+# Test read of iff
+command += oiiotool_and_test ("iff/iff_vd8.1001.iff",
+                              "",
+                              "./iff_vd8.1001.iff")
+command += info_command ("iff_vd8.1001.iff")
 
 
 # Regression test on dealing with DPX with overscan

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -53,7 +53,7 @@ failthresh = 0.004
 hardfail = 0.012
 failpercent = 0.02
 
-image_extensions = [ ".tif", ".tx", ".exr", ".jpg", ".png", ".rla", ".dpx" ]
+image_extensions = [ ".tif", ".tx", ".exr", ".jpg", ".png", ".rla", ".dpx", "iff" ]
 
 # print ("srcdir = " + srcdir)
 # print ("tmpdir = " + tmpdir)


### PR DESCRIPTION
The main thing is that the writer dropped the "Artist" and "Date" metadata.
The reader would read them, but botched the padding slightly and could
end up with extra spaces at the end of the fields.

Fixes #1546 
