### PR TITLE
Add support for version 5 of the bitmap information header

### DIFF
--- a/src/bmp.imageio/bmp_pvt.cpp
+++ b/src/bmp.imageio/bmp_pvt.cpp
@@ -116,7 +116,7 @@ DibInformationHeader::read_header (FILE *fd)
     if (!fread (fd, &size))
         return false;
 
-    if (size == WINDOWS_V3 || size == WINDOWS_V4) {
+    if (size == WINDOWS_V3 || size == WINDOWS_V4 || size == WINDOWS_V5) {
         if (!fread(fd, &width) ||
             !fread(fd, &height) ||
             !fread(fd, &cplanes) ||
@@ -130,12 +130,11 @@ DibInformationHeader::read_header (FILE *fd)
             return false;
         }
 
-        if (size == WINDOWS_V4) {
-            int32_t dummy;
-
+        if (size == WINDOWS_V4 || size == WINDOWS_V5) {
             if (!fread (fd, &red_mask) ||
                 !fread (fd, &blue_mask) ||
                 !fread (fd, &green_mask) ||
+                !fread (fd, &alpha_mask) ||
                 !fread (fd, &cs_type) ||
                 !fread (fd, &red_x) ||
                 !fread (fd, &red_y) ||
@@ -148,8 +147,16 @@ DibInformationHeader::read_header (FILE *fd)
                 !fread (fd, &blue_z) ||
                 !fread (fd, &gamma_x) ||
                 !fread (fd, &gamma_y) ||
-                !fread (fd, &gamma_z) ||
-                !fread (fd, &dummy)) {
+                !fread (fd, &gamma_z)) {
+                return false;
+            }
+        }
+
+        if (size == WINDOWS_V5) {
+            if (!fread (fd, &intent) ||
+                !fread (fd, &profile_data) ||
+                !fread (fd, &profile_size) ||
+                !fread (fd, &reserved)) {
                 return false;
             }
         }

--- a/src/bmp.imageio/bmp_pvt.h
+++ b/src/bmp.imageio/bmp_pvt.h
@@ -47,6 +47,7 @@ namespace bmp_pvt {
     const int OS2_V1 = 12;
     const int WINDOWS_V3 = 40;
     const int WINDOWS_V4 = 108;
+    const int WINDOWS_V5 = 124;
 
     // bmp magic numbers
     const int16_t MAGIC_BM = 0x4D42;
@@ -119,6 +120,13 @@ namespace bmp_pvt {
          int32_t gamma_x;
          int32_t gamma_y;
          int32_t gamma_z;
+
+         // added in Version 5 of the format
+         int32_t intent;
+         int32_t profile_data;
+         int32_t profile_size;
+         int32_t reserved;
+
      private:
          void swap_endian (void);
     };


### PR DESCRIPTION
## Description

Added support for version 5 of the bitmap information header format as per: [BITMAPV5HEADER structure](https://msdn.microsoft.com/en-us/library/windows/desktop/dd183381(v=vs.85).aspx)

Also updated version 4 to match: [BITMAPV4HEADER structure](https://msdn.microsoft.com/en-us/library/windows/desktop/dd183380(v=vs.85).aspx)

This was to fix loading the following image:  https://dl.dropboxusercontent.com/u/1960912/wicked4.bmp

Only support for the bitmap information header was added and not for ICC color profiles to keep it simple.

## Tests

Verified by loading the image in iv after applying the change and ensuring existing bmpsuite tests still passed.





------
