### PR TITLE
ImageSpec::channel_name(int) returns channel name safely

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -398,6 +398,13 @@ public:
             ? channelformats[chan] : format;
     }
 
+    /// Return the channel name of the given channel. This is safe even if
+    /// channelnames is not filled out.
+    string_view channel_name (int chan) const {
+        return chan >= 0 && chan < (int)channelnames.size()
+            ? channelnames[chan] : "";
+    }
+
     /// Fill in an array of channel formats describing all channels in
     /// the image.  (Note that this differs slightly from the member
     /// data channelformats, which is empty if there are not separate

--- a/src/libOpenImageIO/imagespec_test.cpp
+++ b/src/libOpenImageIO/imagespec_test.cpp
@@ -208,6 +208,12 @@ test_get_attribute ()
     OIIO_CHECK_EQUAL (spec.get_int_attribute("width"), 640);
     OIIO_CHECK_EQUAL (spec.get_int_attribute("height"), 480);
     OIIO_CHECK_EQUAL (spec.get_int_attribute("nchannels"), 4);
+    OIIO_CHECK_EQUAL (spec.channelnames.size(), 4);
+    OIIO_CHECK_EQUAL (spec.channel_name(0), "R");
+    OIIO_CHECK_EQUAL (spec.channel_name(1), "G");
+    OIIO_CHECK_EQUAL (spec.channel_name(2), "B");
+    OIIO_CHECK_EQUAL (spec.channel_name(3), "A");
+    OIIO_CHECK_EQUAL (spec.channel_name(4), "");
     OIIO_CHECK_EQUAL (spec.get_int_attribute("x"), 10);
     OIIO_CHECK_EQUAL (spec.get_int_attribute("y"), 12);
     OIIO_CHECK_EQUAL (spec.get_int_attribute("full_x"), -5);


### PR DESCRIPTION
Safely means, even if the channelnames is not filled out or you ask
for an out-of-range index, it will not crash or overrun the array, but
rather just return an empty channel name.
