### PR TITLE
Make unit test errors respect whether stdout is a terminal

### DIFF
--- a/src/include/OpenImageIO/unittest.h
+++ b/src/include/OpenImageIO/unittest.h
@@ -55,10 +55,10 @@ public:
     UnitTestFailureCounter () : m_failures(0) { }
     ~UnitTestFailureCounter () {
         if (m_failures) {
-            std::cout << Sysutil::Term().ansi ("red", "ERRORS!\n");
+            std::cout << Sysutil::Term(std::cout).ansi ("red", "ERRORS!\n");
             std::exit (m_failures != 0);
         } else {
-            std::cout << Sysutil::Term().ansi ("green", "OK\n");
+            std::cout << Sysutil::Term(std::cout).ansi ("green", "OK\n");
         }
     }
     const UnitTestFailureCounter& operator++ () { ++m_failures; return *this; } // prefix


### PR DESCRIPTION
This causes the color only to be used to the terminal, not incorrectly
injected when the output is redirected to a file.

