### PR TITLE
Fix Strutil::strtod_l/strtod_l on Hurd

### DIFF
--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -1146,7 +1146,7 @@ Strutil::strtof (const char *nptr, char **endptr)
     // Complex case -- CHEAT by making a copy of the string and replacing
     // the decimal, then use system strtof!
     std::string s (nptr);
-    const char* pos = strchr (nptr, pointchar);
+    const char* pos = strchr (nptr, nativepoint);
     if (pos) {
         s[pos-nptr] = nativepoint;
         auto d = strtof (s.c_str(), endptr);
@@ -1182,7 +1182,7 @@ Strutil::strtod (const char *nptr, char **endptr)
     // Complex case -- CHEAT by making a copy of the string and replacing
     // the decimal, then use system strtod!
     std::string s (nptr);
-    const char* pos = strchr (nptr, pointchar);
+    const char* pos = strchr (nptr, nativepoint);
     if (pos) {
         s[pos-nptr] = nativepoint;
         auto d = ::strtod (s.c_str(), endptr);

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -1123,7 +1123,7 @@ float
 Strutil::strtof (const char *nptr, char **endptr)
 {
     // Can use strtod_l on platforms that support it
-#if defined (__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+#if defined (__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__GLIBC__)
     // static initialization inside function is thread-safe by C++11 rules!
     static locale_t c_loc = newlocale(LC_ALL_MASK, "C", nullptr);
 # ifdef __APPLE__
@@ -1164,7 +1164,7 @@ double
 Strutil::strtod (const char *nptr, char **endptr)
 {
     // Can use strtod_l on platforms that support it
-#if defined (__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+#if defined (__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__GLIBC__)
     // static initialization inside function is thread-safe by C++11 rules!
     static locale_t c_loc = newlocale(LC_ALL_MASK, "C", nullptr);
     return strtod_l (nptr, endptr, c_loc);


### PR DESCRIPTION
## Description

Fix Strutil::strtod_l/strtod_l, so it builds on Hurd, and on systems using the fallback code using the non-_l versions.

## Tests

Builds on Hurd, using both fallback code and _l versions.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

