### PR TITLE
unittest.h improvements

### DIFF
--- a/src/include/OpenImageIO/unittest.h
+++ b/src/include/OpenImageIO/unittest.h
@@ -32,9 +32,39 @@
 #define OPENIMAGEIO_UNITTEST_H
 
 #include <iostream>
+#include <cstdlib>
+
+#include <OpenImageIO/sysutil.h>
 
 
-static int unit_test_failures = 0;
+OIIO_NAMESPACE_BEGIN
+namespace pvt {
+
+class UnitTestFailureCounter {
+public:
+    UnitTestFailureCounter () : m_failures(0) { }
+    ~UnitTestFailureCounter () {
+        if (m_failures) {
+            std::cout << Sysutil::Term().ansi ("red", "ERRORS!\n");
+            std::exit (m_failures != 0);
+        } else {
+            std::cout << Sysutil::Term().ansi ("green", "OK\n");
+        }
+    }
+    const UnitTestFailureCounter& operator++ () { ++m_failures; return *this; } // prefix
+    int operator++ (int) { return m_failures++; }  // postfix
+    UnitTestFailureCounter operator+= (int i) { m_failures += i; return *this; }
+    operator int () const { return m_failures; }
+private:
+    int m_failures = 0;
+};
+
+}
+OIIO_NAMESPACE_END
+
+static OIIO::pvt::UnitTestFailureCounter unit_test_failures;
+
+
 
 /// OIIO_CHECK_* macros checks if the conditions is met, and if not,
 /// prints an error message indicating the module and line where the
@@ -42,60 +72,95 @@ static int unit_test_failures = 0;
 /// where we do not want one failure.
 #define OIIO_CHECK_ASSERT(x)                                            \
     ((x) ? ((void)0)                                                    \
-         : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
-                       << "FAILED: " << #x << "\n"),                    \
+         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
+           << __FILE__ << ":" << __LINE__ << ":\n"                      \
+           << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")     \
+           << #x << "\n"),                                              \
             (void)++unit_test_failures))
 
 #define OIIO_CHECK_EQUAL(x,y)                                           \
     (((x) == (y)) ? ((void)0)                                           \
-         : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
-             << "FAILED: " << #x << " == " << #y << "\n"                \
+         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
+             << __FILE__ << ":" << __LINE__ << ":\n"                    \
+             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
+             << #x << " == " << #y << "\n"                              \
              << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
             (void)++unit_test_failures))
 
 #define OIIO_CHECK_EQUAL_THRESH(x,y,eps)                                \
     ((std::abs((x)-(y)) <= eps) ? ((void)0)                             \
-         : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
-             << "FAILED: " << #x << " == " << #y << "\n"                \
+         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
+             << __FILE__ << ":" << __LINE__ << ":\n"                    \
+             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
+             << #x << " == " << #y << "\n"                              \
              << "\tvalues were '" << (x) << "' and '" << (y) << "'"     \
              << ", diff was " << std::abs((x)-(y)) << "\n"),            \
             (void)++unit_test_failures))
 
 #define OIIO_CHECK_NE(x,y)                                              \
     (((x) != (y)) ? ((void)0)                                           \
-         : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
-             << "FAILED: " << #x << " != " << #y << "\n"                \
+         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
+           << __FILE__ << ":" << __LINE__ << ":\n"                      \
+             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
+             << #x << " != " << #y << "\n"                              \
              << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
             (void)++unit_test_failures))
 
 #define OIIO_CHECK_LT(x,y)                                              \
     (((x) < (y)) ? ((void)0)                                            \
-         : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
-             << "FAILED: " << #x << " < " << #y << "\n"                 \
+         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
+             << __FILE__ << ":" << __LINE__ << ":\n"                    \
+             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
+             << #x << " < " << #y << "\n"                               \
              << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
             (void)++unit_test_failures))
 
 #define OIIO_CHECK_GT(x,y)                                              \
     (((x) > (y)) ? ((void)0)                                            \
-         : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
-             << "FAILED: " << #x << " > " << #y << "\n"                 \
+         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
+             << __FILE__ << ":" << __LINE__ << ":\n"                    \
+             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
+             << #x << " > " << #y << "\n"                               \
              << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
             (void)++unit_test_failures))
 
 #define OIIO_CHECK_LE(x,y)                                              \
     (((x) <= (y)) ? ((void)0)                                           \
-         : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
-             << "FAILED: " << #x << " <= " << #y << "\n"                \
+         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
+             << __FILE__ << ":" << __LINE__ << ":\n"                    \
+             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
+             << #x << " <= " << #y << "\n"                              \
              << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
             (void)++unit_test_failures))
 
 #define OIIO_CHECK_GE(x,y)                                              \
     (((x) >= (y)) ? ((void)0)                                           \
-         : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
-             << "FAILED: " << #x << " >= " << #y << "\n"                \
+         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
+             << __FILE__ << ":" << __LINE__ << ":\n"                    \
+             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
+             << #x << " >= " << #y << "\n"                              \
              << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
             (void)++unit_test_failures))
 
+
+// Special SIMD related equality checks that use all()
+#define OIIO_CHECK_SIMD_EQUAL(x,y)                                      \
+    (all ((x) == (y)) ? ((void)0)                                       \
+         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
+             << __FILE__ << ":" << __LINE__ << ":\n"                    \
+             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
+             << #x << " == " << #y << "\n"                              \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
+            (void)++unit_test_failures))
+
+#define OIIO_CHECK_SIMD_EQUAL_THRESH(x,y,eps)                           \
+    (all (abs((x)-(y)) < (eps)) ? ((void)0)                             \
+         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
+             << __FILE__ << ":" << __LINE__ << ":\n"                    \
+             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
+             << #x << " == " << #y << "\n"                              \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
+            (void)++unit_test_failures))
 
 
 #endif /* OPENIMAGEIO_UNITTEST_H */

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -39,7 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/unittest.h>
 #include <OpenImageIO/typedesc.h>
 #include <OpenImageIO/strutil.h>
-#include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/timer.h>
 #include <OpenImageIO/ustring.h>
@@ -104,27 +103,6 @@ test_heading (string_view name, string_view name2="")
     std::cout << term.ansi("bold") << name << ' ' << name2
               << term.ansi("normal") << "\n";
 }
-
-
-
-#define OIIO_CHECK_SIMD_EQUAL(x,y)                                      \
-    (all ((x) == (y)) ? ((void)0)                                       \
-         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
-             << __FILE__ << ":" << __LINE__ << ":\n"                    \
-             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
-             << #x << " == " << #y << "\n"                              \
-             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
-            (void)++unit_test_failures))
-
-
-#define OIIO_CHECK_SIMD_EQUAL_THRESH(x,y,eps)                           \
-    (all (abs((x)-(y)) < (eps)) ? ((void)0)                             \
-         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
-             << __FILE__ << ":" << __LINE__ << ":\n"                    \
-             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
-             << #x << " == " << #y << "\n"                              \
-             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
-            (void)++unit_test_failures))
 
 
 
@@ -1709,9 +1687,5 @@ main (int argc, char *argv[])
 
     std::cout << "\nTotal time: " << Strutil::timeintervalformat(timer()) << "\n";
 
-    if (unit_test_failures)
-        std::cout << term.ansi ("red", "ERRORS!\n");
-    else
-        std::cout << term.ansi ("green", "OK\n");
     return unit_test_failures;
 }


### PR DESCRIPTION
* Move the SIMD-oriented comparisons from simd_test.cpp into unittest.h.

* Use Strutil::Term() to use color in the unit test error message macros,
  it makes it a lot easier to spot the assertion messages in the middle
  of a long console output. I had used this in the simd_test.cpp ones
  and really liked it and wanted to propagate the practice to all
  unit test checks.

* Change the global unit_test_failures from a regular int to a special
  counter class that will automatically print an OK/ERRORS message at
  the end of execution when it destructs, and also automatically call
  std::exit() with a nonzero return code if errors occurred, making it
  impossible for a file using the unit tests to accidentail forget to
  return an error code if there were errors.

