### PR TITLE
Fix potential field3d mutex deadlock

### DIFF
--- a/src/field3d.imageio/field3d_pvt.h
+++ b/src/field3d.imageio/field3d_pvt.h
@@ -86,7 +86,7 @@ public:
 
 // Return a reference to the mutex that allows us to use f3d with multiple
 // threads.
-spin_mutex &field3d_mutex ();
+recursive_mutex &field3d_mutex ();
 
 void oiio_field3d_initialize ();
 

--- a/src/field3d.imageio/field3dinput.cpp
+++ b/src/field3d.imageio/field3dinput.cpp
@@ -45,10 +45,10 @@ using namespace OIIO_NAMESPACE::f3dpvt;
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
-spin_mutex &
+recursive_mutex &
 f3dpvt::field3d_mutex ()
 {
-    static spin_mutex m;
+    static recursive_mutex m;
     return m;
 }
 
@@ -129,7 +129,7 @@ f3dpvt::oiio_field3d_initialize ()
     static volatile bool initialized = false;
 
     if (! initialized) {
-        spin_lock lock (field3d_mutex());
+        recursive_lock_guard lock (field3d_mutex());
         if (! initialized) {
             initIO ();
             // Minimize Field3D's own internal caching
@@ -353,7 +353,7 @@ Field3DInput::valid_file (const std::string &filename) const
 
     oiio_field3d_initialize ();
 
-    spin_lock lock (field3d_mutex());
+    recursive_lock_guard lock (field3d_mutex());
     auto in = new Field3DInputFile;
     std::unique_ptr<Field3DInputFile> input (in /*new Field3DInputFile*/);
     bool ok = false;
@@ -386,7 +386,7 @@ Field3DInput::open (const std::string &name, ImageSpec &newspec)
     oiio_field3d_initialize ();
 
     {
-        spin_lock lock (field3d_mutex());
+        recursive_lock_guard lock (field3d_mutex());
         m_input.reset (new Field3DInputFile);
         bool ok = false;
         try {
@@ -432,7 +432,7 @@ Field3DInput::seek_subimage (int subimage, int miplevel)
     if (subimage == m_subimage)
         return true;
 
-    spin_lock lock (field3d_mutex());
+    recursive_lock_guard lock (field3d_mutex());
     m_subimage = subimage;
     m_spec = m_layers[subimage].spec;
     return true;
@@ -443,7 +443,7 @@ Field3DInput::seek_subimage (int subimage, int miplevel)
 bool
 Field3DInput::close ()
 {
-    spin_lock lock (field3d_mutex());
+    recursive_lock_guard lock (field3d_mutex());
     if (m_input) {
         m_input->close ();
         m_input.reset ();
@@ -516,7 +516,7 @@ bool
 Field3DInput::read_native_tile (int subimage, int miplevel,
                                 int x, int y, int z, void *data)
 {
-    spin_lock lock (field3d_mutex());
+    recursive_lock_guard lock (field3d_mutex());
     if (! seek_subimage (subimage, miplevel))
         return false;
     layerrecord &lay (m_layers[m_subimage]);
@@ -546,7 +546,7 @@ void
 Field3DInput::worldToLocal (const Imath::V3f &wsP, Imath::V3f &lsP,
                             float time) const
 {
-    spin_lock lock (field3d_mutex());
+    recursive_lock_guard lock (field3d_mutex());
     const layerrecord &lay (m_layers[m_subimage]);
     V3d Pw (wsP[0], wsP[1], wsP[2]);
     V3d Pl;

--- a/src/field3d.imageio/field3doutput.cpp
+++ b/src/field3d.imageio/field3doutput.cpp
@@ -217,7 +217,7 @@ Field3DOutput::open (const std::string &name, int subimages,
     m_subimage = 0;
 
     {
-        spin_lock lock (field3d_mutex());
+        recursive_lock_guard lock (field3d_mutex());
         m_output = new Field3DOutputFile;
         bool ok = false;
         try {
@@ -303,7 +303,7 @@ Field3DOutput::put_parameter (const std::string &name, TypeDesc type,
 bool
 Field3DOutput::close ()
 {
-    spin_lock lock (field3d_mutex());
+    recursive_lock_guard lock (field3d_mutex());
     if (m_output) {
         write_current_subimage ();
         m_output->close ();


### PR DESCRIPTION
Field3DInput::valid_file locked, then called open() which also locked.
How did this ever work? Yet, this was only symptomatic in one internal
renderer test, and only when OIIO was compiled in DEBUG mode.

The simple solution is just to change to a recursive lock. Field3d isn't
an important enough file type to try to be more clever than that.

