### PR TITLE
clang-format, final-ish update

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -21,10 +21,7 @@ option (CLANG_TIDY "Enable clang-tidy" OFF)
 set (CLANG_TIDY_CHECKS "-*" CACHE STRING "clang-tidy checks to perform")
 set (CLANG_TIDY_ARGS "" CACHE STRING "clang-tidy args")
 option (CLANG_TIDY_FIX "Have clang-tidy fix source" OFF)
-set (CLANG_FORMAT_INCLUDES "src/include/*.h" "src/libutil/*.cpp"
-                        "src/*.imageio/*.h" "src/*.imageio/*.cpp"
-                        "src/libtexture/*.h" "src/libtexture/*.cpp"
-                        "src/libOpenImageIO/*.h" "src/libOpenImageIO/*.cpp"
+set (CLANG_FORMAT_INCLUDES "src/*.h" "src/*.cpp"
     CACHE STRING "Glob patterns to include for clang-format")
     # Eventually: want this to be: "src/*.h;src/*.cpp"
 set (CLANG_FORMAT_EXCLUDES "*pugixml*" "*SHA1*" "*/farmhash.cpp" "*/tinyformat.h"

--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -29,31 +29,31 @@
 */
 
 
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
-#include <cmath>
 #include <ctime>
 #include <iostream>
 #include <iterator>
 #include <memory>
 
 #include <OpenImageIO/argparse.h>
-#include <OpenImageIO/strutil.h>
-#include <OpenImageIO/imageio.h>
+#include <OpenImageIO/deepdata.h>
+#include <OpenImageIO/filesystem.h>
+#include <OpenImageIO/hash.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
-#include <OpenImageIO/deepdata.h>
-#include <OpenImageIO/hash.h>
-#include <OpenImageIO/filesystem.h>
+#include <OpenImageIO/imageio.h>
+#include <OpenImageIO/strutil.h>
 
 #ifdef USE_BOOST_REGEX
-# include <boost/regex.hpp>
-  using boost::regex;
-  using boost::regex_search;
+#    include <boost/regex.hpp>
+using boost::regex;
+using boost::regex_search;
 #else
-# include <regex>
-  using std::regex;
-  using std::regex_search;
+#    include <regex>
+using std::regex;
+using std::regex_search;
 #endif
 
 using namespace OIIO;
@@ -62,48 +62,48 @@ using namespace ImageBufAlgo;
 
 
 static bool verbose = false;
-static bool sum = false;
-static bool help = false;
+static bool sum     = false;
+static bool help    = false;
 static std::vector<std::string> filenames;
 static std::string metamatch;
 static bool filenameprefix = false;
 static regex field_re;
-static bool subimages = false;
-static bool compute_sha1 = false;
+static bool subimages     = false;
+static bool compute_sha1  = false;
 static bool compute_stats = false;
 
 
 
 static void
-print_sha1 (ImageInput *input)
+print_sha1(ImageInput* input)
 {
     SHA1 sha;
-    const ImageSpec &spec (input->spec());
+    const ImageSpec& spec(input->spec());
     if (spec.deep) {
         // Special handling of deep data
         DeepData dd;
-        if (! input->read_native_deep_image (dd)) {
-            printf ("    SHA-1: unable to compute, could not read image\n");
+        if (!input->read_native_deep_image(dd)) {
+            printf("    SHA-1: unable to compute, could not read image\n");
             return;
         }
         // Hash both the sample counds and the data block
-        sha.append (dd.all_samples());
-        sha.append (dd.all_data());
+        sha.append(dd.all_samples());
+        sha.append(dd.all_data());
     } else {
-        imagesize_t size = input->spec().image_bytes (true /*native*/);
+        imagesize_t size = input->spec().image_bytes(true /*native*/);
         if (size >= std::numeric_limits<size_t>::max()) {
-            printf ("    SHA-1: unable to compute, image is too big\n");
+            printf("    SHA-1: unable to compute, image is too big\n");
             return;
         }
-        std::unique_ptr<char[]> buf (new char [size]);
-        if (! input->read_image (TypeDesc::UNKNOWN /*native*/, &buf[0])) {
-            printf ("    SHA-1: unable to compute, could not read image\n");
+        std::unique_ptr<char[]> buf(new char[size]);
+        if (!input->read_image(TypeDesc::UNKNOWN /*native*/, &buf[0])) {
+            printf("    SHA-1: unable to compute, could not read image\n");
             return;
         }
-        sha.append (&buf[0], size);
+        sha.append(&buf[0], size);
     }
 
-    printf ("    SHA-1: %s\n", sha.digest().c_str());
+    printf("    SHA-1: %s\n", sha.digest().c_str());
 }
 
 
@@ -112,14 +112,14 @@ print_sha1 (ImageInput *input)
 // Stats
 
 static bool
-read_input (const std::string &filename, ImageBuf &img,
-            int subimage=0, int miplevel=0)
+read_input(const std::string& filename, ImageBuf& img, int subimage = 0,
+           int miplevel = 0)
 {
     if (img.subimage() >= 0 && img.subimage() == subimage)
         return true;
 
-    if (img.init_spec (filename, subimage, miplevel) && 
-        img.read (subimage, miplevel, false, TypeDesc::FLOAT))
+    if (img.init_spec(filename, subimage, miplevel)
+        && img.read(subimage, miplevel, false, TypeDesc::FLOAT))
         return true;
 
     std::cerr << "iinfo ERROR: Could not read " << filename << ":\n\t"
@@ -130,17 +130,17 @@ read_input (const std::string &filename, ImageBuf &img,
 
 
 static void
-print_stats_num (float val, int maxval, bool round)
+print_stats_num(float val, int maxval, bool round)
 {
     if (maxval == 0) {
-        printf("%f",val);
+        printf("%f", val);
     } else {
         float fval = val * static_cast<float>(maxval);
         if (round) {
-            int v = static_cast<int>(roundf (fval));
-            printf ("%d", v);
+            int v = static_cast<int>(roundf(fval));
+            printf("%d", v);
         } else {
-            printf ("%0.2f", fval);
+            printf("%0.2f", fval);
         }
     }
 }
@@ -150,124 +150,128 @@ print_stats_num (float val, int maxval, bool round)
 // fall back on the TypeDesc. return 0 for float types
 // or those that exceed the int range (long long, etc)
 static unsigned long long
-get_intsample_maxval (const ImageSpec &spec)
+get_intsample_maxval(const ImageSpec& spec)
 {
     TypeDesc type = spec.format;
-    int bits = spec.get_int_attribute ("oiio:BitsPerSample");
+    int bits      = spec.get_int_attribute("oiio:BitsPerSample");
     if (bits > 0) {
-        if (type.basetype == TypeDesc::UINT8 ||
-              type.basetype == TypeDesc::UINT16 ||
-              type.basetype == TypeDesc::UINT32)
+        if (type.basetype == TypeDesc::UINT8
+            || type.basetype == TypeDesc::UINT16
+            || type.basetype == TypeDesc::UINT32)
             return ((1LL) << bits) - 1;
-        if (type.basetype == TypeDesc::INT8 ||
-              type.basetype == TypeDesc::INT16 ||
-              type.basetype == TypeDesc::INT32)
-            return ((1LL) << (bits-1)) - 1;
+        if (type.basetype == TypeDesc::INT8 || type.basetype == TypeDesc::INT16
+            || type.basetype == TypeDesc::INT32)
+            return ((1LL) << (bits - 1)) - 1;
     }
-    
+
     // These correspond to all the int enums in typedesc.h <= int
-    if (type.basetype == TypeDesc::UCHAR)        return 0xff;
-    if (type.basetype == TypeDesc::CHAR)         return 0x7f;
-    if (type.basetype == TypeDesc::USHORT)     return 0xffff;
-    if (type.basetype == TypeDesc::SHORT)      return 0x7fff;
-    if (type.basetype == TypeDesc::UINT)   return 0xffffffff;
-    if (type.basetype == TypeDesc::INT)    return 0x7fffffff;
-    
+    if (type.basetype == TypeDesc::UCHAR)
+        return 0xff;
+    if (type.basetype == TypeDesc::CHAR)
+        return 0x7f;
+    if (type.basetype == TypeDesc::USHORT)
+        return 0xffff;
+    if (type.basetype == TypeDesc::SHORT)
+        return 0x7fff;
+    if (type.basetype == TypeDesc::UINT)
+        return 0xffffffff;
+    if (type.basetype == TypeDesc::INT)
+        return 0x7fffffff;
+
     return 0;
 }
 
 
 static void
-print_stats_footer (unsigned int maxval)
+print_stats_footer(unsigned int maxval)
 {
-    if (maxval==0)
-        printf ("(float)");
+    if (maxval == 0)
+        printf("(float)");
     else
-        printf ("(of %u)", maxval);
+        printf("(of %u)", maxval);
 }
 
 
 static void
-print_stats (const std::string &filename,
-             const ImageSpec &originalspec,
-             int subimage=0, int miplevel=0, bool indentmip=false)
+print_stats(const std::string& filename, const ImageSpec& originalspec,
+            int subimage = 0, int miplevel = 0, bool indentmip = false)
 {
     PixelStats stats;
-    const char *indent = indentmip ? "      " : "    ";
+    const char* indent = indentmip ? "      " : "    ";
 
     ImageBuf input;
-    if (! read_input (filename, input, subimage, miplevel)) {
+    if (!read_input(filename, input, subimage, miplevel)) {
         std::cerr << "Stats: read error: " << input.geterror() << "\n";
         return;
     }
-    
-    if (! computePixelStats (stats, input)) {
-        printf ("%sStats: (unable to compute)\n", indent);
+
+    if (!computePixelStats(stats, input)) {
+        printf("%sStats: (unable to compute)\n", indent);
         if (input.has_error())
             std::cerr << "Error: " << input.geterror() << "\n";
         return;
     }
-    
+
     // The original spec is used, otherwise the bit depth will
     // be reported incorrectly (as FLOAT)
-    unsigned int maxval = (unsigned int)get_intsample_maxval (originalspec);
-    
-    printf ("%sStats Min: ", indent);
-    for (unsigned int i=0; i<stats.min.size(); ++i) {
-        print_stats_num (stats.min[i], maxval, true);
-        printf (" ");
+    unsigned int maxval = (unsigned int)get_intsample_maxval(originalspec);
+
+    printf("%sStats Min: ", indent);
+    for (unsigned int i = 0; i < stats.min.size(); ++i) {
+        print_stats_num(stats.min[i], maxval, true);
+        printf(" ");
     }
-    print_stats_footer (maxval);
-    printf ("\n");
-    
-    printf ("%sStats Max: ", indent);
-    for (unsigned int i=0; i<stats.max.size(); ++i) {
-        print_stats_num (stats.max[i], maxval, true);
-        printf (" ");
+    print_stats_footer(maxval);
+    printf("\n");
+
+    printf("%sStats Max: ", indent);
+    for (unsigned int i = 0; i < stats.max.size(); ++i) {
+        print_stats_num(stats.max[i], maxval, true);
+        printf(" ");
     }
-    print_stats_footer (maxval);
-    printf ("\n");
-    
-    printf ("%sStats Avg: ", indent);
-    for (unsigned int i=0; i<stats.avg.size(); ++i) {
-        print_stats_num (stats.avg[i], maxval, false);
-        printf (" ");
+    print_stats_footer(maxval);
+    printf("\n");
+
+    printf("%sStats Avg: ", indent);
+    for (unsigned int i = 0; i < stats.avg.size(); ++i) {
+        print_stats_num(stats.avg[i], maxval, false);
+        printf(" ");
     }
-    print_stats_footer (maxval);
-    printf ("\n");
-    
-    printf ("%sStats StdDev: ", indent);
-    for (unsigned int i=0; i<stats.stddev.size(); ++i) {
-        print_stats_num (stats.stddev[i], maxval, false);
-        printf (" ");
+    print_stats_footer(maxval);
+    printf("\n");
+
+    printf("%sStats StdDev: ", indent);
+    for (unsigned int i = 0; i < stats.stddev.size(); ++i) {
+        print_stats_num(stats.stddev[i], maxval, false);
+        printf(" ");
     }
-    print_stats_footer (maxval);
-    printf ("\n");
-    
-    printf ("%sStats NanCount: ", indent);
-    for (unsigned int i=0; i<stats.nancount.size(); ++i) {
-        printf ("%llu ", (unsigned long long)stats.nancount[i]);
+    print_stats_footer(maxval);
+    printf("\n");
+
+    printf("%sStats NanCount: ", indent);
+    for (unsigned int i = 0; i < stats.nancount.size(); ++i) {
+        printf("%llu ", (unsigned long long)stats.nancount[i]);
     }
-    printf ("\n");
-    
-    printf ("%sStats InfCount: ", indent);
-    for (unsigned int i=0; i<stats.infcount.size(); ++i) {
-        printf ("%llu ", (unsigned long long)stats.infcount[i]);
+    printf("\n");
+
+    printf("%sStats InfCount: ", indent);
+    for (unsigned int i = 0; i < stats.infcount.size(); ++i) {
+        printf("%llu ", (unsigned long long)stats.infcount[i]);
     }
-    printf ("\n");
-    
-    printf ("%sStats FiniteCount: ", indent);
-    for (unsigned int i=0; i<stats.finitecount.size(); ++i) {
-        printf ("%llu ", (unsigned long long)stats.finitecount[i]);
+    printf("\n");
+
+    printf("%sStats FiniteCount: ", indent);
+    for (unsigned int i = 0; i < stats.finitecount.size(); ++i) {
+        printf("%llu ", (unsigned long long)stats.finitecount[i]);
     }
-    printf ("\n");
+    printf("\n");
 
     if (input.deep()) {
-        const DeepData *dd (input.deepdata());
-        size_t npixels = dd->pixels();
+        const DeepData* dd(input.deepdata());
+        size_t npixels      = dd->pixels();
         size_t totalsamples = 0, emptypixels = 0;
         size_t maxsamples = 0, minsamples = std::numeric_limits<size_t>::max();
-        for (size_t p = 0;  p < npixels;  ++p) {
+        for (size_t p = 0; p < npixels; ++p) {
             size_t c = dd->samples(p);
             totalsamples += c;
             if (c > maxsamples)
@@ -277,32 +281,37 @@ print_stats (const std::string &filename,
             if (c == 0)
                 ++emptypixels;
         }
-        printf ("%sMin deep samples in any pixel : %llu\n", indent, (unsigned long long)minsamples);
-        printf ("%sMax deep samples in any pixel : %llu\n", indent, (unsigned long long)maxsamples);
-        printf ("%sAverage deep samples per pixel: %.2f\n", indent, double(totalsamples)/double(npixels));
-        printf ("%sTotal deep samples in all pixels: %llu\n", indent, (unsigned long long)totalsamples);
-        printf ("%sPixels with deep samples   : %llu\n", indent, (unsigned long long)(npixels-emptypixels));
-        printf ("%sPixels with no deep samples: %llu\n", indent, (unsigned long long)emptypixels);
+        printf("%sMin deep samples in any pixel : %llu\n", indent,
+               (unsigned long long)minsamples);
+        printf("%sMax deep samples in any pixel : %llu\n", indent,
+               (unsigned long long)maxsamples);
+        printf("%sAverage deep samples per pixel: %.2f\n", indent,
+               double(totalsamples) / double(npixels));
+        printf("%sTotal deep samples in all pixels: %llu\n", indent,
+               (unsigned long long)totalsamples);
+        printf("%sPixels with deep samples   : %llu\n", indent,
+               (unsigned long long)(npixels - emptypixels));
+        printf("%sPixels with no deep samples: %llu\n", indent,
+               (unsigned long long)emptypixels);
     } else {
         std::vector<float> constantValues(input.spec().nchannels);
         if (isConstantColor(input, &constantValues[0])) {
-            printf ("%sConstant: Yes\n", indent);
-            printf ("%sConstant Color: ", indent);
-            for (unsigned int i=0; i<constantValues.size(); ++i) {
-                print_stats_num (constantValues[i], maxval, false);
-                printf (" ");
+            printf("%sConstant: Yes\n", indent);
+            printf("%sConstant Color: ", indent);
+            for (unsigned int i = 0; i < constantValues.size(); ++i) {
+                print_stats_num(constantValues[i], maxval, false);
+                printf(" ");
             }
-            print_stats_footer (maxval);
-            printf ("\n");
-        }
-        else {
-            printf ("%sConstant: No\n", indent);
-        }
-    
-        if (isMonochrome(input)) {
-            printf ("%sMonochrome: Yes\n", indent);
+            print_stats_footer(maxval);
+            printf("\n");
         } else {
-            printf ("%sMonochrome: No\n", indent);
+            printf("%sConstant: No\n", indent);
+        }
+
+        if (isMonochrome(input)) {
+            printf("%sMonochrome: Yes\n", indent);
+        } else {
+            printf("%sMonochrome: No\n", indent);
         }
     }
 }
@@ -310,77 +319,71 @@ print_stats (const std::string &filename,
 
 
 static void
-print_metadata (const ImageSpec &spec, const std::string &filename)
+print_metadata(const ImageSpec& spec, const std::string& filename)
 {
     bool printed = false;
-    if (metamatch.empty() ||
-          regex_search ("channels", field_re) ||
-          regex_search ("channel list", field_re)) {
+    if (metamatch.empty() || regex_search("channels", field_re)
+        || regex_search("channel list", field_re)) {
         if (filenameprefix)
-            printf ("%s : ", filename.c_str());
-        printf ("    channel list: ");
-        for (int i = 0;  i < spec.nchannels;  ++i) {
+            printf("%s : ", filename.c_str());
+        printf("    channel list: ");
+        for (int i = 0; i < spec.nchannels; ++i) {
             if (i < (int)spec.channelnames.size())
-                printf ("%s", spec.channelnames[i].c_str());
+                printf("%s", spec.channelnames[i].c_str());
             else
-                printf ("unknown");
+                printf("unknown");
             if (i < (int)spec.channelformats.size())
-                printf (" (%s)", spec.channelformats[i].c_str());
-            if (i < spec.nchannels-1)
-                printf (", ");
+                printf(" (%s)", spec.channelformats[i].c_str());
+            if (i < spec.nchannels - 1)
+                printf(", ");
         }
-        printf ("\n");
+        printf("\n");
         printed = true;
     }
     if (spec.x || spec.y || spec.z) {
-        if (metamatch.empty() ||
-            regex_search ("pixel data origin", field_re)) {
+        if (metamatch.empty() || regex_search("pixel data origin", field_re)) {
             if (filenameprefix)
-                printf ("%s : ", filename.c_str());
-            printf ("    pixel data origin: x=%d, y=%d", spec.x, spec.y);
+                printf("%s : ", filename.c_str());
+            printf("    pixel data origin: x=%d, y=%d", spec.x, spec.y);
             if (spec.depth > 1)
-                printf (", z=%d", spec.z);
-            printf ("\n");
+                printf(", z=%d", spec.z);
+            printf("\n");
             printed = true;
         }
     }
-    if (spec.full_x || spec.full_y || spec.full_z ||
-          (spec.full_width != spec.width && spec.full_width != 0) || 
-          (spec.full_height != spec.height && spec.full_height != 0) ||
-          (spec.full_depth != spec.depth && spec.full_depth != 0)) {
-        if (metamatch.empty() ||
-              regex_search ("full/display size", field_re)) {
+    if (spec.full_x || spec.full_y || spec.full_z
+        || (spec.full_width != spec.width && spec.full_width != 0)
+        || (spec.full_height != spec.height && spec.full_height != 0)
+        || (spec.full_depth != spec.depth && spec.full_depth != 0)) {
+        if (metamatch.empty() || regex_search("full/display size", field_re)) {
             if (filenameprefix)
-                printf ("%s : ", filename.c_str());
-            printf ("    full/display size: %d x %d",
-                    spec.full_width, spec.full_height);
+                printf("%s : ", filename.c_str());
+            printf("    full/display size: %d x %d", spec.full_width,
+                   spec.full_height);
             if (spec.depth > 1)
-                printf (" x %d", spec.full_depth);
-            printf ("\n");
+                printf(" x %d", spec.full_depth);
+            printf("\n");
             printed = true;
         }
-        if (metamatch.empty() ||
-            regex_search ("full/display origin", field_re)) {
+        if (metamatch.empty()
+            || regex_search("full/display origin", field_re)) {
             if (filenameprefix)
-                printf ("%s : ", filename.c_str());
-            printf ("    full/display origin: %d, %d",
-                    spec.full_x, spec.full_y);
+                printf("%s : ", filename.c_str());
+            printf("    full/display origin: %d, %d", spec.full_x, spec.full_y);
             if (spec.depth > 1)
-                printf (", %d", spec.full_z);
-            printf ("\n");
+                printf(", %d", spec.full_z);
+            printf("\n");
             printed = true;
         }
     }
     if (spec.tile_width) {
-        if (metamatch.empty() ||
-            regex_search ("tile", field_re)) {
+        if (metamatch.empty() || regex_search("tile", field_re)) {
             if (filenameprefix)
-                printf ("%s : ", filename.c_str());
-            printf ("    tile size: %d x %d",
-                    spec.tile_width, spec.tile_height);
+                printf("%s : ", filename.c_str());
+            printf("    tile size: %d x %d", spec.tile_width, spec.tile_height);
             if (spec.depth > 1)
-                printf (" x %d", spec.tile_depth);
-            printf ("\n");
+                printf(" x %d", spec.tile_depth);
+            printf("\n");
             printed = true;
         }
     }
@@ -389,43 +392,42 @@ print_metadata (const ImageSpec &spec, const std::string &filename)
     // sure that all non-namespaced attribs appear before namespaced
     // attribs.
     ParamValueList attribs = spec.extra_attribs;
-    attribs.sort (false /* sort case-insensitively */);
+    attribs.sort(false /* sort case-insensitively */);
     for (auto&& p : attribs) {
-        if (! metamatch.empty() &&
-            ! regex_search (p.name().c_str(), field_re))
+        if (!metamatch.empty() && !regex_search(p.name().c_str(), field_re))
             continue;
-        std::string s = spec.metadata_val (p, true);
+        std::string s = spec.metadata_val(p, true);
         if (filenameprefix)
-            printf ("%s : ", filename.c_str());
-        printf ("    %s: ", p.name().c_str());
-        if (! strcmp (s.c_str(), "1.#INF"))
-            printf ("inf");
+            printf("%s : ", filename.c_str());
+        printf("    %s: ", p.name().c_str());
+        if (!strcmp(s.c_str(), "1.#INF"))
+            printf("inf");
         else
-            printf ("%s", s.c_str());
-        printf ("\n");
+            printf("%s", s.c_str());
+        printf("\n");
         printed = true;
     }
 
-    if (! printed && !metamatch.empty()) {
+    if (!printed && !metamatch.empty()) {
         if (filenameprefix)
-            printf ("%s : ", filename.c_str());
-        printf ("    %s: <unknown>\n", metamatch.c_str());
+            printf("%s : ", filename.c_str());
+        printf("    %s: <unknown>\n", metamatch.c_str());
     }
 }
 
 
 
-static const char *
-extended_format_name (TypeDesc type, int bits)
+static const char*
+extended_format_name(TypeDesc type, int bits)
 {
-    if (bits && bits < (int)type.size()*8) {
+    if (bits && bits < (int)type.size() * 8) {
         // The "oiio:BitsPerSample" betrays a different bit depth in the
         // file than the data type we are passing.
-        if (type == TypeDesc::UINT8 || type == TypeDesc::UINT16 ||
-            type == TypeDesc::UINT32 || type == TypeDesc::UINT64)
+        if (type == TypeDesc::UINT8 || type == TypeDesc::UINT16
+            || type == TypeDesc::UINT32 || type == TypeDesc::UINT64)
             return ustring::format("uint%d", bits).c_str();
-        if (type == TypeDesc::INT8 || type == TypeDesc::INT16 ||
-            type == TypeDesc::INT32 || type == TypeDesc::INT64)
+        if (type == TypeDesc::INT8 || type == TypeDesc::INT16
+            || type == TypeDesc::INT32 || type == TypeDesc::INT64)
             return ustring::format("int%d", bits).c_str();
     }
     return type.c_str();  // use the name implied by type
@@ -433,11 +435,11 @@ extended_format_name (TypeDesc type, int bits)
 
 
 
-static const char *
-brief_format_name (TypeDesc type, int bits=0)
+static const char*
+brief_format_name(TypeDesc type, int bits = 0)
 {
-    if (! bits)
-        bits = (int)type.size()*8;
+    if (!bits)
+        bits = (int)type.size() * 8;
     if (type.is_floating_point()) {
         if (type.basetype == TypeDesc::FLOAT)
             return "f";
@@ -457,187 +459,190 @@ brief_format_name (TypeDesc type, int bits=0)
 // prints basic info (resolution, width, height, depth, channels, data format,
 // and format name) about given subimage.
 static void
-print_info_subimage (int current_subimage, int max_subimages, ImageSpec &spec,
-                     ImageInput *input, const std::string &filename)
+print_info_subimage(int current_subimage, int max_subimages, ImageSpec& spec,
+                    ImageInput* input, const std::string& filename)
 {
-    if ( ! input->seek_subimage (current_subimage, 0, spec) )
+    if (!input->seek_subimage(current_subimage, 0, spec))
         return;
 
-    if (! metamatch.empty() &&
-        ! regex_search ("resolution, width, height, depth, channels, sha-1, stats", field_re)) {
+    if (!metamatch.empty()
+        && !regex_search(
+            "resolution, width, height, depth, channels, sha-1, stats",
+            field_re)) {
         // nothing to do here
         return;
     }
 
     int nmip = 1;
 
-    bool printres = verbose && (metamatch.empty() ||
-                                regex_search ("resolution, width, height, depth, channels", field_re));
+    bool printres
+        = verbose
+          && (metamatch.empty()
+              || regex_search("resolution, width, height, depth, channels",
+                              field_re));
     if (printres && max_subimages > 1 && subimages) {
-        printf (" subimage %2d: ", current_subimage);
-        printf ("%4d x %4d", spec.width, spec.height);
+        printf(" subimage %2d: ", current_subimage);
+        printf("%4d x %4d", spec.width, spec.height);
         if (spec.depth > 1)
-            printf (" x %4d", spec.depth);
-        int bits = spec.get_int_attribute ("oiio:BitsPerSample", 0);
-        printf (", %d channel, %s%s%s", spec.nchannels,
-                spec.deep ? "deep " : "",
-                spec.depth > 1 ? "volume " : "",
-                extended_format_name(spec.format, bits));
-        printf (" %s", input->format_name());
-        printf ("\n");
+            printf(" x %4d", spec.depth);
+        int bits = spec.get_int_attribute("oiio:BitsPerSample", 0);
+        printf(", %d channel, %s%s%s", spec.nchannels, spec.deep ? "deep " : "",
+               spec.depth > 1 ? "volume " : "",
+               extended_format_name(spec.format, bits));
+        printf(" %s", input->format_name());
+        printf("\n");
     }
     // Count MIP levels
     ImageSpec mipspec;
-    while (input->seek_subimage (current_subimage, nmip, mipspec)) {
+    while (input->seek_subimage(current_subimage, nmip, mipspec)) {
         if (printres) {
             if (nmip == 1)
-                printf ("    MIP-map levels: %dx%d", spec.width, spec.height);
-            printf (" %dx%d", mipspec.width, mipspec.height);
+                printf("    MIP-map levels: %dx%d", spec.width, spec.height);
+            printf(" %dx%d", mipspec.width, mipspec.height);
         }
         ++nmip;
     }
     if (printres && nmip > 1)
-        printf ("\n");
+        printf("\n");
 
-    if (compute_sha1 && (metamatch.empty() ||
-                         regex_search ("sha-1", field_re))) {
+    if (compute_sha1
+        && (metamatch.empty() || regex_search("sha-1", field_re))) {
         if (filenameprefix)
-            printf ("%s : ", filename.c_str());
+            printf("%s : ", filename.c_str());
         // Before sha-1, be sure to point back to the highest-res MIP level
         ImageSpec tmpspec;
-        input->seek_subimage (current_subimage, 0, tmpspec);
-        print_sha1 (input);
+        input->seek_subimage(current_subimage, 0, tmpspec);
+        print_sha1(input);
     }
 
     if (verbose)
-        print_metadata (spec, filename);
+        print_metadata(spec, filename);
 
-    if (compute_stats && (metamatch.empty() ||
-                          regex_search ("stats", field_re))) {
-        for (int m = 0;  m < nmip;  ++m) {
+    if (compute_stats
+        && (metamatch.empty() || regex_search("stats", field_re))) {
+        for (int m = 0; m < nmip; ++m) {
             ImageSpec mipspec;
-            input->seek_subimage (current_subimage, m, mipspec);
+            input->seek_subimage(current_subimage, m, mipspec);
             if (filenameprefix)
-                printf ("%s : ", filename.c_str());
+                printf("%s : ", filename.c_str());
             if (nmip > 1 && (subimages || m == 0)) {
-                printf ("    MIP %d of %d (%d x %d):\n",
-                        m, nmip, mipspec.width, mipspec.height);
+                printf("    MIP %d of %d (%d x %d):\n", m, nmip, mipspec.width,
+                       mipspec.height);
             }
-            print_stats (filename, spec, current_subimage, m, nmip>1);
+            print_stats(filename, spec, current_subimage, m, nmip > 1);
         }
     }
 
-    if ( ! input->seek_subimage (current_subimage, 0, spec) )
+    if (!input->seek_subimage(current_subimage, 0, spec))
         return;
 }
 
 
 
 static void
-print_info (const std::string &filename, size_t namefieldlength, 
-            ImageInput *input, ImageSpec &spec,
-            bool verbose, bool sum, long long &totalsize)
+print_info(const std::string& filename, size_t namefieldlength,
+           ImageInput* input, ImageSpec& spec, bool verbose, bool sum,
+           long long& totalsize)
 {
-    int padlen = std::max (0, (int)namefieldlength - (int)filename.length());
-    std::string padding (padlen, ' ');
+    int padlen = std::max(0, (int)namefieldlength - (int)filename.length());
+    std::string padding(padlen, ' ');
 
     // checking how many subimages and mipmap levels are stored in the file
     int num_of_subimages = 1;
-    bool any_mipmapping = false;
+    bool any_mipmapping  = false;
     std::vector<int> num_of_miplevels;
     {
         int nmip = 1;
-        while (input->seek_subimage (input->current_subimage(), nmip, spec)) {
+        while (input->seek_subimage(input->current_subimage(), nmip, spec)) {
             ++nmip;
             any_mipmapping = true;
         }
-        num_of_miplevels.push_back (nmip);
+        num_of_miplevels.push_back(nmip);
     }
-    while (input->seek_subimage (num_of_subimages, 0, spec)) {
+    while (input->seek_subimage(num_of_subimages, 0, spec)) {
         // maybe we should do this more gently?
         ++num_of_subimages;
         int nmip = 1;
-        while (input->seek_subimage (input->current_subimage(), nmip, spec)) {
+        while (input->seek_subimage(input->current_subimage(), nmip, spec)) {
             ++nmip;
             any_mipmapping = true;
         }
-        num_of_miplevels.push_back (nmip);
+        num_of_miplevels.push_back(nmip);
     }
-    input->seek_subimage (0, 0, spec);  // re-seek to the first
+    input->seek_subimage(0, 0, spec);  // re-seek to the first
 
-    if (metamatch.empty() ||
-        regex_search ("resolution, width, height, depth, channels", field_re)) {
-        printf ("%s%s : %4d x %4d", filename.c_str(), padding.c_str(),
-                spec.width, spec.height);
+    if (metamatch.empty()
+        || regex_search("resolution, width, height, depth, channels",
+                        field_re)) {
+        printf("%s%s : %4d x %4d", filename.c_str(), padding.c_str(),
+               spec.width, spec.height);
         if (spec.depth > 1)
-            printf (" x %4d", spec.depth);
-        printf (", %d channel, %s%s", spec.nchannels,
-                spec.deep ? "deep " : "",
-                spec.depth > 1 ? "volume " : "");
+            printf(" x %4d", spec.depth);
+        printf(", %d channel, %s%s", spec.nchannels, spec.deep ? "deep " : "",
+               spec.depth > 1 ? "volume " : "");
         if (spec.channelformats.size()) {
-            for (size_t c = 0;  c < spec.channelformats.size();  ++c)
-                printf ("%s%s", c ? "/" : "",
-                        spec.channelformats[c].c_str());
+            for (size_t c = 0; c < spec.channelformats.size(); ++c)
+                printf("%s%s", c ? "/" : "", spec.channelformats[c].c_str());
         } else {
-            int bits = spec.get_int_attribute ("oiio:BitsPerSample", 0);
-            printf ("%s", extended_format_name(spec.format, bits));
+            int bits = spec.get_int_attribute("oiio:BitsPerSample", 0);
+            printf("%s", extended_format_name(spec.format, bits));
         }
-        printf (" %s", input->format_name());
+        printf(" %s", input->format_name());
         if (sum) {
-            imagesize_t imagebytes = spec.image_bytes (true);
+            imagesize_t imagebytes = spec.image_bytes(true);
             totalsize += imagebytes;
-            printf (" (%.2f MB)", (float)imagebytes / (1024.0*1024.0));
+            printf(" (%.2f MB)", (float)imagebytes / (1024.0 * 1024.0));
         }
         // we print info about how many subimages are stored in file
         // only when we have more then one subimage
-        if ( ! verbose && num_of_subimages != 1)
-            printf (" (%d subimages%s)", num_of_subimages,
-                    any_mipmapping ? " +mipmap)" : "");
-        if (! verbose && num_of_subimages == 1 && any_mipmapping)
-            printf (" (+mipmap)");
-        printf ("\n");
+        if (!verbose && num_of_subimages != 1)
+            printf(" (%d subimages%s)", num_of_subimages,
+                   any_mipmapping ? " +mipmap)" : "");
+        if (!verbose && num_of_subimages == 1 && any_mipmapping)
+            printf(" (+mipmap)");
+        printf("\n");
     }
 
-    int movie = spec.get_int_attribute ("oiio:Movie");
+    int movie = spec.get_int_attribute("oiio:Movie");
     if (verbose && num_of_subimages != 1) {
         // info about num of subimages and their resolutions
-        printf ("    %d subimages: ", num_of_subimages);
+        printf("    %d subimages: ", num_of_subimages);
         for (int i = 0; i < num_of_subimages; ++i) {
-            input->seek_subimage (i, 0, spec);
-            int bits = spec.get_int_attribute ("oiio:BitsPerSample",
-                                               spec.format.size()*8);
+            input->seek_subimage(i, 0, spec);
+            int bits = spec.get_int_attribute("oiio:BitsPerSample",
+                                              spec.format.size() * 8);
             if (i)
-                printf (", ");
+                printf(", ");
             if (spec.depth > 1)
-                printf ("%dx%dx%d ", spec.width, spec.height, spec.depth);
+                printf("%dx%dx%d ", spec.width, spec.height, spec.depth);
             else
-                printf ("%dx%d ", spec.width, spec.height);
+                printf("%dx%d ", spec.width, spec.height);
             // printf ("[");
             for (int c = 0; c < spec.nchannels; ++c)
-                printf ("%c%s", c ? ',' : '[',
-                        brief_format_name(spec.channelformat(c), bits));
-            printf ("]");
+                printf("%c%s", c ? ',' : '[',
+                       brief_format_name(spec.channelformat(c), bits));
+            printf("]");
             if (movie)
                 break;
         }
-        printf ("\n");
+        printf("\n");
     }
 
     // if the '-a' flag is not set we print info
     // about first subimage only
-    if ( ! subimages)
+    if (!subimages)
         num_of_subimages = 1;
     for (int i = 0; i < num_of_subimages; ++i) {
-        print_info_subimage (i, num_of_subimages, spec, input, filename);
+        print_info_subimage(i, num_of_subimages, spec, input, filename);
     }
 }
 
 
 
 static int
-parse_files (int argc, const char *argv[])
+parse_files(int argc, const char* argv[])
 {
-    for (int i = 0;  i < argc;  i++)
+    for (int i = 0; i < argc; i++)
         filenames.emplace_back(argv[i]);
     return 0;
 }
@@ -645,10 +650,11 @@ parse_files (int argc, const char *argv[])
 
 
 int
-main (int argc, const char *argv[])
+main(int argc, const char* argv[])
 {
-    Filesystem::convert_native_arguments (argc, (const char **)argv);
+    Filesystem::convert_native_arguments(argc, (const char**)argv);
     ArgParse ap;
+    // clang-format off
     ap.options ("iinfo -- print information about images\n"
                 OIIO_INTRO_STRING "\n"
                 "Usage:  iinfo [options] filename...",
@@ -662,52 +668,53 @@ main (int argc, const char *argv[])
                 "--hash", &compute_sha1, "Print SHA-1 hash of pixel values",
                 "--stats", &compute_stats, "Print image pixel statistics (data window)",
                 NULL);
+    // clang-format on
     if (ap.parse(argc, argv) < 0 || filenames.empty()) {
         std::cerr << ap.geterror() << std::endl;
-        ap.usage ();
+        ap.usage();
         return EXIT_FAILURE;
     }
     if (help) {
-        ap.usage ();
-        exit (EXIT_FAILURE);
+        ap.usage();
+        exit(EXIT_FAILURE);
     }
 
-    if (! metamatch.empty()) {
+    if (!metamatch.empty()) {
 #if USE_BOOST_REGEX
-        field_re.assign (metamatch,
-                     boost::regex::extended | boost::regex_constants::icase);
+        field_re.assign(metamatch,
+                        boost::regex::extended | boost::regex_constants::icase);
 #else
-        field_re.assign (metamatch,
-                     std::regex_constants::extended | std::regex_constants::icase);
+        field_re.assign(metamatch, std::regex_constants::extended
+                                       | std::regex_constants::icase);
 #endif
     }
 
     // Find the longest filename
     size_t longestname = 0;
     for (auto&& s : filenames)
-        longestname = std::max (longestname, s.length());
-    longestname = std::min (longestname, (size_t)40);
+        longestname = std::max(longestname, s.length());
+    longestname = std::min(longestname, (size_t)40);
 
     long long totalsize = 0;
     for (auto&& s : filenames) {
-        auto in = ImageInput::open (s);
-        if (! in) {
+        auto in = ImageInput::open(s);
+        if (!in) {
             std::string err = geterror();
             if (err.empty())
-                err = Strutil::format ("Could not open \"%s\"", s);
+                err = Strutil::format("Could not open \"%s\"", s);
             std::cerr << "iinfo ERROR: " << err << "\n";
             continue;
         }
         ImageSpec spec = in->spec();
-        print_info (s, longestname, in.get(), spec, verbose, sum, totalsize);
+        print_info(s, longestname, in.get(), spec, verbose, sum, totalsize);
     }
 
     if (sum) {
-        double t = (double)totalsize / (1024.0*1024.0);
+        double t = (double)totalsize / (1024.0 * 1024.0);
         if (t > 1024.0)
-            printf ("Total size: %.2f GB\n", t/1024.0);
+            printf("Total size: %.2f GB\n", t / 1024.0);
         else
-            printf ("Total size: %.2f MB\n", t);
+            printf("Total size: %.2f MB\n", t);
     }
 
     return 0;

--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -32,13 +32,13 @@
 #ifndef OPENIMAGEIO_IMAGEVIEWER_H
 #define OPENIMAGEIO_IMAGEVIEWER_H
 
-#if defined (_MSC_VER)
+#if defined(_MSC_VER)
 // Ignore warnings about conditional expressions that always evaluate true
 // on a given platform but may evaluate differently on another. There's
 // nothing wrong with such conditionals.
 // Also ignore warnings about not being able to generate default assignment
 // operators for some Qt classes included in headers below.
-#  pragma warning (disable : 4127 4512)
+#    pragma warning(disable : 4127 4512)
 #endif
 
 // included to remove std::min/std::max errors
@@ -46,18 +46,18 @@
 
 #include <vector>
 
-#include <QGLWidget>
 #include <QAction>
 #include <QCheckBox>
 #include <QDialog>
+#include <QGLWidget>
 #include <QMainWindow>
 
 #ifndef QT_NO_PRINTER
 // #include <QPrinter>
 #endif
 
-#include <OpenImageIO/imageio.h>
 #include <OpenImageIO/imagebuf.h>
+#include <OpenImageIO/imageio.h>
 
 using namespace OIIO;
 
@@ -81,8 +81,8 @@ class IvImage;
 
 class IvImage : public ImageBuf {
 public:
-    IvImage (const std::string &filename);
-    virtual ~IvImage ();
+    IvImage(const std::string& filename);
+    virtual ~IvImage();
 
     /// Read the image into ram.
     /// If secondary buffer is true, and the format is UINT8, then a secondary
@@ -90,33 +90,34 @@ public:
     /// select_channel() methods will work.
     /// Also, scanline will return a pointer to that buffer instead of the read
     /// buffer.
-    bool read_iv (int subimage=0, int miplevel=0,
-                  bool force=false, TypeDesc format = TypeDesc::UNKNOWN,
-                  ProgressCallback progress_callback=NULL,
-                  void *progress_callback_data=NULL, bool secondary_buffer=false);
-    bool init_spec_iv (const std::string &filename,
-                       int subimage, int miplevel);
+    bool read_iv(int subimage = 0, int miplevel = 0, bool force = false,
+                 TypeDesc format                    = TypeDesc::UNKNOWN,
+                 ProgressCallback progress_callback = NULL,
+                 void* progress_callback_data       = NULL,
+                 bool secondary_buffer              = false);
+    bool init_spec_iv(const std::string& filename, int subimage, int miplevel);
 
-    float gamma (void) const { return m_gamma; }
-    void gamma (float e) { m_gamma = e; }
-    float exposure (void) const { return m_exposure; }
-    void exposure (float e) { m_exposure = e; }
+    float gamma(void) const { return m_gamma; }
+    void gamma(float e) { m_gamma = e; }
+    float exposure(void) const { return m_exposure; }
+    void exposure(float e) { m_exposure = e; }
 
-    int nchannels () const {
+    int nchannels() const
+    {
         if (m_corrected_image.localpixels()) {
             return m_corrected_image.nchannels();
         }
         return spec().nchannels;
     }
 
-    std::string shortinfo () const;
-    std::string longinfo () const;
+    std::string shortinfo() const;
+    std::string longinfo() const;
 
-    void invalidate ();
+    void invalidate();
 
     /// Can we read the pixels of this image already?
     ///
-    bool image_valid () const { return m_image_valid; }
+    bool image_valid() const { return m_image_valid; }
 
     /// Copies data from the read buffer to the secondary buffer, selecting the
     /// given channel:
@@ -129,35 +130,35 @@ public:
     /// Then applies gamma/exposure correction (if any). This only works when
     /// the image is UINT8 (for now at least). It also performs sRGB to linear
     /// color space correction when indicated.
-    void pixel_transform (bool srgb_to_linear, int color_mode, int channel);
+    void pixel_transform(bool srgb_to_linear, int color_mode, int channel);
 
-    bool get_pixels (ROI roi, TypeDesc format, void *result) {
-        if (m_corrected_image.localpixels ())
-            return m_corrected_image.get_pixels (roi, format, result);
+    bool get_pixels(ROI roi, TypeDesc format, void* result)
+    {
+        if (m_corrected_image.localpixels())
+            return m_corrected_image.get_pixels(roi, format, result);
         else
-            return ImageBuf::get_pixels (roi, format, result);
+            return ImageBuf::get_pixels(roi, format, result);
     }
 
-    bool auto_subimage (void) const { return m_auto_subimage; }
-    void auto_subimage (bool v) { m_auto_subimage = v; }
+    bool auto_subimage(void) const { return m_auto_subimage; }
+    void auto_subimage(bool v) { m_auto_subimage = v; }
 
 private:
-    ImageBuf m_corrected_image; ///< Colorspace/gamma/exposure corrected image.
-    char *m_thumbnail;         ///< Thumbnail image
-    bool m_thumbnail_valid;    ///< Thumbnail is valid
-    float m_gamma;             ///< Gamma correction of this image
-    float m_exposure;          ///< Exposure gain of this image, in stops
-    TypeDesc m_file_dataformat; ///< TypeDesc of the image on disk (not in ram)
+    ImageBuf m_corrected_image;  ///< Colorspace/gamma/exposure corrected image.
+    char* m_thumbnail;           ///< Thumbnail image
+    bool m_thumbnail_valid;      ///< Thumbnail is valid
+    float m_gamma;               ///< Gamma correction of this image
+    float m_exposure;            ///< Exposure gain of this image, in stops
+    TypeDesc m_file_dataformat;  ///< TypeDesc of the image on disk (not in ram)
     mutable std::string m_shortinfo;
     mutable std::string m_longinfo;
-    bool m_image_valid;        ///< Image is valid and pixels can be read.
-    bool m_auto_subimage;      ///< Automatically use subimages when zooming-in/out.
+    bool m_image_valid;    ///< Image is valid and pixels can be read.
+    bool m_auto_subimage;  ///< Automatically use subimages when zooming-in/out.
 };
 
 
 
-class ImageViewer : public QMainWindow
-{
+class ImageViewer : public QMainWindow {
     Q_OBJECT
 
 public:
@@ -165,58 +166,60 @@ public:
     ~ImageViewer();
 
     enum COLOR_MODE {
-        RGBA = 0,
-        RGB = 1,
+        RGBA           = 0,
+        RGB            = 1,
         SINGLE_CHANNEL = 2,
-        LUMINANCE = 3,
-        HEATMAP = 4
+        LUMINANCE      = 3,
+        HEATMAP        = 4
     };
 
     /// Tell the viewer about an image, but don't load it yet.
-    void add_image (const std::string &filename);
+    void add_image(const std::string& filename);
 
     /// View this image.
     ///
-    void current_image (int newimage);
+    void current_image(int newimage);
 
     /// Which image index are we viewing?
     ///
-    int current_image (void) const { return m_current_image; }
+    int current_image(void) const { return m_current_image; }
 
     /// View slide show (cycle through images with timed interval)
     ///
-    void slide (long t, bool b);
+    void slide(long t, bool b);
 
     /// View a particular channel
     ///
-    void viewChannel (int channel, COLOR_MODE colormode);
+    void viewChannel(int channel, COLOR_MODE colormode);
 
     /// Which channel are we viewing?
     ///
-    int current_channel (void) const { return m_current_channel; }
+    int current_channel(void) const { return m_current_channel; }
 
     /// In what color mode are we?
     ///
-    COLOR_MODE current_color_mode (void) const { return m_color_mode; }
+    COLOR_MODE current_color_mode(void) const { return m_color_mode; }
 
     /// Return the current zoom level.  1.0 == 1:1 pixel ratio.  Positive
     /// is a "zoom in" (closer/maxify), negative is zoom out (farther/minify).
-    float zoom (void) const { return m_zoom; }
+    float zoom(void) const { return m_zoom; }
 
     /// Set a new view (zoom level and center position).  If smooth is
     /// true, switch to the new view smoothly over many gradual steps,
     /// otherwise do it all in one step.  The center position is measured
     /// in pixel coordinates.
-    void view (float xcenter, float ycenter, float zoom, bool smooth=false, bool redraw=true);
+    void view(float xcenter, float ycenter, float zoom, bool smooth = false,
+              bool redraw = true);
 
     /// Set a new zoom level, keeping the center of view.  If smooth is
     /// true, switch to the new zoom level smoothly over many gradual
     /// steps, otherwise do it all in one step.
-    void zoom (float newzoom, bool smooth=false);
+    void zoom(float newzoom, bool smooth = false);
 
     /// Return a ptr to the current image, or NULL if there is no
     /// current image.
-    IvImage *cur (void) const {
+    IvImage* cur(void) const
+    {
         if (m_images.empty())
             return NULL;
         return m_current_image >= 0 ? m_images[m_current_image] : NULL;
@@ -224,111 +227,118 @@ public:
 
     /// Return a ref to the current image spec, or NULL if there is no
     /// current image.
-    const ImageSpec *curspec (void) const {
-        IvImage *img = cur();
+    const ImageSpec* curspec(void) const
+    {
+        IvImage* img = cur();
         return img ? &img->spec() : NULL;
     }
 
-    bool pixelviewOn (void) const {
+    bool pixelviewOn(void) const
+    {
         return showPixelviewWindowAct && showPixelviewWindowAct->isChecked();
     }
 
-    bool pixelviewFollowsMouse (void) const {
-        return pixelviewFollowsMouseBox && pixelviewFollowsMouseBox->isChecked();
+    bool pixelviewFollowsMouse(void) const
+    {
+        return pixelviewFollowsMouseBox
+               && pixelviewFollowsMouseBox->isChecked();
     }
 
-    bool linearInterpolation (void) const {
+    bool linearInterpolation(void) const
+    {
         return linearInterpolationBox && linearInterpolationBox->isChecked();
     }
 
-    bool darkPalette (void) const {
+    bool darkPalette(void) const
+    {
         return darkPaletteBox ? darkPaletteBox->isChecked() : m_darkPalette;
     }
 
-    QPalette palette (void) const { return m_palette; }
+    QPalette palette(void) const { return m_palette; }
 
 private slots:
-    void open();                        ///< Dialog to open new image from file
-    void reload();                      ///< Reread current image from disk
-    void openRecentFile();              ///< Open a recent file
-    void closeImg();                    ///< Close the current image
-    void saveAs();                      ///< Save As... functionality
-    void saveWindowAs();                ///< Save As... functionality
-    void saveSelectionAs();             ///< Save As... functionality
-    void print();                       ///< Print current image
-    void deleteCurrentImage();          ///< Deleting displayed image
-    void zoomIn();                      ///< Zoom in to next power of 2
-    void zoomOut();                     ///< Zoom out to next power of 2
-    void normalSize();                  ///< Adjust zoom to 1:1
-    void fitImageToWindow();            ///< Adjust zoom to fit window exactly
+    void open();                ///< Dialog to open new image from file
+    void reload();              ///< Reread current image from disk
+    void openRecentFile();      ///< Open a recent file
+    void closeImg();            ///< Close the current image
+    void saveAs();              ///< Save As... functionality
+    void saveWindowAs();        ///< Save As... functionality
+    void saveSelectionAs();     ///< Save As... functionality
+    void print();               ///< Print current image
+    void deleteCurrentImage();  ///< Deleting displayed image
+    void zoomIn();              ///< Zoom in to next power of 2
+    void zoomOut();             ///< Zoom out to next power of 2
+    void normalSize();          ///< Adjust zoom to 1:1
+    void fitImageToWindow();    ///< Adjust zoom to fit window exactly
     /// Resize window to fit image exactly.  If zoomok is false, do not
     /// change the zoom, even to fit on screen. If minsize is true, do not
     /// resize smaller than default_width x default_height.
-    void fitWindowToImage(bool zoomok=true, bool minsize=false);
-    void fullScreenToggle();            ///< Toggle full screen mode
-    void about();                       ///< Show "about iv" dialog
-    void prevImage();                   ///< View previous image in sequence
-    void nextImage();                   ///< View next image in sequence
-    void toggleImage();                 ///< View most recently viewed image
-    void exposureMinusOneTenthStop();   ///< Decrease exposure 1/10 stop
-    void exposureMinusOneHalfStop();    ///< Decrease exposure 1/2 stop
-    void exposurePlusOneTenthStop();    ///< Increase exposure 1/10 stop
-    void exposurePlusOneHalfStop();     ///< Increase exposure 1/2 stop
-    void gammaMinus();                  ///< Decrease gamma 0.05
-    void gammaPlus();                   ///< Increase gamma 0.05
-    void viewChannelFull();             ///< View RGB
-    void viewChannelRed();              ///< View just red as gray
-    void viewChannelGreen();            ///< View just green as gray
-    void viewChannelBlue();             ///< View just blue as gray
-    void viewChannelAlpha();            ///< View alpha as gray
-    void viewChannelLuminance();        ///< View current 3 channels as luminance
-    void viewChannelPrev();             ///< View just prev channel as gray
-    void viewChannelNext();             ///< View just next channel as gray
-    void viewColorRGBA();               ///< View current 4 channels as RGBA
-    void viewColorRGB();                ///< View current 3 channels as RGB
-    void viewColor1Ch();                ///< View current channel as gray
-    void viewColorHeatmap();            ///< View current channel as heatmap.
-    void viewSubimagePrev();            ///< View prev subimage
-    void viewSubimageNext();            ///< View next subimage
-    void sortByName();                  ///< Sort images by Name.
-    void sortByPath();                  ///< Sort images based on full file path
-    void sortByImageDate();             ///< Sort images by metadata date
-    void sortByFileDate();              ///< Sort images by file Date Stamp.
-    void sortReverse();                 ///< Reverse the current order of images
-    void slideShow();                   ///< Starts slide show
-    void slideLoop();                   ///< Slide show in a loop
-    void slideNoLoop();                 ///< Slide show without loop
-    void setSlideShowDuration(int seconds); ///< Set the slide show duration in seconds
-    void slideImages();                 ///< Slide show - move to next image
-    void showInfoWindow();              ///< View extended info on image
-    void showPixelviewWindow();         ///< View closeup pixel view
-    void editPreferences();             ///< Edit viewer preferences
+    void fitWindowToImage(bool zoomok = true, bool minsize = false);
+    void fullScreenToggle();           ///< Toggle full screen mode
+    void about();                      ///< Show "about iv" dialog
+    void prevImage();                  ///< View previous image in sequence
+    void nextImage();                  ///< View next image in sequence
+    void toggleImage();                ///< View most recently viewed image
+    void exposureMinusOneTenthStop();  ///< Decrease exposure 1/10 stop
+    void exposureMinusOneHalfStop();   ///< Decrease exposure 1/2 stop
+    void exposurePlusOneTenthStop();   ///< Increase exposure 1/10 stop
+    void exposurePlusOneHalfStop();    ///< Increase exposure 1/2 stop
+    void gammaMinus();                 ///< Decrease gamma 0.05
+    void gammaPlus();                  ///< Increase gamma 0.05
+    void viewChannelFull();            ///< View RGB
+    void viewChannelRed();             ///< View just red as gray
+    void viewChannelGreen();           ///< View just green as gray
+    void viewChannelBlue();            ///< View just blue as gray
+    void viewChannelAlpha();           ///< View alpha as gray
+    void viewChannelLuminance();       ///< View current 3 channels as luminance
+    void viewChannelPrev();            ///< View just prev channel as gray
+    void viewChannelNext();            ///< View just next channel as gray
+    void viewColorRGBA();              ///< View current 4 channels as RGBA
+    void viewColorRGB();               ///< View current 3 channels as RGB
+    void viewColor1Ch();               ///< View current channel as gray
+    void viewColorHeatmap();           ///< View current channel as heatmap.
+    void viewSubimagePrev();           ///< View prev subimage
+    void viewSubimageNext();           ///< View next subimage
+    void sortByName();                 ///< Sort images by Name.
+    void sortByPath();                 ///< Sort images based on full file path
+    void sortByImageDate();            ///< Sort images by metadata date
+    void sortByFileDate();             ///< Sort images by file Date Stamp.
+    void sortReverse();                ///< Reverse the current order of images
+    void slideShow();                  ///< Starts slide show
+    void slideLoop();                  ///< Slide show in a loop
+    void slideNoLoop();                ///< Slide show without loop
+    void setSlideShowDuration(
+        int seconds);            ///< Set the slide show duration in seconds
+    void slideImages();          ///< Slide show - move to next image
+    void showInfoWindow();       ///< View extended info on image
+    void showPixelviewWindow();  ///< View closeup pixel view
+    void editPreferences();      ///< Edit viewer preferences
 private:
-    void createActions ();
-    void createMenus ();
-    void createToolBars ();
-    void createStatusBar ();
-    void readSettings (bool ui_is_set_up=true);
-    void writeSettings ();
-    void updateActions ();
-    void addRecentFile (const std::string &name);
-    void removeRecentFile (const std::string &name);
-    void updateRecentFilesMenu ();
-    bool loadCurrentImage (int subimage = 0, int miplevel = 0);
-    void displayCurrentImage (bool update = true);
-    void updateTitle ();
-    void updateStatusBar ();
-    void keyPressEvent (QKeyEvent *event);
-    void resizeEvent (QResizeEvent *event);
-    void closeEvent (QCloseEvent *event);
+    void createActions();
+    void createMenus();
+    void createToolBars();
+    void createStatusBar();
+    void readSettings(bool ui_is_set_up = true);
+    void writeSettings();
+    void updateActions();
+    void addRecentFile(const std::string& name);
+    void removeRecentFile(const std::string& name);
+    void updateRecentFilesMenu();
+    bool loadCurrentImage(int subimage = 0, int miplevel = 0);
+    void displayCurrentImage(bool update = true);
+    void updateTitle();
+    void updateStatusBar();
+    void keyPressEvent(QKeyEvent* event);
+    void resizeEvent(QResizeEvent* event);
+    void closeEvent(QCloseEvent* event);
 
-    QTimer *slideTimer;          ///< Timer to use for slide show mode
-    long slideDuration_ms;       ///< Slide show mode duration (in ms)
-    bool slide_loop;             ///< Do we loop when in slide mode?
+    QTimer* slideTimer;     ///< Timer to use for slide show mode
+    long slideDuration_ms;  ///< Slide show mode duration (in ms)
+    bool slide_loop;        ///< Do we loop when in slide mode?
 
-    IvGL *glwin;
-    IvInfoWindow *infoWindow;
-    IvPreferenceWindow *preferenceWindow;
+    IvGL* glwin;
+    IvInfoWindow* infoWindow;
+    IvPreferenceWindow* preferenceWindow;
 
 #ifndef QT_NO_PRINTER
     // QPrinter printer;
@@ -336,11 +346,11 @@ private:
 
     QAction *openAct, *reloadAct, *closeImgAct;
     static const unsigned int MaxRecentFiles = 10;
-    QAction *openRecentAct[MaxRecentFiles];
+    QAction* openRecentAct[MaxRecentFiles];
     QAction *saveAsAct, *saveWindowAsAct, *saveSelectionAsAct;
-    QAction *printAct;
-    QAction *deleteCurrentImageAct;
-    QAction *exitAct;
+    QAction* printAct;
+    QAction* deleteCurrentImageAct;
+    QAction* exitAct;
     QAction *gammaPlusAct, *gammaMinusAct;
     QAction *exposurePlusOneTenthStopAct, *exposurePlusOneHalfStopAct;
     QAction *exposureMinusOneTenthStopAct, *exposureMinusOneHalfStopAct;
@@ -350,100 +360,105 @@ private:
     QAction *viewColorRGBAAct, *viewColorRGBAct, *viewColor1ChAct;
     QAction *viewColorLumAct, *viewColorHeatmapAct;
     QAction *viewSubimagePrevAct, *viewSubimageNextAct;
-    QAction *zoomInAct;
-    QAction *zoomOutAct;
-    QAction *normalSizeAct;
+    QAction* zoomInAct;
+    QAction* zoomOutAct;
+    QAction* normalSizeAct;
     QAction *fitWindowToImageAct, *fitImageToWindowAct;
-    QAction *fullScreenAct;
-    QAction *aboutAct;
+    QAction* fullScreenAct;
+    QAction* aboutAct;
     QAction *nextImageAct, *prevImageAct, *toggleImageAct;
     QAction *sortByNameAct, *sortByPathAct, *sortReverseAct;
     QAction *sortByImageDateAct, *sortByFileDateAct;
     QAction *slideShowAct, *slideLoopAct, *slideNoLoopAct;
-    QAction *showInfoWindowAct;
-    QAction *editPreferencesAct;
-    QAction *showPixelviewWindowAct;
-    QMenu *fileMenu, *editMenu, /**imageMenu,*/ *viewMenu, *toolsMenu, *helpMenu;
-    QMenu *openRecentMenu;
+    QAction* showInfoWindowAct;
+    QAction* editPreferencesAct;
+    QAction* showPixelviewWindowAct;
+    QMenu *fileMenu, *editMenu, /**imageMenu,*/ *viewMenu, *toolsMenu,
+        *helpMenu;
+    QMenu* openRecentMenu;
     QMenu *expgamMenu, *channelMenu, *colormodeMenu, *slideMenu, *sortMenu;
     QLabel *statusImgInfo, *statusViewInfo;
-    QProgressBar *statusProgress;
-    QComboBox *mouseModeComboBox;
-    enum MouseMode { MouseModeZoom, MouseModePan, MouseModeWipe,
-                     MouseModeSelect, MouseModeAnnotate };
-    QCheckBox *pixelviewFollowsMouseBox;
-    QCheckBox *linearInterpolationBox;
-    QCheckBox *darkPaletteBox;
-    QCheckBox *autoMipmap;
-    QLabel   *maxMemoryICLabel;
-    QSpinBox *maxMemoryIC;
-    QLabel   *slideShowDurationLabel;
-    QSpinBox *slideShowDuration;
+    QProgressBar* statusProgress;
+    QComboBox* mouseModeComboBox;
+    enum MouseMode {
+        MouseModeZoom,
+        MouseModePan,
+        MouseModeWipe,
+        MouseModeSelect,
+        MouseModeAnnotate
+    };
+    QCheckBox* pixelviewFollowsMouseBox;
+    QCheckBox* linearInterpolationBox;
+    QCheckBox* darkPaletteBox;
+    QCheckBox* autoMipmap;
+    QLabel* maxMemoryICLabel;
+    QSpinBox* maxMemoryIC;
+    QLabel* slideShowDurationLabel;
+    QSpinBox* slideShowDuration;
 
-    std::vector<IvImage *> m_images;  ///< List of images
-    int m_current_image;              ///< Index of current image, -1 if none
-    int m_current_channel;            ///< Channel we're viewing.
-    COLOR_MODE m_color_mode;          ///< How to show the current channel(s).
-    int m_last_image;                 ///< Last image we viewed
-    float m_zoom;                     ///< Zoom amount (positive maxifies)
-    bool m_fullscreen;                ///< Full screen mode
-    std::vector<std::string> m_recent_files;  ///< Recently opened files
-    float m_default_gamma;            ///< Default gamma of the display
-    QPalette m_palette;               ///< Custom palette
-    bool m_darkPalette;               ///< Use dark palette?
+    std::vector<IvImage*> m_images;  // List of images
+    int m_current_image;             // Index of current image, -1 if none
+    int m_current_channel;           // Channel we're viewing.
+    COLOR_MODE m_color_mode;         // How to show the current channel(s).
+    int m_last_image;                // Last image we viewed
+    float m_zoom;                    // Zoom amount (positive maxifies)
+    bool m_fullscreen;               // Full screen mode
+    std::vector<std::string> m_recent_files;  // Recently opened files
+    float m_default_gamma;                    // Default gamma of the display
+    QPalette m_palette;                       // Custom palette
+    bool m_darkPalette;                       // Use dark palette?
 
-    static const int m_default_width = 640; ///< The default width of the window.
-    static const int m_default_height = 480; ///< The default height of the window.
+    // The default width and height of the window:
+    static const int m_default_width  = 640;
+    static const int m_default_height = 480;
 
     // What zoom do we need to fit these window dimensions?
-    float zoom_needed_to_fit (int w, int h);
+    float zoom_needed_to_fit(int w, int h);
 
     friend class IvCanvas;
     friend class IvGL;
     friend class IvInfoWindow;
     friend class IvPreferenceWindow;
-    friend bool image_progress_callback (void *opaque, float done);
+    friend bool image_progress_callback(void* opaque, float done);
 };
 
 
 
-class IvInfoWindow : public QDialog
-{
+class IvInfoWindow : public QDialog {
     Q_OBJECT
 public:
-    IvInfoWindow (ImageViewer &viewer, bool visible=true);
-    void update (IvImage *img);
+    IvInfoWindow(ImageViewer& viewer, bool visible = true);
+    void update(IvImage* img);
 
 protected:
-    void keyPressEvent (QKeyEvent *event);
-    
-private:
-    QPushButton *closeButton;
-    QScrollArea *scrollArea;
-    QLabel *infoLabel;
+    void keyPressEvent(QKeyEvent* event);
 
-    ImageViewer &m_viewer;
+private:
+    QPushButton* closeButton;
+    QScrollArea* scrollArea;
+    QLabel* infoLabel;
+
+    ImageViewer& m_viewer;
     bool m_visible;
 };
 
 
 
-class IvPreferenceWindow : public QDialog
-{
+class IvPreferenceWindow : public QDialog {
     Q_OBJECT
 public:
-    IvPreferenceWindow (ImageViewer &viewer);
+    IvPreferenceWindow(ImageViewer& viewer);
 
 protected:
-    void keyPressEvent (QKeyEvent *event);
-    
-private:
-    QVBoxLayout *layout;
-    QPushButton *closeButton;
+    void keyPressEvent(QKeyEvent* event);
 
-    ImageViewer &m_viewer;
+private:
+    QVBoxLayout* layout;
+    QPushButton* closeButton;
+
+    ImageViewer& m_viewer;
 };
 
 
 
-#endif // OPENIMAGEIO_IMAGEVIEWER_H
+#endif  // OPENIMAGEIO_IMAGEVIEWER_H

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -28,13 +28,13 @@
   (This is the Modified BSD License)
 */
 
-#include "imageviewer.h"
 #include "ivgl.h"
+#include "imageviewer.h"
 
 #include <iostream>
 
-#include <OpenEXR/half.h>
 #include <OpenEXR/ImathFun.h>
+#include <OpenEXR/half.h>
 
 #include <QComboBox>
 #include <QLabel>
@@ -42,13 +42,13 @@
 #include <QProgressBar>
 
 #include "ivutils.h"
-#include <OpenImageIO/strutil.h>
 #include <OpenImageIO/fmath.h>
+#include <OpenImageIO/strutil.h>
 #include <OpenImageIO/timer.h>
 
 
-static const char *
-gl_err_to_string (GLenum err)
+static const char*
+gl_err_to_string(GLenum err)
 {  // Thanks, Dan Wexler, for this function
     switch (err) {
     case GL_NO_ERROR: return "No error";
@@ -63,22 +63,32 @@ gl_err_to_string (GLenum err)
 }
 
 
-#define GLERRPRINT(msg)                                           \
-    for (GLenum err = glGetError();  err != GL_NO_ERROR;  err = glGetError()) \
-        std::cerr << "GL error " << msg << " " << (int)err <<  " - " << gl_err_to_string(err) << "\n";      \
+#define GLERRPRINT(msg)                                                        \
+    for (GLenum err = glGetError(); err != GL_NO_ERROR; err = glGetError())    \
+        std::cerr << "GL error " << msg << " " << (int)err << " - "            \
+                  << gl_err_to_string(err) << "\n";
 
 
 
-IvGL::IvGL (QWidget *parent, ImageViewer &viewer)
-    : QOpenGLWidget(parent), m_viewer(viewer),
-      m_shaders_created(false), m_tex_created(false),
-      m_zoom(1.0), m_centerx(0), m_centery(0), m_dragging(false),
-      m_use_shaders(false),
-      m_use_halffloat(false), m_use_float(false),
-      m_use_srgb(false),
-      m_texture_width(1), m_texture_height(1), m_last_pbo_used(0), 
-      m_current_image(NULL), m_pixelview_left_corner(true),
-      m_last_texbuf_used(0)
+IvGL::IvGL(QWidget* parent, ImageViewer& viewer)
+    : QOpenGLWidget(parent)
+    , m_viewer(viewer)
+    , m_shaders_created(false)
+    , m_tex_created(false)
+    , m_zoom(1.0)
+    , m_centerx(0)
+    , m_centery(0)
+    , m_dragging(false)
+    , m_use_shaders(false)
+    , m_use_halffloat(false)
+    , m_use_float(false)
+    , m_use_srgb(false)
+    , m_texture_width(1)
+    , m_texture_height(1)
+    , m_last_pbo_used(0)
+    , m_current_image(NULL)
+    , m_pixelview_left_corner(true)
+    , m_last_texbuf_used(0)
 {
 #if 0
     QGLFormat format;
@@ -90,28 +100,26 @@ IvGL::IvGL (QWidget *parent, ImageViewer &viewer)
     setFormat (format);
 #endif
     m_mouse_activation = false;
-    this->setFocusPolicy (Qt::StrongFocus);
-    setMouseTracking (true);
+    this->setFocusPolicy(Qt::StrongFocus);
+    setMouseTracking(true);
 }
 
 
 
-IvGL::~IvGL ()
-{
-}
+IvGL::~IvGL() {}
 
 
 
 void
-IvGL::initializeGL ()
+IvGL::initializeGL()
 {
     initializeOpenGLFunctions();
 
-    glClearColor (0.05f, 0.05f, 0.05f, 1.0f);
-    glEnable (GL_BLEND);
-    glEnable (GL_TEXTURE_2D);
+    glClearColor(0.05f, 0.05f, 0.05f, 1.0f);
+    glEnable(GL_BLEND);
+    glEnable(GL_TEXTURE_2D);
     // glBlendFunc (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glBlendFunc (GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
     // Make sure initial matrix is identity (returning to this stack level loads
     // back this matrix).
     glLoadIdentity();
@@ -119,7 +127,7 @@ IvGL::initializeGL ()
 #if 1
     // Compensate for high res displays with device pixel ratio scaling
     float dpr = m_viewer.devicePixelRatio();
-    glScalef (dpr, dpr, 1.0f);
+    glScalef(dpr, dpr, 1.0f);
 #endif
 
     // There's this small detail in the OpenGL 2.1 (probably earlier versions
@@ -133,21 +141,21 @@ IvGL::initializeGL ()
     // means that it was expecting images to be Aligned to 4-bytes, and making
     // several odd "skew-like effects" in the displayed images. Setting the
     // alignment to 1 byte fixes this problems.
-    glPixelStorei (GL_UNPACK_ALIGNMENT, 1);          
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
     // here we check what OpenGL extensions are available, and take action
     // if needed
-    check_gl_extensions ();
+    check_gl_extensions();
 
-    create_textures ();
+    create_textures();
 
-    create_shaders ();
+    create_shaders();
 }
 
 
 
 void
-IvGL::create_textures (void)
+IvGL::create_textures(void)
 {
     if (m_tex_created)
         return;
@@ -156,48 +164,46 @@ IvGL::create_textures (void)
     const int total_texbufs = 4;
     GLuint textures[total_texbufs];
 
-    glGenTextures (total_texbufs, textures);
+    glGenTextures(total_texbufs, textures);
 
     // Initialize texture objects
     for (unsigned int texture : textures) {
         m_texbufs.emplace_back();
-        glBindTexture (GL_TEXTURE_2D, texture);
-        GLERRPRINT ("bind tex");
-        glTexImage2D (GL_TEXTURE_2D, 0 /*mip level*/,
-                      4 /*internal format - color components */,
-                      1 /*width*/, 1 /*height*/, 0 /*border width*/,
-                      GL_RGBA /*type - GL_RGB, GL_RGBA, GL_LUMINANCE */,
-                      GL_FLOAT /*format - GL_FLOAT */,
-                      NULL /*data*/);
-        GLERRPRINT ("tex image 2d");
+        glBindTexture(GL_TEXTURE_2D, texture);
+        GLERRPRINT("bind tex");
+        glTexImage2D(GL_TEXTURE_2D, 0 /*mip level*/,
+                     4 /*internal format - color components */, 1 /*width*/,
+                     1 /*height*/, 0 /*border width*/,
+                     GL_RGBA /*type - GL_RGB, GL_RGBA, GL_LUMINANCE */,
+                     GL_FLOAT /*format - GL_FLOAT */, NULL /*data*/);
+        GLERRPRINT("tex image 2d");
         // Initialize tex parameters.
-        glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-        glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-        glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
-        glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
-        GLERRPRINT ("After tex parameters");
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
+        GLERRPRINT("After tex parameters");
         m_texbufs.back().tex_object = texture;
-        m_texbufs.back().x = 0;
-        m_texbufs.back().y = 0;
-        m_texbufs.back().width = 0;
-        m_texbufs.back().height = 0;
+        m_texbufs.back().x          = 0;
+        m_texbufs.back().y          = 0;
+        m_texbufs.back().width      = 0;
+        m_texbufs.back().height     = 0;
     }
 
     // Create another texture for the pixelview.
-    glGenTextures (1, &m_pixelview_tex);
-    glBindTexture (GL_TEXTURE_2D, m_pixelview_tex);
-    glTexImage2D (GL_TEXTURE_2D, 0, 
-                  4, closeuptexsize, closeuptexsize, 0, 
-                  GL_RGBA, GL_FLOAT, NULL);
-    glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
-    glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
-    glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glGenTextures(1, &m_pixelview_tex);
+    glBindTexture(GL_TEXTURE_2D, m_pixelview_tex);
+    glTexImage2D(GL_TEXTURE_2D, 0, 4, closeuptexsize, closeuptexsize, 0,
+                 GL_RGBA, GL_FLOAT, NULL);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
-    glGenBuffers (2, m_pbo_objects);
-    glBindBuffer (GL_PIXEL_UNPACK_BUFFER, m_pbo_objects[0]);
-    glBindBuffer (GL_PIXEL_UNPACK_BUFFER, m_pbo_objects[1]);
-    glBindBuffer (GL_PIXEL_UNPACK_BUFFER, 0);
+    glGenBuffers(2, m_pbo_objects);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, m_pbo_objects[0]);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, m_pbo_objects[1]);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
 
     m_tex_created = true;
 }
@@ -205,9 +211,10 @@ IvGL::create_textures (void)
 
 
 void
-IvGL::create_shaders (void)
+IvGL::create_shaders(void)
 {
-    static const GLchar *vertex_source = 
+    // clang-format off
+    static const GLchar *vertex_source =
         "varying vec2 vTexCoord;\n"
         "void main ()\n"
         "{\n"
@@ -215,7 +222,7 @@ IvGL::create_shaders (void)
         "    gl_Position = ftransform();\n"
         "}\n";
 
-    static const GLchar *fragment_source = 
+    static const GLchar *fragment_source =
         "uniform sampler2D imgtex;\n"
         "varying vec2 vTexCoord;\n"
         "uniform float gain;\n"
@@ -322,6 +329,7 @@ IvGL::create_shaders (void)
         "    C.xyz = pow (C.xyz, vec3 (invgamma, invgamma, invgamma));\n"
         "    gl_FragColor = C;\n"
         "}\n";
+    // clang-format on
 
     if (!m_use_shaders) {
         std::cerr << "Not using shaders!\n";
@@ -329,62 +337,62 @@ IvGL::create_shaders (void)
     }
     if (m_shaders_created)
         return;
-    
+
     //initialize shader object handles for abort function
-    m_shader_program = 0;
-    m_vertex_shader = 0;
+    m_shader_program  = 0;
+    m_vertex_shader   = 0;
     m_fragment_shader = 0;
 
     // When using extensions to support shaders, we need to load the function
     // entry points (which is actually done by GLEW) and then call them. So
     // we have to get the functions through the right symbols otherwise
     // extension-based shaders won't work.
-    m_shader_program = glCreateProgram ();
+    m_shader_program = glCreateProgram();
 
-    GLERRPRINT ("create progam");
+    GLERRPRINT("create progam");
 
     // This holds the compilation status
     GLint status;
 
-    m_vertex_shader = glCreateShader (GL_VERTEX_SHADER);
-    glShaderSource (m_vertex_shader, 1, &vertex_source, NULL);
-    glCompileShader (m_vertex_shader);
-    glGetShaderiv (m_vertex_shader, GL_COMPILE_STATUS, &status);
+    m_vertex_shader = glCreateShader(GL_VERTEX_SHADER);
+    glShaderSource(m_vertex_shader, 1, &vertex_source, NULL);
+    glCompileShader(m_vertex_shader);
+    glGetShaderiv(m_vertex_shader, GL_COMPILE_STATUS, &status);
 
-    if (! status) {
+    if (!status) {
         std::cerr << "vertex shader compile status: " << status << "\n";
-        print_shader_log (std::cerr, m_vertex_shader);
-        create_shaders_abort ();
+        print_shader_log(std::cerr, m_vertex_shader);
+        create_shaders_abort();
         return;
     }
-    glAttachShader (m_shader_program, m_vertex_shader);
-    GLERRPRINT ("After attach vertex shader.");
+    glAttachShader(m_shader_program, m_vertex_shader);
+    GLERRPRINT("After attach vertex shader.");
 
-    m_fragment_shader = glCreateShader (GL_FRAGMENT_SHADER);
-    glShaderSource (m_fragment_shader, 1, &fragment_source, NULL);
-    glCompileShader (m_fragment_shader);
-    glGetShaderiv (m_fragment_shader, GL_COMPILE_STATUS, &status);
-    if (! status) {
+    m_fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
+    glShaderSource(m_fragment_shader, 1, &fragment_source, NULL);
+    glCompileShader(m_fragment_shader);
+    glGetShaderiv(m_fragment_shader, GL_COMPILE_STATUS, &status);
+    if (!status) {
         std::cerr << "fragment shader compile status: " << status << "\n";
         print_shader_log(std::cerr, m_fragment_shader);
-        create_shaders_abort ();
+        create_shaders_abort();
         return;
     }
-    glAttachShader (m_shader_program, m_fragment_shader);
-    GLERRPRINT ("After attach fragment shader");
+    glAttachShader(m_shader_program, m_fragment_shader);
+    GLERRPRINT("After attach fragment shader");
 
-    glLinkProgram (m_shader_program);
-    GLERRPRINT ("link");
+    glLinkProgram(m_shader_program);
+    GLERRPRINT("link");
     GLint linked;
-    glGetProgramiv (m_shader_program, GL_LINK_STATUS, &linked);
-    if (! linked) {
+    glGetProgramiv(m_shader_program, GL_LINK_STATUS, &linked);
+    if (!linked) {
         std::cerr << "NOT LINKED\n";
         char buf[10000];
         buf[0] = 0;
         GLsizei len;
-        glGetProgramInfoLog (m_shader_program, sizeof(buf), &len, buf);
+        glGetProgramInfoLog(m_shader_program, sizeof(buf), &len, buf);
         std::cerr << "link log:\n" << buf << "---\n";
-        create_shaders_abort ();
+        create_shaders_abort();
         return;
     }
 
@@ -394,69 +402,68 @@ IvGL::create_shaders (void)
 
 
 void
-IvGL::create_shaders_abort (void)
+IvGL::create_shaders_abort(void)
 {
-    glUseProgram (0);
+    glUseProgram(0);
     if (m_shader_program)
-        glDeleteProgram (m_shader_program);
+        glDeleteProgram(m_shader_program);
     if (m_vertex_shader)
-        glDeleteShader (m_vertex_shader);
+        glDeleteShader(m_vertex_shader);
     if (m_fragment_shader)
-        glDeleteShader (m_fragment_shader);
-    
-    GLERRPRINT ("After delete shaders");    
+        glDeleteShader(m_fragment_shader);
+
+    GLERRPRINT("After delete shaders");
     m_use_shaders = false;
 }
 
 
 
 void
-IvGL::resizeGL (int w, int h)
+IvGL::resizeGL(int w, int h)
 {
-    GLERRPRINT ("resizeGL entry");
-    glViewport (0, 0, w, h);
-    glMatrixMode (GL_PROJECTION);
-    glLoadIdentity ();
-    glOrtho (-w/2.0, w/2.0, -h/2.0, h/2.0, 0, 10);
+    GLERRPRINT("resizeGL entry");
+    glViewport(0, 0, w, h);
+    glMatrixMode(GL_PROJECTION);
+    glLoadIdentity();
+    glOrtho(-w / 2.0, w / 2.0, -h / 2.0, h / 2.0, 0, 10);
     // Main GL viewport is set up for orthographic view centered at
     // (0,0) and with width and height equal to the window dimensions IN
     // PIXEL UNITS.
-    glMatrixMode (GL_MODELVIEW);
+    glMatrixMode(GL_MODELVIEW);
 
-    clamp_view_to_window ();
-    GLERRPRINT ("resizeGL exit");
+    clamp_view_to_window();
+    GLERRPRINT("resizeGL exit");
 }
 
 
 
 static void
-gl_rect (float xmin, float ymin, float xmax, float ymax, float z = 0,
-         float smin = 0, float tmin = 0, float smax = 1, float tmax = 1,
-         int rotate = 0)
+gl_rect(float xmin, float ymin, float xmax, float ymax, float z = 0,
+        float smin = 0, float tmin = 0, float smax = 1, float tmax = 1,
+        int rotate = 0)
 {
     float tex[] = { smin, tmin, smax, tmin, smax, tmax, smin, tmax };
-    glBegin (GL_POLYGON);
-    glTexCoord2f (tex[(0+2*rotate)&7], tex[(1+2*rotate)&7]);
-    glVertex3f (xmin,  ymin, z);
-    glTexCoord2f (tex[(2+2*rotate)&7], tex[(3+2*rotate)&7]);
-    glVertex3f (xmax,  ymin, z);
-    glTexCoord2f (tex[(4+2*rotate)&7], tex[(5+2*rotate)&7]);
-    glVertex3f (xmax, ymax, z);
-    glTexCoord2f (tex[(6+2*rotate)&7], tex[(7+2*rotate)&7]);
-    glVertex3f (xmin, ymax, z);
-    glEnd ();
+    glBegin(GL_POLYGON);
+    glTexCoord2f(tex[(0 + 2 * rotate) & 7], tex[(1 + 2 * rotate) & 7]);
+    glVertex3f(xmin, ymin, z);
+    glTexCoord2f(tex[(2 + 2 * rotate) & 7], tex[(3 + 2 * rotate) & 7]);
+    glVertex3f(xmax, ymin, z);
+    glTexCoord2f(tex[(4 + 2 * rotate) & 7], tex[(5 + 2 * rotate) & 7]);
+    glVertex3f(xmax, ymax, z);
+    glTexCoord2f(tex[(6 + 2 * rotate) & 7], tex[(7 + 2 * rotate) & 7]);
+    glVertex3f(xmin, ymax, z);
+    glEnd();
 }
 
 
 
 static void
-handle_orientation (int orientation, int width, int height, 
-                    float &scale_x, float &scale_y, 
-                    float &rotate_z, float &point_x, float &point_y,
-                    bool pixel=false)
+handle_orientation(int orientation, int width, int height, float& scale_x,
+                   float& scale_y, float& rotate_z, float& point_x,
+                   float& point_y, bool pixel = false)
 {
     switch (orientation) {
-    case 2: // flipped horizontally
+    case 2:  // flipped horizontally
         scale_x = -1;
         point_x = width - point_x;
         if (pixel)
@@ -464,7 +471,7 @@ handle_orientation (int orientation, int width, int height,
             // substract 1 to get the right index.
             --point_x;
         break;
-    case 3: // bottom up, rigth to left (rotated 180).
+    case 3:  // bottom up, rigth to left (rotated 180).
         scale_x = -1;
         scale_y = -1;
         point_x = width - point_x;
@@ -474,28 +481,28 @@ handle_orientation (int orientation, int width, int height,
             --point_y;
         }
         break;
-    case 4: // flipped vertically.
+    case 4:  // flipped vertically.
         scale_y = -1;
         point_y = height - point_y;
         if (pixel)
             --point_y;
         break;
-    case 5: // transposed (flip horizontal & rotated 90 ccw).
-        scale_x = -1;
+    case 5:  // transposed (flip horizontal & rotated 90 ccw).
+        scale_x  = -1;
         rotate_z = 90.0;
-        std::swap (point_x, point_y);
+        std::swap(point_x, point_y);
         break;
-    case 6: // rotated 90 cw.
+    case 6:  // rotated 90 cw.
         rotate_z = -270.0;
-        std::swap (point_x, point_y);
+        std::swap(point_x, point_y);
         point_y = height - point_y;
         if (pixel)
             --point_y;
         break;
-    case 7: // transverse, (flip horizontal & rotated 90 cw, r-to-l, b-to-t)
-        scale_x = -1;
-        rotate_z= -90.0;
-        std::swap (point_x, point_y);
+    case 7:  // transverse, (flip horizontal & rotated 90 cw, r-to-l, b-to-t)
+        scale_x  = -1;
+        rotate_z = -90.0;
+        std::swap(point_x, point_y);
         point_x = width - point_x;
         point_y = height - point_y;
         if (pixel) {
@@ -503,103 +510,104 @@ handle_orientation (int orientation, int width, int height,
             --point_y;
         }
         break;
-    case 8: // rotated 90 ccw.
+    case 8:  // rotated 90 ccw.
         rotate_z = -90.0;
-        std::swap (point_x, point_y);
+        std::swap(point_x, point_y);
         point_x = width - point_x;
         if (pixel)
             --point_x;
         break;
-    case 1: // horizontal
-    case 0: // unknown
-    default:
-        break;
+    case 1:  // horizontal
+    case 0:  // unknown
+    default: break;
     }
 }
 
 
 
 void
-IvGL::paintGL ()
+IvGL::paintGL()
 {
 #ifndef NDEBUG
     Timer paint_image_time;
     paint_image_time.start();
 #endif
     //std::cerr << "paintGL " << m_viewer.current_image() << " with zoom " << m_zoom << "\n";
-    glClear (GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    IvImage *img = m_current_image;
-    if (! img || ! img->image_valid())
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    IvImage* img = m_current_image;
+    if (!img || !img->image_valid())
         return;
 
-    const ImageSpec &spec (img->spec());
+    const ImageSpec& spec(img->spec());
     float z = m_zoom;
 
-    glPushMatrix ();
-    glLoadIdentity ();
+    glPushMatrix();
+    glLoadIdentity();
     // Transform is now same as the main GL viewport -- window pixels as
     // units, with (0,0) at the center of the visible unit.
-    glTranslatef (0, 0, -5);
+    glTranslatef(0, 0, -5);
     // Pushed away from the camera 5 units.
-    glScalef (1, -1, 1);
+    glScalef(1, -1, 1);
     // Flip y, because OGL's y runs from bottom to top.
-    glScalef (z, z, 1);
+    glScalef(z, z, 1);
     // Scaled by zoom level.  So now xy units are image pixels as
     // displayed at the current zoom level, with the origin at the
     // center of the visible window.
 
     // Handle the orientation with OpenGL *before* translating our center.
-    float scale_x = 1;
-    float scale_y = 1;
-    float rotate_z= 0;
+    float scale_x      = 1;
+    float scale_y      = 1;
+    float rotate_z     = 0;
     float real_centerx = m_centerx;
     float real_centery = m_centery;
-    handle_orientation (img->orientation(), spec.width, 
-                        spec.height, scale_x, scale_y, rotate_z, 
-                        real_centerx, real_centery);
+    handle_orientation(img->orientation(), spec.width, spec.height, scale_x,
+                       scale_y, rotate_z, real_centerx, real_centery);
 
-    glScalef (scale_x, scale_y, 1);
-    glRotatef (rotate_z, 0, 0, 1);
-    glTranslatef (-real_centerx, -real_centery, 0.0f);
+    glScalef(scale_x, scale_y, 1);
+    glRotatef(rotate_z, 0, 0, 1);
+    glTranslatef(-real_centerx, -real_centery, 0.0f);
     // Recentered so that the pixel space (m_centerx,m_centery) position is
     // at the center of the visible window.
 
-    useshader (m_texture_width, m_texture_height);
+    useshader(m_texture_width, m_texture_height);
 
     float smin = 0, smax = 1.0;
     float tmin = 0, tmax = 1.0;
     // Image pixels shown from the center to the edge of the window.
-    int wincenterx = (int) ceil (width()/(2*m_zoom));
-    int wincentery = (int) ceil (height()/(2*m_zoom));
+    int wincenterx = (int)ceil(width() / (2 * m_zoom));
+    int wincentery = (int)ceil(height() / (2 * m_zoom));
     if (img->orientation() > 4) {
-        std::swap (wincenterx, wincentery);
+        std::swap(wincenterx, wincentery);
     }
 
-    int xbegin = (int) floor (real_centerx) - wincenterx;
-    xbegin = std::max (spec.x, xbegin - (xbegin % m_texture_width));
-    int ybegin = (int) floor (real_centery) - wincentery;
-    ybegin = std::max (spec.y, ybegin - (ybegin % m_texture_height));
-    int xend   = (int) floor (real_centerx) + wincenterx;
-    xend = std::min (spec.x + spec.width, xend + m_texture_width - (xend % m_texture_width));
-    int yend   = (int) floor (real_centery) + wincentery;
-    yend = std::min (spec.y + spec.height, yend + m_texture_height - (yend % m_texture_height));
+    int xbegin = (int)floor(real_centerx) - wincenterx;
+    xbegin     = std::max(spec.x, xbegin - (xbegin % m_texture_width));
+    int ybegin = (int)floor(real_centery) - wincentery;
+    ybegin     = std::max(spec.y, ybegin - (ybegin % m_texture_height));
+    int xend   = (int)floor(real_centerx) + wincenterx;
+    xend       = std::min(spec.x + spec.width,
+                    xend + m_texture_width - (xend % m_texture_width));
+    int yend   = (int)floor(real_centery) + wincentery;
+    yend       = std::min(spec.y + spec.height,
+                    yend + m_texture_height - (yend % m_texture_height));
     //std::cerr << "(" << xbegin << ',' << ybegin << ") - (" << xend << ',' << yend << ")\n";
 
     // Provide some feedback
-    int total_tiles = (int) (ceilf(float(xend-xbegin)/m_texture_width) * ceilf(float(yend-ybegin)/m_texture_height));
-    float tile_advance = 1.0f/total_tiles;
-    float percent = tile_advance;
-    m_viewer.statusViewInfo->hide ();
-    m_viewer.statusProgress->show ();
+    int total_tiles    = (int)(ceilf(float(xend - xbegin) / m_texture_width)
+                            * ceilf(float(yend - ybegin) / m_texture_height));
+    float tile_advance = 1.0f / total_tiles;
+    float percent      = tile_advance;
+    m_viewer.statusViewInfo->hide();
+    m_viewer.statusProgress->show();
 
     // FIXME: change the code path so we can take full advantage of async DMA
     // when using PBO.
-    for (int ystart = ybegin ; ystart < yend; ystart += m_texture_height) {
-        for (int xstart = xbegin ; xstart < xend; xstart += m_texture_width) {
-            int tile_width = std::min (xend - xstart, m_texture_width);
-            int tile_height = std::min (yend - ystart, m_texture_height);
-            smax = tile_width/float (m_texture_width);
-            tmax = tile_height/float (m_texture_height);
+    for (int ystart = ybegin; ystart < yend; ystart += m_texture_height) {
+        for (int xstart = xbegin; xstart < xend; xstart += m_texture_width) {
+            int tile_width  = std::min(xend - xstart, m_texture_width);
+            int tile_height = std::min(yend - ystart, m_texture_height);
+            smax            = tile_width / float(m_texture_width);
+            tmax            = tile_height / float(m_texture_height);
 
             //std::cerr << "xstart: " << xstart << ". ystart: " << ystart << "\n";
             //std::cerr << "tile_width: " << tile_width << ". tile_height: " << tile_height << "\n";
@@ -607,23 +615,23 @@ IvGL::paintGL ()
             // FIXME: This can get too slow. Some ideas: avoid sending the tex
             // images more than necessary, figure an optimum texture size, use
             // multiple texture objects.
-            load_texture (xstart, ystart, tile_width, tile_height, percent);
-            gl_rect (xstart, ystart, xstart+tile_width, ystart+tile_height, 0,
-                     smin, tmin, smax, tmax);
+            load_texture(xstart, ystart, tile_width, tile_height, percent);
+            gl_rect(xstart, ystart, xstart + tile_width, ystart + tile_height,
+                    0, smin, tmin, smax, tmax);
             percent += tile_advance;
         }
     }
 
-    glPopMatrix ();
+    glPopMatrix();
 
     if (m_viewer.pixelviewOn()) {
-        paint_pixelview ();
+        paint_pixelview();
     }
 
     // Show the status info again.
-    m_viewer.statusProgress->hide ();
-    m_viewer.statusViewInfo->show ();
-    unsetCursor ();
+    m_viewer.statusProgress->hide();
+    m_viewer.statusViewInfo->show();
+    unsetCursor();
 
 #ifndef NDEBUG
     std::cerr << "paintGL elapsed time: " << paint_image_time() << " seconds\n";
@@ -633,8 +641,8 @@ IvGL::paintGL ()
 
 
 void
-IvGL::shadowed_text (float x, float y, float z, const std::string &s,
-                     const QFont &font)
+IvGL::shadowed_text(float x, float y, float z, const std::string& s,
+                    const QFont& font)
 {
     /*
      * Paint on intermediate QImage, AA text on QOpenGLWidget based
@@ -658,69 +666,67 @@ IvGL::shadowed_text (float x, float y, float z, const std::string &s,
 
 
 static int
-num_channels (int current_channel, int nchannels, ImageViewer::COLOR_MODE color_mode)
+num_channels(int current_channel, int nchannels,
+             ImageViewer::COLOR_MODE color_mode)
 {
     switch (color_mode) {
-    case ImageViewer::RGBA:
-        return clamp (nchannels-current_channel, 0, 4);
+    case ImageViewer::RGBA: return clamp(nchannels - current_channel, 0, 4);
     case ImageViewer::RGB:
     case ImageViewer::LUMINANCE:
-        return clamp (nchannels-current_channel, 0, 3);
+        return clamp(nchannels - current_channel, 0, 3);
         break;
     case ImageViewer::SINGLE_CHANNEL:
-    case ImageViewer::HEATMAP:
-        return 1;
-    default:
-        return nchannels;
+    case ImageViewer::HEATMAP: return 1;
+    default: return nchannels;
     }
 }
 
 
 
 void
-IvGL::paint_pixelview ()
+IvGL::paint_pixelview()
 {
-    IvImage *img = m_current_image;
-    const ImageSpec &spec (img->spec());
+    IvImage* img = m_current_image;
+    const ImageSpec& spec(img->spec());
 
     // (xw,yw) are the window coordinates of the mouse.
     int xw, yw;
-    get_focus_window_pixel (xw, yw);
+    get_focus_window_pixel(xw, yw);
 
     // (xp,yp) are the image-space [0..res-1] position of the mouse.
     int xp, yp;
-    get_focus_image_pixel (xp, yp);
+    get_focus_image_pixel(xp, yp);
 
-    glPushMatrix ();
-    glLoadIdentity ();
+    glPushMatrix();
+    glLoadIdentity();
     // Transform is now same as the main GL viewport -- window pixels as
     // units, with (0,0) at the center of the visible window.
 
-    glTranslatef (0, 0, -1);
+    glTranslatef(0, 0, -1);
     // Pushed away from the camera 1 unit.  This makes the pixel view
     // elements closer to the camera than the main view.
 
     if (m_viewer.pixelviewFollowsMouse()) {
         // Display closeup overtop mouse -- translate the coordinate system
         // so that it is centered at the mouse position.
-        glTranslatef ( xw - width()/2  + closeupsize/2 + 4,
-                      -yw + height()/2 - closeupsize/2 - 4, 0);
+        glTranslatef(xw - width() / 2 + closeupsize / 2 + 4,
+                     -yw + height() / 2 - closeupsize / 2 - 4, 0);
     } else {
         // Display closeup in corner -- translate the coordinate system so that
         // it is centered near the corner of the window.
         if (m_pixelview_left_corner) {
-            glTranslatef (closeupsize * 0.5f + 5 - width () / 2,
-                          -closeupsize * 0.5f - 5 + height () / 2, 0);
+            glTranslatef(closeupsize * 0.5f + 5 - width() / 2,
+                         -closeupsize * 0.5f - 5 + height() / 2, 0);
             // If the mouse cursor is over the pixelview closeup when it's on
             // the upper left, switch to the upper right
-            if ((xw < closeupsize + 5)  &&  yw < (closeupsize + 5))
+            if ((xw < closeupsize + 5) && yw < (closeupsize + 5))
                 m_pixelview_left_corner = false;
         } else {
-            glTranslatef (-closeupsize * 0.5f - 5 + width () / 2,
-                          -closeupsize * 0.5f - 5 + height () / 2, 0);
+            glTranslatef(-closeupsize * 0.5f - 5 + width() / 2,
+                         -closeupsize * 0.5f - 5 + height() / 2, 0);
             // If the mouse cursor is over the pixelview closeup when it's on
             // the upper right, switch to the upper left
-            if (xw > (width() - closeupsize - 5)  &&  yw < (closeupsize + 5))
+            if (xw > (width() - closeupsize - 5) && yw < (closeupsize + 5))
                 m_pixelview_left_corner = true;
         }
     }
@@ -729,35 +735,37 @@ IvGL::paint_pixelview ()
     // window is going to appear.  All other coordinates from here on
     // (in this procedure) should be relative to the closeup window center.
 
-    glPushAttrib (GL_ENABLE_BIT | GL_TEXTURE_BIT);
-    useshader (closeuptexsize, closeuptexsize, true);
+    glPushAttrib(GL_ENABLE_BIT | GL_TEXTURE_BIT);
+    useshader(closeuptexsize, closeuptexsize, true);
 
-    float scale_x = 1.0f;
-    float scale_y = 1.0f;
-    float rotate_z= 0.0f;
-    float real_xp = xp;
-    float real_yp = yp;
-    handle_orientation (img->orientation(), spec.width, 
-                        spec.height, scale_x, scale_y, rotate_z, 
-                        real_xp, real_yp, true);
+    float scale_x  = 1.0f;
+    float scale_y  = 1.0f;
+    float rotate_z = 0.0f;
+    float real_xp  = xp;
+    float real_yp  = yp;
+    handle_orientation(img->orientation(), spec.width, spec.height, scale_x,
+                       scale_y, rotate_z, real_xp, real_yp, true);
 
     float smin = 0;
     float tmin = 0;
     float smax = 1.0f;
     float tmax = 1.0f;
-    if (xp >= 0 && xp < img->oriented_width() && yp >= 0 && yp < img->oriented_height()) {
+    if (xp >= 0 && xp < img->oriented_width() && yp >= 0
+        && yp < img->oriented_height()) {
         // Keep the view within ncloseuppixels pixels.
-        int xpp = clamp<int> (real_xp, ncloseuppixels/2, spec.width - ncloseuppixels/2 - 1);
-        int ypp = clamp<int> (real_yp, ncloseuppixels/2, spec.height - ncloseuppixels/2 - 1);
+        int xpp = clamp<int>(real_xp, ncloseuppixels / 2,
+                             spec.width - ncloseuppixels / 2 - 1);
+        int ypp = clamp<int>(real_yp, ncloseuppixels / 2,
+                             spec.height - ncloseuppixels / 2 - 1);
         // Calculate patch of the image to use for the pixelview.
-        int xbegin = std::max (xpp - ncloseuppixels/2, 0);
-        int ybegin = std::max (ypp - ncloseuppixels/2, 0);
-        int xend   = std::min (xpp + ncloseuppixels/2+1, spec.width);
-        int yend   = std::min (ypp + ncloseuppixels/2+1, spec.height);
-        smin = 0;
-        tmin = 0;
-        smax = float (xend-xbegin)/closeuptexsize;
-        tmax = float (yend-ybegin)/closeuptexsize;
+        int xbegin = std::max(xpp - ncloseuppixels / 2, 0);
+        int ybegin = std::max(ypp - ncloseuppixels / 2, 0);
+        int xend   = std::min(xpp + ncloseuppixels / 2 + 1, spec.width);
+        int yend   = std::min(ypp + ncloseuppixels / 2 + 1, spec.height);
+        smin       = 0;
+        tmin       = 0;
+        smax       = float(xend - xbegin) / closeuptexsize;
+        tmax       = float(yend - ybegin) / closeuptexsize;
         //std::cerr << "img (" << xbegin << "," << ybegin << ") - (" << xend << "," << yend << ")\n";
         //std::cerr << "tex (" << smin << "," << tmin << ") - (" << smax << "," << tmax << ")\n";
         //std::cerr << "center mouse (" << xp << "," << yp << "), real (" << real_xp << "," << real_yp << ")\n";
@@ -766,53 +774,51 @@ IvGL::paint_pixelview ()
         // For simplicity, we don't support more than 4 channels without shaders
         // (yet).
         if (m_use_shaders) {
-            nchannels = num_channels(m_viewer.current_channel(), nchannels, m_viewer.current_color_mode());
+            nchannels = num_channels(m_viewer.current_channel(), nchannels,
+                                     m_viewer.current_color_mode());
         }
 
-        void *zoombuffer = alloca ((xend-xbegin)*(yend-ybegin)*nchannels*spec.channel_bytes());
-        if (! m_use_shaders) {
-            img->get_pixels (ROI (spec.x + xbegin, spec.x + xend,
-                                  spec.y + ybegin, spec.y + yend),
-                             spec.format, zoombuffer);
+        void* zoombuffer = alloca((xend - xbegin) * (yend - ybegin) * nchannels
+                                  * spec.channel_bytes());
+        if (!m_use_shaders) {
+            img->get_pixels(ROI(spec.x + xbegin, spec.x + xend, spec.y + ybegin,
+                                spec.y + yend),
+                            spec.format, zoombuffer);
         } else {
-            ROI roi (spec.x + xbegin, spec.x + xend,
-                     spec.y + ybegin, spec.y + yend,
-                     0, 1,
-                     m_viewer.current_channel(), m_viewer.current_channel()+nchannels);
-            img->get_pixels (roi, spec.format, zoombuffer);
+            ROI roi(spec.x + xbegin, spec.x + xend, spec.y + ybegin,
+                    spec.y + yend, 0, 1, m_viewer.current_channel(),
+                    m_viewer.current_channel() + nchannels);
+            img->get_pixels(roi, spec.format, zoombuffer);
         }
 
         GLenum glformat, gltype, glinternalformat;
-        typespec_to_opengl (spec, nchannels, gltype, glformat, glinternalformat);
+        typespec_to_opengl(spec, nchannels, gltype, glformat, glinternalformat);
         // Use pixelview's own texture, and upload the corresponding image patch.
-        glBindBuffer (GL_PIXEL_UNPACK_BUFFER, 0);
-        glBindTexture (GL_TEXTURE_2D, m_pixelview_tex);
-        glTexSubImage2D (GL_TEXTURE_2D, 0, 0, 0, 
-                         xend-xbegin, yend-ybegin,
-                         glformat, gltype,
-                         zoombuffer);
-        GLERRPRINT ("After tsi2d");
+        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+        glBindTexture(GL_TEXTURE_2D, m_pixelview_tex);
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, xend - xbegin, yend - ybegin,
+                        glformat, gltype, zoombuffer);
+        GLERRPRINT("After tsi2d");
     } else {
         smin = -1;
         smax = -1;
-        glDisable (GL_TEXTURE_2D);
-        glColor3f (0.1f,0.1f,0.1f);
+        glDisable(GL_TEXTURE_2D);
+        glColor3f(0.1f, 0.1f, 0.1f);
     }
-    if (! m_use_shaders) {
-        glDisable (GL_BLEND);
+    if (!m_use_shaders) {
+        glDisable(GL_BLEND);
     }
 
-    glPushMatrix ();
-    glScalef (1, -1, 1); // Run y from top to bottom.
-    glScalef (scale_x, scale_y, 1);
-    glRotatef (rotate_z, 0, 0, 1);
+    glPushMatrix();
+    glScalef(1, -1, 1);  // Run y from top to bottom.
+    glScalef(scale_x, scale_y, 1);
+    glRotatef(rotate_z, 0, 0, 1);
 
     // This square is the closeup window itself
-    gl_rect (-0.5f*closeupsize, -0.5f*closeupsize,
-            0.5f*closeupsize, 0.5f*closeupsize, 0,
-            smin, tmin, smax, tmax);
-    glPopMatrix ();
-    glPopAttrib ();
+    gl_rect(-0.5f * closeupsize, -0.5f * closeupsize, 0.5f * closeupsize,
+            0.5f * closeupsize, 0, smin, tmin, smax, tmax);
+    glPopMatrix();
+    glPopAttrib();
 
     // Draw a second window, slightly behind the closeup window, as a
     // backdrop.  It's partially transparent, having the effect of
@@ -822,23 +828,23 @@ IvGL::paint_pixelview ()
     // where the text will be printed, so it is very readable.
     const int yspacing = 18;
 
-    glPushAttrib (GL_ENABLE_BIT | GL_CURRENT_BIT);
-    glDisable (GL_TEXTURE_2D);
+    glPushAttrib(GL_ENABLE_BIT | GL_CURRENT_BIT);
+    glDisable(GL_TEXTURE_2D);
     if (m_use_shaders) {
         // Disable shaders for this.
-        glUseProgram (0);
+        glUseProgram(0);
     }
     float extraspace = yspacing * (1 + spec.nchannels) + 4;
-    glColor4f (0.1f, 0.1f, 0.1f, 0.5f);
-    gl_rect (-0.5f*closeupsize-2, 0.5f*closeupsize+2,
-             0.5f*closeupsize+2, -0.5f*closeupsize - extraspace, -0.1f);
+    glColor4f(0.1f, 0.1f, 0.1f, 0.5f);
+    gl_rect(-0.5f * closeupsize - 2, 0.5f * closeupsize + 2,
+            0.5f * closeupsize + 2, -0.5f * closeupsize - extraspace, -0.1f);
 
     if (1 /*xp >= 0 && xp < img->oriented_width() && yp >= 0 && yp < img->oriented_height()*/) {
         // Now we print text giving the mouse coordinates and the numerical
         // values of the pixel that the mouse is over.
         QFont font;
-        font.setFixedPitch (true);
-        float *fpixel = (float *) alloca (spec.nchannels*sizeof(float));
+        font.setFixedPitch(true);
+        float* fpixel = (float*)alloca(spec.nchannels * sizeof(float));
         int textx, texty;
         if (m_viewer.pixelviewFollowsMouse()) {
             textx = xw + 8;
@@ -848,182 +854,184 @@ IvGL::paint_pixelview ()
                 textx = 9;
                 texty = closeupsize + yspacing;
             } else {
-                textx = width () - closeupsize - 1;
+                textx = width() - closeupsize - 1;
                 texty = closeupsize + yspacing;
             }
         }
-        std::string s = Strutil::format ("(%d, %d)", (int) real_xp+spec.x, (int) real_yp+spec.y);
-        shadowed_text (textx, texty, 0.0f, s, font);
+        std::string s = Strutil::format("(%d, %d)", (int)real_xp + spec.x,
+                                        (int)real_yp + spec.y);
+        shadowed_text(textx, texty, 0.0f, s, font);
         texty += yspacing;
-        img->getpixel ((int) real_xp+spec.x, (int) real_yp+spec.y, fpixel);
-        for (int i = 0;  i < spec.nchannels;  ++i) {
+        img->getpixel((int)real_xp + spec.x, (int)real_yp + spec.y, fpixel);
+        for (int i = 0; i < spec.nchannels; ++i) {
             switch (spec.format.basetype) {
-            case TypeDesc::UINT8 : {
-                ImageBuf::ConstIterator<unsigned char,unsigned char> p (*img, (int) real_xp+spec.x, (int) real_yp+spec.y);
-                s = Strutil::format ("%s: %3d  (%5.3f)",
-                                     spec.channelnames[i].c_str(),
-                                     (int)(p[i]), fpixel[i]);
-                }
-                break;
-            case TypeDesc::UINT16 : {
-                ImageBuf::ConstIterator<unsigned short,unsigned short> p (*img, (int) real_xp+spec.x, (int) real_yp+spec.y);
-                s = Strutil::format ("%s: %3d  (%5.3f)",
-                                     spec.channelnames[i].c_str(),
-                                     (int)(p[i]), fpixel[i]);
-                }
-                break;
+            case TypeDesc::UINT8: {
+                ImageBuf::ConstIterator<unsigned char, unsigned char> p(
+                    *img, (int)real_xp + spec.x, (int)real_yp + spec.y);
+                s = Strutil::format("%s: %3d  (%5.3f)",
+                                    spec.channelnames[i].c_str(), (int)(p[i]),
+                                    fpixel[i]);
+            } break;
+            case TypeDesc::UINT16: {
+                ImageBuf::ConstIterator<unsigned short, unsigned short> p(
+                    *img, (int)real_xp + spec.x, (int)real_yp + spec.y);
+                s = Strutil::format("%s: %3d  (%5.3f)",
+                                    spec.channelnames[i].c_str(), (int)(p[i]),
+                                    fpixel[i]);
+            } break;
             default:  // everything else, treat as float
-                s = Strutil::format ("%s: %5.3f",
-                                     spec.channelnames[i].c_str(), fpixel[i]);
+                s = Strutil::format("%s: %5.3f", spec.channelnames[i].c_str(),
+                                    fpixel[i]);
             }
-            shadowed_text (textx, texty, 0.0f, s, font);
+            shadowed_text(textx, texty, 0.0f, s, font);
             texty += yspacing;
         }
     }
 
-    glPopAttrib ();
-    glPopMatrix ();
+    glPopAttrib();
+    glPopMatrix();
 }
 
 
 
 void
-IvGL::useshader (int tex_width, int tex_height, bool pixelview)
+IvGL::useshader(int tex_width, int tex_height, bool pixelview)
 {
-    IvImage *img = m_viewer.cur();
-    if (! img)
+    IvImage* img = m_viewer.cur();
+    if (!img)
         return;
 
     if (!m_use_shaders) {
-        glTexEnvf (GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
+        glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
         for (auto&& tb : m_texbufs) {
-            glBindTexture (GL_TEXTURE_2D, tb.tex_object);
-            if (m_viewer.linearInterpolation ()) {
-                glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-                glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-            }
-            else {
-                glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-                glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+            glBindTexture(GL_TEXTURE_2D, tb.tex_object);
+            if (m_viewer.linearInterpolation()) {
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+                                GL_LINEAR);
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
+                                GL_LINEAR);
+            } else {
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+                                GL_NEAREST);
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
+                                GL_NEAREST);
             }
         }
         return;
     }
 
-    const ImageSpec &spec (img->spec());
+    const ImageSpec& spec(img->spec());
 
-    glUseProgram (m_shader_program);
-    GLERRPRINT ("After use program");
+    glUseProgram(m_shader_program);
+    GLERRPRINT("After use program");
 
     GLint loc;
 
-    loc = glGetUniformLocation (m_shader_program, "startchannel");
-    if (m_viewer.current_channel()>=spec.nchannels) {
-        glUniform1i (loc, -1);
+    loc = glGetUniformLocation(m_shader_program, "startchannel");
+    if (m_viewer.current_channel() >= spec.nchannels) {
+        glUniform1i(loc, -1);
         return;
     }
-    glUniform1i (loc, 0);
+    glUniform1i(loc, 0);
 
-    loc = glGetUniformLocation (m_shader_program, "imgtex");
+    loc = glGetUniformLocation(m_shader_program, "imgtex");
     // This is the texture unit, not the texture object
-    glUniform1i (loc, 0);
+    glUniform1i(loc, 0);
 
-    loc = glGetUniformLocation (m_shader_program, "gain");
+    loc = glGetUniformLocation(m_shader_program, "gain");
 
-    float gain = powf (2.0, img->exposure ());
-    glUniform1f (loc, gain);
+    float gain = powf(2.0, img->exposure());
+    glUniform1f(loc, gain);
 
-    loc = glGetUniformLocation (m_shader_program, "gamma");
-    glUniform1f (loc, img->gamma ());
+    loc = glGetUniformLocation(m_shader_program, "gamma");
+    glUniform1f(loc, img->gamma());
 
-    loc = glGetUniformLocation (m_shader_program, "colormode");
-    glUniform1i (loc, m_viewer.current_color_mode());
+    loc = glGetUniformLocation(m_shader_program, "colormode");
+    glUniform1i(loc, m_viewer.current_color_mode());
 
-    loc = glGetUniformLocation (m_shader_program, "imgchannels");
-    glUniform1i (loc, spec.nchannels);
+    loc = glGetUniformLocation(m_shader_program, "imgchannels");
+    glUniform1i(loc, spec.nchannels);
 
-    loc = glGetUniformLocation (m_shader_program, "pixelview");
-    glUniform1i (loc, pixelview);
+    loc = glGetUniformLocation(m_shader_program, "pixelview");
+    glUniform1i(loc, pixelview);
 
-    loc = glGetUniformLocation (m_shader_program, "linearinterp");
-    glUniform1i (loc, m_viewer.linearInterpolation ());
+    loc = glGetUniformLocation(m_shader_program, "linearinterp");
+    glUniform1i(loc, m_viewer.linearInterpolation());
 
-    loc = glGetUniformLocation (m_shader_program, "width");
-    glUniform1i (loc, tex_width);
+    loc = glGetUniformLocation(m_shader_program, "width");
+    glUniform1i(loc, tex_width);
 
-    loc = glGetUniformLocation (m_shader_program, "height");
-    glUniform1i (loc, tex_height);
-    GLERRPRINT ("After settting uniforms");
+    loc = glGetUniformLocation(m_shader_program, "height");
+    glUniform1i(loc, tex_height);
+    GLERRPRINT("After settting uniforms");
 }
 
 
 
 void
-IvGL::update ()
+IvGL::update()
 {
     //std::cerr << "update image\n";
-    
+
     IvImage* img = m_viewer.cur();
-    if (! img) {
+    if (!img) {
         m_current_image = NULL;
         return;
     }
 
-    const ImageSpec &spec (img->spec());
+    const ImageSpec& spec(img->spec());
 
     int nchannels = img->nchannels();
     // For simplicity, we don't support more than 4 channels without shaders
     // (yet).
     if (m_use_shaders) {
-        nchannels = num_channels(m_viewer.current_channel(), nchannels, m_viewer.current_color_mode());
+        nchannels = num_channels(m_viewer.current_channel(), nchannels,
+                                 m_viewer.current_color_mode());
     }
 
-    if (! nchannels)
-        return; // Don't bother, the shader will show blackness for us.
+    if (!nchannels)
+        return;  // Don't bother, the shader will show blackness for us.
 
-    GLenum gltype = GL_UNSIGNED_BYTE;
-    GLenum glformat = GL_RGB;
+    GLenum gltype           = GL_UNSIGNED_BYTE;
+    GLenum glformat         = GL_RGB;
     GLenum glinternalformat = GL_RGB;
-    typespec_to_opengl (spec, nchannels, gltype, glformat, glinternalformat);
+    typespec_to_opengl(spec, nchannels, gltype, glformat, glinternalformat);
 
-    m_texture_width = clamp (pow2roundup(spec.width), 1, m_max_texture_size);
-    m_texture_height= clamp (pow2roundup(spec.height), 1, m_max_texture_size);
+    m_texture_width  = clamp(pow2roundup(spec.width), 1, m_max_texture_size);
+    m_texture_height = clamp(pow2roundup(spec.height), 1, m_max_texture_size);
 
     glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
 
     for (auto&& tb : m_texbufs) {
-        tb.width = 0;
-        tb.height= 0;
-        glBindTexture (GL_TEXTURE_2D, tb.tex_object);
-        glTexImage2D (GL_TEXTURE_2D, 0 /*mip level*/,
-                      glinternalformat,
-                      m_texture_width,  m_texture_height,
-                      0 /*border width*/,
-                      glformat, gltype, 
-                      NULL /*data*/);
-        GLERRPRINT ("Setting up texture");
+        tb.width  = 0;
+        tb.height = 0;
+        glBindTexture(GL_TEXTURE_2D, tb.tex_object);
+        glTexImage2D(GL_TEXTURE_2D, 0 /*mip level*/, glinternalformat,
+                     m_texture_width, m_texture_height, 0 /*border width*/,
+                     glformat, gltype, NULL /*data*/);
+        GLERRPRINT("Setting up texture");
     }
 
     // Set the right type for the texture used for pixelview.
-    glBindTexture (GL_TEXTURE_2D, m_pixelview_tex);
-    glTexImage2D (GL_TEXTURE_2D, 0, glinternalformat,
-                  closeuptexsize, closeuptexsize, 0,
-                  glformat, gltype, NULL);
-    GLERRPRINT ("Setting up pixelview texture");
+    glBindTexture(GL_TEXTURE_2D, m_pixelview_tex);
+    glTexImage2D(GL_TEXTURE_2D, 0, glinternalformat, closeuptexsize,
+                 closeuptexsize, 0, glformat, gltype, NULL);
+    GLERRPRINT("Setting up pixelview texture");
 
     // Resize the buffer at once, rather than create one each drawing.
-    m_tex_buffer.resize (m_texture_width * m_texture_height * nchannels * spec.channel_bytes());
+    m_tex_buffer.resize(m_texture_width * m_texture_height * nchannels
+                        * spec.channel_bytes());
     m_current_image = img;
 }
 
 
 
 void
-IvGL::view (float xcenter, float ycenter, float zoom, bool redraw)
+IvGL::view(float xcenter, float ycenter, float zoom, bool redraw)
 {
     m_centerx = xcenter;
     m_centery = ycenter;
-    m_zoom = zoom;
+    m_zoom    = zoom;
 
     if (redraw)
         parent_t::update();
@@ -1032,31 +1040,31 @@ IvGL::view (float xcenter, float ycenter, float zoom, bool redraw)
 
 
 void
-IvGL::zoom (float newzoom, bool redraw)
+IvGL::zoom(float newzoom, bool redraw)
 {
-    view (m_centerx, m_centery, newzoom, redraw);
+    view(m_centerx, m_centery, newzoom, redraw);
 }
 
 
 
 void
-IvGL::center (float x, float y, bool redraw)
+IvGL::center(float x, float y, bool redraw)
 {
-    view (x, y, m_viewer.zoom(), redraw);
+    view(x, y, m_viewer.zoom(), redraw);
 }
 
 
 
 void
-IvGL::pan (float dx, float dy)
+IvGL::pan(float dx, float dy)
 {
-    center (m_centerx + dx, m_centery + dy);
+    center(m_centerx + dx, m_centery + dy);
 }
 
 
 
 void
-IvGL::remember_mouse (const QPoint &pos)
+IvGL::remember_mouse(const QPoint& pos)
 {
     m_mousex = pos.x();
     m_mousey = pos.y();
@@ -1065,10 +1073,10 @@ IvGL::remember_mouse (const QPoint &pos)
 
 
 void
-IvGL::clamp_view_to_window ()
+IvGL::clamp_view_to_window()
 {
-    IvImage *img = m_current_image;
-    if (! img)
+    IvImage* img = m_current_image;
+    if (!img)
         return;
     int w = width(), h = height();
     float zoomedwidth  = m_zoom * img->oriented_full_width();
@@ -1084,107 +1092,108 @@ IvGL::clamp_view_to_window ()
     std::cerr << "Bottom right (pixel coords) is " << right << ", " << bottom << "\n";
 #endif
 
-    int xmin = std::min (img->oriented_x(), img->oriented_full_x());
-    int xmax = std::max (img->oriented_x()+img->oriented_width(),
-                         img->oriented_full_x()+img->oriented_full_width());
-    int ymin = std::min (img->oriented_y(), img->oriented_full_y());
-    int ymax = std::max (img->oriented_y()+img->oriented_height(),
-                         img->oriented_full_y()+img->oriented_full_height());
+    int xmin = std::min(img->oriented_x(), img->oriented_full_x());
+    int xmax = std::max(img->oriented_x() + img->oriented_width(),
+                        img->oriented_full_x() + img->oriented_full_width());
+    int ymin = std::min(img->oriented_y(), img->oriented_full_y());
+    int ymax = std::max(img->oriented_y() + img->oriented_height(),
+                        img->oriented_full_y() + img->oriented_full_height());
 
     // Don't let us scroll off the edges
     if (zoomedwidth >= w) {
-        m_centerx = Imath::clamp (m_centerx, xmin + 0.5f*w/m_zoom, xmax - 0.5f*w/m_zoom);
+        m_centerx = Imath::clamp(m_centerx, xmin + 0.5f * w / m_zoom,
+                                 xmax - 0.5f * w / m_zoom);
     } else {
-        m_centerx = img->oriented_full_x() + img->oriented_full_width()/2;
+        m_centerx = img->oriented_full_x() + img->oriented_full_width() / 2;
     }
 
     if (zoomedheight >= h) {
-        m_centery = Imath::clamp (m_centery, ymin + 0.5f*h/m_zoom, ymax - 0.5f*h/m_zoom);
+        m_centery = Imath::clamp(m_centery, ymin + 0.5f * h / m_zoom,
+                                 ymax - 0.5f * h / m_zoom);
     } else {
-        m_centery = img->oriented_full_y() + img->oriented_full_height()/2;
+        m_centery = img->oriented_full_y() + img->oriented_full_height() / 2;
     }
 }
 
 
 
 void
-IvGL::mousePressEvent (QMouseEvent *event)
+IvGL::mousePressEvent(QMouseEvent* event)
 {
-    remember_mouse (event->pos());
-    int mousemode = m_viewer.mouseModeComboBox->currentIndex ();
-    bool Alt = (event->modifiers() & Qt::AltModifier);
+    remember_mouse(event->pos());
+    int mousemode = m_viewer.mouseModeComboBox->currentIndex();
+    bool Alt      = (event->modifiers() & Qt::AltModifier);
     m_drag_button = event->button();
-    if (! m_mouse_activation) {
+    if (!m_mouse_activation) {
         switch (event->button()) {
-        case Qt::LeftButton :
+        case Qt::LeftButton:
             if (mousemode == ImageViewer::MouseModeZoom && !Alt)
                 m_viewer.zoomIn();
             else
                 m_dragging = true;
             return;
-        case Qt::RightButton :
+        case Qt::RightButton:
             if (mousemode == ImageViewer::MouseModeZoom && !Alt)
                 m_viewer.zoomOut();
             else
                 m_dragging = true;
             return;
-        case Qt::MidButton :
+        case Qt::MidButton:
             m_dragging = true;
             // FIXME: should this be return rather than break?
             break;
-        default:
-            break;
+        default: break;
         }
     } else
         m_mouse_activation = false;
-    parent_t::mousePressEvent (event);
+    parent_t::mousePressEvent(event);
 }
 
 
 
 void
-IvGL::mouseReleaseEvent (QMouseEvent *event)
+IvGL::mouseReleaseEvent(QMouseEvent* event)
 {
-    remember_mouse (event->pos());
+    remember_mouse(event->pos());
     m_drag_button = Qt::NoButton;
-    m_dragging = false;
-    parent_t::mouseReleaseEvent (event);
+    m_dragging    = false;
+    parent_t::mouseReleaseEvent(event);
 }
 
 
 
 void
-IvGL::mouseMoveEvent (QMouseEvent *event)
+IvGL::mouseMoveEvent(QMouseEvent* event)
 {
     QPoint pos = event->pos();
     // FIXME - there's probably a better Qt way than tracking the button
     // myself.
-    bool Alt = (event->modifiers() & Qt::AltModifier);
-    int mousemode = m_viewer.mouseModeComboBox->currentIndex ();
+    bool Alt      = (event->modifiers() & Qt::AltModifier);
+    int mousemode = m_viewer.mouseModeComboBox->currentIndex();
     bool do_pan = false, do_zoom = false, do_wipe = false;
     bool do_select = false, do_annotate = false;
     switch (mousemode) {
-    case ImageViewer::MouseModeZoom :
-        if ((m_drag_button == Qt::MidButton) ||
-            (m_drag_button == Qt::LeftButton && Alt)) {
+    case ImageViewer::MouseModeZoom:
+        if ((m_drag_button == Qt::MidButton)
+            || (m_drag_button == Qt::LeftButton && Alt)) {
             do_pan = true;
         } else if (m_drag_button == Qt::RightButton && Alt) {
             do_zoom = true;
         }
         break;
-    case ImageViewer::MouseModePan :
+    case ImageViewer::MouseModePan:
         if (m_drag_button != Qt::NoButton)
             do_pan = true;
         break;
-    case ImageViewer::MouseModeWipe :
+    case ImageViewer::MouseModeWipe:
         if (m_drag_button != Qt::NoButton)
             do_wipe = true;
         break;
-    case ImageViewer::MouseModeSelect :
+    case ImageViewer::MouseModeSelect:
         if (m_drag_button != Qt::NoButton)
             do_select = true;
         break;
-    case ImageViewer::MouseModeAnnotate :
+    case ImageViewer::MouseModeAnnotate:
         if (m_drag_button != Qt::NoButton)
             do_annotate = true;
         break;
@@ -1192,14 +1201,14 @@ IvGL::mouseMoveEvent (QMouseEvent *event)
     if (do_pan) {
         float dx = (pos.x() - m_mousex) / m_zoom;
         float dy = (pos.y() - m_mousey) / m_zoom;
-        pan (-dx, -dy);
+        pan(-dx, -dy);
     } else if (do_zoom) {
         float dx = (pos.x() - m_mousex);
         float dy = (pos.y() - m_mousey);
-        float z = m_viewer.zoom() * (1.0 + 0.005 * (dx + dy));
-        z = Imath::clamp (z, 0.01f, 256.0f);
-        m_viewer.zoom (z);
-        m_viewer.fitImageToWindowAct->setChecked (false);
+        float z  = m_viewer.zoom() * (1.0 + 0.005 * (dx + dy));
+        z        = Imath::clamp(z, 0.01f, 256.0f);
+        m_viewer.zoom(z);
+        m_viewer.fitImageToWindowAct->setChecked(false);
     } else if (do_wipe) {
         // FIXME -- unimplemented
     } else if (do_select) {
@@ -1207,23 +1216,23 @@ IvGL::mouseMoveEvent (QMouseEvent *event)
     } else if (do_annotate) {
         // FIXME -- unimplemented
     }
-    remember_mouse (pos);
+    remember_mouse(pos);
     if (m_viewer.pixelviewOn())
         parent_t::update();
-    parent_t::mouseMoveEvent (event);
+    parent_t::mouseMoveEvent(event);
 }
 
 
 void
-IvGL::wheelEvent (QWheelEvent *event)
+IvGL::wheelEvent(QWheelEvent* event)
 {
     m_mouse_activation = false;
     if (event->orientation() == Qt::Vertical) {
         // TODO: Update this to keep the zoom centered on the event .x, .y
         float oldzoom = m_viewer.zoom();
-        float newzoom = (event->delta()>0) ? \
-            pow2roundupf (oldzoom) : pow2rounddownf (oldzoom);
-        m_viewer.zoom (newzoom);
+        float newzoom = (event->delta() > 0) ? pow2roundupf(oldzoom)
+                                             : pow2rounddownf(oldzoom);
+        m_viewer.zoom(newzoom);
         event->accept();
     }
 }
@@ -1231,7 +1240,7 @@ IvGL::wheelEvent (QWheelEvent *event)
 
 
 void
-IvGL::focusOutEvent (QFocusEvent*)
+IvGL::focusOutEvent(QFocusEvent*)
 {
     m_mouse_activation = true;
 }
@@ -1239,7 +1248,7 @@ IvGL::focusOutEvent (QFocusEvent*)
 
 
 void
-IvGL::get_focus_window_pixel (int &x, int &y)
+IvGL::get_focus_window_pixel(int& x, int& y)
 {
     x = m_mousex;
     y = m_mousey;
@@ -1248,30 +1257,30 @@ IvGL::get_focus_window_pixel (int &x, int &y)
 
 
 void
-IvGL::get_focus_image_pixel (int &x, int &y)
+IvGL::get_focus_image_pixel(int& x, int& y)
 {
     // w,h are the dimensions of the visible window, in pixels
     int w = width(), h = height();
     float z = m_zoom;
-    // left,top,right,bottom are the borders of the visible window, in 
+    // left,top,right,bottom are the borders of the visible window, in
     // pixel coordinates
-    float left    = m_centerx - 0.5 * w / z;
-    float top     = m_centery - 0.5 * h / z;
-    float right   = m_centerx + 0.5 * w / z;
-    float bottom  = m_centery + 0.5 * h / z;
+    float left   = m_centerx - 0.5 * w / z;
+    float top    = m_centery - 0.5 * h / z;
+    float right  = m_centerx + 0.5 * w / z;
+    float bottom = m_centery + 0.5 * h / z;
     // normx,normy are the position of the mouse, in normalized (i.e. [0..1])
     // visible window coordinates.
     float normx = (float)(m_mousex + 0.5f) / w;
     float normy = (float)(m_mousey + 0.5f) / h;
     // imgx,imgy are the position of the mouse, in pixel coordinates
-    float imgx = Imath::lerp (left, right, normx);
-    float imgy = Imath::lerp (top, bottom, normy);
+    float imgx = Imath::lerp(left, right, normx);
+    float imgy = Imath::lerp(top, bottom, normy);
     // So finally x,y are the coordinates of the image pixel (on [0,res-1])
     // underneath the mouse cursor.
     //FIXME: Shouldn't this take image rotation into account?
-    x = (int) floorf (imgx);
-    y = (int) floorf (imgy);
-    
+    x = (int)floorf(imgx);
+    y = (int)floorf(imgy);
+
 #if 0
     std::cerr << "get_focus_pixel\n";
     std::cerr << "    mouse window pixel coords " << m_mousex << ' ' << m_mousey << "\n";
@@ -1286,13 +1295,13 @@ IvGL::get_focus_image_pixel (int &x, int &y)
 
 
 void
-IvGL::print_shader_log (std::ostream& out, const GLuint shader_id)
+IvGL::print_shader_log(std::ostream& out, const GLuint shader_id)
 {
     GLint size = 0;
-    glGetShaderiv (shader_id, GL_INFO_LOG_LENGTH, &size);
-    if (size > 0) {    
+    glGetShaderiv(shader_id, GL_INFO_LOG_LENGTH, &size);
+    if (size > 0) {
         GLchar* log = new GLchar[size];
-        glGetShaderInfoLog (shader_id, size, NULL, log);
+        glGetShaderInfoLog(shader_id, size, NULL, log);
         out << "compile log:\n" << log << "---\n";
         delete[] log;
     }
@@ -1301,28 +1310,28 @@ IvGL::print_shader_log (std::ostream& out, const GLuint shader_id)
 
 
 void
-IvGL::check_gl_extensions (void)
+IvGL::check_gl_extensions(void)
 {
     m_use_shaders = hasOpenGLFeature(QOpenGLFunctions::Shaders);
 
     QOpenGLContext* context = QOpenGLContext::currentContext();
-    QSurfaceFormat format = context->format();
+    QSurfaceFormat format   = context->format();
     bool isGLES = format.renderableType() == QSurfaceFormat::OpenGLES;
 
-    m_use_srgb = (isGLES && format.majorVersion() >= 3) ||
-                 (!isGLES && format.version() >= qMakePair(2, 1)) ||
-                 context->hasExtension("GL_EXT_texture_sRGB") ||
-                 context->hasExtension("GL_EXT_sRGB");
+    m_use_srgb = (isGLES && format.majorVersion() >= 3)
+                 || (!isGLES && format.version() >= qMakePair(2, 1))
+                 || context->hasExtension("GL_EXT_texture_sRGB")
+                 || context->hasExtension("GL_EXT_sRGB");
 
-    m_use_halffloat = (!isGLES && format.version() >= qMakePair(3, 0)) ||
-                      context->hasExtension("GL_ARB_half_float_pixel") ||
-                      context->hasExtension("GL_NV_half_float_pixel") ||
-                      context->hasExtension("GL_OES_texture_half_float");
+    m_use_halffloat = (!isGLES && format.version() >= qMakePair(3, 0))
+                      || context->hasExtension("GL_ARB_half_float_pixel")
+                      || context->hasExtension("GL_NV_half_float_pixel")
+                      || context->hasExtension("GL_OES_texture_half_float");
 
-    m_use_float = (!isGLES && format.version() >= qMakePair(3, 0)) ||
-                  context->hasExtension("GL_ARB_texture_float") ||
-                  context->hasExtension("GL_ATI_texture_float") ||
-                  context->hasExtension("GL_OES_texture_float");
+    m_use_float = (!isGLES && format.version() >= qMakePair(3, 0))
+                  || context->hasExtension("GL_ARB_texture_float")
+                  || context->hasExtension("GL_ATI_texture_float")
+                  || context->hasExtension("GL_OES_texture_float");
 
     m_max_texture_size = 0;
     glGetIntegerv(GL_MAX_TEXTURE_SIZE, &m_max_texture_size);
@@ -1334,9 +1343,12 @@ IvGL::check_gl_extensions (void)
 #ifndef NDEBUG
     // Report back...
     std::cerr << "OpenGL Shading Language supported: " << m_use_shaders << "\n";
-    std::cerr << "OpenGL sRGB color space textures supported: " << m_use_srgb << "\n";
-    std::cerr << "OpenGL half-float pixels supported: " << m_use_halffloat << "\n";
-    std::cerr << "OpenGL float texture storage supported: " << m_use_float << "\n";
+    std::cerr << "OpenGL sRGB color space textures supported: " << m_use_srgb
+              << "\n";
+    std::cerr << "OpenGL half-float pixels supported: " << m_use_halffloat
+              << "\n";
+    std::cerr << "OpenGL float texture storage supported: " << m_use_float
+              << "\n";
     std::cerr << "OpenGL max texture dimension: " << m_max_texture_size << "\n";
 #endif
 }
@@ -1344,36 +1356,37 @@ IvGL::check_gl_extensions (void)
 
 
 void
-IvGL::typespec_to_opengl (const ImageSpec &spec, int nchannels, GLenum &gltype, GLenum &glformat, 
-                          GLenum &glinternalformat) const
+IvGL::typespec_to_opengl(const ImageSpec& spec, int nchannels, GLenum& gltype,
+                         GLenum& glformat, GLenum& glinternalformat) const
 {
     switch (spec.format.basetype) {
-    case TypeDesc::FLOAT  : gltype = GL_FLOAT;          break;
-    case TypeDesc::HALF   : if (m_use_halffloat) {
-                                gltype = GL_HALF_FLOAT_ARB;
-                            } else {
-                                // If we reach here then something really wrong
-                                // happened: When half-float is not supported,
-                                // the image should be loaded as UINT8 (no GLSL
-                                // support) or FLOAT (GLSL support).
-                                // See IvImage::loadCurrentImage()
-                                std::cerr << "Tried to load an unsupported half-float image.\n";
-                                gltype = GL_INVALID_ENUM;
-                            }
-                            break;
-    case TypeDesc::INT    : gltype = GL_INT;            break;
-    case TypeDesc::UINT   : gltype = GL_UNSIGNED_INT;   break;
-    case TypeDesc::INT16  : gltype = GL_SHORT;          break;
-    case TypeDesc::UINT16 : gltype = GL_UNSIGNED_SHORT; break;
-    case TypeDesc::INT8   : gltype = GL_BYTE;           break;
-    case TypeDesc::UINT8  : gltype = GL_UNSIGNED_BYTE;  break;
+    case TypeDesc::FLOAT: gltype = GL_FLOAT; break;
+    case TypeDesc::HALF:
+        if (m_use_halffloat) {
+            gltype = GL_HALF_FLOAT_ARB;
+        } else {
+            // If we reach here then something really wrong happened: When
+            // half-float is not supported, the image should be loaded as
+            // UINT8 (no GLSL support) or FLOAT (GLSL support).
+            // See IvImage::loadCurrentImage()
+            std::cerr << "Tried to load an unsupported half-float image.\n";
+            gltype = GL_INVALID_ENUM;
+        }
+        break;
+    case TypeDesc::INT: gltype = GL_INT; break;
+    case TypeDesc::UINT: gltype = GL_UNSIGNED_INT; break;
+    case TypeDesc::INT16: gltype = GL_SHORT; break;
+    case TypeDesc::UINT16: gltype = GL_UNSIGNED_SHORT; break;
+    case TypeDesc::INT8: gltype = GL_BYTE; break;
+    case TypeDesc::UINT8: gltype = GL_UNSIGNED_BYTE; break;
     default:
         gltype = GL_UNSIGNED_BYTE;  // punt
         break;
     }
 
-    bool issrgb = Strutil::iequals (spec.get_string_attribute ("oiio:ColorSpace"), "sRGB");
-    
+    bool issrgb = Strutil::iequals(spec.get_string_attribute("oiio:ColorSpace"),
+                                   "sRGB");
+
     glinternalformat = nchannels;
     if (nchannels == 1) {
         glformat = GL_LUMINANCE;
@@ -1444,7 +1457,7 @@ IvGL::typespec_to_opengl (const ImageSpec &spec, int nchannels, GLenum &gltype, 
             glinternalformat = GL_RGBA16F_ARB;
         }
     } else {
-        glformat = GL_INVALID_ENUM;
+        glformat         = GL_INVALID_ENUM;
         glinternalformat = GL_INVALID_ENUM;
     }
 }
@@ -1452,13 +1465,14 @@ IvGL::typespec_to_opengl (const ImageSpec &spec, int nchannels, GLenum &gltype, 
 
 
 void
-IvGL::load_texture (int x, int y, int width, int height, float percent)
+IvGL::load_texture(int x, int y, int width, int height, float percent)
 {
-    const ImageSpec &spec = m_current_image->spec ();
+    const ImageSpec& spec = m_current_image->spec();
     // Find if this has already been loaded.
     for (auto&& tb : m_texbufs) {
-        if (tb.x == x && tb.y == y && tb.width >= width && tb.height >= height) {
-            glBindTexture (GL_TEXTURE_2D, tb.tex_object);
+        if (tb.x == x && tb.y == y && tb.width >= width
+            && tb.height >= height) {
+            glBindTexture(GL_TEXTURE_2D, tb.tex_object);
             return;
         }
     }
@@ -1468,66 +1482,60 @@ IvGL::load_texture (int x, int y, int width, int height, float percent)
     // messing up the openGL context
     //m_viewer.statusProgress->setValue ((int)(percent*100));
     //m_viewer.statusProgress->update ();
-    setCursor (Qt::WaitCursor);
+    setCursor(Qt::WaitCursor);
 
     int nchannels = spec.nchannels;
     // For simplicity, we don't support more than 4 channels without shaders
     // (yet).
     if (m_use_shaders) {
-        nchannels = num_channels(m_viewer.current_channel(), nchannels, m_viewer.current_color_mode());
+        nchannels = num_channels(m_viewer.current_channel(), nchannels,
+                                 m_viewer.current_color_mode());
     }
     GLenum gltype, glformat, glinternalformat;
-    typespec_to_opengl (spec, nchannels, gltype, glformat, glinternalformat);
+    typespec_to_opengl(spec, nchannels, gltype, glformat, glinternalformat);
 
-    TexBuffer &tb = m_texbufs[m_last_texbuf_used];
-    tb.x = x;
-    tb.y = y;
-    tb.width = width;
-    tb.height = height;
+    TexBuffer& tb = m_texbufs[m_last_texbuf_used];
+    tb.x          = x;
+    tb.y          = y;
+    tb.width      = width;
+    tb.height     = height;
     // Copy the imagebuf pixels we need, that's the only way we can do
     // it safely since ImageBuf has a cache underneath and the whole image
     // may not be resident at once.
-    if (! m_use_shaders) {
-        m_current_image->get_pixels (ROI (x, x + width, y, y + height),
-                                     spec.format, &m_tex_buffer[0]);
+    if (!m_use_shaders) {
+        m_current_image->get_pixels(ROI(x, x + width, y, y + height),
+                                    spec.format, &m_tex_buffer[0]);
     } else {
-        m_current_image->get_pixels (ROI (x, x+width, y, y+height, 0, 1,
-                                          m_viewer.current_channel(),
-                                          m_viewer.current_channel() + nchannels),
-                                     spec.format, &m_tex_buffer[0]);
+        m_current_image->get_pixels(ROI(x, x + width, y, y + height, 0, 1,
+                                        m_viewer.current_channel(),
+                                        m_viewer.current_channel() + nchannels),
+                                    spec.format, &m_tex_buffer[0]);
     }
 
-    glBindBuffer (GL_PIXEL_UNPACK_BUFFER,
-                     m_pbo_objects[m_last_pbo_used]);
-    glBufferData (GL_PIXEL_UNPACK_BUFFER,
-                     width * height * spec.pixel_bytes(),
-                     &m_tex_buffer[0],
-                     GL_STREAM_DRAW);
-    GLERRPRINT ("After buffer data");
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, m_pbo_objects[m_last_pbo_used]);
+    glBufferData(GL_PIXEL_UNPACK_BUFFER, width * height * spec.pixel_bytes(),
+                 &m_tex_buffer[0], GL_STREAM_DRAW);
+    GLERRPRINT("After buffer data");
     m_last_pbo_used = (m_last_pbo_used + 1) & 1;
 
     // When using PBO this is the offset within the buffer.
-    void *data = 0;
+    void* data = 0;
 
-    glBindTexture (GL_TEXTURE_2D, tb.tex_object);
-    GLERRPRINT ("After bind texture");
-    glTexSubImage2D (GL_TEXTURE_2D, 0,
-                     0, 0,
-                     width, height,
-                     glformat, gltype,
-                     data);
-    GLERRPRINT ("After loading sub image");
+    glBindTexture(GL_TEXTURE_2D, tb.tex_object);
+    GLERRPRINT("After bind texture");
+    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, glformat, gltype,
+                    data);
+    GLERRPRINT("After loading sub image");
     m_last_texbuf_used = (m_last_texbuf_used + 1) % m_texbufs.size();
-    glBindBuffer (GL_PIXEL_UNPACK_BUFFER, 0);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
 }
 
 
 
 bool
-IvGL::is_too_big (float width, float height)
+IvGL::is_too_big(float width, float height)
 {
-    unsigned int tiles = (unsigned int) (ceilf(width/m_max_texture_size) * 
-                                         ceilf(height/m_max_texture_size));
+    unsigned int tiles = (unsigned int)(ceilf(width / m_max_texture_size)
+                                        * ceilf(height / m_max_texture_size));
     return tiles > m_texbufs.size();
-
 }

--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -32,13 +32,13 @@
 #ifndef OPENIMAGEIO_IVGL_H
 #define OPENIMAGEIO_IVGL_H
 
-#if defined (_MSC_VER)
+#if defined(_MSC_VER)
 // Ignore warnings about conditional expressions that always evaluate true
 // on a given platform but may evaluate differently on another. There's
 // nothing wrong with such conditionals.
 // Also ignore warnings about not being able to generate default assignment
 // operators for some Qt classes included in headers below.
-#  pragma warning (disable : 4127 4512)
+#    pragma warning(disable : 4127 4512)
 #endif
 
 // included to remove std::min/std::max errors
@@ -46,11 +46,11 @@
 
 #include <vector>
 
-#include <QOpenGLWidget>
 #include <QOpenGLFunctions>
+#include <QOpenGLWidget>
 
-#include <OpenImageIO/imageio.h>
 #include <OpenImageIO/imagebuf.h>
+#include <OpenImageIO/imageio.h>
 
 using namespace OIIO;
 
@@ -59,95 +59,96 @@ class ImageViewer;
 
 
 
-class IvGL : public QOpenGLWidget, protected QOpenGLFunctions
-{
-Q_OBJECT
+class IvGL : public QOpenGLWidget, protected QOpenGLFunctions {
+    Q_OBJECT
 public:
-    IvGL (QWidget *parent, ImageViewer &viewer);
-    virtual ~IvGL ();
+    IvGL(QWidget* parent, ImageViewer& viewer);
+    virtual ~IvGL();
 
     /// Update the image texture.
     ///
-    virtual void update ();
+    virtual void update();
 
     /// Update the view -- center (in pixel coordinates) and zoom level.
     ///
-    virtual void view (float centerx, float centery, float zoom,
-                       bool redraw=true);
+    virtual void view(float centerx, float centery, float zoom,
+                      bool redraw = true);
 
     /// Update just the zoom, keep the old center
     ///
-    void zoom (float newzoom, bool redraw=true);
+    void zoom(float newzoom, bool redraw = true);
 
     /// Update just the center (in pixel coordinates), keep the old zoom.
     ///
-    void center (float x, float y, bool redraw=true);
+    void center(float x, float y, bool redraw = true);
 
     /// Get the center of the view, in pixel coordinates.
     ///
-    void get_center (float &x, float &y) {
+    void get_center(float& x, float& y)
+    {
         x = m_centerx;
         y = m_centery;
     }
 
-    void pan (float dx, float dy);
+    void pan(float dx, float dy);
 
     /// Let the widget know which pixel the mouse is over
     ///
-    void remember_mouse (const QPoint &pos);
+    void remember_mouse(const QPoint& pos);
 
     /// Which image pixel is the mouse over?
     ///
-    void get_focus_image_pixel (int &x, int &y);
+    void get_focus_image_pixel(int& x, int& y);
 
     /// Which display window pixel is the mouse over?  (Relative to
     /// widget boundaries)
-    void get_focus_window_pixel (int &x, int &y);
+    void get_focus_window_pixel(int& x, int& y);
 
     /// Returns true if OpenGL is capable of loading textures in the sRGB color
     /// space.
-    bool is_srgb_capable (void) const { return m_use_srgb; }
+    bool is_srgb_capable(void) const { return m_use_srgb; }
 
     /// Returns true if OpenGL can use GLSL, either with extensions or as
     /// implementation of version 2.0
-    bool is_glsl_capable (void) const { return m_use_shaders; }
+    bool is_glsl_capable(void) const { return m_use_shaders; }
 
     /// Is OpenGL capable of reading half-float textures?
     ///
-    bool is_half_capable (void) const { return m_use_halffloat; }
+    bool is_half_capable(void) const { return m_use_halffloat; }
 
     /// Returns true if the image is too big to fit within allocated textures
     /// (i.e., it's recommended to use lower resolution versions when zoomed out).
-    bool is_too_big (float width, float height);
+    bool is_too_big(float width, float height);
 
-    void typespec_to_opengl (const ImageSpec& spec, int nchannels, GLenum &gltype,
-                             GLenum &glformat, GLenum &glinternal) const;
+    void typespec_to_opengl(const ImageSpec& spec, int nchannels,
+                            GLenum& gltype, GLenum& glformat,
+                            GLenum& glinternal) const;
 
 protected:
-    ImageViewer &m_viewer;            ///< Backpointer to viewer
-    bool m_shaders_created;           ///< Have the shaders been created?
-    GLuint m_vertex_shader;           ///< Vertex shader id
-    GLuint m_fragment_shader;         ///< Fragment shader id
-    GLuint m_shader_program;          ///< GL shader program id
-    bool m_tex_created;               ///< Have the textures been created?
-    float m_zoom;                     ///< Zoom ratio
-    float m_centerx, m_centery;       ///< Center of view, in pixel coords
-    bool m_dragging;                  ///< Are we dragging?
-    int m_mousex, m_mousey;           ///< Last mouse position
-    Qt::MouseButton m_drag_button;    ///< Button on when dragging
-    bool m_use_shaders;               ///< Are shaders supported?
-    bool m_use_halffloat;             ///< Are half-float textures supported?
-    bool m_use_float;                 ///< Are float textures supported?
-    bool m_use_srgb;                  ///< Are sRGB-space textures supported?
-    bool m_use_npot_texture;          ///< Can we handle NPOT textures?
-    GLint m_max_texture_size;         ///< Maximum allowed texture dimension.
+    ImageViewer& m_viewer;          ///< Backpointer to viewer
+    bool m_shaders_created;         ///< Have the shaders been created?
+    GLuint m_vertex_shader;         ///< Vertex shader id
+    GLuint m_fragment_shader;       ///< Fragment shader id
+    GLuint m_shader_program;        ///< GL shader program id
+    bool m_tex_created;             ///< Have the textures been created?
+    float m_zoom;                   ///< Zoom ratio
+    float m_centerx, m_centery;     ///< Center of view, in pixel coords
+    bool m_dragging;                ///< Are we dragging?
+    int m_mousex, m_mousey;         ///< Last mouse position
+    Qt::MouseButton m_drag_button;  ///< Button on when dragging
+    bool m_use_shaders;             ///< Are shaders supported?
+    bool m_use_halffloat;           ///< Are half-float textures supported?
+    bool m_use_float;               ///< Are float textures supported?
+    bool m_use_srgb;                ///< Are sRGB-space textures supported?
+    bool m_use_npot_texture;        ///< Can we handle NPOT textures?
+    GLint m_max_texture_size;       ///< Maximum allowed texture dimension.
     GLsizei m_texture_width;
     GLsizei m_texture_height;
-    GLuint m_pbo_objects[2];          ///< Pixel buffer objects
-    int m_last_pbo_used;              ///< Last used pixel buffer object.
-    IvImage *m_current_image;         ///< Image to show on screen.
-    GLuint m_pixelview_tex;           ///< Pixelview's own texture.
-    bool m_pixelview_left_corner;     ///< Draw pixelview in upper left or right
+    GLuint m_pbo_objects[2];       ///< Pixel buffer objects
+    int m_last_pbo_used;           ///< Last used pixel buffer object.
+    IvImage* m_current_image;      ///< Image to show on screen.
+    GLuint m_pixelview_tex;        ///< Pixelview's own texture.
+    bool m_pixelview_left_corner;  ///< Draw pixelview in upper left or right
     /// Buffer passed to IvImage::copy_image when not using PBO.
     ///
     std::vector<unsigned char> m_tex_buffer;
@@ -163,28 +164,29 @@ protected:
     };
     std::vector<TexBuffer> m_texbufs;
     int m_last_texbuf_used;
-    bool m_mouse_activation;          ///< Can we expect the window to be activated by mouse?
+    bool m_mouse_activation;  ///< Can we expect the window to be activated by mouse?
 
 
-    virtual void initializeGL ();
-    virtual void resizeGL (int w, int h);
-    virtual void paintGL ();
+    virtual void initializeGL();
+    virtual void resizeGL(int w, int h);
+    virtual void paintGL();
 
-    virtual void mousePressEvent (QMouseEvent *event);
-    virtual void mouseReleaseEvent (QMouseEvent *event);
-    virtual void mouseMoveEvent (QMouseEvent *event);
-    virtual void wheelEvent (QWheelEvent *event);
-    virtual void focusOutEvent (QFocusEvent *event);
+    virtual void mousePressEvent(QMouseEvent* event);
+    virtual void mouseReleaseEvent(QMouseEvent* event);
+    virtual void mouseMoveEvent(QMouseEvent* event);
+    virtual void wheelEvent(QWheelEvent* event);
+    virtual void focusOutEvent(QFocusEvent* event);
 
-    void paint_pixelview ();
-    void glSquare (float xmin, float ymin, float xmax, float ymax, float z=0);
+    void paint_pixelview();
+    void glSquare(float xmin, float ymin, float xmax, float ymax, float z = 0);
 
-    virtual void create_shaders (void);
-    virtual void create_textures (void);
-    virtual void useshader (int tex_width, int tex_height, bool pixelview=false);
+    virtual void create_shaders(void);
+    virtual void create_textures(void);
+    virtual void useshader(int tex_width, int tex_height,
+                           bool pixelview = false);
 
-    void shadowed_text (float x, float y, float z, const std::string &s,
-                        const QFont &font);
+    void shadowed_text(float x, float y, float z, const std::string& s,
+                       const QFont& font);
 
 private:
     typedef QOpenGLWidget parent_t;
@@ -192,7 +194,7 @@ private:
     /// visible in our closeup window.
     const static int ncloseuppixels = 9;
     /// closeuppixelzoom is the zoom factor we use for closeup pixels --
-    /// i.e. one image pixel will appear in the closeup window as a 
+    /// i.e. one image pixel will appear in the closeup window as a
     /// closeuppixelzoom x closeuppixelzoom square.
     const static int closeuppixelzoom = 24;
     /// closeupsize is the size, in pixels, of the closeup window itself --
@@ -202,22 +204,22 @@ private:
     /// to OpenGL.
     const static int closeuptexsize = 16;
 
-    void clamp_view_to_window ();
+    void clamp_view_to_window();
 
     /// checks what OpenGL extensions we have
     ///
-    void check_gl_extensions (void);
+    void check_gl_extensions(void);
 
     /// print shader info to out stream
     ///
-    void print_shader_log (std::ostream& out, const GLuint shader_id);
+    void print_shader_log(std::ostream& out, const GLuint shader_id);
 
     /// Loads the given patch of the image, but first figures if it's already
     /// been loaded.
-    void load_texture (int x, int y, int width, int height, float percent);
-    
+    void load_texture(int x, int y, int width, int height, float percent);
+
     /// Destroys shaders and selects fixed-function pipeline
-    void create_shaders_abort (void);
+    void create_shaders_abort(void);
 };
 
-#endif // OPENIMAGEIO_IVGL_H
+#endif  // OPENIMAGEIO_IVGL_H

--- a/src/iv/ivimage.cpp
+++ b/src/iv/ivimage.cpp
@@ -34,48 +34,48 @@
 #include <OpenEXR/half.h>
 
 #include "imageviewer.h"
-#include <OpenImageIO/strutil.h>
 #include <OpenImageIO/fmath.h>
+#include <OpenImageIO/strutil.h>
 
 
-IvImage::IvImage (const std::string &filename)
-    : ImageBuf(filename), m_thumbnail(NULL),
-      m_thumbnail_valid(false),
-      m_gamma(1), m_exposure(0),
-      m_file_dataformat(TypeDesc::UNKNOWN), 
-      m_image_valid(false), m_auto_subimage(false)
+IvImage::IvImage(const std::string& filename)
+    : ImageBuf(filename)
+    , m_thumbnail(NULL)
+    , m_thumbnail_valid(false)
+    , m_gamma(1)
+    , m_exposure(0)
+    , m_file_dataformat(TypeDesc::UNKNOWN)
+    , m_image_valid(false)
+    , m_auto_subimage(false)
 {
 }
 
 
 
-IvImage::~IvImage ()
-{
-    delete [] m_thumbnail;
-}
+IvImage::~IvImage() { delete[] m_thumbnail; }
 
 
 
 bool
-IvImage::init_spec_iv (const std::string &filename, int subimage, int miplevel)
+IvImage::init_spec_iv(const std::string& filename, int subimage, int miplevel)
 {
     // invalidate info strings
-    m_shortinfo.clear ();
-    m_longinfo.clear ();
+    m_shortinfo.clear();
+    m_longinfo.clear();
 
     // If we're changing mip levels or subimages, the pixels will no
     // longer be valid.
     if (subimage != this->subimage() || miplevel != this->miplevel())
         m_image_valid = false;
-    bool ok = ImageBuf::init_spec (filename, subimage, miplevel);
+    bool ok = ImageBuf::init_spec(filename, subimage, miplevel);
     if (ok && m_file_dataformat.basetype == TypeDesc::UNKNOWN) {
         m_file_dataformat = spec().format;
     }
-    string_view colorspace = spec().get_string_attribute ("oiio:ColorSpace");
-    if (Strutil::istarts_with (colorspace, "GammaCorrected")) {
-        float g = Strutil::from_string<float>(colorspace.c_str()+14);
+    string_view colorspace = spec().get_string_attribute("oiio:ColorSpace");
+    if (Strutil::istarts_with(colorspace, "GammaCorrected")) {
+        float g = Strutil::from_string<float>(colorspace.c_str() + 14);
         if (g > 1.0 && g <= 3.0 /*sanity check*/) {
-            gamma (gamma()/g);
+            gamma(gamma() / g);
         }
     }
     return ok;
@@ -84,26 +84,29 @@ IvImage::init_spec_iv (const std::string &filename, int subimage, int miplevel)
 
 
 bool
-IvImage::read_iv (int subimage, int miplevel, bool force, TypeDesc format,
-               ProgressCallback progress_callback,
-               void *progress_callback_data, bool secondary_data)
+IvImage::read_iv(int subimage, int miplevel, bool force, TypeDesc format,
+                 ProgressCallback progress_callback,
+                 void* progress_callback_data, bool secondary_data)
 {
     // Don't read if we already have it in memory, unless force is true.
     // FIXME: should we also check the time on the file to see if it's
     // been updated since we last loaded?
-    if (m_image_valid && !force
-        && subimage == this->subimage() && miplevel != this->miplevel())
+    if (m_image_valid && !force && subimage == this->subimage()
+        && miplevel != this->miplevel())
         return true;
 
-    m_image_valid = init_spec_iv (name(), subimage, miplevel);
+    m_image_valid = init_spec_iv(name(), subimage, miplevel);
     if (m_image_valid)
-        m_image_valid = ImageBuf::read (subimage, miplevel, force, format,
-                                        progress_callback, progress_callback_data);
+        m_image_valid = ImageBuf::read(subimage, miplevel, force, format,
+                                       progress_callback,
+                                       progress_callback_data);
 
     if (m_image_valid && secondary_data && spec().format == TypeDesc::UINT8) {
-        m_corrected_image.reset ("", ImageSpec (spec().width, spec().height, std::min(spec().nchannels, 4), spec().format));
+        m_corrected_image.reset("", ImageSpec(spec().width, spec().height,
+                                              std::min(spec().nchannels, 4),
+                                              spec().format));
     } else {
-        m_corrected_image.clear ();
+        m_corrected_image.clear();
     }
     return m_image_valid;
 }
@@ -111,16 +114,16 @@ IvImage::read_iv (int subimage, int miplevel, bool force, TypeDesc format,
 
 
 std::string
-IvImage::shortinfo () const
+IvImage::shortinfo() const
 {
     if (m_shortinfo.empty()) {
-        m_shortinfo = Strutil::format ("%d x %d", spec().width, spec().height);
+        m_shortinfo = Strutil::format("%d x %d", spec().width, spec().height);
         if (spec().depth > 1)
-            m_shortinfo += Strutil::format (" x %d", spec().depth);
-        m_shortinfo += Strutil::format (" x %d channel %s (%.2f MB)",
-                                        spec().nchannels,
-                                        m_file_dataformat.c_str(),
-                                        (float)spec().image_bytes() / (1024.0*1024.0));
+            m_shortinfo += Strutil::format(" x %d", spec().depth);
+        m_shortinfo
+            += Strutil::format(" x %d channel %s (%.2f MB)", spec().nchannels,
+                               m_file_dataformat.c_str(),
+                               (float)spec().image_bytes() / (1024.0 * 1024.0));
     }
     return m_shortinfo;
 }
@@ -129,80 +132,85 @@ IvImage::shortinfo () const
 
 // Format name/value pairs as HTML table entries.
 std::string
-html_table_row (const char *name, const std::string &value)
+html_table_row(const char* name, const std::string& value)
 {
-    std::string line = Strutil::format ("<tr><td><i>%s</i> : &nbsp;&nbsp;</td>",
-                                        name);
-    line += Strutil::format ("<td>%s</td></tr>\n", value.c_str());
+    std::string line = Strutil::format("<tr><td><i>%s</i> : &nbsp;&nbsp;</td>",
+                                       name);
+    line += Strutil::format("<td>%s</td></tr>\n", value.c_str());
     return line;
 }
 
 
 std::string
-html_table_row (const char *name, int value)
+html_table_row(const char* name, int value)
 {
-    return html_table_row (name, Strutil::format ("%d", value));
+    return html_table_row(name, Strutil::format("%d", value));
 }
 
 
 std::string
-html_table_row (const char *name, float value)
+html_table_row(const char* name, float value)
 {
-    return html_table_row (name, Strutil::format ("%g", value));
+    return html_table_row(name, Strutil::format("%g", value));
 }
 
 
 
 std::string
-IvImage::longinfo () const
+IvImage::longinfo() const
 {
     using Strutil::format;  // shorthand
     if (m_longinfo.empty()) {
-        const ImageSpec &m_spec (nativespec());
+        const ImageSpec& m_spec(nativespec());
         m_longinfo += "<table>";
-//        m_longinfo += html_table_row (format("<b>%s</b>", m_name.c_str()).c_str(),
-//                                std::string());
+        //        m_longinfo += html_table_row (format("<b>%s</b>", m_name.c_str()).c_str(),
+        //                                std::string());
         if (m_spec.depth <= 1)
-            m_longinfo += html_table_row ("Dimensions", 
-                        format ("%d x %d pixels", m_spec.width, m_spec.height));
+            m_longinfo += html_table_row("Dimensions",
+                                         format("%d x %d pixels", m_spec.width,
+                                                m_spec.height));
         else
-            m_longinfo += html_table_row ("Dimensions", 
-                        format ("%d x %d x %d pixels",
-                                m_spec.width, m_spec.height, m_spec.depth));
-        m_longinfo += html_table_row ("Channels", m_spec.nchannels);
+            m_longinfo += html_table_row("Dimensions",
+                                         format("%d x %d x %d pixels",
+                                                m_spec.width, m_spec.height,
+                                                m_spec.depth));
+        m_longinfo += html_table_row("Channels", m_spec.nchannels);
         std::string chanlist;
-        for (int i = 0;  i < m_spec.nchannels;  ++i) {
+        for (int i = 0; i < m_spec.nchannels; ++i) {
             chanlist += m_spec.channelnames[i].c_str();
-            if (i != m_spec.nchannels-1)
+            if (i != m_spec.nchannels - 1)
                 chanlist += ", ";
         }
-        m_longinfo += html_table_row ("Channel list", chanlist);
-        m_longinfo += html_table_row ("File format", file_format_name());
-        m_longinfo += html_table_row ("Data format", m_file_dataformat.c_str());
-        m_longinfo += html_table_row ("Data size",
-             format("%.2f MB", (float)m_spec.image_bytes() / (1024.0*1024.0)));
-        m_longinfo += html_table_row ("Image origin", 
-                          format ("%d, %d, %d", m_spec.x, m_spec.y, m_spec.z));
-        m_longinfo += html_table_row ("Full/display size", 
-                          format ("%d x %d x %d", m_spec.full_width,
-                                  m_spec.full_height, m_spec.full_depth));
-        m_longinfo += html_table_row ("Full/display origin", 
-                          format ("%d, %d, %d", m_spec.full_x,
-                                  m_spec.full_y, m_spec.full_z));
+        m_longinfo += html_table_row("Channel list", chanlist);
+        m_longinfo += html_table_row("File format", file_format_name());
+        m_longinfo += html_table_row("Data format", m_file_dataformat.c_str());
+        m_longinfo += html_table_row(
+            "Data size",
+            format("%.2f MB", (float)m_spec.image_bytes() / (1024.0 * 1024.0)));
+        m_longinfo += html_table_row("Image origin",
+                                     format("%d, %d, %d", m_spec.x, m_spec.y,
+                                            m_spec.z));
+        m_longinfo += html_table_row("Full/display size",
+                                     format("%d x %d x %d", m_spec.full_width,
+                                            m_spec.full_height,
+                                            m_spec.full_depth));
+        m_longinfo += html_table_row("Full/display origin",
+                                     format("%d, %d, %d", m_spec.full_x,
+                                            m_spec.full_y, m_spec.full_z));
         if (m_spec.tile_width)
-            m_longinfo += html_table_row ("Scanline/tile",
-                            format ("tiled %d x %d x %d", m_spec.tile_width,
-                                    m_spec.tile_height, m_spec.tile_depth));
+            m_longinfo += html_table_row(
+                "Scanline/tile", format("tiled %d x %d x %d", m_spec.tile_width,
+                                        m_spec.tile_height, m_spec.tile_depth));
         else
-            m_longinfo += html_table_row ("Scanline/tile", "scanline");
+            m_longinfo += html_table_row("Scanline/tile", "scanline");
         if (m_spec.alpha_channel >= 0)
-            m_longinfo += html_table_row ("Alpha channel", m_spec.alpha_channel);
+            m_longinfo += html_table_row("Alpha channel", m_spec.alpha_channel);
         if (m_spec.z_channel >= 0)
-            m_longinfo += html_table_row ("Depth (z) channel", m_spec.z_channel);
+            m_longinfo += html_table_row("Depth (z) channel", m_spec.z_channel);
 
         for (auto&& p : m_spec.extra_attribs) {
-            std::string s = m_spec.metadata_val (p, true);
-            m_longinfo += html_table_row (p.name().c_str(), s);
+            std::string s = m_spec.metadata_val(p, true);
+            m_longinfo += html_table_row(p.name().c_str(), s);
         }
 
         m_longinfo += "</table>";
@@ -219,23 +227,24 @@ static EightBitConverter<float> converter;
 /// Helper routine: compute (gain*value)^invgamma
 ///
 
-namespace
-{
+namespace {
 
-inline float calc_exposure (float value, float gain, float invgamma)
+inline float
+calc_exposure(float value, float gain, float invgamma)
 {
     if (invgamma != 1 && value >= 0)
-        return powf (gain * value, invgamma);
+        return powf(gain * value, invgamma);
     // Simple case - skip the expensive pow; also fall back to this
     // case for negative values, for which gamma makes no sense.
     return gain * value;
 }
 
-}
+}  // namespace
 
 
-void 
-IvImage::pixel_transform(bool srgb_to_linear, int color_mode, int select_channel)
+void
+IvImage::pixel_transform(bool srgb_to_linear, int color_mode,
+                         int select_channel)
 {
     /// This table obeys the following function:
     ///
@@ -249,8 +258,9 @@ IvImage::pixel_transform(bool srgb_to_linear, int color_mode, int select_channel
     ///           x_l = powf((x_f+0.055)/1.055,2.4);
     ///       return (unsigned char)(x_l * 255 + 0.5)
     ///   }
-    /// 
+    ///
     ///  It's used to transform from sRGB color space to linear color space.
+    // clang-format off
     static const unsigned char srgb_to_linear_lut[256] = {
         0, 0, 0, 0, 0, 0, 0, 1,
         1, 1, 1, 1, 1, 1, 1, 1,
@@ -285,15 +295,16 @@ IvImage::pixel_transform(bool srgb_to_linear, int color_mode, int select_channel
         222, 224, 226, 229, 231, 233, 235, 237,
         239, 242, 244, 246, 248, 250, 253, 255
     };
+    // clang-format on
     unsigned char correction_table[256];
     int total_channels = spec().nchannels;
     int color_channels = spec().nchannels;
-    int max_channels = m_corrected_image.nchannels();
+    int max_channels   = m_corrected_image.nchannels();
 
     // FIXME: Now with the iterator and data proxy in place, it should be
     // trivial to apply the transformations to any kind of data, not just
     // UINT8.
-    if (spec().format != TypeDesc::UINT8 || ! m_corrected_image.localpixels()) {
+    if (spec().format != TypeDesc::UINT8 || !m_corrected_image.localpixels()) {
         return;
     }
 
@@ -306,15 +317,16 @@ IvImage::pixel_transform(bool srgb_to_linear, int color_mode, int select_channel
     // This image is Luminance or Luminance + Alpha, and we are asked to show
     // luminance.
     if (color_channels == 1 && color_mode == 3) {
-        color_mode = 0; // Just copy as usual.
+        color_mode = 0;  // Just copy as usual.
     }
 
     // Happy path:
-    if (! srgb_to_linear && color_mode <= 1 && m_gamma == 1.0 && m_exposure == 0.0) {
-        ImageBuf::ConstIterator<unsigned char, unsigned char> src (*this);
-        ImageBuf::Iterator<unsigned char, unsigned char> dst (m_corrected_image);
-        for ( ; src.valid (); ++src) {
-            dst.pos (src.x(), src.y());
+    if (!srgb_to_linear && color_mode <= 1 && m_gamma == 1.0
+        && m_exposure == 0.0) {
+        ImageBuf::ConstIterator<unsigned char, unsigned char> src(*this);
+        ImageBuf::Iterator<unsigned char, unsigned char> dst(m_corrected_image);
+        for (; src.valid(); ++src) {
+            dst.pos(src.x(), src.y());
             for (int i = 0; i < max_channels; i++)
                 dst[i] = src[i];
         }
@@ -327,20 +339,19 @@ IvImage::pixel_transform(bool srgb_to_linear, int color_mode, int select_channel
             correction_table[pixelvalue] = pixelvalue;
         }
     } else {
-        float inv_gamma = 1.0/gamma();
-        float gain = powf (2.0f, exposure());
+        float inv_gamma = 1.0 / gamma();
+        float gain      = powf(2.0f, exposure());
         for (int pixelvalue = 0; pixelvalue < 256; ++pixelvalue) {
-            float pv_f = converter (pixelvalue);
-            pv_f = clamp (calc_exposure (pv_f, gain, inv_gamma),
-                          0.0f, 1.0f);
-            correction_table[pixelvalue] = (unsigned char) (pv_f*255 + 0.5);
+            float pv_f = converter(pixelvalue);
+            pv_f = clamp(calc_exposure(pv_f, gain, inv_gamma), 0.0f, 1.0f);
+            correction_table[pixelvalue] = (unsigned char)(pv_f * 255 + 0.5);
         }
     }
 
-    ImageBuf::ConstIterator<unsigned char, unsigned char> src (*this);
-    ImageBuf::Iterator<unsigned char, unsigned char> dst (m_corrected_image);
-    for ( ; src.valid(); ++src) {
-        dst.pos (src.x(), src.y());
+    ImageBuf::ConstIterator<unsigned char, unsigned char> src(*this);
+    ImageBuf::Iterator<unsigned char, unsigned char> dst(m_corrected_image);
+    for (; src.valid(); ++src) {
+        dst.pos(src.x(), src.y());
         if (color_mode == 0 || color_mode == 1) {
             // RGBA, RGB modes.
             int ch = 0;
@@ -357,16 +368,17 @@ IvImage::pixel_transform(bool srgb_to_linear, int color_mode, int select_channel
             // Convert RGB to luminance, (Rec. 709 luma coefficients).
             float luminance;
             if (srgb_to_linear) {
-                luminance = converter (srgb_to_linear_lut[src[0]])*0.2126f +
-                            converter (srgb_to_linear_lut[src[1]])*0.7152f +
-                            converter (srgb_to_linear_lut[src[2]])*0.0722f;
+                luminance = converter(srgb_to_linear_lut[src[0]]) * 0.2126f
+                            + converter(srgb_to_linear_lut[src[1]]) * 0.7152f
+                            + converter(srgb_to_linear_lut[src[2]]) * 0.0722f;
             } else {
-                luminance = converter (src[0])*0.2126f +
-                            converter (src[1])*0.7152f +
-                            converter (src[2])*0.0722f;
+                luminance = converter(src[0]) * 0.2126f
+                            + converter(src[1]) * 0.7152f
+                            + converter(src[2]) * 0.0722f;
             }
-            unsigned char val = (unsigned char) (clamp (luminance, 0.0f, 1.0f) * 255.0 + 0.5);
-            val = correction_table[val];
+            unsigned char val
+                = (unsigned char)(clamp(luminance, 0.0f, 1.0f) * 255.0 + 0.5);
+            val    = correction_table[val];
             dst[0] = val;
             dst[1] = val;
             dst[2] = val;
@@ -375,7 +387,7 @@ IvImage::pixel_transform(bool srgb_to_linear, int color_mode, int select_channel
             for (int ch = 3; ch < total_channels; ++ch) {
                 dst[ch] = src[ch];
             }
-        } else { // Single channel, heatmap.
+        } else {  // Single channel, heatmap.
             unsigned char v = 0;
             if (select_channel < color_channels) {
                 if (srgb_to_linear)
@@ -392,19 +404,19 @@ IvImage::pixel_transform(bool srgb_to_linear, int color_mode, int select_channel
             for (; ch < max_channels; ++ch) {
                 dst[ch] = src[ch];
             }
-        } 
+        }
     }
 }
 
 
 
 void
-IvImage::invalidate ()
+IvImage::invalidate()
 {
-    ustring filename (name());
-    reset (filename.string());
+    ustring filename(name());
+    reset(filename.string());
     m_thumbnail_valid = false;
-    m_image_valid = false;
+    m_image_valid     = false;
     if (imagecache())
-        imagecache()->invalidate (filename);
+        imagecache()->invalidate(filename);
 }

--- a/src/iv/ivinfowin.cpp
+++ b/src/iv/ivinfowin.cpp
@@ -43,56 +43,61 @@
 
 
 
-IvInfoWindow::IvInfoWindow (ImageViewer &viewer, bool visible)
-    : QDialog(&viewer), m_viewer(viewer), m_visible (visible)
+IvInfoWindow::IvInfoWindow(ImageViewer& viewer, bool visible)
+    : QDialog(&viewer)
+    , m_viewer(viewer)
+    , m_visible(visible)
 {
     infoLabel = new QLabel;
-    infoLabel->setPalette (viewer.palette());
+    infoLabel->setPalette(viewer.palette());
 
     scrollArea = new QScrollArea;
-    scrollArea->setPalette (viewer.palette());
-    scrollArea->setWidgetResizable (true);
-    scrollArea->setWidget (infoLabel);
-    scrollArea->setSizePolicy (QSizePolicy (QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding, QSizePolicy::Label));
-    scrollArea->setHorizontalScrollBarPolicy (Qt::ScrollBarAlwaysOff);
-    scrollArea->setFrameStyle (QFrame::NoFrame);
-    scrollArea->setAlignment (Qt::AlignTop);
+    scrollArea->setPalette(viewer.palette());
+    scrollArea->setWidgetResizable(true);
+    scrollArea->setWidget(infoLabel);
+    scrollArea->setSizePolicy(QSizePolicy(QSizePolicy::MinimumExpanding,
+                                          QSizePolicy::MinimumExpanding,
+                                          QSizePolicy::Label));
+    scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    scrollArea->setFrameStyle(QFrame::NoFrame);
+    scrollArea->setAlignment(Qt::AlignTop);
 
-    closeButton = new QPushButton (tr("Close"));
-    connect (closeButton, SIGNAL(clicked()), this, SLOT(hide()));
+    closeButton = new QPushButton(tr("Close"));
+    connect(closeButton, SIGNAL(clicked()), this, SLOT(hide()));
 
-    QVBoxLayout *mainLayout = new QVBoxLayout;
-    mainLayout->addWidget (scrollArea);
-    mainLayout->addWidget (closeButton);
-    setLayout (mainLayout);
+    QVBoxLayout* mainLayout = new QVBoxLayout;
+    mainLayout->addWidget(scrollArea);
+    mainLayout->addWidget(closeButton);
+    setLayout(mainLayout);
     infoLabel->show();
     scrollArea->show();
 
-    setWindowTitle (tr("Image Info"));
+    setWindowTitle(tr("Image Info"));
 }
 
 
 
 void
-IvInfoWindow::update (IvImage *img)
+IvInfoWindow::update(IvImage* img)
 {
     std::string newtitle;
     if (img) {
-        newtitle = Strutil::format ("%s - iv Info", img->name().c_str());
-        infoLabel->setText (img->longinfo().c_str());
+        newtitle = Strutil::format("%s - iv Info", img->name().c_str());
+        infoLabel->setText(img->longinfo().c_str());
     } else {
-        newtitle = Strutil::format ("iv Info");
-        infoLabel->setText (tr("No image loaded."));
+        newtitle = Strutil::format("iv Info");
+        infoLabel->setText(tr("No image loaded."));
     }
-    setWindowTitle (newtitle.c_str());
+    setWindowTitle(newtitle.c_str());
 }
 
 
 
 void
-IvInfoWindow::keyPressEvent (QKeyEvent *event)
+IvInfoWindow::keyPressEvent(QKeyEvent* event)
 {
-    if (event->key() == Qt::Key_W && (event->modifiers() & Qt::ControlModifier)) {
+    if (event->key() == Qt::Key_W
+        && (event->modifiers() & Qt::ControlModifier)) {
         event->accept();
         hide();
     } else {

--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -34,12 +34,12 @@
 // nothing wrong with such conditionals.
 // Also ignore warnings about not being able to generate default assignment
 // operators for some Qt classes included in headers below.
-#  pragma warning (disable : 4127 4512)
+#    pragma warning(disable : 4127 4512)
 #endif
 
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
-#include <cmath>
 #include <ctime>
 #include <iostream>
 #include <iterator>
@@ -47,27 +47,27 @@
 #include <QApplication>
 
 #include "imageviewer.h"
-#include <OpenImageIO/timer.h>
 #include <OpenImageIO/argparse.h>
-#include <OpenImageIO/sysutil.h>
-#include <OpenImageIO/strutil.h>
-#include <OpenImageIO/imagecache.h>
 #include <OpenImageIO/filesystem.h>
+#include <OpenImageIO/imagecache.h>
+#include <OpenImageIO/strutil.h>
+#include <OpenImageIO/sysutil.h>
+#include <OpenImageIO/timer.h>
 
 using namespace OIIO;
 
 
-static bool verbose = false;
+static bool verbose         = false;
 static bool foreground_mode = false;
-static bool autopremult = true;
+static bool autopremult     = true;
 static std::vector<std::string> filenames;
 
 
 
 static int
-parse_files (int argc, const char *argv[])
+parse_files(int argc, const char* argv[])
 {
-    for (int i = 0;  i < argc;  i++)
+    for (int i = 0; i < argc; i++)
         filenames.emplace_back(argv[i]);
     return 0;
 }
@@ -75,73 +75,76 @@ parse_files (int argc, const char *argv[])
 
 
 static void
-getargs (int argc, char *argv[])
+getargs(int argc, char* argv[])
 {
     bool help = false;
     ArgParse ap;
+    // clang-format off
     ap.options ("iv -- image viewer\n"
                 OIIO_INTRO_STRING "\n"
                 "Usage:  iv [options] [filename...]",
-                  "%*", parse_files, "",
-                  "--help", &help, "Print help message",
-                  "-v", &verbose, "Verbose status messages",
-                  "-F", &foreground_mode, "Foreground mode",
-                  "--no-autopremult %!", &autopremult, "Turn off automatic premultiplication of images with unassociated alpha",
-                  NULL);
-    if (ap.parse (argc, (const char**)argv) < 0) {
+                "%*", parse_files, "",
+                "--help", &help, "Print help message",
+                "-v", &verbose, "Verbose status messages",
+                "-F", &foreground_mode, "Foreground mode",
+                "--no-autopremult %!", &autopremult,
+                    "Turn off automatic premultiplication of images with unassociated alpha",
+                nullptr);
+    // clang-format on
+    if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
-        ap.usage ();
-        exit (EXIT_FAILURE);
+        ap.usage();
+        exit(EXIT_FAILURE);
     }
     if (help) {
-        ap.usage ();
-        exit (EXIT_FAILURE);
+        ap.usage();
+        exit(EXIT_FAILURE);
     }
 }
 
 #ifdef WIN32
-    // if we are not in DEBUG mode this code switch the app to
-    // full windowed mode (no console and no need to define WinMain)
-    // FIXME: this should be done in CMakeLists.txt but first we have to
-    // fix Windows Debug build
-# ifdef NDEBUG
-#  pragma comment(linker, "/subsystem:windows /entry:mainCRTStartup")
-# endif
+// if we are not in DEBUG mode this code switch the app to
+// full windowed mode (no console and no need to define WinMain)
+// FIXME: this should be done in CMakeLists.txt but first we have to
+// fix Windows Debug build
+#    ifdef NDEBUG
+#        pragma comment(linker, "/subsystem:windows /entry:mainCRTStartup")
+#    endif
 #endif
 
 
 int
-main (int argc, char *argv[])
+main(int argc, char* argv[])
 {
-    Filesystem::convert_native_arguments (argc, (const char **)argv);
-    getargs (argc, argv);
+    Filesystem::convert_native_arguments(argc, (const char**)argv);
+    getargs(argc, argv);
 
-    if (! foreground_mode)
-        Sysutil::put_in_background (argc, argv);
+    if (!foreground_mode)
+        Sysutil::put_in_background(argc, argv);
 
     // LG
-//    Q_INIT_RESOURCE(iv);
+    //    Q_INIT_RESOURCE(iv);
     QApplication app(argc, argv);
-    ImageViewer *mainWin = new ImageViewer;
+    ImageViewer* mainWin = new ImageViewer;
     mainWin->show();
 
     // Set up the imagecache with parameters that make sense for iv
-    ImageCache *imagecache = ImageCache::create (true);
-    imagecache->attribute ("autotile", 256);
-    imagecache->attribute ("deduplicate", (int)0);
-    if (! autopremult)
-        imagecache->attribute ("unassociatedalpha", 1);
+    ImageCache* imagecache = ImageCache::create(true);
+    imagecache->attribute("autotile", 256);
+    imagecache->attribute("deduplicate", (int)0);
+    if (!autopremult)
+        imagecache->attribute("unassociatedalpha", 1);
 
     // Make sure we are the top window with the focus.
-    mainWin->raise ();
-    mainWin->activateWindow ();
+    mainWin->raise();
+    mainWin->activateWindow();
 
     // Add the images
-    for (const auto &s : filenames) {
-        mainWin->add_image (s);
+    for (const auto& s : filenames) {
+        mainWin->add_image(s);
     }
 
-    mainWin->current_image (0);
+    mainWin->current_image(0);
 
     int r = app.exec();
     // OK to clean up here
@@ -150,10 +153,11 @@ main (int argc, char *argv[])
     if (verbose)
 #endif
     {
-        size_t mem = Sysutil::memory_used (true);
-        std::cout << "iv total memory used: " << Strutil::memformat (mem) << "\n";
+        size_t mem = Sysutil::memory_used(true);
+        std::cout << "iv total memory used: " << Strutil::memformat(mem)
+                  << "\n";
         std::cout << "\n";
-        std::cout << imagecache->getstats (1+verbose) << "\n";
+        std::cout << imagecache->getstats(1 + verbose) << "\n";
     }
 
     return r;

--- a/src/iv/ivpref.cpp
+++ b/src/iv/ivpref.cpp
@@ -43,49 +43,50 @@
 
 
 
-IvPreferenceWindow::IvPreferenceWindow (ImageViewer &viewer)
-    : QDialog(&viewer), m_viewer(viewer)
+IvPreferenceWindow::IvPreferenceWindow(ImageViewer& viewer)
+    : QDialog(&viewer)
+    , m_viewer(viewer)
 {
-    closeButton = new QPushButton (tr("Close"));
-    closeButton->setShortcut (tr("Ctrl+W"));
-    connect (closeButton, SIGNAL(clicked()), this, SLOT(hide()));
+    closeButton = new QPushButton(tr("Close"));
+    closeButton->setShortcut(tr("Ctrl+W"));
+    connect(closeButton, SIGNAL(clicked()), this, SLOT(hide()));
 
     layout = new QVBoxLayout;
-    layout->addWidget (viewer.pixelviewFollowsMouseBox);
-    layout->addWidget (viewer.linearInterpolationBox);
-    layout->addWidget (viewer.darkPaletteBox);
-    layout->addWidget (viewer.autoMipmap);
-    
-    QLayout *inner_layout = new QHBoxLayout;
-    inner_layout->addWidget (viewer.maxMemoryICLabel);
-    inner_layout->addWidget (viewer.maxMemoryIC);
+    layout->addWidget(viewer.pixelviewFollowsMouseBox);
+    layout->addWidget(viewer.linearInterpolationBox);
+    layout->addWidget(viewer.darkPaletteBox);
+    layout->addWidget(viewer.autoMipmap);
 
-    QLayout *slideShowLayout = new QHBoxLayout;
-    slideShowLayout->addWidget (viewer.slideShowDurationLabel);
-    slideShowLayout->addWidget (viewer.slideShowDuration);
+    QLayout* inner_layout = new QHBoxLayout;
+    inner_layout->addWidget(viewer.maxMemoryICLabel);
+    inner_layout->addWidget(viewer.maxMemoryIC);
 
-    layout->addLayout (inner_layout);
-    layout->addLayout (slideShowLayout);
-    layout->addWidget (closeButton);
-    setLayout (layout);
+    QLayout* slideShowLayout = new QHBoxLayout;
+    slideShowLayout->addWidget(viewer.slideShowDurationLabel);
+    slideShowLayout->addWidget(viewer.slideShowDuration);
 
-    setWindowTitle (tr("iv Preferences"));
+    layout->addLayout(inner_layout);
+    layout->addLayout(slideShowLayout);
+    layout->addWidget(closeButton);
+    setLayout(layout);
+
+    setWindowTitle(tr("iv Preferences"));
 }
 
 
 
 void
-IvPreferenceWindow::keyPressEvent (QKeyEvent *event)
+IvPreferenceWindow::keyPressEvent(QKeyEvent* event)
 {
-//    if (event->key() == 'w' && (event->modifiers() & Qt::ControlModifier)) {
+    //    if (event->key() == 'w' && (event->modifiers() & Qt::ControlModifier)) {
     if (event->key() == Qt::Key_W) {
         std::cerr << "found w\n";
         if ((event->modifiers() & Qt::ControlModifier)) {
             std::cerr << "think we did ctrl-w\n";
             event->accept();
             hide();
-        }
-        else std::cerr << "modifier " << (int)event->modifiers() << "\n";
+        } else
+            std::cerr << "modifier " << (int)event->modifiers() << "\n";
     } else {
         event->ignore();
     }

--- a/src/iv/ivutils.h
+++ b/src/iv/ivutils.h
@@ -10,11 +10,11 @@ OIIO_NAMESPACE_BEGIN
 /// representation.  Once optimized and tested, move to fmath.h
 
 inline float
-pow2roundupf (float f)
+pow2roundupf(float f)
 {
-    float logval = logf (f) / logf (2.0f);
-    logval += 1e-6f; // add floating point slop. this supports [0.00012207,8192]
-    return powf (2.0f, ceilf (logval));
+    float logval = logf(f) / logf(2.0f);
+    logval += 1e-6f;  // add floating point slop. this supports [0.00012207,8192]
+    return powf(2.0f, ceilf(logval));
 }
 
 /// Round down to the next power of 2
@@ -22,13 +22,13 @@ pow2roundupf (float f)
 /// representation.  Once optimized and tested, move to fmath.h
 
 inline float
-pow2rounddownf (float f)
+pow2rounddownf(float f)
 {
-    float logval = logf (f) / logf (2.0f);
-    logval -= 1e-6f; // add floating point slop. this supports [0.00012207,8192]
-    return powf (2.0f, floorf (logval));
+    float logval = logf(f) / logf(2.0f);
+    logval -= 1e-6f;  // add floating point slop. this supports [0.00012207,8192]
+    return powf(2.0f, floorf(logval));
 }
 
 OIIO_NAMESPACE_END
 
-#endif // OPENIMAGEIO_IV_UTILS_H
+#endif  // OPENIMAGEIO_IV_UTILS_H

--- a/src/libOpenImageIO/compute_test.cpp
+++ b/src/libOpenImageIO/compute_test.cpp
@@ -253,19 +253,22 @@ getargs(int argc, char* argv[])
 {
     bool help = false;
     ArgParse ap;
+    // clang-format off
     ap.options(
         "compute_test\n" OIIO_INTRO_STRING "\n"
         "Usage:  compute_test [options]",
         // "%*", parse_files, "",
-        "--help", &help, "Print help message", "-v", &verbose, "Verbose mode",
+        "--help", &help, "Print help message",
+        "-v", &verbose, "Verbose mode",
         "--threads %d", &numthreads,
-        ustring::format("Number of threads (default: %d)", numthreads).c_str(),
+            ustring::format("Number of threads (default: %d)", numthreads).c_str(),
         "--iterations %d", &iterations,
-        ustring::format("Number of iterations (default: %d)", iterations)
-            .c_str(),
-        "--trials %d", &ntrials, "Number of trials", "--allgpus", &allgpus,
-        "Run OpenCL tests on all devices, not just default", "--wedge", &wedge,
-        "Do a wedge test", NULL);
+            ustring::format("Number of iterations (default: %d)", iterations).c_str(),
+        "--trials %d", &ntrials, "Number of trials",
+        "--allgpus", &allgpus, "Run OpenCL tests on all devices, not just default",
+        "--wedge", &wedge, "Do a wedge test",
+        nullptr);
+    // clang-format on
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
         ap.usage();

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -60,18 +60,21 @@ getargs(int argc, char* argv[])
 {
     bool help = false;
     ArgParse ap;
+    // clang-format off
     ap.options(
         "imagebufalgo_test\n" OIIO_INTRO_STRING "\n"
         "Usage:  imagebufalgo_test [options]",
         // "%*", parse_files, "",
-        "--help", &help, "Print help message", "-v", &verbose, "Verbose mode",
+        "--help", &help, "Print help message",
+        "-v", &verbose, "Verbose mode",
         "--threads %d", &numthreads,
-        ustring::format("Number of threads (default: %d)", numthreads).c_str(),
+            ustring::format("Number of threads (default: %d)", numthreads).c_str(),
         "--iters %d", &iterations,
-        ustring::format("Number of iterations (default: %d)", iterations)
-            .c_str(),
-        "--trials %d", &ntrials, "Number of trials", "--wedge", &wedge,
-        "Do a wedge test", NULL);
+            ustring::format("Number of iterations (default: %d)", iterations).c_str(),
+        "--trials %d", &ntrials, "Number of trials",
+        "--wedge", &wedge, "Do a wedge test",
+        nullptr);
+    // clang-format on
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
         ap.usage();

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -79,26 +79,28 @@ getargs(int argc, char* argv[])
 {
     bool help = false;
     ArgParse ap;
+    // clang-format off
     ap.options(
         "imagespeed_test\n" OIIO_INTRO_STRING "\n"
         "Usage:  imagespeed_test [options] filename...",
-        "%*", parse_files, "", "--help", &help, "Print help message", "-v",
-        &verbose, "Verbose mode", "--threads %d", &numthreads,
-        ustring::format("Number of threads (default: %d)", numthreads).c_str(),
+        "%*", parse_files, "",
+        "--help", &help, "Print help message",
+        "-v", &verbose, "Verbose mode",
+        "--threads %d", &numthreads,
+            ustring::format("Number of threads (default: %d)", numthreads).c_str(),
         "--iters %d", &iterations,
-        ustring::format("Number of iterations (default: %d)", iterations)
-            .c_str(),
-        "--trials %d", &ntrials, "Number of trials", "--autotile %d",
-        &autotile_size,
-        ustring::format("Autotile size (when used; default: %d)", autotile_size)
-            .c_str(),
-        "--iteronly", &iter_only,
-        "Run ImageBuf iteration tests only (not read tests)", "--noiter",
-        &no_iter, "Don't run ImageBuf iteration tests", "--convert %s",
-        &conversionname, "Convert to named type upon read (default: native)",
-        "--cache %f", &cache_size, "Specify ImageCache size, in MB", "-o %s",
-        &output_filename, "Test output by writing to this file", "-od %s",
-        &output_format, "Requested output format", NULL);
+            ustring::format("Number of iterations (default: %d)", iterations).c_str(),
+        "--trials %d", &ntrials, "Number of trials",
+        "--autotile %d", &autotile_size,
+            ustring::format("Autotile size (when used; default: %d)", autotile_size).c_str(),
+        "--iteronly", &iter_only, "Run ImageBuf iteration tests only (not read tests)",
+        "--noiter", &no_iter, "Don't run ImageBuf iteration tests",
+        "--convert %s", &conversionname, "Convert to named type upon read (default: native)",
+        "--cache %f", &cache_size, "Specify ImageCache size, in MB",
+        "-o %s", &output_filename, "Test output by writing to this file",
+        "-od %s", &output_format, "Requested output format",
+        nullptr);
+    // clang-format on
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
         ap.usage();

--- a/src/libutil/atomic_test.cpp
+++ b/src/libutil/atomic_test.cpp
@@ -205,18 +205,20 @@ getargs(int argc, char* argv[])
 {
     bool help = false;
     ArgParse ap;
+    // clang-format off
     ap.options(
         "atomic_test\n" OIIO_INTRO_STRING "\n"
         "Usage:  atomic_test [options]",
         // "%*", parse_files, "",
-        "--help", &help, "Print help message", "-v", &verbose, "Verbose mode",
+        "--help", &help, "Print help message",
+        "-v", &verbose, "Verbose mode",
         "--threads %d", &numthreads,
-        ustring::format("Number of threads (default: %d)", numthreads).c_str(),
+            ustring::format("Number of threads (default: %d)", numthreads).c_str(),
         "--iters %d", &iterations,
-        ustring::format("Number of iterations (default: %d)", iterations)
-            .c_str(),
-        "--trials %d", &ntrials, "Number of trials", "--wedge", &wedge,
-        "Do a wedge test", NULL);
+            ustring::format("Number of iterations (default: %d)", iterations).c_str(),
+        "--trials %d", &ntrials, "Number of trials", "--wedge", &wedge, "Do a wedge test",
+        nullptr);
+    // clang-format on
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
         ap.usage();

--- a/src/libutil/filter_test.cpp
+++ b/src/libutil/filter_test.cpp
@@ -58,18 +58,21 @@ getargs(int argc, char* argv[])
 {
     bool help = false;
     ArgParse ap;
+    // clang-format off
     ap.options(
         "fmath_test\n" OIIO_INTRO_STRING "\n"
         "Usage:  fmath_test [options]",
         // "%*", parse_files, "",
-        "--help", &help, "Print help message", "-v", &verbose, "Verbose mode",
+        "--help", &help, "Print help message",
+        "-v", &verbose, "Verbose mode",
         // "--threads %d", &numthreads,
         //     ustring::format("Number of threads (default: %d)", numthreads).c_str(),
         "--iterations %d", &iterations,
-        ustring::format("Number of iterations (default: %d)", iterations)
-            .c_str(),
-        "--trials %d", &ntrials, "Number of trials", "--normalize", &normalize,
-        "Normalize/rescale all filters to peak at 1", NULL);
+            ustring::format("Number of iterations (default: %d)", iterations).c_str(),
+        "--trials %d", &ntrials, "Number of trials",
+        "--normalize", &normalize, "Normalize/rescale all filters to peak at 1",
+        nullptr);
+    // clang-format on
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
         ap.usage();

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -56,19 +56,20 @@ getargs(int argc, char* argv[])
 {
     bool help = false;
     ArgParse ap;
+    // clang-format off
     ap.options(
         "fmath_test\n" OIIO_INTRO_STRING "\n"
         "Usage:  fmath_test [options]",
         // "%*", parse_files, "",
-        "--help", &help, "Print help message", "-v", &verbose, "Verbose mode",
+        "--help", &help, "Print help message",
+        "-v", &verbose, "Verbose mode",
         // "--threads %d", &numthreads,
         //     ustring::format("Number of threads (default: %d)", numthreads).c_str(),
         "--iterations %d", &iterations,
-        ustring::format(
-            "Number of values to convert for benchmarks (default: %d)",
-            iterations)
-            .c_str(),
-        "--trials %d", &ntrials, "Number of trials", NULL);
+            ustring::format("Number of values to convert for benchmarks (default: %d)", iterations).c_str(),
+        "--trials %d", &ntrials, "Number of trials",
+        nullptr);
+    // clang-format on
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
         ap.usage();

--- a/src/libutil/hash_test.cpp
+++ b/src/libutil/hash_test.cpp
@@ -185,19 +185,25 @@ test_falkhash(int len)
 }
 #endif
 
+
+
 static void
 getargs(int argc, char* argv[])
 {
     bool help = false;
     ArgParse ap;
-    ap.options("hash_test\n" OIIO_INTRO_STRING "\n"
-               "Usage:  hash_test [options]",
-               // "%*", parse_files, "",
-               "--help", &help, "Print help message", "-v", &verbose,
-               "Verbose mode", "--iters %d", &iterations,
-               Strutil::format("Number of iterations (default: %d)", iterations)
-                   .c_str(),
-               "--trials %d", &ntrials, "Number of trials", NULL);
+    // clang-format off
+    ap.options(
+        "hash_test\n" OIIO_INTRO_STRING "\n"
+        "Usage:  hash_test [options]",
+        // "%*", parse_files, "",
+        "--help", &help, "Print help message",
+        "-v", &verbose, "Verbose mode",
+        "--iters %d", &iterations,
+            Strutil::format("Number of iterations (default: %d)", iterations).c_str(),
+        "--trials %d", &ntrials, "Number of trials",
+        nullptr);
+    // clang-format on
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
         ap.usage();

--- a/src/libutil/parallel_test.cpp
+++ b/src/libutil/parallel_test.cpp
@@ -59,18 +59,21 @@ getargs(int argc, char* argv[])
 {
     bool help = false;
     ArgParse ap;
+    // clang-format off
     ap.options(
         "parallel_test\n" OIIO_INTRO_STRING "\n"
         "Usage:  parallel_test [options]",
         // "%*", parse_files, "",
-        "--help", &help, "Print help message", "-v", &verbose, "Verbose mode",
+        "--help", &help, "Print help message",
+        "-v", &verbose, "Verbose mode",
         "--threads %d", &numthreads,
-        ustring::format("Number of threads (default: %d)", numthreads).c_str(),
+            ustring::format("Number of threads (default: %d)", numthreads).c_str(),
         "--iters %d", &iterations,
-        ustring::format("Number of iterations (default: %d)", iterations)
-            .c_str(),
-        "--trials %d", &ntrials, "Number of trials", "--wedge", &wedge,
-        "Do a wedge test", NULL);
+            ustring::format("Number of iterations (default: %d)", iterations).c_str(),
+        "--trials %d", &ntrials, "Number of trials",
+        "--wedge", &wedge, "Do a wedge test",
+        nullptr);
+    // clang-format on
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
         ap.usage();

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -69,13 +69,14 @@ getargs(int argc, char* argv[])
     bool help = false;
     ArgParse ap;
     ap.options("simd_test\n" OIIO_INTRO_STRING "\n"
-               "Usage:  simd_test [options]",
-               // "%*", parse_files, "",
-               "--help", &help, "Print help message", "-v", &verbose,
-               "Verbose mode", "--iterations %d", &iterations,
-               ustring::format("Number of iterations (default: %d)", iterations)
-                   .c_str(),
-               "--trials %d", &ntrials, "Number of trials", NULL);
+        "Usage:  simd_test [options]",
+        // "%*", parse_files, "",
+        "--help", &help, "Print help message",
+        "-v", &verbose, "Verbose mode",
+        "--iterations %d", &iterations,
+            ustring::format("Number of iterations (default: %d)", iterations).c_str(),
+        "--trials %d", &ntrials, "Number of trials",
+        nullptr);
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
         ap.usage();

--- a/src/libutil/spin_rw_test.cpp
+++ b/src/libutil/spin_rw_test.cpp
@@ -105,21 +105,23 @@ getargs(int argc, char* argv[])
 {
     bool help = false;
     ArgParse ap;
+    // clang-format off
     ap.options(
         "spin_rw_test\n" OIIO_INTRO_STRING "\n"
         "Usage:  spin_rw_test [options]",
         // "%*", parse_files, "",
-        "--help", &help, "Print help message", "-v", &verbose, "Verbose mode",
+        "--help", &help, "Print help message",
+        "-v", &verbose, "Verbose mode",
         "--threads %d", &numthreads,
-        ustring::format("Number of threads (default: %d)", numthreads).c_str(),
+            ustring::format("Number of threads (default: %d)", numthreads).c_str(),
         "--iters %d", &iterations,
-        ustring::format("Number of iterations (default: %d)", iterations)
-            .c_str(),
-        "--trials %d", &ntrials, "Number of trials", "--rwratio %d",
-        &read_write_ratio,
-        ustring::format("Reader::writer ratio (default: %d)", read_write_ratio)
-            .c_str(),
-        "--wedge", &wedge, "Do a wedge test", NULL);
+            ustring::format("Number of iterations (default: %d)", iterations).c_str(),
+        "--trials %d", &ntrials, "Number of trials",
+        "--rwratio %d", &read_write_ratio,
+            ustring::format("Reader::writer ratio (default: %d)", read_write_ratio).c_str(),
+        "--wedge", &wedge, "Do a wedge test",
+        nullptr);
+    // clang-format on
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
         ap.usage();

--- a/src/libutil/spinlock_test.cpp
+++ b/src/libutil/spinlock_test.cpp
@@ -115,18 +115,20 @@ getargs(int argc, char* argv[])
 {
     bool help = false;
     ArgParse ap;
+    // clang-format off
     ap.options(
         "spinlock_test\n" OIIO_INTRO_STRING "\n"
         "Usage:  spinlock_test [options]",
         // "%*", parse_files, "",
-        "--help", &help, "Print help message", "-v", &verbose, "Verbose mode",
+        "--help", &help, "Print help message",
+        "-v", &verbose, "Verbose mode",
         "--threads %d", &numthreads,
-        ustring::format("Number of threads (default: %d)", numthreads).c_str(),
+                ustring::format("Number of threads (default: %d)", numthreads).c_str(),
         "--iters %d", &iterations,
-        ustring::format("Number of iterations (default: %d)", iterations)
-            .c_str(),
-        "--trials %d", &ntrials, "Number of trials", "--wedge", &wedge,
-        "Do a wedge test", NULL);
+                ustring::format("Number of iterations (default: %d)", iterations).c_str(),
+        "--trials %d", &ntrials, "Number of trials", "--wedge", &wedge, "Do a wedge test",
+        nullptr);
+    // clang-format on
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
         ap.usage();

--- a/src/libutil/thread_test.cpp
+++ b/src/libutil/thread_test.cpp
@@ -58,18 +58,21 @@ getargs(int argc, char* argv[])
 {
     bool help = false;
     ArgParse ap;
+    // clang-format off
     ap.options(
         "thread_test\n" OIIO_INTRO_STRING "\n"
         "Usage:  thread_test [options]",
         // "%*", parse_files, "",
-        "--help", &help, "Print help message", "-v", &verbose, "Verbose mode",
+        "--help", &help, "Print help message",
+        "-v", &verbose, "Verbose mode",
         "--threads %d", &numthreads,
-        ustring::format("Number of threads (default: %d)", numthreads).c_str(),
+            ustring::format("Number of threads (default: %d)", numthreads).c_str(),
         "--iters %d", &iterations,
-        ustring::format("Number of iterations (default: %d)", iterations)
-            .c_str(),
-        "--trials %d", &ntrials, "Number of trials", "--wedge", &wedge,
-        "Do a wedge test", NULL);
+            ustring::format("Number of iterations (default: %d)", iterations).c_str(),
+        "--trials %d", &ntrials, "Number of trials",
+        "--wedge", &wedge, "Do a wedge test",
+        nullptr);
+    // clang-format on
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
         ap.usage();

--- a/src/libutil/timer_test.cpp
+++ b/src/libutil/timer_test.cpp
@@ -57,10 +57,13 @@ getargs(int argc, char* argv[])
 {
     bool help = false;
     ArgParse ap;
+    // clang-format off
     ap.options("timer_test\n" OIIO_INTRO_STRING "\n"
                "Usage:  timer_test [options]",
-               "%*", parse_files, "", "--help", &help, "Print help message",
+               "%*", parse_files, "",
+               "--help", &help, "Print help message",
                NULL);
+    // clang-format on
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
         ap.usage();

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -76,18 +76,21 @@ getargs(int argc, char* argv[])
 {
     bool help = false;
     ArgParse ap;
+    // clang-format off
     ap.options(
         "ustring_test\n" OIIO_INTRO_STRING "\n"
         "Usage:  ustring_test [options]",
         // "%*", parse_files, "",
-        "--help", &help, "Print help message", "-v", &verbose, "Verbose mode",
+        "--help", &help, "Print help message",
+        "-v", &verbose, "Verbose mode",
         "--threads %d", &numthreads,
-        ustring::format("Number of threads (default: %d)", numthreads).c_str(),
+            ustring::format("Number of threads (default: %d)", numthreads).c_str(),
         "--iters %d", &iterations,
-        ustring::format("Number of iterations (default: %d)", iterations)
-            .c_str(),
-        "--trials %d", &ntrials, "Number of trials", "--wedge", &wedge,
-        "Do a wedge test", NULL);
+            ustring::format("Number of iterations (default: %d)", iterations).c_str(),
+        "--trials %d", &ntrials, "Number of trials",
+        "--wedge", &wedge, "Do a wedge test",
+        nullptr);
+    // clang-format on
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
         ap.usage();

--- a/src/nuke/txReader/txReader.cpp
+++ b/src/nuke/txReader/txReader.cpp
@@ -1,5 +1,5 @@
 #ifndef _WIN32
-#include <unistd.h>
+#    include <unistd.h>
 #endif
 
 #include "DDImage/Enumeration_KnobI.h"
@@ -23,14 +23,13 @@ using namespace DD::Image;
  */
 
 
-namespace TxReaderNS
-{
+namespace TxReaderNS {
 
 
 using namespace OIIO;
 
 
-static const char* const EMPTY[] = {NULL};
+static const char* const EMPTY[] = { NULL };
 
 
 class TxReaderFormat : public ReaderFormat {
@@ -40,14 +39,16 @@ class TxReaderFormat : public ReaderFormat {
     Knob* mipLevelEnumKnob_;
 
 public:
-    TxReaderFormat() :
-        mipLevel_(0),
-        mipEnumIndex_(0),
-        mipLevelKnob_(NULL),
-        mipLevelEnumKnob_(NULL)
-    { }
+    TxReaderFormat()
+        : mipLevel_(0)
+        , mipEnumIndex_(0)
+        , mipLevelKnob_(NULL)
+        , mipLevelEnumKnob_(NULL)
+    {
+    }
 
-    void knobs(Knob_Callback cb) {
+    void knobs(Knob_Callback cb)
+    {
         // The "real" mip level knob that controls the level read by the Reader
         // class, and whose value is stored when the Read is serialized.
         mipLevelKnob_ = Int_knob(cb, &mipLevel_, "tx_mip_level", "mip index");
@@ -57,13 +58,16 @@ public:
         // Reader when it opens a file, and does not directly contribute to the
         // op hash or get stored when the Read is serialized.
         mipLevelEnumKnob_ = Enumeration_knob(cb, &mipEnumIndex_, EMPTY,
-                                            "tx_user_mip_level", "mip level");
-        SetFlags(cb, Knob::EXPAND_TO_WIDTH | Knob::DO_NOT_WRITE | Knob::NO_RERENDER);
-        Tooltip(cb, "The mip level to read from the file. Currently, this will "
+                                             "tx_user_mip_level", "mip level");
+        SetFlags(cb, Knob::EXPAND_TO_WIDTH | Knob::DO_NOT_WRITE
+                         | Knob::NO_RERENDER);
+        Tooltip(cb,
+                "The mip level to read from the file. Currently, this will "
                 "be resampled to fill the same resolution as the base image.");
     }
 
-    int knob_changed(Knob* k) {
+    int knob_changed(Knob* k)
+    {
         if (k == mipLevelEnumKnob_)
             mipLevelKnob_->set_value(mipEnumIndex_);
         return 1;
@@ -73,12 +77,13 @@ public:
 
     inline int mipLevel() { return mipLevel_; }
 
-    void setMipLabels(std::vector<std::string> items) {
+    void setMipLabels(std::vector<std::string> items)
+    {
         if (mipLevelEnumKnob_) {
             mipLevelEnumKnob_->set_flag(Knob::NO_KNOB_CHANGED);
             mipLevelEnumKnob_->enumerationKnob()->menu(items);
             mipLevelEnumKnob_->set_value(
-                    std::min((int)items.size() - 1, mipLevel_));
+                std::min((int)items.size() - 1, mipLevel_));
             mipLevelEnumKnob_->clear_flag(Knob::NO_KNOB_CHANGED);
         }
     }
@@ -100,32 +105,31 @@ class txReader : public Reader {
 
     static const Description d;
 
-    void fillMetadata(const ImageSpec& spec, bool isEXR) {
+    void fillMetadata(const ImageSpec& spec, bool isEXR)
+    {
         switch (spec.format.basetype) {
-            case TypeDesc::UINT8:
-            case TypeDesc::INT8:
-                meta_.setData(MetaData::DEPTH, MetaData::DEPTH_8);
-                break;
-            case TypeDesc::UINT16:
-            case TypeDesc::INT16:
-                meta_.setData(MetaData::DEPTH, MetaData::DEPTH_16);
-                break;
-            case TypeDesc::UINT32:
-            case TypeDesc::INT32:
-                meta_.setData(MetaData::DEPTH, MetaData::DEPTH_32);
-                break;
-            case TypeDesc::HALF:
-                meta_.setData(MetaData::DEPTH, MetaData::DEPTH_HALF);
-                break;
-            case TypeDesc::FLOAT:
-                meta_.setData(MetaData::DEPTH, MetaData::DEPTH_FLOAT);
-                break;
-            case TypeDesc::DOUBLE:
-                meta_.setData(MetaData::DEPTH, MetaData::DEPTH_DOUBLE);
-                break;
-            default:
-                meta_.setData(MetaData::DEPTH, "Unknown");
-                break;
+        case TypeDesc::UINT8:
+        case TypeDesc::INT8:
+            meta_.setData(MetaData::DEPTH, MetaData::DEPTH_8);
+            break;
+        case TypeDesc::UINT16:
+        case TypeDesc::INT16:
+            meta_.setData(MetaData::DEPTH, MetaData::DEPTH_16);
+            break;
+        case TypeDesc::UINT32:
+        case TypeDesc::INT32:
+            meta_.setData(MetaData::DEPTH, MetaData::DEPTH_32);
+            break;
+        case TypeDesc::HALF:
+            meta_.setData(MetaData::DEPTH, MetaData::DEPTH_HALF);
+            break;
+        case TypeDesc::FLOAT:
+            meta_.setData(MetaData::DEPTH, MetaData::DEPTH_FLOAT);
+            break;
+        case TypeDesc::DOUBLE:
+            meta_.setData(MetaData::DEPTH, MetaData::DEPTH_DOUBLE);
+            break;
+        default: meta_.setData(MetaData::DEPTH, "Unknown"); break;
         }
 
         meta_.setData("tx/tile_width", spec.tile_width);
@@ -166,24 +170,26 @@ class txReader : public Reader {
             if (!val.empty())
                 meta_.setData("exr/line_order", val);
 
-            float cl = spec.get_float_attribute("openexr:dwaCompressionLevel", 0.0f);
+            float cl = spec.get_float_attribute("openexr:dwaCompressionLevel",
+                                                0.0f);
             if (val > 0)
                 meta_.setData("exr/dwa_compression_level", cl);
-        }
-        else {
+        } else {
             val = spec.get_string_attribute("tiff:planarconfig");
             if (!val.empty())
                 meta_.setData("tiff/planar_config", val);
         }
     }
 
-    void setChannels(const ImageSpec& spec) {
+    void setChannels(const ImageSpec& spec)
+    {
         ChannelSet mask;
         Channel chan;
         int chanIndex = 0;
 
-        for (std::vector<std::string>::const_iterator it = spec.channelnames.begin();
-                it != spec.channelnames.end(); it++) {
+        for (std::vector<std::string>::const_iterator it
+             = spec.channelnames.begin();
+             it != spec.channelnames.end(); it++) {
             chan = Reader::channel(it->c_str());
             mask += chan;
             chanMap_[chan] = chanIndex++;
@@ -193,12 +199,13 @@ class txReader : public Reader {
     }
 
 public:
-    txReader(Read* iop) : Reader(iop),
-            oiioInput_(ImageInput::open(filename())),
-            chanCount_(0),
-            lastMipLevel_(-1),
-            haveImage_(false),
-            flip_(false)
+    txReader(Read* iop)
+        : Reader(iop)
+        , oiioInput_(ImageInput::open(filename()))
+        , chanCount_(0)
+        , lastMipLevel_(-1)
+        , haveImage_(false)
+        , flip_(false)
     {
         txFmt_ = dynamic_cast<TxReaderFormat*>(iop->handler());
 
@@ -214,28 +221,30 @@ public:
 
         if (!(baseSpec.width * baseSpec.height)) {
             iop->internalError("tx file has one or more zero dimensions "
-                               "(%d x %d)", baseSpec.width, baseSpec.height);
+                               "(%d x %d)",
+                               baseSpec.width, baseSpec.height);
             return;
         }
 
-        chanCount_ = baseSpec.nchannels;
+        chanCount_       = baseSpec.nchannels;
         const bool isEXR = strcmp(oiioInput_->format_name(), "openexr") == 0;
 
         if (isEXR) {
-            float pixAspect = baseSpec.get_float_attribute("PixelAspectRatio", 0);
+            float pixAspect = baseSpec.get_float_attribute("PixelAspectRatio",
+                                                           0);
             set_info(baseSpec.width, baseSpec.height, 1, pixAspect);
-            meta_.setData(MetaData::PIXEL_ASPECT, pixAspect > 0 ? pixAspect : 1.0f);
+            meta_.setData(MetaData::PIXEL_ASPECT,
+                          pixAspect > 0 ? pixAspect : 1.0f);
             setChannels(baseSpec);  // Fills chanMap_
             flip_ = true;
-        }
-        else {
+        } else {
             set_info(baseSpec.width, baseSpec.height, chanCount_);
             int orientation = baseSpec.get_int_attribute("Orientation", 1);
             meta_.setData("tiff/orientation", orientation);
             flip_ = !((orientation - 1) & 2);
 
             int chanIndex = 0;
-            foreach(z, info_.channels())
+            foreach (z, info_.channels())
                 chanMap_[z] = chanIndex++;
         }
 
@@ -254,8 +263,7 @@ public:
                 buf.str(std::string());
                 buf.clear();
                 mipLevel++;
-            }
-            else
+            } else
                 break;
         }
 
@@ -264,17 +272,20 @@ public:
         txFmt_->setMipLabels(mipLabels);
     }
 
-    virtual ~txReader() {
+    virtual ~txReader()
+    {
         if (oiioInput_)
             oiioInput_->close();
     }
 
-    void open() {
+    void open()
+    {
         if (lastMipLevel_ != txFmt_->mipLevel()) {
             ImageSpec mipSpec;
             if (!oiioInput_->seek_subimage(0, txFmt_->mipLevel(), mipSpec)) {
                 iop->internalError("Failed to seek to mip level %d: %s",
-                        txFmt_->mipLevel(), oiioInput_->geterror().c_str());
+                                   txFmt_->mipLevel(),
+                                   oiioInput_->geterror().c_str());
                 return;
             }
 
@@ -285,13 +296,13 @@ public:
             }
 
             lastMipLevel_ = txFmt_->mipLevel();
-            haveImage_ = false;
+            haveImage_    = false;
         }
 
         if (!haveImage_) {
             const int needSize = oiioInput_->spec().width
-                                * oiioInput_->spec().height
-                                * oiioInput_->spec().nchannels;
+                                 * oiioInput_->spec().height
+                                 * oiioInput_->spec().nchannels;
             if (size_t(needSize) > imageBuf_.size())
                 imageBuf_.resize(needSize);
             oiioInput_->read_image(&imageBuf_[0]);
@@ -299,7 +310,8 @@ public:
         }
     }
 
-    void engine(int y, int x, int r, ChannelMask channels, Row& row) {
+    void engine(int y, int x, int r, ChannelMask channels, Row& row)
+    {
         if (!haveImage_)
             iop->internalError("engine called, but haveImage_ is false");
 
@@ -314,18 +326,19 @@ public:
             y = height() - y - 1;
 
         if (lastMipLevel_) {  // Mip level other than 0
-            const int mipW = oiioInput_->spec().width;
+            const int mipW    = oiioInput_->spec().width;
             const int mipMult = width() / mipW;
 
-            y = y * oiioInput_->spec().height / height();
+            y              = y * oiioInput_->spec().height / height();
             const int bufX = x ? x / mipMult : 0;
             const int bufR = r / mipMult;
             const int bufW = bufR - bufX;
 
             std::vector<float> chanBuf(bufW);
-            float* chanStart = &chanBuf[0];
+            float* chanStart   = &chanBuf[0];
             const int bufStart = y * mipW * chanCount_ + bufX * chanCount_;
-            const float* alpha = doAlpha ? &imageBuf_[bufStart + chanMap_[Chan_Alpha]] : NULL;
+            const float* alpha
+                = doAlpha ? &imageBuf_[bufStart + chanMap_[Chan_Alpha]] : NULL;
             foreach (z, channels) {
                 from_float(z, &chanBuf[0], &imageBuf_[bufStart + chanMap_[z]],
                            alpha, bufW, chanCount_);
@@ -335,14 +348,15 @@ public:
                     for (; c < mipMult; c++)
                         *OUT++ = *(chanStart + stride);
             }
-        }
-        else {  // Mip level 0
+        } else {  // Mip level 0
             const int pixStart = y * width() * chanCount_ + x * chanCount_;
-            const float* alpha = doAlpha ? &imageBuf_[pixStart + chanMap_[Chan_Alpha]] : NULL;
+            const float* alpha
+                = doAlpha ? &imageBuf_[pixStart + chanMap_[Chan_Alpha]] : NULL;
 
             foreach (z, channels) {
-                from_float(z, row.writable(z) + x, &imageBuf_[pixStart + chanMap_[z]],
-                           alpha, r - x, chanCount_);
+                from_float(z, row.writable(z) + x,
+                           &imageBuf_[pixStart + chanMap_[z]], alpha, r - x,
+                           chanCount_);
             }
         }
     }
@@ -351,10 +365,12 @@ public:
 };
 
 
-}  // ~TxReaderNS
+}  // namespace TxReaderNS
 
 
-static Reader* buildReader(Read* iop, int fd, const unsigned char* b, int n) {
+static Reader*
+buildReader(Read* iop, int fd, const unsigned char* b, int n)
+{
     // FIXME: I expect that this close() may be problematic on Windows.
     // For Linux/gcc, we needed to #include <unistd.h> at the top of
     // this file. If this is a problem for Windows, a different #include
@@ -363,11 +379,15 @@ static Reader* buildReader(Read* iop, int fd, const unsigned char* b, int n) {
     return new TxReaderNS::txReader(iop);
 }
 
-static ReaderFormat* buildformat(Read* iop) {
+static ReaderFormat*
+buildformat(Read* iop)
+{
     return new TxReaderNS::TxReaderFormat();
 }
 
-static bool test(int fd, const unsigned char* block, int length) {
+static bool
+test(int fd, const unsigned char* block, int length)
+{
     // Big-endian TIFF
     if (block[0] == 'M' && block[1] == 'M' && block[2] == 0 && block[3] == 42)
         return true;
@@ -375,8 +395,8 @@ static bool test(int fd, const unsigned char* block, int length) {
     if (block[0] == 'I' && block[1] == 'I' && block[2] == 42 && block[3] == 0)
         return true;
     // EXR
-    return block[0] == 0x76 && block[1] == 0x2f &&
-           block[2] == 0x31 && block[3] == 0x01;
+    return block[0] == 0x76 && block[1] == 0x2f && block[2] == 0x31
+           && block[3] == 0x01;
 }
 
 const Reader::Description TxReaderNS::txReader::d("tx\0TX\0", buildReader, test,

--- a/src/nuke/txWriter/txWriter.cpp
+++ b/src/nuke/txWriter/txWriter.cpp
@@ -1,8 +1,8 @@
 #include <vector>
 
-#include "DDImage/Writer.h"
-#include "DDImage/Thread.h"
 #include "DDImage/Row.h"
+#include "DDImage/Thread.h"
+#include "DDImage/Writer.h"
 
 #include <OpenImageIO/filter.h>
 #include <OpenImageIO/imagebuf.h>
@@ -23,50 +23,40 @@
 using namespace DD::Image;
 
 
-namespace TxWriterNS
-{
+namespace TxWriterNS {
 
 
 using namespace OIIO;
 
 // Limit the available output datatypes (for now, at least).
-static const TypeDesc::BASETYPE oiioBitDepths[] = {TypeDesc::INT8,
-                                                   TypeDesc::INT16,
-                                                   TypeDesc::INT32,
-                                                   TypeDesc::FLOAT,
-                                                   TypeDesc::DOUBLE};
+static const TypeDesc::BASETYPE oiioBitDepths[]
+    = { TypeDesc::INT8, TypeDesc::INT16, TypeDesc::INT32, TypeDesc::FLOAT,
+        TypeDesc::DOUBLE };
 
 // Knob values for above bit depths (keep them synced!)
-static const char* const bitDepthValues[] = {"8-bit integer",
-                                             "16-bit integer",
-                                             "32-bit integer",
-                                             "32-bit float",
-                                             "64-bit double",
-                                             NULL};
+static const char* const bitDepthValues[]
+    = { "8-bit integer", "16-bit integer", "32-bit integer",
+        "32-bit float",  "64-bit double",  NULL };
 
 // Knob values for NaN fix modes
-static const char* const nanFixValues[] = {"black\tblack",
-                                           "box3\tbox3 filter",
-                                           NULL};
+static const char* const nanFixValues[] = { "black\tblack", "box3\tbox3 filter",
+                                            NULL };
 
 // Knob values for "preset" modes
-static const char* const presetValues[] = {"oiio", "prman", "custom", NULL};
+static const char* const presetValues[] = { "oiio", "prman", "custom", NULL };
 
 // Knob values for planar configuration
-static const char* const planarValues[] = {"contig\tcontiguous",
-                                           "separate",
-                                           NULL};
+static const char* const planarValues[] = { "contig\tcontiguous", "separate",
+                                            NULL };
 
 // Knob values for texture mode configuration
-static const char* const txModeValues[] = {"Ordinary 2D texture",
-                                           "Latitude-longitude environment map",
-                                           "Latitude-longitude environment map (light probe)",
-                                           "Shadow texture",
-                                           NULL};
-static const ImageBufAlgo::MakeTextureMode oiiotxMode[] = {ImageBufAlgo::MakeTxTexture,
-                                                           ImageBufAlgo::MakeTxEnvLatl,
-                                                           ImageBufAlgo::MakeTxEnvLatlFromLightProbe,
-                                                           ImageBufAlgo::MakeTxShadow};
+static const char* const txModeValues[] = {
+    "Ordinary 2D texture", "Latitude-longitude environment map",
+    "Latitude-longitude environment map (light probe)", "Shadow texture", NULL
+};
+static const ImageBufAlgo::MakeTextureMode oiiotxMode[]
+    = { ImageBufAlgo::MakeTxTexture, ImageBufAlgo::MakeTxEnvLatl,
+        ImageBufAlgo::MakeTxEnvLatlFromLightProbe, ImageBufAlgo::MakeTxShadow };
 
 
 bool gTxFiltersInitialized = false;
@@ -87,7 +77,8 @@ class txWriter : public Writer {
     bool stats_;
 
 
-    void setChannelNames(ImageSpec& spec, const ChannelSet& channels) {
+    void setChannelNames(ImageSpec& spec, const ChannelSet& channels)
+    {
         if (channels == Mask_RGB || channels == Mask_RGBA)
             return;
 
@@ -97,26 +88,18 @@ class txWriter : public Writer {
             if (index > 0)
                 buf << ",";
             switch (z) {
-                case Chan_Red:
-                    buf << "R";
-                    break;
-                case Chan_Green:
-                    buf << "G";
-                    break;
-                case Chan_Blue:
-                    buf << "B";
-                    break;
-                case Chan_Alpha:
-                    buf << "A";
-                    spec.alpha_channel = index;
-                    break;
-                case Chan_Z:
-                    buf << "Z";
-                    spec.z_channel = index;
-                    break;
-                default:
-                    buf << getName(z);
-                    break;
+            case Chan_Red: buf << "R"; break;
+            case Chan_Green: buf << "G"; break;
+            case Chan_Blue: buf << "B"; break;
+            case Chan_Alpha:
+                buf << "A";
+                spec.alpha_channel = index;
+                break;
+            case Chan_Z:
+                buf << "Z";
+                spec.z_channel = index;
+                break;
+            default: buf << getName(z); break;
             }
             index++;
         }
@@ -124,23 +107,27 @@ class txWriter : public Writer {
     }
 
 public:
-    txWriter(Write* iop) : Writer(iop),
-            preset_(0),
-            tileW_(64), tileH_(64),
-            planarMode_(0),
-            txMode_(0),    // ordinary 2d texture
-            bitDepth_(3),  // float
-            filter_(0),
-            fixNan_(false),
-            nanFixType_(0),
-            checkNan_(true),
-            verbose_(false),
-            stats_(false)
+    txWriter(Write* iop)
+        : Writer(iop)
+        , preset_(0)
+        , tileW_(64)
+        , tileH_(64)
+        , planarMode_(0)
+        , txMode_(0)
+        ,  // ordinary 2d texture
+        bitDepth_(3)
+        ,  // float
+        filter_(0)
+        , fixNan_(false)
+        , nanFixType_(0)
+        , checkNan_(true)
+        , verbose_(false)
+        , stats_(false)
     {
         if (!gTxFiltersInitialized) {
-            for (int i = 0, e = Filter2D::num_filters();  i < e;  ++i) {
+            for (int i = 0, e = Filter2D::num_filters(); i < e; ++i) {
                 FilterDesc d;
-                Filter2D::get_filterdesc (i, &d);
+                Filter2D::get_filterdesc(i, &d);
                 gFilterNames.push_back(d.name);
             };
             gFilterNames.push_back(NULL);
@@ -148,9 +135,11 @@ public:
         }
     }
 
-    void knobs(Knob_Callback cb) {
+    void knobs(Knob_Callback cb)
+    {
         Enumeration_knob(cb, &preset_, &presetValues[0], "preset");
-        Tooltip(cb, "Choose a preset for various output parameters.\n"
+        Tooltip(cb,
+                "Choose a preset for various output parameters.\n"
                 "<b>oiio</b>: Tile and planar settings optimized for OIIO.\n"
                 "<b>prman</b>: Tile and planar ettings and metadata safe for "
                 "use with prman.");
@@ -181,8 +170,7 @@ public:
         Tooltip(cb, "Planar mode of the image channels.");
         SetFlags(cb, Knob::STARTLINE);
 
-        Enumeration_knob(cb, &txMode_, &txModeValues[0], "tx_mode",
-                         "mode");
+        Enumeration_knob(cb, &txMode_, &txModeValues[0], "tx_mode", "mode");
         Tooltip(cb, "What type of texture file we are creating.");
 
         Enumeration_knob(cb, &bitDepth_, &bitDepthValues[0], "tx_datatype",
@@ -191,14 +179,14 @@ public:
 
         Enumeration_knob(cb, &filter_, &gFilterNames[0], "tx_filter", "filter");
         Tooltip(cb, "The filter used to resize the image when generating mip "
-                "levels.");
+                    "levels.");
 
         Bool_knob(cb, &fixNan_, "fix_nan", "fix NaN/Inf pixels");
         Tooltip(cb, "Attempt to fix NaN/Inf pixel values in the image.");
         SetFlags(cb, Knob::STARTLINE);
 
-        k = Enumeration_knob(cb, &nanFixType_, &nanFixValues[0],
-                             "nan_fix_type", "");
+        k = Enumeration_knob(cb, &nanFixType_, &nanFixValues[0], "nan_fix_type",
+                             "");
         if (cb.makeKnobs())
             k->disable();
         else if (fixNan_)
@@ -207,7 +195,8 @@ public:
         ClearFlags(cb, Knob::STARTLINE);
 
         Bool_knob(cb, &checkNan_, "check_nan", "error on NaN/Inf");
-        Tooltip(cb, "Check for NaN/Inf pixel values in the output image, and "
+        Tooltip(cb,
+                "Check for NaN/Inf pixel values in the output image, and "
                 "error if any are found. If this is enabled, the check will be "
                 "run <b>after</b> the NaN fix process.");
         SetFlags(cb, Knob::STARTLINE);
@@ -221,7 +210,8 @@ public:
         ClearFlags(cb, Knob::STARTLINE);
     }
 
-    int knob_changed(Knob* k) {
+    int knob_changed(Knob* k)
+    {
         if (k->is("fix_nan")) {
             iop->knob("nan_fix_type")->enable(fixNan_);
             return 1;
@@ -237,10 +227,11 @@ public:
         return Writer::knob_changed(k);
     }
 
-    void execute() {
+    void execute()
+    {
         const int chanCount = num_channels();
         ChannelSet channels = channel_mask(chanCount);
-        const bool doAlpha = channels.contains(Chan_Alpha);
+        const bool doAlpha  = channels.contains(Chan_Alpha);
 
         iop->progressMessage("Preparing image");
         input0().request(0, 0, width(), height(), channels, 1);
@@ -269,25 +260,22 @@ public:
                 srcBuffer.setpixel(x, y, &lutBuffer[x * chanCount]);
         }
 
-        ImageSpec destSpec(width(), height(), chanCount, oiioBitDepths[bitDepth_]);
+        ImageSpec destSpec(width(), height(), chanCount,
+                           oiioBitDepths[bitDepth_]);
 
         setChannelNames(destSpec, channels);
 
         destSpec.attribute("maketx:filtername", gFilterNames[filter_]);
 
         switch (preset_) {
-            case 0:
-                destSpec.attribute("maketx:oiio_options", 1);
-                break;
-            case 1:
-                destSpec.attribute("maketx:prman_options", 1);
-                break;
-            default:
-                destSpec.tile_width = tileW_;
-                destSpec.tile_height = tileH_;
-                destSpec.attribute("planarconfig",
-                                   planarMode_ ? "separate" : "contig");
-                break;
+        case 0: destSpec.attribute("maketx:oiio_options", 1); break;
+        case 1: destSpec.attribute("maketx:prman_options", 1); break;
+        default:
+            destSpec.tile_width  = tileW_;
+            destSpec.tile_height = tileH_;
+            destSpec.attribute("planarconfig",
+                               planarMode_ ? "separate" : "contig");
+            break;
         }
 
         if (fixNan_) {
@@ -295,8 +283,7 @@ public:
                 destSpec.attribute("maketx:fixnan", "box3");
             else
                 destSpec.attribute("maketx:fixnan", "black");
-        }
-        else
+        } else
             destSpec.attribute("maketx:fixnan", "none");
 
         destSpec.attribute("maketx:checknan", checkNan_);
@@ -321,8 +308,12 @@ public:
 };
 
 
-}  // ~TxWriterNS
+}  // namespace TxWriterNS
 
 
-static Writer* build(Write* iop) { return new TxWriterNS::txWriter(iop); }
+static Writer*
+build(Write* iop)
+{
+    return new TxWriterNS::txWriter(iop);
+}
 const Writer::Description TxWriterNS::txWriter::d("tx\0TX\0", build);

--- a/src/oiiotool/diff.cpp
+++ b/src/oiiotool/diff.cpp
@@ -29,21 +29,21 @@
 */
 
 
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>
-#include <cmath>
+#include <iomanip>
 #include <iostream>
 #include <iterator>
-#include <vector>
 #include <string>
-#include <iomanip>
+#include <vector>
 
 #include <OpenImageIO/argparse.h>
-#include <OpenImageIO/imageio.h>
+#include <OpenImageIO/filter.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
-#include <OpenImageIO/filter.h>
+#include <OpenImageIO/imageio.h>
 
 #include "oiiotool.h"
 
@@ -53,16 +53,15 @@ using namespace ImageBufAlgo;
 
 
 
-
 // function that standarize printing NaN and Inf values on
 // Windows (where they are in 1.#INF, 1.#NAN format) and all
 // others platform
 inline void
-safe_double_print (double val)
+safe_double_print(double val)
 {
-    if (OIIO::isnan (val))
+    if (OIIO::isnan(val))
         std::cout << "nan";
-    else if (OIIO::isinf (val))
+    else if (OIIO::isinf(val))
         std::cout << "inf";
     else
         std::cout << val;
@@ -72,7 +71,7 @@ safe_double_print (double val)
 
 
 inline void
-print_subimage (ImageRec &img0, int subimage, int miplevel)
+print_subimage(ImageRec& img0, int subimage, int miplevel)
 {
     if (img0.subimages() > 1)
         std::cout << "Subimage " << subimage << ' ';
@@ -80,7 +79,7 @@ print_subimage (ImageRec &img0, int subimage, int miplevel)
         std::cout << " MIP level " << miplevel << ' ';
     if (img0.subimages() > 1 || img0.miplevels(subimage) > 1)
         std::cout << ": ";
-    const ImageSpec &spec (*img0.spec(subimage));
+    const ImageSpec& spec(*img0.spec(subimage));
     std::cout << spec.width << " x " << spec.height;
     if (spec.depth > 1)
         std::cout << " x " << spec.depth;
@@ -90,55 +89,60 @@ print_subimage (ImageRec &img0, int subimage, int miplevel)
 
 
 int
-OiioTool::do_action_diff (ImageRec &ir0, ImageRec &ir1,
-                          Oiiotool &ot, int perceptual)
+OiioTool::do_action_diff(ImageRec& ir0, ImageRec& ir1, Oiiotool& ot,
+                         int perceptual)
 {
     std::cout << "Computing " << (perceptual ? "perceptual " : "")
-              << "diff of \"" << ir0.name() << "\" vs \""
-              << ir1.name() << "\"\n";
-    ir0.read ();
-    ir1.read ();
+              << "diff of \"" << ir0.name() << "\" vs \"" << ir1.name()
+              << "\"\n";
+    ir0.read();
+    ir1.read();
 
     int ret = DiffErrOK;
-    for (int subimage = 0;  subimage < ir0.subimages();  ++subimage) {
+    for (int subimage = 0; subimage < ir0.subimages(); ++subimage) {
         if (subimage > 0 && !ot.allsubimages)
             break;
         if (subimage >= ir1.subimages())
             break;
 
-        for (int m = 0;  m < ir0.miplevels(subimage);  ++m) {
+        for (int m = 0; m < ir0.miplevels(subimage); ++m) {
             if (m > 0 && !ot.allsubimages)
                 break;
             if (m > 0 && ir0.miplevels(subimage) != ir1.miplevels(subimage)) {
-                std::cout << "Files do not match in their number of MIPmap levels\n";
+                std::cout
+                    << "Files do not match in their number of MIPmap levels\n";
                 ret = DiffErrDifferentSize;
                 break;
             }
 
-            ImageBuf &img0 (ir0(subimage,m));
-            ImageBuf &img1 (ir1(subimage,m));
-            int npels = img0.spec().width * img0.spec().height * img0.spec().depth;
+            ImageBuf& img0(ir0(subimage, m));
+            ImageBuf& img1(ir1(subimage, m));
+            int npels = img0.spec().width * img0.spec().height
+                        * img0.spec().depth;
             if (npels == 0)
-                npels = 1;    // Avoid divide by zero for 0x0 images
-            ASSERT (img0.spec().format == TypeDesc::FLOAT);
+                npels = 1;  // Avoid divide by zero for 0x0 images
+            ASSERT(img0.spec().format == TypeDesc::FLOAT);
 
             // Compare the two images.
             //
             ImageBufAlgo::CompareResults cr;
             int yee_failures = 0;
             switch (perceptual) {
-            case 1 :
-                yee_failures = ImageBufAlgo::compare_Yee (img0, img1, cr);
+            case 1:
+                yee_failures = ImageBufAlgo::compare_Yee(img0, img1, cr);
                 break;
             default:
-                ImageBufAlgo::compare (img0, img1, ot.diff_failthresh, ot.diff_warnthresh, cr);
+                ImageBufAlgo::compare(img0, img1, ot.diff_failthresh,
+                                      ot.diff_warnthresh, cr);
                 break;
             }
 
-            if (cr.nfail > (ot.diff_failpercent/100.0 * npels) || cr.maxerror > ot.diff_hardfail ||
-                yee_failures > (ot.diff_failpercent/100.0 * npels)) {
+            if (cr.nfail > (ot.diff_failpercent / 100.0 * npels)
+                || cr.maxerror > ot.diff_hardfail
+                || yee_failures > (ot.diff_failpercent / 100.0 * npels)) {
                 ret = DiffErrFail;
-            } else if (cr.nwarn > (ot.diff_warnpercent/100.0 * npels) || cr.maxerror > ot.diff_hardwarn) {
+            } else if (cr.nwarn > (ot.diff_warnpercent / 100.0 * npels)
+                       || cr.maxerror > ot.diff_hardwarn) {
                 if (ret != DiffErrFail)
                     ret = DiffErrWarn;
             }
@@ -147,49 +151,57 @@ OiioTool::do_action_diff (ImageRec &ir0, ImageRec &ir1,
             //
             if (ot.verbose || ot.debug || ret != DiffErrOK) {
                 if (ot.allsubimages)
-                    print_subimage (ir0, subimage, m);
+                    print_subimage(ir0, subimage, m);
                 std::cout << "  Mean error = ";
-                safe_double_print (cr.meanerror);
+                safe_double_print(cr.meanerror);
                 std::cout << "  RMS error = ";
-                safe_double_print (cr.rms_error);
+                safe_double_print(cr.rms_error);
                 std::cout << "  Peak SNR = ";
-                safe_double_print (cr.PSNR);
+                safe_double_print(cr.PSNR);
                 std::cout << "  Max error  = " << cr.maxerror;
                 if (cr.maxerror != 0) {
                     std::cout << " @ (" << cr.maxx << ", " << cr.maxy;
                     if (img0.spec().depth > 1)
                         std::cout << ", " << cr.maxz;
                     if (cr.maxc < (int)img0.spec().channelnames.size())
-                        std::cout << ", " << img0.spec().channelnames[cr.maxc] << ')';
+                        std::cout << ", " << img0.spec().channelnames[cr.maxc]
+                                  << ')';
                     else if (cr.maxc < (int)img1.spec().channelnames.size())
-                        std::cout << ", " << img1.spec().channelnames[cr.maxc] << ')';
+                        std::cout << ", " << img1.spec().channelnames[cr.maxc]
+                                  << ')';
                     else
                         std::cout << ", channel " << cr.maxc << ')';
-                    if (! img0.deep()) {
+                    if (!img0.deep()) {
                         std::cout << "  values are ";
                         for (int c = 0; c < img0.spec().nchannels; ++c)
-                            std::cout << (c ? ", " : "") << img0.getchannel(cr.maxx, cr.maxy, 0, c);
+                            std::cout
+                                << (c ? ", " : "")
+                                << img0.getchannel(cr.maxx, cr.maxy, 0, c);
                         std::cout << " vs ";
                         for (int c = 0; c < img1.spec().nchannels; ++c)
-                            std::cout << (c ? ", " : "") << img1.getchannel(cr.maxx, cr.maxy, 0, c);
+                            std::cout
+                                << (c ? ", " : "")
+                                << img1.getchannel(cr.maxx, cr.maxy, 0, c);
                     }
                 }
                 std::cout << "\n";
 
                 std::streamsize precis = std::cout.precision();
-                std::cout << "  " << cr.nwarn << " pixels (" 
-                          << std::setprecision(3) << (100.0*cr.nwarn / npels) 
-                          << std::setprecision(precis) << "%) over " << ot.diff_warnthresh << "\n";
-                std::cout << "  " << cr.nfail << " pixels (" 
-                          << std::setprecision(3) << (100.0*cr.nfail / npels) 
-                          << std::setprecision(precis) << "%) over " << ot.diff_failthresh << "\n";
+                std::cout << "  " << cr.nwarn << " pixels ("
+                          << std::setprecision(3) << (100.0 * cr.nwarn / npels)
+                          << std::setprecision(precis) << "%) over "
+                          << ot.diff_warnthresh << "\n";
+                std::cout << "  " << cr.nfail << " pixels ("
+                          << std::setprecision(3) << (100.0 * cr.nfail / npels)
+                          << std::setprecision(precis) << "%) over "
+                          << ot.diff_failthresh << "\n";
                 if (perceptual == 1)
                     std::cout << "  " << yee_failures << " pixels ("
-                              << std::setprecision(3) << (100.0*yee_failures / npels) 
+                              << std::setprecision(3)
+                              << (100.0 * yee_failures / npels)
                               << std::setprecision(precis)
                               << "%) failed the perceptual test\n";
             }
-
         }
     }
 
@@ -199,9 +211,8 @@ OiioTool::do_action_diff (ImageRec &ir0, ImageRec &ir1,
         ret = DiffErrFail;
     }
     if (!ot.allsubimages && (ir0.subimages() > 1 || ir1.subimages() > 1)) {
-        std::cout << "Only compared the first subimage (of "
-                  << ir0.subimages() << " and " << ir1.subimages() 
-                  << ", respectively)\n";
+        std::cout << "Only compared the first subimage (of " << ir0.subimages()
+                  << " and " << ir1.subimages() << ", respectively)\n";
     }
 
     if (ret == DiffErrOK)

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -29,29 +29,29 @@
 */
 
 
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
-#include <cmath>
 #include <iostream>
 #include <iterator>
-#include <vector>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <OpenImageIO/argparse.h>
-#include <OpenImageIO/imageio.h>
-#include <OpenImageIO/imagebuf.h>
-#include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/filter.h>
+#include <OpenImageIO/imagebuf.h>
+#include <OpenImageIO/imagebufalgo.h>
+#include <OpenImageIO/imageio.h>
 #include <OpenImageIO/thread.h>
 
 #include "oiiotool.h"
 
 #ifdef USE_BOOST_REGEX
-# include <boost/regex.hpp>
+#    include <boost/regex.hpp>
 #else
-# include <regex>
+#    include <regex>
 #endif
 
 using namespace OIIO;
@@ -60,20 +60,21 @@ using namespace ImageBufAlgo;
 
 
 
-ImageRec::ImageRec (const std::string &name, int nsubimages,
-                    const int *miplevels, const ImageSpec *specs)
-    : m_name(name), m_elaborated(true)
+ImageRec::ImageRec(const std::string& name, int nsubimages,
+                   const int* miplevels, const ImageSpec* specs)
+    : m_name(name)
+    , m_elaborated(true)
 {
     int specnum = 0;
-    m_subimages.resize (nsubimages);
-    for (int s = 0;  s < nsubimages;  ++s) {
+    m_subimages.resize(nsubimages);
+    for (int s = 0; s < nsubimages; ++s) {
         int nmips = miplevels ? miplevels[s] : 1;
-        m_subimages[s].m_miplevels.resize (nmips);
-        m_subimages[s].m_specs.resize (nmips);
-        for (int m = 0;  m < nmips;  ++m) {
-            ImageBuf *ib = specs ? new ImageBuf (specs[specnum])
-                                 : new ImageBuf ();
-            m_subimages[s].m_miplevels[m].reset (ib);
+        m_subimages[s].m_miplevels.resize(nmips);
+        m_subimages[s].m_specs.resize(nmips);
+        for (int m = 0; m < nmips; ++m) {
+            ImageBuf* ib = specs ? new ImageBuf(specs[specnum])
+                                 : new ImageBuf();
+            m_subimages[s].m_miplevels[m].reset(ib);
             if (specs)
                 m_subimages[s].m_specs[m] = specs[specnum];
             ++specnum;
@@ -83,39 +84,41 @@ ImageRec::ImageRec (const std::string &name, int nsubimages,
 
 
 
-ImageRec::ImageRec (ImageRec &img, int subimage_to_copy,
-                    int miplevel_to_copy, bool writable, bool copy_pixels)
-    : m_name(img.name()), m_elaborated(true), m_imagecache(img.m_imagecache)
+ImageRec::ImageRec(ImageRec& img, int subimage_to_copy, int miplevel_to_copy,
+                   bool writable, bool copy_pixels)
+    : m_name(img.name())
+    , m_elaborated(true)
+    , m_imagecache(img.m_imagecache)
 {
-    img.read ();
-    int first_subimage = std::max (0, subimage_to_copy);
-    int subimages = (subimage_to_copy < 0) ? img.subimages() : 1;
-    m_subimages.resize (subimages);
-    for (int s = 0;  s < subimages;  ++s) {
-        int srcsub = s + first_subimage;
-        int first_miplevel = std::max (0, miplevel_to_copy);
-        int miplevels = (miplevel_to_copy < 0) ? img.miplevels(srcsub) : 1;
-        m_subimages[s].m_miplevels.resize (miplevels);
-        m_subimages[s].m_specs.resize (miplevels);
-        for (int m = 0;  m < miplevels;  ++m) {
+    img.read();
+    int first_subimage = std::max(0, subimage_to_copy);
+    int subimages      = (subimage_to_copy < 0) ? img.subimages() : 1;
+    m_subimages.resize(subimages);
+    for (int s = 0; s < subimages; ++s) {
+        int srcsub         = s + first_subimage;
+        int first_miplevel = std::max(0, miplevel_to_copy);
+        int miplevels      = (miplevel_to_copy < 0) ? img.miplevels(srcsub) : 1;
+        m_subimages[s].m_miplevels.resize(miplevels);
+        m_subimages[s].m_specs.resize(miplevels);
+        for (int m = 0; m < miplevels; ++m) {
             int srcmip = m + first_miplevel;
-            const ImageBuf &srcib (img(srcsub,srcmip));
-            const ImageSpec &srcspec (*img.spec(srcsub,srcmip));
-            ImageBuf *ib = NULL;
+            const ImageBuf& srcib(img(srcsub, srcmip));
+            const ImageSpec& srcspec(*img.spec(srcsub, srcmip));
+            ImageBuf* ib = NULL;
             if (writable || img.pixels_modified() || !copy_pixels) {
                 // Make our own copy of the pixels
-                ib = new ImageBuf (srcspec);
+                ib = new ImageBuf(srcspec);
                 if (copy_pixels)
-                    ib->copy_pixels (srcib);
+                    ib->copy_pixels(srcib);
             } else {
                 // The other image is not modified, and we don't need to be
                 // writable, either.
-                ib = new ImageBuf (img.name(), srcib.imagecache());
-                bool ok = ib->read (srcsub, srcmip, false /*force*/,
-                                    img.m_input_dataformat /*convert*/);
-                ASSERT (ok);
+                ib      = new ImageBuf(img.name(), srcib.imagecache());
+                bool ok = ib->read(srcsub, srcmip, false /*force*/,
+                                   img.m_input_dataformat /*convert*/);
+                ASSERT(ok);
             }
-            m_subimages[s].m_miplevels[m].reset (ib);
+            m_subimages[s].m_miplevels[m].reset(ib);
             m_subimages[s].m_specs[m] = srcspec;
         }
     }
@@ -123,72 +126,73 @@ ImageRec::ImageRec (ImageRec &img, int subimage_to_copy,
 
 
 
-ImageRec::ImageRec (ImageRec &A, ImageRec &B, int subimage_to_copy,
-                    WinMerge pixwin, WinMerge fullwin,
-                    TypeDesc pixeltype)
-    : m_name(A.name()), m_elaborated(true), m_imagecache(A.m_imagecache)
+ImageRec::ImageRec(ImageRec& A, ImageRec& B, int subimage_to_copy,
+                   WinMerge pixwin, WinMerge fullwin, TypeDesc pixeltype)
+    : m_name(A.name())
+    , m_elaborated(true)
+    , m_imagecache(A.m_imagecache)
 {
-    A.read ();
-    B.read ();
-    int subimages = (subimage_to_copy < 0) ? 
-                          std::min(A.subimages(), B.subimages()) : 1;
-    int first_subimage = clamp (subimage_to_copy, 0, subimages-1);
-    m_subimages.resize (subimages);
-    for (int s = 0;  s < subimages;  ++s) {
+    A.read();
+    B.read();
+    int subimages = (subimage_to_copy < 0)
+                        ? std::min(A.subimages(), B.subimages())
+                        : 1;
+    int first_subimage = clamp(subimage_to_copy, 0, subimages - 1);
+    m_subimages.resize(subimages);
+    for (int s = 0; s < subimages; ++s) {
         int srcsub = s + first_subimage;
-        m_subimages[s].m_miplevels.resize (1);
-        m_subimages[s].m_specs.resize (1);
-        const ImageBuf &Aib (A(srcsub));
-        const ImageBuf &Bib (B(srcsub));
-        const ImageSpec &Aspec (Aib.spec());
-        const ImageSpec &Bspec (Bib.spec());
+        m_subimages[s].m_miplevels.resize(1);
+        m_subimages[s].m_specs.resize(1);
+        const ImageBuf& Aib(A(srcsub));
+        const ImageBuf& Bib(B(srcsub));
+        const ImageSpec& Aspec(Aib.spec());
+        const ImageSpec& Bspec(Bib.spec());
         ImageSpec spec = Aspec;
-        ROI Aroi = get_roi (Aspec), Aroi_full = get_roi_full (Aspec);
-        ROI Broi = get_roi (Bspec), Broi_full = get_roi_full (Bspec);
+        ROI Aroi = get_roi(Aspec), Aroi_full = get_roi_full(Aspec);
+        ROI Broi = get_roi(Bspec), Broi_full = get_roi_full(Bspec);
         switch (pixwin) {
-        case WinMergeUnion :
-            set_roi (spec, roi_union (Aroi, Broi)); break;
-        case WinMergeIntersection :
-            set_roi (spec, roi_intersection (Aroi, Broi)); break;
-        case WinMergeA :
-            set_roi (spec, Aroi); break;
-        case WinMergeB :
-            set_roi (spec, Broi); break;
+        case WinMergeUnion: set_roi(spec, roi_union(Aroi, Broi)); break;
+        case WinMergeIntersection:
+            set_roi(spec, roi_intersection(Aroi, Broi));
+            break;
+        case WinMergeA: set_roi(spec, Aroi); break;
+        case WinMergeB: set_roi(spec, Broi); break;
         }
         switch (fullwin) {
-        case WinMergeUnion :
-            set_roi_full (spec, roi_union (Aroi_full, Broi_full)); break;
-        case WinMergeIntersection :
-            set_roi_full (spec, roi_intersection (Aroi_full, Broi_full)); break;
-        case WinMergeA :
-            set_roi_full (spec, Aroi_full); break;
-        case WinMergeB :
-            set_roi_full (spec, Broi_full); break;
+        case WinMergeUnion:
+            set_roi_full(spec, roi_union(Aroi_full, Broi_full));
+            break;
+        case WinMergeIntersection:
+            set_roi_full(spec, roi_intersection(Aroi_full, Broi_full));
+            break;
+        case WinMergeA: set_roi_full(spec, Aroi_full); break;
+        case WinMergeB: set_roi_full(spec, Broi_full); break;
         }
         if (pixeltype != TypeDesc::UNKNOWN)
-            spec.set_format (pixeltype);
-        spec.nchannels = std::min (Aspec.nchannels, Bspec.nchannels);
-        spec.channelnames.resize (spec.nchannels);
-        spec.channelformats.clear ();
+            spec.set_format(pixeltype);
+        spec.nchannels = std::min(Aspec.nchannels, Bspec.nchannels);
+        spec.channelnames.resize(spec.nchannels);
+        spec.channelformats.clear();
 
-        ImageBuf *ib = new ImageBuf (spec);
+        ImageBuf* ib = new ImageBuf(spec);
 
-        m_subimages[s].m_miplevels[0].reset (ib);
+        m_subimages[s].m_miplevels[0].reset(ib);
         m_subimages[s].m_specs[0] = spec;
     }
 }
 
 
 
-ImageRec::ImageRec (ImageBufRef img, bool copy_pixels)
-    : m_name(img->name()), m_elaborated(true),
-      m_imagecache(img->imagecache())
+ImageRec::ImageRec(ImageBufRef img, bool copy_pixels)
+    : m_name(img->name())
+    , m_elaborated(true)
+    , m_imagecache(img->imagecache())
 {
-    m_subimages.resize (1);
-    m_subimages[0].m_miplevels.resize (1);
-    m_subimages[0].m_specs.push_back (img->spec());
+    m_subimages.resize(1);
+    m_subimages[0].m_miplevels.resize(1);
+    m_subimages[0].m_specs.push_back(img->spec());
     if (copy_pixels) {
-        m_subimages[0].m_miplevels[0].reset (new ImageBuf (*img));
+        m_subimages[0].m_miplevels[0].reset(new ImageBuf(*img));
     } else {
         m_subimages[0].m_miplevels[0] = img;
     }
@@ -196,20 +200,22 @@ ImageRec::ImageRec (ImageBufRef img, bool copy_pixels)
 
 
 
-ImageRec::ImageRec (const std::string &name, const ImageSpec &spec,
-                    ImageCache *imagecache)
-    : m_name(name), m_elaborated(true), m_pixels_modified(true),
-      m_imagecache(imagecache)
+ImageRec::ImageRec(const std::string& name, const ImageSpec& spec,
+                   ImageCache* imagecache)
+    : m_name(name)
+    , m_elaborated(true)
+    , m_pixels_modified(true)
+    , m_imagecache(imagecache)
 {
     int subimages = 1;
-    m_subimages.resize (subimages);
-    for (int s = 0;  s < subimages;  ++s) {
+    m_subimages.resize(subimages);
+    for (int s = 0; s < subimages; ++s) {
         int miplevels = 1;
-        m_subimages[s].m_miplevels.resize (miplevels);
-        m_subimages[s].m_specs.resize (miplevels);
-        for (int m = 0;  m < miplevels;  ++m) {
-            ImageBuf *ib = new ImageBuf (spec);
-            m_subimages[s].m_miplevels[m].reset (ib);
+        m_subimages[s].m_miplevels.resize(miplevels);
+        m_subimages[s].m_specs.resize(miplevels);
+        for (int m = 0; m < miplevels; ++m) {
+            ImageBuf* ib = new ImageBuf(spec);
+            m_subimages[s].m_miplevels[m].reset(ib);
             m_subimages[s].m_specs[m] = spec;
         }
     }
@@ -218,38 +224,41 @@ ImageRec::ImageRec (const std::string &name, const ImageSpec &spec,
 
 
 bool
-ImageRec::read (ReadPolicy readpolicy, string_view channel_set)
+ImageRec::read(ReadPolicy readpolicy, string_view channel_set)
 {
     if (elaborated())
         return true;
     static ustring u_subimages("subimages"), u_miplevels("miplevels");
     int subimages = 0;
-    ustring uname (name());
-    if (! m_imagecache->get_image_info (uname, 0, 0, u_subimages,
-                                        TypeInt, &subimages)) {
-        error ("file not found: \"%s\"", name());
+    ustring uname(name());
+    if (!m_imagecache->get_image_info(uname, 0, 0, u_subimages, TypeInt,
+                                      &subimages)) {
+        error("file not found: \"%s\"", name());
         return false;  // Image not found
     }
-    m_subimages.resize (subimages);
+    m_subimages.resize(subimages);
     bool allok = true;
-    for (int s = 0;  s < subimages;  ++s) {
+    for (int s = 0; s < subimages; ++s) {
         int miplevels = 0;
-        m_imagecache->get_image_info (uname, s, 0, u_miplevels,
-                                      TypeInt, &miplevels);
-        m_subimages[s].m_miplevels.resize (miplevels);
-        m_subimages[s].m_specs.resize (miplevels);
+        m_imagecache->get_image_info(uname, s, 0, u_miplevels, TypeInt,
+                                     &miplevels);
+        m_subimages[s].m_miplevels.resize(miplevels);
+        m_subimages[s].m_specs.resize(miplevels);
         m_subimages[s].m_was_direct_read = true;
-        for (int m = 0;  m < miplevels;  ++m) {
+        for (int m = 0; m < miplevels; ++m) {
             // Force a read now for reasonable-sized first images in the
             // file. This can greatly speed up the multithread case for
             // tiled images by not having multiple threads working on the
             // same image lock against each other on the file handle.
             // We guess that "reasonable size" is 50 MB, that's enough to
-            // hold a 2048x1536 RGBA float image.  Larger things will 
+            // hold a 2048x1536 RGBA float image.  Larger things will
             // simply fall back on ImageCache.
-            bool forceread = (s == 0 && m == 0 &&
-                              m_imagecache->imagespec(uname,s,m)->image_bytes() < 50*1024*1024);
-            ImageBufRef ib (new ImageBuf (name(), 0, 0, m_imagecache, &m_configspec));
+            bool forceread
+                = (s == 0 && m == 0
+                   && m_imagecache->imagespec(uname, s, m)->image_bytes()
+                          < 50 * 1024 * 1024);
+            ImageBufRef ib(
+                new ImageBuf(name(), 0, 0, m_imagecache, &m_configspec));
 
             bool post_channel_set_action = false;
             std::vector<std::string> newchannelnames;
@@ -257,20 +266,23 @@ ImageRec::read (ReadPolicy readpolicy, string_view channel_set)
             std::vector<float> channel_set_values;
             int chbegin = 0, chend = -1;
             if (channel_set.size()) {
-                decode_channel_set (ib->nativespec(), channel_set,
-                                    newchannelnames, channel_set_channels,
-                                    channel_set_values);
-                for (size_t c = 0, e = channel_set_channels.size(); c < e; ++c) {
+                decode_channel_set(ib->nativespec(), channel_set,
+                                   newchannelnames, channel_set_channels,
+                                   channel_set_values);
+                for (size_t c = 0, e = channel_set_channels.size(); c < e;
+                     ++c) {
                     if (channel_set_channels[c] < 0)
-                        post_channel_set_action = true; // value fill-in
-                    else if (c>=1 && channel_set_channels[c] != channel_set_channels[c-1]+1)
-                        post_channel_set_action = true; // non-consecutive chans
+                        post_channel_set_action = true;  // value fill-in
+                    else if (c >= 1
+                             && channel_set_channels[c]
+                                    != channel_set_channels[c - 1] + 1)
+                        post_channel_set_action = true;  // non-consecutive chans
                 }
                 if (ib->deep())
                     post_channel_set_action = true;
-                if (! post_channel_set_action) {
-                    chbegin = channel_set_channels.front();
-                    chend = channel_set_channels.back()+1;
+                if (!post_channel_set_action) {
+                    chbegin   = channel_set_channels.front();
+                    chend     = channel_set_channels.back() + 1;
                     forceread = true;
                 }
             }
@@ -286,49 +298,52 @@ ImageRec::read (ReadPolicy readpolicy, string_view channel_set)
                 if (m_input_dataformat != ib->nativespec().format)
                     m_subimages[s].m_was_direct_read = false;
                 forceread = true;
-            }
-            else if (readpolicy & ReadNative)
+            } else if (readpolicy & ReadNative)
                 convert = ib->nativespec().format;
-            if (! forceread &&
-                convert != TypeDesc::UINT8 && convert != TypeDesc::UINT16 &&
-                convert != TypeDesc::HALF &&  convert != TypeDesc::FLOAT) {
+            if (!forceread && convert != TypeDesc::UINT8
+                && convert != TypeDesc::UINT16 && convert != TypeDesc::HALF
+                && convert != TypeDesc::FLOAT) {
                 // If we're still trying to use the cache but it doesn't
                 // support the native type, force a full read.
                 forceread = true;
             }
 
-            bool ok = ib->read (s, m, chbegin, chend, forceread, convert);
+            bool ok = ib->read(s, m, chbegin, chend, forceread, convert);
             if (ok && post_channel_set_action) {
                 ImageBufRef allchan_buf;
-                std::swap (allchan_buf, ib);
-                ok = ImageBufAlgo::channels (*ib, *allchan_buf,
-                            (int)channel_set_channels.size(), &channel_set_channels[0],
-                            &channel_set_values[0], &newchannelnames[0], false);
+                std::swap(allchan_buf, ib);
+                ok = ImageBufAlgo::channels(*ib, *allchan_buf,
+                                            (int)channel_set_channels.size(),
+                                            &channel_set_channels[0],
+                                            &channel_set_values[0],
+                                            &newchannelnames[0], false);
             }
             if (!ok)
-                error ("%s", ib->geterror());
+                error("%s", ib->geterror());
 
             allok &= ok;
             // Remove any existing SHA-1 hash from the spec.
-            ib->specmod().erase_attribute ("oiio:SHA-1");
-            std::string desc = ib->spec().get_string_attribute ("ImageDescription");
+            ib->specmod().erase_attribute("oiio:SHA-1");
+            std::string desc = ib->spec().get_string_attribute(
+                "ImageDescription");
             if (desc.size()) {
 #ifdef USE_BOOST_REGEX
-                static boost::regex regex_sha ("SHA-1=[[:xdigit:]]*[ ]*");
-                ib->specmod().attribute ("ImageDescription",
-                                         boost::regex_replace (desc, regex_sha, ""));
+                static boost::regex regex_sha("SHA-1=[[:xdigit:]]*[ ]*");
+                ib->specmod().attribute("ImageDescription",
+                                        boost::regex_replace(desc, regex_sha,
+                                                             ""));
 #else
-                static std::regex regex_sha ("SHA-1=[[:xdigit:]]*[ ]*");
-                ib->specmod().attribute ("ImageDescription",
-                                         std::regex_replace (desc, regex_sha, ""));
+                static std::regex regex_sha("SHA-1=[[:xdigit:]]*[ ]*");
+                ib->specmod().attribute("ImageDescription",
+                                        std::regex_replace(desc, regex_sha, ""));
 #endif
             }
 
             m_subimages[s].m_miplevels[m] = ib;
-            m_subimages[s].m_specs[m] = ib->spec();
+            m_subimages[s].m_specs[m]     = ib->spec();
             // For ImageRec purposes, we need to restore a few of the
             // native settings.
-            const ImageSpec &nativespec (ib->nativespec());
+            const ImageSpec& nativespec(ib->nativespec());
             // m_subimages[s].m_specs[m].format = nativespec.format;
             m_subimages[s].m_specs[m].tile_width  = nativespec.tile_width;
             m_subimages[s].m_specs[m].tile_height = nativespec.tile_height;
@@ -336,7 +351,7 @@ ImageRec::read (ReadPolicy readpolicy, string_view channel_set)
         }
     }
 
-    m_time = Filesystem::last_write_time (name());
+    m_time       = Filesystem::last_write_time(name());
     m_elaborated = true;
     return allok;
 }
@@ -349,18 +364,18 @@ static spin_mutex err_mutex;
 
 
 bool
-ImageRec::has_error () const
+ImageRec::has_error() const
 {
-    spin_lock lock (err_mutex);
-    return ! m_err.empty();
+    spin_lock lock(err_mutex);
+    return !m_err.empty();
 }
 
 
 
 std::string
-ImageRec::geterror (bool clear_error) const
+ImageRec::geterror(bool clear_error) const
 {
-    spin_lock lock (err_mutex);
+    spin_lock lock(err_mutex);
     std::string e = m_err;
     if (clear_error)
         m_err.clear();
@@ -370,14 +385,12 @@ ImageRec::geterror (bool clear_error) const
 
 
 void
-ImageRec::append_error (string_view message) const
+ImageRec::append_error(string_view message) const
 {
-    spin_lock lock (err_mutex);
-    ASSERT (m_err.size() < 1024*1024*16 &&
-            "Accumulated error messages > 16MB. Try checking return codes!");
-    if (m_err.size() && m_err[m_err.size()-1] != '\n')
+    spin_lock lock(err_mutex);
+    ASSERT(m_err.size() < 1024 * 1024 * 16
+           && "Accumulated error messages > 16MB. Try checking return codes!");
+    if (m_err.size() && m_err[m_err.size() - 1] != '\n')
         m_err += '\n';
     m_err += message;
 }
-
-

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -29,48 +29,48 @@
 */
 
 
+#include <algorithm>
+#include <cctype>
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
-#include <cmath>
 #include <iostream>
 #include <iterator>
-#include <vector>
-#include <string>
-#include <sstream>
-#include <algorithm>
-#include <utility>
-#include <cctype>
 #include <map>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
-#include <OpenEXR/half.h>
 #include <OpenEXR/ImfTimeCode.h>
+#include <OpenEXR/half.h>
 
 #include <OpenImageIO/argparse.h>
-#include <OpenImageIO/imageio.h>
-#include <OpenImageIO/imagebuf.h>
-#include <OpenImageIO/imagebufalgo.h>
-#include <OpenImageIO/sysutil.h>
-#include <OpenImageIO/strutil.h>
+#include <OpenImageIO/color.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/filter.h>
-#include <OpenImageIO/color.h>
-#include <OpenImageIO/timer.h>
+#include <OpenImageIO/imagebuf.h>
+#include <OpenImageIO/imagebufalgo.h>
+#include <OpenImageIO/imageio.h>
 #include <OpenImageIO/simd.h>
+#include <OpenImageIO/strutil.h>
+#include <OpenImageIO/sysutil.h>
+#include <OpenImageIO/timer.h>
 
 #include "oiiotool.h"
 
 #ifdef USE_BOOST_REGEX
-# include <boost/regex.hpp>
-  using boost::regex;
-  using boost::regex_search;
-  using boost::regex_replace;
-  using boost::match_results;
+#    include <boost/regex.hpp>
+using boost::match_results;
+using boost::regex;
+using boost::regex_replace;
+using boost::regex_search;
 #else
-# include <regex>
-  using std::regex;
-  using std::regex_search;
-  using std::regex_replace;
-  using std::match_results;
+#    include <regex>
+using std::match_results;
+using std::regex;
+using std::regex_replace;
+using std::regex_search;
 #endif
 
 
@@ -84,130 +84,130 @@ static Oiiotool ot;
 
 // Macro to fully set up the "action" function that straightforwardly
 // calls a custom OiiotoolOp class.
-#define OP_CUSTOMCLASS(name,opclass,ninputs)                           \
-    static int action_##name (int argc, const char *argv[]) {          \
-        if (ot.postpone_callback (ninputs, action_##name, argc, argv)) \
-            return 0;                                                  \
-        opclass op (ot, #name, argc, argv);                            \
-        return op();                                                   \
+#define OP_CUSTOMCLASS(name, opclass, ninputs)                                 \
+    static int action_##name(int argc, const char* argv[])                     \
+    {                                                                          \
+        if (ot.postpone_callback(ninputs, action_##name, argc, argv))          \
+            return 0;                                                          \
+        opclass op(ot, #name, argc, argv);                                     \
+        return op();                                                           \
     }
 
 
-#define UNARY_IMAGE_OP(name,impl)                                      \
-    static int action_##name (int argc, const char *argv[]) {          \
-        const int nargs = 1, ninputs = 1;                              \
-        if (ot.postpone_callback (ninputs, action_##name, argc, argv)) \
-            return 0;                                                  \
-        ASSERT (argc == nargs);                                        \
-        OiiotoolSimpleUnaryOp<IBAunary> op (impl, ot, #name,           \
-                                            argc, argv, ninputs);      \
-        return op();                                                   \
+#define UNARY_IMAGE_OP(name, impl)                                             \
+    static int action_##name(int argc, const char* argv[])                     \
+    {                                                                          \
+        const int nargs = 1, ninputs = 1;                                      \
+        if (ot.postpone_callback(ninputs, action_##name, argc, argv))          \
+            return 0;                                                          \
+        ASSERT(argc == nargs);                                                 \
+        OiiotoolSimpleUnaryOp<IBAunary> op(impl, ot, #name, argc, argv,        \
+                                           ninputs);                           \
+        return op();                                                           \
     }
 
 
-#define BINARY_IMAGE_OP(name,impl)                                     \
-    static int action_##name (int argc, const char *argv[]) {          \
-        const int nargs = 1, ninputs = 2;                              \
-        if (ot.postpone_callback (ninputs, action_##name, argc, argv)) \
-            return 0;                                                  \
-        ASSERT (argc == nargs);                                        \
-        OiiotoolSimpleBinaryOp<IBAbinary> op (impl, ot, #name,         \
-                                              argc, argv, ninputs);    \
-        return op();                                                   \
+#define BINARY_IMAGE_OP(name, impl)                                            \
+    static int action_##name(int argc, const char* argv[])                     \
+    {                                                                          \
+        const int nargs = 1, ninputs = 2;                                      \
+        if (ot.postpone_callback(ninputs, action_##name, argc, argv))          \
+            return 0;                                                          \
+        ASSERT(argc == nargs);                                                 \
+        OiiotoolSimpleBinaryOp<IBAbinary> op(impl, ot, #name, argc, argv,      \
+                                             ninputs);                         \
+        return op();                                                           \
     }
 
 
-#define BINARY_IMAGE2_OP(name,impl)                                     \
-    static int action_##name (int argc, const char *argv[]) {          \
-        const int nargs = 1, ninputs = 2;                              \
-        if (ot.postpone_callback (ninputs, action_##name, argc, argv)) \
-            return 0;                                                  \
-        ASSERT (argc == nargs);                                        \
-        OiiotoolSimpleBinaryOp<IBAbinary_> op (impl, ot, #name,         \
-                                              argc, argv, ninputs);    \
-        return op();                                                   \
+#define BINARY_IMAGE2_OP(name, impl)                                           \
+    static int action_##name(int argc, const char* argv[])                     \
+    {                                                                          \
+        const int nargs = 1, ninputs = 2;                                      \
+        if (ot.postpone_callback(ninputs, action_##name, argc, argv))          \
+            return 0;                                                          \
+        ASSERT(argc == nargs);                                                 \
+        OiiotoolSimpleBinaryOp<IBAbinary_> op(impl, ot, #name, argc, argv,     \
+                                              ninputs);                        \
+        return op();                                                           \
     }
 
 
-#define BINARY_IMAGE_COLOR_OP(name,impl,defaultval)                    \
-    static int action_##name (int argc, const char *argv[]) {          \
-        const int nargs = 2, ninputs = 1;                              \
-        if (ot.postpone_callback (ninputs, action_##name, argc, argv)) \
-            return 0;                                                  \
-        ASSERT (argc == nargs);                                        \
-        OiiotoolImageColorOp<IBAbinary_img_col> op (impl, ot, #name,   \
-                                              argc, argv, ninputs);    \
-        return op();                                                   \
+#define BINARY_IMAGE_COLOR_OP(name, impl, defaultval)                          \
+    static int action_##name(int argc, const char* argv[])                     \
+    {                                                                          \
+        const int nargs = 2, ninputs = 1;                                      \
+        if (ot.postpone_callback(ninputs, action_##name, argc, argv))          \
+            return 0;                                                          \
+        ASSERT(argc == nargs);                                                 \
+        OiiotoolImageColorOp<IBAbinary_img_col> op(impl, ot, #name, argc,      \
+                                                   argv, ninputs);             \
+        return op();                                                           \
     }
 
 
 
-
-
-Oiiotool::Oiiotool ()
-{
-    clear_options ();
-}
+Oiiotool::Oiiotool() { clear_options(); }
 
 
 
 void
-Oiiotool::clear_options ()
+Oiiotool::clear_options()
 {
-    verbose = false;
-    debug = false;
-    dryrun = false;
-    runstats = false;
-    noclobber = false;
-    allsubimages = false;
-    printinfo = false;
-    printstats = false;
-    dumpdata = false;
+    verbose            = false;
+    debug              = false;
+    dryrun             = false;
+    runstats           = false;
+    noclobber          = false;
+    allsubimages       = false;
+    printinfo          = false;
+    printstats         = false;
+    dumpdata           = false;
     dumpdata_showempty = true;
-    hash = false;
-    updatemode = false;
-    autoorient = false;
-    autocc = false;
-    autopremult = true;
-    nativeread = false;
-    cachesize = 4096;
-    autotile = 0;   // was: 4096
+    hash               = false;
+    updatemode         = false;
+    autoorient         = false;
+    autocc             = false;
+    autopremult        = true;
+    nativeread         = false;
+    cachesize          = 4096;
+    autotile           = 0;  // was: 4096
     // FIXME: Turned off autotile by default Jan 2018 after thinking that
     // it was possible to deadlock when doing certain parallel IBA functions
     // in combination with autotile. When the deadlock possibility is fixed,
     // maybe we'll turn it back to on by default.
     frame_padding = 0;
-    full_command_line.clear ();
-    printinfo_metamatch.clear ();
-    printinfo_nometamatch.clear ();
+    full_command_line.clear();
+    printinfo_metamatch.clear();
+    printinfo_nometamatch.clear();
     printinfo_verbose = false;
-    clear_input_config ();
+    clear_input_config();
     output_dataformat = TypeDesc::UNKNOWN;
-    output_channelformats.clear ();
-    output_bitspersample = 0;
-    output_scanline = false;
-    output_tilewidth = 0;
-    output_tileheight = 0;
-    output_compression = "";
-    output_quality = -1;
-    output_planarconfig = "default";
-    output_adjust_time = false;
-    output_autocrop = true;
-    output_autotrim = false;
-    output_dither = false;
-    output_force_tiles = false;
-    metadata_nosoftwareattrib = false;
-    diff_warnthresh = 1.0e-6f;
-    diff_warnpercent = 0;
-    diff_hardwarn = std::numeric_limits<float>::max();
-    diff_failthresh = 1.0e-6f;
-    diff_failpercent = 0;
-    diff_hardfail = std::numeric_limits<float>::max();
-    m_pending_callback = NULL;
-    m_pending_argc = 0;
-    frame_number = 0;
-    frame_padding = 0;
-    first_input_dataformat = TypeUnknown;
+    output_channelformats.clear();
+    output_bitspersample        = 0;
+    output_scanline             = false;
+    output_tilewidth            = 0;
+    output_tileheight           = 0;
+    output_compression          = "";
+    output_quality              = -1;
+    output_planarconfig         = "default";
+    output_adjust_time          = false;
+    output_autocrop             = true;
+    output_autotrim             = false;
+    output_dither               = false;
+    output_force_tiles          = false;
+    metadata_nosoftwareattrib   = false;
+    diff_warnthresh             = 1.0e-6f;
+    diff_warnpercent            = 0;
+    diff_hardwarn               = std::numeric_limits<float>::max();
+    diff_failthresh             = 1.0e-6f;
+    diff_failpercent            = 0;
+    diff_hardfail               = std::numeric_limits<float>::max();
+    m_pending_callback          = NULL;
+    m_pending_argc              = 0;
+    frame_number                = 0;
+    frame_padding               = 0;
+    first_input_dataformat      = TypeUnknown;
     first_input_dataformat_bits = 0;
     first_input_channelformats.clear();
 }
@@ -215,12 +215,12 @@ Oiiotool::clear_options ()
 
 
 void
-Oiiotool::clear_input_config ()
+Oiiotool::clear_input_config()
 {
-    input_config = ImageSpec();
+    input_config     = ImageSpec();
     input_config_set = false;
-    if (! autopremult) {
-        input_config.attribute ("oiio:UnassociatedAlpha", 1);
+    if (!autopremult) {
+        input_config.attribute("oiio:UnassociatedAlpha", 1);
         input_config_set = true;
     }
 }
@@ -228,17 +228,17 @@ Oiiotool::clear_input_config ()
 
 
 std::string
-format_resolution (int w, int h, int x, int y)
+format_resolution(int w, int h, int x, int y)
 {
-    return Strutil::format ("%dx%d%+d%+d", w, h, x, y);
+    return Strutil::format("%dx%d%+d%+d", w, h, x, y);
 }
 
 
 
 std::string
-format_resolution (int w, int h, int d, int x, int y, int z)
+format_resolution(int w, int h, int d, int x, int y, int z)
 {
-    return Strutil::format ("%dx%dx%d%+d%+d%+d", w, h, d, x, y, z);
+    return Strutil::format("%dx%dx%d%+d%+d%+d", w, h, d, x, y, z);
 }
 
 
@@ -248,7 +248,7 @@ format_resolution (int w, int h, int d, int x, int y, int z)
 
 
 bool
-Oiiotool::read (ImageRecRef img, ReadPolicy readpolicy)
+Oiiotool::read(ImageRecRef img, ReadPolicy readpolicy)
 {
     // If the image is already elaborated, take an early out, both to
     // save time, but also because we only want to do the format and
@@ -259,37 +259,39 @@ Oiiotool::read (ImageRecRef img, ReadPolicy readpolicy)
     // Cause the ImageRec to get read.  Try to compute how long it took.
     // Subtract out ImageCache time, to avoid double-accounting it later.
     float pre_ic_time, post_ic_time;
-    imagecache->getattribute ("stat:fileio_time", pre_ic_time);
-    total_readtime.start ();
+    imagecache->getattribute("stat:fileio_time", pre_ic_time);
+    total_readtime.start();
     if (ot.nativeread)
-        readpolicy = ReadPolicy (readpolicy | ReadNative);
-    bool ok = img->read (readpolicy);
-    total_readtime.stop ();
-    imagecache->getattribute ("stat:fileio_time", post_ic_time);
+        readpolicy = ReadPolicy(readpolicy | ReadNative);
+    bool ok = img->read(readpolicy);
+    total_readtime.stop();
+    imagecache->getattribute("stat:fileio_time", post_ic_time);
     total_imagecache_readtime += post_ic_time - pre_ic_time;
 
     // If this is the first tiled image we have come across, use it to
     // set our tile size (unless the user explicitly set a tile size, or
     // explicitly instructed scanline output).
-    const ImageSpec &nspec ((*img)().nativespec());
-    if (nspec.tile_width && ! output_tilewidth && ! ot.output_scanline) {
-        output_tilewidth = nspec.tile_width;
+    const ImageSpec& nspec((*img)().nativespec());
+    if (nspec.tile_width && !output_tilewidth && !ot.output_scanline) {
+        output_tilewidth  = nspec.tile_width;
         output_tileheight = nspec.tile_height;
     }
     // Remember the first input format we encountered.
     if (first_input_dataformat == TypeUnknown) {
-        first_input_dataformat = nspec.format;
-        first_input_dataformat_bits = nspec.get_int_attribute ("oiio:BitsPerSample");
+        first_input_dataformat      = nspec.format;
+        first_input_dataformat_bits = nspec.get_int_attribute(
+            "oiio:BitsPerSample");
         if (nspec.channelformats.size()) {
             for (int c = 0; c < nspec.nchannels; ++c) {
-                std::string chname = nspec.channelnames[c];
-                first_input_channelformats[chname] = std::string(nspec.channelformat(c).c_str());
+                std::string chname                 = nspec.channelnames[c];
+                first_input_channelformats[chname] = std::string(
+                    nspec.channelformat(c).c_str());
             }
         }
     }
 
-    if (! ok) {
-        error ("read "+img->name(), img->geterror());
+    if (!ok) {
+        error("read " + img->name(), img->geterror());
     }
     return ok;
 }
@@ -297,15 +299,15 @@ Oiiotool::read (ImageRecRef img, ReadPolicy readpolicy)
 
 
 bool
-Oiiotool::postpone_callback (int required_images, CallbackFunction func,
-                             int argc, const char *argv[])
+Oiiotool::postpone_callback(int required_images, CallbackFunction func,
+                            int argc, const char* argv[])
 {
     if (image_stack_depth() < required_images) {
         // Not enough have inputs been specified so far, so put this
         // function on the "pending" list.
         m_pending_callback = func;
-        m_pending_argc = argc;
-        for (int i = 0;  i < argc;  ++i)
+        m_pending_argc     = argc;
+        for (int i = 0; i < argc; ++i)
             m_pending_argv[i] = ustring(argv[i]).c_str();
         return true;
     }
@@ -315,27 +317,27 @@ Oiiotool::postpone_callback (int required_images, CallbackFunction func,
 
 
 void
-Oiiotool::process_pending ()
+Oiiotool::process_pending()
 {
     // Process any pending command -- this is a case where the
     // command line had prefix 'oiiotool --action file1 file2'
     // instead of infix 'oiiotool file1 --action file2'.
     if (m_pending_callback) {
         int argc = m_pending_argc;
-        const char *argv[4];
-        for (int i = 0;  i < argc;  ++i)
+        const char* argv[4];
+        for (int i = 0; i < argc; ++i)
             argv[i] = m_pending_argv[i];
         CallbackFunction callback = m_pending_callback;
-        m_pending_callback = NULL;
-        m_pending_argc = 0;
-        (*callback) (argc, argv);
+        m_pending_callback        = NULL;
+        m_pending_argc            = 0;
+        (*callback)(argc, argv);
     }
 }
 
 
 
 void
-Oiiotool::error (string_view command, string_view explanation) const
+Oiiotool::error(string_view command, string_view explanation) const
 {
     std::cerr << "oiiotool ERROR: " << command;
     if (explanation.length())
@@ -344,13 +346,13 @@ Oiiotool::error (string_view command, string_view explanation) const
     // Repeat the command line, so if oiiotool is being called from a
     // script, it's easy to debug how the command was mangled.
     std::cerr << "Full command line was:\n> " << full_command_line << "\n";
-    exit (-1);
+    exit(-1);
 }
 
 
 
 void
-Oiiotool::warning (string_view command, string_view explanation) const
+Oiiotool::warning(string_view command, string_view explanation) const
 {
     std::cerr << "oiiotool WARNING: " << command;
     if (explanation.length())
@@ -361,19 +363,20 @@ Oiiotool::warning (string_view command, string_view explanation) const
 
 
 int
-Oiiotool::extract_options (std::map<std::string,std::string> &options,
-                           std::string command)
+Oiiotool::extract_options(std::map<std::string, std::string>& options,
+                          std::string command)
 {
     // std::cout << "extract_options '" << command << "'\n";
     int noptions = 0;
     size_t pos;
     while ((pos = command.find_first_of(":")) != std::string::npos) {
-        command = command.substr (pos+1, std::string::npos);
+        command  = command.substr(pos + 1, std::string::npos);
         size_t e = command.find_first_of("=");
         if (e != std::string::npos) {
-            std::string name = command.substr(0,e);
-            std::string value = command.substr(e+1,command.find_first_of(":")-(e+1));
-            options[name] = value;
+            std::string name  = command.substr(0, e);
+            std::string value = command.substr(e + 1, command.find_first_of(":")
+                                                          - (e + 1));
+            options[name]     = value;
             ++noptions;
             // std::cout << "'" << name << "' -> '" << value << "'\n";
         }
@@ -383,77 +386,76 @@ Oiiotool::extract_options (std::map<std::string,std::string> &options,
 
 
 
-
 static int
-set_threads (int argc, const char *argv[])
+set_threads(int argc, const char* argv[])
 {
-    ASSERT (argc == 2);
+    ASSERT(argc == 2);
     int nthreads = atoi(argv[1]);
-    OIIO::attribute ("threads", nthreads);
-    OIIO::attribute ("exr_threads", nthreads);
+    OIIO::attribute("threads", nthreads);
+    OIIO::attribute("exr_threads", nthreads);
     return 0;
 }
 
 
 
 static int
-set_cachesize (int argc, const char *argv[])
+set_cachesize(int argc, const char* argv[])
 {
-    ASSERT (argc == 2);
+    ASSERT(argc == 2);
     ot.cachesize = atoi(argv[1]);
-    ot.imagecache->attribute ("max_memory_MB", float(ot.cachesize));
+    ot.imagecache->attribute("max_memory_MB", float(ot.cachesize));
     return 0;
 }
 
 
 
 static int
-set_autotile (int argc, const char *argv[])
+set_autotile(int argc, const char* argv[])
 {
-    ASSERT (argc == 2);
+    ASSERT(argc == 2);
     ot.autotile = atoi(argv[1]);
-    ot.imagecache->attribute ("autotile", ot.autotile);
-    ot.imagecache->attribute ("autoscanline", int(ot.autotile ? 1 : 0));
+    ot.imagecache->attribute("autotile", ot.autotile);
+    ot.imagecache->attribute("autoscanline", int(ot.autotile ? 1 : 0));
     return 0;
 }
 
 
 
 static int
-set_native (int argc, const char *argv[])
+set_native(int argc, const char* argv[])
 {
-    ASSERT (argc == 1);
+    ASSERT(argc == 1);
     ot.nativeread = true;
-    ot.imagecache->attribute ("forcefloat", 0);
+    ot.imagecache->attribute("forcefloat", 0);
     return 0;
 }
 
 
 
 static int
-set_dumpdata (int argc, const char *argv[])
+set_dumpdata(int argc, const char* argv[])
 {
-    ASSERT (argc == 1);
-    string_view command = ot.express (argv[0]);
-    ot.dumpdata = true;
-    std::map<std::string,std::string> options;
+    ASSERT(argc == 1);
+    string_view command = ot.express(argv[0]);
+    ot.dumpdata         = true;
+    std::map<std::string, std::string> options;
     options["empty"] = "1";
-    ot.extract_options (options, command);
-    ot.dumpdata_showempty = Strutil::from_string<int> (options["empty"]);
+    ot.extract_options(options, command);
+    ot.dumpdata_showempty = Strutil::from_string<int>(options["empty"]);
     return 0;
 }
 
 
 
 static int
-set_printinfo (int argc, const char *argv[])
+set_printinfo(int argc, const char* argv[])
 {
-    ASSERT (argc == 1);
-    string_view command = ot.express (argv[0]);
-    ot.printinfo = true;
-    std::map<std::string,std::string> options;
-    ot.extract_options (options, command);
-    ot.printinfo_format = options["format"];
+    ASSERT(argc == 1);
+    string_view command = ot.express(argv[0]);
+    ot.printinfo        = true;
+    std::map<std::string, std::string> options;
+    ot.extract_options(options, command);
+    ot.printinfo_format  = options["format"];
     ot.printinfo_verbose = Strutil::from_string<int>(options["verbose"]);
     return 0;
 }
@@ -461,24 +463,24 @@ set_printinfo (int argc, const char *argv[])
 
 
 static int
-set_autopremult (int argc, const char *argv[])
+set_autopremult(int argc, const char* argv[])
 {
-    ASSERT (argc == 1);
+    ASSERT(argc == 1);
     ot.autopremult = true;
-    ot.imagecache->attribute ("unassociatedalpha", 0);
-    ot.input_config.erase_attribute ("oiio:UnassociatedAlpha");
+    ot.imagecache->attribute("unassociatedalpha", 0);
+    ot.input_config.erase_attribute("oiio:UnassociatedAlpha");
     return 0;
 }
 
 
 
 static int
-unset_autopremult (int argc, const char *argv[])
+unset_autopremult(int argc, const char* argv[])
 {
-    ASSERT (argc == 1);
+    ASSERT(argc == 1);
     ot.autopremult = false;
-    ot.imagecache->attribute ("unassociatedalpha", 1);
-    ot.input_config.attribute ("oiio:UnassociatedAlpha", 1);
+    ot.imagecache->attribute("unassociatedalpha", 1);
+    ot.input_config.attribute("oiio:UnassociatedAlpha", 1);
     ot.input_config_set = true;
     return 0;
 }
@@ -486,9 +488,9 @@ unset_autopremult (int argc, const char *argv[])
 
 
 static int
-action_label (int argc, const char *argv[])
+action_label(int argc, const char* argv[])
 {
-    string_view labelname = ot.express(argv[1]);
+    string_view labelname      = ot.express(argv[1]);
     ot.image_labels[labelname] = ot.curimg;
     return 0;
 }
@@ -496,38 +498,48 @@ action_label (int argc, const char *argv[])
 
 
 static void
-string_to_dataformat (const std::string &s, TypeDesc &dataformat, int &bits)
+string_to_dataformat(const std::string& s, TypeDesc& dataformat, int& bits)
 {
     if (s == "uint8") {
-        dataformat = TypeDesc::UINT8;   bits = 0;
+        dataformat = TypeDesc::UINT8;
+        bits       = 0;
     } else if (s == "int8") {
-        dataformat = TypeDesc::INT8;    bits = 0;
+        dataformat = TypeDesc::INT8;
+        bits       = 0;
     } else if (s == "uint10") {
-        dataformat = TypeDesc::UINT16;  bits = 10;
+        dataformat = TypeDesc::UINT16;
+        bits       = 10;
     } else if (s == "uint12") {
-        dataformat = TypeDesc::UINT16;  bits = 12;
+        dataformat = TypeDesc::UINT16;
+        bits       = 12;
     } else if (s == "uint16") {
-        dataformat = TypeDesc::UINT16;  bits = 0;
+        dataformat = TypeDesc::UINT16;
+        bits       = 0;
     } else if (s == "int16") {
-        dataformat = TypeDesc::INT16;   bits = 0;
+        dataformat = TypeDesc::INT16;
+        bits       = 0;
     } else if (s == "uint32") {
-        dataformat = TypeDesc::UINT32;  bits = 0;
+        dataformat = TypeDesc::UINT32;
+        bits       = 0;
     } else if (s == "int32") {
-        dataformat = TypeDesc::INT32;   bits = 0;
+        dataformat = TypeDesc::INT32;
+        bits       = 0;
     } else if (s == "half") {
-        dataformat = TypeDesc::HALF;    bits = 0;
+        dataformat = TypeDesc::HALF;
+        bits       = 0;
     } else if (s == "float") {
-        dataformat = TypeDesc::FLOAT;   bits = 0;
+        dataformat = TypeDesc::FLOAT;
+        bits       = 0;
     } else if (s == "double") {
-        dataformat = TypeDesc::DOUBLE;  bits = 0;
+        dataformat = TypeDesc::DOUBLE;
+        bits       = 0;
     }
 }
 
 
 
-
 inline int
-get_value_override (string_view localoption, int defaultval=0)
+get_value_override(string_view localoption, int defaultval = 0)
 {
     return localoption.size() ? Strutil::from_string<int>(localoption)
                               : defaultval;
@@ -535,7 +547,7 @@ get_value_override (string_view localoption, int defaultval=0)
 
 
 inline float
-get_value_override (string_view localoption, float defaultval)
+get_value_override(string_view localoption, float defaultval)
 {
     return localoption.size() ? Strutil::from_string<float>(localoption)
                               : defaultval;
@@ -543,7 +555,7 @@ get_value_override (string_view localoption, float defaultval)
 
 
 inline string_view
-get_value_override (string_view localoption, string_view defaultval)
+get_value_override(string_view localoption, string_view defaultval)
 {
     return localoption.size() ? localoption : defaultval;
 }
@@ -553,27 +565,27 @@ get_value_override (string_view localoption, string_view defaultval)
 // Given a (potentially empty) overall data format, per-channel formats,
 // and bit depth, modify the existing spec.
 static void
-set_output_dataformat (ImageSpec& spec, TypeDesc format,
-                       const std::map<std::string,std::string>& channelformats,
-                       int bitdepth)
+set_output_dataformat(ImageSpec& spec, TypeDesc format,
+                      const std::map<std::string, std::string>& channelformats,
+                      int bitdepth)
 {
     if (format != TypeUnknown)
         spec.format = format;
     if (bitdepth)
-        spec.attribute ("oiio:BitsPerSample", bitdepth);
+        spec.attribute("oiio:BitsPerSample", bitdepth);
     else
-        spec.erase_attribute ("oiio:BitsPerSample");
+        spec.erase_attribute("oiio:BitsPerSample");
     if (channelformats.size()) {
-        spec.channelformats.clear ();
-        spec.channelformats.resize (spec.nchannels, spec.format);
+        spec.channelformats.clear();
+        spec.channelformats.resize(spec.nchannels, spec.format);
         for (auto& cr : channelformats) {
-            int c = spec.channelindex (cr.first);
-            TypeDesc t (cr.second);
+            int c = spec.channelindex(cr.first);
+            TypeDesc t(cr.second);
             if (c >= 0 && c < spec.nchannels && t != TypeUnknown)
                 spec.channelformats[c] = t;
         }
     } else {
-        spec.channelformats.clear ();
+        spec.channelformats.clear();
     }
 
     // Eliminate the per-channel formats if they are all the same.
@@ -591,12 +603,11 @@ set_output_dataformat (ImageSpec& spec, TypeDesc format,
 
 
 static void
-adjust_output_options (string_view filename,
-                       ImageSpec &spec, const ImageSpec *nativespec,
-                       const Oiiotool &ot,
-                       bool format_supports_tiles,
-                       std::map<std::string,std::string> &fileoptions,
-                       bool was_direct_read = false)
+adjust_output_options(string_view filename, ImageSpec& spec,
+                      const ImageSpec* nativespec, const Oiiotool& ot,
+                      bool format_supports_tiles,
+                      std::map<std::string, std::string>& fileoptions,
+                      bool was_direct_read = false)
 {
     // What data format and bit depth should we use for the output? Here's
     // the logic:
@@ -616,30 +627,30 @@ adjust_output_options (string_view filename,
     TypeDesc requested_output_dataformat = ot.output_dataformat;
     auto requested_output_channelformats = ot.output_channelformats;
     if (fileoptions["datatype"] != "") {
-        requested_output_dataformat.fromstring (fileoptions["datatype"]);
+        requested_output_dataformat.fromstring(fileoptions["datatype"]);
         requested_output_channelformats.clear();
     }
-    int requested_output_bits = get_value_override (fileoptions["bits"], ot.output_bitspersample);
+    int requested_output_bits = get_value_override(fileoptions["bits"],
+                                                   ot.output_bitspersample);
 
     if (requested_output_dataformat != TypeUnknown) {
         // Requested an explicit override of datatype
-        set_output_dataformat (spec, requested_output_dataformat,
-                               requested_output_channelformats,
-                               requested_output_bits);
-    }
-    else if (was_direct_read && nativespec) {
+        set_output_dataformat(spec, requested_output_dataformat,
+                              requested_output_channelformats,
+                              requested_output_bits);
+    } else if (was_direct_read && nativespec) {
         // Do nothing -- use the file's native data format
         spec.channelformats = nativespec->channelformats;
-        set_output_dataformat (spec, nativespec->format,
-                               requested_output_channelformats,
-                               nativespec->get_int_attribute("oiio:BitsPerSample"));
-    }
-    else if (ot.first_input_dataformat != TypeUnknown) {
+        set_output_dataformat(spec, nativespec->format,
+                              requested_output_channelformats,
+                              nativespec->get_int_attribute(
+                                  "oiio:BitsPerSample"));
+    } else if (ot.first_input_dataformat != TypeUnknown) {
         auto mergedlist = ot.first_input_channelformats;
         for (auto& c : requested_output_channelformats)
             mergedlist[c.first] = c.second;
-        set_output_dataformat (spec, ot.first_input_dataformat, mergedlist,
-                               ot.first_input_dataformat_bits);
+        set_output_dataformat(spec, ot.first_input_dataformat, mergedlist,
+                              ot.first_input_dataformat_bits);
     }
 
     // Tiling strategy:
@@ -649,99 +660,103 @@ adjust_output_options (string_view filename,
     //   to write it with the same tile/scanline choices as the input (if
     //   the file format supports it).
     // * Otherwise, just default to scanline.
-    int requested_tilewidth = ot.output_tilewidth;
+    int requested_tilewidth  = ot.output_tilewidth;
     int requested_tileheight = ot.output_tileheight;
-    string_view tilesize = fileoptions["tile"];
+    string_view tilesize     = fileoptions["tile"];
     if (tilesize.size()) {
         int x, y;  // dummy vals for adjust_geometry
-        ot.adjust_geometry ("-o", requested_tilewidth, requested_tileheight,
-                            x, y, tilesize.c_str(), false);
+        ot.adjust_geometry("-o", requested_tilewidth, requested_tileheight, x,
+                           y, tilesize.c_str(), false);
     }
-    bool requested_scanline = get_value_override (fileoptions["scanline"], ot.output_scanline);
+    bool requested_scanline = get_value_override(fileoptions["scanline"],
+                                                 ot.output_scanline);
     if (requested_tilewidth && !requested_scanline && format_supports_tiles) {
         // Explicit request to tile, honor it.
-        spec.tile_width = requested_tilewidth;
-        spec.tile_height = requested_tileheight ? requested_tileheight : requested_tilewidth;
-        spec.tile_depth = 1;   // FIXME if we ever want volume support
-    } else if (was_direct_read && nativespec &&
-               nativespec->tile_width > 0 && nativespec->tile_height > 0 &&
-               !requested_scanline && format_supports_tiles) {
+        spec.tile_width  = requested_tilewidth;
+        spec.tile_height = requested_tileheight ? requested_tileheight
+                                                : requested_tilewidth;
+        spec.tile_depth = 1;  // FIXME if we ever want volume support
+    } else if (was_direct_read && nativespec && nativespec->tile_width > 0
+               && nativespec->tile_height > 0 && !requested_scanline
+               && format_supports_tiles) {
         // No explicit request, but a direct read of a tiled input: keep the
         // input tiling.
-        spec.tile_width = nativespec->tile_width;
+        spec.tile_width  = nativespec->tile_width;
         spec.tile_height = nativespec->tile_height;
-        spec.tile_depth = nativespec->tile_depth;
+        spec.tile_depth  = nativespec->tile_depth;
     } else {
         // Otherwise, be safe and force scanline output.
         spec.tile_width = spec.tile_height = spec.tile_depth = 0;
     }
 
-    if (! ot.output_compression.empty())
-        spec.attribute ("compression", ot.output_compression);
+    if (!ot.output_compression.empty())
+        spec.attribute("compression", ot.output_compression);
     if (ot.output_quality > 0)
-        spec.attribute ("CompressionQuality", ot.output_quality);
+        spec.attribute("CompressionQuality", ot.output_quality);
 
-    if (get_value_override (fileoptions["separate"]))
-        spec.attribute ("planarconfig", "separate");
-    else if (get_value_override (fileoptions["contig"]))
-        spec.attribute ("planarconfig", "contig");
-    else if (ot.output_planarconfig == "contig" ||
-        ot.output_planarconfig == "separate")
-        spec.attribute ("planarconfig", ot.output_planarconfig);
+    if (get_value_override(fileoptions["separate"]))
+        spec.attribute("planarconfig", "separate");
+    else if (get_value_override(fileoptions["contig"]))
+        spec.attribute("planarconfig", "contig");
+    else if (ot.output_planarconfig == "contig"
+             || ot.output_planarconfig == "separate")
+        spec.attribute("planarconfig", ot.output_planarconfig);
 
     // Append command to image history.  Sometimes we may not want to recite the
     // entire command line (eg. when we have loaded it up with metadata attributes
     // that will make it into the header anyway).
-    if (! ot.metadata_nosoftwareattrib) {
-        std::string history = spec.get_string_attribute ("Exif:ImageHistory");
-        if (! Strutil::iends_with (history, ot.full_command_line)) { // don't add twice
-            if (history.length() && ! Strutil::iends_with (history, "\n"))
+    if (!ot.metadata_nosoftwareattrib) {
+        std::string history = spec.get_string_attribute("Exif:ImageHistory");
+        if (!Strutil::iends_with(history,
+                                 ot.full_command_line)) {  // don't add twice
+            if (history.length() && !Strutil::iends_with(history, "\n"))
                 history += std::string("\n");
             history += ot.full_command_line;
-            spec.attribute ("Exif:ImageHistory", history);
+            spec.attribute("Exif:ImageHistory", history);
         }
 
-        std::string software = Strutil::format ("OpenImageIO %s : %s",
-                                       OIIO_VERSION_STRING, ot.full_command_line);
-        spec.attribute ("Software", software);
+        std::string software = Strutil::format("OpenImageIO %s : %s",
+                                               OIIO_VERSION_STRING,
+                                               ot.full_command_line);
+        spec.attribute("Software", software);
     }
 
-    int dither = get_value_override (fileoptions["dither"], ot.output_dither);
+    int dither = get_value_override(fileoptions["dither"], ot.output_dither);
     if (dither) {
-        int h = (int) Strutil::strhash(filename);
+        int h = (int)Strutil::strhash(filename);
         if (!h)
             h = 1;
-        spec.attribute ("oiio:dither", h);
+        spec.attribute("oiio:dither", h);
     }
 
     // Make sure we kill any special hints that maketx adds and that will
     // no longer be valid after whatever oiiotool operations we've done.
-    spec.erase_attribute ("oiio:SHA-1");
-    spec.erase_attribute ("oiio:ConstantColor");
-    spec.erase_attribute ("oiio:AverageColor");
+    spec.erase_attribute("oiio:SHA-1");
+    spec.erase_attribute("oiio:ConstantColor");
+    spec.erase_attribute("oiio:AverageColor");
 }
 
 
 
 static bool
-DateTime_to_time_t (const char *datetime, time_t &timet)
+DateTime_to_time_t(const char* datetime, time_t& timet)
 {
     int year, month, day, hour, min, sec;
-    int r = sscanf (datetime, "%d:%d:%d %d:%d:%d",
-                    &year, &month, &day, &hour, &min, &sec);
+    int r = sscanf(datetime, "%d:%d:%d %d:%d:%d", &year, &month, &day, &hour,
+                   &min, &sec);
     // printf ("%d  %d:%d:%d %d:%d:%d\n", r, year, month, day, hour, min, sec);
     if (r != 6)
         return false;
     struct tm tmtime;
     time_t now;
-    Sysutil::get_local_time (&now, &tmtime); // fill in defaults
-    tmtime.tm_sec = sec;
-    tmtime.tm_min = min;
+    Sysutil::get_local_time(&now, &tmtime);  // fill in defaults
+    tmtime.tm_sec  = sec;
+    tmtime.tm_min  = min;
     tmtime.tm_hour = hour;
     tmtime.tm_mday = day;
-    tmtime.tm_mon = month-1;
-    tmtime.tm_year = year-1900;
-    timet = mktime (&tmtime);
+    tmtime.tm_mon  = month - 1;
+    tmtime.tm_year = year - 1900;
+    timet          = mktime(&tmtime);
     return true;
 }
 
@@ -753,33 +768,33 @@ DateTime_to_time_t (const char *datetime, time_t &timet)
 // in the spec. Return true if all named channels were found, false if one
 // or more were not found.
 static bool
-parse_channels (const ImageSpec &spec, string_view chanlist,
-                std::vector<int> &channels)
+parse_channels(const ImageSpec& spec, string_view chanlist,
+               std::vector<int>& channels)
 {
     bool ok = true;
-    channels.clear ();
+    channels.clear();
     for (int c = 0; chanlist.length(); ++c) {
         int chan = -1;
-        Strutil::skip_whitespace (chanlist);
-        string_view name = Strutil::parse_until (chanlist, ",");
+        Strutil::skip_whitespace(chanlist);
+        string_view name = Strutil::parse_until(chanlist, ",");
         if (name.size()) {
-            for (int i = 0;  i < spec.nchannels;  ++i)
-                if (spec.channelnames[i] == name) { // name of a known channel?
+            for (int i = 0; i < spec.nchannels; ++i)
+                if (spec.channelnames[i] == name) {  // name of a known channel?
                     chan = i;
                     break;
                 }
-            if (chan < 0) { // Didn't find a match? Try case-insensitive.
-                for (int i = 0;  i < spec.nchannels;  ++i)
-                    if (Strutil::iequals (spec.channelnames[i], name)) {
+            if (chan < 0) {  // Didn't find a match? Try case-insensitive.
+                for (int i = 0; i < spec.nchannels; ++i)
+                    if (Strutil::iequals(spec.channelnames[i], name)) {
                         chan = i;
                         break;
                     }
             }
             if (chan < 0)
                 ok = false;
-            channels.push_back (chan);
+            channels.push_back(chan);
         }
-        if (! Strutil::parse_char (chanlist, ','))
+        if (!Strutil::parse_char(chanlist, ','))
             break;
     }
     return ok;
@@ -788,39 +803,42 @@ parse_channels (const ImageSpec &spec, string_view chanlist,
 
 
 static int
-set_dataformat (int argc, const char *argv[])
+set_dataformat(int argc, const char* argv[])
 {
-    ASSERT (argc == 2);
-    string_view command = ot.express (argv[0]);
+    ASSERT(argc == 2);
+    string_view command = ot.express(argv[0]);
     std::vector<std::string> chans;
-    Strutil::split (ot.express(argv[1]), chans, ",");
+    Strutil::split(ot.express(argv[1]), chans, ",");
 
     if (chans.size() == 0) {
-        return 0;   // Nothing to do
+        return 0;  // Nothing to do
     }
 
-    if (chans.size() == 1 && !strchr(chans[0].c_str(),'=')) {
+    if (chans.size() == 1 && !strchr(chans[0].c_str(), '=')) {
         // Of the form:   -d uint8    (for example)
         // Just one default format designated, apply to all channels
-        ot.output_dataformat = TypeDesc::UNKNOWN;
+        ot.output_dataformat    = TypeDesc::UNKNOWN;
         ot.output_bitspersample = 0;
-        string_to_dataformat (chans[0], ot.output_dataformat,
-                              ot.output_bitspersample);
+        string_to_dataformat(chans[0], ot.output_dataformat,
+                             ot.output_bitspersample);
         if (ot.output_dataformat == TypeDesc::UNKNOWN)
-            ot.error (command, Strutil::format ("Unknown data format \"%s\"", chans[0]));
-        ot.output_channelformats.clear ();
+            ot.error(command,
+                     Strutil::format("Unknown data format \"%s\"", chans[0]));
+        ot.output_channelformats.clear();
         return 0;  // we're done
     }
 
     // If we make it here, the format designator was of the form
     //    name0=type0,name1=type1,...
     for (auto& chan : chans) {
-        const char *eq = strchr(chan.c_str(),'=');
+        const char* eq = strchr(chan.c_str(), '=');
         if (eq) {
-            std::string channame (chan, 0, eq - chan.c_str());
-            ot.output_channelformats[channame] = std::string (eq+1);
+            std::string channame(chan, 0, eq - chan.c_str());
+            ot.output_channelformats[channame] = std::string(eq + 1);
         } else {
-            ot.error (command, Strutil::format ("Malformed format designator \"%s\"", chan));
+            ot.error(command,
+                     Strutil::format("Malformed format designator \"%s\"",
+                                     chan));
         }
     }
 
@@ -830,15 +848,14 @@ set_dataformat (int argc, const char *argv[])
 
 
 static int
-set_string_attribute (int argc, const char *argv[])
+set_string_attribute(int argc, const char* argv[])
 {
-    ASSERT (argc == 3);
-    if (! ot.curimg.get()) {
-        ot.warning (argv[0], "no current image available to modify");
+    ASSERT(argc == 3);
+    if (!ot.curimg.get()) {
+        ot.warning(argv[0], "no current image available to modify");
         return 0;
     }
-    set_attribute (ot.curimg, argv[1], TypeString, argv[2],
-                   ot.allsubimages);
+    set_attribute(ot.curimg, argv[1], TypeString, argv[2], ot.allsubimages);
     // N.B. set_attribute does expression expansion on its args
     return 0;
 }
@@ -846,19 +863,19 @@ set_string_attribute (int argc, const char *argv[])
 
 
 static int
-set_any_attribute (int argc, const char *argv[])
+set_any_attribute(int argc, const char* argv[])
 {
-    ASSERT (argc == 3);
-    if (! ot.curimg.get()) {
-        ot.warning (argv[0], "no current image available to modify");
+    ASSERT(argc == 3);
+    if (!ot.curimg.get()) {
+        ot.warning(argv[0], "no current image available to modify");
         return 0;
     }
 
-    std::map<std::string,std::string> options;
-    ot.extract_options (options, argv[0]);
-    TypeDesc type (options["type"]);
+    std::map<std::string, std::string> options;
+    ot.extract_options(options, argv[0]);
+    TypeDesc type(options["type"]);
 
-    set_attribute (ot.curimg, argv[1], type, argv[2], ot.allsubimages);
+    set_attribute(ot.curimg, argv[1], type, argv[2], ot.allsubimages);
     // N.B. set_attribute does expression expansion on its args
     return 0;
 }
@@ -866,107 +883,106 @@ set_any_attribute (int argc, const char *argv[])
 
 
 static bool
-do_erase_attribute (ImageSpec &spec, string_view attribname)
+do_erase_attribute(ImageSpec& spec, string_view attribname)
 {
-    spec.erase_attribute (attribname);
+    spec.erase_attribute(attribname);
     return true;
 }
 
 
 
 static int
-erase_attribute (int argc, const char *argv[])
+erase_attribute(int argc, const char* argv[])
 {
-    ASSERT (argc == 2);
-    if (! ot.curimg.get()) {
-        ot.warning (argv[0], "no current image available to modify");
+    ASSERT(argc == 2);
+    if (!ot.curimg.get()) {
+        ot.warning(argv[0], "no current image available to modify");
         return 0;
     }
-    string_view pattern = ot.express (argv[1]);
-    return apply_spec_mod (*ot.curimg, do_erase_attribute,
-                           pattern, ot.allsubimages);
+    string_view pattern = ot.express(argv[1]);
+    return apply_spec_mod(*ot.curimg, do_erase_attribute, pattern,
+                          ot.allsubimages);
 }
 
 
 
 template<class T>
 static bool
-do_set_any_attribute (ImageSpec &spec, const std::pair<std::string,T> &x)
+do_set_any_attribute(ImageSpec& spec, const std::pair<std::string, T>& x)
 {
-    spec.attribute (x.first, x.second);
+    spec.attribute(x.first, x.second);
     return true;
 }
 
 
 
 bool
-Oiiotool::get_position (string_view command, string_view geom,
-                        int &x, int &y)
+Oiiotool::get_position(string_view command, string_view geom, int& x, int& y)
 {
-    string_view orig_geom (geom);
-    bool ok = Strutil::parse_int (geom, x)
-           && Strutil::parse_char (geom, ',')
-           && Strutil::parse_int (geom, y);
-    if (! ok)
-        error (command, Strutil::format ("Unrecognized position \"%s\"", orig_geom));
+    string_view orig_geom(geom);
+    bool ok = Strutil::parse_int(geom, x) && Strutil::parse_char(geom, ',')
+              && Strutil::parse_int(geom, y);
+    if (!ok)
+        error(command,
+              Strutil::format("Unrecognized position \"%s\"", orig_geom));
     return ok;
 }
 
 
 
 bool
-Oiiotool::adjust_geometry (string_view command,
-                           int &w, int &h, int &x, int &y, const char *geom,
-                           bool allow_scaling) const
+Oiiotool::adjust_geometry(string_view command, int& w, int& h, int& x, int& y,
+                          const char* geom, bool allow_scaling) const
 {
     float scaleX = 1.0f;
     float scaleY = 1.0f;
     int ww = w, hh = h;
     int xx = x, yy = y;
     int xmax, ymax;
-    if (sscanf (geom, "%d,%d,%d,%d", &xx, &yy, &xmax, &ymax) == 4) {
+    if (sscanf(geom, "%d,%d,%d,%d", &xx, &yy, &xmax, &ymax) == 4) {
         x = xx;
         y = yy;
-        w = std::max (0, xmax-xx+1);
-        h = std::max (0, ymax-yy+1);
-    } else if (sscanf (geom, "%dx%d%d%d", &ww, &hh, &xx, &yy) == 4 ||
-               sscanf (geom, "%dx%d+%d+%d", &ww, &hh, &xx, &yy) == 4) {
+        w = std::max(0, xmax - xx + 1);
+        h = std::max(0, ymax - yy + 1);
+    } else if (sscanf(geom, "%dx%d%d%d", &ww, &hh, &xx, &yy) == 4
+               || sscanf(geom, "%dx%d+%d+%d", &ww, &hh, &xx, &yy) == 4) {
         if (ww == 0 && h != 0)
-            ww = int (hh * float(w)/float(h) + 0.5f);
+            ww = int(hh * float(w) / float(h) + 0.5f);
         if (hh == 0 && w != 0)
-            hh = int (ww * float(h)/float(w) + 0.5f);
+            hh = int(ww * float(h) / float(w) + 0.5f);
         w = ww;
         h = hh;
         x = xx;
         y = yy;
-    } else if (sscanf (geom, "%dx%d", &ww, &hh) == 2) {
+    } else if (sscanf(geom, "%dx%d", &ww, &hh) == 2) {
         if (ww == 0 && h != 0)
-            ww = int (hh * float(w)/float(h) + 0.5f);
+            ww = int(hh * float(w) / float(h) + 0.5f);
         if (hh == 0 && w != 0)
-            hh = int (ww * float(h)/float(w) + 0.5f);
+            hh = int(ww * float(h) / float(w) + 0.5f);
         w = ww;
         h = hh;
-    } else if (allow_scaling && sscanf (geom, "%f%%x%f%%", &scaleX, &scaleY) == 2) {
-        scaleX = std::max(0.0f, scaleX*0.01f);
-        scaleY = std::max(0.0f, scaleY*0.01f);
+    } else if (allow_scaling
+               && sscanf(geom, "%f%%x%f%%", &scaleX, &scaleY) == 2) {
+        scaleX = std::max(0.0f, scaleX * 0.01f);
+        scaleY = std::max(0.0f, scaleY * 0.01f);
         if (scaleX == 0 && scaleY != 0)
             scaleX = scaleY;
         if (scaleY == 0 && scaleX != 0)
             scaleY = scaleX;
         w = (int)(w * scaleX + 0.5f);
         h = (int)(h * scaleY + 0.5f);
-    } else if (sscanf (geom, "%d%d", &xx, &yy) == 2) {
+    } else if (sscanf(geom, "%d%d", &xx, &yy) == 2) {
         x = xx;
         y = yy;
-    } else if (allow_scaling && sscanf (geom, "%f%%", &scaleX) == 1) {
+    } else if (allow_scaling && sscanf(geom, "%f%%", &scaleX) == 1) {
         scaleX *= 0.01f;
         w = (int)(w * scaleX + 0.5f);
         h = (int)(h * scaleX + 0.5f);
-    } else if (allow_scaling && sscanf (geom, "%f", &scaleX) == 1) {
+    } else if (allow_scaling && sscanf(geom, "%f", &scaleX) == 1) {
         w = (int)(w * scaleX + 0.5f);
         h = (int)(h * scaleX + 0.5f);
     } else {
-        error (command, Strutil::format ("Unrecognized geometry \"%s\"", geom));
+        error(command, Strutil::format("Unrecognized geometry \"%s\"", geom));
         return false;
     }
     // printf ("geom %dx%d, %+d%+d\n", w, h, x, y);
@@ -976,16 +992,19 @@ Oiiotool::adjust_geometry (string_view command,
 
 
 void
-Oiiotool::express_error (const string_view expr, const string_view s, string_view explanation)
+Oiiotool::express_error(const string_view expr, const string_view s,
+                        string_view explanation)
 {
     int offset = expr.rfind(s) + 1;
-    error("expression", Strutil::format ("%s at char %d of `%s'", explanation, offset, expr));
+    error("expression",
+          Strutil::format("%s at char %d of `%s'", explanation, offset, expr));
 }
 
 
 
 bool
-Oiiotool::express_parse_atom(const string_view expr, string_view& s, std::string& result)
+Oiiotool::express_parse_atom(const string_view expr, string_view& s,
+                             std::string& result)
 {
     // std::cout << " Entering express_parse_atom, s='" << s << "'\n";
 
@@ -998,20 +1017,20 @@ Oiiotool::express_parse_atom(const string_view expr, string_view& s, std::string
     // handle + or - prefixes
     bool negative = false;
     while (s.size()) {
-        if (Strutil::parse_char (s, '-')) {
-            negative = ! negative;
-        } else if (Strutil::parse_char (s, '+')) {
+        if (Strutil::parse_char(s, '-')) {
+            negative = !negative;
+        } else if (Strutil::parse_char(s, '+')) {
             // no op
         } else {
             break;
         }
     }
 
-    if (Strutil::parse_char (s, '(')) {
+    if (Strutil::parse_char(s, '(')) {
         // handle parentheses
-        if (express_parse_summands (expr, s, result)) {
-            if (! Strutil::parse_char (s, ')')) {
-                express_error (expr, s, "missing `)'");
+        if (express_parse_summands(expr, s, result)) {
+            if (!Strutil::parse_char(s, ')')) {
+                express_error(expr, s, "missing `)'");
                 result = orig;
                 return false;
             }
@@ -1020,110 +1039,112 @@ Oiiotool::express_parse_atom(const string_view expr, string_view& s, std::string
             return false;
         }
 
-    } else if (Strutil::starts_with (s,"TOP") || Strutil::starts_with (s, "IMG[")) {
+    } else if (Strutil::starts_with(s, "TOP")
+               || Strutil::starts_with(s, "IMG[")) {
         // metadata substitution
         ImageRecRef img;
-        if (Strutil::parse_prefix (s, "TOP")) {
+        if (Strutil::parse_prefix(s, "TOP")) {
             img = curimg;
-        } else if (Strutil::parse_prefix (s, "IMG[")) {
+        } else if (Strutil::parse_prefix(s, "IMG[")) {
             int index = -1;
-            if (Strutil::parse_int (s, index) && Strutil::parse_char (s, ']')
-                  && index >= 0 && index <= (int)image_stack.size()) {
+            if (Strutil::parse_int(s, index) && Strutil::parse_char(s, ']')
+                && index >= 0 && index <= (int)image_stack.size()) {
                 if (index == 0)
                     img = curimg;
                 else
-                    img = image_stack[image_stack.size()-index];
+                    img = image_stack[image_stack.size() - index];
             } else {
-                string_view name = Strutil::parse_until (s, "]");
-                std::map<std::string,ImageRecRef>::const_iterator found;
+                string_view name = Strutil::parse_until(s, "]");
+                std::map<std::string, ImageRecRef>::const_iterator found;
                 found = ot.image_labels.find(name);
                 if (found != ot.image_labels.end())
                     img = found->second;
                 else
-                    img = ImageRecRef (new ImageRec (name, ot.imagecache));
-                Strutil::parse_char (s, ']');
+                    img = ImageRecRef(new ImageRec(name, ot.imagecache));
+                Strutil::parse_char(s, ']');
             }
         }
-        if (! img.get()) {
-            express_error (expr, s, "not a valid image");
+        if (!img.get()) {
+            express_error(expr, s, "not a valid image");
             result = orig;
             return false;
         }
-        if (! Strutil::parse_char (s, '.')) {
-            express_error (expr, s, "expected `.'");
+        if (!Strutil::parse_char(s, '.')) {
+            express_error(expr, s, "expected `.'");
             result = orig;
             return false;
         }
         string_view metadata;
-        char quote = s.size() ? s.front() : ' ';
+        char quote             = s.size() ? s.front() : ' ';
         bool metadata_in_quote = quote == '\"' || quote == '\'';
         if (metadata_in_quote)
-            Strutil::parse_string (s, metadata);
+            Strutil::parse_string(s, metadata);
         else
-            metadata = Strutil::parse_identifier (s, ":");
+            metadata = Strutil::parse_identifier(s, ":");
 
         if (metadata.size()) {
-            read (img);
+            read(img);
             ParamValue tmpparam;
-            const ParamValue *p = img->spec(0,0)->find_attribute (metadata, tmpparam);
+            const ParamValue* p = img->spec(0, 0)->find_attribute(metadata,
+                                                                  tmpparam);
             if (p) {
-                std::string val = ImageSpec::metadata_val (*p);
+                std::string val = ImageSpec::metadata_val(*p);
                 if (p->type().basetype == TypeDesc::STRING) {
                     // metadata_val returns strings double quoted, strip
-                    val.erase (0, 1);
-                    val.erase (val.size()-1, 1);
+                    val.erase(0, 1);
+                    val.erase(val.size() - 1, 1);
                 }
                 result = val;
-            }
-            else if (metadata == "filename")
+            } else if (metadata == "filename")
                 result = img->name();
             else if (metadata == "file_extension")
-                result = Filesystem::extension (img->name());
+                result = Filesystem::extension(img->name());
             else if (metadata == "file_noextension") {
                 std::string filename = img->name();
-                std::string ext = Filesystem::extension (img->name());
-                result = filename.substr (0, filename.size()-ext.size());
+                std::string ext      = Filesystem::extension(img->name());
+                result = filename.substr(0, filename.size() - ext.size());
             } else if (metadata == "MINCOLOR") {
                 ImageBufAlgo::PixelStats pixstat;
-                ImageBufAlgo::computePixelStats (pixstat, (*img)(0,0));
+                ImageBufAlgo::computePixelStats(pixstat, (*img)(0, 0));
                 std::stringstream out;
                 for (size_t i = 0; i < pixstat.min.size(); ++i)
                     out << (i ? "," : "") << pixstat.min[i];
                 result = out.str();
             } else if (metadata == "MAXCOLOR") {
                 ImageBufAlgo::PixelStats pixstat;
-                ImageBufAlgo::computePixelStats (pixstat, (*img)(0,0));
+                ImageBufAlgo::computePixelStats(pixstat, (*img)(0, 0));
                 std::stringstream out;
                 for (size_t i = 0; i < pixstat.max.size(); ++i)
                     out << (i ? "," : "") << pixstat.max[i];
                 result = out.str();
             } else if (metadata == "AVGCOLOR") {
                 ImageBufAlgo::PixelStats pixstat;
-                ImageBufAlgo::computePixelStats (pixstat, (*img)(0,0));
+                ImageBufAlgo::computePixelStats(pixstat, (*img)(0, 0));
                 std::stringstream out;
                 for (size_t i = 0; i < pixstat.avg.size(); ++i)
                     out << (i ? "," : "") << pixstat.avg[i];
                 result = out.str();
             } else {
-                express_error (expr, s, Strutil::format ("unknown attribute name `%s'", metadata));
+                express_error(expr, s,
+                              Strutil::format("unknown attribute name `%s'",
+                                              metadata));
                 result = orig;
                 return false;
             }
         }
-    } else if (Strutil::parse_float (s, floatval)) {
-        result = Strutil::format ("%g", floatval);
+    } else if (Strutil::parse_float(s, floatval)) {
+        result = Strutil::format("%g", floatval);
     }
     // Test some special identifiers
-    else if (Strutil::parse_identifier_if (s, "FRAME_NUMBER")) {
-        result = Strutil::format ("%d", ot.frame_number);
-    }
-    else if (Strutil::parse_identifier_if (s, "FRAME_NUMBER_PAD")) {
-        std::string fmt = ot.frame_padding == 0 ? std::string("%d")
-                                : Strutil::format ("\"%%0%dd\"", ot.frame_padding);
-        result = Strutil::format (fmt, ot.frame_number);
-    }
-    else {
-        express_error (expr, s, "syntax error");
+    else if (Strutil::parse_identifier_if(s, "FRAME_NUMBER")) {
+        result = Strutil::format("%d", ot.frame_number);
+    } else if (Strutil::parse_identifier_if(s, "FRAME_NUMBER_PAD")) {
+        std::string fmt = ot.frame_padding == 0
+                              ? std::string("%d")
+                              : Strutil::format("\"%%0%dd\"", ot.frame_padding);
+        result = Strutil::format(fmt, ot.frame_number);
+    } else {
+        express_error(expr, s, "syntax error");
         result = orig;
         return false;
     }
@@ -1139,7 +1160,8 @@ Oiiotool::express_parse_atom(const string_view expr, string_view& s, std::string
 
 
 bool
-Oiiotool::express_parse_factors(const string_view expr, string_view& s, std::string& result)
+Oiiotool::express_parse_factors(const string_view expr, string_view& s,
+                                std::string& result)
 {
     // std::cout << " Entering express_parse_factors, s='" << s << "'\n";
 
@@ -1148,7 +1170,7 @@ Oiiotool::express_parse_factors(const string_view expr, string_view& s, std::str
     float lval, rval;
 
     // parse the first factor
-    if (! express_parse_atom (expr, s, atom)) {
+    if (!express_parse_atom(expr, s, atom)) {
         result = orig;
         return false;
     }
@@ -1156,14 +1178,14 @@ Oiiotool::express_parse_factors(const string_view expr, string_view& s, std::str
     if (atom.size() >= 2 && atom.front() == '\"' && atom.back() == '\"') {
         // Double quoted is string, return it
         result = atom;
-    } else if (Strutil::string_is<float> (atom)) {
+    } else if (Strutil::string_is<float>(atom)) {
         // lval is a number
-        lval = Strutil::from_string<float> (atom);
+        lval = Strutil::from_string<float>(atom);
         while (s.size()) {
             char op;
-            if (Strutil::parse_char (s, '*'))
+            if (Strutil::parse_char(s, '*'))
                 op = '*';
-            else if (Strutil::parse_char (s, '/'))
+            else if (Strutil::parse_char(s, '/'))
                 op = '/';
             else {
                 // no more factors
@@ -1171,13 +1193,15 @@ Oiiotool::express_parse_factors(const string_view expr, string_view& s, std::str
             }
 
             // parse the next factor
-            if (! express_parse_atom (expr, s, atom)) {
+            if (!express_parse_atom(expr, s, atom)) {
                 result = orig;
                 return false;
             }
 
-            if (! Strutil::string_is<float> (atom)) {
-                express_error (expr, s, Strutil::format ("expected number but got `%s'", atom));
+            if (!Strutil::string_is<float>(atom)) {
+                express_error(expr, s,
+                              Strutil::format("expected number but got `%s'",
+                                              atom));
                 result = orig;
                 return false;
             }
@@ -1186,11 +1210,11 @@ Oiiotool::express_parse_factors(const string_view expr, string_view& s, std::str
             rval = Strutil::from_string<float>(atom);
             if (op == '*')
                 lval *= rval;
-            else // op == '/'
+            else  // op == '/'
                 lval /= rval;
         }
 
-        result = Strutil::format ("%g", lval);
+        result = Strutil::format("%g", lval);
 
     } else {
         // atom is not a number, so we're done
@@ -1205,7 +1229,8 @@ Oiiotool::express_parse_factors(const string_view expr, string_view& s, std::str
 
 
 bool
-Oiiotool::express_parse_summands(const string_view expr, string_view& s, std::string& result)
+Oiiotool::express_parse_summands(const string_view expr, string_view& s,
+                                 std::string& result)
 {
     // std::cout << " Entering express_parse_summands, s='" << s << "'\n";
 
@@ -1214,22 +1239,22 @@ Oiiotool::express_parse_summands(const string_view expr, string_view& s, std::st
     float lval, rval;
 
     // parse the first summand
-    if (! express_parse_factors(expr, s, atom)) {
+    if (!express_parse_factors(expr, s, atom)) {
         result = orig;
         return false;
     }
 
     if (atom.size() >= 2 && atom.front() == '\"' && atom.back() == '\"') {
         // Double quoted is string, strip it
-        result = atom.substr (1, atom.size()-2);
-    } else if (Strutil::string_is<float> (atom)) {
+        result = atom.substr(1, atom.size() - 2);
+    } else if (Strutil::string_is<float>(atom)) {
         // lval is a number
-        lval = Strutil::from_string<float> (atom);
+        lval = Strutil::from_string<float>(atom);
         while (s.size()) {
             char op;
-            if (Strutil::parse_char (s, '+'))
+            if (Strutil::parse_char(s, '+'))
                 op = '+';
-            else if (Strutil::parse_char (s, '-'))
+            else if (Strutil::parse_char(s, '-'))
                 op = '-';
             else {
                 // no more summands
@@ -1237,13 +1262,14 @@ Oiiotool::express_parse_summands(const string_view expr, string_view& s, std::st
             }
 
             // parse the next summand
-            if (! express_parse_factors(expr, s, atom)) {
+            if (!express_parse_factors(expr, s, atom)) {
                 result = orig;
                 return false;
             }
 
-            if (! Strutil::string_is<float> (atom)) {
-                express_error (expr, s, Strutil::format ("`%s' is not a number", atom));
+            if (!Strutil::string_is<float>(atom)) {
+                express_error(expr, s,
+                              Strutil::format("`%s' is not a number", atom));
                 result = orig;
                 return false;
             }
@@ -1252,11 +1278,11 @@ Oiiotool::express_parse_summands(const string_view expr, string_view& s, std::st
             rval = Strutil::from_string<float>(atom);
             if (op == '+')
                 lval += rval;
-            else // op == '-'
+            else  // op == '-'
                 lval -= rval;
         }
 
-        result = Strutil::format ("%g", lval);
+        result = Strutil::format("%g", lval);
 
     } else {
         // atom is not a number, so we're done
@@ -1272,11 +1298,11 @@ Oiiotool::express_parse_summands(const string_view expr, string_view& s, std::st
 
 // Expression evaluation and substitution for a single expression
 std::string
-Oiiotool::express_impl (string_view s)
+Oiiotool::express_impl(string_view s)
 {
     std::string result;
     string_view orig = s;
-    if (! express_parse_summands(orig, s, result)) {
+    if (!express_parse_summands(orig, s, result)) {
         result = orig;
     }
     return result;
@@ -1286,47 +1312,49 @@ Oiiotool::express_impl (string_view s)
 
 // Perform expression evaluation and substitution on a string
 string_view
-Oiiotool::express (string_view str)
+Oiiotool::express(string_view str)
 {
     string_view s = str;
     // eg. s="ab{cde}fg"
     size_t openbrace = s.find('{');
     if (openbrace == s.npos)
-        return str;    // No open brace found -- no expresion substitution
+        return str;  // No open brace found -- no expresion substitution
 
-    string_view prefix = s.substr (0, openbrace);
-    s.remove_prefix (openbrace);
+    string_view prefix = s.substr(0, openbrace);
+    s.remove_prefix(openbrace);
     // eg. s="{cde}fg", prefix="ab"
-    string_view expr = Strutil::parse_nested (s);
+    string_view expr = Strutil::parse_nested(s);
     if (expr.empty())
-        return str;     // No corresponding close brace found -- give up
+        return str;  // No corresponding close brace found -- give up
     // eg. prefix="ab", expr="{cde}", s="fg", prefix="ab"
-    ASSERT (expr.front() == '{' && expr.back() == '}');
+    ASSERT(expr.front() == '{' && expr.back() == '}');
     expr.remove_prefix(1);
     expr.remove_suffix(1);
     // eg. expr="cde"
-    ustring result = ustring::format("%s%s%s", prefix, express_impl(expr), express(s));
+    ustring result = ustring::format("%s%s%s", prefix, express_impl(expr),
+                                     express(s));
     if (ot.debug)
-        std::cout << "Expanding expression \"" << str << "\" -> \"" << result << "\"\n";
+        std::cout << "Expanding expression \"" << str << "\" -> \"" << result
+                  << "\"\n";
     return result;
 }
 
 
 
 static int
-set_input_attribute (int argc, const char *argv[])
+set_input_attribute(int argc, const char* argv[])
 {
-    ASSERT (argc == 3);
+    ASSERT(argc == 3);
 
-    std::map<std::string,std::string> options;
-    ot.extract_options (options, argv[0]);
-    TypeDesc type (options["type"]);
+    std::map<std::string, std::string> options;
+    ot.extract_options(options, argv[0]);
+    TypeDesc type(options["type"]);
     string_view attribname = ot.express(argv[1]);
-    string_view value = ot.express(argv[2]);
+    string_view value      = ot.express(argv[2]);
 
-    if (! value.size()) {
+    if (!value.size()) {
         // If the value is the empty string, clear the attribute
-        ot.input_config.erase_attribute (attribname);
+        ot.input_config.erase_attribute(attribname);
         return 0;
     }
 
@@ -1335,94 +1363,92 @@ set_input_attribute (int argc, const char *argv[])
     // First, handle the cases where we're told what to expect
     if (type.basetype == TypeDesc::FLOAT) {
         size_t n = type.numelements() * type.aggregate;
-        std::vector<float> vals (n, 0.0f);
+        std::vector<float> vals(n, 0.0f);
         for (size_t i = 0; i < n && value.size(); ++i) {
-            Strutil::parse_float (value, vals[i]);
-            Strutil::parse_char (value, ',');
+            Strutil::parse_float(value, vals[i]);
+            Strutil::parse_char(value, ',');
         }
-        ot.input_config.attribute (attribname, type, &vals[0]);
+        ot.input_config.attribute(attribname, type, &vals[0]);
         return 0;
     }
     if (type.basetype == TypeDesc::INT) {
         size_t n = type.numelements() * type.aggregate;
-        std::vector<int> vals (n, 0);
+        std::vector<int> vals(n, 0);
         for (size_t i = 0; i < n && value.size(); ++i) {
-            Strutil::parse_int (value, vals[i]);
-            Strutil::parse_char (value, ',');
+            Strutil::parse_int(value, vals[i]);
+            Strutil::parse_char(value, ',');
         }
-        ot.input_config.attribute (attribname, type, &vals[0]);
+        ot.input_config.attribute(attribname, type, &vals[0]);
         return 0;
     }
     if (type.basetype == TypeDesc::STRING) {
         size_t n = type.numelements() * type.aggregate;
-        std::vector<ustring> vals (n, ustring());
+        std::vector<ustring> vals(n, ustring());
         if (n == 1)
             vals[0] = ustring(value);
         else {
             for (size_t i = 0; i < n && value.size(); ++i) {
                 string_view s;
-                Strutil::parse_string (value, s);
+                Strutil::parse_string(value, s);
                 vals[i] = ustring(s);
-                Strutil::parse_char (value, ',');
+                Strutil::parse_char(value, ',');
             }
         }
-        ot.input_config.attribute (attribname, type, &vals[0]);
+        ot.input_config.attribute(attribname, type, &vals[0]);
         return 0;
     }
 
-    if (type == TypeInt ||
-        (type == TypeUnknown && Strutil::string_is_int(value))) {
+    if (type == TypeInt
+        || (type == TypeUnknown && Strutil::string_is_int(value))) {
         // Does it seem to be an int, or did the caller explicitly request
         // that it be set as an int?
-        ot.input_config.attribute (attribname, Strutil::stoi(value));
-    } else if (type == TypeFloat ||
-        (type == TypeUnknown && Strutil::string_is_float(value))) {
+        ot.input_config.attribute(attribname, Strutil::stoi(value));
+    } else if (type == TypeFloat
+               || (type == TypeUnknown && Strutil::string_is_float(value))) {
         // Does it seem to be a float, or did the caller explicitly request
         // that it be set as a float?
-        ot.input_config.attribute (attribname, Strutil::stof(value));
+        ot.input_config.attribute(attribname, Strutil::stof(value));
     } else {
         // Otherwise, set it as a string attribute
-        ot.input_config.attribute (attribname, value);
+        ot.input_config.attribute(attribname, value);
     }
     return 0;
 }
 
 
 
-
 bool
-OiioTool::set_attribute (ImageRecRef img, string_view attribname,
-                         TypeDesc type, string_view value,
-                         bool allsubimages)
+OiioTool::set_attribute(ImageRecRef img, string_view attribname, TypeDesc type,
+                        string_view value, bool allsubimages)
 {
     // Expression substitution
     attribname = ot.express(attribname);
-    value = ot.express(value);
+    value      = ot.express(value);
 
-    ot.read (img);
-    img->metadata_modified (true);
-    if (! value.size()) {
+    ot.read(img);
+    img->metadata_modified(true);
+    if (!value.size()) {
         // If the value is the empty string, clear the attribute
-        return apply_spec_mod (*img, do_erase_attribute,
-                               attribname, allsubimages);
+        return apply_spec_mod(*img, do_erase_attribute, attribname,
+                              allsubimages);
     }
 
     // First, handle the cases where we're told what to expect
     if (type.basetype == TypeDesc::FLOAT) {
         size_t n = type.numelements() * type.aggregate;
-        std::vector<float> vals (n, 0.0f);
+        std::vector<float> vals(n, 0.0f);
         for (size_t i = 0; i < n && value.size(); ++i) {
-            Strutil::parse_float (value, vals[i]);
-            Strutil::parse_char (value, ',');
+            Strutil::parse_float(value, vals[i]);
+            Strutil::parse_char(value, ',');
         }
-        for (int s = 0, send = img->subimages();  s < send;  ++s) {
-            for (int m = 0, mend = img->miplevels(s);  m < mend;  ++m) {
-                ((*img)(s,m).specmod()).attribute (attribname, type, &vals[0]);
-                img->update_spec_from_imagebuf (s, m);
-                if (! allsubimages)
+        for (int s = 0, send = img->subimages(); s < send; ++s) {
+            for (int m = 0, mend = img->miplevels(s); m < mend; ++m) {
+                ((*img)(s, m).specmod()).attribute(attribname, type, &vals[0]);
+                img->update_spec_from_imagebuf(s, m);
+                if (!allsubimages)
                     break;
             }
-            if (! allsubimages)
+            if (!allsubimages)
                 break;
         }
         return true;
@@ -1431,16 +1457,16 @@ OiioTool::set_attribute (ImageRecRef img, string_view attribname,
         // Special case: They are specifying a TimeCode as a "HH:MM:SS:FF"
         // string, we need to re-encode as a uint32[2].
         int hour = 0, min = 0, sec = 0, frame = 0;
-        sscanf (value.c_str(), "%d:%d:%d:%d", &hour, &min, &sec, &frame);
-        Imf::TimeCode tc (hour, min, sec, frame);
-        for (int s = 0, send = img->subimages();  s < send;  ++s) {
-            for (int m = 0, mend = img->miplevels(s);  m < mend;  ++m) {
-                ((*img)(s,m).specmod()).attribute (attribname, type, &tc);
-                img->update_spec_from_imagebuf (s, m);
-                if (! allsubimages)
+        sscanf(value.c_str(), "%d:%d:%d:%d", &hour, &min, &sec, &frame);
+        Imf::TimeCode tc(hour, min, sec, frame);
+        for (int s = 0, send = img->subimages(); s < send; ++s) {
+            for (int m = 0, mend = img->miplevels(s); m < mend; ++m) {
+                ((*img)(s, m).specmod()).attribute(attribname, type, &tc);
+                img->update_spec_from_imagebuf(s, m);
+                if (!allsubimages)
                     break;
             }
-            if (! allsubimages)
+            if (!allsubimages)
                 break;
         }
         return true;
@@ -1449,118 +1475,119 @@ OiioTool::set_attribute (ImageRecRef img, string_view attribname,
         // Special case: They are specifying a rational as "a/b", so we need
         // to re-encode as a int32[2].
         int v[2];
-        Strutil::parse_int (value, v[0]);
-        Strutil::parse_char (value, '/');
-        Strutil::parse_int (value, v[1]);
-        for (int s = 0, send = img->subimages();  s < send;  ++s) {
-            for (int m = 0, mend = img->miplevels(s);  m < mend;  ++m) {
-                ((*img)(s,m).specmod()).attribute (attribname, type, v);
-                img->update_spec_from_imagebuf (s, m);
-                if (! allsubimages)
+        Strutil::parse_int(value, v[0]);
+        Strutil::parse_char(value, '/');
+        Strutil::parse_int(value, v[1]);
+        for (int s = 0, send = img->subimages(); s < send; ++s) {
+            for (int m = 0, mend = img->miplevels(s); m < mend; ++m) {
+                ((*img)(s, m).specmod()).attribute(attribname, type, v);
+                img->update_spec_from_imagebuf(s, m);
+                if (!allsubimages)
                     break;
             }
-            if (! allsubimages)
+            if (!allsubimages)
                 break;
         }
         return true;
     }
     if (type.basetype == TypeDesc::INT) {
         size_t n = type.numelements() * type.aggregate;
-        std::vector<int> vals (n, 0);
+        std::vector<int> vals(n, 0);
         for (size_t i = 0; i < n && value.size(); ++i) {
-            Strutil::parse_int (value, vals[i]);
-            Strutil::parse_char (value, ',');
+            Strutil::parse_int(value, vals[i]);
+            Strutil::parse_char(value, ',');
         }
-        for (int s = 0, send = img->subimages();  s < send;  ++s) {
-            for (int m = 0, mend = img->miplevels(s);  m < mend;  ++m) {
-                ((*img)(s,m).specmod()).attribute (attribname, type, &vals[0]);
-                img->update_spec_from_imagebuf (s, m);
-                if (! allsubimages)
+        for (int s = 0, send = img->subimages(); s < send; ++s) {
+            for (int m = 0, mend = img->miplevels(s); m < mend; ++m) {
+                ((*img)(s, m).specmod()).attribute(attribname, type, &vals[0]);
+                img->update_spec_from_imagebuf(s, m);
+                if (!allsubimages)
                     break;
             }
-            if (! allsubimages)
+            if (!allsubimages)
                 break;
         }
         return true;
     }
     if (type.basetype == TypeDesc::STRING) {
         size_t n = type.numelements() * type.aggregate;
-        std::vector<ustring> vals (n, ustring());
+        std::vector<ustring> vals(n, ustring());
         if (n == 1)
             vals[0] = ustring(value);
         else {
             for (size_t i = 0; i < n && value.size(); ++i) {
                 string_view s;
-                Strutil::parse_string (value, s);
+                Strutil::parse_string(value, s);
                 vals[i] = ustring(s);
-                Strutil::parse_char (value, ',');
+                Strutil::parse_char(value, ',');
             }
         }
-        for (int s = 0, send = img->subimages();  s < send;  ++s) {
-            for (int m = 0, mend = img->miplevels(s);  m < mend;  ++m) {
-                ((*img)(s,m).specmod()).attribute (attribname, type, &vals[0]);
-                img->update_spec_from_imagebuf (s, m);
-                if (! allsubimages)
+        for (int s = 0, send = img->subimages(); s < send; ++s) {
+            for (int m = 0, mend = img->miplevels(s); m < mend; ++m) {
+                ((*img)(s, m).specmod()).attribute(attribname, type, &vals[0]);
+                img->update_spec_from_imagebuf(s, m);
+                if (!allsubimages)
                     break;
             }
-            if (! allsubimages)
+            if (!allsubimages)
                 break;
         }
         return true;
     }
 
-    if (type == TypeInt ||
-        (type == TypeUnknown && Strutil::string_is_int(value))) {
+    if (type == TypeInt
+        || (type == TypeUnknown && Strutil::string_is_int(value))) {
         // Does it seem to be an int, or did the caller explicitly request
         // that it be set as an int?
         int v = Strutil::stoi(value);
-        return apply_spec_mod (*img, do_set_any_attribute<int>,
-                               std::pair<std::string,int>(attribname,v),
-                               allsubimages);
-    } else if (type == TypeFloat ||
-        (type == TypeUnknown && Strutil::string_is_float(value))) {
+        return apply_spec_mod(*img, do_set_any_attribute<int>,
+                              std::pair<std::string, int>(attribname, v),
+                              allsubimages);
+    } else if (type == TypeFloat
+               || (type == TypeUnknown && Strutil::string_is_float(value))) {
         // Does it seem to be a float, or did the caller explicitly request
         // that it be set as a float?
         float v = Strutil::stof(value);
-        return apply_spec_mod (*img, do_set_any_attribute<float>,
-                               std::pair<std::string,float>(attribname,v),
-                               allsubimages);
+        return apply_spec_mod(*img, do_set_any_attribute<float>,
+                              std::pair<std::string, float>(attribname, v),
+                              allsubimages);
     } else {
         // Otherwise, set it as a string attribute
-        return apply_spec_mod (*img, do_set_any_attribute<std::string>,
-                               std::pair<std::string,std::string>(attribname,value),
-                               allsubimages);
+        return apply_spec_mod(*img, do_set_any_attribute<std::string>,
+                              std::pair<std::string, std::string>(attribname,
+                                                                  value),
+                              allsubimages);
     }
 }
 
 
 
 static int
-set_caption (int argc, const char *argv[])
+set_caption(int argc, const char* argv[])
 {
-    ASSERT (argc == 2);
-    const char *newargs[3] = { argv[0], "ImageDescription", argv[1] };
-    return set_string_attribute (3, newargs);
+    ASSERT(argc == 2);
+    const char* newargs[3] = { argv[0], "ImageDescription", argv[1] };
+    return set_string_attribute(3, newargs);
     // N.B. set_string_attribute does expression expansion on its args
 }
 
 
 
 static bool
-do_set_keyword (ImageSpec &spec, const std::string &keyword)
+do_set_keyword(ImageSpec& spec, const std::string& keyword)
 {
-    std::string oldkw = spec.get_string_attribute ("Keywords");
+    std::string oldkw = spec.get_string_attribute("Keywords");
     std::vector<std::string> oldkwlist;
-    if (! oldkw.empty())
-        Strutil::split (oldkw, oldkwlist, ";");
+    if (!oldkw.empty())
+        Strutil::split(oldkw, oldkwlist, ";");
     bool dup = false;
-    for (std::string &ok : oldkwlist) {
-        ok = Strutil::strip (ok);
+    for (std::string& ok : oldkwlist) {
+        ok = Strutil::strip(ok);
         dup |= (ok == keyword);
     }
-    if (! dup) {
-        oldkwlist.push_back (keyword);
-        spec.attribute ("Keywords", Strutil::join (oldkwlist, "; "));
+    if (!dup) {
+        oldkwlist.push_back(keyword);
+        spec.attribute("Keywords", Strutil::join(oldkwlist, "; "));
     }
     return true;
 }
@@ -1568,17 +1595,17 @@ do_set_keyword (ImageSpec &spec, const std::string &keyword)
 
 
 static int
-set_keyword (int argc, const char *argv[])
+set_keyword(int argc, const char* argv[])
 {
-    ASSERT (argc == 2);
-    if (! ot.curimg.get()) {
-        ot.warning (argv[0], "no current image available to modify");
+    ASSERT(argc == 2);
+    if (!ot.curimg.get()) {
+        ot.warning(argv[0], "no current image available to modify");
         return 0;
     }
 
-    std::string keyword (ot.express(argv[1]));
+    std::string keyword(ot.express(argv[1]));
     if (keyword.size())
-        apply_spec_mod (*ot.curimg, do_set_keyword, keyword, ot.allsubimages);
+        apply_spec_mod(*ot.curimg, do_set_keyword, keyword, ot.allsubimages);
 
     return 0;
 }
@@ -1586,43 +1613,43 @@ set_keyword (int argc, const char *argv[])
 
 
 static int
-clear_keywords (int argc, const char *argv[])
+clear_keywords(int argc, const char* argv[])
 {
-    ASSERT (argc == 1);
-    const char *newargs[3];
+    ASSERT(argc == 1);
+    const char* newargs[3];
     newargs[0] = argv[0];
     newargs[1] = "Keywords";
     newargs[2] = "";
-    return set_string_attribute (3, newargs);
+    return set_string_attribute(3, newargs);
 }
 
 
 
 static int
-set_orientation (int argc, const char *argv[])
+set_orientation(int argc, const char* argv[])
 {
-    ASSERT (argc == 2);
-    if (! ot.curimg.get()) {
-        ot.warning (argv[0], "no current image available to modify");
+    ASSERT(argc == 2);
+    if (!ot.curimg.get()) {
+        ot.warning(argv[0], "no current image available to modify");
         return 0;
     }
-    return set_attribute (ot.curimg, "Orientation", TypeDesc::INT, argv[1],
-                          ot.allsubimages);
+    return set_attribute(ot.curimg, "Orientation", TypeDesc::INT, argv[1],
+                         ot.allsubimages);
     // N.B. set_attribute does expression expansion on its args
 }
 
 
 
 static bool
-do_rotate_orientation (ImageSpec &spec, string_view cmd)
+do_rotate_orientation(ImageSpec& spec, string_view cmd)
 {
-    bool rotcw = (cmd == "--orientcw" || cmd == "-orientcw" ||
-                  cmd == "--rotcw" || cmd == "-rotcw");
-    bool rotccw = (cmd == "--orientccw" || cmd == "-orientccw" ||
-                   cmd == "--rotccw" || cmd == "-rotccw");
-    bool rot180 = (cmd == "--orient180" || cmd == "-orient180" ||
-                   cmd == "--rot180" || cmd == "-rot180");
-    int orientation = spec.get_int_attribute ("Orientation", 1);
+    bool rotcw  = (cmd == "--orientcw" || cmd == "-orientcw" || cmd == "--rotcw"
+                  || cmd == "-rotcw");
+    bool rotccw = (cmd == "--orientccw" || cmd == "-orientccw"
+                   || cmd == "--rotccw" || cmd == "-rotccw");
+    bool rot180 = (cmd == "--orient180" || cmd == "-orient180"
+                   || cmd == "--rot180" || cmd == "-rot180");
+    int orientation = spec.get_int_attribute("Orientation", 1);
     if (orientation >= 1 && orientation <= 8) {
         static int cw[] = { 0, 6, 7, 8, 5, 2, 3, 4, 1 };
         if (rotcw || rotccw || rot180)
@@ -1631,7 +1658,7 @@ do_rotate_orientation (ImageSpec &spec, string_view cmd)
             orientation = cw[orientation];
         if (rotccw)
             orientation = cw[orientation];
-        spec.attribute ("Orientation", orientation);
+        spec.attribute("Orientation", orientation);
     }
     return true;
 }
@@ -1639,55 +1666,55 @@ do_rotate_orientation (ImageSpec &spec, string_view cmd)
 
 
 static int
-rotate_orientation (int argc, const char *argv[])
+rotate_orientation(int argc, const char* argv[])
 {
-    ASSERT (argc == 1);
-    string_view command = ot.express (argv[0]);
-    if (! ot.curimg.get()) {
-        ot.warning (command, "no current image available to modify");
+    ASSERT(argc == 1);
+    string_view command = ot.express(argv[0]);
+    if (!ot.curimg.get()) {
+        ot.warning(command, "no current image available to modify");
         return 0;
     }
-    apply_spec_mod (*ot.curimg, do_rotate_orientation, command,
-                    ot.allsubimages);
+    apply_spec_mod(*ot.curimg, do_rotate_orientation, command, ot.allsubimages);
     return 0;
 }
 
 
 
 static int
-set_origin (int argc, const char *argv[])
+set_origin(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, set_origin, argc, argv))
+    if (ot.postpone_callback(1, set_origin, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
-    string_view origin  = ot.express (argv[1]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
+    string_view origin  = ot.express(argv[1]);
 
-    ot.read ();
+    ot.read();
     ImageRecRef A = ot.curimg;
     for (int s = 0; s < A->subimages(); ++s) {
-        ImageSpec &spec (*A->spec(s));
+        ImageSpec& spec(*A->spec(s));
         int x = spec.x, y = spec.y, z = spec.z;
         int w = spec.width, h = spec.height, d = spec.depth;
-        ot.adjust_geometry (command, w, h, x, y, origin.c_str());
+        ot.adjust_geometry(command, w, h, x, y, origin.c_str());
         if (spec.width != w || spec.height != h || spec.depth != d)
-            ot.warning (command, "can't be used to change the size, only the origin");
+            ot.warning(command,
+                       "can't be used to change the size, only the origin");
         if (spec.x != x || spec.y != y) {
-            ImageBuf &ib = (*A)(s);
+            ImageBuf& ib = (*A)(s);
             if (ib.storage() == ImageBuf::IMAGECACHE) {
                 // If the image is cached, we will totally screw up the IB/IC
                 // operations if we try to change the origin in place, so in
                 // that case force a full read to convert to a local buffer,
                 // which is safe to diddle the origin.
-                ib.read (0, 0, true /*force*/, spec.format);
+                ib.read(0, 0, true /*force*/, spec.format);
             }
             spec.x = x;
             spec.y = y;
             spec.z = z;
             // That updated the private spec of the ImageRec. In this case
             // we really need to update the underlying IB as well.
-            ib.set_origin (x, y, z);
-            A->metadata_modified (true);
+            ib.set_origin(x, y, z);
+            A->metadata_modified(true);
         }
     }
     ot.function_times[command] += timer();
@@ -1697,35 +1724,35 @@ set_origin (int argc, const char *argv[])
 
 
 static int
-set_fullsize (int argc, const char *argv[])
+set_fullsize(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, set_fullsize, argc, argv))
+    if (ot.postpone_callback(1, set_fullsize, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
-    string_view size    = ot.express (argv[1]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
+    string_view size    = ot.express(argv[1]);
 
-    ot.read ();
+    ot.read();
     ImageRecRef A = ot.curimg;
-    ImageSpec &spec (*A->spec(0,0));
+    ImageSpec& spec(*A->spec(0, 0));
     int x = spec.full_x, y = spec.full_y;
     int w = spec.full_width, h = spec.full_height;
 
-    ot.adjust_geometry (argv[0], w, h, x, y, size.c_str());
-    if (spec.full_x != x || spec.full_y != y ||
-          spec.full_width != w || spec.full_height != h) {
-        spec.full_x = x;
-        spec.full_y = y;
-        spec.full_width = w;
+    ot.adjust_geometry(argv[0], w, h, x, y, size.c_str());
+    if (spec.full_x != x || spec.full_y != y || spec.full_width != w
+        || spec.full_height != h) {
+        spec.full_x      = x;
+        spec.full_y      = y;
+        spec.full_width  = w;
         spec.full_height = h;
         // That updated the private spec of the ImageRec. In this case
         // we really need to update the underlying IB as well.
-        ImageSpec &ibspec = (*A)(0,0).specmod();
-        ibspec.full_x = x;
-        ibspec.full_y = y;
-        ibspec.full_width = w;
+        ImageSpec& ibspec  = (*A)(0, 0).specmod();
+        ibspec.full_x      = x;
+        ibspec.full_y      = y;
+        ibspec.full_width  = w;
         ibspec.full_height = h;
-        A->metadata_modified (true);
+        A->metadata_modified(true);
     }
     ot.function_times[command] += timer();
     return 0;
@@ -1734,36 +1761,36 @@ set_fullsize (int argc, const char *argv[])
 
 
 static int
-set_full_to_pixels (int argc, const char *argv[])
+set_full_to_pixels(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, set_full_to_pixels, argc, argv))
+    if (ot.postpone_callback(1, set_full_to_pixels, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
 
-    ot.read ();
+    ot.read();
     ImageRecRef A = ot.curimg;
-    for (int s = 0, send = A->subimages();  s < send;  ++s) {
-        for (int m = 0, mend = A->miplevels(s);  m < mend;  ++m) {
-            ImageSpec &spec = *A->spec(s,m);
-            spec.full_x = spec.x;
-            spec.full_y = spec.y;
-            spec.full_z = spec.z;
-            spec.full_width = spec.width;
+    for (int s = 0, send = A->subimages(); s < send; ++s) {
+        for (int m = 0, mend = A->miplevels(s); m < mend; ++m) {
+            ImageSpec& spec  = *A->spec(s, m);
+            spec.full_x      = spec.x;
+            spec.full_y      = spec.y;
+            spec.full_z      = spec.z;
+            spec.full_width  = spec.width;
             spec.full_height = spec.height;
-            spec.full_depth = spec.depth;
+            spec.full_depth  = spec.depth;
             // That updated the private spec of the ImageRec. In this case
             // we really need to update the underlying IB as well.
-            ImageSpec &ibspec = (*A)(s,m).specmod();
-            ibspec.full_x = spec.x;
-            ibspec.full_y = spec.y;
-            ibspec.full_z = spec.z;
-            ibspec.full_width = spec.width;
+            ImageSpec& ibspec  = (*A)(s, m).specmod();
+            ibspec.full_x      = spec.x;
+            ibspec.full_y      = spec.y;
+            ibspec.full_z      = spec.z;
+            ibspec.full_width  = spec.width;
             ibspec.full_height = spec.height;
-            ibspec.full_depth = spec.depth;
+            ibspec.full_depth  = spec.depth;
         }
     }
-    A->metadata_modified (true);
+    A->metadata_modified(true);
     ot.function_times[command] += timer();
     return 0;
 }
@@ -1771,21 +1798,21 @@ set_full_to_pixels (int argc, const char *argv[])
 
 
 static int
-set_colorconfig (int argc, const char *argv[])
+set_colorconfig(int argc, const char* argv[])
 {
-    ASSERT (argc == 2);
-    ot.colorconfig.reset (argv[1]);
+    ASSERT(argc == 2);
+    ot.colorconfig.reset(argv[1]);
     return 0;
 }
 
 
 
 static int
-set_colorspace (int argc, const char *argv[])
+set_colorspace(int argc, const char* argv[])
 {
-    ASSERT (argc == 2);
-    const char *args[3] = { argv[0], "oiio:ColorSpace", argv[1] };
-    return set_string_attribute (3, args);
+    ASSERT(argc == 2);
+    const char* args[3] = { argv[0], "oiio:ColorSpace", argv[1] };
+    return set_string_attribute(3, args);
     // N.B. set_string_attribute does expression expansion on its args
 }
 
@@ -1793,154 +1820,179 @@ set_colorspace (int argc, const char *argv[])
 
 class OpColorConvert : public OiiotoolOp {
 public:
-    OpColorConvert (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) {
-            fromspace = args[1];  tospace = args[2];
-        }
-    virtual void option_defaults () {
-        options["strict"] = "1";
+    OpColorConvert(Oiiotool& ot, string_view opname, int argc,
+                   const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+        fromspace = args[1];
+        tospace   = args[2];
+    }
+    virtual void option_defaults()
+    {
+        options["strict"]    = "1";
         options["unpremult"] = "0";
     }
-    virtual bool setup () {
+    virtual bool setup()
+    {
         if (fromspace == tospace) {
             // The whole thing is a no-op. Get rid of the empty result we
             // pushed on the stack, replace it with the original image, and
             // signal that we're done.
-            ot.pop ();
-            ot.push (ir[1]);
+            ot.pop();
+            ot.push(ir[1]);
             return false;
         }
         return true;
     }
-    virtual int impl (ImageBuf **img) {
-        string_view contextkey = options["key"];
+    virtual int impl(ImageBuf** img)
+    {
+        string_view contextkey   = options["key"];
         string_view contextvalue = options["value"];
-        bool strict = Strutil::from_string<int>(options["strict"]);
+        bool strict              = Strutil::from_string<int>(options["strict"]);
         bool unpremult = Strutil::from_string<int>(options["unpremult"]);
-        if (unpremult && img[1]->spec().get_int_attribute("oiio:UnassociatedAlpha") && img[1]->spec().alpha_channel >= 0) {
-            ot.warning (opname(), "Image appears to already be unassociated alpha (un-premultiplied color), beware double unpremult. Don't use --unpremult and also --colorconvert:unpremult=1.");
+        if (unpremult
+            && img[1]->spec().get_int_attribute("oiio:UnassociatedAlpha")
+            && img[1]->spec().alpha_channel >= 0) {
+            ot.warning(
+                opname(),
+                "Image appears to already be unassociated alpha (un-premultiplied color), beware double unpremult. Don't use --unpremult and also --colorconvert:unpremult=1.");
         }
-        bool ok = ImageBufAlgo::colorconvert (*img[0], *img[1],
-                                              fromspace, tospace, unpremult,
-                                              contextkey, contextvalue,
-                                              &ot.colorconfig);
+        bool ok = ImageBufAlgo::colorconvert(*img[0], *img[1], fromspace,
+                                             tospace, unpremult, contextkey,
+                                             contextvalue, &ot.colorconfig);
         if (!ok && !strict) {
             // The color transform failed, but we were told not to be
             // strict, so ignore the error and just copy destination to
             // source.
             std::string err = img[0]->geterror();
-            ot.warning (opname(), err);
+            ot.warning(opname(), err);
             // ok = ImageBufAlgo::copy (*img[0], *img[1], TypeDesc);
-            ok = img[0]->copy (*img[1]);
+            ok = img[0]->copy(*img[1]);
         }
         return ok;
     }
+
 private:
     string_view fromspace, tospace;
 };
 
-OP_CUSTOMCLASS (colorconvert, OpColorConvert, 1);
+OP_CUSTOMCLASS(colorconvert, OpColorConvert, 1);
 
 
 
 static int
-action_tocolorspace (int argc, const char *argv[])
+action_tocolorspace(int argc, const char* argv[])
 {
     // Don't time -- let it get accounted by colorconvert
-    ASSERT (argc == 2);
-    if (! ot.curimg.get()) {
-        ot.warning (argv[0], "no current image available to modify");
+    ASSERT(argc == 2);
+    if (!ot.curimg.get()) {
+        ot.warning(argv[0], "no current image available to modify");
         return 0;
     }
-    const char *args[3] = { argv[0], "current", argv[1] };
-    return action_colorconvert (3, args);
+    const char* args[3] = { argv[0], "current", argv[1] };
+    return action_colorconvert(3, args);
 }
 
 
 
 class OpOcioLook : public OiiotoolOp {
 public:
-    OpOcioLook (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) { }
-    virtual void option_defaults () {
-        options["from"] = "current";
-        options["to"] = "current";
+    OpOcioLook(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual void option_defaults()
+    {
+        options["from"]      = "current";
+        options["to"]        = "current";
         options["unpremult"] = "0";
     }
-    virtual int impl (ImageBuf **img) {
-        string_view lookname = args[1];
-        string_view fromspace = options["from"];
-        string_view tospace = options["to"];
-        string_view contextkey = options["key"];
+    virtual int impl(ImageBuf** img)
+    {
+        string_view lookname     = args[1];
+        string_view fromspace    = options["from"];
+        string_view tospace      = options["to"];
+        string_view contextkey   = options["key"];
         string_view contextvalue = options["value"];
-        bool inverse = Strutil::from_string<int> (options["inverse"]);
+        bool inverse   = Strutil::from_string<int>(options["inverse"]);
         bool unpremult = Strutil::from_string<int>(options["unpremult"]);
         if (fromspace == "current" || fromspace == "")
-            fromspace = img[1]->spec().get_string_attribute ("oiio:Colorspace", "Linear");
+            fromspace = img[1]->spec().get_string_attribute("oiio:Colorspace",
+                                                            "Linear");
         if (tospace == "current" || tospace == "")
-            tospace = img[1]->spec().get_string_attribute ("oiio:Colorspace", "Linear");
-        return ImageBufAlgo::ociolook (*img[0], *img[1], lookname,
-                                       fromspace, tospace, unpremult, inverse,
-                                       contextkey, contextvalue,
-                                       &ot.colorconfig);
+            tospace = img[1]->spec().get_string_attribute("oiio:Colorspace",
+                                                          "Linear");
+        return ImageBufAlgo::ociolook(*img[0], *img[1], lookname, fromspace,
+                                      tospace, unpremult, inverse, contextkey,
+                                      contextvalue, &ot.colorconfig);
     }
 };
 
-OP_CUSTOMCLASS (ociolook, OpOcioLook, 1);
+OP_CUSTOMCLASS(ociolook, OpOcioLook, 1);
 
 
 
 class OpOcioDisplay : public OiiotoolOp {
 public:
-    OpOcioDisplay (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) { }
-    virtual void option_defaults () {
-        options["from"] = "current";
+    OpOcioDisplay(Oiiotool& ot, string_view opname, int argc,
+                  const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual void option_defaults()
+    {
+        options["from"]      = "current";
         options["unpremult"] = "0";
     }
-    virtual int impl (ImageBuf **img) {
+    virtual int impl(ImageBuf** img)
+    {
         string_view displayname  = args[1];
         string_view viewname     = args[2];
         string_view fromspace    = options["from"];
         string_view contextkey   = options["key"];
         string_view contextvalue = options["value"];
-        bool override_looks = options.find("looks") != options.end();
+        bool override_looks      = options.find("looks") != options.end();
         bool unpremult = Strutil::from_string<int>(options["unpremult"]);
         if (fromspace == "current" || fromspace == "")
-            fromspace = img[1]->spec().get_string_attribute ("oiio:Colorspace", "Linear");
-        return ImageBufAlgo::ociodisplay (*img[0], *img[1], displayname,
-                             viewname, fromspace,
-                             override_looks ? options["looks"] : std::string(""),
-                             unpremult, contextkey, contextvalue, &ot.colorconfig);
+            fromspace = img[1]->spec().get_string_attribute("oiio:Colorspace",
+                                                            "Linear");
+        return ImageBufAlgo::ociodisplay(*img[0], *img[1], displayname,
+                                         viewname, fromspace,
+                                         override_looks ? options["looks"]
+                                                        : std::string(""),
+                                         unpremult, contextkey, contextvalue,
+                                         &ot.colorconfig);
     }
 };
 
-OP_CUSTOMCLASS (ociodisplay, OpOcioDisplay, 1);
+OP_CUSTOMCLASS(ociodisplay, OpOcioDisplay, 1);
 
 
 
 class OpOcioFileTransform : public OiiotoolOp {
 public:
-    OpOcioFileTransform (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) { }
-    virtual void option_defaults () {
-        options["unpremult"] = "0";
+    OpOcioFileTransform(Oiiotool& ot, string_view opname, int argc,
+                        const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
     }
-    virtual int impl (ImageBuf **img) {
+    virtual void option_defaults() { options["unpremult"] = "0"; }
+    virtual int impl(ImageBuf** img)
+    {
         string_view name = args[1];
-        bool inverse = Strutil::from_string<int> (options["inverse"]);
-        bool unpremult = Strutil::from_string<int>(options["unpremult"]);
-        return ImageBufAlgo::ociofiletransform (*img[0], *img[1], name,
-                                                inverse, unpremult, &ot.colorconfig);
+        bool inverse     = Strutil::from_string<int>(options["inverse"]);
+        bool unpremult   = Strutil::from_string<int>(options["unpremult"]);
+        return ImageBufAlgo::ociofiletransform(*img[0], *img[1], name, inverse,
+                                               unpremult, &ot.colorconfig);
     }
 };
 
-OP_CUSTOMCLASS (ociofiletransform, OpOcioFileTransform, 1);
+OP_CUSTOMCLASS(ociofiletransform, OpOcioFileTransform, 1);
 
 
 
 static int
-output_tiles (int /*argc*/, const char *argv[])
+output_tiles(int /*argc*/, const char* argv[])
 {
     // the ArgParse will have set the tile size, but we need this routine
     // to clear the scanline flag
@@ -1951,22 +2003,22 @@ output_tiles (int /*argc*/, const char *argv[])
 
 
 static int
-action_unmip (int argc, const char *argv[])
+action_unmip(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_unmip, argc, argv))
+    if (ot.postpone_callback(1, action_unmip, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
 
-    ot.read ();
+    ot.read();
     bool mipmapped = false;
-    for (int s = 0, send = ot.curimg->subimages();  s < send;  ++s)
+    for (int s = 0, send = ot.curimg->subimages(); s < send; ++s)
         mipmapped |= (ot.curimg->miplevels(s) > 1);
-    if (! mipmapped) {
-        return 0;    // --unmip on an unmipped image is a no-op
+    if (!mipmapped) {
+        return 0;  // --unmip on an unmipped image is a no-op
     }
 
-    ImageRecRef newimg (new ImageRec (*ot.curimg, -1, 0, true, true));
+    ImageRecRef newimg(new ImageRec(*ot.curimg, -1, 0, true, true));
     ot.curimg = newimg;
     ot.function_times[command] += timer();
     return 0;
@@ -1975,44 +2027,45 @@ action_unmip (int argc, const char *argv[])
 
 
 static int
-set_channelnames (int argc, const char *argv[])
+set_channelnames(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, set_channelnames, argc, argv))
+    if (ot.postpone_callback(1, set_channelnames, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command    = ot.express (argv[0]);
-    string_view channelarg = ot.express (argv[1]);
+    Timer timer(ot.enable_function_timing);
+    string_view command    = ot.express(argv[0]);
+    string_view channelarg = ot.express(argv[1]);
 
     ImageRecRef A = ot.curimg;
-    ot.read (A);
+    ot.read(A);
 
     std::vector<std::string> newchannelnames;
-    Strutil::split (channelarg, newchannelnames, ",");
+    Strutil::split(channelarg, newchannelnames, ",");
 
     for (int s = 0; s < A->subimages(); ++s) {
         int miplevels = A->miplevels(s);
-        for (int m = 0;  m < miplevels;  ++m) {
-            ImageSpec *spec = &(*A)(s,m).specmod();
-            spec->channelnames.resize (spec->nchannels);
-            for (int c = 0; c < spec->nchannels;  ++c) {
-                if (c < (int)newchannelnames.size() &&
-                      newchannelnames[c].size()) {
+        for (int m = 0; m < miplevels; ++m) {
+            ImageSpec* spec = &(*A)(s, m).specmod();
+            spec->channelnames.resize(spec->nchannels);
+            for (int c = 0; c < spec->nchannels; ++c) {
+                if (c < (int)newchannelnames.size()
+                    && newchannelnames[c].size()) {
                     std::string name = newchannelnames[c];
-                    ot.output_channelformats[name] = ot.output_channelformats[spec->channelnames[c]];
+                    ot.output_channelformats[name]
+                        = ot.output_channelformats[spec->channelnames[c]];
                     spec->channelnames[c] = name;
-                    if (Strutil::iequals(name,"A") ||
-                        Strutil::iends_with(name,".A") ||
-                        Strutil::iequals(name,"Alpha") ||
-                        Strutil::iends_with(name,".Alpha"))
+                    if (Strutil::iequals(name, "A")
+                        || Strutil::iends_with(name, ".A")
+                        || Strutil::iequals(name, "Alpha")
+                        || Strutil::iends_with(name, ".Alpha"))
                         spec->alpha_channel = c;
-                    if (Strutil::iequals(name,"Z") ||
-                        Strutil::iends_with(name,".Z") ||
-                        Strutil::iequals(name,"Depth") ||
-                        Strutil::iends_with(name,".Depth"))
+                    if (Strutil::iequals(name, "Z")
+                        || Strutil::iends_with(name, ".Z")
+                        || Strutil::iequals(name, "Depth")
+                        || Strutil::iends_with(name, ".Depth"))
                         spec->z_channel = c;
                 }
             }
-           A->update_spec_from_imagebuf(s,m);
+            A->update_spec_from_imagebuf(s, m);
         }
     }
     ot.function_times[command] += timer();
@@ -2035,12 +2088,13 @@ set_channelnames (int argc, const char *argv[])
 // newchannelnames will be the name of renamed or non-default-named
 // channels (defaulting to "" if no special name is needed).
 bool
-OiioTool::decode_channel_set (const ImageSpec &spec, string_view chanlist,
-                    std::vector<std::string> &newchannelnames,
-                    std::vector<int> &channels, std::vector<float> &values)
+OiioTool::decode_channel_set(const ImageSpec& spec, string_view chanlist,
+                             std::vector<std::string>& newchannelnames,
+                             std::vector<int>& channels,
+                             std::vector<float>& values)
 {
     // std::cout << "Decode_channel_set '" << chanlist << "'\n";
-    channels.clear ();
+    channels.clear();
     for (int c = 0; chanlist.length(); ++c) {
         // It looks like:
         //     <int>                (put old channel here, by numeric index)
@@ -2049,43 +2103,44 @@ OiioTool::decode_channel_set (const ImageSpec &spec, string_view chanlist,
         //     newname=<float>      (put constant value here, with a name)
         //     =<float>             (put constant value here, default name)
         std::string newname;
-        int chan = -1;
+        int chan  = -1;
         float val = 0.0f;
-        Strutil::skip_whitespace (chanlist);
+        Strutil::skip_whitespace(chanlist);
         if (chanlist.empty())
             break;
-        if (Strutil::parse_int (chanlist, chan) && chan >= 0
-                                                && chan < spec.nchannels) {
+        if (Strutil::parse_int(chanlist, chan) && chan >= 0
+            && chan < spec.nchannels) {
             // case: <int>
             newname = spec.channelnames[chan];
-        } else if (Strutil::parse_char (chanlist, '=')) {
+        } else if (Strutil::parse_char(chanlist, '=')) {
             // case: =<float>
-            Strutil::parse_float (chanlist, val);
+            Strutil::parse_float(chanlist, val);
         } else {
-            string_view n = Strutil::parse_until (chanlist, "=,");
+            string_view n = Strutil::parse_until(chanlist, "=,");
             string_view oldname;
-            if (Strutil::parse_char (chanlist, '=')) {
-                if (Strutil::parse_float (chanlist, val)) {
+            if (Strutil::parse_char(chanlist, '=')) {
+                if (Strutil::parse_float(chanlist, val)) {
                     // case: newname=float
                     newname = n;
                 } else {
                     // case: newname=oldname
                     newname = n;
-                    oldname = Strutil::parse_until (chanlist, ",");
+                    oldname = Strutil::parse_until(chanlist, ",");
                 }
             } else {
                 // case: oldname
                 oldname = n;
             }
             if (oldname.size()) {
-                for (int i = 0;  i < spec.nchannels;  ++i)
-                    if (spec.channelnames[i] == oldname) { // name of a known channel?
+                for (int i = 0; i < spec.nchannels; ++i)
+                    if (spec.channelnames[i]
+                        == oldname) {  // name of a known channel?
                         chan = i;
                         break;
                     }
-                if (chan < 0) { // Didn't find a match? Try case-insensitive.
-                    for (int i = 0;  i < spec.nchannels;  ++i)
-                        if (Strutil::iequals (spec.channelnames[i], oldname)) {
+                if (chan < 0) {  // Didn't find a match? Try case-insensitive.
+                    for (int i = 0; i < spec.nchannels; ++i)
+                        if (Strutil::iequals(spec.channelnames[i], oldname)) {
                             chan = i;
                             break;
                         }
@@ -2095,20 +2150,20 @@ OiioTool::decode_channel_set (const ImageSpec &spec, string_view chanlist,
             }
         }
 
-        if (! newname.size()) {
-            const char *RGBAZ[] = { "R", "G", "B", "A", "Z" };
+        if (!newname.size()) {
+            const char* RGBAZ[] = { "R", "G", "B", "A", "Z" };
             if (c <= 4)
                 newname = std::string(RGBAZ[c]);
             else
-                newname = Strutil::format ("channel%d", c);
+                newname = Strutil::format("channel%d", c);
         }
 
         // std::cout << "  Chan " << c << ": " << newname << ' ' << chan << ' ' << val << "\n";
-        newchannelnames.push_back (newname);
-        channels.push_back (chan);
-        values.push_back (val);
+        newchannelnames.push_back(newname);
+        channels.push_back(chan);
+        values.push_back(val);
 
-        if (! Strutil::parse_char (chanlist, ','))
+        if (!Strutil::parse_char(chanlist, ','))
             break;
     }
     return true;
@@ -2117,18 +2172,18 @@ OiioTool::decode_channel_set (const ImageSpec &spec, string_view chanlist,
 
 
 int
-action_channels (int argc, const char *argv[])
+action_channels(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_channels, argc, argv))
+    if (ot.postpone_callback(1, action_channels, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command  = ot.express (argv[0]);
-    string_view chanlist = ot.express (argv[1]);
+    Timer timer(ot.enable_function_timing);
+    string_view command  = ot.express(argv[0]);
+    string_view chanlist = ot.express(argv[1]);
 
-    ImageRecRef A (ot.pop());
-    ot.read (A);
+    ImageRecRef A(ot.pop());
+    ot.read(A);
 
-    if (chanlist == "RGB")   // Fix common synonyms/mistakes
+    if (chanlist == "RGB")  // Fix common synonyms/mistakes
         chanlist = "R,G,B";
     else if (chanlist == "RGBA")
         chanlist = "R,G,B,A";
@@ -2138,51 +2193,54 @@ action_channels (int argc, const char *argv[])
     std::vector<int> allmiplevels;
     std::vector<ImageSpec> allspecs;
     for (int s = 0, subimages = ot.allsubimages ? A->subimages() : 1;
-         s < subimages;  ++s) {
+         s < subimages; ++s) {
         std::vector<std::string> newchannelnames;
         std::vector<int> channels;
         std::vector<float> values;
-        bool ok = decode_channel_set (*A->spec(s,0), chanlist,
-                                      newchannelnames, channels, values);
-        if (! ok) {
-            ot.error (command, Strutil::format("Invalid or unknown channel selection \"%s\"", chanlist));
-            ot.push (A);
+        bool ok = decode_channel_set(*A->spec(s, 0), chanlist, newchannelnames,
+                                     channels, values);
+        if (!ok) {
+            ot.error(command, Strutil::format(
+                                  "Invalid or unknown channel selection \"%s\"",
+                                  chanlist));
+            ot.push(A);
             return 0;
         }
         int miplevels = ot.allsubimages ? A->miplevels(s) : 1;
-        allmiplevels.push_back (miplevels);
-        for (int m = 0;  m < miplevels;  ++m) {
-            ImageSpec spec = *A->spec(s,m);
+        allmiplevels.push_back(miplevels);
+        for (int m = 0; m < miplevels; ++m) {
+            ImageSpec spec = *A->spec(s, m);
             spec.nchannels = (int)newchannelnames.size();
             spec.channelformats.clear();
-            spec.default_channel_names ();
-            allspecs.push_back (spec);
+            spec.default_channel_names();
+            allspecs.push_back(spec);
         }
     }
 
     // Create the replacement ImageRec
-    ImageRecRef R (new ImageRec(A->name(), (int)allmiplevels.size(),
-                                &allmiplevels[0], &allspecs[0]));
-    ot.push (R);
+    ImageRecRef R(new ImageRec(A->name(), (int)allmiplevels.size(),
+                               &allmiplevels[0], &allspecs[0]));
+    ot.push(R);
 
     // Subimage by subimage, MIP level by MIP level, copy/shuffle the
     // channels individually from the source image into the result.
-    for (int s = 0, subimages = R->subimages();  s < subimages;  ++s) {
+    for (int s = 0, subimages = R->subimages(); s < subimages; ++s) {
         std::vector<std::string> newchannelnames;
         std::vector<int> channels;
         std::vector<float> values;
-        decode_channel_set (*A->spec(s,0), chanlist, newchannelnames,
-                            channels, values);
-        for (int m = 0, miplevels = R->miplevels(s);  m < miplevels;  ++m) {
+        decode_channel_set(*A->spec(s, 0), chanlist, newchannelnames, channels,
+                           values);
+        for (int m = 0, miplevels = R->miplevels(s); m < miplevels; ++m) {
             // Shuffle the indexed/named channels
-            bool ok = ImageBufAlgo::channels ((*R)(s,m), (*A)(s,m),
-                                      (int)channels.size(), &channels[0],
-                                      &values[0], &newchannelnames[0], false);
-            if (! ok)
-                ot.error (command, (*R)(s,m).geterror());
+            bool ok = ImageBufAlgo::channels((*R)(s, m), (*A)(s, m),
+                                             (int)channels.size(), &channels[0],
+                                             &values[0], &newchannelnames[0],
+                                             false);
+            if (!ok)
+                ot.error(command, (*R)(s, m).geterror());
             // Tricky subtlety: IBA::channels changed the underlying IB,
             // we may need to update the IR's copy of the spec.
-            R->update_spec_from_imagebuf(s,m);
+            R->update_spec_from_imagebuf(s, m);
         }
     }
 
@@ -2193,41 +2251,42 @@ action_channels (int argc, const char *argv[])
 
 
 static int
-action_chappend (int argc, const char *argv[])
+action_chappend(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (2, action_chappend, argc, argv))
+    if (ot.postpone_callback(2, action_chappend, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command  = ot.express (argv[0]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
 
-    ImageRecRef B (ot.pop());
-    ImageRecRef A (ot.pop());
-    ot.read (A);
-    ot.read (B);
+    ImageRecRef B(ot.pop());
+    ImageRecRef A(ot.pop());
+    ot.read(A);
+    ot.read(B);
 
     std::vector<int> allmiplevels;
     for (int s = 0, subimages = ot.allsubimages ? A->subimages() : 1;
-         s < subimages;  ++s) {
+         s < subimages; ++s) {
         int miplevels = ot.allsubimages ? A->miplevels(s) : 1;
-        allmiplevels.push_back (miplevels);
+        allmiplevels.push_back(miplevels);
     }
 
     // Create the replacement ImageRec
-    ImageRecRef R (new ImageRec(A->name(), (int)allmiplevels.size(),
-                                &allmiplevels[0]));
-    ot.push (R);
+    ImageRecRef R(
+        new ImageRec(A->name(), (int)allmiplevels.size(), &allmiplevels[0]));
+    ot.push(R);
 
     // Subimage by subimage, MIP level by MIP level, channel_append the
     // two images.
-    for (int s = 0, subimages = R->subimages();  s < subimages;  ++s) {
-        for (int m = 0, miplevels = R->miplevels(s);  m < miplevels;  ++m) {
+    for (int s = 0, subimages = R->subimages(); s < subimages; ++s) {
+        for (int m = 0, miplevels = R->miplevels(s); m < miplevels; ++m) {
             // Shuffle the indexed/named channels
-            bool ok = ImageBufAlgo::channel_append ((*R)(s,m), (*A)(s,m), (*B)(s,m));
-            if (! ok)
-                ot.error (command, (*R)(s,m).geterror());
+            bool ok = ImageBufAlgo::channel_append((*R)(s, m), (*A)(s, m),
+                                                   (*B)(s, m));
+            if (!ok)
+                ot.error(command, (*R)(s, m).geterror());
             // Tricky subtlety: IBA::channels changed the underlying IB,
             // we may need to update the IRR's copy of the spec.
-            R->update_spec_from_imagebuf(s,m);
+            R->update_spec_from_imagebuf(s, m);
         }
     }
     ot.function_times[command] += timer();
@@ -2237,23 +2296,23 @@ action_chappend (int argc, const char *argv[])
 
 
 static int
-action_selectmip (int argc, const char *argv[])
+action_selectmip(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_selectmip, argc, argv))
+    if (ot.postpone_callback(1, action_selectmip, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
-    int miplevel = Strutil::from_string<int> (ot.express(argv[1]));
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
+    int miplevel        = Strutil::from_string<int>(ot.express(argv[1]));
 
-    ot.read ();
+    ot.read();
     bool mipmapped = false;
-    for (int s = 0, send = ot.curimg->subimages();  s < send;  ++s)
+    for (int s = 0, send = ot.curimg->subimages(); s < send; ++s)
         mipmapped |= (ot.curimg->miplevels(s) > 1);
-    if (! mipmapped) {
-        return 0;    // --selectmip on an unmipped image is a no-op
+    if (!mipmapped) {
+        return 0;  // --selectmip on an unmipped image is a no-op
     }
 
-    ImageRecRef newimg (new ImageRec (*ot.curimg, -1, miplevel, true, true));
+    ImageRecRef newimg(new ImageRec(*ot.curimg, -1, miplevel, true, true));
     ot.curimg = newimg;
     ot.function_times[command] += timer();
     return 0;
@@ -2262,49 +2321,52 @@ action_selectmip (int argc, const char *argv[])
 
 
 static int
-action_select_subimage (int argc, const char *argv[])
+action_select_subimage(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_select_subimage, argc, argv))
+    if (ot.postpone_callback(1, action_select_subimage, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    ot.read ();
+    Timer timer(ot.enable_function_timing);
+    ot.read();
 
-    string_view command = ot.express (argv[0]);
-    int subimage = 0;
+    string_view command       = ot.express(argv[0]);
+    int subimage              = 0;
     std::string whichsubimage = ot.express(argv[1]);
-    string_view w (whichsubimage);
-    if (Strutil::parse_int (w, subimage) && w.empty()) {
+    string_view w(whichsubimage);
+    if (Strutil::parse_int(w, subimage) && w.empty()) {
         // Subimage specification was an integer: treat as an index
         if (subimage < 0 || subimage >= ot.curimg->subimages()) {
-            ot.error (command,
-                     Strutil::format ("Invalid -subimage (%d): %s has %d subimage%s",
-                                      subimage, ot.curimg->name(), ot.curimg->subimages(),
-                                      ot.curimg->subimages() == 1 ? "" : "s"));
+            ot.error(command,
+                     Strutil::format(
+                         "Invalid -subimage (%d): %s has %d subimage%s",
+                         subimage, ot.curimg->name(), ot.curimg->subimages(),
+                         ot.curimg->subimages() == 1 ? "" : "s"));
             return 0;
         }
     } else {
         // The subimage specification wasn't an integer. Assume it's a name.
         subimage = -1;
         for (int i = 0, n = ot.curimg->subimages(); i < n; ++i) {
-            string_view siname = ot.curimg->spec(i)->get_string_attribute("oiio:subimagename");
+            string_view siname = ot.curimg->spec(i)->get_string_attribute(
+                "oiio:subimagename");
             if (siname == whichsubimage) {
                 subimage = i;
                 break;
             }
         }
         if (subimage < 0) {
-            ot.error (command,
-                     Strutil::format ("Invalid -subimage (%s): named subimage not found",
-                                      whichsubimage));
+            ot.error(command,
+                     Strutil::format(
+                         "Invalid -subimage (%s): named subimage not found",
+                         whichsubimage));
             return 0;
         }
     }
 
     if (ot.curimg->subimages() == 1 && subimage == 0)
-        return 0;    // asking for the only subimage is a no-op
-    
+        return 0;  // asking for the only subimage is a no-op
+
     ImageRecRef A = ot.pop();
-    ot.push (new ImageRec (*A, subimage));
+    ot.push(new ImageRec(*A, subimage));
     ot.function_times[command] += timer();
     return 0;
 }
@@ -2312,19 +2374,19 @@ action_select_subimage (int argc, const char *argv[])
 
 
 static int
-action_subimage_split (int argc, const char *argv[])
+action_subimage_split(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_subimage_split, argc, argv))
+    if (ot.postpone_callback(1, action_subimage_split, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
 
     ImageRecRef A = ot.pop();
-    ot.read (A);
+    ot.read(A);
 
     // Push the individual subimages onto the stack
-    for (int subimage = 0;  subimage <  A->subimages();  ++subimage)
-        ot.push (new ImageRec (*A, subimage));
+    for (int subimage = 0; subimage < A->subimages(); ++subimage)
+        ot.push(new ImageRec(*A, subimage));
 
     ot.function_times[command] += timer();
     return 0;
@@ -2333,46 +2395,46 @@ action_subimage_split (int argc, const char *argv[])
 
 
 static void
-action_subimage_append_n (int n, string_view command)
+action_subimage_append_n(int n, string_view command)
 {
-    std::vector<ImageRecRef> images (n);
-    for (int i = n-1; i >= 0; --i) {
+    std::vector<ImageRecRef> images(n);
+    for (int i = n - 1; i >= 0; --i) {
         images[i] = ot.pop();
-        ot.read (images[i]);   // necessary?
+        ot.read(images[i]);  // necessary?
     }
 
     // Find the MIP levels in all the subimages of both A and B
     std::vector<int> allmiplevels;
     for (int i = 0; i < n; ++i) {
         ImageRecRef A = images[i];
-        for (int s = 0;  s < A->subimages();  ++s) {
+        for (int s = 0; s < A->subimages(); ++s) {
             int miplevels = ot.allsubimages ? A->miplevels(s) : 1;
-            allmiplevels.push_back (miplevels);
+            allmiplevels.push_back(miplevels);
         }
     }
 
     // Create the replacement ImageRec
-    ImageRecRef R (new ImageRec(images[0]->name(), (int)allmiplevels.size(),
-                                &allmiplevels[0]));
-    ot.push (R);
+    ImageRecRef R(new ImageRec(images[0]->name(), (int)allmiplevels.size(),
+                               &allmiplevels[0]));
+    ot.push(R);
 
     // Subimage by subimage, MIP level by MIP level, copy
     int sub = 0;
     for (int i = 0; i < n; ++i) {
         ImageRecRef A = images[i];
-        for (int s = 0;  s <  A->subimages();  ++s, ++sub) {
-            for (int m = 0;  m < A->miplevels(s);  ++m) {
-                bool ok = (*R)(sub,m).copy ((*A)(s,m));
-                if (! ok)
-                    ot.error (command, (*R)(sub,m).geterror());
+        for (int s = 0; s < A->subimages(); ++s, ++sub) {
+            for (int m = 0; m < A->miplevels(s); ++m) {
+                bool ok = (*R)(sub, m).copy((*A)(s, m));
+                if (!ok)
+                    ot.error(command, (*R)(sub, m).geterror());
                 // Update the IR's copy of the spec.
-                R->update_spec_from_imagebuf(sub,m);
+                R->update_spec_from_imagebuf(sub, m);
             }
             // For subimage append, preserve the notion of whether the
             // format is exactly as read from disk -- this is one of the few
             // operations for which it's true, since we are just appending
             // subimage, not modifying data or data format.
-            (*R)[sub].was_direct_read ((*A)[s].was_direct_read());
+            (*R)[sub].was_direct_read((*A)[s].was_direct_read());
         }
     }
 }
@@ -2380,14 +2442,14 @@ action_subimage_append_n (int n, string_view command)
 
 
 static int
-action_subimage_append (int argc, const char *argv[])
+action_subimage_append(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (2, action_subimage_append, argc, argv))
+    if (ot.postpone_callback(2, action_subimage_append, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
 
-    action_subimage_append_n (2, command);
+    action_subimage_append_n(2, command);
 
     ot.function_times[command] += timer();
     return 0;
@@ -2396,14 +2458,14 @@ action_subimage_append (int argc, const char *argv[])
 
 
 static int
-action_subimage_append_all (int argc, const char *argv[])
+action_subimage_append_all(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_subimage_append_all, argc, argv))
+    if (ot.postpone_callback(1, action_subimage_append_all, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
 
-    action_subimage_append_n (int(ot.image_stack.size()+1), command);
+    action_subimage_append_n(int(ot.image_stack.size() + 1), command);
 
     ot.function_times[command] += timer();
     return 0;
@@ -2412,16 +2474,16 @@ action_subimage_append_all (int argc, const char *argv[])
 
 
 static int
-action_colorcount (int argc, const char *argv[])
+action_colorcount(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_colorcount, argc, argv))
+    if (ot.postpone_callback(1, action_colorcount, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command  = ot.express (argv[0]);
-    string_view colorarg = ot.express (argv[1]);
+    Timer timer(ot.enable_function_timing);
+    string_view command  = ot.express(argv[0]);
+    string_view colorarg = ot.express(argv[1]);
 
-    ot.read ();
-    ImageBuf &Aib ((*ot.curimg)(0,0));
+    ot.read();
+    ImageBuf& Aib((*ot.curimg)(0, 0));
     int nchannels = Aib.nchannels();
 
     // We assume ';' to split, but for the sake of some command shells,
@@ -2429,30 +2491,31 @@ action_colorcount (int argc, const char *argv[])
     std::vector<float> colorvalues;
     std::vector<std::string> colorstrings;
     if (colorarg.find(':') != colorarg.npos)
-        Strutil::split (colorarg, colorstrings, ":");
+        Strutil::split(colorarg, colorstrings, ":");
     else
-        Strutil::split (colorarg, colorstrings, ";");
-    int ncolors = (int) colorstrings.size();
+        Strutil::split(colorarg, colorstrings, ";");
+    int ncolors = (int)colorstrings.size();
     for (int col = 0; col < ncolors; ++col) {
-        std::vector<float> color (nchannels, 0.0f);
-        Strutil::extract_from_list_string (color, colorstrings[col], ",");
-        for (int c = 0;  c < nchannels;  ++c)
-            colorvalues.push_back (c < (int)color.size() ? color[c] : 0.0f);
+        std::vector<float> color(nchannels, 0.0f);
+        Strutil::extract_from_list_string(color, colorstrings[col], ",");
+        for (int c = 0; c < nchannels; ++c)
+            colorvalues.push_back(c < (int)color.size() ? color[c] : 0.0f);
     }
 
-    std::vector<float> eps (nchannels, 0.001f);
-    std::map<std::string,std::string> options;
-    ot.extract_options (options, command);
-    Strutil::extract_from_list_string (eps, options["eps"]);
+    std::vector<float> eps(nchannels, 0.001f);
+    std::map<std::string, std::string> options;
+    ot.extract_options(options, command);
+    Strutil::extract_from_list_string(eps, options["eps"]);
 
-    imagesize_t *count = ALLOCA (imagesize_t, ncolors);
-    bool ok = ImageBufAlgo::color_count ((*ot.curimg)(0,0), count,
-                                         ncolors, &colorvalues[0], &eps[0]);
+    imagesize_t* count = ALLOCA(imagesize_t, ncolors);
+    bool ok = ImageBufAlgo::color_count((*ot.curimg)(0, 0), count, ncolors,
+                                        &colorvalues[0], &eps[0]);
     if (ok) {
-        for (int col = 0;  col < ncolors;  ++col)
-            std::cout << Strutil::format("%8d  %s\n", count[col], colorstrings[col]);
+        for (int col = 0; col < ncolors; ++col)
+            std::cout << Strutil::format("%8d  %s\n", count[col],
+                                         colorstrings[col]);
     } else {
-        ot.error (command, (*ot.curimg)(0,0).geterror());
+        ot.error(command, (*ot.curimg)(0, 0).geterror());
     }
 
     ot.function_times[command] += timer();
@@ -2462,33 +2525,33 @@ action_colorcount (int argc, const char *argv[])
 
 
 static int
-action_rangecheck (int argc, const char *argv[])
+action_rangecheck(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_rangecheck, argc, argv))
+    if (ot.postpone_callback(1, action_rangecheck, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command  = ot.express (argv[0]);
-    string_view lowarg   = ot.express (argv[1]);
-    string_view higharg  = ot.express (argv[2]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
+    string_view lowarg  = ot.express(argv[1]);
+    string_view higharg = ot.express(argv[2]);
 
-    ot.read ();
-    ImageBuf &Aib ((*ot.curimg)(0,0));
+    ot.read();
+    ImageBuf& Aib((*ot.curimg)(0, 0));
     int nchannels = Aib.nchannels();
 
-    std::vector<float> low(nchannels,0.0f), high(nchannels,1.0f);
-    Strutil::extract_from_list_string (low, lowarg, ",");
-    Strutil::extract_from_list_string (high, higharg, ",");
+    std::vector<float> low(nchannels, 0.0f), high(nchannels, 1.0f);
+    Strutil::extract_from_list_string(low, lowarg, ",");
+    Strutil::extract_from_list_string(high, higharg, ",");
 
     imagesize_t lowcount = 0, highcount = 0, inrangecount = 0;
-    bool ok = ImageBufAlgo::color_range_check ((*ot.curimg)(0,0), &lowcount,
-                                               &highcount, &inrangecount,
-                                               &low[0], &high[0]);
+    bool ok = ImageBufAlgo::color_range_check((*ot.curimg)(0, 0), &lowcount,
+                                              &highcount, &inrangecount,
+                                              &low[0], &high[0]);
     if (ok) {
         std::cout << Strutil::format("%8d  < %s\n", lowcount, lowarg);
         std::cout << Strutil::format("%8d  > %s\n", highcount, higharg);
         std::cout << Strutil::format("%8d  within range\n", inrangecount);
     } else {
-        ot.error (command, (*ot.curimg)(0,0).geterror());
+        ot.error(command, (*ot.curimg)(0, 0).geterror());
     }
 
     ot.function_times[command] += timer();
@@ -2498,21 +2561,21 @@ action_rangecheck (int argc, const char *argv[])
 
 
 static int
-action_diff (int argc, const char *argv[])
+action_diff(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (2, action_diff, argc, argv))
+    if (ot.postpone_callback(2, action_diff, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
 
-    int ret = do_action_diff (*ot.image_stack.back(), *ot.curimg, ot);
+    int ret = do_action_diff(*ot.image_stack.back(), *ot.curimg, ot);
     if (ret != DiffErrOK && ret != DiffErrWarn)
         ot.return_value = EXIT_FAILURE;
 
     if (ret != DiffErrOK && ret != DiffErrWarn && ret != DiffErrFail)
-        ot.error (command);
+        ot.error(command);
 
-    ot.printed_info = true; // because taking the diff has output
+    ot.printed_info = true;  // because taking the diff has output
     ot.function_times[command] += timer();
     return 0;
 }
@@ -2520,19 +2583,19 @@ action_diff (int argc, const char *argv[])
 
 
 static int
-action_pdiff (int argc, const char *argv[])
+action_pdiff(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (2, action_pdiff, argc, argv))
+    if (ot.postpone_callback(2, action_pdiff, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
 
-    int ret = do_action_diff (*ot.image_stack.back(), *ot.curimg, ot, 1);
+    int ret = do_action_diff(*ot.image_stack.back(), *ot.curimg, ot, 1);
     if (ret != DiffErrOK && ret != DiffErrWarn)
         ot.return_value = EXIT_FAILURE;
 
     if (ret != DiffErrOK && ret != DiffErrWarn && ret != DiffErrFail)
-        ot.error (command);
+        ot.error(command);
 
     ot.function_times[command] += timer();
     return 0;
@@ -2540,152 +2603,170 @@ action_pdiff (int argc, const char *argv[])
 
 
 
-BINARY_IMAGE2_OP (add, ImageBufAlgo::add);
-BINARY_IMAGE2_OP (sub, ImageBufAlgo::sub);
-BINARY_IMAGE2_OP (mul, ImageBufAlgo::mul);
-BINARY_IMAGE2_OP (div, ImageBufAlgo::div);
-BINARY_IMAGE2_OP (absdiff, ImageBufAlgo::absdiff);
+BINARY_IMAGE2_OP(add, ImageBufAlgo::add);
+BINARY_IMAGE2_OP(sub, ImageBufAlgo::sub);
+BINARY_IMAGE2_OP(mul, ImageBufAlgo::mul);
+BINARY_IMAGE2_OP(div, ImageBufAlgo::div);
+BINARY_IMAGE2_OP(absdiff, ImageBufAlgo::absdiff);
 
-BINARY_IMAGE_COLOR_OP (addc, ImageBufAlgo::add, 0);
-BINARY_IMAGE_COLOR_OP (subc, ImageBufAlgo::sub, 0);
-BINARY_IMAGE_COLOR_OP (mulc, ImageBufAlgo::mul, 1);
-BINARY_IMAGE_COLOR_OP (divc, ImageBufAlgo::div, 1);
-BINARY_IMAGE_COLOR_OP (absdiffc, ImageBufAlgo::absdiff, 0);
-BINARY_IMAGE_COLOR_OP (powc, ImageBufAlgo::pow, 1.0f);
+BINARY_IMAGE_COLOR_OP(addc, ImageBufAlgo::add, 0);
+BINARY_IMAGE_COLOR_OP(subc, ImageBufAlgo::sub, 0);
+BINARY_IMAGE_COLOR_OP(mulc, ImageBufAlgo::mul, 1);
+BINARY_IMAGE_COLOR_OP(divc, ImageBufAlgo::div, 1);
+BINARY_IMAGE_COLOR_OP(absdiffc, ImageBufAlgo::absdiff, 0);
+BINARY_IMAGE_COLOR_OP(powc, ImageBufAlgo::pow, 1.0f);
 
-UNARY_IMAGE_OP (abs, ImageBufAlgo::abs);
+UNARY_IMAGE_OP(abs, ImageBufAlgo::abs);
 
 
 
 class OpPremult : public OiiotoolOp {
 public:
-    OpPremult (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) {}
-    virtual int impl (ImageBuf **img) {
-        return ImageBufAlgo::premult (*img[0], *img[1]);
+    OpPremult(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
+        return ImageBufAlgo::premult(*img[0], *img[1]);
     }
 };
-OP_CUSTOMCLASS (premult, OpPremult, 1);
+OP_CUSTOMCLASS(premult, OpPremult, 1);
 
 
 
 class OpUnpremult : public OiiotoolOp {
 public:
-    OpUnpremult (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) {}
-    virtual int impl (ImageBuf **img) {
-        if (img[1]->spec().get_int_attribute("oiio:UnassociatedAlpha") && img[1]->spec().alpha_channel >= 0) {
-            ot.warning (opname(), "Image appears to already be unassociated alpha (un-premultiplied color), beware double unpremult.");
+    OpUnpremult(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
+        if (img[1]->spec().get_int_attribute("oiio:UnassociatedAlpha")
+            && img[1]->spec().alpha_channel >= 0) {
+            ot.warning(
+                opname(),
+                "Image appears to already be unassociated alpha (un-premultiplied color), beware double unpremult.");
         }
-        return ImageBufAlgo::unpremult (*img[0], *img[1]);
+        return ImageBufAlgo::unpremult(*img[0], *img[1]);
     }
 };
-OP_CUSTOMCLASS (unpremult, OpUnpremult, 1);
-
+OP_CUSTOMCLASS(unpremult, OpUnpremult, 1);
 
 
 
 class OpMad : public OiiotoolOp {
 public:
-    OpMad (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 3) {}
-    virtual int impl (ImageBuf **img) {
-        return ImageBufAlgo::mad (*img[0], *img[1], *img[2], *img[3]);
+    OpMad(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 3)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
+        return ImageBufAlgo::mad(*img[0], *img[1], *img[2], *img[3]);
     }
 };
 
-OP_CUSTOMCLASS (mad, OpMad, 3);
+OP_CUSTOMCLASS(mad, OpMad, 3);
 
 
 
 class OpInvert : public OiiotoolOp {
 public:
-    OpInvert (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) {}
-    virtual int impl (ImageBuf **img) {
+    OpInvert(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
         // invert the first three channels only, spare alpha
-        ROI roi = img[1]->roi();
-        roi.chend = std::min (3, roi.chend);
-        return ImageBufAlgo::invert (*img[0], *img[1], roi, 0);
+        ROI roi   = img[1]->roi();
+        roi.chend = std::min(3, roi.chend);
+        return ImageBufAlgo::invert(*img[0], *img[1], roi, 0);
     }
 };
 
-OP_CUSTOMCLASS (invert, OpInvert, 1);
-
+OP_CUSTOMCLASS(invert, OpInvert, 1);
 
 
 
 class OpNoise : public OiiotoolOp {
 public:
-    OpNoise (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) { }
-    virtual void option_defaults () {
-        options["type"] = "gaussian";
-        options["min"] = "0";
-        options["max"] = "0.1";
-        options["mean"] = "0";
-        options["stddev"] = "0.1";
-        options["portion"] = "0.01";
-        options["value"] = "0";
-        options["mono"] = "0";
-        options["seed"] = "0";
+    OpNoise(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual void option_defaults()
+    {
+        options["type"]      = "gaussian";
+        options["min"]       = "0";
+        options["max"]       = "0.1";
+        options["mean"]      = "0";
+        options["stddev"]    = "0.1";
+        options["portion"]   = "0.01";
+        options["value"]     = "0";
+        options["mono"]      = "0";
+        options["seed"]      = "0";
         options["nchannels"] = "10000";
     }
-    virtual int impl (ImageBuf **img) {
-        img[0]->copy (*img[1]);
-        string_view type (options["type"]);
+    virtual int impl(ImageBuf** img)
+    {
+        img[0]->copy(*img[1]);
+        string_view type(options["type"]);
         float A = 0.0f, B = 0.1f;
         if (type == "gaussian") {
-            A = Strutil::from_string<float> (options["mean"]);
-            B = Strutil::from_string<float> (options["stddev"]);
+            A = Strutil::from_string<float>(options["mean"]);
+            B = Strutil::from_string<float>(options["stddev"]);
         } else if (type == "uniform") {
-            A = Strutil::from_string<float> (options["min"]);
-            B = Strutil::from_string<float> (options["max"]);
+            A = Strutil::from_string<float>(options["min"]);
+            B = Strutil::from_string<float>(options["max"]);
         } else if (type == "salt") {
-            A = Strutil::from_string<float> (options["value"]);
-            B = Strutil::from_string<float> (options["portion"]);
+            A = Strutil::from_string<float>(options["value"]);
+            B = Strutil::from_string<float>(options["portion"]);
         } else {
-            ot.error (opname(), Strutil::format ("Unknown noise type \"%s\"", type));
+            ot.error(opname(),
+                     Strutil::format("Unknown noise type \"%s\"", type));
             return 0;
         }
-        bool mono = Strutil::from_string<int> (options["mono"]);
-        int seed = Strutil::from_string<int> (options["seed"]);
-        int nchannels = Strutil::from_string<int> (options["nchannels"]);
-        ROI roi = img[0]->roi();
-        roi.chend = std::min (roi.chend, nchannels);
-        return ImageBufAlgo::noise (*img[0], type, A, B, mono, seed, roi);
+        bool mono     = Strutil::from_string<int>(options["mono"]);
+        int seed      = Strutil::from_string<int>(options["seed"]);
+        int nchannels = Strutil::from_string<int>(options["nchannels"]);
+        ROI roi       = img[0]->roi();
+        roi.chend     = std::min(roi.chend, nchannels);
+        return ImageBufAlgo::noise(*img[0], type, A, B, mono, seed, roi);
     }
 };
 
-OP_CUSTOMCLASS (noise, OpNoise, 1);
+OP_CUSTOMCLASS(noise, OpNoise, 1);
 
 
 
 static int
-action_chsum (int argc, const char *argv[])
+action_chsum(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_chsum, argc, argv))
+    if (ot.postpone_callback(1, action_chsum, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
 
-    ImageRecRef A (ot.pop());
-    ot.read (A);
-    ImageRecRef R (new ImageRec ("chsum", ot.allsubimages ? A->subimages() : 1));
-    ot.push (R);
+    ImageRecRef A(ot.pop());
+    ot.read(A);
+    ImageRecRef R(new ImageRec("chsum", ot.allsubimages ? A->subimages() : 1));
+    ot.push(R);
 
-    for (int s = 0, subimages = R->subimages();  s < subimages;  ++s) {
-        std::vector<float> weight ((*A)(s).nchannels(), 1.0f);
-        std::map<std::string,std::string> options;
-        ot.extract_options (options, command);
-        Strutil::extract_from_list_string (weight, options["weight"]);
+    for (int s = 0, subimages = R->subimages(); s < subimages; ++s) {
+        std::vector<float> weight((*A)(s).nchannels(), 1.0f);
+        std::map<std::string, std::string> options;
+        ot.extract_options(options, command);
+        Strutil::extract_from_list_string(weight, options["weight"]);
 
-        ImageBuf &Rib ((*R)(s));
-        const ImageBuf &Aib ((*A)(s));
-        bool ok = ImageBufAlgo::channel_sum (Rib, Aib, &weight[0]);
-        if (! ok)
-            ot.error (command, Rib.geterror());
-        R->update_spec_from_imagebuf (s);
+        ImageBuf& Rib((*R)(s));
+        const ImageBuf& Aib((*A)(s));
+        bool ok = ImageBufAlgo::channel_sum(Rib, Aib, &weight[0]);
+        if (!ok)
+            ot.error(command, Rib.geterror());
+        R->update_spec_from_imagebuf(s);
     }
 
     ot.function_times[command] += timer();
@@ -2696,72 +2777,73 @@ action_chsum (int argc, const char *argv[])
 
 class OpColormap : public OiiotoolOp {
 public:
-    OpColormap (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) {}
-    virtual int impl (ImageBuf **img) {
+    OpColormap(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
         if (isalpha(args[1][0])) {
             // Named color map
-            return ImageBufAlgo::color_map (*img[0], *img[1], -1, args[1],
-                                            img[1]->roi(), 0);
+            return ImageBufAlgo::color_map(*img[0], *img[1], -1, args[1],
+                                           img[1]->roi(), 0);
         } else {
             // Values
             std::vector<float> knots;
-            int n = Strutil::extract_from_list_string (knots, args[1]);
-            return ImageBufAlgo::color_map (*img[0], *img[1], -1,
-                                            n/3, 3, knots,
-                                            img[1]->roi(), 0);
+            int n = Strutil::extract_from_list_string(knots, args[1]);
+            return ImageBufAlgo::color_map(*img[0], *img[1], -1, n / 3, 3,
+                                           knots, img[1]->roi(), 0);
         }
     }
 };
 
-OP_CUSTOMCLASS (colormap, OpColormap, 1);
+OP_CUSTOMCLASS(colormap, OpColormap, 1);
 
 
 
-
-
-UNARY_IMAGE_OP (flip, ImageBufAlgo::flip);
-UNARY_IMAGE_OP (flop, ImageBufAlgo::flop);
-UNARY_IMAGE_OP (rotate180, ImageBufAlgo::rotate180);
-UNARY_IMAGE_OP (rotate90, ImageBufAlgo::rotate90);
-UNARY_IMAGE_OP (rotate270, ImageBufAlgo::rotate270);
-UNARY_IMAGE_OP (transpose, ImageBufAlgo::transpose);
+UNARY_IMAGE_OP(flip, ImageBufAlgo::flip);
+UNARY_IMAGE_OP(flop, ImageBufAlgo::flop);
+UNARY_IMAGE_OP(rotate180, ImageBufAlgo::rotate180);
+UNARY_IMAGE_OP(rotate90, ImageBufAlgo::rotate90);
+UNARY_IMAGE_OP(rotate270, ImageBufAlgo::rotate270);
+UNARY_IMAGE_OP(transpose, ImageBufAlgo::transpose);
 
 
 
 int
-action_reorient (int argc, const char *argv[])
+action_reorient(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_reorient, argc, argv))
+    if (ot.postpone_callback(1, action_reorient, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
 
     // Make sure time in the rotate functions is charged to reorient
     bool old_enable_function_timing = ot.enable_function_timing;
-    ot.enable_function_timing = false;
+    ot.enable_function_timing       = false;
 
     ImageRecRef A = ot.pop();
-    ot.read (A);
+    ot.read(A);
 
     // See if any subimages need to be reoriented
     bool needs_reorient = false;
-    for (int s = 0, subimages = A->subimages();  s < subimages;  ++s) {
+    for (int s = 0, subimages = A->subimages(); s < subimages; ++s) {
         int orientation = (*A)(s).orientation();
         needs_reorient |= (orientation != 1);
     }
 
     if (needs_reorient) {
-        ImageRecRef R (new ImageRec ("reorient", ot.allsubimages ? A->subimages() : 1));
-        ot.push (R);
-        for (int s = 0, subimages = R->subimages();  s < subimages;  ++s) {
-            ImageBufAlgo::reorient ((*R)(s), (*A)(s));
-            R->update_spec_from_imagebuf (s);
+        ImageRecRef R(
+            new ImageRec("reorient", ot.allsubimages ? A->subimages() : 1));
+        ot.push(R);
+        for (int s = 0, subimages = R->subimages(); s < subimages; ++s) {
+            ImageBufAlgo::reorient((*R)(s), (*A)(s));
+            R->update_spec_from_imagebuf(s);
         }
     } else {
         // No subimages need modification, just leave the whole thing in
         // place.
-        ot.push (A);
+        ot.push(A);
     }
 
     ot.function_times[command] += timer();
@@ -2773,138 +2855,153 @@ action_reorient (int argc, const char *argv[])
 
 class OpRotate : public OiiotoolOp {
 public:
-    OpRotate (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) {}
-    virtual int impl (ImageBuf **img) {
-        float angle = Strutil::from_string<float> (args[1]);
+    OpRotate(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
+        float angle            = Strutil::from_string<float>(args[1]);
         std::string filtername = options["filter"];
-        bool recompute_roi = Strutil::from_string<int>(options["recompute_roi"]);
-        string_view center (options["center"]);
+        bool recompute_roi     = Strutil::from_string<int>(
+            options["recompute_roi"]);
+        string_view center(options["center"]);
         float center_x = 0.0f, center_y = 0.0f;
         float cx, cy;
-        if (center.size() && Strutil::parse_float(center, center_x) &&
-            Strutil::parse_char(center, ',') && Strutil::parse_float(center, center_y)) {
+        if (center.size() && Strutil::parse_float(center, center_x)
+            && Strutil::parse_char(center, ',')
+            && Strutil::parse_float(center, center_y)) {
             // center supplied
             cx = center_x;
             cy = center_y;
         } else {
             ROI src_roi_full = img[1]->roi_full();
-            cx = 0.5f * (src_roi_full.xbegin + src_roi_full.xend);
-            cy = 0.5f * (src_roi_full.ybegin + src_roi_full.yend);
+            cx               = 0.5f * (src_roi_full.xbegin + src_roi_full.xend);
+            cy               = 0.5f * (src_roi_full.ybegin + src_roi_full.yend);
         }
-        return ImageBufAlgo::rotate (*img[0], *img[1],
-                                     angle*float(M_PI/180.0), cx, cy,
-                                     filtername, 0.0f, recompute_roi);
+        return ImageBufAlgo::rotate(*img[0], *img[1],
+                                    angle * float(M_PI / 180.0), cx, cy,
+                                    filtername, 0.0f, recompute_roi);
     }
 };
 
-OP_CUSTOMCLASS (rotate, OpRotate, 1);
+OP_CUSTOMCLASS(rotate, OpRotate, 1);
 
 
 
 class OpWarp : public OiiotoolOp {
 public:
-    OpWarp (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) {}
-    virtual int impl (ImageBuf **img) {
+    OpWarp(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
         std::string filtername = options["filter"];
-        bool recompute_roi = Strutil::from_string<int>(options["recompute_roi"]);
-        std::vector<float> M (9);
-        if (Strutil::extract_from_list_string (M, args[1]) != 9) {
-            ot.error (opname(), "expected 9 comma-separatd floats to form a 3x3 matrix");
+        bool recompute_roi     = Strutil::from_string<int>(
+            options["recompute_roi"]);
+        std::vector<float> M(9);
+        if (Strutil::extract_from_list_string(M, args[1]) != 9) {
+            ot.error(opname(),
+                     "expected 9 comma-separatd floats to form a 3x3 matrix");
             return 0;
         }
-        return ImageBufAlgo::warp (*img[0], *img[1],
-                                   *(Imath::M33f *)&M[0], filtername, 0.0f,
-                                   recompute_roi, ImageBuf::WrapDefault);
+        return ImageBufAlgo::warp(*img[0], *img[1], *(Imath::M33f*)&M[0],
+                                  filtername, 0.0f, recompute_roi,
+                                  ImageBuf::WrapDefault);
     }
 };
 
-OP_CUSTOMCLASS (warp, OpWarp, 1);
+OP_CUSTOMCLASS(warp, OpWarp, 1);
 
 
 
 class OpCshift : public OiiotoolOp {
 public:
-    OpCshift (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) {}
-    virtual int impl (ImageBuf **img) {
+    OpCshift(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
         int x = 0, y = 0, z = 0;
-        if (sscanf (args[1].c_str(), "%d%d%d", &x, &y, &z) < 2) {
-            ot.error (opname(), Strutil::format ("Invalid shift offset '%s'", args[1]));
+        if (sscanf(args[1].c_str(), "%d%d%d", &x, &y, &z) < 2) {
+            ot.error(opname(),
+                     Strutil::format("Invalid shift offset '%s'", args[1]));
             return 0;
         }
-        return ImageBufAlgo::circular_shift (*img[0], *img[1], x, y, z);
+        return ImageBufAlgo::circular_shift(*img[0], *img[1], x, y, z);
     }
 };
 
-OP_CUSTOMCLASS (cshift, OpCshift, 1);
+OP_CUSTOMCLASS(cshift, OpCshift, 1);
 
 
 
 static int
-action_pop (int argc, const char *argv[])
+action_pop(int argc, const char* argv[])
 {
-    ASSERT (argc == 1);
-    ot.pop ();
+    ASSERT(argc == 1);
+    ot.pop();
     return 0;
 }
 
 
 
 static int
-action_dup (int argc, const char *argv[])
+action_dup(int argc, const char* argv[])
 {
-    ASSERT (argc == 1);
-    ot.push (ot.curimg);
+    ASSERT(argc == 1);
+    ot.push(ot.curimg);
     return 0;
 }
 
 
 static int
-action_swap (int argc, const char *argv[])
+action_swap(int argc, const char* argv[])
 {
-    ASSERT (argc == 1);
-    string_view command = ot.express (argv[0]);
+    ASSERT(argc == 1);
+    string_view command = ot.express(argv[0]);
     if (ot.image_stack.size() < 1) {
-        ot.error (command, "requires at least two loaded images");
+        ot.error(command, "requires at least two loaded images");
         return 0;
     }
-    ImageRecRef B (ot.pop());
-    ImageRecRef A (ot.pop());
-    ot.push (B);
-    ot.push (A);
+    ImageRecRef B(ot.pop());
+    ImageRecRef A(ot.pop());
+    ot.push(B);
+    ot.push(A);
     return 0;
 }
 
 
 static int
-action_create (int argc, const char *argv[])
+action_create(int argc, const char* argv[])
 {
-    ASSERT (argc == 3);
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
-    string_view size    = ot.express (argv[1]);
-    int nchans = Strutil::from_string<int> (ot.express(argv[2]));
+    ASSERT(argc == 3);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
+    string_view size    = ot.express(argv[1]);
+    int nchans          = Strutil::from_string<int>(ot.express(argv[2]));
     if (nchans < 1 || nchans > 1024) {
-        ot.warning (argv[0], Strutil::format ("Invalid number of channels: %d", nchans));
+        ot.warning(argv[0],
+                   Strutil::format("Invalid number of channels: %d", nchans));
         nchans = 3;
     }
-    ImageSpec spec (64, 64, nchans, TypeDesc::FLOAT);
-    ot.adjust_geometry (argv[0], spec.width, spec.height, spec.x, spec.y,
-                        size.c_str());
-    spec.full_x = spec.x;
-    spec.full_y = spec.y;
-    spec.full_z = spec.z;
-    spec.full_width = spec.width;
+    ImageSpec spec(64, 64, nchans, TypeDesc::FLOAT);
+    ot.adjust_geometry(argv[0], spec.width, spec.height, spec.x, spec.y,
+                       size.c_str());
+    spec.full_x      = spec.x;
+    spec.full_y      = spec.y;
+    spec.full_z      = spec.z;
+    spec.full_width  = spec.width;
     spec.full_height = spec.height;
-    spec.full_depth = spec.depth;
-    ImageRecRef img (new ImageRec ("new", spec, ot.imagecache));
-    bool ok = ImageBufAlgo::zero ((*img)());
-    if (! ok)
-        ot.error (command, (*img)().geterror());
+    spec.full_depth  = spec.depth;
+    ImageRecRef img(new ImageRec("new", spec, ot.imagecache));
+    bool ok = ImageBufAlgo::zero((*img)());
+    if (!ok)
+        ot.error(command, (*img)().geterror());
     if (ot.curimg)
-        ot.image_stack.push_back (ot.curimg);
+        ot.image_stack.push_back(ot.curimg);
     ot.curimg = img;
     ot.function_times[command] += timer();
     return 0;
@@ -2913,118 +3010,122 @@ action_create (int argc, const char *argv[])
 
 
 static int
-action_pattern (int argc, const char *argv[])
+action_pattern(int argc, const char* argv[])
 {
-    ASSERT (argc == 4);
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
-    std::string pattern = ot.express (argv[1]);
-    std::string size    = ot.express (argv[2]);
-    int nchans = Strutil::from_string<int> (ot.express(argv[3]));
+    ASSERT(argc == 4);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
+    std::string pattern = ot.express(argv[1]);
+    std::string size    = ot.express(argv[2]);
+    int nchans          = Strutil::from_string<int>(ot.express(argv[3]));
     if (nchans < 1 || nchans > 1024) {
-        ot.warning (argv[0], Strutil::format ("Invalid number of channels: %d", nchans));
+        ot.warning(argv[0],
+                   Strutil::format("Invalid number of channels: %d", nchans));
         nchans = 3;
     }
-    ImageSpec spec (64, 64, nchans, TypeDesc::FLOAT);
-    ot.adjust_geometry (argv[0], spec.width, spec.height, spec.x, spec.y,
-                        size.c_str());
-    spec.full_x = spec.x;
-    spec.full_y = spec.y;
-    spec.full_z = spec.z;
-    spec.full_width = spec.width;
+    ImageSpec spec(64, 64, nchans, TypeDesc::FLOAT);
+    ot.adjust_geometry(argv[0], spec.width, spec.height, spec.x, spec.y,
+                       size.c_str());
+    spec.full_x      = spec.x;
+    spec.full_y      = spec.y;
+    spec.full_z      = spec.z;
+    spec.full_width  = spec.width;
     spec.full_height = spec.height;
-    spec.full_depth = spec.depth;
-    ImageRecRef img (new ImageRec ("new", spec, ot.imagecache));
-    ot.push (img);
-    ImageBuf &ib ((*img)());
+    spec.full_depth  = spec.depth;
+    ImageRecRef img(new ImageRec("new", spec, ot.imagecache));
+    ot.push(img);
+    ImageBuf& ib((*img)());
     bool ok = true;
-    if (Strutil::iequals(pattern,"black")) {
-        ok = ImageBufAlgo::zero (ib);
-    } else if (Strutil::istarts_with(pattern,"constant")) {
-        std::vector<float> fill (nchans, 1.0f);
-        std::map<std::string,std::string> options;
-        ot.extract_options (options, pattern);
-        Strutil::extract_from_list_string (fill, options["color"]);
-        ok = ImageBufAlgo::fill (ib, &fill[0]);
-    } else if (Strutil::istarts_with(pattern,"fill")) {
-        std::vector<float> topleft (nchans, 1.0f);
-        std::vector<float> topright (nchans, 1.0f);
-        std::vector<float> bottomleft (nchans, 1.0f);
-        std::vector<float> bottomright (nchans, 1.0f);
-        std::map<std::string,std::string> options;
-        ot.extract_options (options, pattern);
-        if (Strutil::extract_from_list_string (topleft,     options["topleft"]) &&
-            Strutil::extract_from_list_string (topright,    options["topright"]) &&
-            Strutil::extract_from_list_string (bottomleft,  options["bottomleft"]) &&
-            Strutil::extract_from_list_string (bottomright, options["bottomright"])) {
-            ok = ImageBufAlgo::fill (ib, &topleft[0], &topright[0],
-                                     &bottomleft[0], &bottomright[0]);
+    if (Strutil::iequals(pattern, "black")) {
+        ok = ImageBufAlgo::zero(ib);
+    } else if (Strutil::istarts_with(pattern, "constant")) {
+        std::vector<float> fill(nchans, 1.0f);
+        std::map<std::string, std::string> options;
+        ot.extract_options(options, pattern);
+        Strutil::extract_from_list_string(fill, options["color"]);
+        ok = ImageBufAlgo::fill(ib, &fill[0]);
+    } else if (Strutil::istarts_with(pattern, "fill")) {
+        std::vector<float> topleft(nchans, 1.0f);
+        std::vector<float> topright(nchans, 1.0f);
+        std::vector<float> bottomleft(nchans, 1.0f);
+        std::vector<float> bottomright(nchans, 1.0f);
+        std::map<std::string, std::string> options;
+        ot.extract_options(options, pattern);
+        if (Strutil::extract_from_list_string(topleft, options["topleft"])
+            && Strutil::extract_from_list_string(topright, options["topright"])
+            && Strutil::extract_from_list_string(bottomleft,
+                                                 options["bottomleft"])
+            && Strutil::extract_from_list_string(bottomright,
+                                                 options["bottomright"])) {
+            ok = ImageBufAlgo::fill(ib, &topleft[0], &topright[0],
+                                    &bottomleft[0], &bottomright[0]);
+        } else if (Strutil::extract_from_list_string(topleft, options["top"])
+                   && Strutil::extract_from_list_string(bottomleft,
+                                                        options["bottom"])) {
+            ok = ImageBufAlgo::fill(ib, &topleft[0], &bottomleft[0]);
+        } else if (Strutil::extract_from_list_string(topleft, options["left"])
+                   && Strutil::extract_from_list_string(topright,
+                                                        options["right"])) {
+            ok = ImageBufAlgo::fill(ib, &topleft[0], &topright[0], &topleft[0],
+                                    &topright[0]);
+        } else if (Strutil::extract_from_list_string(topleft,
+                                                     options["color"])) {
+            ok = ImageBufAlgo::fill(ib, &topleft[0]);
         }
-        else if (Strutil::extract_from_list_string (topleft,    options["top"]) &&
-                 Strutil::extract_from_list_string (bottomleft, options["bottom"])) {
-            ok = ImageBufAlgo::fill (ib, &topleft[0], &bottomleft[0]);
-        }
-        else if (Strutil::extract_from_list_string (topleft,  options["left"]) &&
-                 Strutil::extract_from_list_string (topright, options["right"])) {
-            ok = ImageBufAlgo::fill (ib, &topleft[0], &topright[0],
-                                     &topleft[0], &topright[0]);
-        }
-        else if (Strutil::extract_from_list_string (topleft, options["color"])) {
-            ok = ImageBufAlgo::fill (ib, &topleft[0]);
-        }
-    } else if (Strutil::istarts_with(pattern,"checker")) {
-        std::map<std::string,std::string> options;
-        options["width"] = "8";
+    } else if (Strutil::istarts_with(pattern, "checker")) {
+        std::map<std::string, std::string> options;
+        options["width"]  = "8";
         options["height"] = "8";
-        options["depth"] = "8";
-        ot.extract_options (options, pattern);
-        int width = Strutil::from_string<int> (options["width"]);
-        int height = Strutil::from_string<int> (options["height"]);
-        int depth = Strutil::from_string<int> (options["depth"]);
-        std::vector<float> color1 (nchans, 0.0f);
-        std::vector<float> color2 (nchans, 1.0f);
-        Strutil::extract_from_list_string (color1, options["color1"]);
-        Strutil::extract_from_list_string (color2, options["color2"]);
-        ok = ImageBufAlgo::checker (ib, width, height, depth,
-                                    &color1[0], &color2[0], 0, 0, 0);
+        options["depth"]  = "8";
+        ot.extract_options(options, pattern);
+        int width  = Strutil::from_string<int>(options["width"]);
+        int height = Strutil::from_string<int>(options["height"]);
+        int depth  = Strutil::from_string<int>(options["depth"]);
+        std::vector<float> color1(nchans, 0.0f);
+        std::vector<float> color2(nchans, 1.0f);
+        Strutil::extract_from_list_string(color1, options["color1"]);
+        Strutil::extract_from_list_string(color2, options["color2"]);
+        ok = ImageBufAlgo::checker(ib, width, height, depth, &color1[0],
+                                   &color2[0], 0, 0, 0);
     } else if (Strutil::istarts_with(pattern, "noise")) {
-        std::map<std::string,std::string> options;
-        options["type"] = "gaussian";
-        options["min"] = "0.5";
-        options["max"] = "1";
-        options["mean"] = "0.5";
-        options["stddev"] = "0.1";
+        std::map<std::string, std::string> options;
+        options["type"]    = "gaussian";
+        options["min"]     = "0.5";
+        options["max"]     = "1";
+        options["mean"]    = "0.5";
+        options["stddev"]  = "0.1";
         options["portion"] = "0.01";
-        options["value"] = "0";
-        options["mono"] = "0";
-        options["seed"] = "0";
-        ot.extract_options (options, pattern);
+        options["value"]   = "0";
+        options["mono"]    = "0";
+        options["seed"]    = "0";
+        ot.extract_options(options, pattern);
         std::string type = options["type"];
         float A = 0, B = 1;
         if (type == "gaussian") {
-            A = Strutil::from_string<float> (options["mean"]);
-            B = Strutil::from_string<float> (options["stddev"]);
+            A = Strutil::from_string<float>(options["mean"]);
+            B = Strutil::from_string<float>(options["stddev"]);
         } else if (type == "uniform") {
-            A = Strutil::from_string<float> (options["min"]);
-            B = Strutil::from_string<float> (options["max"]);
+            A = Strutil::from_string<float>(options["min"]);
+            B = Strutil::from_string<float>(options["max"]);
         } else if (type == "salt") {
-            A = Strutil::from_string<float> (options["value"]);
-            B = Strutil::from_string<float> (options["portion"]);
+            A = Strutil::from_string<float>(options["value"]);
+            B = Strutil::from_string<float>(options["portion"]);
         } else {
-            ot.error (command, Strutil::format ("Unknown noise type \"%s\"", type));
+            ot.error(command,
+                     Strutil::format("Unknown noise type \"%s\"", type));
             ok = false;
         }
-        bool mono = Strutil::from_string<int> (options["mono"]);
-        int seed = Strutil::from_string<int> (options["seed"]);
-        ImageBufAlgo::zero (ib);
+        bool mono = Strutil::from_string<int>(options["mono"]);
+        int seed  = Strutil::from_string<int>(options["seed"]);
+        ImageBufAlgo::zero(ib);
         if (ok)
-            ok = ImageBufAlgo::noise (ib, type, A, B, mono, seed);
+            ok = ImageBufAlgo::noise(ib, type, A, B, mono, seed);
     } else {
-        ok = ImageBufAlgo::zero (ib);
-        ot.warning (command, Strutil::format("Unknown pattern \"%s\"", pattern));
+        ok = ImageBufAlgo::zero(ib);
+        ot.warning(command, Strutil::format("Unknown pattern \"%s\"", pattern));
     }
-    if (! ok)
-        ot.error (command, ib.geterror());
+    if (!ok)
+        ot.error(command, ib.geterror());
     ot.function_times[command] += timer();
     return 0;
 }
@@ -3033,39 +3134,42 @@ action_pattern (int argc, const char *argv[])
 
 class OpKernel : public OiiotoolOp {
 public:
-    OpKernel (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 0) { }
-    virtual int impl (ImageBuf **img) {
-        string_view kernelname (args[1]);
-        string_view kernelsize (args[2]);
+    OpKernel(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 0)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
+        string_view kernelname(args[1]);
+        string_view kernelsize(args[2]);
         float w = 1.0f, h = 1.0f;
-        if (sscanf (kernelsize.c_str(), "%fx%f", &w, &h) != 2)
-            ot.error (opname(), Strutil::format ("Unknown size %s", kernelsize));
-        return ImageBufAlgo::make_kernel (*img[0], kernelname, w, h);
+        if (sscanf(kernelsize.c_str(), "%fx%f", &w, &h) != 2)
+            ot.error(opname(), Strutil::format("Unknown size %s", kernelsize));
+        return ImageBufAlgo::make_kernel(*img[0], kernelname, w, h);
     }
 };
 
-OP_CUSTOMCLASS (kernel, OpKernel, 0);
+OP_CUSTOMCLASS(kernel, OpKernel, 0);
 
 
 
 static int
-action_capture (int argc, const char *argv[])
+action_capture(int argc, const char* argv[])
 {
-    ASSERT (argc == 1);
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
-    std::map<std::string,std::string> options;
-    ot.extract_options (options, command);
-    int camera = Strutil::from_string<int> (options["camera"]);
+    ASSERT(argc == 1);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
+    std::map<std::string, std::string> options;
+    ot.extract_options(options, command);
+    int camera = Strutil::from_string<int>(options["camera"]);
 
     ImageBuf ib;
-    bool ok = ImageBufAlgo::capture_image (ib, camera, TypeDesc::FLOAT);
-    if (! ok)
-        ot.error (command, ib.geterror());
-    ImageRecRef img (new ImageRec ("capture", ib.spec(), ot.imagecache));
-    (*img)().copy (ib);
-    ot.push (img);
+    bool ok = ImageBufAlgo::capture_image(ib, camera, TypeDesc::FLOAT);
+    if (!ok)
+        ot.error(command, ib.geterror());
+    ImageRecRef img(new ImageRec("capture", ib.spec(), ot.imagecache));
+    (*img)().copy(ib);
+    ot.push(img);
     ot.function_times[command] += timer();
     return 0;
 }
@@ -3073,53 +3177,52 @@ action_capture (int argc, const char *argv[])
 
 
 int
-action_crop (int argc, const char *argv[])
+action_crop(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_crop, argc, argv))
+    if (ot.postpone_callback(1, action_crop, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
-    string_view size    = ot.express (argv[1]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
+    string_view size    = ot.express(argv[1]);
 
-    std::map<std::string,std::string> options;
+    std::map<std::string, std::string> options;
     options["allsubimages"] = std::to_string(ot.allsubimages);
-    ot.extract_options (options, command);
+    ot.extract_options(options, command);
     int crop_all_subimages = Strutil::from_string<int>(options["allsubimages"]);
 
-    ot.read ();
-    ImageRecRef A = ot.curimg;
+    ot.read();
+    ImageRecRef A     = ot.curimg;
     bool crops_needed = false;
-    int subimages = crop_all_subimages ? A->subimages() : 1;
+    int subimages     = crop_all_subimages ? A->subimages() : 1;
     for (int s = 0; s < subimages; ++s) {
-        ImageSpec &spec (*A->spec(s,0));
+        ImageSpec& spec(*A->spec(s, 0));
         int w = spec.width, h = spec.height, d = spec.depth;
         int x = spec.x, y = spec.y, z = spec.z;
-        ot.adjust_geometry (argv[0], w, h, x, y, size.c_str());
-        crops_needed |=
-            (w != spec.width || h != spec.height || d != spec.depth ||
-             x != spec.x || y != spec.y || z != spec.z);
+        ot.adjust_geometry(argv[0], w, h, x, y, size.c_str());
+        crops_needed |= (w != spec.width || h != spec.height || d != spec.depth
+                         || x != spec.x || y != spec.y || z != spec.z);
     }
 
     if (crops_needed) {
-        ot.pop ();
-        ImageRecRef R (new ImageRec (A->name(), subimages, 0));
-        ot.push (R);
+        ot.pop();
+        ImageRecRef R(new ImageRec(A->name(), subimages, 0));
+        ot.push(R);
         for (int s = 0; s < subimages; ++s) {
-            ImageSpec &spec (*A->spec(s,0));
+            ImageSpec& spec(*A->spec(s, 0));
             int w = spec.width, h = spec.height, d = spec.depth;
             int x = spec.x, y = spec.y, z = spec.z;
-            ot.adjust_geometry (argv[0], w, h, x, y, size.c_str());
-            const ImageBuf &Aib ((*A)(s,0));
-            ImageBuf &Rib ((*R)(s,0));
+            ot.adjust_geometry(argv[0], w, h, x, y, size.c_str());
+            const ImageBuf& Aib((*A)(s, 0));
+            ImageBuf& Rib((*R)(s, 0));
             ROI roi = Aib.roi();
-            if (w != spec.width || h != spec.height || d != spec.depth ||
-                    x != spec.x || y != spec.y || z != spec.z) {
-                roi = ROI (x, x+w, y, y+h, z, z+d);
+            if (w != spec.width || h != spec.height || d != spec.depth
+                || x != spec.x || y != spec.y || z != spec.z) {
+                roi = ROI(x, x + w, y, y + h, z, z + d);
             }
-            bool ok = ImageBufAlgo::crop (Rib, Aib, roi);
-            if (! ok)
-                ot.error (command, Rib.geterror());
-            R->update_spec_from_imagebuf (s, 0);
+            bool ok = ImageBufAlgo::crop(Rib, Aib, roi);
+            if (!ok)
+                ot.error(command, Rib.geterror());
+            R->update_spec_from_imagebuf(s, 0);
         }
     }
 
@@ -3130,32 +3233,33 @@ action_crop (int argc, const char *argv[])
 
 
 int
-action_croptofull (int argc, const char *argv[])
+action_croptofull(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_croptofull, argc, argv))
+    if (ot.postpone_callback(1, action_croptofull, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
 
-    ot.read ();
-    ImageRecRef A = ot.curimg;
+    ot.read();
+    ImageRecRef A     = ot.curimg;
     bool crops_needed = false;
     for (int s = 0; s < A->subimages(); ++s) {
         crops_needed |= ((*A)(s).roi() != (*A)(s).roi_full());
     }
 
     if (crops_needed) {
-        ot.pop ();
-        ImageRecRef R (new ImageRec (A->name(), A->subimages(), 0));
-        ot.push (R);
+        ot.pop();
+        ImageRecRef R(new ImageRec(A->name(), A->subimages(), 0));
+        ot.push(R);
         for (int s = 0; s < A->subimages(); ++s) {
-            const ImageBuf &Aib ((*A)(s,0));
-            ImageBuf &Rib ((*R)(s,0));
-            ROI roi = (Aib.roi() != Aib.roi_full()) ? Aib.roi_full() : Aib.roi();
-            bool ok = ImageBufAlgo::crop (Rib, Aib, roi);
-            if (! ok)
-                ot.error (command, Rib.geterror());
-            R->update_spec_from_imagebuf (s, 0);
+            const ImageBuf& Aib((*A)(s, 0));
+            ImageBuf& Rib((*R)(s, 0));
+            ROI roi = (Aib.roi() != Aib.roi_full()) ? Aib.roi_full()
+                                                    : Aib.roi();
+            bool ok = ImageBufAlgo::crop(Rib, Aib, roi);
+            if (!ok)
+                ot.error(command, Rib.geterror());
+            R->update_spec_from_imagebuf(s, 0);
         }
     }
     ot.function_times[command] += timer();
@@ -3165,46 +3269,46 @@ action_croptofull (int argc, const char *argv[])
 
 
 int
-action_trim (int argc, const char *argv[])
+action_trim(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_trim, argc, argv))
+    if (ot.postpone_callback(1, action_trim, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
 
-    ot.read ();
+    ot.read();
     ImageRecRef A = ot.curimg;
-    
+
     // First, figure out shared nonzero region
     ROI nonzero_region;
     for (int s = 0; s < A->subimages(); ++s) {
-        ROI roi = ImageBufAlgo::nonzero_region ((*A)(s));
+        ROI roi = ImageBufAlgo::nonzero_region((*A)(s));
         if (roi.npixels() == 0) {
             // Special case -- all zero; but doctor to make it 1 zero pixel
-            roi = (*A)(s).roi();
-            roi.xend = roi.xbegin+1;
-            roi.yend = roi.ybegin+1;
-            roi.zend = roi.zbegin+1;
+            roi      = (*A)(s).roi();
+            roi.xend = roi.xbegin + 1;
+            roi.yend = roi.ybegin + 1;
+            roi.zend = roi.zbegin + 1;
         }
-        nonzero_region = roi_union (nonzero_region, roi);
+        nonzero_region = roi_union(nonzero_region, roi);
     }
-    
+
     // Now see if any subimges need cropping
     bool crops_needed = false;
     for (int s = 0; s < A->subimages(); ++s) {
         crops_needed |= (nonzero_region != (*A)(s).roi());
     }
     if (crops_needed) {
-        ot.pop ();
-        ImageRecRef R (new ImageRec (A->name(), A->subimages(), 0));
-        ot.push (R);
+        ot.pop();
+        ImageRecRef R(new ImageRec(A->name(), A->subimages(), 0));
+        ot.push(R);
         for (int s = 0; s < A->subimages(); ++s) {
-            const ImageBuf &Aib ((*A)(s,0));
-            ImageBuf &Rib ((*R)(s,0));
-            bool ok = ImageBufAlgo::crop (Rib, Aib, nonzero_region);
-            if (! ok)
-                ot.error (command, Rib.geterror());
-            R->update_spec_from_imagebuf (s, 0);
+            const ImageBuf& Aib((*A)(s, 0));
+            ImageBuf& Rib((*R)(s, 0));
+            bool ok = ImageBufAlgo::crop(Rib, Aib, nonzero_region);
+            if (!ok)
+                ot.error(command, Rib.geterror());
+            R->update_spec_from_imagebuf(s, 0);
         }
     }
     ot.function_times[command] += timer();
@@ -3214,33 +3318,33 @@ action_trim (int argc, const char *argv[])
 
 
 int
-action_cut (int argc, const char *argv[])
+action_cut(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_cut, argc, argv))
+    if (ot.postpone_callback(1, action_cut, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
-    string_view size    = ot.express (argv[1]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
+    string_view size    = ot.express(argv[1]);
 
-    ot.read ();
+    ot.read();
     ImageRecRef A = ot.pop();
-    ImageSpec &Aspec (*A->spec(0,0));
+    ImageSpec& Aspec(*A->spec(0, 0));
     ImageSpec newspec = Aspec;
 
-    ot.adjust_geometry (argv[0], newspec.width, newspec.height,
-                        newspec.x, newspec.y, size.c_str());
+    ot.adjust_geometry(argv[0], newspec.width, newspec.height, newspec.x,
+                       newspec.y, size.c_str());
 
-    ImageRecRef R (new ImageRec (A->name(), newspec, ot.imagecache));
-    const ImageBuf &Aib ((*A)(0,0));
-    ImageBuf &Rib ((*R)(0,0));
-    ImageBufAlgo::cut (Rib, Aib, get_roi(newspec));
+    ImageRecRef R(new ImageRec(A->name(), newspec, ot.imagecache));
+    const ImageBuf& Aib((*A)(0, 0));
+    ImageBuf& Rib((*R)(0, 0));
+    ImageBufAlgo::cut(Rib, Aib, get_roi(newspec));
 
-    ImageSpec &spec (*R->spec(0,0));
-    set_roi (spec, Rib.roi());
-    set_roi_full (spec, Rib.roi());
-    A->metadata_modified (true);
+    ImageSpec& spec(*R->spec(0, 0));
+    set_roi(spec, Rib.roi());
+    set_roi_full(spec, Rib.roi());
+    A->metadata_modified(true);
 
-    ot.push (R);
+    ot.push(R);
 
     ot.function_times[command] += timer();
     return 0;
@@ -3250,157 +3354,167 @@ action_cut (int argc, const char *argv[])
 
 class OpResample : public OiiotoolOp {
 public:
-    OpResample (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) { }
-    virtual int compute_subimages () { return 1; } // just the first one
-    virtual void option_defaults () {
-        options["interp"] = "1";
+    OpResample(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
     }
-    virtual bool setup () {
+    virtual int compute_subimages() { return 1; }  // just the first one
+    virtual void option_defaults() { options["interp"] = "1"; }
+    virtual bool setup()
+    {
         // The size argument will be the resulting display (full) window.
-        const ImageSpec &Aspec (*ir[1]->spec(0,0));
+        const ImageSpec& Aspec(*ir[1]->spec(0, 0));
         ImageSpec newspec = Aspec;
-        ot.adjust_geometry (args[0], newspec.full_width, newspec.full_height,
-                            newspec.full_x, newspec.full_y,
-                            args[1].c_str() /*size*/, true);
-        if (newspec.full_width == Aspec.full_width &&
-            newspec.full_height == Aspec.full_height) {
+        ot.adjust_geometry(args[0], newspec.full_width, newspec.full_height,
+                           newspec.full_x, newspec.full_y,
+                           args[1].c_str() /*size*/, true);
+        if (newspec.full_width == Aspec.full_width
+            && newspec.full_height == Aspec.full_height) {
             // No change -- pop the temp result and restore the original
-            ot.pop ();
-            ot.push (ir[1]);
-            return false;   // nothing more to do
+            ot.pop();
+            ot.push(ir[1]);
+            return false;  // nothing more to do
         }
         // Compute corresponding data window.
         float wratio = float(newspec.full_width) / float(Aspec.full_width);
         float hratio = float(newspec.full_height) / float(Aspec.full_height);
-        newspec.x = newspec.full_x + int(floorf ((Aspec.x - Aspec.full_x) * wratio));
-        newspec.y = newspec.full_y + int(floorf ((Aspec.y - Aspec.full_y) * hratio));
-        newspec.width = int(ceilf (Aspec.width * wratio));
-        newspec.height = int(ceilf (Aspec.height * hratio));
-        (*ir[0])(0,0).reset (newspec);
+        newspec.x    = newspec.full_x
+                    + int(floorf((Aspec.x - Aspec.full_x) * wratio));
+        newspec.y = newspec.full_y
+                    + int(floorf((Aspec.y - Aspec.full_y) * hratio));
+        newspec.width  = int(ceilf(Aspec.width * wratio));
+        newspec.height = int(ceilf(Aspec.height * hratio));
+        (*ir[0])(0, 0).reset(newspec);
         return true;
     }
-    virtual int impl (ImageBuf **img) {
-        bool interp = (bool) Strutil::from_string<int>(options["interp"]);
-        return ImageBufAlgo::resample (*img[0], *img[1], interp);
+    virtual int impl(ImageBuf** img)
+    {
+        bool interp = (bool)Strutil::from_string<int>(options["interp"]);
+        return ImageBufAlgo::resample(*img[0], *img[1], interp);
     }
 };
 
-OP_CUSTOMCLASS (resample, OpResample, 1);
+OP_CUSTOMCLASS(resample, OpResample, 1);
 
 
 
 class OpResize : public OiiotoolOp {
 public:
-    OpResize (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) { }
-    virtual int compute_subimages () { return 1; } // just the first one
-    virtual bool setup () {
+    OpResize(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual int compute_subimages() { return 1; }  // just the first one
+    virtual bool setup()
+    {
         // The size argument will be the resulting display (full) window.
-        const ImageSpec &Aspec (*ir[1]->spec(0,0));
+        const ImageSpec& Aspec(*ir[1]->spec(0, 0));
         ImageSpec newspec = Aspec;
-        ot.adjust_geometry (args[0], newspec.full_width, newspec.full_height,
-                            newspec.full_x, newspec.full_y,
-                            args[1].c_str() /*size*/, true);
-        if (newspec.full_width == Aspec.full_width &&
-            newspec.full_height == Aspec.full_height) {
+        ot.adjust_geometry(args[0], newspec.full_width, newspec.full_height,
+                           newspec.full_x, newspec.full_y,
+                           args[1].c_str() /*size*/, true);
+        if (newspec.full_width == Aspec.full_width
+            && newspec.full_height == Aspec.full_height) {
             // No change -- pop the temp result and restore the original
-            ot.pop ();
-            ot.push (ir[1]);
-            return false;   // nothing more to do
+            ot.pop();
+            ot.push(ir[1]);
+            return false;  // nothing more to do
         }
         // Compute corresponding data window.
         float wratio = float(newspec.full_width) / float(Aspec.full_width);
         float hratio = float(newspec.full_height) / float(Aspec.full_height);
-        newspec.x = newspec.full_x + int(floorf ((Aspec.x - Aspec.full_x) * wratio));
-        newspec.y = newspec.full_y + int(floorf ((Aspec.y - Aspec.full_y) * hratio));
-        newspec.width = int(ceilf (Aspec.width * wratio));
-        newspec.height = int(ceilf (Aspec.height * hratio));
-        (*ir[0])(0,0).reset (newspec);
+        newspec.x    = newspec.full_x
+                    + int(floorf((Aspec.x - Aspec.full_x) * wratio));
+        newspec.y = newspec.full_y
+                    + int(floorf((Aspec.y - Aspec.full_y) * hratio));
+        newspec.width  = int(ceilf(Aspec.width * wratio));
+        newspec.height = int(ceilf(Aspec.height * hratio));
+        (*ir[0])(0, 0).reset(newspec);
         return true;
     }
-    virtual int impl (ImageBuf **img) {
+    virtual int impl(ImageBuf** img)
+    {
         string_view filtername = options["filter"];
         if (ot.debug) {
-            const ImageSpec &newspec (img[0]->spec());
-            const ImageSpec &Aspec (img[1]->spec());
+            const ImageSpec& newspec(img[0]->spec());
+            const ImageSpec& Aspec(img[1]->spec());
             std::cout << "  Resizing " << Aspec.width << "x" << Aspec.height
                       << " to " << newspec.width << "x" << newspec.height
                       << " using "
                       << (filtername.size() ? filtername.c_str() : "default")
                       << " filter\n";
         }
-        return ImageBufAlgo::resize (*img[0], *img[1], filtername,
-                                     0.0f, img[0]->roi());
+        return ImageBufAlgo::resize(*img[0], *img[1], filtername, 0.0f,
+                                    img[0]->roi());
     }
 };
 
-OP_CUSTOMCLASS (resize, OpResize, 1);
+OP_CUSTOMCLASS(resize, OpResize, 1);
 
 
 
 static int
-action_fit (int argc, const char *argv[])
+action_fit(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_fit, argc, argv))
+    if (ot.postpone_callback(1, action_fit, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
+    Timer timer(ot.enable_function_timing);
     bool old_enable_function_timing = ot.enable_function_timing;
-    ot.enable_function_timing = false;
-    string_view command = ot.express (argv[0]);
-    string_view size    = ot.express (argv[1]);
+    ot.enable_function_timing       = false;
+    string_view command             = ot.express(argv[0]);
+    string_view size                = ot.express(argv[1]);
 
     // Examine the top of stack
     ImageRecRef A = ot.top();
-    ot.read ();
-    const ImageSpec *Aspec = A->spec(0,0);
+    ot.read();
+    const ImageSpec* Aspec = A->spec(0, 0);
 
     // Parse the user request for resolution to fit
-    int fit_full_width = Aspec->full_width;
+    int fit_full_width  = Aspec->full_width;
     int fit_full_height = Aspec->full_height;
-    int fit_full_x = Aspec->full_x;
-    int fit_full_y = Aspec->full_y;
-    ot.adjust_geometry (argv[0], fit_full_width, fit_full_height,
-                        fit_full_x, fit_full_y, size.c_str(), false);
+    int fit_full_x      = Aspec->full_x;
+    int fit_full_y      = Aspec->full_y;
+    ot.adjust_geometry(argv[0], fit_full_width, fit_full_height, fit_full_x,
+                       fit_full_y, size.c_str(), false);
 
-    std::map<std::string,std::string> options;
-    options["wrap"] = "black";
+    std::map<std::string, std::string> options;
+    options["wrap"]         = "black";
     options["allsubimages"] = std::to_string(ot.allsubimages);
-    ot.extract_options (options, command);
-    bool pad = Strutil::from_string<int>(options["pad"]);
+    ot.extract_options(options, command);
+    bool pad               = Strutil::from_string<int>(options["pad"]);
     string_view filtername = options["filter"];
-    bool exact = Strutil::from_string<int>(options["exact"]);
-    bool allsubimages = Strutil::from_string<int>(options["allsubimages"]);
+    bool exact             = Strutil::from_string<int>(options["exact"]);
+    bool allsubimages      = Strutil::from_string<int>(options["allsubimages"]);
 
 #if 1
     // New version: use IBA::fit() for the heavy lifting
     int subimages = allsubimages ? A->subimages() : 1;
-    ImageRecRef R (new ImageRec (A->name(), subimages));
+    ImageRecRef R(new ImageRec(A->name(), subimages));
     for (int s = 0; s < subimages; ++s) {
-        ImageSpec newspec = (*A)(s,0).spec();
+        ImageSpec newspec = (*A)(s, 0).spec();
         newspec.width = newspec.full_width = fit_full_width;
         newspec.height = newspec.full_height = fit_full_height;
         newspec.x = newspec.full_x = fit_full_x;
         newspec.y = newspec.full_y = fit_full_y;
-        (*R)(s,0).reset (newspec);
-        ImageBufAlgo::fit ((*R)(s,0), (*A)(s,0), filtername, 0.0f, exact);
-        R->update_spec_from_imagebuf (s, 0);
+        (*R)(s, 0).reset(newspec);
+        ImageBufAlgo::fit((*R)(s, 0), (*A)(s, 0), filtername, 0.0f, exact);
+        R->update_spec_from_imagebuf(s, 0);
     }
     ot.pop();
-    ot.push (R);
-    A = ot.top ();
-    Aspec = A->spec(0,0);
+    ot.push(R);
+    A     = ot.top();
+    Aspec = A->spec(0, 0);
 
 #else
     // Old version: do all the fit logic here. Eventually delete this.
     // Leave for now because it makes it easy to check that we got the
     // same results.
-    ImageBuf::WrapMode wrap = ImageBuf::WrapMode_from_string (options["wrap"]);
+    ImageBuf::WrapMode wrap = ImageBuf::WrapMode_from_string(options["wrap"]);
 
     // Compute scaling factors and use action_resize to do the heavy lifting
-    float oldaspect = float(Aspec->full_width) / Aspec->full_height;
-    float newaspect = float(fit_full_width) / fit_full_height;
-    int resize_full_width = fit_full_width;
+    float oldaspect        = float(Aspec->full_width) / Aspec->full_height;
+    float newaspect        = float(fit_full_width) / fit_full_height;
+    int resize_full_width  = fit_full_width;
     int resize_full_height = fit_full_height;
     int xoffset = 0, yoffset = 0;
     float xoff = 0.0f, yoff = 0.0f;
@@ -3408,13 +3522,13 @@ action_fit (int argc, const char *argv[])
 
     if (newaspect >= oldaspect) {  // same or wider than original
         resize_full_width = int(resize_full_height * oldaspect + 0.5f);
-        xoffset = (fit_full_width - resize_full_width) / 2;
-        scale = float(fit_full_height) / float(Aspec->full_height);
+        xoffset           = (fit_full_width - resize_full_width) / 2;
+        scale             = float(fit_full_height) / float(Aspec->full_height);
         xoff = float(fit_full_width - scale * Aspec->full_width) / 2.0f;
     } else {  // narrower than original
         resize_full_height = int(resize_full_width / oldaspect + 0.5f);
-        yoffset = (fit_full_height - resize_full_height) / 2;
-        scale = float(fit_full_width) / float(Aspec->full_width);
+        yoffset            = (fit_full_height - resize_full_height) / 2;
+        scale              = float(fit_full_width) / float(Aspec->full_width);
         yoff = float(fit_full_height - scale * Aspec->full_height) / 2.0f;
     }
 
@@ -3424,7 +3538,8 @@ action_fit (int argc, const char *argv[])
                                        Aspec->full_x, Aspec->full_y)
                   << " into "
                   << format_resolution(fit_full_width, fit_full_height,
-                                       fit_full_x, fit_full_y) << "\n";
+                                       fit_full_x, fit_full_y)
+                  << "\n";
         std::cout << "  Fit scale factor " << scale << "\n";
     }
 
@@ -3433,69 +3548,69 @@ action_fit (int argc, const char *argv[])
         // ratio and exactly centers the padded image, but might make the
         // edges of the resized area blurry because it's not a whole number
         // of pixels.
-        Imath::M33f M (scale, 0.0f,  0.0f,
-                       0.0f,  scale, 0.0f,
-                       xoff,  yoff,  1.0f);
+        Imath::M33f M(scale, 0.0f, 0.0f, 0.0f, scale, 0.0f, xoff, yoff, 1.0f);
         if (ot.debug)
             std::cout << "   Fit performing warp with " << M << "\n";
         int subimages = allsubimages ? A->subimages() : 1;
-        ImageRecRef R (new ImageRec (A->name(), subimages));
+        ImageRecRef R(new ImageRec(A->name(), subimages));
         for (int s = 0; s < subimages; ++s) {
-            ImageSpec newspec = (*A)(s,0).spec();
+            ImageSpec newspec = (*A)(s, 0).spec();
             newspec.width = newspec.full_width = fit_full_width;
             newspec.height = newspec.full_height = fit_full_height;
             newspec.x = newspec.full_x = fit_full_x;
             newspec.y = newspec.full_y = fit_full_y;
-            (*R)(s,0).reset (newspec);
-            ImageBufAlgo::warp ((*R)(s,0), (*A)(s,0), M, filtername, 0.0f,
-                                false, wrap);
-            R->update_spec_from_imagebuf (s, 0);
+            (*R)(s, 0).reset(newspec);
+            ImageBufAlgo::warp((*R)(s, 0), (*A)(s, 0), M, filtername, 0.0f,
+                               false, wrap);
+            R->update_spec_from_imagebuf(s, 0);
         }
         ot.pop();
-        ot.push (R);
-        A = ot.top ();
-        Aspec = A->spec(0,0);
+        ot.push(R);
+        A     = ot.top();
+        Aspec = A->spec(0, 0);
     } else {
         // Full pixel resize -- gives the sharpest result, but for odd-sized
         // destination resolution, may not be exactly centered and will only
         // preserve the aspect ratio to the nearest integer pixel size.
-        if (resize_full_width != Aspec->full_width ||
-            resize_full_height != Aspec->full_height ||
-            fit_full_x != Aspec->full_x || fit_full_y != Aspec->full_y) {
-            std::string resize = format_resolution (resize_full_width,
-                                                    resize_full_height,
-                                                    0, 0);
+        if (resize_full_width != Aspec->full_width
+            || resize_full_height != Aspec->full_height
+            || fit_full_x != Aspec->full_x || fit_full_y != Aspec->full_y) {
+            std::string resize = format_resolution(resize_full_width,
+                                                   resize_full_height, 0, 0);
             if (ot.debug)
                 std::cout << "    Resizing to " << resize << "\n";
             std::string command = "resize";
             if (filtername.size())
-                command += Strutil::format (":filter=%s", filtername);
-            command += Strutil::format (":allsubimages=%d", allsubimages);
-            const char *newargv[2] = { command.c_str(), resize.c_str() };
-            action_resize (2, newargv);
-            A = ot.top ();
-            Aspec = A->spec(0,0);
+                command += Strutil::format(":filter=%s", filtername);
+            command += Strutil::format(":allsubimages=%d", allsubimages);
+            const char* newargv[2] = { command.c_str(), resize.c_str() };
+            action_resize(2, newargv);
+            A     = ot.top();
+            Aspec = A->spec(0, 0);
             // Now A,Aspec are for the NEW resized top of stack
         } else {
             if (ot.debug)
                 std::cout << "   no need to do a resize\n";
         }
-        A->spec(0,0)->full_width = (*A)(0,0).specmod().full_width = fit_full_width;
-        A->spec(0,0)->full_height = (*A)(0,0).specmod().full_height = fit_full_height;
-        A->spec(0,0)->full_x = (*A)(0,0).specmod().full_x = fit_full_x;
-        A->spec(0,0)->full_y = (*A)(0,0).specmod().full_y = fit_full_y;
-        A->spec(0,0)->x = (*A)(0,0).specmod().x = xoffset;
-        A->spec(0,0)->y = (*A)(0,0).specmod().y = yoffset;
+        A->spec(0, 0)->full_width = (*A)(0, 0).specmod().full_width
+            = fit_full_width;
+        A->spec(0, 0)->full_height = (*A)(0, 0).specmod().full_height
+            = fit_full_height;
+        A->spec(0, 0)->full_x = (*A)(0, 0).specmod().full_x = fit_full_x;
+        A->spec(0, 0)->full_y = (*A)(0, 0).specmod().full_y = fit_full_y;
+        A->spec(0, 0)->x = (*A)(0, 0).specmod().x = xoffset;
+        A->spec(0, 0)->y = (*A)(0, 0).specmod().y = yoffset;
     }
 #endif
 
-    if (pad && (fit_full_width != Aspec->width ||
-                fit_full_height != Aspec->height)) {
+    if (pad
+        && (fit_full_width != Aspec->width
+            || fit_full_height != Aspec->height)) {
         // Needs padding
         if (ot.debug)
             std::cout << "   performing a croptofull\n";
-        const char *argv[] = { "croptofull" };
-        action_croptofull (1, argv);
+        const char* argv[] = { "croptofull" };
+        action_croptofull(1, argv);
     }
 
     ot.function_times[command] += timer();
@@ -3506,36 +3621,39 @@ action_fit (int argc, const char *argv[])
 
 
 static int
-action_pixelaspect (int argc, const char *argv[])
+action_pixelaspect(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_pixelaspect, argc, argv))
+    if (ot.postpone_callback(1, action_pixelaspect, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
+    Timer timer(ot.enable_function_timing);
     bool old_enable_function_timing = ot.enable_function_timing;
-    ot.enable_function_timing = false;
-    string_view command = ot.express (argv[0]);
+    ot.enable_function_timing       = false;
+    string_view command             = ot.express(argv[0]);
 
-    float new_paspect = Strutil::from_string<float> (ot.express (argv[1]));
+    float new_paspect = Strutil::from_string<float>(ot.express(argv[1]));
     if (new_paspect <= 0.0f) {
-        ot.error (command, Strutil::format ("Invalid pixel aspect ratio '%g'", new_paspect));
+        ot.error(command, Strutil::format("Invalid pixel aspect ratio '%g'",
+                                          new_paspect));
         return 0;
     }
 
     // Examine the top of stack
     ImageRecRef A = ot.top();
-    ot.read ();
-    const ImageSpec *Aspec = A->spec(0,0);
+    ot.read();
+    const ImageSpec* Aspec = A->spec(0, 0);
 
     // Get the current pixel aspect ratio
-    float paspect = Aspec->get_float_attribute ("PixelAspectRatio", 1.0);
+    float paspect = Aspec->get_float_attribute("PixelAspectRatio", 1.0);
     if (paspect <= 0.0f) {
-        ot.error (command, Strutil::format ("Invalid pixel aspect ratio '%g' in source", paspect));
+        ot.error(command,
+                 Strutil::format("Invalid pixel aspect ratio '%g' in source",
+                                 paspect));
         return 0;
     }
 
     // Get the current (if any) XResolution/YResolution attributes
-    float xres = Aspec->get_float_attribute( "XResolution", 0.0);
-    float yres = Aspec->get_float_attribute( "YResolution", 0.0);
+    float xres = Aspec->get_float_attribute("XResolution", 0.0);
+    float yres = Aspec->get_float_attribute("YResolution", 0.0);
 
     // Compute scaling factors and use action_resize to do the heavy lifting
     float scaleX = 1.0f;
@@ -3545,46 +3663,46 @@ action_pixelaspect (int argc, const char *argv[])
     if (factor > 1.0)
         scaleX = factor;
     else if (factor < 1.0)
-        scaleY = 1.0/factor;
+        scaleY = 1.0 / factor;
 
-    int scale_full_width = (int)(Aspec->full_width * scaleX + 0.5f);
+    int scale_full_width  = (int)(Aspec->full_width * scaleX + 0.5f);
     int scale_full_height = (int)(Aspec->full_height * scaleY + 0.5f);
 
     float scale_xres = xres * scaleX;
     float scale_yres = yres * scaleY;
 
-    std::map<std::string,std::string> options;
-    ot.extract_options (options, command);
+    std::map<std::string, std::string> options;
+    ot.extract_options(options, command);
     string_view filtername = options["filter"];
 
     if (ot.debug) {
         std::cout << "  Scaling "
                   << format_resolution(Aspec->full_width, Aspec->full_height,
                                        Aspec->full_x, Aspec->full_y)
-                  << " with a pixel aspect ratio of " << paspect
-                  << " to "
+                  << " with a pixel aspect ratio of " << paspect << " to "
                   << format_resolution(scale_full_width, scale_full_height,
                                        Aspec->full_x, Aspec->full_y)
                   << "\n";
     }
-    if (scale_full_width != Aspec->full_width ||
-        scale_full_height != Aspec->full_height) {
-        std::string resize = format_resolution(scale_full_width,
-                                               scale_full_height,
-                                               0, 0);
+    if (scale_full_width != Aspec->full_width
+        || scale_full_height != Aspec->full_height) {
+        std::string resize  = format_resolution(scale_full_width,
+                                               scale_full_height, 0, 0);
         std::string command = "resize";
         if (filtername.size())
-            command += Strutil::format (":filter=%s", filtername);
-        const char *newargv[2] = { command.c_str(), resize.c_str() };
-        action_resize (2, newargv);
-        A = ot.top ();
-        A->spec(0,0)->full_width = (*A)(0,0).specmod().full_width = scale_full_width;
-        A->spec(0,0)->full_height = (*A)(0,0).specmod().full_height = scale_full_height;
-        A->spec(0,0)->attribute ("PixelAspectRatio", new_paspect);
+            command += Strutil::format(":filter=%s", filtername);
+        const char* newargv[2] = { command.c_str(), resize.c_str() };
+        action_resize(2, newargv);
+        A                         = ot.top();
+        A->spec(0, 0)->full_width = (*A)(0, 0).specmod().full_width
+            = scale_full_width;
+        A->spec(0, 0)->full_height = (*A)(0, 0).specmod().full_height
+            = scale_full_height;
+        A->spec(0, 0)->attribute("PixelAspectRatio", new_paspect);
         if (xres)
-            A->spec(0,0)->attribute ("XResolution", scale_xres);
+            A->spec(0, 0)->attribute("XResolution", scale_xres);
         if (yres)
-            A->spec(0,0)->attribute ("YResolution", scale_yres);
+            A->spec(0, 0)->attribute("YResolution", scale_yres);
         // Now A,Aspec are for the NEW resized top of stack
     }
 
@@ -3597,145 +3715,162 @@ action_pixelaspect (int argc, const char *argv[])
 
 class OpConvolve : public OiiotoolOp {
 public:
-    OpConvolve (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 2) {}
-    virtual int impl (ImageBuf **img) {
-        return ImageBufAlgo::convolve (*img[0], *img[1], *img[2]);
+    OpConvolve(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 2)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
+        return ImageBufAlgo::convolve(*img[0], *img[1], *img[2]);
     }
 };
 
-OP_CUSTOMCLASS (convolve, OpConvolve, 2);
-
+OP_CUSTOMCLASS(convolve, OpConvolve, 2);
 
 
 
 class OpBlur : public OiiotoolOp {
 public:
-    OpBlur (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) {}
-    virtual void option_defaults () {
-        options["kernel"] = "gaussian";
-    };
-    virtual int impl (ImageBuf **img) {
+    OpBlur(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual void option_defaults() { options["kernel"] = "gaussian"; };
+    virtual int impl(ImageBuf** img)
+    {
         string_view kernopt = options["kernel"];
         float w = 1.0f, h = 1.0f;
-        if (sscanf (args[1].c_str(), "%fx%f", &w, &h) != 2)
-            ot.error (opname(), Strutil::format ("Unknown size %s", args[1]));
+        if (sscanf(args[1].c_str(), "%fx%f", &w, &h) != 2)
+            ot.error(opname(), Strutil::format("Unknown size %s", args[1]));
         ImageBuf Kernel;
-        if (! ImageBufAlgo::make_kernel (Kernel, kernopt, w, h))
-            ot.error (opname(), Kernel.geterror());
-        return ImageBufAlgo::convolve (*img[0], *img[1], Kernel);
+        if (!ImageBufAlgo::make_kernel(Kernel, kernopt, w, h))
+            ot.error(opname(), Kernel.geterror());
+        return ImageBufAlgo::convolve(*img[0], *img[1], Kernel);
     }
 };
 
-OP_CUSTOMCLASS (blur, OpBlur, 1);
-
+OP_CUSTOMCLASS(blur, OpBlur, 1);
 
 
 
 class OpMedian : public OiiotoolOp {
 public:
-    OpMedian (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) { }
-    virtual int impl (ImageBuf **img) {
-        string_view size (args[1]);
+    OpMedian(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
+        string_view size(args[1]);
         int w = 3, h = 3;
-        if (sscanf (size.c_str(), "%dx%d", &w, &h) != 2)
-            ot.error (opname(), Strutil::format ("Unknown size %s", size));
-        return ImageBufAlgo::median_filter (*img[0], *img[1], w, h);
+        if (sscanf(size.c_str(), "%dx%d", &w, &h) != 2)
+            ot.error(opname(), Strutil::format("Unknown size %s", size));
+        return ImageBufAlgo::median_filter(*img[0], *img[1], w, h);
     }
 };
 
-OP_CUSTOMCLASS (median, OpMedian, 1);
+OP_CUSTOMCLASS(median, OpMedian, 1);
 
 
 
 class OpDilate : public OiiotoolOp {
 public:
-    OpDilate (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) { }
-    virtual int impl (ImageBuf **img) {
-        string_view size (args[1]);
+    OpDilate(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
+        string_view size(args[1]);
         int w = 3, h = 3;
-        if (sscanf (size.c_str(), "%dx%d", &w, &h) != 2)
-            ot.error (opname(), Strutil::format ("Unknown size %s", size));
-        return ImageBufAlgo::dilate (*img[0], *img[1], w, h);
+        if (sscanf(size.c_str(), "%dx%d", &w, &h) != 2)
+            ot.error(opname(), Strutil::format("Unknown size %s", size));
+        return ImageBufAlgo::dilate(*img[0], *img[1], w, h);
     }
 };
 
-OP_CUSTOMCLASS (dilate, OpDilate, 1);
+OP_CUSTOMCLASS(dilate, OpDilate, 1);
 
 
 
 class OpErode : public OiiotoolOp {
 public:
-    OpErode (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) { }
-    virtual int impl (ImageBuf **img) {
-        string_view size (args[1]);
+    OpErode(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
+        string_view size(args[1]);
         int w = 3, h = 3;
-        if (sscanf (size.c_str(), "%dx%d", &w, &h) != 2)
-            ot.error (opname(), Strutil::format ("Unknown size %s", size));
-        return ImageBufAlgo::erode (*img[0], *img[1], w, h);
+        if (sscanf(size.c_str(), "%dx%d", &w, &h) != 2)
+            ot.error(opname(), Strutil::format("Unknown size %s", size));
+        return ImageBufAlgo::erode(*img[0], *img[1], w, h);
     }
 };
 
-OP_CUSTOMCLASS (erode, OpErode, 1);
+OP_CUSTOMCLASS(erode, OpErode, 1);
 
 
 
 class OpUnsharp : public OiiotoolOp {
 public:
-    OpUnsharp (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) { }
-    virtual void option_defaults () {
-        options["kernel"] = "gaussian";
-        options["width"] = "3";
-        options["contrast"] = "1";
+    OpUnsharp(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual void option_defaults()
+    {
+        options["kernel"]    = "gaussian";
+        options["width"]     = "3";
+        options["contrast"]  = "1";
         options["threshold"] = "0";
     }
-    virtual int impl (ImageBuf **img) {
+    virtual int impl(ImageBuf** img)
+    {
         string_view kernel = options["kernel"];
-        float width = Strutil::from_string<float> (options["width"]);
-        float contrast = Strutil::from_string<float> (options["contrast"]);
-        float threshold = Strutil::from_string<float> (options["threshold"]);
-        return ImageBufAlgo::unsharp_mask (*img[0], *img[1], kernel,
-                                           width, contrast, threshold);
+        float width        = Strutil::from_string<float>(options["width"]);
+        float contrast     = Strutil::from_string<float>(options["contrast"]);
+        float threshold    = Strutil::from_string<float>(options["threshold"]);
+        return ImageBufAlgo::unsharp_mask(*img[0], *img[1], kernel, width,
+                                          contrast, threshold);
     }
 };
 
-OP_CUSTOMCLASS (unsharp, OpUnsharp, 1);
+OP_CUSTOMCLASS(unsharp, OpUnsharp, 1);
 
 
 class OpLaplacian : public OiiotoolOp {
 public:
-    OpLaplacian (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) { }
-    virtual int impl (ImageBuf **img) {
-        return ImageBufAlgo::laplacian (*img[0], *img[1]);
+    OpLaplacian(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
+        return ImageBufAlgo::laplacian(*img[0], *img[1]);
     }
 };
 
-OP_CUSTOMCLASS (laplacian, OpLaplacian, 1);
+OP_CUSTOMCLASS(laplacian, OpLaplacian, 1);
 
 
 
-
-UNARY_IMAGE_OP (fft, ImageBufAlgo::fft);
-UNARY_IMAGE_OP (ifft, ImageBufAlgo::ifft);
-UNARY_IMAGE_OP (polar, ImageBufAlgo::complex_to_polar);
-UNARY_IMAGE_OP (unpolar, ImageBufAlgo::polar_to_complex);
+UNARY_IMAGE_OP(fft, ImageBufAlgo::fft);
+UNARY_IMAGE_OP(ifft, ImageBufAlgo::ifft);
+UNARY_IMAGE_OP(polar, ImageBufAlgo::complex_to_polar);
+UNARY_IMAGE_OP(unpolar, ImageBufAlgo::polar_to_complex);
 
 
 
 int
-action_fixnan (int argc, const char *argv[])
+action_fixnan(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_fixnan, argc, argv))
+    if (ot.postpone_callback(1, action_fixnan, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command  = ot.express (argv[0]);
-    string_view modename = ot.express (argv[1]);
+    Timer timer(ot.enable_function_timing);
+    string_view command  = ot.express(argv[0]);
+    string_view modename = ot.express(argv[1]);
 
     NonFiniteFixMode mode = NONFINITE_BOX3;
     if (modename == "black")
@@ -3745,24 +3880,28 @@ action_fixnan (int argc, const char *argv[])
     else if (modename == "error")
         mode = NONFINITE_ERROR;
     else {
-        ot.warning (argv[0], Strutil::format ("\"%s\" not recognized. Valid choices: black, box3, error", modename));
+        ot.warning(
+            argv[0],
+            Strutil::format(
+                "\"%s\" not recognized. Valid choices: black, box3, error",
+                modename));
     }
-    ot.read ();
+    ot.read();
     ImageRecRef A = ot.pop();
-    ot.push (new ImageRec (*A, ot.allsubimages ? -1 : 0,
-                           ot.allsubimages ? -1 : 0, true, false));
+    ot.push(new ImageRec(*A, ot.allsubimages ? -1 : 0, ot.allsubimages ? -1 : 0,
+                         true, false));
     int subimages = ot.curimg->subimages();
-    for (int s = 0;  s < subimages;  ++s) {
+    for (int s = 0; s < subimages; ++s) {
         int miplevels = ot.curimg->miplevels(s);
-        for (int m = 0;  m < miplevels;  ++m) {
-            const ImageBuf &Aib ((*A)(s,m));
-            ImageBuf &Rib ((*ot.curimg)(s,m));
-            bool ok = ImageBufAlgo::fixNonFinite (Rib, Aib, mode);
-            if (! ok)
-                ot.error (command, Rib.geterror());
+        for (int m = 0; m < miplevels; ++m) {
+            const ImageBuf& Aib((*A)(s, m));
+            ImageBuf& Rib((*ot.curimg)(s, m));
+            bool ok = ImageBufAlgo::fixNonFinite(Rib, Aib, mode);
+            if (!ok)
+                ot.error(command, Rib.geterror());
         }
     }
-             
+
     ot.function_times[command] += timer();
     return 0;
 }
@@ -3770,24 +3909,24 @@ action_fixnan (int argc, const char *argv[])
 
 
 static int
-action_fillholes (int argc, const char *argv[])
+action_fillholes(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_fillholes, argc, argv))
+    if (ot.postpone_callback(1, action_fillholes, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
 
     // Read and copy the top-of-stack image
-    ImageRecRef A (ot.pop());
-    ot.read (A);
-    ImageSpec spec = (*A)(0,0).spec();
-    set_roi (spec, roi_union (get_roi(spec), get_roi_full(spec)));
-    ImageRecRef B (new ImageRec("filled", spec, ot.imagecache));
-    ot.push (B);
-    ImageBuf &Rib ((*B)(0,0));
-    bool ok = ImageBufAlgo::fillholes_pushpull (Rib, (*A)(0,0));
-    if (! ok)
-        ot.error (command, Rib.geterror());
+    ImageRecRef A(ot.pop());
+    ot.read(A);
+    ImageSpec spec = (*A)(0, 0).spec();
+    set_roi(spec, roi_union(get_roi(spec), get_roi_full(spec)));
+    ImageRecRef B(new ImageRec("filled", spec, ot.imagecache));
+    ot.push(B);
+    ImageBuf& Rib((*B)(0, 0));
+    bool ok = ImageBufAlgo::fillholes_pushpull(Rib, (*A)(0, 0));
+    if (!ok)
+        ot.error(command, Rib.geterror());
 
     ot.function_times[command] += timer();
     return 0;
@@ -3796,31 +3935,31 @@ action_fillholes (int argc, const char *argv[])
 
 
 static int
-action_paste (int argc, const char *argv[])
+action_paste(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (2, action_paste, argc, argv))
+    if (ot.postpone_callback(2, action_paste, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command  = ot.express (argv[0]);
-    string_view position = ot.express (argv[1]);
+    Timer timer(ot.enable_function_timing);
+    string_view command  = ot.express(argv[0]);
+    string_view position = ot.express(argv[1]);
 
-    ImageRecRef BG (ot.pop());
-    ImageRecRef FG (ot.pop());
-    ot.read (BG);
-    ot.read (FG);
+    ImageRecRef BG(ot.pop());
+    ImageRecRef FG(ot.pop());
+    ot.read(BG);
+    ot.read(FG);
 
     int x = 0, y = 0;
-    if (sscanf (position.c_str(), "%d%d", &x, &y) != 2) {
-        ot.error (command, Strutil::format ("Invalid offset '%s'", position));
+    if (sscanf(position.c_str(), "%d%d", &x, &y) != 2) {
+        ot.error(command, Strutil::format("Invalid offset '%s'", position));
         return 0;
     }
 
-    ImageRecRef R (new ImageRec (*BG, 0, 0, true /* writable*/, true /* copy */));
-    ot.push (R);
+    ImageRecRef R(new ImageRec(*BG, 0, 0, true /* writable*/, true /* copy */));
+    ot.push(R);
 
-    bool ok = ImageBufAlgo::paste ((*R)(), x, y, 0, 0, (*FG)());
-    if (! ok)
-        ot.error (command, (*R)().geterror());
+    bool ok = ImageBufAlgo::paste((*R)(), x, y, 0, 0, (*FG)());
+    if (!ok)
+        ot.error(command, (*R)().geterror());
     ot.function_times[command] += timer();
     return 0;
 }
@@ -3828,18 +3967,18 @@ action_paste (int argc, const char *argv[])
 
 
 static int
-action_mosaic (int argc, const char *argv[])
+action_mosaic(int argc, const char* argv[])
 {
-    Timer timer (ot.enable_function_timing);
+    Timer timer(ot.enable_function_timing);
 
     // Mosaic is tricky. We have to parse the argument before we know
     // how many images it wants to pull off the stack.
-    string_view command = ot.express (argv[0]);
-    string_view size    = ot.express (argv[1]);
+    string_view command = ot.express(argv[0]);
+    string_view size    = ot.express(argv[1]);
     int ximages = 0, yimages = 0;
-    if (sscanf (size.c_str(), "%dx%d", &ximages, &yimages) != 2 
-          || ximages < 1 || yimages < 1) {
-        ot.error (command, Strutil::format ("Invalid size '%s'", size));
+    if (sscanf(size.c_str(), "%dx%d", &ximages, &yimages) != 2 || ximages < 1
+        || yimages < 1) {
+        ot.error(command, Strutil::format("Invalid size '%s'", size));
         return 0;
     }
     int nimages = ximages * yimages;
@@ -3847,45 +3986,45 @@ action_mosaic (int argc, const char *argv[])
     // Make the matrix complete with placeholder images
     ImageRecRef blank_img;
     while (ot.image_stack_depth() < nimages) {
-        if (! blank_img) {
-            ImageSpec blankspec (1, 1, 1, TypeDesc::UINT8);
-            blank_img.reset (new ImageRec ("blank", blankspec, ot.imagecache));
-            ImageBufAlgo::zero ((*blank_img)());
+        if (!blank_img) {
+            ImageSpec blankspec(1, 1, 1, TypeDesc::UINT8);
+            blank_img.reset(new ImageRec("blank", blankspec, ot.imagecache));
+            ImageBufAlgo::zero((*blank_img)());
         }
-        ot.push (blank_img);
+        ot.push(blank_img);
     }
 
     int widest = 0, highest = 0, nchannels = 0;
-    std::vector<ImageRecRef> images (nimages);
-    for (int i = nimages-1;  i >= 0;  --i) {
+    std::vector<ImageRecRef> images(nimages);
+    for (int i = nimages - 1; i >= 0; --i) {
         ImageRecRef img = ot.pop();
-        images[i] = img;
-        ot.read (img);
-        widest = std::max (widest, img->spec()->full_width);
-        highest = std::max (highest, img->spec()->full_height);
-        nchannels = std::max (nchannels, img->spec()->nchannels);
+        images[i]       = img;
+        ot.read(img);
+        widest    = std::max(widest, img->spec()->full_width);
+        highest   = std::max(highest, img->spec()->full_height);
+        nchannels = std::max(nchannels, img->spec()->nchannels);
     }
 
-    std::map<std::string,std::string> options;
+    std::map<std::string, std::string> options;
     options["pad"] = "0";
-    ot.extract_options (options, command);
-    int pad = Strutil::stoi (options["pad"]);
+    ot.extract_options(options, command);
+    int pad = Strutil::stoi(options["pad"]);
 
-    ImageSpec Rspec (ximages*widest + (ximages-1)*pad,
-                     yimages*highest + (yimages-1)*pad,
-                     nchannels, TypeDesc::FLOAT);
-    ImageRecRef R (new ImageRec ("mosaic", Rspec, ot.imagecache));
-    ot.push (R);
+    ImageSpec Rspec(ximages * widest + (ximages - 1) * pad,
+                    yimages * highest + (yimages - 1) * pad, nchannels,
+                    TypeDesc::FLOAT);
+    ImageRecRef R(new ImageRec("mosaic", Rspec, ot.imagecache));
+    ot.push(R);
 
-    ImageBufAlgo::zero ((*R)());
-    for (int j = 0;  j < yimages;  ++j) {
+    ImageBufAlgo::zero((*R)());
+    for (int j = 0; j < yimages; ++j) {
         int y = j * (highest + pad);
-        for (int i = 0;  i < ximages;  ++i) {
-            int x = i * (widest + pad);
-            bool ok = ImageBufAlgo::paste ((*R)(), x, y, 0, 0,
-                                           (*images[j*ximages+i])(0));
-            if (! ok)
-                ot.error (command, (*R)().geterror());
+        for (int i = 0; i < ximages; ++i) {
+            int x   = i * (widest + pad);
+            bool ok = ImageBufAlgo::paste((*R)(), x, y, 0, 0,
+                                          (*images[j * ximages + i])(0));
+            if (!ok)
+                ot.error(command, (*R)().geterror());
         }
     }
 
@@ -3895,7 +4034,7 @@ action_mosaic (int argc, const char *argv[])
 
 
 
-BINARY_IMAGE_OP (over, ImageBufAlgo::over);
+BINARY_IMAGE_OP(over, ImageBufAlgo::over);
 
 
 #if 0
@@ -3917,43 +4056,43 @@ OP_CUSTOMCLASS (zover, OpZover, 1);
 #else
 
 static int
-action_zover (int argc, const char *argv[])
+action_zover(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (2, action_zover, argc, argv))
+    if (ot.postpone_callback(2, action_zover, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
 
     // Get optional flags
     bool z_zeroisinf = false;
-    std::string cmd = argv[0];
+    std::string cmd  = argv[0];
     size_t pos;
     while ((pos = cmd.find_first_of(":")) != std::string::npos) {
-        cmd = cmd.substr (pos+1, std::string::npos);
-        if (Strutil::istarts_with(cmd,"zeroisinf="))
-            z_zeroisinf = (atoi(cmd.c_str()+10) != 0);
+        cmd = cmd.substr(pos + 1, std::string::npos);
+        if (Strutil::istarts_with(cmd, "zeroisinf="))
+            z_zeroisinf = (atoi(cmd.c_str() + 10) != 0);
     }
 
-    ImageRecRef B (ot.pop());
-    ImageRecRef A (ot.pop());
-    ot.read (A);
-    ot.read (B);
-    const ImageBuf &Aib ((*A)());
-    const ImageBuf &Bib ((*B)());
-    const ImageSpec &specA = Aib.spec();
-    const ImageSpec &specB = Bib.spec();
+    ImageRecRef B(ot.pop());
+    ImageRecRef A(ot.pop());
+    ot.read(A);
+    ot.read(B);
+    const ImageBuf& Aib((*A)());
+    const ImageBuf& Bib((*B)());
+    const ImageSpec& specA = Aib.spec();
+    const ImageSpec& specB = Bib.spec();
 
     // Create output image specification.
     ImageSpec specR = specA;
-    set_roi (specR, roi_union (get_roi(specA), get_roi(specB)));
-    set_roi_full (specR, roi_union (get_roi_full(specA), get_roi_full(specB)));
+    set_roi(specR, roi_union(get_roi(specA), get_roi(specB)));
+    set_roi_full(specR, roi_union(get_roi_full(specA), get_roi_full(specB)));
 
-    ot.push (new ImageRec ("zover", specR, ot.imagecache));
-    ImageBuf &Rib ((*ot.curimg)());
+    ot.push(new ImageRec("zover", specR, ot.imagecache));
+    ImageBuf& Rib((*ot.curimg)());
 
-    bool ok = ImageBufAlgo::zover (Rib, Aib, Bib, z_zeroisinf);
-    if (! ok)
-        ot.error (command, Rib.geterror());
+    bool ok = ImageBufAlgo::zover(Rib, Aib, Bib, z_zeroisinf);
+    if (!ok)
+        ot.error(command, Rib.geterror());
     ot.function_times[command] += timer();
     return 0;
 }
@@ -3963,108 +4102,116 @@ action_zover (int argc, const char *argv[])
 
 class OpDeepMerge : public OiiotoolOp {
 public:
-    OpDeepMerge (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 2) {}
-    virtual int impl (ImageBuf **img) {
-        return ImageBufAlgo::deep_merge (*img[0], *img[1], *img[2]);
+    OpDeepMerge(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 2)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
+        return ImageBufAlgo::deep_merge(*img[0], *img[1], *img[2]);
     }
 };
 
-OP_CUSTOMCLASS (deepmerge, OpDeepMerge, 2);
+OP_CUSTOMCLASS(deepmerge, OpDeepMerge, 2);
 
 
 
 class OpDeepHoldout : public OiiotoolOp {
 public:
-    OpDeepHoldout (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 2) {}
-    virtual int impl (ImageBuf **img) {
-        return ImageBufAlgo::deep_holdout (*img[0], *img[1], *img[2]);
+    OpDeepHoldout(Oiiotool& ot, string_view opname, int argc,
+                  const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 2)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
+        return ImageBufAlgo::deep_holdout(*img[0], *img[1], *img[2]);
     }
 };
 
-OP_CUSTOMCLASS (deepholdout, OpDeepHoldout, 2);
+OP_CUSTOMCLASS(deepholdout, OpDeepHoldout, 2);
 
 
 
 class OpDeepen : public OiiotoolOp {
 public:
-    OpDeepen (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) {}
-    virtual void option_defaults () { options["z"] = 1.0; }
-    virtual int impl (ImageBuf **img) {
+    OpDeepen(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual void option_defaults() { options["z"] = 1.0; }
+    virtual int impl(ImageBuf** img)
+    {
         float z = Strutil::from_string<float>(options["z"]);
-        return ImageBufAlgo::deepen (*img[0], *img[1], z);
+        return ImageBufAlgo::deepen(*img[0], *img[1], z);
     }
 };
 
-OP_CUSTOMCLASS (deepen, OpDeepen, 1);
+OP_CUSTOMCLASS(deepen, OpDeepen, 1);
 
 
 
-UNARY_IMAGE_OP (flatten, ImageBufAlgo::flatten);
+UNARY_IMAGE_OP(flatten, ImageBufAlgo::flatten);
 
 
 
 static int
-action_fill (int argc, const char *argv[])
+action_fill(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_fill, argc, argv))
+    if (ot.postpone_callback(1, action_fill, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
-    string_view size    = ot.express (argv[1]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
+    string_view size    = ot.express(argv[1]);
 
     // Read and copy the top-of-stack image
-    ImageRecRef A (ot.pop());
-    ot.read (A);
-    ot.push (new ImageRec (*A, 0, 0, true, true /*copy_pixels*/));
-    ImageBuf &Rib ((*ot.curimg)(0,0));
-    const ImageSpec &Rspec = Rib.spec();
+    ImageRecRef A(ot.pop());
+    ot.read(A);
+    ot.push(new ImageRec(*A, 0, 0, true, true /*copy_pixels*/));
+    ImageBuf& Rib((*ot.curimg)(0, 0));
+    const ImageSpec& Rspec = Rib.spec();
 
     int w = Rib.spec().width, h = Rib.spec().height;
     int x = Rib.spec().x, y = Rib.spec().y;
-    if (! ot.adjust_geometry (argv[0], w, h, x, y, size.c_str(), true)) {
+    if (!ot.adjust_geometry(argv[0], w, h, x, y, size.c_str(), true)) {
         return 0;
     }
 
-    std::vector<float> topleft (Rspec.nchannels, 1.0f);
-    std::vector<float> topright (Rspec.nchannels, 1.0f);
-    std::vector<float> bottomleft (Rspec.nchannels, 1.0f);
-    std::vector<float> bottomright (Rspec.nchannels, 1.0f);
+    std::vector<float> topleft(Rspec.nchannels, 1.0f);
+    std::vector<float> topright(Rspec.nchannels, 1.0f);
+    std::vector<float> bottomleft(Rspec.nchannels, 1.0f);
+    std::vector<float> bottomright(Rspec.nchannels, 1.0f);
 
-    std::map<std::string,std::string> options;
-    ot.extract_options (options, command);
+    std::map<std::string, std::string> options;
+    ot.extract_options(options, command);
 
     bool ok = true;
-    if (Strutil::extract_from_list_string (topleft,     options["topleft"]) &&
-        Strutil::extract_from_list_string (topright,    options["topright"]) &&
-        Strutil::extract_from_list_string (bottomleft,  options["bottomleft"]) &&
-        Strutil::extract_from_list_string (bottomright, options["bottomright"])) {
-        ok = ImageBufAlgo::fill (Rib, &topleft[0], &topright[0],
-                                 &bottomleft[0], &bottomright[0],
-                                 ROI(x, x+w, y, y+h));
+    if (Strutil::extract_from_list_string(topleft, options["topleft"])
+        && Strutil::extract_from_list_string(topright, options["topright"])
+        && Strutil::extract_from_list_string(bottomleft, options["bottomleft"])
+        && Strutil::extract_from_list_string(bottomright,
+                                             options["bottomright"])) {
+        ok = ImageBufAlgo::fill(Rib, &topleft[0], &topright[0], &bottomleft[0],
+                                &bottomright[0], ROI(x, x + w, y, y + h));
+    } else if (Strutil::extract_from_list_string(topleft, options["top"])
+               && Strutil::extract_from_list_string(bottomleft,
+                                                    options["bottom"])) {
+        ok = ImageBufAlgo::fill(Rib, &topleft[0], &bottomleft[0],
+                                ROI(x, x + w, y, y + h));
+    } else if (Strutil::extract_from_list_string(topleft, options["left"])
+               && Strutil::extract_from_list_string(topright,
+                                                    options["right"])) {
+        ok = ImageBufAlgo::fill(Rib, &topleft[0], &topright[0], &topleft[0],
+                                &topright[0], ROI(x, x + w, y, y + h));
+    } else if (Strutil::extract_from_list_string(topleft, options["color"])) {
+        ok = ImageBufAlgo::fill(Rib, &topleft[0], ROI(x, x + w, y, y + h));
+    } else {
+        ot.warning(command,
+                   "No recognized fill parameters: filling with white.");
+        ok = ImageBufAlgo::fill(Rib, &topleft[0], ROI(x, x + w, y, y + h));
     }
-    else if (Strutil::extract_from_list_string (topleft,    options["top"]) &&
-             Strutil::extract_from_list_string (bottomleft, options["bottom"])) {
-        ok = ImageBufAlgo::fill (Rib, &topleft[0], &bottomleft[0],
-                                 ROI(x, x+w, y, y+h));
-    }
-    else if (Strutil::extract_from_list_string (topleft,  options["left"]) &&
-             Strutil::extract_from_list_string (topright, options["right"])) {
-        ok = ImageBufAlgo::fill (Rib, &topleft[0], &topright[0],
-                                 &topleft[0], &topright[0],
-                                 ROI(x, x+w, y, y+h));
-    }
-    else if (Strutil::extract_from_list_string (topleft, options["color"])) {
-        ok = ImageBufAlgo::fill (Rib, &topleft[0], ROI(x, x+w, y, y+h));
-    }
-    else {
-        ot.warning (command, "No recognized fill parameters: filling with white.");
-        ok = ImageBufAlgo::fill (Rib, &topleft[0], ROI(x, x+w, y, y+h));
-    }
-    if (! ok)
-        ot.error (command, Rib.geterror());
+    if (!ok)
+        ot.error(command, Rib.geterror());
 
     ot.function_times[command] += timer();
     return 0;
@@ -4073,37 +4220,38 @@ action_fill (int argc, const char *argv[])
 
 
 static int
-action_clamp (int argc, const char *argv[])
+action_clamp(int argc, const char* argv[])
 {
-    if (ot.postpone_callback (1, action_clamp, argc, argv))
+    if (ot.postpone_callback(1, action_clamp, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
 
     ImageRecRef A = ot.pop();
-    ot.read (A);
-    ImageRecRef R (new ImageRec (*A, ot.allsubimages ? -1 : 0,
-                                 ot.allsubimages ? -1 : 0,
-                                 true /*writeable*/, false /*copy_pixels*/));
-    ot.push (R);
-    for (int s = 0, subimages = R->subimages();  s < subimages;  ++s) {
-        int nchans = (*R)(s,0).nchannels();
+    ot.read(A);
+    ImageRecRef R(new ImageRec(*A, ot.allsubimages ? -1 : 0,
+                               ot.allsubimages ? -1 : 0, true /*writeable*/,
+                               false /*copy_pixels*/));
+    ot.push(R);
+    for (int s = 0, subimages = R->subimages(); s < subimages; ++s) {
+        int nchans      = (*R)(s, 0).nchannels();
         const float big = std::numeric_limits<float>::max();
-        std::vector<float> min (nchans, -big);
-        std::vector<float> max (nchans, big);
-        std::map<std::string,std::string> options;
+        std::vector<float> min(nchans, -big);
+        std::vector<float> max(nchans, big);
+        std::map<std::string, std::string> options;
         options["clampalpha"] = "0";  // initialize
-        ot.extract_options (options, command);
-        Strutil::extract_from_list_string (min, options["min"]);
-        Strutil::extract_from_list_string (max, options["max"]);
-        bool clampalpha01 = Strutil::stoi (options["clampalpha"]);
+        ot.extract_options(options, command);
+        Strutil::extract_from_list_string(min, options["min"]);
+        Strutil::extract_from_list_string(max, options["max"]);
+        bool clampalpha01 = Strutil::stoi(options["clampalpha"]);
 
-        for (int m = 0, miplevels=R->miplevels(s);  m < miplevels;  ++m) {
-            ImageBuf &Rib ((*R)(s,m));
-            ImageBuf &Aib ((*A)(s,m));
-            bool ok = ImageBufAlgo::clamp (Rib, Aib, &min[0], &max[0], clampalpha01);
-            if (! ok)
-                ot.error (command, Rib.geterror());
+        for (int m = 0, miplevels = R->miplevels(s); m < miplevels; ++m) {
+            ImageBuf& Rib((*R)(s, m));
+            ImageBuf& Aib((*A)(s, m));
+            bool ok = ImageBufAlgo::clamp(Rib, Aib, &min[0], &max[0],
+                                          clampalpha01);
+            if (!ok)
+                ot.error(command, Rib.geterror());
         }
     }
 
@@ -4115,137 +4263,165 @@ action_clamp (int argc, const char *argv[])
 
 class OpRangeCompress : public OiiotoolOp {
 public:
-    OpRangeCompress (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) {}
-    virtual int impl (ImageBuf **img) {
+    OpRangeCompress(Oiiotool& ot, string_view opname, int argc,
+                    const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
         bool useluma = Strutil::from_string<int>(options["luma"]);
-        return ImageBufAlgo::rangecompress (*img[0], *img[1], useluma);
+        return ImageBufAlgo::rangecompress(*img[0], *img[1], useluma);
     }
 };
 
-OP_CUSTOMCLASS (rangecompress, OpRangeCompress, 1);
+OP_CUSTOMCLASS(rangecompress, OpRangeCompress, 1);
 
 
 
 class OpRangeExpand : public OiiotoolOp {
 public:
-    OpRangeExpand (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) {}
-    virtual int impl (ImageBuf **img) {
+    OpRangeExpand(Oiiotool& ot, string_view opname, int argc,
+                  const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
         bool useluma = Strutil::from_string<int>(options["luma"]);
-        return ImageBufAlgo::rangeexpand (*img[0], *img[1], useluma);
+        return ImageBufAlgo::rangeexpand(*img[0], *img[1], useluma);
     }
 };
 
-OP_CUSTOMCLASS (rangeexpand, OpRangeExpand, 1);
+OP_CUSTOMCLASS(rangeexpand, OpRangeExpand, 1);
 
 
 
 class OpContrast : public OiiotoolOp {
 public:
-    OpContrast (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) {}
-    virtual void option_defaults () {
-        options["black"] = "0";
-        options["white"] = "1";
-        options["min"] = "0";
-        options["max"] = "1";
-        options["scontrast"] = "1";
-        options["sthresh"] = "0.5";
-        options["clamp"] = "0";
+    OpContrast(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
     }
-    virtual int impl (ImageBuf **img) {
-        size_t n = size_t ((*img[0]).nchannels());
-        auto black = Strutil::extract_from_list_string (options["black"], n, 0.0f);
-        auto white = Strutil::extract_from_list_string (options["white"], n, 1.0f);
-        auto min = Strutil::extract_from_list_string (options["min"], n, 0.0f);
-        auto max = Strutil::extract_from_list_string (options["max"], n, 1.0f);
-        auto scontrast = Strutil::extract_from_list_string (options["scontrast"], n, 1.0f);
-        auto sthresh = Strutil::extract_from_list_string (options["sthresh"], n, 0.50f);
-        bool clamp = Strutil::from_string<int> (options["clamp"]);
-        bool ok = ImageBufAlgo::contrast_remap (*img[0], *img[1], black, white,
-                                                min, max, scontrast, sthresh);
+    virtual void option_defaults()
+    {
+        options["black"]     = "0";
+        options["white"]     = "1";
+        options["min"]       = "0";
+        options["max"]       = "1";
+        options["scontrast"] = "1";
+        options["sthresh"]   = "0.5";
+        options["clamp"]     = "0";
+    }
+    virtual int impl(ImageBuf** img)
+    {
+        size_t n   = size_t((*img[0]).nchannels());
+        auto black = Strutil::extract_from_list_string(options["black"], n,
+                                                       0.0f);
+        auto white = Strutil::extract_from_list_string(options["white"], n,
+                                                       1.0f);
+        auto min   = Strutil::extract_from_list_string(options["min"], n, 0.0f);
+        auto max   = Strutil::extract_from_list_string(options["max"], n, 1.0f);
+        auto scontrast = Strutil::extract_from_list_string(options["scontrast"],
+                                                           n, 1.0f);
+        auto sthresh = Strutil::extract_from_list_string(options["sthresh"], n,
+                                                         0.50f);
+        bool clamp   = Strutil::from_string<int>(options["clamp"]);
+        bool ok = ImageBufAlgo::contrast_remap(*img[0], *img[1], black, white,
+                                               min, max, scontrast, sthresh);
         if (clamp && ok)
-            ok &= ImageBufAlgo::clamp (*img[0], *img[0], min, max);
+            ok &= ImageBufAlgo::clamp(*img[0], *img[0], min, max);
         return ok;
     }
 };
 
-OP_CUSTOMCLASS (contrast, OpContrast, 1);
-
+OP_CUSTOMCLASS(contrast, OpContrast, 1);
 
 
 
 class OpBox : public OiiotoolOp {
 public:
-    OpBox (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) {}
-    virtual int impl (ImageBuf **img) {
-        img[0]->copy (*img[1]);
-        const ImageSpec &Rspec (img[0]->spec());
+    OpBox(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
+        img[0]->copy(*img[1]);
+        const ImageSpec& Rspec(img[0]->spec());
         int x1, y1, x2, y2;
-        string_view s (args[1]);
-        if (Strutil::parse_int (s, x1) && Strutil::parse_char (s, ',') &&
-            Strutil::parse_int (s, y1) && Strutil::parse_char (s, ',') &&
-            Strutil::parse_int (s, x2) && Strutil::parse_char (s, ',') &&
-            Strutil::parse_int (s, y2)) {
-            std::vector<float> color (Rspec.nchannels+1, 1.0f);
-            Strutil::extract_from_list_string (color, options["color"]);
+        string_view s(args[1]);
+        if (Strutil::parse_int(s, x1) && Strutil::parse_char(s, ',')
+            && Strutil::parse_int(s, y1) && Strutil::parse_char(s, ',')
+            && Strutil::parse_int(s, x2) && Strutil::parse_char(s, ',')
+            && Strutil::parse_int(s, y2)) {
+            std::vector<float> color(Rspec.nchannels + 1, 1.0f);
+            Strutil::extract_from_list_string(color, options["color"]);
             bool fill = Strutil::from_string<int>(options["fill"]);
-            return ImageBufAlgo::render_box (*img[0], x1, y1, x2, y2,
-                                             color, fill);
+            return ImageBufAlgo::render_box(*img[0], x1, y1, x2, y2, color,
+                                            fill);
         }
         return false;
     }
 };
 
-OP_CUSTOMCLASS (box, OpBox, 1);
+OP_CUSTOMCLASS(box, OpBox, 1);
 
 
 
 class OpLine : public OiiotoolOp {
 public:
-    OpLine (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) {}
-    virtual int impl (ImageBuf **img) {
-        img[0]->copy (*img[1]);
-        const ImageSpec &Rspec (img[0]->spec());
+    OpLine(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
+        img[0]->copy(*img[1]);
+        const ImageSpec& Rspec(img[0]->spec());
         std::vector<int> points;
-        Strutil::extract_from_list_string (points, args[1]);
-        std::vector<float> color (Rspec.nchannels+1, 1.0f);
-        Strutil::extract_from_list_string (color, options["color"]);
-        bool closed = (points.size() > 4 &&
-                       points[0] == points[points.size()-2] &&
-                       points[1] == points[points.size()-1]);
-        for (size_t i = 0, e = points.size()-2; i < e; i += 2)
-            ImageBufAlgo::render_line (*img[0], points[i+0], points[i+1],
-                                       points[i+2], points[i+3], color,
-                                       closed || i>0 /*skip_first_point*/);
+        Strutil::extract_from_list_string(points, args[1]);
+        std::vector<float> color(Rspec.nchannels + 1, 1.0f);
+        Strutil::extract_from_list_string(color, options["color"]);
+        bool closed = (points.size() > 4
+                       && points[0] == points[points.size() - 2]
+                       && points[1] == points[points.size() - 1]);
+        for (size_t i = 0, e = points.size() - 2; i < e; i += 2)
+            ImageBufAlgo::render_line(*img[0], points[i + 0], points[i + 1],
+                                      points[i + 2], points[i + 3], color,
+                                      closed || i > 0 /*skip_first_point*/);
         return true;
     }
 };
 
-OP_CUSTOMCLASS (line, OpLine, 1);
+OP_CUSTOMCLASS(line, OpLine, 1);
 
 
 
 class OpText : public OiiotoolOp {
 public:
-    OpText (Oiiotool &ot, string_view opname, int argc, const char *argv[])
-        : OiiotoolOp (ot, opname, argc, argv, 1) {}
-    virtual int impl (ImageBuf **img) {
-        img[0]->copy (*img[1]);
-        const ImageSpec &Rspec (img[0]->spec());
-        int x = options["x"].size() ? Strutil::from_string<int>(options["x"]) : (Rspec.x + Rspec.width/2);
-        int y = options["y"].size() ? Strutil::from_string<int>(options["y"]) : (Rspec.y + Rspec.height/2);
-        int fontsize = options["size"].size() ? Strutil::from_string<int>(options["size"]) : 16;
+    OpText(Oiiotool& ot, string_view opname, int argc, const char* argv[])
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+    {
+    }
+    virtual int impl(ImageBuf** img)
+    {
+        img[0]->copy(*img[1]);
+        const ImageSpec& Rspec(img[0]->spec());
+        int x = options["x"].size() ? Strutil::from_string<int>(options["x"])
+                                    : (Rspec.x + Rspec.width / 2);
+        int y = options["y"].size() ? Strutil::from_string<int>(options["y"])
+                                    : (Rspec.y + Rspec.height / 2);
+        int fontsize = options["size"].size()
+                           ? Strutil::from_string<int>(options["size"])
+                           : 16;
         std::string font = options["font"];
-        std::vector<float> textcolor (Rspec.nchannels+1, 1.0f);
-        Strutil::extract_from_list_string (textcolor, options["color"]);
+        std::vector<float> textcolor(Rspec.nchannels + 1, 1.0f);
+        Strutil::extract_from_list_string(textcolor, options["color"]);
         std::string ax = options["xalign"];
         std::string ay = options["yalign"];
-        TextAlignX alignx (TextAlignX::Left);
-        TextAlignY aligny (TextAlignY::Baseline);
+        TextAlignX alignx(TextAlignX::Left);
+        TextAlignY aligny(TextAlignY::Baseline);
         if (Strutil::iequals(ax, "right") || Strutil::iequals(ax, "r"))
             alignx = TextAlignX::Right;
         if (Strutil::iequals(ax, "center") || Strutil::iequals(ax, "c"))
@@ -4257,14 +4433,12 @@ public:
         if (Strutil::iequals(ay, "center") || Strutil::iequals(ay, "c"))
             aligny = TextAlignY::Center;
         int shadow = Strutil::from_string<int>(options["shadow"]);
-        return ImageBufAlgo::render_text (*img[0], x, y, args[1],
-                                          fontsize, font, textcolor,
-                                          alignx, aligny, shadow);
+        return ImageBufAlgo::render_text(*img[0], x, y, args[1], fontsize, font,
+                                         textcolor, alignx, aligny, shadow);
     }
 };
 
-OP_CUSTOMCLASS (text, OpText, 1);
-
+OP_CUSTOMCLASS(text, OpText, 1);
 
 
 
@@ -4296,52 +4470,52 @@ OP_CUSTOMCLASS (text, OpText, 1);
 ///                   histogram is created, instead of a regular one.
 /// --------------------------------------------------------------------------
 static int
-action_histogram (int argc, const char *argv[])
+action_histogram(int argc, const char* argv[])
 {
-    ASSERT (argc == 3);
-    if (ot.postpone_callback (1, action_histogram, argc, argv))
+    ASSERT(argc == 3);
+    if (ot.postpone_callback(1, action_histogram, argc, argv))
         return 0;
-    Timer timer (ot.enable_function_timing);
-    string_view command = ot.express (argv[0]);
-    string_view size = ot.express(argv[1]);
-    int channel = Strutil::from_string<int> (ot.express(argv[2]));
-    std::map<std::string,std::string> options;
-    ot.extract_options (options, command);
-    int cumulative = Strutil::from_string<int> (options["cumulative"]);
+    Timer timer(ot.enable_function_timing);
+    string_view command = ot.express(argv[0]);
+    string_view size    = ot.express(argv[1]);
+    int channel         = Strutil::from_string<int>(ot.express(argv[2]));
+    std::map<std::string, std::string> options;
+    ot.extract_options(options, command);
+    int cumulative = Strutil::from_string<int>(options["cumulative"]);
 
     // Input image.
-    ot.read ();
-    ImageRecRef A (ot.pop());
-    const ImageBuf &Aib ((*A)());
+    ot.read();
+    ImageRecRef A(ot.pop());
+    const ImageBuf& Aib((*A)());
 
     // Extract bins and height from size.
     int bins = 0, height = 0;
-    if (sscanf (size.c_str(), "%dx%d", &bins, &height) != 2) {
-        ot.error (command, Strutil::format ("Invalid size: %s", size));
+    if (sscanf(size.c_str(), "%dx%d", &bins, &height) != 2) {
+        ot.error(command, Strutil::format("Invalid size: %s", size));
         return -1;
     }
 
     // Compute regular histogram.
     std::vector<imagesize_t> hist;
-    bool ok = ImageBufAlgo::histogram (Aib, channel, hist, bins);
-    if (! ok) {
-        ot.error (command, Aib.geterror());
+    bool ok = ImageBufAlgo::histogram(Aib, channel, hist, bins);
+    if (!ok) {
+        ot.error(command, Aib.geterror());
         return 0;
     }
 
     // Compute cumulative histogram if specified.
     if (cumulative == 1)
         for (int i = 1; i < bins; i++)
-            hist[i] += hist[i-1];
+            hist[i] += hist[i - 1];
 
     // Output image.
-    ImageSpec specR (bins, height, 1, TypeDesc::FLOAT);
-    ot.push (new ImageRec ("irec", specR, ot.imagecache));
-    ImageBuf &Rib ((*ot.curimg)());
+    ImageSpec specR(bins, height, 1, TypeDesc::FLOAT);
+    ot.push(new ImageRec("irec", specR, ot.imagecache));
+    ImageBuf& Rib((*ot.curimg)());
 
-    ok = ImageBufAlgo::histogram_draw (Rib, hist);
-    if (! ok)
-        ot.error (command, Rib.geterror());
+    ok = ImageBufAlgo::histogram_draw(Rib, hist);
+    if (!ok)
+        ot.error(command, Rib.geterror());
 
     ot.function_times[command] += timer();
     return 0;
@@ -4350,157 +4524,167 @@ action_histogram (int argc, const char *argv[])
 
 
 static int
-input_file (int argc, const char *argv[])
+input_file(int argc, const char* argv[])
 {
     ot.total_readtime.start();
-    string_view command = ot.express (argv[0]);
+    string_view command = ot.express(argv[0]);
     if (argc > 1 && Strutil::starts_with(command, "-i")) {
         --argc;
         ++argv;
     } else {
         command = "-i";
     }
-    std::map<std::string,std::string> fileoptions;
-    ot.extract_options (fileoptions, command);
-    int printinfo = get_value_override (fileoptions["info"], int(ot.printinfo));
-    bool readnow = get_value_override (fileoptions["now"], int(0));
-    bool autocc = get_value_override (fileoptions["autocc"], int(ot.autocc));
-    std::string infoformat = get_value_override (fileoptions["infoformat"],
-                                                 ot.printinfo_format);
-    TypeDesc input_dataformat (fileoptions["type"]);
+    std::map<std::string, std::string> fileoptions;
+    ot.extract_options(fileoptions, command);
+    int printinfo = get_value_override(fileoptions["info"], int(ot.printinfo));
+    bool readnow  = get_value_override(fileoptions["now"], int(0));
+    bool autocc   = get_value_override(fileoptions["autocc"], int(ot.autocc));
+    std::string infoformat = get_value_override(fileoptions["infoformat"],
+                                                ot.printinfo_format);
+    TypeDesc input_dataformat(fileoptions["type"]);
     std::string channel_set = fileoptions["ch"];
 
-    for (int i = 0;  i < argc;  i++) { // FIXME: this loop is pointless
+    for (int i = 0; i < argc; i++) {  // FIXME: this loop is pointless
         string_view filename = ot.express(argv[i]);
-        std::map<std::string,ImageRecRef>::const_iterator found;
+        std::map<std::string, ImageRecRef>::const_iterator found;
         found = ot.image_labels.find(filename);
         if (found != ot.image_labels.end()) {
             if (ot.debug)
                 std::cout << "Referencing labeled image " << filename << "\n";
-            ot.push (found->second);
-            ot.process_pending ();
+            ot.push(found->second);
+            ot.process_pending();
             break;
         }
-        Timer timer (ot.enable_function_timing);
+        Timer timer(ot.enable_function_timing);
         int exists = 1;
         if (ot.input_config_set) {
             // User has set some input configuration, so seed the cache with
             // that information.
-            ustring fn (filename);
-            ot.imagecache->invalidate (fn);
-            bool ok = ot.imagecache->add_file (fn, nullptr, &ot.input_config);
+            ustring fn(filename);
+            ot.imagecache->invalidate(fn);
+            bool ok = ot.imagecache->add_file(fn, nullptr, &ot.input_config);
             if (!ok) {
                 std::string err = ot.imagecache->geterror();
-                ot.error ("read", err.size() ? err : "(unknown error)");
-                exit (1);
+                ot.error("read", err.size() ? err : "(unknown error)");
+                exit(1);
             }
         }
-        if (! ot.imagecache->get_image_info (ustring(filename), 0, 0,
-                            ustring("exists"), TypeInt, &exists)
+        if (!ot.imagecache->get_image_info(ustring(filename), 0, 0,
+                                           ustring("exists"), TypeInt, &exists)
             || !exists) {
             // Try to get a more precise error message to report
-            auto input = ImageInput::create (filename);
-            bool procedural = input ? input->supports ("procedural") : false;
-            input.reset ();
-            if (! Filesystem::exists(filename) && !procedural)
-                ot.error ("read", Strutil::format ("File does not exist: \"%s\"", filename));
+            auto input      = ImageInput::create(filename);
+            bool procedural = input ? input->supports("procedural") : false;
+            input.reset();
+            if (!Filesystem::exists(filename) && !procedural)
+                ot.error("read", Strutil::format("File does not exist: \"%s\"",
+                                                 filename));
             else {
                 std::string err;
-                auto in = ImageInput::open (filename);
+                auto in = ImageInput::open(filename);
                 if (in) {
                     err = in->geterror();
                 } else {
                     err = OIIO::geterror();
                 }
-                ot.error ("read", err.size() ? err : "(unknown error)");
+                ot.error("read", err.size() ? err : "(unknown error)");
             }
-            exit (1);
+            exit(1);
         }
 
         if (channel_set.size()) {
             ot.input_channel_set = channel_set;
-            readnow = true;
+            readnow              = true;
         }
 
         if (ot.debug || ot.verbose)
             std::cout << "Reading " << filename << "\n";
-        ot.push (ImageRecRef (new ImageRec (filename, ot.imagecache)));
-        ot.curimg->configspec (ot.input_config);
-        ot.curimg->input_dataformat (input_dataformat);
+        ot.push(ImageRecRef(new ImageRec(filename, ot.imagecache)));
+        ot.curimg->configspec(ot.input_config);
+        ot.curimg->input_dataformat(input_dataformat);
         if (readnow) {
-            ot.curimg->read (ReadNoCache, channel_set);
+            ot.curimg->read(ReadNoCache, channel_set);
             // If we do not yet have an expected output format, set it based on
             // this image (presumably the first one read.
             if (ot.output_dataformat == TypeDesc::UNKNOWN) {
-                const ImageSpec &nspec ((*ot.curimg)(0,0).nativespec());
+                const ImageSpec& nspec((*ot.curimg)(0, 0).nativespec());
                 ot.output_dataformat = nspec.format;
-                if (! ot.output_bitspersample)
-                    ot.output_bitspersample = nspec.get_int_attribute ("oiio:BitsPerSample");
+                if (!ot.output_bitspersample)
+                    ot.output_bitspersample = nspec.get_int_attribute(
+                        "oiio:BitsPerSample");
                 if (nspec.channelformats.size()) {
                     for (int c = 0; c < nspec.nchannels; ++c) {
                         std::string chname = nspec.channelnames[c];
-                        ot.output_channelformats[chname] = std::string(nspec.channelformat(c).c_str());
+                        ot.output_channelformats[chname] = std::string(
+                            nspec.channelformat(c).c_str());
                     }
                 }
             }
         }
         if (printinfo || ot.printstats || ot.dumpdata || ot.hash) {
             OiioTool::print_info_options pio;
-            pio.verbose = ot.verbose || printinfo > 1 || ot.printinfo_verbose;
+            pio.verbose   = ot.verbose || printinfo > 1 || ot.printinfo_verbose;
             pio.subimages = ot.allsubimages || printinfo > 1;
-            pio.compute_stats = ot.printstats;
-            pio.dumpdata = ot.dumpdata;
+            pio.compute_stats      = ot.printstats;
+            pio.dumpdata           = ot.dumpdata;
             pio.dumpdata_showempty = ot.dumpdata_showempty;
-            pio.compute_sha1 = ot.hash;
-            pio.metamatch = ot.printinfo_metamatch;
-            pio.nometamatch = ot.printinfo_nometamatch;
-            pio.infoformat = infoformat;
-            long long totalsize = 0;
+            pio.compute_sha1       = ot.hash;
+            pio.metamatch          = ot.printinfo_metamatch;
+            pio.nometamatch        = ot.printinfo_nometamatch;
+            pio.infoformat         = infoformat;
+            long long totalsize    = 0;
             std::string error;
-            bool ok = OiioTool::print_info (ot, filename, pio, totalsize, error);
-            if (! ok)
-                ot.error ("read", error);
+            bool ok = OiioTool::print_info(ot, filename, pio, totalsize, error);
+            if (!ok)
+                ot.error("read", error);
             ot.printed_info = true;
         }
         ot.function_times["input"] += timer();
         if (ot.autoorient) {
-            int action_reorient (int argc, const char *argv[]);
-            const char *argv[] = { "--reorient" };
-            action_reorient (1, argv);
+            int action_reorient(int argc, const char* argv[]);
+            const char* argv[] = { "--reorient" };
+            action_reorient(1, argv);
         }
 
         if (autocc) {
             // Try to deduce the color space it's in
-            string_view colorspace (ot.colorconfig.parseColorSpaceFromString(filename));
+            string_view colorspace(
+                ot.colorconfig.parseColorSpaceFromString(filename));
             if (colorspace.size() && ot.debug)
-                std::cout << "  From " << filename << ", we deduce color space \""
-                          << colorspace << "\"\n";
+                std::cout << "  From " << filename
+                          << ", we deduce color space \"" << colorspace
+                          << "\"\n";
             if (colorspace.empty()) {
-                ot.read ();
-                colorspace = ot.curimg->spec()->get_string_attribute ("oiio:ColorSpace");
+                ot.read();
+                colorspace = ot.curimg->spec()->get_string_attribute(
+                    "oiio:ColorSpace");
                 if (ot.debug)
-                    std::cout << "  Metadata of " << filename << " indicates color space \""
-                              << colorspace << "\"\n";
+                    std::cout << "  Metadata of " << filename
+                              << " indicates color space \"" << colorspace
+                              << "\"\n";
             }
-            string_view linearspace = ot.colorconfig.getColorSpaceNameByRole("linear");
+            string_view linearspace = ot.colorconfig.getColorSpaceNameByRole(
+                "linear");
             if (linearspace.empty())
                 linearspace = string_view("Linear");
-            if (colorspace.size() && !Strutil::iequals(colorspace,linearspace)) {
-                const char *argv[] = { "colorconvert:strict=0", colorspace.c_str(),
+            if (colorspace.size()
+                && !Strutil::iequals(colorspace, linearspace)) {
+                const char* argv[] = { "colorconvert:strict=0",
+                                       colorspace.c_str(),
                                        linearspace.c_str() };
                 if (ot.debug)
                     std::cout << "  Converting " << filename << " from "
                               << colorspace << " to " << linearspace << "\n";
-                action_colorconvert (3, argv);
+                action_colorconvert(3, argv);
             }
         }
 
-        ot.process_pending ();
+        ot.process_pending();
     }
 
-    ot.clear_input_config ();
-    ot.input_channel_set.clear ();
-    ot.check_peak_memory ();
+    ot.clear_input_config();
+    ot.input_channel_set.clear();
+    ot.check_peak_memory();
     ot.total_readtime.stop();
     return 0;
 }
@@ -4508,95 +4692,105 @@ input_file (int argc, const char *argv[])
 
 
 static void
-prep_texture_config (ImageSpec &configspec,
-                     std::map<std::string,std::string> &fileoptions)
+prep_texture_config(ImageSpec& configspec,
+                    std::map<std::string, std::string>& fileoptions)
 {
-    configspec.tile_width  = ot.output_tilewidth  ? ot.output_tilewidth  : 64;
+    configspec.tile_width  = ot.output_tilewidth ? ot.output_tilewidth : 64;
     configspec.tile_height = ot.output_tileheight ? ot.output_tileheight : 64;
     configspec.tile_depth  = 1;
-    string_view wrap = get_value_override (fileoptions["wrap"], "black");
-    string_view swrap = get_value_override (fileoptions["swrap"], wrap);
-    string_view twrap = get_value_override (fileoptions["twrap"], wrap);
-    configspec.attribute ("wrapmodes", Strutil::format("%s,%s", swrap, twrap));
-    configspec.attribute ("maketx:verbose", ot.verbose);
-    configspec.attribute ("maketx:runstats", ot.runstats);
-    configspec.attribute ("maketx:resize",
-                          get_value_override(fileoptions["resize"], 0));
-    configspec.attribute ("maketx:nomipmap",
-                          get_value_override(fileoptions["nomipmap"], 0));
-    configspec.attribute ("maketx:updatemode",
-                          get_value_override(fileoptions["updatemode"], 0));
-    configspec.attribute ("maketx:constant_color_detect",
-                          get_value_override(fileoptions["constant_color_detect"], 0));
-    configspec.attribute ("maketx:monochrome_detect",
-                          get_value_override(fileoptions["monochrome_detect"], 0));
-    configspec.attribute ("maketx:opaque_detect",
-                          get_value_override(fileoptions["opaque_detect"], 0));
-    configspec.attribute ("maketx:compute_average",
-                          get_value_override(fileoptions["compute_average"], 1));
-    configspec.attribute ("maketx:unpremult",
-                          get_value_override(fileoptions["unpremult"], 0));
-    configspec.attribute ("maketx:incolorspace",
-                          get_value_override(fileoptions["incolorspace"], ""));
-    configspec.attribute ("maketx:outcolorspace",
-                          get_value_override(fileoptions["outcolorspace"], ""));
-    configspec.attribute ("maketx:highlightcomp",
-                          get_value_override(fileoptions["highlightcomp"],
-                            get_value_override(fileoptions["hilightcomp"],
-                              get_value_override(fileoptions["hicomp"], 0))));
-    configspec.attribute ("maketx:sharpen",
-                          get_value_override(fileoptions["sharpen"], 0.0f));
+    string_view wrap       = get_value_override(fileoptions["wrap"], "black");
+    string_view swrap      = get_value_override(fileoptions["swrap"], wrap);
+    string_view twrap      = get_value_override(fileoptions["twrap"], wrap);
+    configspec.attribute("wrapmodes", Strutil::format("%s,%s", swrap, twrap));
+    configspec.attribute("maketx:verbose", ot.verbose);
+    configspec.attribute("maketx:runstats", ot.runstats);
+    configspec.attribute("maketx:resize",
+                         get_value_override(fileoptions["resize"], 0));
+    configspec.attribute("maketx:nomipmap",
+                         get_value_override(fileoptions["nomipmap"], 0));
+    configspec.attribute("maketx:updatemode",
+                         get_value_override(fileoptions["updatemode"], 0));
+    configspec.attribute("maketx:constant_color_detect",
+                         get_value_override(fileoptions["constant_color_detect"],
+                                            0));
+    configspec.attribute("maketx:monochrome_detect",
+                         get_value_override(fileoptions["monochrome_detect"],
+                                            0));
+    configspec.attribute("maketx:opaque_detect",
+                         get_value_override(fileoptions["opaque_detect"], 0));
+    configspec.attribute("maketx:compute_average",
+                         get_value_override(fileoptions["compute_average"], 1));
+    configspec.attribute("maketx:unpremult",
+                         get_value_override(fileoptions["unpremult"], 0));
+    configspec.attribute("maketx:incolorspace",
+                         get_value_override(fileoptions["incolorspace"], ""));
+    configspec.attribute("maketx:outcolorspace",
+                         get_value_override(fileoptions["outcolorspace"], ""));
+    configspec.attribute(
+        "maketx:highlightcomp",
+        get_value_override(
+            fileoptions["highlightcomp"],
+            get_value_override(fileoptions["hilightcomp"],
+                               get_value_override(fileoptions["hicomp"], 0))));
+    configspec.attribute("maketx:sharpen",
+                         get_value_override(fileoptions["sharpen"], 0.0f));
     if (fileoptions["filter"].size() || fileoptions["filtername"].size())
-        configspec.attribute ("maketx:filtername",
-                              get_value_override(fileoptions["filtername"],
-                                                 get_value_override(fileoptions["filter"], "")));
+        configspec.attribute(
+            "maketx:filtername",
+            get_value_override(fileoptions["filtername"],
+                               get_value_override(fileoptions["filter"], "")));
     if (fileoptions["fileformatname"].size())
-        configspec.attribute ("maketx:fileformatname",
-                              get_value_override(fileoptions["fileformatname"], ""));
-    configspec.attribute ("maketx:prman_metadata",
-                          get_value_override(fileoptions["prman_metadata"], 0));
-    configspec.attribute ("maketx:oiio_options",
-                          get_value_override(fileoptions["oiio_options"],
-                                             get_value_override(fileoptions["oiio"])));
-    configspec.attribute ("maketx:prman_options",
-                          get_value_override(fileoptions["prman_options"],
-                                             get_value_override(fileoptions["prman"])));    
-    configspec.attribute ("maketx:bumpformat",
-                          get_value_override(fileoptions["bumpformat"], "auto"));
+        configspec.attribute("maketx:fileformatname",
+                             get_value_override(fileoptions["fileformatname"],
+                                                ""));
+    configspec.attribute("maketx:prman_metadata",
+                         get_value_override(fileoptions["prman_metadata"], 0));
+    configspec.attribute("maketx:oiio_options",
+                         get_value_override(fileoptions["oiio_options"],
+                                            get_value_override(
+                                                fileoptions["oiio"])));
+    configspec.attribute("maketx:prman_options",
+                         get_value_override(fileoptions["prman_options"],
+                                            get_value_override(
+                                                fileoptions["prman"])));
+    configspec.attribute("maketx:bumpformat",
+                         get_value_override(fileoptions["bumpformat"], "auto"));
     // if (mipimages.size())
     //     configspec.attribute ("maketx:mipimages", Strutil::join(mipimages,";"));
 
-    std::string software = configspec.get_string_attribute ("Software");
+    std::string software = configspec.get_string_attribute("Software");
     if (software.size())
-        configspec.attribute ("maketx:full_command_line", software);
+        configspec.attribute("maketx:full_command_line", software);
 }
 
 
 
 static int
-output_file (int argc, const char *argv[])
+output_file(int argc, const char* argv[])
 {
-    Timer timer (ot.enable_function_timing);
+    Timer timer(ot.enable_function_timing);
     ot.total_writetime.start();
-    string_view command = ot.express (argv[0]);
-    string_view filename = ot.express (argv[1]);
+    string_view command  = ot.express(argv[0]);
+    string_view filename = ot.express(argv[1]);
 
-    std::map<std::string,std::string> fileoptions;
-    ot.extract_options (fileoptions, command);
+    std::map<std::string, std::string> fileoptions;
+    ot.extract_options(fileoptions, command);
 
     string_view stripped_command = command;
-    Strutil::parse_char (stripped_command, '-');
-    Strutil::parse_char (stripped_command, '-');    
-    bool do_tex = Strutil::starts_with (stripped_command, "otex");
-    bool do_latlong = Strutil::starts_with (stripped_command, "oenv") ||
-                      Strutil::starts_with (stripped_command, "olatlong");
-    bool do_shad = Strutil::starts_with (stripped_command, "oshad");
-    bool do_bumpslopes = Strutil::starts_with (stripped_command, "obump");
+    Strutil::parse_char(stripped_command, '-');
+    Strutil::parse_char(stripped_command, '-');
+    bool do_tex     = Strutil::starts_with(stripped_command, "otex");
+    bool do_latlong = Strutil::starts_with(stripped_command, "oenv")
+                      || Strutil::starts_with(stripped_command, "olatlong");
+    bool do_shad       = Strutil::starts_with(stripped_command, "oshad");
+    bool do_bumpslopes = Strutil::starts_with(stripped_command, "obump");
 
     if (ot.debug)
         std::cout << "Output: " << filename << "\n";
-    if (! ot.curimg.get()) {
-        ot.warning (command, Strutil::format("%s did not have any current image to output.", filename));
+    if (!ot.curimg.get()) {
+        ot.warning(command, Strutil::format(
+                                "%s did not have any current image to output.",
+                                filename));
         return 0;
     }
 
@@ -4606,102 +4800,114 @@ output_file (int argc, const char *argv[])
         // presumed to have a %d in it somewhere, which we will substitute
         // with the image index.
         int startnumber = Strutil::from_string<int>(fileoptions["all"]);
-        int nimages = 1 /*curimg*/ + int(ot.image_stack.size());
-        const char *new_argv[2];
+        int nimages     = 1 /*curimg*/ + int(ot.image_stack.size());
+        const char* new_argv[2];
         // Git rid of the ":all=" part of the command so we don't infinitely
         // recurse.
-        std::string newcmd = regex_replace (command.str(),
-                                                   regex(":all=[0-9]+"), "");
-        new_argv[0] = newcmd.c_str();;
-        ImageRecRef saved_curimg = ot.curimg; // because we'll overwrite it
+        std::string newcmd = regex_replace(command.str(), regex(":all=[0-9]+"),
+                                           "");
+        new_argv[0]        = newcmd.c_str();
+        ;
+        ImageRecRef saved_curimg = ot.curimg;  // because we'll overwrite it
         for (int i = 0; i < nimages; ++i) {
-            if (i < nimages-1)
+            if (i < nimages - 1)
                 ot.curimg = ot.image_stack[i];
             else
-                ot.curimg = saved_curimg;  // note: last iteration also restores it!
+                ot.curimg
+                    = saved_curimg;  // note: last iteration also restores it!
             // Use the filename as a pattern, format with the frame number
-            new_argv[1] = ustring::format(filename.c_str(), i+startnumber).c_str();
+            new_argv[1]
+                = ustring::format(filename.c_str(), i + startnumber).c_str();
             // recurse for this file
-            output_file (2, new_argv);
+            output_file(2, new_argv);
         }
         return 0;
     }
 
     if (ot.noclobber && Filesystem::exists(filename)) {
-        ot.warning (command, Strutil::format("%s already exists, not overwriting.", filename));
+        ot.warning(command,
+                   Strutil::format("%s already exists, not overwriting.",
+                                   filename));
         return 0;
     }
     string_view formatname = fileoptions["fileformatname"];
     if (formatname.empty())
         formatname = filename;
-    auto out = ImageOutput::create (formatname);
-    if (! out) {
+    auto out = ImageOutput::create(formatname);
+    if (!out) {
         std::string err = OIIO::geterror();
-        ot.error (command, err.size() ? err.c_str() : "unknown error creating an ImageOutput");
+        ot.error(command, err.size() ? err.c_str()
+                                     : "unknown error creating an ImageOutput");
         return 0;
     }
-    bool supports_displaywindow = out->supports ("displaywindow");
-    bool supports_negativeorigin = out->supports ("negativeorigin");
-    bool supports_tiles = out->supports ("tiles") || ot.output_force_tiles;
-    ot.read ();
+    bool supports_displaywindow  = out->supports("displaywindow");
+    bool supports_negativeorigin = out->supports("negativeorigin");
+    bool supports_tiles = out->supports("tiles") || ot.output_force_tiles;
+    ot.read();
     ImageRecRef saveimg = ot.curimg;
-    ImageRecRef ir (ot.curimg);
+    ImageRecRef ir(ot.curimg);
     TypeDesc saved_output_dataformat = ot.output_dataformat;
-    int saved_bitspersample = ot.output_bitspersample;
+    int saved_bitspersample          = ot.output_bitspersample;
 
-    timer.stop();   // resume after all these auto-transforms
+    timer.stop();  // resume after all these auto-transforms
 
     // Automatically drop channels we can't support in output
-    if ((ir->spec()->nchannels > 4 && ! out->supports("nchannels")) ||
-        (ir->spec()->nchannels > 3 && ! out->supports("alpha"))) {
+    if ((ir->spec()->nchannels > 4 && !out->supports("nchannels"))
+        || (ir->spec()->nchannels > 3 && !out->supports("alpha"))) {
         bool alpha = (ir->spec()->nchannels > 3 && out->supports("alpha"));
         string_view chanlist = alpha ? "R,G,B,A" : "R,G,B";
         std::vector<int> channels;
-        bool found = parse_channels (*ir->spec(), chanlist, channels);
-        if (! found)
+        bool found = parse_channels(*ir->spec(), chanlist, channels);
+        if (!found)
             chanlist = alpha ? "0,1,2,3" : "0,1,2";
-        const char *argv[] = { "channels", chanlist.c_str() };
-        int action_channels (int argc, const char *argv[]); // forward decl
-        action_channels (2, argv);
-        ot.warning (command, Strutil::format("Can't save %d channels to %f... saving only %s",
-                                              ir->spec()->nchannels, out->format_name(), chanlist.c_str()));
+        const char* argv[] = { "channels", chanlist.c_str() };
+        int action_channels(int argc, const char* argv[]);  // forward decl
+        action_channels(2, argv);
+        ot.warning(
+            command,
+            Strutil::format("Can't save %d channels to %f... saving only %s",
+                            ir->spec()->nchannels, out->format_name(),
+                            chanlist.c_str()));
         ir = ot.curimg;
     }
 
     // Handle --autotrim
-    int autotrim = get_value_override (fileoptions["autotrim"], ot.output_autotrim);
+    int autotrim = get_value_override(fileoptions["autotrim"],
+                                      ot.output_autotrim);
     if (supports_displaywindow && autotrim) {
-        ROI origroi = get_roi(*ir->spec(0,0));
-        ROI roi = ImageBufAlgo::nonzero_region ((*ir)(0,0), origroi);
+        ROI origroi = get_roi(*ir->spec(0, 0));
+        ROI roi     = ImageBufAlgo::nonzero_region((*ir)(0, 0), origroi);
         if (roi.npixels() == 0) {
             // Special case -- all zero; but doctor to make it 1 zero pixel
-            roi = origroi;
-            roi.xend = roi.xbegin+1;
-            roi.yend = roi.ybegin+1;
-            roi.zend = roi.zbegin+1;
+            roi      = origroi;
+            roi.xend = roi.xbegin + 1;
+            roi.yend = roi.ybegin + 1;
+            roi.zend = roi.zbegin + 1;
         }
-        std::string crop = (ir->spec(0,0)->depth == 1)
-            ? format_resolution (roi.width(), roi.height(),
-                                 roi.xbegin, roi.ybegin)
-            : format_resolution (roi.width(), roi.height(), roi.depth(),
-                                 roi.xbegin, roi.ybegin, roi.zbegin);
-        const char *argv[] = { "crop", crop.c_str() };
-        int action_crop (int argc, const char *argv[]); // forward decl
-        action_crop (2, argv);
+        std::string crop = (ir->spec(0, 0)->depth == 1)
+                               ? format_resolution(roi.width(), roi.height(),
+                                                   roi.xbegin, roi.ybegin)
+                               : format_resolution(roi.width(), roi.height(),
+                                                   roi.depth(), roi.xbegin,
+                                                   roi.ybegin, roi.zbegin);
+        const char* argv[] = { "crop", crop.c_str() };
+        int action_crop(int argc, const char* argv[]);  // forward decl
+        action_crop(2, argv);
         ir = ot.curimg;
     }
 
     // Automatically crop/pad if outputting to a format that doesn't
     // support display windows, unless autocrop is disabled.
-    int autocrop = get_value_override (fileoptions["autocrop"], ot.output_autocrop);
-    if (! supports_displaywindow && autocrop &&
-        (ir->spec()->x != ir->spec()->full_x ||
-         ir->spec()->y != ir->spec()->full_y ||
-         ir->spec()->width != ir->spec()->full_width ||
-         ir->spec()->height != ir->spec()->full_height)) {
-        const char *argv[] = { "croptofull" };
-        int action_croptofull (int argc, const char *argv[]); // forward decl
-        action_croptofull (1, argv);
+    int autocrop = get_value_override(fileoptions["autocrop"],
+                                      ot.output_autocrop);
+    if (!supports_displaywindow && autocrop
+        && (ir->spec()->x != ir->spec()->full_x
+            || ir->spec()->y != ir->spec()->full_y
+            || ir->spec()->width != ir->spec()->full_width
+            || ir->spec()->height != ir->spec()->full_height)) {
+        const char* argv[] = { "croptofull" };
+        int action_croptofull(int argc, const char* argv[]);  // forward decl
+        action_croptofull(1, argv);
         ir = ot.curimg;
     }
 
@@ -4709,71 +4915,79 @@ output_file (int argc, const char *argv[])
     // Automatically color convert if --autocc is used and the current
     // color space doesn't match that implied by the filename, and
     // automatically set -d based on the name if --autod is used.
-    int autocc = get_value_override (fileoptions["autocc"], ot.autocc);
-    string_view outcolorspace = ot.colorconfig.parseColorSpaceFromString(filename);
+    int autocc = get_value_override(fileoptions["autocc"], ot.autocc);
+    string_view outcolorspace = ot.colorconfig.parseColorSpaceFromString(
+        filename);
     if (autocc && outcolorspace.size()) {
         TypeDesc type;
         int bits;
-        type = ot.colorconfig.getColorSpaceDataType(outcolorspace,&bits);
+        type = ot.colorconfig.getColorSpaceDataType(outcolorspace, &bits);
         if (type.basetype != TypeDesc::UNKNOWN) {
             if (ot.debug)
                 std::cout << "  Deduced data type " << type << " (" << bits
                           << "bits) for output to " << filename << "\n";
             if ((ot.output_dataformat && ot.output_dataformat != type)
-                || (bits && ot.output_bitspersample && ot.output_bitspersample != bits)) {
-                std::string msg = Strutil::format (
+                || (bits && ot.output_bitspersample
+                    && ot.output_bitspersample != bits)) {
+                std::string msg = Strutil::format(
                     "Output filename colorspace \"%s\" implies %s (%d bits), overriding prior request for %s.",
                     outcolorspace, type, bits, ot.output_dataformat);
-                ot.warning (command, msg);
+                ot.warning(command, msg);
             }
-            ot.output_dataformat = type;
+            ot.output_dataformat    = type;
             ot.output_bitspersample = bits;
         }
     }
     if (autocc) {
-        string_view linearspace = ot.colorconfig.getColorSpaceNameByRole("linear");
+        string_view linearspace = ot.colorconfig.getColorSpaceNameByRole(
+            "linear");
         if (linearspace.empty())
             linearspace = string_view("Linear");
-        string_view currentspace = ir->spec()->get_string_attribute ("oiio:ColorSpace", linearspace);
+        string_view currentspace
+            = ir->spec()->get_string_attribute("oiio:ColorSpace", linearspace);
         // Special cases where we know formats should be particular color
         // spaces
-        if (outcolorspace.empty() && (Strutil::iends_with (filename, ".jpg") ||
-                                      Strutil::iends_with (filename, ".jpeg") ||
-                                      Strutil::iends_with (filename, ".gif")))
+        if (outcolorspace.empty()
+            && (Strutil::iends_with(filename, ".jpg")
+                || Strutil::iends_with(filename, ".jpeg")
+                || Strutil::iends_with(filename, ".gif")))
             outcolorspace = string_view("sRGB");
         if (outcolorspace.size() && currentspace != outcolorspace) {
             if (ot.debug)
                 std::cout << "  Converting from " << currentspace << " to "
-                          << outcolorspace << " for output to " << filename << "\n";
-            const char *argv[] = { "colorconvert:strict=0",
-                                   currentspace.c_str(), outcolorspace.c_str() };
-            action_colorconvert (3, argv);
+                          << outcolorspace << " for output to " << filename
+                          << "\n";
+            const char* argv[] = { "colorconvert:strict=0",
+                                   currentspace.c_str(),
+                                   outcolorspace.c_str() };
+            action_colorconvert(3, argv);
             ir = ot.curimg;
         }
     }
 
     // Automatically crop out the negative areas if outputting to a format
     // that doesn't support negative origins.
-    if (! supports_negativeorigin && autocrop &&
-        (ir->spec()->x < 0 || ir->spec()->y < 0 || ir->spec()->z < 0)) {
-        ROI roi = get_roi (*ir->spec(0,0));
-        roi.xbegin = std::max (0, roi.xbegin);
-        roi.ybegin = std::max (0, roi.ybegin);
-        roi.zbegin = std::max (0, roi.zbegin);
-        std::string crop = (ir->spec(0,0)->depth == 1)
-            ? format_resolution (roi.width(), roi.height(),
-                                 roi.xbegin, roi.ybegin)
-            : format_resolution (roi.width(), roi.height(), roi.depth(),
-                                 roi.xbegin, roi.ybegin, roi.zbegin);
-        const char *argv[] = { "crop", crop.c_str() };
-        int action_crop (int argc, const char *argv[]); // forward decl
-        action_crop (2, argv);
+    if (!supports_negativeorigin && autocrop
+        && (ir->spec()->x < 0 || ir->spec()->y < 0 || ir->spec()->z < 0)) {
+        ROI roi          = get_roi(*ir->spec(0, 0));
+        roi.xbegin       = std::max(0, roi.xbegin);
+        roi.ybegin       = std::max(0, roi.ybegin);
+        roi.zbegin       = std::max(0, roi.zbegin);
+        std::string crop = (ir->spec(0, 0)->depth == 1)
+                               ? format_resolution(roi.width(), roi.height(),
+                                                   roi.xbegin, roi.ybegin)
+                               : format_resolution(roi.width(), roi.height(),
+                                                   roi.depth(), roi.xbegin,
+                                                   roi.ybegin, roi.zbegin);
+        const char* argv[] = { "crop", crop.c_str() };
+        int action_crop(int argc, const char* argv[]);  // forward decl
+        action_crop(2, argv);
         ir = ot.curimg;
     }
 
     if (ot.dryrun) {
-        ot.curimg = saveimg;
-        ot.output_dataformat = saved_output_dataformat;
+        ot.curimg               = saveimg;
+        ot.output_dataformat    = saved_output_dataformat;
         ot.output_bitspersample = saved_bitspersample;
         return 0;
     }
@@ -4788,9 +5002,9 @@ output_file (int argc, const char *argv[])
     bool ok = true;
     if (do_tex || do_latlong || do_bumpslopes) {
         ImageSpec configspec;
-        adjust_output_options (filename, configspec, nullptr,
-                               ot, supports_tiles, fileoptions);
-        prep_texture_config (configspec, fileoptions);
+        adjust_output_options(filename, configspec, nullptr, ot, supports_tiles,
+                              fileoptions);
+        prep_texture_config(configspec, fileoptions);
         ImageBufAlgo::MakeTextureMode mode = ImageBufAlgo::MakeTxTexture;
         if (do_shad)
             mode = ImageBufAlgo::MakeTxShadow;
@@ -4800,27 +5014,27 @@ output_file (int argc, const char *argv[])
             mode = ImageBufAlgo::MakeTxBumpWithSlopes;
         // if (lightprobemode)
         //     mode = ImageBufAlgo::MakeTxEnvLatlFromLightProbe;
-        ok = ImageBufAlgo::make_texture (mode, (*ir)(0,0), filename,
-                                         configspec, &std::cout);
+        ok = ImageBufAlgo::make_texture(mode, (*ir)(0, 0), filename, configspec,
+                                        &std::cout);
         if (!ok)
-            ot.error (command, "Could not make texture");
+            ot.error(command, "Could not make texture");
         // N.B. make_texture already internally writes to a temp file and
         // then atomically moves it to the final destination, so we don't
         // need to explicitly do that here.
     } else {
         // Non-texture case
-        std::vector<ImageSpec> subimagespecs (ir->subimages());
-        for (int s = 0;  s < ir->subimages();  ++s) {
-            ImageSpec spec = *ir->spec(s,0);
-            adjust_output_options (filename, spec, ir->nativespec(s),
-                                   ot, supports_tiles,
-                                   fileoptions, (*ir)[s].was_direct_read());
+        std::vector<ImageSpec> subimagespecs(ir->subimages());
+        for (int s = 0; s < ir->subimages(); ++s) {
+            ImageSpec spec = *ir->spec(s, 0);
+            adjust_output_options(filename, spec, ir->nativespec(s), ot,
+                                  supports_tiles, fileoptions,
+                                  (*ir)[s].was_direct_read());
             // For deep files, must copy the native deep channelformats
             if (spec.deep)
-                spec.channelformats = (*ir)(s,0).nativespec().channelformats;
+                spec.channelformats = (*ir)(s, 0).nativespec().channelformats;
             // If it's not tiled and MIP-mapped, remove any "textureformat"
-            if (! spec.tile_pixels() || ir->miplevels(s) <= 1)
-                spec.erase_attribute ("textureformat");
+            if (!spec.tile_pixels() || ir->miplevels(s) <= 1)
+                spec.erase_attribute("textureformat");
             subimagespecs[s] = spec;
         }
 
@@ -4834,42 +5048,45 @@ output_file (int argc, const char *argv[])
         // a unique filename to protect against multiple processes running
         // at the same time on the same file.
         std::string extension = Filesystem::extension(filename);
-        std::string tmpfilename = Filesystem::replace_extension (filename, ".%%%%%%%%.temp"+extension);
+        std::string tmpfilename
+            = Filesystem::replace_extension(filename,
+                                            ".%%%%%%%%.temp" + extension);
         tmpfilename = Filesystem::unique_path(tmpfilename);
 
         // Do the initial open
         ImageOutput::OpenMode mode = ImageOutput::Create;
         if (ir->subimages() > 1 && out->supports("multiimage")) {
-            if (! out->open (tmpfilename, ir->subimages(), &subimagespecs[0])) {
+            if (!out->open(tmpfilename, ir->subimages(), &subimagespecs[0])) {
                 std::string err = out->geterror();
-                ot.error (command, err.size() ? err.c_str() : "unknown error");
+                ot.error(command, err.size() ? err.c_str() : "unknown error");
                 return 0;
             }
         } else {
-            if (! out->open (tmpfilename, subimagespecs[0], mode)) {
+            if (!out->open(tmpfilename, subimagespecs[0], mode)) {
                 std::string err = out->geterror();
-                ot.error (command, err.size() ? err.c_str() : "unknown error");
+                ot.error(command, err.size() ? err.c_str() : "unknown error");
                 return 0;
             }
         }
 
         // Output all the subimages and MIP levels
-        for (int s = 0, send = ir->subimages();  s < send;  ++s) {
-            for (int m = 0, mend = ir->miplevels(s);  m < mend && ok;  ++m) {
-                ImageSpec spec = *ir->spec(s,m);
-                adjust_output_options (filename, spec, ir->nativespec(s,m),
-                                       ot, supports_tiles,
-                                       fileoptions, (*ir)[s].was_direct_read());
+        for (int s = 0, send = ir->subimages(); s < send; ++s) {
+            for (int m = 0, mend = ir->miplevels(s); m < mend && ok; ++m) {
+                ImageSpec spec = *ir->spec(s, m);
+                adjust_output_options(filename, spec, ir->nativespec(s, m), ot,
+                                      supports_tiles, fileoptions,
+                                      (*ir)[s].was_direct_read());
                 if (s > 0 || m > 0) {  // already opened first subimage/level
-                    if (! out->open (tmpfilename, spec, mode)) {
+                    if (!out->open(tmpfilename, spec, mode)) {
                         std::string err = out->geterror();
-                        ot.error (command, err.size() ? err.c_str() : "unknown error");
+                        ot.error(command,
+                                 err.size() ? err.c_str() : "unknown error");
                         ok = false;
                         break;
                     }
                 }
-                if (! (*ir)(s,m).write (out.get())) {
-                    ot.error (command, (*ir)(s,m).geterror());
+                if (!(*ir)(s, m).write(out.get())) {
+                    ot.error(command, (*ir)(s, m).geterror());
                     ok = false;
                     break;
                 }
@@ -4880,79 +5097,87 @@ output_file (int argc, const char *argv[])
                     } else if (out->supports("multiimage")) {
                         mode = ImageOutput::AppendSubimage;
                     } else {
-                        ot.warning (command, Strutil::format ("%s does not support MIP-maps for %s",
-                                                               out->format_name(), filename));
+                        ot.warning(command,
+                                   Strutil::format(
+                                       "%s does not support MIP-maps for %s",
+                                       out->format_name(), filename));
                         break;
                     }
                 }
             }
             mode = ImageOutput::AppendSubimage;  // for next subimage
-            if (send > 1 && ! out->supports("multiimage")) {
-                ot.warning (command, Strutil::format ("%s does not support multiple subimages for %s",
-                                                       out->format_name(), filename));
+            if (send > 1 && !out->supports("multiimage")) {
+                ot.warning(command,
+                           Strutil::format(
+                               "%s does not support multiple subimages for %s",
+                               out->format_name(), filename));
                 break;
             }
         }
 
-        out->close ();
-        out.reset ();    // make extra sure it's cleaned up
+        out->close();
+        out.reset();  // make extra sure it's cleaned up
 
         // We wrote to a temporary file, so now atomically move it to the
         // original desired location.
         if (ok) {
             std::string err;
-            ok = Filesystem::rename (tmpfilename, filename, err);
-            if (! ok)
-                ot.error (command, Strutil::format("oiiotool ERROR: could not move temp file %s to %s: %s",
-                                                   tmpfilename, filename, err));
+            ok = Filesystem::rename(tmpfilename, filename, err);
+            if (!ok)
+                ot.error(
+                    command,
+                    Strutil::format(
+                        "oiiotool ERROR: could not move temp file %s to %s: %s",
+                        tmpfilename, filename, err));
         }
-        if (! ok)
-            Filesystem::remove (tmpfilename);
+        if (!ok)
+            Filesystem::remove(tmpfilename);
     }
 
     // Make sure to invalidate any IC entries that think they are the
     // file we just wrote.
-    ot.imagecache->invalidate (ustring(filename));
+    ot.imagecache->invalidate(ustring(filename));
 
     if (ot.output_adjust_time && ok) {
-        std::string metadatatime = ir->spec(0,0)->get_string_attribute ("DateTime");
+        std::string metadatatime = ir->spec(0, 0)->get_string_attribute(
+            "DateTime");
         std::time_t in_time = ir->time();
-        if (! metadatatime.empty())
-            DateTime_to_time_t (metadatatime.c_str(), in_time);
-        Filesystem::last_write_time (filename, in_time);
+        if (!metadatatime.empty())
+            DateTime_to_time_t(metadatatime.c_str(), in_time);
+        Filesystem::last_write_time(filename, in_time);
     }
 
     ot.check_peak_memory();
-    ot.curimg = saveimg;
-    ot.output_dataformat = saved_output_dataformat;
+    ot.curimg               = saveimg;
+    ot.output_dataformat    = saved_output_dataformat;
     ot.output_bitspersample = saved_bitspersample;
-    ot.curimg->was_output (true);
+    ot.curimg->was_output(true);
     ot.total_writetime.stop();
     double optime = timer();
     ot.function_times[command] += optime;
     ot.num_outputs += 1;
 
     if (ot.debug)
-        Strutil::printf ("    output took %s  (total time %s, mem %s)\n",
-                         Strutil::timeintervalformat(optime,2),
-                         Strutil::timeintervalformat(ot.total_runtime(),2),
-                         Strutil::memformat(Sysutil::memory_used()));
+        Strutil::printf("    output took %s  (total time %s, mem %s)\n",
+                        Strutil::timeintervalformat(optime, 2),
+                        Strutil::timeintervalformat(ot.total_runtime(), 2),
+                        Strutil::memformat(Sysutil::memory_used()));
     return 0;
 }
 
 
 
 static int
-do_echo (int argc, const char *argv[])
+do_echo(int argc, const char* argv[])
 {
-    ASSERT (argc == 2);
+    ASSERT(argc == 2);
 
-    string_view command = ot.express (argv[0]);
-    string_view message = ot.express (argv[1]);
+    string_view command = ot.express(argv[0]);
+    string_view message = ot.express(argv[1]);
 
-    std::map<std::string,std::string> options;
+    std::map<std::string, std::string> options;
     options["newline"] = "1";
-    ot.extract_options (options, command);
+    ot.extract_options(options, command);
     int newline = Strutil::from_string<int>(options["newline"]);
 
     std::cout << message;
@@ -4968,29 +5193,32 @@ do_echo (int argc, const char *argv[])
 // Concatenate the command line into one string, optionally filtering out
 // verbose attribute commands.
 static std::string
-command_line_string (int argc, char * argv[], bool sansattrib)
+command_line_string(int argc, char* argv[], bool sansattrib)
 {
     std::string s;
-    for (int i = 0;  i < argc;  ++i) {
+    for (int i = 0; i < argc; ++i) {
         if (sansattrib) {
             // skip any filtered attributes
-            if (Strutil::starts_with(argv[i], "--attrib") || Strutil::starts_with(argv[i], "-attrib") ||
-                Strutil::starts_with(argv[i], "--sattrib") || Strutil::starts_with(argv[i], "-sattrib")) {
+            if (Strutil::starts_with(argv[i], "--attrib")
+                || Strutil::starts_with(argv[i], "-attrib")
+                || Strutil::starts_with(argv[i], "--sattrib")
+                || Strutil::starts_with(argv[i], "-sattrib")) {
                 i += 2;  // also skip the following arguments
                 continue;
             }
-            if (Strutil::starts_with(argv[i], "--sansattrib") || Strutil::starts_with(argv[i], "-sansattrib")) {
+            if (Strutil::starts_with(argv[i], "--sansattrib")
+                || Strutil::starts_with(argv[i], "-sansattrib")) {
                 continue;
             }
         }
-        if (strchr (argv[i], ' ')) {  // double quote args with spaces
+        if (strchr(argv[i], ' ')) {  // double quote args with spaces
             s += '\"';
             s += argv[i];
             s += '\"';
         } else {
             s += argv[i];
         }
-        if (i < argc-1)
+        if (i < argc - 1)
             s += ' ';
     }
     return s;
@@ -4999,17 +5227,17 @@ command_line_string (int argc, char * argv[], bool sansattrib)
 
 
 static std::string
-formatted_format_list (string_view format_typename, string_view attr)
+formatted_format_list(string_view format_typename, string_view attr)
 {
     int columns = Sysutil::terminal_columns() - 2;
     std::stringstream s;
     s << format_typename << " formats supported: ";
     std::string format_list;
-    OIIO::getattribute (attr, format_list);
+    OIIO::getattribute(attr, format_list);
     std::vector<string_view> formats;
-    Strutil::split (format_list, formats, ",");
-    std::sort (formats.begin(), formats.end());
-    format_list = Strutil::join (formats, ", ");
+    Strutil::split(format_list, formats, ",");
+    std::sort(formats.begin(), formats.end());
+    format_list = Strutil::join(formats, ", ");
     s << format_list;
     return Strutil::wordwrap(s.str(), columns, 4);
 }
@@ -5017,67 +5245,66 @@ formatted_format_list (string_view format_typename, string_view attr)
 
 
 static void
-print_usage_tips (const ArgParse &ap, std::ostream &out)
+print_usage_tips(const ArgParse& ap, std::ostream& out)
 {
     int columns = Sysutil::terminal_columns() - 2;
 
-    out <<
-      "Important usage tips:\n"
-      << Strutil::wordwrap(
-          "  * The oiiotool command line is processed in order, LEFT to RIGHT.\n",
-          columns, 4)
-      << Strutil::wordwrap(
-          "  * The command line consists of image NAMES ('image.tif') and "
-          "COMMANDS ('--over'). Commands start with dashes (one or two dashes "
-          "are equivalent). Some commands have required arguments which "
-          "must follow on the command line. For example, the '-o' command is "
-          "followed by a filename.\n",
-          columns, 4)
-      << Strutil::wordwrap(
-          "  * oiiotool is STACK-based: naming an image pushes it on the stack, and "
-          "most commands pop the top image (or sometimes more than one image), "
-          "perform a calculation, and push the result image back on the stack. "
-          "For example, the '--over' command pops the top two images off the "
-          "stack, composites them, then pushes the result back onto the stack.\n",
-          columns, 4)
-      << Strutil::wordwrap(
-          "  * Some commands allow one or more optional MODIFIERS in the form "
-          "'name=value', which are appended directly to the command itself "
-          "(no spaces), separated by colons ':'. For example,\n",
-          columns, 4)
-      <<  "       oiiotool in.tif --text:x=100:y=200:color=1,0,0 \"Hello\" -o out.tif\n"
-      << Strutil::wordwrap(
-          "  * Using numerical wildcards will run the whole command line on each of "
-          "several sequentially-named files, for example:\n",
-          columns, 4)
-      << "       oiiotool fg.#.tif bg.#.tif -over -o comp.#.tif\n"
-      << "   See the manual for info about subranges, number of digits, etc.\n"
-      << "\n";
+    out << "Important usage tips:\n"
+        << Strutil::wordwrap(
+               "  * The oiiotool command line is processed in order, LEFT to RIGHT.\n",
+               columns, 4)
+        << Strutil::wordwrap(
+               "  * The command line consists of image NAMES ('image.tif') and "
+               "COMMANDS ('--over'). Commands start with dashes (one or two dashes "
+               "are equivalent). Some commands have required arguments which "
+               "must follow on the command line. For example, the '-o' command is "
+               "followed by a filename.\n",
+               columns, 4)
+        << Strutil::wordwrap(
+               "  * oiiotool is STACK-based: naming an image pushes it on the stack, and "
+               "most commands pop the top image (or sometimes more than one image), "
+               "perform a calculation, and push the result image back on the stack. "
+               "For example, the '--over' command pops the top two images off the "
+               "stack, composites them, then pushes the result back onto the stack.\n",
+               columns, 4)
+        << Strutil::wordwrap(
+               "  * Some commands allow one or more optional MODIFIERS in the form "
+               "'name=value', which are appended directly to the command itself "
+               "(no spaces), separated by colons ':'. For example,\n",
+               columns, 4)
+        << "       oiiotool in.tif --text:x=100:y=200:color=1,0,0 \"Hello\" -o out.tif\n"
+        << Strutil::wordwrap(
+               "  * Using numerical wildcards will run the whole command line on each of "
+               "several sequentially-named files, for example:\n",
+               columns, 4)
+        << "       oiiotool fg.#.tif bg.#.tif -over -o comp.#.tif\n"
+        << "   See the manual for info about subranges, number of digits, etc.\n"
+        << "\n";
 }
 
 
 
 static void
-print_help_end (const ArgParse &ap, std::ostream &out)
+print_help_end(const ArgParse& ap, std::ostream& out)
 {
     out << "\n";
     int columns = Sysutil::terminal_columns() - 2;
 
-    out << formatted_format_list ("Input", "input_format_list") << "\n";
-    out << formatted_format_list ("Output", "output_format_list") << "\n";
+    out << formatted_format_list("Input", "input_format_list") << "\n";
+    out << formatted_format_list("Output", "output_format_list") << "\n";
 
     // debugging color space names
     out << "Color configuration: " << ot.colorconfig.configname() << "\n";
     std::stringstream s;
     s << "Known color spaces: ";
-    const char *linear = ot.colorconfig.getColorSpaceNameByRole("linear");
-    for (int i = 0, e = ot.colorconfig.getNumColorSpaces();  i < e;  ++i) {
-        const char *n = ot.colorconfig.getColorSpaceNameByIndex(i);
+    const char* linear = ot.colorconfig.getColorSpaceNameByRole("linear");
+    for (int i = 0, e = ot.colorconfig.getNumColorSpaces(); i < e; ++i) {
+        const char* n = ot.colorconfig.getColorSpaceNameByIndex(i);
         s << "\"" << n << "\"";
-        if (linear && !Strutil::iequals(n,"linear") &&
-            Strutil::iequals (n, linear))
+        if (linear && !Strutil::iequals(n, "linear")
+            && Strutil::iequals(n, linear))
             s << " (linear)";
-        if (i < e-1)
+        if (i < e - 1)
             s << ", ";
     }
     out << Strutil::wordwrap(s.str(), columns, 4) << "\n";
@@ -5086,89 +5313,93 @@ print_help_end (const ArgParse &ap, std::ostream &out)
     if (nlooks) {
         std::stringstream s;
         s << "Known looks: ";
-        for (int i = 0;  i < nlooks;  ++i) {
-            const char *n = ot.colorconfig.getLookNameByIndex(i);
+        for (int i = 0; i < nlooks; ++i) {
+            const char* n = ot.colorconfig.getLookNameByIndex(i);
             s << "\"" << n << "\"";
-            if (i < nlooks-1)
+            if (i < nlooks - 1)
                 s << ", ";
         }
         out << Strutil::wordwrap(s.str(), columns, 4) << "\n";
     }
 
-    const char *default_display = ot.colorconfig.getDefaultDisplayName();
-    int ndisplays = ot.colorconfig.getNumDisplays();
+    const char* default_display = ot.colorconfig.getDefaultDisplayName();
+    int ndisplays               = ot.colorconfig.getNumDisplays();
     if (ndisplays) {
         std::stringstream s;
         s << "Known displays: ";
         for (int i = 0; i < ndisplays; ++i) {
-            const char *d = ot.colorconfig.getDisplayNameByIndex(i);
+            const char* d = ot.colorconfig.getDisplayNameByIndex(i);
             s << "\"" << d << "\"";
-            if (! strcmp(d, default_display))
+            if (!strcmp(d, default_display))
                 s << "*";
-            const char *default_view = ot.colorconfig.getDefaultViewName(d);
-            int nviews = ot.colorconfig.getNumViews(d);
+            const char* default_view = ot.colorconfig.getDefaultViewName(d);
+            int nviews               = ot.colorconfig.getNumViews(d);
             if (nviews) {
                 s << " (views: ";
                 for (int i = 0; i < nviews; ++i) {
-                    const char *v = ot.colorconfig.getViewNameByIndex(d, i);
+                    const char* v = ot.colorconfig.getViewNameByIndex(d, i);
                     s << "\"" << v << "\"";
-                    if (! strcmp(v, default_view))
+                    if (!strcmp(v, default_view))
                         s << "*";
-                    if (i < nviews-1)
+                    if (i < nviews - 1)
                         s << ", ";
                 }
                 s << ")";
             }
-            if (i < ndisplays-1)
+            if (i < ndisplays - 1)
                 s << ", ";
         }
         s << " (* = default)";
         out << Strutil::wordwrap(s.str(), columns, 4) << "\n";
     }
-    if (! ot.colorconfig.supportsOpenColorIO())
+    if (!ot.colorconfig.supportsOpenColorIO())
         out << "No OpenColorIO support was enabled at build time.\n";
     std::string libs = OIIO::get_string_attribute("library_list");
     if (libs.size()) {
         std::vector<string_view> libvec;
-        Strutil::split (libs, libvec, ";");
+        Strutil::split(libs, libvec, ";");
         for (auto& lib : libvec) {
             size_t pos = lib.find(':');
-            lib.remove_prefix (pos+1);
+            lib.remove_prefix(pos + 1);
         }
-        out << Strutil::wordwrap("Dependent libraries: " +
-                                 Strutil::join (libvec, ", "), columns, 4)
+        out << Strutil::wordwrap("Dependent libraries: "
+                                     + Strutil::join(libvec, ", "),
+                                 columns, 4)
             << std::endl;
     }
 
     // Print the HW info
     std::string buildsimd = OIIO::get_string_attribute("oiio:simd");
-    if (! buildsimd.size())
+    if (!buildsimd.size())
         buildsimd = "no SIMD";
-    auto hwinfo = Strutil::format ("OIIO %s built %s, running on %d cores %.1fGB %s",
-                      OIIO_VERSION_STRING, buildsimd,
-                      Sysutil::hardware_concurrency(),
-                      Sysutil::physical_memory()/float(1<<30),
-                      OIIO::get_string_attribute("hw:simd"));
-    out << Strutil::wordwrap (hwinfo, columns, 4) << std::endl;
+    auto hwinfo
+        = Strutil::format("OIIO %s built %s, running on %d cores %.1fGB %s",
+                          OIIO_VERSION_STRING, buildsimd,
+                          Sysutil::hardware_concurrency(),
+                          Sysutil::physical_memory() / float(1 << 30),
+                          OIIO::get_string_attribute("hw:simd"));
+    out << Strutil::wordwrap(hwinfo, columns, 4) << std::endl;
 
     // Print the path to the docs. If found, use the one installed in the
     // same area is this executable, otherwise just point to the copy on
     // GitHub corresponding to our version of the softare.
     out << "Full OIIO documentation can be found at\n";
     std::string path = Sysutil::this_program_path();
-    path = Filesystem::parent_path (path);
-    path = Filesystem::parent_path (path);
+    path             = Filesystem::parent_path(path);
+    path             = Filesystem::parent_path(path);
     path += "/share/doc/OpenImageIO/openimageio.pdf";
     if (Filesystem::exists(path))
         out << "    " << path << "\n";
     else {
         std::string branch;
-        if (Strutil::ends_with (OIIO_VERSION_STRING, "dev"))
+        if (Strutil::ends_with(OIIO_VERSION_STRING, "dev"))
             branch = "master";
         else
-            branch = Strutil::format ("RB-%d.%d", OIIO_VERSION_MAJOR, OIIO_VERSION_MINOR);
-        std::string docsurl = Strutil::format("https://github.com/OpenImageIO/oiio/blob/%s/src/doc/openimageio.pdf",
-                                              branch);
+            branch = Strutil::format("RB-%d.%d", OIIO_VERSION_MAJOR,
+                                     OIIO_VERSION_MINOR);
+        std::string docsurl = Strutil::format(
+            "https://github.com/OpenImageIO/oiio/blob/%s/src/doc/openimageio.pdf",
+            branch);
         out << "    " << docsurl << "\n";
     }
 }
@@ -5176,27 +5407,28 @@ print_help_end (const ArgParse &ap, std::ostream &out)
 
 
 static void
-print_help (ArgParse &ap)
+print_help(ArgParse& ap)
 {
-    ap.set_preoption_help (print_usage_tips);
-    ap.set_postoption_help (print_help_end);
+    ap.set_preoption_help(print_usage_tips);
+    ap.set_postoption_help(print_help_end);
 
-    ap.usage ();
+    ap.usage();
 }
 
 
 
 static void
-getargs (int argc, char *argv[])
+getargs(int argc, char* argv[])
 {
     bool help = false;
 
     bool sansattrib = false;
     for (int i = 0; i < argc; ++i)
-        if (!strcmp(argv[i],"--sansattrib") || !strcmp(argv[i],"-sansattrib"))
+        if (!strcmp(argv[i], "--sansattrib") || !strcmp(argv[i], "-sansattrib"))
             sansattrib = true;
-    ot.full_command_line = command_line_string (argc, argv, sansattrib);
+    ot.full_command_line = command_line_string(argc, argv, sansattrib);
 
+    // clang-format off
     ArgParse ap (argc, (const char **)argv);
     ap.options ("oiiotool -- simple image processing operations\n"
                 OIIO_INTRO_STRING "\n"
@@ -5445,6 +5677,7 @@ getargs (int argc, char *argv[])
                 "--premult %@", action_premult, NULL,
                     "Multiply all color channels of the current image by the alpha",
                 NULL);
+    // clang-format off
 
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
@@ -5470,8 +5703,8 @@ getargs (int argc, char *argv[])
 // Check if any of the command line arguments contains numeric ranges or
 // wildcards.  If not, just return 'false'.  But if they do, the
 // remainder of processing will happen here (and return 'true').
-static bool 
-handle_sequence (int argc, const char **argv)
+static bool
+handle_sequence(int argc, const char** argv)
 {
     // First, scan the original command line arguments for '#', '@', '%0Nd',
     // '%v' or '%V' characters.  Any found indicate that there are numeric
@@ -5480,65 +5713,66 @@ handle_sequence (int argc, const char **argv)
 #define ONERANGE_SPEC "-?[0-9]+(--?[0-9]+((x|y)-?[0-9]+)?)?"
 #define MANYRANGE_SPEC ONERANGE_SPEC "(," ONERANGE_SPEC ")*"
 #define VIEW_SPEC "%[Vv]"
-#define SEQUENCE_SPEC "((" MANYRANGE_SPEC ")?" "((#|@)+|(%[0-9]*d)))" "|" "(" VIEW_SPEC ")"
-    static regex sequence_re (SEQUENCE_SPEC);
+#define SEQUENCE_SPEC                                                          \
+    "((" MANYRANGE_SPEC ")?"                                                   \
+    "((#|@)+|(%[0-9]*d)))"                                                     \
+    "|"                                                                        \
+    "(" VIEW_SPEC ")"
+    static regex sequence_re(SEQUENCE_SPEC);
     std::string framespec = "";
 
-    static const char *default_views = "left,right";
+    static const char* default_views = "left,right";
     std::vector<string_view> views;
-    Strutil::split (default_views, views, ",");
+    Strutil::split(default_views, views, ",");
 
     int framepadding = 0;
     std::vector<int> sequence_args;  // Args with sequence numbers
     std::vector<bool> sequence_is_output;
     bool is_sequence = false;
     bool wildcard_on = true;
-    for (int a = 1;  a < argc;  ++a) {
-        bool is_output = false;
+    for (int a = 1; a < argc; ++a) {
+        bool is_output     = false;
         bool is_output_all = false;
-        if (Strutil::starts_with (argv[a], "-o") && a < argc-1) {
+        if (Strutil::starts_with(argv[a], "-o") && a < argc - 1) {
             is_output = true;
-            if (Strutil::contains (argv[a], ":all=")) {
+            if (Strutil::contains(argv[a], ":all=")) {
                 // skip wildcard expansion for -o:all, because the name
                 // will be a pattern for expansion of the subimage number.
                 is_output_all = true;
             }
             a++;
         }
-        std::string strarg (argv[a]);
+        std::string strarg(argv[a]);
         match_results<std::string::const_iterator> range_match;
         if (strarg == "--debug" || strarg == "-debug")
             ot.debug = true;
-        else if ((strarg == "--frames" || strarg == "-frames") && a < argc-1) {
-            framespec = argv[++a];
+        else if ((strarg == "--frames" || strarg == "-frames")
+                 && a < argc - 1) {
+            framespec   = argv[++a];
             is_sequence = true;
             // std::cout << "Frame range " << framespec << "\n";
-        }
-        else if ((strarg == "--framepadding" || strarg == "-framepadding")
-                 && a < argc-1) {
-            int f = atoi (argv[++a]);
+        } else if ((strarg == "--framepadding" || strarg == "-framepadding")
+                   && a < argc - 1) {
+            int f = atoi(argv[++a]);
             if (f >= 1 && f < 10)
                 framepadding = f;
-        }
-        else if ((strarg == "--views" || strarg == "-views") && a < argc-1) {
-            Strutil::split (argv[++a], views, ",");
-        }
-        else if (strarg == "--wildcardoff" || strarg == "-wildcardoff") {
+        } else if ((strarg == "--views" || strarg == "-views")
+                   && a < argc - 1) {
+            Strutil::split(argv[++a], views, ",");
+        } else if (strarg == "--wildcardoff" || strarg == "-wildcardoff") {
             wildcard_on = false;
-        }
-        else if (strarg == "--wildcardon" || strarg == "-wildcardon") {
+        } else if (strarg == "--wildcardon" || strarg == "-wildcardon") {
             wildcard_on = true;
-        }
-        else if (wildcard_on && !is_output_all &&
-                 regex_search (strarg, range_match, sequence_re)) {
+        } else if (wildcard_on && !is_output_all
+                   && regex_search(strarg, range_match, sequence_re)) {
             is_sequence = true;
-            sequence_args.push_back (a);
-            sequence_is_output.push_back (is_output);
+            sequence_args.push_back(a);
+            sequence_is_output.push_back(is_output);
         }
     }
 
     // No ranges or wildcards?
-    if (! is_sequence)
+    if (!is_sequence)
         return false;
 
     // For each of the arguments that contains a wildcard, get a normalized
@@ -5549,48 +5783,49 @@ handle_sequence (int argc, const char **argv)
     // sequences without explicit frame ranges inherit the frame numbers of
     // the first input sequence. It's an error if the sequences are not all
     // of the same length.
-    std::vector< std::vector<std::string> > filenames (argc+1);
-    std::vector< std::vector<int> > frame_numbers (argc+1);
-    std::vector< std::vector<string_view> > frame_views (argc+1);
+    std::vector<std::vector<std::string>> filenames(argc + 1);
+    std::vector<std::vector<int>> frame_numbers(argc + 1);
+    std::vector<std::vector<string_view>> frame_views(argc + 1);
     std::string normalized_pattern, sequence_framespec;
     size_t nfilenames = 0;
     bool result;
     for (size_t i = 0; i < sequence_args.size(); ++i) {
-        int a = sequence_args[i];
-        result = Filesystem::parse_pattern (argv[a],
-                                            framepadding,
-                                            normalized_pattern,
-                                            sequence_framespec);
-        if (! result) {
-            ot.error (Strutil::format("Could not parse pattern: %s",
-                                      argv[a]), "");
+        int a  = sequence_args[i];
+        result = Filesystem::parse_pattern(argv[a], framepadding,
+                                           normalized_pattern,
+                                           sequence_framespec);
+        if (!result) {
+            ot.error(Strutil::format("Could not parse pattern: %s", argv[a]),
+                     "");
             return true;
         }
 
         if (sequence_framespec.empty())
             sequence_framespec = framespec;
-        if (! sequence_framespec.empty()) {
-            Filesystem::enumerate_sequence (sequence_framespec.c_str(),
-                                            frame_numbers[a]);
-            Filesystem::enumerate_file_sequence (normalized_pattern,
-                                                 frame_numbers[a],
-                                                 frame_views[a],
-                                                 filenames[a]);
+        if (!sequence_framespec.empty()) {
+            Filesystem::enumerate_sequence(sequence_framespec.c_str(),
+                                           frame_numbers[a]);
+            Filesystem::enumerate_file_sequence(normalized_pattern,
+                                                frame_numbers[a],
+                                                frame_views[a], filenames[a]);
         } else if (sequence_is_output[i]) {
             // use frame numbers from first sequence
-            Filesystem::enumerate_file_sequence (normalized_pattern,
-                                                 frame_numbers[sequence_args[0]],
-                                                 frame_views[sequence_args[0]],
-                                                 filenames[a]);
-        } else if (! sequence_is_output[i]) {
-            result = Filesystem::scan_for_matching_filenames (normalized_pattern,
-                                                              views,
-                                                              frame_numbers[a],
-                                                              frame_views[a],
-                                                              filenames[a]);
-            if (! result) {
-                ot.error (Strutil::format("No filenames found matching pattern: \"%s\" (did you intend to use --wildcardoff?)",
-                                          argv[a]), "");
+            Filesystem::enumerate_file_sequence(normalized_pattern,
+                                                frame_numbers[sequence_args[0]],
+                                                frame_views[sequence_args[0]],
+                                                filenames[a]);
+        } else if (!sequence_is_output[i]) {
+            result = Filesystem::scan_for_matching_filenames(normalized_pattern,
+                                                             views,
+                                                             frame_numbers[a],
+                                                             frame_views[a],
+                                                             filenames[a]);
+            if (!result) {
+                ot.error(
+                    Strutil::format(
+                        "No filenames found matching pattern: \"%s\" (did you intend to use --wildcardoff?)",
+                        argv[a]),
+                    "");
                 return true;
             }
         }
@@ -5598,15 +5833,19 @@ handle_sequence (int argc, const char **argv)
         if (i == 0) {
             nfilenames = filenames[a].size();
         } else if (nfilenames != filenames[a].size()) {
-            ot.error (Strutil::format("Not all sequence specifications matched: %s (%d frames) vs. %s (%d frames)",
-                                      argv[sequence_args[0]], nfilenames, argv[a], filenames[a].size()), "");
+            ot.error(
+                Strutil::format(
+                    "Not all sequence specifications matched: %s (%d frames) vs. %s (%d frames)",
+                    argv[sequence_args[0]], nfilenames, argv[a],
+                    filenames[a].size()),
+                "");
             return true;
         }
     }
 
-    if (! nfilenames && !framespec.empty()) {
+    if (!nfilenames && !framespec.empty()) {
         // Frame sequence specified, but no wildcards used
-        Filesystem::enumerate_sequence (framespec, frame_numbers[0]);
+        Filesystem::enumerate_sequence(framespec, frame_numbers[0]);
         nfilenames = frame_numbers[0].size();
     }
 
@@ -5618,8 +5857,8 @@ handle_sequence (int argc, const char **argv)
     // substituting the i-th sequence entry for its respective argument
     // every time.
     // Note: nfilenames really means, number of frame number iterations.
-    std::vector<const char *> seq_argv (argv, argv+argc+1);
-    for (size_t i = 0;  i < nfilenames;  ++i) {
+    std::vector<const char*> seq_argv(argv, argv + argc + 1);
+    for (size_t i = 0; i < nfilenames; ++i) {
         if (ot.debug)
             std::cout << "SEQUENCE " << i << "\n";
         for (size_t a : sequence_args) {
@@ -5628,21 +5867,23 @@ handle_sequence (int argc, const char **argv)
                 std::cout << "  " << argv[a] << " -> " << seq_argv[a] << "\n";
         }
 
-        ot.clear_options (); // Careful to reset all command line options!
+        ot.clear_options();  // Careful to reset all command line options!
         ot.frame_number = frame_numbers[0][i];
-        getargs (argc, (char **)&seq_argv[0]);
+        getargs(argc, (char**)&seq_argv[0]);
 
-        ot.process_pending ();
+        ot.process_pending();
         if (ot.pending_callback())
-            ot.warning (Strutil::format ("pending '%s' command never executed", ot.pending_callback_name()));
+            ot.warning(Strutil::format("pending '%s' command never executed",
+                                       ot.pending_callback_name()));
         // Clear the stack at the end of each iteration
-        ot.curimg.reset ();
+        ot.curimg.reset();
         ot.image_stack.clear();
 
         if (ot.runstats)
             std::cout << "End iteration " << i << ": "
-                    << Strutil::timeintervalformat(ot.total_runtime(),2) << "  "
-                    << Strutil::memformat(Sysutil::memory_used()) << "\n";
+                      << Strutil::timeintervalformat(ot.total_runtime(), 2)
+                      << "  " << Strutil::memformat(Sysutil::memory_used())
+                      << "\n";
         if (ot.debug)
             std::cout << "\n";
     }
@@ -5653,13 +5894,13 @@ handle_sequence (int argc, const char **argv)
 
 
 int
-main (int argc, char *argv[])
+main(int argc, char* argv[])
 {
 #if OIIO_MSVS_BEFORE_2015
-     // When older Visual Studio is used, float values in scientific foramt
-     // are printed with three digit exponent. We change this behaviour to
-     // fit Linux way.
-    _set_output_format (_TWO_DIGIT_EXPONENT);
+    // When older Visual Studio is used, float values in scientific foramt
+    // are printed with three digit exponent. We change this behaviour to
+    // fit Linux way.
+    _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
 
 #if OIIO_SIMD_SSE && !OIIO_F16C_ENABLED
@@ -5675,7 +5916,7 @@ main (int argc, char *argv[])
     // the f16c hardware half<->float ops are not enabled. This does not
     // seem to be a problem in libopenjpeg > 1.5.
     // And, oy, just to mess with us, this doesn't work in gcc 4.8.
-    simd::set_denorms_zero_mode (false);
+    simd::set_denorms_zero_mode(false);
 #endif
     {
         // DEBUG -- this checks some problematic half->float values if the
@@ -5683,65 +5924,74 @@ main (int argc, char *argv[])
         // case we ever need to check it again.
         // using namespace OIIO::simd;
         const unsigned short bad[] = { 59, 12928, 2146, 32805 };
-        const half *h = (half *)bad;
-        simd::vfloat4 vf (h);
+        const half* h              = (half*)bad;
+        simd::vfloat4 vf(h);
         if (vf[0] == 0.0f || *h != vf[0])
-            Strutil::fprintf (stderr, "Bad half conversion, code %s %f -> %f "
-                              "(suspect badly set DENORMS_ZERO_MODE)\n",
-                              bad[0], h[0], vf[0]);
+            Strutil::fprintf(stderr,
+                             "Bad half conversion, code %s %f -> %f "
+                             "(suspect badly set DENORMS_ZERO_MODE)\n",
+                             bad[0], h[0], vf[0]);
     }
 
     // Globally force classic "C" locale, and turn off all formatting
     // internationalization, for the entire oiiotool application.
-    std::locale::global (std::locale::classic());
+    std::locale::global(std::locale::classic());
 
-    ot.imagecache = ImageCache::create (false);
-    ASSERT (ot.imagecache);
-    ot.imagecache->attribute ("forcefloat", 1);
-    ot.imagecache->attribute ("max_memory_MB", float(ot.cachesize));
-    ot.imagecache->attribute ("autotile", ot.autotile);
-    ot.imagecache->attribute ("autoscanline", int(ot.autotile ? 1 : 0));
+    ot.imagecache = ImageCache::create(false);
+    ASSERT(ot.imagecache);
+    ot.imagecache->attribute("forcefloat", 1);
+    ot.imagecache->attribute("max_memory_MB", float(ot.cachesize));
+    ot.imagecache->attribute("autotile", ot.autotile);
+    ot.imagecache->attribute("autoscanline", int(ot.autotile ? 1 : 0));
 
-    Filesystem::convert_native_arguments (argc, (const char **)argv);
-    if (handle_sequence (argc, (const char **)argv)) {
+    Filesystem::convert_native_arguments(argc, (const char**)argv);
+    if (handle_sequence(argc, (const char**)argv)) {
         // Deal with sequence
 
     } else {
         // Not a sequence
-        getargs (argc, argv);
-        ot.process_pending ();
+        getargs(argc, argv);
+        ot.process_pending();
         if (ot.pending_callback())
-            ot.warning (Strutil::format ("pending '%s' command never executed", ot.pending_callback_name()));
+            ot.warning(Strutil::format("pending '%s' command never executed",
+                                       ot.pending_callback_name()));
     }
 
-    if (!ot.printinfo && !ot.printstats && !ot.dumpdata && !ot.dryrun && !ot.printed_info) {
-        if (ot.curimg && !ot.curimg->was_output() &&
-            (ot.curimg->metadata_modified() || ot.curimg->pixels_modified()))
-            ot.warning ("modified images without outputting them. Did you forget -o?");
+    if (!ot.printinfo && !ot.printstats && !ot.dumpdata && !ot.dryrun
+        && !ot.printed_info) {
+        if (ot.curimg && !ot.curimg->was_output()
+            && (ot.curimg->metadata_modified() || ot.curimg->pixels_modified()))
+            ot.warning(
+                "modified images without outputting them. Did you forget -o?");
         else if (ot.num_outputs == 0)
-            ot.warning ("oiiotool produced no output. Did you forget -o?");
+            ot.warning("oiiotool produced no output. Did you forget -o?");
     }
 
     if (ot.runstats) {
-        double total_time = ot.total_runtime();
+        double total_time  = ot.total_runtime();
         double unaccounted = total_time;
         std::cout << "\n";
         int threads = -1;
-        OIIO::getattribute ("threads", threads);
+        OIIO::getattribute("threads", threads);
         std::cout << "Threads: " << threads << "\n";
         std::cout << "oiiotool runtime statistics:\n";
-        std::cout << "  Total time: " << Strutil::timeintervalformat(total_time,2) << "\n";
-        static const char *timeformat = "      %-12s : %5.2f\n";
-        for (Oiiotool::TimingMap::const_iterator func = ot.function_times.begin();
-             func != ot.function_times.end();  ++func) {
+        std::cout << "  Total time: "
+                  << Strutil::timeintervalformat(total_time, 2) << "\n";
+        static const char* timeformat = "      %-12s : %5.2f\n";
+        for (Oiiotool::TimingMap::const_iterator func
+             = ot.function_times.begin();
+             func != ot.function_times.end(); ++func) {
             double t = func->second;
-            std::cout << Strutil::format (timeformat, func->first, t);
+            std::cout << Strutil::format(timeformat, func->first, t);
             unaccounted -= t;
         }
-        std::cout << Strutil::format (timeformat, "unaccounted", std::max(unaccounted, 0.0));
-        ot.check_peak_memory ();
-        std::cout << "  Peak memory:    " << Strutil::memformat(ot.peak_memory) << "\n";
-        std::cout << "  Current memory: " << Strutil::memformat(Sysutil::memory_used()) << "\n";
+        std::cout << Strutil::format(timeformat, "unaccounted",
+                                     std::max(unaccounted, 0.0));
+        ot.check_peak_memory();
+        std::cout << "  Peak memory:    " << Strutil::memformat(ot.peak_memory)
+                  << "\n";
+        std::cout << "  Current memory: "
+                  << Strutil::memformat(Sysutil::memory_used()) << "\n";
         std::cout << "\n" << ot.imagecache->getstats(2) << "\n";
     }
 

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -29,19 +29,19 @@
 */
 
 
-#ifndef OIIOTOOL_H
+#pragma once
 
 #include <memory>
 
 #include <OpenImageIO/imagebuf.h>
-#include <OpenImageIO/timer.h>
 #include <OpenImageIO/sysutil.h>
+#include <OpenImageIO/timer.h>
 
 
 OIIO_NAMESPACE_BEGIN
 namespace OiioTool {
 
-typedef int (*CallbackFunction)(int argc,const char*argv[]);
+typedef int (*CallbackFunction)(int argc, const char* argv[]);
 
 class ImageRec;
 typedef std::shared_ptr<ImageRec> ImageRecRef;
@@ -49,15 +49,15 @@ typedef std::shared_ptr<ImageRec> ImageRecRef;
 
 /// Polycy hints for reading images
 enum ReadPolicy {
-    ReadDefault = 0,       //< Default: use cache, maybe convert to float.
-                           //<   For "small" files, may bypass cache.
-    ReadNative  = 1,       //< Keep in native type, use cache if it supports
-                           //<   the native type, bypass if not. May still
-                           //<   bypass cache for "small" images.
-    ReadNoCache = 2,       //< Bypass the cache regardless of size (beware!),
-                           //<   but still subject to format conversion.
-    ReadNativeNoCache = 3, //< No cache, no conversion. Do it all now.
-                           //<   You better know what you're doing.
+    ReadDefault = 0,        //< Default: use cache, maybe convert to float.
+                            //<   For "small" files, may bypass cache.
+    ReadNative = 1,         //< Keep in native type, use cache if it supports
+                            //<   the native type, bypass if not. May still
+                            //<   bypass cache for "small" images.
+    ReadNoCache = 2,        //< Bypass the cache regardless of size (beware!),
+                            //<   but still subject to format conversion.
+    ReadNativeNoCache = 3,  //< No cache, no conversion. Do it all now.
+                            //<   You better know what you're doing.
 };
 
 
@@ -78,9 +78,9 @@ public:
     bool hash;
     bool updatemode;
     bool autoorient;
-    bool autocc;                      // automatically color correct
-    bool autopremult;                 // auto premult unassociated alpha input
-    bool nativeread;                  // force native data type reads
+    bool autocc;       // automatically color correct
+    bool autopremult;  // auto premult unassociated alpha input
+    bool nativeread;   // force native data type reads
     bool printinfo_verbose;
     int cachesize;
     int autotile;
@@ -89,12 +89,12 @@ public:
     std::string printinfo_metamatch;
     std::string printinfo_nometamatch;
     std::string printinfo_format;
-    ImageSpec input_config;           // configuration options for reading
-    std::string input_channel_set;    // Optional input channel set
+    ImageSpec input_config;         // configuration options for reading
+    std::string input_channel_set;  // Optional input channel set
 
     // Output options
-    TypeDesc output_dataformat;       // Requested output data format
-    std::map<std::string,std::string> output_channelformats;
+    TypeDesc output_dataformat;  // Requested output data format
+    std::map<std::string, std::string> output_channelformats;
     std::string output_compression;
     std::string output_planarconfig;
     int output_bitspersample;
@@ -105,7 +105,7 @@ public:
     bool output_autocrop;
     bool output_autotrim;
     bool output_dither;
-    bool output_force_tiles; // for debugging
+    bool output_force_tiles;  // for debugging
     bool metadata_nosoftwareattrib;
 
     // Options for --diff
@@ -117,73 +117,76 @@ public:
     float diff_hardfail;
 
     // Internal state
-    ImageRecRef curimg;                      // current image
-    std::vector<ImageRecRef> image_stack;    // stack of previous images
-    std::map<std::string, ImageRecRef> image_labels; // labeled images
-    ImageCache *imagecache = nullptr;        // back ptr to ImageCache
-    ColorConfig colorconfig;                 // OCIO color config
+    ImageRecRef curimg;                    // current image
+    std::vector<ImageRecRef> image_stack;  // stack of previous images
+    std::map<std::string, ImageRecRef> image_labels;  // labeled images
+    ImageCache* imagecache = nullptr;                 // back ptr to ImageCache
+    ColorConfig colorconfig;                          // OCIO color config
     Timer total_runtime;
-    Timer total_readtime  {Timer::DontStartNow};
-    Timer total_writetime {Timer::DontStartNow};
+    Timer total_readtime { Timer::DontStartNow };
+    Timer total_writetime { Timer::DontStartNow };
     double total_imagecache_readtime = 0.0;
     typedef std::map<std::string, double> TimingMap;
     TimingMap function_times;
-    size_t peak_memory = 0;
-    int return_value = EXIT_SUCCESS;         // oiiotool command return code
-    int num_outputs = 0;                     // Count of outputs written
-    int frame_number = 0;
+    size_t peak_memory          = 0;
+    int return_value            = EXIT_SUCCESS;  // oiiotool command return code
+    int num_outputs             = 0;             // Count of outputs written
+    int frame_number            = 0;
     bool enable_function_timing = true;
-    bool input_config_set = false;
-    bool printed_info = false;               // printed info at some point
+    bool input_config_set       = false;
+    bool printed_info           = false;  // printed info at some point
     // Remember the first input dataformats we encountered
     TypeDesc first_input_dataformat;
     int first_input_dataformat_bits = 0;
     std::map<std::string, std::string> first_input_channelformats;
 
-    Oiiotool ();
+    Oiiotool();
 
-    void clear_options ();
-    void clear_input_config ();
+    void clear_options();
+    void clear_input_config();
 
     /// Force img to be read at this point.  Use this wrapper, don't directly
     /// call img->read(), because there's extra work done here specific to
     /// oiiotool.
-    bool read (ImageRecRef img, ReadPolicy readpolicy = ReadDefault);
+    bool read(ImageRecRef img, ReadPolicy readpolicy = ReadDefault);
     // Read the current image
-    bool read (ReadPolicy readpolicy = ReadDefault) {
+    bool read(ReadPolicy readpolicy = ReadDefault)
+    {
         if (curimg)
-            return read (curimg, readpolicy);
+            return read(curimg, readpolicy);
         return true;
     }
 
     // If required_images are not yet on the stack, then postpone this
     // call by putting it on the 'pending' list and return true.
     // Otherwise (if enough images are on the stack), return false.
-    bool postpone_callback (int required_images, CallbackFunction func,
-                            int argc, const char *argv[]);
+    bool postpone_callback(int required_images, CallbackFunction func, int argc,
+                           const char* argv[]);
 
     // Process any pending commands.
-    void process_pending ();
+    void process_pending();
 
-    CallbackFunction pending_callback () const { return m_pending_callback; }
-    const char *pending_callback_name () const { return m_pending_argv[0]; }
+    CallbackFunction pending_callback() const { return m_pending_callback; }
+    const char* pending_callback_name() const { return m_pending_argv[0]; }
 
-    void push (const ImageRecRef &img) {
+    void push(const ImageRecRef& img)
+    {
         if (img) {
             if (curimg)
-                image_stack.push_back (curimg);
+                image_stack.push_back(curimg);
             curimg = img;
         }
     }
 
-    void push (ImageRec *newir) { push (ImageRecRef(newir)); }
+    void push(ImageRec* newir) { push(ImageRecRef(newir)); }
 
-    ImageRecRef pop () {
+    ImageRecRef pop()
+    {
         ImageRecRef r = curimg;
         if (image_stack.size()) {
             // There are images on the full stack -- pop it
-            curimg = image_stack.back ();
-            image_stack.resize (image_stack.size()-1);
+            curimg = image_stack.back();
+            image_stack.resize(image_stack.size() - 1);
         } else {
             // Nothing on the stack, so get rid of the current image
             curimg = ImageRecRef();
@@ -191,15 +194,16 @@ public:
         return r;
     }
 
-    ImageRecRef top () { return curimg; }
+    ImageRecRef top() { return curimg; }
 
     // How many images are on the stack?
-    int image_stack_depth () const {
-        return curimg ? 1+int(image_stack.size()) : 0;
+    int image_stack_depth() const
+    {
+        return curimg ? 1 + int(image_stack.size()) : 0;
     }
 
     // Parse geom in the form of "x,y" to retrieve a 2D integer position.
-    bool get_position (string_view command, string_view geom, int &x, int &y);
+    bool get_position(string_view command, string_view geom, int& x, int& y);
 
     // Modify the resolution and/or offset according to what's in geom.
     // Valid geometries are WxH (resolution), +X+Y (offsets), WxH+X+Y
@@ -207,9 +211,8 @@ public:
     // S% (e.g. "50%") or just S (e.g., "1.2") will be accepted to scale the
     // existing width and height (rounding to the nearest whole number of
     // pixels.
-    bool adjust_geometry (string_view command,
-                          int &w, int &h, int &x, int &y, const char *geom,
-                          bool allow_scaling=false) const;
+    bool adjust_geometry(string_view command, int& w, int& h, int& x, int& y,
+                         const char* geom, bool allow_scaling = false) const;
 
     // Expand substitution expressions in string str. Expressions are
     // enclosed in braces: {...}. An expression consists of:
@@ -221,32 +224,37 @@ public:
     //     "IMG[0]" is the top of the stack; also "TOP" is a synonym). The
     //     metadata can be any of the usual named metadata from the image's
     //     spec, such as "width", "ImageDescription", etc.
-    string_view express (string_view str);
+    string_view express(string_view str);
 
-    int extract_options (std::map<std::string,std::string> &options,
-                         std::string command);
+    int extract_options(std::map<std::string, std::string>& options,
+                        std::string command);
 
-    void error (string_view command, string_view explanation="") const;
-    void warning (string_view command, string_view explanation="") const;
+    void error(string_view command, string_view explanation = "") const;
+    void warning(string_view command, string_view explanation = "") const;
 
-    size_t check_peak_memory () {
-        size_t mem = Sysutil::memory_used();
-        peak_memory = std::max (peak_memory, mem);
+    size_t check_peak_memory()
+    {
+        size_t mem  = Sysutil::memory_used();
+        peak_memory = std::max(peak_memory, mem);
         return mem;
     }
 
 private:
     CallbackFunction m_pending_callback;
     int m_pending_argc;
-    const char *m_pending_argv[4];
+    const char* m_pending_argv[4];
 
-    void express_error (const string_view expr, const string_view s, string_view explanation);
+    void express_error(const string_view expr, const string_view s,
+                       string_view explanation);
 
-    bool express_parse_atom (const string_view expr, string_view& s, std::string& result);
-    bool express_parse_factors (const string_view expr, string_view& s, std::string& result);
-    bool express_parse_summands (const string_view expr, string_view& s, std::string& result);
+    bool express_parse_atom(const string_view expr, string_view& s,
+                            std::string& result);
+    bool express_parse_factors(const string_view expr, string_view& s,
+                               std::string& result);
+    bool express_parse_summands(const string_view expr, string_view& s,
+                                std::string& result);
 
-    std::string express_impl (string_view s);
+    std::string express_impl(string_view s);
 };
 
 
@@ -256,20 +264,19 @@ typedef std::shared_ptr<ImageBuf> ImageBufRef;
 
 class SubimageRec {
 public:
-    int miplevels() const { return (int) m_miplevels.size(); }
-    ImageBuf * operator() () {
-        return miplevels() ? m_miplevels[0].get() : NULL;
-    }
-    ImageBuf * operator[] (int i) {
+    int miplevels() const { return (int)m_miplevels.size(); }
+    ImageBuf* operator()() { return miplevels() ? m_miplevels[0].get() : NULL; }
+    ImageBuf* operator[](int i)
+    {
         return i < miplevels() ? m_miplevels[i].get() : NULL;
     }
-    const ImageBuf * operator[] (int i) const {
+    const ImageBuf* operator[](int i) const
+    {
         return i < miplevels() ? m_miplevels[i].get() : NULL;
     }
-    ImageSpec * spec (int i) {
-        return i < miplevels() ? &m_specs[i] : NULL;
-    }
-    const ImageSpec * spec (int i) const {
+    ImageSpec* spec(int i) { return i < miplevels() ? &m_specs[i] : NULL; }
+    const ImageSpec* spec(int i) const
+    {
         return i < miplevels() ? &m_specs[i] : NULL;
     }
 
@@ -279,13 +286,14 @@ public:
     // handful of operations that should preserve it, but for almost
     // everything else, we don't propagate the value (letting it lapse to
     // false for the result of most image operations).
-    bool was_direct_read () const { return m_was_direct_read; }
-    void was_direct_read (bool f) { m_was_direct_read = f; }
+    bool was_direct_read() const { return m_was_direct_read; }
+    void was_direct_read(bool f) { m_was_direct_read = f; }
 
 private:
     std::vector<ImageBufRef> m_miplevels;
     std::vector<ImageSpec> m_specs;
-    bool m_was_direct_read = false;  ///< Guaranteed pixel data type unmodified since read
+    bool m_was_direct_read
+        = false;  ///< Guaranteed pixel data type unmodified since read
     friend class ImageRec;
 };
 
@@ -296,9 +304,11 @@ private:
 /// and potentially MIPmap levels for each subimage.
 class ImageRec {
 public:
-    ImageRec (const std::string &name, ImageCache *imagecache)
-        : m_name(name), m_imagecache(imagecache)
-    { }
+    ImageRec(const std::string& name, ImageCache* imagecache)
+        : m_name(name)
+        , m_imagecache(imagecache)
+    {
+    }
 
     // Initialize an ImageRec with a collection of prepared ImageSpec's.
     // The number of subimages is nsubimages, the number of MIP levels
@@ -307,8 +317,8 @@ public:
     // contains the specs for all the MIP levels of subimage 0, followed
     // by all the specs for the MIP levels of subimage 1, and so on.
     // If spec == NULL, the IB's will not be fully allocated/initialized.
-    ImageRec (const std::string &name, int nsubimages = 1,
-              const int *miplevels = NULL, const ImageSpec *specs=NULL);
+    ImageRec(const std::string& name, int nsubimages = 1,
+             const int* miplevels = NULL, const ImageSpec* specs = NULL);
 
     // Copy an existing ImageRec.  Copy just the single subimage_to_copy
     // if >= 0, or all subimages if <0.  Copy just the single
@@ -316,20 +326,20 @@ public:
     // is true, we expect to need to alter the pixels of the resulting
     // ImageRec.  If copy_pixels is false, just make the new image big
     // enough, no need to initialize the pixel values.
-    ImageRec (ImageRec &img, int subimage_to_copy = -1,
-              int miplevel_to_copy = -1, bool writable = true,
-              bool copy_pixels = true);
+    ImageRec(ImageRec& img, int subimage_to_copy = -1,
+             int miplevel_to_copy = -1, bool writable = true,
+             bool copy_pixels = true);
 
     // Create an ImageRef that consists of the ImageBuf img.  Copy img
     // if copy_pixels==true, otherwise just take ownership of img (it's
     // a shared pointer).
-    ImageRec (ImageBufRef img, bool copy_pixels = true);
+    ImageRec(ImageBufRef img, bool copy_pixels = true);
 
     // Initialize an ImageRec with the given spec.
-    ImageRec (const std::string &name, const ImageSpec &spec,
-              ImageCache *imagecache);
+    ImageRec(const std::string& name, const ImageSpec& spec,
+             ImageCache* imagecache);
 
-    ImageRec (const ImageRec &copy) = delete;  // Disallow copy ctr
+    ImageRec(const ImageRec& copy) = delete;  // Disallow copy ctr
 
     enum WinMerge { WinMergeUnion, WinMergeIntersection, WinMergeA, WinMergeB };
 
@@ -339,77 +349,77 @@ public:
     // policy for setting up the pixel data and full (display) windows,
     // respectively.  If pixeltype not UNKNOWN, use that rather than
     // A's pixel type (the default behavior).
-    ImageRec (ImageRec &imgA, ImageRec &imgB, int subimage_to_copy = -1,
-              WinMerge pixwin = WinMergeUnion,
-              WinMerge fullwin = WinMergeUnion,
-              TypeDesc pixeltype = TypeDesc::UNKNOWN);
+    ImageRec(ImageRec& imgA, ImageRec& imgB, int subimage_to_copy = -1,
+             WinMerge pixwin = WinMergeUnion, WinMerge fullwin = WinMergeUnion,
+             TypeDesc pixeltype = TypeDesc::UNKNOWN);
 
     // Number of subimages
-    int subimages() const { return (int) m_subimages.size(); }
+    int subimages() const { return (int)m_subimages.size(); }
 
     // Number of MIP levels of the given subimage
-    int miplevels (int subimage=0) const {
+    int miplevels(int subimage = 0) const
+    {
         if (subimage >= subimages())
             return 0;
         return m_subimages[subimage].miplevels();
     }
 
     // Subimage reference accessors.
-    SubimageRec& subimage (int i) {
-        return m_subimages[i];
-    }
-    const SubimageRec& subimage (int i) const {
-        return m_subimages[i];
-    }
+    SubimageRec& subimage(int i) { return m_subimages[i]; }
+    const SubimageRec& subimage(int i) const { return m_subimages[i]; }
 
     // Accessing it like an array returns a specific subimage
-    SubimageRec& operator[] (int i) {
-        return m_subimages[i];
-    }
-    const SubimageRec& operator[] (int i) const {
-        return m_subimages[i];
-    }
+    SubimageRec& operator[](int i) { return m_subimages[i]; }
+    const SubimageRec& operator[](int i) const { return m_subimages[i]; }
 
-    std::string name () const { return m_name; }
+    std::string name() const { return m_name; }
 
     // Has the ImageRec been actually read or evaluated?  (Until needed,
     // it's lazily kept as name only, without reading the file.)
-    bool elaborated () const { return m_elaborated; }
+    bool elaborated() const { return m_elaborated; }
 
-    bool read (ReadPolicy readpolicy = ReadDefault,
-               string_view channel_set = "");
+    bool read(ReadPolicy readpolicy   = ReadDefault,
+              string_view channel_set = "");
 
     // ir(subimg,mip) references a specific MIP level of a subimage
     // ir(subimg) references the first MIP level of a subimage
     // ir() references the first MIP level of the first subimage
-    ImageBuf& operator() (int subimg=0, int mip=0) {
+    ImageBuf& operator()(int subimg = 0, int mip = 0)
+    {
         return *m_subimages[subimg][mip];
     }
-    const ImageBuf& operator() (int subimg=0, int mip=0) const {
+    const ImageBuf& operator()(int subimg = 0, int mip = 0) const
+    {
         return *m_subimages[subimg][mip];
     }
 
-    ImageSpec * spec (int subimg=0, int mip=0) {
+    ImageSpec* spec(int subimg = 0, int mip = 0)
+    {
         return subimg < subimages() ? m_subimages[subimg].spec(mip) : NULL;
     }
-    const ImageSpec * spec (int subimg=0, int mip=0) const {
+    const ImageSpec* spec(int subimg = 0, int mip = 0) const
+    {
         return subimg < subimages() ? m_subimages[subimg].spec(mip) : NULL;
     }
 
-    const ImageSpec * nativespec (int subimg=0, int mip=0) const {
-        return subimg < subimages() ? &((*this)(subimg,mip).nativespec()) : nullptr;
+    const ImageSpec* nativespec(int subimg = 0, int mip = 0) const
+    {
+        return subimg < subimages() ? &((*this)(subimg, mip).nativespec())
+                                    : nullptr;
     }
 
-    bool was_output () const { return m_was_output; }
-    void was_output (bool val) { m_was_output = val; }
-    bool metadata_modified () const { return m_metadata_modified; }
-    void metadata_modified (bool mod) {
+    bool was_output() const { return m_was_output; }
+    void was_output(bool val) { m_was_output = val; }
+    bool metadata_modified() const { return m_metadata_modified; }
+    void metadata_modified(bool mod)
+    {
         m_metadata_modified = mod;
         if (mod)
             was_output(false);
     }
-    bool pixels_modified () const { return m_pixels_modified; }
-    void pixels_modified (bool mod) {
+    bool pixels_modified() const { return m_pixels_modified; }
+    void pixels_modified(bool mod)
+    {
         m_pixels_modified = mod;
         if (mod)
             was_output(false);
@@ -419,58 +429,59 @@ public:
 
     // Request that any eventual input reads be stored internally in this
     // format. UNKNOWN means to use the usual default logic.
-    void input_dataformat (TypeDesc dataformat) {
+    void input_dataformat(TypeDesc dataformat)
+    {
         m_input_dataformat = dataformat;
     }
 
     // This should be called if for some reason the underlying
     // ImageBuf's spec may have been modified in place.  We need to
     // update the outer copy held by the SubimageRec.
-    void update_spec_from_imagebuf (int subimg=0, int mip=0) {
+    void update_spec_from_imagebuf(int subimg = 0, int mip = 0)
+    {
         *m_subimages[subimg].spec(mip) = m_subimages[subimg][mip]->spec();
-        metadata_modified (true);
+        metadata_modified(true);
     }
 
     // Get or set the configuration spec that will be used any time the
     // image is opened.
-    const ImageSpec * configspec () const { return &m_configspec; }
-    void configspec (const ImageSpec &spec) { m_configspec = spec; }
-    void clear_configspec () { configspec (ImageSpec()); }
+    const ImageSpec* configspec() const { return &m_configspec; }
+    void configspec(const ImageSpec& spec) { m_configspec = spec; }
+    void clear_configspec() { configspec(ImageSpec()); }
 
     /// Error reporting for ImageRec: call this with printf-like arguments.
     /// Note however that this is fully typesafe!
     template<typename... Args>
-    void error (string_view fmt, const Args&... args) const {
-        append_error(Strutil::format (fmt, args...));
+    void error(string_view fmt, const Args&... args) const
+    {
+        append_error(Strutil::format(fmt, args...));
     }
 
     /// Return true if the IR has had an error and has an error message
     /// to retrieve via geterror().
-    bool has_error (void) const;
+    bool has_error(void) const;
 
     /// Return the text of all error messages issued since geterror() was
     /// called (or an empty string if no errors are pending).  This also
     /// clears the error message for next time if clear_error is true.
-    std::string geterror (bool clear_error = true) const;
+    std::string geterror(bool clear_error = true) const;
 
 private:
     std::string m_name;
-    bool m_elaborated = false;
+    bool m_elaborated        = false;
     bool m_metadata_modified = false;
-    bool m_pixels_modified = false;
-    bool m_was_output = false;
+    bool m_pixels_modified   = false;
+    bool m_was_output        = false;
     std::vector<SubimageRec> m_subimages;
     std::time_t m_time;  //< Modification time of the input file
     TypeDesc m_input_dataformat;
-    ImageCache *m_imagecache = nullptr;
+    ImageCache* m_imagecache = nullptr;
     mutable std::string m_err;
     ImageSpec m_configspec;
 
     // Add to the error message
-    void append_error (string_view message) const;
-
+    void append_error(string_view message) const;
 };
-
 
 
 
@@ -488,11 +499,18 @@ struct print_info_options {
     std::string infoformat;
     size_t namefieldlength;
 
-    print_info_options ()
-        : verbose(false), filenameprefix(false), sum(false), subimages(false),
-          compute_sha1(false), compute_stats(false), dumpdata(false),
-          dumpdata_showempty(true), namefieldlength(20)
-    {}
+    print_info_options()
+        : verbose(false)
+        , filenameprefix(false)
+        , sum(false)
+        , subimages(false)
+        , compute_sha1(false)
+        , compute_stats(false)
+        , dumpdata(false)
+        , dumpdata_showempty(true)
+        , namefieldlength(20)
+    {
+    }
 };
 
 
@@ -501,9 +519,10 @@ struct print_info_options {
 // of the uncompressed pixels in the file is returned in totalsize.  The
 // return value will be true if everything is ok, or false if there is
 // an error (in which case the error message will be stored in 'error').
-bool print_info (Oiiotool &ot, const std::string &filename, 
-                 const print_info_options &opt,
-                 long long &totalsize, std::string &error);
+bool
+print_info(Oiiotool& ot, const std::string& filename,
+           const print_info_options& opt, long long& totalsize,
+           std::string& error);
 
 
 // Set an attribute of the given image.  The type should be one of
@@ -512,33 +531,36 @@ bool print_info (Oiiotool &ot, const std::string &filename,
 // string).  If the 'value' string is empty, it will delete the
 // attribute.  If allsubimages is true, apply the attribute to all
 // subimages, otherwise just the first subimage.
-bool set_attribute (ImageRecRef img, string_view attribname,
-                    TypeDesc type, string_view value,
-                    bool allsubimages);
+bool
+set_attribute(ImageRecRef img, string_view attribname, TypeDesc type,
+              string_view value, bool allsubimages);
 
-inline bool same_size (const ImageBuf &A, const ImageBuf &B)
+inline bool
+same_size(const ImageBuf& A, const ImageBuf& B)
 {
-    const ImageSpec &a (A.spec()), &b (B.spec());
-    return (a.width == b.width && a.height == b.height &&
-            a.depth == b.depth && a.nchannels == b.nchannels);
+    const ImageSpec &a(A.spec()), &b(B.spec());
+    return (a.width == b.width && a.height == b.height && a.depth == b.depth
+            && a.nchannels == b.nchannels);
 }
 
 
 enum DiffErrors {
-    DiffErrOK = 0,            ///< No errors, the images match exactly
-    DiffErrWarn,              ///< Warning: the errors differ a little
-    DiffErrFail,              ///< Failure: the errors differ a lot
-    DiffErrDifferentSize,     ///< Images aren't even the same size
-    DiffErrFile,              ///< Could not find or open input files, etc.
+    DiffErrOK = 0,         ///< No errors, the images match exactly
+    DiffErrWarn,           ///< Warning: the errors differ a little
+    DiffErrFail,           ///< Failure: the errors differ a lot
+    DiffErrDifferentSize,  ///< Images aren't even the same size
+    DiffErrFile,           ///< Could not find or open input files, etc.
     DiffErrLast
 };
 
-int do_action_diff (ImageRec &ir0, ImageRec &ir1, Oiiotool &options,
-                    int perceptual = 0);
+int
+do_action_diff(ImageRec& ir0, ImageRec& ir1, Oiiotool& options,
+               int perceptual = 0);
 
-bool decode_channel_set (const ImageSpec &spec, string_view chanlist,
-                    std::vector<std::string> &newchannelnames,
-                    std::vector<int> &channels, std::vector<float> &values);
+bool
+decode_channel_set(const ImageSpec& spec, string_view chanlist,
+                   std::vector<std::string>& newchannelnames,
+                   std::vector<int>& channels, std::vector<float>& values);
 
 
 
@@ -546,21 +568,21 @@ bool decode_channel_set (const ImageSpec &spec, string_view chanlist,
 // The action needs a signature like:
 //     bool action(ImageSpec &spec, const T& t))
 template<class Action, class Type>
-bool apply_spec_mod (ImageRec &img, Action act, const Type &t,
-                     bool allsubimages)
+bool
+apply_spec_mod(ImageRec& img, Action act, const Type& t, bool allsubimages)
 {
     bool ok = true;
-    img.read ();
-    img.metadata_modified (true);
-    for (int s = 0, send = img.subimages();  s < send;  ++s) {
-        for (int m = 0, mend = img.miplevels(s);  m < mend;  ++m) {
-            ok &= act (img(s,m).specmod(), t);
+    img.read();
+    img.metadata_modified(true);
+    for (int s = 0, send = img.subimages(); s < send; ++s) {
+        for (int m = 0, mend = img.miplevels(s); m < mend; ++m) {
+            ok &= act(img(s, m).specmod(), t);
             if (ok)
-                img.update_spec_from_imagebuf (s, m);
-            if (! allsubimages)
+                img.update_spec_from_imagebuf(s, m);
+            if (!allsubimages)
                 break;
         }
-        if (! allsubimages)
+        if (!allsubimages)
             break;
     }
     return ok;
@@ -578,26 +600,30 @@ public:
     // The constructor records the arguments (including running them
     // through expression substitution) and pops the input images off the
     // stack.
-    OiiotoolOp (Oiiotool &ot, string_view opname,
-                int argc, const char *argv[], int ninputs)
-        : ot(ot), m_opname(opname), m_nargs(argc), m_nimages(ninputs+1)
+    OiiotoolOp(Oiiotool& ot, string_view opname, int argc, const char* argv[],
+               int ninputs)
+        : ot(ot)
+        , m_opname(opname)
+        , m_nargs(argc)
+        , m_nimages(ninputs + 1)
     {
-        args.reserve (argc);
+        args.reserve(argc);
         for (int i = 0; i < argc; ++i)
-            args.push_back (ot.express (argv[i]));
-        ir.resize (ninputs+1);  // including reserving a spot for result
+            args.push_back(ot.express(argv[i]));
+        ir.resize(ninputs + 1);  // including reserving a spot for result
         for (int i = 0; i < ninputs; ++i)
-            ir[ninputs-i] = ot.pop();
+            ir[ninputs - i] = ot.pop();
     }
-    virtual ~OiiotoolOp () {}
+    virtual ~OiiotoolOp() {}
 
     // The operator(), function-call mode, does most of the work. Although
     // it's virtual, in general you shouldn't need to override it. Instead,
     // just override impl(), and maybe option_defaults.
-    virtual int operator() () {
+    virtual int operator()()
+    {
         // Set up a timer to automatically record how much time is spent in
         // every class of operation.
-        Timer timer (ot.enable_function_timing);
+        Timer timer(ot.enable_function_timing);
         if (ot.debug) {
             std::cout << "Performing '" << opname() << "'";
             if (nargs() > 1)
@@ -608,62 +634,62 @@ public:
         }
 
         // Parse the options.
-        options.clear ();
+        options.clear();
         options["allsubimages"] = ot.allsubimages;
-        option_defaults ();  // this can be customized to set up defaults
-        ot.extract_options (options, args[0]);
+        option_defaults();  // this can be customized to set up defaults
+        ot.extract_options(options, args[0]);
 
         // Read all input images, and reserve (and push) the output image.
         int subimages = compute_subimages();
         if (nimages()) {
             // Read the inputs
             for (int i = 1; i < nimages(); ++i)
-                ot.read (ir[i]);
+                ot.read(ir[i]);
             // Initialize the output image
-            ir[0].reset (new ImageRec (opname(), subimages));
-            ot.push (ir[0]);
+            ir[0].reset(new ImageRec(opname(), subimages));
+            ot.push(ir[0]);
         }
 
         // Give a chance for customization before we walk the subimages.
         // If the setup method returns false, we're done.
-        if (! setup ())
+        if (!setup())
             return 0;
 
         // For each subimage, find the ImageBuf's for input and output
         // images, and call impl().
-        for (int s = 0;  s < subimages;  ++s) {
+        for (int s = 0; s < subimages; ++s) {
             // Get pointers for the ImageBufs for this subimage
-            img.resize (nimages());
+            img.resize(nimages());
             for (int i = 0; i < nimages(); ++i)
-                img[i] = &((*ir[i])(std::min (s, ir[i]->subimages()-1)));
+                img[i] = &((*ir[i])(std::min(s, ir[i]->subimages() - 1)));
 
             // Call the impl kernel for this subimage
-            bool ok = impl (nimages() ? &img[0] : NULL);
-            if (! ok)
-                ot.error (opname(), img[0]->geterror());
-            ir[0]->update_spec_from_imagebuf (s);
+            bool ok = impl(nimages() ? &img[0] : NULL);
+            if (!ok)
+                ot.error(opname(), img[0]->geterror());
+            ir[0]->update_spec_from_imagebuf(s);
         }
 
         // Make sure to forward any errors missed by the impl
         for (int i = 0; i < nimages(); ++i) {
             if (img[i]->has_error())
-                ot.error (opname(), img[i]->geterror());
+                ot.error(opname(), img[i]->geterror());
         }
 
         if (ot.debug || ot.runstats)
             ot.check_peak_memory();
 
         // Optional cleanup after processing all the subimages
-        cleanup ();
+        cleanup();
 
         // Add the time we spent to the stats total for this op type.
         double optime = timer();
         ot.function_times[opname()] += optime;
         if (ot.debug) {
-            Strutil::printf ("    %s took %s  (total time %s, mem %s)\n",
-                             opname(), Strutil::timeintervalformat(optime,2),
-                             Strutil::timeintervalformat(ot.total_runtime(),2),
-                             Strutil::memformat(Sysutil::memory_used()));
+            Strutil::printf("    %s took %s  (total time %s, mem %s)\n",
+                            opname(), Strutil::timeintervalformat(optime, 2),
+                            Strutil::timeintervalformat(ot.total_runtime(), 2),
+                            Strutil::memformat(Sysutil::memory_used()));
         }
         return 0;
     }
@@ -671,105 +697,116 @@ public:
     // THIS is the method that needs to be separately overloaded for each
     // different op. This is called once for each subimage, generally with
     // img[0] the destination ImageBuf, and img[1..] as the inputs.
-    virtual int impl (ImageBuf **img) = 0;
+    virtual int impl(ImageBuf** img) = 0;
 
     // Extra place to inject customization before the subimages are
     // traversed.
-    virtual bool setup () { return true; }
+    virtual bool setup() { return true; }
 
     // Extra place to inject customization after the subimges are traversed.
-    virtual bool cleanup () { return true; }
+    virtual bool cleanup() { return true; }
 
     // Override this if the impl uses options and needs any of them set
     // to defaults. This will be called separate
-    virtual void option_defaults () { }
+    virtual void option_defaults() {}
 
     // Default subimage logic: if the global -a flag was set or if this command
     // had ":allsubimages=1" option set, then apply the command to all subimages
     // (of the first input image). Otherwise, we'll only apply the command to
     // the first subimage. Override this is you want another behavior.
-    virtual int compute_subimages () {
+    virtual int compute_subimages()
+    {
         int all_subimages = Strutil::from_string<int>(options["allsubimages"]);
         return all_subimages ? (nimages() > 1 ? ir[1]->subimages() : 1) : 1;
     }
 
-    int nargs () const { return m_nargs; }
-    int nimages () const { return m_nimages; }
-    string_view opname () const { return m_opname; }
+    int nargs() const { return m_nargs; }
+    int nimages() const { return m_nimages; }
+    string_view opname() const { return m_opname; }
 
 protected:
-    Oiiotool &ot;
+    Oiiotool& ot;
     std::string m_opname;
     int m_nargs;
     int m_nimages;
     std::vector<ImageRecRef> ir;
-    std::vector<ImageBuf *> img;
+    std::vector<ImageBuf*> img;
     std::vector<string_view> args;
-    std::map<std::string,std::string> options;
+    std::map<std::string, std::string> options;
 };
 
 
-typedef bool (*IBAunary) (ImageBuf &dst, const ImageBuf &A, ROI roi, int nthreads);
-typedef bool (*IBAbinary) (ImageBuf &dst, const ImageBuf &A,
-                           const ImageBuf &B, ROI roi, int nthreads);
-typedef bool (*IBAbinary_img_col) (ImageBuf &dst, const ImageBuf &A,
-                                   const float *B, ROI roi, int nthreads);
-typedef bool (*IBAbinary_) (ImageBuf &dst, Image_or_Const A,
-                           Image_or_Const B, ROI roi, int nthreads);
+typedef bool (*IBAunary)(ImageBuf& dst, const ImageBuf& A, ROI roi,
+                         int nthreads);
+typedef bool (*IBAbinary)(ImageBuf& dst, const ImageBuf& A, const ImageBuf& B,
+                          ROI roi, int nthreads);
+typedef bool (*IBAbinary_img_col)(ImageBuf& dst, const ImageBuf& A,
+                                  const float* B, ROI roi, int nthreads);
+typedef bool (*IBAbinary_)(ImageBuf& dst, Image_or_Const A, Image_or_Const B,
+                           ROI roi, int nthreads);
 
-template<typename IBLIMPL=IBAunary>
+template<typename IBLIMPL = IBAunary>
 class OiiotoolSimpleUnaryOp : public OiiotoolOp {
 public:
-    OiiotoolSimpleUnaryOp (IBLIMPL opimpl, Oiiotool &ot, string_view opname,
-                           int argc, const char *argv[], int ninputs)
-        : OiiotoolOp (ot, opname, argc, argv, 1), opimpl(opimpl)
-    {}
-    virtual int impl (ImageBuf **img) {
-        return opimpl (*img[0], *img[1], ROI(), 0);
+    OiiotoolSimpleUnaryOp(IBLIMPL opimpl, Oiiotool& ot, string_view opname,
+                          int argc, const char* argv[], int ninputs)
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+        , opimpl(opimpl)
+    {
     }
+    virtual int impl(ImageBuf** img)
+    {
+        return opimpl(*img[0], *img[1], ROI(), 0);
+    }
+
 protected:
     IBLIMPL opimpl;
 };
 
-template<typename IBLIMPL=IBAbinary>
+template<typename IBLIMPL = IBAbinary>
 class OiiotoolSimpleBinaryOp : public OiiotoolOp {
 public:
-    OiiotoolSimpleBinaryOp (IBLIMPL opimpl, Oiiotool &ot, string_view opname,
-                            int argc, const char *argv[], int ninputs)
-        : OiiotoolOp (ot, opname, argc, argv, 2), opimpl(opimpl)
-    {}
-    virtual int impl (ImageBuf **img) {
-        return opimpl (*img[0], *img[1], *img[2], ROI(), 0);
+    OiiotoolSimpleBinaryOp(IBLIMPL opimpl, Oiiotool& ot, string_view opname,
+                           int argc, const char* argv[], int ninputs)
+        : OiiotoolOp(ot, opname, argc, argv, 2)
+        , opimpl(opimpl)
+    {
     }
+    virtual int impl(ImageBuf** img)
+    {
+        return opimpl(*img[0], *img[1], *img[2], ROI(), 0);
+    }
+
 protected:
     IBLIMPL opimpl;
 };
 
-template<typename IBLIMPL=IBAbinary_img_col>
+template<typename IBLIMPL = IBAbinary_img_col>
 class OiiotoolImageColorOp : public OiiotoolOp {
 public:
-    OiiotoolImageColorOp (IBLIMPL opimpl, Oiiotool &ot, string_view opname,
-                          int argc, const char *argv[], int ninputs,
-                          float defaultval=0.0f)
-        : OiiotoolOp (ot, opname, argc, argv, 1), opimpl(opimpl),
-          defaultval(defaultval)
-    {}
-    virtual int impl (ImageBuf **img) {
-        int nchans = img[1]->spec().nchannels;
-        std::vector<float> val (nchans, defaultval);
-        int nvals = Strutil::extract_from_list_string (val, args[1]);
-        val.resize (nvals);
-        val.resize (nchans, val.size() == 1 ? val.back() : defaultval);
-        return opimpl (*img[0], *img[1], &val[0], ROI(), 0);
+    OiiotoolImageColorOp(IBLIMPL opimpl, Oiiotool& ot, string_view opname,
+                         int argc, const char* argv[], int ninputs,
+                         float defaultval = 0.0f)
+        : OiiotoolOp(ot, opname, argc, argv, 1)
+        , opimpl(opimpl)
+        , defaultval(defaultval)
+    {
     }
+    virtual int impl(ImageBuf** img)
+    {
+        int nchans = img[1]->spec().nchannels;
+        std::vector<float> val(nchans, defaultval);
+        int nvals = Strutil::extract_from_list_string(val, args[1]);
+        val.resize(nvals);
+        val.resize(nchans, val.size() == 1 ? val.back() : defaultval);
+        return opimpl(*img[0], *img[1], &val[0], ROI(), 0);
+    }
+
 protected:
     IBLIMPL opimpl;
     float defaultval;
 };
 
 
-} // OiioTool namespace
+}  // namespace OiioTool
 OIIO_NAMESPACE_END;
-
-
-#endif // OIIOTOOL_H

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -29,40 +29,41 @@
 */
 
 
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
-#include <cmath>
 #include <ctime>
 #include <iostream>
 #include <iterator>
 #include <memory>
 #if defined(_MSC_VER)
-#include <io.h>
+#    include <io.h>
 #endif
 
-#include <OpenEXR/half.h>
 #include <OpenEXR/ImathVec.h>
+#include <OpenEXR/half.h>
 
 #include <OpenImageIO/argparse.h>
-#include <OpenImageIO/strutil.h>
-#include <OpenImageIO/sysutil.h>
-#include <OpenImageIO/imageio.h>
+#include <OpenImageIO/deepdata.h>
+#include <OpenImageIO/fmath.h>
+#include <OpenImageIO/hash.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
-#include <OpenImageIO/deepdata.h>
-#include <OpenImageIO/hash.h>
-#include <OpenImageIO/fmath.h>
+#include <OpenImageIO/imageio.h>
 #include <OpenImageIO/span.h>
+#include <OpenImageIO/strutil.h>
+#include <OpenImageIO/sysutil.h>
+
 #include "oiiotool.h"
 
 #ifdef USE_BOOST_REGEX
-# include <boost/regex.hpp>
-  using boost::regex;
-  using boost::regex_search;
+#    include <boost/regex.hpp>
+using boost::regex;
+using boost::regex_search;
 #else
-# include <regex>
-  using std::regex;
-  using std::regex_search;
+#    include <regex>
+using std::regex;
+using std::regex_search;
 #endif
 
 
@@ -72,36 +73,34 @@ using namespace ImageBufAlgo;
 
 
 
-
-
 static std::string
-compute_sha1 (Oiiotool &ot, ImageInput *input)
+compute_sha1(Oiiotool& ot, ImageInput* input)
 {
     SHA1 sha;
-    const ImageSpec &spec (input->spec());
+    const ImageSpec& spec(input->spec());
     if (spec.deep) {
         // Special handling of deep data
         DeepData dd;
-        if (! input->read_native_deep_image (dd)) {
-            ot.error ("    SHA-1: unable to compute, could not read image\n");
+        if (!input->read_native_deep_image(dd)) {
+            ot.error("    SHA-1: unable to compute, could not read image\n");
             return std::string();
         }
         // Hash both the sample counts and the data block
-        sha.append (dd.all_samples());
-        sha.append (dd.all_data());
+        sha.append(dd.all_samples());
+        sha.append(dd.all_data());
     } else {
-        imagesize_t size = input->spec().image_bytes (true /*native*/);
+        imagesize_t size = input->spec().image_bytes(true /*native*/);
         if (size >= std::numeric_limits<size_t>::max()) {
-            ot.error ("    SHA-1: unable to compute, image is too big\n");
+            ot.error("    SHA-1: unable to compute, image is too big\n");
             return std::string();
-        }
-        else if (size != 0) {
-            std::unique_ptr<char[]> buf (new char [size]);
-            if (! input->read_image (TypeDesc::UNKNOWN /*native*/, &buf[0])) {
-                ot.error ("    SHA-1: unable to compute, could not read image\n");
+        } else if (size != 0) {
+            std::unique_ptr<char[]> buf(new char[size]);
+            if (!input->read_image(TypeDesc::UNKNOWN /*native*/, &buf[0])) {
+                ot.error(
+                    "    SHA-1: unable to compute, could not read image\n");
                 return std::string();
             }
-            sha.append (&buf[0], size);
+            sha.append(&buf[0], size);
         }
     }
 
@@ -112,34 +111,34 @@ compute_sha1 (Oiiotool &ot, ImageInput *input)
 
 template<typename T>
 static void
-print_nums (int n, const T* val, string_view sep=" ")
+print_nums(int n, const T* val, string_view sep = " ")
 {
     if (std::is_floating_point<T>::value) {
         // Ensure uniform printing of NaN and Inf on all platforms
         for (int i = 0; i < n; ++i) {
             if (i)
-                Strutil::printf ("%s", sep);
+                Strutil::printf("%s", sep);
             float v = float(val[i]);
             if (isnan(v))
-                Strutil::printf ("nan");
+                Strutil::printf("nan");
             else if (isinf(v))
-                Strutil::printf ("inf");
+                Strutil::printf("inf");
             else
-                Strutil::printf ("%.9f",v);
+                Strutil::printf("%.9f", v);
         }
     } else {
         // not floating point -- print the int values, then float equivalents
         for (int i = 0; i < n; ++i) {
-            Strutil::printf ("%s%g", i ? sep : "", val[i]);
+            Strutil::printf("%s%g", i ? sep : "", val[i]);
         }
-        Strutil::printf (" (");
+        Strutil::printf(" (");
         for (int i = 0; i < n; ++i) {
             if (i)
-                Strutil::printf ("%s", sep);
-            float v = convert_type<T,float>(val[i]);
-            Strutil::printf ("%g", v);
+                Strutil::printf("%s", sep);
+            float v = convert_type<T, float>(val[i]);
+            Strutil::printf("%g", v);
         }
-        Strutil::printf (")");
+        Strutil::printf(")");
     }
 }
 
@@ -147,19 +146,19 @@ print_nums (int n, const T* val, string_view sep=" ")
 
 template<typename T>
 static bool
-dump_flat_data (ImageInput *input, const print_info_options &opt)
+dump_flat_data(ImageInput* input, const print_info_options& opt)
 {
-    const ImageSpec &spec (input->spec());
+    const ImageSpec& spec(input->spec());
     std::vector<T> buf(spec.image_pixels() * spec.nchannels);
-    if (! input->read_image (BaseTypeFromC<T>::value, &buf[0])) {
-        printf ("    dump data: could not read image\n");
+    if (!input->read_image(BaseTypeFromC<T>::value, &buf[0])) {
+        printf("    dump data: could not read image\n");
         return false;
     }
-    const T *ptr = &buf[0];
-    for (int z = 0;  z < spec.depth;  ++z) {
-        for (int y = 0;  y < spec.height;  ++y) {
-            for (int x = 0;  x < spec.width;  ++x, ptr += spec.nchannels) {
-                if (! opt.dumpdata_showempty) {
+    const T* ptr = &buf[0];
+    for (int z = 0; z < spec.depth; ++z) {
+        for (int y = 0; y < spec.height; ++y) {
+            for (int x = 0; x < spec.width; ++x, ptr += spec.nchannels) {
+                if (!opt.dumpdata_showempty) {
                     bool allzero = true;
                     for (int c = 0; c < spec.nchannels && allzero; ++c)
                         allzero &= (ptr[c] == T(0));
@@ -167,13 +166,13 @@ dump_flat_data (ImageInput *input, const print_info_options &opt)
                         continue;
                 }
                 if (spec.depth > 1 || spec.z != 0)
-                    Strutil::printf("    Pixel (%d, %d, %d): ",
-                                    x+spec.x, y+spec.y, z+spec.z);
+                    Strutil::printf("    Pixel (%d, %d, %d): ", x + spec.x,
+                                    y + spec.y, z + spec.z);
                 else
-                    Strutil::printf("    Pixel (%d, %d): ",
-                                    x+spec.x, y+spec.y);
-                print_nums (spec.nchannels, ptr);
-                Strutil::printf ("\n");
+                    Strutil::printf("    Pixel (%d, %d): ", x + spec.x,
+                                    y + spec.y);
+                print_nums(spec.nchannels, ptr);
+                Strutil::printf("\n");
             }
         }
     }
@@ -183,68 +182,58 @@ dump_flat_data (ImageInput *input, const print_info_options &opt)
 
 
 // Macro to call a type-specialzed version func<type>(R,...)
-#define OIIO_DISPATCH_TYPES(ret,name,func,type,R,...)                   \
-    switch (type.basetype) {                                            \
-    case TypeDesc::FLOAT :                                              \
-        ret = func<float> (R, __VA_ARGS__); break;                      \
-    case TypeDesc::UINT8 :                                              \
-        ret = func<unsigned char> (R, __VA_ARGS__); break;              \
-    case TypeDesc::HALF  :                                              \
-        ret = func<half> (R, __VA_ARGS__); break;                       \
-    case TypeDesc::UINT16:                                              \
-        ret = func<unsigned short> (R, __VA_ARGS__); break;             \
-    case TypeDesc::INT8  :                                              \
-        ret = func<char> (R, __VA_ARGS__); break;                       \
-    case TypeDesc::INT16 :                                              \
-        ret = func<short> (R, __VA_ARGS__); break;                      \
-    case TypeDesc::UINT  :                                              \
-        ret = func<unsigned int> (R, __VA_ARGS__); break;               \
-    case TypeDesc::INT   :                                              \
-        ret = func<int> (R, __VA_ARGS__); break;                        \
-    case TypeDesc::DOUBLE:                                              \
-        ret = func<double> (R, __VA_ARGS__); break;                     \
-    default:                                                            \
-        ret = false;                                                    \
+#define OIIO_DISPATCH_TYPES(ret, name, func, type, R, ...)                     \
+    switch (type.basetype) {                                                   \
+    case TypeDesc::FLOAT: ret = func<float>(R, __VA_ARGS__); break;            \
+    case TypeDesc::UINT8: ret = func<unsigned char>(R, __VA_ARGS__); break;    \
+    case TypeDesc::HALF: ret = func<half>(R, __VA_ARGS__); break;              \
+    case TypeDesc::UINT16: ret = func<unsigned short>(R, __VA_ARGS__); break;  \
+    case TypeDesc::INT8: ret = func<char>(R, __VA_ARGS__); break;              \
+    case TypeDesc::INT16: ret = func<short>(R, __VA_ARGS__); break;            \
+    case TypeDesc::UINT: ret = func<unsigned int>(R, __VA_ARGS__); break;      \
+    case TypeDesc::INT: ret = func<int>(R, __VA_ARGS__); break;                \
+    case TypeDesc::DOUBLE: ret = func<double>(R, __VA_ARGS__); break;          \
+    default: ret = false;                                                      \
     }
 
 
 
 static void
-dump_data (ImageInput *input, const print_info_options &opt)
+dump_data(ImageInput* input, const print_info_options& opt)
 {
-    const ImageSpec &spec (input->spec());
+    const ImageSpec& spec(input->spec());
     if (spec.deep) {
         // Special handling of deep data
         DeepData dd;
-        if (! input->read_native_deep_image (dd)) {
-            printf ("    dump data: could not read image\n");
+        if (!input->read_native_deep_image(dd)) {
+            printf("    dump data: could not read image\n");
             return;
         }
         int nc = spec.nchannels;
-        for (int z = 0, pixel = 0;  z < spec.depth;  ++z) {
-            for (int y = 0;  y < spec.height;  ++y) {
-                for (int x = 0;  x < spec.width;  ++x, ++pixel) {
+        for (int z = 0, pixel = 0; z < spec.depth; ++z) {
+            for (int y = 0; y < spec.height; ++y) {
+                for (int x = 0; x < spec.width; ++x, ++pixel) {
                     int nsamples = dd.samples(pixel);
-                    if (nsamples == 0 && ! opt.dumpdata_showempty)
+                    if (nsamples == 0 && !opt.dumpdata_showempty)
                         continue;
                     std::cout << "    Pixel (";
                     if (spec.depth > 1 || spec.z != 0)
-                        std::cout << Strutil::format("%d, %d, %d",
-                                             x+spec.x, y+spec.y, z+spec.z);
+                        std::cout << Strutil::format("%d, %d, %d", x + spec.x,
+                                                     y + spec.y, z + spec.z);
                     else
-                        std::cout << Strutil::format("%d, %d",
-                                                     x+spec.x, y+spec.y);
-                    std::cout << "): " << nsamples << " samples" 
+                        std::cout << Strutil::format("%d, %d", x + spec.x,
+                                                     y + spec.y);
+                    std::cout << "): " << nsamples << " samples"
                               << (nsamples ? ":" : "");
-                    for (int s = 0;  s < nsamples;  ++s) {
+                    for (int s = 0; s < nsamples; ++s) {
                         if (s)
                             std::cout << " / ";
-                        for (int c = 0;  c < nc;  ++c) {
+                        for (int c = 0; c < nc; ++c) {
                             std::cout << " " << spec.channelnames[c] << "=";
                             if (dd.channeltype(c) == TypeDesc::UINT)
                                 std::cout << dd.deep_value_uint(pixel, c, s);
                             else
-                                std::cout << dd.deep_value (pixel, c, s);
+                                std::cout << dd.deep_value(pixel, c, s);
                         }
                     }
                     std::cout << "\n";
@@ -254,8 +243,8 @@ dump_data (ImageInput *input, const print_info_options &opt)
 
     } else {
         OIIO_UNUSED_OK bool ok = true;
-        OIIO_DISPATCH_TYPES (ok, "dump_flat_data", dump_flat_data,
-                             spec.format, input, opt);
+        OIIO_DISPATCH_TYPES(ok, "dump_flat_data", dump_flat_data, spec.format,
+                            input, opt);
     }
 }
 
@@ -265,22 +254,22 @@ dump_data (ImageInput *input, const print_info_options &opt)
 // Stats
 
 static bool
-read_input (const std::string &filename, ImageBuf &img,
-            int subimage=0, int miplevel=0)
+read_input(const std::string& filename, ImageBuf& img, int subimage = 0,
+           int miplevel = 0)
 {
     if (img.subimage() >= 0 && img.subimage() == subimage)
         return true;
 
-    if (img.init_spec (filename, subimage, miplevel)) {
+    if (img.init_spec(filename, subimage, miplevel)) {
         // Force a read now for reasonable-sized first images in the
         // file. This can greatly speed up the multithread case for
         // tiled images by not having multiple threads working on the
         // same image lock against each other on the file handle.
         // We guess that "reasonable size" is 200 MB, that's enough to
-        // hold a 4k RGBA float image.  Larger things will 
+        // hold a 4k RGBA float image.  Larger things will
         // simply fall back on ImageCache.
-        bool forceread = (img.spec().image_bytes() < 200*1024*1024);
-        return img.read (subimage, miplevel, forceread);
+        bool forceread = (img.spec().image_bytes() < 200 * 1024 * 1024);
+        return img.read(subimage, miplevel, forceread);
     }
 
     return false;
@@ -289,22 +278,22 @@ read_input (const std::string &filename, ImageBuf &img,
 
 
 static void
-print_stats_num (float val, int maxval, bool round)
+print_stats_num(float val, int maxval, bool round)
 {
     // Ensure uniform printing of NaN and Inf on all platforms
     if (isnan(val))
-        printf ("nan");
+        printf("nan");
     else if (isinf(val))
-        printf ("inf");
+        printf("inf");
     else if (maxval == 0) {
-        printf("%f",val);
+        printf("%f", val);
     } else {
         float fval = val * static_cast<float>(maxval);
         if (round) {
-            int v = static_cast<int>(roundf (fval));
-            printf ("%d", v);
+            int v = static_cast<int>(roundf(fval));
+            printf("%d", v);
         } else {
-            printf ("%0.2f", fval);
+            printf("%0.2f", fval);
         }
     }
 }
@@ -314,136 +303,141 @@ print_stats_num (float val, int maxval, bool round)
 // fall back on the TypeDesc. return 0 for float types
 // or those that exceed the int range (long long, etc)
 static unsigned long long
-get_intsample_maxval (const ImageSpec &spec)
+get_intsample_maxval(const ImageSpec& spec)
 {
     TypeDesc type = spec.format;
-    int bits = spec.get_int_attribute ("oiio:BitsPerSample");
+    int bits      = spec.get_int_attribute("oiio:BitsPerSample");
     if (bits > 0) {
-        if (type.basetype == TypeDesc::UINT8 ||
-              type.basetype == TypeDesc::UINT16 ||
-              type.basetype == TypeDesc::UINT32)
+        if (type.basetype == TypeDesc::UINT8
+            || type.basetype == TypeDesc::UINT16
+            || type.basetype == TypeDesc::UINT32)
             return ((1LL) << bits) - 1;
-        if (type.basetype == TypeDesc::INT8 ||
-              type.basetype == TypeDesc::INT16 ||
-              type.basetype == TypeDesc::INT32)
-            return ((1LL) << (bits-1)) - 1;
+        if (type.basetype == TypeDesc::INT8 || type.basetype == TypeDesc::INT16
+            || type.basetype == TypeDesc::INT32)
+            return ((1LL) << (bits - 1)) - 1;
     }
-    
+
     // These correspond to all the int enums in typedesc.h <= int
-    if (type.basetype == TypeDesc::UCHAR)        return 0xff;
-    if (type.basetype == TypeDesc::CHAR)         return 0x7f;
-    if (type.basetype == TypeDesc::USHORT)     return 0xffff;
-    if (type.basetype == TypeDesc::SHORT)      return 0x7fff;
-    if (type.basetype == TypeDesc::UINT)   return 0xffffffff;
-    if (type.basetype == TypeDesc::INT)    return 0x7fffffff;
-    
+    if (type.basetype == TypeDesc::UCHAR)
+        return 0xff;
+    if (type.basetype == TypeDesc::CHAR)
+        return 0x7f;
+    if (type.basetype == TypeDesc::USHORT)
+        return 0xffff;
+    if (type.basetype == TypeDesc::SHORT)
+        return 0x7fff;
+    if (type.basetype == TypeDesc::UINT)
+        return 0xffffffff;
+    if (type.basetype == TypeDesc::INT)
+        return 0x7fffffff;
+
     return 0;
 }
 
 
 static void
-print_stats_footer (unsigned int maxval)
+print_stats_footer(unsigned int maxval)
 {
-    if (maxval==0)
-        printf ("(float)");
+    if (maxval == 0)
+        printf("(float)");
     else
-        printf ("(of %u)", maxval);
+        printf("(of %u)", maxval);
 }
 
 
 static void
-print_stats (Oiiotool &ot,
-             const std::string &filename,
-             const ImageSpec &originalspec,
-             int subimage=0, int miplevel=0, bool indentmip=false)
+print_stats(Oiiotool& ot, const std::string& filename,
+            const ImageSpec& originalspec, int subimage = 0, int miplevel = 0,
+            bool indentmip = false)
 {
-    const char *indent = indentmip ? "      " : "    ";
+    const char* indent = indentmip ? "      " : "    ";
     ImageBuf input;
-    
-    if (! read_input (filename, input, subimage, miplevel)) {
-        ot.error ("stats", input.geterror());
+
+    if (!read_input(filename, input, subimage, miplevel)) {
+        ot.error("stats", input.geterror());
         return;
     }
     PixelStats stats;
-    if (! computePixelStats (stats, input)) {
+    if (!computePixelStats(stats, input)) {
         std::string err = input.geterror();
-        ot.error ("stats", Strutil::format ("unable to compute: %s",
-                                            err.empty() ? "unspecified error" : err.c_str()));
+        ot.error("stats", Strutil::format("unable to compute: %s",
+                                          err.empty() ? "unspecified error"
+                                                      : err.c_str()));
         return;
     }
-    
+
     // The original spec is used, otherwise the bit depth will
     // be reported incorrectly (as FLOAT)
-    unsigned int maxval = (unsigned int)get_intsample_maxval (originalspec);
-    
-    printf ("%sStats Min: ", indent);
-    for (unsigned int i=0; i<stats.min.size(); ++i) {
-        print_stats_num (stats.min[i], maxval, true);
-        printf (" ");
+    unsigned int maxval = (unsigned int)get_intsample_maxval(originalspec);
+
+    printf("%sStats Min: ", indent);
+    for (unsigned int i = 0; i < stats.min.size(); ++i) {
+        print_stats_num(stats.min[i], maxval, true);
+        printf(" ");
     }
-    print_stats_footer (maxval);
-    printf ("\n");
-    
-    printf ("%sStats Max: ", indent);
-    for (unsigned int i=0; i<stats.max.size(); ++i) {
-        print_stats_num (stats.max[i], maxval, true);
-        printf (" ");
+    print_stats_footer(maxval);
+    printf("\n");
+
+    printf("%sStats Max: ", indent);
+    for (unsigned int i = 0; i < stats.max.size(); ++i) {
+        print_stats_num(stats.max[i], maxval, true);
+        printf(" ");
     }
-    print_stats_footer (maxval);
-    printf ("\n");
-    
-    printf ("%sStats Avg: ", indent);
-    for (unsigned int i=0; i<stats.avg.size(); ++i) {
-        print_stats_num (stats.avg[i], maxval, false);
-        printf (" ");
+    print_stats_footer(maxval);
+    printf("\n");
+
+    printf("%sStats Avg: ", indent);
+    for (unsigned int i = 0; i < stats.avg.size(); ++i) {
+        print_stats_num(stats.avg[i], maxval, false);
+        printf(" ");
     }
-    print_stats_footer (maxval);
-    printf ("\n");
-    
-    printf ("%sStats StdDev: ", indent);
-    for (unsigned int i=0; i<stats.stddev.size(); ++i) {
-        print_stats_num (stats.stddev[i], maxval, false);
-        printf (" ");
+    print_stats_footer(maxval);
+    printf("\n");
+
+    printf("%sStats StdDev: ", indent);
+    for (unsigned int i = 0; i < stats.stddev.size(); ++i) {
+        print_stats_num(stats.stddev[i], maxval, false);
+        printf(" ");
     }
-    print_stats_footer (maxval);
-    printf ("\n");
-    
-    printf ("%sStats NanCount: ", indent);
-    for (unsigned int i=0; i<stats.nancount.size(); ++i) {
-        printf ("%llu ", (unsigned long long)stats.nancount[i]);
+    print_stats_footer(maxval);
+    printf("\n");
+
+    printf("%sStats NanCount: ", indent);
+    for (unsigned int i = 0; i < stats.nancount.size(); ++i) {
+        printf("%llu ", (unsigned long long)stats.nancount[i]);
     }
-    printf ("\n");
-    
-    printf ("%sStats InfCount: ", indent);
-    for (unsigned int i=0; i<stats.infcount.size(); ++i) {
-        printf ("%llu ", (unsigned long long)stats.infcount[i]);
+    printf("\n");
+
+    printf("%sStats InfCount: ", indent);
+    for (unsigned int i = 0; i < stats.infcount.size(); ++i) {
+        printf("%llu ", (unsigned long long)stats.infcount[i]);
     }
-    printf ("\n");
-    
-    printf ("%sStats FiniteCount: ", indent);
-    for (unsigned int i=0; i<stats.finitecount.size(); ++i) {
-        printf ("%llu ", (unsigned long long)stats.finitecount[i]);
+    printf("\n");
+
+    printf("%sStats FiniteCount: ", indent);
+    for (unsigned int i = 0; i < stats.finitecount.size(); ++i) {
+        printf("%llu ", (unsigned long long)stats.finitecount[i]);
     }
-    printf ("\n");
-    
+    printf("\n");
+
     if (input.deep()) {
-        const DeepData *dd (input.deepdata());
-        size_t npixels = dd->pixels();
+        const DeepData* dd(input.deepdata());
+        size_t npixels      = dd->pixels();
         size_t totalsamples = 0, emptypixels = 0;
         size_t maxsamples = 0, minsamples = std::numeric_limits<size_t>::max();
         size_t maxsamples_npixels = 0;
-        float mindepth = std::numeric_limits<float>::max();
-        float maxdepth = -std::numeric_limits<float>::max();
-        Imath::V3i maxsamples_pixel(-1,-1,-1), minsamples_pixel(-1,-1,-1);
-        Imath::V3i mindepth_pixel(-1,-1,-1), maxdepth_pixel(-1,-1,-1);
-        Imath::V3i nonfinite_pixel(-1,-1,-1);
+        float mindepth            = std::numeric_limits<float>::max();
+        float maxdepth            = -std::numeric_limits<float>::max();
+        Imath::V3i maxsamples_pixel(-1, -1, -1), minsamples_pixel(-1, -1, -1);
+        Imath::V3i mindepth_pixel(-1, -1, -1), maxdepth_pixel(-1, -1, -1);
+        Imath::V3i nonfinite_pixel(-1, -1, -1);
         int nonfinite_pixel_samp(-1), nonfinite_pixel_chan(-1);
-        size_t sampoffset = 0;
-        int nchannels = dd->channels();
-        int depthchannel = -1;
+        size_t sampoffset    = 0;
+        int nchannels        = dd->channels();
+        int depthchannel     = -1;
         long long nonfinites = 0;
         for (int c = 0; c < nchannels; ++c)
-            if (Strutil::iequals (originalspec.channelnames[c], "Z"))
+            if (Strutil::iequals(originalspec.channelnames[c], "Z"))
                 depthchannel = c;
         int xend = originalspec.x + originalspec.width;
         int yend = originalspec.y + originalspec.height;
@@ -453,13 +447,13 @@ print_stats (Oiiotool &ot,
         for (int z = originalspec.z; z < zend; ++z) {
             for (int y = originalspec.y; y < yend; ++y) {
                 for (int x = originalspec.x; x < xend; ++x, ++p) {
-                    size_t samples = input.deep_samples (x, y, z);
+                    size_t samples = input.deep_samples(x, y, z);
                     totalsamples += samples;
                     if (samples == maxsamples)
                         ++maxsamples_npixels;
                     if (samples > maxsamples) {
                         maxsamples = samples;
-                        maxsamples_pixel.setValue (x, y, z);
+                        maxsamples_pixel.setValue(x, y, z);
                         maxsamples_npixels = 1;
                     }
                     if (samples < minsamples)
@@ -467,14 +461,14 @@ print_stats (Oiiotool &ot,
                     if (samples == 0)
                         ++emptypixels;
                     if (samples >= nsamples_histogram.size())
-                        nsamples_histogram.resize (samples+1, 0);
+                        nsamples_histogram.resize(samples + 1, 0);
                     nsamples_histogram[samples] += 1;
-                    for (unsigned int s = 0;  s < samples;  ++s) {
-                        for (int c = 0;  c < nchannels; ++c) {
-                            float d = input.deep_value (x, y, z, c, s);
-                            if (! isfinite(d)) {
+                    for (unsigned int s = 0; s < samples; ++s) {
+                        for (int c = 0; c < nchannels; ++c) {
+                            float d = input.deep_value(x, y, z, c, s);
+                            if (!isfinite(d)) {
                                 if (nonfinites++ == 0) {
-                                    nonfinite_pixel.setValue (x, y, z);
+                                    nonfinite_pixel.setValue(x, y, z);
                                     nonfinite_pixel_samp = s;
                                     nonfinite_pixel_chan = c;
                                 }
@@ -482,11 +476,11 @@ print_stats (Oiiotool &ot,
                             if (depthchannel == c) {
                                 if (d < mindepth) {
                                     mindepth = d;
-                                    mindepth_pixel.setValue (x, y, z);
+                                    mindepth_pixel.setValue(x, y, z);
                                 }
                                 if (d > maxdepth) {
                                     maxdepth = d;
-                                    maxdepth_pixel.setValue (x, y, z);
+                                    maxdepth_pixel.setValue(x, y, z);
                                 }
                             }
                         }
@@ -495,80 +489,86 @@ print_stats (Oiiotool &ot,
                 }
             }
         }
-        printf ("%sMin deep samples in any pixel : %llu\n", indent, (unsigned long long)minsamples);
-        printf ("%sMax deep samples in any pixel : %llu\n", indent, (unsigned long long)maxsamples);
-        printf ("%s%llu pixel%s had the max of %llu samples, including (x=%d, y=%d)\n",
-                indent, (unsigned long long)maxsamples_npixels,
-                maxsamples_npixels > 1 ? "s" : "",
-                (unsigned long long)maxsamples,
-                maxsamples_pixel.x, maxsamples_pixel.y);
-        printf ("%sAverage deep samples per pixel: %.2f\n", indent, double(totalsamples)/double(npixels));
-        printf ("%sTotal deep samples in all pixels: %llu\n", indent, (unsigned long long)totalsamples);
-        printf ("%sPixels with deep samples   : %llu\n", indent, (unsigned long long)(npixels-emptypixels));
-        printf ("%sPixels with no deep samples: %llu\n", indent, (unsigned long long)emptypixels);
-        printf ("%sSamples/pixel histogram:\n", indent);
+        printf("%sMin deep samples in any pixel : %llu\n", indent,
+               (unsigned long long)minsamples);
+        printf("%sMax deep samples in any pixel : %llu\n", indent,
+               (unsigned long long)maxsamples);
+        printf(
+            "%s%llu pixel%s had the max of %llu samples, including (x=%d, y=%d)\n",
+            indent, (unsigned long long)maxsamples_npixels,
+            maxsamples_npixels > 1 ? "s" : "", (unsigned long long)maxsamples,
+            maxsamples_pixel.x, maxsamples_pixel.y);
+        printf("%sAverage deep samples per pixel: %.2f\n", indent,
+               double(totalsamples) / double(npixels));
+        printf("%sTotal deep samples in all pixels: %llu\n", indent,
+               (unsigned long long)totalsamples);
+        printf("%sPixels with deep samples   : %llu\n", indent,
+               (unsigned long long)(npixels - emptypixels));
+        printf("%sPixels with no deep samples: %llu\n", indent,
+               (unsigned long long)emptypixels);
+        printf("%sSamples/pixel histogram:\n", indent);
         size_t grandtotal = 0;
-        for (size_t i = 0, e = nsamples_histogram.size();  i < e;  ++i)
+        for (size_t i = 0, e = nsamples_histogram.size(); i < e; ++i)
             grandtotal += nsamples_histogram[i];
         size_t binstart = 0, bintotal = 0;
-        for (size_t i = 0, e = nsamples_histogram.size();  i < e;  ++i) {
+        for (size_t i = 0, e = nsamples_histogram.size(); i < e; ++i) {
             bintotal += nsamples_histogram[i];
-            if (i < 8 || i == (e-1) || OIIO::ispow2(i+1)) {
+            if (i < 8 || i == (e - 1) || OIIO::ispow2(i + 1)) {
                 // batch by powers of 2, unless it's a small number
                 if (i == binstart)
-                    printf ("%s  %3lld    ", indent, (long long)i);
+                    printf("%s  %3lld    ", indent, (long long)i);
                 else
-                    printf ("%s  %3lld-%3lld", indent,
-                            (long long)binstart, (long long)i);
-                printf (" : %8lld (%4.1f%%)\n", (long long)bintotal,
-                        (100.0*bintotal)/grandtotal);
-                binstart = i+1;
+                    printf("%s  %3lld-%3lld", indent, (long long)binstart,
+                           (long long)i);
+                printf(" : %8lld (%4.1f%%)\n", (long long)bintotal,
+                       (100.0 * bintotal) / grandtotal);
+                binstart = i + 1;
                 bintotal = 0;
             }
         }
         if (depthchannel >= 0) {
-            printf ("%sMinimum depth was %g at (%d, %d)\n", indent, mindepth,
-                    mindepth_pixel.x, mindepth_pixel.y);
-            printf ("%sMaximum depth was %g at (%d, %d)\n", indent, maxdepth,
-                    maxdepth_pixel.x, maxdepth_pixel.y);
+            printf("%sMinimum depth was %g at (%d, %d)\n", indent, mindepth,
+                   mindepth_pixel.x, mindepth_pixel.y);
+            printf("%sMaximum depth was %g at (%d, %d)\n", indent, maxdepth,
+                   maxdepth_pixel.x, maxdepth_pixel.y);
         }
         if (nonfinites > 0) {
-            printf ("%sNonfinite values: %lld, including (x=%d, y=%d, chan=%s, samp=%d)\n",
-                    indent, nonfinites, nonfinite_pixel.x, nonfinite_pixel.y,
-                    input.spec().channelnames[nonfinite_pixel_chan].c_str(),
-                    nonfinite_pixel_samp);
+            printf(
+                "%sNonfinite values: %lld, including (x=%d, y=%d, chan=%s, samp=%d)\n",
+                indent, nonfinites, nonfinite_pixel.x, nonfinite_pixel.y,
+                input.spec().channelnames[nonfinite_pixel_chan].c_str(),
+                nonfinite_pixel_samp);
         }
     } else {
         std::vector<float> constantValues(input.spec().nchannels);
         if (isConstantColor(input, &constantValues[0])) {
-            printf ("%sConstant: Yes\n", indent);
-            printf ("%sConstant Color: ", indent);
-            for (unsigned int i=0; i<constantValues.size(); ++i) {
-                print_stats_num (constantValues[i], maxval, false);
-                printf (" ");
+            printf("%sConstant: Yes\n", indent);
+            printf("%sConstant Color: ", indent);
+            for (unsigned int i = 0; i < constantValues.size(); ++i) {
+                print_stats_num(constantValues[i], maxval, false);
+                printf(" ");
             }
-            print_stats_footer (maxval);
-            printf ("\n");
-        }
-        else {
-            printf ("%sConstant: No\n", indent);
-        }
-    
-        if( isMonochrome(input)) {
-            printf ("%sMonochrome: Yes\n", indent);
+            print_stats_footer(maxval);
+            printf("\n");
         } else {
-            printf ("%sMonochrome: No\n", indent);
+            printf("%sConstant: No\n", indent);
+        }
+
+        if (isMonochrome(input)) {
+            printf("%sMonochrome: Yes\n", indent);
+        } else {
+            printf("%sMonochrome: No\n", indent);
         }
     }
 }
 
 
 
-static const char *
-brief_format_name (TypeDesc type, int bits=0)
+static const char*
+brief_format_name(TypeDesc type, int bits = 0)
 {
-    if (! bits)
-        bits = (int)type.size()*8;
+    if (!bits)
+        bits = (int)type.size() * 8;
     if (type.is_floating_point()) {
         if (type.basetype == TypeDesc::FLOAT)
             return "f";
@@ -586,118 +586,125 @@ brief_format_name (TypeDesc type, int bits=0)
 
 
 static void
-print_info_subimage (Oiiotool &ot,
-                     int current_subimage, int num_of_subimages, int nmip,
-                     const ImageSpec &spec,
-                     ImageInput *input, const std::string &filename,
-                     const print_info_options &opt,
-                     regex &field_re, regex &field_exclude_re,
-                     ImageSpec::SerialFormat serformat,
-                     ImageSpec::SerialVerbose verbose)
+print_info_subimage(Oiiotool& ot, int current_subimage, int num_of_subimages,
+                    int nmip, const ImageSpec& spec, ImageInput* input,
+                    const std::string& filename, const print_info_options& opt,
+                    regex& field_re, regex& field_exclude_re,
+                    ImageSpec::SerialFormat serformat,
+                    ImageSpec::SerialVerbose verbose)
 {
     using Strutil::format;
 
-    int padlen = std::max (0, (int)opt.namefieldlength - (int)filename.length());
-    std::string padding (padlen, ' ');
-    bool printres = opt.verbose && (opt.metamatch.empty() ||
-                                regex_search ("resolution, width, height, depth, channels", field_re));
+    int padlen = std::max(0, (int)opt.namefieldlength - (int)filename.length());
+    std::string padding(padlen, ' ');
+    bool printres
+        = opt.verbose
+          && (opt.metamatch.empty()
+              || regex_search("resolution, width, height, depth, channels",
+                              field_re));
 
     std::vector<std::string> lines;
-    Strutil::split (spec.serialize(serformat, verbose), lines, "\n");
+    Strutil::split(spec.serialize(serformat, verbose), lines, "\n");
 
-    if (opt.compute_sha1 && (opt.metamatch.empty() ||
-                             regex_search ("sha-1", field_re))) {
+    if (opt.compute_sha1
+        && (opt.metamatch.empty() || regex_search("sha-1", field_re))) {
         // Before sha-1, be sure to point back to the highest-res MIP level
         ImageSpec tmpspec;
-        std::string sha = compute_sha1 (ot, input);
+        std::string sha = compute_sha1(ot, input);
         if (serformat == ImageSpec::SerialText)
-            lines.insert (lines.begin()+1, format("    SHA-1: %s", sha));
+            lines.insert(lines.begin() + 1, format("    SHA-1: %s", sha));
         else if (serformat == ImageSpec::SerialText)
-            lines.insert (lines.begin()+1, format("<SHA1>%s</SHA1>", sha));
+            lines.insert(lines.begin() + 1, format("<SHA1>%s</SHA1>", sha));
     }
 
     // Count MIP levels
     if (printres && nmip > 1) {
         ImageSpec mipspec;
-        std::string mipdesc = format ("    MIP-map levels: %dx%d", spec.width, spec.height);
-        for (int m = 1; input->seek_subimage (current_subimage, m, mipspec); ++m)
-            mipdesc += format (" %dx%d", mipspec.width, mipspec.height);
-        lines.insert (lines.begin()+1, mipdesc);
+        std::string mipdesc = format("    MIP-map levels: %dx%d", spec.width,
+                                     spec.height);
+        for (int m = 1; input->seek_subimage(current_subimage, m, mipspec); ++m)
+            mipdesc += format(" %dx%d", mipspec.width, mipspec.height);
+        lines.insert(lines.begin() + 1, mipdesc);
     }
 
     if (serformat == ImageSpec::SerialText) {
         // Requested a subset of metadata but not res, etc.? Kill first line.
-        if (opt.metamatch.empty() ||
-            regex_search ("resolution, width, height, depth, channels", field_re)) {
+        if (opt.metamatch.empty()
+            || regex_search("resolution, width, height, depth, channels",
+                            field_re)) {
             std::string orig_line0 = lines[0];
             if (current_subimage == 0)
-                lines[0] = Strutil::format ("%s%s : ", filename, padding) + lines[0];
+                lines[0] = Strutil::format("%s%s : ", filename, padding)
+                           + lines[0];
             else
-                lines[0] = Strutil::format (" subimage %2d: ", current_subimage) + lines[0];
+                lines[0] = Strutil::format(" subimage %2d: ", current_subimage)
+                           + lines[0];
             if (opt.sum) {
-                imagesize_t imagebytes = spec.image_bytes (true);
+                imagesize_t imagebytes = spec.image_bytes(true);
                 // totalsize += imagebytes;
-                lines[0] += format (" (%.2f MB)", (float)imagebytes / (1024.0*1024.0));
+                lines[0] += format(" (%.2f MB)",
+                                   (float)imagebytes / (1024.0 * 1024.0));
             }
-            lines[0] += format (" %s", input->format_name());
+            lines[0] += format(" %s", input->format_name());
             // we print info about how many subimages are stored in file
             // only when we have more then one subimage
-            if ( ! opt.verbose && num_of_subimages != 1)
-                lines[0] += format (" (%d subimages%s)", num_of_subimages,
-                                    (nmip > 1) ? " +mipmap)" : "");
-            if (! opt.verbose && num_of_subimages == 1 && (nmip > 1))
+            if (!opt.verbose && num_of_subimages != 1)
+                lines[0] += format(" (%d subimages%s)", num_of_subimages,
+                                   (nmip > 1) ? " +mipmap)" : "");
+            if (!opt.verbose && num_of_subimages == 1 && (nmip > 1))
                 lines[0] += " (+mipmap)";
             if (num_of_subimages > 1 && current_subimage == 0 && opt.subimages)
-                lines.insert (lines.begin()+1, format (" subimage  0: %s %s",
-                                                       orig_line0, input->format_name()));
+                lines.insert(lines.begin() + 1,
+                             format(" subimage  0: %s %s", orig_line0,
+                                    input->format_name()));
         } else {
-            lines.erase (lines.begin());
+            lines.erase(lines.begin());
         }
     } else if (serformat == ImageSpec::SerialXML) {
         if (nmip > 1)
-            lines.insert (lines.begin()+1,
-                          format ("<miplevels>%d</miplevels>", nmip));
+            lines.insert(lines.begin() + 1,
+                         format("<miplevels>%d</miplevels>", nmip));
         if (num_of_subimages > 1)
-            lines.insert (lines.begin()+1,
-                          format ("<subimages>%d</subimages>", num_of_subimages));
+            lines.insert(lines.begin() + 1,
+                         format("<subimages>%d</subimages>", num_of_subimages));
     }
 
     if (current_subimage == 0 && opt.verbose && num_of_subimages != 1
         && serformat == ImageSpec::SerialText) {
         // info about num of subimages and their resolutions
-        int movie = spec.get_int_attribute ("oiio:Movie");
-        std::string s = format ("    %d subimages: ", num_of_subimages);
+        int movie     = spec.get_int_attribute("oiio:Movie");
+        std::string s = format("    %d subimages: ", num_of_subimages);
         for (int i = 0; i < num_of_subimages; ++i) {
             ImageSpec spec;
-            input->seek_subimage (i, 0, spec);
-            int bits = spec.get_int_attribute ("oiio:BitsPerSample",
-                                               spec.format.size()*8);
+            input->seek_subimage(i, 0, spec);
+            int bits = spec.get_int_attribute("oiio:BitsPerSample",
+                                              spec.format.size() * 8);
             if (i)
                 s += ", ";
             if (spec.depth > 1)
-                s += format ("%dx%dx%d ", spec.width, spec.height, spec.depth);
+                s += format("%dx%dx%d ", spec.width, spec.height, spec.depth);
             else
-                s += format ("%dx%d ", spec.width, spec.height);
+                s += format("%dx%d ", spec.width, spec.height);
             for (int c = 0; c < spec.nchannels; ++c)
-                s += format ("%c%s", c ? ',' : '[',
-                        brief_format_name(spec.channelformat(c), bits));
+                s += format("%c%s", c ? ',' : '[',
+                            brief_format_name(spec.channelformat(c), bits));
             s += "]";
             if (movie)
                 break;
         }
-        lines.insert (lines.begin()+1, s);
+        lines.insert(lines.begin() + 1, s);
     }
 
-    if (! opt.metamatch.empty() || ! opt.nometamatch.empty()) {
+    if (!opt.metamatch.empty() || !opt.nometamatch.empty()) {
         for (size_t i = 0; i < lines.size(); ++i) {
             if (i == 0 && serformat == ImageSpec::SerialText && printres) {
                 // Special case for first line in serialized text case.
                 continue;
             }
-            std::string s = lines[i].substr (0, lines[i].find(": "));
-            if ((! opt.nometamatch.empty() && regex_search (s, field_exclude_re)) ||
-                (! opt.metamatch.empty() && ! regex_search (s, field_re))) {
-                lines.erase (lines.begin()+i);
+            std::string s = lines[i].substr(0, lines[i].find(": "));
+            if ((!opt.nometamatch.empty() && regex_search(s, field_exclude_re))
+                || (!opt.metamatch.empty() && !regex_search(s, field_re))) {
+                lines.erase(lines.begin() + i);
                 --i;
             }
         }
@@ -707,32 +714,32 @@ print_info_subimage (Oiiotool &ot,
     // the first line which corresponds to the filename and on windows might
     // contain backslashes as path separators.
     for (size_t i = 1; i < lines.size(); ++i) {
-        lines[i] = Strutil::unescape_chars (lines[i]);
+        lines[i] = Strutil::unescape_chars(lines[i]);
     }
 
-    std::string ser = Strutil::join (lines, "\n");
-    if (ser[ser.size()-1] != '\n')
+    std::string ser = Strutil::join(lines, "\n");
+    if (ser[ser.size() - 1] != '\n')
         ser += '\n';
     std::cout << ser;
 
     if (opt.dumpdata) {
         ImageSpec tmp;
-        input->seek_subimage (current_subimage, 0, tmp);
-        dump_data (input, opt);
+        input->seek_subimage(current_subimage, 0, tmp);
+        dump_data(input, opt);
     }
 
-    if (opt.compute_stats && (opt.metamatch.empty() ||
-                              regex_search ("stats", field_re))) {
-        for (int m = 0;  m < nmip;  ++m) {
+    if (opt.compute_stats
+        && (opt.metamatch.empty() || regex_search("stats", field_re))) {
+        for (int m = 0; m < nmip; ++m) {
             ImageSpec mipspec;
-            input->seek_subimage (current_subimage, m, mipspec);
+            input->seek_subimage(current_subimage, m, mipspec);
             if (opt.filenameprefix)
-                std::cout << format ("%s : ", filename);
+                std::cout << format("%s : ", filename);
             if (nmip > 1) {
-                std::cout << format ("    MIP %d of %d (%d x %d):\n",
-                                     m, nmip, mipspec.width, mipspec.height);
+                std::cout << format("    MIP %d of %d (%d x %d):\n", m, nmip,
+                                    mipspec.width, mipspec.height);
             }
-            print_stats (ot, filename, spec, current_subimage, m, nmip>1);
+            print_stats(ot, filename, spec, current_subimage, m, nmip > 1);
         }
     }
 }
@@ -740,56 +747,58 @@ print_info_subimage (Oiiotool &ot,
 
 
 bool
-OiioTool::print_info (Oiiotool &ot,
-                      const std::string &filename,
-                      const print_info_options &opt,
-                      long long &totalsize,
-                      std::string &error)
+OiioTool::print_info(Oiiotool& ot, const std::string& filename,
+                     const print_info_options& opt, long long& totalsize,
+                     std::string& error)
 {
     using Strutil::format;
     error.clear();
-    auto input = ImageInput::open (filename, &ot.input_config);
-    if (! input) {
+    auto input = ImageInput::open(filename, &ot.input_config);
+    if (!input) {
         error = geterror();
         if (error.empty())
-            error = Strutil::format ("Could not open \"%s\"", filename);
+            error = Strutil::format("Could not open \"%s\"", filename);
         return false;
     }
 
     ImageSpec::SerialFormat serformat = ImageSpec::SerialText;
-    if (Strutil::iequals (opt.infoformat, "xml"))
+    if (Strutil::iequals(opt.infoformat, "xml"))
         serformat = ImageSpec::SerialXML;
-    ImageSpec::SerialVerbose verbose = opt.verbose ? ImageSpec::SerialDetailedHuman : ImageSpec::SerialBrief;
+    ImageSpec::SerialVerbose verbose = opt.verbose
+                                           ? ImageSpec::SerialDetailedHuman
+                                           : ImageSpec::SerialBrief;
 
     regex field_re;
     regex field_exclude_re;
-    if (! opt.metamatch.empty()) {
+    if (!opt.metamatch.empty()) {
         try {
 #if USE_BOOST_REGEX
-            field_re.assign (opt.metamatch,
-                         boost::regex::extended | boost::regex_constants::icase);
+            field_re.assign(opt.metamatch, boost::regex::extended
+                                               | boost::regex_constants::icase);
 #else
-            field_re.assign (opt.metamatch,
-                         std::regex_constants::extended | std::regex_constants::icase);
+            field_re.assign(opt.metamatch, std::regex_constants::extended
+                                               | std::regex_constants::icase);
 #endif
-        } catch (const std::exception &e) {
-            error = Strutil::format ("Regex error '%s' on metamatch regex \"%s\"",
-                                     e.what(), opt.metamatch);
+        } catch (const std::exception& e) {
+            error = Strutil::format("Regex error '%s' on metamatch regex \"%s\"",
+                                    e.what(), opt.metamatch);
             return false;
         }
     }
-    if (! opt.nometamatch.empty()) {
+    if (!opt.nometamatch.empty()) {
         try {
 #if USE_BOOST_REGEX
-            field_exclude_re.assign (opt.nometamatch,
-                         boost::regex::extended | boost::regex_constants::icase);
+            field_exclude_re.assign(opt.nometamatch,
+                                    boost::regex::extended
+                                        | boost::regex_constants::icase);
 #else
-            field_exclude_re.assign (opt.nometamatch,
-                         std::regex_constants::extended | std::regex_constants::icase);
+            field_exclude_re.assign(opt.nometamatch,
+                                    std::regex_constants::extended
+                                        | std::regex_constants::icase);
 #endif
-        } catch (const std::exception &e) {
-            error = Strutil::format ("Regex error '%s' on metamatch regex \"%s\"",
-                                     e.what(), opt.nometamatch);
+        } catch (const std::exception& e) {
+            error = Strutil::format("Regex error '%s' on metamatch regex \"%s\"",
+                                    e.what(), opt.nometamatch);
             return false;
         }
     }
@@ -797,23 +806,25 @@ OiioTool::print_info (Oiiotool &ot,
     // checking how many subimages and mipmap levels are stored in the file
     std::vector<int> num_of_miplevels;
     int num_of_subimages;
-    for (num_of_subimages = 0; input->seek_subimage (num_of_subimages, 0); ++num_of_subimages) {
+    for (num_of_subimages = 0; input->seek_subimage(num_of_subimages, 0);
+         ++num_of_subimages) {
         int nmip = 1;
-        while (input->seek_subimage (num_of_subimages, nmip))
+        while (input->seek_subimage(num_of_subimages, nmip))
             ++nmip;
-        num_of_miplevels.push_back (nmip);
+        num_of_miplevels.push_back(nmip);
     }
 
-    for (int current_subimage = 0; current_subimage < num_of_subimages; ++current_subimage) {
-        if ( ! input->seek_subimage (current_subimage, 0))
+    for (int current_subimage = 0; current_subimage < num_of_subimages;
+         ++current_subimage) {
+        if (!input->seek_subimage(current_subimage, 0))
             break;
-        print_info_subimage (ot, current_subimage, num_of_subimages,
-                             num_of_miplevels[current_subimage],
-                             input->spec(), input.get(), filename, opt,
-                             field_re, field_exclude_re, serformat, verbose);
+        print_info_subimage(ot, current_subimage, num_of_subimages,
+                            num_of_miplevels[current_subimage], input->spec(),
+                            input.get(), filename, opt, field_re,
+                            field_exclude_re, serformat, verbose);
         // if the '-a' flag is not set we print info
         // about first subimage only
-        if ( ! opt.subimages)
+        if (!opt.subimages)
             break;
     }
 

--- a/src/python/py_deepdata.cpp
+++ b/src/python/py_deepdata.cpp
@@ -30,135 +30,136 @@
 
 #include "py_oiio.h"
 
-namespace PyOpenImageIO
-{
+namespace PyOpenImageIO {
 
 
 void
-DeepData_init (DeepData &dd, int npix, int nchan, py::object py_channeltypes,
-               py::object py_channelnames)
+DeepData_init(DeepData& dd, int npix, int nchan, py::object py_channeltypes,
+              py::object py_channelnames)
 {
     std::vector<TypeDesc> chantypes;
-    py_to_stdvector (chantypes, py_channeltypes);
+    py_to_stdvector(chantypes, py_channeltypes);
     std::vector<std::string> channames;
-    py_to_stdvector (channames, py_channelnames);
+    py_to_stdvector(channames, py_channelnames);
     py::gil_scoped_release gil;
-    dd.init (npix, nchan, chantypes, channames);
+    dd.init(npix, nchan, chantypes, channames);
 }
 
 
 
 void
-DeepData_init_spec (DeepData &dd, const ImageSpec &spec)
+DeepData_init_spec(DeepData& dd, const ImageSpec& spec)
 {
     py::gil_scoped_release gil;
-    dd.init (spec);
+    dd.init(spec);
 }
 
 
 
 void
-DeepData_set_nsamples (DeepData &dd, int pixel, int nsamples)
+DeepData_set_nsamples(DeepData& dd, int pixel, int nsamples)
 {
-    dd.set_samples (pixel, uint32_t(nsamples));
+    dd.set_samples(pixel, uint32_t(nsamples));
 }
 
 
 
 void
-DeepData_set_deep_value_float (DeepData &dd, int pixel,
-                               int channel, int sample, float value)
+DeepData_set_deep_value_float(DeepData& dd, int pixel, int channel, int sample,
+                              float value)
 {
-    dd.set_deep_value (pixel, channel, sample, value);
+    dd.set_deep_value(pixel, channel, sample, value);
 }
 
 
 
 void
-DeepData_set_deep_value_uint (DeepData &dd, int pixel,
-                              int channel, int sample, uint32_t value)
+DeepData_set_deep_value_uint(DeepData& dd, int pixel, int channel, int sample,
+                             uint32_t value)
 {
-    dd.set_deep_value (pixel, channel, sample, value);
+    dd.set_deep_value(pixel, channel, sample, value);
 }
-
-
 
 
 
 // Declare the OIIO DeepData class to Python
 void
-declare_deepdata (py::module& m)
+declare_deepdata(py::module& m)
 {
     using namespace pybind11::literals;
 
     py::class_<DeepData>(m, "DeepData")
         .def_property_readonly("pixels",
-                      [](const DeepData& d) { return d.pixels(); })
+                               [](const DeepData& d) { return d.pixels(); })
         .def_property_readonly("channels",
-                      [](const DeepData& d) { return d.channels(); })
+                               [](const DeepData& d) { return d.channels(); })
         .def_property_readonly("A_channel",
-                      [](const DeepData& d) { return d.A_channel(); })
+                               [](const DeepData& d) { return d.A_channel(); })
         .def_property_readonly("AR_channel",
-                      [](const DeepData& d) { return d.AR_channel(); })
+                               [](const DeepData& d) { return d.AR_channel(); })
         .def_property_readonly("AG_channel",
-                      [](const DeepData& d) { return d.AG_channel(); })
+                               [](const DeepData& d) { return d.AG_channel(); })
         .def_property_readonly("AB_channel",
-                      [](const DeepData& d) { return d.AB_channel(); })
+                               [](const DeepData& d) { return d.AB_channel(); })
         .def_property_readonly("Z_channel",
-                      [](const DeepData& d) { return d.Z_channel(); })
+                               [](const DeepData& d) { return d.Z_channel(); })
         .def_property_readonly("Zback_channel",
-                      [](const DeepData& d) { return d.Zback_channel(); })
+                               [](const DeepData& d) {
+                                   return d.Zback_channel();
+                               })
 
         .def(py::init<>())
-        .def("init",  &DeepData_init,
-             "npixels"_a, "nchannels"_a, "channeltypes"_a, "channelnames"_a)
-        .def("init",  &DeepData_init_spec)
+        .def("init", &DeepData_init, "npixels"_a, "nchannels"_a,
+             "channeltypes"_a, "channelnames"_a)
+        .def("init", &DeepData_init_spec)
         .def("clear", &DeepData::clear)
-        .def("free",  &DeepData::free)
-        .def("initialized",     &DeepData::initialized)
-        .def("allocated",       &DeepData::allocated)
+        .def("free", &DeepData::free)
+        .def("initialized", &DeepData::initialized)
+        .def("allocated", &DeepData::allocated)
 
-        .def("samples", [](const DeepData& dd, int pixel){
-                return (int)dd.samples(pixel); },
-                "pixel"_a)
-        .def("set_samples",     &DeepData::set_samples,
-             "pixel"_a, "nsamples"_a)
-        .def("capacity", [](const DeepData& dd, int pixel){
-                return (int)dd.capacity(pixel); },
-                "pixel"_a)
-        .def("set_capacity",    &DeepData::set_capacity,
-             "pixel"_a, "nsamples"_a)
-        .def("insert_samples",  &DeepData::insert_samples,
-             "pixel"_a, "samplepos"_a, "nsamples"_a=1)
-        .def("erase_samples",   &DeepData::erase_samples,
-             "pixel"_a, "samplepos"_a, "nsamples"_a=1)
-        .def("channelname", [](const DeepData& dd, int c){
-                return (std::string)dd.channelname(c); })
-        .def("channeltype",     &DeepData::channeltype)
-        .def("channelsize", [](const DeepData& dd, int c){
-                return (int)dd.channelsize(c); })
-        .def("samplesize",      &DeepData::samplesize)
-        .def("deep_value",      &DeepData::deep_value,
-             "pixel"_a, "channel"_a, "sample"_a)
-        .def("deep_value_uint", &DeepData::deep_value_uint,
-             "pixel"_a, "channel"_a, "sample"_a)
-        .def("set_deep_value",  &DeepData_set_deep_value_float,
-             "pixel"_a, "channel"_a, "sample"_a, "value"_a)
-        .def("set_deep_value_uint", &DeepData_set_deep_value_uint,
-             "pixel"_a, "channel"_a, "sample"_a, "value"_a)
-        .def("copy_deep_sample", &DeepData::copy_deep_sample,
-             "pixel"_a, "sample"_a, "src"_a, "srcpixel"_a, "srcsample"_a)
-        .def("copy_deep_pixel", &DeepData::copy_deep_pixel,
-             "pixel"_a, "src"_a, "srcpixel"_a)
+        .def("samples",
+             [](const DeepData& dd, int pixel) {
+                 return (int)dd.samples(pixel);
+             },
+             "pixel"_a)
+        .def("set_samples", &DeepData::set_samples, "pixel"_a, "nsamples"_a)
+        .def("capacity",
+             [](const DeepData& dd, int pixel) {
+                 return (int)dd.capacity(pixel);
+             },
+             "pixel"_a)
+        .def("set_capacity", &DeepData::set_capacity, "pixel"_a, "nsamples"_a)
+        .def("insert_samples", &DeepData::insert_samples, "pixel"_a,
+             "samplepos"_a, "nsamples"_a = 1)
+        .def("erase_samples", &DeepData::erase_samples, "pixel"_a,
+             "samplepos"_a, "nsamples"_a = 1)
+        .def("channelname",
+             [](const DeepData& dd, int c) {
+                 return (std::string)dd.channelname(c);
+             })
+        .def("channeltype", &DeepData::channeltype)
+        .def("channelsize",
+             [](const DeepData& dd, int c) { return (int)dd.channelsize(c); })
+        .def("samplesize", &DeepData::samplesize)
+        .def("deep_value", &DeepData::deep_value, "pixel"_a, "channel"_a,
+             "sample"_a)
+        .def("deep_value_uint", &DeepData::deep_value_uint, "pixel"_a,
+             "channel"_a, "sample"_a)
+        .def("set_deep_value", &DeepData_set_deep_value_float, "pixel"_a,
+             "channel"_a, "sample"_a, "value"_a)
+        .def("set_deep_value_uint", &DeepData_set_deep_value_uint, "pixel"_a,
+             "channel"_a, "sample"_a, "value"_a)
+        .def("copy_deep_sample", &DeepData::copy_deep_sample, "pixel"_a,
+             "sample"_a, "src"_a, "srcpixel"_a, "srcsample"_a)
+        .def("copy_deep_pixel", &DeepData::copy_deep_pixel, "pixel"_a, "src"_a,
+             "srcpixel"_a)
         .def("split", &DeepData::split, "pixel"_a, "depth"_a)
         .def("sort", &DeepData::sort, "pixel"_a)
         .def("merge_overlaps", &DeepData::merge_overlaps, "pixel"_a)
-        .def("merge_deep_pixels", &DeepData::merge_deep_pixels,
-             "pixel"_a, "src"_a, "srcpixel"_a)
+        .def("merge_deep_pixels", &DeepData::merge_deep_pixels, "pixel"_a,
+             "src"_a, "srcpixel"_a)
         .def("occlusion_cull", &DeepData::occlusion_cull, "pixel"_a)
-        .def("opaque_z", &DeepData::opaque_z, "pixel"_a)
-    ;
+        .def("opaque_z", &DeepData::opaque_z, "pixel"_a);
 }
 
-} // namespace PyOpenImageIO
-
+}  // namespace PyOpenImageIO

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -35,119 +35,117 @@
 #include <OpenImageIO/platform.h>
 
 
-namespace PyOpenImageIO
-{
+namespace PyOpenImageIO {
 
 
 
 py::tuple
-ImageBuf_getpixel (const ImageBuf &buf, int x, int y, int z=0,
-                   const std::string &wrapname="black")
+ImageBuf_getpixel(const ImageBuf& buf, int x, int y, int z = 0,
+                  const std::string& wrapname = "black")
 {
-    ImageBuf::WrapMode wrap = ImageBuf::WrapMode_from_string (wrapname);
-    int nchans = buf.nchannels();
-    float *pixel = ALLOCA (float, nchans);
-    buf.getpixel (x, y, z, pixel, nchans, wrap);
-    return C_to_tuple (pixel, nchans);
+    ImageBuf::WrapMode wrap = ImageBuf::WrapMode_from_string(wrapname);
+    int nchans              = buf.nchannels();
+    float* pixel            = ALLOCA(float, nchans);
+    buf.getpixel(x, y, z, pixel, nchans, wrap);
+    return C_to_tuple(pixel, nchans);
 }
 
 
 
 py::tuple
-ImageBuf_interppixel (const ImageBuf &buf, float x, float y,
-                      const std::string &wrapname="black")
+ImageBuf_interppixel(const ImageBuf& buf, float x, float y,
+                     const std::string& wrapname = "black")
 {
-    ImageBuf::WrapMode wrap = ImageBuf::WrapMode_from_string (wrapname);
-    int nchans = buf.nchannels();
-    float *pixel = ALLOCA (float, nchans);
-    buf.interppixel (x, y, pixel, wrap);
-    return C_to_tuple (pixel, nchans);
+    ImageBuf::WrapMode wrap = ImageBuf::WrapMode_from_string(wrapname);
+    int nchans              = buf.nchannels();
+    float* pixel            = ALLOCA(float, nchans);
+    buf.interppixel(x, y, pixel, wrap);
+    return C_to_tuple(pixel, nchans);
 }
 
 
 
 py::tuple
-ImageBuf_interppixel_NDC (const ImageBuf &buf, float x, float y,
-                          const std::string &wrapname="black")
+ImageBuf_interppixel_NDC(const ImageBuf& buf, float x, float y,
+                         const std::string& wrapname = "black")
 {
-    ImageBuf::WrapMode wrap = ImageBuf::WrapMode_from_string (wrapname);
-    int nchans = buf.nchannels();
-    float *pixel = ALLOCA (float, nchans);
-    buf.interppixel_NDC (x, y, pixel, wrap);
-    return C_to_tuple (pixel, nchans);
+    ImageBuf::WrapMode wrap = ImageBuf::WrapMode_from_string(wrapname);
+    int nchans              = buf.nchannels();
+    float* pixel            = ALLOCA(float, nchans);
+    buf.interppixel_NDC(x, y, pixel, wrap);
+    return C_to_tuple(pixel, nchans);
 }
 
 
 
 py::tuple
-ImageBuf_interppixel_bicubic (const ImageBuf &buf, float x, float y,
-                              const std::string &wrapname="black")
+ImageBuf_interppixel_bicubic(const ImageBuf& buf, float x, float y,
+                             const std::string& wrapname = "black")
 {
-    ImageBuf::WrapMode wrap = ImageBuf::WrapMode_from_string (wrapname);
-    int nchans = buf.nchannels();
-    float *pixel = ALLOCA (float, nchans);
-    buf.interppixel_bicubic (x, y, pixel, wrap);
-    return C_to_tuple (pixel, nchans);
+    ImageBuf::WrapMode wrap = ImageBuf::WrapMode_from_string(wrapname);
+    int nchans              = buf.nchannels();
+    float* pixel            = ALLOCA(float, nchans);
+    buf.interppixel_bicubic(x, y, pixel, wrap);
+    return C_to_tuple(pixel, nchans);
 }
 
 
 
 py::tuple
-ImageBuf_interppixel_bicubic_NDC (const ImageBuf &buf, float x, float y,
-                                  const std::string &wrapname="black")
+ImageBuf_interppixel_bicubic_NDC(const ImageBuf& buf, float x, float y,
+                                 const std::string& wrapname = "black")
 {
-    ImageBuf::WrapMode wrap = ImageBuf::WrapMode_from_string (wrapname);
-    int nchans = buf.nchannels();
-    float *pixel = ALLOCA (float, nchans);
-    buf.interppixel_bicubic_NDC (x, y, pixel, wrap);
-    return C_to_tuple (pixel, nchans);
+    ImageBuf::WrapMode wrap = ImageBuf::WrapMode_from_string(wrapname);
+    int nchans              = buf.nchannels();
+    float* pixel            = ALLOCA(float, nchans);
+    buf.interppixel_bicubic_NDC(x, y, pixel, wrap);
+    return C_to_tuple(pixel, nchans);
 }
 
 
 
 void
-ImageBuf_setpixel (ImageBuf &buf, int x, int y, int z, py::object p)
+ImageBuf_setpixel(ImageBuf& buf, int x, int y, int z, py::object p)
 {
     std::vector<float> pixel;
-    py_to_stdvector (pixel, p);
+    py_to_stdvector(pixel, p);
     if (pixel.size())
-        buf.setpixel (x, y, z, &pixel[0], pixel.size());
+        buf.setpixel(x, y, z, &pixel[0], pixel.size());
 }
 
 void
-ImageBuf_setpixel2 (ImageBuf &buf, int x, int y, py::object p)
+ImageBuf_setpixel2(ImageBuf& buf, int x, int y, py::object p)
 {
-    ImageBuf_setpixel (buf, x, y, 0, p);
+    ImageBuf_setpixel(buf, x, y, 0, p);
 }
 
 
 void
-ImageBuf_setpixel1 (ImageBuf &buf, int i, py::object p)
+ImageBuf_setpixel1(ImageBuf& buf, int i, py::object p)
 {
     std::vector<float> pixel;
-    py_to_stdvector (pixel, p);
+    py_to_stdvector(pixel, p);
     if (pixel.size())
-        buf.setpixel (i, &pixel[0], pixel.size());
+        buf.setpixel(i, &pixel[0], pixel.size());
 }
 
 
 
 py::object
-ImageBuf_get_pixels (const ImageBuf &buf, TypeDesc format, ROI roi=ROI::All())
+ImageBuf_get_pixels(const ImageBuf& buf, TypeDesc format, ROI roi = ROI::All())
 {
     // Allocate our own temp buffer and try to read the image into it.
     // If the read fails, return None.
-    if (! roi.defined())
+    if (!roi.defined())
         roi = buf.roi();
-    roi.chend = std::min (roi.chend, buf.nchannels());
+    roi.chend = std::min(roi.chend, buf.nchannels());
 
-    size_t size = (size_t) roi.npixels() * roi.nchannels() * format.size();
-    std::unique_ptr<char[]> data (new char [size]);
-    if (buf.get_pixels (roi, format, &data[0]))
-        return make_numpy_array (format, data.release(),
-                                 buf.spec().depth > 1 ? 4 : 3,
-                                 roi.nchannels(), roi.width(),
-                                 roi.height(), roi.depth());
+    size_t size = (size_t)roi.npixels() * roi.nchannels() * format.size();
+    std::unique_ptr<char[]> data(new char[size]);
+    if (buf.get_pixels(roi, format, &data[0]))
+        return make_numpy_array(format, data.release(),
+                                buf.spec().depth > 1 ? 4 : 3, roi.nchannels(),
+                                roi.width(), roi.height(), roi.depth());
     else
         return py::none();
 }
@@ -155,145 +153,160 @@ ImageBuf_get_pixels (const ImageBuf &buf, TypeDesc format, ROI roi=ROI::All())
 
 
 void
-ImageBuf_set_deep_value (ImageBuf &buf, int x, int y, int z,
-                         int c, int s, float value)
+ImageBuf_set_deep_value(ImageBuf& buf, int x, int y, int z, int c, int s,
+                        float value)
 {
-    buf.set_deep_value (x, y, z, c, s, value);
+    buf.set_deep_value(x, y, z, c, s, value);
 }
 
 void
-ImageBuf_set_deep_value_uint (ImageBuf &buf, int x, int y, int z,
-                         int c, int s, uint32_t value)
+ImageBuf_set_deep_value_uint(ImageBuf& buf, int x, int y, int z, int c, int s,
+                             uint32_t value)
 {
-    buf.set_deep_value (x, y, z, c, s, value);
+    buf.set_deep_value(x, y, z, c, s, value);
 }
 
 
 
 bool
-ImageBuf_set_pixels_buffer (ImageBuf &self, ROI roi, py::buffer &buffer)
+ImageBuf_set_pixels_buffer(ImageBuf& self, ROI roi, py::buffer& buffer)
 {
-    if (! roi.defined())
+    if (!roi.defined())
         roi = self.roi();
-    roi.chend = std::min (roi.chend, self.nchannels());
-    size_t size = (size_t) roi.npixels() * roi.nchannels();
+    roi.chend   = std::min(roi.chend, self.nchannels());
+    size_t size = (size_t)roi.npixels() * roi.nchannels();
     if (size == 0) {
-        return true;   // done
+        return true;  // done
     }
-    oiio_bufinfo buf (buffer.request(), roi.nchannels(), roi.width(),
-                      roi.height(), roi.depth(), self.spec().depth > 1 ? 3 : 2);
-    if (! buf.data) {
-        self.error ("set_pixels unspecified error decoding the Python buffer");
+    oiio_bufinfo buf(buffer.request(), roi.nchannels(), roi.width(),
+                     roi.height(), roi.depth(), self.spec().depth > 1 ? 3 : 2);
+    if (!buf.data) {
+        self.error("set_pixels unspecified error decoding the Python buffer");
         return false;  // failed sanity checks
     }
-    if (! buf.data || buf.size != size) {
-        self.error ("ImageBuf.set_pixels: array size (%d) did not match ROI size w=%d h=%d d=%d ch=%d (total %d)",
-                    buf.size, roi.width(), roi.height(), roi.depth(),
-                    roi.nchannels(), size);
+    if (!buf.data || buf.size != size) {
+        self.error(
+            "ImageBuf.set_pixels: array size (%d) did not match ROI size w=%d h=%d d=%d ch=%d (total %d)",
+            buf.size, roi.width(), roi.height(), roi.depth(), roi.nchannels(),
+            size);
         return false;
     }
 
     py::gil_scoped_release gil;
-    return self.set_pixels (roi, buf.format, buf.data,
-                            buf.xstride, buf.ystride, buf.zstride);
+    return self.set_pixels(roi, buf.format, buf.data, buf.xstride, buf.ystride,
+                           buf.zstride);
 }
 
 
 
-
-void declare_imagebuf(py::module &m)
+void
+declare_imagebuf(py::module& m)
 {
     using namespace pybind11::literals;
 
-    py::class_<ImageBuf> (m,"ImageBuf")
+    py::class_<ImageBuf>(m, "ImageBuf")
         .def(py::init<>())
         .def(py::init<const std::string&>())
         .def(py::init<const std::string&, int, int>())
         .def(py::init<const ImageSpec&>())
         .def("clear", &ImageBuf::clear)
-        .def("reset", [](ImageBuf &self, const std::string& name,
-                         int subimage, int miplevel){
-                self.reset (name, subimage, miplevel);
-            },
-            "name"_a, "subimage"_a=0, "miplevel"_a=0)
-        .def("reset", [](ImageBuf &self, const std::string& name,
-                         int subimage, int miplevel, const ImageSpec &config){
-                self.reset (name, subimage, miplevel, nullptr, &config);
-            },
-            "name"_a, "subimage"_a=0, "miplevel"_a=0, "config"_a=ImageSpec())
-        .def("reset", [](ImageBuf &self, const ImageSpec &spec){
-                self.reset (spec);
-            },
-            "spec"_a)
-        .def_property_readonly ("initialized", [](const ImageBuf& self){
-                return self.initialized();
-            })
-        .def("init_spec", [](ImageBuf& self, std::string filename, int subimage, int miplevel){
-                py::gil_scoped_release gil;
-                self.init_spec (filename, subimage, miplevel);
-            },
-            "filename"_a, "subimage"_a=0, "miplevel"_a=0)
-        .def("read", [](ImageBuf& self, int subimage, int miplevel,
-                        int chbegin, int chend, bool force, TypeDesc convert){
-                py::gil_scoped_release gil;
-                return self.read (subimage, miplevel, chbegin, chend, force, convert);
-            },
-            "subimage"_a, "miplevel"_a, "chbegin"_a, "chend"_a,
-            "force"_a, "convert"_a)
-        .def("read", [](ImageBuf& self, int subimage, int miplevel,
-                        bool force, TypeDesc convert){
-                py::gil_scoped_release gil;
-                return self.read (subimage, miplevel, force, convert);
-            },
-            "subimage"_a=0, "miplevel"_a=0,
-            "force"_a=false, "convert"_a=TypeUnknown)
+        .def("reset",
+             [](ImageBuf& self, const std::string& name, int subimage,
+                int miplevel) { self.reset(name, subimage, miplevel); },
+             "name"_a, "subimage"_a = 0, "miplevel"_a = 0)
+        .def("reset",
+             [](ImageBuf& self, const std::string& name, int subimage,
+                int miplevel, const ImageSpec& config) {
+                 self.reset(name, subimage, miplevel, nullptr, &config);
+             },
+             "name"_a, "subimage"_a = 0, "miplevel"_a = 0,
+             "config"_a = ImageSpec())
+        .def("reset",
+             [](ImageBuf& self, const ImageSpec& spec) { self.reset(spec); },
+             "spec"_a)
+        .def_property_readonly("initialized",
+                               [](const ImageBuf& self) {
+                                   return self.initialized();
+                               })
+        .def("init_spec",
+             [](ImageBuf& self, std::string filename, int subimage,
+                int miplevel) {
+                 py::gil_scoped_release gil;
+                 self.init_spec(filename, subimage, miplevel);
+             },
+             "filename"_a, "subimage"_a = 0, "miplevel"_a = 0)
+        .def("read",
+             [](ImageBuf& self, int subimage, int miplevel, int chbegin,
+                int chend, bool force, TypeDesc convert) {
+                 py::gil_scoped_release gil;
+                 return self.read(subimage, miplevel, chbegin, chend, force,
+                                  convert);
+             },
+             "subimage"_a, "miplevel"_a, "chbegin"_a, "chend"_a, "force"_a,
+             "convert"_a)
+        .def("read",
+             [](ImageBuf& self, int subimage, int miplevel, bool force,
+                TypeDesc convert) {
+                 py::gil_scoped_release gil;
+                 return self.read(subimage, miplevel, force, convert);
+             },
+             "subimage"_a = 0, "miplevel"_a = 0, "force"_a = false,
+             "convert"_a = TypeUnknown)
 
-        .def("write", [](ImageBuf& self, const std::string &filename,
-                         TypeDesc dtype, const std::string &fileformat){
-                py::gil_scoped_release gil;
-                return self.write (filename, dtype, fileformat);
-            },
-            "filename"_a, "dtype"_a=TypeUnknown, "fileformat"_a="")
+        .def("write",
+             [](ImageBuf& self, const std::string& filename, TypeDesc dtype,
+                const std::string& fileformat) {
+                 py::gil_scoped_release gil;
+                 return self.write(filename, dtype, fileformat);
+             },
+             "filename"_a, "dtype"_a = TypeUnknown, "fileformat"_a = "")
         // deprecated version:
-        .def("write", [](ImageBuf& self, const std::string &filename,
-                         const std::string &fileformat){
-                py::gil_scoped_release gil;
-                return self.write (filename, fileformat);
-            },
-            "filename"_a, "fileformat"_a)
-        .def("make_writeable", [](ImageBuf& self, bool keep_cache_type){
-                py::gil_scoped_release gil;
-                return self.make_writeable (keep_cache_type);
-            },
-            "keep_cache_type"_a=false)
+        .def("write",
+             [](ImageBuf& self, const std::string& filename,
+                const std::string& fileformat) {
+                 py::gil_scoped_release gil;
+                 return self.write(filename, fileformat);
+             },
+             "filename"_a, "fileformat"_a)
+        .def("make_writeable",
+             [](ImageBuf& self, bool keep_cache_type) {
+                 py::gil_scoped_release gil;
+                 return self.make_writeable(keep_cache_type);
+             },
+             "keep_cache_type"_a = false)
         .def("set_write_format", &ImageBuf::set_write_format)
         // FIXME -- write(ImageOut&)
-        .def("set_write_tiles", &ImageBuf::set_write_tiles,
-             "width"_a=0, "height"_a=0, "depth"_a=0)
+        .def("set_write_tiles", &ImageBuf::set_write_tiles, "width"_a = 0,
+             "height"_a = 0, "depth"_a = 0)
         .def("spec", &ImageBuf::spec,
              py::return_value_policy::reference_internal)
         .def("nativespec", &ImageBuf::nativespec,
              py::return_value_policy::reference_internal)
         .def("specmod", &ImageBuf::specmod,
              py::return_value_policy::reference_internal)
-        .def_property_readonly("name", [](const ImageBuf& self){
-                return PY_STR(self.name());
-            })
-        .def_property_readonly("file_format_name", [](const ImageBuf& self){
-                return PY_STR(self.file_format_name());
-            })
+        .def_property_readonly("name",
+                               [](const ImageBuf& self) {
+                                   return PY_STR(self.name());
+                               })
+        .def_property_readonly("file_format_name",
+                               [](const ImageBuf& self) {
+                                   return PY_STR(self.file_format_name());
+                               })
         .def_property_readonly("subimage", &ImageBuf::subimage)
         .def_property_readonly("nsubimages", &ImageBuf::nsubimages)
         .def_property_readonly("miplevel", &ImageBuf::miplevel)
         .def_property_readonly("nmiplevels", &ImageBuf::nmiplevels)
         .def_property_readonly("nchannels", &ImageBuf::nchannels)
-        .def_property("orientation", &ImageBuf::orientation, &ImageBuf::set_orientation)
+        .def_property("orientation", &ImageBuf::orientation,
+                      &ImageBuf::set_orientation)
         .def_property_readonly("oriented_width", &ImageBuf::oriented_width)
         .def_property_readonly("oriented_height", &ImageBuf::oriented_height)
         .def_property_readonly("oriented_x", &ImageBuf::oriented_x)
         .def_property_readonly("oriented_y", &ImageBuf::oriented_y)
-        .def_property_readonly("oriented_full_width", &ImageBuf::oriented_full_width)
-        .def_property_readonly("oriented_full_height", &ImageBuf::oriented_full_height)
+        .def_property_readonly("oriented_full_width",
+                               &ImageBuf::oriented_full_width)
+        .def_property_readonly("oriented_full_height",
+                               &ImageBuf::oriented_full_height)
         .def_property_readonly("oriented_full_x", &ImageBuf::oriented_full_x)
         .def_property_readonly("oriented_full_y", &ImageBuf::oriented_full_y)
         .def_property_readonly("xbegin", &ImageBuf::xbegin)
@@ -309,83 +322,74 @@ void declare_imagebuf(py::module &m)
         .def_property_readonly("zmin", &ImageBuf::zmin)
         .def_property_readonly("zmax", &ImageBuf::zmax)
         .def_property_readonly("roi", &ImageBuf::roi)
-        .def_property("roi_full",
-                      &ImageBuf::roi_full, &ImageBuf::set_roi_full)
-        .def("set_origin", &ImageBuf::set_origin,
-             "x"_a, "y"_a, "z"_a=0)
+        .def_property("roi_full", &ImageBuf::roi_full, &ImageBuf::set_roi_full)
+        .def("set_origin", &ImageBuf::set_origin, "x"_a, "y"_a, "z"_a = 0)
         .def("set_full", &ImageBuf::set_full)
         .def_property_readonly("pixels_valid", &ImageBuf::pixels_valid)
         .def_property_readonly("pixeltype", &ImageBuf::pixeltype)
-        .def_property_readonly("has_error",   &ImageBuf::has_error)
-        .def("geterror",    &ImageBuf::geterror)
+        .def_property_readonly("has_error", &ImageBuf::has_error)
+        .def("geterror", &ImageBuf::geterror)
 
-        .def("pixelindex", &ImageBuf::pixelindex,
-             "x"_a, "y"_a, "z"_a, "check_range"_a=false)
+        .def("pixelindex", &ImageBuf::pixelindex, "x"_a, "y"_a, "z"_a,
+             "check_range"_a = false)
         .def("copy_metadata", &ImageBuf::copy_metadata)
         .def("copy_pixels", &ImageBuf::copy_pixels)
-        .def("copy", [](ImageBuf &self, const ImageBuf &src, TypeDesc format){
-                py::gil_scoped_release gil;
-                return self.copy (src, format);
-            },
-            "src"_a, "format"_a=TypeUnknown)
-        .def("copy", [](const ImageBuf &src, TypeDesc format){
-                py::gil_scoped_release gil;
-                return src.copy(format);
-            },
-            "format"_a=TypeUnknown)
+        .def("copy",
+             [](ImageBuf& self, const ImageBuf& src, TypeDesc format) {
+                 py::gil_scoped_release gil;
+                 return self.copy(src, format);
+             },
+             "src"_a, "format"_a = TypeUnknown)
+        .def("copy",
+             [](const ImageBuf& src, TypeDesc format) {
+                 py::gil_scoped_release gil;
+                 return src.copy(format);
+             },
+             "format"_a = TypeUnknown)
         .def("swap", &ImageBuf::swap)
-        .def("getchannel", &ImageBuf::getchannel,
-             "x"_a, "y"_a, "z"_a, "c"_a, "wrap"_a="black")
-        .def("getpixel", &ImageBuf_getpixel,
-             "x"_a, "y"_a, "z"_a=0, "wrap"_a="black")
+        .def("getchannel", &ImageBuf::getchannel, "x"_a, "y"_a, "z"_a, "c"_a,
+             "wrap"_a = "black")
+        .def("getpixel", &ImageBuf_getpixel, "x"_a, "y"_a, "z"_a = 0,
+             "wrap"_a = "black")
 
-        .def("interppixel", &ImageBuf_interppixel,
-             "x"_a, "y"_a, "wrap"_a="black")
-        .def("interppixel_NDC", &ImageBuf_interppixel_NDC,
-             "x"_a, "y"_a, "wrap"_a="black")
-        .def("interppixel_NDC_full", &ImageBuf_interppixel_NDC,
-             "x"_a, "y"_a, "wrap"_a="black")
-        .def("interppixel_bicubic", &ImageBuf_interppixel_bicubic,
-             "x"_a, "y"_a, "wrap"_a="black")
+        .def("interppixel", &ImageBuf_interppixel, "x"_a, "y"_a,
+             "wrap"_a = "black")
+        .def("interppixel_NDC", &ImageBuf_interppixel_NDC, "x"_a, "y"_a,
+             "wrap"_a = "black")
+        .def("interppixel_NDC_full", &ImageBuf_interppixel_NDC, "x"_a, "y"_a,
+             "wrap"_a = "black")
+        .def("interppixel_bicubic", &ImageBuf_interppixel_bicubic, "x"_a, "y"_a,
+             "wrap"_a = "black")
         .def("interppixel_bicubic_NDC", &ImageBuf_interppixel_bicubic_NDC,
-             "x"_a, "y"_a, "wrap"_a="black")
-        .def("setpixel", &ImageBuf_setpixel,
-            "x"_a, "y"_a, "z"_a, "pixel"_a)
-        .def("setpixel", &ImageBuf_setpixel2,
-            "x"_a, "y"_a, "pixel"_a)
-        .def("setpixel", &ImageBuf_setpixel1,
-            "i"_a, "pixel"_a)
-        .def("get_pixels", &ImageBuf_get_pixels,
-             "format"_a=TypeFloat, "roi"_a=ROI::All())
-        .def("set_pixels", &ImageBuf_set_pixels_buffer,
-             "roi"_a, "pixels"_a)
+             "x"_a, "y"_a, "wrap"_a = "black")
+        .def("setpixel", &ImageBuf_setpixel, "x"_a, "y"_a, "z"_a, "pixel"_a)
+        .def("setpixel", &ImageBuf_setpixel2, "x"_a, "y"_a, "pixel"_a)
+        .def("setpixel", &ImageBuf_setpixel1, "i"_a, "pixel"_a)
+        .def("get_pixels", &ImageBuf_get_pixels, "format"_a = TypeFloat,
+             "roi"_a = ROI::All())
+        .def("set_pixels", &ImageBuf_set_pixels_buffer, "roi"_a, "pixels"_a)
 
         .def_property_readonly("deep", &ImageBuf::deep)
-        .def("deep_samples", &ImageBuf::deep_samples,
-             "x"_a, "y"_a, "z"_a=0)
-        .def("set_deep_samples", &ImageBuf::set_deep_samples,
-             "x"_a, "y"_a, "z"_a=0, "nsamples"_a=1)
-        .def("deep_insert_samples", &ImageBuf::deep_insert_samples,
-             "x"_a, "y"_a, "z"_a=0, "samplepos"_a, "nsamples"_a=1)
-        .def("deep_erase_samples", &ImageBuf::deep_erase_samples,
-             "x"_a, "y"_a, "z"_a=0, "samplepos"_a, "nsamples"_a=1)
-        .def("deep_value", &ImageBuf::deep_value,
-             "x"_a, "y"_a, "z"_a, "channel"_a, "sample"_a)
-        .def("deep_value_uint", &ImageBuf::deep_value_uint,
-             "x"_a, "y"_a, "z"_a, "channel"_a, "sample"_a)
-        .def("set_deep_value", &ImageBuf_set_deep_value,
-             "x"_a, "y"_a, "z"_a, "channel"_a,
-             "sample"_a, "value"_a=0.0f)
-        .def("set_deep_value_uint", &ImageBuf_set_deep_value_uint,
-             "x"_a, "y"_a, "z"_a, "channel"_a,
-             "sample"_a, "value"_a=0)
-        .def("deepdata", [](ImageBuf &self){ return *self.deepdata(); },
+        .def("deep_samples", &ImageBuf::deep_samples, "x"_a, "y"_a, "z"_a = 0)
+        .def("set_deep_samples", &ImageBuf::set_deep_samples, "x"_a, "y"_a,
+             "z"_a = 0, "nsamples"_a = 1)
+        .def("deep_insert_samples", &ImageBuf::deep_insert_samples, "x"_a,
+             "y"_a, "z"_a = 0, "samplepos"_a, "nsamples"_a = 1)
+        .def("deep_erase_samples", &ImageBuf::deep_erase_samples, "x"_a, "y"_a,
+             "z"_a = 0, "samplepos"_a, "nsamples"_a = 1)
+        .def("deep_value", &ImageBuf::deep_value, "x"_a, "y"_a, "z"_a,
+             "channel"_a, "sample"_a)
+        .def("deep_value_uint", &ImageBuf::deep_value_uint, "x"_a, "y"_a, "z"_a,
+             "channel"_a, "sample"_a)
+        .def("set_deep_value", &ImageBuf_set_deep_value, "x"_a, "y"_a, "z"_a,
+             "channel"_a, "sample"_a, "value"_a = 0.0f)
+        .def("set_deep_value_uint", &ImageBuf_set_deep_value_uint, "x"_a, "y"_a,
+             "z"_a, "channel"_a, "sample"_a, "value"_a = 0)
+        .def("deepdata", [](ImageBuf& self) { return *self.deepdata(); },
              py::return_value_policy::reference_internal)
 
         // FIXME -- do we want to provide pixel iterators?
-    ;
-
+        ;
 }
 
-} // namespace PyOpenImageIO
-
+}  // namespace PyOpenImageIO

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -33,1229 +33,1235 @@
 #include <OpenImageIO/imagebufalgo.h>
 
 
-namespace PyOpenImageIO
-{
+namespace PyOpenImageIO {
 
 
-class IBA_dummy { };   // dummy class to establish a scope
+class IBA_dummy {
+};  // dummy class to establish a scope
 
 
 bool
-IBA_zero (ImageBuf &dst, ROI roi, int nthreads)
+IBA_zero(ImageBuf& dst, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::zero (dst, roi, nthreads);
+    return ImageBufAlgo::zero(dst, roi, nthreads);
 }
 
 ImageBuf
-IBA_zero_ret (ROI roi, int nthreads)
+IBA_zero_ret(ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::zero (roi, nthreads);
+    return ImageBufAlgo::zero(roi, nthreads);
 }
 
 
 
 bool
-IBA_fill (ImageBuf &dst, py::object values_tuple,
-          ROI roi=ROI::All(), int nthreads=0)
+IBA_fill(ImageBuf& dst, py::object values_tuple, ROI roi = ROI::All(),
+         int nthreads = 0)
 {
     std::vector<float> values;
-    py_to_stdvector (values, values_tuple);
+    py_to_stdvector(values, values_tuple);
     if (dst.initialized())
-        values.resize (dst.nchannels(), 0.0f);
+        values.resize(dst.nchannels(), 0.0f);
     else if (roi.defined())
-        values.resize (roi.nchannels(), values.size() ? values.back() : 0.0f);
-    else return false;
-    ASSERT (values.size() > 0);
+        values.resize(roi.nchannels(), values.size() ? values.back() : 0.0f);
+    else
+        return false;
+    ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
-    return ImageBufAlgo::fill (dst, values, roi, nthreads);
+    return ImageBufAlgo::fill(dst, values, roi, nthreads);
 }
 
 
 bool
-IBA_fill2 (ImageBuf &dst, py::object top_tuple, py::object bottom_tuple,
-          ROI roi=ROI::All(), int nthreads=0)
+IBA_fill2(ImageBuf& dst, py::object top_tuple, py::object bottom_tuple,
+          ROI roi = ROI::All(), int nthreads = 0)
 {
     std::vector<float> top, bottom;
-    py_to_stdvector (top, top_tuple);
-    py_to_stdvector (bottom, bottom_tuple);
+    py_to_stdvector(top, top_tuple);
+    py_to_stdvector(bottom, bottom_tuple);
     if (dst.initialized()) {
-        top.resize (dst.nchannels(), 0.0f);
-        bottom.resize (dst.nchannels(), 0.0f);
+        top.resize(dst.nchannels(), 0.0f);
+        bottom.resize(dst.nchannels(), 0.0f);
     } else if (roi.defined()) {
-        top.resize (roi.nchannels(), 0.0f);
-        bottom.resize (roi.nchannels(), 0.0f);
-    }
-    else return false;
-    ASSERT (top.size() > 0 && bottom.size() > 0);
+        top.resize(roi.nchannels(), 0.0f);
+        bottom.resize(roi.nchannels(), 0.0f);
+    } else
+        return false;
+    ASSERT(top.size() > 0 && bottom.size() > 0);
     py::gil_scoped_release gil;
-    return ImageBufAlgo::fill (dst, top, bottom, roi, nthreads);
+    return ImageBufAlgo::fill(dst, top, bottom, roi, nthreads);
 }
 
 
 bool
-IBA_fill4 (ImageBuf &dst, py::object top_left_tuple, py::object top_right_tuple,
+IBA_fill4(ImageBuf& dst, py::object top_left_tuple, py::object top_right_tuple,
           py::object bottom_left_tuple, py::object bottom_right_tuple,
-          ROI roi=ROI::All(), int nthreads=0)
+          ROI roi = ROI::All(), int nthreads = 0)
 {
     std::vector<float> top_left, top_right, bottom_left, bottom_right;
-    py_to_stdvector (top_left, top_left_tuple);
-    py_to_stdvector (top_right, top_right_tuple);
-    py_to_stdvector (bottom_left, bottom_left_tuple);
-    py_to_stdvector (bottom_right, bottom_right_tuple);
+    py_to_stdvector(top_left, top_left_tuple);
+    py_to_stdvector(top_right, top_right_tuple);
+    py_to_stdvector(bottom_left, bottom_left_tuple);
+    py_to_stdvector(bottom_right, bottom_right_tuple);
     if (dst.initialized()) {
-        top_left.resize (dst.nchannels(), 0.0f);
-        top_right.resize (dst.nchannels(), 0.0f);
-        bottom_left.resize (dst.nchannels(), 0.0f);
-        bottom_right.resize (dst.nchannels(), 0.0f);
+        top_left.resize(dst.nchannels(), 0.0f);
+        top_right.resize(dst.nchannels(), 0.0f);
+        bottom_left.resize(dst.nchannels(), 0.0f);
+        bottom_right.resize(dst.nchannels(), 0.0f);
     } else if (roi.defined()) {
-        top_left.resize (roi.nchannels(), 0.0f);
-        top_right.resize (roi.nchannels(), 0.0f);
-        bottom_left.resize (roi.nchannels(), 0.0f);
-        bottom_right.resize (roi.nchannels(), 0.0f);
-    }
-    else return false;
-    ASSERT (top_left.size() > 0 && top_right.size() > 0 &&
-            bottom_left.size() > 0 && bottom_right.size() > 0);
+        top_left.resize(roi.nchannels(), 0.0f);
+        top_right.resize(roi.nchannels(), 0.0f);
+        bottom_left.resize(roi.nchannels(), 0.0f);
+        bottom_right.resize(roi.nchannels(), 0.0f);
+    } else
+        return false;
+    ASSERT(top_left.size() > 0 && top_right.size() > 0 && bottom_left.size() > 0
+           && bottom_right.size() > 0);
     py::gil_scoped_release gil;
-    return ImageBufAlgo::fill (dst, top_left, top_right,
-                               bottom_left, bottom_right,
-                               roi, nthreads);
+    return ImageBufAlgo::fill(dst, top_left, top_right, bottom_left,
+                              bottom_right, roi, nthreads);
 }
 
 
 
 ImageBuf
-IBA_fill_ret (py::object values_tuple,
-              ROI roi, int nthreads=0)
+IBA_fill_ret(py::object values_tuple, ROI roi, int nthreads = 0)
 {
     ImageBuf result;
-    IBA_fill (result, values_tuple, roi, nthreads);
+    IBA_fill(result, values_tuple, roi, nthreads);
     return result;
 }
 
 
 ImageBuf
-IBA_fill2_ret (py::object top_tuple, py::object bottom_tuple,
-               ROI roi, int nthreads=0)
+IBA_fill2_ret(py::object top_tuple, py::object bottom_tuple, ROI roi,
+              int nthreads = 0)
 {
     ImageBuf result;
-    IBA_fill2 (result, top_tuple, bottom_tuple, roi, nthreads);
+    IBA_fill2(result, top_tuple, bottom_tuple, roi, nthreads);
     return result;
 }
 
 
 ImageBuf
-IBA_fill4_ret (py::object top_left_tuple, py::object top_right_tuple,
-               py::object bottom_left_tuple, py::object bottom_right_tuple,
-               ROI roi, int nthreads=0)
+IBA_fill4_ret(py::object top_left_tuple, py::object top_right_tuple,
+              py::object bottom_left_tuple, py::object bottom_right_tuple,
+              ROI roi, int nthreads = 0)
 {
     ImageBuf result;
-    IBA_fill4 (result, top_left_tuple, top_right_tuple,
-               bottom_left_tuple, bottom_right_tuple, roi, nthreads);
+    IBA_fill4(result, top_left_tuple, top_right_tuple, bottom_left_tuple,
+              bottom_right_tuple, roi, nthreads);
     return result;
 }
 
 
 
 bool
-IBA_checker (ImageBuf &dst, int width, int height, int depth,
-             py::object color1_tuple, py::object color2_tuple,
-             int xoffset, int yoffset, int zoffset,
-             ROI roi, int nthreads)
+IBA_checker(ImageBuf& dst, int width, int height, int depth,
+            py::object color1_tuple, py::object color2_tuple, int xoffset,
+            int yoffset, int zoffset, ROI roi, int nthreads)
 {
     std::vector<float> color1, color2;
-    py_to_stdvector (color1, color1_tuple);
-    py_to_stdvector (color2, color2_tuple);
+    py_to_stdvector(color1, color1_tuple);
+    py_to_stdvector(color2, color2_tuple);
     if (dst.initialized())
-        color1.resize (dst.nchannels(), 0.0f);
+        color1.resize(dst.nchannels(), 0.0f);
     else if (roi.defined())
-        color1.resize (roi.nchannels(), 0.0f);
-    else return false;
+        color1.resize(roi.nchannels(), 0.0f);
+    else
+        return false;
     if (dst.initialized())
-        color2.resize (dst.nchannels(), 0.0f);
+        color2.resize(dst.nchannels(), 0.0f);
     else if (roi.defined())
-        color2.resize (roi.nchannels(), 0.0f);
-    else return false;
+        color2.resize(roi.nchannels(), 0.0f);
+    else
+        return false;
     py::gil_scoped_release gil;
-    return ImageBufAlgo::checker (dst, width, height, depth, color1, color2,
-                                  xoffset, yoffset, zoffset, roi, nthreads);
+    return ImageBufAlgo::checker(dst, width, height, depth, color1, color2,
+                                 xoffset, yoffset, zoffset, roi, nthreads);
 }
 
 
 
 ImageBuf
-IBA_checker_ret (int width, int height, int depth,
-                 py::object color1_tuple, py::object color2_tuple,
-                 int xoffset, int yoffset, int zoffset,
-                 ROI roi, int nthreads)
+IBA_checker_ret(int width, int height, int depth, py::object color1_tuple,
+                py::object color2_tuple, int xoffset, int yoffset, int zoffset,
+                ROI roi, int nthreads)
 {
     ImageBuf result;
-    IBA_checker (result, width, height, depth, color1_tuple, color2_tuple,
-                 xoffset, yoffset, zoffset, roi, nthreads);
+    IBA_checker(result, width, height, depth, color1_tuple, color2_tuple,
+                xoffset, yoffset, zoffset, roi, nthreads);
     return result;
 }
 
 
 
 bool
-IBA_noise (ImageBuf &dst, const std::string& type, float A, float B,
-           bool mono, int seed, ROI roi, int nthreads)
+IBA_noise(ImageBuf& dst, const std::string& type, float A, float B, bool mono,
+          int seed, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::noise (dst, type, A, B, mono, seed, roi, nthreads);
+    return ImageBufAlgo::noise(dst, type, A, B, mono, seed, roi, nthreads);
 }
 
 
 ImageBuf
-IBA_noise_ret (const std::string& type, float A, float B,
-               bool mono, int seed, ROI roi, int nthreads)
+IBA_noise_ret(const std::string& type, float A, float B, bool mono, int seed,
+              ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::noise (type, A, B, mono, seed, roi, nthreads);
+    return ImageBufAlgo::noise(type, A, B, mono, seed, roi, nthreads);
 }
 
 
 
 bool
-IBA_channels (ImageBuf &dst, const ImageBuf &src,
-              py::tuple channelorder_, py::tuple newchannelnames_,
-              bool shuffle_channel_names, int nthreads)
+IBA_channels(ImageBuf& dst, const ImageBuf& src, py::tuple channelorder_,
+             py::tuple newchannelnames_, bool shuffle_channel_names,
+             int nthreads)
 {
-    size_t nchannels = (size_t) len(channelorder_);
+    size_t nchannels = (size_t)len(channelorder_);
     if (nchannels < 1) {
-        dst.error ("No channels selected");
+        dst.error("No channels selected");
         return false;
     }
-    std::vector<int> channelorder (nchannels, -1);
-    std::vector<float> channelvalues (nchannels, 0.0f);
-    for (size_t i = 0;  i < nchannels;  ++i) {
+    std::vector<int> channelorder(nchannels, -1);
+    std::vector<float> channelvalues(nchannels, 0.0f);
+    for (size_t i = 0; i < nchannels; ++i) {
         auto orderi = channelorder_[i];
         if (py::isinstance<py::int_>(orderi)) {
             channelorder[i] = orderi.cast<py::int_>();
-        }
-        else if (py::isinstance<py::float_>(orderi)) {
+        } else if (py::isinstance<py::float_>(orderi)) {
             channelvalues[i] = orderi.cast<py::float_>();
-        }
-        else if (py::isinstance<py::str>(orderi)) {
+        } else if (py::isinstance<py::str>(orderi)) {
             std::string chname = orderi.cast<py::str>();
-            for (int c = 0;  c < src.nchannels(); ++c) {
+            for (int c = 0; c < src.nchannels(); ++c) {
                 if (src.spec().channelnames[c] == chname)
                     channelorder[i] = c;
             }
         }
     }
     std::vector<std::string> newchannelnames;
-    py_to_stdvector (newchannelnames, newchannelnames_);
+    py_to_stdvector(newchannelnames, newchannelnames_);
     if (newchannelnames.size() != 0 && newchannelnames.size() != nchannels) {
-        dst.error ("Inconsistent number of channel arguments");
+        dst.error("Inconsistent number of channel arguments");
         return false;
     }
     py::gil_scoped_release gil;
-    return ImageBufAlgo::channels (dst, src, (int)nchannels, &channelorder[0],
-                         channelvalues.size() ? &channelvalues[0] : nullptr,
-                         newchannelnames.size() ? &newchannelnames[0] : nullptr,
-                         shuffle_channel_names, nthreads);
+    return ImageBufAlgo::channels(dst, src, (int)nchannels, &channelorder[0],
+                                  channelvalues.size() ? &channelvalues[0]
+                                                       : nullptr,
+                                  newchannelnames.size() ? &newchannelnames[0]
+                                                         : nullptr,
+                                  shuffle_channel_names, nthreads);
 }
 
 
 ImageBuf
-IBA_channels_ret (const ImageBuf &src,
-                  py::tuple channelorder, py::tuple newchannelnames,
-                  bool shuffle_channel_names, int nthreads)
+IBA_channels_ret(const ImageBuf& src, py::tuple channelorder,
+                 py::tuple newchannelnames, bool shuffle_channel_names,
+                 int nthreads)
 {
     ImageBuf result;
-    IBA_channels (result, src, channelorder, newchannelnames,
-                  shuffle_channel_names, nthreads);
+    IBA_channels(result, src, channelorder, newchannelnames,
+                 shuffle_channel_names, nthreads);
     return result;
 }
 
 
 bool
-IBA_channel_append (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
-                    ROI roi, int nthreads)
+IBA_channel_append(ImageBuf& dst, const ImageBuf& A, const ImageBuf& B, ROI roi,
+                   int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::channel_append (dst, A, B, roi, nthreads);
+    return ImageBufAlgo::channel_append(dst, A, B, roi, nthreads);
 }
 
 
 ImageBuf
-IBA_channel_append_ret (const ImageBuf &A, const ImageBuf &B,
-                        ROI roi, int nthreads)
+IBA_channel_append_ret(const ImageBuf& A, const ImageBuf& B, ROI roi,
+                       int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::channel_append (A, B, roi, nthreads);
+    return ImageBufAlgo::channel_append(A, B, roi, nthreads);
 }
 
 
 
 bool
-IBA_deepen (ImageBuf &dst, const ImageBuf &src, float zvalue,
-            ROI roi, int nthreads)
+IBA_deepen(ImageBuf& dst, const ImageBuf& src, float zvalue, ROI roi,
+           int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::deepen (dst, src, zvalue, roi, nthreads);
-}
-
-
-
-ImageBuf
-IBA_deepen_ret (const ImageBuf &src, float zvalue,
-            ROI roi, int nthreads)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::deepen (src, zvalue, roi, nthreads);
-}
-
-
-
-bool
-IBA_flatten (ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::flatten (dst, src, roi, nthreads);
+    return ImageBufAlgo::deepen(dst, src, zvalue, roi, nthreads);
 }
 
 
 
 ImageBuf
-IBA_flatten_ret (const ImageBuf &src, ROI roi, int nthreads)
+IBA_deepen_ret(const ImageBuf& src, float zvalue, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::flatten (src, roi, nthreads);
+    return ImageBufAlgo::deepen(src, zvalue, roi, nthreads);
 }
 
 
 
 bool
-IBA_deep_merge (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
-                 bool occlusion_cull, ROI roi, int nthreads)
+IBA_flatten(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::deep_merge (dst, A, B, occlusion_cull, roi, nthreads);
+    return ImageBufAlgo::flatten(dst, src, roi, nthreads);
 }
 
 
 
 ImageBuf
-IBA_deep_merge_ret (const ImageBuf &A, const ImageBuf &B,
-                    bool occlusion_cull, ROI roi, int nthreads)
+IBA_flatten_ret(const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::deep_merge (A, B, occlusion_cull, roi, nthreads);
+    return ImageBufAlgo::flatten(src, roi, nthreads);
 }
 
 
 
 bool
-IBA_deep_holdout (ImageBuf &dst, const ImageBuf &src, const ImageBuf &holdout,
-                  ROI roi, int nthreads)
+IBA_deep_merge(ImageBuf& dst, const ImageBuf& A, const ImageBuf& B,
+               bool occlusion_cull, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::deep_holdout (dst, src, holdout, roi, nthreads);
+    return ImageBufAlgo::deep_merge(dst, A, B, occlusion_cull, roi, nthreads);
 }
 
 
 
 ImageBuf
-IBA_deep_holdout_ret (const ImageBuf &src, const ImageBuf &holdout,
-                      ROI roi, int nthreads)
+IBA_deep_merge_ret(const ImageBuf& A, const ImageBuf& B, bool occlusion_cull,
+                   ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::deep_holdout (src, holdout, roi, nthreads);
+    return ImageBufAlgo::deep_merge(A, B, occlusion_cull, roi, nthreads);
 }
 
 
 
 bool
-IBA_copy (ImageBuf &dst, const ImageBuf &src, TypeDesc convert,
-          ROI roi, int nthreads)
+IBA_deep_holdout(ImageBuf& dst, const ImageBuf& src, const ImageBuf& holdout,
+                 ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::copy (dst, src, convert, roi, nthreads);
+    return ImageBufAlgo::deep_holdout(dst, src, holdout, roi, nthreads);
 }
 
 
 
 ImageBuf
-IBA_copy_ret (const ImageBuf &src, TypeDesc convert,
-          ROI roi, int nthreads)
+IBA_deep_holdout_ret(const ImageBuf& src, const ImageBuf& holdout, ROI roi,
+                     int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::copy (src, convert, roi, nthreads);
+    return ImageBufAlgo::deep_holdout(src, holdout, roi, nthreads);
 }
 
 
 
 bool
-IBA_crop (ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
+IBA_copy(ImageBuf& dst, const ImageBuf& src, TypeDesc convert, ROI roi,
+         int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::crop (dst, src, roi, nthreads);
+    return ImageBufAlgo::copy(dst, src, convert, roi, nthreads);
 }
 
 
 
 ImageBuf
-IBA_crop_ret (const ImageBuf &src, ROI roi, int nthreads)
+IBA_copy_ret(const ImageBuf& src, TypeDesc convert, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::crop (src, roi, nthreads);
+    return ImageBufAlgo::copy(src, convert, roi, nthreads);
 }
 
 
 
 bool
-IBA_cut (ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
+IBA_crop(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::cut (dst, src, roi, nthreads);
+    return ImageBufAlgo::crop(dst, src, roi, nthreads);
 }
 
 
 
 ImageBuf
-IBA_cut_ret (const ImageBuf &src, ROI roi, int nthreads)
+IBA_crop_ret(const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::cut (src, roi, nthreads);
+    return ImageBufAlgo::crop(src, roi, nthreads);
 }
 
 
 
 bool
-IBA_paste (ImageBuf &dst, int xbegin, int ybegin, int zbegin, int chbegin,
-           const ImageBuf &src, ROI roi, int nthreads)
+IBA_cut(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::paste (dst, xbegin, ybegin, zbegin, chbegin,
-                                src, roi, nthreads);
+    return ImageBufAlgo::cut(dst, src, roi, nthreads);
+}
+
+
+
+ImageBuf
+IBA_cut_ret(const ImageBuf& src, ROI roi, int nthreads)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::cut(src, roi, nthreads);
 }
 
 
 
 bool
-IBA_rotate90 (ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
+IBA_paste(ImageBuf& dst, int xbegin, int ybegin, int zbegin, int chbegin,
+          const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::rotate90 (dst, src, roi, nthreads);
+    return ImageBufAlgo::paste(dst, xbegin, ybegin, zbegin, chbegin, src, roi,
+                               nthreads);
+}
+
+
+
+bool
+IBA_rotate90(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::rotate90(dst, src, roi, nthreads);
 }
 
 ImageBuf
-IBA_rotate90_ret (const ImageBuf &src, ROI roi, int nthreads)
+IBA_rotate90_ret(const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::rotate90 (src, roi, nthreads);
+    return ImageBufAlgo::rotate90(src, roi, nthreads);
 }
 
 
 bool
-IBA_rotate180 (ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
+IBA_rotate180(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::rotate180 (dst, src, roi, nthreads);
+    return ImageBufAlgo::rotate180(dst, src, roi, nthreads);
 }
 
 ImageBuf
-IBA_rotate180_ret (const ImageBuf &src, ROI roi, int nthreads)
+IBA_rotate180_ret(const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::rotate180 (src, roi, nthreads);
+    return ImageBufAlgo::rotate180(src, roi, nthreads);
 }
 
 
 bool
-IBA_rotate270 (ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
+IBA_rotate270(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::rotate270 (dst, src, roi, nthreads);
+    return ImageBufAlgo::rotate270(dst, src, roi, nthreads);
 }
 
 ImageBuf
-IBA_rotate270_ret (const ImageBuf &src, ROI roi, int nthreads)
+IBA_rotate270_ret(const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::rotate270 (src, roi, nthreads);
+    return ImageBufAlgo::rotate270(src, roi, nthreads);
 }
 
 
 bool
-IBA_flip (ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
+IBA_flip(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::flip (dst, src, roi, nthreads);
+    return ImageBufAlgo::flip(dst, src, roi, nthreads);
 }
 
 ImageBuf
-IBA_flip_ret (const ImageBuf &src, ROI roi, int nthreads)
+IBA_flip_ret(const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::flip (src, roi, nthreads);
+    return ImageBufAlgo::flip(src, roi, nthreads);
 }
 
 
 bool
-IBA_flop (ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
+IBA_flop(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::flop (dst, src, roi, nthreads);
+    return ImageBufAlgo::flop(dst, src, roi, nthreads);
 }
 
 ImageBuf
-IBA_flop_ret (const ImageBuf &src, ROI roi, int nthreads)
+IBA_flop_ret(const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::flop (src, roi, nthreads);
+    return ImageBufAlgo::flop(src, roi, nthreads);
 }
 
 
 bool
-IBA_reorient (ImageBuf &dst, const ImageBuf &src, int nthreads)
+IBA_reorient(ImageBuf& dst, const ImageBuf& src, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::reorient (dst, src, nthreads);
+    return ImageBufAlgo::reorient(dst, src, nthreads);
 }
 
 ImageBuf
-IBA_reorient_ret (const ImageBuf &src, int nthreads)
+IBA_reorient_ret(const ImageBuf& src, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::reorient (src, nthreads);
+    return ImageBufAlgo::reorient(src, nthreads);
 }
 
 
 bool
-IBA_transpose (ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
+IBA_transpose(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::transpose (dst, src, roi, nthreads);
+    return ImageBufAlgo::transpose(dst, src, roi, nthreads);
 }
 
 ImageBuf
-IBA_transpose_ret (const ImageBuf &src, ROI roi, int nthreads)
+IBA_transpose_ret(const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::transpose (src, roi, nthreads);
+    return ImageBufAlgo::transpose(src, roi, nthreads);
 }
 
 
 bool
-IBA_circular_shift (ImageBuf &dst, const ImageBuf &src,
-                    int xshift, int yshift, int zshift,
-                    ROI roi, int nthreads)
+IBA_circular_shift(ImageBuf& dst, const ImageBuf& src, int xshift, int yshift,
+                   int zshift, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::circular_shift (dst, src, xshift, yshift, zshift,
-                                         roi, nthreads);
+    return ImageBufAlgo::circular_shift(dst, src, xshift, yshift, zshift, roi,
+                                        nthreads);
 }
 
 ImageBuf
-IBA_circular_shift_ret (const ImageBuf &src, int xshift, int yshift, int zshift,
-                        ROI roi, int nthreads)
+IBA_circular_shift_ret(const ImageBuf& src, int xshift, int yshift, int zshift,
+                       ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::circular_shift (src, xshift, yshift, zshift,
-                                         roi, nthreads);
+    return ImageBufAlgo::circular_shift(src, xshift, yshift, zshift, roi,
+                                        nthreads);
 }
 
 
 
 bool
-IBA_add_color (ImageBuf &dst, const ImageBuf &A, py::object values_tuple,
-               ROI roi=ROI::All(), int nthreads=0)
+IBA_add_color(ImageBuf& dst, const ImageBuf& A, py::object values_tuple,
+              ROI roi = ROI::All(), int nthreads = 0)
 {
     std::vector<float> values;
-    py_to_stdvector (values, values_tuple);
+    py_to_stdvector(values, values_tuple);
     if (roi.defined())
-        values.resize (roi.nchannels(), values.size() ? values.back() : 0.0f);
+        values.resize(roi.nchannels(), values.size() ? values.back() : 0.0f);
     else if (A.initialized())
-        values.resize (A.nchannels(), values.size() ? values.back() : 0.0f);
-    else return false;
-    ASSERT (values.size() > 0);
+        values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
+    else
+        return false;
+    ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
-    return ImageBufAlgo::add (dst, A, &values[0], roi, nthreads);
+    return ImageBufAlgo::add(dst, A, &values[0], roi, nthreads);
 }
 
 bool
-IBA_add_images (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
-                ROI roi=ROI::All(), int nthreads=0)
+IBA_add_images(ImageBuf& dst, const ImageBuf& A, const ImageBuf& B,
+               ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::add (dst, A, B, roi, nthreads);
+    return ImageBufAlgo::add(dst, A, B, roi, nthreads);
 }
 
 ImageBuf
-IBA_add_color_ret (const ImageBuf &A, py::object values_tuple,
-                   ROI roi=ROI::All(), int nthreads=0)
-{
-    ImageBuf result;
-    std::vector<float> values;
-    py_to_stdvector (values, values_tuple);
-    if (roi.defined())
-        values.resize (roi.nchannels(), values.size() ? values.back() : 0.0f);
-    else if (A.initialized())
-        values.resize (A.nchannels(), values.size() ? values.back() : 0.0f);
-    else return result;
-    ASSERT (values.size() > 0);
-    py::gil_scoped_release gil;
-    result = ImageBufAlgo::add (A, values, roi, nthreads);
-    return result;
-}
-
-ImageBuf
-IBA_add_images_ret (const ImageBuf &A, const ImageBuf &B,
-                    ROI roi=ROI::All(), int nthreads=0)
-{
-    py::gil_scoped_release gil;
-    ImageBuf result = ImageBufAlgo::add (A, B, roi, nthreads);
-    return result;
-}
-
-
-
-bool
-IBA_sub_color (ImageBuf &dst, const ImageBuf &A, py::object values_tuple,
-               ROI roi=ROI::All(), int nthreads=0)
-{
-    std::vector<float> values;
-    py_to_stdvector (values, values_tuple);
-    if (roi.defined())
-        values.resize (roi.nchannels(), values.size() ? values.back() : 0.0f);
-    else if (A.initialized())
-        values.resize (A.nchannels(), values.size() ? values.back() : 0.0f);
-    else return false;
-    ASSERT (values.size() > 0);
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::sub (dst, A, &values[0], roi, nthreads);
-}
-
-bool
-IBA_sub_images (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
-                ROI roi=ROI::All(), int nthreads=0)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::sub (dst, A, B, roi, nthreads);
-}
-
-ImageBuf
-IBA_sub_color_ret (const ImageBuf &A, py::object values_tuple,
-                   ROI roi=ROI::All(), int nthreads=0)
+IBA_add_color_ret(const ImageBuf& A, py::object values_tuple,
+                  ROI roi = ROI::All(), int nthreads = 0)
 {
     ImageBuf result;
     std::vector<float> values;
-    py_to_stdvector (values, values_tuple);
+    py_to_stdvector(values, values_tuple);
     if (roi.defined())
-        values.resize (roi.nchannels(), values.size() ? values.back() : 0.0f);
+        values.resize(roi.nchannels(), values.size() ? values.back() : 0.0f);
     else if (A.initialized())
-        values.resize (A.nchannels(), values.size() ? values.back() : 0.0f);
-    else return result;
-    ASSERT (values.size() > 0);
+        values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
+    else
+        return result;
+    ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
-    result = ImageBufAlgo::sub (A, values, roi, nthreads);
+    result = ImageBufAlgo::add(A, values, roi, nthreads);
     return result;
 }
 
 ImageBuf
-IBA_sub_images_ret (const ImageBuf &A, const ImageBuf &B,
-                    ROI roi=ROI::All(), int nthreads=0)
+IBA_add_images_ret(const ImageBuf& A, const ImageBuf& B, ROI roi = ROI::All(),
+                   int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::sub (A, B, roi, nthreads);
+    ImageBuf result = ImageBufAlgo::add(A, B, roi, nthreads);
+    return result;
 }
 
 
 
 bool
-IBA_absdiff_color (ImageBuf &dst, const ImageBuf &A, py::object values_tuple,
-                   ROI roi=ROI::All(), int nthreads=0)
+IBA_sub_color(ImageBuf& dst, const ImageBuf& A, py::object values_tuple,
+              ROI roi = ROI::All(), int nthreads = 0)
 {
     std::vector<float> values;
-    py_to_stdvector (values, values_tuple);
+    py_to_stdvector(values, values_tuple);
     if (roi.defined())
-        values.resize (roi.nchannels(), values.size() ? values.back() : 0.0f);
+        values.resize(roi.nchannels(), values.size() ? values.back() : 0.0f);
     else if (A.initialized())
-        values.resize (A.nchannels(), values.size() ? values.back() : 0.0f);
-    else return false;
-    ASSERT (values.size() > 0);
+        values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
+    else
+        return false;
+    ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
-    return ImageBufAlgo::absdiff (dst, A, &values[0], roi, nthreads);
+    return ImageBufAlgo::sub(dst, A, &values[0], roi, nthreads);
 }
 
 bool
-IBA_absdiff_images (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
-                    ROI roi=ROI::All(), int nthreads=0)
+IBA_sub_images(ImageBuf& dst, const ImageBuf& A, const ImageBuf& B,
+               ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::absdiff (dst, A, B, roi, nthreads);
+    return ImageBufAlgo::sub(dst, A, B, roi, nthreads);
 }
 
 ImageBuf
-IBA_absdiff_color_ref (const ImageBuf &A, py::object values_tuple,
-                       ROI roi=ROI::All(), int nthreads=0)
+IBA_sub_color_ret(const ImageBuf& A, py::object values_tuple,
+                  ROI roi = ROI::All(), int nthreads = 0)
 {
     ImageBuf result;
     std::vector<float> values;
-    py_to_stdvector (values, values_tuple);
+    py_to_stdvector(values, values_tuple);
     if (roi.defined())
-        values.resize (roi.nchannels(), values.size() ? values.back() : 0.0f);
+        values.resize(roi.nchannels(), values.size() ? values.back() : 0.0f);
     else if (A.initialized())
-        values.resize (A.nchannels(), values.size() ? values.back() : 0.0f);
-    else return result;
-    ASSERT (values.size() > 0);
+        values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
+    else
+        return result;
+    ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
-    result = ImageBufAlgo::absdiff (A, values, roi, nthreads);
+    result = ImageBufAlgo::sub(A, values, roi, nthreads);
     return result;
 }
 
 ImageBuf
-IBA_absdiff_images_ret (const ImageBuf &A, const ImageBuf &B,
-                        ROI roi=ROI::All(), int nthreads=0)
+IBA_sub_images_ret(const ImageBuf& A, const ImageBuf& B, ROI roi = ROI::All(),
+                   int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    ImageBuf result = ImageBufAlgo::absdiff (A, B, roi, nthreads);
-    return result;
+    return ImageBufAlgo::sub(A, B, roi, nthreads);
 }
 
 
 
 bool
-IBA_abs (ImageBuf &dst, const ImageBuf &A,
-         ROI roi=ROI::All(), int nthreads=0)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::abs (dst, A, roi, nthreads);
-}
-
-ImageBuf
-IBA_abs_ret (const ImageBuf &A, ROI roi=ROI::All(), int nthreads=0)
-{
-    py::gil_scoped_release gil;
-    ImageBuf result = ImageBufAlgo::abs (A, roi, nthreads);
-    return result;
-}
-
-
-
-bool
-IBA_mul_color (ImageBuf &dst, const ImageBuf &A, py::object values_tuple,
-               ROI roi=ROI::All(), int nthreads=0)
+IBA_absdiff_color(ImageBuf& dst, const ImageBuf& A, py::object values_tuple,
+                  ROI roi = ROI::All(), int nthreads = 0)
 {
     std::vector<float> values;
-    py_to_stdvector (values, values_tuple);
+    py_to_stdvector(values, values_tuple);
     if (roi.defined())
-        values.resize (roi.nchannels(), values.size() ? values.back() : 0.0f);
+        values.resize(roi.nchannels(), values.size() ? values.back() : 0.0f);
     else if (A.initialized())
-        values.resize (A.nchannels(), values.size() ? values.back() : 0.0f);
-    else return false;
-    ASSERT (values.size() > 0);
+        values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
+    else
+        return false;
+    ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
-    return ImageBufAlgo::mul (dst, A, &values[0], roi, nthreads);
+    return ImageBufAlgo::absdiff(dst, A, &values[0], roi, nthreads);
 }
 
 bool
-IBA_mul_images (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
-                ROI roi=ROI::All(), int nthreads=0)
+IBA_absdiff_images(ImageBuf& dst, const ImageBuf& A, const ImageBuf& B,
+                   ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::mul (dst, A, B, roi, nthreads);
+    return ImageBufAlgo::absdiff(dst, A, B, roi, nthreads);
 }
 
 ImageBuf
-IBA_mul_color_ret (const ImageBuf &A, py::object values_tuple,
-                   ROI roi=ROI::All(), int nthreads=0)
+IBA_absdiff_color_ref(const ImageBuf& A, py::object values_tuple,
+                      ROI roi = ROI::All(), int nthreads = 0)
 {
     ImageBuf result;
     std::vector<float> values;
-    py_to_stdvector (values, values_tuple);
+    py_to_stdvector(values, values_tuple);
     if (roi.defined())
-        values.resize (roi.nchannels(), values.size() ? values.back() : 0.0f);
+        values.resize(roi.nchannels(), values.size() ? values.back() : 0.0f);
     else if (A.initialized())
-        values.resize (A.nchannels(), values.size() ? values.back() : 0.0f);
-    else return result;
-    ASSERT (values.size() > 0);
+        values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
+    else
+        return result;
+    ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
-    result = ImageBufAlgo::mul (A, values, roi, nthreads);
+    result = ImageBufAlgo::absdiff(A, values, roi, nthreads);
     return result;
 }
 
 ImageBuf
-IBA_mul_images_ret (const ImageBuf &A, const ImageBuf &B,
-                    ROI roi=ROI::All(), int nthreads=0)
+IBA_absdiff_images_ret(const ImageBuf& A, const ImageBuf& B,
+                       ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::mul (A, B, roi, nthreads);
+    ImageBuf result = ImageBufAlgo::absdiff(A, B, roi, nthreads);
+    return result;
 }
 
 
 
 bool
-IBA_div_color (ImageBuf &dst, const ImageBuf &A, py::object values_tuple,
-               ROI roi=ROI::All(), int nthreads=0)
-{
-    std::vector<float> values;
-    py_to_stdvector (values, values_tuple);
-    if (roi.defined())
-        values.resize (roi.nchannels(), values.size() ? values.back() : 0.0f);
-    else if (A.initialized())
-        values.resize (A.nchannels(), values.size() ? values.back() : 0.0f);
-    else return false;
-    ASSERT (values.size() > 0);
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::div (dst, A, &values[0], roi, nthreads);
-}
-
-bool
-IBA_div_images (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
-                ROI roi=ROI::All(), int nthreads=0)
+IBA_abs(ImageBuf& dst, const ImageBuf& A, ROI roi = ROI::All(),
+        int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::div (dst, A, B, roi, nthreads);
+    return ImageBufAlgo::abs(dst, A, roi, nthreads);
 }
-
-
 
 ImageBuf
-IBA_div_color_ret (const ImageBuf &A, py::object values_tuple,
-                   ROI roi=ROI::All(), int nthreads=0)
+IBA_abs_ret(const ImageBuf& A, ROI roi = ROI::All(), int nthreads = 0)
+{
+    py::gil_scoped_release gil;
+    ImageBuf result = ImageBufAlgo::abs(A, roi, nthreads);
+    return result;
+}
+
+
+
+bool
+IBA_mul_color(ImageBuf& dst, const ImageBuf& A, py::object values_tuple,
+              ROI roi = ROI::All(), int nthreads = 0)
+{
+    std::vector<float> values;
+    py_to_stdvector(values, values_tuple);
+    if (roi.defined())
+        values.resize(roi.nchannels(), values.size() ? values.back() : 0.0f);
+    else if (A.initialized())
+        values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
+    else
+        return false;
+    ASSERT(values.size() > 0);
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::mul(dst, A, &values[0], roi, nthreads);
+}
+
+bool
+IBA_mul_images(ImageBuf& dst, const ImageBuf& A, const ImageBuf& B,
+               ROI roi = ROI::All(), int nthreads = 0)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::mul(dst, A, B, roi, nthreads);
+}
+
+ImageBuf
+IBA_mul_color_ret(const ImageBuf& A, py::object values_tuple,
+                  ROI roi = ROI::All(), int nthreads = 0)
 {
     ImageBuf result;
     std::vector<float> values;
-    py_to_stdvector (values, values_tuple);
+    py_to_stdvector(values, values_tuple);
     if (roi.defined())
-        values.resize (roi.nchannels(), values.size() ? values.back() : 0.0f);
+        values.resize(roi.nchannels(), values.size() ? values.back() : 0.0f);
     else if (A.initialized())
-        values.resize (A.nchannels(), values.size() ? values.back() : 0.0f);
-    else return result;
-    ASSERT (values.size() > 0);
+        values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
+    else
+        return result;
+    ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
-    result = ImageBufAlgo::div (A, values, roi, nthreads);
+    result = ImageBufAlgo::mul(A, values, roi, nthreads);
     return result;
 }
 
 ImageBuf
-IBA_div_images_ret (const ImageBuf &A, const ImageBuf &B,
-                    ROI roi=ROI::All(), int nthreads=0)
+IBA_mul_images_ret(const ImageBuf& A, const ImageBuf& B, ROI roi = ROI::All(),
+                   int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::div (A, B, roi, nthreads);
+    return ImageBufAlgo::mul(A, B, roi, nthreads);
 }
 
 
 
 bool
-IBA_mad_color (ImageBuf &dst, const ImageBuf &A,
-               py::object Bvalues_tuple, py::object Cvalues_tuple,
-               ROI roi=ROI::All(), int nthreads=0)
+IBA_div_color(ImageBuf& dst, const ImageBuf& A, py::object values_tuple,
+              ROI roi = ROI::All(), int nthreads = 0)
+{
+    std::vector<float> values;
+    py_to_stdvector(values, values_tuple);
+    if (roi.defined())
+        values.resize(roi.nchannels(), values.size() ? values.back() : 0.0f);
+    else if (A.initialized())
+        values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
+    else
+        return false;
+    ASSERT(values.size() > 0);
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::div(dst, A, &values[0], roi, nthreads);
+}
+
+bool
+IBA_div_images(ImageBuf& dst, const ImageBuf& A, const ImageBuf& B,
+               ROI roi = ROI::All(), int nthreads = 0)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::div(dst, A, B, roi, nthreads);
+}
+
+
+
+ImageBuf
+IBA_div_color_ret(const ImageBuf& A, py::object values_tuple,
+                  ROI roi = ROI::All(), int nthreads = 0)
+{
+    ImageBuf result;
+    std::vector<float> values;
+    py_to_stdvector(values, values_tuple);
+    if (roi.defined())
+        values.resize(roi.nchannels(), values.size() ? values.back() : 0.0f);
+    else if (A.initialized())
+        values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
+    else
+        return result;
+    ASSERT(values.size() > 0);
+    py::gil_scoped_release gil;
+    result = ImageBufAlgo::div(A, values, roi, nthreads);
+    return result;
+}
+
+ImageBuf
+IBA_div_images_ret(const ImageBuf& A, const ImageBuf& B, ROI roi = ROI::All(),
+                   int nthreads = 0)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::div(A, B, roi, nthreads);
+}
+
+
+
+bool
+IBA_mad_color(ImageBuf& dst, const ImageBuf& A, py::object Bvalues_tuple,
+              py::object Cvalues_tuple, ROI roi = ROI::All(), int nthreads = 0)
 {
     std::vector<float> Bvalues, Cvalues;
-    py_to_stdvector (Bvalues, Bvalues_tuple);
+    py_to_stdvector(Bvalues, Bvalues_tuple);
     if (roi.defined())
-        Bvalues.resize (roi.nchannels(), Bvalues.size() ? Bvalues.back() : 0.0f);
+        Bvalues.resize(roi.nchannels(), Bvalues.size() ? Bvalues.back() : 0.0f);
     else if (A.initialized())
-        Bvalues.resize (A.nchannels(), Bvalues.size() ? Bvalues.back() : 0.0f);
-    else return false;
-    py_to_stdvector (Cvalues, Cvalues_tuple);
+        Bvalues.resize(A.nchannels(), Bvalues.size() ? Bvalues.back() : 0.0f);
+    else
+        return false;
+    py_to_stdvector(Cvalues, Cvalues_tuple);
     if (roi.defined())
-        Cvalues.resize (roi.nchannels(), Cvalues.size() ? Cvalues.back() : 0.0f);
+        Cvalues.resize(roi.nchannels(), Cvalues.size() ? Cvalues.back() : 0.0f);
     else if (A.initialized())
-        Cvalues.resize (A.nchannels(), Cvalues.size() ? Cvalues.back() : 0.0f);
-    else return false;
-    ASSERT (Bvalues.size() > 0 && Cvalues.size() > 0);
+        Cvalues.resize(A.nchannels(), Cvalues.size() ? Cvalues.back() : 0.0f);
+    else
+        return false;
+    ASSERT(Bvalues.size() > 0 && Cvalues.size() > 0);
     py::gil_scoped_release gil;
-    return ImageBufAlgo::mad (dst, A, Bvalues, Cvalues, roi, nthreads);
+    return ImageBufAlgo::mad(dst, A, Bvalues, Cvalues, roi, nthreads);
 }
 
 bool
-IBA_mad_ici (ImageBuf &dst, const ImageBuf &A,
-             py::object Bvalues_tuple, const ImageBuf &C,
-             ROI roi=ROI::All(), int nthreads=0)
+IBA_mad_ici(ImageBuf& dst, const ImageBuf& A, py::object Bvalues_tuple,
+            const ImageBuf& C, ROI roi = ROI::All(), int nthreads = 0)
 {
     std::vector<float> Bvalues, Cvalues;
-    py_to_stdvector (Bvalues, Bvalues_tuple);
+    py_to_stdvector(Bvalues, Bvalues_tuple);
     if (roi.defined())
-        Bvalues.resize (roi.nchannels(), Bvalues.size() ? Bvalues.back() : 0.0f);
+        Bvalues.resize(roi.nchannels(), Bvalues.size() ? Bvalues.back() : 0.0f);
     else if (A.initialized())
-        Bvalues.resize (A.nchannels(), Bvalues.size() ? Bvalues.back() : 0.0f);
-    else return false;
-    ASSERT (Bvalues.size() > 0);
+        Bvalues.resize(A.nchannels(), Bvalues.size() ? Bvalues.back() : 0.0f);
+    else
+        return false;
+    ASSERT(Bvalues.size() > 0);
     py::gil_scoped_release gil;
-    return ImageBufAlgo::mad (dst, A, Bvalues, C, roi, nthreads);
+    return ImageBufAlgo::mad(dst, A, Bvalues, C, roi, nthreads);
 }
 
 bool
-IBA_mad_cii (ImageBuf &dst, py::object Avalues_tuple,
-             const ImageBuf &B, const ImageBuf &C,
-             ROI roi=ROI::All(), int nthreads=0)
+IBA_mad_cii(ImageBuf& dst, py::object Avalues_tuple, const ImageBuf& B,
+            const ImageBuf& C, ROI roi = ROI::All(), int nthreads = 0)
 {
-    return IBA_mad_ici (dst, B, Avalues_tuple, C, roi, nthreads);
+    return IBA_mad_ici(dst, B, Avalues_tuple, C, roi, nthreads);
 }
 
 bool
-IBA_mad_images (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
-                const ImageBuf &C, ROI roi=ROI::All(), int nthreads=0)
+IBA_mad_images(ImageBuf& dst, const ImageBuf& A, const ImageBuf& B,
+               const ImageBuf& C, ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::mad (dst, A, B, C, roi, nthreads);
+    return ImageBufAlgo::mad(dst, A, B, C, roi, nthreads);
 }
 
 
 
 ImageBuf
-IBA_mad_color_ret (const ImageBuf &A,
-                   py::object Bvalues_tuple, py::object Cvalues_tuple,
-                   ROI roi=ROI::All(), int nthreads=0)
-{
-    ImageBuf result;
-    std::vector<float> Bvalues, Cvalues;
-    py_to_stdvector (Bvalues, Bvalues_tuple);
-    if (roi.defined())
-        Bvalues.resize (roi.nchannels(), Bvalues.size() ? Bvalues.back() : 0.0f);
-    else if (A.initialized())
-        Bvalues.resize (A.nchannels(), Bvalues.size() ? Bvalues.back() : 0.0f);
-    else return result;
-    py_to_stdvector (Cvalues, Cvalues_tuple);
-    if (roi.defined())
-        Cvalues.resize (roi.nchannels(), Cvalues.size() ? Cvalues.back() : 0.0f);
-    else if (A.initialized())
-        Cvalues.resize (A.nchannels(), Cvalues.size() ? Cvalues.back() : 0.0f);
-    else return result;
-    ASSERT (Bvalues.size() > 0 && Cvalues.size() > 0);
-    py::gil_scoped_release gil;
-    result = ImageBufAlgo::mad (A, Bvalues, Cvalues, roi, nthreads);
-    return result;
-}
-
-ImageBuf
-IBA_mad_ici_ret (const ImageBuf &A,
-                 py::object Bvalues_tuple, const ImageBuf &C,
-                 ROI roi=ROI::All(), int nthreads=0)
+IBA_mad_color_ret(const ImageBuf& A, py::object Bvalues_tuple,
+                  py::object Cvalues_tuple, ROI roi = ROI::All(),
+                  int nthreads = 0)
 {
     ImageBuf result;
     std::vector<float> Bvalues, Cvalues;
-    py_to_stdvector (Bvalues, Bvalues_tuple);
+    py_to_stdvector(Bvalues, Bvalues_tuple);
     if (roi.defined())
-        Bvalues.resize (roi.nchannels(), Bvalues.size() ? Bvalues.back() : 0.0f);
+        Bvalues.resize(roi.nchannels(), Bvalues.size() ? Bvalues.back() : 0.0f);
     else if (A.initialized())
-        Bvalues.resize (A.nchannels(), Bvalues.size() ? Bvalues.back() : 0.0f);
-    else return result;
-    ASSERT (Bvalues.size() > 0);
+        Bvalues.resize(A.nchannels(), Bvalues.size() ? Bvalues.back() : 0.0f);
+    else
+        return result;
+    py_to_stdvector(Cvalues, Cvalues_tuple);
+    if (roi.defined())
+        Cvalues.resize(roi.nchannels(), Cvalues.size() ? Cvalues.back() : 0.0f);
+    else if (A.initialized())
+        Cvalues.resize(A.nchannels(), Cvalues.size() ? Cvalues.back() : 0.0f);
+    else
+        return result;
+    ASSERT(Bvalues.size() > 0 && Cvalues.size() > 0);
     py::gil_scoped_release gil;
-    result = ImageBufAlgo::mad (A, Bvalues, C, roi, nthreads);
+    result = ImageBufAlgo::mad(A, Bvalues, Cvalues, roi, nthreads);
     return result;
 }
 
 ImageBuf
-IBA_mad_cii_ret (py::object Avalues_tuple,
-                 const ImageBuf &B, const ImageBuf &C,
-                 ROI roi=ROI::All(), int nthreads=0)
+IBA_mad_ici_ret(const ImageBuf& A, py::object Bvalues_tuple, const ImageBuf& C,
+                ROI roi = ROI::All(), int nthreads = 0)
 {
-    return IBA_mad_ici_ret (B, Avalues_tuple, C, roi, nthreads);
+    ImageBuf result;
+    std::vector<float> Bvalues, Cvalues;
+    py_to_stdvector(Bvalues, Bvalues_tuple);
+    if (roi.defined())
+        Bvalues.resize(roi.nchannels(), Bvalues.size() ? Bvalues.back() : 0.0f);
+    else if (A.initialized())
+        Bvalues.resize(A.nchannels(), Bvalues.size() ? Bvalues.back() : 0.0f);
+    else
+        return result;
+    ASSERT(Bvalues.size() > 0);
+    py::gil_scoped_release gil;
+    result = ImageBufAlgo::mad(A, Bvalues, C, roi, nthreads);
+    return result;
 }
 
 ImageBuf
-IBA_mad_images_ret (const ImageBuf &A, const ImageBuf &B,
-                    const ImageBuf &C, ROI roi=ROI::All(), int nthreads=0)
+IBA_mad_cii_ret(py::object Avalues_tuple, const ImageBuf& B, const ImageBuf& C,
+                ROI roi = ROI::All(), int nthreads = 0)
+{
+    return IBA_mad_ici_ret(B, Avalues_tuple, C, roi, nthreads);
+}
+
+ImageBuf
+IBA_mad_images_ret(const ImageBuf& A, const ImageBuf& B, const ImageBuf& C,
+                   ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::mad (A, B, C, roi, nthreads);
+    return ImageBufAlgo::mad(A, B, C, roi, nthreads);
 }
 
 
 
 bool
-IBA_invert (ImageBuf &dst, const ImageBuf &A,
-             ROI roi=ROI::All(), int nthreads=0)
+IBA_invert(ImageBuf& dst, const ImageBuf& A, ROI roi = ROI::All(),
+           int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::invert (dst, A, roi, nthreads);
+    return ImageBufAlgo::invert(dst, A, roi, nthreads);
 }
 
 
 ImageBuf
-IBA_invert_ret (const ImageBuf &A, ROI roi=ROI::All(), int nthreads=0)
+IBA_invert_ret(const ImageBuf& A, ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::invert (A, roi, nthreads);
+    return ImageBufAlgo::invert(A, roi, nthreads);
 }
 
 
 
 bool
-IBA_pow_color (ImageBuf &dst, const ImageBuf &A, py::object values_tuple,
-               ROI roi=ROI::All(), int nthreads=0)
+IBA_pow_color(ImageBuf& dst, const ImageBuf& A, py::object values_tuple,
+              ROI roi = ROI::All(), int nthreads = 0)
 {
     std::vector<float> values;
-    py_to_stdvector (values, values_tuple);
+    py_to_stdvector(values, values_tuple);
     if (roi.defined())
-        values.resize (roi.nchannels(), values.size() ? values.back() : 0.0f);
+        values.resize(roi.nchannels(), values.size() ? values.back() : 0.0f);
     else if (A.initialized())
-        values.resize (A.nchannels(), values.size() ? values.back() : 0.0f);
-    else return false;
-    ASSERT (values.size() > 0);
+        values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
+    else
+        return false;
+    ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
-    return ImageBufAlgo::pow (dst, A, values, roi, nthreads);
+    return ImageBufAlgo::pow(dst, A, values, roi, nthreads);
 }
 
 
 ImageBuf
-IBA_pow_color_ret (const ImageBuf &A, py::object values_tuple,
-                   ROI roi=ROI::All(), int nthreads=0)
+IBA_pow_color_ret(const ImageBuf& A, py::object values_tuple,
+                  ROI roi = ROI::All(), int nthreads = 0)
 {
     ImageBuf result;
     std::vector<float> values;
-    py_to_stdvector (values, values_tuple);
+    py_to_stdvector(values, values_tuple);
     if (roi.defined())
-        values.resize (roi.nchannels(), values.size() ? values.back() : 0.0f);
+        values.resize(roi.nchannels(), values.size() ? values.back() : 0.0f);
     else if (A.initialized())
-        values.resize (A.nchannels(), values.size() ? values.back() : 0.0f);
-    else return result;
-    ASSERT (values.size() > 0);
+        values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
+    else
+        return result;
+    ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
-    result = ImageBufAlgo::pow (A, values, roi, nthreads);
+    result = ImageBufAlgo::pow(A, values, roi, nthreads);
     return result;
 }
 
 
 
 bool
-IBA_clamp (ImageBuf &dst, const ImageBuf &src,
-           py::object min_, py::object max_,
-           bool clampalpha01 = false,
-           ROI roi = ROI::All(), int nthreads=0)
+IBA_clamp(ImageBuf& dst, const ImageBuf& src, py::object min_, py::object max_,
+          bool clampalpha01 = false, ROI roi = ROI::All(), int nthreads = 0)
 {
-    if (! src.initialized())
+    if (!src.initialized())
         return false;
     std::vector<float> min, max;
-    py_to_stdvector (min, min_);
-    py_to_stdvector (max, max_);
-    min.resize (src.nchannels(), -std::numeric_limits<float>::max());
-    max.resize (src.nchannels(), std::numeric_limits<float>::max());
+    py_to_stdvector(min, min_);
+    py_to_stdvector(max, max_);
+    min.resize(src.nchannels(), -std::numeric_limits<float>::max());
+    max.resize(src.nchannels(), std::numeric_limits<float>::max());
     py::gil_scoped_release gil;
-    return ImageBufAlgo::clamp (dst, src, min, max,
-                                clampalpha01, roi, nthreads);
+    return ImageBufAlgo::clamp(dst, src, min, max, clampalpha01, roi, nthreads);
 }
 
 ImageBuf
-IBA_clamp_ret (const ImageBuf &src, py::object min_, py::object max_,
-               bool clampalpha01 = false,
-               ROI roi = ROI::All(), int nthreads=0)
+IBA_clamp_ret(const ImageBuf& src, py::object min_, py::object max_,
+              bool clampalpha01 = false, ROI roi = ROI::All(), int nthreads = 0)
 {
     ImageBuf dst;
-    IBA_clamp (dst, src, min_, max_, clampalpha01, roi, nthreads);
+    IBA_clamp(dst, src, min_, max_, clampalpha01, roi, nthreads);
     return dst;
 }
 
 
 
 bool
-IBA_channel_sum_weight (ImageBuf &dst, const ImageBuf &src,
-                        py::object weight_tuple,
-                        ROI roi=ROI::All(), int nthreads=0)
+IBA_channel_sum_weight(ImageBuf& dst, const ImageBuf& src,
+                       py::object weight_tuple, ROI roi = ROI::All(),
+                       int nthreads = 0)
 {
     std::vector<float> weight;
-    py_to_stdvector (weight, weight_tuple);
-    if (! src.initialized()) {
-        dst.error ("Uninitialized source image for channel_sum");
+    py_to_stdvector(weight, weight_tuple);
+    if (!src.initialized()) {
+        dst.error("Uninitialized source image for channel_sum");
         return false;
     }
     if (weight.size() == 0)
-        weight.resize (src.nchannels(), 1.0f);  // no weights -> uniform
+        weight.resize(src.nchannels(), 1.0f);  // no weights -> uniform
     else
-        weight.resize (src.nchannels(), 0.0f);  // missing weights -> 0
+        weight.resize(src.nchannels(), 0.0f);  // missing weights -> 0
     py::gil_scoped_release gil;
-    return ImageBufAlgo::channel_sum (dst, src, &weight[0], roi, nthreads);
+    return ImageBufAlgo::channel_sum(dst, src, &weight[0], roi, nthreads);
 }
 
 bool
-IBA_channel_sum (ImageBuf &dst, const ImageBuf &src,
-                 ROI roi=ROI::All(), int nthreads=0)
+IBA_channel_sum(ImageBuf& dst, const ImageBuf& src, ROI roi = ROI::All(),
+                int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::channel_sum (dst, src, NULL, roi, nthreads);
+    return ImageBufAlgo::channel_sum(dst, src, NULL, roi, nthreads);
 }
 
 
 
 ImageBuf
-IBA_channel_sum_weight_ret (const ImageBuf &src, py::object weight_tuple,
-                            ROI roi=ROI::All(), int nthreads=0)
+IBA_channel_sum_weight_ret(const ImageBuf& src, py::object weight_tuple,
+                           ROI roi = ROI::All(), int nthreads = 0)
 {
     ImageBuf result;
     std::vector<float> weight;
-    py_to_stdvector (weight, weight_tuple);
-    if (! src.initialized()) {
-        result.error ("Uninitialized source image for channel_sum");
+    py_to_stdvector(weight, weight_tuple);
+    if (!src.initialized()) {
+        result.error("Uninitialized source image for channel_sum");
         return result;
     }
     if (weight.size() == 0)
-        weight.resize (src.nchannels(), 1.0f);  // no weights -> uniform
+        weight.resize(src.nchannels(), 1.0f);  // no weights -> uniform
     else
-        weight.resize (src.nchannels(), 0.0f);  // missing weights -> 0
+        weight.resize(src.nchannels(), 0.0f);  // missing weights -> 0
     py::gil_scoped_release gil;
-    result = ImageBufAlgo::channel_sum (src, weight, roi, nthreads);
+    result = ImageBufAlgo::channel_sum(src, weight, roi, nthreads);
     return result;
 }
 
 ImageBuf
-IBA_channel_sum_ret (const ImageBuf &src, ROI roi=ROI::All(), int nthreads=0)
+IBA_channel_sum_ret(const ImageBuf& src, ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::channel_sum (src, {}, roi, nthreads);
+    return ImageBufAlgo::channel_sum(src, {}, roi, nthreads);
 }
 
 
 
 bool
-IBA_color_map_values (ImageBuf &dst, const ImageBuf &src, int srcchannel,
-                      int nknots, int channels, py::object knots_tuple,
-                      ROI roi=ROI::All(), int nthreads=0)
+IBA_color_map_values(ImageBuf& dst, const ImageBuf& src, int srcchannel,
+                     int nknots, int channels, py::object knots_tuple,
+                     ROI roi = ROI::All(), int nthreads = 0)
 {
     std::vector<float> knots;
-    py_to_stdvector (knots, knots_tuple);
-    if (! src.initialized()) {
-        dst.error ("Uninitialized source image for color_map");
+    py_to_stdvector(knots, knots_tuple);
+    if (!src.initialized()) {
+        dst.error("Uninitialized source image for color_map");
         return false;
     }
-    if (! knots.size()) {
-        dst.error ("No knot values supplied");
+    if (!knots.size()) {
+        dst.error("No knot values supplied");
         return false;
     }
     py::gil_scoped_release gil;
-    return ImageBufAlgo::color_map (dst, src, srcchannel, nknots, channels,
-                                    knots, roi, nthreads);
+    return ImageBufAlgo::color_map(dst, src, srcchannel, nknots, channels,
+                                   knots, roi, nthreads);
 }
 
 
 bool
-IBA_color_map_name (ImageBuf &dst, const ImageBuf &src, int srcchannel,
-                    const std::string& mapname,
-                    ROI roi=ROI::All(), int nthreads=0)
+IBA_color_map_name(ImageBuf& dst, const ImageBuf& src, int srcchannel,
+                   const std::string& mapname, ROI roi = ROI::All(),
+                   int nthreads = 0)
 {
-    if (! src.initialized()) {
-        dst.error ("Uninitialized source image for color_map");
+    if (!src.initialized()) {
+        dst.error("Uninitialized source image for color_map");
         return false;
     }
     py::gil_scoped_release gil;
-    return ImageBufAlgo::color_map (dst, src, srcchannel, mapname,
-                                    roi, nthreads);
+    return ImageBufAlgo::color_map(dst, src, srcchannel, mapname, roi,
+                                   nthreads);
 }
 
 
 
 ImageBuf
-IBA_color_map_values_ret (const ImageBuf &src, int srcchannel,
-                          int nknots, int channels, py::object knots_tuple,
-                          ROI roi=ROI::All(), int nthreads=0)
+IBA_color_map_values_ret(const ImageBuf& src, int srcchannel, int nknots,
+                         int channels, py::object knots_tuple,
+                         ROI roi = ROI::All(), int nthreads = 0)
 {
     ImageBuf dst;
-    IBA_color_map_values (dst, src, srcchannel, nknots, channels, knots_tuple,
-                          roi, nthreads);
+    IBA_color_map_values(dst, src, srcchannel, nknots, channels, knots_tuple,
+                         roi, nthreads);
     return dst;
 }
 
 
 ImageBuf
-IBA_color_map_name_ret (const ImageBuf &src, int srcchannel,
-                        const std::string& mapname,
-                        ROI roi=ROI::All(), int nthreads=0)
+IBA_color_map_name_ret(const ImageBuf& src, int srcchannel,
+                       const std::string& mapname, ROI roi = ROI::All(),
+                       int nthreads = 0)
 {
     ImageBuf dst;
-    IBA_color_map_name (dst, src, srcchannel, mapname, roi, nthreads);
+    IBA_color_map_name(dst, src, srcchannel, mapname, roi, nthreads);
     return dst;
 }
 
 
 
-bool IBA_rangeexpand (ImageBuf &dst, const ImageBuf &src,
-                      bool useluma = false,
-                      ROI roi = ROI::All(), int nthreads=0)
+bool
+IBA_rangeexpand(ImageBuf& dst, const ImageBuf& src, bool useluma = false,
+                ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::rangeexpand (dst, src, useluma, roi, nthreads);
+    return ImageBufAlgo::rangeexpand(dst, src, useluma, roi, nthreads);
 }
 
 
-ImageBuf IBA_rangeexpand_ret (const ImageBuf &src,
-                              bool useluma = false,
-                              ROI roi = ROI::All(), int nthreads=0)
+ImageBuf
+IBA_rangeexpand_ret(const ImageBuf& src, bool useluma = false,
+                    ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::rangeexpand (src, useluma, roi, nthreads);
+    return ImageBufAlgo::rangeexpand(src, useluma, roi, nthreads);
 }
 
 
-bool IBA_rangecompress (ImageBuf &dst, const ImageBuf &src,
-                        bool useluma = false,
-                        ROI roi = ROI::All(), int nthreads=0)
+bool
+IBA_rangecompress(ImageBuf& dst, const ImageBuf& src, bool useluma = false,
+                  ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::rangecompress (dst, src, useluma, roi, nthreads);
-}
-
-
-
-ImageBuf IBA_rangecompress_ret (const ImageBuf &src,
-                                bool useluma = false,
-                                ROI roi = ROI::All(), int nthreads=0)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::rangecompress (src, useluma, roi, nthreads);
+    return ImageBufAlgo::rangecompress(dst, src, useluma, roi, nthreads);
 }
 
 
 
-bool IBA_premult (ImageBuf &dst, const ImageBuf &src,
-                  ROI roi = ROI::All(), int nthreads=0)
+ImageBuf
+IBA_rangecompress_ret(const ImageBuf& src, bool useluma = false,
+                      ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::premult (dst, src, roi, nthreads);
-}
-
-
-ImageBuf IBA_premult_ret (const ImageBuf &src,
-                          ROI roi = ROI::All(), int nthreads=0)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::premult (src, roi, nthreads);
-}
-
-
-bool IBA_unpremult (ImageBuf &dst, const ImageBuf &src,
-                    ROI roi = ROI::All(), int nthreads=0)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::unpremult (dst, src, roi, nthreads);
-}
-
-
-
-ImageBuf IBA_unpremult_ret (const ImageBuf &src,
-                            ROI roi = ROI::All(), int nthreads=0)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::unpremult (src, roi, nthreads);
+    return ImageBufAlgo::rangecompress(src, useluma, roi, nthreads);
 }
 
 
 
 bool
-IBA_contrast_remap (ImageBuf &dst, const ImageBuf &src,
-                    py::object black_, py::object white_,
-                    py::object min_, py::object max_,
-                    py::object scontrast_, py::object sthresh_,
-                    ROI roi = ROI::All(), int nthreads=0)
+IBA_premult(ImageBuf& dst, const ImageBuf& src, ROI roi = ROI::All(),
+            int nthreads = 0)
 {
-    if (! src.initialized())
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::premult(dst, src, roi, nthreads);
+}
+
+
+ImageBuf
+IBA_premult_ret(const ImageBuf& src, ROI roi = ROI::All(), int nthreads = 0)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::premult(src, roi, nthreads);
+}
+
+
+bool
+IBA_unpremult(ImageBuf& dst, const ImageBuf& src, ROI roi = ROI::All(),
+              int nthreads = 0)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::unpremult(dst, src, roi, nthreads);
+}
+
+
+
+ImageBuf
+IBA_unpremult_ret(const ImageBuf& src, ROI roi = ROI::All(), int nthreads = 0)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::unpremult(src, roi, nthreads);
+}
+
+
+
+bool
+IBA_contrast_remap(ImageBuf& dst, const ImageBuf& src, py::object black_,
+                   py::object white_, py::object min_, py::object max_,
+                   py::object scontrast_, py::object sthresh_,
+                   ROI roi = ROI::All(), int nthreads = 0)
+{
+    if (!src.initialized())
         return false;
     std::vector<float> black, white, sthresh, scontrast, min, max;
-    py_to_stdvector (black, black_);
-    py_to_stdvector (white, white_);
-    py_to_stdvector (min, min_);
-    py_to_stdvector (max, max_);
-    py_to_stdvector (sthresh, sthresh_);
-    py_to_stdvector (scontrast, scontrast_);
+    py_to_stdvector(black, black_);
+    py_to_stdvector(white, white_);
+    py_to_stdvector(min, min_);
+    py_to_stdvector(max, max_);
+    py_to_stdvector(sthresh, sthresh_);
+    py_to_stdvector(scontrast, scontrast_);
     // black.resize (src.nchannels(), black.size() ? black.back() : 0.0f);
     // white.resize (src.nchannels(), white.size() ? white.back() : 1.0f);
     // min.resize (src.nchannels(), min.size() ? min.back() : 0.0f);
@@ -1263,747 +1269,721 @@ IBA_contrast_remap (ImageBuf &dst, const ImageBuf &src,
     // sthresh.resize (src.nchannels(), sthresh.size() ? sthresh.back() : 0.5f);
     // scontrast.resize (src.nchannels(), scontrast.size() ? scontrast.back() : 1.0f);
     py::gil_scoped_release gil;
-    return ImageBufAlgo::contrast_remap (dst, src, black, white, min, max,
-                                         scontrast, sthresh, roi, nthreads);
+    return ImageBufAlgo::contrast_remap(dst, src, black, white, min, max,
+                                        scontrast, sthresh, roi, nthreads);
 }
 
 ImageBuf
-IBA_contrast_remap_ret (const ImageBuf &src,
-                        py::object black_, py::object white_,
-                        py::object min_, py::object max_,
-                        py::object scontrast_, py::object sthresh_,
-                        ROI roi = ROI::All(), int nthreads=0)
+IBA_contrast_remap_ret(const ImageBuf& src, py::object black_,
+                       py::object white_, py::object min_, py::object max_,
+                       py::object scontrast_, py::object sthresh_,
+                       ROI roi = ROI::All(), int nthreads = 0)
 {
     ImageBuf dst;
-    IBA_contrast_remap (dst, src, black_, white_, min_, max_,
-                        scontrast_, sthresh_, roi, nthreads);
+    IBA_contrast_remap(dst, src, black_, white_, min_, max_, scontrast_,
+                       sthresh_, roi, nthreads);
     return dst;
 }
 
 
 
 ImageBufAlgo::PixelStats
-IBA_computePixelStats_ret (const ImageBuf &src, ROI roi, int nthreads)
+IBA_computePixelStats_ret(const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::computePixelStats (src, roi, nthreads);
+    return ImageBufAlgo::computePixelStats(src, roi, nthreads);
 }
 
 // deprecated:
-bool IBA_computePixelStats (const ImageBuf &src,
-                            ImageBufAlgo::PixelStats &stats,
-                            ROI roi, int nthreads)
+bool
+IBA_computePixelStats(const ImageBuf& src, ImageBufAlgo::PixelStats& stats,
+                      ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::computePixelStats (stats, src, roi, nthreads);
+    return ImageBufAlgo::computePixelStats(stats, src, roi, nthreads);
 }
 
 
 
 ImageBufAlgo::CompareResults
-IBA_compare_ret (const ImageBuf &A, const ImageBuf &B,
-                 float failthresh, float warnthresh, ROI roi, int nthreads)
+IBA_compare_ret(const ImageBuf& A, const ImageBuf& B, float failthresh,
+                float warnthresh, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::compare (A, B, failthresh, warnthresh, roi, nthreads);
+    return ImageBufAlgo::compare(A, B, failthresh, warnthresh, roi, nthreads);
 }
 
 // deprecated:
-bool IBA_compare (const ImageBuf &A, const ImageBuf &B,
-                  float failthresh, float warnthresh,
-                  ImageBufAlgo::CompareResults &result,
-                  ROI roi, int nthreads)
+bool
+IBA_compare(const ImageBuf& A, const ImageBuf& B, float failthresh,
+            float warnthresh, ImageBufAlgo::CompareResults& result, ROI roi,
+            int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::compare (A, B, failthresh, warnthresh,
-                                  result, roi, nthreads);
-}
-
-
-
-bool IBA_compare_Yee (const ImageBuf &A, const ImageBuf &B,
-                      ImageBufAlgo::CompareResults &result,
-                      float luminance, float fov, ROI roi, int nthreads)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::compare_Yee (A, B, result, luminance, fov,
-                                      roi, nthreads);
-}
-
-
-
-std::string
-IBA_computePixelHashSHA1 (const ImageBuf &src, const std::string &extrainfo,
-                          ROI roi = ROI::All(),
-                          int blocksize = 0, int nthreads=0)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::computePixelHashSHA1 (src, extrainfo, roi,
-                                               blocksize, nthreads);
+    return ImageBufAlgo::compare(A, B, failthresh, warnthresh, result, roi,
+                                 nthreads);
 }
 
 
 
 bool
-IBA_warp (ImageBuf &dst, const ImageBuf &src, py::object values_M,
-          const std::string &filtername = "", float filterwidth = 0.0f,
-          bool recompute_roi = false,
-          const std::string &wrapname="default",
-          ROI roi=ROI::All(), int nthreads=0)
+IBA_compare_Yee(const ImageBuf& A, const ImageBuf& B,
+                ImageBufAlgo::CompareResults& result, float luminance,
+                float fov, ROI roi, int nthreads)
 {
-    ImageBuf::WrapMode wrap = ImageBuf::WrapMode_from_string (wrapname);
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::compare_Yee(A, B, result, luminance, fov, roi,
+                                     nthreads);
+}
+
+
+
+std::string
+IBA_computePixelHashSHA1(const ImageBuf& src, const std::string& extrainfo,
+                         ROI roi = ROI::All(), int blocksize = 0,
+                         int nthreads = 0)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::computePixelHashSHA1(src, extrainfo, roi, blocksize,
+                                              nthreads);
+}
+
+
+
+bool
+IBA_warp(ImageBuf& dst, const ImageBuf& src, py::object values_M,
+         const std::string& filtername = "", float filterwidth = 0.0f,
+         bool recompute_roi = false, const std::string& wrapname = "default",
+         ROI roi = ROI::All(), int nthreads = 0)
+{
+    ImageBuf::WrapMode wrap = ImageBuf::WrapMode_from_string(wrapname);
     std::vector<float> M;
-    py_to_stdvector (M, values_M);
+    py_to_stdvector(M, values_M);
     if (M.size() != 9)
         return false;
     py::gil_scoped_release gil;
-    return ImageBufAlgo::warp (dst, src, *(Imath::M33f *)&M[0],
-                               filtername, filterwidth, recompute_roi, wrap,
-                               roi, nthreads);
+    return ImageBufAlgo::warp(dst, src, *(Imath::M33f*)&M[0], filtername,
+                              filterwidth, recompute_roi, wrap, roi, nthreads);
 }
 
 
 ImageBuf
-IBA_warp_ret (const ImageBuf &src, py::object values_M,
-              const std::string &filtername = "", float filterwidth = 0.0f,
-              bool recompute_roi = false,
-              const std::string &wrapname="default",
-              ROI roi=ROI::All(), int nthreads=0)
+IBA_warp_ret(const ImageBuf& src, py::object values_M,
+             const std::string& filtername = "", float filterwidth = 0.0f,
+             bool recompute_roi          = false,
+             const std::string& wrapname = "default", ROI roi = ROI::All(),
+             int nthreads = 0)
 {
     ImageBuf dst;
-    IBA_warp (dst, src, values_M, filtername, filterwidth,
-              recompute_roi, wrapname, roi, nthreads);
+    IBA_warp(dst, src, values_M, filtername, filterwidth, recompute_roi,
+             wrapname, roi, nthreads);
     return dst;
 }
 
 
 
 bool
-IBA_rotate (ImageBuf &dst, const ImageBuf &src, float angle,
-            const std::string &filtername = "", float filterwidth = 0.0f,
-            bool recompute_roi = false,
-            ROI roi=ROI::All(), int nthreads=0)
+IBA_rotate(ImageBuf& dst, const ImageBuf& src, float angle,
+           const std::string& filtername = "", float filterwidth = 0.0f,
+           bool recompute_roi = false, ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::rotate (dst, src, angle, filtername, filterwidth,
-                                 recompute_roi, roi, nthreads);
+    return ImageBufAlgo::rotate(dst, src, angle, filtername, filterwidth,
+                                recompute_roi, roi, nthreads);
 }
 
 
 bool
-IBA_rotate2 (ImageBuf &dst, const ImageBuf &src, float angle,
-             float center_x, float center_y,
-             const std::string &filtername = "", float filterwidth = 0.0f,
-             bool recompute_roi = false,
-             ROI roi=ROI::All(), int nthreads=0)
+IBA_rotate2(ImageBuf& dst, const ImageBuf& src, float angle, float center_x,
+            float center_y, const std::string& filtername = "",
+            float filterwidth = 0.0f, bool recompute_roi = false,
+            ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::rotate (dst, src, angle, center_x, center_y,
-                                 filtername, filterwidth, recompute_roi,
-                                 roi, nthreads);
+    return ImageBufAlgo::rotate(dst, src, angle, center_x, center_y, filtername,
+                                filterwidth, recompute_roi, roi, nthreads);
 }
 
 
 
 ImageBuf
-IBA_rotate_ret (const ImageBuf &src, float angle,
-            const std::string &filtername = "", float filterwidth = 0.0f,
-            bool recompute_roi = false,
-            ROI roi=ROI::All(), int nthreads=0)
+IBA_rotate_ret(const ImageBuf& src, float angle,
+               const std::string& filtername = "", float filterwidth = 0.0f,
+               bool recompute_roi = false, ROI roi = ROI::All(),
+               int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::rotate (src, angle, filtername, filterwidth,
-                                 recompute_roi, roi, nthreads);
+    return ImageBufAlgo::rotate(src, angle, filtername, filterwidth,
+                                recompute_roi, roi, nthreads);
 }
 
 
 ImageBuf
-IBA_rotate2_ret (const ImageBuf &src, float angle,
-             float center_x, float center_y,
-             const std::string &filtername = "", float filterwidth = 0.0f,
-             bool recompute_roi = false,
-             ROI roi=ROI::All(), int nthreads=0)
+IBA_rotate2_ret(const ImageBuf& src, float angle, float center_x,
+                float center_y, const std::string& filtername = "",
+                float filterwidth = 0.0f, bool recompute_roi = false,
+                ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::rotate (src, angle, center_x, center_y,
-                                 filtername, filterwidth, recompute_roi,
-                                 roi, nthreads);
+    return ImageBufAlgo::rotate(src, angle, center_x, center_y, filtername,
+                                filterwidth, recompute_roi, roi, nthreads);
 }
 
 
 
 bool
-IBA_resize (ImageBuf &dst, const ImageBuf &src,
-            const std::string &filtername = "", float filterwidth = 0.0f,
-            ROI roi=ROI::All(), int nthreads=0)
+IBA_resize(ImageBuf& dst, const ImageBuf& src,
+           const std::string& filtername = "", float filterwidth = 0.0f,
+           ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::resize (dst, src, filtername, filterwidth,
-                                 roi, nthreads);
+    return ImageBufAlgo::resize(dst, src, filtername, filterwidth, roi,
+                                nthreads);
 }
 
 ImageBuf
-IBA_resize_ret (const ImageBuf &src,
-                const std::string &filtername = "", float filterwidth = 0.0f,
-                ROI roi=ROI::All(), int nthreads=0)
+IBA_resize_ret(const ImageBuf& src, const std::string& filtername = "",
+               float filterwidth = 0.0f, ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::resize (src, filtername, filterwidth, roi, nthreads);
+    return ImageBufAlgo::resize(src, filtername, filterwidth, roi, nthreads);
 }
 
 
 
 bool
-IBA_resample (ImageBuf &dst, const ImageBuf &src, bool interpolate,
-              ROI roi, int nthreads)
+IBA_resample(ImageBuf& dst, const ImageBuf& src, bool interpolate, ROI roi,
+             int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::resample (dst, src, interpolate, roi, nthreads);
+    return ImageBufAlgo::resample(dst, src, interpolate, roi, nthreads);
 }
 
 ImageBuf
-IBA_resample_ret (const ImageBuf &src, bool interpolate,
+IBA_resample_ret(const ImageBuf& src, bool interpolate, ROI roi, int nthreads)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::resample(src, interpolate, roi, nthreads);
+}
+
+
+
+bool
+IBA_fit(ImageBuf& dst, const ImageBuf& src, const std::string& filtername = "",
+        float filterwidth = 0.0f, bool exact = false, ROI roi = ROI::All(),
+        int nthreads = 0)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::fit(dst, src, filtername, filterwidth, exact, roi,
+                             nthreads);
+}
+
+ImageBuf
+IBA_fit_ret(const ImageBuf& src, const std::string& filtername = "",
+            float filterwidth = 0.0f, bool exact = false, ROI roi = ROI::All(),
+            int nthreads = 0)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::fit(src, filtername, filterwidth, exact, roi,
+                             nthreads);
+}
+
+
+
+bool
+IBA_make_kernel(ImageBuf& dst, const std::string& name, float width,
+                float height, float depth, bool normalize)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::make_kernel(dst, name, width, height, depth,
+                                     normalize);
+}
+
+ImageBuf
+IBA_make_kernel_ret(const std::string& name, float width, float height,
+                    float depth, bool normalize)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::make_kernel(name, width, height, depth, normalize);
+}
+
+
+
+bool
+IBA_convolve(ImageBuf& dst, const ImageBuf& src, const ImageBuf& kernel,
+             bool normalize, ROI roi, int nthreads)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::convolve(dst, src, kernel, normalize, roi, nthreads);
+}
+
+ImageBuf
+IBA_convolve_ret(const ImageBuf& src, const ImageBuf& kernel, bool normalize,
+                 ROI roi, int nthreads)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::convolve(src, kernel, normalize, roi, nthreads);
+}
+
+
+
+bool
+IBA_unsharp_mask(ImageBuf& dst, const ImageBuf& src, const std::string& kernel,
+                 float width, float contrast, float threshold, ROI roi,
+                 int nthreads)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::unsharp_mask(dst, src, kernel, width, contrast,
+                                      threshold, roi, nthreads);
+}
+
+ImageBuf
+IBA_unsharp_mask_ret(const ImageBuf& src, const std::string& kernel,
+                     float width, float contrast, float threshold, ROI roi,
+                     int nthreads)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::unsharp_mask(src, kernel, width, contrast, threshold,
+                                      roi, nthreads);
+}
+
+
+
+bool
+IBA_median_filter(ImageBuf& dst, const ImageBuf& src, int width, int height,
                   ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::resample (src, interpolate, roi, nthreads);
-}
-
-
-
-bool
-IBA_fit (ImageBuf &dst, const ImageBuf &src,
-         const std::string &filtername = "", float filterwidth = 0.0f,
-         bool exact=false, ROI roi=ROI::All(), int nthreads=0)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::fit (dst, src, filtername, filterwidth,
-                              exact, roi, nthreads);
+    return ImageBufAlgo::median_filter(dst, src, width, height, roi, nthreads);
 }
 
 ImageBuf
-IBA_fit_ret (const ImageBuf &src,
-             const std::string &filtername = "", float filterwidth = 0.0f,
-             bool exact=false, ROI roi=ROI::All(), int nthreads=0)
+IBA_median_filter_ret(const ImageBuf& src, int width, int height, ROI roi,
+                      int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::fit (src, filtername, filterwidth, exact, roi, nthreads);
+    return ImageBufAlgo::median_filter(src, width, height, roi, nthreads);
 }
 
 
 
 bool
-IBA_make_kernel (ImageBuf &dst, const std::string &name,
-                 float width, float height, float depth, bool normalize)
+IBA_dilate(ImageBuf& dst, const ImageBuf& src, int width, int height, ROI roi,
+           int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::make_kernel (dst, name, width, height, depth,
-                                      normalize);
+    return ImageBufAlgo::dilate(dst, src, width, height, roi, nthreads);
 }
 
 ImageBuf
-IBA_make_kernel_ret (const std::string &name,
-                     float width, float height, float depth, bool normalize)
+IBA_dilate_ret(const ImageBuf& src, int width, int height, ROI roi,
+               int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::make_kernel (name, width, height, depth, normalize);
+    return ImageBufAlgo::dilate(src, width, height, roi, nthreads);
 }
 
 
 
 bool
-IBA_convolve (ImageBuf &dst, const ImageBuf &src, const ImageBuf &kernel,
-              bool normalize, ROI roi, int nthreads)
+IBA_erode(ImageBuf& dst, const ImageBuf& src, int width, int height, ROI roi,
+          int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::convolve (dst, src, kernel, normalize, roi, nthreads);
+    return ImageBufAlgo::erode(dst, src, width, height, roi, nthreads);
 }
 
 ImageBuf
-IBA_convolve_ret (const ImageBuf &src, const ImageBuf &kernel,
-              bool normalize, ROI roi, int nthreads)
+IBA_erode_ret(const ImageBuf& src, int width, int height, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::convolve (src, kernel, normalize, roi, nthreads);
+    return ImageBufAlgo::erode(src, width, height, roi, nthreads);
 }
 
 
 
 bool
-IBA_unsharp_mask (ImageBuf &dst, const ImageBuf &src,
-                  const std::string &kernel, float width,
-                  float contrast, float threshold, ROI roi, int nthreads)
+IBA_laplacian(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::unsharp_mask (dst, src, kernel, width,
-                                       contrast, threshold, roi, nthreads);
+    return ImageBufAlgo::laplacian(dst, src, roi, nthreads);
 }
 
 ImageBuf
-IBA_unsharp_mask_ret (const ImageBuf &src,
-                  const std::string &kernel, float width,
-                  float contrast, float threshold, ROI roi, int nthreads)
+IBA_laplacian_ret(const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::unsharp_mask (src, kernel, width,
-                                       contrast, threshold, roi, nthreads);
+    return ImageBufAlgo::laplacian(src, roi, nthreads);
 }
 
 
 
 bool
-IBA_median_filter (ImageBuf &dst, const ImageBuf &src,
-                   int width, int height, ROI roi, int nthreads)
+IBA_fft(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::median_filter (dst, src, width, height, roi, nthreads);
+    return ImageBufAlgo::fft(dst, src, roi, nthreads);
 }
 
 ImageBuf
-IBA_median_filter_ret (const ImageBuf &src,
-                   int width, int height, ROI roi, int nthreads)
+IBA_fft_ret(const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::median_filter (src, width, height, roi, nthreads);
+    return ImageBufAlgo::fft(src, roi, nthreads);
 }
 
 
 
 bool
-IBA_dilate (ImageBuf &dst, const ImageBuf &src,
-            int width, int height, ROI roi, int nthreads)
+IBA_ifft(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::dilate (dst, src, width, height, roi, nthreads);
+    return ImageBufAlgo::ifft(dst, src, roi, nthreads);
 }
 
 ImageBuf
-IBA_dilate_ret (const ImageBuf &src,
-                int width, int height, ROI roi, int nthreads)
+IBA_ifft_ret(const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::dilate (src, width, height, roi, nthreads);
+    return ImageBufAlgo::ifft(src, roi, nthreads);
 }
 
 
 
 bool
-IBA_erode (ImageBuf &dst, const ImageBuf &src,
-           int width, int height, ROI roi, int nthreads)
+IBA_polar_to_complex(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::erode (dst, src, width, height, roi, nthreads);
+    return ImageBufAlgo::polar_to_complex(dst, src, roi, nthreads);
 }
 
 ImageBuf
-IBA_erode_ret (const ImageBuf &src,
-               int width, int height, ROI roi, int nthreads)
+IBA_polar_to_complex_ret(const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::erode (src, width, height, roi, nthreads);
+    return ImageBufAlgo::polar_to_complex(src, roi, nthreads);
 }
 
 
 
 bool
-IBA_laplacian (ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
+IBA_complex_to_polar(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::laplacian (dst, src, roi, nthreads);
+    return ImageBufAlgo::complex_to_polar(dst, src, roi, nthreads);
 }
 
 ImageBuf
-IBA_laplacian_ret (const ImageBuf &src, ROI roi, int nthreads)
+IBA_complex_to_polar_ret(const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::laplacian (src, roi, nthreads);
+    return ImageBufAlgo::complex_to_polar(src, roi, nthreads);
 }
 
 
 
 bool
-IBA_fft (ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
+IBA_fillholes_pushpull(ImageBuf& dst, const ImageBuf& src, ROI roi,
+                       int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::fft (dst, src, roi, nthreads);
+    return ImageBufAlgo::fillholes_pushpull(dst, src, roi, nthreads);
 }
 
 ImageBuf
-IBA_fft_ret (const ImageBuf &src, ROI roi, int nthreads)
+IBA_fillholes_pushpull_ret(const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::fft (src, roi, nthreads);
+    return ImageBufAlgo::fillholes_pushpull(src, roi, nthreads);
 }
 
 
 
 bool
-IBA_ifft (ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
+IBA_over(ImageBuf& dst, const ImageBuf& A, const ImageBuf& B,
+         ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::ifft (dst, src, roi, nthreads);
+    return ImageBufAlgo::over(dst, A, B, roi, nthreads);
 }
 
 ImageBuf
-IBA_ifft_ret (const ImageBuf &src, ROI roi, int nthreads)
+IBA_over_ret(const ImageBuf& A, const ImageBuf& B, ROI roi = ROI::All(),
+             int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::ifft (src, roi, nthreads);
+    return ImageBufAlgo::over(A, B, roi, nthreads);
 }
 
 
 
 bool
-IBA_polar_to_complex (ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
+IBA_zover(ImageBuf& dst, const ImageBuf& A, const ImageBuf& B,
+          bool z_zeroisinf = false, ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::polar_to_complex (dst, src, roi, nthreads);
+    return ImageBufAlgo::zover(dst, A, B, z_zeroisinf, roi, nthreads);
 }
 
 ImageBuf
-IBA_polar_to_complex_ret (const ImageBuf &src, ROI roi, int nthreads)
+IBA_zover_ret(const ImageBuf& A, const ImageBuf& B, bool z_zeroisinf = false,
+              ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::polar_to_complex (src, roi, nthreads);
+    return ImageBufAlgo::zover(A, B, z_zeroisinf, roi, nthreads);
 }
 
 
 
 bool
-IBA_complex_to_polar (ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
+IBA_colorconvert(ImageBuf& dst, const ImageBuf& src, const std::string& from,
+                 const std::string& to, bool unpremult = true,
+                 ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::complex_to_polar (dst, src, roi, nthreads);
-}
-
-ImageBuf
-IBA_complex_to_polar_ret (const ImageBuf &src, ROI roi, int nthreads)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::complex_to_polar (src, roi, nthreads);
-}
-
-
-
-bool
-IBA_fillholes_pushpull (ImageBuf &dst, const ImageBuf &src, ROI roi, int nthreads)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::fillholes_pushpull (dst, src, roi, nthreads);
-}
-
-ImageBuf
-IBA_fillholes_pushpull_ret (const ImageBuf &src, ROI roi, int nthreads)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::fillholes_pushpull (src, roi, nthreads);
-}
-
-
-
-bool
-IBA_over (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
-           ROI roi = ROI::All(), int nthreads = 0)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::over (dst, A, B, roi, nthreads);
-}
-
-ImageBuf
-IBA_over_ret (const ImageBuf &A, const ImageBuf &B,
-           ROI roi = ROI::All(), int nthreads = 0)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::over (A, B, roi, nthreads);
-}
-
-
-
-bool
-IBA_zover (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
-           bool z_zeroisinf = false,
-           ROI roi = ROI::All(), int nthreads = 0)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::zover (dst, A, B, z_zeroisinf, roi, nthreads);
-}
-
-ImageBuf
-IBA_zover_ret (const ImageBuf &A, const ImageBuf &B,
-           bool z_zeroisinf = false,
-           ROI roi = ROI::All(), int nthreads = 0)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::zover (A, B, z_zeroisinf, roi, nthreads);
-}
-
-
-
-bool
-IBA_colorconvert (ImageBuf &dst, const ImageBuf &src,
-                  const std::string &from, const std::string &to,
-                  bool unpremult = true,
-                  ROI roi = ROI::All(), int nthreads = 0)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::colorconvert (dst, src, from, to, unpremult,
-                                       "", "", nullptr, roi, nthreads);
+    return ImageBufAlgo::colorconvert(dst, src, from, to, unpremult, "", "",
+                                      nullptr, roi, nthreads);
 }
 
 
 bool
-IBA_colorconvert_colorconfig (ImageBuf &dst, const ImageBuf &src,
-                  const std::string &from, const std::string &to,
-                  bool unpremult = true,
-                  const std::string &context_key="",
-                  const std::string &context_value="",
-                  const std::string &colorconfig="",
-                  ROI roi = ROI::All(), int nthreads = 0)
+IBA_colorconvert_colorconfig(ImageBuf& dst, const ImageBuf& src,
+                             const std::string& from, const std::string& to,
+                             bool unpremult                   = true,
+                             const std::string& context_key   = "",
+                             const std::string& context_value = "",
+                             const std::string& colorconfig   = "",
+                             ROI roi = ROI::All(), int nthreads = 0)
 {
-    ColorConfig config (colorconfig);
+    ColorConfig config(colorconfig);
     py::gil_scoped_release gil;
-    return ImageBufAlgo::colorconvert (dst, src, from, to, unpremult,
-                                       context_key, context_value,
-                                       &config, roi, nthreads);
+    return ImageBufAlgo::colorconvert(dst, src, from, to, unpremult,
+                                      context_key, context_value, &config, roi,
+                                      nthreads);
 }
 
 
 
 ImageBuf
-IBA_colorconvert_ret (const ImageBuf &src,
-                      const std::string &from, const std::string &to,
-                      bool unpremult = true,
+IBA_colorconvert_ret(const ImageBuf& src, const std::string& from,
+                     const std::string& to, bool unpremult = true,
+                     ROI roi = ROI::All(), int nthreads = 0)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::colorconvert(src, from, to, unpremult, "", "", nullptr,
+                                      roi, nthreads);
+}
+
+
+ImageBuf
+IBA_colorconvert_colorconfig_ret(const ImageBuf& src, const std::string& from,
+                                 const std::string& to, bool unpremult = true,
+                                 const std::string& context_key   = "",
+                                 const std::string& context_value = "",
+                                 const std::string& colorconfig   = "",
+                                 ROI roi = ROI::All(), int nthreads = 0)
+{
+    ColorConfig config(colorconfig);
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::colorconvert(src, from, to, unpremult, context_key,
+                                      context_value, &config, roi, nthreads);
+}
+
+
+
+bool
+IBA_ociolook(ImageBuf& dst, const ImageBuf& src, const std::string& looks,
+             const std::string& from, const std::string& to, bool inverse,
+             bool unpremult, const std::string& context_key,
+             const std::string& context_value, ROI roi = ROI::All(),
+             int nthreads = 0)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::ociolook(dst, src, looks, from, to, inverse, unpremult,
+                                  context_key, context_value, NULL, roi,
+                                  nthreads);
+}
+
+
+bool
+IBA_ociolook_colorconfig(ImageBuf& dst, const ImageBuf& src,
+                         const std::string& looks, const std::string& from,
+                         const std::string& to, bool inverse, bool unpremult,
+                         const std::string& context_key,
+                         const std::string& context_value,
+                         const std::string& colorconfig = "",
+                         ROI roi = ROI::All(), int nthreads = 0)
+{
+    ColorConfig config(colorconfig);
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::ociolook(dst, src, looks, from, to, inverse, unpremult,
+                                  context_key, context_value, &config, roi,
+                                  nthreads);
+}
+
+
+
+ImageBuf
+IBA_ociolook_ret(const ImageBuf& src, const std::string& looks,
+                 const std::string& from, const std::string& to, bool inverse,
+                 bool unpremult, const std::string& context_key,
+                 const std::string& context_value, ROI roi = ROI::All(),
+                 int nthreads = 0)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::ociolook(src, looks, from, to, inverse, unpremult,
+                                  context_key, context_value, NULL, roi,
+                                  nthreads);
+}
+
+
+ImageBuf
+IBA_ociolook_colorconfig_ret(const ImageBuf& src, const std::string& looks,
+                             const std::string& from, const std::string& to,
+                             bool inverse, bool unpremult,
+                             const std::string& context_key,
+                             const std::string& context_value,
+                             const std::string& colorconfig = "",
+                             ROI roi = ROI::All(), int nthreads = 0)
+{
+    ColorConfig config(colorconfig);
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::ociolook(src, looks, from, to, inverse, unpremult,
+                                  context_key, context_value, &config, roi,
+                                  nthreads);
+}
+
+
+
+bool
+IBA_ociodisplay(ImageBuf& dst, const ImageBuf& src, const std::string& display,
+                const std::string& view, const std::string& from,
+                const std::string& looks, bool unpremult,
+                const std::string& context_key,
+                const std::string& context_value, ROI roi = ROI::All(),
+                int nthreads = 0)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::ociodisplay(dst, src, display, view, from, looks,
+                                     unpremult, context_key, context_value,
+                                     NULL, roi, nthreads);
+}
+
+
+bool
+IBA_ociodisplay_colorconfig(ImageBuf& dst, const ImageBuf& src,
+                            const std::string& display, const std::string& view,
+                            const std::string& from, const std::string& looks,
+                            bool unpremult, const std::string& context_key,
+                            const std::string& context_value,
+                            const std::string& colorconfig = "",
+                            ROI roi = ROI::All(), int nthreads = 0)
+{
+    ColorConfig config(colorconfig);
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::ociodisplay(dst, src, display, view, from, looks,
+                                     unpremult, context_key, context_value,
+                                     &config, roi, nthreads);
+}
+
+
+
+ImageBuf
+IBA_ociodisplay_ret(const ImageBuf& src, const std::string& display,
+                    const std::string& view, const std::string& from,
+                    const std::string& looks, bool unpremult,
+                    const std::string& context_key,
+                    const std::string& context_value, ROI roi = ROI::All(),
+                    int nthreads = 0)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::ociodisplay(src, display, view, from, looks, unpremult,
+                                     context_key, context_value, NULL, roi,
+                                     nthreads);
+}
+
+
+ImageBuf
+IBA_ociodisplay_colorconfig_ret(
+    const ImageBuf& src, const std::string& display, const std::string& view,
+    const std::string& from, const std::string& looks, bool unpremult,
+    const std::string& context_key, const std::string& context_value,
+    const std::string& colorconfig = "", ROI roi = ROI::All(), int nthreads = 0)
+{
+    ColorConfig config(colorconfig);
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::ociodisplay(src, display, view, from, looks, unpremult,
+                                     context_key, context_value, &config, roi,
+                                     nthreads);
+}
+
+
+
+bool
+IBA_ociofiletransform(ImageBuf& dst, const ImageBuf& src,
+                      const std::string& name, bool inverse, bool unpremult,
                       ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::colorconvert (src, from, to, unpremult,
-                                       "", "", nullptr, roi, nthreads);
+    return ImageBufAlgo::ociofiletransform(dst, src, name, inverse, unpremult,
+                                           NULL, roi, nthreads);
 }
 
 
-ImageBuf
-IBA_colorconvert_colorconfig_ret (const ImageBuf &src,
-                                  const std::string &from, const std::string &to,
-                                  bool unpremult = true,
-                                  const std::string &context_key="",
-                                  const std::string &context_value="",
-                                  const std::string &colorconfig="",
+bool
+IBA_ociofiletransform_colorconfig(ImageBuf& dst, const ImageBuf& src,
+                                  const std::string& name, bool inverse,
+                                  bool unpremult,
+                                  const std::string& colorconfig = "",
                                   ROI roi = ROI::All(), int nthreads = 0)
 {
-    ColorConfig config (colorconfig);
+    ColorConfig config(colorconfig);
     py::gil_scoped_release gil;
-    return ImageBufAlgo::colorconvert (src, from, to, unpremult,
-                                       context_key, context_value,
-                                       &config, roi, nthreads);
-}
-
-
-
-bool
-IBA_ociolook (ImageBuf &dst, const ImageBuf &src, const std::string &looks,
-              const std::string &from, const std::string &to,
-              bool inverse, bool unpremult,
-              const std::string &context_key, const std::string &context_value,
-              ROI roi = ROI::All(), int nthreads = 0)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::ociolook (dst, src, looks, from, to,
-                                   inverse, unpremult,
-                                   context_key, context_value, NULL,
-                                   roi, nthreads);
-}
-
-
-bool
-IBA_ociolook_colorconfig (ImageBuf &dst, const ImageBuf &src, const std::string &looks,
-              const std::string &from, const std::string &to,
-              bool inverse, bool unpremult,
-              const std::string &context_key, const std::string &context_value,
-              const std::string &colorconfig="",
-              ROI roi = ROI::All(), int nthreads = 0)
-{
-    ColorConfig config (colorconfig);
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::ociolook (dst, src, looks, from, to,
-                                   inverse, unpremult,
-                                   context_key, context_value,
-                                   &config, roi, nthreads);
+    return ImageBufAlgo::ociofiletransform(dst, src, name, inverse, unpremult,
+                                           &config, roi, nthreads);
 }
 
 
 
 ImageBuf
-IBA_ociolook_ret (const ImageBuf &src, const std::string &looks,
-              const std::string &from, const std::string &to,
-              bool inverse, bool unpremult,
-              const std::string &context_key, const std::string &context_value,
-              ROI roi = ROI::All(), int nthreads = 0)
+IBA_ociofiletransform_ret(const ImageBuf& src, const std::string& name,
+                          bool inverse, bool unpremult, ROI roi = ROI::All(),
+                          int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::ociolook (src, looks, from, to,
-                                   inverse, unpremult,
-                                   context_key, context_value, NULL,
-                                   roi, nthreads);
+    return ImageBufAlgo::ociofiletransform(src, name, inverse, unpremult, NULL,
+                                           roi, nthreads);
 }
 
 
 ImageBuf
-IBA_ociolook_colorconfig_ret (const ImageBuf &src, const std::string &looks,
-              const std::string &from, const std::string &to,
-              bool inverse, bool unpremult,
-              const std::string &context_key, const std::string &context_value,
-              const std::string &colorconfig="",
-              ROI roi = ROI::All(), int nthreads = 0)
+IBA_ociofiletransform_colorconfig_ret(const ImageBuf& src,
+                                      const std::string& name, bool inverse,
+                                      bool unpremult,
+                                      const std::string& colorconfig = "",
+                                      ROI roi = ROI::All(), int nthreads = 0)
 {
-    ColorConfig config (colorconfig);
+    ColorConfig config(colorconfig);
     py::gil_scoped_release gil;
-    return ImageBufAlgo::ociolook (src, looks, from, to,
-                                   inverse, unpremult,
-                                   context_key, context_value,
-                                   &config, roi, nthreads);
-}
-
-
-
-bool
-IBA_ociodisplay (ImageBuf &dst, const ImageBuf &src,
-                 const std::string &display, const std::string &view,
-                 const std::string &from, const std::string &looks,
-                 bool unpremult,
-                 const std::string &context_key, const std::string &context_value,
-                 ROI roi = ROI::All(), int nthreads = 0)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::ociodisplay (dst, src, display, view,
-                                      from, looks, unpremult,
-                                      context_key, context_value, NULL,
-                                      roi, nthreads);
-}
-
-
-bool
-IBA_ociodisplay_colorconfig (ImageBuf &dst, const ImageBuf &src,
-                 const std::string &display, const std::string &view,
-                 const std::string &from, const std::string &looks,
-                 bool unpremult,
-                 const std::string &context_key, const std::string &context_value,
-                 const std::string &colorconfig = "",
-                 ROI roi = ROI::All(), int nthreads = 0)
-{
-    ColorConfig config (colorconfig);
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::ociodisplay (dst, src, display, view, from, looks,
-                                      unpremult, context_key, context_value,
-                                      &config, roi, nthreads);
-}
-
-
-
-ImageBuf
-IBA_ociodisplay_ret (const ImageBuf &src,
-                 const std::string &display, const std::string &view,
-                 const std::string &from, const std::string &looks,
-                 bool unpremult,
-                 const std::string &context_key, const std::string &context_value,
-                 ROI roi = ROI::All(), int nthreads = 0)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::ociodisplay (src, display, view,
-                                      from, looks, unpremult,
-                                      context_key, context_value, NULL,
-                                      roi, nthreads);
-}
-
-
-ImageBuf
-IBA_ociodisplay_colorconfig_ret (const ImageBuf &src,
-                 const std::string &display, const std::string &view,
-                 const std::string &from, const std::string &looks,
-                 bool unpremult,
-                 const std::string &context_key, const std::string &context_value,
-                 const std::string &colorconfig = "",
-                 ROI roi = ROI::All(), int nthreads = 0)
-{
-    ColorConfig config (colorconfig);
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::ociodisplay (src, display, view, from, looks,
-                                      unpremult, context_key, context_value,
-                                      &config, roi, nthreads);
-}
-
-
-
-bool
-IBA_ociofiletransform (ImageBuf &dst, const ImageBuf &src,
-                       const std::string &name,
-                       bool inverse, bool unpremult,
-                       ROI roi = ROI::All(), int nthreads = 0)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::ociofiletransform (dst, src, name,
-                                            inverse, unpremult, NULL,
-                                            roi, nthreads);
-}
-
-
-bool
-IBA_ociofiletransform_colorconfig (ImageBuf &dst, const ImageBuf &src,
-                                   const std::string &name,
-                                   bool inverse, bool unpremult,
-                                   const std::string &colorconfig="",
-                                   ROI roi = ROI::All(), int nthreads = 0)
-{
-    ColorConfig config (colorconfig);
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::ociofiletransform (dst, src, name,
-                                            inverse, unpremult, &config,
-                                            roi, nthreads);
-}
-
-
-
-ImageBuf
-IBA_ociofiletransform_ret (const ImageBuf &src,
-                       const std::string &name,
-                       bool inverse, bool unpremult,
-                       ROI roi = ROI::All(), int nthreads = 0)
-{
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::ociofiletransform (src, name,
-                                            inverse, unpremult, NULL,
-                                            roi, nthreads);
-}
-
-
-ImageBuf
-IBA_ociofiletransform_colorconfig_ret (const ImageBuf &src,
-                                   const std::string &name,
-                                   bool inverse, bool unpremult,
-                                   const std::string &colorconfig="",
-                                   ROI roi = ROI::All(), int nthreads = 0)
-{
-    ColorConfig config (colorconfig);
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::ociofiletransform (src, name,
-                                            inverse, unpremult, &config,
-                                            roi, nthreads);
+    return ImageBufAlgo::ociofiletransform(src, name, inverse, unpremult,
+                                           &config, roi, nthreads);
 }
 
 
 
 py::object
-IBA_isConstantColor (const ImageBuf &src, float threshold,
-                     ROI roi = ROI::All(), int nthreads = 0)
+IBA_isConstantColor(const ImageBuf& src, float threshold, ROI roi = ROI::All(),
+                    int nthreads = 0)
 {
-    std::vector<float> constcolor (src.nchannels());
+    std::vector<float> constcolor(src.nchannels());
     bool r;
     {
         py::gil_scoped_release gil;
-        r = ImageBufAlgo::isConstantColor (src, threshold, constcolor,
-                                           roi, nthreads);
+        r = ImageBufAlgo::isConstantColor(src, threshold, constcolor, roi,
+                                          nthreads);
     }
     if (r) {
-        return C_to_tuple (&constcolor[0], (int)constcolor.size());
+        return C_to_tuple(&constcolor[0], (int)constcolor.size());
     } else {
         return py::none();
     }
@@ -2011,26 +1991,28 @@ IBA_isConstantColor (const ImageBuf &src, float threshold,
 
 
 
-bool IBA_isConstantChannel (const ImageBuf &src, int channel, float val,
-                            float threshold, ROI roi, int nthreads)
+bool
+IBA_isConstantChannel(const ImageBuf& src, int channel, float val,
+                      float threshold, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::isConstantChannel (src, channel, val, threshold,
-                                            roi, nthreads);
+    return ImageBufAlgo::isConstantChannel(src, channel, val, threshold, roi,
+                                           nthreads);
 }
 
 
 
-bool IBA_isMonochrome (const ImageBuf &src, float threshold,
-                       ROI roi, int nthreads)
+bool
+IBA_isMonochrome(const ImageBuf& src, float threshold, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::isMonochrome (src, threshold, roi, nthreads);
+    return ImageBufAlgo::isMonochrome(src, threshold, roi, nthreads);
 }
 
 
 
-ROI IBA_nonzero_region(const ImageBuf &src, ROI roi, int nthreads)
+ROI
+IBA_nonzero_region(const ImageBuf& src, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
     return ImageBufAlgo::nonzero_region(src, roi, nthreads);
@@ -2039,78 +2021,79 @@ ROI IBA_nonzero_region(const ImageBuf &src, ROI roi, int nthreads)
 
 
 bool
-IBA_fixNonFinite (ImageBuf &dst, const ImageBuf &src,
-                  ImageBufAlgo::NonFiniteFixMode mode=ImageBufAlgo::NONFINITE_BOX3,
-                  ROI roi = ROI::All(), int nthreads = 0)
+IBA_fixNonFinite(ImageBuf& dst, const ImageBuf& src,
+                 ImageBufAlgo::NonFiniteFixMode mode
+                 = ImageBufAlgo::NONFINITE_BOX3,
+                 ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::fixNonFinite (dst, src, mode, NULL, roi, nthreads);
+    return ImageBufAlgo::fixNonFinite(dst, src, mode, NULL, roi, nthreads);
 }
 
 ImageBuf
-IBA_fixNonFinite_ret (const ImageBuf &src,
-                  ImageBufAlgo::NonFiniteFixMode mode=ImageBufAlgo::NONFINITE_BOX3,
-                  ROI roi = ROI::All(), int nthreads = 0)
+IBA_fixNonFinite_ret(const ImageBuf& src,
+                     ImageBufAlgo::NonFiniteFixMode mode
+                     = ImageBufAlgo::NONFINITE_BOX3,
+                     ROI roi = ROI::All(), int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::fixNonFinite (src, mode, NULL, roi, nthreads);
+    return ImageBufAlgo::fixNonFinite(src, mode, NULL, roi, nthreads);
 }
 
 
 
 bool
-IBA_render_point (ImageBuf &dst, int x, int y, py::object color_)
-{
-    std::vector<float> color;
-    py_to_stdvector (color, color_);
-    color.resize (dst.nchannels(), 1.0f);
-    py::gil_scoped_release gil;
-    return ImageBufAlgo::render_point (dst, x, y, color);
-}
-
-
-bool
-IBA_render_line (ImageBuf &dst, int x1, int y1, int x2, int y2,
-                 py::object color_, bool skip_first_point=false)
+IBA_render_point(ImageBuf& dst, int x, int y, py::object color_)
 {
     std::vector<float> color;
-    py_to_stdvector (color, color_);
-    color.resize (dst.nchannels(), 1.0f);
+    py_to_stdvector(color, color_);
+    color.resize(dst.nchannels(), 1.0f);
     py::gil_scoped_release gil;
-    return ImageBufAlgo::render_line (dst, x1, y1, x2, y2,
-                                      color, skip_first_point);
+    return ImageBufAlgo::render_point(dst, x, y, color);
 }
 
 
 bool
-IBA_render_box (ImageBuf &dst, int x1, int y1, int x2, int y2,
-                 py::object color_, bool fill=false)
+IBA_render_line(ImageBuf& dst, int x1, int y1, int x2, int y2,
+                py::object color_, bool skip_first_point = false)
 {
     std::vector<float> color;
-    py_to_stdvector (color, color_);
-    color.resize (dst.nchannels(), 1.0f);
+    py_to_stdvector(color, color_);
+    color.resize(dst.nchannels(), 1.0f);
     py::gil_scoped_release gil;
-    return ImageBufAlgo::render_box (dst, x1, y1, x2, y2, color, fill);
+    return ImageBufAlgo::render_line(dst, x1, y1, x2, y2, color,
+                                     skip_first_point);
 }
 
 
 bool
-IBA_render_text (ImageBuf &dst, int x, int y,
-                 const std::string &text,
-                 int fontsize=16, const std::string &fontname="",
-                 py::object textcolor_=py::none(),
-                 const std::string ax = "left",
-                 const std::string ay = "baseline",
-                 int shadow = 0, ROI roi = ROI::All(), int nthreads = 0)
+IBA_render_box(ImageBuf& dst, int x1, int y1, int x2, int y2, py::object color_,
+               bool fill = false)
+{
+    std::vector<float> color;
+    py_to_stdvector(color, color_);
+    color.resize(dst.nchannels(), 1.0f);
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::render_box(dst, x1, y1, x2, y2, color, fill);
+}
+
+
+bool
+IBA_render_text(ImageBuf& dst, int x, int y, const std::string& text,
+                int fontsize = 16, const std::string& fontname = "",
+                py::object textcolor_ = py::none(),
+                const std::string ax  = "left",
+                const std::string ay = "baseline", int shadow = 0,
+                ROI roi = ROI::All(), int nthreads = 0)
 {
     std::vector<float> textcolor;
-    py_to_stdvector (textcolor, textcolor_);
-    textcolor.resize (dst.nchannels(), 1.0f);
+    py_to_stdvector(textcolor, textcolor_);
+    textcolor.resize(dst.nchannels(), 1.0f);
     py::gil_scoped_release gil;
     using ImageBufAlgo::TextAlignX;
     using ImageBufAlgo::TextAlignY;
-    TextAlignX alignx (TextAlignX::Left);
-    TextAlignY aligny (TextAlignY::Baseline);
+    TextAlignX alignx(TextAlignX::Left);
+    TextAlignY aligny(TextAlignY::Baseline);
     if (Strutil::iequals(ax, "right") || Strutil::iequals(ax, "r"))
         alignx = TextAlignX::Right;
     if (Strutil::iequals(ax, "center") || Strutil::iequals(ax, "c"))
@@ -2121,31 +2104,31 @@ IBA_render_text (ImageBuf &dst, int x, int y,
         aligny = TextAlignY::Bottom;
     if (Strutil::iequals(ay, "center") || Strutil::iequals(ay, "c"))
         aligny = TextAlignY::Center;
-    return ImageBufAlgo::render_text (dst, x, y, text, fontsize, fontname,
-                                      textcolor, alignx, aligny, shadow,
-                                      roi, nthreads);
+    return ImageBufAlgo::render_text(dst, x, y, text, fontsize, fontname,
+                                     textcolor, alignx, aligny, shadow, roi,
+                                     nthreads);
 }
 
 
 ROI
-IBA_text_size (const std::string &text,
-               int fontsize=16, const std::string &fontname="")
+IBA_text_size(const std::string& text, int fontsize = 16,
+              const std::string& fontname = "")
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::text_size (text, fontsize, fontname);
+    return ImageBufAlgo::text_size(text, fontsize, fontname);
 }
 
 
 
 py::object
-IBA_histogram (const ImageBuf &src, int channel=0, int bins=256,
-               float min=0.0f, float max=1.0f, bool ignore_empty=false,
-               ROI roi={}, int nthreads=0)
+IBA_histogram(const ImageBuf& src, int channel = 0, int bins = 256,
+              float min = 0.0f, float max = 1.0f, bool ignore_empty = false,
+              ROI roi = {}, int nthreads = 0)
 {
     py::gil_scoped_release gil;
-    auto hist = ImageBufAlgo::histogram (src, channel, bins, min, max,
-                                         ignore_empty, roi, nthreads);
-    std::vector<int> h (bins);
+    auto hist = ImageBufAlgo::histogram(src, channel, bins, min, max,
+                                        ignore_empty, roi, nthreads);
+    std::vector<int> h(bins);
     for (int i = 0; i < bins; ++i)
         h[i] = int(hist[i]);
     return C_to_tuple<int>(h);
@@ -2154,69 +2137,63 @@ IBA_histogram (const ImageBuf &src, int channel=0, int bins=256,
 
 
 bool
-IBA_capture_image (ImageBuf &dst, int cameranum,
-                   TypeDesc::BASETYPE convert = TypeDesc::UNKNOWN)
+IBA_capture_image(ImageBuf& dst, int cameranum,
+                  TypeDesc::BASETYPE convert = TypeDesc::UNKNOWN)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::capture_image (dst, cameranum, convert);
+    return ImageBufAlgo::capture_image(dst, cameranum, convert);
 }
 
 ImageBuf
-IBA_capture_image_ret (int cameranum,
-                       TypeDesc::BASETYPE convert = TypeDesc::UNKNOWN)
+IBA_capture_image_ret(int cameranum,
+                      TypeDesc::BASETYPE convert = TypeDesc::UNKNOWN)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::capture_image (cameranum, convert);
+    return ImageBufAlgo::capture_image(cameranum, convert);
 }
 
 
 
 bool
-IBA_make_texture_ib (ImageBufAlgo::MakeTextureMode mode,
-                     const ImageBuf &buf,
-                     const std::string &outputfilename,
-                     const ImageSpec &config)
+IBA_make_texture_ib(ImageBufAlgo::MakeTextureMode mode, const ImageBuf& buf,
+                    const std::string& outputfilename, const ImageSpec& config)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::make_texture (mode, buf, outputfilename, config);
+    return ImageBufAlgo::make_texture(mode, buf, outputfilename, config);
 }
 
 
 bool
-IBA_make_texture_filename (ImageBufAlgo::MakeTextureMode mode,
-                           const std::string &filename,
-                           const std::string &outputfilename,
-                           const ImageSpec &config)
+IBA_make_texture_filename(ImageBufAlgo::MakeTextureMode mode,
+                          const std::string& filename,
+                          const std::string& outputfilename,
+                          const ImageSpec& config)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::make_texture (mode, filename, outputfilename,
-                                       config);
+    return ImageBufAlgo::make_texture(mode, filename, outputfilename, config);
 }
 
 
 
-
-
-void declare_imagebufalgo (py::module &m)
+void
+declare_imagebufalgo(py::module& m)
 {
     using namespace pybind11::literals;
     using py::arg;
 
     py::enum_<ImageBufAlgo::NonFiniteFixMode>(m, "NonFiniteFixMode")
-        .value("NONFINITE_NONE",  ImageBufAlgo::NONFINITE_NONE)
+        .value("NONFINITE_NONE", ImageBufAlgo::NONFINITE_NONE)
         .value("NONFINITE_BLACK", ImageBufAlgo::NONFINITE_BLACK)
-        .value("NONFINITE_BOX3",  ImageBufAlgo::NONFINITE_BOX3)
-        .export_values()
-    ;
+        .value("NONFINITE_BOX3", ImageBufAlgo::NONFINITE_BOX3)
+        .export_values();
 
     py::enum_<ImageBufAlgo::MakeTextureMode>(m, "MakeTextureMode")
         .value("MakeTxTexture", ImageBufAlgo::MakeTxTexture)
-        .value("MakeTxShadow",  ImageBufAlgo::MakeTxShadow)
+        .value("MakeTxShadow", ImageBufAlgo::MakeTxShadow)
         .value("MakeTxEnvLatl", ImageBufAlgo::MakeTxEnvLatl)
         .value("MakeTxEnvLatlFromLightProbe",
-                                ImageBufAlgo::MakeTxEnvLatlFromLightProbe)
-        .export_values()
-    ;
+               ImageBufAlgo::MakeTxEnvLatlFromLightProbe)
+        .export_values();
 
     py::class_<ImageBufAlgo::PixelStats>(m, "PixelStats")
         .def(py::init<>())
@@ -2228,8 +2205,7 @@ void declare_imagebufalgo (py::module &m)
         .def_readonly("infcount", &ImageBufAlgo::PixelStats::infcount)
         .def_readonly("finitecount", &ImageBufAlgo::PixelStats::finitecount)
         .def_readonly("sum", &ImageBufAlgo::PixelStats::sum)
-        .def_readonly("sum2", &ImageBufAlgo::PixelStats::sum2)
-    ;
+        .def_readonly("sum2", &ImageBufAlgo::PixelStats::sum2);
 
     py::class_<ImageBufAlgo::CompareResults>(m, "CompareResults")
         .def(py::init<>())
@@ -2243,579 +2219,550 @@ void declare_imagebufalgo (py::module &m)
         .def_readonly("maxc", &ImageBufAlgo::CompareResults::maxc)
         .def_readonly("nwarn", &ImageBufAlgo::CompareResults::nwarn)
         .def_readonly("nfail", &ImageBufAlgo::CompareResults::nfail)
-        .def_readonly("error", &ImageBufAlgo::CompareResults::error)
-    ;
+        .def_readonly("error", &ImageBufAlgo::CompareResults::error);
 
     // Use a boost::python::scope to put this all inside "ImageBufAlgo"
     py::class_<IBA_dummy>(m, "ImageBufAlgo")
-        .def_static("zero", &IBA_zero,
-            "dst"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("zero", &IBA_zero_ret,
-            "roi"_a, "nthreads"_a=0)
+        .def_static("zero", &IBA_zero, "dst"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("zero", &IBA_zero_ret, "roi"_a, "nthreads"_a = 0)
 
-        .def_static("fill", &IBA_fill,
-            "dst"_a, "values"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("fill", &IBA_fill2,
-            "dst"_a, "top"_a, "bottom"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("fill", &IBA_fill4,
-            "dst"_a, "topleft"_a, "topright"_a, "bottomleft"_a,
-            "bottomright"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("fill", &IBA_fill_ret,
-            "values"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("fill", &IBA_fill2_ret,
-            "top"_a, "bottom"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("fill", &IBA_fill4_ret,
-            "topleft"_a, "topright"_a, "bottomleft"_a,
-            "bottomright"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("fill", &IBA_fill, "dst"_a, "values"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("fill", &IBA_fill2, "dst"_a, "top"_a, "bottom"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("fill", &IBA_fill4, "dst"_a, "topleft"_a, "topright"_a,
+                    "bottomleft"_a, "bottomright"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("fill", &IBA_fill_ret, "values"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("fill", &IBA_fill2_ret, "top"_a, "bottom"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("fill", &IBA_fill4_ret, "topleft"_a, "topright"_a,
+                    "bottomleft"_a, "bottomright"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("checker", &IBA_checker,
-            "dst"_a, "width"_a, "height"_a, "depth"_a, "color1"_a, "color2"_a,
-            "xoffset"_a=0, "yoffset"_a=0, "zoffset"_a=0,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("checker", &IBA_checker_ret,
-            "width"_a, "height"_a, "depth"_a, "color1"_a, "color2"_a,
-            "xoffset"_a=0, "yoffset"_a=0, "zoffset"_a=0,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("checker", &IBA_checker, "dst"_a, "width"_a, "height"_a,
+                    "depth"_a, "color1"_a, "color2"_a, "xoffset"_a = 0,
+                    "yoffset"_a = 0, "zoffset"_a = 0, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("checker", &IBA_checker_ret, "width"_a, "height"_a,
+                    "depth"_a, "color1"_a, "color2"_a, "xoffset"_a = 0,
+                    "yoffset"_a = 0, "zoffset"_a = 0, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("noise", &IBA_noise,
-            "dst"_a, "type"_a="gaussian", "A"_a=0.0f, "B"_a=0.1f,
-            "mono"_a=false, "seed"_a=0, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("noise", &IBA_noise_ret,
-            "type"_a="gaussian", "A"_a=0.0f, "B"_a=0.1f,
-            "mono"_a=false, "seed"_a=0, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("noise", &IBA_noise, "dst"_a, "type"_a = "gaussian",
+                    "A"_a = 0.0f, "B"_a = 0.1f, "mono"_a = false, "seed"_a = 0,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("noise", &IBA_noise_ret, "type"_a = "gaussian",
+                    "A"_a = 0.0f, "B"_a = 0.1f, "mono"_a = false, "seed"_a = 0,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("channels", &IBA_channels,
-            "dst"_a, "src"_a, "channelorder"_a,
-            "newchannelnames"_a=py::tuple(),
-            "shuffle_channel_names"_a=false, "nthreads"_a=0)
-        .def_static("channels", &IBA_channels_ret,
-            "src"_a, "channelorder"_a, "newchannelnames"_a=py::tuple(),
-            "shuffle_channel_names"_a=false, "nthreads"_a=0)
+        .def_static("channels", &IBA_channels, "dst"_a, "src"_a,
+                    "channelorder"_a, "newchannelnames"_a = py::tuple(),
+                    "shuffle_channel_names"_a = false, "nthreads"_a = 0)
+        .def_static("channels", &IBA_channels_ret, "src"_a, "channelorder"_a,
+                    "newchannelnames"_a       = py::tuple(),
+                    "shuffle_channel_names"_a = false, "nthreads"_a = 0)
 
-        .def_static("channel_append", IBA_channel_append,
-            "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("channel_append", IBA_channel_append_ret,
-            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("channel_append", IBA_channel_append, "dst"_a, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("channel_append", IBA_channel_append_ret, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("deepen", IBA_deepen,
-            "dst"_a, "src"_a, "zvalue"_a=1.0f,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("deepen", IBA_deepen_ret,
-            "src"_a, "zvalue"_a=1.0f, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("deepen", IBA_deepen, "dst"_a, "src"_a, "zvalue"_a = 1.0f,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("deepen", IBA_deepen_ret, "src"_a, "zvalue"_a = 1.0f,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("flatten", IBA_flatten,
-            "dst"_a, "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("flatten", IBA_flatten_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("flatten", IBA_flatten, "dst"_a, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("flatten", IBA_flatten_ret, "src"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("deep_merge", IBA_deep_merge,
-            "dst"_a, "A"_a, "B"_a, "occlusion_cull"_a=true,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("deep_merge", IBA_deep_merge_ret,
-            "A"_a, "B"_a, "occlusion_cull"_a=true,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("deep_merge", IBA_deep_merge, "dst"_a, "A"_a, "B"_a,
+                    "occlusion_cull"_a = true, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("deep_merge", IBA_deep_merge_ret, "A"_a, "B"_a,
+                    "occlusion_cull"_a = true, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("deep_holdout", IBA_deep_holdout,
-            "dst"_a, "src"_a, "holdout"_a,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("deep_holdout", IBA_deep_holdout_ret,
-            "src"_a, "holdout"_a,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("deep_holdout", IBA_deep_holdout, "dst"_a, "src"_a,
+                    "holdout"_a, "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("deep_holdout", IBA_deep_holdout_ret, "src"_a, "holdout"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("copy", IBA_copy,
-            "dst"_a, "src"_a, "convert"_a=TypeUnknown,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("copy", IBA_copy_ret,
-            "src"_a, "convert"_a=TypeUnknown,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("copy", IBA_copy, "dst"_a, "src"_a,
+                    "convert"_a = TypeUnknown, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("copy", IBA_copy_ret, "src"_a, "convert"_a = TypeUnknown,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("crop", IBA_crop,
-            "dst"_a, "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("crop", IBA_crop_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("crop", IBA_crop, "dst"_a, "src"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("crop", IBA_crop_ret, "src"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("cut", IBA_cut,
-            "dst"_a, "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("cut", IBA_cut_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("cut", IBA_cut, "dst"_a, "src"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("cut", IBA_cut_ret, "src"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("paste", IBA_paste,
-            "dst"_a, "xbegin"_a, "ybegin"_a, "zbegin"_a, "chbegin"_a, "src"_a,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("paste", IBA_paste, "dst"_a, "xbegin"_a, "ybegin"_a,
+                    "zbegin"_a, "chbegin"_a, "src"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("rotate90", IBA_rotate90,
-            "dst"_a, "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("rotate90", IBA_rotate90_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("rotate90", IBA_rotate90, "dst"_a, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("rotate90", IBA_rotate90_ret, "src"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("rotate180", IBA_rotate180,
-            "dst"_a, "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("rotate180", IBA_rotate180_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("rotate180", IBA_rotate180, "dst"_a, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("rotate180", IBA_rotate180_ret, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("rotate270", IBA_rotate270,
-            "dst"_a, "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("rotate270", IBA_rotate270_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("rotate270", IBA_rotate270, "dst"_a, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("rotate270", IBA_rotate270_ret, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("flip", IBA_flip,
-            "dst"_a, "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("flip", IBA_flip_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("flip", IBA_flip, "dst"_a, "src"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("flip", IBA_flip_ret, "src"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("flop", IBA_flop,
-            "dst"_a, "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("flop", IBA_flop_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("flop", IBA_flop, "dst"_a, "src"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("flop", IBA_flop_ret, "src"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("reorient", IBA_reorient,
-            "dst"_a, "src"_a, "nthreads"_a=0)
-        .def_static("reorient", IBA_reorient_ret,
-            "src"_a, "nthreads"_a=0)
+        .def_static("reorient", IBA_reorient, "dst"_a, "src"_a,
+                    "nthreads"_a = 0)
+        .def_static("reorient", IBA_reorient_ret, "src"_a, "nthreads"_a = 0)
 
-        .def_static("transpose", IBA_transpose,
-            "dst"_a, "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("transpose", IBA_transpose_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("transpose", IBA_transpose, "dst"_a, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("transpose", IBA_transpose_ret, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("circular_shift", &IBA_circular_shift,
-            "dst"_a, "src"_a, "xshift"_a, "yshift"_a, "zshift"_a=0,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("circular_shift", &IBA_circular_shift_ret,
-            "src"_a, "xshift"_a, "yshift"_a, "zshift"_a=0,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("circular_shift", &IBA_circular_shift, "dst"_a, "src"_a,
+                    "xshift"_a, "yshift"_a, "zshift"_a = 0,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("circular_shift", &IBA_circular_shift_ret, "src"_a,
+                    "xshift"_a, "yshift"_a, "zshift"_a = 0,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("add", &IBA_add_images,
-            "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("add", IBA_add_color,
-            "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("add", &IBA_add_images_ret,
-            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("add", IBA_add_color_ret,
-            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("add", &IBA_add_images, "dst"_a, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("add", IBA_add_color, "dst"_a, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("add", &IBA_add_images_ret, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("add", IBA_add_color_ret, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("sub", &IBA_sub_images,
-            "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("sub", IBA_sub_color,
-            "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("sub", &IBA_sub_images_ret,
-            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("sub", IBA_sub_color_ret,
-            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("sub", &IBA_sub_images, "dst"_a, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("sub", IBA_sub_color, "dst"_a, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("sub", &IBA_sub_images_ret, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("sub", IBA_sub_color_ret, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("absdiff", &IBA_absdiff_images,
-            "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("absdiff", IBA_absdiff_color,
-            "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("absdiff", &IBA_absdiff_images_ret,
-            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("absdiff", IBA_absdiff_color_ref,
-            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("absdiff", &IBA_absdiff_images, "dst"_a, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("absdiff", IBA_absdiff_color, "dst"_a, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("absdiff", &IBA_absdiff_images_ret, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("absdiff", IBA_absdiff_color_ref, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("abs", &IBA_abs,
-            "dst"_a, "A"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("abs", &IBA_abs_ret,
-            "A"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("abs", &IBA_abs, "dst"_a, "A"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("abs", &IBA_abs_ret, "A"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("mul", &IBA_mul_images,
-            "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("mul", &IBA_mul_color,
-            "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("mul", &IBA_mul_images_ret,
-            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("mul", &IBA_mul_color_ret,
-            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("mul", &IBA_mul_images, "dst"_a, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("mul", &IBA_mul_color, "dst"_a, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("mul", &IBA_mul_images_ret, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("mul", &IBA_mul_color_ret, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("div", &IBA_div_images,
-            "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("div", &IBA_div_color,
-            "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("div", &IBA_div_images_ret,
-            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("div", &IBA_div_color_ret,
-            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("div", &IBA_div_images, "dst"_a, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("div", &IBA_div_color, "dst"_a, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("div", &IBA_div_images_ret, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("div", &IBA_div_color_ret, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("mad", &IBA_mad_images,
-            "dst"_a, "A"_a, "B"_a, "C"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("mad", &IBA_mad_ici,
-            "dst"_a, "A"_a, "B"_a, "C"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("mad", &IBA_mad_cii,
-            "dst"_a, "A"_a, "B"_a, "C"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("mad", &IBA_mad_color,
-            "dst"_a, "A"_a, "B"_a, "C"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("mad", &IBA_mad_images_ret,
-            "A"_a, "B"_a, "C"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("mad", &IBA_mad_ici_ret,
-            "A"_a, "B"_a, "C"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("mad", &IBA_mad_cii_ret,
-            "A"_a, "B"_a, "C"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("mad", &IBA_mad_color_ret,
-            "A"_a, "B"_a, "C"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("mad", &IBA_mad_images, "dst"_a, "A"_a, "B"_a, "C"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("mad", &IBA_mad_ici, "dst"_a, "A"_a, "B"_a, "C"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("mad", &IBA_mad_cii, "dst"_a, "A"_a, "B"_a, "C"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("mad", &IBA_mad_color, "dst"_a, "A"_a, "B"_a, "C"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("mad", &IBA_mad_images_ret, "A"_a, "B"_a, "C"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("mad", &IBA_mad_ici_ret, "A"_a, "B"_a, "C"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("mad", &IBA_mad_cii_ret, "A"_a, "B"_a, "C"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("mad", &IBA_mad_color_ret, "A"_a, "B"_a, "C"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("invert", &IBA_invert,
-            "dst"_a, "A"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("invert", &IBA_invert_ret,
-            "A"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("invert", &IBA_invert, "dst"_a, "A"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("invert", &IBA_invert_ret, "A"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("pow", &IBA_pow_color,
-            "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("pow", &IBA_pow_color_ret,
-            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("pow", &IBA_pow_color, "dst"_a, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("pow", &IBA_pow_color_ret, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("channel_sum", &IBA_channel_sum,
-            "dst"_a, "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("channel_sum", &IBA_channel_sum_weight,
-            "dst"_a, "src"_a, "weight"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("channel_sum", &IBA_channel_sum_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("channel_sum", &IBA_channel_sum_weight_ret,
-            "src"_a, "weight"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("channel_sum", &IBA_channel_sum, "dst"_a, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("channel_sum", &IBA_channel_sum_weight, "dst"_a, "src"_a,
+                    "weight"_a, "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("channel_sum", &IBA_channel_sum_ret, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("channel_sum", &IBA_channel_sum_weight_ret, "src"_a,
+                    "weight"_a, "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("color_map", &IBA_color_map_name,
-            "dst"_a, "src"_a, "srcchannel"_a, "mapname"_a,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("color_map", &IBA_color_map_values,
-            "dst"_a, "src"_a, "srcchannel"_a,
-            "nknots"_a, "channels"_a, "knots"_a,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("color_map", &IBA_color_map_name_ret,
-            "src"_a, "srcchannel"_a, "mapname"_a,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("color_map", &IBA_color_map_values_ret,
-            "src"_a, "srcchannel"_a,
-            "nknots"_a, "channels"_a, "knots"_a,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("color_map", &IBA_color_map_name, "dst"_a, "src"_a,
+                    "srcchannel"_a, "mapname"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("color_map", &IBA_color_map_values, "dst"_a, "src"_a,
+                    "srcchannel"_a, "nknots"_a, "channels"_a, "knots"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("color_map", &IBA_color_map_name_ret, "src"_a,
+                    "srcchannel"_a, "mapname"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("color_map", &IBA_color_map_values_ret, "src"_a,
+                    "srcchannel"_a, "nknots"_a, "channels"_a, "knots"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("rangecompress", &IBA_rangecompress,
-            "dst"_a, "src"_a, "useluma"_a=false,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("rangecompress", &IBA_rangecompress_ret,
-            "src"_a, "useluma"_a=false,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("rangecompress", &IBA_rangecompress, "dst"_a, "src"_a,
+                    "useluma"_a = false, "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("rangecompress", &IBA_rangecompress_ret, "src"_a,
+                    "useluma"_a = false, "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("rangeexpand", &IBA_rangeexpand,
-            "dst"_a, "src"_a, "useluma"_a=false,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("rangeexpand", &IBA_rangeexpand_ret,
-            "src"_a, "useluma"_a=false,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("rangeexpand", &IBA_rangeexpand, "dst"_a, "src"_a,
+                    "useluma"_a = false, "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("rangeexpand", &IBA_rangeexpand_ret, "src"_a,
+                    "useluma"_a = false, "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("premult", &IBA_premult,
-            "dst"_a, "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("premult", &IBA_premult_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("premult", &IBA_premult, "dst"_a, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("premult", &IBA_premult_ret, "src"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("unpremult", &IBA_unpremult,
-            "dst"_a, "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("unpremult", &IBA_unpremult_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("unpremult", &IBA_unpremult, "dst"_a, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("unpremult", &IBA_unpremult_ret, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("clamp", &IBA_clamp,
-            "dst"_a, "src"_a, "min"_a, "max"_a,
-            "clampalpha01"_a=false,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("clamp", &IBA_clamp_ret,
-            "src"_a, "min"_a, "max"_a,
-            "clampalpha01"_a=false,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("clamp", &IBA_clamp, "dst"_a, "src"_a, "min"_a, "max"_a,
+                    "clampalpha01"_a = false, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("clamp", &IBA_clamp_ret, "src"_a, "min"_a, "max"_a,
+                    "clampalpha01"_a = false, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("contrast_remap", &IBA_contrast_remap,
-            "dst"_a, "src"_a, "black"_a=0.0f, "white"_a=1.0f,
-            "min"_a=0.0f, "max"_a=1.0f,
-            "scontrast"_a=1.0f, "sthresh"_a=0.5f,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("contrast_remap", &IBA_contrast_remap_ret,
-            "src"_a, "black"_a=0.0f, "white"_a=1.0f,
-            "min"_a=0.0f, "max"_a=1.0f,
-            "scontrast"_a=1.0f, "sthresh"_a=0.5f,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("contrast_remap", &IBA_contrast_remap, "dst"_a, "src"_a,
+                    "black"_a = 0.0f, "white"_a = 1.0f, "min"_a = 0.0f,
+                    "max"_a = 1.0f, "scontrast"_a = 1.0f, "sthresh"_a = 0.5f,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("contrast_remap", &IBA_contrast_remap_ret, "src"_a,
+                    "black"_a = 0.0f, "white"_a = 1.0f, "min"_a = 0.0f,
+                    "max"_a = 1.0f, "scontrast"_a = 1.0f, "sthresh"_a = 0.5f,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("colorconvert", &IBA_colorconvert,
-            "dst"_a, "src"_a, "from"_a, "to"_a, "unpremult"_a=true,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("colorconvert", &IBA_colorconvert_colorconfig,
-            "dst"_a, "src"_a, "from"_a, "to"_a, "unpremult"_a=true,
-            "context_key"_a="", "context_value"_a="", "colorconfig"_a="",
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("colorconvert", &IBA_colorconvert_ret,
-            "src"_a, "from"_a, "to"_a, "unpremult"_a=true,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("colorconvert", &IBA_colorconvert_colorconfig_ret,
-            "src"_a, "from"_a, "to"_a, "unpremult"_a=true,
-            "context_key"_a="", "context_value"_a="", "colorconfig"_a="",
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("colorconvert", &IBA_colorconvert, "dst"_a, "src"_a,
+                    "from"_a, "to"_a, "unpremult"_a = true,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("colorconvert", &IBA_colorconvert_colorconfig, "dst"_a,
+                    "src"_a, "from"_a, "to"_a, "unpremult"_a = true,
+                    "context_key"_a = "", "context_value"_a = "",
+                    "colorconfig"_a = "", "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("colorconvert", &IBA_colorconvert_ret, "src"_a, "from"_a,
+                    "to"_a, "unpremult"_a = true, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("colorconvert", &IBA_colorconvert_colorconfig_ret, "src"_a,
+                    "from"_a, "to"_a, "unpremult"_a = true,
+                    "context_key"_a = "", "context_value"_a = "",
+                    "colorconfig"_a = "", "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("ociolook", &IBA_ociolook,
-            "dst"_a, "src"_a, "looks"_a, "from"_a, "to"_a,
-            "unpremult"_a=true, "invert"_a=false,
-            "context_key"_a="", "context_value"_a="",
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("ociolook", &IBA_ociolook_colorconfig,
-            "dst"_a, "src"_a, "looks"_a, "from"_a, "to"_a,
-            "unpremult"_a=true, "invert"_a=false,
-            "context_key"_a="", "context_value"_a="", "colorconfig"_a="",
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("ociolook", &IBA_ociolook_ret,
-            "src"_a, "looks"_a, "from"_a, "to"_a,
-            "unpremult"_a=true, "invert"_a=false,
-            "context_key"_a="", "context_value"_a="",
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("ociolook", &IBA_ociolook_colorconfig_ret,
-            "src"_a, "looks"_a, "from"_a, "to"_a,
-            "unpremult"_a=true, "invert"_a=false,
-            "context_key"_a="", "context_value"_a="", "colorconfig"_a="",
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("ociolook", &IBA_ociolook, "dst"_a, "src"_a, "looks"_a,
+                    "from"_a, "to"_a, "unpremult"_a = true, "invert"_a = false,
+                    "context_key"_a = "", "context_value"_a = "",
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("ociolook", &IBA_ociolook_colorconfig, "dst"_a, "src"_a,
+                    "looks"_a, "from"_a, "to"_a, "unpremult"_a = true,
+                    "invert"_a = false, "context_key"_a = "",
+                    "context_value"_a = "", "colorconfig"_a = "",
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("ociolook", &IBA_ociolook_ret, "src"_a, "looks"_a, "from"_a,
+                    "to"_a, "unpremult"_a = true, "invert"_a = false,
+                    "context_key"_a = "", "context_value"_a = "",
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("ociolook", &IBA_ociolook_colorconfig_ret, "src"_a,
+                    "looks"_a, "from"_a, "to"_a, "unpremult"_a = true,
+                    "invert"_a = false, "context_key"_a = "",
+                    "context_value"_a = "", "colorconfig"_a = "",
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("ociodisplay", &IBA_ociodisplay,
-            "dst"_a, "src"_a, "display"_a, "view"_a,
-            "from"_a="", "looks"_a="", "unpremult"_a=true,
-            "context_key"_a="", "context_value"_a="",
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("ociodisplay", &IBA_ociodisplay_colorconfig,
-            "dst"_a, "src"_a, "display"_a, "view"_a,
-            "from"_a="", "looks"_a="", "unpremult"_a=true,
-            "context_key"_a="", "context_value"_a="", "colorconfig"_a="",
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("ociodisplay", &IBA_ociodisplay_ret,
-            "src"_a, "display"_a, "view"_a,
-            "from"_a="", "looks"_a="", "unpremult"_a=true,
-            "context_key"_a="", "context_value"_a="",
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("ociodisplay", &IBA_ociodisplay_colorconfig_ret,
-            "src"_a, "display"_a, "view"_a,
-            "from"_a="", "looks"_a="", "unpremult"_a=true,
-            "context_key"_a="", "context_value"_a="", "colorconfig"_a="",
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("ociodisplay", &IBA_ociodisplay, "dst"_a, "src"_a,
+                    "display"_a, "view"_a, "from"_a = "", "looks"_a = "",
+                    "unpremult"_a = true, "context_key"_a = "",
+                    "context_value"_a = "", "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("ociodisplay", &IBA_ociodisplay_colorconfig, "dst"_a,
+                    "src"_a, "display"_a, "view"_a, "from"_a = "",
+                    "looks"_a = "", "unpremult"_a = true, "context_key"_a = "",
+                    "context_value"_a = "", "colorconfig"_a = "",
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("ociodisplay", &IBA_ociodisplay_ret, "src"_a, "display"_a,
+                    "view"_a, "from"_a = "", "looks"_a = "",
+                    "unpremult"_a = true, "context_key"_a = "",
+                    "context_value"_a = "", "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("ociodisplay", &IBA_ociodisplay_colorconfig_ret, "src"_a,
+                    "display"_a, "view"_a, "from"_a = "", "looks"_a = "",
+                    "unpremult"_a = true, "context_key"_a = "",
+                    "context_value"_a = "", "colorconfig"_a = "",
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("ociofiletransform", &IBA_ociofiletransform,
-            "dst"_a, "src"_a, "name"_a, "unpremult"_a=true, "invert"_a=false,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("ociofiletransform", &IBA_ociofiletransform, "dst"_a,
+                    "src"_a, "name"_a, "unpremult"_a = true, "invert"_a = false,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
         .def_static("ociofiletransform", &IBA_ociofiletransform_colorconfig,
-            "dst"_a, "src"_a, "name"_a,
-            "unpremult"_a=true, "invert"_a=false, "colorconfig"_a="",
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("ociofiletransform", &IBA_ociofiletransform_ret,
-            "src"_a, "name"_a, "unpremult"_a=true, "invert"_a=false,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+                    "dst"_a, "src"_a, "name"_a, "unpremult"_a = true,
+                    "invert"_a = false, "colorconfig"_a = "",
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("ociofiletransform", &IBA_ociofiletransform_ret, "src"_a,
+                    "name"_a, "unpremult"_a = true, "invert"_a = false,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
         .def_static("ociofiletransform", &IBA_ociofiletransform_colorconfig_ret,
-            "src"_a, "name"_a,
-            "unpremult"_a=true, "invert"_a=false, "colorconfig"_a="",
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+                    "src"_a, "name"_a, "unpremult"_a = true, "invert"_a = false,
+                    "colorconfig"_a = "", "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("computePixelStats", &IBA_computePixelStats,
-            "src"_a, "stats"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("computePixelStats", &IBA_computePixelStats_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("computePixelStats", &IBA_computePixelStats, "src"_a,
+                    "stats"_a, "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("computePixelStats", &IBA_computePixelStats_ret, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("compare", &IBA_compare,
-            "A"_a, "B"_a, "failthresh"_a, "warnthresh"_a,
-            "result"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("compare", &IBA_compare_ret,
-            "A"_a, "B"_a, "failthresh"_a, "warnthresh"_a,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("compare", &IBA_compare, "A"_a, "B"_a, "failthresh"_a,
+                    "warnthresh"_a, "result"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("compare", &IBA_compare_ret, "A"_a, "B"_a, "failthresh"_a,
+                    "warnthresh"_a, "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("compare_Yee", &IBA_compare_Yee,
-            "A"_a, "B"_a, "result"_a,
-            "luminance"_a=100, "fov"_a=45,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("compare_Yee", &IBA_compare_Yee, "A"_a, "B"_a, "result"_a,
+                    "luminance"_a = 100, "fov"_a = 45, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("isConstantColor", &IBA_isConstantColor,
-             "src"_a, "threshold"_a=0.0f, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("isConstantColor", &IBA_isConstantColor, "src"_a,
+                    "threshold"_a = 0.0f, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("isConstantChannel", &IBA_isConstantChannel,
-            "src"_a, "channel"_a, "val"_a, "threshold"_a=0.0f,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("isConstantChannel", &IBA_isConstantChannel, "src"_a,
+                    "channel"_a, "val"_a, "threshold"_a = 0.0f,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("isMonochrome", &IBA_isMonochrome,
-             "src"_a, "threshold"_a=0.0f, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("isMonochrome", &IBA_isMonochrome, "src"_a,
+                    "threshold"_a = 0.0f, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
         // color_count, color_range_check
 
-        .def_static("nonzero_region", &IBA_nonzero_region,
-             "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("nonzero_region", &IBA_nonzero_region, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("computePixelHashSHA1", &IBA_computePixelHashSHA1,
-            "src"_a, "extrainfo"_a="", "roi"_a=ROI::All(),
-            "blocksize"_a=0, "nthreads"_a=0)
+        .def_static("computePixelHashSHA1", &IBA_computePixelHashSHA1, "src"_a,
+                    "extrainfo"_a = "", "roi"_a = ROI::All(), "blocksize"_a = 0,
+                    "nthreads"_a = 0)
 
-        .def_static("warp", &IBA_warp,
-            "dst"_a, "src"_a, "M"_a, "filtername"_a="", "filterwidth"_a=0.0f,
-            "recompute_roi"_a=false, "wrap"_a="default",
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("warp", &IBA_warp_ret,
-            "src"_a, "M"_a, "filtername"_a="", "filterwidth"_a=0.0f,
-            "recompute_roi"_a=false, "wrap"_a="default",
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("warp", &IBA_warp, "dst"_a, "src"_a, "M"_a,
+                    "filtername"_a = "", "filterwidth"_a = 0.0f,
+                    "recompute_roi"_a = false, "wrap"_a = "default",
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("warp", &IBA_warp_ret, "src"_a, "M"_a, "filtername"_a = "",
+                    "filterwidth"_a = 0.0f, "recompute_roi"_a = false,
+                    "wrap"_a = "default", "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("rotate", &IBA_rotate,
-            "dst"_a, "src"_a, "angle"_a,
-            "filtername"_a="", "filterwidth"_a=0.0f, "recompute_roi"_a=false,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("rotate", &IBA_rotate2,
-            "dst"_a, "src"_a, "angle"_a, "center_x"_a, "center_y"_a,
-            "filtername"_a="", "filterwidth"_a=0.0f, "recompute_roi"_a=false,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("rotate", &IBA_rotate_ret,
-            "src"_a, "angle"_a,
-            "filtername"_a="", "filterwidth"_a=0.0f, "recompute_roi"_a=false,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("rotate", &IBA_rotate2_ret,
-            "src"_a, "angle"_a, "center_x"_a, "center_y"_a,
-            "filtername"_a="", "filterwidth"_a=0.0f, "recompute_roi"_a=false,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("rotate", &IBA_rotate, "dst"_a, "src"_a, "angle"_a,
+                    "filtername"_a = "", "filterwidth"_a = 0.0f,
+                    "recompute_roi"_a = false, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("rotate", &IBA_rotate2, "dst"_a, "src"_a, "angle"_a,
+                    "center_x"_a, "center_y"_a, "filtername"_a = "",
+                    "filterwidth"_a = 0.0f, "recompute_roi"_a = false,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("rotate", &IBA_rotate_ret, "src"_a, "angle"_a,
+                    "filtername"_a = "", "filterwidth"_a = 0.0f,
+                    "recompute_roi"_a = false, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("rotate", &IBA_rotate2_ret, "src"_a, "angle"_a,
+                    "center_x"_a, "center_y"_a, "filtername"_a = "",
+                    "filterwidth"_a = 0.0f, "recompute_roi"_a = false,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("resize", &IBA_resize,
-            "dst"_a, "src"_a, "filtername"_a="", "filterwidth"_a=0.0f,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("resize", &IBA_resize_ret,
-            "src"_a, "filtername"_a="", "filterwidth"_a=0.0f,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("resize", &IBA_resize, "dst"_a, "src"_a,
+                    "filtername"_a = "", "filterwidth"_a = 0.0f,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("resize", &IBA_resize_ret, "src"_a, "filtername"_a = "",
+                    "filterwidth"_a = 0.0f, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("resample", &IBA_resample,
-            "dst"_a, "src"_a, "interpolate"_a=true,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("resample", &IBA_resample_ret,
-            "src"_a, "interpolate"_a=true,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("resample", &IBA_resample, "dst"_a, "src"_a,
+                    "interpolate"_a = true, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("resample", &IBA_resample_ret, "src"_a,
+                    "interpolate"_a = true, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("fit", &IBA_fit,
-            "dst"_a, "src"_a, "filtername"_a="", "filterwidth"_a=0.0f,
-             "exact"_a=false, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("fit", &IBA_fit_ret,
-            "src"_a, "filtername"_a="", "filterwidth"_a=0.0f,
-            "exact"_a=false, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("fit", &IBA_fit, "dst"_a, "src"_a, "filtername"_a = "",
+                    "filterwidth"_a = 0.0f, "exact"_a = false,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("fit", &IBA_fit_ret, "src"_a, "filtername"_a = "",
+                    "filterwidth"_a = 0.0f, "exact"_a = false,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("make_kernel", &IBA_make_kernel,
-            "dst"_a, "name"_a, "width"_a, "height"_a,
-            "depth"_a=1.0f, "normalize"_a=true)
-        .def_static("make_kernel", &IBA_make_kernel_ret,
-            "name"_a, "width"_a, "height"_a,
-            "depth"_a=1.0f, "normalize"_a=true)
+        .def_static("make_kernel", &IBA_make_kernel, "dst"_a, "name"_a,
+                    "width"_a, "height"_a, "depth"_a = 1.0f,
+                    "normalize"_a = true)
+        .def_static("make_kernel", &IBA_make_kernel_ret, "name"_a, "width"_a,
+                    "height"_a, "depth"_a = 1.0f, "normalize"_a = true)
 
-        .def_static("convolve", &IBA_convolve,
-            "dst"_a, "src"_a, "kernel"_a, "normalze"_a=true,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("convolve", &IBA_convolve_ret,
-            "src"_a, "kernel"_a, "normalze"_a=true,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("convolve", &IBA_convolve, "dst"_a, "src"_a, "kernel"_a,
+                    "normalze"_a = true, "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("convolve", &IBA_convolve_ret, "src"_a, "kernel"_a,
+                    "normalze"_a = true, "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("unsharp_mask", &IBA_unsharp_mask,
-            "dst"_a, "src"_a, "kernel"_a="gaussian",
-            "width"_a=3.0f, "contrast"_a=1.0f, "threshold"_a=0.0f,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("unsharp_mask", &IBA_unsharp_mask_ret,
-            "src"_a, "kernel"_a="gaussian",
-            "width"_a=3.0f, "contrast"_a=1.0f, "threshold"_a=0.0f,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("unsharp_mask", &IBA_unsharp_mask, "dst"_a, "src"_a,
+                    "kernel"_a = "gaussian", "width"_a = 3.0f,
+                    "contrast"_a = 1.0f, "threshold"_a = 0.0f,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("unsharp_mask", &IBA_unsharp_mask_ret, "src"_a,
+                    "kernel"_a = "gaussian", "width"_a = 3.0f,
+                    "contrast"_a = 1.0f, "threshold"_a = 0.0f,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("median_filter", &IBA_median_filter,
-            "dst"_a, "src"_a, "width"_a=3, "height"_a=-1,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("median_filter", &IBA_median_filter_ret,
-            "src"_a, "width"_a=3, "height"_a=-1,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("median_filter", &IBA_median_filter, "dst"_a, "src"_a,
+                    "width"_a = 3, "height"_a = -1, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("median_filter", &IBA_median_filter_ret, "src"_a,
+                    "width"_a = 3, "height"_a = -1, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("dilate", &IBA_dilate,
-            "dst"_a, "src"_a, "width"_a=3, "height"_a=-1,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("dilate", &IBA_dilate_ret,
-            "src"_a, "width"_a=3, "height"_a=-1,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("dilate", &IBA_dilate, "dst"_a, "src"_a, "width"_a = 3,
+                    "height"_a = -1, "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("dilate", &IBA_dilate_ret, "src"_a, "width"_a = 3,
+                    "height"_a = -1, "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("erode", &IBA_erode,
-            "dst"_a, "src"_a, "width"_a=3, "height"_a=-1,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("erode", &IBA_erode_ret,
-            "src"_a, "width"_a=3, "height"_a=-1,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("erode", &IBA_erode, "dst"_a, "src"_a, "width"_a = 3,
+                    "height"_a = -1, "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("erode", &IBA_erode_ret, "src"_a, "width"_a = 3,
+                    "height"_a = -1, "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("laplacian", &IBA_laplacian,
-            "dst"_a, "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("laplacian", &IBA_laplacian_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("laplacian", &IBA_laplacian, "dst"_a, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("laplacian", &IBA_laplacian_ret, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("fft", &IBA_fft,
-            "dst"_a, "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("fft", &IBA_fft_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("fft", &IBA_fft, "dst"_a, "src"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("fft", &IBA_fft_ret, "src"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("ifft", &IBA_ifft,
-            "dst"_a, "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("ifft", &IBA_ifft_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("ifft", &IBA_ifft, "dst"_a, "src"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("ifft", &IBA_ifft_ret, "src"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("polar_to_complex", &IBA_polar_to_complex,
-            "dst"_a, "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("polar_to_complex", &IBA_polar_to_complex_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("polar_to_complex", &IBA_polar_to_complex, "dst"_a, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("polar_to_complex", &IBA_polar_to_complex_ret, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("complex_to_polar", &IBA_complex_to_polar,
-            "dst"_a, "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("complex_to_polar", &IBA_complex_to_polar_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("complex_to_polar", &IBA_complex_to_polar, "dst"_a, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("complex_to_polar", &IBA_complex_to_polar_ret, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("fixNonFinite", &IBA_fixNonFinite,
-            "dst"_a, "src"_a, "mode"_a=ImageBufAlgo::NONFINITE_BOX3,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("fixNonFinite", &IBA_fixNonFinite_ret,
-            "src"_a, "mode"_a=ImageBufAlgo::NONFINITE_BOX3,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("fixNonFinite", &IBA_fixNonFinite, "dst"_a, "src"_a,
+                    "mode"_a = ImageBufAlgo::NONFINITE_BOX3,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("fixNonFinite", &IBA_fixNonFinite_ret, "src"_a,
+                    "mode"_a = ImageBufAlgo::NONFINITE_BOX3,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("fillholes_pushpull", &IBA_fillholes_pushpull,
-            "dst"_a, "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("fillholes_pushpull", &IBA_fillholes_pushpull_ret,
-            "src"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("fillholes_pushpull", &IBA_fillholes_pushpull, "dst"_a,
+                    "src"_a, "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("fillholes_pushpull", &IBA_fillholes_pushpull_ret, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("capture_image", &IBA_capture_image,
-            "dst"_a, "cameranum"_a=0, "convert"_a=TypeDesc::UNKNOWN)
-        .def_static("capture_image", &IBA_capture_image_ret,
-            "cameranum"_a=0, "convert"_a=TypeDesc::UNKNOWN)
+        .def_static("capture_image", &IBA_capture_image, "dst"_a,
+                    "cameranum"_a = 0, "convert"_a = TypeDesc::UNKNOWN)
+        .def_static("capture_image", &IBA_capture_image_ret, "cameranum"_a = 0,
+                    "convert"_a = TypeDesc::UNKNOWN)
 
-        .def_static("over", &IBA_over,
-            "dst"_a, "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("over", &IBA_over_ret,
-            "A"_a, "B"_a, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("over", &IBA_over, "dst"_a, "A"_a, "B"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("over", &IBA_over_ret, "A"_a, "B"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("zover", &IBA_zover,
-            "dst"_a, "A"_a, "B"_a, "z_zeroisinf"_a=false,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
-        .def_static("zover", &IBA_zover_ret,
-            "A"_a, "B"_a, "z_zeroisinf"_a=false,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("zover", &IBA_zover, "dst"_a, "A"_a, "B"_a,
+                    "z_zeroisinf"_a = false, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("zover", &IBA_zover_ret, "A"_a, "B"_a,
+                    "z_zeroisinf"_a = false, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
-        .def_static("render_point", &IBA_render_point,
-            "dst"_a, "x"_a, "y"_a, "color"_a=py::none())
+        .def_static("render_point", &IBA_render_point, "dst"_a, "x"_a, "y"_a,
+                    "color"_a = py::none())
 
-        .def_static("render_line", &IBA_render_line,
-            "dst"_a, "x1"_a, "y1"_a, "x2"_a, "y2"_a,
-            "color"_a=py::none(), "skip_first_point"_a=false)
+        .def_static("render_line", &IBA_render_line, "dst"_a, "x1"_a, "y1"_a,
+                    "x2"_a, "y2"_a, "color"_a = py::none(),
+                    "skip_first_point"_a = false)
 
-        .def_static("render_box", &IBA_render_box,
-            "dst"_a, "x1"_a, "y1"_a, "x2"_a, "y2"_a,
-            "color"_a=py::none(), "fill"_a=false)
+        .def_static("render_box", &IBA_render_box, "dst"_a, "x1"_a, "y1"_a,
+                    "x2"_a, "y2"_a, "color"_a = py::none(), "fill"_a = false)
 
-        .def_static("render_text", &IBA_render_text,
-            "dst"_a, "x"_a, "y"_a, "text"_a, "fontsize"_a=16,
-            "fontname"_a="", "textcolor"_a=py::tuple(),"alignx"_a="left",
-            "aligny"_a="baseline", "shadow"_a=0,
-            "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("render_text", &IBA_render_text, "dst"_a, "x"_a, "y"_a,
+                    "text"_a, "fontsize"_a = 16, "fontname"_a = "",
+                    "textcolor"_a = py::tuple(), "alignx"_a = "left",
+                    "aligny"_a = "baseline", "shadow"_a = 0,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
 
-        .def_static("text_size", &IBA_text_size,
-            "text"_a, "fontsize"_a=16,"fontname"_a="")
+        .def_static("text_size", &IBA_text_size, "text"_a, "fontsize"_a = 16,
+                    "fontname"_a = "")
 
-        .def_static("histogram", &IBA_histogram,
-            "src"_a, "channel"_a=0, "bins"_a=256, "min"_a=0.0f, "max"_a=1.0f,
-            "ignore_empty"_a=false, "roi"_a=ROI::All(), "nthreads"_a=0)
+        .def_static("histogram", &IBA_histogram, "src"_a, "channel"_a = 0,
+                    "bins"_a = 256, "min"_a = 0.0f, "max"_a = 1.0f,
+                    "ignore_empty"_a = false, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
         // histogram_draw,
 
-        .def_static("make_texture", &IBA_make_texture_filename,
-            "mode"_a, "filename"_a, "outputfilename"_a,
-            "config"_a=ImageSpec())
-        .def_static("make_texture", &IBA_make_texture_ib,
-            "mode"_a, "buf"_a, "outputfilename"_a,
-            "config"_a=ImageSpec())
-        ;
+        .def_static("make_texture", &IBA_make_texture_filename, "mode"_a,
+                    "filename"_a, "outputfilename"_a, "config"_a = ImageSpec())
+        .def_static("make_texture", &IBA_make_texture_ib, "mode"_a, "buf"_a,
+                    "outputfilename"_a, "config"_a = ImageSpec());
 }
 
-} // namespace PyOpenImageIO
-
+}  // namespace PyOpenImageIO

--- a/src/python/py_imagecache.cpp
+++ b/src/python/py_imagecache.cpp
@@ -30,8 +30,7 @@
 
 #include "py_oiio.h"
 
-namespace PyOpenImageIO
-{
+namespace PyOpenImageIO {
 
 // Make a special wrapper to help with the weirdo way we use create/destroy.
 class ImageCacheWrap {
@@ -39,93 +38,104 @@ public:
     struct ICDeleter {
         void operator()(ImageCache* p) const { ImageCache::destroy(p); }
     };
-    std::unique_ptr<ImageCache,ICDeleter> m_cache;
+    std::unique_ptr<ImageCache, ICDeleter> m_cache;
 
-    ImageCacheWrap (bool shared=true) : m_cache(ImageCache::create(shared)) {}
-    ImageCacheWrap(const ImageCacheWrap&) = delete;
-    ImageCacheWrap(ImageCacheWrap&&) = delete;
-    ~ImageCacheWrap () { }  // will call the deleter on the IC
-    static void destroy (ImageCacheWrap *x, bool teardown=false) {
-        ImageCache::destroy (x->m_cache.release(), teardown);
+    ImageCacheWrap(bool shared = true)
+        : m_cache(ImageCache::create(shared))
+    {
     }
-    py::object get_pixels (const std::string &filename,
-                       int subimage, int miplevel, int xbegin, int xend,
-                       int ybegin, int yend, int zbegin, int zend,
-                       TypeDesc datatype);
+    ImageCacheWrap(const ImageCacheWrap&) = delete;
+    ImageCacheWrap(ImageCacheWrap&&)      = delete;
+    ~ImageCacheWrap() {}  // will call the deleter on the IC
+    static void destroy(ImageCacheWrap* x, bool teardown = false)
+    {
+        ImageCache::destroy(x->m_cache.release(), teardown);
+    }
+    py::object get_pixels(const std::string& filename, int subimage,
+                          int miplevel, int xbegin, int xend, int ybegin,
+                          int yend, int zbegin, int zend, TypeDesc datatype);
 };
 
 
 
-py::object ImageCacheWrap::get_pixels (const std::string &filename_,
-                       int subimage, int miplevel, int xbegin, int xend,
-                       int ybegin, int yend, int zbegin, int zend,
-                       TypeDesc datatype)
+py::object
+ImageCacheWrap::get_pixels(const std::string& filename_, int subimage,
+                           int miplevel, int xbegin, int xend, int ybegin,
+                           int yend, int zbegin, int zend, TypeDesc datatype)
 {
-    ustring filename (filename_);
+    ustring filename(filename_);
     if (datatype == TypeUnknown)
         datatype = TypeFloat;
     int chbegin = 0, chend = 0;
-    if (! m_cache->get_image_info (filename, subimage, miplevel,
-                                   ustring("channels"), TypeDesc::INT, &chend))
+    if (!m_cache->get_image_info(filename, subimage, miplevel,
+                                 ustring("channels"), TypeDesc::INT, &chend))
         return py::none();  // couldn't open file
 
-    size_t size = size_t ((xend-xbegin) * (yend-ybegin) * (zend-zbegin) *
-                          (chend-chbegin) * datatype.size());
-    std::unique_ptr<char[]> data (new char [size]);
+    size_t size = size_t((xend - xbegin) * (yend - ybegin) * (zend - zbegin)
+                         * (chend - chbegin) * datatype.size());
+    std::unique_ptr<char[]> data(new char[size]);
     bool ok;
     {
         py::gil_scoped_release gil;
-        ok = m_cache->get_pixels (filename, subimage, miplevel, xbegin, xend,
-                                  ybegin, yend, zbegin, zend, datatype, data.get());
+        ok = m_cache->get_pixels(filename, subimage, miplevel, xbegin, xend,
+                                 ybegin, yend, zbegin, zend, datatype,
+                                 data.get());
     }
     if (ok)
-        return make_numpy_array (datatype, data.release(),
-                                 (zend-zbegin)>1 ? 4 : 3, chend-chbegin,
-                                 xend-xbegin, yend-ybegin, zend-zbegin);
+        return make_numpy_array(datatype, data.release(),
+                                (zend - zbegin) > 1 ? 4 : 3, chend - chbegin,
+                                xend - xbegin, yend - ybegin, zend - zbegin);
     else
         return py::none();
 }
 
 
 
-
-
-void declare_imagecache (py::module &m)
+void
+declare_imagecache(py::module& m)
 {
     using namespace pybind11::literals;
 
     py::class_<ImageCacheWrap>(m, "ImageCache")
-        .def(py::init<bool>(),
-            "shared"_a=true)
+        .def(py::init<bool>(), "shared"_a = true)
         // .def_static("create", &ImageCacheWrap::create,
         //     "shared"_a=true)
-        .def_static("destroy", &ImageCacheWrap::destroy,
-            "cache"_a, "teardown"_a=false)
+        .def_static("destroy", &ImageCacheWrap::destroy, "cache"_a,
+                    "teardown"_a = false)
 
-        .def("attribute", [](ImageCacheWrap &ic, const std::string &name, float val){
-                if (ic.m_cache)
-                    ic.m_cache->attribute(name,val);
-            })
-        .def("attribute", [](ImageCacheWrap &ic, const std::string &name, int val){
-                if (ic.m_cache)
-                    ic.m_cache->attribute(name,val);
-            })
-        .def("attribute", [](ImageCacheWrap &ic, const std::string &name, const std::string &val){
-                if (ic.m_cache)
-                    ic.m_cache->attribute(name,val);
-            })
-        .def("attribute", [](ImageCacheWrap &ic, const std::string &name, TypeDesc type, const py::object &obj) {
-                if (ic.m_cache)
-                    attribute_typed (*ic.m_cache, name, type, obj);
-            })
-        .def("getattribute",  [](const ImageCacheWrap &ic, const std::string &name, TypeDesc type){
-                return getattribute_typed (*ic.m_cache, name, type);
-            },
-            "name"_a, "type"_a=TypeUnknown)
-        .def("resolve_filename", [](ImageCacheWrap &ic, const std::string &filename){
-                py::gil_scoped_release gil;
-                return PY_STR(ic.m_cache->resolve_filename(filename));
-            })
+        .def("attribute",
+             [](ImageCacheWrap& ic, const std::string& name, float val) {
+                 if (ic.m_cache)
+                     ic.m_cache->attribute(name, val);
+             })
+        .def("attribute",
+             [](ImageCacheWrap& ic, const std::string& name, int val) {
+                 if (ic.m_cache)
+                     ic.m_cache->attribute(name, val);
+             })
+        .def("attribute",
+             [](ImageCacheWrap& ic, const std::string& name,
+                const std::string& val) {
+                 if (ic.m_cache)
+                     ic.m_cache->attribute(name, val);
+             })
+        .def("attribute",
+             [](ImageCacheWrap& ic, const std::string& name, TypeDesc type,
+                const py::object& obj) {
+                 if (ic.m_cache)
+                     attribute_typed(*ic.m_cache, name, type, obj);
+             })
+        .def("getattribute",
+             [](const ImageCacheWrap& ic, const std::string& name,
+                TypeDesc type) {
+                 return getattribute_typed(*ic.m_cache, name, type);
+             },
+             "name"_a, "type"_a = TypeUnknown)
+        .def("resolve_filename",
+             [](ImageCacheWrap& ic, const std::string& filename) {
+                 py::gil_scoped_release gil;
+                 return PY_STR(ic.m_cache->resolve_filename(filename));
+             })
         // .def("get_image_info", &ImageCacheWrap::get_image_info)
         // .def("get_imagespec", &ImageCacheWrap::get_imagespec,
         //      "subimage"_a=0),
@@ -134,25 +144,26 @@ void declare_imagecache (py::module &m)
         // .def("release_tile", &ImageCacheWrap::release_tile)
         // .def("tile_pixels", &ImageCacheWrap::tile_pixels)
 
-        .def("geterror", [](ImageCacheWrap &ic){
-                return PY_STR(ic.m_cache->geterror());
-            })
-        .def("getstats", [](ImageCacheWrap &ic, int level){
-                py::gil_scoped_release gil;
-                return PY_STR(ic.m_cache->getstats(level));
-            },
-            "level"_a=1)
-        .def("invalidate", [](ImageCacheWrap &ic, const std::string &filename){
-                py::gil_scoped_release gil;
-                ic.m_cache->invalidate(ustring(filename));
-            },
-            "filename"_a)
-        .def("invalidate_all", [](ImageCacheWrap &ic, bool force){
-                py::gil_scoped_release gil;
-                ic.m_cache->invalidate_all(force);
-            },
-            "force"_a=false)
-    ;
+        .def("geterror",
+             [](ImageCacheWrap& ic) { return PY_STR(ic.m_cache->geterror()); })
+        .def("getstats",
+             [](ImageCacheWrap& ic, int level) {
+                 py::gil_scoped_release gil;
+                 return PY_STR(ic.m_cache->getstats(level));
+             },
+             "level"_a = 1)
+        .def("invalidate",
+             [](ImageCacheWrap& ic, const std::string& filename) {
+                 py::gil_scoped_release gil;
+                 ic.m_cache->invalidate(ustring(filename));
+             },
+             "filename"_a)
+        .def("invalidate_all",
+             [](ImageCacheWrap& ic, bool force) {
+                 py::gil_scoped_release gil;
+                 ic.m_cache->invalidate_all(force);
+             },
+             "force"_a = false);
 }
 
-} // namespace PyOpenImageIO
+}  // namespace PyOpenImageIO

--- a/src/python/py_imageinput.cpp
+++ b/src/python/py_imageinput.cpp
@@ -30,37 +30,37 @@
 
 #include "py_oiio.h"
 
-namespace PyOpenImageIO
-{
+namespace PyOpenImageIO {
 
 static py::object
-ImageInput_read_image (ImageInput &self, int subimage, int miplevel,
-                       int chbegin, int chend, TypeDesc format)
+ImageInput_read_image(ImageInput& self, int subimage, int miplevel, int chbegin,
+                      int chend, TypeDesc format)
 {
     // Allocate our own temp buffer and try to read the into into it.
     // If the read fails, return None.
     self.lock();
-    self.seek_subimage (subimage, miplevel);
+    self.seek_subimage(subimage, miplevel);
     ImageSpec spec;
-    spec.copy_dimensions (self.spec());
+    spec.copy_dimensions(self.spec());
     self.unlock();
 
     if (format == TypeUnknown)
         format = spec.format;
-    chend = clamp (chend, chbegin+1, spec.nchannels);
-    size_t nchans = size_t(chend - chbegin);
+    chend            = clamp(chend, chbegin + 1, spec.nchannels);
+    size_t nchans    = size_t(chend - chbegin);
     size_t pixelsize = size_t(nchans * format.size());
-    size_t size = spec.image_pixels() * pixelsize;
-    int dims = spec.depth > 1 ? 4 : 3;
-    std::unique_ptr<char[]> data (new char[size]);
+    size_t size      = spec.image_pixels() * pixelsize;
+    int dims         = spec.depth > 1 ? 4 : 3;
+    std::unique_ptr<char[]> data(new char[size]);
     bool ok;
     {
         py::gil_scoped_release gil;
-        ok = self.read_image (subimage, miplevel, chbegin, chend, format, data.get());
+        ok = self.read_image(subimage, miplevel, chbegin, chend, format,
+                             data.get());
     }
     if (ok)
-        return make_numpy_array (format, data.release(), dims, nchans, spec.width,
-                                 spec.height, spec.depth);
+        return make_numpy_array(format, data.release(), dims, nchans,
+                                spec.width, spec.height, spec.depth);
     else
         return py::none();
 }
@@ -68,36 +68,35 @@ ImageInput_read_image (ImageInput &self, int subimage, int miplevel,
 
 
 static py::object
-ImageInput_read_scanlines (ImageInput &self, int subimage, int miplevel,
-                           int ybegin, int yend, int z,
-                           int chbegin, int chend, TypeDesc format,
-                           int dims)
+ImageInput_read_scanlines(ImageInput& self, int subimage, int miplevel,
+                          int ybegin, int yend, int z, int chbegin, int chend,
+                          TypeDesc format, int dims)
 {
     // Allocate our own temp buffer and try to read the scanline into it.
     // If the read fails, return None.
     self.lock();
-    self.seek_subimage (subimage, miplevel);
+    self.seek_subimage(subimage, miplevel);
     ImageSpec spec;
-    spec.copy_dimensions (self.spec());
+    spec.copy_dimensions(self.spec());
     self.unlock();
 
     if (format == TypeUnknown)
         format = spec.format;
-    int width = spec.width;
-    chend = clamp (chend, chbegin+1, spec.nchannels);
-    size_t nchans = size_t(chend - chbegin);
+    int width        = spec.width;
+    chend            = clamp(chend, chbegin + 1, spec.nchannels);
+    size_t nchans    = size_t(chend - chbegin);
     size_t pixelsize = size_t(nchans * format.size());
-    size_t size = size_t((yend-ybegin) * width) * pixelsize;
-    std::unique_ptr<char[]> data (new char[size]);
+    size_t size      = size_t((yend - ybegin) * width) * pixelsize;
+    std::unique_ptr<char[]> data(new char[size]);
     bool ok;
     {
         py::gil_scoped_release gil;
-        ok = self.read_scanlines (subimage, miplevel, ybegin, yend, z,
-                                  chbegin, chend, format, data.get());
+        ok = self.read_scanlines(subimage, miplevel, ybegin, yend, z, chbegin,
+                                 chend, format, data.get());
     }
     if (ok)
-        return make_numpy_array (format, data.release(), dims, nchans, width,
-                                 yend-ybegin, 1);
+        return make_numpy_array(format, data.release(), dims, nchans, width,
+                                yend - ybegin, 1);
     else
         return py::none();
 }
@@ -105,36 +104,36 @@ ImageInput_read_scanlines (ImageInput &self, int subimage, int miplevel,
 
 
 static py::object
-ImageInput_read_tiles (ImageInput &self, int subimage, int miplevel,
-                       int xbegin, int xend, int ybegin, int yend,
-                       int zbegin, int zend, int chbegin, int chend,
-                       TypeDesc format)
+ImageInput_read_tiles(ImageInput& self, int subimage, int miplevel, int xbegin,
+                      int xend, int ybegin, int yend, int zbegin, int zend,
+                      int chbegin, int chend, TypeDesc format)
 {
     // Allocate our own temp buffer and try to read the scanline into it.
     // If the read fails, return None.
     self.lock();
-    self.seek_subimage (subimage, miplevel);
+    self.seek_subimage(subimage, miplevel);
     ImageSpec spec;
-    spec.copy_dimensions (self.spec());
+    spec.copy_dimensions(self.spec());
     self.unlock();
 
     if (format == TypeUnknown)
         format = spec.format;
-    chend = clamp (chend, chbegin+1, spec.nchannels);
-    size_t nchans = size_t(chend - chbegin);
+    chend            = clamp(chend, chbegin + 1, spec.nchannels);
+    size_t nchans    = size_t(chend - chbegin);
     size_t pixelsize = size_t(nchans * format.size());
-    size_t size = (xend-xbegin) * (yend-ybegin) * (zend-zbegin) * pixelsize;
+    size_t size      = (xend - xbegin) * (yend - ybegin) * (zend - zbegin)
+                  * pixelsize;
     int dims = spec.tile_depth > 1 ? 4 : 3;
-    std::unique_ptr<char[]> data (new char[size]);
+    std::unique_ptr<char[]> data(new char[size]);
     bool ok;
     {
         py::gil_scoped_release gil;
-        ok = self.read_tiles (subimage, miplevel, xbegin, xend, ybegin, yend,
-                              zbegin, zend, chbegin, chend, format, data.get());
+        ok = self.read_tiles(subimage, miplevel, xbegin, xend, ybegin, yend,
+                             zbegin, zend, chbegin, chend, format, data.get());
     }
     if (ok)
-        return make_numpy_array (format, data.release(), dims, nchans,
-                                 xend-xbegin, yend-ybegin, zend-zbegin);
+        return make_numpy_array(format, data.release(), dims, nchans,
+                                xend - xbegin, yend - ybegin, zend - zbegin);
     else
         return py::none();
 }
@@ -142,17 +141,17 @@ ImageInput_read_tiles (ImageInput &self, int subimage, int miplevel,
 
 
 py::object
-ImageInput_read_native_deep_scanlines_old (ImageInput& self,
-                                       int ybegin, int yend,
-                                       int z, int chbegin, int chend)
+ImageInput_read_native_deep_scanlines_old(ImageInput& self, int ybegin,
+                                          int yend, int z, int chbegin,
+                                          int chend)
 {
     std::unique_ptr<DeepData> dd;
     bool ok = true;
     {
         py::gil_scoped_release gil;
-        dd.reset (new DeepData);
-        ok = self.read_native_deep_scanlines (ybegin, yend, z,
-                                              chbegin, chend, *dd);
+        dd.reset(new DeepData);
+        ok = self.read_native_deep_scanlines(ybegin, yend, z, chbegin, chend,
+                                             *dd);
     }
     return ok ? py::cast(dd.release()) : py::none();
 }
@@ -160,18 +159,17 @@ ImageInput_read_native_deep_scanlines_old (ImageInput& self,
 
 
 py::object
-ImageInput_read_native_deep_scanlines (ImageInput& self,
-                                       int subimage, int miplevel,
-                                       int ybegin, int yend,
-                                       int z, int chbegin, int chend)
+ImageInput_read_native_deep_scanlines(ImageInput& self, int subimage,
+                                      int miplevel, int ybegin, int yend, int z,
+                                      int chbegin, int chend)
 {
     std::unique_ptr<DeepData> dd;
     bool ok = true;
     {
         py::gil_scoped_release gil;
-        dd.reset (new DeepData);
-        ok = self.read_native_deep_scanlines (subimage, miplevel, ybegin,
-                                              yend, z, chbegin, chend, *dd);
+        dd.reset(new DeepData);
+        ok = self.read_native_deep_scanlines(subimage, miplevel, ybegin, yend,
+                                             z, chbegin, chend, *dd);
     }
     return ok ? py::cast(dd.release()) : py::none();
 }
@@ -179,20 +177,18 @@ ImageInput_read_native_deep_scanlines (ImageInput& self,
 
 
 py::object
-ImageInput_read_native_deep_tiles (ImageInput& self, int subimage, int miplevel,
-                                   int xbegin, int xend,
-                                   int ybegin, int yend,
-                                   int zbegin, int zend,
-                                   int chbegin, int chend)
+ImageInput_read_native_deep_tiles(ImageInput& self, int subimage, int miplevel,
+                                  int xbegin, int xend, int ybegin, int yend,
+                                  int zbegin, int zend, int chbegin, int chend)
 {
     std::unique_ptr<DeepData> dd;
     bool ok = true;
     {
         py::gil_scoped_release gil;
-        dd.reset (new DeepData);
-        ok = self.read_native_deep_tiles (subimage, miplevel, xbegin, xend,
-                                          ybegin, yend, zbegin, zend,
-                                          chbegin, chend, *dd);
+        dd.reset(new DeepData);
+        ok = self.read_native_deep_tiles(subimage, miplevel, xbegin, xend,
+                                         ybegin, yend, zbegin, zend, chbegin,
+                                         chend, *dd);
     }
     return ok ? py::cast(dd.release()) : py::none();
 }
@@ -200,162 +196,177 @@ ImageInput_read_native_deep_tiles (ImageInput& self, int subimage, int miplevel,
 
 
 py::object
-ImageInput_read_native_deep_image (ImageInput& self, int subimage, int miplevel)
+ImageInput_read_native_deep_image(ImageInput& self, int subimage, int miplevel)
 {
     std::unique_ptr<DeepData> dd;
     bool ok = true;
     {
         py::gil_scoped_release gil;
-        dd.reset (new DeepData);
-        ok = self.read_native_deep_image (subimage, miplevel, *dd);
+        dd.reset(new DeepData);
+        ok = self.read_native_deep_image(subimage, miplevel, *dd);
     }
     return ok ? py::cast(dd.release()) : py::none();
 }
 
 
 
-
-void declare_imageinput (py::module &m)
+void
+declare_imageinput(py::module& m)
 {
     using namespace pybind11::literals;
 
     py::class_<ImageInput>(m, "ImageInput")
-        .def_static("create", [](const std::string& filename, const std::string& searchpath) ->py::object {
-                auto in = ImageInput::create(filename, searchpath);
-                return in ? py::cast(in.release()) : py::none();
-            },
-            "filename"_a, "plugin_searchpath"_a="")
-        .def_static("open", [](const std::string& filename) ->py::object {
-                auto in = ImageInput::open(filename);
-                return in ? py::cast(in.release()) : py::none();
-                },
-            "filename"_a)
-        .def_static("open", [](const std::string& filename, const ImageSpec& config) ->py::object {
-                auto in = ImageInput::open(filename, &config);
-                return in ? py::cast(in.release()) : py::none();
-            },
-            "filename"_a, "config"_a)
-        .def("format_name",      &ImageInput::format_name)
-        .def("valid_file",       &ImageInput::valid_file)
-        .def("spec", [](ImageInput &self){
-                return self.spec();
-            })
-        .def("spec", [](ImageInput &self, int subimage, int miplevel){
-                return self.spec(subimage, miplevel);
-            },
-            "subimage"_a, "miplevel"_a=0)
-        .def("spec_dimensions", [](ImageInput &self, int subimage, int miplevel){
-                return self.spec_dimensions(subimage, miplevel);
-            },
-            "subimage"_a, "miplevel"_a=0)
-        .def("supports",    [](const ImageInput &self, const std::string& feature){
-                return self.supports(feature); })
-        .def("close",            &ImageInput::close)
+        .def_static("create",
+                    [](const std::string& filename,
+                       const std::string& searchpath) -> py::object {
+                        auto in = ImageInput::create(filename, searchpath);
+                        return in ? py::cast(in.release()) : py::none();
+                    },
+                    "filename"_a, "plugin_searchpath"_a = "")
+        .def_static("open",
+                    [](const std::string& filename) -> py::object {
+                        auto in = ImageInput::open(filename);
+                        return in ? py::cast(in.release()) : py::none();
+                    },
+                    "filename"_a)
+        .def_static("open",
+                    [](const std::string& filename,
+                       const ImageSpec& config) -> py::object {
+                        auto in = ImageInput::open(filename, &config);
+                        return in ? py::cast(in.release()) : py::none();
+                    },
+                    "filename"_a, "config"_a)
+        .def("format_name", &ImageInput::format_name)
+        .def("valid_file", &ImageInput::valid_file)
+        .def("spec", [](ImageInput& self) { return self.spec(); })
+        .def("spec",
+             [](ImageInput& self, int subimage, int miplevel) {
+                 return self.spec(subimage, miplevel);
+             },
+             "subimage"_a, "miplevel"_a = 0)
+        .def("spec_dimensions",
+             [](ImageInput& self, int subimage, int miplevel) {
+                 return self.spec_dimensions(subimage, miplevel);
+             },
+             "subimage"_a, "miplevel"_a = 0)
+        .def("supports",
+             [](const ImageInput& self, const std::string& feature) {
+                 return self.supports(feature);
+             })
+        .def("close", &ImageInput::close)
         .def("current_subimage", &ImageInput::current_subimage)
         .def("current_miplevel", &ImageInput::current_miplevel)
-        .def("seek_subimage",    [](ImageInput &self, int subimage, int miplevel){
-                py::gil_scoped_release gil;
-                return self.seek_subimage (subimage, miplevel);
-            })
-        .def("read_image", [](ImageInput &self, int subimage, int miplevel,
-                              int chbegin, int chend, TypeDesc format)->py::object{
-                return ImageInput_read_image (self, subimage, miplevel,
+        .def("seek_subimage",
+             [](ImageInput& self, int subimage, int miplevel) {
+                 py::gil_scoped_release gil;
+                 return self.seek_subimage(subimage, miplevel);
+             })
+        .def("read_image",
+             [](ImageInput& self, int subimage, int miplevel, int chbegin,
+                int chend, TypeDesc format) -> py::object {
+                 return ImageInput_read_image(self, subimage, miplevel, chbegin,
+                                              chend, format);
+             },
+             "subimage"_a, "miplevel"_a, "chbegin"_a, "chend"_a,
+             "format"_a = TypeFloat)
+        .def("read_image",
+             [](ImageInput& self, TypeDesc format) -> py::object {
+                 return ImageInput_read_image(self, self.current_subimage(),
+                                              self.current_miplevel(), 0, 10000,
+                                              format);
+             },
+             "format"_a = TypeFloat)
+        .def("read_scanline",
+             [](ImageInput& self, int y, int z, TypeDesc format) -> py::object {
+                 return ImageInput_read_scanlines(self, self.current_subimage(),
+                                                  self.current_miplevel(), y,
+                                                  y + 1, z, 0, 10000, format,
+                                                  2);
+             },
+             "y"_a, "z"_a = 0, "format"_a = TypeFloat)
+        .def("read_scanlines",
+             [](ImageInput& self, int subimage, int miplevel, int ybegin,
+                int yend, int z, int chbegin, int chend,
+                TypeDesc format) -> py::object {
+                 return ImageInput_read_scanlines(self, subimage, miplevel,
+                                                  ybegin, yend, z, chbegin,
+                                                  chend, format, 3);
+             },
+             "subimage"_a, "miplevel"_a, "ybegin"_a, "yend"_a, "z"_a,
+             "chbegin"_a, "chend"_a, "format"_a = TypeFloat)
+        .def("read_scanlines",
+             [](ImageInput& self, int ybegin, int yend, int z, int chbegin,
+                int chend, TypeDesc format) -> py::object {
+                 return ImageInput_read_scanlines(self, self.current_subimage(),
+                                                  self.current_miplevel(),
+                                                  ybegin, yend, z, chbegin,
+                                                  chend, format, 3);
+             },
+             "ybegin"_a, "yend"_a, "z"_a, "chbegin"_a, "chend"_a,
+             "format"_a = TypeFloat)
+        .def("read_tiles",
+             [](ImageInput& self, int subimage, int miplevel, int xbegin,
+                int xend, int ybegin, int yend, int zbegin, int zend,
+                int chbegin, int chend, TypeDesc format) -> py::object {
+                 return ImageInput_read_tiles(self, subimage, miplevel, xbegin,
+                                              xend, ybegin, yend, zbegin, zend,
                                               chbegin, chend, format);
-            },
-            "subimage"_a, "miplevel"_a, "chbegin"_a, "chend"_a, "format"_a=TypeFloat)
-        .def("read_image", [](ImageInput &self, TypeDesc format)->py::object{
-                return ImageInput_read_image (self, self.current_subimage(),
-                                              self.current_miplevel(),
-                                              0, 10000, format);
-            },
-            "format"_a=TypeFloat)
-        .def("read_scanline", [](ImageInput &self, int y, int z,
-                                 TypeDesc format)->py::object{
-                return ImageInput_read_scanlines (self, self.current_subimage(),
-                                                  self.current_miplevel(),
-                                                  y, y+1, z,
-                                                  0, 10000, format, 2);
-            },
-            "y"_a, "z"_a=0, "format"_a=TypeFloat)
-        .def("read_scanlines", [](ImageInput &self, int subimage, int miplevel,
-                                  int ybegin, int yend, int z,
-                                  int chbegin, int chend, TypeDesc format)->py::object{
-                return ImageInput_read_scanlines (self, subimage, miplevel,
-                                                  ybegin, yend, z,
-                                                  chbegin, chend, format, 3);
-            },
-            "subimage"_a, "miplevel"_a, "ybegin"_a, "yend"_a, "z"_a,
-            "chbegin"_a, "chend"_a, "format"_a=TypeFloat)
-        .def("read_scanlines", [](ImageInput &self, int ybegin, int yend, int z,
-                                  int chbegin, int chend, TypeDesc format)->py::object{
-                return ImageInput_read_scanlines (self, self.current_subimage(),
-                                                  self.current_miplevel(),
-                                                  ybegin, yend, z,
-                                                  chbegin, chend, format, 3);
-            },
-            "ybegin"_a, "yend"_a, "z"_a, "chbegin"_a, "chend"_a,
-            "format"_a=TypeFloat)
-        .def("read_tiles", [](ImageInput &self, int subimage, int miplevel,
-                              int xbegin, int xend, int ybegin, int yend,
-                              int zbegin, int zend, int chbegin, int chend,
-                              TypeDesc format)->py::object{
-                return ImageInput_read_tiles (self, subimage, miplevel,
-                                              xbegin, xend, ybegin, yend,
-                                              zbegin, zend, chbegin, chend, format);
-            },
-            "subimage"_a, "miplevel"_a,
-            "xbegin"_a, "xend"_a, "ybegin"_a, "yend"_a, "zbegin"_a, "zend"_a,
-            "chbegin"_a, "chend"_a, "format"_a=TypeFloat)
-        .def("read_tiles", [](ImageInput &self, int xbegin, int xend,
-                              int ybegin, int yend, int zbegin, int zend,
-                              int chbegin, int chend, TypeDesc format)->py::object{
-                return ImageInput_read_tiles (self, self.current_subimage(),
-                                              self.current_miplevel(),
-                                              xbegin, xend, ybegin, yend,
-                                              zbegin, zend, chbegin, chend, format);
-            },
-            "xbegin"_a, "xend"_a, "ybegin"_a, "yend"_a, "zbegin"_a, "zend"_a,
-            "chbegin"_a, "chend"_a, "format"_a=TypeFloat)
-        .def("read_tile", [](ImageInput &self, int x, int y, int z,
-                             TypeDesc format)->py::object{
-                const ImageSpec &spec (self.spec());
-                return ImageInput_read_tiles (self, self.current_subimage(),
-                                              self.current_miplevel(),
-                                              x, x+spec.tile_width,
-                                              y, y+spec.tile_height,
-                                              z, z+std::max(1,spec.tile_depth),
+             },
+             "subimage"_a, "miplevel"_a, "xbegin"_a, "xend"_a, "ybegin"_a,
+             "yend"_a, "zbegin"_a, "zend"_a, "chbegin"_a, "chend"_a,
+             "format"_a = TypeFloat)
+        .def("read_tiles",
+             [](ImageInput& self, int xbegin, int xend, int ybegin, int yend,
+                int zbegin, int zend, int chbegin, int chend,
+                TypeDesc format) -> py::object {
+                 return ImageInput_read_tiles(self, self.current_subimage(),
+                                              self.current_miplevel(), xbegin,
+                                              xend, ybegin, yend, zbegin, zend,
+                                              chbegin, chend, format);
+             },
+             "xbegin"_a, "xend"_a, "ybegin"_a, "yend"_a, "zbegin"_a, "zend"_a,
+             "chbegin"_a, "chend"_a, "format"_a = TypeFloat)
+        .def("read_tile",
+             [](ImageInput& self, int x, int y, int z,
+                TypeDesc format) -> py::object {
+                 const ImageSpec& spec(self.spec());
+                 return ImageInput_read_tiles(self, self.current_subimage(),
+                                              self.current_miplevel(), x,
+                                              x + spec.tile_width, y,
+                                              y + spec.tile_height, z,
+                                              z + std::max(1, spec.tile_depth),
                                               0, spec.nchannels, format);
-            },
-            "x"_a, "y"_a, "z"_a, "format"_a=TypeFloat)
-        .def("read_native_deep_scanlines", &ImageInput_read_native_deep_scanlines,
-             "subimage"_a, "miplevel"_a, "ybegin"_a, "yend"_a,
-             "z"_a, "chbegin"_a, "chend"_a)
-        .def("read_native_deep_scanlines", // DEPRECATED(1.9), keep for back compatibility
-                [](ImageInput& self, int ybegin, int yend,
-                                     int z, int chbegin, int chend) {
-                    return ImageInput_read_native_deep_scanlines_old (self,
-                                        ybegin, yend, z, chbegin, chend);
-                },
+             },
+             "x"_a, "y"_a, "z"_a, "format"_a = TypeFloat)
+        .def("read_native_deep_scanlines",
+             &ImageInput_read_native_deep_scanlines, "subimage"_a, "miplevel"_a,
+             "ybegin"_a, "yend"_a, "z"_a, "chbegin"_a, "chend"_a)
+        .def("read_native_deep_scanlines",  // DEPRECATED(1.9), keep for back compatibility
+             [](ImageInput& self, int ybegin, int yend, int z, int chbegin,
+                int chend) {
+                 return ImageInput_read_native_deep_scanlines_old(self, ybegin,
+                                                                  yend, z,
+                                                                  chbegin,
+                                                                  chend);
+             },
              "ybegin"_a, "yend"_a, "z"_a, "chbegin"_a, "chend"_a)
         .def("read_native_deep_tiles", &ImageInput_read_native_deep_tiles,
-             "subimage"_a, "miplevel"_a, "xbegin"_a, "xend"_a,
-             "ybegin"_a, "yend"_a, "zbegin"_a, "zend"_a, "chbegin"_a, "chend"_a)
-        .def("read_native_deep_tiles", // DEPRECATED(1.9), keep for back compatibility
-                [](ImageInput& self, int xbegin, int xend, int ybegin, int yend,
-                        int zbegin, int zend, int chbegin, int chend){
-                return ImageInput_read_native_deep_tiles (self, 0, 0,
-                        xbegin, xend, ybegin, yend, zbegin, zend, chbegin, chend);
+             "subimage"_a, "miplevel"_a, "xbegin"_a, "xend"_a, "ybegin"_a,
+             "yend"_a, "zbegin"_a, "zend"_a, "chbegin"_a, "chend"_a)
+        .def("read_native_deep_tiles",  // DEPRECATED(1.9), keep for back compatibility
+             [](ImageInput& self, int xbegin, int xend, int ybegin, int yend,
+                int zbegin, int zend, int chbegin, int chend) {
+                 return ImageInput_read_native_deep_tiles(self, 0, 0, xbegin,
+                                                          xend, ybegin, yend,
+                                                          zbegin, zend, chbegin,
+                                                          chend);
              },
              "xbegin"_a, "xend"_a, "ybegin"_a, "yend"_a, "zbegin"_a, "zend"_a,
              "chbegin"_a, "chend"_a)
-        .def("read_native_deep_image",
-             &ImageInput_read_native_deep_image,
-             "subimage"_a=0, "miplevel"_a=0)
-        .def("geterror", [](ImageInput &self){
-                return PY_STR(self.geterror());
-            })
-    ;
+        .def("read_native_deep_image", &ImageInput_read_native_deep_image,
+             "subimage"_a = 0, "miplevel"_a = 0)
+        .def("geterror",
+             [](ImageInput& self) { return PY_STR(self.geterror()); });
 }
 
-} // namespace PyOpenImageIO
-
+}  // namespace PyOpenImageIO

--- a/src/python/py_imageoutput.cpp
+++ b/src/python/py_imageoutput.cpp
@@ -32,217 +32,217 @@
 #undef SIZEOF_LONG
 #include "py_oiio.h"
 
-namespace PyOpenImageIO
-{
+namespace PyOpenImageIO {
 
 
-bool ImageOutput_open_specs (ImageOutput &self, const std::string &name,
-                             py::tuple &specs)
+bool
+ImageOutput_open_specs(ImageOutput& self, const std::string& name,
+                       py::tuple& specs)
 {
     const size_t length = len(specs);
     if (length == 0)
         return false;
-    std::vector<ImageSpec> Cspecs (length);
+    std::vector<ImageSpec> Cspecs(length);
     for (size_t i = 0; i < length; ++i) {
         auto s = specs[i];
         if (py::isinstance<ImageSpec>(s))
             Cspecs[i] = s.cast<ImageSpec>();
         else
-            return false; // Tuple item was not an ImageSpec
+            return false;  // Tuple item was not an ImageSpec
     }
-    return self.open (name, int(length), &Cspecs[0]);
+    return self.open(name, int(length), &Cspecs[0]);
 }
 
 
 
 bool
-ImageOutput_write_scanline (ImageOutput &self, int y, int z, py::buffer &buffer)
+ImageOutput_write_scanline(ImageOutput& self, int y, int z, py::buffer& buffer)
 {
-    const ImageSpec& spec (self.spec());
-    oiio_bufinfo buf (buffer.request(), spec.nchannels, spec.width, 1, 1, 1);
-    if (! buf.data) {
-        self.error ("Could not decode python buffer");
+    const ImageSpec& spec(self.spec());
+    oiio_bufinfo buf(buffer.request(), spec.nchannels, spec.width, 1, 1, 1);
+    if (!buf.data) {
+        self.error("Could not decode python buffer");
         return false;  // failed sanity checks
     }
-    if (static_cast<int>(buf.size) < self.spec().width*self.spec().nchannels) {
-        self.error ("write_scanlines was not passed a long enough array");
+    if (static_cast<int>(buf.size)
+        < self.spec().width * self.spec().nchannels) {
+        self.error("write_scanlines was not passed a long enough array");
         return false;
     }
     py::gil_scoped_release gil;
-    return self.write_scanline (y, z, buf.format, buf.data, buf.xstride);
+    return self.write_scanline(y, z, buf.format, buf.data, buf.xstride);
 }
 
 
 
 bool
-ImageOutput_write_scanlines (ImageOutput &self, int ybegin, int yend, int z,
-                             py::buffer &buffer)
+ImageOutput_write_scanlines(ImageOutput& self, int ybegin, int yend, int z,
+                            py::buffer& buffer)
 {
-    const ImageSpec& spec (self.spec());
-    oiio_bufinfo buf (buffer.request(), spec.nchannels, spec.width,
-                      yend-ybegin, 1, 2);
-    if (! buf.data) {
-        self.error ("Could not decode python buffer");
+    const ImageSpec& spec(self.spec());
+    oiio_bufinfo buf(buffer.request(), spec.nchannels, spec.width,
+                     yend - ybegin, 1, 2);
+    if (!buf.data) {
+        self.error("Could not decode python buffer");
         return false;  // failed sanity checks
     }
-    if (static_cast<int>(buf.size) < self.spec().width*self.spec().nchannels*(yend-ybegin)) {
-        self.error ("write_scanlines was not passed a long enough array");
+    if (static_cast<int>(buf.size)
+        < self.spec().width * self.spec().nchannels * (yend - ybegin)) {
+        self.error("write_scanlines was not passed a long enough array");
         return false;
     }
     py::gil_scoped_release gil;
-    return self.write_scanlines (ybegin, yend, z, buf.format, buf.data,
-                                 buf.xstride, buf.ystride);
+    return self.write_scanlines(ybegin, yend, z, buf.format, buf.data,
+                                buf.xstride, buf.ystride);
 }
 
 
 
 bool
-ImageOutput_write_tile (ImageOutput &self, int x, int y, int z, py::buffer &buffer)
+ImageOutput_write_tile(ImageOutput& self, int x, int y, int z,
+                       py::buffer& buffer)
 {
-    const ImageSpec& spec (self.spec());
-    oiio_bufinfo buf (buffer.request(), spec.nchannels, spec.tile_width,
-                      spec.tile_height, spec.tile_depth,
-                      spec.tile_depth > 1 ? 3 : 2);
-    if (! buf.data) {
-        self.error ("Could not decode python buffer");
+    const ImageSpec& spec(self.spec());
+    oiio_bufinfo buf(buffer.request(), spec.nchannels, spec.tile_width,
+                     spec.tile_height, spec.tile_depth,
+                     spec.tile_depth > 1 ? 3 : 2);
+    if (!buf.data) {
+        self.error("Could not decode python buffer");
         return false;  // failed sanity checks
     }
-    if (buf.size < self.spec().tile_pixels()*self.spec().nchannels) {
-        self.error ("write_tile was not passed a long enough array");
+    if (buf.size < self.spec().tile_pixels() * self.spec().nchannels) {
+        self.error("write_tile was not passed a long enough array");
         return false;
     }
     py::gil_scoped_release gil;
-    return self.write_tile (x, y, z, buf.format, buf.data,
-                            buf.xstride, buf.ystride, buf.zstride);
+    return self.write_tile(x, y, z, buf.format, buf.data, buf.xstride,
+                           buf.ystride, buf.zstride);
 }
 
 
 
 bool
-ImageOutput_write_tiles (ImageOutput &self, int xbegin, int xend,
-                         int ybegin, int yend, int zbegin, int zend,
-                         py::buffer &buffer)
+ImageOutput_write_tiles(ImageOutput& self, int xbegin, int xend, int ybegin,
+                        int yend, int zbegin, int zend, py::buffer& buffer)
 {
-    const ImageSpec& spec (self.spec());
-    oiio_bufinfo buf (buffer.request(), spec.nchannels, xend-xbegin,
-                      yend-ybegin, zend-zbegin, spec.tile_depth > 1 ? 3 : 2);
-    if (! buf.data) {
-        self.error ("Could not decode python buffer");
+    const ImageSpec& spec(self.spec());
+    oiio_bufinfo buf(buffer.request(), spec.nchannels, xend - xbegin,
+                     yend - ybegin, zend - zbegin, spec.tile_depth > 1 ? 3 : 2);
+    if (!buf.data) {
+        self.error("Could not decode python buffer");
         return false;  // failed sanity checks
     }
-    if (static_cast<int>(buf.size) < (xend-xbegin)*(yend-ybegin)*(zend-zbegin)*self.spec().nchannels) {
-        self.error ("write_tiles was not passed a long enough array");
+    if (static_cast<int>(buf.size) < (xend - xbegin) * (yend - ybegin)
+                                         * (zend - zbegin)
+                                         * self.spec().nchannels) {
+        self.error("write_tiles was not passed a long enough array");
         return false;
     }
     py::gil_scoped_release gil;
-    return self.write_tiles (xbegin, xend, ybegin, yend, zbegin, zend,
-                             buf.format, buf.data,
-                             buf.xstride, buf.ystride, buf.zstride);
+    return self.write_tiles(xbegin, xend, ybegin, yend, zbegin, zend,
+                            buf.format, buf.data, buf.xstride, buf.ystride,
+                            buf.zstride);
 }
 
 
 
 bool
-ImageOutput_write_image (ImageOutput &self, py::buffer &buffer)
+ImageOutput_write_image(ImageOutput& self, py::buffer& buffer)
 {
-    const ImageSpec& spec (self.spec());
-    oiio_bufinfo buf (buffer.request(), spec.nchannels, spec.width,
-                      spec.height, spec.depth, spec.depth > 1 ? 3 : 2);
-    if (! buf.data || buf.size < spec.image_pixels()*spec.nchannels)
+    const ImageSpec& spec(self.spec());
+    oiio_bufinfo buf(buffer.request(), spec.nchannels, spec.width, spec.height,
+                     spec.depth, spec.depth > 1 ? 3 : 2);
+    if (!buf.data || buf.size < spec.image_pixels() * spec.nchannels)
         return false;  // failed sanity checks
     py::gil_scoped_release gil;
-    return self.write_image (buf.format, buf.data,
-                             buf.xstride, buf.ystride, buf.zstride);
+    return self.write_image(buf.format, buf.data, buf.xstride, buf.ystride,
+                            buf.zstride);
 }
 
 
 
 bool
-ImageOutput_write_deep_scanlines (ImageOutput &self, int ybegin, int yend, int z,
-                                  const DeepData &deepdata)
+ImageOutput_write_deep_scanlines(ImageOutput& self, int ybegin, int yend, int z,
+                                 const DeepData& deepdata)
 {
     py::gil_scoped_release gil;
-    return self.write_deep_scanlines (ybegin, yend, z, deepdata);
+    return self.write_deep_scanlines(ybegin, yend, z, deepdata);
 }
 
 
 bool
-ImageOutput_write_deep_tiles (ImageOutput &self, int xbegin, int xend,
-                              int ybegin, int yend, int zbegin, int zend,
-                              const DeepData &deepdata)
+ImageOutput_write_deep_tiles(ImageOutput& self, int xbegin, int xend,
+                             int ybegin, int yend, int zbegin, int zend,
+                             const DeepData& deepdata)
 {
     py::gil_scoped_release gil;
-    return self.write_deep_tiles (xbegin, xend, ybegin, yend,
-                                  zbegin, zend, deepdata);
+    return self.write_deep_tiles(xbegin, xend, ybegin, yend, zbegin, zend,
+                                 deepdata);
 }
 
 
 bool
-ImageOutput_write_deep_image (ImageOutput &self, const DeepData &deepdata)
+ImageOutput_write_deep_image(ImageOutput& self, const DeepData& deepdata)
 {
     py::gil_scoped_release gil;
-    return self.write_deep_image (deepdata);
+    return self.write_deep_image(deepdata);
 }
 
 
 
-
-
-void declare_imageoutput (py::module &m)
+void
+declare_imageoutput(py::module& m)
 {
     using namespace pybind11::literals;
 
     py::class_<ImageOutput>(m, "ImageOutput")
-        .def_static("create", [](const std::string& filename, const std::string& searchpath) ->py::object {
-                auto out (ImageOutput::create(filename, searchpath));
-                return out ? py::cast(out.release()) : py::none();
-            },
-            "filename"_a, "plugin_searchpath"_a="")
-        .def("format_name",     &ImageOutput::format_name)
-        .def("supports",    [](const ImageOutput &self, const std::string& feature){
-                return self.supports(feature); })
-        .def("spec",            &ImageOutput::spec)
-        .def("open", [](ImageOutput &self, const std::string &name, const ImageSpec &newspec,
-                        const std::string &modestr) {
-                ImageOutput::OpenMode mode = ImageOutput::Create;
-                if (Strutil::iequals(modestr, "AppendSubimage"))
-                    mode = ImageOutput::AppendSubimage;
-                else if (Strutil::iequals(modestr, "AppendMIPLevel"))
-                    mode = ImageOutput::AppendMIPLevel;
-                else if (! Strutil::iequals(modestr, "Create"))
-                    throw std::invalid_argument (Strutil::format("Unknown open mode '%s'", modestr));
-                return self.open (name, newspec, mode);
-            },
-            "filename"_a, "spec"_a, "mode"_a="Create")
-        .def("open",            &ImageOutput_open_specs)
-        .def("close", [](ImageOutput &self){
-                return self.close();
-            })
-        .def("write_image",      &ImageOutput_write_image)
-        .def("write_scanline",   &ImageOutput_write_scanline,
-             "y"_a, "z"_a, "pixels"_a)
-        .def("write_scanlines",  &ImageOutput_write_scanlines,
-             "ybegin"_a, "yend"_a, "z"_a, "pixels"_a)
-        .def("write_tile",       &ImageOutput_write_tile,
-             "x"_a, "y"_a, "z"_a, "pixels"_a)
-        .def("write_tiles",      &ImageOutput_write_tiles,
-             "xbegin"_a, "xend"_a, "ybegin"_a, "yend"_a,
-             "zbegin"_a, "zend"_a, "pixels"_a)
+        .def_static("create",
+                    [](const std::string& filename,
+                       const std::string& searchpath) -> py::object {
+                        auto out(ImageOutput::create(filename, searchpath));
+                        return out ? py::cast(out.release()) : py::none();
+                    },
+                    "filename"_a, "plugin_searchpath"_a = "")
+        .def("format_name", &ImageOutput::format_name)
+        .def("supports",
+             [](const ImageOutput& self, const std::string& feature) {
+                 return self.supports(feature);
+             })
+        .def("spec", &ImageOutput::spec)
+        .def("open",
+             [](ImageOutput& self, const std::string& name,
+                const ImageSpec& newspec, const std::string& modestr) {
+                 ImageOutput::OpenMode mode = ImageOutput::Create;
+                 if (Strutil::iequals(modestr, "AppendSubimage"))
+                     mode = ImageOutput::AppendSubimage;
+                 else if (Strutil::iequals(modestr, "AppendMIPLevel"))
+                     mode = ImageOutput::AppendMIPLevel;
+                 else if (!Strutil::iequals(modestr, "Create"))
+                     throw std::invalid_argument(
+                         Strutil::format("Unknown open mode '%s'", modestr));
+                 return self.open(name, newspec, mode);
+             },
+             "filename"_a, "spec"_a, "mode"_a = "Create")
+        .def("open", &ImageOutput_open_specs)
+        .def("close", [](ImageOutput& self) { return self.close(); })
+        .def("write_image", &ImageOutput_write_image)
+        .def("write_scanline", &ImageOutput_write_scanline, "y"_a, "z"_a,
+             "pixels"_a)
+        .def("write_scanlines", &ImageOutput_write_scanlines, "ybegin"_a,
+             "yend"_a, "z"_a, "pixels"_a)
+        .def("write_tile", &ImageOutput_write_tile, "x"_a, "y"_a, "z"_a,
+             "pixels"_a)
+        .def("write_tiles", &ImageOutput_write_tiles, "xbegin"_a, "xend"_a,
+             "ybegin"_a, "yend"_a, "zbegin"_a, "zend"_a, "pixels"_a)
         .def("write_deep_scanlines", &ImageOutput_write_deep_scanlines,
              "ybegin"_a, "yend"_a, "z"_a, "deepdata"_a)
-        .def("write_deep_tiles", &ImageOutput_write_deep_tiles,
-             "xbegin"_a, "xend"_a, "ybegin"_a, "yend"_a,
-             "zbegin"_a, "zend"_a, "deepdata"_a)
+        .def("write_deep_tiles", &ImageOutput_write_deep_tiles, "xbegin"_a,
+             "xend"_a, "ybegin"_a, "yend"_a, "zbegin"_a, "zend"_a, "deepdata"_a)
         .def("write_deep_image", &ImageOutput_write_deep_image)
-        .def("copy_image", [](ImageOutput &self, ImageInput &in){
-                return self.copy_image (&in);
-            })
-        .def("geterror", [](ImageOutput &self){
-                return PY_STR(self.geterror());
-            })
-    ;
-
+        .def("copy_image", [](ImageOutput& self,
+                              ImageInput& in) { return self.copy_image(&in); })
+        .def("geterror",
+             [](ImageOutput& self) { return PY_STR(self.geterror()); });
 }
 
-} // namespace PyOpenImageIO
-
+}  // namespace PyOpenImageIO

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -30,108 +30,112 @@
 
 #include "py_oiio.h"
 
-namespace PyOpenImageIO
-{
+namespace PyOpenImageIO {
 
 
 // Accessor for channelformats, converts a vector<TypeDesc> to a tuple.
 static py::tuple
-ImageSpec_get_channelformats (const ImageSpec& spec, bool allow_empty=true)
+ImageSpec_get_channelformats(const ImageSpec& spec, bool allow_empty = true)
 {
     std::vector<TypeDesc> formats;
     if (spec.channelformats.size() || !allow_empty)
-        spec.get_channelformats (formats);
-    return C_to_tuple (cspan<TypeDesc>(formats));
+        spec.get_channelformats(formats);
+    return C_to_tuple(cspan<TypeDesc>(formats));
 }
 
 // Mutator for channelformats, initialized using a tuple or list whose int
 // entries give the BASETYPE values.
 static void
-ImageSpec_set_channelformats (ImageSpec& spec, const py::object& py_channelformats)
+ImageSpec_set_channelformats(ImageSpec& spec,
+                             const py::object& py_channelformats)
 {
     spec.channelformats.clear();
-    py_to_stdvector (spec.channelformats, py_channelformats);
+    py_to_stdvector(spec.channelformats, py_channelformats);
 }
 
 
 static py::tuple
-ImageSpec_get_channelnames (const ImageSpec& spec)
+ImageSpec_get_channelnames(const ImageSpec& spec)
 {
-    return C_to_tuple (cspan<std::string>(spec.channelnames));
+    return C_to_tuple(cspan<std::string>(spec.channelnames));
 }
 
 static void
-ImageSpec_set_channelnames (ImageSpec& spec, const py::object& py_channelnames)
+ImageSpec_set_channelnames(ImageSpec& spec, const py::object& py_channelnames)
 {
     spec.channelnames.clear();
-    py_to_stdvector (spec.channelnames, py_channelnames);
+    py_to_stdvector(spec.channelnames, py_channelnames);
 }
 
 
 static py::object
-ImageSpec_getattribute_typed (const ImageSpec& spec,
-                               const std::string &name, TypeDesc type=TypeUnknown)
+ImageSpec_getattribute_typed(const ImageSpec& spec, const std::string& name,
+                             TypeDesc type = TypeUnknown)
 {
     ParamValue tmpparam;
-    const ParamValue *p = spec.find_attribute (name, tmpparam, type);
+    const ParamValue* p = spec.find_attribute(name, tmpparam, type);
     if (!p)
         return py::none();
     type = p->type();
     if (type.basetype == TypeDesc::INT)
-        return C_to_val_or_tuple ((const int *)p->data(), type);
+        return C_to_val_or_tuple((const int*)p->data(), type);
     if (type.basetype == TypeDesc::UINT)
-        return C_to_val_or_tuple ((const unsigned int *)p->data(), type);
+        return C_to_val_or_tuple((const unsigned int*)p->data(), type);
     if (type.basetype == TypeDesc::INT16)
-        return C_to_val_or_tuple ((const short *)p->data(), type);
+        return C_to_val_or_tuple((const short*)p->data(), type);
     if (type.basetype == TypeDesc::UINT16)
-        return C_to_val_or_tuple ((const unsigned short *)p->data(), type);
+        return C_to_val_or_tuple((const unsigned short*)p->data(), type);
     if (type.basetype == TypeDesc::FLOAT)
-        return C_to_val_or_tuple ((const float *)p->data(), type);
+        return C_to_val_or_tuple((const float*)p->data(), type);
     if (type.basetype == TypeDesc::DOUBLE)
-        return C_to_val_or_tuple ((const double *)p->data(), type);
+        return C_to_val_or_tuple((const double*)p->data(), type);
     if (type.basetype == TypeDesc::HALF)
-        return C_to_val_or_tuple ((const half *)p->data(), type);
+        return C_to_val_or_tuple((const half*)p->data(), type);
     if (type.basetype == TypeDesc::STRING)
-        return C_to_val_or_tuple ((const char **)p->data(), type);
+        return C_to_val_or_tuple((const char**)p->data(), type);
     return py::none();
 }
 
 
 
-void declare_imagespec (py::module& m)
+void
+declare_imagespec(py::module& m)
 {
     using namespace pybind11::literals;
 
     py::class_<ImageSpec>(m, "ImageSpec")
-        .def_readwrite("x",             &ImageSpec::x)
-        .def_readwrite("y",             &ImageSpec::y)
-        .def_readwrite("z",             &ImageSpec::z)
-        .def_readwrite("width",         &ImageSpec::width)
-        .def_readwrite("height",        &ImageSpec::height)
-        .def_readwrite("depth",         &ImageSpec::depth)
-        .def_readwrite("full_x",        &ImageSpec::full_x)
-        .def_readwrite("full_y",        &ImageSpec::full_y)
-        .def_readwrite("full_z",        &ImageSpec::full_z)
-        .def_readwrite("full_width",    &ImageSpec::full_width)
-        .def_readwrite("full_height",   &ImageSpec::full_height)
-        .def_readwrite("full_depth",    &ImageSpec::full_depth)
-        .def_readwrite("tile_width",    &ImageSpec::tile_width)
-        .def_readwrite("tile_height",   &ImageSpec::tile_height)
-        .def_readwrite("tile_depth",    &ImageSpec::tile_depth)
-        .def_readwrite("nchannels",     &ImageSpec::nchannels)
-        .def_readwrite("format",        &ImageSpec::format)
+        .def_readwrite("x", &ImageSpec::x)
+        .def_readwrite("y", &ImageSpec::y)
+        .def_readwrite("z", &ImageSpec::z)
+        .def_readwrite("width", &ImageSpec::width)
+        .def_readwrite("height", &ImageSpec::height)
+        .def_readwrite("depth", &ImageSpec::depth)
+        .def_readwrite("full_x", &ImageSpec::full_x)
+        .def_readwrite("full_y", &ImageSpec::full_y)
+        .def_readwrite("full_z", &ImageSpec::full_z)
+        .def_readwrite("full_width", &ImageSpec::full_width)
+        .def_readwrite("full_height", &ImageSpec::full_height)
+        .def_readwrite("full_depth", &ImageSpec::full_depth)
+        .def_readwrite("tile_width", &ImageSpec::tile_width)
+        .def_readwrite("tile_height", &ImageSpec::tile_height)
+        .def_readwrite("tile_depth", &ImageSpec::tile_depth)
+        .def_readwrite("nchannels", &ImageSpec::nchannels)
+        .def_readwrite("format", &ImageSpec::format)
         .def_property("channelformats",
-              [](const ImageSpec &spec){ return ImageSpec_get_channelformats(spec); },
-              &ImageSpec_set_channelformats)
-        .def_property("channelnames",   &ImageSpec_get_channelnames,
-                                        &ImageSpec_set_channelnames)
+                      [](const ImageSpec& spec) {
+                          return ImageSpec_get_channelformats(spec);
+                      },
+                      &ImageSpec_set_channelformats)
+        .def_property("channelnames", &ImageSpec_get_channelnames,
+                      &ImageSpec_set_channelnames)
         .def_readwrite("alpha_channel", &ImageSpec::alpha_channel)
-        .def_readwrite("z_channel",     &ImageSpec::z_channel)
-        .def_readwrite("deep",          &ImageSpec::deep)
+        .def_readwrite("z_channel", &ImageSpec::z_channel)
+        .def_readwrite("deep", &ImageSpec::deep)
         .def_readwrite("extra_attribs", &ImageSpec::extra_attribs)
 
-        .def_property ("roi", &ImageSpec::roi, &ImageSpec::set_roi)
-        .def_property ("roi_full", &ImageSpec::roi_full, &ImageSpec::set_roi_full)
+        .def_property("roi", &ImageSpec::roi, &ImageSpec::set_roi)
+        .def_property("roi_full", &ImageSpec::roi_full,
+                      &ImageSpec::set_roi_full)
 
         .def(py::init<>())
         .def(py::init<int, int, int, TypeDesc>())
@@ -139,112 +143,132 @@ void declare_imagespec (py::module& m)
         .def(py::init<TypeDesc>())
         .def(py::init<const ImageSpec&>())
         .def("set_format", &ImageSpec::set_format)
-        .def("default_channel_names",   &ImageSpec::default_channel_names)
+        .def("default_channel_names", &ImageSpec::default_channel_names)
         .def("channel_bytes",
-             [](const ImageSpec &spec){ return spec.channel_bytes(); })
+             [](const ImageSpec& spec) { return spec.channel_bytes(); })
         .def("channel_bytes",
-             [](const ImageSpec &spec, int chan, bool native){ return spec.channel_bytes(chan, native); },
-             "channel"_a, "native"_a=false)
+             [](const ImageSpec& spec, int chan, bool native) {
+                 return spec.channel_bytes(chan, native);
+             },
+             "channel"_a, "native"_a = false)
         // .def("pixel_bytes",
         //      [](const ImageSpec &spec){ return spec.pixel_bytes(); })
         .def("pixel_bytes",
-             [](const ImageSpec &spec, bool native){ return spec.pixel_bytes(native); },
-             "native"_a=false)
+             [](const ImageSpec& spec, bool native) {
+                 return spec.pixel_bytes(native);
+             },
+             "native"_a = false)
         .def("pixel_bytes",
-             [](const ImageSpec &spec, int chbegin, int chend, bool native){
-                return spec.pixel_bytes(chbegin, chend, native);
-              },
-              "chbegin"_a, "chend"_a, "native"_a=false)
+             [](const ImageSpec& spec, int chbegin, int chend, bool native) {
+                 return spec.pixel_bytes(chbegin, chend, native);
+             },
+             "chbegin"_a, "chend"_a, "native"_a = false)
         // .def("scanline_bytes",
         //      [](const ImageSpec &spec){ return spec.scanline_bytes(); })
         .def("scanline_bytes",
-             [](const ImageSpec &spec, bool native){ return spec.scanline_bytes(native); },
-             "native"_a=false)
+             [](const ImageSpec& spec, bool native) {
+                 return spec.scanline_bytes(native);
+             },
+             "native"_a = false)
         // .def("tile_bytes",
         //      [](const ImageSpec &spec){ return spec.tile_bytes(); })
         .def("tile_bytes",
-             [](const ImageSpec &spec, bool native){ return spec.tile_bytes(native); },
-             "native"_a=false)
+             [](const ImageSpec& spec, bool native) {
+                 return spec.tile_bytes(native);
+             },
+             "native"_a = false)
         // .def("image_bytes",
         //      [](const ImageSpec &spec){ return spec.image_bytes(); })
         .def("image_bytes",
-             [](const ImageSpec &spec, bool native){ return spec.image_bytes(native); },
-             "native"_a=false)
-        .def("tile_pixels",             &ImageSpec::tile_pixels)
-        .def("image_pixels",            &ImageSpec::image_pixels)
-        .def("size_t_safe",             &ImageSpec::size_t_safe)
-        .def("channelformat", [](const ImageSpec &spec, int chan){
-                return spec.channelformat(chan);
-            })
-        .def("channel_name", [](const ImageSpec &spec, int chan){
-                return PY_STR(std::string(spec.channel_name(chan)));
-            })
-        .def("channelindex", [](const ImageSpec &spec, const std::string& name){
-                return spec.channelindex(name);
-            })
-        .def("get_channelformats", [](const ImageSpec &spec){
-                return ImageSpec_get_channelformats (spec, false);
-            })
+             [](const ImageSpec& spec, bool native) {
+                 return spec.image_bytes(native);
+             },
+             "native"_a = false)
+        .def("tile_pixels", &ImageSpec::tile_pixels)
+        .def("image_pixels", &ImageSpec::image_pixels)
+        .def("size_t_safe", &ImageSpec::size_t_safe)
+        .def("channelformat", [](const ImageSpec& spec,
+                                 int chan) { return spec.channelformat(chan); })
+        .def("channel_name",
+             [](const ImageSpec& spec, int chan) {
+                 return PY_STR(std::string(spec.channel_name(chan)));
+             })
+        .def("channelindex",
+             [](const ImageSpec& spec, const std::string& name) {
+                 return spec.channelindex(name);
+             })
+        .def("get_channelformats",
+             [](const ImageSpec& spec) {
+                 return ImageSpec_get_channelformats(spec, false);
+             })
 
         // For now, do not expose auto_stride.  It's not obvious that
         // anybody will want to do pointer work and strides from Python.
 
-        .def("attribute", [](ImageSpec &spec, const std::string &name, float val){
-                spec.attribute(name,val);
-            })
-        .def("attribute", [](ImageSpec &spec, const std::string &name, int val){
-                spec.attribute(name,val);
-            })
-        .def("attribute", [](ImageSpec &spec, const std::string &name, const std::string &val){
-                spec.attribute(name,val);
-            })
-        .def("attribute", [](ImageSpec &spec, const std::string &name, TypeDesc type, const py::tuple &obj) {
-                attribute_typed (spec, name, type, obj);
-            })
+        .def("attribute", [](ImageSpec& spec, const std::string& name,
+                             float val) { spec.attribute(name, val); })
+        .def("attribute", [](ImageSpec& spec, const std::string& name,
+                             int val) { spec.attribute(name, val); })
+        .def("attribute",
+             [](ImageSpec& spec, const std::string& name,
+                const std::string& val) { spec.attribute(name, val); })
+        .def("attribute",
+             [](ImageSpec& spec, const std::string& name, TypeDesc type,
+                const py::tuple& obj) {
+                 attribute_typed(spec, name, type, obj);
+             })
         // .def("attribute", [](ImageSpec &spec, const std::string &name, TypeDesc type, const py::list &obj) {
         //         attribute_typed (spec, name, type, obj);
         //     })
-        .def("get_int_attribute", [](const ImageSpec &spec, const std::string& name, int def) {
-                   return spec.get_int_attribute (name, def); },
-              "name"_a, "defaultval"_a=0)
-        .def("get_float_attribute", [](const ImageSpec &spec, const std::string& name, float def) {
-                   return spec.get_float_attribute (name, def); },
-             "name"_a, "defaultval"_a=0.0f)
-        .def("get_string_attribute", [](const ImageSpec &spec, const std::string& name, const std::string& def) {
-                   return PY_STR(std::string(spec.get_string_attribute (name, def))); },
-             "name"_a, "defaultval"_a="")
-        .def("getattribute",  &ImageSpec_getattribute_typed,
-             "name"_a, "type"_a=TypeUnknown)
-        .def("erase_attribute", &ImageSpec::erase_attribute,
-             "name"_a="", "type"_a=TypeUnknown, "casesensitive"_a=false)
+        .def("get_int_attribute",
+             [](const ImageSpec& spec, const std::string& name, int def) {
+                 return spec.get_int_attribute(name, def);
+             },
+             "name"_a, "defaultval"_a = 0)
+        .def("get_float_attribute",
+             [](const ImageSpec& spec, const std::string& name, float def) {
+                 return spec.get_float_attribute(name, def);
+             },
+             "name"_a, "defaultval"_a = 0.0f)
+        .def("get_string_attribute",
+             [](const ImageSpec& spec, const std::string& name,
+                const std::string& def) {
+                 return PY_STR(
+                     std::string(spec.get_string_attribute(name, def)));
+             },
+             "name"_a, "defaultval"_a = "")
+        .def("getattribute", &ImageSpec_getattribute_typed, "name"_a,
+             "type"_a = TypeUnknown)
+        .def("erase_attribute", &ImageSpec::erase_attribute, "name"_a = "",
+             "type"_a = TypeUnknown, "casesensitive"_a = false)
 
-        .def_static("metadata_val", [](const ParamValue &p, bool human){
-                return PY_STR(ImageSpec::metadata_val (p, human));
-            },
-            "param"_a, "human"_a=false)
-        .def("serialize", [](const ImageSpec& spec, const std::string &format,
-                             const std::string &verbose){
-                ImageSpec::SerialFormat fmt = ImageSpec::SerialText;
-                if (Strutil::iequals(format, "xml"))
-                    fmt = ImageSpec::SerialXML;
-                ImageSpec::SerialVerbose verb = ImageSpec::SerialDetailed;
-                if (Strutil::iequals(verbose, "brief"))
-                    verb = ImageSpec::SerialBrief;
-                else if (Strutil::iequals(verbose, "detailed"))
-                    verb = ImageSpec::SerialDetailed;
-                else if (Strutil::iequals(verbose, "detailedhuman"))
-                    verb = ImageSpec::SerialDetailedHuman;
-                return PY_STR (spec.serialize (fmt, verb));
-            },
-            "format"_a="text", "verbose"_a="detailed")
-        .def("to_xml", [](const ImageSpec& spec){ return PY_STR(spec.to_xml()); })
-        .def("from_xml",    &ImageSpec::from_xml)
-        .def("valid_tile_range",    &ImageSpec::valid_tile_range,
-             "xbegin"_a, "xend"_a, "ybegin"_a, "yend"_a, "zbegin"_a, "zend"_a)
-        .def("copy_dimensions", &ImageSpec::copy_dimensions,
-             "other"_a)
-    ;
+        .def_static("metadata_val",
+                    [](const ParamValue& p, bool human) {
+                        return PY_STR(ImageSpec::metadata_val(p, human));
+                    },
+                    "param"_a, "human"_a = false)
+        .def("serialize",
+             [](const ImageSpec& spec, const std::string& format,
+                const std::string& verbose) {
+                 ImageSpec::SerialFormat fmt = ImageSpec::SerialText;
+                 if (Strutil::iequals(format, "xml"))
+                     fmt = ImageSpec::SerialXML;
+                 ImageSpec::SerialVerbose verb = ImageSpec::SerialDetailed;
+                 if (Strutil::iequals(verbose, "brief"))
+                     verb = ImageSpec::SerialBrief;
+                 else if (Strutil::iequals(verbose, "detailed"))
+                     verb = ImageSpec::SerialDetailed;
+                 else if (Strutil::iequals(verbose, "detailedhuman"))
+                     verb = ImageSpec::SerialDetailedHuman;
+                 return PY_STR(spec.serialize(fmt, verb));
+             },
+             "format"_a = "text", "verbose"_a = "detailed")
+        .def("to_xml",
+             [](const ImageSpec& spec) { return PY_STR(spec.to_xml()); })
+        .def("from_xml", &ImageSpec::from_xml)
+        .def("valid_tile_range", &ImageSpec::valid_tile_range, "xbegin"_a,
+             "xend"_a, "ybegin"_a, "yend"_a, "zbegin"_a, "zend"_a)
+        .def("copy_dimensions", &ImageSpec::copy_dimensions, "other"_a);
 }
 
-} // namespace PyOpenImageIO
-
+}  // namespace PyOpenImageIO

--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -30,24 +30,23 @@
 
 #include "py_oiio.h"
 
-namespace PyOpenImageIO
-{
+namespace PyOpenImageIO {
 
 
-const char *
-python_array_code (TypeDesc format)
+const char*
+python_array_code(TypeDesc format)
 {
     switch (format.basetype) {
-    case TypeDesc::UINT8 :  return "B";
-    case TypeDesc::INT8 :   return "b";
-    case TypeDesc::UINT16 : return "H";
-    case TypeDesc::INT16 :  return "h";
-    case TypeDesc::UINT32 : return "I";
-    case TypeDesc::INT32 :  return "i";
-    case TypeDesc::FLOAT :  return "f";
-    case TypeDesc::DOUBLE : return "d";
-    case TypeDesc::HALF :   return "e";
-    default :
+    case TypeDesc::UINT8: return "B";
+    case TypeDesc::INT8: return "b";
+    case TypeDesc::UINT16: return "H";
+    case TypeDesc::INT16: return "h";
+    case TypeDesc::UINT32: return "I";
+    case TypeDesc::INT32: return "i";
+    case TypeDesc::FLOAT: return "f";
+    case TypeDesc::DOUBLE: return "d";
+    case TypeDesc::HALF: return "e";
+    default:
         // For any other type, including UNKNOWN, pack it into an
         // unsigned byte array.
         return "B";
@@ -57,21 +56,21 @@ python_array_code (TypeDesc format)
 
 
 TypeDesc
-typedesc_from_python_array_code (char code)
+typedesc_from_python_array_code(char code)
 {
     switch (code) {
-    case 'b' :
-    case 'c' : return TypeDesc::INT8;
-    case 'B' : return TypeDesc::UINT8;
-    case 'h' : return TypeDesc::INT16;
-    case 'H' : return TypeDesc::UINT16;
-    case 'i' : return TypeDesc::INT;
-    case 'I' : return TypeDesc::UINT;
-    case 'l' : return TypeDesc::INT64;
-    case 'L' : return TypeDesc::UINT64;
-    case 'f' : return TypeDesc::FLOAT;
-    case 'd' : return TypeDesc::DOUBLE;
-    case 'e' : return TypeDesc::HALF;
+    case 'b':
+    case 'c': return TypeDesc::INT8;
+    case 'B': return TypeDesc::UINT8;
+    case 'h': return TypeDesc::INT16;
+    case 'H': return TypeDesc::UINT16;
+    case 'i': return TypeDesc::INT;
+    case 'I': return TypeDesc::UINT;
+    case 'l': return TypeDesc::INT64;
+    case 'L': return TypeDesc::UINT64;
+    case 'f': return TypeDesc::FLOAT;
+    case 'd': return TypeDesc::DOUBLE;
+    case 'e': return TypeDesc::HALF;
     }
     return TypeDesc::UNKNOWN;
 }
@@ -79,94 +78,103 @@ typedesc_from_python_array_code (char code)
 
 
 std::string
-object_classname (const py::object& obj)
+object_classname(const py::object& obj)
 {
     return obj.attr("__class__").attr("__name__").cast<py::str>();
 }
 
 
-oiio_bufinfo::oiio_bufinfo (const py::buffer_info &pybuf, int nchans,
-                            int width, int height, int depth, int pixeldims)
+oiio_bufinfo::oiio_bufinfo(const py::buffer_info& pybuf, int nchans, int width,
+                           int height, int depth, int pixeldims)
 {
     if (pybuf.format.size())
-        format = typedesc_from_python_array_code (pybuf.format[0]);
-    if (size_t(pybuf.itemsize) != format.size() ||
-          pybuf.size != int64_t(width)*int64_t(height)*int64_t(depth*nchans)) {
-        format = TypeUnknown;   // Something went wrong
-        throw std::length_error (Strutil::format("buffer is wrong size (expected %dx%dx%dx%d, got total %d)",
-                                                 depth, height, width, nchans, pybuf.size));
+        format = typedesc_from_python_array_code(pybuf.format[0]);
+    if (size_t(pybuf.itemsize) != format.size()
+        || pybuf.size
+               != int64_t(width) * int64_t(height) * int64_t(depth * nchans)) {
+        format = TypeUnknown;  // Something went wrong
+        throw std::length_error(Strutil::format(
+            "buffer is wrong size (expected %dx%dx%dx%d, got total %d)", depth,
+            height, width, nchans, pybuf.size));
     }
     size = pybuf.size;
     if (pixeldims == 3) {
         // Reading a 3D volumetric cube
-        if (pybuf.ndim == 4 && pybuf.shape[0] == depth &&
-              pybuf.shape[1] == height &&
-              pybuf.shape[2] == width && pybuf.shape[3] == nchans) {
+        if (pybuf.ndim == 4 && pybuf.shape[0] == depth
+            && pybuf.shape[1] == height && pybuf.shape[2] == width
+            && pybuf.shape[3] == nchans) {
             // passed from python as [z][y][x][c]
             xstride = pybuf.strides[2];
             ystride = pybuf.strides[1];
             zstride = pybuf.strides[0];
-        }
-        else if (pybuf.ndim == 3 && pybuf.shape[0] == depth &&
-              pybuf.shape[1] == height &&
-              pybuf.shape[2] == width*nchans) {
+        } else if (pybuf.ndim == 3 && pybuf.shape[0] == depth
+                   && pybuf.shape[1] == height
+                   && pybuf.shape[2] == width * nchans) {
             // passed from python as [z][y][xpixel] -- chans mushed together
             xstride = pybuf.strides[2];
             ystride = pybuf.strides[1];
             zstride = pybuf.strides[0];
         } else {
             format = TypeUnknown;  // No idea what's going on -- error
-            throw std::invalid_argument ("Bad pixeldims in oiio_bufinfo ctr");
+            throw std::invalid_argument("Bad pixeldims in oiio_bufinfo ctr");
         }
     } else if (pixeldims == 2) {
         // Reading an 2D image rectangle
-        if (pybuf.ndim == 3 && pybuf.shape[0] == height &&
-            pybuf.shape[1] == width && pybuf.shape[2] == nchans) {
+        if (pybuf.ndim == 3 && pybuf.shape[0] == height
+            && pybuf.shape[1] == width && pybuf.shape[2] == nchans) {
             // passed from python as [y][x][c]
             xstride = pybuf.strides[1];
             ystride = pybuf.strides[0];
         } else if (pybuf.ndim == 2) {
             // Somebody collapsed a dimsision. Is it [pixel][c] with x&y
             // combined, or is it [y][xpixel] with channels mushed together?
-            if (pybuf.shape[0] == width*height && pybuf.shape[1] == nchans)
+            if (pybuf.shape[0] == width * height && pybuf.shape[1] == nchans)
                 xstride = pybuf.strides[0];
-            else if (pybuf.shape[0] == height && pybuf.shape[1] == width*nchans) {
+            else if (pybuf.shape[0] == height
+                     && pybuf.shape[1] == width * nchans) {
                 ystride = pybuf.strides[0];
-                xstride = pybuf.strides[0]*nchans;
+                xstride = pybuf.strides[0] * nchans;
             } else {
-                format = TypeUnknown; // error
-                throw std::invalid_argument (Strutil::format("Can't figure out array shape (pixeldims=%d, pydim=%d)",
-                                                             pixeldims, pybuf.ndim));
+                format = TypeUnknown;  // error
+                throw std::invalid_argument(Strutil::format(
+                    "Can't figure out array shape (pixeldims=%d, pydim=%d)",
+                    pixeldims, pybuf.ndim));
             }
-        } else if (pybuf.ndim == 1 && pybuf.shape[0] == height*width*nchans) {
+        } else if (pybuf.ndim == 1
+                   && pybuf.shape[0] == height * width * nchans) {
             // all pixels & channels smushed together
             // just rely on autostride
         } else {
             format = TypeUnknown;  // No idea what's going on -- error
-            throw std::invalid_argument (Strutil::format("Can't figure out array shape (pixeldims=%d, pydim=%d)",
-                                                         pixeldims, pybuf.ndim));
+            throw std::invalid_argument(Strutil::format(
+                "Can't figure out array shape (pixeldims=%d, pydim=%d)",
+                pixeldims, pybuf.ndim));
         }
     } else if (pixeldims == 1) {
         // Reading a 1D scanline span
-        if (pybuf.ndim == 2 && pybuf.shape[0] == width && pybuf.shape[1] == nchans) {
+        if (pybuf.ndim == 2 && pybuf.shape[0] == width
+            && pybuf.shape[1] == nchans) {
             // passed from python as [x][c]
             xstride = pybuf.strides[0];
-        } else if (pybuf.ndim == 1 && pybuf.shape[0] == width*nchans) {
+        } else if (pybuf.ndim == 1 && pybuf.shape[0] == width * nchans) {
             // all pixels & channels smushed together
             xstride = pybuf.strides[0] * nchans;
         } else {
-            format = TypeUnknown; // No idea what's going on -- error
-            throw std::invalid_argument (Strutil::format("Can't figure out array shape (pixeldims=%d, pydim=%d)",
-                                                         pixeldims, pybuf.ndim));
+            format = TypeUnknown;  // No idea what's going on -- error
+            throw std::invalid_argument(Strutil::format(
+                "Can't figure out array shape (pixeldims=%d, pydim=%d)",
+                pixeldims, pybuf.ndim));
         }
     } else {
-        throw std::invalid_argument (Strutil::format("Can't figure out array shape (pixeldims=%d, pydim=%d)",
-                                                     pixeldims, pybuf.ndim));
+        throw std::invalid_argument(Strutil::format(
+            "Can't figure out array shape (pixeldims=%d, pydim=%d)", pixeldims,
+            pybuf.ndim));
     }
 
     if (nchans > 1 && size_t(pybuf.strides.back()) != format.size()) {
         format = TypeUnknown;  // can't handle noncontig channels
-        throw std::invalid_argument ("Can't handle numpy array with noncontiguous channels");
+        throw std::invalid_argument(
+            "Can't handle numpy array with noncontiguous channels");
     }
     if (format != TypeUnknown)
         data = pybuf.ptr;
@@ -175,31 +183,31 @@ oiio_bufinfo::oiio_bufinfo (const py::buffer_info &pybuf, int nchans,
 
 
 bool
-oiio_attribute_typed (const std::string &name, TypeDesc type,
-                      const py::tuple &obj)
+oiio_attribute_typed(const std::string& name, TypeDesc type,
+                     const py::tuple& obj)
 {
     if (type.basetype == TypeDesc::INT) {
         std::vector<int> vals;
-        py_to_stdvector (vals, obj);
-        if (vals.size() == type.numelements()*type.aggregate)
-            return OIIO::attribute (name, type, &vals[0]);
+        py_to_stdvector(vals, obj);
+        if (vals.size() == type.numelements() * type.aggregate)
+            return OIIO::attribute(name, type, &vals[0]);
         return false;
     }
     if (type.basetype == TypeDesc::FLOAT) {
         std::vector<float> vals;
-        py_to_stdvector (vals, obj);
-        if (vals.size() == type.numelements()*type.aggregate)
-            return OIIO::attribute (name, type, &vals[0]);
+        py_to_stdvector(vals, obj);
+        if (vals.size() == type.numelements() * type.aggregate)
+            return OIIO::attribute(name, type, &vals[0]);
         return false;
     }
     if (type.basetype == TypeDesc::STRING) {
         std::vector<std::string> vals;
-        py_to_stdvector (vals, obj);
-        if (vals.size() == type.numelements()*type.aggregate) {
+        py_to_stdvector(vals, obj);
+        if (vals.size() == type.numelements() * type.aggregate) {
             std::vector<ustring> u;
             for (auto& val : vals)
                 u.emplace_back(val);
-            return OIIO::attribute (name, type, &u[0]);
+            return OIIO::attribute(name, type, &u[0]);
         }
         return false;
     }
@@ -209,22 +217,21 @@ oiio_attribute_typed (const std::string &name, TypeDesc type,
 
 
 static py::object
-oiio_getattribute_typed (const std::string &name, TypeDesc type=TypeUnknown)
+oiio_getattribute_typed(const std::string& name, TypeDesc type = TypeUnknown)
 {
     if (type == TypeDesc::UNKNOWN)
         return py::none();
-    char *data = OIIO_ALLOCA(char, type.size());
-    if (! OIIO::getattribute (name, type, data))
+    char* data = OIIO_ALLOCA(char, type.size());
+    if (!OIIO::getattribute(name, type, data))
         return py::none();
     if (type.basetype == TypeDesc::INT)
-        return C_to_val_or_tuple ((const int *)data, type);
+        return C_to_val_or_tuple((const int*)data, type);
     if (type.basetype == TypeDesc::FLOAT)
-        return C_to_val_or_tuple ((const float *)data, type);
+        return C_to_val_or_tuple((const float*)data, type);
     if (type.basetype == TypeDesc::STRING)
-        return C_to_val_or_tuple ((const char **)data, type);
+        return C_to_val_or_tuple((const char**)data, type);
     return py::none();
 }
-
 
 
 
@@ -232,59 +239,64 @@ oiio_getattribute_typed (const std::string &name, TypeDesc type=TypeUnknown)
 // MODULE name as a #define. Google for Argument-Prescan for additional
 // info on why this is necessary
 
-#define OIIO_DECLARE_PYMODULE(x) PYBIND11_MODULE(x,m)
+#define OIIO_DECLARE_PYMODULE(x) PYBIND11_MODULE(x, m)
 
-OIIO_DECLARE_PYMODULE(OIIO_PYMODULE_NAME) {
-
+OIIO_DECLARE_PYMODULE(OIIO_PYMODULE_NAME)
+{
     // Basic helper classes
-    declare_typedesc (m);
-    declare_paramvalue (m);
-    declare_imagespec (m);
-    declare_roi (m);
-    declare_deepdata (m);
+    declare_typedesc(m);
+    declare_paramvalue(m);
+    declare_imagespec(m);
+    declare_roi(m);
+    declare_deepdata(m);
 
     // Main OIIO I/O classes
-    declare_imageinput (m);
-    declare_imageoutput (m);
-    declare_imagebuf (m);
-    declare_imagecache (m);
+    declare_imageinput(m);
+    declare_imageoutput(m);
+    declare_imagebuf(m);
+    declare_imagecache(m);
 
-    declare_imagebufalgo (m);
+    declare_imagebufalgo(m);
 
     // Global (OpenImageIO scope) functions and symbols
-    m.def("geterror",     &OIIO::geterror);
-    m.def("attribute", [](const std::string &name, float val){
-            OIIO::attribute(name,val);
-        });
-    m.def("attribute", [](const std::string &name, int val){
-            OIIO::attribute(name,val);
-        });
-    m.def("attribute", [](const std::string &name, const std::string &val){
-            OIIO::attribute(name,val);
-        });
-    m.def("attribute", [](const std::string &name, TypeDesc type, const py::tuple &obj) {
-            oiio_attribute_typed (name, type, obj);
-        });
+    m.def("geterror", &OIIO::geterror);
+    m.def("attribute", [](const std::string& name, float val) {
+        OIIO::attribute(name, val);
+    });
+    m.def("attribute",
+          [](const std::string& name, int val) { OIIO::attribute(name, val); });
+    m.def("attribute", [](const std::string& name, const std::string& val) {
+        OIIO::attribute(name, val);
+    });
+    m.def("attribute",
+          [](const std::string& name, TypeDesc type, const py::tuple& obj) {
+              oiio_attribute_typed(name, type, obj);
+          });
 
-    m.def("get_int_attribute", [](const std::string& name, int def) {
-            return OIIO::get_int_attribute (name, def); },
-          py::arg("name"), py::arg("defaultval")=0);
-    m.def("get_float_attribute", [](const std::string& name, float def) {
-            return OIIO::get_float_attribute (name, def); },
-         py::arg("name"), py::arg("defaultval")=0.0f);
-    m.def("get_string_attribute", [](const std::string& name, const std::string& def) {
-            return std::string(OIIO::get_string_attribute (name, def)); },
-         py::arg("name"), py::arg("defaultval")="");
-    m.def("getattribute",         &oiio_getattribute_typed);
-    m.attr("AutoStride") = AutoStride;
+    m.def("get_int_attribute",
+          [](const std::string& name, int def) {
+              return OIIO::get_int_attribute(name, def);
+          },
+          py::arg("name"), py::arg("defaultval") = 0);
+    m.def("get_float_attribute",
+          [](const std::string& name, float def) {
+              return OIIO::get_float_attribute(name, def);
+          },
+          py::arg("name"), py::arg("defaultval") = 0.0f);
+    m.def("get_string_attribute",
+          [](const std::string& name, const std::string& def) {
+              return std::string(OIIO::get_string_attribute(name, def));
+          },
+          py::arg("name"), py::arg("defaultval") = "");
+    m.def("getattribute", &oiio_getattribute_typed);
+    m.attr("AutoStride")          = AutoStride;
     m.attr("openimageio_version") = OIIO_VERSION;
-    m.attr("VERSION") = OIIO_VERSION;
-    m.attr("VERSION_STRING") = OIIO_VERSION_STRING;
-    m.attr("VERSION_MAJOR") = OIIO_VERSION_MAJOR;
-    m.attr("VERSION_MINOR") = OIIO_VERSION_MINOR;
-    m.attr("VERSION_PATCH") = OIIO_VERSION_PATCH;
-    m.attr("INTRO_STRING") = OIIO_INTRO_STRING;
+    m.attr("VERSION")             = OIIO_VERSION;
+    m.attr("VERSION_STRING")      = OIIO_VERSION_STRING;
+    m.attr("VERSION_MAJOR")       = OIIO_VERSION_MAJOR;
+    m.attr("VERSION_MINOR")       = OIIO_VERSION_MINOR;
+    m.attr("VERSION_PATCH")       = OIIO_VERSION_PATCH;
+    m.attr("INTRO_STRING")        = OIIO_INTRO_STRING;
 }
 
-} // namespace PyOpenImageIO
-
+}  // namespace PyOpenImageIO

--- a/src/python/py_paramvalue.cpp
+++ b/src/python/py_paramvalue.cpp
@@ -1,4 +1,4 @@
- /*
+/*
   Copyright 2009 Larry Gritz and the other authors and contributors.
   All Rights Reserved.
 
@@ -30,39 +30,39 @@
 
 #include "py_oiio.h"
 
-namespace PyOpenImageIO
-{
+namespace PyOpenImageIO {
 
 
 py::object
-ParamValue_getitem (const ParamValue& self, int n)
+ParamValue_getitem(const ParamValue& self, int n)
 {
     if (n < 0 || n >= self.nvalues()) {
-        throw std::out_of_range (Strutil::format("ParamValue index out of range %d", n));
+        throw std::out_of_range(
+            Strutil::format("ParamValue index out of range %d", n));
     }
 
     TypeDesc t = self.type();
 
-#define ParamValue_convert_dispatch(TYPE) \
-    case TypeDesc::TYPE: \
-    return C_to_val_or_tuple ((CType<TypeDesc::TYPE>::type*)self.data(), t)
+#define ParamValue_convert_dispatch(TYPE)                                      \
+    case TypeDesc::TYPE:                                                       \
+        return C_to_val_or_tuple((CType<TypeDesc::TYPE>::type*)self.data(), t)
 
     switch (t.basetype) {
-    // ParamValue_convert_dispatch(UCHAR);
-    // ParamValue_convert_dispatch(CHAR);
-    ParamValue_convert_dispatch(USHORT);
-    ParamValue_convert_dispatch(SHORT);
-    ParamValue_convert_dispatch(UINT);
-    ParamValue_convert_dispatch(INT);
-    // ParamValue_convert_dispatch(ULONGLONG);
-    // ParamValue_convert_dispatch(LONGLONG);
+        // ParamValue_convert_dispatch(UCHAR);
+        // ParamValue_convert_dispatch(CHAR);
+        ParamValue_convert_dispatch(USHORT);
+        ParamValue_convert_dispatch(SHORT);
+        ParamValue_convert_dispatch(UINT);
+        ParamValue_convert_dispatch(INT);
+        // ParamValue_convert_dispatch(ULONGLONG);
+        // ParamValue_convert_dispatch(LONGLONG);
 #ifdef _HALF_H_
-    ParamValue_convert_dispatch(HALF);
+        ParamValue_convert_dispatch(HALF);
 #endif
-    ParamValue_convert_dispatch(FLOAT);
-    ParamValue_convert_dispatch(DOUBLE);
+        ParamValue_convert_dispatch(FLOAT);
+        ParamValue_convert_dispatch(DOUBLE);
     case TypeDesc::STRING:
-        return C_to_val_or_tuple ((const char **)self.data(), t);
+        return C_to_val_or_tuple((const char**)self.data(), t);
     default: return py::none();
     }
 
@@ -71,64 +71,66 @@ ParamValue_getitem (const ParamValue& self, int n)
 
 
 
-
 void
-declare_paramvalue (py::module& m)
+declare_paramvalue(py::module& m)
 {
     using namespace pybind11::literals;
 
     py::enum_<ParamValue::Interp>(m, "Interp")
         .value("INTERP_CONSTANT", ParamValue::INTERP_CONSTANT)
         .value("INTERP_PERPIECE", ParamValue::INTERP_PERPIECE)
-        .value("INTERP_LINEAR",   ParamValue::INTERP_LINEAR)
-        .value("INTERP_VERTEX",   ParamValue::INTERP_VERTEX)
-    ;
+        .value("INTERP_LINEAR", ParamValue::INTERP_LINEAR)
+        .value("INTERP_VERTEX", ParamValue::INTERP_VERTEX);
 
     py::class_<ParamValue>(m, "ParamValue")
         .def_property_readonly("name",
-                      [](const ParamValue& p) { return p.name().string(); })
+                               [](const ParamValue& p) {
+                                   return p.name().string();
+                               })
         .def_property_readonly("type",
-                      [](const ParamValue& p) { return p.type().c_str(); })
+                               [](const ParamValue& p) {
+                                   return p.type().c_str();
+                               })
         .def_property_readonly("value",
-                      [](const ParamValue& p) { return ParamValue_getitem (p, 0); })
+                               [](const ParamValue& p) {
+                                   return ParamValue_getitem(p, 0);
+                               })
         // .def("__getitem__",       &ParamValue_getitem)
         .def_property_readonly("__len__", &ParamValue::nvalues)
         .def(py::init<const std::string&, int>())
         .def(py::init<const std::string&, float>())
-        .def(py::init<const std::string&, const std::string&>())
-    ;
+        .def(py::init<const std::string&, const std::string&>());
 
     py::class_<ParamValueList>(m, "ParamValueList")
         .def(py::init<>())
-        .def("__getitem__", [](ParamValueList& self, int i){ return self[i]; },
-            py::return_value_policy::reference_internal)
+        .def("__getitem__", [](ParamValueList& self, int i) { return self[i]; },
+             py::return_value_policy::reference_internal)
 
         // .def("__iter__", boost::python::iterator<ParamValueList>())
-        .def("__len__", [](const ParamValueList& p){ return p.size(); })
+        .def("__len__", [](const ParamValueList& p) { return p.size(); })
         // .def("grow",        &ParamValueList::grow,
         //     py::return_value_policy::reference_internal)
-        .def("append", [](ParamValueList& p, const ParamValue &v){ return p.push_back(v); })
-        .def("clear",       &ParamValueList::clear)
-        .def("free",        &ParamValueList::free)
-        .def("resize", [](ParamValueList& p, size_t s){ return p.resize(s); })
-        .def("remove", [](ParamValueList& p, const std::string& name,
-                          TypeDesc type, bool casesensitive) {
-                p.remove (name, type, casesensitive);
-            },
-            "name"_a, "type"_a=TypeUnknown, "casesensitive"_a=true)
-        .def("contains", [](ParamValueList& p, const std::string& name,
-                          TypeDesc type, bool casesensitive) {
-                return p.contains (name, type, casesensitive);
-            },
-            "name"_a, "type"_a=TypeUnknown, "casesensitive"_a=true)
-        .def("add_or_replace", [](ParamValueList& p, const ParamValue& pv,
-                                  bool casesensitive) {
-                return p.add_or_replace (pv, casesensitive);
-            },
-            "value"_a, "casesensitive"_a=true)
-        .def("sort", &ParamValueList::sort,
-             "casesensitive"_a=true)
-    ;
+        .def("append", [](ParamValueList& p,
+                          const ParamValue& v) { return p.push_back(v); })
+        .def("clear", &ParamValueList::clear)
+        .def("free", &ParamValueList::free)
+        .def("resize", [](ParamValueList& p, size_t s) { return p.resize(s); })
+        .def("remove",
+             [](ParamValueList& p, const std::string& name, TypeDesc type,
+                bool casesensitive) { p.remove(name, type, casesensitive); },
+             "name"_a, "type"_a = TypeUnknown, "casesensitive"_a = true)
+        .def("contains",
+             [](ParamValueList& p, const std::string& name, TypeDesc type,
+                bool casesensitive) {
+                 return p.contains(name, type, casesensitive);
+             },
+             "name"_a, "type"_a = TypeUnknown, "casesensitive"_a = true)
+        .def("add_or_replace",
+             [](ParamValueList& p, const ParamValue& pv, bool casesensitive) {
+                 return p.add_or_replace(pv, casesensitive);
+             },
+             "value"_a, "casesensitive"_a = true)
+        .def("sort", &ParamValueList::sort, "casesensitive"_a = true);
 }
 
-}
+}  // namespace PyOpenImageIO

--- a/src/python/py_roi.cpp
+++ b/src/python/py_roi.cpp
@@ -30,80 +30,81 @@
 
 #include "py_oiio.h"
 
-namespace PyOpenImageIO
-{
+namespace PyOpenImageIO {
 
 
 static ROI ROI_All;
 
 
-static bool roi_contains_coord (const ROI& roi, int x, int y, int z, int ch)
+static bool
+roi_contains_coord(const ROI& roi, int x, int y, int z, int ch)
 {
-    return roi.contains (x, y, z, ch);
+    return roi.contains(x, y, z, ch);
 }
 
 
-static bool roi_contains_roi (const ROI& roi, const ROI& other)
+static bool
+roi_contains_roi(const ROI& roi, const ROI& other)
 {
-    return roi.contains (other);
+    return roi.contains(other);
 }
 
 
 
 // Declare the OIIO ROI class to Python
-void declare_roi(py::module& m)
+void
+declare_roi(py::module& m)
 {
     using namespace py;
 
     py::class_<ROI>(m, "ROI")
-        .def_readwrite("xbegin",   &ROI::xbegin)
-        .def_readwrite("xend",     &ROI::xend)
-        .def_readwrite("ybegin",   &ROI::ybegin)
-        .def_readwrite("yend",     &ROI::yend)
-        .def_readwrite("zbegin",   &ROI::zbegin)
-        .def_readwrite("zend",     &ROI::zend)
-        .def_readwrite("chbegin",  &ROI::chbegin)
-        .def_readwrite("chend",    &ROI::chend)
+        .def_readwrite("xbegin", &ROI::xbegin)
+        .def_readwrite("xend", &ROI::xend)
+        .def_readwrite("ybegin", &ROI::ybegin)
+        .def_readwrite("yend", &ROI::yend)
+        .def_readwrite("zbegin", &ROI::zbegin)
+        .def_readwrite("zend", &ROI::zend)
+        .def_readwrite("chbegin", &ROI::chbegin)
+        .def_readwrite("chend", &ROI::chend)
 
         .def(py::init<>())
-        .def(py::init<int,int,int,int>())
-        .def(py::init<int,int,int,int,int,int>())
-        .def(py::init<int,int,int,int,int,int,int,int>())
+        .def(py::init<int, int, int, int>())
+        .def(py::init<int, int, int, int, int, int>())
+        .def(py::init<int, int, int, int, int, int, int, int>())
         .def(py::init<const ROI&>())
 
         // .def("defined",   [](const ROI& roi) { return (int)roi.defined(); })
-        .def_property_readonly("defined",   &ROI::defined)
-        .def_property_readonly("width",     &ROI::width)
-        .def_property_readonly("height",    &ROI::height)
-        .def_property_readonly("depth",     &ROI::depth)
+        .def_property_readonly("defined", &ROI::defined)
+        .def_property_readonly("width", &ROI::width)
+        .def_property_readonly("height", &ROI::height)
+        .def_property_readonly("depth", &ROI::depth)
         .def_property_readonly("nchannels", &ROI::nchannels)
-        .def_property_readonly("npixels",   &ROI::npixels)
-        .def("contains", &roi_contains_coord,
-             "x"_a, "y"_a, "z"_a=0, "ch"_a=0)
-        .def("contains", &roi_contains_roi,
-             "other"_a)
+        .def_property_readonly("npixels", &ROI::npixels)
+        .def("contains", &roi_contains_coord, "x"_a, "y"_a, "z"_a = 0,
+             "ch"_a = 0)
+        .def("contains", &roi_contains_roi, "other"_a)
 
-        .def_readonly_static("All",                &ROI_All)
+        .def_readonly_static("All", &ROI_All)
 
         // Conversion to string
-        .def("__str__", [](const ROI& roi){ return Strutil::format("%s", roi); })
+        .def("__str__",
+             [](const ROI& roi) { return Strutil::format("%s", roi); })
 
         // roi_union, roi_intersection, get_roi(spec), get_roi_full(spec)
         // set_roi(spec,newroi), set_roi_full(newroi)
 
         // overloaded operators
-       .def(py::self == py::self)    // operator==
-       .def(py::self != py::self)    // operator!=
-    ;
+        .def(py::self == py::self)  // operator==
+        .def(py::self != py::self)  // operator!=
+        ;
 
-    m.def("union",        &roi_union);
+    m.def("union", &roi_union);
     m.def("intersection", &roi_intersection);
-    m.def("get_roi",      &get_roi);
+    m.def("get_roi", &get_roi);
     m.def("get_roi_full", &get_roi_full);
-    m.def("set_roi",      &set_roi);
+    m.def("set_roi", &set_roi);
     m.def("set_roi_full", &set_roi_full);
 }
 
 
-} // namespace PyOpenImageIO
-
+}  // namespace PyOpenImageIO

--- a/src/python/py_typedesc.cpp
+++ b/src/python/py_typedesc.cpp
@@ -35,58 +35,56 @@ namespace PyOpenImageIO {
 
 
 // Declare the OIIO TypeDesc type to Python
-void declare_typedesc(py::module& m) {
-
+void
+declare_typedesc(py::module& m)
+{
     py::enum_<TypeDesc::BASETYPE>(m, "BASETYPE")
-        .value("UNKNOWN",   TypeDesc::UNKNOWN)
-        .value("NONE",      TypeDesc::NONE)
-        .value("UCHAR",     TypeDesc::UCHAR)
-        .value("UINT8",     TypeDesc::UINT8)
-        .value("CHAR",      TypeDesc::CHAR)
-        .value("INT8",      TypeDesc::INT8)
-        .value("UINT16",    TypeDesc::UINT16)
-        .value("USHORT",    TypeDesc::USHORT)
-        .value("SHORT",     TypeDesc::SHORT)
-        .value("INT16",     TypeDesc::INT16)
-        .value("UINT",      TypeDesc::UINT)
-        .value("UINT32",    TypeDesc::UINT32)
-        .value("INT",       TypeDesc::INT)
-        .value("INT32",     TypeDesc::INT32)
+        .value("UNKNOWN", TypeDesc::UNKNOWN)
+        .value("NONE", TypeDesc::NONE)
+        .value("UCHAR", TypeDesc::UCHAR)
+        .value("UINT8", TypeDesc::UINT8)
+        .value("CHAR", TypeDesc::CHAR)
+        .value("INT8", TypeDesc::INT8)
+        .value("UINT16", TypeDesc::UINT16)
+        .value("USHORT", TypeDesc::USHORT)
+        .value("SHORT", TypeDesc::SHORT)
+        .value("INT16", TypeDesc::INT16)
+        .value("UINT", TypeDesc::UINT)
+        .value("UINT32", TypeDesc::UINT32)
+        .value("INT", TypeDesc::INT)
+        .value("INT32", TypeDesc::INT32)
         .value("ULONGLONG", TypeDesc::ULONGLONG)
-        .value("UINT64",    TypeDesc::UINT64)
-        .value("LONGLONG",  TypeDesc::LONGLONG)
-        .value("INT64",     TypeDesc::INT64)
-        .value("HALF",      TypeDesc::HALF)
-        .value("FLOAT",     TypeDesc::FLOAT)
-        .value("DOUBLE",    TypeDesc::DOUBLE)
-        .value("STRING",    TypeDesc::STRING)
-        .value("PTR",       TypeDesc::PTR)
-        .value("LASTBASE",  TypeDesc::LASTBASE)
-        .export_values()
-    ;
+        .value("UINT64", TypeDesc::UINT64)
+        .value("LONGLONG", TypeDesc::LONGLONG)
+        .value("INT64", TypeDesc::INT64)
+        .value("HALF", TypeDesc::HALF)
+        .value("FLOAT", TypeDesc::FLOAT)
+        .value("DOUBLE", TypeDesc::DOUBLE)
+        .value("STRING", TypeDesc::STRING)
+        .value("PTR", TypeDesc::PTR)
+        .value("LASTBASE", TypeDesc::LASTBASE)
+        .export_values();
 
     py::enum_<TypeDesc::AGGREGATE>(m, "AGGREGATE")
-        .value("SCALAR",    TypeDesc::SCALAR)
-        .value("VEC2",      TypeDesc::VEC2)
-        .value("VEC3",      TypeDesc::VEC3)
-        .value("VEC4",      TypeDesc::VEC4)
-        .value("MATRIX33",  TypeDesc::MATRIX33)
-        .value("MATRIX44",  TypeDesc::MATRIX44)
-        .export_values()
-    ;
+        .value("SCALAR", TypeDesc::SCALAR)
+        .value("VEC2", TypeDesc::VEC2)
+        .value("VEC3", TypeDesc::VEC3)
+        .value("VEC4", TypeDesc::VEC4)
+        .value("MATRIX33", TypeDesc::MATRIX33)
+        .value("MATRIX44", TypeDesc::MATRIX44)
+        .export_values();
 
     py::enum_<TypeDesc::VECSEMANTICS>(m, "VECSEMANTICS")
-        .value("NOXFORM",  TypeDesc::NOXFORM)
+        .value("NOXFORM", TypeDesc::NOXFORM)
         .value("NOSEMANTICS", TypeDesc::NOSEMANTICS)
-        .value("COLOR",    TypeDesc::COLOR)
-        .value("POINT",    TypeDesc::POINT)
-        .value("VECTOR",   TypeDesc::VECTOR)
-        .value("NORMAL",   TypeDesc::NORMAL)
+        .value("COLOR", TypeDesc::COLOR)
+        .value("POINT", TypeDesc::POINT)
+        .value("VECTOR", TypeDesc::VECTOR)
+        .value("NORMAL", TypeDesc::NORMAL)
         .value("TIMECODE", TypeDesc::TIMECODE)
-        .value("KEYCODE",  TypeDesc::KEYCODE)
+        .value("KEYCODE", TypeDesc::KEYCODE)
         .value("RATIONAL", TypeDesc::RATIONAL)
-        .export_values()
-    ;
+        .export_values();
 
     py::class_<TypeDesc>(m, "TypeDesc")
         // basetype, aggregate, and vecsemantics should look like BASETYPE,
@@ -95,24 +93,36 @@ void declare_typedesc(py::module& m) {
         // use set_foo/get_foo wrappers, but from Python it looks like
         // regular member access.
         .def_property("basetype",
-            [](TypeDesc t){ return TypeDesc::BASETYPE(t.basetype); },
-            [](TypeDesc &t, TypeDesc::BASETYPE b){ return t.basetype = b; })
+                      [](TypeDesc t) { return TypeDesc::BASETYPE(t.basetype); },
+                      [](TypeDesc& t, TypeDesc::BASETYPE b) {
+                          return t.basetype = b;
+                      })
         .def_property("aggregate",
-            [](TypeDesc t){ return TypeDesc::AGGREGATE(t.aggregate); },
-            [](TypeDesc &t, TypeDesc::AGGREGATE b){ return t.aggregate = b; })
+                      [](TypeDesc t) {
+                          return TypeDesc::AGGREGATE(t.aggregate);
+                      },
+                      [](TypeDesc& t, TypeDesc::AGGREGATE b) {
+                          return t.aggregate = b;
+                      })
         .def_property("vecsemantics",
-            [](TypeDesc t){ return TypeDesc::VECSEMANTICS(t.vecsemantics); },
-            [](TypeDesc &t, TypeDesc::VECSEMANTICS b){ return t.vecsemantics = b; })
-        .def_readwrite("arraylen",      &TypeDesc::arraylen)
+                      [](TypeDesc t) {
+                          return TypeDesc::VECSEMANTICS(t.vecsemantics);
+                      },
+                      [](TypeDesc& t, TypeDesc::VECSEMANTICS b) {
+                          return t.vecsemantics = b;
+                      })
+        .def_readwrite("arraylen", &TypeDesc::arraylen)
         // Constructors: () [defined implicitly], (base), (base, agg),
         // (base,agg,vecsem), (base,agg,vecsem,arraylen), string.
         .def(py::init<>())
         .def(py::init<const TypeDesc&>())
         .def(py::init<TypeDesc::BASETYPE>())
         .def(py::init<TypeDesc::BASETYPE, TypeDesc::AGGREGATE>())
-        .def(py::init<TypeDesc::BASETYPE, TypeDesc::AGGREGATE, TypeDesc::VECSEMANTICS>())
-        .def(py::init<TypeDesc::BASETYPE, TypeDesc::AGGREGATE, TypeDesc::VECSEMANTICS, int>())
-        .def(py::init<const char *>())
+        .def(py::init<TypeDesc::BASETYPE, TypeDesc::AGGREGATE,
+                      TypeDesc::VECSEMANTICS>())
+        .def(py::init<TypeDesc::BASETYPE, TypeDesc::AGGREGATE,
+                      TypeDesc::VECSEMANTICS, int>())
+        .def(py::init<const char*>())
         // Unfortunately, overloading the int varieties, as we do in C++,
         // doesn't seem to work properly, it can't distinguish between an
         // int and an AGGREGATE, for example. Maybe in C++11 with strong
@@ -121,48 +131,50 @@ void declare_typedesc(py::module& m) {
         //   .def(init<TypeDesc::BASETYPE, int>())
         //   .def(init<TypeDesc::BASETYPE, TypeDesc::AGGREGATE, int>())
         // FIXME -- I bet this works with Pybind11
-        .def("c_str",            &TypeDesc::c_str)
-        .def("numelements",      &TypeDesc::numelements)
-        .def("basevalues",       &TypeDesc::basevalues)
-        .def("size",             &TypeDesc::size)
-        .def("elementtype",      &TypeDesc::elementtype)
-        .def("elementsize",      &TypeDesc::elementsize)
-        .def("basesize",         &TypeDesc::basesize)
-        .def("fromstring",       [](TypeDesc &t, const char* typestring){
-            t.fromstring (typestring); })
-        .def("equivalent",       &TypeDesc::equivalent)
-        .def("unarray",          &TypeDesc::unarray)
-        .def("is_vec3",          &TypeDesc::is_vec3)
-        .def("is_vec4",          &TypeDesc::is_vec4)
+        .def("c_str", &TypeDesc::c_str)
+        .def("numelements", &TypeDesc::numelements)
+        .def("basevalues", &TypeDesc::basevalues)
+        .def("size", &TypeDesc::size)
+        .def("elementtype", &TypeDesc::elementtype)
+        .def("elementsize", &TypeDesc::elementsize)
+        .def("basesize", &TypeDesc::basesize)
+        .def("fromstring",
+             [](TypeDesc& t, const char* typestring) {
+                 t.fromstring(typestring);
+             })
+        .def("equivalent", &TypeDesc::equivalent)
+        .def("unarray", &TypeDesc::unarray)
+        .def("is_vec3", &TypeDesc::is_vec3)
+        .def("is_vec4", &TypeDesc::is_vec4)
 
         // overloaded operators
-        .def(py::self == py::self)    // operator==
-        .def(py::self != py::self)    // operator!=
+        .def(py::self == py::self)  // operator==
+        .def(py::self != py::self)  // operator!=
 
         // Conversion to string
-        .def("__str__", [](TypeDesc t){ return PY_STR(t.c_str()); })
-        .def("__repr__", [](TypeDesc t){
-                return PY_STR("<TypeDesc '" + std::string(t.c_str()) + "'>");
-            })
+        .def("__str__", [](TypeDesc t) { return PY_STR(t.c_str()); })
+        .def("__repr__",
+             [](TypeDesc t) {
+                 return PY_STR("<TypeDesc '" + std::string(t.c_str()) + "'>");
+             })
 
         // Static members of pre-constructed types
         // DEPRECATED(1.8)
-        .def_readonly_static ("TypeFloat",    &TypeFloat)
-        .def_readonly_static ("TypeColor",    &TypeColor)
-        .def_readonly_static ("TypeString",   &TypeString)
-        .def_readonly_static ("TypeInt",      &TypeInt)
-        .def_readonly_static ("TypeHalf",     &TypeHalf)
-        .def_readonly_static ("TypePoint",    &TypePoint)
-        .def_readonly_static ("TypeVector",   &TypeVector)
-        .def_readonly_static ("TypeNormal",   &TypeNormal)
-        .def_readonly_static ("TypeMatrix",   &TypeMatrix)
-        .def_readonly_static ("TypeMatrix33", &TypeMatrix33)
-        .def_readonly_static ("TypeMatrix44", &TypeMatrix44)
-        .def_readonly_static ("TypeTimeCode", &TypeTimeCode)
-        .def_readonly_static ("TypeKeyCode",  &TypeKeyCode)
-        .def_readonly_static ("TypeRational", &TypeRational)
-        .def_readonly_static ("TypeFloat4",   &TypeFloat4)
-    ;
+        .def_readonly_static("TypeFloat", &TypeFloat)
+        .def_readonly_static("TypeColor", &TypeColor)
+        .def_readonly_static("TypeString", &TypeString)
+        .def_readonly_static("TypeInt", &TypeInt)
+        .def_readonly_static("TypeHalf", &TypeHalf)
+        .def_readonly_static("TypePoint", &TypePoint)
+        .def_readonly_static("TypeVector", &TypeVector)
+        .def_readonly_static("TypeNormal", &TypeNormal)
+        .def_readonly_static("TypeMatrix", &TypeMatrix)
+        .def_readonly_static("TypeMatrix33", &TypeMatrix33)
+        .def_readonly_static("TypeMatrix44", &TypeMatrix44)
+        .def_readonly_static("TypeTimeCode", &TypeTimeCode)
+        .def_readonly_static("TypeKeyCode", &TypeKeyCode)
+        .def_readonly_static("TypeRational", &TypeRational)
+        .def_readonly_static("TypeFloat4", &TypeFloat4);
 
     // Declare that a BASETYPE is implicitly convertible to a TypeDesc.
     // This keeps us from having to separately declare func(TypeDesc)
@@ -202,5 +214,4 @@ void declare_typedesc(py::module& m) {
 #endif
 }
 
-} // namespace PyOpenImageIO
-
+}  // namespace PyOpenImageIO

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -29,9 +29,9 @@
 */
 
 
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
-#include <cmath>
 #include <cstring>
 #include <ctime>
 #include <iostream>
@@ -42,18 +42,19 @@
 #include <OpenEXR/half.h>
 
 #include <OpenImageIO/argparse.h>
-#include <OpenImageIO/imageio.h>
-#include <OpenImageIO/ustring.h>
+#include <OpenImageIO/benchmark.h>
+#include <OpenImageIO/filesystem.h>
+#include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/imagebufalgo_util.h>
-#include <OpenImageIO/texture.h>
-#include <OpenImageIO/fmath.h>
-#include <OpenImageIO/filesystem.h>
-#include <OpenImageIO/sysutil.h>
+#include <OpenImageIO/imageio.h>
 #include <OpenImageIO/strutil.h>
+#include <OpenImageIO/sysutil.h>
+#include <OpenImageIO/texture.h>
 #include <OpenImageIO/timer.h>
-#include <OpenImageIO/benchmark.h>
+#include <OpenImageIO/ustring.h>
+
 #include "../libtexture/imagecache_pvt.h"
 
 using namespace OIIO;
@@ -62,64 +63,66 @@ using OIIO::_1;
 
 static std::vector<ustring> filenames;
 static std::string output_filename = "out.exr";
-static bool verbose = false;
-static int nthreads = 0;
-static int threadtimes = 0;
+static bool verbose                = false;
+static int nthreads                = 0;
+static int threadtimes             = 0;
 static int output_xres = 512, output_yres = 512;
-static int nchannels_override = 0;
+static int nchannels_override     = 0;
 static std::string dataformatname = "half";
 static float sscale = 1, tscale = 1;
 static float sblur = 0, tblur = -1;
-static float width = 1;
+static float width       = 1;
 static float anisoaspect = 1.0;  // anisotropic aspect ratio
-static std::string wrapmodes ("periodic");
-static int anisomax = TextureOpt().anisotropic;
-static int iters = 1;
-static int autotile = 0;
-static bool automip = false;
-static bool dedup = true;
+static std::string wrapmodes("periodic");
+static int anisomax           = TextureOpt().anisotropic;
+static int iters              = 1;
+static int autotile           = 0;
+static bool automip           = false;
+static bool dedup             = true;
 static bool test_construction = false;
-static bool test_gettexels = false;
+static bool test_gettexels    = false;
 static bool test_getimagespec = false;
-static bool filtertest = false;
-static TextureSystem *texsys = NULL;
+static bool filtertest        = false;
+static TextureSystem* texsys  = NULL;
 static std::string searchpath;
-static bool batch = false;
-static bool nowarp = false;
-static bool tube = false;
-static bool use_handle = false;
-static float cachesize = -1;
-static int maxfiles = -1;
-static int mipmode = TextureOpt::MipModeDefault;
-static int interpmode = TextureOpt::InterpSmartBicubic;
-static float missing[4] = {-1, 0, 0, 1};
-static float fill = -1;  // -1 signifies unset
+static bool batch        = false;
+static bool nowarp       = false;
+static bool tube         = false;
+static bool use_handle   = false;
+static float cachesize   = -1;
+static int maxfiles      = -1;
+static int mipmode       = TextureOpt::MipModeDefault;
+static int interpmode    = TextureOpt::InterpSmartBicubic;
+static float missing[4]  = { -1, 0, 0, 1 };
+static float fill        = -1;  // -1 signifies unset
 static float scalefactor = 1.0f;
-static Imath::V3f texoffset (0,0,0);
-static bool nountiled = false;
-static bool nounmipped = false;
-static bool gray_to_rgb = false;
-static bool flip_t = false;
-static bool resetstats = false;
-static bool testhash = false;
-static bool wedge = false;
-static int ntrials = 1;
-static int testicwrite = 0;
-static bool test_derivs = false;
-static bool test_statquery = false;
+static Imath::V3f texoffset(0, 0, 0);
+static bool nountiled              = false;
+static bool nounmipped             = false;
+static bool gray_to_rgb            = false;
+static bool flip_t                 = false;
+static bool resetstats             = false;
+static bool testhash               = false;
+static bool wedge                  = false;
+static int ntrials                 = 1;
+static int testicwrite             = 0;
+static bool test_derivs            = false;
+static bool test_statquery         = false;
 static bool invalidate_before_iter = true;
-static bool close_before_iter = false;
+static bool close_before_iter      = false;
 static Imath::M33f xform;
-void *dummyptr;
+void* dummyptr;
 
-typedef void (*Mapping2D)(const int&,const int&,float&,float&,float&,float&,float&,float&);
-typedef void (*Mapping3D)(const int&,const int&,Imath::V3f&,Imath::V3f&,Imath::V3f&,Imath::V3f &);
+typedef void (*Mapping2D)(const int&, const int&, float&, float&, float&,
+                          float&, float&, float&);
+typedef void (*Mapping3D)(const int&, const int&, Imath::V3f&, Imath::V3f&,
+                          Imath::V3f&, Imath::V3f&);
 
-typedef void (*Mapping2DWide)(const Tex::IntWide&,const Tex::IntWide&,
-                              Tex::FloatWide&,Tex::FloatWide&,
-                              Tex::FloatWide&,Tex::FloatWide&,
-                              Tex::FloatWide&,Tex::FloatWide&);
-typedef void (*Mapping3DWide)(const Tex::IntWide&,const Tex::IntWide&,
+typedef void (*Mapping2DWide)(const Tex::IntWide&, const Tex::IntWide&,
+                              Tex::FloatWide&, Tex::FloatWide&, Tex::FloatWide&,
+                              Tex::FloatWide&, Tex::FloatWide&,
+                              Tex::FloatWide&);
+typedef void (*Mapping3DWide)(const Tex::IntWide&, const Tex::IntWide&,
                               Imath::Vec3<Tex::FloatWide>&,
                               Imath::Vec3<Tex::FloatWide>&,
                               Imath::Vec3<Tex::FloatWide>&,
@@ -128,9 +131,9 @@ typedef void (*Mapping3DWide)(const Tex::IntWide&,const Tex::IntWide&,
 
 
 static int
-parse_files (int argc, const char *argv[])
+parse_files(int argc, const char* argv[])
 {
-    for (int i = 0;  i < argc;  i++)
+    for (int i = 0; i < argc; i++)
         filenames.emplace_back(argv[i]);
     return 0;
 }
@@ -138,10 +141,11 @@ parse_files (int argc, const char *argv[])
 
 
 static void
-getargs (int argc, const char *argv[])
+getargs(int argc, const char* argv[])
 {
     bool help = false;
     ArgParse ap;
+    // clang-format off
     ap.options ("Usage:  testtex [options] inputfile",
                   "%*", parse_files, "",
                   "--help", &help, "Print help message",
@@ -201,126 +205,135 @@ getargs (int argc, const char *argv[])
                   "--closebeforeiter", &close_before_iter, "Close all handles before each --iter",
                   "--testicwrite %d", &testicwrite, "Test ImageCache write ability (1=seeded, 2=generated)",
                   "--teststatquery", &test_statquery, "Test queries of statistics",
-                  NULL);
-    if (ap.parse (argc, argv) < 0) {
+                  nullptr);
+    // clang-format on
+    if (ap.parse(argc, argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
-        ap.usage ();
-        exit (EXIT_FAILURE);
+        ap.usage();
+        exit(EXIT_FAILURE);
     }
     if (help) {
-        ap.usage ();
-        exit (EXIT_FAILURE);
+        ap.usage();
+        exit(EXIT_FAILURE);
     }
 
-    if (filenames.size() < 1 &&
-          !test_construction && !test_getimagespec && !testhash) {
+    if (filenames.size() < 1 && !test_construction && !test_getimagespec
+        && !testhash) {
         std::cerr << "testtex: Must have at least one input file\n";
         ap.usage();
-        exit (EXIT_FAILURE);
+        exit(EXIT_FAILURE);
     }
 }
 
 
 
 static void
-initialize_opt (TextureOpt &opt, int nchannels)
+initialize_opt(TextureOpt& opt, int nchannels)
 {
-    opt.sblur = sblur;
-    opt.tblur = tblur >= 0.0f ? tblur : sblur;
-    opt.rblur = sblur;
+    opt.sblur  = sblur;
+    opt.tblur  = tblur >= 0.0f ? tblur : sblur;
+    opt.rblur  = sblur;
     opt.swidth = width;
     opt.twidth = width;
     opt.rwidth = width;
-//    opt.nchannels = nchannels;
+    //    opt.nchannels = nchannels;
     opt.fill = (fill >= 0.0f) ? fill : 1.0f;
     if (missing[0] >= 0)
-        opt.missingcolor = (float *)&missing;
-    TextureOpt::parse_wrapmodes (wrapmodes.c_str(), opt.swrap, opt.twrap);
-    opt.rwrap = opt.swrap;
+        opt.missingcolor = (float*)&missing;
+    TextureOpt::parse_wrapmodes(wrapmodes.c_str(), opt.swrap, opt.twrap);
+    opt.rwrap       = opt.swrap;
     opt.anisotropic = anisomax;
-    opt.mipmode = (TextureOpt::MipMode) mipmode;
-    opt.interpmode = (TextureOpt::InterpMode) interpmode;
+    opt.mipmode     = (TextureOpt::MipMode)mipmode;
+    opt.interpmode  = (TextureOpt::InterpMode)interpmode;
 }
 
 
 
 static void
-initialize_opt (TextureOptBatch &opt, int nchannels)
+initialize_opt(TextureOptBatch& opt, int nchannels)
 {
     using namespace Tex;
-    FloatWide sb(sblur); sb.store (opt.sblur);
-    FloatWide tb(tblur >= 0.0f ? tblur : sblur); tb.store (opt.tblur);
-    sb.store (opt.rblur);
-    FloatWide w (width);
-    w.store (opt.swidth);
-    w.store (opt.twidth);
-    w.store (opt.rwidth);
+    FloatWide sb(sblur);
+    sb.store(opt.sblur);
+    FloatWide tb(tblur >= 0.0f ? tblur : sblur);
+    tb.store(opt.tblur);
+    sb.store(opt.rblur);
+    FloatWide w(width);
+    w.store(opt.swidth);
+    w.store(opt.twidth);
+    w.store(opt.rwidth);
     opt.fill = (fill >= 0.0f) ? fill : 1.0f;
     if (missing[0] >= 0)
-        opt.missingcolor = (float *)&missing;
-    Tex::parse_wrapmodes (wrapmodes.c_str(), opt.swrap, opt.twrap);
-    opt.rwrap = opt.swrap;
+        opt.missingcolor = (float*)&missing;
+    Tex::parse_wrapmodes(wrapmodes.c_str(), opt.swrap, opt.twrap);
+    opt.rwrap       = opt.swrap;
     opt.anisotropic = anisomax;
-    opt.mipmode = MipMode(mipmode);
-    opt.interpmode = InterpMode(interpmode);
+    opt.mipmode     = MipMode(mipmode);
+    opt.interpmode  = InterpMode(interpmode);
 }
 
 
 
 static void
-test_gettextureinfo (ustring filename)
+test_gettextureinfo(ustring filename)
 {
     bool ok;
 
-    int res[2] = {0};
-    ok = texsys->get_texture_info (filename, 0, ustring("resolution"),
-                                   TypeDesc(TypeDesc::INT,2), res);
-    std::cout << "Result of get_texture_info resolution = " << ok << ' ' << res[0] << 'x' << res[1] << "\n";
+    int res[2] = { 0 };
+    ok         = texsys->get_texture_info(filename, 0, ustring("resolution"),
+                                  TypeDesc(TypeDesc::INT, 2), res);
+    std::cout << "Result of get_texture_info resolution = " << ok << ' '
+              << res[0] << 'x' << res[1] << "\n";
 
     int chan = 0;
-    ok = texsys->get_texture_info (filename, 0, ustring("channels"),
-                                   TypeDesc::INT, &chan);
-    std::cout << "Result of get_texture_info channels = " << ok << ' ' << chan << "\n";
+    ok       = texsys->get_texture_info(filename, 0, ustring("channels"),
+                                  TypeDesc::INT, &chan);
+    std::cout << "Result of get_texture_info channels = " << ok << ' ' << chan
+              << "\n";
 
     float fchan = 0;
-    ok = texsys->get_texture_info (filename, 0, ustring("channels"),
-                                   TypeDesc::FLOAT, &fchan);
-    std::cout << "Result of get_texture_info channels = " << ok << ' ' << fchan << "\n";
+    ok          = texsys->get_texture_info(filename, 0, ustring("channels"),
+                                  TypeDesc::FLOAT, &fchan);
+    std::cout << "Result of get_texture_info channels = " << ok << ' ' << fchan
+              << "\n";
 
     int dataformat = 0;
-    ok = texsys->get_texture_info (filename, 0, ustring("format"),
-                                   TypeDesc::INT, &dataformat);
+    ok = texsys->get_texture_info(filename, 0, ustring("format"), TypeDesc::INT,
+                                  &dataformat);
     std::cout << "Result of get_texture_info data format = " << ok << ' '
               << TypeDesc((TypeDesc::BASETYPE)dataformat).c_str() << "\n";
 
-    const char *datetime = NULL;
-    ok = texsys->get_texture_info (filename, 0, ustring("DateTime"),
-                                   TypeDesc::STRING, &datetime);
+    const char* datetime = NULL;
+    ok = texsys->get_texture_info(filename, 0, ustring("DateTime"),
+                                  TypeDesc::STRING, &datetime);
     std::cout << "Result of get_texture_info datetime = " << ok << ' '
               << (datetime ? datetime : "") << "\n";
 
     float avg[4];
-    ok = texsys->get_texture_info (filename, 0, ustring("averagecolor"),
-                                   TypeDesc(TypeDesc::FLOAT,4), avg);
-    std::cout << "Result of get_texture_info averagecolor = " << (ok?"yes":"no\n");
+    ok = texsys->get_texture_info(filename, 0, ustring("averagecolor"),
+                                  TypeDesc(TypeDesc::FLOAT, 4), avg);
+    std::cout << "Result of get_texture_info averagecolor = "
+              << (ok ? "yes" : "no\n");
     if (ok)
-        std::cout << " " << avg[0] << ' ' << avg[1] << ' '
-                  << avg[2] << ' ' << avg[3] << "\n";
-    ok = texsys->get_texture_info (filename, 0, ustring("averagealpha"),
-                                   TypeFloat, avg);
-    std::cout << "Result of get_texture_info averagealpha = " << (ok?"yes":"no\n");
+        std::cout << " " << avg[0] << ' ' << avg[1] << ' ' << avg[2] << ' '
+                  << avg[3] << "\n";
+    ok = texsys->get_texture_info(filename, 0, ustring("averagealpha"),
+                                  TypeFloat, avg);
+    std::cout << "Result of get_texture_info averagealpha = "
+              << (ok ? "yes" : "no\n");
     if (ok)
         std::cout << " " << avg[0] << "\n";
-    ok = texsys->get_texture_info (filename, 0, ustring("constantcolor"),
-                                   TypeDesc(TypeDesc::FLOAT,4), avg);
-    std::cout << "Result of get_texture_info constantcolor = " << (ok?"yes":"no\n");
+    ok = texsys->get_texture_info(filename, 0, ustring("constantcolor"),
+                                  TypeDesc(TypeDesc::FLOAT, 4), avg);
+    std::cout << "Result of get_texture_info constantcolor = "
+              << (ok ? "yes" : "no\n");
     if (ok)
-        std::cout << " " << avg[0] << ' ' << avg[1] << ' '
-                  << avg[2] << ' ' << avg[3] << "\n";
+        std::cout << " " << avg[0] << ' ' << avg[1] << ' ' << avg[2] << ' '
+                  << avg[3] << "\n";
 
-    const char *texturetype = NULL;
-    ok = texsys->get_texture_info (filename, 0, ustring("textureformat"),
-                                   TypeDesc::STRING, &texturetype);
+    const char* texturetype = NULL;
+    ok = texsys->get_texture_info(filename, 0, ustring("textureformat"),
+                                  TypeDesc::STRING, &texturetype);
     std::cout << "Texture type is " << ok << ' '
               << (texturetype ? texturetype : "") << "\n";
     std::cout << "\n";
@@ -328,31 +341,31 @@ test_gettextureinfo (ustring filename)
 
 
 
-template<typename Float=float>
+template<typename Float = float>
 inline Imath::Vec2<Float>
-warp (const Float& x, const Float& y, const Imath::M33f &xform)
+warp(const Float& x, const Float& y, const Imath::M33f& xform)
 {
-    Imath::Vec2<Float> coord (x, y);
-    xform.multVecMatrix (coord, coord);
+    Imath::Vec2<Float> coord(x, y);
+    xform.multVecMatrix(coord, coord);
     return coord;
 }
 
 
-template<typename Float=float>
+template<typename Float = float>
 inline Imath::Vec3<Float>
-warp (const Float& x, const Float& y, const Float& z, const Imath::M33f &xform)
+warp(const Float& x, const Float& y, const Float& z, const Imath::M33f& xform)
 {
-    Imath::Vec3<Float> coord (x, y, z);
+    Imath::Vec3<Float> coord(x, y, z);
     coord *= xform;
     return coord;
 }
 
 
-template<typename Float=float>
+template<typename Float = float>
 inline Imath::Vec2<Float>
-warp_coord (const Float& x, const Float& y)
+warp_coord(const Float& x, const Float& y)
 {
-    Imath::Vec2<Float> coord = warp (x/output_xres, y/output_yres, xform);
+    Imath::Vec2<Float> coord = warp(x / output_xres, y / output_yres, xform);
     coord.x *= sscale;
     coord.y *= tscale;
     coord += Imath::Vec2<Float>(texoffset.x, texoffset.y);
@@ -362,31 +375,35 @@ warp_coord (const Float& x, const Float& y)
 
 
 // Just map pixels to [0,1] st space
-template<typename Float=float, typename Int=int>
+template<typename Float = float, typename Int = int>
 void
-map_default (const Int& x, const Int& y, Float& s, Float& t,
-             Float& dsdx, Float& dtdx, Float& dsdy, Float& dtdy)
+map_default(const Int& x, const Int& y, Float& s, Float& t, Float& dsdx,
+            Float& dtdx, Float& dsdy, Float& dtdy)
 {
-    s = (Float(x)+0.5f)/output_xres * sscale + texoffset[0];
-    t = (Float(y)+0.5f)/output_yres * tscale + texoffset[1];
-    dsdx = 1.0f/output_xres * sscale;
+    s    = (Float(x) + 0.5f) / output_xres * sscale + texoffset[0];
+    t    = (Float(y) + 0.5f) / output_yres * tscale + texoffset[1];
+    dsdx = 1.0f / output_xres * sscale;
     dtdx = 0.0f;
     dsdy = 0.0f;
-    dtdy = 1.0f/output_yres * tscale;
+    dtdy = 1.0f / output_yres * tscale;
 }
 
 
 
-template<typename Float=float, typename Int=int>
+template<typename Float = float, typename Int = int>
 static void
-map_warp (const Int& x, const Int& y, Float &s, Float &t,
-          Float &dsdx, Float &dtdx, Float &dsdy, Float &dtdy)
+map_warp(const Int& x, const Int& y, Float& s, Float& t, Float& dsdx,
+         Float& dtdx, Float& dsdy, Float& dtdy)
 {
-    const Imath::Vec2<Float> coord  = warp_coord (Float(x)+0.5f, Float(y)+0.5f);
-    const Imath::Vec2<Float> coordx = warp_coord (Float(x)+1.5f, Float(y)+0.5f);
-    const Imath::Vec2<Float> coordy = warp_coord (Float(x)+0.5f, Float(y)+1.5f);
-    s = coord[0];
-    t = coord[1];
+    const Imath::Vec2<Float> coord  = warp_coord(Float(x) + 0.5f,
+                                                Float(y) + 0.5f);
+    const Imath::Vec2<Float> coordx = warp_coord(Float(x) + 1.5f,
+                                                 Float(y) + 0.5f);
+    const Imath::Vec2<Float> coordy = warp_coord(Float(x) + 0.5f,
+                                                 Float(y) + 1.5f);
+
+    s    = coord[0];
+    t    = coord[1];
     dsdx = coordx[0] - coord[0];
     dtdx = coordx[1] - coord[1];
     dsdy = coordy[0] - coord[0];
@@ -396,44 +413,44 @@ map_warp (const Int& x, const Int& y, Float &s, Float &t,
 
 
 static void
-map_tube (const int& x, const int& y, float &s, float &t,
-          float &dsdx, float &dtdx, float &dsdy, float &dtdy)
+map_tube(const int& x, const int& y, float& s, float& t, float& dsdx,
+         float& dtdx, float& dsdy, float& dtdy)
 {
-    float xt = (float(x)+0.5f)/output_xres - 0.5f;
-    float dxt_dx = 1.0f/output_xres;
-    float yt = (float(y)+0.5f)/output_yres - 0.5f;
-    float dyt_dy = 1.0f/output_yres;
-    float theta = atan2f (yt, xt);
+    float xt     = (float(x) + 0.5f) / output_xres - 0.5f;
+    float dxt_dx = 1.0f / output_xres;
+    float yt     = (float(y) + 0.5f) / output_yres - 0.5f;
+    float dyt_dy = 1.0f / output_yres;
+    float theta  = atan2f(yt, xt);
     // See OSL's Dual2 for partial derivs of
     // atan2, hypot, and 1/x
-    double denom = 1.0 / (xt*xt + yt*yt);
-    double dtheta_dx = yt*dxt_dx * denom;
-    double dtheta_dy = -xt*dyt_dy * denom;
-    s = float(4.0 * theta / (2.0 * M_PI));
-    dsdx = float(4.0 * dtheta_dx / (2.0 * M_PI));
-    dsdy = float(4.0 * dtheta_dy / (2.0 * M_PI));
-    double h = hypot(xt,yt);
-    double dh_dx = xt*dxt_dx / h;
-    double dh_dy = yt*dyt_dy / h;
+    double denom     = 1.0 / (xt * xt + yt * yt);
+    double dtheta_dx = yt * dxt_dx * denom;
+    double dtheta_dy = -xt * dyt_dy * denom;
+    s                = float(4.0 * theta / (2.0 * M_PI));
+    dsdx             = float(4.0 * dtheta_dx / (2.0 * M_PI));
+    dsdy             = float(4.0 * dtheta_dy / (2.0 * M_PI));
+    double h         = hypot(xt, yt);
+    double dh_dx     = xt * dxt_dx / h;
+    double dh_dy     = yt * dyt_dy / h;
     h *= M_SQRT2;
-    dh_dx *= M_SQRT2; dh_dy *= M_SQRT2;
+    dh_dx *= M_SQRT2;
+    dh_dy *= M_SQRT2;
     double hinv = 1.0 / h;
-    t = float(hinv);
-    dtdx = float(hinv * (-hinv * dh_dx));
-    dtdy = float(hinv * (-hinv * dh_dy));
+    t           = float(hinv);
+    dtdx        = float(hinv * (-hinv * dh_dx));
+    dtdy        = float(hinv * (-hinv * dh_dy));
 }
 
 
 
 // FIXME -- templatize map_tube. For now, just loop over scalar version.
 static void
-map_tube (const Tex::IntWide& x, const Tex::IntWide& y,
-          Tex::FloatWide& s, Tex::FloatWide& t,
-          Tex::FloatWide& dsdx, Tex::FloatWide& dtdx,
-          Tex::FloatWide& dsdy, Tex::FloatWide& dtdy)
+map_tube(const Tex::IntWide& x, const Tex::IntWide& y, Tex::FloatWide& s,
+         Tex::FloatWide& t, Tex::FloatWide& dsdx, Tex::FloatWide& dtdx,
+         Tex::FloatWide& dsdy, Tex::FloatWide& dtdy)
 {
     for (int i = 0; i < Tex::BatchWidth; ++i)
-        map_tube (x[i], y[i], s[i], t[i], dsdx[i], dtdx[i], dsdy[i], dtdy[i]);
+        map_tube(x[i], y[i], s[i], t[i], dsdx[i], dtdx[i], dsdy[i], dtdy[i]);
 }
 
 
@@ -452,133 +469,133 @@ map_tube (const Tex::IntWide& x, const Tex::IntWide& y,
 // MIP level.  (Though of course, there are other kinds of mistakes we
 // could be making, such as computing the wrong eccentricity or angle.)
 static void
-map_filtertest (const int& x, const int& y, float &s, float &t,
-                float &dsdx, float &dtdx, float &dsdy, float &dtdy)
+map_filtertest(const int& x, const int& y, float& s, float& t, float& dsdx,
+               float& dtdx, float& dsdy, float& dtdy)
 {
-    float minoraxis = 1.0f/256;
-    float majoraxis = minoraxis * lerp (1.0f, 32.0f, (float)x/(output_xres-1));
-    float angle = (float)(2.0 * M_PI * (double)y/(output_yres-1));
+    float minoraxis = 1.0f / 256;
+    float majoraxis = minoraxis
+                      * lerp(1.0f, 32.0f, (float)x / (output_xres - 1));
+    float angle = (float)(2.0 * M_PI * (double)y / (output_yres - 1));
     float sinangle, cosangle;
-    sincos (angle, &sinangle, &cosangle);
+    sincos(angle, &sinangle, &cosangle);
     s = 0.5f;
     t = 0.5f;
 
-    dsdx =  minoraxis * cosangle;
-    dtdx =  minoraxis * sinangle;
+    dsdx = minoraxis * cosangle;
+    dtdx = minoraxis * sinangle;
     dsdy = -majoraxis * sinangle;
-    dtdy =  majoraxis * cosangle;
+    dtdy = majoraxis * cosangle;
 }
 
 
 
 // FIXME -- templatize map_filtertest. For now, just loop over scalar version.
 static void
-map_filtertest (const Tex::IntWide& x, const Tex::IntWide& y,
-          Tex::FloatWide& s, Tex::FloatWide& t,
-          Tex::FloatWide& dsdx, Tex::FloatWide& dtdx,
-          Tex::FloatWide& dsdy, Tex::FloatWide& dtdy)
+map_filtertest(const Tex::IntWide& x, const Tex::IntWide& y, Tex::FloatWide& s,
+               Tex::FloatWide& t, Tex::FloatWide& dsdx, Tex::FloatWide& dtdx,
+               Tex::FloatWide& dsdy, Tex::FloatWide& dtdy)
 {
     for (int i = 0; i < Tex::BatchWidth; ++i)
-        map_filtertest (x[i], y[i], s[i], t[i],
-                        dsdx[i], dtdx[i], dsdy[i], dtdy[i]);
+        map_filtertest(x[i], y[i], s[i], t[i], dsdx[i], dtdx[i], dsdy[i],
+                       dtdy[i]);
 }
 
 
 
-template<typename Float=float, typename Int=int>
+template<typename Float = float, typename Int = int>
 void
-map_default_3D (const Int& x, const Int& y,
-                Imath::Vec3<Float> &P, Imath::Vec3<Float> &dPdx,
-                Imath::Vec3<Float> &dPdy, Imath::Vec3<Float> &dPdz)
+map_default_3D(const Int& x, const Int& y, Imath::Vec3<Float>& P,
+               Imath::Vec3<Float>& dPdx, Imath::Vec3<Float>& dPdy,
+               Imath::Vec3<Float>& dPdz)
 {
-    P[0] = (Float(x)+0.5f)/output_xres * sscale;
-    P[1] = (Float(y)+0.5f)/output_yres * tscale;
+    P[0] = (Float(x) + 0.5f) / output_xres * sscale;
+    P[1] = (Float(y) + 0.5f) / output_yres * tscale;
     P[2] = 0.5f * sscale;
     P += texoffset;
-    dPdx[0] = 1.0f/output_xres * sscale;
+    dPdx[0] = 1.0f / output_xres * sscale;
     dPdx[1] = 0;
     dPdx[2] = 0;
     dPdy[0] = 0;
-    dPdy[1] = 1.0f/output_yres * tscale;
+    dPdy[1] = 1.0f / output_yres * tscale;
     dPdy[2] = 0;
-    dPdz.setValue (0,0,0);
+    dPdz.setValue(0, 0, 0);
 }
 
 
 
-template<typename Float=float, typename Int=int>
+template<typename Float = float, typename Int = int>
 void
-map_warp_3D (const Int& x, const Int& y,
-             Imath::Vec3<Float> &P, Imath::Vec3<Float> &dPdx,
-             Imath::Vec3<Float> &dPdy, Imath::Vec3<Float> &dPdz)
+map_warp_3D(const Int& x, const Int& y, Imath::Vec3<Float>& P,
+            Imath::Vec3<Float>& dPdx, Imath::Vec3<Float>& dPdy,
+            Imath::Vec3<Float>& dPdz)
 {
-    Imath::Vec3<Float> coord = warp ((Float(x)/output_xres),
-                                     (Float(y)/output_yres),
-                                     Float(0.5), xform);
+    Imath::Vec3<Float> coord = warp((Float(x) / output_xres),
+                                    (Float(y) / output_yres), Float(0.5),
+                                    xform);
     coord.x *= sscale;
     coord.y *= tscale;
     coord += texoffset;
-    Imath::Vec3<Float> coordx = warp ((Float(x+1)/output_xres),
-                                      (Float(y)/output_yres),
-                                      Float(0.5), xform);
+    Imath::Vec3<Float> coordx = warp((Float(x + 1) / output_xres),
+                                     (Float(y) / output_yres), Float(0.5),
+                                     xform);
     coordx.x *= sscale;
     coordx.y *= tscale;
     coordx += texoffset;
-    Imath::Vec3<Float> coordy = warp ((Float(x)/output_xres),
-                                      (Float(y+1)/output_yres),
-                                      Float(0.5), xform);
+    Imath::Vec3<Float> coordy = warp((Float(x) / output_xres),
+                                     (Float(y + 1) / output_yres), Float(0.5),
+                                     xform);
     coordy.x *= sscale;
     coordy.y *= tscale;
     coordy += texoffset;
-    P = coord;
+    P    = coord;
     dPdx = coordx - coord;
     dPdy = coordy - coord;
-    dPdz.setValue (0,0,0);
+    dPdz.setValue(0, 0, 0);
 }
 
 
 
 void
-plain_tex_region (ImageBuf &image, ustring filename, Mapping2D mapping,
-                  ImageBuf *image_ds, ImageBuf *image_dt, ROI roi)
+plain_tex_region(ImageBuf& image, ustring filename, Mapping2D mapping,
+                 ImageBuf* image_ds, ImageBuf* image_dt, ROI roi)
 {
-    TextureSystem::Perthread *perthread_info = texsys->get_perthread_info ();
-    TextureSystem::TextureHandle *texture_handle = texsys->get_texture_handle (filename);
+    TextureSystem::Perthread* perthread_info     = texsys->get_perthread_info();
+    TextureSystem::TextureHandle* texture_handle = texsys->get_texture_handle(
+        filename);
     int nchannels = nchannels_override ? nchannels_override : image.nchannels();
 
     TextureOpt opt;
-    initialize_opt (opt, nchannels);
+    initialize_opt(opt, nchannels);
 
-    float *result = ALLOCA (float, std::max (3, nchannels));
-    float *dresultds = test_derivs ? ALLOCA (float, nchannels) : NULL;
-    float *dresultdt = test_derivs ? ALLOCA (float, nchannels) : NULL;
-    for (ImageBuf::Iterator<float> p (image, roi);  ! p.done();  ++p) {
+    float* result    = ALLOCA(float, std::max(3, nchannels));
+    float* dresultds = test_derivs ? ALLOCA(float, nchannels) : NULL;
+    float* dresultdt = test_derivs ? ALLOCA(float, nchannels) : NULL;
+    for (ImageBuf::Iterator<float> p(image, roi); !p.done(); ++p) {
         float s, t, dsdx, dtdx, dsdy, dtdy;
-        mapping (p.x(), p.y(), s, t, dsdx, dtdx, dsdy, dtdy);
+        mapping(p.x(), p.y(), s, t, dsdx, dtdx, dsdy, dtdy);
 
         // Call the texture system to do the filtering.
         bool ok;
         if (use_handle)
-            ok = texsys->texture (texture_handle, perthread_info, opt,
-                                  s, t, dsdx, dtdx, dsdy, dtdy,
-                                  nchannels, result, dresultds, dresultdt);
+            ok = texsys->texture(texture_handle, perthread_info, opt, s, t,
+                                 dsdx, dtdx, dsdy, dtdy, nchannels, result,
+                                 dresultds, dresultdt);
         else
-            ok = texsys->texture (filename, opt,
-                                  s, t, dsdx, dtdx, dsdy, dtdy,
-                                  nchannels, result, dresultds, dresultdt);
-        if (! ok) {
-            std::string e = texsys->geterror ();
-            if (! e.empty())
-                Strutil::fprintf (std::cerr, "ERROR: %s\n", e);
+            ok = texsys->texture(filename, opt, s, t, dsdx, dtdx, dsdy, dtdy,
+                                 nchannels, result, dresultds, dresultdt);
+        if (!ok) {
+            std::string e = texsys->geterror();
+            if (!e.empty())
+                Strutil::fprintf(std::cerr, "ERROR: %s\n", e);
         }
 
         // Save filtered pixels back to the image.
-        for (int i = 0;  i < nchannels;  ++i)
+        for (int i = 0; i < nchannels; ++i)
             result[i] *= scalefactor;
-        image.setpixel (p.x(), p.y(), result);
+        image.setpixel(p.x(), p.y(), result);
         if (test_derivs) {
-            image_ds->setpixel (p.x(), p.y(), dresultds);
-            image_dt->setpixel (p.x(), p.y(), dresultdt);
+            image_ds->setpixel(p.x(), p.y(), dresultds);
+            image_dt->setpixel(p.x(), p.y(), dresultdt);
         }
     }
 }
@@ -586,125 +603,126 @@ plain_tex_region (ImageBuf &image, ustring filename, Mapping2D mapping,
 
 
 void
-test_plain_texture (Mapping2D mapping)
+test_plain_texture(Mapping2D mapping)
 {
-    std::cout << "Testing 2d texture " << filenames[0] << ", output = "
-              << output_filename << "\n";
+    std::cout << "Testing 2d texture " << filenames[0]
+              << ", output = " << output_filename << "\n";
     const int nchannels = 4;
-    ImageSpec outspec (output_xres, output_yres, nchannels, TypeDesc::FLOAT);
-    ImageBuf image (outspec);
-    TypeDesc fmt (dataformatname);
-    image.set_write_format (fmt);
-    OIIO::ImageBufAlgo::zero (image);
+    ImageSpec outspec(output_xres, output_yres, nchannels, TypeDesc::FLOAT);
+    ImageBuf image(outspec);
+    TypeDesc fmt(dataformatname);
+    image.set_write_format(fmt);
+    OIIO::ImageBufAlgo::zero(image);
     ImageBuf image_ds, image_dt;
     if (test_derivs) {
-        image_ds.reset (outspec);
-        image_ds.set_write_format (fmt);
-        OIIO::ImageBufAlgo::zero (image_ds);
-        image_dt.reset (outspec);
-        OIIO::ImageBufAlgo::zero (image_dt);
-        image_dt.set_write_format (fmt);
+        image_ds.reset(outspec);
+        image_ds.set_write_format(fmt);
+        OIIO::ImageBufAlgo::zero(image_ds);
+        image_dt.reset(outspec);
+        OIIO::ImageBufAlgo::zero(image_dt);
+        image_dt.set_write_format(fmt);
     }
 
     ustring filename = filenames[0];
 
-    for (int iter = 0;  iter < iters;  ++iter) {
+    for (int iter = 0; iter < iters; ++iter) {
         if (iters > 1 && filenames.size() > 1) {
             // Use a different filename for each iteration
             int texid = iter % (int)filenames.size();
-            filename = (filenames[texid]);
+            filename  = (filenames[texid]);
             std::cout << "iter " << iter << " file " << filename << "\n";
         }
         if (close_before_iter)
-            texsys->close_all ();
+            texsys->close_all();
 
-        ImageBufAlgo::parallel_image (get_roi(image.spec()), nthreads,
-                std::bind(plain_tex_region, std::ref(image), filename, mapping,
-                          test_derivs ? &image_ds : NULL,
-                          test_derivs ? &image_dt : NULL, _1));
+        ImageBufAlgo::parallel_image(
+            get_roi(image.spec()), nthreads,
+            std::bind(plain_tex_region, std::ref(image), filename, mapping,
+                      test_derivs ? &image_ds : NULL,
+                      test_derivs ? &image_dt : NULL, _1));
         if (resetstats) {
             std::cout << texsys->getstats(2) << "\n";
-            texsys->reset_stats ();
+            texsys->reset_stats();
         }
     }
 
-    if (! image.write (output_filename))
-        Strutil::fprintf (std::cerr, "Error writing %s : %s\n",
-                          output_filename, image.geterror());
+    if (!image.write(output_filename))
+        Strutil::fprintf(std::cerr, "Error writing %s : %s\n", output_filename,
+                         image.geterror());
     if (test_derivs) {
-        if (! image_ds.write (output_filename+"-ds.exr"))
-            Strutil::fprintf (std::cerr, "Error writing %s : %s\n",
-                              (output_filename+"-ds.exr"), image_ds.geterror());
-        if (! image_dt.write (output_filename+"-dt.exr"))
-            Strutil::fprintf (std::cerr, "Error writing %s : %s\n",
-                              (output_filename+"-dt.exr"), image_dt.geterror());
+        if (!image_ds.write(output_filename + "-ds.exr"))
+            Strutil::fprintf(std::cerr, "Error writing %s : %s\n",
+                             (output_filename + "-ds.exr"),
+                             image_ds.geterror());
+        if (!image_dt.write(output_filename + "-dt.exr"))
+            Strutil::fprintf(std::cerr, "Error writing %s : %s\n",
+                             (output_filename + "-dt.exr"),
+                             image_dt.geterror());
     }
 }
 
 
 
 void
-plain_tex_region_batch (ImageBuf &image, ustring filename, Mapping2DWide mapping,
-                  ImageBuf *image_ds, ImageBuf *image_dt, const ROI roi)
+plain_tex_region_batch(ImageBuf& image, ustring filename, Mapping2DWide mapping,
+                       ImageBuf* image_ds, ImageBuf* image_dt, const ROI roi)
 {
     using namespace Tex;
-    TextureSystem::Perthread *perthread_info = texsys->get_perthread_info ();
-    TextureSystem::TextureHandle *texture_handle = texsys->get_texture_handle (filename);
+    TextureSystem::Perthread* perthread_info     = texsys->get_perthread_info();
+    TextureSystem::TextureHandle* texture_handle = texsys->get_texture_handle(
+        filename);
     int nchannels_img = image.nchannels();
     int nchannels = nchannels_override ? nchannels_override : image.nchannels();
-    DASSERT (image.spec().format == TypeDesc::FLOAT);
-    DASSERT (image_ds == nullptr || image_ds->spec().format == TypeDesc::FLOAT);
-    DASSERT (image_dt == nullptr || image_dt->spec().format == TypeDesc::FLOAT);
+    DASSERT(image.spec().format == TypeDesc::FLOAT);
+    DASSERT(image_ds == nullptr || image_ds->spec().format == TypeDesc::FLOAT);
+    DASSERT(image_dt == nullptr || image_dt->spec().format == TypeDesc::FLOAT);
 
     TextureOptBatch opt;
-    initialize_opt (opt, nchannels);
+    initialize_opt(opt, nchannels);
 
-    int nc = std::max (3, nchannels);
-    FloatWide *result = ALLOCA (FloatWide, nc);
-    FloatWide *dresultds = test_derivs ? ALLOCA (FloatWide, nc) : nullptr;
-    FloatWide *dresultdt = test_derivs ? ALLOCA (FloatWide, nc) : nullptr;
+    int nc               = std::max(3, nchannels);
+    FloatWide* result    = ALLOCA(FloatWide, nc);
+    FloatWide* dresultds = test_derivs ? ALLOCA(FloatWide, nc) : nullptr;
+    FloatWide* dresultdt = test_derivs ? ALLOCA(FloatWide, nc) : nullptr;
     for (int y = roi.ybegin; y < roi.yend; ++y) {
         for (int x = roi.xbegin; x < roi.xend; x += BatchWidth) {
             FloatWide s, t, dsdx, dtdx, dsdy, dtdy;
-            mapping (IntWide::Iota(x), y, s, t, dsdx, dtdx, dsdy, dtdy);
-            int npoints = std::min (BatchWidth, roi.xend - x);
+            mapping(IntWide::Iota(x), y, s, t, dsdx, dtdx, dsdy, dtdy);
+            int npoints  = std::min(BatchWidth, roi.xend - x);
             RunMask mask = RunMaskOn >> (BatchWidth - npoints);
             // Call the texture system to do the filtering.
             bool ok;
             if (use_handle)
-                ok = texsys->texture (texture_handle, perthread_info, opt,
-                                      mask, s.data(), t.data(),
-                                      dsdx.data(), dtdx.data(),
-                                      dsdy.data(), dtdy.data(),
-                                      nchannels, (float *)result,
-                                      (float *)dresultds, (float *)dresultdt);
+                ok = texsys->texture(texture_handle, perthread_info, opt, mask,
+                                     s.data(), t.data(), dsdx.data(),
+                                     dtdx.data(), dsdy.data(), dtdy.data(),
+                                     nchannels, (float*)result,
+                                     (float*)dresultds, (float*)dresultdt);
             else
-                ok = texsys->texture (filename, opt,
-                                      mask, s.data(), t.data(),
-                                      dsdx.data(), dtdx.data(),
-                                      dsdy.data(), dtdy.data(),
-                                      nchannels, (float *)result,
-                                      (float *)dresultds, (float *)dresultdt);
-            if (! ok) {
-                std::string e = texsys->geterror ();
-                if (! e.empty())
-                    Strutil::fprintf (std::cerr, "ERROR: %s\n", e);
+                ok = texsys->texture(filename, opt, mask, s.data(), t.data(),
+                                     dsdx.data(), dtdx.data(), dsdy.data(),
+                                     dtdy.data(), nchannels, (float*)result,
+                                     (float*)dresultds, (float*)dresultdt);
+            if (!ok) {
+                std::string e = texsys->geterror();
+                if (!e.empty())
+                    Strutil::fprintf(std::cerr, "ERROR: %s\n", e);
             }
             // Save filtered pixels back to the image.
-            for (int c = 0;  c < nchannels;  ++c)
+            for (int c = 0; c < nchannels; ++c)
                 result[c] *= scalefactor;
-            float *resultptr = (float *)image.pixeladdr (x, y);
+            float* resultptr = (float*)image.pixeladdr(x, y);
             // FIXME: simplify by using SIMD scatter
-            for (int c = 0;  c < nchannels;  ++c)
+            for (int c = 0; c < nchannels; ++c)
                 for (int i = 0; i < npoints; ++i)
-                    resultptr[c+i*nchannels_img] = result[c][i];
+                    resultptr[c + i * nchannels_img] = result[c][i];
             if (test_derivs) {
-                float *resultdsptr = (float *)image_ds->pixeladdr (x, y);
-                float *resultdtptr = (float *)image_dt->pixeladdr (x, y);
-                for (int c = 0;  c < nchannels;  ++c) {
+                float* resultdsptr = (float*)image_ds->pixeladdr(x, y);
+                float* resultdtptr = (float*)image_dt->pixeladdr(x, y);
+                for (int c = 0; c < nchannels; ++c) {
                     for (int i = 0; i < npoints; ++i) {
-                        resultdsptr[c+i*nchannels_img] = dresultds[c][i];
-                        resultdtptr[c+i*nchannels_img] = dresultdt[c][i];
+                        resultdsptr[c + i * nchannels_img] = dresultds[c][i];
+                        resultdtptr[c + i * nchannels_img] = dresultdt[c][i];
                     }
                 }
             }
@@ -715,150 +733,155 @@ plain_tex_region_batch (ImageBuf &image, ustring filename, Mapping2DWide mapping
 
 
 void
-test_plain_texture_batch (Mapping2DWide mapping)
+test_plain_texture_batch(Mapping2DWide mapping)
 {
-    std::cout << "Testing BATCHED 2d texture " << filenames[0] << ", output = "
-              << output_filename << "\n";
+    std::cout << "Testing BATCHED 2d texture " << filenames[0]
+              << ", output = " << output_filename << "\n";
     const int nchannels = 4;
-    ImageSpec outspec (output_xres, output_yres, nchannels, TypeDesc::FLOAT);
-    TypeDesc fmt (dataformatname);
-    ImageBuf image (outspec);
-    image.set_write_format (fmt);
-    OIIO::ImageBufAlgo::zero (image);
+    ImageSpec outspec(output_xres, output_yres, nchannels, TypeDesc::FLOAT);
+    TypeDesc fmt(dataformatname);
+    ImageBuf image(outspec);
+    image.set_write_format(fmt);
+    OIIO::ImageBufAlgo::zero(image);
     std::unique_ptr<ImageBuf> image_ds, image_dt;
     if (test_derivs) {
-        image_ds.reset (new ImageBuf (outspec));
-        image_ds->set_write_format (fmt);
-        OIIO::ImageBufAlgo::zero (*image_ds);
-        image_dt.reset (new ImageBuf (outspec));
-        image_dt->set_write_format (fmt);
-        OIIO::ImageBufAlgo::zero (*image_dt);
+        image_ds.reset(new ImageBuf(outspec));
+        image_ds->set_write_format(fmt);
+        OIIO::ImageBufAlgo::zero(*image_ds);
+        image_dt.reset(new ImageBuf(outspec));
+        image_dt->set_write_format(fmt);
+        OIIO::ImageBufAlgo::zero(*image_dt);
     }
 
     ustring filename = filenames[0];
 
-    for (int iter = 0;  iter < iters;  ++iter) {
+    for (int iter = 0; iter < iters; ++iter) {
         if (iters > 1 && filenames.size() > 1) {
             // Use a different filename for each iteration
             int texid = iter % (int)filenames.size();
-            filename = (filenames[texid]);
+            filename  = (filenames[texid]);
             std::cout << "iter " << iter << " file " << filename << "\n";
         }
         if (close_before_iter)
-            texsys->close_all ();
+            texsys->close_all();
 
-        ImageBufAlgo::parallel_image (get_roi(image.spec()), nthreads,
-                [&](ROI roi){
-                    plain_tex_region_batch (image, filename, mapping,
-                                      image_ds.get(), image_dt.get(), roi);
-                });
+        ImageBufAlgo::parallel_image(
+            get_roi(image.spec()), nthreads, [&](ROI roi) {
+                plain_tex_region_batch(image, filename, mapping, image_ds.get(),
+                                       image_dt.get(), roi);
+            });
         if (resetstats) {
             std::cout << texsys->getstats(2) << "\n";
-            texsys->reset_stats ();
+            texsys->reset_stats();
         }
     }
 
-    if (! image.write (output_filename))
-        Strutil::fprintf (std::cerr, "Error writing %s : %s\n",
-                          output_filename, image.geterror());
+    if (!image.write(output_filename))
+        Strutil::fprintf(std::cerr, "Error writing %s : %s\n", output_filename,
+                         image.geterror());
     if (test_derivs) {
-        if (! image_ds->write (output_filename+"-ds.exr"))
-            Strutil::fprintf (std::cerr, "Error writing %s : %s\n",
-                              (output_filename+"-ds.exr"), image_ds->geterror());
-        if (! image_dt->write (output_filename+"-dt.exr"))
-            Strutil::fprintf (std::cerr, "Error writing %s : %s\n",
-                              (output_filename+"-dt.exr"), image_dt->geterror());
+        if (!image_ds->write(output_filename + "-ds.exr"))
+            Strutil::fprintf(std::cerr, "Error writing %s : %s\n",
+                             (output_filename + "-ds.exr"),
+                             image_ds->geterror());
+        if (!image_dt->write(output_filename + "-dt.exr"))
+            Strutil::fprintf(std::cerr, "Error writing %s : %s\n",
+                             (output_filename + "-dt.exr"),
+                             image_dt->geterror());
     }
 }
 
 
 
 void
-tex3d_region (ImageBuf &image, ustring filename, Mapping3D mapping,
-              ROI roi)
+tex3d_region(ImageBuf& image, ustring filename, Mapping3D mapping, ROI roi)
 {
-    TextureSystem::Perthread *perthread_info = texsys->get_perthread_info ();
-    TextureSystem::TextureHandle *texture_handle = texsys->get_texture_handle (filename);
+    TextureSystem::Perthread* perthread_info     = texsys->get_perthread_info();
+    TextureSystem::TextureHandle* texture_handle = texsys->get_texture_handle(
+        filename);
     int nchannels = nchannels_override ? nchannels_override : image.nchannels();
 
     TextureOpt opt;
-    initialize_opt (opt, nchannels);
+    initialize_opt(opt, nchannels);
     opt.fill = (fill >= 0.0f) ? fill : 0.0f;
-//    opt.swrap = opt.twrap = opt.rwrap = TextureOpt::WrapPeriodic;
+    //    opt.swrap = opt.twrap = opt.rwrap = TextureOpt::WrapPeriodic;
 
-    float *result = ALLOCA (float, nchannels);
-    float *dresultds = test_derivs ? ALLOCA (float, nchannels) : NULL;
-    float *dresultdt = test_derivs ? ALLOCA (float, nchannels) : NULL;
-    float *dresultdr = test_derivs ? ALLOCA (float, nchannels) : NULL;
-    for (ImageBuf::Iterator<float> p (image, roi);  ! p.done();  ++p) {
+    float* result    = ALLOCA(float, nchannels);
+    float* dresultds = test_derivs ? ALLOCA(float, nchannels) : NULL;
+    float* dresultdt = test_derivs ? ALLOCA(float, nchannels) : NULL;
+    float* dresultdr = test_derivs ? ALLOCA(float, nchannels) : NULL;
+    for (ImageBuf::Iterator<float> p(image, roi); !p.done(); ++p) {
         Imath::V3f P, dPdx, dPdy, dPdz;
-        mapping (p.x(), p.y(), P, dPdx, dPdy, dPdz);
+        mapping(p.x(), p.y(), P, dPdx, dPdy, dPdz);
 
         // Call the texture system to do the filtering.
-        bool ok = texsys->texture3d (texture_handle, perthread_info, opt, 
-                                     P, dPdx, dPdy, dPdz, nchannels,
-                                     result, dresultds, dresultdt, dresultdr);
-        if (! ok) {
-            std::string e = texsys->geterror ();
-            if (! e.empty())
-                Strutil::fprintf (std::cerr, "ERROR: %s\n", e);
+        bool ok = texsys->texture3d(texture_handle, perthread_info, opt, P,
+                                    dPdx, dPdy, dPdz, nchannels, result,
+                                    dresultds, dresultdt, dresultdr);
+        if (!ok) {
+            std::string e = texsys->geterror();
+            if (!e.empty())
+                Strutil::fprintf(std::cerr, "ERROR: %s\n", e);
         }
 
         // Save filtered pixels back to the image.
-        for (int i = 0;  i < nchannels;  ++i)
+        for (int i = 0; i < nchannels; ++i)
             result[i] *= scalefactor;
-        image.setpixel (p.x(), p.y(), result);
+        image.setpixel(p.x(), p.y(), result);
     }
 }
 
 
 
 void
-tex3d_region_batch (ImageBuf &image, ustring filename, Mapping3DWide mapping, ROI roi)
+tex3d_region_batch(ImageBuf& image, ustring filename, Mapping3DWide mapping,
+                   ROI roi)
 {
     using namespace Tex;
-    TextureSystem::Perthread *perthread_info = texsys->get_perthread_info ();
-    TextureSystem::TextureHandle *texture_handle = texsys->get_texture_handle (filename);
+    TextureSystem::Perthread* perthread_info     = texsys->get_perthread_info();
+    TextureSystem::TextureHandle* texture_handle = texsys->get_texture_handle(
+        filename);
     int nchannels_img = image.nchannels();
     int nchannels = nchannels_override ? nchannels_override : image.nchannels();
 
     TextureOptBatch opt;
-    initialize_opt (opt, nchannels);
+    initialize_opt(opt, nchannels);
     opt.fill = (fill >= 0.0f) ? fill : 0.0f;
-//    opt.swrap = opt.twrap = opt.rwrap = TextureOpt::WrapPeriodic;
+    //    opt.swrap = opt.twrap = opt.rwrap = TextureOpt::WrapPeriodic;
 
-    FloatWide *result = ALLOCA (FloatWide, nchannels);
-    FloatWide *dresultds = test_derivs ? ALLOCA (FloatWide, nchannels) : NULL;
-    FloatWide *dresultdt = test_derivs ? ALLOCA (FloatWide, nchannels) : NULL;
-    FloatWide *dresultdr = test_derivs ? ALLOCA (FloatWide, nchannels) : NULL;
+    FloatWide* result    = ALLOCA(FloatWide, nchannels);
+    FloatWide* dresultds = test_derivs ? ALLOCA(FloatWide, nchannels) : NULL;
+    FloatWide* dresultdt = test_derivs ? ALLOCA(FloatWide, nchannels) : NULL;
+    FloatWide* dresultdr = test_derivs ? ALLOCA(FloatWide, nchannels) : NULL;
     for (int y = roi.ybegin; y < roi.yend; ++y) {
         for (int x = roi.xbegin; x < roi.xend; x += BatchWidth) {
             Imath::Vec3<FloatWide> P, dPdx, dPdy, dPdz;
-            mapping (IntWide::Iota(x), y, P, dPdx, dPdy, dPdz);
-            int npoints = std::min (BatchWidth, roi.xend - x);
+            mapping(IntWide::Iota(x), y, P, dPdx, dPdy, dPdz);
+            int npoints  = std::min(BatchWidth, roi.xend - x);
             RunMask mask = RunMaskOn >> (BatchWidth - npoints);
 
             // Call the texture system to do the filtering.
             if (y == 0 && x == 0)
                 std::cout << "P = " << P << "\n";
-            bool ok = texsys->texture3d (texture_handle, perthread_info, opt, mask,
-                                         (float*)&P, (float*)&dPdx, (float*)&dPdy, (float*)&dPdz, nchannels,
-                                         (float *)result, (float *)dresultds,
-                                         (float *)dresultdt, (float *)dresultdr);
-            if (! ok) {
-                std::string e = texsys->geterror ();
-                if (! e.empty())
-                    Strutil::fprintf (std::cerr, "ERROR: %s\n", e);
+            bool ok = texsys->texture3d(texture_handle, perthread_info, opt,
+                                        mask, (float*)&P, (float*)&dPdx,
+                                        (float*)&dPdy, (float*)&dPdz, nchannels,
+                                        (float*)result, (float*)dresultds,
+                                        (float*)dresultdt, (float*)dresultdr);
+            if (!ok) {
+                std::string e = texsys->geterror();
+                if (!e.empty())
+                    Strutil::fprintf(std::cerr, "ERROR: %s\n", e);
             }
 
             // Save filtered pixels back to the image.
-            for (int c = 0;  c < nchannels;  ++c)
+            for (int c = 0; c < nchannels; ++c)
                 result[c] *= scalefactor;
-            float *resultptr = (float *)image.pixeladdr (x, y);
+            float* resultptr = (float*)image.pixeladdr(x, y);
             // FIXME: simplify by using SIMD scatter
-            for (int c = 0;  c < nchannels;  ++c)
+            for (int c = 0; c < nchannels; ++c)
                 for (int i = 0; i < npoints; ++i)
-                    resultptr[c+i*nchannels_img] = result[c][i];
+                    resultptr[c + i * nchannels_img] = result[c][i];
         }
     }
 }
@@ -866,160 +889,162 @@ tex3d_region_batch (ImageBuf &image, ustring filename, Mapping3DWide mapping, RO
 
 
 void
-test_texture3d (ustring filename, Mapping3D mapping)
+test_texture3d(ustring filename, Mapping3D mapping)
 {
-    std::cout << "Testing 3d texture " << filename << ", output = "
-              << output_filename << "\n";
+    std::cout << "Testing 3d texture " << filename
+              << ", output = " << output_filename << "\n";
     int nchannels = nchannels_override ? nchannels_override : 4;
-    ImageSpec outspec (output_xres, output_yres, nchannels, TypeDesc::FLOAT);
-    ImageBuf image (outspec);
-    TypeDesc fmt (dataformatname);
-    image.set_write_format (fmt);
-    OIIO::ImageBufAlgo::zero (image);
+    ImageSpec outspec(output_xres, output_yres, nchannels, TypeDesc::FLOAT);
+    ImageBuf image(outspec);
+    TypeDesc fmt(dataformatname);
+    image.set_write_format(fmt);
+    OIIO::ImageBufAlgo::zero(image);
 
-    for (int iter = 0;  iter < iters;  ++iter) {
+    for (int iter = 0; iter < iters; ++iter) {
         // Trick: switch to second texture, if given, for second iteration
         if (iter && filenames.size() > 1)
             filename = filenames[1];
         if (close_before_iter)
-            texsys->close_all ();
-        ImageBufAlgo::parallel_image (get_roi(image.spec()), nthreads,
-                std::bind(tex3d_region, std::ref(image), filename, mapping, _1));
+            texsys->close_all();
+        ImageBufAlgo::parallel_image(get_roi(image.spec()), nthreads,
+                                     std::bind(tex3d_region, std::ref(image),
+                                               filename, mapping, _1));
     }
 
-    if (! image.write (output_filename)) 
-        Strutil::fprintf (std::cerr, "Error writing %s : %s\n",
-                          output_filename, image.geterror());
+    if (!image.write(output_filename))
+        Strutil::fprintf(std::cerr, "Error writing %s : %s\n", output_filename,
+                         image.geterror());
 }
 
 
 
 void
-test_texture3d_batch (ustring filename, Mapping3DWide mapping)
+test_texture3d_batch(ustring filename, Mapping3DWide mapping)
 {
-    std::cout << "Testing 3d texture " << filename << ", output = "
-              << output_filename << "\n";
+    std::cout << "Testing 3d texture " << filename
+              << ", output = " << output_filename << "\n";
     int nchannels = nchannels_override ? nchannels_override : 4;
-    ImageSpec outspec (output_xres, output_yres, nchannels, TypeDesc::FLOAT);
-    ImageBuf image (outspec);
-    TypeDesc fmt (dataformatname);
-    image.set_write_format (fmt);
-    OIIO::ImageBufAlgo::zero (image);
+    ImageSpec outspec(output_xres, output_yres, nchannels, TypeDesc::FLOAT);
+    ImageBuf image(outspec);
+    TypeDesc fmt(dataformatname);
+    image.set_write_format(fmt);
+    OIIO::ImageBufAlgo::zero(image);
 
-    for (int iter = 0;  iter < iters;  ++iter) {
+    for (int iter = 0; iter < iters; ++iter) {
         // Trick: switch to second texture, if given, for second iteration
         if (iter && filenames.size() > 1)
             filename = filenames[1];
         if (close_before_iter)
-            texsys->close_all ();
-        ImageBufAlgo::parallel_image (get_roi(image.spec()), nthreads,
-                [&](ROI roi){
-                    tex3d_region_batch (image, filename, mapping, roi);
-                });
+            texsys->close_all();
+        ImageBufAlgo::parallel_image(get_roi(image.spec()), nthreads,
+                                     [&](ROI roi) {
+                                         tex3d_region_batch(image, filename,
+                                                            mapping, roi);
+                                     });
     }
 
-    if (! image.write (output_filename)) 
-        Strutil::fprintf (std::cerr, "Error writing %s : %s\n",
-                          output_filename, image.geterror());
+    if (!image.write(output_filename))
+        Strutil::fprintf(std::cerr, "Error writing %s : %s\n", output_filename,
+                         image.geterror());
 }
 
 
 
 static void
-test_shadow (ustring filename)
+test_shadow(ustring filename)
 {
 }
 
 
 
 static void
-test_environment (ustring filename)
+test_environment(ustring filename)
 {
 }
 
 
 
 static void
-test_getimagespec_gettexels (ustring filename)
+test_getimagespec_gettexels(ustring filename)
 {
     ImageSpec spec;
     int miplevel = 0;
-    if (! texsys->get_imagespec (filename, 0, spec)) {
-        Strutil::fprintf (std::cerr, "Could not get spec for %s\n", filename);
-        std::string e = texsys->geterror ();
-        if (! e.empty())
-            Strutil::fprintf (std::cerr, "ERROR: %s\n", e);
+    if (!texsys->get_imagespec(filename, 0, spec)) {
+        Strutil::fprintf(std::cerr, "Could not get spec for %s\n", filename);
+        std::string e = texsys->geterror();
+        if (!e.empty())
+            Strutil::fprintf(std::cerr, "ERROR: %s\n", e);
         return;
     }
 
-    if (! test_gettexels)
+    if (!test_gettexels)
         return;
 
-    int w = std::min (spec.width, output_xres);
-    int h = std::min (spec.height, output_yres);
+    int w         = std::min(spec.width, output_xres);
+    int h         = std::min(spec.height, output_yres);
     int nchannels = nchannels_override ? nchannels_override : spec.nchannels;
-    ImageSpec postagespec (w, h, nchannels, TypeDesc::FLOAT);
-    ImageBuf buf (postagespec);
+    ImageSpec postagespec(w, h, nchannels, TypeDesc::FLOAT);
+    ImageBuf buf(postagespec);
     TextureOpt opt;
-    initialize_opt (opt, nchannels);
-    std::vector<float> tmp (w*h*nchannels);
-    int x = spec.x + spec.width/2 - w/2;
-    int y = spec.y + spec.height/2 - h/2;
+    initialize_opt(opt, nchannels);
+    std::vector<float> tmp(w * h * nchannels);
+    int x = spec.x + spec.width / 2 - w / 2;
+    int y = spec.y + spec.height / 2 - h / 2;
     for (int i = 0; i < iters; ++i) {
-        bool ok = texsys->get_texels (filename, opt, miplevel,
-                                      x, x+w, y, y+h, 0, 1, 0, nchannels,
-                                      postagespec.format, &tmp[0]);
-        if (! ok)
-            Strutil::fprintf (std::cerr, "ERROR: %s\n", texsys->geterror());
+        bool ok = texsys->get_texels(filename, opt, miplevel, x, x + w, y,
+                                     y + h, 0, 1, 0, nchannels,
+                                     postagespec.format, &tmp[0]);
+        if (!ok)
+            Strutil::fprintf(std::cerr, "ERROR: %s\n", texsys->geterror());
     }
-    for (int y = 0;  y < h;  ++y)
-        for (int x = 0;  x < w;  ++x) {
-            imagesize_t texoffset = (y*w + x) * spec.nchannels;
-            buf.setpixel (x, y, &tmp[texoffset]);
+    for (int y = 0; y < h; ++y)
+        for (int x = 0; x < w; ++x) {
+            imagesize_t texoffset = (y * w + x) * spec.nchannels;
+            buf.setpixel(x, y, &tmp[texoffset]);
         }
-    TypeDesc fmt (dataformatname);
+    TypeDesc fmt(dataformatname);
     if (fmt != TypeDesc::UNKNOWN)
-        buf.set_write_format (fmt);
-    buf.write (output_filename);
+        buf.set_write_format(fmt);
+    buf.write(output_filename);
 }
 
 
 
 static void
-test_hash ()
+test_hash()
 {
-    std::vector<size_t> fourbits (1<<4, 0);
-    std::vector<size_t> eightbits (1<<8, 0);
-    std::vector<size_t> sixteenbits (1<<16, 0);
-    std::vector<size_t> highereightbits (1<<8, 0);
+    std::vector<size_t> fourbits(1 << 4, 0);
+    std::vector<size_t> eightbits(1 << 8, 0);
+    std::vector<size_t> sixteenbits(1 << 16, 0);
+    std::vector<size_t> highereightbits(1 << 8, 0);
 
     const size_t iters = 1000000;
-    const int res = 4*1024;  // Simulate tiles from a 4k image
+    const int res      = 4 * 1024;  // Simulate tiles from a 4k image
     const int tilesize = 64;
-    const int nfiles = iters / ((res/tilesize)*(res/tilesize));
-    std::cout << "Testing hashing with " << nfiles << " files of "
-              << res << 'x' << res << " with " << tilesize << 'x' << tilesize
-              << " tiles:\n";
+    const int nfiles   = iters / ((res / tilesize) * (res / tilesize));
+    std::cout << "Testing hashing with " << nfiles << " files of " << res << 'x'
+              << res << " with " << tilesize << 'x' << tilesize << " tiles:\n";
 
-    ImageCache *imagecache = ImageCache::create ();
+    ImageCache* imagecache = ImageCache::create();
 
     // Set up the ImageCacheFiles outside of the timing loop
-    using OIIO::pvt::ImageCacheImpl;
     using OIIO::pvt::ImageCacheFile;
     using OIIO::pvt::ImageCacheFileRef;
+    using OIIO::pvt::ImageCacheImpl;
     std::vector<ImageCacheFileRef> icf;
-    for (int f = 0;  f < nfiles;  ++f) {
-        ustring filename = ustring::format ("%06d.tif", f);
-        icf.push_back (new ImageCacheFile(*(ImageCacheImpl *)imagecache, NULL, filename));
+    for (int f = 0; f < nfiles; ++f) {
+        ustring filename = ustring::format("%06d.tif", f);
+        icf.push_back(
+            new ImageCacheFile(*(ImageCacheImpl*)imagecache, NULL, filename));
     }
 
     // First, just try to do raw timings of the hash
     Timer timer;
     size_t i = 0, hh = 0;
-    for (int f = 0;  f < nfiles;  ++f) {
-        for (int y = 0;  y < res;  y += tilesize) {
-            for (int x = 0;  x < res;  x += tilesize, ++i) {
-                OIIO::pvt::TileID id (*icf[f], 0, 0, x, y, 0);
+    for (int f = 0; f < nfiles; ++f) {
+        for (int y = 0; y < res; y += tilesize) {
+            for (int x = 0; x < res; x += tilesize, ++i) {
+                OIIO::pvt::TileID id(*icf[f], 0, 0, x, y, 0);
                 size_t h = id.hash();
                 hh += h;
             }
@@ -1027,23 +1052,23 @@ test_hash ()
     }
     std::cout << "hh = " << hh << "\n";
     double time = timer();
-    double rate = (i/1.0e6) / time;
-    std::cout << "Hashing rate: " << Strutil::format ("%3.2f", rate)
+    double rate = (i / 1.0e6) / time;
+    std::cout << "Hashing rate: " << Strutil::format("%3.2f", rate)
               << " Mhashes/sec\n";
 
     // Now, check the quality of the hash by looking at the low 4, 8, and
     // 16 bits and making sure that they divide into hash buckets fairly
     // evenly.
     i = 0;
-    for (int f = 0;  f < nfiles;  ++f) {
-        for (int y = 0;  y < res;  y += tilesize) {
-            for (int x = 0;  x < res;  x += tilesize, ++i) {
-                OIIO::pvt::TileID id (*icf[f], 0, 0, x, y, 0);
+    for (int f = 0; f < nfiles; ++f) {
+        for (int y = 0; y < res; y += tilesize) {
+            for (int x = 0; x < res; x += tilesize, ++i) {
+                OIIO::pvt::TileID id(*icf[f], 0, 0, x, y, 0);
                 size_t h = id.hash();
-                ++ fourbits[h & 0xf];
-                ++ eightbits[h & 0xff];
-                ++ highereightbits[(h>>24) & 0xff];
-                ++ sixteenbits[h & 0xffff];
+                ++fourbits[h & 0xf];
+                ++eightbits[h & 0xff];
+                ++highereightbits[(h >> 24) & 0xff];
+                ++sixteenbits[h & 0xffff];
                 // if (i < 16) std::cout << Strutil::format("%llx\n", h);
             }
         }
@@ -1052,48 +1077,56 @@ test_hash ()
     size_t min, max;
     min = std::numeric_limits<size_t>::max();
     max = 0;
-    for (int i = 0;  i < 16;  ++i) {
-        if (fourbits[i] < min) min = fourbits[i];
-        if (fourbits[i] > max) max = fourbits[i];
+    for (int i = 0; i < 16; ++i) {
+        if (fourbits[i] < min)
+            min = fourbits[i];
+        if (fourbits[i] > max)
+            max = fourbits[i];
     }
-    std::cout << "4-bit hash buckets range from "
-              << min << " to " << max << "\n";
+    std::cout << "4-bit hash buckets range from " << min << " to " << max
+              << "\n";
 
     min = std::numeric_limits<size_t>::max();
     max = 0;
-    for (int i = 0;  i < 256;  ++i) {
-        if (eightbits[i] < min) min = eightbits[i];
-        if (eightbits[i] > max) max = eightbits[i];
+    for (int i = 0; i < 256; ++i) {
+        if (eightbits[i] < min)
+            min = eightbits[i];
+        if (eightbits[i] > max)
+            max = eightbits[i];
     }
-    std::cout << "8-bit hash buckets range from "
-              << min << " to " << max << "\n";
+    std::cout << "8-bit hash buckets range from " << min << " to " << max
+              << "\n";
 
     min = std::numeric_limits<size_t>::max();
     max = 0;
-    for (int i = 0;  i < 256;  ++i) {
-        if (highereightbits[i] < min) min = highereightbits[i];
-        if (highereightbits[i] > max) max = highereightbits[i];
+    for (int i = 0; i < 256; ++i) {
+        if (highereightbits[i] < min)
+            min = highereightbits[i];
+        if (highereightbits[i] > max)
+            max = highereightbits[i];
     }
-    std::cout << "higher 8-bit hash buckets range from "
-              << min << " to " << max << "\n";
+    std::cout << "higher 8-bit hash buckets range from " << min << " to " << max
+              << "\n";
 
     min = std::numeric_limits<size_t>::max();
     max = 0;
-    for (int i = 0;  i < (1<<16);  ++i) {
-        if (sixteenbits[i] < min) min = sixteenbits[i];
-        if (sixteenbits[i] > max) max = sixteenbits[i];
+    for (int i = 0; i < (1 << 16); ++i) {
+        if (sixteenbits[i] < min)
+            min = sixteenbits[i];
+        if (sixteenbits[i] > max)
+            max = sixteenbits[i];
     }
-    std::cout << "16-bit hash buckets range from "
-              << min << " to " << max << "\n";
+    std::cout << "16-bit hash buckets range from " << min << " to " << max
+              << "\n";
 
     std::cout << "\n";
 
-    ImageCache::destroy (imagecache);
+    ImageCache::destroy(imagecache);
 }
 
 
 
-static const char *workload_names[] = {
+static const char* workload_names[] = {
     /*0*/ "None",
     /*1*/ "Everybody accesses the same spot in one file (handles)",
     /*2*/ "Everybody accesses the same spot in one file",
@@ -1109,44 +1142,45 @@ static const char *workload_names[] = {
 
 
 void
-do_tex_thread_workout (int iterations, int mythread)
+do_tex_thread_workout(int iterations, int mythread)
 {
-    int nfiles = (int) filenames.size();
+    int nfiles = (int)filenames.size();
     float s = 0.1f, t = 0.1f;
     int nchannels = nchannels_override ? nchannels_override : 3;
-    float *result = ALLOCA (float, nchannels);
+    float* result = ALLOCA(float, nchannels);
     TextureOpt opt;
-    initialize_opt (opt, nchannels);
-    float *dresultds = test_derivs ? ALLOCA (float, nchannels) : NULL;
-    float *dresultdt = test_derivs ? ALLOCA (float, nchannels) : NULL;
-    TextureSystem::Perthread *perthread_info = texsys->get_perthread_info ();
+    initialize_opt(opt, nchannels);
+    float* dresultds = test_derivs ? ALLOCA(float, nchannels) : NULL;
+    float* dresultdt = test_derivs ? ALLOCA(float, nchannels) : NULL;
+    TextureSystem::Perthread* perthread_info = texsys->get_perthread_info();
     int pixel, whichfile = 0;
 
-    std::vector<TextureSystem::TextureHandle *> texture_handles;
+    std::vector<TextureSystem::TextureHandle*> texture_handles;
     for (auto f : filenames)
-        texture_handles.emplace_back (texsys->get_texture_handle(f));
+        texture_handles.emplace_back(texsys->get_texture_handle(f));
 
     ImageSpec spec0;
-    bool ok = texsys->get_imagespec (filenames[0], 0, spec0);
+    bool ok = texsys->get_imagespec(filenames[0], 0, spec0);
     if (!ok) {
-        Strutil::fprintf (std::cerr, "Unexpected error: %s\n", texsys->geterror());
+        Strutil::fprintf(std::cerr, "Unexpected error: %s\n",
+                         texsys->geterror());
         return;
     }
     // Compute a filter size that's between the second and third MIP levels.
-    float fw = (1.0f / spec0.width) * 1.5f * 2.0;
-    float fh = (1.0f / spec0.height) * 1.5f * 2.0;
+    float fw   = (1.0f / spec0.width) * 1.5f * 2.0;
+    float fh   = (1.0f / spec0.height) * 1.5f * 2.0;
     float dsdx = fw, dtdx = 0.0f, dsdy = 0.0f, dtdy = fh;
     if (anisoaspect > 1.001f) {
         // Make an ellipse 30 degrees off horizontal, with given aspect
-        float xs = sqrtf(3.0)/2.0, ys = 0.5f;
+        float xs = sqrtf(3.0) / 2.0, ys = 0.5f;
         dsdx = fw * xs * anisoaspect;
         dtdx = fh * ys * anisoaspect;
         dsdy = fw * ys;
         dtdy = -fh * xs;
     }
 
-    for (int i = 0;  i < iterations;  ++i) {
-        pixel = i;
+    for (int i = 0; i < iterations; ++i) {
+        pixel   = i;
         bool ok = false;
         // Several different texture access patterns
         switch (threadtimes) {
@@ -1155,15 +1189,14 @@ do_tex_thread_workout (int iterations, int mythread)
             // texture coordinates all the time, one file), with handles
             // and per-thread data already queried only once rather than
             // per-call.
-            ok = texsys->texture (texture_handles[0], perthread_info, opt, s, t,
-                                  dsdx, dtdx, dsdy, dtdy, nchannels,
-                                  result, dresultds, dresultdt);
+            ok = texsys->texture(texture_handles[0], perthread_info, opt, s, t,
+                                 dsdx, dtdx, dsdy, dtdy, nchannels, result,
+                                 dresultds, dresultdt);
             break;
         case 2:
             // Workload 2: Static texture access, with filenames.
-            ok = texsys->texture (filenames[0], opt, s, t,
-                                  dsdx, dtdx, dsdy, dtdy, nchannels,
-                                  result, dresultds, dresultdt);
+            ok = texsys->texture(filenames[0], opt, s, t, dsdx, dtdx, dsdy,
+                                 dtdy, nchannels, result, dresultds, dresultdt);
             break;
         case 3:
         case 4:
@@ -1173,7 +1206,7 @@ do_tex_thread_workout (int iterations, int mythread)
             // coordinate offset, so likely are not simultaneously
             // accessing the very same tile as the other threads.
             if (threadtimes == 4)
-                pixel += 57557*mythread;
+                pixel += 57557 * mythread;
             break;
         case 5:
         case 6:
@@ -1184,9 +1217,9 @@ do_tex_thread_workout (int iterations, int mythread)
             // coordinate offset, so likely are not simultaneously
             // accessing the very same tile as the other threads.
             whichfile = i % nfiles;
-            pixel = i / nfiles;
+            pixel     = i / nfiles;
             if (threadtimes == 6)
-                pixel += 57557*mythread;
+                pixel += 57557 * mythread;
             break;
         case 7:
         case 8:
@@ -1194,46 +1227,46 @@ do_tex_thread_workout (int iterations, int mythread)
             // a series of textures at each coordinate, which partially
             // overlap with other threads.
             {
-            int file = i % 8;
-            if (file < 2)        // everybody accesses the first 2 files
-                whichfile = std::min (file, nfiles-1);
-            else                 // and a slowly changing set of 6 others
-                whichfile = (file+11*mythread+i/1000) % nfiles;
-            pixel = i / nfiles;
-            pixel += 57557*mythread;
+                int file = i % 8;
+                if (file < 2)  // everybody accesses the first 2 files
+                    whichfile = std::min(file, nfiles - 1);
+                else  // and a slowly changing set of 6 others
+                    whichfile = (file + 11 * mythread + i / 1000) % nfiles;
+                pixel = i / nfiles;
+                pixel += 57557 * mythread;
             }
             break;
-        default:
-            ASSERT_MSG (0, "Unkonwn thread work pattern %d", threadtimes);
+        default: ASSERT_MSG(0, "Unkonwn thread work pattern %d", threadtimes);
         }
-        if (! ok && spec0.width && spec0.height) {
-            s = (((2*pixel) % spec0.width) + 0.5f) / spec0.width;
-            t = (((2*((2*pixel) / spec0.width)) % spec0.height) + 0.5f) / spec0.height;
+        if (!ok && spec0.width && spec0.height) {
+            s = (((2 * pixel) % spec0.width) + 0.5f) / spec0.width;
+            t = (((2 * ((2 * pixel) / spec0.width)) % spec0.height) + 0.5f)
+                / spec0.height;
             if (use_handle)
-                ok = texsys->texture (texture_handles[whichfile],
-                                      perthread_info, opt, s, t,
-                                      dsdx, dtdx, dsdy, dtdy, nchannels,
-                                      result, dresultds, dresultdt);
+                ok = texsys->texture(texture_handles[whichfile], perthread_info,
+                                     opt, s, t, dsdx, dtdx, dsdy, dtdy,
+                                     nchannels, result, dresultds, dresultdt);
             else
-                ok = texsys->texture (filenames[whichfile], opt, s, t,
-                                      dsdx, dtdx, dsdy, dtdy, nchannels,
-                                      result, dresultds, dresultdt);
+                ok = texsys->texture(filenames[whichfile], opt, s, t, dsdx,
+                                     dtdx, dsdy, dtdy, nchannels, result,
+                                     dresultds, dresultdt);
         }
-        if (! ok) {
-            Strutil::fprintf (std::cerr, "Unexpected error: %s\n", texsys->geterror());
+        if (!ok) {
+            Strutil::fprintf(std::cerr, "Unexpected error: %s\n",
+                             texsys->geterror());
             return;
         }
         // Do some pointless work, to simulate that in a real app, there
         // would be operations interspersed with texture accesses.
         if (threadtimes != 8 /* skip on this test */) {
-            for (int j = 0;  j < 30;  ++j)
-                for (int c = 0;  c < nchannels;  ++c)
-                    result[c] = cosf (result[c]);
+            for (int j = 0; j < 30; ++j)
+                for (int c = 0; c < nchannels; ++c)
+                    result[c] = cosf(result[c]);
         }
     }
     // Force the compiler to not optimize away the "other work"
-    for (int c = 0;  c < nchannels;  ++c)
-        ASSERT (! isnan(result[c]));
+    for (int c = 0; c < nchannels; ++c)
+        ASSERT(!isnan(result[c]));
 }
 
 
@@ -1241,34 +1274,42 @@ do_tex_thread_workout (int iterations, int mythread)
 // Launch numthreads threads each of which performs a workout of texture
 // accesses.
 void
-launch_tex_threads (int numthreads, int iterations)
+launch_tex_threads(int numthreads, int iterations)
 {
     if (invalidate_before_iter)
-        texsys->invalidate_all (true);
+        texsys->invalidate_all(true);
     OIIO::thread_group threads;
-    for (int i = 0;  i < numthreads;  ++i) {
-        threads.create_thread (std::bind(do_tex_thread_workout,iterations,i));
+    for (int i = 0; i < numthreads; ++i) {
+        threads.create_thread(std::bind(do_tex_thread_workout, iterations, i));
     }
-    ASSERT ((int)threads.size() == numthreads);
-    threads.join_all ();
+    ASSERT((int)threads.size() == numthreads);
+    threads.join_all();
 }
 
 
 
 class GridImageInput final : public ImageInput {
 public:
-    GridImageInput () : m_miplevel(-1) { }
-    virtual ~GridImageInput () { close(); }
-    virtual const char * format_name (void) const final { return "grid"; }
-    virtual bool valid_file (const std::string &filename) const final { return true; }
-    virtual bool open (const std::string &name, ImageSpec &newspec) final {
-        bool ok = seek_subimage (0, 0);
+    GridImageInput()
+        : m_miplevel(-1)
+    {
+    }
+    virtual ~GridImageInput() { close(); }
+    virtual const char* format_name(void) const final { return "grid"; }
+    virtual bool valid_file(const std::string& filename) const final
+    {
+        return true;
+    }
+    virtual bool open(const std::string& name, ImageSpec& newspec) final
+    {
+        bool ok = seek_subimage(0, 0);
         newspec = spec();
         return ok;
     }
-    virtual bool close () { return true; }
-    virtual int current_miplevel (void) const final { return m_miplevel; }
-    virtual bool seek_subimage (int subimage, int miplevel) final {
+    virtual bool close() { return true; }
+    virtual int current_miplevel(void) const final { return m_miplevel; }
+    virtual bool seek_subimage(int subimage, int miplevel) final
+    {
         if (subimage > 0)
             return false;
         if (miplevel > 0 && automip /* if automip is on, don't generate MIP */)
@@ -1279,68 +1320,75 @@ public:
         res >>= miplevel;
         if (res == 0)
             return false;
-        m_spec = ImageSpec (res, res, 3, TypeDesc::FLOAT);
-        m_spec.tile_width = std::min (64, res);
-        m_spec.tile_height = std::min (64, res);
-        m_spec.tile_depth = 1;
-        m_miplevel = miplevel;
+        m_spec             = ImageSpec(res, res, 3, TypeDesc::FLOAT);
+        m_spec.tile_width  = std::min(64, res);
+        m_spec.tile_height = std::min(64, res);
+        m_spec.tile_depth  = 1;
+        m_miplevel         = miplevel;
         return true;
     }
-    virtual bool read_native_scanline (int subimage, int miplevel,
-                                       int y, int z, void *data) final {
+    virtual bool read_native_scanline(int subimage, int miplevel, int y, int z,
+                                      void* data) final
+    {
         return false;
     }
-    virtual bool read_native_tile (int subimage, int miplevel,
-                                   int xbegin, int ybegin,
-                                   int zbegin, void *data) final {
-        lock_guard lock (m_mutex);
-        if (! seek_subimage (subimage, miplevel))
+    virtual bool read_native_tile(int subimage, int miplevel, int xbegin,
+                                  int ybegin, int zbegin, void* data) final
+    {
+        lock_guard lock(m_mutex);
+        if (!seek_subimage(subimage, miplevel))
             return false;
-        float *tile = (float *)data;
-        for (int z = zbegin, zend = z+m_spec.tile_depth; z < zend; ++z)
-            for (int y = ybegin, yend = y+m_spec.tile_height; y < yend; ++y)
-                for (int x = xbegin, xend = x+m_spec.tile_width; x < xend; ++x) {
-                    tile[0] = float(x)/m_spec.width;
-                    tile[2] = float(y)/m_spec.height;
-                    tile[1] = (((x/16)&1) == ((y/16)&1)) ? 1.0f/(m_miplevel+1) : 0.05f;
+        float* tile = (float*)data;
+        for (int z = zbegin, zend = z + m_spec.tile_depth; z < zend; ++z)
+            for (int y = ybegin, yend = y + m_spec.tile_height; y < yend; ++y)
+                for (int x = xbegin, xend = x + m_spec.tile_width; x < xend;
+                     ++x) {
+                    tile[0] = float(x) / m_spec.width;
+                    tile[2] = float(y) / m_spec.height;
+                    tile[1] = (((x / 16) & 1) == ((y / 16) & 1))
+                                  ? 1.0f / (m_miplevel + 1)
+                                  : 0.05f;
                     tile += m_spec.nchannels;
                 }
         return true;
     }
+
 private:
     int m_miplevel;
 };
 
 
 
-ImageInput *make_grid_input () {
+ImageInput*
+make_grid_input()
+{
     return new GridImageInput;
 }
 
 
 
 void
-test_icwrite (int testicwrite)
+test_icwrite(int testicwrite)
 {
     std::cout << "Testing IC write, mode " << testicwrite << "\n";
 
     // The global "shared" ImageCache will be the same one the
     // TextureSystem uses.
-    ImageCache *ic = ImageCache::create ();
+    ImageCache* ic = ImageCache::create();
 
     // Set up the fake file ane add it
     int tw = 64, th = 64;  // tile width and height
     int nc = nchannels_override ? nchannels_override : 3;  // channels
-    ImageSpec spec (512, 512, nc, TypeDesc::FLOAT);
-    spec.depth = 1;
-    spec.tile_width = tw;
+    ImageSpec spec(512, 512, nc, TypeDesc::FLOAT);
+    spec.depth       = 1;
+    spec.tile_width  = tw;
     spec.tile_height = th;
-    spec.tile_depth = 1;
-    ustring filename (filenames[0]);
-    bool ok = ic->add_file (filename, make_grid_input);
-    if (! ok)
+    spec.tile_depth  = 1;
+    ustring filename(filenames[0]);
+    bool ok = ic->add_file(filename, make_grid_input);
+    if (!ok)
         std::cout << "ic->add_file error: " << ic->geterror() << "\n";
-    ASSERT (ok);
+    ASSERT(ok);
 
     // Now add all the tiles if it's a seeded map
     // testicwrite == 1 means to seed the first MIP level using add_tile.
@@ -1348,25 +1396,27 @@ test_icwrite (int testicwrite)
     // the make_grid_input custom ImageInput that constructs a pattern
     // procedurally.
     if (testicwrite == 1) {
-        std::vector<float> tile (spec.tile_pixels() * spec.nchannels);
-        for (int ty = 0;  ty < spec.height;  ty += th) {
-            for (int tx = 0;  tx < spec.width;  tx += tw) {
+        std::vector<float> tile(spec.tile_pixels() * spec.nchannels);
+        for (int ty = 0; ty < spec.height; ty += th) {
+            for (int tx = 0; tx < spec.width; tx += tw) {
                 // Construct a tile
                 for (int y = 0; y < th; ++y)
                     for (int x = 0; x < tw; ++x) {
-                        int index = (y*tw + x) * nc;
-                        int xx = x+tx, yy = y+ty;
-                        tile[index+0] = float(xx)/spec.width;
-                        tile[index+1] = float(yy)/spec.height;
-                        tile[index+2] = (!(xx%10) || !(yy%10)) ? 1.0f : 0.0f;
+                        int index = (y * tw + x) * nc;
+                        int xx = x + tx, yy = y + ty;
+                        tile[index + 0] = float(xx) / spec.width;
+                        tile[index + 1] = float(yy) / spec.height;
+                        tile[index + 2] = (!(xx % 10) || !(yy % 10)) ? 1.0f
+                                                                     : 0.0f;
                     }
-                bool ok = ic->add_tile (filename, 0, 0, tx, ty, 0, 0, -1,
-                                        TypeDesc::FLOAT, &tile[0]);
-                if (! ok) {
-                    Strutil::fprintf (std::cerr, "ic->add_tile error: %s\n", ic->geterror());
+                bool ok = ic->add_tile(filename, 0, 0, tx, ty, 0, 0, -1,
+                                       TypeDesc::FLOAT, &tile[0]);
+                if (!ok) {
+                    Strutil::fprintf(std::cerr, "ic->add_tile error: %s\n",
+                                     ic->geterror());
                     return;
                 }
-                ASSERT (ok);
+                ASSERT(ok);
             }
         }
     }
@@ -1375,41 +1425,41 @@ test_icwrite (int testicwrite)
 
 
 int
-main (int argc, const char *argv[])
+main(int argc, const char* argv[])
 {
-    Filesystem::convert_native_arguments (argc, argv);
-    getargs (argc, argv);
+    Filesystem::convert_native_arguments(argc, argv);
+    getargs(argc, argv);
 
     // environment variable TESTTEX_BATCH can force batch mode
     string_view testtex_batch = Sysutil::getenv("TESTTEX_BATCH");
     if (testtex_batch.size())
         batch = Strutil::from_string<int>(testtex_batch);
 
-    OIIO::attribute ("threads", nthreads);
+    OIIO::attribute("threads", nthreads);
 
-    texsys = TextureSystem::create ();
+    texsys = TextureSystem::create();
     std::cout << "Created texture system\n";
-    texsys->attribute ("autotile", autotile);
-    texsys->attribute ("automip", (int)automip);
-    texsys->attribute ("deduplicate", (int)dedup);
+    texsys->attribute("autotile", autotile);
+    texsys->attribute("automip", (int)automip);
+    texsys->attribute("deduplicate", (int)dedup);
     if (cachesize >= 0)
-        texsys->attribute ("max_memory_MB", cachesize);
+        texsys->attribute("max_memory_MB", cachesize);
     else
-        texsys->getattribute ("max_memory_MB", TypeFloat, &cachesize);
+        texsys->getattribute("max_memory_MB", TypeFloat, &cachesize);
     if (maxfiles >= 0)
-        texsys->attribute ("max_open_files", maxfiles);
+        texsys->attribute("max_open_files", maxfiles);
     if (searchpath.length())
-        texsys->attribute ("searchpath", searchpath);
+        texsys->attribute("searchpath", searchpath);
     if (nountiled)
-        texsys->attribute ("accept_untiled", 0);
+        texsys->attribute("accept_untiled", 0);
     if (nounmipped)
-        texsys->attribute ("accept_unmipped", 0);
-    texsys->attribute ("gray_to_rgb", gray_to_rgb);
-    texsys->attribute ("flip_t", flip_t);
+        texsys->attribute("accept_unmipped", 0);
+    texsys->attribute("gray_to_rgb", gray_to_rgb);
+    texsys->attribute("flip_t", flip_t);
 
     if (test_construction) {
         Timer t;
-        for (int i = 0;  i < 1000000000;  ++i) {
+        for (int i = 0; i < 1000000000; ++i) {
             TextureOpt opt;
             dummyptr = &opt;  // This forces the optimizer to keep the loop
         }
@@ -1417,40 +1467,41 @@ main (int argc, const char *argv[])
         TextureOpt canonical, copy;
         t.reset();
         t.start();
-        for (int i = 0;  i < 1000000000;  ++i) {
-            copy = canonical;
+        for (int i = 0; i < 1000000000; ++i) {
+            copy     = canonical;
             dummyptr = &copy;  // This forces the optimizer to keep the loop
         }
         std::cout << "TextureOpt copy: " << t() << " ns\n";
     }
 
     if (testicwrite && filenames.size()) {
-        test_icwrite (testicwrite);
+        test_icwrite(testicwrite);
     }
 
     if (test_getimagespec) {
         ImageSpec spec;
-        for (int i = 0;  i < iters;  ++i) {
-            texsys->get_imagespec (filenames[0], 0, spec);
+        for (int i = 0; i < iters; ++i) {
+            texsys->get_imagespec(filenames[0], 0, spec);
         }
         iters = 0;
     }
 
     if (test_gettexels) {
-        test_getimagespec_gettexels (filenames[0]);
+        test_getimagespec_gettexels(filenames[0]);
         iters = 0;
     }
 
     if (testhash) {
-        test_hash ();
+        test_hash();
     }
 
-    Imath::M33f scale;  scale.scale (Imath::V2f (0.3, 0.3));
-    Imath::M33f rot;    rot.rotate (radians(25.0f));
-    Imath::M33f trans;  trans.translate (Imath::V2f (0.75f, 0.25f));
-    Imath::M33f persp (2, 0, 0,
-                       0, 0.8, -0.55,
-                       0, 0, 1);
+    Imath::M33f scale;
+    scale.scale(Imath::V2f(0.3, 0.3));
+    Imath::M33f rot;
+    rot.rotate(radians(25.0f));
+    Imath::M33f trans;
+    trans.translate(Imath::V2f(0.75f, 0.25f));
+    Imath::M33f persp(2, 0, 0, 0, 0.8, -0.55, 0, 0, 1);
     xform = persp * rot * trans * scale;
     xform.invert();
 
@@ -1458,7 +1509,7 @@ main (int argc, const char *argv[])
         // If the --iters flag was used, do that number of iterations total
         // (divided among the threads). If not supplied (iters will be 1),
         // then use a large constant *per thread*.
-        const int iterations = iters>1 ? iters : 2000000;
+        const int iterations = iters > 1 ? iters : 2000000;
         std::cout << "Workload: " << workload_names[threadtimes] << "\n";
         std::cout << "texture cache size = " << cachesize << " MB\n";
         std::cout << "hw threads = " << Sysutil::hardware_concurrency() << "\n";
@@ -1468,114 +1519,123 @@ main (int argc, const char *argv[])
 
         if (nthreads == 0)
             nthreads = Sysutil::hardware_concurrency();
-        static int threadcounts[] = { 1, 2, 4, 8, 12, 16, 24, 32, 64, 128, 1024, 1<<30 };
-        float single_thread_time = 0.0f;
+        static int threadcounts[] = { 1,  2,  4,  8,   12,   16,
+                                      24, 32, 64, 128, 1024, 1 << 30 };
+        float single_thread_time  = 0.0f;
         for (int i = 0; threadcounts[i] <= nthreads; ++i) {
-            int nt = wedge ? threadcounts[i] : nthreads;
-            int its = iters>1 ? (std::max (1, iters/nt)) : iterations; // / nt;
+            int nt  = wedge ? threadcounts[i] : nthreads;
+            int its = iters > 1 ? (std::max(1, iters / nt))
+                                : iterations;  // / nt;
             double range;
-            double t = time_trial (std::bind(launch_tex_threads,nt,its),
-                                   ntrials, &range);
+            double t = time_trial(std::bind(launch_tex_threads, nt, its),
+                                  ntrials, &range);
             if (nt == 1)
                 single_thread_time = (float)t;
-            float speedup = (single_thread_time /*/nt*/) / (float)t;
+            float speedup    = (single_thread_time /*/nt*/) / (float)t;
             float efficiency = (single_thread_time / nt) / float(t);
-            std::cout << Strutil::format ("%3d     %8.2f   %6.1fx  %6.1f%%    range %.2f\t(%d iters/thread)\n",
-                                          nt, t, speedup, efficiency*100.0f, range, its);
+            std::cout << Strutil::format(
+                "%3d     %8.2f   %6.1fx  %6.1f%%    range %.2f\t(%d iters/thread)\n",
+                nt, t, speedup, efficiency * 100.0f, range, its);
             std::cout.flush();
-            if (! wedge)
-                break;    // don't loop if we're not wedging
+            if (!wedge)
+                break;  // don't loop if we're not wedging
         }
         std::cout << "\n";
 
     } else if (iters > 0 && filenames.size()) {
-        ustring filename (filenames[0]);
-        test_gettextureinfo (filenames[0]);
-        const char *texturetype = "Plain Texture";
-        texsys->get_texture_info (filename, 0, ustring("texturetype"),
-                                  TypeDesc::STRING, &texturetype);
+        ustring filename(filenames[0]);
+        test_gettextureinfo(filenames[0]);
+        const char* texturetype = "Plain Texture";
+        texsys->get_texture_info(filename, 0, ustring("texturetype"),
+                                 TypeDesc::STRING, &texturetype);
         Timer timer;
-        if (! strcmp (texturetype, "Plain Texture")) {
+        if (!strcmp(texturetype, "Plain Texture")) {
             if (batch) {
                 if (nowarp)
-                    test_plain_texture_batch (map_default);
+                    test_plain_texture_batch(map_default);
                 else if (tube)
-                    test_plain_texture_batch (map_tube);
+                    test_plain_texture_batch(map_tube);
                 else if (filtertest)
-                    test_plain_texture_batch (map_filtertest);
+                    test_plain_texture_batch(map_filtertest);
                 else
-                    test_plain_texture_batch (map_warp);
+                    test_plain_texture_batch(map_warp);
 
             } else {
                 if (nowarp)
-                    test_plain_texture (map_default);
+                    test_plain_texture(map_default);
                 else if (tube)
-                    test_plain_texture (map_tube);
+                    test_plain_texture(map_tube);
                 else if (filtertest)
-                    test_plain_texture (map_filtertest);
+                    test_plain_texture(map_filtertest);
                 else
-                    test_plain_texture (map_warp);
+                    test_plain_texture(map_warp);
             }
         }
-        if (! strcmp (texturetype, "Volume Texture")) {
+        if (!strcmp(texturetype, "Volume Texture")) {
             if (batch) {
                 if (nowarp)
-                    test_texture3d_batch (filename, map_default_3D);
+                    test_texture3d_batch(filename, map_default_3D);
                 else
-                    test_texture3d_batch (filename, map_warp_3D);
+                    test_texture3d_batch(filename, map_warp_3D);
             } else {
                 if (nowarp)
-                    test_texture3d (filename, map_default_3D);
+                    test_texture3d(filename, map_default_3D);
                 else
-                    test_texture3d (filename, map_warp_3D);
+                    test_texture3d(filename, map_warp_3D);
             }
         }
-        if (! strcmp (texturetype, "Shadow")) {
-            test_shadow (filename);
+        if (!strcmp(texturetype, "Shadow")) {
+            test_shadow(filename);
         }
-        if (! strcmp (texturetype, "Environment")) {
-            test_environment (filename);
+        if (!strcmp(texturetype, "Environment")) {
+            test_environment(filename);
         }
-        test_getimagespec_gettexels (filename);
-        std::cout << "Time: " << Strutil::timeintervalformat (timer()) << "\n";
+        test_getimagespec_gettexels(filename);
+        std::cout << "Time: " << Strutil::timeintervalformat(timer()) << "\n";
     }
 
     if (test_statquery) {
         std::cout << "Testing statistics queries:\n";
         int total_files = 0;
-        texsys->getattribute ("total_files", total_files);
+        texsys->getattribute("total_files", total_files);
         std::cout << "  Total files: " << total_files << "\n";
-        std::vector<ustring> all_filenames (total_files);
-        std::cout << TypeDesc(TypeDesc::STRING,total_files) << "\n";
-        texsys->getattribute ("all_filenames", TypeDesc(TypeDesc::STRING,total_files), &all_filenames[0]);
+        std::vector<ustring> all_filenames(total_files);
+        std::cout << TypeDesc(TypeDesc::STRING, total_files) << "\n";
+        texsys->getattribute("all_filenames",
+                             TypeDesc(TypeDesc::STRING, total_files),
+                             &all_filenames[0]);
         for (int i = 0; i < total_files; ++i) {
-            int timesopened = 0;
+            int timesopened   = 0;
             int64_t bytesread = 0;
-            float iotime = 0.0f;
+            float iotime      = 0.0f;
             int64_t data_size = 0, file_size = 0;
-            texsys->get_texture_info (all_filenames[i], 0, ustring("stat:timesopened"),
-                                      TypeDesc::INT, &timesopened);
-            texsys->get_texture_info (all_filenames[i], 0, ustring("stat:bytesread"),
-                                      TypeDesc::INT64, &bytesread);
-            texsys->get_texture_info (all_filenames[i], 0, ustring("stat:iotime"),
-                                      TypeDesc::FLOAT, &iotime);
-            texsys->get_texture_info (all_filenames[i], 0, ustring("stat:image_size"),
-                                      TypeDesc::INT64, &data_size);
-            texsys->get_texture_info (all_filenames[i], 0, ustring("stat:file_size"),
-                                      TypeDesc::INT64, &file_size);
-            std::cout << Strutil::format ("  %d: %s  opens=%d, read=%s, time=%s, data=%s, file=%s\n",
-                                          i, all_filenames[i], timesopened,
-                                          Strutil::memformat(bytesread),
-                                          Strutil::timeintervalformat(iotime,2),
-                                          Strutil::memformat(data_size),
-                                          Strutil::memformat(file_size));
+            texsys->get_texture_info(all_filenames[i], 0,
+                                     ustring("stat:timesopened"), TypeDesc::INT,
+                                     &timesopened);
+            texsys->get_texture_info(all_filenames[i], 0,
+                                     ustring("stat:bytesread"), TypeDesc::INT64,
+                                     &bytesread);
+            texsys->get_texture_info(all_filenames[i], 0,
+                                     ustring("stat:iotime"), TypeDesc::FLOAT,
+                                     &iotime);
+            texsys->get_texture_info(all_filenames[i], 0,
+                                     ustring("stat:image_size"),
+                                     TypeDesc::INT64, &data_size);
+            texsys->get_texture_info(all_filenames[i], 0,
+                                     ustring("stat:file_size"), TypeDesc::INT64,
+                                     &file_size);
+            std::cout << Strutil::format(
+                "  %d: %s  opens=%d, read=%s, time=%s, data=%s, file=%s\n", i,
+                all_filenames[i], timesopened, Strutil::memformat(bytesread),
+                Strutil::timeintervalformat(iotime, 2),
+                Strutil::memformat(data_size), Strutil::memformat(file_size));
         }
     }
 
     std::cout << "Memory use: "
-              << Strutil::memformat (Sysutil::memory_used(true)) << "\n";
-    std::cout << texsys->getstats (verbose ? 2 : 0) << "\n";
-    TextureSystem::destroy (texsys);
+              << Strutil::memformat(Sysutil::memory_used(true)) << "\n";
+    std::cout << texsys->getstats(verbose ? 2 : 0) << "\n";
+    TextureSystem::destroy(texsys);
 
     if (verbose)
         std::cout << "\nustrings: " << ustring::getstats(false) << "\n\n";


### PR DESCRIPTION
This fully uses clang-format on the entire codebase (except for a few
files, and a few sections of files, where we explicitly disable it for
reasons.

Henceforth, we will assume that any new code contributions should be
conformant and reject pull requests that are not. The basic idea is:

1. For large code changes, make sure you have a fairly recent version
   of clang-format installed on your end, and use

        make clang-format

   to format the code before sending off the PR.

2. The TravisCI tests include one entry that merely does a 'make
   clang-format' and considers it an error if there are any resulting
   diffs (i.e. if clang-format needed to reformat anything). In such a
   case, it will also print the diffs themselves if you click on the
   failed test.

Note that for small patches and users who aren't easily able to have a
local clang-format copy, you can essentially skip step 1, submit your PR
as-is and then examine the failure diffs of step 2, making the requested
changes by hand and then updating your PR.

It is also worth noting that as a result of this massive reformat, it is no longer reliable to use 'git blame'  to track down authors on a line-by-line basis (across this boundary), since so very many lines were altered by the reformatting and thus look like they were edited by me, this week, when in fact they are often just reformatted lines written by other people long ago. 

Similarly, certain ways of accounting for how many lines of the code base were authored by each contributor are no longer accurate, since I now have a disproportionate amount attributed to me as a result of the reformatting. So it goes. This is a one-time thing, and the transition to "2.0" seems like the right time to do it.
