### PR TITLE
Fix ImageSpec::erase_attribute using backwards logic for casesensitive

### DIFF
--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -351,7 +351,7 @@ ImageSpec::erase_attribute (string_view name, TypeDesc searchtype,
             flag |= boost::regex_constants::icase;
 #else
         std::regex_constants::syntax_option_type flag = std::regex_constants::basic;
-        if (casesensitive)
+        if (! casesensitive)
             flag |= std::regex_constants::icase;
 #endif
         regex re = regex(name.str(), flag);


### PR DESCRIPTION
## Description

While testing my [Go language bindings](https://github.com/justinfx/openimageigo) against the 1.8 branch, I found that one of my `ImageSpec::erase_attribute` tests was failing when checking the `casesensitive=true` option. Digging into the history it looks like with the addition of the `std::regex` ifdef, a copy-paste error has left the opposite check for the boolean. So you get case-insensitive when you as for case-sensitive. Again this is only when not using boost::regex. 

One other issue I noticed, after fixing this bug, was that the `TypeDesc` is no longer honored when searching for the attribute. Another test that I have fails on this assumption, but I am not sure if this was the intended new behavior. My test tries to set an int, and then erase it as a float. Previously it will not erase the attribute, but in 1.8 the attribute is erased regardless of type.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

