### PR TITLE
Fix statics contributing to static initialization order fiasco

### DIFF
--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -338,6 +338,12 @@ static std::locale& loc ()
     // inside the function that is allocated the first time it's needed. It
     // will "leak" in the sense that this one locale is never deleted, but
     // so what?
+#if OIIO_MSVS_BEFORE_2015
+    // MSVS prior to 2015 could not be trusted to make in-function static
+    // initialization thread-safe, as required by C++11.
+    static spin_mutex mutex;
+    spin_lock lock (mutex);
+#endif
     static std::locale *loc = new std::locale (std::locale::classic());
     return *loc;
 }

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -330,15 +330,24 @@ Strutil::wordwrap (string_view src, int columns, int prefix)
 
 
 
-namespace {
-static std::locale loc = std::locale::classic();
+
+static std::locale& loc ()
+{
+    // Rather than have a file-level static locale which could suffer from
+    // the static initialization order fiasco, make it a static pointer
+    // inside the function that is allocated the first time it's needed. It
+    // will "leak" in the sense that this one locale is never deleted, but
+    // so what?
+    static std::locale *loc = new std::locale (std::locale::classic());
+    return *loc;
 }
+
 
 
 bool
 Strutil::iequals (string_view a, string_view b)
 {
-    return boost::algorithm::iequals (a, b, loc);
+    return boost::algorithm::iequals (a, b, loc());
 }
 
 
@@ -352,7 +361,7 @@ Strutil::starts_with (string_view a, string_view b)
 bool
 Strutil::istarts_with (string_view a, string_view b)
 {
-    return boost::algorithm::istarts_with (a, b, loc);
+    return boost::algorithm::istarts_with (a, b, loc());
 }
 
 
@@ -366,7 +375,7 @@ Strutil::ends_with (string_view a, string_view b)
 bool
 Strutil::iends_with (string_view a, string_view b)
 {
-    return boost::algorithm::iends_with (a, b, loc);
+    return boost::algorithm::iends_with (a, b, loc());
 }
 
 
@@ -380,21 +389,21 @@ Strutil::contains (string_view a, string_view b)
 bool
 Strutil::icontains (string_view a, string_view b)
 {
-    return boost::algorithm::icontains (a, b, loc);
+    return boost::algorithm::icontains (a, b, loc());
 }
 
 
 void
 Strutil::to_lower (std::string &a)
 {
-    boost::algorithm::to_lower (a, loc);
+    boost::algorithm::to_lower (a, loc());
 }
 
 
 void
 Strutil::to_upper (std::string &a)
 {
-    boost::algorithm::to_upper (a, loc);
+    boost::algorithm::to_upper (a, loc());
 }
 
 

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -70,9 +70,6 @@ static bool envlatlmode = false;
 static bool envcubemode = false;
 static bool lightprobemode = false;
 
-static ColorConfig colorconfig;
-
-
 
 
 static std::string
@@ -115,6 +112,7 @@ colorconvert_help_string ()
     "to the proper bit depth using the -d option. ";
     
     s += " (choices: ";
+    ColorConfig colorconfig;
     if (colorconfig.error() || colorconfig.getNumColorSpaces()==0) {
         s += "NONE";
     } else {


### PR DESCRIPTION
Fixes #1750

These two spots were implicated in the initialization order fiasco. (See: https://isocpp.org/wiki/faq/ctors#static-init-order )

The solution for maketx.cpp is that since we only are using the ColorConfig for the sake of generating a help message, there's no reason it can't be an ordinary local variable in the one (rarely called) function where it's used.

For the std::locale involved in strutil.cpp, use the old trick where instead of a file static, we have a function returning a reference, which itself has a function-static pointer that's allocated the first time it's needed. This leaks (a single std::locale), but who cares?

