### PR TITLE
VDB tweaks for library initialization and CMake

### DIFF
--- a/src/cmake/modules/FindOpenVDB.cmake
+++ b/src/cmake/modules/FindOpenVDB.cmake
@@ -45,6 +45,7 @@ FIND_PATH(OPENVDB_INCLUDE_DIR
     include
 )
 
+LIST(INSERT oiio_vdblib_search 0 lib)
 IF (DEBUGMODE)
   LIST(INSERT oiio_vdblib_search 0 lib/debug)
 ENDIF ()

--- a/src/openvdb.imageio/openvdbinput.cpp
+++ b/src/openvdb.imageio/openvdbinput.cpp
@@ -297,7 +297,9 @@ openVDB (const std::string& filename, const ImageInput* errReport)
         return nullptr;
 
     // Endianess of OPENVDB_MAGIC isn't clear, so just leave as is
-    std::remove_const<std::remove_reference<decltype(OPENVDB_MAGIC)>::type>::type magic;
+    int32_t magic;
+    static_assert(sizeof(magic)==sizeof(OPENVDB_MAGIC), "Magic type not the same size");
+
     if (fread(&magic, sizeof(magic), 1, f) != 1)
         magic = 0;
     fclose(f);

--- a/src/openvdb.imageio/openvdbinput.cpp
+++ b/src/openvdb.imageio/openvdbinput.cpp
@@ -292,6 +292,18 @@ openVDB (const std::string& filename, const ImageInput* errReport)
     if (! Filesystem::is_regular (filename))
         return nullptr;
 
+    FILE* f = fopen(filename.c_str(), "r");
+    if (!f)
+        return nullptr;
+
+    // Endianess of OPENVDB_MAGIC isn't clear, so just leave as is
+    std::remove_const<std::remove_reference<decltype(OPENVDB_MAGIC)>::type>::type magic;
+    if (fread(&magic, sizeof(magic), 1, f) != 1)
+        magic = 0;
+    fclose(f);
+    if (magic != OPENVDB_MAGIC)
+        return nullptr;
+
     static struct OpenVDBLib {
         OpenVDBLib()  { openvdb::initialize(); }
         ~OpenVDBLib() { openvdb::uninitialize(); }


### PR DESCRIPTION
VDB library exposes a magic one can test against, so use this before initializing the library.
CMake fixes for custom VDB locations in release mode.
