### PR TITLE
Travis: on OSX, don't load libraw from homebrew (temporary)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,7 +41,9 @@ NEW or CHANGED dependencies since the last major release are **bold**.
      * Python >= 2.7 (or 3.x)
      * **NumPy**
      * **pybind11** (but OIIO will auto-download it if not found)
- * libRaw >= 0.17 ("RAW" image reading will be disabled if not found)
+ * libRaw >= 0.15 ("RAW" image reading will be disabled if not found,
+   note that 0.18+ is necessary for ACES support, and 0.19 has some known
+   problems for OIIO)
  * ffmpeg >= 2.6 (tested through 4.0)
 
 

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -23,7 +23,8 @@ brew install ccache cmake
 brew install ilmbase openexr
 brew install opencolorio
 brew install freetype
-brew install libraw libpng webp jpeg-turbo
+#brew install libraw
+brew install libpng webp jpeg-turbo
 brew install openjpeg
 brew install dcmtk
 brew install qt


### PR DESCRIPTION
libraw on homebrew just upgraded to the new 0.19.0. This breaks our raw
tests (builds ok, but seems to not find all the metadata). I'm not sure
if this is a bug in 0.19.0, or if the API changed in some way that we need
to change things on our side. But in either case, it's a more lengthy
investigation than I have time for today, so disabling it on OSX Travis
tests seems like the expedient workaround. Libraw (0.15) is still exercised
on the Linux Travis tests.

As soon as I track down the real problems satisfactorally, I'll restore
the tests.

