### PR TITLE
Field3d: don't crash under opening failures

### DIFF
--- a/src/field3d.imageio/field3dinput.cpp
+++ b/src/field3d.imageio/field3dinput.cpp
@@ -342,6 +342,12 @@ Field3DInput::valid_file (const std::string &filename) const
     if (! Filesystem::is_regular (filename))
         return false;
 
+    // The f3d is flaky when opening some non-f3d files. It should just fail
+    // gracefully, but it doesn't always. So to keep my sanity, don't even
+    // bother trying for filenames that don't end in .f3d.
+    if (! Strutil::iends_with (filename, ".f3d"))
+        return false;
+
     oiio_field3d_initialize ();
 
     bool ok = false;
@@ -369,6 +375,12 @@ Field3DInput::open (const std::string &name, ImageSpec &newspec)
         close();
 
     if (! Filesystem::is_regular (name))
+        return false;
+
+    // The f3d is flaky when opening some non-f3d files. It should just fail
+    // gracefully, but it doesn't always. So to keep my sanity, don't even
+    // bother trying for filenames that don't end in .f3d.
+    if (! Strutil::iends_with (name, ".f3d"))
         return false;
 
     oiio_field3d_initialize ();


### PR DESCRIPTION
Field3D is supposed to just throw an exception that we can catch if it
can't open the file, but under some circumstances it just plain crashes
when asked to open a file that isn't a f3d file at all.

The reason this comes up is that OIIO's behaveior when the usual reader
can't open a file is to try ALL of them (hoping that maybe the file is
just mis-named) or the hint heuristics are wrong.

I'm not inclined to try to fix the field3d internals myself at this
moment, so for now I'm just making the OIIO field3d reader fail if the
file is not named ".f3d". This violates our intended rule of "it doesn't
matter what the file is called", but I can only rely on that if the
underlying format library is rock solid when presented a file of the
wrong type.

