### PR TITLE
idiff and oiiotool --diff enhancements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -565,6 +565,7 @@ oiio_add_tests (
                 oiiotool-pattern oiiotool-readerror
                 oiiotool-subimage oiiotool-text
                 maketx oiiotool-maketx
+                diff
                 dither dup-channels
                 dpx ico iff png psd rla sgi
                 python-typedesc python-imagespec python-roi python-deep

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -302,6 +302,12 @@ main (int argc, char *argv[])
                         std::cout << ", " << img1.spec().channelnames[cr.maxc] << ')';
                     else
                         std::cout << ", channel " << cr.maxc << ')';
+                    std::cout << "  values are ";
+                    for (int c = 0; c < img0.spec().nchannels; ++c)
+                        std::cout << (c ? ", " : "") << img0.getchannel(cr.maxx, cr.maxy, 0, c);
+                    std::cout << " vs ";
+                    for (int c = 0; c < img1.spec().nchannels; ++c)
+                        std::cout << (c ? ", " : "") << img1.getchannel(cr.maxx, cr.maxy, 0, c);
                 }
                 std::cout << "\n";
 #if OIIO_MSVS_BEFORE_2015

--- a/src/oiiotool/diff.cpp
+++ b/src/oiiotool/diff.cpp
@@ -165,6 +165,12 @@ OiioTool::do_action_diff (ImageRec &ir0, ImageRec &ir1,
                         std::cout << ", " << img1.spec().channelnames[cr.maxc] << ')';
                     else
                         std::cout << ", channel " << cr.maxc << ')';
+                    std::cout << "  values are ";
+                    for (int c = 0; c < img0.spec().nchannels; ++c)
+                        std::cout << (c ? ", " : "") << img0.getchannel(cr.maxx, cr.maxy, 0, c);
+                    std::cout << " vs ";
+                    for (int c = 0; c < img1.spec().nchannels; ++c)
+                        std::cout << (c ? ", " : "") << img1.getchannel(cr.maxx, cr.maxy, 0, c);
                 }
                 std::cout << "\n";
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -2327,6 +2327,7 @@ action_diff (int argc, const char *argv[])
     if (ret != DiffErrOK && ret != DiffErrWarn && ret != DiffErrFail)
         ot.error (command);
 
+    ot.printed_info = true; // because taking the diff has output
     ot.function_times[command] += timer();
     return 0;
 }

--- a/testsuite/diff/ref/out.txt
+++ b/testsuite/diff/ref/out.txt
@@ -1,0 +1,16 @@
+Comparing "img1.exr" and "img2.exr"
+  Mean error = 0.00166667
+  RMS error = 0.0288675
+  Peak SNR = 30.7918
+  Max error  = 0.5 @ (5, 7, G)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
+  1 pixels (1%) over 1e-06
+  1 pixels (1%) over 1e-06
+FAILURE
+Computing diff of "img1.exr" vs "img2.exr"
+  Mean error = 0.00166667
+  RMS error = 0.0288675
+  Peak SNR = 30.7918
+  Max error  = 0.5 @ (5, 7, G)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
+  1 pixels (1%) over 1e-06
+  1 pixels (1%) over 1e-06
+FAILURE

--- a/testsuite/diff/run.py
+++ b/testsuite/diff/run.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+import OpenImageIO as oiio
+
+# Make two images that differ by a particular known pixel value
+buf = oiio.ImageBuf (oiio.ImageSpec (10, 10, 3, oiio.FLOAT))
+oiio.ImageBufAlgo.fill (buf, (0.1,0.1,0.1))
+buf.write ("img1.exr")
+buf.setpixel (5, 7, (0.1,0.6,0.1))
+buf.write ("img2.exr")
+
+# Now make sure idiff and oiiotool --diff print the right info
+failureok = True
+command += oiio_app("idiff") + " img1.exr img2.exr >> out.txt ;\n"
+command += oiio_app("oiiotool") + " -diff img1.exr img2.exr >> out.txt ;\n"
+
+
+# Outputs to check against references
+outputs = [ "out.txt" ]


### PR DESCRIPTION
* Print more info about mismatch in idiff and oiiotool --diff. In
  addition to the pixel coordintes and difference of the biggest
  difference, print the full values of all channels at that pixel
  for both images.

* testsuite test for idiff and oiiotool --diff

* Don't have oiiotool print the warning about no output for --diff, when
  the console output is all that's wanted.