### PR TITLE
Use pkgconfig in FindOpenEXR.cmake if available

### DIFF
--- a/src/cmake/modules/FindOpenEXR.cmake
+++ b/src/cmake/modules/FindOpenEXR.cmake
@@ -27,6 +27,13 @@ if (CMAKE_USE_PTHREADS_INIT)
     set (ILMBASE_PTHREADS ${CMAKE_THREAD_LIBS_INIT})
 endif ()
 
+# Attempt to find OpenEXR with pkgconfig
+find_package(PkgConfig)
+if (PKG_CONFIG_FOUND)
+    pkg_check_modules(_ILMBASE QUIET IlmBase)
+    pkg_check_modules(_OPENEXR QUIET OpenEXR>=2.0.0)
+endif (PKG_CONFIG_FOUND)
+
 # List of likely places to find the headers -- note priority override of
 # OPENEXR_CUSTOM_INCLUDE_DIR and ${OPENEXR_HOME}/include.
 # ILMBASE is needed in case ilmbase an openexr are installed in separate
@@ -35,6 +42,8 @@ set (GENERIC_INCLUDE_PATHS
     ${OPENEXR_CUSTOM_INCLUDE_DIR}
     ${OPENEXR_HOME}/include
     ${ILMBASE_HOME}/include
+    ${_ILMBASE_INCLUDEDIR}
+    ${_OPENEXR_INCLUDEDIR}
     /usr/local/include
     /usr/include
     /usr/include/${CMAKE_LIBRARY_ARCHITECTURE}

--- a/src/cmake/modules/FindOpenEXR.cmake
+++ b/src/cmake/modules/FindOpenEXR.cmake
@@ -99,6 +99,8 @@ set (GENERIC_LIBRARY_PATHS
     ${GENERIC_LIBRARY_PATHS}
     ${OPENEXR_INCLUDE_PATH}/../lib
     ${ILMBASE_INCLUDE_PATH}/../lib
+    ${_ILMBASE_LIBDIR}
+    ${_OPENEXR_LIBDIR}
     /usr/local/lib
     /usr/local/lib/${CMAKE_LIBRARY_ARCHITECTURE}
     /usr/lib


### PR DESCRIPTION
## Description
Inspired by the FindFFmpeg.cmake and FindLibRaw.cmake files I added similar use of pkgconfig to locate IlmBase and OpenEXR include directories.
The potentially found paths are appended to `GENERIC_INCLUDE_PATHS` respecting the search order that was before.

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests
I have not added any tests, but it seems to build the way it should.
<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

