### PR TITLE
iv / Qt5 -- compensate for display scaling

### DIFF
--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -123,6 +123,13 @@ IvGL::initializeGL ()
     // Make sure initial matrix is identity (returning to this stack level loads
     // back this matrix).
     glLoadIdentity();
+
+#if 1
+    // Compensate for high res displays with device pixel ratio scaling
+    float dpr = m_viewer.devicePixelRatio();
+    glScalef (dpr, dpr, 1.0f);
+#endif
+
     // There's this small detail in the OpenGL 2.1 (probably earlier versions
     // too) spec:
     //


### PR DESCRIPTION
After upgrading to Qt5, display scaling was all wrong on my Mac laptop with retina display. Some web searching revealed how to retrieve the device pixel ratio and use it as a scaling factor for GL.

This seems to mostly fix things.
