### PR TITLE
Refactor of metadata printing and Exif read/write

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1454,55 +1454,6 @@ OIIO_API bool copy_image (int nchannels, int width, int height, int depth,
                           void *dst, stride_t dst_xstride,
                           stride_t dst_ystride, stride_t dst_zstride);
 
-/// Decode a raw Exif data block and save all the metadata in an
-/// ImageSpec.  Return true if all is ok, false if the exif block was
-/// somehow malformed.  The binary data pointed to by 'exif' should
-/// start with a TIFF directory header.
-OIIO_API bool decode_exif (string_view exif, ImageSpec &spec);
-OIIO_API bool decode_exif (const void *exif, int length, ImageSpec &spec); // DEPRECATED (1.8)
-
-/// Construct an Exif data block from the ImageSpec, appending the Exif 
-/// data as a big blob to the char vector.
-OIIO_API void encode_exif (const ImageSpec &spec, std::vector<char> &blob);
-
-/// Helper: For the given OIIO metadata attribute name, look up the Exif tag
-/// ID, TIFFDataType (expressed as an int), and count. Return true and fill
-/// in the fields if found, return false if not found.
-OIIO_API bool exif_tag_lookup (string_view name, int &tag,
-                               int &tifftype, int &count);
-
-/// Add metadata to spec based on raw IPTC (International Press
-/// Telecommunications Council) metadata in the form of an IIM
-/// (Information Interchange Model).  Return true if all is ok, false if
-/// the iptc block was somehow malformed.  This is a utility function to
-/// make it easy for multiple format plugins to support embedding IPTC
-/// metadata without having to duplicate functionality within each
-/// plugin.  Note that IIM is actually considered obsolete and is
-/// replaced by an XML scheme called XMP.
-OIIO_API bool decode_iptc_iim (const void *iptc, int length, ImageSpec &spec);
-
-/// Find all the IPTC-amenable metadata in spec and assemble it into an
-/// IIM data block in iptc.  This is a utility function to make it easy
-/// for multiple format plugins to support embedding IPTC metadata
-/// without having to duplicate functionality within each plugin.  Note
-/// that IIM is actually considered obsolete and is replaced by an XML
-/// scheme called XMP.
-OIIO_API void encode_iptc_iim (const ImageSpec &spec, std::vector<char> &iptc);
-
-/// Add metadata to spec based on XMP data in an XML block.  Return true
-/// if all is ok, false if the xml was somehow malformed.  This is a
-/// utility function to make it easy for multiple format plugins to
-/// support embedding XMP metadata without having to duplicate
-/// functionality within each plugin.
-OIIO_API bool decode_xmp (const std::string &xml, ImageSpec &spec);
-
-/// Find all the relavant metadata (IPTC, Exif, etc.) in spec and
-/// assemble it into an XMP XML string.  This is a utility function to
-/// make it easy for multiple format plugins to support embedding XMP
-/// metadata without having to duplicate functionality within each
-/// plugin.  If 'minimal' is true, then don't encode things that would
-/// be part of ordinary TIFF or exif tags.
-OIIO_API std::string encode_xmp (const ImageSpec &spec, bool minimal=false);
 
 // All the wrap_foo functions implement a wrap mode, wherein coord is
 // altered to be origin <= coord < origin+width.  The return value

--- a/src/include/OpenImageIO/tiffutils.h
+++ b/src/include/OpenImageIO/tiffutils.h
@@ -1,0 +1,270 @@
+/*
+  Copyright 2017 Larry Gritz et al. All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the software's owners nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  (This is the Modified BSD License)
+*/
+
+/////////////////////////////////////////////////////////////////////////////
+/// \file
+///
+/// Utilities for dealing with TIFF tags and data structures (common to
+/// plugins that have to deal with TIFF itself, Exif data blocks, and other
+/// miscellaneous stuff that piggy-backs off TIFF format).
+///
+/////////////////////////////////////////////////////////////////////////////
+
+
+#pragma once
+
+#ifndef OIIO_TIFFUTILS_H
+#define OIIO_TIFFUTILS_H
+
+extern "C" {
+#include "tiff.h"
+}
+
+#include <OpenImageIO/imageio.h>
+
+
+#ifdef TIFF_VERSION_BIG
+// In old versions of TIFF, this was defined in tiff.h.  It's gone from
+// "BIG TIFF" (libtiff 4.x), so we just define it here.
+
+struct TIFFHeader {
+    uint16_t tiff_magic;  /* magic number (defines byte order) */
+    uint16_t tiff_version;/* TIFF version number */
+    uint32_t tiff_diroff; /* byte offset to first directory */
+};
+
+struct TIFFDirEntry {
+    uint16_t tdir_tag;    /* tag ID */
+    uint16_t tdir_type;   /* data type -- see TIFFDataType enum */
+    uint32_t tdir_count;  /* number of items; length in spec */
+    uint32_t tdir_offset; /* byte offset to field data */
+};
+#endif
+
+
+
+
+OIIO_NAMESPACE_BEGIN
+
+// Define EXIF constants
+enum TIFFTAG {
+    EXIF_EXPOSURETIME               = 33434,
+    EXIF_FNUMBER                    = 33437,
+    EXIF_EXPOSUREPROGRAM            = 34850,
+    EXIF_SPECTRALSENSITIVITY        = 34852,
+    EXIF_PHOTOGRAPHICSENSITIVITY    = 34855,
+    EXIF_ISOSPEEDRATINGS            = 34855, // old nme for PHOTOGRAPHICSENSITIVITY
+    EXIF_OECF                       = 34856,
+    EXIF_SENSITIVITYTYPE            = 34864,
+    EXIF_STANDARDOUTPUTSENSITIVITY  = 34865,
+    EXIF_RECOMMENDEDEXPOSUREINDEX   = 34866,
+    EXIF_ISOSPEED                   = 34867,
+    EXIF_ISOSPEEDLATITUDEYYY        = 34868,
+    EXIF_ISOSPEEDLATITUDEZZZ        = 34869,
+    EXIF_EXIFVERSION                = 36864,
+    EXIF_DATETIMEORIGINAL           = 36867,
+    EXIF_DATETIMEDIGITIZED          = 36868,
+    EXIF_OFFSETTIME                 = 36880,
+    EXIF_OFFSETTIMEORIGINAL         = 36881,
+    EXIF_OFFSETTIMEDIGITIZED        = 36882,
+    EXIF_COMPONENTSCONFIGURATION    = 37121,
+    EXIF_COMPRESSEDBITSPERPIXEL     = 37122,
+    EXIF_SHUTTERSPEEDVALUE          = 37377,
+    EXIF_APERTUREVALUE              = 37378,
+    EXIF_BRIGHTNESSVALUE            = 37379,
+    EXIF_EXPOSUREBIASVALUE          = 37380,
+    EXIF_MAXAPERTUREVALUE           = 37381,
+    EXIF_SUBJECTDISTANCE            = 37382,
+    EXIF_METERINGMODE               = 37383,
+    EXIF_LIGHTSOURCE                = 37384,
+    EXIF_FLASH                      = 37385,
+    EXIF_FOCALLENGTH                = 37386,
+    EXIF_SECURITYCLASSIFICATION     = 37394,
+    EXIF_IMAGEHISTORY               = 37395,
+    EXIF_SUBJECTAREA                = 37396,
+    EXIF_MAKERNOTE                  = 37500,
+    EXIF_USERCOMMENT                = 37510,
+    EXIF_SUBSECTIME                 = 37520,
+    EXIF_SUBSECTIMEORIGINAL         = 37521,
+    EXIF_SUBSECTIMEDIGITIZED        = 37522,
+    EXIF_TEMPERATURE                = 37888,
+    EXIF_HUMIDITY                   = 37889,
+    EXIF_PRESSURE                   = 37890,
+    EXIF_WATERDEPTH                 = 37891,
+    EXIF_ACCELERATION               = 37892,
+    EXIF_CAMERAELEVATIONANGLE       = 37893,
+    EXIF_FLASHPIXVERSION            = 40960,
+    EXIF_COLORSPACE                 = 40961,
+    EXIF_PIXELXDIMENSION            = 40962,
+    EXIF_PIXELYDIMENSION            = 40963,
+    EXIF_RELATEDSOUNDFILE           = 40964,
+    EXIF_FLASHENERGY                = 41483,
+    EXIF_SPATIALFREQUENCYRESPONSE   = 41484,
+    EXIF_FOCALPLANEXRESOLUTION      = 41486,
+    EXIF_FOCALPLANEYRESOLUTION      = 41487,
+    EXIF_FOCALPLANERESOLUTIONUNIT   = 41488,
+    EXIF_SUBJECTLOCATION            = 41492,
+    EXIF_EXPOSUREINDEX              = 41493,
+    EXIF_SENSINGMETHOD              = 41495,
+    EXIF_FILESOURCE                 = 41728,
+    EXIF_SCENETYPE                  = 41729,
+    EXIF_CFAPATTERN                 = 41730,
+    EXIF_CUSTOMRENDERED             = 41985,
+    EXIF_EXPOSUREMODE               = 41986,
+    EXIF_WHITEBALANCE               = 41987,
+    EXIF_DIGITALZOOMRATIO           = 41988,
+    EXIF_FOCALLENGTHIN35MMFILM      = 41989,
+    EXIF_SCENECAPTURETYPE           = 41990,
+    EXIF_GAINCONTROL                = 41991,
+    EXIF_CONTRAST                   = 41992,
+    EXIF_SATURATION                 = 41993,
+    EXIF_SHARPNESS                  = 41994,
+    EXIF_DEVICESETTINGDESCRIPTION   = 41995,
+    EXIF_SUBJECTDISTANCERANGE       = 41996,
+    EXIF_IMAGEUNIQUEID              = 42016,
+    EXIF_CAMERAOWNERNAME            = 42032,
+    EXIF_BODYSERIALNUMBER           = 42033,
+    EXIF_LENSSPECIFICATION          = 42034,
+    EXIF_LENSMAKE                   = 42035,
+    EXIF_LENSMODEL                  = 42036,
+    EXIF_LENSSERIALNUMBER           = 42037,
+    EXIF_GAMMA                      = 42240,
+};
+
+
+
+/// Given a TIFF data type code (defined in tiff.h) and a count, return the
+/// equivalent TypeDesc where one exists. .Return TypeUndefined if there
+/// is no obvious equivalent.
+OIIO_API TypeDesc tiff_datatype_to_typedesc (TIFFDataType tifftype, size_t tiffcount=1);
+
+inline TypeDesc tiff_datatype_to_typedesc (const TIFFDirEntry& dir) {
+    return tiff_datatype_to_typedesc (TIFFDataType(dir.tdir_type), dir.tdir_count);
+}
+
+/// Return the data size (in bytes) of the TIFF type.
+OIIO_API size_t tiff_data_size (TIFFDataType tifftype);
+
+/// Return the data size (in bytes) of the data for the given TIFFDirEntry.
+OIIO_API size_t tiff_data_size (const TIFFDirEntry &dir);
+
+/// Given a TIFFDirEntry and a data arena (represented by an array view
+/// of unsigned bytes), return an array_view of where the values for the
+/// tiff dir lives. Return an empty array_view if there is an error, which
+/// could include a nonsensical situation where the TIFFDirEntry seems to
+/// point outside the data arena.
+OIIO_API array_view<const uint8_t>
+OIIO_API tiff_dir_data (const TIFFDirEntry &td, array_view<const uint8_t> data);
+
+/// Decode a raw Exif data block and save all the metadata in an
+/// ImageSpec.  Return true if all is ok, false if the exif block was
+/// somehow malformed.  The binary data pointed to by 'exif' should
+/// start with a TIFF directory header.
+OIIO_API bool decode_exif (array_view<const uint8_t> exif, ImageSpec &spec);
+OIIO_API bool decode_exif (string_view exif, ImageSpec &spec);
+OIIO_API bool decode_exif (const void *exif, int length, ImageSpec &spec); // DEPRECATED (1.8)
+
+/// Construct an Exif data block from the ImageSpec, appending the Exif 
+/// data as a big blob to the char vector.
+OIIO_API void encode_exif (const ImageSpec &spec, std::vector<char> &blob);
+
+/// Helper: For the given OIIO metadata attribute name, look up the Exif tag
+/// ID, TIFFDataType (expressed as an int), and count. Return true and fill
+/// in the fields if found, return false if not found.
+OIIO_API bool exif_tag_lookup (string_view name, int &tag,
+                               int &tifftype, int &count);
+
+/// Add metadata to spec based on raw IPTC (International Press
+/// Telecommunications Council) metadata in the form of an IIM
+/// (Information Interchange Model).  Return true if all is ok, false if
+/// the iptc block was somehow malformed.  This is a utility function to
+/// make it easy for multiple format plugins to support embedding IPTC
+/// metadata without having to duplicate functionality within each
+/// plugin.  Note that IIM is actually considered obsolete and is
+/// replaced by an XML scheme called XMP.
+OIIO_API bool decode_iptc_iim (const void *iptc, int length, ImageSpec &spec);
+
+/// Find all the IPTC-amenable metadata in spec and assemble it into an
+/// IIM data block in iptc.  This is a utility function to make it easy
+/// for multiple format plugins to support embedding IPTC metadata
+/// without having to duplicate functionality within each plugin.  Note
+/// that IIM is actually considered obsolete and is replaced by an XML
+/// scheme called XMP.
+OIIO_API void encode_iptc_iim (const ImageSpec &spec, std::vector<char> &iptc);
+
+/// Add metadata to spec based on XMP data in an XML block.  Return true
+/// if all is ok, false if the xml was somehow malformed.  This is a
+/// utility function to make it easy for multiple format plugins to
+/// support embedding XMP metadata without having to duplicate
+/// functionality within each plugin.
+OIIO_API bool decode_xmp (const std::string &xml, ImageSpec &spec);
+
+/// Find all the relavant metadata (IPTC, Exif, etc.) in spec and
+/// assemble it into an XMP XML string.  This is a utility function to
+/// make it easy for multiple format plugins to support embedding XMP
+/// metadata without having to duplicate functionality within each
+/// plugin.  If 'minimal' is true, then don't encode things that would
+/// be part of ordinary TIFF or exif tags.
+OIIO_API std::string encode_xmp (const ImageSpec &spec, bool minimal=false);
+
+
+/// Handy structure to hold information mapping TIFF/EXIF tags to their
+/// names and actions.
+struct TagInfo {
+    typedef void (*HandlerFunc)(const TagInfo& taginfo, const TIFFDirEntry& dir,
+                                array_view<const uint8_t> buf, ImageSpec& spec,
+                                bool swapendian, int offset_adjustment);
+
+    TagInfo (int tag, const char *name, TIFFDataType type,
+             int count, HandlerFunc handler = nullptr)
+        : tifftag(tag), name(name), tifftype(type), tiffcount(count),
+          handler(handler) {}
+
+    int tifftag = -1;                     // TIFF tag used for this info
+    const char *name = nullptr;           // OIIO attribute name we use
+    TIFFDataType tifftype = TIFF_NOTYPE;  // Data type that TIFF wants
+    int tiffcount = 0;                    // Number of items
+    HandlerFunc handler = nullptr;        // Special decoding handler
+};
+
+/// Return an array_view of a TagInfo array for the corresponding table.
+/// Valid names are "Exif", "GPS", and "TIFF". This can be handy for
+/// iterating through all possible tags for each category.
+OIIO_API array_view<const TagInfo> tag_table (string_view tablename);
+
+/// Look up the TagInfo of a numbered or named tag from a named domain
+/// ("TIFF", "Exif", or "GPS"). Return nullptr if it is not known.
+OIIO_API const TagInfo* tag_lookup (string_view domain, int tag);
+OIIO_API const TagInfo* tag_lookup (string_view domain, string_view tagname);
+
+
+
+OIIO_NAMESPACE_END
+
+#endif  // OIIO_TIFFUTILS_H

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -37,6 +37,7 @@
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/color.h>
+#include <OpenImageIO/tiffutils.h>
 #include "jpeg_pvt.h"
 
 OIIO_PLUGIN_NAMESPACE_BEGIN

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -36,6 +36,7 @@
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/fmath.h>
+#include <OpenImageIO/tiffutils.h>
 #include "jpeg_pvt.h"
 
 OIIO_PLUGIN_NAMESPACE_BEGIN

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -29,7 +29,8 @@ if (NOT MSVC)
 endif()
 
 list (APPEND libOpenImageIO_srcs
-                          deepdata.cpp exif.cpp formatspec.cpp imagebuf.cpp
+                          deepdata.cpp exif.cpp exif-canon.cpp
+                          formatspec.cpp imagebuf.cpp
                           imageinput.cpp imageio.cpp imageioplugin.cpp
                           imageoutput.cpp iptc.cpp xmp.cpp
                           color_ocio.cpp

--- a/src/libOpenImageIO/exif-canon.cpp
+++ b/src/libOpenImageIO/exif-canon.cpp
@@ -1,0 +1,1057 @@
+/*
+  Copyright 2017 Larry Gritz et al. All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the software's owners nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  (This is the Modified BSD License)
+*/
+
+
+// See: https://sno.phy.queensu.ca/~phil/exiftool/TagNames/Canon.html
+// 
+
+#include <algorithm>
+#include <array>
+#include <type_traits>
+
+#include "exif.h"
+
+OIIO_NAMESPACE_BEGIN
+namespace pvt {
+
+
+static LabelIndex canon_macromode_table[] = {
+    { 1, "macro" }, { 2, "normal" }, { -1, nullptr }
+};
+
+static LabelIndex canon_quality_table[] = {
+    { 1, "economy" }, { 2, "normal" }, { 2, "fine" }, { 4, "RAW" },
+    { 5, "superfine" }, { 130, "normal movie" }, { 131, "movie(2)" },
+    { -1, nullptr }
+};
+
+static LabelIndex canon_flashmode_table[] = {
+    { 0, "off" }, { 1, "auto" }, { 2, "on" }, { 3, "red-eye reduction" },
+    { 4, "slow-sync" }, { 5, "red-eye reduction (auto)" },
+    { 6, "red-eye reduction (on)" }, { 16, "external flash" },
+    { -1, nullptr }
+};
+
+static LabelIndex canon_continuousdrive_table[] = {
+    { 0, "single" },
+    { 1, "continuous" },
+    { 2, "movie" },
+    { 3, "continuous, speed priority" },
+    { 4, "continuous, low" },
+    { 5, "continuous, high" },
+    { 6, "silent single" },
+    { 9, "single, silent" },
+    { 10, "continuous, silent" },
+    { -1, nullptr }
+};
+
+static LabelIndex canon_focusmode_table[] = {
+    { 0, "one-shot AF" }, { 1, "AI servo AF" }, { 2, "AI focus AF" },
+    { 3, "manual focus(3)" }, { 4, "single" }, { 5, "continuous" },
+    { 6, "manual focus(6)" }, { 16, "pan focus" }, { 256, "AF + MF" },
+    { 512, "movie snap focus" }, { 519, "movie servo AF" }, { -1, nullptr }
+};
+
+static LabelIndex canon_recordmode_table[] = {
+    { 1, "JPEG" }, { 2, "CRW+THM" }, { 3, "AVI+THM" }, { 4, "TIF" },
+    { 5, "TIF+JPEG" }, { 6, "CR2" }, { 7, "CR2+JPEG" }, { 9, "MOV" },
+    { 10, "MP4" }, { -1, nullptr }
+};
+
+static LabelIndex canon_imagesize_table[] = {
+    { 0, "large" }, { 1, "medium" }, { 2, "small" }, { 5, "medium 1" },
+    { 6, "medium 2" }, { 7, "medium 3" }, { 8, "postcard" },
+    { 9, "widescreen" }, { 10, "medium widescreen" }, { 14, "small 1" },
+    { 15, "small 2" }, { 16, "small 3" }, { 128, "640x480 movie" },
+    { 129, "medium movie" }, { 130, "small movie" }, { 137, "1280x720 movie" },
+    { 142, "1920x1080 movie" }, { -1, nullptr }
+};
+
+static LabelIndex canon_easymode_table[] = {
+    { 0, "Full auto" }, { 1, "Manual" }, { 2, "Landscape" }, { 3, "Fast shutter" },
+    { 4, "Slow shutter" }, { 5, "Night" }, { 6, "Gray Scale" }, { 7, "Sepia" },
+    { 8, "Portrait" }, { 9, "Sports" }, { 10, "Macro" }, { 11, "Black & White" },
+    { 12, "Pan focus" }, { 13, "Vivid" }, { 14, "Neutral" }, { 15, "Flash Off" },
+    { 16, "Long Shutter" }, { 17, "Super Macro" }, { 18, "Foliage" },
+    { 19, "Indoor" }, { 20, "Fireworks" }, { 21, "Beach" }, { 22, "Underwater" },
+    { 23, "Snow" }, { 24, "Kids & Pets" }, { 25, "Night Snapshot" },
+    { 26, "Digital Macro" }, { 27, "My Colors" }, { 28, "Movie Snap" },
+    { 29, "Super Macro 2" }, { 30, "Color Accent" }, { 31, "Color Swap" },
+    { 32, "Aquarium" }, { 33, "ISO 3200" }, { 34, "ISO 6400" },
+    { 35, "Creative Light Effect" }, { 36, "Easy" }, { 37, "Quick Shot" },
+    { 38, "Creative Auto" }, { 39, "Zoom Blur" }, { 40, "Low Light" },
+    { 41, "Nostalgic" }, { 42, "Super Vivid" }, { 43, "Poster Effect" },
+    { 44, "Face Self-timer" }, { 45, "Smile" }, { 46, "Wink Self-timer" },
+    { 47, "Fisheye Effect" }, { 48, "Miniature Effect" }, { 49, "High-speed Burst" },
+    { 50, "Best Image Selection" }, { 51, "High Dynamic Range" },
+    { 52, "Handheld Night Scene" }, { 53, "Movie Digest" },
+    { 54, "Live View Control" }, { 55, "Discreet" }, { 56, "Blur Reduction" },
+    { 57, "Monochrome" }, { 58, "Toy Camera Effect" }, { 59, "Scene Intelligent Auto" },
+    { 60, "High-speed Burst HQ" }, { 61, "Smooth Skin" }, { 62, "Soft Focus" },
+    { 257, "Spotlight" }, { 258, "Night 2" }, { 259, "Night+" }, { 260, "Super Night" },
+    { 261, "Sunset" }, { 263, "Night Scene" }, { 264, "Surface" },
+    { 265, "Low Light 2" }, { -1, nullptr }
+};
+
+static LabelIndex canon_digitalzoom_table[] = {
+    { 0, "none" }, { 1, "2x" }, { 2, "4x" }, { 3, "other" }, { -1, nullptr }
+};
+
+static LabelIndex canon_meteringmode_table[] = {
+    { 0, "default" }, { 1, "spot" }, { 2, "average" }, { 3, "evaluative" },
+    { 4, "partial" }, { 5, "center-weighted average" }, { -1, nullptr }
+};
+
+static LabelIndex canon_focusrange_table[] = {
+    { 0, "manual" }, { 1, "auto" }, { 2, "not known" }, { 3, "macro" },
+    { 4, "very close" }, { 5, "close" }, { 6, "middle range" },
+    { 7, "far range" }, { 8, "pan focus" }, { 9, "super macro" },
+    { 10, "infinity" }, { -1, nullptr }
+};
+
+static LabelIndex canon_afpoint_table[] = {
+    { 0x2005, "Manual AF point selection" }, { 0x3000, "None (MF)" },
+    { 0x3001, "Auto AF point selection" }, { 0x3002, "Right" },
+    { 0x3003, "Center" }, { 0x3004, "Left" },
+    { 0x4001, "Auto AF point selection" }, { 0x4006, "Face Detect" },
+    { -1, nullptr }
+};
+
+static LabelIndex canon_exposuremode_table[] = {
+    { 0, "Easy" }, { 1, "Program AE" }, { 2, "Shutter speed priority AE" },
+    { 3, "Aperture-priority AE" }, { 4, "Manual" }, { 5, "Depth-of-field AE" },
+    { 6, "M-Dep" }, { 7, "Bulb" }, { -1, nullptr }
+};
+
+static std::string
+explain_canon_flashbits (const ParamValue &p, const void *extradata)
+{
+    int val = p.get_int();
+    if (val == 0)
+        return "none";
+    std::vector<std::string> bits;
+    if (val & (1<<0))  bits.emplace_back ("manual");
+    if (val & (1<<1))  bits.emplace_back ("TTL");
+    if (val & (1<<2))  bits.emplace_back ("A-TTL");
+    if (val & (1<<3))  bits.emplace_back ("E-TTL");
+    if (val & (1<<4))  bits.emplace_back ("FP sync enabled");
+    if (val & (1<<7))  bits.emplace_back ("2nd-curtain sync used");
+    if (val & (1<<11)) bits.emplace_back ("FP sync used");
+    if (val & (1<<13)) bits.emplace_back ("built-in");
+    if (val & (1<<14)) bits.emplace_back ("external");
+    return Strutil::join (bits, ", ");
+}
+
+static LabelIndex canon_focuscontinuous_table[] = {
+    { 0, "single" }, { 1, "continuous" }, { 8, "manual" }, { -1, nullptr }
+};
+
+static LabelIndex canon_aesetting_table[] = {
+    { 0, "normal AE" }, { 1, "exposure compensation" }, { 2, "AE lock" },
+    { 3, "AE lock + exposure compensation" }, { 4, "no AE" }, { -1, nullptr }
+};
+
+static LabelIndex canon_imagestabilization_table[] = {
+    { 0, "Off" }, { 1, "On" }, { 2, "Shoot Only" }, { 3, "Panning" },
+    { 4, "Dynamic" }, { 256, "Off (2)" }, { 257, "On (2)" },
+    { 258, "Shoot Only (2)" }, { 259, "Panning (2)" }, { 260, "Dynamic (2)" },
+    { -1, nullptr }
+};
+
+static LabelIndex canon_spotmeteringmode_table[] = {
+    { 0, "center" }, { 1, "AF point" }, { -1, nullptr }
+};
+
+static LabelIndex canon_photoeffect_table[] = {
+    { 0, "off" }, { 1, "vivid" }, { 2, "neutral" }, { 3, "smooth" },
+    { 4, "sepia" }, { 5, "b&w" }, { 6, "custom" }, { 100, "my color data" },
+    { -1, nullptr }
+};
+
+static LabelIndex canon_manualflashoutput_table[] = {
+    { 0, "n/a" }, { 0x500, "full" }, { 0x502, "medium" }, { 0x504, "low" },
+    { 0x7fff, "n/a" }, { -1, nullptr }
+};
+
+static LabelIndex canon_srawquality_table[] = {
+    { 0, "n/a" }, { 1, "sRAW1 (mRAW)" }, { 2, "sRAW2 (sRAW)" }, { -1, nullptr }
+};
+
+static LabelIndex canon_slowshutter_table[] = {
+    { 0, "off" }, { 1, "night scene" }, { 2, "on" }, { 3, "none" }, { -1, nullptr }
+};
+
+static LabelIndex canon_afpointsinfocus_table[] = {
+    { 0x3000, "none" }, { 0x3001, "right" }, { 0x3002, "center" },
+    { 0x3003, "center+right" }, { 0x3004, "left" }, { 0x3005, "left+right" },
+    { 0x3006, "left+center" }, { 0x3007, "all" }, { -1, nullptr }
+};
+
+static LabelIndex canon_autoexposurebracketing_table[] = {
+    { -1, "on" }, { 0, "off" }, { 1, "on shot 1" }, { 2, "on shot 2" },
+    { 3, "on shot 3" }, { -1, nullptr }
+};
+
+static LabelIndex canon_controlmode_table[] = {
+    { 0, "n/a" }, { 1, "camera local control" },
+    { 3, "computer remote control" }, { -1, nullptr }
+};
+
+static LabelIndex canon_cameratype_table[] = {
+    { 0, "n/a" }, { 248, "EOS High-end" }, { 250, "Compact" },
+    { 252, "EOS Mid-range" }, { 2554, "DV Camera" }, { -1, nullptr }
+};
+
+static LabelIndex canon_autorotate_table[] = {
+    { -1, "n/a" }, { 0, "none" }, { 1, "rotate 90 CW" },
+    { 2, "rotate 180" }, { 3, "rotate 270 CW" }, { -1, nullptr }
+};
+
+static LabelIndex canon_ndfilter_table[] = {
+    { -1, "n/a" }, { 0, "off" }, { 1, "on" }, { -1, nullptr }
+};
+
+static LabelIndex canon_whitebalance_table[] = {
+    { 0,  "Auto" }, { 1,  "Daylight" }, { 2,  "Cloudy" }, { 3,  "Tungsten" },
+    { 4,  "Fluorescent" }, { 5,  "Flash" }, { 6,  "Custom" }, { 7,  "Black & White" },
+    { 8,  "Shade" }, { 9,  "Manual Temperature (Kelvin)" }, { 10, "PC Set1" },
+    { 11, "PC Set2" }, { 12, "PC Set3" }, { 14, "Daylight Fluorescent" },
+    { 15, "Custom 1" }, { 16, "Custom 2" }, { 17, "Underwater" },
+    { 18, "Custom 3" }, { 19, "Custom 4" }, { 20, "PC Set4" }, { 21, "PC Set5" },
+    { 23, "Auto (ambience priority)" }, { -1, nullptr }
+};
+
+static LabelIndex canon_modelid_table[] = {
+    { int(0x1010000), "PowerShot A30" },
+    { int(0x1040000), "PowerShot S300 / Digital IXUS 300 / IXY Digital 300" },
+    { int(0x1060000), "PowerShot A20" },
+    { int(0x1080000), "PowerShot A10" },
+    { int(0x1090000), "PowerShot S110 / Digital IXUS v / IXY Digital 200" },
+    { int(0x1100000), "PowerShot G2" },
+    { int(0x1110000), "PowerShot S40" },
+    { int(0x1120000), "PowerShot S30" },
+    { int(0x1130000), "PowerShot A40" },
+    { int(0x1140000), "EOS D30" },
+    { int(0x1150000), "PowerShot A100" },
+    { int(0x1160000), "PowerShot S200 / Digital IXUS v2 / IXY Digital 200a" },
+    { int(0x1170000), "PowerShot A200" },
+    { int(0x1180000), "PowerShot S330 / Digital IXUS 330 / IXY Digital 300a" },
+    { int(0x1190000), "PowerShot G3" },
+    { int(0x1210000), "PowerShot S45" },
+    { int(0x1230000), "PowerShot SD100 / Digital IXUS II / IXY Digital 30" },
+    { int(0x1240000), "PowerShot S230 / Digital IXUS v3 / IXY Digital 320" },
+    { int(0x1250000), "PowerShot A70" },
+    { int(0x1260000), "PowerShot A60" },
+    { int(0x1270000), "PowerShot S400 / Digital IXUS 400 / IXY Digital 400" },
+    { int(0x1290000), "PowerShot G5" },
+    { int(0x1300000), "PowerShot A300" },
+    { int(0x1310000), "PowerShot S50" },
+    { int(0x1340000), "PowerShot A80" },
+    { int(0x1350000), "PowerShot SD10 / Digital IXUS i / IXY Digital L" },
+    { int(0x1360000), "PowerShot S1 IS" },
+    { int(0x1370000), "PowerShot Pro1" },
+    { int(0x1380000), "PowerShot S70" },
+    { int(0x1390000), "PowerShot S60" },
+    { int(0x1400000), "PowerShot G6" },
+    { int(0x1410000), "PowerShot S500 / Digital IXUS 500 / IXY Digital 500" },
+    { int(0x1420000), "PowerShot A75" },
+    { int(0x1440000), "PowerShot SD110 / Digital IXUS IIs / IXY Digital 30a" },
+    { int(0x1450000), "PowerShot A400" },
+    { int(0x1470000), "PowerShot A310" },
+    { int(0x1490000), "PowerShot A85" },
+    { int(0x1520000), "PowerShot S410 / Digital IXUS 430 / IXY Digital 450" },
+    { int(0x1530000), "PowerShot A95" },
+    { int(0x1540000), "PowerShot SD300 / Digital IXUS 40 / IXY Digital 50" },
+    { int(0x1550000), "PowerShot SD200 / Digital IXUS 30 / IXY Digital 40" },
+    { int(0x1560000), "PowerShot A520" },
+    { int(0x1570000), "PowerShot A510" },
+    { int(0x1590000), "PowerShot SD20 / Digital IXUS i5 / IXY Digital L2" },
+    { int(0x1640000), "PowerShot S2 IS" },
+    { int(0x1650000), "PowerShot SD430 / Digital IXUS Wireless / IXY Digital Wireless" },
+    { int(0x1660000), "PowerShot SD500 / Digital IXUS 700 / IXY Digital 600" },
+    { int(0x1668000), "EOS D60" },
+    { int(0x1700000), "PowerShot SD30 / Digital IXUS i Zoom / IXY Digital L3" },
+    { int(0x1740000), "PowerShot A430" },
+    { int(0x1750000), "PowerShot A410" },
+    { int(0x1760000), "PowerShot S80" },
+    { int(0x1780000), "PowerShot A620" },
+    { int(0x1790000), "PowerShot A610" },
+    { int(0x1800000), "PowerShot SD630 / Digital IXUS 65 / IXY Digital 80" },
+    { int(0x1810000), "PowerShot SD450 / Digital IXUS 55 / IXY Digital 60" },
+    { int(0x1820000), "PowerShot TX1" },
+    { int(0x1870000), "PowerShot SD400 / Digital IXUS 50 / IXY Digital 55" },
+    { int(0x1880000), "PowerShot A420" },
+    { int(0x1890000), "PowerShot SD900 / Digital IXUS 900 Ti / IXY Digital 1000" },
+    { int(0x1900000), "PowerShot SD550 / Digital IXUS 750 / IXY Digital 700" },
+    { int(0x1920000), "PowerShot A700" },
+    { int(0x1940000), "PowerShot SD700 IS / Digital IXUS 800 IS / IXY Digital 800 IS" },
+    { int(0x1950000), "PowerShot S3 IS" },
+    { int(0x1960000), "PowerShot A540" },
+    { int(0x1970000), "PowerShot SD600 / Digital IXUS 60 / IXY Digital 70" },
+    { int(0x1980000), "PowerShot G7" },
+    { int(0x1990000), "PowerShot A530" },
+    { int(0x2000000), "PowerShot SD800 IS / Digital IXUS 850 IS / IXY Digital 900 IS" },
+    { int(0x2010000), "PowerShot SD40 / Digital IXUS i7 / IXY Digital L4" },
+    { int(0x2020000), "PowerShot A710 IS" },
+    { int(0x2030000), "PowerShot A640" },
+    { int(0x2040000), "PowerShot A630" },
+    { int(0x2090000), "PowerShot S5 IS" },
+    { int(0x2100000), "PowerShot A460" },
+    { int(0x2120000), "PowerShot SD850 IS / Digital IXUS 950 IS / IXY Digital 810 IS" },
+    { int(0x2130000), "PowerShot A570 IS" },
+    { int(0x2140000), "PowerShot A560" },
+    { int(0x2150000), "PowerShot SD750 / Digital IXUS 75 / IXY Digital 90" },
+    { int(0x2160000), "PowerShot SD1000 / Digital IXUS 70 / IXY Digital 10" },
+    { int(0x2180000), "PowerShot A550" },
+    { int(0x2190000), "PowerShot A450" },
+    { int(0x2230000), "PowerShot G9" },
+    { int(0x2240000), "PowerShot A650 IS" },
+    { int(0x2260000), "PowerShot A720 IS" },
+    { int(0x2290000), "PowerShot SX100 IS" },
+    { int(0x2300000), "PowerShot SD950 IS / Digital IXUS 960 IS / IXY Digital 2000 IS" },
+    { int(0x2310000), "PowerShot SD870 IS / Digital IXUS 860 IS / IXY Digital 910 IS" },
+    { int(0x2320000), "PowerShot SD890 IS / Digital IXUS 970 IS / IXY Digital 820 IS" },
+    { int(0x2360000), "PowerShot SD790 IS / Digital IXUS 90 IS / IXY Digital 95 IS" },
+    { int(0x2370000), "PowerShot SD770 IS / Digital IXUS 85 IS / IXY Digital 25 IS" },
+    { int(0x2380000), "PowerShot A590 IS" },
+    { int(0x2390000), "PowerShot A580" },
+    { int(0x2420000), "PowerShot A470" },
+    { int(0x2430000), "PowerShot SD1100 IS / Digital IXUS 80 IS / IXY Digital 20 IS" },
+    { int(0x2460000), "PowerShot SX1 IS" },
+    { int(0x2470000), "PowerShot SX10 IS" },
+    { int(0x2480000), "PowerShot A1000 IS" },
+    { int(0x2490000), "PowerShot G10" },
+    { int(0x2510000), "PowerShot A2000 IS" },
+    { int(0x2520000), "PowerShot SX110 IS" },
+    { int(0x2530000), "PowerShot SD990 IS / Digital IXUS 980 IS / IXY Digital 3000 IS" },
+    { int(0x2540000), "PowerShot SD880 IS / Digital IXUS 870 IS / IXY Digital 920 IS" },
+    { int(0x2550000), "PowerShot E1" },
+    { int(0x2560000), "PowerShot D10" },
+    { int(0x2570000), "PowerShot SD960 IS / Digital IXUS 110 IS / IXY Digital 510 IS" },
+    { int(0x2580000), "PowerShot A2100 IS" },
+    { int(0x2590000), "PowerShot A480" },
+    { int(0x2600000), "PowerShot SX200 IS" },
+    { int(0x2610000), "PowerShot SD970 IS / Digital IXUS 990 IS / IXY Digital 830 IS" },
+    { int(0x2620000), "PowerShot SD780 IS / Digital IXUS 100 IS / IXY Digital 210 IS" },
+    { int(0x2630000), "PowerShot A1100 IS" },
+    { int(0x2640000), "PowerShot SD1200 IS / Digital IXUS 95 IS / IXY Digital 110 IS" },
+    { int(0x2700000), "PowerShot G11" },
+    { int(0x2710000), "PowerShot SX120 IS" },
+    { int(0x2720000), "PowerShot S90" },
+    { int(0x2750000), "PowerShot SX20 IS" },
+    { int(0x2760000), "PowerShot SD980 IS / Digital IXUS 200 IS / IXY Digital 930 IS" },
+    { int(0x2770000), "PowerShot SD940 IS / Digital IXUS 120 IS / IXY Digital 220 IS" },
+    { int(0x2800000), "PowerShot A495" },
+    { int(0x2810000), "PowerShot A490" },
+    { int(0x2820000), "PowerShot A3100/A3150 IS" },
+    { int(0x2830000), "PowerShot A3000 IS" },
+    { int(0x2840000), "PowerShot SD1400 IS / IXUS 130 / IXY 400F" },
+    { int(0x2850000), "PowerShot SD1300 IS / IXUS 105 / IXY 200F" },
+    { int(0x2860000), "PowerShot SD3500 IS / IXUS 210 / IXY 10S" },
+    { int(0x2870000), "PowerShot SX210 IS" },
+    { int(0x2880000), "PowerShot SD4000 IS / IXUS 300 HS / IXY 30S" },
+    { int(0x2890000), "PowerShot SD4500 IS / IXUS 1000 HS / IXY 50S" },
+    { int(0x2920000), "PowerShot G12" },
+    { int(0x2930000), "PowerShot SX30 IS" },
+    { int(0x2940000), "PowerShot SX130 IS" },
+    { int(0x2950000), "PowerShot S95" },
+    { int(0x2980000), "PowerShot A3300 IS" },
+    { int(0x2990000), "PowerShot A3200 IS" },
+    { int(0x3000000), "PowerShot ELPH 500 HS / IXUS 310 HS / IXY 31S" },
+    { int(0x3010000), "PowerShot Pro90 IS" },
+    { int(0x3010001), "PowerShot A800" },
+    { int(0x3020000), "PowerShot ELPH 100 HS / IXUS 115 HS / IXY 210F" },
+    { int(0x3030000), "PowerShot SX230 HS" },
+    { int(0x3040000), "PowerShot ELPH 300 HS / IXUS 220 HS / IXY 410F" },
+    { int(0x3050000), "PowerShot A2200" },
+    { int(0x3060000), "PowerShot A1200" },
+    { int(0x3070000), "PowerShot SX220 HS" },
+    { int(0x3080000), "PowerShot G1 X" },
+    { int(0x3090000), "PowerShot SX150 IS" },
+    { int(0x3100000), "PowerShot ELPH 510 HS / IXUS 1100 HS / IXY 51S" },
+    { int(0x3110000), "PowerShot S100 (new)" },
+    { int(0x3120000), "PowerShot ELPH 310 HS / IXUS 230 HS / IXY 600F" },
+    { int(0x3130000), "PowerShot SX40 HS" },
+    { int(0x3140000), "IXY 32S" },
+    { int(0x3160000), "PowerShot A1300" },
+    { int(0x3170000), "PowerShot A810" },
+    { int(0x3180000), "PowerShot ELPH 320 HS / IXUS 240 HS / IXY 420F" },
+    { int(0x3190000), "PowerShot ELPH 110 HS / IXUS 125 HS / IXY 220F" },
+    { int(0x3200000), "PowerShot D20" },
+    { int(0x3210000), "PowerShot A4000 IS" },
+    { int(0x3220000), "PowerShot SX260 HS" },
+    { int(0x3230000), "PowerShot SX240 HS" },
+    { int(0x3240000), "PowerShot ELPH 530 HS / IXUS 510 HS / IXY 1" },
+    { int(0x3250000), "PowerShot ELPH 520 HS / IXUS 500 HS / IXY 3" },
+    { int(0x3260000), "PowerShot A3400 IS" },
+    { int(0x3270000), "PowerShot A2400 IS" },
+    { int(0x3280000), "PowerShot A2300" },
+    { int(0x3330000), "PowerShot G15" },
+    { int(0x3340000), "PowerShot SX50 HS" },
+    { int(0x3350000), "PowerShot SX160 IS" },
+    { int(0x3360000), "PowerShot S110 (new)" },
+    { int(0x3370000), "PowerShot SX500 IS" },
+    { int(0x3380000), "PowerShot N" },
+    { int(0x3390000), "IXUS 245 HS / IXY 430F" },
+    { int(0x3400000), "PowerShot SX280 HS" },
+    { int(0x3410000), "PowerShot SX270 HS" },
+    { int(0x3420000), "PowerShot A3500 IS" },
+    { int(0x3430000), "PowerShot A2600" },
+    { int(0x3440000), "PowerShot SX275 HS" },
+    { int(0x3450000), "PowerShot A1400" },
+    { int(0x3460000), "PowerShot ELPH 130 IS / IXUS 140 / IXY 110F" },
+    { int(0x3470000), "PowerShot ELPH 115/120 IS / IXUS 132/135 / IXY 90F/100F" },
+    { int(0x3490000), "PowerShot ELPH 330 HS / IXUS 255 HS / IXY 610F" },
+    { int(0x3510000), "PowerShot A2500" },
+    { int(0x3540000), "PowerShot G16" },
+    { int(0x3550000), "PowerShot S120" },
+    { int(0x3560000), "PowerShot SX170 IS" },
+    { int(0x3580000), "PowerShot SX510 HS" },
+    { int(0x3590000), "PowerShot S200 (new)" },
+    { int(0x3600000), "IXY 620F" },
+    { int(0x3610000), "PowerShot N100" },
+    { int(0x3640000), "PowerShot G1 X Mark II" },
+    { int(0x3650000), "PowerShot D30" },
+    { int(0x3660000), "PowerShot SX700 HS" },
+    { int(0x3670000), "PowerShot SX600 HS" },
+    { int(0x3680000), "PowerShot ELPH 140 IS / IXUS 150 / IXY 130" },
+    { int(0x3690000), "PowerShot ELPH 135 / IXUS 145 / IXY 120" },
+    { int(0x3700000), "PowerShot ELPH 340 HS / IXUS 265 HS / IXY 630" },
+    { int(0x3710000), "PowerShot ELPH 150 IS / IXUS 155 / IXY 140" },
+    { int(0x3740000), "EOS M3" },
+    { int(0x3750000), "PowerShot SX60 HS" },
+    { int(0x3760000), "PowerShot SX520 HS" },
+    { int(0x3770000), "PowerShot SX400 IS" },
+    { int(0x3780000), "PowerShot G7 X" },
+    { int(0x3790000), "PowerShot N2" },
+    { int(0x3800000), "PowerShot SX530 HS" },
+    { int(0x3820000), "PowerShot SX710 HS" },
+    { int(0x3830000), "PowerShot SX610 HS" },
+    { int(0x3840000), "EOS M10" },
+    { int(0x3850000), "PowerShot G3 X" },
+    { int(0x3860000), "PowerShot ELPH 165 HS / IXUS 165 / IXY 160" },
+    { int(0x3870000), "PowerShot ELPH 160 / IXUS 160" },
+    { int(0x3880000), "PowerShot ELPH 350 HS / IXUS 275 HS / IXY 640" },
+    { int(0x3890000), "PowerShot ELPH 170 IS / IXUS 170" },
+    { int(0x3910000), "PowerShot SX410 IS" },
+    { int(0x3930000), "PowerShot G9 X" },
+    { int(0x3940000), "EOS M5" },
+    { int(0x3950000), "PowerShot G5 X" },
+    { int(0x3970000), "PowerShot G7 X Mark II" },
+    { int(0x3990000), "PowerShot ELPH 360 HS / IXUS 285 HS / IXY 650" },
+    { int(0x4010000), "PowerShot SX540 HS" },
+    { int(0x4020000), "PowerShot SX420 IS" },
+    { int(0x4030000), "PowerShot ELPH 190 IS / IXUS 180 / IXY 190" },
+    { int(0x4040000), "PowerShot G1" },
+    { int(0x4040001), "IXY 180" },
+    { int(0x4050000), "PowerShot SX720 HS" },
+    { int(0x4060000), "PowerShot SX620 HS" },
+    { int(0x4070000), "EOS M6" },
+    { int(0x4100000), "PowerShot G9 X Mark II" },
+    { int(0x4150000), "PowerShot ELPH 185 / IXUS 185 / IXY 200" },
+    { int(0x4160000), "PowerShot SX430 IS" },
+    { int(0x4170000), "PowerShot SX730 HS" },
+    { int(0x6040000), "PowerShot S100 / Digital IXUS / IXY Digital" },
+    { int(0x4007d673), "C19/DC21/DC22" },
+    { int(0x4007d674), "H A1" },
+    { int(0x4007d675), "V10" },
+    { int(0x4007d676), "D130/MD140/MD150/MD160/ZR850" },
+    { int(0x4007d777), "C50" },
+    { int(0x4007d778), "V20" },
+    { int(0x4007d779), "C211" },
+    { int(0x4007d77a), "G10" },
+    { int(0x4007d77b), "R10" },
+    { int(0x4007d77d), "D255/ZR950" },
+    { int(0x4007d81c), "F11" },
+    { int(0x4007d878), "V30" },
+    { int(0x4007d87c), "H A1S" },
+    { int(0x4007d87e), "C301/DC310/DC311/DC320/DC330" },
+    { int(0x4007d87f), "S100" },
+    { int(0x4007d880), "F10" },
+    { int(0x4007d882), "G20/HG21" },
+    { int(0x4007d925), "F21" },
+    { int(0x4007d926), "F S11" },
+    { int(0x4007d978), "V40" },
+    { int(0x4007d987), "C410/DC411/DC420" },
+    { int(0x4007d988), "S19/FS20/FS21/FS22/FS200" },
+    { int(0x4007d989), "F20/HF200" },
+    { int(0x4007d98a), "F S10/S100" },
+    { int(0x4007da8e), "F R10/R16/R17/R18/R100/R106" },
+    { int(0x4007da8f), "F M30/M31/M36/M300/M306" },
+    { int(0x4007da90), "F S20/S21/S200" },
+    { int(0x4007da92), "S31/FS36/FS37/FS300/FS305/FS306/FS307" },
+    { int(0x4007dda9), "F G25" },
+    { int(0x4007dfb4), "C10" },
+    { int(0x80000001), "OS-1D" },
+    { int(0x80000167), "OS-1DS" },
+    { int(0x80000168), "OS 10D" },
+    { int(0x80000169), "OS-1D Mark III" },
+    { int(0x80000170), "OS Digital Rebel / 300D / Kiss Digital" },
+    { int(0x80000174), "OS-1D Mark II" },
+    { int(0x80000175), "OS 20D" },
+    { int(0x80000176), "OS Digital Rebel XSi / 450D / Kiss X2" },
+    { int(0x80000188), "OS-1Ds Mark II" },
+    { int(0x80000189), "OS Digital Rebel XT / 350D / Kiss Digital N" },
+    { int(0x80000190), "OS 40D" },
+    { int(0x80000213), "OS 5D" },
+    { int(0x80000215), "OS-1Ds Mark III" },
+    { int(0x80000218), "OS 5D Mark II" },
+    { int(0x80000219), "FT-E1" },
+    { int(0x80000232), "OS-1D Mark II N" },
+    { int(0x80000234), "OS 30D" },
+    { int(0x80000236), "OS Digital Rebel XTi / 400D / Kiss Digital X" },
+    { int(0x80000241), "FT-E2" },
+    { int(0x80000246), "FT-E3" },
+    { int(0x80000250), "OS 7D" },
+    { int(0x80000252), "OS Rebel T1i / 500D / Kiss X3" },
+    { int(0x80000254), "OS Rebel XS / 1000D / Kiss F" },
+    { int(0x80000261), "OS 50D" },
+    { int(0x80000269), "OS-1D X" },
+    { int(0x80000270), "OS Rebel T2i / 550D / Kiss X4" },
+    { int(0x80000271), "FT-E4" },
+    { int(0x80000273), "FT-E5" },
+    { int(0x80000281), "OS-1D Mark IV" },
+    { int(0x80000285), "OS 5D Mark III" },
+    { int(0x80000286), "OS Rebel T3i / 600D / Kiss X5" },
+    { int(0x80000287), "OS 60D" },
+    { int(0x80000288), "OS Rebel T3 / 1100D / Kiss X50" },
+    { int(0x80000289), "OS 7D Mark II" },
+    { int(0x80000297), "FT-E2 II" },
+    { int(0x80000298), "FT-E4 II" },
+    { int(0x80000301), "OS Rebel T4i / 650D / Kiss X6i" },
+    { int(0x80000302), "OS 6D" },
+    { int(0x80000324), "OS-1D C" },
+    { int(0x80000325), "OS 70D" },
+    { int(0x80000326), "OS Rebel T5i / 700D / Kiss X7i" },
+    { int(0x80000327), "OS Rebel T5 / 1200D / Kiss X70" },
+    { int(0x80000328), "OS-1D X MARK II" },
+    { int(0x80000331), "OS M" },
+    { int(0x80000346), "OS Rebel SL1 / 100D / Kiss X7" },
+    { int(0x80000347), "OS Rebel T6s / 760D / 8000D" },
+    { int(0x80000349), "OS 5D Mark IV" },
+    { int(0x80000350), "OS 80D" },
+    { int(0x80000355), "OS M2" },
+    { int(0x80000382), "OS 5DS" },
+    { int(0x80000393), "OS Rebel T6i / 750D / Kiss X8i" },
+    { int(0x80000401), "OS 5DS R" },
+    { int(0x80000404), "OS Rebel T6 / 1300D / Kiss X80" },
+    { int(0x80000405), "OS Rebel T7i / 800D / Kiss X9i" },
+    { int(0x80000406), "OS 6D Mark II" },
+    { int(0x80000408), "OS 77D / 9000D" },
+    { int(0x80000417), "OS Rebel SL2 / 200D / Kiss X9" },
+    { -1, nullptr }
+};
+
+#if 0
+static LabelIndex canon_xxx_table[] = {
+    { 0, "" },
+    { 1, "" },
+    { 2, "" },
+    { 3, "" },
+    { 4, "" },
+    { 5, "" },
+    { 6, "" },
+    { 7, "" },
+    { 8, "" },
+    { 9, "" },
+    { 10, "" },
+    { 11, "" },
+    { 12, "" },
+    { -1, nullptr }
+};
+#endif
+
+
+static const ExplanationTableEntry canon_explanations[] = {
+    { "Canon:MacroMode", explain_labeltable, canon_macromode_table },
+    { "Canon:Quality", explain_labeltable, canon_quality_table },
+    { "Canon:FlashMode", explain_labeltable, canon_flashmode_table },
+    { "Canon:ContinuousDrive", explain_labeltable, canon_continuousdrive_table },
+    { "Canon:FocusMode", explain_labeltable, canon_focusmode_table },
+    { "Canon:RecordMode", explain_labeltable, canon_recordmode_table },
+    { "Canon:ImageSize", explain_labeltable, canon_imagesize_table },
+    { "Canon:EasyMode", explain_labeltable, canon_easymode_table },
+    { "Canon:DigitalZoom", explain_labeltable, canon_digitalzoom_table },
+    { "Canon:MeteringMode", explain_labeltable, canon_meteringmode_table },
+    { "Canon:FocusRange", explain_labeltable, canon_focusrange_table },
+    { "Canon:AFPoint", explain_labeltable, canon_afpoint_table },
+    { "Canon:ExposureMode", explain_labeltable, canon_exposuremode_table },
+    { "Canon:FlashBits", explain_canon_flashbits, nullptr },
+    { "Canon:FocusContinuous", explain_labeltable, canon_focuscontinuous_table },
+    { "CanonAESetting:", explain_labeltable, canon_aesetting_table },
+    { "Canon:ImageStabilization", explain_labeltable, canon_imagestabilization_table },
+    { "CanonSpotMeteringMode:", explain_labeltable, canon_spotmeteringmode_table },
+    { "Canon:PhotoEffect", explain_labeltable, canon_photoeffect_table },
+    { "Canon:ManualFlashOutput", explain_labeltable, canon_manualflashoutput_table },
+    { "Canon:SRAWQuality", explain_labeltable, canon_srawquality_table },
+    { "Canon:SlowShutter", explain_labeltable, canon_slowshutter_table },
+    { "Canon:AFPointsInFocus", explain_labeltable, canon_afpointsinfocus_table },
+    { "CanonAutoExposureBracketing:", explain_labeltable, canon_autoexposurebracketing_table },
+    { "Canon:ControlMode", explain_labeltable, canon_controlmode_table },
+    { "Canon:CameraType", explain_labeltable, canon_cameratype_table },
+    { "Canon:AutoRotate", explain_labeltable, canon_autorotate_table },
+    { "Canon:NDFilter", explain_labeltable, canon_ndfilter_table },
+    { "Canon:WhiteBalance", explain_labeltable, canon_whitebalance_table },
+    { "Canon:ModelID", explain_labeltable, canon_modelid_table },
+    // { "Canon:", explain_labeltable, canon__table },
+};
+
+
+
+array_view<const ExplanationTableEntry>
+canon_explanation_table ()
+{
+    return array_view<const ExplanationTableEntry>(canon_explanations);
+}
+
+
+/////////////////////////////////////////////////////////////////////////
+
+
+
+// Put a whole bunch of sub-indexed data into the spec.
+template<typename T>
+inline void
+array_to_spec (ImageSpec& spec,                 // spec to put attribs into
+               const TIFFDirEntry& dir,         // TIFF dir entry
+               array_view<const uint8_t> buf,   // raw buffer blob
+               array_view<const LabelIndex> indices, // LabelIndex table
+               int offset_adjustment,
+               int na_value = std::numeric_limits<int>::max())
+{
+    // Make sure it's the right tag type. Be tolerant of signed/unsigned
+    // mistakes.
+    if (std::is_same<T,int16_t>::value || std::is_same<T,uint16_t>::value) {
+        if ((dir.tdir_type != TIFF_SHORT && dir.tdir_type != TIFF_SSHORT))
+            return;
+    } else if (std::is_same<T,int32_t>::value || std::is_same<T,uint32_t>::value) {
+        if ((dir.tdir_type != TIFF_LONG && dir.tdir_type != TIFF_SLONG))
+            return;
+    }
+    else {
+        ASSERT(0 && "unsupported type");
+    }
+    const T *s = (const T *) pvt::dataptr (dir, buf, offset_adjustment);
+    for (auto&& attr : indices) {
+        if (attr.value < int(dir.tdir_count)) {
+            T ival = int (s[attr.value]);
+            if (ival != na_value)
+                spec.attribute (attr.label, ival);
+        }
+    }
+}
+
+
+static LabelIndex canon_camerasettings_indices[] = {
+    { 1, "Canon:MacroMode" },
+    { 2, "Canon:SelfTimer" },
+    { 3, "Canon:Quality" },
+    { 4, "Canon:FlashMode" },
+    { 5, "Canon:ContinuousDrive" },
+    { 7, "Canon:FocusMode" },
+    { 9, "Canon:RecordMode" },
+    { 10, "Canon:ImageSize" },
+    { 11, "Canon:EasyMode" },
+    { 12, "Canon:DigitalZoom" },
+    { 13, "Canon:Contrast" },
+    { 14, "Canon:Saturation" },
+    { 15, "Canon:Sharpness" },
+    { 16, "Canon:CameraISO" },
+    { 17, "Canon:MeteringMode" },
+    { 18, "Canon:FocusRange" },
+    { 19, "Canon:AFPoint" },
+    { 20, "Canon:ExposureMode" },
+    { 22, "Canon:LensType" },
+    { 23, "Canon:MaxFocalLength" },
+    { 24, "Canon:MinFocalLength" },
+    { 25, "Canon:FocalUnits" },
+    { 26, "Canon:MaxAperture" },
+    { 27, "Canon:MinAperture" },
+    { 28, "Canon:FlashActivity" },
+    { 29, "Canon:FlashBits" },
+    { 32, "Canon:FocusContinuous" },
+    { 33, "Canon:AESetting" },
+    { 34, "Canon:ImageStabilization" },
+    { 35, "Canon:DisplayAperture" },
+    { 36, "Canon:ZoomSourceWidth" },
+    { 37, "Canon:ZoomTargetWidth" },
+    { 39, "Canon:SpotMeteringMode" },
+    { 40, "Canon:PhotoEffect" },
+    { 41, "Canon:ManualFlashOutput" },
+    { 42, "Canon:ColorTone" },
+    { 46, "Canon:SRAWQuality" }
+};
+
+static void
+canon_camerasettings_handler (const TagInfo& taginfo, const TIFFDirEntry& dir,
+                              array_view<const uint8_t> buf, ImageSpec& spec,
+                              bool swapendian, int offset_adjustment)
+{
+    array_to_spec<int16_t> (spec, dir, buf, canon_camerasettings_indices,
+                            offset_adjustment, -1);
+}
+
+
+static LabelIndex canon_focallength_indices[] = {
+    { 0, "Canon:FocalType" },
+    { 1, "Canon:FocalLength" },
+    { 2, "Canon:FocalPlaneXSize" },
+    { 3, "Canon:FocalPlaneYSize" }
+};
+
+
+static void
+canon_focallength_handler (const TagInfo& taginfo, const TIFFDirEntry& dir,
+                           array_view<const uint8_t> buf, ImageSpec& spec,
+                           bool swapendian, int offset_adjustment)
+{
+    array_to_spec<uint16_t> (spec, dir, buf, canon_focallength_indices, offset_adjustment);
+}
+
+
+static LabelIndex canon_shotinfo_indices[] = {
+    { 1, "Canon:AutoISO" },
+    { 2, "Canon:BaseISO" },
+    { 3, "Canon:MeasuredEV" },
+    { 4, "Canon:TargetAperture" },
+    { 5, "Canon:TargetExposureTime" },
+    { 6, "Canon:ExposureCompensation" },
+    { 7, "Canon:WhiteBalance" },
+    { 8, "Canon:SlowShutter" },
+    { 9, "Canon:SequenceNumber" },
+    { 10, "Canon:OpticalZoomCode" },
+    { 12, "Canon:CameraTemperature" },
+    { 13, "Canon:FlashGuideNumber" },
+    { 14, "Canon:AFPointsInFocus" },
+    { 15, "Canon:ExposureComp" },
+    { 16, "Canon:FlashExposureComp" },
+    { 17, "Canon:AutoExposureBracketing" },
+    { 18, "Canon:AEBBracketValue" },
+    { 19, "Canon:ControlMode" },
+    { 20, "Canon:FocusDistanceUpper" },
+    { 21, "Canon:FocusDistanceLower" },
+    { 22, "Canon:FNumber" },
+    { 23, "Canon:ExposureTime" },
+    { 24, "Canon:MeasuredEV2" },
+    { 25, "Canon:BulbDuration" },
+    { 26, "Canon:CameraType" },
+    { 27, "Canon:AutoRotate" },
+    { 28, "Canon:NDFilter" },
+    { 29, "Canon:SelfTimer2" },
+    { 33, "Canon:FlashOutput" },
+};
+
+static void
+canon_shotinfo_handler (const TagInfo& taginfo, const TIFFDirEntry& dir,
+                        array_view<const uint8_t> buf, ImageSpec& spec,
+                        bool swapendian, int offset_adjustment)
+{
+    array_to_spec<int16_t> (spec, dir, buf, canon_shotinfo_indices, offset_adjustment);
+}
+
+
+static LabelIndex canon_panorama_indices[] = {
+    { 2, "Canon:PanoramaFrameNumber" },
+    { 5, "Canon:PanoramaDirection" },
+};
+
+static void
+canon_panorama_handler (const TagInfo& taginfo, const TIFFDirEntry& dir,
+                        array_view<const uint8_t> buf, ImageSpec& spec,
+                        bool swapendian, int offset_adjustment)
+{
+    array_to_spec<int16_t> (spec, dir, buf, canon_panorama_indices, offset_adjustment);
+}
+
+static LabelIndex canon_sensorinfo_indices[] = {
+    { 1, "Canon:SensorWidth" },
+    { 2, "Canon:SensorHeight" },
+    { 5, "Canon:SensorLeftBorder" },
+    { 6, "Canon:SensorTopBorder" },
+    { 7, "Canon:SensorRightBorder" },
+    { 8, "Canon:SensorBottomBorder" },
+    { 9, "Canon:BlackMaskLeftBorder" },
+    { 10, "Canon:BlackMaskTopBorder" },
+    { 11, "Canon:BlackMaskRightBorder" },
+    { 12, "Canon:BlackMaskBottomBorder" },
+};
+
+static void
+canon_sensorinfo_handler (const TagInfo& taginfo, const TIFFDirEntry& dir,
+                        array_view<const uint8_t> buf, ImageSpec& spec,
+                        bool swapendian, int offset_adjustment)
+{
+    array_to_spec<uint16_t> (spec, dir, buf, canon_sensorinfo_indices, offset_adjustment);
+}
+
+
+
+enum CANON_TAGS {
+    CANON_CAMERASETTINGS    = 0X0001,
+    CANON_FOCALLENGTH       = 0X0002,
+    CANON_FLASHINFO         = 0X0003,
+    CANON_SHOTINFO          = 0X0004,
+    CANON_PANORAMA          = 0X0005,
+    CANON_IMAGETYPE         = 0X0006,
+    CANON_FIRMWAREVERSION   = 0X0007,
+    CANON_FILENUMBER        = 0X0008,
+    CANON_OWNERNAME         = 0X0009,
+    CANON_SERIALNUMBER      = 0X000C,
+    CANON_CAMERAINFO        = 0X000D,
+    CANON_FILELENGTH        = 0X000E,
+    CANON_CUSTOMFUNCTIONS   = 0X000F,
+    CANON_MODELID           = 0X0010,
+    CANON_MOVIEINFO         = 0X0011,
+    CANON_AFINFO            = 0X0012,
+    CANON_THUMBNAILIMAGEVALIDAREA = 0X0013,
+    CANON_SERIALNUMBERFORMAT = 0X0015,
+    CANON_SUPERMACRO        = 0X001A,
+    CANON_DATESTAMPMODE     = 0X001C,
+    CANON_MYCOLORS          = 0X001D,
+    CANON_FIRMWAREREVISION  = 0X001E,
+    CANON_CATEGORIES        = 0X0023,
+    CANON_FACEDETECT1       = 0X0024,
+    CANON_FACEDETECT2       = 0X0025,
+    CANON_AFINFO2           = 0X0026,
+    CANON_CONTRASTINFO      = 0X0027,
+    CANON_IMAGEUNIQUEID     = 0X0028,
+    CANON_FACEDETECT3       = 0X002F,
+    CANON_TIMEINFO          = 0X0035,
+    CANON_AFINFO3           = 0X003C,
+    CANON_ORIGINALDECISIONDATAOFFSET = 0X0083,
+    CANON_CUSTOMFUNCTIONS1D = 0X0090,
+    CANON_PERSONALFUNCTIONS = 0X0091,
+    CANON_PERSONALFUNCTIONVALUES    = 0X0092,
+    CANON_FILEINFO          = 0X0093,
+    CANON_AFPOINTSINFOCUS1D = 0X0094,
+    CANON_LENSMODEL         = 0X0095,
+    CANON_SERIALINFO        = 0X0096,
+    CANON_DUSTREMOVALDATA   = 0X0097,
+    CANON_CROPINFO          = 0X0098,
+    CANON_CUSTOMFUNCTIONS2  = 0X0099,
+    CANON_ASPECTINFO        = 0X009A,
+    CANON_PROCESSINGINFO    = 0X00a0,
+    CANON_TONECURVETABLE    = 0X00A1,
+    CANON_SHARPNESSTABLE    = 0X00A2,
+    CANON_SHARPNESSFREQTABLE = 0X00A3,
+    CANON_WHITEBALANCETABLE = 0X00A4,
+    CANON_COLORBALANCE      = 0X00A9,
+    CANON_MEASUREDCOLOR     = 0X00AA,
+    CANON_COLORTEMPERATURE  = 0X00AE,
+    CANON_CANONFLAGS        = 0X00B0,
+    CANON_MODIFIEDINFO      = 0X00B1,
+    CANON_TONECURVEMATCHING = 0X00B2,
+    CANON_WHITEBALANCEMATCHING  = 0X00B3,
+    CANON_COLORSPACE        = 0X00B4,
+    CANON_PREVIEWIMAGEINFO  = 0X00B6,
+    CANON_VRDOFFSET         = 0X00D0,
+    CANON_SENSORINFO        = 0X00E0,
+    CANON_COLORDATA         = 0X4001,
+    CANON_CRWPARAM          = 0X4002,
+    CANON_FLAVOR            = 0X4005,
+    CANON_PICTURESTYLEUSERDEF = 0X4008,
+    CANON_PICTURESTYLEPC    = 0X4009,
+    CANON_CUSTOMPICTURESTYLEFILENAME = 0X4010,
+    CANON_AFMICROADJ        = 0X4013,
+    CANON_VIGNETTINGCORR    = 0X4015,
+    CANON_VIGNETTINGCORR2   = 0X4016,
+    CANON_LIGHTINGOPT       = 0X4018,
+    CANON_LENSINFO          = 0X4019,
+    CANON_AMBIENCEINFO      = 0X4020,
+    CANON_MULTIEXP          = 0X4021,
+    CANON_FILTERINFO        = 0X4024,
+    CANON_HDRINFO           = 0X4025,
+    CANON_AFCONFIG          = 0X4028
+};
+
+
+
+static const TagInfo canon_maker_tag_table[] = {
+    { CANON_CAMERASETTINGS, "Canon:CameraSettings",  TIFF_SHORT, 0, canon_camerasettings_handler },
+    { CANON_FOCALLENGTH, "Canon:FocalLength",  TIFF_SHORT, 0, canon_focallength_handler },
+    // { CANON_FLASHINFO, "Canon:FlashInfo", unknown }
+    { CANON_SHOTINFO, "Canon:ShotInfo",  TIFF_SHORT, 0, canon_shotinfo_handler },
+    { CANON_PANORAMA, "Canon:Panorama",  TIFF_SHORT, 0, canon_panorama_handler },
+    { CANON_IMAGETYPE, "Canon:ImageType",       TIFF_ASCII, 0 },
+    { CANON_FIRMWAREVERSION, "Canon:FirmwareVersion", TIFF_ASCII, 1 },
+    { CANON_FILENUMBER, "Canon:FileNumber",      TIFF_LONG,  1 },
+    { CANON_OWNERNAME, "Canon:OwnerName",       TIFF_ASCII, 0 },
+    // { 0x000a, unknown }
+    { CANON_SERIALNUMBER, "Canon:SerialNumber",    TIFF_LONG,  1 },
+    // { CANON_CAMERAINFO, "Canon:CameraInfo",    TIFF_LONG,  0, canon_blah_handler },
+    // { CANON_FILELENGTH, "Canon:FileLength",    TIFF_LONG,  1 },
+    // { CANON_CUSTOMFUNCTIONS, "Canon:CustomFunctions",    TIFF_LONG,  0, canon_blah_handler },
+    { CANON_MODELID, "Canon:ModelID",    TIFF_LONG,  1 },
+    // { CANON_MOVIEINFO, "Canon:MovieInfo",    TIFF_LONG,  0, canon_blah_handler },
+    // { CANON_AFINFO, "Canon:AFInfo",    TIFF_LONG,  0, canon_blah_handler },
+    { CANON_THUMBNAILIMAGEVALIDAREA, "Canon:ThumbnailImageValidArea", TIFF_LONG, 4 },
+    { CANON_SERIALNUMBERFORMAT, "Canon:SerialNumberFormat", TIFF_LONG, 1 },
+    { CANON_SUPERMACRO, "Canon:SuperMacro", TIFF_SHORT, 1 },
+    { CANON_DATESTAMPMODE, "Canon:DateStampMode", TIFF_SHORT, 1 },
+    // { CANON_MYCOLORS, "Canon:MyColors",    TIFF_NOTYPE,  0, canon_blah_handler },
+    { CANON_FIRMWAREREVISION, "Canon:FirmwareRevision", TIFF_LONG, 1 },
+    { CANON_CATEGORIES, "Canon:Categories", TIFF_LONG, 2 },
+    // { CANON_FACEDETECT1, "Canon:FaceDetect1",    TIFF_NOTYPE,  0, canon_blah_handler },
+    // { CANON_FACEDETECT2, "Canon:FaceDetect2",    TIFF_NOTYPE,  0, canon_blah_handler },
+    // { CANON_AFINFO2, "Canon:AFInfo2",    TIFF_NOTYPE,  0, canon_blah_handler },
+    // { CANON_CONTRASTINFO, "Canon:ContrastInfo",    TIFF_NOTYPE,  0, canon_blah_handler },
+    { CANON_IMAGEUNIQUEID, "Canon:ImageUniqueID",    TIFF_BYTE,  1 },
+    // { CANON_FACEDETECT3, "Canon:FaceDetect3",    TIFF_NOTYPE,  0, canon_blah_handler },
+    // { CANON_TIMEINFO, "Canon:TimeInfo",    TIFF_NOTYPE,  0, canon_blah_handler },
+    // { CANON_AFINFO3, "Canon:AFInfo3",    TIFF_NOTYPE,  0, canon_blah_handler },
+    // { CANON_ORIGINALDECISIONDATAOFFSET, "Canon:OriginalDecisionDataOffset", TIFF_NOTYPE,  0 },
+    // { CANON_CUSTOMFUNCTIONS1D, "Canon:CustomFunctions1D", TIFF_NOTYPE,  0, canon_blah_handler },
+    // { CANON_PERSONALFUNCTIONS, "Canon:PersonalFunctions", TIFF_NOTYPE,  0, canon_blah_handler },
+    // { CANON_PERSONALFUNCTIONVALUES, "Canon:PersonalFunctionValues", TIFF_NOTYPE,  0, canon_blah_handler },
+    // { CANON_FILEINFO, "Canon:FileInfo", TIFF_NOTYPE,  0, canon_blah_handler },
+    // { CANON_AFPOINTSINFOCUS1D, "Canon:AFPointsInFocus1D", TIFF_NOTYPE,  0, canon_blah_handler },
+    { CANON_LENSMODEL, "Canon:LensModel", TIFF_ASCII, 1 },
+    // { CANON_SERIALINFO, "Canon:SerialInfo", TIFF_NOTYPE, 0, canon_blah_handler },
+    // { CANON_DUSTREMOVALDATA, "Canon:DustRemovalData", TIFF_NOTYPE, 0, canon_blah_handler }, // unknown format
+    { CANON_CROPINFO, "Canon:CropInfo", TIFF_SHORT, 4 },
+    // { CANON_CUSTOMFUNCTIONS2, "Canon:CustomFunctions2", TIFF_NOTYPE,  0, canon_blah_handler },
+    // { CANON_ASPECTINFO, "Canon:AspectInfo", TIFF_NOTYPE,  0, canon_blah_handler },
+    // { CANON_PROCESSINGINFO, "Canon:ProcessingInfo", TIFF_NOTYPE,  0, canon_blah_handler },
+    // CANON_TONECURVETABLE, ToneCurveTable
+    // CANON_SHARPNESSTABLE, SharpnessTable
+    // CANON_SHARPNESSFREQTABLE, SharpnessFreqTable
+    // CANON_WHITEBALANCETABLE, WhiteBalanceTable
+    // { CANON_COLORBALANCE, "Canon:ColorBalance", TIFF_NOTYPE,  0, canon_blah_handler },
+    // { CANON_MEASUREDCOLOR, "Canon:MeasuredColor", TIFF_NOTYPE,  0, canon_blah_handler },
+    { CANON_COLORTEMPERATURE, "Canon:ColorTemperature", TIFF_SHORT, 1 },
+    // { CANON_CANONFLAGS, "Canon:CanonFlags", TIFF_NOTYPE,  0, canon_blah_handler },
+    // { CANON_MODIFIEDINFO, "Canon:ModifiedInfo", TIFF_NOTYPE,  0, canon_blah_handler },
+    // CANON_TONECURVEMATCHING, ToneCurveMatching
+    // CANON_WHITEBALANCEMATCHING, WhiteBalanceMatching
+    // CANON_COLORSPACE, ColorSpace, TIFF_SHORT, // 1=sRGB, 2=Adobe RGB
+    // CANON_PREVIEWIMAGEINFO, PreviewImageInfo
+    // CANON_VRDOFFSET, VRDOffset
+    { CANON_SENSORINFO, "Canon:SensorInfo", TIFF_SHORT, 17, canon_sensorinfo_handler },
+    // CANON_COLORDATA ColorData    varies by model
+    // CANON_CRWPARAM CRWParam
+    // CANON_FLAVOR Flavor
+    // CANON_PICTURESTYLEUSERDEF, PictureStyleUserDef
+    // CANON_PICTURESTYLEPC, PictureStylePC
+    { CANON_CUSTOMPICTURESTYLEFILENAME, "Canon:CustomPictureStyleFileName", TIFF_ASCII, 1 },
+    // CANON_AFMICROADJ, AFMicroAdj
+    // CANON_VIGNETTINGCORR, VignettingCorr     varies by model
+    // CANON_VIGNETTINGCORR2, VignettingCorr2
+    // CANON_LIGHTINGOPT, LightingOpt
+    // CANON_LENSINFO, LensInfo
+    // CANON_AMBIENCEINFO, AmbienceInfo
+    // CANON_MULTIEXP, MultiExp
+    // CANON_FILTERINFO, FilterInfo
+    // CANON_HDRINFO, HDRInfo
+    // CANON_AFCONFIG, AFConfig
+};
+
+
+
+const TagMap& canon_maker_tagmap_ref () {
+    static TagMap T ("Canon", canon_maker_tag_table);
+    return T;
+}
+
+
+
+// Put a whole bunch of sub-indexed data into the spec into the given TIFF
+// tag.
+template<typename T>
+static void
+encode_indexed_tag (int tifftag, TIFFDataType tifftype, // TIFF tag and type
+                    array_view<const LabelIndex> indices, // LabelIndex table
+                    std::vector<char>& data,   // data blob to add to
+                    std::vector<TIFFDirEntry> &dirs,  // TIFF dirs to add to
+                    const ImageSpec& spec,          // spec to get attribs from
+                    size_t offset_correction) // offset correction
+{
+    // array length is determined by highest index value
+    std::vector<T> array (indices.back().value + 1, T(0));
+    bool anyfound = false;
+    for (auto&& attr : indices) {
+        if (attr.value < int(array.size())) {
+            const ParamValue *param = spec.find_attribute (attr.label);
+            if (param) {
+                array[attr.value] = T (param->get_int());
+                anyfound = true;
+            }
+        }
+    }
+    if (anyfound)
+        append_tiff_dir_entry (dirs, data, tifftag, tifftype,
+                               array.size(), array.data(), offset_correction);
+}
+
+
+
+
+void
+encode_canon_makernote (std::vector<char>& data,
+                        std::vector<TIFFDirEntry> &makerdirs,
+                        const ImageSpec& spec, size_t offset_correction)
+{
+    // Easy ones that get coded straight from the attribs
+    for (const TagInfo& t : canon_maker_tag_table) {
+        if (t.handler)   // skip  ones with handlers
+            continue;
+        if (const ParamValue* param = spec.find_attribute (t.name)) {
+            size_t count = t.tiffcount;
+            const void* d = param->data();
+            if (t.tifftype == TIFF_ASCII) {
+                // special case: strings need their real length, plus
+                // trailing null, and the data must be the characters.
+                d = param->get_ustring().c_str();
+                count = param->get_ustring().size() + 1;
+            }
+            append_tiff_dir_entry (makerdirs, data, t.tifftag, t.tifftype,
+                                   count, d, offset_correction);
+        }
+    }
+
+    // Hard ones that need to fill in complicated structures
+    encode_indexed_tag<int16_t> (CANON_CAMERASETTINGS, TIFF_SSHORT,
+                                 canon_camerasettings_indices,
+                                 data, makerdirs, spec, offset_correction);
+    encode_indexed_tag<uint16_t> (CANON_FOCALLENGTH, TIFF_SHORT,
+                                 canon_focallength_indices,
+                                 data, makerdirs, spec, offset_correction);
+    encode_indexed_tag<int16_t> (CANON_SHOTINFO, TIFF_SSHORT,
+                                 canon_shotinfo_indices,
+                                 data, makerdirs, spec, offset_correction);
+    encode_indexed_tag<int16_t> (CANON_SHOTINFO, TIFF_SSHORT,
+                                 canon_shotinfo_indices,
+                                 data, makerdirs, spec, offset_correction);
+    encode_indexed_tag<int16_t> (CANON_PANORAMA, TIFF_SSHORT,
+                                 canon_panorama_indices,
+                                 data, makerdirs, spec, offset_correction);
+}
+
+
+}  // end namespace pvt
+OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -32,87 +32,413 @@
 #include <cctype>
 #include <cstdio>
 #include <iostream>
+#include <sstream>
 #include <vector>
 #include <set>
 #include <algorithm>
 
 #include <boost/container/flat_map.hpp>
 
+#include <OpenImageIO/imageio.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/strutil.h>
+#include <OpenImageIO/tiffutils.h>
 
-extern "C" {
-#include "tiff.h"
-}
-
-// Some EXIF tags that don't seem to be in tiff.h
-#ifndef EXIFTAG_SECURITYCLASSIFICATION
-#define EXIFTAG_SECURITYCLASSIFICATION 37394
-#endif
-#ifndef EXIFTAG_IMAGEHISTORY
-#define EXIFTAG_IMAGEHISTORY 37395
-#endif
-
-#ifdef TIFF_VERSION_BIG
-// In old versions of TIFF, this was defined in tiff.h.  It's gone from
-// "BIG TIFF" (libtiff 4.x), so we just define it here.
-
-struct TIFFHeader {
-    uint16_t tiff_magic;  /* magic number (defines byte order) */
-    uint16_t tiff_version;/* TIFF version number */
-    uint32_t tiff_diroff; /* byte offset to first directory */
-};
-
-struct TIFFDirEntry {
-    uint16_t tdir_tag;    /* tag ID */
-    uint16_t tdir_type;   /* data type -- see TIFFDataType enum */
-    uint32_t tdir_count;  /* number of items; length in spec */
-    uint32_t tdir_offset; /* byte offset to field data */
-};
-#endif
-
-#include <OpenImageIO/imageio.h>
-
-
-#define DEBUG_EXIF_READ  0
-#define DEBUG_EXIF_WRITE 0
+#include "exif.h"
 
 OIIO_NAMESPACE_BEGIN
 
-namespace {
+using namespace pvt;
 
 
-// Sizes of TIFFDataType members
-static size_t tiff_data_sizes[] = {
-    0, 1, 1, 2, 4, 8, 1, 1, 2, 4, 8, 4, 8, 4
+class TagMap::Impl {
+public:
+    typedef boost::container::flat_map<int, const TagInfo *> tagmap_t;
+    typedef boost::container::flat_map<std::string, const TagInfo *> namemap_t;
+    // Name map is lower case so it's effectively case-insensitive
+
+    Impl (string_view mapname, array_view<const TagInfo> tag_table)
+            : m_mapname(mapname)
+    {
+        for (const auto& tag : tag_table) {
+            m_tagmap[tag.tifftag] = &tag;
+            if (tag.name) {
+                std::string lowername (tag.name);
+                Strutil::to_lower (lowername);
+                m_namemap[lowername] = &tag;
+            }
+        }
+    }
+
+    tagmap_t m_tagmap;
+    namemap_t m_namemap;
+    std::string m_mapname;
 };
 
-static int
-tiff_data_size (const TIFFDirEntry &dir)
+
+
+TagMap::TagMap (string_view mapname, array_view<const TagInfo> tag_table)
+        : m_impl(new Impl (mapname, tag_table))
 {
-    const int num_data_sizes = sizeof(tiff_data_sizes) / sizeof(*tiff_data_sizes);
-    int dir_index = (int)dir.tdir_type;
+}
+
+
+
+TagMap::~TagMap ()
+{
+}
+
+
+const TagInfo * TagMap::find (int tag) const
+{
+    auto i = m_impl->m_tagmap.find (tag);
+    return i == m_impl->m_tagmap.end() ? NULL : i->second;
+}
+
+
+const TagInfo * TagMap::find (string_view name) const
+{
+    std::string lowername (name);
+    Strutil::to_lower (lowername);
+    auto i = m_impl->m_namemap.find (lowername);
+    return i == m_impl->m_namemap.end() ? NULL : i->second;
+}
+
+
+const char * TagMap::name (int tag) const
+{
+    auto i = m_impl->m_tagmap.find (tag);
+    return i == m_impl->m_tagmap.end() ? NULL : i->second->name;
+}
+
+
+TIFFDataType TagMap::tifftype (int tag) const
+{
+    auto i = m_impl->m_tagmap.find (tag);
+    return i == m_impl->m_tagmap.end() ? TIFF_NOTYPE : i->second->tifftype;
+}
+
+
+int TagMap::tiffcount (int tag) const
+{
+    auto i = m_impl->m_tagmap.find (tag);
+    return i == m_impl->m_tagmap.end() ? 0 : i->second->tiffcount;
+}
+
+
+int TagMap::tag (string_view name) const
+{
+    std::string lowername (name);
+    Strutil::to_lower (lowername);
+    auto i = m_impl->m_namemap.find (lowername);
+    return i == m_impl->m_namemap.end() ? -1 : i->second->tifftag;
+}
+
+
+string_view TagMap::mapname() const
+{
+    return m_impl->m_mapname;
+}
+
+
+
+const TagInfo *
+tag_lookup (string_view domain, int tag)
+{
+    const TagMap *tm = nullptr;
+    if (domain == "Exif")
+        tm = &exif_tagmap_ref();
+    else if (domain == "GPS")
+        tm = &gps_tagmap_ref();
+    else
+        tm = &tiff_tagmap_ref();
+    return tm ? tm->find(tag) : nullptr;
+}
+
+
+
+const TagInfo *
+tag_lookup (string_view domain, string_view tag)
+{
+    const TagMap *tm = nullptr;
+    if (domain == "Exif")
+        tm = &exif_tagmap_ref();
+    else if (domain == "GPS")
+        tm = &gps_tagmap_ref();
+    else
+        tm = &tiff_tagmap_ref();
+    return tm ? tm->find(tag) : nullptr;
+}
+
+
+
+size_t
+tiff_data_size (TIFFDataType tifftype)
+{
+    // Sizes of TIFFDataType members
+    static size_t sizes[] = { 0, 1, 1, 2, 4, 8, 1, 1, 2, 4, 8, 4, 8, 4 };
+    const int num_data_sizes = sizeof(sizes) / sizeof(*sizes);
+    int dir_index = (int)tifftype;
     if (dir_index < 0 || dir_index >= num_data_sizes) {
         // Inform caller about corrupted entry.
         return -1;
     }
-    return tiff_data_sizes[dir_index] * dir.tdir_count;
+    return sizes[dir_index];
 }
 
 
 
-struct EXIF_tag_info {
-    int tifftag;            // TIFF tag used for this info
-    const char *name;       // Attribute name we use
-    TIFFDataType tifftype;  // Data type that TIFF wants
-    int tiffcount;          // Number of items
+size_t
+tiff_data_size (const TIFFDirEntry &dir)
+{
+    return tiff_data_size(TIFFDataType(dir.tdir_type)) * dir.tdir_count;
+}
+
+
+
+TypeDesc
+tiff_datatype_to_typedesc (TIFFDataType tifftype, size_t tiffcount)
+{
+    if (tiffcount == 1)
+        tiffcount = 0;    // length 1 == not an array
+    switch (tifftype) {
+    case TIFF_NOTYPE :
+        return TypeUnknown;
+    case TIFF_BYTE :
+        return TypeDesc(TypeDesc::UINT8, tiffcount);
+    case TIFF_ASCII :
+        return TypeString;
+    case TIFF_SHORT :
+        return TypeDesc(TypeDesc::UINT16, tiffcount);
+    case TIFF_LONG :
+        return TypeDesc(TypeDesc::UINT32, tiffcount);
+    case TIFF_RATIONAL :
+        return TypeDesc(TypeDesc::INT32, TypeDesc::VEC2, TypeDesc::RATIONAL, tiffcount);
+    case TIFF_SBYTE :
+        return TypeDesc(TypeDesc::INT8, tiffcount);
+    case TIFF_UNDEFINED :
+        return TypeDesc(TypeDesc::UINT8, tiffcount); // 8-bit untyped data
+    case TIFF_SSHORT :
+        return TypeDesc(TypeDesc::INT16, tiffcount);
+    case TIFF_SLONG :
+        return TypeDesc(TypeDesc::INT32, tiffcount);
+    case TIFF_SRATIONAL :
+        return TypeDesc(TypeDesc::INT32, TypeDesc::VEC2, TypeDesc::RATIONAL, tiffcount);
+    case TIFF_FLOAT :
+        return TypeDesc(TypeDesc::FLOAT, tiffcount);
+    case TIFF_DOUBLE :
+        return TypeDesc(TypeDesc::DOUBLE, tiffcount);
+    case TIFF_IFD :
+        return TypeUnknown;
+    case TIFF_LONG8 :
+        return TypeDesc(TypeDesc::UINT64, tiffcount);
+    case TIFF_SLONG8 :
+        return TypeDesc(TypeDesc::INT64, tiffcount);
+    case TIFF_IFD8 :
+        return TypeUnknown;
+    }
+    return TypeUnknown;
+}
+
+
+
+array_view<const uint8_t>
+tiff_dir_data (const TIFFDirEntry &td, array_view<const uint8_t> data)
+{
+    size_t len = tiff_data_size (td);
+    if (len <= 4) {
+        // Short data are stored in the offset field itself
+        return array_view<const uint8_t> ((const uint8_t *)&td.tdir_offset, len);
+    }
+    // Long data
+    size_t begin = td.tdir_offset;
+    if (begin+len > data.size()) {
+        // Invalid span -- it is not entirely contained in the data window.
+        // Signal error by returning an empty array_view.
+        return array_view<const uint8_t>();
+    }
+    return array_view<const uint8_t> (data.data()+begin, len);
+}
+
+
+
+#if DEBUG_EXIF_READ || DEBUG_EXIF_WRITE
+static bool
+print_dir_entry (std::ostream &out, const TagMap &tagmap, const TIFFDirEntry &dir,
+                 array_view<const uint8_t> buf, int offset_adjustment)
+{
+    int len = tiff_data_size (dir);
+    if (len < 0) {
+        out << "Ignoring bad directory entry\n";
+        return false;
+    }
+    const char *mydata = (const char *) dataptr (dir, buf, offset_adjustment);
+    if (! mydata)
+        return false;    // bogus! overruns the buffer
+    mydata += offset_adjustment;
+    const char *name = tagmap.name(dir.tdir_tag);
+    Strutil::fprintf (out, "  Tag %d/0x%s (%s) type=%d (%s) count=%d offset=%d = ",
+                  dir.tdir_tag, dir.tdir_tag, (name ? name : "unknown"),
+                  dir.tdir_type, tiff_datatype_to_typedesc(dir),
+                  dir.tdir_count, dir.tdir_offset);
+
+    switch (dir.tdir_type) {
+    case TIFF_ASCII :
+        out << "'" << string_view(mydata,dir.tdir_count) << "'";
+        break;
+    case TIFF_RATIONAL :
+        {
+            const unsigned int *u = (unsigned int *)mydata;
+            for (size_t i = 0; i < dir.tdir_count;  ++i)
+                out << u[2*i] << "/" << u[2*i+1] << " = "
+                          << (double)u[2*i]/(double)u[2*i+1] << " ";
+        }
+        break;
+    case TIFF_SRATIONAL :
+        {
+            const int *u = (int *)mydata;
+            for (size_t i = 0; i < dir.tdir_count;  ++i)
+                out << u[2*i] << "/" << u[2*i+1] << " = "
+                          << (double)u[2*i]/(double)u[2*i+1] << " ";
+        }
+        break;
+    case TIFF_SHORT :
+        out << ((unsigned short *)mydata)[0];
+        break;
+    case TIFF_LONG :
+        out << ((unsigned int *)mydata)[0];
+        break;
+    case TIFF_BYTE :
+    case TIFF_UNDEFINED :
+    case TIFF_NOTYPE :
+    default:
+        if (len <= 4 && dir.tdir_count > 4) {
+            // Request more data than is stored.
+            out << "Ignoring buffer with too much count of short data.\n";
+            return false;
+        }
+        for (size_t i = 0;  i < dir.tdir_count;  ++i)
+            out << (int)((unsigned char *)mydata)[i] << ' ';
+        break;
+    }
+    out << "\n";
+    return true;
+}
+
+
+
+// debugging
+static std::string
+dumpdata (array_view<const uint8_t> blob,
+          array_view<const size_t> ifdoffsets, size_t start, int offset_adjustment)
+{
+    std::stringstream out;
+    for (size_t pos = 0; pos < blob.size(); ++pos) {
+        bool at_ifd = (std::find (ifdoffsets.cbegin(), ifdoffsets.cend(), pos) != ifdoffsets.end());
+        if (pos == 0 || pos == start || at_ifd || (pos % 10) == 0) {
+            out << "\n@" << pos << ": ";
+            if (at_ifd) {
+                uint16_t n = *(uint16_t *)&blob[pos];
+                out << "\nNew IFD: " << n << " tags:  [offset_adjustment=" << offset_adjustment << "\n";
+                TIFFDirEntry *td = (TIFFDirEntry *) &blob[pos+2];
+                for (int i = 0; i < n; ++i, ++td)
+                print_dir_entry (out, tiff_tagmap_ref(), *td, blob, offset_adjustment);
+            }
+        }
+        unsigned char c = (unsigned char) blob[pos];
+        if (c >= ' ' && c < 127)
+            out << c << ' ';
+        out << "(" << (int)c << ") ";
+    }
+    out << "\n";
+    return out.str();
+}
+#endif
+
+
+
+static void
+version4char_handler (const TagInfo& taginfo, const TIFFDirEntry& dir,
+                      array_view<const uint8_t> buf, ImageSpec& spec,
+                      bool swapendian=false, int offset_adjustment=0)
+{
+    const char* data = (const char*) dataptr (dir, buf, offset_adjustment);
+    if (tiff_data_size(dir) == 4 && data != nullptr)   // sanity check
+        spec.attribute (taginfo.name, std::string(data, data+4));
+}
+
+
+static void
+version4uint8_handler (const TagInfo& taginfo, const TIFFDirEntry& dir,
+                       array_view<const uint8_t> buf, ImageSpec& spec,
+                       bool swapendian=false, int offset_adjustment=0)
+{
+    const char* data = (const char*) dataptr (dir, buf, offset_adjustment);
+    if (tiff_data_size(dir) == 4 && data != nullptr)  // sanity check
+        spec.attribute (taginfo.name, TypeDesc(TypeDesc::UINT8,4),
+                        (const char*)data);
+}
+
+
+static void
+makernote_handler (const TagInfo& taginfo, const TIFFDirEntry& dir,
+                   array_view<const uint8_t> buf, ImageSpec& spec,
+                   bool swapendian=false, int offset_adjustment=0)
+{
+    if (tiff_data_size(dir) <= 4) return;  // sanity check
+
+    if (spec.get_string_attribute("Make") == "Canon") {
+        std::vector<size_t> ifdoffsets {0};
+        std::set<size_t> offsets_seen;
+        decode_ifd ((unsigned char *)buf.data() + dir.tdir_offset, buf,
+                    spec, pvt::canon_maker_tagmap_ref(), offsets_seen,
+                    swapendian, offset_adjustment);
+    } else {
+        // Maybe we just haven't parsed the Maker metadata yet?
+        // Allow a second try later by just stashing the maker note offset.
+        spec.attribute ("oiio:MakerNoteOffset", int(dir.tdir_offset));
+    }
+}
+
+
+
+static const TagInfo tiff_tag_table[] = {
+    { TIFFTAG_IMAGEDESCRIPTION, "ImageDescription", TIFF_ASCII, 0 },
+    { TIFFTAG_ORIENTATION,      "Orientation",      TIFF_SHORT, 1 },
+    { TIFFTAG_XRESOLUTION,      "XResolution",      TIFF_RATIONAL, 1 },
+    { TIFFTAG_YRESOLUTION,      "YResolution",      TIFF_RATIONAL, 1 },
+    { TIFFTAG_RESOLUTIONUNIT,   "ResolutionUnit",   TIFF_SHORT, 1 },
+    { TIFFTAG_MAKE,             "Make",             TIFF_ASCII, 0 },
+    { TIFFTAG_MODEL,            "Model",            TIFF_ASCII, 0 },
+    { TIFFTAG_SOFTWARE,         "Software",         TIFF_ASCII, 0 },
+    { TIFFTAG_ARTIST,           "Artist",           TIFF_ASCII, 0 },
+    { TIFFTAG_COPYRIGHT,        "Copyright",        TIFF_ASCII, 0 },
+    { TIFFTAG_DATETIME,         "DateTime",         TIFF_ASCII, 0 },
+    { TIFFTAG_DOCUMENTNAME,     "DocumentName",     TIFF_ASCII, 0 },
+    { TIFFTAG_PAGENAME,         "tiff:PageName",    TIFF_ASCII, 0 },
+    { TIFFTAG_PAGENUMBER,       "tiff:PageNumber",  TIFF_SHORT, 1 },
+    { TIFFTAG_HOSTCOMPUTER,     "HostComputer",     TIFF_ASCII, 0 },
+    { TIFFTAG_PIXAR_TEXTUREFORMAT, "textureformat", TIFF_ASCII, 0 },
+    { TIFFTAG_PIXAR_WRAPMODES,  "wrapmodes",        TIFF_ASCII, 0 },
+    { TIFFTAG_PIXAR_FOVCOT,     "fovcot",           TIFF_FLOAT, 1 },
+    { TIFFTAG_JPEGQUALITY,      "CompressionQuality", TIFF_LONG, 1 },
+    { TIFFTAG_ZIPQUALITY,       "tiff:zipquality",  TIFF_LONG, 1 },
+    { TIFFTAG_XMLPACKET,        "tiff:XMLPacket",   TIFF_ASCII, 0 },
 };
 
-static const EXIF_tag_info exif_tag_table[] = {
+const TagMap& pvt::tiff_tagmap_ref () {
+    static TagMap T ("TIFF", tiff_tag_table);
+    return T;
+}
+
+
+
+static const TagInfo exif_tag_table[] = {
     // Skip ones handled by the usual JPEG code
+    // N.B. We use TIFF_NOTYPE to indicate an item that should be skipped.
     { TIFFTAG_IMAGEWIDTH,	"Exif:ImageWidth",	TIFF_NOTYPE, 1 },
     { TIFFTAG_IMAGELENGTH,	"Exif:ImageLength",	TIFF_NOTYPE, 1 },
-    { TIFFTAG_BITSPERSAMPLE,	"Exif:BitsPerSample",	TIFF_NOTYPE, 1 },
+    { TIFFTAG_BITSPERSAMPLE,	"Exif:BitsPerSample",	TIFF_NOTYPE, 0 },
     { TIFFTAG_COMPRESSION,	"Exif:Compression",	TIFF_NOTYPE, 1 },
     { TIFFTAG_PHOTOMETRIC,	"Exif:Photometric",	TIFF_NOTYPE, 1 },
     { TIFFTAG_SAMPLESPERPIXEL,	"Exif:SamplesPerPixel",	TIFF_NOTYPE, 1 },
@@ -136,80 +462,93 @@ static const EXIF_tag_info exif_tag_table[] = {
     { TIFFTAG_GPSIFD,           "Exif:GPSIFD",  TIFF_NOTYPE, 1 },
 
     // EXIF tags we may come across
-    { EXIFTAG_EXPOSURETIME,	"ExposureTime",	TIFF_RATIONAL, 1 },
-    { EXIFTAG_FNUMBER,	        "FNumber",	TIFF_RATIONAL, 1 },
-    { EXIFTAG_EXPOSUREPROGRAM,	"Exif:ExposureProgram",	TIFF_SHORT, 1 }, // ?? translate to ascii names?
-    { EXIFTAG_SPECTRALSENSITIVITY,"Exif:SpectralSensitivity",	TIFF_ASCII, 0 },
-    { EXIFTAG_ISOSPEEDRATINGS,	"Exif:ISOSpeedRatings",	TIFF_SHORT, 1 },
-    { EXIFTAG_OECF,	        "Exif:OECF",	TIFF_NOTYPE, 1 },	 // skip it
-    { EXIFTAG_EXIFVERSION,	"Exif:ExifVersion",	TIFF_NOTYPE, 1 },	 // skip it
-    { EXIFTAG_DATETIMEORIGINAL,	"Exif:DateTimeOriginal",	TIFF_ASCII, 0 },
-    { EXIFTAG_DATETIMEDIGITIZED,"Exif:DateTimeDigitized",	TIFF_ASCII, 0 },
-    { EXIFTAG_COMPONENTSCONFIGURATION, "Exif:ComponentsConfiguration",	TIFF_UNDEFINED, 1 },
-    { EXIFTAG_COMPRESSEDBITSPERPIXEL,  "Exif:CompressedBitsPerPixel",	TIFF_RATIONAL, 1 },
-    { EXIFTAG_SHUTTERSPEEDVALUE,"Exif:ShutterSpeedValue",	TIFF_SRATIONAL, 1 }, // APEX units
-    { EXIFTAG_APERTUREVALUE,	"Exif:ApertureValue",	TIFF_RATIONAL, 1 },	// APEX units
-    { EXIFTAG_BRIGHTNESSVALUE,	"Exif:BrightnessValue",	TIFF_SRATIONAL, 1 },
-    { EXIFTAG_EXPOSUREBIASVALUE,"Exif:ExposureBiasValue",	TIFF_SRATIONAL, 1 },
-    { EXIFTAG_MAXAPERTUREVALUE,	"Exif:MaxApertureValue",TIFF_RATIONAL, 1 },
-    { EXIFTAG_SUBJECTDISTANCE,	"Exif:SubjectDistance",	TIFF_RATIONAL, 1 },
-    { EXIFTAG_METERINGMODE,	"Exif:MeteringMode",	TIFF_SHORT, 1 },
-    { EXIFTAG_LIGHTSOURCE,	"Exif:LightSource",	TIFF_SHORT, 1 },
-    { EXIFTAG_FLASH,	        "Exif:Flash",	        TIFF_SHORT, 1 },
-    { EXIFTAG_FOCALLENGTH,	"Exif:FocalLength",	TIFF_RATIONAL, 1 }, // mm
-    { EXIFTAG_SECURITYCLASSIFICATION, "Exif:SecurityClassification", TIFF_ASCII, 1 },
-    { EXIFTAG_IMAGEHISTORY,     "Exif:ImageHistory",    TIFF_ASCII, 1 },
-    { EXIFTAG_SUBJECTAREA,	"Exif:SubjectArea",	TIFF_NOTYPE, 1 }, // skip
-    { EXIFTAG_MAKERNOTE,	"Exif:MakerNote",	TIFF_NOTYPE, 1 },	 // skip it
-    { EXIFTAG_USERCOMMENT,	"Exif:UserComment",	TIFF_NOTYPE, 1 },	// skip it
-    { EXIFTAG_SUBSECTIME,	"Exif:SubsecTime",	        TIFF_ASCII, 0 },
-    { EXIFTAG_SUBSECTIMEORIGINAL,"Exif:SubsecTimeOriginal",	TIFF_ASCII, 0 },
-    { EXIFTAG_SUBSECTIMEDIGITIZED,"Exif:SubsecTimeDigitized",	TIFF_ASCII, 0 },
-    { EXIFTAG_FLASHPIXVERSION,	"Exif:FlashPixVersion",	TIFF_NOTYPE, 1 },	// skip "Exif:FlashPixVesion",	TIFF_NOTYPE, 1 },
-    { EXIFTAG_COLORSPACE,	"Exif:ColorSpace",	TIFF_SHORT, 1 },
-    { EXIFTAG_PIXELXDIMENSION,	"Exif:PixelXDimension",	TIFF_LONG, 1 },
-    { EXIFTAG_PIXELYDIMENSION,	"Exif:PixelYDimension",	TIFF_LONG, 1 },
-    { EXIFTAG_RELATEDSOUNDFILE,	"Exif:RelatedSoundFile", TIFF_ASCII, 0 },
-    { EXIFTAG_FLASHENERGY,	"Exif:FlashEnergy",	TIFF_RATIONAL, 1 },
-    { EXIFTAG_SPATIALFREQUENCYRESPONSE,	"Exif:SpatialFrequencyResponse",	TIFF_NOTYPE, 1 },
-    { EXIFTAG_FOCALPLANEXRESOLUTION,	"Exif:FocalPlaneXResolution",	TIFF_RATIONAL, 1 },
-    { EXIFTAG_FOCALPLANEYRESOLUTION,	"Exif:FocalPlaneYResolution",	TIFF_RATIONAL, 1 },
-    { EXIFTAG_FOCALPLANERESOLUTIONUNIT,	"Exif:FocalPlaneResolutionUnit",	TIFF_SHORT, 1 }, // Symbolic?
-    { EXIFTAG_SUBJECTLOCATION,	"Exif:SubjectLocation",	TIFF_SHORT, 1 }, // FIXME: short[2]
-    { EXIFTAG_EXPOSUREINDEX,	"Exif:ExposureIndex",	TIFF_RATIONAL, 1 },
-    { EXIFTAG_SENSINGMETHOD,	"Exif:SensingMethod",	TIFF_SHORT, 1 },
-    { EXIFTAG_FILESOURCE,	"Exif:FileSource",	TIFF_SHORT, 1 },
-    { EXIFTAG_SCENETYPE,	"Exif:SceneType",	TIFF_SHORT, 1 },
-    { EXIFTAG_CFAPATTERN,	"Exif:CFAPattern",	TIFF_NOTYPE, 1 },
-    { EXIFTAG_CUSTOMRENDERED,	"Exif:CustomRendered",	TIFF_SHORT, 1 },
-    { EXIFTAG_EXPOSUREMODE,	"Exif:ExposureMode",	TIFF_SHORT, 1 },
-    { EXIFTAG_WHITEBALANCE,	"Exif:WhiteBalance",	TIFF_SHORT, 1 },
-    { EXIFTAG_DIGITALZOOMRATIO,	"Exif:DigitalZoomRatio",TIFF_RATIONAL, 1 },
-    { EXIFTAG_FOCALLENGTHIN35MMFILM, "Exif:FocalLengthIn35mmFilm",	TIFF_SHORT, 1 },
-    { EXIFTAG_SCENECAPTURETYPE,	"Exif:SceneCaptureType",TIFF_SHORT, 1 },
-    { EXIFTAG_GAINCONTROL,	"Exif:GainControl",	TIFF_RATIONAL, 1 },
-    { EXIFTAG_CONTRAST,	        "Exif:Contrast",	TIFF_SHORT, 1 },
-    { EXIFTAG_SATURATION,	"Exif:Saturation",	TIFF_SHORT, 1 },
-    { EXIFTAG_SHARPNESS,	"Exif:Sharpness",	TIFF_SHORT, 1 },
-    { EXIFTAG_DEVICESETTINGDESCRIPTION,	"Exif:DeviceSettingDescription",	TIFF_NOTYPE, 1 },
-    { EXIFTAG_SUBJECTDISTANCERANGE,	"Exif:SubjectDistanceRange",	TIFF_SHORT, 1 },
-    { EXIFTAG_IMAGEUNIQUEID,	"Exif:ImageUniqueID",   TIFF_ASCII, 0 },
-    { 34855,                    "Exif:PhotographicSensitivity",  TIFF_SHORT, 1 },
-    { 34864,                    "Exif:SensitivityType",  TIFF_SHORT, 1 },
-    { 34865,                    "Exif:StandardOutputSensitivity", TIFF_LONG, 1 },
-    { 34866,                    "Exif:RecommendedExposureIndex", TIFF_LONG, 1 },
-    { 34867,                    "Exif:ISOSpeed", TIFF_LONG, 1 },
-    { 34868,                    "Exif:ISOSpeedLatitudeyyy", TIFF_LONG, 1 },
-    { 34869,                    "Exif:ISOSpeedLatitudezzz", TIFF_LONG, 1 },
-    { 42032,                    "Exif:CameraOwnerName",  TIFF_ASCII, 0 },
-    { 42033,                    "Exif:BodySerialNumber", TIFF_ASCII, 0 },
-    { 42034,                    "Exif:LensSpecification",TIFF_RATIONAL, 4 },
-    { 42035,                    "Exif:LensMake",         TIFF_ASCII, 0 },
-    { 42036,                    "Exif:LensModel",        TIFF_ASCII, 0 },
-    { 42037,                    "Exif:LensSerialNumber", TIFF_ASCII, 0 },
-    { 42240,                    "Exif:Gamma", TIFF_RATIONAL, 0 },
-    { -1, NULL }  // signal end of table
+    { EXIF_EXPOSURETIME,	"ExposureTime",	TIFF_RATIONAL, 1 },
+    { EXIF_FNUMBER,	        "FNumber",	TIFF_RATIONAL, 1 },
+    { EXIF_EXPOSUREPROGRAM,	"Exif:ExposureProgram",	TIFF_SHORT, 1 }, // ?? translate to ascii names?
+    { EXIF_SPECTRALSENSITIVITY,"Exif:SpectralSensitivity",	TIFF_ASCII, 0 },
+    { EXIF_ISOSPEEDRATINGS,	"Exif:ISOSpeedRatings",	TIFF_SHORT, 1 },
+    { EXIF_OECF,	        "Exif:OECF",	TIFF_NOTYPE, 1 },	 // skip it
+    { EXIF_EXIFVERSION,	"Exif:ExifVersion",	TIFF_UNDEFINED, 1, version4char_handler },	 // skip it
+    { EXIF_DATETIMEORIGINAL,	"Exif:DateTimeOriginal",	TIFF_ASCII, 0 },
+    { EXIF_DATETIMEDIGITIZED,"Exif:DateTimeDigitized",   TIFF_ASCII, 0 },
+    { EXIF_OFFSETTIME,"Exif:OffsetTime",   TIFF_ASCII, 0 },
+    { EXIF_OFFSETTIMEORIGINAL,"Exif:OffsetTimeOriginal",   TIFF_ASCII, 0 },
+    { EXIF_OFFSETTIMEDIGITIZED,"Exif:OffsetTimeDigitized",	TIFF_ASCII, 0 },
+    { EXIF_COMPONENTSCONFIGURATION, "Exif:ComponentsConfiguration",	TIFF_UNDEFINED, 1 },
+    { EXIF_COMPRESSEDBITSPERPIXEL,  "Exif:CompressedBitsPerPixel",	TIFF_RATIONAL, 1 },
+    { EXIF_SHUTTERSPEEDVALUE,"Exif:ShutterSpeedValue",	TIFF_SRATIONAL, 1 }, // APEX units
+    { EXIF_APERTUREVALUE,	"Exif:ApertureValue",	TIFF_RATIONAL, 1 },	// APEX units
+    { EXIF_BRIGHTNESSVALUE,	"Exif:BrightnessValue",	TIFF_SRATIONAL, 1 },
+    { EXIF_EXPOSUREBIASVALUE,"Exif:ExposureBiasValue",	TIFF_SRATIONAL, 1 },
+    { EXIF_MAXAPERTUREVALUE,	"Exif:MaxApertureValue",TIFF_RATIONAL, 1 },
+    { EXIF_SUBJECTDISTANCE,	"Exif:SubjectDistance",	TIFF_RATIONAL, 1 },
+    { EXIF_METERINGMODE,	"Exif:MeteringMode",	TIFF_SHORT, 1 },
+    { EXIF_LIGHTSOURCE,	"Exif:LightSource",	TIFF_SHORT, 1 },
+    { EXIF_FLASH,	        "Exif:Flash",	        TIFF_SHORT, 1 },
+    { EXIF_FOCALLENGTH,	"Exif:FocalLength",	TIFF_RATIONAL, 1 }, // mm
+    { EXIF_SECURITYCLASSIFICATION, "Exif:SecurityClassification", TIFF_ASCII, 1 },
+    { EXIF_IMAGEHISTORY,     "Exif:ImageHistory",    TIFF_ASCII, 1 },
+    { EXIF_SUBJECTAREA,	"Exif:SubjectArea",	TIFF_NOTYPE, 1 }, // FIXME
+    { EXIF_MAKERNOTE,	"Exif:MakerNote",	TIFF_BYTE, 0, makernote_handler },
+    { EXIF_USERCOMMENT,	"Exif:UserComment",	TIFF_BYTE, 0 },
+    { EXIF_SUBSECTIME,	"Exif:SubsecTime",	        TIFF_ASCII, 0 },
+    { EXIF_SUBSECTIMEORIGINAL,"Exif:SubsecTimeOriginal",	TIFF_ASCII, 0 },
+    { EXIF_SUBSECTIMEDIGITIZED,"Exif:SubsecTimeDigitized",	TIFF_ASCII, 0 },
+    { EXIF_FLASHPIXVERSION,	"Exif:FlashPixVersion",	TIFF_UNDEFINED, 1, version4char_handler },	// skip "Exif:FlashPixVesion",	TIFF_NOTYPE, 1 },
+    { EXIF_COLORSPACE,	"Exif:ColorSpace",	TIFF_SHORT, 1 },
+    { EXIF_PIXELXDIMENSION,	"Exif:PixelXDimension",	TIFF_LONG, 1 },
+    { EXIF_PIXELYDIMENSION,	"Exif:PixelYDimension",	TIFF_LONG, 1 },
+    { EXIF_RELATEDSOUNDFILE,	"Exif:RelatedSoundFile", TIFF_ASCII, 0 },
+    { EXIF_FLASHENERGY,	"Exif:FlashEnergy",	TIFF_RATIONAL, 1 },
+    { EXIF_SPATIALFREQUENCYRESPONSE,	"Exif:SpatialFrequencyResponse",	TIFF_NOTYPE, 1 },
+    { EXIF_FOCALPLANEXRESOLUTION,	"Exif:FocalPlaneXResolution",	TIFF_RATIONAL, 1 },
+    { EXIF_FOCALPLANEYRESOLUTION,	"Exif:FocalPlaneYResolution",	TIFF_RATIONAL, 1 },
+    { EXIF_FOCALPLANERESOLUTIONUNIT,	"Exif:FocalPlaneResolutionUnit",	TIFF_SHORT, 1 }, // Symbolic?
+    { EXIF_SUBJECTLOCATION,	"Exif:SubjectLocation",	TIFF_SHORT, 2 },
+    { EXIF_EXPOSUREINDEX,	"Exif:ExposureIndex",	TIFF_RATIONAL, 1 },
+    { EXIF_SENSINGMETHOD,	"Exif:SensingMethod",	TIFF_SHORT, 1 },
+    { EXIF_FILESOURCE,	"Exif:FileSource",	TIFF_UNDEFINED, 1 },
+    { EXIF_SCENETYPE,	"Exif:SceneType",	TIFF_UNDEFINED, 1 },
+    { EXIF_CFAPATTERN,	"Exif:CFAPattern",	TIFF_NOTYPE, 1 }, // FIXME
+    { EXIF_CUSTOMRENDERED,	"Exif:CustomRendered",	TIFF_SHORT, 1 },
+    { EXIF_EXPOSUREMODE,	"Exif:ExposureMode",	TIFF_SHORT, 1 },
+    { EXIF_WHITEBALANCE,	"Exif:WhiteBalance",	TIFF_SHORT, 1 },
+    { EXIF_DIGITALZOOMRATIO,	"Exif:DigitalZoomRatio", TIFF_RATIONAL, 1 },
+    { EXIF_FOCALLENGTHIN35MMFILM, "Exif:FocalLengthIn35mmFilm",	TIFF_SHORT, 1 },
+    { EXIF_SCENECAPTURETYPE,	"Exif:SceneCaptureType", TIFF_SHORT, 1 },
+    { EXIF_GAINCONTROL,	"Exif:GainControl",	TIFF_RATIONAL, 1 },
+    { EXIF_CONTRAST,	        "Exif:Contrast",	TIFF_SHORT, 1 },
+    { EXIF_SATURATION,	"Exif:Saturation",	TIFF_SHORT, 1 },
+    { EXIF_SHARPNESS,	"Exif:Sharpness",	TIFF_SHORT, 1 },
+    { EXIF_DEVICESETTINGDESCRIPTION,	"Exif:DeviceSettingDescription",	TIFF_NOTYPE, 1 }, // FIXME
+    { EXIF_SUBJECTDISTANCERANGE,	"Exif:SubjectDistanceRange",	TIFF_SHORT, 1 },
+    { EXIF_IMAGEUNIQUEID,	"Exif:ImageUniqueID",   TIFF_ASCII, 0 },
+    { EXIF_PHOTOGRAPHICSENSITIVITY,  "Exif:PhotographicSensitivity",  TIFF_SHORT, 1 },
+    { EXIF_SENSITIVITYTYPE,  "Exif:SensitivityType",  TIFF_SHORT, 1 },
+    { EXIF_STANDARDOUTPUTSENSITIVITY,  "Exif:StandardOutputSensitivity", TIFF_LONG, 1 },
+    { EXIF_RECOMMENDEDEXPOSUREINDEX,  "Exif:RecommendedExposureIndex", TIFF_LONG, 1 },
+    { EXIF_ISOSPEED,  "Exif:ISOSpeed", TIFF_LONG, 1 },
+    { EXIF_ISOSPEEDLATITUDEYYY,  "Exif:ISOSpeedLatitudeyyy", TIFF_LONG, 1 },
+    { EXIF_ISOSPEEDLATITUDEZZZ,  "Exif:ISOSpeedLatitudezzz", TIFF_LONG, 1 },
+    { EXIF_TEMPERATURE,  "Exif:Temperature", TIFF_SRATIONAL, 1 },
+    { EXIF_HUMIDITY,  "Exif:Humidity", TIFF_RATIONAL, 1 },
+    { EXIF_PRESSURE,  "Exif:Pressure", TIFF_RATIONAL, 1 },
+    { EXIF_WATERDEPTH,  "Exif:WaterDepth", TIFF_SRATIONAL, 1 },
+    { EXIF_ACCELERATION,  "Exif:Acceleration", TIFF_RATIONAL, 1 },
+    { EXIF_CAMERAELEVATIONANGLE,  "Exif:CameraElevationAngle", TIFF_SRATIONAL, 1 },
+    { EXIF_CAMERAOWNERNAME,  "Exif:CameraOwnerName",  TIFF_ASCII, 0 },
+    { EXIF_BODYSERIALNUMBER,  "Exif:BodySerialNumber", TIFF_ASCII, 0 },
+    { EXIF_LENSSPECIFICATION,  "Exif:LensSpecification", TIFF_RATIONAL, 4 },
+    { EXIF_LENSMAKE,  "Exif:LensMake",         TIFF_ASCII, 0 },
+    { EXIF_LENSMODEL,  "Exif:LensModel",        TIFF_ASCII, 0 },
+    { EXIF_LENSSERIALNUMBER,  "Exif:LensSerialNumber", TIFF_ASCII, 0 },
+    { EXIF_GAMMA,  "Exif:Gamma", TIFF_RATIONAL, 0 }
 };
+
+const TagMap& pvt::exif_tagmap_ref () {
+    static TagMap T ("EXIF", exif_tag_table);
+    return T;
+}
 
 
 
@@ -238,8 +577,8 @@ enum GPSTag {
     GPSTAG_HPOSITIONINGERROR = 31
 };
 
-static const EXIF_tag_info gps_tag_table[] = {
-    { GPSTAG_VERSIONID,		"GPS:VersionID",	TIFF_BYTE, 4 }, 
+static const TagInfo gps_tag_table[] = {
+    { GPSTAG_VERSIONID,		"GPS:VersionID",	TIFF_BYTE, 4, version4uint8_handler }, 
     { GPSTAG_LATITUDEREF,	"GPS:LatitudeRef",	TIFF_ASCII, 2 },
     { GPSTAG_LATITUDE,		"GPS:Latitude",		TIFF_RATIONAL, 3 },
     { GPSTAG_LONGITUDEREF,	"GPS:LongitudeRef",	TIFF_ASCII, 2 },
@@ -270,151 +609,27 @@ static const EXIF_tag_info gps_tag_table[] = {
     { GPSTAG_AREAINFORMATION,	"GPS:AreaInformation",	TIFF_UNDEFINED, 1 },
     { GPSTAG_DATESTAMP,		"GPS:DateStamp",	TIFF_ASCII, 0 },
     { GPSTAG_DIFFERENTIAL,	"GPS:Differential",	TIFF_SHORT, 1 },
-    { GPSTAG_HPOSITIONINGERROR,	"GPS:HPositioningError",TIFF_RATIONAL, 1 },
-    { -1, NULL }  // signal end of table
+    { GPSTAG_HPOSITIONINGERROR,	"GPS:HPositioningError",TIFF_RATIONAL, 1 }
 };
 
 
-
-
-
-class TagMap {
-    typedef boost::container::flat_map<int, const EXIF_tag_info *> tagmap_t;
-    typedef boost::container::flat_map<std::string, const EXIF_tag_info *> namemap_t;
-    // Name map is lower case so it's effectively case-insensitive
-public:
-    TagMap (const EXIF_tag_info *tag_table) {
-        for (int i = 0;  tag_table[i].tifftag >= 0;  ++i) {
-            const EXIF_tag_info *eti = &tag_table[i];
-            m_tagmap[eti->tifftag] = eti;
-            if (eti->name) {
-                std::string lowername (eti->name);
-                Strutil::to_lower (lowername);
-                m_namemap[lowername] = eti;
-            }
-        }
-    }
-
-    const EXIF_tag_info * find (int tag) const {
-        tagmap_t::const_iterator i = m_tagmap.find (tag);
-        return i == m_tagmap.end() ? NULL : i->second;
-    }
-
-    const EXIF_tag_info * find (string_view name) const {
-        std::string lowername (name);
-        Strutil::to_lower (lowername);
-        namemap_t::const_iterator i = m_namemap.find (lowername);
-        return i == m_namemap.end() ? NULL : i->second;
-    }
-
-    const char * name (int tag) const {
-        tagmap_t::const_iterator i = m_tagmap.find (tag);
-        return i == m_tagmap.end() ? NULL : i->second->name;
-    }
-
-    TIFFDataType tifftype (int tag) const {
-        tagmap_t::const_iterator i = m_tagmap.find (tag);
-        return i == m_tagmap.end() ? TIFF_NOTYPE : i->second->tifftype;
-    }
-
-    int tiffcount (int tag) const {
-        tagmap_t::const_iterator i = m_tagmap.find (tag);
-        return i == m_tagmap.end() ? 0 : i->second->tiffcount;
-    }
-
-    int tag (string_view name) const {
-        std::string lowername (name);
-        Strutil::to_lower (lowername);
-        namemap_t::const_iterator i = m_namemap.find (lowername);
-        return i == m_namemap.end() ? -1 : i->second->tifftag;
-    }
-
-private:
-    tagmap_t m_tagmap;
-    namemap_t m_namemap;
-};
-
-static TagMap& exif_tagmap_ref () {
-    static TagMap T (exif_tag_table);
-    return T;
-}
-
-static TagMap& gps_tagmap_ref () {
-    static TagMap T (gps_tag_table);
+const TagMap& pvt::gps_tagmap_ref () {
+    static TagMap T ("GPS", gps_tag_table);
     return T;
 }
 
 
 
-
-#if (DEBUG_EXIF_WRITE || DEBUG_EXIF_READ)
-static bool
-print_dir_entry (const TagMap &tagmap,
-                 const TIFFDirEntry &dir, string_view buf)
+array_view<const TagInfo>
+tag_table (string_view tablename)
 {
-    int len = tiff_data_size (dir);
-    if (len < 0) {
-        std::cerr << "Ignoring bad directory entry\n";
-        return false;
-    }
-    const char *mydata = NULL;
-    if (len <= 4) {  // short data is stored in the offset field
-        mydata = (const char *)&dir.tdir_offset;
-    } else {
-        if (dir.tdir_offset >= buf.size() ||
-           (dir.tdir_offset+tiff_data_size(dir)) >= buf.size())
-            return false;    // bogus! overruns the buffer
-        mydata = buf.data() + dir.tdir_offset;
-    }
-    const char *name = tagmap.name(dir.tdir_tag);
-    std::cerr << "tag=" << dir.tdir_tag
-              << " (" << (name ? name : "unknown") << ")"
-              << ", type=" << dir.tdir_type
-              << ", count=" << dir.tdir_count
-              << ", offset=" << dir.tdir_offset << " = " ;
-    switch (dir.tdir_type) {
-    case TIFF_ASCII :
-        std::cerr << "'" << (char *)mydata << "'";
-        break;
-    case TIFF_RATIONAL :
-        {
-            const unsigned int *u = (unsigned int *)mydata;
-            for (size_t i = 0; i < dir.tdir_count;  ++i)
-                std::cerr << u[2*i] << "/" << u[2*i+1] << " = "
-                          << (double)u[2*i]/(double)u[2*i+1] << " ";
-        }
-        break;
-    case TIFF_SRATIONAL :
-        {
-            const int *u = (int *)mydata;
-            for (size_t i = 0; i < dir.tdir_count;  ++i)
-                std::cerr << u[2*i] << "/" << u[2*i+1] << " = "
-                          << (double)u[2*i]/(double)u[2*i+1] << " ";
-        }
-        break;
-    case TIFF_SHORT :
-        std::cerr << ((unsigned short *)mydata)[0];
-        break;
-    case TIFF_LONG :
-        std::cerr << ((unsigned int *)mydata)[0];
-        break;
-    case TIFF_BYTE :
-    case TIFF_UNDEFINED :
-    case TIFF_NOTYPE :
-    default:
-        if (len <= 4 && dir.tdir_count > 4) {
-            // Request more data than is stored.
-            std::cerr << "Ignoring buffer with too much count of short data.\n";
-            return false;
-        }
-        for (size_t i = 0;  i < dir.tdir_count;  ++i)
-            std::cerr << (int)((unsigned char *)mydata)[i] << ' ';
-        break;
-    }
-    std::cerr << "\n";
-    return true;
+    if (tablename == "Exif")
+        return array_view<const TagInfo> (exif_tag_table);
+    if (tablename == "GPS")
+        return array_view<const TagInfo> (gps_tag_table);
+    // if (tablename == "TIFF")
+        return array_view<const TagInfo> (tiff_tag_table);
 }
-#endif
 
 
 
@@ -427,30 +642,38 @@ print_dir_entry (const TagMap &tagmap,
 /// if necessary, so no byte swapping on *dirp is necessary.
 static void
 add_exif_item_to_spec (ImageSpec &spec, const char *name,
-                       const TIFFDirEntry *dirp, string_view buf, bool swab)
+                       const TIFFDirEntry *dirp,
+                       array_view<const uint8_t> buf, bool swab,
+                       int offset_adjustment=0)
 {
-    if (dirp->tdir_type == TIFF_SHORT && dirp->tdir_count == 1) {
-        union { uint32_t i32; uint16_t i16[2]; } convert;
-        convert.i32 = dirp->tdir_offset;
-        unsigned short d = convert.i16[0];
-        // N.B. The Exif spec says that for a 16 bit value, it's stored in
-        // the *first* 16 bits of the offset area.
+    ASSERT (dirp);
+    const uint8_t *dataptr = (const uint8_t *) pvt::dataptr (*dirp, buf, offset_adjustment);
+    if (!dataptr)
+        return;
+    TypeDesc type = tiff_datatype_to_typedesc (*dirp);
+    if (dirp->tdir_type == TIFF_SHORT) {
+        std::vector<uint16_t> d ((const uint16_t *)dataptr,
+                                 (const uint16_t *)dataptr+dirp->tdir_count);
         if (swab)
-            swap_endian (&d);
-        spec.attribute (name, (unsigned int)d);
-    } else if (dirp->tdir_type == TIFF_LONG && dirp->tdir_count == 1) {
-        unsigned int d;
-        d = * (const unsigned int *) &dirp->tdir_offset;  // int stored in offset itself
+            swap_endian (d.data(), d.size());
+        spec.attribute (name, type, d.data());
+        return;
+    }
+    if (dirp->tdir_type == TIFF_LONG) {
+        std::vector<uint32_t> d ((const uint32_t *)dataptr,
+                                 (const uint32_t *)dataptr+dirp->tdir_count);
         if (swab)
-            swap_endian (&d);
-        spec.attribute (name, (unsigned int)d);
-    } else if (dirp->tdir_type == TIFF_RATIONAL) {
+            swap_endian (d.data(), d.size());
+        spec.attribute (name, type, d.data());
+        return;
+    }
+    if (dirp->tdir_type == TIFF_RATIONAL) {
         int n = dirp->tdir_count;  // How many
         float *f = (float *) alloca (n * sizeof(float));
         for (int i = 0;  i < n;  ++i) {
             unsigned int num, den;
-            num = ((const unsigned int *) &(buf[dirp->tdir_offset]))[2*i+0];
-            den = ((const unsigned int *) &(buf[dirp->tdir_offset]))[2*i+1];
+            num = ((const unsigned int *) dataptr)[2*i+0];
+            den = ((const unsigned int *) dataptr)[2*i+1];
             if (swab) {
                 swap_endian (&num);
                 swap_endian (&den);
@@ -461,13 +684,15 @@ add_exif_item_to_spec (ImageSpec &spec, const char *name,
             spec.attribute (name, *f);
         else
             spec.attribute (name, TypeDesc(TypeDesc::FLOAT, n), f);
-    } else if (dirp->tdir_type == TIFF_SRATIONAL) {
+        return;
+    }
+    if (dirp->tdir_type == TIFF_SRATIONAL) {
         int n = dirp->tdir_count;  // How many
         float *f = (float *) alloca (n * sizeof(float));
         for (int i = 0;  i < n;  ++i) {
             int num, den;
-            num = ((const int *) &(buf[dirp->tdir_offset]))[2*i+0];
-            den = ((const int *) &(buf[dirp->tdir_offset]))[2*i+1];
+            num = ((const int *) dataptr)[2*i+0];
+            den = ((const int *) dataptr)[2*i+1];
             if (swab) {
                 swap_endian (&num);
                 swap_endian (&den);
@@ -478,35 +703,41 @@ add_exif_item_to_spec (ImageSpec &spec, const char *name,
             spec.attribute (name, *f);
         else
             spec.attribute (name, TypeDesc(TypeDesc::FLOAT, n), f);
-    } else if (dirp->tdir_type == TIFF_ASCII) {
+        return;
+    }
+    if (dirp->tdir_type == TIFF_ASCII) {
         int len = tiff_data_size (*dirp);
-        const char *ptr = (len <= 4) ? (const char *)&dirp->tdir_offset 
-                                     : (buf.data() + dirp->tdir_offset);
+        const char *ptr = (const char *)dataptr;
         while (len && ptr[len-1] == 0)  // Don't grab the terminating null
             --len;
         std::string str (ptr, len);
         if (strlen(str.c_str()) < str.length())  // Stray \0 in the middle
             str = std::string (str.c_str());
         spec.attribute (name, str);
-    } else if (dirp->tdir_type == TIFF_BYTE && dirp->tdir_count == 1) {
+        return;
+    }
+    if (dirp->tdir_type == TIFF_BYTE && dirp->tdir_count == 1) {
         // Not sure how to handle "bytes" generally, but certainly for just
         // one, add it as an int.
         unsigned char d;
-        d = * (const unsigned char *) &dirp->tdir_offset;  // byte stored in offset itself
+        d = *dataptr;  // byte stored in offset itself
         spec.attribute (name, (int)d);
-    } else if (dirp->tdir_type == TIFF_UNDEFINED || dirp->tdir_type == TIFF_BYTE) {
-        // Add it as bytes
+        return;
+    }
+
 #if 0
+    if (dirp->tdir_type == TIFF_UNDEFINED || dirp->tdir_type == TIFF_BYTE) {
+        // Add it as bytes
         const void *addr = dirp->tdir_count <= 4 ? (const void *) &dirp->tdir_offset 
                                                  : (const void *) &buf[dirp->tdir_offset];
-        spec.attribute (name, TypeDesc::UINT8, dirp->tdir_count, addr);
-#endif
-    } else {
-#ifndef NDEBUG
-        std::cerr << "didn't know how to process " << name << ", type " 
-                  << dirp->tdir_type << " x " << dirp->tdir_count << "\n";
-#endif
+        spec.attribute (name, TypeDesc(TypeDesc::UINT8, dirp->tdir_count), addr);
     }
+#endif
+
+#if !defined(NDEBUG) || DEBUG_EXIF_UNHANDLED
+    std::cerr << "add_exif_item_to_spec: didn't know how to process " << name << ", type "
+              << dirp->tdir_type << " x " << dirp->tdir_count << "\n";
+#endif
 }
 
 
@@ -522,19 +753,20 @@ add_exif_item_to_spec (ImageSpec &spec, const char *name,
 /// endianness of the file.
 static void
 read_exif_tag (ImageSpec &spec, const TIFFDirEntry *dirp,
-               string_view buf, bool swab,
-               std::set<size_t> &ifd_offsets_seen,
+               array_view<const uint8_t> buf, bool swab,
+               int offset_adjustment, std::set<size_t> &ifd_offsets_seen,
                const TagMap &tagmap)
 {
-    if ((char*)dirp < buf.data() || (char*)dirp >= buf.data() + buf.size()) {
+    if ((const uint8_t*)dirp < buf.data() ||
+        (const uint8_t*)dirp+sizeof(TIFFDirEntry) >= buf.data() + buf.size()) {
 #if DEBUG_EXIF_READ
         std::cerr << "Ignoring directory outside of the buffer.\n";
 #endif
         return;
     }
 
-    TagMap& exif_tagmap (exif_tagmap_ref());
-    TagMap& gps_tagmap (gps_tagmap_ref());
+    const TagMap& exif_tagmap (exif_tagmap_ref());
+    const TagMap& gps_tagmap (gps_tagmap_ref());
 
     // Make a copy of the pointed-to TIFF directory, swab the components
     // if necessary.
@@ -549,8 +781,8 @@ read_exif_tag (ImageSpec &spec, const TIFFDirEntry *dirp,
     }
 
 #if DEBUG_EXIF_READ
-    std::cerr << "Read ";
-    print_dir_entry (tagmap, dir, buf);
+    std::cerr << "Read " << tagmap.mapname() << " ";
+    print_dir_entry (tagmap, dir, buf, offset_adjustment);
 #endif
 
     if (dir.tdir_tag == TIFFTAG_EXIFIFD || dir.tdir_tag == TIFFTAG_GPSIFD) {
@@ -601,7 +833,7 @@ read_exif_tag (ImageSpec &spec, const TIFFDirEntry *dirp,
 #endif
         for (int d = 0;  d < ndirs;  ++d)
             read_exif_tag (spec, (const TIFFDirEntry *)(ifd+2+d*sizeof(TIFFDirEntry)),
-                           buf, swab, ifd_offsets_seen,
+                           buf, swab, offset_adjustment, ifd_offsets_seen,
                            dir.tdir_tag == TIFFTAG_EXIFIFD ? exif_tagmap : gps_tagmap);
 #if DEBUG_EXIF_READ
         std::cerr << "> End EXIF\n";
@@ -629,21 +861,24 @@ read_exif_tag (ImageSpec &spec, const TIFFDirEntry *dirp,
 #endif
         for (int d = 0;  d < ndirs;  ++d)
             read_exif_tag (spec, (const TIFFDirEntry *)(ifd+2+d*sizeof(TIFFDirEntry)),
-                           buf, swab, ifd_offsets_seen, exif_tagmap);
+                           buf, swab, offset_adjustment, ifd_offsets_seen, exif_tagmap);
 #if DEBUG_EXIF_READ
         std::cerr << "> End Interoperability\n\n";
 #endif
     } else {
         // Everything else -- use our table to handle the general case
-        const char *name = tagmap.name (dir.tdir_tag);
-        if (name) {
-            add_exif_item_to_spec (spec, name, &dir, buf, swab);
+        const TagInfo* taginfo = tagmap.find (dir.tdir_tag);
+        if (taginfo) {
+            if (taginfo->handler)
+                taginfo->handler (*taginfo, dir, buf, spec, swab, offset_adjustment);
+            else if (taginfo->tifftype != TIFF_NOTYPE)
+                add_exif_item_to_spec (spec, taginfo->name, &dir, buf, swab, offset_adjustment);
         } else {
-#if DEBUG_EXIF_READ
-            std::cerr << "Dir : tag=" << dir.tdir_tag
-                      << ", type=" << dir.tdir_type
-                      << ", count=" << dir.tdir_count
-                      << ", offset=" << dir.tdir_offset << "\n";
+#if DEBUG_EXIF_READ || DEBUG_EXIF_UNHANDLED
+            Strutil::fprintf (stderr, "read_exif_tag: Unhandled %s tag=%d (0x%x), type=%d count=%d (%s), offset=%d\n",
+                              tagmap.mapname(), dir.tdir_tag, dir.tdir_tag,
+                              dir.tdir_type, dir.tdir_count,
+                              tiff_datatype_to_typedesc(dir), dir.tdir_offset);
 #endif
         }
     }
@@ -651,56 +886,20 @@ read_exif_tag (ImageSpec &spec, const TIFFDirEntry *dirp,
 
 
 
-class tagcompare {
-public:
-    int operator() (const TIFFDirEntry &a, const TIFFDirEntry &b) {
-        return (a.tdir_tag < b.tdir_tag);
-    }
-};
-
-
-
-
-static void
-append_dir_entry (const TagMap &tagmap,
-                  std::vector<TIFFDirEntry> &dirs, std::vector<char> &data,
-                  int tag, TIFFDataType type, size_t count, const void *mydata)
-{
-    TIFFDirEntry dir;
-    dir.tdir_tag = tag;
-    dir.tdir_type = type;
-    dir.tdir_count = count;
-    size_t len = tiff_data_sizes[(int)type] * count;
-    if (len <= 4) {
-        dir.tdir_offset = 0;
-        memcpy (&dir.tdir_offset, mydata, len);
-    } else {
-        dir.tdir_offset = data.size();
-        data.insert (data.end(), (char *)mydata, (char *)mydata + len);
-    }
-#if DEBUG_EXIF_WRITE
-    std::cerr << "Adding ";
-    print_dir_entry (tagmap, dir, string_view((const char *)mydata, len));
-#endif
-    // Don't double-add
-    for (TIFFDirEntry &d : dirs) {
-        if (d.tdir_tag == tag) {
-            d = dir;
-            return;
-        }
-    }
-    dirs.push_back (dir);
+inline int tagcompare (const TIFFDirEntry &a, const TIFFDirEntry &b) {
+    return (a.tdir_tag < b.tdir_tag);
 }
 
 
 
-/// Convert to the desired integer type and then append_dir_entry it.
+/// Convert to the desired integer type and then append_tiff_dir_entry it.
 ///
 template <class T>
-bool
-append_dir_entry_integer (const ParamValue &p, const TagMap &tagmap,
-                          std::vector<TIFFDirEntry> &dirs,
-                          std::vector<char> &data, int tag, TIFFDataType type)
+static bool
+append_tiff_dir_entry_integer (const ParamValue &p,
+                               std::vector<TIFFDirEntry> &dirs,
+                               std::vector<char> &data, int tag,
+                               TIFFDataType type, size_t offset_correction)
 {
     T i;
     switch (p.type().basetype) {
@@ -719,10 +918,9 @@ append_dir_entry_integer (const ParamValue &p, const TagMap &tagmap,
     default:
         return false;
     }
-    append_dir_entry (tagmap, dirs, data, tag, type, 1, &i);
+    append_tiff_dir_entry (dirs, data, tag, type, 1, &i, offset_correction);
     return true;
 }
-
 
 
 /// Helper: For param that needs to be added as a tag, create a TIFF
@@ -733,9 +931,11 @@ append_dir_entry_integer (const ParamValue &p, const TagMap &tagmap,
 static void
 encode_exif_entry (const ParamValue &p, int tag,
                    std::vector<TIFFDirEntry> &dirs,
-                   std::vector<char> &data,
-                   const TagMap &tagmap)
+                   std::vector<char> &data, const TagMap &tagmap,
+                   size_t offset_correction)
 {
+    if (tag < 0)
+        return;
     TIFFDataType type = tagmap.tifftype (tag);
     size_t count = (size_t) tagmap.tiffcount (tag);
     TypeDesc element = p.type().elementtype();
@@ -745,7 +945,7 @@ encode_exif_entry (const ParamValue &p, int tag,
         if (p.type() == TypeDesc::STRING) {
             const char *s = *(const char **) p.data();
             int len = strlen(s) + 1;
-            append_dir_entry (tagmap, dirs, data, tag, type, len, s);
+            append_tiff_dir_entry (dirs, data, tag, type, len, s, offset_correction);
             return;
         }
         break;
@@ -755,7 +955,7 @@ encode_exif_entry (const ParamValue &p, int tag,
             const float *f = (const float *)p.data();
             for (size_t i = 0;  i < count;  ++i)
                 float_to_rational (f[i], rat[2*i], rat[2*i+1]);
-            append_dir_entry (tagmap, dirs, data, tag, type, count, rat);
+            append_tiff_dir_entry (dirs, data, tag, type, count, rat, offset_correction);
             return;
         }
         break;
@@ -765,65 +965,28 @@ encode_exif_entry (const ParamValue &p, int tag,
             const float *f = (const float *)p.data();
             for (size_t i = 0;  i < count;  ++i)
                 float_to_rational (f[i], rat[2*i], rat[2*i+1]);
-            append_dir_entry (tagmap, dirs, data, tag, type, count, rat);
+            append_tiff_dir_entry (dirs, data, tag, type, count, rat, offset_correction);
             return;
         }
         break;
     case TIFF_SHORT :
-        if (append_dir_entry_integer<unsigned short> (p, tagmap, dirs, data, tag, type))
+        if (append_tiff_dir_entry_integer<unsigned short> (p, dirs, data, tag, type, offset_correction))
             return;
         break;
     case TIFF_LONG :
-        if (append_dir_entry_integer<unsigned int> (p, tagmap, dirs, data, tag, type))
+        if (append_tiff_dir_entry_integer<unsigned int> (p, dirs, data, tag, type, offset_correction))
             return;
         break;
     case TIFF_BYTE :
-        if (append_dir_entry_integer<unsigned char> (p, tagmap, dirs, data, tag, type))
+        if (append_tiff_dir_entry_integer<unsigned char> (p, dirs, data, tag, type, offset_correction))
             return;
         break;
     default:
         break;
     }
-#if DEBUG_EXIF_WRITE
-    std::cerr << "  Don't know how to add " << p.name() << ", tag " << tag << ", type " << type << ' ' << p.type().c_str() << "\n";
+#if DEBUG_EXIF_WRITE || DEBUG_EXIF_UNHANDLED
+    std::cerr << "encode_exif_entry: Don't know how to add " << p.name() << ", tag " << tag << ", type " << type << ' ' << p.type().c_str() << "\n";
 #endif
-}
-
-
-
-/// Given a list of directory entries, add 'offset' to their tdir_offset
-/// fields (unless, of course, they are less than 4 bytes of data and are
-/// therefore stored locally rather than having an offset at all).
-static void
-reoffset (std::vector<TIFFDirEntry> &dirs, const TagMap &tagmap,
-          size_t offset)
-{
-    for (TIFFDirEntry &dir : dirs) {
-        if (tiff_data_size (dir) <= 4 &&
-            dir.tdir_tag != TIFFTAG_EXIFIFD && dir.tdir_tag != TIFFTAG_GPSIFD) {
-#if DEBUG_EXIF_WRITE
-            const char *name = tagmap.name (dir.tdir_tag);
-            std::cerr << "    NO re-offset of exif entry " << " tag " << dir.tdir_tag << " " << (name ? name : "") << " to " << dir.tdir_offset << '\n';
-#endif
-            continue;
-        }
-        dir.tdir_offset += offset;
-#if DEBUG_EXIF_WRITE
-        const char *name = tagmap.name (dir.tdir_tag);
-        std::cerr << "    re-offsetting entry " << " tag " << dir.tdir_tag << " " << (name ? name : "") << " to " << dir.tdir_offset << '\n';
-#endif
-    }
-}
-
-
-}  // anon namespace
-
-
-// DEPRECATED (1.8)
-bool
-decode_exif (const void *exif, int length, ImageSpec &spec)
-{
-    return decode_exif (string_view ((const char *)exif, length), spec);
 }
 
 
@@ -831,17 +994,78 @@ decode_exif (const void *exif, int length, ImageSpec &spec)
 // Decode a raw Exif data block and save all the metadata in an
 // ImageSpec.  Return true if all is ok, false if the exif block was
 // somehow malformed.
+void
+pvt::decode_ifd (const unsigned char *ifd,
+            array_view<const uint8_t> buf, ImageSpec &spec, const TagMap& tag_map,
+            std::set<size_t>& ifd_offsets_seen, bool swab, int offset_adjustment)
+{
+    // Read the directory that the header pointed to.  It should contain
+    // some number of directory entries containing tags to process.
+    unsigned short ndirs = *(const unsigned short *)ifd;
+    if (swab)
+        swap_endian (&ndirs);
+    for (int d = 0;  d < ndirs;  ++d)
+        read_exif_tag (spec, (const TIFFDirEntry *) (ifd+2+d*sizeof(TIFFDirEntry)),
+                       buf, swab, offset_adjustment, ifd_offsets_seen, tag_map);
+}
+
+
+
+void
+pvt::append_tiff_dir_entry (std::vector<TIFFDirEntry> &dirs,
+                            std::vector<char> &data,
+                            int tag, TIFFDataType type, size_t count,
+                            const void *mydata, size_t offset_correction,
+                            size_t offset_override)
+{
+    TIFFDirEntry dir;
+    dir.tdir_tag = tag;
+    dir.tdir_type = type;
+    dir.tdir_count = count;
+    size_t len = tiff_data_size (dir);
+    if (len <= 4) {
+        dir.tdir_offset = 0;
+        memcpy (&dir.tdir_offset, mydata, len);
+    } else {
+        if (mydata) {
+            // Add to the data vector and use its offset
+            dir.tdir_offset = data.size() - offset_correction;
+            data.insert (data.end(), (char *)mydata, (char *)mydata + len);
+        } else {
+            // An offset override was given, use that, it means that data
+            // ALREADY contains what we want.
+            dir.tdir_offset = uint32_t(offset_override);
+        }
+    }
+    // Don't double-add
+    for (TIFFDirEntry &d : dirs) {
+        if (d.tdir_tag == tag) {
+            d = dir;
+            return;
+        }
+    }
+    dirs.push_back (dir);
+}
+
+
+
 bool
 decode_exif (string_view exif, ImageSpec &spec)
 {
-    TagMap& exif_tagmap (exif_tagmap_ref());
+    return decode_exif (array_view<const uint8_t>((const uint8_t*)exif.data(), exif.size()), spec);
+}
 
+
+
+bool
+decode_exif (array_view<const uint8_t> exif, ImageSpec &spec)
+{
 #if DEBUG_EXIF_READ
     std::cerr << "Exif dump:\n";
     for (size_t i = 0;  i < exif.size();  ++i) {
         if (exif[i] >= ' ')
             std::cerr << (char)exif[i] << ' ';
-        std::cerr << "(" << (int)(unsigned char)exif[i] << ") ";
+        std::cerr << "(" << (int)exif[i] << ") ";
     }
     std::cerr << "\n";
 #endif
@@ -864,19 +1088,11 @@ decode_exif (string_view exif, ImageSpec &spec)
     if (swab)
         swap_endian (&head.tiff_diroff);
 
+    const unsigned char *ifd = ((const unsigned char *)exif.data() + head.tiff_diroff);
     // keep track of IFD offsets we've already seen to avoid infinite
     // recursion if there are circular references.
     std::set<size_t> ifd_offsets_seen;
-
-    // Read the directory that the header pointed to.  It should contain
-    // some number of directory entries containing tags to process.
-    const unsigned char *ifd = ((const unsigned char *)exif.data() + head.tiff_diroff);
-    unsigned short ndirs = *(const unsigned short *)ifd;
-    if (swab)
-        swap_endian (&ndirs);
-    for (int d = 0;  d < ndirs;  ++d)
-        read_exif_tag (spec, (const TIFFDirEntry *) (ifd+2+d*sizeof(TIFFDirEntry)),
-                       exif, swab, ifd_offsets_seen, exif_tagmap);
+    decode_ifd (ifd, exif, spec, exif_tagmap_ref(), ifd_offsets_seen, swab);
 
     // A few tidbits to look for
     ParamValue *p;
@@ -896,7 +1112,45 @@ decode_exif (string_view exif, ImageSpec &spec)
         if (cs != 0xffff)
             spec.attribute ("oiio:ColorSpace", "sRGB");
     }
+
+    // Look for a maker note offset, now that we have seen all the metadata
+    // and therefore are sure we know the camera Make. See the comments in
+    // makernote_handler for why this needs to come at the end.
+    int makernote_offset = spec.get_int_attribute ("oiio:MakerNoteOffset");
+    if (makernote_offset > 0) {
+        if (spec.get_string_attribute("Make") == "Canon") {
+            decode_ifd ((unsigned char *)exif.data() + makernote_offset, exif,
+                        spec, pvt::canon_maker_tagmap_ref(), ifd_offsets_seen, swab);
+        }
+        // Now we can erase the attrib we used to pass the message about
+        // the maker note offset.
+        spec.erase_attribute ("oiio:MakerNoteOffset");
+    }
+
     return true;
+}
+
+
+
+// DEPRECATED (1.8)
+bool
+decode_exif (const void *exif, int length, ImageSpec &spec)
+{
+    return decode_exif (array_view<const uint8_t> ((const uint8_t*)exif, length), spec);
+}
+
+
+
+template<class T>
+inline void append (std::vector<char>& blob, const T& v)
+{
+    blob.insert (blob.end(), (const char *)&v, (const char*)&v + sizeof(T));
+}
+
+template<class T>
+inline void appendvec (std::vector<char>& blob, const std::vector<T>& v)
+{
+    blob.insert (blob.end(), (const char *)v.data(), (const char*)(v.data()+v.size()));
 }
 
 
@@ -906,8 +1160,9 @@ decode_exif (string_view exif, ImageSpec &spec)
 void
 encode_exif (const ImageSpec &spec, std::vector<char> &blob)
 {
-    TagMap& exif_tagmap (exif_tagmap_ref());
-    TagMap& gps_tagmap (gps_tagmap_ref());
+    const TagMap& exif_tagmap (exif_tagmap_ref());
+    const TagMap& gps_tagmap (gps_tagmap_ref());
+    // const TagMap& canon_tagmap (pvt::canon_maker_tagmap_ref());
 
     // Reserve maximum space that an APP1 can take in a JPEG file, so
     // we can push_back to our heart's content and know that no offsets
@@ -916,172 +1171,193 @@ encode_exif (const ImageSpec &spec, std::vector<char> &blob)
     blob.reserve (0xffff);
 
     // Layout:
-    //    (tiffstart)      TIFFHeader
-    //                     number of top dir entries 
-    //                     top dir entry 0
-    //                     ...
-    //                     top dir entry (point to Exif IFD)
-    //                     data for top dir entries (except Exif)
-    //
-    //                     Exif IFD number of dir entries (n)
-    //                     Exif IFD entry 0
-    //                     ...
-    //                     Exif IFD entry n-1
-    //                     ...More Data for Exif entries...
+    //                     .-----------------------------------------
+    //    (tiffstart) ---->|  TIFFHeader
+    //                     |    magic
+    //                     |    version
+    //                  .--+--  diroff
+    //                  |  |-----------------------------------------
+    //            .-----+->|  d
+    //            |     |  |   a
+    //            |  .--+->|    t
+    //            |  |  |  |     a
+    //        .---+--+--+->|  d
+    //        |   |  |  |  |   a
+    //      .-+---+--+--+->|    t
+    //      | |   |  |  |  |     a
+    //      | |   |  |  |  +-----------------------------------------
+    //      | |   |  |  `->|  number of top dir entries
+    //      | |   `--+-----+- top dir entry 0
+    //      | |      |     |  ...
+    //      | |      | .---+- top dir Exif entry (point to Exif IFD)
+    //      | |      | |   |  ...
+    //      | |      | |   +------------------------------------------
+    //      | |      | `-->|  number of Exif IFD dir entries (n)
+    //      | |      `-----+- Exif IFD entry 0
+    //      | |            |  ...
+    //      | |        .---+- Exif entry for maker note
+    //      | |        |   |  ...
+    //      | `--------+---+- Exif IFD entry n-1
+    //      |          |   +------------------------------------------
+    //      |           `->|  number of makernote IFD dir entries
+    //      `--------------+- Makernote IFD entry 0
+    //                     |  ...
+    //                     `------------------------------------------
 
-    // Here is where the TIFF info starts.  All TIFF tag offsets are
-    // relative to this position within the blob.
-    int tiffstart = blob.size();
-
-    // Handy macro -- grow the blob to accommodate a new variable, which
-    // we position at its end.
-#define BLOB_ADD(vartype, varname)                          \
-    blob.resize (blob.size() + sizeof(vartype));            \
-    vartype & varname (* (vartype *) (&blob[0] + blob.size() - sizeof(vartype)));
-    
     // Put a TIFF header
-    BLOB_ADD (TIFFHeader, head);
-    bool host_little = littleendian();
-    head.tiff_magic = host_little ? 0x4949 : 0x4d4d;
+    size_t tiffstart = blob.size();   // store initial size
+    TIFFHeader head;
+    head.tiff_magic = littleendian() ? 0x4949 : 0x4d4d;
     head.tiff_version = 42;
-    head.tiff_diroff = blob.size() - tiffstart;
-
-    // Placeholder for number of directories
-    BLOB_ADD (unsigned short, ndirs);
-    ndirs = 0;
+    // head.tiff_diroff -- fix below, once we know the sizes
+    append (blob, head);
 
     // Accumulate separate tag directories for TIFF, Exif, GPS, and Interop.
-    std::vector<TIFFDirEntry> tiffdirs, exifdirs, gpsdirs, interopdirs;
-    std::vector<char> data;    // Put data here
-    int endmarker = 0;  // 4 bytes of 0's that marks the end of a directory
+    std::vector<TIFFDirEntry> tiffdirs, exifdirs, gpsdirs;
+    std::vector<TIFFDirEntry> makerdirs;
 
     // Go through all spec attribs, add them to the appropriate tag
-    // directory (tiff, gps, or exif).
+    // directory (tiff, gps, or exif), adding their data to the main blob.
     for (const ParamValue &p : spec.extra_attribs) {
         // Which tag domain are we using?
-        if (! strncmp (p.name().c_str(), "GPS:", 4)) {
-            // GPS
-            int tag = gps_tagmap.tag (p.name().string());
-            encode_exif_entry (p, tag, gpsdirs, data, gps_tagmap);
+        if (Strutil::starts_with (p.name(), "GPS:")) {
+            int tag = gps_tagmap.tag (p.name());
+            if (tag >= 0)
+                encode_exif_entry (p, tag, gpsdirs, blob, gps_tagmap, tiffstart);
         } else {
             // Not GPS
-            int tag = exif_tagmap.tag (p.name().string());
-            if (tag < EXIFTAG_EXPOSURETIME || tag > EXIFTAG_IMAGEUNIQUEID) {
-                encode_exif_entry (p, tag, tiffdirs, data, exif_tagmap);
+            int tag = exif_tagmap.tag (p.name());
+            if (tag < EXIF_EXPOSURETIME || tag > EXIF_IMAGEUNIQUEID) {
+                // This range of Exif tags go in the main TIFF directories,
+                // not the Exif IFD. Whatever.
+                encode_exif_entry (p, tag, tiffdirs, blob, exif_tagmap, tiffstart);
             } else {
-                encode_exif_entry (p, tag, exifdirs, data, exif_tagmap);
+                encode_exif_entry (p, tag, exifdirs, blob, exif_tagmap, tiffstart);
             }
         }
     }
+
+    // If we're a canon camera, construct the dirs for the Makernote,
+    // with the data adding to the main blob.
+    if (Strutil::iequals (spec.get_string_attribute("Make"), "Canon"))
+        pvt::encode_canon_makernote (blob, makerdirs, spec, tiffstart);
 
 #if DEBUG_EXIF_WRITE
     std::cerr << "Blob header size " << blob.size() << "\n";
     std::cerr << "tiff tags: " << tiffdirs.size() << "\n";
     std::cerr << "exif tags: " << exifdirs.size() << "\n";
     std::cerr << "gps tags: " << gpsdirs.size() << "\n";
+    std::cerr << "canon makernote tags: " << makerdirs.size() << "\n";
 #endif
 
-    // If any legit Exif info was found...
-    if (exifdirs.size()) {
+    // If any legit Exif info was found (including if there's a maker note),
+    // add some extra required Exif fields.
+    if (exifdirs.size() || makerdirs.size()) {
         // Add some required Exif tags that wouldn't be in the spec
-        append_dir_entry (exif_tagmap, exifdirs, data, 
-                          EXIFTAG_EXIFVERSION, TIFF_UNDEFINED, 4, "0220");
-        append_dir_entry (exif_tagmap, exifdirs, data, 
-                          EXIFTAG_FLASHPIXVERSION, TIFF_UNDEFINED, 4, "0100");
-        char componentsconfig[] = { 1, 2, 3, 0 };
-        append_dir_entry (exif_tagmap, exifdirs, data, 
-                          EXIFTAG_COMPONENTSCONFIGURATION, TIFF_UNDEFINED, 4, componentsconfig);
-        // Sort the exif tag directory
-        std::sort (exifdirs.begin(), exifdirs.end(), tagcompare());
-
-        // If we had exif info, add one more main dir entry to point to
-        // the private exif tag directory.
-        unsigned int size = (unsigned int) data.size();
-        append_dir_entry (exif_tagmap, tiffdirs, data, TIFFTAG_EXIFIFD, TIFF_LONG, 1, &size);
-
-        // Create interop directory boilerplate.
-        // In all honesty, I have no idea what this is all about.
-        append_dir_entry (exif_tagmap, interopdirs, data, 1, TIFF_ASCII, 4, "R98");
-        append_dir_entry (exif_tagmap, interopdirs, data, 2, TIFF_UNDEFINED, 4, "0100");
-        std::sort (interopdirs.begin(), interopdirs.end(), tagcompare());
-
-#if 0
-        // FIXME -- is this necessary?  If so, it's not completed.
-        // Add the interop directory IFD entry to the main IFD
-        size = (unsigned int) data.size();
-        append_dir_entry (exif_tagmap, tiffdirs, data,
-                          TIFFTAG_INTEROPERABILITYIFD, TIFF_LONG, 1, &size);
-        std::sort (tiffdirs.begin(), tiffdirs.end(), tagcompare());
-#endif
+        append_tiff_dir_entry (exifdirs, blob,
+                               EXIF_EXIFVERSION, TIFF_UNDEFINED, 4, "0230", tiffstart);
+        append_tiff_dir_entry (exifdirs, blob,
+                               EXIF_FLASHPIXVERSION, TIFF_UNDEFINED, 4, "0100", tiffstart);
+        static char componentsconfig[] = { 1, 2, 3, 0 };
+        append_tiff_dir_entry (exifdirs, blob,
+                          EXIF_COMPONENTSCONFIGURATION, TIFF_UNDEFINED, 4, componentsconfig, tiffstart);
     }
 
-    // If any GPS info was found...
+    // If any GPS info was found, add a version tag to the GPS fields.
     if (gpsdirs.size()) {
         // Add some required Exif tags that wouldn't be in the spec
         static char ver[] = { 2, 2, 0, 0 };
-        append_dir_entry (gps_tagmap, gpsdirs, data,
-                          GPSTAG_VERSIONID, TIFF_BYTE, 4, &ver);
-        // Sort the gps tag directory
-        std::sort (gpsdirs.begin(), gpsdirs.end(), tagcompare());
-
-        // If we had gps info, add one more main dir entry to point to
-        // the private gps tag directory.
-        unsigned int size = (unsigned int) data.size();
-        if (exifdirs.size())
-            size += sizeof(unsigned short) + exifdirs.size()*sizeof(TIFFDirEntry) + 4;
-        append_dir_entry (exif_tagmap, tiffdirs, data, TIFFTAG_GPSIFD, TIFF_LONG, 1, &size);
+        append_tiff_dir_entry (gpsdirs, blob, GPSTAG_VERSIONID, TIFF_BYTE, 4, &ver, tiffstart);
     }
 
-    // Where will the data begin (we need this to adjust the directory
-    // offsets once we append data to the exif blob)?
-    size_t datastart = blob.size() - tiffstart + 
-                       tiffdirs.size() * sizeof(TIFFDirEntry) +
-                       4 /* end marker */;
+    // Compute offsets:
+    // TIFF dirs will start after the data
+    size_t tiffdirs_offset = blob.size() - tiffstart;
+    size_t tiffdirs_size = sizeof(uint16_t)  // ndirs
+                         + sizeof(TIFFDirEntry) * tiffdirs.size()
+                         + (exifdirs.size() ? sizeof(TIFFDirEntry) : 0)
+                         + (gpsdirs.size() ? sizeof(TIFFDirEntry) : 0)
+                         + sizeof(uint32_t);  // zero pad for next IFD offset
+    // Exif dirs will start after the TIFF dirs.
+    size_t exifdirs_offset = tiffdirs_offset + tiffdirs_size;
+    size_t exifdirs_size = exifdirs.empty() ? 0 :
+                           ( sizeof(uint16_t)  // ndirs
+                           + sizeof(TIFFDirEntry) * exifdirs.size()
+                           + (makerdirs.size() ? sizeof(TIFFDirEntry) : 0)
+                           + sizeof(uint32_t));  // zero pad for next IFD offset
+    // GPS dirs will start after Exif
+    size_t gpsdirs_offset = exifdirs_offset + exifdirs_size;
+    size_t gpsdirs_size = gpsdirs.empty() ? 0 :
+                          ( sizeof(uint16_t)  // ndirs
+                          + sizeof(TIFFDirEntry) * gpsdirs.size()
+                          + sizeof(uint32_t));  // zero pad for next IFD offset
+    // MakerNote is after GPS
+    size_t makerdirs_offset = gpsdirs_offset + gpsdirs_size;
+    size_t makerdirs_size = makerdirs.empty() ? 0 :
+                          ( sizeof(uint16_t)  // ndirs
+                          + sizeof(TIFFDirEntry) * makerdirs.size()
+                          + sizeof(uint32_t));  // zero pad for next IFD offset
 
-    // Adjust the TIFF offsets, add the TIFF directory entries to the main
-    // Exif block, followed by 4 bytes of 0's.
-    reoffset (tiffdirs, exif_tagmap, datastart);
-    ndirs = tiffdirs.size();
-    if (ndirs)
-	    blob.insert (blob.end(), (char *)&tiffdirs[0],
-                 (char *)(&tiffdirs[0] + tiffdirs.size()));
-    blob.insert (blob.end(), (char *)&endmarker, (char *)&endmarker + sizeof(int));
+    // If any Maker info was found, add a MakerNote tag to the Exif dirs
+    if (makerdirs.size()) {
+        ASSERT (exifdirs.size());
+        // unsigned int size = (unsigned int) makerdirs_offset;
+        append_tiff_dir_entry (exifdirs, blob, EXIF_MAKERNOTE, TIFF_BYTE,
+                               makerdirs_size, nullptr, 0, makerdirs_offset);
+    }
 
-    // If legit Exif metadata was found, adjust the Exif directory offsets,
-    // append the Exif tag directory entries onto the main data block,
-    // followed by 4 bytes of 0's.
+    // If any Exif info was found, add a Exif IFD tag to the TIFF dirs
     if (exifdirs.size()) {
-        reoffset (exifdirs, exif_tagmap, datastart);
-        unsigned short nd = exifdirs.size();
-        data.insert (data.end(), (char *)&nd, (char *)&nd + sizeof(nd));
-        data.insert (data.end(), (char *)&exifdirs[0], (char *)(&exifdirs[0] + exifdirs.size()));
-        data.insert (data.end(), (char *)&endmarker, (char *)&endmarker + sizeof(int));
+        unsigned int size = (unsigned int) exifdirs_offset;
+        append_tiff_dir_entry (tiffdirs, blob, TIFFTAG_EXIFIFD, TIFF_LONG, 1, &size, tiffstart);
     }
 
-    // If legit GPS metadata was found, adjust the GPS directory offsets,
-    // append the GPS tag directory entries onto the main data block,
-    // followed by 4 bytes of 0's.
+    // If any GPS info was found, add a GPS IFD tag to the TIFF dirs
     if (gpsdirs.size()) {
-        reoffset (gpsdirs, gps_tagmap, datastart);
-        unsigned short nd = gpsdirs.size();
-        data.insert (data.end(), (char *)&nd, (char *)&nd + sizeof(nd));
-        data.insert (data.end(), (char *)&gpsdirs[0], (char *)(&gpsdirs[0] + gpsdirs.size()));
-        data.insert (data.end(), (char *)&endmarker, (char *)&endmarker + sizeof(int));
+        unsigned int size = (unsigned int) gpsdirs_offset;
+        append_tiff_dir_entry (tiffdirs, blob, TIFFTAG_GPSIFD, TIFF_LONG, 1, &size, tiffstart);
     }
 
-    // Now append the data block onto the end of the main exif block that
-    // we're returning to the caller.
-    blob.insert (blob.end(), data.begin(), data.end());
+    // All the tag dirs need to be sorted
+    std::sort (exifdirs.begin(), exifdirs.end(), tagcompare);
+    std::sort (gpsdirs.begin(), gpsdirs.end(), tagcompare);
+    std::sort (makerdirs.begin(), makerdirs.end(), tagcompare);
+
+    // Now mash everything together
+    size_t tiffdirstart = blob.size();
+    append (blob, uint16_t(tiffdirs.size()));      // ndirs for tiff
+    appendvec (blob, tiffdirs);                    // tiff dirs
+    append (blob, uint32_t(0));                    // addr of next IFD (none)
+    if (exifdirs.size()) {
+        ASSERT (blob.size() == exifdirs_offset + tiffstart);
+        append (blob, uint16_t(exifdirs.size()));  // ndirs for exif
+        appendvec (blob, exifdirs);                // exif dirs
+        append (blob, uint32_t(0));                // addr of next IFD (none)
+    }
+    if (gpsdirs.size()) {
+        ASSERT (blob.size() == gpsdirs_offset + tiffstart);
+        append (blob, uint16_t(gpsdirs.size()));   // ndirs for gps
+        appendvec (blob, gpsdirs);                 // gps dirs
+        append (blob, uint32_t(0));                // addr of next IFD (none)
+    }
+    if (makerdirs.size()) {
+        ASSERT (blob.size() == makerdirs_offset + tiffstart);
+        append (blob, uint16_t(makerdirs.size())); // ndirs for canon
+        appendvec (blob, makerdirs);               // canon dirs
+        append (blob, uint32_t(0));                // addr of next IFD (none)
+    }
+
+    // Now go back and patch the header with the offset of the first TIFF
+    // directory.
+    ((TIFFHeader *)(blob.data()+tiffstart))->tiff_diroff = tiffdirstart - tiffstart;
 
 #if DEBUG_EXIF_WRITE
     std::cerr << "resulting exif block is a total of " << blob.size() << "\n";
-#if 0
-    std::cerr << "APP1 dump:\n";
-    for (char c : blob) {
-        if (c >= ' ')
-            std::cerr << c << ' ';
-        std::cerr << "(" << (int)c << ") ";
-    }
+#if 1
+    std::vector<size_t> ifdoffsets {
+        tiffdirs_offset+tiffstart, exifdirs_offset+tiffstart,
+        gpsdirs_offset+tiffstart, makerdirs_offset+tiffstart };
+    std::cerr << "APP1 dump:" << dumpdata (blob, ifdoffsets, tiffstart);
 #endif
 #endif
 }
@@ -1091,7 +1367,7 @@ encode_exif (const ImageSpec &spec, std::vector<char> &blob)
 bool
 exif_tag_lookup (string_view name, int &tag, int &tifftype, int &count)
 {
-    const EXIF_tag_info *e = exif_tagmap_ref().find (name);
+    const TagInfo *e = exif_tagmap_ref().find (name);
     if (! e)
         return false;  // not found
 

--- a/src/libOpenImageIO/exif.h
+++ b/src/libOpenImageIO/exif.h
@@ -1,0 +1,149 @@
+/*
+  Copyright 2008 Larry Gritz et al. All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the software's owners nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  (This is the Modified BSD License)
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <set>
+#include <vector>
+#include <memory>
+
+#include <OpenImageIO/imageio.h>
+#include <OpenImageIO/paramlist.h>
+#include <OpenImageIO/tiffutils.h>
+
+
+#define DEBUG_EXIF_READ  0
+#define DEBUG_EXIF_WRITE 0
+#define DEBUG_EXIF_UNHANDLED 0
+
+
+
+OIIO_NAMESPACE_BEGIN
+namespace pvt {
+
+
+
+inline const void *
+dataptr (const TIFFDirEntry &td, array_view<const uint8_t> data,
+         int offset_adjustment)
+{
+    int len = tiff_data_size (td);
+    if (len <= 4)
+        return (const char *)&td.tdir_offset;
+    else {
+        int offset = td.tdir_offset + offset_adjustment;
+        if (offset < 0 || offset+len > (int)data.size())
+            return nullptr;   // out of bounds!
+        return (const char*)data.data() + offset;
+    }
+}
+
+
+
+struct LabelIndex {
+    int value;
+    const char *label;
+};
+
+
+typedef std::string (*ExplainerFunc) (const ParamValue &p, const void *extradata);
+
+struct ExplanationTableEntry {
+    const char    *oiioname;
+    ExplainerFunc  explainer;
+    const void    *extradata;
+};
+
+
+std::string explain_justprint (const ParamValue &p, const void *extradata);
+std::string explain_labeltable (const ParamValue &p, const void *extradata);
+
+
+
+class OIIO_API TagMap {
+public:
+    TagMap (string_view mapname, array_view<const TagInfo> tag_table);
+    ~TagMap ();
+
+    /// Find a TagInfo record for the tag index. or nullptr if not found.
+    const TagInfo * find (int tag) const;
+
+    /// Find a TagInfo record for the named tag. or nullptr if not found.
+    const TagInfo * find (string_view name) const;
+
+    /// Return the name for the tag index.
+    const char * name (int tag) const;
+
+    /// Return a TIFFDataType, given a tag index.
+    TIFFDataType tifftype (int tag) const;
+
+    /// Return a data item count, given a tag index.
+    int tiffcount (int tag) const;
+
+    /// Return the tag number, given a tag name.
+    int tag (string_view name) const;
+
+    /// Return the name of the map
+    string_view mapname() const;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> m_impl;
+};
+
+
+
+const TagMap& tiff_tagmap_ref ();
+const TagMap& exif_tagmap_ref ();
+const TagMap& gps_tagmap_ref ();
+const TagMap& canon_maker_tagmap_ref ();
+
+array_view<const ExplanationTableEntry> canon_explanation_table ();
+
+
+void append_tiff_dir_entry (std::vector<TIFFDirEntry> &dirs,
+                            std::vector<char> &data,
+                            int tag, TIFFDataType type, size_t count,
+                            const void *mydata, size_t offset_correction,
+                            size_t offset_override=0);
+
+void decode_ifd (const unsigned char *ifd, array_view<const uint8_t> buf,
+                 ImageSpec &spec, const TagMap& tag_map,
+                 std::set<size_t>& ifd_offsets_seen, bool swab=false,
+                 int offset_adjustment=0);
+
+void encode_canon_makernote (std::vector<char>& exifblob,
+                             std::vector<TIFFDirEntry> &exifdirs,
+                             const ImageSpec& spec, size_t offset_correction);
+
+}  // end namespace pvt
+
+OIIO_NAMESPACE_END
+

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -42,6 +42,7 @@
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/imagebuf.h>
 #include "imageio_pvt.h"
+#include "exif.h"
 
 #if USE_EXTERNAL_PUGIXML
 # include "pugixml.hpp"
@@ -63,6 +64,9 @@
 
 
 OIIO_NAMESPACE_BEGIN
+
+using namespace pvt;
+
 
 // Generate the default quantization parameters, templated on the data
 // type.
@@ -489,36 +493,34 @@ ImageSpec::channelindex (string_view name) const
 
 
 
-namespace {  // make an anon namespace
 
-struct LabelTable {
-    int value;
-    const char *label;
-};
-
-static std::string
-explain_justprint (const ParamValue &p, const void *extradata)
+std::string
+pvt::explain_justprint (const ParamValue &p, const void *extradata)
 {
     return p.get_string() + " " + std::string ((const char *)extradata);
 }
 
-static std::string
-explain_labeltable (const ParamValue &p, const void *extradata)
+std::string
+pvt::explain_labeltable (const ParamValue &p, const void *extradata)
 {
     int val;
-    if (p.type() == TypeDesc::INT)
-        val = *(const int *)p.data();
-    else if (p.type() == TypeDesc::UINT)
-        val = (int) *(const unsigned int *)p.data();
+    auto b = p.type().basetype;
+    if (b == TypeDesc::INT || b == TypeDesc::UINT ||
+        b == TypeDesc::SHORT || b == TypeDesc::USHORT)
+        val = p.get_int();
     else if (p.type() == TypeDesc::STRING)
         val = (int) **(const char **)p.data();
     else
         return std::string();
-    for (const LabelTable *lt = (const LabelTable *)extradata; lt->label; ++lt)
-        if (val == lt->value)
+    for (const LabelIndex *lt = (const LabelIndex *)extradata; lt->label; ++lt)
+        if (val == lt->value && lt->label)
             return std::string (lt->label);
     return std::string();  // nothing
 }
+
+
+
+namespace {  // make an anon namespace
 
 static std::string
 explain_shutterapex (const ParamValue &p, const void *extradata)
@@ -537,19 +539,14 @@ static std::string
 explain_apertureapex (const ParamValue &p, const void *extradata)
 {
     if (p.type() == TypeDesc::FLOAT)
-        return Strutil::format ("f/%g", powf (2.0f, *(float *)p.data()/2.0f));
+        return Strutil::format ("f/%2.1f", powf (2.0f, *(float *)p.data()/2.0f));
     return std::string();
 }
 
 static std::string
 explain_ExifFlash (const ParamValue &p, const void *extradata)
 {
-    int val = 0;
-    if (p.type() == TypeDesc::INT)
-        val = *(int *)p.data();
-    else if (p.type() == TypeDesc::UINT)
-        val = *(unsigned int *)p.data();
-    else return std::string();
+    int val = p.get_int();
     return Strutil::format ("%s%s%s%s%s%s%s%s",
                                 (val&1) ? "flash fired" : "no flash",
                                 (val&6) == 4 ? ", no strobe return" : "",
@@ -561,7 +558,7 @@ explain_ExifFlash (const ParamValue &p, const void *extradata)
                                 (val&64) ? ", red-eye reduction" : "");
 }
 
-static LabelTable ExifExposureProgram_table[] = {
+static LabelIndex ExifExposureProgram_table[] = {
     { 0, "" }, { 1, "manual" }, { 2, "normal program" },
     { 3, "aperture priority" }, { 4, "shutter priority" },
     { 5, "Creative program, biased toward DOF" },
@@ -572,7 +569,7 @@ static LabelTable ExifExposureProgram_table[] = {
     { -1, NULL }
 };
 
-static LabelTable ExifLightSource_table[] = {
+static LabelIndex ExifLightSource_table[] = {
     { 0, "unknown" }, { 1, "daylight" }, { 2, "tungsten/incandescent" },
     { 4, "flash" }, { 9, "fine weather" }, { 10, "cloudy" }, { 11, "shade" },
     { 12, "daylight fluorescent D 5700-7100K" },
@@ -585,23 +582,23 @@ static LabelTable ExifLightSource_table[] = {
     { 24, "ISO studio tungsten" }, { 255, "other" }, { -1, NULL }
 };
 
-static LabelTable ExifMeteringMode_table[] = {
+static LabelIndex ExifMeteringMode_table[] = {
     { 0, "" }, { 1, "average" }, { 2, "center-weighted average" },
     { 3, "spot" }, { 4, "multi-spot" }, { 5, "pattern" }, { 6, "partial" },
     { -1, NULL }
 };
 
-static LabelTable ExifSubjectDistanceRange_table[] = {
+static LabelIndex ExifSubjectDistanceRange_table[] = {
     { 0, "unknown" }, { 1, "macro" }, { 2, "close" }, { 3, "distant" },
     { -1, NULL }
 };
 
-static LabelTable ExifSceneCaptureType_table[] = {
+static LabelIndex ExifSceneCaptureType_table[] = {
     { 0, "standard" }, { 1, "landscape" }, { 2, "portrait" }, 
     { 3, "night scene" }, { -1, NULL }
 };
 
-static LabelTable orientation_table[] = {
+static LabelIndex orientation_table[] = {
     { 1, "normal" }, 
     { 2, "flipped horizontally" }, 
     { 3, "rotated 180 deg" }, 
@@ -613,88 +610,91 @@ static LabelTable orientation_table[] = {
     { -1, NULL }
 };
 
-static LabelTable resunit_table[] = {
+static LabelIndex resunit_table[] = {
     { 1, "none" }, { 2, "inches" }, { 3, "cm" },
     { 4, "mm" }, { 5, "um" }, { -1, NULL }
 };
 
-static LabelTable ExifSensingMethod_table[] = {
+static LabelIndex ExifSensingMethod_table[] = {
     { 1, "undefined" }, { 2, "1-chip color area" }, 
     { 3, "2-chip color area" }, { 4, "3-chip color area" }, 
     { 5, "color sequential area" }, { 7, "trilinear" }, 
     { 8, "color trilinear" }, { -1, NULL }
 };
 
-static LabelTable ExifFileSource_table[] = {
+static LabelIndex ExifFileSource_table[] = {
     { 1, "film scanner" }, { 2, "reflection print scanner" },
     { 3, "digital camera" }, { -1, NULL }
 };
 
-static LabelTable ExifSceneType_table[] = {
+static LabelIndex ExifSceneType_table[] = {
     { 1, "directly photographed" }, { -1, NULL }
 };
 
-static LabelTable ExifExposureMode_table[] = {
+static LabelIndex ExifExposureMode_table[] = {
     { 0, "auto" }, { 1, "manual" }, { 2, "auto-bracket" }, { -1, NULL }
 };
 
-static LabelTable ExifWhiteBalance_table[] = {
+static LabelIndex ExifWhiteBalance_table[] = {
     { 0, "auto" }, { 1, "manual" }, { -1, NULL }
 };
 
-static LabelTable ExifGainControl_table[] = {
+static LabelIndex ExifGainControl_table[] = {
     { 0, "none" }, { 1, "low gain up" }, { 2, "high gain up" }, 
     { 3, "low gain down" }, { 4, "high gain down" },
     { -1, NULL }
 };
 
-static LabelTable yesno_table[] = {
+static LabelIndex ExifSensitivityType_table[] = {
+    { 0, "unknown" }, { 1, "standard output sensitivity" },
+    { 2, "recommended exposure index" },
+    { 3, "ISO speed" },
+    { 4, "standard output sensitivity and recommended exposure index" },
+    { 5, "standard output sensitivity and ISO speed" },
+    { 6, "recommended exposure index and ISO speed" },
+    { 7, "standard output sensitivity and recommended exposure index and ISO speed" },
+    { -1, NULL }
+};
+
+static LabelIndex yesno_table[] = {
     { 0, "no" }, { 1, "yes" }, { -1, NULL }
 };
 
-static LabelTable softhard_table[] = {
+static LabelIndex softhard_table[] = {
     { 0, "normal" }, { 1, "soft" }, { 2, "hard" }, { -1, NULL }
 };
 
-static LabelTable lowhi_table[] = {
+static LabelIndex lowhi_table[] = {
     { 0, "normal" }, { 1, "low" }, { 2, "high" }, { -1, NULL }
 };
 
-static LabelTable GPSAltitudeRef_table[] = {
+static LabelIndex GPSAltitudeRef_table[] = {
     { 0, "above sea level" }, { 1, "below sea level" }, { -1, NULL }
 };
 
-static LabelTable GPSStatus_table[] = {
+static LabelIndex GPSStatus_table[] = {
     { 'A', "measurement active" }, { 'V', "measurement void" },
     { -1, NULL }
 };
 
-static LabelTable GPSMeasureMode_table[] = {
+static LabelIndex GPSMeasureMode_table[] = {
     { '2', "2-D" }, { '3', "3-D" }, { -1, NULL }
 };
 
-static LabelTable GPSSpeedRef_table[] = {
+static LabelIndex GPSSpeedRef_table[] = {
     { 'K', "km/hour" }, { 'M', "miles/hour" }, { 'N', "knots" }, 
     { -1, NULL }
 };
 
-static LabelTable GPSDestDistanceRef_table[] = {
+static LabelIndex GPSDestDistanceRef_table[] = {
     { 'K', "km" }, { 'M', "miles" }, { 'N', "nautical miles" },
     { -1, NULL }
 };
 
-static LabelTable magnetic_table[] = {
+static LabelIndex magnetic_table[] = {
     { 'T', "true north" }, { 'M', "magnetic north" }, { -1, NULL }
 };
 
-typedef std::string (*ExplainerFunc) (const ParamValue &p, 
-                                      const void *extradata);
-
-struct ExplanationTableEntry {
-    const char    *oiioname;
-    ExplainerFunc  explainer;
-    const void    *extradata;
-};
 
 static ExplanationTableEntry explanation[] = {
     { "ResolutionUnit", explain_labeltable, resunit_table },
@@ -722,6 +722,7 @@ static ExplanationTableEntry explanation[] = {
     { "Exif:Saturation", explain_labeltable, lowhi_table },
     { "Exif:Sharpness", explain_labeltable, softhard_table },
     { "Exif:SubjectDistanceRange", explain_labeltable, ExifSubjectDistanceRange_table },
+    { "Exif:SensitivityType", explain_labeltable, ExifSensitivityType_table },
     { "GPS:AltitudeRef", explain_labeltable, GPSAltitudeRef_table },
     { "GPS:Altitude", explain_justprint, "m" },
     { "GPS:Status", explain_labeltable, GPSStatus_table },
@@ -732,8 +733,8 @@ static ExplanationTableEntry explanation[] = {
     { "GPS:DestBearingRef", explain_labeltable, magnetic_table },
     { "GPS:DestDistanceRef", explain_labeltable, GPSDestDistanceRef_table },
     { "GPS:Differential", explain_labeltable, yesno_table },
-    { NULL, NULL, NULL }
-}; 
+    { nullptr, nullptr, nullptr }
+};
 
 } // end anon namespace
 
@@ -746,23 +747,34 @@ ImageSpec::metadata_val (const ParamValue &p, bool human)
 
     // ParamValue::get_string() doesn't escape or double-quote single
     // strings, so we need to correct for that here.
-    if (p.type() == TypeString && p.nvalues() == 1)
+    TypeDesc ptype = p.type();
+    if (ptype == TypeString && p.nvalues() == 1)
         out = Strutil::format ("\"%s\"", Strutil::escape_chars(out));
     if (human) {
+        const ExplanationTableEntry *exp = nullptr;
+        for (const auto& e : explanation)
+            if (Strutil::iequals (e.oiioname, p.name()))
+                exp = &e;
         std::string nice;
-        for (int e = 0;  explanation[e].oiioname;  ++e) {
-            if (! strcmp (explanation[e].oiioname, p.name().c_str()) &&
-                explanation[e].explainer) {
-                nice = explanation[e].explainer (p, explanation[e].extradata);
-                break;
+        if (!exp && Strutil::istarts_with (p.name(), "Canon:")) {
+            for (const auto& e : canon_explanation_table())
+                if (Strutil::iequals (e.oiioname, p.name()))
+                    exp = &e;
+        }
+        if (exp)
+            nice = exp->explainer (p, exp->extradata);
+        if (ptype.elementtype() == TypeRational) {
+            for (int i = 0, n = (int)ptype.numelements(); i < n; ++i) {
+                if (i)
+                    nice += ", ";
+                int num = p.get<int>(2*i+0), den = p.get<int>(2*i+1);
+                if (den)
+                    nice += Strutil::format ("%g", float(num)/float(den));
+                else
+                    nice += "inf";
             }
         }
-        if (p.type() == TypeRational) {
-            int num = p.get<int>(0), den = p.get<int>(1);
-            if (den)
-                nice = Strutil::format ("%g", float(num)/float(den));
-        }
-        if (p.type() == TypeTimeCode) {
+        if (ptype == TypeTimeCode) {
             Imf::TimeCode tc = *reinterpret_cast<const Imf::TimeCode *>(p.data());
             nice = Strutil::format ("%02d:%02d:%02d:%02d", tc.hours(),
                                     tc.minutes(), tc.seconds(), tc.frame());

--- a/src/libOpenImageIO/xmp.cpp
+++ b/src/libOpenImageIO/xmp.cpp
@@ -37,6 +37,7 @@
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imageio.h>
+#include <OpenImageIO/tiffutils.h>
 
 extern "C" {
 #include "tiff.h"

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -303,7 +303,15 @@ ParamValue::get_string (int maxsize) const
             formatType< int >(*this, n, "%d", out);
         }
     } else if (element.basetype == TypeDesc::UINT) {
-        formatType< unsigned int >(*this, n, "%u", out);
+        if (element.vecsemantics == TypeDesc::RATIONAL && element.aggregate == TypeDesc::VEC2) {
+            const int *val = (const int *)data();
+            for (int i = 0;  i < n;  ++i, val += 2) {
+                if (i) out += ", ";
+                out += Strutil::format ("%d/%d", val[0], val[1]);
+            }
+        } else {
+            formatType< unsigned int >(*this, n, "%u", out);
+        }
     } else if (element.basetype == TypeDesc::UINT16) {
         formatType< unsigned short >(*this, n, "%u", out);
     } else if (element.basetype == TypeDesc::INT16) {

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4814,6 +4814,7 @@ do_echo (int argc, const char *argv[])
     std::cout << message;
     for (int i = 0; i < newline; ++i)
         std::cout << '\n';
+    std::cout.flush();
     ot.printed_info = true;
     return 0;
 }

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -42,6 +42,7 @@
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/sysutil.h>
+#include <OpenImageIO/tiffutils.h>
 
 
 #define OIIO_LIBPNG_VERSION (PNG_LIBPNG_VER_MAJOR*10000 + PNG_LIBPNG_VER_MINOR*100 + PNG_LIBPNG_VER_RELEASE)

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -35,6 +35,8 @@
 #include <functional>
 #include <memory>
 
+#include <OpenImageIO/tiffutils.h>
+
 #include "psd_pvt.h"
 #include "jpeg_memory_src.h"
 

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -28,11 +28,15 @@
   (This is the Modified BSD License)
 */
 
+#include <algorithm>
+#include <iostream>
+#include <ctime>       /* time_t, struct tm, gmtime */
+
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/strutil.h>
-#include <iostream>
-#include <ctime>       /* time_t, struct tm, gmtime */
+#include <OpenImageIO/tiffutils.h>
+
 #include <libraw/libraw.h>
 #include <libraw/libraw_version.h>
 
@@ -68,7 +72,6 @@ private:
     std::string m_filename;
 
     bool do_unpack();
-    void read_tiff_metadata (const std::string &filename);
 };
 
 
@@ -106,11 +109,92 @@ RawInput::open (const std::string &name, ImageSpec &newspec)
 
 
 
+static void
+exif_parser_cb (ImageSpec* spec, int tag, int tifftype, int len,
+                unsigned int byteorder, LibRaw_abstract_datastream* ifp)
+{
+    // Oy, the data offsets are all going to be relative to the start of the
+    // stream, not relative to our current position and data block. So we
+    // need to remember that offset and pass its negative as the
+    // offset_adjustment to the handler.
+    size_t streampos = ifp->tell();
+    // std::cerr << "Stream position " << streampos << "\n";
+
+    TypeDesc type = tiff_datatype_to_typedesc (TIFFDataType(tifftype), size_t(len));
+    const TagInfo* taginfo = tag_lookup ("Exif", tag);
+    if (! taginfo) {
+        // Strutil::fprintf (std::cerr, "NO TAGINFO FOR CALLBACK tag=%d (0x%x): tifftype=%d,len=%d (%s), byteorder=0x%x\n",
+        //                   tag, tag, tifftype, len, type, byteorder);
+        return;
+    }
+    if (type.size() >= (1<<20))
+        return;   // sanity check -- too much memory
+    size_t size = tiff_data_size(TIFFDataType(tifftype)) * len;
+    std::vector<unsigned char> buf (size);
+    ifp->read (buf.data(), size, 1);
+
+    // debug scaffolding
+    // Strutil::fprintf (std::cerr, "CALLBACK tag=%s: tifftype=%d,len=%d (%s), byteorder=0x%x\n",
+    //                   taginfo->name, tifftype, len, type, byteorder);
+    // for (int i = 0; i < std::min(16UL,size); ++i) {
+    //     if (buf[i] >= ' ' && buf[i] < 128)
+    //         std::cerr << char(buf[i]);
+    //     Strutil::fprintf (std::cerr, "(%d) ", int(buf[i]));
+    // }
+    // std::cerr << "\n";
+
+    bool swab = (littleendian() != (byteorder == 0x4949));
+    if (swab) {
+        if (type.basetype == TypeDesc::UINT16)
+            swap_endian ((uint16_t *)buf.data(), len);
+        if (type.basetype == TypeDesc::UINT32)
+            swap_endian ((uint32_t *)buf.data(), len);
+    }
+
+    if (taginfo->handler) {
+        TIFFDirEntry dir;
+        dir.tdir_tag = uint16_t(tag);
+        dir.tdir_type = uint16_t(tifftype);
+        dir.tdir_count = uint32_t(len);
+        dir.tdir_offset = 0;
+        taginfo->handler (*taginfo, dir, buf, *spec, swab, -int(streampos));
+        // std::cerr << "HANDLED " << taginfo->name << "\n";
+        return;
+    }
+    if (taginfo->tifftype == TIFF_NOTYPE)
+        return;   // skip
+    if (tifftype == TIFF_RATIONAL || tifftype == TIFF_SRATIONAL) {
+        spec->attribute (taginfo->name, type, buf.data());
+        return;
+    }
+    if (type.basetype == TypeDesc::UINT16) {
+        spec->attribute (taginfo->name, type, buf.data());
+        return;
+    }
+    if (type.basetype == TypeDesc::UINT32) {
+        spec->attribute (taginfo->name, type, buf.data());
+        return;
+    }
+    if (type == TypeString) {
+        spec->attribute (taginfo->name, string_view((char*)buf.data(), size));
+        return;
+    }
+    // Strutil::fprintf (std::cerr, "RAW metadata NOT HANDLED: tag=%s: tifftype=%d,len=%d (%s), byteorder=0x%x\n",
+    //                   taginfo->name, tifftype, len, type, byteorder);
+}
+
+
+
 bool
 RawInput::open (const std::string &name, ImageSpec &newspec,
                 const ImageSpec &config)
 {
     int ret;
+
+    // Temp spec for exif parser callback to dump into
+    ImageSpec exifspec;
+    m_processor.set_exifparser_handler ((exif_parser_callback)exif_parser_cb,
+                                        &exifspec);
 
     // open the image
     m_filename = name;
@@ -138,6 +222,8 @@ RawInput::open (const std::string &name, ImageSpec &newspec,
                        m_processor.imgdata.sizes.iheight,
                        3, // LibRaw should only give us 3 channels
                        TypeDesc::UINT16);
+    // Move the exif attribs we already read into the spec we care about
+    m_spec.extra_attribs.swap (exifspec.extra_attribs);
 
     // Output 16 bit images
     m_processor.imgdata.params.output_bps = 16;
@@ -332,39 +418,9 @@ RawInput::open (const std::string &name, ImageSpec &newspec,
 
     // FIXME -- thumbnail possibly in m_processor.imgdata.thumbnail
 
-    read_tiff_metadata (name);
-
     // Copy the spec to return to the user
     newspec = m_spec;
     return true;
-}
-
-
-
-void
-RawInput::read_tiff_metadata (const std::string &filename)
-{
-    // Many of these raw formats look just like TIFF files, and we can use
-    // that to extract a bunch of extra Exif metadata and thumbnail.
-    ImageInput *in = ImageInput::create ("tiff");
-    if (! in) {
-        (void) OIIO::geterror();  // eat the error
-        return;
-    }
-    ImageSpec newspec;
-    bool ok = in->open (filename, newspec);
-    if (ok) {
-        // Transfer "Exif:" metadata to the raw spec.
-        for (ParamValueList::const_iterator p = newspec.extra_attribs.begin();
-             p != newspec.extra_attribs.end();  ++p) {
-            if (Strutil::istarts_with (p->name().c_str(), "Exif:")) {
-                m_spec.attribute (p->name().c_str(), p->type(), p->data());
-            }
-        }
-    }
-
-    in->close ();
-    delete in;
 }
 
 

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -38,14 +38,6 @@
 
 #include <tiffio.h>
 
-// Some EXIF tags that don't seem to be in tiff.h
-#ifndef EXIFTAG_SECURITYCLASSIFICATION
-#define EXIFTAG_SECURITYCLASSIFICATION 37394
-#endif
-#ifndef EXIFTAG_IMAGEHISTORY
-#define EXIFTAG_IMAGEHISTORY 37395
-#endif
-
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/filesystem.h>
@@ -53,6 +45,7 @@
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/timer.h>
 #include <OpenImageIO/fmath.h>
+#include <OpenImageIO/tiffutils.h>
 
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
@@ -735,9 +728,9 @@ TIFFOutput::write_exif_data ()
         int tag, tifftype, count;
         if (exif_tag_lookup (p.name(), tag, tifftype, count) &&
                 tifftype != TIFF_NOTYPE) {
-            if (tag == EXIFTAG_SECURITYCLASSIFICATION ||
-                tag == EXIFTAG_IMAGEHISTORY ||
-                tag == EXIFTAG_ISOSPEEDRATINGS)
+            if (tag == EXIF_SECURITYCLASSIFICATION ||
+                tag == EXIF_IMAGEHISTORY ||
+                tag == EXIF_PHOTOGRAPHICSENSITIVITY)
                 continue;   // libtiff doesn't understand these
             any_exif = true;
             break;
@@ -769,9 +762,9 @@ TIFFOutput::write_exif_data ()
         int tag, tifftype, count;
         if (exif_tag_lookup (p.name(), tag, tifftype, count) &&
                 tifftype != TIFF_NOTYPE) {
-            if (tag == EXIFTAG_SECURITYCLASSIFICATION ||
-                tag == EXIFTAG_IMAGEHISTORY ||
-                tag == EXIFTAG_ISOSPEEDRATINGS)
+            if (tag == EXIF_SECURITYCLASSIFICATION ||
+                tag == EXIF_IMAGEHISTORY ||
+                tag == EXIF_PHOTOGRAPHICSENSITIVITY)
                 continue;   // libtiff doesn't understand these
             bool ok = false;
             if (tifftype == TIFF_ASCII) {

--- a/testsuite/gpsread/ref/out-alt.txt
+++ b/testsuite/gpsread/ref/out-alt.txt
@@ -12,12 +12,15 @@ Reading ../../../../../oiio-images/tahoe-gps.jpg
     ResolutionUnit: "none"
     Software: "title;va"
     Exif:YCbCrPositioning: 1
+    Exif:ExifVersion: "0220"
     Exif:DateTimeOriginal: "2009:02:21 08:32:04"
     Exif:DateTimeDigitized: "2009:02:21 08:32:04"
+    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 2048
     Exif:PixelYDimension: 1536
     Exif:WhiteBalance: 0 (auto)
+    GPS:VersionID: 2, 2, 0, 0
     GPS:LatitudeRef: "N"
     GPS:Latitude: 39, 18, 24.4
     GPS:LongitudeRef: "W"
@@ -27,3 +30,32 @@ Reading ../../../../../oiio-images/tahoe-gps.jpg
     GPS:TimeStamp: 17, 56, 33
     GPS:MapDatum: "WGS-84"
     GPS:DateStamp: "1915:08:08"
+Reading tahoe-gps.jpg
+tahoe-gps.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
+    SHA-1: 2623446988E34395C6B0A4AA4FC75107C708BF18
+    channel list: R, G, B
+    oiio:ColorSpace: "sRGB"
+    jpeg:subsampling: "4:2:0"
+    Make: "HTC"
+    Model: "T-Mobile G1"
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    Exif:YCbCrPositioning: 1
+    Exif:ExifVersion: "0230"
+    Exif:FlashPixVersion: "0100"
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 2048
+    Exif:PixelYDimension: 1536
+    Exif:WhiteBalance: 0 (auto)
+    GPS:VersionID: 2, 2, 0, 0
+    GPS:LatitudeRef: "N"
+    GPS:Latitude: 39, 18, 24.4
+    GPS:LongitudeRef: "W"
+    GPS:Longitude: 120, 20, 6.25
+    GPS:AltitudeRef: 0 (above sea level)
+    GPS:Altitude: 0 (0 m)
+    GPS:TimeStamp: 17, 56, 33
+    GPS:MapDatum: "WGS-84"
+    GPS:DateStamp: "1915:08:08"
+    ResolutionUnit: "none"

--- a/testsuite/gpsread/ref/out.txt
+++ b/testsuite/gpsread/ref/out.txt
@@ -12,12 +12,15 @@ Reading ../../../../../oiio-images/tahoe-gps.jpg
     ResolutionUnit: "none"
     Software: "title;va"
     Exif:YCbCrPositioning: 1
+    Exif:ExifVersion: "0220"
     Exif:DateTimeOriginal: "2009:02:21 08:32:04"
     Exif:DateTimeDigitized: "2009:02:21 08:32:04"
+    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 2048
     Exif:PixelYDimension: 1536
     Exif:WhiteBalance: 0 (auto)
+    GPS:VersionID: 2, 2, 0, 0
     GPS:LatitudeRef: "N"
     GPS:Latitude: 39, 18, 24.4
     GPS:LongitudeRef: "W"
@@ -27,3 +30,32 @@ Reading ../../../../../oiio-images/tahoe-gps.jpg
     GPS:TimeStamp: 17, 56, 33
     GPS:MapDatum: "WGS-84"
     GPS:DateStamp: "1915:08:08"
+Reading tahoe-gps.jpg
+tahoe-gps.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
+    SHA-1: 2623446988E34395C6B0A4AA4FC75107C708BF18
+    channel list: R, G, B
+    oiio:ColorSpace: "sRGB"
+    jpeg:subsampling: "4:2:0"
+    Make: "HTC"
+    Model: "T-Mobile G1"
+    Orientation: 1 (normal)
+    XResolution: 72
+    YResolution: 72
+    Exif:YCbCrPositioning: 1
+    Exif:ExifVersion: "0230"
+    Exif:FlashPixVersion: "0100"
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 2048
+    Exif:PixelYDimension: 1536
+    Exif:WhiteBalance: 0 (auto)
+    GPS:VersionID: 2, 2, 0, 0
+    GPS:LatitudeRef: "N"
+    GPS:Latitude: 39, 18, 24.4
+    GPS:LongitudeRef: "W"
+    GPS:Longitude: 120, 20, 6.25
+    GPS:AltitudeRef: 0 (above sea level)
+    GPS:Altitude: 0 (0 m)
+    GPS:TimeStamp: 17, 56, 33
+    GPS:MapDatum: "WGS-84"
+    GPS:DateStamp: "1915:08:08"
+    ResolutionUnit: "none"

--- a/testsuite/gpsread/run.py
+++ b/testsuite/gpsread/run.py
@@ -1,3 +1,6 @@
 #!/usr/bin/env python
 
-command = info_command (parent + "/oiio-images/tahoe-gps.jpg")
+filename = (parent + "/oiio-images/tahoe-gps.jpg")
+command += info_command (filename)
+command += oiiotool (filename + " -o ./tahoe-gps.jpg")
+command += info_command ("tahoe-gps.jpg", safematch=True)

--- a/testsuite/oiiotool-attribs/ref/out.txt
+++ b/testsuite/oiiotool-attribs/ref/out.txt
@@ -9,10 +9,13 @@ nomake.jpg           : 2048 x 1536, 3 channel, uint8 jpeg
     XResolution: 72
     YResolution: 72
     Exif:YCbCrPositioning: 1
+    Exif:ExifVersion: "0230"
+    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 2048
     Exif:PixelYDimension: 1536
     Exif:WhiteBalance: 0 (auto)
+    GPS:VersionID: 2, 2, 0, 0
     GPS:LatitudeRef: "N"
     GPS:Latitude: 39, 18, 24.4
     GPS:LongitudeRef: "W"
@@ -35,6 +38,8 @@ nogps.jpg            : 2048 x 1536, 3 channel, uint8 jpeg
     XResolution: 72
     YResolution: 72
     Exif:YCbCrPositioning: 1
+    Exif:ExifVersion: "0230"
+    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 2048
     Exif:PixelYDimension: 1536
@@ -46,3 +51,5 @@ noattribs.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     channel list: R, G, B
     oiio:ColorSpace: "sRGB"
     jpeg:subsampling: "4:2:0"
+    Exif:ExifVersion: "0230"
+    Exif:FlashPixVersion: "0100"

--- a/testsuite/psd/ref/out-alt.txt
+++ b/testsuite/psd/ref/out-alt.txt
@@ -251,13 +251,9 @@ Reading ../../../../../oiio-images/psd_bitmap.psd
     thumbnail_height: 120
     thumbnail_nchannels: 3
     thumbnail_image: 90, 90, 90, 255, 255, 255, 255, 255, 255, 251, 251, 251, 250, 250, 250, 255, ... [57600 x uint8]
-    Exif:ImageWidth: 3648
-    Exif:ImageLength: 2736
-    Exif:Photometric: 2
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
-    Exif:SamplesPerPixel: 3
     Software: "Adobe Photoshop CS5.1 Windows"
     DateTime: "2007-01-18T15:49:21"
     Artist: "Daniel Wyatt"
@@ -265,17 +261,19 @@ Reading ../../../../../oiio-images/psd_bitmap.psd
     ExposureTime: 0.0166667
     FNumber: 3.5
     Exif:PhotographicSensitivity: 75
+    Exif:ExifVersion: "0220"
     Exif:DateTimeOriginal: "2007:01:18 15:49:21"
     Exif:DateTimeDigitized: "2007:01:18 15:49:21"
     Exif:CompressedBitsPerPixel: 5
     Exif:ShutterSpeedValue: 5.90625 (1/59 s)
-    Exif:ApertureValue: 3.625 (f/3.5125)
+    Exif:ApertureValue: 3.625 (f/3.5)
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.79796)
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
     Exif:SubjectDistance: 3.39 (3.39 m)
     Exif:MeteringMode: 5 (pattern)
     Exif:Flash: 16 (no flash, flash supression)
     Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 65535
     Exif:PixelXDimension: 320
     Exif:PixelYDimension: 240
@@ -322,13 +320,9 @@ Reading ../../../../../oiio-images/psd_indexed_trans.psd
     thumbnail_height: 120
     thumbnail_nchannels: 3
     thumbnail_image: 166, 170, 173, 203, 207, 210, 225, 229, 232, 228, 232, 235, 232, 236, 239, 230, ... [57600 x uint8]
-    Exif:ImageWidth: 3648
-    Exif:ImageLength: 2736
-    Exif:Photometric: 2
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
-    Exif:SamplesPerPixel: 3
     Software: "Adobe Photoshop CS5.1 Windows"
     DateTime: "2007-01-18T15:49:21"
     Artist: "Daniel Wyatt"
@@ -336,17 +330,19 @@ Reading ../../../../../oiio-images/psd_indexed_trans.psd
     ExposureTime: 0.0166667
     FNumber: 3.5
     Exif:PhotographicSensitivity: 75
+    Exif:ExifVersion: "0220"
     Exif:DateTimeOriginal: "2007:01:18 15:49:21"
     Exif:DateTimeDigitized: "2007:01:18 15:49:21"
     Exif:CompressedBitsPerPixel: 5
     Exif:ShutterSpeedValue: 5.90625 (1/59 s)
-    Exif:ApertureValue: 3.625 (f/3.5125)
+    Exif:ApertureValue: 3.625 (f/3.5)
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.79796)
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
     Exif:SubjectDistance: 3.39 (3.39 m)
     Exif:MeteringMode: 5 (pattern)
     Exif:Flash: 16 (no flash, flash supression)
     Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 320
     Exif:PixelYDimension: 240
@@ -395,13 +391,9 @@ Reading ../../../../../oiio-images/psd_rgb_8.psd
     thumbnail_height: 120
     thumbnail_nchannels: 3
     thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ... [57600 x uint8]
-    Exif:ImageWidth: 3648
-    Exif:ImageLength: 2736
-    Exif:Photometric: 2
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
-    Exif:SamplesPerPixel: 3
     Software: "Adobe Photoshop CS5.1 Windows"
     DateTime: "2007-01-18T15:49:21"
     Artist: "Daniel Wyatt"
@@ -409,17 +401,19 @@ Reading ../../../../../oiio-images/psd_rgb_8.psd
     ExposureTime: 0.0166667
     FNumber: 3.5
     Exif:PhotographicSensitivity: 75
+    Exif:ExifVersion: "0220"
     Exif:DateTimeOriginal: "2007:01:18 15:49:21"
     Exif:DateTimeDigitized: "2007:01:18 15:49:21"
     Exif:CompressedBitsPerPixel: 5
     Exif:ShutterSpeedValue: 5.90625 (1/59 s)
-    Exif:ApertureValue: 3.625 (f/3.5125)
+    Exif:ApertureValue: 3.625 (f/3.5)
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.79796)
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
     Exif:SubjectDistance: 3.39 (3.39 m)
     Exif:MeteringMode: 5 (pattern)
     Exif:Flash: 16 (no flash, flash supression)
     Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 320
     Exif:PixelYDimension: 240
@@ -468,13 +462,9 @@ Reading ../../../../../oiio-images/psd_rgb_16.psd
     thumbnail_height: 120
     thumbnail_nchannels: 3
     thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ... [57600 x uint8]
-    Exif:ImageWidth: 3648
-    Exif:ImageLength: 2736
-    Exif:Photometric: 2
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
-    Exif:SamplesPerPixel: 3
     Software: "Adobe Photoshop CS5.1 Windows"
     DateTime: "2007-01-18T15:49:21"
     Artist: "Daniel Wyatt"
@@ -482,17 +472,19 @@ Reading ../../../../../oiio-images/psd_rgb_16.psd
     ExposureTime: 0.0166667
     FNumber: 3.5
     Exif:PhotographicSensitivity: 75
+    Exif:ExifVersion: "0220"
     Exif:DateTimeOriginal: "2007:01:18 15:49:21"
     Exif:DateTimeDigitized: "2007:01:18 15:49:21"
     Exif:CompressedBitsPerPixel: 5
     Exif:ShutterSpeedValue: 5.90625 (1/59 s)
-    Exif:ApertureValue: 3.625 (f/3.5125)
+    Exif:ApertureValue: 3.625 (f/3.5)
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.79796)
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
     Exif:SubjectDistance: 3.39 (3.39 m)
     Exif:MeteringMode: 5 (pattern)
     Exif:Flash: 16 (no flash, flash supression)
     Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 320
     Exif:PixelYDimension: 240
@@ -541,13 +533,9 @@ Reading ../../../../../oiio-images/psd_rgb_32.psd
     thumbnail_height: 120
     thumbnail_nchannels: 3
     thumbnail_image: 217, 225, 227, 219, 227, 229, 224, 229, 232, 228, 233, 236, 231, 236, 239, 233, ... [57600 x uint8]
-    Exif:ImageWidth: 3648
-    Exif:ImageLength: 2736
-    Exif:Photometric: 2
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
-    Exif:SamplesPerPixel: 3
     Software: "Adobe Photoshop CS5.1 Windows"
     DateTime: "2007-01-18T15:49:21"
     Artist: "Daniel Wyatt"
@@ -555,17 +543,19 @@ Reading ../../../../../oiio-images/psd_rgb_32.psd
     ExposureTime: 0.0166667
     FNumber: 3.5
     Exif:PhotographicSensitivity: 75
+    Exif:ExifVersion: "0220"
     Exif:DateTimeOriginal: "2007:01:18 15:49:21"
     Exif:DateTimeDigitized: "2007:01:18 15:49:21"
     Exif:CompressedBitsPerPixel: 5
     Exif:ShutterSpeedValue: 5.90625 (1/59 s)
-    Exif:ApertureValue: 3.625 (f/3.5125)
+    Exif:ApertureValue: 3.625 (f/3.5)
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.79796)
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
     Exif:SubjectDistance: 3.39 (3.39 m)
     Exif:MeteringMode: 5 (pattern)
     Exif:Flash: 16 (no flash, flash supression)
     Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 65535
     Exif:PixelXDimension: 320
     Exif:PixelYDimension: 240

--- a/testsuite/psd/ref/out.txt
+++ b/testsuite/psd/ref/out.txt
@@ -251,13 +251,9 @@ Reading ../../../../../oiio-images/psd_bitmap.psd
     thumbnail_height: 120
     thumbnail_nchannels: 3
     thumbnail_image: 90, 90, 90, 255, 255, 255, 255, 255, 255, 251, 251, 251, 250, 250, 250, 255, ... [57600 x uint8]
-    Exif:ImageWidth: 3648
-    Exif:ImageLength: 2736
-    Exif:Photometric: 2
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
-    Exif:SamplesPerPixel: 3
     Software: "Adobe Photoshop CS5.1 Windows"
     DateTime: "2007-01-18T15:49:21"
     Artist: "Daniel Wyatt"
@@ -265,17 +261,19 @@ Reading ../../../../../oiio-images/psd_bitmap.psd
     ExposureTime: 0.0166667
     FNumber: 3.5
     Exif:PhotographicSensitivity: 75
+    Exif:ExifVersion: "0220"
     Exif:DateTimeOriginal: "2007:01:18 15:49:21"
     Exif:DateTimeDigitized: "2007:01:18 15:49:21"
     Exif:CompressedBitsPerPixel: 5
     Exif:ShutterSpeedValue: 5.90625 (1/59 s)
-    Exif:ApertureValue: 3.625 (f/3.5125)
+    Exif:ApertureValue: 3.625 (f/3.5)
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.79796)
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
     Exif:SubjectDistance: 3.39 (3.39 m)
     Exif:MeteringMode: 5 (pattern)
     Exif:Flash: 16 (no flash, flash supression)
     Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 65535
     Exif:PixelXDimension: 320
     Exif:PixelYDimension: 240
@@ -322,13 +320,9 @@ Reading ../../../../../oiio-images/psd_indexed_trans.psd
     thumbnail_height: 120
     thumbnail_nchannels: 3
     thumbnail_image: 166, 170, 173, 203, 207, 210, 225, 229, 232, 228, 232, 235, 232, 236, 239, 230, ... [57600 x uint8]
-    Exif:ImageWidth: 3648
-    Exif:ImageLength: 2736
-    Exif:Photometric: 2
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
-    Exif:SamplesPerPixel: 3
     Software: "Adobe Photoshop CS5.1 Windows"
     DateTime: "2007-01-18T15:49:21"
     Artist: "Daniel Wyatt"
@@ -336,17 +330,19 @@ Reading ../../../../../oiio-images/psd_indexed_trans.psd
     ExposureTime: 0.0166667
     FNumber: 3.5
     Exif:PhotographicSensitivity: 75
+    Exif:ExifVersion: "0220"
     Exif:DateTimeOriginal: "2007:01:18 15:49:21"
     Exif:DateTimeDigitized: "2007:01:18 15:49:21"
     Exif:CompressedBitsPerPixel: 5
     Exif:ShutterSpeedValue: 5.90625 (1/59 s)
-    Exif:ApertureValue: 3.625 (f/3.5125)
+    Exif:ApertureValue: 3.625 (f/3.5)
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.79796)
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
     Exif:SubjectDistance: 3.39 (3.39 m)
     Exif:MeteringMode: 5 (pattern)
     Exif:Flash: 16 (no flash, flash supression)
     Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 320
     Exif:PixelYDimension: 240
@@ -395,13 +391,9 @@ Reading ../../../../../oiio-images/psd_rgb_8.psd
     thumbnail_height: 120
     thumbnail_nchannels: 3
     thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ... [57600 x uint8]
-    Exif:ImageWidth: 3648
-    Exif:ImageLength: 2736
-    Exif:Photometric: 2
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
-    Exif:SamplesPerPixel: 3
     Software: "Adobe Photoshop CS5.1 Windows"
     DateTime: "2007-01-18T15:49:21"
     Artist: "Daniel Wyatt"
@@ -409,17 +401,19 @@ Reading ../../../../../oiio-images/psd_rgb_8.psd
     ExposureTime: 0.0166667
     FNumber: 3.5
     Exif:PhotographicSensitivity: 75
+    Exif:ExifVersion: "0220"
     Exif:DateTimeOriginal: "2007:01:18 15:49:21"
     Exif:DateTimeDigitized: "2007:01:18 15:49:21"
     Exif:CompressedBitsPerPixel: 5
     Exif:ShutterSpeedValue: 5.90625 (1/59 s)
-    Exif:ApertureValue: 3.625 (f/3.5125)
+    Exif:ApertureValue: 3.625 (f/3.5)
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.79796)
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
     Exif:SubjectDistance: 3.39 (3.39 m)
     Exif:MeteringMode: 5 (pattern)
     Exif:Flash: 16 (no flash, flash supression)
     Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 320
     Exif:PixelYDimension: 240
@@ -468,13 +462,9 @@ Reading ../../../../../oiio-images/psd_rgb_16.psd
     thumbnail_height: 120
     thumbnail_nchannels: 3
     thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ... [57600 x uint8]
-    Exif:ImageWidth: 3648
-    Exif:ImageLength: 2736
-    Exif:Photometric: 2
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
-    Exif:SamplesPerPixel: 3
     Software: "Adobe Photoshop CS5.1 Windows"
     DateTime: "2007-01-18T15:49:21"
     Artist: "Daniel Wyatt"
@@ -482,17 +472,19 @@ Reading ../../../../../oiio-images/psd_rgb_16.psd
     ExposureTime: 0.0166667
     FNumber: 3.5
     Exif:PhotographicSensitivity: 75
+    Exif:ExifVersion: "0220"
     Exif:DateTimeOriginal: "2007:01:18 15:49:21"
     Exif:DateTimeDigitized: "2007:01:18 15:49:21"
     Exif:CompressedBitsPerPixel: 5
     Exif:ShutterSpeedValue: 5.90625 (1/59 s)
-    Exif:ApertureValue: 3.625 (f/3.5125)
+    Exif:ApertureValue: 3.625 (f/3.5)
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.79796)
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
     Exif:SubjectDistance: 3.39 (3.39 m)
     Exif:MeteringMode: 5 (pattern)
     Exif:Flash: 16 (no flash, flash supression)
     Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 320
     Exif:PixelYDimension: 240
@@ -541,13 +533,9 @@ Reading ../../../../../oiio-images/psd_rgb_32.psd
     thumbnail_height: 120
     thumbnail_nchannels: 3
     thumbnail_image: 217, 225, 227, 221, 226, 229, 224, 229, 232, 228, 233, 236, 231, 236, 239, 233, ... [57600 x uint8]
-    Exif:ImageWidth: 3648
-    Exif:ImageLength: 2736
-    Exif:Photometric: 2
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
-    Exif:SamplesPerPixel: 3
     Software: "Adobe Photoshop CS5.1 Windows"
     DateTime: "2007-01-18T15:49:21"
     Artist: "Daniel Wyatt"
@@ -555,17 +543,19 @@ Reading ../../../../../oiio-images/psd_rgb_32.psd
     ExposureTime: 0.0166667
     FNumber: 3.5
     Exif:PhotographicSensitivity: 75
+    Exif:ExifVersion: "0220"
     Exif:DateTimeOriginal: "2007:01:18 15:49:21"
     Exif:DateTimeDigitized: "2007:01:18 15:49:21"
     Exif:CompressedBitsPerPixel: 5
     Exif:ShutterSpeedValue: 5.90625 (1/59 s)
-    Exif:ApertureValue: 3.625 (f/3.5125)
+    Exif:ApertureValue: 3.625 (f/3.5)
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.79796)
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
     Exif:SubjectDistance: 3.39 (3.39 m)
     Exif:MeteringMode: 5 (pattern)
     Exif:Flash: 16 (no flash, flash supression)
     Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 65535
     Exif:PixelXDimension: 320
     Exif:PixelYDimension: 240

--- a/testsuite/tiff-suite/ref/out-alt.txt
+++ b/testsuite/tiff-suite/ref/out-alt.txt
@@ -47,6 +47,7 @@ Reading ../../../../../libtiffpic/dscf0013.tif
     Software: "Digital Camera MX-2900ZOOM Ver1.00"
     Copyright: "          "
     DateTime: "2004:11:10 00:00:31"
+    Exif:YCbCrPositioning: 2
     tiff:PhotometricInterpretation: 6
     tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
@@ -60,10 +61,10 @@ Reading ../../../../../libtiffpic/dscf0013.tif
     Exif:DateTimeOriginal: "2004:11:10 00:00:31"
     Exif:DateTimeDigitized: "2004:11:10 00:00:31"
     Exif:ShutterSpeedValue: 6.5 (1/90 s)
-    Exif:ApertureValue: 3.53 (f/3.39874)
+    Exif:ApertureValue: 3.53 (f/3.4)
     Exif:BrightnessValue: -0.4
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 3.53 (f/3.39874)
+    Exif:MaxApertureValue: 3.53 (f/3.4)
     Exif:MeteringMode: 1 (average)
     Exif:Flash: 1 (flash fired)
     Exif:FocalLength: 7.4 (7.4 mm)
@@ -81,6 +82,7 @@ Reading ../../../../../libtiffpic/dscf0013.tif
     XResolution: 72
     YResolution: 72
     ResolutionUnit: "in"
+    Exif:YCbCrPositioning: 2
     tiff:PhotometricInterpretation: 6
     tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
@@ -226,7 +228,7 @@ Reading ../../../../../libtiffpic/pc260001.tif
     Exif:DateTimeOriginal: "2005:12:26 17:09:35"
     Exif:DateTimeDigitized: "2005:12:26 17:09:35"
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 3 (f/2.82843)
+    Exif:MaxApertureValue: 3 (f/2.8)
     Exif:MeteringMode: 5 (pattern)
     Exif:LightSource: 0 (unknown)
     Exif:Flash: 89 (flash fired, auto flash, red-eye reduction)
@@ -295,6 +297,7 @@ Reading ../../../../../libtiffpic/ycbcr-cat.tif
     oiio:BitsPerSample: 8
     ImageDescription: "YCbCr conversion of cat.tif"
     Orientation: 1 (normal)
+    Exif:YCbCrPositioning: 1
     tiff:PhotometricInterpretation: 6
     tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
@@ -313,6 +316,7 @@ Reading ../../../../../libtiffpic/smallliz.tif
     YResolution: 100
     ResolutionUnit: "in"
     Software: "HP IL v1.1"
+    Exif:YCbCrPositioning: 1
     tiff:PhotometricInterpretation: 6
     tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1

--- a/testsuite/tiff-suite/ref/out-jpeg9b.txt
+++ b/testsuite/tiff-suite/ref/out-jpeg9b.txt
@@ -47,6 +47,7 @@ Reading ../../../../../libtiffpic/dscf0013.tif
     Software: "Digital Camera MX-2900ZOOM Ver1.00"
     Copyright: "          "
     DateTime: "2004:11:10 00:00:31"
+    Exif:YCbCrPositioning: 2
     tiff:PhotometricInterpretation: 6
     tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
@@ -60,10 +61,10 @@ Reading ../../../../../libtiffpic/dscf0013.tif
     Exif:DateTimeOriginal: "2004:11:10 00:00:31"
     Exif:DateTimeDigitized: "2004:11:10 00:00:31"
     Exif:ShutterSpeedValue: 6.5 (1/90 s)
-    Exif:ApertureValue: 3.53 (f/3.39874)
+    Exif:ApertureValue: 3.53 (f/3.4)
     Exif:BrightnessValue: -0.4
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 3.53 (f/3.39874)
+    Exif:MaxApertureValue: 3.53 (f/3.4)
     Exif:MeteringMode: 1 (average)
     Exif:Flash: 1 (flash fired)
     Exif:FocalLength: 7.4 (7.4 mm)
@@ -81,6 +82,7 @@ Reading ../../../../../libtiffpic/dscf0013.tif
     XResolution: 72
     YResolution: 72
     ResolutionUnit: "in"
+    Exif:YCbCrPositioning: 2
     tiff:PhotometricInterpretation: 6
     tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
@@ -226,7 +228,7 @@ Reading ../../../../../libtiffpic/pc260001.tif
     Exif:DateTimeOriginal: "2005:12:26 17:09:35"
     Exif:DateTimeDigitized: "2005:12:26 17:09:35"
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 3 (f/2.82843)
+    Exif:MaxApertureValue: 3 (f/2.8)
     Exif:MeteringMode: 5 (pattern)
     Exif:LightSource: 0 (unknown)
     Exif:Flash: 89 (flash fired, auto flash, red-eye reduction)
@@ -295,6 +297,7 @@ Reading ../../../../../libtiffpic/ycbcr-cat.tif
     oiio:BitsPerSample: 8
     ImageDescription: "YCbCr conversion of cat.tif"
     Orientation: 1 (normal)
+    Exif:YCbCrPositioning: 1
     tiff:PhotometricInterpretation: 6
     tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
@@ -313,6 +316,7 @@ Reading ../../../../../libtiffpic/smallliz.tif
     YResolution: 100
     ResolutionUnit: "in"
     Software: "HP IL v1.1"
+    Exif:YCbCrPositioning: 1
     tiff:PhotometricInterpretation: 6
     tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1

--- a/testsuite/tiff-suite/ref/out.txt
+++ b/testsuite/tiff-suite/ref/out.txt
@@ -47,6 +47,7 @@ Reading ../../../../../libtiffpic/dscf0013.tif
     Software: "Digital Camera MX-2900ZOOM Ver1.00"
     Copyright: "          "
     DateTime: "2004:11:10 00:00:31"
+    Exif:YCbCrPositioning: 2
     tiff:PhotometricInterpretation: 6
     tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
@@ -60,10 +61,10 @@ Reading ../../../../../libtiffpic/dscf0013.tif
     Exif:DateTimeOriginal: "2004:11:10 00:00:31"
     Exif:DateTimeDigitized: "2004:11:10 00:00:31"
     Exif:ShutterSpeedValue: 6.5 (1/90 s)
-    Exif:ApertureValue: 3.53 (f/3.39874)
+    Exif:ApertureValue: 3.53 (f/3.4)
     Exif:BrightnessValue: -0.4
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 3.53 (f/3.39874)
+    Exif:MaxApertureValue: 3.53 (f/3.4)
     Exif:MeteringMode: 1 (average)
     Exif:Flash: 1 (flash fired)
     Exif:FocalLength: 7.4 (7.4 mm)
@@ -81,6 +82,7 @@ Reading ../../../../../libtiffpic/dscf0013.tif
     XResolution: 72
     YResolution: 72
     ResolutionUnit: "in"
+    Exif:YCbCrPositioning: 2
     tiff:PhotometricInterpretation: 6
     tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
@@ -226,7 +228,7 @@ Reading ../../../../../libtiffpic/pc260001.tif
     Exif:DateTimeOriginal: "2005:12:26 17:09:35"
     Exif:DateTimeDigitized: "2005:12:26 17:09:35"
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 3 (f/2.82843)
+    Exif:MaxApertureValue: 3 (f/2.8)
     Exif:MeteringMode: 5 (pattern)
     Exif:LightSource: 0 (unknown)
     Exif:Flash: 89 (flash fired, auto flash, red-eye reduction)
@@ -295,6 +297,7 @@ Reading ../../../../../libtiffpic/ycbcr-cat.tif
     oiio:BitsPerSample: 8
     ImageDescription: "YCbCr conversion of cat.tif"
     Orientation: 1 (normal)
+    Exif:YCbCrPositioning: 1
     tiff:PhotometricInterpretation: 6
     tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1
@@ -313,6 +316,7 @@ Reading ../../../../../libtiffpic/smallliz.tif
     YResolution: 100
     ResolutionUnit: "in"
     Software: "HP IL v1.1"
+    Exif:YCbCrPositioning: 1
     tiff:PhotometricInterpretation: 6
     tiff:ColorSpace: "YCbCr"
     tiff:PlanarConfiguration: 1


### PR DESCRIPTION
"Maker notes" are extra camera manufacturer-specific metadata stored as
opaque blobs inside Exif records. The manufacturers don't seem to
publish the specs for these blobs, but they have been reverse engineered
and with some hunting you can find tinkerer-prouced documentation (at a
range of levels of completeness or correctness).

With this patch, we do a substantial refactor of exif.cpp to incorporate
full awareness of maker notes into our metadata processing. At this
stage, we only read Canon makernotes, and quite incompletely. But we get
a lot more of the metadata than we used to (previously we just ignored
any makernotes we found), and the structure is now sound for adding more
complete support for this and other cameras. It involved a substantial
refactor of exif.cpp, as well as some other assorted tweaks.

This will be an ongoing project to support more cameras, but the foundation
is now set for this work.
