### PR TITLE
string_view -- document a subtle but rare bug, turn off address sanitizer

### DIFF
--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -303,6 +303,18 @@
 #endif
 
 
+// OIIO_NO_SANITIZE_ADDRESS can be used to mark a function that you don't
+// want address sanitizer to catch. Only use this if you know there are
+// false positives that you can't easily get rid of.
+// This should work for any clang >= 3.3 and gcc >= 4.8, which are
+// guaranteed by our minimum requirements.
+#if defined(__clang__) || defined (__GNUC__)
+#  define OIIO_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+#else
+#  define OIIO_NO_SANITIZE_ADDRESS
+#endif
+
+
 // Try to deduce endianness
 #if (defined(_WIN32) || defined(__i386__) || defined(__x86_64__))
 #  ifndef __LITTLE_ENDIAN__

--- a/src/include/OpenImageIO/string_view.h
+++ b/src/include/OpenImageIO/string_view.h
@@ -121,9 +121,23 @@ public:
     }
 
     /// Explicitly request a 0-terminated string. USUALLY, this turns out to
-    /// be just data(), with no significant added expense. But in the more
-    /// rare case that the string_view represetns a non-0-terminated
-    /// substring, it will force an allocation and copy underneath.
+    /// be just data(), with no significant added expense (because most uses
+    /// of string_view are simple wrappers of C strings, C++ std::string, or
+    /// ustring -- all of which are 0-terminated). But in the more rare case
+    /// that the string_view represetns a non-0-terminated substring, it
+    /// will force an allocation and copy underneath.
+    ///
+    /// Caveats:
+    /// 1. This is NOT going to be part of the C++17 std::string_view, so
+    ///    it's probably best to avoid this method if you want to have 100%
+    ///    drop-in compatibility with std::string_view.
+    /// 2. It is NOT SAFE to use c_str() on a string_view whose last char
+    ///    is the end of an allocation -- because that next char may only
+    ///    *coincidentally* be a '\0', which will cause c_str() to return
+    ///    the string start (thinking it's a valid C string, so why not just
+    ///    return its address?), if there's any chance that the subsequent
+    ///    char could change from 0 to non-zero during the use of the result
+    ///    of c_str(), and thus break the assumption that it's a valid C str.
     const char * c_str() const;
 
     // assignments


### PR DESCRIPTION
See the comments in the patch for details. It's been like this for a
long time. I think in practice, we'll never hit the bug. But we'll
probably phase this method out anyway, since it's not part of the C++17
std::string_view.
