### PR TITLE
Fixes to handle input images with unassociated alpha ("unpremultiplied")

### DIFF
--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -59,6 +59,7 @@ using namespace OIIO;
 
 static bool verbose = false;
 static bool foreground_mode = false;
+static bool autopremult = true;
 static std::vector<std::string> filenames;
 
 
@@ -85,6 +86,7 @@ getargs (int argc, char *argv[])
                   "--help", &help, "Print help message",
                   "-v", &verbose, "Verbose status messages",
                   "-F", &foreground_mode, "Foreground mode",
+                  "--no-autopremult %!", &autopremult, "Turn off automatic premultiplication of images with unassociated alpha",
                   NULL);
     if (ap.parse (argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
@@ -127,6 +129,8 @@ main (int argc, char *argv[])
     ImageCache *imagecache = ImageCache::create (true);
     imagecache->attribute ("autotile", 256);
     imagecache->attribute ("deduplicate", (int)0);
+    if (! autopremult)
+        imagecache->attribute ("unassociatedalpha", 1);
 
     // Make sure we are the top window with the focus.
     mainWin->raise ();

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -79,6 +79,7 @@ public:
     bool updatemode;
     bool autoorient;
     bool autocc;                      // automatically color correct
+    bool autopremult;                 // auto premult unassociated alpha input
     bool nativeread;                  // force native data type reads
     bool printinfo_verbose;
     int cachesize;
@@ -142,6 +143,7 @@ public:
     Oiiotool ();
 
     void clear_options ();
+    void clear_input_config ();
 
     /// Force img to be read at this point.  Use this wrapper, don't directly
     /// call img->read(), because there's extra work done here specific to

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -966,6 +966,8 @@ TIFFInput::readspec (bool read_meta)
                 m_spec.channelnames[0] = "Y";
         }
     }
+    if (alpha_is_unassociated)
+        m_spec.attribute ("tiff:UnassociatedAlpha", 1);
     // Will we need to do alpha conversions?
     m_convert_alpha = (m_spec.alpha_channel >= 0 && alpha_is_unassociated &&
                        ! m_keep_unassociated_alpha);


### PR DESCRIPTION
It's an abomination, but it's one we have to sometimes live with.
This patch has several small goodies for people who are forced to
deal with "unpremultiplied" images.

* A variety of fixes to oiiotool --no-autopremult, which turns off the
  automatic premultiplication that is ordinaryily done for
  unpremultiplied inputs. It was only working for inputs that were
  backed by the ImageCache, which excluded small files read directly,
  and also excluded --info results (which bypass the cache and to
  straight for an ordinary ImageInput).

* iv: add a `--no-autopremult` flag, much like the one for oiiotool.
  This makes it easier to use iv to examine the unmodified input values.

* TIFF read: be sure to set an attribute called "tiff:UnaociatedAlpha"
  to indicate that the original input was unpremultiplied in the file,
  regardless of whether the usual auto-premultiplication was used upon
  input.
