### PR TITLE
Simplify and speed up some unit tests

### DIFF
--- a/src/libutil/atomic_test.cpp
+++ b/src/libutil/atomic_test.cpp
@@ -49,9 +49,9 @@ using namespace OIIO;
 // and decrementing the crap out of it, and make sure it has the right
 // value at the end.
 
-static int iterations = 20000000;
+static int iterations = 2000000;
 static int numthreads = clamp ((int)Sysutil::physical_concurrency(), 2, 16);
-static int ntrials = 1;
+static int ntrials = 5;
 static bool verbose = false;
 static bool wedge = false;
 


### PR DESCRIPTION
(had this sitting in my tree for weeks, helps speed up build/test cycles)

For compute_test and filter_test, switch from time_trial to Benchmarker.
This reduces the code complexity, and because Benchmarker figures out
on its own how many iterations to do in order to get good timings, it
runs MUCH faster overall (we were using too many iterations), so this
will speed up testsuite runs.

Also reduce time spend on atomic_test by lowering iterations, raising trials.
