### PR TITLE
Fix bug in recent cmake refactor

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -290,20 +290,3 @@ else ()
 endif ()
 
 
-###########################################################################
-# Rpath handling.
-if (CMAKE_SKIP_RPATH)
-    # We need to disallow the user from truly setting CMAKE_SKIP_RPATH, since
-    # we want to run the generated executables from the build tree in order to
-    # generate the manual page documentation.  However, we make sure the
-    # install rpath is unset so that the install tree is still free of rpaths
-    # for linux packaging purposes.
-    set (CMAKE_SKIP_RPATH FALSE)
-    unset (CMAKE_INSTALL_RPATH)
-else ()
-    set (CMAKE_INSTALL_RPATH "${LIB_INSTALL_DIR}")
-    if (NOT IS_ABSOLUTE ${CMAKE_INSTALL_RPATH})
-        set (CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}")
-    endif ()
-    set (CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-endif ()

--- a/src/cmake/install.cmake
+++ b/src/cmake/install.cmake
@@ -57,6 +57,25 @@ set (INSTALL_DOCS ON CACHE BOOL "Install documentation")
 set (INSTALL_FONTS ON CACHE BOOL "Install default fonts")
 
 
+###########################################################################
+# Rpath handling at the install step
+if (CMAKE_SKIP_RPATH)
+    # We need to disallow the user from truly setting CMAKE_SKIP_RPATH, since
+    # we want to run the generated executables from the build tree in order to
+    # generate the manual page documentation.  However, we make sure the
+    # install rpath is unset so that the install tree is still free of rpaths
+    # for linux packaging purposes.
+    set (CMAKE_SKIP_RPATH FALSE)
+    unset (CMAKE_INSTALL_RPATH)
+else ()
+    set (CMAKE_INSTALL_RPATH "${LIB_INSTALL_DIR}")
+    if (NOT IS_ABSOLUTE ${CMAKE_INSTALL_RPATH})
+        set (CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}")
+    endif ()
+    set (CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+endif ()
+
+
 
 # Macro to install targets to the appropriate locations.  Use this instead of
 # the install(TARGETS ...) signature.


### PR DESCRIPTION
Don't set CMAKE_INSTALL_RPATH to be LIB_INSTALL_DIR until **AFTER**
we have set the value of LIB_INSTALL_DIR.

The order got flipped around as a result of the refactor.
