### PR TITLE
Fix segfault when reading gif with Comment Extension and no Comment Data

### DIFF
--- a/src/gif.imageio/gifinput.cpp
+++ b/src/gif.imageio/gifinput.cpp
@@ -273,7 +273,9 @@ GIFInput::read_subimage_metadata (ImageSpec &newspec)
                 report_last_error ();
                 return false;
             }
-            read_gif_extension (ext_code, ext, newspec);
+            if (ext != NULL) {
+                read_gif_extension (ext_code, ext, newspec);
+            }
             
             while (ext != NULL)
             {


### PR DESCRIPTION
## Description

The GIFInput::read_gif_extension method segfaults when reading a GIF that has a Comment Extension with no Comment Data. I don't know how the problem GIF was generated and unfortunately I can't share it but it seems valid and can be opened without issue in other applications.

## Tests

Prior to the change OpenImageIO was segfaulting as soon as the image was opened, now it opens without issue.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

