### PR TITLE
Improvement to printing of long metadata

### DIFF
--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -578,7 +578,8 @@ format_raw_metadata (const ImageIOParameter &p, int maxsize=16)
                 p.type().vecsemantics);
     }
     if (n < nfull)
-        out += ", ...";
+        out += Strutil::format (", ... [%d x %s]", nfull,
+                                TypeDesc(TypeDesc::BASETYPE(element.basetype)));
     return out;
 }
 

--- a/testsuite/jpeg2000/ref/out.txt
+++ b/testsuite/jpeg2000/ref/out.txt
@@ -41,7 +41,7 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file5.jp2
     oiio:BitsPerSample: 8
     oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
-    ICCProfile: 0, 0, 2, 34, 0, 0, 0, 0, 2, 32, 0, 0, 115, 99, 110, 114, ...
+    ICCProfile: 0, 0, 2, 34, 0, 0, 0, 0, 2, 32, 0, 0, 115, 99, 110, 114, ... [546 x uint8]
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file5.jp2" and "file5.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file6.jp2
@@ -60,7 +60,7 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file7.jp2
     oiio:BitsPerSample: 16
     oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
-    ICCProfile: 0, 0, 52, 20, 65, 80, 80, 76, 2, 16, 0, 0, 115, 99, 110, 114, ...
+    ICCProfile: 0, 0, 52, 20, 65, 80, 80, 76, 2, 16, 0, 0, 115, 99, 110, 114, ... [13332 x uint8]
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file7.jp2" and "file7.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file8.jp2
@@ -70,7 +70,7 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file8.jp2
     oiio:BitsPerSample: 8
     oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
-    ICCProfile: 0, 0, 1, 158, 0, 0, 0, 0, 2, 32, 0, 0, 115, 99, 110, 114, ...
+    ICCProfile: 0, 0, 1, 158, 0, 0, 0, 0, 2, 32, 0, 0, 115, 99, 110, 114, ... [414 x uint8]
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file8.jp2" and "file8.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file9.jp2

--- a/testsuite/psd/ref/out-alt.txt
+++ b/testsuite/psd/ref/out-alt.txt
@@ -10,7 +10,7 @@ Reading ../../../../../oiio-images/psd_123.psd
     thumbnail_width: 160
     thumbnail_height: 78
     thumbnail_nchannels: 3
-    thumbnail_image: 249, 255, 255, 249, 255, 255, 252, 255, 255, 252, 255, 255, 255, 254, 255, 255, ...
+    thumbnail_image: 249, 255, 255, 249, 255, 255, 252, 255, 255, 252, 255, 255, 255, 254, 255, 255, ... [37440 x uint8]
     Orientation: 1 (normal)
     Software: "Adobe Photoshop CS5.1 Windows"
     DateTime: "2011-08-22T22:14:43-04:00"
@@ -129,7 +129,7 @@ Reading ../../../../../oiio-images/psd_123_nomaxcompat.psd
     thumbnail_width: 160
     thumbnail_height: 78
     thumbnail_nchannels: 3
-    thumbnail_image: 249, 255, 255, 249, 255, 255, 252, 255, 255, 252, 255, 255, 255, 254, 255, 255, ...
+    thumbnail_image: 249, 255, 255, 249, 255, 255, 252, 255, 255, 252, 255, 255, 255, 254, 255, 255, ... [37440 x uint8]
     Orientation: 1 (normal)
     Software: "Adobe Photoshop CS5.1 Windows"
     DateTime: "2011-08-22T22:14:43-04:00"
@@ -250,7 +250,7 @@ Reading ../../../../../oiio-images/psd_bitmap.psd
     thumbnail_width: 160
     thumbnail_height: 120
     thumbnail_nchannels: 3
-    thumbnail_image: 90, 90, 90, 255, 255, 255, 255, 255, 255, 251, 251, 251, 250, 250, 250, 255, ...
+    thumbnail_image: 90, 90, 90, 255, 255, 255, 255, 255, 255, 251, 251, 251, 250, 250, 250, 255, ... [57600 x uint8]
     Exif:ImageWidth: 3648
     Exif:ImageLength: 2736
     Exif:Photometric: 2
@@ -321,7 +321,7 @@ Reading ../../../../../oiio-images/psd_indexed_trans.psd
     thumbnail_width: 160
     thumbnail_height: 120
     thumbnail_nchannels: 3
-    thumbnail_image: 166, 170, 173, 203, 207, 210, 225, 229, 232, 228, 232, 235, 232, 236, 239, 230, ...
+    thumbnail_image: 166, 170, 173, 203, 207, 210, 225, 229, 232, 228, 232, 235, 232, 236, 239, 230, ... [57600 x uint8]
     Exif:ImageWidth: 3648
     Exif:ImageLength: 2736
     Exif:Photometric: 2
@@ -394,7 +394,7 @@ Reading ../../../../../oiio-images/psd_rgb_8.psd
     thumbnail_width: 160
     thumbnail_height: 120
     thumbnail_nchannels: 3
-    thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ...
+    thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ... [57600 x uint8]
     Exif:ImageWidth: 3648
     Exif:ImageLength: 2736
     Exif:Photometric: 2
@@ -467,7 +467,7 @@ Reading ../../../../../oiio-images/psd_rgb_16.psd
     thumbnail_width: 160
     thumbnail_height: 120
     thumbnail_nchannels: 3
-    thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ...
+    thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ... [57600 x uint8]
     Exif:ImageWidth: 3648
     Exif:ImageLength: 2736
     Exif:Photometric: 2
@@ -540,7 +540,7 @@ Reading ../../../../../oiio-images/psd_rgb_32.psd
     thumbnail_width: 160
     thumbnail_height: 120
     thumbnail_nchannels: 3
-    thumbnail_image: 217, 225, 227, 219, 227, 229, 224, 229, 232, 228, 233, 236, 231, 236, 239, 233, ...
+    thumbnail_image: 217, 225, 227, 219, 227, 229, 224, 229, 232, 228, 233, 236, 231, 236, 239, 233, ... [57600 x uint8]
     Exif:ImageWidth: 3648
     Exif:ImageLength: 2736
     Exif:Photometric: 2
@@ -614,7 +614,7 @@ Reading ../../../../../oiio-images/psd_rgba_8.psd
     thumbnail_width: 160
     thumbnail_height: 120
     thumbnail_nchannels: 3
-    thumbnail_image: 220, 224, 227, 222, 226, 229, 225, 229, 232, 229, 233, 236, 232, 236, 239, 234, ...
+    thumbnail_image: 220, 224, 227, 222, 226, 229, 225, 229, 232, 229, 233, 236, 232, 236, 239, 234, ... [57600 x uint8]
     Orientation: 1 (normal)
     Software: "Adobe Photoshop CS5.1 Windows"
     DateTime: "2011-08-22T22:07:44-04:00"

--- a/testsuite/psd/ref/out.txt
+++ b/testsuite/psd/ref/out.txt
@@ -10,7 +10,7 @@ Reading ../../../../../oiio-images/psd_123.psd
     thumbnail_width: 160
     thumbnail_height: 78
     thumbnail_nchannels: 3
-    thumbnail_image: 249, 255, 255, 251, 255, 255, 252, 255, 255, 254, 254, 255, 255, 254, 255, 255, ...
+    thumbnail_image: 249, 255, 255, 251, 255, 255, 252, 255, 255, 254, 254, 255, 255, 254, 255, 255, ... [37440 x uint8]
     Orientation: 1 (normal)
     Software: "Adobe Photoshop CS5.1 Windows"
     DateTime: "2011-08-22T22:14:43-04:00"
@@ -129,7 +129,7 @@ Reading ../../../../../oiio-images/psd_123_nomaxcompat.psd
     thumbnail_width: 160
     thumbnail_height: 78
     thumbnail_nchannels: 3
-    thumbnail_image: 249, 255, 255, 251, 255, 255, 252, 255, 255, 254, 254, 255, 255, 254, 255, 255, ...
+    thumbnail_image: 249, 255, 255, 251, 255, 255, 252, 255, 255, 254, 254, 255, 255, 254, 255, 255, ... [37440 x uint8]
     Orientation: 1 (normal)
     Software: "Adobe Photoshop CS5.1 Windows"
     DateTime: "2011-08-22T22:14:43-04:00"
@@ -250,7 +250,7 @@ Reading ../../../../../oiio-images/psd_bitmap.psd
     thumbnail_width: 160
     thumbnail_height: 120
     thumbnail_nchannels: 3
-    thumbnail_image: 90, 90, 90, 255, 255, 255, 255, 255, 255, 251, 251, 251, 250, 250, 250, 255, ...
+    thumbnail_image: 90, 90, 90, 255, 255, 255, 255, 255, 255, 251, 251, 251, 250, 250, 250, 255, ... [57600 x uint8]
     Exif:ImageWidth: 3648
     Exif:ImageLength: 2736
     Exif:Photometric: 2
@@ -321,7 +321,7 @@ Reading ../../../../../oiio-images/psd_indexed_trans.psd
     thumbnail_width: 160
     thumbnail_height: 120
     thumbnail_nchannels: 3
-    thumbnail_image: 166, 170, 173, 203, 207, 210, 225, 229, 232, 228, 232, 235, 232, 236, 239, 230, ...
+    thumbnail_image: 166, 170, 173, 203, 207, 210, 225, 229, 232, 228, 232, 235, 232, 236, 239, 230, ... [57600 x uint8]
     Exif:ImageWidth: 3648
     Exif:ImageLength: 2736
     Exif:Photometric: 2
@@ -394,7 +394,7 @@ Reading ../../../../../oiio-images/psd_rgb_8.psd
     thumbnail_width: 160
     thumbnail_height: 120
     thumbnail_nchannels: 3
-    thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ...
+    thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ... [57600 x uint8]
     Exif:ImageWidth: 3648
     Exif:ImageLength: 2736
     Exif:Photometric: 2
@@ -467,7 +467,7 @@ Reading ../../../../../oiio-images/psd_rgb_16.psd
     thumbnail_width: 160
     thumbnail_height: 120
     thumbnail_nchannels: 3
-    thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ...
+    thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ... [57600 x uint8]
     Exif:ImageWidth: 3648
     Exif:ImageLength: 2736
     Exif:Photometric: 2
@@ -540,7 +540,7 @@ Reading ../../../../../oiio-images/psd_rgb_32.psd
     thumbnail_width: 160
     thumbnail_height: 120
     thumbnail_nchannels: 3
-    thumbnail_image: 217, 225, 227, 221, 226, 229, 224, 229, 232, 228, 233, 236, 231, 236, 239, 233, ...
+    thumbnail_image: 217, 225, 227, 221, 226, 229, 224, 229, 232, 228, 233, 236, 231, 236, 239, 233, ... [57600 x uint8]
     Exif:ImageWidth: 3648
     Exif:ImageLength: 2736
     Exif:Photometric: 2
@@ -614,7 +614,7 @@ Reading ../../../../../oiio-images/psd_rgba_8.psd
     thumbnail_width: 160
     thumbnail_height: 120
     thumbnail_nchannels: 3
-    thumbnail_image: 220, 224, 227, 222, 226, 229, 225, 229, 232, 229, 233, 236, 232, 236, 239, 234, ...
+    thumbnail_image: 220, 224, 227, 222, 226, 229, 225, 229, 232, 229, 233, 236, 232, 236, 239, 234, ... [57600 x uint8]
     Orientation: 1 (normal)
     Software: "Adobe Photoshop CS5.1 Windows"
     DateTime: "2011-08-22T22:07:44-04:00"

--- a/testsuite/targa-tgautils/ref/out.txt
+++ b/testsuite/targa-tgautils/ref/out.txt
@@ -13,7 +13,7 @@ Reading ../../../../../TGAUTILS/CBW8.TGA
     thumbnail_width: 64
     thumbnail_height: 64
     thumbnail_nchannels: 1
-    thumbnail_image: 76, 76, 76, 76, 149, 149, 149, 149, 178, 178, 178, 178, 0, 0, 0, 0, ...
+    thumbnail_image: 76, 76, 76, 76, 149, 149, 149, 149, 178, 178, 178, 178, 0, 0, 0, 0, ... [4096 x uint8]
 Comparing "../../../../../TGAUTILS/CBW8.TGA" and "CBW8.TGA"
 PASS
 Reading ../../../../../TGAUTILS/CCM8.TGA
@@ -31,7 +31,7 @@ Reading ../../../../../TGAUTILS/CCM8.TGA
     thumbnail_width: 64
     thumbnail_height: 64
     thumbnail_nchannels: 3
-    thumbnail_image: 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0, 255, 0, 0, ...
+    thumbnail_image: 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0, 255, 0, 0, ... [12288 x uint8]
 Comparing "../../../../../TGAUTILS/CCM8.TGA" and "CCM8.TGA"
 PASS
 Reading ../../../../../TGAUTILS/CTC16.TGA
@@ -49,7 +49,7 @@ Reading ../../../../../TGAUTILS/CTC16.TGA
     thumbnail_width: 64
     thumbnail_height: 64
     thumbnail_nchannels: 3
-    thumbnail_image: 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0, 255, 0, 0, ...
+    thumbnail_image: 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0, 255, 0, 0, ... [12288 x uint8]
 Comparing "../../../../../TGAUTILS/CTC16.TGA" and "CTC16.TGA"
 PASS
 Reading ../../../../../TGAUTILS/CTC24.TGA
@@ -67,7 +67,7 @@ Reading ../../../../../TGAUTILS/CTC24.TGA
     thumbnail_width: 64
     thumbnail_height: 64
     thumbnail_nchannels: 3
-    thumbnail_image: 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0, 255, 0, 0, ...
+    thumbnail_image: 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0, 255, 0, 0, ... [12288 x uint8]
 Comparing "../../../../../TGAUTILS/CTC24.TGA" and "CTC24.TGA"
 PASS
 Reading ../../../../../TGAUTILS/CTC32.TGA
@@ -85,7 +85,7 @@ Reading ../../../../../TGAUTILS/CTC32.TGA
     thumbnail_width: 64
     thumbnail_height: 64
     thumbnail_nchannels: 4
-    thumbnail_image: 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, ...
+    thumbnail_image: 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, ... [16384 x uint8]
 Comparing "../../../../../TGAUTILS/CTC32.TGA" and "CTC32.TGA"
 PASS
 Reading ../../../../../TGAUTILS/UBW8.TGA
@@ -102,7 +102,7 @@ Reading ../../../../../TGAUTILS/UBW8.TGA
     thumbnail_width: 64
     thumbnail_height: 64
     thumbnail_nchannels: 1
-    thumbnail_image: 76, 76, 76, 76, 149, 149, 149, 149, 178, 178, 178, 178, 0, 0, 0, 0, ...
+    thumbnail_image: 76, 76, 76, 76, 149, 149, 149, 149, 178, 178, 178, 178, 0, 0, 0, 0, ... [4096 x uint8]
 Comparing "../../../../../TGAUTILS/UBW8.TGA" and "UBW8.TGA"
 PASS
 Reading ../../../../../TGAUTILS/UCM8.TGA
@@ -119,7 +119,7 @@ Reading ../../../../../TGAUTILS/UCM8.TGA
     thumbnail_width: 64
     thumbnail_height: 64
     thumbnail_nchannels: 3
-    thumbnail_image: 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0, 255, 0, 0, ...
+    thumbnail_image: 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0, 255, 0, 0, ... [12288 x uint8]
 Comparing "../../../../../TGAUTILS/UCM8.TGA" and "UCM8.TGA"
 PASS
 Reading ../../../../../TGAUTILS/UTC16.TGA
@@ -136,7 +136,7 @@ Reading ../../../../../TGAUTILS/UTC16.TGA
     thumbnail_width: 64
     thumbnail_height: 64
     thumbnail_nchannels: 3
-    thumbnail_image: 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0, 255, 0, 0, ...
+    thumbnail_image: 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0, 255, 0, 0, ... [12288 x uint8]
 Comparing "../../../../../TGAUTILS/UTC16.TGA" and "UTC16.TGA"
 PASS
 Reading ../../../../../TGAUTILS/UTC24.TGA
@@ -153,7 +153,7 @@ Reading ../../../../../TGAUTILS/UTC24.TGA
     thumbnail_width: 64
     thumbnail_height: 64
     thumbnail_nchannels: 3
-    thumbnail_image: 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0, 255, 0, 0, ...
+    thumbnail_image: 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0, 255, 0, 0, ... [12288 x uint8]
 Comparing "../../../../../TGAUTILS/UTC24.TGA" and "UTC24.TGA"
 PASS
 Reading ../../../../../TGAUTILS/UTC32.TGA
@@ -170,6 +170,6 @@ Reading ../../../../../TGAUTILS/UTC32.TGA
     thumbnail_width: 64
     thumbnail_height: 64
     thumbnail_nchannels: 4
-    thumbnail_image: 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, ...
+    thumbnail_image: 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, ... [16384 x uint8]
 Comparing "../../../../../TGAUTILS/UTC32.TGA" and "UTC32.TGA"
 PASS


### PR DESCRIPTION
In various contexts (such as oiiotool -v -info) when printing metadata that consists of an arbitrarily long array of values, it will print the first several values and then "..." to avoid going haywire if there are 100000 values, say.

But, hmmm, in such a case you just might want to know how many values there are and their type. So now instead of

    Foobar: 0, 0, 0, 0, 0, 0, 0, 0, ...

it will more helpfully say

    Foobar: 0, 0, 0, 0, 0, 0, 0, 0, ... [557168 x uint8]

And then you know who you can yell at about what.
