### PR TITLE
oiiotool: expressions recognize FRAME_NUMBER and FRAME_NUMBER_PAD

### DIFF
--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -222,6 +222,16 @@ specified image (e.g., {\cf ImageDescription}, or {\cf width})
 \item[{Arithmetic}] Sub-expressions may be joined by {\cf +}, {\cf -},
 {\cf *}, or {\cf /} for arithmetic operations. Parentheses are supported,
 and standard operator precedence applies.
+
+\item[{Special variables}] \spc
+
+\begin{itemize}
+\item {\cf FRAME_NUMBER} : the number of the frame in this iteration of
+    wildcard expansion.
+\item {\cf FRAME_NUMBER_PAD} : like {\cf FRAME_NUMBER}, but 0-padded based
+    on the value set on the command line by {\cf --framepadding}.
+\end{itemize}
+
 \end{description}
 
 To illustrate how this works, consider the following command, which trims

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -82,6 +82,7 @@ public:
     bool nativeread;                  // force native data type reads
     int cachesize;
     int autotile;
+    int frame_padding;
     std::string full_command_line;
     std::string printinfo_metamatch;
     std::string printinfo_nometamatch;
@@ -132,6 +133,7 @@ public:
     size_t peak_memory;
     int num_outputs;                         // Count of outputs written
     bool printed_info;                       // printed info at some point
+    int frame_number;
 
     Oiiotool ();
 


### PR DESCRIPTION
On oiiotool command line {expressions}, FRAME_NUMBER is replaced based
on the numeric wildcard iteration, and FRAME_NUMBER_PAD is the same
value but as a string that appears zero padded to the number of digits
specificed by --framepadding.

So, for example, to burn in frame numbers to every image in a sequence:

    oiiotool -framepadding 4 -frames 1-100 in.#.exr \
        -text:x=50:y={TOP.height-50} "Frame {FRAME_NUMBER_PAD}" \
        -o out.#.exr
