### PR TITLE
oiio: fixed move constructor of ParamValue class.

### DIFF
--- a/src/include/OpenImageIO/paramlist.h
+++ b/src/include/OpenImageIO/paramlist.h
@@ -117,6 +117,7 @@ public:
         : m_name(p.m_name), m_nvalues(p.m_nvalues), m_interp(p.m_interp),
           m_copy(p.m_copy), m_nonlocal(p.m_nonlocal)
     {
+        m_type = p.m_type;
         m_data.ptr = p.m_data.ptr;
         p.m_data.ptr = nullptr;
     }


### PR DESCRIPTION
## Description

ParamValue move constructor was not copying the internal ParamValue type.


## Checklist:
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

