### PR TITLE
Speed up TIFF scanlines output

### DIFF
--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -535,9 +535,7 @@ pvt::parallel_convert_from_float (const float *src, void *dst, size_t nvals,
     if (format.basetype == TypeDesc::FLOAT)
         return src;
 
-    const int64_t blocksize = 100000;   // good choice?
-
-    parallel_for_chunked (0, int64_t(nvals), blocksize, [=](int64_t b, int64_t e){
+    parallel_for_chunked (0, int64_t(nvals), 0, [=](int64_t b, int64_t e){
         convert_from_float (src+b, (char *)dst+b*format.size(), e-b, format);
     });
     return dst;

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -466,7 +466,7 @@ ImageOutput::write_image (TypeDesc format, const void *data,
         }
     } else {
         // Scanline image
-        const int chunk = 256;
+        int chunk = std::max (1, (1<<26)/int(m_spec.scanline_bytes(true)));
         for (int z = 0;  z < m_spec.depth;  ++z)
             for (int y = 0;  y < m_spec.height && ok;  y += chunk) {
                 int yend = std::min (y+m_spec.y+chunk, m_spec.y+m_spec.height);


### PR DESCRIPTION
TIFF didn't have write_scanlines() of its own, just depending on the
default implementation, which calls write_scanline repeatedly.  So we
give it a proper write_scanlines implementation, which tries to speed
things up by first doing all the conversions and data shuffling on the
whole block (which can be parallelized by our code), before writing the
individual scanlines.

Slightly adjust the chunk size for write_image (it was a little too
conservative).

In parallel_convert_from_float, instead of a hard-coded block size, let
parallel_for_chunked make the choice on its own, which will be better
because it takes into account the number of threads in the pool

These changes, cumulatively, speed up whole-image writes of scanline TIFF
files by about 10%. I was hoping for more than this, but the bottleneck
is the unthreaded code in libtiff that's doing the compression encoding.

This wasn't a problem on the specific images I was testing, but I also
noticed an odditity in the way we did image checkpointing for TIFF
output -- it tries to only checkpoint every 5 seconds (which is longer
than most image writes, so it usually doesn't happen anyway), but the
timer started running when the ImageOutput was created. Seems to me now
that it's better to start the timer when the output opens, not merely
when the ImageOutput is constructed (in case there's a delay between
the two).
