### PR TITLE
Fix typo that prevented reading of all possible Exif tags in TIFF files.

### DIFF
--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -785,7 +785,7 @@ TIFFInput::readspec (bool read_meta)
         for (int i = 0;  tiff_tag_table[i].name;  ++i)
             find_tag (tiff_tag_table[i].tifftag,
                       tiff_tag_table[i].tifftype, tiff_tag_table[i].name);
-        for (int i = 0;  tiff_tag_table[i].name;  ++i)
+        for (int i = 0;  exif_tag_table[i].name;  ++i)
             find_tag (exif_tag_table[i].tifftag,
                       exif_tag_table[i].tifftype, exif_tag_table[i].name);
     }


### PR DESCRIPTION
Obvious cut and paste error. Spotted by Frédéric Devernay.

Fixes #1624
