### PR TITLE
ColorConfig refactor

### DIFF
--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -63,30 +63,34 @@ public:
           context_key(key), context_value(val), looks(looks), file(file),
           inverse(inverse)
     {
-        hash = (inputColorSpace.hash() ^ outputColorSpace.hash() ^
-                context_key.hash() ^ context_value.hash() ^
-                looks.hash() ^ display.hash() ^ view.hash() ^ file.hash())
+        hash = inputColorSpace.hash() + 14033ul*outputColorSpace.hash()
+             + 823ul*context_key.hash() + 28411ul*context_value.hash()
+             + 1741ul*(looks.hash() + display.hash() + view.hash() + file.hash())
              + (inverse?6421:0);
+        // N.B. no separate multipliers for looks, display, view, file
+        // because they're never used for the same lookup.
     }
 
     friend bool operator< (const ColorProcCacheKey& a, const ColorProcCacheKey& b) {
         if (a.hash < b.hash) return true;
         if (b.hash < a.hash) return false;
-        // They hash the same, so now compare for real
-        if (a.inputColorSpace < b.inputColorSpace) return true;
-        else if (b.inputColorSpace < a.inputColorSpace) return false;
-        if (a.outputColorSpace < b.outputColorSpace) return true;
-        else if (b.outputColorSpace < a.outputColorSpace) return false;
-        if (a.context_key < b.context_key) return true;
-        else if (b.context_key < a.context_key) return false;
-        if (a.looks < b.looks) return true;
-        else if (b.looks < a.looks) return false;
-        if (a.display < b.display) return true;
-        else if (b.display < a.display) return false;
-        if (a.view < b.view) return true;
-        else if (b.view < a.view) return false;
-        if (a.file < b.view) return true;
-        else if (b.view < a.view) return false;
+        // They hash the same, so now compare for real. Note that we just to
+        // impose an order, any order -- does not need to be alphabetical --
+        // so we just compare the pointers.
+        if (a.inputColorSpace.c_str() < b.inputColorSpace.c_str()) return true;
+        if (b.inputColorSpace.c_str() < a.inputColorSpace.c_str()) return false;
+        if (a.outputColorSpace.c_str() < b.outputColorSpace.c_str()) return true;
+        if (b.outputColorSpace.c_str() < a.outputColorSpace.c_str()) return false;
+        if (a.context_key.c_str() < b.context_key.c_str()) return true;
+        if (b.context_key.c_str() < a.context_key.c_str()) return false;
+        if (a.looks.c_str() < b.looks.c_str()) return true;
+        if (b.looks.c_str() < a.looks.c_str()) return false;
+        if (a.display.c_str() < b.display.c_str()) return true;
+        if (b.display.c_str() < a.display.c_str()) return false;
+        if (a.view.c_str() < b.view.c_str()) return true;
+        if (b.view.c_str() < a.view.c_str()) return false;
+        if (a.file.c_str() < b.view.c_str()) return true;
+        if (b.view.c_str() < a.view.c_str()) return false;
         return int(a.inverse) < int(b.inverse);
     }
 

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1241,8 +1241,8 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
             return false;
         }
         
-        ColorProcessor * processor = colorconfig.createColorProcessor (
-            incolorspace.c_str(), outcolorspace.c_str());
+        ColorProcessorHandle processor =
+            colorconfig.createColorProcessor (incolorspace, outcolorspace);
         if (!processor || colorconfig.error()) {
             outstream << "Error Creating Color Processor." << std::endl;
             outstream << colorconfig.geterror() << std::endl;
@@ -1253,14 +1253,14 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
         if (unpremult && verbose)
             outstream << "  Unpremulting image..." << std::endl;
         
-        if (!ImageBufAlgo::colorconvert (*ccSrc, *src, processor, unpremult)) {
+        if (!ImageBufAlgo::colorconvert (*ccSrc, *src, processor.get(), unpremult)) {
             outstream << "Error applying color conversion to image.\n";
             return false;
         }
         
         if (isConstantColor) {
             if (!ImageBufAlgo::colorconvert (&constantColor[0],
-                static_cast<int>(constantColor.size()), processor, unpremult)) {
+                static_cast<int>(constantColor.size()), processor.get(), unpremult)) {
                 outstream << "Error applying color conversion to constant color.\n";
                 return false;
             }
@@ -1268,14 +1268,11 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
 
         if (compute_average_color) {
             if (!ImageBufAlgo::colorconvert (&pixel_stats.avg[0],
-                static_cast<int>(pixel_stats.avg.size()), processor, unpremult)) {
+                static_cast<int>(pixel_stats.avg.size()), processor.get(), unpremult)) {
                 outstream << "Error applying color conversion to average color.\n";
                 return false;
             }
         }
-
-        ColorConfig::deleteColorProcessor(processor);
-        processor = NULL;
 
         // swap the color-converted buffer and src (making src be the
         // working master that's color converted).


### PR DESCRIPTION
* Change ColorConfig to return shared ptrs to ColorProcessors. This frees
  the caller from having to own the resource and remember to delete it.
  It also makes leaks impossible.

* Establish an internal cache of ColorProcessors, so that repeated requests
  for the same processor (i.e., same color space transformation) doesn't
  need to do any allocations or trigger anything expensive on the OCIO
  side.

* Added new create...() methods that take ustring arguments, in addition
  to the existing ones that take string_view. That version is faster
  if you already have ustrings on the app side -- especially the part of
  looking it up in the cache. The string_view ones are still fine to use,
  they just build ustrings on their own.

* A little bit of C++ modernization.

NOTE that this is a breaking change, although a minor one. Any applications
that had explicitly asked for a ColorConfig and used it to request a raw
ColorProcessor will need to make some minor changes:
  - The return type of the ColorConfig::create... has changed from
    ColorProcessor* to ColorProcessorHandle.
  - You don't need to free the handle, it's a shared pointer now and will
    clean itself up.

