### PR TITLE
Fix important performance issues with IBA::deep_merge()

### DIFF
--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -547,7 +547,8 @@ void
 DeepData::insert_samples (int pixel, int samplepos, int n)
 {
     int oldsamps = samples(pixel);
-    set_capacity (pixel, oldsamps + n);
+    if (oldsamps+n > int(m_impl->m_capacity[pixel]))
+        set_capacity (pixel, oldsamps + n);
     // set_capacity is thread-safe, it locks internally. Once the capacity
     // is adjusted, we can alter nsamples or copy the data around within
     // the pixel without a lock, we presume that if multiple threads are


### PR DESCRIPTION
When merging, high number of splits was crippling performance due to
constant realocation.

New strategy more carefully pre-computes the NUMBER of splits expected
in the merged pixel, and allocates enough storage for the result pixel
to hold the number of samples in both of the input images, and also the
expected number of new segments that will result from splitting.

This speeds things up for very complicated frames by a couple orders of
magnitude.

