### PR TITLE
Parallelize computePixelStats

### DIFF
--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -1154,6 +1154,12 @@ struct OIIO_API PixelStats {
     std::vector<imagesize_t> infcount;
     std::vector<imagesize_t> finitecount;
     std::vector<double> sum, sum2;  // for intermediate calculation
+    OIIO::spin_mutex mutex;   // in case you need to lock it
+
+    PixelStats () {}
+    PixelStats (int nchannels) { reset(nchannels); }
+    void reset (int nchannels);
+    void merge (const PixelStats &p);
 };
 
 

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1038,6 +1038,8 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
         mode = ImageBufAlgo::MakeTxTexture;
         src = bumpslopes;
     }
+    double misc_time_2 = alltime.lap();
+    STATUS ("misc2", misc_time_2);
 
     // Some things require knowing a bunch about the pixel statistics.
     bool constant_color_detect = configspec.get_int_attribute("maketx:constant_color_detect");
@@ -1045,8 +1047,11 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
     bool compute_average_color = configspec.get_int_attribute("maketx:compute_average", 1);
     ImageBufAlgo::PixelStats pixel_stats;
     bool compute_stats = (constant_color_detect || opaque_detect || compute_average_color);
-    if (compute_stats)
+    if (compute_stats) {
         ImageBufAlgo::computePixelStats (pixel_stats, *src);
+    }
+    double stat_pixelstatstime = alltime.lap();
+    STATUS ("pixelstats", stat_pixelstatstime);
 
     // If requested - and we're a constant color - make a tiny texture instead
     // Only safe if the full/display window is the same as the data window.
@@ -1315,8 +1320,8 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
         }
     }
 
-    double misc_time_2 = alltime.lap();
-    STATUS ("misc2", misc_time_2);
+    double misc_time_3 = alltime.lap();
+    STATUS ("misc2b", misc_time_3);
 
     // Color convert the pixels, if needed, in place.  If a color
     // conversion is required we will promote the src to floating point
@@ -1427,8 +1432,8 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
     }
     std::string filtername = configspec.get_string_attribute ("maketx:filtername", "box");
 
-    double misc_time_3 = alltime.lap(); 
-    STATUS ("misc3", misc_time_3);
+    double misc_time_4 = alltime.lap(); 
+    STATUS ("misc3", misc_time_4);
 
     std::shared_ptr<ImageBuf> toplevel;  // Ptr to top level of mipmap
     if (! do_resize && dstspec.format == src->spec().format) {
@@ -1577,8 +1582,8 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
 
     maketx_merge_spec (dstspec, configspec);
 
-    double misc_time_4 = alltime.lap();
-    STATUS ("misc4", misc_time_4);
+    double misc_time_5 = alltime.lap();
+    STATUS ("misc4", misc_time_5);
 
     // Write out, and compute, the mipmap levels for the speicifed image
     bool nomipmap = configspec.get_int_attribute ("maketx:nomipmap") != 0;
@@ -1613,11 +1618,12 @@ make_texture_impl (ImageBufAlgo::MakeTextureMode mode,
         outstream << Strutil::format ("  file write:      %5.2f\n", stat_writetime);
         outstream << Strutil::format ("  initial resize:  %5.2f\n", stat_resizetime);
         outstream << Strutil::format ("  hash:            %5.2f\n", stat_hashtime);
+        outstream << Strutil::format ("  pixelstats:      %5.2f\n", stat_pixelstatstime);
         outstream << Strutil::format ("  mip computation: %5.2f\n", stat_miptime);
         outstream << Strutil::format ("  color convert:   %5.2f\n", stat_colorconverttime);
-        outstream << Strutil::format ("  unaccounted:     %5.2f  (%5.2f %5.2f %5.2f %5.2f)\n",
+        outstream << Strutil::format ("  unaccounted:     %5.2f  (%5.2f %5.2f %5.2f %5.2f %5.2f)\n",
                                       all-stat_readtime-stat_writetime-stat_resizetime-stat_hashtime-stat_miptime,
-                                      misc_time_1, misc_time_2, misc_time_3, misc_time_4);
+                                      misc_time_1, misc_time_2, misc_time_3, misc_time_4, misc_time_5);
         outstream << Strutil::format ("maketx peak memory used: %s\n",
                                       Strutil::memformat(peak_mem));
     }


### PR DESCRIPTION
ImageBufAlgo::computePixelStats was completely serialized. Turns out that
this was a big chunk of "unaccounted" time in maketx.

So parallelize it in the usual way, with parallel_for_chunked_2D,
and some other cleanup to the PixelStats struct.

Also modify the stats keeping in make_texture() to account for and
report the computePixelStats time separately.
