### PR TITLE
Fix uninitialized read within texture system

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -252,7 +252,10 @@ ImageCacheFile::LevelInfo::LevelInfo (const ImageSpec &spec_,
     }
     int total_tiles = nxtiles * nytiles * nztiles;
     ASSERT (total_tiles >= 1);
-    tiles_read = new atomic_ll [round_to_multiple (total_tiles, 64) / 64];
+    const int sz = round_to_multiple (total_tiles, 64) / 64;
+    tiles_read = new atomic_ll [sz];
+    for (int i = 0; i < sz; i++)
+        tiles_read[i] = 0;
 }
 
 


### PR DESCRIPTION
Found this bug with valgrind. The `std::atomic` default constructor does not initialize the memory. Therefore this array was not getting properly filled in.

I am not really sure how this didn't cause problems, it could be I am missing something subtle. But the valgrind warning definitely goes away after this fix.