### PR TITLE
maketx did not incorporate "highlight compensation" into the hash!

### DIFF
--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -1139,7 +1139,7 @@ appended arguments for {\cf -otex} and {\cf -oenv} also include:
     color conversions, and re-premultiply after. (default: 0) \\[0.5ex]
 & {\cf\small incolorspace=}\emph{string} & Specify color space conversion. \\
 & {\cf\small outcolorspace=}\emph{string} & ... \\[0.5ex]
-& {\cf hilightcomp=}\emph{int} & Use highlight compensation for HDR images when
+& {\cf highlightcomp=}\emph{int} & Use highlight compensation for HDR images when
     resizing for MIP-map levels. (default: 0) \\
 & {\cf sharpen=}\emph{float} & Additional sharpening factor when resizing for
     MIP-map levels. (default: 0.0) \\

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -95,7 +95,7 @@
 }
 \date{{\large
 Date: 2 Nov 2016
-\\ (with corrections, 6 Dec 2016)
+\\ (with corrections, 6 Jan 2017)
 }}
 
 

--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -126,6 +126,7 @@ main (int argc, char *argv[])
     // Set up the imagecache with parameters that make sense for iv
     ImageCache *imagecache = ImageCache::create (true);
     imagecache->attribute ("autotile", 256);
+    imagecache->attribute ("deduplicate", (int)0);
 
     // Make sure we are the top window with the focus.
     mainWin->raise ();

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1375,7 +1375,7 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
     }
     
     // The hash is only computed for the top mipmap level of pixel data.
-    // Thus, any additional information that will effect the lower levels
+    // Thus, any additional information that will affect the lower levels
     // (such as filtering information) needs to be manually added into the
     // hash.
     std::ostringstream addlHashData;
@@ -1385,6 +1385,8 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
         addlHashData << "sharpen_A=" << sharpen << " ";
         // NB if we change the sharpening algorithm, change the letter!
     }
+    if (configspec.get_int_attribute ("maketx:highlightcomp", 0))
+        addlHashData << "highlightcomp=1 ";
 
     const int sha1_blocksize = 256;
     std::string hash_digest = configspec.get_int_attribute("maketx:hash", 1) ?

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4223,8 +4223,9 @@ prep_texture_config (ImageSpec &configspec,
     configspec.attribute ("maketx:outcolorspace",
                           get_value_override(fileoptions["outcolorspace"], ""));
     configspec.attribute ("maketx:highlightcomp",
-                          get_value_override(fileoptions["hilightcomp"], 
-                              get_value_override(fileoptions["hicomp"], 0)));
+                          get_value_override(fileoptions["highlightcomp"],
+                            get_value_override(fileoptions["hilightcomp"],
+                              get_value_override(fileoptions["hicomp"], 0))));
     configspec.attribute ("maketx:sharpen",
                           get_value_override(fileoptions["sharpen"], 0.0f));
     if (fileoptions["filter"].size() || fileoptions["filtername"].size())

--- a/testsuite/maketx/ref/out-alt-tiff4-2.txt
+++ b/testsuite/maketx/ref/out-alt-tiff4-2.txt
@@ -341,6 +341,12 @@ small.tx             :   64 x   64, 3 channel, uint8 tiff
     oiio:ConstantColor: "1,0,0"
     oiio:AverageColor: "1,0,0"
     oiio:SHA-1: "1DD1CB3C76F9A491B115F85A6DAC1B1A8DD2D3CB"
+Reading grid.tx
+    oiio:SHA-1: "9B24D4CC05313A43973AC384718D81D19183B691"
+Reading grid-lanczos3.tx
+    oiio:SHA-1: "D6C3DEE1A567726FB962FE39F0FE94A3E94530CF"
+Reading grid-lanczos3-hicomp.tx
+    oiio:SHA-1: "3994E2C39E040A372BA1894E805382E5D470790F"
 whiteenv.exr         :    4 x    2, 3 channel, half openexr (+mipmap)
     MIP 0 of 3 (4 x 2):
       Stats Min: 1.000000 1.000000 1.000000 (float)

--- a/testsuite/maketx/ref/out-alt-tiff4.txt
+++ b/testsuite/maketx/ref/out-alt-tiff4.txt
@@ -340,6 +340,12 @@ small.tx             :   64 x   64, 3 channel, uint8 tiff
     oiio:ConstantColor: "1,0,0"
     oiio:AverageColor: "1,0,0"
     oiio:SHA-1: "1DD1CB3C76F9A491B115F85A6DAC1B1A8DD2D3CB"
+Reading grid.tx
+    oiio:SHA-1: "9B24D4CC05313A43973AC384718D81D19183B691"
+Reading grid-lanczos3.tx
+    oiio:SHA-1: "D6C3DEE1A567726FB962FE39F0FE94A3E94530CF"
+Reading grid-lanczos3-hicomp.tx
+    oiio:SHA-1: "3994E2C39E040A372BA1894E805382E5D470790F"
 whiteenv.exr         :    4 x    2, 3 channel, half openexr (+mipmap)
     MIP 0 of 3 (4 x 2):
       Stats Min: 1.000000 1.000000 1.000000 (float)

--- a/testsuite/maketx/ref/out.txt
+++ b/testsuite/maketx/ref/out.txt
@@ -356,6 +356,12 @@ small.tx             :   64 x   64, 3 channel, uint8 tiff
     oiio:ConstantColor: "1,0,0"
     oiio:AverageColor: "1,0,0"
     oiio:SHA-1: "1DD1CB3C76F9A491B115F85A6DAC1B1A8DD2D3CB"
+Reading grid.tx
+    oiio:SHA-1: "9B24D4CC05313A43973AC384718D81D19183B691"
+Reading grid-lanczos3.tx
+    oiio:SHA-1: "D6C3DEE1A567726FB962FE39F0FE94A3E94530CF"
+Reading grid-lanczos3-hicomp.tx
+    oiio:SHA-1: "3994E2C39E040A372BA1894E805382E5D470790F"
 whiteenv.exr         :    4 x    2, 3 channel, half openexr (+mipmap)
     MIP 0 of 3 (4 x 2):
       Stats Min: 1.000000 1.000000 1.000000 (float)

--- a/testsuite/maketx/run.py
+++ b/testsuite/maketx/run.py
@@ -90,6 +90,19 @@ command += info_command ("small.tif", safematch=1);
 command += maketx_command ("small.tif", "small.tx",
                            "--oiio --constant-color-detect", showinfo=True)
 
+# Test that the oiio:SHA-1 hash is stable, and that that changing filter and
+# using -hicomp result in different images and different hashes.
+command += maketx_command (oiio_images + "grid.tif", "grid-lanczos3.tx",
+                           extraargs = "-filter lanczos3")
+command += maketx_command (oiio_images + "grid.tif", "grid-lanczos3-hicomp.tx",
+                           extraargs = "-filter lanczos3 -hicomp")
+command += info_command ("grid.tx",
+                         extraargs="--metamatch oiio:SHA-1")
+command += info_command ("grid-lanczos3.tx",
+                         extraargs="--metamatch oiio:SHA-1")
+command += info_command ("grid-lanczos3-hicomp.tx",
+                         extraargs="--metamatch oiio:SHA-1")
+
 # Regression test -- at one point, we had a bug where we were botching
 # the poles of OpenEXR env maps, adding energy.  Check it by creating an
 # all-white image, turning it into an env map, and calculating its

--- a/testsuite/oiiotool-maketx/ref/out.txt
+++ b/testsuite/oiiotool-maketx/ref/out.txt
@@ -306,6 +306,12 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     screenWindowCenter: 0 0
     screenWindowWidth: 1
     wrapmodes: "black,black"
+Reading grid.tx
+    oiio:SHA-1: "9B24D4CC05313A43973AC384718D81D19183B691"
+Reading grid-lanczos3.tx
+    oiio:SHA-1: "D6C3DEE1A567726FB962FE39F0FE94A3E94530CF"
+Reading grid-lanczos3-hicomp.tx
+    oiio:SHA-1: "3994E2C39E040A372BA1894E805382E5D470790F"
 Reading small.tif
 small.tif            :   64 x   64, 3 channel, uint8 tiff
     SHA-1: BE1D5EA24E907A4C4B3FB3C28EAC872A20F5B414

--- a/testsuite/oiiotool-maketx/run.py
+++ b/testsuite/oiiotool-maketx/run.py
@@ -101,6 +101,19 @@ command += omaketx_command ("../oiiotool-fixnan/src/bad.exr", "nan.exr",
 command += omaketx_command ("checker.tif", "checker-exr.pdq",
                             options=":fileformatname=exr")
 
+# Test that the oiio:SHA-1 hash is stable, and that that changing filter and
+# using -hicomp result in different images and different hashes.
+command += omaketx_command (oiio_images + "grid.tif", "grid-lanczos3.tx",
+                           options = ":filter=lanczos3", showinfo=False)
+command += omaketx_command (oiio_images + "grid.tif", "grid-lanczos3-hicomp.tx",
+                           options = ":filter=lanczos3:highlightcomp=1", showinfo=False)
+command += info_command ("grid.tx",
+                         extraargs="--metamatch oiio:SHA-1")
+command += info_command ("grid-lanczos3.tx",
+                         extraargs="--metamatch oiio:SHA-1")
+command += info_command ("grid-lanczos3-hicomp.tx",
+                         extraargs="--metamatch oiio:SHA-1")
+
 # Test that we cleanly replace any existing SHA-1 hash and ConstantColor
 # hint in the ImageDescription of the input file.
 command += oiiotool (" --pattern constant:color=1,0,0 64x64 3 "

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -134,12 +134,16 @@ def oiio_app (app):
 # Construct a command that will print info for an image, appending output to
 # the file "out.txt".  If 'safematch' is nonzero, it will exclude printing
 # of fields that tend to change from run to run or release to release.
-def info_command (file, extraargs="", safematch=False, hash=True) :
+def info_command (file, extraargs="", safematch=False, hash=True,
+                  verbose=True) :
+    args = "--info"
+    if verbose :
+        args += " -v -a"
     if safematch :
-        extraargs += " --no-metamatch \"DateTime|Software|OriginatingProgram|ImageHistory\""
+        args += " --no-metamatch \"DateTime|Software|OriginatingProgram|ImageHistory\""
     if hash :
-        extraargs += " --hash"
-    return (oiio_app("oiiotool") + "--info -v -a " + extraargs
+        args += " --hash"
+    return (oiio_app("oiiotool") + args + " " + extraargs
             + " " + oiio_relpath(file,tmpdir) + " >> out.txt ;\n")
 
 


### PR DESCRIPTION
The results when comparing "maketx --hicomp" versus without that flag
were especially hilarious when using 'iv' to view the images -- for high
resolution images, it will fall back on ImageCache, which thinks two
images with the same hash are identical and don't need to be redundantly
read from disk. So, the hicomp and nohicomp images looked identical in
iv, leading to even more confusion.

So, also turn off the ImageCache de-duplication for iv so we don't
get bitten by this again. I don't think there is a legit case where we
rely on deduplication for iv, so this seems like the safe choice.

