### PR TITLE
Refactor fmath.h for Cuda.

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -224,7 +224,7 @@ clamp (const T& a, const T& low, const T& high)
 }
 
 
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
 // Specialization of clamp for vfloat4
 template<> inline simd::vfloat4
 clamp (const simd::vfloat4& a, const simd::vfloat4& low, const simd::vfloat4& high)
@@ -475,7 +475,7 @@ floorfrac (float x, int *xint)
 }
 
 
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
 inline simd::vfloat4 floorfrac (const simd::vfloat4& x, simd::vint4 *xint) {
     simd::vfloat4 f = simd::floor(x);
     *xint = simd::vint4(f);
@@ -513,7 +513,7 @@ sincos (float x, float* sine, float* cosine)
 {
 #if defined(__GNUC__) && defined(__linux__) && !defined(__clang__)
     __builtin_sincosf(x, sine, cosine);
-#elif defined(__CUDACC__)
+#elif defined(__CUDA_ARCH__)
     // Explicitly select the single-precision CUDA library function
     sincosf(x, sine, cosine);
 #else
@@ -527,7 +527,7 @@ sincos (double x, double* sine, double* cosine)
 {
 #if defined(__GNUC__) && defined(__linux__) && !defined(__clang__)
     __builtin_sincos(x, sine, cosine);
-#elif defined(__CUDACC__)
+#elif defined(__CUDA_ARCH__)
     // Use of anonymous namespace resolves to the CUDA library function and
     // avoids infinite recursion
     ::sincos(x, sine, cosine);
@@ -698,7 +698,7 @@ void convert_type (const S *src, D *dst, size_t n, D _min, D _max)
 }
 
 
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
 template<>
 inline void convert_type<uint8_t,float> (const uint8_t *src,
                                          float *dst, size_t n,
@@ -1160,7 +1160,7 @@ inline OIIO_HOSTDEVICE int fast_rint (float x) {
 #endif
 }
 
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
 inline simd::vint4 fast_rint (const simd::vfloat4& x) {
     return simd::rint (x);
 }
@@ -1168,7 +1168,7 @@ inline simd::vint4 fast_rint (const simd::vfloat4& x) {
 
 
 inline OIIO_HOSTDEVICE float fast_sin (float x) {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     // very accurate argument reduction from SLEEF
     // starts failing around x=262000
     // Results on: [-2pi,2pi]
@@ -1201,7 +1201,7 @@ inline OIIO_HOSTDEVICE float fast_sin (float x) {
 
 
 inline OIIO_HOSTDEVICE float fast_cos (float x) {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     // same argument reduction as fast_sin
     int q = fast_rint (x * float(M_1_PI));
     float qf = q;
@@ -1229,7 +1229,7 @@ inline OIIO_HOSTDEVICE float fast_cos (float x) {
 
 
 inline OIIO_HOSTDEVICE void fast_sincos (float x, float* sine, float* cosine) {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     // same argument reduction as fast_sin
     int q = fast_rint (x * float(M_1_PI));
     float qf = q;
@@ -1265,7 +1265,7 @@ inline OIIO_HOSTDEVICE void fast_sincos (float x, float* sine, float* cosine) {
 // NOTE: this approximation is only valid on [-8192.0,+8192.0], it starts becoming
 // really poor outside of this range because the reciprocal amplifies errors
 inline OIIO_HOSTDEVICE float fast_tan (float x) {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     // derived from SLEEF implementation
     // note that we cannot apply the "denormal crush" trick everywhere because
     // we sometimes need to take the reciprocal of the polynomial
@@ -1297,7 +1297,7 @@ inline OIIO_HOSTDEVICE float fast_tan (float x) {
 /// Note that this is MUCH faster, but much less accurate than fast_sin.
 inline OIIO_HOSTDEVICE float fast_sinpi (float x)
 {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
 	// Fast trick to strip the integral part off, so our domain is [-1,1]
 	const float z = x - ((x + 25165824.0f) - 25165824.0f);
     const float y = z - z * fabsf(z);
@@ -1335,7 +1335,7 @@ inline OIIO_HOSTDEVICE float fast_sinpi (float x)
 /// Note that this is MUCH faster, but much less accurate than fast_cos.
 inline OIIO_HOSTDEVICE float fast_cospi (float x)
 {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     return fast_sinpi (x+0.5f);
 #else
     return cospif(x);
@@ -1343,7 +1343,7 @@ inline OIIO_HOSTDEVICE float fast_cospi (float x)
 }
 
 inline OIIO_HOSTDEVICE float fast_acos (float x) {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     const float f = fabsf(x);
     const float m = (f < 1.0f) ? 1.0f - (1.0f - f) : 1.0f; // clamp and crush denormals
     // based on http://www.pouet.net/topic.php?which=9132&page=2
@@ -1358,7 +1358,7 @@ inline OIIO_HOSTDEVICE float fast_acos (float x) {
 }
 
 inline OIIO_HOSTDEVICE float fast_asin (float x) {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     // based on acosf approximation above
     // max error is 4.51133e-05 (ulps are higher because we are consistently off by a little amount)
     const float f = fabsf(x);
@@ -1371,7 +1371,7 @@ inline OIIO_HOSTDEVICE float fast_asin (float x) {
 }
 
 inline OIIO_HOSTDEVICE float fast_atan (float x) {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     const float a = fabsf(x);
     const float k = a > 1.0f ? 1 / a : a;
     const float s = 1.0f - (1.0f - k); // crush denormals
@@ -1388,7 +1388,7 @@ inline OIIO_HOSTDEVICE float fast_atan (float x) {
 }
 
 inline OIIO_HOSTDEVICE float fast_atan2 (float y, float x) {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     // based on atan approximation above
     // the special cases around 0 and infinity were tested explicitly
     // the only case not handled correctly is x=NaN,y=0 which returns 0 instead of nan
@@ -1434,7 +1434,7 @@ inline OIIO_HOSTDEVICE T fast_log2 (const T& xval) {
 
 template<>
 inline OIIO_HOSTDEVICE float fast_log2 (const float& xval) {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     // NOTE: clamp to avoid special cases and make result "safe" from large negative values/nans
     float x = clamp (xval, std::numeric_limits<float>::min(), std::numeric_limits<float>::max());
     // based on https://github.com/LiraNuna/glsl-sse2/blob/master/source/vec4.h
@@ -1468,7 +1468,7 @@ inline OIIO_HOSTDEVICE T fast_log (const T& x) {
     return fast_log2(x) * T(M_LN2);
 }
 
-#ifdef __CUDACC__
+#ifdef __CUDA_ARCH__
 template<>
 inline OIIO_HOSTDEVICE float fast_log(const float& x)
 {
@@ -1483,7 +1483,7 @@ inline OIIO_HOSTDEVICE T fast_log10 (const T& x) {
     return fast_log2(x) * T(M_LN2 / M_LN10);
 }
 
-#ifdef __CUDACC__
+#ifdef __CUDA_ARCH__
 template<>
 inline OIIO_HOSTDEVICE float fast_log10(const float& x)
 {
@@ -1492,7 +1492,7 @@ inline OIIO_HOSTDEVICE float fast_log10(const float& x)
 #endif
 
 inline OIIO_HOSTDEVICE float fast_logb (float x) {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     // don't bother with denormals
     x = fabsf(x);
     if (x < std::numeric_limits<float>::min()) x = std::numeric_limits<float>::min();
@@ -1505,7 +1505,7 @@ inline OIIO_HOSTDEVICE float fast_logb (float x) {
 }
 
 inline OIIO_HOSTDEVICE float fast_log1p (float x) {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     if (fabsf(x) < 0.01f) {
         float y = 1.0f - (1.0f - x); // crush denormals
         return copysignf(madd(-0.5f, y * y, y), x);
@@ -1554,7 +1554,7 @@ inline OIIO_HOSTDEVICE T fast_exp2 (const T& xval) {
 
 template<>
 inline OIIO_HOSTDEVICE float fast_exp2 (const float& xval) {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     // clamp to safe range for final addition
     float x = clamp (xval, -126.0f, 126.0f);
     // range reduction
@@ -1588,7 +1588,7 @@ inline OIIO_HOSTDEVICE T fast_exp (const T& x) {
     return fast_exp2(x * T(1 / M_LN2));
 }
 
-#ifdef __CUDACC__
+#ifdef __CUDA_ARCH__
 template<>
 inline OIIO_HOSTDEVICE float fast_exp (const float& x) {
     return __expf(x);
@@ -1611,7 +1611,7 @@ inline OIIO_HOSTDEVICE float fast_correct_exp (float x)
 
 
 inline OIIO_HOSTDEVICE float fast_exp10 (float x) {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     // Examined 2217701018 values of exp10 on [-37.9290009,37.9290009]: 2.71732409 avg ulp diff, 232 max ulp
     return fast_exp2(x * float(M_LN10 / M_LN2));
 #else
@@ -1620,7 +1620,7 @@ inline OIIO_HOSTDEVICE float fast_exp10 (float x) {
 }
 
 inline OIIO_HOSTDEVICE float fast_expm1 (float x) {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     if (fabsf(x) < 0.03f) {
         float y = 1.0f - (1.0f - x); // crush denormals
         return copysignf(madd(0.5f, y * y, y), x);
@@ -1632,7 +1632,7 @@ inline OIIO_HOSTDEVICE float fast_expm1 (float x) {
 }
 
 inline OIIO_HOSTDEVICE float fast_sinh (float x) {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     float a = fabsf(x);
     if (a > 1.0f) {
         // Examined 53389559 values of sinh on [1,87.3300018]: 33.6886442 avg ulp diff, 178 max ulp
@@ -1655,7 +1655,7 @@ inline OIIO_HOSTDEVICE float fast_sinh (float x) {
 }
 
 inline OIIO_HOSTDEVICE float fast_cosh (float x) {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     // Examined 2237485550 values of cosh on [-87.3300018,87.3300018]: 1.78256726 avg ulp diff, 178 max ulp
     float e = fast_exp(fabsf(x));
     return 0.5f * e + 0.5f / e;
@@ -1665,7 +1665,7 @@ inline OIIO_HOSTDEVICE float fast_cosh (float x) {
 }
 
 inline OIIO_HOSTDEVICE float fast_tanh (float x) {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     // Examined 4278190080 values of tanh on [-3.40282347e+38,3.40282347e+38]: 3.12924e-06 max error
     // NOTE: ulp error is high because of sub-optimal handling around the origin
     float e = fast_exp(2.0f * fabsf(x));
@@ -1682,7 +1682,7 @@ inline OIIO_HOSTDEVICE float fast_safe_pow (float x, float y) {
     if (y == 1.0f)
         return x;
     if (y == 2.0f) {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
         return std::min (x*x, std::numeric_limits<float>::max());
 #else
         return fminf (x*x, std::numeric_limits<float>::max());
@@ -1720,7 +1720,7 @@ inline OIIO_HOSTDEVICE T fast_pow_pos (const T& x, const U& y) {
 
 inline OIIO_HOSTDEVICE float fast_erf (float x)
 {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     // Examined 1082130433 values of erff on [0,4]: 1.93715e-06 max error
     // Abramowitz and Stegun, 7.1.28
     const float a1 = 0.0705230784f;
@@ -1744,7 +1744,7 @@ inline OIIO_HOSTDEVICE float fast_erf (float x)
 
 inline OIIO_HOSTDEVICE float fast_erfc (float x)
 {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     // Examined 2164260866 values of erfcf on [-4,4]: 1.90735e-06 max error
     // ulp histogram:
     //   0  = 80.30%
@@ -1863,14 +1863,14 @@ T invert (Func &func, T y, T xmin=0.0, T xmax=1.0,
 inline OIIO_HOSTDEVICE float
 interpolate_linear (float x, array_view_strided<const float> y)
 {
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     DASSERT_MSG (y.size() >= 2, "interpolate_linear needs at least 2 knot values (%zd)", y.size());
 #endif
     x = clamp (x, float(0.0), float(1.0));
     int nsegs = int(y.size()) - 1;
     int segnum;
     x = floorfrac (x*nsegs, &segnum);
-#ifndef __CUDACC__
+#ifndef __CUDA_ARCH__
     int nextseg = std::min (segnum+1, nsegs);
 #else
     int nextseg = min (segnum+1, nsegs);


### PR DESCRIPTION
Turns out that nvcc considers it an error if a `__device__` function is
called from a `__host__ __device__` function, even if the latter is
conditionally compiled only for Cuda mode.  So a function like fast_sin
(which for Cuda calls `__sinf` underneath), this will hit the error.

To make it even more complicated, this is only a problem with nvcc, not
with clang when compiling Cuda, which is how this was overlooked before.

So, as an example, you can't do this:

    __host__ __device__ void myfunc () {
    #ifndef __CUDACC__
        ...generic code...
    #else
        device_only_func();
    #endif
    }

It seems you have to structure it like this:

    #ifndef __CUDACC__
    void myfunc () {
        ...generic code...
    }
    #else
    __device__ void myfunc () {
        device_only_func();
    }
    #endif

I'm sorry, @timgrant , this is the original way you implemented the
Cuda-fication of fmath.h, and I encouraged you to change it. I think
because for that particular use for OSL, you were using clang to generate PTX,
you didn't encounter the error. So your instincts were right, sorry to
have created extra work for you.

