### PR TITLE
Option to time all IBA functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,13 @@ Public API changes:
     * ImageBufAlgo::colorconvert variety deprecated since 1.7.
     * ImageCache::clear, deprecated since 1.7.
     * ImageCache::add_tile variety deprecated since 1.6.
+* Global OIIO attribute "log_times" (which defaults to 0 but can be overridden
+  by setting the `OPENIMAGEIO_LOG_TIMES` environment variable), when nonzero,
+  instruments ImageBufAlgo functions to record the number of times they are
+  called and how much time they take to execute. A report of these times
+  can be retrieved as a string as the "timing_report" attribute, or it will
+  be printed to stdout automatically if the value of log_times is 2 or more
+  at the time that the application exits. #1885 (1.9.2)
 
 Performance improvements:
 * ImageBufAlgo::computePixelStats is now multithreaded and should improve by

--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -999,7 +999,52 @@ and decoding multiple scanlines).  The default is 256.  The special value
 of 0 indicates that it should try to read the whole image if possible.
 \apiend
 
+\apiitem{int debug}
+\vspace{10pt}
+\index{debug}
+When nonzero, various debug messages may be printed. The default is 0 for
+release builds, 1 for {\cf DEBUG} builds, but also may be overridden by the
+{\cf OPENIMAGEIO\_DEBUG} env variable.
 \apiend
+
+\apiitem{int log_times \\
+string timing_report}
+\vspace{10pt}
+\index{log_times} \index{timing_report}
+\NEW % 1.9
+
+When the \qkw{log_times} attribute is nonzero, {\cf ImageBufAlgo} functions
+are instrumented to record the number of times they were called and the
+total amount of time spent executing them. When enabled, there is a slight
+runtime performance cost due to checking the time at the start and end of
+each of those function calls, and the locking and recording of the data
+structure that holds the log information. When the {\cf log_times} attribute
+is disabled, there is no additional performance cost.
+
+The {\cf log_times} attribute is initialized to 0, but may be overridden by
+environment variable {\cf OPENIMAGEIO_LOG_TIMES}.
+\index{OPENIMAGEIO_LOG_TIMES}
+
+The report of totals can be retrieved as the value of the
+\qkw{timing_report} attribute, which is a string and is read-only. The
+report is sorted alphabetically and for each named instrumentation region,
+prints the number of times it executed, the total runtime, and the average
+per call, like this:
+\begin{code}
+    IBA::computePixelStats        2   2.69ms  (avg   1.34ms)
+    IBA::make_texture             1  74.05ms  (avg  74.05ms)
+    IBA::mul                      8   2.42ms  (avg   0.30ms)
+    IBA::over                    10  23.82ms  (avg   2.38ms)
+    IBA::resize                  20   0.24s   (avg  12.18ms)
+    IBA::zero                     8   0.66ms  (avg   0.08ms)
+\end{code}
+
+If the value of {\cf log_times} is 2 or more when the application terminates,
+the timing report will be printed to {\cf stdout} upon exit.
+\apiend
+
+\apiend
+
 
 \apiitem{bool {\ce attribute} (string_view name, int val) \\
 bool {\ce attribute} (string_view name, float val) \\

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -1979,7 +1979,7 @@ bool OIIO_API render_text (ImageBuf &dst, int x, int y, string_view text,
                            int shadow = 0,
                            ROI roi = ROI::All(), int nthreads = 0);
 
-// Old style (pre-1.8) -- will eventually be deprecated.
+// DEPRECATED: Old style (pre-1.8) -- will eventually be deprecated.
 bool OIIO_API render_text (ImageBuf &dst, int x, int y, string_view text,
                            int fontsize, string_view fontname,
                            const float *textcolor);

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1278,6 +1278,12 @@ OIIO_API std::string geterror ();
 ///             The default is 0 for release builds, 1 for DEBUG builds,
 ///             but also may be overridden by the OPENIMAGEIO_DEBUG env
 ///             variable.
+///     int log_times
+///             When nonzero, various internals will record how much total
+///             time they spend in execution. If the value is >= 2, these
+///             times will be printed upon exit. Thd default is 0, but will
+///             be initialized to the value of the OPENIMAGEIO_LOG_TIMES
+///             environment variable, if it exists.
 ///     int tiff:half
 ///             When nonzero, allows TIFF to write 'half' pixel data.
 ///             N.B. Most apps may not read these correctly, but OIIO will.
@@ -1326,6 +1332,8 @@ inline bool attribute (string_view name, string_view val) {
 ///             the library. Semicolons separate the lists for formats. For
 ///             example,
 ///              "jpeg:jpeg-turbo 1.5.1;png:libpng 1.6.29;gif:gif_lib 5.1.4"
+///     string "timing_report"
+///             A string containing the report of all the log_times.
 ///     string "oiio:simd"
 ///             Comma-separated list of the SIMD-related capabilities
 ///             enabled when the OIIO library was built. For example,

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1131,6 +1131,8 @@ ImageBufAlgo::colorconvert (ImageBuf &dst, const ImageBuf &src,
             return false;
         }
     }
+
+    logtime.stop();   // transition to other colorconvert
     bool ok = colorconvert (dst, src, processor.get(), unpremult, roi, nthreads);
     if (ok)
         dst.specmod().attribute ("oiio:ColorSpace", to);
@@ -1350,6 +1352,8 @@ ImageBufAlgo::ociolook (ImageBuf &dst, const ImageBuf &src,
             return false;
         }
     }
+
+    logtime.stop();   // transition to colorconvert
     bool ok = colorconvert (dst, src, processor.get(), unpremult, roi, nthreads);
     if (ok)
         dst.specmod().attribute ("oiio:ColorSpace", to);
@@ -1391,6 +1395,8 @@ ImageBufAlgo::ociodisplay (ImageBuf &dst, const ImageBuf &src,
             return false;
         }
     }
+
+    logtime.stop();   // transition to colorconvert
     bool ok = colorconvert (dst, src, processor.get(), unpremult, roi, nthreads);
     return ok;
 }
@@ -1423,6 +1429,8 @@ ImageBufAlgo::ociofiletransform (ImageBuf &dst, const ImageBuf &src,
             return false;
         }
     }
+
+    logtime.stop();   // transition to colorconvert
     bool ok = colorconvert (dst, src, processor.get(), unpremult, roi, nthreads);
     if (ok)
         dst.specmod().attribute ("oiio:ColorSpace", name);

--- a/src/libOpenImageIO/imagebufalgo_addsub.cpp
+++ b/src/libOpenImageIO/imagebufalgo_addsub.cpp
@@ -43,6 +43,7 @@
 #include <OpenImageIO/imagebufalgo_util.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/dassert.h>
+#include "imageio_pvt.h"
 
 
 
@@ -113,6 +114,7 @@ bool
 ImageBufAlgo::add (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
                    ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::add");
     if (! IBAprep (roi, &dst, &A, &B))
         return false;
     ROI origroi = roi;
@@ -145,6 +147,7 @@ bool
 ImageBufAlgo::add (ImageBuf &dst, const ImageBuf &A, const float *b,
                    ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::add");
     if (! IBAprep (roi, &dst, &A,
                    IBAprep_CLAMP_MUTUAL_NCHANNELS | IBAprep_SUPPORT_DEEP))
         return false;
@@ -167,6 +170,7 @@ bool
 ImageBufAlgo::add (ImageBuf &dst, const ImageBuf &A, float b,
                    ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::add");
     if (! IBAprep (roi, &dst, &A,
                    IBAprep_CLAMP_MUTUAL_NCHANNELS | IBAprep_SUPPORT_DEEP))
         return false;
@@ -202,6 +206,7 @@ bool
 ImageBufAlgo::sub (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
                    ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::sub");
     if (! IBAprep (roi, &dst, &A, &B))
         return false;
     ROI origroi = roi;
@@ -234,6 +239,7 @@ bool
 ImageBufAlgo::sub (ImageBuf &dst, const ImageBuf &A, const float *b,
                    ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::sub");
     if (! IBAprep (roi, &dst, &A,
                    IBAprep_CLAMP_MUTUAL_NCHANNELS | IBAprep_SUPPORT_DEEP))
         return false;
@@ -261,6 +267,7 @@ bool
 ImageBufAlgo::sub (ImageBuf &dst, const ImageBuf &A, float b,
                    ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::sub");
     if (! IBAprep (roi, &dst, &A,
                    IBAprep_CLAMP_MUTUAL_NCHANNELS | IBAprep_SUPPORT_DEEP))
         return false;

--- a/src/libOpenImageIO/imagebufalgo_channels.cpp
+++ b/src/libOpenImageIO/imagebufalgo_channels.cpp
@@ -43,6 +43,7 @@
 #include <OpenImageIO/imagebufalgo_util.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/thread.h>
+#include "imageio_pvt.h"
 
 
 
@@ -81,6 +82,7 @@ ImageBufAlgo::channels (ImageBuf &dst, const ImageBuf &src,
                         const std::string *newchannelnames,
                         bool shuffle_channel_names, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::channels");
     // Not intended to create 0-channel images.
     if (nchannels <= 0) {
         dst.error ("%d-channel images not supported", nchannels);
@@ -229,6 +231,7 @@ ImageBufAlgo::channel_append (ImageBuf &dst, const ImageBuf &A,
                               const ImageBuf &B, ROI roi,
                               int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::channel_append");
     // If the region is not defined, set it to the union of the valid
     // regions of the two source images.
     if (! roi.defined())

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -44,7 +44,7 @@
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/thread.h>
 #include <OpenImageIO/SHA1.h>
-
+#include "imageio_pvt.h"
 
 
 OIIO_NAMESPACE_BEGIN
@@ -187,6 +187,7 @@ bool
 ImageBufAlgo::computePixelStats (PixelStats &stats, const ImageBuf &src,
                                  ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtimer("IBA::computePixelStats");
     if (! roi.defined())
         roi = get_roi (src.spec());
     else
@@ -318,6 +319,7 @@ ImageBufAlgo::compare (const ImageBuf &A, const ImageBuf &B,
                        ImageBufAlgo::CompareResults &result,
                        ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtimer("IBA::compare");
     // If no ROI is defined, use the union of the data windows of the two
     // images.
     if (! roi.defined())
@@ -378,6 +380,7 @@ bool
 ImageBufAlgo::isConstantColor (const ImageBuf &src, float *color,
                                ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtimer("IBA::isConstantColor");
     // If no ROI is defined, use the data window of src.
     if (! roi.defined())
         roi = get_roi(src.spec());
@@ -415,6 +418,7 @@ bool
 ImageBufAlgo::isConstantChannel (const ImageBuf &src, int channel, float val,
                                  ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtimer("IBA::isConstantChannel");
     // If no ROI is defined, use the data window of src.
     if (! roi.defined())
         roi = get_roi(src.spec());
@@ -455,6 +459,7 @@ isMonochrome_ (const ImageBuf &src, ROI roi, int nthreads)
 bool
 ImageBufAlgo::isMonochrome (const ImageBuf &src, ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtimer("IBA::isMonochrome");
     // If no ROI is defined, use the data window of src.
     if (! roi.defined())
         roi = get_roi(src.spec());
@@ -511,6 +516,7 @@ ImageBufAlgo::color_count (const ImageBuf &src, imagesize_t *count,
                            const float *eps,
                            ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtimer("IBA::color_count");
     // If no ROI is defined, use the data window of src.
     if (! roi.defined())
         roi = get_roi(src.spec());
@@ -577,6 +583,7 @@ ImageBufAlgo::color_range_check (const ImageBuf &src, imagesize_t *lowcount,
                                  const float *low, const float *high,
                                  ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtimer("IBA::color_range_check");
     // If no ROI is defined, use the data window of src.
     if (! roi.defined())
         roi = get_roi(src.spec());
@@ -628,6 +635,7 @@ deep_nonempty_region (const ImageBuf &src, ROI roi)
 ROI
 ImageBufAlgo::nonzero_region (const ImageBuf &src, ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtimer("IBA::nonzero_region");
     roi = roi_intersection (roi, src.roi());
 
     if (src.deep()) {
@@ -737,6 +745,7 @@ ImageBufAlgo::computePixelHashSHA1 (const ImageBuf &src,
                                     string_view extrainfo,
                                     ROI roi, int blocksize, int nthreads)
 {
+    pvt::LoggedTimer logtimer("IBA::computePixelHashSHA1");
     if (! roi.defined())
         roi = get_roi (src.spec());
 
@@ -834,6 +843,7 @@ ImageBufAlgo::histogram (const ImageBuf &A, int channel,
                          float min, float max, imagesize_t *submin,
                          imagesize_t *supermax, ROI roi)
 {
+    pvt::LoggedTimer logtimer("IBA::histogram");
     if (A.spec().format != TypeFloat) {
         A.error ("Unsupported pixel data format '%s'", A.spec().format);
         return false;
@@ -876,6 +886,7 @@ bool
 ImageBufAlgo::histogram_draw (ImageBuf &R,
                               const std::vector<imagesize_t> &histogram)
 {
+    pvt::LoggedTimer logtimer("IBA::histogram_draw");
     // Fail if there are no bins to draw.
     int bins = histogram.size();
     if (bins == 0) {

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -43,6 +43,7 @@
 #include <OpenImageIO/imagebufalgo_util.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/thread.h>
+#include "imageio_pvt.h"
 
 
 
@@ -84,6 +85,7 @@ ImageBufAlgo::paste (ImageBuf &dst, int xbegin, int ybegin,
                      int zbegin, int chbegin,
                      const ImageBuf &src, ROI srcroi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::paste");
     if (! srcroi.defined())
         srcroi = get_roi(src.spec());
 
@@ -163,6 +165,7 @@ bool
 ImageBufAlgo::copy (ImageBuf &dst, const ImageBuf &src, TypeDesc convert,
                     ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::copy");
     if (&dst == &src)   // trivial copy to self
         return true;
 
@@ -215,6 +218,7 @@ bool
 ImageBufAlgo::crop (ImageBuf &dst, const ImageBuf &src,
                     ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::crop");
     dst.clear ();
     roi.chend = std::min (roi.chend, src.nchannels());
     if (! IBAprep (roi, &dst, &src, IBAprep_SUPPORT_DEEP))
@@ -257,6 +261,7 @@ bool
 ImageBufAlgo::cut (ImageBuf &dst, const ImageBuf &src,
                    ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::cut");
     bool ok = crop (dst, src, roi, nthreads);
     ASSERT(ok);
     if (! ok)
@@ -304,6 +309,7 @@ ImageBufAlgo::circular_shift (ImageBuf &dst, const ImageBuf &src,
                               int xshift, int yshift, int zshift,
                               ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::circular_shift");
     if (! IBAprep (roi, &dst, &src))
         return false;
     bool ok;

--- a/src/libOpenImageIO/imagebufalgo_deep.cpp
+++ b/src/libOpenImageIO/imagebufalgo_deep.cpp
@@ -42,6 +42,7 @@
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/thread.h>
 #include <OpenImageIO/timer.h>
+#include "imageio_pvt.h"
 
 
 OIIO_NAMESPACE_BEGIN
@@ -114,6 +115,7 @@ bool
 ImageBufAlgo::flatten (ImageBuf &dst, const ImageBuf &src,
                        ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::flatten");
     if (! src.deep()) {
         // For some reason, we were asked to flatten an already-flat image.
         // So just copy it.
@@ -151,6 +153,7 @@ bool
 ImageBufAlgo::deepen (ImageBuf &dst, const ImageBuf &src, float zvalue,
                       ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::deepen");
     if (src.deep()) {
         // For some reason, we were asked to deepen an already-deep image.
         // So just copy it.
@@ -243,6 +246,7 @@ ImageBufAlgo::deep_merge (ImageBuf &dst, const ImageBuf &A,
                           const ImageBuf &B, bool occlusion_cull,
                           ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::deep_merge");
     if (! A.deep() || ! B.deep()) {
         // For some reason, we were asked to merge a flat image.
         dst.error ("deep_merge can only be performed on deep images");
@@ -351,6 +355,7 @@ ImageBufAlgo::deep_holdout (ImageBuf &dst, const ImageBuf &src,
                             const ImageBuf &thresh,
                             ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::deep_holdout");
     if (! src.deep() || ! thresh.deep()) {
         dst.error ("deep_holdout can only be performed on deep images");
         return false;

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -43,6 +43,7 @@
 #include <OpenImageIO/thread.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/hash.h>
+#include "imageio_pvt.h"
 
 #ifdef USE_FREETYPE
 #include <ft2build.h>
@@ -107,6 +108,7 @@ fill_corners_ (ImageBuf &dst, const float *topleft, const float *topright,
 bool
 ImageBufAlgo::fill (ImageBuf &dst, const float *pixel, ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::fill");
     ASSERT (pixel && "fill must have a non-NULL pixel value pointer");
     if (! IBAprep (roi, &dst))
         return false;
@@ -121,6 +123,7 @@ bool
 ImageBufAlgo::fill (ImageBuf &dst, const float *top, const float *bottom,
                     ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::fill");
     ASSERT (top && bottom && "fill must have a non-NULL pixel value pointers");
     if (! IBAprep (roi, &dst))
         return false;
@@ -136,6 +139,7 @@ ImageBufAlgo::fill (ImageBuf &dst, const float *topleft, const float *topright,
                     const float *bottomleft, const float *bottomright,
                     ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::fill");
     ASSERT (topleft && topright && bottomleft && bottomright &&
             "fill must have a non-NULL pixel value pointers");
     if (! IBAprep (roi, &dst))
@@ -151,6 +155,7 @@ ImageBufAlgo::fill (ImageBuf &dst, const float *topleft, const float *topright,
 bool
 ImageBufAlgo::zero (ImageBuf &dst, ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::zero");
     if (! IBAprep (roi, &dst))
         return false;
     float *zero = ALLOCA(float,roi.chend);
@@ -179,6 +184,7 @@ ImageBufAlgo::render_point (ImageBuf &dst, int x, int y,
                             array_view<const float> color,
                             ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::render_point");
     if (! IBAprep (roi, &dst))
         return false;
 
@@ -305,6 +311,7 @@ ImageBufAlgo::render_line (ImageBuf &dst, int x1, int y1, int x2, int y2,
                            bool skip_first_point,
                            ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::render_line");
     if (! IBAprep (roi, &dst))
         return false;
 
@@ -366,6 +373,7 @@ ImageBufAlgo::render_box (ImageBuf &dst, int x1, int y1, int x2, int y2,
                           array_view<const float> color, bool fill,
                           ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::render_box");
     if (! IBAprep (roi, &dst))
         return false;
     if (int(color.size()) < roi.chend) {
@@ -436,6 +444,7 @@ ImageBufAlgo::checker (ImageBuf &dst, int width, int height, int depth,
                        int xoffset, int yoffset, int zoffset,
                        ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::checker");
     if (! IBAprep (roi, &dst))
         return false;
     bool ok;
@@ -549,6 +558,7 @@ ImageBufAlgo::noise (ImageBuf &dst, string_view noisetype,
                      float A, float B, bool mono, int seed,
                      ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::noise");
     if (! IBAprep (roi, &dst))
         return false;
     bool ok;
@@ -716,6 +726,7 @@ resolve_font (int fontsize, string_view font_, std::string &result)
 ROI
 ImageBufAlgo::text_size (string_view text, int fontsize, string_view font_)
 {
+    pvt::LoggedTimer logtime("IBA::text_size");
     ROI size;
 #ifdef USE_FREETYPE
     // Thread safety
@@ -790,6 +801,7 @@ ImageBufAlgo::render_text (ImageBuf &R, int x, int y, string_view text,
                            TextAlignX alignx, TextAlignY aligny,
                            int shadow, ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::render_text");
     if (R.spec().depth > 1) {
         R.error ("ImageBufAlgo::render_text does not support volume images");
         return false;

--- a/src/libOpenImageIO/imagebufalgo_mad.cpp
+++ b/src/libOpenImageIO/imagebufalgo_mad.cpp
@@ -42,7 +42,7 @@
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/imagebufalgo_util.h>
 #include <OpenImageIO/dassert.h>
-
+#include "imageio_pvt.h"
 
 
 OIIO_NAMESPACE_BEGIN
@@ -148,6 +148,7 @@ bool
 ImageBufAlgo::mad (ImageBuf &dst, const ImageBuf &A_, const ImageBuf &B_,
                    const ImageBuf &C_, ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::mad");
     const ImageBuf *A = &A_, *B = &B_, *C = &C_;
     if (!A->initialized() || !B->initialized() || !C->initialized()) {
         dst.error ("Uninitialized input image");
@@ -188,6 +189,7 @@ bool
 ImageBufAlgo::mad (ImageBuf &dst, const ImageBuf &A_, const float *B,
                    const ImageBuf &C_, ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::mad");
     const ImageBuf *A = &A_, *C = &C_;
     if (!A->initialized() || !C->initialized()) {
         dst.error ("Uninitialized input image");
@@ -222,6 +224,7 @@ bool
 ImageBufAlgo::mad (ImageBuf &dst, const ImageBuf &A, const float *B,
                    const float *C, ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::mad");
     if (!A.initialized()) {
         dst.error ("Uninitialized input image");
         return false;
@@ -241,6 +244,7 @@ bool
 ImageBufAlgo::mad (ImageBuf &dst, const ImageBuf &A, float b,
                    float c, ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::mad");
     if (!A.initialized()) {
         dst.error ("Uninitialized input image");
         return false;

--- a/src/libOpenImageIO/imagebufalgo_muldiv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_muldiv.cpp
@@ -44,6 +44,7 @@
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/simd.h>
+#include "imageio_pvt.h"
 
 
 
@@ -72,6 +73,7 @@ bool
 ImageBufAlgo::mul (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
                    ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::mul");
     if (! IBAprep (roi, &dst, &A, &B, NULL, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
@@ -131,6 +133,7 @@ bool
 ImageBufAlgo::mul (ImageBuf &dst, const ImageBuf &A, const float *b,
                    ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::mul");
     if (! IBAprep (roi, &dst, &A,
                    IBAprep_CLAMP_MUTUAL_NCHANNELS | IBAprep_SUPPORT_DEEP))
         return false;
@@ -153,6 +156,7 @@ bool
 ImageBufAlgo::mul (ImageBuf &dst, const ImageBuf &A, float b,
                    ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::mul");
     if (! IBAprep (roi, &dst, &A,
                    IBAprep_CLAMP_MUTUAL_NCHANNELS | IBAprep_SUPPORT_DEEP))
         return false;
@@ -191,6 +195,7 @@ bool
 ImageBufAlgo::div (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
                    ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::div");
     if (! IBAprep (roi, &dst, &A, &B, NULL, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
@@ -206,6 +211,7 @@ bool
 ImageBufAlgo::div (ImageBuf &dst, const ImageBuf &A, const float *b,
                    ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::div");
     if (! IBAprep (roi, &dst, &A,
                    IBAprep_CLAMP_MUTUAL_NCHANNELS | IBAprep_SUPPORT_DEEP))
         return false;
@@ -233,6 +239,7 @@ bool
 ImageBufAlgo::div (ImageBuf &dst, const ImageBuf &A, float b,
                    ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::div");
     if (! IBAprep (roi, &dst, &A,
                    IBAprep_CLAMP_MUTUAL_NCHANNELS | IBAprep_SUPPORT_DEEP))
         return false;

--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -49,7 +49,7 @@
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/thread.h>
 #include <OpenImageIO/sysutil.h>
-
+#include "imageio_pvt.h"
 
 
 OIIO_NAMESPACE_BEGIN
@@ -60,6 +60,7 @@ bool
 ImageBufAlgo::from_IplImage (ImageBuf &dst, const IplImage *ipl,
                              TypeDesc convert)
 {
+    pvt::LoggedTimer logtime("IBA::from_IplImage");
     if (! ipl) {
         DASSERT (0 && "ImageBufAlgo::fromIplImage called with NULL ipl");
         dst.error ("Passed NULL source IplImage");
@@ -138,6 +139,7 @@ ImageBufAlgo::from_IplImage (ImageBuf &dst, const IplImage *ipl,
 IplImage *
 ImageBufAlgo::to_IplImage (const ImageBuf &src)
 {
+    pvt::LoggedTimer logtime("IBA::to_IplImage");
 #ifdef USE_OPENCV
     ImageBuf tmp = src;
     ImageSpec spec = tmp.spec();
@@ -250,6 +252,7 @@ static CameraHolder cameras;
 bool
 ImageBufAlgo::capture_image (ImageBuf &dst, int cameranum, TypeDesc convert)
 {
+    pvt::LoggedTimer logtime("IBA::capture_image");
 #ifdef USE_OPENCV
     IplImage *frame = NULL;
     {

--- a/src/libOpenImageIO/imagebufalgo_orient.cpp
+++ b/src/libOpenImageIO/imagebufalgo_orient.cpp
@@ -43,6 +43,7 @@
 #include <OpenImageIO/imagebufalgo_util.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/thread.h>
+#include "imageio_pvt.h"
 
 
 
@@ -75,6 +76,7 @@ ImageBufAlgo::flip(ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
         tmp.swap (const_cast<ImageBuf&>(src));
         return flip (dst, tmp, roi, nthreads);
     }
+    pvt::LoggedTimer logtime("IBA::flip");
 
     ROI src_roi = roi.defined() ? roi : src.roi();
     ROI src_roi_full = src.roi_full();
@@ -127,6 +129,7 @@ ImageBufAlgo::flop(ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
         return flop (dst, tmp, roi, nthreads);
     }
 
+    pvt::LoggedTimer logtime("IBA::flop");
     ROI src_roi = roi.defined() ? roi : src.roi();
     ROI src_roi_full = src.roi_full();
     int offset = src_roi.xbegin - src_roi_full.xbegin;
@@ -179,6 +182,7 @@ ImageBufAlgo::rotate90 (ImageBuf &dst, const ImageBuf &src,
         return rotate90 (dst, tmp, roi, nthreads);
     }
 
+    pvt::LoggedTimer logtime("IBA::rotate90");
     ROI src_roi = roi.defined() ? roi : src.roi();
     ROI src_roi_full = src.roi_full();
 
@@ -243,6 +247,7 @@ ImageBufAlgo::rotate180 (ImageBuf &dst, const ImageBuf &src,
         return rotate180 (dst, tmp, roi, nthreads);
     }
 
+    pvt::LoggedTimer logtime("IBA::rotate180");
     ROI src_roi = roi.defined() ? roi : src.roi();
     ROI src_roi_full = src.roi_full();
     int xoffset = src_roi.xbegin - src_roi_full.xbegin;
@@ -297,6 +302,7 @@ ImageBufAlgo::rotate270 (ImageBuf &dst, const ImageBuf &src,
         return rotate270 (dst, tmp, roi, nthreads);
     }
 
+    pvt::LoggedTimer logtime("IBA::rotate270");
     ROI src_roi = roi.defined() ? roi : src.roi();
     ROI src_roi_full = src.roi_full();
 
@@ -401,6 +407,7 @@ bool
 ImageBufAlgo::transpose (ImageBuf &dst, const ImageBuf &src,
                          ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::transpose");
     if (! roi.defined())
         roi = get_roi (src.spec());
     roi.chend = std::min (roi.chend, src.nchannels());

--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -45,6 +45,7 @@
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/simd.h>
 #include <OpenImageIO/color.h>
+#include "imageio_pvt.h"
 
 
 
@@ -79,6 +80,7 @@ ImageBufAlgo::clamp (ImageBuf &dst, const ImageBuf &src,
                      const float *min, const float *max,
                      bool clampalpha01, ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::clamp");
     if (! IBAprep (roi, &dst, &src))
         return false;
     std::vector<float> minvec, maxvec;
@@ -150,6 +152,7 @@ bool
 ImageBufAlgo::absdiff (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
                        ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::absdiff");
     if (! IBAprep (roi, &dst, &A, &B))
         return false;
     ROI origroi = roi;
@@ -182,6 +185,7 @@ bool
 ImageBufAlgo::absdiff (ImageBuf &dst, const ImageBuf &A, const float *b,
                        ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::absdiff");
     if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
@@ -196,6 +200,7 @@ bool
 ImageBufAlgo::absdiff (ImageBuf &dst, const ImageBuf &A, float b,
                        ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::absdiff");
     if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     int nc = dst.nchannels();
@@ -239,6 +244,7 @@ bool
 ImageBufAlgo::pow (ImageBuf &dst, const ImageBuf &A, const float *b,
                    ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::pow");
     if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
@@ -253,6 +259,7 @@ bool
 ImageBufAlgo::pow (ImageBuf &dst, const ImageBuf &A, float b,
                    ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::pow");
     if (! IBAprep (roi, &dst, &A, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     int nc = A.nchannels();
@@ -293,6 +300,7 @@ bool
 ImageBufAlgo::channel_sum (ImageBuf &dst, const ImageBuf &src,
                            const float *weights, ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::channel_sum");
     if (! roi.defined())
         roi = get_roi(src.spec());
     roi.chend = std::min (roi.chend, src.nchannels());
@@ -492,6 +500,7 @@ bool
 ImageBufAlgo::rangecompress (ImageBuf &dst, const ImageBuf &src,
                              bool useluma, ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::rangecompress");
     if (! IBAprep (roi, &dst, &src, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
@@ -507,6 +516,7 @@ bool
 ImageBufAlgo::rangeexpand (ImageBuf &dst, const ImageBuf &src,
                            bool useluma, ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::rangeexpand");
     if (! IBAprep (roi, &dst, &src, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     bool ok;
@@ -560,6 +570,7 @@ bool
 ImageBufAlgo::unpremult (ImageBuf &dst, const ImageBuf &src,
                          ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::unpremult");
     if (! IBAprep (roi, &dst, &src, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     if (src.spec().alpha_channel < 0 
@@ -619,6 +630,7 @@ bool
 ImageBufAlgo::premult (ImageBuf &dst, const ImageBuf &src,
                        ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::premult");
     if (! IBAprep (roi, &dst, &src, IBAprep_CLAMP_MUTUAL_NCHANNELS))
         return false;
     if (src.spec().alpha_channel < 0) {
@@ -670,6 +682,7 @@ ImageBufAlgo::color_map (ImageBuf &dst, const ImageBuf &src,
                          array_view<const float> knots,
                          ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::color_map");
     if (srcchannel >= src.nchannels()) {
         dst.error ("invalid source channel selected");
         return false;
@@ -760,6 +773,7 @@ ImageBufAlgo::color_map (ImageBuf &dst, const ImageBuf &src,
                          int srcchannel, string_view mapname,
                          ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::color_map");
     if (srcchannel >= src.nchannels()) {
         dst.error ("invalid source channel selected");
         return false;
@@ -940,6 +954,7 @@ ImageBufAlgo::fixNonFinite (ImageBuf &dst, const ImageBuf &src,
                             NonFiniteFixMode mode, int *pixelsFixed,
                             ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::fixNonFinite");
     if (mode != ImageBufAlgo::NONFINITE_NONE &&
         mode != ImageBufAlgo::NONFINITE_BLACK &&
         mode != ImageBufAlgo::NONFINITE_BOX3 &&
@@ -1110,6 +1125,7 @@ bool
 ImageBufAlgo::over (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
                     ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::over");
     if (! IBAprep (roi, &dst, &A, &B, NULL,
                    IBAprep_REQUIRE_ALPHA | IBAprep_REQUIRE_SAME_NCHANNELS))
         return false;
@@ -1141,6 +1157,7 @@ bool
 ImageBufAlgo::zover (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
                      bool z_zeroisinf, ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::zover");
     if (! IBAprep (roi, &dst, &A, &B, NULL,
                    IBAprep_REQUIRE_ALPHA | IBAprep_REQUIRE_Z |
                    IBAprep_REQUIRE_SAME_NCHANNELS))

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -45,6 +45,7 @@
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filter.h>
 #include <OpenImageIO/thread.h>
+#include "imageio_pvt.h"
 
 OIIO_NAMESPACE_BEGIN
 
@@ -412,6 +413,7 @@ bool
 ImageBufAlgo::resize (ImageBuf &dst, const ImageBuf &src,
                       Filter2D *filter, ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::resize");
     if (! IBAprep (roi, &dst, &src,
             IBAprep_REQUIRE_SAME_NCHANNELS | IBAprep_NO_SUPPORT_VOLUME |
             IBAprep_NO_COPY_ROI_FULL))
@@ -447,6 +449,7 @@ ImageBufAlgo::resize (ImageBuf &dst, const ImageBuf &src,
                       string_view filtername_, float fwidth,
                       ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::resize");
     if (! IBAprep (roi, &dst, &src,
             IBAprep_REQUIRE_SAME_NCHANNELS | IBAprep_NO_SUPPORT_VOLUME |
             IBAprep_NO_COPY_ROI_FULL))
@@ -569,6 +572,7 @@ bool
 ImageBufAlgo::resample (ImageBuf &dst, const ImageBuf &src,
                         bool interpolate, ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::resample");
     if (! IBAprep (roi, &dst, &src,
             IBAprep_REQUIRE_SAME_NCHANNELS | IBAprep_NO_SUPPORT_VOLUME |
             IBAprep_NO_COPY_ROI_FULL | IBAprep_SUPPORT_DEEP))
@@ -666,6 +670,7 @@ ImageBufAlgo::warp (ImageBuf &dst, const ImageBuf &src,
                     bool recompute_roi, ImageBuf::WrapMode wrap,
                     ROI roi, int nthreads)
 {
+    pvt::LoggedTimer logtime("IBA::warp");
     ROI src_roi_full = src.roi_full();
     ROI dst_roi, dst_roi_full;
     if (dst.initialized()) {

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -45,6 +45,7 @@
 #include <OpenImageIO/parallel.h>
 #include <OpenImageIO/hash.h>
 #include <OpenImageIO/imageio.h>
+#include <OpenImageIO/timer.h>
 #include "imageio_pvt.h"
 
 OIIO_NAMESPACE_BEGIN
@@ -71,6 +72,7 @@ std::string input_format_list;   // comma-separated list of readable formats
 std::string output_format_list;  // comma-separated list of writeable formats
 std::string extension_list;   // list of all extensions for all formats
 std::string library_list;   // list of all libraries for all formats
+int oiio_log_times = Strutil::from_string<int>(Sysutil::getenv("OPENIMAGEIO_LOG_TIMES"));
 }
 
 using namespace pvt;
@@ -87,7 +89,58 @@ int print_debug (oiio_debug_env ? atoi(oiio_debug_env) : 0);
 #else
 int print_debug (oiio_debug_env ? atoi(oiio_debug_env) : 1);
 #endif
+
+class TimingLog {
+public:
+    spin_mutex mutex;
+    std::map<std::string, std::pair<double,size_t>> timing_map;
+
+    TimingLog () {}
+
+    // Destructor prints the timing report if oiio_log_times >= 2
+    ~TimingLog () {
+        if (oiio_log_times >= 2)
+            std::cout << report ();
+    }
+
+    // Call like a function to record times (but only if oiio_log_times > 0)
+    void operator() (string_view key, const Timer& timer) {
+        if (oiio_log_times) {
+            auto t = timer();
+            spin_lock lock (mutex);
+            auto entry = timing_map.find(key);
+            if (entry == timing_map.end())
+                timing_map[key] = std::make_pair(t,size_t(1));
+            else {
+                entry->second.first += t;
+                entry->second.second += 1;
+            }
+        }
+    }
+
+    // Retrieve the report as a big string
+    std::string report () {
+        std::stringstream out;
+        spin_lock lock (mutex);
+        for (const auto& item : timing_map) {
+            size_t ncalls = item.second.second;
+            double time = item.second.first;
+            double percall = time/ncalls;
+            bool use_ms = (item.second.first < 0.1);
+            bool use_ms_percall = (percall < 0.1);
+            out << Strutil::format ("%-25s%6d %6.2f%s  (avg %6.2f%s)\n", item.first,
+                                    ncalls,
+                                    time * (use_ms ? 1000.0 : 1.0),
+                                    use_ms ? "ms" : "s ",
+                                    percall * (use_ms_percall ? 1000.0 : 1.0),
+                                    use_ms_percall ? "ms" : "s");
+        }
+        return out.str();
+    }
 };
+static TimingLog timing_log;
+
+}   // end anon namespace
 
 
 
@@ -212,6 +265,14 @@ debug (string_view message)
 
 
 
+void
+pvt::log_time (string_view key, const Timer& timer)
+{
+    timing_log (key, timer);
+}
+
+
+
 bool
 attribute (string_view name, TypeDesc type, const void *val)
 {
@@ -242,6 +303,10 @@ attribute (string_view name, TypeDesc type, const void *val)
     }
     if (name == "debug" && type == TypeInt) {
         print_debug = *(const int *)val;
+        return true;
+    }
+    if (name == "log_times" && type == TypeInt) {
+        oiio_log_times = *(const int *)val;
         return true;
     }
     return false;
@@ -305,6 +370,14 @@ getattribute (string_view name, TypeDesc type, void *val)
     }
     if (name == "debug" && type == TypeInt) {
         *(int *)val = print_debug;
+        return true;
+    }
+    if (name == "log_times" && type == TypeInt) {
+        *(int *)val = oiio_log_times;
+        return true;
+    }
+    if (name == "timing_report" && type == TypeString) {
+        *(ustring *)val = ustring(timing_log.report());
         return true;
     }
     if (name == "hw:simd" && type == TypeString) {

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -126,12 +126,9 @@ public:
             size_t ncalls = item.second.second;
             double time = item.second.first;
             double percall = time/ncalls;
-            bool use_ms = (item.second.first < 0.1);
             bool use_ms_percall = (percall < 0.1);
-            out << Strutil::format ("%-25s%6d %6.2f%s  (avg %6.2f%s)\n", item.first,
-                                    ncalls,
-                                    time * (use_ms ? 1000.0 : 1.0),
-                                    use_ms ? "ms" : "s ",
+            out << Strutil::format ("%-25s%6d %7.3fs  (avg %6.2f%s)\n", item.first,
+                                    ncalls, time,
                                     percall * (use_ms_percall ? 1000.0 : 1.0),
                                     use_ms_percall ? "ms" : "s");
         }

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -38,6 +38,7 @@
 
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/thread.h>
+#include <OpenImageIO/timer.h>
 
 
 
@@ -56,6 +57,7 @@ extern std::string input_format_list;
 extern std::string output_format_list;
 extern std::string extension_list;
 extern std::string library_list;
+extern int oiio_log_times;
 
 
 // For internal use - use error() below for a nicer interface.
@@ -110,6 +112,33 @@ const void *parallel_convert_from_float (const float *src, void *dst,
 /// wrong and delete them. Return true if we think it's one of these
 /// incorrect files and it was fixed.
 bool check_texture_metadata_sanity (ImageSpec &spec);
+
+/// Internal function to log time recorded by an OIIO::timer(). It will only
+/// trigger a read of the time if the "log_times" attribute is set or the
+/// OPENIMAGEIO_LOG_TIMES env variable is set.
+OIIO_API void log_time (string_view key, const Timer& timer);
+
+/// Get the timing report from log_time entries.
+OIIO_API std::string timing_report ();
+
+/// An object that, if oiio_log_times is nonzero, logs time until its
+/// destruction. If oiio_log_times is 0, it does nothing.
+class LoggedTimer {
+public:
+    LoggedTimer (string_view name) : m_timer(oiio_log_times) {
+        if (oiio_log_times)
+            m_name = name;
+    }
+    ~LoggedTimer () {
+        if (oiio_log_times)
+            log_time (m_name, m_timer);
+    }
+    void stop () { m_timer.stop(); }
+    void rename (string_view name) { m_name = name; }
+private:
+    Timer m_timer;
+    std::string m_name;
+};
 
 }  // namespace pvt
 

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -55,6 +55,7 @@
 #include <OpenImageIO/imagebufalgo_util.h>
 #include <OpenImageIO/thread.h>
 #include <OpenImageIO/filter.h>
+#include "imageio_pvt.h"
 
 #ifdef USE_BOOST_REGEX
 # include <boost/regex.hpp>
@@ -1641,6 +1642,7 @@ ImageBufAlgo::make_texture (ImageBufAlgo::MakeTextureMode mode,
                             const ImageSpec &configspec,
                             std::ostream *outstream)
 {
+    pvt::LoggedTimer logtime("IBA::make_texture");
     return make_texture_impl (mode, NULL, filename, outputfilename,
                               configspec, outstream);
 }
@@ -1654,6 +1656,7 @@ ImageBufAlgo::make_texture (ImageBufAlgo::MakeTextureMode mode,
                             const ImageSpec &configspec,
                             std::ostream *outstream_ptr)
 {
+    pvt::LoggedTimer logtime("IBA::make_texture");
     return make_texture_impl (mode, NULL, filenames[0], outputfilename,
                               configspec, outstream_ptr);
 }
@@ -1667,6 +1670,7 @@ ImageBufAlgo::make_texture (ImageBufAlgo::MakeTextureMode mode,
                             const ImageSpec &configspec,
                             std::ostream *outstream)
 {
+    pvt::LoggedTimer logtime("IBA::make_texture");
     return make_texture_impl (mode, &input, "", outputfilename,
                               configspec, outstream);
 }


### PR DESCRIPTION
All ImageBufAlgo functions (for now; other functionality may be added to logging down the line) are outfitted with optional timers to count the number of executions and total time spent for each.

This is enabled by a new global OIIO attribute "log_times", which can be enabled and disabled at any time (for example, to only log a certain phase of execution of an app).

The default is 0, meaning not to log -- and I believe that when turned off, there is no added runtime cost (except for checking the flag once per IBA function).

The initial default can be changed with the OPENIMAGEIO_LOG_TIMES environment variable.

When log_times is nonzero, logging will occur, with a slight increase in runtime expense to check the times and to lock and access the map that stores all the running totals (stored separately, indexed by name). This extra cost is probably not significant for whole-image operations such as IBA calls, but it would not be an especially accurate way to time fine-grained operations that work on one or a few pixels at a time.

The global getattribute() call may be used to retrieve "timing_report", which will return a string containing a list of all the timing totals, alphabetized by name, like this:

    IBA::computePixelStats        2   2.69ms  (avg   1.34ms)
    IBA::make_texture             1  74.05ms  (avg  74.05ms)
    IBA::mul                      8   2.42ms  (avg   0.30ms)
    IBA::over                    10  23.82ms  (avg   2.38ms)
    IBA::resize                  20   0.24s   (avg  12.18ms)
    IBA::zero                     8   0.66ms  (avg   0.08ms)

If the log_times option has a value > 1 at the time that the program terminates, the destructor of the timing data structure will automatically print the timing report to stdout.

So, even for a program (that uses OIIO ImageBufAlgo internally) that has no exposed option to retrieve and print the report, you can still find out how it's spending its time by launching as

    OPENIMAGEIO_LOG_TIMES=2 my_application

Some caveats to keep in mind:
* It's possible that in situations where one IBA function ends up   calling another, the time could be doubled-counted.
* Small times are reported in ms, large times in seconds -- make sure   you are paying attention to the units in the report.
* This measures "wall clock time", so interpret carefully in the presence of multithreading.
