### PR TITLE
fmath: Avoid edge case bug in interpolate_linear

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -1710,7 +1710,8 @@ interpolate_linear (float x, array_view_strided<const float> y)
     int nsegs = int(y.size()) - 1;
     int segnum;
     x = floorfrac (x*nsegs, &segnum);
-    return lerp (y[segnum], y[segnum+1], x);
+    int nextseg = std::min (segnum+1, nsegs);
+    return lerp (y[segnum], y[nextseg], x);
 }
 
 // (end miscellaneous numerical methods)


### PR DESCRIPTION
The lerp(y[seg], y[seg+1], x), if on the very last segment and x ==
1.0f, was possible to read past the end of y into uninitialized memory.
Even though it would weight that value by 0, if it happened to contain a
NaN, NaN*0 == NaN, and it was also possible to read past the end of
usable memory. So it is safer to use an appropriate clamp to be super
sure we never read past the end of y.
