### PR TITLE
ImageBuf: add pixel data type override to write() method

### DIFF
--- a/src/doc/imagebuf.tex
+++ b/src/doc/imagebuf.tex
@@ -213,13 +213,15 @@ resolution or data type.  Optionally, it names the \ImageBuf.
 \subsection*{Writing an \ImageBuf to a file}
 
 \apiitem{bool {\ce write} (string_view filename, \\
+  \bigspc               TypeDesc dtype = TypeUnknown, \\
   \bigspc               string_view fileformat = "", \\
   \bigspc               ProgressCallback progress_callback=NULL, \\
   \bigspc               void *progress_callback_data=NULL) const}
-Write the image to the named file in the named format
-(an empty format means to infer the type from the filename
-extension).  Return {\cf true} if all went ok, {\cf false} if there were
-errors writing.
+Write the image to the named file, converted to the specified pixel data
+type {\cf dtype} ({\cf TypeUnknown} signifies to use the data type of the
+buffer), in the named file format (an empty {\cf fileformat} means to infer
+the type from the filename extension).  Return {\cf true} if all went ok,
+{\cf false} if there were errors writing.
 
 By default, it will always write a scanline-oriented file, unless the
 {\cf set_write_tiles()} method has been used to override this.

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -1442,16 +1442,22 @@ call that accesses the spec will read it automatically it has not yet been
 done.
 \apiend
 
-\apiitem{bool ImageBuf.{\ce write} (filename, fileformat="")}
-Write the contents of the \ImageBuf to the named file.  Optionally, {\cf
-fileformat} can specify a particular file format to use (by default, it
-will infer it from the extension of the file name).
+\apiitem{bool ImageBuf.{\ce write} (filename, dtype="", fileformat="")}
+Write the contents of the \ImageBuf to the named file.  Optionally,
+{\cf dtype} can override the pixel data type (by default, the pixel data
+type of the buffer), and {\cf fileformat} can specify a particular file
+format to use (by default, it will infer it from the extension of the file
+name).
 
 \noindent Example:
 \begin{code}
     # No-frills conversion of a TIFF file to JPEG
     buf = ImageBuf ("in.tif")
     buf.write ("out.jpg")
+
+    # Convert to uint16 TIFF
+    buf = ImageBuf ("in.exr")
+    buf.write ("out.tif", "uint16")
 \end{code}
 \apiend
 

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -205,13 +205,24 @@ public:
     bool init_spec (string_view filename,
                     int subimage, int miplevel);
 
-    /// Write the image to the named file and file format ("" means to infer
-    /// the type from the filename extension). Return true if all went ok,
-    /// false if there were errors writing.
+    /// Write the image to the named file, converted to the specified pixel
+    /// data type `dtype` (TypeUnknown signifies to use the data type of the
+    /// buffer), and file format ("" means to infer the type from the
+    /// filename extension). Return true if all went ok, false if there were
+    /// errors writing.
     bool write (string_view filename,
+                TypeDesc dtype = TypeUnknown,
                 string_view fileformat = string_view(),
-                ProgressCallback progress_callback=NULL,
-                void *progress_callback_data=NULL) const;
+                ProgressCallback progress_callback=nullptr,
+                void *progress_callback_data=nullptr) const;
+    // DEPRECATED(1.9): old version did not have the data type
+    bool write (string_view filename,
+                string_view fileformat,
+                ProgressCallback progress_callback=nullptr,
+                void *progress_callback_data=nullptr) const {
+        return write (filename, TypeUnknown, fileformat,
+                      progress_callback, progress_callback_data);
+    }
 
     /// Inform the ImageBuf what data format you'd like for any subsequent
     /// write().

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1036,7 +1036,8 @@ ImageBuf::write (ImageOutput *out,
 
 
 bool
-ImageBuf::write (string_view _filename, string_view _fileformat,
+ImageBuf::write (string_view _filename, TypeDesc dtype,
+                 string_view _fileformat,
                  ProgressCallback progress_callback,
                  void *progress_callback_data) const
 {
@@ -1094,8 +1095,10 @@ ImageBuf::write (string_view _filename, string_view _fileformat,
         newspec.tile_depth  = 0;
     }
     // Allow for format override via ImageBuf::set_write_format()
-    if (impl()->m_write_format != TypeDesc::UNKNOWN) {
-        newspec.set_format (impl()->m_write_format);
+    if (dtype == TypeUnknown)
+        dtype = impl()->m_write_format;
+    if (dtype != TypeUnknown) {
+        newspec.set_format (dtype);
         newspec.channelformats.clear();
     } else {
         newspec.set_format (nativespec().format);

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -249,11 +249,18 @@ void declare_imagebuf(py::module &m)
             "force"_a=false, "convert"_a=TypeUnknown)
 
         .def("write", [](ImageBuf& self, const std::string &filename,
+                         TypeDesc dtype, const std::string &fileformat){
+                py::gil_scoped_release gil;
+                return self.write (filename, dtype, fileformat);
+            },
+            "filename"_a, "dtype"_a=TypeUnknown, "fileformat"_a="")
+        // deprecated version:
+        .def("write", [](ImageBuf& self, const std::string &filename,
                          const std::string &fileformat){
                 py::gil_scoped_release gil;
                 return self.write (filename, fileformat);
             },
-            "filename"_a, "fileformat"_a="")
+            "filename"_a, "fileformat"_a)
         .def("make_writeable", [](ImageBuf& self, bool keep_cache_type){
                 py::gil_scoped_release gil;
                 return self.make_writeable (keep_cache_type);

--- a/testsuite/python-imagebuf/src/test_imagebuf.py
+++ b/testsuite/python-imagebuf/src/test_imagebuf.py
@@ -42,8 +42,7 @@ def print_imagespec (spec, subimage=0, mip=0, msg="") :
 
 def write (image, filename, format=oiio.UNKNOWN) :
     if not image.has_error :
-        image.set_write_format (format)
-        image.write (filename)
+        image.write (filename, format)
     if image.has_error :
         print ("Error writing", filename, ":", image.geterror())
 


### PR DESCRIPTION
(more weekend tinkering)

This avoids the need for separate set_write_format() call if you're only
needing it to affect this one write call. Less clunky this way.

