### PR TITLE
ImageCache stats: don't print files as "broken" if they aren't

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1909,7 +1909,7 @@ ImageCacheImpl::getstats (int level) const
         }
         int nbroken = 0;
         for (const ImageCacheFileRef &file : files) {
-            if (file->broken() || !file->validspec())
+            if (file->broken())
                 ++nbroken;
         }
         out << "  Broken or invalid files: " << nbroken << "\n";
@@ -1917,7 +1917,7 @@ ImageCacheImpl::getstats (int level) const
             std::sort (files.begin(), files.end(), filename_compare);
             int nprinted = 0;
             for (const ImageCacheFileRef &file : files) {
-                if (file->broken() || !file->validspec()) {
+                if (file->broken()) {
                     ++nprinted;
                     out << Strutil::format ("   %4d  %s\n", nprinted, file->filename());
                 }


### PR DESCRIPTION
At the end of the IC/TS stats, there's a list of "broken" files, and what printed there were those files which were either `broken() || !validspec()`.

Two circumstances lead to the spec being not valid, without it being also broken:

(1) Calls to invalidate() mark the spec as invalid, of course! But just because the app invalidated the file (perhaps because it thought the file might be subsequently updated on disk and wanted a fresh look at
it) doesn't mean the file was ever broken.

(2) When the app requests an ImageCacheFile handle up front (as OSL does) but then never opens the file. That also doesn't mean it was broken. You just never read from it.

For both of these circumstances, it's misleading to list the file among those that are known to be broken (presumed corrupted or missing).
