### PR TITLE
Improvement to decoding metadata from files with XMP blocks

### DIFF
--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -33,11 +33,13 @@
 #include <cstdio>
 #include <iostream>
 #include <vector>
-#include <map>
 #include <set>
 #include <algorithm>
 
-#include "OpenImageIO/fmath.h"
+#include <boost/container/flat_map.hpp>
+
+#include <OpenImageIO/fmath.h>
+#include <OpenImageIO/strutil.h>
 
 extern "C" {
 #include "tiff.h"
@@ -271,15 +273,19 @@ static const EXIF_tag_info gps_tag_table[] = {
 
 
 class TagMap {
-    typedef std::map<int, const EXIF_tag_info *> tagmap_t;
-    typedef std::map<string_view, const EXIF_tag_info *> namemap_t;
+    typedef boost::container::flat_map<int, const EXIF_tag_info *> tagmap_t;
+    typedef boost::container::flat_map<std::string, const EXIF_tag_info *> namemap_t;
+    // Name map is lower case so it's effectively case-insensitive
 public:
     TagMap (const EXIF_tag_info *tag_table) {
         for (int i = 0;  tag_table[i].tifftag >= 0;  ++i) {
             const EXIF_tag_info *eti = &tag_table[i];
             m_tagmap[eti->tifftag] = eti;
-            if (eti->name)
-                 m_namemap[string_view(eti->name)] = eti;
+            if (eti->name) {
+                std::string lowername (eti->name);
+                Strutil::to_lower (lowername);
+                m_namemap[lowername] = eti;
+            }
         }
     }
 
@@ -289,7 +295,9 @@ public:
     }
 
     const EXIF_tag_info * find (string_view name) const {
-        namemap_t::const_iterator i = m_namemap.find (name);
+        std::string lowername (name);
+        Strutil::to_lower (lowername);
+        namemap_t::const_iterator i = m_namemap.find (lowername);
         return i == m_namemap.end() ? NULL : i->second;
     }
 
@@ -309,7 +317,9 @@ public:
     }
 
     int tag (string_view name) const {
-        namemap_t::const_iterator i = m_namemap.find (name);
+        std::string lowername (name);
+        Strutil::to_lower (lowername);
+        namemap_t::const_iterator i = m_namemap.find (lowername);
         return i == m_namemap.end() ? -1 : i->second->tifftag;
     }
 


### PR DESCRIPTION
OK, this is subtle. When decoding XMP, I originally thought that it wouldn't include Exif data, but sometimes it does. But the XML is just string data.  So this patch will look up the name to see if it's a known Exif field, and if so, use the type we know it ought to be to correctly decode from a string.

Also in exif.cpp, changed the implementation of the tag map used by exif_tag_lookup so that it's case insensitive (because, ugh, some raw images have their Exif data in XMP as "exif" rather than "Exif").

The bottom line is that these changes improve proper recognition of certain metadata when reading RAW files.
