### PR TITLE
simd.h touchups

### DIFF
--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -917,6 +917,12 @@ void test_bitwise_bool ()
     OIIO_CHECK_EQUAL (reduce_or(onebit), true);
     OIIO_CHECK_EQUAL (reduce_and(VEC::True()), true);
     OIIO_CHECK_EQUAL (reduce_and(onebit), false);
+    OIIO_CHECK_EQUAL (all(VEC::True()), true);
+    OIIO_CHECK_EQUAL (any(VEC::True()), true);
+    OIIO_CHECK_EQUAL (none(VEC::True()), false);
+    OIIO_CHECK_EQUAL (all(VEC::False()), false);
+    OIIO_CHECK_EQUAL (any(VEC::False()), false);
+    OIIO_CHECK_EQUAL (none(VEC::False()), true);
 
     benchmark2 ("operator&", do_and<VEC>, a, b);
     benchmark2 ("operator|", do_or<VEC>, a, b);


### PR DESCRIPTION
* Minor improvements to rcp_fast, rsqrt_fast for AVX512.

* Maked load/store tweaks:
  * Remove some concern comments on 4-wide masked load/store for AVX
    because benchmarks show it to be no concern (the lines of potential
    concern were indeed faster on AVX).
  * Change implementation of 4-wide scatter and masked scatter for avx512
    after benchmarks show that the non-SIMD way is faster. Come back to
    retest on future hardware.

* Speed up reduce_and / reduce_or for vbool16

* Fix typo
