### PR TITLE
Avoid warning from pybind11 vs Python.h interaction

### DIFF
--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -28,9 +28,10 @@
   (This is the Modified BSD License)
 */
 
+#include "py_oiio.h"
+
 #include <memory>
 
-#include "py_oiio.h"
 #include <OpenImageIO/platform.h>
 
 

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -27,9 +27,10 @@
 
   (This is the Modified BSD License)
 */
+
+#include "py_oiio.h"
 #include <OpenImageIO/color.h>
 #include <OpenImageIO/imagebufalgo.h>
-#include "py_oiio.h"
 
 
 namespace PyOpenImageIO

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -31,6 +31,9 @@
 #ifndef PYOPENIMAGEIO_PY_OIIO_H
 #define PYOPENIMAGEIO_PY_OIIO_H
 
+// Must include Python.h first to avoid certain warnings
+#include <Python.h>
+
 #include <memory>
 
 // Avoid a compiler warning from a duplication in tiffconf.h/pyconfig.h


### PR DESCRIPTION
Fixes #1938 
