### PR TITLE
Replace std::unordered_map in the concurrent hash map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,9 @@ include (CTest)
 # Tell CMake to process the sub-directories
 add_subdirectory (src/libutil)
 
+find_or_download_robin_map ()
+
+
 # Add IO plugin directories -- if we are embedding plugins, we need to visit
 # these directories BEFORE the OpenImageIO target is established (in
 # src/libOpenImageIO). For each plugin, we append to the lists of source

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -541,7 +541,6 @@ macro (find_or_download_pybind11)
         message (STATUS "Building local Pybind11")
         set (PYBIND11_INSTALL_DIR "${PROJECT_SOURCE_DIR}/ext/pybind11")
         set (PYBIND11_GIT_REPOSITORY "https://github.com/pybind/pybind11")
-        set (PYBIND11_GIT_TAG "https://github.com/pybind/pybind11")
         if (NOT IS_DIRECTORY ${PYBIND11_INSTALL_DIR}/include)
             find_package (Git REQUIRED)
             execute_process(COMMAND
@@ -568,6 +567,38 @@ macro (find_or_download_pybind11)
                  "Or build with -DUSE_PYTHON=OFF.")
     endif ()
 endmacro()
+
+###########################################################################
+# Tessil/robin-map
+
+set (BUILD_ROBINMAP_VERSION "1e59f1993c7b6eace15032f38b5acb0bc34f530b" CACHE STRING "Preferred Tessil/robin-map version, of downloading/building our own")
+
+macro (find_or_download_robin_map)
+    # Download the headers from github
+    message (STATUS "Downloading local Tessil/robin-map")
+    set (ROBINMAP_INSTALL_DIR "${PROJECT_SOURCE_DIR}/ext/robin-map")
+    set (ROBINMAP_GIT_REPOSITORY "https://github.com/Tessil/robin-map")
+    if (NOT IS_DIRECTORY ${ROBINMAP_INSTALL_DIR}/tsl)
+        find_package (Git REQUIRED)
+        execute_process(COMMAND             ${GIT_EXECUTABLE} clone    ${ROBINMAP_GIT_REPOSITORY} -n ${ROBINMAP_INSTALL_DIR})
+        execute_process(COMMAND             ${GIT_EXECUTABLE} checkout ${BUILD_ROBINMAP_VERSION}
+                        WORKING_DIRECTORY   ${ROBINMAP_INSTALL_DIR})
+
+        if (IS_DIRECTORY ${ROBINMAP_INSTALL_DIR}/tsl)
+            message (STATUS "DOWNLOADED Tessil/robin-map to ${ROBINMAP_INSTALL_DIR}.\n"
+                     "Remove that dir to get rid of it.")
+        else ()
+            message (FATAL_ERROR "Could not download Tessil/robin-map")
+        endif ()
+    endif ()
+    set (ROBINMAP_INCLUDE_DIR "${ROBINMAP_INSTALL_DIR}")
+    if (ROBINMAP_INCLUDE_DIR)
+        message (STATUS "Tessil/robin-map include dir: ${ROBINMAP_INCLUDE_DIR}")
+    else ()
+        message (FATAL_ERROR "Tessil/robin-map is missing!")
+    endif ()
+endmacro()
+
 
 ###########################################################################
 

--- a/src/include/OpenImageIO/unordered_map_concurrent.h
+++ b/src/include/OpenImageIO/unordered_map_concurrent.h
@@ -127,13 +127,13 @@ public:
 
         // Dereferencing returns a reference to the hash table entry the
         // iterator refers to.
-        typename BinMap_t::value_type & operator* () {
+        const typename BinMap_t::value_type & operator* () const {
             return *m_biniterator;
         }
 
         /// Dereferencing returns a reference to the hash table entry the
         /// iterator refers to.
-        typename BinMap_t::value_type * operator-> () {
+        const typename BinMap_t::value_type * operator-> () const {
             return &(*m_biniterator);
         }
 
@@ -322,15 +322,14 @@ public:
         Bin &bin (m_bins[b]);
         if (do_lock)
             bin.lock ();
-        bool add = (bin.map.find (key) == bin.map.end());
-        if (add) {
-            // not found -- add it!
-            bin.map[key] = value;
+        auto result = bin.map.emplace(key, value);
+        if (result.second) {
+            // the insert was succesful!
             ++m_size;
         }
         if (do_lock)
             bin.unlock();
-        return add;
+        return result.second;
     }
 
     /// If the key is in the map, safely erase it.
@@ -342,10 +341,7 @@ public:
         Bin &bin (m_bins[b]);
         if (do_lock)
             bin.lock ();
-        typename BinMap_t::iterator it = bin.map.find (key);
-        if (it != bin.map.end()) {
-            bin.map.erase (it);
-        }
+        bin.map.erase (key);
         if (do_lock)
             bin.unlock();
     }

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -117,6 +117,7 @@ target_link_libraries (OpenImageIO
                        ${format_plugin_libs} # Add all the target link libraries from the plugins
                        ${Boost_LIBRARIES})
 
+include_directories (${ROBINMAP_INCLUDE_DIR})
 
 # Include OpenColorIO if using it
 if (USE_OCIO AND OCIO_FOUND)

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3211,7 +3211,7 @@ ImageCacheImpl::invalidate_all (bool force)
     std::vector<ustring> all_files;
     for (FilenameMap::iterator fileit = m_files.begin(), e = m_files.end();
              fileit != e;  ++fileit) {
-        ImageCacheFileRef &f (fileit->second);
+        const ImageCacheFileRef &f (fileit->second);
         ustring name = f->filename();
         Timer input_mutex_timer;
         recursive_lock_guard guard (f->m_input_mutex);

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -36,6 +36,8 @@
 #ifndef OPENIMAGEIO_IMAGECACHE_PVT_H
 #define OPENIMAGEIO_IMAGECACHE_PVT_H
 
+#include <tsl/robin_map.h>
+
 #include <boost/version.hpp>
 #include <boost/thread/tss.hpp>
 #include <boost/container/flat_map.hpp>
@@ -436,7 +438,18 @@ typedef intrusive_ptr<ImageCacheFile> ImageCacheFileRef;
 
 
 /// Map file names to file references
-typedef unordered_map_concurrent<ustring,ImageCacheFileRef,ustringHash,std::equal_to<ustring>, FILE_CACHE_SHARDS> FilenameMap;
+typedef unordered_map_concurrent<
+            ustring,
+            ImageCacheFileRef,
+            ustringHash,
+            std::equal_to<ustring>,
+            FILE_CACHE_SHARDS,
+            tsl::robin_map<
+                ustring,
+                ImageCacheFileRef,
+                ustringHash
+            >
+        > FilenameMap;
 typedef std::unordered_map<ustring,ImageCacheFileRef,ustringHash> FingerprintMap;
 
 
@@ -673,7 +686,18 @@ typedef intrusive_ptr<ImageCacheTile> ImageCacheTileRef;
 
 /// Hash table that maps TileID to ImageCacheTileRef -- this is the type of the
 /// main tile cache.
-typedef unordered_map_concurrent<TileID, ImageCacheTileRef, TileID::Hasher, std::equal_to<TileID>, TILE_CACHE_SHARDS> TileCache;
+typedef unordered_map_concurrent<
+            TileID,
+            ImageCacheTileRef,
+            TileID::Hasher,
+            std::equal_to<TileID>,
+            TILE_CACHE_SHARDS,
+            tsl::robin_map<
+                TileID,
+                ImageCacheTileRef,
+                TileID::Hasher
+            >
+        > TileCache;
 
 
 /// A very small amount of per-thread data that saves us from locking

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -485,7 +485,10 @@ public:
     void xyz (int x, int y, int z) { m_x = x; m_y = y; m_z = z; }
 
     /// Is this an uninitialized tileID?
-    bool empty () const { return m_file == NULL; }
+    bool empty () const { return m_file == nullptr; }
+
+    /// Treating it like a bool says whether it's non-empty.
+    operator bool () const { return m_file != nullptr; }
 
     /// Do the two ID's refer to the same tile?  
     ///

--- a/src/testtex/CMakeLists.txt
+++ b/src/testtex/CMakeLists.txt
@@ -1,4 +1,5 @@
 set (testtex_srcs testtex.cpp)
 add_executable (testtex ${testtex_srcs})
+include_directories (${ROBINMAP_INCLUDE_DIR})
 set_target_properties (testtex PROPERTIES FOLDER "Tools")
 target_link_libraries (testtex OpenImageIO ${SANITIZE_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})


### PR DESCRIPTION
This improves performance of the texture cache by a bit (proper benchmark numbers running over the weekend).

This is a very conservative first step, lots more can be done to further speed this up, and there are more uses of `std::unordered_map` we should benchmark, but I want to do those one at a time.