### PR TITLE
fmath: slight reformulation of clamp() to ensure NaN safety

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -219,7 +219,7 @@ template <class T>
 inline T
 clamp (T a, T low, T high)
 {
-    return (a < low) ? low : ((a > high) ? high : a);
+    return (a >= low) ? ((a <= high) ? a : high) : low;
 }
 
 

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -233,6 +233,11 @@ static void test_interpolate_linear ()
     OIIO_CHECK_EQUAL (interpolate_linear (1.0f, knots2),  2.0f);
     OIIO_CHECK_EQUAL (interpolate_linear (-0.1f, knots2), 1.0f);
     OIIO_CHECK_EQUAL (interpolate_linear (1.1f, knots2),  2.0f);
+    float inf = std::numeric_limits<float>::infinity();
+    float nan = std::numeric_limits<float>::quiet_NaN();
+    OIIO_CHECK_EQUAL (interpolate_linear (-inf, knots2), 1.0f); // Test -inf
+    OIIO_CHECK_EQUAL (interpolate_linear (inf, knots2), 2.0f); // Test inf
+    OIIO_CHECK_EQUAL (interpolate_linear (nan, knots2), 1.0f); // Test nan
 
     // More complex case of many knots
     float knots4[] = { 1.0f, 2.0f, 4.0f, 6.0f };


### PR DESCRIPTION
Remember that floating point comparisons involving NaN always return
false. This rearrangement guarantees that clamp(x,lo,hi) always returns
a value in [lo,hi], even if x is NaN. (Specifically, it returns lo.)
