### PR TITLE
Use override keyword on ImageInput and ImageOutput subclasses

### DIFF
--- a/src/bmp.imageio/bmp_pvt.h
+++ b/src/bmp.imageio/bmp_pvt.h
@@ -145,11 +145,11 @@ class BmpInput final : public ImageInput {
  public:
     BmpInput () { init (); }
     virtual ~BmpInput () { close (); }
-    virtual const char *format_name (void) const { return "bmp"; }
-    virtual bool valid_file (const std::string &filename) const;
-    virtual bool open (const std::string &name, ImageSpec &spec);
-    virtual bool close (void);
-    virtual bool read_native_scanline (int y, int z, void *data);
+    virtual const char *format_name (void) const override { return "bmp"; }
+    virtual bool valid_file (const std::string &filename) const override;
+    virtual bool open (const std::string &name, ImageSpec &spec) override;
+    virtual bool close (void) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
  private:
     int m_padded_scanline_size;
     int m_pad_size;
@@ -176,16 +176,16 @@ class BmpOutput final : public ImageOutput {
  public:
     BmpOutput () { init (); }
     virtual ~BmpOutput () { close (); }
-    virtual const char *format_name (void) const { return "bmp"; }
-    virtual int supports (string_view feature) const;
+    virtual const char *format_name (void) const override { return "bmp"; }
+    virtual int supports (string_view feature) const override;
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode);
-    virtual bool close (void);
+                       OpenMode mode) override;
+    virtual bool close (void) override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
+                                 const void *data, stride_t xstride) override;
     virtual bool write_tile (int x, int y, int z, TypeDesc format,
                              const void *data, stride_t xstride,
-                             stride_t ystride, stride_t zstride);
+                             stride_t ystride, stride_t zstride) override;
  private:
     int m_padded_scanline_size;
     FILE *m_fd;

--- a/src/cineon.imageio/cineoninput.cpp
+++ b/src/cineon.imageio/cineoninput.cpp
@@ -45,10 +45,10 @@ class CineonInput final : public ImageInput {
 public:
     CineonInput () : m_stream(NULL) { init(); }
     virtual ~CineonInput () { close(); }
-    virtual const char * format_name (void) const { return "cineon"; }
-    virtual bool open (const std::string &name, ImageSpec &newspec);
-    virtual bool close ();
-    virtual bool read_native_scanline (int y, int z, void *data);
+    virtual const char * format_name (void) const override { return "cineon"; }
+    virtual bool open (const std::string &name, ImageSpec &newspec) override;
+    virtual bool close () override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
 
 private:
     InStream *m_stream;

--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -52,14 +52,14 @@ class DDSInput final : public ImageInput {
 public:
     DDSInput () { init(); }
     virtual ~DDSInput () { close(); }
-    virtual const char * format_name (void) const { return "dds"; }
-    virtual bool open (const std::string &name, ImageSpec &newspec);
-    virtual bool close ();
-    virtual int current_subimage (void) const { return m_subimage; }
-    virtual int current_miplevel (void) const { return m_miplevel; }
-    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec);
-    virtual bool read_native_scanline (int y, int z, void *data);
-    virtual bool read_native_tile (int x, int y, int z, void *data);
+    virtual const char * format_name (void) const override { return "dds"; }
+    virtual bool open (const std::string &name, ImageSpec &newspec) override;
+    virtual bool close () override;
+    virtual int current_subimage (void) const override { return m_subimage; }
+    virtual int current_miplevel (void) const override{ return m_miplevel; }
+    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_tile (int x, int y, int z, void *data) override;
 
 private:
     std::string m_filename;           ///< Stash the filename

--- a/src/dicom.imageio/dicominput.cpp
+++ b/src/dicom.imageio/dicominput.cpp
@@ -62,14 +62,14 @@ class DICOMInput final : public ImageInput {
 public:
     DICOMInput () {}
     virtual ~DICOMInput() { close(); }
-    virtual const char * format_name (void) const { return "dicom"; }
-    virtual int supports (string_view feature) const { return false; }
-    virtual bool open (const std::string &name, ImageSpec &newspec);
+    virtual const char * format_name (void) const override { return "dicom"; }
+    virtual int supports (string_view feature) const override { return false; }
+    virtual bool open (const std::string &name, ImageSpec &newspec) override;
     virtual bool open (const std::string &name, ImageSpec &newspec,
-                       const ImageSpec &config);
-    virtual bool close();
-    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec);
-    virtual bool read_native_scanline (int y, int z, void *data);
+                       const ImageSpec &config) override;
+    virtual bool close() override;
+    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
 
 private:
     std::unique_ptr<DicomImage> m_img;

--- a/src/doc/writingplugins.tex
+++ b/src/doc/writingplugins.tex
@@ -161,9 +161,9 @@ real-world example of writing a JPEG/JFIF plug-in.
      public:
         JpgInput () { init(); }
         virtual ~JpgInput () { close(); }
-        virtual const char * format_name (void) const { return "jpeg"; }
-        virtual bool open (const std::string &name, ImageSpec &spec);
-        virtual bool read_native_scanline (int y, int z, void *data);
+        virtual const char * format_name (void) const override { return "jpeg"; }
+        virtual bool open (const std::string &name, ImageSpec &spec) override;
+        virtual bool read_native_scanline (int y, int z, void *data) override;
         virtual bool close ();
      private:
         FILE *m_fd;
@@ -318,7 +318,7 @@ real-world example of writing a JPEG/JFIF plug-in.
      public:
         JpgOutput () { init(); }
         virtual ~JpgOutput () { close(); }
-        virtual const char * format_name (void) const { return "jpeg"; }
+        virtual const char * format_name (void) const override { return "jpeg"; }
         virtual int supports (string_view property) const { return false; }
         virtual bool open (const std::string &name, const ImageSpec &spec,
                            bool append=false);

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -45,13 +45,13 @@ class DPXInput final : public ImageInput {
 public:
     DPXInput () : m_stream(NULL), m_dataPtr(NULL) { init(); }
     virtual ~DPXInput () { close(); }
-    virtual const char * format_name (void) const { return "dpx"; }
-    virtual bool valid_file (const std::string &filename) const;
-    virtual bool open (const std::string &name, ImageSpec &newspec);
-    virtual bool close ();
-    virtual int current_subimage (void) const { return m_subimage; }
-    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec);
-    virtual bool read_native_scanline (int y, int z, void *data);
+    virtual const char * format_name (void) const override { return "dpx"; }
+    virtual bool valid_file (const std::string &filename) const override;
+    virtual bool open (const std::string &name, ImageSpec &newspec) override;
+    virtual bool close () override;
+    virtual int current_subimage (void) const override { return m_subimage; }
+    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
 
 private:
     int m_subimage;

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -52,8 +52,8 @@ class DPXOutput final : public ImageOutput {
 public:
     DPXOutput ();
     virtual ~DPXOutput ();
-    virtual const char * format_name (void) const { return "dpx"; }
-    virtual int supports (string_view feature) const {
+    virtual const char * format_name (void) const override { return "dpx"; }
+    virtual int supports (string_view feature) const override {
         if (feature == "multiimage"
             || feature == "alpha"
             || feature == "nchannels"
@@ -65,15 +65,15 @@ public:
         return false;
     }
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode=Create);
+                       OpenMode mode=Create) override;
     virtual bool open (const std::string &name, int subimages,
-                       const ImageSpec *specs);
-    virtual bool close ();
+                       const ImageSpec *specs) override;
+    virtual bool close () override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
+                                 const void *data, stride_t xstride) override;
     virtual bool write_tile (int x, int y, int z, TypeDesc format,
                              const void *data, stride_t xstride,
-                             stride_t ystride, stride_t zstride);
+                             stride_t ystride, stride_t zstride) override;
 
 private:
     OutStream *m_stream;

--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -136,12 +136,12 @@ class FFmpegInput final : public ImageInput {
 public:
     FFmpegInput ();
     virtual ~FFmpegInput();
-    virtual const char *format_name (void) const { return "FFmpeg movie"; }
-    virtual bool open (const std::string &name, ImageSpec &spec);
-    virtual bool close (void);
-    virtual int current_subimage (void) const { return m_subimage; }
-    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec);
-    virtual bool read_native_scanline (int y, int z, void *data);
+    virtual const char *format_name (void) const override { return "FFmpeg movie"; }
+    virtual bool open (const std::string &name, ImageSpec &spec) override;
+    virtual bool close (void) override;
+    virtual int current_subimage (void) const override { return m_subimage; }
+    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
     void read_frame(int pos);
 #if 0
     const char *metadata (const char * key);

--- a/src/field3d.imageio/field3dinput.cpp
+++ b/src/field3d.imageio/field3dinput.cpp
@@ -54,26 +54,26 @@ f3dpvt::field3d_mutex ()
 
 
 
-class Field3DInput : public Field3DInput_Interface {
+class Field3DInput final : public Field3DInput_Interface {
 public:
     Field3DInput () { init(); }
     virtual ~Field3DInput () { close(); }
-    virtual const char * format_name (void) const { return "field3d"; }
-    virtual int supports (string_view feature) const {
+    virtual const char * format_name (void) const override { return "field3d"; }
+    virtual int supports (string_view feature) const override {
         return (feature == "arbitrary_metadata");
     }
-    virtual bool valid_file (const std::string &filename) const;
-    virtual bool open (const std::string &name, ImageSpec &newspec);
-    virtual bool close ();
-    virtual int current_subimage (void) const { return m_subimage; }
-    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec);
-    virtual bool read_native_scanline (int y, int z, void *data);
-    virtual bool read_native_tile (int x, int y, int z, void *data);
+    virtual bool valid_file (const std::string &filename) const override;
+    virtual bool open (const std::string &name, ImageSpec &newspec) override;
+    virtual bool close () override;
+    virtual int current_subimage (void) const override { return m_subimage; }
+    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_tile (int x, int y, int z, void *data) override;
 
     /// Transform a world space position to local coordinates, using the
     /// mapping of the current subimage.
     virtual void worldToLocal (const Imath::V3f &wsP, Imath::V3f &lsP,
-                               float time) const;
+                               float time) const override;
 
 private:
     std::string m_name;

--- a/src/field3d.imageio/field3doutput.cpp
+++ b/src/field3d.imageio/field3doutput.cpp
@@ -52,18 +52,18 @@ class Field3DOutput final : public ImageOutput {
 public:
     Field3DOutput ();
     virtual ~Field3DOutput ();
-    virtual const char * format_name (void) const { return "field3d"; }
-    virtual int supports (string_view feature) const;
+    virtual const char * format_name (void) const override { return "field3d"; }
+    virtual int supports (string_view feature) const override;
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode);
+                       OpenMode mode) override;
     virtual bool open (const std::string &name, int subimages,
-                       const ImageSpec *specs);
-    virtual bool close ();
+                       const ImageSpec *specs) override;
+    virtual bool close () override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
+                                 const void *data, stride_t xstride) override;
     virtual bool write_tile (int x, int y, int z,
                              TypeDesc format, const void *data,
-                             stride_t xstride, stride_t ystride, stride_t zstride);
+                             stride_t xstride, stride_t ystride, stride_t zstride) override;
 
 private:
     std::string m_name;

--- a/src/fits.imageio/fits_pvt.h
+++ b/src/fits.imageio/fits_pvt.h
@@ -68,18 +68,18 @@ class FitsInput final : public ImageInput {
  public:
     FitsInput () { init (); }
     virtual ~FitsInput () { close (); }
-    virtual const char *format_name (void) const { return "fits"; }
-    virtual int supports (string_view feature) const {
+    virtual const char *format_name (void) const override { return "fits"; }
+    virtual int supports (string_view feature) const override {
         return (feature == "arbitrary_metadata"
              || feature == "exif"   // Because of arbitrary_metadata
              || feature == "iptc"); // Because of arbitrary_metadata
     }
-    virtual bool valid_file (const std::string &filename) const;
-    virtual bool open (const std::string &name, ImageSpec &spec);
-    virtual bool close (void);
-    virtual bool read_native_scanline (int y, int z, void *data);
-    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec);
-    virtual int current_subimage () const { return m_cur_subimage; }
+    virtual bool valid_file (const std::string &filename) const override;
+    virtual bool open (const std::string &name, ImageSpec &spec) override;
+    virtual bool close (void) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) override;
+    virtual int current_subimage () const override { return m_cur_subimage; }
  private:
     FILE *m_fd;
     std::string m_filename;
@@ -140,16 +140,16 @@ class FitsOutput final : public ImageOutput {
  public:
     FitsOutput () { init (); }
     virtual ~FitsOutput () { close (); }
-    virtual const char *format_name (void) const { return "fits"; }
-    virtual int supports (string_view feature) const;
+    virtual const char *format_name (void) const override { return "fits"; }
+    virtual int supports (string_view feature) const override;
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode=Create);
-    virtual bool close (void);
+                       OpenMode mode=Create) override;
+    virtual bool close (void) override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
+                                 const void *data, stride_t xstride) override;
     virtual bool write_tile (int x, int y, int z, TypeDesc format,
                              const void *data, stride_t xstride,
-                             stride_t ystride, stride_t zstride);
+                             stride_t ystride, stride_t zstride) override;
 
  private:
     FILE *m_fd;

--- a/src/gif.imageio/gifinput.cpp
+++ b/src/gif.imageio/gifinput.cpp
@@ -59,15 +59,15 @@ class GIFInput final : public ImageInput {
 public:
     GIFInput () { init (); }
     virtual ~GIFInput () { close (); }
-    virtual const char *format_name (void) const { return "gif"; }
-    virtual bool open (const std::string &name, ImageSpec &newspec);
-    virtual bool close (void);
-    virtual bool read_native_scanline (int y, int z, void *data);
-    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec);
+    virtual const char *format_name (void) const override { return "gif"; }
+    virtual bool open (const std::string &name, ImageSpec &newspec) override;
+    virtual bool close (void) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) override;
 
-    virtual int current_subimage (void) const { return m_subimage; }
+    virtual int current_subimage (void) const override { return m_subimage; }
     
-    virtual int current_miplevel (void) const {
+    virtual int current_miplevel (void) const override {
         // No mipmap support
         return 0;
     }

--- a/src/gif.imageio/gifoutput.cpp
+++ b/src/gif.imageio/gifoutput.cpp
@@ -53,20 +53,20 @@ class GIFOutput final : public ImageOutput {
  public:
     GIFOutput () { init(); }
     virtual ~GIFOutput () { close(); }
-    virtual const char * format_name (void) const { return "gif"; }
-    virtual int supports (string_view feature) const {
+    virtual const char * format_name (void) const override { return "gif"; }
+    virtual int supports (string_view feature) const override {
         return (feature == "alpha" ||
                 feature == "random_access" ||
                 feature == "multiimage" ||
                 feature == "appendsubimage");
     }
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode=Create);
+                       OpenMode mode=Create) override;
     virtual bool open (const std::string &name, int subimages,
-                       const ImageSpec *specs);
+                       const ImageSpec *specs) override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
-    virtual bool close ();
+                                 const void *data, stride_t xstride) override;
+    virtual bool close () override;
 
  private:
     std::string m_filename;

--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -59,12 +59,12 @@ class HdrInput final : public ImageInput {
 public:
     HdrInput () { init(); }
     virtual ~HdrInput () { close(); }
-    virtual const char * format_name (void) const { return "hdr"; }
-    virtual bool open (const std::string &name, ImageSpec &spec);
-    virtual bool read_native_scanline (int y, int z, void *data);
-    virtual bool close ();
-    virtual int current_subimage (void) const { return m_subimage; }
-    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec);
+    virtual const char * format_name (void) const override { return "hdr"; }
+    virtual bool open (const std::string &name, ImageSpec &spec) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool close () override;
+    virtual int current_subimage (void) const override { return m_subimage; }
+    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) override;
 
 private:
     std::string m_filename;       ///< File name

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -45,15 +45,15 @@ class HdrOutput final : public ImageOutput {
  public:
     HdrOutput () { init(); }
     virtual ~HdrOutput () { close(); }
-    virtual const char * format_name (void) const { return "hdr"; }
+    virtual const char * format_name (void) const override { return "hdr"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode);
+                       OpenMode mode) override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
+                                 const void *data, stride_t xstride) override;
     virtual bool write_tile (int x, int y, int z, TypeDesc format,
                              const void *data, stride_t xstride,
-                             stride_t ystride, stride_t zstride);
-    virtual bool close ();
+                             stride_t ystride, stride_t zstride) override;
+    virtual bool close () override;
  private:
     FILE *m_fd;
     std::vector<unsigned char> scratch;

--- a/src/ico.imageio/icoinput.cpp
+++ b/src/ico.imageio/icoinput.cpp
@@ -50,12 +50,12 @@ class ICOInput final : public ImageInput {
 public:
     ICOInput () { init(); }
     virtual ~ICOInput () { close(); }
-    virtual const char * format_name (void) const { return "ico"; }
-    virtual bool open (const std::string &name, ImageSpec &newspec);
-    virtual bool close ();
-    virtual int current_subimage (void) const { return m_subimage; }
-    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec);
-    virtual bool read_native_scanline (int y, int z, void *data);
+    virtual const char * format_name (void) const override { return "ico"; }
+    virtual bool open (const std::string &name, ImageSpec &newspec) override;
+    virtual bool close () override;
+    virtual int current_subimage (void) const override { return m_subimage; }
+    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
 
 private:
     std::string m_filename;           ///< Stash the filename

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -51,16 +51,16 @@ class ICOOutput final : public ImageOutput {
 public:
     ICOOutput ();
     virtual ~ICOOutput ();
-    virtual const char * format_name (void) const { return "ico"; }
-    virtual int supports (string_view feature) const;
+    virtual const char * format_name (void) const override { return "ico"; }
+    virtual int supports (string_view feature) const override;
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode=Create);
-    virtual bool close ();
+                       OpenMode mode=Create) override;
+    virtual bool close () override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
+                                 const void *data, stride_t xstride) override;
     virtual bool write_tile (int x, int y, int z, TypeDesc format,
                              const void *data, stride_t xstride,
-                             stride_t ystride, stride_t zstride);
+                             stride_t ystride, stride_t zstride) override;
 
 private:
     std::string m_filename;           ///< Stash the filename

--- a/src/iff.imageio/iff_pvt.h
+++ b/src/iff.imageio/iff_pvt.h
@@ -139,11 +139,11 @@ class IffInput final : public ImageInput {
 public:
     IffInput () { init(); }
     virtual ~IffInput () { close(); }
-    virtual const char *format_name (void) const { return "iff"; }
-    virtual bool open (const std::string &name, ImageSpec &spec);
-    virtual bool close (void);
-    virtual bool read_native_scanline (int y, int z, void *data);
-    virtual bool read_native_tile (int x, int y, int z, void *data);
+    virtual const char *format_name (void) const override { return "iff"; }
+    virtual bool open (const std::string &name, ImageSpec &spec) override;
+    virtual bool close (void) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_tile (int x, int y, int z, void *data) override;
 private:
     FILE *m_fd;
     std::string m_filename;
@@ -209,16 +209,16 @@ class IffOutput final : public ImageOutput {
 public:
     IffOutput () { init (); }
     virtual ~IffOutput () { close (); }
-    virtual const char *format_name (void) const { return "iff"; }
-    virtual int supports (string_view feature) const;
+    virtual const char *format_name (void) const override { return "iff"; }
+    virtual int supports (string_view feature) const override;
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode);
-    virtual bool close (void);
+                       OpenMode mode) override;
+    virtual bool close (void) override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
+                                 const void *data, stride_t xstride) override;
     virtual bool write_tile (int x, int y, int z,
                              TypeDesc format, const void *data,
-                             stride_t xstride, stride_t ystride, stride_t zstride);
+                             stride_t xstride, stride_t ystride, stride_t zstride) override;
 private:
     FILE *m_fd;
     std::string m_filename;

--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -73,17 +73,17 @@ class JpgInput final : public ImageInput {
  public:
     JpgInput () { init(); }
     virtual ~JpgInput () { close(); }
-    virtual const char * format_name (void) const { return "jpeg"; }
-    virtual int supports (string_view feature) const {
+    virtual const char * format_name (void) const override { return "jpeg"; }
+    virtual int supports (string_view feature) const override {
         return (feature == "exif"
              || feature == "iptc");
     }
-    virtual bool valid_file (const std::string &filename) const;
-    virtual bool open (const std::string &name, ImageSpec &spec);
+    virtual bool valid_file (const std::string &filename) const override;
+    virtual bool open (const std::string &name, ImageSpec &spec) override;
     virtual bool open (const std::string &name, ImageSpec &spec,
-                       const ImageSpec &config);
-    virtual bool read_native_scanline (int y, int z, void *data);
-    virtual bool close ();
+                       const ImageSpec &config) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool close () override;
     const std::string &filename () const { return m_filename; }
     void * coeffs () const { return m_coeffs; }
     struct my_error_mgr {

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -1,4 +1,4 @@
-/*
+ /*
   Copyright 2008 Larry Gritz and the other authors and contributors.
   All Rights Reserved.
   Based on BSD-licensed software Copyright 2004 NVIDIA Corp.
@@ -56,20 +56,20 @@ class JpgOutput final : public ImageOutput {
  public:
     JpgOutput () { init(); }
     virtual ~JpgOutput () { close(); }
-    virtual const char * format_name (void) const { return "jpeg"; }
-    virtual int supports (string_view feature) const {
+    virtual const char * format_name (void) const override { return "jpeg"; }
+    virtual int supports (string_view feature) const override {
         return (feature == "exif"
              || feature == "iptc");
     }
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode=Create);
+                       OpenMode mode=Create) override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
+                                 const void *data, stride_t xstride) override;
     virtual bool write_tile (int x, int y, int z, TypeDesc format,
                              const void *data, stride_t xstride,
-                             stride_t ystride, stride_t zstride);
-    virtual bool close ();
-    virtual bool copy_image (ImageInput *in);
+                             stride_t ystride, stride_t zstride) override;
+    virtual bool close () override;
+    virtual bool copy_image (ImageInput *in) override;
 
  private:
     FILE *m_fd;

--- a/src/jpeg2000.imageio/jpeg2000input-v1.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input-v1.cpp
@@ -85,16 +85,16 @@ class Jpeg2000Input final : public ImageInput {
  public:
     Jpeg2000Input () { init (); }
     virtual ~Jpeg2000Input () { close (); }
-    virtual const char *format_name (void) const { return "jpeg2000"; }
-    virtual int supports (string_view feature) const {
+    virtual const char *format_name (void) const override { return "jpeg2000"; }
+    virtual int supports (string_view feature) const override {
         return false;
         // FIXME: we should support Exif/IPTC, but currently don't.
     }
-    virtual bool open (const std::string &name, ImageSpec &spec);
+    virtual bool open (const std::string &name, ImageSpec &spec) override;
     virtual bool open (const std::string &name, ImageSpec &newspec,
-                       const ImageSpec &config);
-    virtual bool close (void);
-    virtual bool read_native_scanline (int y, int z, void *data);
+                       const ImageSpec &config) override;
+    virtual bool close (void) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
 
  private:
     std::string m_filename;

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -101,16 +101,16 @@ class Jpeg2000Input final : public ImageInput {
  public:
     Jpeg2000Input () { init (); }
     virtual ~Jpeg2000Input () { close (); }
-    virtual const char *format_name (void) const { return "jpeg2000"; }
-    virtual int supports (string_view feature) const {
+    virtual const char *format_name (void) const override { return "jpeg2000"; }
+    virtual int supports (string_view feature) const override {
         return false;
         // FIXME: we should support Exif/IPTC, but currently don't.
     }
-    virtual bool open (const std::string &name, ImageSpec &spec);
+    virtual bool open (const std::string &name, ImageSpec &spec) override;
     virtual bool open (const std::string &name, ImageSpec &newspec,
-                       const ImageSpec &config);
-    virtual bool close (void);
-    virtual bool read_native_scanline (int y, int z, void *data);
+                       const ImageSpec &config) override;
+    virtual bool close (void) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
 
  private:
 

--- a/src/jpeg2000.imageio/jpeg2000output-v1.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output-v1.cpp
@@ -48,7 +48,7 @@ class Jpeg2000Output final : public ImageOutput {
         // FIXME: we should support Exif/IPTC, but currently don't.
     }
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode=Create);
+                       OpenMode mode=Create) override;
     virtual bool close ();
     virtual bool write_scanline (int y, int z, TypeDesc format,
                                  const void *data, stride_t xstride);

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -59,19 +59,19 @@ class Jpeg2000Output final : public ImageOutput {
  public:
     Jpeg2000Output () { init (); }
     virtual ~Jpeg2000Output () { close (); }
-    virtual const char *format_name (void) const { return "jpeg2000"; }
-    virtual int supports (string_view feature) const {
+    virtual const char *format_name (void) const override { return "jpeg2000"; }
+    virtual int supports (string_view feature) const override {
         return (feature == "alpha");
         // FIXME: we should support Exif/IPTC, but currently don't.
     }
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode=Create);
-    virtual bool close ();
+                       OpenMode mode=Create) override;
+    virtual bool close () override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
+                                 const void *data, stride_t xstride) override;
     virtual bool write_tile (int x, int y, int z, TypeDesc format,
                              const void *data, stride_t xstride,
-                             stride_t ystride, stride_t zstride);
+                             stride_t ystride, stride_t zstride) override;
  private:
     std::string m_filename;
     FILE *m_file;

--- a/src/null.imageio/nullimageio.cpp
+++ b/src/null.imageio/nullimageio.cpp
@@ -48,21 +48,21 @@ class NullOutput final : public ImageOutput {
 public:
     NullOutput () { }
     virtual ~NullOutput () { }
-    virtual const char * format_name (void) const { return "null"; }
-    virtual int supports (string_view feature) const { return true; }
+    virtual const char * format_name (void) const override { return "null"; }
+    virtual int supports (string_view feature) const override { return true; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode=Create) {
+                       OpenMode mode=Create) override {
         m_spec = spec;
         return true;
     }
-    virtual bool close () { return true; }
+    virtual bool close () override { return true; }
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride) {
+                                 const void *data, stride_t xstride) override {
         return true;
     }
     virtual bool write_tile (int x, int y, int z, TypeDesc format,
                              const void *data, stride_t xstride,
-                             stride_t ystride, stride_t zstride) {
+                             stride_t ystride, stride_t zstride) override {
         return true;
     }
 };
@@ -77,18 +77,18 @@ class NullInput final : public ImageInput {
 public:
     NullInput () { init(); }
     virtual ~NullInput () { }
-    virtual const char * format_name (void) const { return "null"; }
-    virtual bool valid_file (const std::string &filename) const;
-    virtual int supports (string_view feature) const { return true; }
-    virtual bool open (const std::string &name, ImageSpec &newspec);
+    virtual const char * format_name (void) const override { return "null"; }
+    virtual bool valid_file (const std::string &filename) const override;
+    virtual int supports (string_view feature) const override { return true; }
+    virtual bool open (const std::string &name, ImageSpec &newspec) override;
     virtual bool open (const std::string &name, ImageSpec &newspec,
-                       const ImageSpec &config);
-    virtual bool close () { return true; }
-    virtual int current_subimage (void) const { return m_subimage; }
-    virtual int current_miplevel (void) const { return m_miplevel; }
-    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec);
-    virtual bool read_native_scanline (int y, int z, void *data);
-    virtual bool read_native_tile (int x, int y, int z, void *data);
+                       const ImageSpec &config) override;
+    virtual bool close () override { return true; }
+    virtual int current_subimage (void) const override { return m_subimage; }
+    virtual int current_miplevel (void) const override { return m_miplevel; }
+    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_tile (int x, int y, int z, void *data) override;
 
 private:
     std::string m_filename;          ///< Stash the filename

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -146,36 +146,36 @@ class OpenEXRInput final : public ImageInput {
 public:
     OpenEXRInput ();
     virtual ~OpenEXRInput () { close(); }
-    virtual const char * format_name (void) const { return "openexr"; }
-    virtual int supports (string_view feature) const {
+    virtual const char * format_name (void) const override { return "openexr"; }
+    virtual int supports (string_view feature) const override {
         return (feature == "arbitrary_metadata"
              || feature == "exif"   // Because of arbitrary_metadata
              || feature == "iptc"); // Because of arbitrary_metadata
     }
-    virtual bool valid_file (const std::string &filename) const;
-    virtual bool open (const std::string &name, ImageSpec &newspec);
-    virtual bool close ();
-    virtual int current_subimage (void) const { return m_subimage; }
-    virtual int current_miplevel (void) const { return m_miplevel; }
-    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec);
-    virtual bool read_native_scanline (int y, int z, void *data);
-    virtual bool read_native_scanlines (int ybegin, int yend, int z, void *data);
+    virtual bool valid_file (const std::string &filename) const override;
+    virtual bool open (const std::string &name, ImageSpec &newspec) override;
+    virtual bool close () override;
+    virtual int current_subimage (void) const override { return m_subimage; }
+    virtual int current_miplevel (void) const override { return m_miplevel; }
+    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_scanlines (int ybegin, int yend, int z, void *data) override;
     virtual bool read_native_scanlines (int ybegin, int yend, int z,
-                                        int chbegin, int chend, void *data);
-    virtual bool read_native_tile (int x, int y, int z, void *data);
+                                        int chbegin, int chend, void *data) override;
+    virtual bool read_native_tile (int x, int y, int z, void *data) override;
     virtual bool read_native_tiles (int xbegin, int xend, int ybegin, int yend,
-                                    int zbegin, int zend, void *data);
+                                    int zbegin, int zend, void *data) override;
     virtual bool read_native_tiles (int xbegin, int xend, int ybegin, int yend,
                                     int zbegin, int zend,
-                                    int chbegin, int chend, void *data);
+                                    int chbegin, int chend, void *data) override;
     virtual bool read_native_deep_scanlines (int ybegin, int yend, int z,
                                              int chbegin, int chend,
-                                             DeepData &deepdata);
+                                             DeepData &deepdata) override;
     virtual bool read_native_deep_tiles (int xbegin, int xend,
                                          int ybegin, int yend,
                                          int zbegin, int zend,
                                          int chbegin, int chend,
-                                         DeepData &deepdata);
+                                         DeepData &deepdata) override;
 
 private:
     struct PartInfo {

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -132,30 +132,30 @@ class OpenEXROutput final : public ImageOutput {
 public:
     OpenEXROutput ();
     virtual ~OpenEXROutput ();
-    virtual const char * format_name (void) const { return "openexr"; }
-    virtual int supports (string_view feature) const;
+    virtual const char * format_name (void) const override { return "openexr"; }
+    virtual int supports (string_view feature) const override;
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode=Create);
+                       OpenMode mode=Create) override;
     virtual bool open (const std::string &name, int subimages,
-                       const ImageSpec *specs);
-    virtual bool close ();
+                       const ImageSpec *specs) override;
+    virtual bool close () override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
+                                 const void *data, stride_t xstride) override;
     virtual bool write_scanlines (int ybegin, int yend, int z,
                                   TypeDesc format, const void *data,
-                                  stride_t xstride, stride_t ystride);
+                                  stride_t xstride, stride_t ystride) override;
     virtual bool write_tile (int x, int y, int z, TypeDesc format,
                              const void *data, stride_t xstride,
-                             stride_t ystride, stride_t zstride);
+                             stride_t ystride, stride_t zstride) override;
     virtual bool write_tiles (int xbegin, int xend, int ybegin, int yend,
                               int zbegin, int zend, TypeDesc format,
                               const void *data, stride_t xstride,
-                              stride_t ystride, stride_t zstride);
+                              stride_t ystride, stride_t zstride) override;
     virtual bool write_deep_scanlines (int ybegin, int yend, int z,
-                                       const DeepData &deepdata);
+                                       const DeepData &deepdata) override;
     virtual bool write_deep_tiles (int xbegin, int xend, int ybegin, int yend,
                                    int zbegin, int zend,
-                                   const DeepData &deepdata);
+                                   const DeepData &deepdata) override;
 
 private:
     std::unique_ptr<OpenEXROutputStream> m_output_stream; ///< Stream for output file

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -43,14 +43,14 @@ class PNGInput final : public ImageInput {
 public:
     PNGInput () { init(); }
     virtual ~PNGInput () { close(); }
-    virtual const char * format_name (void) const { return "png"; }
-    virtual bool valid_file (const std::string &filename) const;
-    virtual bool open (const std::string &name, ImageSpec &newspec);
+    virtual const char * format_name (void) const override { return "png"; }
+    virtual bool valid_file (const std::string &filename) const override;
+    virtual bool open (const std::string &name, ImageSpec &newspec) override;
     virtual bool open (const std::string &name, ImageSpec &newspec,
-                       const ImageSpec &config);
-    virtual bool close ();
-    virtual int current_subimage (void) const { return m_subimage; }
-    virtual bool read_native_scanline (int y, int z, void *data);
+                       const ImageSpec &config) override;
+    virtual bool close () override;
+    virtual int current_subimage (void) const override { return m_subimage; }
+    virtual bool read_native_scanline (int y, int z, void *data) override;
 
 private:
     std::string m_filename;           ///< Stash the filename

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -44,18 +44,18 @@ class PNGOutput final : public ImageOutput {
 public:
     PNGOutput ();
     virtual ~PNGOutput ();
-    virtual const char * format_name (void) const { return "png"; }
-    virtual int supports (string_view feature) const {
+    virtual const char * format_name (void) const override { return "png"; }
+    virtual int supports (string_view feature) const override {
         return (feature == "alpha");
     }
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode=Create);
-    virtual bool close ();
+                       OpenMode mode=Create) override;
+    virtual bool close () override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
+                                 const void *data, stride_t xstride) override;
     virtual bool write_tile (int x, int y, int z, TypeDesc format,
                              const void *data, stride_t xstride,
-                             stride_t ystride, stride_t zstride);
+                             stride_t ystride, stride_t zstride) override;
 
 private:
     std::string m_filename;           ///< Stash the filename

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -42,11 +42,11 @@ class PNMInput final : public ImageInput {
 public:
     PNMInput() { }
     virtual ~PNMInput() { close(); }
-    virtual const char* format_name (void) const { return "pnm"; }
-    virtual bool open (const std::string &name, ImageSpec &newspec);
-    virtual bool close ();
-    virtual int current_subimage (void) const { return 0; }
-    virtual bool read_native_scanline (int y, int z, void *data);
+    virtual const char* format_name (void) const override { return "pnm"; }
+    virtual bool open (const std::string &name, ImageSpec &newspec) override;
+    virtual bool close () override;
+    virtual int current_subimage (void) const override { return 0; }
+    virtual bool read_native_scanline (int y, int z, void *data) override;
 
 private:
     enum PNMType {

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -39,15 +39,15 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class PNMOutput final : public ImageOutput {
 public:
     virtual ~PNMOutput ();
-    virtual const char * format_name (void) const { return "pnm"; }
+    virtual const char * format_name (void) const override { return "pnm"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode=Create);
-    virtual bool close ();
+                       OpenMode mode=Create) override;
+    virtual bool close () override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
+                                 const void *data, stride_t xstride) override;
     virtual bool write_tile (int x, int y, int z, TypeDesc format,
                              const void *data, stride_t xstride,
-                             stride_t ystride, stride_t zstride);
+                             stride_t ystride, stride_t zstride) override;
 
 private:
     std::string m_filename;           ///< Stash the filename

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -49,18 +49,18 @@ class PSDInput final : public ImageInput {
 public:
     PSDInput ();
     virtual ~PSDInput () { close(); }
-    virtual const char * format_name (void) const { return "psd"; }
-    virtual int supports (string_view feature) const {
+    virtual const char * format_name (void) const override { return "psd"; }
+    virtual int supports (string_view feature) const override {
         return (feature == "exif"
              || feature == "iptc");
     }
-    virtual bool open (const std::string &name, ImageSpec &newspec);
+    virtual bool open (const std::string &name, ImageSpec &newspec) override;
     virtual bool open (const std::string &name, ImageSpec &newspec,
-                       const ImageSpec &config);
-    virtual bool close ();
-    virtual int current_subimage () const { return m_subimage; }
-    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec);
-    virtual bool read_native_scanline (int y, int z, void *data);
+                       const ImageSpec &config) override;
+    virtual bool close () override;
+    virtual int current_subimage () const override { return m_subimage; }
+    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
 
 private:
     enum ColorMode {

--- a/src/ptex.imageio/ptexinput.cpp
+++ b/src/ptex.imageio/ptexinput.cpp
@@ -42,19 +42,19 @@ class PtexInput final : public ImageInput {
 public:
     PtexInput () : m_ptex(NULL) { init(); }
     virtual ~PtexInput () { close(); }
-    virtual const char * format_name (void) const { return "ptex"; }
-    virtual int supports (string_view feature) const {
+    virtual const char * format_name (void) const override { return "ptex"; }
+    virtual int supports (string_view feature) const override {
         return (feature == "arbitrary_metadata"
              || feature == "exif"   // Because of arbitrary_metadata
              || feature == "iptc"); // Because of arbitrary_metadata
     }
-    virtual bool open (const std::string &name, ImageSpec &newspec);
-    virtual bool close ();
-    virtual int current_subimage (void) const { return m_subimage; }
-    virtual int current_miplevel (void) const { return m_miplevel; }
-    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec);
-    virtual bool read_native_scanline (int y, int z, void *data);
-    virtual bool read_native_tile (int x, int y, int z, void *data);
+    virtual bool open (const std::string &name, ImageSpec &newspec) override;
+    virtual bool close () override;
+    virtual int current_subimage (void) const override { return m_subimage; }
+    virtual int current_miplevel (void) const override { return m_miplevel; }
+    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_tile (int x, int y, int z, void *data) override;
 
 private:
     PtexTexture *m_ptex;

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -55,16 +55,16 @@ class RawInput final : public ImageInput {
 public:
     RawInput () {}
     virtual ~RawInput() { close(); }
-    virtual const char * format_name (void) const { return "raw"; }
-    virtual int supports (string_view feature) const {
+    virtual const char * format_name (void) const override { return "raw"; }
+    virtual int supports (string_view feature) const override {
         return (feature == "exif"
              /* not yet? || feature == "iptc"*/);
     }
-    virtual bool open (const std::string &name, ImageSpec &newspec);
+    virtual bool open (const std::string &name, ImageSpec &newspec) override;
     virtual bool open (const std::string &name, ImageSpec &newspec,
-                       const ImageSpec &config);
-    virtual bool close();
-    virtual bool read_native_scanline (int y, int z, void *data);
+                       const ImageSpec &config) override;
+    virtual bool close() override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
 
 private:
     bool process();

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -50,12 +50,12 @@ class RLAInput final : public ImageInput {
 public:
     RLAInput () { init(); }
     virtual ~RLAInput () { close(); }
-    virtual const char * format_name (void) const { return "rla"; }
-    virtual bool open (const std::string &name, ImageSpec &newspec);
-    virtual int current_subimage (void) const { return m_subimage; }
-    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec);
-    virtual bool close ();
-    virtual bool read_native_scanline (int y, int z, void *data);
+    virtual const char * format_name (void) const override { return "rla"; }
+    virtual bool open (const std::string &name, ImageSpec &newspec) override;
+    virtual int current_subimage (void) const override { return m_subimage; }
+    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) override;
+    virtual bool close () override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
 
 private:
     std::string m_filename;           ///< Stash the filename

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -57,16 +57,16 @@ class RLAOutput final : public ImageOutput {
 public:
     RLAOutput ();
     virtual ~RLAOutput ();
-    virtual const char * format_name (void) const { return "rla"; }
-    virtual int supports (string_view feature) const;
+    virtual const char * format_name (void) const override { return "rla"; }
+    virtual int supports (string_view feature) const override;
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode=Create);
-    virtual bool close ();
+                       OpenMode mode=Create) override;
+    virtual bool close () override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
+                                 const void *data, stride_t xstride) override;
     virtual bool write_tile (int x, int y, int z, TypeDesc format,
                              const void *data, stride_t xstride,
-                             stride_t ystride, stride_t zstride);
+                             stride_t ystride, stride_t zstride) override;
 
 private:
     std::string m_filename;           ///< Stash the filename

--- a/src/sgi.imageio/sgi_pvt.h
+++ b/src/sgi.imageio/sgi_pvt.h
@@ -91,11 +91,11 @@ class SgiInput final : public ImageInput {
  public:
     SgiInput () { init(); }
     virtual ~SgiInput () { close(); }
-    virtual const char *format_name (void) const { return "sgi"; }
-    virtual bool valid_file (const std::string &filename) const;
-    virtual bool open (const std::string &name, ImageSpec &spec);
-    virtual bool close (void);
-    virtual bool read_native_scanline (int y, int z, void *data);
+    virtual const char *format_name (void) const override { return "sgi"; }
+    virtual bool valid_file (const std::string &filename) const override;
+    virtual bool open (const std::string &name, ImageSpec &spec) override;
+    virtual bool close (void) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
  private:
     FILE *m_fd;
     std::string m_filename;
@@ -140,16 +140,16 @@ class SgiOutput final : public ImageOutput {
  public:
     SgiOutput () : m_fd(NULL) { }
     virtual ~SgiOutput () { close(); }
-    virtual const char *format_name (void) const { return "sgi"; }
-    virtual int supports (string_view feature) const;
+    virtual const char *format_name (void) const override { return "sgi"; }
+    virtual int supports (string_view feature) const override;
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode=Create);
-    virtual bool close (void);
+                       OpenMode mode=Create) override;
+    virtual bool close (void) override;
     virtual bool write_scanline (int y, int z, TypeDesc format, const void *data,
-                                 stride_t xstride);
+                                 stride_t xstride) override;
     virtual bool write_tile (int x, int y, int z, TypeDesc format,
                              const void *data, stride_t xstride,
-                             stride_t ystride, stride_t zstride);
+                             stride_t ystride, stride_t zstride) override;
  private:
     FILE *m_fd;
     std::string m_filename;

--- a/src/socket.imageio/socket_pvt.h
+++ b/src/socket.imageio/socket_pvt.h
@@ -63,17 +63,17 @@ class SocketOutput final : public ImageOutput {
  public:
     SocketOutput ();
     virtual ~SocketOutput () { close(); }
-    virtual const char * format_name (void) const { return "socket"; }
-    virtual int supports (string_view property) const;
+    virtual const char * format_name (void) const override { return "socket"; }
+    virtual int supports (string_view property) const override;
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode=Create);
+                       OpenMode mode=Create) override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
+                                 const void *data, stride_t xstride) override;
     virtual bool write_tile (int x, int y, int z,
                              TypeDesc format, const void *data,
-                             stride_t xstride, stride_t ystride, stride_t zstride);
-    virtual bool close ();
-    virtual bool copy_image (ImageInput *in);
+                             stride_t xstride, stride_t ystride, stride_t zstride) override;
+    virtual bool close () override;
+    virtual bool copy_image (ImageInput *in) override;
 
  private:
     int m_next_scanline;             // Which scanline is the next to write?
@@ -91,14 +91,14 @@ class SocketInput final : public ImageInput {
  public:
     SocketInput ();
     virtual ~SocketInput () { close(); }
-    virtual const char * format_name (void) const { return "socket"; }
-    virtual bool valid_file (const std::string &filename) const;
-    virtual bool open (const std::string &name, ImageSpec &spec);
+    virtual const char * format_name (void) const override { return "socket"; }
+    virtual bool valid_file (const std::string &filename) const override;
+    virtual bool open (const std::string &name, ImageSpec &spec) override;
     virtual bool open (const std::string &name, ImageSpec &spec,
-                       const ImageSpec &config);
-    virtual bool read_native_scanline (int y, int z, void *data);
-    virtual bool read_native_tile (int x, int y, int z, void *data);
-    virtual bool close ();
+                       const ImageSpec &config) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_tile (int x, int y, int z, void *data) override;
+    virtual bool close () override;
 
  private:
     int m_next_scanline;      // Which scanline is the next to read?

--- a/src/softimage.imageio/softimageinput.cpp
+++ b/src/softimage.imageio/softimageinput.cpp
@@ -48,12 +48,12 @@ public:
     virtual ~SoftimageInput() {
         close();
     }
-    virtual const char *format_name (void) const {
+    virtual const char *format_name (void) const override {
         return "softimage";
     }
-    virtual bool open (const std::string &name, ImageSpec &spec);
-    virtual bool close();
-    virtual bool read_native_scanline (int y, int z, void *data);
+    virtual bool open (const std::string &name, ImageSpec &spec) override;
+    virtual bool close() override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
 
 private:
     /// Resets the core data members to defaults.

--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -50,12 +50,12 @@ class TGAInput final : public ImageInput {
 public:
     TGAInput () { init(); }
     virtual ~TGAInput () { close(); }
-    virtual const char * format_name (void) const { return "targa"; }
-    virtual bool open (const std::string &name, ImageSpec &newspec);
+    virtual const char * format_name (void) const override { return "targa"; }
+    virtual bool open (const std::string &name, ImageSpec &newspec) override;
     virtual bool open (const std::string &name, ImageSpec &newspec,
-                       const ImageSpec &config);
-    virtual bool close ();
-    virtual bool read_native_scanline (int y, int z, void *data);
+                       const ImageSpec &config) override;
+    virtual bool close () override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
 
 private:
     std::string m_filename;           ///< Stash the filename

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -50,18 +50,18 @@ class TGAOutput final : public ImageOutput {
 public:
     TGAOutput ();
     virtual ~TGAOutput ();
-    virtual const char * format_name (void) const { return "targa"; }
-    virtual int supports (string_view feature) const {
+    virtual const char * format_name (void) const override { return "targa"; }
+    virtual int supports (string_view feature) const override {
         return (feature == "alpha");
     }
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode=Create);
-    virtual bool close ();
+                       OpenMode mode=Create) override;
+    virtual bool close () override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
+                                 const void *data, stride_t xstride) override;
     virtual bool write_tile (int x, int y, int z, TypeDesc format,
                              const void *data, stride_t xstride,
-                             stride_t ystride, stride_t zstride);
+                             stride_t ystride, stride_t zstride) override;
 
 private:
     std::string m_filename;           ///< Stash the filename

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -110,43 +110,43 @@ class TIFFInput final : public ImageInput {
 public:
     TIFFInput ();
     virtual ~TIFFInput ();
-    virtual const char * format_name (void) const { return "tiff"; }
-    virtual bool valid_file (const std::string &filename) const;
-    virtual int supports (string_view feature) const {
+    virtual const char * format_name (void) const override { return "tiff"; }
+    virtual bool valid_file (const std::string &filename) const override;
+    virtual int supports (string_view feature) const override {
         return (feature == "exif"
              || feature == "iptc");
         // N.B. No support for arbitrary metadata.
     }
-    virtual bool open (const std::string &name, ImageSpec &newspec);
+    virtual bool open (const std::string &name, ImageSpec &newspec) override;
     virtual bool open (const std::string &name, ImageSpec &newspec,
-                       const ImageSpec &config);
-    virtual bool close ();
-    virtual int current_subimage (void) const {
+                       const ImageSpec &config) override;
+    virtual bool close () override;
+    virtual int current_subimage (void) const override {
         // If m_emulate_mipmap is true, pretend subimages are mipmap levels
         return m_emulate_mipmap ? 0 : m_subimage;
     }
-    virtual int current_miplevel (void) const {
+    virtual int current_miplevel (void) const override {
         // If m_emulate_mipmap is true, pretend subimages are mipmap levels
         return m_emulate_mipmap ? m_subimage : 0;
     }
-    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec);
-    virtual bool read_native_scanline (int y, int z, void *data);
-    virtual bool read_native_scanlines (int ybegin, int yend, int z, void *data);
-    virtual bool read_native_tile (int x, int y, int z, void *data);
+    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_scanlines (int ybegin, int yend, int z, void *data) override;
+    virtual bool read_native_tile (int x, int y, int z, void *data) override;
     virtual bool read_native_tiles (int xbegin, int xend, int ybegin, int yend,
-                                    int zbegin, int zend, void *data);
+                                    int zbegin, int zend, void *data) override;
     virtual bool read_scanline (int y, int z, TypeDesc format, void *data,
-                                stride_t xstride);
+                                stride_t xstride) override;
     virtual bool read_scanlines (int ybegin, int yend, int z,
                                  int chbegin, int chend,
                                  TypeDesc format, void *data,
-                                 stride_t xstride, stride_t ystride);
+                                 stride_t xstride, stride_t ystride) override;
     virtual bool read_tile (int x, int y, int z, TypeDesc format, void *data,
-                            stride_t xstride, stride_t ystride, stride_t zstride);
+                            stride_t xstride, stride_t ystride, stride_t zstride) override;
     virtual bool read_tiles (int xbegin, int xend, int ybegin, int yend,
                              int zbegin, int zend, int chbegin, int chend,
                              TypeDesc format, void *data,
-                             stride_t xstride, stride_t ystride, stride_t zstride);
+                             stride_t xstride, stride_t ystride, stride_t zstride) override;
 
 private:
     TIFF *m_tif;                     ///< libtiff handle

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -67,24 +67,24 @@ class TIFFOutput final : public ImageOutput {
 public:
     TIFFOutput ();
     virtual ~TIFFOutput ();
-    virtual const char * format_name (void) const { return "tiff"; }
-    virtual int supports (string_view feature) const;
+    virtual const char * format_name (void) const override { return "tiff"; }
+    virtual int supports (string_view feature) const override;
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode=Create);
-    virtual bool close ();
+                       OpenMode mode=Create) override;
+    virtual bool close () override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
+                                 const void *data, stride_t xstride) override;
     virtual bool write_scanlines (int ybegin, int yend, int z,
                                   TypeDesc format, const void *data,
-                                  stride_t xstride, stride_t ystride);
+                                  stride_t xstride, stride_t ystride) override;
     virtual bool write_tile (int x, int y, int z,
                              TypeDesc format, const void *data,
-                             stride_t xstride, stride_t ystride, stride_t zstride);
+                             stride_t xstride, stride_t ystride, stride_t zstride) override;
     virtual bool write_tiles (int xbegin, int xend, int ybegin, int yend,
                               int zbegin, int zend, TypeDesc format,
                               const void *data, stride_t xstride=AutoStride,
                               stride_t ystride=AutoStride,
-                              stride_t zstride=AutoStride);
+                              stride_t zstride=AutoStride) override;
 private:
     TIFF *m_tif;
     std::vector<unsigned char> m_scratch;

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -43,10 +43,10 @@ class WebpInput final : public ImageInput
  public:
     WebpInput() { init(); }
     virtual ~WebpInput() { close(); }
-    virtual const char* format_name() const { return "webp"; }
-    virtual bool open (const std::string &name, ImageSpec &spec);
-    virtual bool read_native_scanline (int y, int z, void *data);
-    virtual bool close ();
+    virtual const char* format_name() const override { return "webp"; }
+    virtual bool open (const std::string &name, ImageSpec &spec) override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool close () override;
 
  private:
     std::string m_filename;

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -42,16 +42,16 @@ class WebpOutput final : public ImageOutput
  public:
     WebpOutput(){ init(); }
     virtual ~WebpOutput(){ close(); }
-    virtual const char* format_name () const { return "webp"; }
+    virtual const char* format_name () const override { return "webp"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode=Create);
-    virtual int supports (string_view feature) const;
+                       OpenMode mode=Create) override;
+    virtual int supports (string_view feature) const override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
+                                 const void *data, stride_t xstride) override;
     virtual bool write_tile (int x, int y, int z, TypeDesc format,
                              const void *data, stride_t xstride,
-                             stride_t ystride, stride_t zstride);
-    virtual bool close();
+                             stride_t ystride, stride_t zstride) override;
+    virtual bool close() override;
 
  private:
     WebPPicture m_webp_picture;

--- a/src/zfile.imageio/zfile.cpp
+++ b/src/zfile.imageio/zfile.cpp
@@ -66,11 +66,11 @@ class ZfileInput final : public ImageInput {
 public:
     ZfileInput () { init(); }
     virtual ~ZfileInput () { close(); }
-    virtual const char * format_name (void) const { return "zfile"; }
-    virtual bool valid_file (const std::string &filename) const;
-    virtual bool open (const std::string &name, ImageSpec &newspec);
-    virtual bool close ();
-    virtual bool read_native_scanline (int y, int z, void *data);
+    virtual const char * format_name (void) const override { return "zfile"; }
+    virtual bool valid_file (const std::string &filename) const override;
+    virtual bool open (const std::string &name, ImageSpec &newspec) override;
+    virtual bool close () override;
+    virtual bool read_native_scanline (int y, int z, void *data) override;
 
 private:
     std::string m_filename;       ///< Stash the filename
@@ -92,15 +92,15 @@ class ZfileOutput final : public ImageOutput {
 public:
     ZfileOutput () { init(); }
     virtual ~ZfileOutput () { close(); }
-    virtual const char * format_name (void) const { return "zfile"; }
+    virtual const char * format_name (void) const override { return "zfile"; }
     virtual bool open (const std::string &name, const ImageSpec &spec,
-                       OpenMode mode=Create);
-    virtual bool close ();
+                       OpenMode mode=Create) override;
+    virtual bool close () override;
     virtual bool write_scanline (int y, int z, TypeDesc format,
-                                 const void *data, stride_t xstride);
+                                 const void *data, stride_t xstride) override;
     virtual bool write_tile (int x, int y, int z, TypeDesc format,
                              const void *data, stride_t xstride,
-                             stride_t ystride, stride_t zstride);
+                             stride_t ystride, stride_t zstride) override;
 
 private:
     std::string m_filename;       ///< Stash the filename


### PR DESCRIPTION
The C++11 `override` keyword is helpful in preventing coding errors by
ensuring that your subclasses aren't using virtual functions with the
wrong signature (and thus making a new, useless methods rather than
correctly overloading the method you intended).

