### PR TITLE
thread.h: modernize, thread_pool, parallel_for

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ Release 1.8 (in progress) -- compared to 1.7.x
 ----------------------------------------------
 New minimum dependencies:
  * **C++11** (gcc 4.8.2, clang 3.3, or MSVS 2013)
- * **Boost >= 1.50**
+ * **Boost >= 1.53**
 
 Major new features and improvements:
 * New oiiotool commands:
@@ -106,6 +106,12 @@ Developer goodies / internals:
    * Fixed typo in fmath.h that made bitcast_to_float incorrect. #1543 (1.8.0)
    * Templatize round_to_multiple() so it works with types other than `int`.
      #1548 (1.8.0)
+* thread.h:
+   * thread_pool class offers true persistent thread pool. #1556 (1.8.1)
+   * Lots of C++ modernization of thread_group and spin_mutex. #1556 (1.8.1)
+* parallel.h:
+   * parallel_for, parallel_for_chunked, parallel_for_each offer simple
+     thread_pool-based parallel looping. #1556 (1.8.1)
 
 
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -117,8 +117,8 @@ endif ()
 
 if (NOT DEFINED Boost_ADDITIONAL_VERSIONS)
   set (Boost_ADDITIONAL_VERSIONS "1.62" "1.61" "1.60"
-                                 "1.59" "1.58" "1.57" "1.56"
-                                 "1.55" "1.54" "1.53" "1.52" "1.51" "1.50")
+                                 "1.59" "1.58" "1.57" "1.56" "1.55"
+                                 "1.54" "1.53")
 endif ()
 if (LINKSTATIC)
     set (Boost_USE_STATIC_LIBS   ON)

--- a/src/doc/oiiointro.tex
+++ b/src/doc/oiiointro.tex
@@ -213,7 +213,7 @@ fixed if pointed out. The full original licenses can be found in the
 relevant parts of the source code.
 
 \smallskip
-\noindent \product incorporates or distributes:
+\noindent \product incorporates, distributes, or contains derived works of:
 
 \begin{itemize}
 \item The SHA-1 implemenation we use is public domain by
@@ -234,6 +234,8 @@ Dominik Reichl \\ {\cf http://www.dominik-reichl.de/}
 {\cf http://code.google.com/p/farmhash/}
 \item {\cf KissFFT} \copyright\ 2003--2010 Mark Borgerding.
 {\cf http://sourceforge.net/projects/kissfft}
+\item {\cf CTPL} thread pool \copyright\ 2014 Vitaliy Vitsentiy, Apache License.
+{\cf https://github.com/vit-vit/CTPL}
 \item Droid fonts from the Android SDK are distributed under the
     Apache license. \\ {\cf http://www.droidfonts.com}
 \end{itemize}

--- a/src/include/OpenImageIO/parallel.h
+++ b/src/include/OpenImageIO/parallel.h
@@ -1,0 +1,150 @@
+/*
+  Copyright 2016 Larry Gritz and the other authors and contributors.
+  All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the software's owners nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  (This is the Modified BSD License)
+*/
+
+
+#ifndef OPENIMAGEIO_PARALLEL_H
+#define OPENIMAGEIO_PARALLEL_H
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "thread.h"
+
+
+OIIO_NAMESPACE_BEGIN
+
+
+/// Parallel "for" loop, chunked: for a task that takes an int thread ID
+/// followed by an int64_t [begin,end) range, break it into non-overlapping
+/// sections that run in parallel using the default thread pool:
+///
+///    task (threadid, start, start+chunksize);
+///    task (threadid, start+chunksize, start+2*chunksize);
+///    ...
+///    task (threadid, start+n*chunksize, end);
+///
+/// and wait for them all to complete.
+///
+/// If chunksize is 0, a chunksize will be chosen to divide the range into
+/// a number of chunks equal to the twice number of threads in the queue.
+/// (We do this to offer better load balancing than if we used exactly the
+/// thread count.)
+inline void
+parallel_for_chunked (int64_t start, int64_t end, int64_t chunksize,
+                   std::function<void(int id, int64_t b, int64_t e)>&& task)
+{
+    thread_pool *pool (default_thread_pool());
+    if (chunksize < 1)
+        chunksize = std::max (int64_t(1), (end-start) / (2*pool->size()));
+    for (task_set<void> ts; start < end; start += chunksize)
+        ts.push (pool->push (task, start, std::min (end, start+chunksize)));
+}
+
+
+/// Parallel "for" loop, chunked: for a task that takes a [begin,end) range
+/// (but not a thread ID).
+inline void parallel_for_chunked (int64_t start, int64_t end, int64_t chunksize,
+                           std::function<void(int64_t b, int64_t e)>&& task)
+{
+    thread_pool *pool (default_thread_pool());
+    if (chunksize < 1)
+        chunksize = std::max (int64_t(1), (end-start) / (2*pool->size()));
+    auto wrapper = [&](int id, int64_t b, int64_t e){ task(b,e); };
+    for (task_set<void> ts; start < end; start += chunksize)
+        ts.push (pool->push (wrapper, start, std::min (end, start+chunksize)));
+
+}
+
+
+
+/// Parallel "for" loop, for a task that takes a single int64_t index, run
+/// it on all indices on the range [begin,end):
+///
+///    task (begin);
+///    task (begin+1);
+///    ...
+///    task (end-1);
+///
+/// Using the default thread pool, spawn parallel jobs. Conceptually, it
+/// behaves as if each index gets called separately, but actually each
+/// thread will iterate over some chunk of adjacent indices (to aid data
+/// coherence and minimuize the amount of thread queue diddling). The chunk
+/// size is chosen automatically.
+inline void
+parallel_for (int64_t start, int64_t end,
+              std::function<void(int64_t index)>&& task)
+{
+    parallel_for_chunked (start, end, 0, [&task](int id, int64_t i, int64_t e) {
+        for ( ; i < e; ++i)
+            task (i);
+    });
+}
+
+
+/// parallel_for, for a task that takes an int threadid and an int64_t
+/// index, running all of:
+///    task (id, begin);
+///    task (id, begin+1);
+///    ...
+///    task (id, end-1);
+inline void
+parallel_for (int64_t start, int64_t end,
+              std::function<void(int id, int64_t index)>&& task)
+{
+    parallel_for_chunked (start, end, 0, [&task](int id, int64_t i, int64_t e) {
+        for ( ; i < e; ++i)
+            task (id, i);
+    });
+}
+
+
+
+/// parallel_for_each, semantically is like std::for_each(), but each
+/// iteration is a separate job for the default thread pool.
+template<class InputIt, class UnaryFunction>
+UnaryFunction
+parallel_for_each (InputIt first, InputIt last, UnaryFunction f)
+{
+    thread_pool *pool (default_thread_pool());
+    for (task_set<void> ts; first != last; ++first)
+        ts.push (pool->push ([&](int id){ f(*first); }));
+    return std::move(f);
+}
+
+
+OIIO_NAMESPACE_END
+
+#endif // OPENIMAGEIO_PARALLEL_H

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -53,6 +53,7 @@ list (APPEND libOpenImageIO_srcs
                           ../libutil/SHA1.cpp 
                           ../libutil/strutil.cpp 
                           ../libutil/sysutil.cpp 
+                          ../libutil/thread.cpp 
                           ../libutil/timer.cpp 
                           ../libutil/typedesc.cpp 
                           ../libutil/ustring.cpp 

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -48,6 +48,7 @@ namespace pvt {
 /// Mutex allowing thread safety of ImageOutput internals
 ///
 extern recursive_mutex imageio_mutex;
+extern thread_pool *oiio_thread_pool;
 extern atomic_int oiio_threads;
 extern atomic_int oiio_read_chunk;
 extern ustring plugin_searchpath;
@@ -100,8 +101,7 @@ const void *convert_from_float (const float *src, void *dst, size_t nvals,
 /// A version of convert_from_float that will break up big jobs with
 /// multiple threads.
 const void *parallel_convert_from_float (const float *src, void *dst,
-                                         size_t nvals,
-                                         TypeDesc format, int nthreads=0);
+                                         size_t nvals, TypeDesc format);
 
 }  // namespace pvt
 

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -1,7 +1,7 @@
 set (libOpenImageIO_Util_srcs argparse.cpp errorhandler.cpp filesystem.cpp
                   farmhash.cpp filter.cpp hashes.cpp paramlist.cpp
                   plugin.cpp SHA1.cpp
-                  strutil.cpp sysutil.cpp timer.cpp
+                  strutil.cpp sysutil.cpp thread.cpp timer.cpp
                   typedesc.cpp ustring.cpp xxhash.cpp)
 
 if (BUILDSTATIC)
@@ -88,10 +88,20 @@ if (OIIO_BUILD_TESTS)
     target_link_libraries (hash_test OpenImageIO_Util ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
     add_test (unit_hash hash_test)
 
+    add_executable (parallel_test parallel_test.cpp)
+    set_target_properties (parallel_test PROPERTIES FOLDER "Unit Tests")
+    target_link_libraries (parallel_test OpenImageIO_Util ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+    add_test (unit_parallel parallel_test)
+
     add_executable (timer_test timer_test.cpp)
     set_target_properties (timer_test PROPERTIES FOLDER "Unit Tests")
     target_link_libraries (timer_test OpenImageIO_Util ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
     add_test (unit_timer timer_test)
+
+    add_executable (thread_test thread_test.cpp)
+    set_target_properties (thread_test PROPERTIES FOLDER "Unit Tests")
+    target_link_libraries (thread_test OpenImageIO_Util ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+    add_test (unit_thread thread_test)
 
     add_executable (simd_test simd_test.cpp)
     set_target_properties (simd_test PROPERTIES FOLDER "Unit Tests")

--- a/src/libutil/spin_rw_test.cpp
+++ b/src/libutil/spin_rw_test.cpp
@@ -29,6 +29,7 @@
 */
 
 
+#include <functional>
 #include <iostream>
 
 #include "OpenImageIO/thread.h"
@@ -37,9 +38,6 @@
 #include "OpenImageIO/timer.h"
 #include "OpenImageIO/argparse.h"
 #include "OpenImageIO/ustring.h"
-
-#include <boost/thread/thread.hpp>
-#include <boost/bind.hpp>
 
 #include "OpenImageIO/unittest.h"
 
@@ -86,9 +84,9 @@ do_accum (int iterations)
 void test_spin_rw (int numthreads, int iterations)
 {
     accum = 0;
-    boost::thread_group threads;
+    thread_group threads;
     for (int i = 0;  i < numthreads;  ++i) {
-        threads.create_thread (boost::bind(do_accum,iterations));
+        threads.create_thread (do_accum, iterations);
     }
     if (verbose)
         std::cout << "Created " << threads.size() << " threads\n";
@@ -149,7 +147,7 @@ int main (int argc, char *argv[])
         int its = iterations/nt;
 
         double range;
-        double t = time_trial (boost::bind(test_spin_rw,nt,its),
+        double t = time_trial (std::bind(test_spin_rw,nt,its),
                                ntrials, &range);
 
         std::cout << Strutil::format ("%2d\t%s\t%5.1fs, range %.1f\t(%d iters/thread)\n",

--- a/src/libutil/spinlock_test.cpp
+++ b/src/libutil/spinlock_test.cpp
@@ -29,6 +29,7 @@
 */
 
 
+#include <functional>
 #include <iostream>
 
 #include "OpenImageIO/thread.h"
@@ -37,9 +38,6 @@
 #include "OpenImageIO/timer.h"
 #include "OpenImageIO/argparse.h"
 #include "OpenImageIO/ustring.h"
-
-#include <boost/thread/thread.hpp>
-#include <boost/bind.hpp>
 
 #include "OpenImageIO/unittest.h"
 
@@ -70,7 +68,7 @@ do_accum (int iterations)
 {
     if (verbose) {
         spin_lock lock(print_mutex);
-        std::cout << "thread " << boost::this_thread::get_id() 
+        std::cout << "thread " << std::this_thread::get_id() 
                   << ", accum = " << accum << "\n";
     }
 #if 1
@@ -96,9 +94,9 @@ do_accum (int iterations)
 void test_spinlock (int numthreads, int iterations)
 {
     accum = 0;
-    boost::thread_group threads;
+    thread_group threads;
     for (int i = 0;  i < numthreads;  ++i) {
-        threads.create_thread (boost::bind(do_accum,iterations));
+        threads.create_thread (do_accum, iterations);
     }
     ASSERT ((int)threads.size() == numthreads);
     threads.join_all ();
@@ -152,7 +150,7 @@ int main (int argc, char *argv[])
         int its = iterations/nt;
 
         double range;
-        double t = time_trial (boost::bind(test_spinlock,nt,its),
+        double t = time_trial (std::bind(test_spinlock,nt,its),
                                ntrials, &range);
 
         std::cout << Strutil::format ("%2d\t%5.1f   range %.2f\t(%d iters/thread)\n",

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -1,0 +1,289 @@
+/*
+  Copyright 2016 Larry Gritz and the other authors and contributors.
+  All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the software's owners nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  (This is the Modified BSD License)
+*/
+
+
+// This implementation of thread_pool is based on CTPL
+// https://github.com/vit-vit/CTPL
+// Copyright (C) 2014 by Vitaliy Vitsentiy
+// Licensed with Apache 2.0
+// (see https://github.com/vit-vit/CTPL/blob/master/LICENSE)
+
+
+#if defined(_MSC_VER)
+#define _ENABLE_ATOMIC_ALIGNMENT_FIX /* Avoid MSVS error, ugh */
+#endif
+
+#include <exception>
+#include <functional>
+#include <future>
+#include <memory>
+
+// Use boost::lockfree::queue for the task queue
+#include <boost/lockfree/queue.hpp>
+
+#include <OpenImageIO/sysutil.h>
+#include <OpenImageIO/thread.h>
+
+
+OIIO_NAMESPACE_BEGIN
+
+
+class thread_pool::Impl {
+public:
+    Impl (int nThreads = 0, int queueSize = 1024) : q(queueSize) { this->init(); this->resize(nThreads); }
+
+    // the destructor waits for all the functions in the queue to be finished
+    ~Impl () {
+        this->stop(true);
+    }
+
+    // get the number of running threads in the pool
+    int size() const { return static_cast<int>(this->threads.size()); }
+
+    // number of idle threads
+    int n_idle() { return this->nWaiting; }
+    std::thread & get_thread(int i) { return *this->threads[i]; }
+
+    // change the number of threads in the pool
+    // should be called from one thread, otherwise be careful to not interleave, also with this->stop()
+    // nThreads must be >= 0
+    void resize(int nThreads) {
+        if (nThreads < 1)
+            nThreads = Sysutil::hardware_concurrency();
+        if (!this->isStop && !this->isDone) {
+            int oldNThreads = static_cast<int>(this->threads.size());
+            if (oldNThreads <= nThreads) {  // if the number of threads is increased
+                this->threads.resize(nThreads);
+                this->flags.resize(nThreads);
+                for (int i = oldNThreads; i < nThreads; ++i) {
+                    this->flags[i] = std::make_shared<std::atomic<bool>>(false);
+                    this->set_thread(i);
+                }
+            }
+            else {  // the number of threads is decreased
+                for (int i = oldNThreads - 1; i >= nThreads; --i) {
+                    *this->flags[i] = true;  // this thread will finish
+                    this->threads[i]->detach();
+                }
+                {
+                    // stop the detached threads that were waiting
+                    std::unique_lock<std::mutex> lock(this->mutex);
+                    this->cv.notify_all();
+                }
+                this->threads.resize(nThreads);  // safe to delete because the threads are detached
+                this->flags.resize(nThreads);  // safe to delete because the threads have copies of shared_ptr of the flags, not originals
+            }
+        }
+    }
+
+    // empty the queue
+    void clear_queue() {
+        std::function<void(int id)> * _f;
+        while (this->q.pop(_f))
+            delete _f;  // empty the queue
+    }
+
+    // pops a functional wraper to the original function
+    std::function<void(int)> pop() {
+        std::function<void(int id)> * _f = nullptr;
+        this->q.pop(_f);
+        std::unique_ptr<std::function<void(int id)>> func(_f);  // at return, delete the function even if an exception occurred
+        std::function<void(int)> f;
+        if (_f)
+            f = *_f;
+        return f;
+    }
+
+
+    // wait for all computing threads to finish and stop all threads
+    // may be called asyncronously to not pause the calling thread while waiting
+    // if isWait == true, all the functions in the queue are run, otherwise the queue is cleared without running the functions
+    void stop(bool isWait = false) {
+        if (!isWait) {
+            if (this->isStop)
+                return;
+            this->isStop = true;
+            for (int i = 0, n = this->size(); i < n; ++i) {
+                *this->flags[i] = true;  // command the threads to stop
+            }
+            this->clear_queue();  // empty the queue
+        }
+        else {
+            if (this->isDone || this->isStop)
+                return;
+            this->isDone = true;  // give the waiting threads a command to finish
+        }
+        {
+            std::unique_lock<std::mutex> lock(this->mutex);
+            this->cv.notify_all();  // stop all waiting threads
+        }
+        for (int i = 0; i < static_cast<int>(this->threads.size()); ++i) {  // wait for the computing threads to finish
+            if (this->threads[i]->joinable())
+                this->threads[i]->join();
+        }
+        // if there were no threads in the pool but some functors in the queue, the functors are not deleted by the threads
+        // therefore delete them here
+        this->clear_queue();
+        this->threads.clear();
+        this->flags.clear();
+    }
+
+    template<typename F, typename... Rest>
+    auto push(F && f, Rest&&... rest) ->std::future<decltype(f(0, rest...))> {
+        auto pck = std::make_shared<std::packaged_task<decltype(f(0, rest...))(int)>>(
+            std::bind(std::forward<F>(f), std::placeholders::_1, std::forward<Rest>(rest)...)
+        );
+        auto _f = new std::function<void(int id)>([pck](int id) {
+            (*pck)(id);
+        });
+        this->q.push(_f);
+        std::unique_lock<std::mutex> lock(this->mutex);
+        this->cv.notify_one();
+        return pck->get_future();
+    }
+
+    // run the user's function that excepts argument int - id of the running thread. returned value is templatized
+    // operator returns std::future, where the user can get the result and rethrow the catched exceptins
+    template<typename F>
+    auto push(F && f) ->std::future<decltype(f(0))> {
+        auto pck = std::make_shared<std::packaged_task<decltype(f(0))(int)>>(std::forward<F>(f));
+        auto _f = new std::function<void(int id)>([pck](int id) {
+            (*pck)(id);
+        });
+        this->q.push(_f);
+        std::unique_lock<std::mutex> lock(this->mutex);
+        this->cv.notify_one();
+        return pck->get_future();
+    }
+
+    void push_queue_and_notify (std::function<void(int id)> *f) {
+        this->q.push(f);
+        std::unique_lock<std::mutex> lock(this->mutex);
+        this->cv.notify_one();
+    }
+
+private:
+    Impl (const Impl  &) = delete;
+    Impl (Impl  &&) = delete;
+    Impl  & operator=(const Impl  &) = delete;
+    Impl  & operator=(Impl  &&) = delete;
+
+    void set_thread(int i) {
+        std::shared_ptr<std::atomic<bool>> flag(this->flags[i]);  // a copy of the shared ptr to the flag
+        auto f = [this, i, flag/* a copy of the shared ptr to the flag */]() {
+            std::atomic<bool> & _flag = *flag;
+            std::function<void(int id)> * _f;
+            bool isPop = this->q.pop(_f);
+            while (true) {
+                while (isPop) {  // if there is anything in the queue
+                    std::unique_ptr<std::function<void(int id)>> func(_f);  // at return, delete the function even if an exception occurred
+                    (*_f)(i);
+                    if (_flag)
+                        return;  // the thread is wanted to stop, return even if the queue is not empty yet
+                    else
+                        isPop = this->q.pop(_f);
+                }
+                // the queue is empty here, wait for the next command
+                std::unique_lock<std::mutex> lock(this->mutex);
+                ++this->nWaiting;
+                this->cv.wait(lock, [this, &_f, &isPop, &_flag](){ isPop = this->q.pop(_f); return isPop || this->isDone || _flag; });
+                --this->nWaiting;
+                if (!isPop)
+                    return;  // if the queue is empty and this->isDone == true or *flag then return
+            }
+        };
+        this->threads[i].reset(new std::thread(f));  // compiler may not support std::make_unique()
+    }
+
+    void init() { this->nWaiting = 0; this->isStop = false; this->isDone = false; }
+
+    std::vector<std::unique_ptr<std::thread>> threads;
+    std::vector<std::shared_ptr<std::atomic<bool>>> flags;
+    mutable boost::lockfree::queue<std::function<void(int id)> *> q;
+    std::atomic<bool> isDone;
+    std::atomic<bool> isStop;
+    std::atomic<int> nWaiting;  // how many threads are waiting
+    std::mutex mutex;
+    std::condition_variable cv;
+};
+
+
+
+
+
+thread_pool::thread_pool (int nthreads, int queue_size)
+    : m_impl (new Impl (nthreads, queue_size))
+{
+    resize (nthreads);
+}
+
+
+
+thread_pool::~thread_pool ()
+{
+    // Will implicitly delete the impl
+}
+
+
+
+int
+thread_pool::size () const
+{
+    return m_impl->size();
+}
+
+
+
+void
+thread_pool::resize (int nthreads)
+{
+    m_impl->resize (nthreads);
+}
+
+
+
+void
+thread_pool::push_queue_and_notify (std::function<void(int id)> *f)
+{
+    m_impl->push_queue_and_notify (f);
+}
+
+
+
+thread_pool *
+default_thread_pool ()
+{
+    static std::unique_ptr<thread_pool> shared_pool (new thread_pool);
+    return shared_pool.get();
+}
+
+
+OIIO_NAMESPACE_END
+

--- a/src/libutil/thread_test.cpp
+++ b/src/libutil/thread_test.cpp
@@ -1,0 +1,175 @@
+/*
+  Copyright 2016 Larry Gritz and the other authors and contributors.
+  All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  * Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+  * Neither the name of the software's owners nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  (This is the Modified BSD License)
+*/
+
+
+#include <iostream>
+#include <functional>
+#include <algorithm>
+
+#include <OpenImageIO/argparse.h>
+#include <OpenImageIO/sysutil.h>
+#include <OpenImageIO/thread.h>
+#include <OpenImageIO/timer.h>
+#include <OpenImageIO/unittest.h>
+#include <OpenImageIO/ustring.h>
+
+OIIO_NAMESPACE_USING;
+
+static int iterations = 100000;
+static int numthreads = 16;
+static int ntrials = 1;
+static bool verbose = false;
+static bool wedge = false;
+static int threadcounts[] = { 1, 2, 4, 8, 12, 16, 20, 24, 28, 32, 64, 128, 1024, 1<<30 };
+
+
+
+static void
+getargs (int argc, char *argv[])
+{
+    bool help = false;
+    ArgParse ap;
+    ap.options ("thread_test\n"
+                OIIO_INTRO_STRING "\n"
+                "Usage:  thread_test [options]",
+                // "%*", parse_files, "",
+                "--help", &help, "Print help message",
+                "-v", &verbose, "Verbose mode",
+                "--threads %d", &numthreads, 
+                    ustring::format("Number of threads (default: %d)", numthreads).c_str(),
+                "--iters %d", &iterations,
+                    ustring::format("Number of iterations (default: %d)", iterations).c_str(),
+                "--trials %d", &ntrials, "Number of trials",
+                "--wedge", &wedge, "Do a wedge test",
+                NULL);
+    if (ap.parse (argc, (const char**)argv) < 0) {
+        std::cerr << ap.geterror() << std::endl;
+        ap.usage ();
+        exit (EXIT_FAILURE);
+    }
+    if (help) {
+        ap.usage ();
+        exit (EXIT_FAILURE);
+    }
+}
+
+
+
+void do_nothing (int thread_id) { }
+
+
+
+void
+time_thread_group ()
+{
+    std::cout << "\nTiming how long it takes to start/end thread_group:\n";
+    std::cout << "threads\ttime (best of " << ntrials << ")\n";
+    std::cout << "-------\t----------\n";
+    for (int i = 0; threadcounts[i] <= numthreads; ++i) {
+        int nt = wedge ? threadcounts[i] : numthreads;
+        int its = iterations/nt;
+
+        // make a lambda function that spawns a bunch of threads, calls a
+        // trivial function, then waits for them to finish and tears down
+        // the group.
+        auto func = [=](){
+            thread_group g;
+            for (int i = 0; i < nt; ++i)
+                g.create_thread (do_nothing, i);
+            g.join_all ();
+        };
+
+        double range;
+        double t = time_trial (func, ntrials, its, &range);
+
+        std::cout << Strutil::format ("%2d\t%5.1f   launch %8.1f threads/sec\n",
+                                      nt, t, (nt*its)/t);
+        if (! wedge)
+            break;    // don't loop if we're not wedging
+    }
+}
+
+
+
+void
+time_thread_pool ()
+{
+    std::cout << "\nTiming how long it takes to launch from thread_pool:\n";
+    std::cout << "threads\ttime (best of " << ntrials << ")\n";
+    std::cout << "-------\t----------\n";
+    thread_pool *pool (default_thread_pool());
+    for (int i = 0; threadcounts[i] <= numthreads; ++i) {
+        int nt = wedge ? threadcounts[i] : numthreads;
+        pool->resize (nt);
+        int its = iterations/nt;
+
+        // make a lambda function that spawns a bunch of threads, calls a
+        // trivial function, then waits for them to finish and tears down
+        // the group.
+        auto func = [=](){
+            task_set<void> taskset;
+            for (int i = 0; i < nt; ++i) {
+                taskset.push (pool->push (do_nothing));
+            }
+            taskset.wait();
+        };
+
+        double range;
+        double t = time_trial (func, ntrials, its, &range);
+
+        std::cout << Strutil::format ("%2d\t%5.1f   launch %8.1f threads/sec\n",
+                                      nt, t, (nt*its)/t);
+        if (! wedge)
+            break;    // don't loop if we're not wedging
+    }
+}
+
+
+
+int
+main (int argc, char **argv)
+{
+#if !defined(NDEBUG) || defined(OIIO_CI) || defined(OIIO_CODECOV)
+    // For the sake of test time, reduce the default iterations for DEBUG,
+    // CI, and code coverage builds. Explicit use of --iters or --trials
+    // will override this, since it comes before the getargs() call.
+    iterations /= 10;
+    ntrials = 1;
+#endif
+
+    getargs (argc, argv);
+
+    std::cout << "hw threads = " << Sysutil::hardware_concurrency() << "\n";
+
+    time_thread_group ();
+    time_thread_pool ();
+
+    return unit_test_failures;
+}


### PR DESCRIPTION
* Bring thread_group into modern C++11 era: use std components, no more
  boost dependency, use variadic templates for a better create_thread
  signature. Also remove the last vestigages of using boost::thread_group
  instead of ours.

* Modernize spin_mutex to use C++11 std::atomic_flag instead of doing
  everything with bespoke code.

* thread_pool : persistent threads feeding from a task queue. This is
  generally a better way forward than explicitly spawning new threads
  with thread_group every time you want to do things in parallel.

* task_set : Because the thread_pool is asynchronous (fire and forget,
  or fire and get future's back), a simple task_set object lets you collect
  a set of related asynchronous tasks and wait for them to all have been
  completed before proceeding.

* parallel_for : several easy constructs for a variety of parallel
  loops, using the default thread pool. Makes parallelizing "1-D" loops
  very similar to writing an ordinary 'for' loop, or calling
  std::for_each.

* OIIO attribute("nthreads") sets the size of the thread pool.

The implementation of the thread pool is based on the CTPL project
(Apache license). It's hidden completely in thread.cpp, totally
independent of the thread.h exposed APIs that use the PIMPL idiom, so we
are free to replace the underlying pool implementation if we realize
with more experience that CTPL was not the best choice.

Note also that we have bumped the minimum version of Boost to 1.53 to
accommodate the thread_pool's internal use of boost::lockfree::queue.
That seems reasonable, considering that VFX recommended Boost 1.53 as
the recommended version in 2014, 1.55 in 2015 & 2016. Boost lockfree
queue is header-only, so this doesn't introduce any new linkage or
version mismatch issues.

Read the comments in thread.h for a full explanation, but just for
illustration in this review, here is what it looks like to use it:

Serial tasks:

    for (int i = 0; i < N; ++i)
        job(i);

Parallel tasks using thread_pool, and waiting for them to finish before
proceeding:

    thread_pool *p = thread_pool::get_thread_pool();
    work_set w;
    for (int i = 0; i < N; ++i)
        w.push (p->push (job, i));
    w.wait();

Serial loop:

    for (int i = 0; i < N; ++i) {
        a[i] += b[i];
    }

Parallel loop, will divide the range among threads:

    parallel_for (0, N, [&](int64_t i){
        a[i] += b[i];
    });