### PR TITLE
SIMD - new Travis cases, fixups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,9 @@ script:
     # - ls -R $OIIO_LIBRARY_PATH
     - export PYTHONPATH=$OPENIMAGEIOHOME/python:$PYTHONPATH
     - export LSAN_OPTIONS=suppressions=$PWD/src/build-scripts/nosanitize.txt
-    - make $BUILD_FLAGS test
+    - if [ "$SKIP_TESTS" == "" ] ; then
+          make $BUILD_FLAGS test ;
+      fi
 
 
 after_success:
@@ -161,6 +163,14 @@ matrix:
       - os: linux
         compiler: gcc
         env: USE_SIMD=0 USE_JPEGTURBO=0
+    # build for AVX2, don't run the tests (ensure against build breaks)
+      - os: linux
+        compiler: gcc
+        env: WHICHGCC=5 USE_SIMD=avx2 SKIP_TESTS=1
+    # build for AVX512, don't run the tests (ensure against build breaks)
+      - os: linux
+        compiler: gcc
+        env: WHICHGCC=6 USE_SIMD=avx2,avx512f,f16c SKIP_TESTS=1
     # Build with EMBEDPLUGINS=0, both platforms.
       # FIXME: doesn't work yet on Travis
       # - os: linux


### PR DESCRIPTION
Primarily, this is adding test cases to the Travis matrix to build for AVX2 and AVX512F. The Travis VMs can't execute code compiled for that ISA, so I disable the running of tests for those cases. But it can build it, so at least we'll avoid accidentally breaking the build for those architectures.

Along the way, I did some minor touch-ups to substitute different intrinsics for some of the ones that appeared to be missing from the compiler versions on Travis (and thus would probably have caused troubles for other people as well).
