### PR TITLE
SIMD batched texture APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ set (USE_EXTERNAL_PUGIXML OFF CACHE BOOL
      "Use an externally built shared library version of the pugixml library")
 set (PUGIXML_HOME "" CACHE STRING "Hint about where to find external PugiXML library")
 option (USE_DICOM "Use DICOM if DCMTK is found" ON)
-
+set (TEX_BATCH_SIZE "" CACHE STRING "Force TextureSystem SIMD batch size (e.g. 16)")
 set (SOVERSION ${OIIO_VERSION_MAJOR}.${OIIO_VERSION_MINOR}
      CACHE STRING "Set the SO version in the SO name of the output library")
 option (BUILD_OIIOUTIL_ONLY "If ON, will build *only* libOpenImageIO_Util")
@@ -106,6 +106,9 @@ if (NOT OIIO_THREAD_ALLOW_DCLP)
     add_definitions ("-DOIIO_THREAD_ALLOW_DCLP=0")
 endif ()
 
+if (TEX_BATCH_SIZE)
+    add_definitions ("-DOIIO_TEXTURE_SIMD_BATCH_WIDTH=${TEX_BATCH_SIZE}")
+endif ()
 
 # Set the default namespace
 set (PROJ_NAMESPACE "${${PROJ_NAME}_NAMESPACE}")

--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,10 @@ ifneq (${USE_SIMD},)
 MY_CMAKE_FLAGS += -DUSE_SIMD:STRING="${USE_SIMD}"
 endif
 
+ifneq (${TEX_BATCH_SIZE},)
+MY_CMAKE_FLAGS += -DTEX_BATCH_SIZE:STRING="${TEX_BATCH_SIZE}"
+endif
+
 ifneq (${TEST},)
 TEST_FLAGS += -R ${TEST}
 endif
@@ -499,9 +503,10 @@ help:
 	@echo "      OIIO_BUILD_TOOLS=0       Skip building the command-line tools"
 	@echo "      OIIO_BUILD_TESTS=0       Skip building the unit tests"
 	@echo "      BUILD_OIIOUTIL_ONLY=1    Build *only* libOpenImageIO_Util"
-	@echo "      USE_SIMD=arch            Build with SIMD support (choices: 0, sse2, sse3,"
-	@echo "                                  ssse3, sse4.1, sse4.2, f16c, avx, avx2"
-	@echo "                                  comma-separated ok)"
+	@echo "      USE_SIMD=arch            Build with SIMD support (comma-separated choices:"
+	@echo "                                  0, sse2, sse3, ssse3, sse4.1, sse4.2, f16c,"
+	@echo "                                  avx, avx2, avx512f)"
+	@echo "      TEX_BATCH_SIZE=16        Override TextureSystem SIMD batch size"
 	@echo "  make test, extra options:"
 	@echo "      TEST=regex               Run only tests matching the regex"
 	@echo ""

--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -4,6 +4,7 @@
 
 \def\TextureSystem{{\kw TextureSystem}\xspace}
 \def\TextureOptions{{\kw TextureOptions}\xspace}
+\def\TextureOptBatch{{\kw TextureOptBatch}\xspace}
 \def\TextureOpt{{\kw TextureOpt}\xspace}
 
 
@@ -42,6 +43,7 @@ as arguments to \TextureSystem methods.
 
 \subsection{\TextureOpt}
 \indexapi{TextureOpt}
+\label{sec:textureopt}
 
 \TextureOpt is a structure that holds many options controlling
 single-point texture lookups.  Because each texture lookup API call takes
@@ -148,196 +150,11 @@ Specifies wrap, blur, and width for the third component of 3D volume texture
 lookups.  These are not used for 2D texture lookups.
 \apiend
 
-\subsection{\TextureOptions}
 
-\TextureOptions is a structure that holds many options controlling
-batched texture lookups.  Because each texture lookup API call takes
-a reference to a \TextureOptions, the call signatures remain uncluttered
-rather than having an ever-growing list of parameters, most of which
-will never vary from their defaults.  Here is a brief description of
-the data members of a \TextureOptions structure:
-
-\apiitem{int firstchannel}
-The beginning channel for the lookup.  For example, to retrieve just the blue
-channel, you should have {\cf firstchannel} = 2 while passing {\cf nchannels} = 1
-to the appropriate texture function.
-\apiend
-
-\apiitem{int subimage}
-The subimage or face within the file to use for the texture lookup.
-The default is 0, and larger values only make sense for a texture file
-that supports subimages or separate images per face (such as Ptex).
-This will be ignored if the file does not have multiple subimages or
-separate per-face textures.
-\apiend
-
-\apiitem{Wrap swrap, twrap}
-Specify the \emph{wrap mode} for 2D texture lookups (and 3D volume
-texture lookups, using the additional {\cf rwrap} field).  These fields
-are ignored for shadow and environment lookups.
-
-These specify what happens when texture coordinates are found to be
-outside the usual $[0,1]$ range over which the texture is defined.
-{\cf Wrap} is an enumerated type that may take on any of the
-following values:
-\begin{description}
-\item[\spc] \spc
-\item[\rm \kw{WrapBlack}] The texture is black outside the [0,1] range.
-\item[\rm \kw{WrapClamp}] The texture coordinates will be clamped to
-  [0,1], i.e., the value outside [0,1] will be the same as the color
-  at the nearest point on the border.
-\item[\rm \kw{WrapPeriodic}] The texture is periodic, i.e., wraps back
-  to 0 after going past 1.
-\item[\rm \kw{WrapMirror}] The texture presents a mirror image at the
-  edges, i.e., the coordinates go from 0 to 1, then back down to 0, then
-  back up to 1, etc.
-\item[\rm \kw{WrapDefault}] Use whatever wrap might be specified in the
-  texture file itself, or some other suitable default (caveat emptor).
-\end{description}
-
-The wrap mode does not need to be identical in the $s$ and $t$
-directions.
-\apiend
-
-\apiitem{VaryingRef<float> swidth, twidth}
-For each direction, gives a multiplier for the derivatives.  Note that
-a width of 0 indicates a point sampled lookup (assuming that blur is
-also zero).  The default width is 1, indicating that the derivatives
-should guide the amount of blur applied to the texture filtering (not
-counting any additional \emph{blur} specified).
-\apiend
-
-\apiitem{VaryingRef<float> sblur, tblur}
-For each direction, specifies an additional amount of pre-blur to apply
-to the texture (\emph{after} derivatives are taken into account),
-expressed as a portion of the width of the texture.  In other words,
-blur = 0.1 means that the texture lookup should act as if the texture
-was pre-blurred with a filter kernel with a width 1/10 the size of the
-full image.  The default blur amount is 0, indicating a sharp texture
-lookup.
-\apiend
-
-\apiitem{VaryingRef<float> fill}
-Specifies the value that will be used for any color channels that are
-requested but not found in the file.  For example, if you perform a
-4-channel lookup on a 3-channel texture, the lsat channel will
-get the fill value.  (Note: this behavior is affected by the
-\qkw{gray_to_rgb} attribute described in 
-Section~\ref{sec:texturesys:attributes}.)
-\apiend
-
-\apiitem{VaryingRef<float> missingcolor}
-If supplied, indicates that a missing or broken texture should \emph{not}
-be treated as an error, but rather will simply return the supplied color
-as the texture lookup color and {\cf texture()} will return {\cf true}.  
-If the {\cf missingcolor} field is left at its default (a NULL pointer),
-a missing or broken texture will be treated as an error and
-{\cf texture()} will return {\cf false}.
-
-Although this is a {\cf VaryingRef<float>}, the data must point to
-\emph{nchannels} contiguous floats, and if ``varying,'' the step size must
-be set to {\cf nchannels*sizeof(float)}, not {\cf sizeof(float)}.
-\apiend
-
-\apiitem{VaryingRef<float> bias}
-For shadow map lookups only, this gives the ``shadow bias'' amount.
-\apiend
-
-\apiitem{VaryingRef<int> samples}
-For shadow map lookups only, the number of samples to use for each lookup.
-\apiend
-
-\apiitem{Wrap rwrap \\
-VaryingRef<float> rblur, rwidth}
-Specifies wrap, blur, and width for the third component of 3D volume texture
-lookups.  These are not used for 2D texture lookups.
-\apiend
-
-\subsection{{\cf VaryingRef}: encapsulate uniform and varying}
-
-Many texture access API routines are designed to look up
-texture efficiently at many points at once.  Therefore, many of
-the parameters to the API routines, and many of the fields in
-\TextureOptions need to accommodate both uniform and varying values.
-\emph{Uniform} means that a single value may be used for each of
-the many simultaneous texture lookups, whereas \emph{varying} means
-that a different value is provided for each of the positions where
-you are sampling the texture.
-
-Please read the comments in \qkw{varyingref.h} for the full gory 
-details, but here's all you really need to know about it to use the
-texture functionality.  Let's suppose that we have a routine 
-whose prototype looks like this:
-
-\begin{code}
-        void API (int n, VaryingRef<float> x);
-\end{code}
-
-\noindent This means that parameter $x$ may either be a single value
-for use at each of the $n$ texture lookups, or it may have $n$ different
-values of $x$.  
-
-If you want to pass a uniform value, you may do any of the following:
-
-\begin{code}
-      float x;   // just one value
-      API (n, x);   // automatically knows what to do!
-      API (n, &x);  // Also ok to pass the pointer to x
-      API (n, VaryingRef<float>(x));  // Wordy but correct
-      API (n, Uniform(x));  // Shorthand
-\end{code}
-
-If you want to pass a varying value, i.e., an array of values,
-
-\begin{code}
-      float x[n];   // One value for each of n points
-      API (n, VaryingRef<float>(x), sizeof(x));  // Wordy but correct
-      API (n, Varying(x));  // Shorthand if stride is sizeof(x)
-\end{code}
-
-You can also initialize a VaryingRef directly:
-
-\begin{code}
-    float x;     // just one value
-    float y[n];  // array of values
-    VaryingRef<float> r;
-    r.init (&x);                 // Initialize to uniform
-    r.init (&x, 0);              // Initialize to uniform the wordy way
-    r.init (&y, sizeof(float));  // Initialize to varying
-    ...
-    API (n, r);
-\end{code}
-
-
-\subsection{SIMD Run Flags}
-
-Many of the texture lookup API routines are written to accommodate
-queries about many points at once.  Furthermore, only a subset of
-points may need to compute.  This is all expressed using three
-parameters:  {\cf Runflag *runflags, int beginactive, int endactive}.
-There are also {\cf VaryingRef} parameters such as {\cf s} and {\cf t}
-that act as if they are arrays.
-
-The {\cf beginactive} and {\cf endactive} indices are the first
-(inclusive) and
-last (exclusive) points that should be computed, and for each point
-{\cf runflags[i]} is nonzero if the point should be computed.  To
-illustrate, here is how a routine might be written that would copy
-values in {\cf arg} to {\cf result} using runflags:
-
-\begin{code}
-        void copy (Runflag *runflags, int beginactive, int endactive,
-                   VaryingRef<float> arg, VaryingRef <float> result)
-        {
-            for (int i = beginactive; i < endactive;  ++i)
-                if (runflags[i])
-                    result[i] = arg[i];
-        }
-\end{code}
 
 
 \newpage
-\section{TextureSystem API}
+\section{TextureSystem Setup}
 \label{sec:texturesys:api}
 
 \subsection{Creating and destroying texture systems}
@@ -634,8 +451,10 @@ or sampled.
 \apiend
 
 
-%\newpage
-\subsection{Texture Lookups}
+\newpage
+\section{Texture Lookups -- single point}
+
+\subsection{2D Texture Lookups}
 \label{sec:texturesys:api:texture}
 
 \apiitem{bool {\ce texture} (ustring filename, TextureOpt \&options,\\
@@ -743,42 +562,6 @@ may be retrieved by the {\cf get_texture_handle()} and
 {\cf get_perthread_info()} methods, respectively.
 \apiend
 
-\apiitem{bool {\ce texture} (ustring filename, TextureOptions \&options,\\
-\bigspc                   Runflag *runflags, int beginactive, int endactive,\\
-\bigspc                   VaryingRef<float> s, VaryingRef<float> t,\\
-\bigspc                   VaryingRef<float> dsdx, VaryingRef<float> dtdx,\\
-\bigspc                   VaryingRef<float> dsdy, VaryingRef<float> dtdy,\\
-\bigspc                   int nchannels, float *result,\\
-\bigspc                   float *dresultds=NULL, float *dresultdt=NULL) \\[2ex]
-bool {\ce texture} (TextureHandle *texture_handle,
-                          Perthread *thread_info, \\
-\bigspc                   TextureOptions \&options,\\
-\bigspc                   Runflag *runflags, int beginactive, int endactive,\\
-\bigspc                   VaryingRef<float> s, VaryingRef<float> t,\\
-\bigspc                   VaryingRef<float> dsdx, VaryingRef<float> dtdx,\\
-\bigspc                   VaryingRef<float> dsdy, VaryingRef<float> dtdy,\\
-\bigspc                   int nchannels, float *result,\\
-\bigspc                   float *dresultds=NULL, float *dresultdt=NULL) \\
-}
-
-Perform filtered 2D texture lookups on a collection of positions all at
-once, which may be much more efficient than repeatedly calling the
-single-point version of {\cf texture()}.  The parameters {\cf s},
-{\cf t}, {\cf dsdx}, {\cf dtdx}, and {\cf dsdy}, {\cf dtdy} are now
-{\cf VaryingRef}'s that may refer to either a single or an array of
-values, as are many of the fields in the {\cf options}.
-
-Texture will be computed at indices {\cf beginactive} through
-{\cf endactive} (exclusive of the end), but only at indices where {\cf runflags[i]}
-is nonzero.  Results will be stored at corresponding positions of
-{\cf result}, that is, 
-{\cf result[i*nchannels ... (i+1)*nchannels-1]} (and similarly for
-{\cf dresultds} and {\cf dresultdt}, if they are not {\cf NULL}).
-
-This function returns {\cf true} upon success, or {\cf false} if the
-file was not found or could not be opened by any available ImageIO
-plugin.
-\apiend
 
 
 %\newpage
@@ -896,38 +679,6 @@ may be retrieved by the {\cf get_texture_handle()} and
 {\cf get_perthread_info()} methods, respectively.
 \apiend
 
-\apiitem{bool {\ce texture3d} (ustring filename, TextureOptions \&options,\\
-\bigspc                          Runflag *runflags, int beginactive, int endactive,\\
-\bigspc                          VaryingRef<Imath::V3f> P, VaryingRef<Imath::V3f> dPdx,\\
-\bigspc                          VaryingRef<Imath::V3f> dPdy, VaryingRef<Imath::V3f> dPdz,\\
-\bigspc                          int nchannels, float *result, float *dresultds=NULL,\\
-\bigspc                          float *dresultdt=NULL,float *dresultdr=NULL)\\[2ex]
-bool {\ce texture3d} (TextureHandle *texture_handle,
-                          Perthread *thread_info, \\
-\bigspc                   TextureOptions \&options,\\
-\bigspc                          Runflag *runflags, int beginactive, int endactive,\\
-\bigspc                          VaryingRef<Imath::V3f> P, VaryingRef<Imath::V3f> dPdx,\\
-\bigspc                          VaryingRef<Imath::V3f> dPdy, VaryingRef<Imath::V3f> dPdz,\\
-\bigspc                          int nchannels, float *result, float *dresultds=NULL,\\
-\bigspc                          float *dresultdt=NULL, float *dresultdr=NULL)}
-
-Perform filtered 3D volumetric texture lookups on a collection of positions all at
-once, which may be much more efficient than repeatedly calling the
-single-point version of {\cf texture()}.  The parameters {\cf P},
-{\cf dPdx}, {\cf dPdy}, and {\cf dPdz} are now
-{\cf VaryingRef}'s that may refer to either a single or an array of
-values, as are all the fields in the {\cf options}.
-
-Texture will be computed at indices {\cf beginactive} through
-{\cf endactive} (exclusive of the end), but only at indices where {\cf runflags[i]}
-is nonzero.  Results will be stored at corresponding positions of
-{\cf result}, that is, {\cf result[i*n ... (i+1)*n-1]} where $n$ 
-is the number of channels requested by {\cf options.nchannels}.
-
-This function returns {\cf true} upon success, or {\cf false} if the
-file was not found or could not be opened by any available ImageIO
-plugin.
-\apiend
 
 %\newpage
 \subsection{Shadow Lookups}
@@ -1004,35 +755,6 @@ may be retrieved by the {\cf get_texture_handle()} and
 {\cf get_perthread_info()} methods, respectively.
 \apiend
 
-\apiitem{bool {\ce shadow} (ustring filename, TextureOptions \&options,\\
-\bigspc                         Runflag *runflags, int beginactive, int endactive,\\
-\bigspc                         VaryingRef<Imath::V3f> P, VaryingRef<Imath::V3f> dPdx,\\
-\bigspc                         VaryingRef<Imath::V3f> dPdy, int nchannels, float *result,\\
-\bigspc                         float *dresultds=NULL, float *dresultdt=NULL)\\[2ex]
-bool {\ce shadow} (TextureHandle *texture_handle,  Perthread *thread_info, \\
-\bigspc                         TextureOptions \&options,\\
-\bigspc                         Runflag *runflags, int beginactive, int endactive,\\
-\bigspc                         VaryingRef<Imath::V3f> P, VaryingRef<Imath::V3f> dPdx,\\
-\bigspc                         VaryingRef<Imath::V3f> dPdy, int nchannels, float *result,\\
-\bigspc                         float *dresultds=NULL, float *dresultdt=NULL)}
-
-Perform filtered shadow map lookups on a collection of positions all at
-once, which may be much more efficient than repeatedly calling the
-single-point version of {\cf shadow()}.  The parameters {\cf P},
-{\cf dPdx}, and {\cf dPdy} are now
-{\cf VaryingRef}'s that may refer to either a single or an array of
-values, as are many the fields in the {\cf options}.
-
-Shadow lookups will be computed at indices {\cf beginactive} through
-{\cf endactive} (exclusive of the end), but only at indices where {\cf runflags[i]}
-is nonzero.  Results will be stored at corresponding positions of
-{\cf result}, that is, {\cf result[i*n ... (i+1)*n-1]} where $n$ 
-is the number of channels requested by {\cf options.nchannels}.
-
-This function returns {\cf true} upon success, or {\cf false} if the
-file was not found or could not be opened by any available ImageIO
-plugin.
-\apiend
 
 %\newpage
 \subsection{Environment Lookups}
@@ -1110,18 +832,202 @@ may be retrieved by the {\cf get_texture_handle()} and
 {\cf get_perthread_info()} methods, respectively.
 \apiend
 
-\apiitem{bool {\ce environment} (ustring filename, TextureOptions \&options,\\
-\bigspc\spc                              Runflag *runflags, int beginactive, int endactive,\\
-\bigspc\spc                              VaryingRef<Imath::V3f> R, VaryingRef<Imath::V3f> dRdx,\\
-\bigspc\spc                              VaryingRef<Imath::V3f> dRdy, int nchannels, float *result,\\
-\bigspc\spc                         float *dresultds=NULL, float *dresultdt=NULL)\\[2ex]
-bool {\ce environment} (TextureHandle *texture_handle,
+
+
+\section{Batched Texture Lookups}
+\label{sec:texturesys:api:batched}
+\index{SIMD} \index{batched texture lookups}
+
+On CPU architectures with SIMD processing, texturing entire batches of
+samples at once may provide a large speedup compared to texturing each
+sample point individually. The batch size is fixed (for any build of
+\product) and may be accessed with the following constant:
+
+\apiitem{static const int {\ce Tex::BatchWidth}}
+This constant specifies the batch size. This is fixed within any release
+of \product, but may change from release to release and also may be
+overridden at build time. A typical batch size is 16.
+\apiend
+
+All of the batched calls take a \emph{run mask}, which describes which
+subset of ``lanes'' should be computed by the batched lookup:
+
+\apiitem{typedef ... {\ce Tex::RunMask}}
+
+The {\cf RunMask} is defined to be an integer large enough to hold at least
+{\cf BatchWidth} bits. The least significant bit corresponds to the first
+(i.e., {\cf [0]}) position of all batch arrays. For each position
+{\cf i} in the batch, the bit identified by {\cf (1 << i)} controls whether
+that position will be computed.
+
+The defined constant {\cf RunMaskOn} contants the value with all bits
+{\cf 0..BatchWidth-1} set to 1.
+\apiend
+
+\subsection{Batched Options}
+
+\apiitem{class {\ce TextureOptBatch}}
+\label{sec:textureoptbatch}
+
+\TextureOptBatch is a structure that holds the options for doing an entire
+batch of lookups from the same texture at once.
+The members of \TextureOptBatch correspond to the similarly named members of
+the single-point \TextureOpt, so we refer you to
+Section~\ref{sec:textureopt} for detailed explanations, and this section
+will only explain the differences between batched and single-point options.
+
+\apiitem{int firstchannel \\
+int subimage \\
+ustring subimagename \\
+Tex::Wrap swrap, twrap, rwrap \\
+Tex::MipMode mipmode \\
+Tex::InterpMode interpmode \\
+int anisotropic \\
+bool conservative_filter \\
+float fill \\
+const float *missingcolor } ~\\
+These fields are all scalars --- a single value for each \TextureOptBatch
+--- which means that the value of these options must be the same for every
+texture sample point within a batch. If you have a number of texture lookups
+to perform for the same texture, but they have (for example) differing wrap
+modes or subimages from point to point, then you must split them into
+separate batch calls.
+\apiend
+
+\apiitem{float sblur[Tex::BatchWidth] \\
+float tblur[Tex::BatchWidth] \\
+float rblur[Tex::BatchWidth] } ~\\
+These arrays hold the $s$, and $t$ blur amounts, for each sample in the
+batch, respectively. (And the $r$ blur amount, used only for volumetric
+{\cf texture3d()} lookups.)
+\apiend
+
+\apiitem{float swidth[Tex::BatchWidth] \\
+float twidth[Tex::BatchWidth] \\
+float rwidth[Tex::BatchWidth] } ~\\
+These arrays hold the $s$, and $t$ filtering width multiplier for
+derivatives, for each sample in the batch, respectively. (And the $r$
+multiplier, used only for volumetric {\cf texture3d()} lookups.)
+\apiend
+\apiend
+
+\subsection{Batched Texture Lookup Calls}
+
+\apiitem{bool {\ce texture} (ustring filename, TextureOptBatch \&options,\\
+\bigspc                   Tex::RunMask mask, const float *s, const float *t,\\
+\bigspc                   const float *dsdx, const float *dtdx,\\
+\bigspc                   const float *dsdy, const float *dtdy,\\
+\bigspc                   int nchannels, float *result,\\
+\bigspc                   float *dresultds=nullptr, float *dresultdt=nullptr) \\[2ex]
+bool {\ce texture} (TextureHandle *texture_handle,
                           Perthread *thread_info, \\
-\bigspc\spc                   TextureOptions \&options,\\
-\bigspc\spc                              Runflag *runflags, int beginactive, int endactive,\\
-\bigspc\spc                              VaryingRef<Imath::V3f> R, VaryingRef<Imath::V3f> dRdx,\\
-\bigspc\spc                              VaryingRef<Imath::V3f> dRdy, int nchannels, float *result,\\
-\bigspc\spc                         float *dresultds=NULL, float *dresultdt=NULL)}
+\bigspc                   TextureOptBatch \&options,\\
+\bigspc                   Tex::RunMask mask, const float *s, const float *t,\\
+\bigspc                   const float *dsdx, const float *dtdx,\\
+\bigspc                   const float *dsdy, const float *dtdy,\\
+\bigspc                   int nchannels, float *result,\\
+\bigspc                   float *dresultds=nullptr, float *dresultdt=nullptr) \\
+}
+
+Perform filtered 2D texture lookups on a batch of positions from the
+same texture, all at once.  The parameters {\cf s},
+{\cf t}, {\cf dsdx}, {\cf dtdx}, and {\cf dsdy}, {\cf dtdy} are each
+a pointer to {\cf [BatchSize]} values.  The {\cf mask} determines which
+of those array elements to actually compute.
+
+The various results are arranged as arrays that behave as if they were
+declared
+
+~~~~ {\cf  float result[channels][BatchSize]}
+
+\noindent In other words, all the batch values for channel 0 are
+adjacent, followed by all the batch values for channel 1, etc. (This is
+``SOA'' order.)
+
+This function returns {\cf true} upon success, or {\cf false} if the
+file was not found or could not be opened by any available ImageIO
+plugin.
+\apiend
+
+\apiitem{bool {\ce texture3d} (ustring filename, TextureOptBatch \&options,\\
+\bigspc                        Tex::RunMask mask, const float *P, const float *dPdx,\\
+\bigspc                        const float *dPdy, const float *dPdz,\\
+\bigspc                        int nchannels, float *result, float *dresultds=nullptr,\\
+\bigspc                        float *dresultdt=nullptr,float *dresultdr=nullptr)\\[2ex]
+bool {\ce texture3d} (TextureHandle *texture_handle,
+                      Perthread *thread_info, \\
+\bigspc               TextureOptBatch \&options,\\
+\bigspc               Tex::RunMask mask, const float *P, const float *dPdx,\\
+\bigspc               const float *dPdy, const float *dPdz,\\
+\bigspc               int nchannels, float *result, float *dresultds=nullptr,\\
+\bigspc               float *dresultdt=nullptr, float *dresultdr=nullptr)}
+
+Perform filtered 3D volumetric texture lookups on a batch of positions from
+the same texture, all at once. The ``point-like'' parameters {\cf P}, {\cf
+dPdx}, {\cf dPdy}, and {\cf dPdz} are each a pointers to arrays of
+{\cf float value[3][BatchSize]}. That is, each one points to all the $x$ values
+for the batch, immediately followed by all the $y$ values, followed by the
+$z$ values.
+
+The various results arrays are also arranged as arrays that behave as if
+they were declared {\cf  float result[channels][BatchSize]}, where all the
+batch values for channel 0 are adjacent, followed by all the batch values
+for channel 1, etc.
+
+This function returns {\cf true} upon success, or {\cf false} if the
+file was not found or could not be opened by any available ImageIO
+plugin.
+\apiend
+
+\begin{comment}
+\apiitem{bool {\ce shadow} (ustring filename, TextureOptBatch \&options,\\
+\bigspc                         Tex::RunMask mask, \\
+\bigspc                         const float *P, const float *dPdx,\\
+\bigspc                         const float *dPdy, int nchannels, float *result,\\
+\bigspc                         float *dresultds=nullptr, float *dresultdt=nullptr)\\[2ex]
+bool {\ce shadow} (TextureHandle *texture_handle,  Perthread *thread_info, \\
+\bigspc                         TextureOptBatch \&options,\\
+\bigspc                         Tex::RunMask mask, \\
+\bigspc                         const float *P, const float *dPdx,\\
+\bigspc                         const float *dPdy, int nchannels, float *result,\\
+\bigspc                         float *dresultds=nullptr, float *dresultdt=nullptr)}
+
+Perform filtered shadow map lookups on a batch of positions from
+the same texture, all at once. The ``point-like'' parameters {\cf P},
+{\cf dPdx}, and {\cf dPdy} are each a pointers to arrays of
+{\cf float value[3][BatchSize]}. That is, each one points to all the $x$ values
+for the batch, immediately followed by all the $y$ values, followed by the
+$z$ values.
+
+The various results arrays are also arranged as arrays that behave as if
+they were declared {\cf  float result[channels][BatchSize]}, where all the
+batch values for channel 0 are adjacent, followed by all the batch values
+for channel 1, etc.
+
+This function returns {\cf true} upon success, or {\cf false} if the
+file was not found or could not be opened by any available ImageIO
+plugin.
+\apiend
+\end{comment}
+
+\apiitem{bool {\ce environment} (ustring filename, TextureOptBatch \&options,\\
+\bigspc\spc                      Tex::RunMask mask, \\
+\bigspc\spc                      const float *R, const float *dRdx,\\
+\bigspc\spc                      const float *dRdy, int nchannels, float *result,\\
+\bigspc\spc                      float *dresultds=nullptr, float *dresultdt=nullptr)\\[2ex]
+bool {\ce environment} (TextureHandle *texture_handle,
+                        Perthread *thread_info, \\
+\bigspc\spc             TextureOptBatch \&options, Tex::RunMask mask, \\
+\bigspc\spc             const float *R, const float *dRdx,\\
+\bigspc\spc             const float *dRdy, int nchannels, float *result,\\
+\bigspc\spc             float *dresultds=nullptr, float *dresultdt=nullptr)}
+
+Perform filtered directional environment map lookups on a batch of positions
+from the same texture, all at once. The ``point-like'' parameters {\cf R},
+{\cf dRdx}, and {\cf dRdy} are each a pointers to arrays of
+{\cf float value[3][BatchSize]}. That is, each one points to all the $x$ values
+for the batch, immediately followed by all the $y$ values, followed by the
+$z$ values.
 
 Perform filtered directional environment map lookups on a collection of
 directions all at once, which may be much more efficient than repeatedly
@@ -1130,19 +1036,19 @@ calling the single-point version of {\cf environment()}.  The parameters
 refer to either a single or an array of values, as are many the fields in
 the {\cf options}.
 
-Results will be computed at indices {\cf beginactive} through
-{\cf endactive} (exclusive of the end), but only at indices where {\cf runflags[i]}
-is nonzero.  Results will be stored at corresponding positions of
-{\cf result}, that is, {\cf result[i*n ... (i+1)*n-1]} where $n$ 
-is the number of channels requested by {\cf options.nchannels}.
+The various results arrays are also arranged as arrays that behave as if
+they were declared {\cf  float result[channels][BatchSize]}, where all the
+batch values for channel 0 are adjacent, followed by all the batch values
+for channel 1, etc.
 
 This function returns {\cf true} upon success, or {\cf false} if the
 file was not found or could not be opened by any available ImageIO
 plugin.
 \apiend
 
+
 %\newpage
-\subsection{Texture Metadata and Raw Texels}
+\section{Texture Metadata and Raw Texels}
 \label{sec:texturesys:api:gettextureinfo}
 \label{sec:texturesys:api:getimagespec}
 
@@ -1392,7 +1298,7 @@ Returns the true path to the given file name, with searchpath logic
 applied.
 \apiend
 
-\subsection{Miscellaneous -- Statistics, errors, flushing the cache}
+\section{Miscellaneous -- Statistics, errors, flushing the cache}
 \label{sec:texturesys:api:geterror}
 \label{sec:texturesys:api:getstats}
 \label{sec:texturesys:api:resetstats}

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -577,6 +577,75 @@ TextureSystemImpl::environment (TextureHandle *texture_handle_,
 
 
 
+bool
+TextureSystemImpl::environment (TextureHandle *texture_handle, Perthread *thread_info,
+                                TextureOptBatch &options, Tex::RunMask mask,
+                                const float *R, const float *dRdx, const float *dRdy,
+                                int nchannels, float *result,
+                                float *dresultds, float *dresultdt)
+{
+    // (FIXME) CHEAT! Texture points individually
+    TextureOpt opt;
+    opt.firstchannel = options.firstchannel;
+    opt.subimage = options.subimage;
+    opt.subimagename = options.subimagename;
+    opt.swrap = (TextureOpt::Wrap) options.swrap;
+    opt.twrap = (TextureOpt::Wrap) options.twrap;
+    opt.mipmode = (TextureOpt::MipMode) options.mipmode;
+    opt.interpmode = (TextureOpt::InterpMode) options.interpmode;
+    opt.anisotropic = options.anisotropic;
+    opt.conservative_filter = options.conservative_filter;
+    opt.fill = options.fill;
+    opt.missingcolor = options.missingcolor;
+
+    bool ok = true;
+    Tex::RunMask bit = 1;
+    for (int i = 0; i < Tex::BatchWidth;  ++i, bit <<= 1) {
+        float r[4], drds[4], drdt[4];  // temp result
+        if (mask & bit) {
+            opt.sblur = options.sblur[i];
+            opt.tblur = options.tblur[i];
+            opt.swidth = options.swidth[i];
+            opt.twidth = options.twidth[i];
+            Imath::V3f R_ (R[i], R[i+Tex::BatchWidth], R[i+2*Tex::BatchWidth]);
+            Imath::V3f dRdx_ (dRdx[i], dRdx[i+Tex::BatchWidth], dRdx[i+2*Tex::BatchWidth]);
+            Imath::V3f dRdy_ (dRdy[i], dRdy[i+Tex::BatchWidth], dRdy[i+2*Tex::BatchWidth]);
+            if (dresultds) {
+                ok &= environment (texture_handle, thread_info, opt,
+                                   R_, dRdx_, dRdy_, nchannels, r, drds, drdt);
+                for (int c = 0; c < nchannels; ++c) {
+                    result[c*Tex::BatchWidth+i] = r[c];
+                    dresultds[c*Tex::BatchWidth+i] = drds[c];
+                    dresultdt[c*Tex::BatchWidth+i] = drdt[c];
+                }
+            } else {
+                ok &= environment (texture_handle, thread_info, opt,
+                                   R_, dRdx_, dRdy_, nchannels, r);
+                for (int c = 0; c < nchannels; ++c) {
+                    result[c*Tex::BatchWidth+i] = r[c];
+                }
+            }
+        }
+    }
+    return ok;
+}
+
+
+
+bool
+TextureSystemImpl::environment (ustring filename,
+                                TextureOptBatch &options, Tex::RunMask mask,
+                                const float *R, const float *dRdx, const float *dRdy,
+                                int nchannels, float *result,
+                                float *dresultds, float *dresultdt)
+{
+    Perthread *thread_info = get_perthread_info();
+    TextureHandle *texture_handle = get_texture_handle (filename, thread_info);
+    return environment (texture_handle, thread_info, options, mask,
+                        R, dRdx, dRdy, nchannels, result, dresultds, dresultdt);
+}
+
+
 }  // end namespace pvt
 
 OIIO_NAMESPACE_END

--- a/src/libtexture/texoptions.cpp
+++ b/src/libtexture/texoptions.cpp
@@ -130,32 +130,32 @@ TextureOpt::TextureOpt (const TextureOptions &opt, int index)
 
 
 
-TextureOpt::Wrap
-TextureOpt::decode_wrapmode (const char *name)
+Tex::Wrap
+Tex::decode_wrapmode (const char *name)
 {
-    for (int i = 0;  i < (int)WrapLast;  ++i)
+    for (int i = 0;  i < (int)Tex::Wrap::Last;  ++i)
         if (! strcmp (name, wrap_type_name[i].c_str()))
             return (Wrap) i;
-    return TextureOpt::WrapDefault;
+    return Tex::Wrap::Default;
 }
 
 
 
-TextureOpt::Wrap
-TextureOpt::decode_wrapmode (ustring name)
+Tex::Wrap
+Tex::decode_wrapmode (ustring name)
 {
-    for (int i = 0;  i < (int)WrapLast;  ++i)
+    for (int i = 0;  i < (int)Tex::Wrap::Last;  ++i)
         if (name == wrap_type_name[i])
             return (Wrap) i;
-    return TextureOpt::WrapDefault;
+    return Tex::Wrap::Default;
 }
 
 
 
 void
-TextureOpt::parse_wrapmodes (const char *wrapmodes,
-                             TextureOpt::Wrap &swrapcode,
-                             TextureOpt::Wrap &twrapcode)
+Tex::parse_wrapmodes (const char *wrapmodes,
+                      Tex::Wrap &swrapcode,
+                      Tex::Wrap &twrapcode)
 {
     char *swrap = (char *) alloca (strlen(wrapmodes)+1);
     const char *twrap;
@@ -169,5 +169,6 @@ TextureOpt::parse_wrapmodes (const char *wrapmodes,
     swrapcode = decode_wrapmode (swrap);
     twrapcode = decode_wrapmode (twrap);
 }
+
 
 OIIO_NAMESPACE_END

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -147,6 +147,19 @@ public:
                           float dsdy, float dtdy,
                           int nchannels, float *result,
                           float *dresultds=NULL, float *dresultdt=NULL);
+    virtual bool texture (ustring filename, TextureOptBatch &options,
+                          Tex::RunMask mask, const float *s, const float *t,
+                          const float *dsdx, const float *dtdx,
+                          const float *dsdy, const float *dtdy,
+                          int nchannels, float *result,
+                          float *dresultds=nullptr, float *dresultdt=nullptr);
+    virtual bool texture (TextureHandle *texture_handle,
+                          Perthread *thread_info, TextureOptBatch &options,
+                          Tex::RunMask mask, const float *s, const float *t,
+                          const float *dsdx, const float *dtdx,
+                          const float *dsdy, const float *dtdy,
+                          int nchannels, float *result,
+                          float *dresultds=nullptr, float *dresultdt=nullptr);
     virtual bool texture (ustring filename, TextureOptions &options,
                           Runflag *runflags, int beginactive, int endactive,
                           VaryingRef<float> s, VaryingRef<float> t,
@@ -163,7 +176,6 @@ public:
                           int nchannels, float *result,
                           float *dresultds=NULL, float *dresultdt=NULL);
 
-
     virtual bool texture3d (ustring filename, TextureOpt &options,
                             const Imath::V3f &P, const Imath::V3f &dPdx,
                             const Imath::V3f &dPdy, const Imath::V3f &dPdz,
@@ -177,6 +189,21 @@ public:
                             int nchannels, float *result,
                             float *dresultds=NULL, float *dresultdt=NULL,
                             float *dresultdr=NULL);
+    virtual bool texture3d (ustring filename,
+                            TextureOptBatch &options, Tex::RunMask mask,
+                            const float *P, const float *dPdx,
+                            const float *dPdy, const float *dPdz,
+                            int nchannels, float *result,
+                            float *dresultds=nullptr, float *dresultdt=nullptr,
+                            float *dresultdr=nullptr);
+    virtual bool texture3d (TextureHandle *texture_handle,
+                            Perthread *thread_info,
+                            TextureOptBatch &options, Tex::RunMask mask,
+                            const float *P, const float *dPdx,
+                            const float *dPdy, const float *dPdz,
+                            int nchannels, float *result,
+                            float *dresultds=nullptr, float *dresultdt=nullptr,
+                            float *dresultdr=nullptr);
     virtual bool texture3d (ustring filename, TextureOptions &options,
                             Runflag *runflags, int beginactive, int endactive,
                             VaryingRef<Imath::V3f> P,
@@ -210,6 +237,18 @@ public:
                          float *dresultds=NULL, float *dresultdt=NULL) {
         return false;
     }
+    virtual bool shadow (ustring filename,
+                         TextureOptBatch &options, Tex::RunMask mask,
+                         const float *P, const float *dPdx, const float *dPdy,
+                         float *result, float *dresultds=nullptr, float *dresultdt=nullptr) {
+        return false;
+    }
+    virtual bool shadow (TextureHandle *texture_handle, Perthread *thread_info,
+                         TextureOptBatch &options, Tex::RunMask mask,
+                         const float *P, const float *dPdx, const float *dPdy,
+                         float *result, float *dresultds=nullptr, float *dresultdt=nullptr) {
+        return false;
+    }
     virtual bool shadow (ustring filename, TextureOptions &options,
                          Runflag *runflags, int beginactive, int endactive,
                          VaryingRef<Imath::V3f> P,
@@ -240,6 +279,16 @@ public:
                               const Imath::V3f &R, const Imath::V3f &dRdx,
                               const Imath::V3f &dRdy, int nchannels, float *result,
                               float *dresultds=NULL, float *dresultdt=NULL);
+    virtual bool environment (ustring filename,
+                              TextureOptBatch &options, Tex::RunMask mask,
+                              const float *R, const float *dRdx, const float *dRdy,
+                              int nchannels, float *result,
+                              float *dresultds=nullptr, float *dresultdt=nullptr);
+    virtual bool environment (TextureHandle *texture_handle, Perthread *thread_info,
+                              TextureOptBatch &options, Tex::RunMask mask,
+                              const float *R, const float *dRdx, const float *dRdy,
+                              int nchannels, float *result,
+                              float *dresultds=nullptr, float *dresultdt=nullptr);
     virtual bool environment (ustring filename, TextureOptions &options,
                               Runflag *runflags, int beginactive, int endactive,
                               VaryingRef<Imath::V3f> R,


### PR DESCRIPTION
There was previously a set of TextureSystem API calls (with multi-point TextureOptions struct and a fancy VaryingRef helper class) that was a multi-point interface, but we never did much with it and in retrospect, it does not use a data organization that is good for future-looking architectures. We are therefore depcrecating it, it will remain for 1.8 in case anybody is using it, but will thereafter be removed. 

But we are adding a new set of batched routines that are organized differently, we think in a way that will be well-suited for better parallelism.

The new API assumes that the inputs and outputs have a SOA rather than AOS layout, and the arrays are a fixed width, defined by Tex::BatchWidth, which is a constant and set to 16. Build-time overrides let us change this for experimentation and future expansion. You can texture fewer points than this using the RunMask, which is a bit field saying which "lanes" should be used. Inputs will not be read, or outputs written, for the lanes where the run mask is 0.

The goal is for this to really fly on chips with ISA that includes AVX-512 support (naturally 16 wide), and to also perform very well for AVX2 class machines (emulating 16x operations with pairs of 8x SIMD instructions). I'm not very hopeful that old SSE hardware (4x wide) will have a high payoff using the batched functionality rather than the single-point texturing, but we'll see what happens. We'll also experiment with 32 wide (there's no true 32 wide hardware, but pairs of 16-wide instructions may dual-issue in nice ways that provides an advantage, we'll see).

I'm not planning to ever remove the single-point scalar API calls. There will always be a use for them and they'll certainly be more efficient for applications that don't have a good way to batch the calls.

This pull request only implements the batched APIs -- the internals are still scalar, they just loop over the enabled lanes and call the scalar functionality.

I'm actually working on the true batched reversions right now, but they aren't ready to review yet. Expect a second PR for that as soon as I have good results. But in the mean time, this allows applications to start experimenting with the batched interface.

The testtex program now has modes that exercise the batched interfaces, and the testsuite has been doctored so that every test whose name contains the substring "texture" will run twice: once using the old scalar mode, and once using the batched API calls. This means that starting now, we will immediately notice any breakages or regressions in the batched versions, as well as have a convenient way to benchmark the scalar versus batched calls.

If you have any issues with this organization of the batched APIs -- for example, if you can see that I'm making some kind of stupid mistake that I'll regret later -- please speak up NOW. I'd prefer that the APIs have a good chance of being stable, since we are getting close to branching a release. It's much easier to address any deficiencies now, rather than after I'm finished fully implementing the internals.


