### PR TITLE
Fix imagecache handling of "displaywindow" and "datawindow"

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -2588,6 +2588,7 @@ ImageCacheImpl::get_image_info (ImageCacheFile *file,
             d[4] = spec.y + spec.height - 1;
             d[5] = spec.z + spec.depth - 1;
         }
+        return true;
     }
     if (dataname == s_displaywindow && datatype.basetype == TypeDesc::INT &&
         (datatype == TypeDesc(TypeDesc::INT,4) ||
@@ -2606,6 +2607,7 @@ ImageCacheImpl::get_image_info (ImageCacheFile *file,
             d[4] = spec.full_y + spec.full_height - 1;
             d[5] = spec.full_z + spec.full_depth - 1;
         }
+        return true;
     }
     if (dataname == s_averagecolor && datatype.basetype == TypeDesc::FLOAT) {
         int datalen = datatype.numelements() * datatype.aggregate;


### PR DESCRIPTION
Hey, I don't have CLA, but hopefully it's not necessary for a trivial bugfix ( Maybe I should have just made an issue, but I wasn't sure what the issue was until tracking down the code. )

It looks like these return statements were just missed for displaywindow and datawindow - the if statements for every other dataname return true if there is a match.

I noticed this while using OSL, where the symptom is that a call like "r = gettextureinfo (filename, "datawindow", datawin);" will fill out the datawindow correctly, but will incorrectly set r to 0.

The corresponding test case in OSL checks the return values for other gettextureinfo calls, but does not check the return value for displaywindow and datawindow:
https://github.com/imageworks/OpenShadingLanguage/blob/master/testsuite/gettextureinfo/test.osl