### PR TITLE
Strutil::parse_identifier_if

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -487,6 +487,12 @@ string_view OIIO_API parse_identifier (string_view &str, bool eat=true);
 string_view OIIO_API parse_identifier (string_view &str,
                                        string_view allowed, bool eat);
 
+/// If the C-like identifier at the head of str exactly matches id,
+/// return true, and also advance str if eat is true. If it is not a match
+/// for id, return false and do not alter str.
+bool OIIO_API parse_identifier_if (string_view &str, string_view id,
+                                   bool eat=true);
+
 /// Return the characters until any character in sep is found, storing it in
 /// str, and additionally modify str to skip over the parsed section if eat
 /// is also true. Otherwise, if no word is found at the beginning of str,

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -777,6 +777,20 @@ Strutil::parse_identifier (string_view &str, string_view allowed, bool eat)
 
 
 
+bool
+Strutil::parse_identifier_if (string_view &str, string_view id, bool eat)
+{
+    string_view head = parse_identifier (str, false /* don't eat */);
+    if (head == id) {
+        if (eat)
+            parse_identifier (str);
+        return true;
+    }
+    return false;
+}
+
+
+
 string_view
 Strutil::parse_until (string_view &str, string_view sep, bool eat)
 {

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -542,6 +542,16 @@ void test_parse ()
     s = "fl$orp 14";  ss = parse_identifier (s, "$:", true);
     OIIO_CHECK_ASSERT (ss == "fl$orp" && s == " 14");
 
+    bool b;
+    s = " foo bar"; b = parse_identifier_if (s, "bar");
+    OIIO_CHECK_ASSERT (b == false && s == " foo bar");
+    s = " foo bar"; b = parse_identifier_if (s, "foo");
+    OIIO_CHECK_ASSERT (b == true && s == " bar");
+    s = " foo_14 bar"; b = parse_identifier_if (s, "foo");
+    OIIO_CHECK_ASSERT (b == false && s == " foo_14 bar");
+    s = " foo_14 bar"; b = parse_identifier_if (s, "foo_14");
+    OIIO_CHECK_ASSERT (b == true && s == " bar");
+
     s = "foo;bar blow"; ss = parse_until (s, ";");
     OIIO_CHECK_ASSERT (ss == "foo" && s == ";bar blow");
     s = "foo;bar blow"; ss = parse_until (s, "\t ");


### PR DESCRIPTION
Utility to return whether the identifier at the head of a string matches
a pattern, and advance the pointer only if it does.

