### PR TITLE
Add a bumpformat option for the bumpslopes exporter

### DIFF
--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -488,7 +488,9 @@ bump_to_bumpslopes (ImageBuf &dst, const ImageBuf &src, const std::string &bumpf
 
     // detect bump input format according to channel count
     void (*bump_filter)(const ImageBuf&, const ImageBuf::Iterator<float>&, float*, float*, float*);
-             
+    
+    bump_filter = &sobel_gradient<SRCTYPE>;
+    
     if(Strutil::iequals(bumpformat, "height"))
          bump_filter = &sobel_gradient<SRCTYPE>; // default one considering height value in channel 0 
     else

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -72,7 +72,6 @@ static bool lightprobemode = false;
 static bool bumpslopesmode = false;
 
 
-
 static std::string
 filter_help_string ()
 {
@@ -212,6 +211,7 @@ getargs (int argc, char *argv[], ImageSpec &configspec)
     std::string outcolorspace;
     std::string colorconfigname;
     std::string channelnames;
+    std::string bumpformat = "auto";
     std::vector<std::string> string_attrib_names, string_attrib_values;
     std::vector<std::string> any_attrib_names, any_attrib_values;
     filenames.clear();
@@ -277,6 +277,7 @@ getargs (int argc, char *argv[], ImageSpec &configspec)
                   "--envlatl", &envlatlmode, "Create lat/long environment map",
                   "--lightprobe", &lightprobemode, "Create lat/long environment map from a light probe",
                   "--bumpslopes", &bumpslopesmode, "Create a 6 channels bump-map with height, derivatives and square derivatives from an height or a normal map",
+                  "--bumpformat %s", &bumpformat, "Specify the input bump format for the --bumpslopes option: height, normal or auto:default.",
             
 //                  "--envcube", &envcubemode, "Create cubic env map (file order: px, nx, py, ny, pz, nz) (UNIMP)",
                   "<SEPARATOR>", colortitle_help_string().c_str(),
@@ -396,7 +397,9 @@ getargs (int argc, char *argv[], ImageSpec &configspec)
     configspec.attribute ("maketx:prman_options", prman);
     if (mipimages.size())
         configspec.attribute ("maketx:mipimages", Strutil::join(mipimages,";"));
-
+    if(bumpslopesmode)
+        configspec.attribute ("maketx:bumpformat", bumpformat);
+    
     std::string cmdline = Strutil::format ("OpenImageIO %s : %s",
                                      OIIO_VERSION_STRING,
                                      command_line_string (argc, argv, sansattrib));

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4515,7 +4515,9 @@ prep_texture_config (ImageSpec &configspec,
                                              get_value_override(fileoptions["oiio"])));
     configspec.attribute ("maketx:prman_options",
                           get_value_override(fileoptions["prman_options"],
-                                             get_value_override(fileoptions["prman"])));
+                                             get_value_override(fileoptions["prman"])));    
+    configspec.attribute ("maketx:bumpformat",
+                          get_value_override(fileoptions["bumpformat"], "auto"));
     // if (mipimages.size())
     //     configspec.attribute ("maketx:mipimages", Strutil::join(mipimages,";"));
 
@@ -4545,6 +4547,7 @@ output_file (int argc, const char *argv[])
                       Strutil::starts_with (stripped_command, "olatlong");
     bool do_shad = Strutil::starts_with (stripped_command, "oshad");
     bool do_bumpslopes = Strutil::starts_with (stripped_command, "obump");
+    
 
     if (ot.debug)
         std::cout << "Output: " << filename << "\n";
@@ -5190,7 +5193,7 @@ getargs (int argc, char *argv[])
                 "-o %@ %s", output_file, NULL, "Output the current image to the named file",
                 "-otex %@ %s", output_file, NULL, "Output the current image as a texture",
                 "-oenv %@ %s", output_file, NULL, "Output the current image as a latlong env map",
-                "-obump %@ %s", output_file, NULL, "Output the current normal or height texture map as a 6 channels bump texture including the first and second moment of slopes",
+                "-obump %@ %s", output_file, NULL, "Output the current bump texture map as a 6 channels texture including the first and second moment of the bump slopes (options: bumpformat=height, normal, default=auto)",
                 "<SEPARATOR>", "Options that affect subsequent image output:",
                 "-d %@ %s", set_dataformat, NULL,
                     "'-d TYPE' sets the output data format of all channels, "


### PR DESCRIPTION
This option prevents situations where the bumpslopes exporter fails to detect an input bump format as an height map. The typical situation is a 3 channels RGB height map we would expect to be monochromatic (R=G=B for all pixels) but having subtle color variations introduced by a texture publication process (typically a precision or rounding error). In such situation the exporter will automatically interpret the bump map as a false normal map, resulting in a corrupted texture output.

The bumpformat option allows the user to bypass the automatic detection and manually specify the input bump format.