### PR TITLE
Print metadata (oiiotool -info -v, etc.) in sorted order.

### DIFF
--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -385,7 +385,12 @@ print_metadata (const ImageSpec &spec, const std::string &filename)
         }
     }
 
-    for (auto&& p : spec.extra_attribs) {
+    // Sort the metadata alphabetically, case-insensitive, but making
+    // sure that all non-namespaced attribs appear before namespaced
+    // attribs.
+    ParamValueList attribs = spec.extra_attribs;
+    attribs.sort (false /* sort case-insensitively */);
+    for (auto&& p : attribs) {
         if (! metamatch.empty() &&
             ! regex_search (p.name().c_str(), field_re))
             continue;

--- a/src/include/OpenImageIO/paramlist.h
+++ b/src/include/OpenImageIO/paramlist.h
@@ -286,6 +286,12 @@ public:
     void add_or_replace (const ParamValue& pv, bool casesensitive=true);
     void add_or_replace (ParamValue&& pv, bool casesensitive=true);
 
+    // Sort alphabetically, optionally case-insensitively, locale-
+    // independently, and with all the "un-namespaced" items appearing
+    // first, followed by items with "prefixed namespaces" (e.g. "z" comes
+    // before "foo:a").
+    void sort (bool casesensitive=true);
+
     /// Even more radical than clear, free ALL memory associated with the
     /// list itself.
     void free () { clear(); shrink_to_fit(); }

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -201,6 +201,10 @@ strhash (string_view s)
 /// a static locale that doesn't require a mutex.
 bool OIIO_API iequals (string_view a, string_view b);
 
+/// Case-insensitive ordered comparison of strings.  For speed, this always
+/// uses a static locale that doesn't require a mutex.
+bool OIIO_API iless (string_view a, string_view b);
+
 /// Does 'a' start with the string 'b', with a case-sensitive comparison?
 bool OIIO_API starts_with (string_view a, string_view b);
 
@@ -424,17 +428,35 @@ public:
 
 
 
-/// C++ functor class for comparing two char*'s or std::string's for
-/// equality of their strings.
-class StringEqual {
-public:
-    bool operator() (const char *a, const char *b) const {
-        return strcmp (a, b) == 0;
-    }
-    bool operator() (string_view a, string_view b) const {
-        return a == b;
-    }
+/// C++ functor for comparing two strings for equality of their characters.
+struct OIIO_API StringEqual {
+    bool operator() (const char *a, const char *b) const { return strcmp (a, b) == 0; }
+    bool operator() (string_view a, string_view b) const { return a == b; }
 };
+
+
+/// C++ functor for comparing two strings for equality of their characters
+/// in a case-insensitive and locale-insensitive way.
+struct OIIO_API StringIEqual {
+    bool operator() (const char *a, const char *b) const;
+    bool operator() (string_view a, string_view b) const { return iequals (a, b); }
+};
+
+
+/// C++ functor for comparing the ordering of two strings.
+struct OIIO_API StringLess {
+    bool operator() (const char *a, const char *b) const { return strcmp (a, b) < 0; }
+    bool operator() (string_view a, string_view b) const { return a < b; }
+};
+
+
+/// C++ functor for comparing the ordering of two strings in a
+/// case-insensitive and locale-insensitive way.
+struct OIIO_API StringILess {
+    bool operator() (const char *a, const char *b) const;
+    bool operator() (string_view a, string_view b) const { return a < b; }
+};
+
 
 
 #ifdef _WIN32

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -1005,7 +1005,13 @@ ImageSpec::serialize (SerialFormat fmt, SerialVerbose verbose) const
                 << format_res (*this, tile_width, tile_height, tile_depth) << '\n';
         }
 
-        for (auto&& p : extra_attribs) {
+        // Sort the metadata alphabetically, case-insensitive, but making
+        // sure that all non-namespaced attribs appear before namespaced
+        // attribs.
+        ParamValueList attribs = extra_attribs;
+        attribs.sort (false /* sort case-insensitively */);
+
+        for (auto&& p : attribs) {
             out << format ("    %s: ", p.name());
             std::string s = metadata_val (p, verbose == SerialDetailedHuman);
             if (s == "1.#INF")

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -28,6 +28,7 @@
   (This is the Modified BSD License)
 */
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 
@@ -525,5 +526,25 @@ ParamValueList::add_or_replace (ParamValue&& pv, bool casesensitive)
         emplace_back (pv);
 }
 
+
+
+void
+ParamValueList::sort (bool casesensitive)
+{
+    if (casesensitive)
+        std::sort (begin(), end(),
+                   [&](const ParamValue &a, const ParamValue &b) -> bool {
+                        bool aprefix = a.name().find(':') != ustring::npos;
+                        bool bprefix = b.name().find(':') != ustring::npos;
+                        return (aprefix != bprefix) ? bprefix : a.name() < b.name();
+                    });
+    else
+        std::sort (begin(), end(),
+                   [&](const ParamValue &a, const ParamValue &b) -> bool {
+                        bool aprefix = a.name().find(':') != ustring::npos;
+                        bool bprefix = b.name().find(':') != ustring::npos;
+                        return (aprefix != bprefix) ? bprefix : Strutil::iless(a.name(), b.name());
+                    });
+}
 
 OIIO_NAMESPACE_END

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -368,29 +368,17 @@ Strutil::wordwrap (string_view src, int columns, int prefix)
 
 
 
-static std::locale& loc ()
-{
-    // Rather than have a file-level static locale which could suffer from
-    // the static initialization order fiasco, make it a static pointer
-    // inside the function that is allocated the first time it's needed. It
-    // will "leak" in the sense that this one locale is never deleted, but
-    // so what?
-#if OIIO_MSVS_BEFORE_2015
-    // MSVS prior to 2015 could not be trusted to make in-function static
-    // initialization thread-safe, as required by C++11.
-    static spin_mutex mutex;
-    spin_lock lock (mutex);
-#endif
-    static std::locale *loc = new std::locale (std::locale::classic());
-    return *loc;
-}
-
-
-
 bool
 Strutil::iequals (string_view a, string_view b)
 {
-    return boost::algorithm::iequals (a, b, loc());
+    return boost::algorithm::iequals (a, b, std::locale::classic());
+}
+
+
+bool
+Strutil::iless (string_view a, string_view b)
+{
+    return boost::algorithm::ilexicographical_compare (a, b, std::locale::classic());
 }
 
 
@@ -404,7 +392,7 @@ Strutil::starts_with (string_view a, string_view b)
 bool
 Strutil::istarts_with (string_view a, string_view b)
 {
-    return boost::algorithm::istarts_with (a, b, loc());
+    return boost::algorithm::istarts_with (a, b, std::locale::classic());
 }
 
 
@@ -418,7 +406,7 @@ Strutil::ends_with (string_view a, string_view b)
 bool
 Strutil::iends_with (string_view a, string_view b)
 {
-    return boost::algorithm::iends_with (a, b, loc());
+    return boost::algorithm::iends_with (a, b, std::locale::classic());
 }
 
 
@@ -432,21 +420,36 @@ Strutil::contains (string_view a, string_view b)
 bool
 Strutil::icontains (string_view a, string_view b)
 {
-    return boost::algorithm::icontains (a, b, loc());
+    return boost::algorithm::icontains (a, b, std::locale::classic());
 }
 
 
 void
 Strutil::to_lower (std::string &a)
 {
-    boost::algorithm::to_lower (a, loc());
+    boost::algorithm::to_lower (a, std::locale::classic());
 }
 
 
 void
 Strutil::to_upper (std::string &a)
 {
-    boost::algorithm::to_upper (a, loc());
+    boost::algorithm::to_upper (a, std::locale::classic());
+}
+
+
+
+bool
+Strutil::StringIEqual::operator () (const char *a, const char *b) const
+{
+    return boost::algorithm::iequals (a, b, std::locale::classic());
+}
+
+
+bool
+Strutil::StringILess::operator () (const char *a, const char *b) const
+{
+    return boost::algorithm::ilexicographical_compare (a, b, std::locale::classic());
 }
 
 

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -238,6 +238,23 @@ void test_comparisons ()
     OIIO_CHECK_EQUAL (Strutil::icontains ("abcde", ""), true);
     OIIO_CHECK_EQUAL (Strutil::icontains ("", ""), true);
     OIIO_CHECK_EQUAL (Strutil::icontains ("", "x"), false);
+
+    StringEqual  eq;
+    StringIEqual ieq;
+    StringLess   less;
+    StringILess  iless;
+    OIIO_CHECK_ASSERT (eq ("abc", "abc"));
+    OIIO_CHECK_ASSERT (! eq ("abc", "ABC"));
+    OIIO_CHECK_ASSERT (! eq ("abc", "axc"));
+    OIIO_CHECK_ASSERT (ieq ("abc", "abc"));
+    OIIO_CHECK_ASSERT (ieq ("abc", "ABC"));
+    OIIO_CHECK_ASSERT (! ieq ("abc", "axc"));
+    OIIO_CHECK_ASSERT (less ("abc", "abd"));
+    OIIO_CHECK_ASSERT (! less ("xbc", "abd"));
+    OIIO_CHECK_ASSERT (! less ("abc", "ABD"));
+    OIIO_CHECK_ASSERT (iless ("abc", "abd"));
+    OIIO_CHECK_ASSERT (! iless ("xbc", "abd"));
+    OIIO_CHECK_ASSERT (iless ("abc", "ABD"));
 }
 
 

--- a/src/python/py_paramvalue.cpp
+++ b/src/python/py_paramvalue.cpp
@@ -126,6 +126,8 @@ declare_paramvalue (py::module& m)
                 return p.add_or_replace (pv, casesensitive);
             },
             "value"_a, "casesensitive"_a=true)
+        .def("sort", &ParamValueList::sort,
+             "casesensitive"_a=true)
     ;
 }
 

--- a/testsuite/bmp/ref/out.txt
+++ b/testsuite/bmp/ref/out.txt
@@ -2,36 +2,36 @@ Reading ../../../../../bmpsuite/g01bg.bmp
 ../../../../../bmpsuite/g01bg.bmp :  127 x   64, 3 channel, uint8 bmp
     SHA-1: 3A3A9A7D3A25907693A33D4403B3FB5BFCC9E5B1
     channel list: R, G, B
+    ResolutionUnit: "m"
     XResolution: 0
     YResolution: 0
-    ResolutionUnit: "m"
 Comparing "../../../../../bmpsuite/g01bg.bmp" and "g01bg.bmp"
 PASS
 Reading ../../../../../bmpsuite/g04.bmp
 ../../../../../bmpsuite/g04.bmp :  127 x   64, 3 channel, uint8 bmp
     SHA-1: 83CE69952523E32894E14052E6B497E9D2C8867C
     channel list: R, G, B
+    ResolutionUnit: "m"
     XResolution: 0
     YResolution: 0
-    ResolutionUnit: "m"
 Comparing "../../../../../bmpsuite/g04.bmp" and "g04.bmp"
 PASS
 Reading ../../../../../bmpsuite/g08.bmp
 ../../../../../bmpsuite/g08.bmp :  127 x   64, 3 channel, uint8 bmp
     SHA-1: 18C1DA0C611E94F164B5C0758132EF9CE202DD47
     channel list: R, G, B
+    ResolutionUnit: "m"
     XResolution: 0
     YResolution: 0
-    ResolutionUnit: "m"
 Comparing "../../../../../bmpsuite/g08.bmp" and "g08.bmp"
 PASS
 Reading ../../../../../bmpsuite/g16bf555.bmp
 ../../../../../bmpsuite/g16bf555.bmp :  127 x   64, 3 channel, uint4 bmp
     SHA-1: 630022A1DFE41AA6AE07F272E3D441205F612240
     channel list: R, G, B
+    ResolutionUnit: "m"
     XResolution: 0
     YResolution: 0
-    ResolutionUnit: "m"
     oiio:BitsPerSample: 4
 Comparing "../../../../../bmpsuite/g16bf555.bmp" and "g16bf555.bmp"
 PASS
@@ -39,26 +39,26 @@ Reading ../../../../../bmpsuite/g24.bmp
 ../../../../../bmpsuite/g24.bmp :  127 x   64, 3 channel, uint8 bmp
     SHA-1: B1FB63649469F31D02D7AD065D3128EE04CC662E
     channel list: R, G, B
+    ResolutionUnit: "m"
     XResolution: 0
     YResolution: 0
-    ResolutionUnit: "m"
 Comparing "../../../../../bmpsuite/g24.bmp" and "g24.bmp"
 PASS
 Reading ../../../../../bmpsuite/g32bf.bmp
 ../../../../../bmpsuite/g32bf.bmp :  127 x   64, 4 channel, uint8 bmp
     SHA-1: AB315E7E66DBE94299A2E0F2749C5947D924B48B
     channel list: R, G, B, A
+    ResolutionUnit: "m"
     XResolution: 0
     YResolution: 0
-    ResolutionUnit: "m"
 Comparing "../../../../../bmpsuite/g32bf.bmp" and "g32bf.bmp"
 PASS
 Reading src/g01bg2-v5.bmp
 src/g01bg2-v5.bmp    :  127 x   64, 3 channel, uint8 bmp
     SHA-1: 3A3A9A7D3A25907693A33D4403B3FB5BFCC9E5B1
     channel list: R, G, B
+    ResolutionUnit: "m"
     XResolution: 2835
     YResolution: 2835
-    ResolutionUnit: "m"
 Comparing "src/g01bg2-v5.bmp" and "g01bg2-v5.bmp"
 PASS

--- a/testsuite/dpx/ref/out.txt
+++ b/testsuite/dpx/ref/out.txt
@@ -2,82 +2,82 @@ Reading ../../../../../oiio-images/dpx_nuke_10bits_rgb.dpx
 ../../../../../oiio-images/dpx_nuke_10bits_rgb.dpx :  512 x  512, 3 channel, uint10 dpx
     SHA-1: D63D2EC8C60AB41B1C0F72A65AE8FF27DA8A620E
     channel list: R, G, B
-    oiio:BitsPerSample: 10
-    Orientation: 1 (normal)
-    dpx:Transfer: "User defined"
-    dpx:Colorimetric: "User defined"
-    Software: "Nuke"
     DateTime: "2011:03:08 14:47:25"
+    Orientation: 1 (normal)
     PixelAspectRatio: 1
-    dpx:ImageDescriptor: "RGB"
+    Software: "Nuke"
+    dpx:BlackGain: 0
+    dpx:BlackLevel: 0
+    dpx:BreakPoint: 0
+    dpx:Colorimetric: "User defined"
     dpx:DittoKey: 1
-    dpx:LowQuantity: 2.1391e+09
-    dpx:HighQuantity: 2.1391e+09
-    dpx:EndOfLinePadding: 0
     dpx:EndOfImagePadding: 0
-    dpx:XScannedSize: 0
-    dpx:YScannedSize: 0
+    dpx:EndOfLinePadding: 0
+    dpx:FieldNumber: 0
     dpx:FramePosition: 32895
     dpx:FrameRate: 0
-    dpx:ShutterAngle: 0
-    dpx:Version: "V1.0"
-    dpx:Interlace: 0
-    dpx:FieldNumber: 0
+    dpx:HighQuantity: 2.1391e+09
     dpx:HorizontalSampleRate: 0
-    dpx:VerticalSampleRate: 0
-    dpx:TemporalFrameRate: 0
-    dpx:TimeOffset: 0
-    dpx:BlackLevel: 0
-    dpx:BlackGain: 0
-    dpx:BreakPoint: 0
-    dpx:WhiteLevel: 0
+    dpx:ImageDescriptor: "RGB"
     dpx:IntegrationTimes: 0
+    dpx:Interlace: 0
+    dpx:LowQuantity: 2.1391e+09
     dpx:Packing: "Filled, method A"
-    smpte:TimeCode: 0, 0 (00:00:00:00)
-    dpx:TimeCode: "00:00:00:00"
-    dpx:UserBits: 0
+    dpx:ShutterAngle: 0
     dpx:Signal: "Undefined"
+    dpx:TemporalFrameRate: 0
+    dpx:TimeCode: "00:00:00:00"
+    dpx:TimeOffset: 0
+    dpx:Transfer: "User defined"
+    dpx:UserBits: 0
+    dpx:Version: "V1.0"
+    dpx:VerticalSampleRate: 0
+    dpx:WhiteLevel: 0
+    dpx:XScannedSize: 0
+    dpx:YScannedSize: 0
+    oiio:BitsPerSample: 10
+    smpte:TimeCode: 0, 0 (00:00:00:00)
 Comparing "../../../../../oiio-images/dpx_nuke_10bits_rgb.dpx" and "dpx_nuke_10bits_rgb.dpx"
 PASS
 Reading ../../../../../oiio-images/dpx_nuke_16bits_rgba.dpx
 ../../../../../oiio-images/dpx_nuke_16bits_rgba.dpx :  512 x  512, 4 channel, uint10 dpx
     SHA-1: E9FECE70CD875C5654F58DA9EC576399F089D855
     channel list: R, G, B, A
-    oiio:BitsPerSample: 10
-    Orientation: 1 (normal)
-    dpx:Transfer: "User defined"
-    dpx:Colorimetric: "User defined"
-    Software: "Nuke"
     DateTime: "2011:03:08 14:47:01"
+    Orientation: 1 (normal)
     PixelAspectRatio: 1
-    dpx:ImageDescriptor: "RGBA"
+    Software: "Nuke"
+    dpx:BlackGain: 0
+    dpx:BlackLevel: 0
+    dpx:BreakPoint: 0
+    dpx:Colorimetric: "User defined"
     dpx:DittoKey: 1
-    dpx:LowQuantity: 2.1391e+09
-    dpx:HighQuantity: 2.1391e+09
-    dpx:EndOfLinePadding: 0
     dpx:EndOfImagePadding: 0
-    dpx:XScannedSize: 0
-    dpx:YScannedSize: 0
+    dpx:EndOfLinePadding: 0
+    dpx:FieldNumber: 0
     dpx:FramePosition: 32895
     dpx:FrameRate: 0
-    dpx:ShutterAngle: 0
-    dpx:Version: "V1.0"
-    dpx:Interlace: 0
-    dpx:FieldNumber: 0
+    dpx:HighQuantity: 2.1391e+09
     dpx:HorizontalSampleRate: 0
-    dpx:VerticalSampleRate: 0
-    dpx:TemporalFrameRate: 0
-    dpx:TimeOffset: 0
-    dpx:BlackLevel: 0
-    dpx:BlackGain: 0
-    dpx:BreakPoint: 0
-    dpx:WhiteLevel: 0
+    dpx:ImageDescriptor: "RGBA"
     dpx:IntegrationTimes: 0
+    dpx:Interlace: 0
+    dpx:LowQuantity: 2.1391e+09
     dpx:Packing: "Filled, method A"
-    smpte:TimeCode: 0, 0 (00:00:00:00)
-    dpx:TimeCode: "00:00:00:00"
-    dpx:UserBits: 0
+    dpx:ShutterAngle: 0
     dpx:Signal: "Undefined"
+    dpx:TemporalFrameRate: 0
+    dpx:TimeCode: "00:00:00:00"
+    dpx:TimeOffset: 0
+    dpx:Transfer: "User defined"
+    dpx:UserBits: 0
+    dpx:Version: "V1.0"
+    dpx:VerticalSampleRate: 0
+    dpx:WhiteLevel: 0
+    dpx:XScannedSize: 0
+    dpx:YScannedSize: 0
+    oiio:BitsPerSample: 10
+    smpte:TimeCode: 0, 0 (00:00:00:00)
 Comparing "../../../../../oiio-images/dpx_nuke_16bits_rgba.dpx" and "dpx_nuke_16bits_rgba.dpx"
 PASS
 Comparing "src/input_rgb_mattes.tif" and "output_rgb_mattes.dpx"
@@ -87,19 +87,19 @@ stereo.dpx           :   80 x   60, 3 channel, uint10 dpx
     2 subimages: 80x60 [u10,u10,u10], 80x60 [u10,u10,u10]
  subimage  0:   80 x   60, 3 channel, uint10 dpx
     channel list: R, G, B
-    oiio:BitsPerSample: 10
-    Orientation: 1 (normal)
-    dpx:Transfer: "Undefined"
-    dpx:Colorimetric: "User defined"
     ImageDescription: "view angle: left"
+    Orientation: 1 (normal)
     PixelAspectRatio: 1
-    dpx:ImageDescriptor: "RGB"
+    dpx:Colorimetric: "User defined"
     dpx:DittoKey: 1
-    dpx:EndOfLinePadding: 0
     dpx:EndOfImagePadding: 0
-    dpx:Version: "V2.0"
+    dpx:EndOfLinePadding: 0
+    dpx:ImageDescriptor: "RGB"
     dpx:Packing: "Filled, method A"
     dpx:Signal: "Undefined"
+    dpx:Transfer: "Undefined"
+    dpx:Version: "V2.0"
+    oiio:BitsPerSample: 10
     Stats Min: 0 0 0 (of 1023)
     Stats Max: 1023 1023 1023 (of 1023)
     Stats Avg: 18.64 18.64 18.64 (of 1023)
@@ -111,19 +111,19 @@ stereo.dpx           :   80 x   60, 3 channel, uint10 dpx
     Monochrome: Yes
  subimage  1:   80 x   60, 3 channel, uint10 dpx
     channel list: R, G, B
-    oiio:BitsPerSample: 10
-    Orientation: 1 (normal)
-    dpx:Transfer: "Undefined"
-    dpx:Colorimetric: "User defined"
     ImageDescription: "view angle: right"
+    Orientation: 1 (normal)
     PixelAspectRatio: 1
-    dpx:ImageDescriptor: "RGB"
+    dpx:Colorimetric: "User defined"
     dpx:DittoKey: 1
-    dpx:EndOfLinePadding: 0
     dpx:EndOfImagePadding: 0
-    dpx:Version: "V2.0"
+    dpx:EndOfLinePadding: 0
+    dpx:ImageDescriptor: "RGB"
     dpx:Packing: "Filled, method A"
     dpx:Signal: "Undefined"
+    dpx:Transfer: "Undefined"
+    dpx:Version: "V2.0"
+    oiio:BitsPerSample: 10
     Stats Min: 0 0 0 (of 1023)
     Stats Max: 1023 1023 1023 (of 1023)
     Stats Avg: 24.44 24.44 24.44 (of 1023)

--- a/testsuite/dup-channels/ref/out.txt
+++ b/testsuite/dup-channels/ref/out.txt
@@ -2,20 +2,20 @@ Reading out.exr
 out.exr              :   64 x   64, 6 channel, half openexr
     SHA-1: 6FECD5769C727E137B7580AE3B1823B06EE6F9D9
     channel list: R, G, B, channel3, channel4, channel5
-    oiio:ColorSpace: "Linear"
     compression: "zip"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Reading out2.exr
 out2.exr             :   64 x   64, 6 channel, half openexr
     SHA-1: 6FECD5769C727E137B7580AE3B1823B06EE6F9D9
     channel list: R, G, B, Bimg.R, Bimg.G, Bimg.B
-    oiio:ColorSpace: "Linear"
     compression: "zip"
     name: "Aimg"
-    openexr:chunkCount: 4
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
     oiio:subimagename: "Aimg"
+    openexr:chunkCount: 4

--- a/testsuite/field3d/ref/out.txt
+++ b/testsuite/field3d/ref/out.txt
@@ -3,16 +3,16 @@ Reading ../texture-field3d/src/dense_float.f3d
     SHA-1: 776F6CFF0B2C6834785A6EABA740C0DC7F1C78A2
     channel list: density
     tile size: 64 x 64 x 64
-    ImageDescription: "sphere:density"
-    oiio:subimagename: "sphere:density"
-    field3d:partition: "sphere"
-    field3d:layer: "density"
-    field3d:fieldtype: "DenseField"
-    field3d:mapping: "MatrixFieldMapping"
-    field3d:localtoworld: 2 0 0 0 0 2 0 0 0 0 2 0 -1 -1 -1 1
-    worldtocamera: 0.5 0 0 0 0 0.5 0 0 0 0 0.5 0 0.5 0.5 0.5 1
     field_type: 0
+    ImageDescription: "sphere:density"
     storage_type: 2
+    worldtocamera: 0.5 0 0 0 0 0.5 0 0 0 0 0.5 0 0.5 0.5 0.5 1
+    field3d:fieldtype: "DenseField"
+    field3d:layer: "density"
+    field3d:localtoworld: 2 0 0 0 0 2 0 0 0 0 2 0 -1 -1 -1 1
+    field3d:mapping: "MatrixFieldMapping"
+    field3d:partition: "sphere"
+    oiio:subimagename: "sphere:density"
 Comparing "../texture-field3d/src/dense_float.f3d" and "dense_float.f3d"
 PASS
 Reading ../texture-field3d/src/sparse_float.f3d
@@ -20,16 +20,16 @@ Reading ../texture-field3d/src/sparse_float.f3d
     SHA-1: 776F6CFF0B2C6834785A6EABA740C0DC7F1C78A2
     channel list: density
     tile size: 16 x 16 x 16
-    ImageDescription: "sphere:density"
-    oiio:subimagename: "sphere:density"
-    field3d:partition: "sphere"
-    field3d:layer: "density"
-    field3d:fieldtype: "SparseField"
-    field3d:mapping: "MatrixFieldMapping"
-    field3d:localtoworld: 2 0 0 0 0 2 0 0 0 0 2 0 -1 -1 -1 1
-    worldtocamera: 0.5 0 0 0 0 0.5 0 0 0 0 0.5 0 0.5 0.5 0.5 1
     field_type: 1
+    ImageDescription: "sphere:density"
     storage_type: 2
+    worldtocamera: 0.5 0 0 0 0 0.5 0 0 0 0 0.5 0 0.5 0.5 0.5 1
+    field3d:fieldtype: "SparseField"
+    field3d:layer: "density"
+    field3d:localtoworld: 2 0 0 0 0 2 0 0 0 0 2 0 -1 -1 -1 1
+    field3d:mapping: "MatrixFieldMapping"
+    field3d:partition: "sphere"
+    oiio:subimagename: "sphere:density"
 Comparing "../texture-field3d/src/sparse_float.f3d" and "sparse_float.f3d"
 PASS
 Reading ../texture-field3d/src/dense_half.f3d
@@ -37,16 +37,16 @@ Reading ../texture-field3d/src/dense_half.f3d
     SHA-1: E5F0EC2FDFB1C6D093F3FDDA6E72EE77B86514D5
     channel list: density
     tile size: 64 x 64 x 64
-    ImageDescription: "sphere:density"
-    oiio:subimagename: "sphere:density"
-    field3d:partition: "sphere"
-    field3d:layer: "density"
-    field3d:fieldtype: "DenseField"
-    field3d:mapping: "MatrixFieldMapping"
-    field3d:localtoworld: 2 0 0 0 0 2 0 0 0 0 2 0 -1 -1 -1 1
-    worldtocamera: 0.5 0 0 0 0 0.5 0 0 0 0 0.5 0 0.5 0.5 0.5 1
     field_type: 0
+    ImageDescription: "sphere:density"
     storage_type: 1
+    worldtocamera: 0.5 0 0 0 0 0.5 0 0 0 0 0.5 0 0.5 0.5 0.5 1
+    field3d:fieldtype: "DenseField"
+    field3d:layer: "density"
+    field3d:localtoworld: 2 0 0 0 0 2 0 0 0 0 2 0 -1 -1 -1 1
+    field3d:mapping: "MatrixFieldMapping"
+    field3d:partition: "sphere"
+    oiio:subimagename: "sphere:density"
 Comparing "../texture-field3d/src/dense_half.f3d" and "dense_half.f3d"
 PASS
 Reading ../texture-field3d/src/sparse_half.f3d
@@ -54,15 +54,15 @@ Reading ../texture-field3d/src/sparse_half.f3d
     SHA-1: E5F0EC2FDFB1C6D093F3FDDA6E72EE77B86514D5
     channel list: density
     tile size: 16 x 16 x 16
-    ImageDescription: "sphere:density"
-    oiio:subimagename: "sphere:density"
-    field3d:partition: "sphere"
-    field3d:layer: "density"
-    field3d:fieldtype: "SparseField"
-    field3d:mapping: "MatrixFieldMapping"
-    field3d:localtoworld: 2 0 0 0 0 2 0 0 0 0 2 0 -1 -1 -1 1
-    worldtocamera: 0.5 0 0 0 0 0.5 0 0 0 0 0.5 0 0.5 0.5 0.5 1
     field_type: 1
+    ImageDescription: "sphere:density"
     storage_type: 1
+    worldtocamera: 0.5 0 0 0 0 0.5 0 0 0 0 0.5 0 0.5 0.5 0.5 1
+    field3d:fieldtype: "SparseField"
+    field3d:layer: "density"
+    field3d:localtoworld: 2 0 0 0 0 2 0 0 0 0 2 0 -1 -1 -1 1
+    field3d:mapping: "MatrixFieldMapping"
+    field3d:partition: "sphere"
+    oiio:subimagename: "sphere:density"
 Comparing "../texture-field3d/src/sparse_half.f3d" and "sparse_half.f3d"
 PASS

--- a/testsuite/fits/ref/out.txt
+++ b/testsuite/fits/ref/out.txt
@@ -2,21 +2,21 @@ Reading ../../../../../fits-images/pg93/tst0001.fits
 ../../../../../fits-images/pg93/tst0001.fits :  123 x  321, 1 channel, uint8 fits
     SHA-1: FC4F635D410B219477B709E4D6F993E9AA42C7B3
     channel list: Y
-    Extend: "T"
     Blocked: "T"
     Cdelt1: -2.3
-    Crval1: -73.3
-    Crpix1: 12
-    Ctype1: "PIXEL"
     Cdelt2: 7.1
-    Crval2: 300.1
-    Crpix2: -11
-    Ctype2: "PIXEL"
-    Object: "Ramp 8-bit"
-    Origin: "ESO"
-    DateTime: "1992:08:19 00:00:00"
     Comment: "This test file was created by P.Grosbol, ESO (pgrosbol@eso.org)
 Simple 8-bit ramp pattern for testing of FITS readers"
+    Crpix1: 12
+    Crpix2: -11
+    Crval1: -73.3
+    Crval2: 300.1
+    Ctype1: "PIXEL"
+    Ctype2: "PIXEL"
+    DateTime: "1992:08:19 00:00:00"
+    Extend: "T"
+    Object: "Ramp 8-bit"
+    Origin: "ESO"
 Comparing "../../../../../fits-images/pg93/tst0001.fits" and "tst0001.fits"
 PASS
 Reading ../../../../../fits-images/pg93/tst0002.fits
@@ -24,91 +24,88 @@ Reading ../../../../../fits-images/pg93/tst0002.fits
     SHA-1: 4FCD0E343956DEA4E792786138651F9D8C81F615
     channel list: Y
     Cdelt1: -2.3
-    Crval1: -73.5
-    Crpix1: 12.1
     Cdelt2: 7.1
-    Crval2: 300.9
-    Crpix2: -11.3
     Cdelt3: 0.003
-    Crval3: 21.1
-    Crpix3: 199
-    Ctype3: "VELO"
-    Cunit3: "M/SEC"
-    Object: "Ramp 16-bit"
-    Origin: "ESO"
-    DateTime: "1992:08:20 00:00:00"
     Comment: "This test file was created by P.Grosbol, ESO (pgrosbol@eso.org)
 Simple 16-bit ramp pattern for testing of FITS readers"
+    Crpix1: 12.1
+    Crpix2: -11.3
+    Crpix3: 199
+    Crval1: -73.5
+    Crval2: 300.9
+    Crval3: 21.1
+    Ctype3: "VELO"
+    Cunit3: "M/SEC"
+    DateTime: "1992:08:20 00:00:00"
+    Object: "Ramp 16-bit"
+    Origin: "ESO"
 Comparing "../../../../../fits-images/pg93/tst0002.fits" and "tst0002.fits"
 PASS
 Reading ../../../../../fits-images/pg93/tst0003.fits
 ../../../../../fits-images/pg93/tst0003.fits :  137 x  271, 1 channel, uint fits
     SHA-1: 9D2DEE3C1411AB38B5DBAD0532F3679B797B2374
     channel list: Y
-    Extend: "T"
     Blocked: "T"
     Cdelt1: -0.12321
-    Crval1: 15.231
-    Crpix1: 12
-    Ctype1: "RA"
-    Cunit1: "DEGREES"
     Cdelt2: 0.001231
-    Crval2: -10.123
-    Crpix2: -11.1
-    Ctype2: "DEC"
-    Cunit2: "DEGREES"
-    Object: "Ramp 32-bit"
-    Origin: "ESO"
-    DateTime: "1992:08:20 00:00:00"
     Comment: "This test file was created by P.Grosbol, ESO (pgrosbol@eso.org)
 Simple 32-bit ramp pattern for testing of FITS readers"
+    Crpix1: 12
+    Crpix2: -11.1
+    Crval1: 15.231
+    Crval2: -10.123
+    Ctype1: "RA"
+    Ctype2: "DEC"
+    Cunit1: "DEGREES"
+    Cunit2: "DEGREES"
+    DateTime: "1992:08:20 00:00:00"
+    Extend: "T"
+    Object: "Ramp 32-bit"
+    Origin: "ESO"
 Comparing "../../../../../fits-images/pg93/tst0003.fits" and "tst0003.fits"
 PASS
 Reading ../../../../../fits-images/pg93/tst0005.fits
 ../../../../../fits-images/pg93/tst0005.fits :  102 x  109, 1 channel, float fits
     SHA-1: 763996BCEADB93234A73AD0D714C3E9D874014CE
     channel list: Y
-    Extend: "T"
     Blocked: "T"
     Cdelt1: 3.1
-    Crval1: 1299.1
-    Crpix1: 12.3
     Cdelt2: -0.17
-    Crval2: -102.4
-    Crpix2: -2031.8
-    Object: "Wave 32-bit FP"
-    Origin: "ESO"
-    DateTime: "1992:08:20 00:00:00"
     Comment: "This test file was created by P.Grosbol, ESO (pgrosbol@eso.org)
 Simple 32-bit FP sine wave pattern for testing of FITS readers"
+    Crpix1: 12.3
+    Crpix2: -2031.8
+    Crval1: 1299.1
+    Crval2: -102.4
+    DateTime: "1992:08:20 00:00:00"
+    Extend: "T"
+    Object: "Wave 32-bit FP"
+    Origin: "ESO"
 Comparing "../../../../../fits-images/pg93/tst0005.fits" and "tst0005.fits"
 PASS
 Reading ../../../../../fits-images/pg93/tst0006.fits
 ../../../../../fits-images/pg93/tst0006.fits :   77 x  173, 1 channel, double fits
     SHA-1: B043726D3F76840AAC84713C1A6C323D85CADC74
     channel list: Y
-    Extend: "T"
     Blocked: "T"
     Cdelt1: -0.25
-    Crval1: 1.5
-    Crpix1: 12.5
     Cdelt2: 1.1
-    Crval2: -3.7
-    Crpix2: 19.3
-    Object: "Wave 64-bit fp"
-    Origin: "ESO"
-    DateTime: "1992:08:20 00:00:00"
     Comment: "This test file was created by P.Grosbol, ESO (pgrosbol@eso.org)
 Simple 64-bit FP sine wave pattern for testing of FITS readers"
+    Crpix1: 12.5
+    Crpix2: 19.3
+    Crval1: 1.5
+    Crval2: -3.7
+    DateTime: "1992:08:20 00:00:00"
+    Extend: "T"
+    Object: "Wave 64-bit fp"
+    Origin: "ESO"
 Comparing "../../../../../fits-images/pg93/tst0006.fits" and "tst0006.fits"
 PASS
 Reading ../../../../../fits-images/pg93/tst0007.fits
 ../../../../../fits-images/pg93/tst0007.fits :   38 x    1, 1 channel, float fits
     SHA-1: 32FB2E046F09E6DC814A6040B03706174EAE7229
     channel list: Y
-    Object: "IEEE 32-bit test"
-    Origin: "ESO"
-    DateTime: "1992:08:20 00:00:00"
     Comment: "This test file was created by P.Grosbol, ESO (pgrosbol@eso.org)
 This is a test file containing special 32-bit IEEE FP values
 such as:
@@ -156,15 +153,15 @@ bfffffff      !  -1.9999999e+00
 80800000      !  -1.1754944e-38
 ff7fffff      !  -3.4028235e+38
 So best of luck with the decoding"
+    DateTime: "1992:08:20 00:00:00"
+    Object: "IEEE 32-bit test"
+    Origin: "ESO"
 Comparing "../../../../../fits-images/pg93/tst0007.fits" and "tst0007.fits"
 PASS
 Reading ../../../../../fits-images/pg93/tst0008.fits
 ../../../../../fits-images/pg93/tst0008.fits :   38 x    1, 1 channel, double fits
     SHA-1: 5C21742E65AF385B106DE98BE7004190C6F2E2BC
     channel list: Y
-    Object: "IEEE 64-bit test"
-    Origin: "ESO"
-    DateTime: "1992:08:20 00:00:00"
     Comment: "This test file was created by P.Grosbol, ESO (pgrosbol@eso.org)
 This is a test file containing special 64-bit IEEE FP values
 such as:
@@ -211,35 +208,30 @@ bfffffff ffffffff   ! -1.99999999999999978e+00
 80100000 00000000   ! -2.22507385850720138e-308
 ff7fffff ffffffff   ! -1.40444776161118415e+306
 So best of luck with the decoding"
+    DateTime: "1992:08:20 00:00:00"
+    Object: "IEEE 64-bit test"
+    Origin: "ESO"
 Comparing "../../../../../fits-images/pg93/tst0008.fits" and "tst0008.fits"
 PASS
 Reading ../../../../../fits-images/pg93/tst0013.fits
 ../../../../../fits-images/pg93/tst0013.fits :  128 x  128, 1 channel, float fits
     SHA-1: 2DAE86283E1BCB155774A83F88C75B045FB9B28C
     channel list: Y
-    Blocked: "T"
-    Origin: "BASIC-UX-LA SILLA"
-    Object: "Test data"
-    DateTime: "1993:05:13 00:00:00"
-    Date-obs: 13
-    Tm-start: 69932
-    Tm-end: 70121
-    Time-sid: 36564
-    Ra: 187.372
-    Dec: -21.2211
     Airmass: 1.019
-    Instrume: "IRAC-2a"
-    Crval1: 1
-    Crpix1: 1
+    Blocked: "T"
     Cdelt1: 1
-    Ctype1: "PIXEL"
-    Crval2: 1
-    Crpix2: 1
     Cdelt2: 1
-    Ctype2: "PIXEL"
-    Exptime: 2
-    Observer: "P.Grosbol"
     Comment: "May 13           ,           /"
+    Crpix1: 1
+    Crpix2: 1
+    Crval1: 1
+    Crval2: 1
+    Ctype1: "PIXEL"
+    Ctype2: "PIXEL"
+    Date-obs: 13
+    DateTime: "1993:05:13 00:00:00"
+    Dec: -21.2211
+    Exptime: 2
     Hierarch: "ESO GEN ID = 'Unknown '
 ESO GEN NO = 12371
 ESO GEN TYPE = 'SCI '
@@ -268,68 +260,71 @@ ESO DET NDIT = 90
 ESO DET NINT = 1
 ESO DET DUMDIT = 0
 ESO DET NCORRS = 'Double '"
+    Instrume: "IRAC-2a"
+    Object: "Test data"
+    Observer: "P.Grosbol"
+    Origin: "BASIC-UX-LA SILLA"
+    Ra: 187.372
+    Time-sid: 36564
+    Tm-end: 70121
+    Tm-start: 69932
 Comparing "../../../../../fits-images/pg93/tst0013.fits" and "tst0013.fits"
 PASS
 Reading ../../../../../fits-images/ftt4b/file001.fits
 ../../../../../fits-images/ftt4b/file001.fits :    0 x    0, 1 channel, uint8 fits
     SHA-1: DA39A3EE5E6B4B0D3255BFEF95601890AFD80709
     channel list: Y
-    Extend: "T"
-    Origin: "ESO"
-    Object: "SNG - CAT."
     DateTime: "1984:05:27 00:00:00"
+    Extend: "T"
+    Object: "SNG - CAT."
+    Origin: "ESO"
 Comparing "../../../../../fits-images/ftt4b/file001.fits" and "file001.fits"
 PASS
 Reading ../../../../../fits-images/ftt4b/file002.fits
 ../../../../../fits-images/ftt4b/file002.fits :    0 x    0, 1 channel, uint8 fits
     SHA-1: DA39A3EE5E6B4B0D3255BFEF95601890AFD80709
     channel list: Y
-    Extend: "T"
-    Origin: "ESO"
-    Object: "PGSNC - SN.CAT."
     DateTime: "1984:05:27 00:00:00"
+    Extend: "T"
+    Object: "PGSNC - SN.CAT."
+    Origin: "ESO"
 Comparing "../../../../../fits-images/ftt4b/file002.fits" and "file002.fits"
 PASS
 Reading ../../../../../fits-images/ftt4b/file003.fits
 ../../../../../fits-images/ftt4b/file003.fits :  512 x  512, 1 channel, uint16 fits
     SHA-1: 5CC4340F5D8AB2B776D2E12BFE946CA5CAFA38C6
     channel list: Y
-    Extend: "T"
-    Object: 3
-    Observer: "LISZ"
-    Date-obs: 29
-    Date-map: 26
-    Bscale: 2.59397e-05
-    Bzero: 0.710747
-    Bunit: "JY/BEAM"
-    Epoch: 1950
     Blank: -32768
-    Obsra: 252.167
-    Obsdec: 5.07648
+    Bscale: 2.59397e-05
+    Bunit: "JY/BEAM"
+    Bzero: 0.710747
+    Cdelt1: -0.000305556
+    Cdelt2: 0.000305556
+    Cdelt3: 293000
+    Cdelt4: 1
+    Crota1: 0
+    Crota2: 0
+    Crota3: 0
+    Crota4: 0
+    Crpix1: 256
+    Crpix2: 257
+    Crpix3: 1
+    Crpix4: 1
+    Crval1: 252.167
+    Crval2: 5.07648
+    Crval3: 1420584192
+    Crval4: -1
+    Ctype1: "RA---SIN"
+    Ctype2: "DEC--SIN"
+    Ctype3: "FREQ"
+    Ctype4: "STOKES"
     Datamax: 1.56066
     Datamin: -0.139115
-    Ctype1: "RA---SIN"
-    Crval1: 252.167
-    Cdelt1: -0.000305556
-    Crpix1: 256
-    Crota1: 0
-    Ctype2: "DEC--SIN"
-    Crval2: 5.07648
-    Cdelt2: 0.000305556
-    Crpix2: 257
-    Crota2: 0
-    Ctype3: "FREQ"
-    Crval3: 1420584192
-    Cdelt3: 293000
-    Crpix3: 1
-    Crota3: 0
-    Ctype4: "STOKES"
-    Crval4: -1
-    Cdelt4: 1
-    Crpix4: 1
-    Crota4: 0
-    Origin: "AIPSNRAO node CVAX       15JUL84"
+    Date-map: 26
+    Date-obs: 29
     DateTime: "1984:05:24 00:00:00"
+    Epoch: 1950
+    Extend: "T"
     History: "/--------------------------------------------------------------------
 /BEGIN "HISTORY" INFORMATION FOUND IN FITS TAPE HEADER BY IMLOD
 /---------------------------------------------------------------HISTORY
@@ -501,62 +496,26 @@ AIPS   IMNAME='3C348-CONT  ' IMCLASS='RCLN  ' IMSEQ=   1
 AIPS   USERNO=  545
 AIPS   CLEAN BMAJ=  1.2767E-03 BMIN=  1.2206E-03 BPA= -34.71
 AIPS   CLEAN NITER= 12000 PRODUCT=1"
+    Object: 3
+    Obsdec: 5.07648
+    Observer: "LISZ"
+    Obsra: 252.167
+    Origin: "AIPSNRAO node CVAX       15JUL84"
 Comparing "../../../../../fits-images/ftt4b/file003.fits" and "file003.fits"
 PASS
 Reading ../../../../../fits-images/ftt4b/file009.fits
 ../../../../../fits-images/ftt4b/file009.fits :    0 x    0, 1 channel, uint16 fits
     SHA-1: DA39A3EE5E6B4B0D3255BFEF95601890AFD80709
     channel list: Y
-    Groups: "T"
-    Pcount: 5
-    Gcount: 631
-    Bscale: 0.000244141
-    Bzero: 0
-    Bunit: "JY"
     Blank: -32768
-    Object: 742
-    Instrume: "VLA"
-    Telescop: "VLA"
-    Epoch: 1950
-    Observer: "BRID"
-    Date-obs: 5
-    DateTime: "1980:04:12 00:00:00"
-    Origin: "NRAO(CV) PGM=DUV2FITS(V1)"
-    Ctype2: "COMPLEX"
-    Crpix2: 1
-    Crval2: 1
+    Bscale: 0.000244141
+    Bunit: "JY"
+    Bzero: 0
     Cdelt2: 1
-    Ctype3: "STOKES"
-    Crpix3: 1
-    Crval3: 1
     Cdelt3: 1
-    Ctype4: "FREQ"
-    Crpix4: 1
-    Crval4: 4.8851e+09
     Cdelt4: 0
-    Ctype5: "RA"
-    Crpix5: 1
-    Crval5: 115.702
     Cdelt5: 0
-    Ctype6: "DEC"
-    Crpix6: 1
-    Crval6: 10.3091
     Cdelt6: 0
-    Ptype1: "BASELINE"
-    Pscal1: 1
-    Pzero1: 0
-    Ptype2: "HA"
-    Pscal2: 0.00549316
-    Pzero2: 0
-    Ptype3: "UU"
-    Pscal3: 4e-09
-    Pzero3: 0
-    Ptype4: "VV"
-    Pscal4: 4e-09
-    Pzero4: 0
-    Ptype5: "WW"
-    Pscal5: 4e-09
-    Pzero5: 0
     Comment: "FORMULA FOR BASELINE # FROM ANTENNA PAIR I < J
 B = (256 * I)  +  J
 ANTENNA LOCATIONS IN NANOSECONDS:
@@ -566,6 +525,26 @@ FORMULAE FOR UU, VV, WW :
 UU = BX * SIN(HA)  +  BY * COS(HA)
 VV = BZ * COS(DEC)  +  SIN(DEC) * (BY * SIN(HA) - BX * COS(HA))
 WW = BZ * SIN(DEC)  +  COS(DEC) * (BX * COS(HA) - BY * SIN(HA))"
+    Crpix2: 1
+    Crpix3: 1
+    Crpix4: 1
+    Crpix5: 1
+    Crpix6: 1
+    Crval2: 1
+    Crval3: 1
+    Crval4: 4.8851e+09
+    Crval5: 115.702
+    Crval6: 10.3091
+    Ctype2: "COMPLEX"
+    Ctype3: "STOKES"
+    Ctype4: "FREQ"
+    Ctype5: "RA"
+    Ctype6: "DEC"
+    Date-obs: 5
+    DateTime: "1980:04:12 00:00:00"
+    Epoch: 1950
+    Gcount: 631
+    Groups: "T"
     History: "VLACV SORT   ORDER='BH'
 VLACV ANT   N= 2 X=  5470.525 Y=-14443.176 Z= -8061.210 ST='AW4'
 VLACV ANT   N= 4 X=  1667.280 Y= -4396.334 Z= -2452.399 ST='CW8'
@@ -583,45 +562,62 @@ VLACV ANT   N=18 X=  2552.452 Y=  9638.185 Z= -3698.873 ST='BE6'
 VLACV ANT   N=20 X=  -100.221 Y=   -15.904 Z=   152.474 ST='DW2'
 VLACV ANT   N=21 X=  -812.570 Y=  -126.899 Z=  1200.964 ST='DN8'
 VLACV ANT   N=22 X=  1021.275 Y= -2683.726 Z= -1494.627 ST='CW6'"
+    Instrume: "VLA"
+    Object: 742
+    Observer: "BRID"
+    Origin: "NRAO(CV) PGM=DUV2FITS(V1)"
+    Pcount: 5
+    Pscal1: 1
+    Pscal2: 0.00549316
+    Pscal3: 4e-09
+    Pscal4: 4e-09
+    Pscal5: 4e-09
+    Ptype1: "BASELINE"
+    Ptype2: "HA"
+    Ptype3: "UU"
+    Ptype4: "VV"
+    Ptype5: "WW"
+    Pzero1: 0
+    Pzero2: 0
+    Pzero3: 0
+    Pzero4: 0
+    Pzero5: 0
+    Telescop: "VLA"
 Comparing "../../../../../fits-images/ftt4b/file009.fits" and "file009.fits"
 PASS
 Reading ../../../../../fits-images/ftt4b/file012.fits
 ../../../../../fits-images/ftt4b/file012.fits :  513 x  513, 1 channel, uint16 fits
     SHA-1: 844CE9474D5C9E91154E41D7ED417173DE57286D
     channel list: Y
-    Tables: 1
-    Object: "M84"
-    Observer: "LAIN"
-    Date-obs: 16
-    Date-map: 9
     Bscale: 2.85522e-06
-    Bzero: 0.0889426
     Bunit: "JY/BEAM"
-    Ctype1: "LL"
-    Ctype2: "MM"
-    Ctype3: "FREQ"
-    Ctype4: "STOKES"
-    Crval1: 185.631
-    Crval2: 13.1638
-    Crval3: 4.8851e+09
-    Crval4: 1
+    Bzero: 0.0889426
     Cdelt1: -0.000277778
     Cdelt2: 0.000277778
     Cdelt3: 50000000
     Cdelt4: 0
-    Crpix1: 257
-    Crpix2: 258
-    Crpix3: 1
-    Crpix4: 1
     Crota1: 0
     Crota2: 0
     Crota3: 0
     Crota4: 0
-    Epoch: 1950
+    Crpix1: 257
+    Crpix2: 258
+    Crpix3: 1
+    Crpix4: 1
+    Crval1: 185.631
+    Crval2: 13.1638
+    Crval3: 4.8851e+09
+    Crval4: 1
+    Ctype1: "LL"
+    Ctype2: "MM"
+    Ctype3: "FREQ"
+    Ctype4: "STOKES"
     Datamax: 0.18248
     Datamin: -0.00459448
-    Origin: "AIPS"
+    Date-map: 9
+    Date-obs: 16
     DateTime: "1982:09:02 00:00:00"
+    Epoch: 1950
     History: "UVLOD
 UVLOD OUTNAME='M84 6 EC    '   OUTCLASS='UVTB  '
 UVLOD OUTSEQ=    1   OUTDISK=  3
@@ -720,5 +716,9 @@ AIPS   IMNAME='M84 6C SC2  ' IMCLASS='ICLN  ' IMSEQ=   1
 AIPS   USERNO=  504
 AIPS   CLEAN BMAJ=  0.1078E-02 BMIN=  0.1067E-02 BPA= -34.45
 AIPS   CLEAN NITER= 12000 PRODUCT=1"
+    Object: "M84"
+    Observer: "LAIN"
+    Origin: "AIPS"
+    Tables: 1
 Comparing "../../../../../fits-images/ftt4b/file012.fits" and "file012.fits"
 PASS

--- a/testsuite/gif/ref/out.txt
+++ b/testsuite/gif/ref/out.txt
@@ -4,97 +4,97 @@ Reading ../../../../../oiio-images/gif_animation.gif
  subimage  0:   30 x   30, 4 channel, uint8 gif
     SHA-1: DDECBD8686D4C2BCB43C2AA05F75C5BDB1CAF54B
     channel list: R, G, B, A
-    oiio:ColorSpace: "sRGB"
     FramesPerSecond: 100/123 (0.813008)
-    oiio:Movie: 1
     gif:Interlacing: 0
+    oiio:ColorSpace: "sRGB"
+    oiio:Movie: 1
  subimage  1:   30 x   30, 4 channel, uint8 gif
     SHA-1: D69F1E35C727EEC9E3DF750374E41D42192DFFBE
     channel list: R, G, B, A
-    oiio:ColorSpace: "sRGB"
     FramesPerSecond: 100/123 (0.813008)
-    oiio:Movie: 1
     gif:Interlacing: 0
+    oiio:ColorSpace: "sRGB"
+    oiio:Movie: 1
  subimage  2:   30 x   30, 4 channel, uint8 gif
     SHA-1: 3897B49CE5378D3C65590497269B1BB3F9D7630F
     channel list: R, G, B, A
-    oiio:ColorSpace: "sRGB"
     FramesPerSecond: 100/123 (0.813008)
-    oiio:Movie: 1
     gif:Interlacing: 0
+    oiio:ColorSpace: "sRGB"
+    oiio:Movie: 1
 Reading ../../../../../oiio-images/gif_oiio_logo_with_alpha.gif
 ../../../../../oiio-images/gif_oiio_logo_with_alpha.gif :  135 x  135, 4 channel, uint8 gif
     SHA-1: 8EDEB5C51B7C376D2526BAC0E3CFE2BE500F4115
     channel list: R, G, B, A
-    oiio:ColorSpace: "sRGB"
     ImageDescription: "oiio logo with alpha"
     gif:Interlacing: 0
+    oiio:ColorSpace: "sRGB"
 Reading ../../../../../oiio-images/gif_tahoe.gif
 ../../../../../oiio-images/gif_tahoe.gif : 2048 x 1536, 4 channel, uint8 gif
     SHA-1: 4E76899178CDAA94690E52CD18E07B810E40A273
     channel list: R, G, B, A
-    oiio:ColorSpace: "sRGB"
     gif:Interlacing: 0
+    oiio:ColorSpace: "sRGB"
 Reading ../../../../../oiio-images/gif_tahoe_interlaced.gif
 ../../../../../oiio-images/gif_tahoe_interlaced.gif : 2048 x 1536, 4 channel, uint8 gif
     SHA-1: 4E76899178CDAA94690E52CD18E07B810E40A273
     channel list: R, G, B, A
-    oiio:ColorSpace: "sRGB"
     gif:Interlacing: 1
+    oiio:ColorSpace: "sRGB"
 Reading ../../../../../oiio-images/gif_bluedot.gif
 ../../../../../oiio-images/gif_bluedot.gif :    1 x    1, 4 channel, uint8 gif
     SHA-1: EE0202803A0133BDA7BC40AC63091DCC58A4225B
     channel list: R, G, B, A
-    oiio:ColorSpace: "sRGB"
     gif:Interlacing: 0
+    oiio:ColorSpace: "sRGB"
 Reading ../../../../../oiio-images/gif_diagonal_interlaced.gif
 ../../../../../oiio-images/gif_diagonal_interlaced.gif :  200 x  200, 4 channel, uint8 gif
     SHA-1: CE1C613BB8B7EE80673B640CA3E392345C8C9FF4
     channel list: R, G, B, A
-    oiio:ColorSpace: "sRGB"
     gif:Interlacing: 1
+    oiio:ColorSpace: "sRGB"
 Reading ../../../../../oiio-images/gif_triangle_interlaced.gif
 ../../../../../oiio-images/gif_triangle_interlaced.gif :  200 x  200, 4 channel, uint8 gif
     SHA-1: 44F8A0F4F39AB3ED532268B9EB45E09548925345
     channel list: R, G, B, A
-    oiio:ColorSpace: "sRGB"
     gif:Interlacing: 1
+    oiio:ColorSpace: "sRGB"
 Reading ../../../../../oiio-images/gif_test_disposal_method.gif
 ../../../../../oiio-images/gif_test_disposal_method.gif :   50 x   50, 4 channel, uint8 gif
     4 subimages: 50x50 [u8,u8,u8,u8], 50x50 [u8,u8,u8,u8], 50x50 [u8,u8,u8,u8], 50x50 [u8,u8,u8,u8]
  subimage  0:   50 x   50, 4 channel, uint8 gif
     SHA-1: 30839F361083DA6893F6A29B4F4628DCFBF9F1B5
     channel list: R, G, B, A
-    oiio:ColorSpace: "sRGB"
     gif:Interlacing: 0
+    oiio:ColorSpace: "sRGB"
  subimage  1:   50 x   50, 4 channel, uint8 gif
     SHA-1: 214A1EE026296A399D8A530C44275FC5BDFBA3BA
     channel list: R, G, B, A
-    oiio:ColorSpace: "sRGB"
     gif:Interlacing: 0
+    oiio:ColorSpace: "sRGB"
  subimage  2:   50 x   50, 4 channel, uint8 gif
     SHA-1: 298C45330E7FAF68A6922C521EA766CA1594B1A4
     channel list: R, G, B, A
-    oiio:ColorSpace: "sRGB"
     gif:Interlacing: 0
+    oiio:ColorSpace: "sRGB"
  subimage  3:   50 x   50, 4 channel, uint8 gif
     SHA-1: 6D46A3F714B4BD68D289B9A945FF2716F1EB3A64
     channel list: R, G, B, A
-    oiio:ColorSpace: "sRGB"
     gif:Interlacing: 0
+    oiio:ColorSpace: "sRGB"
 Reading ../../../../../oiio-images/gif_test_loop_count.gif
 ../../../../../oiio-images/gif_test_loop_count.gif :   20 x   20, 4 channel, uint8 gif
     SHA-1: C4AA837A5833B05CFCA50BD090D42AEB033069E1
     channel list: R, G, B, A
-    oiio:ColorSpace: "sRGB"
-    gif:LoopCount: 12345
     gif:Interlacing: 0
+    gif:LoopCount: 12345
+    oiio:ColorSpace: "sRGB"
 Reading tahoe-tiny.gif
 tahoe-tiny.gif       :  128 x   96, 4 channel, uint8 gif
     SHA-1: B05CB30B2108904DAAD7B39E1BD7AA68D1D844CC
     channel list: R, G, B, A
-    oiio:ColorSpace: "sRGB"
-    gif:LoopCount: 0
     FramesPerSecond: 100/100 (1)
-    oiio:Movie: 1
     gif:Interlacing: 0
+    gif:LoopCount: 0
+    oiio:ColorSpace: "sRGB"
+    oiio:Movie: 1

--- a/testsuite/gpsread/ref/out-alt.txt
+++ b/testsuite/gpsread/ref/out-alt.txt
@@ -2,60 +2,60 @@ Reading ../../../../../oiio-images/tahoe-gps.jpg
 ../../../../../oiio-images/tahoe-gps.jpg : 2048 x 1536, 3 channel, uint8 jpeg
     SHA-1: 71EBEC73B8E8B3533780B15147E61D895C80E8B1
     channel list: R, G, B
-    oiio:ColorSpace: "sRGB"
-    jpeg:subsampling: "4:2:0"
     Make: "HTC"
     Model: "T-Mobile G1"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
     ResolutionUnit: "none"
     Software: "title;va"
-    Exif:YCbCrPositioning: 1
-    Exif:ExifVersion: "0220"
-    Exif:DateTimeOriginal: "2009:02:21 08:32:04"
-    Exif:DateTimeDigitized: "2009:02:21 08:32:04"
-    Exif:FlashPixVersion: "0100"
+    XResolution: 72
+    YResolution: 72
     Exif:ColorSpace: 1
+    Exif:DateTimeDigitized: "2009:02:21 08:32:04"
+    Exif:DateTimeOriginal: "2009:02:21 08:32:04"
+    Exif:ExifVersion: "0220"
+    Exif:FlashPixVersion: "0100"
     Exif:PixelXDimension: 2048
     Exif:PixelYDimension: 1536
     Exif:WhiteBalance: 0 (auto)
-    GPS:VersionID: 2, 2, 0, 0
-    GPS:LatitudeRef: "N"
-    GPS:Latitude: 39, 18, 24.4
-    GPS:LongitudeRef: "W"
-    GPS:Longitude: 120, 20, 6.25
-    GPS:AltitudeRef: 0 (above sea level)
+    Exif:YCbCrPositioning: 1
     GPS:Altitude: 0 (0 m)
-    GPS:TimeStamp: 17, 56, 33
-    GPS:MapDatum: "WGS-84"
+    GPS:AltitudeRef: 0 (above sea level)
     GPS:DateStamp: "1915:08:08"
+    GPS:Latitude: 39, 18, 24.4
+    GPS:LatitudeRef: "N"
+    GPS:Longitude: 120, 20, 6.25
+    GPS:LongitudeRef: "W"
+    GPS:MapDatum: "WGS-84"
+    GPS:TimeStamp: 17, 56, 33
+    GPS:VersionID: 2, 2, 0, 0
+    jpeg:subsampling: "4:2:0"
+    oiio:ColorSpace: "sRGB"
 Reading tahoe-gps.jpg
 tahoe-gps.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     SHA-1: 2623446988E34395C6B0A4AA4FC75107C708BF18
     channel list: R, G, B
-    oiio:ColorSpace: "sRGB"
-    jpeg:subsampling: "4:2:0"
     Make: "HTC"
     Model: "T-Mobile G1"
     Orientation: 1 (normal)
+    ResolutionUnit: "none"
     XResolution: 72
     YResolution: 72
-    Exif:YCbCrPositioning: 1
+    Exif:ColorSpace: 1
     Exif:ExifVersion: "0230"
     Exif:FlashPixVersion: "0100"
-    Exif:ColorSpace: 1
     Exif:PixelXDimension: 2048
     Exif:PixelYDimension: 1536
     Exif:WhiteBalance: 0 (auto)
-    GPS:VersionID: 2, 2, 0, 0
-    GPS:LatitudeRef: "N"
-    GPS:Latitude: 39, 18, 24.4
-    GPS:LongitudeRef: "W"
-    GPS:Longitude: 120, 20, 6.25
-    GPS:AltitudeRef: 0 (above sea level)
+    Exif:YCbCrPositioning: 1
     GPS:Altitude: 0 (0 m)
-    GPS:TimeStamp: 17, 56, 33
-    GPS:MapDatum: "WGS-84"
+    GPS:AltitudeRef: 0 (above sea level)
     GPS:DateStamp: "1915:08:08"
-    ResolutionUnit: "none"
+    GPS:Latitude: 39, 18, 24.4
+    GPS:LatitudeRef: "N"
+    GPS:Longitude: 120, 20, 6.25
+    GPS:LongitudeRef: "W"
+    GPS:MapDatum: "WGS-84"
+    GPS:TimeStamp: 17, 56, 33
+    GPS:VersionID: 2, 2, 0, 0
+    jpeg:subsampling: "4:2:0"
+    oiio:ColorSpace: "sRGB"

--- a/testsuite/gpsread/ref/out.txt
+++ b/testsuite/gpsread/ref/out.txt
@@ -2,60 +2,60 @@ Reading ../../../../../oiio-images/tahoe-gps.jpg
 ../../../../../oiio-images/tahoe-gps.jpg : 2048 x 1536, 3 channel, uint8 jpeg
     SHA-1: C3B420EF8C20C4771F6F7BF89EA9D9D4002BA016
     channel list: R, G, B
-    oiio:ColorSpace: "sRGB"
-    jpeg:subsampling: "4:2:0"
     Make: "HTC"
     Model: "T-Mobile G1"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
     ResolutionUnit: "none"
     Software: "title;va"
-    Exif:YCbCrPositioning: 1
-    Exif:ExifVersion: "0220"
-    Exif:DateTimeOriginal: "2009:02:21 08:32:04"
-    Exif:DateTimeDigitized: "2009:02:21 08:32:04"
-    Exif:FlashPixVersion: "0100"
+    XResolution: 72
+    YResolution: 72
     Exif:ColorSpace: 1
+    Exif:DateTimeDigitized: "2009:02:21 08:32:04"
+    Exif:DateTimeOriginal: "2009:02:21 08:32:04"
+    Exif:ExifVersion: "0220"
+    Exif:FlashPixVersion: "0100"
     Exif:PixelXDimension: 2048
     Exif:PixelYDimension: 1536
     Exif:WhiteBalance: 0 (auto)
-    GPS:VersionID: 2, 2, 0, 0
-    GPS:LatitudeRef: "N"
-    GPS:Latitude: 39, 18, 24.4
-    GPS:LongitudeRef: "W"
-    GPS:Longitude: 120, 20, 6.25
-    GPS:AltitudeRef: 0 (above sea level)
+    Exif:YCbCrPositioning: 1
     GPS:Altitude: 0 (0 m)
-    GPS:TimeStamp: 17, 56, 33
-    GPS:MapDatum: "WGS-84"
+    GPS:AltitudeRef: 0 (above sea level)
     GPS:DateStamp: "1915:08:08"
+    GPS:Latitude: 39, 18, 24.4
+    GPS:LatitudeRef: "N"
+    GPS:Longitude: 120, 20, 6.25
+    GPS:LongitudeRef: "W"
+    GPS:MapDatum: "WGS-84"
+    GPS:TimeStamp: 17, 56, 33
+    GPS:VersionID: 2, 2, 0, 0
+    jpeg:subsampling: "4:2:0"
+    oiio:ColorSpace: "sRGB"
 Reading tahoe-gps.jpg
 tahoe-gps.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     SHA-1: 2623446988E34395C6B0A4AA4FC75107C708BF18
     channel list: R, G, B
-    oiio:ColorSpace: "sRGB"
-    jpeg:subsampling: "4:2:0"
     Make: "HTC"
     Model: "T-Mobile G1"
     Orientation: 1 (normal)
+    ResolutionUnit: "none"
     XResolution: 72
     YResolution: 72
-    Exif:YCbCrPositioning: 1
+    Exif:ColorSpace: 1
     Exif:ExifVersion: "0230"
     Exif:FlashPixVersion: "0100"
-    Exif:ColorSpace: 1
     Exif:PixelXDimension: 2048
     Exif:PixelYDimension: 1536
     Exif:WhiteBalance: 0 (auto)
-    GPS:VersionID: 2, 2, 0, 0
-    GPS:LatitudeRef: "N"
-    GPS:Latitude: 39, 18, 24.4
-    GPS:LongitudeRef: "W"
-    GPS:Longitude: 120, 20, 6.25
-    GPS:AltitudeRef: 0 (above sea level)
+    Exif:YCbCrPositioning: 1
     GPS:Altitude: 0 (0 m)
-    GPS:TimeStamp: 17, 56, 33
-    GPS:MapDatum: "WGS-84"
+    GPS:AltitudeRef: 0 (above sea level)
     GPS:DateStamp: "1915:08:08"
-    ResolutionUnit: "none"
+    GPS:Latitude: 39, 18, 24.4
+    GPS:LatitudeRef: "N"
+    GPS:Longitude: 120, 20, 6.25
+    GPS:LongitudeRef: "W"
+    GPS:MapDatum: "WGS-84"
+    GPS:TimeStamp: 17, 56, 33
+    GPS:VersionID: 2, 2, 0, 0
+    jpeg:subsampling: "4:2:0"
+    oiio:ColorSpace: "sRGB"

--- a/testsuite/ico/ref/out.txt
+++ b/testsuite/ico/ref/out.txt
@@ -28,8 +28,8 @@ Reading ../../../../../oiio-images/oiio.ico
  subimage  6:  256 x  256, 4 channel, uint2 ico
     SHA-1: F44C9B94AB7D612F62A4DC29FD9C56FD173F2614
     channel list: R, G, B, A
-    oiio:UnassociatedAlpha: 1
     oiio:BitsPerSample: 2
+    oiio:UnassociatedAlpha: 1
  subimage  7:   48 x   48, 4 channel, uint8 ico
     SHA-1: 127700A3DACBF25FCD800642D78F8EE91EDE24B9
     channel list: R, G, B, A

--- a/testsuite/jpeg-corrupt-exif/ref/out.txt
+++ b/testsuite/jpeg-corrupt-exif/ref/out.txt
@@ -2,9 +2,9 @@ Reading src/corrupt.jpg
 src/corrupt.jpg      :  256 x  256, 3 channel, uint8 jpeg
     SHA-1: 3EA7BAEB0871E9B9BAADF286521423199ACA2401
     channel list: R, G, B
-    oiio:ColorSpace: "sRGB"
-    jpeg:subsampling: "4:2:0"
     Orientation: 1 (normal)
+    ResolutionUnit: "in"
     XResolution: 300
     YResolution: 300
-    ResolutionUnit: "in"
+    jpeg:subsampling: "4:2:0"
+    oiio:ColorSpace: "sRGB"

--- a/testsuite/jpeg2000/ref/out-alt.txt
+++ b/testsuite/jpeg2000/ref/out-alt.txt
@@ -3,8 +3,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file1.jp2
     SHA-1: 746B1B44D0E5EE3999B1350B2A4245D679A617F7
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file1.jp2" and "file1.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file2.jp2
@@ -12,8 +12,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file2.jp2
     SHA-1: FB4746F0C4909CE8FED60C0179B70B2EEA0C0BA9
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file2.jp2" and "file2.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file3.jp2
@@ -21,8 +21,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file3.jp2
     SHA-1: B8A8FBF015263C072B051839F6BE645E7F27C671
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file3.jp2" and "file3.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file4.jp2
@@ -30,8 +30,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file4.jp2
     SHA-1: A45171430806BA3E74705675C855A781FC04BE44
     channel list: Y
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file4.jp2" and "file4.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file5.jp2
@@ -39,8 +39,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file5.jp2
     SHA-1: FEF67669AB05A25F8A42455206B64C789CFCA38F
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file5.jp2" and "file5.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file6.jp2
@@ -48,8 +48,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file6.jp2
     SHA-1: 3A29DFAD0AA3F910AA2D37007989A4CC6E7BDE2A
     channel list: Y
     oiio:BitsPerSample: 12
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file6.jp2" and "file6.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file7.jp2
@@ -57,8 +57,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file7.jp2
     SHA-1: C1110501C2784B4AB29B98B2C6EC05C0C6C16F77
     channel list: R, G, B
     oiio:BitsPerSample: 16
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file7.jp2" and "file7.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file8.jp2
@@ -66,8 +66,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file8.jp2
     SHA-1: 593D82DE9935FC3F7963CABAAD5ACB7F8134E39A
     channel list: Y
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file8.jp2" and "file8.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file9.jp2
@@ -75,7 +75,7 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file9.jp2
     SHA-1: 501807547A6F9B8FA61EF7A4FD9AB7B369E7800C
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file9.jp2" and "file9.jp2"
 PASS

--- a/testsuite/jpeg2000/ref/out-spinux.txt
+++ b/testsuite/jpeg2000/ref/out-spinux.txt
@@ -3,8 +3,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file1.jp2
     SHA-1: 746B1B44D0E5EE3999B1350B2A4245D679A617F7
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file1.jp2" and "file1.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file2.jp2
@@ -12,8 +12,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file2.jp2
     SHA-1: FB4746F0C4909CE8FED60C0179B70B2EEA0C0BA9
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file2.jp2" and "file2.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file3.jp2
@@ -21,8 +21,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file3.jp2
     SHA-1: B8A8FBF015263C072B051839F6BE645E7F27C671
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file3.jp2" and "file3.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file4.jp2
@@ -30,8 +30,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file4.jp2
     SHA-1: A45171430806BA3E74705675C855A781FC04BE44
     channel list: Y
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file4.jp2" and "file4.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file5.jp2
@@ -39,8 +39,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file5.jp2
     SHA-1: FEF67669AB05A25F8A42455206B64C789CFCA38F
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file5.jp2" and "file5.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file6.jp2
@@ -48,8 +48,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file6.jp2
     SHA-1: 3A29DFAD0AA3F910AA2D37007989A4CC6E7BDE2A
     channel list: Y
     oiio:BitsPerSample: 12
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file6.jp2" and "file6.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file7.jp2
@@ -57,8 +57,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file7.jp2
     SHA-1: C1110501C2784B4AB29B98B2C6EC05C0C6C16F77
     channel list: R, G, B
     oiio:BitsPerSample: 16
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file7.jp2" and "file7.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file8.jp2
@@ -66,8 +66,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file8.jp2
     SHA-1: 593D82DE9935FC3F7963CABAAD5ACB7F8134E39A
     channel list: Y
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file8.jp2" and "file8.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file9.jp2
@@ -75,7 +75,7 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file9.jp2
     SHA-1: 9784D248E95A47CDB3D0B260C7FBFFE2A4A2D492
     channel list: Y
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file9.jp2" and "file9.jp2"
 PASS

--- a/testsuite/jpeg2000/ref/out.txt
+++ b/testsuite/jpeg2000/ref/out.txt
@@ -3,8 +3,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file1.jp2
     SHA-1: 746B1B44D0E5EE3999B1350B2A4245D679A617F7
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file1.jp2" and "file1.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file2.jp2
@@ -12,8 +12,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file2.jp2
     SHA-1: 668A651D2B8C3B99CCCC560F993F5BBD33F2B3E7
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file2.jp2" and "file2.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file3.jp2
@@ -21,8 +21,8 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file3.jp2
     SHA-1: B8A8FBF015263C072B051839F6BE645E7F27C671
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file3.jp2" and "file3.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file4.jp2
@@ -30,18 +30,18 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file4.jp2
     SHA-1: A45171430806BA3E74705675C855A781FC04BE44
     channel list: Y
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file4.jp2" and "file4.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file5.jp2
 ../../../../../j2kp4files_v1_5/testfiles_jp2/file5.jp2 :  768 x  512, 3 channel, uint8 jpeg2000
     SHA-1: FEF67669AB05A25F8A42455206B64C789CFCA38F
     channel list: R, G, B
-    oiio:BitsPerSample: 8
-    oiio:Orientation: 1
-    oiio:ColorSpace: "sRGB"
     ICCProfile: 0, 0, 2, 34, 0, 0, 0, 0, 2, 32, 0, 0, 115, 99, 110, 114, ... [546 x uint8]
+    oiio:BitsPerSample: 8
+    oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file5.jp2" and "file5.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file6.jp2
@@ -49,28 +49,28 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file6.jp2
     SHA-1: 3A29DFAD0AA3F910AA2D37007989A4CC6E7BDE2A
     channel list: Y
     oiio:BitsPerSample: 12
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file6.jp2" and "file6.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file7.jp2
 ../../../../../j2kp4files_v1_5/testfiles_jp2/file7.jp2 :  480 x  640, 3 channel, uint16 jpeg2000
     SHA-1: C1110501C2784B4AB29B98B2C6EC05C0C6C16F77
     channel list: R, G, B
-    oiio:BitsPerSample: 16
-    oiio:Orientation: 1
-    oiio:ColorSpace: "sRGB"
     ICCProfile: 0, 0, 52, 20, 65, 80, 80, 76, 2, 16, 0, 0, 115, 99, 110, 114, ... [13332 x uint8]
+    oiio:BitsPerSample: 16
+    oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file7.jp2" and "file7.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file8.jp2
 ../../../../../j2kp4files_v1_5/testfiles_jp2/file8.jp2 :  700 x  400, 1 channel, uint8 jpeg2000
     SHA-1: 593D82DE9935FC3F7963CABAAD5ACB7F8134E39A
     channel list: Y
-    oiio:BitsPerSample: 8
-    oiio:Orientation: 1
-    oiio:ColorSpace: "sRGB"
     ICCProfile: 0, 0, 1, 158, 0, 0, 0, 0, 2, 32, 0, 0, 115, 99, 110, 114, ... [414 x uint8]
+    oiio:BitsPerSample: 8
+    oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file8.jp2" and "file8.jp2"
 PASS
 Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file9.jp2
@@ -78,7 +78,7 @@ Reading ../../../../../j2kp4files_v1_5/testfiles_jp2/file9.jp2
     SHA-1: 501807547A6F9B8FA61EF7A4FD9AB7B369E7800C
     channel list: R, G, B
     oiio:BitsPerSample: 8
-    oiio:Orientation: 1
     oiio:ColorSpace: "sRGB"
+    oiio:Orientation: 1
 Comparing "../../../../../j2kp4files_v1_5/testfiles_jp2/file9.jp2" and "file9.jp2"
 PASS

--- a/testsuite/maketx/ref/out.txt
+++ b/testsuite/maketx/ref/out.txt
@@ -4,281 +4,281 @@ grid.tx              : 1000 x 1000, 4 channel, uint8 tiff
     SHA-1: 97D6548FF9E9BFD21424B773B1D84FACDF0C1797
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
-    Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
-    ResolutionUnit: "in"
+    compression: "zip"
     DocumentName: "g.tif"
+    fovcot: 1
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    XResolution: 72
+    YResolution: 72
+    oiio:AverageColor: "0.608983,0.608434,0.608728,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "9B24D4CC05313A43973AC384718D81D19183B691"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    PixelAspectRatio: 1
-    oiio:AverageColor: "0.608983,0.608434,0.608728,1"
-    oiio:SHA-1: "9B24D4CC05313A43973AC384718D81D19183B691"
 Reading grid-resize.tx
 grid-resize.tx       : 1024 x 1024, 4 channel, uint8 tiff
     MIP-map levels: 1024x1024 512x512 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 1DAB274639828223059FDBC0E30BD569C07B66C0
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
-    Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
-    ResolutionUnit: "in"
+    compression: "zip"
     DocumentName: "g.tif"
+    fovcot: 1
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    XResolution: 72
+    YResolution: 72
+    oiio:AverageColor: "0.608983,0.608434,0.608728,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "2E23E9B4C6E707427A73B5433B23104D4183724E"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    PixelAspectRatio: 1
-    oiio:AverageColor: "0.608983,0.608434,0.608728,1"
-    oiio:SHA-1: "2E23E9B4C6E707427A73B5433B23104D4183724E"
 Reading checker-uint16.tx
 checker-uint16.tx    :  128 x  128, 4 channel, uint16 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 75BCACCE72A4275AD11FAF4A5D328C624DFF69AB
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 16
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 16
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-1chan.tx
 checker-1chan.tx     :  128 x  128, 1 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: F7DAC8772B7C6BFABDA884D61ABC84844C949AF1
     channel list: Y
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "1D0A2254373A69C054C08672041FC7DE3BAE5179"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5"
-    oiio:SHA-1: "1D0A2254373A69C054C08672041FC7DE3BAE5179"
 Reading checker-16x32tile.tx
 checker-16x32tile.tx :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 16 x 32
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-seplzw.tx
 checker-seplzw.tx    :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "lzw"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "separate"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
-    planarconfig: "separate"
-    tiff:Compression: 5
-    compression: "lzw"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-clamp.tx
 checker-clamp.tx     :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "clamp,clamp"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-permir.tx
 checker-permir.tx    :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "periodic,mirror"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-nomip.tx
 checker-nomip.tx     :  128 x  128, 4 channel, uint8 tiff
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-camera.tx
 checker-camera.tx    :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
-    Orientation: 1 (normal)
-    textureformat: "Plain Texture"
-    wrapmodes: "black,black"
-    fovcot: 1
-    tiff:PhotometricInterpretation: 2
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
     compression: "zip"
+    fovcot: 1
+    Orientation: 1 (normal)
+    planarconfig: "contig"
+    textureformat: "Plain Texture"
     worldtocamera: 1 0 0 0 0 2 0 0 0 0 1 0 0 0 0 1
     worldtoscreen: 3 0 0 0 0 3 0 0 0 0 3 0 1 2 3 1
+    wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
 Reading checker-opaque.tx
 checker-opaque.tx    :  128 x  128, 3 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 6827D9ED3A5674C1FAB56F96E5D7D06796D43144
     channel list: R, G, B
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "2BE3743A64D4309645F94CA7B37D0CD08AF0B38E"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:SHA-1: "2BE3743A64D4309645F94CA7B37D0CD08AF0B38E"
 Reading gray-mono.tx
 gray-mono.tx         :  256 x  256, 1 channel, uint8 tiff
     MIP-map levels: 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: F5C1F9FA963006D501B14542F5E941AEDB4C5907
     channel list: Y
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.25098"
+    oiio:BitsPerSample: 8
+    oiio:ConstantColor: "0.25098"
+    oiio:SHA-1: "24049CDF337F17E162291C7B626E0588A9D71160"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:ConstantColor: "0.25098"
-    oiio:AverageColor: "0.25098"
-    oiio:SHA-1: "24049CDF337F17E162291C7B626E0588A9D71160"
 Reading pink-mono.tx
 pink-mono.tx         :  256 x  256, 3 channel, uint8 tiff
     MIP-map levels: 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: D781FABF7CF958AE9D9429255C8591C77BAA9917
     channel list: R, G, B
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.25098,0.2,0.14902"
+    oiio:BitsPerSample: 8
+    oiio:ConstantColor: "0.25098,0.2,0.14902"
+    oiio:SHA-1: "41B1A0D1C1EBB4CEEBC7BCEE2CAB2AAAB4139724"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:ConstantColor: "0.25098,0.2,0.14902"
-    oiio:AverageColor: "0.25098,0.2,0.14902"
-    oiio:SHA-1: "41B1A0D1C1EBB4CEEBC7BCEE2CAB2AAAB4139724"
 Reading checker-prman.tx
 checker-prman.tx     :  128 x  128, 4 channel, int16 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: DE42A8468161DA333BABF1BEB60811EA0FEF6534
     channel list: R, G, B, A
     tile size: 64 x 32
-    oiio:BitsPerSample: 16
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "separate"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 16
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
-    planarconfig: "separate"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading nan.exr
 nan.exr              :   64 x   64, 3 channel, half openexr
     SHA-1: 47A8E8F3E8B2C3B6B032FCC8C39D3C5FC1AAA390
     channel list: R, G, B
     tile size: 64 x 64
-    oiio:ColorSpace: "Linear"
     compression: "zip"
     fovcot: 1
-    oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
-    openexr:levelmode: 0
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
+    oiio:AverageColor: "0.5,0.5,0.5"
+    oiio:ColorSpace: "Linear"
+    oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
+    openexr:levelmode: 0
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
     Stats Avg: 0.500000 0.500000 0.500000 (float)
@@ -294,30 +294,30 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     SHA-1: FA921281D5C8AF14FC50885DD54E2E17509202EC
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:ColorSpace: "Linear"
-    openexr:roundingmode: 0
-    textureformat: "Plain Texture"
     compression: "zip"
-    Orientation: 1 (normal)
     fovcot: 1
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    Orientation: 1 (normal)
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    textureformat: "Plain Texture"
     wrapmodes: "black,black"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:ColorSpace: "Linear"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    openexr:roundingmode: 0
 Reading small.tif
 small.tif            :   64 x   64, 3 channel, uint8 tiff
     SHA-1: BE1D5EA24E907A4C4B3FB3C28EAC872A20F5B414
     channel list: R, G, B
-    oiio:BitsPerSample: 8
+    compression: "zip"
     ImageDescription: "foo ConstantColor=[0.0,0,-0.0] bar"
     Orientation: 1 (normal)
+    planarconfig: "contig"
+    oiio:BitsPerSample: 8
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
     tiff:RowsPerStrip: 32
 Reading small.tx
 small.tx             :   64 x   64, 3 channel, uint8 tiff
@@ -325,20 +325,20 @@ small.tx             :   64 x   64, 3 channel, uint8 tiff
     SHA-1: BE1D5EA24E907A4C4B3FB3C28EAC872A20F5B414
     channel list: R, G, B
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     ImageDescription: "foo bar "
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "1,0,0"
+    oiio:BitsPerSample: 8
+    oiio:ConstantColor: "1,0,0"
+    oiio:SHA-1: "1DD1CB3C76F9A491B115F85A6DAC1B1A8DD2D3CB"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:ConstantColor: "1,0,0"
-    oiio:AverageColor: "1,0,0"
-    oiio:SHA-1: "1DD1CB3C76F9A491B115F85A6DAC1B1A8DD2D3CB"
 Reading grid.tx
     oiio:SHA-1: "9B24D4CC05313A43973AC384718D81D19183B691"
 Reading grid-lanczos3.tx
@@ -385,14 +385,14 @@ bumpslope.exr        :   64 x   64, 6 channel, half openexr
     SHA-1: 8A309ED5DD4C7ADC8B752735651BAEE9FA326B82
     channel list: b0_h, b1_dhds, b2_dhdt, b3_dhds2, b4_dhdt2, b5_dh2dsdt
     tile size: 64 x 64
-    oiio:ColorSpace: "Linear"
-    openexr:roundingmode: 0
-    textureformat: "Plain Texture"
     compression: "zip"
     fovcot: 1
-    oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
-    oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    textureformat: "Plain Texture"
     wrapmodes: "black,black"
+    oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
+    oiio:ColorSpace: "Linear"
+    oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
+    openexr:roundingmode: 0

--- a/testsuite/misnamed-file/ref/out.txt
+++ b/testsuite/misnamed-file/ref/out.txt
@@ -2,17 +2,17 @@ Reading misnamed.exr
 misnamed.exr         : 1000 x 1000, 4 channel, uint8 tiff
     SHA-1: 97D6548FF9E9BFD21424B773B1D84FACDF0C1797
     channel list: R, G, B, A
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    DocumentName: "g.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.3.6 2009-07-25 Q8 http://www.GraphicsMagick.org/"
-    DocumentName: "g.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
     tiff:RowsPerStrip: 8
-    PixelAspectRatio: 1

--- a/testsuite/oiiotool-attribs/ref/out.txt
+++ b/testsuite/oiiotool-attribs/ref/out.txt
@@ -2,54 +2,54 @@ Reading nomake.jpg
 nomake.jpg           : 2048 x 1536, 3 channel, uint8 jpeg
     SHA-1: 2623446988E34395C6B0A4AA4FC75107C708BF18
     channel list: R, G, B
-    oiio:ColorSpace: "sRGB"
-    jpeg:subsampling: "4:2:0"
     Model: "T-Mobile G1"
     Orientation: 1 (normal)
+    ResolutionUnit: "none"
     XResolution: 72
     YResolution: 72
-    Exif:YCbCrPositioning: 1
+    Exif:ColorSpace: 1
     Exif:ExifVersion: "0230"
     Exif:FlashPixVersion: "0100"
-    Exif:ColorSpace: 1
     Exif:PixelXDimension: 2048
     Exif:PixelYDimension: 1536
     Exif:WhiteBalance: 0 (auto)
-    GPS:VersionID: 2, 2, 0, 0
-    GPS:LatitudeRef: "N"
-    GPS:Latitude: 39, 18, 24.4
-    GPS:LongitudeRef: "W"
-    GPS:Longitude: 120, 20, 6.25
-    GPS:AltitudeRef: 0 (above sea level)
+    Exif:YCbCrPositioning: 1
     GPS:Altitude: 0 (0 m)
-    GPS:TimeStamp: 17, 56, 33
-    GPS:MapDatum: "WGS-84"
+    GPS:AltitudeRef: 0 (above sea level)
     GPS:DateStamp: "1915:08:08"
-    ResolutionUnit: "none"
+    GPS:Latitude: 39, 18, 24.4
+    GPS:LatitudeRef: "N"
+    GPS:Longitude: 120, 20, 6.25
+    GPS:LongitudeRef: "W"
+    GPS:MapDatum: "WGS-84"
+    GPS:TimeStamp: 17, 56, 33
+    GPS:VersionID: 2, 2, 0, 0
+    jpeg:subsampling: "4:2:0"
+    oiio:ColorSpace: "sRGB"
 Reading nogps.jpg
 nogps.jpg            : 2048 x 1536, 3 channel, uint8 jpeg
     SHA-1: 2623446988E34395C6B0A4AA4FC75107C708BF18
     channel list: R, G, B
-    oiio:ColorSpace: "sRGB"
-    jpeg:subsampling: "4:2:0"
     Make: "HTC"
     Model: "T-Mobile G1"
     Orientation: 1 (normal)
+    ResolutionUnit: "none"
     XResolution: 72
     YResolution: 72
-    Exif:YCbCrPositioning: 1
+    Exif:ColorSpace: 1
     Exif:ExifVersion: "0230"
     Exif:FlashPixVersion: "0100"
-    Exif:ColorSpace: 1
     Exif:PixelXDimension: 2048
     Exif:PixelYDimension: 1536
     Exif:WhiteBalance: 0 (auto)
-    ResolutionUnit: "none"
+    Exif:YCbCrPositioning: 1
+    jpeg:subsampling: "4:2:0"
+    oiio:ColorSpace: "sRGB"
 Reading noattribs.jpg
 noattribs.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     SHA-1: 2623446988E34395C6B0A4AA4FC75107C708BF18
     channel list: R, G, B
-    oiio:ColorSpace: "sRGB"
-    jpeg:subsampling: "4:2:0"
     Exif:ExifVersion: "0230"
     Exif:FlashPixVersion: "0100"
+    jpeg:subsampling: "4:2:0"
+    oiio:ColorSpace: "sRGB"

--- a/testsuite/oiiotool-fixnan/ref/out.txt
+++ b/testsuite/oiiotool-fixnan/ref/out.txt
@@ -2,11 +2,11 @@ Reading src/bad.exr
 src/bad.exr          :   64 x   64, 3 channel, half openexr
     SHA-1: BDEA744AE77E178C4F9C3462110F57923AB496CE
     channel list: R, G, B
-    oiio:ColorSpace: "Linear"
     compression: "zip"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
     Stats Avg: 0.500000 0.500000 0.500000 (float)
@@ -20,11 +20,11 @@ Reading black.exr
 black.exr            :   64 x   64, 3 channel, half openexr
     SHA-1: A29F8126A8FB6A57851C1A5B6BE928AE3B2490F7
     channel list: R, G, B
-    oiio:ColorSpace: "Linear"
     compression: "zip"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
     Stats Avg: 0.499756 0.500000 0.500000 (float)
@@ -38,11 +38,11 @@ Reading box3.exr
 box3.exr             :   64 x   64, 3 channel, half openexr
     SHA-1: 47A8E8F3E8B2C3B6B032FCC8C39D3C5FC1AAA390
     channel list: R, G, B
-    oiio:ColorSpace: "Linear"
     compression: "zip"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
     Stats Avg: 0.500000 0.500000 0.500000 (float)

--- a/testsuite/oiiotool-maketx/ref/out-rhel7.txt
+++ b/testsuite/oiiotool-maketx/ref/out-rhel7.txt
@@ -4,281 +4,281 @@ grid.tx              : 1000 x 1000, 4 channel, uint8 tiff
     SHA-1: 97D6548FF9E9BFD21424B773B1D84FACDF0C1797
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
-    Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
-    ResolutionUnit: "in"
+    compression: "zip"
     DocumentName: "g.tif"
+    fovcot: 1
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    XResolution: 72
+    YResolution: 72
+    oiio:AverageColor: "0.608983,0.608434,0.608728,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "9B24D4CC05313A43973AC384718D81D19183B691"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    PixelAspectRatio: 1
-    oiio:AverageColor: "0.608983,0.608434,0.608728,1"
-    oiio:SHA-1: "9B24D4CC05313A43973AC384718D81D19183B691"
 Reading grid-resize.tx
 grid-resize.tx       : 1024 x 1024, 4 channel, uint8 tiff
     MIP-map levels: 1024x1024 512x512 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 1DAB274639828223059FDBC0E30BD569C07B66C0
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
-    Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
-    ResolutionUnit: "in"
+    compression: "zip"
     DocumentName: "g.tif"
+    fovcot: 1
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    XResolution: 72
+    YResolution: 72
+    oiio:AverageColor: "0.608983,0.608434,0.608728,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "2E23E9B4C6E707427A73B5433B23104D4183724E"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    PixelAspectRatio: 1
-    oiio:AverageColor: "0.608983,0.608434,0.608728,1"
-    oiio:SHA-1: "2E23E9B4C6E707427A73B5433B23104D4183724E"
 Reading checker-uint16.tx
 checker-uint16.tx    :  128 x  128, 4 channel, uint16 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 75BCACCE72A4275AD11FAF4A5D328C624DFF69AB
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 16
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 16
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-1chan.tx
 checker-1chan.tx     :  128 x  128, 1 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: F7DAC8772B7C6BFABDA884D61ABC84844C949AF1
     channel list: Y
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "1D0A2254373A69C054C08672041FC7DE3BAE5179"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5"
-    oiio:SHA-1: "1D0A2254373A69C054C08672041FC7DE3BAE5179"
 Reading checker-16x32tile.tx
 checker-16x32tile.tx :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 16 x 32
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-seplzw.tx
 checker-seplzw.tx    :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "lzw"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "separate"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
-    planarconfig: "separate"
-    tiff:Compression: 5
-    compression: "lzw"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-clamp.tx
 checker-clamp.tx     :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "clamp,clamp"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-permir.tx
 checker-permir.tx    :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "periodic,mirror"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-nomip.tx
 checker-nomip.tx     :  128 x  128, 4 channel, uint8 tiff
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-camera.tx
 checker-camera.tx    :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
-    Orientation: 1 (normal)
-    textureformat: "Plain Texture"
-    wrapmodes: "black,black"
-    fovcot: 1
-    tiff:PhotometricInterpretation: 2
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
     compression: "zip"
+    fovcot: 1
+    Orientation: 1 (normal)
+    planarconfig: "contig"
+    textureformat: "Plain Texture"
     worldtocamera: 1 0 0 0 0 2 0 0 0 0 1 0 0 0 0 1
     worldtoscreen: 3 0 0 0 0 3 0 0 0 0 3 0 1 2 3 1
+    wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
 Reading checker-opaque.tx
 checker-opaque.tx    :  128 x  128, 3 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 6827D9ED3A5674C1FAB56F96E5D7D06796D43144
     channel list: R, G, B
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "2BE3743A64D4309645F94CA7B37D0CD08AF0B38E"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:SHA-1: "2BE3743A64D4309645F94CA7B37D0CD08AF0B38E"
 Reading gray-mono.tx
 gray-mono.tx         :  256 x  256, 1 channel, uint8 tiff
     MIP-map levels: 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: F5C1F9FA963006D501B14542F5E941AEDB4C5907
     channel list: Y
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.25098"
+    oiio:BitsPerSample: 8
+    oiio:ConstantColor: "0.25098"
+    oiio:SHA-1: "24049CDF337F17E162291C7B626E0588A9D71160"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:ConstantColor: "0.25098"
-    oiio:AverageColor: "0.25098"
-    oiio:SHA-1: "24049CDF337F17E162291C7B626E0588A9D71160"
 Reading pink-mono.tx
 pink-mono.tx         :  256 x  256, 3 channel, uint8 tiff
     MIP-map levels: 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: D781FABF7CF958AE9D9429255C8591C77BAA9917
     channel list: R, G, B
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.25098,0.2,0.14902"
+    oiio:BitsPerSample: 8
+    oiio:ConstantColor: "0.25098,0.2,0.14902"
+    oiio:SHA-1: "41B1A0D1C1EBB4CEEBC7BCEE2CAB2AAAB4139724"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:ConstantColor: "0.25098,0.2,0.14902"
-    oiio:AverageColor: "0.25098,0.2,0.14902"
-    oiio:SHA-1: "41B1A0D1C1EBB4CEEBC7BCEE2CAB2AAAB4139724"
 Reading checker-prman.tx
 checker-prman.tx     :  128 x  128, 4 channel, int16 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: DE42A8468161DA333BABF1BEB60811EA0FEF6534
     channel list: R, G, B, A
     tile size: 64 x 32
-    oiio:BitsPerSample: 16
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "separate"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 16
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
-    planarconfig: "separate"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading nan.exr
 nan.exr              :   64 x   64, 3 channel, half openexr
     SHA-1: 47A8E8F3E8B2C3B6B032FCC8C39D3C5FC1AAA390
     channel list: R, G, B
     tile size: 64 x 64
-    oiio:ColorSpace: "Linear"
     compression: "zip"
     fovcot: 1
-    oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
-    openexr:levelmode: 0
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
+    oiio:AverageColor: "0.5,0.5,0.5"
+    oiio:ColorSpace: "Linear"
+    oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
+    openexr:levelmode: 0
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
     Stats Avg: 0.500000 0.500000 0.500000 (float)
@@ -294,18 +294,18 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     SHA-1: FA921281D5C8AF14FC50885DD54E2E17509202EC
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:ColorSpace: "Linear"
-    openexr:roundingmode: 0
-    textureformat: "Plain Texture"
     compression: "zip"
-    Orientation: 1 (normal)
     fovcot: 1
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    Orientation: 1 (normal)
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    textureformat: "Plain Texture"
     wrapmodes: "black,black"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:ColorSpace: "Linear"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    openexr:roundingmode: 0
 Reading grid.tx
     oiio:SHA-1: "9B24D4CC05313A43973AC384718D81D19183B691"
 Reading grid-lanczos3.tx
@@ -316,14 +316,14 @@ Reading small.tif
 small.tif            :   64 x   64, 3 channel, uint8 tiff
     SHA-1: BE1D5EA24E907A4C4B3FB3C28EAC872A20F5B414
     channel list: R, G, B
-    oiio:BitsPerSample: 8
+    compression: "zip"
     ImageDescription: "foo ConstantColor=[0.0,0,-0.0] bar"
     Orientation: 1 (normal)
+    planarconfig: "contig"
+    oiio:BitsPerSample: 8
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
     tiff:RowsPerStrip: 32
 Reading small.tx
 small.tx             :   64 x   64, 3 channel, uint8 tiff
@@ -331,20 +331,20 @@ small.tx             :   64 x   64, 3 channel, uint8 tiff
     SHA-1: BE1D5EA24E907A4C4B3FB3C28EAC872A20F5B414
     channel list: R, G, B
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     ImageDescription: "foo bar "
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "1,0,0"
+    oiio:BitsPerSample: 8
+    oiio:ConstantColor: "1,0,0"
+    oiio:SHA-1: "1DD1CB3C76F9A491B115F85A6DAC1B1A8DD2D3CB"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:ConstantColor: "1,0,0"
-    oiio:AverageColor: "1,0,0"
-    oiio:SHA-1: "1DD1CB3C76F9A491B115F85A6DAC1B1A8DD2D3CB"
 whiteenv.exr         :    4 x    2, 3 channel, half openexr (+mipmap)
     MIP 0 of 3 (4 x 2):
       Stats Min: 1.000000 1.000000 1.000000 (float)

--- a/testsuite/oiiotool-maketx/ref/out.txt
+++ b/testsuite/oiiotool-maketx/ref/out.txt
@@ -4,281 +4,281 @@ grid.tx              : 1000 x 1000, 4 channel, uint8 tiff
     SHA-1: 97D6548FF9E9BFD21424B773B1D84FACDF0C1797
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
-    Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
-    ResolutionUnit: "in"
+    compression: "zip"
     DocumentName: "g.tif"
+    fovcot: 1
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    XResolution: 72
+    YResolution: 72
+    oiio:AverageColor: "0.608983,0.608434,0.608728,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "9B24D4CC05313A43973AC384718D81D19183B691"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    PixelAspectRatio: 1
-    oiio:AverageColor: "0.608983,0.608434,0.608728,1"
-    oiio:SHA-1: "9B24D4CC05313A43973AC384718D81D19183B691"
 Reading grid-resize.tx
 grid-resize.tx       : 1024 x 1024, 4 channel, uint8 tiff
     MIP-map levels: 1024x1024 512x512 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 1DAB274639828223059FDBC0E30BD569C07B66C0
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
-    Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
-    ResolutionUnit: "in"
+    compression: "zip"
     DocumentName: "g.tif"
+    fovcot: 1
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    XResolution: 72
+    YResolution: 72
+    oiio:AverageColor: "0.608983,0.608434,0.608728,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "2E23E9B4C6E707427A73B5433B23104D4183724E"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    PixelAspectRatio: 1
-    oiio:AverageColor: "0.608983,0.608434,0.608728,1"
-    oiio:SHA-1: "2E23E9B4C6E707427A73B5433B23104D4183724E"
 Reading checker-uint16.tx
 checker-uint16.tx    :  128 x  128, 4 channel, uint16 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 75BCACCE72A4275AD11FAF4A5D328C624DFF69AB
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 16
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 16
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-1chan.tx
 checker-1chan.tx     :  128 x  128, 1 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: F7DAC8772B7C6BFABDA884D61ABC84844C949AF1
     channel list: Y
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "1D0A2254373A69C054C08672041FC7DE3BAE5179"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5"
-    oiio:SHA-1: "1D0A2254373A69C054C08672041FC7DE3BAE5179"
 Reading checker-16x32tile.tx
 checker-16x32tile.tx :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 16 x 32
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-seplzw.tx
 checker-seplzw.tx    :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "lzw"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "separate"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
-    planarconfig: "separate"
-    tiff:Compression: 5
-    compression: "lzw"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-clamp.tx
 checker-clamp.tx     :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "clamp,clamp"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-permir.tx
 checker-permir.tx    :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "periodic,mirror"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-nomip.tx
 checker-nomip.tx     :  128 x  128, 4 channel, uint8 tiff
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading checker-camera.tx
 checker-camera.tx    :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
-    Orientation: 1 (normal)
-    textureformat: "Plain Texture"
-    wrapmodes: "black,black"
-    fovcot: 1
-    tiff:PhotometricInterpretation: 2
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
     compression: "zip"
+    fovcot: 1
+    Orientation: 1 (normal)
+    planarconfig: "contig"
+    textureformat: "Plain Texture"
     worldtocamera: 1 0 0 0 0 2 0 0 0 0 1 0 0 0 0 1
     worldtoscreen: 3 0 0 0 0 3 0 0 0 0 3 0 1 2 3 1
+    wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
 Reading checker-opaque.tx
 checker-opaque.tx    :  128 x  128, 3 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: 6827D9ED3A5674C1FAB56F96E5D7D06796D43144
     channel list: R, G, B
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "2BE3743A64D4309645F94CA7B37D0CD08AF0B38E"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:SHA-1: "2BE3743A64D4309645F94CA7B37D0CD08AF0B38E"
 Reading gray-mono.tx
 gray-mono.tx         :  256 x  256, 1 channel, uint8 tiff
     MIP-map levels: 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: F5C1F9FA963006D501B14542F5E941AEDB4C5907
     channel list: Y
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.25098"
+    oiio:BitsPerSample: 8
+    oiio:ConstantColor: "0.25098"
+    oiio:SHA-1: "24049CDF337F17E162291C7B626E0588A9D71160"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:ConstantColor: "0.25098"
-    oiio:AverageColor: "0.25098"
-    oiio:SHA-1: "24049CDF337F17E162291C7B626E0588A9D71160"
 Reading pink-mono.tx
 pink-mono.tx         :  256 x  256, 3 channel, uint8 tiff
     MIP-map levels: 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: D781FABF7CF958AE9D9429255C8591C77BAA9917
     channel list: R, G, B
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.25098,0.2,0.14902"
+    oiio:BitsPerSample: 8
+    oiio:ConstantColor: "0.25098,0.2,0.14902"
+    oiio:SHA-1: "41B1A0D1C1EBB4CEEBC7BCEE2CAB2AAAB4139724"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:ConstantColor: "0.25098,0.2,0.14902"
-    oiio:AverageColor: "0.25098,0.2,0.14902"
-    oiio:SHA-1: "41B1A0D1C1EBB4CEEBC7BCEE2CAB2AAAB4139724"
 Reading checker-prman.tx
 checker-prman.tx     :  128 x  128, 4 channel, int16 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
     SHA-1: DE42A8468161DA333BABF1BEB60811EA0FEF6534
     channel list: R, G, B, A
     tile size: 64 x 32
-    oiio:BitsPerSample: 16
+    compression: "zip"
+    fovcot: 1
     Orientation: 1 (normal)
+    planarconfig: "separate"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 16
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
-    planarconfig: "separate"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
 Reading nan.exr
 nan.exr              :   64 x   64, 3 channel, half openexr
     SHA-1: 47A8E8F3E8B2C3B6B032FCC8C39D3C5FC1AAA390
     channel list: R, G, B
     tile size: 64 x 64
-    oiio:ColorSpace: "Linear"
     compression: "zip"
     fovcot: 1
-    oiio:AverageColor: "0.5,0.5,0.5"
-    oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
-    openexr:levelmode: 0
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
+    oiio:AverageColor: "0.5,0.5,0.5"
+    oiio:ColorSpace: "Linear"
+    oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
+    openexr:levelmode: 0
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
     Stats Avg: 0.500000 0.500000 0.500000 (float)
@@ -294,18 +294,18 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     SHA-1: FA921281D5C8AF14FC50885DD54E2E17509202EC
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:ColorSpace: "Linear"
-    openexr:roundingmode: 0
-    textureformat: "Plain Texture"
     compression: "zip"
-    Orientation: 1 (normal)
     fovcot: 1
-    oiio:AverageColor: "0.5,0.5,0.5,1"
-    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    Orientation: 1 (normal)
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    textureformat: "Plain Texture"
     wrapmodes: "black,black"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:ColorSpace: "Linear"
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    openexr:roundingmode: 0
 Reading grid.tx
     oiio:SHA-1: "9B24D4CC05313A43973AC384718D81D19183B691"
 Reading grid-lanczos3.tx
@@ -316,14 +316,14 @@ Reading small.tif
 small.tif            :   64 x   64, 3 channel, uint8 tiff
     SHA-1: BE1D5EA24E907A4C4B3FB3C28EAC872A20F5B414
     channel list: R, G, B
-    oiio:BitsPerSample: 8
+    compression: "zip"
     ImageDescription: "foo ConstantColor=[0.0,0,-0.0] bar"
     Orientation: 1 (normal)
+    planarconfig: "contig"
+    oiio:BitsPerSample: 8
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
     tiff:RowsPerStrip: 32
 Reading small.tx
 small.tx             :   64 x   64, 3 channel, uint8 tiff
@@ -331,20 +331,20 @@ small.tx             :   64 x   64, 3 channel, uint8 tiff
     SHA-1: BE1D5EA24E907A4C4B3FB3C28EAC872A20F5B414
     channel list: R, G, B
     tile size: 64 x 64
-    oiio:BitsPerSample: 8
+    compression: "zip"
+    fovcot: 1
     ImageDescription: "foo bar "
     Orientation: 1 (normal)
+    planarconfig: "contig"
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
-    fovcot: 1
+    oiio:AverageColor: "1,0,0"
+    oiio:BitsPerSample: 8
+    oiio:ConstantColor: "1,0,0"
+    oiio:SHA-1: "1DD1CB3C76F9A491B115F85A6DAC1B1A8DD2D3CB"
+    tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 8
-    compression: "zip"
-    oiio:ConstantColor: "1,0,0"
-    oiio:AverageColor: "1,0,0"
-    oiio:SHA-1: "1DD1CB3C76F9A491B115F85A6DAC1B1A8DD2D3CB"
 whiteenv.exr         :    4 x    2, 3 channel, half openexr (+mipmap)
     MIP 0 of 3 (4 x 2):
       Stats Min: 1.000000 1.000000 1.000000 (float)

--- a/testsuite/oiiotool-spi/ref/out.txt
+++ b/testsuite/oiiotool-spi/ref/out.txt
@@ -3,8 +3,8 @@ iff_vd8.1001.iff     : 1998 x 1080, 4 channel, uint8 iff
     SHA-1: 8DCC7F60EEA962A70ACE8E443BFA73D899123332
     channel list: R, G, B, A
     tile size: 64 x 64
-    compression: "rle"
     Artist: "arturo on duck7105.spimageworks.com, Linux 3.10.0-327.22.2.el7.x86_64 x86_64"
+    compression: "rle"
     DateTime: "Tue Oct 11 09:21:35 2016"
 Comparing "fit_lg10.dpx" and "../../../../../spi-oiio-tests/ref/fit_lg10.dpx"
 PASS

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -10,39 +10,39 @@ chname.exr           :   38 x   38, 5 channel, float openexr
     channel list: Red, G, B, A, Depth
     full/display size: 40 x 40
     full/display origin: 0, 0
-    oiio:ColorSpace: "Linear"
     compression: "zips"
-    Orientation: 1 (normal)
     nuke/node_hash: ""
+    Orientation: 1 (normal)
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Reading allhalf.exr
 allhalf.exr          :   38 x   38, 5 channel, half openexr
     SHA-1: 1C71682E8D8F6DCDC2A7A7B23842DFEEC51438F2
     channel list: R, G, B, A, Z
     full/display size: 40 x 40
     full/display origin: 0, 0
-    oiio:ColorSpace: "Linear"
     compression: "zips"
-    Orientation: 1 (normal)
     nuke/node_hash: ""
+    Orientation: 1 (normal)
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Reading rgbahalf-zfloat.exr
 rgbahalf-zfloat.exr  :   38 x   38, 5 channel, half/half/half/half/float openexr
     SHA-1: 9324AFD44451321A8D87E09F656C7B86E827E5CD
     channel list: R (half), G (half), B (half), A (half), Z (float)
     full/display size: 40 x 40
     full/display origin: 0, 0
-    oiio:ColorSpace: "Linear"
     compression: "zips"
-    Orientation: 1 (normal)
     nuke/node_hash: ""
+    Orientation: 1 (normal)
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 copyA.0001.jpg       :  128 x   96, 3 channel, uint8 jpeg
 copyA.0002.jpg       :  128 x   96, 3 channel, uint8 jpeg
 copyA.0003.jpg       :  128 x   96, 3 channel, uint8 jpeg
@@ -79,11 +79,11 @@ Reading add_rgb_rgba.exr
 add_rgb_rgba.exr     :   64 x   64, 4 channel, float openexr
     SHA-1: 9CCAC57A0A0D45F40EF14337A95207094D008E02
     channel list: R, G, B, A
-    oiio:ColorSpace: "Linear"
     compression: "zip"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Comparing "filled.tif" and "ref/filled.tif"
 PASS
 Comparing "autotrim.tif" and "ref/autotrim.tif"

--- a/testsuite/openexr-chroma/ref/out.txt
+++ b/testsuite/openexr-chroma/ref/out.txt
@@ -3,11 +3,11 @@ Reading ../../../../../openexr-images/LuminanceChroma/Garden.exr
     SHA-1: FDC1BE9592AD4B1FE4EF2FF431783BAC83E619DE
     channel list: Y
     tile size: 128 x 128
-    oiio:ColorSpace: "Linear"
     compression: "piz"
     Copyright: "Copyright 2004 Industrial Light & Magic"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/LuminanceChroma/Garden.exr" and "Garden.exr"
 PASS

--- a/testsuite/openexr-multires/ref/out.txt
+++ b/testsuite/openexr-multires/ref/out.txt
@@ -4,16 +4,16 @@ Reading ../../../../../openexr-images/MultiResolution/Bonita.exr
     SHA-1: 564202D0616E02C51CBAD01C4FC34A3D5D77861C
     channel list: R, G, B
     tile size: 128 x 128
-    oiio:ColorSpace: "Linear"
-    openexr:roundingmode: 0
-    textureformat: "Plain Texture"
     compression: "zip"
-    ImageDescription: "Point Bonita, Marin County, California"
     Copyright: "Copyright 2004 Industrial Light & Magic"
+    ImageDescription: "Point Bonita, Marin County, California"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    textureformat: "Plain Texture"
     wrapmodes: "clamp,clamp"
+    oiio:ColorSpace: "Linear"
+    openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/Bonita.exr" and "Bonita.exr"
 PASS
 Reading ../../../../../openexr-images/MultiResolution/ColorCodedLevels.exr
@@ -22,16 +22,16 @@ Reading ../../../../../openexr-images/MultiResolution/ColorCodedLevels.exr
     SHA-1: 3694F36696BA49FBA37BC7D35E7ACB2DFDDED2EC
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:ColorSpace: "Linear"
-    openexr:roundingmode: 0
-    textureformat: "Plain Texture"
     compression: "pxr24"
-    ImageDescription: "a mip-map image with color-coded levels"
     Copyright: "Copyright 2005 Industrial Light & Magic"
+    ImageDescription: "a mip-map image with color-coded levels"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    textureformat: "Plain Texture"
     wrapmodes: "periodic,periodic"
+    oiio:ColorSpace: "Linear"
+    openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/ColorCodedLevels.exr" and "ColorCodedLevels.exr"
 PASS
 Reading ../../../../../openexr-images/MultiResolution/KernerEnvCube.exr
@@ -42,15 +42,15 @@ Reading ../../../../../openexr-images/MultiResolution/KernerEnvCube.exr
     full/display size: 256 x 256
     full/display origin: 0, 0
     tile size: 64 x 64
-    oiio:ColorSpace: "Linear"
-    openexr:roundingmode: 0
-    textureformat: "CubeFace Environment"
-    oiio:sampleborder: 1
     compression: "zip"
     Copyright: "Copyright 2005 Industrial Light & Magic"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    textureformat: "CubeFace Environment"
+    oiio:ColorSpace: "Linear"
+    oiio:sampleborder: 1
+    openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/KernerEnvCube.exr" and "KernerEnvCube.exr"
 PASS
 Reading ../../../../../openexr-images/MultiResolution/KernerEnvLatLong.exr
@@ -59,16 +59,16 @@ Reading ../../../../../openexr-images/MultiResolution/KernerEnvLatLong.exr
     SHA-1: 10D3B289F5E6E0497AC5C297373BEEEEA4F7EEA4
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:ColorSpace: "Linear"
-    openexr:roundingmode: 0
-    textureformat: "LatLong Environment"
-    oiio:updirection: "y"
-    oiio:sampleborder: 1
     compression: "zip"
     Copyright: "Copyright 2005 Industrial Light & Magic"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    textureformat: "LatLong Environment"
+    oiio:ColorSpace: "Linear"
+    oiio:sampleborder: 1
+    oiio:updirection: "y"
+    openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/KernerEnvLatLong.exr" and "KernerEnvLatLong.exr"
 PASS
 Reading ../../../../../openexr-images/MultiResolution/MirrorPattern.exr
@@ -77,15 +77,15 @@ Reading ../../../../../openexr-images/MultiResolution/MirrorPattern.exr
     SHA-1: 1E48D1639C572C689EE82ACA93EEE9FC9EFB24EB
     channel list: R, G, B
     tile size: 64 x 64
-    oiio:ColorSpace: "Linear"
-    openexr:roundingmode: 0
-    textureformat: "Plain Texture"
     compression: "zip"
     Copyright: "Copyright 2004 Industrial Light & Magic"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    textureformat: "Plain Texture"
     wrapmodes: "mirror,mirror"
+    oiio:ColorSpace: "Linear"
+    openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/MirrorPattern.exr" and "MirrorPattern.exr"
 PASS
 Reading ../../../../../openexr-images/MultiResolution/OrientationCube.exr
@@ -96,15 +96,15 @@ Reading ../../../../../openexr-images/MultiResolution/OrientationCube.exr
     full/display size: 512 x 512
     full/display origin: 0, 0
     tile size: 64 x 64
-    oiio:ColorSpace: "Linear"
-    openexr:roundingmode: 0
-    textureformat: "CubeFace Environment"
-    oiio:sampleborder: 1
     compression: "zip"
     Copyright: "Copyright 2005 Industrial Light & Magic"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    textureformat: "CubeFace Environment"
+    oiio:ColorSpace: "Linear"
+    oiio:sampleborder: 1
+    openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/OrientationCube.exr" and "OrientationCube.exr"
 PASS
 Reading ../../../../../openexr-images/MultiResolution/OrientationLatLong.exr
@@ -113,16 +113,16 @@ Reading ../../../../../openexr-images/MultiResolution/OrientationLatLong.exr
     SHA-1: 91BB1952FB9254759FA0629F40A721C6D461C8FC
     channel list: R, G, B, A
     tile size: 64 x 64
-    oiio:ColorSpace: "Linear"
-    openexr:roundingmode: 0
-    textureformat: "LatLong Environment"
-    oiio:updirection: "y"
-    oiio:sampleborder: 1
     compression: "zip"
     Copyright: "Copyright 2005 Industrial Light & Magic"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    textureformat: "LatLong Environment"
+    oiio:ColorSpace: "Linear"
+    oiio:sampleborder: 1
+    oiio:updirection: "y"
+    openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/OrientationLatLong.exr" and "OrientationLatLong.exr"
 PASS
 Reading ../../../../../openexr-images/MultiResolution/PeriodicPattern.exr
@@ -131,15 +131,15 @@ Reading ../../../../../openexr-images/MultiResolution/PeriodicPattern.exr
     SHA-1: B83B67E1FF9B24991A6582C997AA9F629C094ED2
     channel list: R, G, B
     tile size: 64 x 64
-    oiio:ColorSpace: "Linear"
-    openexr:roundingmode: 0
-    textureformat: "Plain Texture"
     compression: "zip"
     Copyright: "Copyright 2004 Industrial Light & Magic"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    textureformat: "Plain Texture"
     wrapmodes: "periodic,periodic"
+    oiio:ColorSpace: "Linear"
+    openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/PeriodicPattern.exr" and "PeriodicPattern.exr"
 PASS
 Reading ../../../../../openexr-images/MultiResolution/StageEnvCube.exr
@@ -150,15 +150,15 @@ Reading ../../../../../openexr-images/MultiResolution/StageEnvCube.exr
     full/display size: 256 x 256
     full/display origin: 0, 0
     tile size: 64 x 64
-    oiio:ColorSpace: "Linear"
-    openexr:roundingmode: 0
-    textureformat: "CubeFace Environment"
-    oiio:sampleborder: 1
     compression: "zip"
     Copyright: "Copyright 2004 Industrial Light & Magic"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    textureformat: "CubeFace Environment"
+    oiio:ColorSpace: "Linear"
+    oiio:sampleborder: 1
+    openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/StageEnvCube.exr" and "StageEnvCube.exr"
 PASS
 Reading ../../../../../openexr-images/MultiResolution/StageEnvLatLong.exr
@@ -167,16 +167,16 @@ Reading ../../../../../openexr-images/MultiResolution/StageEnvLatLong.exr
     SHA-1: 573137DBE0076465729FC3DBE2B586A19330515D
     channel list: R, G, B
     tile size: 64 x 64
-    oiio:ColorSpace: "Linear"
-    openexr:roundingmode: 1
-    textureformat: "LatLong Environment"
-    oiio:updirection: "y"
-    oiio:sampleborder: 1
     compression: "zip"
     Copyright: "Copyright 2004 Industrial Light & Magic"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    textureformat: "LatLong Environment"
+    oiio:ColorSpace: "Linear"
+    oiio:sampleborder: 1
+    oiio:updirection: "y"
+    openexr:roundingmode: 1
 Comparing "../../../../../openexr-images/MultiResolution/StageEnvLatLong.exr" and "StageEnvLatLong.exr"
 PASS
 Reading ../../../../../openexr-images/MultiResolution/WavyLinesCube.exr
@@ -187,15 +187,15 @@ Reading ../../../../../openexr-images/MultiResolution/WavyLinesCube.exr
     full/display size: 256 x 256
     full/display origin: 0, 0
     tile size: 64 x 64
-    oiio:ColorSpace: "Linear"
-    openexr:roundingmode: 0
-    textureformat: "CubeFace Environment"
-    oiio:sampleborder: 1
     compression: "zip"
     Copyright: "Copyright 2005 Industrial Light & Magic"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    textureformat: "CubeFace Environment"
+    oiio:ColorSpace: "Linear"
+    oiio:sampleborder: 1
+    openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/WavyLinesCube.exr" and "WavyLinesCube.exr"
 PASS
 Reading ../../../../../openexr-images/MultiResolution/WavyLinesLatLong.exr
@@ -204,27 +204,27 @@ Reading ../../../../../openexr-images/MultiResolution/WavyLinesLatLong.exr
     SHA-1: D7CB49482CFB4D2854089E7FF92690F69337DED0
     channel list: R, G, B
     tile size: 64 x 64
-    oiio:ColorSpace: "Linear"
-    openexr:roundingmode: 0
-    textureformat: "LatLong Environment"
-    oiio:updirection: "y"
-    oiio:sampleborder: 1
     compression: "zip"
     Copyright: "Copyright 2005 Industrial Light & Magic"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    textureformat: "LatLong Environment"
+    oiio:ColorSpace: "Linear"
+    oiio:sampleborder: 1
+    oiio:updirection: "y"
+    openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/WavyLinesLatLong.exr" and "WavyLinesLatLong.exr"
 PASS
 Reading ../../../../../openexr-images/MultiResolution/WavyLinesSphere.exr
 ../../../../../openexr-images/MultiResolution/WavyLinesSphere.exr :  480 x  480, 4 channel, half openexr
     SHA-1: E802DC23DA0EEF8EE782CC5D7BA56294C0FA7462
     channel list: R, G, B, A
-    oiio:ColorSpace: "Linear"
     compression: "piz"
     Copyright: "Copyright 2005 Industrial Light & Magic"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/MultiResolution/WavyLinesSphere.exr" and "WavyLinesSphere.exr"
 PASS

--- a/testsuite/openexr-suite/ref/out.txt
+++ b/testsuite/openexr-suite/ref/out.txt
@@ -2,72 +2,72 @@ Reading ../../../../../openexr-images/ScanLines/Desk.exr
 ../../../../../openexr-images/ScanLines/Desk.exr :  644 x  874, 4 channel, half openexr
     SHA-1: CBFEA416A3CA23DF2B1599A0495EECE6FB009E5D
     channel list: R, G, B, A
-    oiio:ColorSpace: "Linear"
     compression: "piz"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/ScanLines/Desk.exr" and "Desk.exr"
 PASS
 Reading ../../../../../openexr-images/ScanLines/MtTamWest.exr
 ../../../../../openexr-images/ScanLines/MtTamWest.exr : 1214 x  732, 4 channel, half openexr
     SHA-1: 0C7FC9D17BCF20EE043335F7D2DCFA2F19B3BA09
     channel list: R, G, B, A
-    oiio:ColorSpace: "Linear"
-    compression: "piz"
     altitude: 716
+    compression: "piz"
+    Copyright: "Copyright 2002 Industrial Light & Magic"
     DateTime: "2002:06:23 16:00:00"
     ImageDescription: "View from Mount Tamalpais, Marin County, California, U.S.A."
     latitude: 37.929
     longitude: -122.579
-    Copyright: "Copyright 2002 Industrial Light & Magic"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
     utcOffset: 25200
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/ScanLines/MtTamWest.exr" and "MtTamWest.exr"
 PASS
 Reading ../../../../../openexr-images/ScanLines/Cannon.exr
 ../../../../../openexr-images/ScanLines/Cannon.exr :  780 x  566, 3 channel, half openexr
     SHA-1: 8855671D158731258798358D78E90B2A62CF206D
     channel list: R, G, B
-    oiio:ColorSpace: "Linear"
     compression: "b44"
     Copyright: "Copyright 2006 Industrial Light & Magic"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/ScanLines/Cannon.exr" and "Cannon.exr"
 PASS
 Reading ../../../../../openexr-images/ScanLines/StillLife.exr
 ../../../../../openexr-images/ScanLines/StillLife.exr : 1240 x  846, 4 channel, half openexr
     SHA-1: F794B0D381CA2FDCE32BCAEC3734B2AB49579401
     channel list: R, G, B, A
-    oiio:ColorSpace: "Linear"
     compression: "piz"
-    DateTime: "2002:06:23 21:30:10"
     Copyright: "Copyright 2002 Industrial Light & Magic"
+    DateTime: "2002:06:23 21:30:10"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 0.45
     utcOffset: 25200
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/ScanLines/StillLife.exr" and "StillLife.exr"
 PASS
 Reading ../../../../../openexr-images/ScanLines/Tree.exr
 ../../../../../openexr-images/ScanLines/Tree.exr :  928 x  906, 4 channel, half openexr
     SHA-1: 75D2AAD6D04D8B8F520D391926767BC4A00E6A0F
     channel list: R, G, B, A
-    oiio:ColorSpace: "Linear"
-    compression: "piz"
-    DateTime: "2002:06:23 15:00:00"
     chromaticities: 0.62955, 0.341, 0.2867, 0.6108, 0.1489, 0.07125, 0.3155, 0.33165
-    focus: 3.5
+    compression: "piz"
     Copyright: "Copyright 2002 Industrial Light & Magic"
+    DateTime: "2002:06:23 15:00:00"
+    focus: 3.5
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 0.48
     utcOffset: 25200
     whiteLuminance: 621
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/ScanLines/Tree.exr" and "Tree.exr"
 PASS
 Reading ../../../../../openexr-images/ScanLines/Blobbies.exr
@@ -77,127 +77,127 @@ Reading ../../../../../openexr-images/ScanLines/Blobbies.exr
     pixel data origin: x=-20, y=-20
     full/display size: 1000 x 1000
     full/display origin: 0, 0
-    oiio:ColorSpace: "Linear"
-    compression: "zip"
-    DateTime: "2004:01:19 12:55:33"
     chromaticities: 0.62955, 0.341, 0.2867, 0.6108, 0.1489, 0.07125, 0.3155, 0.33165
+    compression: "zip"
     Copyright: "Copyright 2004 Industrial Light & Magic"
+    DateTime: "2004:01:19 12:55:33"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
     utcOffset: 28800
     whiteLuminance: 50
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/ScanLines/Blobbies.exr" and "Blobbies.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/AllHalfValues.exr
 ../../../../../openexr-images/TestImages/AllHalfValues.exr :  256 x  256, 3 channel, half openexr
     SHA-1: 4428F325F403515E6B3BF8E290FB7EDBF959ECF7
     channel list: R, G, B
-    oiio:ColorSpace: "Linear"
     compression: "piz"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/AllHalfValues.exr" and "AllHalfValues.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/BrightRings.exr
 ../../../../../openexr-images/TestImages/BrightRings.exr :  800 x  800, 3 channel, half openexr
     SHA-1: F6528D07E75DA1CE490DA6A93EB68573070FFB4B
     channel list: R, G, B
-    oiio:ColorSpace: "Linear"
     compression: "zip"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/BrightRings.exr" and "BrightRings.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/BrightRingsNanInf.exr
 ../../../../../openexr-images/TestImages/BrightRingsNanInf.exr :  800 x  800, 3 channel, half openexr
     SHA-1: 73F0C53CFCE17B37DD873CF5FE4C9DF0DDB4D3DD
     channel list: R, G, B
-    oiio:ColorSpace: "Linear"
     compression: "zip"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/BrightRingsNanInf.exr" and "BrightRingsNanInf.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/GammaChart.exr
 ../../../../../openexr-images/TestImages/GammaChart.exr :  800 x  800, 3 channel, half openexr
     SHA-1: D21C1DC58FEC725E62D5A9F1503965CBD1A9BFD4
     channel list: R, G, B
-    oiio:ColorSpace: "Linear"
     compression: "pxr24"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/GammaChart.exr" and "GammaChart.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/GrayRampsDiagonal.exr
 ../../../../../openexr-images/TestImages/GrayRampsDiagonal.exr :  800 x  800, 1 channel, half openexr
     SHA-1: 4CC9922AFAD6CA706D66E466BEA9E93D9E813B39
     channel list: Y
-    oiio:ColorSpace: "Linear"
     compression: "pxr24"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/GrayRampsDiagonal.exr" and "GrayRampsDiagonal.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/GrayRampsHorizontal.exr
 ../../../../../openexr-images/TestImages/GrayRampsHorizontal.exr :  800 x  800, 1 channel, half openexr
     SHA-1: 1F0A6393B53BCA1AF072EA8B7795AE19FE2C8883
     channel list: Y
-    oiio:ColorSpace: "Linear"
     compression: "pxr24"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/GrayRampsHorizontal.exr" and "GrayRampsHorizontal.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/RgbRampsDiagonal.exr
 ../../../../../openexr-images/TestImages/RgbRampsDiagonal.exr :  800 x  800, 3 channel, half openexr
     SHA-1: 8C973B65215B6C1BC0D29376F1C49D6A9A6CFA19
     channel list: R, G, B
-    oiio:ColorSpace: "Linear"
     compression: "pxr24"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/RgbRampsDiagonal.exr" and "RgbRampsDiagonal.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/SquaresSwirls.exr
 ../../../../../openexr-images/TestImages/SquaresSwirls.exr : 1000 x 1000, 3 channel, half openexr
     SHA-1: C0A591BDED4A83540BBEFC9FD0549FEEE499EB3A
     channel list: R, G, B
-    oiio:ColorSpace: "Linear"
     compression: "pxr24"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/SquaresSwirls.exr" and "SquaresSwirls.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/WideColorGamut.exr
 ../../../../../openexr-images/TestImages/WideColorGamut.exr :  800 x  800, 3 channel, half openexr
     SHA-1: B49406C6AA10E1E3CCA7AAF3BF68FDD3E5790643
     channel list: R, G, B
-    oiio:ColorSpace: "Linear"
-    compression: "zip"
     chromaticities: 0.64, 0.33, 0.3, 0.6, 0.15, 0.06, 0.3127, 0.329
+    compression: "zip"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/WideColorGamut.exr" and "WideColorGamut.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/WideFloatRange.exr
 ../../../../../openexr-images/TestImages/WideFloatRange.exr :  500 x  500, 1 channel, float openexr
     SHA-1: 9009BE7DD8CC438F258A48243056E6D46E6147EB
     channel list: G
-    oiio:ColorSpace: "Linear"
     compression: "pxr24"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/WideFloatRange.exr" and "WideFloatRange.exr"
 PASS
 Reading ../../../../../openexr-images/Tiles/GoldenGate.exr
@@ -205,22 +205,22 @@ Reading ../../../../../openexr-images/Tiles/GoldenGate.exr
     SHA-1: 828CD8188CC4A237C8025BA6634D1682A7F8C9BB
     channel list: R, G, B
     tile size: 128 x 128
-    oiio:ColorSpace: "Linear"
-    compression: "piz"
     altitude: 274.5
-    FNumber: 2.8
+    compression: "piz"
+    Copyright: "Copyright 2004 Industrial Light & Magic"
     DateTime: "2004:01:04 18:10:00"
-    ImageDescription: "View from Hawk Hill towards San Francisco"
     ExposureTime: 8
+    FNumber: 2.8
     focus: inf
+    ImageDescription: "View from Hawk Hill towards San Francisco"
     isoSpeed: 50
     latitude: 37.8277
     longitude: -122.5
-    Copyright: "Copyright 2004 Industrial Light & Magic"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1.15
     utcOffset: 28800
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/Tiles/GoldenGate.exr" and "GoldenGate.exr"
 PASS
 Reading ../../../../../openexr-images/Tiles/Ocean.exr
@@ -228,13 +228,13 @@ Reading ../../../../../openexr-images/Tiles/Ocean.exr
     SHA-1: 32BF0712FEABFFB448898D91F97E5C38BD351FD7
     channel list: R, G, B
     tile size: 128 x 128
-    oiio:ColorSpace: "Linear"
     compression: "zip"
-    focus: inf
     Copyright: "Copyright 2004 Industrial Light & Magic"
+    focus: inf
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/Tiles/Ocean.exr" and "Ocean.exr"
 PASS
 Reading ../../../../../openexr-images/Tiles/Spirals.exr
@@ -245,15 +245,15 @@ Reading ../../../../../openexr-images/Tiles/Spirals.exr
     full/display size: 1000 x 1000
     full/display origin: 0, 0
     tile size: 287 x 126
-    oiio:ColorSpace: "Linear"
-    compression: "pxr24"
-    DateTime: "2004:01:19 10:25:14"
     chromaticities: 0.62955, 0.341, 0.2867, 0.6108, 0.1489, 0.07125, 0.3155, 0.33165
+    compression: "pxr24"
     Copyright: "Copyright 2004 Industrial Light & Magic"
+    DateTime: "2004:01:19 10:25:14"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
     utcOffset: 28800
     whiteLuminance: 90
+    oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/Tiles/Spirals.exr" and "Spirals.exr"
 PASS

--- a/testsuite/openexr-v2/ref/out.txt
+++ b/testsuite/openexr-v2/ref/out.txt
@@ -7,65 +7,65 @@ Reading ../../../../../openexr-images/v2/Stereo/composited.exr
     pixel data origin: x=1, y=1
     full/display size: 1920 x 1080
     full/display origin: 0, 0
-    oiio:ColorSpace: "Linear"
     compression: "zips"
-    openexr:chunkCount: 1078
+    Copyright: "Copyright 2012 Weta Digital Ltd"
     name: "rgba.left"
     nuke/node_hash: "b4ea9f917764b762"
-    Copyright: "Copyright 2012 Weta Digital Ltd"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
     view: "left"
+    oiio:ColorSpace: "Linear"
     oiio:subimagename: "rgba.left"
+    openexr:chunkCount: 1078
  subimage  1: 1918 x 1078, 1 channel, half openexr
     SHA-1: 5FAE17E1E8BDB2E7C3A6B3EBCA8E0CA15A07B80A
     channel list: Z
     pixel data origin: x=1, y=1
     full/display size: 1920 x 1080
     full/display origin: 0, 0
-    oiio:ColorSpace: "Linear"
     compression: "zips"
-    openexr:chunkCount: 1078
-    name: "depth.left"
     Copyright: "Copyright 2012 Weta Digital Ltd"
+    name: "depth.left"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
     view: "left"
+    oiio:ColorSpace: "Linear"
     oiio:subimagename: "depth.left"
+    openexr:chunkCount: 1078
  subimage  2: 1918 x 1078, 4 channel, half openexr
     SHA-1: 3CC2362892007C6AACABE356DF93F87408C988B3
     channel list: R, G, B, A
     pixel data origin: x=1, y=1
     full/display size: 1920 x 1080
     full/display origin: 0, 0
-    oiio:ColorSpace: "Linear"
     compression: "zips"
-    openexr:chunkCount: 1078
-    name: "rgba.right"
     Copyright: "Copyright 2012 Weta Digital Ltd"
+    name: "rgba.right"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
     view: "right"
+    oiio:ColorSpace: "Linear"
     oiio:subimagename: "rgba.right"
+    openexr:chunkCount: 1078
  subimage  3: 1918 x 1078, 1 channel, half openexr
     SHA-1: FBB31FC1CD9EC4759703F033C8D0E14E5806AE92
     channel list: Z
     pixel data origin: x=1, y=1
     full/display size: 1920 x 1080
     full/display origin: 0, 0
-    oiio:ColorSpace: "Linear"
     compression: "zips"
-    openexr:chunkCount: 1078
-    name: "depth.right"
     Copyright: "Copyright 2012 Weta Digital Ltd"
+    name: "depth.right"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
     view: "right"
+    oiio:ColorSpace: "Linear"
     oiio:subimagename: "depth.right"
+    openexr:chunkCount: 1078
 ../../../../../openexr-images/v2/Stereo/composited.exr : 1918 x 1078, 4 channel, half openexr (4 subimages)
     Stats Min: 0.000000 0.000000 0.000000 0.000000 (float)
     Stats Max: 0.600586 0.593262 0.344971 1.000000 (float)
@@ -87,34 +87,34 @@ Reading ../../../../../openexr-images/v2/Stereo/Balls.exr
     pixel data origin: x=247, y=319
     full/display size: 1920 x 1080
     full/display origin: 0, 0
-    oiio:ColorSpace: "Linear"
     compression: "zips"
-    openexr:chunkCount: 761
-    name: "rgba.left"
     Copyright: "Copyright 2012 Weta Digital Ltd"
+    name: "rgba.left"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
-    openexr:version: 1
     view: "left"
+    oiio:ColorSpace: "Linear"
     oiio:subimagename: "rgba.left"
+    openexr:chunkCount: 761
+    openexr:version: 1
  subimage  1: 1452 x  761, 5 channel, deep half/half/half/half/float openexr
     SHA-1: 23D591E3BE032257729B30F078D62F6A16D40377
     channel list: R (half), G (half), B (half), A (half), Z (float)
     pixel data origin: x=389, y=319
     full/display size: 1920 x 1080
     full/display origin: 0, 0
-    oiio:ColorSpace: "Linear"
     compression: "zips"
-    openexr:chunkCount: 761
-    name: "rgba.right"
     Copyright: "Copyright 2012 Weta Digital Ltd"
+    name: "rgba.right"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
-    openexr:version: 1
     view: "right"
+    oiio:ColorSpace: "Linear"
     oiio:subimagename: "rgba.right"
+    openexr:chunkCount: 761
+    openexr:version: 1
 ../../../../../openexr-images/v2/Stereo/Balls.exr : 1431 x  761, 5 channel, deep half/half/half/half/float openexr (2 subimages)
     Stats Min: 0.000169 0.000083 0.000092 0.015625 127.872681 (float)
     Stats Max: 0.622070 0.265625 0.267822 1.000000 738.560669 (float)
@@ -144,31 +144,31 @@ Reading ../../../../../openexr-images/v2/Stereo/Leaves.exr
  subimage  0: 1920 x 1080, 5 channel, deep half/half/half/half/float openexr
     SHA-1: 63932A1F4D607129054D80A4361176BA54955E90
     channel list: R (half), G (half), B (half), A (half), Z (float)
-    oiio:ColorSpace: "Linear"
     compression: "zips"
-    openexr:chunkCount: 1080
-    name: "rgba.left"
     Copyright: "Copyright 2012 Weta Digital Ltd"
+    name: "rgba.left"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
-    openexr:version: 1
     view: "left"
+    oiio:ColorSpace: "Linear"
     oiio:subimagename: "rgba.left"
+    openexr:chunkCount: 1080
+    openexr:version: 1
  subimage  1: 1920 x 1080, 5 channel, deep half/half/half/half/float openexr
     SHA-1: B0B52A15E0E25796832E4C25BD835C3F3B970BC0
     channel list: R (half), G (half), B (half), A (half), Z (float)
-    oiio:ColorSpace: "Linear"
     compression: "zips"
-    openexr:chunkCount: 1080
-    name: "rgba.right"
     Copyright: "Copyright 2012 Weta Digital Ltd"
+    name: "rgba.right"
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
-    openexr:version: 1
     view: "right"
+    oiio:ColorSpace: "Linear"
     oiio:subimagename: "rgba.right"
+    openexr:chunkCount: 1080
+    openexr:version: 1
 ../../../../../openexr-images/v2/Stereo/Leaves.exr : 1920 x 1080, 5 channel, deep half/half/half/half/float openexr (2 subimages)
     Stats Min: 0.000099 0.000341 0.000152 0.015625 72.493698 (float)
     Stats Max: 0.403564 0.593262 0.345215 1.000000 954.392700 (float)

--- a/testsuite/png/ref/out.txt
+++ b/testsuite/png/ref/out.txt
@@ -2,23 +2,23 @@ Reading ../../../../../oiio-images/oiio-logo-no-alpha.png
 ../../../../../oiio-images/oiio-logo-no-alpha.png :  135 x  135, 4 channel, uint8 png
     SHA-1: 75ED9B183E083ECF0A4881EEE0B553457B698CF4
     channel list: R, G, B, A
-    oiio:ColorSpace: "sRGB"
-    DateTime: "2009:03:26 17:19:47"
     Comment: "Created with GIMP"
+    DateTime: "2009:03:26 17:19:47"
     ResolutionUnit: "inch"
     XResolution: 72.009
     YResolution: 72.009
+    oiio:ColorSpace: "sRGB"
 Comparing "../../../../../oiio-images/oiio-logo-no-alpha.png" and "oiio-logo-no-alpha.png"
 PASS
 Reading ../../../../../oiio-images/oiio-logo-with-alpha.png
 ../../../../../oiio-images/oiio-logo-with-alpha.png :  135 x  135, 4 channel, uint8 png
     SHA-1: 8AED04DCCE8F83B068C537DC0982A42EFBE431B6
     channel list: R, G, B, A
-    oiio:ColorSpace: "sRGB"
-    DateTime: "2009:03:26 18:44:26"
     Comment: "Created with GIMP"
+    DateTime: "2009:03:26 18:44:26"
     ResolutionUnit: "inch"
     XResolution: 72.009
     YResolution: 72.009
+    oiio:ColorSpace: "sRGB"
 Comparing "../../../../../oiio-images/oiio-logo-with-alpha.png" and "oiio-logo-with-alpha.png"
 PASS

--- a/testsuite/psd/ref/out-alt.txt
+++ b/testsuite/psd/ref/out-alt.txt
@@ -4,847 +4,847 @@ Reading ../../../../../oiio-images/psd_123.psd
  subimage  0:  257 x  126, 4 channel, uint8 psd
     SHA-1: F7A1BCAC9115D886FC6D6C23639529955D74DD58
     channel list: R, G, B, A
+    DateTime: "2011-08-22T22:14:43-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
+    thumbnail_height: 78
+    thumbnail_image: 249, 255, 255, 249, 255, 255, 252, 255, 255, 252, 255, 255, 255, 254, 255, 255, ... [37440 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    thumbnail_width: 160
-    thumbnail_height: 78
-    thumbnail_nchannels: 3
-    thumbnail_image: 249, 255, 255, 249, 255, 255, 252, 255, 255, 252, 255, 255, 255, 254, 255, 255, ... [37440 x uint8]
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:14:43-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
-    rdf:parseType: "Resource"
-    photoshop:LayerName: "3"
-    photoshop:LayerText: "3"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: "3"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    photoshop:LayerName: "3"
+    photoshop:LayerText: "3"
+    rdf:parseType: "Resource"
     stEvt:action: "created"
     stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
-    stEvt:when: "2011-08-22T22:14:43-04:00"
     stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
-    PixelAspectRatio: 1
+    stEvt:when: "2011-08-22T22:14:43-04:00"
  subimage  1:   33 x   98, 4 channel, uint8 psd
     SHA-1: CDA136B1B34A86AEBDCB88283F0D2323F921C00C
     channel list: R, G, B, A
+    DateTime: "2011-08-22T22:14:43-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:14:43-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
-    rdf:parseType: "Resource"
-    photoshop:LayerName: "3"
-    photoshop:LayerText: "3"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: "3"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    photoshop:LayerName: "3"
+    photoshop:LayerText: "3"
+    rdf:parseType: "Resource"
     stEvt:action: "created"
     stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
-    stEvt:when: "2011-08-22T22:14:43-04:00"
     stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
-    PixelAspectRatio: 1
+    stEvt:when: "2011-08-22T22:14:43-04:00"
  subimage  2:   63 x  100, 4 channel, uint8 psd
     SHA-1: E0B9D4A8BE16B52126EC5BC1E829D099EF4C5DC4
     channel list: R, G, B, A
+    DateTime: "2011-08-22T22:14:43-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:14:43-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
-    rdf:parseType: "Resource"
-    photoshop:LayerName: "3"
-    photoshop:LayerText: "3"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: "3"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    photoshop:LayerName: "3"
+    photoshop:LayerText: "3"
+    rdf:parseType: "Resource"
     stEvt:action: "created"
     stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
-    stEvt:when: "2011-08-22T22:14:43-04:00"
     stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
-    PixelAspectRatio: 1
+    stEvt:when: "2011-08-22T22:14:43-04:00"
  subimage  3:   61 x  102, 4 channel, uint8 psd
     SHA-1: 11FDE5499A2150FD5C779C9012649E839750C1D8
     channel list: R, G, B, A
+    DateTime: "2011-08-22T22:14:43-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:14:43-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
-    rdf:parseType: "Resource"
-    photoshop:LayerName: "3"
-    photoshop:LayerText: "3"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: "3"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    photoshop:LayerName: "3"
+    photoshop:LayerText: "3"
+    rdf:parseType: "Resource"
     stEvt:action: "created"
     stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
-    stEvt:when: "2011-08-22T22:14:43-04:00"
     stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
-    PixelAspectRatio: 1
+    stEvt:when: "2011-08-22T22:14:43-04:00"
 Reading ../../../../../oiio-images/psd_123_nomaxcompat.psd
 ../../../../../oiio-images/psd_123_nomaxcompat.psd :  257 x  126, 3 channel, uint8 psd
     4 subimages: 257x126 [u8,u8,u8], 33x98 [u8,u8,u8,u8], 63x100 [u8,u8,u8,u8], 61x102 [u8,u8,u8,u8]
  subimage  0:  257 x  126, 3 channel, uint8 psd
     SHA-1: 5A7BDC7A11A9E4BDCBEC968375EE466DE74D0481
     channel list: R, G, B
+    DateTime: "2011-08-22T22:14:43-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
+    thumbnail_height: 78
+    thumbnail_image: 249, 255, 255, 249, 255, 255, 252, 255, 255, 252, 255, 255, 255, 254, 255, 255, ... [37440 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    thumbnail_width: 160
-    thumbnail_height: 78
-    thumbnail_nchannels: 3
-    thumbnail_image: 249, 255, 255, 249, 255, 255, 252, 255, 255, 252, 255, 255, 255, 254, 255, 255, ... [37440 x uint8]
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:14:43-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
     IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: "3"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    rdf:parseType: "Resource"
     photoshop:LayerName: "3"
     photoshop:LayerText: "3"
-    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
-    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
-    stEvt:when: "2011-08-29T12:10:28-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-29T12:10:28-04:00"
  subimage  1:   33 x   98, 4 channel, uint8 psd
     SHA-1: CDA136B1B34A86AEBDCB88283F0D2323F921C00C
     channel list: R, G, B, A
+    DateTime: "2011-08-22T22:14:43-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:14:43-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
     IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: "3"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    rdf:parseType: "Resource"
     photoshop:LayerName: "3"
     photoshop:LayerText: "3"
-    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
-    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
-    stEvt:when: "2011-08-29T12:10:28-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-29T12:10:28-04:00"
  subimage  2:   63 x  100, 4 channel, uint8 psd
     SHA-1: E0B9D4A8BE16B52126EC5BC1E829D099EF4C5DC4
     channel list: R, G, B, A
+    DateTime: "2011-08-22T22:14:43-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:14:43-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
     IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: "3"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    rdf:parseType: "Resource"
     photoshop:LayerName: "3"
     photoshop:LayerText: "3"
-    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
-    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
-    stEvt:when: "2011-08-29T12:10:28-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-29T12:10:28-04:00"
  subimage  3:   61 x  102, 4 channel, uint8 psd
     SHA-1: 11FDE5499A2150FD5C779C9012649E839750C1D8
     channel list: R, G, B, A
+    DateTime: "2011-08-22T22:14:43-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:14:43-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
     IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: "3"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    rdf:parseType: "Resource"
     photoshop:LayerName: "3"
     photoshop:LayerText: "3"
-    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
-    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
-    stEvt:when: "2011-08-29T12:10:28-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-29T12:10:28-04:00"
 Reading ../../../../../oiio-images/psd_bitmap.psd
 ../../../../../oiio-images/psd_bitmap.psd :  320 x  240, 3 channel, uint8 psd
     SHA-1: F23185BC048E31BAC6BB4B319E5E5AC570CC7B89
     channel list: R, G, B
-    XResolution: 180
-    YResolution: 180
-    ResolutionUnit: 2 (inches)
-    thumbnail_width: 160
-    thumbnail_height: 120
-    thumbnail_nchannels: 3
-    thumbnail_image: 90, 90, 90, 255, 255, 255, 255, 255, 255, 251, 251, 251, 250, 250, 250, 255, ... [57600 x uint8]
+    Artist: "Daniel Wyatt"
+    DateTime: "2007-01-18T15:49:21"
+    ExposureTime: 0.0166667
+    FNumber: 3.5
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
     Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2007-01-18T15:49:21"
-    Artist: "Daniel Wyatt"
-    Exif:YCbCrPositioning: 1
-    ExposureTime: 0.0166667
-    FNumber: 3.5
-    Exif:PhotographicSensitivity: 75
-    Exif:ExifVersion: "0220"
-    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
-    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
-    Exif:CompressedBitsPerPixel: 5
-    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    thumbnail_height: 120
+    thumbnail_image: 90, 90, 90, 255, 255, 255, 255, 255, 255, 251, 251, 251, 250, 250, 250, 255, ... [57600 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 180
+    YResolution: 180
+    aux:ApproximateFocusDistance: "339/100"
+    aux:Firmware: "1.00"
+    aux:FlashCompensation: "0/1"
+    aux:Lens: "7.3-29.2 mm"
+    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
+    aux:OwnerName: "Daniel Wyatt"
     Exif:ApertureValue: 3.625 (f/3.5)
-    Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.8)
-    Exif:SubjectDistance: 3.39 (3.39 m)
-    Exif:MeteringMode: 5 (pattern)
-    Exif:Flash: 16 (no flash, flash supression)
-    Exif:FocalLength: 7.3 (7.3 mm)
-    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 65535
-    Exif:PixelXDimension: 320
-    Exif:PixelYDimension: 240
+    Exif:CompressedBitsPerPixel: 5
+    Exif:CustomRendered: 0 (no)
+    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
+    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
+    Exif:DigitalZoomRatio: 1
+    Exif:ExifVersion: "0220"
+    Exif:ExposureBiasValue: 0
+    Exif:ExposureMode: 0 (auto)
+    Exif:Flash: 16 (no flash, flash supression)
+    Exif:FlashPixVersion: "0100"
+    Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FocalPlaneResolutionUnit: 2 (inches)
     Exif:FocalPlaneXResolution: 12710.8
     Exif:FocalPlaneYResolution: 12725.6
-    Exif:FocalPlaneResolutionUnit: 2 (inches)
-    Exif:SensingMethod: 2 (1-chip color area)
-    Exif:CustomRendered: 0 (no)
-    Exif:ExposureMode: 0 (auto)
-    Exif:WhiteBalance: 0 (auto)
-    Exif:DigitalZoomRatio: 1
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
+    Exif:MeteringMode: 5 (pattern)
+    Exif:PhotographicSensitivity: 75
+    Exif:PixelXDimension: 320
+    Exif:PixelYDimension: 240
     Exif:SceneCaptureType: 1 (landscape)
-    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
-    aux:Lens: "7.3-29.2 mm"
-    aux:ApproximateFocusDistance: "339/100"
-    aux:FlashCompensation: "0/1"
-    aux:OwnerName: "Daniel Wyatt"
-    aux:Firmware: "1.00"
-    IPTC:ModifyDate: "2011-08-25T17:40:47-04:00"
-    IPTC:MetadataDate: "2011-08-25T17:40:47-04:00"
-    photoshop:ColorMode: "0"
+    Exif:SensingMethod: 2 (1-chip color area)
+    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    Exif:SubjectDistance: 3.39 (3.39 m)
+    Exif:WhiteBalance: 0 (auto)
+    Exif:YCbCrPositioning: 1
     IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
     IPTC:InstanceID: "xmp.iid:F410E7E462CFE011B8B8C52D9599FB9E"
+    IPTC:MetadataDate: "2011-08-25T17:40:47-04:00"
+    IPTC:ModifyDate: "2011-08-25T17:40:47-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    photoshop:ColorMode: "0"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:F410E7E462CFE011B8B8C52D9599FB9E"
-    stEvt:when: "2011-08-25T17:40:47-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:F410E7E462CFE011B8B8C52D9599FB9E"
     stEvt:parameters: "converted from image/jpeg to application/vnd.adobe.photoshop"
-    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-25T17:40:47-04:00"
     stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
     stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-    PixelAspectRatio: 1
 Reading ../../../../../oiio-images/psd_indexed_trans.psd
 ../../../../../oiio-images/psd_indexed_trans.psd :  320 x  240, 4 channel, uint8 psd
     SHA-1: 6181660E78F3583DBCC077F79715DA9804D68CF8
     channel list: R, G, B, A
-    XResolution: 180
-    YResolution: 180
-    ResolutionUnit: 2 (inches)
-    thumbnail_width: 160
-    thumbnail_height: 120
-    thumbnail_nchannels: 3
-    thumbnail_image: 166, 170, 173, 203, 207, 210, 225, 229, 232, 228, 232, 235, 232, 236, 239, 230, ... [57600 x uint8]
+    Artist: "Daniel Wyatt"
+    DateTime: "2007-01-18T15:49:21"
+    ExposureTime: 0.0166667
+    FNumber: 3.5
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
     Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2007-01-18T15:49:21"
-    Artist: "Daniel Wyatt"
-    Exif:YCbCrPositioning: 1
-    ExposureTime: 0.0166667
-    FNumber: 3.5
-    Exif:PhotographicSensitivity: 75
-    Exif:ExifVersion: "0220"
-    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
-    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
-    Exif:CompressedBitsPerPixel: 5
-    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    thumbnail_height: 120
+    thumbnail_image: 166, 170, 173, 203, 207, 210, 225, 229, 232, 228, 232, 235, 232, 236, 239, 230, ... [57600 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 180
+    YResolution: 180
+    aux:ApproximateFocusDistance: "339/100"
+    aux:Firmware: "1.00"
+    aux:FlashCompensation: "0/1"
+    aux:Lens: "7.3-29.2 mm"
+    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
+    aux:OwnerName: "Daniel Wyatt"
     Exif:ApertureValue: 3.625 (f/3.5)
-    Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.8)
-    Exif:SubjectDistance: 3.39 (3.39 m)
-    Exif:MeteringMode: 5 (pattern)
-    Exif:Flash: 16 (no flash, flash supression)
-    Exif:FocalLength: 7.3 (7.3 mm)
-    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 1
-    Exif:PixelXDimension: 320
-    Exif:PixelYDimension: 240
+    Exif:CompressedBitsPerPixel: 5
+    Exif:CustomRendered: 0 (no)
+    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
+    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
+    Exif:DigitalZoomRatio: 1
+    Exif:ExifVersion: "0220"
+    Exif:ExposureBiasValue: 0
+    Exif:ExposureMode: 0 (auto)
+    Exif:Flash: 16 (no flash, flash supression)
+    Exif:FlashPixVersion: "0100"
+    Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FocalPlaneResolutionUnit: 2 (inches)
     Exif:FocalPlaneXResolution: 12710.8
     Exif:FocalPlaneYResolution: 12725.6
-    Exif:FocalPlaneResolutionUnit: 2 (inches)
-    Exif:SensingMethod: 2 (1-chip color area)
-    Exif:CustomRendered: 0 (no)
-    Exif:ExposureMode: 0 (auto)
-    Exif:WhiteBalance: 0 (auto)
-    Exif:DigitalZoomRatio: 1
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
+    Exif:MeteringMode: 5 (pattern)
+    Exif:PhotographicSensitivity: 75
+    Exif:PixelXDimension: 320
+    Exif:PixelYDimension: 240
     Exif:SceneCaptureType: 1 (landscape)
-    oiio:ColorSpace: "sRGB"
-    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
-    aux:Lens: "7.3-29.2 mm"
-    aux:ApproximateFocusDistance: "339/100"
-    aux:FlashCompensation: "0/1"
-    aux:OwnerName: "Daniel Wyatt"
-    aux:Firmware: "1.00"
-    IPTC:ModifyDate: "2011-08-29T11:54:09-04:00"
-    IPTC:MetadataDate: "2011-08-29T11:54:09-04:00"
-    photoshop:ColorMode: "2"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    Exif:SensingMethod: 2 (1-chip color area)
+    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    Exif:SubjectDistance: 3.39 (3.39 m)
+    Exif:WhiteBalance: 0 (auto)
+    Exif:YCbCrPositioning: 1
     IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
     IPTC:InstanceID: "xmp.iid:F3BDDC0457D2E011BF419187EAB8EBB9"
+    IPTC:MetadataDate: "2011-08-29T11:54:09-04:00"
+    IPTC:ModifyDate: "2011-08-29T11:54:09-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: "2"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:F3BDDC0457D2E011BF419187EAB8EBB9"
-    stEvt:when: "2011-08-29T11:54:09-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:F3BDDC0457D2E011BF419187EAB8EBB9"
     stEvt:parameters: "converted from image/jpeg to application/vnd.adobe.photoshop"
-    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-29T11:54:09-04:00"
     stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
     stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-    PixelAspectRatio: 1
 Reading ../../../../../oiio-images/psd_rgb_8.psd
 ../../../../../oiio-images/psd_rgb_8.psd :  320 x  240, 3 channel, uint8 psd
     SHA-1: 44362B2D9E51C40DF8ABF87CC749B77F2D0D9F4F
     channel list: R, G, B
-    XResolution: 180
-    YResolution: 180
-    ResolutionUnit: 2 (inches)
-    thumbnail_width: 160
-    thumbnail_height: 120
-    thumbnail_nchannels: 3
-    thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ... [57600 x uint8]
+    Artist: "Daniel Wyatt"
+    DateTime: "2007-01-18T15:49:21"
+    ExposureTime: 0.0166667
+    FNumber: 3.5
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
     Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2007-01-18T15:49:21"
-    Artist: "Daniel Wyatt"
-    Exif:YCbCrPositioning: 1
-    ExposureTime: 0.0166667
-    FNumber: 3.5
-    Exif:PhotographicSensitivity: 75
-    Exif:ExifVersion: "0220"
-    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
-    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
-    Exif:CompressedBitsPerPixel: 5
-    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    thumbnail_height: 120
+    thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ... [57600 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 180
+    YResolution: 180
+    aux:ApproximateFocusDistance: "339/100"
+    aux:Firmware: "1.00"
+    aux:FlashCompensation: "0/1"
+    aux:Lens: "7.3-29.2 mm"
+    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
+    aux:OwnerName: "Daniel Wyatt"
     Exif:ApertureValue: 3.625 (f/3.5)
-    Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.8)
-    Exif:SubjectDistance: 3.39 (3.39 m)
-    Exif:MeteringMode: 5 (pattern)
-    Exif:Flash: 16 (no flash, flash supression)
-    Exif:FocalLength: 7.3 (7.3 mm)
-    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 1
-    Exif:PixelXDimension: 320
-    Exif:PixelYDimension: 240
+    Exif:CompressedBitsPerPixel: 5
+    Exif:CustomRendered: 0 (no)
+    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
+    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
+    Exif:DigitalZoomRatio: 1
+    Exif:ExifVersion: "0220"
+    Exif:ExposureBiasValue: 0
+    Exif:ExposureMode: 0 (auto)
+    Exif:Flash: 16 (no flash, flash supression)
+    Exif:FlashPixVersion: "0100"
+    Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FocalPlaneResolutionUnit: 2 (inches)
     Exif:FocalPlaneXResolution: 12710.8
     Exif:FocalPlaneYResolution: 12725.6
-    Exif:FocalPlaneResolutionUnit: 2 (inches)
-    Exif:SensingMethod: 2 (1-chip color area)
-    Exif:CustomRendered: 0 (no)
-    Exif:ExposureMode: 0 (auto)
-    Exif:WhiteBalance: 0 (auto)
-    Exif:DigitalZoomRatio: 1
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
+    Exif:MeteringMode: 5 (pattern)
+    Exif:PhotographicSensitivity: 75
+    Exif:PixelXDimension: 320
+    Exif:PixelYDimension: 240
     Exif:SceneCaptureType: 1 (landscape)
-    oiio:ColorSpace: "sRGB"
-    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
-    aux:Lens: "7.3-29.2 mm"
-    aux:ApproximateFocusDistance: "339/100"
-    aux:FlashCompensation: "0/1"
-    aux:OwnerName: "Daniel Wyatt"
-    aux:Firmware: "1.00"
-    IPTC:ModifyDate: "2011-08-25T17:40-04:00"
-    IPTC:MetadataDate: "2011-08-25T17:40-04:00"
-    photoshop:ColorMode: "3"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    Exif:SensingMethod: 2 (1-chip color area)
+    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    Exif:SubjectDistance: 3.39 (3.39 m)
+    Exif:WhiteBalance: 0 (auto)
+    Exif:YCbCrPositioning: 1
     IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
     IPTC:InstanceID: "xmp.iid:2A93235262CFE011B8B8C52D9599FB9E"
+    IPTC:MetadataDate: "2011-08-25T17:40-04:00"
+    IPTC:ModifyDate: "2011-08-25T17:40-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: "3"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:2A93235262CFE011B8B8C52D9599FB9E"
-    stEvt:when: "2011-08-25T17:40-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:2A93235262CFE011B8B8C52D9599FB9E"
     stEvt:parameters: "converted from image/jpeg to application/vnd.adobe.photoshop"
-    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-25T17:40-04:00"
     stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
     stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-    PixelAspectRatio: 1
 Reading ../../../../../oiio-images/psd_rgb_16.psd
 ../../../../../oiio-images/psd_rgb_16.psd :  320 x  240, 3 channel, uint16 psd
     SHA-1: E42334B0F0684E3C3BF9125F2920B07C44C17B11
     channel list: R, G, B
-    XResolution: 180
-    YResolution: 180
-    ResolutionUnit: 2 (inches)
-    thumbnail_width: 160
-    thumbnail_height: 120
-    thumbnail_nchannels: 3
-    thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ... [57600 x uint8]
+    Artist: "Daniel Wyatt"
+    DateTime: "2007-01-18T15:49:21"
+    ExposureTime: 0.0166667
+    FNumber: 3.5
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
     Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2007-01-18T15:49:21"
-    Artist: "Daniel Wyatt"
-    Exif:YCbCrPositioning: 1
-    ExposureTime: 0.0166667
-    FNumber: 3.5
-    Exif:PhotographicSensitivity: 75
-    Exif:ExifVersion: "0220"
-    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
-    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
-    Exif:CompressedBitsPerPixel: 5
-    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    thumbnail_height: 120
+    thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ... [57600 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 180
+    YResolution: 180
+    aux:ApproximateFocusDistance: "339/100"
+    aux:Firmware: "1.00"
+    aux:FlashCompensation: "0/1"
+    aux:Lens: "7.3-29.2 mm"
+    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
+    aux:OwnerName: "Daniel Wyatt"
     Exif:ApertureValue: 3.625 (f/3.5)
-    Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.8)
-    Exif:SubjectDistance: 3.39 (3.39 m)
-    Exif:MeteringMode: 5 (pattern)
-    Exif:Flash: 16 (no flash, flash supression)
-    Exif:FocalLength: 7.3 (7.3 mm)
-    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 1
-    Exif:PixelXDimension: 320
-    Exif:PixelYDimension: 240
+    Exif:CompressedBitsPerPixel: 5
+    Exif:CustomRendered: 0 (no)
+    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
+    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
+    Exif:DigitalZoomRatio: 1
+    Exif:ExifVersion: "0220"
+    Exif:ExposureBiasValue: 0
+    Exif:ExposureMode: 0 (auto)
+    Exif:Flash: 16 (no flash, flash supression)
+    Exif:FlashPixVersion: "0100"
+    Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FocalPlaneResolutionUnit: 2 (inches)
     Exif:FocalPlaneXResolution: 12710.8
     Exif:FocalPlaneYResolution: 12725.6
-    Exif:FocalPlaneResolutionUnit: 2 (inches)
-    Exif:SensingMethod: 2 (1-chip color area)
-    Exif:CustomRendered: 0 (no)
-    Exif:ExposureMode: 0 (auto)
-    Exif:WhiteBalance: 0 (auto)
-    Exif:DigitalZoomRatio: 1
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
+    Exif:MeteringMode: 5 (pattern)
+    Exif:PhotographicSensitivity: 75
+    Exif:PixelXDimension: 320
+    Exif:PixelYDimension: 240
     Exif:SceneCaptureType: 1 (landscape)
-    oiio:ColorSpace: "sRGB"
-    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
-    aux:Lens: "7.3-29.2 mm"
-    aux:ApproximateFocusDistance: "339/100"
-    aux:FlashCompensation: "0/1"
-    aux:OwnerName: "Daniel Wyatt"
-    aux:Firmware: "1.00"
-    IPTC:ModifyDate: "2011-08-25T17:39:49-04:00"
-    IPTC:MetadataDate: "2011-08-25T17:39:49-04:00"
-    photoshop:ColorMode: "3"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    Exif:SensingMethod: 2 (1-chip color area)
+    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    Exif:SubjectDistance: 3.39 (3.39 m)
+    Exif:WhiteBalance: 0 (auto)
+    Exif:YCbCrPositioning: 1
     IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
     IPTC:InstanceID: "xmp.iid:2993235262CFE011B8B8C52D9599FB9E"
+    IPTC:MetadataDate: "2011-08-25T17:39:49-04:00"
+    IPTC:ModifyDate: "2011-08-25T17:39:49-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: "3"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:2993235262CFE011B8B8C52D9599FB9E"
-    stEvt:when: "2011-08-25T17:39:49-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:2993235262CFE011B8B8C52D9599FB9E"
     stEvt:parameters: "converted from image/jpeg to application/vnd.adobe.photoshop"
-    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-25T17:39:49-04:00"
     stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
     stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-    PixelAspectRatio: 1
 Reading ../../../../../oiio-images/psd_rgb_32.psd
 ../../../../../oiio-images/psd_rgb_32.psd :  320 x  240, 3 channel, float psd
     SHA-1: 63CF8F7B010D24EFD3C41F51C16D8D285FE07313
     channel list: R, G, B
-    XResolution: 180
-    YResolution: 180
-    ResolutionUnit: 2 (inches)
-    thumbnail_width: 160
-    thumbnail_height: 120
-    thumbnail_nchannels: 3
-    thumbnail_image: 217, 225, 227, 219, 227, 229, 224, 229, 232, 228, 233, 236, 231, 236, 239, 233, ... [57600 x uint8]
+    Artist: "Daniel Wyatt"
+    DateTime: "2007-01-18T15:49:21"
+    ExposureTime: 0.0166667
+    FNumber: 3.5
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
     Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2007-01-18T15:49:21"
-    Artist: "Daniel Wyatt"
-    Exif:YCbCrPositioning: 1
-    ExposureTime: 0.0166667
-    FNumber: 3.5
-    Exif:PhotographicSensitivity: 75
-    Exif:ExifVersion: "0220"
-    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
-    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
-    Exif:CompressedBitsPerPixel: 5
-    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    thumbnail_height: 120
+    thumbnail_image: 217, 225, 227, 219, 227, 229, 224, 229, 232, 228, 233, 236, 231, 236, 239, 233, ... [57600 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 180
+    YResolution: 180
+    aux:ApproximateFocusDistance: "339/100"
+    aux:Firmware: "1.00"
+    aux:FlashCompensation: "0/1"
+    aux:Lens: "7.3-29.2 mm"
+    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
+    aux:OwnerName: "Daniel Wyatt"
     Exif:ApertureValue: 3.625 (f/3.5)
-    Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.8)
-    Exif:SubjectDistance: 3.39 (3.39 m)
-    Exif:MeteringMode: 5 (pattern)
-    Exif:Flash: 16 (no flash, flash supression)
-    Exif:FocalLength: 7.3 (7.3 mm)
-    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 65535
-    Exif:PixelXDimension: 320
-    Exif:PixelYDimension: 240
+    Exif:CompressedBitsPerPixel: 5
+    Exif:CustomRendered: 0 (no)
+    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
+    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
+    Exif:DigitalZoomRatio: 1
+    Exif:ExifVersion: "0220"
+    Exif:ExposureBiasValue: 0
+    Exif:ExposureMode: 0 (auto)
+    Exif:Flash: 16 (no flash, flash supression)
+    Exif:FlashPixVersion: "0100"
+    Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FocalPlaneResolutionUnit: 2 (inches)
     Exif:FocalPlaneXResolution: 12710.8
     Exif:FocalPlaneYResolution: 12725.6
-    Exif:FocalPlaneResolutionUnit: 2 (inches)
-    Exif:SensingMethod: 2 (1-chip color area)
-    Exif:CustomRendered: 0 (no)
-    Exif:ExposureMode: 0 (auto)
-    Exif:WhiteBalance: 0 (auto)
-    Exif:DigitalZoomRatio: 1
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
+    Exif:MeteringMode: 5 (pattern)
+    Exif:PhotographicSensitivity: 75
+    Exif:PixelXDimension: 320
+    Exif:PixelYDimension: 240
     Exif:SceneCaptureType: 1 (landscape)
-    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
-    aux:Lens: "7.3-29.2 mm"
-    aux:ApproximateFocusDistance: "339/100"
-    aux:FlashCompensation: "0/1"
-    aux:OwnerName: "Daniel Wyatt"
-    aux:Firmware: "1.00"
-    IPTC:ModifyDate: "2011-08-25T17:39:38-04:00"
-    IPTC:MetadataDate: "2011-08-25T17:39:38-04:00"
-    photoshop:ColorMode: "3"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1 (Linear RGB Profile)"
+    Exif:SensingMethod: 2 (1-chip color area)
+    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    Exif:SubjectDistance: 3.39 (3.39 m)
+    Exif:WhiteBalance: 0 (auto)
+    Exif:YCbCrPositioning: 1
     IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
     IPTC:InstanceID: "xmp.iid:2893235262CFE011B8B8C52D9599FB9E"
+    IPTC:MetadataDate: "2011-08-25T17:39:38-04:00"
+    IPTC:ModifyDate: "2011-08-25T17:39:38-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    photoshop:ColorMode: "3"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1 (Linear RGB Profile)"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:2893235262CFE011B8B8C52D9599FB9E"
-    stEvt:when: "2011-08-25T17:39:38-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:2893235262CFE011B8B8C52D9599FB9E"
     stEvt:parameters: "converted from image/jpeg to application/vnd.adobe.photoshop"
-    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-25T17:39:38-04:00"
     stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
     stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-    PixelAspectRatio: 1
 Reading ../../../../../oiio-images/psd_rgba_8.psd
 ../../../../../oiio-images/psd_rgba_8.psd :  320 x  240, 4 channel, uint8 psd
     2 subimages: 320x240 [u8,u8,u8,u8], 320x240 [u8,u8,u8,u8]
  subimage  0:  320 x  240, 4 channel, uint8 psd
     SHA-1: 9519DFB5CDF4D8BAC10A20EAE6433A9216885F9D
     channel list: R, G, B, A
+    DateTime: "2011-08-22T22:07:44-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
+    thumbnail_height: 120
+    thumbnail_image: 220, 224, 227, 222, 226, 229, 225, 229, 232, 229, 233, 236, 232, 236, 239, 234, ... [57600 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    thumbnail_width: 160
-    thumbnail_height: 120
-    thumbnail_nchannels: 3
-    thumbnail_image: 220, 224, 227, 222, 226, 229, 225, 229, 232, 229, 233, 236, 232, 236, 239, 234, ... [57600 x uint8]
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:07:44-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 320
     Exif:PixelYDimension: 240
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
     IPTC:MetadataDate: "2011-08-25T17:39:28-04:00"
     IPTC:ModifyDate: "2011-08-25T17:39:28-04:00"
-    photoshop:ColorMode: "3"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:DocumentAncestors: "E146B3E37A92795EE3EA6577040DE6D5"
-    IPTC:InstanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
-    IPTC:DocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:OriginalDocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: "3"
+    photoshop:DocumentAncestors: "E146B3E37A92795EE3EA6577040DE6D5"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
-    stEvt:when: "2011-08-25T17:39:28-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-25T17:39:28-04:00"
  subimage  1:  320 x  240, 4 channel, uint8 psd
     SHA-1: 131A372FD9B67B580B0380A4F754281D5F33E12E
     channel list: R, G, B, A
+    DateTime: "2011-08-22T22:07:44-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:07:44-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 320
     Exif:PixelYDimension: 240
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
     IPTC:MetadataDate: "2011-08-25T17:39:28-04:00"
     IPTC:ModifyDate: "2011-08-25T17:39:28-04:00"
-    photoshop:ColorMode: "3"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:DocumentAncestors: "E146B3E37A92795EE3EA6577040DE6D5"
-    IPTC:InstanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
-    IPTC:DocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:OriginalDocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: "3"
+    photoshop:DocumentAncestors: "E146B3E37A92795EE3EA6577040DE6D5"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
-    stEvt:when: "2011-08-25T17:39:28-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-25T17:39:28-04:00"
 Reading src/different-mask-size.psd
 src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     4 subimages: 30x90 [u8,u8,u8], 30x90 [u8,u8,u8,u8], 4x93 [u8,u8,u8,u8], 4x93 [u8,u8,u8,u8]
  subimage  0:   30 x   90, 3 channel, uint8 psd
     SHA-1: 42E73C11525323760BF0BEB74370AECC18FC2D92
     channel list: R, G, B
+    DateTime: "2014-02-16T17:20:13+09:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CC 2015.5 (Windows)"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CC 2015.5 (Windows)"
-    DateTime: "2014-02-16T17:20:13+09:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 30
     Exif:PixelYDimension: 90
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
     IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
-    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
-    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: "3"
+    photoshop:DocumentAncestors: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
-    stEvt:when: "2017-01-10T17:55:32+09:00"
-    stEvt:softwareAgent: "Adobe Photoshop CC 2015.5 (Windows)"
     stEvt:changed: "/"
-    photoshop:ColorMode: "3"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:DocumentAncestors: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
+    stEvt:softwareAgent: "Adobe Photoshop CC 2015.5 (Windows)"
+    stEvt:when: "2017-01-10T17:55:32+09:00"
  subimage  1:   30 x   90, 4 channel, uint8 psd
     SHA-1: B2E0D74684B53DF0382EAB0BB1A277438715BB2F
     channel list: R, G, B, A
+    DateTime: "2014-02-16T17:20:13+09:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CC 2015.5 (Windows)"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CC 2015.5 (Windows)"
-    DateTime: "2014-02-16T17:20:13+09:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 30
     Exif:PixelYDimension: 90
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
     IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
-    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
-    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: "3"
+    photoshop:DocumentAncestors: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
-    stEvt:when: "2017-01-10T17:55:32+09:00"
-    stEvt:softwareAgent: "Adobe Photoshop CC 2015.5 (Windows)"
     stEvt:changed: "/"
-    photoshop:ColorMode: "3"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:DocumentAncestors: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
+    stEvt:softwareAgent: "Adobe Photoshop CC 2015.5 (Windows)"
+    stEvt:when: "2017-01-10T17:55:32+09:00"
  subimage  2:    4 x   93, 4 channel, uint8 psd
     SHA-1: 8CE9A2A394ED148194055A22E59E55CE7BDFB3B7
     channel list: R, G, B, A
+    DateTime: "2014-02-16T17:20:13+09:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CC 2015.5 (Windows)"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CC 2015.5 (Windows)"
-    DateTime: "2014-02-16T17:20:13+09:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 30
     Exif:PixelYDimension: 90
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
     IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
-    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
-    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: "3"
+    photoshop:DocumentAncestors: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
-    stEvt:when: "2017-01-10T17:55:32+09:00"
-    stEvt:softwareAgent: "Adobe Photoshop CC 2015.5 (Windows)"
     stEvt:changed: "/"
-    photoshop:ColorMode: "3"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:DocumentAncestors: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
+    stEvt:softwareAgent: "Adobe Photoshop CC 2015.5 (Windows)"
+    stEvt:when: "2017-01-10T17:55:32+09:00"
  subimage  3:    4 x   93, 4 channel, uint8 psd
     SHA-1: 8CE9A2A394ED148194055A22E59E55CE7BDFB3B7
     channel list: R, G, B, A
+    DateTime: "2014-02-16T17:20:13+09:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CC 2015.5 (Windows)"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CC 2015.5 (Windows)"
-    DateTime: "2014-02-16T17:20:13+09:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 30
     Exif:PixelYDimension: 90
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
     IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
-    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
-    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: "3"
+    photoshop:DocumentAncestors: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
-    stEvt:when: "2017-01-10T17:55:32+09:00"
-    stEvt:softwareAgent: "Adobe Photoshop CC 2015.5 (Windows)"
     stEvt:changed: "/"
-    photoshop:ColorMode: "3"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:DocumentAncestors: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
+    stEvt:softwareAgent: "Adobe Photoshop CC 2015.5 (Windows)"
+    stEvt:when: "2017-01-10T17:55:32+09:00"
 Reading src/layer-mask.psd
 src/layer-mask.psd   :   10 x   10, 4 channel, uint8 psd
     3 subimages: 10x10 [u8,u8,u8,u8], 8x8 [u8,u8,u8,u8], 9x9 [u8,u8,u8,u8]
  subimage  0:   10 x   10, 4 channel, uint8 psd
     SHA-1: 9C9176DD4E1E7E1DF656D39DB7E1506E1E1260F3
     channel list: R, G, B, A
+    DateTime: "2017-07-13T10:26:10+09:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CC 2017 (Windows)"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CC 2017 (Windows)"
-    DateTime: "2017-07-13T10:26:10+09:00"
     Exif:ColorSpace: 65535
     Exif:PixelXDimension: 10
     Exif:PixelYDimension: 10
+    IPTC:DocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
+    IPTC:InstanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
     IPTC:MetadataDate: "2017-07-13T11:42:54+09:00"
     IPTC:ModifyDate: "2017-07-13T11:42:54+09:00"
-    IPTC:InstanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
-    IPTC:DocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
     IPTC:OriginalDocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
+    photoshop:ColorMode: "3"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
-    stEvt:when: "2017-07-13T11:42:54+09:00"
-    stEvt:softwareAgent: "Adobe Photoshop CC 2017 (Windows)"
     stEvt:changed: "/"
-    photoshop:ColorMode: "3"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
+    stEvt:softwareAgent: "Adobe Photoshop CC 2017 (Windows)"
+    stEvt:when: "2017-07-13T11:42:54+09:00"
  subimage  1:    8 x    8, 4 channel, uint8 psd
     SHA-1: D1803D25687AA8C80C50AC74CCD47B1C59865B2F
     channel list: R, G, B, A
+    DateTime: "2017-07-13T10:26:10+09:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CC 2017 (Windows)"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CC 2017 (Windows)"
-    DateTime: "2017-07-13T10:26:10+09:00"
     Exif:ColorSpace: 65535
     Exif:PixelXDimension: 10
     Exif:PixelYDimension: 10
+    IPTC:DocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
+    IPTC:InstanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
     IPTC:MetadataDate: "2017-07-13T11:42:54+09:00"
     IPTC:ModifyDate: "2017-07-13T11:42:54+09:00"
-    IPTC:InstanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
-    IPTC:DocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
     IPTC:OriginalDocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
+    photoshop:ColorMode: "3"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
-    stEvt:when: "2017-07-13T11:42:54+09:00"
-    stEvt:softwareAgent: "Adobe Photoshop CC 2017 (Windows)"
     stEvt:changed: "/"
-    photoshop:ColorMode: "3"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
+    stEvt:softwareAgent: "Adobe Photoshop CC 2017 (Windows)"
+    stEvt:when: "2017-07-13T11:42:54+09:00"
  subimage  2:    9 x    9, 4 channel, uint8 psd
     SHA-1: 6BEB9ABA4756704D8A330EA3B8F79640F3D88088
     channel list: R, G, B, A
+    DateTime: "2017-07-13T10:26:10+09:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CC 2017 (Windows)"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CC 2017 (Windows)"
-    DateTime: "2017-07-13T10:26:10+09:00"
     Exif:ColorSpace: 65535
     Exif:PixelXDimension: 10
     Exif:PixelYDimension: 10
+    IPTC:DocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
+    IPTC:InstanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
     IPTC:MetadataDate: "2017-07-13T11:42:54+09:00"
     IPTC:ModifyDate: "2017-07-13T11:42:54+09:00"
-    IPTC:InstanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
-    IPTC:DocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
     IPTC:OriginalDocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
+    photoshop:ColorMode: "3"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
-    stEvt:when: "2017-07-13T11:42:54+09:00"
-    stEvt:softwareAgent: "Adobe Photoshop CC 2017 (Windows)"
     stEvt:changed: "/"
-    photoshop:ColorMode: "3"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
+    stEvt:softwareAgent: "Adobe Photoshop CC 2017 (Windows)"
+    stEvt:when: "2017-07-13T11:42:54+09:00"

--- a/testsuite/psd/ref/out.txt
+++ b/testsuite/psd/ref/out.txt
@@ -4,847 +4,847 @@ Reading ../../../../../oiio-images/psd_123.psd
  subimage  0:  257 x  126, 4 channel, uint8 psd
     SHA-1: F7A1BCAC9115D886FC6D6C23639529955D74DD58
     channel list: R, G, B, A
+    DateTime: "2011-08-22T22:14:43-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
+    thumbnail_height: 78
+    thumbnail_image: 249, 255, 255, 251, 255, 255, 252, 255, 255, 254, 255, 255, 255, 254, 255, 255, ... [37440 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    thumbnail_width: 160
-    thumbnail_height: 78
-    thumbnail_nchannels: 3
-    thumbnail_image: 249, 255, 255, 251, 255, 255, 252, 255, 255, 254, 254, 255, 255, 254, 255, 255, ... [37440 x uint8]
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:14:43-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
-    rdf:parseType: "Resource"
-    photoshop:LayerName: "3"
-    photoshop:LayerText: "3"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: "3"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    photoshop:LayerName: "3"
+    photoshop:LayerText: "3"
+    rdf:parseType: "Resource"
     stEvt:action: "created"
     stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
-    stEvt:when: "2011-08-22T22:14:43-04:00"
     stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
-    PixelAspectRatio: 1
+    stEvt:when: "2011-08-22T22:14:43-04:00"
  subimage  1:   33 x   98, 4 channel, uint8 psd
     SHA-1: CDA136B1B34A86AEBDCB88283F0D2323F921C00C
     channel list: R, G, B, A
+    DateTime: "2011-08-22T22:14:43-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:14:43-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
-    rdf:parseType: "Resource"
-    photoshop:LayerName: "3"
-    photoshop:LayerText: "3"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: "3"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    photoshop:LayerName: "3"
+    photoshop:LayerText: "3"
+    rdf:parseType: "Resource"
     stEvt:action: "created"
     stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
-    stEvt:when: "2011-08-22T22:14:43-04:00"
     stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
-    PixelAspectRatio: 1
+    stEvt:when: "2011-08-22T22:14:43-04:00"
  subimage  2:   63 x  100, 4 channel, uint8 psd
     SHA-1: E0B9D4A8BE16B52126EC5BC1E829D099EF4C5DC4
     channel list: R, G, B, A
+    DateTime: "2011-08-22T22:14:43-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:14:43-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
-    rdf:parseType: "Resource"
-    photoshop:LayerName: "3"
-    photoshop:LayerText: "3"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: "3"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    photoshop:LayerName: "3"
+    photoshop:LayerText: "3"
+    rdf:parseType: "Resource"
     stEvt:action: "created"
     stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
-    stEvt:when: "2011-08-22T22:14:43-04:00"
     stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
-    PixelAspectRatio: 1
+    stEvt:when: "2011-08-22T22:14:43-04:00"
  subimage  3:   61 x  102, 4 channel, uint8 psd
     SHA-1: 11FDE5499A2150FD5C779C9012649E839750C1D8
     channel list: R, G, B, A
+    DateTime: "2011-08-22T22:14:43-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:14:43-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
-    rdf:parseType: "Resource"
-    photoshop:LayerName: "3"
-    photoshop:LayerText: "3"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: "3"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    photoshop:LayerName: "3"
+    photoshop:LayerText: "3"
+    rdf:parseType: "Resource"
     stEvt:action: "created"
     stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
-    stEvt:when: "2011-08-22T22:14:43-04:00"
     stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
-    PixelAspectRatio: 1
+    stEvt:when: "2011-08-22T22:14:43-04:00"
 Reading ../../../../../oiio-images/psd_123_nomaxcompat.psd
 ../../../../../oiio-images/psd_123_nomaxcompat.psd :  257 x  126, 3 channel, uint8 psd
     4 subimages: 257x126 [u8,u8,u8], 33x98 [u8,u8,u8,u8], 63x100 [u8,u8,u8,u8], 61x102 [u8,u8,u8,u8]
  subimage  0:  257 x  126, 3 channel, uint8 psd
     SHA-1: 5A7BDC7A11A9E4BDCBEC968375EE466DE74D0481
     channel list: R, G, B
+    DateTime: "2011-08-22T22:14:43-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
+    thumbnail_height: 78
+    thumbnail_image: 249, 255, 255, 251, 255, 255, 252, 255, 255, 254, 255, 255, 255, 254, 255, 255, ... [37440 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    thumbnail_width: 160
-    thumbnail_height: 78
-    thumbnail_nchannels: 3
-    thumbnail_image: 249, 255, 255, 251, 255, 255, 252, 255, 255, 254, 254, 255, 255, 254, 255, 255, ... [37440 x uint8]
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:14:43-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
     IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: "3"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    rdf:parseType: "Resource"
     photoshop:LayerName: "3"
     photoshop:LayerText: "3"
-    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
-    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
-    stEvt:when: "2011-08-29T12:10:28-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-29T12:10:28-04:00"
  subimage  1:   33 x   98, 4 channel, uint8 psd
     SHA-1: CDA136B1B34A86AEBDCB88283F0D2323F921C00C
     channel list: R, G, B, A
+    DateTime: "2011-08-22T22:14:43-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:14:43-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
     IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: "3"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    rdf:parseType: "Resource"
     photoshop:LayerName: "3"
     photoshop:LayerText: "3"
-    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
-    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
-    stEvt:when: "2011-08-29T12:10:28-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-29T12:10:28-04:00"
  subimage  2:   63 x  100, 4 channel, uint8 psd
     SHA-1: E0B9D4A8BE16B52126EC5BC1E829D099EF4C5DC4
     channel list: R, G, B, A
+    DateTime: "2011-08-22T22:14:43-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:14:43-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
     IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: "3"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    rdf:parseType: "Resource"
     photoshop:LayerName: "3"
     photoshop:LayerText: "3"
-    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
-    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
-    stEvt:when: "2011-08-29T12:10:28-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-29T12:10:28-04:00"
  subimage  3:   61 x  102, 4 channel, uint8 psd
     SHA-1: 11FDE5499A2150FD5C779C9012649E839750C1D8
     channel list: R, G, B, A
+    DateTime: "2011-08-22T22:14:43-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:14:43-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
     IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: "3"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    rdf:parseType: "Resource"
     photoshop:LayerName: "3"
     photoshop:LayerText: "3"
-    IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
-    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
-    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
-    stEvt:when: "2011-08-29T12:10:28-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-29T12:10:28-04:00"
 Reading ../../../../../oiio-images/psd_bitmap.psd
 ../../../../../oiio-images/psd_bitmap.psd :  320 x  240, 3 channel, uint8 psd
     SHA-1: F23185BC048E31BAC6BB4B319E5E5AC570CC7B89
     channel list: R, G, B
-    XResolution: 180
-    YResolution: 180
-    ResolutionUnit: 2 (inches)
-    thumbnail_width: 160
-    thumbnail_height: 120
-    thumbnail_nchannels: 3
-    thumbnail_image: 90, 90, 90, 255, 255, 255, 255, 255, 255, 251, 251, 251, 250, 250, 250, 255, ... [57600 x uint8]
+    Artist: "Daniel Wyatt"
+    DateTime: "2007-01-18T15:49:21"
+    ExposureTime: 0.0166667
+    FNumber: 3.5
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
     Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2007-01-18T15:49:21"
-    Artist: "Daniel Wyatt"
-    Exif:YCbCrPositioning: 1
-    ExposureTime: 0.0166667
-    FNumber: 3.5
-    Exif:PhotographicSensitivity: 75
-    Exif:ExifVersion: "0220"
-    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
-    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
-    Exif:CompressedBitsPerPixel: 5
-    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    thumbnail_height: 120
+    thumbnail_image: 90, 90, 90, 255, 255, 255, 255, 255, 255, 251, 251, 251, 250, 250, 250, 255, ... [57600 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 180
+    YResolution: 180
+    aux:ApproximateFocusDistance: "339/100"
+    aux:Firmware: "1.00"
+    aux:FlashCompensation: "0/1"
+    aux:Lens: "7.3-29.2 mm"
+    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
+    aux:OwnerName: "Daniel Wyatt"
     Exif:ApertureValue: 3.625 (f/3.5)
-    Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.8)
-    Exif:SubjectDistance: 3.39 (3.39 m)
-    Exif:MeteringMode: 5 (pattern)
-    Exif:Flash: 16 (no flash, flash supression)
-    Exif:FocalLength: 7.3 (7.3 mm)
-    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 65535
-    Exif:PixelXDimension: 320
-    Exif:PixelYDimension: 240
+    Exif:CompressedBitsPerPixel: 5
+    Exif:CustomRendered: 0 (no)
+    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
+    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
+    Exif:DigitalZoomRatio: 1
+    Exif:ExifVersion: "0220"
+    Exif:ExposureBiasValue: 0
+    Exif:ExposureMode: 0 (auto)
+    Exif:Flash: 16 (no flash, flash supression)
+    Exif:FlashPixVersion: "0100"
+    Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FocalPlaneResolutionUnit: 2 (inches)
     Exif:FocalPlaneXResolution: 12710.8
     Exif:FocalPlaneYResolution: 12725.6
-    Exif:FocalPlaneResolutionUnit: 2 (inches)
-    Exif:SensingMethod: 2 (1-chip color area)
-    Exif:CustomRendered: 0 (no)
-    Exif:ExposureMode: 0 (auto)
-    Exif:WhiteBalance: 0 (auto)
-    Exif:DigitalZoomRatio: 1
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
+    Exif:MeteringMode: 5 (pattern)
+    Exif:PhotographicSensitivity: 75
+    Exif:PixelXDimension: 320
+    Exif:PixelYDimension: 240
     Exif:SceneCaptureType: 1 (landscape)
-    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
-    aux:Lens: "7.3-29.2 mm"
-    aux:ApproximateFocusDistance: "339/100"
-    aux:FlashCompensation: "0/1"
-    aux:OwnerName: "Daniel Wyatt"
-    aux:Firmware: "1.00"
-    IPTC:ModifyDate: "2011-08-25T17:40:47-04:00"
-    IPTC:MetadataDate: "2011-08-25T17:40:47-04:00"
-    photoshop:ColorMode: "0"
+    Exif:SensingMethod: 2 (1-chip color area)
+    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    Exif:SubjectDistance: 3.39 (3.39 m)
+    Exif:WhiteBalance: 0 (auto)
+    Exif:YCbCrPositioning: 1
     IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
     IPTC:InstanceID: "xmp.iid:F410E7E462CFE011B8B8C52D9599FB9E"
+    IPTC:MetadataDate: "2011-08-25T17:40:47-04:00"
+    IPTC:ModifyDate: "2011-08-25T17:40:47-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    photoshop:ColorMode: "0"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:F410E7E462CFE011B8B8C52D9599FB9E"
-    stEvt:when: "2011-08-25T17:40:47-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:F410E7E462CFE011B8B8C52D9599FB9E"
     stEvt:parameters: "converted from image/jpeg to application/vnd.adobe.photoshop"
-    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-25T17:40:47-04:00"
     stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
     stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-    PixelAspectRatio: 1
 Reading ../../../../../oiio-images/psd_indexed_trans.psd
 ../../../../../oiio-images/psd_indexed_trans.psd :  320 x  240, 4 channel, uint8 psd
     SHA-1: 6181660E78F3583DBCC077F79715DA9804D68CF8
     channel list: R, G, B, A
-    XResolution: 180
-    YResolution: 180
-    ResolutionUnit: 2 (inches)
-    thumbnail_width: 160
-    thumbnail_height: 120
-    thumbnail_nchannels: 3
-    thumbnail_image: 166, 170, 173, 203, 207, 210, 225, 229, 232, 228, 232, 235, 232, 236, 239, 230, ... [57600 x uint8]
+    Artist: "Daniel Wyatt"
+    DateTime: "2007-01-18T15:49:21"
+    ExposureTime: 0.0166667
+    FNumber: 3.5
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
     Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2007-01-18T15:49:21"
-    Artist: "Daniel Wyatt"
-    Exif:YCbCrPositioning: 1
-    ExposureTime: 0.0166667
-    FNumber: 3.5
-    Exif:PhotographicSensitivity: 75
-    Exif:ExifVersion: "0220"
-    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
-    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
-    Exif:CompressedBitsPerPixel: 5
-    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    thumbnail_height: 120
+    thumbnail_image: 166, 170, 173, 203, 207, 210, 225, 229, 232, 228, 232, 235, 232, 236, 239, 230, ... [57600 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 180
+    YResolution: 180
+    aux:ApproximateFocusDistance: "339/100"
+    aux:Firmware: "1.00"
+    aux:FlashCompensation: "0/1"
+    aux:Lens: "7.3-29.2 mm"
+    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
+    aux:OwnerName: "Daniel Wyatt"
     Exif:ApertureValue: 3.625 (f/3.5)
-    Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.8)
-    Exif:SubjectDistance: 3.39 (3.39 m)
-    Exif:MeteringMode: 5 (pattern)
-    Exif:Flash: 16 (no flash, flash supression)
-    Exif:FocalLength: 7.3 (7.3 mm)
-    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 1
-    Exif:PixelXDimension: 320
-    Exif:PixelYDimension: 240
+    Exif:CompressedBitsPerPixel: 5
+    Exif:CustomRendered: 0 (no)
+    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
+    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
+    Exif:DigitalZoomRatio: 1
+    Exif:ExifVersion: "0220"
+    Exif:ExposureBiasValue: 0
+    Exif:ExposureMode: 0 (auto)
+    Exif:Flash: 16 (no flash, flash supression)
+    Exif:FlashPixVersion: "0100"
+    Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FocalPlaneResolutionUnit: 2 (inches)
     Exif:FocalPlaneXResolution: 12710.8
     Exif:FocalPlaneYResolution: 12725.6
-    Exif:FocalPlaneResolutionUnit: 2 (inches)
-    Exif:SensingMethod: 2 (1-chip color area)
-    Exif:CustomRendered: 0 (no)
-    Exif:ExposureMode: 0 (auto)
-    Exif:WhiteBalance: 0 (auto)
-    Exif:DigitalZoomRatio: 1
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
+    Exif:MeteringMode: 5 (pattern)
+    Exif:PhotographicSensitivity: 75
+    Exif:PixelXDimension: 320
+    Exif:PixelYDimension: 240
     Exif:SceneCaptureType: 1 (landscape)
-    oiio:ColorSpace: "sRGB"
-    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
-    aux:Lens: "7.3-29.2 mm"
-    aux:ApproximateFocusDistance: "339/100"
-    aux:FlashCompensation: "0/1"
-    aux:OwnerName: "Daniel Wyatt"
-    aux:Firmware: "1.00"
-    IPTC:ModifyDate: "2011-08-29T11:54:09-04:00"
-    IPTC:MetadataDate: "2011-08-29T11:54:09-04:00"
-    photoshop:ColorMode: "2"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    Exif:SensingMethod: 2 (1-chip color area)
+    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    Exif:SubjectDistance: 3.39 (3.39 m)
+    Exif:WhiteBalance: 0 (auto)
+    Exif:YCbCrPositioning: 1
     IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
     IPTC:InstanceID: "xmp.iid:F3BDDC0457D2E011BF419187EAB8EBB9"
+    IPTC:MetadataDate: "2011-08-29T11:54:09-04:00"
+    IPTC:ModifyDate: "2011-08-29T11:54:09-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: "2"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:F3BDDC0457D2E011BF419187EAB8EBB9"
-    stEvt:when: "2011-08-29T11:54:09-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:F3BDDC0457D2E011BF419187EAB8EBB9"
     stEvt:parameters: "converted from image/jpeg to application/vnd.adobe.photoshop"
-    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-29T11:54:09-04:00"
     stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
     stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-    PixelAspectRatio: 1
 Reading ../../../../../oiio-images/psd_rgb_8.psd
 ../../../../../oiio-images/psd_rgb_8.psd :  320 x  240, 3 channel, uint8 psd
     SHA-1: 44362B2D9E51C40DF8ABF87CC749B77F2D0D9F4F
     channel list: R, G, B
-    XResolution: 180
-    YResolution: 180
-    ResolutionUnit: 2 (inches)
-    thumbnail_width: 160
-    thumbnail_height: 120
-    thumbnail_nchannels: 3
-    thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ... [57600 x uint8]
+    Artist: "Daniel Wyatt"
+    DateTime: "2007-01-18T15:49:21"
+    ExposureTime: 0.0166667
+    FNumber: 3.5
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
     Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2007-01-18T15:49:21"
-    Artist: "Daniel Wyatt"
-    Exif:YCbCrPositioning: 1
-    ExposureTime: 0.0166667
-    FNumber: 3.5
-    Exif:PhotographicSensitivity: 75
-    Exif:ExifVersion: "0220"
-    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
-    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
-    Exif:CompressedBitsPerPixel: 5
-    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    thumbnail_height: 120
+    thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ... [57600 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 180
+    YResolution: 180
+    aux:ApproximateFocusDistance: "339/100"
+    aux:Firmware: "1.00"
+    aux:FlashCompensation: "0/1"
+    aux:Lens: "7.3-29.2 mm"
+    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
+    aux:OwnerName: "Daniel Wyatt"
     Exif:ApertureValue: 3.625 (f/3.5)
-    Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.8)
-    Exif:SubjectDistance: 3.39 (3.39 m)
-    Exif:MeteringMode: 5 (pattern)
-    Exif:Flash: 16 (no flash, flash supression)
-    Exif:FocalLength: 7.3 (7.3 mm)
-    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 1
-    Exif:PixelXDimension: 320
-    Exif:PixelYDimension: 240
+    Exif:CompressedBitsPerPixel: 5
+    Exif:CustomRendered: 0 (no)
+    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
+    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
+    Exif:DigitalZoomRatio: 1
+    Exif:ExifVersion: "0220"
+    Exif:ExposureBiasValue: 0
+    Exif:ExposureMode: 0 (auto)
+    Exif:Flash: 16 (no flash, flash supression)
+    Exif:FlashPixVersion: "0100"
+    Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FocalPlaneResolutionUnit: 2 (inches)
     Exif:FocalPlaneXResolution: 12710.8
     Exif:FocalPlaneYResolution: 12725.6
-    Exif:FocalPlaneResolutionUnit: 2 (inches)
-    Exif:SensingMethod: 2 (1-chip color area)
-    Exif:CustomRendered: 0 (no)
-    Exif:ExposureMode: 0 (auto)
-    Exif:WhiteBalance: 0 (auto)
-    Exif:DigitalZoomRatio: 1
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
+    Exif:MeteringMode: 5 (pattern)
+    Exif:PhotographicSensitivity: 75
+    Exif:PixelXDimension: 320
+    Exif:PixelYDimension: 240
     Exif:SceneCaptureType: 1 (landscape)
-    oiio:ColorSpace: "sRGB"
-    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
-    aux:Lens: "7.3-29.2 mm"
-    aux:ApproximateFocusDistance: "339/100"
-    aux:FlashCompensation: "0/1"
-    aux:OwnerName: "Daniel Wyatt"
-    aux:Firmware: "1.00"
-    IPTC:ModifyDate: "2011-08-25T17:40-04:00"
-    IPTC:MetadataDate: "2011-08-25T17:40-04:00"
-    photoshop:ColorMode: "3"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    Exif:SensingMethod: 2 (1-chip color area)
+    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    Exif:SubjectDistance: 3.39 (3.39 m)
+    Exif:WhiteBalance: 0 (auto)
+    Exif:YCbCrPositioning: 1
     IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
     IPTC:InstanceID: "xmp.iid:2A93235262CFE011B8B8C52D9599FB9E"
+    IPTC:MetadataDate: "2011-08-25T17:40-04:00"
+    IPTC:ModifyDate: "2011-08-25T17:40-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: "3"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:2A93235262CFE011B8B8C52D9599FB9E"
-    stEvt:when: "2011-08-25T17:40-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:2A93235262CFE011B8B8C52D9599FB9E"
     stEvt:parameters: "converted from image/jpeg to application/vnd.adobe.photoshop"
-    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-25T17:40-04:00"
     stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
     stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-    PixelAspectRatio: 1
 Reading ../../../../../oiio-images/psd_rgb_16.psd
 ../../../../../oiio-images/psd_rgb_16.psd :  320 x  240, 3 channel, uint16 psd
     SHA-1: E42334B0F0684E3C3BF9125F2920B07C44C17B11
     channel list: R, G, B
-    XResolution: 180
-    YResolution: 180
-    ResolutionUnit: 2 (inches)
-    thumbnail_width: 160
-    thumbnail_height: 120
-    thumbnail_nchannels: 3
-    thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ... [57600 x uint8]
+    Artist: "Daniel Wyatt"
+    DateTime: "2007-01-18T15:49:21"
+    ExposureTime: 0.0166667
+    FNumber: 3.5
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
     Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2007-01-18T15:49:21"
-    Artist: "Daniel Wyatt"
-    Exif:YCbCrPositioning: 1
-    ExposureTime: 0.0166667
-    FNumber: 3.5
-    Exif:PhotographicSensitivity: 75
-    Exif:ExifVersion: "0220"
-    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
-    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
-    Exif:CompressedBitsPerPixel: 5
-    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    thumbnail_height: 120
+    thumbnail_image: 219, 223, 226, 221, 225, 228, 225, 229, 232, 229, 233, 236, 232, 236, 239, 235, ... [57600 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 180
+    YResolution: 180
+    aux:ApproximateFocusDistance: "339/100"
+    aux:Firmware: "1.00"
+    aux:FlashCompensation: "0/1"
+    aux:Lens: "7.3-29.2 mm"
+    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
+    aux:OwnerName: "Daniel Wyatt"
     Exif:ApertureValue: 3.625 (f/3.5)
-    Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.8)
-    Exif:SubjectDistance: 3.39 (3.39 m)
-    Exif:MeteringMode: 5 (pattern)
-    Exif:Flash: 16 (no flash, flash supression)
-    Exif:FocalLength: 7.3 (7.3 mm)
-    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 1
-    Exif:PixelXDimension: 320
-    Exif:PixelYDimension: 240
+    Exif:CompressedBitsPerPixel: 5
+    Exif:CustomRendered: 0 (no)
+    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
+    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
+    Exif:DigitalZoomRatio: 1
+    Exif:ExifVersion: "0220"
+    Exif:ExposureBiasValue: 0
+    Exif:ExposureMode: 0 (auto)
+    Exif:Flash: 16 (no flash, flash supression)
+    Exif:FlashPixVersion: "0100"
+    Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FocalPlaneResolutionUnit: 2 (inches)
     Exif:FocalPlaneXResolution: 12710.8
     Exif:FocalPlaneYResolution: 12725.6
-    Exif:FocalPlaneResolutionUnit: 2 (inches)
-    Exif:SensingMethod: 2 (1-chip color area)
-    Exif:CustomRendered: 0 (no)
-    Exif:ExposureMode: 0 (auto)
-    Exif:WhiteBalance: 0 (auto)
-    Exif:DigitalZoomRatio: 1
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
+    Exif:MeteringMode: 5 (pattern)
+    Exif:PhotographicSensitivity: 75
+    Exif:PixelXDimension: 320
+    Exif:PixelYDimension: 240
     Exif:SceneCaptureType: 1 (landscape)
-    oiio:ColorSpace: "sRGB"
-    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
-    aux:Lens: "7.3-29.2 mm"
-    aux:ApproximateFocusDistance: "339/100"
-    aux:FlashCompensation: "0/1"
-    aux:OwnerName: "Daniel Wyatt"
-    aux:Firmware: "1.00"
-    IPTC:ModifyDate: "2011-08-25T17:39:49-04:00"
-    IPTC:MetadataDate: "2011-08-25T17:39:49-04:00"
-    photoshop:ColorMode: "3"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    Exif:SensingMethod: 2 (1-chip color area)
+    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    Exif:SubjectDistance: 3.39 (3.39 m)
+    Exif:WhiteBalance: 0 (auto)
+    Exif:YCbCrPositioning: 1
     IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
     IPTC:InstanceID: "xmp.iid:2993235262CFE011B8B8C52D9599FB9E"
+    IPTC:MetadataDate: "2011-08-25T17:39:49-04:00"
+    IPTC:ModifyDate: "2011-08-25T17:39:49-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: "3"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:2993235262CFE011B8B8C52D9599FB9E"
-    stEvt:when: "2011-08-25T17:39:49-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:2993235262CFE011B8B8C52D9599FB9E"
     stEvt:parameters: "converted from image/jpeg to application/vnd.adobe.photoshop"
-    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-25T17:39:49-04:00"
     stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
     stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-    PixelAspectRatio: 1
 Reading ../../../../../oiio-images/psd_rgb_32.psd
 ../../../../../oiio-images/psd_rgb_32.psd :  320 x  240, 3 channel, float psd
     SHA-1: 63CF8F7B010D24EFD3C41F51C16D8D285FE07313
     channel list: R, G, B
-    XResolution: 180
-    YResolution: 180
-    ResolutionUnit: 2 (inches)
-    thumbnail_width: 160
-    thumbnail_height: 120
-    thumbnail_nchannels: 3
-    thumbnail_image: 217, 225, 227, 221, 226, 229, 224, 229, 232, 228, 233, 236, 231, 236, 239, 233, ... [57600 x uint8]
+    Artist: "Daniel Wyatt"
+    DateTime: "2007-01-18T15:49:21"
+    ExposureTime: 0.0166667
+    FNumber: 3.5
     Make: "Canon"
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
     Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2007-01-18T15:49:21"
-    Artist: "Daniel Wyatt"
-    Exif:YCbCrPositioning: 1
-    ExposureTime: 0.0166667
-    FNumber: 3.5
-    Exif:PhotographicSensitivity: 75
-    Exif:ExifVersion: "0220"
-    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
-    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
-    Exif:CompressedBitsPerPixel: 5
-    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    thumbnail_height: 120
+    thumbnail_image: 217, 225, 227, 221, 226, 229, 224, 229, 232, 228, 233, 236, 231, 236, 239, 233, ... [57600 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 180
+    YResolution: 180
+    aux:ApproximateFocusDistance: "339/100"
+    aux:Firmware: "1.00"
+    aux:FlashCompensation: "0/1"
+    aux:Lens: "7.3-29.2 mm"
+    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
+    aux:OwnerName: "Daniel Wyatt"
     Exif:ApertureValue: 3.625 (f/3.5)
-    Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 2.96875 (f/2.8)
-    Exif:SubjectDistance: 3.39 (3.39 m)
-    Exif:MeteringMode: 5 (pattern)
-    Exif:Flash: 16 (no flash, flash supression)
-    Exif:FocalLength: 7.3 (7.3 mm)
-    Exif:FlashPixVersion: "0100"
     Exif:ColorSpace: 65535
-    Exif:PixelXDimension: 320
-    Exif:PixelYDimension: 240
+    Exif:CompressedBitsPerPixel: 5
+    Exif:CustomRendered: 0 (no)
+    Exif:DateTimeDigitized: "2007:01:18 15:49:21"
+    Exif:DateTimeOriginal: "2007:01:18 15:49:21"
+    Exif:DigitalZoomRatio: 1
+    Exif:ExifVersion: "0220"
+    Exif:ExposureBiasValue: 0
+    Exif:ExposureMode: 0 (auto)
+    Exif:Flash: 16 (no flash, flash supression)
+    Exif:FlashPixVersion: "0100"
+    Exif:FocalLength: 7.3 (7.3 mm)
+    Exif:FocalPlaneResolutionUnit: 2 (inches)
     Exif:FocalPlaneXResolution: 12710.8
     Exif:FocalPlaneYResolution: 12725.6
-    Exif:FocalPlaneResolutionUnit: 2 (inches)
-    Exif:SensingMethod: 2 (1-chip color area)
-    Exif:CustomRendered: 0 (no)
-    Exif:ExposureMode: 0 (auto)
-    Exif:WhiteBalance: 0 (auto)
-    Exif:DigitalZoomRatio: 1
+    Exif:MaxApertureValue: 2.96875 (f/2.8)
+    Exif:MeteringMode: 5 (pattern)
+    Exif:PhotographicSensitivity: 75
+    Exif:PixelXDimension: 320
+    Exif:PixelYDimension: 240
     Exif:SceneCaptureType: 1 (landscape)
-    aux:LensInfo: "7300/1000 29200/1000 0/0 0/0"
-    aux:Lens: "7.3-29.2 mm"
-    aux:ApproximateFocusDistance: "339/100"
-    aux:FlashCompensation: "0/1"
-    aux:OwnerName: "Daniel Wyatt"
-    aux:Firmware: "1.00"
-    IPTC:ModifyDate: "2011-08-25T17:39:38-04:00"
-    IPTC:MetadataDate: "2011-08-25T17:39:38-04:00"
-    photoshop:ColorMode: "3"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1 (Linear RGB Profile)"
+    Exif:SensingMethod: 2 (1-chip color area)
+    Exif:ShutterSpeedValue: 5.90625 (1/59 s)
+    Exif:SubjectDistance: 3.39 (3.39 m)
+    Exif:WhiteBalance: 0 (auto)
+    Exif:YCbCrPositioning: 1
     IPTC:DocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
     IPTC:InstanceID: "xmp.iid:2893235262CFE011B8B8C52D9599FB9E"
+    IPTC:MetadataDate: "2011-08-25T17:39:38-04:00"
+    IPTC:ModifyDate: "2011-08-25T17:39:38-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    photoshop:ColorMode: "3"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1 (Linear RGB Profile)"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:2893235262CFE011B8B8C52D9599FB9E"
-    stEvt:when: "2011-08-25T17:39:38-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
+    stEvt:instanceID: "xmp.iid:2893235262CFE011B8B8C52D9599FB9E"
     stEvt:parameters: "converted from image/jpeg to application/vnd.adobe.photoshop"
-    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-25T17:39:38-04:00"
     stRef:documentID: "E146B3E37A92795EE3EA6577040DE6D5"
+    stRef:instanceID: "xmp.iid:51DA7E112BCDE011A998CBE7B5CCEB92"
     stRef:originalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-    PixelAspectRatio: 1
 Reading ../../../../../oiio-images/psd_rgba_8.psd
 ../../../../../oiio-images/psd_rgba_8.psd :  320 x  240, 4 channel, uint8 psd
     2 subimages: 320x240 [u8,u8,u8,u8], 320x240 [u8,u8,u8,u8]
  subimage  0:  320 x  240, 4 channel, uint8 psd
     SHA-1: 9519DFB5CDF4D8BAC10A20EAE6433A9216885F9D
     channel list: R, G, B, A
+    DateTime: "2011-08-22T22:07:44-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
+    thumbnail_height: 120
+    thumbnail_image: 220, 224, 227, 222, 226, 229, 225, 229, 232, 229, 233, 236, 232, 236, 239, 234, ... [57600 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    thumbnail_width: 160
-    thumbnail_height: 120
-    thumbnail_nchannels: 3
-    thumbnail_image: 220, 224, 227, 222, 226, 229, 225, 229, 232, 229, 233, 236, 232, 236, 239, 234, ... [57600 x uint8]
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:07:44-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 320
     Exif:PixelYDimension: 240
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
     IPTC:MetadataDate: "2011-08-25T17:39:28-04:00"
     IPTC:ModifyDate: "2011-08-25T17:39:28-04:00"
-    photoshop:ColorMode: "3"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:DocumentAncestors: "E146B3E37A92795EE3EA6577040DE6D5"
-    IPTC:InstanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
-    IPTC:DocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:OriginalDocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: "3"
+    photoshop:DocumentAncestors: "E146B3E37A92795EE3EA6577040DE6D5"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
-    stEvt:when: "2011-08-25T17:39:28-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-25T17:39:28-04:00"
  subimage  1:  320 x  240, 4 channel, uint8 psd
     SHA-1: 131A372FD9B67B580B0380A4F754281D5F33E12E
     channel list: R, G, B, A
+    DateTime: "2011-08-22T22:07:44-04:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CS5.1 Windows"
-    DateTime: "2011-08-22T22:07:44-04:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 320
     Exif:PixelYDimension: 240
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
     IPTC:MetadataDate: "2011-08-25T17:39:28-04:00"
     IPTC:ModifyDate: "2011-08-25T17:39:28-04:00"
-    photoshop:ColorMode: "3"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:DocumentAncestors: "E146B3E37A92795EE3EA6577040DE6D5"
-    IPTC:InstanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
-    IPTC:DocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:OriginalDocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: "3"
+    photoshop:DocumentAncestors: "E146B3E37A92795EE3EA6577040DE6D5"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
-    stEvt:when: "2011-08-25T17:39:28-04:00"
-    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:changed: "/"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-25T17:39:28-04:00"
 Reading src/different-mask-size.psd
 src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     4 subimages: 30x90 [u8,u8,u8], 30x90 [u8,u8,u8,u8], 4x93 [u8,u8,u8,u8], 4x93 [u8,u8,u8,u8]
  subimage  0:   30 x   90, 3 channel, uint8 psd
     SHA-1: 42E73C11525323760BF0BEB74370AECC18FC2D92
     channel list: R, G, B
+    DateTime: "2014-02-16T17:20:13+09:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CC 2015.5 (Windows)"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CC 2015.5 (Windows)"
-    DateTime: "2014-02-16T17:20:13+09:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 30
     Exif:PixelYDimension: 90
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
     IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
-    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
-    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: "3"
+    photoshop:DocumentAncestors: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
-    stEvt:when: "2017-01-10T17:55:32+09:00"
-    stEvt:softwareAgent: "Adobe Photoshop CC 2015.5 (Windows)"
     stEvt:changed: "/"
-    photoshop:ColorMode: "3"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:DocumentAncestors: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
+    stEvt:softwareAgent: "Adobe Photoshop CC 2015.5 (Windows)"
+    stEvt:when: "2017-01-10T17:55:32+09:00"
  subimage  1:   30 x   90, 4 channel, uint8 psd
     SHA-1: B2E0D74684B53DF0382EAB0BB1A277438715BB2F
     channel list: R, G, B, A
+    DateTime: "2014-02-16T17:20:13+09:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CC 2015.5 (Windows)"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CC 2015.5 (Windows)"
-    DateTime: "2014-02-16T17:20:13+09:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 30
     Exif:PixelYDimension: 90
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
     IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
-    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
-    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: "3"
+    photoshop:DocumentAncestors: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
-    stEvt:when: "2017-01-10T17:55:32+09:00"
-    stEvt:softwareAgent: "Adobe Photoshop CC 2015.5 (Windows)"
     stEvt:changed: "/"
-    photoshop:ColorMode: "3"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:DocumentAncestors: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
+    stEvt:softwareAgent: "Adobe Photoshop CC 2015.5 (Windows)"
+    stEvt:when: "2017-01-10T17:55:32+09:00"
  subimage  2:    4 x   93, 4 channel, uint8 psd
     SHA-1: 8CE9A2A394ED148194055A22E59E55CE7BDFB3B7
     channel list: R, G, B, A
+    DateTime: "2014-02-16T17:20:13+09:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CC 2015.5 (Windows)"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CC 2015.5 (Windows)"
-    DateTime: "2014-02-16T17:20:13+09:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 30
     Exif:PixelYDimension: 90
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
     IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
-    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
-    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: "3"
+    photoshop:DocumentAncestors: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
-    stEvt:when: "2017-01-10T17:55:32+09:00"
-    stEvt:softwareAgent: "Adobe Photoshop CC 2015.5 (Windows)"
     stEvt:changed: "/"
-    photoshop:ColorMode: "3"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:DocumentAncestors: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
+    stEvt:softwareAgent: "Adobe Photoshop CC 2015.5 (Windows)"
+    stEvt:when: "2017-01-10T17:55:32+09:00"
  subimage  3:    4 x   93, 4 channel, uint8 psd
     SHA-1: 8CE9A2A394ED148194055A22E59E55CE7BDFB3B7
     channel list: R, G, B, A
+    DateTime: "2014-02-16T17:20:13+09:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CC 2015.5 (Windows)"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CC 2015.5 (Windows)"
-    DateTime: "2014-02-16T17:20:13+09:00"
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 30
     Exif:PixelYDimension: 90
-    oiio:ColorSpace: "sRGB"
+    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
     IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
-    IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
-    IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    oiio:ColorSpace: "sRGB"
+    photoshop:ColorMode: "3"
+    photoshop:DocumentAncestors: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
-    stEvt:when: "2017-01-10T17:55:32+09:00"
-    stEvt:softwareAgent: "Adobe Photoshop CC 2015.5 (Windows)"
     stEvt:changed: "/"
-    photoshop:ColorMode: "3"
-    photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:DocumentAncestors: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
+    stEvt:softwareAgent: "Adobe Photoshop CC 2015.5 (Windows)"
+    stEvt:when: "2017-01-10T17:55:32+09:00"
 Reading src/layer-mask.psd
 src/layer-mask.psd   :   10 x   10, 4 channel, uint8 psd
     3 subimages: 10x10 [u8,u8,u8,u8], 8x8 [u8,u8,u8,u8], 9x9 [u8,u8,u8,u8]
  subimage  0:   10 x   10, 4 channel, uint8 psd
     SHA-1: 9C9176DD4E1E7E1DF656D39DB7E1506E1E1260F3
     channel list: R, G, B, A
+    DateTime: "2017-07-13T10:26:10+09:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CC 2017 (Windows)"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CC 2017 (Windows)"
-    DateTime: "2017-07-13T10:26:10+09:00"
     Exif:ColorSpace: 65535
     Exif:PixelXDimension: 10
     Exif:PixelYDimension: 10
+    IPTC:DocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
+    IPTC:InstanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
     IPTC:MetadataDate: "2017-07-13T11:42:54+09:00"
     IPTC:ModifyDate: "2017-07-13T11:42:54+09:00"
-    IPTC:InstanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
-    IPTC:DocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
     IPTC:OriginalDocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
+    photoshop:ColorMode: "3"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
-    stEvt:when: "2017-07-13T11:42:54+09:00"
-    stEvt:softwareAgent: "Adobe Photoshop CC 2017 (Windows)"
     stEvt:changed: "/"
-    photoshop:ColorMode: "3"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
+    stEvt:softwareAgent: "Adobe Photoshop CC 2017 (Windows)"
+    stEvt:when: "2017-07-13T11:42:54+09:00"
  subimage  1:    8 x    8, 4 channel, uint8 psd
     SHA-1: D1803D25687AA8C80C50AC74CCD47B1C59865B2F
     channel list: R, G, B, A
+    DateTime: "2017-07-13T10:26:10+09:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CC 2017 (Windows)"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CC 2017 (Windows)"
-    DateTime: "2017-07-13T10:26:10+09:00"
     Exif:ColorSpace: 65535
     Exif:PixelXDimension: 10
     Exif:PixelYDimension: 10
+    IPTC:DocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
+    IPTC:InstanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
     IPTC:MetadataDate: "2017-07-13T11:42:54+09:00"
     IPTC:ModifyDate: "2017-07-13T11:42:54+09:00"
-    IPTC:InstanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
-    IPTC:DocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
     IPTC:OriginalDocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
+    photoshop:ColorMode: "3"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
-    stEvt:when: "2017-07-13T11:42:54+09:00"
-    stEvt:softwareAgent: "Adobe Photoshop CC 2017 (Windows)"
     stEvt:changed: "/"
-    photoshop:ColorMode: "3"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
+    stEvt:softwareAgent: "Adobe Photoshop CC 2017 (Windows)"
+    stEvt:when: "2017-07-13T11:42:54+09:00"
  subimage  2:    9 x    9, 4 channel, uint8 psd
     SHA-1: 6BEB9ABA4756704D8A330EA3B8F79640F3D88088
     channel list: R, G, B, A
+    DateTime: "2017-07-13T10:26:10+09:00"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: 2 (inches)
+    Software: "Adobe Photoshop CC 2017 (Windows)"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: 2 (inches)
-    Orientation: 1 (normal)
-    Software: "Adobe Photoshop CC 2017 (Windows)"
-    DateTime: "2017-07-13T10:26:10+09:00"
     Exif:ColorSpace: 65535
     Exif:PixelXDimension: 10
     Exif:PixelYDimension: 10
+    IPTC:DocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
+    IPTC:InstanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
     IPTC:MetadataDate: "2017-07-13T11:42:54+09:00"
     IPTC:ModifyDate: "2017-07-13T11:42:54+09:00"
-    IPTC:InstanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
-    IPTC:DocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
     IPTC:OriginalDocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
+    photoshop:ColorMode: "3"
     rdf:parseType: "Resource"
     stEvt:action: "saved"
-    stEvt:instanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
-    stEvt:when: "2017-07-13T11:42:54+09:00"
-    stEvt:softwareAgent: "Adobe Photoshop CC 2017 (Windows)"
     stEvt:changed: "/"
-    photoshop:ColorMode: "3"
-    PixelAspectRatio: 1
+    stEvt:instanceID: "xmp.iid:ddf40b95-b12c-744e-a1a9-5e7724fe4ca9"
+    stEvt:softwareAgent: "Adobe Photoshop CC 2017 (Windows)"
+    stEvt:when: "2017-07-13T11:42:54+09:00"

--- a/testsuite/ptex/ref/out.txt
+++ b/testsuite/ptex/ref/out.txt
@@ -6,61 +6,61 @@ src/triangle.ptx     :    4 x    4, 3 channel, float ptex
     SHA-1: 7BC2F942597DAEB92D3E51C8C72EA9C957F5A891
     channel list: R, G, B
     tile size: 4 x 4
-    ptex:meshType: "triangle"
     wrapmode: "clamp,clamp"
+    ptex:meshType: "triangle"
  subimage  1:    4 x    4, 3 channel, float ptex
     MIP-map levels: 4x4 2x2 1x1
     SHA-1: 2E813D8DAA6013C7DFE8EF84E56B6BD9BEA7F93B
     channel list: R, G, B
     tile size: 4 x 4
-    ptex:meshType: "triangle"
     wrapmode: "clamp,clamp"
+    ptex:meshType: "triangle"
  subimage  2:    4 x    4, 3 channel, float ptex
     MIP-map levels: 4x4 2x2 1x1
     SHA-1: 79B3511C35A63D9AD8EF2691E76DE191103CF450
     channel list: R, G, B
     tile size: 4 x 4
-    ptex:meshType: "triangle"
     wrapmode: "clamp,clamp"
+    ptex:meshType: "triangle"
  subimage  3:    4 x    4, 3 channel, float ptex
     MIP-map levels: 4x4 2x2 1x1
     SHA-1: E5AEE2FB805B38C351034D4FECEF603AD8042ABE
     channel list: R, G, B
     tile size: 4 x 4
-    ptex:meshType: "triangle"
     wrapmode: "clamp,clamp"
+    ptex:meshType: "triangle"
  subimage  4:    4 x    4, 3 channel, float ptex
     MIP-map levels: 4x4 2x2 1x1
     SHA-1: 749BBBD8B925A6F78B9A307AFDF56ACAE8E0B7E1
     channel list: R, G, B
     tile size: 4 x 4
-    ptex:meshType: "triangle"
     wrapmode: "clamp,clamp"
+    ptex:meshType: "triangle"
  subimage  5:    4 x    4, 3 channel, float ptex
     MIP-map levels: 4x4 2x2 1x1
     SHA-1: 2125A335891CB63F42574D4CDE73B00A81530D00
     channel list: R, G, B
     tile size: 4 x 4
-    ptex:meshType: "triangle"
     wrapmode: "clamp,clamp"
+    ptex:meshType: "triangle"
  subimage  6:    4 x    4, 3 channel, float ptex
     MIP-map levels: 4x4 2x2 1x1
     SHA-1: F4F98B602AC70B7FD5021A1493E769526927AB04
     channel list: R, G, B
     tile size: 4 x 4
-    ptex:meshType: "triangle"
     wrapmode: "clamp,clamp"
+    ptex:meshType: "triangle"
  subimage  7:    4 x    4, 3 channel, float ptex
     MIP-map levels: 4x4 2x2 1x1
     SHA-1: EAC7068342FC9F973BE55178218E9B6191154C95
     channel list: R, G, B
     tile size: 4 x 4
-    ptex:meshType: "triangle"
     wrapmode: "clamp,clamp"
+    ptex:meshType: "triangle"
  subimage  8:    4 x    4, 3 channel, float ptex
     MIP-map levels: 4x4 2x2 1x1
     SHA-1: 36A0877272CDB3322250E4097CCF09CDFCEA3F1C
     channel list: R, G, B
     tile size: 4 x 4
-    ptex:meshType: "triangle"
     wrapmode: "clamp,clamp"
+    ptex:meshType: "triangle"

--- a/testsuite/python-imagespec/ref/out-python3.txt
+++ b/testsuite/python-imagespec/ref/out-python3.txt
@@ -143,11 +143,11 @@ serialize(text, human):
     full/display size: 1280 x 960
     full/display origin: 4, 5
     tile size: 32 x 64
-    foo_str: "blah"
-    foo_int: 14
     foo_float: 3.14
-    foo_vector: 1 0 11
+    foo_int: 14
     foo_matrix: 1 0 0 0 0 2 0 0 0 0 1 0 1 2 3 1
+    foo_str: "blah"
+    foo_vector: 1 0 11
 
 Testing construction from ROI:
   resolution (width,height,depth) =  640 480 1

--- a/testsuite/python-imagespec/ref/out.txt
+++ b/testsuite/python-imagespec/ref/out.txt
@@ -143,11 +143,11 @@ serialize(text, human):
     full/display size: 1280 x 960
     full/display origin: 4, 5
     tile size: 32 x 64
-    foo_str: "blah"
-    foo_int: 14
     foo_float: 3.14
-    foo_vector: 1 0 11
+    foo_int: 14
     foo_matrix: 1 0 0 0 0 2 0 0 0 0 1 0 1 2 3 1
+    foo_str: "blah"
+    foo_vector: 1 0 11
 
 Testing construction from ROI:
   resolution (width,height,depth) =  640 480 1

--- a/testsuite/rational/ref/out.txt
+++ b/testsuite/rational/ref/out.txt
@@ -2,10 +2,6 @@ Reading src/test.exr
 src/test.exr         :   64 x   64, 3 channel, half openexr
     SHA-1: 8B72B6EA35D9E5CFBD3AAE08D7204FBEF3895FAA
     channel list: R, G, B
-    oiio:ColorSpace: "Linear"
-    compression: "none"
-    Exif:ImageHistory: "oiiotool cropped-stripped-Isabella.0.exr -cut 64x64+0+0 -o test.exr"
-    Software: "OpenImageIO 1.8.5dev : oiiotool cropped-stripped-Isabella.0.exr -cut 64x64+0+0 -o test.exr"
     acesImageContainerFlag: 1
     adoptedNeutral: 0.32168 0.33767
     cameraFirmwareVersion: "23192"
@@ -14,7 +10,6 @@ src/test.exr         :   64 x   64, 3 channel, half openexr
     cameraMake: "ARRI"
     cameraModel: "Alexa EV"
     cameraSerialNumber: "2719"
-    DateTime: "2000-01-01 01:00:17"
     captureRate: 24000/1000 (24)
     chromaticities: 0.7347, 0.2653, 0, 1, 0.0001, -0.077, 0.32168, 0.33767
     com.arri.camera.AmcVersion: 0
@@ -37,12 +32,14 @@ src/test.exr         :   64 x   64, 3 channel, half openexr
     com.arri.camera.Variframe: 0
     com.arri.camera.WbFactor: 1.68334 1 1.42
     com.arri.camera.WbTintCc: -1
-    ImageDescription: "ARC3_3.5.0.8_ARRIRAW_SDK_Version_5.4.0.b7"
+    compression: "none"
+    DateTime: "2000-01-01 01:00:17"
     ExposureTime: 0.02
     focalLength: 100
     focus: 3.969
     framesPerSecond: 24000/1000 (24)
     imageCounter: 112782
+    ImageDescription: "ARC3_3.5.0.8_ARRIRAW_SDK_Version_5.4.0.b7"
     imageRotation: 0
     interim.camera.shutterAngle: 172.8
     interim.camera.wbKelvin: 5500
@@ -62,17 +59,20 @@ src/test.exr         :   64 x   64, 3 channel, half openexr
     reelName: "A004R23J"
     screenWindowCenter: 0 0
     screenWindowWidth: 1
-    smpte:TimeCode: 18356486, 4294967295 (01:18:19:06)
+    Software: "OpenImageIO 1.8.5dev : oiiotool cropped-stripped-Isabella.0.exr -cut 64x64+0+0 -o test.exr"
     timecodeRate: 24
+    Exif:ImageHistory: "oiiotool cropped-stripped-Isabella.0.exr -cut 64x64+0+0 -o test.exr"
+    oiio:ColorSpace: "Linear"
+    smpte:TimeCode: 18356486, 4294967295 (01:18:19:06)
 Comparing "src/test.exr" and "test.exr"
 PASS
 Reading rat2.exr
 rat2.exr             :   64 x   64, 3 channel, float openexr
     SHA-1: 6FECD5769C727E137B7580AE3B1823B06EE6F9D9
     channel list: R, G, B
-    oiio:ColorSpace: "Linear"
     compression: "zip"
     onehalf: 50/100 (0.5)
     PixelAspectRatio: 1
     screenWindowCenter: 0 0
     screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"

--- a/testsuite/raw/ref/out-oldlibraw0.15.txt
+++ b/testsuite/raw/ref/out-oldlibraw0.15.txt
@@ -1,39 +1,39 @@
 ../../../../../oiio-images/raw/RAW_CANON_EOS_7D.CR2 : 5202 x 3465, 3 channel, uint16 raw
     channel list: R, G, B
-    oiio:ColorSpace: "Linear"
-    raw:ColorSpace: "sRGB"
-    raw:Demosaic: "AHD"
-    PixelAspectRatio: 1
+    DateTime: "2009-10-09 14:18:45"
+    ExposureTime: 0.00301213
+    FNumber: 2.82843
     Make: "Canon"
     Model: "EOS 7D"
-    Exif:Flash: 0 (no flash)
-    Software: "Firmware Version 1.0.7"
-    Exif:ISOSpeedRatings: 100
-    ExposureTime: 0.00301213
-    Exif:ShutterSpeedValue: 8.375 (1/331 s)
-    FNumber: 2.82843
-    Exif:ApertureValue: 3 (f/2.8)
-    Exif:FocalLength: 200 (200 mm)
-    DateTime: "2009-10-09 14:18:45"
     Orientation: 1 (normal)
-../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
-    channel list: R, G, B
+    PixelAspectRatio: 1
+    Software: "Firmware Version 1.0.7"
+    Exif:ApertureValue: 3 (f/2.8)
+    Exif:Flash: 0 (no flash)
+    Exif:FocalLength: 200 (200 mm)
+    Exif:ISOSpeedRatings: 100
+    Exif:ShutterSpeedValue: 8.375 (1/331 s)
     oiio:ColorSpace: "Linear"
     raw:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
-    PixelAspectRatio: 1
+../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
+    channel list: R, G, B
+    Artist: "                                    "
+    DateTime: "2008-12-01 14:52:13"
+    ExposureTime: 0.02
+    FNumber: 5.6
     Make: "NIKON"
     Model: "D3X"
-    Exif:Flash: 0 (no flash)
-    Exif:ISOSpeedRatings: 100
-    ExposureTime: 0.02
-    Exif:ShutterSpeedValue: 5.64386 (1/49 s)
-    FNumber: 5.6
-    Exif:ApertureValue: 4.97085 (f/5.6)
-    Exif:FocalLength: 70 (70 mm)
-    DateTime: "2008-12-01 14:52:13"
-    Artist: "                                    "
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    Exif:ApertureValue: 4.97085 (f/5.6)
+    Exif:Flash: 0 (no flash)
+    Exif:FocalLength: 70 (70 mm)
+    Exif:ISOSpeedRatings: 100
+    Exif:ShutterSpeedValue: 5.64386 (1/49 s)
+    oiio:ColorSpace: "Linear"
+    raw:ColorSpace: "sRGB"
+    raw:Demosaic: "AHD"
 Comparing "RAW_CANON_EOS_7D.CR2.tif" and "ref/RAW_CANON_EOS_7D.CR2.tif"
 PASS
 Comparing "RAW_NIKON_D3X.NEF.tif" and "ref/RAW_NIKON_D3X.NEF.tif"

--- a/testsuite/raw/ref/out.txt
+++ b/testsuite/raw/ref/out.txt
@@ -1,179 +1,85 @@
 ../../../../../oiio-images/raw/RAW_CANON_EOS_7D.CR2 : 5202 x 3465, 3 channel, uint16 raw
     channel list: R, G, B
+    DateTime: "2009-10-09 14:18:45"
+    ExposureTime: 0.003125
+    FNumber: 2.8
     Make: "Canon"
     Model: "EOS 7D"
     Orientation: 1 (normal)
-    XResolution: 72/1 (72)
-    YResolution: 72/1 (72)
-    ResolutionUnit: 2 (inches)
-    DateTime: "2009-10-09 14:18:45"
-    Artist: ""
-    Copyright: ""
-    ExposureTime: 0.003125
-    FNumber: 2.8
-    Exif:ExposureProgram: 3 (aperture priority)
-    Exif:PhotographicSensitivity: 100
-    Exif:ExifVersion: ""
-    Exif:DateTimeOriginal: "2009:10:09 14:18:45"
-    Exif:DateTimeDigitized: "2009:10:09 14:18:45"
-    Exif:ShutterSpeedValue: 8.32193 (1/319 s)
-    Exif:ApertureValue: 2.97085 (f/2.8)
-    Exif:ExposureBiasValue: 0/1 (0)
-    Exif:MeteringMode: 5 (pattern)
-    Exif:Flash: 16 (no flash, flash supression)
-    Exif:FocalLength: 200 (200 mm)
-    Canon:MacroMode: 2 (normal)
-    Canon:SelfTimer: 0
-    Canon:Quality: 4 (RAW)
-    Canon:FlashMode: 0 (off)
-    Canon:ContinuousDrive: 0 (single)
-    Canon:FocusMode: 0 (one-shot AF)
-    Canon:RecordMode: 6 (CR2)
-    Canon:EasyMode: 1 (Manual)
-    Canon:DigitalZoom: 0 (none)
-    Canon:Contrast: 0
-    Canon:Saturation: 0
-    Canon:Sharpness: 32767
-    Canon:CameraISO: 32767
-    Canon:MeteringMode: 3 (evaluative)
-    Canon:FocusRange: 2 (not known)
-    Canon:AFPoint: 0
-    Canon:ExposureMode: 3 (Aperture-priority AE)
-    Canon:LensType: 224
-    Canon:MaxFocalLength: 200
-    Canon:MinFocalLength: 70
-    Canon:FocalUnits: 1
-    Canon:MaxAperture: 96
-    Canon:MinAperture: 320
-    Canon:FlashActivity: 0
-    Canon:FlashBits: 0 (none)
-    Canon:DisplayAperture: 0
-    Canon:ZoomSourceWidth: 0
-    Canon:ZoomTargetWidth: 0
-    Canon:ManualFlashOutput: 0 (n/a)
-    Canon:ColorTone: 0
-    Canon:SRAWQuality: 0 (n/a)
-    Canon:FocalType: 0
-    Canon:FocalLength: 200
-    Canon:FocalPlaneXSize: 11675
-    Canon:FocalPlaneYSize: 19690
-    Canon:AutoISO: 0
-    Canon:BaseISO: 160
-    Canon:MeasuredEV: 204
-    Canon:TargetAperture: 96
-    Canon:TargetExposureTime: 268
-    Canon:ExposureCompensation: 0
-    Canon:WhiteBalance: 0 (Auto)
-    Canon:SlowShutter: 3 (none)
-    Canon:SequenceNumber: 0
-    Canon:OpticalZoomCode: 8
-    Canon:CameraTemperature: 155
-    Canon:FlashGuideNumber: 0
-    Canon:AFPointsInFocus: 0
-    Canon:ExposureComp: 0
-    Canon:FlashExposureComp: 0
-    Canon:AutoExposureBracketing: 0
-    Canon:AEBBracketValue: 1
-    Canon:ControlMode: 0 (n/a)
-    Canon:FocusDistanceUpper: 0
-    Canon:FocusDistanceLower: 96
-    Canon:FNumber: 268
-    Canon:ExposureTime: 133
-    Canon:MeasuredEV2: 0
-    Canon:BulbDuration: 0
-    Canon:CameraType: 248 (EOS High-end)
-    Canon:AutoRotate: -1 (n/a)
-    Canon:NDFilter: -1 (n/a)
-    Canon:SelfTimer2: -1
-    Canon:FlashOutput: 0
-    Canon:ImageType: "Canon EOS 7D"
-    Canon:FirmwareVersion: "Firmware Version 1.0.7"
-    Canon:OwnerName: ""
-    Canon:SerialNumber: 230101900
-    Canon:ModelID: 2147484240 (OS 7D)
-    Canon:ThumbnailImageValidArea: 0, 159, 7, 112
-    Canon:SerialNumberFormat: 2684354560
-    Canon:LensModel: "EF70-200mm f/2.8L IS USM"
-    Canon:CropInfo: 0, 0, 0, 0
-    Canon:SensorWidth: 5360
-    Canon:SensorHeight: 3516
-    Canon:SensorLeftBorder: 168
-    Canon:SensorTopBorder: 56
-    Canon:SensorRightBorder: 5351
-    Canon:SensorBottomBorder: 3511
-    Canon:BlackMaskLeftBorder: 0
-    Canon:BlackMaskTopBorder: 0
-    Canon:BlackMaskRightBorder: 0
-    Canon:BlackMaskBottomBorder: 0
-    Canon:CustomPictureStyleFileName: ""
-    Exif:SubsecTime: "00"
-    Exif:SubsecTimeOriginal: "00"
-    Exif:SubsecTimeDigitized: "00"
-    Exif:FlashPixVersion: ""
-    Exif:ColorSpace: 1
-    Exif:PixelXDimension: 5184
-    Exif:PixelYDimension: 3456
-    Exif:FocalPlaneXResolution: 5184000/907 (5715.55)
-    Exif:FocalPlaneYResolution: 3456000/595 (5808.4)
-    Exif:FocalPlaneResolutionUnit: 2 (inches)
-    Exif:CustomRendered: 0 (no)
-    Exif:ExposureMode: 0 (auto)
-    Exif:WhiteBalance: 0 (auto)
-    Exif:SceneCaptureType: 0 (standard)
-    oiio:ColorSpace: "Linear"
-    raw:ColorSpace: "sRGB"
-    raw:Demosaic: "AHD"
     PixelAspectRatio: 1
     Software: "Firmware Version 1.0.7"
+    Exif:ApertureValue: 2.97085 (f/2.8)
+    Exif:ColorSpace: 1
+    Exif:CustomRendered: 0 (no)
+    Exif:DateTimeDigitized: "2009:10:09 14:18:45"
+    Exif:DateTimeOriginal: "2009:10:09 14:18:45"
+    Exif:ExifVersion: ""
+    Exif:ExposureBiasValue: 0/1 (0)
+    Exif:ExposureMode: 0 (auto)
+    Exif:ExposureProgram: 3 (aperture priority)
+    Exif:Flash: 16 (no flash, flash supression)
+    Exif:FlashPixVersion: ""
+    Exif:FocalLength: 200 (200 mm)
+    Exif:FocalPlaneResolutionUnit: 2 (inches)
+    Exif:FocalPlaneXResolution: 5184000/907 (5715.55)
+    Exif:FocalPlaneYResolution: 3456000/595 (5808.4)
     Exif:ISOSpeedRatings: 100
+    Exif:MeteringMode: 5 (pattern)
+    Exif:PhotographicSensitivity: 100
+    Exif:PixelXDimension: 5184
+    Exif:PixelYDimension: 3456
+    Exif:SceneCaptureType: 0 (standard)
+    Exif:ShutterSpeedValue: 8.32193 (1/319 s)
+    Exif:SubsecTime: "00"
+    Exif:SubsecTimeDigitized: "00"
+    Exif:SubsecTimeOriginal: "00"
+    Exif:WhiteBalance: 0 (auto)
+    oiio:ColorSpace: "Linear"
+    oiio:MakerNoteOffset: 0
+    raw:ColorSpace: "sRGB"
+    raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
+    Artist: "                                    "
+    DateTime: "2008-12-01 14:52:13"
+    ExposureTime: 0.02
+    FNumber: 5.6
     Make: "Nikon"
     Model: "D3X"
     Orientation: 1 (normal)
-    XResolution: 738263040/16777216 (44.0039)
-    YResolution: 738263040/16777216 (44.0039)
-    ResolutionUnit: 2 (inches)
-    Software: "Ver.1.00 "
-    DateTime: "2008-12-01 14:52:13"
-    Artist: "                                    "
-    Exif:YCbCrPositioning: 2
-    Copyright: "                                                      "
-    ExposureTime: 0.02
-    FNumber: 5.6
-    Exif:ExposureProgram: 3 (aperture priority)
-    Exif:PhotographicSensitivity: 100
-    Exif:DateTimeOriginal: "2008:12:01 14:52:13"
+    PixelAspectRatio: 1
+    Exif:ApertureValue: 4.97085 (f/5.6)
+    Exif:Contrast: 0 (normal)
+    Exif:CustomRendered: 0 (no)
     Exif:DateTimeDigitized: "2008:12:01 14:52:13"
+    Exif:DateTimeOriginal: "2008:12:01 14:52:13"
+    Exif:DigitalZoomRatio: 16777216/16777216 (1)
     Exif:ExposureBiasValue: 0/100663296 (0)
-    Exif:MaxApertureValue: 503316480/167772160 (3)
-    Exif:MeteringMode: 5 (pattern)
-    Exif:LightSource: 0 (unknown)
+    Exif:ExposureMode: 0 (auto)
+    Exif:ExposureProgram: 3 (aperture priority)
     Exif:Flash: 0 (no flash)
     Exif:FocalLength: 70 (70 mm)
-    oiio:MakerNoteOffset: 0
-    Exif:SubsecTime: "00"
-    Exif:SubsecTimeOriginal: "00"
-    Exif:SubsecTimeDigitized: "00"
-    Exif:SensingMethod: 2 (1-chip color area)
-    Exif:CustomRendered: 0 (no)
-    Exif:ExposureMode: 0 (auto)
-    Exif:WhiteBalance: 1 (manual)
-    Exif:DigitalZoomRatio: 16777216/16777216 (1)
     Exif:FocalLengthIn35mmFilm: 70
-    Exif:SceneCaptureType: 0 (standard)
     Exif:GainControl: 0 (none)
-    Exif:Contrast: 0 (normal)
+    Exif:ISOSpeedRatings: 100
+    Exif:LightSource: 0 (unknown)
+    Exif:MaxApertureValue: 503316480/167772160 (3)
+    Exif:MeteringMode: 5 (pattern)
+    Exif:PhotographicSensitivity: 100
     Exif:Saturation: 0 (normal)
+    Exif:SceneCaptureType: 0 (standard)
+    Exif:SensingMethod: 2 (1-chip color area)
     Exif:Sharpness: 0 (normal)
+    Exif:ShutterSpeedValue: 5.64386 (1/49 s)
     Exif:SubjectDistanceRange: 0 (unknown)
+    Exif:SubsecTime: "00"
+    Exif:SubsecTimeDigitized: "00"
+    Exif:SubsecTimeOriginal: "00"
+    Exif:WhiteBalance: 1 (manual)
     oiio:ColorSpace: "Linear"
+    oiio:MakerNoteOffset: 0
     raw:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
-    PixelAspectRatio: 1
-    Exif:ISOSpeedRatings: 100
-    Exif:ShutterSpeedValue: 5.64386 (1/49 s)
-    Exif:ApertureValue: 4.97085 (f/5.6)
 Comparing "RAW_CANON_EOS_7D.CR2.tif" and "ref/RAW_CANON_EOS_7D.CR2.tif"
 PASS
 Comparing "RAW_NIKON_D3X.NEF.tif" and "ref/RAW_NIKON_D3X.NEF.tif"

--- a/testsuite/sgi/ref/out.txt
+++ b/testsuite/sgi/ref/out.txt
@@ -9,8 +9,8 @@ Reading ref/rle-8.sgi
 ref/rle-8.sgi        :  100 x   63, 4 channel, uint8 sgi
     SHA-1: AB45F4C8F7DC146D019C1B6C5FCF45EB86884C81
     channel list: R, G, B, A
-    ImageDescription: "...rnold_SGI_Texture_Crash_Bugreport_01\Default_Pass_Main.1.sgi"
     compression: "rle"
+    ImageDescription: "...rnold_SGI_Texture_Crash_Bugreport_01\Default_Pass_Main.1.sgi"
 Comparing "ref/rle-8.sgi" and "rle-8.sgi"
 PASS
 Reading ref/norle-16.sgi
@@ -24,7 +24,7 @@ Reading ref/rle-16.sgi
 ref/rle-16.sgi       :  100 x   63, 4 channel, uint16 sgi
     SHA-1: 6F0B94D6649760B785381A551E5F08C72712D02D
     channel list: R, G, B, A
-    ImageDescription: "...rnold_SGI_Texture_Crash_Bugreport_01\Default_Pass_Main.1.sgi"
     compression: "rle"
+    ImageDescription: "...rnold_SGI_Texture_Crash_Bugreport_01\Default_Pass_Main.1.sgi"
 Comparing "ref/rle-16.sgi" and "rle-16.sgi"
 PASS

--- a/testsuite/targa-tgautils/ref/out.txt
+++ b/testsuite/targa-tgautils/ref/out.txt
@@ -2,174 +2,174 @@ Reading ../../../../../TGAUTILS/CBW8.TGA
 ../../../../../TGAUTILS/CBW8.TGA :  128 x  128, 1 channel, uint8 targa
     SHA-1: E157488A1D82536C6CC5F38CA2BF3CAA397BE69A
     channel list: Y
-    oiio:BitsPerSample: 8
-    compression: "rle"
-    targa:ImageID: "Truevision(R) Sample Image"
     Artist: "Ricky True"
-    ImageDescription: "Sample 8 bit run length compressed black and white image"
+    compression: "rle"
     DateTime: "1990:03:24 10:00:00"
     DocumentName: "TGA Utilities"
+    ImageDescription: "Sample 8 bit run length compressed black and white image"
     Software: "TGAEdit 2.0"
-    thumbnail_width: 64
     thumbnail_height: 64
-    thumbnail_nchannels: 1
     thumbnail_image: 76, 76, 76, 76, 149, 149, 149, 149, 178, 178, 178, 178, 0, 0, 0, 0, ... [4096 x uint8]
+    thumbnail_nchannels: 1
+    thumbnail_width: 64
+    oiio:BitsPerSample: 8
+    targa:ImageID: "Truevision(R) Sample Image"
 Comparing "../../../../../TGAUTILS/CBW8.TGA" and "CBW8.TGA"
 PASS
 Reading ../../../../../TGAUTILS/CCM8.TGA
 ../../../../../TGAUTILS/CCM8.TGA :  128 x  128, 3 channel, uint2 targa
     SHA-1: C3CFE6424C5A9D88BB212BFE230F5B9875F434C4
     channel list: R, G, B
-    oiio:BitsPerSample: 2
-    compression: "rle"
-    targa:ImageID: "Truevision(R) Sample Image"
     Artist: "Ricky True"
-    ImageDescription: "Sample 8 bit run length compressed color mapped image"
+    compression: "rle"
     DateTime: "1990:03:24 10:00:00"
     DocumentName: "TGA Utilities"
+    ImageDescription: "Sample 8 bit run length compressed color mapped image"
     Software: "TGAEdit 2.0"
-    thumbnail_width: 64
     thumbnail_height: 64
-    thumbnail_nchannels: 3
     thumbnail_image: 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0, 255, 0, 0, ... [12288 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 64
+    oiio:BitsPerSample: 2
+    targa:ImageID: "Truevision(R) Sample Image"
 Comparing "../../../../../TGAUTILS/CCM8.TGA" and "CCM8.TGA"
 PASS
 Reading ../../../../../TGAUTILS/CTC16.TGA
 ../../../../../TGAUTILS/CTC16.TGA :  128 x  128, 3 channel, uint5 targa
     SHA-1: C3CFE6424C5A9D88BB212BFE230F5B9875F434C4
     channel list: R, G, B
-    oiio:BitsPerSample: 5
-    compression: "rle"
-    targa:ImageID: "Truevision(R) Sample Image"
     Artist: "Ricky True"
-    ImageDescription: "Sample 16 bit run length compressed true color image"
+    compression: "rle"
     DateTime: "1990:03:24 10:00:00"
     DocumentName: "TGA Utilities"
+    ImageDescription: "Sample 16 bit run length compressed true color image"
     Software: "TGAEdit 2.0"
-    thumbnail_width: 64
     thumbnail_height: 64
-    thumbnail_nchannels: 3
     thumbnail_image: 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0, 255, 0, 0, ... [12288 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 64
+    oiio:BitsPerSample: 5
+    targa:ImageID: "Truevision(R) Sample Image"
 Comparing "../../../../../TGAUTILS/CTC16.TGA" and "CTC16.TGA"
 PASS
 Reading ../../../../../TGAUTILS/CTC24.TGA
 ../../../../../TGAUTILS/CTC24.TGA :  128 x  128, 3 channel, uint8 targa
     SHA-1: C3CFE6424C5A9D88BB212BFE230F5B9875F434C4
     channel list: R, G, B
-    oiio:BitsPerSample: 8
-    compression: "rle"
-    targa:ImageID: "Truevision(R) Sample Image"
     Artist: "Ricky True"
-    ImageDescription: "Sample 24 bit run length compressed true color image"
+    compression: "rle"
     DateTime: "1990:03:24 10:00:00"
     DocumentName: "TGA Utilities"
+    ImageDescription: "Sample 24 bit run length compressed true color image"
     Software: "TGAEdit 2.0"
-    thumbnail_width: 64
     thumbnail_height: 64
-    thumbnail_nchannels: 3
     thumbnail_image: 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0, 255, 0, 0, ... [12288 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 64
+    oiio:BitsPerSample: 8
+    targa:ImageID: "Truevision(R) Sample Image"
 Comparing "../../../../../TGAUTILS/CTC24.TGA" and "CTC24.TGA"
 PASS
 Reading ../../../../../TGAUTILS/CTC32.TGA
 ../../../../../TGAUTILS/CTC32.TGA :  128 x  128, 4 channel, uint8 targa
     SHA-1: 1ADC95BEBE9EEA8C112D40CD04AB7A8D75C4F961
     channel list: R, G, B, A
-    oiio:BitsPerSample: 8
-    compression: "rle"
-    targa:ImageID: "Truevision(R) Sample Image"
     Artist: "Ricky True"
-    ImageDescription: "Sample 32 bit run length compressed true color image"
+    compression: "rle"
     DateTime: "1990:03:24 10:00:00"
     DocumentName: "TGA Utilities"
+    ImageDescription: "Sample 32 bit run length compressed true color image"
     Software: "TGAEdit 2.0"
-    thumbnail_width: 64
     thumbnail_height: 64
-    thumbnail_nchannels: 4
     thumbnail_image: 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, ... [16384 x uint8]
+    thumbnail_nchannels: 4
+    thumbnail_width: 64
+    oiio:BitsPerSample: 8
+    targa:ImageID: "Truevision(R) Sample Image"
 Comparing "../../../../../TGAUTILS/CTC32.TGA" and "CTC32.TGA"
 PASS
 Reading ../../../../../TGAUTILS/UBW8.TGA
 ../../../../../TGAUTILS/UBW8.TGA :  128 x  128, 1 channel, uint8 targa
     SHA-1: E157488A1D82536C6CC5F38CA2BF3CAA397BE69A
     channel list: Y
-    oiio:BitsPerSample: 8
-    targa:ImageID: "Truevision(R) Sample Image"
     Artist: "Ricky True"
-    ImageDescription: "Sample 8 bit uncompressed black and white image"
     DateTime: "1990:02:23 10:00:00"
     DocumentName: "TGA Utilities"
+    ImageDescription: "Sample 8 bit uncompressed black and white image"
     Software: "TGAEdit 1.30"
-    thumbnail_width: 64
     thumbnail_height: 64
-    thumbnail_nchannels: 1
     thumbnail_image: 76, 76, 76, 76, 149, 149, 149, 149, 178, 178, 178, 178, 0, 0, 0, 0, ... [4096 x uint8]
+    thumbnail_nchannels: 1
+    thumbnail_width: 64
+    oiio:BitsPerSample: 8
+    targa:ImageID: "Truevision(R) Sample Image"
 Comparing "../../../../../TGAUTILS/UBW8.TGA" and "UBW8.TGA"
 PASS
 Reading ../../../../../TGAUTILS/UCM8.TGA
 ../../../../../TGAUTILS/UCM8.TGA :  128 x  128, 3 channel, uint2 targa
     SHA-1: C3CFE6424C5A9D88BB212BFE230F5B9875F434C4
     channel list: R, G, B
-    oiio:BitsPerSample: 2
-    targa:ImageID: "Truevision(R) Sample Image"
     Artist: "Ricky True"
-    ImageDescription: "Sample 8 bit uncompressed color mapped image"
     DateTime: "1990:02:24 10:00:00"
     DocumentName: "TGA Utilities"
+    ImageDescription: "Sample 8 bit uncompressed color mapped image"
     Software: "TGAEdit 1.40"
-    thumbnail_width: 64
     thumbnail_height: 64
-    thumbnail_nchannels: 3
     thumbnail_image: 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0, 255, 0, 0, ... [12288 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 64
+    oiio:BitsPerSample: 2
+    targa:ImageID: "Truevision(R) Sample Image"
 Comparing "../../../../../TGAUTILS/UCM8.TGA" and "UCM8.TGA"
 PASS
 Reading ../../../../../TGAUTILS/UTC16.TGA
 ../../../../../TGAUTILS/UTC16.TGA :  128 x  128, 3 channel, uint5 targa
     SHA-1: C3CFE6424C5A9D88BB212BFE230F5B9875F434C4
     channel list: R, G, B
-    oiio:BitsPerSample: 5
-    targa:ImageID: "Truevision(R) Sample Image"
     Artist: "Ricky True"
-    ImageDescription: "Sample 16 bit uncompressed true color image"
     DateTime: "1990:02:23 10:00:00"
     DocumentName: "TGA Utilities"
+    ImageDescription: "Sample 16 bit uncompressed true color image"
     Software: "TGAEdit 1.30"
-    thumbnail_width: 64
     thumbnail_height: 64
-    thumbnail_nchannels: 3
     thumbnail_image: 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0, 255, 0, 0, ... [12288 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 64
+    oiio:BitsPerSample: 5
+    targa:ImageID: "Truevision(R) Sample Image"
 Comparing "../../../../../TGAUTILS/UTC16.TGA" and "UTC16.TGA"
 PASS
 Reading ../../../../../TGAUTILS/UTC24.TGA
 ../../../../../TGAUTILS/UTC24.TGA :  128 x  128, 3 channel, uint8 targa
     SHA-1: C3CFE6424C5A9D88BB212BFE230F5B9875F434C4
     channel list: R, G, B
-    oiio:BitsPerSample: 8
-    targa:ImageID: "Truevision(R) Sample Image"
     Artist: "Ricky True"
-    ImageDescription: "Sample 24 bit uncompressed true color image"
     DateTime: "1990:02:24 10:00:00"
     DocumentName: "TGA Utilities"
+    ImageDescription: "Sample 24 bit uncompressed true color image"
     Software: "TGAEdit 1.40"
-    thumbnail_width: 64
     thumbnail_height: 64
-    thumbnail_nchannels: 3
     thumbnail_image: 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0, 255, 0, 0, ... [12288 x uint8]
+    thumbnail_nchannels: 3
+    thumbnail_width: 64
+    oiio:BitsPerSample: 8
+    targa:ImageID: "Truevision(R) Sample Image"
 Comparing "../../../../../TGAUTILS/UTC24.TGA" and "UTC24.TGA"
 PASS
 Reading ../../../../../TGAUTILS/UTC32.TGA
 ../../../../../TGAUTILS/UTC32.TGA :  128 x  128, 4 channel, uint8 targa
     SHA-1: 1ADC95BEBE9EEA8C112D40CD04AB7A8D75C4F961
     channel list: R, G, B, A
-    oiio:BitsPerSample: 8
-    targa:ImageID: "Truevision(R) Sample Image"
     Artist: "Ricky True"
-    ImageDescription: "Sample 32 bit uncompressed true color image"
     DateTime: "1990:02:24 10:00:00"
     DocumentName: "TGA Utilities"
+    ImageDescription: "Sample 32 bit uncompressed true color image"
     Software: "TGAEdit 1.40"
-    thumbnail_width: 64
     thumbnail_height: 64
-    thumbnail_nchannels: 4
     thumbnail_image: 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, ... [16384 x uint8]
+    thumbnail_nchannels: 4
+    thumbnail_width: 64
+    oiio:BitsPerSample: 8
+    targa:ImageID: "Truevision(R) Sample Image"
 Comparing "../../../../../TGAUTILS/UTC32.TGA" and "UTC32.TGA"
 PASS

--- a/testsuite/tiff-depths/ref/out.txt
+++ b/testsuite/tiff-depths/ref/out.txt
@@ -2,629 +2,629 @@ Reading ../../../../../libtiffpic/depth/flower-minisblack-02.tif
 ../../../../../libtiffpic/depth/flower-minisblack-02.tif :   73 x   43, 1 channel, uint2 tiff
     SHA-1: F6BD9D10FB0DD8E9AC62DEBBB743A78FC48D3C9B
     channel list: Y
-    oiio:BitsPerSample: 2
+    compression: "none"
+    DocumentName: "flower-minisblack-02.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-minisblack-02.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 2
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 431
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-02.tif" and "flower-minisblack-02.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-minisblack-04.tif
 ../../../../../libtiffpic/depth/flower-minisblack-04.tif :   73 x   43, 1 channel, uint4 tiff
     SHA-1: 8C0CF14B3B585F4B1F249C681BEDEA4CB63E3EDD
     channel list: Y
-    oiio:BitsPerSample: 4
+    compression: "none"
+    DocumentName: "flower-minisblack-04.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-minisblack-04.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 4
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 221
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-04.tif" and "flower-minisblack-04.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-minisblack-06.tif
 ../../../../../libtiffpic/depth/flower-minisblack-06.tif :   73 x   43, 1 channel, uint6 tiff
     SHA-1: AE809BFEF36E3E0047343655231200A916D83492
     channel list: Y
-    oiio:BitsPerSample: 6
+    compression: "none"
+    DocumentName: "flower-minisblack-06.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-minisblack-06.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 6
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 148
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-06.tif" and "flower-minisblack-06.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-minisblack-08.tif
 ../../../../../libtiffpic/depth/flower-minisblack-08.tif :   73 x   43, 1 channel, uint8 tiff
     SHA-1: 1A909C8E70CC479D8A35BAA9BFEDDCBF4BF46FDC
     channel list: Y
-    oiio:BitsPerSample: 8
+    compression: "none"
+    DocumentName: "flower-minisblack-08.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-minisblack-08.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 112
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-08.tif" and "flower-minisblack-08.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-minisblack-10.tif
 ../../../../../libtiffpic/depth/flower-minisblack-10.tif :   73 x   43, 1 channel, uint10 tiff
     SHA-1: E9240FEF19CC8EF5EBBF2EE4A10EDF25E51C67B4
     channel list: Y
-    oiio:BitsPerSample: 10
+    compression: "none"
+    DocumentName: "flower-minisblack-10.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-minisblack-10.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 10
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 89
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-10.tif" and "flower-minisblack-10.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-minisblack-12.tif
 ../../../../../libtiffpic/depth/flower-minisblack-12.tif :   73 x   43, 1 channel, uint12 tiff
     SHA-1: AAE977957ED6AAC647967192A74E4AD55FF75811
     channel list: Y
-    oiio:BitsPerSample: 12
+    compression: "none"
+    DocumentName: "flower-minisblack-12.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-minisblack-12.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 12
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 74
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-12.tif" and "flower-minisblack-12.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-minisblack-14.tif
 ../../../../../libtiffpic/depth/flower-minisblack-14.tif :   73 x   43, 1 channel, uint14 tiff
     SHA-1: C1B9CA21C227EF11626EF0C58BD49769EEF48363
     channel list: Y
-    oiio:BitsPerSample: 14
+    compression: "none"
+    DocumentName: "flower-minisblack-14.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-minisblack-14.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 14
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 64
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-14.tif" and "flower-minisblack-14.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-minisblack-16.tif
 ../../../../../libtiffpic/depth/flower-minisblack-16.tif :   73 x   43, 1 channel, uint16 tiff
     SHA-1: 7EBB74E46C869CA0D6D091183732214B6A75173A
     channel list: Y
-    oiio:BitsPerSample: 16
+    compression: "none"
+    DocumentName: "flower-minisblack-16.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-minisblack-16.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 16
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 56
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-16.tif" and "flower-minisblack-16.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-minisblack-32.tif
 ../../../../../libtiffpic/depth/flower-minisblack-32.tif :   73 x   43, 1 channel, uint tiff
     SHA-1: C98FB1125C7210E380E3F86DFCAEFF49A16742E0
     channel list: Y
-    oiio:BitsPerSample: 32
+    compression: "none"
+    DocumentName: "flower-minisblack-32.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-minisblack-32.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 32
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 1
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 28
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-32.tif" and "flower-minisblack-32.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-palette-02.tif
 ../../../../../libtiffpic/depth/flower-palette-02.tif :   73 x   43, 3 channel, uint8 tiff
     SHA-1: 52B3033465AA01129BAE149FF96CBB49877DAB7C
     channel list: R, G, B
-    oiio:BitsPerSample: 8
+    compression: "none"
+    DocumentName: "flower-palette-02.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-palette-02.tif"
-    tiff:PhotometricInterpretation: 3
-    tiff:ColorSpace: "palette"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
     tiff:BitsPerSample: 2
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
+    tiff:ColorSpace: "palette"
     tiff:Compression: 1
-    compression: "none"
+    tiff:PhotometricInterpretation: 3
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 431
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-palette-02.tif" and "flower-palette-02.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-palette-04.tif
 ../../../../../libtiffpic/depth/flower-palette-04.tif :   73 x   43, 3 channel, uint8 tiff
     SHA-1: C6E40A3D134F1A29E153FE15459D8DE657CB7F9C
     channel list: R, G, B
-    oiio:BitsPerSample: 8
+    compression: "none"
+    DocumentName: "flower-palette-04.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-palette-04.tif"
-    tiff:PhotometricInterpretation: 3
-    tiff:ColorSpace: "palette"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
     tiff:BitsPerSample: 4
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
+    tiff:ColorSpace: "palette"
     tiff:Compression: 1
-    compression: "none"
+    tiff:PhotometricInterpretation: 3
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 221
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-palette-04.tif" and "flower-palette-04.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-palette-08.tif
 ../../../../../libtiffpic/depth/flower-palette-08.tif :   73 x   43, 3 channel, uint8 tiff
     SHA-1: 0ADA355BABFE9866F3D88AF7CA3AAC69D7DC036D
     channel list: R, G, B
-    oiio:BitsPerSample: 8
+    compression: "none"
+    DocumentName: "flower-palette-08.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-palette-08.tif"
-    tiff:PhotometricInterpretation: 3
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
     tiff:ColorSpace: "palette"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
     tiff:Compression: 1
-    compression: "none"
+    tiff:PhotometricInterpretation: 3
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 112
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-palette-08.tif" and "flower-palette-08.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-rgb-contig-02.tif
 ../../../../../libtiffpic/depth/flower-rgb-contig-02.tif :   73 x   43, 3 channel, uint2 tiff
     SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
     channel list: R, G, B
-    oiio:BitsPerSample: 2
+    compression: "none"
+    DocumentName: "flower-rgb-contig-02.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-rgb-contig-02.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 2
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 148
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-02.tif" and "flower-rgb-contig-02.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-rgb-contig-04.tif
 ../../../../../libtiffpic/depth/flower-rgb-contig-04.tif :   73 x   43, 3 channel, uint4 tiff
     SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
     channel list: R, G, B
-    oiio:BitsPerSample: 4
+    compression: "none"
+    DocumentName: "flower-rgb-contig-04.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-rgb-contig-04.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 4
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 74
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-04.tif" and "flower-rgb-contig-04.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-rgb-contig-08.tif
 ../../../../../libtiffpic/depth/flower-rgb-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
     SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
     channel list: R, G, B
-    oiio:BitsPerSample: 8
+    compression: "none"
+    DocumentName: "flower-rgb-contig-08.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-rgb-contig-08.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 37
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-08.tif" and "flower-rgb-contig-08.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-rgb-contig-10.tif
 ../../../../../libtiffpic/depth/flower-rgb-contig-10.tif :   73 x   43, 3 channel, uint10 tiff
     SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
     channel list: R, G, B
-    oiio:BitsPerSample: 10
+    compression: "none"
+    DocumentName: "flower-rgb-contig-10.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-rgb-contig-10.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 10
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 29
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-10.tif" and "flower-rgb-contig-10.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-rgb-contig-12.tif
 ../../../../../libtiffpic/depth/flower-rgb-contig-12.tif :   73 x   43, 3 channel, uint12 tiff
     SHA-1: E61083B50548C7D304A45735452FD05C1814677B
     channel list: R, G, B
-    oiio:BitsPerSample: 12
+    compression: "none"
+    DocumentName: "flower-rgb-contig-12.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-rgb-contig-12.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 12
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 24
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-12.tif" and "flower-rgb-contig-12.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-rgb-contig-14.tif
 ../../../../../libtiffpic/depth/flower-rgb-contig-14.tif :   73 x   43, 3 channel, uint14 tiff
     SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
     channel list: R, G, B
-    oiio:BitsPerSample: 14
+    compression: "none"
+    DocumentName: "flower-rgb-contig-14.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-rgb-contig-14.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 14
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 21
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-14.tif" and "flower-rgb-contig-14.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-rgb-contig-16.tif
 ../../../../../libtiffpic/depth/flower-rgb-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
     SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
     channel list: R, G, B
-    oiio:BitsPerSample: 16
+    compression: "none"
+    DocumentName: "flower-rgb-contig-16.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-rgb-contig-16.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 16
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 18
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-16.tif" and "flower-rgb-contig-16.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-rgb-contig-32.tif
 ../../../../../libtiffpic/depth/flower-rgb-contig-32.tif :   73 x   43, 3 channel, uint tiff
     SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
     channel list: R, G, B
-    oiio:BitsPerSample: 32
+    compression: "none"
+    DocumentName: "flower-rgb-contig-32.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-rgb-contig-32.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 32
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 9
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-32.tif" and "flower-rgb-contig-32.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-rgb-planar-02.tif
 ../../../../../libtiffpic/depth/flower-rgb-planar-02.tif :   73 x   43, 3 channel, uint2 tiff
     SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
     channel list: R, G, B
-    oiio:BitsPerSample: 2
+    compression: "none"
+    DocumentName: "flower-rgb-planar-02.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "separate"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-rgb-planar-02.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 2
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
-    planarconfig: "separate"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 431
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-rgb-planar-02.tif" and "flower-rgb-planar-02.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-rgb-planar-04.tif
 ../../../../../libtiffpic/depth/flower-rgb-planar-04.tif :   73 x   43, 3 channel, uint4 tiff
     SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
     channel list: R, G, B
-    oiio:BitsPerSample: 4
+    compression: "none"
+    DocumentName: "flower-rgb-planar-04.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "separate"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-rgb-planar-04.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 4
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
-    planarconfig: "separate"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 221
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-rgb-planar-04.tif" and "flower-rgb-planar-04.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-rgb-planar-08.tif
 ../../../../../libtiffpic/depth/flower-rgb-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
     SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
     channel list: R, G, B
-    oiio:BitsPerSample: 8
+    compression: "none"
+    DocumentName: "flower-rgb-planar-08.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "separate"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-rgb-planar-08.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
-    planarconfig: "separate"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 112
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-rgb-planar-08.tif" and "flower-rgb-planar-08.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-rgb-planar-10.tif
 ../../../../../libtiffpic/depth/flower-rgb-planar-10.tif :   73 x   43, 3 channel, uint10 tiff
     SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
     channel list: R, G, B
-    oiio:BitsPerSample: 10
+    compression: "none"
+    DocumentName: "flower-rgb-planar-10.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "separate"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-rgb-planar-10.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 10
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
-    planarconfig: "separate"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 89
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-rgb-planar-10.tif" and "flower-rgb-planar-10.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-rgb-planar-12.tif
 ../../../../../libtiffpic/depth/flower-rgb-planar-12.tif :   73 x   43, 3 channel, uint12 tiff
     SHA-1: E61083B50548C7D304A45735452FD05C1814677B
     channel list: R, G, B
-    oiio:BitsPerSample: 12
+    compression: "none"
+    DocumentName: "flower-rgb-planar-12.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "separate"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-rgb-planar-12.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 12
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
-    planarconfig: "separate"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 74
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-rgb-planar-12.tif" and "flower-rgb-planar-12.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-rgb-planar-14.tif
 ../../../../../libtiffpic/depth/flower-rgb-planar-14.tif :   73 x   43, 3 channel, uint14 tiff
     SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
     channel list: R, G, B
-    oiio:BitsPerSample: 14
+    compression: "none"
+    DocumentName: "flower-rgb-planar-14.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "separate"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-rgb-planar-14.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 14
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
-    planarconfig: "separate"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 64
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-rgb-planar-14.tif" and "flower-rgb-planar-14.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-rgb-planar-16.tif
 ../../../../../libtiffpic/depth/flower-rgb-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
     SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
     channel list: R, G, B
-    oiio:BitsPerSample: 16
+    compression: "none"
+    DocumentName: "flower-rgb-planar-16.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "separate"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-rgb-planar-16.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 16
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
-    planarconfig: "separate"
-    tiff:Compression: 1
-    compression: "none"
     tiff:RowsPerStrip: 56
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-rgb-planar-16.tif" and "flower-rgb-planar-16.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-separated-contig-08.tif
 ../../../../../libtiffpic/depth/flower-separated-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
     SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
     channel list: R, G, B
-    oiio:BitsPerSample: 8
+    compression: "none"
+    DocumentName: "flower-separated-contig-08.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-separated-contig-08.tif"
-    tiff:PhotometricInterpretation: 5
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
     tiff:ColorSpace: "CMYK"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
     tiff:Compression: 1
-    compression: "none"
+    tiff:PhotometricInterpretation: 5
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 28
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-separated-contig-08.tif" and "flower-separated-contig-08.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-separated-contig-16.tif
 ../../../../../libtiffpic/depth/flower-separated-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
     SHA-1: A5C53C7628B01F12DCAE09A42D8B15433644C54C
     channel list: R, G, B
-    oiio:BitsPerSample: 16
+    compression: "none"
+    DocumentName: "flower-separated-contig-16.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-separated-contig-16.tif"
-    tiff:PhotometricInterpretation: 5
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 16
     tiff:ColorSpace: "CMYK"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
     tiff:Compression: 1
-    compression: "none"
+    tiff:PhotometricInterpretation: 5
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 14
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-separated-contig-16.tif" and "flower-separated-contig-16.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-separated-planar-08.tif
 ../../../../../libtiffpic/depth/flower-separated-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
     SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
     channel list: R, G, B
-    oiio:BitsPerSample: 8
+    compression: "none"
+    DocumentName: "flower-separated-planar-08.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "separate"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-separated-planar-08.tif"
-    tiff:PhotometricInterpretation: 5
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
     tiff:ColorSpace: "CMYK"
-    tiff:PlanarConfiguration: 2
-    planarconfig: "separate"
     tiff:Compression: 1
-    compression: "none"
+    tiff:PhotometricInterpretation: 5
+    tiff:PlanarConfiguration: 2
     tiff:RowsPerStrip: 112
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-separated-planar-08.tif" and "flower-separated-planar-08.tif"
 PASS
 Reading ../../../../../libtiffpic/depth/flower-separated-planar-16.tif
 ../../../../../libtiffpic/depth/flower-separated-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
     SHA-1: A5C53C7628B01F12DCAE09A42D8B15433644C54C
     channel list: R, G, B
-    oiio:BitsPerSample: 16
+    compression: "none"
+    DocumentName: "flower-separated-planar-16.tif"
     Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
+    PixelAspectRatio: 1
+    planarconfig: "separate"
     ResolutionUnit: "in"
     Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
-    DocumentName: "flower-separated-planar-16.tif"
-    tiff:PhotometricInterpretation: 5
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 16
     tiff:ColorSpace: "CMYK"
-    tiff:PlanarConfiguration: 2
-    planarconfig: "separate"
     tiff:Compression: 1
-    compression: "none"
+    tiff:PhotometricInterpretation: 5
+    tiff:PlanarConfiguration: 2
     tiff:RowsPerStrip: 56
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/depth/flower-separated-planar-16.tif" and "flower-separated-planar-16.tif"
 PASS
 Comparing "cmyk_as_cmyk.tif" and "ref/cmyk_as_cmyk.tif"

--- a/testsuite/tiff-suite/ref/out-alt.txt
+++ b/testsuite/tiff-suite/ref/out-alt.txt
@@ -2,17 +2,17 @@ Reading ../../../../../libtiffpic/cramps.tif
 ../../../../../libtiffpic/cramps.tif :  800 x  607, 1 channel, uint8 tiff
     SHA-1: A1CA337CBB22D84410BBE710BB31D5D6646CF839
     channel list: Y
-    oiio:BitsPerSample: 8
+    compression: "packbits"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     XResolution: 72
     YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:Compression: 32773
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 32773
-    compression: "packbits"
     tiff:RowsPerStrip: 12
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/cramps.tif" and "cramps.tif"
 PASS
 Reading ../../../../../libtiffpic/cramps-tile.tif
@@ -20,13 +20,13 @@ Reading ../../../../../libtiffpic/cramps-tile.tif
     SHA-1: A1CA337CBB22D84410BBE710BB31D5D6646CF839
     channel list: Y
     tile size: 256 x 256
-    oiio:BitsPerSample: 8
+    compression: "none"
     Orientation: 1 (normal)
+    planarconfig: "contig"
+    oiio:BitsPerSample: 8
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
 Comparing "../../../../../libtiffpic/cramps-tile.tif" and "cramps-tile.tif"
 PASS
 Comparing "../../../../../libtiffpic/cramps-tile.tif" and "../../../../../libtiffpic/cramps.tif"
@@ -37,110 +37,110 @@ Reading ../../../../../libtiffpic/dscf0013.tif
  subimage  0:  640 x  480, 3 channel, uint8 tiff
     SHA-1: 5A28EA8AB0FD8E03EA11BF008E842CFEB42A9716
     channel list: R, G, B
-    oiio:BitsPerSample: 8
-    Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
-    ResolutionUnit: "in"
-    Make: "FUJIFILM"
-    Model: "MX-2900ZOOM"
-    Software: "Digital Camera MX-2900ZOOM Ver1.00"
+    compression: "none"
     Copyright: "          "
     DateTime: "2004:11:10 00:00:31"
-    Exif:YCbCrPositioning: 2
-    tiff:PhotometricInterpretation: 6
-    tiff:ColorSpace: "YCbCr"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
-    tiff:RowsPerStrip: 15
-    PixelAspectRatio: 1
     FNumber: 3.4
-    Exif:ExposureProgram: 2 (normal program)
-    Exif:DateTimeOriginal: "2004:11:10 00:00:31"
-    Exif:DateTimeDigitized: "2004:11:10 00:00:31"
-    Exif:ShutterSpeedValue: 6.5 (1/90 s)
+    Make: "FUJIFILM"
+    Model: "MX-2900ZOOM"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "Digital Camera MX-2900ZOOM Ver1.00"
+    XResolution: 72
+    YResolution: 72
     Exif:ApertureValue: 3.53 (f/3.4)
     Exif:BrightnessValue: -0.4
+    Exif:ColorSpace: 1
+    Exif:DateTimeDigitized: "2004:11:10 00:00:31"
+    Exif:DateTimeOriginal: "2004:11:10 00:00:31"
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 3.53 (f/3.4)
-    Exif:MeteringMode: 1 (average)
+    Exif:ExposureProgram: 2 (normal program)
     Exif:Flash: 1 (flash fired)
     Exif:FocalLength: 7.4 (7.4 mm)
-    Exif:ColorSpace: 1
+    Exif:FocalPlaneResolutionUnit: 3 (cm)
     Exif:FocalPlaneXResolution: 847
     Exif:FocalPlaneYResolution: 847
-    Exif:FocalPlaneResolutionUnit: 3 (cm)
+    Exif:MaxApertureValue: 3.53 (f/3.4)
+    Exif:MeteringMode: 1 (average)
     Exif:SensingMethod: 2 (1-chip color area)
+    Exif:ShutterSpeedValue: 6.5 (1/90 s)
+    Exif:YCbCrPositioning: 2
+    oiio:BitsPerSample: 8
     oiio:ColorSpace: "sRGB"
+    tiff:ColorSpace: "YCbCr"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 6
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 15
  subimage  1:  160 x  120, 3 channel, uint8 tiff
     SHA-1: D7C5E398DC47C1FF619F62650EE2F8B303ADCDDC
     channel list: R, G, B
-    oiio:BitsPerSample: 8
+    compression: "none"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: "in"
     Exif:YCbCrPositioning: 2
-    tiff:PhotometricInterpretation: 6
+    oiio:BitsPerSample: 8
     tiff:ColorSpace: "YCbCr"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
     tiff:Compression: 1
-    compression: "none"
+    tiff:PhotometricInterpretation: 6
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 25
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/dscf0013.tif" and "dscf0013.tif"
 PASS
 Reading ../../../../../libtiffpic/fax2d.tif
 ../../../../../libtiffpic/fax2d.tif : 1728 x 1082, 1 channel, uint1 tiff
     SHA-1: A57ECEDA78607AE81ABA344E4456EDB1E34A6CB0
     channel list: Y
-    oiio:BitsPerSample: 1
+    compression: "ccittfax3"
     Orientation: 1 (normal)
-    XResolution: 204
-    YResolution: 98
+    PixelAspectRatio: 0.480392
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "fax2tiff"
+    XResolution: 204
+    YResolution: 98
+    oiio:BitsPerSample: 1
+    tiff:Compression: 3
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 3
-    compression: "ccittfax3"
-    PixelAspectRatio: 0.480392
 Comparing "../../../../../libtiffpic/fax2d.tif" and "fax2d.tif"
 PASS
 Reading ../../../../../libtiffpic/g3test.tif
 ../../../../../libtiffpic/g3test.tif : 1728 x 1103, 1 channel, uint1 tiff
     SHA-1: D674B2BB7707525F8DD678E81CAF50EE3A15D1E8
     channel list: Y
-    oiio:BitsPerSample: 1
+    compression: "ccittfax3"
     Orientation: 1 (normal)
-    XResolution: 204
-    YResolution: 98
+    PixelAspectRatio: 0.480392
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "fax2tiff"
+    XResolution: 204
+    YResolution: 98
+    oiio:BitsPerSample: 1
+    tiff:Compression: 3
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 3
-    compression: "ccittfax3"
-    PixelAspectRatio: 0.480392
 Comparing "../../../../../libtiffpic/g3test.tif" and "g3test.tif"
 PASS
 Reading ../../../../../libtiffpic/jello.tif
 ../../../../../libtiffpic/jello.tif :  256 x  192, 3 channel, uint8 tiff
     SHA-1: 41CD2AD5CA87F8CCBF7B181B58BEF136E6C64E1A
     channel list: R, G, B
-    oiio:BitsPerSample: 8
-    Orientation: 1 (normal)
-    tiff:PhotometricInterpretation: 3
-    tiff:ColorSpace: "palette"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 32773
     compression: "packbits"
+    Orientation: 1 (normal)
+    planarconfig: "contig"
+    oiio:BitsPerSample: 8
+    tiff:ColorSpace: "palette"
+    tiff:Compression: 32773
+    tiff:PhotometricInterpretation: 3
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 32
 Comparing "../../../../../libtiffpic/jello.tif" and "jello.tif"
 PASS
@@ -148,101 +148,101 @@ Reading ../../../../../libtiffpic/off_l16.tif
 ../../../../../libtiffpic/off_l16.tif :  333 x  225, 1 channel, uint8 tiff
     SHA-1: 430C2B645099A186CC7AE28C5DA697297E40A4D5
     channel list: Y
-    oiio:BitsPerSample: 16
+    compression: "sgilog"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: "in"
-    tiff:PhotometricInterpretation: 32844
+    oiio:BitsPerSample: 16
     tiff:ColorSpace: "LOGL"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
     tiff:Compression: 34676
-    compression: "sgilog"
+    tiff:PhotometricInterpretation: 32844
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 8
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/off_l16.tif" and "off_l16.tif"
 PASS
 Reading ../../../../../libtiffpic/off_luv24.tif
 ../../../../../libtiffpic/off_luv24.tif :  333 x  225, 3 channel, uint8 tiff
     SHA-1: CBB091760E8D9859F3DB5D5A168AF90D0C709A0B
     channel list: R, G, B
-    oiio:BitsPerSample: 16
+    compression: "sgilog24"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: "in"
-    tiff:PhotometricInterpretation: 32845
+    oiio:BitsPerSample: 16
     tiff:ColorSpace: "LOGLUV"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
     tiff:Compression: 34677
-    compression: "sgilog24"
+    tiff:PhotometricInterpretation: 32845
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 8
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/off_luv24.tif" and "off_luv24.tif"
 PASS
 Reading ../../../../../libtiffpic/off_luv32.tif
 ../../../../../libtiffpic/off_luv32.tif :  333 x  225, 3 channel, uint8 tiff
     SHA-1: FA6245246E4E92A0D8112249976843128338DBDD
     channel list: R, G, B
-    oiio:BitsPerSample: 16
+    compression: "sgilog"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: "in"
-    tiff:PhotometricInterpretation: 32845
+    oiio:BitsPerSample: 16
     tiff:ColorSpace: "LOGLUV"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
     tiff:Compression: 34676
-    compression: "sgilog"
+    tiff:PhotometricInterpretation: 32845
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 8
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/off_luv32.tif" and "off_luv32.tif"
 PASS
 Reading ../../../../../libtiffpic/pc260001.tif
 ../../../../../libtiffpic/pc260001.tif :  640 x  480, 3 channel, uint8 tiff
     SHA-1: F34868893B33383BE653ADA9FC054C8EA61BAC53
     channel list: R, G, B
-    oiio:BitsPerSample: 8
-    ImageDescription: "OLYMPUS DIGITAL CAMERA         "
-    Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
-    ResolutionUnit: "in"
-    Make: "OLYMPUS IMAGING CORP."
-    Model: "C7070WZ"
-    Software: "Version 1.0"
-    DateTime: "2005:12:26 17:09:35"
-    tiff:PhotometricInterpretation: 2
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
     compression: "none"
-    tiff:RowsPerStrip: 32
-    PixelAspectRatio: 1
+    DateTime: "2005:12:26 17:09:35"
     ExposureTime: 0.0125
     FNumber: 5.6
-    Exif:ExposureProgram: 2 (normal program)
-    Exif:DateTimeOriginal: "2005:12:26 17:09:35"
+    ImageDescription: "OLYMPUS DIGITAL CAMERA         "
+    Make: "OLYMPUS IMAGING CORP."
+    Model: "C7070WZ"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "Version 1.0"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:Contrast: 2 (hard)
+    Exif:CustomRendered: 0 (no)
     Exif:DateTimeDigitized: "2005:12:26 17:09:35"
+    Exif:DateTimeOriginal: "2005:12:26 17:09:35"
+    Exif:DigitalZoomRatio: 0
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 3 (f/2.8)
-    Exif:MeteringMode: 5 (pattern)
-    Exif:LightSource: 0 (unknown)
+    Exif:ExposureMode: 0 (auto)
+    Exif:ExposureProgram: 2 (normal program)
     Exif:Flash: 89 (flash fired, auto flash, red-eye reduction)
     Exif:FocalLength: 17.8 (17.8 mm)
-    Exif:ColorSpace: 1
-    Exif:CustomRendered: 0 (no)
-    Exif:ExposureMode: 0 (auto)
-    Exif:WhiteBalance: 0 (auto)
-    Exif:DigitalZoomRatio: 0
-    Exif:SceneCaptureType: 0 (standard)
-    Exif:Contrast: 2 (hard)
+    Exif:LightSource: 0 (unknown)
+    Exif:MaxApertureValue: 3 (f/2.8)
+    Exif:MeteringMode: 5 (pattern)
     Exif:Saturation: 0 (normal)
+    Exif:SceneCaptureType: 0 (standard)
     Exif:Sharpness: 2 (hard)
+    Exif:WhiteBalance: 0 (auto)
+    oiio:BitsPerSample: 8
     oiio:ColorSpace: "sRGB"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 32
 Comparing "../../../../../libtiffpic/pc260001.tif" and "pc260001.tif"
 PASS
 Reading ../../../../../libtiffpic/quad-tile.tif
@@ -250,26 +250,26 @@ Reading ../../../../../libtiffpic/quad-tile.tif
     SHA-1: EAE4D1FB2E60558747B8DDA9E93F0217191491A9
     channel list: R, G, B
     tile size: 128 x 128
-    oiio:BitsPerSample: 8
+    compression: "lzw"
     Orientation: 1 (normal)
+    planarconfig: "contig"
+    oiio:BitsPerSample: 8
+    tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 5
-    compression: "lzw"
 Comparing "../../../../../libtiffpic/quad-tile.tif" and "quad-tile.tif"
 PASS
 Reading ../../../../../libtiffpic/quad-jpeg.tif
 ../../../../../libtiffpic/quad-jpeg.tif :  512 x  384, 3 channel, uint8 tiff
     SHA-1: 3EF052D81D73F129B65F2199DFDD74E0A8E6356B
     channel list: R, G, B
-    oiio:BitsPerSample: 8
-    tiff:PhotometricInterpretation: 6
-    tiff:ColorSpace: "YCbCr"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 7
     compression: "jpeg"
+    planarconfig: "contig"
+    oiio:BitsPerSample: 8
+    tiff:ColorSpace: "YCbCr"
+    tiff:Compression: 7
+    tiff:PhotometricInterpretation: 6
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 16
 Comparing "../../../../../libtiffpic/quad-jpeg.tif" and "quad-jpeg.tif"
 PASS
@@ -277,33 +277,33 @@ Reading ../../../../../libtiffpic/strike.tif
 ../../../../../libtiffpic/strike.tif :  256 x  200, 4 channel, uint8 tiff
     SHA-1: C764170BDD3B192C3F0D16EB761E690A3128C520
     channel list: R, G, B, A
-    oiio:BitsPerSample: 8
+    compression: "lzw"
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "none"
     XResolution: 1
     YResolution: 1
-    ResolutionUnit: "none"
+    oiio:BitsPerSample: 8
+    tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 5
-    compression: "lzw"
     tiff:RowsPerStrip: 8
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/strike.tif" and "strike.tif"
 PASS
 Reading ../../../../../libtiffpic/ycbcr-cat.tif
 ../../../../../libtiffpic/ycbcr-cat.tif :  250 x  325, 3 channel, uint8 tiff
     SHA-1: E2FCF4BF1C9005987432CFCC8FD3A50F9417285D
     channel list: R, G, B
-    oiio:BitsPerSample: 8
+    compression: "lzw"
     ImageDescription: "YCbCr conversion of cat.tif"
     Orientation: 1 (normal)
-    Exif:YCbCrPositioning: 1
-    tiff:PhotometricInterpretation: 6
-    tiff:ColorSpace: "YCbCr"
-    tiff:PlanarConfiguration: 1
     planarconfig: "contig"
+    Exif:YCbCrPositioning: 1
+    oiio:BitsPerSample: 8
+    tiff:ColorSpace: "YCbCr"
     tiff:Compression: 5
-    compression: "lzw"
+    tiff:PhotometricInterpretation: 6
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 10
 Comparing "../../../../../libtiffpic/ycbcr-cat.tif" and "ycbcr-cat.tif"
 PASS
@@ -311,45 +311,45 @@ Reading ../../../../../libtiffpic/smallliz.tif
 ../../../../../libtiffpic/smallliz.tif :  160 x  160, 3 channel, uint8 tiff
     SHA-1: 9F2F09DBBD1A3C00DE84EA9174B821D64709BE28
     channel list: R, G, B
-    oiio:BitsPerSample: 8
-    XResolution: 100
-    YResolution: 100
+    compression: "ojpeg"
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "HP IL v1.1"
+    XResolution: 100
+    YResolution: 100
     Exif:YCbCrPositioning: 1
-    tiff:PhotometricInterpretation: 6
+    oiio:BitsPerSample: 8
     tiff:ColorSpace: "YCbCr"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
     tiff:Compression: 6
-    compression: "ojpeg"
+    tiff:PhotometricInterpretation: 6
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 160
-    PixelAspectRatio: 1
     tiff:subfiletype: 0
 Reading ../../../../../libtiffpic/zackthecat.tif
 ../../../../../libtiffpic/zackthecat.tif :  234 x  213, 3 channel, uint8 tiff
     SHA-1: 061497BA196953824E24E5E6EF765D00BE85702C
     channel list: R, G, B
     tile size: 240 x 224
-    oiio:BitsPerSample: 8
-    XResolution: 75
-    YResolution: 75
-    ResolutionUnit: "in"
-    tiff:PhotometricInterpretation: 6
-    tiff:ColorSpace: "YCbCr"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 6
     compression: "ojpeg"
     PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    XResolution: 75
+    YResolution: 75
+    oiio:BitsPerSample: 8
+    tiff:ColorSpace: "YCbCr"
+    tiff:Compression: 6
+    tiff:PhotometricInterpretation: 6
+    tiff:PlanarConfiguration: 1
 Reading ../../../../../libtiffpic/oxford.tif
 ../../../../../libtiffpic/oxford.tif :  601 x   81, 3 channel, uint8 tiff
     SHA-1: 6158BC605553813CD61D99900DAE389EEC3763D8
     channel list: R, G, B
+    compression: "lzw"
+    planarconfig: "separate"
     oiio:BitsPerSample: 8
+    tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
-    planarconfig: "separate"
-    tiff:Compression: 5
-    compression: "lzw"
     tiff:RowsPerStrip: 1

--- a/testsuite/tiff-suite/ref/out-jpeg9b.txt
+++ b/testsuite/tiff-suite/ref/out-jpeg9b.txt
@@ -2,17 +2,17 @@ Reading ../../../../../libtiffpic/cramps.tif
 ../../../../../libtiffpic/cramps.tif :  800 x  607, 1 channel, uint8 tiff
     SHA-1: A1CA337CBB22D84410BBE710BB31D5D6646CF839
     channel list: Y
-    oiio:BitsPerSample: 8
+    compression: "packbits"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     XResolution: 72
     YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:Compression: 32773
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 32773
-    compression: "packbits"
     tiff:RowsPerStrip: 12
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/cramps.tif" and "cramps.tif"
 PASS
 Reading ../../../../../libtiffpic/cramps-tile.tif
@@ -20,13 +20,13 @@ Reading ../../../../../libtiffpic/cramps-tile.tif
     SHA-1: A1CA337CBB22D84410BBE710BB31D5D6646CF839
     channel list: Y
     tile size: 256 x 256
-    oiio:BitsPerSample: 8
+    compression: "none"
     Orientation: 1 (normal)
+    planarconfig: "contig"
+    oiio:BitsPerSample: 8
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
 Comparing "../../../../../libtiffpic/cramps-tile.tif" and "cramps-tile.tif"
 PASS
 Comparing "../../../../../libtiffpic/cramps-tile.tif" and "../../../../../libtiffpic/cramps.tif"
@@ -37,110 +37,110 @@ Reading ../../../../../libtiffpic/dscf0013.tif
  subimage  0:  640 x  480, 3 channel, uint8 tiff
     SHA-1: 5A28EA8AB0FD8E03EA11BF008E842CFEB42A9716
     channel list: R, G, B
-    oiio:BitsPerSample: 8
-    Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
-    ResolutionUnit: "in"
-    Make: "FUJIFILM"
-    Model: "MX-2900ZOOM"
-    Software: "Digital Camera MX-2900ZOOM Ver1.00"
+    compression: "none"
     Copyright: "          "
     DateTime: "2004:11:10 00:00:31"
-    Exif:YCbCrPositioning: 2
-    tiff:PhotometricInterpretation: 6
-    tiff:ColorSpace: "YCbCr"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
-    tiff:RowsPerStrip: 15
-    PixelAspectRatio: 1
     FNumber: 3.4
-    Exif:ExposureProgram: 2 (normal program)
-    Exif:DateTimeOriginal: "2004:11:10 00:00:31"
-    Exif:DateTimeDigitized: "2004:11:10 00:00:31"
-    Exif:ShutterSpeedValue: 6.5 (1/90 s)
+    Make: "FUJIFILM"
+    Model: "MX-2900ZOOM"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "Digital Camera MX-2900ZOOM Ver1.00"
+    XResolution: 72
+    YResolution: 72
     Exif:ApertureValue: 3.53 (f/3.4)
     Exif:BrightnessValue: -0.4
+    Exif:ColorSpace: 1
+    Exif:DateTimeDigitized: "2004:11:10 00:00:31"
+    Exif:DateTimeOriginal: "2004:11:10 00:00:31"
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 3.53 (f/3.4)
-    Exif:MeteringMode: 1 (average)
+    Exif:ExposureProgram: 2 (normal program)
     Exif:Flash: 1 (flash fired)
     Exif:FocalLength: 7.4 (7.4 mm)
-    Exif:ColorSpace: 1
+    Exif:FocalPlaneResolutionUnit: 3 (cm)
     Exif:FocalPlaneXResolution: 847
     Exif:FocalPlaneYResolution: 847
-    Exif:FocalPlaneResolutionUnit: 3 (cm)
+    Exif:MaxApertureValue: 3.53 (f/3.4)
+    Exif:MeteringMode: 1 (average)
     Exif:SensingMethod: 2 (1-chip color area)
+    Exif:ShutterSpeedValue: 6.5 (1/90 s)
+    Exif:YCbCrPositioning: 2
+    oiio:BitsPerSample: 8
     oiio:ColorSpace: "sRGB"
+    tiff:ColorSpace: "YCbCr"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 6
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 15
  subimage  1:  160 x  120, 3 channel, uint8 tiff
     SHA-1: D7C5E398DC47C1FF619F62650EE2F8B303ADCDDC
     channel list: R, G, B
-    oiio:BitsPerSample: 8
+    compression: "none"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: "in"
     Exif:YCbCrPositioning: 2
-    tiff:PhotometricInterpretation: 6
+    oiio:BitsPerSample: 8
     tiff:ColorSpace: "YCbCr"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
     tiff:Compression: 1
-    compression: "none"
+    tiff:PhotometricInterpretation: 6
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 25
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/dscf0013.tif" and "dscf0013.tif"
 PASS
 Reading ../../../../../libtiffpic/fax2d.tif
 ../../../../../libtiffpic/fax2d.tif : 1728 x 1082, 1 channel, uint1 tiff
     SHA-1: A57ECEDA78607AE81ABA344E4456EDB1E34A6CB0
     channel list: Y
-    oiio:BitsPerSample: 1
+    compression: "ccittfax3"
     Orientation: 1 (normal)
-    XResolution: 204
-    YResolution: 98
+    PixelAspectRatio: 0.480392
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "fax2tiff"
+    XResolution: 204
+    YResolution: 98
+    oiio:BitsPerSample: 1
+    tiff:Compression: 3
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 3
-    compression: "ccittfax3"
-    PixelAspectRatio: 0.480392
 Comparing "../../../../../libtiffpic/fax2d.tif" and "fax2d.tif"
 PASS
 Reading ../../../../../libtiffpic/g3test.tif
 ../../../../../libtiffpic/g3test.tif : 1728 x 1103, 1 channel, uint1 tiff
     SHA-1: D674B2BB7707525F8DD678E81CAF50EE3A15D1E8
     channel list: Y
-    oiio:BitsPerSample: 1
+    compression: "ccittfax3"
     Orientation: 1 (normal)
-    XResolution: 204
-    YResolution: 98
+    PixelAspectRatio: 0.480392
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "fax2tiff"
+    XResolution: 204
+    YResolution: 98
+    oiio:BitsPerSample: 1
+    tiff:Compression: 3
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 3
-    compression: "ccittfax3"
-    PixelAspectRatio: 0.480392
 Comparing "../../../../../libtiffpic/g3test.tif" and "g3test.tif"
 PASS
 Reading ../../../../../libtiffpic/jello.tif
 ../../../../../libtiffpic/jello.tif :  256 x  192, 3 channel, uint8 tiff
     SHA-1: 41CD2AD5CA87F8CCBF7B181B58BEF136E6C64E1A
     channel list: R, G, B
-    oiio:BitsPerSample: 8
-    Orientation: 1 (normal)
-    tiff:PhotometricInterpretation: 3
-    tiff:ColorSpace: "palette"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 32773
     compression: "packbits"
+    Orientation: 1 (normal)
+    planarconfig: "contig"
+    oiio:BitsPerSample: 8
+    tiff:ColorSpace: "palette"
+    tiff:Compression: 32773
+    tiff:PhotometricInterpretation: 3
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 32
 Comparing "../../../../../libtiffpic/jello.tif" and "jello.tif"
 PASS
@@ -148,101 +148,101 @@ Reading ../../../../../libtiffpic/off_l16.tif
 ../../../../../libtiffpic/off_l16.tif :  333 x  225, 1 channel, uint8 tiff
     SHA-1: 430C2B645099A186CC7AE28C5DA697297E40A4D5
     channel list: Y
-    oiio:BitsPerSample: 16
+    compression: "sgilog"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: "in"
-    tiff:PhotometricInterpretation: 32844
+    oiio:BitsPerSample: 16
     tiff:ColorSpace: "LOGL"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
     tiff:Compression: 34676
-    compression: "sgilog"
+    tiff:PhotometricInterpretation: 32844
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 8
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/off_l16.tif" and "off_l16.tif"
 PASS
 Reading ../../../../../libtiffpic/off_luv24.tif
 ../../../../../libtiffpic/off_luv24.tif :  333 x  225, 3 channel, uint8 tiff
     SHA-1: CBB091760E8D9859F3DB5D5A168AF90D0C709A0B
     channel list: R, G, B
-    oiio:BitsPerSample: 16
+    compression: "sgilog24"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: "in"
-    tiff:PhotometricInterpretation: 32845
+    oiio:BitsPerSample: 16
     tiff:ColorSpace: "LOGLUV"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
     tiff:Compression: 34677
-    compression: "sgilog24"
+    tiff:PhotometricInterpretation: 32845
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 8
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/off_luv24.tif" and "off_luv24.tif"
 PASS
 Reading ../../../../../libtiffpic/off_luv32.tif
 ../../../../../libtiffpic/off_luv32.tif :  333 x  225, 3 channel, uint8 tiff
     SHA-1: FA6245246E4E92A0D8112249976843128338DBDD
     channel list: R, G, B
-    oiio:BitsPerSample: 16
+    compression: "sgilog"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: "in"
-    tiff:PhotometricInterpretation: 32845
+    oiio:BitsPerSample: 16
     tiff:ColorSpace: "LOGLUV"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
     tiff:Compression: 34676
-    compression: "sgilog"
+    tiff:PhotometricInterpretation: 32845
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 8
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/off_luv32.tif" and "off_luv32.tif"
 PASS
 Reading ../../../../../libtiffpic/pc260001.tif
 ../../../../../libtiffpic/pc260001.tif :  640 x  480, 3 channel, uint8 tiff
     SHA-1: F34868893B33383BE653ADA9FC054C8EA61BAC53
     channel list: R, G, B
-    oiio:BitsPerSample: 8
-    ImageDescription: "OLYMPUS DIGITAL CAMERA         "
-    Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
-    ResolutionUnit: "in"
-    Make: "OLYMPUS IMAGING CORP."
-    Model: "C7070WZ"
-    Software: "Version 1.0"
-    DateTime: "2005:12:26 17:09:35"
-    tiff:PhotometricInterpretation: 2
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
     compression: "none"
-    tiff:RowsPerStrip: 32
-    PixelAspectRatio: 1
+    DateTime: "2005:12:26 17:09:35"
     ExposureTime: 0.0125
     FNumber: 5.6
-    Exif:ExposureProgram: 2 (normal program)
-    Exif:DateTimeOriginal: "2005:12:26 17:09:35"
+    ImageDescription: "OLYMPUS DIGITAL CAMERA         "
+    Make: "OLYMPUS IMAGING CORP."
+    Model: "C7070WZ"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "Version 1.0"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:Contrast: 2 (hard)
+    Exif:CustomRendered: 0 (no)
     Exif:DateTimeDigitized: "2005:12:26 17:09:35"
+    Exif:DateTimeOriginal: "2005:12:26 17:09:35"
+    Exif:DigitalZoomRatio: 0
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 3 (f/2.8)
-    Exif:MeteringMode: 5 (pattern)
-    Exif:LightSource: 0 (unknown)
+    Exif:ExposureMode: 0 (auto)
+    Exif:ExposureProgram: 2 (normal program)
     Exif:Flash: 89 (flash fired, auto flash, red-eye reduction)
     Exif:FocalLength: 17.8 (17.8 mm)
-    Exif:ColorSpace: 1
-    Exif:CustomRendered: 0 (no)
-    Exif:ExposureMode: 0 (auto)
-    Exif:WhiteBalance: 0 (auto)
-    Exif:DigitalZoomRatio: 0
-    Exif:SceneCaptureType: 0 (standard)
-    Exif:Contrast: 2 (hard)
+    Exif:LightSource: 0 (unknown)
+    Exif:MaxApertureValue: 3 (f/2.8)
+    Exif:MeteringMode: 5 (pattern)
     Exif:Saturation: 0 (normal)
+    Exif:SceneCaptureType: 0 (standard)
     Exif:Sharpness: 2 (hard)
+    Exif:WhiteBalance: 0 (auto)
+    oiio:BitsPerSample: 8
     oiio:ColorSpace: "sRGB"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 32
 Comparing "../../../../../libtiffpic/pc260001.tif" and "pc260001.tif"
 PASS
 Reading ../../../../../libtiffpic/quad-tile.tif
@@ -250,26 +250,26 @@ Reading ../../../../../libtiffpic/quad-tile.tif
     SHA-1: EAE4D1FB2E60558747B8DDA9E93F0217191491A9
     channel list: R, G, B
     tile size: 128 x 128
-    oiio:BitsPerSample: 8
+    compression: "lzw"
     Orientation: 1 (normal)
+    planarconfig: "contig"
+    oiio:BitsPerSample: 8
+    tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 5
-    compression: "lzw"
 Comparing "../../../../../libtiffpic/quad-tile.tif" and "quad-tile.tif"
 PASS
 Reading ../../../../../libtiffpic/quad-jpeg.tif
 ../../../../../libtiffpic/quad-jpeg.tif :  512 x  384, 3 channel, uint8 tiff
     SHA-1: F907BED70BDEA0315FEB94F3042F9BDE61142BDA
     channel list: R, G, B
-    oiio:BitsPerSample: 8
-    tiff:PhotometricInterpretation: 6
-    tiff:ColorSpace: "YCbCr"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 7
     compression: "jpeg"
+    planarconfig: "contig"
+    oiio:BitsPerSample: 8
+    tiff:ColorSpace: "YCbCr"
+    tiff:Compression: 7
+    tiff:PhotometricInterpretation: 6
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 16
 Comparing "../../../../../libtiffpic/quad-jpeg.tif" and "quad-jpeg.tif"
 PASS
@@ -277,33 +277,33 @@ Reading ../../../../../libtiffpic/strike.tif
 ../../../../../libtiffpic/strike.tif :  256 x  200, 4 channel, uint8 tiff
     SHA-1: C764170BDD3B192C3F0D16EB761E690A3128C520
     channel list: R, G, B, A
-    oiio:BitsPerSample: 8
+    compression: "lzw"
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "none"
     XResolution: 1
     YResolution: 1
-    ResolutionUnit: "none"
+    oiio:BitsPerSample: 8
+    tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 5
-    compression: "lzw"
     tiff:RowsPerStrip: 8
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/strike.tif" and "strike.tif"
 PASS
 Reading ../../../../../libtiffpic/ycbcr-cat.tif
 ../../../../../libtiffpic/ycbcr-cat.tif :  250 x  325, 3 channel, uint8 tiff
     SHA-1: E2FCF4BF1C9005987432CFCC8FD3A50F9417285D
     channel list: R, G, B
-    oiio:BitsPerSample: 8
+    compression: "lzw"
     ImageDescription: "YCbCr conversion of cat.tif"
     Orientation: 1 (normal)
-    Exif:YCbCrPositioning: 1
-    tiff:PhotometricInterpretation: 6
-    tiff:ColorSpace: "YCbCr"
-    tiff:PlanarConfiguration: 1
     planarconfig: "contig"
+    Exif:YCbCrPositioning: 1
+    oiio:BitsPerSample: 8
+    tiff:ColorSpace: "YCbCr"
     tiff:Compression: 5
-    compression: "lzw"
+    tiff:PhotometricInterpretation: 6
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 10
 Comparing "../../../../../libtiffpic/ycbcr-cat.tif" and "ycbcr-cat.tif"
 PASS
@@ -311,45 +311,45 @@ Reading ../../../../../libtiffpic/smallliz.tif
 ../../../../../libtiffpic/smallliz.tif :  160 x  160, 3 channel, uint8 tiff
     SHA-1: 9F2F09DBBD1A3C00DE84EA9174B821D64709BE28
     channel list: R, G, B
-    oiio:BitsPerSample: 8
-    XResolution: 100
-    YResolution: 100
+    compression: "ojpeg"
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "HP IL v1.1"
+    XResolution: 100
+    YResolution: 100
     Exif:YCbCrPositioning: 1
-    tiff:PhotometricInterpretation: 6
+    oiio:BitsPerSample: 8
     tiff:ColorSpace: "YCbCr"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
     tiff:Compression: 6
-    compression: "ojpeg"
+    tiff:PhotometricInterpretation: 6
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 160
-    PixelAspectRatio: 1
     tiff:subfiletype: 0
 Reading ../../../../../libtiffpic/zackthecat.tif
 ../../../../../libtiffpic/zackthecat.tif :  234 x  213, 3 channel, uint8 tiff
     SHA-1: 061497BA196953824E24E5E6EF765D00BE85702C
     channel list: R, G, B
     tile size: 240 x 224
-    oiio:BitsPerSample: 8
-    XResolution: 75
-    YResolution: 75
-    ResolutionUnit: "in"
-    tiff:PhotometricInterpretation: 6
-    tiff:ColorSpace: "YCbCr"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 6
     compression: "ojpeg"
     PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    XResolution: 75
+    YResolution: 75
+    oiio:BitsPerSample: 8
+    tiff:ColorSpace: "YCbCr"
+    tiff:Compression: 6
+    tiff:PhotometricInterpretation: 6
+    tiff:PlanarConfiguration: 1
 Reading ../../../../../libtiffpic/oxford.tif
 ../../../../../libtiffpic/oxford.tif :  601 x   81, 3 channel, uint8 tiff
     SHA-1: 6158BC605553813CD61D99900DAE389EEC3763D8
     channel list: R, G, B
+    compression: "lzw"
+    planarconfig: "separate"
     oiio:BitsPerSample: 8
+    tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
-    planarconfig: "separate"
-    tiff:Compression: 5
-    compression: "lzw"
     tiff:RowsPerStrip: 1

--- a/testsuite/tiff-suite/ref/out.txt
+++ b/testsuite/tiff-suite/ref/out.txt
@@ -2,17 +2,17 @@ Reading ../../../../../libtiffpic/cramps.tif
 ../../../../../libtiffpic/cramps.tif :  800 x  607, 1 channel, uint8 tiff
     SHA-1: A1CA337CBB22D84410BBE710BB31D5D6646CF839
     channel list: Y
-    oiio:BitsPerSample: 8
+    compression: "packbits"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     XResolution: 72
     YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:Compression: 32773
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 32773
-    compression: "packbits"
     tiff:RowsPerStrip: 12
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/cramps.tif" and "cramps.tif"
 PASS
 Reading ../../../../../libtiffpic/cramps-tile.tif
@@ -20,13 +20,13 @@ Reading ../../../../../libtiffpic/cramps-tile.tif
     SHA-1: A1CA337CBB22D84410BBE710BB31D5D6646CF839
     channel list: Y
     tile size: 256 x 256
-    oiio:BitsPerSample: 8
+    compression: "none"
     Orientation: 1 (normal)
+    planarconfig: "contig"
+    oiio:BitsPerSample: 8
+    tiff:Compression: 1
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
 Comparing "../../../../../libtiffpic/cramps-tile.tif" and "cramps-tile.tif"
 PASS
 Comparing "../../../../../libtiffpic/cramps-tile.tif" and "../../../../../libtiffpic/cramps.tif"
@@ -37,110 +37,110 @@ Reading ../../../../../libtiffpic/dscf0013.tif
  subimage  0:  640 x  480, 3 channel, uint8 tiff
     SHA-1: 5A28EA8AB0FD8E03EA11BF008E842CFEB42A9716
     channel list: R, G, B
-    oiio:BitsPerSample: 8
-    Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
-    ResolutionUnit: "in"
-    Make: "FUJIFILM"
-    Model: "MX-2900ZOOM"
-    Software: "Digital Camera MX-2900ZOOM Ver1.00"
+    compression: "none"
     Copyright: "          "
     DateTime: "2004:11:10 00:00:31"
-    Exif:YCbCrPositioning: 2
-    tiff:PhotometricInterpretation: 6
-    tiff:ColorSpace: "YCbCr"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
-    compression: "none"
-    tiff:RowsPerStrip: 15
-    PixelAspectRatio: 1
     FNumber: 3.4
-    Exif:ExposureProgram: 2 (normal program)
-    Exif:DateTimeOriginal: "2004:11:10 00:00:31"
-    Exif:DateTimeDigitized: "2004:11:10 00:00:31"
-    Exif:ShutterSpeedValue: 6.5 (1/90 s)
+    Make: "FUJIFILM"
+    Model: "MX-2900ZOOM"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "Digital Camera MX-2900ZOOM Ver1.00"
+    XResolution: 72
+    YResolution: 72
     Exif:ApertureValue: 3.53 (f/3.4)
     Exif:BrightnessValue: -0.4
+    Exif:ColorSpace: 1
+    Exif:DateTimeDigitized: "2004:11:10 00:00:31"
+    Exif:DateTimeOriginal: "2004:11:10 00:00:31"
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 3.53 (f/3.4)
-    Exif:MeteringMode: 1 (average)
+    Exif:ExposureProgram: 2 (normal program)
     Exif:Flash: 1 (flash fired)
     Exif:FocalLength: 7.4 (7.4 mm)
-    Exif:ColorSpace: 1
+    Exif:FocalPlaneResolutionUnit: 3 (cm)
     Exif:FocalPlaneXResolution: 847
     Exif:FocalPlaneYResolution: 847
-    Exif:FocalPlaneResolutionUnit: 3 (cm)
+    Exif:MaxApertureValue: 3.53 (f/3.4)
+    Exif:MeteringMode: 1 (average)
     Exif:SensingMethod: 2 (1-chip color area)
+    Exif:ShutterSpeedValue: 6.5 (1/90 s)
+    Exif:YCbCrPositioning: 2
+    oiio:BitsPerSample: 8
     oiio:ColorSpace: "sRGB"
+    tiff:ColorSpace: "YCbCr"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 6
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 15
  subimage  1:  160 x  120, 3 channel, uint8 tiff
     SHA-1: D7C5E398DC47C1FF619F62650EE2F8B303ADCDDC
     channel list: R, G, B
-    oiio:BitsPerSample: 8
+    compression: "none"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: "in"
     Exif:YCbCrPositioning: 2
-    tiff:PhotometricInterpretation: 6
+    oiio:BitsPerSample: 8
     tiff:ColorSpace: "YCbCr"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
     tiff:Compression: 1
-    compression: "none"
+    tiff:PhotometricInterpretation: 6
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 25
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/dscf0013.tif" and "dscf0013.tif"
 PASS
 Reading ../../../../../libtiffpic/fax2d.tif
 ../../../../../libtiffpic/fax2d.tif : 1728 x 1082, 1 channel, uint1 tiff
     SHA-1: A57ECEDA78607AE81ABA344E4456EDB1E34A6CB0
     channel list: Y
-    oiio:BitsPerSample: 1
+    compression: "ccittfax3"
     Orientation: 1 (normal)
-    XResolution: 204
-    YResolution: 98
+    PixelAspectRatio: 0.480392
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "fax2tiff"
+    XResolution: 204
+    YResolution: 98
+    oiio:BitsPerSample: 1
+    tiff:Compression: 3
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 3
-    compression: "ccittfax3"
-    PixelAspectRatio: 0.480392
 Comparing "../../../../../libtiffpic/fax2d.tif" and "fax2d.tif"
 PASS
 Reading ../../../../../libtiffpic/g3test.tif
 ../../../../../libtiffpic/g3test.tif : 1728 x 1103, 1 channel, uint1 tiff
     SHA-1: D674B2BB7707525F8DD678E81CAF50EE3A15D1E8
     channel list: Y
-    oiio:BitsPerSample: 1
+    compression: "ccittfax3"
     Orientation: 1 (normal)
-    XResolution: 204
-    YResolution: 98
+    PixelAspectRatio: 0.480392
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "fax2tiff"
+    XResolution: 204
+    YResolution: 98
+    oiio:BitsPerSample: 1
+    tiff:Compression: 3
     tiff:PhotometricInterpretation: 0
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 3
-    compression: "ccittfax3"
-    PixelAspectRatio: 0.480392
 Comparing "../../../../../libtiffpic/g3test.tif" and "g3test.tif"
 PASS
 Reading ../../../../../libtiffpic/jello.tif
 ../../../../../libtiffpic/jello.tif :  256 x  192, 3 channel, uint8 tiff
     SHA-1: 41CD2AD5CA87F8CCBF7B181B58BEF136E6C64E1A
     channel list: R, G, B
-    oiio:BitsPerSample: 8
-    Orientation: 1 (normal)
-    tiff:PhotometricInterpretation: 3
-    tiff:ColorSpace: "palette"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 32773
     compression: "packbits"
+    Orientation: 1 (normal)
+    planarconfig: "contig"
+    oiio:BitsPerSample: 8
+    tiff:ColorSpace: "palette"
+    tiff:Compression: 32773
+    tiff:PhotometricInterpretation: 3
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 32
 Comparing "../../../../../libtiffpic/jello.tif" and "jello.tif"
 PASS
@@ -148,101 +148,101 @@ Reading ../../../../../libtiffpic/off_l16.tif
 ../../../../../libtiffpic/off_l16.tif :  333 x  225, 1 channel, uint8 tiff
     SHA-1: 430C2B645099A186CC7AE28C5DA697297E40A4D5
     channel list: Y
-    oiio:BitsPerSample: 16
+    compression: "sgilog"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: "in"
-    tiff:PhotometricInterpretation: 32844
+    oiio:BitsPerSample: 16
     tiff:ColorSpace: "LOGL"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
     tiff:Compression: 34676
-    compression: "sgilog"
+    tiff:PhotometricInterpretation: 32844
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 8
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/off_l16.tif" and "off_l16.tif"
 PASS
 Reading ../../../../../libtiffpic/off_luv24.tif
 ../../../../../libtiffpic/off_luv24.tif :  333 x  225, 3 channel, uint8 tiff
     SHA-1: CBB091760E8D9859F3DB5D5A168AF90D0C709A0B
     channel list: R, G, B
-    oiio:BitsPerSample: 16
+    compression: "sgilog24"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: "in"
-    tiff:PhotometricInterpretation: 32845
+    oiio:BitsPerSample: 16
     tiff:ColorSpace: "LOGLUV"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
     tiff:Compression: 34677
-    compression: "sgilog24"
+    tiff:PhotometricInterpretation: 32845
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 8
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/off_luv24.tif" and "off_luv24.tif"
 PASS
 Reading ../../../../../libtiffpic/off_luv32.tif
 ../../../../../libtiffpic/off_luv32.tif :  333 x  225, 3 channel, uint8 tiff
     SHA-1: FA6245246E4E92A0D8112249976843128338DBDD
     channel list: R, G, B
-    oiio:BitsPerSample: 16
+    compression: "sgilog"
     Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
     XResolution: 72
     YResolution: 72
-    ResolutionUnit: "in"
-    tiff:PhotometricInterpretation: 32845
+    oiio:BitsPerSample: 16
     tiff:ColorSpace: "LOGLUV"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
     tiff:Compression: 34676
-    compression: "sgilog"
+    tiff:PhotometricInterpretation: 32845
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 8
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/off_luv32.tif" and "off_luv32.tif"
 PASS
 Reading ../../../../../libtiffpic/pc260001.tif
 ../../../../../libtiffpic/pc260001.tif :  640 x  480, 3 channel, uint8 tiff
     SHA-1: F34868893B33383BE653ADA9FC054C8EA61BAC53
     channel list: R, G, B
-    oiio:BitsPerSample: 8
-    ImageDescription: "OLYMPUS DIGITAL CAMERA         "
-    Orientation: 1 (normal)
-    XResolution: 72
-    YResolution: 72
-    ResolutionUnit: "in"
-    Make: "OLYMPUS IMAGING CORP."
-    Model: "C7070WZ"
-    Software: "Version 1.0"
-    DateTime: "2005:12:26 17:09:35"
-    tiff:PhotometricInterpretation: 2
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 1
     compression: "none"
-    tiff:RowsPerStrip: 32
-    PixelAspectRatio: 1
+    DateTime: "2005:12:26 17:09:35"
     ExposureTime: 0.0125
     FNumber: 5.6
-    Exif:ExposureProgram: 2 (normal program)
-    Exif:DateTimeOriginal: "2005:12:26 17:09:35"
+    ImageDescription: "OLYMPUS DIGITAL CAMERA         "
+    Make: "OLYMPUS IMAGING CORP."
+    Model: "C7070WZ"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "Version 1.0"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:Contrast: 2 (hard)
+    Exif:CustomRendered: 0 (no)
     Exif:DateTimeDigitized: "2005:12:26 17:09:35"
+    Exif:DateTimeOriginal: "2005:12:26 17:09:35"
+    Exif:DigitalZoomRatio: 0
     Exif:ExposureBiasValue: 0
-    Exif:MaxApertureValue: 3 (f/2.8)
-    Exif:MeteringMode: 5 (pattern)
-    Exif:LightSource: 0 (unknown)
+    Exif:ExposureMode: 0 (auto)
+    Exif:ExposureProgram: 2 (normal program)
     Exif:Flash: 89 (flash fired, auto flash, red-eye reduction)
     Exif:FocalLength: 17.8 (17.8 mm)
-    Exif:ColorSpace: 1
-    Exif:CustomRendered: 0 (no)
-    Exif:ExposureMode: 0 (auto)
-    Exif:WhiteBalance: 0 (auto)
-    Exif:DigitalZoomRatio: 0
-    Exif:SceneCaptureType: 0 (standard)
-    Exif:Contrast: 2 (hard)
+    Exif:LightSource: 0 (unknown)
+    Exif:MaxApertureValue: 3 (f/2.8)
+    Exif:MeteringMode: 5 (pattern)
     Exif:Saturation: 0 (normal)
+    Exif:SceneCaptureType: 0 (standard)
     Exif:Sharpness: 2 (hard)
+    Exif:WhiteBalance: 0 (auto)
+    oiio:BitsPerSample: 8
     oiio:ColorSpace: "sRGB"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 32
 Comparing "../../../../../libtiffpic/pc260001.tif" and "pc260001.tif"
 PASS
 Reading ../../../../../libtiffpic/quad-tile.tif
@@ -250,26 +250,26 @@ Reading ../../../../../libtiffpic/quad-tile.tif
     SHA-1: EAE4D1FB2E60558747B8DDA9E93F0217191491A9
     channel list: R, G, B
     tile size: 128 x 128
-    oiio:BitsPerSample: 8
+    compression: "lzw"
     Orientation: 1 (normal)
+    planarconfig: "contig"
+    oiio:BitsPerSample: 8
+    tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 5
-    compression: "lzw"
 Comparing "../../../../../libtiffpic/quad-tile.tif" and "quad-tile.tif"
 PASS
 Reading ../../../../../libtiffpic/quad-jpeg.tif
 ../../../../../libtiffpic/quad-jpeg.tif :  512 x  384, 3 channel, uint8 tiff
     SHA-1: F035DB0C05B1AC8E0301F41D27C1FF604EFA65E3
     channel list: R, G, B
-    oiio:BitsPerSample: 8
-    tiff:PhotometricInterpretation: 6
-    tiff:ColorSpace: "YCbCr"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 7
     compression: "jpeg"
+    planarconfig: "contig"
+    oiio:BitsPerSample: 8
+    tiff:ColorSpace: "YCbCr"
+    tiff:Compression: 7
+    tiff:PhotometricInterpretation: 6
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 16
 Comparing "../../../../../libtiffpic/quad-jpeg.tif" and "quad-jpeg.tif"
 PASS
@@ -277,33 +277,33 @@ Reading ../../../../../libtiffpic/strike.tif
 ../../../../../libtiffpic/strike.tif :  256 x  200, 4 channel, uint8 tiff
     SHA-1: C764170BDD3B192C3F0D16EB761E690A3128C520
     channel list: R, G, B, A
-    oiio:BitsPerSample: 8
+    compression: "lzw"
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "none"
     XResolution: 1
     YResolution: 1
-    ResolutionUnit: "none"
+    oiio:BitsPerSample: 8
+    tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 5
-    compression: "lzw"
     tiff:RowsPerStrip: 8
-    PixelAspectRatio: 1
 Comparing "../../../../../libtiffpic/strike.tif" and "strike.tif"
 PASS
 Reading ../../../../../libtiffpic/ycbcr-cat.tif
 ../../../../../libtiffpic/ycbcr-cat.tif :  250 x  325, 3 channel, uint8 tiff
     SHA-1: E2FCF4BF1C9005987432CFCC8FD3A50F9417285D
     channel list: R, G, B
-    oiio:BitsPerSample: 8
+    compression: "lzw"
     ImageDescription: "YCbCr conversion of cat.tif"
     Orientation: 1 (normal)
-    Exif:YCbCrPositioning: 1
-    tiff:PhotometricInterpretation: 6
-    tiff:ColorSpace: "YCbCr"
-    tiff:PlanarConfiguration: 1
     planarconfig: "contig"
+    Exif:YCbCrPositioning: 1
+    oiio:BitsPerSample: 8
+    tiff:ColorSpace: "YCbCr"
     tiff:Compression: 5
-    compression: "lzw"
+    tiff:PhotometricInterpretation: 6
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 10
 Comparing "../../../../../libtiffpic/ycbcr-cat.tif" and "ycbcr-cat.tif"
 PASS
@@ -311,45 +311,45 @@ Reading ../../../../../libtiffpic/smallliz.tif
 ../../../../../libtiffpic/smallliz.tif :  160 x  160, 3 channel, uint8 tiff
     SHA-1: 9F2F09DBBD1A3C00DE84EA9174B821D64709BE28
     channel list: R, G, B
-    oiio:BitsPerSample: 8
-    XResolution: 100
-    YResolution: 100
+    compression: "ojpeg"
+    PixelAspectRatio: 1
+    planarconfig: "contig"
     ResolutionUnit: "in"
     Software: "HP IL v1.1"
+    XResolution: 100
+    YResolution: 100
     Exif:YCbCrPositioning: 1
-    tiff:PhotometricInterpretation: 6
+    oiio:BitsPerSample: 8
     tiff:ColorSpace: "YCbCr"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
     tiff:Compression: 6
-    compression: "ojpeg"
+    tiff:PhotometricInterpretation: 6
+    tiff:PlanarConfiguration: 1
     tiff:RowsPerStrip: 160
-    PixelAspectRatio: 1
     tiff:subfiletype: 0
 Reading ../../../../../libtiffpic/zackthecat.tif
 ../../../../../libtiffpic/zackthecat.tif :  234 x  213, 3 channel, uint8 tiff
     SHA-1: 061497BA196953824E24E5E6EF765D00BE85702C
     channel list: R, G, B
     tile size: 240 x 224
-    oiio:BitsPerSample: 8
-    XResolution: 75
-    YResolution: 75
-    ResolutionUnit: "in"
-    tiff:PhotometricInterpretation: 6
-    tiff:ColorSpace: "YCbCr"
-    tiff:PlanarConfiguration: 1
-    planarconfig: "contig"
-    tiff:Compression: 6
     compression: "ojpeg"
     PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    XResolution: 75
+    YResolution: 75
+    oiio:BitsPerSample: 8
+    tiff:ColorSpace: "YCbCr"
+    tiff:Compression: 6
+    tiff:PhotometricInterpretation: 6
+    tiff:PlanarConfiguration: 1
 Reading ../../../../../libtiffpic/oxford.tif
 ../../../../../libtiffpic/oxford.tif :  601 x   81, 3 channel, uint8 tiff
     SHA-1: 6158BC605553813CD61D99900DAE389EEC3763D8
     channel list: R, G, B
+    compression: "lzw"
+    planarconfig: "separate"
     oiio:BitsPerSample: 8
+    tiff:Compression: 5
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
-    planarconfig: "separate"
-    tiff:Compression: 5
-    compression: "lzw"
     tiff:RowsPerStrip: 1


### PR DESCRIPTION
When oiiotool or iinfo print metadata, do so alphabetically, but case-insensitive, locale-independent, and with "un-namespaced" metadata appearing before "namespace-prefixed" metadata.

(Note: previously, it would print in whatever order the metadata were haphazardly added to the ParamValueList.)

The main purpose is to canonicalize the order of appearance of metadata   in test reference output. This minimizes the amount of reference output    churn that happens when we change code of image format readers, or upgrade    reader libraries, or add support for new metadata.

Some minor changes to strutil to add Strutil::iless() and functors to make it easier to sort case-insensitively.

The code changes are small; most of the deltas of this PR are the couple dozen 