### PR TITLE
Minor debug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ MY_CMAKE_FLAGS += -G Ninja
 BUILDSENTINEL := build.ninja
 endif
 
-ifneq (${CODECOV},)
+ifeq (${CODECOV},1)
 MY_CMAKE_FLAGS += -DCMAKE_BUILD_TYPE:STRING=Debug -DCODECOV:BOOL=${CODECOV}
 endif
 

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -673,13 +673,11 @@ OpenEXRInput::PartInfo::parse_header (const Imf::Header *header)
                 int r[2];
                 r[0] = n;
                 r[1] = static_cast<int>(d);
-                OIIO::debug ("adding rational with numerator %d and denominator %u (easy case)", n, d);
                 spec.attribute (oname, TypeRational, r);    
             } else if (int f = static_cast<int>(boost::math::gcd<long int>(rational[0], rational[1])) > 1) {
                 int r[2];
                 r[0] = n / f;
                 r[1] = static_cast<int>(d / f);
-                OIIO::debug ("adding rational with numerator %d and denominator %u (hard case)", n, d);
                spec.attribute (oname, TypeRational, r);
             } else {
                 // TODO: find a way to allow the client to accept "close" rational values


### PR DESCRIPTION
1. Remove debugging output that is no longer needed.

2. Bug in Makefile where CMAKE_BUILD_TYPE was set to Debug any time CODECOV was specified on the make command line, even when setting `CODECOV=0`.

Fixes #1790 
