### PR TITLE
Fix a double free of imagecache and add a replace mode for add_file()

### DIFF
--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -346,9 +346,12 @@ public:
     /// have no effect if there's already an image by the same name in the
     /// cache. Custom creators or configurations only "work" the FIRST time
     /// a particular filename is referenced in the lifetime of the
-    /// ImageCache.
+    /// ImageCache. But if replace is true, any existing entry will be
+    /// invalidated, closed and overwritten. So any subsequent access will see
+    /// the new file. Existing texture handles will still be valid.
     virtual bool add_file (ustring filename, ImageInput::Creator creator=nullptr,
-                           const ImageSpec *config=nullptr) = 0;
+                           const ImageSpec *config=nullptr,
+                           bool replace = false) = 0;
 
     /// Preemptively add a tile corresponding to the named image, at the
     /// given subimage, MIP level, and channel range.  The tile added is the

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -158,6 +158,7 @@ public:
                     const ImageSpec *config=nullptr);
     ~ImageCacheFile ();
 
+    void reset (ImageInput::Creator creator, const ImageSpec *config);
     bool broken () const { return m_broken; }
     int subimages () const { return (int)m_subimages.size(); }
     int miplevels (int subimage) const {
@@ -880,7 +881,8 @@ public:
                                ImageCachePerThreadInfo *thread_info,
                                ImageInput::Creator creator=nullptr,
                                bool header_only=false,
-                               const ImageSpec *config=nullptr);
+                               const ImageSpec *config=nullptr,
+                               bool replace=false);
 
     /// Verify & prep the ImageCacheFile record for the named image,
     /// return the pointer (which may have changed for deduplication),
@@ -953,7 +955,7 @@ public:
     virtual ROI tile_roi (const Tile *tile) const;
     virtual const void * tile_pixels (Tile *tile, TypeDesc &format) const;
     virtual bool add_file (ustring filename, ImageInput::Creator creator,
-                           const ImageSpec *config);
+                           const ImageSpec *config, bool replace);
     virtual bool add_tile (ustring filename, int subimage, int miplevel,
                            int x, int y, int z,  int chbegin, int chend,
                            TypeDesc format, const void *buffer,

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -365,8 +365,6 @@ TextureSystemImpl::init ()
 TextureSystemImpl::~TextureSystemImpl ()
 {
     printstats ();
-    ImageCache::destroy (m_imagecache);
-    m_imagecache = NULL;
     delete hq_filter;
 }
 


### PR DESCRIPTION
It is split in two commits, see the log. First one fixes a double free bug when the imagecache is provided to the texture system. The second is an option to make add_file() replace any existing entries. Useful for providing user buffers as textures that have already been queried (for instance to get a handle).