### PR TITLE
Remove C++11 guards that are no longer needed

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -240,7 +240,7 @@ clamp (const simd::float8& a, const simd::float8& low, const simd::float8& high)
 
 /// Fused multiply and add: (a*b + c)
 inline float madd (float a, float b, float c) {
-#if OIIO_FMA_ENABLED && (OIIO_CPLUSPLUS_VERSION >= 11)
+#if OIIO_FMA_ENABLED
     // C++11 defines std::fma, which we assume is implemented using an
     // intrinsic.
     return std::fma (a, b, c);
@@ -1032,11 +1032,7 @@ inline T safe_log2 (T x) {
     // match clamping from fast version
     if (x < std::numeric_limits<T>::min()) x = std::numeric_limits<T>::min();
     if (x > std::numeric_limits<T>::max()) x = std::numeric_limits<T>::max();
-#if OIIO_CPLUSPLUS_VERSION >= 11
     return std::log2(x);
-#else
-    return log2f(x);   // punt: just use the float one
-#endif
 }
 
 /// Safe log: clamp to valid domain.
@@ -1060,11 +1056,7 @@ inline T safe_log10 (T x) {
 /// Safe logb: clamp to valid domain.
 template <typename T>
 inline T safe_logb (T x) {
-#if OIIO_CPLUSPLUS_VERSION >= 11
     return (x != T(0)) ? std::logb(x) : -std::numeric_limits<T>::max();
-#else
-    return (x != T(0)) ? logbf(x) : -std::numeric_limits<T>::max();
-#endif
 }
 
 /// Safe pow: clamp the domain so it never returns Inf or NaN or has divide

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -876,10 +876,8 @@ DeepData::copy_deep_pixel (int pixel, const DeepData &src, int srcpixel)
 bool
 DeepData::split (int pixel, float depth)
 {
-#if OIIO_CPLUSPLUS_VERSION >= 11
     using std::log1p;
     using std::expm1;
-#endif
     bool splits_occurred = false;
     int zchan = m_impl->m_z_channel;
     int zbackchan = m_impl->m_zback_channel;
@@ -997,12 +995,7 @@ DeepData::sort (int pixel)
     // swapper, so there's no way to std::sort a data type whose size is not
     // known at compile time. So we just sort the indices!
     int *sample_indices = OIIO_ALLOCA (int, nsamples);
-#if OIIO_CPLUSPLUS_VERSION >= 11
     std::iota (sample_indices, sample_indices+nsamples, 0);
-#else
-    for (int i = 0; i < nsamples; ++i)
-        sample_indices[i] = i;
-#endif
     std::stable_sort (sample_indices, sample_indices+nsamples,
                       SampleComparator(*this, pixel, zchan, zbackchan));
 
@@ -1020,9 +1013,7 @@ DeepData::sort (int pixel)
 void
 DeepData::merge_overlaps (int pixel)
 {
-#if OIIO_CPLUSPLUS_VERSION >= 11
     using std::log1p;
-#endif
     int zchan = m_impl->m_z_channel;
     int zbackchan = m_impl->m_zback_channel;
     if (zchan < 0)

--- a/src/libutil/array_view_test.cpp
+++ b/src/libutil/array_view_test.cpp
@@ -82,7 +82,6 @@ void test_offset ()
     { offset<2> o = off2b; o *= 2; OIIO_CHECK_EQUAL(o, offset<2>(20,24)); }
     { offset<2> o = off2b; o /= 2; OIIO_CHECK_EQUAL(o, offset<2>(5,6)); }
 
-#if OIIO_CPLUSPLUS_VERSION >= 11
     {
         // test initializer list
         offset<1> off1 {42};
@@ -91,7 +90,6 @@ void test_offset ()
         OIIO_CHECK_EQUAL (off2[0], 14);
         OIIO_CHECK_EQUAL (off2[1], 43);
     }
-#endif
 }
 
 
@@ -165,7 +163,6 @@ void test_bounds ()
         ++i; OIIO_CHECK_EQUAL (i, b.end());
     }
 
-#if OIIO_CPLUSPLUS_VERSION >= 11
     {
         // test initializer list
         bounds<1> b1 {42};
@@ -174,7 +171,6 @@ void test_bounds ()
         OIIO_CHECK_EQUAL (b2[0], 14);
         OIIO_CHECK_EQUAL (b2[1], 43);
     }
-#endif
 }
 
 
@@ -216,7 +212,6 @@ void test_array_view_mutable ()
 
 void test_array_view_initlist ()
 {
-#if OIIO_CPLUSPLUS_VERSION >= 11
     // Try the array_view syntax with initializer_list.
     array_view<const float> a { 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 0 };
     OIIO_CHECK_EQUAL (a.size(), 12);
@@ -224,7 +219,6 @@ void test_array_view_initlist ()
     OIIO_CHECK_EQUAL (a[1], 1.0f);
     OIIO_CHECK_EQUAL (a[2], 0.0f);
     OIIO_CHECK_EQUAL (a[3], 2.0f);
-#endif
 }
 
 

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -57,9 +57,7 @@
 
 using namespace OIIO;
 
-#if OIIO_CPLUSPLUS_VERSION >= 11
 using OIIO::_1;
-#endif
 
 static std::vector<ustring> filenames;
 static std::string output_filename = "out.exr";


### PR DESCRIPTION
Just removing some pointless `#if` guards that are no longer needed.
