### PR TITLE
oiiotool: Revamp of logic for propagating data format.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,8 @@ add_custom_target ( CopyFiles ALL DEPENDS "${CMAKE_BINARY_DIR}/testsuite/runtest
 oiio_add_tests (
                 gpsread misnamed-file nonwhole-tiles
                 oiiotool oiiotool-attribs
-                oiiotool-composite oiiotool-deep oiiotool-fixnan
+                oiiotool-composite oiiotool-copy
+                oiiotool-deep oiiotool-fixnan
                 oiiotool-pattern oiiotool-readerror
                 oiiotool-subimage oiiotool-text oiiotool-xform
                 maketx oiiotool-maketx

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -1144,12 +1144,14 @@ current image from the image stack, it merely saves a copy of it.
 {\cf autocrop=}\emph{int} & Enable or disable autocrop for
      this output image. \\
 {\cf autotrim=}\emph{int} & Enable or disable {\cf --autotrim} for
-     this output image. \index{autotrim} \\
+     this output image. \index{autotrim} \\[0.5ex]
 {\cf separate=}\emph{int} & \\
 {\cf contig=}\emph{int} & Set separate or contiguous planar configuration
-    for this output. \\
+    for this output. \\[0.5ex]
 {\cf\small fileformatname=}\emph{string} & Specify the desired output file
-  format, overriding any guess based on file name extension. \\
+  format, overriding any guess based on file name extension. \\[0.5ex]
+{\cf scanline=}{int} & If nonzero, force scanline output. \\
+{\cf tile=}\emph{int}{\cf x}\emph{int} &  Force tiling with given size. \\[0.5ex]
 {\cf all=}\emph{n} & Output all images currently on the stack using a
       pattern. See further explanation below.
 \end{tabular}

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -92,7 +92,7 @@ public:
     std::string input_channel_set;    // Optional input channel set
 
     // Output options
-    TypeDesc output_dataformat;
+    TypeDesc output_dataformat;       // Requested output data format
     std::map<std::string,std::string> output_channelformats;
     std::string output_compression;
     std::string output_planarconfig;
@@ -134,6 +134,10 @@ public:
     bool enable_function_timing = true;
     bool input_config_set = false;
     bool printed_info = false;               // printed info at some point
+    // Remember the first input dataformats we encountered
+    TypeDesc first_input_dataformat;
+    int first_input_dataformat_bits = 0;
+    std::map<std::string, std::string> first_input_channelformats;
 
     Oiiotool ();
 
@@ -203,7 +207,7 @@ public:
     // pixels.
     bool adjust_geometry (string_view command,
                           int &w, int &h, int &x, int &y, const char *geom,
-                          bool allow_scaling=false);
+                          bool allow_scaling=false) const;
 
     // Expand substitution expressions in string str. Expressions are
     // enclosed in braces: {...}. An expression consists of:
@@ -220,8 +224,8 @@ public:
     int extract_options (std::map<std::string,std::string> &options,
                          std::string command);
 
-    void error (string_view command, string_view explanation="");
-    void warning (string_view command, string_view explanation="");
+    void error (string_view command, string_view explanation="") const;
+    void warning (string_view command, string_view explanation="") const;
 
     size_t check_peak_memory () {
         size_t mem = Sysutil::memory_used();
@@ -247,6 +251,7 @@ private:
 typedef std::shared_ptr<ImageBuf> ImageBufRef;
 
 
+
 class SubimageRec {
 public:
     int miplevels() const { return (int) m_miplevels.size(); }
@@ -265,20 +270,32 @@ public:
     const ImageSpec * spec (int i) const {
         return i < miplevels() ? &m_specs[i] : NULL;
     }
+
+    // was_direct_read describes whether this subimage has is unomdified in
+    // content and pixel format (i.e. data type) since it was read from a
+    // preexisting file on disk. We set it to true upon first read, and a
+    // handful of operations that should preserve it, but for almost
+    // everything else, we don't propagate the value (letting it lapse to
+    // false for the result of most image operations).
+    bool was_direct_read () const { return m_was_direct_read; }
+    void was_direct_read (bool f) { m_was_direct_read = f; }
+
 private:
     std::vector<ImageBufRef> m_miplevels;
     std::vector<ImageSpec> m_specs;
+    bool m_was_direct_read = false;  ///< Guaranteed pixel data type unmodified since read
     friend class ImageRec;
 };
 
 
 
+/// ImageRec is conceptually similar to an ImageBuf, except that whereas an
+/// IB is truly a single image, an ImageRec encapsulates multiple subimages,
+/// and potentially MIPmap levels for each subimage.
 class ImageRec {
 public:
     ImageRec (const std::string &name, ImageCache *imagecache)
-        : m_name(name), m_elaborated(false),
-          m_metadata_modified(false), m_pixels_modified(false),
-          m_imagecache(imagecache)
+        : m_name(name), m_imagecache(imagecache)
     { }
 
     // Initialize an ImageRec with a collection of prepared ImageSpec's.
@@ -309,6 +326,8 @@ public:
     // Initialize an ImageRec with the given spec.
     ImageRec (const std::string &name, const ImageSpec &spec,
               ImageCache *imagecache);
+
+    ImageRec (const ImageRec &copy) = delete;  // Disallow copy ctr
 
     enum WinMerge { WinMergeUnion, WinMergeIntersection, WinMergeA, WinMergeB };
 
@@ -375,6 +394,10 @@ public:
         return subimg < subimages() ? m_subimages[subimg].spec(mip) : NULL;
     }
 
+    const ImageSpec * nativespec (int subimg=0, int mip=0) const {
+        return subimg < subimages() ? &((*this)(subimg,mip).nativespec()) : nullptr;
+    }
+
     bool was_output () const { return m_was_output; }
     void was_output (bool val) { m_was_output = val; }
     bool metadata_modified () const { return m_metadata_modified; }
@@ -430,14 +453,14 @@ public:
 
 private:
     std::string m_name;
-    bool m_elaborated;
-    bool m_metadata_modified;
-    bool m_pixels_modified;
-    bool m_was_output;
+    bool m_elaborated = false;
+    bool m_metadata_modified = false;
+    bool m_pixels_modified = false;
+    bool m_was_output = false;
     std::vector<SubimageRec> m_subimages;
     std::time_t m_time;  //< Modification time of the input file
     TypeDesc m_input_dataformat;
-    ImageCache *m_imagecache;
+    ImageCache *m_imagecache = nullptr;
     mutable std::string m_err;
     ImageSpec m_configspec;
 

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -622,6 +622,10 @@ print_info_subimage (Oiiotool &ot,
 
     if (! opt.metamatch.empty() || ! opt.nometamatch.empty()) {
         for (size_t i = 0; i < lines.size(); ++i) {
+            if (i == 0 && serformat == ImageSpec::SerialText && printres) {
+                // Special case for first line in serialized text case.
+                continue;
+            }
             std::string s = lines[i].substr (0, lines[i].find(": "));
             if ((! opt.nometamatch.empty() && regex_search (s, field_exclude_re)) ||
                 (! opt.metamatch.empty() && ! regex_search (s, field_re))) {

--- a/testsuite/oiiotool-copy/ref/out.txt
+++ b/testsuite/oiiotool-copy/ref/out.txt
@@ -1,0 +1,22 @@
+
+explicit -d uint save result: 
+uint8.tif            :  128 x  128, 3 channel, uint8 tiff
+    tile size: 16 x 16
+
+unmodified copy result: 
+tmp.tif              :  128 x  128, 3 channel, uint8 tiff
+    tile size: 16 x 16
+
+copy with explicit -d uint16 result: 
+copy_uint16.tif      :  128 x  128, 3 channel, uint16 tiff
+    tile size: 16 x 16
+
+siappend result: 
+tmp.tif              :  128 x  128, 3 channel, uint8 tiff
+    tile size: 16 x 16
+ subimage  1:  128 x  128, 3 channel, uint16 tiff
+    tile size: 16 x 16
+
+combining images result: 
+tmp.tif              :  128 x  128, 3 channel, uint8 tiff
+    tile size: 16 x 16

--- a/testsuite/oiiotool-copy/run.py
+++ b/testsuite/oiiotool-copy/run.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+
+# Some tests to verify that we are transferring data formats properly.
+#
+command += oiiotool ("-pattern checker 128x128 3 -d uint8 -tile 16 16 -o uint8.tif " +
+                     "-echo '\nexplicit -d uint save result: ' -metamatch \"width|tile\" -i:info=2 uint8.tif")
+# Un-modified copy should preserve data type and tiling
+command += oiiotool ("uint8.tif -o tmp.tif " +
+                     "-echo '\nunmodified copy result: ' -metamatch \"width|tile\" -i:info=2 tmp.tif")
+# Copy with explicit data request should change data type
+command += oiiotool ("uint8.tif -d uint16 -o copy_uint16.tif " +
+                     "-echo '\ncopy with explicit -d uint16 result: ' -metamatch \"width|tile\" -i:info=2 copy_uint16.tif")
+# Subimage concatenation should preserve data type
+command += oiiotool ("uint8.tif copy_uint16.tif -siappend -o tmp.tif " +
+                     "-echo '\nsiappend result: ' -metamatch \"width|tile\" -i:info=2 tmp.tif")
+# Combining two images preserves the format of the first read input, if
+# there are not any other hints:
+command += oiiotool ("-pattern checker 128x128 3 uint8.tif -add -o tmp.tif " +
+                     "-echo '\ncombining images result: ' -metamatch \"width|tile\" -i:info=2 tmp.tif")
+
+
+
+
+
+# Outputs to check against references
+outputs = [ "out.txt" ]
+
+#print "Running this command:\n" + command + "\n"


### PR DESCRIPTION
So, oiiotool reads one or more images, might combine them, might
generate some from whole cloth. And the ones read from disk might not be
stored internally with the same data format as it existed on disk (it's
biased to store in float internally). How does it decide what data
format to write to disk for output?

We thought we were doing something sensible -- which is to allow an
explicit override (via `-d`), but in other cases to write using the
same data format as whatever was the FIRST file input. That at least
guarantees that a basic read-write cycle preserved the format.

But Chris Allen pointed out an interesting corner case, which is that
when you use `--siappend`, it will write out all subimages using the
first format it encountered.  But it seems like in this case, it ought
to be able to keep each subimage in the format it started in.

This sent me down a bit of a rabbit hole.

The logic is hereby modified to:

1. Explicit format requests (`-d`) are honored.
2. Otherwise, a file that appears to be an unmodified copy of a file read
   from disk will write using its native (i.e., from disk) format.
3. Otherwise (for a modified or generated file), it will write using
   a data format taken from whatever was the first file read.
4. If all those fail, it will just use the format of the buffer.

Note that (2) is the new bit of logic.

Turned out to take a fair bit of refactoring to really track this
through all the corner cases, and also make it understand that the
"subimage append" operation does not lose the "it's a directly read
image" property.

I implemented similar logic for tracking tile sizes as well. So output
tiling should more accurately reflect input tiling, except when overridden.

Some other miscellaneous things that came along for the ride:

* New testsuite entry: oiiotool-copy to test these cases.
* A bit more care internal to ImageBuf::copy() of keeping track of the
  "native" format info.
* Some C++ modernization of some ImageRec and Oiiotool internals.
* Minor fixes to how regex matching is done for `oiiotool -info` when
  `-metamatch` is used.
* The `-o` command now takes additional arguments: `scanline=1`,
   `tile=XxY`, which can override the tile size or scanlineness
   on a per-output basis (just like how it could override data type
   or contig/separate).

It's a lot of change, but the stuff in oiiotool.cpp, adjust_output_options(), 
is where most of the important new logic is.
