### PR TITLE
Python: can't use 'from' as a parameter name -- it's a reserved word!

### DIFF
--- a/src/doc/imagebufalgo.tex
+++ b/src/doc/imagebufalgo.tex
@@ -2200,12 +2200,12 @@ higher-contrast edges.
 \label{sec:iba:color}
 
 \apiitem{ImageBuf {\ce colorconvert} (const ImageBuf \&src, \\
-  \bigspc\spc string_view from, string_view to, bool unpremult=true, \\
+  \bigspc\spc string_view fromspace, string_view tospace, bool unpremult=true, \\
   \bigspc\spc string_view context_key="", string_view context_value="", \\
   \bigspc\spc ColorConfig *colorconfig=nullptr, \\
   \bigspc\spc ROI roi=\{\}, int nthreads=0) \\
 bool {\ce colorconvert} (ImageBuf \&dst, const ImageBuf \&src, \\
-  \bigspc\spc string_view from, string_view to, bool unpremult=true, \\
+  \bigspc\spc string_view fromspace, string_view tospace, bool unpremult=true, \\
   \bigspc\spc string_view context_key="", string_view context_value="", \\
   \bigspc\spc ColorConfig *colorconfig=nullptr, \\
   \bigspc\spc ROI roi=\{\}, int nthreads=0) \\[1.0ex]
@@ -2263,13 +2263,13 @@ to \qkw{linear} and vice versa.
 \apiend
 
 \apiitem{ImageBuf {\ce ociolook} (const ImageBuf \&src, \\
-  \bigspc\spc string_view looks, string_view from, string_view to, \\
+  \bigspc\spc string_view looks, string_view fromspace, string_view tospace, \\
   \bigspc\spc bool inverse=false, bool unpremult=true, \\
   \bigspc\spc string_view context_key="", string_view context_value="", \\
   \bigspc\spc ColorConfig *colorconfig=NULL, \\
   \bigspc\spc ROI roi=\{\}, int nthreads=0) \\[1.0ex]
 bool {\ce ociolook} (ImageBuf \&dst, const ImageBuf \&src, \\
-  \bigspc\spc string_view looks, string_view from, string_view to, \\
+  \bigspc\spc string_view looks, string_view fromspace, string_view tospace, \\
   \bigspc\spc bool inverse=false, bool unpremult=true, \\
   \bigspc\spc string_view context_key="", string_view context_value="", \\
   \bigspc\spc ColorConfig *colorconfig=NULL, \\
@@ -2302,12 +2302,12 @@ environment variable will be used instead.
 
 
 \apiitem{ImageBuf {\ce ociodisplay} (const ImageBuf \&src, string_view display,\\
-  \bigspc\spc string_view view, string_view from="", string_view looks="",\\
+  \bigspc\spc string_view view, string_view fromspace="", string_view looks="",\\
   \bigspc\spc bool unpremult=true, string_view key="", string_view value="", \\
   \bigspc\spc ColorConfig *colorconfig=nullptr, \\
   \bigspc\spc ROI roi=\{\}, int nthreads=0) \\[1.0ex]
 bool {\ce ociodisplay} (ImageBuf \&dst, const ImageBuf \&src, string_view display,\\
-  \bigspc\spc string_view view, string_view from="", string_view looks="",\\
+  \bigspc\spc string_view view, string_view fromspace="", string_view looks="",\\
   \bigspc\spc bool unpremult=true, string_view key="", string_view value="", \\
   \bigspc\spc ColorConfig *colorconfig=nullptr, \\
   \bigspc\spc ROI roi=\{\}, int nthreads=0)}

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -3211,10 +3211,10 @@ the ``unsharp mask'' technique.
 \subsection{Color manipulation}
 \label{sec:iba:py:color}
 
-\apiitem{ImageBuf ImageBufAlgo.{\ce colorconvert} (src, from, to, unpremult=True, \\
+\apiitem{ImageBuf ImageBufAlgo.{\ce colorconvert} (src, fromspace, tospace, unpremult=True, \\
   \bigspc\bigspc context_key="", context_value="", \\
   \bigspc\bigspc  colorconfig="", roi=ROI.All, nthreads=0) \\
-bool ImageBufAlgo.{\ce colorconvert} (dst, src, from, to, unpremult=True, \\
+bool ImageBufAlgo.{\ce colorconvert} (dst, src, fromspace, tospace, unpremult=True, \\
   \bigspc\bigspc context_key="", context_value="", \\
   \bigspc\bigspc  colorconfig="", roi=ROI.All, nthreads=0)
 }
@@ -3230,11 +3230,11 @@ Apply a color transform to the pixel values.
 \apiend
 
 
-\apiitem{ImageBuf ImageBufAlgo.{\ce ociolook} (src, looks, from, to,  \\
+\apiitem{ImageBuf ImageBufAlgo.{\ce ociolook} (src, looks, fromspace, tospace,  \\
   \bigspc\bigspc  inverse=False, unpremult=True, \\
   \bigspc\bigspc context_key="", context_value="", colorconfig="", \\
   \bigspc\bigspc roi=ROI.All, nthreads=0)\\
-bool ImageBufAlgo.{\ce ociolook} (dst, src, looks, from, to,  \\
+bool ImageBufAlgo.{\ce ociolook} (dst, src, looks, fromspace, tospace,  \\
   \bigspc\bigspc  inverse=False, unpremult=True, \\
   \bigspc\bigspc context_key="", context_value="", colorconfig="", \\
   \bigspc\bigspc roi=ROI.All, nthreads=0)}
@@ -3252,11 +3252,11 @@ Apply an OpenColorIO ``look'' transform to the pixel values.
 
 
 \apiitem{ImageBuf ImageBufAlgo.{\ce ociodisplay} (src, display, view, \\
-  \bigspc\bigspc from=None, looks=None, unpremult=True, \\
+  \bigspc\bigspc fromspace="", looks="", unpremult=True, \\
   \bigspc\bigspc context_key="", context_value="", colorconfig="", \\
   \bigspc\bigspc roi=ROI.All, nthreads=0) \\
 bool ImageBufAlgo.{\ce ociodisplay} (dst, src, display, view, \\
-  \bigspc\bigspc from=None, looks=None, unpremult=True, \\
+  \bigspc\bigspc fromspace="", looks="", unpremult=True, \\
   \bigspc\bigspc context_key="", context_value="", colorconfig="", \\
   \bigspc\bigspc roi=ROI.All, nthreads=0)}
 \index{ImageBufAlgo!ociodisplay} \indexapi{ociodisplay}

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -623,12 +623,12 @@ bool OIIO_API rangeexpand (ImageBuf &dst, const ImageBuf &src,
 /// which may be desirable if you know that the image is "unassociated alpha"
 /// (a.k.a. "not pre-multiplied colors").
 ImageBuf OIIO_API colorconvert (const ImageBuf &src,
-                      string_view from, string_view to, bool unpremult=true,
+                      string_view fromspace, string_view tospace, bool unpremult=true,
                       string_view context_key="", string_view context_value="",
                       ColorConfig *colorconfig=nullptr,
                       ROI roi={}, int nthreads=0);
 bool OIIO_API colorconvert (ImageBuf &dst, const ImageBuf &src,
-                  string_view from, string_view to, bool unpremult=true,
+                  string_view fromspace, string_view tospace, bool unpremult=true,
                   string_view context_key="", string_view context_value="",
                   ColorConfig *colorconfig=nullptr,
                   ROI roi={}, int nthreads=0);
@@ -674,13 +674,13 @@ inline bool colorconvert (float *color, int nchannels,
 /// flag if your image contains an alpha channel. If inverse is true, it
 /// will reverse the color transformation.
 ImageBuf OIIO_API ociolook (const ImageBuf &src, string_view looks,
-                            string_view from, string_view to,
+                            string_view fromspace, string_view tospace,
                             bool unpremult=true, bool inverse=false,
                             string_view key="", string_view value="",
                             ColorConfig *colorconfig=nullptr,
                             ROI roi={}, int nthreads=0);
 bool OIIO_API ociolook (ImageBuf &dst, const ImageBuf &src, string_view looks,
-                        string_view from, string_view to,
+                        string_view fromspace, string_view tospace,
                         bool unpremult=true, bool inverse=false,
                         string_view key="", string_view value="",
                         ColorConfig *colorconfig=nullptr,
@@ -699,14 +699,14 @@ bool OIIO_API ociolook (ImageBuf &dst, const ImageBuf &src, string_view looks,
 /// (a.k.a. "not pre-multiplied colors").
 ImageBuf OIIO_API ociodisplay (const ImageBuf &src,
                                string_view display, string_view view,
-                               string_view from="", string_view looks="",
+                               string_view fromspace="", string_view looks="",
                                bool unpremult=true,
                                string_view key="", string_view value="",
                                ColorConfig *colorconfig=nullptr,
                                ROI roi={}, int nthreads=0);
 bool OIIO_API ociodisplay (ImageBuf &dst, const ImageBuf &src,
                            string_view display, string_view view,
-                           string_view from="", string_view looks="",
+                           string_view fromspace="", string_view looks="",
                            bool unpremult=true,
                            string_view key="", string_view value="",
                            ColorConfig *colorconfig=nullptr,
@@ -742,7 +742,8 @@ bool OIIO_API ociofiletransform (ImageBuf &dst, const ImageBuf &src,
 /// is just a copy if there is no identified alpha channel (and a no-op if
 /// dst and src are the same image).
 ImageBuf OIIO_API unpremult (const ImageBuf &src, ROI roi={}, int nthreads=0);
-bool OIIO_API unpremult (ImageBuf &dst, const ImageBuf &src, ROI roi={}, int nthreads=0);
+bool OIIO_API unpremult (ImageBuf &dst, const ImageBuf &src,
+                         ROI roi={}, int nthreads=0);
 
 /// Return (or copy into dst) pixels from src, and in the process multiply
 /// all color channels (those not alpha or z) by the alpha value, to
@@ -754,7 +755,8 @@ bool OIIO_API unpremult (ImageBuf &dst, const ImageBuf &src, ROI roi={}, int nth
 /// just a copy if there is no identified alpha channel (and a no-op if dst
 /// and src are the same image).
 ImageBuf OIIO_API premult (const ImageBuf &src, ROI roi={}, int nthreads=0);
-bool OIIO_API premult (ImageBuf &dst, const ImageBuf &src, ROI roi={}, int nthreads=0);
+bool OIIO_API premult (ImageBuf &dst, const ImageBuf &src,
+                       ROI roi={}, int nthreads=0);
 
 
 /// Return (or copy into dst) pixel values determined by looking up a color

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -2489,58 +2489,60 @@ declare_imagebufalgo(py::module& m)
                     "roi"_a = ROI::All(), "nthreads"_a = 0)
 
         .def_static("colorconvert", &IBA_colorconvert, "dst"_a, "src"_a,
-                    "from"_a, "to"_a, "unpremult"_a = true,
+                    "fromspace"_a, "tospace"_a, "unpremult"_a = true,
                     "roi"_a = ROI::All(), "nthreads"_a = 0)
         .def_static("colorconvert", &IBA_colorconvert_colorconfig, "dst"_a,
-                    "src"_a, "from"_a, "to"_a, "unpremult"_a = true,
+                    "src"_a, "fromspace"_a, "tospace"_a, "unpremult"_a = true,
                     "context_key"_a = "", "context_value"_a = "",
                     "colorconfig"_a = "", "roi"_a = ROI::All(),
                     "nthreads"_a = 0)
-        .def_static("colorconvert", &IBA_colorconvert_ret, "src"_a, "from"_a,
-                    "to"_a, "unpremult"_a = true, "roi"_a = ROI::All(),
-                    "nthreads"_a = 0)
+        .def_static("colorconvert", &IBA_colorconvert_ret, "src"_a,
+                    "fromspace"_a, "tospace"_a, "unpremult"_a = true,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
         .def_static("colorconvert", &IBA_colorconvert_colorconfig_ret, "src"_a,
-                    "from"_a, "to"_a, "unpremult"_a = true,
+                    "fromspace"_a, "tospace"_a, "unpremult"_a = true,
                     "context_key"_a = "", "context_value"_a = "",
                     "colorconfig"_a = "", "roi"_a = ROI::All(),
                     "nthreads"_a = 0)
 
         .def_static("ociolook", &IBA_ociolook, "dst"_a, "src"_a, "looks"_a,
-                    "from"_a, "to"_a, "unpremult"_a = true, "invert"_a = false,
-                    "context_key"_a = "", "context_value"_a = "",
-                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+                    "fromspace"_a, "tospace"_a, "unpremult"_a = true,
+                    "invert"_a = false, "context_key"_a = "",
+                    "context_value"_a = "", "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
         .def_static("ociolook", &IBA_ociolook_colorconfig, "dst"_a, "src"_a,
-                    "looks"_a, "from"_a, "to"_a, "unpremult"_a = true,
+                    "looks"_a, "fromspace"_a, "tospace"_a, "unpremult"_a = true,
                     "invert"_a = false, "context_key"_a = "",
                     "context_value"_a = "", "colorconfig"_a = "",
                     "roi"_a = ROI::All(), "nthreads"_a = 0)
-        .def_static("ociolook", &IBA_ociolook_ret, "src"_a, "looks"_a, "from"_a,
-                    "to"_a, "unpremult"_a = true, "invert"_a = false,
-                    "context_key"_a = "", "context_value"_a = "",
-                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("ociolook", &IBA_ociolook_ret, "src"_a, "looks"_a,
+                    "fromspace"_a, "tospace"_a, "unpremult"_a = true,
+                    "invert"_a = false, "context_key"_a = "",
+                    "context_value"_a = "", "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
         .def_static("ociolook", &IBA_ociolook_colorconfig_ret, "src"_a,
-                    "looks"_a, "from"_a, "to"_a, "unpremult"_a = true,
+                    "looks"_a, "fromspace"_a, "tospace"_a, "unpremult"_a = true,
                     "invert"_a = false, "context_key"_a = "",
                     "context_value"_a = "", "colorconfig"_a = "",
                     "roi"_a = ROI::All(), "nthreads"_a = 0)
 
         .def_static("ociodisplay", &IBA_ociodisplay, "dst"_a, "src"_a,
-                    "display"_a, "view"_a, "from"_a = "", "looks"_a = "",
+                    "display"_a, "view"_a, "fromspace"_a = "", "looks"_a = "",
                     "unpremult"_a = true, "context_key"_a = "",
                     "context_value"_a = "", "roi"_a = ROI::All(),
                     "nthreads"_a = 0)
         .def_static("ociodisplay", &IBA_ociodisplay_colorconfig, "dst"_a,
-                    "src"_a, "display"_a, "view"_a, "from"_a = "",
+                    "src"_a, "display"_a, "view"_a, "fromspace"_a = "",
                     "looks"_a = "", "unpremult"_a = true, "context_key"_a = "",
                     "context_value"_a = "", "colorconfig"_a = "",
                     "roi"_a = ROI::All(), "nthreads"_a = 0)
         .def_static("ociodisplay", &IBA_ociodisplay_ret, "src"_a, "display"_a,
-                    "view"_a, "from"_a = "", "looks"_a = "",
+                    "view"_a, "fromspace"_a = "", "looks"_a = "",
                     "unpremult"_a = true, "context_key"_a = "",
                     "context_value"_a = "", "roi"_a = ROI::All(),
                     "nthreads"_a = 0)
         .def_static("ociodisplay", &IBA_ociodisplay_colorconfig_ret, "src"_a,
-                    "display"_a, "view"_a, "from"_a = "", "looks"_a = "",
+                    "display"_a, "view"_a, "fromspace"_a = "", "looks"_a = "",
                     "unpremult"_a = true, "context_key"_a = "",
                     "context_value"_a = "", "colorconfig"_a = "",
                     "roi"_a = ROI::All(), "nthreads"_a = 0)


### PR DESCRIPTION
It came to my attention that IBA.ociodisplay (and also it turns out
ociolook and colorconvert) have parameters named 'from', which it turns
out that if you use the `name=value` named argument syntax in Python
will actually be a syntax error because 'from' is a reserved word!

Rename that parameter 'fromspace', and to be symmetric, also rename
'to' to 'tospace'. And do the same in C++ bindings so that they match.
