### PR TITLE
Speed up ImageBuf::get_pixels()

### DIFF
--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -598,6 +598,13 @@ public:
     void *localpixels ();
     const void *localpixels () const;
 
+    /// Pixel-to-pixel stride within the localpixels memory.
+    stride_t pixel_stride () const;
+    /// Scanline-to-scanline stride within the localpixels memory.
+    stride_t scanline_stride () const;
+    /// Z plane stride within the localpixels memory.
+    stride_t z_stride () const;
+
     /// Are the pixels backed by an ImageCache, rather than the whole
     /// image being in RAM somewhere?
     bool cachedpixels () const;


### PR DESCRIPTION
The fully general case uses IB::iterator element by element and can
handle ImageCache-backed images.

For the common case of the image being fully in memory, it reduces to
a call to parallel_convert_image, which is about 3x faster.

