### PR TITLE
Fix ustring issue flagged by ubsan

### DIFF
--- a/src/libutil/ustring.cpp
+++ b/src/libutil/ustring.cpp
@@ -164,6 +164,9 @@ private:
     }
 
     char* pool_alloc(size_t len) {
+        // round up to nearest multiple of pointer size to guarentee proper alignment of TableRep objects
+        len = (len + alignof(ustring::TableRep) - 1) & ~(alignof(ustring::TableRep) - 1);
+
         if (len >= POOL_SIZE) {
             memory_usage += len;
             return (char*) malloc(len); // no need to try and use the pool


### PR DESCRIPTION
Pad the length of pool allocations for ustring::TableRep so that the next one allocated will also be aligned.

This was noticed by the undefined behavior sanitizer.

I don't think this was causing any issues, but its an easy fix that doesn't cost too much.