### PR TITLE
Many small fixes for gcc 8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
    packages:
       - g++-6
       - g++-7
+      - g++-8
       - libboost-filesystem1.55
       - libboost-regex1.55
       - libboost-system1.55
@@ -173,6 +174,10 @@ matrix:
       - os: linux
         compiler: gcc
         env: USE_SIMD=0 USE_JPEGTURBO=0 EMBEDPLUGINS=0
+    # test with C++14, gcc 8, latest SIMD flags supported by TravisCI VMs
+      - os: linux
+        compiler: gcc
+        env: WHICHGCC=8 USE_CPP=14 USE_SIMD=avx,f16c
     # build for AVX2, don't run the tests (ensure against build breaks)
       - os: linux
         compiler: gcc

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,7 +26,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
 ### Required dependencies -- OIIO will not build at all without these
 
  * C++11 (should also build with C++14 and C++17)
- * Compilers: gcc 4.8.2 - gcc 7, clang 3.3 - 6.0, MSVS 2013 - 2017, icc version 13 or higher
+ * Compilers: gcc 4.8.2 - gcc 8, clang 3.3 - 6.0, MSVS 2013 - 2017, icc version 13 or higher
  * Boost >= 1.53 (tested up through 1.67)
  * CMake >= 3.2.2 (tested up through 3.11)
  * OpenEXR >= 2.0 (recommended: 2.2)
@@ -42,7 +42,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
      * **NumPy**
      * **pybind11** (but OIIO will auto-download it if not found)
  * libRaw >= 0.17 ("RAW" image reading will be disabled if not found)
- * ffmpeg >= 3.0 (tested through 4.0)
+ * ffmpeg >= 2.6 (tested through 4.0)
 
 
 

--- a/site/spi/Makefile-bits-arnold
+++ b/site/spi/Makefile-bits-arnold
@@ -191,6 +191,10 @@ else ifeq (${platform}, macosx)
         MY_CMAKE_FLAGS += \
            -DCMAKE_C_COMPILER=gcc-6 -DCMAKE_CXX_COMPILER=g++-6
         USE_LIBCPLUSPLUS := 0
+    else ifeq (${COMPILER}, gcc8)
+        MY_CMAKE_FLAGS += \
+           -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8
+        USE_LIBCPLUSPLUS := 0
     else ifeq (${COMPILER},clang35)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang-3.5 -DCMAKE_CXX_COMPILER=clang++-3.5
     else ifeq (${COMPILER},clang38)

--- a/src/cineon.imageio/libcineon/CineonHeader.cpp
+++ b/src/cineon.imageio/libcineon/CineonHeader.cpp
@@ -33,7 +33,6 @@
  */
 
 
-
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
@@ -551,8 +550,8 @@ void cineon::GenericHeader::SetCreationTimeDate(const long sec)
 	const time_t t = time_t(sec);
 	tm_time = ::localtime(&t);
 	::strftime(str, 32, "%Y:%m:%d:%H:%M:%S%Z", tm_time);
-	::strncpy(this->creationDate, str, 10);
-	::strncpy(this->creationTime, str + 11, 12);
+	OIIO::Strutil::safe_strcpy(this->creationDate, str, 11);
+	OIIO::Strutil::safe_strcpy(this->creationTime, str + 11, 12);
 }
 
 
@@ -568,8 +567,8 @@ void cineon::GenericHeader::SetSourceTimeDate(const long sec)
 	const time_t t = time_t(sec);
 	tm_time = ::localtime(&t);
 	::strftime(str, 32, "%Y:%m:%d:%H:%M:%S%Z", tm_time);
-	::strncpy(this->sourceDate, str, 10);
-	::strncpy(this->sourceTime, str + 11, 12);
+	OIIO::Strutil::safe_strcpy(this->sourceDate, str, 11);
+	OIIO::Strutil::safe_strcpy(this->sourceTime, str + 11, 12);
 }
 
 

--- a/src/cineon.imageio/libcineon/CineonHeader.h
+++ b/src/cineon.imageio/libcineon/CineonHeader.h
@@ -43,6 +43,7 @@
 
 #include <cstring>
 #include <limits>
+#include <OpenImageIO/strutil.h>
 
 #if defined(_MSC_VER) && _MSC_VER < 1600
    typedef __int32 int32_t;
@@ -1151,13 +1152,12 @@ namespace cineon
 
 	inline void GenericHeader::Version(char *v) const
 	{
-		::strncpy(v, this->version, 8);
-		v[8] = '\0';
+		OIIO::Strutil::safe_strcpy(v, this->version, 8);
 	}
 
 	inline void GenericHeader::SetVersion(const char * v)
 	{
-		::strncpy(this->version, v, 8);
+		OIIO::Strutil::safe_strcpy(this->version, v, 8);
 	}
 
 	inline U32 GenericHeader::FileSize() const
@@ -1192,35 +1192,32 @@ namespace cineon
 
 	inline void GenericHeader::FileName(char *fn) const
 	{
-		::strncpy(fn, this->fileName, 100);
-		fn[100] = '\0';
+		OIIO::Strutil::safe_strcpy(fn, this->fileName, 100);
 	}
 
 	inline void GenericHeader::SetFileName(const char *fn)
 	{
-		::strncpy(this->fileName, fn, 100);
+		OIIO::Strutil::safe_strcpy(this->fileName, fn, 100);
 	}
 
 	inline void GenericHeader::CreationDate(char *ct) const
 	{
-		::strncpy(ct, this->creationDate, 12);
-		ct[24] = '\0';
+		OIIO::Strutil::safe_strcpy(ct, this->creationDate, 12);
 	}
 
 	inline void GenericHeader::SetCreationDate(const char *ct)
 	{
-		::strncpy(this->creationDate, ct, 12);
+		OIIO::Strutil::safe_strcpy(this->creationDate, ct, 12);
 	}
 
 	inline void GenericHeader::CreationTime(char *ct) const
 	{
-		::strncpy(ct, this->creationTime, 12);
-		ct[24] = '\0';
+		OIIO::Strutil::safe_strcpy(ct, this->creationTime, 12);
 	}
 
 	inline void GenericHeader::SetCreationTime(const char *ct)
 	{
-		::strncpy(this->creationTime, ct, 12);
+		OIIO::Strutil::safe_strcpy(this->creationTime, ct, 12);
 	}
 
 	inline Orientation GenericHeader::ImageOrientation() const
@@ -1425,12 +1422,12 @@ namespace cineon
 
 	inline void GenericHeader::LabelText(char *desc) const
 	{
-		strncpy(desc, this->labelText, 200);
+		OIIO::Strutil::safe_strcpy(desc, this->labelText, 200);
 	}
 
 	inline void GenericHeader::SetLabelText(const char *desc)
 	{
-		::strncpy(this->labelText, desc, 200);
+		OIIO::Strutil::safe_strcpy(this->labelText, desc, 200);
 	}
 
 
@@ -1496,68 +1493,62 @@ namespace cineon
 
 	inline void GenericHeader::SourceImageFileName(char *fn) const
 	{
-		::strncpy(fn, this->sourceImageFileName, 100);
-		fn[100] = '\0';
+		OIIO::Strutil::safe_strcpy(fn, this->sourceImageFileName, 100);
 	}
 
 	inline void GenericHeader::SetSourceImageFileName(const char *fn)
 	{
-		::strncpy(this->sourceImageFileName, fn, 100);
+		OIIO::Strutil::safe_strcpy(this->sourceImageFileName, fn, 100);
 	}
 
 	inline void GenericHeader::SourceDate(char *td) const
 	{
-		::strncpy(td, this->sourceDate, 12);
-		td[12] = '\0';
+		OIIO::Strutil::safe_strcpy(td, this->sourceDate, 12);
 	}
 
 	inline void GenericHeader::SetSourceDate(const char *td)
 	{
-		::strncpy(this->sourceDate, td, 12);
+		OIIO::Strutil::safe_strcpy(this->sourceDate, td, 12);
 	}
 
 	inline void GenericHeader::SourceTime(char *td) const
 	{
-		::strncpy(td, this->sourceTime, 12);
-		td[12] = '\0';
+		OIIO::Strutil::safe_strcpy(td, this->sourceTime, 12);
 	}
 
 	inline void GenericHeader::SetSourceTime(const char *td)
 	{
-		::strncpy(this->sourceTime, td, 12);
+		OIIO::Strutil::safe_strcpy(this->sourceTime, td, 12);
 	}
 
 	inline void GenericHeader::InputDevice(char *dev) const
 	{
-		::strncpy(dev, this->inputDevice, 32);
-		dev[32] = '\0';
+		OIIO::Strutil::safe_strcpy(dev, this->inputDevice, 32);
 	}
 
 	inline void  GenericHeader::SetInputDevice(const char *dev)
 	{
-		::strncpy(this->inputDevice, dev, 32);
+		OIIO::Strutil::safe_strcpy(this->inputDevice, dev, 32);
 	}
 
 	inline void GenericHeader::InputDeviceModelNumber(char *sn) const
 	{
-		::strncpy(sn, this->inputDeviceModelNumber, 32);
-		sn[32] = '\0';
+		OIIO::Strutil::safe_strcpy(sn, this->inputDeviceModelNumber, 32);
 	}
 
 	inline void GenericHeader::SetInputDeviceModelNumber(const char *sn)
 	{
-		::strncpy(this->inputDeviceModelNumber, sn, 32);
+		OIIO::Strutil::safe_strcpy(this->inputDeviceModelNumber, sn, 32);
 	}
 
 	inline void GenericHeader::InputDeviceSerialNumber(char *sn) const
 	{
-		::strncpy(sn, this->inputDeviceSerialNumber, 32);
-		sn[32] = '\0';
+		OIIO::Strutil::safe_strcpy(sn, this->inputDeviceSerialNumber, 32);
 	}
 
 	inline void GenericHeader::SetInputDeviceSerialNumber(const char *sn)
 	{
-		::strncpy(this->inputDeviceSerialNumber, sn, 32);
+		OIIO::Strutil::safe_strcpy(this->inputDeviceSerialNumber, sn, 32);
 	}
 
 	inline R32 GenericHeader::XDevicePitch() const
@@ -1582,13 +1573,12 @@ namespace cineon
 
 	inline void IndustryHeader::Format(char *fmt) const
 	{
-		::strncpy(fmt, this->format, 32);
-		fmt[32] = '\0';
+		OIIO::Strutil::safe_strcpy(fmt, this->format, 32);
 	}
 
 	inline void IndustryHeader::SetFormat(const char *fmt)
 	{
-		::strncpy(this->format, fmt, 32);
+		OIIO::Strutil::safe_strcpy(this->format, fmt, 32);
 	}
 
 	inline U32 IndustryHeader::FramePosition() const
@@ -1613,24 +1603,22 @@ namespace cineon
 
 	inline void IndustryHeader::FrameId(char *id) const
 	{
-		::strncpy(id, this->frameId, 32);
-		id[32] = '\0';
+		OIIO::Strutil::safe_strcpy(id, this->frameId, 32);
 	}
 
 	inline void IndustryHeader::SetFrameId(const char *id)
 	{
-		::strncpy(this->frameId, id, 32);
+		OIIO::Strutil::safe_strcpy(this->frameId, id, 32);
 	}
 
 	inline void IndustryHeader::SlateInfo(char *slate) const
 	{
-		::strncpy(slate, this->slateInfo, 100);
-		slate[100] = '\0';
+		OIIO::Strutil::safe_strcpy(slate, this->slateInfo, 100);
 	}
 
 	inline void IndustryHeader::SetSlateInfo(const char *slate)
 	{
-		::strncpy(this->slateInfo, slate, 100);
+		OIIO::Strutil::safe_strcpy(this->slateInfo, slate, 100);
 	}
 
 	inline R32 GenericHeader::Gamma() const

--- a/src/dpx.imageio/libdpx/DPXHeader.cpp
+++ b/src/dpx.imageio/libdpx/DPXHeader.cpp
@@ -774,7 +774,7 @@ void dpx::GenericHeader::SetCreationTimeDate(const long sec)
 	const time_t t = time_t(sec);
 	tm_time = ::localtime(&t);
 	::strftime(str, 32, "%Y:%m:%d:%H:%M:%S%Z", tm_time);
-	::strncpy(this->creationTimeDate, str, 24);
+	OIIO::Strutil::safe_strcpy(this->creationTimeDate, str, 24);
 }
 
 
@@ -790,7 +790,7 @@ void dpx::GenericHeader::SetSourceTimeDate(const long sec)
 	const time_t t = time_t(sec);
 	tm_time = ::localtime(&t);
 	::strftime(str, 32, "%Y:%m:%d:%H:%M:%S%Z", tm_time);
-	::strncpy(this->sourceTimeDate, str, 24);
+	OIIO::Strutil::safe_strcpy(this->sourceTimeDate, str, 24);
 }
 
 

--- a/src/dpx.imageio/libdpx/DPXHeader.h
+++ b/src/dpx.imageio/libdpx/DPXHeader.h
@@ -1583,57 +1583,52 @@ namespace dpx
 	
 	inline void GenericHeader::FileName(char *fn) const
 	{
-		::strncpy(fn, this->fileName, sizeof(this->fileName));
-		fn[100] = '\0';
+		OIIO::Strutil::safe_strcpy(fn, this->fileName, sizeof(this->fileName));
 	}
 	
 	inline void GenericHeader::SetFileName(const char *fn)
 	{
-		::strncpy(this->fileName, fn, sizeof(this->fileName));
+		OIIO::Strutil::safe_strcpy(this->fileName, fn, sizeof(this->fileName));
 	}
 	
 	inline void GenericHeader::CreationTimeDate(char *ct) const
 	{
-		::strncpy(ct, this->creationTimeDate, sizeof(this->creationTimeDate));
-		ct[24] = '\0';
+		OIIO::Strutil::safe_strcpy(ct, this->creationTimeDate, sizeof(this->creationTimeDate));
 	}
 	
 	inline void GenericHeader::SetCreationTimeDate(const char *ct)
 	{
-		::strncpy(this->creationTimeDate, ct, sizeof(this->creationTimeDate));
+		OIIO::Strutil::safe_strcpy(this->creationTimeDate, ct, sizeof(this->creationTimeDate));
 	}
 	
 	inline void GenericHeader::Creator(char *creat) const
 	{
-		::strncpy(creat, this->creator, sizeof(this->creator));
-		creat[200] = '\0';		
+		OIIO::Strutil::safe_strcpy(creat, this->creator, sizeof(this->creator));
 	}
 	
 	inline void GenericHeader::SetCreator(const char *creat)
 	{
-		::strncpy(this->creator, creat, sizeof(this->creator));
+		OIIO::Strutil::safe_strcpy(this->creator, creat, sizeof(this->creator));
 	}
 	
 	inline void GenericHeader::Project(char *prj) const
 	{
-		::strncpy(prj, this->project, sizeof(this->project));
-		prj[200] = '\0';
+		OIIO::Strutil::safe_strcpy(prj, this->project, sizeof(this->project));
 	}
 	
 	inline void GenericHeader::SetProject(const char *prj)
 	{
-		::strncpy(this->project, prj, sizeof(this->project));
+		OIIO::Strutil::safe_strcpy(this->project, prj, sizeof(this->project));
 	}
 	
 	inline void GenericHeader::Copyright(char *copy) const
 	{
-		::strncpy(copy, this->copyright, sizeof(this->copyright));
-		copy[200] = '\0';
+		OIIO::Strutil::safe_strcpy(copy, this->copyright, sizeof(this->copyright));
 	}
 	
 	inline void GenericHeader::SetCopyright(const char *copy)
 	{
-		::strncpy(this->copyright, copy, sizeof(this->copyright));
+		OIIO::Strutil::safe_strcpy(this->copyright, copy, sizeof(this->copyright));
 	}
 	
 	inline U32 GenericHeader::EncryptKey() const
@@ -1898,14 +1893,14 @@ namespace dpx
 	{
 		if (i < 0 || i >= MAX_ELEMENTS)
 			return;
-		strncpy(desc, this->chan[i].description, 32);
+		OIIO::Strutil::safe_strcpy(desc, this->chan[i].description, 32);
 	}
 
 	inline void GenericHeader::SetDescription(const int i, const char *desc)
 	{
 		if (i < 0 || i >= MAX_ELEMENTS)
 			return;
-		::strncpy(this->chan[i].description, desc, 32);
+		OIIO::Strutil::safe_strcpy(this->chan[i].description, desc, 32);
 	}
 	
 	
@@ -1971,46 +1966,42 @@ namespace dpx
 	
 	inline void GenericHeader::SourceImageFileName(char *fn) const
 	{
-		::strncpy(fn, this->sourceImageFileName, sizeof(this->sourceImageFileName));
-		fn[100] = '\0';
+		OIIO::Strutil::safe_strcpy(fn, this->sourceImageFileName, sizeof(this->sourceImageFileName));
 	}
 	
 	inline void GenericHeader::SetSourceImageFileName(const char *fn)
 	{
-		::strncpy(this->sourceImageFileName, fn, sizeof(this->sourceImageFileName));
+		OIIO::Strutil::safe_strcpy(this->sourceImageFileName, fn, sizeof(this->sourceImageFileName));
 	}
 	
 	inline void GenericHeader::SourceTimeDate(char *td) const
 	{
-		::strncpy(td, this->sourceTimeDate, sizeof(this->sourceTimeDate));
-		td[24] = '\0';
+		OIIO::Strutil::safe_strcpy(td, this->sourceTimeDate, sizeof(this->sourceTimeDate));
 	}
 	
 	inline void GenericHeader::SetSourceTimeDate(const char *td)
 	{
-		::strncpy(this->sourceTimeDate, td, sizeof(this->sourceTimeDate));
+		OIIO::Strutil::safe_strcpy(this->sourceTimeDate, td, sizeof(this->sourceTimeDate));
 	}
 	
 	inline void GenericHeader::InputDevice(char *dev) const
 	{
-		::strncpy(dev, this->inputDevice, sizeof(this->inputDevice));
-		dev[32] = '\0';
+		OIIO::Strutil::safe_strcpy(dev, this->inputDevice, sizeof(this->inputDevice));
 	}
 	
 	inline void  GenericHeader::SetInputDevice(const char *dev)
 	{
-		::strncpy(this->inputDevice, dev, sizeof(this->inputDevice));
+		OIIO::Strutil::safe_strcpy(this->inputDevice, dev, sizeof(this->inputDevice));
 	}
 	
 	inline void GenericHeader::InputDeviceSerialNumber(char *sn) const
 	{
-		::strncpy(sn, this->inputDeviceSerialNumber, sizeof(this->inputDeviceSerialNumber));
-		sn[32] = '\0';
+		OIIO::Strutil::safe_strcpy(sn, this->inputDeviceSerialNumber, sizeof(this->inputDeviceSerialNumber));
 	}
 	
 	inline void GenericHeader::SetInputDeviceSerialNumber(const char *sn)
 	{
-		::strncpy(this->inputDeviceSerialNumber, sn, sizeof(this->inputDeviceSerialNumber));
+		OIIO::Strutil::safe_strcpy(this->inputDeviceSerialNumber, sn, sizeof(this->inputDeviceSerialNumber));
 	}
 	
 	inline U16 GenericHeader::Border(const int i) const
@@ -2066,13 +2057,12 @@ namespace dpx
 	
 	inline void IndustryHeader::Format(char *fmt) const
 	{
-		::strncpy(fmt, this->format, sizeof(this->format));
-		fmt[32] = '\0';
+		OIIO::Strutil::safe_strcpy(fmt, this->format, sizeof(this->format));
 	}
 
 	inline void IndustryHeader::SetFormat(const char *fmt)
 	{
-		::strncpy(this->format, fmt, sizeof(this->format));
+		OIIO::Strutil::safe_strcpy(this->format, fmt, sizeof(this->format));
 	}
 
 	inline U32 IndustryHeader::FramePosition() const
@@ -2127,24 +2117,22 @@ namespace dpx
 
 	inline void IndustryHeader::FrameId(char *id) const
 	{
-		::strncpy(id, this->frameId, sizeof(this->frameId));
-		id[32] = '\0';
+		OIIO::Strutil::safe_strcpy(id, this->frameId, sizeof(this->frameId));
 	}
 
 	inline void IndustryHeader::SetFrameId(const char *id)
 	{
-		::strncpy(this->frameId, id, sizeof(this->frameId));
+		OIIO::Strutil::safe_strcpy(this->frameId, id, sizeof(this->frameId));
 	}
 
 	inline void IndustryHeader::SlateInfo(char *slate) const
 	{
-		::strncpy(slate, this->slateInfo, sizeof(this->slateInfo));
-		slate[100] = '\0';
+		OIIO::Strutil::safe_strcpy(slate, this->slateInfo, sizeof(this->slateInfo));
 	}
 
 	inline void IndustryHeader::SetSlateInfo(const char *slate)
 	{
-		::strncpy(this->slateInfo, slate, sizeof(this->slateInfo));
+		OIIO::Strutil::safe_strcpy(this->slateInfo, slate, sizeof(this->slateInfo));
 	}
 
 

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -216,7 +216,7 @@ public:
         sblur(0.0f), tblur(0.0f), swidth(1.0f), twidth(1.0f),
         fill(0.0f), missingcolor(NULL),
         // dresultds(NULL), dresultdt(NULL),
-        time(0.0f), // bias(0.0f), samples(1),
+        time(0.0f), bias(0.0f), samples(1),
         rwrap(WrapDefault), rblur(0.0f), rwidth(1.0f), // dresultdr(NULL),
         // actualchannels(0),
         envlayout(0)

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1252,7 +1252,7 @@ colorconvert_impl_float_rgba (ImageBuf &R, const ImageBuf &A,
         for (int k = roi.zbegin; k < roi.zend; ++k) {
             for (int j = roi.ybegin; j < roi.yend; ++j) {
                 // Load the scanline
-                memcpy (scanline, A.pixeladdr (roi.xbegin, j, k), width*4*sizeof(float));
+                memcpy ((void *)scanline, A.pixeladdr (roi.xbegin, j, k), width*4*sizeof(float));
                 // Optionally unpremult
                 if (unpremult) {
                     for (int i = 0; i < width; ++i) {

--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -1027,7 +1027,8 @@ pvt::append_tiff_dir_entry (std::vector<TIFFDirEntry> &dirs,
     size_t len = tiff_data_size (dir);
     if (len <= 4) {
         dir.tdir_offset = 0;
-        memcpy (&dir.tdir_offset, mydata, len);
+        if (mydata)
+            memcpy (&dir.tdir_offset, mydata, len);
     } else {
         if (mydata) {
             // Add to the data vector and use its offset

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -50,6 +50,12 @@
 #include FT_FREETYPE_H
 #endif
 
+#if OIIO_GNUC_VERSION >= 80000  /* gcc 8+ */
+// gcc8 complains about memcpy (in fill_const_) of half values because it
+// has no trivial copy assignment.
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
+
 
 OIIO_NAMESPACE_BEGIN
 

--- a/src/libutil/array_view_test.cpp
+++ b/src/libutil/array_view_test.cpp
@@ -88,15 +88,21 @@ void test_array_view_mutable ()
 
 
 
-void test_array_view_initlist ()
+void test_array_view_initlist_called (array_view<const float> a)
 {
-    // Try the array_view syntax with initializer_list.
-    array_view<const float> a { 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 0 };
     OIIO_CHECK_EQUAL (a.size(), 12);
     OIIO_CHECK_EQUAL (a[0], 0.0f);
     OIIO_CHECK_EQUAL (a[1], 1.0f);
     OIIO_CHECK_EQUAL (a[2], 0.0f);
     OIIO_CHECK_EQUAL (a[3], 2.0f);
+}
+
+
+
+void test_array_view_initlist ()
+{
+    // Exercise the array_view syntax with initializer_list.
+    test_array_view_initlist_called ({ 0.0f, 1.0f, 0.0f, 2.0f, 0.0f, 3.0f, 0.0f, 4.0f, 0.0f, 5.0f, 0.0f, 0.0f });
 }
 
 

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -82,7 +82,8 @@ ParamValue::init_noclear (ustring _name, TypeDesc _type, int _nvalues,
         if (m_type.basetype == TypeDesc::STRING) {
             ustring *u = (ustring *) data();
             for (size_t i = 0;  i < n;  ++i)
-                u[i] = ustring(u[i].c_str());
+                if (u)
+                    u[i] = ustring(u[i].c_str());
         }
     } else {
         // Big enough to warrant a malloc, but the caller said don't

--- a/src/libutil/ustring.cpp
+++ b/src/libutil/ustring.cpp
@@ -379,8 +379,7 @@ ustring::TableRep::~TableRep ()
         // This is one of those cases where we've carefully doctored the
         // string to point to our allocated characters.  To make a safe
         // string destroy, now force it to look like an empty string.
-        std::string empty;
-        memcpy (&str, &empty, sizeof(std::string));
+        new (&str) std::string();   // "placement new"
     }
 }
 

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -32,10 +32,16 @@
 #include <iostream>
 #include <ctime>       /* time_t, struct tm, gmtime */
 
+#include <OpenImageIO/platform.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/tiffutils.h>
+
+#if OIIO_GNUC_VERSION >= 80000
+// fix gcc8 warnings in libraw headers: use of auto_ptr
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 #include <libraw/libraw.h>
 #include <libraw/libraw_version.h>

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -1418,10 +1418,10 @@ main (int argc, const char *argv[])
         t.reset();
         t.start();
         for (int i = 0;  i < 1000000000;  ++i) {
-            memcpy (&copy, &canonical, sizeof(TextureOpt));
+            copy = canonical;
             dummyptr = &copy;  // This forces the optimizer to keep the loop
         }
-        std::cout << "TextureOpt memcpy: " << t() << " ns\n";
+        std::cout << "TextureOpt copy: " << t() << " ns\n";
     }
 
     if (testicwrite && filenames.size()) {


### PR DESCRIPTION
Add gcc8 to the TravisCI test matrix.

Fixed a bunch of minor things for all the new warnings that cropped up with gcc8. Many were legit things that were questionable (though asymptomatic). In a few cases, they were clearly false positives and I just disabled the new warnings in the narrowest way I could.
