### PR TITLE
IC/TS close() and close_all() methods

### DIFF
--- a/src/doc/imagecache.tex
+++ b/src/doc/imagecache.tex
@@ -868,6 +868,16 @@ force is false, in actuality files will only be invalidated if their
 modification times have been changed since they were first opened.
 \apiend
 
+\apiitem{void {\ce close} (ustring filename) \\
+void {\ce close_all} ()}
+\NEW % 1.9
+Close any open file handles associated with a named file, or for all
+files, but do not invalidate any image spec information or pixels
+associated with the files.  A client might do this in order to
+release OS file handle resources, or to make it safe for other
+processes to modify cached files.
+\apiend
+
 \subsection{Seeding the cache}
 \label{sec:imagecache:api:seeding}
 \apiitem{bool {\ce add_file} (ustring filename, \\

--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -1357,6 +1357,16 @@ force is false, in actuality files will only be invalidated if their
 modification times have been changed since they were first opened.
 \apiend
 
+\apiitem{void {\ce close} (ustring filename) \\
+void {\ce close_all} ()}
+\NEW % 1.9
+Close any open file handles associated with a named file, or for all
+files, but do not invalidate any image spec information or pixels
+associated with the files.  A client might do this in order to
+release OS file handle resources, or to make it safe for other
+processes to modify cached files.
+\apiend
+
 \subsection{UDIM and texture atlases}
 \label{sec:texturesys:udim}
 The {\cf texture()} call supports virtual filenames that expand per lookup

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -41,6 +41,12 @@
 #include <OpenImageIO/imageio.h>
 
 
+// Define symbols that let client applications determine if newly added
+// features are supported.
+#define OIIO_IMAGECACHE_SUPPORTS_CLOSE 1
+
+
+
 OIIO_NAMESPACE_BEGIN
 
 struct ROI;
@@ -395,6 +401,14 @@ public:
     /// modification times have been changed since they were first
     /// opened.
     virtual void invalidate_all (bool force=false) = 0;
+
+    /// Close any open file handles associated with a named file, or for all
+    /// files, but do not invalidate any image spec information or pixels
+    /// associated with the files.  A client might do this in order to
+    /// release OS file handle resources, or to make it safe for other
+    /// processes to modify cached files.
+    virtual void close (ustring filename) = 0;
+    virtual void close_all () = 0;
 
 private:
     // Make delete private and unimplemented in order to prevent apps

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -43,6 +43,13 @@
 
 #include <OpenEXR/ImathVec.h>       /* because we need V3f */
 
+
+// Define symbols that let client applications determine if newly added
+// features are supported.
+#define OIIO_TEXTURESYSTEM_SUPPORTS_CLOSE 1
+
+
+
 OIIO_NAMESPACE_BEGIN
 
 // Forward declaration
@@ -878,6 +885,14 @@ public:
     /// requests will not match the number of tile reads, etc., that
     /// would have resulted from a new TextureSystem.
     virtual void reset_stats () = 0;
+
+    /// Close any open file handles associated with a named file, or for all
+    /// files, but do not invalidate any image spec information or pixels
+    /// associated with the files.  A client might do this in order to
+    /// release OS file handle resources, or to make it safe for other
+    /// processes to modify cached files.
+    virtual void close (ustring filename) = 0;
+    virtual void close_all () = 0;
 
 private:
     // Make delete private and unimplemented in order to prevent apps

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3276,6 +3276,25 @@ ImageCacheImpl::invalidate_all (bool force)
 
 
 
+void
+ImageCacheImpl::close (ustring filename)
+{
+    auto f = m_files.find (filename);
+    if (f != m_files.end())
+        f->second->close ();
+}
+
+
+
+void
+ImageCacheImpl::close_all ()
+{
+    for (auto &f : m_files)
+        f.second->close ();
+}
+
+
+
 namespace {
 // Mutex to protect all the UDIM table access.
 static mutex_pool<spin_rw_mutex,ustring,ustringHash,8> udim_lookup_mutex_pool;

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -981,6 +981,8 @@ public:
     virtual void reset_stats ();
     virtual void invalidate (ustring filename);
     virtual void invalidate_all (bool force=false);
+    virtual void close (ustring filename);
+    virtual void close_all ();
 
     /// Merge all the per-thread statistics into one set of stats.
     ///

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -342,6 +342,8 @@ public:
 
     virtual void invalidate (ustring filename);
     virtual void invalidate_all (bool force=false);
+    virtual void close (ustring filename);
+    virtual void close_all ();
 
     void operator delete (void *todel) { ::delete ((char *)todel); }
 

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -804,6 +804,22 @@ TextureSystemImpl::invalidate_all (bool force)
 
 
 
+void
+TextureSystemImpl::close (ustring filename)
+{
+    m_imagecache->close (filename);
+}
+
+
+
+void
+TextureSystemImpl::close_all ()
+{
+    m_imagecache->close_all ();
+}
+
+
+
 bool
 TextureSystemImpl::missing_texture (TextureOpt &options, int nchannels,
                                     float *result, float *dresultds,

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -108,6 +108,7 @@ static int testicwrite = 0;
 static bool test_derivs = false;
 static bool test_statquery = false;
 static bool invalidate_before_iter = true;
+static bool close_before_iter = false;
 static Imath::M33f xform;
 void *dummyptr;
 
@@ -197,6 +198,7 @@ getargs (int argc, const char *argv[])
                   "--trials %d", &ntrials, "Number of trials for timings",
                   "--wedge", &wedge, "Wedge test",
                   "--noinvalidate %!", &invalidate_before_iter, "Don't invalidate the cache before each --threadtimes trial",
+                  "--closebeforeiter", &close_before_iter, "Close all handles before each --iter",
                   "--testicwrite %d", &testicwrite, "Test ImageCache write ability (1=seeded, 2=generated)",
                   "--teststatquery", &test_statquery, "Test queries of statistics",
                   NULL);
@@ -609,10 +611,12 @@ test_plain_texture (Mapping2D mapping)
     for (int iter = 0;  iter < iters;  ++iter) {
         if (iters > 1 && filenames.size() > 1) {
             // Use a different filename for each iteration
-            int texid = std::min (iter, (int)filenames.size()-1);
+            int texid = iter % (int)filenames.size();
             filename = (filenames[texid]);
             std::cout << "iter " << iter << " file " << filename << "\n";
         }
+        if (close_before_iter)
+            texsys->close_all ();
 
         ImageBufAlgo::parallel_image (get_roi(image.spec()), nthreads,
                 std::bind(plain_tex_region, std::ref(image), filename, mapping,
@@ -736,10 +740,12 @@ test_plain_texture_batch (Mapping2DWide mapping)
     for (int iter = 0;  iter < iters;  ++iter) {
         if (iters > 1 && filenames.size() > 1) {
             // Use a different filename for each iteration
-            int texid = std::min (iter, (int)filenames.size()-1);
+            int texid = iter % (int)filenames.size();
             filename = (filenames[texid]);
             std::cout << "iter " << iter << " file " << filename << "\n";
         }
+        if (close_before_iter)
+            texsys->close_all ();
 
         ImageBufAlgo::parallel_image (get_roi(image.spec()), nthreads,
                 [&](ROI roi){
@@ -875,6 +881,8 @@ test_texture3d (ustring filename, Mapping3D mapping)
         // Trick: switch to second texture, if given, for second iteration
         if (iter && filenames.size() > 1)
             filename = filenames[1];
+        if (close_before_iter)
+            texsys->close_all ();
         ImageBufAlgo::parallel_image (get_roi(image.spec()), nthreads,
                 std::bind(tex3d_region, std::ref(image), filename, mapping, _1));
     }
@@ -902,6 +910,8 @@ test_texture3d_batch (ustring filename, Mapping3DWide mapping)
         // Trick: switch to second texture, if given, for second iteration
         if (iter && filenames.size() > 1)
             filename = filenames[1];
+        if (close_before_iter)
+            texsys->close_all ();
         ImageBufAlgo::parallel_image (get_roi(image.spec()), nthreads,
                 [&](ROI roi){
                     tex3d_region_batch (image, filename, mapping, roi);


### PR DESCRIPTION
The existing methods invalidate() and invalidate_all() fully invalidate
everything the IC/TS knows about a file (or all files) -- the specs,
the pixels, etc.

But sometimes you just want to close any currently-open handles, but not
necessarily forget about what you know about those images, or any pixel
tiles in the cache. That wasn't possible before, but this patch adds the
functionality as close(filename) and close_all() methods to both IC and
TS.

One interesting use case that this enables is a render-paint loop:

    render();
    ts->close_all();
    ... here, it's ok to modify the texture files ...
    ts->invalidate_all (false);
    render();
    ... repeat

The close_all(), performed after the render, closes any open file
handles, which is especially important on Windows where the IC holding
the file open essentially locks the files. Then, right before the
next render, invalidate_all(false) will fully invalidate any files that
have been modified since they were last opened, but not any whose
modification time has not changed.

Note that the act of closing means that if additional tiles need to be
read from disk, it will need to re-open the file. But as long as
any pixels needed are already in the cache from last time, it may not
need to re-open at all.

