### PR TITLE
Bug fix: wrong dimensions for premult in TIFFInput::read_tiles

### DIFF
--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1821,7 +1821,7 @@ bool TIFFInput::read_tile (int x, int y, int z, TypeDesc format, void *data,
         OIIO::premult (m_spec.nchannels, m_spec.tile_width, m_spec.tile_height,
                        std::max (1, m_spec.tile_depth),
                        0, m_spec.nchannels, format, data,
-                       xstride, AutoStride, AutoStride,
+                       xstride, ystride, zstride,
                        m_spec.alpha_channel, m_spec.z_channel);
     }
     return ok;
@@ -1845,10 +1845,9 @@ bool TIFFInput::read_tiles (int xbegin, int xend, int ybegin, int yend,
         // by alpha should happen after we've already done data format
         // conversions. That's why we do it here, rather than in
         // read_native_blah.
-        OIIO::premult (m_spec.nchannels, m_spec.tile_width, m_spec.tile_height,
-                       std::max (1, m_spec.tile_depth),
+        OIIO::premult (m_spec.nchannels, xend-xbegin, yend-ybegin, zend-zbegin,
                        chbegin, chend, format, data,
-                       xstride, AutoStride, AutoStride,
+                       xstride, ystride, zstride,
                        m_spec.alpha_channel, m_spec.z_channel);
     }
     return ok;


### PR DESCRIPTION
Just noticed this while doing other things. Nobody has reported a problem, but it's clear to me that if people were using the special "give me the unassociated values" attribute, and reading multiple tiles, this would be using the wrong dimensions for the buffer.
