### PR TITLE
TIFF bug fix: don't forget byte swap when we uncompress ourselves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,7 @@ oiio_add_tests (bmp
 
 oiio_add_tests (tiff-suite tiff-depths tiff-misc
     IMAGEDIR libtiffpic
-    URL http://www.remotesensing.org/libtiff/images.html)
+    URL http://www.simplesystems.org/libtiff/images.html)
 
 oiio_add_tests (openexr-suite openexr-multires openexr-chroma openexr-v2 perchannel
     IMAGEDIR openexr-images

--- a/src/build-scripts/install_test_images.bash
+++ b/src/build-scripts/install_test_images.bash
@@ -5,7 +5,7 @@ if [ ! -e ../oiio-images ] ; then
 fi
 
 if [ ! -e ../libtiffpic ] ; then
-    wget ftp://ftp.remotesensing.org/pub/libtiff/pics-3.8.0.tar.gz
+    wget ftp://download.osgeo.org/libtiff/pics-3.8.0.tar.gz
     tar xf pics-3.8.0.tar.gz -C ..
 fi
 

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -368,6 +368,9 @@ private:
             *ok = false;
             return;
         }
+        if (TIFFIsByteSwapped(m_tif) && m_spec.format == TypeUInt16)
+            TIFFSwabArrayOfShort ((unsigned short *)uncompressed_buf,
+                                  width*height*channels);
         if (m_spec.format == TypeUInt8)
             undo_horizontal_predictor ((unsigned char *)uncompressed_buf,
                                        (unsigned char *)uncompressed_buf,


### PR DESCRIPTION
The recent patch that greatly speeds up reading whole TIFF images, where we do our own decompression, forgot to consider the case where the TIFF was written with the opposite byte order as the machine reading. Luckily, that doesn't seem to come up frequently in practice, but it's still a critical error when dealing with old TIFF files.

Embarrassingly, I also noticed that our CI tests were not running some of the important TIFF unit tests, due to the libtiff project losing its domain and moving to a new URL a few months back. The download location for the test images in our scripts was therefore inoperative, and I hadn't noticed. This is now fixed as well.
