### PR TITLE
Fix CMake error with MSVC compiler

### DIFF
--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -155,7 +155,9 @@ if (WIN32)
     target_link_libraries (OpenImageIO psapi.lib)
 endif ()
 
-add_dependencies (OpenImageIO "${VISIBILITY_MAP_FILE}")
+if (VISIBILITY_MAP_FILE)
+    add_dependencies (OpenImageIO "${VISIBILITY_MAP_FILE}")
+endif ()
 
 if (USE_EXTERNAL_PUGIXML)
     target_link_libraries (OpenImageIO ${PUGIXML_LIBRARIES})


### PR DESCRIPTION
This is simple change that fix MSVC error:
```
CMake Error at src/libOpenImageIO/CMakeLists.txt:154 (add_dependencies):
  The dependency target "" of target "OpenImageIO" does not exist.
```