### PR TITLE
Add a .clang-format file and a 'make clang-format' target

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,119 @@
+Language:        Cpp
+BasedOnStyle:  WebKit
+SpaceBeforeParens: ControlStatements
+
+#AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+#AlignConsecutiveAssignments: false
+#AlignConsecutiveDeclarations: false
+#AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+#AllowShortFunctionsOnASingleLine: All
+#AllowShortIfStatementsOnASingleLine: false
+#AllowShortLoopsOnASingleLine: false
+#AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: TopLevel
+#AlwaysBreakBeforeMultilineStrings: false
+#AlwaysBreakTemplateDeclarations: MultiLine
+#BinPackArguments: true
+#BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+#BreakBeforeBinaryOperators: All
+#BreakBeforeBraces: WebKit
+#BreakBeforeInheritanceComma: false
+#BreakInheritanceList: BeforeColon
+#BreakBeforeTernaryOperators: true
+#BreakConstructorInitializersBeforeComma: false
+#BreakConstructorInitializers: BeforeComma
+#BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: false
+ColumnLimit:     80
+#CommentPragmas:  '^ IWYU pragma:'
+#CompactNamespaces: false
+#ConstructorInitializerAllOnOneLineOrOnePerLine: false
+#ConstructorInitializerIndentWidth: 4
+#ContinuationIndentWidth: 4
+#Cpp11BracedListStyle: false
+#DerivePointerAlignment: true
+#DisableFormat:   false
+#ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+#ForEachMacros:   
+#  - foreach
+#  - Q_FOREACH
+#  - BOOST_FOREACH
+#IncludeBlocks:   Preserve
+#IncludeCategories: 
+#  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+#    Priority:        2
+#  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+#    Priority:        3
+#  - Regex:           '.*'
+#    Priority:        1
+#IncludeIsMainRegex: '(Test)?$'
+#IndentCaseLabels: false
+IndentPPDirectives: AfterHash
+#IndentWidth:     4
+#IndentWrappedFunctionNames: false
+#JavaScriptQuotes: Leave
+#JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+#MacroBlockBegin: ''
+#MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 3
+#NamespaceIndentation: Inner
+#ObjCBinPackProtocolList: Auto
+#ObjCBlockIndentWidth: 4
+#ObjCSpaceAfterProperty: true
+#ObjCSpaceBeforeProtocolList: true
+#PenaltyBreakAssignment: 2
+#PenaltyBreakBeforeFirstCallParameter: 19
+#PenaltyBreakComment: 300
+#PenaltyBreakFirstLessLess: 120
+#PenaltyBreakString: 1000
+#PenaltyBreakTemplateDeclaration: 10
+#PenaltyExcessCharacter: 1000000
+#PenaltyReturnTypeOnItsOwnLine: 60
+#PointerAlignment: Left
+ReflowComments:  false
+#SortIncludes:    true
+#SortUsingDeclarations: true
+#SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+#SpaceBeforeAssignmentOperators: true
+#SpaceBeforeCpp11BracedList: true
+#SpaceBeforeCtorInitializerColon: true
+#SpaceBeforeInheritanceColon: true
+#SpaceBeforeParens: ControlStatements
+#SpaceBeforeRangeBasedForLoopColon: true
+#SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+#SpacesInAngles:  false
+#SpacesInContainerLiterals: true
+#SpacesInCStyleCastParentheses: false
+#SpacesInParentheses: false
+#SpacesInSquareBrackets: false
+#Standard:        Cpp11
+#TabWidth:        8
+#UseTab:          Never
+#...
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ cache:
 before_install:
     - if [ "$WHICHGCC" == "" ]; then export WHICHGCC="4.8" ; fi
     - if [ "$PYTHON_VERSION" == "" ]; then export PYTHON_VERSION="2.7" ; fi
+    - if [ "$BUILD_MISSING_DEPS" == "" ] ; then export BUILD_MISSING_DEPS=1 ; fi
     - if [ $TRAVIS_OS_NAME == osx ] ; then
           uname -n ;
           export PLATFORM=macosx ;
@@ -87,18 +88,21 @@ install:
 
 script:
     - make VERBOSE=1 $BUILD_FLAGS BUILD_MISSING_DEPS=1 cmakesetup
-    - make -j2 $BUILD_FLAGS
+    - make -j2 $BUILD_FLAGS $OIIOTARGET
     - export OPENIMAGEIO_ROOT_DIR=$PWD/dist/$PLATFORM
-    - export DYLD_LIBRARY_PATH=$OPENIMAGEIO_ROOT_DIR/lib:$DYLD_LIBRARY_PATH 
+    - export DYLD_LIBRARY_PATH=$OPENIMAGEIO_ROOT_DIR/lib:$DYLD_LIBRARY_PATH
     - export LD_LIBRARY_PATH=$OPENIMAGEIO_ROOT_DIR/lib:$LD_LIBRARY_PATH
     - export OIIO_LIBRARY_PATH=$OPENIMAGEIO_ROOT_DIR/lib
-    - echo "OIIO_LIBRARY_PATH is ${OIIO_LIBRARY_PATH}"
-    # - echo "list of library path:"
-    # - ls -R $OIIO_LIBRARY_PATH
     - export PYTHONPATH=$OPENIMAGEIO_ROOT_DIR/python:$PYTHONPATH
     - export LSAN_OPTIONS=suppressions=$PWD/src/build-scripts/nosanitize.txt
     - if [ "$SKIP_TESTS" == "" ] ; then
           make $BUILD_FLAGS test ;
+      fi
+    - git diff --color ;
+      THEDIFF=`git diff` ;
+      if [ "$THEDIFF" != "" ] ; then
+          echo "git diff was not empty. Failing clang-format check." ;
+          exit 1 ;
       fi
 
 
@@ -124,30 +128,36 @@ matrix:
 
     include:
     # test default compile: C++11, optimized, default compilers, SSE2
-      - os: linux
+      - name: "Linux Standard (gcc48, py27)"
+        os: linux
         compiler: gcc
-      - os: osx
+      - name: "Mac (latest clang, py37)"
+        os: osx
         compiler: clang
         env: PYTHON_VERSION=3.7
     # Make sure Python 2.7 still works on OSX, but only for PRs, master/RB
     # pushes, or if the branch name includes "python".
-      - os: osx
+      - name: "Mac py27 (latest clang)"
+        os: osx
         compiler: clang
         env: PYTHON_VERSION=2.7
         if: branch =~ /(master|RB|travis|python)/ OR type = pull_request
     # test debug build with default compiler
-      - os: linux
+      - name: "Linux DEBUG Standard"
+        os: linux
         compiler: gcc
         env: DEBUG=1
       # - os: osx
       #   compiler: clang
       #   env: DEBUG=1
     # test with C++14, gcc 6, SSE 4.2
-      - os: linux
+      - name: "VFX Platform 2018 (gcc6, cpp14), sse4.2"
+        os: linux
         compiler: gcc
         env: WHICHGCC=6 USE_CPP=14 USE_SIMD=sse4.2
     # test with C++14, gcc 7, latest SIMD flags supported by TravisCI VMs
-      - os: linux
+      - name: "gcc7, cpp14, avx"
+        os: linux
         compiler: gcc
         env: WHICHGCC=7 USE_CPP=14 USE_SIMD=avx,f16c
     # Test LINKSTATIC on both platforms. This is incomplete and to make it
@@ -168,7 +178,8 @@ matrix:
     # pushes to master or RB branches, or if the branch name includes
     # "sanitize". Other ordinary work branch pushes don't need to run this
     # every time.
-      - os: linux
+      - name: "Sanitizers"
+        os: linux
         compiler: gcc
         env: WHICHGCC=6 SANITIZE=address USE_PYTHON=0
         if: branch =~ /(master|RB|travis|san)/ OR type = pull_request
@@ -180,7 +191,8 @@ matrix:
     # Only build this case for PRs, direct pushes to master or RB branches,
     # or if the branch name includes "simd". Other ordinary work branch
     # pushes don't need to run this.
-      - os: linux
+      - name: "Test no simd, no jpegturbo, dso plugins"
+        os: linux
         compiler: gcc
         env: USE_SIMD=0 USE_JPEGTURBO=0 EMBEDPLUGINS=0
         if: branch =~ /(master|RB|travis|simd)/ OR type = pull_request
@@ -189,7 +201,8 @@ matrix:
     # case for PRs, direct pushes to master or RB branches, or if the branch
     # name includes "gcc". Other ordinary work branch pushes don't
     # need to run this.
-      - os: linux
+      - name: "Linux gcc8 cpp14 avx"
+        os: linux
         compiler: gcc
         env: WHICHGCC=8 USE_CPP=14 USE_SIMD=avx,f16c
         if: branch =~ /(master|RB|travis|gcc)/ OR type = pull_request
@@ -198,7 +211,8 @@ matrix:
     # case for PRs, direct pushes to master or RB branches, or if the branch
     # name includes "17" or "gcc". Other ordinary work branch pushes don't
     # need to run this.
-      - os: linux
+      - name: "Linux most advanced (gcc8, cpp17, avx/f16c)"
+        os: linux
         compiler: gcc
         env: WHICHGCC=8 USE_CPP=17 USE_SIMD=avx,f16c
         if: branch =~ /(master|RB|travis|gcc|17)/ OR type = pull_request
@@ -206,7 +220,8 @@ matrix:
     # Only build this case for PRs, direct pushes to master or RB branches,
     # or if the branch name includes "simd". Other ordinary work branch
     # pushes don't need to run this.
-      - os: linux
+      - name: "Build clean AVX2"
+        os: linux
         compiler: gcc
         env: WHICHGCC=6 USE_SIMD=avx2 SKIP_TESTS=1
         if: branch =~ /(master|RB|travis|simd)/ OR type = pull_request
@@ -214,10 +229,17 @@ matrix:
     # Only build this case for PRs, direct pushes to master or RB branches,
     # or if the branch name includes "simd". Other ordinary work branch
     # pushes don't need to run this.
-      - os: linux
+      - name: "Build clean vs AVX512"
+        os: linux
         compiler: gcc
         env: WHICHGCC=7 USE_SIMD=avx2,avx512f,f16c SKIP_TESTS=1
         if: branch =~ /(master|RB|travis|simd)/ OR type = pull_request
+    # Just run clang-format, this test only checks formatting rule conformance
+      - name: "clang-format format verification"
+        os: osx
+        compiler: clang
+        env: OIIOTARGET=clang-format SKIP_TESTS=1 BUILD_MISSING_DEPS=0
+        #if: branch =~ /(master|RB|travis|simd)/ OR type = pull_request
     # Build with EMBEDPLUGINS=0, both platforms.
       # FIXME: doesn't work yet on Travis
       # - os: linux

--- a/Makefile
+++ b/Makefile
@@ -322,6 +322,13 @@ ifneq (${CLANG_TIDY_FIX},)
   # N.B. when fixing, you don't want parallel jobs!
 endif
 
+ifneq (${CLANG_FORMAT_INCLUDES},)
+  MY_CMAKE_FLAGS += -DCLANG_FORMAT_INCLUDES:STRING=${CLANG_FORMAT_INCLUDES}
+endif
+ifneq (${CLANG_FORMAT_EXCLUDES},)
+  MY_CMAKE_FLAGS += -DCLANG_FORMAT_EXCLUDES:STRING=${CLANG_FORMAT_EXCLUDES}
+endif
+
 ifneq (${USE_FREETYPE},)
 MY_CMAKE_FLAGS += -DUSE_FREETYPE:BOOL=${USE_FREETYPE}
 endif
@@ -386,6 +393,10 @@ package: cmakeinstall
 package_source: cmakeinstall
 	@ ( cd ${build_dir} ; ${NINJA} ${MY_NINJA_FLAGS} package_source )
 
+# 'make clang-format' runs clang-format on all source files (if it's installed)
+clang-format: cmakesetup
+	@ ( cd ${build_dir} ; ${NINJA} ${MY_NINJA_FLAGS} clang-format )
+
 else
 
 # 'make cmake' does a basic build (after first setting it up)
@@ -406,6 +417,10 @@ package: cmakeinstall
 # (platform dependent -- may be .tar.gz, .sh, .dmg, .rpm, .deb. .exe)
 package_source: cmakeinstall
 	@ ( cd ${build_dir} ; ${MAKE} ${MY_MAKE_FLAGS} package_source )
+
+# 'make clang-format' runs clang-format on all source files (if it's installed)
+clang-format: cmakesetup
+	@ ( cd ${build_dir} ; ${MAKE} ${MY_MAKE_FLAGS} clang-format )
 
 endif
 
@@ -462,6 +477,7 @@ help:
 	@echo "  make nuke         Remove ALL of build and dist (not just ${platform})"
 	@echo "  make test         Run tests"
 	@echo "  make testall      Run all tests, even broken ones"
+	@echo "  make clang-format Run clang-format on all the source files"
 	@echo "  make doxygen      Build the Doxygen docs in ${top_build_dir}/doxygen"
 	@echo ""
 	@echo "Helpful modifiers:"
@@ -480,6 +496,8 @@ help:
 	@echo "      SANITIZE=name1,...       Enable sanitizers (address, leak, thread)"
 	@echo "      CLANG_TIDY=1             Run clang-tidy on all source (can be modified"
 	@echo "                                  by CLANG_TIDY_ARGS=... and CLANG_TIDY_FIX=1"
+	@echo "      CLANG_FORMAT_INCLUDES=... CLANG_FORMAT_EXCLUDES=..."
+	@echo "                               Customize files for 'make clang-format'"
 	@echo "  Linking and libraries:"
 	@echo "      HIDE_SYMBOLS=1           Hide symbols not in the public API"
 	@echo "      SOVERSION=nn             Include the specifed major version number "

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -15,6 +15,14 @@ if [ `which brew` == "" ] ; then
     exit 1
 fi
 
+
+if [ "$OIIOTARGET" == "clang-format" ] ; then
+    # If we are running for the sake of clang-format only, just install the
+    # bare minimum packages and return.
+    brew install ilmbase openexr clang-format
+    exit 0
+fi
+
 brew update >/dev/null
 echo ""
 echo "Before my brew installs:"

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -21,7 +21,8 @@ option (CLANG_TIDY "Enable clang-tidy" OFF)
 set (CLANG_TIDY_CHECKS "-*" CACHE STRING "clang-tidy checks to perform")
 set (CLANG_TIDY_ARGS "" CACHE STRING "clang-tidy args")
 option (CLANG_TIDY_FIX "Have clang-tidy fix source" OFF)
-set (CLANG_FORMAT_INCLUDES "src/*.h;src/*.cpp" CACHE STRING "Glob patterns to include for clang-format")
+set (CLANG_FORMAT_INCLUDES "" CACHE STRING "Glob patterns to include for clang-format")
+    # Eventually: want this to be: "src/*.h;src/*.cpp"
 set (CLANG_FORMAT_EXCLUDES "src/include/*.h;*pugixml*" CACHE STRING "Glob patterns to exclude for clang-format")
 set (GLIBCXX_USE_CXX11_ABI "" CACHE STRING "For gcc, use the new C++11 library ABI (0|1)")
 


### PR DESCRIPTION
clang-format is a part of the LLVM/Clang compiler suite that will
reformat your code -- but much better than most code reformatters,
because this one is based on a compiler toolkit and is working on the
fully understood AST, not just text.

The idea here is that we give up a little bit of individual creativity
in code formatting, in exchange for every pull request trivially being
able to conform to the house style and never having to go through
multiple rounds of PR edits for formatting issues, nor ever have any
squabbles about it. I know that nobody will be 100% happy with the
require formatting (even me), but I think if we can make everybody 80%
happy and avoid those other problems forever after, it's worth it.
People I respect running othe projects consistently swear that adopting
clang-format was one of the best decisions they made.

Basically, after the initial cmake configuration, you can reformat
files with

    make clang-format

Configuration variables CLANG_FORMAT_INCLUDES and CLANG_FORMAT_EXCLUDES
let you customize the lists of glob patterns that get included, or
excluded, from reformatting. For example, if you only want to reformat
one file (and you should try this to see how the whole thing works!):

    make nuke
    make CLANG_FORMAT_INCLUDES="exrinput.cpp" clang-format

Currently, I'm thinking that public header files will NOT be reformatted
(i.e. the exclude list will default to including src/include).  I just
can't seem to get fully satisfied with the transformations, and I think
that's because I think of public headers as documentation, so I'm
extremely picky about the formatting and think that readability is
paramount, so I make little one-off rule breaks all the time to improve
the flow, readability, and appearance. Of public headers. I think for
everything else, I'm willing to live with a set of rigid rules.

I'm still experimenting with getting the parameters right. I may keep
tinkering a bit before committing any actual reformatting. For that reason,
I'm merely proposing the build script and style configuration portions
now. Only after people have tried it out and we think we can live with
it, will I do the great reformatting checkin.

Also, eventually, we'll make one of the Travis-CI tests do a
clang-format and fail if anything needs to be changed (and print the
diffs), thus making the CI make it very clear when any PR fails to
conform, and we will expect the submitter to run clang-format (or change
the offending parts by hand) and resubmit.

