### PR TITLE
oiiotool --eraseattrib [regex]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,7 +227,8 @@ add_custom_target ( CopyFiles ALL DEPENDS "${CMAKE_BINARY_DIR}/testsuite/runtest
 # Basic tests that apply even to continuous integration tests:
 oiio_add_tests (
                 gpsread misnamed-file nonwhole-tiles
-                oiiotool oiiotool-composite oiiotool-deep oiiotool-fixnan
+                oiiotool oiiotool-attribs
+                oiiotool-composite oiiotool-deep oiiotool-fixnan
                 oiiotool-pattern oiiotool-readerror
                 oiiotool-subimage oiiotool-text oiiotool-xform
                 maketx oiiotool-maketx

--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -594,11 +594,11 @@ floating-point value, or string.
 \bigspc\bigspc                   TypeDesc searchtype=UNKNOWN,\\
 \bigspc\bigspc                   bool casesensitive=false)}
 
-Searches {\cf extra_attribs} for an attribute matching {\cf name},
-and if it exists, remove it entirely from {\cf extra_attribs}.
+Searches {\cf extra_attribs} for any attributes matching {\cf name} (as
+a regular expression), removing them entirely from {\cf extra_attribs}.
 If {\cf searchtype} is anything other than {\cf TypeDesc::UNKNOWN},
 matches will be restricted only to attributes with the given type.
-The name comparison will be exact if {\cf casesensitive} is true, otherwise
+The name comparison will be case-sensitive if {\cf casesensitive} is true, otherwise
 in a case-insensitive manner if {\cf caseinsensitive} is false.
 \apiend
 

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -1317,7 +1317,8 @@ all subimages or MIPmap levels of the current top image.  Otherwise,
 they only apply to the highest-resolution MIPmap level of the first
 subimage of the current top image.
 
-\apiitem{\ce --attrib {\rm \emph{name value}}}
+\apiitem{\ce --attrib {\rm \emph{name value}} \\
+{\ce --sattrib {\rm \emph{name value}}}
 Adds or replaces metadata with the given \emph{name} to have the
 specified \emph{value}.
 
@@ -1335,13 +1336,14 @@ be saved as {\cf int} metadata; if it also contains a decimal point, it
 will be saved as {\cf float} metadata; otherwise, it will be saved as
 a {\cf string} metadata.
 
+\noindent The {\cf --sattrib} command is equivalent to {\cf --attrib:type=string}.
 
 \noindent Examples:
 
 \begin{code}
-    oiiotool in.jpg --attrib "IPTC:City" "Berkeley" out.jpg
+    oiiotool in.jpg --attrib "IPTC:City" "Berkeley" -o out.jpg
 
-    oiiotool in.jpg --attrib:type=string "Name" "0" out.jpg
+    oiiotool in.jpg --attrib:type=string "Name" "0" -o out.jpg
 
     oiiotool in.exr --attrib:type=matrix worldtocam \
             "1,0,0,0,0,1,0,0,0,0,1,0,2.3,2.1,0,1" -o out.exr
@@ -1349,15 +1351,6 @@ a {\cf string} metadata.
     oiiotool in.exr --attrib:type=timecode smpte:TimeCode "11:34:04:00" \
             -o out.exr
 \end{code}
-\apiend
-
-\apiitem{\ce --sattrib {\rm \emph{name value}}}
-Adds or replaces metadata with the given \emph{name} to have the
-specified \emph{value}, forcing it to be interpreted as a {\cf string}.
-This is helpful if you want to set a {\cf string} metadata to a value
-that the {\cf --attrib} command would normally interpret as a number.
-
-\noindent Note also that {\cf --sattrib} is equivalent to {\cf --attrib:type=string}.
 \apiend
 
 \apiitem{\ce --caption {\rm \emph{text}}}
@@ -1395,6 +1388,25 @@ When set, this prevents the normal adjustment of \qkw{Software} and
 When set, this edits the command line inserted in the \qkw{Software} and
 \qkw{ImageHistory} metadata to omit any verbose {\cf --attrib} and
 {\cf --sattrib} commands.
+\apiend
+
+\apiitem{\ce --eraseattrib {\rm \emph{pattern}}}
+\NEW % 1.8
+Removes any metadata whose name matches the regular expression \emph{pattern}.
+The pattern will be case insensitive.
+
+\noindent Examples:
+
+\begin{code}
+    # Remove one item only
+    oiiotool in.jpg --eraseattrib "smpte:TimeCode" -o no_timecode.jpg
+
+    # Remove all GPS tags
+    oiiotool in.jpg --eraseattrib "GPS:.*" -o no_gps_metadata.jpg
+
+    # Remove all metadata
+    oiiotool in.exr --eraseattrib ".*" -o no_metadata.exr
+\end{code}
 \apiend
 
 \apiitem{\ce --orientation {\rm \emph{orient}}}

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -94,7 +94,7 @@
  \bigskip \\
 }
 \date{{\large
-Date: 5 Mar 2017
+Date: 14 Mar 2017
 %\\ (with corrections, 2 Mar 2017)
 }}
 

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -408,8 +408,8 @@ Section~\ref{sec:ImageSpecMemberFuncs} for details.)
 
 \apiitem{ImageSpec.{\ce erase_attribute} (name, searchtype=TypeDesc(TypeDesc.UNKNOWN),\\
 \bigspc\bigspc\spc casesensitive=False)}
-Remove the specified attribute from the list of extra_attribs. If not found,
-do nothing.
+Remove any specified attributes matching the regular expression {\cf name}
+from the list of extra_attribs.
 \apiend
 
 \apiitem{ImageSpec.{\ce attribute} (name, int) \\

--- a/src/include/OpenImageIO/paramlist.h
+++ b/src/include/OpenImageIO/paramlist.h
@@ -196,6 +196,7 @@ public:
 
     void resize (size_t newsize) { m_vals.resize (newsize); }
     size_t size () const { return m_vals.size(); }
+    bool empty () const { return size() == 0; }
 
     /// Add space for one more ParamValue to the list, and return a
     /// reference to its slot.

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -760,11 +760,27 @@ set_any_attribute (int argc, const char *argv[])
 
 
 static bool
-do_erase_attribute (ImageSpec &spec, const std::string &attribname)
+do_erase_attribute (ImageSpec &spec, string_view attribname)
 {
     spec.erase_attribute (attribname);
     return true;
 }
+
+
+
+static int
+erase_attribute (int argc, const char *argv[])
+{
+    ASSERT (argc == 2);
+    if (! ot.curimg.get()) {
+        ot.warning (argv[0], "no current image available to modify");
+        return 0;
+    }
+    string_view pattern = ot.express (argv[1]);
+    return apply_spec_mod (*ot.curimg, do_erase_attribute,
+                           pattern, ot.allsubimages);
+}
+
 
 
 template<class T>
@@ -4843,6 +4859,7 @@ getargs (int argc, char *argv[])
                 "<SEPARATOR>", "Options that change current image metadata (but not pixel values):",
                 "--attrib %@ %s %s", set_any_attribute, NULL, NULL, "Sets metadata attribute (name, value) (options: type=...)",
                 "--sattrib %@ %s %s", set_string_attribute, NULL, NULL, "Sets string metadata attribute (name, value)",
+                "--eraseattrib %@ %s", erase_attribute, NULL, "Erase attributes matching regex",
                 "--caption %@ %s", set_caption, NULL, "Sets caption (ImageDescription metadata)",
                 "--keyword %@ %s", set_keyword, NULL, "Add a keyword",
                 "--clear-keywords %@", clear_keywords, NULL, "Clear all keywords",

--- a/testsuite/oiiotool-attribs/ref/out.txt
+++ b/testsuite/oiiotool-attribs/ref/out.txt
@@ -1,0 +1,48 @@
+Reading nomake.jpg
+nomake.jpg           : 2048 x 1536, 3 channel, uint8 jpeg
+    SHA-1: 2623446988E34395C6B0A4AA4FC75107C708BF18
+    channel list: R, G, B
+    oiio:ColorSpace: "sRGB"
+    jpeg:subsampling: "4:2:0"
+    Model: "T-Mobile G1"
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    Exif:YCbCrPositioning: 1
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 2048
+    Exif:PixelYDimension: 1536
+    Exif:WhiteBalance: 0 (auto)
+    GPS:LatitudeRef: "N"
+    GPS:Latitude: 39, 18, 24.4
+    GPS:LongitudeRef: "W"
+    GPS:Longitude: 120, 20, 6.25
+    GPS:AltitudeRef: 0 (above sea level)
+    GPS:Altitude: 0 (0 m)
+    GPS:TimeStamp: 17, 56, 33
+    GPS:MapDatum: "WGS-84"
+    GPS:DateStamp: "1915:08:08"
+    ResolutionUnit: "none"
+Reading nogps.jpg
+nogps.jpg            : 2048 x 1536, 3 channel, uint8 jpeg
+    SHA-1: 2623446988E34395C6B0A4AA4FC75107C708BF18
+    channel list: R, G, B
+    oiio:ColorSpace: "sRGB"
+    jpeg:subsampling: "4:2:0"
+    Make: "HTC"
+    Model: "T-Mobile G1"
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    Exif:YCbCrPositioning: 1
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 2048
+    Exif:PixelYDimension: 1536
+    Exif:WhiteBalance: 0 (auto)
+    ResolutionUnit: "none"
+Reading noattribs.jpg
+noattribs.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
+    SHA-1: 2623446988E34395C6B0A4AA4FC75107C708BF18
+    channel list: R, G, B
+    oiio:ColorSpace: "sRGB"
+    jpeg:subsampling: "4:2:0"

--- a/testsuite/oiiotool-attribs/run.py
+++ b/testsuite/oiiotool-attribs/run.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+# Test oiiotool's ability to add and delete attributes
+
+
+# Test --eraseattrib ability to erase one specific attribute
+# The result should not have "Make"
+command += oiiotool (parent+"/oiio-images/tahoe-gps.jpg --eraseattrib Make -o nomake.jpg")
+command += info_command ("nomake.jpg", safematch=True)
+
+# Test --eraseattrib ability to match patterns
+# The result should have no GPS tags
+command += oiiotool (parent+"/oiio-images/tahoe-gps.jpg --eraseattrib \"GPS:.*\" -o nogps.jpg")
+command += info_command ("nogps.jpg", safematch=True)
+
+# Test --eraseattrib ability to strip all attribs
+# The result should be very minimal
+command += oiiotool (parent+"/oiio-images/tahoe-gps.jpg --eraseattrib \".*\" -o noattribs.jpg")
+command += info_command ("noattribs.jpg", safematch=True)
+
+


### PR DESCRIPTION
Extend ImageSpec::erase_attribute so that the name of the attribute to
erase is a regex, and any matching attributes will be erased.

Add oiiotool --eraseattrib, taking an argument with regex pattern,
and it will strip any matching metadata from the top image.

Example uses:

    oiiooool in.jpg --eraseattrib smpte:TimeCode -o no_timecode.jpg
    oiiotool in.jpg --eraseattrib "GPS:.*" -o no_gps_metadata.jpg
    oiiotool in.jpg --eraseattrib ".*" -o no_metadata_at_all.jpg
