### PR TITLE
simd.h overhaul for 16-wide and AVX-512 support

### DIFF
--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -251,7 +251,7 @@ inline float sRGB_to_linear (float x)
                            : powf ((x + 0.055f) * (1.0f / 1.055f), 2.4f);
 }
 
-inline simd::float4 sRGB_to_linear (const simd::float4& x)
+inline simd::vfloat4 sRGB_to_linear (const simd::vfloat4& x)
 {
     return simd::select (x <= 0.04045f, x * (1.0f/12.92f),
                          fast_pow_pos (madd (x, (1.0f / 1.055f), 0.055f*(1.0f/1.055f)), 2.4f));
@@ -266,9 +266,9 @@ inline float linear_to_sRGB (float x)
 
 
 /// Utility -- convert linear value to sRGB
-inline simd::float4 linear_to_sRGB (const simd::float4& x)
+inline simd::vfloat4 linear_to_sRGB (const simd::vfloat4& x)
 {
-    // x = simd::max (x, simd::float4::Zero());
+    // x = simd::max (x, simd::vfloat4::Zero());
     return simd::select (x <= 0.0031308f, 12.92f * x,
                          madd (1.055f, fast_pow_pos (x, 1.f/2.4f),  -0.055f));
 }

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -223,15 +223,15 @@ clamp (const T& a, const T& low, const T& high)
 }
 
 
-// Specialization of clamp for float4
-template<> inline simd::float4
-clamp (const simd::float4& a, const simd::float4& low, const simd::float4& high)
+// Specialization of clamp for vfloat4
+template<> inline simd::vfloat4
+clamp (const simd::vfloat4& a, const simd::vfloat4& low, const simd::vfloat4& high)
 {
     return simd::min (high, simd::max (low, a));
 }
 
-template<> inline simd::float8
-clamp (const simd::float8& a, const simd::float8& low, const simd::float8& high)
+template<> inline simd::vfloat8
+clamp (const simd::vfloat8& a, const simd::vfloat8& low, const simd::vfloat8& high)
 {
     return simd::min (high, simd::max (low, a));
 }
@@ -663,10 +663,10 @@ inline void convert_type<uint8_t,float> (const uint8_t *src,
                                          float _min, float _max)
 {
     float scale (1.0f/std::numeric_limits<uint8_t>::max());
-    simd::float4 scale_simd (scale);
+    simd::vfloat4 scale_simd (scale);
     for ( ; n >= 4; n -= 4, src += 4, dst += 4) {
-        simd::float4 s_simd (src);
-        simd::float4 d_simd = s_simd * scale_simd;
+        simd::vfloat4 s_simd (src);
+        simd::vfloat4 d_simd = s_simd * scale_simd;
         d_simd.store (dst);
     }
     while (n--)
@@ -681,10 +681,10 @@ inline void convert_type<uint16_t,float> (const uint16_t *src,
                                           float _min, float _max)
 {
     float scale (1.0f/std::numeric_limits<uint16_t>::max());
-    simd::float4 scale_simd (scale);
+    simd::vfloat4 scale_simd (scale);
     for ( ; n >= 4; n -= 4, src += 4, dst += 4) {
-        simd::float4 s_simd (src);
-        simd::float4 d_simd = s_simd * scale_simd;
+        simd::vfloat4 s_simd (src);
+        simd::vfloat4 d_simd = s_simd * scale_simd;
         d_simd.store (dst);
     }
     while (n--)
@@ -699,7 +699,7 @@ inline void convert_type<half,float> (const half *src,
                                       float _min, float _max)
 {
     for ( ; n >= 4; n -= 4, src += 4, dst += 4) {
-        simd::float4 s_simd (src);
+        simd::vfloat4 s_simd (src);
         s_simd.store (dst);
     }
     while (n--)
@@ -717,13 +717,13 @@ convert_type<float,uint16_t> (const float *src, uint16_t *dst, size_t n,
     float min = std::numeric_limits<uint16_t>::min();
     float max = std::numeric_limits<uint16_t>::max();
     float scale = max;
-    simd::float4 max_simd (max);
-    simd::float4 one_half_simd (0.5f);
-    simd::float4 zero_simd (0.0f);
+    simd::vfloat4 max_simd (max);
+    simd::vfloat4 one_half_simd (0.5f);
+    simd::vfloat4 zero_simd (0.0f);
     for ( ; n >= 4; n -= 4, src += 4, dst += 4) {
-        simd::float4 scaled = simd::round (simd::float4(src) * max_simd);
-        simd::float4 clamped = clamp (scaled, zero_simd, max_simd);
-        simd::int4 i (clamped);
+        simd::vfloat4 scaled = simd::round (simd::vfloat4(src) * max_simd);
+        simd::vfloat4 clamped = clamp (scaled, zero_simd, max_simd);
+        simd::vint4 i (clamped);
         i.store (dst);
     }
     while (n--)
@@ -739,13 +739,13 @@ convert_type<float,uint8_t> (const float *src, uint8_t *dst, size_t n,
     float min = std::numeric_limits<uint8_t>::min();
     float max = std::numeric_limits<uint8_t>::max();
     float scale = max;
-    simd::float4 max_simd (max);
-    simd::float4 one_half_simd (0.5f);
-    simd::float4 zero_simd (0.0f);
+    simd::vfloat4 max_simd (max);
+    simd::vfloat4 one_half_simd (0.5f);
+    simd::vfloat4 zero_simd (0.0f);
     for ( ; n >= 4; n -= 4, src += 4, dst += 4) {
-        simd::float4 scaled = simd::round (simd::float4(src) * max_simd);
-        simd::float4 clamped = clamp (scaled, zero_simd, max_simd);
-        simd::int4 i (clamped);
+        simd::vfloat4 scaled = simd::round (simd::vfloat4(src) * max_simd);
+        simd::vfloat4 clamped = clamp (scaled, zero_simd, max_simd);
+        simd::vint4 i (clamped);
         i.store (dst);
     }
     while (n--)
@@ -760,7 +760,7 @@ convert_type<float,half> (const float *src, half *dst, size_t n,
                           half _min, half _max)
 {
     for ( ; n >= 4; n -= 4, src += 4, dst += 4) {
-        simd::float4 s (src);
+        simd::vfloat4 s (src);
         s.store (dst);
     }
     while (n--)
@@ -1110,7 +1110,7 @@ inline int fast_rint (float x) {
 #endif
 }
 
-inline simd::int4 fast_rint (const simd::float4& x) {
+inline simd::vint4 fast_rint (const simd::vfloat4& x) {
     return simd::rint (x);
 }
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1272,21 +1272,6 @@ OIIO_API std::string geterror ();
 ///     string plugin_searchpath
 ///             Colon-separated list of directories to search for 
 ///             dynamically-loaded format plugins.
-///     string format_list     (for 'getattribute' only, cannot set)
-///             Comma-separated list of all format names supported
-///             or for which plugins could be found.
-///     string input_format_list     (for 'getattribute' only, cannot set)
-///             Comma-separated list of all format names supported
-///             or for which plugins could be found that can read images.
-///     string output_format_list     (for 'getattribute' only, cannot set)
-///             Comma-separated list of all format names supported
-///             or for which plugins could be found that can write images.
-///     string extension_list   (for 'getattribute' only, cannot set)
-///             For each format, the format name followed by a colon,
-///             followed by comma-separated list of all extensions that
-///             are presumed to be used for that format.  Semicolons
-///             separate the lists for formats.  For example,
-///                "tiff:tif;jpeg:jpg,jpeg;openexr:exr"
 ///     int read_chunk
 ///             The number of scanlines that will be attempted to read at
 ///             once for read_image calls (default: 256).
@@ -1318,6 +1303,39 @@ inline bool attribute (string_view name, string_view val) {
 /// otherwise return false and do not modify the contents of *val.  It
 /// is up to the caller to ensure that val points to the right kind and
 /// size of storage for the given type.
+///
+/// In addition to being able to retrieve all the attributes that are
+/// documented as settable by the attribute() call, getattribute() can
+/// also retrieve the following read-only attributes:
+///     string "format_list"
+///             Comma-separated list of all format names supported
+///             or for which plugins could be found.
+///     string "input_format_list"
+///             Comma-separated list of all format names supported
+///             or for which plugins could be found that can read images.
+///     string "output_format_list"
+///             Comma-separated list of all format names supported
+///             or for which plugins could be found that can write images.
+///     string "extension_list"
+///             For each format, the format name followed by a colon,
+///             followed by comma-separated list of all extensions that
+///             are presumed to be used for that format.  Semicolons
+///             separate the lists for formats.  For example,
+///                "tiff:tif;jpeg:jpg,jpeg;openexr:exr"
+///     string "library_list"
+///             For each format that uses an external expendent library, the
+///             format name followed by a colon, followed by the name of
+///             the library. Semicolons separate the lists for formats. For
+///             example,
+///              "jpeg:jpeg-turbo 1.5.1;png:libpng 1.6.29;gif:gif_lib 5.1.4"
+///     string "oiio:simd"
+///             Comma-separated list of the SIMD-related capabilities
+///             enabled when the OIIO library was built. For example,
+///                 "sse2,sse3,ssse3,sse41,sse42,avx"
+///     string "hw:simd"
+///             Comma-separated list of the SIMD-related capabilities
+///             detected at runtime at the time of the query (which may not
+///             match the support compiled into the library).
 OIIO_API bool getattribute (string_view name, TypeDesc type, void *val);
 // Shortcuts for common types
 inline bool getattribute (string_view name, int &val) {

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -379,6 +379,15 @@ inline bool cpu_has_popcnt() {int i[4]; cpuid(i,1,0); return (i[2] & (1<<23)) !=
 inline bool cpu_has_avx   () {int i[4]; cpuid(i,1,0); return (i[2] & (1<<28)) != 0; }
 inline bool cpu_has_f16c  () {int i[4]; cpuid(i,1,0); return (i[2] & (1<<29)) != 0; }
 inline bool cpu_has_rdrand() {int i[4]; cpuid(i,1,0); return (i[2] & (1<<30)) != 0; }
+inline bool cpu_has_avx2  () {int i[4]; cpuid(i,7,0); return (i[1] & (1<<5)) != 0; }
+inline bool cpu_has_avx512f() {int i[4]; cpuid(i,7,0); return (i[1] & (1<<16)) != 0; }
+inline bool cpu_has_avx512dq() {int i[4]; cpuid(i,7,0); return (i[1] & (1<<17)) != 0; }
+inline bool cpu_has_avx512ifma() {int i[4]; cpuid(i,7,0); return (i[1] & (1<<21)) != 0; }
+inline bool cpu_has_avx512pf() {int i[4]; cpuid(i,7,0); return (i[1] & (1<<26)) != 0; }
+inline bool cpu_has_avx512er() {int i[4]; cpuid(i,7,0); return (i[1] & (1<<27)) != 0; }
+inline bool cpu_has_avx512cd() {int i[4]; cpuid(i,7,0); return (i[1] & (1<<28)) != 0; }
+inline bool cpu_has_avx512bw() {int i[4]; cpuid(i,7,0); return (i[1] & (1<<30)) != 0; }
+inline bool cpu_has_avx512vl() {int i[4]; cpuid(i,7,0); return (i[1] & (0x80000000 /*1<<31*/)) != 0; }
 
 
 OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -409,9 +409,9 @@ public:
             for (int y = 0;  y < height;  ++y) {
                 char *d = (char *)data + y*ystride;
                 for (int x = 0;  x < width;  ++x, d += xstride) {
-                    simd::float4 r;
+                    simd::vfloat4 r;
                     r.load ((float *)d, 3);
-                    r = sRGB_to_linear (simd::float4((float *)d));
+                    r = sRGB_to_linear (simd::vfloat4((float *)d));
                     r.store ((float *)d, 3);
                 }
             }
@@ -443,9 +443,9 @@ public:
             for (int y = 0;  y < height;  ++y) {
                 char *d = (char *)data + y*ystride;
                 for (int x = 0;  x < width;  ++x, d += xstride) {
-                    simd::float4 r;
+                    simd::vfloat4 r;
                     r.load ((float *)d, 3);
-                    r = linear_to_sRGB (simd::float4((float *)d));
+                    r = linear_to_sRGB (simd::vfloat4((float *)d));
                     r.store ((float *)d, 3);
                 }
             }
@@ -522,13 +522,13 @@ public:
         if (channels > 3)
             channels = 3;
         if (channels == 3) {
-            simd::float4 g = m_gamma;
+            simd::vfloat4 g = m_gamma;
             for (int y = 0;  y < height;  ++y) {
                 char *d = (char *)data + y*ystride;
                 for (int x = 0;  x < width;  ++x, d += xstride) {
-                    simd::float4 r;
+                    simd::vfloat4 r;
                     r.load ((float *)d, 3);
-                    r = fast_pow_pos (simd::float4((float *)d), g);
+                    r = fast_pow_pos (simd::vfloat4((float *)d), g);
                     r.store ((float *)d, 3);
                 }
             }

--- a/src/libOpenImageIO/compute_test.cpp
+++ b/src/libOpenImageIO/compute_test.cpp
@@ -129,8 +129,8 @@ test_arrays_simd4 (ROI roi)
     float *r = (float *)imgR.localpixels(); ASSERT(r);
     int x, end4 = size - (size&3);
     for (x = 0; x < end4; x += 4, a += 4, b += 4, r += 4) {
-        simd::float4 a_simd(a), b_simd(b);
-        *(simd::float4 *)r = a_simd * a_simd + b_simd;
+        simd::vfloat4 a_simd(a), b_simd(b);
+        *(simd::vfloat4 *)r = a_simd * a_simd + b_simd;
     }
     for ( ; x < size; ++x, ++a, ++b, ++r) {
         *r = a[0]*a[0] + b[0];
@@ -149,7 +149,7 @@ test_arrays_like_image_simd (ROI roi)
     for (int y = 0; y < yres; ++y) {
         for (int x = 0; x < xres; ++x) {
             int i = (y*xres + x) * nchannels;
-            simd::float4 a_simd, b_simd, r_simd;
+            simd::vfloat4 a_simd, b_simd, r_simd;
             a_simd.load (a+i, 3);
             b_simd.load (b+i, 3);
             r_simd = a_simd * a_simd + b_simd;
@@ -169,7 +169,7 @@ test_arrays_like_image_simd_multithread (ROI roi)
     for (int y = roi.ybegin; y < roi.yend; ++y) {
         for (int x = roi.xbegin; x < roi.xend; ++x) {
             int i = (y*xres + x) * nchannels;
-            simd::float4 a_simd, b_simd, r_simd;
+            simd::vfloat4 a_simd, b_simd, r_simd;
             a_simd.load (a+i, 3);
             b_simd.load (b+i, 3);
             r_simd = a_simd * a_simd + b_simd;

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -91,6 +91,65 @@ int print_debug (oiio_debug_env ? atoi(oiio_debug_env) : 1);
 
 
 
+// Return a comma-separated list of all the important SIMD/capabilities
+// supported by the hardware we're running on right now.
+static std::string
+hw_simd_caps ()
+{
+    std::vector<string_view> caps;
+    if (cpu_has_sse2())        caps.emplace_back ("sse2");
+    if (cpu_has_sse3())        caps.emplace_back ("sse3");
+    if (cpu_has_ssse3())       caps.emplace_back ("ssse3");
+    if (cpu_has_sse41())       caps.emplace_back ("sse41");
+    if (cpu_has_sse42())       caps.emplace_back ("sse42");
+    if (cpu_has_avx())         caps.emplace_back ("avx");
+    if (cpu_has_avx2())        caps.emplace_back ("avx2");
+    if (cpu_has_avx512f())     caps.emplace_back ("avx512f");
+    if (cpu_has_avx512dq())    caps.emplace_back ("avx512dq");
+    if (cpu_has_avx512ifma())  caps.emplace_back ("avx512ifma");
+    if (cpu_has_avx512pf())    caps.emplace_back ("avx512pf");
+    if (cpu_has_avx512er())    caps.emplace_back ("avx512er");
+    if (cpu_has_avx512cd())    caps.emplace_back ("avx512cd");
+    if (cpu_has_avx512bw())    caps.emplace_back ("avx512bw");
+    if (cpu_has_avx512vl())    caps.emplace_back ("avx512vl");
+    if (cpu_has_fma())         caps.emplace_back ("fma");
+    if (cpu_has_f16c())        caps.emplace_back ("f16c");
+    if (cpu_has_popcnt())      caps.emplace_back ("popcnt");
+    if (cpu_has_rdrand())      caps.emplace_back ("rdrand");
+    return Strutil::join (caps, ",");
+}
+
+
+
+// Return a comma-separated list of all the important SIMD/capabilities
+// that were enabled as a compile-time option when OIIO was built.
+static std::string
+oiio_simd_caps ()
+{
+    std::vector<string_view> caps;
+    if (OIIO_SIMD_SSE >= 2)      caps.emplace_back ("sse2");
+    if (OIIO_SIMD_SSE >= 3)      caps.emplace_back ("sse3");
+    if (OIIO_SIMD_SSE >= 3)      caps.emplace_back ("ssse3");
+    if (OIIO_SIMD_SSE >= 4)      caps.emplace_back ("sse41");
+    if (OIIO_SIMD_SSE >= 4)      caps.emplace_back ("sse42");
+    if (OIIO_SIMD_AVX)           caps.emplace_back ("avx");
+    if (OIIO_SIMD_AVX >= 2)      caps.emplace_back ("avx2");
+    if (OIIO_SIMD_AVX >= 512)    caps.emplace_back ("avx512f");
+    if (OIIO_AVX512DQ_ENABLED)   caps.emplace_back ("avx512dq");
+    if (OIIO_AVX512IFMA_ENABLED) caps.emplace_back ("avx512ifma");
+    if (OIIO_AVX512PF_ENABLED)   caps.emplace_back ("avx512pf");
+    if (OIIO_AVX512ER_ENABLED)   caps.emplace_back ("avx512er");
+    if (OIIO_AVX512CD_ENABLED)   caps.emplace_back ("avx512cd");
+    if (OIIO_AVX512BW_ENABLED)   caps.emplace_back ("avx512bw");
+    if (OIIO_AVX512VL_ENABLED)   caps.emplace_back ("avx512vl");
+    if (OIIO_FMA_ENABLED)        caps.emplace_back ("fma");
+    if (OIIO_F16C_ENABLED)       caps.emplace_back ("f16c");
+    // if (OIIO_POPCOUNT_ENABLED)   caps.emplace_back ("popcnt");
+    return Strutil::join (caps, ",");
+}
+
+
+
 int
 openimageio_version ()
 {
@@ -246,6 +305,14 @@ getattribute (string_view name, TypeDesc type, void *val)
     }
     if (name == "debug" && type == TypeDesc::TypeInt) {
         *(int *)val = print_debug;
+        return true;
+    }
+    if (name == "hw:simd" && type == TypeDesc::TypeString) {
+        *(ustring *)val = ustring(hw_simd_caps());
+        return true;
+    }
+    if (name == "oiio:simd" && type == TypeDesc::TypeString) {
+        *(ustring *)val = ustring(oiio_simd_caps());
         return true;
     }
     return false;

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -551,7 +551,7 @@ TextureSystemImpl::environment (TextureHandle *texture_handle_,
             OIIO_SIMD4_ALIGN float tval[4] = { t, 0.0f, 0.0f, 0.0f };
             OIIO_SIMD4_ALIGN float weight[4] = { levelweight[level]*invsamples,
                                                  0.0f, 0.0f, 0.0f };
-            float4 r, drds, drdt;
+            vfloat4 r, drds, drdt;
             ok &= (this->*sampler) (1, sval, tval, miplevel[level],
                                     *texturefile, thread_info, options,
                                     nchannels, actualchannels, weight,

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -400,26 +400,26 @@ private:
                           int level, TextureFile &texturefile,
                           PerThreadInfo *thread_info, TextureOpt &options,
                           int nchannels_result, int actualchannels,
-                          const float *weight, simd::float4 *accum,
-                          simd::float4 *daccumds, simd::float4 *daccumdt);
+                          const float *weight, simd::vfloat4 *accum,
+                          simd::vfloat4 *daccumds, simd::vfloat4 *daccumdt);
     bool sample_closest  (int nsamples, const float *s, const float *t,
                           int level, TextureFile &texturefile,
                           PerThreadInfo *thread_info, TextureOpt &options,
                           int nchannels_result, int actualchannels,
-                          const float *weight, simd::float4 *accum,
-                          simd::float4 *daccumds, simd::float4 *daccumdt);
+                          const float *weight, simd::vfloat4 *accum,
+                          simd::vfloat4 *daccumds, simd::vfloat4 *daccumdt);
     bool sample_bilinear (int nsamples, const float *s, const float *t,
                           int level, TextureFile &texturefile,
                           PerThreadInfo *thread_info, TextureOpt &options,
                           int nchannels_result, int actualchannels,
-                          const float *weight, simd::float4 *accum,
-                          simd::float4 *daccumds, simd::float4 *daccumdt);
+                          const float *weight, simd::vfloat4 *accum,
+                          simd::vfloat4 *daccumds, simd::vfloat4 *daccumdt);
     bool sample_bicubic  (int nsamples, const float *s, const float *t,
                           int level, TextureFile &texturefile,
                           PerThreadInfo *thread_info, TextureOpt &options,
                           int nchannels_result, int actualchannels,
-                          const float *weight, simd::float4 *accum,
-                          simd::float4 *daccumds, simd::float4 *daccumdt);
+                          const float *weight, simd::vfloat4 *accum,
+                          simd::vfloat4 *daccumds, simd::vfloat4 *daccumdt);
 
     // Define a prototype of a member function pointer for texture3d
     // lookups.

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -110,7 +110,7 @@ if (OIIO_BUILD_TESTS)
 
     add_executable (simd_test simd_test.cpp)
     set_target_properties (simd_test PROPERTIES FOLDER "Unit Tests")
-    target_link_libraries (simd_test OpenImageIO_Util ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+    target_link_libraries (simd_test OpenImageIO ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
     add_test (unit_simd simd_test)
 
     add_executable (filter_test filter_test.cpp)

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -192,28 +192,28 @@ inline VEC mkvec (typename VEC::value_t a, typename VEC::value_t b,
     return VEC(a,b,c,d);
 }
 
-template<> inline float3 mkvec<float3> (float a, float b, float c, float d) {
-    return float3(a,b,c);
+template<> inline vfloat3 mkvec<vfloat3> (float a, float b, float c, float d) {
+    return vfloat3(a,b,c);
 }
 
-template<> inline float8 mkvec<float8> (float a, float b, float c, float d) {
-    return float8(a,b,c,d,a,b,c,d);
+template<> inline vfloat8 mkvec<vfloat8> (float a, float b, float c, float d) {
+    return vfloat8(a,b,c,d,a,b,c,d);
 }
 
-template<> inline float16 mkvec<float16> (float a, float b, float c, float d) {
-    return float16(a,b,c,d,a,b,c,d,a,b,c,d,a,b,c,d);
+template<> inline vfloat16 mkvec<vfloat16> (float a, float b, float c, float d) {
+    return vfloat16(a,b,c,d,a,b,c,d,a,b,c,d,a,b,c,d);
 }
 
-template<> inline int8 mkvec<int8> (int a, int b, int c, int d) {
-    return int8(a,b,c,d,a,b,c,d);
+template<> inline vint8 mkvec<vint8> (int a, int b, int c, int d) {
+    return vint8(a,b,c,d,a,b,c,d);
 }
 
-template<> inline bool8 mkvec<bool8> (bool a, bool b, bool c, bool d) {
-    return bool8(a,b,c,d,a,b,c,d);
+template<> inline vbool8 mkvec<vbool8> (bool a, bool b, bool c, bool d) {
+    return vbool8(a,b,c,d,a,b,c,d);
 }
 
-template<> inline bool16 mkvec<bool16> (bool a, bool b, bool c, bool d) {
-    return bool16(a,b,c,d,a,b,c,d,a,b,c,d,a,b,c,d);
+template<> inline vbool16 mkvec<vbool16> (bool a, bool b, bool c, bool d) {
+    return vbool16(a,b,c,d,a,b,c,d,a,b,c,d,a,b,c,d);
 }
 
 
@@ -228,35 +228,35 @@ inline VEC mkvec (typename VEC::value_t a, typename VEC::value_t b,
 }
 
 
-template<> inline bool4 mkvec<bool4> (bool a, bool b, bool c, bool d,
+template<> inline vbool4 mkvec<vbool4> (bool a, bool b, bool c, bool d,
                                       bool e, bool f, bool g, bool h) {
-    return bool4(a,b,c,d);
+    return vbool4(a,b,c,d);
 }
 
-template<> inline int4 mkvec<int4> (int a, int b, int c, int d,
+template<> inline vint4 mkvec<vint4> (int a, int b, int c, int d,
                                     int e, int f, int g, int h) {
-    return int4(a,b,c,d);
+    return vint4(a,b,c,d);
 }
 
-template<> inline int16 mkvec<int16> (int a, int b, int c, int d,
+template<> inline vint16 mkvec<vint16> (int a, int b, int c, int d,
                                       int e, int f, int g, int h) {
-    return int16(a,b,c,d,e,f,g,h,
+    return vint16(a,b,c,d,e,f,g,h,
                  h+1,h+2,h+3,h+4,h+5,h+6,h+7,h+8);
 }
 
-template<> inline float4 mkvec<float4> (float a, float b, float c, float d,
+template<> inline vfloat4 mkvec<vfloat4> (float a, float b, float c, float d,
                                         float e, float f, float g, float h) {
-    return float4(a,b,c,d);
+    return vfloat4(a,b,c,d);
 }
 
-template<> inline float3 mkvec<float3> (float a, float b, float c, float d,
+template<> inline vfloat3 mkvec<vfloat3> (float a, float b, float c, float d,
                                         float e, float f, float g, float h) {
-    return float3(a,b,c);
+    return vfloat3(a,b,c);
 }
 
-template<> inline float16 mkvec<float16> (float a, float b, float c, float d,
+template<> inline vfloat16 mkvec<vfloat16> (float a, float b, float c, float d,
                                           float e, float f, float g, float h) {
-    return float16(a,b,c,d,e,f,g,h,
+    return vfloat16(a,b,c,d,e,f,g,h,
                    h+1,h+2,h+3,h+4,h+5,h+6,h+7,h+8);
 }
 
@@ -287,10 +287,10 @@ inline float dot_imath (const Imath::V3f &v) {
     return v.dot(v);
 }
 inline float dot_imath_simd (const Imath::V3f &v_) {
-    float3 v (v_);
+    vfloat3 v (v_);
     return simd::dot(v,v);
 }
-inline float dot_simd (const simd::float3 v) {
+inline float dot_simd (const simd::vfloat3 v) {
     return dot(v,v);
 }
 
@@ -300,22 +300,22 @@ norm_imath (const Imath::V3f &a) {
 }
 
 inline Imath::V3f
-norm_imath_simd (float3 a) {
+norm_imath_simd (vfloat3 a) {
     return a.normalized().V3f();
 }
 
 inline Imath::V3f
-norm_imath_simd_fast (float3 a) {
+norm_imath_simd_fast (vfloat3 a) {
     return a.normalized_fast().V3f();
 }
 
-inline float3
-norm_simd_fast (float3 a) {
+inline vfloat3
+norm_simd_fast (vfloat3 a) {
     return a.normalized_fast();
 }
 
-inline float3
-norm_simd (float3 a) {
+inline vfloat3
+norm_simd (vfloat3 a) {
     return a.normalized();
 }
 
@@ -575,9 +575,9 @@ void test_component_access ()
 
 
 template<>
-void test_component_access<bool4> ()
+void test_component_access<vbool4> ()
 {
-    typedef bool4 VEC;
+    typedef vbool4 VEC;
     typedef VEC::value_t ELEM;
     test_heading ("component_access ", VEC::type_name());
 
@@ -612,9 +612,9 @@ void test_component_access<bool4> ()
 
 
 template<>
-void test_component_access<bool8> ()
+void test_component_access<vbool8> ()
 {
-    typedef bool8 VEC;
+    typedef vbool8 VEC;
     typedef VEC::value_t ELEM;
     test_heading ("component_access ", VEC::type_name());
 
@@ -662,9 +662,9 @@ void test_component_access<bool8> ()
 
 
 template<>
-void test_component_access<bool16> ()
+void test_component_access<vbool16> ()
 {
-    typedef bool16 VEC;
+    typedef vbool16 VEC;
     typedef VEC::value_t ELEM;
     test_heading ("component_access ", VEC::type_name());
 
@@ -743,7 +743,7 @@ template<typename T> inline T do_mul (const T &a, const T &b) { return a*b; }
 template<typename T> inline T do_div (const T &a, const T &b) { return a/b; }
 template<typename T> inline T do_safe_div (const T &a, const T &b) { return T(safe_div(a,b)); }
 inline Imath::V3f add_vec_simd (const Imath::V3f &a, const Imath::V3f &b) {
-    return (float3(a)+float3(b)).V3f();
+    return (vfloat3(a)+vfloat3(b)).V3f();
 }
 
 
@@ -784,7 +784,7 @@ void test_arithmetic ()
     benchmark2 ("operator*", do_mul<VEC>, a, b);
     benchmark2 ("operator/", do_div<VEC>, a, b);
     benchmark  ("reduce_add", [](VEC& a){ return vreduce_add(a); }, a);
-    if (is_same<VEC,float3>::value) {  // For float3, compare to Imath
+    if (is_same<VEC,vfloat3>::value) {  // For vfloat3, compare to Imath
         Imath::V3f a(2.51f,1.0f,1.0f), b(3.1f,1.0f,1.0f);
         benchmark2 ("add Imath::V3f", do_add<Imath::V3f>, a, b, 3 /*work*/);
         benchmark2 ("add Imath::V3f with simd", add_vec_simd, a, b, 3 /*work*/);
@@ -1143,9 +1143,9 @@ void test_shift ()
 
 
 
-void test_vectorops_float4 ()
+void test_vectorops_vfloat4 ()
 {
-    typedef float4 VEC;
+    typedef vfloat4 VEC;
     typedef VEC::value_t ELEM;
     test_heading ("vectorops ", VEC::type_name());
 
@@ -1155,7 +1155,7 @@ void test_vectorops_float4 ()
     OIIO_CHECK_EQUAL (dot3(a,b), ELEM(10+22+36));
     OIIO_CHECK_SIMD_EQUAL (vdot(a,b), VEC(10+22+36+52));
     OIIO_CHECK_SIMD_EQUAL (vdot3(a,b), VEC(10+22+36));
-    OIIO_CHECK_SIMD_EQUAL (hdiv(float4(1.0f,2.0f,3.0f,2.0f)), float3(0.5f,1.0f,1.5f));
+    OIIO_CHECK_SIMD_EQUAL (hdiv(vfloat4(1.0f,2.0f,3.0f,2.0f)), vfloat3(0.5f,1.0f,1.5f));
 
     benchmark2 ("vdot", [](VEC& a, VEC& b){ return vdot(a,b); }, a, b);
     benchmark2 ("dot", [](VEC& a, VEC& b){ return dot(a,b); }, a, b);
@@ -1165,9 +1165,9 @@ void test_vectorops_float4 ()
 
 
 
-void test_vectorops_float3 ()
+void test_vectorops_vfloat3 ()
 {
-    typedef float3 VEC;
+    typedef vfloat3 VEC;
     typedef VEC::value_t ELEM;
     test_heading ("vectorops ", VEC::type_name());
 
@@ -1177,22 +1177,22 @@ void test_vectorops_float3 ()
     OIIO_CHECK_EQUAL (dot3(a,b), ELEM(10+22+36));
     OIIO_CHECK_SIMD_EQUAL (vdot(a,b), VEC(10+22+36));
     OIIO_CHECK_SIMD_EQUAL (vdot3(a,b), VEC(10+22+36));
-    OIIO_CHECK_SIMD_EQUAL (float3(1.0f,2.0f,3.0f).normalized(),
-                           float3(norm_imath(Imath::V3f(1.0f,2.0f,3.0f))));
-    OIIO_CHECK_SIMD_EQUAL_THRESH (float3(1.0f,2.0f,3.0f).normalized_fast(),
-                                  float3(norm_imath(Imath::V3f(1.0f,2.0f,3.0f))), 0.0005);
+    OIIO_CHECK_SIMD_EQUAL (vfloat3(1.0f,2.0f,3.0f).normalized(),
+                           vfloat3(norm_imath(Imath::V3f(1.0f,2.0f,3.0f))));
+    OIIO_CHECK_SIMD_EQUAL_THRESH (vfloat3(1.0f,2.0f,3.0f).normalized_fast(),
+                                  vfloat3(norm_imath(Imath::V3f(1.0f,2.0f,3.0f))), 0.0005);
 
     benchmark2 ("vdot", [](VEC& a, VEC& b){ return vdot(a,b); }, a, b);
     benchmark2 ("dot", [](VEC& a, VEC& b){ return dot(a,b); }, a, b);
-    benchmark ("dot float3", dot_simd, float3(2.0f,1.0f,0.0f), 1);
+    benchmark ("dot vfloat3", dot_simd, vfloat3(2.0f,1.0f,0.0f), 1);
     // benchmark2 ("dot Imath::V3f", [](Imath::V3f& a, Imath::V3f& b){ return a.dot(b); }, a.V3f(), b.V3f());
     benchmark ("dot Imath::V3f", dot_imath, Imath::V3f(2.0f,1.0f,0.0f), 1);
     benchmark ("dot Imath::V3f with simd", dot_imath_simd, Imath::V3f(2.0f,1.0f,0.0f), 1);
     benchmark ("normalize Imath", norm_imath, Imath::V3f(1.0f,4.0f,9.0f));
     benchmark ("normalize Imath with simd", norm_imath_simd, Imath::V3f(1.0f,4.0f,9.0f));
     benchmark ("normalize Imath with simd fast", norm_imath_simd_fast, Imath::V3f(1.0f,4.0f,9.0f));
-    benchmark ("normalize simd", norm_simd, float3(1.0f,4.0f,9.0f));
-    benchmark ("normalize simd fast", norm_simd_fast, float3(1.0f,4.0f,9.0f));
+    benchmark ("normalize simd", norm_simd, vfloat3(1.0f,4.0f,9.0f));
+    benchmark ("normalize simd fast", norm_simd_fast, vfloat3(1.0f,4.0f,9.0f));
 }
 
 
@@ -1201,79 +1201,79 @@ void test_constants ()
 {
     test_heading ("constants");
 
-    OIIO_CHECK_SIMD_EQUAL (bool4::False(), bool4(false));
-    OIIO_CHECK_SIMD_EQUAL (bool4::True(), bool4(true));
+    OIIO_CHECK_SIMD_EQUAL (vbool4::False(), vbool4(false));
+    OIIO_CHECK_SIMD_EQUAL (vbool4::True(), vbool4(true));
 
-    OIIO_CHECK_SIMD_EQUAL (bool8::False(), bool8(false));
-    OIIO_CHECK_SIMD_EQUAL (bool8::True(), bool8(true));
+    OIIO_CHECK_SIMD_EQUAL (vbool8::False(), vbool8(false));
+    OIIO_CHECK_SIMD_EQUAL (vbool8::True(), vbool8(true));
 
-    OIIO_CHECK_SIMD_EQUAL (bool16::False(), bool16(false));
-    OIIO_CHECK_SIMD_EQUAL (bool16::True(), bool16(true));
-    OIIO_CHECK_SIMD_EQUAL (bool16::False(), bool16(false));
-    OIIO_CHECK_SIMD_EQUAL (bool16::True(), bool16(true));
+    OIIO_CHECK_SIMD_EQUAL (vbool16::False(), vbool16(false));
+    OIIO_CHECK_SIMD_EQUAL (vbool16::True(), vbool16(true));
+    OIIO_CHECK_SIMD_EQUAL (vbool16::False(), vbool16(false));
+    OIIO_CHECK_SIMD_EQUAL (vbool16::True(), vbool16(true));
 
-    OIIO_CHECK_SIMD_EQUAL (int4::Zero(), int4(0));
-    OIIO_CHECK_SIMD_EQUAL (int4::One(), int4(1));
-    OIIO_CHECK_SIMD_EQUAL (int4::NegOne(), int4(-1));
-    OIIO_CHECK_SIMD_EQUAL (int4::Iota(), int4(0,1,2,3));
-    OIIO_CHECK_SIMD_EQUAL (int4::Iota(3), int4(3,4,5,6));
-    OIIO_CHECK_SIMD_EQUAL (int4::Iota(3,2), int4(3,5,7,9));
-    OIIO_CHECK_SIMD_EQUAL (int4::Giota(), int4(1,2,4,8));
+    OIIO_CHECK_SIMD_EQUAL (vint4::Zero(), vint4(0));
+    OIIO_CHECK_SIMD_EQUAL (vint4::One(), vint4(1));
+    OIIO_CHECK_SIMD_EQUAL (vint4::NegOne(), vint4(-1));
+    OIIO_CHECK_SIMD_EQUAL (vint4::Iota(), vint4(0,1,2,3));
+    OIIO_CHECK_SIMD_EQUAL (vint4::Iota(3), vint4(3,4,5,6));
+    OIIO_CHECK_SIMD_EQUAL (vint4::Iota(3,2), vint4(3,5,7,9));
+    OIIO_CHECK_SIMD_EQUAL (vint4::Giota(), vint4(1,2,4,8));
 
-    OIIO_CHECK_SIMD_EQUAL (int8::Zero(), int8(0));
-    OIIO_CHECK_SIMD_EQUAL (int8::One(), int8(1));
-    OIIO_CHECK_SIMD_EQUAL (int8::NegOne(), int8(-1));
-    OIIO_CHECK_SIMD_EQUAL (int8::Iota(), int8(0,1,2,3, 4,5,6,7));
-    OIIO_CHECK_SIMD_EQUAL (int8::Iota(3), int8(3,4,5,6, 7,8,9,10));
-    OIIO_CHECK_SIMD_EQUAL (int8::Iota(3,2), int8(3,5,7,9, 11,13,15,17));
-    OIIO_CHECK_SIMD_EQUAL (int8::Giota(), int8(1,2,4,8, 16,32,64,128));
+    OIIO_CHECK_SIMD_EQUAL (vint8::Zero(), vint8(0));
+    OIIO_CHECK_SIMD_EQUAL (vint8::One(), vint8(1));
+    OIIO_CHECK_SIMD_EQUAL (vint8::NegOne(), vint8(-1));
+    OIIO_CHECK_SIMD_EQUAL (vint8::Iota(), vint8(0,1,2,3, 4,5,6,7));
+    OIIO_CHECK_SIMD_EQUAL (vint8::Iota(3), vint8(3,4,5,6, 7,8,9,10));
+    OIIO_CHECK_SIMD_EQUAL (vint8::Iota(3,2), vint8(3,5,7,9, 11,13,15,17));
+    OIIO_CHECK_SIMD_EQUAL (vint8::Giota(), vint8(1,2,4,8, 16,32,64,128));
 
-    OIIO_CHECK_SIMD_EQUAL (int16::Zero(), int16(0));
-    OIIO_CHECK_SIMD_EQUAL (int16::One(), int16(1));
-    OIIO_CHECK_SIMD_EQUAL (int16::NegOne(), int16(-1));
-    OIIO_CHECK_SIMD_EQUAL (int16::Iota(), int16(0,1,2,3, 4,5,6,7, 8,9,10,11, 12,13,14,15));
-    OIIO_CHECK_SIMD_EQUAL (int16::Iota(3), int16(3,4,5,6, 7,8,9,10, 11,12,13,14, 15,16,17,18));
-    OIIO_CHECK_SIMD_EQUAL (int16::Iota(3,2), int16(3,5,7,9, 11,13,15,17, 19,21,23,25, 27,29,31,33));
-    OIIO_CHECK_SIMD_EQUAL (int16::Giota(), int16(1,2,4,8, 16,32,64,128, 256,512,1024,2048, 4096,8192,16384,32768));
+    OIIO_CHECK_SIMD_EQUAL (vint16::Zero(), vint16(0));
+    OIIO_CHECK_SIMD_EQUAL (vint16::One(), vint16(1));
+    OIIO_CHECK_SIMD_EQUAL (vint16::NegOne(), vint16(-1));
+    OIIO_CHECK_SIMD_EQUAL (vint16::Iota(), vint16(0,1,2,3, 4,5,6,7, 8,9,10,11, 12,13,14,15));
+    OIIO_CHECK_SIMD_EQUAL (vint16::Iota(3), vint16(3,4,5,6, 7,8,9,10, 11,12,13,14, 15,16,17,18));
+    OIIO_CHECK_SIMD_EQUAL (vint16::Iota(3,2), vint16(3,5,7,9, 11,13,15,17, 19,21,23,25, 27,29,31,33));
+    OIIO_CHECK_SIMD_EQUAL (vint16::Giota(), vint16(1,2,4,8, 16,32,64,128, 256,512,1024,2048, 4096,8192,16384,32768));
 
-    OIIO_CHECK_SIMD_EQUAL (float4::Zero(), float4(0.0f));
-    OIIO_CHECK_SIMD_EQUAL (float4::One(), float4(1.0f));
-    OIIO_CHECK_SIMD_EQUAL (float4::Iota(), float4(0,1,2,3));
-    OIIO_CHECK_SIMD_EQUAL (float4::Iota(3.0f), float4(3,4,5,6));
-    OIIO_CHECK_SIMD_EQUAL (float4::Iota(3.0f,2.0f), float4(3,5,7,9));
+    OIIO_CHECK_SIMD_EQUAL (vfloat4::Zero(), vfloat4(0.0f));
+    OIIO_CHECK_SIMD_EQUAL (vfloat4::One(), vfloat4(1.0f));
+    OIIO_CHECK_SIMD_EQUAL (vfloat4::Iota(), vfloat4(0,1,2,3));
+    OIIO_CHECK_SIMD_EQUAL (vfloat4::Iota(3.0f), vfloat4(3,4,5,6));
+    OIIO_CHECK_SIMD_EQUAL (vfloat4::Iota(3.0f,2.0f), vfloat4(3,5,7,9));
 
-    OIIO_CHECK_SIMD_EQUAL (float3::Zero(), float3(0.0f));
-    OIIO_CHECK_SIMD_EQUAL (float3::One(), float3(1.0f));
-    OIIO_CHECK_SIMD_EQUAL (float3::Iota(), float3(0,1,2));
-    OIIO_CHECK_SIMD_EQUAL (float3::Iota(3.0f), float3(3,4,5));
-    OIIO_CHECK_SIMD_EQUAL (float3::Iota(3.0f,2.0f), float3(3,5,7));
+    OIIO_CHECK_SIMD_EQUAL (vfloat3::Zero(), vfloat3(0.0f));
+    OIIO_CHECK_SIMD_EQUAL (vfloat3::One(), vfloat3(1.0f));
+    OIIO_CHECK_SIMD_EQUAL (vfloat3::Iota(), vfloat3(0,1,2));
+    OIIO_CHECK_SIMD_EQUAL (vfloat3::Iota(3.0f), vfloat3(3,4,5));
+    OIIO_CHECK_SIMD_EQUAL (vfloat3::Iota(3.0f,2.0f), vfloat3(3,5,7));
 
-    OIIO_CHECK_SIMD_EQUAL (float8::Zero(), float8(0.0f));
-    OIIO_CHECK_SIMD_EQUAL (float8::One(), float8(1.0f));
-    OIIO_CHECK_SIMD_EQUAL (float8::Iota(), float8(0,1,2,3,4,5,6,7));
-    OIIO_CHECK_SIMD_EQUAL (float8::Iota(3.0f), float8(3,4,5,6,7,8,9,10));
-    OIIO_CHECK_SIMD_EQUAL (float8::Iota(3.0f,2.0f), float8(3,5,7,9,11,13,15,17));
+    OIIO_CHECK_SIMD_EQUAL (vfloat8::Zero(), vfloat8(0.0f));
+    OIIO_CHECK_SIMD_EQUAL (vfloat8::One(), vfloat8(1.0f));
+    OIIO_CHECK_SIMD_EQUAL (vfloat8::Iota(), vfloat8(0,1,2,3,4,5,6,7));
+    OIIO_CHECK_SIMD_EQUAL (vfloat8::Iota(3.0f), vfloat8(3,4,5,6,7,8,9,10));
+    OIIO_CHECK_SIMD_EQUAL (vfloat8::Iota(3.0f,2.0f), vfloat8(3,5,7,9,11,13,15,17));
 
-    OIIO_CHECK_SIMD_EQUAL (float16::Zero(), float16(0.0f));
-    OIIO_CHECK_SIMD_EQUAL (float16::One(), float16(1.0f));
-    OIIO_CHECK_SIMD_EQUAL (float16::Iota(), float16(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15));
-    OIIO_CHECK_SIMD_EQUAL (float16::Iota(3.0f), float16(3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18));
-    OIIO_CHECK_SIMD_EQUAL (float16::Iota(3.0f,2.0f), float16(3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33));
+    OIIO_CHECK_SIMD_EQUAL (vfloat16::Zero(), vfloat16(0.0f));
+    OIIO_CHECK_SIMD_EQUAL (vfloat16::One(), vfloat16(1.0f));
+    OIIO_CHECK_SIMD_EQUAL (vfloat16::Iota(), vfloat16(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15));
+    OIIO_CHECK_SIMD_EQUAL (vfloat16::Iota(3.0f), vfloat16(3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18));
+    OIIO_CHECK_SIMD_EQUAL (vfloat16::Iota(3.0f,2.0f), vfloat16(3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33));
 
-    benchmark ("float4 = float(const)", [](float f){ return float4(f); }, 1.0f);
-    benchmark ("float4 = Zero()", [](int){ return float4::Zero(); }, 0);
-    benchmark ("float4 = One()", [](int){ return float4::One(); }, 0);
-    benchmark ("float4 = Iota()", [](int){ return float4::Iota(); }, 0);
+    benchmark ("vfloat4 = float(const)", [](float f){ return vfloat4(f); }, 1.0f);
+    benchmark ("vfloat4 = Zero()", [](int){ return vfloat4::Zero(); }, 0);
+    benchmark ("vfloat4 = One()", [](int){ return vfloat4::One(); }, 0);
+    benchmark ("vfloat4 = Iota()", [](int){ return vfloat4::Iota(); }, 0);
 
-    benchmark ("float8 = float(const)", [](float f){ return float8(f); }, 1.0f);
-    benchmark ("float8 = Zero()", [](int){ return float8::Zero(); }, 0);
-    benchmark ("float8 = One()", [](int){ return float8::One(); }, 0);
-    benchmark ("float8 = Iota()", [](int){ return float8::Iota(); }, 0);
+    benchmark ("vfloat8 = float(const)", [](float f){ return vfloat8(f); }, 1.0f);
+    benchmark ("vfloat8 = Zero()", [](int){ return vfloat8::Zero(); }, 0);
+    benchmark ("vfloat8 = One()", [](int){ return vfloat8::One(); }, 0);
+    benchmark ("vfloat8 = Iota()", [](int){ return vfloat8::Iota(); }, 0);
 
-    benchmark ("float16 = float(const)", [](float f){ return float16(f); }, 1.0f);
-    benchmark ("float16 = Zero()", [](int){ return float16::Zero(); }, 0);
-    benchmark ("float16 = One()", [](int){ return float16::One(); }, 0);
-    benchmark ("float16 = Iota()", [](int){ return float16::Iota(); }, 0);
+    benchmark ("vfloat16 = float(const)", [](float f){ return vfloat16(f); }, 1.0f);
+    benchmark ("vfloat16 = Zero()", [](int){ return vfloat16::Zero(); }, 0);
+    benchmark ("vfloat16 = One()", [](int){ return vfloat16::One(); }, 0);
+    benchmark ("vfloat16 = Iota()", [](int){ return vfloat16::Iota(); }, 0);
 }
 
 
@@ -1283,21 +1283,21 @@ void test_special ()
 {
     test_heading ("special");
     {
-        // Make sure a float4 constructed from saturated unsigned short,
+        // Make sure a vfloat4 constructed from saturated unsigned short,
         // short, unsigned char, or char values, then divided by the float
         // max, exactly equals 1.0.
         short s32767[] = {32767, 32767, 32767, 32767};
         unsigned short us65535[] = {65535, 65535, 65535, 65535};
         char c127[] = {127, 127, 127, 127};
         unsigned char uc255[] = {255, 255, 255, 255};
-        OIIO_CHECK_SIMD_EQUAL (float4(us65535)/float4(65535.0), float4(1.0f));
-        OIIO_CHECK_SIMD_EQUAL (float4(us65535)*float4(1.0f/65535.0), float4(1.0f));
-        OIIO_CHECK_SIMD_EQUAL (float4(s32767)/float4(32767.0), float4(1.0f));
-        OIIO_CHECK_SIMD_EQUAL (float4(s32767)*float4(1.0f/32767.0), float4(1.0f));
-        OIIO_CHECK_SIMD_EQUAL (float4(uc255)/float4(255.0), float4(1.0f));
-        OIIO_CHECK_SIMD_EQUAL (float4(uc255)*float4(1.0f/255.0), float4(1.0f));
-        OIIO_CHECK_SIMD_EQUAL (float4(c127)/float4(127.0), float4(1.0f));
-        OIIO_CHECK_SIMD_EQUAL (float4(c127)*float4(1.0f/127.0), float4(1.0f));
+        OIIO_CHECK_SIMD_EQUAL (vfloat4(us65535)/vfloat4(65535.0), vfloat4(1.0f));
+        OIIO_CHECK_SIMD_EQUAL (vfloat4(us65535)*vfloat4(1.0f/65535.0), vfloat4(1.0f));
+        OIIO_CHECK_SIMD_EQUAL (vfloat4(s32767)/vfloat4(32767.0), vfloat4(1.0f));
+        OIIO_CHECK_SIMD_EQUAL (vfloat4(s32767)*vfloat4(1.0f/32767.0), vfloat4(1.0f));
+        OIIO_CHECK_SIMD_EQUAL (vfloat4(uc255)/vfloat4(255.0), vfloat4(1.0f));
+        OIIO_CHECK_SIMD_EQUAL (vfloat4(uc255)*vfloat4(1.0f/255.0), vfloat4(1.0f));
+        OIIO_CHECK_SIMD_EQUAL (vfloat4(c127)/vfloat4(127.0), vfloat4(1.0f));
+        OIIO_CHECK_SIMD_EQUAL (vfloat4(c127)*vfloat4(1.0f/127.0), vfloat4(1.0f));
     }
 }
 
@@ -1305,9 +1305,9 @@ void test_special ()
 
 // Wrappers to resolve the return type ambiguity
 inline float fast_exp_float (float x) { return fast_exp(x); }
-inline float4 fast_exp_float4 (const float4& x) { return fast_exp(x); }
+inline vfloat4 fast_exp_vfloat4 (const vfloat4& x) { return fast_exp(x); }
 inline float fast_log_float (float x) { return fast_log(x); }
-//inline float4 fast_log_float (const float4& x) { return fast_log(x); }
+//inline vfloat4 fast_log_float (const vfloat4& x) { return fast_log(x); }
 inline float rsqrtf (float f) { return 1.0f / sqrtf(f); }
 inline float rcp (float f) { return 1.0f / f; }
 
@@ -1364,49 +1364,49 @@ void test_mathfuncs ()
 void test_metaprogramming ()
 {
     test_heading ("metaprogramming");
-    OIIO_CHECK_EQUAL (SimdSize<float4>::size, 4);
-    OIIO_CHECK_EQUAL (SimdSize<float3>::size, 4);
-    OIIO_CHECK_EQUAL (SimdSize<int4>::size, 4);
-    OIIO_CHECK_EQUAL (SimdSize<bool4>::size, 4);
-    OIIO_CHECK_EQUAL (SimdSize<float8>::size, 8);
-    OIIO_CHECK_EQUAL (SimdSize<int8>::size, 8);
-    OIIO_CHECK_EQUAL (SimdSize<bool8>::size, 8);
-    OIIO_CHECK_EQUAL (SimdSize<float16>::size, 16);
-    OIIO_CHECK_EQUAL (SimdSize<int16>::size, 16);
-    OIIO_CHECK_EQUAL (SimdSize<bool16>::size, 16);
+    OIIO_CHECK_EQUAL (SimdSize<vfloat4>::size, 4);
+    OIIO_CHECK_EQUAL (SimdSize<vfloat3>::size, 4);
+    OIIO_CHECK_EQUAL (SimdSize<vint4>::size, 4);
+    OIIO_CHECK_EQUAL (SimdSize<vbool4>::size, 4);
+    OIIO_CHECK_EQUAL (SimdSize<vfloat8>::size, 8);
+    OIIO_CHECK_EQUAL (SimdSize<vint8>::size, 8);
+    OIIO_CHECK_EQUAL (SimdSize<vbool8>::size, 8);
+    OIIO_CHECK_EQUAL (SimdSize<vfloat16>::size, 16);
+    OIIO_CHECK_EQUAL (SimdSize<vint16>::size, 16);
+    OIIO_CHECK_EQUAL (SimdSize<vbool16>::size, 16);
     OIIO_CHECK_EQUAL (SimdSize<float>::size, 1);
     OIIO_CHECK_EQUAL (SimdSize<int>::size, 1);
     OIIO_CHECK_EQUAL (SimdSize<bool>::size, 1);
 
-    OIIO_CHECK_EQUAL (SimdElements<float4>::size, 4);
-    OIIO_CHECK_EQUAL (SimdElements<float3>::size, 3);
-    OIIO_CHECK_EQUAL (SimdElements<int4>::size, 4);
-    OIIO_CHECK_EQUAL (SimdElements<bool4>::size, 4);
-    OIIO_CHECK_EQUAL (SimdElements<float8>::size, 8);
-    OIIO_CHECK_EQUAL (SimdElements<int8>::size, 8);
-    OIIO_CHECK_EQUAL (SimdElements<bool8>::size, 8);
-    OIIO_CHECK_EQUAL (SimdElements<float16>::size, 16);
-    OIIO_CHECK_EQUAL (SimdElements<int16>::size, 16);
-    OIIO_CHECK_EQUAL (SimdElements<bool16>::size, 16);
+    OIIO_CHECK_EQUAL (SimdElements<vfloat4>::size, 4);
+    OIIO_CHECK_EQUAL (SimdElements<vfloat3>::size, 3);
+    OIIO_CHECK_EQUAL (SimdElements<vint4>::size, 4);
+    OIIO_CHECK_EQUAL (SimdElements<vbool4>::size, 4);
+    OIIO_CHECK_EQUAL (SimdElements<vfloat8>::size, 8);
+    OIIO_CHECK_EQUAL (SimdElements<vint8>::size, 8);
+    OIIO_CHECK_EQUAL (SimdElements<vbool8>::size, 8);
+    OIIO_CHECK_EQUAL (SimdElements<vfloat16>::size, 16);
+    OIIO_CHECK_EQUAL (SimdElements<vint16>::size, 16);
+    OIIO_CHECK_EQUAL (SimdElements<vbool16>::size, 16);
     OIIO_CHECK_EQUAL (SimdElements<float>::size, 1);
     OIIO_CHECK_EQUAL (SimdElements<int>::size, 1);
     OIIO_CHECK_EQUAL (SimdElements<bool>::size, 1);
 
-    OIIO_CHECK_EQUAL (float4::elements, 4);
-    OIIO_CHECK_EQUAL (float3::elements, 3);
-    OIIO_CHECK_EQUAL (int4::elements, 4);
-    OIIO_CHECK_EQUAL (bool4::elements, 4);
-    OIIO_CHECK_EQUAL (float8::elements, 8);
-    OIIO_CHECK_EQUAL (int8::elements, 8);
-    OIIO_CHECK_EQUAL (bool8::elements, 8);
-    OIIO_CHECK_EQUAL (float16::elements, 16);
-    OIIO_CHECK_EQUAL (int16::elements, 16);
-    OIIO_CHECK_EQUAL (bool16::elements, 16);
+    OIIO_CHECK_EQUAL (vfloat4::elements, 4);
+    OIIO_CHECK_EQUAL (vfloat3::elements, 3);
+    OIIO_CHECK_EQUAL (vint4::elements, 4);
+    OIIO_CHECK_EQUAL (vbool4::elements, 4);
+    OIIO_CHECK_EQUAL (vfloat8::elements, 8);
+    OIIO_CHECK_EQUAL (vint8::elements, 8);
+    OIIO_CHECK_EQUAL (vbool8::elements, 8);
+    OIIO_CHECK_EQUAL (vfloat16::elements, 16);
+    OIIO_CHECK_EQUAL (vint16::elements, 16);
+    OIIO_CHECK_EQUAL (vbool16::elements, 16);
 
-    // OIIO_CHECK_EQUAL (is_same<float4::value_t,float>::value, true);
-    // OIIO_CHECK_EQUAL (is_same<float3::value_t,float>::value, true);
-    // OIIO_CHECK_EQUAL (is_same<int4::value_t,int>::value, true);
-    // OIIO_CHECK_EQUAL (is_same<bool4::value_t,int>::value, true);
+    // OIIO_CHECK_EQUAL (is_same<vfloat4::value_t,float>::value, true);
+    // OIIO_CHECK_EQUAL (is_same<vfloat3::value_t,float>::value, true);
+    // OIIO_CHECK_EQUAL (is_same<vint4::value_t,int>::value, true);
+    // OIIO_CHECK_EQUAL (is_same<vbool4::value_t,int>::value, true);
 }
 
 
@@ -1428,8 +1428,8 @@ transformp_imath_simd (const Imath::V3f &v, const Imath::M44f &m)
 }
 
 // Transform a simd point by an Imath matrix using SIMD
-inline float3
-transformp_simd (const float3 &v, const Imath::M44f &m)
+inline vfloat3
+transformp_simd (const vfloat3 &v, const Imath::M44f &m)
 {
     return simd::transformp (m, v);
 }
@@ -1509,7 +1509,7 @@ void test_matrix ()
     Imath::M44f mx (1,0,0,0, 0,1,0,0, 0,0,1,0, 10,11,12,1);
     benchmark2 ("transformp Imath", transformp_imath, vx, mx, 1);
     benchmark2 ("transformp Imath with simd", transformp_imath_simd, vx, mx, 1);
-    benchmark2 ("transformp simd", transformp_simd, float3(vx), mx, 1);
+    benchmark2 ("transformp simd", transformp_simd, vfloat3(vx), mx, 1);
     benchmark ("transpose m44", mat_transpose, mx, 1);
     benchmark ("transpose m44 with simd", mat_transpose_simd, mx, 1);
     // Reduce the iterations of the ones below, if we can
@@ -1554,120 +1554,120 @@ main (int argc, char *argv[])
 
     Timer timer;
 
-    int4 dummy4(0);
-    int8 dummy8(0);
-    benchmark ("null benchmark 4", [](const int4&){ return int(0); }, dummy4);
-    benchmark ("null benchmark 8", [](const int8&){ return int(0); }, dummy8);
+    vint4 dummy4(0);
+    vint8 dummy8(0);
+    benchmark ("null benchmark 4", [](const vint4&){ return int(0); }, dummy4);
+    benchmark ("null benchmark 8", [](const vint8&){ return int(0); }, dummy8);
 
-    category_heading ("float4");
-    test_partial_loadstore<float4> ();
-    test_conversion_loadstore_float<float4> ();
-    test_component_access<float4> ();
-    test_arithmetic<float4> ();
-    test_comparisons<float4> ();
-    test_shuffle4<float4> ();
-    test_swizzle<float4> ();
-    test_blend<float4> ();
-    test_transpose4<float4> ();
-    test_vectorops_float4 ();
-    test_fused<float4> ();
-    test_mathfuncs<float4>();
+    category_heading ("vfloat4");
+    test_partial_loadstore<vfloat4> ();
+    test_conversion_loadstore_float<vfloat4> ();
+    test_component_access<vfloat4> ();
+    test_arithmetic<vfloat4> ();
+    test_comparisons<vfloat4> ();
+    test_shuffle4<vfloat4> ();
+    test_swizzle<vfloat4> ();
+    test_blend<vfloat4> ();
+    test_transpose4<vfloat4> ();
+    test_vectorops_vfloat4 ();
+    test_fused<vfloat4> ();
+    test_mathfuncs<vfloat4>();
 
-    category_heading ("float3");
-    test_partial_loadstore<float3> ();
-    test_conversion_loadstore_float<float3> ();
-    test_component_access<float3> ();
-    test_arithmetic<float3> ();
-    // Unnecessary to test these, they just use the float4 ops.
-    // test_comparisons<float3> ();
-    // test_shuffle4<float3> ();
-    // test_swizzle<float3> ();
-    // test_blend<float3> ();
-    // test_transpose4<float3> ();
-    test_vectorops_float3 ();
-    test_fused<float3> ();
-    // test_mathfuncs<float3>();
+    category_heading ("vfloat3");
+    test_partial_loadstore<vfloat3> ();
+    test_conversion_loadstore_float<vfloat3> ();
+    test_component_access<vfloat3> ();
+    test_arithmetic<vfloat3> ();
+    // Unnecessary to test these, they just use the vfloat4 ops.
+    // test_comparisons<vfloat3> ();
+    // test_shuffle4<vfloat3> ();
+    // test_swizzle<vfloat3> ();
+    // test_blend<vfloat3> ();
+    // test_transpose4<vfloat3> ();
+    test_vectorops_vfloat3 ();
+    test_fused<vfloat3> ();
+    // test_mathfuncs<vfloat3>();
 
-    category_heading ("float8");
-    test_partial_loadstore<float8> ();
-    test_conversion_loadstore_float<float8> ();
-    test_masked_loadstore<float8> ();
-    test_component_access<float8> ();
-    test_arithmetic<float8> ();
-    test_comparisons<float8> ();
-    test_shuffle8<float8> ();
-    test_blend<float8> ();
-    test_fused<float8> ();
-    test_mathfuncs<float8>();
+    category_heading ("vfloat8");
+    test_partial_loadstore<vfloat8> ();
+    test_conversion_loadstore_float<vfloat8> ();
+    test_masked_loadstore<vfloat8> ();
+    test_component_access<vfloat8> ();
+    test_arithmetic<vfloat8> ();
+    test_comparisons<vfloat8> ();
+    test_shuffle8<vfloat8> ();
+    test_blend<vfloat8> ();
+    test_fused<vfloat8> ();
+    test_mathfuncs<vfloat8>();
 
-    category_heading ("float16");
-    test_partial_loadstore<float16> ();
-    test_conversion_loadstore_float<float16> ();
-    test_masked_loadstore<float16> ();
-    test_component_access<float16> ();
-    test_arithmetic<float16> ();
-    test_comparisons<float16> ();
-    test_shuffle16<float16> ();
-    test_blend<float16> ();
-    test_fused<float16> ();
-    test_mathfuncs<float16>();
+    category_heading ("vfloat16");
+    test_partial_loadstore<vfloat16> ();
+    test_conversion_loadstore_float<vfloat16> ();
+    test_masked_loadstore<vfloat16> ();
+    test_component_access<vfloat16> ();
+    test_arithmetic<vfloat16> ();
+    test_comparisons<vfloat16> ();
+    test_shuffle16<vfloat16> ();
+    test_blend<vfloat16> ();
+    test_fused<vfloat16> ();
+    test_mathfuncs<vfloat16>();
 
-    category_heading ("int4");
-    test_partial_loadstore<int4> ();
-    test_conversion_loadstore_int<int4> ();
-    test_component_access<int4> ();
-    test_arithmetic<int4> ();
-    test_bitwise_int<int4> ();
-    test_comparisons<int4> ();
-    test_shuffle4<int4> ();
-    test_blend<int4> ();
-    test_vint_to_uint16s<int4> ();
-    test_vint_to_uint8s<int4> ();
-    test_shift<int4> ();
-    test_transpose4<int4> ();
+    category_heading ("vint4");
+    test_partial_loadstore<vint4> ();
+    test_conversion_loadstore_int<vint4> ();
+    test_component_access<vint4> ();
+    test_arithmetic<vint4> ();
+    test_bitwise_int<vint4> ();
+    test_comparisons<vint4> ();
+    test_shuffle4<vint4> ();
+    test_blend<vint4> ();
+    test_vint_to_uint16s<vint4> ();
+    test_vint_to_uint8s<vint4> ();
+    test_shift<vint4> ();
+    test_transpose4<vint4> ();
 
-    category_heading ("int8");
-    test_partial_loadstore<int8> ();
-    test_conversion_loadstore_int<int8> ();
-    test_masked_loadstore<int8> ();
-    test_component_access<int8> ();
-    test_arithmetic<int8> ();
-    test_bitwise_int<int8> ();
-    test_comparisons<int8> ();
-    test_shuffle8<int8> ();
-    test_blend<int8> ();
-    test_vint_to_uint16s<int8> ();
-    test_vint_to_uint8s<int8> ();
-    test_shift<int8> ();
+    category_heading ("vint8");
+    test_partial_loadstore<vint8> ();
+    test_conversion_loadstore_int<vint8> ();
+    test_masked_loadstore<vint8> ();
+    test_component_access<vint8> ();
+    test_arithmetic<vint8> ();
+    test_bitwise_int<vint8> ();
+    test_comparisons<vint8> ();
+    test_shuffle8<vint8> ();
+    test_blend<vint8> ();
+    test_vint_to_uint16s<vint8> ();
+    test_vint_to_uint8s<vint8> ();
+    test_shift<vint8> ();
 
-    category_heading ("int16");
-    test_partial_loadstore<int16> ();
-    test_conversion_loadstore_int<int16> ();
-    test_masked_loadstore<int16> ();
-    test_component_access<int16> ();
-    test_arithmetic<int16> ();
-    test_bitwise_int<int16> ();
-    test_comparisons<int16> ();
-    test_shuffle16<int16> ();
-    test_blend<int16> ();
-    test_vint_to_uint16s<int16> ();
-    test_vint_to_uint16s<int16> ();
-    test_shift<int16> ();
+    category_heading ("vint16");
+    test_partial_loadstore<vint16> ();
+    test_conversion_loadstore_int<vint16> ();
+    test_masked_loadstore<vint16> ();
+    test_component_access<vint16> ();
+    test_arithmetic<vint16> ();
+    test_bitwise_int<vint16> ();
+    test_comparisons<vint16> ();
+    test_shuffle16<vint16> ();
+    test_blend<vint16> ();
+    test_vint_to_uint16s<vint16> ();
+    test_vint_to_uint16s<vint16> ();
+    test_shift<vint16> ();
 
-    category_heading ("bool4");
-    test_shuffle4<bool4> ();
-    test_component_access<bool4> ();
-    test_bitwise_bool<bool4> ();
+    category_heading ("vbool4");
+    test_shuffle4<vbool4> ();
+    test_component_access<vbool4> ();
+    test_bitwise_bool<vbool4> ();
 
-    category_heading ("bool8");
-    test_shuffle8<bool8> ();
-    test_component_access<bool8> ();
-    test_bitwise_bool<bool8> ();
+    category_heading ("vbool8");
+    test_shuffle8<vbool8> ();
+    test_component_access<vbool8> ();
+    test_bitwise_bool<vbool8> ();
 
-    category_heading ("bool16");
-    // test_shuffle16<bool16> ();
-    test_component_access<bool16> ();
-    test_bitwise_bool<bool16> ();
+    category_heading ("vbool16");
+    // test_shuffle16<vbool16> ();
+    test_component_access<vbool16> ();
+    test_bitwise_bool<vbool16> ();
 
     category_heading ("Odds and ends");
     test_constants();

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -127,8 +127,6 @@ test_heading (string_view name, string_view name2="")
 
 
 
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
-
 // What I really want to do is merge benchmark() and benchmark2() into
 // one template using variadic arguments, like this:
 //   template <typename FUNC, typename ...ARGS>
@@ -185,14 +183,6 @@ void benchmark2 (string_view funcname, FUNC func, T x, U y,
                                   (iterations/1.0e6)/time);
 }
 
-#else
-
-// No support of lambdas, just skip the benchmarks
-#define benchmark(a,b,c,d)
-#define benchmark2(a,b,c,d,e)
-
-#endif
-
 
 
 template<typename VEC>
@@ -210,12 +200,20 @@ template<> inline float8 mkvec<float8> (float a, float b, float c, float d) {
     return float8(a,b,c,d,a,b,c,d);
 }
 
+template<> inline float16 mkvec<float16> (float a, float b, float c, float d) {
+    return float16(a,b,c,d,a,b,c,d,a,b,c,d,a,b,c,d);
+}
+
 template<> inline int8 mkvec<int8> (int a, int b, int c, int d) {
     return int8(a,b,c,d,a,b,c,d);
 }
 
 template<> inline bool8 mkvec<bool8> (bool a, bool b, bool c, bool d) {
     return bool8(a,b,c,d,a,b,c,d);
+}
+
+template<> inline bool16 mkvec<bool16> (bool a, bool b, bool c, bool d) {
+    return bool16(a,b,c,d,a,b,c,d,a,b,c,d,a,b,c,d);
 }
 
 
@@ -240,6 +238,12 @@ template<> inline int4 mkvec<int4> (int a, int b, int c, int d,
     return int4(a,b,c,d);
 }
 
+template<> inline int16 mkvec<int16> (int a, int b, int c, int d,
+                                      int e, int f, int g, int h) {
+    return int16(a,b,c,d,e,f,g,h,
+                 h+1,h+2,h+3,h+4,h+5,h+6,h+7,h+8);
+}
+
 template<> inline float4 mkvec<float4> (float a, float b, float c, float d,
                                         float e, float f, float g, float h) {
     return float4(a,b,c,d);
@@ -249,6 +253,13 @@ template<> inline float3 mkvec<float3> (float a, float b, float c, float d,
                                         float e, float f, float g, float h) {
     return float3(a,b,c);
 }
+
+template<> inline float16 mkvec<float16> (float a, float b, float c, float d,
+                                          float e, float f, float g, float h) {
+    return float16(a,b,c,d,e,f,g,h,
+                   h+1,h+2,h+3,h+4,h+5,h+6,h+7,h+8);
+}
+
 
 
 template<typename VEC>
@@ -323,20 +334,22 @@ inline matrix44 inverse_simd (const matrix44 &M)
 
 
 template<typename VEC>
-void test_loadstore ()
+void test_partial_loadstore ()
 {
     typedef typename VEC::value_t ELEM;
-    test_heading ("loadstore ", VEC::type_name());
-    VEC C1234 = mkvec<VEC>(1, 2, 3, 4, 5, 6, 7, 8);
-    // VEC C0 (0);
-    ELEM partial[] = { 101, 102, 103, 104, 105, 106, 107, 108 };
+    test_heading ("partial loadstore ", VEC::type_name());
+    VEC C1234 = VEC::Iota(1);
+    ELEM partial[] = { 101, 102, 103, 104, 105, 106, 107, 108,
+                       109, 110, 111, 112, 113, 114, 115, 116 };
+    OIIO_CHECK_SIMD_EQUAL (VEC(partial), VEC::Iota(101));
     for (int i = 1; i <= VEC::elements; ++i) {
         VEC a (ELEM(0));
         a.load (partial, i);
         for (int j = 0; j < VEC::elements; ++j)
             OIIO_CHECK_EQUAL (a[j], j<i ? partial[j] : ELEM(0));
         std::cout << "  partial load " << i << " : " << a << "\n";
-        ELEM stored[] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+        ELEM stored[] = { 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0 };
         C1234.store (stored, i);
         for (int j = 0; j < VEC::elements; ++j)
             OIIO_CHECK_EQUAL (stored[j], j<i ? ELEM(j+1) : ELEM(0));
@@ -346,20 +359,12 @@ void test_loadstore ()
         std::cout << std::endl;
     }
 
-    {
-    // Check load from integers
-    unsigned short us1234[] = {1, 2, 3, 4, 5, 6, 7, 8};
-    short s1234[]           = {1, 2, 3, 4, 5, 6, 7, 8};
-    unsigned char uc1234[]  = {1, 2, 3, 4, 5, 6, 7, 8};
-    char c1234[]            = {1, 2, 3, 4, 5, 6, 7, 8};
-    OIIO_CHECK_SIMD_EQUAL (VEC(us1234), C1234);
-    OIIO_CHECK_SIMD_EQUAL (VEC( s1234), C1234);
-    OIIO_CHECK_SIMD_EQUAL (VEC(uc1234), C1234);
-    OIIO_CHECK_SIMD_EQUAL (VEC( c1234), C1234);
-    }
-
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
     benchmark ("load/store", loadstore_vec<VEC>, 0, VEC::elements);
+    if (VEC::elements == 16) {
+        benchmark ("load/store, 16 comps", loadstore_vec_N<VEC, 16>, 0, 16);
+        benchmark ("load/store, 13 comps", loadstore_vec_N<VEC, 13>, 0, 13);
+        benchmark ("load/store, 9 comps", loadstore_vec_N<VEC, 9>, 0, 9);
+    }
     if (VEC::elements > 4) {
         benchmark ("load/store, 8 comps", loadstore_vec_N<VEC, 8>, 0, 8);
         benchmark ("load/store, 7 comps", loadstore_vec_N<VEC, 7>, 0, 7);
@@ -372,7 +377,67 @@ void test_loadstore ()
     benchmark ("load/store, 3 comps", loadstore_vec_N<VEC, 3>, 0, 3);
     benchmark ("load/store, 2 comps", loadstore_vec_N<VEC, 2>, 0, 2);
     benchmark ("load/store, 1 comps", loadstore_vec_N<VEC, 1>, 0, 1);
-#endif
+}
+
+
+
+template<typename VEC>
+void test_conversion_loadstore_float ()
+{
+    typedef typename VEC::value_t ELEM;
+    test_heading ("loadstore with conversion", VEC::type_name());
+    VEC C1234 = VEC::Iota(1);
+    ELEM partial[] = { 101, 102, 103, 104, 105, 106, 107, 108,
+                       109, 110, 111, 112, 113, 114, 115, 116 };
+    OIIO_CHECK_SIMD_EQUAL (VEC(partial), VEC::Iota(101));
+
+    // Check load from integers
+    unsigned short us1234[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    short s1234[]           = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    unsigned char uc1234[]  = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    char c1234[]            = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    half h1234[]            = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    OIIO_CHECK_SIMD_EQUAL (VEC(us1234), C1234);
+    OIIO_CHECK_SIMD_EQUAL (VEC( s1234), C1234);
+    OIIO_CHECK_SIMD_EQUAL (VEC(uc1234), C1234);
+    OIIO_CHECK_SIMD_EQUAL (VEC( c1234), C1234);
+
+    benchmark ("load from unsigned short[]", [](const unsigned short *d){ return VEC(d); }, us1234);
+    benchmark ("load from short[]", [](const short *d){ return VEC(d); }, s1234);
+    benchmark ("load from unsigned char[]", [](const unsigned char *d){ return VEC(d); }, uc1234);
+    benchmark ("load from char[]", [](const char *d){ return VEC(d); }, c1234);
+    benchmark ("load from half[]", [](const half *d){ return VEC(d); }, h1234);
+}
+
+
+
+template<typename VEC>
+void test_conversion_loadstore_int ()
+{
+    typedef typename VEC::value_t ELEM;
+    test_heading ("loadstore with conversion", VEC::type_name());
+    VEC C1234 = VEC::Iota(1);
+    ELEM partial[] = { 101, 102, 103, 104, 105, 106, 107, 108,
+                       109, 110, 111, 112, 113, 114, 115, 116 };
+    OIIO_CHECK_SIMD_EQUAL (VEC(partial), VEC::Iota(101));
+
+    // Check load from integers
+    int i1234[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    unsigned short us1234[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    short s1234[]           = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    unsigned char uc1234[]  = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    char c1234[]            = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    OIIO_CHECK_SIMD_EQUAL (VEC( i1234), C1234);
+    OIIO_CHECK_SIMD_EQUAL (VEC(us1234), C1234);
+    OIIO_CHECK_SIMD_EQUAL (VEC( s1234), C1234);
+    OIIO_CHECK_SIMD_EQUAL (VEC(uc1234), C1234);
+    OIIO_CHECK_SIMD_EQUAL (VEC( c1234), C1234);
+
+    benchmark ("load from int[]", [](const int *d){ return VEC(d); }, i1234);
+    benchmark ("load from unsigned short[]", [](const unsigned short *d){ return VEC(d); }, us1234);
+    benchmark ("load from short[]", [](const short *d){ return VEC(d); }, s1234);
+    benchmark ("load from unsigned char[]", [](const unsigned char *d){ return VEC(d); }, uc1234);
+    benchmark ("load from char[]", [](const char *d){ return VEC(d); }, c1234);
 }
 
 
@@ -386,9 +451,9 @@ void test_vint_to_uint16s ()
     ival.store (buf);
     for (int i = 0; i < VEC::elements; ++i)
         OIIO_CHECK_EQUAL (int(buf[i]), i);
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
+
+    benchmark2 ("load from uint16", [](VEC& a, unsigned short *s){ a.load(s); return 1; }, ival, buf, VEC::elements);
     benchmark2 ("convert to uint16", [](VEC& a, unsigned short *s){ a.store(s); return 1; }, ival, buf, VEC::elements);
-#endif
 }
 
 
@@ -402,9 +467,37 @@ void test_vint_to_uint8s ()
     ival.store (buf);
     for (int i = 0; i < VEC::elements; ++i)
         OIIO_CHECK_EQUAL (int(buf[i]), i);
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
+
+    benchmark2 ("load from uint8", [](VEC& a, unsigned char *s){ a.load(s); return 1; }, ival, buf, VEC::elements);
     benchmark2 ("convert to uint16", [](VEC& a, unsigned char *s){ a.store(s); return 1; }, ival, buf, VEC::elements);
-#endif
+}
+
+
+
+template<typename VEC>
+void test_masked_loadstore ()
+{
+    typedef typename VEC::value_t ELEM;
+    typedef typename VEC::bool_t BOOL;
+    test_heading ("masked loadstore ", VEC::type_name());
+    ELEM iota[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+    BOOL mask1 = mkvec<BOOL> (true, false, true, false);
+    BOOL mask2 = mkvec<BOOL> (true, true, false,false);
+
+    VEC v;
+    v = -1;
+    v.load_mask (mask1, iota);
+    ELEM r1[] = { 1, 0, 3, 0, 5, 0, 7, 0, 9, 0, 11, 0, 13, 0, 15, 0 };
+    OIIO_CHECK_SIMD_EQUAL (v, VEC(r1));
+    ELEM buf[] = { -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2 };
+    v.store_mask (mask2, buf);
+    ELEM r2[] = { 1, 0, -2, -2, 5, 0, -2, -2, 9, 0, -2, -2, 13, 0, -2, -2 };
+    OIIO_CHECK_SIMD_EQUAL (VEC(buf), VEC(r2));
+
+    benchmark ("masked load with int mask", [](const ELEM *d){ VEC v; v.load_mask (0xffff, d); return v; }, iota);
+    benchmark ("masked load with bool mask", [](const ELEM *d){ VEC v; v.load_mask (BOOL::True(), d); return v; }, iota);
+    benchmark ("masked store with int mask", [&](ELEM *d){ v.store_mask (0xffff, d); return 0; }, r2);
+    benchmark ("masked store with bool mask", [&](ELEM *d){ v.store_mask (BOOL::True(), d); return 0; }, r2);
 }
 
 
@@ -415,24 +508,24 @@ void test_component_access ()
     typedef typename VEC::value_t ELEM;
     test_heading ("component_access ", VEC::type_name());
 
-    const ELEM vals[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
-    VEC a = mkvec<VEC>(0, 1, 2, 3, 4, 5, 6, 7);
+    const ELEM vals[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+    VEC a = VEC::Iota();
     for (int i = 0; i < VEC::elements; ++i)
         OIIO_CHECK_EQUAL (a[i], vals[i]);
 
     if (VEC::elements <= 4) {
-    OIIO_CHECK_EQUAL (a.x(), 0);
-    OIIO_CHECK_EQUAL (a.y(), 1);
-    OIIO_CHECK_EQUAL (a.z(), 2);
-    if (SimdElements<VEC>::size > 3)
-        OIIO_CHECK_EQUAL (a.w(), 3);
-    VEC t;
-    t = a; t.set_x(42); OIIO_CHECK_SIMD_EQUAL (t, mkvec<VEC>(42,1,2,3,4,5,6,7));
-    t = a; t.set_y(42); OIIO_CHECK_SIMD_EQUAL (t, mkvec<VEC>(0,42,2,3,4,5,6,7));
-    t = a; t.set_z(42); OIIO_CHECK_SIMD_EQUAL (t, mkvec<VEC>(0,1,42,3,4,5,6,7));
-    if (SimdElements<VEC>::size > 3) {
-        t = a; t.set_w(42); OIIO_CHECK_SIMD_EQUAL (t, mkvec<VEC>(0,1,2,42,4,5,6,7));
-    }
+        OIIO_CHECK_EQUAL (a.x(), 0);
+        OIIO_CHECK_EQUAL (a.y(), 1);
+        OIIO_CHECK_EQUAL (a.z(), 2);
+        if (SimdElements<VEC>::size > 3)
+            OIIO_CHECK_EQUAL (a.w(), 3);
+        VEC t;
+        t = a; t.set_x(42); OIIO_CHECK_SIMD_EQUAL (t, mkvec<VEC>(42,1,2,3,4,5,6,7));
+        t = a; t.set_y(42); OIIO_CHECK_SIMD_EQUAL (t, mkvec<VEC>(0,42,2,3,4,5,6,7));
+        t = a; t.set_z(42); OIIO_CHECK_SIMD_EQUAL (t, mkvec<VEC>(0,1,42,3,4,5,6,7));
+        if (SimdElements<VEC>::size > 3) {
+            t = a; t.set_w(42); OIIO_CHECK_SIMD_EQUAL (t, mkvec<VEC>(0,1,2,42,4,5,6,7));
+        }
     }
 
     OIIO_CHECK_EQUAL (extract<0>(a), 0);
@@ -460,15 +553,23 @@ void test_component_access ()
         OIIO_CHECK_EQUAL (extract<6>(b), 6);
         OIIO_CHECK_EQUAL (extract<7>(b), 7);
     }
+    if (SimdElements<VEC>::size > 8) {
+        OIIO_CHECK_EQUAL (extract<8>(b), 8);
+        OIIO_CHECK_EQUAL (extract<9>(b), 9);
+        OIIO_CHECK_EQUAL (extract<10>(b), 10);
+        OIIO_CHECK_EQUAL (extract<11>(b), 11);
+        OIIO_CHECK_EQUAL (extract<12>(b), 12);
+        OIIO_CHECK_EQUAL (extract<13>(b), 13);
+        OIIO_CHECK_EQUAL (extract<14>(b), 14);
+        OIIO_CHECK_EQUAL (extract<15>(b), 15);
+    }
 
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
     benchmark2 ("operator[i]", [&](const VEC& v, int i){ return v[i]; },  b, 2, 1 /*work*/);
     benchmark2 ("operator[2]", [&](const VEC& v, int i){ return v[2]; },  b, 2, 1 /*work*/);
     benchmark2 ("operator[0]", [&](const VEC& v, int i){ return v[0]; },  b, 0, 1 /*work*/);
     benchmark2 ("extract<2> ", [&](const VEC& v, int i){ return extract<2>(v); },  b, 2, 1 /*work*/);
     benchmark2 ("extract<0> ", [&](const VEC& v, int i){ return extract<0>(v); },  b, 0, 1 /*work*/);
     benchmark2 ("insert<2> ", [&](const VEC& v, ELEM i){ return insert<2>(v, i); }, b, ELEM(1), 1 /*work*/);
-#endif
 }
 
 
@@ -480,19 +581,32 @@ void test_component_access<bool4> ()
     typedef VEC::value_t ELEM;
     test_heading ("component_access ", VEC::type_name());
 
-    VEC a (false, true, true, true);
-    OIIO_CHECK_EQUAL (bool(a[0]), false);
-    OIIO_CHECK_EQUAL (bool(a[1]), true);
-    OIIO_CHECK_EQUAL (bool(a[2]), true);
-    OIIO_CHECK_EQUAL (bool(a[3]), true);
-    OIIO_CHECK_EQUAL (extract<0>(a), false);
-    OIIO_CHECK_EQUAL (extract<1>(a), true);
-    OIIO_CHECK_EQUAL (extract<2>(a), true);
-    OIIO_CHECK_EQUAL (extract<3>(a), true);
-    OIIO_CHECK_SIMD_EQUAL (insert<0>(a, ELEM(true)), VEC(true,true,true,true));
-    OIIO_CHECK_SIMD_EQUAL (insert<1>(a, ELEM(false)), VEC(false,false,true,true));
-    OIIO_CHECK_SIMD_EQUAL (insert<2>(a, ELEM(false)), VEC(false,true,false,true));
-    OIIO_CHECK_SIMD_EQUAL (insert<3>(a, ELEM(false)), VEC(false,true,true,false));
+    for (int bit = 0; bit < VEC::elements; ++bit) {
+        VEC ctr (bit == 0, bit == 1, bit == 2, bit == 3);
+        VEC a;
+        a.clear ();
+        for (int b = 0; b < VEC::elements; ++b)
+            a.setcomp (b, b==bit);
+        OIIO_CHECK_SIMD_EQUAL (ctr, a);
+        for (int b = 0; b < VEC::elements; ++b)
+            OIIO_CHECK_EQUAL (bool(a[b]), b == bit);
+        OIIO_CHECK_EQUAL (extract<0>(a), bit == 0);
+        OIIO_CHECK_EQUAL (extract<1>(a), bit == 1);
+        OIIO_CHECK_EQUAL (extract<2>(a), bit == 2);
+        OIIO_CHECK_EQUAL (extract<3>(a), bit == 3);
+    }
+
+    VEC a;
+    a.load (0,0,0,0);
+    OIIO_CHECK_SIMD_EQUAL (insert<0>(a, 1), VEC(1,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<1>(a, 1), VEC(0,1,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<2>(a, 1), VEC(0,0,1,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<3>(a, 1), VEC(0,0,0,1));
+    a.load (1,1,1,1);
+    OIIO_CHECK_SIMD_EQUAL (insert<0>(a, 0), VEC(0,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<1>(a, 0), VEC(1,0,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<2>(a, 0), VEC(1,1,0,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<3>(a, 0), VEC(1,1,1,0));
 }
 
 
@@ -504,39 +618,121 @@ void test_component_access<bool8> ()
     typedef VEC::value_t ELEM;
     test_heading ("component_access ", VEC::type_name());
 
-    VEC a (false, true, true, true, false, false, true, true);
-    OIIO_CHECK_EQUAL (bool(a[0]), false);
-    OIIO_CHECK_EQUAL (bool(a[1]), true);
-    OIIO_CHECK_EQUAL (bool(a[2]), true);
-    OIIO_CHECK_EQUAL (bool(a[3]), true);
-    OIIO_CHECK_EQUAL (bool(a[4]), false);
-    OIIO_CHECK_EQUAL (bool(a[5]), false);
-    OIIO_CHECK_EQUAL (bool(a[6]), true);
-    OIIO_CHECK_EQUAL (bool(a[7]), true);
-    OIIO_CHECK_EQUAL (extract<0>(a), false);
-    OIIO_CHECK_EQUAL (extract<1>(a), true);
-    OIIO_CHECK_EQUAL (extract<2>(a), true);
-    OIIO_CHECK_EQUAL (extract<3>(a), true);
-    OIIO_CHECK_EQUAL (extract<4>(a), false);
-    OIIO_CHECK_EQUAL (extract<5>(a), false);
-    OIIO_CHECK_EQUAL (extract<6>(a), true);
-    OIIO_CHECK_EQUAL (extract<7>(a), true);
-    OIIO_CHECK_SIMD_EQUAL (insert<0>(a, ELEM(true)),
-                           VEC(true, true, true, true, false, false, true, true));
-    OIIO_CHECK_SIMD_EQUAL (insert<1>(a, ELEM(false)),
-                           VEC(false, false, true, true, false, false, true, true));
-    OIIO_CHECK_SIMD_EQUAL (insert<2>(a, ELEM(false)),
-                           VEC(false, true, false, true, false, false, true, true));
-    OIIO_CHECK_SIMD_EQUAL (insert<3>(a, ELEM(false)),
-                           VEC(false, true, true, false, false, false, true, true));
-    OIIO_CHECK_SIMD_EQUAL (insert<4>(a, ELEM(true)),
-                           VEC(false, true, true, true, true, false, true, true));
-    OIIO_CHECK_SIMD_EQUAL (insert<5>(a, ELEM(true)),
-                           VEC(false, true, true, true, false, true, true, true));
-    OIIO_CHECK_SIMD_EQUAL (insert<6>(a, ELEM(false)),
-                           VEC(false, true, true, true, false, false, false, true));
-    OIIO_CHECK_SIMD_EQUAL (insert<7>(a, ELEM(false)),
-                           VEC(false, true, true, true, false, false, true, false));
+    for (int bit = 0; bit < VEC::elements; ++bit) {
+        VEC ctr (bit == 0, bit == 1, bit == 2, bit == 3,
+                 bit == 4, bit == 5, bit == 6, bit == 7);
+        VEC a;
+        a.clear ();
+        for (int b = 0; b < VEC::elements; ++b)
+            a.setcomp (b, b==bit);
+        OIIO_CHECK_SIMD_EQUAL (ctr, a);
+        for (int b = 0; b < VEC::elements; ++b)
+            OIIO_CHECK_EQUAL (bool(a[b]), b == bit);
+        OIIO_CHECK_EQUAL (extract<0>(a), bit == 0);
+        OIIO_CHECK_EQUAL (extract<1>(a), bit == 1);
+        OIIO_CHECK_EQUAL (extract<2>(a), bit == 2);
+        OIIO_CHECK_EQUAL (extract<3>(a), bit == 3);
+        OIIO_CHECK_EQUAL (extract<4>(a), bit == 4);
+        OIIO_CHECK_EQUAL (extract<5>(a), bit == 5);
+        OIIO_CHECK_EQUAL (extract<6>(a), bit == 6);
+        OIIO_CHECK_EQUAL (extract<7>(a), bit == 7);
+    }
+
+    VEC a;
+    a.load (0,0,0,0,0,0,0,0);
+    OIIO_CHECK_SIMD_EQUAL (insert<0>(a, 1), VEC(1,0,0,0,0,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<1>(a, 1), VEC(0,1,0,0,0,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<2>(a, 1), VEC(0,0,1,0,0,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<3>(a, 1), VEC(0,0,0,1,0,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<4>(a, 1), VEC(0,0,0,0,1,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<5>(a, 1), VEC(0,0,0,0,0,1,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<6>(a, 1), VEC(0,0,0,0,0,0,1,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<7>(a, 1), VEC(0,0,0,0,0,0,0,1));
+    a.load (1,1,1,1,1,1,1,1);
+    OIIO_CHECK_SIMD_EQUAL (insert<0>(a, 0), VEC(0,1,1,1,1,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<1>(a, 0), VEC(1,0,1,1,1,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<2>(a, 0), VEC(1,1,0,1,1,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<3>(a, 0), VEC(1,1,1,0,1,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<4>(a, 0), VEC(1,1,1,1,0,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<5>(a, 0), VEC(1,1,1,1,1,0,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<6>(a, 0), VEC(1,1,1,1,1,1,0,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<7>(a, 0), VEC(1,1,1,1,1,1,1,0));
+}
+
+
+
+template<>
+void test_component_access<bool16> ()
+{
+    typedef bool16 VEC;
+    typedef VEC::value_t ELEM;
+    test_heading ("component_access ", VEC::type_name());
+
+    for (int bit = 0; bit < VEC::elements; ++bit) {
+        VEC ctr (bit == 0, bit == 1, bit == 2, bit == 3,
+                 bit == 4, bit == 5, bit == 6, bit == 7,
+                 bit == 8, bit == 9, bit == 10, bit == 11,
+                 bit == 12, bit == 13, bit == 14, bit == 15);
+        VEC a;
+        a.clear ();
+        for (int b = 0; b < VEC::elements; ++b)
+            a.setcomp (b, b==bit);
+        OIIO_CHECK_SIMD_EQUAL (ctr, a);
+        for (int b = 0; b < VEC::elements; ++b)
+            OIIO_CHECK_EQUAL (bool(a[b]), b == bit);
+        OIIO_CHECK_EQUAL (extract<0>(a), bit == 0);
+        OIIO_CHECK_EQUAL (extract<1>(a), bit == 1);
+        OIIO_CHECK_EQUAL (extract<2>(a), bit == 2);
+        OIIO_CHECK_EQUAL (extract<3>(a), bit == 3);
+        OIIO_CHECK_EQUAL (extract<4>(a), bit == 4);
+        OIIO_CHECK_EQUAL (extract<5>(a), bit == 5);
+        OIIO_CHECK_EQUAL (extract<6>(a), bit == 6);
+        OIIO_CHECK_EQUAL (extract<7>(a), bit == 7);
+        OIIO_CHECK_EQUAL (extract<8>(a), bit == 8);
+        OIIO_CHECK_EQUAL (extract<9>(a), bit == 9);
+        OIIO_CHECK_EQUAL (extract<10>(a), bit == 10);
+        OIIO_CHECK_EQUAL (extract<11>(a), bit == 11);
+        OIIO_CHECK_EQUAL (extract<12>(a), bit == 12);
+        OIIO_CHECK_EQUAL (extract<13>(a), bit == 13);
+        OIIO_CHECK_EQUAL (extract<14>(a), bit == 14);
+        OIIO_CHECK_EQUAL (extract<15>(a), bit == 15);
+    }
+
+    VEC a;
+    a.load (0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0);
+    OIIO_CHECK_SIMD_EQUAL (insert<0> (a, 1), VEC(1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<1> (a, 1), VEC(0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<2> (a, 1), VEC(0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<3> (a, 1), VEC(0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<4> (a, 1), VEC(0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<5> (a, 1), VEC(0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<6> (a, 1), VEC(0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<7> (a, 1), VEC(0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<8> (a, 1), VEC(0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<9> (a, 1), VEC(0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<10>(a, 1), VEC(0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<11>(a, 1), VEC(0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<12>(a, 1), VEC(0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<13>(a, 1), VEC(0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<14>(a, 1), VEC(0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0));
+    OIIO_CHECK_SIMD_EQUAL (insert<15>(a, 1), VEC(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1));
+    a.load (1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1);
+    OIIO_CHECK_SIMD_EQUAL (insert<0> (a, 0), VEC(0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<1> (a, 0), VEC(1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<2> (a, 0), VEC(1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<3> (a, 0), VEC(1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<4> (a, 0), VEC(1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<5> (a, 0), VEC(1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<6> (a, 0), VEC(1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<7> (a, 0), VEC(1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<8> (a, 0), VEC(1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<9> (a, 0), VEC(1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<10>(a, 0), VEC(1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<11>(a, 0), VEC(1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<12>(a, 0), VEC(1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<13>(a, 0), VEC(1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<14>(a, 0), VEC(1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1));
+    OIIO_CHECK_SIMD_EQUAL (insert<15>(a, 0), VEC(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0));
 }
 
 
@@ -557,8 +753,8 @@ void test_arithmetic ()
     typedef typename VEC::value_t ELEM;
     test_heading ("arithmetic ", VEC::type_name());
 
-    VEC a = VEC::Iota (1.0f, 3.0f);
-    VEC b = VEC::Iota (1.0f, 1.0f);
+    VEC a = VEC::Iota (1, 3);
+    VEC b = VEC::Iota (1, 1);
     VEC add(ELEM(0)), sub(ELEM(0)), mul(ELEM(0)), div(ELEM(0));
     ELEM bsum(ELEM(0));
     for (int i = 0; i < VEC::elements; ++i) {
@@ -583,7 +779,6 @@ void test_arithmetic ()
     OIIO_CHECK_SIMD_EQUAL (vreduce_add(b), VEC(bsum));
     OIIO_CHECK_EQUAL (reduce_add(VEC(1.0f)), SimdElements<VEC>::size);
 
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
     benchmark2 ("operator+", do_add<VEC>, a, b);
     benchmark2 ("operator-", do_sub<VEC>, a, b);
     benchmark2 ("operator*", do_mul<VEC>, a, b);
@@ -600,7 +795,6 @@ void test_arithmetic ()
     benchmark2 ("reference: add scalar", do_add<ELEM>, a[2], b[1]);
     benchmark2 ("reference: mul scalar", do_mul<ELEM>, a[2], b[1]);
     benchmark2 ("reference: div scalar", do_div<ELEM>, a[2], b[1]);
-#endif
 }
 
 
@@ -618,7 +812,6 @@ void test_fused ()
     OIIO_CHECK_SIMD_EQUAL (nmadd (a, b, c), -(a*b)+c);
     OIIO_CHECK_SIMD_EQUAL (nmsub (a, b, c), -(a*b)-c);
 
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
     benchmark2 ("madd old *+", [&](VEC&a, VEC&b){ return a*b+c; }, a, b);
     benchmark2 ("madd fused", [&](VEC&a, VEC&b){ return madd(a,b,c); }, a, b);
     benchmark2 ("msub old *-", [&](VEC&a, VEC&b){ return a*b-c; }, a, b);
@@ -627,7 +820,6 @@ void test_fused ()
     benchmark2 ("nmadd fused", [&](VEC&a, VEC&b){ return nmadd(a,b,c); }, a, b);
     benchmark2 ("nmsub old -(*+)", [&](VEC&a, VEC&b){ return -(a*b)-c; }, a, b);
     benchmark2 ("nmsub fused", [&](VEC&a, VEC&b){ return nmsub(a,b,c); }, a, b);
-#endif
 }
 
 
@@ -654,10 +846,12 @@ void test_bitwise_int ()
     OIIO_CHECK_SIMD_EQUAL (andnot (b, a), (~(b)) & a);
     OIIO_CHECK_SIMD_EQUAL (andnot (b, a), VEC(0x02240224));
 
-    OIIO_CHECK_EQUAL (reduce_and(mkvec<VEC>(15, 7, 15, 15, 15, 15, 15, 15)), 7);
-    OIIO_CHECK_EQUAL (reduce_or(mkvec<VEC>(0, 3, 4, 0, 0, 0, 0, 0)), 7);
+    VEC atest(15);  atest[1] = 7;
+    OIIO_CHECK_EQUAL (reduce_and(atest), 7);
 
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
+    VEC otest(0);  otest[1] = 3;  otest[2] = 4;
+    OIIO_CHECK_EQUAL (reduce_or(otest), 7);
+
     benchmark2 ("operator&", do_and<VEC>, a, b);
     benchmark2 ("operator|", do_or<VEC>, a, b);
     benchmark2 ("operator^", do_xor<VEC>, a, b);
@@ -665,7 +859,6 @@ void test_bitwise_int ()
     benchmark2 ("andnot",    do_andnot<VEC>, a, b);
     benchmark  ("reduce_and", [](VEC& a){ return reduce_and(a); }, a);
     benchmark  ("reduce_or ", [](VEC& a){ return reduce_or(a); }, a);
-#endif
 }
 
 
@@ -675,31 +868,36 @@ void test_bitwise_bool ()
 {
     test_heading ("bitwise ", VEC::type_name());
 
-    bool A[]   = { true,  true,  false, false, false, false, true,  true  };
-    bool B[]   = { true,  false, true,  false, true,  false, true,  false };
-    bool AND[] = { true,  false, false, false, false, false, true,  false };
-    bool OR[]  = { true,  true,  true,  false, true,  false, true,  true  };
-    bool XOR[] = { false, true,  true,  false, true,  false, false, true  };
-    bool NOT[] = { false, false, true,  true,  true,  true,  false, false  };
+    bool A[]   = { true,  true,  false, false, false, false, true,  true,
+                   true,  true,  false, false, false, false, true,  true  };
+    bool B[]   = { true,  false, true,  false, true,  false, true,  false,
+                   true,  false, true,  false, true,  false, true,  false };
+    bool AND[] = { true,  false, false, false, false, false, true,  false,
+                   true,  false, false, false, false, false, true,  false };
+    bool OR[]  = { true,  true,  true,  false, true,  false, true,  true,
+                   true,  true,  true,  false, true,  false, true,  true  };
+    bool XOR[] = { false, true,  true,  false, true,  false, false, true,
+                   false, true,  true,  false, true,  false, false, true  };
+    bool NOT[] = { false, false, true,  true,  true,  true,  false, false,
+                   false, false, true,  true,  true,  true,  false, false  };
     VEC a(A), b(B), rand(AND), ror(OR), rxor(XOR), rnot(NOT);
     OIIO_CHECK_SIMD_EQUAL (a & b, rand);
     OIIO_CHECK_SIMD_EQUAL (a | b, ror);
     OIIO_CHECK_SIMD_EQUAL (a ^ b, rxor);
     OIIO_CHECK_SIMD_EQUAL (~a, rnot);
 
-    OIIO_CHECK_EQUAL (reduce_or(mkvec<VEC>(0, 0, 0, 0, 0, 0, 0, 0)), false);
-    OIIO_CHECK_EQUAL (reduce_or(mkvec<VEC>(0, 1, 0, 0, 0, 0, 0, 0)), true);
-    OIIO_CHECK_EQUAL (reduce_and(mkvec<VEC>(1, 1, 1, 1, 1, 1, 1, 1)), true);
-    OIIO_CHECK_EQUAL (reduce_and(mkvec<VEC>(0, 1, 0, 0, 0, 0, 0, 0)), false);
+    VEC onebit(false); onebit.setcomp(3,true);
+    OIIO_CHECK_EQUAL (reduce_or(VEC::False()), false);
+    OIIO_CHECK_EQUAL (reduce_or(onebit), true);
+    OIIO_CHECK_EQUAL (reduce_and(VEC::True()), true);
+    OIIO_CHECK_EQUAL (reduce_and(onebit), false);
 
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
     benchmark2 ("operator&", do_and<VEC>, a, b);
     benchmark2 ("operator|", do_or<VEC>, a, b);
     benchmark2 ("operator^", do_xor<VEC>, a, b);
     benchmark  ("operator!", do_compl<VEC>, a);
     benchmark  ("reduce_and", [](VEC& a){ return reduce_and(a); }, a);
     benchmark  ("reduce_or ", [](VEC& a){ return reduce_or(a); }, a);
-#endif
 }
 
 
@@ -721,12 +919,12 @@ void test_comparisons ()
     test_heading ("comparisons ", VEC::type_name());
 
     VEC a = VEC::Iota();
-    bool lt2[] = { 1, 1, 0, 0, 0, 0, 0, 0 };
-    bool gt2[] = { 0, 0, 0, 1, 1, 1, 1, 1 };
-    bool le2[] = { 1, 1, 1, 0, 0, 0, 0, 0 };
-    bool ge2[] = { 0, 0, 1, 1, 1, 1, 1, 1 };
-    bool eq2[] = { 0, 0, 1, 0, 0, 0, 0, 0 };
-    bool ne2[] = { 1, 1, 0, 1, 1, 1, 1, 1 };
+    bool lt2[] = { 1, 1, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0 };
+    bool gt2[] = { 0, 0, 0, 1, 1, 1, 1, 1,  1, 1, 1, 1, 1, 1, 1, 1 };
+    bool le2[] = { 1, 1, 1, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0 };
+    bool ge2[] = { 0, 0, 1, 1, 1, 1, 1, 1,  1, 1, 1, 1, 1, 1, 1, 1 };
+    bool eq2[] = { 0, 0, 1, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0 };
+    bool ne2[] = { 1, 1, 0, 1, 1, 1, 1, 1,  1, 1, 1, 1, 1, 1, 1, 1 };
     OIIO_CHECK_SIMD_EQUAL ((a < 2), bool_t(lt2));
     OIIO_CHECK_SIMD_EQUAL ((a > 2), bool_t(gt2));
     OIIO_CHECK_SIMD_EQUAL ((a <= 2), bool_t(le2));
@@ -740,14 +938,13 @@ void test_comparisons ()
     OIIO_CHECK_SIMD_EQUAL ((a >= b), bool_t(ge2));
     OIIO_CHECK_SIMD_EQUAL ((a == b), bool_t(eq2));
     OIIO_CHECK_SIMD_EQUAL ((a != b), bool_t(ne2));
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
+
     benchmark2 ("operator< ", do_lt<VEC,bool_t>, a, b);
     benchmark2 ("operator> ", do_gt<VEC,bool_t>, a, b);
     benchmark2 ("operator<=", do_le<VEC,bool_t>, a, b);
     benchmark2 ("operator>=", do_ge<VEC,bool_t>, a, b);
     benchmark2 ("operator==", do_eq<VEC,bool_t>, a, b);
     benchmark2 ("operator!=", do_ne<VEC,bool_t>, a, b);
-#endif
 }
 
 
@@ -763,13 +960,12 @@ void test_shuffle4 ()
     OIIO_CHECK_SIMD_EQUAL ((shuffle<1,1,3,3>(a)), VEC(1,1,3,3));
     OIIO_CHECK_SIMD_EQUAL ((shuffle<0,1,0,1>(a)), VEC(0,1,0,1));
     OIIO_CHECK_SIMD_EQUAL ((shuffle<2>(a)), VEC(2));
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
+
     benchmark ("shuffle<...> ", [&](VEC& v){ return shuffle<3,2,1,0>(v); }, a);
     benchmark ("shuffle<0> ", [&](VEC& v){ return shuffle<0>(v); }, a);
     benchmark ("shuffle<1> ", [&](VEC& v){ return shuffle<1>(v); }, a);
     benchmark ("shuffle<2> ", [&](VEC& v){ return shuffle<2>(v); }, a);
     benchmark ("shuffle<3> ", [&](VEC& v){ return shuffle<3>(v); }, a);
-#endif
 }
 
 
@@ -784,7 +980,7 @@ void test_shuffle8 ()
     OIIO_CHECK_SIMD_EQUAL ((shuffle<1,1,3,3,1,1,3,3>(a)), VEC(1,1,3,3,1,1,3,3));
     OIIO_CHECK_SIMD_EQUAL ((shuffle<0,1,0,1,0,1,0,1>(a)), VEC(0,1,0,1,0,1,0,1));
     OIIO_CHECK_SIMD_EQUAL ((shuffle<2>(a)), VEC(2));
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
+
     benchmark ("shuffle<...> ", [&](VEC& v){ return shuffle<7,6,5,4,3,2,1,0>(v); }, a);
     benchmark ("shuffle<0> ", [&](VEC& v){ return shuffle<0>(v); }, a);
     benchmark ("shuffle<1> ", [&](VEC& v){ return shuffle<1>(v); }, a);
@@ -794,7 +990,30 @@ void test_shuffle8 ()
     benchmark ("shuffle<5> ", [&](VEC& v){ return shuffle<5>(v); }, a);
     benchmark ("shuffle<6> ", [&](VEC& v){ return shuffle<6>(v); }, a);
     benchmark ("shuffle<7> ", [&](VEC& v){ return shuffle<7>(v); }, a);
-#endif
+}
+
+
+
+template<typename VEC>
+void test_shuffle16 ()
+{
+    test_heading ("shuffle ", VEC::type_name());
+    VEC a (0, 1, 2, 3, 4, 5, 6, 7,  8, 9, 10, 11, 12, 13, 14, 15);
+
+    // Shuffle groups of 4
+    OIIO_CHECK_SIMD_EQUAL ((shuffle4<3,2,1,0>(a)),
+                           VEC(12,13,14,15,8,9,10,11,4,5,6,7,0,1,2,3));
+    OIIO_CHECK_SIMD_EQUAL ((shuffle4<3>(a)),
+                           VEC(12,13,14,15,12,13,14,15,12,13,14,15,12,13,14,15));
+
+    // Shuffle within groups of 4
+    OIIO_CHECK_SIMD_EQUAL ((shuffle<3,2,1,0>(a)),
+                           VEC(3,2,1,0,7,6,5,4,11,10,9,8,15,14,13,12));
+    OIIO_CHECK_SIMD_EQUAL ((shuffle<3>(a)),
+                           VEC(3,3,3,3,7,7,7,7,11,11,11,11,15,15,15,15));
+
+    benchmark ("shuffle4<> ", [&](VEC& v){ return shuffle<3,2,1,0>(v); }, a);
+    benchmark ("shuffle<> ",  [&](VEC& v){ return shuffle<3,2,1,0>(v); }, a);
 }
 
 
@@ -824,30 +1043,29 @@ void test_blend ()
     VEC a = VEC::Iota (1);
     VEC b = VEC::Iota (10);
     bool_t f(false), t(true);
-    bool tf_values[] = { true, false, true, false, true, false, true, false };
+    bool tf_values[] = { true, false, true, false, true, false, true, false,
+                         true, false, true, false, true, false, true, false };
     bool_t tf ((bool *)tf_values);
 
     OIIO_CHECK_SIMD_EQUAL (blend (a, b, f), a);
     OIIO_CHECK_SIMD_EQUAL (blend (a, b, t), b);
 
-    ELEM r1[] = { 10, 2, 12, 4, 14, 6, 16, 8 };
+    ELEM r1[] = { 10, 2, 12, 4, 14, 6, 16, 8,  18, 10, 20, 12, 22, 14, 24, 16 };
     OIIO_CHECK_SIMD_EQUAL (blend (a, b, tf), VEC(r1));
 
     OIIO_CHECK_SIMD_EQUAL (blend0 (a, f), VEC::Zero());
     OIIO_CHECK_SIMD_EQUAL (blend0 (a, t), a);
-    ELEM r2[] = { 1, 0, 3, 0, 5, 0, 7, 0 };
+    ELEM r2[] = { 1, 0, 3, 0, 5, 0, 7, 0,  9, 0, 11, 0, 13, 0, 15, 0 };
     OIIO_CHECK_SIMD_EQUAL (blend0 (a, tf), VEC(r2));
 
     OIIO_CHECK_SIMD_EQUAL (blend0not (a, f), a);
     OIIO_CHECK_SIMD_EQUAL (blend0not (a, t), VEC::Zero());
-    ELEM r3[] = { 0, 2, 0, 4, 0, 6, 0, 8 };
+    ELEM r3[] = { 0, 2, 0, 4, 0, 6, 0, 8,  0, 10, 0, 12, 0, 14, 0, 16 };
     OIIO_CHECK_SIMD_EQUAL (blend0not (a, tf), VEC(r3));
 
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
     benchmark2 ("blend", [&](VEC& a, VEC& b){ return blend(a,b,tf); }, a, b);
     benchmark2 ("blend0", [](VEC& a, bool_t& b){ return blend0(a,b); }, a, tf);
     benchmark2 ("blend0not", [](VEC& a, bool_t& b){ return blend0not(a,b); }, a, tf);
-#endif
 }
 
 
@@ -899,25 +1117,17 @@ void test_shift ()
     OIIO_CHECK_SIMD_EQUAL (i >> 1, VEC::Iota(5, 5));
 
     // Tricky cases with high bits, and the difference between >> and srl
-    int a = 1<<31, b = -1, c = 0xffff, d = 3;
-    VEC hard = mkvec<VEC> (a, b, c, d, d, c, b, a);
-    OIIO_CHECK_SIMD_EQUAL (hard >> 1,
-                           mkvec<VEC>(a>>1, b>>1, c>>1, d>>1, d>>1, c>>1, b>>1, a>>1));
-    OIIO_CHECK_SIMD_EQUAL (srl(hard,1),
-                           mkvec<VEC>(unsigned(a)>>1, unsigned(b)>>1,
-                                      unsigned(c)>>1, unsigned(d)>>1,
-                                      unsigned(d)>>1, unsigned(c)>>1,
-                                      unsigned(b)>>1, unsigned(a)>>1));
-    std::cout << Strutil::format ("  [%x] >>  1 == [%x]\n", hard, hard>>1);
-    std::cout << Strutil::format ("  [%x] srl 1 == [%x]\n", hard, srl(hard,1));
-    OIIO_CHECK_SIMD_EQUAL (hard >> 4, mkvec<VEC>(a>>4, b>>4, c>>4, d>>4,
-                                                 d>>4, c>>4, b>>4, a>>4));
-    OIIO_CHECK_SIMD_EQUAL (srl(hard,4), mkvec<VEC>(unsigned(a)>>4, unsigned(b)>>4,
-                                                   unsigned(c)>>4, unsigned(d)>>4,
-                                                   unsigned(d)>>4, unsigned(c)>>4,
-                                                   unsigned(b)>>4, unsigned(a)>>4));
-    std::cout << Strutil::format ("  [%x] >>  4 == [%x]\n", hard, hard>>4);
-    std::cout << Strutil::format ("  [%x] srl 4 == [%x]\n", hard, srl(hard,4));
+    int vals[4] = { 1<<31, -1, 0xffff, 3 };
+    for (auto hard : vals) {
+        VEC vhard(hard);
+        OIIO_CHECK_SIMD_EQUAL (vhard >> 1, VEC(hard>>1));
+        OIIO_CHECK_SIMD_EQUAL (srl(vhard,1), VEC(unsigned(hard)>>1));
+        std::cout << Strutil::format ("  [%x] >>  1 == [%x]\n", vhard, vhard>>1);
+        std::cout << Strutil::format ("  [%x] srl 1 == [%x]\n", vhard, srl(vhard,1));
+        OIIO_CHECK_SIMD_EQUAL (srl(vhard,4), VEC(unsigned(hard)>>4));
+        std::cout << Strutil::format ("  [%x] >>  4 == [%x]\n", vhard, vhard>>4);
+        std::cout << Strutil::format ("  [%x] srl 4 == [%x]\n", vhard, srl(vhard,4));
+    }
 
     // Test <<= and >>=
     i = VEC::Iota (10, 10);   i <<= 2;
@@ -925,12 +1135,10 @@ void test_shift ()
     i = VEC::Iota (10, 10);   i >>= 1;
     OIIO_CHECK_SIMD_EQUAL (i, VEC::Iota(5, 5));
 
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
     // Benchmark
     benchmark2 ("operator<<", do_shl<VEC>, i, 2);
     benchmark2 ("operator>>", do_shr<VEC>, i, 2);
     benchmark2 ("srl       ", do_srl<VEC>, i, 2);
-#endif
 }
 
 
@@ -949,12 +1157,10 @@ void test_vectorops_float4 ()
     OIIO_CHECK_SIMD_EQUAL (vdot3(a,b), VEC(10+22+36));
     OIIO_CHECK_SIMD_EQUAL (hdiv(float4(1.0f,2.0f,3.0f,2.0f)), float3(0.5f,1.0f,1.5f));
 
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
     benchmark2 ("vdot", [](VEC& a, VEC& b){ return vdot(a,b); }, a, b);
     benchmark2 ("dot", [](VEC& a, VEC& b){ return dot(a,b); }, a, b);
     benchmark2 ("vdot3", [](VEC& a, VEC& b){ return vdot3(a,b); }, a, b);
     benchmark2 ("dot3", [](VEC& a, VEC& b){ return dot3(a,b); }, a, b);
-#endif
 }
 
 
@@ -976,7 +1182,6 @@ void test_vectorops_float3 ()
     OIIO_CHECK_SIMD_EQUAL_THRESH (float3(1.0f,2.0f,3.0f).normalized_fast(),
                                   float3(norm_imath(Imath::V3f(1.0f,2.0f,3.0f))), 0.0005);
 
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
     benchmark2 ("vdot", [](VEC& a, VEC& b){ return vdot(a,b); }, a, b);
     benchmark2 ("dot", [](VEC& a, VEC& b){ return dot(a,b); }, a, b);
     benchmark ("dot float3", dot_simd, float3(2.0f,1.0f,0.0f), 1);
@@ -988,7 +1193,6 @@ void test_vectorops_float3 ()
     benchmark ("normalize Imath with simd fast", norm_imath_simd_fast, Imath::V3f(1.0f,4.0f,9.0f));
     benchmark ("normalize simd", norm_simd, float3(1.0f,4.0f,9.0f));
     benchmark ("normalize simd fast", norm_simd_fast, float3(1.0f,4.0f,9.0f));
-#endif
 }
 
 
@@ -1000,9 +1204,37 @@ void test_constants ()
     OIIO_CHECK_SIMD_EQUAL (bool4::False(), bool4(false));
     OIIO_CHECK_SIMD_EQUAL (bool4::True(), bool4(true));
 
+    OIIO_CHECK_SIMD_EQUAL (bool8::False(), bool8(false));
+    OIIO_CHECK_SIMD_EQUAL (bool8::True(), bool8(true));
+
+    OIIO_CHECK_SIMD_EQUAL (bool16::False(), bool16(false));
+    OIIO_CHECK_SIMD_EQUAL (bool16::True(), bool16(true));
+    OIIO_CHECK_SIMD_EQUAL (bool16::False(), bool16(false));
+    OIIO_CHECK_SIMD_EQUAL (bool16::True(), bool16(true));
+
     OIIO_CHECK_SIMD_EQUAL (int4::Zero(), int4(0));
     OIIO_CHECK_SIMD_EQUAL (int4::One(), int4(1));
     OIIO_CHECK_SIMD_EQUAL (int4::NegOne(), int4(-1));
+    OIIO_CHECK_SIMD_EQUAL (int4::Iota(), int4(0,1,2,3));
+    OIIO_CHECK_SIMD_EQUAL (int4::Iota(3), int4(3,4,5,6));
+    OIIO_CHECK_SIMD_EQUAL (int4::Iota(3,2), int4(3,5,7,9));
+    OIIO_CHECK_SIMD_EQUAL (int4::Giota(), int4(1,2,4,8));
+
+    OIIO_CHECK_SIMD_EQUAL (int8::Zero(), int8(0));
+    OIIO_CHECK_SIMD_EQUAL (int8::One(), int8(1));
+    OIIO_CHECK_SIMD_EQUAL (int8::NegOne(), int8(-1));
+    OIIO_CHECK_SIMD_EQUAL (int8::Iota(), int8(0,1,2,3, 4,5,6,7));
+    OIIO_CHECK_SIMD_EQUAL (int8::Iota(3), int8(3,4,5,6, 7,8,9,10));
+    OIIO_CHECK_SIMD_EQUAL (int8::Iota(3,2), int8(3,5,7,9, 11,13,15,17));
+    OIIO_CHECK_SIMD_EQUAL (int8::Giota(), int8(1,2,4,8, 16,32,64,128));
+
+    OIIO_CHECK_SIMD_EQUAL (int16::Zero(), int16(0));
+    OIIO_CHECK_SIMD_EQUAL (int16::One(), int16(1));
+    OIIO_CHECK_SIMD_EQUAL (int16::NegOne(), int16(-1));
+    OIIO_CHECK_SIMD_EQUAL (int16::Iota(), int16(0,1,2,3, 4,5,6,7, 8,9,10,11, 12,13,14,15));
+    OIIO_CHECK_SIMD_EQUAL (int16::Iota(3), int16(3,4,5,6, 7,8,9,10, 11,12,13,14, 15,16,17,18));
+    OIIO_CHECK_SIMD_EQUAL (int16::Iota(3,2), int16(3,5,7,9, 11,13,15,17, 19,21,23,25, 27,29,31,33));
+    OIIO_CHECK_SIMD_EQUAL (int16::Giota(), int16(1,2,4,8, 16,32,64,128, 256,512,1024,2048, 4096,8192,16384,32768));
 
     OIIO_CHECK_SIMD_EQUAL (float4::Zero(), float4(0.0f));
     OIIO_CHECK_SIMD_EQUAL (float4::One(), float4(1.0f));
@@ -1022,7 +1254,12 @@ void test_constants ()
     OIIO_CHECK_SIMD_EQUAL (float8::Iota(3.0f), float8(3,4,5,6,7,8,9,10));
     OIIO_CHECK_SIMD_EQUAL (float8::Iota(3.0f,2.0f), float8(3,5,7,9,11,13,15,17));
 
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
+    OIIO_CHECK_SIMD_EQUAL (float16::Zero(), float16(0.0f));
+    OIIO_CHECK_SIMD_EQUAL (float16::One(), float16(1.0f));
+    OIIO_CHECK_SIMD_EQUAL (float16::Iota(), float16(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15));
+    OIIO_CHECK_SIMD_EQUAL (float16::Iota(3.0f), float16(3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18));
+    OIIO_CHECK_SIMD_EQUAL (float16::Iota(3.0f,2.0f), float16(3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33));
+
     benchmark ("float4 = float(const)", [](float f){ return float4(f); }, 1.0f);
     benchmark ("float4 = Zero()", [](int){ return float4::Zero(); }, 0);
     benchmark ("float4 = One()", [](int){ return float4::One(); }, 0);
@@ -1032,7 +1269,11 @@ void test_constants ()
     benchmark ("float8 = Zero()", [](int){ return float8::Zero(); }, 0);
     benchmark ("float8 = One()", [](int){ return float8::One(); }, 0);
     benchmark ("float8 = Iota()", [](int){ return float8::Iota(); }, 0);
-#endif
+
+    benchmark ("float16 = float(const)", [](float f){ return float16(f); }, 1.0f);
+    benchmark ("float16 = Zero()", [](int){ return float16::Zero(); }, 0);
+    benchmark ("float16 = One()", [](int){ return float16::One(); }, 0);
+    benchmark ("float16 = Iota()", [](int){ return float16::Iota(); }, 0);
 }
 
 
@@ -1068,6 +1309,7 @@ inline float4 fast_exp_float4 (const float4& x) { return fast_exp(x); }
 inline float fast_log_float (float x) { return fast_log(x); }
 //inline float4 fast_log_float (const float4& x) { return fast_log(x); }
 inline float rsqrtf (float f) { return 1.0f / sqrtf(f); }
+inline float rcp (float f) { return 1.0f / f; }
 
 
 
@@ -1093,27 +1335,28 @@ void test_mathfuncs ()
     OIIO_CHECK_SIMD_EQUAL (rsqrt(mkvec<VEC>(1.0f,4.0f,9.0f,16.0f)), VEC(1.0f)/mkvec<VEC>(1.0f,2.0f,3.0f,4.0f));
     OIIO_CHECK_SIMD_EQUAL_THRESH (rsqrt_fast(mkvec<VEC>(1.0f,4.0f,9.0f,16.0f)),
                                   VEC(1.0f)/mkvec<VEC>(1.0f,2.0f,3.0f,4.0f), 0.0005f);
+    OIIO_CHECK_SIMD_EQUAL_THRESH (rcp_fast(VEC::Iota(1.0f)),
+                                  VEC(1.0f)/VEC::Iota(1.0f), 0.0005f);
 
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
-    benchmark2 ("operator/", do_div<VEC>, A, A);
-    benchmark2 ("safe_div", do_safe_div<VEC>, A, A);
+    benchmark2 ("simd operator/", do_div<VEC>, A, A);
+    benchmark2 ("simd safe_div", do_safe_div<VEC>, A, A);
+    benchmark ("simd rcp_fast", [](VEC& v){ return rcp_fast(v); }, mkvec<VEC>(1.0f,4.0f,9.0f,16.0f));
     benchmark ("float expf", expf, 0.67f);
-    benchmark ("fast_exp", fast_exp_float, 0.67f);
-    benchmark ("simd::exp", [](VEC& v){ return simd::exp(v); }, VEC(0.67f));
-    benchmark ("simd::fast_exp", [](VEC& v){ return fast_exp(v); }, VEC(0.67f));
+    benchmark ("float fast_exp", fast_exp_float, 0.67f);
+    benchmark ("simd exp", [](VEC& v){ return simd::exp(v); }, VEC(0.67f));
+    benchmark ("simd fast_exp", [](VEC& v){ return fast_exp(v); }, VEC(0.67f));
 
     benchmark ("float logf", logf, 0.67f);
     benchmark ("fast_log", fast_log_float, 0.67f);
-    benchmark ("simd::log", [](VEC& v){ return simd::log(v); }, VEC(0.67f));
-    benchmark ("simd::fast_log", fast_log<VEC>, VEC(0.67f));
+    benchmark ("simd log", [](VEC& v){ return simd::log(v); }, VEC(0.67f));
+    benchmark ("simd fast_log", fast_log<VEC>, VEC(0.67f));
     benchmark2 ("float powf", powf, 0.67f, 0.67f);
     benchmark2 ("simd fast_pow_pos", [](VEC& x,VEC& y){ return fast_pow_pos(x,y); }, VEC(0.67f), VEC(0.67f));
     benchmark ("float sqrt", sqrtf, 4.0f);
-    benchmark ("simd::sqrt", [](VEC& v){ return sqrt(v); }, mkvec<VEC>(1.0f,4.0f,9.0f,16.0f));
+    benchmark ("simd sqrt", [](VEC& v){ return sqrt(v); }, mkvec<VEC>(1.0f,4.0f,9.0f,16.0f));
     benchmark ("float rsqrt", rsqrtf, 4.0f);
-    benchmark ("simd::rsqrt", [](VEC& v){ return rsqrt(v); }, mkvec<VEC>(1.0f,4.0f,9.0f,16.0f));
-    benchmark ("simd::rsqrt_fast", [](VEC& v){ return rsqrt_fast(v); }, mkvec<VEC>(1.0f,4.0f,9.0f,16.0f));
-#endif
+    benchmark ("simd rsqrt", [](VEC& v){ return rsqrt(v); }, mkvec<VEC>(1.0f,4.0f,9.0f,16.0f));
+    benchmark ("simd rsqrt_fast", [](VEC& v){ return rsqrt_fast(v); }, mkvec<VEC>(1.0f,4.0f,9.0f,16.0f));
 }
 
 
@@ -1125,20 +1368,41 @@ void test_metaprogramming ()
     OIIO_CHECK_EQUAL (SimdSize<float3>::size, 4);
     OIIO_CHECK_EQUAL (SimdSize<int4>::size, 4);
     OIIO_CHECK_EQUAL (SimdSize<bool4>::size, 4);
+    OIIO_CHECK_EQUAL (SimdSize<float8>::size, 8);
+    OIIO_CHECK_EQUAL (SimdSize<int8>::size, 8);
+    OIIO_CHECK_EQUAL (SimdSize<bool8>::size, 8);
+    OIIO_CHECK_EQUAL (SimdSize<float16>::size, 16);
+    OIIO_CHECK_EQUAL (SimdSize<int16>::size, 16);
+    OIIO_CHECK_EQUAL (SimdSize<bool16>::size, 16);
     OIIO_CHECK_EQUAL (SimdSize<float>::size, 1);
     OIIO_CHECK_EQUAL (SimdSize<int>::size, 1);
+    OIIO_CHECK_EQUAL (SimdSize<bool>::size, 1);
 
     OIIO_CHECK_EQUAL (SimdElements<float4>::size, 4);
     OIIO_CHECK_EQUAL (SimdElements<float3>::size, 3);
     OIIO_CHECK_EQUAL (SimdElements<int4>::size, 4);
     OIIO_CHECK_EQUAL (SimdElements<bool4>::size, 4);
+    OIIO_CHECK_EQUAL (SimdElements<float8>::size, 8);
+    OIIO_CHECK_EQUAL (SimdElements<int8>::size, 8);
+    OIIO_CHECK_EQUAL (SimdElements<bool8>::size, 8);
+    OIIO_CHECK_EQUAL (SimdElements<float16>::size, 16);
+    OIIO_CHECK_EQUAL (SimdElements<int16>::size, 16);
+    OIIO_CHECK_EQUAL (SimdElements<bool16>::size, 16);
     OIIO_CHECK_EQUAL (SimdElements<float>::size, 1);
     OIIO_CHECK_EQUAL (SimdElements<int>::size, 1);
+    OIIO_CHECK_EQUAL (SimdElements<bool>::size, 1);
 
     OIIO_CHECK_EQUAL (float4::elements, 4);
     OIIO_CHECK_EQUAL (float3::elements, 3);
     OIIO_CHECK_EQUAL (int4::elements, 4);
     OIIO_CHECK_EQUAL (bool4::elements, 4);
+    OIIO_CHECK_EQUAL (float8::elements, 8);
+    OIIO_CHECK_EQUAL (int8::elements, 8);
+    OIIO_CHECK_EQUAL (bool8::elements, 8);
+    OIIO_CHECK_EQUAL (float16::elements, 16);
+    OIIO_CHECK_EQUAL (int16::elements, 16);
+    OIIO_CHECK_EQUAL (bool16::elements, 16);
+
     // OIIO_CHECK_EQUAL (is_same<float4::value_t,float>::value, true);
     // OIIO_CHECK_EQUAL (is_same<float3::value_t,float>::value, true);
     // OIIO_CHECK_EQUAL (is_same<int4::value_t,int>::value, true);
@@ -1240,7 +1504,7 @@ void test_matrix ()
                        matrix44(Mrot).inverse(), 1.0e-6f));
     OIIO_CHECK_EQUAL (matrix44(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15),
                       Imath::M44f(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15));
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
+
     Imath::V3f vx (2.51f,1.0f,1.0f);
     Imath::M44f mx (1,0,0,0, 0,1,0,0, 0,0,1,0, 10,11,12,1);
     benchmark2 ("transformp Imath", transformp_imath, vx, mx, 1);
@@ -1257,7 +1521,6 @@ void test_matrix ()
     benchmark ("m44 inverse_simd native simd", inverse_simd, matrix44(mx), 1);
     // std::cout << "inv " << inverse_simd(mx) << "\n";
     iterations *= 2;  // put things the way they were
-#endif
 }
 
 
@@ -1293,13 +1556,12 @@ main (int argc, char *argv[])
 
     int4 dummy4(0);
     int8 dummy8(0);
-#if OIIO_CPLUSPLUS_VERSION >= 11  /* So easy with lambdas */
     benchmark ("null benchmark 4", [](const int4&){ return int(0); }, dummy4);
     benchmark ("null benchmark 8", [](const int8&){ return int(0); }, dummy8);
-#endif
 
     category_heading ("float4");
-    test_loadstore<float4> ();
+    test_partial_loadstore<float4> ();
+    test_conversion_loadstore_float<float4> ();
     test_component_access<float4> ();
     test_arithmetic<float4> ();
     test_comparisons<float4> ();
@@ -1312,7 +1574,8 @@ main (int argc, char *argv[])
     test_mathfuncs<float4>();
 
     category_heading ("float3");
-    test_loadstore<float3> ();
+    test_partial_loadstore<float3> ();
+    test_conversion_loadstore_float<float3> ();
     test_component_access<float3> ();
     test_arithmetic<float3> ();
     // Unnecessary to test these, they just use the float4 ops.
@@ -1326,7 +1589,9 @@ main (int argc, char *argv[])
     // test_mathfuncs<float3>();
 
     category_heading ("float8");
-    test_loadstore<float8> ();
+    test_partial_loadstore<float8> ();
+    test_conversion_loadstore_float<float8> ();
+    test_masked_loadstore<float8> ();
     test_component_access<float8> ();
     test_arithmetic<float8> ();
     test_comparisons<float8> ();
@@ -1335,8 +1600,21 @@ main (int argc, char *argv[])
     test_fused<float8> ();
     test_mathfuncs<float8>();
 
+    category_heading ("float16");
+    test_partial_loadstore<float16> ();
+    test_conversion_loadstore_float<float16> ();
+    test_masked_loadstore<float16> ();
+    test_component_access<float16> ();
+    test_arithmetic<float16> ();
+    test_comparisons<float16> ();
+    test_shuffle16<float16> ();
+    test_blend<float16> ();
+    test_fused<float16> ();
+    test_mathfuncs<float16>();
+
     category_heading ("int4");
-    test_loadstore<int4> ();
+    test_partial_loadstore<int4> ();
+    test_conversion_loadstore_int<int4> ();
     test_component_access<int4> ();
     test_arithmetic<int4> ();
     test_bitwise_int<int4> ();
@@ -1349,7 +1627,9 @@ main (int argc, char *argv[])
     test_transpose4<int4> ();
 
     category_heading ("int8");
-    test_loadstore<int8> ();
+    test_partial_loadstore<int8> ();
+    test_conversion_loadstore_int<int8> ();
+    test_masked_loadstore<int8> ();
     test_component_access<int8> ();
     test_arithmetic<int8> ();
     test_bitwise_int<int8> ();
@@ -1360,6 +1640,20 @@ main (int argc, char *argv[])
     test_vint_to_uint8s<int8> ();
     test_shift<int8> ();
 
+    category_heading ("int16");
+    test_partial_loadstore<int16> ();
+    test_conversion_loadstore_int<int16> ();
+    test_masked_loadstore<int16> ();
+    test_component_access<int16> ();
+    test_arithmetic<int16> ();
+    test_bitwise_int<int16> ();
+    test_comparisons<int16> ();
+    test_shuffle16<int16> ();
+    test_blend<int16> ();
+    test_vint_to_uint16s<int16> ();
+    test_vint_to_uint16s<int16> ();
+    test_shift<int16> ();
+
     category_heading ("bool4");
     test_shuffle4<bool4> ();
     test_component_access<bool4> ();
@@ -1369,6 +1663,11 @@ main (int argc, char *argv[])
     test_shuffle8<bool8> ();
     test_component_access<bool8> ();
     test_bitwise_bool<bool8> ();
+
+    category_heading ("bool16");
+    // test_shuffle16<bool16> ();
+    test_component_access<bool16> ();
+    test_bitwise_bool<bool16> ();
 
     category_heading ("Odds and ends");
     test_constants();

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenEXR/ImathMatrix.h>
 
 #include <OpenImageIO/simd.h>
+#include <OpenImageIO/imageio.h>
 #include <OpenImageIO/unittest.h>
 #include <OpenImageIO/typedesc.h>
 #include <OpenImageIO/strutil.h>
@@ -1280,15 +1281,14 @@ main (int argc, char *argv[])
 
     getargs (argc, argv);
 
-#if defined(OIIO_SIMD_AVX)
-    std::cout << "SIMD is AVX " << OIIO_SIMD_AVX << "\n";
-#elif defined(OIIO_SIMD_SSE)
-    std::cout << "SIMD is SSE " << OIIO_SIMD_SSE << "\n";
-#elif defined(OIIO_SIMD_NEON)
-    std::cout << "SIMD is NEON " << OIIO_SIMD_NEON << "\n";
-#else
-    std::cout << "NO SIMD!!\n";
-#endif
+    std::string oiiosimd = OIIO::get_string_attribute ("oiio:simd");
+    std::string hwsimd = OIIO::get_string_attribute ("hw:simd");
+    std::cout << "OIIO SIMD support is: "
+              << (oiiosimd.size() ? oiiosimd : "") << "\n";
+    std::cout << "Hardware SIMD support is: "
+              << (hwsimd.size() ? hwsimd : "") << "\n";
+    std::cout << "\n";
+
     Timer timer;
 
     int4 dummy4(0);


### PR DESCRIPTION
* Add float16, int16, bool16 classes.
    
* When 16x HW support (AVX512) is selected, it is used, but otherwise just fall back to 8x[2] style      implementation. The aim is to make it convenient to code AS IF we were on AVX-512, but have pretty decent performance for AVX. The 16-wide classes should also run for SSE class hardware (or no SIMD at all), but I'm not working hard to optimize its performance in that case. Let's just accept that using 16-wide classes if you don't have at least 8-wide HW available is not going to get you a performance gain over scalar code.

* Preliminary support for masked loads & stores (including propagating those to 8x and 4x, which admittedly will not be very efficient for older HW).
   
* Lots of miscellaneous fixes to the 4x and 8x classes and cleanup of      this big header file (lessons learned, and conform to more clear      semantics apparent when expanding to 16x). This includes, when AVX512 is enabled, using some of the new intrinsics to speed up 8x and occasionally 4x tasks as well, in cases where some nice new intrinsics have been added.

* Big refactor in simd_test.cpp (unit tests) to better accommodate the additional classes without too much additional replicated code for each class.

* New OIIO getattribute() tokens to query hardware and build-time SIMD capabilities: "oiio:simd" retrieves the comma-separated list of mostly-SIMD-related capabilities that were enabled at build time (e.g., "sse2,sse3,sse41,sse42,avx"), and "hw:simd" is a similar list of the capabilities detected  on the actual hardware at runtime.

* Add Travis tests that build for AVX2 and AVX-512F. The Travis VMs can't run these, but we can at least ensure that they build cleanly, thus reducing the chances of accidentally breaking those cases (so many `#if` clauses).