### PR TITLE
Modifying fmath.h to allow CUDA compilation

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -1604,8 +1604,6 @@ inline OIIO_HOSTDEVICE float fast_correct_exp (float x)
     // On x86_64, versions of glibc < 2.16 have an issue where expf is
     // much slower than the double version.  This was fixed in glibc 2.16.
     return static_cast<float>(std::exp(static_cast<double>(x)));
-#elif defined(__CUDACC__)
-    return static_cast<float>(std::exp(static_cast<double>(x)));
 #else
     return std::exp(x);
 #endif
@@ -1713,13 +1711,11 @@ inline OIIO_HOSTDEVICE float fast_safe_pow (float x, float y) {
 }
 
 
-#ifndef __CUDACC__
 // Fast simd pow that only needs to work for positive x
 template<typename T, typename U>
 inline OIIO_HOSTDEVICE T fast_pow_pos (const T& x, const U& y) {
     return fast_exp2(y * fast_log2(x));
 }
-#endif
 
 
 inline OIIO_HOSTDEVICE float fast_erf (float x)

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -62,9 +62,7 @@
 #include <OpenImageIO/platform.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/missing_math.h>
-#ifndef __CUDACC__
 #include <OpenImageIO/simd.h>
-#endif
 #include <OpenImageIO/array_view.h>
 
 
@@ -89,7 +87,7 @@ template<typename T> struct is_same<T,T> { static const bool value = true; };
 /// Quick test for whether an integer is a power of 2.
 ///
 template<typename T>
-inline bool
+inline OIIO_HOSTDEVICE bool
 ispow2 (T x)
 {
     // Numerous references for this bit trick are on the web.  The
@@ -102,7 +100,7 @@ ispow2 (T x)
 
 /// Round up to next higher power of 2 (return x if it's already a power
 /// of 2).
-inline int
+inline OIIO_HOSTDEVICE int
 pow2roundup (int x)
 {
     // Here's a version with no loops.
@@ -125,7 +123,7 @@ pow2roundup (int x)
 
 /// Round down to next lower power of 2 (return x if it's already a power
 /// of 2).
-inline int
+inline OIIO_HOSTDEVICE int
 pow2rounddown (int x)
 {
     // Make all bits past the first 1 also be 1, i.e. 0001xxxx -> 00011111
@@ -144,7 +142,7 @@ pow2rounddown (int x)
 /// Round value up to the next whole multiple.
 /// For example, round_to_multiple(7,10) returns 10.
 template <typename V, typename M>
-inline V round_to_multiple (V value, M multiple)
+inline OIIO_HOSTDEVICE V round_to_multiple (V value, M multiple)
 {
     return V (((value + V(multiple) - 1) / V(multiple)) * V(multiple));
 }
@@ -156,7 +154,7 @@ inline V round_to_multiple (V value, M multiple)
 /// round_to_multiple). This is a template that should work for any
 // integer type.
 template<typename T>
-inline T
+inline OIIO_HOSTDEVICE T
 round_to_multiple_of_pow2 (T x, T m)
 {
     DASSERT (ispow2 (m));
@@ -167,7 +165,7 @@ round_to_multiple_of_pow2 (T x, T m)
 
 /// Multiply two unsigned 32-bit ints safely, carefully checking for
 /// overflow, and clamping to uint32_t's maximum value.
-inline uint32_t
+inline OIIO_HOSTDEVICE uint32_t
 clamped_mult32 (uint32_t a, uint32_t b)
 {
     const uint32_t Err = std::numeric_limits<uint32_t>::max();
@@ -179,7 +177,7 @@ clamped_mult32 (uint32_t a, uint32_t b)
 
 /// Multiply two unsigned 64-bit ints safely, carefully checking for
 /// overflow, and clamping to uint64_t's maximum value.
-inline uint64_t
+inline OIIO_HOSTDEVICE uint64_t
 clamped_mult64 (uint64_t a, uint64_t b)
 {
     uint64_t ab = a*b;
@@ -192,12 +190,12 @@ clamped_mult64 (uint64_t a, uint64_t b)
 
 
 /// Bitwise circular rotation left by k bits (for 32 bit unsigned integers)
-OIIO_FORCEINLINE uint32_t rotl32 (uint32_t x, int k) {
+OIIO_FORCEINLINE OIIO_HOSTDEVICE uint32_t rotl32 (uint32_t x, int k) {
     return (x<<k) | (x>>(32-k));
 }
 
 /// Bitwise circular rotation left by k bits (for 64 bit unsigned integers)
-OIIO_FORCEINLINE uint64_t rotl64 (uint64_t x, int k) {
+OIIO_FORCEINLINE OIIO_HOSTDEVICE uint64_t rotl64 (uint64_t x, int k) {
     return (x<<k) | (x>>(64-k));
 }
 
@@ -219,7 +217,7 @@ OIIO_FORCEINLINE uint64_t rotl64 (uint64_t x, int k) {
 
 /// clamp a to bounds [low,high].
 template <class T>
-inline T
+inline OIIO_HOSTDEVICE T
 clamp (const T& a, const T& low, const T& high)
 {
     return (a >= low) ? ((a <= high) ? a : high) : low;
@@ -244,7 +242,7 @@ clamp (const simd::vfloat8& a, const simd::vfloat8& low, const simd::vfloat8& hi
 
 
 /// Fused multiply and add: (a*b + c)
-inline float madd (float a, float b, float c) {
+inline OIIO_HOSTDEVICE float madd (float a, float b, float c) {
 #if OIIO_FMA_ENABLED
     // C++11 defines std::fma, which we assume is implemented using an
     // intrinsic.
@@ -258,21 +256,21 @@ inline float madd (float a, float b, float c) {
 
 
 /// Fused multiply and subtract: -(a*b - c)
-inline float msub (float a, float b, float c) {
+inline OIIO_HOSTDEVICE float msub (float a, float b, float c) {
     return a * b - c; // Hope for the best
 }
 
 
 
 /// Fused negative multiply and add: -(a*b) + c
-inline float nmadd (float a, float b, float c) {
+inline OIIO_HOSTDEVICE float nmadd (float a, float b, float c) {
     return c - (a * b); // Hope for the best
 }
 
 
 
 /// Negative fused multiply and subtract: -(a*b) - c
-inline float nmsub (float a, float b, float c) {
+inline OIIO_HOSTDEVICE float nmsub (float a, float b, float c) {
     return -(a * b) - c; // Hope for the best
 }
 
@@ -281,7 +279,7 @@ inline float nmsub (float a, float b, float c) {
 /// Linearly interpolate values v0-v1 at x: v0*(1-x) + v1*x.
 /// This is a template, and so should work for any types.
 template <class T, class Q>
-inline T
+inline OIIO_HOSTDEVICE T
 lerp (const T& v0, const T& v1, const Q& x)
 {
     // NOTE: a*(1-x) + b*x is much more numerically stable than a+x*(b-a)
@@ -294,7 +292,7 @@ lerp (const T& v0, const T& v1, const Q& x)
 /// v2 lower left, v3 lower right) at coordinates (s,t) and return the
 /// result.  This is a template, and so should work for any types.
 template <class T, class Q>
-inline T
+inline OIIO_HOSTDEVICE T
 bilerp(const T& v0, const T& v1, const T& v2, const T& v3, const Q& s, const Q& t)
 {
     // NOTE: a*(t-1) + b*t is much more numerically stable than a+t*(b-a)
@@ -309,7 +307,7 @@ bilerp(const T& v0, const T& v1, const T& v2, const T& v3, const Q& s, const Q& 
 /// storing the results in 'result'.  These are all vectors, so do it
 /// for each of 'n' contiguous values (using the same s,t interpolants).
 template <class T, class Q>
-inline void
+inline OIIO_HOSTDEVICE void
 bilerp (const T *v0, const T *v1,
         const T *v2, const T *v3,
         Q s, Q t, int n, T *result)
@@ -328,7 +326,7 @@ bilerp (const T *v0, const T *v1,
 /// 'result'.  These are all vectors, so do it for each of 'n'
 /// contiguous values (using the same s,t interpolants).
 template <class T, class Q>
-inline void
+inline OIIO_HOSTDEVICE void
 bilerp_mad (const T *v0, const T *v1,
             const T *v2, const T *v3,
             Q s, Q t, Q scale, int n, T *result)
@@ -346,7 +344,7 @@ bilerp_mad (const T *v0, const T *v1,
 /// upper right top, ...) at coordinates (s,t,r), and return the
 /// result.  This is a template, and so should work for any types.
 template <class T, class Q>
-inline T
+inline OIIO_HOSTDEVICE T
 trilerp (T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7, Q s, Q t, Q r)
 {
     // NOTE: a*(t-1) + b*t is much more numerically stable than a+t*(b-a)
@@ -364,7 +362,7 @@ trilerp (T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7, Q s, Q t, Q r)
 /// storing the results in 'result'.  These are all vectors, so do it
 /// for each of 'n' contiguous values (using the same s,t,r interpolants).
 template <class T, class Q>
-inline void
+inline OIIO_HOSTDEVICE void
 trilerp (const T *v0, const T *v1, const T *v2, const T *v3,
          const T *v4, const T *v5, const T *v6, const T *v7,
          Q s, Q t, Q r, int n, T *result)
@@ -385,7 +383,7 @@ trilerp (const T *v0, const T *v1, const T *v2, const T *v3,
 /// 'result'.  These are all vectors, so do it for each of 'n'
 /// contiguous values (using the same s,t,r interpolants).
 template <class T, class Q>
-inline void
+inline OIIO_HOSTDEVICE void
 trilerp_mad (const T *v0, const T *v1, const T *v2, const T *v3,
              const T *v4, const T *v5, const T *v6, const T *v7,
              Q s, Q t, Q r, Q scale, int n, T *result)
@@ -400,7 +398,7 @@ trilerp_mad (const T *v0, const T *v1, const T *v2, const T *v3,
 /// Evaluate B-spline weights in w[0..3] for the given fraction.  This
 /// is an important component of performing a cubic interpolation.
 template <typename T>
-inline void evalBSplineWeights (T w[4], T fraction)
+inline OIIO_HOSTDEVICE void evalBSplineWeights (T w[4], T fraction)
 {
     T one_frac = 1 - fraction;
     w[0] = T(1.0 / 6.0) * one_frac * one_frac * one_frac;
@@ -414,7 +412,7 @@ inline void evalBSplineWeights (T w[4], T fraction)
 /// fraction.  This is an important component of performing a cubic
 /// interpolation with derivatives.
 template <typename T>
-inline void evalBSplineWeightDerivs (T dw[4], T fraction)
+inline OIIO_HOSTDEVICE void evalBSplineWeightDerivs (T dw[4], T fraction)
 {
     T one_frac = 1 - fraction;
     dw[0] = -T(0.5) * one_frac * one_frac;
@@ -431,7 +429,7 @@ inline void evalBSplineWeightDerivs (T dw[4], T fraction)
 /// results in 'result'.  These are all vectors, so do it for each of
 /// 'n' contiguous values (using the same s,t interpolants).
 template <class T>
-inline void
+inline OIIO_HOSTDEVICE void
 bicubic_interp (const T **val, T s, T t, int n, T *result)
 {
     for (int c = 0;  c < n;  ++c)
@@ -450,7 +448,7 @@ bicubic_interp (const T **val, T s, T t, int n, T *result)
 
 
 /// Return floor(x) cast to an int.
-inline int
+inline OIIO_HOSTDEVICE int
 ifloor (float x)
 {
     return (int)floorf(x);
@@ -462,11 +460,15 @@ ifloor (float x)
 /// to the built-in modf, but returns a true int, always rounds down
 /// (compared to modf which rounds toward 0), and always returns
 /// frac >= 0 (comapred to modf which can return <0 if x<0).
-inline float
+inline OIIO_HOSTDEVICE float
 floorfrac (float x, int *xint)
 {
 #if 1
+#ifndef __CUDACC__
     float f = std::floor(x);
+#else
+    float f = floor(x);
+#endif
     *xint = int(f);
     return x - f;
 #else /* vvv This idiom is slower */
@@ -502,30 +504,34 @@ inline simd::vfloat16 floorfrac (const simd::vfloat16& x, simd::vint16 *xint) {
 
 /// Convert degrees to radians.
 template <typename T>
-inline T radians (T deg) { return deg * T(M_PI / 180.0); }
+inline OIIO_HOSTDEVICE T radians (T deg) { return deg * T(M_PI / 180.0); }
 
 /// Convert radians to degrees
 template <typename T>
-inline T degrees (T rad) { return rad * T(180.0 / M_PI); }
+inline OIIO_HOSTDEVICE T degrees (T rad) { return rad * T(180.0 / M_PI); }
 
 
 
-inline void
+inline OIIO_HOSTDEVICE void
 sincos (float x, float* sine, float* cosine)
 {
 #if defined(__GNUC__) && defined(__linux__) && !defined(__clang__)
     __builtin_sincosf(x, sine, cosine);
+#elif defined(__CUDACC__)
+    ::sincos(x, sine, cosine);
 #else
     *sine = std::sin(x);
     *cosine = std::cos(x);
 #endif
 }
 
-inline void
+inline OIIO_HOSTDEVICE void
 sincos (double x, double* sine, double* cosine)
 {
 #if defined(__GNUC__) && defined(__linux__) && !defined(__clang__)
     __builtin_sincos(x, sine, cosine);
+#elif defined(__CUDACC__)
+    ::sincos(x, sine, cosine);
 #else
     *sine = std::sin(x);
     *cosine = std::cos(x);
@@ -533,7 +539,7 @@ sincos (double x, double* sine, double* cosine)
 }
 
 
-inline float sign (float x)
+inline OIIO_HOSTDEVICE float sign (float x)
 {
     return x < 0.0f ? -1.0f : (x==0.0f ? 0.0f : 1.0f);
 }
@@ -553,7 +559,7 @@ inline float sign (float x)
 
 
 template <typename IN_TYPE, typename OUT_TYPE>
-inline OUT_TYPE bit_cast (const IN_TYPE in) {
+inline OIIO_HOSTDEVICE OUT_TYPE bit_cast (const IN_TYPE in) {
     // NOTE: this is the only standards compliant way of doing this type of casting,
     // luckily the compilers we care about know how to optimize away this idiom.
     OUT_TYPE out;
@@ -562,8 +568,8 @@ inline OUT_TYPE bit_cast (const IN_TYPE in) {
 }
 
 
-inline int bitcast_to_int (float x) { return bit_cast<float,int>(x); }
-inline float bitcast_to_float (int x) { return bit_cast<int,float>(x); }
+inline OIIO_HOSTDEVICE int bitcast_to_int (float x) { return bit_cast<float,int>(x); }
+inline OIIO_HOSTDEVICE float bitcast_to_float (int x) { return bit_cast<int,float>(x); }
 
 
 
@@ -571,7 +577,7 @@ inline float bitcast_to_float (int x) { return bit_cast<int,float>(x); }
 /// or 8 bytes.  This should work for any of short, unsigned short, int,
 /// unsigned int, float, long long, pointers.
 template<class T>
-inline void
+inline OIIO_HOSTDEVICE void
 swap_endian (T *f, int len=1)
 {
     for (char *c = (char *) f;  len--;  c += sizeof(T)) {
@@ -605,7 +611,7 @@ template<> struct big_enough_float<double>       { typedef double float_t; };
 /// (presumed to be integer).  This is just a helper for the convert_type
 /// templates, it probably has no other use.
 template<typename S, typename D, typename F>
-inline D
+inline OIIO_HOSTDEVICE D
 scaled_conversion (const S &src, F scale, F min, F max)
 {
     if (std::numeric_limits<S>::is_signed) {
@@ -862,7 +868,7 @@ convert_type (const S &src)
 /// It is assumed that the original value is a valid FROM_BITS integer, i.e.
 /// shifted fully to the right.
 template<unsigned int FROM_BITS, unsigned int TO_BITS>
-inline unsigned int bit_range_convert(unsigned int in) {
+inline OIIO_HOSTDEVICE unsigned int bit_range_convert(unsigned int in) {
     unsigned int out = 0;
     int shift = TO_BITS - FROM_BITS;
     for (; shift > 0; shift -= FROM_BITS)
@@ -874,7 +880,7 @@ inline unsigned int bit_range_convert(unsigned int in) {
 
 
 // non-templated version.  Slow but general
-inline unsigned int
+inline OIIO_HOSTDEVICE unsigned int
 bit_range_convert(unsigned int in, unsigned int FROM_BITS, unsigned int TO_BITS)
 {
     unsigned int out = 0;
@@ -979,7 +985,7 @@ private:
 /// that approximates the float, for example 52.83 will simply
 /// return 5283/100.  This does not attempt to gracefully handle
 /// floats that are out of range that could be easily int/int.
-inline void
+inline OIIO_HOSTDEVICE void
 float_to_rational (float f, unsigned int &num, unsigned int &den)
 {
     if (f <= 0) {   // Trivial case of zero, and handle all negative values
@@ -1006,7 +1012,7 @@ float_to_rational (float f, unsigned int &num, unsigned int &den)
 /// example 52.83 will simply return 5283/100.  This does not attempt to
 /// gracefully handle floats that are out of range that could be easily
 /// int/int.
-inline void
+inline OIIO_HOSTDEVICE void
 float_to_rational (float f, int &num, int &den)
 {
     unsigned int n, d;
@@ -1036,55 +1042,79 @@ float_to_rational (float f, int &num, int &den)
 
 /// Safe (clamping) sqrt: safe_sqrt(x<0) returns 0, not NaN.
 template <typename T>
-inline T safe_sqrt (T x) {
+inline OIIO_HOSTDEVICE T safe_sqrt (T x) {
+#ifndef __CUDACC__
     return x >= T(0) ? std::sqrt(x) : T(0);
+#else
+    return x >= T(0) ? sqrt(x) : T(0);
+#endif
 }
 
 /// Safe (clamping) inverse sqrt: safe_inversesqrt(x<=0) returns 0.
 template <typename T>
-inline T safe_inversesqrt (T x) {
+inline OIIO_HOSTDEVICE T safe_inversesqrt (T x) {
+#ifndef __CUDACC__
     return x > T(0) ? T(1) / std::sqrt(x) : T(0);
+#else
+    return x > T(0) ? rsqrt(x) : T(0);
+#endif
 }
 
 
 /// Safe (clamping) arcsine: clamp to the valid domain.
 template <typename T>
-inline T safe_asin (T x) {
+inline OIIO_HOSTDEVICE T safe_asin (T x) {
     if (x <= T(-1)) return T(-M_PI_2);
     if (x >= T(+1)) return T(+M_PI_2);
+#ifndef __CUDACC__
     return std::asin(x);
+#else
+    return asin(x);
+#endif
 }
 
 /// Safe (clamping) arccosine: clamp to the valid domain.
 template <typename T>
-inline T safe_acos (T x) {
+inline OIIO_HOSTDEVICE T safe_acos (T x) {
     if (x <= T(-1)) return T(M_PI);
     if (x >= T(+1)) return T(0);
+#ifndef __CUDACC__
     return std::acos(x);
+#else
+    return acos(x);
+#endif
 }
 
 
 /// Safe log2: clamp to valid domain.
 template <typename T>
-inline T safe_log2 (T x) {
+inline OIIO_HOSTDEVICE T safe_log2 (T x) {
     // match clamping from fast version
     if (x < std::numeric_limits<T>::min()) x = std::numeric_limits<T>::min();
     if (x > std::numeric_limits<T>::max()) x = std::numeric_limits<T>::max();
+#ifndef __CUDACC__
     return std::log2(x);
+#else
+    return log2(x);
+#endif
 }
 
 /// Safe log: clamp to valid domain.
 template <typename T>
-inline T safe_log (T x) {
+inline OIIO_HOSTDEVICE T safe_log (T x) {
     // slightly different than fast version since clamping happens before scaling
     if (x < std::numeric_limits<T>::min()) x = std::numeric_limits<T>::min();
     if (x > std::numeric_limits<T>::max()) x = std::numeric_limits<T>::max();
+#ifndef __CUDACC__
     return std::log(x);
+#else
+    return log(x);
+#endif
 }
 
 /// Safe log10: clamp to valid domain.
 template <typename T>
-inline T safe_log10 (T x) {
+inline OIIO_HOSTDEVICE T safe_log10 (T x) {
     // slightly different than fast version since clamping happens before scaling
     if (x < std::numeric_limits<T>::min()) x = std::numeric_limits<T>::min();
     if (x > std::numeric_limits<T>::max()) x = std::numeric_limits<T>::max();
@@ -1093,20 +1123,28 @@ inline T safe_log10 (T x) {
 
 /// Safe logb: clamp to valid domain.
 template <typename T>
-inline T safe_logb (T x) {
+inline OIIO_HOSTDEVICE T safe_logb (T x) {
+#ifndef __CUDACC__
     return (x != T(0)) ? std::logb(x) : -std::numeric_limits<T>::max();
+#else
+    return (x != T(0)) ? logb(x) : -std::numeric_limits<T>::max();
+#endif
 }
 
 /// Safe pow: clamp the domain so it never returns Inf or NaN or has divide
 /// by zero error.
 template <typename T>
-inline T safe_pow (T x, T y) {
+inline OIIO_HOSTDEVICE T safe_pow (T x, T y) {
     if (y == T(0)) return T(1);
     if (x == T(0)) return T(0);
     // if x is negative, only deal with integer powers
     if ((x < T(0)) && (y != floor(y))) return T(0);
     // FIXME: this does not match "fast" variant because clamping limits are different
+#ifndef __CUDACC__
     T r = std::pow(x, y);
+#else
+    T r = pow(x, y);
+#endif
     // Clamp to avoid returning Inf.
     const T big = std::numeric_limits<T>::max();
     return clamp (r, -big, big);
@@ -1134,10 +1172,17 @@ inline T safe_pow (T x, T y) {
 // Some functions are fast_safe_*, which is both a faster approximation as
 // well as clamped input domain to ensure no NaN, Inf, or divide by zero.
 //
+// NB: When compiling for CUDA devices, selection of the 'fast' intrinsics
+//     is influenced by compiler options (-ffast-math for clang/gcc,
+//     --use-fast-math for NVCC).
+//
+// TODO: Quantify the performance and accuracy of the CUDA Math functions
+//       relative to the definitions in this file. It may be better in some
+//       cases to use the approximate versions defined below.
 
 
 /// Round to nearest integer, returning as an int.
-inline int fast_rint (float x) {
+inline OIIO_HOSTDEVICE int fast_rint (float x) {
     // used by sin/cos/tan range reduction
 #if OIIO_SIMD_SSE >= 4
     // single roundps instruction on SSE4.1+ (for gcc/clang at least)
@@ -1154,8 +1199,9 @@ inline simd::vint4 fast_rint (const simd::vfloat4& x) {
 }
 #endif
 
+
+inline OIIO_HOSTDEVICE float fast_sin (float x) {
 #ifndef __CUDACC__
-inline float fast_sin (float x) {
     // very accurate argument reduction from SLEEF
     // starts failing around x=262000
     // Results on: [-2pi,2pi]
@@ -1181,10 +1227,14 @@ inline float fast_sin (float x) {
     // values away (setting to 0.0f means no branches need to be generated).
     if (fabsf(u) > 1.0f) u = 0.0f;
     return u;
+#else
+    return __sinf(x);
+#endif
 }
 
 
-inline float fast_cos (float x) {
+inline OIIO_HOSTDEVICE float fast_cos (float x) {
+#ifndef __CUDACC__
     // same argument reduction as fast_sin
     int q = fast_rint (x * float(M_1_PI));
     float qf = q;
@@ -1205,9 +1255,14 @@ inline float fast_cos (float x) {
     if ((q & 1) != 0) u = -u;
     if (fabsf(u) > 1.0f) u = 0.0f;
     return u;
+#else
+    return __cosf(x);
+#endif
 }
 
-inline void fast_sincos (float x, float* sine, float* cosine) {
+
+inline OIIO_HOSTDEVICE void fast_sincos (float x, float* sine, float* cosine) {
+#ifndef __CUDACC__
     // same argument reduction as fast_sin
     int q = fast_rint (x * float(M_1_PI));
     float qf = q;
@@ -1235,11 +1290,15 @@ inline void fast_sincos (float x, float* sine, float* cosine) {
     if (fabsf(cu) > 1.0f) cu = 0.0f;
     *sine   = su;
     *cosine = cu;
+#else
+    __sincosf(x, sine, cosine);
+#endif
 }
 
 // NOTE: this approximation is only valid on [-8192.0,+8192.0], it starts becoming
 // really poor outside of this range because the reciprocal amplifies errors
-inline float fast_tan (float x) {
+inline OIIO_HOSTDEVICE float fast_tan (float x) {
+#ifndef __CUDACC__
     // derived from SLEEF implementation
     // note that we cannot apply the "denormal crush" trick everywhere because
     // we sometimes need to take the reciprocal of the polynomial
@@ -1261,13 +1320,17 @@ inline float fast_tan (float x) {
     u = madd(s, u * x, x);
     if ((q & 1) != 0) u = -1.0f / u;
     return u;
+#else
+    return __tanf(x);
+#endif
 }
 
 /// Fast, approximate sin(x*M_PI) with maximum absolute error of 0.000918954611.
 /// Adapted from http://devmaster.net/posts/9648/fast-and-accurate-sine-cosine#comment-76773
 /// Note that this is MUCH faster, but much less accurate than fast_sin.
-inline float fast_sinpi (float x)
+inline OIIO_HOSTDEVICE float fast_sinpi (float x)
 {
+#ifndef __CUDACC__
 	// Fast trick to strip the integral part off, so our domain is [-1,1]
 	const float z = x - ((x + 25165824.0f) - 25165824.0f);
     const float y = z - z * fabsf(z);
@@ -1296,16 +1359,24 @@ inline float fast_sinpi (float x)
      * NOTE: this function actually computes sin(x * pi) which avoids one or two
      * mults in many cases and guarantees exact values at integer periods.
      */
+#else
+    return __sinf(float(M_PI)) * x;
+#endif
 }
 
 /// Fast approximate cos(x*M_PI) with ~0.1% absolute error.
 /// Note that this is MUCH faster, but much less accurate than fast_cos.
-inline float fast_cospi (float x)
+inline OIIO_HOSTDEVICE float fast_cospi (float x)
 {
+#ifndef __CUDACC__
     return fast_sinpi (x+0.5f);
+#else
+    return __cosf(float(M_PI)) * x;
+#endif
 }
 
-inline float fast_acos (float x) {
+inline OIIO_HOSTDEVICE float fast_acos (float x) {
+#ifndef __CUDACC__
     const float f = fabsf(x);
     const float m = (f < 1.0f) ? 1.0f - (1.0f - f) : 1.0f; // clamp and crush denormals
     // based on http://www.pouet.net/topic.php?which=9132&page=2
@@ -1314,18 +1385,26 @@ inline float fast_acos (float x) {
     // Examined 2130706434 values of acos: 15.2007108 avg ulp diff, 4492 max ulp, 4.51803e-05 max error // with "denormal crush"
     const float a = sqrtf(1.0f - m) * (1.5707963267f + m * (-0.213300989f + m * (0.077980478f + m * -0.02164095f)));
     return x < 0 ? float(M_PI) - a : a;
+#else
+    return acosf(x);
+#endif
 }
 
-inline float fast_asin (float x) {
+inline OIIO_HOSTDEVICE float fast_asin (float x) {
+#ifndef __CUDACC__
     // based on acosf approximation above
     // max error is 4.51133e-05 (ulps are higher because we are consistently off by a little amount)
     const float f = fabsf(x);
     const float m = (f < 1.0f) ? 1.0f - (1.0f - f) : 1.0f; // clamp and crush denormals
     const float a = float(M_PI_2) - sqrtf(1.0f - m) * (1.5707963267f + m * (-0.213300989f + m * (0.077980478f + m * -0.02164095f)));
     return copysignf(a, x);
+#else
+    return asinf(x);
+#endif
 }
 
-inline float fast_atan (float x) {
+inline OIIO_HOSTDEVICE float fast_atan (float x) {
+#ifndef __CUDACC__
     const float a = fabsf(x);
     const float k = a > 1.0f ? 1 / a : a;
     const float s = 1.0f - (1.0f - k); // crush denormals
@@ -1336,9 +1415,13 @@ inline float fast_atan (float x) {
     float r = s * madd(0.43157974f, t, 1.0f) / madd(madd(0.05831938f, t, 0.76443945f), t, 1.0f);
     if (a > 1.0f) r = 1.570796326794896557998982f - r;
     return copysignf(r, x);
+#else
+    return atanf(x);
+#endif
 }
 
-inline float fast_atan2 (float y, float x) {
+inline OIIO_HOSTDEVICE float fast_atan2 (float y, float x) {
+#ifndef __CUDACC__
     // based on atan approximation above
     // the special cases around 0 and infinity were tested explicitly
     // the only case not handled correctly is x=NaN,y=0 which returns 0 instead of nan
@@ -1355,11 +1438,14 @@ inline float fast_atan2 (float y, float x) {
     if (bit_cast<float, unsigned>(x) & 0x80000000u) // test sign bit of x
         r = float(M_PI) - r;
     return copysignf(r, y);
+#else
+    return atan2f(y, x);
+#endif
 }
 
 
 template<typename T>
-inline T fast_log2 (const T& xval) {
+inline OIIO_HOSTDEVICE T fast_log2 (const T& xval) {
     using namespace simd;
     typedef typename T::int_t intN;
     // See float fast_log2 for explanations
@@ -1380,7 +1466,8 @@ inline T fast_log2 (const T& xval) {
 
 
 template<>
-inline float fast_log2 (const float& xval) {
+inline OIIO_HOSTDEVICE float fast_log2 (const float& xval) {
+#ifndef __CUDACC__
     // NOTE: clamp to avoid special cases and make result "safe" from large negative values/nans
     float x = clamp (xval, std::numeric_limits<float>::min(), std::numeric_limits<float>::max());
     // based on https://github.com/LiraNuna/glsl-sse2/blob/master/source/vec4.h
@@ -1401,45 +1488,71 @@ inline float fast_log2 (const float& xval) {
     hi = madd(f, hi, -0.34730547155299f);
     lo = madd(f, lo,  1.442689881667200f);
     return ((f4 * hi) + (f * lo)) + exponent;
+#else
+    return __log2f(xval);
+#endif
 }
 
 
-
 template<typename T>
-inline T fast_log (const T& x) {
+inline OIIO_HOSTDEVICE T fast_log (const T& x) {
     // Examined 2130706432 values of logf on [1.17549435e-38,3.40282347e+38]: 0.313865375 avg ulp diff, 5148137 max ulp, 7.62939e-06 max error
     return fast_log2(x) * T(M_LN2);
 }
 
+#ifdef __CUDACC__
+template<>
+inline OIIO_HOSTDEVICE float fast_log(const float& x)
+{
+     return __logf(x);
+}
+#endif
+
 
 template<typename T>
-inline T fast_log10 (const T& x) {
+inline OIIO_HOSTDEVICE T fast_log10 (const T& x) {
     // Examined 2130706432 values of log10f on [1.17549435e-38,3.40282347e+38]: 0.631237033 avg ulp diff, 4471615 max ulp, 3.8147e-06 max error
     return fast_log2(x) * T(M_LN2 / M_LN10);
 }
 
-inline float fast_logb (float x) {
+#ifdef __CUDACC__
+template<>
+inline OIIO_HOSTDEVICE float fast_log10(const float& x)
+{
+     return __log10f(x);
+}
+#endif
+
+inline OIIO_HOSTDEVICE float fast_logb (float x) {
+#ifndef __CUDACC__
     // don't bother with denormals
     x = fabsf(x);
     if (x < std::numeric_limits<float>::min()) x = std::numeric_limits<float>::min();
     if (x > std::numeric_limits<float>::max()) x = std::numeric_limits<float>::max();
     unsigned bits = bit_cast<float, unsigned>(x);
     return float (int(bits >> 23) - 127);
+#else
+    return logbf(x);
+#endif
 }
 
-inline float fast_log1p (float x) {
+inline OIIO_HOSTDEVICE float fast_log1p (float x) {
+#ifndef __CUDACC__
     if (fabsf(x) < 0.01f) {
         float y = 1.0f - (1.0f - x); // crush denormals
         return copysignf(madd(-0.5f, y * y, y), x);
     } else {
         return fast_log(x + 1);
     }
+#else
+    return log1pf(x);
+#endif
 }
 
 
 
 template<typename T>
-inline T fast_exp2 (const T& xval) {
+inline OIIO_HOSTDEVICE T fast_exp2 (const T& xval) {
     using namespace simd;
     typedef typename T::int_t intN;
 #if OIIO_SIMD_SSE
@@ -1472,7 +1585,8 @@ inline T fast_exp2 (const T& xval) {
 
 
 template<>
-inline float fast_exp2 (const float& xval) {
+inline OIIO_HOSTDEVICE float fast_exp2 (const float& xval) {
+#ifndef __CUDACC__
     // clamp to safe range for final addition
     float x = clamp (xval, -126.0f, 126.0f);
     // range reduction
@@ -1492,46 +1606,67 @@ inline float fast_exp2 (const float& xval) {
     // multiply by 2 ^ m by adding in the exponent
     // NOTE: left-shift of negative number is undefined behavior
     return bit_cast<unsigned, float>(bit_cast<float, unsigned>(r) + (unsigned(m) << 23));
+#else
+    return exp2f(xval);
+#endif
 }
 
 
 
 
 template <typename T>
-inline T fast_exp (const T& x) {
+inline OIIO_HOSTDEVICE T fast_exp (const T& x) {
     // Examined 2237485550 values of exp on [-87.3300018,87.3300018]: 2.6666452 avg ulp diff, 230 max ulp
     return fast_exp2(x * T(1 / M_LN2));
 }
 
+#ifdef __CUDACC__
+template<>
+inline OIIO_HOSTDEVICE float fast_exp (const float& x) {
+    return __expf(x);
+}
+#endif
+
 
 
 /// Faster float exp than is in libm, but still 100% accurate
-inline float fast_correct_exp (float x)
+inline OIIO_HOSTDEVICE float fast_correct_exp (float x)
 {
 #if defined(__x86_64__) && defined(__GNU_LIBRARY__) && defined(__GLIBC__ ) && defined(__GLIBC_MINOR__) && __GLIBC__ <= 2 && __GLIBC_MINOR__ < 16
     // On x86_64, versions of glibc < 2.16 have an issue where expf is
     // much slower than the double version.  This was fixed in glibc 2.16.
     return static_cast<float>(std::exp(static_cast<double>(x)));
+#elif defined(__CUDACC__)
+    return static_cast<float>(exp(static_cast<double>(x)));
 #else
     return std::exp(x);
 #endif
 }
 
 
-inline float fast_exp10 (float x) {
+inline OIIO_HOSTDEVICE float fast_exp10 (float x) {
+#ifndef __CUDACC__
     // Examined 2217701018 values of exp10 on [-37.9290009,37.9290009]: 2.71732409 avg ulp diff, 232 max ulp
     return fast_exp2(x * float(M_LN10 / M_LN2));
+#else
+    return __exp10f(x);
+#endif
 }
 
-inline float fast_expm1 (float x) {
+inline OIIO_HOSTDEVICE float fast_expm1 (float x) {
+#ifdef __CUDACC__
     if (fabsf(x) < 0.03f) {
         float y = 1.0f - (1.0f - x); // crush denormals
         return copysignf(madd(0.5f, y * y, y), x);
     } else
         return fast_exp(x) - 1.0f;
+#else
+    return expm1f(x);
+#endif
 }
 
-inline float fast_sinh (float x) {
+inline OIIO_HOSTDEVICE float fast_sinh (float x) {
+#ifdef __CUDACC__
     float a = fabsf(x);
     if (a > 1.0f) {
         // Examined 53389559 values of sinh on [1,87.3300018]: 33.6886442 avg ulp diff, 178 max ulp
@@ -1548,29 +1683,44 @@ inline float fast_sinh (float x) {
         r = madd(r * a, a2, a);
         return copysignf(r, x);
     }
+#else
+    return sinhf(x);
+#endif
 }
 
-inline float fast_cosh (float x) {
+inline OIIO_HOSTDEVICE float fast_cosh (float x) {
+#ifndef __CUDACC__
     // Examined 2237485550 values of cosh on [-87.3300018,87.3300018]: 1.78256726 avg ulp diff, 178 max ulp
     float e = fast_exp(fabsf(x));
     return 0.5f * e + 0.5f / e;
+#else
+    return coshf(x);
+#endif
 }
 
-inline float fast_tanh (float x) {
+inline OIIO_HOSTDEVICE float fast_tanh (float x) {
+#ifndef __CUDACC__
     // Examined 4278190080 values of tanh on [-3.40282347e+38,3.40282347e+38]: 3.12924e-06 max error
     // NOTE: ulp error is high because of sub-optimal handling around the origin
     float e = fast_exp(2.0f * fabsf(x));
     return copysignf(1 - 2 / (1 + e), x);
+#else
+    return tanhf(x);
+#endif
 }
 
-inline float fast_safe_pow (float x, float y) {
+inline OIIO_HOSTDEVICE float fast_safe_pow (float x, float y) {
     if (y == 0) return 1.0f; // x^0=1
     if (x == 0) return 0.0f; // 0^y=0
     // be cheap & exact for special case of squaring and identity
     if (y == 1.0f)
         return x;
     if (y == 2.0f)
+#ifndef __CUDACC__
         return std::min (x*x, std::numeric_limits<float>::max());
+#else
+        return min (x*x, std::numeric_limits<float>::max());
+#endif
     float sign = 1.0f;
     if (x < 0) {
         // if x is negative, only deal with integer powers
@@ -1594,15 +1744,18 @@ inline float fast_safe_pow (float x, float y) {
 }
 
 
+#ifndef __CUDACC__
 // Fast simd pow that only needs to work for positive x
 template<typename T, typename U>
-inline T fast_pow_pos (const T& x, const U& y) {
+inline OIIO_HOSTDEVICE T fast_pow_pos (const T& x, const U& y) {
     return fast_exp2(y * fast_log2(x));
 }
+#endif
 
 
-inline float fast_erf (float x)
+inline OIIO_HOSTDEVICE float fast_erf (float x)
 {
+#ifndef __CUDACC__
     // Examined 1082130433 values of erff on [0,4]: 1.93715e-06 max error
     // Abramowitz and Stegun, 7.1.28
     const float a1 = 0.0705230784f;
@@ -1619,17 +1772,24 @@ inline float fast_erf (float x)
     const float u = t * t; // ^8
     const float v = u * u; // ^16
     return copysignf(1.0f - 1.0f / v, x);
+#else
+    return erff(x);
+#endif
 }
 
-inline float fast_erfc (float x)
+inline OIIO_HOSTDEVICE float fast_erfc (float x)
 {
+#ifndef __CUDACC__
     // Examined 2164260866 values of erfcf on [-4,4]: 1.90735e-06 max error
     // ulp histogram:
     //   0  = 80.30%
     return 1.0f - fast_erf(x);
+#else
+    return erfcf(x);
+#endif
 }
 
-inline float fast_ierf (float x)
+inline OIIO_HOSTDEVICE float fast_ierf (float x)
 {
     // from: Approximating the erfinv function by Mike Giles
     // to avoid trouble at the limit, clamp input to 1-eps
@@ -1660,7 +1820,6 @@ inline float fast_ierf (float x)
     }
     return p * x;
 }
-#endif
 
 // (end of fast* functions)
 ////////////////////////////////////////////////////////////////////////////
@@ -1736,7 +1895,7 @@ T invert (Func &func, T y, T xmin=0.0, T xmax=1.0,
 /// Linearly interpolate a list of evenly-spaced knots y[0..len-1] with
 /// y[0] corresponding to the value at x==0.0 and y[len-1] corresponding to
 /// x==1.0.
-inline float
+inline OIIO_HOSTDEVICE float
 interpolate_linear (float x, array_view_strided<const float> y)
 {
     DASSERT_MSG (y.size() >= 2, "interpolate_linear needs at least 2 knot values (%zd)", y.size());
@@ -1744,188 +1903,15 @@ interpolate_linear (float x, array_view_strided<const float> y)
     int nsegs = int(y.size()) - 1;
     int segnum;
     x = floorfrac (x*nsegs, &segnum);
+#ifndef __CUDACC__
     int nextseg = std::min (segnum+1, nsegs);
+#else
+    int nextseg = fminf (segnum+1, nsegs);
+#endif
     return lerp (y[segnum], y[nextseg], x);
 }
 
 // (end miscellaneous numerical methods)
-////////////////////////////////////////////////////////////////////////////
-
-
-
-
-////////////////////////////////////////////////////////////////////////////
-// CUDA device functions & intrinsics
-//
-// For now, the selection of 'fast' instrinsics is controlled via compiler
-// flags.
-
-#ifdef __CUDACC__
-__device__ inline float fast_sin (float x) {
-    return __sinf(x);
-}
-
-__device__ inline float fast_cos (float x) {
-    return __cosf(x);
-}
-
-__device__ inline void fast_sincos (float x, float* sine, float* cosine) {
-    __sincosf(x, sine, cosine);
-}
-
-__device__ inline float fast_tan (float x) {
-    return __tanf(x);
-}
-
-__device__ inline float fast_sinpi (float x) {
-    return __sinf(float(M_PI)) * x;
-}
-
-__device__ inline float fast_cospi (float x) {
-    return __cosf(float(M_PI)) * x;
-}
-
-__device__ inline float fast_acos (float x) {
-    return acosf(x);
-}
-
-__device__ inline float fast_asin (float x) {
-    return asinf(x);
-}
-
-__device__ inline float fast_atan (float x) {
-    return atanf(x);
-}
-
-__device__ inline float fast_atan2 (float y, float x) {
-    return atan2f( y, x );
-}
-
-__device__ inline float fast_log2 (float xval) {
-    return __log2f( xval );
-}
-
-__device__ inline float fast_log (float x) {
-    return __logf(x);
-}
-
-__device__ inline float fast_log10 (float x) {
-    return __log10f(x);
-}
-
-__device__ inline float fast_logb (float x) {
-    return logbf(x);
-}
-
-__device__ inline float fast_log1p (float x) {
-    return log1pf(x);
-}
-
-__device__ inline float fast_exp (float x) {
-    return __expf(x);
-}
-
-__device__ inline float fast_exp2 (float x) {
-    return exp2f(x);
-}
-
-__device__ inline float fast_exp10 (float x) {
-    return __exp10f(x);
-}
-
-__device__ inline float fast_expm1 (float x) {
-    return expm1f(x);
-}
-
-__device__ inline float fast_erf (float x) {
-    return erff(x);
-}
-
-__device__ inline float fast_erfc (float x) {
-    return erfcf(x);
-}
-
-__device__ inline float fast_sinh (float x) {
-    return sinhf(x);
-}
-
-__device__ inline float fast_cosh (float x) {
-    return coshf(x);
-}
-
-__device__ inline float fast_tanh (float x) {
-    return tanhf(x);
-}
-
-__device__ inline float fast_sqrt (float x) {
-    return __fsqrt_rn(x);
-}
-
-__device__ inline float fast_inversesqrt (float x) {
-    return __frsqrt_rn(x);
-}
-
-__device__ inline float safe_sqrt (float x) {
-    return x >= 0.0f ? __fsqrt_rn(x) : 0.0f;
-}
-
-__device__ inline float safe_inversesqrt (float x) {
-    return x > 0.0f ? __frsqrt_rn(x) : 0.0f;
-}
-
-// (end CUDA intrinsics)
-////////////////////////////////////////////////////////////////////////////
-
-////////////////////////////////////////////////////////////////////////////
-// 'Safe' device functions & helpers
-
-template <typename IN_TYPE, typename OUT_TYPE> __device__
-inline OUT_TYPE device_bit_cast (const IN_TYPE in) {
-    // NOTE: this is the only standards compliant way of doing this type of casting,
-    // luckily the compilers we care about know how to optimize away this idiom.
-    OUT_TYPE out;
-    memcpy (&out, &in, sizeof(IN_TYPE));
-    return out;
-}
-
-__device__ inline float safe_acos (float x) {
-    if (x <= -1.0f) return float(M_PI);
-    if (x >=  1.0f) return 0.0f;
-    return acosf(x);
-}
-
-__device__ inline float fast_safe_pow (float x, float y) {
-    if (y == 0) return 1.0f; // x^0=1
-    if (x == 0) return 0.0f; // 0^y=0
-    // be cheap & exact for special case of squaring and identity
-    if (y == 1.0f)
-        return x;
-    if (y == 2.0f)
-        return std::min (x*x, std::numeric_limits<float>::max());
-    float sign = 1.0f;
-    if (x < 0) {
-        // if x is negative, only deal with integer powers
-        // powf returns NaN for non-integers, we will return 0 instead
-        int ybits = device_bit_cast<float, int>(y) & 0x7fffffff;
-        if (ybits >= 0x4b800000) {
-            // always even int, keep positive
-        } else if (ybits >= 0x3f800000) {
-            // bigger than 1, check
-            int k = (ybits >> 23) - 127;  // get exponent
-            int j =  ybits >> (23 - k);   // shift out possible fractional bits
-            if ((j << (23 - k)) == ybits) // rebuild number and check for a match
-                sign = device_bit_cast<int, float>(0x3f800000 | (j << 31)); // +1 for even, -1 for odd
-            else
-                return 0.0f; // not integer
-        } else {
-            return 0.0f; // not integer
-        }
-    }
-    return sign * fast_exp2(y * fast_log2(fabsf(x)));
-}
-#endif
-
-// (end safe functions)
 ////////////////////////////////////////////////////////////////////////////
 
 

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -238,7 +238,9 @@
 // always inline. On many compilers regular 'inline' is only advisory. Put
 // this attribute before the function return type, just like you would use
 // 'inline'.
-#if defined(__GNUC__) || defined(__clang__) || __has_attribute(always_inline)
+#if defined(__CUDACC__)
+#  define OIIO_FORCEINLINE __inline__
+#elif defined(__GNUC__) || defined(__clang__) || __has_attribute(always_inline)
 #  define OIIO_FORCEINLINE inline __attribute__((always_inline))
 #elif defined(_MSC_VER) || defined(__INTEL_COMPILER)
 #  define OIIO_FORCEINLINE __forceinline
@@ -323,6 +325,15 @@
 #    define __LITTLE_ENDIAN__ 1
 #    undef __BIG_ENDIAN__
 #  endif
+#endif
+
+
+// OIIO_HOSTDEVICE is used to supply the function decorators needed when
+// compiling for CUDA devices.
+#ifdef __CUDACC__
+#  define OIIO_HOSTDEVICE __host__ __device__
+#else
+#  define OIIO_HOSTDEVICE
 #endif
 
 


### PR DESCRIPTION
## Description

To support compilation for CUDA targets, we have added device-friendly specializations of a subset of functions in ``fmath.h``. Where necessary, include directives and function definitions that are not able to be compiled in device mode have been guarded with a preprocessor macro.
## Tests

The changes are guarded by a preprocessor macro and are only active when being compiled by a CUDA compiler. Since CPU compilation is not affected, no additional test cases have been added at this time.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

