### PR TITLE
texture()/texture3d() -- don't let subimage error be nondeterministic

### DIFF
--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -164,8 +164,9 @@ TextureSystemImpl::texture3d (TextureHandle *texture_handle_,
         int s = m_imagecache->subimage_from_name (texturefile, options.subimagename);
         if (s < 0) {
             error ("Unknown subimage \"%s\" in texture \"%s\"",
-                   options.subimagename.c_str(), texturefile->filename().c_str());
-            return false;
+                   options.subimagename, texturefile->filename());
+            return missing_texture (options, nchannels, result,
+                                    dresultds, dresultdt, dresultdr);
         }
         options.subimage = s;
         options.subimagename.clear();

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -992,7 +992,8 @@ TextureSystemImpl::texture (TextureHandle *texture_handle_,
         if (s < 0) {
             error ("Unknown subimage \"%s\" in texture \"%s\"",
                    options.subimagename, texturefile->filename());
-            return false;
+            return missing_texture (options, nchannels, result,
+                                    dresultds, dresultdt);
         }
         options.subimage = s;
         options.subimagename.clear();


### PR DESCRIPTION
We realized that for the error condition of the optional "subimage"
specifying a nonexistant subimage would issue an error and return
without writing any values into the location of the color result.

The proposed patch treats the nonexistant-subimage case just like we
always treated the nonexistant-texture case: issue an error and store
the "fill" color in the result, unless the "missingcolor" optional
parameter is supplied, in which case return the missingcolor and do
not issue an error.

