### PR TITLE
Adjust __GLIBCXX__ test guarding use of std::atomic_load(ptr)

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -330,7 +330,7 @@ ImageCacheFile::~ImageCacheFile ()
 std::shared_ptr<ImageInput>
 ImageCacheFile::get_imageinput (ImageCachePerThreadInfo *thread_info)
 {
-#if defined(__GLIBCXX__) && __GLIBCXX__ < 20160427
+#if defined(__GLIBCXX__) && __GLIBCXX__ < 20160822
     // Older gcc libstdc++ does not properly support std::atomic
     // operations on std::shared_ptr, despite it being a C++11
     // feature. No choice but to lock.
@@ -349,7 +349,7 @@ ImageCacheFile::set_imageinput (std::shared_ptr<ImageInput> newval)
 {
     if (newval)
         imagecache().incr_open_files ();
-#if defined(__GLIBCXX__) && __GLIBCXX__ < 20160427
+#if defined(__GLIBCXX__) && __GLIBCXX__ < 20160822
     // Older gcc libstdc++ does not properly support std::atomic
     // operations on std::shared_ptr, despite it being a C++11
     // feature. No choice but to lock.


### PR DESCRIPTION
I didn't realize that the prior number I picked inadvertently included
a 4.9 version that did not in fact support this feature.

Changing to the new value will not have any more "false positives" (error
by incorrectly thinking the feature is present), but does make a "false
negative" (avoid the feature even though it's supported) for gcc 5 and
gcc < 6.2, even though it would work there. That will still behave
correctly, though at a very slight performance penalty, but VFXPlatform
skips from gcc 4.8 to gcc 6.3, thus leapfrogging over those false
negative cases. So I'm going to not care that we get less than maximal
performance from some compiler+library versions that we are unlikely to
use.
