### PR TITLE
Improvements to thread_pool and 2D parallelism

### DIFF
--- a/src/include/OpenImageIO/parallel.h
+++ b/src/include/OpenImageIO/parallel.h
@@ -166,8 +166,9 @@ UnaryFunction
 parallel_for_each (InputIt first, InputIt last, UnaryFunction f)
 {
     thread_pool *pool (default_thread_pool());
-    if (pool->this_thread_is_in_pool()) {
-        // don't use the pool recursively
+    if (pool->size() == 1 || pool->this_thread_is_in_pool()) {
+        // Don't use the pool recursively or if there are no workers --
+        // just run the function directly.
         for ( ; first != last; ++first)
             f (*first);
     } else {

--- a/src/include/OpenImageIO/parallel.h
+++ b/src/include/OpenImageIO/parallel.h
@@ -71,6 +71,8 @@ parallel_for_chunked (int64_t start, int64_t end, int64_t chunksize,
                    std::function<void(int id, int64_t b, int64_t e)>&& task)
 {
     thread_pool *pool (default_thread_pool());
+    if (chunksize < end-start && pool->this_thread_is_in_pool())
+        chunksize = end-start;    // don't use the pool recursively
     if (chunksize < 1) {
         int p = std::max (1, 2*pool->size());
         chunksize = std::max (int64_t(1), (end-start) / p);
@@ -94,6 +96,8 @@ inline void parallel_for_chunked (int64_t start, int64_t end, int64_t chunksize,
                            std::function<void(int64_t b, int64_t e)>&& task)
 {
     thread_pool *pool (default_thread_pool());
+    if (chunksize < end-start && pool->this_thread_is_in_pool())
+        chunksize = end-start;    // don't use the pool recursively
     if (chunksize < 1) {
         int p = std::max (1, 2*pool->size());
         chunksize = std::max (int64_t(1), (end-start) / p);
@@ -162,10 +166,119 @@ UnaryFunction
 parallel_for_each (InputIt first, InputIt last, UnaryFunction f)
 {
     thread_pool *pool (default_thread_pool());
-    for (task_set<void> ts (pool); first != last; ++first)
-        ts.push (pool->push ([&](int id){ f(*first); }));
+    if (pool->this_thread_is_in_pool()) {
+        // don't use the pool recursively
+        for ( ; first != last; ++first)
+            f (*first);
+    } else {
+        for (task_set<void> ts (pool); first != last; ++first)
+            ts.push (pool->push ([&](int id){ f(*first); }));
+    }
     return std::move(f);
 }
+
+
+
+/// Parallel "for" loop in 2D, chunked: for a task that takes an int thread
+/// ID followed by begin, end, chunksize for each of x and y, subdivide that
+/// run in parallel using the default thread pool.
+///
+///    task (threadid, xstart, xstart+xchunksize, );
+///    task (threadid, start+chunksize, start+2*chunksize);
+///    ...
+///    task (threadid, start+n*chunksize, end);
+///
+/// and wait for them all to complete.
+///
+/// If chunksize is 0, a chunksize will be chosen to divide the range into
+/// a number of chunks equal to the twice number of threads in the queue.
+/// (We do this to offer better load balancing than if we used exactly the
+/// thread count.)
+inline void
+parallel_for_chunked_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
+                         int64_t ystart, int64_t yend, int64_t ychunksize,
+                   std::function<void(int id, int64_t xbegin, int64_t xend,
+                                      int64_t ybegin, int64_t yend)>&& task)
+{
+    thread_pool *pool (default_thread_pool());
+    if (pool->this_thread_is_in_pool()) {
+        // don't use the pool recursively
+        task (-1, xstart, xend, ystart, yend);
+        return;
+    }
+    if (ychunksize < 1)
+        ychunksize = std::max (int64_t(1), (yend-ystart) / (pool->size()));
+    if (xchunksize < 1) {
+        int64_t ny = std::max (int64_t(1), (yend-ystart) / ychunksize);
+        int64_t nx = std::max (int64_t(1), pool->size() / ny);
+        xchunksize = std::max (int64_t(1), (xend-xstart) / nx);
+    }
+    task_set<void> ts (pool);
+    for (auto y = ystart; y < yend; y += ychunksize) {
+        int64_t ychunkend = std::min (yend, y+ychunksize);
+        for (auto x = xstart; x < xend; x += xchunksize)
+            ts.push (pool->push (task, x, std::min (xend, x+xchunksize),
+                                 y, ychunkend));
+    }
+}
+
+
+
+/// Parallel "for" loop, chunked: for a task that takes a 2D [begin,end)
+/// range and chunk sizes.
+inline void
+parallel_for_chunked_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
+                         int64_t ystart, int64_t yend, int64_t ychunksize,
+                     std::function<void(int64_t xbegin, int64_t xend,
+                                        int64_t ybegin, int64_t yend)>&& task)
+{
+    auto wrapper = [&](int id, int64_t xb, int64_t xe,
+                       int64_t yb, int64_t ye) { task(xb,xe,yb,ye); };
+    parallel_for_chunked_2D (xstart, xend, xchunksize,
+                             ystart, yend, ychunksize, wrapper);
+}
+
+
+
+/// parallel_for, for a task that takes an int threadid and int64_t x & y
+/// indices, running all of:
+///    task (id, xstart, ystart);
+///    ...
+///    task (id, xend-1, ystart);
+///    task (id, xstart, ystart+1);
+///    task (id, xend-1, ystart+1);
+///    ...
+///    task (id, xend-1, yend-1);
+inline void
+parallel_for_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
+                 int64_t ystart, int64_t yend, int64_t ychunksize,
+                 std::function<void(int id, int64_t i, int64_t j)>&& task)
+{
+    parallel_for_chunked_2D (xstart, xend, 0, ystart, yend, 0,
+            [&task](int id, int64_t xb, int64_t xe, int64_t yb, int64_t ye) {
+        for (auto y = yb; y < ye; ++y)
+            for (auto x = xb; x < xe; ++x)
+                task (id, x, y);
+    });
+}
+
+
+
+/// parallel_for, for a 2D task that takes int64_t x & y indices (no
+/// threadid).
+inline void
+parallel_for_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
+                 int64_t ystart, int64_t yend, int64_t ychunksize,
+                 std::function<void(int64_t i, int64_t j)>&& task)
+{
+    parallel_for_chunked_2D (xstart, xend, 0, ystart, yend, 0,
+            [&task](int id, int64_t xb, int64_t xe, int64_t yb, int64_t ye) {
+        for (auto y = yb; y < ye; ++y)
+            for (auto x = xb; x < xe; ++x)
+                task (x, y);
+    });
+}
+
 
 
 OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/compute_test.cpp
+++ b/src/libOpenImageIO/compute_test.cpp
@@ -116,7 +116,7 @@ test_arrays_like_image_multithread (ROI roi)
 static void
 test_arrays_like_image_multithread_wrapper (ROI roi)
 {
-    ImageBufAlgo::parallel_image (test_arrays_like_image_multithread, roi, numthreads);
+    ImageBufAlgo::parallel_image (roi, numthreads, test_arrays_like_image_multithread);
 }
 
 
@@ -182,7 +182,7 @@ test_arrays_like_image_simd_multithread (ROI roi)
 static void
 test_arrays_like_image_simd_multithread_wrapper (ROI roi)
 {
-    ImageBufAlgo::parallel_image (test_arrays_like_image_simd_multithread, roi, 0);
+    ImageBufAlgo::parallel_image (roi, test_arrays_like_image_simd_multithread);
 }
 
 
@@ -206,7 +206,7 @@ test_compute ()
 
     std::cout << "Test straightforward as 1D array of float: ";
     ImageBufAlgo::zero (imgR);
-    time = time_trial (OIIO::bind (test_arrays, roi), ntrials, iterations) / iterations;
+    time = time_trial (std::bind (test_arrays, roi), ntrials, iterations) / iterations;
     std::cout << Strutil::format ("%.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
     OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,0), 0.25, 0.001);
     OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,1), 0.25, 0.001);
@@ -215,7 +215,7 @@ test_compute ()
 
     std::cout << "Test array iterated like an image: ";
     ImageBufAlgo::zero (imgR);
-    time = time_trial (OIIO::bind (test_arrays_like_image, roi), ntrials, iterations) / iterations;
+    time = time_trial (std::bind (test_arrays_like_image, roi), ntrials, iterations) / iterations;
     std::cout << Strutil::format ("%.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
     OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,0), 0.25, 0.001);
     OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,1), 0.25, 0.001);
@@ -223,7 +223,7 @@ test_compute ()
 
     std::cout << "Test array iterated like an image, multithreaded: ";
     ImageBufAlgo::zero (imgR);
-    time = time_trial (OIIO::bind (test_arrays_like_image_multithread_wrapper, roi), ntrials, iterations) / iterations;
+    time = time_trial (std::bind (test_arrays_like_image_multithread_wrapper, roi), ntrials, iterations) / iterations;
     std::cout << Strutil::format ("%.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
     OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,0), 0.25, 0.001);
     OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,1), 0.25, 0.001);
@@ -231,7 +231,7 @@ test_compute ()
 
     std::cout << "Test array as 1D, using SIMD: ";
     ImageBufAlgo::zero (imgR);
-    time = time_trial (OIIO::bind (test_arrays_simd4, roi), ntrials, iterations) / iterations;
+    time = time_trial (std::bind (test_arrays_simd4, roi), ntrials, iterations) / iterations;
     std::cout << Strutil::format ("%.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
     OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,0), 0.25, 0.001);
     OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,1), 0.25, 0.001);
@@ -239,7 +239,7 @@ test_compute ()
 
     std::cout << "Test array iterated like an image, using SIMD: ";
     ImageBufAlgo::zero (imgR);
-    time = time_trial (OIIO::bind (test_arrays_like_image_simd, roi), ntrials, iterations) / iterations;
+    time = time_trial (std::bind (test_arrays_like_image_simd, roi), ntrials, iterations) / iterations;
     std::cout << Strutil::format ("%.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
     OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,0), 0.25, 0.001);
     OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,1), 0.25, 0.001);
@@ -247,7 +247,7 @@ test_compute ()
 
     std::cout << "Test array iterated like an image, using SIMD, multithreaded: ";
     ImageBufAlgo::zero (imgR);
-    time = time_trial (OIIO::bind (test_arrays_like_image_simd_multithread_wrapper, roi), ntrials, iterations) / iterations;
+    time = time_trial (std::bind (test_arrays_like_image_simd_multithread_wrapper, roi), ntrials, iterations) / iterations;
     std::cout << Strutil::format ("%.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
     OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,0), 0.25, 0.001);
     OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,1), 0.25, 0.001);
@@ -255,7 +255,7 @@ test_compute ()
 
     std::cout << "Test ImageBufAlgo::mad 1 thread: ";
     ImageBufAlgo::zero (imgR);
-    time = time_trial (OIIO::bind (test_IBA, roi, 1),
+    time = time_trial (std::bind (test_IBA, roi, 1),
                        ntrials, iterations) / iterations;
     std::cout << Strutil::format ("%.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
     OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,0), 0.25, 0.001);
@@ -264,7 +264,7 @@ test_compute ()
 
     std::cout << "Test ImageBufAlgo::mad multi-thread " << numthreads << ": ";
     ImageBufAlgo::zero (imgR);
-    time = time_trial (OIIO::bind (test_IBA, roi, numthreads),
+    time = time_trial (std::bind (test_IBA, roi, numthreads),
                        ntrials, iterations) / iterations;
     std::cout << Strutil::format ("%.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
     OIIO_CHECK_EQUAL_THRESH (imgR.getchannel(xres/2,yres/2,0,0), 0.25, 0.001);

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -336,51 +336,40 @@ static bool
 convolve_ (ImageBuf &dst, const ImageBuf &src, const ImageBuf &kernel,
            bool normalize, ROI roi, int nthreads)
 {
-    if (nthreads != 1 && roi.npixels() >= 1000) {
-        // Lots of pixels and request for multi threads? Parallelize.
-        ImageBufAlgo::parallel_image (
-            OIIO::bind(convolve_<DSTTYPE,SRCTYPE>, OIIO::ref(dst),
-                        OIIO::cref(src), OIIO::cref(kernel), normalize,
-                        _1 /*roi*/, 1 /*nthreads*/),
-            roi, nthreads);
-        return true;
-    }
+    using namespace ImageBufAlgo;
+    parallel_image (roi, nthreads, [&](ROI roi){
+        ASSERT (kernel.spec().format == TypeDesc::FLOAT && kernel.localpixels() &&
+                "kernel should be float and in local memory");
+        ROI kroi = kernel.roi();
+        int kchans = kernel.nchannels();
 
-    // Serial case
-
-    ASSERT (kernel.spec().format == TypeDesc::FLOAT && kernel.localpixels() &&
-            "kernel should be float and in local memory");
-    ROI kroi = kernel.roi();
-    int kchans = kernel.nchannels();
-
-    float scale = 1.0f;
-    if (normalize) {
-        scale = 0.0f;
-        for (ImageBuf::ConstIterator<float> k (kernel); ! k.done(); ++k)
-            scale += k[0];
-        scale = 1.0f / scale;
-    }
-    float *sum = ALLOCA (float, roi.chend);
-
-    // Final case: handle full generality
-    ImageBuf::Iterator<DSTTYPE> d (dst, roi);
-    ImageBuf::ConstIterator<SRCTYPE> s (src, roi, ImageBuf::WrapClamp);
-    for ( ; ! d.done();  ++d) {
-        for (int c = roi.chbegin; c < roi.chend; ++c)
-            sum[c] = 0.0f;
-        const float *k = (const float *)kernel.localpixels();
-        s.rerange (d.x() + kroi.xbegin, d.x() + kroi.xend,
-                   d.y() + kroi.ybegin, d.y() + kroi.yend,
-                   d.z() + kroi.zbegin, d.z() + kroi.zend,
-                   ImageBuf::WrapClamp);
-        for ( ; ! s.done(); ++s, k += kchans) {
-            for (int c = roi.chbegin; c < roi.chend; ++c)
-                sum[c] += k[0] * s[c];
+        float scale = 1.0f;
+        if (normalize) {
+            scale = 0.0f;
+            for (ImageBuf::ConstIterator<float> k (kernel); ! k.done(); ++k)
+                scale += k[0];
+            scale = 1.0f / scale;
         }
-        for (int c = roi.chbegin; c < roi.chend; ++c)
-            d[c] = scale * sum[c];
-    }
+        float *sum = ALLOCA (float, roi.chend);
 
+        ImageBuf::Iterator<DSTTYPE> d (dst, roi);
+        ImageBuf::ConstIterator<SRCTYPE> s (src, roi, ImageBuf::WrapClamp);
+        for ( ; ! d.done();  ++d) {
+            for (int c = roi.chbegin; c < roi.chend; ++c)
+                sum[c] = 0.0f;
+            const float *k = (const float *)kernel.localpixels();
+            s.rerange (d.x() + kroi.xbegin, d.x() + kroi.xend,
+                       d.y() + kroi.ybegin, d.y() + kroi.yend,
+                       d.z() + kroi.zbegin, d.z() + kroi.zend,
+                       ImageBuf::WrapClamp);
+            for ( ; ! s.done(); ++s, k += kchans) {
+                for (int c = roi.chbegin; c < roi.chend; ++c)
+                    sum[c] += k[0] * s[c];
+            }
+            for (int c = roi.chbegin; c < roi.chend; ++c)
+                d[c] = scale * sum[c];
+        }
+    });
     return true;
 }
 
@@ -500,21 +489,12 @@ threshold_to_zero (ImageBuf &dst, float threshold,
 {
     ASSERT (dst.spec().format.basetype == TypeDesc::FLOAT);
 
-    if (nthreads != 1 && roi.npixels() >= 1000) {
-        // Lots of pixels and request for multi threads? Parallelize.
-        ImageBufAlgo::parallel_image (
-            OIIO::bind(threshold_to_zero, OIIO::ref(dst), threshold,
-                        _1 /*roi*/, 1 /*nthreads*/),
-            roi, nthreads);
-        return true;
-    }
-
-    // Serial case
-    for (ImageBuf::Iterator<float> p (dst, roi);  ! p.done();  ++p)
-        for (int c = roi.chbegin;  c < roi.chend;  ++c)
-            if (fabsf(p[c]) < threshold)
-                p[c] = 0.0f;
-
+    ImageBufAlgo::parallel_image (roi, nthreads, [&](ROI roi){
+        for (ImageBuf::Iterator<float> p (dst, roi);  ! p.done();  ++p)
+            for (int c = roi.chbegin;  c < roi.chend;  ++c)
+                if (fabsf(p[c]) < threshold)
+                    p[c] = 0.0f;
+    });
     return true;
 }
 
@@ -599,52 +579,44 @@ static bool
 median_filter_impl (ImageBuf &R, const ImageBuf &A, int width, int height,
                     ROI roi, int nthreads)
 {
-    if (nthreads != 1 && roi.npixels() >= 1000) {
-        // Possible multiple thread case -- recurse via parallel_image
-        ImageBufAlgo::parallel_image (
-            OIIO::bind(median_filter_impl<Rtype,Atype>,
-                        OIIO::ref(R), OIIO::cref(A),
-                        width, height, _1 /*roi*/, 1 /*nthreads*/),
-            roi, nthreads);
-        return true;
-    }
+    ImageBufAlgo::parallel_image (roi, nthreads, [&](ROI roi){
+        if (width < 1)
+            width = 1;
+        if (height < 1)
+            height = width;
+        int w_2 = std::max (1, width/2);
+        int h_2 = std::max (1, height/2);
+        int windowsize = width*height;
+        int nchannels = R.nchannels();
+        float **chans = OIIO_ALLOCA (float*, nchannels);
+        for (int c = 0;  c < nchannels;  ++c)
+            chans[c] = OIIO_ALLOCA (float, windowsize);
 
-    if (width < 1)
-        width = 1;
-    if (height < 1)
-        height = width;
-    int w_2 = std::max (1, width/2);
-    int h_2 = std::max (1, height/2);
-    int windowsize = width*height;
-    int nchannels = R.nchannels();
-    float **chans = OIIO_ALLOCA (float*, nchannels);
-    for (int c = 0;  c < nchannels;  ++c)
-        chans[c] = OIIO_ALLOCA (float, windowsize);
-
-    ImageBuf::ConstIterator<Atype> a (A, roi);
-    for (ImageBuf::Iterator<Rtype> r (R, roi);  !r.done();  ++r) {
-        a.rerange (r.x()-w_2, r.x()-w_2+width,
-                   r.y()-h_2, r.y()-h_2+height,
-                   r.z(), r.z()+1, ImageBuf::WrapClamp);
-        int n = 0;
-        for ( ;  ! a.done(); ++a) {
-            if (a.exists()) {
+        ImageBuf::ConstIterator<Atype> a (A, roi);
+        for (ImageBuf::Iterator<Rtype> r (R, roi);  !r.done();  ++r) {
+            a.rerange (r.x()-w_2, r.x()-w_2+width,
+                       r.y()-h_2, r.y()-h_2+height,
+                       r.z(), r.z()+1, ImageBuf::WrapClamp);
+            int n = 0;
+            for ( ;  ! a.done(); ++a) {
+                if (a.exists()) {
+                    for (int c = 0;  c < nchannels;  ++c)
+                        chans[c][n] = a[c];
+                    ++n;
+                }
+            }
+            if (n) {
+                int mid = n/2;
+                for (int c = 0;  c < nchannels;  ++c) {
+                    std::sort (chans[c]+0, chans[c]+n);
+                    r[c] = chans[c][mid];
+                }
+            } else {
                 for (int c = 0;  c < nchannels;  ++c)
-                    chans[c][n] = a[c];
-                ++n;
+                    r[c] = 0.0f;
             }
         }
-        if (n) {
-            int mid = n/2;
-            for (int c = 0;  c < nchannels;  ++c) {
-                std::sort (chans[c]+0, chans[c]+n);
-                r[c] = chans[c][mid];
-            }
-        } else {
-            for (int c = 0;  c < nchannels;  ++c)
-                r[c] = 0.0f;
-        }
-    }
+    });
     return true;
 }
 
@@ -676,54 +648,45 @@ static bool
 morph_impl (ImageBuf &R, const ImageBuf &A, int width, int height,
             MorphOp op, ROI roi, int nthreads)
 {
-    if (nthreads != 1 && roi.npixels() >= 1000) {
-        // Possible multiple thread case -- recurse via parallel_image
-        ImageBufAlgo::parallel_image (
-            OIIO::bind(morph_impl<Rtype,Atype>,
-                        OIIO::ref(R), OIIO::cref(A),
-                        width, height, op, _1 /*roi*/, 1 /*nthreads*/),
-            roi, nthreads);
-        return true;
-    }
-
-    if (width < 1)
-        width = 1;
-    if (height < 1)
-        height = width;
-    int w_2 = std::max (1, width/2);
-    int h_2 = std::max (1, height/2);
-    int nchannels = R.nchannels();
-    float *vals = OIIO_ALLOCA (float, nchannels);
-
-    ImageBuf::ConstIterator<Atype> a (A, roi);
-    for (ImageBuf::Iterator<Rtype> r (R, roi);  !r.done();  ++r) {
-        a.rerange (r.x()-w_2, r.x()-w_2+width,
-                   r.y()-h_2, r.y()-h_2+height,
-                   r.z(), r.z()+1, ImageBuf::WrapClamp);
-        if (op == MorphDilate) {
-            for (int c = 0; c < nchannels; ++c)
-                vals[c] = -std::numeric_limits<float>::max();
-            for ( ;  ! a.done(); ++a) {
-                if (a.exists()) {
-                    for (int c = 0;  c < nchannels;  ++c)
-                        vals[c] = std::max(vals[c], a[c]);
+    ImageBufAlgo::parallel_image (roi, nthreads, [&](ROI roi){
+        if (width < 1)
+            width = 1;
+        if (height < 1)
+            height = width;
+        int w_2 = std::max (1, width/2);
+        int h_2 = std::max (1, height/2);
+        int nchannels = R.nchannels();
+        float *vals = OIIO_ALLOCA (float, nchannels);
+        ImageBuf::ConstIterator<Atype> a (A, roi);
+        for (ImageBuf::Iterator<Rtype> r (R, roi);  !r.done();  ++r) {
+            a.rerange (r.x()-w_2, r.x()-w_2+width,
+                       r.y()-h_2, r.y()-h_2+height,
+                       r.z(), r.z()+1, ImageBuf::WrapClamp);
+            if (op == MorphDilate) {
+                for (int c = 0; c < nchannels; ++c)
+                    vals[c] = -std::numeric_limits<float>::max();
+                for ( ;  ! a.done(); ++a) {
+                    if (a.exists()) {
+                        for (int c = 0;  c < nchannels;  ++c)
+                            vals[c] = std::max(vals[c], a[c]);
+                    }
                 }
-            }
-        } else if (op == MorphErode) {
-            for (int c = 0; c < nchannels; ++c)
-                vals[c] = std::numeric_limits<float>::max();
-            for ( ;  ! a.done(); ++a) {
-                if (a.exists()) {
-                    for (int c = 0;  c < nchannels;  ++c)
-                        vals[c] = std::min(vals[c], a[c]);
+            } else if (op == MorphErode) {
+                for (int c = 0; c < nchannels; ++c)
+                    vals[c] = std::numeric_limits<float>::max();
+                for ( ;  ! a.done(); ++a) {
+                    if (a.exists()) {
+                        for (int c = 0;  c < nchannels;  ++c)
+                            vals[c] = std::min(vals[c], a[c]);
+                    }
                 }
+            } else {
+                ASSERT (0 && "Unknown morphological operator");
             }
-        } else {
-            ASSERT (0 && "Unknown morphological operator");
+            for (int c = 0;  c < nchannels;  ++c)
+                r[c] = vals[c];
         }
-        for (int c = 0;  c < nchannels;  ++c)
-            r[c] = vals[c];
-    }
+    });
     return true;
 }
 
@@ -778,31 +741,22 @@ hfft_ (ImageBuf &dst, const ImageBuf &src, bool inverse, bool unitary,
             (src.storage() == ImageBuf::LOCALBUFFER || src.storage() == ImageBuf::APPBUFFER)
         );
 
-    if (nthreads != 1 && roi.npixels() >= 1000) {
-        // Lots of pixels and request for multi threads? Parallelize.
-        ImageBufAlgo::parallel_image (
-            OIIO::bind (hfft_, OIIO::ref(dst), OIIO::cref(src),
-                         inverse, unitary,
-                         _1 /*roi*/, 1 /*nthreads*/),
-            roi, nthreads);
-        return true;
-    }
-
-    // Serial case
-    int width = roi.width();
-    float rescale = sqrtf (1.0f / width);
-    kissfft<float> F (width, inverse);
-    for (int z = roi.zbegin;  z < roi.zend;  ++z) {
-        for (int y = roi.ybegin;  y < roi.yend;  ++y) {
-            std::complex<float> *s, *d;
-            s = (std::complex<float> *)src.pixeladdr(roi.xbegin, y, z);
-            d = (std::complex<float> *)dst.pixeladdr(roi.xbegin, y, z);
-            F.transform (s, d);
-            if (unitary)
-                for (int x = 0;  x < width;  ++x)
-                    d[x] *= rescale;
+    ImageBufAlgo::parallel_image (roi, nthreads, [&](ROI roi){
+        int width = roi.width();
+        float rescale = sqrtf (1.0f / width);
+        kissfft<float> F (width, inverse);
+        for (int z = roi.zbegin;  z < roi.zend;  ++z) {
+            for (int y = roi.ybegin;  y < roi.yend;  ++y) {
+                std::complex<float> *s, *d;
+                s = (std::complex<float> *)src.pixeladdr(roi.xbegin, y, z);
+                d = (std::complex<float> *)dst.pixeladdr(roi.xbegin, y, z);
+                F.transform (s, d);
+                if (unitary)
+                    for (int x = 0;  x < width;  ++x)
+                        d[x] *= rescale;
+            }
         }
-    }
+    });
     return true;
 }
 
@@ -944,24 +898,17 @@ template<class Rtype, class Atype>
 static bool
 polar_to_complex_impl (ImageBuf &R, const ImageBuf &A, ROI roi, int nthreads)
 {
-    if (nthreads != 1 && roi.npixels() >= 1000) {
-        // Possible multiple thread case -- recurse via parallel_image
-        ImageBufAlgo::parallel_image (
-            OIIO::bind(polar_to_complex_impl<Rtype,Atype>, OIIO::ref(R), OIIO::cref(A),
-                        _1 /*roi*/, 1 /*nthreads*/),
-            roi, nthreads);
-        return true;
-    }
-
-    ImageBuf::ConstIterator<Atype> a (A, roi);
-    for (ImageBuf::Iterator<Rtype> r (R, roi);  !r.done();  ++r, ++a) {
-        float amp = a[0];
-        float phase = a[1];
-        float sine, cosine;
-        sincos (phase, &sine, &cosine);
-        r[0] = amp * cosine;
-        r[1] = amp * sine;
-    }
+    ImageBufAlgo::parallel_image (roi, nthreads, [&](ROI roi){
+        ImageBuf::ConstIterator<Atype> a (A, roi);
+        for (ImageBuf::Iterator<Rtype> r (R, roi);  !r.done();  ++r, ++a) {
+            float amp = a[0];
+            float phase = a[1];
+            float sine, cosine;
+            sincos (phase, &sine, &cosine);
+            r[0] = amp * cosine;
+            r[1] = amp * sine;
+        }
+    });
     return true;
 }
 
@@ -971,25 +918,18 @@ template<class Rtype, class Atype>
 static bool
 complex_to_polar_impl (ImageBuf &R, const ImageBuf &A, ROI roi, int nthreads)
 {
-    if (nthreads != 1 && roi.npixels() >= 1000) {
-        // Possible multiple thread case -- recurse via parallel_image
-        ImageBufAlgo::parallel_image (
-            OIIO::bind(complex_to_polar_impl<Rtype,Atype>, OIIO::ref(R), OIIO::cref(A),
-                        _1 /*roi*/, 1 /*nthreads*/),
-            roi, nthreads);
-        return true;
-    }
-
-    ImageBuf::ConstIterator<Atype> a (A, roi);
-    for (ImageBuf::Iterator<Rtype> r (R, roi);  !r.done();  ++r, ++a) {
-        float real = a[0];
-        float imag = a[1];
-        float phase = std::atan2 (imag, real);
-        if (phase < 0.0f)
-            phase += float (M_TWO_PI);
-        r[0] = hypotf (real, imag);
-        r[1] = phase;
-    }
+    ImageBufAlgo::parallel_image (roi, nthreads, [&](ROI roi){
+        ImageBuf::ConstIterator<Atype> a (A, roi);
+        for (ImageBuf::Iterator<Rtype> r (R, roi);  !r.done();  ++r, ++a) {
+            float real = a[0];
+            float imag = a[1];
+            float phase = std::atan2 (imag, real);
+            if (phase < 0.0f)
+                phase += float (M_TWO_PI);
+            r[0] = hypotf (real, imag);
+            r[1] = phase;
+        }
+    });
     return true;
 }
 
@@ -1050,27 +990,19 @@ ImageBufAlgo::complex_to_polar (ImageBuf &dst, const ImageBuf &src,
 static bool
 divide_by_alpha (ImageBuf &dst, ROI roi, int nthreads)
 {
-    if (nthreads != 1 && roi.npixels() >= 1000) {
-        // Lots of pixels and request for multi threads? Parallelize.
-        ImageBufAlgo::parallel_image (
-            OIIO::bind(divide_by_alpha, OIIO::ref(dst),
-                        _1 /*roi*/, 1 /*nthreads*/),
-            roi, nthreads);
-        return true;
-    }
-
-    // Serial case
-    const ImageSpec &spec (dst.spec());
-    ASSERT (spec.format == TypeDesc::FLOAT);
-    int nc = spec.nchannels;
-    int ac = spec.alpha_channel;
-    for (ImageBuf::Iterator<float> d (dst, roi);  ! d.done();  ++d) {
-        float alpha = d[ac];
-        if (alpha != 0.0f) {
-            for (int c = 0; c < nc; ++c)
-                d[c] = d[c] / alpha;
+    ImageBufAlgo::parallel_image (roi, nthreads, [&](ROI roi){
+        const ImageSpec &spec (dst.spec());
+        ASSERT (spec.format == TypeDesc::FLOAT);
+        int nc = spec.nchannels;
+        int ac = spec.alpha_channel;
+        for (ImageBuf::Iterator<float> d (dst, roi);  ! d.done();  ++d) {
+            float alpha = d[ac];
+            if (alpha != 0.0f) {
+                for (int c = 0; c < nc; ++c)
+                    d[c] = d[c] / alpha;
+            }
         }
-    }
+    });
     return true;
 }
 

--- a/src/libOpenImageIO/imagebufalgo_yee.cpp
+++ b/src/libOpenImageIO/imagebufalgo_yee.cpp
@@ -117,22 +117,15 @@ AdobeRGBToXYZ_color (const Color3f &rgb)
 static bool
 AdobeRGBToXYZ (ImageBuf &A, ROI roi, int nthreads)
 {
-    if (nthreads != 1 && roi.npixels() >= 1000) {
-        // Possible multiple thread case -- recurse via parallel_image
-        ImageBufAlgo::parallel_image (OIIO::bind(AdobeRGBToXYZ, OIIO::ref(A),
-                                                  _1 /*roi*/, 1 /*nthreads*/),
-                                      roi, nthreads);
-        return true;
-    }
-
-    // Serial case
-    for (ImageBuf::Iterator<float> a (A, roi);  !a.done();  ++a) {
-        Color3f rgb (a[0], a[1], a[2]);
-        Color3f XYZ = AdobeRGBToXYZ_color (rgb);
-        a[0] = XYZ[0];
-        a[1] = XYZ[1];
-        a[2] = XYZ[2];
-    }
+    ImageBufAlgo::parallel_image (roi, nthreads, [&](ROI roi){
+        for (ImageBuf::Iterator<float> a (A, roi);  !a.done();  ++a) {
+            Color3f rgb (a[0], a[1], a[2]);
+            Color3f XYZ = AdobeRGBToXYZ_color (rgb);
+            a[0] = XYZ[0];
+            a[1] = XYZ[1];
+            a[2] = XYZ[2];
+        }
+    });
     return true;
 }
 
@@ -168,22 +161,15 @@ XYZToLAB_color (const Color3f xyz)
 static bool
 XYZToLAB (ImageBuf &A, ROI roi, int nthreads)
 {
-    if (nthreads != 1 && roi.npixels() >= 1000) {
-        // Possible multiple thread case -- recurse via parallel_image
-        ImageBufAlgo::parallel_image (OIIO::bind(XYZToLAB, OIIO::ref(A),
-                                                  _1 /*roi*/, 1 /*nthreads*/),
-                                      roi, nthreads);
-        return true;
-    }
-
-    // Serial case
-    for (ImageBuf::Iterator<float> a (A, roi);  !a.done();  ++a) {
-        Color3f XYZ (a[0], a[1], a[2]);
-        Color3f LAB = XYZToLAB_color (XYZ);
-        a[0] = LAB[0];
-        a[1] = LAB[1];
-        a[2] = LAB[2];
-    }
+    ImageBufAlgo::parallel_image (roi, nthreads, [&](ROI roi){
+        for (ImageBuf::Iterator<float> a (A, roi);  !a.done();  ++a) {
+            Color3f XYZ (a[0], a[1], a[2]);
+            Color3f LAB = XYZToLAB_color (XYZ);
+            a[0] = LAB[0];
+            a[1] = LAB[1];
+            a[2] = LAB[2];
+        }
+    });
     return true;
 }
 

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -191,7 +191,7 @@ void benchmark_convert_type ()
     std::cout << Strutil::format("Benchmark conversion of %6s -> %6s : ",
                                  TypeDesc(BaseTypeFromC<S>::value),
                                  TypeDesc(BaseTypeFromC<D>::value));
-    float time = time_trial (bind (do_convert_type<S,D>, OIIO::cref(svec), OIIO::ref(dvec)),
+    float time = time_trial (bind (do_convert_type<S,D>, std::cref(svec), std::ref(dvec)),
                              ntrials, iterations) / iterations;
     std::cout << Strutil::format ("%7.1f Mvals/sec", (size/1.0e6)/time) << std::endl;
     D r = convert_type<S,D>(testval);

--- a/src/libutil/parallel_test.cpp
+++ b/src/libutil/parallel_test.cpp
@@ -115,22 +115,39 @@ time_parallel_for ()
 void
 test_parallel_for ()
 {
-    { // 1D test
-        // vector of ints, initialized to zero
-        const int length = 1000;
-        std::vector<int> vals (length, 0);
+    // vector of ints, initialized to zero
+    const int length = 1000;
+    std::vector<int> vals (length, 0);
 
-        // Increment all the integers via parallel_for
-        parallel_for (0, length, [&](uint64_t i){
-            vals[i] += 1;
-        });
+    // Increment all the integers via parallel_for
+    parallel_for (0, length, [&](uint64_t i){
+        vals[i] += 1;
+    });
 
-        // Verify that all elements are exactly 1
-        bool all_one = std::all_of (vals.cbegin(), vals.cend(),
-                                    [&](int i){ return vals[i] == 1; });
-        OIIO_CHECK_ASSERT (all_one);
-    }
+    // Verify that all elements are exactly 1
+    bool all_one = std::all_of (vals.cbegin(), vals.cend(),
+                                [&](int i){ return vals[i] == 1; });
+    OIIO_CHECK_ASSERT (all_one);
+}
 
+
+
+void
+test_parallel_for_2D ()
+{
+    // vector of ints, initialized to zero
+    const int size = 100;
+    std::vector<int> vals (size*size, 0);
+
+    // Increment all the integers via parallel_for
+    parallel_for_2D (0, size, 0, 0, size, 0, [&](uint64_t i, uint64_t j){
+        vals[j*size+i] += 1;
+    });
+
+    // Verify that all elements are exactly 1
+    bool all_one = std::all_of (vals.cbegin(), vals.cend(),
+                                [&](int i){ return vals[i] == 1; });
+    OIIO_CHECK_ASSERT (all_one);
 }
 
 
@@ -151,7 +168,7 @@ test_thread_pool_recursion ()
         parallel_for (0, 10, [&](int id, int64_t i){
             Sysutil::usleep (2);
             spin_lock lock (print_mutex);
-            std::cout << "  recursive running thread " << id << std::endl;
+            // std::cout << "  recursive running thread " << id << std::endl;
         });
     });
 }
@@ -174,6 +191,7 @@ main (int argc, char **argv)
     std::cout << "hw threads = " << Sysutil::hardware_concurrency() << "\n";
 
     test_parallel_for ();
+    test_parallel_for_2D ();
 
     time_parallel_for ();
 

--- a/src/libutil/parallel_test.cpp
+++ b/src/libutil/parallel_test.cpp
@@ -175,6 +175,27 @@ test_thread_pool_recursion ()
 
 
 
+void
+test_empty_thread_pool ()
+{
+    std::cout << "\nTesting that pool size 0 makes all jobs run by caller" << std::endl;
+    thread_pool *pool (default_thread_pool());
+    pool->resize (0);
+    OIIO_CHECK_EQUAL (pool->size(), 0);
+    atomic_int count (0);
+    const int ntasks = 100;
+    task_set<void> ts (pool);
+    for (int i = 0; i < ntasks; ++i)
+        ts.push (pool->push ([&](int id){
+            ASSERT (id == -1 && "Must be run by calling thread");
+            count += 1;
+        }));
+    ts.wait();
+    OIIO_CHECK_EQUAL (count, ntasks);
+}
+
+
+
 int
 main (int argc, char **argv)
 {
@@ -192,10 +213,9 @@ main (int argc, char **argv)
 
     test_parallel_for ();
     test_parallel_for_2D ();
-
     time_parallel_for ();
-
     test_thread_pool_recursion ();
+    test_empty_thread_pool ();
 
     return unit_test_failures;
 }

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -103,8 +103,6 @@ private:
 
 OIIO_NAMESPACE_BEGIN
 
-bool debug_threads = false; // FIXME -- remove this after debugging
-
 static int
 threads_default ()
 {


### PR DESCRIPTION
It took me a long time of working on this as a background task, but it's finally in good shape. This is a continuation of the thread pool & parallel loop work I merged a few weeks ago.

------

2D parallelism loops:

* Add parallel_for_2D varieties for easy thread_pool parallelization over 2D domains.
* Refactor ImageBufAlgo::parallel_image:
  - Use thread pool rather than spawning new threads.
  - Options struct includes max number of threads to use, domain subdivision hints, minimum number of pixels per thread task, and custom pool. Users should almost never need to adjust any of these.
* Refactor all the places using parallel_image to use the new style, and to use lambdas in a pleasing way rather than the prior idiom of recursing and handling the 1-thread and many-thread cases separately.
* More miscellaneous refactor of places where we used thread_group launch into use of parallel_for with pool.
* The resulting refactor of the IBA functions is pleasing to me, and the whole thing is much more idiomatic C++11.

thread pool improvements:

* New thread_pool method, this_thread_is_in_pool(), lets a caller find out if it (the calling thread) is a pool thread, so it may avoid submitting more jobs to the pool and clogging it up. A pool thread (which presumably is a task in a larger parallel work group) is probably better off doing any further subtasks itself rather than enqueuing them.  That also helps naive users from writing tasks that accidentally deadlock. This is implemented with a thread-specific pointer that lets the pool keep track of which threads participate. The various parallel_for functions employ this to avoid recursively splitting parallel tasks into more enqueued parallel tasks.
* Change the thread_pool to be able to switch (via #if) between a traditional mutexed queue and the boost::lockfree::queue. Interestingly, in my benchmarks on both OSX and Linux, the mutexted queue is slightly faster! So it remains the default for now.
* Allow environment variable OPENIMAGEIO_THREADS, if set, to override the hardware_concurrency (number of cores) as the default pool size and default OIIO threading count. This is primarily for debugging, so it's easy to force an artificially high or low thread count.
