### PR TITLE
RAW: Support RAW input to ACES color space.

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4089,7 +4089,12 @@ input_file (int argc, const char *argv[])
             // that information.
             ustring fn (filename);
             ot.imagecache->invalidate (fn);
-            ot.imagecache->add_file (fn, NULL, &ot.input_config);
+            bool ok = ot.imagecache->add_file (fn, NULL, &ot.input_config);
+            if (!ok) {
+                std::string err = ot.imagecache->geterror();
+                ot.error ("read", err.size() ? err : "(unknown error)");
+                exit (1);
+            }
         }
         if (! ot.imagecache->get_image_info (ustring(filename), 0, 0,
                             ustring("exists"), TypeDesc::TypeInt, &exists)

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -165,16 +165,27 @@ RawInput::open (const std::string &name, ImageSpec &newspec,
                                              "Adobe",
                                              "Wide",
                                              "ProPhoto",
-                                             "XYZ", NULL
+                                             "XYZ",
+#if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0,18,0)
+                                             "ACES",
+#endif
+                                             NULL
                                              };
 
         size_t c;
-        for (c=0; c < sizeof(colorspaces) / sizeof(colorspaces[0]); c++)
-            if (cs == colorspaces[c])
+        for (c=0; colorspaces[c]; c++)
+            if (Strutil::iequals (cs, colorspaces[c]))
                 break;
-        if (cs == colorspaces[c])
+        if (colorspaces[c])
             m_processor.imgdata.params.output_color = c;
         else {
+#if LIBRAW_VERSION < LIBRAW_MAKE_VERSION(0,18,0)
+            if (cs == "ACES")
+                error ("raw:ColorSpace value of \"ACES\" is not supported by libRaw %d.%d.%d",
+                       LIBRAW_MAJOR_VERSION, LIBRAW_MINOR_VERSION,
+                       LIBRAW_PATCH_VERSION);
+            else
+#endif
             error("raw:ColorSpace set to unknown value");
             return false;
         }


### PR DESCRIPTION
The "raw" reader by default will convert its input to sRGB color space, but allows you to request that it be converted upon read to other color space (or not alter the values) by setting the "configuration" option "raw:ColorSpace" to the name of the color space you want.

This patch adds "ACES" to the list of color spaces it understands,  at least for the versions of libraw that support it (version 0.18 and newer, it seems). In cases where it's not supported, you'll get an error message like this:

    $ oiiotool -iconfig raw:ColorSpace "ACES" ~/Downloads/L1004220.DNG  -o out.jpg
    oiiotool ERROR: read : raw:ColorSpace value of "ACES" is not supported by libRaw 0.17.2

While I was in there, I changed the color space names it recognizes to be case-insensitive.

Also, in order to test that the error was reported properly, I also ran across and fixed a buglet wherein for the particular cases of "open with config" (triggered by the --iconfig option), oiiotool was not properly propagating any errors that were encountered upon opening the file.