### PR TITLE
RAW: control of libraw's correction for chromatic aberration

### DIFF
--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -945,6 +945,12 @@ Configuration attribute & Type & Meaning \\
 \qkws{raw:user_sat} & int & If nonzero, sets the camera maximum value that
                             will be normalized to appear saturated.
                             (Default: 0) \\
+\qwks{raw:aber} & float[2] & Red and blue scale factors for chromatic
+                                aberration correction when decoding the raw
+                                image. The default (1,1) means to perform
+                                no correction. This is an overall spatial
+                                scale, sensible values will be very close
+                                to 1.0. \\
 \qkws{raw:ColorSpace} & string & Which color primaries to use: \qkw{raw},
                                 \qkw{sRGB}, \qkw{Adobe}, \qkw{Wide},
                                 \qkw{ProPhoto}, \qkw{ACES}, \qkw{XYZ}.

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -97,7 +97,7 @@
 }
 \date{{\large
 Date: 7 Aug 2018
-%\\ (with corrections, 19 Mar 2018)
+\\ (with corrections, 8 Oct 2018)
 }}
 
 

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -398,6 +398,17 @@ RawInput::open_raw (bool unpack, const std::string &name,
     // Set camera maximum value if "raw:user_sat" is not 0
     m_processor->imgdata.params.user_sat =
         config.get_int_attribute("raw:user_sat", 0);
+    {
+        auto p = config.find_attribute ("raw:aber");
+        if (p && p->type() == TypeDesc(TypeDesc::FLOAT, 2)) {
+            m_processor->imgdata.params.aber[0] = p->get<float>(0);
+            m_processor->imgdata.params.aber[2] = p->get<float>(1);
+        }
+        if (p && p->type() == TypeDesc(TypeDesc::DOUBLE, 2)) {
+            m_processor->imgdata.params.aber[0] = p->get<double>(0);
+            m_processor->imgdata.params.aber[2] = p->get<double>(1);
+        }
+    }
 
     // Use embedded color profile. Values mean:
     // 0: do not use embedded color profile


### PR DESCRIPTION
Using a new "raw:aber" (float[2]) input config attribute.

Fixes #2029

Example command line to see this in action:

    oiiotool -iconfig:type="float[2]" "raw:aber" "1.01,0.99" ../oiio-images/raw/RAW_OLYMPUS_E3.ORF  -o out.exr