### PR TITLE
[RAW] fix TimeStamp typo in exif

### DIFF
--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -604,7 +604,7 @@ RawInput::open_raw (bool unpack, const std::string &name,
     if (other.parsed_gps.gpsparsed) {
         add ("GPS", "Latitude", other.parsed_gps.latitude, false, 0.0f);
         add ("GPS", "Longitude", other.parsed_gps.longtitude, false, 0.0f); // N.B. wrong spelling!
-        add ("GPS", "TimeTtamp", other.parsed_gps.gpstimestamp, false, 0.0f);
+        add ("GPS", "TimeStamp", other.parsed_gps.gpstimestamp, false, 0.0f);
         add ("GPS", "Altitude", other.parsed_gps.altitude, false, 0.0f);
         add ("GPS", "LatitudeRef", string_view(&other.parsed_gps.latref, 1), false);
         add ("GPS", "LongitudeRef", string_view(&other.parsed_gps.longref, 1), false);


### PR DESCRIPTION
## Description

Fix typo in exif keyword.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

