### PR TITLE
oiiotool: autotile off by default.

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -156,7 +156,11 @@ Oiiotool::clear_options ()
     autocc = false;
     nativeread = false;
     cachesize = 4096;
-    autotile = 4096;
+    autotile = 0;   // was: 4096
+    // FIXME: Turned off autotile by default Jan 2018 after thinking that
+    // it was possible to deadlock when doing certain parallel IBA functions
+    // in combination with autotile. When the deadlock possibility is fixed,
+    // maybe we'll turn it back to on by default.
     frame_padding = 0;
     full_command_line.clear ();
     printinfo_metamatch.clear ();


### PR DESCRIPTION
I think it's possible to deadlock when doing certain parallel IBA functions in combination with autotile. When the deadlock possibility is fixed, maybe we'll turn it back to on by default, but for now this seems safer.  Users can always turn it on with the --autotile command line flag to oiiotool.

I think we've been lucky up until now. To trigger, it needs the right combination of enough threads, timing just right and traversing particular patterns, large enough image that the autotile uses more than one tile (remember, the default was 4k, so I only noticed the problem on an 8k image).

I think I know how to fix it, but I don't have time to do it right now. So better to just change the default oiiotool behavior to not trigger the possible bug.