### PR TITLE
Fixes to un-break the EMBEDPLUGINS=0 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,12 +166,13 @@ matrix:
         compiler: gcc
         env: WHICHGCC=6 SANITIZE=address USE_PYTHON=0
     # One more, just for the heck of it, turn all SIMD off, and also make
-    # sure we're falling back on libjpeg, not jpeg-turbo.  I guess this
+    # sure we're falling back on libjpeg, not jpeg-turbo, and don't embed
+    # the plugins (to make sure that doesn't rust away).  I guess this
     # should/could be both platforms, but in the interest of making the
     # tests go faster, don't bother doing it on OSX.
       - os: linux
         compiler: gcc
-        env: USE_SIMD=0 USE_JPEGTURBO=0
+        env: USE_SIMD=0 USE_JPEGTURBO=0 EMBEDPLUGINS=0
     # build for AVX2, don't run the tests (ensure against build breaks)
       - os: linux
         compiler: gcc

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -2,8 +2,7 @@ if (VERBOSE)
    message (STATUS "Create imagio_pvt.h from imageio_pvt.h.in")
 endif ()
 file (TO_NATIVE_PATH "${PLUGIN_SEARCH_PATH}" PLUGIN_SEARCH_PATH_NATIVE)
-configure_file (imageio_pvt.h.in "${CMAKE_CURRENT_BINARY_DIR}/imageio_pvt.h" @ONLY)
-include_directories("${CMAKE_CURRENT_BINARY_DIR}")
+configure_file (imageio_pvt.h.in "${CMAKE_BINARY_DIR}/include/imageio_pvt.h" @ONLY)
 
 file (GLOB libOpenImageIO_hdrs ../include/OpenImageIO/*.h)
 


### PR DESCRIPTION
This had been broken for a while, I guess we stopped testing the EMBEDPLUGINS=0 case (i.e. building each format reader/writer as a separate DSO/DLL instead of compiling them all into the main libOpenImageIO library). This is still an important case to test, since it verifies that it's still easy to supply run-time / site-specific / custom format-reading functionality as dynamic libraries.

The only thing that was really broken was where certain include files were found. Easy to fix. Add the EMBEDPLUGINS=0 to one of the Travis test cases to be sure we don't break again.
