### PR TITLE
oiiotool expression evaluation enhancements

### DIFF
--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -119,7 +119,7 @@ be {\cf SEMANTICS}.}
   4-byte encoding of an SMPTE timecode. \\
 {\cf KEYCODE} & indicates an {\cf int[7]} representing the standard
   28-byte encoding of an SMPTE keycode. \\
-{\cf RATIONAL} & indicates an {\cf int[2]} representing a rational
+{\cf RATIONAL} & indicates an {\cf VEC2} representing a rational
   number {\cf val[0] / val[1]}. \\
 \end{tabular}
 \medskip

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -32,7 +32,6 @@
 #include <cstdlib>
 #include <sstream>
 
-#include <OpenEXR/ImfTimeCode.h>
 #include <OpenEXR/half.h>
 
 #include <OpenImageIO/dassert.h>
@@ -826,12 +825,8 @@ ImageSpec::metadata_val(const ParamValue& p, bool human)
                     nice += "inf";
             }
         }
-        if (ptype == TypeTimeCode) {
-            Imf::TimeCode tc = *reinterpret_cast<const Imf::TimeCode*>(
-                p.data());
-            nice = Strutil::format("%02d:%02d:%02d:%02d", tc.hours(),
-                                   tc.minutes(), tc.seconds(), tc.frame());
-        }
+        // if (ptype == TypeTimeCode)
+        //     nice = p.get_string(); // convert to "hh:mm:ss:ff"
         if (nice.length())
             out = out + " (" + nice + ")";
     }
@@ -979,12 +974,8 @@ spec_to_xml(const ImageSpec& spec, ImageSpec::SerialVerbose verbose)
                     break;
                 }
             }
-            if (p.type() == TypeTimeCode) {
-                Imf::TimeCode tc = *reinterpret_cast<const Imf::TimeCode*>(
-                    p.data());
-                desc = Strutil::format("%02d:%02d:%02d:%02d", tc.hours(),
-                                       tc.minutes(), tc.seconds(), tc.frame());
-            }
+            if (p.type() == TypeTimeCode)
+                desc = p.get_string();
             xml_node n = add_node(node, "attrib", s.c_str());
             n.append_attribute("name").set_value(p.name().c_str());
             n.append_attribute("type").set_value(p.type().c_str());

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -185,9 +185,10 @@ TypeDesc::c_str() const
     // we don't have to re-assemble strings all the time?
 
     // Timecode and Keycode are hard coded
-    if (basetype == UINT && vecsemantics == TIMECODE && arraylen == 2)
+    static constexpr TypeDesc TypeTimeCodeAlt(UINT, VEC2, TIMECODE);
+    if (*this == TypeTimeCode || *this == TypeTimeCodeAlt)
         return ustring("timecode").c_str();
-    else if (basetype == INT && vecsemantics == KEYCODE && arraylen == 7)
+    else if (*this == TypeKeyCode)
         return ustring("keycode").c_str();
 
     std::string result;
@@ -218,7 +219,7 @@ TypeDesc::c_str() const
         case VECTOR: vec = "vector"; break;
         case NORMAL: vec = "normal"; break;
         case RATIONAL: vec = "rational"; break;
-        default: ASSERT(0 && "Invalid vector semantics");
+        default: DASSERT(0 && "Invalid vector semantics");
         }
         const char* agg = "";
         switch (aggregate) {

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1054,7 +1054,14 @@ Oiiotool::express_parse_atom(const string_view expr, string_view& s, std::string
             result = orig;
             return false;
         }
-        string_view metadata = Strutil::parse_identifier (s, ":", true);
+        string_view metadata;
+        char quote = s.size() ? s.front() : ' ';
+        bool metadata_in_quote = quote == '\"' || quote == '\'';
+        if (metadata_in_quote)
+            Strutil::parse_string (s, metadata);
+        else
+            metadata = Strutil::parse_identifier (s, ":");
+
         if (metadata.size()) {
             read (img);
             ParamValue tmpparam;

--- a/testsuite/dpx/ref/out.txt
+++ b/testsuite/dpx/ref/out.txt
@@ -36,7 +36,7 @@ Reading ../../../../../oiio-images/dpx_nuke_10bits_rgb.dpx
     dpx:XScannedSize: 0
     dpx:YScannedSize: 0
     oiio:BitsPerSample: 10
-    smpte:TimeCode: 0, 0 (00:00:00:00)
+    smpte:TimeCode: 00:00:00:00
 Comparing "../../../../../oiio-images/dpx_nuke_10bits_rgb.dpx" and "dpx_nuke_10bits_rgb.dpx"
 PASS
 Reading ../../../../../oiio-images/dpx_nuke_16bits_rgba.dpx
@@ -77,7 +77,7 @@ Reading ../../../../../oiio-images/dpx_nuke_16bits_rgba.dpx
     dpx:XScannedSize: 0
     dpx:YScannedSize: 0
     oiio:BitsPerSample: 10
-    smpte:TimeCode: 0, 0 (00:00:00:00)
+    smpte:TimeCode: 00:00:00:00
 Comparing "../../../../../oiio-images/dpx_nuke_16bits_rgba.dpx" and "dpx_nuke_16bits_rgba.dpx"
 PASS
 Comparing "src/input_rgb_mattes.tif" and "output_rgb_mattes.dpx"

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -73,6 +73,8 @@ Sequence -5--2:  -5
 Sequence -5--2:  -4
 Sequence -5--2:  -3
 Sequence -5--2:  -2
+xyz should say xyz
+timecode is 01:02:03:04
 Reading black.tif
     oiio:DebugOpenConfig!: 42
 Reading add_rgb_rgba.exr

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -220,6 +220,11 @@ command += oiiotool ("src/tahoe-small.tif --pattern fill:top=0,0,0,0:bottom=0,0,
 command += oiiotool ("src/tahoe-small.tif -cut '{TOP.width-20* 2}x{TOP.height-40+(4*2- 2 ) /6-1}+{TOP.x+100.5-80.5 }+{TOP.y+20}' -d uint8 -o exprcropped.tif")
 command += oiiotool ("src/tahoe-small.tif -o exprstrcat{TOP.compression}.tif")
 command += oiiotool ("src/tahoe-tiny.tif -subc '{TOP.MINCOLOR}' -divc '{TOP.MAXCOLOR}' -o tahoe-contraststretch.tif")
+# test use of quotes inside evaluation, {TOP.foo/bar} would ordinarily want
+# to interpret '/' for division, but we want to look up metadata called
+# 'foo/bar'.
+command += oiiotool ("-create 16x16 3 -attrib \"foo/bar\" \"xyz\" -echo \"{TOP.'foo/bar'} should say xyz\"")
+command += oiiotool ("-create 16x16 3 -attrib smpte:TimeCode \"01:02:03:04\" -echo \"timecode is {TOP.'smpte:TimeCode'}\"")
 
 # test --iconfig
 command += oiiotool ("--info -v -metamatch Debug --iconfig oiio:DebugOpenConfig! 1 black.tif")

--- a/testsuite/rational/ref/out.txt
+++ b/testsuite/rational/ref/out.txt
@@ -63,7 +63,7 @@ src/test.exr         :   64 x   64, 3 channel, half openexr
     timecodeRate: 24
     Exif:ImageHistory: "oiiotool cropped-stripped-Isabella.0.exr -cut 64x64+0+0 -o test.exr"
     oiio:ColorSpace: "Linear"
-    smpte:TimeCode: 18356486, 4294967295 (01:18:19:06)
+    smpte:TimeCode: 01:18:19:06
 Comparing "src/test.exr" and "test.exr"
 PASS
 Reading rat2.exr


### PR DESCRIPTION
1. Allow embedded single or double quotes to group arbitrary text in metadata name. This solves the problem that the default parsing of a metadata name in the expression syntax uses "C identifier" rules. For example, suppose somebody has put a metadata attribute in an exr file named "foo/bar". If you do:

        oiiotool file.exr -echo "{TOP.foo/bar}"

   it will be wrong, thinking that it's looking up TOP.foo ("foo" attribute, which doesn't exist) and dividing by "bar", which isn't a value it knows. Instead, we now allow

       oiiotool file.exr -echo "{TOP.'foo/bar'}"

   It's not pretty, but it allows arbitrary strings to be used as metadata lookups, like "foo/bar" or "foo.bar" or other ill-advised names. (Oh, and for that matter, it was hard to retrieve "foo:bar", which we use all the time, oops. Now it is possible by quoting.)

2. Ensure that retrieved "timecode" values, when retrieved as strings, print as human readable timecodes ("00:00:00:00") not the underlying bit patterns.

The sum of these means that you can set and retrieve timecodes like this:

       oiiotool foo.exr -attrib:type=timecode "smpte:TimeCode" "01:01:01:01" -o out.exr
       oiiotool out.exr -echo "{TOP.'smpte:TimeCode'}"

Fixes #2063

