### PR TITLE
span.h: Work towards the C++20 nomenclature (instead of array_view)

### DIFF
--- a/src/include/OpenImageIO/span.h
+++ b/src/include/OpenImageIO/span.h
@@ -1,0 +1,24 @@
+// OpenImageIO Copyright 2018 Larry Gritz, et al.  All Rights Reserved.
+//  https://github.com/OpenImageIO/oiio
+// BSD 3-clause license:
+//  https://github.com/OpenImageIO/oiio/blob/master/LICENSE
+
+
+#pragma once
+
+#include <OpenImageIO/array_view.h>
+
+OIIO_NAMESPACE_BEGIN
+
+// C++20 will have std::span<> which is basically the same as our
+// array_view<>. We want to slowly transition to their nomenclature, and
+// then eventually (in a far future when we can count on C++20 everywhere)
+// switch to std::span.
+//
+// First step: just make OIIO::span<> is a synonym for OIIO::array_view<>.
+
+template<typename T>
+using span = array_view<T>;
+
+
+OIIO_NAMESPACE_END

--- a/src/libutil/array_view_test.cpp
+++ b/src/libutil/array_view_test.cpp
@@ -33,6 +33,7 @@
 
 #include <OpenImageIO/strided_ptr.h>
 #include <OpenImageIO/array_view.h>
+#include <OpenImageIO/span.h>
 #include <OpenImageIO/image_view.h>
 #include <OpenImageIO/unittest.h>
 
@@ -294,6 +295,10 @@ int main (int argc, char *argv[])
     test_array_view_strided_mutable ();
     test_image_view ();
     test_image_view_mutable ();
+
+    // array_view and span should be synonyms
+    OIIO_CHECK_ASSERT ((std::is_same<OIIO::array_view<const float>,
+                                     OIIO::span<const float>>::value));
 
     return unit_test_failures;
 }


### PR DESCRIPTION
Something exactly like our array_view<> template is coming to standard
C++20, but it's named span<>. Slowly, we will migrate our nomenclature
and behavior to match it exactly, eventually (I assume in the late
2020's) just switching entirely to std.

In this first step, we merely establish a span.h that defines span<> as
a template alias for array_view<>. This will let applications (and our
internals) freely use array_view or span as synonyms. I will even
backport this change to older branches, since it's totally harmless to
existing code that uses array_view.

In a later step (not this patch) in master only, we'll swap those roles,
so that moving forward, span<> will be the "real" template, and
array_view will be the synonym for compatibility with legacy apps.

