### PR TITLE
oiiotool: Better channel name logic when combining images

### DIFF
--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -178,6 +178,33 @@ ImageBufAlgo::IBAprep (ROI &roi, ImageBuf *dst, const ImageBuf *A,
                     spec.nchannels = minchans;
                 else
                     spec.nchannels = maxchans;
+                // Fix channel names and designations
+                spec.default_channel_names();
+                spec.alpha_channel = -1;
+                spec.z_channel = -1;
+                for (int c = 0; c < spec.nchannels; ++c) {
+                    if (A && A->spec().channel_name(c) != "") {
+                        spec.channelnames[c] = A->spec().channel_name(c);
+                        if (spec.alpha_channel < 0 && A->spec().alpha_channel == c)
+                            spec.alpha_channel = c;
+                        if (spec.z_channel < 0 && A->spec().z_channel == c)
+                            spec.z_channel = c;
+                    }
+                    else if (B && B->spec().channel_name(c) != "") {
+                        spec.channelnames[c] = B->spec().channel_name(c);
+                        if (spec.alpha_channel < 0 && B->spec().alpha_channel == c)
+                            spec.alpha_channel = c;
+                        if (spec.z_channel < 0 && B->spec().z_channel == c)
+                            spec.z_channel = c;
+                    }
+                    else if (C && C->spec().channel_name(c) != "") {
+                        spec.channelnames[c] = C->spec().channel_name(c);
+                        if (spec.alpha_channel < 0 && C->spec().alpha_channel == c)
+                            spec.alpha_channel = c;
+                        if (spec.z_channel < 0 && C->spec().z_channel == c)
+                            spec.z_channel = c;
+                    }
+                }
             }
             // For multiple inputs, if they aren't the same data type, punt and
             // allocate a float buffer. If the user wanted something else,

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -55,6 +55,15 @@ copyA.0009.jpg       :  128 x   96, 3 channel, uint8 jpeg
 copyA.0010.jpg       :  128 x   96, 3 channel, uint8 jpeg
 Reading black.tif
     oiio:DebugOpenConfig!: 42
+Reading add_rgb_rgba.exr
+add_rgb_rgba.exr     :   64 x   64, 4 channel, float openexr
+    SHA-1: 9CCAC57A0A0D45F40EF14337A95207094D008E02
+    channel list: R, G, B, A
+    oiio:ColorSpace: "Linear"
+    compression: "zip"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0 0
+    screenWindowWidth: 1
 Comparing "filled.tif" and "ref/filled.tif"
 PASS
 Comparing "autotrim.tif" and "ref/autotrim.tif"

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -241,6 +241,12 @@ command += oiiotool ("--info -v -metamatch Debug --iconfig oiio:DebugOpenConfig!
 command += oiiotool ("--pattern fill:color=.6,.5,.4,.3,.2 64x64 5 -d uint8 -o const5.tif")
 command += oiiotool ("-i:ch=R,G,B const5.tif -o const5-rgb.tif")
 
+# Test that combining two images, if the first has no alpha but the second
+# does, gets the right channel names instead of just copying from the first.
+command += oiiotool ("-pattern constant:color=1,0,0 64x64 3 -pattern constant:color=0,1,0,1 64x64 4 -add -o add_rgb_rgba.exr")
+command += info_command ("add_rgb_rgba.exr", safematch=True)
+
+
 # To add more tests, just append more lines like the above and also add
 # the new 'feature.tif' (or whatever you call it) to the outputs list,
 # below.


### PR DESCRIPTION
Interesting edge case I came across:

    oiiotool rgb.exr rgba.exr -add -o out.exr

The logic was that the result had 4 channels (the greater of the two
inputs), but the channel names were just copied straight from the first
input, and it was (coincidentally, in this example) the one with fewer
channels, so it did not know that channel 3 was alpha, it would just get
"R", "G", "B", "channel3".

The new logic is that for all channels, it tries to get the name from
the first image, and if it doesn't exist, then it gets it from the
second. Also it's smarter about setting alpha_channel and z_channel in
the spec of the output, even if those didn't come along with the first
input.

