### PR TITLE
updating output_channelformats variable after renaming channel names.…

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1818,6 +1818,7 @@ set_channelnames (int argc, const char *argv[])
                 if (c < (int)newchannelnames.size() &&
                       newchannelnames[c].size()) {
                     std::string name = newchannelnames[c];
+                    ot.output_channelformats[name] = ot.output_channelformats[spec->channelnames[c]];
                     spec->channelnames[c] = name;
                     if (Strutil::iequals(name,"A") ||
                         Strutil::iends_with(name,".A") ||


### PR DESCRIPTION
## Description

"--chnames" argument converts bit depths to 32 bit if an input image is a mix of different bit depths such as half/float for example, which is because set_channelnames method doesn't update a map variable called "output_channelformats" after renaming channel names.

This fix is to update the variable after renaming in the set_channelnames method so oiiotool can keep the original bit depths even after renaming channel names.

## Tests

1. create an image having 16-bit/32-bit channels
```
oiiotool --create 320x240 6 --chnames diffuse.r,diffuse.g,diffuse.b,specular.r,specular.g,specular.b -d diffuse.r=half -d diffuse.g=half -d diffuse.b=half -d specular.r=float -d specular.g=float -d specular.b=float -o ./input.exr
```

2. check bit depth
```
oiiotool input.exr --ch "diffuse.r,diffuse.g,diffuse.b" --chnames "__diffuse.r,__diffuse.g,__diffuse.b" -o output.exr
```

3. rename "diffuse" to "__diffuse" by using --chnames
```
oiiotool input.exr --ch "diffuse.r,diffuse.g,diffuse.b" --chnames "__diffuse.r,__diffuse.g,__diffuse.b" -o output.exr
```

4. check bit depth
```
    __diffuse.b, 16-bit floating-point, sampling 1 1
    __diffuse.g, 16-bit floating-point, sampling 1 1
    __diffuse.r, 16-bit floating-point, sampling 1 1
```

which was the following before
```
    __diffuse.b, 32-bit floating-point, sampling 1 1
    __diffuse.g, 32-bit floating-point, sampling 1 1
    __diffuse.r, 32-bit floating-point, sampling 1 1
```

------

… #1562