### PR TITLE
oiiotool --echo

### DIFF
--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -718,6 +718,32 @@ are printed.
 \end{tabular}
 \apiend
 
+\apiitem{{\ce --echo} {\rm \emph{message}}}
+\NEW % 1.8
+Prints the message to the console, at that point in the left-to-right
+execution of command line arguments.
+The message may contain expressions for substitution.
+
+\noindent Optional appended arguments include:
+
+\noindent
+\begin{tabular}{p{10pt} p{0.75in} p{4.0in}}
+  & {\cf newline=}\emph{n} & The number of newlines to print after the
+      message (default is 1, but 0 will suppress the newline, and a larger
+      number will make more vertical space. \\
+\end{tabular}
+
+\noindent Examples:
+
+\begin{code}
+    oiiotool test.tif --resize 256x0 --echo "result is {TOP.width}x{TOP.height}"
+\end{code}
+
+This will resize the input to be 256 pixels wide and automatically size
+it vertically to preserve the original aspect ratio, and then print
+a message to the console revealing the resolution of the resulting image.
+\apiend
+
 \apiitem{{\ce --metamatch} {\rm \emph{regex}} \\
 {\ce --no-metamatch} {\rm \emph{regex}}}
 Regular expressions to restrict which metadata are output when using

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -94,8 +94,8 @@
  \bigskip \\
 }
 \date{{\large
-Date: 2 Nov 2016
-\\ (with corrections, 2 Mar 2017)
+Date: 5 Mar 2017
+%\\ (with corrections, 2 Mar 2017)
 }}
 
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4607,6 +4607,28 @@ output_file (int argc, const char *argv[])
 
 
 
+static int
+do_echo (int argc, const char *argv[])
+{
+    ASSERT (argc == 2);
+
+    string_view command = ot.express (argv[0]);
+    string_view message = ot.express (argv[1]);
+
+    std::map<std::string,std::string> options;
+    options["newline"] = "1";
+    ot.extract_options (options, command);
+    int newline = Strutil::from_string<int>(options["newline"]);
+
+    std::cout << message;
+    for (int i = 0; i < newline; ++i)
+        std::cout << '\n';
+    ot.printed_info = true;
+    return 0;
+}
+
+
+
 // Concatenate the command line into one string, optionally filtering out
 // verbose attribute commands.
 static std::string
@@ -4757,10 +4779,11 @@ getargs (int argc, char *argv[])
                 "-v", &ot.verbose, "Verbose status messages",
                 "-q %!", &ot.verbose, "Quiet mode (turn verbose off)",
                 "-n", &ot.dryrun, "No saved output (dry run)",
+                "-a", &ot.allsubimages, "Do operations on all subimages/miplevels",
                 "--debug", &ot.debug, "Debug mode",
                 "--runstats", &ot.runstats, "Print runtime statistics",
-                "-a", &ot.allsubimages, "Do operations on all subimages/miplevels",
                 "--info %@", set_printinfo, NULL, "Print resolution and basic info on all inputs, detailed metadata if -v is also used (options: format=xml:verbose=1)",
+                "--echo %@ %s", do_echo, NULL, "Echo message to console (options: newline=0)",
                 "--metamatch %s", &ot.printinfo_metamatch,
                     "Regex: which metadata is printed with -info -v",
                 "--no-metamatch %s", &ot.printinfo_nometamatch,


### PR DESCRIPTION
This adds an --echo MESSAGE command to oiiotool, which will print the
message to the console at that point the left-to-right evaluation of
command line arguments.

For example:

    oiiotool test.tif --resize 256x0 --echo "result is {TOP.width}x{TOP.height}"

This will resize the input to be 256 pixels wide and automatically size
it vertically to preserve the original aspect ratio, and then print
a message to the console revealing the resolution of the resulting image.
