### PR TITLE
For error conditions, print the full command line.

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -301,6 +301,9 @@ Oiiotool::error (string_view command, string_view explanation)
     if (explanation.length())
         std::cerr << " : " << explanation;
     std::cerr << "\n";
+    // Repeat the command line, so if oiiotool is being called from a
+    // script, it's easy to debug how the command was mangled.
+    std::cerr << "Full command line was:\n> " << full_command_line << "\n";
     exit (-1);
 }
 
@@ -4973,6 +4976,9 @@ getargs (int argc, char *argv[])
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
         print_help (ap);
+        // Repeat the command line, so if oiiotool is being called from a
+        // script, it's easy to debug how the command was mangled.
+        std::cerr << "\nFull command line was:\n> " << ot.full_command_line << "\n";
         exit (EXIT_FAILURE);
     }
     if (help) {

--- a/testsuite/oiiotool-readerror/ref/out.err-alt.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err-alt.txt
@@ -1,1 +1,3 @@
 oiiotool ERROR: read src/incomplete.exr : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Unexpected end of file.
+Full command line was:
+> ../../src/oiiotool/oiiotool src/incomplete.exr -o out.exr

--- a/testsuite/oiiotool-readerror/ref/out.err-alt2.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err-alt2.txt
@@ -1,1 +1,3 @@
 oiiotool ERROR: read src/incomplete.exr : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../src/oiiotool/oiiotool src/incomplete.exr -o out.exr

--- a/testsuite/oiiotool-readerror/ref/out.err-debug.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err-debug.txt
@@ -1,3 +1,5 @@
 read was not necessary -- using cache
 going to have to read src/incomplete.exr: float vs float
 oiiotool ERROR: read src/incomplete.exr : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Scan line 126 is missing.
+Full command line was:
+> ../../src/oiiotool/oiiotool src/incomplete.exr -o out.exr

--- a/testsuite/oiiotool-readerror/ref/out.err.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err.txt
@@ -1,1 +1,3 @@
 oiiotool ERROR: read src/incomplete.exr : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Scan line 126 is missing.
+Full command line was:
+> ../../src/oiiotool/oiiotool src/incomplete.exr -o out.exr


### PR DESCRIPTION
It's common to call oiiotool from a script, which may assemble the
command line programmatically. If it botches this and ends up with a
mangled command line, it really helps in debugging the script if its
author can see exactly what oiiotool got as a command (essentially,
as part of the original error message).
