### PR TITLE
Add C++17 to CI tests and fix issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -178,6 +178,10 @@ matrix:
       - os: linux
         compiler: gcc
         env: WHICHGCC=8 USE_CPP=14 USE_SIMD=avx,f16c
+    # test with C++17, gcc 8, latest SIMD flags supported by TravisCI VMs
+      - os: linux
+        compiler: gcc
+        env: WHICHGCC=8 USE_CPP=17 USE_SIMD=avx,f16c
     # build for AVX2, don't run the tests (ensure against build breaks)
       - os: linux
         compiler: gcc

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -4,7 +4,7 @@
 message (STATUS "CMAKE_CXX_COMPILER is ${CMAKE_CXX_COMPILER}")
 message (STATUS "CMAKE_CXX_COMPILER_ID is ${CMAKE_CXX_COMPILER_ID}")
 
-set (USE_CPP 11 CACHE STRING "C++ standard to prefer (11, 14, etc.)")
+set (USE_CPP 11 CACHE STRING "C++ standard to prefer (11, 14, 17, etc.)")
 option (USE_LIBCPLUSPLUS "Compile with clang libc++")
 set (USE_SIMD "" CACHE STRING "Use SIMD directives (0, sse2, sse3, ssse3, sse4.1, sse4.2, avx, avx2, avx512f, f16c, aes)")
 option (STOP_ON_WARNING "Stop building if there are any compiler warnings" ON)

--- a/src/doc/oiiointro.tex
+++ b/src/doc/oiiointro.tex
@@ -240,6 +240,9 @@ Dominik Reichl \\ \url{http://www.dominik-reichl.de/}
   \\ \url{https://github.com/vit-vit/CTPL}
 \item Droid fonts from the Android SDK are distributed under the
     Apache license. \\ \url{http://www.droidfonts.com}
+\item {\cf function_view.h} contains code derived from LLVM,
+  \copyright\ 2003--2018 University of Illinois at Urbana-Champaign.
+  UIUC license (compatible with BSD) \\ \url{llvm.org}
 \end{itemize}
 
 \noindent \product Has the following build-time dependencies (using

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -31,6 +31,12 @@
 #ifndef PYOPENIMAGEIO_PY_OIIO_H
 #define PYOPENIMAGEIO_PY_OIIO_H
 
+// Python.h uses the 'register' keyword, don't warn about it being
+// deprecated in C++17.
+#if (__cplusplus >= 201703L && defined(__GNUC__))
+#pragma GCC diagnostic ignored "-Wregister"
+#endif
+
 // Must include Python.h first to avoid certain warnings
 #include <Python.h>
 

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <iostream>
 #include <ctime>       /* time_t, struct tm, gmtime */
+#include <memory>
 
 #include <OpenImageIO/platform.h>
 #include <OpenImageIO/imageio.h>
@@ -41,6 +42,14 @@
 #if OIIO_GNUC_VERSION >= 80000
 // fix gcc8 warnings in libraw headers: use of auto_ptr
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+#if OIIO_CPLUSPLUS_VERSION >= 17 && (OIIO_CLANG_VERSION || OIIO_APPLE_CLANG_VERSION)
+// libraw uses auto_ptr, which is not in C++17 at all for clang, though
+// it does seem to be for gcc. So for clang, alias it to unique_ptr.
+namespace std {
+template<class T> using auto_ptr = unique_ptr<T>;
+}
 #endif
 
 #include <libraw/libraw.h>


### PR DESCRIPTION
Add a test to the TravisCI matrix that builds with C++17 using gcc8.

There were a couple minor warnings to fix (including those I found building for C++17 with clang on my Mac), nothing dramatic.

The only significant change was that the implementation of `function_view` gave me all sorts of trouble with C++17, stemming from the fact that C++17 considers 'noexcept' to be part of the function signature for template matching. I looked into alternate implementations and found out that LLVM's `FunctionRef` was extremely similar and worked flawlessly. So I swapped it in, in place of our previous implementation (but keeping our old name, function_view, so there should be no break in source compatibility).
