### PR TITLE
Increase "local" space of ParamValue

### DIFF
--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -67,7 +67,7 @@ ParamValue::init_noclear (ustring _name, TypeDesc _type, int _nvalues,
             if (_value)
                 memcpy (&m_data, _value, size);
             else
-                m_data.localval = 0;
+                memset (&m_data, 0, sizeof(m_data));
             m_copy = false;
             m_nonlocal = false;
         } else {

--- a/src/libutil/paramlist_test.cpp
+++ b/src/libutil/paramlist_test.cpp
@@ -184,6 +184,17 @@ void test_value_types ()
         // make sure we can retrieve rational as nicely formatted string
         OIIO_CHECK_EQUAL (p.get_string(), "1/2");
     }
+
+    // Double check that short data are "local", long data are allocated
+    ParamValue pvint ("", TypeInt, 1, nullptr);
+    OIIO_CHECK_ASSERT (pvint.datasize() == 4);
+    OIIO_CHECK_ASSERT (! pvint.is_nonlocal());
+    ParamValue pvcolor ("", TypeColor, 1, nullptr);
+    OIIO_CHECK_ASSERT (pvcolor.datasize() == 12);
+    OIIO_CHECK_ASSERT (! pvcolor.is_nonlocal());
+    ParamValue pvmatrix ("", TypeMatrix, 1, nullptr);
+    OIIO_CHECK_ASSERT (pvmatrix.datasize() == 64);
+    OIIO_CHECK_ASSERT (pvmatrix.is_nonlocal());
 }
 
 
@@ -256,6 +267,7 @@ test_paramlist ()
 
 int main (int argc, char *argv[])
 {
+    std::cout << "ParamValue size = " << sizeof(ParamValue) << "\n";
     test_value_types ();
     test_from_string ();
     test_paramlist ();


### PR DESCRIPTION
ParamValue holds "small" data locally (in the struct), and only
allocates when above that threshold. Previously, the threshold was 8
bytes, the size that the allcoated pointer would be anyway. But it seems
to me that the way we us ParamValue frequently must contain a color (3
floats), so I bumped the local space from 8 to 16 bytes (meaning it can
hold up to 4 floats or ints before a malloc). This increases the total
size of a ParamValue from 32 to 40 bytes, but I think it will make it
fairly rare to allocate, so we'll come out ahead.

This should all be inconsequential from an API perspective.
