### PR TITLE
Safer thread_pool destruction using native threads status (Windows)

### DIFF
--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -44,6 +44,10 @@
 #define _ENABLE_ATOMIC_ALIGNMENT_FIX /* Avoid MSVS error, ugh */
 #endif
 
+#if defined(WIN32)
+#include <windows.h>
+#endif
+
 #include <exception>
 #include <functional>
 #include <future>
@@ -211,6 +215,22 @@ public:
                 return;
             this->isDone = true;  // give the waiting threads a command to finish
         }
+
+#if defined(WIN32)
+        // When the static variable in default_thread_pool() is destroyed during DLL unloading,
+        // the thread_pool destructor is called but the threads are already terminated.
+        // So it is illegal to communicate with those other threads at this point.
+        // Checking Windows native thread status allows to detect this specific scenario and avoid an unnecessary call
+        // to this->cv.notify_all() which creates a deadlock (noticed only on Windows 7 but still unsafe in other versions).
+        bool hasTerminatedThread = std::any_of (this->threads.begin(), this->threads.end(),
+                [](std::unique_ptr<std::thread>& t){
+                    DWORD rcode;
+                    GetExitCodeThread(t->native_handle(), &rcode);
+                    return rcode != STILL_ACTIVE;
+            });
+
+        if (!hasTerminatedThread)
+#endif
         {
             std::unique_lock<std::mutex> lock(this->mutex);
             this->cv.notify_all();  // stop all waiting threads


### PR DESCRIPTION

## Description
Prevent deadlock from illegal communication with already terminated threads when global shared thread_pool is being destroyed during DLL unloading. This scenario is detected by checking native threads status.
Fix #1795 

## Tests
Tested on Windows 7 with Visual Studio 2017. 
Fixes the deadlock issue for global static thread_pool destruction and does not modify the current behavior when thread_pool is used as a non-static variable.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

