### PR TITLE
A variety of warning/buglet fixes revealed by clang-tidy static analysis

### DIFF
--- a/src/bmp.imageio/bmp_pvt.h
+++ b/src/bmp.imageio/bmp_pvt.h
@@ -141,7 +141,7 @@ namespace bmp_pvt {
 
 
 
-class BmpInput : public ImageInput {
+class BmpInput final : public ImageInput {
  public:
     BmpInput () { init (); }
     virtual ~BmpInput () { close (); }
@@ -172,7 +172,7 @@ class BmpInput : public ImageInput {
 
 
 
-class BmpOutput : public ImageOutput {
+class BmpOutput final : public ImageOutput {
  public:
     BmpOutput () { init (); }
     virtual ~BmpOutput () { close (); }

--- a/src/cineon.imageio/cineoninput.cpp
+++ b/src/cineon.imageio/cineoninput.cpp
@@ -41,7 +41,7 @@ using namespace cineon;
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
 
-class CineonInput : public ImageInput {
+class CineonInput final : public ImageInput {
 public:
     CineonInput () : m_stream(NULL) { init(); }
     virtual ~CineonInput () { close(); }

--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -48,7 +48,7 @@ using namespace DDS_pvt;
 // uncomment the following define to enable 3x2 cube map layout
 //#define DDS_3X2_CUBE_MAP_LAYOUT
 
-class DDSInput : public ImageInput {
+class DDSInput final : public ImageInput {
 public:
     DDSInput () { init(); }
     virtual ~DDSInput () { close(); }

--- a/src/dicom.imageio/dicominput.cpp
+++ b/src/dicom.imageio/dicominput.cpp
@@ -58,7 +58,7 @@
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
-class DICOMInput : public ImageInput {
+class DICOMInput final : public ImageInput {
 public:
     DICOMInput () {}
     virtual ~DICOMInput() { close(); }

--- a/src/doc/writingplugins.tex
+++ b/src/doc/writingplugins.tex
@@ -157,7 +157,7 @@ real-world example of writing a JPEG/JFIF plug-in.
   or tiled images.
 
   \begin{code}
-    class JpgInput : public ImageInput {
+    class JpgInput final : public ImageInput {
      public:
         JpgInput () { init(); }
         virtual ~JpgInput () { close(); }
@@ -314,7 +314,7 @@ real-world example of writing a JPEG/JFIF plug-in.
   or tiled images.
 
   \begin{code}
-    class JpgOutput : public ImageOutput {
+    class JpgOutput final : public ImageOutput {
      public:
         JpgOutput () { init(); }
         virtual ~JpgOutput () { close(); }

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -41,7 +41,7 @@
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
 
-class DPXInput : public ImageInput {
+class DPXInput final : public ImageInput {
 public:
     DPXInput () : m_stream(NULL), m_dataPtr(NULL) { init(); }
     virtual ~DPXInput () { close(); }

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -48,7 +48,7 @@ static const int MAX_DPX_IMAGE_ELEMENTS = 8;  // max subimages in DPX spec
 
 
 
-class DPXOutput : public ImageOutput {
+class DPXOutput final : public ImageOutput {
 public:
     DPXOutput ();
     virtual ~DPXOutput ();

--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -132,7 +132,7 @@ inline int receive_frame(AVCodecContext *avctx, AVFrame *picture,
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
 
-class FFmpegInput : public ImageInput {
+class FFmpegInput final : public ImageInput {
 public:
     FFmpegInput ();
     virtual ~FFmpegInput();

--- a/src/field3d.imageio/field3doutput.cpp
+++ b/src/field3d.imageio/field3doutput.cpp
@@ -48,7 +48,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 
 
 
-class Field3DOutput : public ImageOutput {
+class Field3DOutput final : public ImageOutput {
 public:
     Field3DOutput ();
     virtual ~Field3DOutput ();

--- a/src/fits.imageio/fits_pvt.h
+++ b/src/fits.imageio/fits_pvt.h
@@ -64,7 +64,7 @@ struct Subimage {
 
 
 
-class FitsInput : public ImageInput {
+class FitsInput final : public ImageInput {
  public:
     FitsInput () { init (); }
     virtual ~FitsInput () { close (); }
@@ -136,7 +136,7 @@ class FitsInput : public ImageInput {
 
 
 
-class FitsOutput : public ImageOutput {
+class FitsOutput final : public ImageOutput {
  public:
     FitsOutput () { init (); }
     virtual ~FitsOutput () { close (); }

--- a/src/gif.imageio/gifinput.cpp
+++ b/src/gif.imageio/gifinput.cpp
@@ -55,7 +55,7 @@
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
-class GIFInput : public ImageInput {
+class GIFInput final : public ImageInput {
 public:
     GIFInput () { init (); }
     virtual ~GIFInput () { close (); }

--- a/src/gif.imageio/gifoutput.cpp
+++ b/src/gif.imageio/gifoutput.cpp
@@ -49,7 +49,7 @@ namespace {
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
-class GIFOutput : public ImageOutput {
+class GIFOutput final : public ImageOutput {
  public:
     GIFOutput () { init(); }
     virtual ~GIFOutput () { close(); }

--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -55,7 +55,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 
 
 
-class HdrInput : public ImageInput {
+class HdrInput final : public ImageInput {
 public:
     HdrInput () { init(); }
     virtual ~HdrInput () { close(); }

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -41,7 +41,7 @@
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
-class HdrOutput : public ImageOutput {
+class HdrOutput final : public ImageOutput {
  public:
     HdrOutput () { init(); }
     virtual ~HdrOutput () { close(); }

--- a/src/ico.imageio/icoinput.cpp
+++ b/src/ico.imageio/icoinput.cpp
@@ -46,7 +46,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 
 using namespace ICO_pvt;
 
-class ICOInput : public ImageInput {
+class ICOInput final : public ImageInput {
 public:
     ICOInput () { init(); }
     virtual ~ICOInput () { close(); }

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -47,7 +47,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 
 using namespace ICO_pvt;
 
-class ICOOutput : public ImageOutput {
+class ICOOutput final : public ImageOutput {
 public:
     ICOOutput ();
     virtual ~ICOOutput ();

--- a/src/iff.imageio/iff_pvt.h
+++ b/src/iff.imageio/iff_pvt.h
@@ -135,7 +135,7 @@ namespace iff_pvt {
 
 
 
-class IffInput : public ImageInput {
+class IffInput final : public ImageInput {
 public:
     IffInput () { init(); }
     virtual ~IffInput () { close(); }
@@ -205,7 +205,7 @@ private:
 
 
 
-class IffOutput : public ImageOutput {
+class IffOutput final : public ImageOutput {
 public:
     IffOutput () { init (); }
     virtual ~IffOutput () { close (); }

--- a/src/include/OpenImageIO/dassert.h
+++ b/src/include/OpenImageIO/dassert.h
@@ -96,7 +96,7 @@
 # define DASSERT(x) ASSERT(x)
 #else
  /* DASSERT does nothing when not debugging; sizeof trick prevents warnings */
-# define DASSERT(x) ((void)sizeof(x))
+# define DASSERT(x) ((void)sizeof(x)) /*NOLINT*/
 #endif
 
 /// DASSERT_MSG(condition,msg,...) is just like ASSERT_MSG, except that it
@@ -105,7 +105,8 @@
 #ifndef NDEBUG
 # define DASSERT_MSG ASSERT_MSG
 #else
-# define DASSERT_MSG(x,...) ((void)sizeof(x)) /* does nothing when not debugging */
+ /* does nothing when not debugging */
+# define DASSERT_MSG(x,...) ((void)sizeof(x)) /*NOLINT*/
 #endif
 
 #ifndef DASSERTMSG

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -733,7 +733,7 @@ public:
     class IteratorBase {
     public:
         IteratorBase (const ImageBuf &ib, WrapMode wrap)
-            : m_ib(&ib), m_tile(NULL), m_proxydata(NULL)
+            : m_ib(&ib)
         {
             init_ib (wrap);
             range_is_image ();
@@ -741,7 +741,7 @@ public:
 
         /// Construct valid iteration region from ImageBuf and ROI.
         IteratorBase (const ImageBuf &ib, const ROI &roi, WrapMode wrap)
-            : m_ib(&ib), m_tile(NULL), m_proxydata(NULL)
+            : m_ib(&ib)
         {
             init_ib (wrap);
             if (roi.defined()) {
@@ -761,7 +761,7 @@ public:
         IteratorBase (const ImageBuf &ib, int xbegin, int xend,
                       int ybegin, int yend, int zbegin, int zend,
                       WrapMode wrap)
-            : m_ib(&ib), m_tile(NULL), m_proxydata(NULL)
+            : m_ib(&ib)
         {
             init_ib (wrap);
             m_rng_xbegin = xbegin;
@@ -777,7 +777,7 @@ public:
               m_rng_xbegin(i.m_rng_xbegin), m_rng_xend(i.m_rng_xend), 
               m_rng_ybegin(i.m_rng_ybegin), m_rng_yend(i.m_rng_yend),
               m_rng_zbegin(i.m_rng_zbegin), m_rng_zend(i.m_rng_zend),
-              m_tile(NULL), m_proxydata(i.m_proxydata)
+              m_proxydata(i.m_proxydata)
         {
             init_ib (i.m_wrap);
         }
@@ -956,10 +956,10 @@ public:
     protected:
         friend class ImageBuf;
         friend class ImageBufImpl;
-        const ImageBuf *m_ib;
-        bool m_valid, m_exists;
-        bool m_deep;
-        bool m_localpixels;
+        const ImageBuf *m_ib = nullptr;
+        bool m_valid = false, m_exists = false;
+        bool m_deep = false;
+        bool m_localpixels = false;
         // Image boundaries
         int m_img_xbegin, m_img_xend, m_img_ybegin, m_img_yend,
             m_img_zbegin, m_img_zend;
@@ -967,13 +967,13 @@ public:
         int m_rng_xbegin, m_rng_xend, m_rng_ybegin, m_rng_yend,
             m_rng_zbegin, m_rng_zend;
         int m_x, m_y, m_z;
-        ImageCache::Tile *m_tile;
+        ImageCache::Tile *m_tile = nullptr;
         int m_tilexbegin, m_tileybegin, m_tilezbegin;
         int m_tilexend;
         int m_nchannels;
         size_t m_pixel_bytes;
-        char *m_proxydata;
-        WrapMode m_wrap;
+        char *m_proxydata = nullptr;
+        WrapMode m_wrap = WrapBlack;
 
         // Helper called by ctrs -- set up some locally cached values
         // that are copied or derived from the ImageBuf.

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -171,18 +171,24 @@
 #endif
 
 // Tests for MSVS versions, always 0 if not MSVS at all.
-#define OIIO_MSVS_AT_LEAST_2013 (defined(_MSC_VER) && _MSC_VER >= 1800)
-#define OIIO_MSVS_BEFORE_2013   (defined(_MSC_VER) && _MSC_VER <  1800)
-#define OIIO_MSVS_AT_LEAST_2015 (defined(_MSC_VER) && _MSC_VER >= 1900)
-#define OIIO_MSVS_BEFORE_2015   (defined(_MSC_VER) && _MSC_VER <  1900)
-
+#if defined(_MSC_VER)
+#  define OIIO_MSVS_AT_LEAST_2013 (_MSC_VER >= 1800)
+#  define OIIO_MSVS_BEFORE_2013   (_MSC_VER <  1800)
+#  define OIIO_MSVS_AT_LEAST_2015 (_MSC_VER >= 1900)
+#  define OIIO_MSVS_BEFORE_2015   (_MSC_VER <  1900)
+#else
+#  define OIIO_MSVS_AT_LEAST_2013 0
+#  define OIIO_MSVS_BEFORE_2013   0
+#  define OIIO_MSVS_AT_LEAST_2015 0
+#  define OIIO_MSVS_BEFORE_2015   0
+#endif
 
 
 /// allocates memory, equivalent of C99 type var_name[size]
-#define OIIO_ALLOCA(type, size) ((type*)alloca((size) * sizeof (type)))
+#define OIIO_ALLOCA(type, size) ((size) ? ((type*)alloca((size) * sizeof (type))) : nullptr)
 
 /// Deprecated (for namespace pollution reasons)
-#define ALLOCA(type, size) ((type*)alloca((size) * sizeof (type)))
+#define ALLOCA(type, size) ((size) ? ((type*)alloca((size) * sizeof (type))) : nullptr)
 
 
 // Define a macro that can be used for memory alignment.

--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -69,7 +69,7 @@ static const int JPEG_420_COMP[6] = {2,2, 1,1, 1,1};
 static const int JPEG_411_COMP[6] = {4,1, 1,1, 1,1};
 
 
-class JpgInput : public ImageInput {
+class JpgInput final : public ImageInput {
  public:
     JpgInput () { init(); }
     virtual ~JpgInput () { close(); }

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -51,7 +51,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 
 
 
-class JpgOutput : public ImageOutput {
+class JpgOutput final : public ImageOutput {
  public:
     JpgOutput () { init(); }
     virtual ~JpgOutput () { close(); }

--- a/src/jpeg2000.imageio/jpeg2000input-v1.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input-v1.cpp
@@ -81,7 +81,7 @@ associateAlpha (T * data, int size, int channels, int alpha_channel, float gamma
 }  // namespace
 
 
-class Jpeg2000Input : public ImageInput {
+class Jpeg2000Input final : public ImageInput {
  public:
     Jpeg2000Input () { init (); }
     virtual ~Jpeg2000Input () { close (); }

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -97,7 +97,7 @@ associateAlpha (T * data, int size, int channels, int alpha_channel, float gamma
 }  // namespace
 
 
-class Jpeg2000Input : public ImageInput {
+class Jpeg2000Input final : public ImageInput {
  public:
     Jpeg2000Input () { init (); }
     virtual ~Jpeg2000Input () { close (); }

--- a/src/jpeg2000.imageio/jpeg2000output-v1.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output-v1.cpp
@@ -38,7 +38,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 
 static void openjpeg_dummy_callback(const char*, void*) {}
 
-class Jpeg2000Output : public ImageOutput {
+class Jpeg2000Output final : public ImageOutput {
  public:
     Jpeg2000Output () { init (); }
     virtual ~Jpeg2000Output () { close (); }

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -55,7 +55,7 @@ openjpeg_dummy_callback(const char *msg, void *data)
 
 
 
-class Jpeg2000Output : public ImageOutput {
+class Jpeg2000Output final : public ImageOutput {
  public:
     Jpeg2000Output () { init (); }
     virtual ~Jpeg2000Output () { close (); }

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -90,6 +90,7 @@ ImageBufAlgo::IBAprep (ROI &roi, ImageBuf *dst, const ImageBuf *A,
                        const ImageBuf *B, const ImageBuf *C,
                        ImageSpec *force_spec, int prepflags)
 {
+    ASSERT (dst);
     if ((A && !A->initialized()) ||
         (B && !B->initialized()) ||
         (C && !C->initialized())) {

--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -1499,7 +1499,6 @@ decode_over_channels (const ImageBuf &R, int &nchannels,
     if (! has_alpha && colors == 4) {
         // No marked alpha channel, but suspiciously 4 channel -- assume
         // it's RGBA. 
-        has_alpha = true;
         colors -= 1;
         // Assume alpha is the highest channel that's not z
         alpha = nchannels - 1;

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -428,8 +428,8 @@ TextureSystemImpl::environment (TextureHandle *texture_handle_,
         minorlength = xfilt;
     }
 
-    sampler_prototype sampler;
-    long long *probecount;
+    sampler_prototype sampler = nullptr;
+    long long *probecount = nullptr;
     switch (options.interpmode) {
     case TextureOpt::InterpClosest :
         sampler = &TextureSystemImpl::sample_closest;
@@ -444,9 +444,7 @@ TextureSystemImpl::environment (TextureHandle *texture_handle_,
         probecount = &stats.cubic_interps;
         break;
     default:
-        sampler = NULL;
-        probecount = NULL;
-        break;
+        return false;
     }
 
     TextureOpt::MipMode mipmode = options.mipmode;

--- a/src/libutil/SHA1.cpp
+++ b/src/libutil/SHA1.cpp
@@ -152,7 +152,7 @@ void CSHA1::Transform(UINT_32* pState, const UINT_8* pBuffer)
 
 	// Wipe variables
 #ifdef SHA1_WIPE_VARIABLES
-	a = b = c = d = e = 0;
+	a = b = c = d = e = 0;   // NOLINT
 #endif
 }
 

--- a/src/libutil/argparse.cpp
+++ b/src/libutil/argparse.cpp
@@ -155,8 +155,6 @@ ArgOption::initialize()
             // Parse the scanf-like parameters
 
             m_type = Regular;
-    
-            n = (m_format.length() - n) / 2;       // conservative estimate
             m_code.clear ();
     
             while (*s != '\0') {

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -159,7 +159,7 @@ void test_convert_type (double tolerance = 1e-6)
             }
         }
     } else {
-        for (float i = 0.0f; i <= 1.0f;  i += 0.001) {
+        for (float i = 0.0f; i <= 1.0f;  i += 0.001) {   // NOLINT
             T in = (T)i;
             F f = convert_type<T,F> (in);
             T out = convert_type<F,T> (f);

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -708,10 +708,8 @@ Strutil::parse_string (string_view &str, string_view &val,
             break;   // not quoted and we hit whitespace: we're done
         if (quoted && *end == '\"' && ! escaped)
             break;   // closing quite -- we're done (beware embedded quote)
-        if (p[0] == '\\')
-            escaped = true;
+        escaped = (p[0] == '\\');
         ++end;
-        escaped = false;
     }
     if (quoted && keep_quotes == KeepQuotes) {
         if (*end == '\"')

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -54,7 +54,7 @@ TypeDesc::TypeDesc (string_view typestring)
 
 namespace {
 
-static int basetype_size[] = {
+static int basetype_size[TypeDesc::LASTBASE] = {
     0, // UNKNOWN
     0, // VOID
     sizeof(unsigned char),   // UCHAR
@@ -77,7 +77,6 @@ static int basetype_size[] = {
 size_t
 TypeDesc::basesize () const
 {
-    DASSERT (sizeof(basetype_size)/sizeof(basetype_size[0]) == TypeDesc::LASTBASE);
     DASSERT (basetype < TypeDesc::LASTBASE);
     return basetype_size[basetype];
 }
@@ -87,7 +86,7 @@ TypeDesc::basesize () const
 bool
 TypeDesc::is_floating_point () const
 {
-    static bool isfloat[] = {
+    static bool isfloat[TypeDesc::LASTBASE] = {
         0, // UNKNOWN
         0, // VOID
         0, // UCHAR
@@ -104,7 +103,6 @@ TypeDesc::is_floating_point () const
         0, // STRING
         0  // PTR
     };
-    DASSERT (sizeof(isfloat)/sizeof(isfloat[0]) == TypeDesc::LASTBASE);
     DASSERT (basetype < TypeDesc::LASTBASE);
     return isfloat[basetype];
 }
@@ -114,7 +112,7 @@ TypeDesc::is_floating_point () const
 bool
 TypeDesc::is_signed () const
 {
-    static bool issigned[] = {
+    static bool issigned[TypeDesc::LASTBASE] = {
         0, // UNKNOWN
         0, // VOID
         0, // UCHAR
@@ -131,7 +129,6 @@ TypeDesc::is_signed () const
         0, // STRING
         0  // PTR
     };
-    DASSERT (sizeof(issigned)/sizeof(issigned[0]) == TypeDesc::LASTBASE);
     DASSERT (basetype < TypeDesc::LASTBASE);
     return issigned[basetype];
 }

--- a/src/libutil/ustring.cpp
+++ b/src/libutil/ustring.cpp
@@ -182,14 +182,14 @@ private:
         return result;
     }
 
-    OIIO_CACHE_ALIGN ustring_mutex_t mutex;
     size_t mask;
     ustring::TableRep** entries;
     size_t num_entries;
     char* pool;
     size_t pool_offset;
     size_t memory_usage;
-    OIIO_CACHE_ALIGN size_t num_lookups;
+    size_t num_lookups;
+    ustring_mutex_t mutex;
 };
 
 #if 0

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -131,14 +131,6 @@ static Oiiotool ot;
 
 
 Oiiotool::Oiiotool ()
-    : imagecache(NULL),
-      return_value (EXIT_SUCCESS),
-      total_readtime (Timer::DontStartNow),
-      total_writetime (Timer::DontStartNow),
-      total_imagecache_readtime (0.0),
-      enable_function_timing(true),
-      peak_memory(0),
-      num_outputs(0), printed_info(false), frame_number(0)
 {
     clear_options ();
 }
@@ -2877,7 +2869,6 @@ action_pattern (int argc, const char *argv[])
         ot.extract_options (options, pattern);
         std::string type = options["type"];
         float A = 0, B = 1;
-        bool ok = true;
         if (type == "gaussian") {
             A = Strutil::from_string<float> (options["mean"]);
             B = Strutil::from_string<float> (options["stddev"]);
@@ -3430,7 +3421,6 @@ action_pixelaspect (int argc, const char *argv[])
         const char *newargv[2] = { command.c_str(), resize.c_str() };
         action_resize (2, newargv);
         A = ot.top ();
-        Aspec = A->spec(0,0);
         A->spec(0,0)->full_width = (*A)(0,0).specmod().full_width = scale_full_width;
         A->spec(0,0)->full_height = (*A)(0,0).specmod().full_height = scale_full_height;
         A->spec(0,0)->attribute ("PixelAspectRatio", new_paspect);

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -80,6 +80,7 @@ public:
     bool autoorient;
     bool autocc;                      // automatically color correct
     bool nativeread;                  // force native data type reads
+    bool printinfo_verbose;
     int cachesize;
     int autotile;
     int frame_padding;
@@ -87,20 +88,18 @@ public:
     std::string printinfo_metamatch;
     std::string printinfo_nometamatch;
     std::string printinfo_format;
-    bool printinfo_verbose;
     ImageSpec input_config;           // configuration options for reading
-    bool input_config_set;
     std::string input_channel_set;    // Optional input channel set
 
     // Output options
     TypeDesc output_dataformat;
     std::map<std::string,std::string> output_channelformats;
-    int output_bitspersample;
-    bool output_scanline;
-    int output_tilewidth, output_tileheight;
     std::string output_compression;
-    int output_quality;
     std::string output_planarconfig;
+    int output_bitspersample;
+    int output_tilewidth, output_tileheight;
+    int output_quality;
+    bool output_scanline;
     bool output_adjust_time;
     bool output_autocrop;
     bool output_autotrim;
@@ -120,20 +119,21 @@ public:
     ImageRecRef curimg;                      // current image
     std::vector<ImageRecRef> image_stack;    // stack of previous images
     std::map<std::string, ImageRecRef> image_labels; // labeled images
-    ImageCache *imagecache;                  // back ptr to ImageCache
-    int return_value;                        // oiiotool command return code
+    ImageCache *imagecache = nullptr;        // back ptr to ImageCache
     ColorConfig colorconfig;                 // OCIO color config
     Timer total_runtime;
-    Timer total_readtime;
-    Timer total_writetime;
-    double total_imagecache_readtime;
+    Timer total_readtime  {Timer::DontStartNow};
+    Timer total_writetime {Timer::DontStartNow};
+    double total_imagecache_readtime = 0.0;
     typedef std::map<std::string, double> TimingMap;
     TimingMap function_times;
-    bool enable_function_timing;
-    size_t peak_memory;
-    int num_outputs;                         // Count of outputs written
-    bool printed_info;                       // printed info at some point
-    int frame_number;
+    size_t peak_memory = 0;
+    int return_value = EXIT_SUCCESS;         // oiiotool command return code
+    int num_outputs = 0;                     // Count of outputs written
+    int frame_number = 0;
+    bool enable_function_timing = true;
+    bool input_config_set = false;
+    bool printed_info = false;               // printed info at some point
 
     Oiiotool ();
 

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -143,7 +143,7 @@ private:
 
 
 
-class OpenEXRInput : public ImageInput {
+class OpenEXRInput final : public ImageInput {
 public:
     OpenEXRInput ();
     virtual ~OpenEXRInput () { close(); }

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -133,7 +133,7 @@ private:
 
 
 
-class OpenEXROutput : public ImageOutput {
+class OpenEXROutput final : public ImageOutput {
 public:
     OpenEXROutput ();
     virtual ~OpenEXROutput ();

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -39,7 +39,7 @@
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
 
-class PNGInput : public ImageInput {
+class PNGInput final : public ImageInput {
 public:
     PNGInput () { init(); }
     virtual ~PNGInput () { close(); }

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -40,7 +40,7 @@
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
 
-class PNGOutput : public ImageOutput {
+class PNGOutput final : public ImageOutput {
 public:
     PNGOutput ();
     virtual ~PNGOutput ();

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -38,7 +38,7 @@
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
-class PNMInput : public ImageInput {
+class PNMInput final : public ImageInput {
 public:
     PNMInput() { }
     virtual ~PNMInput() { close(); }

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -36,7 +36,7 @@
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
 
-class PNMOutput : public ImageOutput {
+class PNMOutput final : public ImageOutput {
 public:
     virtual ~PNMOutput ();
     virtual const char * format_name (void) const { return "pnm"; }

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -43,7 +43,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 using namespace psd_pvt;
 
 
-class PSDInput : public ImageInput {
+class PSDInput final : public ImageInput {
 public:
     PSDInput ();
     virtual ~PSDInput () { close(); }

--- a/src/ptex.imageio/ptexinput.cpp
+++ b/src/ptex.imageio/ptexinput.cpp
@@ -38,7 +38,7 @@
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
 
-class PtexInput : public ImageInput {
+class PtexInput final : public ImageInput {
 public:
     PtexInput () : m_ptex(NULL) { init(); }
     virtual ~PtexInput () { close(); }

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -44,7 +44,7 @@
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
-class RawInput : public ImageInput {
+class RawInput final : public ImageInput {
 public:
     RawInput () : m_process(true), m_image(NULL) {}
     virtual ~RawInput() { close(); }

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -46,7 +46,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 using namespace RLA_pvt;
 
 
-class RLAInput : public ImageInput {
+class RLAInput final : public ImageInput {
 public:
     RLAInput () { init(); }
     virtual ~RLAInput () { close(); }

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -53,7 +53,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 using namespace RLA_pvt;
 
 
-class RLAOutput : public ImageOutput {
+class RLAOutput final : public ImageOutput {
 public:
     RLAOutput ();
     virtual ~RLAOutput ();

--- a/src/sgi.imageio/sgi_pvt.h
+++ b/src/sgi.imageio/sgi_pvt.h
@@ -87,7 +87,7 @@ namespace sgi_pvt {
 
 
 
-class SgiInput : public ImageInput {
+class SgiInput final : public ImageInput {
  public:
     SgiInput () { init(); }
     virtual ~SgiInput () { close(); }
@@ -136,7 +136,7 @@ class SgiInput : public ImageInput {
 
 
 
-class SgiOutput : public ImageOutput {
+class SgiOutput final : public ImageOutput {
  public:
     SgiOutput () : m_fd(NULL) { }
     virtual ~SgiOutput () { close(); }

--- a/src/socket.imageio/socket_pvt.h
+++ b/src/socket.imageio/socket_pvt.h
@@ -59,7 +59,7 @@ using namespace boost::asio;
 
 
 
-class SocketOutput : public ImageOutput {
+class SocketOutput final : public ImageOutput {
  public:
     SocketOutput ();
     virtual ~SocketOutput () { close(); }
@@ -87,7 +87,7 @@ class SocketOutput : public ImageOutput {
 
 
 
-class SocketInput : public ImageInput {
+class SocketInput final : public ImageInput {
  public:
     SocketInput ();
     virtual ~SocketInput () { close(); }

--- a/src/softimage.imageio/softimageinput.cpp
+++ b/src/softimage.imageio/softimageinput.cpp
@@ -39,7 +39,7 @@ using namespace softimage_pvt;
 
 
 
-class SoftimageInput : public ImageInput
+class SoftimageInput final : public ImageInput
 {
 public:
     SoftimageInput() {

--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -46,7 +46,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 using namespace TGA_pvt;
 
 
-class TGAInput : public ImageInput {
+class TGAInput final : public ImageInput {
 public:
     TGAInput () { init(); }
     virtual ~TGAInput () { close(); }

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -46,7 +46,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 using namespace TGA_pvt;
 
 
-class TGAOutput : public ImageOutput {
+class TGAOutput final : public ImageOutput {
 public:
     TGAOutput ();
     virtual ~TGAOutput ();

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -977,7 +977,7 @@ launch_tex_threads (int numthreads, int iterations)
 
 
 
-class GridImageInput : public ImageInput {
+class GridImageInput final : public ImageInput {
 public:
     GridImageInput () : m_miplevel(-1) { }
     virtual ~GridImageInput () { close(); }

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -102,7 +102,7 @@ struct TIFF_tag_info {
 
 
 
-class TIFFInput : public ImageInput {
+class TIFFInput final : public ImageInput {
 public:
     TIFFInput ();
     virtual ~TIFFInput ();

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -68,7 +68,7 @@ namespace
     static int MIN_SCANLINES_OR_TILES_PER_CHECKPOINT = 64;
 }
 
-class TIFFOutput : public ImageOutput {
+class TIFFOutput final : public ImageOutput {
 public:
     TIFFOutput ();
     virtual ~TIFFOutput ();

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -38,7 +38,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 namespace webp_pvt {
 
 
-class WebpInput : public ImageInput
+class WebpInput final : public ImageInput
 {
  public:
     WebpInput() { init(); }

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -37,7 +37,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 namespace webp_pvt {
 
 
-class WebpOutput : public ImageOutput
+class WebpOutput final : public ImageOutput
 {
  public:
     WebpOutput(){ init(); }

--- a/src/zfile.imageio/zfile.cpp
+++ b/src/zfile.imageio/zfile.cpp
@@ -62,7 +62,7 @@ static const int zfile_magic_endian = 0xab67082f;  // other endianness
 
 
 
-class ZfileInput : public ImageInput {
+class ZfileInput final : public ImageInput {
 public:
     ZfileInput () { init(); }
     virtual ~ZfileInput () { close(); }
@@ -88,7 +88,7 @@ private:
 
 
 
-class ZfileOutput : public ImageOutput {
+class ZfileOutput final : public ImageOutput {
 public:
     ZfileOutput () { init(); }
     virtual ~ZfileOutput () { close(); }


### PR DESCRIPTION
Some notable/interesting fixes:

* Marking of ImageInput/ImageOutput subclasses as `final` fixes a no-no that I had overlooked, which is that we usually called close() from within the class destructors. But it's virtual, and it's generally considered unsafe to call a virtual function within a destructor (unless it's a final class) because it might not end up being the version for that level of the class hierarchy.

* alloca(0) has undefined behavior, so we change the OIIO_ALLOCA macros to detect that case and return NULL rather than blindly calling alloca(0).

* Calling defined() within a macro definition itself is apparently not guaranteed to work with all compilers (though in practice it seems ok). 

* I'm starting to favor the idiom of specifying the default initializers of non-static struct/class data members in their declaration, rather than in long lists of initializers in the constructors themselves. It's a compact notation, removes redundancy (or inadvertent mismatches) when you have multiple constructors, and if you rearrange structure member ordering, you don't have to chase down the warnings about initializer lists being in the wrong order.





