### PR TITLE
TIFF: clean up alpha channel handling

### DIFF
--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -867,8 +867,13 @@ TIFFInput::readspec (bool read_meta)
                 }
             }
         }
-        if (m_spec.alpha_channel >= 0)
+        if (m_spec.alpha_channel >= 0) {
             m_spec.channelnames[m_spec.alpha_channel] = "A";
+            // Special case: "R","A" should really be named "Y","A", since
+            // the first channel is luminance, not red.
+            if (m_spec.nchannels == 2 && m_spec.alpha_channel == 1)
+                m_spec.channelnames[0] = "Y";
+        }
     }
     // Will we need to do alpha conversions?
     m_convert_alpha = (m_spec.alpha_channel >= 0 && alpha_is_unassociated &&

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -393,7 +393,7 @@ TIFFOutput::open (const std::string &name, const ImageSpec &userspec,
     TIFFSetField (m_tif, TIFFTAG_BITSPERSAMPLE, m_bitspersample);
     TIFFSetField (m_tif, TIFFTAG_SAMPLEFORMAT, sampformat);
 
-    m_photometric = (m_spec.nchannels > 1 ? PHOTOMETRIC_RGB : PHOTOMETRIC_MINISBLACK);
+    m_photometric = (m_spec.nchannels >= 3 ? PHOTOMETRIC_RGB : PHOTOMETRIC_MINISBLACK);
 
     string_view comp = m_spec.get_string_attribute("Compression", "zip");
     if (Strutil::iequals (comp, "jpeg") &&
@@ -482,12 +482,14 @@ TIFFOutput::open (const std::string &name, const ImageSpec &userspec,
     TIFFSetField (m_tif, TIFFTAG_PHOTOMETRIC, m_photometric);
 
     // ExtraSamples tag
-    if (m_spec.nchannels > 3 && m_photometric != PHOTOMETRIC_SEPARATED) {
+    if ((m_spec.alpha_channel >= 0 || m_spec.nchannels > 3)
+         && m_photometric != PHOTOMETRIC_SEPARATED) {
         bool unass = m_spec.get_int_attribute("oiio:UnassociatedAlpha", 0);
-        short e = m_spec.nchannels-3;
+        int defaultchans = m_spec.nchannels >= 3 ? 3 : 1;
+        short e = m_spec.nchannels - defaultchans;
         std::vector<unsigned short> extra (e);
         for (int c = 0;  c < e;  ++c) {
-            if (m_spec.alpha_channel == (c+3))
+            if (m_spec.alpha_channel == (c+defaultchans))
                 extra[c] = unass ? EXTRASAMPLE_UNASSALPHA : EXTRASAMPLE_ASSOCALPHA;
             else
                 extra[c] = EXTRASAMPLE_UNSPECIFIED;


### PR DESCRIPTION
For 2-channel images where the first channel is intensity and the second is
alpha, TIFF output was neglecting to set the TIFF "EXTRASAMPLES" tag to mark
the alpha channel. In particular, it just didn't consider extrasamples for images
that had fewer than 4 channels.

This was in turn causing the file, when re-input, to not realize that
the second channel was "A" or that there was an alpha channel at all
(since TIFF does not store channel names, we infer it all from the
EXTRASAMPLES tag).

One consequence of this mistake was that a grey-alpha image (say, coming
from OpenEXR or PNG or some other format that allows it) and run through
'maketx' (converting to TIFF if not otherwise specified) would lose this
knowledge, which in turn would affect the ability of the TextureSystem's
"gray_to_rgb" mode, which only applies to certain channel combinations.

Also noticed that for TIFF input, 2-channel images where the second is
alpha were still being named "R","A", but we actually changed the convention
some time ago for a single intensity channel to be named "Y", no "R", since
it's almost certainly representing luminance and not "red" per se.

