### PR TITLE
fix oiiotool --info windows_path

### DIFF
--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -703,8 +703,10 @@ print_info_subimage (Oiiotool &ot,
         }
     }
 
-    // Unescape the strings if we're printing for human consumption
-    for (size_t i = 0; i < lines.size(); ++i) {
+    // Unescape the strings if we're printing for human consumption, except for
+    // the first line which corresponds to the filename and on windows might
+    // contain backslashes as path separators.
+    for (size_t i = 1; i < lines.size(); ++i) {
         lines[i] = Strutil::unescape_chars (lines[i]);
     }
 


### PR DESCRIPTION
As mentioned in #2054, windows paths have backslashes which are getting removed by `oiiotool --info`.  This fix solves the filename issue and I verified still works with the maketx "Software" metadata which has backslashed filenames but does not the unescaping to be skipped.

I have not run the testsuite nor made a test.

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

