### PR TITLE
m_fingerprint key is the hash, not the filename.

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3230,13 +3230,15 @@ ImageCacheImpl::invalidate(ustring filename)
     for (const TileID& id : tiles_to_delete)
         m_tilecache.erase(id);
 
+    const ustring fingerprint = file->fingerprint();
+
     // Invalidate the file itself (close it and clear its spec)
     file->invalidate();
 
     // Remove the fingerprint corresponding to this file
     {
         spin_lock lock(m_fingerprints_mutex);
-        m_fingerprints.erase(filename);
+        m_fingerprints.erase(fingerprint);
     }
 
     purge_perthread_microcaches();


### PR DESCRIPTION
The m_fingerprint key is supposed to be the hash, but we were searching by filename. End result is that no fingerprints were ever removed from the m_fingerprint container. This results in crashes later on if OIIO thinks a duplicate file already exists and so rather than read it in, it tries to use the now non-existent data.

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

