### PR TITLE
Fix exr_threads value -1 to disable thread pools not working.

### DIFF
--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -166,7 +166,7 @@ attribute (string_view name, TypeDesc type, const void *val)
         return true;
     }
     if (name == "exr_threads" && type == TypeDesc::TypeInt) {
-        oiio_exr_threads = Imath::clamp (*(const int *)val, 0, maxthreads);
+        oiio_exr_threads = Imath::clamp (*(const int *)val, -1, maxthreads);
         return true;
     }
     if (name == "tiff:half" && type == TypeDesc::TypeInt) {


### PR DESCRIPTION
29766348b27a2030820147561ef47cf44835c595 never actually worked, because the -1 value was getting clamped.