### PR TITLE
All platforms can rely on std::snprintf now.

### DIFF
--- a/src/include/OpenImageIO/SHA1.h
+++ b/src/include/OpenImageIO/SHA1.h
@@ -123,9 +123,9 @@
 #endif
 
 #ifdef _MSC_VER
-#define _sntprintf _snprintf
+#define _sntprintf std::snprintf
 #else
-#define _sntprintf snprintf
+#define _sntprintf std::snprintf
 #endif
 
 // Fallback, if no 64-bit support

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -43,9 +43,6 @@
 
 #include "rla_pvt.h"
 
-#ifdef WIN32
-#    define snprintf _snprintf
-#endif
 
 
 OIIO_PLUGIN_NAMESPACE_BEGIN


### PR DESCRIPTION
snprintf is a C++11 feature. No need for Windows to try to substitute
_snprintf, which in any case didn't behave quite the same (didn't add a
terminating null character in the case where the alotted space will
filled and the string had to truncate).
