### PR TITLE
Some documentation, help, and error message improvements

### DIFF
--- a/src/doc/imageinput.tex
+++ b/src/doc/imageinput.tex
@@ -1,4 +1,4 @@
-\chapter{Image I/O: Reading Images}
+\chapter{ImageInput: Reading Images}
 \label{chap:imageinput}
 \index{Image I/O API|(}
 

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -29,7 +29,7 @@ the new \emph{current image}.
 Most other commands either alter the current image (replacing it with
 the alteration), or in some cases will pull more than one image off the
 stack (such as the current image and the next item on the stack) and
-then push a new image.
+then push a new result image onto the stack.
 
 \subsubsection*{Argument order matters!}
 
@@ -41,8 +41,9 @@ on the command line is extremely important. For example,
 \end{code}
 
 \noindent has the effect of reading \qkw{in.tif} (thus making it the
-\emph{current image}), resizing it (as the current image, and making the
-resized version the new current image), and then writing the new current
+\emph{current image}), resizing it (taking the original off the stack,
+and placing the resized result back on the stack),
+and then writing the new current
 image to the file \qkw{out.tif}.  Contrast that with the following
 subtly-incorrect command:
 
@@ -69,12 +70,18 @@ take one or more arguments (like {\cf --resize} or {\cf -o}):
 A few commands take optional modifiers for options that are so
 rarely-used or confusing that they should not be required arguments.
 In these cases, they are appended to the command name, after a colon
-(``{\cf :}''), and with a \emph{name}{\cf =}\emph{value} format.  As
+(``{\cf :}''), and with a \emph{name}{\cf =}\emph{value} format.  Multiple
+optional modifiers can be chained together, with colon separators. As
 an example:
 
-\smallskip
-\hspace{0.25in} {\cf oiiotool --capture:camera=1 -o out.tif}
-\smallskip
+\begin{code}
+       oiiotool in.tif --text:x=400:y=600:color=1,0,0 "Hello" -o out.tif
+                       \____/\____/\____/\__________/ \____/
+                         |     |     |        |         |
+          command -------+     |     |        |         +----- required argument
+                               |     |        |
+   optional modifiers ---------+-----+--------+
+\end{code}
 
 \subsubsection*{Frame sequences}
 \index{frame sequences}\index{wildcard}

--- a/src/include/OpenImageIO/argparse.h
+++ b/src/include/OpenImageIO/argparse.h
@@ -44,6 +44,7 @@
 #endif
 
 #include <vector>
+#include <functional>
 
 #include <OpenImageIO/export.h>
 #include <OpenImageIO/oiioversion.h>

--- a/src/include/OpenImageIO/argparse.h
+++ b/src/include/OpenImageIO/argparse.h
@@ -164,7 +164,7 @@ public:
     /// (and clear any error flags).  If no error has occurred since the
     /// last time geterror() was called, it will return an empty string.
     std::string geterror () const;
-    
+
     /// Print the usage message to stdout.  The usage message is
     /// generated and formatted automatically based on the command and
     /// description arguments passed to parse().
@@ -179,6 +179,18 @@ public:
     ///
     std::string command_line () const;
 
+    // Type for a callback that writes something to the output stream.
+    typedef std::function<void(const ArgParse& ap, std::ostream&)> callback_t;
+
+    // Set callbacks to run that will print any matter you want as part
+    // of the verbose usage, before and after the options are detailed.
+    void set_preoption_help (callback_t callback) {
+        m_preoption_help = callback;
+    }
+    void set_postoption_help (callback_t callback) {
+        m_postoption_help = callback;
+    }
+
 private:
     int m_argc;                           // a copy of the command line argc
     const char **m_argv;                  // a copy of the command line argv
@@ -186,6 +198,8 @@ private:
     ArgOption *m_global;                  // option for extra cmd line arguments
     std::string m_intro;
     std::vector<ArgOption *> m_option;
+    callback_t m_preoption_help = [](const ArgParse& ap, std::ostream&){};
+    callback_t m_postoption_help = [](const ArgParse& ap, std::ostream&){};
 
     ArgOption *find_option(const char *name);
 

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1769,6 +1769,10 @@ bool
 ImageBuf::set_pixels (ROI roi, TypeDesc format, const void *data,
                       stride_t xstride, stride_t ystride, stride_t zstride)
 {
+    if (! initialized()) {
+        error ("Cannot set_pixels() on an uninitialized ImageBuf");
+        return false;
+    }
     bool ok;
     if (! roi.defined())
         roi = this->roi();

--- a/src/libutil/argparse.cpp
+++ b/src/libutil/argparse.cpp
@@ -500,6 +500,7 @@ ArgParse::usage () const
 {
     const size_t longline = 35;
     std::cout << m_intro << '\n';
+    m_preoption_help (*this, std::cout);
     size_t maxlen = 0;
     
     for (auto&& opt : m_option) {
@@ -527,6 +528,7 @@ ArgParse::usage () const
             }
         }
     }
+    m_postoption_help (*this, std::cout);
 }
 
 

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -179,14 +179,17 @@ ImageBuf_set_pixels_buffer (ImageBuf &self, ROI roi, py::buffer &buffer)
     if (size == 0) {
         return true;   // done
     }
-    const ImageSpec& spec (self.spec());
-    oiio_bufinfo buf (buffer.request(), spec.nchannels, spec.width,
-                      spec.height, spec.depth, self.spec().depth > 1 ? 3 : 2);
+    oiio_bufinfo buf (buffer.request(), roi.nchannels(), roi.width(),
+                      roi.height(), roi.depth(), self.spec().depth > 1 ? 3 : 2);
     if (! buf.data) {
+        self.error ("set_pixels unspecified error decoding the Python buffer");
         return false;  // failed sanity checks
     }
     if (! buf.data || buf.size != size) {
-        return false;  // failed sanity checks
+        self.error ("ImageBuf.set_pixels: array size (%d) did not match ROI size w=%d h=%d d=%d ch=%d (total %d)",
+                    buf.size, roi.width(), roi.height(), roi.depth(),
+                    roi.nchannels(), size);
+        return false;
     }
 
     py::gil_scoped_release gil;


### PR DESCRIPTION
Most notable is that `oiio --help` now prints some important usage tips
that explain command parsing, syntax of optional modifiers, and the path
where you can find the full PDF docs.

Along they way, I made a couple small additions to ArgParse, in order to
make it easier to insert this extra help information in the place where I
wanted it to appear.
