### PR TITLE
intrusive_ptr bug fix

### DIFF
--- a/src/include/OpenImageIO/refcnt.h
+++ b/src/include/OpenImageIO/refcnt.h
@@ -98,9 +98,11 @@ public:
 
     /// Reset to point to a pointer
     void reset (T *r) {
-        if (m_ptr) intrusive_ptr_release (m_ptr);
-        m_ptr = r;
-        if (m_ptr) intrusive_ptr_add_ref (m_ptr);
+        if (r != m_ptr) {
+            if (r) intrusive_ptr_add_ref (r);
+            if (m_ptr) intrusive_ptr_release (m_ptr);
+            m_ptr = r;
+        }
     }
 
     /// Swap intrusive pointers


### PR DESCRIPTION
I realized that if `intrusive_ptr<T>::reset(T*)` is called with a pointer
to the same object it already refers to, it could be erroneously freed
because it was decrementing the existing refcnt before incrementing the
refcnt of the new value. So rewrote reset() to be safe under that
circumstance.
