### PR TITLE
Stop using typedefs ImageIOParameter & ImageIOParameterList

### DIFF
--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -205,13 +205,13 @@ BmpOutput::create_and_write_bitmap_header (void)
     m_dib_header.cpalete = 0;
     m_dib_header.important = 0;
 
-    ImageIOParameter *p = NULL;
+    ParamValue *p = NULL;
     p = m_spec.find_attribute ("ResolutionUnit", TypeDesc::STRING);
     if (p && p->data()) {
         std::string res_units = *(char**)p->data ();
         if (Strutil::iequals (res_units, "m") ||
               Strutil::iequals (res_units, "pixel per meter")) {
-            ImageIOParameter *resx = NULL, *resy = NULL;
+            ParamValue *resx = NULL, *resy = NULL;
             resx = m_spec.find_attribute ("XResolution", TypeDesc::INT32);
             if (resx && resx->data())
                 m_dib_header.hres = *(int*)resx->data ();

--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -609,10 +609,10 @@ The name comparison will be case-sensitive if {\cf casesensitive} is true, other
 in a case-insensitive manner if {\cf caseinsensitive} is false.
 \apiend
 
-\apiitem{ImageIOParameter * {\ce find_attribute} (string_view name,\\
+\apiitem{ParamValue * {\ce find_attribute} (string_view name,\\
 \bigspc\bigspc\bigspc                        TypeDesc searchtype=UNKNOWN,\\
 \bigspc\bigspc\bigspc                        bool casesensitive=false)\\
-const ImageIOParameter * {\ce find_attribute} (string_view name,\\
+const ParamValue * {\ce find_attribute} (string_view name,\\
 \bigspc\bigspc\bigspc\spc                     TypeDesc searchtype=UNKNOWN,\\
 \bigspc\bigspc\bigspc\spc                     bool casesensitive=false) const}
 
@@ -624,12 +624,12 @@ The name comparison will be exact if {\cf casesensitive} is true, otherwise
 in a case-insensitive manner if {\cf caseinsensitive} is false.
 \apiend
 
-\apiitem{const ImageIOParameter * {\ce find_attribute} (string_view name,\\
-\bigspc\bigspc\bigspc\spc                     ImageIOParameter \&tmpparam,\\
+\apiitem{const ParamValue * {\ce find_attribute} (string_view name,\\
+\bigspc\bigspc\bigspc\spc                     ParamValue \&tmpparam,\\
 \bigspc\bigspc\bigspc\spc                     TypeDesc searchtype=UNKNOWN,\\
 \bigspc\bigspc\bigspc\spc                     bool casesensitive=false) const}
 Search for the named attribute and return the pointer to its
-{\cf ImageIOParameter} record, or {\cf NULL} if not found.  This variety of
+{\cf ParamValue} record, or {\cf NULL} if not found.  This variety of
 {\cf find_attribute(}) can retrieve items such as \qkw{width}, which are
 part of the \ImageSpec, but not in {\cf extra_attribs}. The {\cf tmpparam}
 is a temporary storage area owned by the caller, which is used as temporary
@@ -660,7 +660,7 @@ function for when you know you are just looking for a simple string value.
 \apiend
 
 
-\apiitem{static std::string {\ce metadata_val} (const ImageIOParamaeter \&p,
+\apiitem{static std::string {\ce metadata_val} (const ParamValue \&p,
   bool human=true) const}
 For a given parameter {\cf p}, format the value nicely as a string.
 If {\cf human} is true, use

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -361,7 +361,7 @@ DPXOutput::open (const std::string &name, const ImageSpec &userspec,
     orient = DpxOrientations[clamp (orient, 0, 8)];
     m_dpx.header.SetImageOrientation ((dpx::Orientation)orient);
 
-    ImageIOParameter *tc = m_spec.find_attribute("smpte:TimeCode", TypeDesc::TypeTimeCode, false);
+    ParamValue *tc = m_spec.find_attribute("smpte:TimeCode", TypeDesc::TypeTimeCode, false);
     if (tc) {
         unsigned int *timecode = (unsigned int*) tc->data();
         m_dpx.header.timeCode = timecode[0];
@@ -377,7 +377,7 @@ DPXOutput::open (const std::string &name, const ImageSpec &userspec,
         m_dpx.header.userBits = m_spec.get_int_attribute ("dpx:UserBits", ~0);
     }
 
-    ImageIOParameter *kc = m_spec.find_attribute("smpte:KeyCode", TypeDesc::TypeKeyCode, false);
+    ParamValue *kc = m_spec.find_attribute("smpte:KeyCode", TypeDesc::TypeKeyCode, false);
     if (kc) {
         int *array = (int*) kc->data();
         set_keycode_values(array);
@@ -401,7 +401,7 @@ DPXOutput::open (const std::string &name, const ImageSpec &userspec,
     }
 
     // set the user data size
-    ImageIOParameter *user = m_spec.find_attribute ("dpx:UserData");
+    ParamValue *user = m_spec.find_attribute ("dpx:UserData");
     if (user && user->datasize () > 0 && user->datasize () <= 1024 * 1024) {
         m_dpx.SetUserData (user->datasize ());
     }

--- a/src/field3d.imageio/field3doutput.cpp
+++ b/src/field3d.imageio/field3doutput.cpp
@@ -494,12 +494,12 @@ Field3DOutput::prep_subimage_specialized ()
 
     // Mapping matrix
     TypeDesc TypeMatrixD (TypeDesc::DOUBLE, TypeDesc::MATRIX44);
-    if (ImageIOParameter *mx = m_spec.find_attribute ("field3d:localtoworld", TypeMatrixD)) {
+    if (ParamValue *mx = m_spec.find_attribute ("field3d:localtoworld", TypeMatrixD)) {
         MatrixFieldMapping::Ptr mapping (new MatrixFieldMapping);
         mapping->setLocalToWorld (*((FIELD3D_NS::M44d*)mx->data()));
         m_field->setMapping (mapping);
     }
-    else if (ImageIOParameter *mx = m_spec.find_attribute ("worldtocamera", TypeDesc::TypeMatrix)) {
+    else if (ParamValue *mx = m_spec.find_attribute ("worldtocamera", TypeDesc::TypeMatrix)) {
         Imath::M44f m = *((Imath::M44f*)mx->data());
         m = m.inverse();
         FIELD3D_NS::M44d md (m[0][0], m[0][1], m[0][1], m[0][3],

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -123,7 +123,7 @@ HdrOutput::open (const std::string &name, const ImageSpec &newspec,
     h.valid |= RGBE_VALID_PROGRAMTYPE;
     Strutil::safe_strcpy (h.programtype, "RADIANCE", sizeof(h.programtype));
 
-    ImageIOParameter *p;
+    ParamValue *p;
     p = m_spec.find_attribute ("Orientation", TypeDesc::INT);
     if (p) {
         h.valid |= RGBE_VALID_ORIENTATION;

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -182,7 +182,7 @@ ICOOutput::open (const std::string &name, const ImageSpec &userspec,
     // check if the client wants this subimage written as PNG
     // also force PNG if image size is 256 because ico_header->width and height
     // are 8-bit
-    const ImageIOParameter *p = m_spec.find_attribute ("ico:PNG",
+    const ParamValue *p = m_spec.find_attribute ("ico:PNG",
                                                        TypeDesc::TypeInt);
     m_want_png = (p && *(int *)p->data())
                  || m_spec.width == 256 || m_spec.height == 256;

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -101,6 +101,7 @@ typedef bool (*ProgressCallback)(void *opaque_data, float portion_done);
 
 
 
+// Deprecated typedefs. Just use ParamValue and ParamValueList directly.
 typedef ParamValue ImageIOParameter;
 typedef ParamValueList ImageIOParameterList;
 
@@ -142,7 +143,7 @@ public:
     /// these data.  Note, however, that the names and semantics of such
     /// extra attributes are plugin-dependent and are not enforced by
     /// the imageio library itself.
-    ImageIOParameterList extra_attribs;  ///< Additional attributes
+    ParamValueList extra_attribs;  ///< Additional attributes
 
     /// Constructor: given just the data format, set all other fields to
     /// something reasonable.
@@ -320,23 +321,23 @@ public:
     /// matches to only those of the given type. If casesensitive is true,
     /// the name search will be case-sensitive, otherwise the name search
     /// will be performed without regard to case (this is the default).
-    ImageIOParameter * find_attribute (string_view name,
-                                       TypeDesc searchtype=TypeDesc::UNKNOWN,
-                                       bool casesensitive=false);
-    const ImageIOParameter *find_attribute (string_view name,
-                                            TypeDesc searchtype=TypeDesc::UNKNOWN,
-                                            bool casesensitive=false) const;
+    ParamValue * find_attribute (string_view name,
+                                 TypeDesc searchtype=TypeDesc::UNKNOWN,
+                                 bool casesensitive=false);
+    const ParamValue *find_attribute (string_view name,
+                                      TypeDesc searchtype=TypeDesc::UNKNOWN,
+                                      bool casesensitive=false) const;
 
     /// Search for the named attribute and return a pointer to an
-    /// ImageIOParameter record, or NULL if not found.  This variety of
+    /// ParamValue record, or NULL if not found.  This variety of
     /// find_attribute() can retrieve items such as "width", which are part
     /// of the ImageSpec, but not in extra_attribs. The tmpparam is a
     /// temporary storage area owned by the caller, which is used as
     /// temporary buffer in cases where the information does not correspond
     /// to an actual extra_attribs (in this case, the return value will be
     /// &tmpparam).
-    const ImageIOParameter * find_attribute (string_view name,
-                         ImageIOParameter &tmpparam,
+    const ParamValue * find_attribute (string_view name,
+                         ParamValue &tmpparam,
                          TypeDesc searchtype=TypeDesc::UNKNOWN,
                          bool casesensitive=false) const;
 
@@ -358,7 +359,7 @@ public:
     /// For a given parameter p, format the value nicely as a string.  If
     /// 'human' is true, use especially human-readable explanations (units,
     /// or decoding of values) for certain known metadata.
-    static std::string metadata_val (const ImageIOParameter &p,
+    static std::string metadata_val (const ParamValue &p,
                               bool human=false);
 
     enum SerialFormat  { SerialText, SerialXML };

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -171,7 +171,7 @@ bool
 JpgInput::open (const std::string &name, ImageSpec &newspec,
                 const ImageSpec &config)
 {
-    const ImageIOParameter *p = config.find_attribute ("_jpeg:raw",
+    const ParamValue *p = config.find_attribute ("_jpeg:raw",
                                                        TypeDesc::TypeInt);
     m_raw = p && *(int *)p->data();
     return open (name, newspec);

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -235,7 +235,7 @@ JpgOutput::open (const std::string &name, const ImageSpec &newspec,
     m_next_scanline = 0;    // next scanline we'll write
 
     // Write JPEG comment, if sent an 'ImageDescription'
-    ImageIOParameter *comment = m_spec.find_attribute ("ImageDescription",
+    ParamValue *comment = m_spec.find_attribute ("ImageDescription",
                                                        TypeDesc::STRING);
     if (comment && comment->data()) {
         const char **c = (const char **) comment->data();
@@ -290,7 +290,7 @@ JpgOutput::open (const std::string &name, const ImageSpec &newspec,
     m_spec.set_format (TypeDesc::UINT8);  // JPG is only 8 bit
 
     // Write ICC profile, if we have anything
-    const ImageIOParameter* icc_profile_parameter = m_spec.find_attribute(ICC_PROFILE_ATTR);
+    const ParamValue* icc_profile_parameter = m_spec.find_attribute(ICC_PROFILE_ATTR);
     if (icc_profile_parameter != NULL) {
         unsigned char *icc_profile = (unsigned char*)icc_profile_parameter->data();
         unsigned int icc_profile_length = icc_profile_parameter->type().size();

--- a/src/jpeg2000.imageio/jpeg2000output-v1.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output-v1.cpp
@@ -317,7 +317,7 @@ Jpeg2000Output::create_jpeg2000_image()
         color_space = CLRSPC_GRAY;
 
     int precision = 16;
-    const ImageIOParameter *prec = m_spec.find_attribute ("oiio:BitsPerSample",
+    const ParamValue *prec = m_spec.find_attribute ("oiio:BitsPerSample",
                                                           TypeDesc::INT);
     if (prec)
         precision = *(int*)prec->data();
@@ -340,7 +340,7 @@ Jpeg2000Output::create_jpeg2000_image()
     // OPENJPEG_VERSION only seems to exist in 1.3, which doesn't have
     // the ICC fields. So assume its absence in the newer one (at least,
     // 1.5) means the field is valid.
-    const ImageIOParameter *icc = m_spec.find_attribute ("ICCProfile");
+    const ParamValue *icc = m_spec.find_attribute ("ICCProfile");
     if (icc && icc->type().basetype == TypeDesc::UINT8 && icc->type().arraylen > 0) {
         m_image->icc_profile_len = icc->type().arraylen;
         m_image->icc_profile_buf = (unsigned char *) icc->data();
@@ -460,34 +460,34 @@ void Jpeg2000Output::setup_compression_params()
     m_compression_parameters.tcp_numlayers++;
     m_compression_parameters.cp_disto_alloc = 1;
 
-    const ImageIOParameter *is_cinema2k = m_spec.find_attribute ("jpeg2000:Cinema2K",
+    const ParamValue *is_cinema2k = m_spec.find_attribute ("jpeg2000:Cinema2K",
                                                                  TypeDesc::UINT);
     if (is_cinema2k)
         setup_cinema_compression(CINEMA2K);
 
-    const ImageIOParameter *is_cinema4k = m_spec.find_attribute ("jpeg2000:Cinema4K",
+    const ParamValue *is_cinema4k = m_spec.find_attribute ("jpeg2000:Cinema4K",
                                                                  TypeDesc::UINT);
     if (is_cinema4k)
         setup_cinema_compression(CINEMA4K);
 
-    const ImageIOParameter *initial_cb_width = m_spec.find_attribute ("jpeg2000:InitialCodeBlockWidth",
+    const ParamValue *initial_cb_width = m_spec.find_attribute ("jpeg2000:InitialCodeBlockWidth",
                                                                       TypeDesc::UINT);
     if (initial_cb_width && initial_cb_width->data())
         m_compression_parameters.cblockw_init = *(unsigned int*)initial_cb_width->data();
 
-    const ImageIOParameter *initial_cb_height = m_spec.find_attribute ("jpeg2000:InitialCodeBlockHeight",
+    const ParamValue *initial_cb_height = m_spec.find_attribute ("jpeg2000:InitialCodeBlockHeight",
                                                                        TypeDesc::UINT);
     if (initial_cb_height && initial_cb_height->data())
         m_compression_parameters.cblockh_init = *(unsigned int*)initial_cb_height->data();
 
-    const ImageIOParameter *progression_order = m_spec.find_attribute ("jpeg2000:ProgressionOrder",
+    const ParamValue *progression_order = m_spec.find_attribute ("jpeg2000:ProgressionOrder",
                                                                        TypeDesc::STRING);
     if (progression_order && progression_order->data()) {
         std::string prog_order((const char*)progression_order->data());
         m_compression_parameters.prog_order = get_progression_order(prog_order);
     }
 
-    const ImageIOParameter *compression_mode = m_spec.find_attribute ("jpeg2000:CompressionMode",
+    const ParamValue *compression_mode = m_spec.find_attribute ("jpeg2000:CompressionMode",
                                                                        TypeDesc::INT);
     if (compression_mode && compression_mode->data())
         m_compression_parameters.mode = *(int*)compression_mode->data();

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -360,7 +360,7 @@ Jpeg2000Output::create_jpeg2000_image()
         color_space = OPJ_CLRSPC_GRAY;
 
     int precision = 16;
-    const ImageIOParameter *prec = m_spec.find_attribute ("oiio:BitsPerSample",
+    const ParamValue *prec = m_spec.find_attribute ("oiio:BitsPerSample",
                                                           TypeDesc::INT);
     if (prec)
         precision = *(int*)prec->data();
@@ -388,7 +388,7 @@ Jpeg2000Output::create_jpeg2000_image()
     // someboody comes along that desperately needs JPEG2000 and ICC
     // profiles, maybe they will be motivated enough to track down the
     // problem.
-    const ImageIOParameter *icc = m_spec.find_attribute ("ICCProfile");
+    const ParamValue *icc = m_spec.find_attribute ("ICCProfile");
     if (icc && icc->type().basetype == TypeDesc::UINT8 && icc->type().arraylen > 0) {
         m_image->icc_profile_len = icc->type().arraylen;
         m_image->icc_profile_buf = (unsigned char *) icc->data();
@@ -508,34 +508,34 @@ void Jpeg2000Output::setup_compression_params()
     m_compression_parameters.tcp_numlayers++;
     m_compression_parameters.cp_disto_alloc = 1;
 
-    const ImageIOParameter *is_cinema2k = m_spec.find_attribute ("jpeg2000:Cinema2K",
+    const ParamValue *is_cinema2k = m_spec.find_attribute ("jpeg2000:Cinema2K",
                                                                  TypeDesc::UINT);
     if (is_cinema2k)
         setup_cinema_compression(OPJ_CINEMA2K);
 
-    const ImageIOParameter *is_cinema4k = m_spec.find_attribute ("jpeg2000:Cinema4K",
+    const ParamValue *is_cinema4k = m_spec.find_attribute ("jpeg2000:Cinema4K",
                                                                  TypeDesc::UINT);
     if (is_cinema4k)
         setup_cinema_compression(OPJ_CINEMA4K);
 
-    const ImageIOParameter *initial_cb_width = m_spec.find_attribute ("jpeg2000:InitialCodeBlockWidth",
+    const ParamValue *initial_cb_width = m_spec.find_attribute ("jpeg2000:InitialCodeBlockWidth",
                                                                       TypeDesc::UINT);
     if (initial_cb_width && initial_cb_width->data())
         m_compression_parameters.cblockw_init = *(unsigned int*)initial_cb_width->data();
 
-    const ImageIOParameter *initial_cb_height = m_spec.find_attribute ("jpeg2000:InitialCodeBlockHeight",
+    const ParamValue *initial_cb_height = m_spec.find_attribute ("jpeg2000:InitialCodeBlockHeight",
                                                                        TypeDesc::UINT);
     if (initial_cb_height && initial_cb_height->data())
         m_compression_parameters.cblockh_init = *(unsigned int*)initial_cb_height->data();
 
-    const ImageIOParameter *progression_order = m_spec.find_attribute ("jpeg2000:ProgressionOrder",
+    const ParamValue *progression_order = m_spec.find_attribute ("jpeg2000:ProgressionOrder",
                                                                        TypeDesc::STRING);
     if (progression_order && progression_order->data()) {
         std::string prog_order((const char*)progression_order->data());
         m_compression_parameters.prog_order = get_progression_order(prog_order);
     }
 
-    const ImageIOParameter *compression_mode = m_spec.find_attribute ("jpeg2000:CompressionMode",
+    const ParamValue *compression_mode = m_spec.find_attribute ("jpeg2000:CompressionMode",
                                                                        TypeDesc::INT);
     if (compression_mode && compression_mode->data())
         m_compression_parameters.mode = *(int*)compression_mode->data();

--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -698,7 +698,7 @@ append_dir_entry (const TagMap &tagmap,
 ///
 template <class T>
 bool
-append_dir_entry_integer (const ImageIOParameter &p, const TagMap &tagmap,
+append_dir_entry_integer (const ParamValue &p, const TagMap &tagmap,
                           std::vector<TIFFDirEntry> &dirs,
                           std::vector<char> &data, int tag, TIFFDataType type)
 {
@@ -731,7 +731,7 @@ append_dir_entry_integer (const ImageIOParameter &p, const TagMap &tagmap,
 /// reside.  Don't worry about it being relative to the start of some
 /// TIFF structure.
 static void
-encode_exif_entry (const ImageIOParameter &p, int tag,
+encode_exif_entry (const ParamValue &p, int tag,
                    std::vector<TIFFDirEntry> &dirs,
                    std::vector<char> &data,
                    const TagMap &tagmap)
@@ -879,7 +879,7 @@ decode_exif (string_view exif, ImageSpec &spec)
                        exif, swab, ifd_offsets_seen, exif_tagmap);
 
     // A few tidbits to look for
-    ImageIOParameter *p;
+    ParamValue *p;
     if ((p = spec.find_attribute ("Exif:ColorSpace")) ||
         (p = spec.find_attribute ("ColorSpace"))) {
         int cs = -1;
@@ -957,7 +957,7 @@ encode_exif (const ImageSpec &spec, std::vector<char> &blob)
 
     // Go through all spec attribs, add them to the appropriate tag
     // directory (tiff, gps, or exif).
-    for (const ImageIOParameter &p : spec.extra_attribs) {
+    for (const ParamValue &p : spec.extra_attribs) {
         // Which tag domain are we using?
         if (! strncmp (p.name().c_str(), "GPS:", 4)) {
             // GPS

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -310,7 +310,7 @@ void
 ImageSpec::attribute (string_view name, TypeDesc type, const void *value)
 {
     // Don't allow duplicates
-    ImageIOParameter *f = find_attribute (name);
+    ParamValue *f = find_attribute (name);
     if (! f) {
         extra_attribs.resize (extra_attribs.size() + 1);
         f = &extra_attribs.back();
@@ -362,12 +362,11 @@ ImageSpec::erase_attribute (string_view name, TypeDesc searchtype,
 }
 
 
-ImageIOParameter *
+ParamValue *
 ImageSpec::find_attribute (string_view name, TypeDesc searchtype,
                            bool casesensitive)
 {
-    ImageIOParameterList::iterator iter =
-        extra_attribs.find (name, searchtype, casesensitive);
+    auto iter = extra_attribs.find (name, searchtype, casesensitive);
     if (iter != extra_attribs.end())
         return &(*iter);
     return NULL;
@@ -375,12 +374,11 @@ ImageSpec::find_attribute (string_view name, TypeDesc searchtype,
 
 
 
-const ImageIOParameter *
+const ParamValue *
 ImageSpec::find_attribute (string_view name, TypeDesc searchtype,
                            bool casesensitive) const
 {
-    ImageIOParameterList::const_iterator iter =
-        extra_attribs.find (name, searchtype, casesensitive);
+    auto iter = extra_attribs.find (name, searchtype, casesensitive);
     if (iter != extra_attribs.end())
         return &(*iter);
     return NULL;
@@ -388,12 +386,11 @@ ImageSpec::find_attribute (string_view name, TypeDesc searchtype,
 
 
 
-const ImageIOParameter *
-ImageSpec::find_attribute (string_view name, ImageIOParameter &tmpparam,
+const ParamValue *
+ImageSpec::find_attribute (string_view name, ParamValue &tmpparam,
                            TypeDesc searchtype, bool casesensitive) const
 {
-    ImageIOParameterList::const_iterator iter =
-        extra_attribs.find (name, searchtype, casesensitive);
+    auto iter = extra_attribs.find (name, searchtype, casesensitive);
     if (iter != extra_attribs.end())
         return &(*iter);
     // Check named items in the ImageSpec structs, not in extra_attrubs
@@ -452,7 +449,7 @@ ImageSpec::get_int_attribute (string_view name, int defaultval) const
 {
     // Call find_attribute with the tmpparam, in order to retrieve special
     // "virtual" attribs that aren't really in extra_attribs.
-    ImageIOParameter tmpparam;
+    ParamValue tmpparam;
     auto p = find_attribute (name, tmpparam);
     return p ? p->get_int (defaultval) : defaultval;
 }
@@ -473,8 +470,8 @@ ImageSpec::get_float_attribute (string_view name, float defaultval) const
 string_view
 ImageSpec::get_string_attribute (string_view name, string_view defaultval) const
 {
-    ImageIOParameter tmpparam;
-    const ImageIOParameter *p = find_attribute (name, tmpparam, TypeDesc::STRING);
+    ParamValue tmpparam;
+    const ParamValue *p = find_attribute (name, tmpparam, TypeDesc::STRING);
     return p ? p->get_ustring() : defaultval;
 }
 
@@ -483,7 +480,7 @@ ImageSpec::get_string_attribute (string_view name, string_view defaultval) const
 namespace {  // make an anon namespace
 
 template < typename T >
-void formatType(const ImageIOParameter& p, const int n, const TypeDesc& element, const char* formatString, std::string& out) {
+void formatType(const ParamValue& p, const int n, const TypeDesc& element, const char* formatString, std::string& out) {
   const T *f = (const T *)p.data();
   for (int i = 0;  i < n;  ++i) {
       if (i)
@@ -494,7 +491,7 @@ void formatType(const ImageIOParameter& p, const int n, const TypeDesc& element,
 }
 
 static std::string
-format_raw_metadata (const ImageIOParameter &p, int maxsize=16)
+format_raw_metadata (const ParamValue &p, int maxsize=16)
 {
     std::string out;
     TypeDesc element = p.type().elementtype();
@@ -545,13 +542,13 @@ struct LabelTable {
 };
 
 static std::string
-explain_justprint (const ImageIOParameter &p, const void *extradata)
+explain_justprint (const ParamValue &p, const void *extradata)
 {
     return format_raw_metadata(p) + " " + std::string ((const char *)extradata);
 }
 
 static std::string
-explain_labeltable (const ImageIOParameter &p, const void *extradata)
+explain_labeltable (const ParamValue &p, const void *extradata)
 {
     int val;
     if (p.type() == TypeDesc::INT)
@@ -569,7 +566,7 @@ explain_labeltable (const ImageIOParameter &p, const void *extradata)
 }
 
 static std::string
-explain_shutterapex (const ImageIOParameter &p, const void *extradata)
+explain_shutterapex (const ParamValue &p, const void *extradata)
 {
     if (p.type() == TypeDesc::FLOAT) {
         double val = pow (2.0, - (double)*(float *)p.data());
@@ -582,7 +579,7 @@ explain_shutterapex (const ImageIOParameter &p, const void *extradata)
 }
 
 static std::string
-explain_apertureapex (const ImageIOParameter &p, const void *extradata)
+explain_apertureapex (const ParamValue &p, const void *extradata)
 {
     if (p.type() == TypeDesc::FLOAT)
         return Strutil::format ("f/%g", powf (2.0f, *(float *)p.data()/2.0f));
@@ -590,7 +587,7 @@ explain_apertureapex (const ImageIOParameter &p, const void *extradata)
 }
 
 static std::string
-explain_ExifFlash (const ImageIOParameter &p, const void *extradata)
+explain_ExifFlash (const ParamValue &p, const void *extradata)
 {
     int val = 0;
     if (p.type() == TypeDesc::INT)
@@ -735,7 +732,7 @@ static LabelTable magnetic_table[] = {
     { 'T', "true north" }, { 'M', "magnetic north" }, { -1, NULL }
 };
 
-typedef std::string (*ExplainerFunc) (const ImageIOParameter &p, 
+typedef std::string (*ExplainerFunc) (const ParamValue &p, 
                                       const void *extradata);
 
 struct ExplanationTableEntry {
@@ -788,7 +785,7 @@ static ExplanationTableEntry explanation[] = {
 
 
 std::string
-ImageSpec::metadata_val (const ImageIOParameter &p, bool human)
+ImageSpec::metadata_val (const ParamValue &p, bool human)
 {
     std::string out = format_raw_metadata (p, human ? 16 : 1024);
 

--- a/src/libOpenImageIO/imagespec_test.cpp
+++ b/src/libOpenImageIO/imagespec_test.cpp
@@ -89,7 +89,7 @@ static void
 metadata_val_test (void *data, int num_elements, TypeDesc type, std::string& val)
 {
     static ImageSpec spec;
-    ImageIOParameter p;
+    ParamValue p;
 
     p.init ("name", type, num_elements, data);
     val = spec.metadata_val (p);

--- a/src/libOpenImageIO/iptc.cpp
+++ b/src/libOpenImageIO/iptc.cpp
@@ -207,7 +207,7 @@ encode_iptc_iim (const ImageSpec &spec, std::vector<char> &iptc)
 {
     iptc.clear ();
     
-    const ImageIOParameter *p;
+    const ParamValue *p;
     for (int i = 0;  iimtag[i].name;  ++i) {
         if ((p = spec.find_attribute (iimtag[i].name))) {
             if (iimtag[i].repeatable) {

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -496,7 +496,7 @@ static void
 maketx_merge_spec (ImageSpec &dstspec, const ImageSpec &srcspec)
 {
     for (size_t i = 0, e = srcspec.extra_attribs.size(); i < e; ++i) {
-        const ImageIOParameter &p (srcspec.extra_attribs[i]);
+        const ParamValue &p (srcspec.extra_attribs[i]);
         ustring name = p.name();
         if (Strutil::istarts_with (name.string(), "maketx:")) {
             // Special instruction -- don't copy it to the destination spec

--- a/src/libOpenImageIO/xmp.cpp
+++ b/src/libOpenImageIO/xmp.cpp
@@ -317,7 +317,7 @@ add_attrib (ImageSpec &spec, const char *xmlname, const char *xmlvalue)
         if (special & (IsList|IsSeq)) {
             // Special case -- append it to a list
             std::vector<std::string> items;
-            ImageIOParameter *p = spec.find_attribute (oiioname, TypeDesc::STRING); 
+            ParamValue *p = spec.find_attribute (oiioname, TypeDesc::STRING); 
             bool dup = false;
             if (p) {
                 Strutil::split (*(const char **)p->data(), items, ";");
@@ -509,10 +509,10 @@ decode_xmp (const std::string &xml, ImageSpec &spec)
 
 
 
-// Turn one ImageIOParameter (whose xmp info we know) into a properly
+// Turn one ParamValue (whose xmp info we know) into a properly
 // serialized xmp string.
 static std::string
-stringize (const ImageIOParameterList::const_iterator &p,
+stringize (const ParamValueList::const_iterator &p,
            const XMPtag &xmptag)
 {
     if (p->type() == TypeDesc::STRING) {
@@ -545,7 +545,7 @@ gather_xmp_attribs (const ImageSpec &spec,
                     std::vector<std::pair<const XMPtag*,std::string> > &list)
 {
     // Loop over all params...
-    for (ImageIOParameterList::const_iterator p = spec.extra_attribs.begin();
+    for (ParamValueList::const_iterator p = spec.extra_attribs.begin();
          p != spec.extra_attribs.end();  ++p) {
         // For this param, see if there's a table entry with a matching
         // name, where the xmp name is in the right category.

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -603,7 +603,7 @@ void
 ImageCacheFile::init_from_spec ()
 {
     const ImageSpec &spec (this->spec(0,0));
-    const ImageIOParameter *p;
+    const ParamValue *p;
 
     // FIXME -- this should really be per-subimage
     if (spec.depth <= 1 && spec.full_depth <= 1)
@@ -2646,7 +2646,7 @@ ImageCacheImpl::get_image_info (ImageCacheFile *file,
 
     // general case -- handle anything else that's able to be found by
     // spec.find_attribute().
-    const ImageIOParameter *p = spec.find_attribute (dataname.string());
+    const ParamValue *p = spec.find_attribute (dataname.string());
     if (p && p->type().arraylen == datatype.arraylen) {
         // First test for exact type match
         if (p->type() == datatype) {

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -954,8 +954,8 @@ Oiiotool::express_parse_atom(const string_view expr, string_view& s, std::string
         string_view metadata = Strutil::parse_identifier (s, ":", true);
         if (metadata.size()) {
             read (img);
-            ImageIOParameter tmpparam;
-            const ImageIOParameter *p = img->spec(0,0)->find_attribute (metadata, tmpparam);
+            ParamValue tmpparam;
+            const ParamValue *p = img->spec(0,0)->find_attribute (metadata, tmpparam);
             if (p) {
                 std::string val = ImageSpec::metadata_val (*p);
                 if (p->type().basetype == TypeDesc::STRING) {

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -331,7 +331,7 @@ OpenEXROutput::supports (string_view feature) const
     // EXR supports random write order iff lineOrder is set to 'random Y'
     // and it's a tiled file.
     if (feature == "random_access" && m_spec.tile_width != 0) {
-        const ImageIOParameter *param = m_spec.find_attribute("openexr:lineOrder");
+        const ParamValue *param = m_spec.find_attribute("openexr:lineOrder");
         const char *lineorder = param ? *(char **)param->data() : NULL;
         return (lineorder && Strutil::iequals (lineorder, "randomY"));
     }

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -512,7 +512,7 @@ write_info (png_structp& sp, png_infop& ip, int& color_type,
     }
 
     // Write ICC profile, if we have anything
-    const ImageIOParameter* icc_profile_parameter = spec.find_attribute(ICC_PROFILE_ATTR);
+    const ParamValue* icc_profile_parameter = spec.find_attribute(ICC_PROFILE_ATTR);
     if (icc_profile_parameter != NULL) {
         unsigned int length = icc_profile_parameter->type().size();
 #if OIIO_LIBPNG_VERSION > 10500 /* PNG function signatures changed */

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -232,8 +232,8 @@ static object
 ImageSpec_get_attribute_typed (const ImageSpec& spec,
                                const std::string &name, TypeDesc type)
 {
-    ImageIOParameter tmpparam;
-    const ImageIOParameter *p = spec.find_attribute (name, tmpparam, type);
+    ParamValue tmpparam;
+    const ParamValue *p = spec.find_attribute (name, tmpparam, type);
     if (!p)
         return object();   // None
     type = p->type();
@@ -343,7 +343,7 @@ void declare_imagespec()
         .def_readwrite("z_channel",     &ImageSpec::z_channel)
         .def_readwrite("deep",          &ImageSpec::deep)
         .add_property("extra_attribs", 
-            make_getter(&ImageSpec::extra_attribs))//ImageIOParameterList
+            make_getter(&ImageSpec::extra_attribs))//ParamValueList
         
         .def(init<int, int, int, TypeDesc>())
         .def(init<int, int, int, TypeDesc::BASETYPE>())

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -85,7 +85,7 @@ private:
     }
     
     /// Helper - sets a chromaticity from attribute
-    inline void set_chromaticity (const ImageIOParameter *p, char *dst,
+    inline void set_chromaticity (const ParamValue *p, char *dst,
                                   size_t field_size, const char *default_val);
     
     // Helper - handles the repetitive work of encoding and writing a
@@ -321,7 +321,7 @@ RLAOutput::open (const std::string &name, const ImageSpec &userspec,
         snprintf (m_rla.Gamma, sizeof(m_rla.Gamma), "%.10f", g);
     }
 
-    const ImageIOParameter *p;
+    const ParamValue *p;
     // default NTSC chromaticities
     p = m_spec.find_attribute ("rla:RedChroma");
     set_chromaticity (p, m_rla.RedChroma, sizeof (m_rla.RedChroma), "0.67 0.08");
@@ -407,7 +407,7 @@ RLAOutput::open (const std::string &name, const ImageSpec &userspec,
 
 
 inline void
-RLAOutput::set_chromaticity (const ImageIOParameter *p, char *dst,
+RLAOutput::set_chromaticity (const ParamValue *p, char *dst,
                              size_t field_size, const char *default_val)
 {
     if (p && p->type().basetype == TypeDesc::FLOAT) {

--- a/src/sgi.imageio/sgioutput.cpp
+++ b/src/sgi.imageio/sgioutput.cpp
@@ -193,7 +193,7 @@ SgiOutput::create_and_write_header()
     sgi_header.pixmax = (sgi_header.bpc == 1) ? 255 : 65535;
     sgi_header.dummy = 0;
 
-    ImageIOParameter *ip = m_spec.find_attribute ("ImageDescription",
+    ParamValue *ip = m_spec.find_attribute ("ImageDescription",
                                                    TypeDesc::STRING);
     if (ip && ip->data()) {
         const char** img_descr = (const char**)ip->data();

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -316,7 +316,7 @@ TGAOutput::write_tga20_data_fields ()
         unsigned char th = m_spec.get_int_attribute ("thumbnail_width", 0);
         int tc = m_spec.get_int_attribute ("thumbnail_nchannels", 0);
         if (tw && th && tc == m_spec.nchannels) {
-            ImageIOParameter *p = m_spec.find_attribute ("thumbnail_image");
+            ParamValue *p = m_spec.find_attribute ("thumbnail_image");
             if (p) {
                 ofs_thumb = (uint32_t) ftell (m_file);
                 // dump thumbnail size

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -942,7 +942,7 @@ TIFFInput::readspec (bool read_meta)
         TIFFSetDirectory (m_tif, m_subimage);
 
         // A few tidbits to look for
-        ImageIOParameter *p;
+        ParamValue *p;
         if ((p = m_spec.find_attribute ("Exif:ColorSpace", TypeDesc::INT))) {
             // Exif spec says that anything other than 0xffff==uncalibrated
             // should be interpreted to be sRGB.

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -495,7 +495,7 @@ TIFFOutput::open (const std::string &name, const ImageSpec &userspec,
         TIFFSetField (m_tif, TIFFTAG_EXTRASAMPLES, e, &extra[0]);
     }
 
-    ImageIOParameter *param;
+    ParamValue *param;
     const char *str = NULL;
 
     // Did the user request separate planar configuration?
@@ -533,7 +533,7 @@ TIFFOutput::open (const std::string &name, const ImageSpec &userspec,
     }
 
     // Write ICC profile, if we have anything
-    const ImageIOParameter* icc_profile_parameter = m_spec.find_attribute(ICC_PROFILE_ATTR);
+    const ParamValue* icc_profile_parameter = m_spec.find_attribute(ICC_PROFILE_ATTR);
     if (icc_profile_parameter != NULL) {
         unsigned char *icc_profile = (unsigned char*)icc_profile_parameter->data();
         uint32 length = icc_profile_parameter->type().size();
@@ -714,7 +714,7 @@ TIFFOutput::write_exif_data ()
     // First, see if we have any Exif data at all
     bool any_exif = false;
     for (size_t i = 0, e = m_spec.extra_attribs.size(); i < e; ++i) {
-        const ImageIOParameter &p (m_spec.extra_attribs[i]);
+        const ParamValue &p (m_spec.extra_attribs[i]);
         int tag, tifftype, count;
         if (exif_tag_lookup (p.name(), tag, tifftype, count) &&
                 tifftype != TIFF_NOTYPE) {
@@ -748,7 +748,7 @@ TIFFOutput::write_exif_data ()
     }
 
     for (size_t i = 0, e = m_spec.extra_attribs.size(); i < e; ++i) {
-        const ImageIOParameter &p (m_spec.extra_attribs[i]);
+        const ParamValue &p (m_spec.extra_attribs[i]);
         int tag, tifftype, count;
         if (exif_tag_lookup (p.name(), tag, tifftype, count) &&
                 tifftype != TIFF_NOTYPE) {

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -142,7 +142,7 @@ WebpOutput::open (const std::string &name, const ImageSpec &spec,
 
     m_webp_config.method = 6;
     int compression_quality = 100;
-    const ImageIOParameter *qual = m_spec.find_attribute ("CompressionQuality",
+    const ParamValue *qual = m_spec.find_attribute ("CompressionQuality",
                                                           TypeDesc::INT);
     if (qual)
     {

--- a/src/zfile.imageio/zfile.cpp
+++ b/src/zfile.imageio/zfile.cpp
@@ -292,7 +292,7 @@ ZfileOutput::open (const std::string &name, const ImageSpec &userspec,
     header.width = (int)m_spec.width;
     header.height = (int)m_spec.height;
 
-    ImageIOParameter *p;
+    ParamValue *p;
     static float ident[16] = { 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 };
     if ((p = m_spec.find_attribute ("worldtocamera", TypeDesc::TypeMatrix)))
         memcpy (header.worldtocamera, p->data(), 16*sizeof(float));


### PR DESCRIPTION
Just use ParamValue and ParamValueList. Those typedefs never served any purpose, just deprecate them.
