### PR TITLE
[CMake] Allow builds outside the source tree to pass testsuite.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,8 @@ option (BUILD_OIIOUTIL_ONLY "If ON, will build *only* libOpenImageIO_Util" OFF)
 option (BUILD_DOCS "If ON, build documentation and man pages." ON)
 option (INSTALL_DOCS "If ON, install documentation and man pages." ON)
 
+set(OIIO_TESTSUITE_IMAGEDIR "${PROJECT_SOURCE_DIR}/.." CACHE STRING
+    "Location of oiio-images, openexr-images, libtiffpic, etc.." )
 
 if (NOT OIIO_THREAD_ALLOW_DCLP)
     add_definitions ("-DOIIO_THREAD_ALLOW_DCLP=0")
@@ -235,21 +237,13 @@ add_custom_command (OUTPUT "${CMAKE_BINARY_DIR}/testsuite/runtest.py"
 add_custom_target ( CopyFiles ALL DEPENDS "${CMAKE_BINARY_DIR}/testsuite/runtest.py" )
 
 # Basic tests that apply even to continuous integration tests:
-oiio_add_tests (
-                gpsread misnamed-file nonwhole-tiles
-                oiiotool oiiotool-attribs oiiotool-composite oiiotool-copy
-                oiiotool-deep oiiotool-fixnan
-                oiiotool-pattern oiiotool-readerror
-                oiiotool-subimage oiiotool-text oiiotool-xform
+#   Tests that require oiio-images:
+oiio_add_tests (gpsread
+                oiiotool oiiotool-attribs oiiotool-readerror oiiotool-xform
+                oiiotool-fixnan ## maketx & oiiotool-maketx depend on this
                 maketx oiiotool-maketx
-                diff
-                dither dup-channels
-                dpx ico iff
-                jpeg-corrupt-exif
-                null png
-                psd psd-colormodes
-                rla sgi
-                rational
+                misnamed-file
+                dpx ico iff png psd rla sgi
                 texture-interp-bicubic
                 texture-blurtube
                 texture-crop texture-cropover
@@ -261,7 +255,26 @@ oiio_add_tests (
                 texture-width0blur
                 texture-fat texture-skinny texture-wrapfill
                 texture-missing texture-res texture-udim texture-udim2
+                IMAGEDIR oiio-images
               )
+
+#   Tests that require openexr-images:
+oiio_add_tests (oiiotool-deep
+                IMAGEDIR openexr-images
+              )
+
+#   Remaining freestanding tests:
+oiio_add_tests (nonwhole-tiles
+                oiiotool-composite oiiotool-copy
+                oiiotool-pattern
+                oiiotool-subimage oiiotool-text
+                diff
+                dither dup-channels
+                jpeg-corrupt-exif
+                null psd-colormodes
+                rational
+              )
+
 
 # Add tests that require the Python bindings if we built the Python
 # bindings. This is mostly the test that are specifically about testing
@@ -277,6 +290,7 @@ if (USE_PYTHON AND NOT BUILD_OIIOUTIL_ONLY)
                 python-typedesc python-imagespec python-roi python-deep
                 python-imageinput python-imageoutput
                 python-imagebuf python-imagebufalgo
+                IMAGEDIR oiio-images
             )
     endif ()
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ endif ()
 
 include (GNUInstallDirs)
 
-set (CMAKE_MODULE_PATH
+list(APPEND CMAKE_MODULE_PATH
      "${PROJECT_SOURCE_DIR}/src/cmake/modules"
      "${PROJECT_SOURCE_DIR}/src/cmake")
 

--- a/testsuite/bmp/run.py
+++ b/testsuite/bmp/run.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 
-imagedir = parent + "/bmpsuite"
 files = [ "g01bg.bmp", "g04.bmp", "g08.bmp",
           "g16bf555.bmp", "g24.bmp", "g32bf.bmp" ]
 for f in files :
-    command += rw_command (imagedir, f)
+    command += rw_command (OIIO_TESTSUITE_IMAGEDIR, f)
 
 # Test BMR version 5
 command += rw_command ("src", "g01bg2-v5.bmp")

--- a/testsuite/dpx/run.py
+++ b/testsuite/dpx/run.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 
-imagedir = parent + "/oiio-images"
 files = [ "dpx_nuke_10bits_rgb.dpx", "dpx_nuke_16bits_rgba.dpx" ]
 for f in files:
-    command += rw_command (imagedir, f)
+    command += rw_command (OIIO_TESTSUITE_IMAGEDIR, f)
 
 
 # Additionally, test for regressions for endian issues with 16 bit DPX output

--- a/testsuite/fits/run.py
+++ b/testsuite/fits/run.py
@@ -2,7 +2,7 @@
 
 # ../fits-image/pg93:
 # tst0001.fits to tst0014.fits
-imagedir = parent + "/fits-images/pg93"
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/pg93"
 files = [ "tst0001.fits", "tst0002.fits", "tst0003.fits",
            "tst0005.fits", "tst0006.fits", "tst0007.fits",  "tst0008.fits",
            #FIXME? "tst0009.fits",
@@ -11,7 +11,7 @@ files = [ "tst0001.fits", "tst0002.fits", "tst0003.fits",
 for f in files :
     command += rw_command (imagedir, f)
 
-imagedir = parent + "/fits-images/ftt4b"
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/ftt4b"
 files = [ "file001.fits", "file002.fits", "file003.fits",
           "file009.fits", "file012.fits" ]
 for f in files :

--- a/testsuite/gif/run.py
+++ b/testsuite/gif/run.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python
 
-imagedir = parent + "/oiio-images"
 files = ["gif_animation.gif", "gif_oiio_logo_with_alpha.gif",
          "gif_tahoe.gif", "gif_tahoe_interlaced.gif",
          "gif_bluedot.gif", "gif_diagonal_interlaced.gif",
          "gif_triangle_interlaced.gif", "gif_test_disposal_method.gif",
          "gif_test_loop_count.gif"]
 for f in files:
-    command += info_command (imagedir + "/" + f)
+    command += info_command (OIIO_TESTSUITE_IMAGEDIR + "/" + f)
 
 # Test write / conversion to GIF
 command += oiiotool ("../oiiotool/src/tahoe-tiny.tif -o tahoe-tiny.gif")

--- a/testsuite/gpsread/run.py
+++ b/testsuite/gpsread/run.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-filename = (parent + "/oiio-images/tahoe-gps.jpg")
+filename = (OIIO_TESTSUITE_IMAGEDIR + "/tahoe-gps.jpg")
 command += info_command (filename)
 command += oiiotool (filename + " -o ./tahoe-gps.jpg")
 command += info_command ("tahoe-gps.jpg", safematch=True)

--- a/testsuite/ico/run.py
+++ b/testsuite/ico/run.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python
 
-imagedir = parent + "/oiio-images"
-command = rw_command (imagedir, "oiio.ico")
+command = rw_command (OIIO_TESTSUITE_IMAGEDIR, "oiio.ico")

--- a/testsuite/iff/run.py
+++ b/testsuite/iff/run.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
-imagedir = parent + "/oiio-images"
-command += oiiotool (imagedir+"/grid.tif --scanline -o gridscanline.iff")
-command += diff_command (imagedir+"/grid.tif", "gridscanline.iff")
-command += oiiotool (imagedir+"/grid.tif --tile 64 64 -o gridtile.iff")
-command += diff_command (imagedir+"/grid.tif", "gridtile.iff")
+command += oiiotool (OIIO_TESTSUITE_IMAGEDIR+"/grid.tif --scanline -o gridscanline.iff")
+command += diff_command (OIIO_TESTSUITE_IMAGEDIR+"/grid.tif", "gridscanline.iff")
+command += oiiotool (OIIO_TESTSUITE_IMAGEDIR+"/grid.tif --tile 64 64 -o gridtile.iff")
+command += diff_command (OIIO_TESTSUITE_IMAGEDIR+"/grid.tif", "gridtile.iff")

--- a/testsuite/jpeg2000/run.py
+++ b/testsuite/jpeg2000/run.py
@@ -6,7 +6,7 @@ failthresh = 0.02
 failpercent = 0.02
 
 # ../j2kp4files_v1_5/testfiles_jp2
-imagedir = parent + "/j2kp4files_v1_5/testfiles_jp2"
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/testfiles_jp2"
 files = [ "file1.jp2", "file2.jp2", "file3.jp2","file4.jp2",
           "file5.jp2", "file6.jp2", "file7.jp2","file8.jp2",
           "file9.jp2" ]
@@ -14,7 +14,7 @@ for f in files:
     command += rw_command (imagedir, f)
 
 # ../j2kp4files_v1_5/codestreams_profile0:
-imagedir = parent + "/j2kp4files_v1_5/codestreams_profile0"
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/codestreams_profile0"
 files = [ "p0_01.j2k", "p0_02.j2k",
           #"p0_03.j2k",
           "p0_04.j2k",
@@ -30,7 +30,7 @@ files = [ "p0_01.j2k", "p0_02.j2k",
 # later if we speed up the jpeg2000 reader.
 
 # ../j2kp4files_v1_5/codestreams_profile1:
-imagedir = parent + "/j2kp4files_v1_5/codestreams_profile1"
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/codestreams_profile1"
 files = [ "p1_01.j2k", "p1_02.j2k", "p1_03.j2k", "p1_04.j2k",
           "p1_05.j2k", "p1_06.j2k", "p1_07.j2k" ]
 # for f in files:

--- a/testsuite/maketx/run.py
+++ b/testsuite/maketx/run.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python 
 
 # location of oiio-images directory
-oiio_images = parent + "/oiio-images/"
+oiio_images = OIIO_TESTSUITE_IMAGEDIR
 
 # Just for simplicity, make a checkerboard with a solid alpha
 command += oiiotool (" --pattern checker 128x128 4 --ch R,G,B,=1.0"
             + " -d uint8 -o " + oiio_relpath("checker.tif") )
 
 # Basic test - recreate the grid texture
-command += maketx_command (oiio_images + "grid.tif", "grid.tx", showinfo=True)
+command += maketx_command (oiio_images + "/grid.tif", "grid.tx", showinfo=True)
 
 # Test --resize (to power of 2) with the grid, which is 1000x1000
-command += maketx_command (oiio_images + "grid.tif", "grid-resize.tx",
+command += maketx_command (oiio_images + "/grid.tif", "grid-resize.tx",
                            "--resize", showinfo=True)
 
 # Test -d to set output data type
@@ -92,9 +92,9 @@ command += maketx_command ("small.tif", "small.tx",
 
 # Test that the oiio:SHA-1 hash is stable, and that that changing filter and
 # using -hicomp result in different images and different hashes.
-command += maketx_command (oiio_images + "grid.tif", "grid-lanczos3.tx",
+command += maketx_command (oiio_images + "/grid.tif", "grid-lanczos3.tx",
                            extraargs = "-filter lanczos3")
-command += maketx_command (oiio_images + "grid.tif", "grid-lanczos3-hicomp.tx",
+command += maketx_command (oiio_images + "/grid.tif", "grid-lanczos3-hicomp.tx",
                            extraargs = "-filter lanczos3 -hicomp")
 command += info_command ("grid.tx",
                          extraargs="--metamatch oiio:SHA-1")

--- a/testsuite/misnamed-file/run.py
+++ b/testsuite/misnamed-file/run.py
@@ -3,7 +3,7 @@
 import shutil
 
 # Make a copy called "misnamed.exr" that's actually a TIFF file
-shutil.copyfile (parent+"/oiio-images/grid.tif", "misnamed.exr")
+shutil.copyfile (OIIO_TESTSUITE_IMAGEDIR + "/grid.tif", "misnamed.exr")
 
 # Now see if it is read correctly
 command = info_command ("misnamed.exr")

--- a/testsuite/oiiotool-attribs/run.py
+++ b/testsuite/oiiotool-attribs/run.py
@@ -5,17 +5,17 @@
 
 # Test --eraseattrib ability to erase one specific attribute
 # The result should not have "Make"
-command += oiiotool (parent+"/oiio-images/tahoe-gps.jpg --eraseattrib Make -o nomake.jpg")
+command += oiiotool (OIIO_TESTSUITE_IMAGEDIR+"/tahoe-gps.jpg --eraseattrib Make -o nomake.jpg")
 command += info_command ("nomake.jpg", safematch=True)
 
 # Test --eraseattrib ability to match patterns
 # The result should have no GPS tags
-command += oiiotool (parent+"/oiio-images/tahoe-gps.jpg --eraseattrib \"GPS:.*\" -o nogps.jpg")
+command += oiiotool (OIIO_TESTSUITE_IMAGEDIR+"/tahoe-gps.jpg --eraseattrib \"GPS:.*\" -o nogps.jpg")
 command += info_command ("nogps.jpg", safematch=True)
 
 # Test --eraseattrib ability to strip all attribs
 # The result should be very minimal
-command += oiiotool (parent+"/oiio-images/tahoe-gps.jpg --eraseattrib \".*\" -o noattribs.jpg")
+command += oiiotool (OIIO_TESTSUITE_IMAGEDIR+"/tahoe-gps.jpg --eraseattrib \".*\" -o noattribs.jpg")
 command += info_command ("noattribs.jpg", safematch=True)
 
 

--- a/testsuite/oiiotool-deep/run.py
+++ b/testsuite/oiiotool-deep/run.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python 
 
-exrdir = parent+"/openexr-images/v2/LowResLeftView"
+exrdir = OIIO_TESTSUITE_IMAGEDIR + "/v2/LowResLeftView"
 
 # test --flatten : turn deep into composited non-deep
 command += oiiotool("src/deepalpha.exr --flatten -o flat.exr")

--- a/testsuite/oiiotool-maketx/run.py
+++ b/testsuite/oiiotool-maketx/run.py
@@ -21,17 +21,17 @@ def omaketx_command (infile, outfile, extraargs="",
 
 
 # location of oiio-images directory
-oiio_images = parent + "/oiio-images/"
+oiio_images = OIIO_TESTSUITE_IMAGEDIR
 
 # Just for simplicity, make a checkerboard with a solid alpha
 command += oiiotool (" --pattern checker 128x128 4 --ch R,G,B,=1.0"
                      + " -d uint8 -o " + oiio_relpath("checker.tif") )
 
 # Basic test - recreate the grid texture
-command += omaketx_command (oiio_images + "grid.tif", "grid.tx")
+command += omaketx_command (oiio_images + "/grid.tif", "grid.tx")
 
 # Test --resize (to power of 2) with the grid, which is 1000x1000
-command += omaketx_command (oiio_images + "grid.tif", "grid-resize.tx",
+command += omaketx_command (oiio_images + "/grid.tif", "grid-resize.tx",
                             options=":resize=1")
 
 # Test -d to set output data type
@@ -103,9 +103,9 @@ command += omaketx_command ("checker.tif", "checker-exr.pdq",
 
 # Test that the oiio:SHA-1 hash is stable, and that that changing filter and
 # using -hicomp result in different images and different hashes.
-command += omaketx_command (oiio_images + "grid.tif", "grid-lanczos3.tx",
+command += omaketx_command (oiio_images + "/grid.tif", "grid-lanczos3.tx",
                            options = ":filter=lanczos3", showinfo=False)
-command += omaketx_command (oiio_images + "grid.tif", "grid-lanczos3-hicomp.tx",
+command += omaketx_command (oiio_images + "/grid.tif", "grid-lanczos3-hicomp.tx",
                            options = ":filter=lanczos3:highlightcomp=1", showinfo=False)
 command += info_command ("grid.tx",
                          extraargs="--metamatch oiio:SHA-1")

--- a/testsuite/oiiotool-spi/run.py
+++ b/testsuite/oiiotool-spi/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-imagedir = parent + "spi-oiio-tests/"
-refdir = imagedir + "ref/"
+imagedir = OIIO_TESTSUITE_IMAGEDIR
+refdir = imagedir + "/ref/"
 refdirlist = [ "ref/", refdir ]
 outputs = [ ]
 
@@ -9,7 +9,7 @@ outputs = [ ]
 # Define a handy function that runs an oiiotool command, and
 # also diffs the result against a reference image.
 def oiiotool_and_test (inputfile, ops, outputfile, precommand="") :
-    cmd = oiiotool (precommand + " " + imagedir + inputfile +
+    cmd = oiiotool (precommand + " " + imagedir + "/" + inputfile +
                     " " + ops + " -o " + outputfile)
     outputs.append (outputfile)
     return cmd
@@ -25,7 +25,7 @@ command += oiiotool_and_test ("testFullFrame_2kfa_lg10.0006.dpx",
 command += oiiotool_and_test ("mkt019_comp_wayn_fullres_s3d_lf_v51_misc_lnh.1001.exr",
                               "--croptofull --colorconvert:unpremult=1 lnh vd16 --ch R,G,B,A -d uint16",
                               "mkt019_comp_wayn_fullres_s3d_lf_v51_alpha_misc_vd16.1001.tif",
-                              precommand = "--colorconfig " + imagedir + "ht2.ocio/config.ocio")
+                              precommand = "--colorconfig " + imagedir + "/ht2.ocio/config.ocio")
 
 # Test fit/cut on JPEG
 command += oiiotool_and_test ("ffr0830_avid_ref_v3_hd_ref8.1024.jpg",
@@ -37,13 +37,13 @@ command += oiiotool_and_test ("ffr0830_avid_ref_v3_hd_ref8.1024.jpg",
 command += oiiotool_and_test ("ep0400_bg1_v101_3kalxog_alogc16.1001.dpx",
                               "--fit 1028x662 --colorconvert alogc16 vd8",
                               "ep0400-v2_bg1_v101_1kalxog_vd8.1001.jpg",
-                              precommand = "--colorconfig " + imagedir + "pxl.ocio/config.ocio")
+                              precommand = "--colorconfig " + imagedir + "/pxl.ocio/config.ocio")
 
 # Test ociofiletransform
 command += oiiotool_and_test ("os0225_110_lightingfix_v002.0101.dpx",
                               "--colorconvert lm10 lnf --ociofiletransform srgb_look.csp --colorconvert lnf vd8 -d uint8",
                               "os0225_110_lightingfix_v002.0101.png",
-                              precommand = "--colorconfig " + imagedir + "os4.ocio/config.ocio")
+                              precommand = "--colorconfig " + imagedir + "/os4.ocio/config.ocio")
 
 # Test read of iff
 command += oiiotool_and_test ("iff/iff_vd8.1001.iff",

--- a/testsuite/oiiotool-xform/run.py
+++ b/testsuite/oiiotool-xform/run.py
@@ -33,14 +33,14 @@ shutil.copy ("../oiiotool/src/image.tif", "./image.tif")
 
 
 # test resample
-command += oiiotool (parent + "/oiio-images/grid.tif --resample 128x128 -o resample.tif")
+command += oiiotool (OIIO_TESTSUITE_IMAGEDIR + "/grid.tif --resample 128x128 -o resample.tif")
 
 # test resize
-command += oiiotool (parent + "/oiio-images/grid.tif --resize 256x256 -o resize.tif")
-command += oiiotool (parent + "/oiio-images/grid.tif --resize 25% -o resize2.tif")
+command += oiiotool (OIIO_TESTSUITE_IMAGEDIR + "/grid.tif --resize 256x256 -o resize.tif")
+command += oiiotool (OIIO_TESTSUITE_IMAGEDIR + "/grid.tif --resize 25% -o resize2.tif")
 
 # test extreme resize
-command += oiiotool (parent + "/oiio-images/grid.tif --resize 64x64 -o resize64.tif")
+command += oiiotool (OIIO_TESTSUITE_IMAGEDIR + "/grid.tif --resize 64x64 -o resize64.tif")
 command += oiiotool ("resize64.tif --resize 512x512 -o resize512.tif")
 
 # test resize with nonzero origin. Save to exr to make extra sure we have
@@ -49,8 +49,8 @@ command += oiiotool ("--pattern fill:topleft=1,0,0:topright=0,1,0:bottomleft=0,0
                      "--origin +100+100 --fullsize 256x256+0+0 " +
                      "--resize 128x128 -d half -o resized-offset.exr")
 # test fit
-command += oiiotool (parent + "/oiio-images/grid.tif --fit 360x240 -d uint8 -o fit.tif")
-command += oiiotool (parent + "/oiio-images/grid.tif --fit 240x360 -d uint8 -o fit2.tif")
+command += oiiotool (OIIO_TESTSUITE_IMAGEDIR + "/grid.tif --fit 360x240 -d uint8 -o fit.tif")
+command += oiiotool (OIIO_TESTSUITE_IMAGEDIR + "/grid.tif --fit 240x360 -d uint8 -o fit2.tif")
 # regression test: --fit without needing resize used to be problematic
 command += oiiotool ("tahoe-tiny.tif --fit 128x128 -d uint8 -o fit3.tif")
 # test --fit:exact=1 when we can't get a precise whole-pixel fit of aspect

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -86,13 +86,13 @@ command += oiiotool ("ref/histogram_input.png --histogram:cumulative=1 256x256 0
             + "-o histogram_cumulative.tif")
 
 # test --crop
-command += oiiotool (parent + "/oiio-images/grid.tif --crop 100x400+50+200 -o crop.tif")
+command += oiiotool (OIIO_TESTSUITE_IMAGEDIR + "/grid.tif --crop 100x400+50+200 -o crop.tif")
 
 # test --cut
-command += oiiotool (parent + "/oiio-images/grid.tif --cut 100x400+50+200 -o cut.tif")
+command += oiiotool (OIIO_TESTSUITE_IMAGEDIR + "/grid.tif --cut 100x400+50+200 -o cut.tif")
 
 # test paste
-command += oiiotool (parent + "/oiio-images/grid.tif "
+command += oiiotool (OIIO_TESTSUITE_IMAGEDIR + "/grid.tif "
             + "--pattern checker 256x256 3 --paste +150+75 -o pasted.tif")
 
 # test --trim
@@ -112,7 +112,7 @@ command += oiiotool ("--pattern constant:color=1,0,0 50x50 3 "
             + "--mosaic:pad=10 2x2 -d uint8 -o mosaic.tif")
 
 # test channel shuffling
-command += oiiotool (parent + "/oiio-images/grid.tif"
+command += oiiotool (OIIO_TESTSUITE_IMAGEDIR + "/grid.tif"
             + " --ch =0.25,B,G -o chanshuffle.tif")
 
 # test --ch to separate RGBA from an RGBAZ file
@@ -141,7 +141,7 @@ command += oiiotool ("ref/hole.tif --fillholes -o tahoe-filled.tif")
 command += oiiotool ("-pattern checker 64x64+32+32 3 -ch R,G,B,A=1.0 -fullsize 128x128+0+0 --croptofull -fillholes -d uint8 -o growholes.tif")
 
 # test clamping
-command += oiiotool (parent + "/oiio-images/grid.tif --resize 50%"
+command += oiiotool (OIIO_TESTSUITE_IMAGEDIR + "/grid.tif --resize 50%"
             + " --clamp:min=0.2:max=,,0.5,1 -o grid-clamped.tif")
 
 # test kernel

--- a/testsuite/openexr-chroma/run.py
+++ b/testsuite/openexr-chroma/run.py
@@ -2,13 +2,13 @@
 
 # ../openexr-images/Chromaticities:
 # README         Rec709.exr     Rec709_YC.exr  XYZ.exr        XYZ_YC.exr
-imagedir = parent + "/openexr-images/Chromaciticies"
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/Chromaciticies"
 # FIXME - we don't currently understand chromaticities
 
 # ../openexr-images/LuminanceChroma:
 # CrissyField.exr  Garden.exr       StarField.exr
 # Flowers.exr      MtTamNorth.exr
-imagedir = parent + "/openexr-images/LuminanceChroma"
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/LuminanceChroma"
 #command += rw_command (imagedir, "CrissyField.exr", extraargs="--compression zip")
 #command += rw_command (imagedir, "Flowers.exr", extraargs="--compression zip")
 command += rw_command (imagedir, "Garden.exr")

--- a/testsuite/openexr-multires/run.py
+++ b/testsuite/openexr-multires/run.py
@@ -6,7 +6,7 @@
 # Kapaa.exr               OrientationLatLong.exr  WavyLinesCube.exr
 # KernerEnvCube.exr       PeriodicPattern.exr     WavyLinesLatLong.exr
 # KernerEnvLatLong.exr    README                  WavyLinesSphere.exr
-imagedir = parent + "/openexr-images/MultiResolution"
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/MultiResolution"
 files = [ "Bonita.exr", "ColorCodedLevels.exr",
           # FIXME -- we don't know how to deal with RIP-maps -- Kapaa, 
           "KernerEnvCube.exr", "KernerEnvLatLong.exr", "MirrorPattern.exr",

--- a/testsuite/openexr-suite/run.py
+++ b/testsuite/openexr-suite/run.py
@@ -4,12 +4,12 @@
 # README   t03.exr  t06.exr  t09.exr  t12.exr  t15.exr
 # t01.exr  t04.exr  t07.exr  t10.exr  t13.exr  t16.exr
 # t02.exr  t05.exr  t08.exr  t11.exr  t14.exr
-imagedir = parent + "/openexr-images/DisplayWindow"
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/DisplayWindow"
 
 # ../openexr-images/ScanLines:
 # Blobbies.exr   Desk.exr       StillLife.exr
 # Cannon.exr     MtTamWest.exr  Tree.exr
-imagedir = parent + "/openexr-images/ScanLines"
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/ScanLines"
 files = [ "Desk.exr", "MtTamWest.exr" ]
 for f in files:
     command += rw_command (imagedir, f)
@@ -25,7 +25,7 @@ for f in files:
 # BrightRings.exr          GrayRampsHorizontal.exr  WideColorGamut.exr
 # BrightRingsNanInf.exr    README                   WideFloatRange.exr
 # GammaChart.exr           RgbRampsDiagonal.exr
-imagedir = parent + "/openexr-images/TestImages"
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/TestImages"
 files = [ "AllHalfValues.exr", "BrightRings.exr", "BrightRingsNanInf.exr",
           "GammaChart.exr", "GrayRampsDiagonal.exr",
           "GrayRampsHorizontal.exr", "RgbRampsDiagonal.exr",
@@ -35,7 +35,7 @@ for f in files:
 
 # ../openexr-images/Tiles:
 # GoldenGate.exr  Ocean.exr       Spirals.exr
-imagedir = parent + "/openexr-images/Tiles"
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/Tiles"
 files = [ "GoldenGate.exr", "Ocean.exr", "Spirals.exr" ]
 for f in files:
     command += rw_command (imagedir, f)

--- a/testsuite/openexr-v2/run.py
+++ b/testsuite/openexr-v2/run.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-imagedir = parent + "/openexr-images/v2/Stereo"
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/v2/Stereo"
 
 # Multi-part, not deep
 command += rw_command (imagedir, "composited.exr", use_oiiotool=1,

--- a/testsuite/perchannel/run.py
+++ b/testsuite/perchannel/run.py
@@ -5,7 +5,7 @@
 
 # Few image formats support per-channel formats, but OpenEXR is one
 # of them, and the OpenEXR test images contains one such image:
-image = parent + "/openexr-images/ScanLines/Blobbies.exr"
+image = OIIO_TESTSUITE_IMAGEDIR + "/ScanLines/Blobbies.exr"
 
 # iconvert reads and writes native format, test that.
 command += (oiio_app("iconvert") + image + " blob1.exr ;\n")
@@ -18,7 +18,7 @@ command += diff_command (image, "blob2.exr")
 
 
 # Now we do a similar test for a tiled OpenEXR file with per-channel formats
-image = parent + "/openexr-images/Tiles/Spirals.exr"
+image = OIIO_TESTSUITE_IMAGEDIR + "/Tiles/Spirals.exr"
 
 # iconvert reads and writes native format, test that.
 command += (oiio_app("iconvert") + image + " spiral1.exr ;\n")

--- a/testsuite/png/run.py
+++ b/testsuite/png/run.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-imagedir = parent + "/oiio-images"
 files = [ "oiio-logo-no-alpha.png",  "oiio-logo-with-alpha.png" ]
 for f in files:
-        command += rw_command (imagedir,  f)
+        command += rw_command (OIIO_TESTSUITE_IMAGEDIR,  f)

--- a/testsuite/pnm/run.py
+++ b/testsuite/pnm/run.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python
 
-imagedir = parent + "/oiio-images/pnm"
-
 
 #files = [ "oiio-logo-no-alpha.png",  "oiio-logo-with-alpha.png" ]
 #for f in files:
-#    command += rw_command (imagedir,  f)
+#    command += rw_command (OIIO_TESTSUITE_IMAGEDIR,  f)
 
 
 # We can't yet write PFM files, so just get the hashes and call it a day
 files = [ "test-1.pfm", "test-2.pfm", "test-3.pfm" ]
 for f in files:
-    command += info_command (imagedir+"/"+f, safematch=True, hash=True)
-    #command += rw_command (imagedir,  f)
+    command += info_command (OIIO_TESTSUITE_IMAGEDIR + "/" + f,
+                             safematch=True, hash=True)
+    #command += rw_command (OIIO_TESTSUITE_IMAGEDIR,  f)

--- a/testsuite/psd/run.py
+++ b/testsuite/psd/run.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 
-imagedir = parent + "/oiio-images/"
 files = [ "psd_123.psd", "psd_123_nomaxcompat.psd", "psd_bitmap.psd",
           "psd_indexed_trans.psd", "psd_rgb_8.psd", "psd_rgb_16.psd",
           "psd_rgb_32.psd", "psd_rgba_8.psd" ]
 for f in files:
-    command += info_command (imagedir + f)
+    command += info_command (OIIO_TESTSUITE_IMAGEDIR + "/" + f)
 
 command += info_command ("src/different-mask-size.psd")
 command += info_command ("src/layer-mask.psd")

--- a/testsuite/python-imagebuf/run.py
+++ b/testsuite/python-imagebuf/run.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python 
 
-imagedir = parent + "oiio-images"
-
 # Run the script 
 command += pythonbin + " src/test_imagebuf.py > out.txt ;"
 

--- a/testsuite/python-imagebufalgo/run.py
+++ b/testsuite/python-imagebufalgo/run.py
@@ -1,21 +1,16 @@
 #!/usr/bin/env python
 
-import os.path
-
-imagedir = parent + "oiio-images"
-
 refdirlist = [
-    "../../../../testsuite/oiiotool/ref/",
-    "../../../../testsuite/oiiotool-color/ref/",
-    "../../../../testsuite/oiiotool-composite/ref/",
-    "../../../../testsuite/oiiotool-fixnan/ref/",
-    "../../../../testsuite/oiiotool-deep/ref/",
-    "../../../../testsuite/oiiotool-pattern/ref/",
-    "../../../../testsuite/oiiotool-text/ref/",
-    "../../../../testsuite/oiiotool-xform/ref/",
+    OIIO_TESTSUITE_ROOT + "/oiiotool/ref/",
+    OIIO_TESTSUITE_ROOT + "/oiiotool-color/ref/",
+    OIIO_TESTSUITE_ROOT + "/oiiotool-composite/ref/",
+    OIIO_TESTSUITE_ROOT + "/oiiotool-fixnan/ref/",
+    OIIO_TESTSUITE_ROOT + "/oiiotool-deep/ref/",
+    OIIO_TESTSUITE_ROOT + "/oiiotool-pattern/ref/",
+    OIIO_TESTSUITE_ROOT + "/oiiotool-text/ref/",
+    OIIO_TESTSUITE_ROOT + "/oiiotool-xform/ref/",
     refdir
 ]
-
 
 # Run the script
 command += pythonbin + " src/test_imagebufalgo.py > out.txt ;"

--- a/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
+++ b/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-import math
+import math, os
 import OpenImageIO as oiio
 from OpenImageIO import ImageBuf, ImageSpec, ImageBufAlgo, ROI
 
 
+OIIO_TESTSUITE_IMAGEDIR = os.environ['OIIO_TESTSUITE_IMAGEDIR']
 
 def make_constimage (xres, yres, chans=3, format=oiio.UINT8, value=(0,0,0),
                 xoffset=0, yoffset=0) :
@@ -30,7 +31,7 @@ def write (image, filename, format=oiio.UNKNOWN) :
 
 try:
     # Some handy images to work with
-    gridname = "../../../../../oiio-images/grid.tif"
+    gridname = os.path.join(OIIO_TESTSUITE_IMAGEDIR, "grid.tif")
     grid = ImageBuf (gridname)
     checker = ImageBuf(ImageSpec(256, 256, 3, oiio.UINT8))
     ImageBufAlgo.checker (checker, 8, 8, 8, (0,0,0), (1,1,1))

--- a/testsuite/python-imageinput/src/test_imageinput.py
+++ b/testsuite/python-imageinput/src/test_imageinput.py
@@ -2,7 +2,9 @@
 
 from __future__ import print_function
 import OpenImageIO as oiio
+import os
 
+OIIO_TESTSUITE_IMAGEDIR = os.environ['OIIO_TESTSUITE_IMAGEDIR']
 
 # Print the contents of an ImageSpec
 def print_imagespec (spec, subimage=0, mip=0, msg="") :
@@ -201,22 +203,22 @@ def write (image, filename, format=oiio.UNKNOWN) :
 try:
     # test basic opening and being able to read the spec
     poor_mans_iinfo ("badname.tif")
-    poor_mans_iinfo ("../../../../../oiio-images/tahoe-gps.jpg")
+    poor_mans_iinfo (OIIO_TESTSUITE_IMAGEDIR + "/tahoe-gps.jpg")
     poor_mans_iinfo ("grid.tx")
 
     # test readimage
     print ("Testing read_image:")
-    test_readimage ("../../../../../oiio-images/tahoe-gps.jpg")
+    test_readimage (OIIO_TESTSUITE_IMAGEDIR + "/tahoe-gps.jpg")
     # again, force a float buffer
-    test_readimage ("../../../../../oiio-images/tahoe-gps.jpg",
+    test_readimage (OIIO_TESTSUITE_IMAGEDIR + "/tahoe-gps.jpg",
                     type=oiio.FLOAT)
     # Test read of partial channels
-    test_readimage ("../../../../../oiio-images/tahoe-gps.jpg",
+    test_readimage (OIIO_TESTSUITE_IMAGEDIR + "/tahoe-gps.jpg",
                     method="scanlines", nchannels=1)
 
     # test readscanline
     print ("Testing read_scanline:")
-    test_readscanline ("../../../../../oiio-images/tahoe-gps.jpg")
+    test_readscanline (OIIO_TESTSUITE_IMAGEDIR + "/tahoe-gps.jpg")
 
     # test readtile
     print ("Testing read_tile:")
@@ -224,7 +226,7 @@ try:
 
     # test readscanlines
     print ("Testing read_scanlines:")
-    test_readimage ("../../../../../oiio-images/tahoe-gps.jpg",
+    test_readimage (OIIO_TESTSUITE_IMAGEDIR + "/tahoe-gps.jpg",
                     method="scanlines")
 
     # test readtiles

--- a/testsuite/python-imageoutput/run.py
+++ b/testsuite/python-imageoutput/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python 
 
 # Copy the grid to both a tiled and scanline version
-imagedir = parent + "oiio-images"
+imagedir = OIIO_TESTSUITE_IMAGEDIR
 command += oiio_app("iconvert") + imagedir + "/grid.tif --scanline scanline.tif > out.txt ;" 
 command += oiio_app("iconvert") + imagedir + "/grid.tif --tile 64 64 tiled.tif > out.txt ;" 
 

--- a/testsuite/raw/run.py
+++ b/testsuite/raw/run.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-imagedir = parent + "oiio-images/raw"
 files = [ "RAW_CANON_EOS_7D.CR2",
           "RAW_NIKON_D3X.NEF",
           "RAW_FUJI_F700.RAF",
@@ -15,7 +14,7 @@ outputs = []
 # the ref images small) and compared to the reference.
 for f in files:
     outputname = f+".tif"
-    command += oiiotool ("-i:info=2 " + imagedir+"/"+f
+    command += oiiotool ("-i:info=2 " + OIIO_TESTSUITE_IMAGEDIR + "/" + f
                          + " -resample '5%' -d uint8 "
                          + "-o " + outputname)
     outputs += [ outputname ]

--- a/testsuite/rla/run.py
+++ b/testsuite/rla/run.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 
-imagedir = parent + "/oiio-images"
 files = [ "ginsu_a_nc10.rla", "ginsu_a_ncf.rla", "ginsu_rgba_nc8.rla",
           "ginsu_rgb_nc16.rla", "imgmake_rgba_nc10.rla", "ginsu_a_nc16.rla",
           "ginsu_rgba_nc10.rla", "ginsu_rgba_ncf.rla", "ginsu_rgb_nc8.rla",
           "imgmake_rgba_nc16.rla", "ginsu_a_nc8.rla", "ginsu_rgba_nc16.rla",
           "ginsu_rgb_nc10.rla", "ginsu_rgb_ncf.rla", "imgmake_rgba_nc8.rla" ]
 for f in files:
-    command += rw_command (imagedir, f)
+    command += rw_command (OIIO_TESTSUITE_IMAGEDIR, f)
 
 # Regression test to ensure crops work
-command += oiiotool (imagedir+"/ginsu_rgb_nc8.rla -crop 100x100+100+100 -o rlacrop.rla")
+command += oiiotool (OIIO_TESTSUITE_IMAGEDIR +
+                     "/ginsu_rgb_nc8.rla -crop 100x100+100+100 -o rlacrop.rla")
 
 outputs = [ "rlacrop.rla" ]

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -42,11 +42,45 @@ path = os.path.normpath (path)
 tmpdir = "."
 tmpdir = os.path.abspath (tmpdir)
 
+def oiio_relpath (path, start=os.curdir):
+    "Wrapper around os.path.relpath which always uses '/' as the separator."
+    p = os.path.relpath (path, start)
+    return p if sys.platform != "win32" else p.replace ('\\', '/')
+
+OIIO_TESTSUITE_ROOT = oiio_relpath(os.environ['OIIO_TESTSUITE_ROOT'])
+OIIO_TESTSUITE_IMAGEDIR = os.environ.get('OIIO_TESTSUITE_IMAGEDIR', None)
+if OIIO_TESTSUITE_IMAGEDIR:
+    OIIO_TESTSUITE_IMAGEDIR = oiio_relpath(OIIO_TESTSUITE_IMAGEDIR)
+    # Set it back so test's can use it (python-imagebufalgo)
+    os.environ['OIIO_TESTSUITE_IMAGEDIR'] = OIIO_TESTSUITE_IMAGEDIR
+
 refdir = "ref/"
 refdirlist = [ refdir ]
-parent = "../../../../../"
-test_source_dir = "../../../../testsuite/" + os.path.basename(os.path.abspath(srcdir))
-colorconfig_file = "../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio"
+test_source_dir = os.environ['OIIO_TESTSUITE_SRC']
+colorconfig_file = os.path.join(OIIO_TESTSUITE_ROOT,
+                                "common", "OpenColorIO", "nuke-default", "config.ocio")
+
+
+# Swap the relative diff lines if the test suite is not being run via Makefile
+if OIIO_TESTSUITE_ROOT != "../../../../testsuite":
+    def replace_relative(lines):
+        imgdir = None
+        if OIIO_TESTSUITE_IMAGEDIR:
+            imgdir = os.path.basename(OIIO_TESTSUITE_IMAGEDIR)
+            if imgdir != "oiio-images":
+                oiioimgs = os.path.basename(os.path.dirname(OIIO_TESTSUITE_IMAGEDIR))
+                if oiioimgs == "oiio-images":
+                    imgdir = "oiio-images/" + imgdir
+                imgdir = "../../../../../" + imgdir
+
+        for i in xrange(len(lines)):
+            lines[i] = lines[i].replace("../../../../testsuite", OIIO_TESTSUITE_ROOT)
+            if imgdir:
+                lines[i] = lines[i].replace(imgdir, OIIO_TESTSUITE_IMAGEDIR)
+        return lines
+else:
+    replace_relative = None
+
 
 command = ""
 outputs = [ "out.txt" ]    # default
@@ -75,14 +109,21 @@ if platform.system() == 'Windows' :
     # if not os.path.exists("../common") :
     #     shutil.copytree ("../../../testsuite/common", "..")
 else :
+    def newsymlink(src, dst):
+        print("newsymlink", src, dst)
+        # os.path.exists returns False for broken symlinks, so remove if thats the case
+        if os.path.islink(dst):
+            os.remove(dst)
+        os.symlink (src, dst)
     if not os.path.exists("./ref") :
-        os.symlink (os.path.join (test_source_dir, "ref"), "./ref")
+        newsymlink (os.path.join (test_source_dir, "ref"), "./ref")
     if os.path.exists (os.path.join (test_source_dir, "src")) and not os.path.exists("./src") :
-        os.symlink (os.path.join (test_source_dir, "src"), "./src")
+        newsymlink (os.path.join (test_source_dir, "src"), "./src")
     if not os.path.exists("./data") :
-        os.symlink (test_source_dir, "./data")
+        newsymlink (test_source_dir, "./data")
     if not os.path.exists("../common") :
-        os.symlink ("../../../testsuite/common", "../common")
+        newsymlink (os.path.join(os.environ['OIIO_TESTSUITE_ROOT'], "common"),
+                    "../common")
 
 
 # Disable this test on Travis when using leak sanitizer, because the error
@@ -113,6 +154,8 @@ def text_diff (fromfile, tofile, diff_file=None):
         todate = time.ctime (os.stat (tofile).st_mtime)
         fromlines = open (fromfile, 'r').readlines()
         tolines   = open (tofile, 'r').readlines()
+        if replace_relative:
+            tolines = replace_relative(tolines)
     except:
         print ("Unexpected error:", sys.exc_info()[0])
         return -1
@@ -134,13 +177,6 @@ def text_diff (fromfile, tofile, diff_file=None):
         except:
             print ("Unexpected error:", sys.exc_info()[0])
     return 1
-
-
-
-def oiio_relpath (path, start=os.curdir):
-    "Wrapper around os.path.relpath which always uses '/' as the separator."
-    p = os.path.relpath (path, start)
-    return p if sys.platform != "win32" else p.replace ('\\', '/')
 
 
 def oiio_app (app):

--- a/testsuite/targa-tgautils/run.py
+++ b/testsuite/targa-tgautils/run.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
-imagedir = parent + "/TGAUTILS"
 files = [ "CBW8.TGA", "CCM8.TGA", "CTC16.TGA", "CTC24.TGA", "CTC32.TGA",
           "UBW8.TGA", "UCM8.TGA", "UTC16.TGA", "UTC24.TGA", "UTC32.TGA" ]
 for f in files:
-    command += rw_command (imagedir, f)
+    command += rw_command (OIIO_TESTSUITE_IMAGEDIR, f)

--- a/testsuite/texture-crop/run.py
+++ b/testsuite/texture-crop/run.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python 
 
-command += oiiotool(parent + "/oiio-images/grid.tif " +
+command += oiiotool(OIIO_TESTSUITE_IMAGEDIR + "/grid.tif " +
                     "--crop 512x512+200+100 -o grid-crop.tif")
 command += maketx_command ("grid-crop.tif",
                            "grid-crop.tx")

--- a/testsuite/texture-cropover/run.py
+++ b/testsuite/texture-cropover/run.py
@@ -2,7 +2,7 @@
 
 # Tests input image which is partial crop, partial overscan!
 
-command += oiiotool(parent + "/oiio-images/grid.tif " +
+command += oiiotool(OIIO_TESTSUITE_IMAGEDIR + "/grid.tif " +
                     "--crop 500x1000+250+0 --fullsize 1000x800+0+100 -o grid-cropover.exr")
 command += maketx_command ("grid-cropover.exr",
                            "grid-cropover.tx.exr")

--- a/testsuite/texture-filtersize/run.py
+++ b/testsuite/texture-filtersize/run.py
@@ -36,6 +36,6 @@
 
 
 
-command = testtex_command (parent + "/oiio-images/miplevels.tx",
+command = testtex_command (OIIO_TESTSUITE_IMAGEDIR + "/miplevels.tx",
                            " --filtertest -res 256 256 -d uint8 -o out.tif")
 outputs = [ "out.tif" ]

--- a/testsuite/texture-icwrite/run.py
+++ b/testsuite/texture-icwrite/run.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
 # test 1: seed top level, no MIP map
-command += testtex_command (parent + " -res 256 256 -d uint8 -o out1.tif --testicwrite 1 blah")
+command += testtex_command (OIIO_TESTSUITE_IMAGEDIR + " -res 256 256 -d uint8 -o out1.tif --testicwrite 1 blah")
 # test 2: seed top level, automip
-command += testtex_command (parent + " -res 256 256 -d uint8 -o out2.tif --testicwrite 1 --automip blah")
+command += testtex_command (OIIO_TESTSUITE_IMAGEDIR + " -res 256 256 -d uint8 -o out2.tif --testicwrite 1 --automip blah")
 
 # test 3: procedural MIP map
-command += testtex_command (parent + " -res 256 256 -d uint8 -o out3.tif --testicwrite 2 blah")
+command += testtex_command (OIIO_TESTSUITE_IMAGEDIR + " -res 256 256 -d uint8 -o out3.tif --testicwrite 2 blah")
 # test 4: procedural top level, automip
-command += testtex_command (parent + " -res 256 256 -d uint8 -o out4.tif --testicwrite 2 --automip blah")
+command += testtex_command (OIIO_TESTSUITE_IMAGEDIR + " -res 256 256 -d uint8 -o out4.tif --testicwrite 2 --automip blah")
 
 outputs = [ "out1.tif", "out2.tif", "out3.tif", "out4.tif" ]

--- a/testsuite/texture-overscan/run.py
+++ b/testsuite/texture-overscan/run.py
@@ -10,7 +10,7 @@
 #    surrounded by the red check border, surrounded by black. The grid
 #    itself should be the "middle half" of the image.
 
-command += (oiio_app("oiiotool") + parent+"/oiio-images/grid.tif"
+command += (oiio_app("oiiotool") + OIIO_TESTSUITE_IMAGEDIR + "/grid.tif"
             + " -resize 512x512 "
             + " -pattern checker:color1=1,0,0:color2=.25,0,0 640x640 3 "
             + "-origin -64-64 -paste +0+0 -fullsize 512x512+0+0 -o overscan-src.exr ;\n")

--- a/testsuite/texture-res/run.py
+++ b/testsuite/texture-res/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 command = (oiio_app("testtex") + " -res 256 256 --nowarp "
-           + parent + "/oiio-images/miplevels.tx"
+           + OIIO_TESTSUITE_IMAGEDIR + "/miplevels.tx"
            + " -o out.tif ;\n")
 command += diff_command ("out.tif", "ref/out.tif", "--fail 0.0005 --warn 0.0005")
 

--- a/testsuite/texture-wrapfill/run.py
+++ b/testsuite/texture-wrapfill/run.py
@@ -6,12 +6,12 @@
 
 # Make an RGB grid for our test
 command += (oiio_app("oiiotool")
-            + parent + "/oiio-images/grid.tif"
+            + OIIO_TESTSUITE_IMAGEDIR + "/grid.tif"
             + " -ch R,G,B -o grid3.tif >> out.txt ;\n")
 
 # And a 1-channel grid for our test
 command += (oiio_app("oiiotool")
-            + parent + "/oiio-images/grid.tif"
+            + OIIO_TESTSUITE_IMAGEDIR + "/grid.tif"
             + " -ch R -o grid1.tif >> out.txt ;\n")
 
 command += testtex_command ("grid3.tif",

--- a/testsuite/tiff-depths/run.py
+++ b/testsuite/tiff-depths/run.py
@@ -3,7 +3,7 @@
 # FIXME -- eventually, we want more (all?) of these to work
 
 outputs = []
-imagedir = parent + "/libtiffpic/depth"
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/depth"
 files = [
     "flower-minisblack-02.tif",   #  73x43 2-bit minisblack gray image
     "flower-minisblack-04.tif",   #  73x43 4-bit minisblack gray image
@@ -48,7 +48,7 @@ for f in files:
 
 # Test CMYK without conversion to RGB
 command += oiiotool ("-iconfig oiio:RawColor 1 " +
-                     parent+"/libtiffpic/depth/flower-separated-contig-08.tif " +
+                     imagedir+"/flower-separated-contig-08.tif " +
                      "-attrib oiio:ColorSpace linear -o cmyk_as_cmyk.tif")
 outputs += [ "cmyk_as_cmyk.tif", "out.txt" ]
 

--- a/testsuite/tiff-suite/run.py
+++ b/testsuite/tiff-suite/run.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-imagedir = parent + "/libtiffpic"
 
 # caspian.tif	279x220 64-bit floating point (deflate) Caspian Sea from space
 #   I can't get this to work with OIIO, but I can't get it to read with 
@@ -13,24 +12,24 @@ imagedir = parent + "/libtiffpic"
 #    Tests tiled images (especially tiled 1-bit) -- compare it to cramps
 # dscf0013.tif  640x480 YCbCr digital camera image which lacks Reference
 #       Black/White values. Contains EXIF SubIFD. No compression.
-command += rw_command (imagedir, "cramps.tif")
-command += rw_command (imagedir, "cramps-tile.tif")
-command += diff_command (imagedir+"/cramps-tile.tif",
-                                          imagedir+"/cramps.tif")
-command += rw_command (imagedir, "dscf0013.tif")
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "cramps.tif")
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "cramps-tile.tif")
+command += diff_command (OIIO_TESTSUITE_IMAGEDIR + "/cramps-tile.tif",
+                         OIIO_TESTSUITE_IMAGEDIR + "/cramps.tif")
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "dscf0013.tif")
 
 # fax2d.tif	1728x1082 1-bit b&w (G3/2D) facsimile
 # FIXME - we read the pixel data fine, but we fail to recognize that
 #   differing XResolution and YResolution imply a non-square pixel
 #   aspect ratio, and iv fails to display it well for this reason.
-command += rw_command (imagedir, "fax2d.tif")
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "fax2d.tif")
 
 # g3test.tif	TIFF equivalent of g3test.g3 created by fax2tiff
-command += rw_command (imagedir, "g3test.tif")
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "g3test.tif")
 # FIXME - same aspect ratio issue as fax2d.tif
 
 # jello.tif	256x192 8-bit RGB (packbits palette) Paul Heckbert "jello"
-command += rw_command (imagedir, "jello.tif")
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "jello.tif")
 
 # ladoga.tif	158x118 16-bit unsigned, single band, deflate
 # NOTE -- I have no idea if we read this correctly.  Neither ImageMagick
@@ -39,15 +38,15 @@ command += rw_command (imagedir, "jello.tif")
 # off_l16.tif	333x225 8-bit CIE LogL (SGILog) office from Greg Larson
 # off_luv24.tif	333x225 8-bit CIE LogLuv (SGILog24) office from " "
 # off_luv32.tif	333x225	8-bit CIE LogLuv (SGILog) office from " "
-command += rw_command (imagedir, "off_l16.tif")
-command += rw_command (imagedir, "off_luv24.tif")
-command += rw_command (imagedir, "off_luv32.tif")
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "off_l16.tif")
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "off_luv24.tif")
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "off_luv32.tif")
 
 # pc260001.tif	640x480 8-bit RGB digital camera image. Contains EXIF SubIFD.
 # 		No compression.
 # FIXME? - we don't seem to recognize additional Exif data that's in the
 #    'Maker Note', which includes GainControl
-command += rw_command (imagedir, "pc260001.tif")
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "pc260001.tif")
 
 # quad-lzw.tif	512x384 8-bit RGB (lzw) "quadric surfaces"
 # quad-tile.tif	512x384 tiled version of quad-lzw.tif (lzw)
@@ -55,30 +54,30 @@ command += rw_command (imagedir, "pc260001.tif")
 
 # FIXME - temporarily disable quad-lzw.tif to address a regression in
 # libtiff 4.0.8. Re-enable these tests after libtiff is patched.
-#command += rw_command (imagedir, "quad-lzw.tif")
-command += rw_command (imagedir, "quad-tile.tif")
-#command += diff_command (imagedir+"/quad-tile.tif",
-#                                          imagedir+"/quad-lzw.tif")
-command += rw_command (imagedir, "quad-jpeg.tif",
+#command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "quad-lzw.tif")
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "quad-tile.tif")
+#command += diff_command (OIIO_TESTSUITE_IMAGEDIR + "/quad-tile.tif",
+#                         OIIO_TESTSUITE_IMAGEDIR + "/quad-lzw.tif")
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "quad-jpeg.tif",
                        extraargs="-compression zip")
 
 # strike.tif	256x200 8-bit RGBA (lzw) "bowling pins" from Pixar
-command += rw_command (imagedir, "strike.tif")
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "strike.tif")
 
 # text.tif	1512x359 4-bit b&w (thunderscan) am-express credit card
 #  FIXME -- we don't get this right
 
 # ycbcr-cat.tif	250x325 8-bit YCbCr (lzw) "kitty" created by rgb2ycbcr
-command += rw_command (imagedir, "ycbcr-cat.tif")
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "ycbcr-cat.tif")
 
 # smallliz.tif	160x160 8-bit YCbCr (OLD jpeg) lizard from HP**
-command += rw_command (imagedir, "smallliz.tif", 0)
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "smallliz.tif", 0)
 # zackthecat.tif 234x213 8-bit YCbCr (OLD jpeg) tiled "ZackTheCat" from NeXT**
 #   considered a deprecated format, not supported by libtiff
-command += rw_command (imagedir, "zackthecat.tif", 0)
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "zackthecat.tif", 0)
 
 # oxford.tif	601x81 8-bit RGB (lzw) screendump off oxford
-command += rw_command (imagedir, "oxford.tif", 0)
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "oxford.tif", 0)
 
 # The other images are from Hewlett Packard and exemplify the use of the
 # HalftoneHints tag (in their words):

--- a/testsuite/webp/run.py
+++ b/testsuite/webp/run.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-imagedir = parent + "/webp-images/"
 files = [ "1.webp", "2.webp", "3.webp", "4.webp" ]
 for f in files:
-    command = command + info_command (imagedir + f)
+    command = command + info_command (OIIO_TESTSUITE_IMAGEDIR + "/" + f)


### PR DESCRIPTION
## Description
Allows builds outside of the source tree to pass. Adds a CMake variable OIIO_TESTSUITE_IMAGEDIR to specify where the image test's can be run from.  The two are currently tied together, in that building from the source tree it is assumed the testsuite should be run as usual/prior.
Can probably split OIIO_TESTSUITE_IMAGEDIR to have meaning when building from the checkout if these changes are desired. 
Also part of the change is explicitly marking some of the -regular- tessuite as requiring oiio-images.

## Tests
The following are still failing locally, but I think unrelated to these changes?
oiiotool-subimage
oiiotool-text
texture-icwrite
texture-icwrite.batch
