### PR TITLE
More care with /bigobj on Windows

### DIFF
--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -150,10 +150,15 @@ endif ()
 
 
 if (MSVC)
-    set_property (SOURCE imagebufalgo_pixelmath.cpp APPEND_STRING PROPERTY COMPILE_FLAGS " /bigobj ")
-    set_property (SOURCE imagebufalgo_addsub.cpp APPEND_STRING PROPERTY COMPILE_FLAGS " /bigobj ")
-    set_property (SOURCE imagebufalgo_muldiv.cpp APPEND_STRING PROPERTY COMPILE_FLAGS " /bigobj ")
-    set_property (SOURCE imagebuf.cpp APPEND_STRING PROPERTY COMPILE_FLAGS " /bigobj ")
+    # In some MSVC setups, the IBA functions with huge template expansions
+    # can run into trouble if the /bigobj flag is not used. Turn it on for
+    # these files most likely to use it.
+    # FIXME: Does anybody know if there is an advantage to limiting it to
+    # just the files that most need it? Or is it better to make it totally
+    # foolproof by using /bigobj for all our modules on Windows?
+    file (GLOB iba_sources "imagebufalgo_*.cpp")
+    set_property (SOURCE imagebuf.cpp ${iba_sources}
+                  APPEND_STRING PROPERTY COMPILE_FLAGS " /bigobj ")
 endif ()
 
 if (WIN32)


### PR DESCRIPTION
Expand the set of files to all the imagebufalgo_*.cpp, which are the most likely files to need it because they tend to have template expansion for big sets of data type pairings.

Does anybody know if there is an advantage to limiting it to just the files that most need it? Or is it better to make it totally foolproof by using /bigobj for all our modules on Windows?
