### PR TITLE
ImageCache :  Fix crash caused by dereferencing end iterator

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -2336,8 +2336,10 @@ ImageCacheImpl::check_max_mem (ImageCachePerThreadInfo *thread_info)
     // looking up the first entry in the tile cache.
     if (m_tile_sweep_id.empty()) {
         TileCache::iterator sweep = m_tilecache.begin();
-        DASSERT (sweep != m_tilecache.end() &&
-                "no way m_tilecache can be empty and use too much memory");
+        if (sweep == m_tilecache.end()) {
+            m_tile_sweep_mutex.unlock();
+            return;
+        }
         m_tile_sweep_id = (*sweep).first;
     }
 


### PR DESCRIPTION
In issue #1239, @lgritz described a situation in which the assertion in `check_max_mem()` could be triggered because `m_tilecache` could be empty, but `m_mem_used` could still be over the limit due to "dead man walking" tiles still being held in per-thread microcaches. A temporary fix was created in PR #1240, simply replacing the ASSERT with a DASSERT so that release builds wouldn't trigger the assertions. But this just allowed release builds to execute exactly the code path that the assertions were intended to protect - leading to the dereferencing of an invalid TileCache iterator. Here we simply replace the DASSERT with an early return if we detect this unexpected (but still entirely possible) situation.


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

