### PR TITLE
New feature: write image to memory buffer instead of file

### DIFF
--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -732,6 +732,10 @@ PNG files use the file extension {\cf .png}.
 \qkw{ICCProfile} & uint8[] & The ICC color profile \\
 \end{tabular}
 
+PNG output supports the ``write to memory'' feature via the special
+\qkw{oiio:write_memory} and \qkw{oiio:write_memory_size} attributes
+(see Section~\ref{sec:imageoutput:writefiletomemory}).
+
 \subsubsection*{Limitations}
 
 \begin{itemize}

--- a/src/doc/imageoutput.tex
+++ b/src/doc/imageoutput.tex
@@ -1135,6 +1135,96 @@ without alteration while modifying the image description metadata:
 \end{code}
 
 
+\subsection{Writing the file to a memory buffer}
+\label{sec:imageoutput:writefiletomemory}
+\index{writing an image file to memory buffer}
+\NEW   % 1.9
+
+Some file format writers allow you to write the output to an in-memory
+buffer rather than a stored file on disk. The buffer is not merely the pixel
+array, but is a byte-for-byte representation of the correctly formatted file
+that would have been written.
+
+This is very incompletely implemented -- currently, only PNG supports this
+feature, though others may be supported in the future (based on demand
+and volunteers).
+
+To find out if a particular file format supports this feature, you can create
+an \ImageOutput of the right type, and check if it supports the feature
+name \qkw{write_memory}:
+
+\begin{code}
+    ImageOutput *out = ImageOutput::create (filename);
+    if (! out  ||  ! out->supports ("write_memory")) {
+        ImageOutput::destroy (out);
+        out = nullptr;
+        return;
+    }
+\end{code}
+
+\ImageOutput writers that support \qkw{write_memory} will respond to two
+special attributes: (1) \qkw{oiio:write_memory}, which passes a pointer to a
+{\cf unsigned char*} that will be modified to contain the address of the
+allocated memory block that will contain the file image bytes; (2)
+\qkw{oiio:write_memory_size}, which passes a pointer to a {\cf uint64_t}
+that will hold the size (in bytes) of the block.
+
+You just add these two attributes to the \ImageSpec that you pass when you
+open the file. Note that you aren't passing the \emph{values} of your
+variables, you are passing their \emph{addresses}, and this extra level of
+indirection requires an unusual idiom in setting up the attributes:
+
+\begin{code}
+    // ImageSpec describing the image we want to write.
+    ImageSpec spec (xres, yres, channels, TypeDesc::UINT8);
+
+    unsigned char *file_buffer = nullptr;  // will get ptr to the memory
+    uint64_t file_buffer_size = 0;         // will get the size
+    void *ptr = &file_buffer;
+    spec.attribute ("oiio:write_memory", TypeDesc::PTR, &ptr);
+    ptr = &file_buffer_size;
+    spec.attribute ("oiio:write_memory_size", TypeDesc::PTR, &ptr);
+\end{code}
+
+Extra explanation, because this idiom is confusing: If you were passing the
+value of a {\cf uint64_t}, you could say
+
+\begin{code}
+    uint64_t value;
+    attribute("myvalue", TypeDesc::UINT64, &value);
+\end{code}
+
+\noindent but to pass a \emph{pointer} to the value, you need
+
+\begin{code}
+    uint64_t value;
+    uint64_t * pointer = &value;
+    attribute("myvalue", TypeDesc::PTR, &pointer);
+\end{code}
+
+Okay, now that you have set up the two magic variables, just write the image
+as you always did. It is the presence of a nonzero value in the metadata
+{\cf oiio:write_memory} that will trigger the behavior of writing to a
+memory buffer rather than saving a file.
+
+\begin{code}
+    // open and write the image
+    out->open (filename, spec);
+    out->write_image (TypeDesc::UINT8, pixels);
+    out->close ();
+    ImageOutput::destroy (out);
+\end{code}
+
+At this point, {\cf file_buffer} should contain a pointer to allocated
+memory containing an in-memory representation of the file. The length of the
+buffer is stored in {\cf file_buffer_size}. We now own the memory that was
+allocated, so when we're all done with it, we must:
+
+\begin{code}
+    delete [] file_buffer;
+\end{code}
+
+
 \subsection{Custom search paths for plugins}
 \label{sec:imageoutput:searchpaths}
 
@@ -1331,6 +1421,9 @@ as such). The following features are recognized by this query:
   (either specifically, or via arbitrary named metadata)?
 \item[\rm \qkw{iptc}] Does the image file format support IPTC data
   (either specifically, or via arbitrary named metadata)?
+\item[\rm \qkw{write_memory}] Does the image file format support writing
+  a byte-for-byte representaton of the image file to a memory buffer, rather
+  than writing it to a file?
 \end{description}
 
 \noindent This list of queries may be extended in future releases.

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -95,7 +95,7 @@
  \bigskip \\
 }
 \date{{\large
-Date: 23 Feb 2018
+Date: 17 Mar 2018
 \\ (with corrections, 19 Mar 2018)
 }}
 

--- a/src/doc/stdmetadata.tex
+++ b/src/doc/stdmetadata.tex
@@ -200,6 +200,28 @@ plugins and compression methods that allow a variable amount of
 compression, with higher numbers indicating higher image fidelity.
 \apiend
 
+\section{Writing the file image to a memory buffer}
+\index{writing an image file to memory buffer}
+
+Format writers that respond positively to {\cf supports("write_memory")}
+have the ability to write the file to a memory buffer rather than saving
+to disk. (Currently, only PNG has the ability to do this.) This behavior is
+controlled by two special attributes:
+
+\apiitem{"oiio:write_memory" : pointer}
+Pointer to a {\cf unsigned char *} in which will be stored the pointer to
+the allocated buffer.
+\apiend
+
+\apiitem{"oiio:write_memory_size" : pointer}
+Pointer to a {\cf uint64_t} in which will be stored the size of the
+buffer.
+\apiend
+
+An explanation of how this feature is used may be found in
+Section~\ref{sec:imageoutput:writefiletomemory}.
+
+
 \section{Photographs or scanned images}
 
 The following metadata items are specific to photos or captured images.

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1082,6 +1082,8 @@ public:
     ///                        arbitrary names and types?
     ///    "exif"           Can this format store Exif camera data?
     ///    "iptc"           Can this format store IPTC data?
+    ///    "write_memory"   Can this format writer write the file to a
+    ///                        memory buffer?
     ///
     /// Note that main advantage of this approach, versus having
     /// separate individual supports_foo() methods, is that this allows

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -324,6 +324,9 @@ ParamValue::get_string (int maxsize) const
         formatType< unsigned char >(*this, n, "%d", out);
     } else if (element.basetype == TypeDesc::INT8) {
         formatType< char >(*this, n, "%d", out);
+    } else if (element.basetype == TypeDesc::PTR) {
+        out += "ptr ";
+        formatType< void* >(*this, n, "%p", out);
     } else {
         out += Strutil::format ("<unknown data type> (base %d, agg %d vec %d)",
                 type().basetype, type().aggregate,

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -329,6 +329,13 @@ destroy_read_struct (png_structp& sp, png_infop& ip)
 }
 
 
+inline void
+null_png_errhandler (png_structp png, png_const_charp message)
+{
+    // ignore
+}
+
+
 
 /// Initializes a PNG write struct.
 /// \return empty string on success, C-string error message on failure.
@@ -371,7 +378,8 @@ create_write_struct (png_structp& sp, png_infop& ip, int& color_type,
     // N.B. PNG is very rigid about the meaning of the channels, so enforce
     // which channel is alpha, that's the only way PNG can do it.
 
-    sp = png_create_write_struct (PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+    sp = png_create_write_struct (PNG_LIBPNG_VER_STRING,
+                                  nullptr, null_png_errhandler, nullptr);
     if (! sp)
         return "Could not create PNG write structure";
 


### PR DESCRIPTION
ImageOutput::supports("write_memory") will return true for a format writer
that supports the ability to write an in-memory representation of the
fully encoded file, but without creating a file on disk.

For supporting formats, the caller can trigger this behavior by setting
two special attributes in the ImageSpec that is passed to
ImageOutput::open():

"oiio:write_image" (PTR) is a pointer to an `unsigned char *` which will
    receive the address of the allocated buffer (which will then be owned
    by the caller, who must eventually free it).

"oiio:write_image_size" (PTR) is a pointer to a `uint64_t` which will
    receive the size of the allocated buffer.

The documentation (in the ImageOutput chapter) and imagebuf_test.cpp both
contain examples showing how to do this.

Currently, the only output file type to support this feature is PNG.
Others may be added in the future, but it will be as demand (and
volunteers) materialize. Each one will have to be added as a separate
effort, since the means of redirecting the file output to memory will be
quite different for each format library -- what we did for libpng is
different from what libtiff will need, and some formats may not have any
such facility.

Fixes #1895 
