### PR TITLE
Fix invalid string_view return from channel_name()

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -402,7 +402,7 @@ public:
     /// channelnames is not filled out.
     string_view channel_name (int chan) const {
         return chan >= 0 && chan < (int)channelnames.size()
-            ? channelnames[chan] : "";
+            ? string_view(channelnames[chan]) : "";
     }
 
     /// Fill in an array of channel formats describing all channels in


### PR DESCRIPTION
In this case implicit conversion caused the allocation of a temporary
std::string, which is deallocated before the string_view can be used.
