### PR TITLE
OpenEXR reader: gracefully reject subsampled channels

### DIFF
--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -689,8 +689,8 @@ main (int argc, const char *argv[])
         if (! in) {
             std::string err = geterror();
             if (err.empty())
-                err = Strutil::format ("Could not open \"%s\"", s.c_str());
-            std::cerr << "iinfo: " << err << "\n";
+                err = Strutil::format ("Could not open \"%s\"", s);
+            std::cerr << "iinfo ERROR: " << err << "\n";
             continue;
         }
         ImageSpec spec = in->spec();


### PR DESCRIPTION
The EXR spec allows for channels to be subsampled, but we don't handle
this properly in the exr ImageInput, and it can lead to a crash.  Since
it's a rarely used feature (if ever), I'm not inclined to fix it for
real until somebody says they actually need it. Instead, let's just
detect this unusual case and correctly issue an error saying that we
don't support it.

This required a bit of housekeeping to allow the errors to be propagated
up from the place where it was convenient to notice this.

