### PR TITLE
More principled handling of string<->numeric conversions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ addons:
       - libavformat-dev
       - libswscale-dev
       - libavutil-dev
+      - locales
       # - qtbase5-dev   # FIXME: enable Qt5 on Linux
       # - bzip2
       # - libtinyxml-dev

--- a/src/fits.imageio/fitsinput.cpp
+++ b/src/fits.imageio/fitsinput.cpp
@@ -348,7 +348,7 @@ FitsInput::add_to_spec (const std::string &keyname, const std::string &value)
     // converting string to float or integer
     bool isNumSign = (value[0] == '+' || value[0] == '-' || value[0] == '.');
     if (isdigit (value[0]) || isNumSign) {
-        float val = atof (value.c_str ());
+        float val = Strutil::stof (value);
         if (val == (int)val)
             m_spec.attribute (keyname, (int)val);
         else

--- a/src/include/OpenImageIO/optparser.h
+++ b/src/include/OpenImageIO/optparser.h
@@ -40,6 +40,7 @@
 #define OPENIMAGEIO_OPTPARSER_H
 
 #include <string>
+#include <OpenImageIO/strutil.h>
 
 OIIO_NAMESPACE_BEGIN
 
@@ -67,9 +68,9 @@ optparse1 (C &system, const std::string &opt)
     char v = value.size() ? value[0] : ' ';
     if ((v >= '0' && v <= '9') || v == '+' || v == '-') {  // numeric
         if (strchr (value.c_str(), '.'))  // float
-            return system.attribute (name.c_str(), (float)atof(value.c_str()));
+            return system.attribute (name, Strutil::stof(value));
         else  // int
-            return system.attribute (name.c_str(), (int)atoi(value.c_str()));
+            return system.attribute (name, Strutil::stoi(value));
     }
     // otherwise treat it as a string
 

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -626,6 +626,8 @@ public:
     /// something like:
     ///    ustring s = ustring::format ("blah %d %g", (int)foo, (float)bar);
     /// The argument list is fully typesafe.
+    /// The formatting of the string will always use the classic "C" locale
+    /// conventions (in particular, '.' as decimal separator for float values).
     template<typename... Args>
     static ustring format (string_view fmt, const Args&... args)
     {
@@ -750,6 +752,12 @@ inline bool iequals (const std::string &a, ustring b) {
     return Strutil::iequals(a, b.string());
 }
 
+
+
+// ustring variant stof from OpenImageIO/strutil.h
+namespace Strutil {
+inline int stof (ustring s) { return Strutil::stof (s.string()); }
+} // end namespace Strutil
 
 OIIO_NAMESPACE_END
 

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -117,12 +117,9 @@ ImageViewer::ImageViewer ()
 {
     readSettings (false);
 
-    const char *gamenv = getenv ("GAMMA");
-    if (gamenv) {
-        float g = atof (gamenv);
-        if (g >= 0.1 && g <= 5)
-            m_default_gamma = g;
-    }
+    float gam = Strutil::stof (Sysutil::getenv ("GAMMA"));
+    if (gam >= 0.1 && gam <= 5)
+        m_default_gamma = gam;
     // FIXME -- would be nice to have a more nuanced approach to display
     // color space, in particular knowing whether the display is sRGB.
     // Also, some time in the future we may want a real 3D LUT for 

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -936,6 +936,7 @@ spec_to_xml (const ImageSpec &spec, ImageSpec::SerialVerbose verbose)
     }
 
     std::ostringstream result;
+    result.imbue (std::locale::classic());  // force "C" locale with '.' decimal
     doc.print (result, "");
     return result.str();
 }

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1386,6 +1386,7 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
     // (such as filtering information) needs to be manually added into the
     // hash.
     std::ostringstream addlHashData;
+    addlHashData.imbue (std::locale::classic()); // Force "C" locale with '.' decimal
     addlHashData << filtername << " ";
     float sharpen = configspec.get_float_attribute ("maketx:sharpen", 0.0f);
     if (sharpen != 0.0f) {
@@ -1417,6 +1418,7 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
   
     if (isConstantColor) {
         std::ostringstream os; // Emulate a JSON array
+        os.imbue (std::locale::classic());  // Force "C" locale with '.' decimal
         for (int i = 0; i < dstspec.nchannels; ++i) {
             if (i!=0) os << ",";
             os << (i<(int)constantColor.size() ? constantColor[i] : 0.0f);
@@ -1436,6 +1438,7 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
     
     if (compute_average_color) {
         std::ostringstream os; // Emulate a JSON array
+        os.imbue (std::locale::classic());  // Force "C" locale with '.' decimal
         for (int i = 0; i < dstspec.nchannels; ++i) {
             if (i!=0) os << ",";
             os << (i<(int)pixel_stats.avg.size() ? pixel_stats.avg[i] : 0.0f);

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1610,6 +1610,7 @@ ImageCacheImpl::onefile_stat_line (const ImageCacheFileRef &file,
 {
     // FIXME -- make meaningful stat printouts for multi-image textures
     std::ostringstream out;
+    out.imbue (std::locale::classic());  // Force "C" locale with '.' decimal
     const ImageSpec &spec (file->spec(0,0));
     const char *formatcode = "u8";
     switch (spec.format.basetype) {
@@ -1737,6 +1738,7 @@ ImageCacheImpl::getstats (int level) const
     }
 
     std::ostringstream out;
+    out.imbue (std::locale::classic());  // Force "C" locale with '.' decimal
     if (level > 0) {
         out << "OpenImageIO ImageCache statistics (";
         {

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -379,6 +379,7 @@ TextureSystemImpl::getstats (int level, bool icstats) const
     m_imagecache->mergestats (stats);
 
     std::ostringstream out;
+    out.imbue (std::locale::classic());  // Force "C" locale with '.' decimal
     bool anytexture = (stats.texture_queries + stats.texture3d_queries +
                        stats.shadow_queries + stats.environment_queries);
     if (level > 0 && anytexture) {

--- a/src/libutil/argparse.cpp
+++ b/src/libutil/argparse.cpp
@@ -252,11 +252,11 @@ ArgOption::set_parameter (int i, const char *argv)
 
     case 'f':
     case 'g':
-        *(float *)m_param[i] = (float)atof(argv);
+        *(float *)m_param[i] = Strutil::stof(argv);
         break;
 
     case 'F':
-        *(double *)m_param[i] = atof(argv);
+        *(double *)m_param[i] = Strutil::stod(argv);
         break;
 
     case 's':

--- a/src/libutil/benchmark.cpp
+++ b/src/libutil/benchmark.cpp
@@ -144,6 +144,12 @@ std::ostream& operator<< (std::ostream& out, const Benchmarker &bench)
     }
     const char* unitname = unitnames[unit];
     double scale = unitscales[unit];
+    char rateunit = 'M';
+    double ratescale = 1.0e6;
+    if (bench.avg() >= 1.0e-6) {
+        rateunit = 'k';
+        ratescale = 1.0e3;
+    }
 
     avg *= scale;
     stddev *= scale;
@@ -163,12 +169,12 @@ std::ostream& operator<< (std::ostream& out, const Benchmarker &bench)
         return out;
     }
     if (bench.work() == 1)
-        out << Strutil::format ("%6.1f M/s",
-                                (1.0f/1.0e6)/bench.avg());
+        out << Strutil::format ("%6.1f %c/s",
+                                (1.0f/ratescale)/bench.avg(), rateunit);
     else
-        out << Strutil::format ("%6.1f Mvals/s, %.1f Mcalls/s",
-                                (bench.work()/1.0e6)/bench.avg(),
-                                (1.0f/1.0e6)/bench.avg());
+        out << Strutil::format ("%6.1f %cvals/s, %.1f %ccalls/s",
+                                (bench.work()/ratescale)/bench.avg(), rateunit,
+                                (1.0f/ratescale)/bench.avg(), rateunit);
     if (bench.verbose() >= 2)
         out << Strutil::format (" (%dx%d, rng=%.1f%%, med=%.1f)",
                                 bench.trials(), bench.iterations(), unitname,

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -723,16 +723,16 @@ Filesystem::enumerate_sequence (string_view desc, std::vector<int> &numbers)
         // If 'y' is used, generate the complement.
         std::vector<std::string> range;
         Strutil::split (s, range, "-", 2);
-        int first = Strutil::from_string<int> (range[0]);
+        int first = Strutil::stoi (range[0]);
         int last = first;
         int step = 1;
         bool complement = false;
         if (range.size() > 1) {
-            last = Strutil::from_string<int> (range[1]);
+            last = Strutil::stoi (range[1]);
             if (const char *x = strchr (range[1].c_str(), 'x'))
-                step = (int) strtol (x+1, NULL, 10);
+                step = Strutil::stoi (x+1);
             else if (const char *x = strchr (range[1].c_str(), 'y')) {
-                step = (int) strtol (x+1, NULL, 10);
+                step = Strutil::stoi (x+1);
                 complement = true;
             }
             if (step == 0)
@@ -989,7 +989,7 @@ Filesystem::scan_for_matching_filenames(const std::string &pattern_,
             match_results<std::string::const_iterator> frame_match;
             if (regex_match (f, frame_match, pattern_re)) {
                 std::string thenumber (frame_match[1].first, frame_match[1].second);
-                int frame = (int)strtol (thenumber.c_str(), NULL, 10);
+                int frame = Strutil::stoi (thenumber);
                 matches.push_back (std::make_pair (frame, f));
             }
         }

--- a/src/libutil/ustring.cpp
+++ b/src/libutil/ustring.cpp
@@ -406,6 +406,7 @@ ustring::getstats (bool verbose)
 {
     UstringTable &table (ustring_table());
     std::ostringstream out;
+    out.imbue (std::locale::classic());  // Force "C" locale with '.' decimal
     size_t n_l = table.get_num_lookups();
     size_t n_e = table.get_num_entries();
     size_t mem = table.get_memory_usage();

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -446,6 +446,10 @@ main (int argc, char *argv[])
 {
     Timer alltimer;
 
+    // Globally force classic "C" locale, and turn off all formatting
+    // internationalization, for the entire maketx application.
+    std::locale::global (std::locale::classic());
+
     ImageSpec configspec;
     Filesystem::convert_native_arguments (argc, (const char **)argv);
     getargs (argc, argv, configspec);

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -392,7 +392,7 @@ RLAInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
         }
     }
 
-    float aspect = atof (m_rla.AspectRatio);
+    float aspect = Strutil::stof (m_rla.AspectRatio);
     if (aspect > 0.f)
         m_spec.attribute ("PixelAspectRatio", aspect);
 


### PR DESCRIPTION
This refactor comes after a belated realization that our numeric
conversion routines (principally from_string<> and format) are
"locale-dependent" via their use of strtod, as well as atof() scattered
through the code.

In particular, this means that when software using this code is running
with a locale in which the decimal mark is something other than '.'
(e.g., many European locales that use ',' for decimal mark), these
functions will incorrectly parse text floating point numbers that use
the standard period as decimal mark.  For example, if the locale is
"fr_FR", atof("123.45") will return 123.0, rather than the correct
123.45.

After much debate, and a few implementations, we are declaring that
since the whole point of OIIO is about reading and writing persistent
data (image files!), that in order to be consistent, ALL of OIIO's
string parsing and formatting, including that done by utility library
functions, will be locale-independent by using the "C" locale (in
particular, we will use the usual North American default of '.' for
decimal separator).

Additionally:

* Added a new stof(), stoi(), stoul() to replace the clunkier template
syntax of from_string<>. As explained, these are hard-coded to "C" locale,
not the native/global locale.

* Much more attention to string_view safety, finding a number of subtle
bugs (including Strutil::parse_int, etc.)  where it was definitely not
safe to assume that the string_view passed was the null-terminated edge
of the string, and so, for example if a string_view pointed to the
characters "12" but the very next characters were "345" parse_int would
return 12345 instead of the correct 12.

* Strutil::format and ustring::format (and our copy of tinyformat
underneath) were touched up so that the versions of format() that return
strings will use the "C" locale, versions added that return strings and
use an explicitly-passed locale, and the versions that append their
results to existing streams continue to operate as before by honoring
the existing locale conventions of the streams they are using.
We may revise this later depending on what the upstream tinyformat
chooses to do about the issue.

* Several places where we assembled strings using std::ostringstream,
I forced the stream to use classic "C" locale in cases where it was
likely to have any floating-point data output.

* For maketx and oiiotool, globally set the locale to classic. In these
cases, we control the whole app, so this is safe to do.

If we ever decide that we want versions of these functions that take
explicit locales, it's not hard to add.

