### PR TITLE
Be more reslient to malformed Exif data blocks with bogus offsets.

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1414,7 +1414,8 @@ OIIO_API bool copy_image (int nchannels, int width, int height, int depth,
 /// ImageSpec.  Return true if all is ok, false if the exif block was
 /// somehow malformed.  The binary data pointed to by 'exif' should
 /// start with a TIFF directory header.
-OIIO_API bool decode_exif (const void *exif, int length, ImageSpec &spec);
+OIIO_API bool decode_exif (string_view exif, ImageSpec &spec);
+OIIO_API bool decode_exif (const void *exif, int length, ImageSpec &spec); // DEPRECATED (1.8)
 
 /// Construct an Exif data block from the ImageSpec, appending the Exif 
 /// data as a big blob to the char vector.

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -274,7 +274,7 @@ JpgInput::open (const std::string &name, ImageSpec &newspec)
                 ! strcmp ((const char *)m->data, "Exif")) {
             // The block starts with "Exif\0\0", so skip 6 bytes to get
             // to the start of the actual Exif data TIFF directory
-            decode_exif ((unsigned char *)m->data+6, m->data_length-6, m_spec);
+            decode_exif (string_view((char *)m->data+6, m->data_length-6), m_spec);
         }
         else if (m->marker == (JPEG_APP0+1) &&
                  ! strcmp ((const char *)m->data, "http://ns.adobe.com/xap/1.0/")) {

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -1116,8 +1116,8 @@ PSDInput::load_resource_1058 (uint32_t length)
     if (!m_file.read (&data[0], length))
         return false;
 
-    if (!decode_exif (&data[0], length, m_composite_attribs) ||
-        !decode_exif (&data[0], length, m_common_attribs)) {
+    if (!decode_exif (data, m_composite_attribs) ||
+        !decode_exif (data, m_common_attribs)) {
         error ("Failed to decode Exif data");
         return false;
     }


### PR DESCRIPTION
Use string_buf to patrol the buffer size.
Fixes #1576