### PR TITLE
Fixes related to debugging half -> float conversion

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -744,10 +744,19 @@ inline void convert_type<half,float> (const half *src,
                                       float *dst, size_t n,
                                       float _min, float _max)
 {
+#if OIIO_SIMD >= 8 && OIIO_F16C_ENABLED
+    // If f16c ops are enabled, it's worth doing this by 8's
+    for ( ; n >= 8; n -= 8, src += 8, dst += 8) {
+        simd::vfloat8 s_simd (src);
+        s_simd.store (dst);
+    }
+#endif
+#if OIIO_SIMD >= 4
     for ( ; n >= 4; n -= 4, src += 4, dst += 4) {
         simd::vfloat4 s_simd (src);
         s_simd.store (dst);
     }
+#endif
     while (n--)
         *dst++ = (*src++);
 }
@@ -764,7 +773,6 @@ convert_type<float,uint16_t> (const float *src, uint16_t *dst, size_t n,
     float max = std::numeric_limits<uint16_t>::max();
     float scale = max;
     simd::vfloat4 max_simd (max);
-    simd::vfloat4 one_half_simd (0.5f);
     simd::vfloat4 zero_simd (0.0f);
     for ( ; n >= 4; n -= 4, src += 4, dst += 4) {
         simd::vfloat4 scaled = simd::round (simd::vfloat4(src) * max_simd);
@@ -786,7 +794,6 @@ convert_type<float,uint8_t> (const float *src, uint8_t *dst, size_t n,
     float max = std::numeric_limits<uint8_t>::max();
     float scale = max;
     simd::vfloat4 max_simd (max);
-    simd::vfloat4 one_half_simd (0.5f);
     simd::vfloat4 zero_simd (0.0f);
     for ( ; n >= 4; n -= 4, src += 4, dst += 4) {
         simd::vfloat4 scaled = simd::round (simd::vfloat4(src) * max_simd);
@@ -805,10 +812,19 @@ inline void
 convert_type<float,half> (const float *src, half *dst, size_t n,
                           half _min, half _max)
 {
+#if OIIO_SIMD >= 8 && OIIO_F16C_ENABLED
+    // If f16c ops are enabled, it's worth doing this by 8's
+    for ( ; n >= 8; n -= 8, src += 8, dst += 8) {
+        simd::vfloat8 s (src);
+        s.store (dst);
+    }
+#endif
+#if OIIO_SIMD >= 4
     for ( ; n >= 4; n -= 4, src += 4, dst += 4) {
         simd::vfloat4 s (src);
         s.store (dst);
     }
+#endif
     while (n--)
         *dst++ = *src++;
 }

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -2977,6 +2977,48 @@ vfloat16 nmsub (const vfloat16& a, const vfloat16& b, const vfloat16& c); // -a*
 
 
 
+// Odds and ends, other CPU hardware tricks
+
+// Try to set the flush_zero_mode CPU flag on x86. Return true if we are
+// able, otherwise false (because it's not available on that platform,
+// or because it's gcc 4.8 which has a bug that lacks this intrinsic).
+inline bool set_flush_zero_mode (bool on) {
+#if (defined(__x86_64__) || defined(__i386__)) && (OIIO_GNUC_VERSION == 0 || OIIO_GNUC_VERSION > 40900)
+    _MM_SET_FLUSH_ZERO_MODE (on ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF);
+    return true;
+#endif
+    return false;
+}
+
+// Try to set the denorms_zero_mode CPU flag on x86. Return true if we are
+// able, otherwise false (because it's not available on that platform,
+// or because it's gcc 4.8 which has a bug that lacks this intrinsic).
+inline bool set_denorms_zero_mode (bool on) {
+#if (defined(__x86_64__) || defined(__i386__)) && (OIIO_GNUC_VERSION == 0 || OIIO_GNUC_VERSION > 40900)
+    _MM_SET_DENORMALS_ZERO_MODE (on ? _MM_DENORMALS_ZERO_ON : _MM_DENORMALS_ZERO_OFF);
+    return true;
+#endif
+    return false;
+}
+
+// Get the flush_zero_mode CPU flag on x86.
+inline bool get_flush_zero_mode () {
+#if (defined(__x86_64__) || defined(__i386__)) && (OIIO_GNUC_VERSION == 0 || OIIO_GNUC_VERSION > 40900)
+    return _MM_GET_FLUSH_ZERO_MODE() == _MM_FLUSH_ZERO_ON;
+#endif
+    return false;
+}
+
+// Get the denorms_zero_mode CPU flag on x86.
+inline bool get_denorms_zero_mode () {
+#if (defined(__x86_64__) || defined(__i386__)) && (OIIO_GNUC_VERSION == 0 || OIIO_GNUC_VERSION > 40900)
+    return _MM_GET_DENORMALS_ZERO_MODE() == _MM_DENORMALS_ZERO_ON;
+#endif
+    return false;
+}
+
+
+
 
 
 


### PR DESCRIPTION
We found that certain 'half' pixel values that involved "denormalized"
values (very close to zero) were inexplicably getting squashed to exact
0.0f in some circumstances but not others. Long story short, we traced
this to an older version of libopenjpeg (in turn pulled in by ffmpeg's
libraries) that set the x86 DENORMALS_ZERO_MODE upon its DSO load, and
left it like that, which is a truly terrible thing to do because it can
inject math bugs elsewhere into the app, even in parts that seemingly
have nothing to do with decoding jpeg-2000 images.

The code is only symptomatic in OIIO when we build with SSE support but
not with f16c instruction support -- the symptom is specific to the
series of ops we use to accelerate the half->float conversion with SSE
but without f16c. There could be other effects, but we haven't seen
them.

This seems to be fixed in newer versions of libopenjpeg. But we
encountered it, so others may also. It seems equally evil for our
library to reset the flag and leave it that way. However, for a full
application like oiiotool, we can safely set the flag, and so we do (if
the intrinsic is available, which unfortunately it is not in gcc 4.8).
I think that's the best we can do for now, out of several options that
were less than satisfactory. (A different set of instructions for h->f
conversion also avoided the problem, but was much slower.) We also advise
people to use a sufficiently new version of libopenjpeg to avoid this.

Along the way...

* simd.h methods to get/set the flush_zero and denorms_zero modes.
  (Note: known gcc 4.8 bug omits access to those intrinsics.)

* Preemptively turn off the denorms zero mode in oiiotool, in case some
  rogue library has turned it on.

* `oiiotool --stats` : Don't force a conversion to float when reading
  the full image to compute stats on. This change also avoids the bug,
  though in a brittle way. Still probably good to compute the stats on
  the native data.

* fmath_test checks EVERY 'half' value and makes sure the h->f->h round
  trip works properly.

* Change the behavior of `oiiotool --dumpdata` do try to dump the values
  of each data type without conversion, rather than converting all to
  float and printing the float values. This is a more true representation
  of the raw data in the file, which I assume is why somebody wants to
  do the --dumpdata.

* fmath.h changes to speed up bulk h[]<->f[] conversions by using
  8-wide simd ops when f16c is available. (This is just incidental,
  something I saw along the way.)

* `oiiotool --help` prints the number of cores, main mem size, and set
  of processor capabilities (SIMD level, etc.) on the hardware it's
  currently running on, and which set of SIMD capabilities was requested
  at build time.
