### PR TITLE
Adjust deprecated IBA color conversion functions

### DIFF
--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -972,16 +972,13 @@ bool OIIO_API colorconvert (ImageBuf &dst, const ImageBuf &src,
                             string_view context_value="",
                             ColorConfig *colorconfig=NULL,
                             ROI roi=ROI::All(), int nthreads=0);
-// DEPRECATED: [1.7]
+
+OIIO_DEPRECATED("Use the other version. [1.7]")
 bool OIIO_API colorconvert (ImageBuf &dst, const ImageBuf &src,
                             string_view from, string_view to,
-                            bool unpremult=false,
-                            ColorConfig *colorconfig=NULL,
+                            bool unpremult,
+                            ColorConfig *colorconfig,
                             ROI roi=ROI::All(), int nthreads=0);
-OIIO_DEPRECATED("Use the version that takes a ColorConfig*. [1.6]")
-bool OIIO_API colorconvert (ImageBuf &dst, const ImageBuf &src,
-                            string_view from, string_view to,
-                            bool unpremult, ROI roi, int nthreads=0);
 
 /// Copy pixels within the ROI from src to dst, applying a color transform.
 /// In-place operations (dst == src) are supported.
@@ -1032,12 +1029,6 @@ bool OIIO_API ociolook (ImageBuf &dst, const ImageBuf &src,
                         string_view key="", string_view value="",
                         ColorConfig *colorconfig=NULL,
                         ROI roi=ROI::All(), int nthreads=0);
-OIIO_DEPRECATED("Use the version that takes a ColorConfig*. [1.6]")
-bool OIIO_API ociolook (ImageBuf &dst, const ImageBuf &src,
-                        string_view looks, string_view from, string_view to,
-                        bool unpremult, bool inverse,
-                        string_view key, string_view value,
-                        ROI roi, int nthreads=0);
 
 /// Copy pixels within the ROI from src to dst, applying an OpenColorIO
 /// "display" transform.  If from or looks are NULL, it will not
@@ -1063,12 +1054,6 @@ bool OIIO_API ociodisplay (ImageBuf &dst, const ImageBuf &src,
                         string_view key="", string_view value="",
                         ColorConfig *colorconfig=NULL,
                         ROI roi=ROI::All(), int nthreads=0);
-OIIO_DEPRECATED("Use the version that takes a ColorConfig*. [1.6]")
-bool OIIO_API ociodisplay (ImageBuf &dst, const ImageBuf &src,
-                        string_view display, string_view view,
-                        string_view from, string_view looks,
-                        bool unpremult, string_view key, string_view value,
-                        ROI roi, int nthreads=0);
 
 /// Copy pixels within the ROI from src to dst, applying an OpenColorIO
 /// "file" transform.  If inverse is true, it will reverse the color

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -888,16 +888,6 @@ static spin_mutex colorconfig_mutex;
 bool
 ImageBufAlgo::colorconvert (ImageBuf &dst, const ImageBuf &src,
                             string_view from, string_view to,
-                            bool unpremult, ROI roi, int nthreads)
-{
-    return colorconvert (dst, src, from, to, unpremult, NULL, roi, nthreads);
-}
-
-
-
-bool
-ImageBufAlgo::colorconvert (ImageBuf &dst, const ImageBuf &src,
-                            string_view from, string_view to,
                             bool unpremult, ColorConfig *colorconfig,
                             ROI roi, int nthreads)
 {
@@ -1086,19 +1076,6 @@ ImageBufAlgo::ociolook (ImageBuf &dst, const ImageBuf &src,
                         string_view looks, string_view from, string_view to,
                         bool inverse, bool unpremult,
                         string_view key, string_view value,
-                        ROI roi, int nthreads)
-{
-    return ociolook (dst, src, looks, from, to, inverse, unpremult,
-                     key, value, NULL, roi, nthreads);
-}
-
-
-
-bool
-ImageBufAlgo::ociolook (ImageBuf &dst, const ImageBuf &src,
-                        string_view looks, string_view from, string_view to,
-                        bool inverse, bool unpremult,
-                        string_view key, string_view value,
                         ColorConfig *colorconfig,
                         ROI roi, int nthreads)
 {
@@ -1137,20 +1114,6 @@ ImageBufAlgo::ociolook (ImageBuf &dst, const ImageBuf &src,
         colorconfig->deleteColorProcessor (processor);
     }
     return ok;
-}
-
-
-    
-bool
-ImageBufAlgo::ociodisplay (ImageBuf &dst, const ImageBuf &src,
-                           string_view display, string_view view,
-                           string_view from, string_view looks,
-                           bool unpremult,
-                           string_view key, string_view value,
-                           ROI roi, int nthreads)
-{
-    return ociodisplay (dst, src, display, view, from, looks, unpremult,
-                        key, value, NULL, roi, nthreads);
 }
 
 

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -1022,8 +1022,8 @@ IBA_colorconvert (ImageBuf &dst, const ImageBuf &src,
                   ROI roi = ROI::All(), int nthreads = 0)
 {
     ScopedGILRelease gil;
-    return ImageBufAlgo::colorconvert (dst, src, from, to,
-                                       unpremult, NULL, roi, nthreads);
+    return ImageBufAlgo::colorconvert (dst, src, from, to, unpremult,
+                                       "", "", nullptr, roi, nthreads);
 }
 
 


### PR DESCRIPTION
For several ImageBufAlgo functions related to color conversion:

* Deprecated in 1.7 -> turn on the OIIO_DEPRECATED attribute.

* Deprecated in 1.6, attribute turned on in 1.7 -> remove them.

