### PR TITLE
deep holdout operation

### DIFF
--- a/src/doc/imagebufalgo.tex
+++ b/src/doc/imagebufalgo.tex
@@ -2614,6 +2614,26 @@ the first opaque sample will be discarded, otherwise they will be kept.
 \end{code}
 \apiend
 
+\apiitem{bool {\ce deep_holdout} (ImageBuf \&dst, const ImageBuf \&src, \\
+\bigspc\spc  const ImageBuf \&holdout, ROI roi=ROI::All(), int nthreads=0)}
+\index{ImageBufAlgo!deep_holdout} \indexapi{deep_holdout} \index{deep images}
+\NEW % 1.8
+Set the pixels of {\cf dst} to the pixels of {\cf src}, but only copying the
+samples that are closer than the opaque frontier of image {\cf holdout}.
+That is, {\cf holdout} will serve as a depth holdout mask, but no samples
+from {\cf holdout} will actually be copied to {\cf dst}.
+
+\smallskip
+\noindent Examples:
+\begin{code}
+    ImageBuf Img ("image.exr");
+    ImageBuf Holdout ("holdout.exr");
+    ImageBuf Thresholded;
+    ImageBufAlgo::deep_holdout (Thresholded, Img, Holdout);
+\end{code}
+\apiend
+
+
 \subsection{General functions that also work for deep images}
 
 \apiitem{bool {\ce channels} (ImageBuf \&dst, const ImageBuf \&src, int nchannels, \\

--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -810,8 +810,9 @@ layout. Return {\cf true} if ok, {\cf false} if the operation could not be
 performed.
 \apiend
 
-\apiitem{void {\ce split} (int pixel, float depth)}
-Split any samples of the pixel that cross {\cf depth}.
+\apiitem{bool {\ce split} (int pixel, float depth)}
+Split any samples of the pixel that cross {\cf depth}. Return {\cf true} if
+any splits occurred, {\cf false} if the pixel was unmodified.
 \apiend
 
 \apiitem{void {\ce sort} (int pixel)}

--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -835,6 +835,11 @@ performed.
 Eliminate any samples beyond an opaque sample.
 \apiend
 
+\apiitem{float {\ce opaque_z} (int pixel)}
+\NEW % 1.8
+For the given pixel index. return the $z$ value at which the pixel reaches
+full opacity.
+\apiend
 
 
 \section{Miscellaneous Utilities}

--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -580,6 +580,13 @@ be represented by a {\cf size_t} on that platform.  If this returns
 storage!
 \apiend
 
+\apiitem{int {\ce channelindex} (string_view name) const}
+\NEW % 1.8
+Returns the index of the channel with the given name, or -1 if no such
+channel is present in {\cf channelnames}.
+\apiend
+
+
 % FIXME - document auto_stride() ?
 
 \apiitem{void {\ce attribute} (string_view name, TypeDesc type, \\

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -3007,6 +3007,15 @@ number and order of channels and must contain an alpha channel and depth
 channel.
 \apiend
 
+\apiitem{\ce --deepholdout}
+\index{composite}
+\NEW % 1.8
+Replace the \emph{two} top images with a new deep image that is the ``deep
+holdout'' of the first image by the second --- that is, the samples from
+the first image that are closer than the opaque frontier of the second
+image. Both input inputs must be deep images.
+\apiend
+
 
 \subsection{General commands that also work for deep images}
 

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -94,7 +94,7 @@
  \bigskip \\
 }
 \date{{\large
-Date: 9 May 2017
+Date: 20 May 2017
 %\\ (with corrections, 2 Mar 2017)
 }}
 

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -3156,6 +3156,25 @@ the first opaque sample will be discarded, otherwise they will be kept.
 \end{code}
 \apiend
 
+\apiitem{bool ImageBufAlgo.{\ce deep_holdout} (dst, src, holdout, roi=ROI.All, nthreads=0)}
+\index{ImageBufAlgo!deep_holdout} \indexapi{deep_holdout} \index{deep images}
+
+Set the pixels of {\cf dst} to the pixels of {\cf src}, but only copying the
+samples that are closer than the opaque frontier of image {\cf holdout}.
+That is, {\cf holdout} will serve as a depth holdout mask, but no samples
+from {\cf holdout} will actually be copied to {\cf dst}.
+
+\smallskip
+\noindent Examples:
+\begin{code}
+    Img = ImageBuf("image.exr")
+    Mask = ImageBuf("mask.exr")
+    Thresholded = ImageBuf()
+    ImageBufAlgo.deep_holdout (Thresholded, Img, Mask)
+\end{code}
+\apiend
+
+
 \subsection*{Other ImageBufAlgo methods that understand deep images}
 
 In addition to the previously described methods that are specific to

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -619,6 +619,18 @@ collection of deep data.
 This {\cf int} field constains the number of channels.
 \apiend
 
+\apiitem{int DeepData.{\ce A_channel} \\
+int DeepData.{\ce AR_channel} \\
+int DeepData.{\ce AG_channel} \\
+int DeepData.{\ce AB_channel} \\
+int DeepData.{\ce Z_channel} \\
+int DeepData.{\ce Zback_channel}}
+\NEW % 1.8
+The channel index of certain named channels, or -1 if they don't exist. For
+{\cf AR_channel}, {\cf AG_channel}, {\cf AB_channel}, if they don't exist,
+they will contain the value of {\cf A_channel}, and {\cf Zback_channel} will
+contain the value of {\cf Z_channel} if there is no actual {\cf Zback}.
+\apiend
 
 \apiitem{string DeepData.{\ce channelname} (c)}
 Retrieve the name of channel {\cf c}.

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -689,8 +689,9 @@ Copy a deep sample from \DeepData {\cf src} into this \DeepData.
 Copy a deep pixel from \DeepData {\cf src} into this \DeepData.
 \apiend
 
-\apiitem{DeepData.{\ce split} (pixel, depth)}
-Split any samples of the pixel that cross {\cf depth}.
+\apiitem{bool DeepData.{\ce split} (pixel, depth)}
+Split any samples of the pixel that cross {\cf depth}. Return {\cf True} if
+any splits occurred, {\cf False} if the pixel was unmodified.
 \apiend
 
 \apiitem{DeepData.{\ce sort} (pixel)}

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -703,6 +703,12 @@ Merge the samples of {\cf src}'s pixel into this \DeepData's pixel.
 Eliminate any samples beyond an opaque sample.
 \apiend
 
+\apiitem{float DeepData.{\ce opaque_z} (pixel)}
+\NEW % 1.8
+For the given pixel index. return the $z$ value at which the pixel reaches
+full opacity.
+\apiend
+
 
 
 \section{ImageInput}

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -610,6 +610,14 @@ samples for each pixel (using {\cf set_nsamples}) and then call {\cf alloc()}
 to actually allocate the sample memory.
 \apiend
 
+\apiitem{bool {\ce DeepData}.initialized ()}
+Returns {\cf True} if the \DeepData is initialized at all.
+\apiend
+
+\apiitem{bool {\ce DeepData}.allocated ()}
+Returns {\cf True} if the \DeepData has already had pixel memory allocated.
+\apiend
+
 \apiitem{DeepData.{\ce pixels}}
 This {\cf int} field constains the total number of pixels in this
 collection of deep data.

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -379,6 +379,12 @@ Sets {\cf channel_names} to the default names given the value of
 the {\cf nchannels} field.
 \apiend
 
+\apiitem{int ImageSpec.{\ce channelindex} (name)}
+\NEW % 1.8
+Return (as an int) the index of the channel with the given name, or -1
+if it does not exist.
+\apiend
+
 \apiitem{ImageSpec.{\ce channel_bytes} () \\
 ImageSpec.{\ce channel_bytes} (channel, native=False)}
 Returns the size of a single channel value, in bytes (as an

--- a/src/include/OpenImageIO/deepdata.h
+++ b/src/include/OpenImageIO/deepdata.h
@@ -75,6 +75,13 @@ public:
     /// of pixels, channels, and channel types in the ImageSpec.
     void init (const ImageSpec &spec);
 
+    /// Is the DeepData initialized?
+    bool initialized () const;
+
+    /// Has the DeepData fully allocated? If no, it is still very
+    /// inexpensive to call set_capacity().
+    bool allocated () const;
+
     /// Retrieve the total number of pixels.
     int pixels () const;
     /// Retrieve the number of channels.

--- a/src/include/OpenImageIO/deepdata.h
+++ b/src/include/OpenImageIO/deepdata.h
@@ -178,8 +178,9 @@ public:
     /// with depth ranges [z,zsplit] and [zsplit,zback] with appropriate
     /// changes to their color and alpha values. Samples not spanning zsplit
     /// will remain intact. This operation will have no effect if there are
-    /// not Z and Zback channels present.
-    void split (int pixel, float depth);
+    /// not Z and Zback channels present. Return true if any splits
+    /// occurred, false if the pixel was not modified.
+    bool split (int pixel, float depth);
 
     /// Sort the samples of a pixel by Z.
     void sort (int pixel);

--- a/src/include/OpenImageIO/deepdata.h
+++ b/src/include/OpenImageIO/deepdata.h
@@ -80,6 +80,19 @@ public:
     /// Retrieve the number of channels.
     int channels () const;
 
+    // Retrieve the index of the Z channel.
+    int Z_channel () const;
+    // Retrieve the index of the Zback channel, which will return the
+    // Z channel if no Zback exists.
+    int Zback_channel () const;
+    // Retrieve the index of the A (alpha) channel.
+    int A_channel () const;
+    // Retrieve the index of the AR, AG, AB channel, respectively. If they
+    // don't exist, the A channel (which always exists) will be returned.
+    int AR_channel () const;
+    int AG_channel () const;
+    int AB_channel () const;
+
     /// The name of channel c.
     string_view channelname (int c) const;
 

--- a/src/include/OpenImageIO/deepdata.h
+++ b/src/include/OpenImageIO/deepdata.h
@@ -186,6 +186,9 @@ public:
     /// Merge src's samples into dst's samples
     void merge_deep_pixels (int pixel, const DeepData &src, int srcpixel);
 
+    /// Return the z depth at which the pixel becomes opaque.
+    float opaque_z (int pixel) const;
+
     /// Occlusion cull samples hidden behind opaque samples.
     void occlusion_cull (int pixel);
 

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -1893,6 +1893,17 @@ bool OIIO_API zover (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
                      ROI roi = ROI::All(), int nthreads = 0);
 
 
+/// Set dst to the samples of deep image src that are closer than the opaque
+/// frontier of deep image holdout, returning true upon success and false
+/// for any failures. Samples of src that are farther than the first opaque
+/// sample of holdout (for the corresponding pixel)will not be copied to
+/// dst. Image holdout is only used as the depth threshold; no sample values
+/// from holdout are themselves copied to dst.
+bool OIIO_API deep_holdout (ImageBuf &dst, const ImageBuf &src,
+                            const ImageBuf &holdout,
+                            ROI roi = ROI::All(), int nthreads = 0);
+
+
 
 /// Render a single point at (x,y) of the given color "over" the existing
 /// image dst. If there is no alpha channel, the color will be written

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -407,6 +407,9 @@ public:
         if ((int)formats.size() < nchannels)
             formats.resize (nchannels, format);
     }
+
+    /// Return the index of the named channel, or -1 if not found.
+    int channelindex (string_view name) const;
 };
 
 

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -429,6 +429,22 @@ DeepData::free ()
 
 
 
+bool
+DeepData::initialized () const
+{
+    return m_impl != nullptr;
+}
+
+
+
+bool
+DeepData::allocated () const
+{
+    return m_impl && m_impl->m_allocated;
+}
+
+
+
 int
 DeepData::capacity (int pixel) const
 {

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -74,6 +74,9 @@ public:
     size_t m_samplesize;
     int m_z_channel, m_zback_channel;
     int m_alpha_channel;
+    int m_AR_channel;
+    int m_AG_channel;
+    int m_AB_channel;
     bool m_allocated;
     spin_mutex m_mutex;
 
@@ -93,6 +96,9 @@ public:
         m_z_channel = -1;
         m_zback_channel = -1;
         m_alpha_channel = -1;
+        m_AR_channel = -1;
+        m_AG_channel = -1;
+        m_AB_channel = -1;
         m_allocated = false;
     }
 
@@ -215,6 +221,48 @@ int DeepData::channels () const
 
 
 
+int DeepData::Z_channel () const
+{
+    return m_impl->m_z_channel;
+}
+
+
+
+int DeepData::Zback_channel () const
+{
+    return m_impl->m_zback_channel >= 0 ? m_impl->m_zback_channel : m_impl->m_z_channel;
+}
+
+
+
+int DeepData::A_channel () const
+{
+    return m_impl->m_alpha_channel;
+}
+
+
+
+int DeepData::AR_channel () const
+{
+    return m_impl->m_AR_channel >= 0 ? m_impl->m_AR_channel : m_impl->m_alpha_channel;
+}
+
+
+
+int DeepData::AG_channel () const
+{
+    return m_impl->m_AG_channel >= 0 ? m_impl->m_AG_channel : m_impl->m_alpha_channel;
+}
+
+
+
+int DeepData::AB_channel () const
+{
+    return m_impl->m_AB_channel >= 0 ? m_impl->m_AB_channel : m_impl->m_alpha_channel;
+}
+
+
+
 string_view
 DeepData::channelname (int c) const
 {
@@ -304,6 +352,12 @@ DeepData::init (int npix, int nchan,
             m_impl->m_zback_channel = c;
         else if (m_impl->m_alpha_channel < 0 && is_or_endswithdot (channelnames[c], "A"))
             m_impl->m_alpha_channel = c;
+        else if (m_impl->m_AR_channel < 0 && is_or_endswithdot (channelnames[c], "AR"))
+            m_impl->m_AR_channel = c;
+        else if (m_impl->m_AG_channel < 0 && is_or_endswithdot (channelnames[c], "AG"))
+            m_impl->m_AG_channel = c;
+        else if (m_impl->m_AB_channel < 0 && is_or_endswithdot (channelnames[c], "AB"))
+            m_impl->m_AB_channel = c;
     }
     // Now try to find which alpha corresponds to each channel
     for (int c = 0; c < m_nchannels; ++c) {
@@ -313,8 +367,8 @@ DeepData::init (int npix, int nchan,
             continue;
         string_view name (channelnames[c]);
         // Alpha channels are their own alpha
-        if (is_or_endswithdot (name, "A")  || is_or_endswithdot (name, "RA") ||
-            is_or_endswithdot (name, "GA") || is_or_endswithdot (name, "BA")) {
+        if (is_or_endswithdot (name, "A")  || is_or_endswithdot (name, "AR") ||
+            is_or_endswithdot (name, "AG") || is_or_endswithdot (name, "AB")) {
             m_impl->m_myalphachannel[c] = c;
             continue;
         }
@@ -327,7 +381,7 @@ DeepData::init (int npix, int nchan,
             prefix = prefix.substr (0, dot+1);
             suffix = suffix.substr (dot+1);
         }
-        std::string targetalpha = std::string(prefix) + std::string(suffix) + "A";
+        std::string targetalpha = std::string(prefix) + "A" + std::string(suffix);
         for (int i = 0; i < m_nchannels; ++i) {
             if (Strutil::iequals (m_impl->m_channelnames[i], targetalpha)) {
                 m_impl->m_myalphachannel[c] = i;

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -545,7 +545,7 @@ DeepData::insert_samples (int pixel, int samplepos, int n)
 {
     int oldsamps = samples(pixel);
     set_capacity (pixel, oldsamps + n);
-    // set_capacity is thread-safe, it locks internalls. Once the acpacity
+    // set_capacity is thread-safe, it locks internally. Once the capacity
     // is adjusted, we can alter nsamples or copy the data around within
     // the pixel without a lock, we presume that if multiple threads are
     // in play, they are working on separate pixels.

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -477,6 +477,18 @@ ImageSpec::get_string_attribute (string_view name, string_view defaultval) const
 
 
 
+int
+ImageSpec::channelindex (string_view name) const
+{
+    ASSERT (nchannels == int(channelnames.size()));
+    for (int i = 0; i < nchannels; ++i)
+        if (channelnames[i] == name)
+            return i;
+    return -1;
+}
+
+
+
 namespace {  // make an anon namespace
 
 template < typename T >

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -3804,6 +3804,19 @@ OP_CUSTOMCLASS (deepmerge, OpDeepMerge, 2);
 
 
 
+class OpDeepHoldout : public OiiotoolOp {
+public:
+    OpDeepHoldout (Oiiotool &ot, string_view opname, int argc, const char *argv[])
+        : OiiotoolOp (ot, opname, argc, argv, 2) {}
+    virtual int impl (ImageBuf **img) {
+        return ImageBufAlgo::deep_holdout (*img[0], *img[1], *img[2]);
+    }
+};
+
+OP_CUSTOMCLASS (deepholdout, OpDeepHoldout, 2);
+
+
+
 class OpDeepen : public OiiotoolOp {
 public:
     OpDeepen (Oiiotool &ot, string_view opname, int argc, const char *argv[])
@@ -5003,6 +5016,7 @@ getargs (int argc, char *argv[])
                 "--over %@", action_over, NULL, "'Over' composite of two images",
                 "--zover %@", action_zover, NULL, "Depth composite two images with Z channels (options: zeroisinf=%d)",
                 "--deepmerge %@", action_deepmerge, NULL, "Merge/composite two deep images",
+                "--deepholdout %@", action_deepholdout, NULL, "Hold out one deep image by another",
                 "--histogram %@ %s %d", action_histogram, NULL, NULL, "Histogram one channel (options: cumulative=0)",
                 "--rotate90 %@", action_rotate90, NULL, "Rotate the image 90 degrees clockwise",
                 "--rotate180 %@", action_rotate180, NULL, "Rotate the image 180 degrees",

--- a/src/python/py_deepdata.cpp
+++ b/src/python/py_deepdata.cpp
@@ -174,6 +174,7 @@ void declare_deepdata()
         .def("merge_deep_pixels", &DeepData::merge_deep_pixels,
              (arg("pixel"), arg("src"), arg("srcpixel")))
         .def("occlusion_cull", &DeepData::occlusion_cull, (arg("pixel")))
+        .def("opaque_z", &DeepData::opaque_z, (arg("pixel")))
     ;
 }
 

--- a/src/python/py_deepdata.cpp
+++ b/src/python/py_deepdata.cpp
@@ -125,6 +125,12 @@ void declare_deepdata()
         .def_readonly ("nchannels",  &DeepData::channels) //DEPRECATED(1.7)
         .def_readonly ("pixels",     &DeepData::pixels)
         .def_readonly ("channels",   &DeepData::channels)
+        .def_readonly ("A_channel",  &DeepData::A_channel)
+        .def_readonly ("AR_channel", &DeepData::AR_channel)
+        .def_readonly ("AG_channel", &DeepData::AG_channel)
+        .def_readonly ("AB_channel", &DeepData::AB_channel)
+        .def_readonly ("Z_channel",  &DeepData::Z_channel)
+        .def_readonly ("Zback_channel", &DeepData::Zback_channel)
 
         .def("init",  &DeepData_init,
              (arg("npixels"), arg("nchannels"),

--- a/src/python/py_deepdata.cpp
+++ b/src/python/py_deepdata.cpp
@@ -138,6 +138,8 @@ void declare_deepdata()
         .def("init",  &DeepData_init_spec)
         .def("clear", &DeepData::clear)
         .def("free",  &DeepData::free)
+        .def("initialized",     &DeepData::initialized)
+        .def("allocated",       &DeepData::allocated)
 
         .def("samples",         &DeepData_get_samples,
              (arg("pixel")))

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -244,6 +244,16 @@ IBA_deep_merge (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
 
 
 bool
+IBA_deep_holdout (ImageBuf &dst, const ImageBuf &src, const ImageBuf &holdout,
+                  ROI roi, int nthreads)
+{
+    ScopedGILRelease gil;
+    return ImageBufAlgo::deep_holdout (dst, src, holdout, roi, nthreads);
+}
+
+
+
+bool
 IBA_copy (ImageBuf &dst, const ImageBuf &src, TypeDesc::BASETYPE convert,
           ROI roi, int nthreads)
 {
@@ -1518,6 +1528,11 @@ void declare_imagebufalgo()
              (arg("dst"), arg("A"), arg("B"), arg("occlusion_cull")=true,
               arg("roi")=ROI::All(), arg("nthreads")=0))
         .staticmethod("deep_merge")
+
+        .def("deep_holdout", IBA_deep_holdout,
+             (arg("dst"), arg("src"), arg("holdout"),
+              arg("roi")=ROI::All(), arg("nthreads")=0))
+        .staticmethod("deep_holdout")
 
         .def("copy", IBA_copy,
              (arg("dst"), arg("src"), arg("convert")=TypeDesc::UNKNOWN,

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -313,6 +313,12 @@ ImageSpec_get_string_attribute_d (const ImageSpec& spec, const char *name,
 
 
 
+static int
+ImageSpec_channelindex (const ImageSpec& spec, const std::string &name)
+{
+    return spec.channelindex (name);
+}
+
 
 
 void declare_imagespec()
@@ -370,7 +376,8 @@ void declare_imagespec()
              ImageSpec_image_bytes_overloads(args("native")))
         .def("tile_pixels",             &ImageSpec::tile_pixels)
         .def("image_pixels",            &ImageSpec::image_pixels)
-        .def("size_t_safe",             &ImageSpec::size_t_safe) 
+        .def("size_t_safe",             &ImageSpec::size_t_safe)
+        .def("channelindex",            &ImageSpec_channelindex)
 
         // For now, do not expose auto_stride.  It's not obvious that
         // anybody will want to do pointer work and strides from Python.

--- a/testsuite/python-deep/ref/out.txt
+++ b/testsuite/python-deep/ref/out.txt
@@ -190,5 +190,51 @@ Values dd has 3 pixels, 6 channels.
   sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
   sample 2 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
-Opaque z:  11.5 3.40282346639e+38 3.40282346639e+38 
+Opaque z:  11.5 3.40282346639e+38 3.40282346639e+38
+
+Testing ImageBufAlgo.deep_holdout...
+Input image dd has 6 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
+  Nsamples[ 1 ] = 1  (capacity= 1 ) samples:
+  sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.75 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
+  Nsamples[ 2 ] = 1  (capacity= 1 ) samples:
+  sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.75 /  [4 Z] 20.00 /  [5 Zback] 20.50 / 
+  Nsamples[ 3 ] = 2  (capacity= 2 ) samples:
+  sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.75 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
+  sample 1 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.75 /  [4 Z] 20.00 /  [5 Zback] 20.50 / 
+  Nsamples[ 4 ] = 3  (capacity= 3 ) samples:
+  sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.75 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
+  sample 1 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.75 /  [4 Z] 15.00 /  [5 Zback] 16.00 / 
+  sample 2 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.75 /  [4 Z] 20.00 /  [5 Zback] 20.50 / 
+Holdout image dd has 6 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
+  Nsamples[ 0 ] = 2  (capacity= 2 ) samples:
+  sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
+  sample 1 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 15.00 /  [5 Zback] 15.10 / 
+  Nsamples[ 1 ] = 2  (capacity= 2 ) samples:
+  sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
+  sample 1 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 15.10 /  [5 Zback] 15.20 / 
+  Nsamples[ 2 ] = 2  (capacity= 2 ) samples:
+  sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
+  sample 1 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 15.20 /  [5 Zback] 15.30 / 
+  Nsamples[ 3 ] = 2  (capacity= 2 ) samples:
+  sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
+  sample 1 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 15.30 /  [5 Zback] 15.40 / 
+  Nsamples[ 4 ] = 2  (capacity= 2 ) samples:
+  sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
+  sample 1 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 15.40 /  [5 Zback] 15.50 / 
+  Nsamples[ 5 ] = 2  (capacity= 2 ) samples:
+  sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
+  sample 1 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 15.50 /  [5 Zback] 15.60 / 
+Result after holdout dd has 6 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
+  Nsamples[ 1 ] = 1  (capacity= 1 ) samples:
+  sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.75 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
+  Nsamples[ 2 ] = 0  (capacity= 1 ) samples:
+  Nsamples[ 3 ] = 1  (capacity= 2 ) samples:
+  sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.75 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
+  Nsamples[ 4 ] = 2  (capacity= 3 ) samples:
+  sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.75 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
+  sample 1 :  [0 R] 0.33 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 15.00 /  [5 Zback] 15.50 / 
+
 Done.

--- a/testsuite/python-deep/ref/out.txt
+++ b/testsuite/python-deep/ref/out.txt
@@ -1,5 +1,6 @@
 test_chantypes  half half half half float float
 After init, dd has 9 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
   Nsamples[ 1 ] = 1  (capacity= 1 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 1.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   Nsamples[ 3 ] = 3  (capacity= 3 ) samples:
@@ -25,6 +26,7 @@ Writing image...
 
 Reading image...
 After init, dd has 9 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
   Nsamples[ 1 ] = 1  (capacity= 1 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 1.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   Nsamples[ 3 ] = 3  (capacity= 3 ) samples:
@@ -48,20 +50,24 @@ After init, dd has 9 pixels, 6 channels.
 
 Testing insert and erase...
 After setting one sample: dd has 3 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
   Nsamples[ 1 ] = 1  (capacity= 1 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.00 /  [4 Z] 10.00 /  [5 Zback] 0.00 / 
 After inserting before and after: dd has 3 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
   Nsamples[ 1 ] = 3  (capacity= 3 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.00 /  [4 Z] 9.00 /  [5 Zback] 0.00 / 
   sample 1 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.00 /  [4 Z] 10.00 /  [5 Zback] 0.00 / 
   sample 2 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.00 /  [4 Z] 11.00 /  [5 Zback] 0.00 / 
 After deleting the middle: dd has 3 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
   Nsamples[ 1 ] = 2  (capacity= 3 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.00 /  [4 Z] 9.00 /  [5 Zback] 0.00 / 
   sample 1 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.00 /  [4 Z] 11.00 /  [5 Zback] 0.00 / 
 
 Testing copy_deep_pixel...
 test_deep_copy: should swap pixels 3 and 5, dd has 9 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
   Nsamples[ 1 ] = 1  (capacity= 1 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 1.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   Nsamples[ 3 ] = 5  (capacity= 5 ) samples:
@@ -85,6 +91,7 @@ test_deep_copy: should swap pixels 3 and 5, dd has 9 pixels, 6 channels.
 
 Testing split...
 After split, dd has 2 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
   Nsamples[ 0 ] = 2  (capacity= 2 ) samples:
   sample 0 :  [0 R] 0.50 /  [1 G] 0.10 /  [2 B] 0.10 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 11.00 / 
   sample 1 :  [0 R] 0.10 /  [1 G] 0.50 /  [2 B] 0.10 /  [3 A] 0.50 /  [4 Z] 20.00 /  [5 Zback] 21.00 / 
@@ -95,6 +102,7 @@ After split, dd has 2 pixels, 6 channels.
 
 Testing sort...
 Before z sort, dd has 2 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
   Nsamples[ 0 ] = 4  (capacity= 4 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 20.00 /  [5 Zback] 20.50 / 
   sample 1 :  [0 R] 0.10 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 19.00 /  [5 Zback] 19.50 / 
@@ -106,6 +114,7 @@ Before z sort, dd has 2 pixels, 6 channels.
   sample 2 :  [0 R] 0.20 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 18.00 /  [5 Zback] 18.50 / 
   sample 3 :  [0 R] 0.30 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 17.00 /  [5 Zback] 17.50 / 
 After z sort of pixel 1, dd has 2 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
   Nsamples[ 0 ] = 4  (capacity= 4 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 20.00 /  [5 Zback] 20.50 / 
   sample 1 :  [0 R] 0.10 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 19.00 /  [5 Zback] 19.50 / 
@@ -119,6 +128,7 @@ After z sort of pixel 1, dd has 2 pixels, 6 channels.
 
 Testing merge_overlaps...
 Before merge_overlaps, dd has 2 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
   Nsamples[ 0 ] = 4  (capacity= 4 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.10 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
@@ -130,6 +140,7 @@ Before merge_overlaps, dd has 2 pixels, 6 channels.
   sample 2 :  [0 R] 0.20 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
   sample 3 :  [0 R] 0.30 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
 After merge_overlaps of pixel 1, dd has 2 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
   Nsamples[ 0 ] = 4  (capacity= 4 ) samples:
   sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.10 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
@@ -141,12 +152,15 @@ After merge_overlaps of pixel 1, dd has 2 pixels, 6 channels.
 
 Testing merge_deep_pixels...
 Before merge_deep_pixels, dd has 1 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
   Nsamples[ 0 ] = 1  (capacity= 1 ) samples:
   sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 12.00 / 
 And the other image, dd has 1 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
   Nsamples[ 0 ] = 1  (capacity= 1 ) samples:
   sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 11.00 /  [5 Zback] 13.00 / 
 After merge_deep_pixels, dd has 1 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
   Nsamples[ 0 ] = 3  (capacity= 4 ) samples:
   sample 0 :  [0 R] 0.29 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.29 /  [4 Z] 10.00 /  [5 Zback] 11.00 / 
   sample 1 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 11.00 /  [5 Zback] 12.00 / 
@@ -154,11 +168,13 @@ After merge_deep_pixels, dd has 1 pixels, 6 channels.
 
 Testing occlusion_cull...
 Before occlusion_cull, dd has 1 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
   Nsamples[ 0 ] = 3  (capacity= 3 ) samples:
   sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
   sample 2 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
 After occlusion_cull, dd has 1 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
   Nsamples[ 0 ] = 2  (capacity= 3 ) samples:
   sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 

--- a/testsuite/python-deep/ref/out.txt
+++ b/testsuite/python-deep/ref/out.txt
@@ -179,4 +179,16 @@ After occlusion_cull, dd has 1 pixels, 6 channels.
   sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
   sample 1 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
 
+Testing opaque_z...
+Values dd has 3 pixels, 6 channels.
+  Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
+  Nsamples[ 0 ] = 3  (capacity= 3 ) samples:
+  sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
+  sample 1 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 1.00 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
+  sample 2 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
+  Nsamples[ 1 ] = 3  (capacity= 3 ) samples:
+  sample 0 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 10.00 /  [5 Zback] 10.50 / 
+  sample 1 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 11.00 /  [5 Zback] 11.50 / 
+  sample 2 :  [0 R] 0.50 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 12.00 /  [5 Zback] 12.50 / 
+Opaque z:  11.5 3.40282346639e+38 3.40282346639e+38 
 Done.

--- a/testsuite/python-deep/src/test_deep.py
+++ b/testsuite/python-deep/src/test_deep.py
@@ -42,6 +42,7 @@ def make_test_deep_image () :
 
 def print_deep_image (dd, prefix="After init,") :
     print prefix, "dd has", dd.pixels, "pixels,", dd.channels, "channels."
+    print "  Channel indices: Z=", dd.Z_channel, "Zback=", dd.Zback_channel, "A=", dd.A_channel, "AR=", dd.AR_channel, "AG=", dd.AG_channel, "AB=", dd.AB_channel
     for p in range(dd.pixels) :
         ns = dd.samples(p)
         if ns > 0 or dd.capacity(p) > 0 :

--- a/testsuite/python-deep/src/test_deep.py
+++ b/testsuite/python-deep/src/test_deep.py
@@ -192,6 +192,35 @@ def test_occlusion_cull () :
     dd.occlusion_cull (0)
     print_deep_image (dd, "After occlusion_cull,")
 
+def test_opaque_z () :
+    print "\nTesting opaque_z..."
+    dd = oiio.DeepData ()
+    # 3 test pixels
+    dd.init (3, test_nchannels, test_chantypes, test_channames)
+    # First pixel: has 3 samples, middle one is opaque
+    dd.set_samples (0, 3)
+    for s in range(dd.samples(0)) :
+        dd.set_deep_value (0, 0, s, 0.5) # R
+        dd.set_deep_value (0, 1, s, 0.0) # G
+        dd.set_deep_value (0, 2, s, 0.0) # B
+        dd.set_deep_value (0, 3, s, (1.0 if s==1 else 0.5)) # A
+        dd.set_deep_value (0, 4, s, 10.0+s) # Z
+        dd.set_deep_value (0, 5, s, 10.5+s) # Zback
+    # Second pixel: 3 samples, none are opaque
+    dd.set_samples (1, 3)
+    for s in range(dd.samples(0)) :
+        dd.set_deep_value (1, 0, s, 0.5) # R
+        dd.set_deep_value (1, 1, s, 0.0) # G
+        dd.set_deep_value (1, 2, s, 0.0) # B
+        dd.set_deep_value (1, 3, s, 0.5) # A
+        dd.set_deep_value (1, 4, s, 10.0+s) # Z
+        dd.set_deep_value (1, 5, s, 10.5+s) # Zback
+    # Third pixel is empty
+    print_deep_image (dd, "Values")
+    print "Opaque z: ",
+    for p in range(dd.pixels) :
+        print dd.opaque_z(p),
+
 
 
 ######################################################################
@@ -227,6 +256,7 @@ try:
     test_merge_overlaps ()
     test_merge_deep_pixels ()
     test_occlusion_cull ()
+    test_opaque_z ()
 
     print "\nDone."
 

--- a/testsuite/python-imagespec/ref/out.txt
+++ b/testsuite/python-imagespec/ref/out.txt
@@ -54,6 +54,8 @@ lots of fields
   z channel =  -1
   deep =  False
 
+ B channel = 2
+ foo channel = -1
 channel bytes = 4
   channel_bytes(1) = 4 native 1
   channel_bytes(4) = 4 native 4

--- a/testsuite/python-imagespec/src/test_imagespec.py
+++ b/testsuite/python-imagespec/src/test_imagespec.py
@@ -63,6 +63,8 @@ try:
     s.default_channel_names()
     s.channelformats = (oiio.UINT8, oiio.UINT8, oiio.UINT8, oiio.UINT8, oiio.FLOAT)
     print_imagespec (s, "lots of fields")
+    print " B channel =", s.channelindex("B")
+    print " foo channel =", s.channelindex("foo")
 
     print "channel bytes =", s.channel_bytes()
     print "  channel_bytes(1) =", s.channel_bytes(1), "native", s.channel_bytes(1,True)


### PR DESCRIPTION
The deep holdout function is one that culls the deep samples in one deep    image (A) that are behind the opaque depth of a second deep image (B).    No samples of B are included in the output, it is only used to mask    parts of A. Samples of A that straddle the opaque frontier are split.

This is implemented as ImageBufAlgo::deep_holdout(), and also in  oiiotool --deepholeout.

This was suggested/requested by users. I believe the use case is that you have separately rendered volumetric elements and hard surfaces, and the user wants an oiiotool-based workflow that can inexpensively cull large sections of the volume that will get hidden by the opaque hard surfaces anyway, to make it much lighter and faster in Nuke or other processing that needs to happen to it.

Along the way, I made several other changes in the various utilities and APIs related to processing deep images (partitioned into several independent commits):

* New `ImageSpec::channelindex()` retrieves index of named channel.

* Have `DeepData::impl` find, store, and retrieve important channel indices.

* Alter `DeepData::split()` to return a bool indicating whether or not any splits occurred.

* New `DeepData::opaque_z()` method returns the z at which a deep pixel is fully opaque.

* New `DeepData::initialized()` and `allocated()` methods let you find out if the DD is initialized or allocated. As it turns out, in the end I didn't use these for the deep holdout work, but I want to keep it anyway.

This all looks complicated in toto, but if you are curious to inspect the individual commits, each one is a fairly isolated change that is easy to follow.
