### PR TITLE
TypeDesc: add constexpr typedescs at the OIIO scope

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,10 @@ Public API changes:
    * Rational support: new 'semantic' hint RATIONAL and TypeDesc::Rational.
      A rational is an int of aggregate VEC2 and hint RATIONAL, and should
      be interpreted as val[0]/val[1]. #1698 (1.8.5)
+   * Added OIIO-scoped `static constexpr` versions of preconstructed
+     TypeDescs (e.g., `TypeFloat`). We are deprecating the ones that were
+     static data members of TypeDesc (e.g., TypeDesc::TypeFloat), they will
+     be removed in some future release. (1.8.5)
 * ImageSpec:
    * New `ImageSpec::serialize()` returns a string with a serialized version
      of the contents of the ImageSpec. It may be text (human readable, like

--- a/src/doc/imageinput.tex
+++ b/src/doc/imageinput.tex
@@ -391,7 +391,7 @@ of a single integer:
         ImageInput *in = ImageInput::open (filename);
         const ImageSpec &spec = in->spec();
         ...
-        ParamValue *p = spec.find_attribute ("Orientation", TypeDesc::TypeInt);
+        ParamValue *p = spec.find_attribute ("Orientation", TypeInt);
         if (p) {
             int orientation = * (int *) p->data();
         } else {
@@ -431,15 +431,15 @@ This can be accomplished using the technique of the following example:
         for (size_t i = 0;  i < spec.extra_attribs.size();  ++i) {
             const ParamValue &p (spec.extra_attribs[i]);
             printf ("    \%s: ", p.name.c_str());
-            if (p.type() == TypeDesc::TypeString)
+            if (p.type() == TypeString)
                 printf ("\"\%s\"", *(const char **)p.data());
-            else if (p.type() == TypeDesc::TypeFloat)
+            else if (p.type() == TypeFloat)
                 printf ("\%g", *(const float *)p.data());
-            else if (p.type() == TypeDesc::TypeInt)
+            else if (p.type() == TypeInt)
                 printf ("\%d", *(const int *)p.data());
             else if (p.type() == TypeDesc::UINT)
                 printf ("\%u", *(const unsigned int *)p.data());
-            else if (p.type() == TypeDesc::TypeMatrix) {
+            else if (p.type() == TypeMatrix) {
                 const float *f = (const float *)p.data();
                 printf ("\%f \%f \%f \%f \%f \%f \%f \%f "
                         "\%f \%f \%f \%f \%f \%f \%f \%f",

--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -150,6 +150,31 @@ Of these, the only ones commonly used to store pixel values in image files
 are scalars of {\cf UINT8}, {\cf UINT16}, {\cf FLOAT}, and {\cf HALF}
 (the last only used by OpenEXR, to the best of our knowledge).
 
+A number of {\cf static constexpr TypeDesc} aliases for common types exist
+in the outer {\cf OpenImageIO} scope:
+
+\begin{quote}
+{\cf
+TypeUnknown
+TypeFloat
+TypeColor
+TypePoint
+TypeVector
+TypeNormal \\
+TypeMatrix33
+TypeMatrix44
+TypeMatrix
+TypeHalf
+TypeInt
+TypeUInt \\
+TypeString
+TypeTimeCode
+TypeKeyCode
+TypeFloat4
+TypeRational
+}
+\end{quote}
+
 Note that the \TypeDesc (which is also used for applications other
 than images) can describe many types not used by
 \product.  Please ignore this extra complexity; only the above simple types are understood by
@@ -888,7 +913,7 @@ containing the new value for the attribute.
 If the name is known, valid attribute that matches the type specified,
 the attribute will be set to the new value and {\cf attribute()} will
 return {\cf true}.  If {\cf name} is not recognized, or if the types do
-not match (e.g., {\cf type} is {\cf TypeDesc::TypeFloat} but the named
+not match (e.g., {\cf type} is {\cf TypeFloat} but the named
 attribute is a string), the attribute will not be modified, and {\cf
   attribute()} will return {\cf false}.
 
@@ -1003,7 +1028,7 @@ If the attribute name is valid and matches the type specified, the
 attribute value will be stored at address {\cf val} and {\cf
   attribute()} will return {\cf true}.  If {\cf name} is not recognized
 as a valid attribute name, or if the types do not match (e.g., {\cf
-  type} is {\cf TypeDesc::TypeFloat} but the named attribute is a
+  type} is {\cf TypeFloat} but the named attribute is a
 string), no data will be written to {\cf val}, and {\cf attribute()}
 will return {\cf false}.
 

--- a/src/doc/imageoutput.tex
+++ b/src/doc/imageoutput.tex
@@ -636,7 +636,7 @@ complex arrangements, you can use the more general form of {\cf
 
         // Attach a 4x4 matrix to describe the camera coordinates
         float mymatrix[16] = { ... };
-        spec.attribute ("worldtocamera", TypeDesc::TypeMatrix, &mymatrix);
+        spec.attribute ("worldtocamera", TypeMatrix, &mymatrix);
 
         // Attach an array of two floats giving the CIE neutral color
         float neutral[2] = { ... };

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -86,24 +86,28 @@ Construct a {\cf TypeDesc} object.
 \end{code}
 \apiend
 
-\apiitem{TypeDesc.TypeFloat() \\
-TypeDesc.TypeInt() \\
-TypeDesc.TypeString() \\
-TypeDesc.TypeHalf() \\
-TypeDesc.TypeColor() \\
-TypeDesc.TypePoint() \\
-TypeDesc.TypeVector() \\
-TypeDesc.TypeNormal() \\
-TypeDesc.TypeMatrix() \\
-TypeDesc.TypeMatrix33() \\
-TypeDesc.TypeTimeCode() \\
-TypeDesc.TypeKeyCode() \\
-TypeDesc.TypeFloat4()}
-Pre-constructed \TypeDesc objects for some common types.
+\apiitem{TypeFloat \\
+TypeInt \\
+TypeUInt \\
+TypeString \\
+TypeHalf \\
+TypeColor \\
+TypePoint \\
+TypeVector \\
+TypeNormal \\
+TypeMatrix \\
+TypeMatrix33 \\
+TypeTimeCode \\
+TypeKeyCode \\
+TypeFloat4 \\
+TypeRational \\
+}
+Pre-constructed \TypeDesc objects for some common types, available in the
+outer OpenImageIO scope.
 
 \noindent Example:
 \begin{code}
-    t = TypeDesc.TypeFloat()
+    t = TypeFloat
 \end{code}
 \apiend
 

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -478,13 +478,13 @@ DPXInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
 
         int kc[7];
         get_keycode_values (kc);
-        m_spec.attribute("smpte:KeyCode", TypeDesc::TypeKeyCode, kc);
+        m_spec.attribute("smpte:KeyCode", TypeKeyCode, kc);
     }
 
     if (m_dpx.header.timeCode != 0xFFFFFFFF) {
 
         unsigned int timecode[2] = {m_dpx.header.timeCode, m_dpx.header.userBits};
-        m_spec.attribute("smpte:TimeCode", TypeDesc::TypeTimeCode, timecode);
+        m_spec.attribute("smpte:TimeCode", TypeTimeCode, timecode);
 
         // This attribute is dpx specific and is left in for backwards compatability.
         // Users should utilise the new smpte:TimeCode attribute instead

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -361,7 +361,7 @@ DPXOutput::open (const std::string &name, const ImageSpec &userspec,
     orient = DpxOrientations[clamp (orient, 0, 8)];
     m_dpx.header.SetImageOrientation ((dpx::Orientation)orient);
 
-    ParamValue *tc = m_spec.find_attribute("smpte:TimeCode", TypeDesc::TypeTimeCode, false);
+    ParamValue *tc = m_spec.find_attribute("smpte:TimeCode", TypeTimeCode, false);
     if (tc) {
         unsigned int *timecode = (unsigned int*) tc->data();
         m_dpx.header.timeCode = timecode[0];
@@ -377,7 +377,7 @@ DPXOutput::open (const std::string &name, const ImageSpec &userspec,
         m_dpx.header.userBits = m_spec.get_int_attribute ("dpx:UserBits", ~0);
     }
 
-    ParamValue *kc = m_spec.find_attribute("smpte:KeyCode", TypeDesc::TypeKeyCode, false);
+    ParamValue *kc = m_spec.find_attribute("smpte:KeyCode", TypeKeyCode, false);
     if (kc) {
         int *array = (int*) kc->data();
         set_keycode_values(array);

--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -432,7 +432,7 @@ FFmpegInput::open (const std::string &name, ImageSpec &spec)
         m_spec.attribute (tag->key, tag->value);
     }
     int rat[2] = { m_frame_rate.num, m_frame_rate.den };
-    m_spec.attribute ("FramesPerSecond", TypeDesc::TypeRational, &rat);
+    m_spec.attribute ("FramesPerSecond", TypeRational, &rat);
     m_spec.attribute ("oiio:Movie", true);
     m_spec.attribute ("oiio:BitsPerSample", m_codec_context->bits_per_raw_sample);
     m_nsubimages = m_frames;

--- a/src/field3d.imageio/field3dinput.cpp
+++ b/src/field3d.imageio/field3dinput.cpp
@@ -176,7 +176,7 @@ read_metadata (const M &meta, ImageSpec &spec)
     }
     for (typename M::VecFloatMetadata::const_iterator i = meta.vecFloatMetadata().begin(),
              e = meta.vecFloatMetadata().end(); i != e;  ++i) {
-        spec.attribute (i->first, TypeDesc::TypeVector, &(i->second));
+        spec.attribute (i->first, TypeVector, &(i->second));
     }
 }
 
@@ -277,7 +277,7 @@ Field3DInput::read_one_layer (FieldRes::Ptr field, layerrecord &lay,
                        (float)md[2][0], (float)md[2][1], (float)md[2][2], (float)md[2][3],
                        (float)md[3][0], (float)md[3][1], (float)md[3][2], (float)md[3][3]);
         m = m.inverse();
-        lay.spec.attribute ("worldtocamera", TypeDesc::TypeMatrix, &m);
+        lay.spec.attribute ("worldtocamera", TypeMatrix, &m);
     }
 
     // Other metadata

--- a/src/field3d.imageio/field3doutput.cpp
+++ b/src/field3d.imageio/field3doutput.cpp
@@ -284,11 +284,11 @@ Field3DOutput::put_parameter (const std::string &name, TypeDesc type,
         }
     }
 
-    if (type == TypeDesc::TypeString)
+    if (type == TypeString)
         m_field->metadata().setStrMetadata (name, *(const char **)data);
-    else if (type == TypeDesc::TypeInt)
+    else if (type == TypeInt)
         m_field->metadata().setIntMetadata (name, *(const int *)data);
-    else if (type == TypeDesc::TypeFloat)
+    else if (type == TypeFloat)
         m_field->metadata().setFloatMetadata (name, *(const float *)data);
     else if (type.basetype == TypeDesc::FLOAT && type.aggregate == 3)
         m_field->metadata().setVecFloatMetadata (name, *(const FIELD3D_NS::V3f *)data);
@@ -499,7 +499,7 @@ Field3DOutput::prep_subimage_specialized ()
         mapping->setLocalToWorld (*((FIELD3D_NS::M44d*)mx->data()));
         m_field->setMapping (mapping);
     }
-    else if (ParamValue *mx = m_spec.find_attribute ("worldtocamera", TypeDesc::TypeMatrix)) {
+    else if (ParamValue *mx = m_spec.find_attribute ("worldtocamera", TypeMatrix)) {
         Imath::M44f m = *((Imath::M44f*)mx->data());
         m = m.inverse();
         FIELD3D_NS::M44d md (m[0][0], m[0][1], m[0][1], m[0][3],

--- a/src/gif.imageio/gifinput.cpp
+++ b/src/gif.imageio/gifinput.cpp
@@ -202,7 +202,7 @@ GIFInput::read_gif_extension (int ext_code, GifByteType *ext,
         int delay = (ext[3] << 8) | ext[2];
         if (delay) {
             int rat[2] = { 100, delay };
-            newspec.attribute ("FramesPerSecond", TypeDesc::TypeRational, &rat);
+            newspec.attribute ("FramesPerSecond", TypeRational, &rat);
             newspec.attribute ("oiio:Movie", 1);
         }
         

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -182,8 +182,7 @@ ICOOutput::open (const std::string &name, const ImageSpec &userspec,
     // check if the client wants this subimage written as PNG
     // also force PNG if image size is 256 because ico_header->width and height
     // are 8-bit
-    const ParamValue *p = m_spec.find_attribute ("ico:PNG",
-                                                       TypeDesc::TypeInt);
+    const ParamValue *p = m_spec.find_attribute ("ico:PNG", TypeInt);
     m_want_png = (p && *(int *)p->data())
                  || m_spec.width == 256 || m_spec.height == 256;
 

--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -368,7 +368,7 @@ convert_file (const std::string &in_filename, const std::string &out_filename)
         int nsubimages = 0;
         ustring ufilename (in_filename);
         imagecache->get_image_info (ufilename, 0, 0, ustring("subimages"),
-                                    TypeDesc::TypeInt, &nsubimages);
+                                    TypeInt, &nsubimages);
         if (nsubimages > 1) {
             subimagespecs.resize (nsubimages);
             for (int i = 0;  i < nsubimages;  ++i) {

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -146,7 +146,7 @@ read_input (const std::string &filename, ImageBuf &img,
         return true;
 
     img.reset (filename, cache);
-    if (img.read (subimage, miplevel, false, TypeDesc::TypeFloat))
+    if (img.read (subimage, miplevel, false, TypeFloat))
         return true;
 
     std::cerr << "idiff ERROR: Could not read " << filename << ":\n\t"
@@ -259,7 +259,7 @@ main (int argc, char *argv[])
             int npels = img0.spec().width * img0.spec().height * img0.spec().depth;
             if (npels == 0)
                 npels = 1;    // Avoid divide by zero for 0x0 images
-            ASSERT (img0.spec().format == TypeDesc::FLOAT);
+            ASSERT (img0.spec().format == TypeFloat);
 
             // Compare the two images.
             //

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1288,14 +1288,14 @@ OIIO_API std::string geterror ();
 OIIO_API bool attribute (string_view name, TypeDesc type, const void *val);
 // Shortcuts for common types
 inline bool attribute (string_view name, int val) {
-    return attribute (name, TypeDesc::TypeInt, &val);
+    return attribute (name, TypeInt, &val);
 }
 inline bool attribute (string_view name, float val) {
-    return attribute (name, TypeDesc::TypeFloat, &val);
+    return attribute (name, TypeFloat, &val);
 }
 inline bool attribute (string_view name, string_view val) {
     const char *s = val.c_str();
-    return attribute (name, TypeDesc::TypeString, &s);
+    return attribute (name, TypeString, &s);
 }
 
 /// Get the named global attribute of OpenImageIO, store it in *val.
@@ -1339,33 +1339,33 @@ inline bool attribute (string_view name, string_view val) {
 OIIO_API bool getattribute (string_view name, TypeDesc type, void *val);
 // Shortcuts for common types
 inline bool getattribute (string_view name, int &val) {
-    return getattribute (name, TypeDesc::TypeInt, &val);
+    return getattribute (name, TypeInt, &val);
 }
 inline bool getattribute (string_view name, float &val) {
-    return getattribute (name, TypeDesc::TypeFloat, &val);
+    return getattribute (name, TypeFloat, &val);
 }
 inline bool getattribute (string_view name, char **val) {
-    return getattribute (name, TypeDesc::TypeString, val);
+    return getattribute (name, TypeString, val);
 }
 inline bool getattribute (string_view name, std::string &val) {
     ustring s;
-    bool ok = getattribute (name, TypeDesc::TypeString, &s);
+    bool ok = getattribute (name, TypeString, &s);
     if (ok)
         val = s.string();
     return ok;
 }
 inline int get_int_attribute (string_view name, int defaultval=0) {
     int val;
-    return getattribute (name, TypeDesc::TypeInt, &val) ? val : defaultval;
+    return getattribute (name, TypeInt, &val) ? val : defaultval;
 }
 inline float get_float_attribute (string_view name, float defaultval=0) {
     float val;
-    return getattribute (name, TypeDesc::TypeFloat, &val) ? val : defaultval;
+    return getattribute (name, TypeFloat, &val) ? val : defaultval;
 }
 inline string_view get_string_attribute (string_view name,
                                  string_view defaultval = string_view()) {
     ustring val;
-    return getattribute (name, TypeDesc::TypeString, &val) ? string_view(val) : defaultval;
+    return getattribute (name, TypeString, &val) ? string_view(val) : defaultval;
 }
 
 

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -297,6 +297,12 @@ struct OIIO_API TypeDesc {
     /// containers and algorithms.
     bool operator< (const TypeDesc &x) const;
 
+    // DEPRECATED(1.8): These static const member functions were mildly
+    // problematic because they required external linkage (and possibly
+    // even static initialization order fiasco) and were a memory reference
+    // that incurred some performance penalty and inability to optimize.
+    // Please instead use the out-of-class constexpr versions below.  We
+    // will eventually remove these.
     static const TypeDesc TypeFloat;
     static const TypeDesc TypeColor;
     static const TypeDesc TypeString;
@@ -313,6 +319,30 @@ struct OIIO_API TypeDesc {
     static const TypeDesc TypeFloat4;
     static const TypeDesc TypeRational;
 };
+
+
+
+
+// Static values for commonly used types. Because these are constexpr,
+// they should incur no runtime construction cost and should optimize nicely
+// in various ways.
+static constexpr TypeDesc TypeUnknown (TypeDesc::UNKNOWN);
+static constexpr TypeDesc TypeFloat (TypeDesc::FLOAT);
+static constexpr TypeDesc TypeColor (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::COLOR);
+static constexpr TypeDesc TypePoint (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::POINT);
+static constexpr TypeDesc TypeVector (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::VECTOR);
+static constexpr TypeDesc TypeNormal (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::NORMAL);
+static constexpr TypeDesc TypeMatrix33 (TypeDesc::FLOAT, TypeDesc::MATRIX33);
+static constexpr TypeDesc TypeMatrix44 (TypeDesc::FLOAT, TypeDesc::MATRIX44);
+static constexpr TypeDesc TypeMatrix = TypeMatrix44;
+static constexpr TypeDesc TypeString (TypeDesc::STRING);
+static constexpr TypeDesc TypeInt (TypeDesc::INT);
+static constexpr TypeDesc TypeUInt (TypeDesc::UINT);
+static constexpr TypeDesc TypeHalf (TypeDesc::HALF);
+static constexpr TypeDesc TypeTimeCode (TypeDesc::UINT, TypeDesc::SCALAR, TypeDesc::TIMECODE, 2);
+static constexpr TypeDesc TypeKeyCode (TypeDesc::INT, TypeDesc::SCALAR, TypeDesc::KEYCODE, 7);
+static constexpr TypeDesc TypeFloat4 (TypeDesc::FLOAT, TypeDesc::VEC4);
+static constexpr TypeDesc TypeRational(TypeDesc::INT, TypeDesc::VEC2, TypeDesc::RATIONAL);
 
 
 

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -171,8 +171,7 @@ bool
 JpgInput::open (const std::string &name, ImageSpec &newspec,
                 const ImageSpec &config)
 {
-    const ParamValue *p = config.find_attribute ("_jpeg:raw",
-                                                       TypeDesc::TypeInt);
+    const ParamValue *p = config.find_attribute ("_jpeg:raw", TypeInt);
     m_raw = p && *(int *)p->data();
     return open (name, newspec);
 }

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -397,8 +397,8 @@ ImageSpec::find_attribute (string_view name, ParamValue &tmpparam,
 #define MATCH(n,t) (((!casesensitive && Strutil::iequals(name,n)) || \
                      ( casesensitive && name == n)) && \
                     (searchtype == TypeDesc::UNKNOWN || searchtype == t))
-#define GETINT(n) if (MATCH(#n,TypeDesc::TypeInt)) { \
-                      tmpparam.init (#n, TypeDesc::TypeInt, 1, &this->n); \
+#define GETINT(n) if (MATCH(#n,TypeInt)) { \
+                      tmpparam.init (#n, TypeInt, 1, &this->n); \
                       return &tmpparam; \
                   }
     GETINT(nchannels);
@@ -420,21 +420,21 @@ ImageSpec::find_attribute (string_view name, ParamValue &tmpparam,
     GETINT(alpha_channel);
     GETINT(z_channel);
     // some special cases
-    if (MATCH("geom", TypeDesc::TypeString)) {
+    if (MATCH("geom", TypeString)) {
         ustring s = (depth <= 1 && full_depth <= 1)
                     ? ustring::format ("%dx%d%+d%+d", width, height, x, y)
                     : ustring::format ("%dx%dx%d%+d%+d%+d", width, height, depth, x, y, z);
-        tmpparam.init ("geom", TypeDesc::TypeString, 1, &s);
+        tmpparam.init ("geom", TypeString, 1, &s);
         return &tmpparam;
     }
-    if (MATCH("full_geom", TypeDesc::TypeString)) {
+    if (MATCH("full_geom", TypeString)) {
         ustring s = (depth <= 1 && full_depth <= 1)
                     ? ustring::format ("%dx%d%+d%+d",
                                        full_width, full_height, full_x, full_y)
                     : ustring::format ("%dx%dx%d%+d%+d%+d",
                                        full_width, full_height, full_depth,
                                        full_x, full_y, full_z);
-        tmpparam.init ("full_geom", TypeDesc::TypeString, 1, &s);
+        tmpparam.init ("full_geom", TypeString, 1, &s);
         return &tmpparam;
     }
 #undef GETINT
@@ -746,7 +746,7 @@ ImageSpec::metadata_val (const ParamValue &p, bool human)
 
     // ParamValue::get_string() doesn't escape or double-quote single
     // strings, so we need to correct for that here.
-    if (p.type() == TypeDesc::TypeString && p.nvalues() == 1)
+    if (p.type() == TypeString && p.nvalues() == 1)
         out = Strutil::format ("\"%s\"", Strutil::escape_chars(out));
     if (human) {
         std::string nice;
@@ -757,12 +757,12 @@ ImageSpec::metadata_val (const ParamValue &p, bool human)
                 break;
             }
         }
-        if (p.type() == TypeDesc::TypeRational) {
+        if (p.type() == TypeRational) {
             int num = p.get<int>(0), den = p.get<int>(1);
             if (den)
                 nice = Strutil::format ("%g", float(num)/float(den));
         }
-        if (p.type() == TypeDesc::TypeTimeCode) {
+        if (p.type() == TypeTimeCode) {
             Imf::TimeCode tc = *reinterpret_cast<const Imf::TimeCode *>(p.data());
             nice = Strutil::format ("%02d:%02d:%02d:%02d", tc.hours(),
                                     tc.minutes(), tc.seconds(), tc.frame());
@@ -910,7 +910,7 @@ spec_to_xml (const ImageSpec &spec, ImageSpec::SerialVerbose verbose)
                     break;
                 }
             }
-            if (p.type() == TypeDesc::TypeTimeCode) {
+            if (p.type() == TypeTimeCode) {
                 Imf::TimeCode tc = *reinterpret_cast<const Imf::TimeCode *>(p.data());
                 desc = Strutil::format ("%02d:%02d:%02d:%02d", tc.hours(),
                                         tc.minutes(), tc.seconds(), tc.frame());

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -710,12 +710,12 @@ ImageBufImpl::init_spec (string_view filename, int subimage, int miplevel)
     if (m_configspec)  // Pass configuration options to cache
         m_imagecache->add_file (m_name, NULL, m_configspec.get());
     m_imagecache->get_image_info (m_name, subimage, miplevel, s_subimages,
-                                  TypeDesc::TypeInt, &m_nsubimages);
+                                  TypeInt, &m_nsubimages);
     m_imagecache->get_image_info (m_name, subimage, miplevel, s_miplevels,
-                                  TypeDesc::TypeInt, &m_nmiplevels);
+                                  TypeInt, &m_nmiplevels);
     const char *fmt = NULL;
     m_imagecache->get_image_info (m_name, subimage, miplevel,
-                                  s_fileformat, TypeDesc::TypeString, &fmt);
+                                  s_fileformat, TypeString, &fmt);
     m_fileformat = ustring(fmt);
     m_imagecache->get_imagespec (m_name, m_spec, subimage, miplevel);
     m_imagecache->get_imagespec (m_name, m_nativespec, subimage, miplevel, true);
@@ -734,7 +734,7 @@ ImageBufImpl::init_spec (string_view filename, int subimage, int miplevel)
     int peltype = TypeDesc::UNKNOWN;
     m_imagecache->get_image_info (m_name, subimage, miplevel,
                                   ustring("cachedpixeltype"),
-                                  TypeDesc::TypeInt, &peltype);
+                                  TypeInt, &peltype);
     if (peltype != TypeDesc::UNKNOWN) {
         m_spec.format = (TypeDesc::BASETYPE)peltype;
         m_spec.channelformats.clear();
@@ -824,7 +824,7 @@ ImageBufImpl::read (int subimage, int miplevel, int chbegin, int chend,
     int peltype = TypeDesc::UNKNOWN;
     m_imagecache->get_image_info (m_name, subimage, miplevel,
                                   ustring("cachedpixeltype"),
-                                  TypeDesc::TypeInt, &peltype);
+                                  TypeInt, &peltype);
     m_cachedpixeltype = TypeDesc ((TypeDesc::BASETYPE)peltype);
     if (! m_localpixels && ! force && ! use_channel_subset &&
         (convert == m_cachedpixeltype || convert == TypeDesc::UNKNOWN)) {

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -902,7 +902,7 @@ ImageBufAlgo::histogram (const ImageBuf &A, int channel,
                          float min, float max, imagesize_t *submin,
                          imagesize_t *supermax, ROI roi)
 {
-    if (A.spec().format != TypeDesc::TypeFloat) {
+    if (A.spec().format != TypeFloat) {
         A.error ("Unsupported pixel data format '%s'", A.spec().format);
         return false;
     }
@@ -953,7 +953,7 @@ ImageBufAlgo::histogram_draw (ImageBuf &R,
 
     // Check R and modify it if needed.
     int height = R.spec().height;
-    if (R.spec().format != TypeDesc::TypeFloat || R.nchannels() != 1 ||
+    if (R.spec().format != TypeFloat || R.nchannels() != 1 ||
         R.spec().width != bins) {
         ImageSpec newspec = ImageSpec (bins, height, 1, TypeDesc::FLOAT);
         R.reset ("dummy", newspec);

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -161,7 +161,7 @@ ImageBufAlgo::copy (ImageBuf &dst, const ImageBuf &src, TypeDesc convert,
         ImageSpec newspec = src.spec();
         set_roi (newspec, roi);
         newspec.nchannels = roi.chend;
-        if (convert != TypeDesc::UNKNOWN)
+        if (convert != TypeUnknown)
             newspec.set_format (convert);
         dst.reset (newspec);
     }
@@ -833,7 +833,7 @@ ImageBufAlgo::channel_append (ImageBuf &dst, const ImageBuf &A,
     // make it unconditinally float.
     if (! dst.pixels_valid()) {
         ImageSpec dstspec = A.spec();
-        dstspec.set_format (TypeDesc::TypeFloat);
+        dstspec.set_format (TypeFloat);
         // Append the channel descriptions
         dstspec.nchannels = A.spec().nchannels + B.spec().nchannels;
         for (int c = 0;  c < B.spec().nchannels;  ++c) {

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -215,7 +215,7 @@ debug (string_view message)
 bool
 attribute (string_view name, TypeDesc type, const void *val)
 {
-    if (name == "threads" && type == TypeDesc::TypeInt) {
+    if (name == "threads" && type == TypeInt) {
         int ot = Imath::clamp (*(const int *)val, 0, maxthreads);
         if (ot == 0)
             ot = threads_default();
@@ -224,23 +224,23 @@ attribute (string_view name, TypeDesc type, const void *val)
         return true;
     }
     spin_lock lock (attrib_mutex);
-    if (name == "read_chunk" && type == TypeDesc::TypeInt) {
+    if (name == "read_chunk" && type == TypeInt) {
         oiio_read_chunk = *(const int *)val;
         return true;
     }
-    if (name == "plugin_searchpath" && type == TypeDesc::TypeString) {
+    if (name == "plugin_searchpath" && type == TypeString) {
         plugin_searchpath = ustring (*(const char **)val);
         return true;
     }
-    if (name == "exr_threads" && type == TypeDesc::TypeInt) {
+    if (name == "exr_threads" && type == TypeInt) {
         oiio_exr_threads = Imath::clamp (*(const int *)val, -1, maxthreads);
         return true;
     }
-    if (name == "tiff:half" && type == TypeDesc::TypeInt) {
+    if (name == "tiff:half" && type == TypeInt) {
         tiff_half = *(const int *)val;
         return true;
     }
-    if (name == "debug" && type == TypeDesc::TypeInt) {
+    if (name == "debug" && type == TypeInt) {
         print_debug = *(const int *)val;
         return true;
     }
@@ -252,66 +252,66 @@ attribute (string_view name, TypeDesc type, const void *val)
 bool
 getattribute (string_view name, TypeDesc type, void *val)
 {
-    if (name == "threads" && type == TypeDesc::TypeInt) {
+    if (name == "threads" && type == TypeInt) {
         *(int *)val = oiio_threads;
         return true;
     }
     spin_lock lock (attrib_mutex);
-    if (name == "read_chunk" && type == TypeDesc::TypeInt) {
+    if (name == "read_chunk" && type == TypeInt) {
         *(int *)val = oiio_read_chunk;
         return true;
     }
-    if (name == "plugin_searchpath" && type == TypeDesc::TypeString) {
+    if (name == "plugin_searchpath" && type == TypeString) {
         *(ustring *)val = plugin_searchpath;
         return true;
     }
-    if (name == "format_list" && type == TypeDesc::TypeString) {
+    if (name == "format_list" && type == TypeString) {
         if (format_list.empty())
             pvt::catalog_all_plugins (plugin_searchpath.string());
         *(ustring *)val = ustring(format_list);
         return true;
     }
-    if (name == "input_format_list" && type == TypeDesc::TypeString) {
+    if (name == "input_format_list" && type == TypeString) {
         if (input_format_list.empty())
             pvt::catalog_all_plugins (plugin_searchpath.string());
         *(ustring *)val = ustring(input_format_list);
         return true;
     }
-    if (name == "output_format_list" && type == TypeDesc::TypeString) {
+    if (name == "output_format_list" && type == TypeString) {
         if (output_format_list.empty())
             pvt::catalog_all_plugins (plugin_searchpath.string());
         *(ustring *)val = ustring(output_format_list);
         return true;
     }
-    if (name == "extension_list" && type == TypeDesc::TypeString) {
+    if (name == "extension_list" && type == TypeString) {
         if (extension_list.empty())
             pvt::catalog_all_plugins (plugin_searchpath.string());
         *(ustring *)val = ustring(extension_list);
         return true;
     }
-    if (name == "library_list" && type == TypeDesc::TypeString) {
+    if (name == "library_list" && type == TypeString) {
         if (library_list.empty())
             pvt::catalog_all_plugins (plugin_searchpath.string());
         *(ustring *)val = ustring(library_list);
         return true;
     }
-    if (name == "exr_threads" && type == TypeDesc::TypeInt) {
+    if (name == "exr_threads" && type == TypeInt) {
         *(int *)val = oiio_exr_threads;
         return true;
     }
-    if (name == "tiff:half" && type == TypeDesc::TypeInt) {
+    if (name == "tiff:half" && type == TypeInt) {
         *(int *)val = tiff_half;
         return true;
     }
-    if (name == "debug" && type == TypeDesc::TypeInt) {
+    if (name == "debug" && type == TypeInt) {
         *(int *)val = print_debug;
         return true;
     }
-    if (name == "hw:simd" && type == TypeDesc::TypeString) {
+    if (name == "hw:simd" && type == TypeString) {
         *(ustring *)val = ustring(hw_simd_caps());
         return true;
     }
-    if (name == "oiio:simd" && type == TypeDesc::TypeString) {
+    if (name == "oiio:simd" && type == TypeString) {
         *(ustring *)val = ustring(oiio_simd_caps());
         return true;
     }
@@ -568,7 +568,7 @@ convert_types (TypeDesc src_type, const void *src,
         return true;
     }
 
-    if (dst_type == TypeDesc::TypeFloat) {
+    if (dst_type == TypeFloat) {
         // Special case -- converting non-float to float
         pvt::convert_to_float (src, (float *)dst, n, src_type);
         return true;
@@ -578,7 +578,7 @@ convert_types (TypeDesc src_type, const void *src,
 
     std::unique_ptr<float[]> tmp;   // In case we need a lot of temp space
     float *buf = (float *)src;
-    if (src_type != TypeDesc::TypeFloat) {
+    if (src_type != TypeFloat) {
         // If src is also not float, convert through an intermediate buffer
         if (n <= 4096)  // If < 16k, use the stack
             buf = ALLOCA (float, n);

--- a/src/libOpenImageIO/imagespec_test.cpp
+++ b/src/libOpenImageIO/imagespec_test.cpp
@@ -103,16 +103,16 @@ void test_imagespec_metadata_val ()
     std::string ret;
 
     int imatrix[] = {100, 200, 300, 400};
-    metadata_val_test (&imatrix[0], 1, TypeDesc::TypeInt, ret);
+    metadata_val_test (&imatrix[0], 1, TypeInt, ret);
     OIIO_CHECK_EQUAL (ret, "100");
-    metadata_val_test (imatrix, sizeof (imatrix)/sizeof(int), TypeDesc::TypeInt, ret);
+    metadata_val_test (imatrix, sizeof (imatrix)/sizeof(int), TypeInt, ret);
     OIIO_CHECK_EQUAL (ret, "100, 200, 300, 400");
     OIIO_CHECK_NE (ret, "100, 200, 300, 400,");
 
     float fmatrix[] = {10.12f, 200.34f, 300.11f, 400.9f};
-    metadata_val_test (&fmatrix[0], 1, TypeDesc::TypeFloat, ret);
+    metadata_val_test (&fmatrix[0], 1, TypeFloat, ret);
     OIIO_CHECK_EQUAL (ret, "10.12");
-    metadata_val_test (fmatrix, sizeof (fmatrix) / sizeof (float), TypeDesc::TypeFloat, ret);
+    metadata_val_test (fmatrix, sizeof (fmatrix) / sizeof (float), TypeFloat, ret);
     OIIO_CHECK_EQUAL (ret, "10.12, 200.34, 300.11, 400.9");
     OIIO_CHECK_NE (ret, "10, 200, 300, 400");
     OIIO_CHECK_NE (ret, "10.12, 200.34, 300.11, 400.9,");
@@ -126,19 +126,19 @@ void test_imagespec_metadata_val ()
     OIIO_CHECK_NE (ret, "18446744073709551615, 18446744073709551615,");
 
     const char* smatrix[] = {"this is \"a test\"", "this is another test"};
-    metadata_val_test (smatrix, 1, TypeDesc::TypeString, ret);
+    metadata_val_test (smatrix, 1, TypeString, ret);
     OIIO_CHECK_EQUAL (ret, "\"this is \\\"a test\\\"\"");
     OIIO_CHECK_NE (ret, smatrix[0]);
     OIIO_CHECK_NE (ret, "\"this is \"a test\"\",");
-    metadata_val_test (smatrix, sizeof (smatrix) / sizeof (char *), TypeDesc::TypeString, ret);
+    metadata_val_test (smatrix, sizeof (smatrix) / sizeof (char *), TypeString, ret);
     OIIO_CHECK_EQUAL (ret, "\"this is \\\"a test\\\"\", \"this is another test\"");
 
     float matrix16[2][16] = {{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
                         {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25}};
-    metadata_val_test (&matrix16[0], 1, TypeDesc::TypeMatrix, ret);
+    metadata_val_test (&matrix16[0], 1, TypeMatrix, ret);
     OIIO_CHECK_EQUAL (ret, "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16");
     OIIO_CHECK_NE (ret, "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16,");
-    metadata_val_test (matrix16, sizeof (matrix16) / (16 * sizeof (float)), TypeDesc::TypeMatrix, ret);
+    metadata_val_test (matrix16, sizeof (matrix16) / (16 * sizeof (float)), TypeMatrix, ret);
     OIIO_CHECK_EQUAL (ret, "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16, 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25");
 }
 
@@ -157,14 +157,14 @@ attribute_test (const std::string &data, TypeDesc type, std::string &ret)
 void test_imagespec_attribute_from_string ()
 {
     std::cout << "test_imagespec_attribute_from_string\n";
-    TypeDesc type = TypeDesc::TypeInt;
+    TypeDesc type = TypeInt;
     std::string ret, data, invalid_data;
 
     data = "142";
     attribute_test (data, type, ret);
     OIIO_CHECK_EQUAL (ret, data);
 
-    type = TypeDesc::TypeFloat;
+    type = TypeFloat;
     data = "1.23";
     attribute_test (data, type, ret);
     OIIO_CHECK_EQUAL (ret, data);
@@ -179,12 +179,12 @@ void test_imagespec_attribute_from_string ()
     attribute_test (data, type, ret);
     OIIO_CHECK_EQUAL (ret, data);
 
-    type = TypeDesc::TypeMatrix;
+    type = TypeMatrix;
     data = "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16";
     attribute_test (data, type, ret);
     OIIO_CHECK_EQUAL (ret, data);
 
-    type = TypeDesc::TypeString;
+    type = TypeString;
     data = "foo";
     attribute_test (data, type, ret);
     OIIO_CHECK_EQUAL (ret, "\"foo\"");

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -358,7 +358,7 @@ test_write (const std::string &explanation,
 static float
 time_loop_pixels_1D (ImageBuf &ib, int iters)
 {
-    ASSERT (ib.localpixels() && ib.pixeltype() == TypeDesc::TypeFloat);
+    ASSERT (ib.localpixels() && ib.pixeltype() == TypeFloat);
     const ImageSpec &spec (ib.spec());
     imagesize_t npixels = spec.image_pixels();
     int nchannels = spec.nchannels;
@@ -380,7 +380,7 @@ time_loop_pixels_1D (ImageBuf &ib, int iters)
 static float
 time_loop_pixels_3D (ImageBuf &ib, int iters)
 {
-    ASSERT (ib.localpixels() && ib.pixeltype() == TypeDesc::TypeFloat);
+    ASSERT (ib.localpixels() && ib.pixeltype() == TypeFloat);
     const ImageSpec &spec (ib.spec());
     imagesize_t npixels = spec.image_pixels();
     int nchannels = spec.nchannels;
@@ -406,7 +406,7 @@ time_loop_pixels_3D (ImageBuf &ib, int iters)
 static float
 time_loop_pixels_3D_getchannel (ImageBuf &ib, int iters)
 {
-    ASSERT (ib.pixeltype() == TypeDesc::TypeFloat);
+    ASSERT (ib.pixeltype() == TypeFloat);
     const ImageSpec &spec (ib.spec());
     imagesize_t npixels = spec.image_pixels();
     double sum = 0.0f;
@@ -428,7 +428,7 @@ time_loop_pixels_3D_getchannel (ImageBuf &ib, int iters)
 static float
 time_iterate_pixels (ImageBuf &ib, int iters)
 {
-    ASSERT (ib.pixeltype() == TypeDesc::TypeFloat);
+    ASSERT (ib.pixeltype() == TypeFloat);
     const ImageSpec &spec (ib.spec());
     imagesize_t npixels = spec.image_pixels();
     double sum = 0.0f;
@@ -446,7 +446,7 @@ time_iterate_pixels (ImageBuf &ib, int iters)
 static float
 time_iterate_pixels_slave_pos (ImageBuf &ib, int iters)
 {
-    ASSERT (ib.pixeltype() == TypeDesc::TypeFloat);
+    ASSERT (ib.pixeltype() == TypeFloat);
     const ImageSpec &spec (ib.spec());
     imagesize_t npixels = spec.image_pixels();
     double sum = 0.0f;
@@ -466,7 +466,7 @@ time_iterate_pixels_slave_pos (ImageBuf &ib, int iters)
 static float
 time_iterate_pixels_slave_incr (ImageBuf &ib, int iters)
 {
-    ASSERT (ib.pixeltype() == TypeDesc::TypeFloat);
+    ASSERT (ib.pixeltype() == TypeFloat);
     const ImageSpec &spec (ib.spec());
     imagesize_t npixels = spec.image_pixels();
     double sum = 0.0f;
@@ -493,7 +493,7 @@ test_pixel_iteration (const std::string &explanation,
     imagecache->attribute ("autotile", autotile);
     imagecache->attribute ("autoscanline", 1);
     ImageBuf ib (input_filename[0].string(), imagecache);
-    ib.read (0, 0, preload, TypeDesc::TypeFloat);
+    ib.read (0, 0, preload, TypeFloat);
     double t = time_trial (std::bind(func,std::ref(ib),iters), ntrials);
     double rate = double(ib.spec().image_pixels()) / (t/iters);
     std::cout << "  " << explanation << ": "

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -246,7 +246,7 @@ resize_block_ (ImageBuf &dst, const ImageBuf &src, ROI roi, bool envlatlmode)
     float xscale = 1.0f / (float)dstspec.full_width;
     float yscale = 1.0f / (float)dstspec.full_height;
     int nchannels = dst.nchannels();
-    ASSERT (dst.spec().format == TypeDesc::TypeFloat);
+    ASSERT (dst.spec().format == TypeFloat);
     ImageBuf::Iterator<float> d (dst, roi);
     for (int y = y0;  y < y1;  ++y) {
         float t = (y+0.5f)*yscale + yoffset;
@@ -348,7 +348,7 @@ resize_block (ImageBuf &dst, const ImageBuf &src, ROI roi, bool envlatlmode,
         OIIO_DISPATCH_TYPES (ok, "resize_block_2pass", resize_block_2pass,
                              srcspec.format, dst, src, roi, allow_shift);
     } else {
-        ASSERT (dst.spec().format == TypeDesc::TypeFloat);
+        ASSERT (dst.spec().format == TypeFloat);
         OIIO_DISPATCH_TYPES (ok, "resize_block", resize_block_, srcspec.format,
                              dst, src, roi, envlatlmode);
     }

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -530,7 +530,7 @@ ImageCacheFile::open (ImageCachePerThreadInfo *thread_info)
             (tempspec.width > 1 || tempspec.height > 1 || tempspec.depth > 1))
             si.unmipped = true;
         if (si.unmipped && imagecache().automip() &&
-            ! tempspec.find_attribute ("textureformat", TypeDesc::TypeString)) {
+            ! tempspec.find_attribute ("textureformat", TypeString)) {
             int w = tempspec.full_width;
             int h = tempspec.full_height;
             int d = tempspec.full_depth;
@@ -666,11 +666,11 @@ ImageCacheFile::init_from_spec ()
 #if USE_SHADOW_MATRICES
     Imath::M44f c2w;
     m_imagecache.get_commontoworld (c2w);
-    if ((p = spec.find_attribute ("worldtocamera", TypeDesc::TypeMatrix))) {
+    if ((p = spec.find_attribute ("worldtocamera", TypeMatrix))) {
         const Imath::M44f *m = (const Imath::M44f *)p->data();
         m_Mlocal = c2w * (*m);
     }
-    if ((p = spec.find_attribute ("worldtoscreen", TypeDesc::TypeMatrix))) {
+    if ((p = spec.find_attribute ("worldtoscreen", TypeMatrix))) {
         const Imath::M44f *m = (const Imath::M44f *)p->data();
         m_Mproj = c2w * (*m);
     }
@@ -1085,7 +1085,7 @@ ImageCacheFile::get_average_color (float *avg, int subimage,
             bool ok = m_imagecache.get_pixels (this, NULL, subimage, nlevels-1,
                              spec.x, spec.x+1, spec.y, spec.y+1,
                              spec.z, spec.z+1, 0, spec.nchannels,
-                             TypeDesc::TypeFloat, &si.average_color[0]);
+                             TypeFloat, &si.average_color[0]);
             si.has_average_color = ok;
         }
     }
@@ -2153,12 +2153,12 @@ ImageCacheImpl::getattribute (string_view name, TypeDesc type,
         *(ustring *)val = m_plugin_searchpath;
         return true;
     }
-    if (name == "worldtocommon" && (type == TypeDesc::TypeMatrix ||
+    if (name == "worldtocommon" && (type == TypeMatrix ||
                                     type == TypeDesc(TypeDesc::FLOAT,16))) {
         *(Imath::M44f *)val = m_Mw2c;
         return true;
     }
-    if (name == "commontoworld" && (type == TypeDesc::TypeMatrix ||
+    if (name == "commontoworld" && (type == TypeMatrix ||
                                     type == TypeDesc(TypeDesc::FLOAT,16))) {
         *(Imath::M44f *)val = m_Mc2w;
         return true;
@@ -2468,7 +2468,7 @@ ImageCacheImpl::get_image_info (ImageCacheFile *file,
     }
 
     file = verify_file (file, thread_info, true);
-    if (dataname == s_exists && datatype == TypeDesc::TypeInt) {
+    if (dataname == s_exists && datatype == TypeInt) {
         // Just check for existence.  Need to do this before the invalid
         // file error below, since in this one case, it's not an error
         // for the file to be nonexistant or broken!
@@ -2502,7 +2502,7 @@ ImageCacheImpl::get_image_info (ImageCacheFile *file,
     }
     // No other queries below are expected to work with broken
 
-    if (dataname == s_UDIM && datatype == TypeDesc::TypeInt) {
+    if (dataname == s_UDIM && datatype == TypeInt) {
         // Just check for existence.  Need to do this before the invalid
         // file error below, since in this one case, it's not an error
         // for the file to be nonexistant or broken!
@@ -2532,7 +2532,7 @@ ImageCacheImpl::get_image_info (ImageCacheFile *file,
     if (file->is_udim()) {
         return false;     // UDIM-like files fail all other queries
     }
-    if (dataname == s_subimages && datatype == TypeDesc::TypeInt) {
+    if (dataname == s_subimages && datatype == TypeInt) {
         *(int *)data = file->subimages();
         return true;
     }
@@ -2566,38 +2566,38 @@ ImageCacheImpl::get_image_info (ImageCacheFile *file,
         d[2] = spec.depth;
         return true;
     }
-    if (dataname == s_texturetype && datatype == TypeDesc::TypeString) {
+    if (dataname == s_texturetype && datatype == TypeString) {
         ustring s (texture_type_name (file->textureformat()));
         *(const char **)data = s.c_str();
         return true;
     }
-    if (dataname == s_textureformat && datatype == TypeDesc::TypeString) {
+    if (dataname == s_textureformat && datatype == TypeString) {
         ustring s (texture_format_name (file->textureformat()));
         *(const char **)data = s.c_str();
         return true;
     }
-    if (dataname == s_fileformat && datatype == TypeDesc::TypeString) {
+    if (dataname == s_fileformat && datatype == TypeString) {
         *(const char **)data = file->fileformat().c_str();
         return true;
     }
-    if (dataname == s_channels && datatype == TypeDesc::TypeInt) {
+    if (dataname == s_channels && datatype == TypeInt) {
         *(int *)data = spec.nchannels;
         return true;
     }
-    if (dataname == s_channels && datatype == TypeDesc::TypeFloat) {
+    if (dataname == s_channels && datatype == TypeFloat) {
         *(float *)data = spec.nchannels;
         return true;
     }
-    if (dataname == s_format && datatype == TypeDesc::TypeInt) {
+    if (dataname == s_format && datatype == TypeInt) {
         *(int *)data = (int) spec.format.basetype;
         return true;
     }
     if ((dataname == s_cachedformat || dataname == s_cachedpixeltype) &&
-            datatype == TypeDesc::TypeInt) {
+            datatype == TypeInt) {
         *(int *)data = (int) file->datatype(subimage).basetype;
         return true;
     }
-    if (dataname == s_miplevels && datatype == TypeDesc::TypeInt) {
+    if (dataname == s_miplevels && datatype == TypeInt) {
         *(int *)data = file->miplevels(subimage);
         return true;
     }

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -452,32 +452,32 @@ TextureSystemImpl::attribute (string_view name, TypeDesc type,
     if (name == "options" && type == TypeDesc::STRING) {
         return optparser (*this, *(const char **)val);
     }
-    if (name == "worldtocommon" && (type == TypeDesc::TypeMatrix ||
+    if (name == "worldtocommon" && (type == TypeMatrix ||
                                     type == TypeDesc(TypeDesc::FLOAT,16))) {
         m_Mw2c = *(const Imath::M44f *)val;
         m_Mc2w = m_Mw2c.inverse();
         return true;
     }
-    if (name == "commontoworld" && (type == TypeDesc::TypeMatrix ||
+    if (name == "commontoworld" && (type == TypeMatrix ||
                                     type == TypeDesc(TypeDesc::FLOAT,16))) {
         m_Mc2w = *(const Imath::M44f *)val;
         m_Mw2c = m_Mc2w.inverse();
         return true;
     }
     if ((name == "gray_to_rgb" || name == "grey_to_rgb") &&
-        (type == TypeDesc::TypeInt)) {
+        (type == TypeInt)) {
         m_gray_to_rgb = *(const int *)val;
         return true;
     }
-    if (name == "flip_t" && type == TypeDesc::TypeInt) {
+    if (name == "flip_t" && type == TypeInt) {
         m_flip_t = *(const int *)val;
         return true;
     }
-    if (name == "m_max_tile_channels" && type == TypeDesc::TypeInt) {
+    if (name == "m_max_tile_channels" && type == TypeInt) {
         m_max_tile_channels = *(const int *)val;
         return true;
     }
-    if (name == "statistics:level" && type == TypeDesc::TypeInt) {
+    if (name == "statistics:level" && type == TypeInt) {
         m_statslevel = *(const int *)val;
         // DO NOT RETURN! pass the same message to the image cache
     }
@@ -492,26 +492,26 @@ bool
 TextureSystemImpl::getattribute (string_view name, TypeDesc type,
                                  void *val) const
 {
-    if (name == "worldtocommon" && (type == TypeDesc::TypeMatrix ||
+    if (name == "worldtocommon" && (type == TypeMatrix ||
                                     type == TypeDesc(TypeDesc::FLOAT,16))) {
         *(Imath::M44f *)val = m_Mw2c;
         return true;
     }
-    if (name == "commontoworld" && (type == TypeDesc::TypeMatrix ||
+    if (name == "commontoworld" && (type == TypeMatrix ||
                                     type == TypeDesc(TypeDesc::FLOAT,16))) {
         *(Imath::M44f *)val = m_Mc2w;
         return true;
     }
     if ((name == "gray_to_rgb" || name == "grey_to_rgb") &&
-        (type == TypeDesc::TypeInt)) {
+        (type == TypeInt)) {
         *(int *)val = m_gray_to_rgb;
         return true;
     }
-    if (name == "flip_t" && type == TypeDesc::TypeInt) {
+    if (name == "flip_t" && type == TypeInt) {
         *(int *)val = m_flip_t;
         return true;
     }
-    if (name == "m_max_tile_channels" && type == TypeDesc::TypeInt) {
+    if (name == "m_max_tile_channels" && type == TypeInt) {
         *(int *)val = m_max_tile_channels;
         return true;
     }

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -214,7 +214,7 @@ ParamValue::get_float (float defaultval) const
         if (Strutil::parse_float(str, val) && str.empty())
             return val;
     }
-    if (type() == TypeDesc::TypeRational) {
+    if (type() == TypeRational) {
         int num = get<int>(0);
         int den = get<int>(1);
         return den ? float(num)/float(den) : 0.0f;

--- a/src/libutil/paramlist_test.cpp
+++ b/src/libutil/paramlist_test.cpp
@@ -72,18 +72,18 @@ void test_value_types ()
 
     {
         int imatrix[] = {100, 200, 300, 400};
-        ret = test_one_value (&imatrix[0], 1, TypeDesc::TypeInt);
+        ret = test_one_value (&imatrix[0], 1, TypeInt);
         OIIO_CHECK_EQUAL (ret, "100");
-        ret = test_one_value (imatrix, sizeof (imatrix)/sizeof(int), TypeDesc::TypeInt);
+        ret = test_one_value (imatrix, sizeof (imatrix)/sizeof(int), TypeInt);
         OIIO_CHECK_EQUAL (ret, "100, 200, 300, 400");
         OIIO_CHECK_NE (ret, "100, 200, 300, 400,");
     }
 
     {
         float fmatrix[] = {10.12f, 200.34f, 300.11f, 400.9f};
-        ret = test_one_value (&fmatrix[0], 1, TypeDesc::TypeFloat);
+        ret = test_one_value (&fmatrix[0], 1, TypeFloat);
         OIIO_CHECK_EQUAL (ret, "10.12");
-        ret = test_one_value (fmatrix, sizeof (fmatrix) / sizeof (float), TypeDesc::TypeFloat);
+        ret = test_one_value (fmatrix, sizeof (fmatrix) / sizeof (float), TypeFloat);
         OIIO_CHECK_EQUAL (ret, "10.12, 200.34, 300.11, 400.9");
         OIIO_CHECK_NE (ret, "10, 200, 300, 400");
         OIIO_CHECK_NE (ret, "10.12, 200.34, 300.11, 400.9,");
@@ -101,26 +101,26 @@ void test_value_types ()
 
     {
         const char* smatrix[] = {"this is \"a test\"", "this is another test"};
-        ret = test_one_value (smatrix, 1, TypeDesc::TypeString);
+        ret = test_one_value (smatrix, 1, TypeString);
         OIIO_CHECK_EQUAL (ret, "this is \"a test\"");
-        ret = test_one_value (smatrix, sizeof (smatrix) / sizeof (char *), TypeDesc::TypeString);
+        ret = test_one_value (smatrix, sizeof (smatrix) / sizeof (char *), TypeString);
         OIIO_CHECK_EQUAL (ret, "\"this is \\\"a test\\\"\", \"this is another test\"");
     }
 
     {
         float matrix16[2][16] = {{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
         {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25}};
-        ret = test_one_value (&matrix16[0], 1, TypeDesc::TypeMatrix);
+        ret = test_one_value (&matrix16[0], 1, TypeMatrix);
         OIIO_CHECK_EQUAL (ret, "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16");
         OIIO_CHECK_NE (ret, "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16,");
-        ret = test_one_value (matrix16, sizeof (matrix16) / (16 * sizeof (float)), TypeDesc::TypeMatrix);
+        ret = test_one_value (matrix16, sizeof (matrix16) / (16 * sizeof (float)), TypeMatrix);
         OIIO_CHECK_EQUAL (ret, "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16, 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25");
     }
 
     // Test rational
     {
         int rat[2] = { 1, 2 };
-        ParamValue p ("name", TypeDesc::TypeRational, 1, rat);
+        ParamValue p ("name", TypeRational, 1, rat);
         // make sure we can retrieve it as int[2] (numerator, denominator)
         OIIO_CHECK_EQUAL (p.get<int>(0), rat[0]);
         OIIO_CHECK_EQUAL (p.get<int>(1), rat[1]);
@@ -145,13 +145,13 @@ list_test (const std::string &data, TypeDesc type)
 void test_from_string ()
 {
     std::cout << "test_from_string\n";
-    TypeDesc type = TypeDesc::TypeInt;
+    TypeDesc type = TypeInt;
     std::string ret, data, invalid_data;
 
     data = "142";
     OIIO_CHECK_EQUAL (data, list_test(data,type));
 
-    type = TypeDesc::TypeFloat;
+    type = TypeFloat;
     data = "1.23";
     OIIO_CHECK_EQUAL (data, list_test(data,type));
 
@@ -163,11 +163,11 @@ void test_from_string ()
     data = "18446744073709551615";
     OIIO_CHECK_EQUAL (data, list_test(data,type));
 
-    type = TypeDesc::TypeMatrix;
+    type = TypeMatrix;
     data = "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16";
     OIIO_CHECK_EQUAL (data, list_test(data,type));
 
-    type = TypeDesc::TypeString;
+    type = TypeString;
     data = "foo";
     OIIO_CHECK_EQUAL (data, list_test(data,type));
 }

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -357,9 +357,9 @@ getargs (int argc, char *argv[], ImageSpec &configspec)
         configspec.attribute ("fovcot", fovcot);
     configspec.attribute ("planarconfig", separate ? "separate" : "contig");
     if (Mcam != Imath::M44f(0.0f))
-        configspec.attribute ("worldtocamera", TypeDesc::TypeMatrix, &Mcam);
+        configspec.attribute ("worldtocamera", TypeMatrix, &Mcam);
     if (Mscr != Imath::M44f(0.0f))
-        configspec.attribute ("worldtoscreen", TypeDesc::TypeMatrix, &Mscr);
+        configspec.attribute ("worldtoscreen", TypeMatrix, &Mscr);
     std::string wrapmodes = (swrap.size() ? swrap : wrap) + ',' + 
                             (twrap.size() ? twrap : wrap);
     configspec.attribute ("wrapmodes", wrapmodes);

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -239,7 +239,7 @@ ImageRec::read (ReadPolicy readpolicy, string_view channel_set)
     int subimages = 0;
     ustring uname (name());
     if (! m_imagecache->get_image_info (uname, 0, 0, u_subimages,
-                                        TypeDesc::TypeInt, &subimages)) {
+                                        TypeInt, &subimages)) {
         error ("file not found: \"%s\"", name());
         return false;  // Image not found
     }
@@ -248,7 +248,7 @@ ImageRec::read (ReadPolicy readpolicy, string_view channel_set)
     for (int s = 0;  s < subimages;  ++s) {
         int miplevels = 0;
         m_imagecache->get_image_info (uname, s, 0, u_miplevels,
-                                      TypeDesc::TypeInt, &miplevels);
+                                      TypeInt, &miplevels);
         m_subimages[s].m_miplevels.resize (miplevels);
         m_subimages[s].m_specs.resize (miplevels);
         for (int m = 0;  m < miplevels;  ++m) {

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -726,7 +726,7 @@ set_string_attribute (int argc, const char *argv[])
         ot.warning (argv[0], "no current image available to modify");
         return 0;
     }
-    set_attribute (ot.curimg, argv[1], TypeDesc::TypeString, argv[2],
+    set_attribute (ot.curimg, argv[1], TypeString, argv[2],
                    ot.allsubimages);
     // N.B. set_attribute does expression expansion on its args
     return 0;
@@ -1323,7 +1323,7 @@ OiioTool::set_attribute (ImageRecRef img, string_view attribname,
         }
         return true;
     }
-    if (type == TypeDesc::TypeTimeCode && value.find(':') != value.npos) {
+    if (type == TypeTimeCode && value.find(':') != value.npos) {
         // Special case: They are specifying a TimeCode as a "HH:MM:SS:FF"
         // string, we need to re-encode as a uint32[2].
         int hour = 0, min = 0, sec = 0, frame = 0;
@@ -1341,7 +1341,7 @@ OiioTool::set_attribute (ImageRecRef img, string_view attribname,
         }
         return true;
     }
-    if (type == TypeDesc::TypeRational && value.find('/') != value.npos) {
+    if (type == TypeRational && value.find('/') != value.npos) {
         // Special case: They are specifying a rational as "a/b", so we need
         // to re-encode as a int32[2].
         int v[2];
@@ -4205,7 +4205,7 @@ input_file (int argc, const char *argv[])
             }
         }
         if (! ot.imagecache->get_image_info (ustring(filename), 0, 0,
-                            ustring("exists"), TypeDesc::TypeInt, &exists)
+                            ustring("exists"), TypeInt, &exists)
             || !exists) {
             // Try to get a more precise error message to report
             ImageInput *input = ImageInput::create (filename);

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -565,13 +565,13 @@ OpenEXRInput::PartInfo::parse_header (const Imf::Header *header)
             spec.attribute (oname, fattr->value());
         else if (type == "m33f" &&
             (m33fattr = header->findTypedAttribute<Imf::M33fAttribute> (name)))
-            spec.attribute (oname, TypeDesc::TypeMatrix33, &(m33fattr->value()));
+            spec.attribute (oname, TypeMatrix33, &(m33fattr->value()));
         else if (type == "m44f" &&
             (m44fattr = header->findTypedAttribute<Imf::M44fAttribute> (name)))
-            spec.attribute (oname, TypeDesc::TypeMatrix44, &(m44fattr->value()));
+            spec.attribute (oname, TypeMatrix44, &(m44fattr->value()));
         else if (type == "v3f" &&
                  (v3fattr = header->findTypedAttribute<Imf::V3fAttribute> (name)))
-            spec.attribute (oname, TypeDesc::TypeVector, &(v3fattr->value()));
+            spec.attribute (oname, TypeVector, &(v3fattr->value()));
         else if (type == "v3i" &&
                  (v3iattr = header->findTypedAttribute<Imf::V3iAttribute> (name))) {
             TypeDesc v3 (TypeDesc::INT, TypeDesc::VEC3, TypeDesc::VECTOR);
@@ -640,7 +640,7 @@ OpenEXRInput::PartInfo::parse_header (const Imf::Header *header)
             // Elevate "timeCode" to smpte:TimeCode
             if (oname == "timeCode")
                 oname = "smpte:TimeCode";
-            spec.attribute(oname, TypeDesc::TypeTimeCode, timecode);
+            spec.attribute(oname, TypeTimeCode, timecode);
         }
         else if (type == "keycode" &&
                  (kcattr = header->findTypedAttribute<Imf::KeyCodeAttribute> (name))) {
@@ -657,7 +657,7 @@ OpenEXRInput::PartInfo::parse_header (const Imf::Header *header)
             // Elevate "keyCode" to smpte:KeyCode
             if (oname == "keyCode")
                 oname = "smpte:KeyCode";
-            spec.attribute(oname, TypeDesc::TypeKeyCode, keycode);
+            spec.attribute(oname, TypeKeyCode, keycode);
         } else if (type == "chromaticities" &&
                    (crattr = header->findTypedAttribute<Imf::ChromaticitiesAttribute> (name))) {
             const Imf::Chromaticities *chroma = &crattr->value();
@@ -674,13 +674,13 @@ OpenEXRInput::PartInfo::parse_header (const Imf::Header *header)
                 r[0] = n;
                 r[1] = static_cast<int>(d);
                 OIIO::debug ("adding rational with numerator %d and denominator %u (easy case)", n, d);
-                spec.attribute (oname, TypeDesc::TypeRational, r);    
+                spec.attribute (oname, TypeRational, r);    
             } else if (int f = static_cast<int>(boost::math::gcd<long int>(rational[0], rational[1])) > 1) {
                 int r[2];
                 r[0] = n / f;
                 r[1] = static_cast<int>(d / f);
                 OIIO::debug ("adding rational with numerator %d and denominator %u (hard case)", n, d);
-               spec.attribute (oname, TypeDesc::TypeRational, r);
+               spec.attribute (oname, TypeRational, r);
             } else {
                 // TODO: find a way to allow the client to accept "close" rational values
                 OIIO::debug ("Don't know what to do with OpenEXR Rational attribute %s with value %d / %u that we cannot represent exactly", oname, n, d);

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -84,7 +84,7 @@ ImageBuf_reset_spec (ImageBuf &buf, const ImageSpec &spec)
 
 bool
 ImageBuf_read (ImageBuf &buf, int subimage=0, int miplevel=0,
-               bool force=false, TypeDesc convert=TypeDesc::UNKNOWN)
+               bool force=false, TypeDesc convert=TypeUnknown)
 {
     ScopedGILRelease gil;
     return buf.read (subimage, miplevel, force, convert);
@@ -139,7 +139,7 @@ ImageBuf_set_write_format (ImageBuf &buf, TypeDesc::BASETYPE format)
 
 bool
 ImageBuf_copy (ImageBuf &buf, const ImageBuf &src,
-               TypeDesc format = TypeDesc::UNKNOWN)
+               TypeDesc format = TypeUnknown)
 {
     ScopedGILRelease gil;
     return buf.copy (src, format);
@@ -358,7 +358,7 @@ ImageBuf_set_pixels_tuple (ImageBuf &buf, ROI roi, const tuple& data)
     py_to_stdvector (vals, data);
     if (size > vals.size())
         return false;   // Not enough data to fill our ROI
-    buf.set_pixels (roi, TypeDesc::TypeFloat, &vals[0]);
+    buf.set_pixels (roi, TypeFloat, &vals[0]);
     return true;
 }
 
@@ -384,9 +384,9 @@ ImageBuf_set_pixels_array (ImageBuf &buf, ROI roi, const object& data)
     if (!addr || size > numelements)
         return false;   // Not enough data to fill our ROI
     std::vector<float> vals (numelements);
-    convert_types (elementtype, addr, TypeDesc::TypeFloat, vals.data(),
+    convert_types (elementtype, addr, TypeFloat, vals.data(),
                    int(numelements));
-    buf.set_pixels (roi, TypeDesc::TypeFloat, &vals[0]);
+    buf.set_pixels (roi, TypeFloat, &vals[0]);
     return true;
 }
 

--- a/src/python/py_typedesc.cpp
+++ b/src/python/py_typedesc.cpp
@@ -161,21 +161,41 @@ void declare_typedesc() {
         .def(str(self))    // __str__
 
         // Static members of pre-constructed types
-        .def_readonly("TypeFloat",    &TypeDesc::TypeFloat)
-        .def_readonly("TypeColor",    &TypeDesc::TypeColor)
-        .def_readonly("TypeString",   &TypeDesc::TypeString)
-        .def_readonly("TypeInt",      &TypeDesc::TypeInt)
-        .def_readonly("TypeHalf",     &TypeDesc::TypeHalf)
-        .def_readonly("TypePoint",    &TypeDesc::TypePoint)
-        .def_readonly("TypeVector",   &TypeDesc::TypeVector)
-        .def_readonly("TypeNormal",   &TypeDesc::TypeNormal)
-        .def_readonly("TypeMatrix",   &TypeDesc::TypeMatrix)
-        .def_readonly("TypeMatrix33", &TypeDesc::TypeMatrix33)
-        .def_readonly("TypeMatrix44", &TypeDesc::TypeMatrix44)
-        .def_readonly("TypeTimeCode", &TypeDesc::TypeTimeCode)
-        .def_readonly("TypeKeyCode",  &TypeDesc::TypeKeyCode)
-        .def_readonly("TypeFloat4",   &TypeDesc::TypeFloat4)
+        // DEPRECATED(1.8)
+        .def_readonly("TypeFloat",    &TypeFloat)
+        .def_readonly("TypeColor",    &TypeColor)
+        .def_readonly("TypeString",   &TypeString)
+        .def_readonly("TypeInt",      &TypeInt)
+        .def_readonly("TypeHalf",     &TypeHalf)
+        .def_readonly("TypePoint",    &TypePoint)
+        .def_readonly("TypeVector",   &TypeVector)
+        .def_readonly("TypeNormal",   &TypeNormal)
+        .def_readonly("TypeMatrix",   &TypeMatrix)
+        .def_readonly("TypeMatrix33", &TypeMatrix33)
+        .def_readonly("TypeMatrix44", &TypeMatrix44)
+        .def_readonly("TypeTimeCode", &TypeTimeCode)
+        .def_readonly("TypeKeyCode",  &TypeKeyCode)
+        .def_readonly("TypeFloat4",   &TypeFloat4)
     ;
+
+    // Global constants of common TypeDescs
+    scope().attr("TypeUnknown")  = TypeUnknown;
+    scope().attr("TypeFloat")    = TypeFloat;
+    scope().attr("TypeColor")    = TypeColor;
+    scope().attr("TypePoint")    = TypePoint;
+    scope().attr("TypeVector")   = TypeVector;
+    scope().attr("TypeNormal")   = TypeNormal;
+    scope().attr("TypeString")   = TypeString;
+    scope().attr("TypeInt")      = TypeInt;
+    scope().attr("TypeUInt")     = TypeUInt;
+    scope().attr("TypeHalf")     = TypeHalf;
+    scope().attr("TypeMatrix")   = TypeMatrix;
+    scope().attr("TypeMatrix33") = TypeMatrix33;
+    scope().attr("TypeMatrix44") = TypeMatrix44;
+    scope().attr("TypeTimeCode") = TypeTimeCode;
+    scope().attr("TypeKeyCode")  = TypeKeyCode;
+    scope().attr("TypeFloat4")   = TypeFloat4;
+    scope().attr("TypeRational") = TypeRational;
 
 }
 

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -305,7 +305,7 @@ test_gettextureinfo (ustring filename)
         std::cout << " " << avg[0] << ' ' << avg[1] << ' '
                   << avg[2] << ' ' << avg[3] << "\n";
     ok = texsys->get_texture_info (filename, 0, ustring("averagealpha"),
-                                   TypeDesc::TypeFloat, avg);
+                                   TypeFloat, avg);
     std::cout << "Result of get_texture_info averagealpha = " << (ok?"yes":"no\n");
     if (ok)
         std::cout << " " << avg[0] << "\n";
@@ -1363,7 +1363,7 @@ main (int argc, const char *argv[])
     if (cachesize >= 0)
         texsys->attribute ("max_memory_MB", cachesize);
     else
-        texsys->getattribute ("max_memory_MB", TypeDesc::TypeFloat, &cachesize);
+        texsys->getattribute ("max_memory_MB", TypeFloat, &cachesize);
     if (maxfiles >= 0)
         texsys->attribute ("max_open_files", maxfiles);
     if (searchpath.length())

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -267,7 +267,7 @@ private:
     void get_matrix_attribute (string_view name, int tag) {
         float *f = NULL;
         if (safe_tiffgetfield (name, tag, &f) && f)
-            m_spec.attribute (name, TypeDesc::TypeMatrix, f);
+            m_spec.attribute (name, TypeMatrix, f);
     }
 
     // Get a float tiff tag field and put it into extra_params

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -692,11 +692,11 @@ TIFFOutput::put_parameter (const std::string &name, TypeDesc type,
         TIFFSetField (m_tif, TIFFTAG_PIXAR_WRAPMODES, *(char**)data);
         return true;
     }
-    if (Strutil::iequals(name, "worldtocamera") && type == TypeDesc::TypeMatrix) {
+    if (Strutil::iequals(name, "worldtocamera") && type == TypeMatrix) {
         TIFFSetField (m_tif, TIFFTAG_PIXAR_MATRIX_WORLDTOCAMERA, data);
         return true;
     }
-    if (Strutil::iequals(name, "worldtoscreen") && type == TypeDesc::TypeMatrix) {
+    if (Strutil::iequals(name, "worldtoscreen") && type == TypeMatrix) {
         TIFFSetField (m_tif, TIFFTAG_PIXAR_MATRIX_WORLDTOSCREEN, data);
         return true;
     }

--- a/src/zfile.imageio/zfile.cpp
+++ b/src/zfile.imageio/zfile.cpp
@@ -199,9 +199,9 @@ ZfileInput::open (const std::string &name, ImageSpec &newspec)
         m_spec.channelnames[0] = "z";
     m_spec.z_channel = 0;
 
-    m_spec.attribute ("worldtoscreen", TypeDesc::TypeMatrix,
+    m_spec.attribute ("worldtoscreen", TypeMatrix,
                       (float *)&header.worldtoscreen);
-    m_spec.attribute ("worldtocamera", TypeDesc::TypeMatrix,
+    m_spec.attribute ("worldtocamera", TypeMatrix,
                       (float *)&header.worldtocamera);
 
     newspec = spec ();
@@ -294,11 +294,11 @@ ZfileOutput::open (const std::string &name, const ImageSpec &userspec,
 
     ParamValue *p;
     static float ident[16] = { 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 };
-    if ((p = m_spec.find_attribute ("worldtocamera", TypeDesc::TypeMatrix)))
+    if ((p = m_spec.find_attribute ("worldtocamera", TypeMatrix)))
         memcpy (header.worldtocamera, p->data(), 16*sizeof(float));
     else
         memcpy (header.worldtocamera, ident, 16*sizeof(float));
-    if ((p = m_spec.find_attribute ("worldtoscreen", TypeDesc::TypeMatrix)))
+    if ((p = m_spec.find_attribute ("worldtoscreen", TypeMatrix)))
         memcpy (header.worldtoscreen, p->data(), 16*sizeof(float));
     else
         memcpy (header.worldtoscreen, ident, 16*sizeof(float));

--- a/testsuite/python-typedesc/ref/out.txt
+++ b/testsuite/python-typedesc/ref/out.txt
@@ -149,4 +149,37 @@ type 'TypeFloat4'
 type 'TypeHalf'
     c_str "half"
 
+type 'TypeFloat'
+    c_str "float"
+type 'TypeColor'
+    c_str "color"
+type 'TypeString'
+    c_str "string"
+type 'TypeInt'
+    c_str "int"
+type 'TypePoint'
+    c_str "point"
+type 'TypeVector'
+    c_str "vector"
+type 'TypeNormal'
+    c_str "normal"
+type 'TypeMatrix'
+    c_str "matrix"
+type 'TypeMatrix33'
+    c_str "matrix33"
+type 'TypeMatrix44'
+    c_str "matrix"
+type 'TypeTimeCode'
+    c_str "timecode"
+type 'TypeKeyCode'
+    c_str "keycode"
+type 'TypeFloat4'
+    c_str "float4"
+type 'TypeHalf'
+    c_str "half"
+type 'TypeRational'
+    c_str "rational2i"
+type 'TypeUInt'
+    c_str "uint"
+
 Done.

--- a/testsuite/python-typedesc/src/test_typedesc.py
+++ b/testsuite/python-typedesc/src/test_typedesc.py
@@ -128,7 +128,7 @@ try:
     print "equivalent(vector,float)", oiio.TypeDesc.equivalent(oiio.TypeDesc("vector"), oiio.TypeDesc("float"))
     print
 
-    # Test the static data member types of pre-constructed types
+    # DEPRECATED(1.8): Test the static data member types of pre-constructed types
     breakdown_test (oiio.TypeDesc.TypeFloat,    "TypeFloat",    verbose=False)
     breakdown_test (oiio.TypeDesc.TypeColor,    "TypeColor",    verbose=False)
     breakdown_test (oiio.TypeDesc.TypeString,   "TypeString",   verbose=False)
@@ -143,6 +143,25 @@ try:
     breakdown_test (oiio.TypeDesc.TypeKeyCode,  "TypeKeyCode",  verbose=False)
     breakdown_test (oiio.TypeDesc.TypeFloat4,   "TypeFloat4",   verbose=False)
     breakdown_test (oiio.TypeDesc.TypeHalf,     "TypeHalf",     verbose=False)
+    print
+
+    # Test the pre-constructed types
+    breakdown_test (oiio.TypeFloat,    "TypeFloat",    verbose=False)
+    breakdown_test (oiio.TypeColor,    "TypeColor",    verbose=False)
+    breakdown_test (oiio.TypeString,   "TypeString",   verbose=False)
+    breakdown_test (oiio.TypeInt,      "TypeInt",      verbose=False)
+    breakdown_test (oiio.TypePoint,    "TypePoint",    verbose=False)
+    breakdown_test (oiio.TypeVector,   "TypeVector",   verbose=False)
+    breakdown_test (oiio.TypeNormal,   "TypeNormal",   verbose=False)
+    breakdown_test (oiio.TypeMatrix,   "TypeMatrix",   verbose=False)
+    breakdown_test (oiio.TypeMatrix33, "TypeMatrix33", verbose=False)
+    breakdown_test (oiio.TypeMatrix44, "TypeMatrix44", verbose=False)
+    breakdown_test (oiio.TypeTimeCode, "TypeTimeCode", verbose=False)
+    breakdown_test (oiio.TypeKeyCode,  "TypeKeyCode",  verbose=False)
+    breakdown_test (oiio.TypeFloat4,   "TypeFloat4",   verbose=False)
+    breakdown_test (oiio.TypeHalf,     "TypeHalf",     verbose=False)
+    breakdown_test (oiio.TypeRational, "TypeRational", verbose=False)
+    breakdown_test (oiio.TypeUInt,     "TypeUInt",     verbose=False)
     print
 
     print "Done."


### PR DESCRIPTION
Previously, we had pre-constructed TypeDescs of common types as static data members of TypeDesc itself. This presented two (minor) problems:
1. Because their full definitions were in typedesc.cpp, all other modules did not know what was actually in the fields, so optimization opportunities were potentially missed.
2. There existed the potential for the static initialization order fiasco, if the compiler could not figure out that the definitions in typedesc.cpp could be expressed as POD and baked into the module without running the constructor at module load time.

So we are deprecating these, though they will stick around for another major release in order to not break any apps that are depending on them.

In their place, we are making OIIO-scoped 'static constexpr' versions. These serve the same purpose, but by being constexpr (yay, C++11!), they are should be turned into compile-time constants everyplace they are used, which is what we ideally wanted all along.


(When reviewing: typedesc.h is the place where the heavy lifting is done. All the rest is just documenting and using it.)


