### PR TITLE
Use C++11 vector::emplace_back()

### DIFF
--- a/src/cineon.imageio/cineoninput.cpp
+++ b/src/cineon.imageio/cineoninput.cpp
@@ -141,7 +141,7 @@ CineonInput::open (const std::string &name, ImageSpec &newspec)
                     std::string ch = Strutil::format ("I%d", gscount);
                     m_spec.channelnames.push_back (ch);
                 } else
-                    m_spec.channelnames.push_back ("I");
+                    m_spec.channelnames.emplace_back("I");
                 break;
             case cineon::kPrintingDensityRed:
             case cineon::kRec709Red:
@@ -149,7 +149,7 @@ CineonInput::open (const std::string &name, ImageSpec &newspec)
                     std::string ch = Strutil::format ("R%d", rcount);
                     m_spec.channelnames.push_back (ch);
                 } else
-                    m_spec.channelnames.push_back ("R");
+                    m_spec.channelnames.emplace_back("R");
                 break;
             case cineon::kPrintingDensityGreen:
             case cineon::kRec709Green:
@@ -157,7 +157,7 @@ CineonInput::open (const std::string &name, ImageSpec &newspec)
                     std::string ch = Strutil::format ("G%d", gcount);
                     m_spec.channelnames.push_back (ch);
                 } else
-                    m_spec.channelnames.push_back ("G");
+                    m_spec.channelnames.emplace_back("G");
                 break;
             case cineon::kPrintingDensityBlue:
             case cineon::kRec709Blue:
@@ -165,7 +165,7 @@ CineonInput::open (const std::string &name, ImageSpec &newspec)
                     std::string ch = Strutil::format ("B%d", bcount);
                     m_spec.channelnames.push_back (ch);
                 } else
-                    m_spec.channelnames.push_back ("B");
+                    m_spec.channelnames.emplace_back("B");
                 break;
             default:
                 std::string ch = Strutil::format ("channel%d", (int)m_spec.channelnames.size());

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -210,25 +210,25 @@ DPXInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
         /*case dpx::kUserDefinedDescriptor:
             break;*/
         case dpx::kRed:
-            m_spec.channelnames.push_back("R");
+            m_spec.channelnames.emplace_back("R");
             break;
         case dpx::kGreen:
-            m_spec.channelnames.push_back("G");
+            m_spec.channelnames.emplace_back("G");
             break;
         case dpx::kBlue:
-            m_spec.channelnames.push_back("B");
+            m_spec.channelnames.emplace_back("B");
             break;
         case dpx::kAlpha:
-            m_spec.channelnames.push_back("A");
+            m_spec.channelnames.emplace_back("A");
             m_spec.alpha_channel = 0;
             break;
         case dpx::kLuma:
             // FIXME: do we treat this as intensity or do we use Y' as per
             // convention to differentiate it from linear luminance?
-            m_spec.channelnames.push_back("Y'");
+            m_spec.channelnames.emplace_back("Y'");
             break;
         case dpx::kDepth:
-            m_spec.channelnames.push_back("Z");
+            m_spec.channelnames.emplace_back("Z");
             m_spec.z_channel = 0;
             break;
         /*case dpx::kCompositeVideo:
@@ -240,8 +240,8 @@ DPXInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
             break;
         case dpx::kCbYCrY:
             if (m_wantRaw) {
-                m_spec.channelnames.push_back("CbCr");
-                m_spec.channelnames.push_back("Y");
+                m_spec.channelnames.emplace_back("CbCr");
+                m_spec.channelnames.emplace_back("Y");
             } else {
                 m_spec.nchannels = 3;
                 m_spec.default_channel_names ();
@@ -249,9 +249,9 @@ DPXInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
             break;
         case dpx::kCbYACrYA:
             if (m_wantRaw) {
-                m_spec.channelnames.push_back("CbCr");
-                m_spec.channelnames.push_back("Y");
-                m_spec.channelnames.push_back("A");
+                m_spec.channelnames.emplace_back("CbCr");
+                m_spec.channelnames.emplace_back("Y");
+                m_spec.channelnames.emplace_back("A");
                 m_spec.alpha_channel = 2;
             } else {
                 m_spec.nchannels = 4;
@@ -260,18 +260,18 @@ DPXInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
             break;
         case dpx::kCbYCr:
             if (m_wantRaw) {
-                m_spec.channelnames.push_back("Cb");
-                m_spec.channelnames.push_back("Y");
-                m_spec.channelnames.push_back("Cr");
+                m_spec.channelnames.emplace_back("Cb");
+                m_spec.channelnames.emplace_back("Y");
+                m_spec.channelnames.emplace_back("Cr");
             } else
                 m_spec.default_channel_names ();
             break;
         case dpx::kCbYCrA:
             if (m_wantRaw) {
-                m_spec.channelnames.push_back("Cb");
-                m_spec.channelnames.push_back("Y");
-                m_spec.channelnames.push_back("Cr");
-                m_spec.channelnames.push_back("A");
+                m_spec.channelnames.emplace_back("Cb");
+                m_spec.channelnames.emplace_back("Y");
+                m_spec.channelnames.emplace_back("Cr");
+                m_spec.channelnames.emplace_back("A");
                 m_spec.alpha_channel = 3;
             } else {
                 m_spec.default_channel_names ();

--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -79,7 +79,7 @@ static int
 parse_files (int argc, const char *argv[])
 {
     for (int i = 0;  i < argc;  i++)
-        filenames.push_back (argv[i]);
+        filenames.emplace_back(argv[i]);
     return 0;
 }
 

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -84,7 +84,7 @@ static int
 parse_files (int argc, const char *argv[])
 {
     for (int i = 0;  i < argc;  i++)
-        filenames.push_back (argv[i]);
+        filenames.emplace_back(argv[i]);
     return 0;
 }
 

--- a/src/igrep/igrep.cpp
+++ b/src/igrep/igrep.cpp
@@ -152,7 +152,7 @@ parse_files (int argc, const char *argv[])
         if (pattern.empty())
             pattern = argv[i];
         else
-            filenames.push_back (argv[i]);
+            filenames.emplace_back(argv[i]);
     }
     return 0;
 }

--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -633,7 +633,7 @@ static int
 parse_files (int argc, const char *argv[])
 {
     for (int i = 0;  i < argc;  i++)
-        filenames.push_back (argv[i]);
+        filenames.emplace_back(argv[i]);
     return 0;
 }
 

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -161,7 +161,7 @@ IvGL::create_textures (void)
 
     // Initialize texture objects
     for (int i = 0; i < total_texbufs; i++) {
-        m_texbufs.push_back (TexBuffer());
+        m_texbufs.emplace_back();
         glBindTexture (GL_TEXTURE_2D, textures[i]);
         GLERRPRINT ("bind tex");
         glTexImage2D (GL_TEXTURE_2D, 0 /*mip level*/,

--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -67,7 +67,7 @@ static int
 parse_files (int argc, const char *argv[])
 {
     for (int i = 0;  i < argc;  i++)
-        filenames.push_back (argv[i]);
+        filenames.emplace_back(argv[i]);
     return 0;
 }
 

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -76,7 +76,7 @@ public:
     ~Impl() { }
     void inventory ();
     void add (const std::string &name, int index) {
-        colorspaces.push_back (std::pair<std::string,int> (name, index));
+        colorspaces.emplace_back(name, index);
     }
 };
 

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -185,18 +185,18 @@ ImageSpec::default_channel_names ()
     alpha_channel = -1;
     z_channel = -1;
     if (nchannels == 1) {   // Special case: 1-channel is named "Y"
-        channelnames.push_back ("Y");
+        channelnames.emplace_back("Y");
         return;
     }
     // General case: name channels R, G, B, A, channel4, channel5, ...
     if (nchannels >= 1)
-        channelnames.push_back ("R");
+        channelnames.emplace_back("R");
     if (nchannels >= 2)
-        channelnames.push_back ("G");
+        channelnames.emplace_back("G");
     if (nchannels >= 3)
-        channelnames.push_back ("B");
+        channelnames.emplace_back("B");
     if (nchannels >= 4) {
-        channelnames.push_back ("A");
+        channelnames.emplace_back("A");
         alpha_channel = 3;
     }
     for (int c = 4;  c < nchannels;  ++c)
@@ -948,7 +948,7 @@ get_channelnames (const xml_node &n, std::vector<std::string> &channelnames)
 
     for (xml_node n = channel_node.child ("channelname"); n;
             n = n.next_sibling ("channelname")) {
-        channelnames.push_back (n.child_value ());
+        channelnames.emplace_back(n.child_value ());
     }
 }
 

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -797,8 +797,8 @@ ImageBufAlgo::fft (ImageBuf &dst, const ImageBuf &src,
     spec.channelformats.clear();
     spec.nchannels = 2;
     spec.channelnames.clear();
-    spec.channelnames.push_back ("real");
-    spec.channelnames.push_back ("imag");
+    spec.channelnames.emplace_back("real");
+    spec.channelnames.emplace_back("imag");
 
     // And a spec that describes the transposed intermediate
     ImageSpec specT = spec;
@@ -873,8 +873,8 @@ ImageBufAlgo::ifft (ImageBuf &dst, const ImageBuf &src,
     spec.channelformats.clear();
     spec.nchannels = 2;
     spec.channelnames.clear();
-    spec.channelnames.push_back ("real");
-    spec.channelnames.push_back ("imag");
+    spec.channelnames.emplace_back("real");
+    spec.channelnames.emplace_back("imag");
 
     // Inverse FFT the rows (into temp buffer B).
     ImageBuf B (spec);
@@ -894,7 +894,7 @@ ImageBufAlgo::ifft (ImageBuf &dst, const ImageBuf &src,
     // imaginary part and go back to a single (real) channel.
     spec.nchannels = 1;
     spec.channelnames.clear ();
-    spec.channelnames.push_back ("R");
+    spec.channelnames.emplace_back("R");
     dst.reset (dst.name(), spec);
     ROI Broi = get_roi(B.spec());
     Broi.chend = 1;
@@ -1052,7 +1052,7 @@ ImageBufAlgo::fillholes_pushpull (ImageBuf &dst, const ImageBuf &src,
     topspec.set_format (TypeDesc::FLOAT);
     ImageBuf *top = new ImageBuf (topspec);
     paste (*top, topspec.x, topspec.y, topspec.z, 0, src);
-    pyramid.push_back (std::shared_ptr<ImageBuf>(top));
+    pyramid.emplace_back(top);
 
     // Construct the rest of the pyramid by successive x/2 resizing and
     // then dividing nonzero alpha pixels by their alpha (this "spreads
@@ -1065,7 +1065,7 @@ ImageBufAlgo::fillholes_pushpull (ImageBuf &dst, const ImageBuf &src,
         ImageBuf *small = new ImageBuf (smallspec);
         ImageBufAlgo::resize (*small, *pyramid.back(), "triangle");
         divide_by_alpha (*small, get_roi(smallspec), nthreads);
-        pyramid.push_back (std::shared_ptr<ImageBuf>(small));
+        pyramid.emplace_back(small);
         //debug small->save();
     }
 

--- a/src/libOpenImageIO/imagebufalgo_deep.cpp
+++ b/src/libOpenImageIO/imagebufalgo_deep.cpp
@@ -222,7 +222,7 @@ ImageBufAlgo::deepen (ImageBuf &dst, const ImageBuf &src, float zvalue,
     if (add_z_channel) {
         // No z channel? Make one.
         force_spec.z_channel = force_spec.nchannels++;
-        force_spec.channelnames.push_back ("Z");
+        force_spec.channelnames.emplace_back("Z");
     }
 
     if (! IBAprep (roi, &dst, &src, NULL, &force_spec,

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -643,11 +643,11 @@ resolve_font (int fontsize, string_view font_, std::string &result)
         string_view systemRoot = Sysutil::getenv ("SystemRoot");
         if (systemRoot.size())
             font_search_dirs.push_back (std::string(systemRoot) + "/Fonts");
-        font_search_dirs.push_back ("/usr/share/fonts");
-        font_search_dirs.push_back ("/Library/Fonts");
-        font_search_dirs.push_back ("C:/Windows/Fonts");
-        font_search_dirs.push_back ("/usr/local/share/fonts");
-        font_search_dirs.push_back ("/opt/local/share/fonts");
+        font_search_dirs.emplace_back ("/usr/share/fonts");
+        font_search_dirs.emplace_back ("/Library/Fonts");
+        font_search_dirs.emplace_back ("C:/Windows/Fonts");
+        font_search_dirs.emplace_back ("/usr/local/share/fonts");
+        font_search_dirs.emplace_back ("/opt/local/share/fonts");
         // Try $OPENIMAGEIOHOME/fonts
         string_view oiiohomedir = Sysutil::getenv ("OPENIMAGEIOHOME");
         if (oiiohomedir.size())

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -67,7 +67,7 @@ static float cache_size = 0;
 static int
 parse_files (int argc, const char *argv[])
 {
-    input_filename.push_back (ustring(argv[0]));
+    input_filename.emplace_back(argv[0]);
     return 0;
 }
 

--- a/src/libOpenImageIO/xmp.cpp
+++ b/src/libOpenImageIO/xmp.cpp
@@ -218,7 +218,7 @@ add_attrib (ImageSpec &spec, const char *xmlname, const char *xmlvalue)
                 dup |= (xmlvalue == std::string(*(const char **)p->data()));
             }
             if (! dup)
-                items.push_back (xmlvalue);
+                items.emplace_back (xmlvalue);
             val = Strutil::join (items, "; ");
         } else {
             val = xmlvalue;
@@ -415,7 +415,7 @@ gather_xmp_attribs (const ImageSpec &spec,
             }
             std::string s = stringize (p,xmptag[i]);
             if (s.size()) {
-                list.push_back (std::pair<int,std::string>(i, s));
+                list.emplace_back (i, s);
                 //std::cerr << "  " << xmptag[i].xmpname << " = " << s << "\n"; 
             }
         }

--- a/src/libutil/argparse.cpp
+++ b/src/libutil/argparse.cpp
@@ -311,7 +311,7 @@ ArgOption::invoke_callback () const
 void
 ArgOption::add_argument (const char *argv)
 {
-    m_argv.push_back (argv);
+    m_argv.emplace_back(argv);
 }
 
 

--- a/src/libutil/filesystem_test.cpp
+++ b/src/libutil/filesystem_test.cpp
@@ -239,7 +239,7 @@ test_file_seq_with_view (const char *pattern, const char *override, const char *
 
     if (view) {
         for (size_t i = 0, e = numbers.size(); i < e; ++i)
-            views.push_back(view);
+            views.emplace_back(view);
     }
 
     Filesystem::enumerate_file_sequence (normalized_pattern, numbers, views, names);
@@ -290,7 +290,7 @@ test_scan_file_seq_with_views (const char *pattern, const char **views_, const s
     std::vector<string_view> views;
 
     for (size_t i = 0; views_[i]; ++i)
-        views.push_back(views_[i]);
+        views.emplace_back(views_[i]);
 
     Filesystem::parse_pattern(pattern, 0, normalized_pattern, frame_range);
     Filesystem::scan_for_matching_filenames (normalized_pattern, views, frame_numbers, frame_views, frame_names);

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -280,10 +280,10 @@ void test_split ()
 void test_join ()
 {
     std::vector<std::string> seq;
-    seq.push_back ("Now");
-    seq.push_back ("is");
-    seq.push_back ("the");
-    seq.push_back ("time");
+    seq.emplace_back("Now");
+    seq.emplace_back("is");
+    seq.emplace_back("the");
+    seq.emplace_back("time");
     OIIO_CHECK_EQUAL (Strutil::join (seq, ". "),
                       "Now. is. the. time");
 }

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -133,7 +133,7 @@ static int
 parse_files (int argc, const char *argv[])
 {
     for (int i = 0;  i < argc;  i++)
-        filenames.push_back (argv[i]);
+        filenames.emplace_back(argv[i]);
     return 0;
 }
 

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -811,7 +811,7 @@ OpenEXRInput::PartInfo::query_channels (const Imf::Header *header)
     int c = 0;
     for (Imf::ChannelList::ConstIterator ci = channels.begin();
          ci != channels.end();  ++c, ++ci) {
-        cnh.push_back (ChanNameHolder (ci.name(), c, ci.channel().type));
+        cnh.emplace_back (ci.name(), c, ci.channel().type);
         ++spec.nchannels;
     }
     std::sort (cnh.begin(), cnh.end(), ChanNameHolder::compare_cnh);

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -1068,8 +1068,8 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
                     return true;
                 case TypeDesc::STRING:
                     Imf::StringVector v;
-                    v.push_back(((const char **)data)[0]);
-                    v.push_back(((const char **)data)[1]);
+                    v.emplace_back(((const char **)data)[0]);
+                    v.emplace_back(((const char **)data)[1]);
                     header.insert (xname.c_str(), Imf::StringVectorAttribute (v));
                     return true;
 #endif
@@ -1091,9 +1091,9 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
                     return true;
                 case TypeDesc::STRING:
                     Imf::StringVector v;
-                    v.push_back(((const char **)data)[0]);
-                    v.push_back(((const char **)data)[1]);
-                    v.push_back(((const char **)data)[2]);
+                    v.emplace_back(((const char **)data)[0]);
+                    v.emplace_back(((const char **)data)[1]);
+                    v.emplace_back(((const char **)data)[2]);
                     header.insert (xname.c_str(), Imf::StringVectorAttribute (v));
                     return true;
 #endif
@@ -1231,7 +1231,7 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
         if (type.basetype == TypeDesc::STRING) {
             Imf::StringVector v;
             for (int i=0; i<type.arraylen; i++) {
-                v.push_back(((const char **)data)[i]);
+                v.emplace_back(((const char **)data)[i]);
             }
             header.insert (xname.c_str(), Imf::StringVectorAttribute (v));
             return true;

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -1508,7 +1508,7 @@ PSDInput::load_layer (Layer &layer)
 
     extra_remaining -= read_pascal_string(layer.name, 4);
     while (m_file && extra_remaining >= 12) {
-        layer.additional_info.push_back (Layer::AdditionalInfo());
+        layer.additional_info.emplace_back();
         Layer::AdditionalInfo &info = layer.additional_info.back();
 
         char signature[4];
@@ -1781,8 +1781,8 @@ PSDInput::setup ()
     }
 
     // Composite spec
-    m_specs.push_back (ImageSpec (m_header.width, m_header.height,
-                                  spec_channel_count, m_type_desc));
+    m_specs.emplace_back (m_header.width, m_header.height,
+                          spec_channel_count, m_type_desc);
     m_specs.back().extra_attribs = m_composite_attribs.extra_attribs;
     if (m_WantRaw)
         fill_channel_names (m_specs.back(), m_image_data.transparency);
@@ -1802,8 +1802,8 @@ PSDInput::setup ()
             spec_channel_count++;
             raw_channel_count++;
         }
-        m_specs.push_back (ImageSpec (layer.width, layer.height,
-                                      spec_channel_count, m_type_desc));
+        m_specs.emplace_back (layer.width, layer.height,
+                              spec_channel_count, m_type_desc);
         ImageSpec &spec = m_specs.back ();
         spec.extra_attribs = m_common_attribs.extra_attribs;
         if (m_WantRaw)
@@ -1834,9 +1834,9 @@ PSDInput::fill_channel_names (ImageSpec &spec, bool transparency)
         spec.default_channel_names ();
     } else {
         for (unsigned int i = 0; i < mode_channel_count[m_header.color_mode]; ++i)
-            spec.channelnames.push_back (mode_channel_names[m_header.color_mode][i]);
+            spec.channelnames.emplace_back(mode_channel_names[m_header.color_mode][i]);
         if (transparency)
-            spec.channelnames.push_back ("A");
+            spec.channelnames.emplace_back("A");
     }
 }
 

--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -194,7 +194,7 @@ oiio_attribute_typed (const std::string &name, TypeDesc type, object &obj)
         if (vals.size() == type.numelements()*type.aggregate) {
             std::vector<ustring> u;
             for (size_t i = 0, e = vals.size(); i < e; ++i)
-                u.push_back (ustring(vals[i]));
+                u.emplace_back(vals[i]);
             return OIIO::attribute (name, type, &u[0]);
         }
         return false;
@@ -228,7 +228,7 @@ oiio_attribute_tuple_typed (const std::string &name,
         if (vals.size() == type.numelements()*type.aggregate) {
             std::vector<ustring> u;
             for (size_t i = 0, e = vals.size(); i < e; ++i)
-                u.push_back (ustring(vals[i]));
+                u.emplace_back(vals[i]);
             return OIIO::attribute (name, type, &u[0]);
         }
         return false;

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -172,7 +172,7 @@ attribute_typed (T &myobj, string_view name, TypeDesc type, object &dataobj)
         if (vals.size() == type.numelements()*type.aggregate) {
             std::vector<ustring> u;
             for (size_t i = 0, e = vals.size(); i < e; ++i)
-                u.push_back (ustring(vals[i]));
+                u.emplace_back(vals[i]);
             myobj.attribute (name, type, &u[0]);
         }
         return;
@@ -207,7 +207,7 @@ attribute_tuple_typed (T &myobj, string_view name,
         if (vals.size() == type.numelements()*type.aggregate) {
             std::vector<ustring> u;
             for (size_t i = 0, e = vals.size(); i < e; ++i)
-                u.push_back (ustring(vals[i]));
+                u.emplace_back(vals[i]);
             myobj.attribute (name, type, &u[0]);
         }
         return;

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -261,7 +261,7 @@ RawInput::open (const std::string &name, ImageSpec &newspec,
             m_spec.height = m_processor.imgdata.sizes.raw_height;
             m_spec.nchannels = 1;
             m_spec.channelnames.clear();
-            m_spec.channelnames.push_back("R");
+            m_spec.channelnames.emplace_back("R");
 
             // Also, any previously set demosaicing options are void, so remove them
             m_spec.erase_attribute("oiio:Colorspace");

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -120,7 +120,7 @@ static int
 parse_files (int argc, const char *argv[])
 {
     for (int i = 0;  i < argc;  i++)
-        filenames.push_back (ustring(argv[i]));
+        filenames.emplace_back(argv[i]);
     return 0;
 }
 

--- a/src/zfile.imageio/zfile.cpp
+++ b/src/zfile.imageio/zfile.cpp
@@ -194,7 +194,7 @@ ZfileInput::open (const std::string &name, ImageSpec &newspec)
 
     m_spec = ImageSpec (header.width, header.height, 1, TypeDesc::FLOAT);
     if (m_spec.channelnames.size() == 0)
-        m_spec.channelnames.push_back ("z");
+        m_spec.channelnames.emplace_back("z");
     else
         m_spec.channelnames[0] = "z";
     m_spec.z_channel = 0;


### PR DESCRIPTION
Using vector::push_back when constructing a new object can cause
extra copies or allocations/deallocations. The new (C++11) emplace_back
grows the vector first and then constructs the object in place, avoiding
any unnecessary moves, copies, or allocations.

Thanks, clang-tidy, for finding all of these for us with no hassle.
