### PR TITLE
Fix __has_attribute vs __has_cpp_attribute and other C++ std things

### DIFF
--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -15,12 +15,18 @@ endif ()
 string (REGEX REPLACE "\\." "_" MANGLED_SOVERSION ${SOVERSION})
 set (OIIO_VERSION_NS "v${MANGLED_SOVERSION}")
 set (OIIO_BUILD_CPP11 1)
-if (USE_CPP VERSION_GREATER 11)
+if (USE_CPP VERSION_GREATER 14 OR USE_CPP VERSION_EQUAL 14)
     set (OIIO_BUILD_CPP14 1)
 endif ()
-if (USE_CPP VERSION_GREATER 17)
+if (USE_CPP VERSION_GREATER 17 OR USE_CPP VERSION_EQUAL 17)
     set (OIIO_BUILD_CPP17 1)
 endif ()
+if (USE_CPP VERSION_GREATER 20 OR USE_CPP VERSION_EQUAL 20)
+    set (OIIO_BUILD_CPP20 1)
+endif ()
+# Note: When our CMake minimum is at least 3.7, we can switch to less
+# complex statements with VERSION_GREATER_EQUAL.
+
 configure_file(OpenImageIO/oiioversion.h.in "${CMAKE_BINARY_DIR}/include/OpenImageIO/oiioversion.h" @ONLY)
 list(APPEND public_headers "${CMAKE_BINARY_DIR}/include/OpenImageIO/oiioversion.h")
 

--- a/src/include/OpenImageIO/oiioversion.h.in
+++ b/src/include/OpenImageIO/oiioversion.h.in
@@ -116,10 +116,12 @@ namespace @PROJ_NAME@ = @PROJ_NAMESPACE_V@;
 #endif
 
 #define OIIO_BUILD_CPP11 1 /* Always build for C++ >= 11 */
-// OIIO_BUILD_CPP14 will be 1 if this OIIO was built using C++14
+// OIIO_BUILD_CPP14 will be 1 if this OIIO was built using C++14 or higher
 #cmakedefine01 OIIO_BUILD_CPP14
-// OIIO_BUILD_CPP17 will be 1 if this OIIO was built using C++17
+// OIIO_BUILD_CPP17 will be 1 if this OIIO was built using C++17 or higher
 #cmakedefine01 OIIO_BUILD_CPP17
+// OIIO_BUILD_CPP20 will be 1 if this OIIO was built using C++20 or higher
+#cmakedefine01 OIIO_BUILD_CPP20
 
 #endif
 


### PR DESCRIPTION
I had not correctly understood that __has_attribute is specifically for
GCC `__attribute__((attr))` things, and `__has_cpp_attribute` is the new
C++20 test for standard `[[attr]]` style attributes. Fix up that use.

Also get rid of `__has_builtin` and `__has_feature`, those are gcc only,
not the way the standard works, and we don't use it anywhere.

Some other very minor fixes related to discerning which C++ standard
we're using.
