### PR TITLE
TIFF whole-file I/O speedup 5-10x with multithreading

### DIFF
--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -66,6 +66,7 @@ atomic_int oiio_threads (threads_default());
 atomic_int oiio_exr_threads (threads_default());
 atomic_int oiio_read_chunk (256);
 int tiff_half (0);
+int tiff_multithread (1);
 ustring plugin_searchpath (OIIO_DEFAULT_PLUGIN_SEARCHPATH);
 std::string format_list;   // comma-separated list of all formats
 std::string input_format_list;   // comma-separated list of readable formats
@@ -298,6 +299,10 @@ attribute (string_view name, TypeDesc type, const void *val)
         tiff_half = *(const int *)val;
         return true;
     }
+    if (name == "tiff:multithread" && type == TypeInt) {
+        tiff_multithread = *(const int *)val;
+        return true;
+    }
     if (name == "debug" && type == TypeInt) {
         print_debug = *(const int *)val;
         return true;
@@ -363,6 +368,10 @@ getattribute (string_view name, TypeDesc type, void *val)
     }
     if (name == "tiff:half" && type == TypeInt) {
         *(int *)val = tiff_half;
+        return true;
+    }
+    if (name == "tiff:multithread" && type == TypeInt) {
+        *(int *)val = tiff_multithread;
         return true;
     }
     if (name == "debug" && type == TypeInt) {

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -118,6 +118,7 @@ test_int_helpers ()
     OIIO_CHECK_EQUAL (pow2rounddown(8), 8);
 
     // round_to_multiple
+    OIIO_CHECK_EQUAL (round_to_multiple(0, 5), 0);
     OIIO_CHECK_EQUAL (round_to_multiple(1, 5), 5);
     OIIO_CHECK_EQUAL (round_to_multiple(2, 5), 5);
     OIIO_CHECK_EQUAL (round_to_multiple(3, 5), 5);


### PR DESCRIPTION
OpenEXR's library has a neat feature where it maintains a thread pool and if you are using the multi-scanline or multi-tile I/O API calls, it will do the compression/decompression of the scanlines or tiles in parallel, even though the disk I/O itself is serial (but the codec work accounts for most of the time, so this is a big speed win). The result is that with many threads, a 5-7x speedup in I/O is typical, versus the single threaded case.

libtiff doesn't do this -- it is not thread-safe or reentrant (for a single file), and lacks API calls to write multiple tiles or scanlines at once (small exception: it will output a "strip" of several scanlines, but not in a flexible way like OpenEXR's). So any straightforward use of libtiff means using one core to do all the work writing (or reading) a file, and all the other cores just waiting around, unable to contribute. 

So with this patch, I take an end run around these libtiff limitations. Instead of using the TIFFWriteScanline or TIFFWriteTile calls, I use the alternative TIFFWriteRaw{Scanline,Tile}, where you have to hand it a "raw" buffer (already compressed, ready for direct write to disk), which means we have to compress it ourselves. But for the very common case of "zip/deflate" compression, we can do this with our own call to zlib and get the same compressed data blob that libtiff would have produced. And in doing so, we can do that compression, and a bunch of other data wrangling and format conversion, in parallel using our thread pool! We can also pipeline the operation, having the serialized write happen even while later chunks are still in the queue waiting to be compressed.

And of course, the same process in reverse for reading.

Some limitations: for now, I only support uint8 and uint16, only deflate/zip compression, only "contig" planarconfig, no weird modes like cmyk or palette images, etc.  But these are the common (nearly exclusive) settings for TIFF files, as we use them.

Note also that this ONLY applies when writing multiple scanlines or tiles at once. It can't parallelize this work if the calling app is only reading or writing (from the OIIO API perspective) a single scanline or tile at a time. But again, a very common use pattern is to read or write the whole image at once. (Important exception: ImageCache/TextureSystem).

The results are stunning: I'm easily getting a 5-10x performance improvement in TIFF input or output time, sometimes even much more. This translates directly into large performance improvements for oiiotool as well as maketx texture creation (of which by far the biggest portion of runtime is the output of the texture, and most of that was due to the compression, which is now multithreaded).

As a specific example, when doing "maketx" of an 8192 x 8192, 4 channel, uint16 data TIFF input file on my 16 core (32 hyperthread) workstation,

    Old:  28.2s total (1.13s read, 23.3s write)
    New:   1.6s total (0.13s read,  1.0s write)

(These times also incorporate a change being reviewed separately as 3 seconds of the original total.)
