### PR TITLE
Fixes for parallel_for_2D

### DIFF
--- a/src/include/OpenImageIO/parallel.h
+++ b/src/include/OpenImageIO/parallel.h
@@ -251,8 +251,8 @@ parallel_for_chunked_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
 ///    ...
 ///    task (id, xend-1, yend-1);
 inline void
-parallel_for_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
-                 int64_t ystart, int64_t yend, int64_t ychunksize,
+parallel_for_2D (int64_t xstart, int64_t xend,
+                 int64_t ystart, int64_t yend,
                  std::function<void(int id, int64_t i, int64_t j)>&& task)
 {
     parallel_for_chunked_2D (xstart, xend, 0, ystart, yend, 0,
@@ -265,11 +265,18 @@ parallel_for_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
 
 
 
-/// parallel_for, for a 2D task that takes int64_t x & y indices (no
-/// threadid).
+/// parallel_for, for a task that takes an int threadid and int64_t x & y
+/// indices, running all of:
+///    task (xstart, ystart);
+///    ...
+///    task (xend-1, ystart);
+///    task (xstart, ystart+1);
+///    task (xend-1, ystart+1);
+///    ...
+///    task (xend-1, yend-1);
 inline void
-parallel_for_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
-                 int64_t ystart, int64_t yend, int64_t ychunksize,
+parallel_for_2D (int64_t xstart, int64_t xend,
+                 int64_t ystart, int64_t yend,
                  std::function<void(int64_t i, int64_t j)>&& task)
 {
     parallel_for_chunked_2D (xstart, xend, 0, ystart, yend, 0,
@@ -281,6 +288,17 @@ parallel_for_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
 }
 
 
+
+// DEPRECATED(1.8): This version accidentally accepted chunksizes that
+// weren't used. Preserve for a version to not break 3rd party apps.
+inline void
+parallel_for_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
+                 int64_t ystart, int64_t yend, int64_t ychunksize,
+                 std::function<void(int id, int64_t i, int64_t j)>&& task)
+{
+    parallel_for_2D (xstart, xend, ystart, yend,
+                     std::forward<std::function<void(int,int64_t,int64_t)>>(task));
+}
 
 OIIO_NAMESPACE_END
 

--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -509,7 +509,7 @@ private:
 /// to make this easy:
 ///     task_set<decltype(myfunc())> tasks (pool);
 ///     for (int i = 0; i < n_subtasks; ++i)
-///         tasks.push_back (pool->push (myfunc));
+///         tasks.push (pool->push (myfunc));
 ///     tasks.wait ();
 /// Note that the tasks.wait() is optional -- it will be called
 /// automatically when the task_set exits its scope.
@@ -635,7 +635,7 @@ OIIO_API thread_pool* default_thread_pool ();
 ///        task_set<decltype(myfunc())> tasks (pool);
 ///        // Launch a bunch of tasks into the thread pool
 ///        for (int i = 0; i < ntasks; ++i)
-///            tasks.push_back (pool->push (myfunc));
+///            tasks.push (pool->push (myfunc));
 ///        // The following brace, by ending the scope of 'tasks', will
 ///        // wait for all those queue tasks to finish.
 ///    }

--- a/src/libutil/parallel_test.cpp
+++ b/src/libutil/parallel_test.cpp
@@ -140,7 +140,7 @@ test_parallel_for_2D ()
     std::vector<int> vals (size*size, 0);
 
     // Increment all the integers via parallel_for
-    parallel_for_2D (0, size, 0, 0, size, 0, [&](uint64_t i, uint64_t j){
+    parallel_for_2D (0, size, 0, size, [&](uint64_t i, uint64_t j){
         vals[j*size+i] += 1;
     });
 


### PR DESCRIPTION
Upon reviewing parallel.h, it was apparent that there was a cut-and-paste
error that resulted in parallel_2D() having extra unused parameters.
Put it like I clearly meant it to be.

