### PR TITLE
Debugging improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
           sysctl machdep.cpu.features ;
       elif [ $TRAVIS_OS_NAME == linux ] ; then
           export PLATFORM=linux64 ;
-          cat /proc/cpuinfo ;
+          head -40 /proc/cpuinfo ;
       fi
     - if [ "$DEBUG" == 1 ] ; then export PLATFORM=${PLATFORM}.debug ; fi
     - echo "Build platform name is $PLATFORM"
@@ -75,8 +75,8 @@ script:
     - export LD_LIBRARY_PATH=$OPENIMAGEIOHOME/lib:$LD_LIBRARY_PATH
     - export OIIO_LIBRARY_PATH=$OPENIMAGEIOHOME/lib
     - echo "OIIO_LIBRARY_PATH is ${OIIO_LIBRARY_PATH}"
-    - echo "list of library path:"
-    - ls -R $OIIO_LIBRARY_PATH
+    # - echo "list of library path:"
+    # - ls -R $OIIO_LIBRARY_PATH
     - export PYTHONPATH=$OPENIMAGEIOHOME/python:$PYTHONPATH
     - make $BUILD_FLAGS test
 

--- a/src/cmake/oiio_macros.cmake
+++ b/src/cmake/oiio_macros.cmake
@@ -86,7 +86,7 @@ endmacro ()
 # the user where to find such tests.
 #
 macro (oiio_add_tests)
-    parse_arguments (_ats "URL;IMAGEDIR;LABEL;FOUNDVAR" "" ${ARGN})
+    parse_arguments (_ats "URL;IMAGEDIR;LABEL;FOUNDVAR;TESTNAME" "" ${ARGN})
     set (_ats_testdir "${PROJECT_SOURCE_DIR}/../${_ats_IMAGEDIR}")
     # If there was a FOUNDVAR param specified and that variable name is
     # not defined, mark the test as broken.
@@ -109,6 +109,9 @@ macro (oiio_add_tests)
             set (_testdir "${CMAKE_BINARY_DIR}/testsuite/${_testname}")
             if (_ats_LABEL MATCHES "broken")
                 set (_testname "${_testname}-broken")
+            endif ()
+            if (_ats_TESTNAME)
+                set (_testname "${_ats_TESTNAME}")
             endif ()
             if (_has_generator_expr)
                 set (_add_test_args NAME ${_testname} 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -59,6 +59,7 @@
 #include "platform.h"
 #include "typedesc.h"   /* Needed for TypeDesc definition */
 #include "paramlist.h"
+#include "strutil.h"
 #include "array_view.h"
 
 OIIO_NAMESPACE_BEGIN
@@ -1473,18 +1474,17 @@ OIIO_API bool wrap_mirror (int &coord, int origin, int width);
 typedef bool (*wrap_impl) (int &coord, int origin, int width);
 
 
-namespace pvt {
-// For internal use - use debugmsg() below for a nicer interface.
-OIIO_API void debugmsg_ (string_view message);
-};
-
-/// debugmsg(format, ...) prints debugging message when attribute "debug" is
+/// debug(format, ...) prints debugging message when attribute "debug" is
 /// nonzero, which it is by default for DEBUG compiles or when the
 /// environment variable OPENIMAGEIO_DEBUG is set. This is preferred to raw
 /// output to stderr for debugging statements.
-///   void debugmsg (const char *format, ...);
-TINYFORMAT_WRAP_FORMAT (void, debugmsg, /**/,
-                        std::ostringstream msg;, msg, pvt::debugmsg_(msg.str());)
+OIIO_API void debug (string_view str);
+
+template<typename T1, typename... Args>
+void debug (string_view fmt, const T1& v1, const Args&... args)
+{
+    debug (Strutil::format(fmt.c_str(), v1, args...));
+}
 
 
 // to force correct linkage on some systems

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -156,10 +156,10 @@ catalog_plugin (const std::string &format_name,
             // It's ok if they're both the same file; just skip it.
             return;
         }
-        OIIO::debugmsg ("OpenImageIO WARNING: %s had multiple plugins:\n"
-                        "\t\"%s\"\n    as well as\n\t\"%s\"\n"
-                        "    Ignoring all but the first one.\n",
-                        format_name, found_path->second, plugin_fullpath);
+        OIIO::debug ("OpenImageIO WARNING: %s had multiple plugins:\n"
+                     "\t\"%s\"\n    as well as\n\t\"%s\"\n"
+                     "    Ignoring all but the first one.\n",
+                     format_name, found_path->second, plugin_fullpath);
         return;
     }
 

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -1014,8 +1014,8 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
     // Now if we still don't match a specific type OpenEXR is looking for,
     // skip it.
     if (exrtype != TypeDesc() && ! exrtype.equivalent(type)) {
-        OIIO::debugmsg ("OpenEXR output metadata \"%s\" type mismatch: expected %s, got %s\n",
-                        name, exrtype, type);
+        OIIO::debug ("OpenEXR output metadata \"%s\" type mismatch: expected %s, got %s\n",
+                     name, exrtype, type);
         return false;
     }
 
@@ -1244,12 +1244,12 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
 #endif
     }
     } catch (const std::exception &e) {
-        OIIO::debugmsg ("Caught OpenEXR exception: %s\n", e.what());
+        OIIO::debug ("Caught OpenEXR exception: %s\n", e.what());
     } catch (...) {  // catch-all for edge cases or compiler bugs
-        OIIO::debugmsg ("Caught unknown OpenEXR exception\n");
+        OIIO::debug ("Caught unknown OpenEXR exception\n");
     }
 
-    OIIO::debugmsg ("Don't know what to do with %s %s\n", type, xname);
+    OIIO::debug ("Don't know what to do with %s %s\n", type, xname);
     return false;
 }
 

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -273,6 +273,8 @@ def runtest (command, outputs, failureok=0) :
 #    print ("working dir = " + tmpdir)
     os.chdir (srcdir)
     open ("out.txt", "w").close()    # truncate out.txt
+    if os.path.isfile("debug.log") :
+        os.remove ("debug.log")
 
     if options.path != "" :
         sys.path = [options.path] + sys.path
@@ -313,13 +315,20 @@ def runtest (command, outputs, failureok=0) :
                 # file and the diff, for easy debugging.
                 print ("-----" + out + "----->")
                 print (open(out,'r').read() + "<----------")
+                print ("-----" + testfile + "----->")
+                print (open(testfile,'r').read() + "<----------")
+                os.system ("ls -al " +out+" "+testfile)
                 print ("Diff was:\n-------")
                 print (open (out+".diff", 'rU').read())
             if extension in image_extensions :
                 # If we failed to get a match for an image, send the idiff
                 # results to the console
                 os.system (diff_command (out, testfile, silent=False))
-
+            if os.path.isfile("debug.log") and os.path.getsize("debug.log") :
+                print ("---   DEBUG LOG   ---\n")
+                with open("debug.log", "r") as flog :
+                    print flog.read()
+                print ("--- END DEBUG LOG ---\n")
     return (err)
 
 


### PR DESCRIPTION
Rolling up several things I did while debugging something recently:

1. debugmsg tweaks

    * Rename debugmsg -> debug
    * Use variadic templates
    * Use Strutil::fprintf underneath, to guarantee threads not clobbering each other.
    * Use OPENIMAGEIO_DEBUG_FILE to let you redirect it to a file.

 2.   Debugging and testsuite improvements:

    * For failed tests, print full test output, and debug.log, if it exists. 
    * Reduce unnecessary travis verbosity
    * testsuite cmake tweak: allow optional decouple of test name from dir name       This makes it possible, for debugging purposes, to make a test dir run       several times as separate tests. Why? Maybe you have a spurious       nondeterministic error you are tracking down and want your travis runs       to have a higher chance of triggering it, so you run a problematic test       several times.
    * testsuite: print debug.log after a failed test, if it exists.
