### PR TITLE
Make building and installing of documentation more packaging friendly.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,9 @@ set (TEX_BATCH_SIZE "" CACHE STRING "Force TextureSystem SIMD batch size (e.g. 1
 set (SOVERSION ${OIIO_VERSION_MAJOR}.${OIIO_VERSION_MINOR}
      CACHE STRING "Set the SO version in the SO name of the output library")
 option (BUILD_OIIOUTIL_ONLY "If ON, will build *only* libOpenImageIO_Util")
+option (BUILD_DOCS "If ON, build documentation and man pages.")
+option (INSTALL_DOCS "If ON, install documentation and man pages.")
+
 
 if (NOT OIIO_THREAD_ALLOW_DCLP)
     add_definitions ("-DOIIO_THREAD_ALLOW_DCLP=0")
@@ -190,7 +193,7 @@ if (USE_PYTHON AND NOT BUILD_OIIOUTIL_ONLY)
 endif ()
 
 add_subdirectory (src/include)
-if (INSTALL_DOCS)
+if (BUILD_DOCS)
     add_subdirectory (src/doc)
 endif ()
 add_subdirectory (src/fonts)

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -6,10 +6,11 @@ set (public_docs
      "${OpenImageIO_SOURCE_DIR}/CHANGES.md"
 )
 
-install (FILES ${public_docs}
-         DESTINATION ${CMAKE_INSTALL_DOCDIR}
-         COMPONENT documentation)
-
+if (INSTALL_DOCS)
+    install (FILES ${public_docs}
+             DESTINATION ${CMAKE_INSTALL_DOCDIR}
+             COMPONENT documentation)
+endif()
 
 # generate man pages using txt2man and a tiny python script to munge the
 # result of "$tool --help"
@@ -19,8 +20,7 @@ if (UNIX AND TXT2MAN AND PYTHONINTERP_FOUND)
     message (STATUS "Unix man page documentation will be generated")
     set (cli_tools oiiotool iinfo maketx idiff igrep iconvert)
 
-    find_program (IV_FOUND iv)
-    if (IV_FOUND)
+    if (TARGET iv)
         list (APPEND cli_tools iv)
     endif()
 
@@ -37,7 +37,9 @@ if (UNIX AND TXT2MAN AND PYTHONINTERP_FOUND)
     # force man page build before install
     add_custom_target (man_pages ALL DEPENDS ${manpage_files})
 
+if (INSTALL_DOCS)
     install (FILES ${manpage_files}
              DESTINATION ${CMAKE_INSTALL_MANDIR}
              COMPONENT documentation)
+endif()
 endif()


### PR DESCRIPTION
## Description

I've been carrying around this patch for a while. It's much easier for me to use rpmbuild to install the documentation in the right places for Fedora. This allows me to build the documentation without installing it. 

It also uses the target to find IV instead of looking for the binary directly as it will always find the installed iv of the previous released package instead of the one in the build tree.

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

