### PR TITLE
DESIGN REVIEW: Overhaul ImageBufAlgo to return ImageBuf results

### DIFF
--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -393,6 +393,42 @@ IBA_add_images (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
     return ImageBufAlgo::add (dst, A, B, roi, nthreads);
 }
 
+ImageBuf
+IBA_add_color_ret (const ImageBuf &A, py::object values_tuple,
+                   ROI roi=ROI::All(), int nthreads=0)
+{
+    ImageBuf result;
+    std::vector<float> values;
+    py_to_stdvector (values, values_tuple);
+    if (roi.defined())
+        values.resize (roi.nchannels(), 0.0f);
+    else if (A.initialized())
+        values.resize (A.nchannels(), 0.0f);
+    else return result;
+    ASSERT (values.size() > 0);
+    py::gil_scoped_release gil;
+    result = ImageBufAlgo::add (A, values, roi, nthreads);
+    return result;
+}
+
+ImageBuf
+IBA_add_float_ret (const ImageBuf &A, float val,
+                   ROI roi=ROI::All(), int nthreads=0)
+{
+    py::gil_scoped_release gil;
+    ImageBuf result = ImageBufAlgo::add (A, val, roi, nthreads);
+    return result;
+}
+
+ImageBuf
+IBA_add_images_ret (const ImageBuf &A, const ImageBuf &B,
+                    ROI roi=ROI::All(), int nthreads=0)
+{
+    py::gil_scoped_release gil;
+    ImageBuf result = ImageBufAlgo::add (A, B, roi, nthreads);
+    return result;
+}
+
 
 
 bool
@@ -425,6 +461,42 @@ IBA_sub_images (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
 {
     py::gil_scoped_release gil;
     return ImageBufAlgo::sub (dst, A, B, roi, nthreads);
+}
+
+ImageBuf
+IBA_sub_color_ret (const ImageBuf &A, py::object values_tuple,
+                   ROI roi=ROI::All(), int nthreads=0)
+{
+    ImageBuf result;
+    std::vector<float> values;
+    py_to_stdvector (values, values_tuple);
+    if (roi.defined())
+        values.resize (roi.nchannels(), 0.0f);
+    else if (A.initialized())
+        values.resize (A.nchannels(), 0.0f);
+    else return result;
+    ASSERT (values.size() > 0);
+    py::gil_scoped_release gil;
+    result = ImageBufAlgo::sub (A, values, roi, nthreads);
+    return result;
+}
+
+ImageBuf
+IBA_sub_float_ret (const ImageBuf &A, float val,
+                   ROI roi=ROI::All(), int nthreads=0)
+{
+    py::gil_scoped_release gil;
+    ImageBuf result = ImageBufAlgo::sub (A, val, roi, nthreads);
+    return result;
+}
+
+ImageBuf
+IBA_sub_images_ret (const ImageBuf &A, const ImageBuf &B,
+                    ROI roi=ROI::All(), int nthreads=0)
+{
+    py::gil_scoped_release gil;
+    ImageBuf result = ImageBufAlgo::sub (A, B, roi, nthreads);
+    return result;
 }
 
 
@@ -461,6 +533,42 @@ IBA_absdiff_images (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
     return ImageBufAlgo::absdiff (dst, A, B, roi, nthreads);
 }
 
+ImageBuf
+IBA_absdiff_color_ref (const ImageBuf &A, py::object values_tuple,
+                       ROI roi=ROI::All(), int nthreads=0)
+{
+    ImageBuf result;
+    std::vector<float> values;
+    py_to_stdvector (values, values_tuple);
+    if (roi.defined())
+        values.resize (roi.nchannels(), 0.0f);
+    else if (A.initialized())
+        values.resize (A.nchannels(), 0.0f);
+    else return result;
+    ASSERT (values.size() > 0);
+    py::gil_scoped_release gil;
+    result = ImageBufAlgo::absdiff (A, values, roi, nthreads);
+    return result;
+}
+
+ImageBuf
+IBA_absdiff_float_ref (const ImageBuf &A, float val,
+                       ROI roi=ROI::All(), int nthreads=0)
+{
+    py::gil_scoped_release gil;
+    ImageBuf result = ImageBufAlgo::absdiff (A, val, roi, nthreads);
+    return result;
+}
+
+ImageBuf
+IBA_absdiff_images_ret (const ImageBuf &A, const ImageBuf &B,
+                        ROI roi=ROI::All(), int nthreads=0)
+{
+    py::gil_scoped_release gil;
+    ImageBuf result = ImageBufAlgo::absdiff (A, B, roi, nthreads);
+    return result;
+}
+
 
 
 bool
@@ -469,6 +577,14 @@ IBA_abs (ImageBuf &dst, const ImageBuf &A,
 {
     py::gil_scoped_release gil;
     return ImageBufAlgo::abs (dst, A, roi, nthreads);
+}
+
+ImageBuf
+IBA_abs_ret (const ImageBuf &A, ROI roi=ROI::All(), int nthreads=0)
+{
+    py::gil_scoped_release gil;
+    ImageBuf result = ImageBufAlgo::abs (A, roi, nthreads);
+    return result;
 }
 
 
@@ -1497,6 +1613,12 @@ void declare_imagebufalgo (py::module &m)
             "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
         .def_static("add", IBA_add_color,
             "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("add", &IBA_add_images_ret,
+            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("add", IBA_add_color_ret,
+            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("add", &IBA_add_float_ret,
+            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
 
         .def_static("sub", &IBA_sub_images,
             "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
@@ -1504,6 +1626,12 @@ void declare_imagebufalgo (py::module &m)
             "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
         .def_static("sub", IBA_sub_color,
             "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("sub", &IBA_sub_images_ret,
+            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("sub", &IBA_sub_float_ret,
+            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("sub", IBA_sub_color_ret,
+            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
 
         .def_static("absdiff", &IBA_absdiff_images,
             "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
@@ -1511,9 +1639,17 @@ void declare_imagebufalgo (py::module &m)
             "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
         .def_static("absdiff", IBA_absdiff_color,
             "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("absdiff", &IBA_absdiff_images_ret,
+            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("absdiff", &IBA_absdiff_float_ref,
+            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("absdiff", IBA_absdiff_color_ref,
+            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
 
         .def_static("abs", &IBA_abs,
             "dst"_a, "A"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("abs", &IBA_abs_ret,
+            "A"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
 
         .def_static("mul", &IBA_mul_images,
             "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)

--- a/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
+++ b/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
@@ -174,15 +174,13 @@ try:
     b = ImageBuf()
     ImageBufAlgo.add (b, gray128, (0, 0.25, -0.25))
     write (b, "cadd2.exr")
-    b = ImageBuf()
-    ImageBufAlgo.add (b, make_constimage(64,64,3,oiio.HALF,(.1,.2,.3)),
-                      make_constimage(64,64,3,oiio.HALF,(.1,.1,.1),20,20))
+    b = ImageBufAlgo.add (make_constimage(64,64,3,oiio.HALF,(.1,.2,.3)),
+                          make_constimage(64,64,3,oiio.HALF,(.1,.1,.1),20,20))
     write (b, "add.exr")
 
     # sub
-    b = ImageBuf()
-    ImageBufAlgo.sub (b, make_constimage(64,64,3,oiio.HALF,(.1,.2,.3)),
-                      make_constimage(64,64,3,oiio.HALF,(.1,.1,.1),20,20))
+    b = ImageBufAlgo.sub (make_constimage(64,64,3,oiio.HALF,(.1,.2,.3)),
+                          make_constimage(64,64,3,oiio.HALF,(.1,.1,.1),20,20))
     write (b, "sub.exr")
 
     # Test --absdiff and --abs
@@ -190,11 +188,9 @@ try:
     a = ImageBuf (ImageSpec(128,128,3,oiio.HALF))
     ImageBufAlgo.fill (a, (0.5,0.5,0.5))
     ImageBufAlgo.fill (a, (-0.25,-0.25,-0.25), oiio.ROI(0,64,0,128))
-    b = ImageBuf()
-    ImageBufAlgo.abs (b, a)
+    b = ImageBufAlgo.abs (a)
     write (b, "abs.exr", oiio.HALF)
-    b = ImageBuf()
-    ImageBufAlgo.absdiff (b, a, (0.2,0.2,0.2))
+    b = ImageBufAlgo.absdiff (a, (0.2,0.2,0.2))
     write (b, "absdiff.exr", oiio.HALF)
     a = ImageBuf()
 


### PR DESCRIPTION
All ImageBufAlgo functions, in both C++ and Python, have signatures that looks like this:

    bool IBA::func (ImageBuf& result, ...args..., ROI roi=All, int nthreads=0);

So, for example, to add two images A and B,

    ImageBuf Result;
    ImageBufAlgo::add (Result, A, B);

and in Python,

    Result = ImageBuf()
    ImageBufAlgo.add (Result, A, B)

There are circumstances in which this approach of writing into an existing    buffers is crucial -- it gives you completely control over allocations and    copying, lets you write partial results into an existing buffer (using    a ROI of a smaller region than the whole), and lets you accumulate results.    As an example, consider the efficiency of:

    ImageBuf images[10];
    ImageBuf sum (images[0]);
    for (int i = 1; i < 10; ++i)
        ImageBufAlgo::add (sum, sum, images[i]);

Note that there are no additional allocations inside the loop.

OK, but this is not the usual case. For the vast majority of uses, you    are just doing a simple

    ImageBuf Result;
    ImageBufAlgo::add (Result, A, B);

and especially in Python, this necessity to pre-declare the result is    very "non-Pythonic". What we really want to say is:

    Result = ImageBufAlgo.add (A, B)

So simple! And why wouldn't we want the same thing in C++?

    auto Result = ImageBufAlgo::add (A, B);

At long last we get to the point of this proposal:

This patch aims to add a variety of each IBA function that returns the    ImageBuf result, rather than take an existing IB destination as a    parameter.

We will still keep the "in-place" methods we've always had (which, as    noted above, are still useful), but for most uses, the new calls    will be preferred for their notational simplicty.

Also, I'm simultaneously replacing the functions that take a raw    `float *` for per-channel colors, with versions that instead take    an array_view<const float>, which should be safer because it guarantees    knowledge of the length of the array.

At this stage, I have only done this for add, sub, absdiff, abs, as a    way to prototype the ideas. Consider this a "design review", circulating    for comments and feedback before I undertake the work to fully overhaul    the rest of the IBA suite of functions.

Feedback?
