### PR TITLE
Improvements for frame sequence wildcards

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5371,7 +5371,7 @@ handle_sequence (int argc, const char **argv)
     // '%v' or '%V' characters.  Any found indicate that there are numeric
     // range or wildcards to deal with.  Also look for --frames,
     // --framepadding and --views options.
-#define ONERANGE_SPEC "[0-9]+(-[0-9]+((x|y)-?[0-9]+)?)?"
+#define ONERANGE_SPEC "-?[0-9]+(--?[0-9]+((x|y)-?[0-9]+)?)?"
 #define MANYRANGE_SPEC ONERANGE_SPEC "(," ONERANGE_SPEC ")*"
 #define VIEW_SPEC "%[Vv]"
 #define SEQUENCE_SPEC "((" MANYRANGE_SPEC ")?" "((#|@)+|(%[0-9]*d)))" "|" "(" VIEW_SPEC ")"
@@ -5405,6 +5405,8 @@ handle_sequence (int argc, const char **argv)
             ot.debug = true;
         else if ((strarg == "--frames" || strarg == "-frames") && a < argc-1) {
             framespec = argv[++a];
+            is_sequence = true;
+            // std::cout << "Frame range " << framespec << "\n";
         }
         else if ((strarg == "--framepadding" || strarg == "-framepadding")
                  && a < argc-1) {
@@ -5496,6 +5498,16 @@ handle_sequence (int argc, const char **argv)
         }
     }
 
+    if (! nfilenames && !framespec.empty()) {
+        // Frame sequence specified, but no wildcards used
+        Filesystem::enumerate_sequence (framespec, frame_numbers[0]);
+        nfilenames = frame_numbers[0].size();
+    }
+
+    // Make sure frame_numbers[0] has the canonical frame number list
+    if (sequence_args.size() && frame_numbers[0].empty())
+        frame_numbers[0] = frame_numbers[sequence_args[0]];
+
     // OK, now we just call getargs once for each item in the sequences,
     // substituting the i-th sequence entry for its respective argument
     // every time.
@@ -5511,7 +5523,7 @@ handle_sequence (int argc, const char **argv)
         }
 
         ot.clear_options (); // Careful to reset all command line options!
-        ot.frame_number = frame_numbers[sequence_args[0]][i];
+        ot.frame_number = frame_numbers[0][i];
         getargs (argc, (char **)&seq_argv[0]);
 
         ot.process_pending ();

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -53,6 +53,26 @@ copyA.0007.jpg       :  128 x   96, 3 channel, uint8 jpeg
 copyA.0008.jpg       :  128 x   96, 3 channel, uint8 jpeg
 copyA.0009.jpg       :  128 x   96, 3 channel, uint8 jpeg
 copyA.0010.jpg       :  128 x   96, 3 channel, uint8 jpeg
+Sequence 1-5:  1
+Sequence 1-5:  2
+Sequence 1-5:  3
+Sequence 1-5:  4
+Sequence 1-5:  5
+Sequence -5-5:  -5
+Sequence -5-5:  -4
+Sequence -5-5:  -3
+Sequence -5-5:  -2
+Sequence -5-5:  -1
+Sequence -5-5:  0
+Sequence -5-5:  1
+Sequence -5-5:  2
+Sequence -5-5:  3
+Sequence -5-5:  4
+Sequence -5-5:  5
+Sequence -5--2:  -5
+Sequence -5--2:  -4
+Sequence -5--2:  -3
+Sequence -5--2:  -2
 Reading black.tif
     oiio:DebugOpenConfig!: 42
 Reading add_rgb_rgba.exr

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -208,8 +208,11 @@ command += oiiotool ("subimages-2.exr --sisplit -o subimage2.exr " +
                      "--pop -o subimage1.exr")
 
 # test sequences
-command += oiiotool ("src/tahoe-tiny.tif -o copyA.1-10#.jpg");
+command += oiiotool ("src/tahoe-tiny.tif -o copyA.1-10#.jpg")
 command += oiiotool (" --info  " +  " ".join(["copyA.{0:04}.jpg".format(x) for x in range(1,11)]))
+command += oiiotool ("--frames 1-5 --echo \"Sequence 1-5:  {FRAME_NUMBER}\"")
+command += oiiotool ("--frames -5-5 --echo \"Sequence -5-5:  {FRAME_NUMBER}\"")
+command += oiiotool ("--frames -5--2 --echo \"Sequence -5--2:  {FRAME_NUMBER}\"")
 
 # test expression substitution
 command += oiiotool ("src/tahoe-small.tif --pattern fill:top=0,0,0,0:bottom=0,0,1,1 " +


### PR DESCRIPTION
Fixes #1889, which reported that frame sequence wildcards involving
negative frame numbers were not correctly supported. For example,

    oiiotool --frames 1-5 ...      # 1, 2, 3, 4, 5  (as usual)
    oiiotool --frames -3-3 ...     # -3, -2, -1, 0, 1, 2, 3
    oiiotool --frames -3--1 ...    # -3, -2, -1

In addition to handling negative frame numbers and ranges, I also made a
change to facilitate testing and benchmarking, which is that the
presence of `--frames` is now itself enough to trigger the looping +
wildcard expansion. Previously, if there were no numeric wildcards in
any of the filenames, it would not execute the frame loop (even if there
was a --frames).

