### PR TITLE
Minor bug fixes in raw file input.

### DIFF
--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -841,8 +841,9 @@ Configuration attribute & Type & Meaning \\
                                correction. (Default: 0) \\
 \qkws{raw:use_camera_wb} & int & If 1, use libraw's camera white
                                balance adjustment. (Default: 1) \\
-\qkws{raw:use_camera_matrix} & int & If 1, use libraw's camera matrix
-                               balance adjustment. (Default: 0) \\
+\qkws{raw:use_camera_matrix} & int & Whether to use the embedded color profile,
+                            if it's present: 0 = never,
+                            1 (default) = only for DNG files, 3 = always. \\
 \qkws{raw:adjust_maximum_thr} & float & If nonzero, auto-adjusting maximum
                                     value. (Default:0.0) \\
 \qkws{raw:ColorSpace} & string & Which color primaries to use: \qkw{raw},
@@ -854,9 +855,9 @@ Configuration attribute & Type & Meaning \\
                                 (Default: 0, meaning no correction.) \\
 \qkws{raw:Demosaic} & string & Force a demosaicing algorithm: \qkw{linear},
                                 \qkw{VNG}, \qkw{PPG}, \qkw{AHD} (default),
-                                \qkw{DCB}, \qkw{Modified AHD}, \qkw{AFD},
+                                \qkw{DCB}, \qkw{AHD-Mod}, \qkw{AFD},
                                 \qkw{VCD}, \qkw{Mixed}, \qkw{LMMSE},
-                                \qkw{AMaZE}. \\
+                                \qkw{AMaZE}, \qkw{DHT}, \qkw{AAHD}. \\
 \end{tabular}
 
 

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -95,7 +95,7 @@
 }
 \date{{\large
 Date: 2 Nov 2016
-\\ (with corrections, 17 Jan 2017)
+\\ (with corrections, 2 Mar 2017)
 }}
 
 

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -30,9 +30,11 @@
 
 #include "OpenImageIO/imageio.h"
 #include "OpenImageIO/fmath.h"
+#include "OpenImageIO/strutil.h"
 #include <iostream>
 #include <time.h>       /* time_t, struct tm, gmtime */
 #include <libraw/libraw.h>
+#include <libraw/libraw_version.h>
 
 
 // This plugin utilises LibRaw:
@@ -145,9 +147,14 @@ RawInput::open (const std::string &name, ImageSpec &newspec,
     m_processor.imgdata.params.adjust_maximum_thr =
         config.get_float_attribute("raw:adjust_maximum_thr", 0.0f);
 
-    // Use camera matrix (if config "raw:use_camera_matrix" is not 0)
+    // Use embedded color profile. Values mean:
+    // 0: do not use embedded color profile
+    // 1 (default): use embedded color profile (if present) for DNG files
+    //    (always), for other files only if use_camera_wb is set.
+    // 3: use embedded color data (if present) regardless of white
+    //    balance setting.
     m_processor.imgdata.params.use_camera_matrix =
-        config.get_int_attribute("raw:use_camera_matrix", 0);
+        config.get_int_attribute("raw:use_camera_matrix", 1);
 
 
     // Check to see if the user has explicitly set the output colorspace primaries
@@ -193,9 +200,10 @@ RawInput::open (const std::string &name, ImageSpec &newspec,
     }
 
     // Interpolation quality
-    // note: LibRaw must be compiled with demosaic pack GPL2 to use
-    // demosaic algorithms 5-9. It must be compiled with demosaic pack GPL3 for 
-    // algorithm 10. If either of these packs are not includeded, it will silently use option 3 - AHD
+    // note: LibRaw must be compiled with demosaic pack GPL2 to use demosaic
+    // algorithms 5-9. It must be compiled with demosaic pack GPL3 for
+    // algorithm 10 (AMAzE). If either of these packs are not included, it
+    // will silently use option 3 - AHD.
     std::string demosaic = config.get_string_attribute ("raw:Demosaic");
     if (demosaic.size()) {
         static const char *demosaic_algs[] = { "linear",
@@ -203,22 +211,26 @@ RawInput::open (const std::string &name, ImageSpec &newspec,
                                                "PPG",
                                                "AHD",
                                                "DCB",
-                                               "Modified AHD",
+                                               "AHD-Mod",
                                                "AFD",
                                                "VCD",
                                                "Mixed",
                                                "LMMSE",
                                                "AMaZE",
+#if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0,16,0)
+                                               "DHT",
+                                               "AAHD",
+#endif
                                                // Future demosaicing algorithms should go here
                                                NULL
                                                };
         size_t d;
-        for (d=0; d < sizeof(demosaic_algs) / sizeof(demosaic_algs[0]); d++)
-            if (demosaic == demosaic_algs[d])
+        for (d=0; demosaic_algs[d]; d++)
+            if (Strutil::iequals (demosaic, demosaic_algs[d]))
                 break;
-        if (demosaic == demosaic_algs[d])
+        if (demosaic_algs[d])
             m_processor.imgdata.params.user_qual = d;
-        else if (demosaic == "none") {
+        else if (Strutil::iequals (demosaic, "none")) {
 #ifdef LIBRAW_DECODER_FLATFIELD
             // See if we can access the Bayer patterned data for this raw file
             libraw_decoder_info_t decoder_info;
@@ -241,10 +253,9 @@ RawInput::open (const std::string &name, ImageSpec &newspec,
             m_spec.channelnames.push_back("R");
 
             // Also, any previously set demosaicing options are void, so remove them
-            m_spec.erase_attribute("oiio:Colorspace", TypeDesc::STRING);
-            m_spec.erase_attribute("raw:Colorspace", TypeDesc::STRING);
-            m_spec.erase_attribute("raw:Exposure", TypeDesc::STRING);
-
+            m_spec.erase_attribute("oiio:Colorspace");
+            m_spec.erase_attribute("raw:Colorspace");
+            m_spec.erase_attribute("raw:Exposure");
         }
         else {
             error("raw:Demosaic set to unknown value");


### PR DESCRIPTION
Fixes #1628

1. The default value for missing "raw:use_camera_matrix" attribute should have been 1, not 0, in order to match the default behavior of libraw/dcraw.

2. The demosicing control logic wanted to erase the "raw:Exposure" attribute, but incorrectly specified the search to be constrainted to a string attribute (thereby failing to erase the attribute which is actually a float). The simple solution is that those erase_attribute calls really don't need to constrain the type at all.

3. Add support for newer (as of LibRaw 0.16) demosaic algorithms "DMT" (mode 11) and "AAHD" (mode 12). Also allow the demosaic algorithm names to be case insensitive.

4. Rename "Modified AHD" to "AHD-Mod", to simplify the name and match libraw terminology.
