### PR TITLE
Add support for OpenEXR rationals, implementing TypeDesc::TypeRationa…

### DIFF
--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -91,7 +91,8 @@ struct OIIO_API TypeDesc {
                         VECTOR,   // spatial direction
                         NORMAL,   // surface normal
                         TIMECODE, // SMPTE timecode (should be int[2])
-                        KEYCODE   // SMPTE keycode (should be int[7])
+                        KEYCODE,  // SMPTE keycode (should be int[7])
+                        RATIONAL  // paired numerator and denominator
                       };
 
     unsigned char basetype;     ///< C data type at the heart of our type
@@ -310,6 +311,7 @@ struct OIIO_API TypeDesc {
     static const TypeDesc TypeTimeCode;
     static const TypeDesc TypeKeyCode;
     static const TypeDesc TypeFloat4;
+    static const TypeDesc TypeRational;
 };
 
 

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -607,7 +607,7 @@ void test_arithmetic ()
 template<typename VEC>
 void test_fused ()
 {
-    typedef typename VEC::value_t ELEM;
+    // typedef typename VEC::value_t ELEM;
     test_heading ("fused ", VEC::type_name());
 
     VEC a = VEC::Iota (10);
@@ -643,7 +643,7 @@ template<typename T> T do_andnot (const T& a, const T& b) { return andnot(a,b); 
 template<typename VEC>
 void test_bitwise_int ()
 {
-    typedef typename VEC::value_t ELEM;
+    // typedef typename VEC::value_t ELEM;
     test_heading ("bitwise ", VEC::type_name());
 
     VEC a (0x12341234);
@@ -674,7 +674,7 @@ void test_bitwise_int ()
 template<typename VEC>
 void test_bitwise_bool ()
 {
-    typedef int ELEM;
+    // typedef int ELEM;
     test_heading ("bitwise ", VEC::type_name());
 
     bool A[]   = { true,  true,  false, false, false, false, true,  true  };
@@ -894,7 +894,7 @@ template<typename VEC>
 void test_shift ()
 {
     test_heading ("shift ", VEC::type_name());
-    typedef typename VEC::value_t ELEM;
+    // typedef typename VEC::value_t ELEM;
 
     // Basics of << and >>
     VEC i = VEC::Iota (10, 10);   // 10, 20, 30 ...
@@ -1078,7 +1078,7 @@ template<typename VEC>
 void test_mathfuncs ()
 {
     test_heading ("mathfuncs", VEC::type_name());
-    typedef typename VEC::value_t ELEM;
+    // typedef typename VEC::value_t ELEM;
 
     VEC A = mkvec<VEC> (-1.0f, 0.0f, 1.0f, 4.5f);
     VEC expA = mkvec<VEC> (0.367879441171442f, 1.0f, 2.718281828459045f, 90.0171313005218f);

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -607,7 +607,6 @@ void test_arithmetic ()
 template<typename VEC>
 void test_fused ()
 {
-    // typedef typename VEC::value_t ELEM;
     test_heading ("fused ", VEC::type_name());
 
     VEC a = VEC::Iota (10);
@@ -643,7 +642,6 @@ template<typename T> T do_andnot (const T& a, const T& b) { return andnot(a,b); 
 template<typename VEC>
 void test_bitwise_int ()
 {
-    // typedef typename VEC::value_t ELEM;
     test_heading ("bitwise ", VEC::type_name());
 
     VEC a (0x12341234);
@@ -674,7 +672,6 @@ void test_bitwise_int ()
 template<typename VEC>
 void test_bitwise_bool ()
 {
-    // typedef int ELEM;
     test_heading ("bitwise ", VEC::type_name());
 
     bool A[]   = { true,  true,  false, false, false, false, true,  true  };
@@ -894,7 +891,6 @@ template<typename VEC>
 void test_shift ()
 {
     test_heading ("shift ", VEC::type_name());
-    // typedef typename VEC::value_t ELEM;
 
     // Basics of << and >>
     VEC i = VEC::Iota (10, 10);   // 10, 20, 30 ...
@@ -1078,7 +1074,6 @@ template<typename VEC>
 void test_mathfuncs ()
 {
     test_heading ("mathfuncs", VEC::type_name());
-    // typedef typename VEC::value_t ELEM;
 
     VEC A = mkvec<VEC> (-1.0f, 0.0f, 1.0f, 4.5f);
     VEC expA = mkvec<VEC> (0.367879441171442f, 1.0f, 2.718281828459045f, 90.0171313005218f);

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -217,6 +217,7 @@ TypeDesc::c_str () const
         case POINT  : vec = "point"; break;
         case VECTOR : vec = "vector"; break;
         case NORMAL : vec = "normal"; break;
+        case RATIONAL  : vec = "rational"; break;
         default: ASSERT (0 && "Invalid vector semantics");
         }
         const char *agg = "";
@@ -301,6 +302,8 @@ TypeDesc::fromstring (string_view typestring)
         t = TypeMatrix44;
     else if (type == "timecode")
         t = TypeTimeCode;
+    else if (type == "rational")
+        t = TypeRational;
     else {
         return 0;  // unknown
     }
@@ -436,6 +439,7 @@ const TypeDesc TypeDesc::TypeHalf (TypeDesc::HALF);
 const TypeDesc TypeDesc::TypeTimeCode (TypeDesc::UINT, TypeDesc::SCALAR, TypeDesc::TIMECODE, 2);
 const TypeDesc TypeDesc::TypeKeyCode (TypeDesc::INT, TypeDesc::SCALAR, TypeDesc::KEYCODE, 7);
 const TypeDesc TypeDesc::TypeFloat4 (TypeDesc::FLOAT, TypeDesc::VEC4);
+const TypeDesc TypeDesc::TypeRational(TypeDesc::INT, TypeDesc::VEC2, TypeDesc::RATIONAL);
 
 
 OIIO_NAMESPACE_END

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -715,7 +715,7 @@ OpenEXRInput::PartInfo::parse_header (const Imf::Header *header)
             const Imf::Rational *rational = &rattr->value();
             int n = rational->n;
             unsigned int d = rational->d;
-            if (d < (1 << 31)) {
+            if (d < (1UL << 31)) {
                 int r[2];
                 r[0] = n;
                 r[1] = static_cast<int>(d);

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -58,6 +58,7 @@
 #include <OpenEXR/ImfEnvmapAttribute.h>
 #include <OpenEXR/ImfCompressionAttribute.h>
 #include <OpenEXR/ImfChromaticitiesAttribute.h>
+#include <OpenEXR/ImfRationalAttribute.h>
 #include <OpenEXR/ImfCRgbaFile.h>  // JUST to get symbols to figure out version!
 #include <OpenEXR/IexBaseExc.h>
 #include <OpenEXR/IexThrowErrnoExc.h>
@@ -1057,6 +1058,13 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
                 case TypeDesc::UINT:
                 case TypeDesc::INT:
                 // TODO could probably handle U/INT16 here too
+                    if (type.vecsemantics == TypeDesc::RATIONAL) {
+                        // It's a floor wax AND a dessert topping
+                        const int* intArray = reinterpret_cast<const int*>(data);
+                        const unsigned int* uIntArray = reinterpret_cast<const unsigned int*>(data);
+                        header.insert(xname.c_str(), Imf::RationalAttribute(Imf::Rational(intArray[0], uIntArray[1])));
+                        return true;
+                    }
                     header.insert (xname.c_str(), Imf::V2iAttribute (*(Imath::V2i*)data));
                     return true;
                 case TypeDesc::FLOAT:
@@ -1080,7 +1088,7 @@ OpenEXROutput::put_parameter (const std::string &name, TypeDesc type,
                 case TypeDesc::UINT:
                 case TypeDesc::INT:
                 // TODO could probably handle U/INT16 here too
-                    header.insert (xname.c_str(), Imf::V3iAttribute (*(Imath::V3i*)data));
+                     header.insert (xname.c_str(), Imf::V3iAttribute (*(Imath::V3i*)data));
                     return true;
                 case TypeDesc::FLOAT:
                     header.insert (xname.c_str(), Imf::V3fAttribute (*(Imath::V3f*)data));


### PR DESCRIPTION
…l along the way. Comment out some unused typedefs in simd_test that were stopping the compile.


## Description

OpenEXR includes a Rational type, defined as the ratio of a 32-bit signed numerator and a 32-bit unsigned denominator. As it stands OpenImageIO has no support for such rationals, and oiiotool -I foo.exr -o bar.exr will drop Rational attributes such as framesPerSecond and captureRate. This patch adds a new type description, TypeDesc::TypeRational, and makes some small changes to the OpenEXR reader and write to handle such types when encountered.

There are two open design issues and one open seemingly unrelated implementation issue.

The first design issue is this: other rational types (such as those found in TIFF) implement rationals differently. TIFF in particular supports rationals that are unsigned 32-bit int over unsigned 32-bit int. If a TIFF file has a rational attribute of this type, and the GCD of the numerator and denominator is 1, and the magnitude of the denominator is > than (1 << 31), then this TIFF value cannot be transcoded exactly to an OpenEXR rational. On the one hand the purpose of rational arithmetic type is to preserve exact proportions; on the other hand, in practice, rationals are usually employed to represent fractional frame rates, which are relatively small integers multiple by the ration (1000 / 1001), e.g. 30000 / 1001. I have never in practice seen a rational whose denominator was anywhere near (1 << 31) in magnitude. So, what to do in this transcoding case? The two possibilities would seem to be to throw an exception or produce an approximate result. If the former, I think it should be possible via some global mechanism to suppress the exception and force an approximate result. Larry has said in private email he is inclined to the latter. In any case I am not sure where one would put code to handle these transcoding cases, especially as any non-OpenEXR rationals must today be getting converted to and from floats, as to date there has been no true rational type.

The other open design issue is that users may wish to add rational attributes to OpenEXR on the command line, and this pull request as it stands does not add the functionality of parsing rationals as would be needed to support
oiiotool in.exr -attrib:type=rational captureRate "30000/1001" -o out.exr
or the like. But I didn't want to try and develop this functionality until the underlying rational support had received some review and, I hope, approval.

The seemingly unrelated implementation issue is that I was unable to get OpenImageIO to compile until I commented out several unused typedefs in simd_util.cpp. My compiler is:
Apple LLVM version 8.1.0 (clang-802.0.42)
Target: x86_64-apple-darwin16.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
and the OS is macOS Sierra 10.12.5.

## Tests

The only testing I have done is to manually copy (with oiiotool -I foo.exr -o bar.exr) an OpenEXR file with framesPerSecond and captureRate set in foo.exr, and verify that bar.exr contains those attributes, unchanged. Would it suffice to add an image with those attributes to the opener-images/TestImages folder, and if so, how do I submit such an image?

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).

- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
I am about to send email to corporate so that I can get their approval. For this, I don't think there should be any problem.

- [X] I have updated the documentation, if applicable.
(I don't see that this is applicable, so yeah.)

- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
This has not been done but if as mentioned above it's just a matter of submitting a test image with rational attributes, I can do that.

- [X] My code follows the prevailing code style of this project.
Yes, except for one spurious comment I expect Larry to remove.

