### PR TITLE
OpenEXR better UTF-8 filename support

### DIFF
--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -343,7 +343,12 @@ OpenEXRInput::OpenEXRInput ()
 bool
 OpenEXRInput::valid_file (const std::string &filename) const
 {
-    return Imf::isOpenExrFile (filename.c_str());
+    try {
+        OpenEXRInputStream IStream (filename.c_str());
+        return Imf::isOpenExrFile (IStream);
+    } catch (const std::exception &e) {
+        return false;
+    }
 }
 
 
@@ -356,8 +361,7 @@ OpenEXRInput::open (const std::string &name, ImageSpec &newspec)
         error ("Could not open file \"%s\"", name.c_str());
         return false;
     }
-    bool tiled;
-    if (! Imf::isOpenExrFile (name.c_str(), tiled)) {
+    if (! valid_file(name)) {
         error ("\"%s\" is not an OpenEXR file", name.c_str());
         return false;
     }


### PR DESCRIPTION
We already were careful when opening the file to use the
OpenEXRInputStream to ensure proper UTF-8 filename handling.

But valid_file() used Imf::isOpenExrFile, which is not careful enough.
So we instead switch to making an IStream and then calling the version
of isOpenExrFile that takes the stream. Should be correct.

