### PR TITLE
parallel_for_chunked: avoid divide by 0 when pool size is 0

### DIFF
--- a/src/include/OpenImageIO/parallel.h
+++ b/src/include/OpenImageIO/parallel.h
@@ -71,8 +71,10 @@ parallel_for_chunked (int64_t start, int64_t end, int64_t chunksize,
                    std::function<void(int id, int64_t b, int64_t e)>&& task)
 {
     thread_pool *pool (default_thread_pool());
-    if (chunksize < 1)
-        chunksize = std::max (int64_t(1), (end-start) / (2*pool->size()));
+    if (chunksize < 1) {
+        int p = std::max (1, 2*pool->size());
+        chunksize = std::max (int64_t(1), (end-start) / p);
+    }
     for (task_set<void> ts (pool); start < end; start += chunksize) {
         int64_t e = std::min (end, start+chunksize);
         if (e == end) {
@@ -92,8 +94,10 @@ inline void parallel_for_chunked (int64_t start, int64_t end, int64_t chunksize,
                            std::function<void(int64_t b, int64_t e)>&& task)
 {
     thread_pool *pool (default_thread_pool());
-    if (chunksize < 1)
-        chunksize = std::max (int64_t(1), (end-start) / (2*pool->size()));
+    if (chunksize < 1) {
+        int p = std::max (1, 2*pool->size());
+        chunksize = std::max (int64_t(1), (end-start) / p);
+    }
     auto wrapper = [&](int id, int64_t b, int64_t e){ task(b,e); };
     for (task_set<void> ts (pool); start < end; start += chunksize) {
         int64_t e = std::min (end, start+chunksize);

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -81,7 +81,7 @@ public:
     // nThreads must be >= 0
     void resize(int nThreads) {
         if (nThreads < 1)
-            nThreads = Sysutil::hardware_concurrency() - 1;
+            nThreads = std::max (1, int(Sysutil::hardware_concurrency()) - 1);
         if (!this->isStop && !this->isDone) {
             int oldNThreads = static_cast<int>(this->threads.size());
             if (oldNThreads <= nThreads) {  // if the number of threads is increased


### PR DESCRIPTION
Also avoid sizing thread to 0 by default (it better be on purpose).

This is an edge case I don't expect to see much in the real world, but
it was really messing with our Travis-CI builds, which seem to run on
VMs that think they have only one core allocated. This would initialize
the pool to 0 size, which could lead to a math exception, ugh.