### PR TITLE
OpenEXR: ensure that "YA" images get channels presented in the right order

### DIFF
--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -796,7 +796,7 @@ struct ChanNameHolder {
             suffix = string_view (fullname.data()+dot+1, fullname.size()-dot-1);
         }
         static const char * special[] = {
-            "R", "Red", "G", "Green", "B", "Blue", "real", "imag",
+            "R", "Red", "G", "Green", "B", "Blue", "Y", "real", "imag",
             "A", "Alpha", "AR", "RA", "AG", "GA", "AB", "BA",
             "Z", "Depth", "Zback", NULL
         };


### PR DESCRIPTION
Background: OpenEXR forces channels to be stored (or at least presents
it through its API) in strictly alphabetical order. But OIIO expects
uniform channel orders for all the common cases such as RGBA.

For a 2-channel image that's intensity and alpha, we name the channels
"Y" and "A", and expect it to be presented with alpha second, as usual.
But OpenEXR was flipping the channel order because "A" comes before "Y"
alphabetically. Sheesh. It was because we neglected to put "Y" in the
list of special channel names that have order imposed. Easy fix.

