### PR TITLE
Bump pybind11 version from 2.2.1 to 2.2.4

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -525,7 +525,7 @@ endif()
 
 option (BUILD_PYBIND11_FORCE "Force local download/build of Pybind11 even if installed" OFF)
 option (BUILD_MISSING_PYBIND11 "Local download/build of Pybind11 if not installed" ON)
-set (BUILD_PYBIND11_VERSION "v2.2.1" CACHE STRING "Preferred pybind11 version, of downloading/building our own")
+set (BUILD_PYBIND11_VERSION "v2.2.4" CACHE STRING "Preferred pybind11 version, of downloading/building our own")
 set (PYBIND11_HOME "" CACHE STRING "Installed pybind11 location hint")
 
 macro (find_or_download_pybind11)


### PR DESCRIPTION
I was finding crashes with certain combinations of OIIO, Python 3.6.x, and NumPy/PyTorch -- crashes upon import of either oiio or torch (whichever was second). Seems to be all better when I upgrade pybind to 2.2.4, I guess we were using one that was a year old.
