### PR TITLE
oiiotool.cpp: fix action_crop to actually take into account the allsubimages option

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -2874,7 +2874,7 @@ action_crop (int argc, const char *argv[])
     string_view size    = ot.express (argv[1]);
 
     std::map<std::string,std::string> options;
-    options["allsubimages"] = ot.allsubimages;
+    options["allsubimages"] = std::to_string(ot.allsubimages);
     ot.extract_options (options, command);
     int crop_all_subimages = Strutil::from_string<int>(options["allsubimages"]);
 


### PR DESCRIPTION
### Problem
action_crop function in oiiotool wasn't working working with multiple subimages as ot.allsubimages wasn't taken into account.

### Solution
To fix that I just convert ot.allsubimages into a string (so the boolean will give "0" or "1") and options["allsubimages"] becomes valid to use.

### Suggestion
I could also have use directly ot.allsubimages directly, as it is into the other functions, but it feels that this change is the one that less touch the logic of the function.
