### PR TITLE
Use std::regex any time it is available.

### DIFF
--- a/site/spi/Makefile-bits-arnold
+++ b/site/spi/Makefile-bits-arnold
@@ -112,7 +112,7 @@ ifeq ($(SP_OS), rhel7)
 	-DBoost_INCLUDE_DIRS=/usr/include/boost_${BOOSTVERSSP} \
 	-DBoost_LIBRARY_DIRS=/usr/lib64/boost_${BOOSTVERSSP} \
 	-Dboost_PYTHON_FOUND=1 -DPYTHONLIBS_FOUND=1 \
-	-DBoost_LIBRARIES:STRING="/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_filesystem-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_filesystem-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_regex-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_system-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_thread-gcc48-mt${BOOSTVERS_SUFFIX}.so" \
+	-DBoost_LIBRARIES:STRING="/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_filesystem-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_regex-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_system-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_thread-gcc48-mt${BOOSTVERS_SUFFIX}.so" \
 	-DBoost_PYTHON_LIBRARIES:STRING="/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_python-gcc48-mt${BOOSTVERS_SUFFIX}.so" \
 	-DPYTHON_LIBRARIES:STRING="/usr/lib64/libpython${PYVER}.so"
     # FIXME: Force use of libtiff 3.9.4 because libtiff symbols are not
@@ -172,7 +172,7 @@ else ifeq ($(SP_OS), lion)
             -DBOOST_CUSTOM=1 \
             -DBoost_INCLUDE_DIRS=/usr/include/boost_${BOOSTVERS} \
             -DBoost_LIBRARY_DIRS=/usr/lib64/boost_${BOOSTVERS} \
-            -DBoost_LIBRARIES=optimized;/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt-${BOOSTVERS_UNDERSCORE}.so;optimized;/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt-${BOOSTVERS_UNDERSCORE}.so;optimized;/usr/lib64/boost_${BOOSTVERS}/libboost_regex-gcc44-mt-${BOOSTVERS_UNDERSCORE}.so;optimized;/usr/lib64/boost_${BOOSTVERS}/libboost_system-gcc44-mt-${BOOSTVERS_UNDERSCORE}.so;optimized;/usr/lib64/boost_${BOOSTVERS}/libboost_thread-gcc44-mt-${BOOSTVERS_UNDERSCORE}.so
+            -DBoost_LIBRARIES=optimized;/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt-${BOOSTVERS_UNDERSCORE}.so;optimized;/usr/lib64/boost_${BOOSTVERS}/libboost_system-gcc44-mt-${BOOSTVERS_UNDERSCORE}.so;optimized;/usr/lib64/boost_${BOOSTVERS}/libboost_thread-gcc44-mt-${BOOSTVERS_UNDERSCORE}.so
     endif
 
     # end SPI lion

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -213,6 +213,27 @@ if (USE_fPIC)
     add_definitions ("-fPIC")
 endif ()
 
+
+# Test for features
+if (NOT VERBOSE)
+    set (CMAKE_REQUIRED_QUIET 1)
+endif ()
+include (CMakePushCheckState)
+include (CheckCXXSourceRuns)
+
+check_cxx_source_runs("
+      #include <regex>
+      int main() {
+          return std::regex_match(\"abc\", std::regex(\"(a)(.*)\")) ? 0 : 1;
+      }"
+      USE_STD_REGEX)
+if (USE_STD_REGEX)
+    add_definitions (-DUSE_STD_REGEX)
+else ()
+    add_definitions (-DUSE_BOOST_REGEX)
+endif ()
+
+
 # Code coverage options
 if (CODECOV AND (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG))
     message (STATUS "Compiling for code coverage analysis")

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -103,10 +103,12 @@ if (BOOST_CUSTOM)
     # N.B. For a custom version, the caller had better set up the variables
     # Boost_VERSION, Boost_INCLUDE_DIRS, Boost_LIBRARY_DIRS, Boost_LIBRARIES.
 else ()
-    set (Boost_COMPONENTS filesystem regex system thread)
+    set (Boost_COMPONENTS filesystem system thread)
+    if (NOT USE_STD_REGEX)
+        list (APPEND Boost_COMPONENTS regex)
+    endif ()
     find_package (Boost 1.53 REQUIRED
-                  COMPONENTS ${Boost_COMPONENTS}
-                 )
+                  COMPONENTS ${Boost_COMPONENTS})
 
     # Try to figure out if this boost distro has Boost::python.  If we
     # include python in the component list above, cmake will abort if

--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -37,8 +37,6 @@
 #include <iterator>
 #include <memory>
 
-#include <boost/regex.hpp>
-
 #include "OpenImageIO/argparse.h"
 #include "OpenImageIO/strutil.h"
 #include "OpenImageIO/imageio.h"
@@ -47,6 +45,16 @@
 #include "OpenImageIO/deepdata.h"
 #include "OpenImageIO/hash.h"
 #include "OpenImageIO/filesystem.h"
+
+#ifdef USE_BOOST_REGEX
+# include <boost/regex.hpp>
+  using boost::regex;
+  using boost::regex_search;
+#else
+# include <regex>
+  using std::regex;
+  using std::regex_search;
+#endif
 
 OIIO_NAMESPACE_USING;
 
@@ -59,7 +67,7 @@ static bool help = false;
 static std::vector<std::string> filenames;
 static std::string metamatch;
 static bool filenameprefix = false;
-static boost::regex field_re;
+static regex field_re;
 static bool subimages = false;
 static bool compute_sha1 = false;
 static bool compute_stats = false;
@@ -306,8 +314,8 @@ print_metadata (const ImageSpec &spec, const std::string &filename)
 {
     bool printed = false;
     if (metamatch.empty() ||
-          boost::regex_search ("channels", field_re) ||
-          boost::regex_search ("channel list", field_re)) {
+          regex_search ("channels", field_re) ||
+          regex_search ("channel list", field_re)) {
         if (filenameprefix)
             printf ("%s : ", filename.c_str());
         printf ("    channel list: ");
@@ -326,7 +334,7 @@ print_metadata (const ImageSpec &spec, const std::string &filename)
     }
     if (spec.x || spec.y || spec.z) {
         if (metamatch.empty() ||
-            boost::regex_search ("pixel data origin", field_re)) {
+            regex_search ("pixel data origin", field_re)) {
             if (filenameprefix)
                 printf ("%s : ", filename.c_str());
             printf ("    pixel data origin: x=%d, y=%d", spec.x, spec.y);
@@ -341,7 +349,7 @@ print_metadata (const ImageSpec &spec, const std::string &filename)
           (spec.full_height != spec.height && spec.full_height != 0) ||
           (spec.full_depth != spec.depth && spec.full_depth != 0)) {
         if (metamatch.empty() ||
-              boost::regex_search ("full/display size", field_re)) {
+              regex_search ("full/display size", field_re)) {
             if (filenameprefix)
                 printf ("%s : ", filename.c_str());
             printf ("    full/display size: %d x %d",
@@ -352,7 +360,7 @@ print_metadata (const ImageSpec &spec, const std::string &filename)
             printed = true;
         }
         if (metamatch.empty() ||
-            boost::regex_search ("full/display origin", field_re)) {
+            regex_search ("full/display origin", field_re)) {
             if (filenameprefix)
                 printf ("%s : ", filename.c_str());
             printf ("    full/display origin: %d, %d",
@@ -365,7 +373,7 @@ print_metadata (const ImageSpec &spec, const std::string &filename)
     }
     if (spec.tile_width) {
         if (metamatch.empty() ||
-            boost::regex_search ("tile", field_re)) {
+            regex_search ("tile", field_re)) {
             if (filenameprefix)
                 printf ("%s : ", filename.c_str());
             printf ("    tile size: %d x %d",
@@ -379,7 +387,7 @@ print_metadata (const ImageSpec &spec, const std::string &filename)
 
     for (auto&& p : spec.extra_attribs) {
         if (! metamatch.empty() &&
-            ! boost::regex_search (p.name().c_str(), field_re))
+            ! regex_search (p.name().c_str(), field_re))
             continue;
         std::string s = spec.metadata_val (p, true);
         if (filenameprefix)
@@ -451,7 +459,7 @@ print_info_subimage (int current_subimage, int max_subimages, ImageSpec &spec,
         return;
 
     if (! metamatch.empty() &&
-        ! boost::regex_search ("resolution, width, height, depth, channels, sha-1, stats", field_re)) {
+        ! regex_search ("resolution, width, height, depth, channels, sha-1, stats", field_re)) {
         // nothing to do here
         return;
     }
@@ -459,7 +467,7 @@ print_info_subimage (int current_subimage, int max_subimages, ImageSpec &spec,
     int nmip = 1;
 
     bool printres = verbose && (metamatch.empty() ||
-                                boost::regex_search ("resolution, width, height, depth, channels", field_re));
+                                regex_search ("resolution, width, height, depth, channels", field_re));
     if (printres && max_subimages > 1 && subimages) {
         printf (" subimage %2d: ", current_subimage);
         printf ("%4d x %4d", spec.width, spec.height);
@@ -487,7 +495,7 @@ print_info_subimage (int current_subimage, int max_subimages, ImageSpec &spec,
         printf ("\n");
 
     if (compute_sha1 && (metamatch.empty() ||
-                         boost::regex_search ("sha-1", field_re))) {
+                         regex_search ("sha-1", field_re))) {
         if (filenameprefix)
             printf ("%s : ", filename.c_str());
         // Before sha-1, be sure to point back to the highest-res MIP level
@@ -500,7 +508,7 @@ print_info_subimage (int current_subimage, int max_subimages, ImageSpec &spec,
         print_metadata (spec, filename);
 
     if (compute_stats && (metamatch.empty() ||
-                          boost::regex_search ("stats", field_re))) {
+                          regex_search ("stats", field_re))) {
         for (int m = 0;  m < nmip;  ++m) {
             ImageSpec mipspec;
             input->seek_subimage (current_subimage, m, mipspec);
@@ -553,7 +561,7 @@ print_info (const std::string &filename, size_t namefieldlength,
     input->seek_subimage (0, 0, spec);  // re-seek to the first
 
     if (metamatch.empty() ||
-        boost::regex_search ("resolution, width, height, depth, channels", field_re)) {
+        regex_search ("resolution, width, height, depth, channels", field_re)) {
         printf ("%s%s : %4d x %4d", filename.c_str(), padding.c_str(),
                 spec.width, spec.height);
         if (spec.depth > 1)
@@ -659,9 +667,15 @@ main (int argc, const char *argv[])
         exit (EXIT_FAILURE);
     }
 
-    if (! metamatch.empty())
+    if (! metamatch.empty()) {
+#if USE_BOOST_REGEX
         field_re.assign (metamatch,
-                         boost::regex::extended | boost::regex_constants::icase);
+                     boost::regex::extended | boost::regex_constants::icase);
+#else
+        field_re.assign (metamatch,
+                     std::regex_constants::extended | std::regex_constants::icase);
+#endif
+    }
 
     // Find the longest filename
     size_t longestname = 0;

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -38,7 +38,6 @@
 #include <memory>
 
 #include <boost/version.hpp>
-#include <boost/regex.hpp>
 
 #include <OpenEXR/ImathMatrix.h>
 #include <OpenEXR/half.h>
@@ -56,6 +55,16 @@
 #include "OpenImageIO/imagebufalgo_util.h"
 #include "OpenImageIO/thread.h"
 #include "OpenImageIO/filter.h"
+
+#ifdef USE_BOOST_REGEX
+# include <boost/regex.hpp>
+  using boost::regex;
+  using boost::regex_replace;
+#else
+# include <regex>
+  using std::regex;
+  using std::regex_replace;
+#endif
 
 OIIO_NAMESPACE_USING
 
@@ -1362,15 +1371,15 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
     
     // Eliminate any SHA-1 or ConstantColor hints in the ImageDescription.
     if (desc.size()) {
-        desc = boost::regex_replace (desc, boost::regex("SHA-1=[[:xdigit:]]*[ ]*"), "");
+        desc = regex_replace (desc, regex("SHA-1=[[:xdigit:]]*[ ]*"), "");
         static const char *fp_number_pattern =
             "([+-]?((?:(?:[[:digit:]]*\\.)?[[:digit:]]+(?:[eE][+-]?[[:digit:]]+)?)))";
         const std::string constcolor_pattern =
             std::string ("ConstantColor=(\\[?") + fp_number_pattern + ",?)+\\]?[ ]*";
         const std::string average_pattern =
             std::string ("AverageColor=(\\[?") + fp_number_pattern + ",?)+\\]?[ ]*";
-        desc = boost::regex_replace (desc, boost::regex(constcolor_pattern), "");
-        desc = boost::regex_replace (desc, boost::regex(average_pattern), "");
+        desc = regex_replace (desc, regex(constcolor_pattern), "");
+        desc = regex_replace (desc, regex(average_pattern), "");
         updatedDesc = true;
     }
     

--- a/src/libOpenImageIO/xmp.cpp
+++ b/src/libOpenImageIO/xmp.cpp
@@ -31,8 +31,6 @@
 
 #include <iostream>
 
-#include <boost/regex.hpp>
-
 #include "OpenImageIO/thread.h"
 #include "OpenImageIO/strutil.h"
 #include "OpenImageIO/fmath.h"

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -42,8 +42,6 @@
 #include <ctype.h>
 #include <map>
 
-#include <boost/regex.hpp>
-
 #include <OpenEXR/ImfTimeCode.h>
 
 #include "OpenImageIO/argparse.h"
@@ -58,6 +56,21 @@
 #include "OpenImageIO/timer.h"
 
 #include "oiiotool.h"
+
+#ifdef USE_BOOST_REGEX
+# include <boost/regex.hpp>
+  using boost::regex;
+  using boost::regex_search;
+  using boost::regex_replace;
+  using boost::match_results;
+#else
+# include <regex>
+  using std::regex;
+  using std::regex_search;
+  using std::regex_replace;
+  using std::match_results;
+#endif
+
 
 OIIO_NAMESPACE_USING
 using namespace OiioTool;
@@ -4295,8 +4308,8 @@ output_file (int argc, const char *argv[])
         const char *new_argv[2];
         // Git rid of the ":all=" part of the command so we don't infinitely
         // recurse.
-        std::string newcmd = boost::regex_replace (command.str(),
-                                                   boost::regex(":all=[0-9]+"), "");
+        std::string newcmd = regex_replace (command.str(),
+                                                   regex(":all=[0-9]+"), "");
         new_argv[0] = newcmd.c_str();;
         ImageRecRef saved_curimg = ot.curimg; // because we'll overwrite it
         for (int i = 0; i < nimages; ++i) {
@@ -5008,7 +5021,7 @@ handle_sequence (int argc, const char **argv)
 #define MANYRANGE_SPEC ONERANGE_SPEC "(," ONERANGE_SPEC ")*"
 #define VIEW_SPEC "%[Vv]"
 #define SEQUENCE_SPEC "((" MANYRANGE_SPEC ")?" "((#|@)+|(%[0-9]*d)))" "|" "(" VIEW_SPEC ")"
-    static boost::regex sequence_re (SEQUENCE_SPEC);
+    static regex sequence_re (SEQUENCE_SPEC);
     std::string framespec = "";
 
     static const char *default_views = "left,right";
@@ -5033,7 +5046,7 @@ handle_sequence (int argc, const char **argv)
             a++;
         }
         std::string strarg (argv[a]);
-        boost::match_results<std::string::const_iterator> range_match;
+        match_results<std::string::const_iterator> range_match;
         if (strarg == "--debug" || strarg == "-debug")
             ot.debug = true;
         else if ((strarg == "--frames" || strarg == "-frames") && a < argc-1) {
@@ -5055,7 +5068,7 @@ handle_sequence (int argc, const char **argv)
             wildcard_on = true;
         }
         else if (wildcard_on && !is_output_all &&
-                 boost::regex_search (strarg, range_match, sequence_re)) {
+                 regex_search (strarg, range_match, sequence_re)) {
             is_sequence = true;
             sequence_args.push_back (a);
             sequence_is_output.push_back (is_output);

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -34,7 +34,6 @@
 #include <cmath>
 #include <algorithm>
 
-#include <boost/regex.hpp>
 #include <boost/thread/tss.hpp>
 
 #include <tiffio.h>
@@ -46,6 +45,17 @@
 #include "OpenImageIO/strutil.h"
 #include "OpenImageIO/filesystem.h"
 #include "OpenImageIO/fmath.h"
+
+#ifdef USE_BOOST_REGEX
+# include <boost/regex.hpp>
+  using boost::regex;
+  using boost::regex_replace;
+#else
+# include <regex>
+  using std::regex;
+  using std::regex_replace;
+#endif
+
 
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
@@ -1062,7 +1072,7 @@ TIFFInput::readspec (bool read_meta)
         m_spec.attribute ("oiio:ConstantColor", s);
         const std::string constcolor_pattern =
             std::string ("oiio:ConstantColor=(\\[?") + fp_number_pattern + ",?)+\\]?[ ]*";
-        desc = boost::regex_replace (desc, boost::regex(constcolor_pattern), "");
+        desc = regex_replace (desc, regex(constcolor_pattern), "");
         updatedDesc = true;
     }
     found = desc.rfind ("oiio:AverageColor=");
@@ -1073,7 +1083,7 @@ TIFFInput::readspec (bool read_meta)
         m_spec.attribute ("oiio:AverageColor", s);
         const std::string average_pattern =
             std::string ("oiio:AverageColor=(\\[?") + fp_number_pattern + ",?)+\\]?[ ]*";
-        desc = boost::regex_replace (desc, boost::regex(average_pattern), "");
+        desc = regex_replace (desc, regex(average_pattern), "");
         updatedDesc = true;
     }
     found = desc.rfind ("oiio:SHA-1=");
@@ -1084,8 +1094,8 @@ TIFFInput::readspec (bool read_meta)
         size_t end = std::min (begin+40, desc.size());
         string_view s = string_view (desc.data()+begin, end-begin);
         m_spec.attribute ("oiio:SHA-1", s);
-        desc = boost::regex_replace (desc, boost::regex("oiio:SHA-1=[[:xdigit:]]*[ ]*"), "");
-        desc = boost::regex_replace (desc, boost::regex("SHA-1=[[:xdigit:]]*[ ]*"), "");
+        desc = regex_replace (desc, regex("oiio:SHA-1=[[:xdigit:]]*[ ]*"), "");
+        desc = regex_replace (desc, regex("SHA-1=[[:xdigit:]]*[ ]*"), "");
         updatedDesc = true;
     }
     if (updatedDesc) {


### PR DESCRIPTION
On the currently supported compilers, we believe the only time we need to fall back to boost::regex is for g++ 4.8.x. The rest of the time, we can rely on C++11 std::regex.
