### PR TITLE
Fix FindOpenEXR.cmake to use version detected by pkg-config, if available

### DIFF
--- a/src/cmake/modules/FindOpenEXR.cmake
+++ b/src/cmake/modules/FindOpenEXR.cmake
@@ -53,7 +53,11 @@ find_path (OPENEXR_INCLUDE_PATH OpenEXR/OpenEXRConfig.h
 find_path (OPENEXR_INCLUDE_PATH OpenEXR/OpenEXRConfig.h)
 
 # Try to figure out version number
-if (EXISTS "${OPENEXR_INCLUDE_PATH}/OpenEXR/ImfMultiPartInputFile.h")
+if (DEFINED _OPENEXR_VERSION AND NOT "${_OPENEXR_VERSION}" STREQUAL "")
+    set (OPENEXR_VERSION "${_OPENEXR_VERSION}")
+    string (REGEX REPLACE "([0-9]+)\\.[0-9]+" "\\1" OPENEXR_VERSION_MAJOR "${_OPENEXR_VERSION}")
+    string (REGEX REPLACE "[0-9]+\\.([0-9]+)" "\\1" OPENEXR_VERSION_MINOR "${_OPENEXR_VERSION}")
+elseif (EXISTS "${OPENEXR_INCLUDE_PATH}/OpenEXR/ImfMultiPartInputFile.h")
     # Must be at least 2.0
     file(STRINGS "${OPENEXR_INCLUDE_PATH}/OpenEXR/OpenEXRConfig.h" TMP REGEX "^#define OPENEXR_VERSION_STRING .*$")
     string (REGEX MATCHALL "[0-9]+[.0-9]+" OPENEXR_VERSION ${TMP})


### PR DESCRIPTION
Detecting the OpenEXR version by parsing a C header can be unreliable.  Since
 we already use pkg-config to detect the presence of the library, we can also
 use the version number it gives us, if available, and only resort to parsing
 the header file if that failed.

See-Also: https://bugs.gentoo.org/668412
Fixes: ec4f679cd7ba175a5470a6198c07ebc6780f4c29

## Description

See commit message.  I suggest to backport this to branch RB-1.8.

## Tests

I applied this patch to release 1.8.16 and successfully compiled a Gentoo package with it.

## Checklist:

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
  - N/A
- [ ] I have updated the documentation, if applicable.
  - N/A
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
  - N/A
- [X] My code follows the prevailing code style of this project.