### PR TITLE
More careful gzopen on windows.

### DIFF
--- a/src/zfile.imageio/zfile.cpp
+++ b/src/zfile.imageio/zfile.cpp
@@ -143,13 +143,14 @@ OIIO_PLUGIN_EXPORTS_END
 bool
 ZfileInput::valid_file (const std::string &filename) const
 {
-    FILE *fd = Filesystem::fopen (filename, "rb");
-    gzFile gz = (fd) ? gzdopen (fileno (fd), "rb") : NULL;
-    if (! gz) {
-        if (fd)
-            fclose (fd);
+#ifdef _WIN32
+    std::wstring wpath = Strutil::utf8_to_utf16(filename);
+    gzFile gz = gzopen_w (wpath.c_str(), "rb");
+#else
+    gzFile gz = gzopen (filename.c_str(), "rb");
+#endif
+    if (! gz)
         return false;
-    }
 
     ZfileHeader header;
     gzread (gz, &header, sizeof(header));


### PR DESCRIPTION
This could make crashes with certain filenames on Windows. And even though zfiles are rare, when OIIO is not sure which plugin to use, it tries them all, so when given a bogus filename or a file that isn't really an image, it will be called sooner or later.

Submitted on behalf of Thiago Ize.
