### PR TITLE
Gcc 7 1 0 / Qt 5.8 fixes

### DIFF
--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -42,6 +42,7 @@
 #include <algorithm>
 #include <atomic>
 #include <future>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <thread>

--- a/src/iv/CMakeLists.txt
+++ b/src/iv/CMakeLists.txt
@@ -1,5 +1,8 @@
 if (Qt5_FOUND AND OPENGL_FOUND AND GLEW_FOUND)
     set (CMAKE_AUTOMOC ON)
+	if (Qt5_POSITION_INDEPENDENT_CODE)
+        set (CMAKE_POSITION_INDEPENDENT_CODE ON)
+	endif()
     include_directories (${OPENGL_INCLUDE_DIR} ${GLEW_INCLUDES})
     set (iv_srcs imageviewer.cpp ivimage.cpp ivgl.cpp ivinfowin.cpp 
                  ivpref.cpp ivmain.cpp)

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -931,7 +931,7 @@ Strutil::utf8_to_unicode (string_view str, std::vector<uint32_t> &uvec)
     const char* end = str.end();
     uint32_t state = 0;
     for (; begin != end; ++begin) {
-        uint32_t codepoint;
+        uint32_t codepoint = 0;
         if (!decode(&state, &codepoint, (unsigned char) *begin))
             uvec.push_back(codepoint);
     }


### PR DESCRIPTION
## Description

The following are small fixes caught by the GCC 7.1.0 compiler when used in combination with Qt 5.8.
As it stands there are still a number of warnings being emitted, but their scope was much greater than my drive-by edit had time to fix.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

