### PR TITLE
TextureSys: bump max_tile_channels limit to 6

### DIFF
--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -344,7 +344,7 @@ TextureSystemImpl::init ()
     m_Mw2c.makeIdentity();
     m_gray_to_rgb = false;
     m_flip_t = false;
-    m_max_tile_channels = 5;
+    m_max_tile_channels = 6;
     delete hq_filter;
     hq_filter = Filter1D::create ("b-spline", 4);
     m_statslevel = 0;


### PR DESCRIPTION
A use case has come up that makes me think 6 channel textures are going to be important for us, so I want the threshold for splitting tiles to include that situation.

