### PR TITLE
First stab at using clang-tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,6 +281,19 @@ ifneq (${SANITIZE},)
 MY_CMAKE_FLAGS += -DSANITIZE=${SANITIZE}
 endif
 
+ifneq (${CLANG_TIDY},)
+  MY_CMAKE_FLAGS += -DCLANG_TIDY:BOOL=1
+endif
+ifneq (${CLANG_TIDY_CHECKS},)
+  MY_CMAKE_FLAGS += -DCLANG_TIDY_CHECKS:STRING=${CLANG_TIDY_CHECKS}
+endif
+ifneq (${CLANG_TIDY_ARGS},)
+  MY_CMAKE_FLAGS += -DCLANG_TIDY_ARGS:STRING=${CLANG_TIDY_ARGS}
+endif
+ifneq (${CLANG_TIDY_FIX},)
+  MY_CMAKE_FLAGS += -DCLANG_TIDY_FIX:BOOL=${CLANG_TIDY_FIX}
+endif
+
 ifneq (${USE_FREETYPE},)
 MY_CMAKE_FLAGS += -DUSE_FREETYPE:BOOL=${USE_FREETYPE}
 endif
@@ -436,6 +449,8 @@ help:
 	@echo "      USE_CCACHE=0             Disable ccache (even if available)"
 	@echo "      CODECOV=1                Enable code coverage tests"
 	@echo "      SANITIZE=name1,...       Enablie sanitizers (address, leak, thread)"
+	@echo "      CLANG_TIDY=1             Run clang-tidy on all source (can be modified"
+	@echo "                                  by CLANG_TIDY_ARGS=... and CLANG_TIDY_FIX=1"
 	@echo "  Linking and libraries:"
 	@echo "      HIDE_SYMBOLS=1           Hide symbols not in the public API"
 	@echo "      SOVERSION=nn             Include the specifed major version number "

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -17,7 +17,10 @@ option (BUILDSTATIC "Build static libraries instead of shared")
 option (LINKSTATIC  "Link with static external libraries when possible")
 option (CODECOV "Build code coverage tests")
 set (SANITIZE "" CACHE STRING "Build code using sanitizer (address, thread)")
-
+option (CLANG_TIDY "Enable clang-tidy" OFF)
+set (CLANG_TIDY_CHECKS "-*" CACHE STRING "clang-tidy checks to perform")
+set (CLANG_TIDY_ARGS "" CACHE STRING "clang-tidy args")
+option (CLANG_TIDY_FIX "Have clang-tidy fix source" OFF)
 
 # Figure out which compiler we're using
 if (CMAKE_COMPILER_IS_GNUCC)
@@ -276,6 +279,18 @@ if (SANITIZE AND (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG))
     add_definitions ("-D${PROJECT_NAME}_SANITIZE=1")
 endif ()
 
+# clang-tidy options
+if (CLANG_TIDY)
+    set (CMAKE_CXX_CLANG_TIDY "clang-tidy")
+    if (CLANG_TIDY_ARGS)
+        set (CMAKE_CXX_CLANG_TIDY "${CMAKE_CXX_CLANG_TIDY};${CLANG_TIDY_ARGS}")
+    endif ()
+    if (CLANG_TIDY_FIX)
+        set (CMAKE_CXX_CLANG_TIDY "${CMAKE_CXX_CLANG_TIDY};-fix")
+    endif ()
+    set (CMAKE_CXX_CLANG_TIDY "${CMAKE_CXX_CLANG_TIDY};-checks=${CLANG_TIDY_CHECKS}")
+    message (STATUS, "clang-tidy command line is: ${CMAKE_CXX_CLANG_TIDY}")
+endif ()
 
 if (EXTRA_CPP_ARGS)
     message (STATUS "Extra C++ args: ${EXTRA_CPP_ARGS}")

--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -29,7 +29,7 @@
 */
 
 extern "C" { // ffmpeg is a C api
-#include <errno.h>
+#include <cerrno>
 #include <libavformat/avformat.h>
 #include <libavcodec/avcodec.h>
 #include <libswscale/swscale.h>

--- a/src/fits.imageio/fitsinput.cpp
+++ b/src/fits.imageio/fitsinput.cpp
@@ -30,7 +30,7 @@
 
 
 #include <cstdlib>
-#include <ctype.h>
+#include <cctype>
 
 #include "fits_pvt.h"
 

--- a/src/hdr.imageio/rgbe.cpp
+++ b/src/hdr.imageio/rgbe.cpp
@@ -3,10 +3,10 @@
  * IT IS STRICTLY USE AT YOUR OWN RISK.  */
 
 #include "rgbe.h"
-#include <math.h>
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <cctype>
 
 /* This file contains code to read and write four byte rgbe file format
  developed by Greg Ward.  It handles the conversions between rgbe and

--- a/src/include/OpenImageIO/pugixml.cpp
+++ b/src/include/OpenImageIO/pugixml.cpp
@@ -16,15 +16,15 @@
 
 #include "pugixml.hpp"
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <assert.h>
-#include <wchar.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <cassert>
+#include <cwchar>
 
 #ifndef PUGIXML_NO_XPATH
-#	include <math.h>
-#	include <float.h>
+#	include <cmath>
+#	include <cfloat>
 #	ifdef PUGIXML_NO_EXCEPTIONS
 #		include <setjmp.h>
 #	endif
@@ -121,7 +121,7 @@ using std::memmove;
 
 // uintptr_t
 #if !defined(_MSC_VER) || _MSC_VER >= 1600
-#	include <stdint.h>
+#	include <cstdint>
 #else
 #	ifndef _UINTPTR_T_DEFINED
 // No native uintptr_t in MSVC6 and in some WinCE versions

--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -29,7 +29,7 @@
 */
 
 
-#include <ctype.h>
+#include <cctype>
 #include <cstdio>
 #include <iostream>
 #include <vector>

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -29,7 +29,7 @@
 */
 
 
-#include <math.h>
+#include <cmath>
 #include <string>
 #include <sstream>
 #include <list>

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -29,7 +29,7 @@
 */
 
 
-#include <math.h>
+#include <cmath>
 #include <string>
 #include <sstream>
 #include <list>

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -29,7 +29,7 @@
 */
 
 
-#include <math.h>
+#include <cmath>
 #include <string>
 #include <sstream>
 #include <cstring>

--- a/src/libutil/hashes.cpp
+++ b/src/libutil/hashes.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>      /* defines printf for tests */
-#include <time.h>       /* defines time_t for timings in the test */
+#include <cstdio>      /* defines printf for tests */
+#include <ctime>       /* defines time_t for timings in the test */
 #if defined(__linux__) || defined(__APPLE__)
 # include <sys/param.h>  /* attempt to define endianness */
 #endif

--- a/src/libutil/xxhash.cpp
+++ b/src/libutil/xxhash.cpp
@@ -83,7 +83,7 @@ You can contact the author at :
 #include "OpenImageIO/hash.h"
 
 
-#include <stddef.h>   /* size_t */
+#include <cstddef>   /* size_t */
 typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 typedef struct { long long ll[ 6]; } XXH32_state_t;
 typedef struct { long long ll[11]; } XXH64_state_t;
@@ -94,11 +94,11 @@ typedef struct { long long ll[11]; } XXH64_state_t;
 //#include "xxhash.h"
 // Modify the local functions below should you wish to use some other memory routines
 // for malloc(), free()
-#include <stdlib.h>
+#include <cstdlib>
 static void* XXH_malloc(size_t s) { return malloc(s); }
 static void  XXH_free  (void* p)  { free(p); }
 // for memcpy()
-#include <string.h>
+#include <cstring>
 static void* XXH_memcpy(void* dest, const void* src, size_t size)
 {
     return memcpy(dest,src,size);

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -39,7 +39,7 @@
 #include <sstream>
 #include <algorithm>
 #include <utility>
-#include <ctype.h>
+#include <cctype>
 #include <map>
 
 #include <OpenEXR/ImfTimeCode.h>

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -31,7 +31,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cmath>
-#include <errno.h>
+#include <cerrno>
 #include <fstream>
 #include <map>
 #include <numeric>

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -31,7 +31,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cmath>
-#include <errno.h>
+#include <cerrno>
 #include <fstream>
 #include <iostream>
 #include <map>

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -32,7 +32,7 @@
 #include <cstdlib>
 #include <cmath>
 #include <iostream>
-#include <time.h>
+#include <ctime>
 
 #include "png_pvt.h"
 

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -28,7 +28,7 @@
   (This is the Modified BSD License)
 */
 
-#include <setjmp.h>
+#include <csetjmp>
 #include <fstream>
 #include <vector>
 #include <map>

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -32,7 +32,7 @@
 #include "OpenImageIO/fmath.h"
 #include "OpenImageIO/strutil.h"
 #include <iostream>
-#include <time.h>       /* time_t, struct tm, gmtime */
+#include <ctime>       /* time_t, struct tm, gmtime */
 #include <libraw/libraw.h>
 #include <libraw/libraw_version.h>
 


### PR DESCRIPTION
clang-tidy is part of the llvm/clang suite of tools. It a fancy linter, with deep ties into the clang AST, providing has a whole bunch of static code analysis tools and stylistic checks.

Turns out that cmake is pretty clang-tidy aware, so just by setting a cmake variable (CMAKE_CXX_CLANG_TIDY) to the clang-tidy command line args you want, cmake will run clang-tidy on every .cpp file that it would compile in the course of the build.

This PR adds new build flags to control this: CLANG_TIDY, CLANG_TIDY_CHECKS, CLANG_TIDY_ARGS, CLANG_TIDY_FIX

All off by default, but allows really easy use of clang-tidy while building.
For example,
    
    make CLANG_TIDY=1 CLANG_TIDY_CHECKS="-*,modernize-*"
    
or if you are really adventurous
    
    make CLANG_TIDY=1 CLANG_TIDY_CHECKS="-*,modernize-*" CLANG_TIDY_FIX=1

And then we run just one check, modernize-deprecated-headers. The second commit in the PR is the results, changing all the stray includes of old C style headers into their proper C++ names.

I did not make these changes by hand, I just used `clang-tide -fix`!

Moving forward, I'll tackle other checks one by one (and, if I agree with them, submit the changes).
