### PR TITLE
Use TravisCI conditions to limit builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -134,7 +134,7 @@ matrix:
         compiler: gcc
       - os: osx
         compiler: clang
-    # test debug build
+    # test debug build with default compiler
       - os: linux
         compiler: gcc
         env: DEBUG=1
@@ -163,33 +163,60 @@ matrix:
       ##  compiler: clang
       ##  env: LINKSTATIC=1 USE_FFMPEG=0 USE_OCIO=0 USE_OPENCV=0
     # Build with sanitizers
+    # Because this test takes so long to run, only build for PRs, direct
+    # pushes to master or RB branches, or if the branch name includes
+    # "sanitize". Other ordinary work branch pushes don't need to run this
+    # every time.
       - os: linux
         compiler: gcc
         env: WHICHGCC=6 SANITIZE=address USE_PYTHON=0
+        if: branch =~ /(master|RB|san)/ OR type = pull_request
     # One more, just for the heck of it, turn all SIMD off, and also make
     # sure we're falling back on libjpeg, not jpeg-turbo, and don't embed
     # the plugins (to make sure that doesn't rust away).  I guess this
     # should/could be both platforms, but in the interest of making the
     # tests go faster, don't bother doing it on OSX.
+    # Only build this case for PRs, direct pushes to master or RB branches,
+    # or if the branch name includes "simd". Other ordinary work branch
+    # pushes don't need to run this.
       - os: linux
         compiler: gcc
         env: USE_SIMD=0 USE_JPEGTURBO=0 EMBEDPLUGINS=0
+        if: branch =~ /(master|RB|simd)/ OR type = pull_request
     # test with C++14, gcc 8, latest SIMD flags supported by TravisCI VMs
+    # Since VFXPlatform doesn't bless gcc8 yet, only build this
+    # case for PRs, direct pushes to master or RB branches, or if the branch
+    # name includes "gcc". Other ordinary work branch pushes don't
+    # need to run this.
       - os: linux
         compiler: gcc
         env: WHICHGCC=8 USE_CPP=14 USE_SIMD=avx,f16c
-    # test with C++17, gcc 8, latest SIMD flags supported by TravisCI VMs
+        if: branch =~ /(master|RB|gcc)/ OR type = pull_request
+    # test with C++17, gcc 8, latest SIMD flags supported by TravisCI VMs.
+    # Since VFXPlatform doesn't bless C++17 or gcc8 yet, only build this
+    # case for PRs, direct pushes to master or RB branches, or if the branch
+    # name includes "17" or "gcc". Other ordinary work branch pushes don't
+    # need to run this.
       - os: linux
         compiler: gcc
         env: WHICHGCC=8 USE_CPP=17 USE_SIMD=avx,f16c
+        if: branch =~ /(master|RB|gcc|17)/ OR type = pull_request
     # build for AVX2, don't run the tests (ensure against build breaks)
+    # Only build this case for PRs, direct pushes to master or RB branches,
+    # or if the branch name includes "simd". Other ordinary work branch
+    # pushes don't need to run this.
       - os: linux
         compiler: gcc
         env: WHICHGCC=6 USE_SIMD=avx2 SKIP_TESTS=1
+        if: branch =~ /(master|RB|simd)/ OR type = pull_request
     # build for AVX512, don't run the tests (ensure against build breaks)
+    # Only build this case for PRs, direct pushes to master or RB branches,
+    # or if the branch name includes "simd". Other ordinary work branch
+    # pushes don't need to run this.
       - os: linux
         compiler: gcc
         env: WHICHGCC=7 USE_SIMD=avx2,avx512f,f16c SKIP_TESTS=1
+        if: branch =~ /(master|RB|simd)/ OR type = pull_request
     # Build with EMBEDPLUGINS=0, both platforms.
       # FIXME: doesn't work yet on Travis
       # - os: linux


### PR DESCRIPTION
We have a growing matrix of tests, and there is development friction from the fact that every push to a working branch kicks off the whole matrix, many of which exist to test very specialized things that are probably not changed by the vast majority of patches.

TravisCI recently started supporting "conditions" that can let you limit which test cases or stages to run.

I'm proposing that the full test matrix always run when it's:

* a pull request
* a direct push of an updated "master" or "RB" top of tree.
* a nightly cron job (which, also, are only for "master" and certain "RB" branches)

But in other cases -- that is, ordinary work branch pushes while we develop -- there are many tests that don't really need to run every time, and just clog up our Travis queue. So I'm adding the following exclusions:

- The tests that exist solely to make sure we don't break simd.h (builds that exercise AVX2, avx512, and no SIMD) will now only build for   working branch pushes if the branch name includes the substring "simd". (Pro tip: if you are editing simd.h or using it heavily in your modified code, name your working branch to include that substring to force those tests to run on every push.)

- The tests for gcc8 and/or C++17 (which aren't yet documented as blessed   by VFXPlatform) only run for working branch pushes if the branch includes the substring "gcc" or "17", respectively.  (Note: since gcc6 and C++14 *are* VFXPlatform blessed, those tests are never   excluded.)

- The test that runs sanitizers, which takes ~4x longer to run than   other tests, only runs from ordinary working branch pushes if the   branch name includes the substring "san".

The neat thing is that with the exclusions, an ordinary working branch push that not have its name indicate that it cares specifically about simd, san, gcc8, or C++17, only has 5 tests in the remaining matrix, which is exactly the amount that TravisCI will parallelize. Thus, the new "common case" will complete its CI in roughly the time it takes to do just one matrix entry (~10-15 minutes), versus the full test suite that would have taken 3-4x that.

Remember that this is just for working branch pushes. Once you submit your work as a PR, the full test matrix will be run.

