### PR TITLE
List the available formats by name and extensions supported.

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4628,11 +4628,19 @@ print_help (ArgParse &ap)
         std::stringstream s;
         s << "Image formats supported: ";
         std::string format_list;
-        OIIO::getattribute ("format_list", format_list);
+        OIIO::getattribute ("extension_list", format_list);
         std::vector<string_view> formats;
-        Strutil::split (format_list, formats, ",");
+        Strutil::split (format_list, formats, ";");
         std::sort (formats.begin(), formats.end());
-        format_list = Strutil::join (formats, ", ");
+
+        // Strip colon from formats with only one extension
+        for (std::vector<string_view>::iterator fmt = formats.begin(), end = formats.end();
+             fmt != end; ++fmt) {
+            if (fmt->back() == ':')
+                fmt->remove_suffix(1);
+        }
+        
+        format_list = Strutil::join (formats, "; ");
         s << format_list;
         std::cout << Strutil::wordwrap(s.str(), columns, 4) << "\n";
     }


### PR DESCRIPTION
`oiitool --help ` currently prints registered plugin names, this changes it to plugin name and all extensions supported.

```
Image formats supported: bmp; cineon:cin; dds; dpx; ffmpeg:3g2,3gp,avi,m4a,m4v,mj2,mov,mp4,mpg,qt; field3d:f3d; fits; gif; hdr:rgbe; ico; iff:z; jpeg2000:j2c,j2k,jp2;
    jpeg:jfi,jfif,jif,jpe,jpg; openexr:exr,mxr,sxr; png; pnm:pbm,pfm,pgm,ppm; psd:pdd,psb; ptex:ptx;
    raw:3fr,arw,bay,bmq,cap,cine,cr2,crw,cs1,dc2,dcr,dng,drf,dsc,erf,fff,ia,iiq,k25,kc2,kdc,mdc,mef,mos,mrw,nef,nrw,orf,pef,pxn,qtk,raf,rdc,rw2,rwl,rwz,sr2,srf,
    srw,sti,x3f; rla; sgi:bw,int,inta,rgb,rgba; socket; softimage:pic; targa:tga,tpic; tiff:env,sm,tif,tx,vsm; webp; zfile
```