### PR TITLE
ImageBuf: tweak copy and assignment

### DIFF
--- a/src/doc/imagebuf.tex
+++ b/src/doc/imagebuf.tex
@@ -390,8 +390,19 @@ has already spawned multiple worker threads.
 
 \section{Copying \ImageBuf's and blocks of pixels}
 
-\apiitem{bool {\ce copy} (const ImageBuf \&src) \\
-bool {\ce copy} (const ImageBuf \&src, TypeDesc format)}
+\apiitem{const ImageBuf\& operator= (const ImageBuf \&src) \\
+const ImageBuf\& operator= (ImageBuf \&\&src)}
+\NEW % 1.9
+Copy and move assignment.
+\apiend
+
+\apiitem{ImageBuf {\ce copy} (TypeDesc format=TypeUnknown) const}
+\NEW % 1.9
+Returns a full copy of {\cf this} (pixels and metadata), with optional data
+format conversion.
+\apiend
+
+\apiitem{bool {\ce copy} (const ImageBuf \&src, TypeDesc format=TypeUnknown)}
 Copies {\cf src} to {\cf this} -- both pixel values and all metadata.
 If a {\cf format} is provided, {\cf this} will get the specified pixel
 data type rather than using the same pixel format as {\cf src}.

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -1616,8 +1616,23 @@ Replace the pixels in this \ImageBuf with the values from the other
 \ImageBuf.
 \apiend
 
-\apiitem{ImageBuf.{\ce copy} (other_imagebuf) \\
-ImageBuf.{\ce copy} (other_imagebuf, format)}
+\apiitem{ImageBuf ImageBuf.{\ce copy} (format=TypeUnknown)}
+Return a full copy of this \ImageBuf (with optional data format conversion,
+if {\cf format} is supplied).
+
+\noindent Example:
+\begin{code}
+    A = ImageBuf("A.tif")
+
+    # Make a separate, duplicate copy of A
+    B = A.copy()
+
+    # Make another copy of A, but converting to float pixels
+    C = A.copy ("float")
+\end{code}
+\apiend
+
+\apiitem{ImageBuf.{\ce copy} (other_imagebuf, format=TypeUnknown)}
 Make this \ImageBuf a complete copy of the other \ImageBuf.
 If a {\cf format} is provided, {\cf this} will get the specified pixel
 data type rather than using the same pixel format as the source \ImageBuf.

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -457,9 +457,33 @@ ImageBuf::ImageBuf (const ImageBuf &src)
 
 
 
+ImageBuf::ImageBuf (ImageBuf &&src)
+    : m_impl (std::move (src.m_impl))
+{
+}
+
+
+
 ImageBuf::~ImageBuf ()
 {
-    delete m_impl; m_impl = NULL;
+}
+
+
+
+const ImageBuf&
+ImageBuf::operator= (const ImageBuf &src)
+{
+    copy (src);
+    return *this;
+}
+
+
+
+const ImageBuf&
+ImageBuf::operator= (ImageBuf &&src)
+{
+    m_impl = std::move(src.m_impl);
+    return *this;
 }
 
 
@@ -1488,10 +1512,12 @@ ImageBuf::copy (const ImageBuf &src, TypeDesc format)
 
 
 
-bool
-ImageBuf::copy (const ImageBuf &src)
+ImageBuf
+ImageBuf::copy (TypeDesc format) const
 {
-    return copy (src, TypeDesc::UNKNOWN);
+    ImageBuf result;
+    result.copy (*this, format);
+    return result;
 }
 
 

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -321,6 +321,11 @@ void declare_imagebuf(py::module &m)
                 return self.copy (src, format);
             },
             "src"_a, "format"_a=TypeUnknown)
+        .def("copy", [](const ImageBuf &src, TypeDesc format){
+                py::gil_scoped_release gil;
+                return src.copy(format);
+            },
+            "format"_a=TypeUnknown)
         .def("swap", &ImageBuf::swap)
         .def("getchannel", &ImageBuf::getchannel,
              "x"_a, "y"_a, "z"_a, "c"_a, "wrap"_a="black")


### PR DESCRIPTION
* Add a 'move' constructor
* Add variety of copy() that returns a copy of *this.
* Add operator=, both copy and move varieties. I has avoided this purposely in the early days, but with C++11 move semantics, I think it's not as unavoidably wasteful as it once was.


