### PR TITLE
Bug fix in ImageInput::read_tiles

### DIFF
--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -456,7 +456,7 @@ ImageInput::read_tiles (int xbegin, int xend, int ybegin, int yend,
     stride_t full_tilewidthbytes = full_pixelsize * m_spec.tile_width;
     stride_t full_tilewhbytes = full_tilewidthbytes * m_spec.tile_height;
     stride_t full_tilebytes = full_tilewhbytes * m_spec.tile_depth;
-    size_t prefix_bytes = m_spec.pixel_bytes (0,chbegin,true);
+    size_t prefix_bytes = chbegin * format.size();
     std::vector<char> buf;
     for (int z = zbegin;  z < zend;  z += std::max(1,m_spec.tile_depth)) {
         int zd = std::min (zend-z, m_spec.tile_depth);

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -456,7 +456,8 @@ ImageInput::read_tiles (int xbegin, int xend, int ybegin, int yend,
     stride_t full_tilewidthbytes = full_pixelsize * m_spec.tile_width;
     stride_t full_tilewhbytes = full_tilewidthbytes * m_spec.tile_height;
     stride_t full_tilebytes = full_tilewhbytes * m_spec.tile_depth;
-    size_t prefix_bytes = chbegin * format.size();
+    size_t prefix_bytes = native_data ? m_spec.pixel_bytes (0,chbegin,true)
+                                      : format.size() * chbegin;
     std::vector<char> buf;
     for (int z = zbegin;  z < zend;  z += std::max(1,m_spec.tile_depth)) {
         int zd = std::min (zend-z, m_spec.tile_depth);


### PR DESCRIPTION
ImageInput::read_tiles: prefix_bytes must use the user format and not the spec format since the temporary buffer is also using pixels in the user format.


Here is a sample image to test it. 

[test_tiled.exr.zip](https://github.com/OpenImageIO/oiio/files/682319/test_tiled.exr.zip)

I don't have code to share, but can guarantee it has been tested and fixes the issue. 