### PR TITLE
Fix unimplemented Python ImageBufAlgo.computePixelStats

### DIFF
--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -2437,50 +2437,35 @@ $Z$ channels to decide which is in front on a pixel-by-pixel basis.
 \subsection{Image comparison and statistics}
 \label{sec:iba:py:stats}
 
-\begin{comment}   % Not figured out yet
 
-\apiitem{bool ImageBufAlgo.{\ce computePixelStats} (PixelStats \&stats, src, \\
+\apiitem{bool ImageBufAlgo.{\ce computePixelStats} (src, stats, \\
    \bigspc\bigspc  roi=ROI.All, nthreads=0)}
 \index{ImageBufAlgo!computePixelStats} \indexapi{computePixelStats}
 
 Compute statistics about the ROI of the image {\cf src}, storing results
-in {\cf stats} (each of the vectors within {\cf stats} will be
-automatically resized to the number of channels in the image).  A return
-value of {\cf true} indicates success, {\cf false} indicates that it was
+in {\cf stats} (which must refer to an {\cf PixelStats} object).  A return
+value of {\cf True} indicates success, {\cf False} indicates that it was
 not possible to complete the operation.
- The {\cf PixelStats} structure is defined as follows:
-\begin{code}
-struct PixelStats {
-    std::vector<float> min
-    std::vector<float> max
-    std::vector<float> avg
-    std::vector<float> stddev
-    std::vector<imagesize_t> nancount
-    std::vector<imagesize_t> infcount
-    std::vector<imagesize_t> finitecount
-    std::vector<double> sum, sum2  # for intermediate calculation
-}
-\end{code}
+The {\cf PixelStats} structure is defined as contining the following
+data fields: {\cf min}, {\cf max}, {\cf avg}, {\cf stddev},
+{\cf nancount}, {\cf infcount}, {\cf finitecount}, {\cf sum}, {\cf sum2},
+each of which is a \emph{tuple} with one value for each channel of the image.
 
 \smallskip
 \noindent Examples:
 \begin{code}
-    ImageBuf A ("a.exr")
-    ImageBufAlgo.PixelStats stats
-    ImageBufAlgo.computePixelStats (stats, A)
-    for (int c = 0;  c < A.nchannels();  ++c) {
-        print "Channel ", c, ":"
-        print "   min = ", stats.min[c]
-        print "   max = ", stats.max[c]
-        print "   average = ", stats.avg[c]
-        print "   standard deviation  = ", stats.stddev[c]
-        print "   # NaN values    = ", stats.nancount[c]
-        print "   # Inf values    = ", stats.infcount[c]
-        print "   # finite values = ", stats.finitecount[c]
-    }
+    A = ImageBuf("a.exr")
+    stats = OpenImageIO.PixelStats()
+    computePixelStats (A, stats)
+    print "   min = ", stats.min
+    print "   max = ", stats.max
+    print "   average = ", stats.avg
+    print "   standard deviation  = ", stats.stddev
+    print "   # NaN values    = ", stats.nancount
+    print "   # Inf values    = ", stats.infcount
+    print "   # finite values = ", stats.finitecount
 \end{code}
 \apiend
-\end{comment}
 
 
 \apiitem{bool ImageBufAlgo.{\ce compare} (A, B, failthresh, warnthresh, 

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -753,6 +753,15 @@ bool IBA_unpremult (ImageBuf &dst, const ImageBuf &src,
 
 
 
+bool IBA_computePixelStats (const ImageBuf &src, ImageBufAlgo::PixelStats &stats,
+                            ROI roi, int nthreads)
+{
+    ScopedGILRelease gil;
+    return ImageBufAlgo::computePixelStats (stats, src, roi, nthreads);
+}
+
+
+
 bool IBA_compare (const ImageBuf &A, const ImageBuf &B,
                   float failthresh, float warnthresh,
                   ImageBufAlgo::CompareResults &result,
@@ -1282,6 +1291,108 @@ IBA_make_texture_filename (ImageBufAlgo::MakeTextureMode mode,
 
 
 
+#if PY_MAJOR_VERSION >= 3
+# define PYLONG(x) PyLong_FromLong((long)x)
+#else
+# define PYLONG(x) PyInt_FromLong((long)x)
+#endif
+
+
+static object
+PixelStats_get_min(const ImageBufAlgo::PixelStats& stats)
+{
+    size_t size = stats.min.size();
+    PyObject* result = PyTuple_New(size);
+    for (size_t i = 0; i < size; ++i)
+        PyTuple_SetItem(result, i, PyFloat_FromDouble(stats.min[i]));
+    return object(handle<>(result));
+}
+
+static object
+PixelStats_get_max(const ImageBufAlgo::PixelStats& stats)
+{
+    size_t size = stats.min.size();
+    PyObject* result = PyTuple_New(size);
+    for (size_t i = 0; i < size; ++i)
+        PyTuple_SetItem(result, i, PyFloat_FromDouble(stats.max[i]));
+    return object(handle<>(result));
+}
+
+static object
+PixelStats_get_avg(const ImageBufAlgo::PixelStats& stats)
+{
+    size_t size = stats.min.size();
+    PyObject* result = PyTuple_New(size);
+    for (size_t i = 0; i < size; ++i)
+        PyTuple_SetItem(result, i, PyFloat_FromDouble(stats.avg[i]));
+    return object(handle<>(result));
+}
+
+static object
+PixelStats_get_stddev(const ImageBufAlgo::PixelStats& stats)
+{
+    size_t size = stats.min.size();
+    PyObject* result = PyTuple_New(size);
+    for (size_t i = 0; i < size; ++i)
+        PyTuple_SetItem(result, i, PyFloat_FromDouble(stats.stddev[i]));
+    return object(handle<>(result));
+}
+
+static object
+PixelStats_get_nancount(const ImageBufAlgo::PixelStats& stats)
+{
+    size_t size = stats.min.size();
+    PyObject* result = PyTuple_New(size);
+    for (size_t i = 0; i < size; ++i)
+        PyTuple_SetItem(result, i, PYLONG((long)stats.nancount[i]));
+    return object(handle<>(result));
+}
+
+static object
+PixelStats_get_infcount(const ImageBufAlgo::PixelStats& stats)
+{
+    size_t size = stats.min.size();
+    PyObject* result = PyTuple_New(size);
+    for (size_t i = 0; i < size; ++i)
+        PyTuple_SetItem(result, i, PYLONG((long)stats.infcount[i]));
+    return object(handle<>(result));
+}
+
+static object
+PixelStats_get_finitecount(const ImageBufAlgo::PixelStats& stats)
+{
+    size_t size = stats.min.size();
+    PyObject* result = PyTuple_New(size);
+    for (size_t i = 0; i < size; ++i)
+        PyTuple_SetItem(result, i, PYLONG((long)stats.finitecount[i]));
+    return object(handle<>(result));
+}
+
+static object
+PixelStats_get_sum(const ImageBufAlgo::PixelStats& stats)
+{
+    size_t size = stats.min.size();
+    PyObject* result = PyTuple_New(size);
+    for (size_t i = 0; i < size; ++i)
+        PyTuple_SetItem(result, i, PyFloat_FromDouble(stats.sum[i]));
+    return object(handle<>(result));
+}
+
+static object
+PixelStats_get_sum2(const ImageBufAlgo::PixelStats& stats)
+{
+    size_t size = stats.min.size();
+    PyObject* result = PyTuple_New(size);
+    for (size_t i = 0; i < size; ++i)
+        PyTuple_SetItem(result, i, PyFloat_FromDouble(stats.sum2[i]));
+    return object(handle<>(result));
+}
+
+
+
+
+
+
 void declare_imagebufalgo()
 {
     enum_<ImageBufAlgo::NonFiniteFixMode>("NonFiniteFixMode")
@@ -1298,6 +1409,18 @@ void declare_imagebufalgo()
         .value("MakeTxEnvLatlFromLightProbe",
                                 ImageBufAlgo::MakeTxEnvLatlFromLightProbe)
         .export_values()
+    ;
+
+    class_<ImageBufAlgo::PixelStats>("PixelStats")
+        .add_property("min", &PixelStats_get_min)
+        .add_property("max", &PixelStats_get_max)
+        .add_property("avg", &PixelStats_get_avg)
+        .add_property("stddev", &PixelStats_get_stddev)
+        .add_property("nancount", &PixelStats_get_nancount)
+        .add_property("infcount", &PixelStats_get_infcount)
+        .add_property("finitecount", &PixelStats_get_finitecount)
+        .add_property("sum", &PixelStats_get_sum)
+        .add_property("sum2", &PixelStats_get_sum2)
     ;
 
     class_<ImageBufAlgo::CompareResults>("CompareResults")
@@ -1620,7 +1743,10 @@ void declare_imagebufalgo()
               arg("roi")=ROI::All(), arg("nthreads")=0))
         .staticmethod("ociofiletransform")
 
-        // computePixelStats, 
+        .def("computePixelStats", &IBA_computePixelStats,
+             (arg("src"), arg("stats"),
+              arg("roi")=ROI::All(), arg("nthreads")=0))
+        .staticmethod("computePixelStats")
 
         .def("compare", &IBA_compare,
              (arg("A"), arg("B"), arg("failthresh"), arg("warnthresh"),

--- a/testsuite/python-imagebufalgo/ref/out-alt.txt
+++ b/testsuite/python-imagebufalgo/ref/out-alt.txt
@@ -152,5 +152,5 @@ Comparing "a_over_b.exr" and "../../../../testsuite/oiiotool-composite/ref/a_ove
 PASS
 Comparing "tahoe-small.tx" and "ref/tahoe-small.tx"
 PASS
-Comparing "text.tif" and "../../../../testsuite/oiiotool-text/ref/text-freetype2.7.tif"
+Comparing "text.tif" and "../../../../testsuite/oiiotool-text/ref/text.tif"
 PASS

--- a/testsuite/python-imagebufalgo/run.py
+++ b/testsuite/python-imagebufalgo/run.py
@@ -50,7 +50,8 @@ outputs = ["black.tif", "filled.tif", "checker.tif",
            "box3.exr",
            "a_over_b.exr",
            "tahoe-small.tx",
-           "text.tif"
+           "text.tif",
+           "out.txt"
          ]
     # command += checkref (f)
 

--- a/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
+++ b/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
@@ -274,6 +274,17 @@ try:
     # FIXME - colorconvert, ociolook need tests
 
     # computePixelStats
+    b = ImageBuf ("../oiiotool/src/tahoe-small.tif")
+    stats = oiio.PixelStats()
+    ImageBufAlgo.computePixelStats (b, stats)
+    print ("Stats for tahoe-small.tif:")
+    print "  min         = ", stats.min
+    print "  max         = ", stats.max
+    print "  avg         = ", stats.avg
+    print "  stddev      = ", stats.stddev
+    print "  nancount    = ", stats.nancount
+    print "  infcount    = ", stats.infcount
+    print "  finitecount = ", stats.finitecount
 
     compresults = oiio.CompareResults()
     ImageBufAlgo.compare (ImageBuf("flip.tif"), ImageBuf("flop.tif"),


### PR DESCRIPTION
Oops, noticed recently that the Python binding for this function was never implemented.
