### PR TITLE
Minor simd.h touchups

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -459,7 +459,7 @@ bool none (const bool4& v);
 
 /// bool8: An 8-vector whose elements act mostly like bools, accelerated by
 /// SIMD instructions when available. This is what is naturally produced by
-/// SIMD comparison operators on the float4 and int4 types.
+/// SIMD comparison operators on the float8 and int8 types.
 class bool8 {
 public:
     static const char* type_name() { return "bool8"; }
@@ -540,7 +540,6 @@ public:
     void store (bool *values, int n) const;
 
     /// Logical/bitwise operators, component-by-component
-    friend bool4 operator! (const bool4& a);
     friend bool8 operator! (const bool8& a);
     friend bool8 operator& (const bool8& a, const bool8& b);
     friend bool8 operator| (const bool8& a, const bool8& b);

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -349,7 +349,7 @@ public:
     /// Construct from a single value (store it in all slots)
     bool4 (bool a) { load(a); }
 
-    explicit bool4 (bool *a);
+    explicit bool4 (const bool *a);
 
     /// Construct from 4 values
     bool4 (bool a, bool b, bool c, bool d) { load (a, b, c, d); }
@@ -476,7 +476,7 @@ public:
     /// Construct from a single value (store it in all slots)
     bool8 (bool a) { load (a); }
 
-    explicit bool8 (bool *values);
+    explicit bool8 (const bool *values);
 
     /// Construct from 8 values
     bool8 (bool a, bool b, bool c, bool d, bool e, bool f, bool g, bool h);
@@ -2004,7 +2004,7 @@ OIIO_FORCEINLINE void bool4::load (bool a, bool b, bool c, bool d) {
 #endif
 }
 
-OIIO_FORCEINLINE bool4::bool4 (bool *a) {
+OIIO_FORCEINLINE bool4::bool4 (const bool *a) {
     load (a[0], a[1], a[2], a[3]);
 }
 
@@ -2306,7 +2306,7 @@ OIIO_FORCEINLINE bool8::bool8 (bool a, bool b, bool c, bool d,
     load (a, b, c, d, e, f, g, h);
 }
 
-OIIO_FORCEINLINE bool8::bool8 (bool *a) {
+OIIO_FORCEINLINE bool8::bool8 (const bool *a) {
     load (a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]);
 }
 

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -386,9 +386,10 @@ public:
     int operator[] (int i) const;
 
     /// Component access (set).
-    /// NOTE: use with caution. The implementation sets the integer
-    /// value, which may not have the same bit pattern as the bool returned
-    /// by operator[]const.
+    void setcomp (int i, bool value);
+
+    /// Component access (set).
+    /// NOTE: avoid this unsafe construct. It will go away some day.
     int& operator[] (int i);
 
     /// Helper: load a single value into all components.
@@ -515,9 +516,10 @@ public:
     int operator[] (int i) const;
 
     /// Component access (set).
-    /// NOTE: use with caution. The implementation sets the integer
-    /// value, which may not have the same bit pattern as the bool returned
-    /// by operator[]const.
+    void setcomp (int i, bool value);
+
+    /// Component access (set).
+    /// NOTE: avoid this unsafe construct. It will go away some day.
     int& operator[] (int i);
 
     /// Extract the lower percision bool4
@@ -1965,6 +1967,12 @@ OIIO_FORCEINLINE int& bool4::operator[] (int i) {
 }
 
 
+OIIO_FORCEINLINE void bool4::setcomp (int i, bool value) {
+    DASSERT(i >= 0 && i < elements);
+    m_val[i] = value ? -1 : 0;
+}
+
+
 OIIO_FORCEINLINE std::ostream& operator<< (std::ostream& cout, const bool4& a) {
     cout << a[0];
     for (int i = 1; i < a.elements; ++i)
@@ -2243,6 +2251,11 @@ OIIO_FORCEINLINE int bool8::operator[] (int i) const {
 #else
     return m_val[i];
 #endif
+}
+
+OIIO_FORCEINLINE void bool8::setcomp (int i, bool value) {
+    DASSERT(i >= 0 && i < elements);
+    m_val[i] = value ? -1 : 0;
 }
 
 OIIO_FORCEINLINE int& bool8::operator[] (int i) {


### PR DESCRIPTION
* Add a bool4 and bool8 setcomp() method. It's a safer alternative to the existing `int& operator[]`, which is very sketchy with its exposing an `int&`, which isn't guaranteed to be the underlying representation (and won't be, when we add AVX-512). Eventually we'll make the unsafe ones deprecated. We certainly won't be extending them to bool16.

* Properly const bool4 and bool construction and load from `bool *`. Lack of const here was just an oversight.

* Fix a comment and remove a redundant declaration.
