### PR TITLE
[cmake] ffmpeg ensure minimal required version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,7 +42,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
      * **NumPy**
      * **pybind11** (but OIIO will auto-download it if not found)
  * libRaw >= 0.17 ("RAW" image reading will be disabled if not found)
- * ffmpeg >= 3.0 (tested through 4.0)
+ * ffmpeg >= 2.6 (tested through 4.0)
 
 
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -219,7 +219,7 @@ endif ()
 # FFmpeg
 
 if (USE_FFMPEG)
-    find_package (FFmpeg)
+    find_package (FFmpeg 2.6)
     if (FFMPEG_INCLUDE_DIR AND FFMPEG_LIBRARIES)
         set (FFMPEG_FOUND TRUE)
         if (NOT FFmpeg_FIND_QUIETLY)


### PR DESCRIPTION
## Description

On older platforms (eg ubuntu 14.04) ffmpeg is detected, so it builds the plugin but the build fail as does not meet the minimum version.

## Checklist:

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [X] I have updated the documentation, if applicable.
- [X] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project.
