### PR TITLE
unittest.h: Make the reference to Strutil fully qualified with OIIO::

### DIFF
--- a/src/include/OpenImageIO/unittest.h
+++ b/src/include/OpenImageIO/unittest.h
@@ -87,106 +87,106 @@ static OIIO::pvt::UnitTestFailureCounter unit_test_failures;
 /// prints an error message indicating the module and line where the
 /// error occurred, but does NOT abort.  This is helpful for unit tests
 /// where we do not want one failure.
-#define OIIO_CHECK_ASSERT(x)                                            \
-    ((x) ? ((void)0)                                                    \
-         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
-           << __FILE__ << ":" << __LINE__ << ":\n"                      \
-           << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")     \
-           << #x << "\n"),                                              \
+#define OIIO_CHECK_ASSERT(x)                                                \
+    ((x) ? ((void)0)                                                        \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")   \
+           << __FILE__ << ":" << __LINE__ << ":\n"                          \
+           << "FAILED: " << OIIO::Sysutil::Term(std::cout).ansi("normal")   \
+           << #x << "\n"),                                                  \
+            (void)++unit_test_failures)    )
+
+#define OIIO_CHECK_EQUAL(x,y)                                               \
+    (((x) == (y)) ? ((void)0)                                               \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")   \
+             << __FILE__ << ":" << __LINE__ << ":\n"                        \
+             << "FAILED: " << OIIO::Sysutil::Term(std::cout).ansi("normal") \
+             << #x << " == " << #y << "\n"                                  \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"),     \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_EQUAL(x,y)                                           \
-    (((x) == (y)) ? ((void)0)                                           \
-         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
-             << __FILE__ << ":" << __LINE__ << ":\n"                    \
-             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
-             << #x << " == " << #y << "\n"                              \
-             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
-            (void)++unit_test_failures))
-
-#define OIIO_CHECK_EQUAL_THRESH(x,y,eps)                                \
-    ((std::abs((x)-(y)) <= eps) ? ((void)0)                             \
-         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
-             << __FILE__ << ":" << __LINE__ << ":\n"                    \
-             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
-             << #x << " == " << #y << "\n"                              \
-             << "\tvalues were '" << (x) << "' and '" << (y) << "'"     \
+#define OIIO_CHECK_EQUAL_THRESH(x,y,eps)                                    \
+    ((std::abs((x)-(y)) <= eps) ? ((void)0)                                 \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")   \
+             << __FILE__ << ":" << __LINE__ << ":\n"                        \
+             << "FAILED: " << OIIO::Sysutil::Term(std::cout).ansi("normal") \
+             << #x << " == " << #y << "\n"                                  \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'"         \
              << ", diff was " << std::abs((x)-(y)) << "\n"),            \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_EQUAL_APPROX(x,y)                                    \
-    (pvt::equal_approx(x,y) ? ((void)0)                                 \
-         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
-             << __FILE__ << ":" << __LINE__ << ":\n"                    \
-             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
-             << #x << " == " << #y << "\n"                              \
-             << "\tvalues were '" << (x) << "' and '" << (y) << "'"     \
+#define OIIO_CHECK_EQUAL_APPROX(x,y)                                        \
+    (pvt::equal_approx(x,y) ? ((void)0)                                     \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")   \
+             << __FILE__ << ":" << __LINE__ << ":\n"                        \
+             << "FAILED: " << OIIO::Sysutil::Term(std::cout).ansi("normal") \
+             << #x << " == " << #y << "\n"                                  \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'"         \
              << ", diff was " << ((x)-(y)) << "\n"),                    \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_NE(x,y)                                              \
-    (((x) != (y)) ? ((void)0)                                           \
-         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
-           << __FILE__ << ":" << __LINE__ << ":\n"                      \
-             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
-             << #x << " != " << #y << "\n"                              \
-             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
+#define OIIO_CHECK_NE(x,y)                                                  \
+    (((x) != (y)) ? ((void)0)                                               \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")   \
+           << __FILE__ << ":" << __LINE__ << ":\n"                          \
+             << "FAILED: " << OIIO::Sysutil::Term(std::cout).ansi("normal") \
+             << #x << " != " << #y << "\n"                                  \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"),     \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_LT(x,y)                                              \
-    (((x) < (y)) ? ((void)0)                                            \
-         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
-             << __FILE__ << ":" << __LINE__ << ":\n"                    \
-             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
-             << #x << " < " << #y << "\n"                               \
-             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
+#define OIIO_CHECK_LT(x,y)                                                  \
+    (((x) < (y)) ? ((void)0)                                                \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")   \
+             << __FILE__ << ":" << __LINE__ << ":\n"                        \
+             << "FAILED: " << OIIO::Sysutil::Term(std::cout).ansi("normal") \
+             << #x << " < " << #y << "\n"                                   \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"),     \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_GT(x,y)                                              \
-    (((x) > (y)) ? ((void)0)                                            \
-         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
-             << __FILE__ << ":" << __LINE__ << ":\n"                    \
-             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
-             << #x << " > " << #y << "\n"                               \
-             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
+#define OIIO_CHECK_GT(x,y)                                                  \
+    (((x) > (y)) ? ((void)0)                                                \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")   \
+             << __FILE__ << ":" << __LINE__ << ":\n"                        \
+             << "FAILED: " << OIIO::Sysutil::Term(std::cout).ansi("normal") \
+             << #x << " > " << #y << "\n"                                   \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"),     \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_LE(x,y)                                              \
-    (((x) <= (y)) ? ((void)0)                                           \
-         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
-             << __FILE__ << ":" << __LINE__ << ":\n"                    \
-             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
-             << #x << " <= " << #y << "\n"                              \
-             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
+#define OIIO_CHECK_LE(x,y)                                                  \
+    (((x) <= (y)) ? ((void)0)                                               \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")   \
+             << __FILE__ << ":" << __LINE__ << ":\n"                        \
+             << "FAILED: " << OIIO::Sysutil::Term(std::cout).ansi("normal") \
+             << #x << " <= " << #y << "\n"                                  \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"),     \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_GE(x,y)                                              \
-    (((x) >= (y)) ? ((void)0)                                           \
-         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
-             << __FILE__ << ":" << __LINE__ << ":\n"                    \
-             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
-             << #x << " >= " << #y << "\n"                              \
-             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
+#define OIIO_CHECK_GE(x,y)                                                  \
+    (((x) >= (y)) ? ((void)0)                                               \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")   \
+             << __FILE__ << ":" << __LINE__ << ":\n"                        \
+             << "FAILED: " << OIIO::Sysutil::Term(std::cout).ansi("normal") \
+             << #x << " >= " << #y << "\n"                                  \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"),     \
             (void)++unit_test_failures))
 
 
 // Special SIMD related equality checks that use all()
-#define OIIO_CHECK_SIMD_EQUAL(x,y)                                      \
-    (all ((x) == (y)) ? ((void)0)                                       \
-         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
-             << __FILE__ << ":" << __LINE__ << ":\n"                    \
-             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
-             << #x << " == " << #y << "\n"                              \
-             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
+#define OIIO_CHECK_SIMD_EQUAL(x,y)                                          \
+    (all ((x) == (y)) ? ((void)0)                                           \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")   \
+             << __FILE__ << ":" << __LINE__ << ":\n"                        \
+             << "FAILED: " << OIIO::Sysutil::Term(std::cout).ansi("normal") \
+             << #x << " == " << #y << "\n"                                  \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"),     \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_SIMD_EQUAL_THRESH(x,y,eps)                           \
-    (all (abs((x)-(y)) < (eps)) ? ((void)0)                             \
-         : ((std::cout << Sysutil::Term(std::cout).ansi("red,bold")     \
-             << __FILE__ << ":" << __LINE__ << ":\n"                    \
-             << "FAILED: " << Sysutil::Term(std::cout).ansi("normal")   \
-             << #x << " == " << #y << "\n"                              \
-             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
+#define OIIO_CHECK_SIMD_EQUAL_THRESH(x,y,eps)                               \
+    (all (abs((x)-(y)) < (eps)) ? ((void)0)                                 \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")   \
+             << __FILE__ << ":" << __LINE__ << ":\n"                        \
+             << "FAILED: " << OIIO::Sysutil::Term(std::cout).ansi("normal") \
+             << #x << " == " << #y << "\n"                                  \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"),     \
             (void)++unit_test_failures))
 
 


### PR DESCRIPTION
It previously worked for the OIIO tests that all seemed to have a
'using namespace OIIO', but failed for external projects that just wanted
to use unittest.h and weren't inside namespace OIIO.

