### PR TITLE
Fix Ilmbase linker warning with LINKSTATIC on Windows.

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -150,7 +150,6 @@ if (MSVC)
     add_definitions (-D_CRT_NONSTDC_NO_WARNINGS)
     add_definitions (-D_SCL_SECURE_NO_WARNINGS)
     add_definitions (-DJAS_WIN_MSVC_BUILD)
-    add_definitions (-DOPENEXR_DLL)
 endif (MSVC)
 
 # Use ccache if found
@@ -330,6 +329,7 @@ if (LINKSTATIC)
 else ()
     if (MSVC)
         add_definitions (-DBOOST_ALL_DYN_LINK)
+        add_definitions (-DOPENEXR_DLL)
     endif ()
 endif ()
 


### PR DESCRIPTION
After recent refactoring OPENEXR_DLL is defined when LINKSTATIC=ON which I'm guessing was not an intentional change. This restores the behavior before the refactor, fixing a bunch of LNK4217 warnings when building with static IlmBase libraries.

This matches the OSL fix in imageworks/OpenShadingLanguage#768