### PR TITLE
ImageBuf::set_origin()

### DIFF
--- a/src/doc/imagebuf.tex
+++ b/src/doc/imagebuf.tex
@@ -348,8 +348,16 @@ The data type of the pixels stored in the buffer (equivalent to
 {\cf spec().format}).
 \apiend
 
+\apiitem{void {\ce set_origin} (int x, int y, int z=0)}
+\NEW % 1.9
+Alters the metadata of the spec in the \ImageBuf to reset the ``origin''
+of the pixel data window to be the specified coordinates.  This does not
+affect the size of the pixel data window, only its position.
+\apiend
+
 \apiitem{void {\ce set_full} (int xbegin, int xend, int ybegin, int yend, \\
-  \bigspc\spc       int zbegin, int zend)}
+  \bigspc\spc       int zbegin, int zend) \\
+  void {\ce set_roi_full} (const ROI \&newroi)}
 Alters the metadata of the spec in the \ImageBuf to reset the ``full''
 image size (a.k.a.\ ``display window'').  This does not affect the size
 of the pixel data window.

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -1571,6 +1571,18 @@ These fields return an \ROI description of the pixel data window
 \end{code}
 \apiend
 
+\apiitem{ImageBuf.{\ce set_origin} (x, y, z=0)}
+\NEW % 1.9
+Changes the ``origin'' of the data pixel data window to the specified
+coordinates.
+
+\noindent Example:
+\begin{code}
+    # Shift the pixel data so the upper left is at pixel (10, 10)
+    buf.set_origin (10, 10)
+\end{code}
+\apiend
+
 \apiitem{ImageBuf.{\ce set_full} (roi)}
 Changes the ``full'' (a.k.a. ``display'') window to the specified ROI.
 

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -487,6 +487,9 @@ public:
     /// Return the maximum z coordinate of the defined image.
     int zmax () const;
 
+    /// Set a new origin position for the pixel data.
+    void set_origin (int x, int y, int z=0);
+
     /// Set the "full" (a.k.a. display) window to [xbegin,xend) x
     /// [ybegin,yend) x [zbegin,zend).
     void set_full (int xbegin, int xend, int ybegin, int yend,

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -2116,6 +2116,17 @@ ImageBuf::oriented_full_y () const
 
 
 void
+ImageBuf::set_origin (int x, int y, int z)
+{
+    ImageSpec &spec (impl()->specmod());
+    spec.x = x;
+    spec.y = y;
+    spec.z = z;
+}
+
+
+
+void
 ImageBuf::set_full (int xbegin, int xend, int ybegin, int yend,
                     int zbegin, int zend)
 {

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1645,10 +1645,7 @@ set_origin (int argc, const char *argv[])
             spec.z = z;
             // That updated the private spec of the ImageRec. In this case
             // we really need to update the underlying IB as well.
-            ImageSpec &ibspec = ib.specmod();
-            ibspec.x = x;
-            ibspec.y = y;
-            ibspec.z = z;
+            ib.set_origin (x, y, z);
             A->metadata_modified (true);
         }
     }

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -304,6 +304,8 @@ void declare_imagebuf(py::module &m)
         .def_property_readonly("roi", &ImageBuf::roi)
         .def_property("roi_full",
                       &ImageBuf::roi_full, &ImageBuf::set_roi_full)
+        .def("set_origin", &ImageBuf::set_origin,
+             "x"_a, "y"_a, "z"_a=0)
         .def("set_full", &ImageBuf::set_full)
         .def_property_readonly("pixels_valid", &ImageBuf::pixels_valid)
         .def_property_readonly("pixeltype", &ImageBuf::pixeltype)

--- a/testsuite/python-imagebuf/ref/out-alt-python3.txt
+++ b/testsuite/python-imagebuf/ref/out-alt-python3.txt
@@ -31,8 +31,9 @@ setting full res...
 roi = 0 1024 0 1024 0 1 0 4
 full roi = 0 2048 0 2048 0 1 0 4
 setting full roi again, as ROI...
+Changing origin...
 Printing the whole spec to be sure:
-  resolution 1024x1024+0+0
+  resolution 1024x1024+15+20
   tile size  64x64x1
   4 channels: ('R', 'G', 'B', 'A')
   format =  uint8

--- a/testsuite/python-imagebuf/ref/out-alt.txt
+++ b/testsuite/python-imagebuf/ref/out-alt.txt
@@ -31,8 +31,9 @@ setting full res...
 roi = 0 1024 0 1024 0 1 0 4
 full roi = 0 2048 0 2048 0 1 0 4
 setting full roi again, as ROI...
+Changing origin...
 Printing the whole spec to be sure:
-  resolution 1024x1024+0+0
+  resolution 1024x1024+15+20
   tile size  64x64x1
   4 channels: ('R', 'G', 'B', 'A')
   format =  uint8

--- a/testsuite/python-imagebuf/ref/out-python3.txt
+++ b/testsuite/python-imagebuf/ref/out-python3.txt
@@ -31,8 +31,9 @@ setting full res...
 roi = 0 1024 0 1024 0 1 0 4
 full roi = 0 2048 0 2048 0 1 0 4
 setting full roi again, as ROI...
+Changing origin...
 Printing the whole spec to be sure:
-  resolution 1024x1024+0+0
+  resolution 1024x1024+15+20
   tile size  64x64x1
   4 channels: ('R', 'G', 'B', 'A')
   format =  uint8

--- a/testsuite/python-imagebuf/ref/out.txt
+++ b/testsuite/python-imagebuf/ref/out.txt
@@ -31,8 +31,9 @@ setting full res...
 roi = 0 1024 0 1024 0 1 0 4
 full roi = 0 2048 0 2048 0 1 0 4
 setting full roi again, as ROI...
+Changing origin...
 Printing the whole spec to be sure:
-  resolution 1024x1024+0+0
+  resolution 1024x1024+15+20
   tile size  64x64x1
   4 channels: ('R', 'G', 'B', 'A')
   format =  uint8

--- a/testsuite/python-imagebuf/src/test_imagebuf.py
+++ b/testsuite/python-imagebuf/src/test_imagebuf.py
@@ -82,6 +82,8 @@ try:
     print ("full roi =", b.roi_full)
     print ("setting full roi again, as ROI...")
     b.roi_full = oiio.ROI(0, 1024, 0, 1024, 0, 1, 0, b.nchannels)
+    print ("Changing origin...")
+    b.set_origin (15, 20);
     print ("Printing the whole spec to be sure:")
     print_imagespec (b.spec())
     print ("")


### PR DESCRIPTION
We had set_roi_full() to change the display window metadata, needed an
equally easy way to alter the pixel data window origin. (But note that
for pixel data, it's only safe to change the origin with metadata, not
the size, which would change the whole pixel data layout, lead to
reallocations, etc.)
