### PR TITLE
task_set refactor

### DIFF
--- a/src/include/OpenImageIO/parallel.h
+++ b/src/include/OpenImageIO/parallel.h
@@ -118,7 +118,7 @@ parallel_for_chunked (int64_t start, int64_t end, int64_t chunksize,
     }
     // N.B. If chunksize was specified, honor it, even for the single
     // threaded case.
-    for (task_set<void> ts (opt.pool); start < end; start += chunksize) {
+    for (task_set ts (opt.pool); start < end; start += chunksize) {
         int64_t e = std::min (end, start+chunksize);
         if (e == end || opt.singlethread()) {
             // For the last (or only) subtask, or if we are using just one
@@ -203,7 +203,7 @@ parallel_for_each (InputIt first, InputIt last, UnaryFunction f,
         for ( ; first != last; ++first)
             f (*first);
     } else {
-        for (task_set<void> ts (opt.pool); first != last; ++first)
+        for (task_set ts (opt.pool); first != last; ++first)
             ts.push (opt.pool->push ([&](int id){ f(*first); }));
     }
     return std::move(f);
@@ -245,7 +245,7 @@ parallel_for_chunked_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
         int64_t nx = std::max (int64_t(1), opt.maxthreads / ny);
         xchunksize = std::max (int64_t(1), (xend-xstart) / nx);
     }
-    task_set<void> ts (opt.pool);
+    task_set ts (opt.pool);
     for (auto y = ystart; y < yend; y += ychunksize) {
         int64_t ychunkend = std::min (yend, y+ychunksize);
         for (auto x = xstart; x < xend; x += xchunksize) {

--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -770,11 +770,14 @@ OIIO_API thread_pool* default_thread_pool ();
 ///
 class OIIO_API task_set {
 public:
-    task_set (thread_pool *pool)
+    task_set (thread_pool *pool=nullptr)
         : m_pool (pool ? pool : default_thread_pool()),
           m_submitter_thread (std::this_thread::get_id())
         {}
     ~task_set () { wait(); }
+
+    task_set (const task_set&) = delete;
+    const task_set& operator= (const task_set&) = delete;
 
     // Return the thread id of the thread that set up this task_set and
     // submitted its tasks to the thread pool.

--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -623,7 +623,7 @@ private:
 /// A common idiom is to fire a bunch of sub-tasks at the queue, and then
 /// wait for them to all complete. We provide a helper class, task_set,
 /// to make this easy:
-///     task_set<decltype(myfunc())> tasks (pool);
+///     task_set tasks (pool);
 ///     for (int i = 0; i < n_subtasks; ++i)
 ///         tasks.push (pool->push (myfunc));
 ///     tasks.wait ();
@@ -749,7 +749,7 @@ OIIO_API thread_pool* default_thread_pool ();
 
 
 
-/// task_set<T> is a group of future<T>'s from a thread_queue that you can
+/// task_set is a group of future<void>'s from a thread_queue that you can
 /// add to, and when you either call wait() or just leave the task_set's
 /// scope, it will wait for all the tasks in the set to be done before
 /// proceeding.
@@ -760,7 +760,7 @@ OIIO_API thread_pool* default_thread_pool ();
 ///
 ///    thread_pool* pool (default_thread_pool());
 ///    {
-///        task_set<decltype(myfunc())> tasks (pool);
+///        task_set tasks (pool);
 ///        // Launch a bunch of tasks into the thread pool
 ///        for (int i = 0; i < ntasks; ++i)
 ///            tasks.push (pool->push (myfunc));
@@ -768,8 +768,7 @@ OIIO_API thread_pool* default_thread_pool ();
 ///        // wait for all those queue tasks to finish.
 ///    }
 ///
-template<typename T=void>
-class task_set {
+class OIIO_API task_set {
 public:
     task_set (thread_pool *pool)
         : m_pool (pool ? pool : default_thread_pool()),
@@ -794,101 +793,13 @@ public:
     // while waiting for that task to finish. If block is false, then busy
     // wait, and opportunistically run queue tasks yourself while you are
     // waiting for the task to finish.
-    void wait_for_task (size_t taskindex, bool block=false) {
-        DASSERT (submitter() == std::this_thread::get_id());
-        if (taskindex >= m_futures.size())
-            return;  // nothing to wait for
-        auto &f (m_futures[taskindex]);
-        if (block || m_pool->is_worker (m_submitter_thread)) {
-            // Block on completion of all the task and don't try to do any
-            // of the work with the calling thread.
-            f.wait ();
-            return;
-        }
-        // If we made it here, we want to allow the calling thread to help
-        // do pool work if it's waiting around for a while.
-        const std::chrono::milliseconds wait_time (0);
-        int tries = 0;
-        while (1) {
-            // Asking future.wait_for for 0 time just checks the status.
-            if (f.wait_for (wait_time) == std::future_status::ready)
-                return;  // task has completed
-            // We're still waiting for the task to complete. What next?
-            if (++tries < 4) {   // First few times,
-                pause(4);        //   just busy-wait, check status again
-                continue;
-            }
-            // Since we're waiting, try to run a task ourselves to help
-            // with the load. If none is available, just yield schedule.
-            if (! m_pool->run_one_task(m_submitter_thread)) {
-                // We tried to do a task ourselves, but there weren't any
-                // left, so just wait for the rest to finish.
-                yield ();
-            }
-        }
-    }
+    void wait_for_task (size_t taskindex, bool block=false);
 
     // Wait for all tasks in the set to finish. If block == true, fully
     // block while waiting for the pool threads to all finish. If block is
     // false, then busy wait, and opportunistically run queue tasks yourself
     // while you are waiting for other tasks to finish.
-    void wait (bool block = false)
-    {
-        DASSERT (submitter() == std::this_thread::get_id());
-        const std::chrono::milliseconds wait_time (0);
-        if (m_pool->is_worker (m_submitter_thread))
-            block = true;   // don't get into recursive work stealing
-        if (block == false) {
-            int tries = 0;
-            while (1) {
-                bool all_finished = true;
-                int nfutures = 0, finished = 0;
-                for (auto&& f : m_futures) {
-                    // Asking future.wait_for for 0 time just checks the status.
-                    ++nfutures;
-                    auto status = f.wait_for (wait_time);
-                    if (status != std::future_status::ready)
-                        all_finished = false;
-                    else ++finished;
-                }
-                if (all_finished)   // All futures are ready? We're done.
-                    break;
-                // We're still waiting on some tasks to complete. What next?
-                if (++tries < 4) {   // First few times,
-                    pause(4);        //   just busy-wait, check status again
-                    continue;
-                }
-                // Since we're waiting, try to run a task ourselves to help
-                // with the load. If none is available, just yield schedule.
-                if (! m_pool->run_one_task(m_submitter_thread)) {
-                    // We tried to do a task ourselves, but there weren't any
-                    // left, so just wait for the rest to finish.
-#if 1
-                    yield ();
-#else
-                    // FIXME -- as currently written, if we see an empty queue
-                    // but we're still waiting for the tasks in our set to end,
-                    // we will keep looping and potentially ourselves do work
-                    // that was part of another task set. If there a benefit to,
-                    // once we see an empty queue, only waiting for the existing
-                    // tasks to finish and not altruistically executing any more
-                    // tasks?  This is how we would take the exit now:
-                    for (auto&& f : m_futures)
-                        f.wait ();
-                    break;
-#endif
-                }
-            }
-        } else {
-            // If block is true, just block on completion of all the tasks
-            // and don't try to do any of the work with the calling thread.
-            for (auto&& f : m_futures)
-                f.wait ();
-        }
-#ifndef NDEBUG
-        check_done ();
-#endif
-    }
+    void wait (bool block = false);
 
     // Debugging sanity check, called after wait(), to ensure that all the
     // tasks were completed.

--- a/src/libutil/parallel_test.cpp
+++ b/src/libutil/parallel_test.cpp
@@ -185,7 +185,7 @@ test_empty_thread_pool ()
     OIIO_CHECK_EQUAL (pool->size(), 0);
     atomic_int count (0);
     const int ntasks = 100;
-    task_set<void> ts (pool);
+    task_set ts (pool);
     for (int i = 0; i < ntasks; ++i)
         ts.push (pool->push ([&](int id){
             ASSERT (id == -1 && "Must be run by calling thread");

--- a/src/libutil/thread_test.cpp
+++ b/src/libutil/thread_test.cpp
@@ -135,7 +135,7 @@ time_thread_pool ()
         // trivial function, then waits for them to finish and tears down
         // the group.
         auto func = [=](){
-            task_set<void> taskset (pool);
+            task_set taskset (pool);
             for (int i = 0; i < nt; ++i) {
                 taskset.push (pool->push (do_nothing));
             }


### PR DESCRIPTION
There was no reason for task_set to be a template -- the templated type
was no longer used for anything. Changing it from template to normal
class also means that it was convenient to move task_set::wait() and
wait_for_task() from inline to be in thread.cpp. This makes it so that
tinkering with these methods just rebuilds one file, whereas when it's
in thread.h, any changes to it forces a recompile of most of OIIO.

