### PR TITLE
Fix ImageBuf::contains_roi always returning true

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -2149,7 +2149,7 @@ ImageBuf::set_roi_full (const ROI &newroi)
 bool
 ImageBuf::contains_roi (ROI roi) const
 {
-    ROI myroi = roi;
+    ROI myroi = this->roi();
     return (roi.defined() && myroi.defined() &&
             roi.xbegin >= myroi.xbegin && roi.xend <= myroi.xend &&
             roi.ybegin >= myroi.ybegin && roi.yend <= myroi.yend &&


### PR DESCRIPTION
## Description

While updating my [Go language bindings](https://github.com/justinfx/openimageigo) to oiio 1.7 compatability, I found that `ImageBuf::contains_roi()` was always returning true. There looked to be a bug where the `roi` input parameter was always being compared against itself instead of the `roi` of the `ImageBuf` instance.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

