### PR TITLE
Add Strutil::printf and fprintf.

### DIFF
--- a/src/include/OpenImageIO/dassert.h
+++ b/src/include/OpenImageIO/dassert.h
@@ -71,7 +71,7 @@
 #ifndef ASSERT
 # define ASSERT(x)                                              \
     (OIIO_LIKELY(x) ? ((void)0)                                 \
-         : (fprintf (stderr, "%s:%u: failed assertion '%s'\n",  \
+         : (std::fprintf (stderr, "%s:%u: failed assertion '%s'\n",  \
                      __FILE__, __LINE__, #x), abort()))
 #endif
 
@@ -80,7 +80,7 @@
 #ifndef ASSERT_MSG
 # define ASSERT_MSG(x,msg,...)                                      \
     (OIIO_LIKELY(x) ? ((void)0)                                     \
-         : (fprintf (stderr, "%s:%u: failed assertion '%s': " msg "\n", \
+         : (std::fprintf (stderr, "%s:%u: failed assertion '%s': " msg "\n", \
                     __FILE__, __LINE__, #x,  __VA_ARGS__), abort()))
 #endif
 

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -629,9 +629,12 @@ public:
     /// The printf argument list is fully typesafe via tinyformat; format
     /// conceptually has the signature
     ///
-    /// static ustring format (const char *fmt, ...);
-    TINYFORMAT_WRAP_FORMAT (static ustring, format, /**/,
-        std::ostringstream msg;, msg, return ustring(msg.str());)
+    template<typename T1, typename... Args>
+    static ustring format (string_view fmt, const T1& v1, const Args&... args)
+    {
+        return ustring (Strutil::format (fmt, v1, args...));
+    }
+    friend inline ustring format (string_view str) { return ustring(str); }
 
     /// Generic stream output of a ustring.
     ///

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -1039,7 +1039,7 @@ ImageSpec::serialize (SerialFormat fmt, SerialVerbose verbose) const
     out << '\n';
 
     if (verbose >= SerialDetailed) {
-        out << format ("    channel list: ");
+        out << "    channel list: ";
         for (int i = 0;  i < nchannels;  ++i) {
             if (i < (int)channelnames.size())
                 out << channelnames[i];

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -65,7 +65,7 @@ if (OIIO_BUILD_TESTS)
 
     add_executable (strutil_test strutil_test.cpp)
     set_target_properties (strutil_test PROPERTIES FOLDER "Unit Tests")
-    target_link_libraries (strutil_test OpenImageIO_Util ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+    target_link_libraries (strutil_test OpenImageIO ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
     add_test (unit_strutil strutil_test)
 
     add_executable (fmath_test fmath_test.cpp)

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -36,6 +36,7 @@
 #include <cmath>
 #include <sstream>
 #include <limits>
+#include <mutex>
 
 #include <boost/algorithm/string.hpp>
 
@@ -68,6 +69,19 @@ string_view::c_str() const
     // the ustring table forever. Punt on this for now, it's an edge case
     // that we need to handle, but is not likely to ever be an issue.
     return ustring(m_chars, 0, m_len).c_str();
+}
+
+
+
+void
+Strutil::sync_output (FILE *file, string_view str)
+{
+    static std::mutex output_mutex;
+    if (str.size() && file) {
+        std::unique_lock<std::mutex> lock (output_mutex);
+        fwrite (str.data(), 1, str.size(), file);
+        fflush (file);
+    }
 }
 
 

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -572,10 +572,10 @@ test_float_formatting ()
         sprintf (buffer, "%.9g", *f);
         std::string tiny = Strutil::format ("%.9g", *f);
         if (sstream.str() != tiny || tiny != buffer)
-            printf ("%x  stream '%s'  printf '%s'  Strutil::format '%s'\n",
-                    i32, sstream.str().c_str(), buffer, tiny.c_str());
+            Strutil::printf ("%x  stream '%s'  printf '%s'  Strutil::format '%s'\n",
+                    i32, sstream.str(), buffer, tiny);
         if ((i32 & 0xfffffff) == 0xfffffff) {
-            printf ("%x\n", i32);
+            Strutil::printf ("%x\n", i32);
             fflush (stdout);
         }
     }


### PR DESCRIPTION
They are like std printf/fprintf, except with all the typesafe goodness of Strutil::format (a.k.a. Tinyformat), and also I rigged them to internally use a mutex to prevent simultaneous threads from clobbering each other's console or file output. The full contents of printf's from different threads may end up interleaved non-deterministically, but each print individually will be "atomic" and not get mixed up character-by-character with those of other threads.

These are so much easier now that we are C++11 and can rely on variadic templates.