### PR TITLE
vsnprintf only returns -1 on encoding error

### DIFF
--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -175,12 +175,12 @@ Strutil::vsprintf(const char* fmt, va_list ap)
         int needed = vsnprintf(buf, size, fmt, ap);
         va_end(ap);
 
-        // NB. C99 (which modern Linux and OS X follow) says vsnprintf
-        // failure returns the length it would have needed.  But older
-        // glibc and current Windows return -1 for failure, i.e., not
-        // telling us how much was needed.
-
-        if (needed < (int)size && needed >= 0) {
+        // NB. C99 says vsnprintf returns -1 on an encoding error. Otherwise
+        // it's the number of characters that would have been written if the
+        // buffer were large enough.
+        if (needed == -1)
+            return std::string("ENCODING ERROR");
+        if (needed < (int)size) {
             // It fit fine so we're done.
             return std::string(buf, (size_t)needed);
         }


### PR DESCRIPTION
I know there's a comment about vsnprintf not working properly on Windows and old linux, but that's no longer the case.  VS2015, along with linux and OSX all return -1 when there's an encoding error. Otherwise they all return the full size.

See: https://msdn.microsoft.com/en-us/library/1kt27hek.aspx and http://www.cplusplus.com/reference/cstdio/vsnprintf/.

## Description
This means that on encoding error we'll always get -1 and OIIO will keep doubling the buffer size until we run out of memory and crash.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

