### PR TITLE
Protect against bogus texture SHA-1 and other attributes

### DIFF
--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -105,6 +105,13 @@ const void *convert_from_float (const float *src, void *dst, size_t nvals,
 const void *parallel_convert_from_float (const float *src, void *dst,
                                          size_t nvals, TypeDesc format);
 
+/// Internal utility: Error checking on the spec -- if it contains texture-
+/// specific metadata but there are clues it's not actually a texture file
+/// written by maketx or `oiiotool -otex`, then assume these metadata are
+/// wrong and delete them. Return true if we think it's one of these
+/// incorrect files and it was fixed.
+bool check_texture_metadata_sanity (ImageSpec &spec);
+
 }  // namespace pvt
 
 OIIO_NAMESPACE_END

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -89,6 +89,7 @@
 #include <OpenImageIO/imagebufalgo_util.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/sysutil.h>
+#include "imageio_pvt.h"
 
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
@@ -703,6 +704,9 @@ OpenEXRInput::PartInfo::parse_header (const Imf::Header *header)
     // EXR "name" also gets passed along as "oiio:subimagename".
     if (header->hasName())
         spec.attribute ("oiio:subimagename", header->name());
+
+    // Squash some problematic texture metadata if we suspect it's wrong
+    pvt::check_texture_metadata_sanity (spec);
 
     initialized = true;
 }

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -45,6 +45,7 @@
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/fmath.h>
+#include "imageio_pvt.h"
 
 #ifdef USE_BOOST_REGEX
 # include <boost/regex.hpp>
@@ -1086,6 +1087,9 @@ TIFFInput::readspec (bool read_meta)
         else
             m_spec.erase_attribute ("ImageDescription");
     }
+
+    // Squash some problematic texture metadata if we suspect it's wrong
+    pvt::check_texture_metadata_sanity (m_spec);
 
     if (m_testopenconfig)  // open-with-config debugging
         m_spec.attribute ("oiio:DebugOpenConfig!", 42);

--- a/testsuite/maketx/ref/out-alt-tiff4-2.txt
+++ b/testsuite/maketx/ref/out-alt-tiff4-2.txt
@@ -320,7 +320,6 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     tiff:Compression: 8
     compression: "zip"
     tiff:RowsPerStrip: 32
-    oiio:SHA-1: "1234abcd ConstantColor=[0.0,0,-0.0] bar"
 Reading small.tx
 small.tx             :   64 x   64, 3 channel, uint8 tiff
     MIP-map levels: 64x64 32x32 16x16 8x8 4x4 2x2 1x1

--- a/testsuite/maketx/ref/out-alt-tiff4.txt
+++ b/testsuite/maketx/ref/out-alt-tiff4.txt
@@ -319,7 +319,6 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     tiff:Compression: 8
     compression: "zip"
     tiff:RowsPerStrip: 32
-    oiio:SHA-1: "1234abcd ConstantColor=[0.0,0,-0.0] bar"
 Reading small.tx
 small.tx             :   64 x   64, 3 channel, uint8 tiff
     MIP-map levels: 64x64 32x32 16x16 8x8 4x4 2x2 1x1

--- a/testsuite/maketx/ref/out.txt
+++ b/testsuite/maketx/ref/out.txt
@@ -334,7 +334,6 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     compression: "zip"
     tiff:RowsPerStrip: 32
     IPTC:Caption: "foo SHA-1=1234abcd ConstantColor=[0.0,0,-0.0] bar"
-    oiio:SHA-1: "1234abcd ConstantColor=[0.0,0,-0.0] bar"
 Reading small.tx
 small.tx             :   64 x   64, 3 channel, uint8 tiff
     MIP-map levels: 64x64 32x32 16x16 8x8 4x4 2x2 1x1

--- a/testsuite/oiiotool-maketx/ref/out.txt
+++ b/testsuite/oiiotool-maketx/ref/out.txt
@@ -325,7 +325,6 @@ small.tif            :   64 x   64, 3 channel, uint8 tiff
     tiff:Compression: 8
     compression: "zip"
     tiff:RowsPerStrip: 32
-    oiio:SHA-1: "1234abcd ConstantColor=[0.0,0,-0.0] bar"
 Reading small.tx
 small.tx             :   64 x   64, 3 channel, uint8 tiff
     MIP-map levels: 64x64 32x32 16x16 8x8 4x4 2x2 1x1


### PR DESCRIPTION
It came to my attention that somebody could take a maketx-generated (or,
`oiiotool -otex`, same thing) texture, load it in Photoshop or other
utility, change it, and save it, and it just might still have some of
the maketx-specific metadata in the altered file, such as the SHA-1 hash
that allows us to find duplicates, and those data may be totally wrong
in the new file.

So this patch is intended to do a sanity check: if there is no
"textureformat" metadata present, or if it's not tiled, or if the
"Software" metadata doesn't say maketx or OpenImageIO, then it can't
have come straight out of maketx/oiiotool, so erase any of the
problematic attributes that maketx writes, because they are very likely
wrong and no longer match the potentially modified pixel values in the
file.

Photoshop always writes scanline images, so the check for tiling works
for that case. It will catch others as well. Not perfect by any means,
but it's better than before and I'm not sure if we can ever be certain.
We still rely on users not being foolish -- please only use textures
that have passed through `maketx` or `oiiotool -otex` and don't modify
the pixels after that step without re-maketxing it.

