### PR TITLE
I/O proxies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,10 +6,6 @@ Major new features and improvements:
 * Major refactor of Exif metadata handling, including much more complete
   metadata support for RAW formats and support of camera "maker notes"
   for Canon cameras. #1774 (1.9.0)
-* New "null" I/O plugin -- null reader just returns black (or constant
-  colored) pixels, null writer just returns. This can be used for
-  benchmarking (to eliminate all actual file I/O time), "dry run" where you
-  want to test without creating output files. #1778 (1.9.0)
 * New `maketx` option `--bumpslopes` specifically for converting bump maps,
   saves additional channels containing slope distribution moments that can
   be used in shaders for "bump to roughness" calculations. #1810,#1913 (1.9.2)
@@ -18,6 +14,16 @@ Major new features and improvements:
   on modern multicore systems. We've seen 10x or more faster oiiotool
   performance for uint8 and uint16 TIFF files using "zip" (deflate)
   compression, on modern 12-16 core machines. #1853 (1.9.2)
+* For some readers and writers, an "IOProxy" can be passed that customizes
+  the I/O methods. An important use of this is to write an image "file"
+  to memory or to read an image "file" from a memory, rather than disk.
+  Currently, OpenEXR supports this for both reading and writing, and PNG
+  supports it for writing. You specify a pointer to the proxy via the
+  configuration option "oiio:ioproxy". #1931 (1.9.3)
+* New "null" I/O plugin -- null reader just returns black (or constant
+  colored) pixels, null writer just returns. This can be used for
+  benchmarking (to eliminate all actual file I/O time), "dry run" where you
+  want to test without creating output files. #1778 (1.9.0)
 
 Public API changes:
 * **Python binding overhaul**
@@ -257,6 +263,9 @@ Developer goodies / internals:
   constructors from pointer pairs and from std::array. (1.9.0/1.8.6)
 * color.h: add guards to make this header safe for Cuda compilation.
   #1905 (1.9.2/1.8.10)
+* filesystem.h:
+    * IOProxy classes that can abstract file operations for custom I/O
+      substitutions. #1931 (1.9.3)
 * fmath.h:
     * Now defines preprocessor symbol `OIIO_FMATH_H` so other files can
       easily detect if it has been included. (1.9.0/1.8.6)

--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -681,6 +681,10 @@ The official OpenEXR site is \url{http://www.openexr.com/}.
   name and apparent type.
 \end{longtable}
 
+OpenEXR input and output both support the ``custom I/O'' feature via the
+special \qkw{oiio:ioproxy} attributes (see
+Sections~\ref{sec:imageoutput:ioproxy} and \ref{sec:imageinput:ioproxy}).
+
 \subsubsection*{A note on channel names}
 
 The underlying OpenEXR library (libIlmImf) always saves channels
@@ -731,6 +735,9 @@ PNG files use the file extension {\cf .png}.
 \qkw{oiio:Gamma} & float & the gamma correction value (if specified). \\
 \qkw{ICCProfile} & uint8[] & The ICC color profile \\
 \end{tabular}
+
+PNG output supports the ``custom I/O'' feature via the special
+\qkw{oiio:ioproxy} attributes (see Section~\ref{sec:imageoutput:ioproxy}).
 
 \subsubsection*{Limitations}
 

--- a/src/doc/imageinput.tex
+++ b/src/doc/imageinput.tex
@@ -680,6 +680,58 @@ a file and print all its values:
 \end{code}
 
 
+\subsection{Custom I/O proxies (and reading the file from a memory buffer)}
+\label{sec:imageinput:ioproxy}
+\index{reading an image file from memory buffer}
+\NEW   % 1.9
+
+Some file format readers allow you to supply a custom I/O proxy object that
+can allow bypassing the usual file I/O with custom behavior, including the
+ability to read the file form an in-memory buffer rather than reading from
+disk.
+
+Only some input format readers support this feature. To find out if a
+particular file format supports this feature, you can create an \ImageInput
+of the right type, and check if it supports the feature name \qkw{ioproxy}:
+
+\begin{code}
+    ImageInput *in = ImageInput::create (filename);
+    if (! in  ||  ! in->supports ("ioproxy")) {
+        ImageInput::destroy (in);
+        in = nullptr;
+        return;
+    }
+\end{code}
+
+\ImageInput readers that support \qkw{ioproxy} will respond to a special
+attribute, \qkw{oiio:ioproxy}, which passes a pointer to a {\cf
+Filesystem::IOProxy*} (see \product's {\cf filesystem.h} for this type and
+its subclasses). {\cf IOProxy} is an abstract type, and concrete subclasses
+include {\cf IOFile} (which wraps I/O to an open {\cf FILE*}) and {\cf
+IOMemReader} (which reads input from a block of memory).
+
+Here is an example of using a proxy that reads the ``file'' from a memory
+buffer:
+
+\begin{code}
+    const void *buf = ...;   // pointer to memory block
+    size_t size = ...;       // length of memory block
+
+    ImageSpec config; // ImageSpec describing input configuration options
+    Filesystem::IOMemReader memreader (buf, size);  // I/O proxy object
+    void *ptr = &memreader;
+    config.attribute ("oiio:ioproxy", TypeDesc::PTR, &ptr);
+
+    ImageSpec spec;
+    ImageInput *in = ImageInput::open ("in.exr", spec, &config);
+    in->read_image (...);
+    ImageInput::destroy (in);
+
+    // That will have read the "file" from the memory buffer
+\end{code}
+
+
+
 \subsection{Custom search paths for plugins}
 \label{sec:imageinput:searchpaths}
 
@@ -781,10 +833,14 @@ will be tried until one is found that will open the file.
 \apiend
 
 \apiitem{ImageInput * {\ce create} (const std::string \&filename, \\
-\bigspc\bigspc   const std::string \&plugin_searchpath="")}
+\bigspc\bigspc   bool do_open=false, const ImageSpec *config=nullptr,\\
+\bitspc\bigspc   string_view plugin_searchpath="")}
 
 Create and return an \ImageInput implementation that is able
-to read the given file.  The {\kw plugin_searchpath} parameter is a
+to read the given file.  If {\cf do_open} is {\cf true}, fully open it if
+possible (using the optional configuration spec, if supplied),
+otherwise just create the \ImageInput but don't open it.
+The {\kw plugin_searchpath} parameter is an override of the searchpath,
 colon-separated list of directories to search for \product plugin
 DSO/DLL's (not a searchpath for the image itself!).  This will
 actually just try every ImageIO plugin it can locate, until it
@@ -827,6 +883,8 @@ as such). The following features are recognized by this query:
 \item[\rm \qkw{procedural}] Might the image ``file format'' generate pixels
   procedurally, without the need for any disk file to be present?
   \end{description}
+\item[\rm \qkw{ioproxy}] Does the image file format support reading
+  from an {\cf IOProxy}?
 \apiend
 
 \apiitem{bool {\ce valid_file} (const std::string \&filename) const}

--- a/src/doc/imageoutput.tex
+++ b/src/doc/imageoutput.tex
@@ -1135,6 +1135,57 @@ without alteration while modifying the image description metadata:
 \end{code}
 
 
+\subsection{Custom I/O proxies (and writing the file to a memory buffer)}
+\label{sec:imageoutput:ioproxy}
+\index{writing an image file to memory buffer}
+\NEW   % 1.9
+
+Some file format writers allow you to supply a custom I/O proxy object that
+can allow bypassing the usual file I/O with custom behavior, including the
+ability to fill an in-memory buffer with a byte-for-byte representation of
+the correctly formatted file that would have been written to disk.
+
+Only some output format writers support this feature. To find out if a
+particular file format supports this feature, you can create an \ImageOutput
+of the right type, and check if it supports the feature name \qkw{ioproxy}:
+
+\begin{code}
+    ImageOutput *out = ImageOutput::create (filename);
+    if (! out  ||  ! out->supports ("ioproxy")) {
+        ImageOutput::destroy (out);
+        out = nullptr;
+        return;
+    }
+\end{code}
+
+\ImageOutput writers that support \qkw{ioproxy} will respond to a special
+attribute, \qkw{oiio:ioproxy}, which passes a pointer to a {\cf
+Filesystem::IOProxy*} (see \product's {\cf filesystem.h} for this type and
+its subclasses). {\cf IOProxy} is an abstract type, and concrete subclasses
+include {\cf IOFile} (which wraps I/O to an open {\cf FILE*}) and {\cf
+IOVecOutput} (which sends output to a {\cf std::vector<unsigned char>}).
+
+Here is an example of using a proxy that writes the ``file'' to a
+{\cf std::vector<unsigned char>}:
+
+\begin{code}
+    // ImageSpec describing the image we want to write.
+    ImageSpec spec (xres, yres, channels, TypeDesc::UINT8);
+
+    std::vector<unsigned char> file_buffer;  // bytes will go here
+    Filesystem::IOVecOutput vecout (file_buffer);  // I/O proxy object
+    void *ptr = &file_buffer;
+    spec.attribute ("oiio:ioproxy", TypeDesc::PTR, &ptr);
+
+    ImageOutput *out = ImageOutput::open ("out.exr", spec);
+    out->write_image (...);
+    ImageOutput::destroy (out);
+
+    // At this point, file_buffer will contain the "file"
+\end{code}
+
+
+
 \subsection{Custom search paths for plugins}
 \label{sec:imageoutput:searchpaths}
 
@@ -1331,6 +1382,8 @@ as such). The following features are recognized by this query:
   (either specifically, or via arbitrary named metadata)?
 \item[\rm \qkw{iptc}] Does the image file format support IPTC data
   (either specifically, or via arbitrary named metadata)?
+\item[\rm \qkw{ioproxy}] Does the image file format support writing
+  to an {\cf IOProxy}?
 \end{description}
 
 \noindent This list of queries may be extended in future releases.

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -95,7 +95,7 @@
  \bigskip \\
 }
 \date{{\large
-Date: 7 Apr 2018
+Date: 29 Apr 2018
 %\\ (with corrections, 19 Mar 2018)
 }}
 

--- a/src/doc/stdmetadata.tex
+++ b/src/doc/stdmetadata.tex
@@ -200,6 +200,27 @@ plugins and compression methods that allow a variable amount of
 compression, with higher numbers indicating higher image fidelity.
 \apiend
 
+\section{Substituting an {\cf IOPRoxy} for custom I/O overrides}
+\index{writing an image file to memory buffer}
+\index{reading an image file to memory buffer}
+
+\NEW % 1.9
+Format readers and writers that respond positively to {\cf
+supports("ioproxy")} have the ability to read or write using an \emph{I/O
+proxy} object. Among other things, this lets an \ImageOutput write the file
+to a memory buffer rather than saving to disk, and for an \ImageInput to
+read the file from a memory buffer. (Currently, only PNG and OpenEXR have
+the ability to do this.) This behavior is controlled by a special attributes
+
+\apiitem{"oiio:ioproxy" : pointer}
+Pointer to a {\cf Filesystem::IOProxy} that will handle the I/O.
+\apiend
+
+An explanation of how this feature is used may be found in
+Sections~\ref{sec:imageoutput:writefiletomemory} and
+\ref{sec:imageoutput:writefiletomemory}.
+
+
 \section{Photographs or scanned images}
 
 The following metadata items are specific to photos or captured images.

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -627,18 +627,23 @@ public:
     static ImageInput *open (const std::string &filename,
                              const ImageSpec *config = NULL);
 
-    /// Create and return an ImageInput implementation that is willing
-    /// to read the given file.  The plugin_searchpath parameter is a
+    /// Create and return an ImageInput implementation that is able
+    /// to read the given file.  If do_open is true, fully open it if
+    /// possible (using the optional configuration spec, if supplied),
+    /// otherwise just create the ImageInput but don't open it.
+    /// The plugin_searchpath parameter is an override of the searchpath.
     /// colon-separated list of directories to search for ImageIO plugin
     /// DSO/DLL's (not a searchpath for the image itself!).  This will
     /// actually just try every imageio plugin it can locate, until it
-    /// finds one that's able to open the file without error.  This just
-    /// creates the ImageInput, it does not open the file.
+    /// finds one that's able to open the file without error.
     ///
     /// If the caller intends to immediately open the file, then it is
-    /// simpler to call static ImageInput::open().
+    /// often simpler to call static ImageInput::open().
+    static ImageInput *create (const std::string &filename, bool do_open=false,
+                               const ImageSpec *config=nullptr,
+                               string_view plugin_searchpath="");
     static ImageInput *create (const std::string &filename,
-                               const std::string &plugin_searchpath="");
+                               const std::string &plugin_searchpath);
 
     /// Destroy an ImageInput that was created using ImageInput::create() or
     /// the static open(). For some systems (Windows, I'm looking at you),
@@ -673,6 +678,7 @@ public:
     ///    "iptc"           Can this format store IPTC data?
     ///    "procedural"     Can this format create images without reading
     ///                        from a disk file?
+    ///    "ioproxy"        Does this format reader support IOProxy?
     ///
     /// Note that main advantage of this approach, versus having
     /// separate individual supports_foo() methods, is that this allows
@@ -1133,9 +1139,9 @@ private:
     mutable std::string m_errmessage;  // private storage of error message
     int m_threads;    // Thread policy
     void append_error (const std::string& message) const; // add to m_errmessage
+    // Deprecated:
     static ImageInput *create (const std::string &filename, bool do_open,
                                const std::string &plugin_searchpath);
-
 };
 
 
@@ -1217,6 +1223,7 @@ public:
     ///                        arbitrary names and types?
     ///    "exif"           Can this format store Exif camera data?
     ///    "iptc"           Can this format store IPTC data?
+    ///    "ioproxy"        Does this format writer support IOProxy?
     ///
     /// Note that main advantage of this approach, versus having
     /// separate individual supports_foo() methods, is that this allows

--- a/src/libOpenImageIO/imagebuf_test.cpp
+++ b/src/libOpenImageIO/imagebuf_test.cpp
@@ -362,6 +362,97 @@ test_read_channel_subset ()
 
 
 
+void
+test_write_png_to_memory ()
+{
+    std::cout << "\nTesting writing a png file to a memory buffer\n";
+
+    // Make a 2x2 red image
+    ImageSpec spec (2, 2, 3, TypeUInt8);
+    ImageBuf buf (spec);
+    float red[3] = { 1, 0, 0 };
+    ImageBufAlgo::fill (buf, red);
+
+    // Use an IOVecOutput proxy to make the bytes go to file_buffer instead
+    // of to disk.
+    std::vector<unsigned char> file_buffer;
+    Filesystem::IOVecOutput memout (file_buffer);
+    void *ptr = &memout;
+    buf.specmod().attribute ("oiio:ioproxy", TypeDesc::PTR, &ptr);
+
+    // Write the image. The proxy should do its magic.
+    buf.write ("test.png");
+
+    // Check the results against the output of `hexdump test.png` when we
+    // saved the same image to disk. It should be byte-by-byte identical.
+    static const unsigned char reference[] = {
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+        0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x02, 0x08, 0x02, 0x00, 0x00, 0x00, 0xfd, 0xd4, 0x9a,
+        0x73, 0x00, 0x00, 0x00, 0x09, 0x6f, 0x46, 0x46, 0x73, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0xda, 0x2a, 0xb6, 0xce, 0x00, 0x00, 0x00, 0x10, 0x49, 0x44, 0x41, 0x54, 0x08, 0x99,
+        0x63, 0xfc, 0xcf, 0x00, 0x02, 0x4c, 0x60, 0x92, 0x01, 0x00, 0x0d, 0x1d, 0x01, 0x03, 0x6e, 0x28,
+        0x7c, 0x6d, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82
+    };
+    OIIO_CHECK_EQUAL (file_buffer.size(), 94ul);
+    OIIO_CHECK_ASSERT (! memcmp (file_buffer.data(), reference, file_buffer.size()));
+    // for (size_t i = 0; i < file_buffer_size; ++i)
+    //     Strutil::printf ("%c%02x", i%16 ? ' ' : '\n', file_buffer[i]);
+    // Strutil::printf ("\n");
+
+}
+
+
+
+void
+test_write_exr_to_memory ()
+{
+    std::cout << "\nTesting writing an exr to a memory buffer\n";
+
+    // Make a 2x2 red image
+    ImageSpec spec (2, 2, 3, TypeHalf);
+    ImageBuf buf (spec);
+    float red[3] = { 1, 0, 0 };
+    ImageBufAlgo::fill (buf, red);
+
+    // Use an IOVecOutput proxy to make the bytes go to file_buffer instead
+    // of to disk.
+    std::vector<unsigned char> file_buffer;
+    Filesystem::IOVecOutput memout (file_buffer);
+    void *ptr = &memout;
+    buf.specmod().attribute ("oiio:ioproxy", TypeDesc::PTR, &ptr);
+       // N.B. comment out the above line to write to disk
+
+    // Write the image. The proxy should do its magic.
+    buf.write ("test.exr");
+
+    // Check the results against the known size of the disk output.
+    OIIO_CHECK_EQUAL (file_buffer.size(), 383ul);
+
+    // Now read it back again:
+    // * Set up an IOMemReader that reads from the buffer we have
+    Filesystem::IOMemReader memreader (file_buffer);
+    // * Make an config that specifies the memreader as IOProxy.
+    ImageSpec configspec;
+    ptr = &memreader;
+    configspec.attribute ("oiio:ioproxy", TypeDesc::PTR, &ptr);
+    // * Make an ImageBuf that uses that config.
+    ImageBuf readbuf ("test.exr", 0, 0, nullptr, &configspec);
+    // * The image we read should be the same as the one we started with.
+    OIIO_CHECK_EQUAL (readbuf.spec().height*readbuf.spec().width, 4);
+    for (int y = 0; y < readbuf.spec().height; ++y) {
+        for (int x = 0; x < readbuf.spec().width; ++x) {
+            float rpixel[3], bpixel[3];
+            readbuf.getpixel (x, y, rpixel);
+            buf.getpixel (x, y, bpixel);
+            OIIO_CHECK_EQUAL (rpixel[0], bpixel[0]);
+            OIIO_CHECK_EQUAL (rpixel[1], bpixel[1]);
+            OIIO_CHECK_EQUAL (rpixel[2], bpixel[2]);
+        }
+    }
+}
+
+
+
 int
 main (int argc, char **argv)
 {
@@ -383,6 +474,9 @@ main (int argc, char **argv)
 
     test_set_get_pixels ();
     time_get_pixels ();
+
+    test_write_png_to_memory ();
+    test_write_exr_to_memory ();
 
     Filesystem::remove ("A_imagebuf_test.tif");
     return unit_test_failures;

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -85,11 +85,11 @@ ImageInput::open (const std::string &filename,
 {
     if (config == NULL) {
         // Without config, this is really just a call to create-with-open.
-        return ImageInput::create (filename, true, std::string());
+        return ImageInput::create (filename, true, nullptr, std::string());
     }
 
     // With config, create without open, then try to open with config.
-    ImageInput *in = ImageInput::create (filename, false, std::string());
+    ImageInput *in = ImageInput::create (filename, false, config, std::string());
     if (! in)
         return NULL;  // create() failed
     ImageSpec newspec;

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -694,7 +694,7 @@ write_mipmap (ImageBufAlgo::MakeTextureMode mode,
             if (mipimages.size()) {
                 // Special case -- the user specified a custom MIP level
                 small->reset (mipimages[0]);
-                small->read (0, 0, true, TypeDesc::FLOAT);
+                small->read (0, 0, true, TypeFloat);
                 smallspec = small->spec();
                 if (smallspec.nchannels != outspec.nchannels) {
                     outstream << "WARNING: Custom mip level \"" << mipimages[0]

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -477,22 +477,23 @@ ImageCacheFile::open (ImageCachePerThreadInfo *thread_info)
         return inp;
     ASSERT (inp.get() == nullptr);
 
+    ImageSpec configspec;
+    if (m_configspec)
+        configspec = *m_configspec;
+    if (imagecache().unassociatedalpha())
+        configspec.attribute ("oiio:UnassociatedAlpha", 1);
+
     if (m_inputcreator)
         inp.reset (m_inputcreator());
     else
-        inp.reset (ImageInput::create (m_filename.string(),
+        inp.reset (ImageInput::create (m_filename.string(), false,
+                                       &configspec,
                                        m_imagecache.plugin_searchpath()));
     if (! inp) {
         mark_broken (OIIO::geterror());
         invalidate_spec ();
         return {};
     }
-
-    ImageSpec configspec;
-    if (m_configspec)
-        configspec = *m_configspec;
-    if (imagecache().unassociatedalpha())
-        configspec.attribute ("oiio:UnassociatedAlpha", 1);
 
     ImageSpec nativespec, tempspec;
     mark_not_broken ();

--- a/src/libutil/filesystem_test.cpp
+++ b/src/libutil/filesystem_test.cpp
@@ -440,6 +440,30 @@ void test_scan_sequences ()
 
 
 
+void test_mem_proxies ()
+{
+    std::cout << "Testing memory file proxies:\n";
+    std::vector<unsigned char> input_buf { 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 };
+    std::vector<unsigned char> output_buf;
+
+    Filesystem::IOMemReader in (input_buf);
+    Filesystem::IOVecOutput out (output_buf);
+    char b[4];
+    size_t len = 0;
+    while ((len = in.read(b,4)))  // read up to 4 bytes at a time
+        out.write(b, len);
+    OIIO_CHECK_ASSERT (input_buf == output_buf);
+    // Now test seeking
+    in.seek (3);
+    out.seek (1);
+    in.read (b, 2);
+    out.write (b, 2);
+    std::vector<unsigned char> ref_buf { 10, 13, 14, 13, 14, 15, 16, 17, 18, 19 };
+    OIIO_CHECK_ASSERT (output_buf == ref_buf);
+}
+
+
+
 int main (int argc, char *argv[])
 {
     test_filename_decomposition ();
@@ -447,6 +471,7 @@ int main (int argc, char *argv[])
     test_file_status ();
     test_frame_sequences ();
     test_scan_sequences ();
+    test_mem_proxies ();
 
     return unit_test_failures;
 }

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -324,6 +324,9 @@ ParamValue::get_string (int maxsize) const
         formatType< unsigned char >(*this, n, "%d", out);
     } else if (element.basetype == TypeDesc::INT8) {
         formatType< char >(*this, n, "%d", out);
+    } else if (element.basetype == TypeDesc::PTR) {
+        out += "ptr ";
+        formatType< void* >(*this, n, "%p", out);
     } else {
         out += Strutil::format ("<unknown data type> (base %d, agg %d vec %d)",
                 type().basetype, type().aggregate,

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -329,6 +329,13 @@ destroy_read_struct (png_structp& sp, png_infop& ip)
 }
 
 
+inline void
+null_png_errhandler (png_structp png, png_const_charp message)
+{
+    // ignore
+}
+
+
 
 /// Initializes a PNG write struct.
 /// \return empty string on success, C-string error message on failure.
@@ -371,7 +378,8 @@ create_write_struct (png_structp& sp, png_infop& ip, int& color_type,
     // N.B. PNG is very rigid about the meaning of the channels, so enforce
     // which channel is alpha, that's the only way PNG can do it.
 
-    sp = png_create_write_struct (PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+    sp = png_create_write_struct (PNG_LIBPNG_VER_STRING,
+                                  nullptr, null_png_errhandler, nullptr);
     if (! sp)
         return "Could not create PNG write structure";
 


### PR DESCRIPTION
For ImageOutput and ImageInput, supports("ioproxy") will now return true for a     format reader or writer that supports the ability to use a     Filesystem::IOProxy object for customized I/O.

For supporting formats, the caller can pass the IOProxy via    a special attribute in the ImageSpec that is passed to    ImageOutput::open() or the configuration ImageSpec passed to    ImageInput::open():

     "oiio:ioproxy" (PTR) is a pointer to a `Filesystem::IOProxy`.

One use for this is to read an image "file" from an in-memory buffer     (using the IOProxy subclass IOMemReader), or to write an image "file" to    an in-memory buffer (using the IOProxy subclass IOVecOutput).

The documentation (in the ImageInput and ImageOutput chapters) and    imagebuf_test.cpp contain examples showing how to do this. It's also pretty straightforward for both ImageBuf and ImageCache to do this, since in both cases there is a way to declare the configuration spec to use when the file is opened.

We implement both reading and writing with I/O proxies for OpenEXR,    and writing with prixies for PNG. More format support will be added    as needed.

The IOProxy itself is implemented in the Filesystem namespace (filesystem.h).     IOProxy is an abstract base class that presents a very simple API that     encapsulates fundamental file methods: seek, tell, read, write, close.

We initially implement three concrete subclasses of IOProxy:

* IOFile : wraps a FILE*, can be used for either input and output (but      not both).

* IOMemReader : wraps a memory buffer, so it can be read "like a file".

* IOVecOutput : wraps a std::vector<unsigned char>, so writing "like a      file" stores the bytes in the vector.
