### PR TITLE
Fix Windows warnings (simd and bool/int)

### DIFF
--- a/src/cineon.imageio/libcineon/InStream.cpp
+++ b/src/cineon.imageio/libcineon/InStream.cpp
@@ -96,7 +96,7 @@ bool InStream::Seek(long offset, Origin origin)
 	}
 
 	if (this->fp == 0)
-		return -1;
+		return false;
 	return (::fseek(this->fp, offset, o) == 0);
 }
 

--- a/src/cineon.imageio/libcineon/OutStream.cpp
+++ b/src/cineon.imageio/libcineon/OutStream.cpp
@@ -97,7 +97,7 @@ bool OutStream::Seek(long offset, Origin origin)
 	}
 
 	if (this->fp == 0)
-		return -1;
+		return false;
 	return (::fseek(this->fp, offset, o) == 0);
 }
 

--- a/src/dpx.imageio/libdpx/InStream.cpp
+++ b/src/dpx.imageio/libdpx/InStream.cpp
@@ -95,7 +95,7 @@ bool InStream::Seek(long offset, Origin origin)
 	}
 	
 	if (this->fp == 0)
-		return -1;
+		return false;
 	return (::fseek(this->fp, offset, o) == 0);
 }
 

--- a/src/dpx.imageio/libdpx/OutStream.cpp
+++ b/src/dpx.imageio/libdpx/OutStream.cpp
@@ -95,7 +95,7 @@ bool OutStream::Seek(long offset, Origin origin)
 	}
 	
 	if (this->fp == 0)
-		return -1;
+		return false;
 	return (::fseek(this->fp, offset, o) == 0);
 }
 

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -251,7 +251,7 @@ inline float sRGB_to_linear (float x)
                            : powf ((x + 0.055f) * (1.0f / 1.055f), 2.4f);
 }
 
-inline simd::float4 sRGB_to_linear (simd::float4 x)
+inline simd::float4 sRGB_to_linear (const simd::float4& x)
 {
     return simd::select (x <= 0.04045f, x * (1.0f/12.92f),
                          fast_pow_pos (madd (x, (1.0f / 1.055f), 0.055f*(1.0f/1.055f)), 2.4f));
@@ -266,7 +266,7 @@ inline float linear_to_sRGB (float x)
 
 
 /// Utility -- convert linear value to sRGB
-inline simd::float4 linear_to_sRGB (simd::float4 x)
+inline simd::float4 linear_to_sRGB (const simd::float4& x)
 {
     // x = simd::max (x, simd::float4::Zero());
     return simd::select (x <= 0.0031308f, 12.92f * x,

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -217,7 +217,7 @@ OIIO_FORCEINLINE uint64_t rotl64 (uint64_t x, int k) {
 /// clamp a to bounds [low,high].
 template <class T>
 inline T
-clamp (T a, T low, T high)
+clamp (const T& a, const T& low, const T& high)
 {
     return (a >= low) ? ((a <= high) ? a : high) : low;
 }
@@ -225,13 +225,13 @@ clamp (T a, T low, T high)
 
 // Specialization of clamp for float4
 template<> inline simd::float4
-clamp (simd::float4 a, simd::float4 low, simd::float4 high)
+clamp (const simd::float4& a, const simd::float4& low, const simd::float4& high)
 {
     return simd::min (high, simd::max (low, a));
 }
 
 template<> inline simd::float8
-clamp (simd::float8 a, simd::float8 low, simd::float8 high)
+clamp (const simd::float8& a, const simd::float8& low, const simd::float8& high)
 {
     return simd::min (high, simd::max (low, a));
 }

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -677,7 +677,7 @@ public:
     const int4 & operator= (int a);
 
     /// Assignment from another int4
-    const int4 & operator= (int4 other) ;
+    const int4 & operator= (const int4& other) ;
 
     /// Component access (set)
     int& operator[] (int i) ;
@@ -920,7 +920,7 @@ public:
     const int8 & operator= (int a);
 
     /// Assignment from another int8
-    const int8 & operator= (int8 other) ;
+    const int8 & operator= (const int8& other) ;
 
     /// Component access (set)
     int& operator[] (int i) ;
@@ -2226,7 +2226,7 @@ OIIO_FORCEINLINE bool reduce_and (const bool4& v) {
 #elif OIIO_SIMD_SSE
     return _mm_movemask_ps(v.simd()) == 0xf;
 #else
-    SIMD_RETURN_REDUCE (bool, true, r &= v[i]);
+    SIMD_RETURN_REDUCE (bool, true, r &= (v[i] != 0));
 #endif
 }
 
@@ -2236,7 +2236,7 @@ OIIO_FORCEINLINE bool reduce_or (const bool4& v) {
 #elif OIIO_SIMD_SSE
     return _mm_movemask_ps(v) != 0;
 #else
-    SIMD_RETURN_REDUCE (bool, false, r |= v[i]);
+    SIMD_RETURN_REDUCE (bool, false, r |= (v[i] != 0));
 #endif
 }
 
@@ -2534,7 +2534,7 @@ OIIO_FORCEINLINE bool none (const bool8& v) { return reduce_or(v) == false; }
 //////////////////////////////////////////////////////////////////////
 // int4 implementation
 
-OIIO_FORCEINLINE const int4 & int4::operator= (int4 other) {
+OIIO_FORCEINLINE const int4 & int4::operator= (const int4& other) {
     m_simd = other.m_simd;
     return *this;
 }
@@ -3228,7 +3228,7 @@ OIIO_FORCEINLINE bool4::bool4 (const int4& ival) {
 //////////////////////////////////////////////////////////////////////
 // int8 implementation
 
-OIIO_FORCEINLINE const int8 & int8::operator= (int8 other) {
+OIIO_FORCEINLINE const int8 & int8::operator= (const int8& other) {
     m_simd = other.m_simd;
     return *this;
 }

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1345,7 +1345,7 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
         if ((resize_filter == "box" || resize_filter == "triangle")
             && !orig_was_overscan) {
             ImageBufAlgo::parallel_image (get_roi(dstspec),
-                                          std::bind(resize_block, std::ref(*toplevel), std::cref(*src), _1, envlatlmode, allow_shift));
+                                          std::bind(resize_block, std::ref(*toplevel), std::cref(*src), _1, envlatlmode, allow_shift != 0));
         } else {
             Filter2D *filter = setup_filter (toplevel->spec(), src->spec(), resize_filter);
             if (! filter) {


### PR DESCRIPTION
Submitted on behalf of Ray Molenkamp (diff sent to me via email):

1. Fix several instances where int was passed or returned where a bool was expected, resulting in warnings on Windows.

2. Change places were simd types were passed to functions by value -- which apparently MSVS is not happy about because it can't guarantee alignment on the stack -- with pass by const value ref. Should be harmless, I think all the functions in question are inline anyway.
