### PR TITLE
Added explicit link to CMAKE_DL_LIBS for OpenImageIO target

### DIFF
--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -108,7 +108,8 @@ endif ()
 target_link_libraries (OpenImageIO
                        ${SANITIZE_LIBRARIES}
                        ${format_plugin_libs} # Add all the target link libraries from the plugins
-                       ${Boost_LIBRARIES})
+                       ${Boost_LIBRARIES}
+                       ${CMAKE_DL_LIBS})
 
 
 # Include OpenColorIO if using it
@@ -205,33 +206,32 @@ if (OIIO_BUILD_TESTS)
 
     add_executable (imagebuf_test imagebuf_test.cpp)
     set_target_properties (imagebuf_test PROPERTIES FOLDER "Unit Tests")
-    target_link_libraries (imagebuf_test OpenImageIO ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+    target_link_libraries (imagebuf_test OpenImageIO ${Boost_LIBRARIES})
     add_test (unit_imagebuf imagebuf_test)
 
     add_executable (imagecache_test imagecache_test.cpp)
     set_target_properties (imagecache_test PROPERTIES FOLDER "Unit Tests")
-    target_link_libraries (imagecache_test OpenImageIO ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+    target_link_libraries (imagecache_test OpenImageIO ${Boost_LIBRARIES})
     add_test (unit_imagecache imagecache_test)
 
     add_executable (imagebufalgo_test imagebufalgo_test.cpp)
     set_target_properties (imagebufalgo_test PROPERTIES FOLDER "Unit Tests")
-    target_link_libraries (imagebufalgo_test OpenImageIO ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+    target_link_libraries (imagebufalgo_test OpenImageIO ${Boost_LIBRARIES})
     add_test (unit_imagebufalgo imagebufalgo_test)
 
     add_executable (imagespec_test imagespec_test.cpp)
     set_target_properties (imagespec_test PROPERTIES FOLDER "Unit Tests")
-    target_link_libraries (imagespec_test OpenImageIO ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+    target_link_libraries (imagespec_test OpenImageIO ${Boost_LIBRARIES})
     add_test (unit_imagespec imagespec_test)
     
     add_executable (imagespeed_test imagespeed_test.cpp)
     set_target_properties (imagespeed_test PROPERTIES FOLDER "Unit Tests")
-    target_link_libraries (imagespeed_test OpenImageIO ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+    target_link_libraries (imagespeed_test OpenImageIO ${Boost_LIBRARIES})
     #add_test (imagespeed_test imagespeed_test)
 
     add_executable (compute_test compute_test.cpp)
     set_target_properties (compute_test PROPERTIES FOLDER "Unit Tests")
-    target_link_libraries (compute_test OpenImageIO ${Boost_LIBRARIES}
-                           ${CMAKE_DL_LIBS})
+    target_link_libraries (compute_test OpenImageIO ${Boost_LIBRARIES})
     add_test (unit_compute compute_test)
 
 endif (OIIO_BUILD_TESTS)


### PR DESCRIPTION
## Description

OpenImageIO leaves undefined symbols for dlopen / dlclose / dlsym and friends. At the moment it seems we are working around the issue by explicitly linking ${CMAKE_DL_LIBS} in the unit tests, but this still leaves the main library missing symbols. This commit makes the dependency on ${CMAKE_DL_LIBS} explicit.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

