### PR TITLE
clang-tidy fixes: include headers in analysys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,8 @@ ifneq (${CLANG_TIDY_ARGS},)
 endif
 ifneq (${CLANG_TIDY_FIX},)
   MY_CMAKE_FLAGS += -DCLANG_TIDY_FIX:BOOL=${CLANG_TIDY_FIX}
+  MY_NINJA_FLAGS += -j 1
+  # N.B. when fixing, you don't want parallel jobs!
 endif
 
 ifneq (${USE_FREETYPE},)

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -281,7 +281,7 @@ endif ()
 
 # clang-tidy options
 if (CLANG_TIDY)
-    set (CMAKE_CXX_CLANG_TIDY "clang-tidy")
+    set (CMAKE_CXX_CLANG_TIDY "clang-tidy;-header-filter=OpenImageIO/*.h")
     if (CLANG_TIDY_ARGS)
         set (CMAKE_CXX_CLANG_TIDY "${CMAKE_CXX_CLANG_TIDY};${CLANG_TIDY_ARGS}")
     endif ()


### PR DESCRIPTION
The first review of clang-tidy support neglected to use the --header-filter=
command, thus excluding headers from analysys.

Also, when tidying headers, if you use -fix, it's very important to
ensure that only one module is compiled at a time, or two processes
might try to modify a header at the same time, garbling it.
