### PR TITLE
RefCnt enhancement: release()

### DIFF
--- a/src/include/OpenImageIO/refcnt.h
+++ b/src/include/OpenImageIO/refcnt.h
@@ -118,7 +118,8 @@ public:
     T* release () {
         T* p = m_ptr;
         if (p) {
-            p->_decref ();
+            if (! p->_decref ())
+                DASSERT (0 && "release() when you aren't the sole owner");
             m_ptr = nullptr;
         }
         return p;


### PR DESCRIPTION
refcntptr::release() sets the pointer to null and reduces the ref count, returns the original pointer, but does NOT free the object even if the new ref count is 0.

The motivation for this will be in a forthcoming OSL PR.
