### PR TITLE
Improved memory-use debugging

### DIFF
--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -1141,7 +1141,8 @@ of 0 indicates that it should try to read the whole image if possible.
 \index{debug}
 When nonzero, various debug messages may be printed. The default is 0 for
 release builds, 1 for {\cf DEBUG} builds, but also may be overridden by the
-{\cf OPENIMAGEIO\_DEBUG} env variable.
+{\cf OPENIMAGEIO\_DEBUG} env variable. Values $> 1$ are for OIIO developers
+to print even more debugging information.
 \apiend
 
 \apiitem{int log_times \\
@@ -1178,6 +1179,25 @@ per call, like this:
 
 If the value of {\cf log_times} is 2 or more when the application terminates,
 the timing report will be printed to {\cf stdout} upon exit.
+\apiend
+
+\apiitem{string hw:simd \\
+string oiio:simd}
+\vspace{10pt}
+\index{hw:simd} \index{oiio:simd}
+% added in 1.8
+The \qkw{hw:simd} read-only attribute is a comma-separated list of
+hardware CPU features for SIMD (and some other things). The \qkw{oiio:simd}
+is similarly a list of which features this build of OIIO was compiled
+to support.
+\apiend
+
+\apiitem{float resident_memory_used_MB}
+\vspace{10pt}
+\index{resident_memory_used_MB}
+\NEW % 1.9
+This read-only attribute can be used for debugging purposes to report
+the approximate process memory used (resident) by the application, in MB.
 \apiend
 
 \apiend

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -96,8 +96,8 @@
  \bigskip \\
 }
 \date{{\large
-Date: 7 Aug 2018
-\\ (with corrections, 8 Oct 2018)
+Date: 8 Oct 2018
+%\\ (with corrections, 19 Mar 2018)
 }}
 
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1574,7 +1574,7 @@ OIIO_API std::string geterror ();
 ///             once for read_image calls (default: 256).
 ///     int debug
 ///             When nonzero, various debug messages may be printed.
-///             The default is 0 for release builds, 1 for DEBUG builds,
+///             The default is 0 for release builds, >=1 for DEBUG builds,
 ///             but also may be overridden by the OPENIMAGEIO_DEBUG env
 ///             variable.
 ///     int log_times
@@ -1641,6 +1641,9 @@ inline bool attribute (string_view name, string_view val) {
 ///             Comma-separated list of the SIMD-related capabilities
 ///             detected at runtime at the time of the query (which may not
 ///             match the support compiled into the library).
+///     int "resident_memory_used_MB"
+///             Approximate process memory used (resident) by the application,
+///             in MB. This might be helpful in debugging.
 OIIO_API bool getattribute (string_view name, TypeDesc type, void *val);
 // Shortcuts for common types
 inline bool getattribute (string_view name, int &val) {

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -57,6 +57,7 @@ extern std::string input_format_list;
 extern std::string output_format_list;
 extern std::string extension_list;
 extern std::string library_list;
+extern int oiio_print_debug;
 extern int oiio_log_times;
 
 


### PR DESCRIPTION
* ImageBuf: more careful tracking of allocations, print alloc/free/total  messages when "debug" attrib (or env OPENIMAGEIO_DEBUG) > 1.

* Change interpretation of the debug attribute so that 1 is ordinary debug, values > 1 are extra debugging for developers.

* Add oiio query for process resident memory in MB (this is helpful  for Python scripts that want to check how each OIIO call they make  might have changed the overall memory footprint).

* Add docs for the "hw:simd" and "oiio:simd" attribute -- not changed here, just happened to notice they were undocumented.

