### PR TITLE
Fixes for ifloor, fast_ifloor, floatfrac

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -444,9 +444,22 @@ bicubic_interp (const T **val, T s, T t, int n, T *result)
 
 
 
-/// Return floor(x) as an int, as efficiently as possible.
+/// Return floor(x) cast to an int.
 inline int
 ifloor (float x)
+{
+    return (int)floorf(x);
+}
+
+
+
+/// Like ifloor(), but ~25% faster and it incorrectly rounds negative
+/// integers down to the NEXT integer. In other words, fast_ifloor(-1) ==
+/// -2, oh my. But it's fine if either (a) you are sure your inputs will not
+/// be negative integers, or (b) for some reason it's ok with you that
+/// negative integer values n are rounded down as if they are (n-epsilon).
+inline int
+fast_ifloor (float x)
 {
     // Find the greatest whole number <= x.  This cast is faster than
     // calling floorf.
@@ -462,10 +475,36 @@ ifloor (float x)
 inline float
 floorfrac (float x, int *xint)
 {
+#if 1
+    float f = std::floor(x);
+    *xint = int(f);
+    return x - f;
+#else /* vvv This idiom is slower */
     int i = ifloor(x);
     *xint = i;
     return x - static_cast<float>(i);   // Return the fraction left over
+#endif
 }
+
+
+inline simd::vfloat4 floorfrac (const simd::vfloat4& x, simd::vint4 *xint) {
+    simd::vfloat4 f = simd::floor(x);
+    *xint = simd::vint4(f);
+    return x - f;
+}
+
+inline simd::vfloat8 floorfrac (const simd::vfloat8& x, simd::vint8 *xint) {
+    simd::vfloat8 f = simd::floor(x);
+    *xint = simd::vint8(f);
+    return x - f;
+}
+
+inline simd::vfloat16 floorfrac (const simd::vfloat16& x, simd::vint16 *xint) {
+    simd::vfloat16 f = simd::floor(x);
+    *xint = simd::vint16(f);
+    return x - f;
+}
+
 
 
 
@@ -499,6 +538,12 @@ sincos (double x, double* sine, double* cosine)
     *sine = std::sin(x);
     *cosine = std::cos(x);
 #endif
+}
+
+
+inline float sign (float x)
+{
+    return x < 0.0f ? -1.0f : (x==0.0f ? 0.0f : 1.0f);
 }
 
 

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -453,21 +453,6 @@ ifloor (float x)
 
 
 
-/// Like ifloor(), but ~25% faster and it incorrectly rounds negative
-/// integers down to the NEXT integer. In other words, fast_ifloor(-1) ==
-/// -2, oh my. But it's fine if either (a) you are sure your inputs will not
-/// be negative integers, or (b) for some reason it's ok with you that
-/// negative integer values n are rounded down as if they are (n-epsilon).
-inline int
-fast_ifloor (float x)
-{
-    // Find the greatest whole number <= x.  This cast is faster than
-    // calling floorf.
-    return (int) x - (x < 0.0f ? 1 : 0);
-}
-
-
-
 /// Return (x-floor(x)) and put (int)floor(x) in *xint.  This is similar
 /// to the built-in modf, but returns a true int, always rounds down
 /// (compared to modf which rounds toward 0), and always returns

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -575,7 +575,8 @@ bool all (const vbool4& v);
 bool any (const vbool4& v);
 bool none (const vbool4& v);
 
-
+// It's handy to have this defined for regular bool as well
+inline bool all (bool v) { return v; }
 
 
 
@@ -2039,7 +2040,9 @@ vfloat4 abs (const vfloat4& a);    ///< absolute value (float)
 vfloat4 sign (const vfloat4& a);   ///< 1.0 when value >= 0, -1 when negative
 vfloat4 ceil (const vfloat4& a);
 vfloat4 floor (const vfloat4& a);
-vint4 floori (const vfloat4& a);    ///< (int)floor
+vint4 ifloor (const vfloat4& a);    ///< (int)floor
+inline vint4 floori (const vfloat4& a) { return ifloor(a); }  // DEPRECATED(1.8) alias
+vint4 fast_ifloor (const vfloat4& a);  ///< fast ifloor, inaccurate for neg ints
 
 /// Per-element round to nearest integer (rounding away from 0 in cases
 /// that are exactly half way).
@@ -2621,7 +2624,9 @@ vfloat8 abs (const vfloat8& a);    ///< absolute value (float)
 vfloat8 sign (const vfloat8& a);   ///< 1.0 when value >= 0, -1 when negative
 vfloat8 ceil (const vfloat8& a);
 vfloat8 floor (const vfloat8& a);
-vint8 floori (const vfloat8& a);    ///< (int)floor
+vint8 ifloor (const vfloat8& a);    ///< (int)floor
+inline vint8 floori (const vfloat8& a) { return ifloor(a); }  // DEPRECATED(1.8) alias
+vint8 fast_ifloor (const vfloat8& a);  ///< fast ifloor, inaccurate for neg ints
 
 /// Per-element round to nearest integer (rounding away from 0 in cases
 /// that are exactly half way).
@@ -2931,7 +2936,9 @@ vfloat16 abs (const vfloat16& a);    ///< absolute value (float)
 vfloat16 sign (const vfloat16& a);   ///< 1.0 when value >= 0, -1 when negative
 vfloat16 ceil (const vfloat16& a);
 vfloat16 floor (const vfloat16& a);
-vint16 floori (const vfloat16& a);    ///< (int)floor
+vint16 ifloor (const vfloat16& a);    ///< (int)floor
+inline vint16 floori (const vfloat16& a) { return ifloor(a); }  // DEPRECATED(1.8) alias
+vint16 fast_ifloor (const vfloat16& a);  ///< fast ifloor, inaccurate for neg ints
 
 /// Per-element round to nearest integer (rounding away from 0 in cases
 /// that are exactly half way).
@@ -7048,12 +7055,20 @@ OIIO_FORCEINLINE vfloat4 round (const vfloat4& a)
 #endif
 }
 
-OIIO_FORCEINLINE vint4 floori (const vfloat4& a)
+OIIO_FORCEINLINE vint4 ifloor (const vfloat4& a)
 {
     // FIXME: look into this, versus the method of quick_floor in texturesys.cpp
 #if OIIO_SIMD_SSE >= 4  /* SSE >= 4.1 */
     return vint4(floor(a));
-#elif OIIO_SIMD_SSE   /* SSE2/3 */
+#else
+    SIMD_RETURN (vint4, (int)floorf(a[i]));
+#endif
+}
+
+
+OIIO_FORCEINLINE vint4 fast_ifloor (const vfloat4& a)
+{
+#if OIIO_SIMD_SSE   /* SSE2/3 */
     vint4 i (a);  // truncates
     vint4 isneg = bitcast_to_int (a < vfloat4::Zero());
     return i + isneg;
@@ -7061,7 +7076,7 @@ OIIO_FORCEINLINE vint4 floori (const vfloat4& a)
     // that the comparison will return (int)-1 for components that are less
     // than zero, and adding that is the same as subtracting one!
 #else
-    SIMD_RETURN (vint4, (int)floorf(a[i]));
+    SIMD_RETURN (vint4, (int) a[i] - (a[i] < 0.0f ? 1 : 0));
 #endif
 }
 
@@ -8548,12 +8563,22 @@ OIIO_FORCEINLINE vfloat8 round (const vfloat8& a)
 #endif
 }
 
-OIIO_FORCEINLINE vint8 floori (const vfloat8& a)
+OIIO_FORCEINLINE vint8 ifloor (const vfloat8& a)
 {
     // FIXME: look into this, versus the method of quick_floor in texturesys.cpp
 #if OIIO_SIMD_AVX
     return vint8(floor(a));
 #elif OIIO_SIMD_SSE   /* SSE2/3 */
+    return vint8 (ifloor(a.lo()), ifloor(a.hi()));
+#else
+    SIMD_RETURN (vint8, (int)floorf(a[i]));
+#endif
+}
+
+
+OIIO_FORCEINLINE vint8 fast_ifloor (const vfloat8& a)
+{
+#if OIIO_SIMD_SSE   /* SSE2/3 */
     vint8 i (a);  // truncates
     vint8 isneg = bitcast_to_int (a < vfloat8::Zero());
     return i + isneg;
@@ -8561,7 +8586,7 @@ OIIO_FORCEINLINE vint8 floori (const vfloat8& a)
     // that the comparison will return (int)-1 for components that are less
     // than zero, and adding that is the same as subtracting one!
 #else
-    SIMD_RETURN (vint8, (int)floorf(a[i]));
+    SIMD_RETURN (vint8, (int) a[i] - (a[i] < 0.0f ? 1 : 0));
 #endif
 }
 
@@ -9384,12 +9409,24 @@ OIIO_FORCEINLINE vfloat16 round (const vfloat16& a)
 #endif
 }
 
-OIIO_FORCEINLINE vint16 floori (const vfloat16& a)
+OIIO_FORCEINLINE vint16 ifloor (const vfloat16& a)
 {
 #if OIIO_SIMD_AVX >= 512
     return _mm512_cvt_roundps_epi32 (a, (_MM_FROUND_TO_NEG_INF |_MM_FROUND_NO_EXC));
 #else
     return vint16(floor(a));
+#endif
+}
+
+
+OIIO_FORCEINLINE vint16 fast_ifloor (const vfloat16& a)
+{
+#if OIIO_SIMD_AVX >= 512
+    return _mm512_cvt_roundps_epi32 (a, (_MM_FROUND_TO_NEG_INF |_MM_FROUND_NO_EXC));
+#elif OIIO_SIMD_SSE   /* SSE2/3 */
+    return vint16 (ifloor(a.lo()), ifloor(a.hi()));
+#else
+    SIMD_RETURN (vint16, (int) a[i] - (a[i] < 0.0f ? 1 : 0));
 #endif
 }
 

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -1922,40 +1922,6 @@ TextureSystemImpl::sample_closest (int nsamples, const float *s_,
 
 
 
-// return the greatest integer <= x, for 4 values at once
-OIIO_FORCEINLINE vint4 quick_floor (const vfloat4& x) {
-    // FIXME -- compare to simd::floati -- is this really the fastest?
-#if 0
-    // Even on SSE 4.1, this is actually very slightly slower!
-    // Continue to test on future architectures.
-    return floori(x);
-#else
-    vint4 b (x);  // truncates
-    vint4 isneg = bitcast_to_int (x < vfloat4::Zero());
-    return b + isneg;
-    // Trick here (thanks, Cycles, for letting me spy on your code): the
-    // comparison will return (int)-1 for components that are less than
-    // zero, and adding that is the same as subtracting one!
-#endif
-}
-
-
-// floatfrac for four sets of values at once.
-inline vfloat4 floorfrac (const vfloat4& x, vint4 * i) {
-    // FIXME -- is this really the fastest?
-#if 0
-    vfloat4 thefloor = floor(x);
-    *i = vint4(thefloor);
-    return x-thefloor;
-#else
-    vint4 thefloor = quick_floor (x);
-    *i = thefloor;
-    return x - vfloat4(thefloor);
-#endif
-}
-
-
-
 /// Convert texture coordinates (s,t), which range on 0-1 for the "full"
 /// image boundary, to texel coordinates (i+ifrac,j+jfrac) where (i,j) is
 /// the texel to the immediate upper left of the sample position, and ifrac

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -160,17 +160,6 @@ test_math_functions ()
     OIIO_CHECK_EQUAL (ifloor(1.001f), 1);
     float fval = 1.1; clobber(fval);
     bench ("ifloor", [&](){ return DoNotOptimize(ifloor(fval)); });
-    bench ("fast_ifloor", [&](){ return DoNotOptimize(fast_ifloor(fval)); });
-
-    OIIO_CHECK_EQUAL (fast_ifloor(0.0f), 0);
-    OIIO_CHECK_EQUAL (fast_ifloor(-0.999f), -1);
-    OIIO_CHECK_EQUAL (fast_ifloor(-1.0f), -2);   // fast floor compromise!
-    OIIO_CHECK_EQUAL (fast_ifloor(-1.001f), -2);
-    OIIO_CHECK_EQUAL (fast_ifloor(0.999f), 0);
-    OIIO_CHECK_EQUAL (fast_ifloor(1.0f), 1);
-    OIIO_CHECK_EQUAL (fast_ifloor(1.001f), 1);
-    fval = -1.1; clobber(fval);
-    bench ("fast_ifloor neg value", [&](float x){ return DoNotOptimize(fast_ifloor(x)); }, fval);
 
     int ival;
     OIIO_CHECK_EQUAL_APPROX (floorfrac(0.0f,    &ival), 0.0f);   OIIO_CHECK_EQUAL (ival, 0);

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -1374,9 +1374,7 @@ void test_mathfuncs ()
     OIIO_CHECK_SIMD_EQUAL (ifloor(mkvec<VEC>(0.0f, -0.999f, -1.0f, -1.001f)),
                            mkvec<vint_t>(0, -1, -1, -2));
     benchmark ("float ifloor", [](float&v){ return ifloor(v); }, 1.1f);
-    benchmark ("float fast_ifloor", [](float&v){ return fast_ifloor(v); }, 1.1f);
     benchmark ("simd ifloor", [](VEC&v){ return simd::ifloor(v); }, VEC(1.1f));
-    benchmark ("simd fast_ifloor", [](VEC&v){ return simd::fast_ifloor(v); }, VEC(1.1f));
 
     int iscalar;
     vint_t ival;

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -188,6 +188,10 @@ template<> inline vint8 mkvec<vint8> (int a, int b, int c, int d) {
     return vint8(a,b,c,d,a,b,c,d);
 }
 
+template<> inline vint16 mkvec<vint16> (int a, int b, int c, int d) {
+    return vint16(a,b,c,d,a,b,c,d,a,b,c,d,a,b,c,d);
+}
+
 template<> inline vbool8 mkvec<vbool8> (bool a, bool b, bool c, bool d) {
     return vbool8(a,b,c,d,a,b,c,d);
 }
@@ -1338,6 +1342,7 @@ inline float rcp (float f) { return 1.0f / f; }
 template<typename VEC>
 void test_mathfuncs ()
 {
+    typedef typename VEC::vint_t vint_t;
     test_heading ("mathfuncs", VEC::type_name());
 
     VEC A = mkvec<VEC> (-1.0f, 0.0f, 1.0f, 4.5f);
@@ -1363,6 +1368,29 @@ void test_mathfuncs ()
     benchmark2 ("simd operator/", do_div<VEC>, A, A);
     benchmark2 ("simd safe_div", do_safe_div<VEC>, A, A);
     benchmark ("simd rcp_fast", [](VEC& v){ return rcp_fast(v); }, mkvec<VEC>(1.0f,4.0f,9.0f,16.0f));
+
+    OIIO_CHECK_SIMD_EQUAL (ifloor(mkvec<VEC>(0.0f, 0.999f, 1.0f, 1.001f)),
+                           mkvec<vint_t>(0, 0, 1, 1));
+    OIIO_CHECK_SIMD_EQUAL (ifloor(mkvec<VEC>(0.0f, -0.999f, -1.0f, -1.001f)),
+                           mkvec<vint_t>(0, -1, -1, -2));
+    benchmark ("float ifloor", [](float&v){ return ifloor(v); }, 1.1f);
+    benchmark ("float fast_ifloor", [](float&v){ return fast_ifloor(v); }, 1.1f);
+    benchmark ("simd ifloor", [](VEC&v){ return simd::ifloor(v); }, VEC(1.1f));
+    benchmark ("simd fast_ifloor", [](VEC&v){ return simd::fast_ifloor(v); }, VEC(1.1f));
+
+    int iscalar;
+    vint_t ival;
+    VEC fval = -1.1;
+    OIIO_CHECK_EQUAL_APPROX (floorfrac(VEC(0.0f),    &ival), 0.0f);   OIIO_CHECK_SIMD_EQUAL (ival, 0);
+    OIIO_CHECK_EQUAL_APPROX (floorfrac(VEC(-0.999f), &ival), 0.001f); OIIO_CHECK_SIMD_EQUAL (ival, -1);
+    OIIO_CHECK_EQUAL_APPROX (floorfrac(VEC(-1.0f),   &ival), 0.0f);   OIIO_CHECK_SIMD_EQUAL (ival, -1);
+    OIIO_CHECK_EQUAL_APPROX (floorfrac(VEC(-1.001f), &ival), 0.999f); OIIO_CHECK_SIMD_EQUAL (ival, -2);
+    OIIO_CHECK_EQUAL_APPROX (floorfrac(VEC(0.999f),  &ival), 0.999f); OIIO_CHECK_SIMD_EQUAL (ival, 0);
+    OIIO_CHECK_EQUAL_APPROX (floorfrac(VEC(1.0f),    &ival), 0.0f);   OIIO_CHECK_SIMD_EQUAL (ival, 1);
+    OIIO_CHECK_EQUAL_APPROX (floorfrac(VEC(1.001f),  &ival), 0.001f); OIIO_CHECK_SIMD_EQUAL (ival, 1);
+    benchmark ("float floorfrac", [&](float x){ return DoNotOptimize(floorfrac(x,&iscalar)); }, 1.1f);
+    benchmark ("simd floorfrac", [&](const VEC& x){ return DoNotOptimize(floorfrac(x,&ival)); }, fval);
+
     benchmark ("float expf", expf, 0.67f);
     benchmark ("float fast_exp", fast_exp_float, 0.67f);
     benchmark ("simd exp", [](VEC& v){ return simd::exp(v); }, VEC(0.67f));


### PR DESCRIPTION
Say it together, boys and girls: "Untested code is buggy code!"

In this episode, I realize that the ifloor() function in fmath.h,
and also the inconsistently-named floori() from simd.h, both of which
have been used for many years without complaint, have a rather
startling bug: they give the wrong answer for negative integers!

The formal specification is that it returns the equivalent of
int(floor(x)), but the implementation tried to execute faster by using a
bit twiddling trick to avoid the 'floor' part of the computation, just
cast to int and then correct for negative values.

I don't even remember how I stumbled across this, but something caused
me to make a unit test for ifloor, and to my surprise, it failed for
exact negative integers. (For reasons that are head-smackingly obvious
once you think about what the code is doing.)

Now, the obvious fix is to just implement as int(floor(x)), but
benchmarking shows that to be 25-50% slower! It may fail for negative
integers, but I can imagine cases where you are darned sure you will
only fed it positive values, OR maybe there are situations where it's ok
if the negative integer values are wrong. So I "fixed" ifloor(), but I
also made a fast_ifloor() that is the old code -- wrong for negative
integers, but much faster.

And so down the rabbit hole we go...

* The simd versions have the same problem. Fix them there as well, and
  also rename (floori -> ifloor) so that the simd and fmath versions
  have the same naming convention. Add unit tests and benchmarks, and in
  light of that, tighten up some of the SIMD code paths a bit.

* floorfrac uses the same trick. Do I also make fast_floorfrac?  NO!
  Because along the way, I realized that a slightly different idiom
  was much faster -- even slightly faster than the "fast but buggy"
  version we used previously. So I took the win, and stuck with
  "very slightly faster and not buggy," and did not bother confusing
  the matter with the "buggy and even faster" variant.

* Added simd versions of floorfrac, in fmath.h (where the float version
  was defined).

* texturesys.cpp: use the fmath floorfrac (remember, we put simd versions
  there now) instead of defining it locally, which also lets us remove
  a redundant quick_floor() that was identical to the old buggy
  ifloor anyway.

* Various unit tests for both the scalar and simd cases of these related
  functions, which led to...

* unittest.h: added an "OIIO_CHECK_EQUAL_APPROX" unit test macro,
  basically it checks a result and considers it ok if it's within
  0.1% of the larger of the quantities being compared. Some extra
  trickery makes it work with either scalar or simd values.


