### PR TITLE
EXR input: Fix to canonical sorting order -- typo bug fix

### DIFF
--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -771,7 +771,8 @@ struct ChanNameHolder {
         }
         static const char * special[] = {
             "R", "Red", "G", "Green", "B", "Blue", "real", "imag",
-            "A", "Alpha", "RA", "RG", "RB", "Z", "Depth", "Zback", NULL
+            "A", "Alpha", "AR", "RA", "AG", "GA", "AB", "BA",
+            "Z", "Depth", "Zback", NULL
         };
         special_index = 10000;
         for (int i = 0; special[i]; ++i)


### PR DESCRIPTION
A finger malfunction ages ago botched the list of channel names that
help us sort channels into canonical order. Where I wanted to say
RA, GA, BA, somehow I said RA, RG, RB. Oh boy.
