### PR TITLE
Fixes rare crash when lowering number of threads

### DIFF
--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -159,7 +159,8 @@ public:
             else {  // the number of threads is decreased
                 for (int i = oldNThreads - 1; i >= nThreads; --i) {
                     *this->flags[i] = true;  // this thread will finish
-                    this->threads[i]->detach();
+                    this->terminating_threads.push_back(std::move(this->threads[i]));
+                    this->threads.erase(this->threads.begin() + i);
                 }
                 {
                     // stop the detached threads that were waiting
@@ -218,10 +219,15 @@ public:
             if (thread->joinable())
                 thread->join();
         }
+        for (auto& thread : this->terminating_threads) {  // wait for the terminated threads to finish
+            if (thread->joinable())
+                thread->join();
+        }
         // if there were no threads in the pool but some functors in the queue, the functors are not deleted by the threads
         // therefore delete them here
         this->clear_queue();
         this->threads.clear();
+        this->terminating_threads.clear();
         this->flags.clear();
     }
 
@@ -317,6 +323,7 @@ private:
     void init() { this->nWaiting = 0; this->isStop = false; this->isDone = false; }
 
     std::vector<std::unique_ptr<std::thread>> threads;
+    std::vector<std::unique_ptr<std::thread>> terminating_threads;
     std::vector<std::shared_ptr<std::atomic<bool>>> flags;
     mutable Queue<std::function<void(int id)> *> q;
     std::atomic<bool> isDone;


### PR DESCRIPTION
## Description
More details, including a hopefully easy repro that works on OSX, are in #1991.

The way this fix works is that instead of detaching threads, which by bad luck might stay running and access thread pool data after the thread pool is destroyed, we stay attached and move the threads into a list of threads that we have to explicitly wait on to be finished, just like we already do for the active threads.

## Tests

The crash is very hard to reproduce without adding a 1s sleep, and even then I suspect the 1s worked for me because my process runs in under 1s. Maybe you'll need to sleep for at least as long as it takes to go from lowering the number of threads to terminating the process so that we can be assured the detached threads survive to the end?

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x ] My code follows the prevailing code style of this project.

