### PR TITLE
More deprecated header fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project (OpenImageIO
          VERSION 1.8.4
          LANGUAGES CXX C)
 set (PROJ_NAME OIIO)    # short name
+string (TOLOWER ${PROJ_NAME} PROJ_NAME_LOWER)  # short name lower case
 set (PROJECT_VERSION_RELEASE_TYPE "dev")   # "dev", "betaX", "RCY", ""
 set (${PROJECT_NAME}_VERSION_RELEASE_TYPE ${PROJECT_VERSION_RELEASE_TYPE})
 set (PROJECT_COPYRIGHTYEARS "2008-2017")

--- a/src/cineon.imageio/libcineon/CineonHeader.h
+++ b/src/cineon.imageio/libcineon/CineonHeader.h
@@ -50,7 +50,7 @@
    typedef __int64 int64_t;
    typedef unsigned __int64 uint64_t;
 #else
-# include <stdint.h>
+# include <cstdint>
 #endif
 
 #include "CineonStream.h"

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -281,7 +281,7 @@ endif ()
 
 # clang-tidy options
 if (CLANG_TIDY)
-    set (CMAKE_CXX_CLANG_TIDY "clang-tidy;-header-filter=OpenImageIO/*.h")
+    set (CMAKE_CXX_CLANG_TIDY "clang-tidy;-header-filter=(${PROJECT_NAME})|(${PROJ_NAME})|(${PROJ_NAME_LOWER})|(_pvt.h)")
     if (CLANG_TIDY_ARGS)
         set (CMAKE_CXX_CLANG_TIDY "${CMAKE_CXX_CLANG_TIDY};${CLANG_TIDY_ARGS}")
     endif ()

--- a/src/gif.imageio/gif.h
+++ b/src/gif.imageio/gif.h
@@ -55,9 +55,9 @@ For more information, please refer to <http://unlicense.org>
 #ifndef gif_h
 #define gif_h
 
-#include <stdio.h>   // for FILE*
-#include <string.h>  // for memcpy and bzero
-#include <stdint.h>  // for integer typedefs
+#include <cstdio>   // for FILE*
+#include <cstring>  // for memcpy and bzero
+#include <cstdint>  // for integer typedefs
 
 // Define these macros to hook into a custom memory allocator.
 // TEMP_MALLOC and TEMP_FREE will only be called in stack fashion - frees in the reverse order of mallocs

--- a/src/hdr.imageio/rgbe.h
+++ b/src/hdr.imageio/rgbe.h
@@ -8,7 +8,7 @@
    See rgbe.txt file for more details.
 */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <OpenImageIO/imageio.h>
 

--- a/src/include/OpenImageIO/SHA1.h
+++ b/src/include/OpenImageIO/SHA1.h
@@ -94,8 +94,8 @@
 #include <memory.h>
 
 #ifdef SHA1_UTILITY_FUNCTIONS
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #endif
 
 #ifdef SHA1_STL_FUNCTIONS

--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -42,7 +42,7 @@
 #ifndef OPENIMAGEIO_FILESYSTEM_H
 #define OPENIMAGEIO_FILESYSTEM_H
 
-#include <stdint.h>
+#include <cstdint>
 #include <cstdio>
 #include <ctime>
 #include <fstream>

--- a/src/include/OpenImageIO/image_view.h
+++ b/src/include/OpenImageIO/image_view.h
@@ -48,7 +48,7 @@
 #  ifndef __STDC_LIMIT_MACROS
 #    define __STDC_LIMIT_MACROS  /* needed for some defs in stdint.h */
 #  endif
-#  include <stdint.h>
+#  include <cstdint>
 #  if ! defined(INT64_MIN)
 #    error You must define __STDC_LIMIT_MACROS prior to including stdint.h
 #  endif

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -56,7 +56,7 @@
 #  ifndef __STDC_LIMIT_MACROS
 #    define __STDC_LIMIT_MACROS  /* needed for some defs in stdint.h */
 #  endif
-#  include <stdint.h>
+#  include <cstdint>
 #endif
 
 #if defined(__FreeBSD__)

--- a/src/include/OpenImageIO/pugixml.hpp
+++ b/src/include/OpenImageIO/pugixml.hpp
@@ -26,7 +26,7 @@
 #define USING_OIIO_PUGI 1
 
 // Include stddef.h for size_t and ptrdiff_t
-#include <stddef.h>
+#include <cstddef>
 
 // Include exception header for XPath
 #if !defined(PUGIXML_NO_XPATH) && !defined(PUGIXML_NO_EXCEPTIONS)

--- a/src/include/OpenImageIO/sysutil.h
+++ b/src/include/OpenImageIO/sysutil.h
@@ -40,7 +40,7 @@
 #pragma once
 
 #include <string>
-#include <time.h>
+#include <ctime>
 
 #ifdef __MINGW32__
 #include <malloc.h> // for alloca


### PR DESCRIPTION
Be even more thorough with our header name filer -- now get all the "_pvt.h" files, as well as anything with the short and lower case project name in the filename. 

And this finds a handful of additional old headers.
