### PR TITLE
raw DSLR image read improvements to color space identification.

### DIFF
--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -383,7 +383,6 @@ RawInput::open_raw (bool unpack, const std::string &name,
     m_processor->imgdata.params.output_bps = 16;
 
     // Set the gamma curve to Linear
-    m_spec.attribute("oiio:ColorSpace","Linear");
     m_processor->imgdata.params.gamm[0] = 1.0;
     m_processor->imgdata.params.gamm[1] = 1.0;
 
@@ -410,7 +409,8 @@ RawInput::open_raw (bool unpack, const std::string &name,
         config.get_int_attribute("raw:use_camera_matrix", 1);
 
 
-    // Check to see if the user has explicitly set the output colorspace primaries
+    // Check to see if the user has explicitly set the output colorspace primaries.
+    // The default is to ask it to convert to sRGB space.
     std::string cs = config.get_string_attribute ("raw:ColorSpace", "sRGB");
     if (cs.size()) {
         static const char *colorspaces[] = { "raw",
@@ -442,12 +442,11 @@ RawInput::open_raw (bool unpack, const std::string &name,
             error("raw:ColorSpace set to unknown value");
             return false;
         }
-        // Set the attribute in the output spec
-        m_spec.attribute("raw:ColorSpace", cs);
+        m_spec.attribute ("oiio:ColorSpace", cs);
     } else {
         // By default we use sRGB primaries for simplicity
         m_processor->imgdata.params.output_color = 1;
-        m_spec.attribute("raw:ColorSpace", "sRGB");
+        m_spec.attribute ("oiio:ColorSpace", "sRGB");
     }
 
     // Exposure adjustment

--- a/testsuite/raw/ref/out-libraw0.18.11.txt
+++ b/testsuite/raw/ref/out-libraw0.18.11.txt
@@ -149,8 +149,7 @@
     Exif:SubsecTimeDigitized: "00"
     Exif:SubsecTimeOriginal: "00"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "Linear"
-    raw:ColorSpace: "sRGB"
+    oiio:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
@@ -217,9 +216,8 @@
     Nikon:MaxFocal: 70
     Nikon:MCUVersion: 99
     Nikon:MinFocal: 28
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "sRGB"
     oiio:MakerNoteOffset: 0
-    raw:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
     raw:Orientation: 8
 ../../../../../oiio-images/raw/RAW_FUJI_F700.RAF : 2035 x 1533, 3 channel, uint16 raw
@@ -290,9 +288,8 @@
     Fujifilm:Rating: 0
     Fujifilm:ShutterType: 0
     Fujifilm:WB_Preset: 0
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "sRGB"
     oiio:MakerNoteOffset: 0
-    raw:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
@@ -359,9 +356,8 @@
     Nikon:MaxFocal: 70
     Nikon:MCUVersion: 99
     Nikon:MinFocal: 28
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "sRGB"
     oiio:MakerNoteOffset: 0
-    raw:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
     raw:Orientation: 8
 ../../../../../oiio-images/raw/RAW_OLYMPUS_E3.ORF : 3720 x 2800, 3 channel, uint16 raw
@@ -403,7 +399,7 @@
     Exif:Sharpness: 1 (soft)
     Exif:ShutterSpeedValue: 8.32193 (1/319 s)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "sRGB"
     oiio:MakerNoteOffset: 0
     Olympus:AFPoint: 0
     Olympus:AFPointSelected: 0, 0, 0, 0, 0
@@ -431,7 +427,6 @@
     Olympus:OlympusCropID: -1
     Olympus:OlympusFrame: 0, 0, 0, 0
     Olympus:OlympusSensorCalibration: 0, 0
-    raw:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_PANASONIC_G1.RW2 : 4016 x 3016, 3 channel, uint16 raw
     channel list: R, G, B
@@ -455,13 +450,12 @@
     Exif:MaxApertureValue: 925/256 (3.61328)
     Exif:MeteringMode: 5 (pattern)
     Exif:ShutterSpeedValue: 8.64386 (1/399 s)
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "sRGB"
     Panasonic:AFPoint: -1
     Panasonic:CanonFocalUnits: 1
     Panasonic:EXIF_MaxAp: 3.49827
     Panasonic:ImageStabilization: -1
     Panasonic:LensID: 18446744073709551615
-    raw:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_PENTAX_K200D.PEF : 2616 x 3896, 3 channel, uint16 raw
     channel list: R, G, B
@@ -497,7 +491,7 @@
     Exif:ShutterSpeedValue: 7.96578 (1/249 s)
     Exif:SubjectDistanceRange: 3 (distant)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "sRGB"
     oiio:MakerNoteOffset: 0
     Pentax:AFPoint: -1
     Pentax:BodySerial: "0"
@@ -518,7 +512,6 @@
     Pentax:MinAp4CurFocal: 32
     Pentax:MinAp4MinFocal: 32
     Pentax:MinFocusDistance: 16
-    raw:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
     raw:Orientation: 8
 ../../../../../oiio-images/raw/RAW_SONY_A300.ARW : 3880 x 2608, 3 channel, uint16 raw
@@ -563,9 +556,8 @@
     Exif:Sharpness: 0 (normal)
     Exif:ShutterSpeedValue: 5.90689 (1/59 s)
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "sRGB"
     oiio:MakerNoteOffset: 0
-    raw:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
     Sony:AFPoint: -1
     Sony:CameraFormat: 1

--- a/testsuite/raw/ref/out-oldlibraw0.15.txt
+++ b/testsuite/raw/ref/out-oldlibraw0.15.txt
@@ -13,8 +13,7 @@
     Exif:FocalLength: 200 (200 mm)
     Exif:ISOSpeedRatings: 100
     Exif:ShutterSpeedValue: 8.375 (1/331 s)
-    oiio:ColorSpace: "Linear"
-    raw:ColorSpace: "sRGB"
+    oiio:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
@@ -31,8 +30,7 @@
     Exif:FocalLength: 70 (70 mm)
     Exif:ISOSpeedRatings: 100
     Exif:ShutterSpeedValue: 5.64386 (1/49 s)
-    oiio:ColorSpace: "Linear"
-    raw:ColorSpace: "sRGB"
+    oiio:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_FUJI_F700.RAF : 2035 x 1533, 3 channel, uint16 raw
     channel list: R, G, B
@@ -48,8 +46,7 @@
     Exif:FocalLength: 8.5 (8.5 mm)
     Exif:ISOSpeedRatings: 200
     Exif:ShutterSpeedValue: 9.7 (1/831 s)
-    oiio:ColorSpace: "Linear"
-    raw:ColorSpace: "sRGB"
+    oiio:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
@@ -66,8 +63,7 @@
     Exif:FocalLength: 70 (70 mm)
     Exif:ISOSpeedRatings: 100
     Exif:ShutterSpeedValue: 5.64386 (1/49 s)
-    oiio:ColorSpace: "Linear"
-    raw:ColorSpace: "sRGB"
+    oiio:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_OLYMPUS_E3.ORF : 3720 x 2800, 3 channel, uint16 raw
     channel list: R, G, B
@@ -84,8 +80,7 @@
     Exif:FocalLength: 50 (50 mm)
     Exif:ISOSpeedRatings: 200
     Exif:ShutterSpeedValue: 8.32193 (1/319 s)
-    oiio:ColorSpace: "Linear"
-    raw:ColorSpace: "sRGB"
+    oiio:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_PANASONIC_G1.RW2 : 4016 x 3016, 3 channel, uint16 raw
     channel list: R, G, B
@@ -101,8 +96,7 @@
     Exif:FocalLength: 14 (14 mm)
     Exif:ISOSpeedRatings: 100
     Exif:ShutterSpeedValue: 8.64386 (1/399 s)
-    oiio:ColorSpace: "Linear"
-    raw:ColorSpace: "sRGB"
+    oiio:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_PENTAX_K200D.PEF : 2616 x 3896, 3 channel, uint16 raw
     channel list: R, G, B
@@ -118,8 +112,7 @@
     Exif:FocalLength: 42.5 (42.5 mm)
     Exif:ISOSpeedRatings: 100
     Exif:ShutterSpeedValue: 7.96578 (1/249 s)
-    oiio:ColorSpace: "Linear"
-    raw:ColorSpace: "sRGB"
+    oiio:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_SONY_A300.ARW : 3880 x 2608, 3 channel, uint16 raw
     channel list: R, G, B
@@ -136,8 +129,7 @@
     Exif:FocalLength: 35 (35 mm)
     Exif:ISOSpeedRatings: 400
     Exif:ShutterSpeedValue: 5.90689 (1/59 s)
-    oiio:ColorSpace: "Linear"
-    raw:ColorSpace: "sRGB"
+    oiio:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 Comparing "RAW_CANON_EOS_7D.CR2.tif" and "ref/RAW_CANON_EOS_7D.CR2.tif"
 PASS

--- a/testsuite/raw/ref/out.txt
+++ b/testsuite/raw/ref/out.txt
@@ -74,9 +74,8 @@
     Exif:SubsecTimeDigitized: "00"
     Exif:SubsecTimeOriginal: "00"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "sRGB"
     oiio:MakerNoteOffset: 0
-    raw:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
@@ -160,9 +159,8 @@
     Nikon:PhaseDetectAF: 0
     Nikon:ShootingMode: 0
     Nikon:VRMode: 0
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "sRGB"
     oiio:MakerNoteOffset: 0
-    raw:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_FUJI_F700.RAF : 2035 x 1533, 3 channel, uint16 raw
     channel list: R, G, B
@@ -227,9 +225,8 @@
     Fujifilm:Rating: 0
     Fujifilm:ShutterType: 0
     Fujifilm:WB_Preset: 0
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "sRGB"
     oiio:MakerNoteOffset: 0
-    raw:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
@@ -313,9 +310,8 @@
     Nikon:PhaseDetectAF: 0
     Nikon:ShootingMode: 0
     Nikon:VRMode: 0
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "sRGB"
     oiio:MakerNoteOffset: 0
-    raw:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_OLYMPUS_E3.ORF : 3720 x 2800, 3 channel, uint16 raw
     channel list: R, G, B
@@ -353,7 +349,7 @@
     Exif:Sharpness: 1 (soft)
     Exif:ShutterSpeedValue: 8.32193 (1/319 s)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "sRGB"
     oiio:MakerNoteOffset: 0
     Olympus:AFFineTune: 0
     Olympus:AFPoint: 0
@@ -382,7 +378,6 @@
     Olympus:OlympusCropID: -1
     Olympus:OlympusFrame: 0, 0, 0, 0
     Olympus:OlympusSensorCalibration: 0, 0
-    raw:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_PANASONIC_G1.RW2 : 4016 x 3016, 3 channel, uint16 raw
     channel list: R, G, B
@@ -405,7 +400,7 @@
     Exif:MaxApertureValue: 925/256 (3.61328)
     Exif:MeteringMode: 5 (pattern)
     Exif:ShutterSpeedValue: 8.64386 (1/399 s)
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "sRGB"
     Panasonic:AFPoint: -1
     Panasonic:BlackLevel: 0, 0, 0, 0, 0, 0, 0, 0
     Panasonic:CanonFocalUnits: 1
@@ -413,7 +408,6 @@
     Panasonic:EXIF_MaxAp: 3.49827
     Panasonic:ImageStabilization: -1
     Panasonic:LensID: 18446744073709551615
-    raw:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_PENTAX_K200D.PEF : 2616 x 3896, 3 channel, uint16 raw
     channel list: R, G, B
@@ -446,7 +440,7 @@
     Exif:ShutterSpeedValue: 7.96578 (1/249 s)
     Exif:SubjectDistanceRange: 3 (distant)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "sRGB"
     oiio:MakerNoteOffset: 0
     Pentax:AFAdjustment: 0
     Pentax:AFPoint: -1
@@ -473,7 +467,6 @@
     Pentax:MinAp4CurFocal: 32
     Pentax:MinAp4MinFocal: 32
     Pentax:MinFocusDistance: 16
-    raw:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_SONY_A300.ARW : 3880 x 2608, 3 channel, uint16 raw
     channel list: R, G, B
@@ -514,9 +507,8 @@
     Exif:Sharpness: 0 (normal)
     Exif:ShutterSpeedValue: 5.90689 (1/59 s)
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "Linear"
+    oiio:ColorSpace: "sRGB"
     oiio:MakerNoteOffset: 0
-    raw:ColorSpace: "sRGB"
     raw:Demosaic: "AHD"
     Sony:AFMicroAdjOn: 0
     Sony:AFMicroAdjValue: 0


### PR DESCRIPTION
We were previously reporting "oiio:ColorSpace" for raw images always as "linear", but that's not really how the underlying libraw operates.  It converts to one of several color spaces as part of the debayering process (by default, sRGB), so make sure to report back the correct one, which should be the one you ask for. Also, no need to set the "raw:ColorSpace" attribute, that doesn't really tell you anything useful (it just repeats back the hint you asked for, but that's the same as the "oiio:ColorSpace").

