### PR TITLE
TIFF header read speedup

### DIFF
--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -612,7 +612,7 @@ TIFFInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
     }
     
     m_next_scanline = 0;   // next scanline we'll read
-    if (TIFFSetDirectory (m_tif, subimage)) {
+    if (subimage == m_subimage || TIFFSetDirectory (m_tif, subimage)) {
         m_subimage = subimage;
         readspec (read_meta);
         // OK, some edge cases we just don't handle. For those, fall back on
@@ -969,7 +969,8 @@ TIFFInput::readspec (bool read_meta)
 #else
         m_tif = TIFFOpen (m_filename.c_str(), "rm");
 #endif
-        TIFFSetDirectory (m_tif, m_subimage);
+        if (m_subimage)
+            TIFFSetDirectory (m_tif, m_subimage);
 
         // A few tidbits to look for
         ParamValue *p;


### PR DESCRIPTION
Calls to TIFFSetDirectory are redundant if the file was just opened
and you are positioning to the first subdirectory.

Yet, libtiff seems not to notice that, and will happily repeat a bunch
of the header reading that it already did for the TIFFOpen.

So making sure that we only call TIFFSetDirectory when we need to
actually change the current subimage, saves some work (and in fact
can approximately double the speed of reading the header).

