### PR TITLE
TIFF: Change interpretation of XPOSITION,YPOSITION.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -312,6 +312,10 @@ Fixes, minor enhancements, and performance improvements:
      #1642 (1.8.3/1.7.13)
    * Images with fewer than 4 channels, but one of those channels was alpha,
      were not correctly marking spec.alpha_channel. #1718 (1.8.5/1.7.16)
+   * The XPOSITION and YPOSITION tags are now interpreted as relative to
+     the RESOLUTIONUNIT, whereas before it was assumed to be measured in
+     pixels. We are confident that the new way is more in line with the
+     intent of the TIFF spec. #1631 (1.8.5)
 * webp:
    * Several new sanity checks prevent the webp reader from spending too
      much I/O time and memory reading bogus files (malformed, corrupted,

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -235,8 +235,9 @@ private:
         return ok;
     }
 
-    // Get a string tiff tag field and put it into extra_params
-    void get_string_attribute (const std::string &name, int tag) {
+    // Get a string tiff tag field and save it it as a string_view. The
+    // return value will be true if the tag was found, otherwise false.
+    bool tiff_get_string_field (int tag, string_view &result) {
         char *s = NULL;
         void *ptr = NULL;  // dummy -- expect it to stay NULL
         bool ok = TIFFGetField (m_tif, tag, &s, &ptr);
@@ -247,35 +248,43 @@ private:
             // and try it again with 2 args, first one is count.
             unsigned short count;
             ok = TIFFGetField (m_tif, tag, &count, &s);
-            m_spec.attribute (name, string_view(s,count));
+            result = string_view (s, count);
         }
         else if (ok && s && *s)
+            result = string_view (s);
+        return ok;
+    }
+
+    // Get a string tiff tag field and put it into extra_params
+    void get_string_attribute (string_view name, int tag) {
+        string_view s;
+        if (tiff_get_string_field (tag, s))
             m_spec.attribute (name, s);
     }
 
     // Get a matrix tiff tag field and put it into extra_params
-    void get_matrix_attribute (const std::string &name, int tag) {
+    void get_matrix_attribute (string_view name, int tag) {
         float *f = NULL;
         if (safe_tiffgetfield (name, tag, &f) && f)
             m_spec.attribute (name, TypeDesc::TypeMatrix, f);
     }
 
     // Get a float tiff tag field and put it into extra_params
-    void get_float_attribute (const std::string &name, int tag) {
+    void get_float_attribute (string_view name, int tag) {
         float f[16];
         if (safe_tiffgetfield (name, tag, f))
             m_spec.attribute (name, f[0]);
     }
 
     // Get an int tiff tag field and put it into extra_params
-    void get_int_attribute (const std::string &name, int tag) {
+    void get_int_attribute (string_view name, int tag) {
         int i;
         if (safe_tiffgetfield (name, tag, &i))
             m_spec.attribute (name, i);
     }
 
     // Get an int tiff tag field and put it into extra_params
-    void get_short_attribute (const std::string &name, int tag) {
+    void get_short_attribute (string_view name, int tag) {
         // Make room for two shorts, in case the tag is not the type we
         // expect, and libtiff writes a long instead.
         unsigned short s[2] = {0,0};
@@ -287,7 +296,7 @@ private:
 
     // Search for TIFF tag 'tagid' having type 'tifftype', and if found,
     // add it in the obvious way to m_spec under the name 'oiioname'.
-    void find_tag (int tifftag, TIFFDataType tifftype, const char *oiioname) {
+    void find_tag (int tifftag, TIFFDataType tifftype, string_view oiioname) {
 #ifdef TIFF_VERSION_BIG
         const TIFFField *info = TIFFFindField (m_tif, tifftag, tifftype);
 #else
@@ -686,15 +695,43 @@ TIFFInput::readspec (bool read_meta)
         m_spec.nchannels = (int)m_inputchannels;
     }
 
-    float x = 0, y = 0;
-    TIFFGetField (m_tif, TIFFTAG_XPOSITION, &x);
-    TIFFGetField (m_tif, TIFFTAG_YPOSITION, &y);
-    m_spec.x = (int)x;
-    m_spec.y = (int)y;
+    float xpos = 0, ypos = 0;
+    TIFFGetField (m_tif, TIFFTAG_XPOSITION, &xpos);
+    TIFFGetField (m_tif, TIFFTAG_YPOSITION, &ypos);
+    if (xpos || ypos) {
+        // In the TIFF files, the positions are in resolutionunit. But we
+        // didn't used to interpret it that way, hence the mess below.
+        float xres = 1, yres = 1;
+        TIFFGetField (m_tif, TIFFTAG_XRESOLUTION, &xres);
+        TIFFGetField (m_tif, TIFFTAG_YRESOLUTION, &yres);
+        // See if the 'Software' field has a clue about what version of OIIO
+        // wrote the TIFF file. This can save us from embarrassing mistakes
+        // misinterpreting the image offset.
+        int oiio_write_version = 0;
+        string_view software;
+        if (tiff_get_string_field (TIFFTAG_SOFTWARE, software)
+            && Strutil::parse_prefix (software, "OpenImageIO")) {
+            int major = 0, minor = 0, patch = 0;
+            if (Strutil::parse_int(software, major)
+                && Strutil::parse_char(software,'.')
+                && Strutil::parse_int(software, minor)
+                && Strutil::parse_char(software,'.')
+                && Strutil::parse_int(software, patch)) {
+                oiio_write_version = major*10000 + minor*100 + patch;
+            }
+        }
+        // Old version of OIIO did not write the field correctly, so try
+        // to compensate.
+        if (oiio_write_version && oiio_write_version < 10803) {
+            xres = yres = 1.0f;
+        }
+        m_spec.x = (int)(xpos*xres);
+        m_spec.y = (int)(ypos*yres);
+    } else {
+        m_spec.x = 0;
+        m_spec.y = 0;
+    }
     m_spec.z = 0;
-    // FIXME? - TIFF spec describes the positions as in resolutionunit.
-    // What happens if this is not unitless pixels?  Are we interpreting
-    // it all wrong?
 
     // Start by assuming the "full" (aka display) window is the same as the
     // data window. That's what we'll stick to if there is no further


### PR DESCRIPTION
The TIFF spec says these (which we use to generate the ImageSpec x,y fields giving the data window origin of the image) should be relative to the "resolution units" described by the XRESOLUTION and YRESOLUTION.

But OIIO has always just stored the data origin directly in this field, without regard to any scaling factor of the [XY]RESOLUTION fields.

Now, let's realize that it's not very common to have files with nonzero data origin (crop windows) in TIFF files, also not common to have any RESOLUTION tags in the files. So the problematic combination, which would be interpreted differently by versions on either side of this patch, is rare.

But one way that we can get into trouble is the following sequence: (a) a JPEG from a camera (or any number of other cases) has resolution or density data (common for cameras); (b) that JPEG is converted to TIFF, thereby copying the fields; (c) the TIFF file is cropped, and written by a version of OIIO prior to this patch. Oops.

Mitigation strategy: OIIO (at least insofar as oiiotool and maketx) likes to store its name and version in the "Software" TIFF field. So upon input, we check this, and if the file seems to have been written by OIIO with a version prior to this patch, use the old interpretation.

Fixes #1623

(Also changed some std::string& parameters used internally only to string_view, to reduce allocations from creating and destroying temporary strings as we read tag fields.) 

**I'm really nervous about this. Any objections should be voiced. If you might possibly deal with TIFF files with nonzero origin, please try this patch out before we commit it.**