### PR TITLE
parallel utility improvements

### DIFF
--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -43,6 +43,7 @@
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/color.h>
 #include <OpenImageIO/array_view.h>
+#include <OpenImageIO/parallel.h>
 
 #include <OpenEXR/ImathMatrix.h>       /* because we need M33f */
 
@@ -90,6 +91,10 @@ class Filter2D;  // forward declaration
 
 
 namespace ImageBufAlgo {
+
+// old name (DEPRECATED 1.9)
+typedef parallel_options parallel_image_options;
+
 
 /// Zero out (set to 0, black) the image region.
 ///

--- a/src/include/OpenImageIO/parallel.h
+++ b/src/include/OpenImageIO/parallel.h
@@ -46,6 +46,41 @@
 
 OIIO_NAMESPACE_BEGIN
 
+/// Split strategies
+enum SplitDir { Split_X, Split_Y, Split_Z, Split_Biggest, Split_Tile };
+
+
+/// Encapsulation of options that control parallel_image().
+class parallel_options {
+public:
+    parallel_options (int maxthreads=0, SplitDir splitdir=Split_Y,
+                      size_t minitems=16384)
+        : maxthreads(maxthreads), splitdir(splitdir), minitems(minitems) { }
+
+    // Fix up all the TBD parameters:
+    // * If no pool was specified, use the default pool.
+    // * If no max thread count was specified, use the pool size.
+    // * If the calling thread is itself in the pool and the recursive flag
+    //   was not turned on, just use one thread.
+    void resolve () {
+        if (pool == nullptr)
+            pool = default_thread_pool();
+        if (maxthreads <= 0)
+            maxthreads = pool->size()+1;  // pool size + caller
+        if (!recursive && pool->is_worker())
+            maxthreads = 1;
+    }
+
+    bool singlethread () const { return maxthreads == 1; }
+
+    int maxthreads = 0;           // Max threads (0 = use all)
+    SplitDir splitdir = Split_Y;  // Primary split direction
+    bool recursive = false;       // Allow thread pool recursion
+    size_t minitems = 16384;      // Min items per task
+    thread_pool *pool = nullptr;  // If non-NULL, custom thread pool
+};
+
+
 
 /// Parallel "for" loop, chunked: for a task that takes an int thread ID
 /// followed by an int64_t [begin,end) range, break it into non-overlapping
@@ -68,51 +103,44 @@ OIIO_NAMESPACE_BEGIN
 /// is stealing work from the pool.
 inline void
 parallel_for_chunked (int64_t start, int64_t end, int64_t chunksize,
-                   std::function<void(int id, int64_t b, int64_t e)>&& task)
+                      std::function<void(int id, int64_t b, int64_t e)>&& task,
+                      parallel_options opt=parallel_options(0,Split_Y,1))
 {
-    thread_pool *pool (default_thread_pool());
-    if (chunksize < end-start && pool->this_thread_is_in_pool())
-        chunksize = end-start;    // don't use the pool recursively
-    if (chunksize < 1) {
-        int p = std::max (1, 2*pool->size());
-        chunksize = std::max (int64_t(1), (end-start) / p);
+    opt.resolve ();
+    chunksize = std::min (chunksize, end-start);
+    if (chunksize < 1) {   // If caller left chunk size to us...
+        if (opt.singlethread()) {  // Single thread: do it all in one shot
+            chunksize = end-start;
+        } else {   // Multithread: choose a good chunk size
+            int p = std::max (1, 2*opt.maxthreads);
+            chunksize = std::max (int64_t(opt.minitems), (end-start) / p);
+        }
     }
-    for (task_set<void> ts (pool); start < end; start += chunksize) {
+    // N.B. If chunksize was specified, honor it, even for the single
+    // threaded case.
+    for (task_set<void> ts (opt.pool); start < end; start += chunksize) {
         int64_t e = std::min (end, start+chunksize);
-        if (e == end) {
-            // For the last (or only) subtask, do it ourselves and avoid
-            // messing with the queue or handing off between threads.
+        if (e == end || opt.singlethread()) {
+            // For the last (or only) subtask, or if we are using just one
+            // thread, do it ourselves and avoid messing with the queue or
+            // handing off between threads.
             task (-1, start, e);
         } else {
-            ts.push (pool->push (task, start, e));
+            ts.push (opt.pool->push (task, start, e));
         }
     }
 }
 
 
+
 /// Parallel "for" loop, chunked: for a task that takes a [begin,end) range
 /// (but not a thread ID).
 inline void parallel_for_chunked (int64_t start, int64_t end, int64_t chunksize,
-                           std::function<void(int64_t b, int64_t e)>&& task)
+                                  std::function<void(int64_t, int64_t)>&& task,
+                                  parallel_options opt=parallel_options(0,Split_Y,1))
 {
-    thread_pool *pool (default_thread_pool());
-    if (chunksize < end-start && pool->this_thread_is_in_pool())
-        chunksize = end-start;    // don't use the pool recursively
-    if (chunksize < 1) {
-        int p = std::max (1, 2*pool->size());
-        chunksize = std::max (int64_t(1), (end-start) / p);
-    }
-    auto wrapper = [&](int id, int64_t b, int64_t e){ task(b,e); };
-    for (task_set<void> ts (pool); start < end; start += chunksize) {
-        int64_t e = std::min (end, start+chunksize);
-        if (e == end) {
-            // For the last (or only) subtask, do it ourselves and avoid
-            // messing with the queue or handing off between threads.
-            task (start, e);
-        } else {
-            ts.push (pool->push (wrapper, start, std::min (end, e)));
-        }
-    }
+    auto wrapper = [&](int id, int64_t b, int64_t e) { task(b,e); };
+    parallel_for_chunked (start, end, chunksize, wrapper, opt);
 }
 
 
@@ -132,12 +160,13 @@ inline void parallel_for_chunked (int64_t start, int64_t end, int64_t chunksize,
 /// size is chosen automatically.
 inline void
 parallel_for (int64_t start, int64_t end,
-              std::function<void(int64_t index)>&& task)
+              std::function<void(int64_t index)>&& task,
+              parallel_options opt=parallel_options(0,Split_Y,1))
 {
     parallel_for_chunked (start, end, 0, [&task](int id, int64_t i, int64_t e) {
         for ( ; i < e; ++i)
             task (i);
-    });
+    }, opt);
 }
 
 
@@ -149,12 +178,13 @@ parallel_for (int64_t start, int64_t end,
 ///    task (id, end-1);
 inline void
 parallel_for (int64_t start, int64_t end,
-              std::function<void(int id, int64_t index)>&& task)
+              std::function<void(int id, int64_t index)>&& task,
+              parallel_options opt=parallel_options(0,Split_Y,1))
 {
     parallel_for_chunked (start, end, 0, [&task](int id, int64_t i, int64_t e) {
         for ( ; i < e; ++i)
             task (id, i);
-    });
+    }, opt);
 }
 
 
@@ -163,17 +193,18 @@ parallel_for (int64_t start, int64_t end,
 /// iteration is a separate job for the default thread pool.
 template<class InputIt, class UnaryFunction>
 UnaryFunction
-parallel_for_each (InputIt first, InputIt last, UnaryFunction f)
+parallel_for_each (InputIt first, InputIt last, UnaryFunction f,
+                   parallel_options opt=parallel_options(0,Split_Y,1))
 {
-    thread_pool *pool (default_thread_pool());
-    if (pool->size() == 1 || pool->this_thread_is_in_pool()) {
+    opt.resolve ();
+    if (opt.singlethread()) {
         // Don't use the pool recursively or if there are no workers --
         // just run the function directly.
         for ( ; first != last; ++first)
             f (*first);
     } else {
-        for (task_set<void> ts (pool); first != last; ++first)
-            ts.push (pool->push ([&](int id){ f(*first); }));
+        for (task_set<void> ts (opt.pool); first != last; ++first)
+            ts.push (opt.pool->push ([&](int id){ f(*first); }));
     }
     return std::move(f);
 }
@@ -198,28 +229,29 @@ parallel_for_each (InputIt first, InputIt last, UnaryFunction f)
 inline void
 parallel_for_chunked_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
                          int64_t ystart, int64_t yend, int64_t ychunksize,
-                   std::function<void(int id, int64_t xbegin, int64_t xend,
-                                      int64_t ybegin, int64_t yend)>&& task)
+                         std::function<void(int id, int64_t, int64_t,
+                                            int64_t, int64_t)>&& task,
+                         parallel_options opt=0)
 {
-    thread_pool *pool (default_thread_pool());
-    if (pool->this_thread_is_in_pool()) {
-        // don't use the pool recursively
+    opt.resolve ();
+    if (opt.singlethread() || (xchunksize >= (xend-xstart) && ychunksize >= (yend-ystart))) {
         task (-1, xstart, xend, ystart, yend);
         return;
     }
     if (ychunksize < 1)
-        ychunksize = std::max (int64_t(1), (yend-ystart) / (pool->size()));
+        ychunksize = std::max (int64_t(1), (yend-ystart) / (2*opt.maxthreads));
     if (xchunksize < 1) {
         int64_t ny = std::max (int64_t(1), (yend-ystart) / ychunksize);
-        int64_t nx = std::max (int64_t(1), pool->size() / ny);
+        int64_t nx = std::max (int64_t(1), opt.maxthreads / ny);
         xchunksize = std::max (int64_t(1), (xend-xstart) / nx);
     }
-    task_set<void> ts (pool);
+    task_set<void> ts (opt.pool);
     for (auto y = ystart; y < yend; y += ychunksize) {
         int64_t ychunkend = std::min (yend, y+ychunksize);
-        for (auto x = xstart; x < xend; x += xchunksize)
-            ts.push (pool->push (task, x, std::min (xend, x+xchunksize),
-                                 y, ychunkend));
+        for (auto x = xstart; x < xend; x += xchunksize) {
+            ts.push (opt.pool->push (task, x, std::min (xend, x+xchunksize),
+                                     y, ychunkend));
+        }
     }
 }
 
@@ -230,13 +262,14 @@ parallel_for_chunked_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
 inline void
 parallel_for_chunked_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
                          int64_t ystart, int64_t yend, int64_t ychunksize,
-                     std::function<void(int64_t xbegin, int64_t xend,
-                                        int64_t ybegin, int64_t yend)>&& task)
+                         std::function<void(int64_t, int64_t,
+                                            int64_t, int64_t)>&& task,
+                         parallel_options opt=0)
 {
     auto wrapper = [&](int id, int64_t xb, int64_t xe,
                        int64_t yb, int64_t ye) { task(xb,xe,yb,ye); };
     parallel_for_chunked_2D (xstart, xend, xchunksize,
-                             ystart, yend, ychunksize, wrapper);
+                             ystart, yend, ychunksize, wrapper, opt);
 }
 
 
@@ -253,14 +286,15 @@ parallel_for_chunked_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
 inline void
 parallel_for_2D (int64_t xstart, int64_t xend,
                  int64_t ystart, int64_t yend,
-                 std::function<void(int id, int64_t i, int64_t j)>&& task)
+                 std::function<void(int id, int64_t i, int64_t j)>&& task,
+                 parallel_options opt=0)
 {
     parallel_for_chunked_2D (xstart, xend, 0, ystart, yend, 0,
             [&task](int id, int64_t xb, int64_t xe, int64_t yb, int64_t ye) {
         for (auto y = yb; y < ye; ++y)
             for (auto x = xb; x < xe; ++x)
                 task (id, x, y);
-    });
+    }, opt);
 }
 
 
@@ -277,20 +311,22 @@ parallel_for_2D (int64_t xstart, int64_t xend,
 inline void
 parallel_for_2D (int64_t xstart, int64_t xend,
                  int64_t ystart, int64_t yend,
-                 std::function<void(int64_t i, int64_t j)>&& task)
+                 std::function<void(int64_t i, int64_t j)>&& task,
+                 parallel_options opt=0)
 {
     parallel_for_chunked_2D (xstart, xend, 0, ystart, yend, 0,
             [&task](int id, int64_t xb, int64_t xe, int64_t yb, int64_t ye) {
         for (auto y = yb; y < ye; ++y)
             for (auto x = xb; x < xe; ++x)
                 task (x, y);
-    });
+    }, opt);
 }
 
 
 
 // DEPRECATED(1.8): This version accidentally accepted chunksizes that
 // weren't used. Preserve for a version to not break 3rd party apps.
+OIIO_DEPRECATED("Use the version without chunk sizes (1.8)")
 inline void
 parallel_for_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
                  int64_t ystart, int64_t yend, int64_t ychunksize,

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -133,6 +133,7 @@ Strutil::sync_output (std::ostream& file, string_view str)
     if (str.size()) {
         std::unique_lock<std::mutex> lock (output_mutex);
         file << str;
+        file.flush ();
     }
 }
 

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -51,10 +51,12 @@
 
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/thread.h>
+#include <OpenImageIO/parallel.h>
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/strutil.h>
 
 #include <boost/thread/tss.hpp>
+#include <boost/container/flat_map.hpp>
 
 #if 0
 
@@ -137,6 +139,7 @@ public:
     void resize(int nThreads) {
         if (nThreads < 0)
             nThreads = std::max (1, int(threads_default()) - 1);
+        nThreads = 0;
         if (!this->isStop && !this->isDone) {
             int oldNThreads = static_cast<int>(this->threads.size());
             if (oldNThreads <= nThreads) {  // if the number of threads is increased
@@ -220,7 +223,7 @@ public:
         auto pck = std::make_shared<std::packaged_task<decltype(f(0, rest...))(int)>>(
             std::bind(std::forward<F>(f), std::placeholders::_1, std::forward<Rest>(rest)...)
         );
-        if (size() < 1) {
+        if (size() < 1 || is_worker(std::this_thread::get_id())) {
             (*pck)(-1); // No worker threads, run it with the calling thread
         } else {
             auto _f = new std::function<void(int id)>([pck](int id) {
@@ -238,7 +241,7 @@ public:
     template<typename F>
     auto push(F && f) ->std::future<decltype(f(0))> {
         auto pck = std::make_shared<std::packaged_task<decltype(f(0))(int)>>(std::forward<F>(f));
-        if (size() < 1) {
+        if (size() < 1 || is_worker(std::this_thread::get_id())) {
             (*pck)(-1); // No worker threads, run it with the calling thread
         } else {
             auto _f = new std::function<void(int id)>([pck](int id) {
@@ -259,12 +262,17 @@ public:
 
     // If any tasks are on the queue, pop and run one with the calling
     // thread.
-    bool run_one_task () {
-        std::function<void(int id)> * f;
+    bool run_one_task (std::thread::id id) {
+        std::function<void(int)> * f = nullptr;
         bool isPop = this->q.pop(f);
         if (isPop) {
+            DASSERT (f);
             std::unique_ptr<std::function<void(int id)>> func(f);  // at return, delete the function even if an exception occurred
+            register_worker (id);
             (*f)(-1);
+            deregister_worker (id);
+        } else {
+            DASSERT (f == nullptr);
         }
         return isPop;
     }
@@ -272,6 +280,19 @@ public:
     bool this_thread_is_in_pool () const {
         int *p = m_pool_members.get();
         return p && (*p);
+    }
+
+    void register_worker (std::thread::id id) {
+        spin_lock lock (m_worker_threadids_mutex);
+        m_worker_threadids[id] += 1;
+    }
+    void deregister_worker (std::thread::id id) {
+        spin_lock lock (m_worker_threadids_mutex);
+        m_worker_threadids[id] -= 1;
+    }
+    bool is_worker (std::thread::id id) {
+        spin_lock lock (m_worker_threadids_mutex);
+        return m_worker_threadids[id] != 0;
     }
 
 private:
@@ -284,6 +305,7 @@ private:
         std::shared_ptr<std::atomic<bool>> flag(this->flags[i]);  // a copy of the shared ptr to the flag
         auto f = [this, i, flag/* a copy of the shared ptr to the flag */]() {
             this->m_pool_members.reset (new int (1)); // I'm in the pool
+            register_worker (std::this_thread::get_id());
             std::atomic<bool> & _flag = *flag;
             std::function<void(int id)> * _f;
             bool isPop = this->q.pop(_f);
@@ -308,6 +330,7 @@ private:
                     break;  // if the queue is empty and this->isDone == true or *flag then return
             }
             this->m_pool_members.reset (); // I'm no longer in the pool
+            deregister_worker (std::this_thread::get_id());
         };
         this->threads[i].reset(new std::thread(f));  // compiler may not support std::make_unique()
     }
@@ -323,6 +346,8 @@ private:
     std::mutex mutex;
     std::condition_variable cv;
     boost::thread_specific_ptr<int> m_pool_members; // Who's in the pool
+    boost::container::flat_map<std::thread::id,int> m_worker_threadids;
+    spin_mutex m_worker_threadids_mutex;
 };
 
 
@@ -369,9 +394,9 @@ thread_pool::idle () const
 
 
 bool
-thread_pool::run_one_task ()
+thread_pool::run_one_task (std::thread::id id)
 {
-    return m_impl->run_one_task ();
+    return m_impl->run_one_task (id);
 }
 
 
@@ -387,6 +412,26 @@ bool
 thread_pool::this_thread_is_in_pool () const
 {
     return m_impl->this_thread_is_in_pool ();
+}
+
+
+
+void
+thread_pool::register_worker (std::thread::id id)
+{
+    m_impl->register_worker (id);
+}
+
+void
+thread_pool::deregister_worker (std::thread::id id)
+{
+    m_impl->deregister_worker (id);
+}
+
+bool
+thread_pool::is_worker (std::thread::id id)
+{
+    return m_impl->is_worker (id);
 }
 
 

--- a/src/libutil/thread_test.cpp
+++ b/src/libutil/thread_test.cpp
@@ -150,6 +150,16 @@ time_thread_pool ()
         if (! wedge)
             break;    // don't loop if we're not wedging
     }
+
+    Benchmarker bench;
+    bench ("std::this_thread::get_id()", [=](){
+        DoNotOptimize (std::this_thread::get_id());
+    });
+    std::thread::id threadid = std::this_thread::get_id();
+    bench ("register/deregister pool worker", [=](){
+        pool->register_worker (threadid);
+        pool->deregister_worker (threadid);
+    });
 }
 
 


### PR DESCRIPTION
* Move parallel_image_options to OIIO level in parallel.h as parallel_options.
* Add field to parallel_options to allow for recursion within the
  thread pool (use with caution to avoid thread explosion!).
* Use parallel_options as a control parameter to the various parallel_for
  family of functions as a way of communicating preferences for maximum
  threads, custom thread pool, and recursion.
* Some minor logic changes in chunking logic.
* More careful tracking of which threads are participating in the pool --
  not only pool threads, but also the *calling* threads that opportunistically
  execute tasks from the queue while they are waiting for the rest of the
  task set to be done... those also need to be protected from inadvertent
  recursively adding things to the queue.

Note that this should be source back-compatible, since the places we add
parallel_options to functions all are either (a) adding it to the end of
the parameter listings, with a default value, or (b) putting it in place
of a `nthreads` parameter (a parallel_options struct can be implicitly
constructed from an int, which does in fact initialize the maxthreads
field).

