### PR TITLE
array_view: enable front() and back()

### DIFF
--- a/src/include/OpenImageIO/array_view.h
+++ b/src/include/OpenImageIO/array_view.h
@@ -157,15 +157,14 @@ public:
     constexpr T& operator[] (offset_type idx) const {
         return VIEW_ACCESS(data(), idx, stride(), Rank);
     }
-    T& at (offset_type idx) const {  // FIXME -- should be offset_type
+    T& at (offset_type idx) const {
         if (! bounds().contains(idx))
             throw (std::out_of_range ("OpenImageIO::array_view::at"));
         return VIEW_ACCESS(data(), idx, stride(), Rank);
     }
-    // T& front() const { return m_data[0]; }   // FIXME - delete?
-    // T& back() const { return m_data[size()-1]; }   // FIXME - delete?
 
-    // FIXME -- slicing and sectioning
+    T& front() const { return m_data[0]; }
+    T& back() const { return m_data[size()-1]; }
 
 private:
     T * m_data;

--- a/src/libutil/array_view_test.cpp
+++ b/src/libutil/array_view_test.cpp
@@ -184,6 +184,10 @@ void test_array_view ()
     OIIO_CHECK_EQUAL (a[1], 1.0f);
     OIIO_CHECK_EQUAL (a[2], 0.0f);
     OIIO_CHECK_EQUAL (a[3], 2.0f);
+
+    OIIO_CHECK_EQUAL (&a.front(), &a[0]);
+    OIIO_CHECK_EQUAL (&a.back(), &a[a.size()-1]);
+
     // array_view<float>::const_iterator i = a.begin();
     // OIIO_CHECK_EQUAL (*i, 0.0f);
     // ++i;  OIIO_CHECK_EQUAL (*i, 1.0f);
@@ -200,6 +204,9 @@ void test_array_view_mutable ()
     OIIO_CHECK_EQUAL (a[1], 1.0f);
     OIIO_CHECK_EQUAL (a[2], 0.0f);
     OIIO_CHECK_EQUAL (a[3], 2.0f);
+
+    OIIO_CHECK_EQUAL (&a.front(), &a[0]);
+    OIIO_CHECK_EQUAL (&a.back(), &a[a.size()-1]);
 
     a[2] = 42.0f;
     OIIO_CHECK_EQUAL (a[2], 42.0f);


### PR DESCRIPTION
I don't remember exactly why these were commented out. But now I want them.
