### PR TITLE
Remove ustring::operator int()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -186,6 +186,16 @@ Public API changes:
 * Rename/move of `array_view` to `span`. Deprecated `array_view` and moved
   array_view.h contents to span.h. You should change `array_view<T>`
   to `span<T>` and `array_view<const T>` to `cspan<T>`. #1956 (1.9.4)
+* ustring: removed `operator int()` that allowed simple int casting such as:
+  ```
+      ustring u, v;
+      if (u || !v) { ... }
+  ```
+  This was error-prone, neither std::string nor std::string_view had the
+  equivalent, so we are removing it. The preferred idiom is:
+  ```
+      if (!u.empty() || v.empty()) { ... }
+  ```
 
 Performance improvements:
 * ImageBufAlgo::computePixelStats is now multithreaded and should improve by

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -340,11 +340,6 @@ public:
     /// point to an empty string?
     bool empty (void) const { return (size() == 0); }
 
-    /// Cast to int, which is interpreted as testing whether it's not an
-    /// empty string.  This allows you to write "if (t)" with the same
-    /// semantics as if it were a char*.
-    operator int (void) const { return !empty(); }
-
     /// Return a const_iterator that references the first character of
     /// the string.
     const_iterator begin () const { return string().begin(); }

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1161,7 +1161,7 @@ ImageCacheImpl::find_file (ustring filename,
 {
     // Debugging aid: attribute "substitute_image" forces all image
     // references to be to one named file.
-    if (m_substitute_image)
+    if (! m_substitute_image.empty())
         filename = m_substitute_image;
 
     // Shortcut - check the per-thread microcache before grabbing a more
@@ -1246,7 +1246,7 @@ ImageCacheImpl::verify_file (ImageCacheFile *tf,
             // What if we've opened another file, with a different name,
             // but the SAME pixels?  It can happen!  Bad user, bad!  But
             // let's save them from their own foolishness.
-            if (tf->fingerprint() && m_deduplicate) {
+            if (!tf->fingerprint().empty() && m_deduplicate) {
                 // std::cerr << filename << " hash=" << tf->fingerprint() << "\n";
                 ImageCacheFile *dup = find_fingerprint (tf->fingerprint(), tf);
                 if (dup != tf) {
@@ -1353,7 +1353,7 @@ ImageCacheImpl::check_max_files (ImageCachePerThreadInfo *thread_info)
 
     // Get a (locked) iterator for the next tile to be examined.
     FilenameMap::iterator sweep;
-    if (m_file_sweep_name) {
+    if (! m_file_sweep_name.empty()) {
         // We saved the sweep_id. Find the iterator corresponding to it.
         sweep = m_files.find (m_file_sweep_name);
         // Note: if the sweep_id is no longer in the table, sweep will be an

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -159,7 +159,7 @@ TextureSystemImpl::texture3d (TextureHandle *texture_handle_,
         return missing_texture (options, nchannels, result,
                                 dresultds, dresultdt, dresultdr);
 
-    if (options.subimagename) {
+    if (! options.subimagename.empty()) {
         // If subimage was specified by name, figure out its index.
         int s = m_imagecache->subimage_from_name (texturefile, options.subimagename);
         if (s < 0) {

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -1001,7 +1001,7 @@ TextureSystemImpl::texture (TextureHandle *texture_handle_,
     if (! texturefile  ||  texturefile->broken())
         return missing_texture (options, nchannels, result, dresultds, dresultdt);
 
-    if (options.subimagename) {
+    if (! options.subimagename.empty()) {
         // If subimage was specified by name, figure out its index.
         int s = m_imagecache->subimage_from_name (texturefile, options.subimagename);
         if (s < 0) {


### PR DESCRIPTION
As pointed out by Thiago Ize and John Haddon (but unfortunately not
heard by me until literally years later), this is error prone because
there are times when a ustring is converted to an int/bool in unexpected
situations. It even led to verifiable errors in OSL that I only
discovered after commenting out this operator to see what would happen.

Neither std::string nor std::string_view have this operator, bolstering
Thiago & John's arguments.

So we are removing it from OIIO 2.0. Hopefully this won't break too many
people's apps that happen to make use of ustring. The fix is simple, just
change:

    if (myustring)

to

    if (! myustring.empty())

Because this is a back-compatibility break, this change will only be merged into master, NOT backported to any current release branches.
