### PR TITLE
strided_ptr<> improvements

### DIFF
--- a/site/spi/Makefile-bits-arnold
+++ b/site/spi/Makefile-bits-arnold
@@ -50,6 +50,8 @@ ifeq ($(SP_OS), rhel7)
         MY_CMAKE_FLAGS += -DCMAKE_MAKE_PROGRAM=${NINJA}
     endif
     export CCACHE_CPP2 ?= 1
+    # Override lib64 and use SPI convention of lib
+    MY_CMAKE_FLAGS += -DCMAKE_INSTALL_LIBDIR="${working_dir}/dist/${platform}${variant}/lib"
     BOOSTVERS ?= 1.55
     SPCOMP2_USE_BOOSTVERS ?= 1
     OCIO_PATH ?= "${SPCOMP2_SHOTTREE_LOCATION}/OpenColorIO/${SP_OS}-${SPCOMP2_COMPILER}/v${OCIO_SPCOMP_VERSION}"
@@ -131,10 +133,6 @@ else ifeq ($(SP_OS), lion)
     FIELD3D_HOME ?= "${INSTALL_SPCOMP2_LOCATION}/Field3D/${SP_OS}-${SPCOMP2_COMPILER}-boost151/v306"
     # CMAKE_CXX_COMPILER:
     #   otherwise g++ is used and SPI standardized on clang.
-    # CMAKE_INSTALL_NAME_DIR:
-    #   without libraries and applications linking against this
-    #   library will not be able to find it at run time; prepends
-    #   "@rpath/" to the internal ID
     # OVERRIDE_SHARED_LIBRARY_SUFFIX:
     #   Set to .so so that shared libraries end in .so to be consistent
     #   with Linux SpComp2 shared libraries
@@ -153,8 +151,6 @@ else ifeq ($(SP_OS), lion)
       -DPYTHON_INCLUDE_DIR=${MACPORTS_PREFIX}/Library/Frameworks/Python.framework/Versions/2.7/Headers \
       -DPYTHON_LIBRARIES=${MACPORTS_PREFIX}/Library/Frameworks/Python.framework/Versions/2.7/Python \
       -DZLIB_ROOT=${MACPORTS_PREFIX}
-    MY_CMAKE_FLAGS += \
-        -DCMAKE_INSTALL_NAME_DIR="${working_dir}/dist/${SP_OS}${variant}/lib"
     ifeq (${SPCOMP2_USE_BOOSTVERS}, 1)
 	BOOSTVERS_UNDERSCORE = ${shell echo ${BOOSTVERS} | sed "s/\\./_/"}
 	MY_CMAKE_FLAGS += \
@@ -169,9 +165,6 @@ else ifeq ($(SP_OS), lion)
 ## Generic OSX machines (including LG's laptop)
 else ifeq (${platform}, macosx)
     USE_SIMD ?= sse4.2
-    MY_CMAKE_FLAGS += \
-        -DCMAKE_INSTALL_NAME_DIR="${working_dir}/dist/${platform}${variant}/lib"
-    # don't need this? -DBUILD_WITH_INSTALL_RPATH=1
 
     # A variety of tags can be used to try specific versions of gcc or
     # clang from the site-specific places we have installed them.

--- a/site/spi/Makefile-bits-spcomp2
+++ b/site/spi/Makefile-bits-spcomp2
@@ -77,6 +77,8 @@ ifeq ($(SP_OS), rhel7)
         MY_CMAKE_FLAGS += -DCMAKE_MAKE_PROGRAM=${NINJA}
     endif
     export CCACHE_CPP2 ?= 1
+    # Override lib64 and use SPI convention of lib
+    MY_CMAKE_FLAGS += -DCMAKE_INSTALL_LIBDIR="${working_dir}/dist/${platform}${variant}/lib"
     BOOSTVERS ?= 1.55
     SPCOMP2_USE_BOOSTVERS ?= 1
     BOOSTSPSUFFIX ?= sp
@@ -216,9 +218,6 @@ else ifeq ($(SP_OS), lion)
 ## Generic OSX machines (including LG's laptop)
 else ifeq (${platform}, macosx)
     USE_SIMD ?= sse4.2
-    MY_CMAKE_FLAGS += \
-        -DCMAKE_INSTALL_NAME_DIR="${working_dir}/dist/${platform}${variant}/lib"
-    # don't need this? -DBUILD_WITH_INSTALL_RPATH=1
 
     # A variety of tags can be used to try specific versions of gcc or
     # clang from the site-specific places we have installed them.

--- a/src/include/OpenImageIO/image_view.h
+++ b/src/include/OpenImageIO/image_view.h
@@ -107,12 +107,13 @@ public:
         return *this;
     }
 
-    /// iav(x,y,z)returns a strided_ptr for the pixel (x,y,z).  The z
+    /// iav(x,y,z)returns a strided_ptr<T,1> for the pixel (x,y,z).  The z
     /// can be omitted for 2D images.  Note than the resulting
     /// strided_ptr can then have individual channels accessed with
-    /// operator[].
-    strided_ptr<T> operator() (int x, int y, int z=0) {
-        return strided_ptr<T> (getptr(0,x,y,z), m_chanstride);
+    /// operator[]. This particular strided pointer has stride multiplier
+    /// 1, because this class uses bytes as strides, not sizeof(T).
+    strided_ptr<T,1> operator() (int x, int y, int z=0) {
+        return strided_ptr<T,1> (getptr(0,x,y,z), m_chanstride);
     }
 
     int nchannels() const { return m_nchannels; }

--- a/src/include/OpenImageIO/strided_ptr.h
+++ b/src/include/OpenImageIO/strided_ptr.h
@@ -35,43 +35,66 @@
 #include <cstddef>
 
 #include <OpenImageIO/oiioversion.h>
+#include <OpenImageIO/platform.h>
 
 
 OIIO_NAMESPACE_BEGIN
 
 
-/// strided_ptr<T> looks like a 'T*', but it incorporates a stride (in
-/// bytes) that may be different than sizeof(T).  Operators ++, --, [], and
-/// so on, take the stride into account when computing where each "array
-/// element" actually exists.  A strided_ptr<T> is mutable (the values
-/// pointed to may be modified), whereas an strided_ptr<const T> is not
-/// mutable.
-template <typename T>
+/// strided_ptr<T> looks like a 'T*', but it incorporates a stride, so
+/// it's not limited to adjacent elements.
+/// Operators ++, --, [], and so on, take the stride into account when
+/// computing where each "array element" actually exists.
+///
+/// A strided_ptr<T> is mutable (the values pointed to may be modified),
+/// whereas an strided_ptr<const T> is not mutable.
+///
+/// Fun trick: strided_ptr<T>(&my_value,0) makes a strided_pointer that
+/// is addressed like an array, but because the stride is 0, every
+/// accessed "element" actually will actually refer to the same value.
+///
+/// By default, if StrideUnits == sizeof(T), then the stride refers to
+/// multiples of the size of T. But every once in a while, you need a
+/// a byte-addressable stride, and in that case you use a StrideUnits
+/// of 1, like:   strided_ptr<T,1>.
+template <typename T, int StrideUnits = sizeof(T) >
 class strided_ptr {
 public:
-    strided_ptr (T* ptr=NULL, ptrdiff_t stride=sizeof(T))
+    constexpr strided_ptr (T* ptr=nullptr, ptrdiff_t stride=1) noexcept
         : m_ptr(ptr), m_stride(stride) { }
-    strided_ptr (const strided_ptr &p)
-        : m_ptr(p.m_ptr), m_stride(p.m_stride) {}
-    const strided_ptr& operator= (const strided_ptr &p) {
+    constexpr strided_ptr (const strided_ptr &p) noexcept
+        : strided_ptr(p.data(), p.stride()) { }
+
+    const strided_ptr& operator= (const strided_ptr &p) noexcept {
         m_ptr = p.m_ptr;
         m_stride = p.m_stride;
         return *this;
     }
 
-    T& operator* () const { return *m_ptr; }
-    T& operator[] (ptrdiff_t pos) const { return get(pos); }
-    T* data() const { return m_ptr; }
-    ptrdiff_t stride () const { return m_stride; }
-    bool operator== (const T *p) const { return m_ptr == p; }
-    bool operator!= (const T *p) const { return m_ptr != p; }
+    // Assignment of a pointer sets the pointer and implies a stride of 1.
+    const strided_ptr& operator= (T *p) noexcept {
+        m_ptr = p;
+        m_stride = 1;
+        return *this;
+    }
 
+    constexpr T& operator* () const { return *m_ptr; }
+    constexpr T& operator[] (ptrdiff_t pos) const { return get(pos); }
+    constexpr T* data() const { return m_ptr; }
+    constexpr ptrdiff_t stride () const { return m_stride; }
+
+    // Careful: == and != only compare the pointer
+    constexpr bool operator== (const T *p) const { return m_ptr == p; }
+    constexpr bool operator!= (const T *p) const { return m_ptr != p; }
+
+    // Increment and decrement moves the pointer to the next element
+    // one stride length away.
     const strided_ptr& operator++ () {   // prefix
         m_ptr = getptr(1);
         return *this;
     }
     strided_ptr operator++(int) {  // postfix
-        strided_ptr r;
+        strided_ptr r(*this);
         ++(*this);
         return r;
     }
@@ -80,33 +103,42 @@ public:
         return *this;
     }
     strided_ptr operator--(int) {  // postfix
-        strided_ptr r;
+        strided_ptr r(*this);
         --(*this);
         return r;
     }
 
-    strided_ptr operator+ (int d) const {
+    // Addition and subtraction returns new strided pointers that are
+    // the given number of strides away.
+    constexpr strided_ptr operator+ (ptrdiff_t d) const noexcept {
         return strided_ptr (getptr(d), m_stride);
     }
-    const strided_ptr& operator+= (int d) {
+    constexpr strided_ptr operator- (ptrdiff_t d) const noexcept {
+        return strided_ptr (getptr(-d), m_stride);
+    }
+    const strided_ptr& operator+= (ptrdiff_t d) noexcept {
         m_ptr = getptr(d);
         return *this;
     }
-    strided_ptr operator- (int d) const {
-        return strided_ptr (getptr(-d), m_stride);
-    }
-    const strided_ptr& operator-= (int d) {
+    const strided_ptr& operator-= (ptrdiff_t d) {
         m_ptr = getptr(-d);
         return *this;
     }
 
 private:
-    T *        m_ptr;
-    ptrdiff_t  m_stride;
-    inline T* getptr (ptrdiff_t pos=0) const {
-        return (T*)((char *)m_ptr + pos*m_stride);
+    // The implementation of a strided_ptr is just the pointer and a stride.
+    // Note that when computing addressing, the stride is implicitly
+    // multiplied by the StrideUnits, which defaults to sizeof(T), but when
+    // StrideUnits==1 means that your stride value is measured in bytes.
+    T *        m_ptr    = nullptr;
+    ptrdiff_t  m_stride = 1;
+
+    // getptr is the real brains of the operation, computing the pointer
+    // for a given element, with strides taken into consideration.
+    constexpr inline T* getptr (ptrdiff_t pos=0) const noexcept {
+        return (T*)((char *)m_ptr + pos*m_stride*StrideUnits);
     }
-    inline T& get (ptrdiff_t pos=0) const {
+    constexpr inline T& get (ptrdiff_t pos=0) const noexcept {
         return *getptr(pos);
     }
 };

--- a/src/libutil/array_view_test.cpp
+++ b/src/libutil/array_view_test.cpp
@@ -107,7 +107,7 @@ void test_const_strided_ptr ()
     OIIO_CHECK_EQUAL (a[3], 2.0f);
 
     // All the other tests are with stride of 2 elements
-    a = strided_ptr<const float> (&A[1], 2*sizeof(A[0]));
+    a = strided_ptr<const float> (&A[1], 2);
     OIIO_CHECK_EQUAL (*a, 1.0f);
     OIIO_CHECK_EQUAL (a[0], 1.0f);
     OIIO_CHECK_EQUAL (a[1], 2.0f);
@@ -140,7 +140,7 @@ void test_strided_ptr ()
     OIIO_CHECK_EQUAL (a[3], 2.0f);
 
     // All the other tests are with stride of 2 elements
-    a = strided_ptr<float> (&A[1], 2*sizeof(A[0]));
+    a = strided_ptr<float> (&A[1], 2);
     OIIO_CHECK_EQUAL (*a, 1.0f);
     OIIO_CHECK_EQUAL (a[0], 1.0f);
     OIIO_CHECK_EQUAL (a[1], 2.0f);


### PR DESCRIPTION
Templatize based on the stride units. The default strided_ptr<T>
is equivalent to strided_ptr<T,sizeof(T)>, which means that strides
are measured in terms of the size of the element type. But, if you
really want to, you could make strided_ptr<T,1> which would be a
strided pointer where the strides are bytes rather than T's.

Note that this is a compatibility break -- previously, strided_ptr<>
used byte addressing all the time. This was counter-intuitive in many
circumstances, so now the default is to use array-like addressing where
the strides are measured in units of sizeof(T)>. But we have the ability
to still use byte addressing when really needed.

While I was in there, I changed a lot of the declarations to use
constexpr and noexcept very liberally, to maximize the chances that the
compiler can exploit certain optimizations.

