### PR TITLE
oiio/master: Use GNUInstallDirs for installation paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,8 @@ if (CMAKE_USE_FOLDERS)
     set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 endif ()
 
+include (GNUInstallDirs)
+
 set (CMAKE_MODULE_PATH
      "${PROJECT_SOURCE_DIR}/src/cmake/modules"
      "${PROJECT_SOURCE_DIR}/src/cmake")
@@ -193,7 +195,9 @@ if (USE_PYTHON3 AND boost_PYTHON_FOUND AND NOT BUILD_OIIOUTIL_ONLY)
 endif ()
 
 add_subdirectory (src/include)
-add_subdirectory (src/doc)
+if (INSTALL_DOCS)
+    add_subdirectory (src/doc)
+endif ()
 add_subdirectory (src/fonts)
 add_subdirectory (src/nuke)
 

--- a/src/cmake/install.cmake
+++ b/src/cmake/install.cmake
@@ -1,56 +1,30 @@
 ###########################################################################
-# Paths for install tree customization.  Note that relative paths are relative
-# to CMAKE_INSTALL_PREFIX.
-set (DEFAULT_BIN_INSTALL_DIR   "bin")
-set (DEFAULT_LIB_INSTALL_DIR   "lib")
-set (DEFAULT_INCLUDE_INSTALL_DIR "include/${PROJECT_NAME}")
+# Set install paths for the python modules
+# TODO: Figure out how to get the correct python directory
+
 if (UNIX AND NOT SELF_CONTAINED_INSTALL_TREE)
-    # Try to be well-behaved and install into reasonable places according to
-    # the "standard" unix directory heirarchy
     # TODO: Figure out how to get the correct python directory
-    set (DEFAULT_PYLIB_INSTALL_DIR "lib/python${PYTHONLIBS_VERSION_MAJOR}.${PYTHONLIBS_VERSION_MINOR}/site-packages")
-    set (DEFAULT_PYLIB3_INSTALL_DIR "lib/python3/site-packages")
-    set (DEFAULT_DOC_INSTALL_DIR "share/doc/${PROJECT_NAME}")
-    set (DEFAULT_MAN_INSTALL_DIR "share/man/man1")
-    set (DEFAULT_FONTS_INSTALL_DIR "share/fonts/${PROJECT_NAME}")
+    set (DEFAULT_PYLIB_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/python/site-packages")
+    set (DEFAULT_PYLIB3_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/python3/site-packages")
 else ()
     # Here is the "self-contained install tree" case: the expectation here
     # is that everything related to this project will go into its own
     # directory, not into some standard system heirarchy.
     set (DEFAULT_PYLIB_INSTALL_DIR "python")
     set (DEFAULT_PYLIB3_INSTALL_DIR "python3")
-    set (DEFAULT_DOC_INSTALL_DIR "doc")
-    set (DEFAULT_MAN_INSTALL_DIR "doc/man")
-    set (DEFAULT_FONTS_INSTALL_DIR "fonts/${PROJECT_NAME}")
 endif ()
 if (EXEC_INSTALL_PREFIX)
     # Tack on an extra prefix to support multi-arch builds.
-    set (DEFAULT_BIN_INSTALL_DIR   "${EXEC_INSTALL_PREFIX}/${DEFAULT_BIN_INSTALL_DIR}")
-    set (DEFAULT_LIB_INSTALL_DIR   "${EXEC_INSTALL_PREFIX}/${DEFAULT_LIB_INSTALL_DIR}")
     set (DEFAULT_PYLIB_INSTALL_DIR "${EXEC_INSTALL_PREFIX}/${DEFAULT_PYLIB_INSTALL_DIR}")
     set (DEFAULT_PYLIB3_INSTALL_DIR "${EXEC_INSTALL_PREFIX}/${DEFAULT_PYLIB3_INSTALL_DIR}")
-    set (DEFAULT_FONTS_INSTALL_DIR "${EXEC_INSTALL_PREFIX}/${DEFAULT_FONTS_INSTALL_DIR}")
 endif ()
 # Set up cmake cache variables corresponding to the defaults deduced above, so
 # that the user can override them as desired:
-set (BIN_INSTALL_DIR ${DEFAULT_BIN_INSTALL_DIR} CACHE STRING
-     "Install location for binaries (relative to CMAKE_INSTALL_PREFIX or absolute)")
-set (LIB_INSTALL_DIR ${DEFAULT_LIB_INSTALL_DIR} CACHE STRING
-     "Install location for libraries (relative to CMAKE_INSTALL_PREFIX or absolute)")
 set (PYLIB_INSTALL_DIR ${DEFAULT_PYLIB_INSTALL_DIR} CACHE STRING
      "Install location for python libraries (relative to CMAKE_INSTALL_PREFIX or absolute)")
 set (PYLIB3_INSTALL_DIR ${DEFAULT_PYLIB3_INSTALL_DIR} CACHE STRING
      "Install location for python3 libraries (relative to CMAKE_INSTALL_PREFIX or absolute)")
-set (INCLUDE_INSTALL_DIR ${DEFAULT_INCLUDE_INSTALL_DIR} CACHE STRING
-     "Install location of header files (relative to CMAKE_INSTALL_PREFIX or absolute)")
-set (DOC_INSTALL_DIR ${DEFAULT_DOC_INSTALL_DIR} CACHE STRING
-     "Install location for documentation (relative to CMAKE_INSTALL_PREFIX or absolute)")
-set (FONTS_INSTALL_DIR ${DEFAULT_FONTS_INSTALL_DIR} CACHE STRING
-     "Install location for fonts (relative to CMAKE_INSTALL_PREFIX or absolute)")
-if (UNIX)
-    set (MAN_INSTALL_DIR ${DEFAULT_MAN_INSTALL_DIR} CACHE STRING
-         "Install location for manual pages (relative to CMAKE_INSTALL_PREFIX or absolute)")
-endif()
+
 set (PLUGIN_SEARCH_PATH "" CACHE STRING "Default plugin search path")
 
 set (INSTALL_DOCS ON CACHE BOOL "Install documentation")
@@ -69,10 +43,7 @@ if (CMAKE_SKIP_RPATH)
     set (CMAKE_SKIP_RPATH FALSE)
     unset (CMAKE_INSTALL_RPATH)
 else ()
-    set (CMAKE_INSTALL_RPATH "${LIB_INSTALL_DIR}")
-    if (NOT IS_ABSOLUTE ${CMAKE_INSTALL_RPATH})
-        set (CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}")
-    endif ()
+    set (CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
     # add the automatically determined parts of the RPATH that
     # point to directories outside the build tree to the install RPATH
     set (CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
@@ -80,20 +51,3 @@ else ()
         message (STATUS "CMAKE_INSTALL_RPATH = ${CMAKE_INSTALL_RPATH}")
     endif ()
 endif ()
-
-
-
-# Macro to install targets to the appropriate locations.  Use this instead of
-# the install(TARGETS ...) signature.
-#
-# Usage:
-#
-#    install_targets (target1 [target2 ...])
-#
-macro (install_targets)
-    install (TARGETS ${ARGN}
-             RUNTIME DESTINATION "${BIN_INSTALL_DIR}" COMPONENT user
-             LIBRARY DESTINATION "${LIB_INSTALL_DIR}" COMPONENT user
-             ARCHIVE DESTINATION "${LIB_INSTALL_DIR}" COMPONENT developer)
-endmacro ()
-

--- a/src/cmake/oiio_macros.cmake
+++ b/src/cmake/oiio_macros.cmake
@@ -7,9 +7,9 @@
 #
 macro (oiio_install_targets)
     install (TARGETS ${ARGN}
-             RUNTIME DESTINATION "${BIN_INSTALL_DIR}" COMPONENT user
-             LIBRARY DESTINATION "${LIB_INSTALL_DIR}" COMPONENT user
-             ARCHIVE DESTINATION "${LIB_INSTALL_DIR}" COMPONENT developer)
+             RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT user
+             LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT user
+             ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT developer)
 endmacro ()
 
 # Macro to add a build target for an IO plugin.

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -6,10 +6,10 @@ set (public_docs
      "${OpenImageIO_SOURCE_DIR}/CHANGES.md"
 )
 
-if (INSTALL_DOCS)
-    install (FILES ${public_docs} DESTINATION ${DOC_INSTALL_DIR}
-             COMPONENT documentation)
-endif ()
+install (FILES ${public_docs}
+         DESTINATION ${CMAKE_INSTALL_DOCDIR}
+         COMPONENT documentation)
+
 
 # generate man pages using txt2man and a tiny python script to munge the
 # result of "$tool --help"
@@ -37,8 +37,7 @@ if (UNIX AND TXT2MAN AND PYTHONINTERP_FOUND)
     # force man page build before install
     add_custom_target (man_pages ALL DEPENDS ${manpage_files})
 
-    if (INSTALL_DOCS)
-        install (FILES ${manpage_files}
-                 DESTINATION ${MAN_INSTALL_DIR} COMPONENT documentation)
-    endif ()
+    install (FILES ${manpage_files}
+             DESTINATION ${CMAKE_INSTALL_MANDIR}
+             COMPONENT documentation)
 endif()

--- a/src/fonts/CMakeLists.txt
+++ b/src/fonts/CMakeLists.txt
@@ -1,7 +1,8 @@
 file (GLOB public_fonts "*/*.ttf")
 
 if (INSTALL_FONTS AND USE_FREETYPE)
-    install (FILES ${public_fonts} DESTINATION ${FONTS_INSTALL_DIR}
+    install (FILES ${public_fonts}
+             DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/fonts/OpenImageIO
              COMPONENT fonts)
 endif ()
 

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -24,5 +24,6 @@ endif ()
 configure_file(OpenImageIO/oiioversion.h.in "${CMAKE_BINARY_DIR}/include/OpenImageIO/oiioversion.h" @ONLY)
 list(APPEND public_headers "${CMAKE_BINARY_DIR}/include/OpenImageIO/oiioversion.h")
 
-install (FILES ${public_headers} DESTINATION ${INCLUDE_INSTALL_DIR}
+install (FILES ${public_headers}
+         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/OpenImageIO
          COMPONENT developer)

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -644,20 +644,27 @@ resolve_font (int fontsize, string_view font_, std::string &result)
         if (systemRoot.size())
             font_search_dirs.push_back (std::string(systemRoot) + "/Fonts");
         font_search_dirs.emplace_back ("/usr/share/fonts");
+        font_search_dirs.emplace_back ("/usr/share/fonts/OpenImageIO");
         font_search_dirs.emplace_back ("/Library/Fonts");
+        font_search_dirs.emplace_back ("/Library/Fonts/OpenImageIO");
         font_search_dirs.emplace_back ("C:/Windows/Fonts");
+        font_search_dirs.emplace_back ("C:/Windows/Fonts/OpenImageIO");
         font_search_dirs.emplace_back ("/usr/local/share/fonts");
+        font_search_dirs.emplace_back ("/usr/local/share/fonts/OpenImageIO");
         font_search_dirs.emplace_back ("/opt/local/share/fonts");
+        font_search_dirs.emplace_back ("/opt/local/share/fonts/OpenImageIO");
         // Try $OPENIMAGEIOHOME/fonts
         string_view oiiohomedir = Sysutil::getenv ("OPENIMAGEIOHOME");
         if (oiiohomedir.size())
             font_search_dirs.push_back (std::string(oiiohomedir) + "/fonts");
+            font_search_dirs.push_back (std::string(oiiohomedir) + "/share/fonts/OpenImageIO");
         // Try ../fonts relative to where this executing binary came from
         std::string this_program = OIIO::Sysutil::this_program_path ();
         if (this_program.size()) {
             std::string path = Filesystem::parent_path (this_program);
             path = Filesystem::parent_path (path);
             font_search_dirs.push_back (path+"/fonts");
+            font_search_dirs.push_back (path+"/shared/fonts/OpenImageIO");
         }
     }
 

--- a/src/nuke/txReader/CMakeLists.txt
+++ b/src/nuke/txReader/CMakeLists.txt
@@ -33,5 +33,4 @@ else ()
         COMPILE_FLAGS "-fPIC -msse")
 endif ()
 
-install (TARGETS txReader
-    LIBRARY DESTINATION "${LIB_INSTALL_DIR}/nuke")
+oiio_install_targets (txReader)

--- a/src/nuke/txWriter/CMakeLists.txt
+++ b/src/nuke/txWriter/CMakeLists.txt
@@ -33,5 +33,4 @@ else ()
         COMPILE_FLAGS "-fPIC -msse")
 endif ()
 
-install (TARGETS txWriter
-    LIBRARY DESTINATION "${LIB_INSTALL_DIR}/nuke")
+oiio_install_targets (txWriter)


### PR DESCRIPTION
Change all hard coded paths to GNUInstallDirs varibles.

Remove variable setting in main CMakeFiles.txt file since
GNUInstallDirs does all this for you.

Signed-off by: Jonathan Scruggs <j.scruggs@gmail.com>

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project.

As discussed in the similar PR from OpenShadingLanuage. I can sign the CLA as needed.

The new Python install directory code is just my attempt at a single variable to hold the install path. The idea was to show how GNUInstallDirs can be used for the path. You may be able to think of a better way. None of the prefixing needs to be done that the old way has since those prefixes are set by CMake, even the exec ones. Let me know your thoughts and I can update this accordingly.

I can't test the python module as the boost-python libs are not being found. There was this issue with another program that we fixed, but I can't remember how. I'll look at the detection code later. This has nothing to do with the new install path code I have, but the detection routines. This was always an issue with OpenImageIO.