### PR TITLE
Add some extra checks to exif parser to avoid memory access issues

### DIFF
--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -90,7 +90,13 @@ static size_t tiff_data_sizes[] = {
 static int
 tiff_data_size (const TIFFDirEntry &dir)
 {
-    return tiff_data_sizes[(int)dir.tdir_type] * dir.tdir_count;
+    const int num_data_sizes = sizeof(tiff_data_sizes) / sizeof(*tiff_data_sizes);
+    int dir_index = (int)dir.tdir_type;
+    if (dir_index < 0 || dir_index >= num_data_sizes) {
+        // Inform caller about corrupted entry.
+        return -1;
+    }
+    return tiff_data_sizes[dir_index] * dir.tdir_count;
 }
 
 
@@ -347,6 +353,10 @@ print_dir_entry (const TagMap &tagmap,
                  const TIFFDirEntry &dir, string_view buf)
 {
     int len = tiff_data_size (dir);
+    if (len < 0) {
+        std::cerr << "Ignoring bad directory entry\n";
+        return false;
+    }
     const char *mydata = NULL;
     if (len <= 4) {  // short data is stored in the offset field
         mydata = (const char *)&dir.tdir_offset;
@@ -392,6 +402,11 @@ print_dir_entry (const TagMap &tagmap,
     case TIFF_UNDEFINED :
     case TIFF_NOTYPE :
     default:
+        if (len <= 4 && dir.tdir_count > 4) {
+            // Request more data than is stored.
+            std::cerr << "Ignoring buffer with too much count of short data.\n";
+            return false;
+        }
         for (size_t i = 0;  i < dir.tdir_count;  ++i)
             std::cerr << (int)((unsigned char *)mydata)[i] << ' ';
         break;
@@ -511,6 +526,13 @@ read_exif_tag (ImageSpec &spec, const TIFFDirEntry *dirp,
                std::set<size_t> &ifd_offsets_seen,
                const TagMap &tagmap)
 {
+    if ((char*)dirp < buf.data() || (char*)dirp >= buf.data() + buf.size()) {
+#if DEBUG_EXIF_READ
+        std::cerr << "Ignoring directory outside of the buffer.\n";
+#endif
+        return;
+    }
+
     TagMap& exif_tagmap (exif_tagmap_ref());
     TagMap& gps_tagmap (gps_tagmap_ref());
 


### PR DESCRIPTION
This is an attempt to solve #1635. This avoids the crash by ignoring
any directory entry which is outside of the parsing buffer (that would
be really weird if there is a legit memory pointer to an outside memory
block).

There are much more places where there is potential crash is burried
in here, but those i don't feel like going into.

For such things it's really good idea to trust no input data and verify
it, otherwise it's really easy to run into crashes and even possibly
security issues.

Maybe it's also not a bad idea to add an option tyo ignore exif headers
reading for the applications which doesn't need exif.

Unfortunately, can't run testsuite, all the tests are failing on some
`os.symlink` stuff. Why would tests mock around with file system anyway?