### PR TITLE
Fix threadpool

### DIFF
--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -46,6 +46,7 @@
 #include <mutex>
 #include <thread>
 #include <vector>
+#include <chrono>
 
 #include "oiioversion.h"
 #include "export.h"
@@ -503,12 +504,17 @@ private:
 /// A common idiom is to fire a bunch of sub-tasks at the queue, and then
 /// wait for them to all complete. We provide a helper class, task_set,
 /// to make this easy:
-///     task_set<decltype(myfunc())> tasks;
+///     task_set<decltype(myfunc())> tasks (pool);
 ///     for (int i = 0; i < n_subtasks; ++i)
 ///         tasks.push_back (pool->push (myfunc));
 ///     tasks.wait ();
 /// Note that the tasks.wait() is optional -- it will be called
 /// automatically when the task_set exits its scope.
+///
+/// The task function's first argument, the thread_id, is the thread number
+/// for the pool, or -1 if it's being executed by a non-pool thread (this
+/// can happen in cases where the whole pool is occupied and the calling
+/// thread contributes to running the work load).
 ///
 /// Thread pool. Have fun, be safe.
 ///
@@ -525,6 +531,10 @@ public:
     /// Change the number of threads in the pool. BEWARE! This should not
     /// be done while jobs are running.
     void resize (int nthreads = 0);
+
+    /// Return the number of currently idle threads in the queue. Zero
+    /// means the queue is fully engaged.
+    int idle () const;
 
     /// Run the user's function that accepts argument int - id of the
     /// running thread. The returned value is templatized std::future, where
@@ -554,6 +564,11 @@ public:
         return pck->get_future();
     }
 
+    /// If there are any tasks on the queue, pull one off and run it (on
+    /// this calling thread) and return true. Otherwise (there are no
+    /// pending jobs), return false immediately.
+    bool run_one_task ();
+
 private:
     // Disallow copy construction and assignment
     thread_pool (const thread_pool&) = delete;
@@ -579,7 +594,7 @@ OIIO_API thread_pool* default_thread_pool ();
 
 
 
-/// task_set<T> is a group of tasks represented by future<T> that you can
+/// task_set<T> is a group of future<T>'s from a thread_queue that you can
 /// add to, and when you either call wait() or just leave the task_set's
 /// scope, it will wait for all the tasks in the set to be done before
 /// proceeding.
@@ -588,9 +603,9 @@ OIIO_API thread_pool* default_thread_pool ();
 ///
 ///    void myfunc (int id) { ... do something ... }
 ///
-///    thread_pool& pool (default_thread_pool());
+///    thread_pool* pool (default_thread_pool());
 ///    {
-///        task_set<decltype(myfunc())> tasks;
+///        task_set<decltype(myfunc())> tasks (pool);
 ///        // Launch a bunch of tasks into the thread pool
 ///        for (int i = 0; i < ntasks; ++i)
 ///            tasks.push_back (pool->push (myfunc));
@@ -601,14 +616,33 @@ OIIO_API thread_pool* default_thread_pool ();
 template<typename T>
 class task_set {
 public:
-    task_set () { }
+    task_set (thread_pool *pool) { m_pool = pool; }
     ~task_set () { wait(); }
     void push (std::future<T> &&f) { m_futures.emplace_back (std::move(f)); }
     void wait () {
-        for (auto& f : m_futures)
-            f.wait();
+        int tries = 0;
+        std::chrono::milliseconds wait_time (0);
+        while (1) {
+            bool all_finished = true;
+            for (auto& f : m_futures) {
+                // Asking future.wait_for for 0 time just checks the status.
+                auto status = f.wait_for (wait_time);
+                if (status != std::future_status::ready)
+                    all_finished = false;
+            }
+            if (all_finished)   // All futures are ready? We're done.
+                break;
+            // We're still waiting on some tasks to complete. What next?
+            if (++tries < 4)    // First few times,
+                continue;       //   just busy-wait, check status again
+            // Since we're waiting, try to run a task ourselves to help
+            // with the load. If none is available, just yield schedule.
+            if (! m_pool->run_one_task())
+                yield();
+        }
     }
 private:
+    thread_pool *m_pool;
     std::vector<std::future<T>> m_futures;
 };
 

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -81,7 +81,7 @@ public:
     // nThreads must be >= 0
     void resize(int nThreads) {
         if (nThreads < 1)
-            nThreads = Sysutil::hardware_concurrency();
+            nThreads = Sysutil::hardware_concurrency() - 1;
         if (!this->isStop && !this->isDone) {
             int oldNThreads = static_cast<int>(this->threads.size());
             if (oldNThreads <= nThreads) {  // if the number of threads is increased

--- a/src/libutil/thread_test.cpp
+++ b/src/libutil/thread_test.cpp
@@ -134,7 +134,7 @@ time_thread_pool ()
         // trivial function, then waits for them to finish and tears down
         // the group.
         auto func = [=](){
-            task_set<void> taskset;
+            task_set<void> taskset (pool);
             for (int i = 0; i < nt; ++i) {
                 taskset.push (pool->push (do_nothing));
             }


### PR DESCRIPTION
I discovered that the thread_pool could deadlock if the pool queue
filled and then the subtasks themselves added further subtasks to
the queue and waited for their results (since those subtasks would
never themselves get around to executing, with all the pool threads
waiting).

The solution is primarily to modify task_set::wait() so that instead
of unconditionally blocking for the subtasks to complete, it polls
them without blocking, and so when it finds itself waiting for queue
results to still complete, it steals some work from the queue to do
itself. This unclogs the system nicely.

I also modified parallel_for_chunked (which is the basis for the
unchunked parallel_for as well) so that the calling thread itself
executes the last (or only) subtask rather than send it to the pool.
This is yet another way to reduce pressure on the queue, and especially
for cases where you call parallel_for but only one task is necessary
(due to chunking size), it avoids any overhead of using the pool.