### PR TITLE
Reorganize how texture3d transforms points to local space of the volume.

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -436,17 +436,12 @@ ImageCacheFile::SubimageInfo::init (ImageCacheFile &icfile,
             has_average_color = true;
     }
 
-    if (icfile.m_texformat == TexFormatTexture3d ||
-            icfile.m_texformat == TexFormatShadow ||
-            icfile.m_texformat == TexFormatCubeFaceShadow ||
-            icfile.m_texformat == TexFormatVolumeShadow) {
-        const ParamValue *p = spec.find_attribute ("worldtolocal", TypeMatrix);
-        if (p) {
-            Imath::M44f c2w;
-            icfile.m_imagecache.get_commontoworld (c2w);
-            const Imath::M44f *m = (const Imath::M44f *)p->data();
-            Mlocal.reset (new Imath::M44f (c2w * (*m)));
-        }
+    const ParamValue *p = spec.find_attribute ("worldtolocal", TypeMatrix);
+    if (p) {
+        Imath::M44f c2w;
+        icfile.m_imagecache.get_commontoworld (c2w);
+        const Imath::M44f *m = (const Imath::M44f *)p->data();
+        Mlocal.reset (new Imath::M44f (c2w * (*m)));
     }
 }
 


### PR DESCRIPTION
What happens when texture3d is called on a point? There was a special
back door for Field3d, but this didn't generalize well. For example, we
want to support texture3d lookups from OpenVDB files (coming soon under
a separate PR -- this is a necessary prelude).

This patch:

* Makes each ImageCacheFile::SubimageInfo contain a unique_ptr to a 4x4
  matrix (so it doesn't use as much space except when needed, which is a
  small minority of all texture files). This also moves (commented-out)
  matrix info for (unsupported) shadow maps from per-file to per-subimage.

* If reading the spec for that subimage yields a "worldtocamera" or
  "worldtolocal" matrix metada, we allocate the space and stash the
  matrix there.

* The texture3d() call looks for the matrix, and if found, uses it to
  transform the input point to the local volume space. Only if this is
  not found does it check for the special field3d back door (which
  exists because f3d supports time-varying transforms that aren't a
  single matrix). If that, too fails, then no transform is applied.

