### PR TITLE
ImageCache: add a way to add_tile without a pixel copy

### DIFF
--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -355,12 +355,15 @@ public:
     /// given format, with supplied strides) which will be copied and
     /// inserted into the cache and made available for future lookups.
     /// If chend < chbegin, it will add a tile containing the full set of
-    /// channels for the image.
+    /// channels for the image. Note that if the 'copy' flag is false, the
+    /// data is assumed to be in some kind of persistent storage and will
+    /// not be copied, nor will its pixels take up additional memory in the
+    /// cache.
     virtual bool add_tile (ustring filename, int subimage, int miplevel,
                      int x, int y, int z, int chbegin, int chend,
                      TypeDesc format, const void *buffer,
                      stride_t xstride=AutoStride, stride_t ystride=AutoStride,
-                     stride_t zstride=AutoStride) = 0;
+                     stride_t zstride=AutoStride, bool copy = true) = 0;
 
     /// If any of the API routines returned false indicating an error,
     /// this routine will return the error string (and clear any error

--- a/src/libOpenImageIO/imagecache_test.cpp
+++ b/src/libOpenImageIO/imagecache_test.cpp
@@ -41,7 +41,8 @@ using namespace OIIO;
 
 
 
-
+// Tests various ways for the subset of channels to be cached in a
+// many-channel image.
 void
 test_get_pixels_cachechannels (int chbegin = 0, int chend = 4,
                                int cache_chbegin = 0, int cache_chend = -1)
@@ -84,6 +85,81 @@ test_get_pixels_cachechannels (int chbegin = 0, int chend = 4,
 
 
 
+// Wimple wrapper to return a raw "null" ImageInput*.
+static ImageInput* NullInputCreator ()
+{
+    // Note: we can't create it directly, but we can ask for a managed
+    // pointer and then release the raw pointer from it.
+    return ImageInput::create("0.null").release ();
+}
+
+
+// Test the ability to add an application buffer to make it appear as if
+// it's an image in the cache.
+void
+test_app_buffer ()
+{
+    ImageCache *imagecache = ImageCache::create (false /*not shared*/);
+
+    // Add a file entry with a "null" ImageInput proxy configured to look
+    // like a 2x2 RGB float image.
+    ustring fooname ("foo");
+    const int xres = 2, yres = 2, chans = 3;
+    TypeDesc imgtype = TypeDesc::FLOAT;
+    ImageSpec config (xres, yres, chans, imgtype);
+    config.tile_width = xres;
+    config.tile_height = yres;
+    config.attribute ("null:force", 1); // necessary because no .null extension
+    bool fadded = imagecache->add_file (fooname, NullInputCreator, &config);
+    OIIO_CHECK_ASSERT (fadded);
+
+    // Make sure it got added correctly
+    ImageSpec retrieved_spec;
+    imagecache->get_imagespec (fooname, retrieved_spec);
+    OIIO_CHECK_EQUAL (retrieved_spec.width, xres);
+    OIIO_CHECK_EQUAL (retrieved_spec.height, yres);
+    OIIO_CHECK_EQUAL (retrieved_spec.format, imgtype);
+
+    // Here's our image of data, in our own buffer.
+    static float pixels[yres][xres][chans] = {
+        { {0, 0, 0},  {0, 1, 0} },
+        { {1, 0, 0},  {1, 1, 0} } };
+    // Add a proxy tile that points to -- but does not copy -- the image.
+    bool ok = imagecache->add_tile (fooname,
+                                    0 /* subimage */, 0 /* miplevel */,
+                                    0, 0, 0, /* origin */
+                                    0, chans, /* channel range */
+                                    imgtype, pixels,  /* the buffer */
+                                    AutoStride, AutoStride, AutoStride, /* strides */
+                                    false /* DO NOT COPY THE PIXELS! */);
+    OIIO_CHECK_ASSERT (ok);
+
+    // Check that we can retrieve the tile.
+    ImageCache::Tile *tile = imagecache->get_tile (fooname, 0, 0, 0, 0, 0);
+    OIIO_CHECK_ASSERT (tile != nullptr);
+    imagecache->release_tile (tile);  // de-refcount what we got from get_tile
+
+    // Check that the tile's pixels appear to actually be our own buffer
+    TypeDesc format;
+    const void *pels = imagecache->tile_pixels (tile, format);
+    OIIO_CHECK_EQUAL (pels, pixels);
+    OIIO_CHECK_EQUAL (format, TypeDesc::FLOAT);
+
+    // Check that retrieving the pixel (as would be done by the texture
+    // system) returns the right color. This would work for texture calls
+    // and whatnot as well.
+    float testpixel[3] = { -1, -1, -1 };
+    imagecache->get_pixels (fooname, 0, 0, 1, 2, 1, 2, 0, 1, 0, 3,
+                            TypeDesc::FLOAT, testpixel);
+    OIIO_CHECK_EQUAL (testpixel[0], pixels[1][1][0]);
+    OIIO_CHECK_EQUAL (testpixel[1], pixels[1][1][1]);
+    OIIO_CHECK_EQUAL (testpixel[2], pixels[1][1][2]);
+
+    ImageCache::destroy (imagecache);
+}
+
+
+
 int
 main (int argc, char **argv)
 {
@@ -93,6 +169,8 @@ main (int argc, char **argv)
     test_get_pixels_cachechannels (0, 4, 0, 4);
     test_get_pixels_cachechannels (6, 9);
     test_get_pixels_cachechannels (6, 9, 6, 9);
+
+    test_app_buffer ();
 
     return unit_test_failures;
 }

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -568,7 +568,8 @@ public:
     /// Construct a new tile out of the pixels supplied.
     ///
     ImageCacheTile (const TileID &id, const void *pels, TypeDesc format,
-                    stride_t xstride, stride_t ystride, stride_t zstride);
+                    stride_t xstride, stride_t ystride, stride_t zstride,
+                    bool copy = true);
 
     ~ImageCacheTile ();
 
@@ -654,12 +655,13 @@ public:
 private:
     TileID m_id;                  ///< ID of this tile
     std::unique_ptr<char[]> m_pixels;  ///< The pixel data
-    size_t m_pixels_size;         ///< How much m_pixels has allocated
-    int m_channelsize;            ///< How big is each channel (bytes)
-    int m_pixelsize;              ///< How big is each pixel (bytes)
-    bool m_valid;                 ///< Valid pixels
-    volatile bool m_pixels_ready; ///< The pixels have been read from disk
-    atomic_int m_used;            ///< Used recently
+    size_t m_pixels_size {0};     ///< How much m_pixels has allocated
+    int m_channelsize {0};        ///< How big is each channel (bytes)
+    int m_pixelsize {0};          ///< How big is each pixel (bytes)
+    bool m_valid {false};         ///< Valid pixels
+    bool m_nofree {false};        ///< We do NOT own the pixels, do not free!
+    volatile bool m_pixels_ready {false}; ///< The pixels have been read from disk
+    atomic_int m_used {1};        ///< Used recently
 };
 
 
@@ -956,7 +958,7 @@ public:
                            int x, int y, int z,  int chbegin, int chend,
                            TypeDesc format, const void *buffer,
                            stride_t xstride, stride_t ystride,
-                           stride_t zstride);
+                           stride_t zstride, bool copy);
 
     /// Return the numerical subimage index for the given subimage name,
     /// as stored in the "oiio:subimagename" metadata.  Return -1 if no

--- a/testsuite/null/ref/out.txt
+++ b/testsuite/null/ref/out.txt
@@ -1,5 +1,5 @@
-Reading foo.null?RES=640x480&CHANNELS=3&PIXEL=0.25,0.5,1
-foo.null?RES=640x480&CHANNELS=3&PIXEL=0.25,0.5,1 :  640 x  480, 3 channel, uint8 null
+Reading foo.null?RES=640x480&CHANNELS=3&TYPE=uint8&PIXEL=0.25,0.5,1
+foo.null?RES=640x480&CHANNELS=3&TYPE=uint8&PIXEL=0.25,0.5,1 :  640 x  480, 3 channel, uint8 null
     channel list: R, G, B
     Stats Min: 64 128 255 (of 255)
     Stats Max: 64 128 255 (of 255)

--- a/testsuite/null/run.py
+++ b/testsuite/null/run.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-command += oiiotool ("-v -info -stats 'foo.null?RES=640x480&CHANNELS=3&PIXEL=0.25,0.5,1'")
+command += oiiotool ("-v -info -stats 'foo.null?RES=640x480&CHANNELS=3&TYPE=uint8&PIXEL=0.25,0.5,1'")


### PR DESCRIPTION
The point of this feature is that your app has a buffer of pixels, and
you want the IC or TextureSystem to use that buffer directly, without
copying the texels or owning the memory. It should also not count the
memory against the limits of the cache.

See imagecache_test.cpp, the test I added as text_app_buffer() which
pretty much spells out how to do it from the app point of view.

From an API standpoint, all that changes is an optional argument to
add_tile that lets you disable the copy.

You need to make it a tile of an image in the cache, though, and the
obvious no-drama choice is just to use a "null" ImageInput as a
placeholder.  In the process, I noticed two helpful enhancement I could
make to the null ImageInput better:

1. Make sure that passing a "config" spec results in the right resolution
   and data type -- in fact, there was a bug where the config's res would
   be overwritten by a 1024x1024x4xUINT8 default. Oops. So only overwrite
   those fields if they are not set in the config.

2. What if you want one of these fake inputs but you don't want the name
   of the texture to be "blah.null"? So I added it so that if the config
   has metadata hint "null:force" set to nonzero, it will always succeed
   in creating a null ImageInput.

