### PR TITLE
raw: Added raw:HighlightMode attribute to control highlight clamping

### DIFF
--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -311,6 +311,18 @@ RawInput::open (const std::string &name, ImageSpec &newspec,
         m_spec.attribute ("raw:Exposure", exposure);
     }
 
+    // Highlight adjustment
+    int highlight_mode = config.get_int_attribute("raw:HighlightMode", 0);
+    if (highlight_mode != 0)
+    {
+        if (highlight_mode < 0 || highlight_mode > 9) {
+            error("raw:HighlightMode invalid value. range 0-9");
+            return false;
+        }
+        m_processor.imgdata.params.highlight = highlight_mode;
+        m_spec.attribute ("raw:HighlightMode", highlight_mode);
+    }
+
     // Interpolation quality
     // note: LibRaw must be compiled with demosaic pack GPL2 to use demosaic
     // algorithms 5-9. It must be compiled with demosaic pack GPL3 for


### PR DESCRIPTION
## Description

This commit exposes the HighlightMode setting in libraw to allow users to control the method of highlight clamping performed by the library. This follows the usage of "-H" in the dcraw command line utility.

The valid values are:
0 (default) - clip
1 - unclip
2 - blend
3-9 - rebuild / interpolate (at various levels of intensity).


## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->
There are not currently any raw image tests that I know of, but it works on my machine!™

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

