### PR TITLE
Bring gcc5 and gcc4.9 back into the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,10 @@ addons:
    sources:
       - boost-latest
       - ubuntu-toolchain-r-test
+      - george-edison55-precise-backports
    packages:
       - gcc-4.8
       - g++-4.8
-      - gcc-5
-      - g++-5
-      - gcc-6
-      - g++-6
       - libboost1.55-all-dev
       - libgif-dev
       - libtiff4-dev
@@ -116,17 +113,19 @@ matrix:
       # - os: osx
       #   compiler: clang
       #   env: DEBUG=1
-    # test with C++14, most modern compiler
+    # test with C++14, most modern compiler, latest SIMD flags
       # - os: osx
       #   compiler: clang
       #   env: USE_CPP=14
       - os: linux
         compiler: gcc
-        env: WHICHGCC=6 USE_CPP=14
-    # Build with a higher SIMD level (SSE4.2). Only bother testing linux.
-      - os: linux
-        compiler: gcc
-        env: USE_SIMD=sse4.2
+        addons:
+          apt:
+            sources: [ 'ubuntu-toolchain-r-test', 'boost-latest', 'george-edison55-precise-backports' ]
+            packages: [ 'g++-6', 'cmake', 'cmake-data', 'libboost1.55-all-dev',
+                        'libtiff4-dev', 'libgif-dev', 'libopenjpeg-dev', 'libwebp-dev',
+                        'ffmpeg', 'libfreetype6-dev', 'libjpeg-turbo8-dev', 'dcmtk' ]
+        env: WHICHGCC=6 USE_CPP=14 USE_SIMD=avx,f16c
     # Test LINKSTATIC on both platforms. This is incomplete and to make it
     # work we still need to disable a bunch of specific plugins.
       # FIXME: Don't have LINKSTATIC working on Travis for Linux, it's
@@ -137,17 +136,36 @@ matrix:
       - os: osx
         compiler: clang
         env: LINKSTATIC=1 USE_FFMPEG=0 USE_OCIO=0 USE_OPENCV=0
-    # Linux only: test gcc 6 (catch new warnings hot off the presses) and
-    # also use a higher SIMD level, avx and f16c, to make sure all is well.
-    # TravisCI's OSX images don't yet support avx/f16c, so we only do this
-    # on Linux for now, but eventually we'll want to separate these concerns
-    # into separate tests.
+    # Linux only: test gcc 4.9, and simultaneously, test with a higher SIMD
+    # level (SSE4.2).
       - os: linux
         compiler: gcc
-        env: WHICHGCC=6 USE_SIMD=avx,f16c
+        addons:
+          apt:
+            sources: [ 'ubuntu-toolchain-r-test', 'boost-latest', 'george-edison55-precise-backports' ]
+            packages: [ 'g++-4.9', 'cmake', 'cmake-data', 'libboost1.55-all-dev',
+                        'libtiff4-dev', 'libgif-dev', 'libopenjpeg-dev', 'libwebp-dev',
+                        'ffmpeg', 'libfreetype6-dev', 'libjpeg-turbo8-dev', 'dcmtk' ]
+        env: WHICHGCC=4.9
+    # Linux only: test gcc 5
+      - os: linux
+        compiler: gcc
+        addons:
+          apt:
+            sources: [ 'ubuntu-toolchain-r-test', 'boost-latest', 'george-edison55-precise-backports' ]
+            packages: [ 'g++-5', 'cmake', 'cmake-data', 'libboost1.55-all-dev',
+                        'libtiff4-dev', 'libgif-dev', 'libopenjpeg-dev', 'libwebp-dev',
+                        'ffmpeg', 'libfreetype6-dev', 'libjpeg-turbo8-dev', 'dcmtk' ]
+        env: WHICHGCC=5
     # Build with sanitizers
       - os: linux
         compiler: gcc
+        addons:
+          apt:
+            sources: [ 'ubuntu-toolchain-r-test', 'boost-latest', 'george-edison55-precise-backports' ]
+            packages: [ 'g++-6', 'cmake', 'cmake-data', 'libboost1.55-all-dev',
+                        'libtiff4-dev', 'libgif-dev', 'libopenjpeg-dev', 'libwebp-dev',
+                        'ffmpeg', 'libfreetype6-dev', 'libjpeg-turbo8-dev', 'dcmtk' ]
         env: WHICHGCC=6 SANITIZE=address USE_PYTHON=0
     # One more, just for the heck of it, turn all SIMD off, and also make
     # sure we're falling back on libjpeg, not jpeg-turbo.  I guess this

--- a/site/spi/Makefile-bits-arnold
+++ b/site/spi/Makefile-bits-arnold
@@ -186,12 +186,22 @@ else ifeq (${platform}, macosx)
 
     # A variety of tags can be used to try specific versions of gcc or
     # clang from the site-specific places we have installed them.
-    ifeq (${COMPILER}, gcc5)
+    ifeq (${COMPILER}, gcc48)
         MY_CMAKE_FLAGS += \
-           -DCMAKE_C_COMPILER=/usr/local/bin/gcc-5 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++-5
+           -DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8
+        USE_LIBCPLUSPLUS := 0
+    else ifeq (${COMPILER}, gcc49)
+        MY_CMAKE_FLAGS += \
+           -DCMAKE_C_COMPILER=gcc-4.9 -DCMAKE_CXX_COMPILER=g++-4.9
+        USE_LIBCPLUSPLUS := 0
+    else ifeq (${COMPILER}, gcc5)
+        MY_CMAKE_FLAGS += \
+           -DCMAKE_C_COMPILER=gcc-5 -DCMAKE_CXX_COMPILER=g++-5
+        USE_LIBCPLUSPLUS := 0
     else ifeq (${COMPILER}, gcc6)
         MY_CMAKE_FLAGS += \
-           -DCMAKE_C_COMPILER=/usr/local/bin/gcc-6 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++-6
+           -DCMAKE_C_COMPILER=gcc-6 -DCMAKE_CXX_COMPILER=g++-6
+        USE_LIBCPLUSPLUS := 0
     else ifeq (${COMPILER},clang35)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang-3.5 -DCMAKE_CXX_COMPILER=clang++-3.5
     else ifeq (${COMPILER},clang38)

--- a/src/dicom.imageio/dicominput.cpp
+++ b/src/dicom.imageio/dicominput.cpp
@@ -237,7 +237,7 @@ DICOMInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
     m_spec = ImageSpec(m_img->getWidth(), m_img->getHeight(), nchannels, format);
 
     m_bitspersample = m_img->getDepth();
-    if (m_bitspersample != m_spec.format.size()*8)
+    if (size_t(m_bitspersample) != m_spec.format.size()*8)
         m_spec.attribute ("oiio:BitsPerSample", m_bitspersample);
 
     m_spec.attribute ("PixelAspectRatio", (float)m_img->getWidthHeightRatio());


### PR DESCRIPTION
Because there are rumblings that VFXPlatform for CY2018 will probably upgrade the C++ requirements to gcc 5.x, add a gcc5 test to the Travis build matrix, fix a compiler warning that popped up. We want to make sure we are not introducing anything that will give us a headache next year.

Also add gcc 4.9,because we've recently discovered that gcc 4.8 doesn't have full support for C++11 (lacks proper std::regex), so maybe people will try using it, so we want it to work.

Finally, modify the Travis matrix (now that we have several distinct gcc versions) so that loads packages per-matrix-entry rather than for all, so each matrix test is only downloading and installing the gcc packages for the specific version it wants to run. Trims a little fat off the CI build times.



