### PR TITLE
raw: unpack the pixels when you need them, not when you open

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -296,6 +296,10 @@ Fixes, minor enhancements, and performance improvements:
      images (supported in libraw 0.18 or newer). #1626 (1.8.3/1.7.13)
    * Add "raw:user_sat" configuration attribute to the reader.
      #1666 (1.7.15/1.8.4)
+   * The pixels are now decoded (expensive) only when they are read, not
+     when the file is first opened. This makes raw reading much faster for
+     apps that are only interested in the metadata and not the pixel data.
+     #1741 (1.8.5)
 * RLA:
    * Fix RLA reading and writing with certain channel orders and mixded data
      formats. #1499 (1.8.0/1.7.8)


### PR DESCRIPTION
I'm concerned about this breaking raw reads. Looks ok to me and works on my cursory tests, but other stakeholders that rely on the raw format reader should please try this patch on their end and let me know if it's ok!
