### PR TITLE
Remove accommodations for MSVS older than 2013

### DIFF
--- a/src/include/OpenImageIO/missing_math.h
+++ b/src/include/OpenImageIO/missing_math.h
@@ -113,77 +113,11 @@ OIIO_NAMESPACE_BEGIN
 #define copysignf(x,y) float(copysign(x,y))
 
 
-
 inline float
 truncf (float val)
 {
     return (float)(int)val;
 }
-
-
-#if defined(_MSC_VER)
-#if _MSC_VER < 1800 /* Needed for MSVS prior to 2013 */
-
-template<class T>
-inline int isnan (T x) {
-    return _isnan(x);
-}
-
-
-template<class T>
-inline int isfinite (T x) {
-    return _finite(x);
-}
-
-
-template<class T>
-inline int isinf (T x) {
-    return (isfinite(x)||isnan(x)) ? 0 : static_cast<int>(copysign(T(1.0), x));
-}
-
-
-inline double
-round (float val) {
-    return floor (val + 0.5);
-}
-
-
-inline float
-roundf (float val) {
-    return static_cast<float>(round (val));
-}
-
-
-inline float
-log2f (float val) {
-    return logf (val)/static_cast<float>(M_LN2);
-}
-
-
-inline float
-cbrtf (float val) {
-	return powf (val, 1.0/3.0);
-}
-
-
-inline float
-rintf (float val) {
-    return val + copysignf(0.5f, val);
-}
-
-#elif _MSC_VER >= 1800 && __cplusplus <= 201103L
-// Prior to c++11, these were implementation defined, and on msvc, were not in the
-// std namespace
-using ::isnan;
-using ::isinf;
-using ::isfinite;
-#else
-using std::isnan;
-using std::isinf;
-using std::isfinite;
-#endif
-
-#endif /* MSVS < 2013 */
 
 
 inline float
@@ -193,89 +127,21 @@ exp2f (float val) {
 }
 
 
-#if defined(_MSC_VER) && _MSC_VER < 1800 /* Needed for MSVS prior to 2013 */
-inline float
-logbf (float val) {
-   // please see http://www.kernel.org/doc/man-pages/online/pages/man3/logb.3.html
-   return floorf (logf(fabsf(val))/logf(FLT_RADIX));
-}
-
-
-// from http://www.johndcook.com/cpp_expm1.html
-inline double
-expm1(double val)
-{
-    // exp(x) - 1 without loss of precision for small values of x.
-    if (fabs(val) < 1e-5)
-        return val + 0.5*val*val;
-    else
-        return exp(val) - 1.0;
-}
-
-
-inline float
-expm1f (float val)
-{
-    return (float)expm1(val);
-}
-
-
-// from http://www.johndcook.com/cpp_erf.html
-inline double
-erf(double x)
-{
-    // constants
-    double a1 =  0.254829592;
-    double a2 = -0.284496736;
-    double a3 =  1.421413741;
-    double a4 = -1.453152027;
-    double a5 =  1.061405429;
-    double p  =  0.3275911;
-
-    // Save the sign of x
-    int sign = 1;
-    if (x < 0)
-        sign = -1;
-    x = fabs(x);
-
-    // A&S formula 7.1.26
-    double t = 1.0/(1.0 + p*x);
-    double y = 1.0 - (((((a5*t + a4)*t) + a3)*t + a2)*t + a1)*t*exp(-x*x);
-
-    return sign*y;
-}
-
-
-inline float
-erff (float val)
-{
-    return (float)erf(val);
-}
-
-
-inline double
-erfc(double val)
-{
-    return 1.0 - erf(val);
-}
-
-
-inline float
-erfcf (float val)
-{
-    return (float)erfc(val);
-}
-
-#endif /* MSVS < 2013 */
-
 #endif  /* _WIN32 */
 
 
-#if !defined(_MSC_VER)
- using std::isnan;
- using std::isinf;
- using std::isfinite;
+#if OIIO_MSVS_AT_LEAST_2013 && __cplusplus <= 201103L
+  // Prior to c++11, these were implementation defined, and on msvc, were
+  // not in the std namespace.
+  using ::isnan;
+  using ::isinf;
+  using ::isfinite;
+#else
+  using std::isnan;
+  using std::isinf;
+  using std::isfinite;
 #endif
+
 
 
 

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -41,25 +41,10 @@
 #include <utility> // std::forward
 
 // Make sure all platforms have the explicit sized integer types
-#if defined(_MSC_VER) && _MSC_VER < 1600
-   typedef __int8  int8_t;
-   typedef __int16 int16_t;
-   typedef __int32 int32_t;
-   typedef __int64 int64_t;
-   typedef unsigned __int8  uint8_t;
-   typedef unsigned __int16 uint16_t;
-# ifndef _UINT64_T
-   typedef unsigned __int32 uint32_t;
-   typedef unsigned __int64 uint64_t;
-#  define _UINT32_T
-#  define _UINT64_T
-# endif
-#else
-#  ifndef __STDC_LIMIT_MACROS
-#    define __STDC_LIMIT_MACROS  /* needed for some defs in stdint.h */
-#  endif
-#  include <cstdint>
+#ifndef __STDC_LIMIT_MACROS
+#  define __STDC_LIMIT_MACROS  /* needed for some defs in stdint.h */
 #endif
+#include <cstdint>
 
 #if defined(__FreeBSD__)
 #include <sys/param.h>
@@ -174,15 +159,22 @@
 
 // Tests for MSVS versions, always 0 if not MSVS at all.
 #if defined(_MSC_VER)
+#  if _MSC_VER < 1800
+#    error "This version of OIIO is meant to work only with Visual Studio 2013 or later"
+#  endif
 #  define OIIO_MSVS_AT_LEAST_2013 (_MSC_VER >= 1800)
 #  define OIIO_MSVS_BEFORE_2013   (_MSC_VER <  1800)
 #  define OIIO_MSVS_AT_LEAST_2015 (_MSC_VER >= 1900)
 #  define OIIO_MSVS_BEFORE_2015   (_MSC_VER <  1900)
+#  define OIIO_MSVS_AT_LEAST_2017 (_MSC_VER >= 1910)
+#  define OIIO_MSVS_BEFORE_2017   (_MSC_VER <  1910)
 #else
 #  define OIIO_MSVS_AT_LEAST_2013 0
 #  define OIIO_MSVS_BEFORE_2013   0
 #  define OIIO_MSVS_AT_LEAST_2015 0
 #  define OIIO_MSVS_BEFORE_2015   0
+#  define OIIO_MSVS_AT_LEAST_2017 0
+#  define OIIO_MSVS_BEFORE_2017   0
 #endif
 
 


### PR DESCRIPTION
We've advertised for some time that 2013 was the minimum version. Get
rid of some cruft from before that.

