### PR TITLE
Fix Python typo bug

### DIFF
--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -353,7 +353,7 @@ make_numpy_array (T *data, int dims, size_t chans, size_t width,
         shape.assign ({ height, width, chans });
         strides.assign ({ width*chans*sizeof(T), chans*sizeof(T), sizeof(T) });
     }
-    else if (depth == 2 && depth == 1 && height == 1) { // 1D (scanline) + channels
+    else if (dims == 2 && depth == 1 && height == 1) { // 1D (scanline) + channels
         shape.assign ({ width, chans });
         strides.assign ({ chans*sizeof(T), sizeof(T) });
     }

--- a/testsuite/python-imageinput/src/test_imageinput.py
+++ b/testsuite/python-imageinput/src/test_imageinput.py
@@ -149,8 +149,7 @@ def test_readscanline (filename, sub=0, mip=0, type=oiio.UNKNOWN) :
             return
         # print the first pixel of the first and last scanline
         if y == 0 or y == (spec.height-1) :
-            i = 0 * spec.nchannels
-            print ("@", (spec.x,y+spec.y), "=", data[i:i+spec.nchannels])
+            print ("@", (spec.x,y+spec.y), "=", data[0])
     input.close ()
     print ()
 


### PR DESCRIPTION
Spotted an obvious typo in make_numpy_array.

The manefestation of the bug is that ImageInput.read_scanline would
make the wrong "shape" of the numpy array, mashing all channels of all
pixels in the scanline into a 1D array of values, instead of properly
making it a 2D array of pixels which are each arrays of the channels
within a pixel. (I also had not noticed the presence of that symptom in
the python-imageinput unit test.

