### PR TITLE
DPX: catch write errors

### DIFF
--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -32,6 +32,8 @@
 
 #include <OpenEXR/ImfTimeCode.h>  //For TimeCode support
 
+// Note: libdpx originally from: https://github.com/PatrickPalmer/dpx
+// But that seems not to be actively maintained.
 #include "libdpx/DPX.h"
 #include "libdpx/DPXColorConverter.h"
 

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -33,6 +33,8 @@
 #include <cstdlib>
 #include <iomanip>
 
+// Note: libdpx originally from: https://github.com/PatrickPalmer/dpx
+// But that seems not to be actively maintained.
 #include "libdpx/DPX.h"
 #include "libdpx/DPXColorConverter.h"
 
@@ -582,11 +584,17 @@ DPXOutput::prep_subimage(int s, bool allocate)
 bool
 DPXOutput::write_buffer()
 {
+    bool ok = true;
     if (m_write_pending) {
-        m_dpx.WriteElement(m_subimage, &m_buf[0], m_datasize);
+        ok = m_dpx.WriteElement(m_subimage, &m_buf[0], m_datasize);
+        if (!ok) {
+            const char* err = strerror(errno);
+            error("DPX write failed (%s)",
+                  (err && err[0]) ? err : "unknown error");
+        }
         m_write_pending = false;
     }
-    return true;
+    return ok;
 }
 
 

--- a/src/dpx.imageio/libdpx/DPXHeader.cpp
+++ b/src/dpx.imageio/libdpx/DPXHeader.cpp
@@ -231,7 +231,7 @@ bool dpx::Header::Write(OutStream *io)
 
 	// write the header to the file
 	size_t r = sizeof(GenericHeader) + sizeof(IndustryHeader);
-	if (io->Write(&(this->magicNumber), r) != r)
+	if (! io->WriteCheck(&(this->magicNumber), r))
 		return false;
 
 	// swap back - data is in file, now we need it native again
@@ -251,7 +251,7 @@ bool dpx::Header::WriteOffsetData(OutStream *io)
 		return false;
 	if (this->RequiresByteSwap())
 		SwapBytes(this->imageOffset);
-	if (io->Write(&this->imageOffset, sizeof(U32)) == false)
+	if (!io->WriteCheck(&this->imageOffset, sizeof(U32)))
 		return false;
 	if (this->RequiresByteSwap())
 		SwapBytes(this->imageOffset);
@@ -263,7 +263,7 @@ bool dpx::Header::WriteOffsetData(OutStream *io)
 		return false;
 	if (this->RequiresByteSwap())
 		SwapBytes(this->fileSize);
-	if (io->Write(&this->fileSize, sizeof(U32)) == false)
+	if (! io->WriteCheck(&this->fileSize, sizeof(U32)))
 		return false;
 	if (this->RequiresByteSwap())
 		SwapBytes(this->fileSize);
@@ -274,7 +274,7 @@ bool dpx::Header::WriteOffsetData(OutStream *io)
 		return false;
 	if (this->RequiresByteSwap())
 		SwapBytes(this->numberOfElements);
-	if (io->Write(&this->numberOfElements, sizeof(U16)) == false)
+	if (! io->WriteCheck(&this->numberOfElements, sizeof(U16)))
 		return false;
 	if (this->RequiresByteSwap())
 		SwapBytes(this->numberOfElements);
@@ -297,7 +297,7 @@ bool dpx::Header::WriteOffsetData(OutStream *io)
 			// write
 			if (this->RequiresByteSwap())
 				SwapBytes(this->chan[i].dataOffset);
-			if (io->Write(&this->chan[i].dataOffset, sizeof(U32)) == false)
+			if (! io->WriteCheck(&this->chan[i].dataOffset, sizeof(U32)))
 				return false;
 			if (this->RequiresByteSwap())
 				SwapBytes(this->chan[i].dataOffset);

--- a/src/dpx.imageio/libdpx/DPXStream.h
+++ b/src/dpx.imageio/libdpx/DPXStream.h
@@ -170,14 +170,25 @@ class OutStream
 	 */
 	virtual void Close();
 		
-	/*!
-	 * \brief Write data to file
-	 * \param buf data buffer
-	 * \param size bytes to write
-	 * \return number of bytes written
-	 */
-	virtual size_t Write(void * buf, const size_t size);
-		
+    /*!
+     * \brief Write data to file
+     * \param buf data buffer
+     * \param size bytes to write
+     * \return number of bytes written
+     */
+    virtual size_t Write(void * buf, const size_t size);
+        
+    /*!
+     * \brief Write data to file
+     * \param buf data buffer
+     * \param size bytes to write
+     * \return true for success, false if it didn't write all the bytes.
+     */
+    bool WriteCheck(void * buf, const size_t size)
+    {
+        return Write(buf, size) == size;
+    }
+        
 	/*!
 	 * \brief Seek to a position in the file
 	 * \param offset offset from originating position

--- a/src/dpx.imageio/libdpx/OutStream.cpp
+++ b/src/dpx.imageio/libdpx/OutStream.cpp
@@ -74,7 +74,7 @@ size_t OutStream::Write(void *buf, const size_t size)
 {
 	if (this->fp == 0)
 		return false;
-	return ::fwrite(buf, 1, size, this->fp);
+    return ::fwrite(buf, 1, size, this->fp);
 }
 
 

--- a/src/dpx.imageio/libdpx/Writer.cpp
+++ b/src/dpx.imageio/libdpx/Writer.cpp
@@ -141,7 +141,7 @@ void dpx::Writer::SetUserData(const long size)
 bool dpx::Writer::WriteUserData(void *data)
 {
     size_t size = this->header.UserSize();
-	if (fd->Write(data, size) != size)
+	if (!fd->WriteCheck(data, size))
 		return false;
     this->fileLoc += size;
 	return true;
@@ -213,7 +213,7 @@ bool dpx::Writer::WriteElement(const int element, void *data, const long count)
 	this->fileLoc += count;
 		
 	// write
-	return (this->fd->Write(data, count) > 0);
+	return this->fd->WriteCheck(data, count);
 }
 
 
@@ -353,7 +353,7 @@ bool dpx::Writer::WriteElement(const int element, void *data, const DataSize siz
 	{
 		// end of image padding
 		this->fileLoc += eoimPad;
-		status = (this->fd->Write(blank, eoimPad) > 0);
+		status = this->fd->WriteCheck(blank, eoimPad);
 	}
 	
 	// rid of memory
@@ -383,14 +383,14 @@ bool dpx::Writer::WriteThrough(void *data, const U32 width, const U32 height, co
 		for (i = 0; i < height; i++)
 		{
 			// write one line
-			if (this->fd->Write(imageBuf+(width*bytes*i), bytes * width) == false)
+			if (!this->fd->WriteCheck(imageBuf+(width*bytes*i), bytes * width))
 			{
 				status = false;
 				break;
 			}
 			
 			// write end of line padding
-			if (this->fd->Write(blank, eoimPad) == false)
+			if (!this->fd->WriteCheck(blank, eoimPad))
 			{
 				status = false;
 				break;
@@ -400,7 +400,7 @@ bool dpx::Writer::WriteThrough(void *data, const U32 width, const U32 height, co
 	else
 	{
 		// write data as one chunk
-		if (this->fd->Write(imageBuf, bytes * count) == false)
+		if (!this->fd->WriteCheck(imageBuf, bytes * count))
 		{
 			status = false;
 		}
@@ -410,7 +410,7 @@ bool dpx::Writer::WriteThrough(void *data, const U32 width, const U32 height, co
 	if (status && eoimPad)
 	{
 		this->fileLoc += eoimPad;
-		status = (this->fd->Write(blank, eoimPad) > 0);
+		status = this->fd->WriteCheck(blank, eoimPad);
 	}
 	
 	return status;

--- a/src/dpx.imageio/libdpx/WriterInternal.h
+++ b/src/dpx.imageio/libdpx/WriterInternal.h
@@ -341,7 +341,7 @@ namespace dpx
 			fileOffset += (bufaccess.length * sizeof(IB));
 			if (swapEndian)
 			    EndianBufferSwap(BITDEPTH, packing, dst + bufaccess.offset, bufaccess.length * sizeof(IB));
-			if (fd->Write(dst+bufaccess.offset, (bufaccess.length * sizeof(IB))) == false)
+			if (!fd->WriteCheck(dst+bufaccess.offset, (bufaccess.length * sizeof(IB))))
 			{
 				status = false;
 				break;
@@ -351,7 +351,7 @@ namespace dpx
 			if (eolnPad)
 			{
 				fileOffset += eolnPad;
-				if (fd->Write(blank, eolnPad) == false)
+				if (!fd->WriteCheck(blank, eolnPad))
 				{
 					status = false;
 					break;
@@ -416,7 +416,7 @@ namespace dpx
 			fileOffset += (bufaccess.length * sizeof(IB));
 			if (swapEndian)
 			    EndianBufferSwap(BITDEPTH, packing, dst + bufaccess.offset, bufaccess.length * sizeof(IB));
-			if (fd->Write(dst+bufaccess.offset, (bufaccess.length * sizeof(IB))) == false)
+			if (!fd->WriteCheck(dst+bufaccess.offset, (bufaccess.length * sizeof(IB))))
 			{
 				status = false;
 				break;
@@ -426,7 +426,7 @@ namespace dpx
 			if (eolnPad)
 			{
 				fileOffset += eolnPad;
-				if (fd->Write(blank, eolnPad) == false)
+				if (!fd->WriteCheck(blank, eolnPad))
 				{
 					status = false;
 					break;

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5115,7 +5115,10 @@ output_file(int argc, const char* argv[])
             }
         }
 
-        out->close();
+        if (!out->close()) {
+            ot.error(command, out->geterror());
+            ok = false;
+        }
         out.reset();  // make extra sure it's cleaned up
 
         // We wrote to a temporary file, so now atomically move it to the


### PR DESCRIPTION
It was reported that if you filled a disk while writing a DPX file, no
errors would be reported, just leaving a corrupted file. (Admittedly,
filling disk volumes is not something I had thoroughly tested.)

The problem turned out to be threefold:

First, inside the DPX library (which was an imported project from
Patrick Palmer, which to the best of my knowledge is no longer actively
maintained outside of OIIO), the underlying OutStream class was used
incorrectly throughout its own library -- in particular, the Write()
method returned the number of bytes correctly written, but the return
results were almost always used incorrectly by merely checking != 0 (as
if it was a bool return for success, when in fact it should check for
any value != the number of bytes being requested to write).

To fix, I added a WriteCheck() method, which returns a simple bool
success/fail, and fixed the call points to use this function. I didn't
replace the original Write() method because there really was one place
where it expected the number of bytes written to be returned.

Second, in our DPXOutput::write_buffer() method, we weren't checking
the return results of the underlying call to m_dpx.WriteElement().
Now we do, and in case of failure try to check `strerror(errno)` in
the hopes of finding a useful system error (and in fact, in this case
of filling the disk, we do!).

Finally, in oiiotool's output_file() function, while we did check the
return codes for the call to out->write_image(), we neglected to check
the return code for out->close(), figuring that nothing could go wrong.
But, oho, the particular workings of our DPX writer are that the
write_scanline calls just batch output, and all the real I/O happens on
the call to close(), so the exact place where the error would occur was
the one place we didn't check. Fun. For most file format types, real
I/O happens in the individual write calls, so this was particular to DPX,
in addition to its other internal bugs described above.

How did I test? On my Mac I created a disk image with the smallest possible
space (around 8MB, I think), then tried to write a big file, like this:

    oiiotool -pattern noise 8000x8000 3 -d uint16 -o /Volumes/SmallTest/out.dpx

which now results in the following error:

    oiiotool ERROR: -o : DPX write failed (No space left on device)

which is about as good as we can hope for.

I also double checked what happens when we fill the disk while writing
tiff, exr, jpg, and they all correctly reported a write error.

So case closed, and thanks to Pavel Jurkas for reporting the DPX error
when the disk volume is full.

