### PR TITLE
Modernize OpenCV support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -161,6 +161,10 @@ Public API changes:
       the more correct choice. Also, if their input image is clearly marked
       as having unasociated alpha already, they will not bracket the color
       conversion with the requested unpremult/premult. #1864 (1.9.2)
+    * Updated the OpenCV interoperability with new functions to_OpenCV (make
+      an ImageBuf out of a cv::Mat) and from_OpenCV (fill in a cv::Mat with
+      the contents of an ImageBuf). Deprecated the old from_IplImage and
+      to_IplImage, which are very OpenCV-1.x-centric. (2.0.2)
 * **ImageCache/TextureSystem:**
     * ImageCache and TextureSystem now have `close(filename)` and
       `close_all()` methods, which for one file or all files will close the
@@ -520,6 +524,7 @@ Build/test system improvements and platform ports:
   #2036 (1.9.4)
 * Fixes for Windows when making Unicode builds, and fix Plugin::dlopen
   on Windows to properly support UTF-8 filenames. #1454 (2.0.1)
+* Support added for OpenCV 4.0. (2.0.1)
 
 Developer goodies / internals:
 * **Formatting with clang-format**: All submissions are expected to be

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,6 +53,9 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * Field3D
  * If you want support for OpenVDB files:
      * OpenVDB >= 5.0 and Intel TBB >= 2018
+ * If you want support for converting to and from OpenCV data structures,
+   or for capturing images from a camera:
+     * OpenCV 2.x, 3.x, or 4.x
 
 
 Building OpenImageIO on Linux or OS X

--- a/src/cmake/modules/FindOpenCV.cmake
+++ b/src/cmake/modules/FindOpenCV.cmake
@@ -16,51 +16,70 @@ IF(PKG_CONFIG_FOUND AND NOT LIBRAW_PATH)
    SET(LibRaw_r_DEFINITIONS ${PC_LIBRAW_R_CFLAGS_OTHER})   
 ENDIF()
 
-find_path (OpenCV_INCLUDE_DIR opencv/cv.h
+find_path (OpenCV_INCLUDE_DIR
+           NAMES opencv4/opencv2/opencv.hpp opencv2/opencv.hpp
+           PATHS
            "${PROJECT_SOURCE_DIR}/include"
            "${OpenCV_DIR}/include"
+           "${OpenCV_DIR}/include/opencv4"
            "$ENV{OpenCV_DIR}/include"
            /usr/local/include
            /opt/local/include
+           /usr/local/opt/opencv4/include
            /usr/local/opt/opencv3/include
+           PATH_SUFFIXES opencv4
            )
-if (OpenCV_INCLUDE_DIR AND EXISTS "${OpenCV_INCLUDE_DIR}/opencv2/core/version.hpp")
-    file (STRINGS "${OpenCV_INCLUDE_DIR}/opencv2/core/version.hpp" TMP REGEX "^#define CV_VERSION_EPOCH .*$")
+
+set (_ocv_include_root "${OpenCV_INCLUDE_DIR}")
+if (OpenCV_INCLUDE_DIR AND EXISTS "${OpenCV_INCLUDE_DIR}/opencv4/opencv2/core/version.hpp")
+    set (OpenCV_INCLUDE_DIR "${OpenCV_INCLUDE_DIR}/opencv4")
+endif ()
+set (_ocv_version_file "${OpenCV_INCLUDE_DIR}/opencv2/core/version.hpp")
+if (EXISTS "${_ocv_version_file}")
+    file (STRINGS "${_ocv_version_file}" TMP REGEX "^#define CV_VERSION_EPOCH .*$")
     if (TMP)
         string (REGEX MATCHALL "[0-9]+" CV_VERSION_EPOCH ${TMP})
     endif ()
-    file (STRINGS "${OpenCV_INCLUDE_DIR}/opencv2/core/version.hpp" TMP REGEX "^#define CV_VERSION_MAJOR .*$")
+    file (STRINGS "${_ocv_version_file}" TMP REGEX "^#define CV_VERSION_MAJOR .*$")
     string (REGEX MATCHALL "[0-9]+" CV_VERSION_MAJOR ${TMP})
-    file (STRINGS "${OpenCV_INCLUDE_DIR}/opencv2/core/version.hpp" TMP REGEX "^#define CV_VERSION_MINOR .*$")
+    file (STRINGS "${_ocv_version_file}" TMP REGEX "^#define CV_VERSION_MINOR .*$")
     string (REGEX MATCHALL "[0-9]+" CV_VERSION_MINOR ${TMP})
-    file (STRINGS "${OpenCV_INCLUDE_DIR}/opencv2/core/version.hpp" TMP REGEX "^#define CV_VERSION_REVISION .*$")
+    file (STRINGS "${_ocv_version_file}" TMP REGEX "^#define CV_VERSION_REVISION .*$")
     string (REGEX MATCHALL "[0-9]+" CV_VERSION_REVISION ${TMP})
     if (CV_VERSION_EPOCH)
         set (OpenCV_VERSION "${CV_VERSION_EPOCH}.${CV_VERSION_MAJOR}.${CV_VERSION_MINOR}")
     else ()
         set (OpenCV_VERSION "${CV_VERSION_MAJOR}.${CV_VERSION_MINOR}.${CV_VERSION_REVISION}")
     endif ()
+    message (STATUS "Found OpenCV ${OpenCV_VERSION} include in ${OpenCV_INCLUDE_DIR}")
 endif ()
 
 set (libdirs "${PROJECT_SOURCE_DIR}/lib"
              "${OpenCV_DIR}/lib"
              "$ENV{OpenCV_DIR}/lib"
+             "${_ocv_include_root}/../lib"
              /usr/local/lib
              /opt/local/lib
+             /usr/local/opt/opencv4/lib
              /usr/local/opt/opencv3/lib
              )
 
-
-set (opencv_components opencv_imgproc opencv_core)
-if (NOT ${OpenCV_VERSION} VERSION_LESS 3.0.0)
-    set (opencv_components opencv_videoio ${opencv_components})
-else (NOT ${OpenCV_VERSION} VERSION_LESS 3.0.0)
-    set (opencv_components opencv_videoio ${opencv_components})
+if (NOT ${OpenCV_VERSION} VERSION_LESS 4.0.0)
+    set (opencv_components opencv_core opencv_imgproc opencv_videoio)
+elseif (NOT ${OpenCV_VERSION} VERSION_LESS 3.0.0)
+    set (opencv_components opencv_videoio opencv_imgproc opencv_core)
+else (NOT ${OpenCV_VERSION} VERSION_LESS 2.0.0)
+    set (opencv_components opencv_highgui opencv_imgproc opencv_core)
 endif ()
 foreach (component ${opencv_components})
     find_library (${component}_lib
                   NAMES ${component}
-                  PATHS ${libdirs} )
+                  PATHS ${libdirs}
+                  NO_DEFAULT_PATH)
+    # If that didn't work, try again with default paths
+    find_library (${component}_lib
+                  NAMES ${component}
+                  PATHS ${libdirs})
     if (${component}_lib)
         set (OpenCV_LIBS ${OpenCV_LIBS} ${${component}_lib})
     endif ()
@@ -68,14 +87,17 @@ endforeach ()
 
 if (OpenCV_INCLUDE_DIR AND OpenCV_LIBS)
     set (OpenCV_FOUND TRUE)
+    message (STATUS "Found OpenCV libs: ${OpenCV_LIBS}")
 endif ()
 
 include (FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS (OpenCV
-                                   REQUIRED_VARS OpenCV_LIBS OpenCV_INCLUDE_DIR
-                                   VERSION_VAR OpenCV_VERSION )
+                REQUIRED_VARS OpenCV_LIBS OpenCV_INCLUDE_DIR OpenCV_VERSION
+                VERSION_VAR   OpenCV_VERSION )
 
 MARK_AS_ADVANCED (OpenCV_VERSION
                   OpenCV_INCLUDE_DIR
                   OpenCV_LIBS
                   OpenCV_DEFINITIONS )
+unset (_ocv_version_file)
+unset (_ocv_include_root)

--- a/src/doc/imagebufalgo.tex
+++ b/src/doc/imagebufalgo.tex
@@ -2593,16 +2593,17 @@ created.  The full list of supported configuration options is:
 \apiend
 
 
-\apiitem{ImageBuf {\ce from_IplImage} (const IplImage *ipl, TypeDesc convert=TypeUnknown)}
-\index{ImageBufAlgo!from_IplImage} \indexapi{from_IplImage}
-\index{OpenCV}\indexapi{IplImage}\index{Intel Image Library}
-Convert an {\cf IplImage}, used by OpenCV and Intel's Image Libray, to
-an \ImageBuf (copying the pixels).  If {\cf convert} is
-not set to {\cf UNKNOWN}, try to establish the result as holding that
-data type and convert the {\cf IplImage} data.  Return {\cf true} if ok,
-{\cf false} if it couldn't figure out how to make the conversion from
-{\cf IplImage} to an \ImageBuf.  If OpenImageIO was compiled without OpenCV
-support, this function will fail.
+\apiitem{ImageBuf {\ce from_OpenCV} (const cv::Mat\& mat, TypeDesc convert=TypeUnknown, \\
+        \bigspc  ROI roi=\{\}, int nthreads=0)}
+\index{ImageBufAlgo!from_OpenCV} \indexapi{from_OpenCV}
+\index{OpenCV}
+Convert an OpenCV {\cf cv::Mat} into an \ImageBuf, copying the pixels
+(optionally converting to the pixel data type specified by {\cf convert}, if
+not {\cf UNKNOWN}, which means to preserve the original data type if
+possible).  Return true if ok, false if it couldn't figure out how to
+make the conversion from Mat to ImageBuf. If OpenImageIO was compiled
+without OpenCV support, this function will return an empty image with
+error message set.
 
 \begin{comment}
 \smallskip
@@ -2613,14 +2614,15 @@ support, this function will fail.
 \apiend
 
 
-\apiitem{IplImage* {\ce to_IplImage} (const ImageBuf \&src)}
-\index{ImageBufAlgo!to_IplImage} \indexapi{to_IplImage}
-\index{OpenCV}\indexapi{IplImage}\index{Intel Image Library}
-Construct an {\cf IplImage*}, used by OpenCV and Intel's Image Library,
-that is equivalent to the \ImageBuf {\cf src}.  If it is not possible, or
-if OpenImageIO was compiled without OpenCV support, then return
-{\cf nullptr}.  The ownership of the {\cf IplImage} is fully transferred to the
-calling application.
+\apiitem{bool {\ce to_OpenCV} (cv::Mat\& dst, const ImageBuf\& src,\\
+        \bigspc  ROI roi=\{\}, int nthreads=0)}
+\index{ImageBufAlgo!to_OpenCV} \indexapi{to_OpenCV}
+\index{OpenCV}
+Construct an OpenCV {\cf cv::Mat} containing the contents of \ImageBuf src,
+and return true. If it is not possible, or if OpenImageIO was compiled
+without OpenCV support, then return false. Note that OpenCV only supports up
+to 4 channels, so images with more than 4 channels will be truncated in the
+conversion.
 
 \begin{comment}
 \smallskip

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -53,6 +53,9 @@
 
 #if !defined(__OPENCV_CORE_TYPES_H__) && !defined(OPENCV_CORE_TYPES_H)
 struct IplImage;  // Forward declaration; used by Intel Image lib & OpenCV
+namespace cv {
+    class Mat;
+}
 #endif
 
 
@@ -1408,27 +1411,24 @@ bool OIIO_API fillholes_pushpull (ImageBuf &dst, const ImageBuf &src,
                                   ROI roi={}, int nthreads=0);
 
 
-/// Convert an IplImage, used by OpenCV and Intel's Image Libray, into an
-/// ImageBuf (copying the pixels).  If convert is not set to UNKNOWN,
-/// convert the IplImage to that data type. Return true if ok, false if it
-/// couldn't figure out how to make the conversion from IplImage to
-/// ImageBuf.  If OpenImageIO was compiled without OpenCV support, this
-/// function will return an empty image with error message set.
-ImageBuf OIIO_API from_IplImage (const IplImage *ipl,
-                                 TypeDesc convert=TypeUnknown);
-// DEPRECATED(1.9):
-inline bool from_IplImage (ImageBuf &dst, const IplImage *ipl,
-                           TypeDesc convert=TypeUnknown) {
-    dst = from_IplImage (ipl, convert);
-    return ! dst.has_error();
-}
+/// Convert an OpenCV cv::Mat into an ImageBuf, copying the pixels
+/// (optionally converting to the pixel data type specified by `convert`, if
+/// not UNKNOWN, which means to preserve the original data type if
+/// possible).  Return true if ok, false if it couldn't figure out how to
+/// make the conversion from Mat to ImageBuf. If OpenImageIO was compiled
+/// without OpenCV support, this function will return an empty image with
+/// error message set.
+OIIO_API ImageBuf
+from_OpenCV (const cv::Mat& mat, TypeDesc convert = TypeUnknown,
+             ROI roi={}, int nthreads=0);
 
-/// Construct an IplImage*, used by OpenCV and Intel's Image Library, that
-/// is equivalent to the ImageBuf src.  If it is not possible, or if
-/// OpenImageIO was compiled without OpenCV support, then return nullptr.
-/// The ownership of the IplImage is fully transferred to the calling
-/// application.
-OIIO_API IplImage* to_IplImage (const ImageBuf &src);
+/// Construct an OpenCV cv::Mat containing the contents of ImageBuf src, and
+/// return true. If it is not possible, or if OpenImageIO was compiled
+/// without OpenCV support, then return false. Note that OpenCV only
+/// supports up to 4 channels, so >4 channel images will be truncated in the
+/// conversion.
+OIIO_API bool to_OpenCV (cv::Mat& dst, const ImageBuf& src,
+                         ROI roi={}, int nthreads=0);
 
 /// Capture a still image from a designated camera.  If able to do so,
 /// store the image in dst and return true.  If there is no such device,
@@ -1443,6 +1443,35 @@ inline bool capture_image (ImageBuf &dst, int cameranum = 0,
     dst = capture_image (cameranum, convert);
     return !dst.has_error();
 }
+
+/// Convert an IplImage, used by OpenCV and Intel's Image Libray, into an
+/// ImageBuf (copying the pixels).  If convert is not set to UNKNOWN,
+/// convert the IplImage to that data type. Return true if ok, false if it
+/// couldn't figure out how to make the conversion from IplImage to
+/// ImageBuf.  If OpenImageIO was compiled without OpenCV support, this
+/// function will return an empty image with error message set.
+///
+/// DEPRECATED(2.0). The OpenCV 1.x era IplImage-based functions should be
+/// avoided, giving preference to from_OpenCV.
+ImageBuf OIIO_API from_IplImage (const IplImage *ipl,
+                                 TypeDesc convert=TypeUnknown);
+// DEPRECATED(1.9):
+inline bool from_IplImage (ImageBuf &dst, const IplImage *ipl,
+                           TypeDesc convert=TypeUnknown) {
+    dst = from_IplImage (ipl, convert);
+    return ! dst.has_error();
+}
+
+/// Construct an IplImage*, used by OpenCV and Intel's Image Library, that
+/// is equivalent to the ImageBuf src.  If it is not possible, or if
+/// OpenImageIO was compiled without OpenCV support, then return nullptr.
+/// The ownership of the IplImage is fully transferred to the calling
+/// application.
+///
+/// DEPRECATED(2.0). The OpenCV 1.x era IplImage-based functions should be
+/// avoided, giving preference to from_OpenCV.
+OIIO_API IplImage* to_IplImage (const ImageBuf &src);
+
 
 
 

--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -34,9 +34,21 @@
 /// These are nonfunctional if OpenCV is not found at build time.
 
 #ifdef USE_OPENCV
-#    include <opencv2/core/core_c.h>
-#    include <opencv2/highgui/highgui_c.h>
-#    include <opencv2/imgproc/imgproc_c.h>
+#    include <opencv2/core/version.hpp>
+#    ifdef CV_VERSION_EPOCH
+#        define OIIO_OPENCV_VERSION                                            \
+            (10000 * CV_VERSION_EPOCH + 100 * CV_VERSION_MAJOR                 \
+             + CV_VERSION_MINOR)
+#    else
+#        define OIIO_OPENCV_VERSION                                            \
+            (10000 * CV_VERSION_MAJOR + 100 * CV_VERSION_MINOR                 \
+             + CV_VERSION_REVISION)
+#    endif
+#    include <opencv2/opencv.hpp>
+#    if OIIO_OPENCV_VERSION >= 40000
+#        include <opencv2/core/core_c.h>
+#        include <opencv2/imgproc/imgproc_c.h>
+#    endif
 #endif
 
 #include <algorithm>
@@ -44,18 +56,24 @@
 #include <map>
 #include <vector>
 
+#include <OpenEXR/half.h>
+
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
+#include <OpenImageIO/imagebufalgo_util.h>
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/thread.h>
 
 #include "imageio_pvt.h"
 
+// using namespace cv;
+
 OIIO_NAMESPACE_BEGIN
 
 
 
+// Note: DEPRECATED(2.0)
 ImageBuf
 ImageBufAlgo::from_IplImage(const IplImage* ipl, TypeDesc convert)
 {
@@ -129,6 +147,7 @@ ImageBufAlgo::from_IplImage(const IplImage* ipl, TypeDesc convert)
 
 
 
+// Note: DEPRECATED(2.0)
 IplImage*
 ImageBufAlgo::to_IplImage(const ImageBuf& src)
 {
@@ -210,6 +229,148 @@ ImageBufAlgo::to_IplImage(const ImageBuf& src)
 
 
 
+// Templated fast swap of R and B channels.
+template<class Rtype>
+static bool
+RBswap(ImageBuf& R, ROI roi, int nthreads)
+{
+    ImageBufAlgo::parallel_image(roi, nthreads, [&](ROI roi) {
+        for (ImageBuf::Iterator<Rtype, Rtype> r(R, roi); !r.done(); ++r)
+            for (int c = roi.chbegin; c < roi.chend; ++c) {
+                Rtype tmp = r[0];
+                r[0]      = Rtype(r[2]);
+                r[2]      = tmp;
+            }
+    });
+    return true;
+}
+
+
+
+ImageBuf
+ImageBufAlgo::from_OpenCV(const cv::Mat& mat, TypeDesc convert, ROI roi,
+                          int nthreads)
+{
+    pvt::LoggedTimer logtime("IBA::from_OpenCV");
+    ImageBuf dst;
+#ifdef USE_OPENCV
+    TypeDesc srcformat;
+    switch (mat.depth()) {
+    case CV_8U: srcformat = TypeDesc::UINT8; break;
+    case CV_8S: srcformat = TypeDesc::INT8; break;
+    case CV_16U: srcformat = TypeDesc::UINT16; break;
+    case CV_16S: srcformat = TypeDesc::INT16; break;
+    case CV_32F: srcformat = TypeDesc::FLOAT; break;
+    case CV_64F: srcformat = TypeDesc::DOUBLE; break;
+    default:
+        dst.errorf("Unsupported OpenCV data type, depth=%d", mat.depth());
+        return dst;
+    }
+
+    TypeDesc dstformat = (convert != TypeDesc::UNKNOWN) ? convert : srcformat;
+    ROI matroi(0, mat.cols, 0, mat.rows, 0, 1, 0, mat.channels());
+    roi = roi_intersection(roi, matroi);
+    ImageSpec spec(roi, dstformat);
+    dst.reset(dst.name(), spec);
+    size_t pixelsize = srcformat.size() * spec.nchannels;
+    size_t linestep  = mat.step[0];
+    // Block copy and convert
+    parallel_convert_image(spec.nchannels, spec.width, spec.height, 1,
+                           mat.ptr(), srcformat, pixelsize, linestep, 0,
+                           dst.pixeladdr(roi.xbegin, roi.ybegin), dstformat,
+                           spec.pixel_bytes(), spec.scanline_bytes(), 0, -1, -1,
+                           nthreads);
+
+    // OpenCV uses BGR ordering
+    if (spec.nchannels >= 3) {
+        bool ok = true;
+        OIIO_DISPATCH_TYPES(ok, "from_OpenCV R/B swap", RBswap, dstformat, dst,
+                            roi, nthreads);
+    }
+
+#else
+    dst.error(
+        "from_OpenCV() not supported -- no OpenCV support at compile time");
+#endif
+
+    return dst;
+}
+
+
+
+bool
+ImageBufAlgo::to_OpenCV(cv::Mat& dst, const ImageBuf& src, ROI roi,
+                        int nthreads)
+{
+    pvt::LoggedTimer logtime("IBA::to_OpenCV");
+#ifdef USE_OPENCV
+    if (!roi.defined())
+        roi = src.roi();
+    roi.chend              = std::min(roi.chend, src.nchannels());
+    const ImageSpec& spec  = src.spec();
+    int chans              = std::min(4, roi.nchannels());
+    int dstFormat          = 0;
+    TypeDesc dstSpecFormat = spec.format;
+    if (spec.format == TypeDesc(TypeDesc::UINT8)) {
+        dstFormat = CV_MAKETYPE(CV_8U, chans);
+    } else if (spec.format == TypeDesc(TypeDesc::INT8)) {
+        dstFormat = CV_MAKETYPE(CV_8S, chans);
+    } else if (spec.format == TypeDesc(TypeDesc::UINT16)) {
+        dstFormat = CV_MAKETYPE(CV_16U, chans);
+    } else if (spec.format == TypeDesc(TypeDesc::INT16)) {
+        dstFormat = CV_MAKETYPE(CV_16S, chans);
+    } else if (spec.format == TypeDesc(TypeDesc::UINT32)) {
+        dstFormat     = CV_MAKETYPE(CV_16U, chans);
+        dstSpecFormat = TypeUInt16;
+    } else if (spec.format == TypeDesc(TypeDesc::INT32)) {
+        dstFormat     = CV_MAKETYPE(CV_16S, chans);
+        dstSpecFormat = TypeInt16;
+    } else if (spec.format == TypeDesc(TypeDesc::HALF)) {
+        dstFormat     = CV_MAKETYPE(CV_32F, chans);
+        dstSpecFormat = TypeFloat;
+    } else if (spec.format == TypeDesc(TypeDesc::FLOAT)) {
+        dstFormat = CV_MAKETYPE(CV_32F, chans);
+    } else if (spec.format == TypeDesc(TypeDesc::DOUBLE)) {
+        dstFormat = CV_MAKETYPE(CV_64F, chans);
+    } else {
+        DASSERT(0 && "Unknown data format in ImageBuf.");
+        return false;
+    }
+    cv::Mat mat(roi.height(), roi.width(), dstFormat);
+    if (mat.empty()) {
+        DASSERT(0 && "Unable to create cv::Mat.");
+        return false;
+    }
+
+    size_t pixelsize = dstSpecFormat.size() * chans;
+    size_t linestep  = pixelsize * roi.width();
+    bool converted   = parallel_convert_image(
+        chans, roi.width(), roi.height(), 1,
+        src.pixeladdr(roi.xbegin, roi.ybegin, roi.zbegin, roi.chbegin),
+        spec.format, spec.pixel_bytes(), spec.scanline_bytes(), 0, mat.ptr(),
+        dstSpecFormat, pixelsize, linestep, 0, -1, -1, nthreads);
+
+    if (!converted) {
+        DASSERT(0 && "convert_image failed.");
+        return false;
+    }
+
+    // OpenCV uses BGR ordering
+    if (chans == 3) {
+        cv::cvtColor(mat, mat, cv::COLOR_RGB2BGR);
+    } else if (chans == 4) {
+        cv::cvtColor(mat, mat, cv::COLOR_RGBA2BGRA);
+    }
+
+    dst = std::move(mat);
+    return true;
+#else
+    return false;
+#endif
+}
+
+
+
 namespace {
 
 #ifdef USE_OPENCV
@@ -219,26 +380,20 @@ class CameraHolder {
 public:
     CameraHolder() {}
     // Destructor frees all cameras
-    ~CameraHolder()
-    {
-        for (camera_map::iterator i = m_cvcaps.begin(); i != m_cvcaps.end();
-             ++i)
-            cvReleaseCapture(&(i->second));
-    }
+    ~CameraHolder() {}
     // Get the capture device, creating a new one if necessary.
-    CvCapture* operator[](int cameranum)
+    cv::VideoCapture* operator[](int cameranum)
     {
-        camera_map::iterator i = m_cvcaps.find(cameranum);
+        auto i = m_cvcaps.find(cameranum);
         if (i != m_cvcaps.end())
-            return i->second;
-        CvCapture* cvcam    = cvCreateCameraCapture(cameranum);
-        m_cvcaps[cameranum] = cvcam;
+            return i->second.get();
+        auto cvcam = new cv::VideoCapture(cameranum);
+        m_cvcaps[cameranum].reset(cvcam);
         return cvcam;
     }
 
 private:
-    typedef std::map<int, CvCapture*> camera_map;
-    camera_map m_cvcaps;
+    std::map<int, std::unique_ptr<cv::VideoCapture>> m_cvcaps;
 };
 
 static CameraHolder cameras;
@@ -254,24 +409,25 @@ ImageBufAlgo::capture_image(int cameranum, TypeDesc convert)
     pvt::LoggedTimer logtime("IBA::capture_image");
     ImageBuf dst;
 #ifdef USE_OPENCV
-    IplImage* frame = nullptr;
+    cv::Mat frame;
     {
         // This block is mutex-protected
         lock_guard lock(opencv_mutex);
-        CvCapture* cvcam = cameras[cameranum];
+        auto cvcam = cameras[cameranum];
         if (!cvcam) {
             dst.error("Could not create a capture camera (OpenCV error)");
             return dst;  // failed somehow
         }
-        frame = cvQueryFrame(cvcam);
-        if (!frame) {
+        (*cvcam) >> frame;
+        if (frame.empty()) {
             dst.error("Could not cvQueryFrame (OpenCV error)");
             return dst;  // failed somehow
         }
     }
 
-    dst = from_IplImage(frame, convert);
-    // cvReleaseImage (&frame);   // unnecessary?
+    logtime.stop();
+    dst = from_OpenCV(frame, convert);
+    logtime.start();
     if (!dst.has_error()) {
         time_t now;
         time(&now);
@@ -288,7 +444,6 @@ ImageBufAlgo::capture_image(int cameranum, TypeDesc convert)
     dst.error(
         "capture_image not supported -- no OpenCV support at compile time");
 #endif
-
     return dst;
 }
 

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -135,6 +135,7 @@ public:
             log_time (m_name, m_timer);
     }
     void stop () { m_timer.stop(); }
+    void start () { m_timer.start(); }
     void rename (string_view name) { m_name = name; }
 private:
     Timer m_timer;

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -3153,7 +3153,7 @@ action_capture(int argc, const char* argv[])
     int camera = Strutil::from_string<int>(options["camera"]);
 
     ImageBuf ib;
-    bool ok = ImageBufAlgo::capture_image(ib, camera, TypeDesc::FLOAT);
+    bool ok = ImageBufAlgo::capture_image(ib, camera /*, TypeDesc::FLOAT*/);
     if (!ok)
         ot.error(command, ib.geterror());
     ImageRecRef img(new ImageRec("capture", ib.spec(), ot.imagecache));


### PR DESCRIPTION
Should now build against OpenCV 2.x, 3.x, and 4.x. (Note that 4.x was just released days ago.)

Added more modern from_OpenCV and to_OpenCV, converting ImageBuf <-> cv::Mat, and taking the common ROI and nthreads parameters that we use for the rest of IBA.  Deprecate the old IplImage-based functions, which is an OpenCV 1.x thing.

Add a test of ImageBuf -> cv::Mat -> ImageBuf round trip to make sure it works.

Fixes #2087 
