### PR TITLE
Strutil enhancements

### DIFF
--- a/src/include/OpenImageIO/unittest.h
+++ b/src/include/OpenImageIO/unittest.h
@@ -37,6 +37,7 @@
 #include <algorithm>
 
 #include <OpenImageIO/sysutil.h>
+#include <OpenImageIO/strutil.h>
 
 
 OIIO_NAMESPACE_BEGIN
@@ -75,9 +76,18 @@ inline bool equal_approx (const X& x, const Y& y) {
     return all(abs((x)-(y)) <= 0.001f * max(abs(x), abs(y)));
 }
 
+
 }  // end namespace pvt
 
 OIIO_NAMESPACE_END
+
+// Helper: print entire vectors. This makes the OIIO_CHECK_EQUAL macro
+// work for std::vector!
+template<typename T>
+inline std::ostream& operator<< (std::ostream& out, const std::vector<T>& v) {
+    out << '{' << OIIO::Strutil::join (v, ",") << '}';
+    return out;
+}
 
 static OIIO::pvt::UnitTestFailureCounter unit_test_failures;
 

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -496,31 +496,39 @@ split_whitespace (string_view str, std::vector<string_view> &result,
 
 
 
-void
-Strutil::split (string_view str, std::vector<std::string> &result,
-                string_view sep, int maxsplit)
+std::vector<std::string>
+Strutil::splits (string_view str, string_view sep, int maxsplit)
 {
-    std::vector<string_view> sr_result;
-    split (str, sr_result, sep, maxsplit);
-    result.clear ();
+    auto sr_result = splitsv (str, sep, maxsplit);
+    std::vector<std::string> result;
     result.reserve (sr_result.size());
     for (size_t i = 0, e = sr_result.size(); i != e; ++i)
         result.push_back (sr_result[i]);
+    return result;
 }
 
 
 
 void
-Strutil::split (string_view str, std::vector<string_view> &result,
+Strutil::split (string_view str, std::vector<std::string> &result,
                 string_view sep, int maxsplit)
 {
+    result = splits (str, sep, maxsplit);
+}
+
+
+
+std::vector<string_view>
+Strutil::splitsv (string_view str, string_view sep, int maxsplit)
+{
+    std::vector<string_view> result;
+
     // Implementation inspired by Pystring
-    result.clear();
     if (maxsplit < 0)
         maxsplit = std::numeric_limits<int>::max();
     if (sep.size() == 0) {
         split_whitespace (str, result, maxsplit);
-        return;
+        return result;
     }
     size_t i = 0, j = 0, len = str.size(), n = sep.size();
     while (i+n <= len) {
@@ -534,34 +542,16 @@ Strutil::split (string_view str, std::vector<string_view> &result,
         }
     }
     result.push_back (str.substr(j, len-j));
-}
-
-
-
-std::string
-Strutil::join (const std::vector<string_view> &seq, string_view str)
-{
-    // Implementation inspired by Pystring
-    size_t seqlen = seq.size();
-    if (seqlen == 0)
-        return std::string();
-    std::string result (seq[0]);
-    for (size_t i = 1; i < seqlen; ++i) {
-        result += str;
-        result += seq[i];
-    }
     return result;
 }
 
 
 
-std::string
-Strutil::join (const std::vector<std::string> &seq, string_view str)
+void
+Strutil::split (string_view str, std::vector<string_view> &result,
+                string_view sep, int maxsplit)
 {
-    std::vector<string_view> seq_sr (seq.size());
-    for (size_t i = 0, e = seq.size(); i != e; ++i)
-        seq_sr[i] = seq[i];
-    return join (seq_sr, str);
+    result = splitsv (str, sep, maxsplit);
 }
 
 

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -324,13 +324,20 @@ void test_split ()
 
 void test_join ()
 {
-    std::vector<std::string> seq;
-    seq.emplace_back("Now");
-    seq.emplace_back("is");
-    seq.emplace_back("the");
-    seq.emplace_back("time");
-    OIIO_CHECK_EQUAL (Strutil::join (seq, ". "),
+    std::vector<std::string> strvec { "Now", "is", "the", "time" };
+    OIIO_CHECK_EQUAL (Strutil::join (strvec, ". "),
                       "Now. is. the. time");
+
+    std::vector<string_view> svvec { "Now", "is", "the", "time" };
+    OIIO_CHECK_EQUAL (Strutil::join (svvec, "/"),
+                      "Now/is/the/time");
+
+    std::vector<int> intvec { 3, 2, 1 };
+    OIIO_CHECK_EQUAL (Strutil::join (intvec, " "),
+                      "3 2 1");
+
+    int intarr[] = { 4, 2 };
+    OIIO_CHECK_EQUAL (Strutil::join (intarr, ","), "4,2");
 }
 
 
@@ -513,51 +520,49 @@ void test_extract ()
 
     vals.clear(); vals.resize (3, -1);
     n = Strutil::extract_from_list_string (vals, "1");
-    OIIO_CHECK_EQUAL (vals.size(), 3);
-    OIIO_CHECK_EQUAL (vals[0], 1);
-    OIIO_CHECK_EQUAL (vals[1], 1);
-    OIIO_CHECK_EQUAL (vals[2], 1);
+    OIIO_CHECK_EQUAL (vals, std::vector<int>({1, 1, 1}));
     OIIO_CHECK_EQUAL (n, 1);
 
     vals.clear(); vals.resize (3, -1);
     n = Strutil::extract_from_list_string (vals, "1,3,5");
-    OIIO_CHECK_EQUAL (vals.size(), 3);
-    OIIO_CHECK_EQUAL (vals[0], 1);
-    OIIO_CHECK_EQUAL (vals[1], 3);
-    OIIO_CHECK_EQUAL (vals[2], 5);
+    OIIO_CHECK_EQUAL (vals, std::vector<int>({1, 3, 5}));
     OIIO_CHECK_EQUAL (n, 3);
 
     vals.clear(); vals.resize (3, -1);
     n = Strutil::extract_from_list_string (vals, "1,,5");
-    OIIO_CHECK_EQUAL (vals.size(), 3);
-    OIIO_CHECK_EQUAL (vals[0], 1);
-    OIIO_CHECK_EQUAL (vals[1], -1);
-    OIIO_CHECK_EQUAL (vals[2], 5);
+    OIIO_CHECK_EQUAL (vals, std::vector<int>({1, -1, 5}));
     OIIO_CHECK_EQUAL (n, 3);
 
     vals.clear(); vals.resize (3, -1);
     n = Strutil::extract_from_list_string (vals, "abc");
-    OIIO_CHECK_EQUAL (vals.size(), 3);
-    OIIO_CHECK_EQUAL (vals[0], 0);
-    OIIO_CHECK_EQUAL (vals[1], 0);
-    OIIO_CHECK_EQUAL (vals[2], 0);
+    OIIO_CHECK_EQUAL (vals, std::vector<int>({0, 0, 0}));
     OIIO_CHECK_EQUAL (n, 1);
 
     vals.clear(); vals.resize (3, -1);
     n = Strutil::extract_from_list_string (vals, "");
-    OIIO_CHECK_EQUAL (vals.size(), 3);
-    OIIO_CHECK_EQUAL (vals[0], -1);
-    OIIO_CHECK_EQUAL (vals[1], -1);
-    OIIO_CHECK_EQUAL (vals[2], -1);
+    OIIO_CHECK_EQUAL (vals, std::vector<int>({-1, -1, -1}));
     OIIO_CHECK_EQUAL (n, 0);
 
     vals.clear();
     n = Strutil::extract_from_list_string (vals, "1,3,5");
-    OIIO_CHECK_EQUAL (vals.size(), 3);
-    OIIO_CHECK_EQUAL (vals[0], 1);
-    OIIO_CHECK_EQUAL (vals[1], 3);
-    OIIO_CHECK_EQUAL (vals[2], 5);
+    OIIO_CHECK_EQUAL (vals, std::vector<int>({1, 3, 5}));
     OIIO_CHECK_EQUAL (n, 3);
+
+    // Make sure that the vector-returning version works
+    OIIO_CHECK_EQUAL (Strutil::extract_from_list_string<float> ("1", 3, -1.0f),
+                      std::vector<float>({1, 1, 1}));
+    OIIO_CHECK_EQUAL (Strutil::extract_from_list_string<float> ("1,3,5", 3, -1.0f),
+                      std::vector<float>({1, 3, 5}));
+    OIIO_CHECK_EQUAL (Strutil::extract_from_list_string<float> ("1,,5", 3, -1.0f),
+                      std::vector<float>({1, -1, 5}));
+    OIIO_CHECK_EQUAL (Strutil::extract_from_list_string<float> ("abc", 3, -1.0f),
+                      std::vector<float>({0, 0, 0}));
+    OIIO_CHECK_EQUAL (Strutil::extract_from_list_string<float> ("", 3, -1.0f),
+                      std::vector<float>({-1, -1, -1}));
+    OIIO_CHECK_EQUAL (Strutil::extract_from_list_string<float> ("1,3,5"),
+                      std::vector<float>({1, 3, 5}));
+    OIIO_CHECK_EQUAL (Strutil::extract_from_list_string<float> ("1,3,5,7"),
+                      std::vector<float>({1, 3, 5, 7}));
 }
 
 


### PR DESCRIPTION
Found this while doing fall cleaning. These are some mods I've had sitting around in a private branch for a long time.

1. Turn join() into a template that can act on any iterable container
   of objects that allow stream output.

2. New splits()/splitsv() that directly return a vector of string or
   string_view, respectively (more modern C++ idiom than passing a
   result vector as an argument).

3. A second version of extract_from_list_string that directly returns
   a std::vector (instead of being passed as an argument).

4. Minor fix in unittest.h to allow the OIIO_CHECK_EQUAL macro work to
   compare std::vectors. (This utilizes the new join() to turn them into
   strings and thus allow them to output with <<).

