### PR TITLE
ffmpeg: more precise time for switching symbol to AV_CODEC_CAP_DELAY

### DIFF
--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -128,7 +128,7 @@ inline int receive_frame(AVCodecContext *avctx, AVFrame *picture,
 // Changes for ffmpeg 4.0
 #define USE_FFMPEG_4_0 (LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 18, 100))
 
-#if USE_FFMPEG_4_0
+#if (LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(56, 56, 100))
 #  define CODEC_CAP_DELAY AV_CODEC_CAP_DELAY
 #endif
 


### PR DESCRIPTION
There are some intermediate checkins between ffmpeg 3.4 and 4.0 where my previous attempt at this broke. So switch to the new symbol as soon as it was introduced (a while back). Fixes #1935
