### PR TITLE
Fix recent build break against old libtiff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ addons:
       - g++-7
       - libboost1.55-all-dev
       - libgif-dev
-      - libtiff4-dev
       - libopenjpeg-dev
       - libwebp-dev
       - libfreetype6-dev

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,6 +30,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
  * **Boost >= 1.53** (tested up through 1.65)
  * **CMake >= 3.2.2** (tested up through 3.9)
  * **OpenEXR >= 2.0** (recommended: 2.2)
+ * libTIFF >= 3.9 (recommended: 4.0+)
 
 ### Optional dependencies
  * **Qt >= 5.6**  (Only needed if you want the `iv` viewer.)

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -38,7 +38,7 @@ endif ()
 ###########################################################################
 # TIFF
 if (NOT TIFF_LIBRARIES OR NOT TIFF_INCLUDE_DIR)
-    find_package (TIFF REQUIRED)
+    find_package (TIFF 3.9 REQUIRED)
     include_directories (${TIFF_INCLUDE_DIR})
 else ()
     message (STATUS "Custom TIFF_LIBRARIES ${TIFF_LIBRARIES}")

--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -230,12 +230,14 @@ tiff_datatype_to_typedesc (TIFFDataType tifftype, size_t tiffcount)
         return TypeDesc(TypeDesc::DOUBLE, tiffcount);
     case TIFF_IFD :
         return TypeUnknown;
+#ifdef TIFF_VERSION_BIG
     case TIFF_LONG8 :
         return TypeDesc(TypeDesc::UINT64, tiffcount);
     case TIFF_SLONG8 :
         return TypeDesc(TypeDesc::INT64, tiffcount);
     case TIFF_IFD8 :
         return TypeUnknown;
+#endif
     }
     return TypeUnknown;
 }


### PR DESCRIPTION
The recent Exif patch broke for old TIFF versions. Fix.

Also document more clearly what the TIFF library version requirements
are.

