### PR TITLE
CMake: Fix Python detection on Gentoo Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,10 +185,10 @@ if (NOT EMBEDPLUGINS AND NOT BUILD_OIIOUTIL_ONLY)
     endforeach ()
 endif ()
 
-if (USE_PYTHON AND boost_PYTHON_FOUND AND NOT BUILD_OIIOUTIL_ONLY)
+if (USE_PYTHON AND Boost_PYTHON_FOUND AND NOT BUILD_OIIOUTIL_ONLY)
     add_subdirectory (src/python)
 endif ()
-if (USE_PYTHON3 AND boost_PYTHON_FOUND AND NOT BUILD_OIIOUTIL_ONLY)
+if (USE_PYTHON3 AND Boost_PYTHON_FOUND AND NOT BUILD_OIIOUTIL_ONLY)
     #build the python3 module in a different binary directory since it will
     #have the same name as the python2 module (e.g. OpenImageIO.so)
     add_subdirectory (src/python src/python3)

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -107,6 +107,10 @@ else ()
     find_package (Boost 1.53 REQUIRED
                   COMPONENTS ${Boost_COMPONENTS})
 
+    if (CMAKE_GENTOO_BUILD OR CMAKE_BUILD_TYPE STREQUAL Gentoo)
+        # Gentoo's patches to CMake make sure that we will always find exactly the version of Python required by Gentoo
+        find_package (Boost 1.53 COMPONENTS ${Boost_COMPONENTS} python)
+    else ()
     # Try to figure out if this boost distro has Boost::python.  If we
     # include python in the component list above, cmake will abort if
     # it's not found.  So we resort to checking for the boost_python
@@ -144,9 +148,10 @@ else ()
     endif ()
     if (my_boost_python_lib OR
         my_boost_PYTHON_LIBRARY_RELEASE OR my_boost_PYTHON_LIBRARY_DEBUG)
-        set (boost_PYTHON_FOUND ON)
+        set (Boost_PYTHON_FOUND ON)
     else ()
-        set (boost_PYTHON_FOUND OFF)
+        set (Boost_PYTHON_FOUND OFF)
+    endif ()
     endif ()
 endif ()
 
@@ -162,9 +167,9 @@ if (NOT Boost_FIND_QUIETLY)
     message (STATUS "Boost include dirs ${Boost_INCLUDE_DIRS}")
     message (STATUS "Boost library dirs ${Boost_LIBRARY_DIRS}")
     message (STATUS "Boost libraries    ${Boost_LIBRARIES}")
-    message (STATUS "Boost python found ${boost_PYTHON_FOUND}")
+    message (STATUS "Boost python found ${Boost_PYTHON_FOUND}")
 endif ()
-if (NOT boost_PYTHON_FOUND)
+if (NOT Boost_PYTHON_FOUND)
     # If Boost python components were not found, turn off all python support.
     message (STATUS "Boost python support not found -- will not build python components!")
     if (APPLE AND USE_PYTHON)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -8,7 +8,14 @@ else ()
     set (BUILD_PY3 OFF)
 endif ()
 
-if (NOT BOOST_CUSTOM AND NOT BUILD_PY3)
+if (CMAKE_GENTOO_BUILD OR CMAKE_BUILD_TYPE STREQUAL Gentoo)
+    # Gentoo's patches to CMake make sure that we will always find exactly the version of Python required by Gentoo
+    if (BUILD_PY3)
+        find_package (PythonInterp ${PYTHON3_VERSION} REQUIRED)
+        find_package (PythonLibs ${PYTHON3_VERSION} REQUIRED)
+    endif ()
+    find_package (Boost 1.53 REQUIRED COMPONENTS python)
+elseif (NOT BOOST_CUSTOM AND NOT BUILD_PY3)
     #Unset those, otherwise find_package(PythonLibs) will pick up old stuff
     #if it has been run before
     unset(Python_ADDITIONAL_VERSIONS)


### PR DESCRIPTION
## Description

This fixes Python detection on Gentoo Linux

## Tests

Tested by building on Gentoo Linux using [my modified ebuild](https://github.com/devurandom/gentoo-overlay/tree/master/media-libs/openimageio).

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] N/A: If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] N/A: I have updated the documentation, if applicable.
- [ ] N/A: I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] N/A: My code follows the prevailing code style of this project.

