### PR TITLE
[WIP] Use Conan package manager to build OpenImageIO on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,11 @@ if (NOT CMAKE_VERSION VERSION_LESS 3.2.2)
 endif ()
 set (CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS TRUE)
 
+if(USE_CONAN)
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
+endif()
+
 # N.B./FIXME - after CMake 3.0 is our minimum, we should change many of the
 # add_definitions to add_compile_options. In newer cmake versions, the
 # former is designated for definitions (-Dblah) and the latter is for
@@ -218,6 +223,7 @@ set (EXTRA_DSO_LINK_ARGS "" CACHE STRING "Extra command line definitions when bu
 set (USE_SIMD "" CACHE STRING "Use SIMD directives (0, sse2, sse3, ssse3, sse4.1, sse4.2, avx, avx2, avx512f, f16c)")
 set (USE_CCACHE ON CACHE BOOL "Use ccache if found")
 set (CODECOV OFF CACHE BOOL "Build code coverage tests")
+set (USE_CONAN OFF CACHE BOOL "Use Conan package manager to download build dependencies")
 
 # Use ccache if found
 find_program (CCACHE_FOUND ccache)
@@ -325,6 +331,15 @@ if (BUILDSTATIC)
     endif ()
 endif()
 
+if(WIN32)
+    ADD_DEFINITIONS(/bigobj)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+    SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /bigobj")
+    SET(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} /bigobj")
+    SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /bigobj")
+    SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /bigobj")
+endif()
+
 # Use .a files if LINKSTATIC is enabled
 if (LINKSTATIC)
     set (_orig_link_suffixes ${CMAKE_FIND_LIBRARY_SUFFIXES})
@@ -340,8 +355,10 @@ if (LINKSTATIC)
 endif ()
 
 set (CMAKE_MODULE_PATH
+     "${CMAKE_MODULE_PATH}"
      "${PROJECT_SOURCE_DIR}/src/cmake/modules"
-     "${PROJECT_SOURCE_DIR}/src/cmake")
+     "${PROJECT_SOURCE_DIR}/src/cmake"
+     )
 
 include (util_macros)
 include (oiio_macros)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,15 @@
+[requires]
+zlib/1.2.8@lasote/stable
+libtiff/4.0.6@bilke/stable
+libpng/1.6.23@lasote/stable
+OpenEXR/2.2.0@Mikayex/stable
+Boost/1.60.0@lasote/stable
+libjpeg-turbo/1.5.1@lasote/ci
+OpenSSL/1.0.2j@lasote/stable
+giflib/5.1.3@lasote/stable
+
+[generators]
+cmake
+
+[options]
+libpng:shared=False

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -54,7 +54,6 @@ if (THIRD_PARTY_TOOLS_HOME AND EXISTS "${THIRD_PARTY_TOOLS_HOME}")
     endforeach ()
 endif ()
 
-
 setup_string (SPECIAL_COMPILE_FLAGS ""
                "Custom compilation flags")
 if (SPECIAL_COMPILE_FLAGS)
@@ -82,7 +81,6 @@ include_directories (${ZLIB_INCLUDE_DIR})
 ###########################################################################
 # PNG
 find_package (PNG REQUIRED)
-
 
 ###########################################################################
 # IlmBase & OpenEXR setup
@@ -410,8 +408,11 @@ endif ()
 
 ###########################################################################
 # JPEG
-
 if (USE_JPEGTURBO)
+    if(USE_CONAN)
+        set(JPEG_INCLUDE_DIR ${CONAN_INCLUDE_DIRS_LIBJPEG})
+        set(JPEG_LIBRARY ${CONAN_LIB_DIRS_LIBJPEG-TURBO}/turbojpeg-static.lib)
+    endif()
     find_package (JPEGTurbo)
 endif ()
 if (JPEG_FOUND)


### PR DESCRIPTION
Hi,

I was wondering how to "fix" OIIO Windows build and one of the option that came to my mind is to use Conan C/C++ package manager (https://conan.io/).

I gave it a go and managed to build static-linked libOpenImageIO with few basic plugins (ico, png, exr, jped and probably other).

To make it work I needed to install Conan on my system. After that I added a conanfile.txt that defines required dependencies and generator.

Then, in the OIIO_ROOT/build directory I run:

`conan install .. -s compiler="Visual Studio" -s compiler.version=14 -s arch=x86 -s build_type=Debug -s compiler.runtime=MDd`

and after that I run cmake:

`cmake -D USE_SIMD=0 -D LINKSTATIC=1 -D USE_JPEGTURBO=1 ../`

it build cleanly, but I didn't manage to test it yet (need some additional  work on it).

I would say that for the Windows build it would be very good option as it easy to integrate with CMake and (hopefully) will allow to build OIIO also with clang on windows.

Obviously, there are some problems, like not all libraries being discovered by cmake due to non-standard library namings, but that's should be easy to solve either by updating conan package or having our own find* function for affected libraries.

Other question is how to maintain packages, as not all of them are found on conan.io (like boost 1.53 as example).

I'm willing to invest some time to make Windows build painless, but first I wanted to discuss possible options with you.
