### PR TITLE
ImageCache/TextureSystem create/destroy adjustment

### DIFF
--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -166,13 +166,14 @@ through the external API of \product.  Because of this, you cannot
 construct or destroy the concrete implementation, so two static
 methods of \TextureSystem are provided:
 
-\apiitem{static TextureSystem *TextureSystem::{\ce create} (bool share=true)}
+\apiitem{static TextureSystem *TextureSystem::{\ce create} (bool share=true,\\
+\bitspc\bigspc ImageCache *imagecache=nullptr)}
 Creates a new \TextureSystem and returns a pointer to it.
-If {\cf shared} is {\cf true}, the \TextureSystem created will share its
-underlying \ImageCache with any other \TextureSystem's or \ImageCache's
-that requested shared caches.  If {\cf shared} is {\cf false}, a
-completely unique \ImageCache will be created that is private to this
-particular \TextureSystem.
+If {\cf shared} is {\cf true}, the \TextureSystem returned will be a global
+shared one, with a globally shared cache. If {\cf shared} is {\cf false}, a
+new private \TextureSystem will be created, either with a newly created
+private \ImageCache (if {\cf imagecache} is {\cf nullptr}), or with the
+\ImageCache passed from (and owned by) the caller.
 \apiend
 
 \apiitem{static void TextureSystem::{\ce destroy} (TextureSystem *x, \\

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -75,11 +75,12 @@ public:
     /// false, a private image cache will be created.
     static ImageCache *create (bool shared=true);
 
-    /// Destroy a ImageCache that was created using ImageCache::create().
-    /// The variety that takes a 'teardown' parameter, when set to true,
-    /// will fully destroy even a "shared" ImageCache.
-    static void destroy (ImageCache * x);
-    static void destroy (ImageCache * x, bool teardown);
+    /// Destroy an ImageCache that was created using ImageCache::create(),
+    /// unless it's recognized that this is the global "shared" ImageCache,
+    /// in which case it will stay active.
+    /// However, if 'teardown' is true, it will fully destroy the IC even
+    /// if it's the shared one (use with caution).
+    static void destroy (ImageCache * x, bool teardown = false);
 
     ImageCache (void) { }
     virtual ~ImageCache () { }

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3555,11 +3555,4 @@ ImageCache::destroy (ImageCache *x, bool teardown)
 }
 
 
-
-void
-ImageCache::destroy (ImageCache *x)
-{
-    destroy (x, false);
-}
-
 OIIO_NAMESPACE_END

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -349,6 +349,10 @@ public:
 
     typedef bool (*wrap_impl) (int &coord, int origin, int width);
 
+    /// Return an opaque, non-owning pointer to the underlying ImageCache
+    /// (if there is one).
+    virtual ImageCache *imagecache () const { return m_imagecache; }
+
 private:
     typedef ImageCacheTileRef TileRef;
     typedef ImageCachePerThreadInfo PerThreadInfo;
@@ -573,7 +577,8 @@ private:
     void visualize_ellipse (const std::string &name, float dsdx, float dtdx,
                             float dsdy, float dtdy, float sblur, float tblur);
 
-    ImageCacheImpl *m_imagecache;
+    ImageCacheImpl *m_imagecache = nullptr;
+    bool m_imagecache_owner = false; ///< True if we own the ImageCache
     Imath::M44f m_Mw2c;          ///< world-to-"common" matrix
     Imath::M44f m_Mc2w;          ///< common-to-world matrix
     bool m_gray_to_rgb;          ///< automatically copy gray to rgb channels?


### PR DESCRIPTION
* Add an optional argument to TS::create() that lets the caller directly
supply a pointer to an IC (which will not be freed when the TS destroys --
it's owned by the caller).

* Add a TextureSystem::imagecache() method that returns a blind,
non-owning pointer to the underlying IC.

* Clean up the 'destroy' methods, which previously for the sake of not
breaking compatibility mid-release had two separate varieties, but
clearly they can be one signature with an optional argument.
