### PR TITLE
ImageBuf::pixeladdr() -- extend with channel parameter

### DIFF
--- a/src/doc/imagebuf.tex
+++ b/src/doc/imagebuf.tex
@@ -707,15 +707,16 @@ clears the error message for next time.
 \apiitem{void *{\ce localpixels} (); \\
     const void *{\ce localpixels} () const;}
 Returns a raw pointer to the ``local'' pixel memory, if they are fully
-in RAM and not backed by an \ImageCache (in which case, {\cf NULL} will
+in RAM and not backed by an \ImageCache (in which case, {\cf nullptr} will
 be returned).  You can also test it like a {\cf bool} to find out if
 pixels are local.
 \apiend
 
-\apiitem{const void *{\ce pixeladdr} (int x, int y, int z=0) const \\
-void *{\ce pixeladdr} (int x, int y, int z)}
-Return the address where pixel (x,y,z) is stored in the image buffer.
-Use with extreme caution!  Will return NULL if the pixel values
+\apiitem{const void *{\ce pixeladdr} (int x, int y, int z=0, int ch=0) const \\
+void *{\ce pixeladdr} (int x, int y, int z=0, int ch=0)}
+Return the address where pixel {\cf (x,y,z)}, channel {\cf ch} is stored in
+the local image buffer memory.
+Use with extreme caution!  Will return {\cf nullptr} if the pixel values
 aren't local (for example, if backed by an \ImageCache).
 \apiend
 

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -607,7 +607,7 @@ public:
     TypeDesc pixeltype () const;
 
     /// A raw pointer to "local" pixel memory, if they are fully in RAM
-    /// and not backed by an ImageCache, or NULL otherwise.  You can
+    /// and not backed by an ImageCache, or nullptr otherwise.  You can
     /// also test it like a bool to find out if pixels are local.
     void *localpixels ();
     const void *localpixels () const;
@@ -625,20 +625,15 @@ public:
 
     ImageCache *imagecache () const;
 
-    /// Return the address where pixel (x,y,z) is stored in the image buffer.
-    /// Use with extreme caution!  Will return NULL if the pixel values
-    /// aren't local.
-    const void *pixeladdr (int x, int y, int z=0) const;
+    /// Return the address where pixel (x,y,z), channel ch, is stored in the
+    /// image buffer.  Use with extreme caution!  Will return nullptr if the
+    /// pixel values aren't local.
+    const void *pixeladdr (int x, int y, int z=0, int ch=0) const;
 
-    /// Return the address where pixel (x,y) is stored in the image buffer.
-    /// Use with extreme caution!  Will return NULL if the pixel values
-    /// aren't local.
-    void *pixeladdr (int x, int y) { return pixeladdr (x, y, 0); }
-
-    /// Return the address where pixel (x,y,z) is stored in the image buffer.
-    /// Use with extreme caution!  Will return NULL if the pixel values
-    /// aren't local.
-    void *pixeladdr (int x, int y, int z);
+    /// Return the address where pixel (x,y,z), channel ch, is stored in the
+    /// image buffer.  Use with extreme caution!  Will return nullptr if the
+    /// pixel values aren't local.
+    void *pixeladdr (int x, int y, int z=0, int ch=0);
 
     /// Return the index of pixel (x,y,z). If check_range is true, return
     /// -1 for an invalid coordinate that is not within the data window.

--- a/src/libOpenImageIO/imagebuf_test.cpp
+++ b/src/libOpenImageIO/imagebuf_test.cpp
@@ -222,6 +222,10 @@ void ImageBuf_test_appbuffer ()
     // same application buffer.
     ImageBuf C (A);
     OIIO_CHECK_EQUAL ((void *)A.pixeladdr(0,0,0), (void*)C.pixeladdr(0,0,0));
+
+    // Test that channel and pixel strides work
+    OIIO_CHECK_EQUAL ((float *)A.pixeladdr(0,0,0,1), (float *)A.pixeladdr(0,0,0)+1);
+    OIIO_CHECK_EQUAL (A.pixel_stride(), (stride_t)sizeof(float)*CHANNELS);
 }
 
 

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -188,16 +188,16 @@ ImageBufAlgo::copy (ImageBuf &dst, const ImageBuf &src, TypeDesc convert,
         return copy_deep (dst, src, roi, nthreads);
     }
 
-    if (src.localpixels() && src.roi().contains(roi) && roi.chbegin == 0) {
+    if (src.localpixels() && src.roi().contains(roi)) {
         // Easy case -- if the buffer is already fully in memory and the roi
         // is completely contained in the pixel window, this reduces to a
         // parallel_convert_image, which is both threaded and already
         // handles many special cases.
         return parallel_convert_image (roi.nchannels(), roi.width(), roi.height(), roi.depth(),
-                                       src.pixeladdr (roi.xbegin, roi.ybegin, roi.zbegin),
+                                       src.pixeladdr (roi.xbegin, roi.ybegin, roi.zbegin, roi.chbegin),
                                        src.spec().format, src.pixel_stride(),
                                        src.scanline_stride(), src.z_stride(),
-                                       dst.pixeladdr (roi.xbegin, roi.ybegin, roi.zbegin),
+                                       dst.pixeladdr (roi.xbegin, roi.ybegin, roi.zbegin, roi.chbegin),
                                        dst.spec().format, dst.pixel_stride(),
                                        dst.scanline_stride(), dst.z_stride(),
                                        -1, -1, nthreads);
@@ -230,16 +230,16 @@ ImageBufAlgo::crop (ImageBuf &dst, const ImageBuf &src,
         return copy_deep (dst, src, roi, nthreads);
     }
 
-    if (src.localpixels() && src.roi().contains(roi) && roi.chbegin == 0) {
+    if (src.localpixels() && src.roi().contains(roi)) {
         // Easy case -- if the buffer is already fully in memory and the roi
         // is completely contained in the pixel window, this reduces to a
         // parallel_convert_image, which is both threaded and already
         // handles many special cases.
         return parallel_convert_image (roi.nchannels(), roi.width(), roi.height(), roi.depth(),
-                                       src.pixeladdr (roi.xbegin, roi.ybegin, roi.zbegin),
+                                       src.pixeladdr (roi.xbegin, roi.ybegin, roi.zbegin, roi.chbegin),
                                        src.spec().format, src.pixel_stride(),
                                        src.scanline_stride(), src.z_stride(),
-                                       dst.pixeladdr (roi.xbegin, roi.ybegin, roi.zbegin),
+                                       dst.pixeladdr (roi.xbegin, roi.ybegin, roi.zbegin, roi.chbegin),
                                        dst.spec().format, dst.pixel_stride(),
                                        dst.scanline_stride(), dst.z_stride(),
                                        -1, -1, nthreads);


### PR DESCRIPTION
Let the pixeladdr also take a channel offset.

Clean up some legacy versions of pixeladdr(); only one version is
needed with parameter defaults properly used.

Simplify the implementation of pixel_stride, scanline_stride, z_stride
to be based on the already-computed byte counts (I just didn't remember
that they existed when I exposed those functions).

With the new pixeladdr method that takes a channel offset, I can
lift the restrictions on special cases of copy and crop that require
starting at channel 0.

