### PR TITLE
Support (and minor fixes) for building with clang 5.0

### DIFF
--- a/site/spi/Makefile-bits-arnold
+++ b/site/spi/Makefile-bits-arnold
@@ -57,25 +57,15 @@ ifeq ($(SP_OS), rhel7)
 
     ## If not overridden, here is our preferred LLVM installation
     ## (may be changed as new versions are rolled out to the facility)
-    LLVM_DIRECTORY ?= /shots/spi/home/lib/arnold/rhel7/llvm_4.0_final/
+    LLVM_DIRECTORY ?= /shots/spi/home/lib/arnold/rhel7/llvm_4.0_final
 
     # A variety of tags can be used to try specific versions of gcc or
     # clang from the site-specific places we have installed them.
-    ifeq (${COMPILER}, clang342)
-        MY_CMAKE_FLAGS += \
-           -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/spinux1/llvm_3.4.2/bin/clang \
-           -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/spinux1/llvm_3.4.2/bin/clang++
-    else ifeq (${COMPILER}, clang35)
-        MY_CMAKE_FLAGS += \
-           -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/spinux1/llvm_3.5/bin/clang \
-           -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/spinux1/llvm_3.5/bin/clang++
-    else ifeq (${COMPILER},clang38)
-        MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang-3.8 -DCMAKE_CXX_COMPILER=clang++-3.8
-    else ifeq (${COMPILER},clang39)
-	LLVM_DIRECTORY := /shots/spi/home/lib/arnold/rhel7/llvm_3.9
+    ifeq (${COMPILER},clang4)
+	LLVM_DIRECTORY := /shots/spi/home/lib/arnold/rhel7/llvm_4.0_final
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
-    else ifeq (${COMPILER},clang40)
-	LLVM_DIRECTORY := /shots/spi/home/lib/arnold/rhel7/llvm_4.0
+    else ifeq (${COMPILER},clang5)
+	LLVM_DIRECTORY := /shots/spi/home/lib/arnold/rhel7/llvm_5.0_RC2
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
     else ifeq (${COMPILER},clang)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++

--- a/site/spi/Makefile-bits-spcomp2
+++ b/site/spi/Makefile-bits-spcomp2
@@ -101,21 +101,11 @@ ifeq ($(SP_OS), rhel7)
 
     # A variety of tags can be used to try specific versions of gcc or
     # clang from the site-specific places we have installed them.
-    ifeq (${COMPILER}, clang342)
-        MY_CMAKE_FLAGS += \
-           -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/spinux1/llvm_3.4.2/bin/clang \
-           -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/spinux1/llvm_3.4.2/bin/clang++
-    else ifeq (${COMPILER}, clang35)
-        MY_CMAKE_FLAGS += \
-           -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/spinux1/llvm_3.5/bin/clang \
-           -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/spinux1/llvm_3.5/bin/clang++
-    else ifeq (${COMPILER},clang38)
-        MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang-3.8 -DCMAKE_CXX_COMPILER=clang++-3.8
-    else ifeq (${COMPILER},clang39)
-	LLVM_DIRECTORY := /shots/spi/home/lib/arnold/rhel7/llvm_3.9
+    ifeq (${COMPILER},clang4)
+	LLVM_DIRECTORY := /shots/spi/home/lib/arnold/rhel7/llvm_4.0_final
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
-    else ifeq (${COMPILER},clang40)
-	LLVM_DIRECTORY := /shots/spi/home/lib/arnold/rhel7/llvm_4.0
+    else ifeq (${COMPILER},clang5)
+	LLVM_DIRECTORY := /shots/spi/home/lib/arnold/rhel7/llvm_5.0
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
     else ifeq (${COMPILER},clang)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++

--- a/src/nuke/txReader/CMakeLists.txt
+++ b/src/nuke/txReader/CMakeLists.txt
@@ -1,6 +1,11 @@
 include_directories (${NUKE_INCLUDE_DIRS})
 link_directories (${NUKE_LIBRARY_DIRS})
 
+# Ignore Nuke 10's use of deprecated auto_ptr
+if (NOT MSVC)
+    set_source_files_properties (txReader.cpp PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
+endif ()
+
 add_library (txReader SHARED
     txReader.cpp)
 

--- a/src/nuke/txWriter/CMakeLists.txt
+++ b/src/nuke/txWriter/CMakeLists.txt
@@ -1,6 +1,11 @@
 include_directories (${NUKE_INCLUDE_DIRS})
 link_directories (${NUKE_LIBRARY_DIRS})
 
+# Ignore Nuke 10's use of deprecated auto_ptr
+if (NOT MSVC)
+    set_source_files_properties (txWriter.cpp PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
+endif ()
+
 add_library (txWriter SHARED
     txWriter.cpp)
 


### PR DESCRIPTION
The most important bit is to disable warnings about deprecated auto_ptr in the Nuke 10 headers.
