### PR TITLE
New hash functions in hash.h and revamped hash_test

### DIFF
--- a/site/spi/Makefile-bits-arnold
+++ b/site/spi/Makefile-bits-arnold
@@ -42,7 +42,7 @@ OCIO_SPCOMP_VERSION ?= 2
 ## Rhel7 (current)
 ifeq (${SP_OS}, rhel7)
     USE_CPP ?= 11
-    USE_SIMD ?= sse4.1
+    USE_SIMD ?= sse4.1,aes
     CMAKE ?= cmake
     USE_NINJA ?= 1
     NINJA ?= ninja

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -6,7 +6,7 @@ message (STATUS "CMAKE_CXX_COMPILER_ID is ${CMAKE_CXX_COMPILER_ID}")
 
 set (USE_CPP 11 CACHE STRING "C++ standard to prefer (11, 14, etc.)")
 option (USE_LIBCPLUSPLUS "Compile with clang libc++")
-set (USE_SIMD "" CACHE STRING "Use SIMD directives (0, sse2, sse3, ssse3, sse4.1, sse4.2, avx, avx2, avx512f, f16c)")
+set (USE_SIMD "" CACHE STRING "Use SIMD directives (0, sse2, sse3, ssse3, sse4.1, sse4.2, avx, avx2, avx512f, f16c, aes)")
 option (STOP_ON_WARNING "Stop building if there are any compiler warnings" ON)
 option (HIDE_SYMBOLS "Hide symbols not in the public API" OFF)
 option (USE_CCACHE "Use ccache if found" ON)

--- a/src/include/OpenImageIO/hash.h
+++ b/src/include/OpenImageIO/hash.h
@@ -59,6 +59,84 @@ OIIO_NAMESPACE_BEGIN
 using std::unordered_map;
 using std::hash;
 
+namespace fasthash {
+
+/* The MIT License
+   Copyright (C) 2012 Zilong Tan (eric.zltan@gmail.com)
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the "Software"), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+// Compression function for Merkle-Damgard construction.
+// This function is generated using the framework provided.
+static inline uint64_t mix(uint64_t h) {
+	h ^= h >> 23;
+	h *= 0x2127599bf4325c37ULL;
+	h ^= h >> 47;
+	return h;
+}
+
+inline uint64_t fasthash64(const void *buf, size_t len, uint64_t seed)
+{
+	const uint64_t    m = 0x880355f21e6d1965ULL;
+	const uint64_t *pos = (const uint64_t *)buf;
+	const uint64_t *end = pos + (len / 8);
+	const unsigned char *pos2;
+	uint64_t h = seed ^ (len * m);
+	uint64_t v;
+
+	while (pos != end) {
+		v  = *pos++;
+		h ^= mix(v);
+		h *= m;
+	}
+
+	pos2 = (const unsigned char*)pos;
+	v = 0;
+
+	switch (len & 7) {
+        case 7: v ^= (uint64_t)pos2[6] << 48;
+        case 6: v ^= (uint64_t)pos2[5] << 40;
+        case 5: v ^= (uint64_t)pos2[4] << 32;
+        case 4: v ^= (uint64_t)pos2[3] << 24;
+        case 3: v ^= (uint64_t)pos2[2] << 16;
+        case 2: v ^= (uint64_t)pos2[1] << 8;
+        case 1: v ^= (uint64_t)pos2[0];
+                h ^= mix(v);
+                h *= m;
+	}
+
+	return mix(h);
+}
+
+// simplified version for hashing just a few ints
+inline uint64_t fasthash64(const std::initializer_list<uint64_t> buf) {
+	const uint64_t    m = 0x880355f21e6d1965ULL;
+	uint64_t h = (buf.size() * sizeof(uint64_t)) * m;
+	for (const uint64_t v : buf) {
+		h ^= mix(v);
+		h *= m;
+	}
+	return mix(h);
+}
+
+} // namespace fasthash
+
 
 namespace xxhash {
 

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3320,13 +3320,7 @@ ImageCacheImpl::resolve_udim (ImageCacheFile *udimfile, float &s, float &t)
         // been added by another thread during the brief time when we
         // weren't holding any lock.
         spin_rw_mutex::write_lock_guard rlock (udim_lookup_mutex);
-        UdimLookupMap::iterator f = udimfile->m_udim_lookup.find (id);
-        if (f == udimfile->m_udim_lookup.end()) {
-            // Not yet in the lookup table, so create one so we don't have
-            // to do that lookup again.
-            udimfile->m_udim_lookup[id] = realfile;
-            // std::cout << "Associate " << id << " with " << (void*)realfile << "\n";
-        }
+        udimfile->m_udim_lookup.emplace(id, realfile);
     }
     return realfile;
 }

--- a/src/libutil/hash_test.cpp
+++ b/src/libutil/hash_test.cpp
@@ -29,11 +29,11 @@
 */
 
 
-#include <iostream>
 #include <cstdio>
-#include <string>
-#include <vector>
 #include <functional>
+#include <iostream>
+#include <random>
+#include <vector>
 
 #include <OpenImageIO/hash.h>
 #include <OpenImageIO/timer.h>
@@ -46,124 +46,146 @@
 
 using namespace OIIO;
 
-static int iterations = 100000000;
+static int iterations = 100 << 20;
 static int ntrials = 1;
 static bool verbose = false;
 
-static const int shortlength = 5;
-static const int medlength = 50;
-static const int longlength = 501;  // Purposely not multiple of 4
-static std::string shortstring (shortlength,char('a'));
-static std::string medstring (medlength,char('a'));
-static std::string longstring (longlength,char('a'));
-static std::vector<uint32_t> data (1000,42);
-size_t dummy = 0;
-
+static std::vector<uint32_t> data;
 
 size_t
-test_bjhash_small ()
+test_bjhash (int len)
 {
-    void *ptr = &data[0];
-    int len = 2*sizeof(int);
+    char* ptr = reinterpret_cast<char*>(data.data());
     size_t a = 0;
-    for (int i = 0, e = iterations/len;  i < e;  ++i)
-        a += bjhash::hashlittle (ptr, len);
+    for (int i = 0, e = iterations / len;  i < e; i++, ptr += len)
+        a += bjhash::hashlittle(ptr, len);
     return a;
 }
 
-
-
 size_t
-test_bjhash_big ()
+test_xxhash (int len)
 {
-    void *ptr = &data[0];
-    int len = (int)(data.size() * sizeof(int));
+    char* ptr = reinterpret_cast<char*>(data.data());
     size_t a = 0;
-    for (int i = 0, e = iterations/len;  i < e;  ++i)
-        a += bjhash::hashlittle (ptr, len);
+    for (int i = 0, e = iterations / len;  i < e; i++, ptr += len)
+        a += xxhash::xxhash (ptr, len, 0);
     return a;
 }
 
-
-
 size_t
-test_bjhash_small_words ()
+test_farmhash (int len)
 {
-    uint32_t *ptr = &data[0];
-    int len = 2*sizeof(int);
+    char* ptr = reinterpret_cast<char*>(data.data());
     size_t a = 0;
-    for (int i = 0, e = iterations/len;  i < e;  ++i)
-        a += bjhash::hashword (ptr, len/sizeof(int));
+    for (int i = 0, e = iterations / len;  i < e; i++, ptr += len)
+        a += farmhash::Hash (ptr, len);
     return a;
 }
 
-
-
 size_t
-test_bjhash_big_words ()
+test_fasthash64 (int len)
 {
-    uint32_t *ptr = &data[0];
-    int len = (int)(data.size() * sizeof(int));
+    char* ptr = reinterpret_cast<char*>(data.data());
     size_t a = 0;
-    for (int i = 0, e = iterations/len;  i < e;  ++i)
-        a += bjhash::hashword (ptr, len/sizeof(int));
+    for (int i = 0, e = iterations / len;  i < e; i++, ptr += len)
+        a += fasthash::fasthash64 (ptr, len, 0);
     return a;
 }
 
+#ifdef __AES__
 
+// https://github.com/gamozolabs/falkhash
 
-size_t
-test_xxhash (const void *ptr, size_t len)
+// Licensed with the unlicense ( http://choosealicense.com/licenses/unlicense/ )
+
+inline uint64_t falkhash(
+                void     *pbuf,
+                uint64_t  len,
+                uint64_t  pseed = 0)
 {
-    size_t a = 0;
-    for (int i = 0, e = iterations/len;  i < e;  ++i)
-        a += xxhash::xxhash (ptr, len);
-    return a;
-}
+    uint8_t *buf = (uint8_t*)pbuf;
 
+    uint64_t iv[2];
 
+    __m128i hash, seed;
 
-size_t
-test_bjstrhash (const std::string &str)
-{
-    int len = int(str.length());
-    size_t a = 0;
-    for (int i = 0, e = iterations/len;  i < e;  ++i) {
-        a += bjhash::strhash (str);
-        dummy = a;
+    /* Create the 128-bit seed. Low 64-bits gets seed, high 64-bits gets
+     * seed + len + 1. The +1 ensures that both 64-bits values will never be
+     * the same (with the exception of a length of -1. If you have that much
+     * ram, send me some).
+     */
+    iv[0] = pseed;
+    iv[1] = pseed + len + 1;
+
+    /* Load the IV into a __m128i */
+    seed = _mm_loadu_si128((__m128i*)iv);
+
+    /* Hash starts out with the seed */
+    hash = seed;
+
+    while (len) {
+        uint8_t tmp[0x50];
+
+        __m128i piece[5];
+
+        /* If the data is smaller than one chunk, pad it with zeros */
+        if (len < 0x50) {
+            memset(tmp, 0, 0x50);
+            for (int i = 0; i < int(len); i++)
+                tmp[i] = buf[i];
+            buf = tmp;
+            len = 0x50;
+        }
+
+        /* Load up the data into __m128is */
+        piece[0] = _mm_loadu_si128((__m128i*)(buf + 0*0x10));
+        piece[1] = _mm_loadu_si128((__m128i*)(buf + 1*0x10));
+        piece[2] = _mm_loadu_si128((__m128i*)(buf + 2*0x10));
+        piece[3] = _mm_loadu_si128((__m128i*)(buf + 3*0x10));
+        piece[4] = _mm_loadu_si128((__m128i*)(buf + 4*0x10));
+
+        /* xor each piece against the seed */
+        piece[0] = _mm_xor_si128(piece[0], seed);
+        piece[1] = _mm_xor_si128(piece[1], seed);
+        piece[2] = _mm_xor_si128(piece[2], seed);
+        piece[3] = _mm_xor_si128(piece[3], seed);
+        piece[4] = _mm_xor_si128(piece[4], seed);
+
+        /* aesenc all into piece[0] */
+        piece[0] = _mm_aesenc_si128(piece[0], piece[1]);
+        piece[0] = _mm_aesenc_si128(piece[0], piece[2]);
+        piece[0] = _mm_aesenc_si128(piece[0], piece[3]);
+        piece[0] = _mm_aesenc_si128(piece[0], piece[4]);
+
+        /* Finalize piece[0] by aesencing against seed */
+        piece[0] = _mm_aesenc_si128(piece[0], seed);
+
+        /* aesenc the piece into the hash */
+        hash = _mm_aesenc_si128(hash, piece[0]);
+
+        buf += 0x50;
+        len -= 0x50;
     }
-    return a;
+
+    /* Finalize hash by aesencing against seed four times */
+    hash = _mm_aesenc_si128(hash, seed);
+    hash = _mm_aesenc_si128(hash, seed);
+    hash = _mm_aesenc_si128(hash, seed);
+    hash = _mm_aesenc_si128(hash, seed);
+
+    return _mm_cvtsi128_si64(hash);
 }
-
-
 
 size_t
-test_farmhashstr (const std::string &str)
+test_falkhash (int len)
 {
-    int len = int(str.length());
+    char* ptr = reinterpret_cast<char*>(data.data());
     size_t a = 0;
-    for (int i = 0, e = iterations/len;  i < e;  ++i) {
-        a += farmhash::Hash (str);
-        // dummy = a;
-    }
+    for (int i = 0, e = iterations / len;  i < e; i++, ptr += len)
+        a += falkhash (ptr, len, 0);
     return a;
 }
-
-
-
-size_t
-test_farmhashchar (const char *str)
-{
-    int len = strlen(str);
-    size_t a = 0;
-    for (int i = 0, e = iterations/len;  i < e;  ++i) {
-        a += farmhash::Hash (str, strlen(str));
-        // dummy = a;
-    }
-    return a;
-}
-
-
+#endif
 
 static void
 getargs (int argc, char *argv[])
@@ -191,8 +213,6 @@ getargs (int argc, char *argv[])
     }
 }
 
-
-
 int main (int argc, char *argv[])
 {
 #if !defined(NDEBUG) || defined(OIIO_CI) || defined(OIIO_CODE_COVERAGE)
@@ -205,69 +225,54 @@ int main (int argc, char *argv[])
 
     getargs (argc, argv);
 
-    double t;
+    // fill data with random values so we can hash it a bunch of different ways
+    std::mt19937 rng(42);
+    data.resize(iterations / sizeof(data[0]), 0);
+    for (uint32_t& d : data)
+        d = rng();
 
-    std::cout << "All times are seconds per " << iterations << " bytes.\n\n";
+    printf("All times are seconds per %s\n", Strutil::memformat(iterations).c_str());
 
-    t = time_trial (test_bjhash_small, ntrials);
-    std::cout << "BJ hash of small data as bytes: " 
-              << Strutil::timeintervalformat(t, 2) << "\n";
-    t = time_trial (test_bjhash_small_words, ntrials);
-    std::cout << "BJ hash of small data as words: " 
-              << Strutil::timeintervalformat(t, 2) << "\n";
-    t = time_trial (test_bjhash_big, ntrials);
-    std::cout << "BJ hash of big data: " 
-              << Strutil::timeintervalformat(t, 2) << "\n";
-    t = time_trial (test_bjhash_big_words, ntrials);
-    std::cout << "BJ hash of big data as words: " 
-              << Strutil::timeintervalformat(t, 2) << "\n";
+    // a sampling of sizes, both tiny and large-ish
+    int hashlen[] = { 1, 2, 4, 8, 12, 16, 20, 24, 32, 64, // small to medium
+                      3, 5, 6, 7, 13, 15, 19, 23, 49, 67, // small to medium - odd sizes
+                         128, 256, 512, 1024,             // large (even)
+                     95, 155, 243, 501, 1337,             // large (odd sizes)
+                         iterations                       // huge
+    };
 
-    t = time_trial (std::bind(test_xxhash, &data[0], 2*sizeof(data[0])), ntrials);
-    std::cout << "XX hash of small data: " 
-              << Strutil::timeintervalformat(t, 2) << "\n";
-    t = time_trial (std::bind(test_xxhash, &data[0], data.size()*sizeof(data[0])), ntrials);
-    std::cout << "XX hash of big data: " 
-              << Strutil::timeintervalformat(t, 2) << "\n";
+    // present results from smallest to largest
+    std::sort(std::begin(hashlen), std::end(hashlen));
 
-    t = time_trial (std::bind(test_bjstrhash, shortstring), ntrials);
-    std::cout << "BJ strhash hash of short string: "
-              << Strutil::timeintervalformat(t, 2) << "\n";
-    t = time_trial (std::bind(test_bjstrhash, medstring), ntrials);
-    std::cout << "BJ strhash hash of medium string: "
-              << Strutil::timeintervalformat(t, 2) << "\n";
-    t = time_trial (std::bind(test_bjstrhash, longstring), ntrials);
-    std::cout << "BJ strhash hash of long string: "
-              << Strutil::timeintervalformat(t, 2) << "\n";
+    auto candidates = {
+        std::make_pair(test_bjhash       , "BJ hash      "),
+        std::make_pair(test_xxhash       , "XX hash      "),
+        std::make_pair(test_farmhash     , "farmhash     "),
+        std::make_pair(test_fasthash64   , "fasthash64   "),
+#ifdef __AES__
+        std::make_pair(test_falkhash     , "falkhash     "),
+#endif
+    };
 
-    t = time_trial (std::bind(test_farmhashstr, shortstring), ntrials);
-    std::cout << "farmhash of short string: "
-              << Strutil::timeintervalformat(t, 2) << "\n";
-    t = time_trial (std::bind(test_farmhashstr, medstring), ntrials);
-    std::cout << "farmhash of medium string: "
-              << Strutil::timeintervalformat(t, 2) << "\n";
-    t = time_trial (std::bind(test_farmhashstr, longstring), ntrials);
-    std::cout << "farmhash of long string: "
-              << Strutil::timeintervalformat(t, 2) << "\n";
+    for (int len : hashlen) {
+        auto mem = Strutil::memformat(len, 2);
+        printf("\nHash benchmark for %s hashes\n", mem.c_str());
 
-    t = time_trial (std::bind(test_farmhashchar, shortstring.c_str()), ntrials);
-    std::cout << "farmhash of short char*: "
-              << Strutil::timeintervalformat(t, 2) << "\n";
-    t = time_trial (std::bind(test_farmhashchar, medstring.c_str()), ntrials);
-    std::cout << "farmhash of medium char*: "
-              << Strutil::timeintervalformat(t, 2) << "\n";
-    t = time_trial (std::bind(test_farmhashchar, longstring.c_str()), ntrials);
-    std::cout << "farmhash of long char*: "
-              << Strutil::timeintervalformat(t, 2) << "\n";
+        double best_time = std::numeric_limits<double>::max();
+        const char* best = "";
+        for (auto&& c : candidates) {
+            double range;
+            double t = time_trial(std::bind(c.first, len), ntrials, 1, &range);
+            printf("  %s took %s (range %s)\n", c.second, Strutil::timeintervalformat(t, 3).c_str(), Strutil::timeintervalformat(range, 3).c_str());
+            if (t < best_time) {
+                best_time = t;
+                best = c.second;
+            }
+        }
 
-    t = time_trial (std::bind(test_xxhash, shortstring.c_str(), shortstring.length()), ntrials);
-    std::cout << "xxhash XH64 of short string: "
-              << Strutil::timeintervalformat(t, 2) << "\n";
-    t = time_trial (std::bind(test_xxhash, medstring.c_str(), medstring.length()), ntrials);
-    std::cout << "xxhash XH64 of medium string: "
-              << Strutil::timeintervalformat(t, 2) << "\n";
-    t = time_trial (std::bind(test_xxhash, longstring.c_str(), longstring.length()), ntrials);
-    std::cout << "xxhash XH64 of long string: "
-              << Strutil::timeintervalformat(t, 2) << "\n";
+        printf("%s winner: %s\n", mem.c_str(), best);
+        fflush(stdout);
+    }
 
     return unit_test_failures;
 }


### PR DESCRIPTION
Just add a new hash (fasthash64) and one called falkhash that is disabled by default, but quite fast for large buffers if you have the AES instruction set

I tried a whole bunch more, but on my work machine - farmhash (our current default) is still the best.

fasthash64 is interesting because it is quite short (inline-able) and easy for the compiler to specialize for short lists of 64 bit ints. In these contexts it can do better than farmhash, and is quite flexible.


There's also an unrelated minor optimization for udims in here I had sitting around.
