### PR TITLE
ImageInput overhaul to reduce ImageCache locking

### DIFF
--- a/src/bmp.imageio/bmp_pvt.h
+++ b/src/bmp.imageio/bmp_pvt.h
@@ -149,7 +149,8 @@ class BmpInput final : public ImageInput {
     virtual bool valid_file (const std::string &filename) const override;
     virtual bool open (const std::string &name, ImageSpec &spec) override;
     virtual bool close (void) override;
-    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_scanline (int subimage, int miplevel,
+                                       int y, int z, void *data) override;
  private:
     int m_padded_scanline_size;
     int m_pad_size;

--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -142,8 +142,13 @@ BmpInput::open (const std::string &name, ImageSpec &spec)
 
 
 bool
-BmpInput::read_native_scanline (int y, int z, void *data)
+BmpInput::read_native_scanline (int subimage, int miplevel,
+                                int y, int z, void *data)
 {
+    lock_guard lock (m_mutex);
+    if (! seek_subimage (subimage, miplevel))
+        return false;
+
     if (y < 0 || y > m_spec.height)
         return false;
 

--- a/src/cineon.imageio/cineoninput.cpp
+++ b/src/cineon.imageio/cineoninput.cpp
@@ -48,7 +48,8 @@ public:
     virtual const char * format_name (void) const override { return "cineon"; }
     virtual bool open (const std::string &name, ImageSpec &newspec) override;
     virtual bool close () override;
-    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_scanline (int subimage, int miplevel,
+                                       int y, int z, void *data) override;
 
 private:
     InStream *m_stream;
@@ -422,8 +423,13 @@ CineonInput::close ()
 
 
 bool
-CineonInput::read_native_scanline (int y, int z, void *data)
+CineonInput::read_native_scanline (int subimage, int miplevel,
+                                   int y, int z, void *data)
 {
+    lock_guard lock (m_mutex);
+    if (! seek_subimage (subimage, miplevel))
+        return false;
+
     cineon::Block block(0, y, m_cin.header.Width () - 1, y);
 
     // FIXME: un-hardcode the channel from 0

--- a/src/doc/imageinput.tex
+++ b/src/doc/imageinput.tex
@@ -871,20 +871,30 @@ current subimage.  Note that the contents of the spec are
 invalid before {\kw open()} or after {\kw close()}.
 \apiend
 
+\apiitem {ImageSpec {\ce spec} (int subimage, int miplevel=0) \\
+\apiitem {ImageSpec {\ce spec_dimensions} (int subimage, int miplevel=0)}
+\NEW % 1.9
+Both of these thread-safe methods return a copy of the \ImageSpec of the
+designated subimage/miplevel.
+
+The {\cf spec()} method returns a full copy of the \ImageSpec, including all
+metadata (which may be expensive).  The {\cf spec_dimensions()} method only
+copies the dimension fields but none of the arbitrary named metadata (just
+as with a call to {\cf ImageSpec::copy_dimensions()}), and thus is
+relatively inexpensive.
+\apiend
+
 \apiitem{bool {\ce close} ()}
 Closes an open image.
 \apiend
 
-
-\apiitem{int {\ce current_subimage} (void) const}
-Returns the index of the subimage that is currently being read.
-The first subimage (or the only subimage, if there is just one) is
-number 0.
+\apiitem{int {\ce current_subimage} (void) const \\
+int {\ce current_miplevel} (void) const}
+Returns the index of the subimage and MIP level, respectively, that is
+currently being read. Subimage and MIP level index numbers begin with 0.
 \apiend
 
-
 \apiitem{bool {\ce seek_subimage} (int subimage, int miplevel, ImageSpec \&newspec)}
-
 Seek to the given subimage and MIP-map level within the open image file.
 The first subimage in the file has index 0, and for each subimage, the
 highest-resolution MIP level has index 0.  Return {\kw true} on success,
@@ -896,7 +906,6 @@ appearance of random access to subimages and MIP levels --- in other
 words, if it can't randomly seek to the given subimage or MIP level, it
 should transparently close, reopen, and sequentially read through prior
 subimages and levels.
-
 \apiend
 
 \apiitem{bool {\ce read_scanline} (int y, int z, TypeDesc format, void *data,\\

--- a/src/doc/imageinput.tex
+++ b/src/doc/imageinput.tex
@@ -621,15 +621,18 @@ pixel.  Instead, \ImageInput has three special member functions used
 only for reading deep data:
 
 \begin{code}
-    bool read_native_deep_scanlines (int ybegin, int yend, int z,
+    bool read_native_deep_scanlines (int subimage, int miplevel,
+                                     int ybegin, int yend, int z,
                                      int chbegin, int chend,
                                      DeepData &deepdata);
 
-    bool read_native_deep_tiles (int xbegin, int xend, int ybegin, int yend,
+    bool read_native_deep_tiles (int subimage, int miplevel,
+                                 int xbegin, int xend, int ybegin int yend,
                                  int zbegin, int zend,
                                  int chbegin, int chend, DeepData &deepdata);
 
-    bool read_native_deep_image (DeepData &deepdata);
+    bool read_native_deep_image (int subimage, int miplevel,
+                                 DeepData &deepdata);
 \end{code}
 
 It is only possible to read ``native'' data types from deep files; that
@@ -648,7 +651,7 @@ a file and print all its values:
     const ImageSpec &spec = in->spec();
     if (spec.deep) {
         DeepData deepdata;
-        in->read_native_deep_image (deepdata);
+        in->read_native_deep_image (0, 0, deepdata);
         int p = 0;  // absolute pixel number
         for (int y = 0; y < spec.height;  ++y) {
             for (int x = 0;  x < spec.width;  ++x, ++p) {
@@ -923,21 +926,39 @@ This simplified version of {\kw read_scanline()} reads to contiguous
 float pixels.
 \apiend
 
-\apiitem{bool {\ce read_scanlines} (int ybegin, int yend, int z,\\
-  \bigspc TypeDesc format, void *data,\\
-  \bigspc stride_t xstride=AutoStride, stride_t ystride=AutoStride) \\
-bool {\ce read_scanlines} (int ybegin, int yend, int z,\\
+\apiitem{bool {\ce read_scanlines} (int subimage, int miplevel \\
+  \bigspc int ybegin, int yend, int z,\\
   \bigspc int chbegin, int chend, TypeDesc format, void *data,\\
   \bigspc                      stride_t xstride=AutoStride, stride_t ystride=AutoStride)}
 
-Read all the scanlines that include pixels $(*,y,z)$, where
-$\mathit{ybegin} \le y < \mathit{yend}$, into {\kw data}.  This is 
-essentially identical to \readscanline, except that can read more than
-one scanline at a time, which may be more efficient for certain image
-format readers.
+Read from the specified subimage and MIP level all the scanlines that
+include pixels $(*,y,z)$, where $\mathit{ybegin} \le y < \mathit{yend}$, and
+the given channel subset {\kw chbegin} $\le c <$ {\kw chend}, into
+{\kw data}, converting if necessary from the file's native data format to
+the specified buffer {\kw format}.
+If {\cf format} is {\cf TypeDesc::UNKNOWN}, the data will be preserved
+in its native format (including per-channel formats, if applicable).
+The stride values
+give the data spacing of adjacent pixels and scanlines,
+respectively (measured in bytes).  Strides set to the special
+value of {\kw AutoStride} imply contiguous data in the shape of
+the region specified, i.e., \\
+\spc {\kw xstride} $=$ {\kw spec.pixel_size() * (chend - chbegin)} \\
+\spc {\kw ystride} $=$ {\kw xstride * (xend - xbegin)} \\
 
-The version that specifies a channel range will read only
-channels $[${\cf chbegin},{\cf chend}$)$ into the buffer.
+This function returns {\cf true} if it successfully reads the scanlines,
+otherwise {\cf false} for a failure.
+
+This function is guaranteed to be thread-safe against other concurrent calls
+to the {\cf read_tiles()} or {\cf read_scanlines()} varieties that takes
+explicit subimage and miplevel (but not necessarily against any other
+\ImageInput methods).
+
+\NEW % 1.9
+This call was changed for \OpenImageIO 1.9 to include the explicit subimage
+and miplevel parameters. The previous versions, which lacked subimage and
+miplevel parameters (thus were dependent on a prior call to
+{\cf seek_subimage}) are considered deprecated.
 \apiend
 
 
@@ -978,19 +999,16 @@ Simple version of {\kw read_tile} that reads to contiguous float pixels.
 \apiend
 
 
-\apiitem{bool {\ce read_tiles} (int xbegin, int xend, int ybegin, int
-  yend, \\ \bigspc int zbegin, int zend, TypeDesc format,
-                            void *data, \\ \bigspc stride_t xstride=AutoStride,
-                            stride_t ystride=AutoStride, \\ \bigspc stride_t
-                            zstride=AutoStride) \\
-bool {\ce read_tiles} (int xbegin, int xend, int ybegin, int yend, \\
- \bigspc int zbegin, int zend, int chbegin, int chend,\\
- \bigspc TypeDesc format, void *data, \\ 
- \bigspc stride_t xstride=AutoStride, stride_t ystride=AutoStride, \\
- \bigspc stride_t zstride=AutoStride)}
+\apiitem{bool {\ce read_tiles} (int subimage, int miplevel, \\
+         \bigspc int xbegin, int xend, int ybegin, int yend, \\
+         \bigspc int zbegin, int zend, int chbegin, int chend,\\
+         \bigspc TypeDesc format, void *data, \\
+         \bigspc stride_t xstride=AutoStride, stride_t ystride=AutoStride, \\
+         \bigspc stride_t zstride=AutoStride)}
 Read the tiles bounded by {\kw xbegin} $\le x <$ {\kw xend},
-{\kw ybegin} $\le y <$ {\kw yend}, {\kw zbegin} $\le z <$ {\kw zend}
-into {\kw data}
+{\kw ybegin} $\le y <$ {\kw yend}, {\kw zbegin} $\le z <$ {\kw zend},
+and the given channel subset {\kw chbegin} $\le c <$ {\kw chend},
+into {\kw data},
 converting if necessary from the file's native data format into
 the specified buffer {\kw format}.
 If {\cf format} is {\cf TypeDesc::UNKNOWN}, the data will be preserved 
@@ -1000,7 +1018,7 @@ give the data spacing of adjacent pixels, scanlines, and volumetric
 slices, respectively (measured in bytes).  Strides set to the special
 value of {\kw AutoStride} imply contiguous data in the shape of
 the region specified, i.e., \\
-\spc {\kw xstride} $=$ {\kw spec.nchannels * spec.pixel_size()} \\
+\spc {\kw xstride} $=$ {\kw spec.pixel_size() * (chend - chbegin)} \\
 \spc {\kw ystride} $=$ {\kw xstride * (xend - xbegin)} \\
 \spc {\kw zstride} $=$ {\kw ystride * (yend - ybegin)} \\
 The \ImageInput is expected to give the appearance of random access
@@ -1016,8 +1034,16 @@ The call will fail if the image is not tiled, or if the pixel ranges
 do not fall along tile (or image) boundaries, or if it is not a valid
 tile range.
 
-The version that specifies a channel range will read only
-channels $[${\cf chbegin},{\cf chend}$)$ into the buffer.
+This function is guaranteed to be thread-safe against other concurrent calls
+to the {\cf read_tiles()} or {\cf read_scanlines()} varieties that takes
+explicit subimage and miplevel (but not necessarily against any other
+\ImageInput methods).
+
+\NEW % 1.9
+This call was changed for \OpenImageIO 1.9 to include the explicit subimage
+and miplevel parameters. The previous versions, which lacked subimage and
+miplevel parameters (thus were dependent on a prior call to
+{\cf seek_subimage}) are considered deprecated.
 \apiend
 
 
@@ -1027,7 +1053,7 @@ channels $[${\cf chbegin},{\cf chend}$)$ into the buffer.
                              \bigspc stride_t zstride=AutoStride, \\
                              \bigspc ProgressCallback progress_callback=NULL,\\
                              \bigspc void *progress_callback_data=NULL) \\
-bool {\ce read_image} (int chbegin, int chend, \\
+bool {\ce read_image} (int subimage, int miplevel, int chbegin, int chend, \\
                              \bigspc TypeDesc format, void *data, \\
                              \bigspc stride_t xstride=AutoStride,
                              stride_t ystride=AutoStride, \\
@@ -1063,13 +1089,22 @@ Periodically, it will be called as follows:\\
 \end{code}
 \noindent where \emph{done} gives the portion of the image 
 (between 0.0 and 1.0) that has been read thus far.
+
+\NEW % 1.9
+The version of {\cf read_image} that takes explicit subimage and
+miplevel parameters is guaranteed to be thread-safe against other concurrent
+calls to the {\cf read_scanlines()}, {\cf read_tiles()}, or
+{\cf read_image()} varieties that take an explicit
+subimage and miplevel (but not necessarily against any other \ImageInput
+methods).
 \apiend
 
 \apiitem{bool {\ce read_image} (float *data)}
 Simple version of {\kw read_image()} reads to contiguous float pixels.
 \apiend
 
-\apiitem{bool {\ce read_native_scanline} (int y, int z, void *data)}
+\apiitem{bool {\ce read_native_scanline} (int subimage, int miplevel,\\
+    \bigspc int y, int z, void *data)}
 The {\kw read_native_scanline()} function is just like {\kw
   read_scanline()}, except that it keeps the data in the native format
 of the disk file and always reads into contiguous memory (no strides).
@@ -1078,7 +1113,8 @@ with the data.  IT IS EXPECTED THAT EACH FORMAT PLUGIN WILL OVERRIDE
 THIS METHOD.
 \apiend
 
-\apiitem{bool {\ce read_native_scanlines} (int ybegin, int yend, int z, void *data)}
+\apiitem{bool {\ce read_native_scanlines} (int subimage, int miplevel,\\
+    \bigspc int ybegin, int yend, int z, void *data)}
 The {\kw read_native_scanlines()} function is just like 
 {\cf read_native_scanline}, except that it reads
 a range of scanlines rather than only one scanline.  It is not necessary
@@ -1089,8 +1125,8 @@ override this method if there is a way to achieve higher performance by
 reading multiple scanlines at once.
 \apiend
 
-\apiitem{bool {\ce read_native_scanlines} (int ybegin, int yend, int z,
-\\ \bigspc  int chbegin, int chend, void *data)}
+\apiitem{bool {\ce read_native_scanlines} (int subimage, int miplevel,\\
+    \bigspc int ybegin, int yend, int z, int chbegin, int chend, void *data)}
 A variant of {\cf read_native_scanlines} that reads only a subset of 
 channels \\ $[${\cf chbegin},{\cf chend}$)$.  
 If a format reader subclass does
@@ -1099,7 +1135,8 @@ call the all-channel version of {\cf read_native_scanlines} into a
 temporary buffer and copy the subset of channels.
 \apiend
 
-\apiitem{bool {\ce read_native_tile} (int x, int y, int z, void *data)}
+\apiitem{bool {\ce read_native_tile} (int subimage, int miplevel,\\
+    \bigspc int x, int y, int z, void *data)}
 The {\kw read_native_tile()} function is just like {\kw read_tile()}, 
 except that it keeps the data in the native format of the disk file and
 always read into contiguous memory (no strides).  It's up to the user to
@@ -1108,7 +1145,8 @@ EXPECTED THAT EACH FORMAT PLUGIN WILL OVERRIDE THIS METHOD IF IT
 SUPPORTS TILED IMAGES.
 \apiend
 
-\apiitem{bool {\ce read_native_tiles} (int xbegin, int xend, int ybegin,
+\apiitem{bool {\ce read_native_tiles} (int subimage, int miplevel,\\
+    \bigspc int xbegin, int xend, int ybegin,
   int yend, \\ \bigspc int zbegin, int zend, void *data)}
 The {\kw read_native_tiles()} function is just like {\kw read_tiles()}, 
 except that it keeps the data in the native format of the disk file and
@@ -1118,8 +1156,9 @@ implementation it will simply be a loop calling read_native_tile
 for each tile in the block.
 \apiend
 
-\apiitem{bool {\ce read_native_tiles} (int xbegin, int xend, int ybegin,
-  int yend, \\ \bigspc int zbegin, int zend, int chbegin, int chend, void *data)}
+\apiitem{bool {\ce read_native_tiles} (int subimage, int miplevel,\\
+    \bigspc int xbegin, int xend, int ybegin, int yend, \\
+    \bigspc int zbegin, int zend, int chbegin, int chend, void *data)}
 A variant of {\kw read_native_tiles()} that reads only a subset of 
 channels \\ $[${\cf chbegin},{\cf chend}$)$.  
 If a format reader subclass does
@@ -1128,20 +1167,20 @@ call the all-channel version of {\cf read_native_tiles} into a
 temporary buffer and copy the subset of channels.
 \apiend
 
-\apiitem{bool {\ce read_native_deep_scanlines} (int ybegin, int yend, int z,
- \\ \bigspc   int chbegin, int chend, DeepData \&deepdata) \\
-bool {\ce read_native_deep_tiles} (int xbegin, int xend,
-                                         int ybegin, int yend, \\ \bigspc
-                                         int zbegin, int zend,
-                                         int chbegin, int chend,
-                                         DeepData \&deepdata) \\
-bool {\ce read_native_deep_image} (DeepData \&deepdata)}
+\apiitem{bool {\ce read_native_deep_scanlines} (int subimage, int miplevel,
+ \\ \bigspc   int ybegin, int yend, int z, int chbegin, int chend, \\
+ \\ bigspc     DeepData \&deepdata) \\
+bool {\ce read_native_deep_tiles} (int subimage, int miplevel, \\
+    \bigspc int xbegin, int xend, int ybegin, int yend, \\
+    \bigspc int zbegin, int zend, int chbegin, int chend, DeepData \&deepdata) \\
+bool {\ce read_native_deep_image} (int subimage, int miplevel, DeepData \&deepdata)}
 Read native deep data from scanlines, tiles, or an entire image, 
 storing the results in {\cf deepdata} (analogously to the usual
-{\cf read_scanlines}, {\cf read_tiles},
-and {\cf read_image}, but with deep data).
-Only channels $[${\cf chbegin},{\cf chend}$)$
-will be read.
+{\cf read_scanlines}, {\cf read_tiles}, and {\cf read_image}, but with deep data).
+Only channels $[${\cf chbegin},{\cf chend}$)$ will be read.
+Note that for the scanline variety, the {\cf roi}'s $x$ range must specify
+the complete width of the image, and the $z$ range must be a single plane.
+For the tile variety, the {\cf roi} must specify a whole number of tiles.
 \apiend
 
 \apiitem{int {\ce send_to_input} (const char *format, ...)}

--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -728,6 +728,12 @@ for an \ImageSpec with lots of metadata, it is much less expensive than
 copying the whole thing with {\cf operator=()}).
 \apiend
 
+\apiitem{bool {\ce undefined} () const}
+\NEW % 1.9
+Returns {\cf true} for a newly initialized (undefined) \ImageSpec.
+\apiend
+
+
 % FIXME - document auto_stride() ?
 
 \apiitem{void {\ce attribute} (string_view name, TypeDesc type, \\

--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -720,6 +720,13 @@ window, respectively. Note that the channel range of the \ROI is ignored,
 i.e., these methods do not modify the {\cf nchannels} field of the \ImageSpec.
 \apiend
 
+\apiitem{void {\ce copy_dimensions} (const ImageSpec &other)}
+\NEW % 1.9
+Copies from {\cf other} only the fields describing the dimensions and
+data types, and \emph{not} arbitrary named metadata or channel names (thus,
+for an \ImageSpec with lots of metadata, it is much less expensive than
+copying the whole thing with {\cf operator=()}).
+\apiend
 
 % FIXME - document auto_stride() ?
 

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -95,7 +95,7 @@
  \bigskip \\
 }
 \date{{\large
-Date: 23 Feb 2018
+Date: 23 Mar 2018
 \\ (with corrections, 19 Mar 2018)
 }}
 

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -95,8 +95,8 @@
  \bigskip \\
 }
 \date{{\large
-Date: 23 Mar 2018
-\\ (with corrections, 19 Mar 2018)
+Date: 7 Apr 2018
+%\\ (with corrections, 19 Mar 2018)
 }}
 
 

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -588,6 +588,11 @@ Returns {\cf True} if the given tile range exactly covers a set of tiles, or
 {\cf False} if it isn't (or if the image is not tiled).
 \apiend
 
+\apiitem{ImageSpec.{\ce copy_dimensions} (other)}
+\NEW % 1.9
+Copies from \ImageSpec {\cf other} only the fields describing the size
+and data types, but not the arbitrary named metadata or channel names.
+\apiend
 
 \newpage
 \subsection*{Example: Header info}
@@ -884,8 +889,9 @@ specified subimage or MIP level).
 \end{code}
 \apiend
 
-\apiitem{ImageInput.{\ce read_image} (type="float") \\
-ImageInput.{\ce read_image} (chbegin, chend, type="float")}
+\apiitem{ImageInput.{\ce read_image} (format="float") \\
+ImageInput.{\ce read_image} (chbegin, chend, format="float") \\
+ImageInput.{\ce read_image} (subimage, miplevel, chbegin, chend, format="float")}
 
 Read the entire image and return the pixels as a NumPy array of values of
 the given {\cf type} (described by a \TypeDesc or a string, float by
@@ -908,7 +914,7 @@ For a normal (2D) image, the array returned will be 3D indexed as
 \end{code}
 \apiend
 
-\apiitem{ndarray ImageInput.{\ce read_scanline} (y, z, type="float")}
+\apiitem{ndarray ImageInput.{\ce read_scanline} (y, z, format="float")}
 Read scanline number {\cf y} from depth plane {\cf z} from the open file,
 returning the pixels as a NumPy array of values of
 the given {\cf type} (described by a \TypeDesc or a string, float by
@@ -932,7 +938,7 @@ The pixel array returned be 2D, indexed as {\cf [x][channel]}.
 \end{code}
 \apiend
 
-\apiitem{ndarray ImageInput.{\ce read_tile} (x, y, z, type="float")}
+\apiitem{ndarray ImageInput.{\ce read_tile} (x, y, z, format="float")}
 Read the tile whose upper left corner is pixel {\cf (x,y,z)} from the open
 file, returning the pixels as a NumPy array of values of
 the given {\cf type} (described by a \TypeDesc or a string, float by
@@ -960,10 +966,14 @@ returned will be 4D with shape indexed as {\cf [z][y][x][channel]}.
 \end{code}
 \apiend
 
-\apiitem{ndarray ImageInput.{\ce read_scanlines} (ybegin, yend, z, chbegin, chend, \\
-\bigspc\bigspc\spc type="float") \\
-array ImageInput.{\ce read_tiles} (xbegin, xend, ybegin, yend, zbegin, zend, \\
-    \bigspc\bigspc\spc chbegin, chend, type="float")}
+\apiitem{ndarray ImageInput.{\ce read_scanlines} (subimage, miplevel, \\
+\bigspc\bigspc\spc ybegin, yend, z, chbegin, chend, format="float") \\
+ndarray ImageInput.{\ce read_scanlines} (ybegin, yend, z, chbegin, chend, \\
+\bigspc\bigspc\spc format="float") \\
+ndarray ImageInput.{\ce read_tiles} (xbegin, xend, ybegin, yend, zbegin, zend, \\
+    \bigspc\bigspc\spc chbegin, chend, format="float") \\
+ndarray ImageInput.{\ce read_tiles} (subimage, miplevel, \\
+    \bigspc\bigspc\spc xbegin, xend, ybegin, yend, zbegin, zend, format="float")}
 Similar to the C++ routines, these functions read multiple scanlines or
 tiles at once, which in some cases may be more efficient than reading
 each scanline or tile separately.  Additionally, they allow you to read only
@@ -995,15 +1005,20 @@ array indexed as {\cf [z][y][x][channel]},
 \end{code}
 \apiend
 
-\apiitem{DeepData ImageInput.{\ce read_native_deep_scanlines} (ybegin, yend, z,\\
-\bigspc\bigspc chbegin, chend) \\
-DeepData ImageInput.{\ce read_native_deep_tiles} (xbegin, xend, ybegin, yend,\\
-\bigspc\bigspc zbegin, zend, chbegin, chend) \\
-DeepData ImageInput.{\ce read_native_deep_image} (chbegin, chend)}
-
+\apiitem{DeepData ImageInput.{\ce read_native_deep_scanlines} (subimage, miplevel, \\
+\bigspc\bigspc ybegin, yend, z, chbegin, chend) \\
+DeepData ImageInput.{\ce read_native_deep_tiles} (subimage, miplevel, \\
+\bigspc\bigspc xbegin, xend, ybegin, yend, zbegin, zend, chbegin, chend) \\
+DeepData ImageInput.{\ce read_native_deep_image} (subimage=0, miplevel=0)}
+\NEW % 1.9
 Read a collection of scanlines, tiles, or an entire image of ``deep'' pixel
-data. The begin/end coordinates are all integer values. The value returned
-will be a \DeepData if the read succeeds, or {\cf None} if the read fails.
+data from the specified subimage and MIP level. The begin/end coordinates
+are all integer values. The value returned will be a \DeepData if the read
+succeeds, or {\cf None} if the read fails.
+
+These methods are guaranteed to be thread-safe against simultaneous calls to
+any of the other other {\cf read_native} calls that take an explicit
+subimage/miplevel.
 \apiend
 
 \apiitem{str ImageInput.{\ce geterror} ()}

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -592,6 +592,10 @@ Returns {\cf True} if the given tile range exactly covers a set of tiles, or
 \NEW % 1.9
 Copies from \ImageSpec {\cf other} only the fields describing the size
 and data types, but not the arbitrary named metadata or channel names.
+
+\apiitem{ImageSpec.{\ce undefined}()}
+\NEW % 1.9
+Returns {\cf True} for a newly initialized (undefined) \ImageSpec.
 \apiend
 
 \newpage
@@ -863,6 +867,16 @@ MIP level of the file.
     spec = input.spec()
     print "resolution ", spec.width, "x", spec.height
 \end{code}
+\apiend
+
+\apiitem{ImageSpec ImageInput.{\ce spec} (subimage, miplevel=0) \\
+ImageSpec ImageInput.{\ce spec_dimensions} (subimage, miplevel=0)}
+\NEW % 1.9
+Returns a copy of the \ImageSpec corresponding to the designated subimage
+and MIP level. Note that {\cf spec()} copies the entire \ImageSpec including
+all metadata, whereas {\cf spec_dimensions()} only copies the dimension
+fields and not any of the arbitrary named metadata (and is thus much less
+expensive).
 \apiend
 
 \apiitem{int ImageInput.{\ce current_subimage} () \\

--- a/src/field3d.imageio/field3dinput.cpp
+++ b/src/field3d.imageio/field3dinput.cpp
@@ -65,10 +65,15 @@ public:
     virtual bool valid_file (const std::string &filename) const override;
     virtual bool open (const std::string &name, ImageSpec &newspec) override;
     virtual bool close () override;
-    virtual int current_subimage (void) const override { return m_subimage; }
-    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) override;
-    virtual bool read_native_scanline (int y, int z, void *data) override;
-    virtual bool read_native_tile (int x, int y, int z, void *data) override;
+    virtual int current_subimage (void) const override {
+        lock_guard lock (m_mutex);
+        return m_subimage;
+    }
+    virtual bool seek_subimage (int subimage, int miplevel) override;
+    virtual bool read_native_scanline (int subimage, int miplevel,
+                                       int y, int z, void *data) override;
+    virtual bool read_native_tile (int subimage, int miplevel,
+                                   int x, int y, int z, void *data) override;
 
     /// Transform a world space position to local coordinates, using the
     /// mapping of the current subimage.
@@ -415,13 +420,16 @@ Field3DInput::open (const std::string &name, ImageSpec &newspec)
     }
 
     m_nsubimages = (int) m_layers.size();
-    return seek_subimage (0, 0, newspec);
+
+    bool ok = seek_subimage (0, 0);
+    newspec = spec();
+    return ok;
 }
 
 
 
 bool
-Field3DInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
+Field3DInput::seek_subimage (int subimage, int miplevel)
 {
     if (subimage < 0 || subimage >= m_nsubimages)   // out of range
         return false;
@@ -430,7 +438,6 @@ Field3DInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
 
     m_subimage = subimage;
     m_spec = m_layers[subimage].spec;
-    newspec = m_spec;
     return true;
 }
 
@@ -454,7 +461,8 @@ Field3DInput::close ()
 
 
 bool
-Field3DInput::read_native_scanline (int y, int z, void *data)
+Field3DInput::read_native_scanline (int subimage, int miplevel,
+                                    int y, int z, void *data)
 {
     // scanlines not supported
     return false;
@@ -509,9 +517,12 @@ bool Field3DInput::readtile (int x, int y, int z, T *data)
 
 
 bool
-Field3DInput::read_native_tile (int x, int y, int z, void *data)
+Field3DInput::read_native_tile (int subimage, int miplevel,
+                                int x, int y, int z, void *data)
 {
     spin_lock lock (field3d_mutex());
+    if (! seek_subimage (subimage, miplevel))
+        return false;
     layerrecord &lay (m_layers[m_subimage]);
     if (lay.datatype == TypeDesc::FLOAT) {
         if (lay.vecfield)

--- a/src/fits.imageio/fits_pvt.h
+++ b/src/fits.imageio/fits_pvt.h
@@ -77,8 +77,9 @@ class FitsInput final : public ImageInput {
     virtual bool valid_file (const std::string &filename) const override;
     virtual bool open (const std::string &name, ImageSpec &spec) override;
     virtual bool close (void) override;
-    virtual bool read_native_scanline (int y, int z, void *data) override;
-    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) override;
+    virtual bool read_native_scanline (int subimage, int miplevel,
+                                       int y, int z, void *data) override;
+    virtual bool seek_subimage (int subimage, int miplevel) override;
     virtual int current_subimage () const override { return m_cur_subimage; }
  private:
     FILE *m_fd;

--- a/src/fits.imageio/fitsinput.cpp
+++ b/src/fits.imageio/fitsinput.cpp
@@ -111,8 +111,13 @@ FitsInput::open (const std::string &name, ImageSpec &spec)
 
 
 bool
-FitsInput::read_native_scanline (int y, int z, void *data)
+FitsInput::read_native_scanline (int subimage, int miplevel,
+                                 int y, int z, void *data)
 {
+    lock_guard lock (m_mutex);
+    if (! seek_subimage (subimage, miplevel))
+        return false;
+
     // we return true just to support 0x0 images
     if (!m_naxes)
         return true;
@@ -156,7 +161,7 @@ FitsInput::read_native_scanline (int y, int z, void *data)
 
 
 bool
-FitsInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
+FitsInput::seek_subimage (int subimage, int miplevel)
 {
     if (miplevel != 0)
         return false;
@@ -164,7 +169,6 @@ FitsInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
         return false;
 
     if (subimage == m_cur_subimage) {
-        newspec = m_spec;
         return true;
     }
 
@@ -175,7 +179,6 @@ FitsInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
     if (! set_spec_info ())
         return false;
 
-    newspec = m_spec;
     return true;
 }
 

--- a/src/iff.imageio/iff_pvt.h
+++ b/src/iff.imageio/iff_pvt.h
@@ -142,8 +142,10 @@ public:
     virtual const char *format_name (void) const override { return "iff"; }
     virtual bool open (const std::string &name, ImageSpec &spec) override;
     virtual bool close (void) override;
-    virtual bool read_native_scanline (int y, int z, void *data) override;
-    virtual bool read_native_tile (int x, int y, int z, void *data) override;
+    virtual bool read_native_scanline (int subimage, int miplevel,
+                                       int y, int z, void *data) override;
+    virtual bool read_native_tile (int subimage, int miplevel,
+                                   int x, int y, int z, void *data) override;
 private:
     FILE *m_fd;
     std::string m_filename;

--- a/src/iff.imageio/iffinput.cpp
+++ b/src/iff.imageio/iffinput.cpp
@@ -147,7 +147,8 @@ IffInput::open (const std::string &name, ImageSpec &spec)
 
 
 bool
-IffInput::read_native_scanline (int y, int z, void *data)
+IffInput::read_native_scanline (int subimage, int miplevel,
+                                int y, int z, void *data)
 {
     // scanline not used for Maya IFF, uses tiles instead.
     return false;
@@ -156,8 +157,13 @@ IffInput::read_native_scanline (int y, int z, void *data)
 
 
 bool
-IffInput::read_native_tile (int x, int y, int z, void *data)
+IffInput::read_native_tile (int subimage, int miplevel,
+                            int x, int y, int z, void *data)
 {
+    lock_guard lock (m_mutex);
+    if (! seek_subimage (subimage, miplevel))
+        return false;
+
     if (m_buf.empty ())
         readimg ();
 

--- a/src/include/OpenImageIO/oiioversion.h.in
+++ b/src/include/OpenImageIO/oiioversion.h.in
@@ -96,7 +96,8 @@ namespace @PROJ_NAME@ = @PROJ_NAMESPACE_V@;
 /// Version 20 added FMT_imageio_library_version() to plugins. (OIIO 1.7)
 /// Version 21 changed the signatures of ImageInput methods: added
 ///     subimage,miplevel params to many read_*() methods; changed thread
-///     safety expectations; removed newspec param from seek_subimage.
+///     safety expectations; removed newspec param from seek_subimage;
+///     added spec(subimage,miplevel) and spec_dimensions(subimage,miplevel).
 ///     (OIIO 1.9)
 
 #define OIIO_PLUGIN_VERSION 21

--- a/src/include/OpenImageIO/oiioversion.h.in
+++ b/src/include/OpenImageIO/oiioversion.h.in
@@ -94,8 +94,12 @@ namespace @PROJ_NAME@ = @PROJ_NAMESPACE_V@;
 /// Version 18 changed to add an m_threads member to ImageInput/Output.
 /// Version 19 changed the definition of DeepData.
 /// Version 20 added FMT_imageio_library_version() to plugins. (OIIO 1.7)
+/// Version 21 changed the signatures of ImageInput methods: added
+///     subimage,miplevel params to many read_*() methods; changed thread
+///     safety expectations; removed newspec param from seek_subimage.
+///     (OIIO 1.9)
 
-#define OIIO_PLUGIN_VERSION 20
+#define OIIO_PLUGIN_VERSION 21
 
 #define OIIO_PLUGIN_NAMESPACE_BEGIN OIIO_NAMESPACE_BEGIN
 #define OIIO_PLUGIN_NAMESPACE_END OIIO_NAMESPACE_END

--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -82,7 +82,8 @@ class JpgInput final : public ImageInput {
     virtual bool open (const std::string &name, ImageSpec &spec) override;
     virtual bool open (const std::string &name, ImageSpec &spec,
                        const ImageSpec &config) override;
-    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_scanline (int subimage, int miplevel,
+                                       int y, int z, void *data) override;
     virtual bool close () override;
     const std::string &filename () const { return m_filename; }
     void * coeffs () const { return m_coeffs; }

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -406,8 +406,11 @@ cmyk_to_rgb (int n, const unsigned char *cmyk, size_t cmyk_stride,
 
 
 bool
-JpgInput::read_native_scanline (int y, int z, void *data)
+JpgInput::read_native_scanline (int subimage, int miplevel,
+                                int y, int z, void *data)
 {
+    if (! seek_subimage (subimage, miplevel))
+        return false;
     if (m_raw)
         return false;
     if (y < 0 || y >= (int)m_cinfo.output_height)   // out of range scanline
@@ -419,7 +422,7 @@ JpgInput::read_native_scanline (int y, int z, void *data)
         int subimage = current_subimage();
         if (! close ()  ||
             ! open (m_filename, dummyspec)  ||
-            ! seek_subimage (subimage, 0, dummyspec))
+            ! seek_subimage (subimage, 0))
             return false;    // Somehow, the re-open failed
         assert (m_next_scanline == 0 && current_subimage() == subimage);
     }

--- a/src/jpeg2000.imageio/jpeg2000input-v1.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input-v1.cpp
@@ -94,7 +94,8 @@ class Jpeg2000Input final : public ImageInput {
     virtual bool open (const std::string &name, ImageSpec &newspec,
                        const ImageSpec &config) override;
     virtual bool close (void) override;
-    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_scanline (int subimage, int miplevel,
+                                       int y, int z, void *data) override;
 
  private:
     std::string m_filename;
@@ -309,8 +310,13 @@ Jpeg2000Input::open (const std::string &name, ImageSpec &newspec,
 
 
 bool
-Jpeg2000Input::read_native_scanline (int y, int z, void *data)
+Jpeg2000Input::read_native_scanline (int subimage, int miplevel,
+                                     int y, int z, void *data)
 {
+    lock_guard lock (m_mutex);
+    if (! seek_subimage (subimage, miplevel))
+        return false;
+
     if (m_spec.format == TypeDesc::UINT8)
         read_scanline<uint8_t>(y, z, data);
     else

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -110,7 +110,8 @@ class Jpeg2000Input final : public ImageInput {
     virtual bool open (const std::string &name, ImageSpec &newspec,
                        const ImageSpec &config) override;
     virtual bool close (void) override;
-    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_scanline (int subimage, int miplevel,
+                                       int y, int z, void *data) override;
 
  private:
 
@@ -324,8 +325,13 @@ Jpeg2000Input::open (const std::string &name, ImageSpec &newspec,
 
 
 bool
-Jpeg2000Input::read_native_scanline (int y, int z, void *data)
+Jpeg2000Input::read_native_scanline (int subimage, int miplevel,
+                                     int y, int z, void *data)
 {
+    lock_guard lock (m_mutex);
+    if (! seek_subimage (subimage, miplevel))
+        return false;
+
     if (m_spec.format == TypeDesc::UINT8)
         read_scanline<uint8_t>(y, z, data);
     else

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -786,12 +786,7 @@ ImageBufImpl::read (int subimage, int miplevel, int chbegin, int chend,
             return false;
         }
         input->threads (threads());  // Pass on our thread policy
-        ImageSpec dummyspec;
-        if (! input->seek_subimage (subimage, miplevel, dummyspec)) {
-            error ("%s", input->geterror());
-            return false;
-        }
-        if (! input->read_native_deep_image (m_deepdata)) {
+        if (! input->read_native_deep_image (subimage, miplevel, m_deepdata)) {
             error ("%s", input->geterror());
             return false;
         }

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -111,6 +111,8 @@ bool
 ImageInput::read_scanline (int y, int z, TypeDesc format, void *data,
                            stride_t xstride)
 {
+    lock_guard lock (m_mutex);
+
     // native_pixel_bytes is the size of a pixel in the FILE, including
     // the per-channel format.
     stride_t native_pixel_bytes = (stride_t) m_spec.pixel_bytes (true);
@@ -130,12 +132,14 @@ ImageInput::read_scanline (int y, int z, TypeDesc format, void *data,
     // If user's format and strides are set up to accept the native data
     // layout, read the scanline directly into the user's buffer.
     if (native_data && contiguous)
-        return read_native_scanline (y, z, data);
+        return read_native_scanline (current_subimage(), current_miplevel(),
+                                     y, z, data);
 
     // Complex case -- either changing data type or stride
     int scanline_values = m_spec.width * m_spec.nchannels;
     unsigned char *buf = (unsigned char *) alloca (m_spec.scanline_bytes(true));
-    bool ok = read_native_scanline (y, z, buf);
+    bool ok = read_native_scanline (current_subimage(), current_miplevel(),
+                                    y, z, buf);
     if (! ok)
         return false;
     if (! perchanfile) {
@@ -173,7 +177,9 @@ ImageInput::read_scanlines (int ybegin, int yend, int z,
                             TypeDesc format, void *data,
                             stride_t xstride, stride_t ystride)
 {
-    return read_scanlines (ybegin, yend, z, 0, m_spec.nchannels,
+    lock_guard lock (m_mutex);
+    return read_scanlines (current_subimage(), current_miplevel(),
+                           ybegin, yend, z, 0, m_spec.nchannels,
                            format, data, xstride, ystride);
 }
 
@@ -185,58 +191,87 @@ ImageInput::read_scanlines (int ybegin, int yend, int z,
                             TypeDesc format, void *data,
                             stride_t xstride, stride_t ystride)
 {
-    chend = clamp (chend, chbegin+1, m_spec.nchannels);
+    lock_guard lock (m_mutex);
+    return read_scanlines (current_subimage(), current_miplevel(),
+                           ybegin, yend, z, chbegin, chend,
+                           format, data, xstride, ystride);
+}
+
+
+
+bool
+ImageInput::read_scanlines (int subimage, int miplevel,
+                            int ybegin, int yend, int z,
+                            int chbegin, int chend,
+                            TypeDesc format, void *data,
+                            stride_t xstride, stride_t ystride)
+{
+    ImageSpec spec;
+    {
+        lock_guard lock (m_mutex);
+        if (! seek_subimage (subimage, miplevel))
+            return false;
+        // Copying the dimensions of the designated subimage/miplevel to a
+        // local `spec` means that we can release the lock!  (Calls to
+        // read_native_* will internally lock again if necessary.)
+        spec.copy_dimensions (m_spec);
+    }
+
+    chend = clamp (chend, chbegin+1, spec.nchannels);
     int nchans = chend - chbegin;
-    yend = std::min (yend, spec().y+spec().height);
-    size_t native_pixel_bytes = m_spec.pixel_bytes (chbegin, chend, true);
-    imagesize_t native_scanline_bytes = clamped_mult64 ((imagesize_t)m_spec.width,
+    yend = std::min (yend, spec.y+spec.height);
+    size_t native_pixel_bytes = spec.pixel_bytes (chbegin, chend, true);
+    imagesize_t native_scanline_bytes = clamped_mult64 ((imagesize_t)spec.width,
                                                         (imagesize_t)native_pixel_bytes);
     bool native = (format == TypeDesc::UNKNOWN);
     size_t pixel_bytes = native ? native_pixel_bytes : format.size()*nchans;
     if (native && xstride == AutoStride)
         xstride = pixel_bytes;
     stride_t zstride = AutoStride;
-    m_spec.auto_stride (xstride, ystride, zstride, format, nchans,
-                        m_spec.width, m_spec.height);
+    spec.auto_stride (xstride, ystride, zstride, format, nchans,
+                        spec.width, spec.height);
     bool contiguous = (xstride == (stride_t) native_pixel_bytes &&
                        ystride == (stride_t) native_scanline_bytes);
     // If user's format and strides are set up to accept the native data
     // layout, read the scanlines directly into the user's buffer.
     bool rightformat = (format == TypeDesc::UNKNOWN) ||
-        (format == m_spec.format && m_spec.channelformats.empty());
+        (format == spec.format && spec.channelformats.empty());
     if (rightformat && contiguous) {
-        if (chbegin == 0 && chend == m_spec.nchannels)
-            return read_native_scanlines (ybegin, yend, z, data);
+        if (chbegin == 0 && chend == spec.nchannels)
+            return read_native_scanlines (current_subimage(), current_miplevel(),
+                                          ybegin, yend, z, data);
         else
-            return read_native_scanlines (ybegin, yend, z, chbegin, chend, data);
+            return read_native_scanlines (current_subimage(), current_miplevel(),
+                                          ybegin, yend, z, chbegin, chend, data);
     }
 
     // No such luck.  Read scanlines in chunks.
 
     // Split into reasonable chunks -- try to use around 64 MB, but
     // round up to a multiple of the TIFF rows per strip (or 64).
-    int rps = m_spec.get_int_attribute ("tiff:RowsPerStrip", 64);
-    int chunk = std::max (1, (1<<26)/int(m_spec.scanline_bytes(true)));
+    int rps = spec.get_int_attribute ("tiff:RowsPerStrip", 64);
+    int chunk = std::max (1, (1<<26)/int(spec.scanline_bytes(true)));
     chunk = round_to_multiple (chunk, rps);
     std::unique_ptr<char[]> buf (new char [chunk * native_scanline_bytes]);
 
     bool ok = true;
-    int scanline_values = m_spec.width * nchans;
+    int scanline_values = spec.width * nchans;
     for (;  ok && ybegin < yend;  ybegin += chunk) {
         int y1 = std::min (ybegin+chunk, yend);
-        ok &= read_native_scanlines (ybegin, y1, z, chbegin, chend, &buf[0]);
+        ok &= read_native_scanlines (current_subimage(), current_miplevel(),
+                                     ybegin, y1, z, chbegin, chend, &buf[0]);
         if (! ok)
             break;
 
         int nscanlines = y1 - ybegin;
         int chunkvalues = scanline_values * nscanlines;
-        if (m_spec.channelformats.empty()) {
+        if (spec.channelformats.empty()) {
             // No per-channel formats -- do the conversion in one shot
             if (contiguous) {
-                ok = convert_types (m_spec.format, &buf[0], format, data, chunkvalues);
+                ok = convert_types (spec.format, &buf[0], format, data, chunkvalues);
             } else {
-                ok = parallel_convert_image (nchans, m_spec.width, nscanlines, 1, 
-                                    &buf[0], m_spec.format, AutoStride, AutoStride, AutoStride,
+                ok = parallel_convert_image (nchans, spec.width, nscanlines, 1,
+                                    &buf[0], spec.format, AutoStride, AutoStride, AutoStride,
                                     data, format, xstride, ystride, zstride,
                                     -1 /*alpha*/, -1 /*z*/, threads());
             }
@@ -245,14 +280,14 @@ ImageInput::read_scanlines (int ybegin, int yend, int z,
             size_t offset = 0;
             int n = 1;
             for (int c = 0;  ok && c < nchans; c += n) {
-                TypeDesc chanformat = m_spec.channelformats[c+chbegin];
+                TypeDesc chanformat = spec.channelformats[c+chbegin];
                 // Try to do more than one channel at a time to improve
                 // memory coherence, if there are groups of adjacent
                 // channels needing the same data conversion.
                 for (n = 1; c+n < nchans; ++n)
-                    if (m_spec.channelformats[c+chbegin+n] != chanformat)
+                    if (spec.channelformats[c+chbegin+n] != chanformat)
                         break;
-                ok = parallel_convert_image (n /* channels */, m_spec.width, nscanlines, 1, 
+                ok = parallel_convert_image (n /* channels */, spec.width, nscanlines, 1,
                                     &buf[offset], chanformat,
                                     native_pixel_bytes, AutoStride, AutoStride,
                                     (char *)data + c*format.size(),
@@ -263,7 +298,7 @@ ImageInput::read_scanlines (int ybegin, int yend, int z,
         }
         if (! ok)
             error ("ImageInput::read_scanlines : no support for format %s",
-                   m_spec.format.c_str());
+                   spec.format.c_str());
         data = (char *)data + ystride*nscanlines;
     }
     return ok;
@@ -272,16 +307,18 @@ ImageInput::read_scanlines (int ybegin, int yend, int z,
 
 
 bool
-ImageInput::read_native_scanlines (int ybegin, int yend, int z, void *data)
+ImageInput::read_native_scanlines (int subimage, int miplevel,
+                                   int ybegin, int yend, int z, void *data)
 {
     // Base class implementation of read_native_scanlines just repeatedly
     // calls read_native_scanline, which is supplied by every plugin.
     // Only the hardcore ones will overload read_native_scanlines with
     // their own implementation.
+    lock_guard lock (m_mutex);
     size_t ystride = m_spec.scanline_bytes (true);
     yend = std::min (yend, spec().y+spec().height);
     for (int y = ybegin;  y < yend;  ++y) {
-        bool ok = read_native_scanline (y, z, data);
+        bool ok = read_native_scanline (subimage, miplevel, y, z, data);
         if (! ok)
             return false;
         data = (char *)data + ystride;
@@ -292,26 +329,38 @@ ImageInput::read_native_scanlines (int ybegin, int yend, int z, void *data)
 
 
 bool
-ImageInput::read_native_scanlines (int ybegin, int yend, int z,
+ImageInput::read_native_scanlines (int subimage, int miplevel,
+                                   int ybegin, int yend, int z,
                                    int chbegin, int chend, void *data)
 {
+    ImageSpec spec;
+    {
+        lock_guard lock (m_mutex);
+        if (! seek_subimage (subimage, miplevel))
+            return false;
+        // Copying the dimensions of the designated subimage/miplevel to a
+        // local `spec` means that we can release the lock!  (Calls to
+        // read_native_* will internally lock again if necessary.)
+        spec.copy_dimensions (m_spec);
+    }
+
     // All-channel case just reduces to the simpler read_native_scanlines.
-    if (chbegin == 0 && chend >= m_spec.nchannels)
-        return read_native_scanlines (ybegin, yend, z, data);
+    if (chbegin == 0 && chend >= spec.nchannels)
+        return read_native_scanlines (subimage, miplevel, ybegin, yend, z, data);
 
     // Base class implementation of read_native_scanlines (with channel
     // subset) just calls read_native_scanlines (all channels), and
     // copies the appropriate subset.
-    size_t prefix_bytes = m_spec.pixel_bytes (0,chbegin,true);
-    size_t subset_bytes = m_spec.pixel_bytes (chbegin,chend,true);
-    size_t subset_ystride = m_spec.width * subset_bytes;
+    size_t prefix_bytes = spec.pixel_bytes (0,chbegin,true);
+    size_t subset_bytes = spec.pixel_bytes (chbegin,chend,true);
+    size_t subset_ystride = spec.width * subset_bytes;
 
     // Read all channels of the scanlines into a temp buffer.
-    size_t native_pixel_bytes = m_spec.pixel_bytes (true);
-    size_t native_ystride = m_spec.width * native_pixel_bytes;
+    size_t native_pixel_bytes = spec.pixel_bytes (true);
+    size_t native_ystride = spec.width * native_pixel_bytes;
     std::unique_ptr<char[]> buf (new char [native_ystride*(yend-ybegin)]);
-    yend = std::min (yend, spec().y+spec().height);
-    bool ok = read_native_scanlines (ybegin, yend, z, buf.get());
+    yend = std::min (yend, spec.y+spec.height);
+    bool ok = read_native_scanlines (subimage, miplevel, ybegin, yend, z, buf.get());
     if (! ok)
         return false;
 
@@ -321,7 +370,7 @@ ImageInput::read_native_scanlines (int ybegin, int yend, int z,
                   [&,subset_bytes,prefix_bytes,native_pixel_bytes](int64_t y){
         char *b = buf.get() + native_ystride * y;
         char *d = (char *)data + subset_ystride * y;
-        for (int x = 0;  x < m_spec.width;  ++x)
+        for (int x = 0;  x < spec.width;  ++x)
             memcpy (d + subset_bytes*x,
                     &b[prefix_bytes+native_pixel_bytes*x], subset_bytes);
     });
@@ -334,6 +383,7 @@ bool
 ImageInput::read_tile (int x, int y, int z, TypeDesc format, void *data,
                        stride_t xstride, stride_t ystride, stride_t zstride)
 {
+    lock_guard lock (m_mutex);
     if (! m_spec.tile_width ||
         ((x-m_spec.x) % m_spec.tile_width) != 0 ||
         ((y-m_spec.y) % m_spec.tile_height) != 0 ||
@@ -361,13 +411,15 @@ ImageInput::read_tile (int x, int y, int z, TypeDesc format, void *data,
     // If user's format and strides are set up to accept the native data
     // layout, read the tile directly into the user's buffer.
     if (native_data && contiguous)
-        return read_native_tile (x, y, z, data);  // Simple case
+        return read_native_tile (current_subimage(), current_miplevel(),
+                                 x, y, z, data);  // Simple case
 
     // Complex case -- either changing data type or stride
     size_t tile_values = (size_t)m_spec.tile_pixels() * m_spec.nchannels;
 
     std::unique_ptr<char[]> buf (new char [m_spec.tile_bytes(true)]);
-    bool ok = read_native_tile (x, y, z, &buf[0]);
+    bool ok = read_native_tile (current_subimage(), current_miplevel(),
+                                x, y, z, &buf[0]);
     if (! ok)
         return false;
     if (! perchanfile) {
@@ -406,9 +458,17 @@ ImageInput::read_tiles (int xbegin, int xend, int ybegin, int yend,
                         int zbegin, int zend, TypeDesc format, void *data,
                         stride_t xstride, stride_t ystride, stride_t zstride)
 {
-    return read_tiles (xbegin, xend, ybegin, yend, zbegin, zend,
-                       0, m_spec.nchannels, format, data,
-                       xstride, ystride, zstride);
+    int subimage, miplevel, chend;
+    {
+        lock_guard lock (m_mutex);
+        subimage = current_subimage();
+        miplevel = current_miplevel();
+        chend = spec().nchannels;
+    }
+    ROI roi (xbegin, xend, ybegin, yend, zbegin, zend, 0, chend);
+    return read_tiles (subimage, miplevel,
+                       xbegin, xend, ybegin, yend, zbegin, zend, 0, chend,
+                       format, data, xstride, ystride, zstride);
 }
 
 
@@ -421,46 +481,88 @@ ImageInput::read_tiles (int xbegin, int xend, int ybegin, int yend,
                         TypeDesc format, void *data,
                         stride_t xstride, stride_t ystride, stride_t zstride)
 {
-    if (! m_spec.valid_tile_range (xbegin, xend, ybegin, yend, zbegin, zend))
+    int subimage, miplevel;
+    {
+        lock_guard lock (m_mutex);
+        subimage = current_subimage();
+        miplevel = current_miplevel();
+    }
+    return read_tiles (subimage, miplevel, xbegin, xend, ybegin, yend,
+                       zbegin, zend, chbegin, chend,
+                       format, data, xstride, ystride, zstride);
+}
+
+
+
+bool
+ImageInput::read_tiles (int subimage, int miplevel,
+                        int xbegin, int xend, int ybegin, int yend,
+                        int zbegin, int zend, int chbegin, int chend,
+                        TypeDesc format, void *data,
+                        stride_t xstride, stride_t ystride, stride_t zstride)
+{
+    ImageSpec spec;
+    {
+        lock_guard lock (m_mutex);
+        if (! seek_subimage (subimage, miplevel))
+            return false;
+        // Copying the dimensions of the designated subimage/miplevel to a
+        // local `spec` means that we can release the lock!  (Calls to
+        // read_native_* will internally lock again if necessary.)
+        spec.copy_dimensions (m_spec);
+    }
+
+    chend = clamp (chend, chbegin+1, spec.nchannels);
+    // roi.chend = clamp (roi.chend, roi.chbegin+1, spec.nchannels);
+    // int xbegin = roi.xbegin;
+    // int xend = roi.xend;
+    // int ybegin = roi.ybegin;
+    // int yend = roi.yend;
+    // int zbegin = roi.zbegin;
+    // int zend = roi.zend;
+    // int chbegin = roi.chbegin;
+    // int chend = roi.chend;
+    int nchans = chend - chbegin;
+    if (! spec.valid_tile_range (xbegin, xend, ybegin, yend, zbegin, zend))
         return false;
 
-    chend = clamp (chend, chbegin+1, m_spec.nchannels);
-    int nchans = chend - chbegin;
     // native_pixel_bytes is the size of a pixel in the FILE, including
     // the per-channel format.
-    stride_t native_pixel_bytes = (stride_t) m_spec.pixel_bytes (chbegin, chend, true);
+    stride_t native_pixel_bytes = (stride_t) spec.pixel_bytes (chbegin, chend, true);
     // perchanfile is true if the file has different per-channel formats
-    bool perchanfile = m_spec.channelformats.size();
+    bool perchanfile = spec.channelformats.size();
     // native_data is true if the user asking for data in the native format
     bool native_data = (format == TypeDesc::UNKNOWN ||
-                        (format == m_spec.format && !perchanfile));
+                        (format == spec.format && !perchanfile));
     if (format == TypeDesc::UNKNOWN && xstride == AutoStride)
         xstride = native_pixel_bytes;
-    m_spec.auto_stride (xstride, ystride, zstride, format, nchans,
+    spec.auto_stride (xstride, ystride, zstride, format, nchans,
                         xend-xbegin, yend-ybegin);
     // Do the strides indicate that the data area is contiguous?
     bool contiguous = (native_data && xstride == native_pixel_bytes) ||
-        (!native_data && xstride == (stride_t)m_spec.pixel_bytes(false));
+        (!native_data && xstride == (stride_t)spec.pixel_bytes(false));
     contiguous &= (ystride == xstride*(xend-xbegin) &&
                    (zstride == ystride*(yend-ybegin) || (zend-zbegin) <= 1));
 
-    int nxtiles = (xend - xbegin + m_spec.tile_width - 1) / m_spec.tile_width;
-    int nytiles = (yend - ybegin + m_spec.tile_height - 1) / m_spec.tile_height;
-    int nztiles = (zend - zbegin + m_spec.tile_depth - 1) / m_spec.tile_depth;
+    int nxtiles = (xend - xbegin + spec.tile_width - 1) / spec.tile_width;
+    int nytiles = (yend - ybegin + spec.tile_height - 1) / spec.tile_height;
+    int nztiles = (zend - zbegin + spec.tile_depth - 1) / spec.tile_depth;
 
     // If user's format and strides are set up to accept the native data
     // layout, and we're asking for a whole number of tiles (no partial
     // tiles at the edges), then read the tile directly into the user's
     // buffer.
     if (native_data && contiguous &&
-        (xend-xbegin) == nxtiles*m_spec.tile_width &&
-        (yend-ybegin) == nytiles*m_spec.tile_height &&
-        (zend-zbegin) == nztiles*m_spec.tile_depth) {
-        if (chbegin == 0 && chend == m_spec.nchannels)
-            return read_native_tiles (xbegin, xend, ybegin, yend, zbegin, zend,
+        (xend-xbegin) == nxtiles*spec.tile_width &&
+        (yend-ybegin) == nytiles*spec.tile_height &&
+        (zend-zbegin) == nztiles*spec.tile_depth) {
+        if (chbegin == 0 && chend == spec.nchannels)
+            return read_native_tiles (subimage, miplevel,
+                                      xbegin, xend, ybegin, yend, zbegin, zend,
                                       data);  // Simple case
         else
-            return read_native_tiles (xbegin, xend, ybegin, yend, zbegin, zend,
+            return read_native_tiles (subimage, miplevel,
+                                      xbegin, xend, ybegin, yend, zbegin, zend,
                                       chbegin, chend, data);
     }
 
@@ -468,52 +570,56 @@ ImageInput::read_tiles (int xbegin, int xend, int ybegin, int yend,
     bool ok = true;
     stride_t pixelsize = native_data ? native_pixel_bytes 
                                      : (format.size() * nchans);
-    stride_t native_pixelsize = m_spec.pixel_bytes(true);
+    stride_t native_pixelsize = spec.pixel_bytes(true);
     stride_t full_pixelsize = native_data ? native_pixelsize
-                                          : (format.size() * m_spec.nchannels);
-    stride_t full_tilewidthbytes = full_pixelsize * m_spec.tile_width;
-    stride_t full_tilewhbytes = full_tilewidthbytes * m_spec.tile_height;
-    stride_t full_tilebytes = full_tilewhbytes * m_spec.tile_depth;
-    stride_t full_native_tilebytes = m_spec.tile_bytes(true);
-    size_t prefix_bytes = native_data ? m_spec.pixel_bytes (0,chbegin,true)
+                                          : (format.size() * spec.nchannels);
+    stride_t full_tilewidthbytes = full_pixelsize * spec.tile_width;
+    stride_t full_tilewhbytes = full_tilewidthbytes * spec.tile_height;
+    stride_t full_tilebytes = full_tilewhbytes * spec.tile_depth;
+    stride_t full_native_tilebytes = spec.tile_bytes(true);
+    size_t prefix_bytes = native_data ? spec.pixel_bytes (0,chbegin,true)
                                       : format.size() * chbegin;
-    bool allchans = (chbegin == 0 && chend == m_spec.nchannels);
+    bool allchans = (chbegin == 0 && chend == spec.nchannels);
     std::vector<char> buf;
-    for (int z = zbegin;  z < zend;  z += std::max(1,m_spec.tile_depth)) {
-        int zd = std::min (zend-z, m_spec.tile_depth);
-        bool full_z = (zd == m_spec.tile_depth);
-        for (int y = ybegin;  ok && y < yend;  y += m_spec.tile_height) {
+    for (int z = zbegin;  z < zend;  z += std::max(1,spec.tile_depth)) {
+        int zd = std::min (zend-z, spec.tile_depth);
+        bool full_z = (zd == spec.tile_depth);
+        for (int y = ybegin;  ok && y < yend;  y += spec.tile_height) {
             char *tilestart = ((char *)data + (z-zbegin)*zstride
                                + (y-ybegin)*ystride);
-            int yh = std::min (yend-y, m_spec.tile_height);
-            bool full_y = (yh == m_spec.tile_height);
+            int yh = std::min (yend-y, spec.tile_height);
+            bool full_y = (yh == spec.tile_height);
             int x = xbegin;
             // If we're reading full y and z tiles and not doing any funny
             // business with channels, try to read as many complete x tiles
             // as we can in this row.
-            int x_full_tiles = (xend-xbegin)/m_spec.tile_width;
-            if (full_z && full_y && allchans && !perchanfile && x_full_tiles > 1) {
-                int x_full_tile_end = xbegin + x_full_tiles*m_spec.tile_width;
+            int x_full_tiles = (xend-xbegin)/spec.tile_width;
+            if (full_z && full_y && allchans && !perchanfile && x_full_tiles >= 1) {
+                int x_full_tile_end = xbegin + x_full_tiles*spec.tile_width;
                 if (buf.size() < size_t(full_native_tilebytes*x_full_tiles))
                     buf.resize (full_native_tilebytes*x_full_tiles);
-                ok &= read_native_tiles (xbegin, x_full_tile_end, y, y+yh, z, z+zd,
+                ok &= read_native_tiles (subimage, miplevel,
+                                         xbegin, x_full_tile_end, y, y+yh, z, z+zd,
                                          chbegin, chend, &buf[0]);
                 if (ok)
-                    convert_image (nchans, x_full_tiles*m_spec.tile_width, yh, zd,
-                                   &buf[0], m_spec.format, native_pixelsize,
-                                   native_pixelsize*x_full_tiles*m_spec.tile_width,
-                                   native_pixelsize*x_full_tiles*m_spec.tile_width*m_spec.tile_height,
+                    convert_image (nchans, x_full_tiles*spec.tile_width, yh, zd,
+                                   &buf[0], spec.format, native_pixelsize,
+                                   native_pixelsize*x_full_tiles*spec.tile_width,
+                                   native_pixelsize*x_full_tiles*spec.tile_width*spec.tile_height,
                                    tilestart, format,
                                    xstride, ystride, zstride);
-                tilestart += x_full_tiles * m_spec.tile_width * xstride;
-                x += x_full_tiles * m_spec.tile_width;
+                tilestart += x_full_tiles * spec.tile_width * xstride;
+                x += x_full_tiles * spec.tile_width;
             }
 
             // Now get the rest in the row, anything that is only a
             // partial tile, which needs extra care.
-            for ( ;  ok && x < xend;  x += m_spec.tile_width) {
-                int xw = std::min (xend-x, m_spec.tile_width);
-                bool full_x = (xw == m_spec.tile_width);
+            // Since we are here relying on the non-thread-safe read_tile()
+            // call, we re-establish the lock and make sure we're on the
+            // right subimage/miplevel.
+            for ( ;  ok && x < xend;  x += spec.tile_width) {
+                int xw = std::min (xend-x, spec.tile_width);
+                bool full_x = (xw == spec.tile_width);
                 // Full tiles are read directly into the user buffer,
                 // but partial tiles (such as at the image edge) or
                 // partial channel subsets are read into a buffer and
@@ -521,6 +627,9 @@ ImageInput::read_tiles (int xbegin, int xend, int ybegin, int yend,
                 if (full_x && full_y && full_z && allchans && !perchanfile) {
                     // Full tile, either native data or not needing
                     // per-tile data format conversion.
+                    lock_guard lock (m_mutex);
+                    if (! seek_subimage (subimage, miplevel))
+                        return false;
                     ok &= read_tile (x, y, z, format, tilestart,
                                      xstride, ystride, zstride);
                     if (! ok)
@@ -528,9 +637,14 @@ ImageInput::read_tiles (int xbegin, int xend, int ybegin, int yend,
                 } else {
                     if (buf.size() < size_t(full_tilebytes))
                         buf.resize (full_tilebytes);
-                    ok &= read_tile (x, y, z, format,
-                                     &buf[0], full_pixelsize,
-                                     full_tilewidthbytes, full_tilewhbytes);
+                    {
+                        lock_guard lock (m_mutex);
+                        if (! seek_subimage (subimage, miplevel))
+                            return false;
+                        ok &= read_tile (x, y, z, format,
+                                         &buf[0], full_pixelsize,
+                                         full_tilewidthbytes, full_tilewhbytes);
+                    }
                     if (ok)
                         copy_image (nchans, xw, yh, zd, &buf[prefix_bytes],
                                     pixelsize, full_pixelsize,
@@ -543,7 +657,7 @@ ImageInput::read_tiles (int xbegin, int xend, int ybegin, int yend,
                     // format, so all we have to do on our own is the
                     // copy_image.
                 }
-                tilestart += m_spec.tile_width * xstride;
+                tilestart += spec.tile_width * xstride;
             }
             if (! ok)
                 break;
@@ -552,37 +666,65 @@ ImageInput::read_tiles (int xbegin, int xend, int ybegin, int yend,
 
     if (! ok)
         error ("ImageInput::read_tiles : no support for format %s",
-               m_spec.format.c_str());
+               spec.format);
     return ok;
 }
 
 
 
 bool
-ImageInput::read_native_tiles (int xbegin, int xend, int ybegin, int yend,
+ImageInput::read_native_tile (int subimage, int miplevel,
+                              int x, int y, int z, void * data)
+{
+    // The base class read_native_tile fails. A format reader that supports
+    // tiles MUST overload this virtual method that reads a single tile
+    // (all channels).
+    return false;
+}
+
+
+bool
+ImageInput::read_native_tiles (int subimage, int miplevel,
+                               int xbegin, int xend, int ybegin, int yend,
                                int zbegin, int zend, void *data)
 {
-    if (! m_spec.valid_tile_range (xbegin, xend, ybegin, yend, zbegin, zend))
+    // A format reader that supports reading multiple tiles at once (in
+    // a way that's more efficient than reading the tiles one at a time)
+    // is advised (but not required) to overload this virtual method.
+    // If an ImageInput subclass does not overload this, the default
+    // implementation here is simply to loop over the tiles, calling the
+    // single-tile read_native_tile() for each one.
+    ImageSpec spec;
+    {
+        lock_guard lock (m_mutex);
+        if (! seek_subimage (subimage, miplevel))
+            return false;
+        // Copying the dimensions of the designated subimage/miplevel to a
+        // local `spec` means that we can release the lock!  (Calls to
+        // read_native_* will internally lock again if necessary.)
+        spec.copy_dimensions (m_spec);
+    }
+    if (! spec.valid_tile_range (xbegin, xend, ybegin, yend, zbegin, zend))
         return false;
 
     // Base class implementation of read_native_tiles just repeatedly
     // calls read_native_tile, which is supplied by every plugin that
     // supports tiles.  Only the hardcore ones will overload
     // read_native_tiles with their own implementation.
-    stride_t pixel_bytes = (stride_t) m_spec.pixel_bytes (true);
-    stride_t tileystride = pixel_bytes * m_spec.tile_width;
-    stride_t tilezstride = tileystride * m_spec.tile_height;
+    stride_t pixel_bytes = (stride_t) spec.pixel_bytes (true);
+    stride_t tileystride = pixel_bytes * spec.tile_width;
+    stride_t tilezstride = tileystride * spec.tile_height;
     stride_t ystride = (xend-xbegin) * pixel_bytes;
     stride_t zstride = (yend-ybegin) * ystride;
-    std::unique_ptr<char[]> pels (new char [m_spec.tile_bytes(true)]);
-    for (int z = zbegin;  z < zend;  z += m_spec.tile_depth) {
-        for (int y = ybegin;  y < yend;  y += m_spec.tile_height) {
-            for (int x = xbegin;  x < xend;  x += m_spec.tile_width) {
-                bool ok = read_native_tile (x, y, z, &pels[0]);
+    std::unique_ptr<char[]> pels (new char [spec.tile_bytes(true)]);
+    for (int z = zbegin;  z < zend;  z += spec.tile_depth) {
+        for (int y = ybegin;  y < yend;  y += spec.tile_height) {
+            for (int x = xbegin;  x < xend;  x += spec.tile_width) {
+                bool ok = read_native_tile (subimage, miplevel, x, y, z, &pels[0]);
                 if (! ok)
                     return false;
-                copy_image (m_spec.nchannels, m_spec.tile_width,
-                            m_spec.tile_height, m_spec.tile_depth,
+                copy_image (spec.nchannels, spec.tile_width,
+                            spec.tile_height, spec.tile_depth,
                             &pels[0], size_t(pixel_bytes),
                             pixel_bytes, tileystride, tilezstride,
                             (char *)data+ (z-zbegin)*zstride + 
@@ -597,19 +739,38 @@ ImageInput::read_native_tiles (int xbegin, int xend, int ybegin, int yend,
 
 
 bool
-ImageInput::read_native_tiles (int xbegin, int xend, int ybegin, int yend,
-                               int zbegin, int zend, 
+ImageInput::read_native_tiles (int subimage, int miplevel,
+                               int xbegin, int xend, int ybegin, int yend,
+                               int zbegin, int zend,
                                int chbegin, int chend, void *data)
 {
-    chend = clamp (chend, chbegin+1, m_spec.nchannels);
-    int nchans = chend - chbegin;
+    // A format reader that supports reading multiple tiles at once, and can
+    // handle a channel subset while doing so, is advised (but not required)
+    // to overload this virtual method. If an ImageInput subclass does not
+    // overload this, the default implementation here is simply to loop over
+    // the tiles, calling the single-tile read_native_tile() for each one
+    // (and copying carefully to handle the channel subset issues).
+    ImageSpec spec;
+    {
+        lock_guard lock (m_mutex);
+        if (! seek_subimage (subimage, miplevel))
+            return false;
+        chend = clamp (chend, chbegin+1, spec.nchannels);
 
-    // All-channel case just reduces to the simpler read_native_scanlines.
-    if (chbegin == 0 && chend >= m_spec.nchannels)
-        return read_native_tiles (xbegin, xend, ybegin, yend,
-                                  zbegin, zend, data);
+        // All-channel case just reduces to the simpler version of
+        // read_native_tiles.
+        if (chbegin == 0 && chend >= spec.nchannels)
+            return read_native_tiles (subimage, miplevel, xbegin, xend,
+                                      ybegin, yend, zbegin, zend, data);
+        // More complicated cases follow.
 
-    if (! m_spec.valid_tile_range (xbegin, xend, ybegin, yend, zbegin, zend))
+        // Copying the dimensions of the designated subimage/miplevel to a
+        // local `spec` means that we can release the lock!  (Calls to
+        // read_native_* will internally lock again if necessary.)
+        spec.copy_dimensions (m_spec);
+    }
+
+    if (! spec.valid_tile_range (xbegin, xend, ybegin, yend, zbegin, zend))
         return false;
 
     // Base class implementation of read_native_tiles just repeatedly
@@ -617,24 +778,25 @@ ImageInput::read_native_tiles (int xbegin, int xend, int ybegin, int yend,
     // supports tiles.  Only the hardcore ones will overload
     // read_native_tiles with their own implementation.
 
-    stride_t native_pixel_bytes = (stride_t) m_spec.pixel_bytes (true);
-    stride_t native_tileystride = native_pixel_bytes * m_spec.tile_width;
-    stride_t native_tilezstride = native_tileystride * m_spec.tile_height;
+    int nchans = chend - chbegin;
+    stride_t native_pixel_bytes = (stride_t) spec.pixel_bytes (true);
+    stride_t native_tileystride = native_pixel_bytes * spec.tile_width;
+    stride_t native_tilezstride = native_tileystride * spec.tile_height;
 
-    size_t prefix_bytes = m_spec.pixel_bytes (0,chbegin,true);
-    size_t subset_bytes = m_spec.pixel_bytes (chbegin,chend,true);
+    size_t prefix_bytes = spec.pixel_bytes (0,chbegin,true);
+    size_t subset_bytes = spec.pixel_bytes (chbegin,chend,true);
     stride_t subset_ystride = (xend-xbegin) * subset_bytes;
     stride_t subset_zstride = (yend-ybegin) * subset_ystride;
 
-    std::unique_ptr<char[]> pels (new char [m_spec.tile_bytes(true)]);
-    for (int z = zbegin;  z < zend;  z += m_spec.tile_depth) {
-        for (int y = ybegin;  y < yend;  y += m_spec.tile_height) {
-            for (int x = xbegin;  x < xend;  x += m_spec.tile_width) {
-                bool ok = read_native_tile (x, y, z, &pels[0]);
+    std::unique_ptr<char[]> pels (new char [spec.tile_bytes(true)]);
+    for (int z = zbegin;  z < zend;  z += spec.tile_depth) {
+        for (int y = ybegin;  y < yend;  y += spec.tile_height) {
+            for (int x = xbegin;  x < xend;  x += spec.tile_width) {
+                bool ok = read_native_tile (subimage, miplevel, x, y, z, &pels[0]);
                 if (! ok)
                     return false;
-                copy_image (nchans, m_spec.tile_width,
-                            m_spec.tile_height, m_spec.tile_depth,
+                copy_image (nchans, spec.tile_width,
+                            spec.tile_height, spec.tile_depth,
                             &pels[prefix_bytes], subset_bytes,
                             native_pixel_bytes, native_tileystride,
                             native_tilezstride,
@@ -668,36 +830,71 @@ ImageInput::read_image (int chbegin, int chend, TypeDesc format, void *data,
                         ProgressCallback progress_callback,
                         void *progress_callback_data)
 {
+    int subimage, miplevel;
+    {
+        lock_guard lock (m_mutex);
+        subimage = current_subimage();
+        miplevel = current_miplevel();
+    }
+    return read_image (subimage, miplevel, chbegin, chend,
+                       format, data, xstride, ystride, zstride,
+                       progress_callback, progress_callback_data);
+}
+
+
+
+bool
+ImageInput::read_image (int subimage, int miplevel,
+                        int chbegin, int chend, TypeDesc format, void *data,
+                        stride_t xstride, stride_t ystride, stride_t zstride,
+                        ProgressCallback progress_callback,
+                        void *progress_callback_data)
+{
+    ImageSpec spec;
+    int rps = 0;
+    {
+        lock_guard lock (m_mutex);
+        if (! seek_subimage (subimage, miplevel))
+            return false;
+        // Copying the dimensions of the designated subimage/miplevel to a
+        // local `spec` means that we can release the lock!  (Calls to
+        // read_native_* will internally lock again if necessary.)
+        spec.copy_dimensions (m_spec);
+        // For scanline files, we also need one piece of metadata
+        if (! spec.tile_width)
+            rps = m_spec.get_int_attribute ("tiff:RowsPerStrip", 64);
+    }
+
     if (chend < 0)
-        chend = m_spec.nchannels;
-    chend = clamp (chend, chbegin+1, m_spec.nchannels);
+        chend = spec.nchannels;
+    chend = clamp (chend, chbegin+1, spec.nchannels);
     int nchans = chend - chbegin;
     bool native = (format == TypeDesc::UNKNOWN);
-    stride_t pixel_bytes = native ? (stride_t) m_spec.pixel_bytes (chbegin, chend, native)
+    stride_t pixel_bytes = native ? (stride_t) spec.pixel_bytes (chbegin, chend, native)
                                   : (stride_t) (format.size()*nchans);
     if (native && xstride == AutoStride)
         xstride = pixel_bytes;
-    m_spec.auto_stride (xstride, ystride, zstride, format, nchans,
-                        m_spec.width, m_spec.height);
+    spec.auto_stride (xstride, ystride, zstride, format, nchans,
+                        spec.width, spec.height);
     bool ok = true;
     if (progress_callback)
         if (progress_callback (progress_callback_data, 0.0f))
             return ok;
-    if (m_spec.tile_width) {  // Tiled image -- rely on read_tiles
+    if (spec.tile_width) {  // Tiled image -- rely on read_tiles
         // Read in chunks of a whole row of tiles at once. If tiles are
         // 64x64, a 2k image has 32 tiles across. That's fine for now (for
         // parallelization purposes), but as typical core counts increase,
         // we may someday want to revisit this to batch multiple rows.
-        for (int z = 0;  z < m_spec.depth;  z += m_spec.tile_depth) {
-            for (int y = 0;  y < m_spec.height && ok;  y += m_spec.tile_height) {
-                ok &= read_tiles (m_spec.x, m_spec.x+m_spec.width,
-                                  y+m_spec.y, std::min (y+m_spec.y+m_spec.tile_height, m_spec.y+m_spec.height),
-                                  z+m_spec.z, std::min (z+m_spec.z+m_spec.tile_depth, m_spec.z+m_spec.depth),
+        for (int z = 0;  z < spec.depth;  z += spec.tile_depth) {
+            for (int y = 0;  y < spec.height && ok;  y += spec.tile_height) {
+                ok &= read_tiles (spec.x, spec.x+spec.width,
+                                  y+spec.y, std::min (y+spec.y+spec.tile_height, spec.y+spec.height),
+                                  z+spec.z, std::min (z+spec.z+spec.tile_depth, spec.z+spec.depth),
                                   chbegin, chend,
                                   format, (char *)data + z*zstride + y*ystride,
                                   xstride, ystride, zstride);
                 if (progress_callback &&
-                    progress_callback (progress_callback_data, (float)y/m_spec.height))
+                    progress_callback (progress_callback_data, (float)y/spec.height))
                     return ok;
             }
         }
@@ -705,19 +902,18 @@ ImageInput::read_image (int chbegin, int chend, TypeDesc format, void *data,
         // Split into reasonable chunks -- try to use around 64 MB or the
         // oiio_read_chunk value, which ever is bigger, but also round up to
         // a multiple of the TIFF rows per strip (or 64).
-        int rps = m_spec.get_int_attribute ("tiff:RowsPerStrip", 64);
-        int chunk = std::max (1, (1<<26)/int(m_spec.scanline_bytes(true)));
+        int chunk = std::max (1, (1<<26)/int(spec.scanline_bytes(true)));
         chunk = std::max (chunk, int(oiio_read_chunk));
         chunk = round_to_multiple (chunk, rps);
-        for (int z = 0;  z < m_spec.depth;  ++z) {
-            for (int y = 0;  y < m_spec.height && ok;  y += chunk) {
-                int yend = std::min (y+m_spec.y+chunk, m_spec.y+m_spec.height);
-                ok &= read_scanlines (y+m_spec.y, yend, z+m_spec.z,
+        for (int z = 0;  z < spec.depth;  ++z) {
+            for (int y = 0;  y < spec.height && ok;  y += chunk) {
+                int yend = std::min (y+spec.y+chunk, spec.y+spec.height);
+                ok &= read_scanlines (y+spec.y, yend, z+spec.z,
                                       chbegin, chend, format,
                                       (char *)data + z*zstride + y*ystride,
                                       xstride, ystride);
                 if (progress_callback)
-                    if (progress_callback (progress_callback_data, (float)y/m_spec.height))
+                    if (progress_callback (progress_callback_data, (float)y/spec.height))
                         return ok;
             }
         }
@@ -730,7 +926,8 @@ ImageInput::read_image (int chbegin, int chend, TypeDesc format, void *data,
 
 
 bool
-ImageInput::read_native_deep_scanlines (int ybegin, int yend, int z,
+ImageInput::read_native_deep_scanlines (int subimage, int miplevel,
+                                        int ybegin, int yend, int z,
                                         int chbegin, int chend,
                                         DeepData &deepdata)
 {
@@ -740,7 +937,8 @@ ImageInput::read_native_deep_scanlines (int ybegin, int yend, int z,
 
 
 bool
-ImageInput::read_native_deep_tiles (int xbegin, int xend,
+ImageInput::read_native_deep_tiles (int subimage, int miplevel,
+                                    int xbegin, int xend,
                                     int ybegin, int yend,
                                     int zbegin, int zend,
                                     int chbegin, int chend,
@@ -752,8 +950,12 @@ ImageInput::read_native_deep_tiles (int xbegin, int xend,
 
 
 bool
-ImageInput::read_native_deep_image (DeepData &deepdata)
+ImageInput::read_native_deep_image (int subimage, int miplevel,
+                                    DeepData &deepdata)
 {
+    lock_guard lock (m_mutex);
+    if (! seek_subimage (subimage, miplevel))
+        return false;
     if (m_spec.depth > 1) {
         error ("read_native_deep_image is not supported for volume (3D) images.");
         return false;
@@ -763,13 +965,15 @@ ImageInput::read_native_deep_image (DeepData &deepdata)
     }
     if (m_spec.tile_width) {
         // Tiled image
-        return read_native_deep_tiles (m_spec.x, m_spec.x+m_spec.width,
+        return read_native_deep_tiles (subimage, miplevel,
+                                       m_spec.x, m_spec.x+m_spec.width,
                                        m_spec.y, m_spec.y+m_spec.height,
                                        m_spec.z, m_spec.z+m_spec.depth,
                                        0, m_spec.nchannels, deepdata);
     } else {
         // Scanline image
-        return read_native_deep_scanlines (m_spec.y, m_spec.y+m_spec.height, 0,
+        return read_native_deep_scanlines (subimage, miplevel,
+                                           m_spec.y, m_spec.y+m_spec.height, 0,
                                            0, m_spec.nchannels, deepdata);
     }
 }
@@ -797,17 +1001,12 @@ ImageInput::send_to_client (const char *format, ...)
 void 
 ImageInput::append_error (const std::string& message) const
 {
+    lock_guard lock (m_mutex);
     ASSERT (m_errmessage.size() < 1024*1024*16 &&
             "Accumulated error messages > 16MB. Try checking return codes!");
     if (m_errmessage.size())
         m_errmessage += '\n';
     m_errmessage += message;
-}
-
-bool
-ImageInput::read_native_tile (int x, int y, int z, void * data)
-{
-    return false;
 }
 
 OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -530,7 +530,8 @@ ImageOutput::copy_image (ImageInput *in)
     if (spec().deep) {
         // Special case for ''deep'' images
         DeepData deepdata;
-        bool ok = in->read_native_deep_image (deepdata);
+        bool ok = in->read_native_deep_image (in->current_subimage(),
+                                              in->current_miplevel(), deepdata);
         if (ok)
             ok = write_deep_image (deepdata);
         else

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -196,12 +196,8 @@ TextureSystemImpl::texture3d (TextureHandle *texture_handle_,
     // knowledge of the few volume reader internals to the back doors.
     Imath::V3f Plocal;
     if (texturefile->fileformat() == s_field3d) {
-        if (! texturefile->opened()) {
-            // We need a valid ImageInput pointer below.  If the handle
-            // has been invalidated, force it open again.
-            texturefile->forceopen (thread_info);
-        }
-        Field3DInput_Interface *f3di = (Field3DInput_Interface *)texturefile->imageinput();
+        auto input = texturefile->open (thread_info);
+        Field3DInput_Interface *f3di = (Field3DInput_Interface *)input.get();
         ASSERT (f3di);
         f3di->worldToLocal (P, Plocal, options.time);
     } else {

--- a/src/null.imageio/nullimageio.cpp
+++ b/src/null.imageio/nullimageio.cpp
@@ -86,9 +86,11 @@ public:
     virtual bool close () override { return true; }
     virtual int current_subimage (void) const override { return m_subimage; }
     virtual int current_miplevel (void) const override { return m_miplevel; }
-    virtual bool seek_subimage (int subimage, int miplevel, ImageSpec &newspec) override;
-    virtual bool read_native_scanline (int y, int z, void *data) override;
-    virtual bool read_native_tile (int x, int y, int z, void *data) override;
+    virtual bool seek_subimage (int subimage, int miplevel) override;
+    virtual bool read_native_scanline (int subimage, int miplevel,
+                                       int y, int z, void *data) override;
+    virtual bool read_native_tile (int subimage, int miplevel,
+                                   int x, int y, int z, void *data) override;
 
 private:
     std::string m_filename;          ///< Stash the filename
@@ -322,16 +324,17 @@ NullInput::open (const std::string &name, ImageSpec &newspec,
                        m_topspec.nchannels);
     }
 
-    return seek_subimage (0, 0, newspec);
+    bool ok = seek_subimage (0, 0);
+    newspec = spec();
+    return ok;
 }
 
 
 
 bool
-NullInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
+NullInput::seek_subimage (int subimage, int miplevel)
 {
     if (subimage == current_subimage() && miplevel == current_miplevel()) {
-        newspec = spec();
         return true;
     }
 
@@ -353,14 +356,14 @@ NullInput::seek_subimage (int subimage, int miplevel, ImageSpec &newspec)
         m_spec.full_height = m_spec.height;
         m_spec.full_depth = m_spec.depth;
     }
-    newspec = spec();
     return true;
 }
 
 
 
 bool
-NullInput::read_native_scanline (int y, int z, void *data)
+NullInput::read_native_scanline (int subimage, int miplevel,
+                                 int y, int z, void *data)
 {
     if (m_value.size()) {
         size_t s = m_spec.pixel_bytes();
@@ -375,7 +378,8 @@ NullInput::read_native_scanline (int y, int z, void *data)
 
 
 bool
-NullInput::read_native_tile (int x, int y, int z, void *data)
+NullInput::read_native_tile (int subimage, int miplevel,
+                             int x, int y, int z, void *data)
 {
     if (m_value.size()) {
         size_t s = m_spec.pixel_bytes();

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -46,7 +46,8 @@ public:
     virtual bool open (const std::string &name, ImageSpec &newspec) override;
     virtual bool close () override;
     virtual int current_subimage (void) const override { return 0; }
-    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_scanline (int subimage, int miplevel,
+                                       int y, int z, void *data) override;
 
 private:
     enum PNMType {
@@ -474,8 +475,13 @@ PNMInput::close ()
 
 
 bool
-PNMInput::read_native_scanline (int y, int z, void *data)
+PNMInput::read_native_scanline (int subimage, int miplevel,
+                                int y, int z, void *data)
 {
+    lock_guard lock (m_mutex);
+    if (! seek_subimage (subimage, miplevel))
+        return false;
+
     if (z)
         return false;
     if (!read_file_scanline (data, y))

--- a/src/python/py_imageinput.cpp
+++ b/src/python/py_imageinput.cpp
@@ -237,7 +237,17 @@ void declare_imageinput (py::module &m)
             "filename"_a, "config"_a)
         .def("format_name",      &ImageInput::format_name)
         .def("valid_file",       &ImageInput::valid_file)
-        .def("spec",             &ImageInput::spec)
+        .def("spec", [](ImageInput &self){
+                return self.spec();
+            })
+        .def("spec", [](ImageInput &self, int subimage, int miplevel){
+                return self.spec(subimage, miplevel);
+            },
+            "subimage"_a, "miplevel"_a=0)
+        .def("spec_dimensions", [](ImageInput &self, int subimage, int miplevel){
+                return self.spec_dimensions(subimage, miplevel);
+            },
+            "subimage"_a, "miplevel"_a=0)
         .def("supports",    [](const ImageInput &self, const std::string& feature){
                 return self.supports(feature); })
         .def("close",            &ImageInput::close)

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -241,6 +241,8 @@ void declare_imagespec (py::module& m)
         .def("from_xml",    &ImageSpec::from_xml)
         .def("valid_tile_range",    &ImageSpec::valid_tile_range,
              "xbegin"_a, "xend"_a, "ybegin"_a, "yend"_a, "zbegin"_a, "zend"_a)
+        .def("copy_dimensions", &ImageSpec::copy_dimensions,
+             "other"_a)
     ;
 }
 

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -64,7 +64,8 @@ public:
     virtual bool open (const std::string &name, ImageSpec &newspec,
                        const ImageSpec &config) override;
     virtual bool close() override;
-    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_scanline (int subimage, int miplevel,
+                                       int y, int z, void *data) override;
 
 private:
     bool process();
@@ -530,8 +531,13 @@ RawInput::process()
 
 
 bool
-RawInput::read_native_scanline (int y, int z, void *data)
+RawInput::read_native_scanline (int subimage, int miplevel,
+                                int y, int z, void *data)
 {
+    lock_guard lock (m_mutex);
+    if (! seek_subimage (subimage, miplevel))
+        return false;
+
     if (y < 0 || y >= m_spec.height) // out of range scanline
         return false;
 

--- a/src/sgi.imageio/sgi_pvt.h
+++ b/src/sgi.imageio/sgi_pvt.h
@@ -95,7 +95,8 @@ class SgiInput final : public ImageInput {
     virtual bool valid_file (const std::string &filename) const override;
     virtual bool open (const std::string &name, ImageSpec &spec) override;
     virtual bool close (void) override;
-    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_scanline (int subimage, int miplevel,
+                                       int y, int z, void *data) override;
  private:
     FILE *m_fd;
     std::string m_filename;

--- a/src/sgi.imageio/sgiinput.cpp
+++ b/src/sgi.imageio/sgiinput.cpp
@@ -129,8 +129,13 @@ SgiInput::open (const std::string &name, ImageSpec &spec)
 
 
 bool
-SgiInput::read_native_scanline (int y, int z, void *data)
+SgiInput::read_native_scanline (int subimage, int miplevel,
+                                int y, int z, void *data)
 {
+    lock_guard lock (m_mutex);
+    if (! seek_subimage (subimage, miplevel))
+        return false;
+
     if (y < 0 || y > m_spec.height)
         return false;
 

--- a/src/socket.imageio/socket_pvt.h
+++ b/src/socket.imageio/socket_pvt.h
@@ -96,8 +96,10 @@ class SocketInput final : public ImageInput {
     virtual bool open (const std::string &name, ImageSpec &spec) override;
     virtual bool open (const std::string &name, ImageSpec &spec,
                        const ImageSpec &config) override;
-    virtual bool read_native_scanline (int y, int z, void *data) override;
-    virtual bool read_native_tile (int x, int y, int z, void *data) override;
+    virtual bool read_native_scanline (int subimage, int miplevel,
+                                       int y, int z, void *data) override;
+    virtual bool read_native_tile (int subimage, int miplevel,
+                                   int x, int y, int z, void *data) override;
     virtual bool close () override;
 
  private:

--- a/src/socket.imageio/socketinput.cpp
+++ b/src/socket.imageio/socketinput.cpp
@@ -106,8 +106,12 @@ SocketInput::open (const std::string &name, ImageSpec &newspec,
 
 
 bool
-SocketInput::read_native_scanline (int y, int z, void *data)
-{    
+SocketInput::read_native_scanline (int subimage, int miplevel,
+                                   int y, int z, void *data)
+{
+    lock_guard lock (m_mutex);
+    if (! seek_subimage (subimage, miplevel))
+        return false;
     try {
         boost::asio::read (socket, buffer (reinterpret_cast<char *> (data),
                 m_spec.scanline_bytes ()));
@@ -125,8 +129,12 @@ SocketInput::read_native_scanline (int y, int z, void *data)
 
 
 bool
-SocketInput::read_native_tile (int x, int y, int z, void *data)
+SocketInput::read_native_tile (int subimage, int miplevel,
+                               int x, int y, int z, void *data)
 {
+    lock_guard lock (m_mutex);
+    if (! seek_subimage (subimage, miplevel))
+        return false;
     try {
         boost::asio::read (socket, buffer (reinterpret_cast<char *> (data),
                 m_spec.tile_bytes ()));

--- a/src/softimage.imageio/softimageinput.cpp
+++ b/src/softimage.imageio/softimageinput.cpp
@@ -53,7 +53,8 @@ public:
     }
     virtual bool open (const std::string &name, ImageSpec &spec) override;
     virtual bool close() override;
-    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_scanline (int subimage, int miplevel,
+                                       int y, int z, void *data) override;
 
 private:
     /// Resets the core data members to defaults.
@@ -180,8 +181,13 @@ SoftimageInput::open (const std::string& name, ImageSpec& spec)
 
 
 bool
-SoftimageInput::read_native_scanline (int y, int z, void* data)
+SoftimageInput::read_native_scanline (int subimage, int miplevel,
+                                      int y, int z, void* data)
 {
+    lock_guard lock (m_mutex);
+    if (! seek_subimage (subimage, miplevel))
+        return false;
+
     bool result = false;
     if (y == (int)m_scanline_markers.size() - 1) {
         // we're up to this scanline

--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -55,7 +55,8 @@ public:
     virtual bool open (const std::string &name, ImageSpec &newspec,
                        const ImageSpec &config) override;
     virtual bool close () override;
-    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_scanline (int subimage, int miplevel,
+                                       int y, int z, void *data) override;
 
 private:
     std::string m_filename;           ///< Stash the filename
@@ -788,8 +789,13 @@ TGAInput::close ()
 
 
 bool
-TGAInput::read_native_scanline (int y, int z, void *data)
+TGAInput::read_native_scanline (int subimage, int miplevel,
+                                int y, int z, void *data)
 {
+    lock_guard lock (m_mutex);
+    if (! seek_subimage (subimage, miplevel))
+        return false;
+
     if (m_buf.empty ())
         readimg ();
 

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -45,7 +45,8 @@ class WebpInput final : public ImageInput
     virtual ~WebpInput() { close(); }
     virtual const char* format_name() const override { return "webp"; }
     virtual bool open (const std::string &name, ImageSpec &spec) override;
-    virtual bool read_native_scanline (int y, int z, void *data) override;
+    virtual bool read_native_scanline (int subimage, int miplevel,
+                                       int y, int z, void *data) override;
     virtual bool close () override;
 
  private:
@@ -145,12 +146,20 @@ WebpInput::open (const std::string &name, ImageSpec &spec)
 
 
 bool
-WebpInput::read_native_scanline (int y, int z, void *data)
+WebpInput::read_native_scanline (int subimage, int miplevel,
+                                 int y, int z, void *data)
 {
+    // Not necessary to lock and seek -- no subimages in Webp, and since
+    // the only thing we're doing here is a memcpy, it's already threadsafe.
+    //
+    // lock_guard lock (m_mutex);
+    // if (! seek_subimage (subimage, miplevel))
+    //     return false;
+
     if (y < 0 || y >= m_spec.width)   // out of range scanline
         return false;
     memcpy(data, &m_decoded_image[y*m_scanline_size], m_scanline_size);
-    return true;    
+    return true;
 }
 
 

--- a/testsuite/python-deep/src/test_deep.py
+++ b/testsuite/python-deep/src/test_deep.py
@@ -307,7 +307,7 @@ try:
     print ("\nReading image...")
     input = oiio.ImageInput.open ("deeptest.exr")
     ddr = input.read_native_deep_image ()
-    if ddr != None :
+    if ddr :
         print_deep_image (ddr)
 
     test_insert_erase ()

--- a/testsuite/python-imageinput/ref/out-alt2.txt
+++ b/testsuite/python-imageinput/ref/out-alt2.txt
@@ -1,0 +1,156 @@
+Could not open "badname.tif"
+	Error:  Could not open file: badname.tif: No such file or directory
+Opened "../../../../../oiio-images/tahoe-gps.jpg" as a jpeg
+  resolution 2048x1536+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  oiio:ColorSpace = "sRGB"
+  jpeg:subsampling = "4:2:0"
+  Make = "HTC"
+  Model = "T-Mobile G1"
+  Orientation = 1
+  XResolution = 72.0
+  YResolution = 72.0
+  ResolutionUnit = "none"
+  Software = "title;va"
+  Exif:YCbCrPositioning = 1
+  Exif:ExifVersion = "0220"
+  Exif:DateTimeOriginal = "2009:02:21 08:32:04"
+  Exif:DateTimeDigitized = "2009:02:21 08:32:04"
+  Exif:FlashPixVersion = "0100"
+  Exif:ColorSpace = 1
+  Exif:PixelXDimension = 2048
+  Exif:PixelYDimension = 1536
+  Exif:WhiteBalance = 0
+  GPS:VersionID = None
+  GPS:LatitudeRef = "N"
+  GPS:Latitude = (39.0, 18.0, 24.399999618530273)
+  GPS:LongitudeRef = "W"
+  GPS:Longitude = (120.0, 20.0, 6.25)
+  GPS:AltitudeRef = 0
+  GPS:Altitude = 0.0
+  GPS:TimeStamp = (17.0, 56.0, 33.0)
+  GPS:MapDatum = "WGS-84"
+  GPS:DateStamp = "1915:08:08"
+
+Opened "grid.tx" as a tiff
+  resolution 1024x1024+0+0
+  tile size  64x64x1
+  4 channels: ('R', 'G', 'B', 'A')
+  format =  uint8
+  alpha channel =  3
+  z channel =  -1
+  deep =  False
+  oiio:BitsPerSample = 8
+  Orientation = 1
+  XResolution = 72.0
+  YResolution = 72.0
+  ResolutionUnit = "in"
+  Software = "OpenImageIO 1.5.7dev : maketx -filter lanczos3 --resize grid.tif -o grid.tx"
+  DateTime = "2014:11:29 23:20:23"
+  DocumentName = "g.tif"
+  textureformat = "Plain Texture"
+  wrapmodes = "black,black"
+  fovcot = 1.0
+  tiff:PhotometricInterpretation = 2
+  tiff:PlanarConfiguration = 1
+  planarconfig = "contig"
+  tiff:Compression = 8
+  compression = "zip"
+  PixelAspectRatio = 1.0
+  oiio:AverageColor = "0.608983,0.608434,0.608728,1"
+  oiio:SHA-1 = "233A1D3412A54A5F49814AB7BFFD04F56F46D3D7"
+Subimage 0 MIP level 1 :
+  resolution 512x512+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 2 :
+  resolution 256x256+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 3 :
+  resolution 128x128+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 4 :
+  resolution 64x64+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 5 :
+  resolution 32x32+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 6 :
+  resolution 16x16+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 7 :
+  resolution 8x8+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 8 :
+  resolution 4x4+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 9 :
+  resolution 2x2+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 10 :
+  resolution 1x1+0+0
+  tile size  64x64x1
+
+Testing read_image:
+Opened "../../../../../oiio-images/tahoe-gps.jpg" as a jpeg
+@ (0L, 0L) = [40 35 57]
+@ (2047L, 1535L) = [37 56 89]
+@ (1024L, 768L) = [137 183 233]
+
+Opened "../../../../../oiio-images/tahoe-gps.jpg" as a jpeg
+@ (0L, 0L) = [0.15686275 0.13725491 0.22352943]
+@ (2047L, 1535L) = [0.14509805 0.21960786 0.34901962]
+@ (1024L, 768L) = [0.5372549  0.7176471  0.91372555]
+
+Opened "../../../../../oiio-images/tahoe-gps.jpg" as a jpeg
+@ (0L, 0L) = [40]
+@ (2047L, 1535L) = [37]
+@ (1024L, 768L) = [137]
+
+Testing read_scanline:
+Opened "../../../../../oiio-images/tahoe-gps.jpg" as a jpeg
+@ (0L, 0L) = [40 35 57]
+@ (0L, 1535L) = [ 82  94 136]
+
+Testing read_tile:
+Opened "grid.tx" as a tiff
+@ (32L, 32L) = [  1   1   1 255]
+@ (32L, 32L) = [255 127 127 255]
+
+Testing read_scanlines:
+Opened "../../../../../oiio-images/tahoe-gps.jpg" as a jpeg
+@ (0L, 0L) = [40 35 57]
+@ (2047L, 1535L) = [37 56 89]
+@ (1024L, 768L) = [137 183 233]
+
+Testing read_tiles:
+Opened "grid.tx" as a tiff
+@ (0L, 0L) = [  0   0   0 255]
+@ (1023L, 1023L) = [  0   0   0 255]
+@ (512L, 512L) = [  0   0   0 255]
+
+Test read_image native u16:
+Opened "testu16.tif" as a tiff
+Read array typecode uint16  [ 12288 ]
+
+Test read_scanlines native u16:
+Opened "testu16.tif" as a tiff
+Read array typecode uint16  [ 12288 ]
+
+Test read_tiles native half:
+Opened "testf16.exr" as a openexr
+Read array typecode uint16  [ 12288 ]
+
+Test read_image into half:
+Opened "testu16.tif" as a tiff
+Read array typecode uint16  [ 12288 ]
+
+Test read_image into FLOAT:
+Opened "testu16.tif" as a tiff
+Read array typecode float32  [ 12288 ]
+
+Done.

--- a/testsuite/python-imageinput/src/test_imageinput.py
+++ b/testsuite/python-imageinput/src/test_imageinput.py
@@ -113,6 +113,13 @@ def test_readimage (filename, sub=0, mip=0, type=oiio.UNKNOWN,
         print ("@", (x,y), "=", data[y,x])
     else :
         print ("Read array typecode", data.dtype, " [", data.size, "]")
+    # Test the spec and spec_dimensions methods
+    spec = input.spec_dimensions (0, 0)
+    if len(spec.extra_attribs) > 0 :
+        print ("wrong spec_dimensions(s,m) metadata items: ", len(spec.extra_attribs))
+    spec = input.spec (0, 0)
+    if len(spec.extra_attribs) == 0 :
+        print ("wrong spec(s,m) metadata items: ", len(spec.extra_attribs))
     input.close ()
     print ()
 

--- a/testsuite/python-imagespec/ref/out-python3.txt
+++ b/testsuite/python-imagespec/ref/out-python3.txt
@@ -101,7 +101,7 @@ extra_attribs size is 5
 1 0 0 0 0 2 0 0 0 0 1 0 1 2 3 1
 
 seralize(xml):
-<ImageSpec version="20">
+<ImageSpec version="21">
 <x>1</x>
 <y>2</y>
 <z>3</z>

--- a/testsuite/python-imagespec/ref/out.txt
+++ b/testsuite/python-imagespec/ref/out.txt
@@ -101,7 +101,7 @@ extra_attribs size is 5
 1 0 0 0 0 2 0 0 0 0 1 0 1 2 3 1
 
 seralize(xml):
-<ImageSpec version="20">
+<ImageSpec version="21">
 <x>1</x>
 <y>2</y>
 <z>3</z>


### PR DESCRIPTION
Summary: In order to reduce the amount of thread locking in ImageCache (in particular, of each file's ImageInput, when multiple threads are asking for tiles of the same file), we need to make certain ImageInput operations inherently thread-safe, which they currently are not because of the stateful relationship between seek_subimage() and read_stuff(). We introduce additional varieties of ImageInput read_*, spec(), and spec_dimensions() that are stateless because they take explicit subimage and miplevel parameters, and are also guaranteed to be mutually thread-safe.

I'm sorry to say that results are mixed: on some scenes/tests, this speeds up highly threaded renders by up to 4%, on others it doesn't seem to make any difference. But every little bit helps, it's a small step forward, and I think that phasing out the stateful interface in favor of the new one is the right thing to do.

More detailed explanastion of the commits follow:

First, ImageInput overhaul for better thread safety and efficiency.
The point of all this is to take client code that looks like this:

        lock();  // necessary because of implied state of the current
                 // subimage/miplevel between the seek_subimage and
                 // subsequent read.
        imageinput->seek_subimage (subimage, miplevel);
        read_scanlines (ybegin, yend, z, pixels);
        unlock();

and replace it with this:

        read_scanlines (subimage, miplevel, ybegin, yend, z, pixels);

with no implied saved state (at least, none that is relevant and visible
to the client), and thus with no client-side lock necessary.

* Change signature of seek_subimage to no longer take an ImageSpec&,    to avoid an obligatory ImageSpec copy that is often unnecessary.   The preferred idiom, if one must call seek_subimage at all, is to   call it and then separately copy the spec(). For back compatibility,   a non-overloadable entry point exists that matches the old call   signature, but should be considered a candidate for deprecation.

* All of the read_native_*() methods take subimage and miplevel       parameters, are expected to do a seek_subimage if necessary.      For the read_native_deep_*() methods, which are the only ones that      user could would ordinarily have called, back-compatible entry points      exist (but should be considered deprecated and not thread-safe).

* New varieties of read_scanlines, read_tiles(), and read_image() are      available that takes explicit subimage and miplevel parameters (and      thus do not require a stateful prior call to seek_subimage).

* All of the read_* calls that take explicit subimage/miplevel parameters      are guaranteed to be thread-safe against concurrent calls to any other      of the read_* calls with explicit subimage/miplevel (but not necessarily      against any other ImageInput methods).

* The ImageInput base class contains a mutex now, to be used internally      by functions that need to lock.

* The generic implementations of read_scanlines/tiles, and the specific      implementations for TIFF and OpenEXR, are very carefully constructed      to hold their internal locks for as little time as possible, only when      required by the underlying format-reading library).

Second, we add new methods ImageInput::spec(s,m) and spec_dimensions(s,m).

The previously existing spec() is not thread-safe, since it depends on retained state of the last seek_subimage. It also returns a const     reference to a single ImageSpec, so it's not even safe to access the     resulting reference if there may be other threads that might change the     current subimage or miplevel.

The new spec(s,m) is thread-safe, and it COPIES the result. The base    class default implementation just locks, does the seek, and    copies. Individual ImageInput subclass implementations may do something    more clever, for example if they are already inventorying and retaining    the ImageSpec's for all subimages, they may not need to lock or seek at    all.

Beware, though, that because it makes a full copy of the ImageSpec, it    may be expensive if the spec in quesiton contains a lot of arbitrary    metadata (which need to be allocated and copied individually).

So there is a second thread-safe method, spec_dimensions(s,m), which    only copies the dimensional and type fields of the spec (just like    ImageSpec::copy_dimensions()), omitting the channel names and the    arbitrary named metadata in the extra_attribs field. This is very    inexpensive copared to copying the rest of the metadata.

Overload these with custom versions for OpenEXR and TIFF. For OpenEXR,    we already collected all the specs, so we can return it without doing a    lock, seek, or read at all. For TIFF, we change to save the specs (not    unlike what we did all along with OpenEXR), and now for the cost of a    shortly-held lock, we can usually avoid the seek and read and just copy.
