### PR TITLE
Formally bump MSVS minimum to 2015

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,7 +26,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
 ### Required dependencies -- OIIO will not build at all without these
 
  * C++11 (also builds with C++14 and C++17)
- * Compilers: gcc 4.8.2 - 8.2, clang 3.3 - 7.0, MSVS 2013 - 2017,
+ * Compilers: gcc 4.8.2 - 8.2, clang 3.3 - 7.0, **MSVS 2015 - 2017**,
    icc version 13 or higher
  * Boost >= 1.53 (tested up through 1.68)
  * CMake >= 3.2.2 (tested up through 3.12)

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -99,7 +99,7 @@
 #    define OIIO_CONSTEXPR14 constexpr
 #    define OIIO_CONSTEXPR17 /* not constexpr before C++17 */
 #    define OIIO_CONSTEXPR20 /* not constexpr before C++20 */
-#elif (__cplusplus >= 201103L) || _MSC_VER >= 1900
+#elif (__cplusplus >= 201103L) || (defined(_MSC_VER) && _MSC_VER >= 1900)
 #    define OIIO_CPLUSPLUS_VERSION 11
 #    define OIIO_CONSTEXPR14 /* not constexpr before C++14 */
 #    define OIIO_CONSTEXPR17 /* not constexpr before C++17 */
@@ -166,8 +166,8 @@
 
 // Tests for MSVS versions, always 0 if not MSVS at all.
 #if defined(_MSC_VER)
-#  if _MSC_VER < 1800
-#    error "This version of OIIO is meant to work only with Visual Studio 2013 or later"
+#  if _MSC_VER < 1900
+#    error "This version of OIIO is meant to work only with Visual Studio 2015 or later"
 #  endif
 #  define OIIO_MSVS_AT_LEAST_2013 (_MSC_VER >= 1800)
 #  define OIIO_MSVS_BEFORE_2013   (_MSC_VER <  1800)


### PR DESCRIPTION
We think that as a practical matter, this has been the case for a long
time. But the documentation didn't keep up.

