### PR TITLE
JPEG: auto conform to supported channel count.

### DIFF
--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -480,11 +480,10 @@ Exif, IPTC, XMP, GPS & & Extensive Exif, IPTC, XMP, and GPS data are supported b
 \subsubsection*{Limitations}
 \begin{itemize}
 \item JPEG/JFIF only supports 1- (grayscale) and 3-channel (RGB) images.
-  As a special case, \product's JPEG writer will accept 4-channel image
-  data and silently drop the alpha channel while outputting.  Other
-  channel count requests (i.e., anything other than 1, 3, and 4) will
-  cause {\cf open()} to fail, since it is not possible to write a JFIF
-  file with other than 1 or 3 channels.
+  As a special case, \product's JPEG writer will accept $n$-channel image
+  data, but will only output the first 3 channels (if $n \ge 3$) or the
+  first channel (if $n \le 2$), silently drop any extra channels from the
+  output.
 \item Since JPEG/JFIF only supports 8 bits per channel, \product's
   JPEG/JFIF writer will silently convert to UINT8 upon output,
   regardless of requests to the contrary from the calling program.

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -94,7 +94,7 @@
  \bigskip \\
 }
 \date{{\large
-Date: 14 Mar 2017
+Date: 19 Mar 2017
 %\\ (with corrections, 2 Mar 2017)
 }}
 

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -140,13 +140,6 @@ JpgOutput::open (const std::string &name, const ImageSpec &newspec,
         return false;
     }
 
-    if (m_spec.nchannels != 1 && m_spec.nchannels != 3 &&
-            m_spec.nchannels != 4) {
-        error ("%s does not support %d-channel images",
-               format_name(), m_spec.nchannels);
-        return false;
-    }
-
     m_fd = Filesystem::fopen (name, "wb");
     if (m_fd == NULL) {
         error ("Unable to open file \"%s\"", name.c_str());
@@ -161,10 +154,13 @@ JpgOutput::open (const std::string &name, const ImageSpec &newspec,
     m_cinfo.image_width = m_spec.width;
     m_cinfo.image_height = m_spec.height;
 
-    if (m_spec.nchannels == 3 || m_spec.nchannels == 4) {
+    // JFIF can only handle grayscale and RGB. Do the best we can with this
+    // limited format by truncating to 3 channels if > 3 are requested,
+    // truncating to 1 channel if 2 are requested.
+    if (m_spec.nchannels >= 3) {
         m_cinfo.input_components = 3;
         m_cinfo.in_color_space = JCS_RGB;
-    } else if (m_spec.nchannels == 1) {
+    } else {
         m_cinfo.input_components = 1;
         m_cinfo.in_color_space = JCS_GRAYSCALE;
     }
@@ -349,18 +345,17 @@ JpgOutput::write_scanline (int y, int z, TypeDesc format,
     }
     assert (y == (int)m_cinfo.next_scanline);
 
-    // It's so common to want to write RGBA data out as JPEG (which only
-    // supports RGB) than it would be too frustrating to reject it.
-    // Instead, we just silently drop the alpha.  Here's where we do the
-    // dirty work, temporarily doctoring the spec so that
-    // to_native_scanline properly contiguizes the first three channels,
+    // Here's where we do the dirty work of conforming to JFIF's limitation
+    // of 1 or 3 channels, by temporarily doctoring the spec so that
+    // to_native_scanline properly contiguizes the first 1 or 3 channels,
     // then we restore it.  The call to to_native_scanline below needs
     // m_spec.nchannels to be set to the true number of channels we're
-    // writing, or it won't arrange the data properly.  But if we
-    // doctored m_spec.nchannels = 3 permanently, then subsequent calls
-    // to write_scanline (including any surrounding call to write_image)
-    // with stride=AutoStride would screw up the strides since the
-    // user's stride is actually not 3 channels.
+    // writing, or it won't arrange the data properly.  But if we doctored
+    // m_spec.nchannels permanently, then subsequent calls to write_scanline
+    // (including any surrounding call to write_image) with
+    // stride=AutoStride would screw up the strides since the user's stride
+    // is actually not 1 or 3 channels.
+    m_spec.auto_stride (xstride, format, m_spec.nchannels);
     int save_nchannels = m_spec.nchannels;
     m_spec.nchannels = m_cinfo.input_components;
 


### PR DESCRIPTION
JFIF files, as you know, only support 1 or 3 channels (grayscale and RGB, respectively).

Previously, we accepted the special case of 4 channel output (presumably RGBA) by silently dropping the last channel (A, not representable in JFIF files), but for any other channel count (2, or >= 5) would just allow open() to fail.

With this patch, we make the JPEG writer even more forgiving. For nchannels > 3, we truncate to just the first three channels, and for 2 channels, we truncate to just the first channel (outputting grayscale).

The reason why we want this extra flexibility is that JPEG is such a common format for "proxies", "thumbnails", and other kinds of embedded or web-facing images, where we might want to just quickly generate such a proxy for arbitrary images without wanting to think hard about the logic of how to conform unusual channel counts to JPEG's limitations. And let's face it, if the user really wanted high fidelity, they would not be using JPEG -- a usually-lossy, 8-bit-only, 1-and-3-channel-only format -- and so silently dropping a channel that can't be represented is probably not the biggest compromise being made to the original data when saving to this format.
