### PR TITLE
Remove empty destructors to resolve MSVC warning C4714 

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -346,9 +346,6 @@ public:
     /// Default constructor (contents undefined)
     bool4 () { }
 
-    /// Destructor
-    ~bool4 () { }
-
     /// Construct from a single value (store it in all slots)
     bool4 (bool a) { load(a); }
 
@@ -474,9 +471,6 @@ public:
 
     /// Default constructor (contents undefined)
     bool8 () { }
-
-    /// Destructor
-    ~bool8 () { }
 
     /// Construct from a single value (store it in all slots)
     bool8 (bool a) { load (a); }
@@ -616,9 +610,6 @@ public:
 
     /// Default constructor (contents undefined)
     int4 () { }
-
-    /// Destructor
-    ~int4 () { }
 
     /// Construct from a single value (store it in all slots)
     int4 (int a);
@@ -858,9 +849,6 @@ public:
 
     /// Default constructor (contents undefined)
     int8 () { }
-
-    /// Destructor
-    ~int8 () { }
 
     /// Construct from a single value (store it in all slots)
     int8 (int a);
@@ -1110,9 +1098,6 @@ public:
 
     /// Default constructor (contents undefined)
     float4 () { }
-
-    /// Destructor
-    ~float4 () { }
 
     /// Construct from a single value (store it in all slots)
     float4 (float a) { load(a); }
@@ -1419,9 +1404,6 @@ public:
     /// Default constructor (contents undefined)
     float3 () { }
 
-    /// Destructor
-    ~float3 () { }
-
     /// Construct from a single value (store it in all slots)
     float3 (float a) { load(a); }
 
@@ -1688,9 +1670,6 @@ public:
 
     /// Default constructor (contents undefined)
     float8 () { }
-
-    /// Destructor
-    ~float8 () { }
 
     /// Construct from a single value (store it in all slots)
     float8 (float a) { load(a); }


### PR DESCRIPTION
(C4714  : function marked as __forceinline not inlined)

## Description

Curious bug, MSVC refuses to inline the algorithmic operators in simd.h , but only tells you about it when you turn up the warning level to 4 or higher.  the [msdn docs](https://msdn.microsoft.com/en-us/library/a98sb923.aspx) list a number of reasons why it chooses not to inline a function, but the one that applies in this case is

> Functions returning an unwindable object by value when -GX/EHs/EHa is on.

By having a destructor (even an empty one) msvc deems the object unwindable and will refuse to inline it causing some rather severe performance issues in oiio. (blenders classroom benchmark scene rendered with OSL, reference : 09:15.15, with this fix: 06:49.26 , identical output) 

## Tests

No tests changed, besides a performance difference there's no functional changes.   Only way to really tell the change did anything is enabling assembly output from the compiler and validating it's no longer doing function calls to OpenImageIO::v1_7::simd::operator *

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

