### PR TITLE
Performance tweaks

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1793,7 +1793,7 @@ ImageCacheImpl::getstats (int level) const
                 if (nthreads > 1) {
                     double perthreadtime = stats.fileio_time / (float)nthreads;
                     out << " (" << Strutil::timeintervalformat (perthreadtime)
-                        << " average per thread)";
+                        << " average per thread, for " << nthreads << " threads)";
                 }
             }
             out << "\n";

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3514,7 +3514,7 @@ ImageCache::create (bool shared)
         // exists, just return it, otherwise record the new cache.
         spin_lock guard (shared_image_cache_mutex);
         if (! shared_image_cache.get())
-            shared_image_cache.reset (new ImageCacheImpl);
+            shared_image_cache.reset(aligned_new<ImageCacheImpl>(), aligned_delete<ImageCacheImpl>);
 
 #if 0
         std::cerr << " shared ImageCache is "
@@ -3524,7 +3524,7 @@ ImageCache::create (bool shared)
     }
 
     // Doesn't need a shared cache
-    ImageCacheImpl *ic = new ImageCacheImpl;
+    ImageCacheImpl* ic = aligned_new<ImageCacheImpl>();
 #if 0
     std::cerr << "creating new ImageCache " << (void *)ic << "\n";
 #endif
@@ -3541,7 +3541,7 @@ ImageCache::destroy (ImageCache *x, bool teardown)
     spin_lock guard (shared_image_cache_mutex);
     if (x == shared_image_cache.get()) {
         // This is the shared cache, so don't really delete it. Invalidate
-        // it fully, closing the files and throwing out any tiles that 
+        // it fully, closing the files and throwing out any tiles that
         // nobody is currently holding references to.  But only delete the
         // IC fully if 'teardown' is true, and even then, it won't destroy
         // until nobody else is still holding a shared_ptr to it.
@@ -3550,7 +3550,7 @@ ImageCache::destroy (ImageCache *x, bool teardown)
             shared_image_cache.reset ();
     } else {
         // Not a shared cache, we are the only owner, so truly destroy it.
-        delete (ImageCacheImpl *) x;
+        aligned_delete(x);
     }
 }
 

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -68,6 +68,7 @@
 # include <Psapi.h>
 # include <cstdio>
 # include <io.h>
+# include <malloc.h>
 #else
 # include <sys/resource.h>
 #endif
@@ -581,5 +582,23 @@ Sysutil::max_open_files ()
 #endif
     return size_t(-1); // Couldn't figure out, so return effectively infinity
 }
+
+void* aligned_malloc(std::size_t size, std::size_t align) {
+#if defined(_WIN32)
+    return _aligned_malloc(size, align);
+#else
+    void* ptr;
+    return posix_memalign(&ptr, align, size) == 0 ? ptr : nullptr;
+#endif
+}
+
+void aligned_free(void* ptr) {
+#if defined(_WIN32)
+    _aligned_free(ptr);
+#else
+    free(ptr);
+#endif
+}
+
 
 OIIO_NAMESPACE_END


### PR DESCRIPTION
A small collection a minor performance tweaks. The most important is probably correctly aligning the `ImageCache` struct because this isn't guaranteed by the C++ standard.

These aren't moving the needle too much just yet, but show a small decrease in the relevant functions in vtune.