### PR TITLE
 Speed up IBA::copy and IBA::crop

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1774,9 +1774,7 @@ ImageBuf::get_pixels (ROI roi, TypeDesc format, void *result,
     roi.chend = std::min (roi.chend, nchannels());
     ImageSpec::auto_stride (xstride, ystride, zstride, format.size(),
                             roi.nchannels(), roi.width(), roi.height());
-    if (localpixels() && roi.xbegin >= xbegin() && roi.xend <= xend() &&
-                         roi.ybegin >= ybegin() && roi.yend <= yend() &&
-                         roi.zbegin >= zbegin() && roi.zend <= zend()) {
+    if (localpixels() && this->roi().contains(roi) && roi.chbegin == 0) {
         // Easy case -- if the buffer is already fully in memory and the roi
         // is completely contained in the pixel window, this reduces to a
         // parallel_convert_image, which is both threaded and already


### PR DESCRIPTION
Both of these (crop calls copy underneath) were threaded, but used
iterators to be fully general.

Much like the recent ImageBuf::get_pixels fix, using
parallel_convert_image (which has been heavily optimized) speeds up the
common situation where the source image is already in local memory and
the ROI being copied is fully contained in the pixel data window.

I'm seeing speedup of copy about 35% when copying a 4 channel float
image (to either a float or an uninitialized buffer), 3x speedup when a
data conversion is involved (copying a 4 channel float to a 4 channel
uint8 buffer), and almost 4x improvement copying 4-chan half to 4-chan
half (because the general code did an expensive half->float->half set of
conversions in the process).

