### PR TITLE
ImageCache: improve thread contention

### DIFF
--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -69,6 +69,8 @@ namespace pvt {
 // shadow maps!
 #define USE_SHADOW_MATRICES 0
 
+#define FILE_CACHE_SHARDS 64
+#define TILE_CACHE_SHARDS 128
 
 using boost::thread_specific_ptr;
 
@@ -434,7 +436,7 @@ typedef intrusive_ptr<ImageCacheFile> ImageCacheFileRef;
 
 
 /// Map file names to file references
-typedef unordered_map_concurrent<ustring,ImageCacheFileRef,ustringHash,std::equal_to<ustring>, 8> FilenameMap;
+typedef unordered_map_concurrent<ustring,ImageCacheFileRef,ustringHash,std::equal_to<ustring>, FILE_CACHE_SHARDS> FilenameMap;
 typedef std::unordered_map<ustring,ImageCacheFileRef,ustringHash> FingerprintMap;
 
 
@@ -671,7 +673,7 @@ typedef intrusive_ptr<ImageCacheTile> ImageCacheTileRef;
 
 /// Hash table that maps TileID to ImageCacheTileRef -- this is the type of the
 /// main tile cache.
-typedef unordered_map_concurrent<TileID, ImageCacheTileRef, TileID::Hasher, std::equal_to<TileID>, 32> TileCache;
+typedef unordered_map_concurrent<TileID, ImageCacheTileRef, TileID::Hasher, std::equal_to<TileID>, TILE_CACHE_SHARDS> TileCache;
 
 
 /// A very small amount of per-thread data that saves us from locking

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -1441,8 +1441,8 @@ main (int argc, const char *argv[])
         std::cout << "texture cache size = " << cachesize << " MB\n";
         std::cout << "hw threads = " << Sysutil::hardware_concurrency() << "\n";
         std::cout << "times are best of " << ntrials << " trials\n\n";
-        std::cout << "threads  time (s) efficiency\n";
-        std::cout << "-------- -------- ----------\n";
+        std::cout << "threads  time (s)   speedup efficiency\n";
+        std::cout << "-------- -------- --------- ----------\n";
 
         if (nthreads == 0)
             nthreads = Sysutil::hardware_concurrency();
@@ -1456,9 +1456,11 @@ main (int argc, const char *argv[])
                                    ntrials, &range);
             if (nt == 1)
                 single_thread_time = (float)t;
-            float efficiency = (single_thread_time /*/nt*/) / (float)t;
-            std::cout << Strutil::format ("%2d      %8.2f %6.1f%%    range %.2f\t(%d iters/thread)\n",
-                                          nt, t, efficiency*100.0f, range, its);
+            float speedup = (single_thread_time /*/nt*/) / (float)t;
+            float efficiency = (single_thread_time / nt) / float(t);
+            std::cout << Strutil::format ("%3d     %8.2f   %6.1fx  %6.1f%%    range %.2f\t(%d iters/thread)\n",
+                                          nt, t, speedup, efficiency*100.0f, range, its);
+            std::cout.flush();
             if (! wedge)
                 break;    // don't loop if we're not wedging
         }


### PR DESCRIPTION
Increase the number of shards in the unordered_map_concurrent used by the ImageCache for file and tile caches. As we get machines with larger core counts and thread them more heavily, the previous limits were causing bottlenecks.

This solution is not perfect nor complete. But it does push the bottleneck from ~16 to more like ~32 threads. I'm separately working on some other strategies to reduce the amount of locking, with an eye toward every-growing core counts. But this is a solid step forward for our newer machines.

I also made some of the timings printed by testtex be just a bit more explanatory.
