### PR TITLE
Fix build break for old libraw

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,6 +34,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
 ### Optional dependencies
  * **Qt >= 5.6**  (Only needed if you want the `iv` viewer.)
  * Python >= 2.7
+ * libRaw (0.17 or higher is recommended for full functionality)
 
 
 

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -193,8 +193,10 @@ RawInput::open (const std::string &name, ImageSpec &newspec,
 
     // Temp spec for exif parser callback to dump into
     ImageSpec exifspec;
+#if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0,17,0)
     m_processor.set_exifparser_handler ((exif_parser_callback)exif_parser_cb,
                                         &exifspec);
+#endif
 
     // open the image
     m_filename = name;


### PR DESCRIPTION
An API call I recently started using turns out not to be available in older versions of libraw. Like the one we have installed at work, ahem.
