### PR TITLE
For Travis Linux, build against OpenEXR 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,11 +67,6 @@ install:
     - if [ "$CXX" == "g++" ]; then export CXX="g++-${WHICHGCC}" ; fi
     - export USE_CCACHE=1
     - export CCACHE_CPP2=1
-    # Temporary fix: Use LG's private openexr branch, until the
-    # fixes are merged into the OpenEXR project that will address
-    # the warnings for gcc7 and C++17 compatibility.
-    -   export EXRREPO=https://github.com/lgritz/openexr.git ;
-    -   export EXRBRANCH=lg-cpp11 ;
     - if [ $TRAVIS_OS_NAME == osx ] ; then
           src/build-scripts/install_homebrew_deps.bash ;
           export PATH=/usr/local/opt/qt5/bin:$PATH ;
@@ -80,8 +75,8 @@ install:
           export PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages:$PYTHONPATH ;
       elif [ $TRAVIS_OS_NAME == linux ] ; then
           CXX="ccache $CXX" CCACHE_CPP2=1 src/build-scripts/build_openexr.bash ;
-          export ILMBASE_HOME=$PWD/openexr-install ;
-          export OPENEXR_HOME=$PWD/openexr-install ;
+          export ILMBASE_HOME=$PWD/ext/openexr-install ;
+          export OPENEXR_HOME=$PWD/ext/openexr-install ;
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OPENEXR_HOME/lib ;
           CXX="ccache $CXX" CCACHE_CPP2=1 src/build-scripts/build_ocio.bash ;
           export OCIO_PATH=$PWD/ext/OpenColorIO/dist ;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,12 +23,12 @@ environment:
 install:
   - cinstall: python
   - git submodule update --init --recursive
-  - set CMAKE_PREFIX_PATH=C:/Sys;%APPVEYOR_BUILD_FOLDER%/deps
-  - set CMAKE_LIBRARY_PATH=C:/Sys/lib;%APPVEYOR_BUILD_FOLDER%/deps/lib
-  - set CMAKE_INCLUDE_PATH=C:/Sys/include;%APPVEYOR_BUILD_FOLDER%/deps/include
+  - set CMAKE_PREFIX_PATH=C:/Sys;%APPVEYOR_BUILD_FOLDER%/ext
+  - set CMAKE_LIBRARY_PATH=C:/Sys/lib;%APPVEYOR_BUILD_FOLDER%/ext/lib
+  - set CMAKE_INCLUDE_PATH=C:/Sys/include;%APPVEYOR_BUILD_FOLDER%/ext/include
   - mkdir c:\sys
-  - mkdir deps
-  - cd deps
+  - mkdir ext
+  - cd ext
   - mkdir lib
   - mkdir include
 
@@ -47,10 +47,10 @@ install:
 
   # PNG
   - nuget install libpng-%tbs_tools%-%tbs_arch%-master -Version 1.6.18.44 -Source https://ci.appveyor.com/nuget/libpng-7hwq4pmmrc48
-  - set CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%APPVEYOR_BUILD_FOLDER%/deps/libpng-msvc14-x64-master.1.6.18.44
+  - set CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%APPVEYOR_BUILD_FOLDER%/ext/libpng-msvc14-x64-master.1.6.18.44
 
   # OpenEXR   FIXME - this is 2.0?
-  - set EXRINSTALLDIR=%APPVEYOR_BUILD_FOLDER%/deps/openexr-install
+  - set EXRINSTALLDIR=%APPVEYOR_BUILD_FOLDER%/ext/openexr-install
   - set EXRVERSION=2.2.0
   - mkdir openexr-install
   - git clone -b v%EXRVERSION% https://github.com/openexr/openexr.git ./openexr
@@ -84,7 +84,7 @@ install:
 
   # JPEG
   - nuget install libjpeg-%tbs_tools%-%tbs_arch%-master -Version 1.4.80.21 -Source https://ci.appveyor.com/nuget/libjpegturbo-o6k4js4y7pjw
-  - set CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%APPVEYOR_BUILD_FOLDER%/deps/libjpeg-msvc14-x64-master.1.4.80.21
+  - set CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%APPVEYOR_BUILD_FOLDER%/ext/libjpeg-msvc14-x64-master.1.4.80.21
 
   # Boost
   - set BOOST_ROOT=C:\Libraries\boost_1_63_0
@@ -94,24 +94,24 @@ install:
 
   # OpenColorIO
   # - svn co https://svn.blender.org/svnroot/bf-blender/trunk//lib/win64_vc14/OpenColorIO
-  # - set CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%APPVEYOR_BUILD_FOLDER%/deps/OpenColorIO
+  # - set CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%APPVEYOR_BUILD_FOLDER%/ext/OpenColorIO
 
   # FFmpeg
   # - svn co https://svn.blender.org/svnroot/bf-blender/trunk//lib/win64/ffmpeg
-  # - set CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%APPVEYOR_BUILD_FOLDER%/deps/ffmpeg
+  # - set CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%APPVEYOR_BUILD_FOLDER%/ext/ffmpeg
 
   # Freetype
   # - nuget install freetype-%tbs_tools%-%tbs_arch%-master -Version 2.6.2.1 -Source https://ci.appveyor.com/nuget/freetype-vf7bw7v5ec29
-  # - ps: move freetype*\* deps -force
-  # - set CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%APPVEYOR_BUILD_FOLDER%/deps/freetype
+  # - ps: move freetype*\* ext -force
+  # - set CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%APPVEYOR_BUILD_FOLDER%/ext/freetype
 
   - cd ..
   - dir C:\Sys
   - dir C:\Sys\include
   - dir C:\Sys\lib
-  - dir C:\projects\oiio\deps
-  - dir C:\projects\oiio\deps\include
-  - dir C:\projects\oiio\deps\lib
+  - dir C:\projects\oiio\ext
+  - dir C:\projects\oiio\ext\include
+  - dir C:\projects\oiio\ext\lib
 
 
 build_script:
@@ -120,7 +120,7 @@ build_script:
   - mkdir build
   - mkdir build\windows64
   - cd build\windows64
-  - cmake -G "%CMAKE_PLATFORM%" -DPYTHON_INCLUDE_DIR:PATH=%PYTHON_DIR%/include -DPYTHON_LIBRARY:FILEPATH=%PYTHON_DIR%/libs/python27.lib -DPYTHON_EXECUTABLE:FILEPATH=%PYTHON_DIR%/python.exe -DCMAKE_LIBRARY_PATH=%CMAKE_LIBRARY_PATH% -DCMAKE_INCLUDE_PATH=%CMAKE_INCLUDE_PATH%  -DCMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH% -DOPENEXR_HOME=C:\projects\oiio\deps -DVERBOSE=1 -DBUILD_MISSING_DEPS=1 ../..
+  - cmake -G "%CMAKE_PLATFORM%" -DPYTHON_INCLUDE_DIR:PATH=%PYTHON_DIR%/include -DPYTHON_LIBRARY:FILEPATH=%PYTHON_DIR%/libs/python27.lib -DPYTHON_EXECUTABLE:FILEPATH=%PYTHON_DIR%/python.exe -DCMAKE_LIBRARY_PATH=%CMAKE_LIBRARY_PATH% -DCMAKE_INCLUDE_PATH=%CMAKE_INCLUDE_PATH%  -DCMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH% -DOPENEXR_HOME=C:\projects\oiio\ext -DVERBOSE=1 -DBUILD_MISSING_DEPS=1 ../..
   - dir c:\projects\oiio
   - dir c:\projects\oiio\build
   - dir c:\projects\oiio\build\windows64

--- a/site/spi/Makefile-bits-arnold
+++ b/site/spi/Makefile-bits-arnold
@@ -97,9 +97,15 @@ ifeq (${SP_OS}, rhel7)
 	MY_CMAKE_FLAGS += -DCMAKE_C_FLAGS="--gcc-toolchain=/usr" -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr"
     endif
 
+    # Set our preferred OpenEXR path, but allow env variable to override
+    # with custom/test version.
+    ifeq (${OPENEXR_HOME},)
+	MY_CMAKE_FLAGS += \
+	    -DOPENEXR_CUSTOM_INCLUDE_DIR=/usr/include/OpenEXR2 \
+	    -DOPENEXR_CUSTOM_LIB_DIR=/usr/lib64/OpenEXR2
+    endif
+
     MY_CMAKE_FLAGS += \
-	-DOPENEXR_CUSTOM_INCLUDE_DIR=/usr/include/OpenEXR2 \
-	-DOPENEXR_CUSTOM_LIB_DIR=/usr/lib64/OpenEXR2 \
 	-DOCIO_PATH=${OCIO_PATH} \
 	-DFIELD3D_HOME=${FIELD3D_HOME} \
 	-DHDF5_CUSTOM=1 \

--- a/site/spi/Makefile-bits-spcomp2
+++ b/site/spi/Makefile-bits-spcomp2
@@ -129,9 +129,15 @@ ifeq (${SP_OS}, rhel7)
            -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
     endif
 
+    # Set our preferred OpenEXR path, but allow env variable to override
+    # with custom/test version.
+    ifeq (${OPENEXR_HOME},)
+	MY_CMAKE_FLAGS += \
+	    -DOPENEXR_CUSTOM_INCLUDE_DIR=/usr/include/OpenEXR2 \
+	    -DOPENEXR_CUSTOM_LIB_DIR=/usr/lib64/OpenEXR2
+    endif
+
     MY_CMAKE_FLAGS += \
-	-DOPENEXR_CUSTOM_INCLUDE_DIR=/usr/include/OpenEXR2 \
-	-DOPENEXR_CUSTOM_LIB_DIR=/usr/lib64/OpenEXR2 \
 	-DOCIO_PATH=${OCIO_PATH} \
 	-DFIELD3D_HOME=${FIELD3D_HOME} \
 	-DHDF5_CUSTOM=1 \

--- a/src/build-scripts/build_openexr.bash
+++ b/src/build-scripts/build_openexr.bash
@@ -1,23 +1,24 @@
 #!/bin/bash
 
 # The Linux VM used by Travis has OpenEXR 1.x. We really want 2.x.
+# This script downloads and builds OpenEXR in the ext/ subdirectory.
 
 EXRREPO=${EXRREPO:=https://github.com/openexr/openexr.git}
-EXRINSTALLDIR=${EXRINSTALLDIR:=${PWD}/openexr-install}
-EXRBRANCH=${EXRBRANCH:=v2.2.0}
+EXRINSTALLDIR=${EXRINSTALLDIR:=${PWD}/ext/openexr-install}
+EXRBRANCH=${EXRBRANCH:=v2.3.0}
 EXRCXXFLAGS=${EXRCXXFLAGS:=""}
 BASEDIR=`pwd`
 pwd
 echo "EXR install dir will be: ${EXRINSTALLDIR}"
 
 if [ ! -e ${EXRINSTALLDIR} ] ; then
-    mkdir ${EXRINSTALLDIR}
+    mkdir -p ${EXRINSTALLDIR}
 fi
 
 # Clone OpenEXR project (including IlmBase) from GitHub and build
-if [ ! -e ./openexr ] ; then
-    echo "git clone ${EXRREPO} ./openexr"
-    git clone ${EXRREPO} ./openexr
+if [ ! -e ./ext/openexr ] ; then
+    echo "git clone ${EXRREPO} ./ext/openexr"
+    git clone ${EXRREPO} ./ext/openexr
 fi
 
 flags=
@@ -26,23 +27,36 @@ if [ ${LINKSTATIC:=0} == 1 ] ; then
     flags=${flags} --enable-static --enable-shared=no --with-pic
 fi
 
-pushd ./openexr
+pushd ./ext/openexr
 echo "git checkout ${EXRBRANCH} --force"
 git checkout ${EXRBRANCH} --force
-cd IlmBase
-mkdir build
-cd build
-cmake --config Release -DCMAKE_INSTALL_PREFIX=${EXRINSTALLDIR} -DCMAKE_CXX_FLAGS=${EXRCXXFLAGS} .. && make clean && make -j 4 && make install
-cd ..
-cd ../OpenEXR
-cp ${BASEDIR}/src/build-scripts/OpenEXR-CMakeLists.txt CMakeLists.txt
-cp ${BASEDIR}/src/build-scripts/OpenEXR-IlmImf-CMakeLists.txt IlmImf/CMakeLists.txt
-mkdir build
-mkdir build/IlmImf
-cd build
-unzip -d IlmImf ${BASEDIR}/src/build-scripts/b44ExpLogTable.h.zip
-unzip -d IlmImf ${BASEDIR}/src/build-scripts/dwaLookups.h.zip
-cmake --config Release -DCMAKE_INSTALL_PREFIX=${EXRINSTALLDIR} -DILMBASE_PACKAGE_PREFIX=${EXRINSTALLDIR} -DBUILD_UTILS=0 -DBUILD_TESTS=0 -DCMAKE_CXX_FLAGS=${EXRCXXFLAGS} .. && make clean && make -j 4 && make install
+
+if [ ${EXRBRANCH} == "v2.3.0" ] ; then
+    # Simplified setup for 2.3+
+    mkdir build
+    cd build
+    mkdir OpenEXR
+    mkdir OpenEXR/IlmImf
+    unzip -d OpenEXR/IlmImf ${BASEDIR}/src/build-scripts/b44ExpLogTable.h.zip
+    unzip -d OpenEXR/IlmImf ${BASEDIR}/src/build-scripts/dwaLookups.h.zip
+    cmake --config Release -DCMAKE_INSTALL_PREFIX=${EXRINSTALLDIR} -DILMBASE_PACKAGE_PREFIX=${EXRINSTALLDIR} -DOPENEXR_BUILD_UTILS=0 -DOPENEXR_BUILD_TESTS=0 -DOPENEXR_BUILD_PYTHON_LIBS=0 -DCMAKE_CXX_FLAGS=${EXRCXXFLAGS} .. && make clean && make -j 4 && make install
+else
+    cd IlmBase
+    mkdir build
+    cd build
+    cmake --config Release -DCMAKE_INSTALL_PREFIX=${EXRINSTALLDIR} -DCMAKE_CXX_FLAGS=${EXRCXXFLAGS} .. && make clean && make -j 4 && make install
+    cd ..
+    cd ../OpenEXR
+    cp ${BASEDIR}/src/build-scripts/OpenEXR-CMakeLists.txt CMakeLists.txt
+    cp ${BASEDIR}/src/build-scripts/OpenEXR-IlmImf-CMakeLists.txt IlmImf/CMakeLists.txt
+    mkdir build
+    mkdir build/IlmImf
+    cd build
+    unzip -d IlmImf ${BASEDIR}/src/build-scripts/b44ExpLogTable.h.zip
+    unzip -d IlmImf ${BASEDIR}/src/build-scripts/dwaLookups.h.zip
+    cmake --config Release -DCMAKE_INSTALL_PREFIX=${EXRINSTALLDIR} -DILMBASE_PACKAGE_PREFIX=${EXRINSTALLDIR} -DBUILD_UTILS=0 -DBUILD_TESTS=0 -DCMAKE_CXX_FLAGS=${EXRCXXFLAGS} .. && make clean && make -j 4 && make install
+fi
+
 popd
 
 ls -R ${EXRINSTALLDIR}


### PR DESCRIPTION
No longer need to build an lgritz private one, since 2.3.0 has some
fixes we needed for gcc7 and C++17 compatibility.

Also move the OpenEXR download and installation into the ext/ subdir
where we put other build dependencies.

For SPI, change the site/Makefile-bits files so that OPENEXR_HOME env
variable can override the default system install of OpenEXR (makes it
easier for me to test custom builds).

