### PR TITLE
Tweak OpenJPEG include file search rules to prefer newer versions

### DIFF
--- a/src/cmake/modules/FindOpenJpeg.cmake
+++ b/src/cmake/modules/FindOpenJpeg.cmake
@@ -64,8 +64,10 @@ set (OpenJpeg_include_paths
      /usr/local/include/openjpeg-2.0
      /usr/local/include/openjpeg
      /usr/local/include
-     /usr/include/openjpeg
+     /usr/include/openjpeg-2.2
+     /usr/include/openjpeg-2.1
      /usr/include/openjpeg-1.5
+     /usr/include/openjpeg
      /usr/local/include/openjpeg-1.5
      /usr/include
      /opt/local/include)


### PR DESCRIPTION
Tweak OpenJPEG include file search rules to prefer newer versions when multiple are installed on the system.
