### PR TITLE
Remove unused channel arguments from convert_image()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -559,6 +559,10 @@ Developer goodies / internals:
   borrowed from LLVM. (1.9.4)
 * hash.h: add guards to make this header safe for Cuda compilation.
   #1905 (1.9.2/1.8.10)
+* imageio.h: `convert_image()` and `parallel_convert_image` have been
+  simplified to remove optional `alpha_channel` and `z_channel` parameters
+  that were never actually used. The old versions are still present but
+  are deprecated. #2088 (2.0.1)
 * parallel.h:
     * `parallel_options` passed to many functions. #1807 (1.9.2)
     * More careful avoidance of threads not recursively using the thread

--- a/src/gif.imageio/gifoutput.cpp
+++ b/src/gif.imageio/gifoutput.cpp
@@ -228,8 +228,7 @@ GIFOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
     return convert_image(spec().nchannels, spec().width, 1 /*1 scanline*/, 1,
                          data, format, xstride, AutoStride, AutoStride,
                          &m_canvas[y * spec().width * 4], TypeDesc::UINT8, 4,
-                         AutoStride, AutoStride,
-                         spec().nchannels > 3 ? 3 : -1 /*alpha channel*/);
+                         AutoStride, AutoStride);
 }
 
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1741,8 +1741,20 @@ OIIO_API bool convert_image (int nchannels, int width, int height, int depth,
                              stride_t src_zstride,
                              void *dst, TypeDesc dst_type,
                              stride_t dst_xstride, stride_t dst_ystride,
-                             stride_t dst_zstride,
-                             int alpha_channel = -1, int z_channel = -1);
+                             stride_t dst_zstride);
+/// DEPRECATED(2.0) -- the alpha_channel, z_channel were never used
+inline bool convert_image(int nchannels, int width, int height, int depth,
+            const void *src, TypeDesc src_type,
+            stride_t src_xstride, stride_t src_ystride, stride_t src_zstride,
+            void *dst, TypeDesc dst_type,
+            stride_t dst_xstride, stride_t dst_ystride, stride_t dst_zstride,
+            int alpha_channel, int z_channel = -1)
+{
+    return convert_image(nchannels, width, height, depth, src, src_type,
+                         src_xstride, src_ystride, src_zstride, dst, dst_type,
+                         dst_xstride, dst_ystride, dst_zstride);
+}
+
 
 /// A version of convert_image that will break up big jobs into multiple
 /// threads.
@@ -1753,8 +1765,20 @@ OIIO_API bool parallel_convert_image (
                stride_t src_zstride,
                void *dst, TypeDesc dst_type,
                stride_t dst_xstride, stride_t dst_ystride,
-               stride_t dst_zstride,
-               int alpha_channel=-1, int z_channel=-1, int nthreads=0);
+               stride_t dst_zstride, int nthreads=0);
+/// DEPRECATED(2.0) -- the alpha_channel, z_channel were never used
+inline bool parallel_convert_image(
+            int nchannels, int width, int height, int depth,
+            const void *src, TypeDesc src_type,
+            stride_t src_xstride, stride_t src_ystride, stride_t src_zstride,
+            void *dst, TypeDesc dst_type,
+            stride_t dst_xstride, stride_t dst_ystride, stride_t dst_zstride,
+            int alpha_channel, int z_channel, int nthreads=0)
+{
+    return parallel_convert_image (nchannels, width, height, depth,
+           src, src_type, src_xstride, src_ystride, src_zstride,
+           dst, dst_type, dst_xstride, dst_ystride, dst_zstride, nthreads);
+}
 
 /// Add random [-theramplitude,ditheramplitude] dither to the color channels
 /// of the image.  Dither will not be added to the alpha or z channel.  The

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1891,7 +1891,7 @@ ImageBuf::get_pixels(ROI roi, TypeDesc format, void* result, stride_t xstride,
             pixeladdr(roi.xbegin, roi.ybegin, roi.zbegin, roi.chbegin),
             spec().format, pixel_stride(), scanline_stride(), z_stride(),
             result, format, roi.nchannels() * format.size(), AutoStride,
-            AutoStride, -1, -1, threads());
+            AutoStride, threads());
     }
 
     // General case -- can handle IC-backed images.

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -198,7 +198,7 @@ ImageBufAlgo::copy(ImageBuf& dst, const ImageBuf& src, TypeDesc convert,
             src.z_stride(),
             dst.pixeladdr(roi.xbegin, roi.ybegin, roi.zbegin, roi.chbegin),
             dst.spec().format, dst.pixel_stride(), dst.scanline_stride(),
-            dst.z_stride(), -1, -1, nthreads);
+            dst.z_stride(), nthreads);
     }
 
     bool ok;
@@ -252,7 +252,7 @@ ImageBufAlgo::crop(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
             src.z_stride(),
             dst.pixeladdr(roi.xbegin, roi.ybegin, roi.zbegin, roi.chbegin),
             dst.spec().format, dst.pixel_stride(), dst.scanline_stride(),
-            dst.z_stride(), -1, -1, nthreads);
+            dst.z_stride(), nthreads);
     }
 
     bool ok;

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -321,7 +321,7 @@ ImageInput::read_scanlines(int subimage, int miplevel, int ybegin, int yend,
                                             &buf[0], spec.format, AutoStride,
                                             AutoStride, AutoStride, data,
                                             format, xstride, ystride, zstride,
-                                            -1 /*alpha*/, -1 /*z*/, threads());
+                                            threads());
             }
         } else {
             // Per-channel formats -- have to convert/copy channels individually
@@ -341,7 +341,7 @@ ImageInput::read_scanlines(int subimage, int miplevel, int ybegin, int yend,
                                             AutoStride, AutoStride,
                                             (char*)data + c * format.size(),
                                             format, xstride, ystride, zstride,
-                                            -1 /*alpha*/, -1 /*z*/, threads());
+                                            threads());
                 offset += n * chanformat.size();
             }
         }

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -662,8 +662,7 @@ bool
 convert_image(int nchannels, int width, int height, int depth, const void* src,
               TypeDesc src_type, stride_t src_xstride, stride_t src_ystride,
               stride_t src_zstride, void* dst, TypeDesc dst_type,
-              stride_t dst_xstride, stride_t dst_ystride, stride_t dst_zstride,
-              int alpha_channel, int z_channel)
+              stride_t dst_xstride, stride_t dst_ystride, stride_t dst_zstride)
 {
     // If no format conversion is taking place, use the simplified
     // copy_image.
@@ -714,8 +713,7 @@ parallel_convert_image(int nchannels, int width, int height, int depth,
                        const void* src, TypeDesc src_type, stride_t src_xstride,
                        stride_t src_ystride, stride_t src_zstride, void* dst,
                        TypeDesc dst_type, stride_t dst_xstride,
-                       stride_t dst_ystride, stride_t dst_zstride,
-                       int alpha_channel, int z_channel, int nthreads)
+                       stride_t dst_ystride, stride_t dst_zstride, int nthreads)
 {
     if (nthreads <= 0)
         nthreads = oiio_threads;
@@ -725,8 +723,7 @@ parallel_convert_image(int nchannels, int width, int height, int depth,
     if (nthreads <= 1)
         return convert_image(nchannels, width, height, depth, src, src_type,
                              src_xstride, src_ystride, src_zstride, dst,
-                             dst_type, dst_xstride, dst_ystride, dst_zstride,
-                             alpha_channel, z_channel);
+                             dst_type, dst_xstride, dst_ystride, dst_zstride);
 
     ImageSpec::auto_stride(src_xstride, src_ystride, src_zstride, src_type,
                            nchannels, width, height);
@@ -740,8 +737,7 @@ parallel_convert_image(int nchannels, int width, int height, int depth,
                           (const char*)src + src_ystride * ybegin, src_type,
                           src_xstride, src_ystride, src_zstride,
                           (char*)dst + dst_ystride * ybegin, dst_type,
-                          dst_xstride, dst_ystride, dst_zstride, alpha_channel,
-                          z_channel);
+                          dst_xstride, dst_ystride, dst_zstride);
         });
     return true;
 }

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -378,9 +378,7 @@ ImageOutput::to_native_rectangle(int xbegin, int xend, int ybegin, int yend,
             convert_image(1 /* channels */, width, height, depth,
                           (char*)data + c * format.size(), format, xstride,
                           ystride, zstride, &scratch[offset], chanformat,
-                          native_pixel_bytes, AutoStride, AutoStride,
-                          c == m_spec.alpha_channel ? 0 : -1,
-                          c == m_spec.z_channel ? 0 : -1);
+                          native_pixel_bytes, AutoStride, AutoStride);
             offset += chanformat.size();
         }
         return &scratch[0];


### PR DESCRIPTION
`convert_image()` and `parallel_convert_image()` had alpha_channel and
z_channel parameters that weren't actually used. I don't even remember
why they were present; I think I imagined that certain conversions might
dither the color channels or something and need to know not to do it to
these channels. But in any case, they were unused, so remove the
clutter.

