### PR TITLE
Bump minimum OpenEXR/Ilmbase to 2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,12 @@
 Release 1.8 (in progress) -- compared to 1.7.x
 ----------------------------------------------
 New minimum dependencies:
- * **C++11** (gcc 4.8.2 - gcc 7, clang 3.3 - 5.0, or MSVS 2013 - 2017)
+ * **C++11** (should also build with C++14 and C++17)
+ * **Compilers**: gcc 4.8.2 - gcc 7, clang 3.3 - 5.0, or MSVS 2013 - 2017
  * **Boost >= 1.53** (tested up through 1.65)
- * **CMake >= 3.0** (tested up through 3.9)
+ * **CMake >= 3.2.2** (tested up through 3.9)
+ * **OpenEXR >= 2.0** (recommended: 2.2)
  * (optional) **Qt >= 5.6**
- * (optional) **Python >= 2.7**
 
 Major new features and improvements:
 * New oiiotool features:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,12 +25,15 @@ NEW or CHANGED dependencies since the last major release are **bold**.
 
 ### Required dependencies
 
- * **C++11** (gcc 4.8.2, clang 3.3, or MSVS 2013)
- * **Boost >= 1.53**
- * **CMake >= 3.0**
+ * **C++11** (should also build with C++14 and C++17)
+ * **Compilers**: gcc 4.8.2 - gcc 7, clang 3.3 - 5.0, MSVS 2013 - 2017, icc version 13 or higher
+ * **Boost >= 1.53** (tested up through 1.65)
+ * **CMake >= 3.2.2** (tested up through 3.9)
+ * **OpenEXR >= 2.0** (recommended: 2.2)
 
 ### Optional dependencies
  * **Qt >= 5.6**  (Only needed if you want the `iv` viewer.)
+ * Python >= 2.7
 
 
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -60,17 +60,14 @@ find_package (PNG REQUIRED)
 ###########################################################################
 # IlmBase & OpenEXR setup
 
-find_package (OpenEXR REQUIRED)
+find_package (OpenEXR 2.0 REQUIRED)
 #OpenEXR 2.2 still has problems with importing ImathInt64.h unqualified
 #thus need for ilmbase/OpenEXR
 include_directories ("${OPENEXR_INCLUDE_DIR}"
                      "${ILMBASE_INCLUDE_DIR}"
                      "${ILMBASE_INCLUDE_DIR}/OpenEXR")
 if (${OPENEXR_VERSION} VERSION_LESS 2.0.0)
-    # OpenEXR 1.x had weird #include dirctives, this is also necessary:
-    include_directories ("${OPENEXR_INCLUDE_DIR}/OpenEXR")
-else ()
-    add_definitions (-DUSE_OPENEXR_VERSION2=1)
+    message (FATAL_ERROR "OpenEXR/Ilmbase is too old")
 endif ()
 if (NOT OpenEXR_FIND_QUIETLY)
     message (STATUS "OPENEXR_INCLUDE_DIR = ${OPENEXR_INCLUDE_DIR}")


### PR DESCRIPTION
VFXPlatform has dictated a minimum OpenEXR version of 2.0 since 2014,
and 2.2 since 2015.

Upgrading our minimum to 2.0 eliminates a lot of `#if` nonsense that was
necessary to continue supporting OpenEXR 1.x. There's no real burden
in continuing to support 2.0 & 2.1 for now. But we will continue to
re-evaluate the appropriate minimum in future releases.

