### PR TITLE
Linking with OpenCV highgui component is not needed for 3.X and newer.

### DIFF
--- a/src/cmake/modules/FindOpenCV.cmake
+++ b/src/cmake/modules/FindOpenCV.cmake
@@ -51,8 +51,10 @@ set (libdirs "${PROJECT_SOURCE_DIR}/lib"
              )
 
 
-set (opencv_components opencv_highgui opencv_imgproc opencv_core)
+set (opencv_components opencv_imgproc opencv_core)
 if (NOT ${OpenCV_VERSION} VERSION_LESS 3.0.0)
+    set (opencv_components opencv_videoio ${opencv_components})
+else (NOT ${OpenCV_VERSION} VERSION_LESS 3.0.0)
     set (opencv_components opencv_videoio ${opencv_components})
 endif ()
 foreach (component ${opencv_components})


### PR DESCRIPTION
## Description

It is not necessary to link against the OpenCV highgui component in version 3.X and above as it has been split into 3 components.

## Checklist:

- [x ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x ] My code follows the prevailing code style of this project.

