### PR TITLE
IC Cache "clock" algorithm -- fix iterator invalidation problem

### DIFF
--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -485,7 +485,10 @@ public:
     void xyz (int x, int y, int z) { m_x = x; m_y = y; m_z = z; }
 
     /// Is this an uninitialized tileID?
-    bool empty () const { return m_file == NULL; }
+    bool empty () const { return m_file == nullptr; }
+
+    /// Treating it like a bool says whether it's non-empty.
+    operator bool () const { return m_file != nullptr; }
 
     /// Do the two ID's refer to the same tile?  
     ///


### PR DESCRIPTION
It seems that the clock sweeping algorithm for finding cache pages to
evict (i.e., the uts of ImageCacheImpl::check_max_mem) relied on the
fact that it could erase entries from the cache and continue sweeping
with the iterator.

This worked fine for the original unordered_map, and as well for the
unordered_map_concurrent as long as the individual shards were also
implemented by unordered_map -- but only because unordered_map used
chaining and thus an iterator would still be valid after an erase
(assuming the iterator wasn't pointing to the erased item itself).

But when Chris tried using a different underlying hash table which didn't
have this property, things broke.

Some refactoring of check_max_mem fixes the problem. Basically, I just
save the ID of the advanced iterator, allow the iterator to be
invalidated by the erase operation and then re-establish a new iterator
by using the ID we saved in the previous step. Some other cleanup of the
loop also helps make the logic of the whole affair a little more clear.
