### PR TITLE
Fix xmp parsing bug

### DIFF
--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -313,6 +313,8 @@ ImageSpec::image_bytes (bool native) const
 void
 ImageSpec::attribute (string_view name, TypeDesc type, const void *value)
 {
+    if (name.empty())   // Guard against bogus empty names
+        return;
     // Don't allow duplicates
     ParamValue *f = find_attribute (name);
     if (! f) {
@@ -327,6 +329,8 @@ ImageSpec::attribute (string_view name, TypeDesc type, const void *value)
 void
 ImageSpec::attribute (string_view name, TypeDesc type, string_view value)
 {
+    if (name.empty())   // Guard against bogus empty names
+        return;
     // Don't allow duplicates
     ParamValue *f = find_attribute (name);
     if (f) {

--- a/src/libOpenImageIO/xmp.cpp
+++ b/src/libOpenImageIO/xmp.cpp
@@ -114,6 +114,8 @@ static XMPtag xmptag [] = {
     { "tiff:Software", "Software", TypeDesc::STRING, TiffRedundant },
 
     { "exif:ColorSpace", "Exif:ColorSpace", TypeDesc::INT, ExifRedundant },
+    { "exif:PixelXDimension", "", TypeDesc::INT, ExifRedundant|TiffRedundant},
+    { "exif:PixelYDimension", "", TypeDesc::INT, ExifRedundant|TiffRedundant },
     { "exifEX:PhotographicSensitivity", "Exif:ISOSpeedRatings", TypeDesc::INT, ExifRedundant },
 
     { "xmp:CreateDate", "DateTime", TypeDesc::STRING, DateConversion|TiffRedundant },
@@ -275,7 +277,7 @@ add_attrib (ImageSpec &spec, const char *xmlname, const char *xmlvalue)
 #if DEBUG_XMP_READ
     std::cerr << "add_attrib " << xmlname << ": '" << xmlvalue << "'\n";
 #endif
-    std::string oiioname;
+    std::string oiioname = xmlname;
     TypeDesc oiiotype;
     int special = NothingSpecial;
 


### PR DESCRIPTION
A strange edge case turned up: when parsing a file with XMP data block,
and the XMP contained metadata "Exif:PixelXDimension" (or PixelYDimension),
a cascade of failures eventually led to a crash in `oiiotool -info -v`.

Fixes herein include:

* Add those two entries to the table of xmp fields we expect to see, in
  xmp.cpp.
* In xmp.cpp's add_attrib(), if something is not found in the xmp table
  (which among other things translates the XMP name into an OIIO name),
  stick with the xmp name it came with. We were actually adding it as an
  attribute using 'oiioname', which for that case was uninitialized!
* Finally, in ImageSpec::attribute(), check for empty names, which are
  obviously errors, and don't add those attributes.
