### PR TITLE
FindLibRaw: fix access to the version info thanks to LibRaw_INCLUDE_DIR

### DIFF
--- a/src/cmake/modules/FindLibRaw.cmake
+++ b/src/cmake/modules/FindLibRaw.cmake
@@ -44,7 +44,7 @@ FIND_LIBRARY(LibRaw_r_LIBRARIES NAMES raw_r
             )
 
 IF(LibRaw_INCLUDE_DIR)
-   FILE(READ ${LibRaw_INCLUDE_DIR}/libraw_version.h _libraw_version_content)
+   FILE(READ ${LibRaw_INCLUDE_DIR}/libraw/libraw_version.h _libraw_version_content)
    
    STRING(REGEX MATCH "#define LIBRAW_MAJOR_VERSION[ \t]*([0-9]*)\n" _version_major_match ${_libraw_version_content})
    SET(_libraw_version_major "${CMAKE_MATCH_1}")
@@ -59,7 +59,7 @@ IF(LibRaw_INCLUDE_DIR)
       SET(LibRaw_VERSION_STRING "${_libraw_version_major}.${_libraw_version_minor}.${_libraw_version_patch}")
    ELSE()
       IF(NOT LibRaw_FIND_QUIETLY)
-         MESSAGE(STATUS "Failed to get version information from ${LibRaw_INCLUDE_DIR}/libraw_version.h")
+         MESSAGE(STATUS "Failed to get version information from ${LibRaw_INCLUDE_DIR}/libraw/libraw_version.h")
       ENDIF()
    ENDIF()
 ENDIF()


### PR DESCRIPTION
Hello, and thank you for your amazing io library!

## Description

Fix issues to detect libraw library and compile the corresponding plugins.
According to the includes found in src/raw.imageio/*.cpp, the
LibRaw_INCLUDE_DIR should be a path to 'libraw/libraw_version.h'.

## Tests

libraw is not installed on my computer. I compile it locally, and 
indicate the path to the local installation to CMake.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.