### PR TITLE
Add ROI::contains(ROI)

### DIFF
--- a/src/doc/imagebuf.tex
+++ b/src/doc/imagebuf.tex
@@ -106,6 +106,12 @@ in the channel range.
 Returns {\cf true} if the ROI contains the coordinate.
 \apiend
 
+\apiitem{bool ROI::{\ce contains} (const ROI \&other) const}
+\NEW % 1.9
+Returns {\cf true} if the ROI {\cf other} is entirel contained within
+this ROI.
+\apiend
+
 \apiitem{ROI {\ce roi_union} (const ROI \&A, const ROI \&B) \\
 ROI {\ce roi_intersection} (const ROI \&A, const ROI \&B)}
 Returns the union of two \ROI's (an \ROI that is exactly big enough

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -251,7 +251,13 @@ The total number of pixels in the region described by the \ROI.
 
 \apiitem{int ROI.{\ce contains} (x, y, z=0, ch=0)}
 \NEW % 1.9
-Returns {\cf true} if the ROI contains the coordinate.
+Returns {\cf True} if the ROI contains the coordinate.
+\apiend
+
+\apiitem{int ROI.{\ce contains} (other)}
+\NEW % 1.9
+Returns {\cf True} if the ROI {\cf other} is entirel contained within
+this ROI.
 \apiend
 
 

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -128,6 +128,14 @@ struct ROI {
             && z >= zbegin && z < zend && ch >= chbegin && ch < chend;
     }
 
+    /// Test if another ROI is entirely within our ROI.
+    bool contains (const ROI& other) const {
+        return (other.xbegin >= xbegin && other.xend <= xend &&
+                other.ybegin >= ybegin && other.yend <= yend &&
+                other.zbegin >= zbegin && other.zend <= zend &&
+                other.chbegin >= chbegin && other.chend <= chend);
+    }
+
     /// Stream output of the range
     friend std::ostream & operator<< (std::ostream &out, const ROI &roi) {
         out << roi.xbegin << ' ' << roi.xend << ' ' << roi.ybegin << ' '

--- a/src/python/py_roi.cpp
+++ b/src/python/py_roi.cpp
@@ -37,6 +37,19 @@ namespace PyOpenImageIO
 static ROI ROI_All;
 
 
+static bool roi_contains_coord (const ROI& roi, int x, int y, int z, int ch)
+{
+    return roi.contains (x, y, z, ch);
+}
+
+
+static bool roi_contains_roi (const ROI& roi, const ROI& other)
+{
+    return roi.contains (other);
+}
+
+
+
 // Declare the OIIO ROI class to Python
 void declare_roi(py::module& m)
 {
@@ -65,8 +78,10 @@ void declare_roi(py::module& m)
         .def_property_readonly("depth",     &ROI::depth)
         .def_property_readonly("nchannels", &ROI::nchannels)
         .def_property_readonly("npixels",   &ROI::npixels)
-        .def("contains", &ROI::contains,
+        .def("contains", &roi_contains_coord,
              "x"_a, "y"_a, "z"_a=0, "ch"_a=0)
+        .def("contains", &roi_contains_roi,
+             "other"_a)
 
         .def_readonly_static("All",                &ROI_All)
 

--- a/testsuite/python-roi/ref/out.txt
+++ b/testsuite/python-roi/ref/out.txt
@@ -24,6 +24,10 @@ r != r2 (expect no):  False
 r == r3 (expect no):  False
 r != r3 (expect yes):  True
 
+r contains (10,10) (expect yes):  True
+r contains (1000,10) (expect no):  False
+r contains roi(10,20,10,20,0,1,0,1) (expect yes):  True
+r contains roi(1010,1020,10,20,0,1,0,1) (expect no):  False
 A = 0 10 0 8 0 1 0 4
 B = 5 15 -1 10 0 1 0 4
 ROI.union(A,B) = 0 15 -1 10 0 1 0 4

--- a/testsuite/python-roi/src/test_roi.py
+++ b/testsuite/python-roi/src/test_roi.py
@@ -43,6 +43,11 @@ try:
     print "r != r3 (expect yes): ", (r != r3)
     print
 
+    print "r contains (10,10) (expect yes): ", r.contains(10,10);
+    print "r contains (1000,10) (expect no): ", r.contains(1000,10);
+    print "r contains roi(10,20,10,20,0,1,0,1) (expect yes): ", r.contains(oiio.ROI(10,20,10,20,0,1,0,1))
+    print "r contains roi(1010,1020,10,20,0,1,0,1) (expect no): ", r.contains(oiio.ROI(1010,1020,10,20,0,1,0,1))
+
     A = oiio.ROI (0, 10, 0, 8, 0, 1, 0, 4)
     B = oiio.ROI (5, 15, -1, 10, 0, 1, 0, 4)
     print "A =", A


### PR DESCRIPTION
To both C++ and Python. Also add unit tests for this as well as the
recently-added contains(x,y,z,ch).

