### PR TITLE
Add thresholds to IBA::isConstantColor, isConstantChannel, isMonochrome

### DIFF
--- a/src/doc/imagebufalgo.tex
+++ b/src/doc/imagebufalgo.tex
@@ -1563,11 +1563,12 @@ struct CompareResults {
 
 
 \apiitem{bool {\ce isConstantColor} (const ImageBuf \&src, span<float> color=\{\}, \\
- \bigspc\bigspc         ROI roi=\{\}, int nthreads=0)}
+ \bigspc\bigspc         float threshold=0.0f, ROI roi=\{\}, int nthreads=0)}
 \index{ImageBufAlgo!isConstantColor} \indexapi{isConstantColor}
 
-If all pixels of {\cf src} within the ROI have the same values (for the
-subset of channels described by {\cf roi}), return {\cf true} and store
+If all pixels of {\cf src} within the ROI have the same values, (for the
+subset of channels described by {\cf roi}), within
+tolerance of {\cf threshold}, return {\cf true} and store
 the values in {\cf color[roi.chbegin...roi.chend-1]}.  Otherwise, return
 {\cf false}.
 
@@ -1589,11 +1590,11 @@ the values in {\cf color[roi.chbegin...roi.chend-1]}.  Otherwise, return
 
 
 \apiitem{bool {\ce isConstantChannel} (const ImageBuf \&src, int channel, float val, \\
- \bigspc\bigspc         ROI roi=\{\}, int nthreads=0)}
+ \bigspc\bigspc         float threshold=0.0f, ROI roi=\{\}, int nthreads=0)}
 \index{ImageBufAlgo!isConstantChannel} \indexapi{isConstantChannel}
 
 Returns {\cf true} if all pixels of {\cf src} within the ROI have the
-given {\cf channel} value {\cf val}.
+given {\cf channel} value {\cf val} (within {\cf threshold}).
 
 \smallskip
 \noindent Examples:
@@ -1609,13 +1610,15 @@ given {\cf channel} value {\cf val}.
 \end{code}
 \apiend
 
-\apiitem{bool {\ce isMonochrome} (const ImageBuf \&src, ROI roi=\{\}, int nthreads=0)}
+\apiitem{bool {\ce isMonochrome} (const ImageBuf \&src, float threshold=0.0f, \\
+\bigspc\bigspc ROI roi=\{\}, int nthreads=0)}
 \index{ImageBufAlgo!isMonochrome} \indexapi{isMonochrome}
 
-Returns {\cf true} if the image is monochrome within the ROI, that is,
-for all pixels within the region, do all channels {\cf [roi.chbegin, roi.chend)}
-have the same value?  If roi is not defined (the default), it will be
-understood to be all of the defined pixels and channels of source.
+Returns {\cf true} if the image is monochrome within the ROI, that is, for
+all pixels within the region, do all channels {\cf [roi.chbegin, roi.chend)}
+have the same value (within tolerance {\cf threshold}?  If roi is not
+defined (the default), it will be understood to be all of the defined pixels
+and channels of source.
 
 \smallskip
 \noindent Examples:

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -2814,7 +2814,7 @@ which is defined as a class having the following members:
 \apiend
 
 
-\apiitem{tuple ImageBufAlgo.{\ce isConstantColor} (src, roi=ROI.All, nthreads=0)}
+\apiitem{tuple ImageBufAlgo.{\ce isConstantColor} (src, threshold=0.0, roi=ROI.All, nthreads=0)}
 \index{ImageBufAlgo!isConstantColor} \indexapi{isConstantColor}
 
 If all pixels of {\cf src} within the ROI have the same values (for the
@@ -2835,7 +2835,7 @@ color (one {\cf float} for each channel), otherwise return {\cf None}.
 
 
 \apiitem{bool ImageBufAlgo.{\ce isConstantChannel} (src, channel, val, \\
- \bigspc\bigspc         roi=ROI.All, nthreads=0)}
+ \bigspc\bigspc         threshold=0.0, roi=ROI.All, nthreads=0)}
 \index{ImageBufAlgo!isConstantChannel} \indexapi{isConstantChannel}
 
 Returns {\cf True} if all pixels of {\cf src} within the ROI have the
@@ -2856,7 +2856,7 @@ given {\cf channel} value {\cf val}.
 \apiend
 
 
-\apiitem{bool ImageBufAlgo.{\ce isMonochrome} (src, 
+\apiitem{bool ImageBufAlgo.{\ce isMonochrome} (src, threshold=0.0,
           roi=ROI.All, nthreads=0)}
 \index{ImageBufAlgo!isMonochrome} \indexapi{isMonochrome}
 

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -920,26 +920,42 @@ int OIIO_API compare_Yee (const ImageBuf &A, const ImageBuf &B,
 
 
 /// Do all pixels within the ROI have the same values for channels
-/// [roi.chbegin..roi.chend-1]?  If so, return true and store that color
-/// in color[chbegin...chend-1] (if color is not empty); otherwise return
-/// false.  If roi is not defined (the default), it will be understood
-/// to be all of the defined pixels and channels of source.
-bool OIIO_API isConstantColor (const ImageBuf &src, span<float> color = {},
+/// [roi.chbegin..roi.chend-1], within a tolerance of +/- threshold?  If so,
+/// return true and store that color in color[chbegin...chend-1] (if color
+/// is not empty); otherwise return false.  If roi is not defined (the
+/// default), it will be understood to be all of the defined pixels and
+/// channels of source.
+OIIO_API bool isConstantColor (const ImageBuf &src, float threshold=0.0f,
+                               span<float> color = {},
                                ROI roi={}, int nthreads=0);
+inline bool isConstantColor (const ImageBuf &src, span<float> color,
+                             ROI roi={}, int nthreads=0) {
+    return isConstantColor (src, 0.0f, color, roi, nthreads);
+}
 
-/// Does the requested channel have a given value over the ROI?  (For
-/// this function, the ROI's chbegin/chend are ignored.)  Return true if
-/// so, otherwise return false.  If roi is not defined (the default), it
-/// will be understood to be all of the defined pixels and channels of
-/// source.
-bool OIIO_API isConstantChannel (const ImageBuf &src, int channel, float val,
+/// Does the requested channel have a given value (within a tolerance of +/-
+/// threshold) for every channel within the ROI?  (For this function, the
+/// ROI's chbegin/chend are ignored.)  Return true if so, otherwise return
+/// false.  If roi is not defined (the default), it will be understood to be
+/// all of the defined pixels and channels of source.
+OIIO_API bool isConstantChannel (const ImageBuf &src, int channel,
+                                 float val, float threshold=0.0f,
                                  ROI roi={}, int nthreads=0);
+inline bool isConstantChannel (const ImageBuf &src, int channel, float val,
+                               ROI roi, int nthreads=0) {
+    return isConstantChannel (src, channel, val, 0.0f, roi, nthreads);
+}
 
-/// Is the image monochrome within the ROI, i.e., for all pixels within
-/// the region, do all channels [roi.chbegin, roi.chend) have the same
-/// value?  If roi is not defined (the default), it will be understood
-/// to be all of the defined pixels and channels of source.
-bool OIIO_API isMonochrome (const ImageBuf &src, ROI roi={}, int nthreads=0);
+/// Is the image monochrome within the ROI, i.e., for every pixel within the
+/// region, do all channels [roi.chbegin, roi.chend) have the same value
+/// (within a tolerance of +/- threshold)?  If roi is not defined (the
+/// default), it will be understood to be all of the defined pixels and
+/// channels of source.
+OIIO_API bool isMonochrome (const ImageBuf &src, float threshold=0.0f,
+                            ROI roi={}, int nthreads=0);
+inline bool isMonochrome (const ImageBuf &src, ROI roi, int nthreads=0) {
+    return isMonochrome (src, 0.0f, roi, nthreads);
+}
 
 /// Count how many pixels in the ROI match a list of colors.
 ///

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -622,14 +622,16 @@ void test_isConstantColor ()
     OIIO_CHECK_EQUAL (col[2], thecolor[2]);
 
     // Now introduce a difference
-    const float another[CHANNELS] = { 0, 1, 1 };
+    const float another[CHANNELS] = { 0.25, 0.51, 0.75 };
     A.setpixel (2, 2, 0, another, 3);
     OIIO_CHECK_EQUAL (ImageBufAlgo::isConstantColor (A), false);
     OIIO_CHECK_EQUAL (ImageBufAlgo::isConstantColor (A, thecolor), false);
+    // But not with lower threshold
+    OIIO_CHECK_EQUAL (ImageBufAlgo::isConstantColor (A, 0.015), true);
 
     // Make sure ROI works
     ROI roi (0, WIDTH, 0, 2, 0, 1, 0, CHANNELS);  // should match for this ROI
-    OIIO_CHECK_EQUAL (ImageBufAlgo::isConstantColor (A, NULL, roi), true);
+    OIIO_CHECK_EQUAL (ImageBufAlgo::isConstantColor (A, 0.0f, {}, roi), true);
 }
 
 
@@ -647,13 +649,18 @@ void test_isConstantChannel ()
     OIIO_CHECK_EQUAL (ImageBufAlgo::isConstantChannel (A, 1, 0.5f), true);
 
     // Now introduce a difference
-    const float another[CHANNELS] = { 0, 1, 1 };
+    const float another[CHANNELS] = { 0.25, 0.51, 0.75 };
     A.setpixel (2, 2, 0, another, 3);
+    // It should still pass if within the threshold
+    OIIO_CHECK_EQUAL (ImageBufAlgo::isConstantChannel (A, 1, 0.5f, 0.015f), true);
+    // But not with lower threshold
+    OIIO_CHECK_EQUAL (ImageBufAlgo::isConstantChannel (A, 1, 0.5f, 0.005), false);
+    // And certainly not with zero threshold
     OIIO_CHECK_EQUAL (ImageBufAlgo::isConstantChannel (A, 1, 0.5f), false);
 
     // Make sure ROI works
     ROI roi (0, WIDTH, 0, 2, 0, 1, 0, CHANNELS);  // should match for this ROI
-    OIIO_CHECK_EQUAL (ImageBufAlgo::isConstantChannel (A, 1, 0.5f, roi), true);
+    OIIO_CHECK_EQUAL (ImageBufAlgo::isConstantChannel (A, 1, 0.5f, roi=roi), true);
 }
 
 
@@ -670,10 +677,16 @@ void test_isMonochrome ()
 
     OIIO_CHECK_EQUAL (ImageBufAlgo::isMonochrome (A), true);
 
-    // Now introduce a difference
-    const float another[CHANNELS] = { 0.25, 0.25, 1 };
+    // Now introduce a tiny difference
+    const float another[CHANNELS] = { 0.25, 0.25, 0.26 };
     A.setpixel (2, 2, 0, another, 3);
+    // It should still pass if within the threshold
+    OIIO_CHECK_EQUAL (ImageBufAlgo::isMonochrome (A, 0.015f), true);
+    // But not with lower threshold
+    OIIO_CHECK_EQUAL (ImageBufAlgo::isMonochrome (A, 0.005f), false);
+    // And certainly not with zero threshold
     OIIO_CHECK_EQUAL (ImageBufAlgo::isMonochrome (A), false);
+
 
     // Make sure ROI works
     ROI roi (0, WIDTH, 0, 2, 0, 1, 0, CHANNELS);  // should match for this ROI

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -1992,14 +1992,15 @@ IBA_ociofiletransform_colorconfig_ret (const ImageBuf &src,
 
 
 py::object
-IBA_isConstantColor (const ImageBuf &src,
+IBA_isConstantColor (const ImageBuf &src, float threshold,
                      ROI roi = ROI::All(), int nthreads = 0)
 {
     std::vector<float> constcolor (src.nchannels());
     bool r;
     {
         py::gil_scoped_release gil;
-        r = ImageBufAlgo::isConstantColor (src, &constcolor[0], roi, nthreads);
+        r = ImageBufAlgo::isConstantColor (src, threshold, constcolor,
+                                           roi, nthreads);
     }
     if (r) {
         return C_to_tuple (&constcolor[0], (int)constcolor.size());
@@ -2011,18 +2012,20 @@ IBA_isConstantColor (const ImageBuf &src,
 
 
 bool IBA_isConstantChannel (const ImageBuf &src, int channel, float val,
-                            ROI roi, int nthreads)
+                            float threshold, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::isConstantChannel (src, channel, val, roi, nthreads);
+    return ImageBufAlgo::isConstantChannel (src, channel, val, threshold,
+                                            roi, nthreads);
 }
 
 
 
-bool IBA_isMonochrome (const ImageBuf &src, ROI roi, int nthreads)
+bool IBA_isMonochrome (const ImageBuf &src, float threshold,
+                       ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::isMonochrome (src, roi, nthreads);
+    return ImageBufAlgo::isMonochrome (src, threshold, roi, nthreads);
 }
 
 
@@ -2617,14 +2620,14 @@ void declare_imagebufalgo (py::module &m)
             "roi"_a=ROI::All(), "nthreads"_a=0)
 
         .def_static("isConstantColor", &IBA_isConstantColor,
-             "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+             "src"_a, "threshold"_a=0.0f, "roi"_a=ROI::All(), "nthreads"_a=0)
 
         .def_static("isConstantChannel", &IBA_isConstantChannel,
-            "src"_a, "channel"_a, "val"_a,
+            "src"_a, "channel"_a, "val"_a, "threshold"_a=0.0f,
             "roi"_a=ROI::All(), "nthreads"_a=0)
 
         .def_static("isMonochrome", &IBA_isMonochrome,
-             "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+             "src"_a, "threshold"_a=0.0f, "roi"_a=ROI::All(), "nthreads"_a=0)
 
         // color_count, color_range_check
 


### PR DESCRIPTION
A situation came up recently that made me realize it would be good to
have a handy way of knowing whether an image is *almost* a constant
color (e.g., allow the channels in a pixel to differ within some
expected threshold and still be considered monochrome).

So this patch proposes to add an optional `threshold` parameter to
these three IBA functions. The default is 0.0, which is identical to
the old behavior and checks for exact matches only.

While I was in there, I noticed that these three functions were not
previously parallelized/threaded, so I added that as well. That should
speed them up considerably when running on multicore machines.
