### PR TITLE
Thread pool and parallel-for refactor/improvements

### DIFF
--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -724,6 +724,18 @@ public:
     bool is_worker (std::thread::id id);
     bool is_worker () { return is_worker (std::this_thread::get_id()); }
 
+    /// How many jobs are waiting to run?  (Use with caution! Can be out of
+    /// date by the time you look at it.)
+    size_t jobs_in_queue () const;
+
+    /// Is the pool very busy? Meaning that there are significantly more
+    /// tasks in the queue waiting to run than there are threads in the
+    /// pool. It may be wise for a caller to check this before submitting
+    /// tasks -- if the queue is very busy, it's probably more expedient to
+    /// execute the code directly rather than add it to an oversubscribed
+    /// queue.
+    bool very_busy () const;
+
 private:
     // Disallow copy construction and assignment
     thread_pool (const thread_pool&) = delete;


### PR DESCRIPTION
1. Move the body of parallel_for_chunked and parallel_for_chunked_2D
from an inline in parallel.h to being non-inlined in thread.cpp.
The main advantage is so that as I tinker with the internals of these
functions, it's just one module that needs to recompile, rather than
the fact that an altered parallel.h forces a rebuild of most of the
project.

2. Implement a thread_pool::jobs_in_queue() that reports how many tasks
are waiting to execute (but haven't started yet) and a
thread_pool::very_busy() method that basically tells whether the number
of tasks waiting in the queue is significantly larger (currently: >4x)
than the number of threads in the pool. The idea here is that clients of
the thread pool could use this to avoid putting things onto the end of a
greatly oversubscribed queue and therefore avoid a long latency waiting
for other tasks to be completed.

3. And so the parallel_for loops use this -- before adding tasks to the
queue, it checks if it's very_busy() and if so, will execute the
sub-task directly. This helps reduce latency in situations where the
queue is heavily oversubscribed, which can happen if several threads are
each adding lots of jobs, oblivious that all the others are also piling
tasks on. This shouldn't come up commonly, but it makes things more sane
for this particular edge case.

4. Add an optional name field to parallel_options. This make it vastly
easier for me, when debugging, to have a particular launching of a
parallel loop have a unique name, and then trigger various debugging
scaffolding inside the execution of the parallel loops, only when
certain ones are called.
