### PR TITLE
Deprecate OIIO_CONSTEXPR, OIIO_CONSTEXPR_OR_CONST, OIIO_NOEXCEPT

### DIFF
--- a/src/include/OpenImageIO/array_view.h
+++ b/src/include/OpenImageIO/array_view.h
@@ -78,7 +78,7 @@ class array_view {
 public:
     // using iterator        = bounds_iterator<Rank>;
     // using const_iterator  = bounds_iterator<Rank>;
-    static OIIO_CONSTEXPR_OR_CONST size_t rank = Rank;
+    static constexpr size_t rank = Rank;
     using offset_type     = offset<Rank>;
     using bounds_type     = OIIO::bounds<Rank>;
     using stride_type     = offset<Rank>;
@@ -135,13 +135,13 @@ public:
         return *this;
     }
 
-    OIIO_CONSTEXPR bounds_type bounds() const OIIO_NOEXCEPT {
+    constexpr bounds_type bounds() const noexcept {
         return m_bounds;
     }
-    OIIO_CONSTEXPR14 size_type size() const OIIO_NOEXCEPT {
+    OIIO_CONSTEXPR14 size_type size() const noexcept {
         return m_bounds.size();
     }
-    OIIO_CONSTEXPR14 offset_type stride() const OIIO_NOEXCEPT {
+    OIIO_CONSTEXPR14 offset_type stride() const noexcept {
         if (Rank == 1) {
             return offset_type(1);
         } else {
@@ -152,9 +152,9 @@ public:
             return offset;
         }
     }
-    OIIO_CONSTEXPR pointer data() const OIIO_NOEXCEPT { return m_data; }
+    constexpr pointer data() const noexcept { return m_data; }
 
-    OIIO_CONSTEXPR T& operator[] (offset_type idx) const {
+    constexpr T& operator[] (offset_type idx) const {
         return VIEW_ACCESS(data(), idx, stride(), Rank);
     }
     T& at (offset_type idx) const {  // FIXME -- should be offset_type
@@ -192,7 +192,7 @@ class array_view_strided {
     OIIO_STATIC_ASSERT (Rank >= 1);
     OIIO_STATIC_ASSERT (std::is_array<T>::value == false);
 public:
-    static OIIO_CONSTEXPR_OR_CONST size_t rank = Rank;
+    static constexpr size_t rank = Rank;
     using offset_type     = offset<Rank>;
     using bounds_type     = OIIO::bounds<Rank>;
     using stride_type     = offset<Rank>;
@@ -260,7 +260,7 @@ public:
     size_type size() const { return m_bounds.size(); }
     stride_type stride() const { return m_stride; }
 
-    OIIO_CONSTEXPR T& operator[] (size_type idx) const {
+    constexpr T& operator[] (size_type idx) const {
         return VIEW_ACCESS(data(), idx, stride(), Rank);
     }
     const T& at (size_t idx) const {

--- a/src/include/OpenImageIO/coordinate.h
+++ b/src/include/OpenImageIO/coordinate.h
@@ -57,24 +57,24 @@ class offset {
     OIIO_STATIC_ASSERT (Rank >= 1);
 public:
     // constants and types
-    static OIIO_CONSTEXPR_OR_CONST size_t rank = Rank;
+    static constexpr size_t rank = Rank;
     using reference           = ptrdiff_t&;
     using const_reference     = const ptrdiff_t&;
     using size_type           = size_t;
     using value_type          = ptrdiff_t;
 
     /// Default constructor
-    OIIO_CONSTEXPR14 offset() OIIO_NOEXCEPT {
+    OIIO_CONSTEXPR14 offset() noexcept {
         std::fill (m_ind+0, m_ind+Rank, 0);
     }
     /// Constructor for 1D case
-    OIIO_CONSTEXPR14 offset (value_type v) OIIO_NOEXCEPT {
+    OIIO_CONSTEXPR14 offset (value_type v) noexcept {
         DASSERT (Rank == 1);
         m_ind[0] = v;
         std::fill (m_ind+1, m_ind+Rank, 1);
     }
     /// Constructor for 2D case
-    OIIO_CONSTEXPR14 offset (value_type v0, value_type v1) OIIO_NOEXCEPT {
+    OIIO_CONSTEXPR14 offset (value_type v0, value_type v1) noexcept {
         DASSERT (Rank == 2);
         m_ind[0] = v0;
         m_ind[1] = v1;
@@ -88,11 +88,11 @@ public:
     }
 
     /// Equality test.
-    OIIO_CONSTEXPR bool operator== (const offset& rhs) const OIIO_NOEXCEPT {
+    constexpr bool operator== (const offset& rhs) const noexcept {
         return std::equal (m_ind+0, m_ind+Rank, rhs.m_ind+0);
     }
     /// Inequality test.
-    OIIO_CONSTEXPR bool operator!= (const offset& rhs) const OIIO_NOEXCEPT {
+    constexpr bool operator!= (const offset& rhs) const noexcept {
         return ! (*this == rhs);
     }
 
@@ -153,7 +153,7 @@ public:
         return ret;
     }
 
-    OIIO_CONSTEXPR offset operator+ () const OIIO_NOEXCEPT { return *this; }
+    constexpr offset operator+ () const noexcept { return *this; }
     OIIO_CONSTEXPR14 offset operator- () const {
         offset result;
         for (size_t i = 0; i < Rank; ++i)
@@ -204,7 +204,7 @@ class bounds {
     OIIO_STATIC_ASSERT (Rank >= 1);
 public:
     // constants and types
-    static OIIO_CONSTEXPR_OR_CONST size_t rank = Rank;
+    static constexpr size_t rank = Rank;
     using reference           = ptrdiff_t&;
     using const_reference     = const ptrdiff_t&;
     using size_type           = size_t;
@@ -213,7 +213,7 @@ public:
     using const_iterator      = bounds_iterator<Rank>;
 
     /// Default constructor
-    OIIO_CONSTEXPR14 bounds() OIIO_NOEXCEPT {
+    OIIO_CONSTEXPR14 bounds() noexcept {
         std::fill (m_bnd+0, m_bnd+Rank, 0);
     }
     /// Constructor for 1D case
@@ -236,13 +236,13 @@ public:
         std::copy (il.begin(), il.end(), m_bnd+0);
     }
 
-    OIIO_CONSTEXPR14 size_type size() const OIIO_NOEXCEPT {
+    OIIO_CONSTEXPR14 size_type size() const noexcept {
         size_type r = m_bnd[0];
         for (size_t i = 1; i < Rank; ++i)
             r *= m_bnd[i];
         return r;
     }
-    OIIO_CONSTEXPR14 bool contains(const offset<Rank>& idx) const OIIO_NOEXCEPT {
+    OIIO_CONSTEXPR14 bool contains(const offset<Rank>& idx) const noexcept {
         for (size_t i = 0; i < Rank; ++i)
             if (idx[i] < 0 || idx[i] > m_bnd[i])
                 return false;
@@ -250,20 +250,20 @@ public:
     }
 
     /// Equality test.
-    OIIO_CONSTEXPR bool operator== (const bounds& rhs) const OIIO_NOEXCEPT {
+    constexpr bool operator== (const bounds& rhs) const noexcept {
         return std::equal (m_bnd+0, m_bnd+Rank, rhs.m_bnd+0);
     }
     /// Inequality test.
-    OIIO_CONSTEXPR bool operator!= (const bounds& rhs) const OIIO_NOEXCEPT {
+    constexpr bool operator!= (const bounds& rhs) const noexcept {
         return ! (*this == rhs);
     }
 
     // bounds iterators
-    const_iterator begin() const OIIO_NOEXCEPT {
+    const_iterator begin() const noexcept {
         return const_iterator(*this, offset<Rank>());
     }
     // Return a bounds_iterator that is one-past-the-end of *this.
-    const_iterator end() const OIIO_NOEXCEPT {
+    const_iterator end() const noexcept {
         offset<Rank> off;
         off[0] = m_bnd[0];
         return const_iterator (*this, off);

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -90,11 +90,8 @@
 //
 // OIIO_CPLUSPLUS_VERSION : which C++ standard is compiling (3, 11, 14, ...)
 // OIIO_USING_CPP11 : (deprecated) defined and 1 if using C++11 or newer.
-// OIIO_CONSTEXPR : constexpr for C++ >= 11, otherwise nothing
-// OIIO_CONSTEXPR_OR_CONST : constexpr for C++ >= 11, otherwise const
 // OIIO_CONSTEXPR14 : constexpr for C++ >= 14, otherwise nothing (this is
 //                      useful for things that can only be constexpr for 14)
-// OIIO_NOEXCEPT : noexcept for C++ >= 11, otherwise nothing
 //
 // Note: oiioversion.h defines OIIO_BUILD_CPP11 or OIIO_BUILD_CPP14 to be 1
 // if OIIO itself was built using C++11 or C++14, respectively. In contrast,
@@ -107,21 +104,21 @@
 #if (__cplusplus >= 201402L)
 #  define OIIO_USING_CPP11        1 /* deprecated */
 #  define OIIO_CPLUSPLUS_VERSION  14
-#  define OIIO_CONSTEXPR          constexpr
-#  define OIIO_CONSTEXPR_OR_CONST constexpr
 #  define OIIO_CONSTEXPR14        constexpr
-#  define OIIO_NOEXCEPT           noexcept
 #elif (__cplusplus >= 201103L) || _MSC_VER >= 1900
 #  define OIIO_USING_CPP11        1 /* deprecated */
 #  define OIIO_CPLUSPLUS_VERSION  11
-#  define OIIO_CONSTEXPR          constexpr
-#  define OIIO_CONSTEXPR_OR_CONST constexpr
 #  define OIIO_CONSTEXPR14        /* not constexpr before C++14 */
-#  define OIIO_NOEXCEPT           noexcept
 #else
 #  error "This version of OIIO is meant to work only with C++11 and above"
 #endif
 
+// DEPRECATED(1.8): use C++11 constexpr
+#define OIIO_CONSTEXPR          constexpr
+#define OIIO_CONSTEXPR_OR_CONST constexpr
+
+// DEPRECATED(1.8): use C++11 noexcept
+#define OIIO_NOEXCEPT noexcept
 
 
 // Fallback definitions for feature testing. Some newer compilers define

--- a/src/include/OpenImageIO/refcnt.h
+++ b/src/include/OpenImageIO/refcnt.h
@@ -58,7 +58,7 @@ public:
     typedef T element_type;
 
     /// Default ctr
-    intrusive_ptr () OIIO_NOEXCEPT : m_ptr(NULL) { }
+    intrusive_ptr () noexcept : m_ptr(NULL) { }
 
     /// Construct from a raw pointer (presumed to be just now allocated,
     /// and now owned by us).
@@ -72,7 +72,7 @@ public:
     }
 
     /// Move construct from another intrusive_ptr.
-    intrusive_ptr (intrusive_ptr &&r) OIIO_NOEXCEPT : m_ptr(r.get()) {
+    intrusive_ptr (intrusive_ptr &&r) noexcept : m_ptr(r.get()) {
         r.m_ptr = NULL;
     }
 
@@ -86,13 +86,13 @@ public:
     }
 
     /// Move assignment from intrusive_ptr
-    intrusive_ptr & operator= (intrusive_ptr&& r) OIIO_NOEXCEPT {
+    intrusive_ptr & operator= (intrusive_ptr&& r) noexcept {
         intrusive_ptr (static_cast<intrusive_ptr&&>(r)).swap(*this);
         return *this;
     }
 
     /// Reset to null reference
-    void reset () OIIO_NOEXCEPT {
+    void reset () noexcept {
         if (m_ptr) { intrusive_ptr_release (m_ptr); m_ptr = NULL; }
     }
 
@@ -106,7 +106,7 @@ public:
     }
 
     /// Swap intrusive pointers
-    void swap (intrusive_ptr &r) OIIO_NOEXCEPT {
+    void swap (intrusive_ptr &r) noexcept {
         T *tmp = m_ptr; m_ptr = r.m_ptr; r.m_ptr = tmp;
     }
 
@@ -117,10 +117,10 @@ public:
     T* operator->() const { DASSERT (m_ptr); return m_ptr; }
 
     /// Get raw pointer
-    T* get() const OIIO_NOEXCEPT { return m_ptr; }
+    T* get() const noexcept { return m_ptr; }
 
     /// Cast to bool to detect whether it points to anything
-    operator bool () const OIIO_NOEXCEPT { return m_ptr != NULL; }
+    operator bool () const noexcept { return m_ptr != NULL; }
 
 private:
     T* m_ptr;   // the raw pointer


### PR DESCRIPTION
Use C++11 constexpr and noexcept instead.
