### PR TITLE
Make Travis build OCIO faster, only build the parts we need

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,7 @@ install:
           export OPENEXR_ROOT_DIR=$PWD/ext/openexr-install ;
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OPENEXR_ROOT_DIR/lib ;
           CXX="ccache $CXX" CCACHE_CPP2=1 src/build-scripts/build_ocio.bash ;
-          export OCIO_PATH=$PWD/ext/OpenColorIO/dist ;
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OCIO_PATH/lib ;
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/ext/OpenColorIO/dist/lib ;
       fi
     - src/build-scripts/install_test_images.bash
 

--- a/src/build-scripts/build_ocio.bash
+++ b/src/build-scripts/build_ocio.bash
@@ -5,6 +5,11 @@ OCIOBUILDDIR=${OCIOBUILDDIR:=${PWD}/ext/OpenColorIO}
 OCIOINSTALLDIR=${OCIOINSTALLDIR:=${PWD}/ext/OpenColorIO/dist}
 OCIOBRANCH=${OCIOBRANCH:=v1.1.0}
 OCIOCXXFLAGS=${OCIOCXXFLAGS:="-Wno-unused-function -Wno-deprecated-declarations -Wno-cast-qual -Wno-write-strings"}
+# Just need libs:
+OCIO_BUILDOPTS="-DOCIO_BUILD_APPS=OFF -DOCIO_BUILD_NUKE=OFF \
+               -DOCIO_BUILD_DOCS=OFF -DOCIO_BUILD_TESTS=OFF \
+               -DOCIO_BUILD_PYTHON=OFF -DOCIO_BUILD_PYGLUE=OFF \
+               -DOCIO_BUILD_JAVA=OFF"
 BASEDIR=`pwd`
 pwd
 echo "OpenColorIO install dir will be: ${OCIOINSTALLDIR}"
@@ -22,9 +27,7 @@ cd OpenColorIO
 echo "git checkout ${OCIOBRANCH} --force"
 git checkout ${OCIOBRANCH} --force
 mkdir -p build
-cd build
-cmake --config Release -DCMAKE_INSTALL_PREFIX=${OCIOINSTALLDIR} -DCMAKE_CXX_FLAGS="${OCIOCXXFLAGS}" .. && make clean && make -j 4 && make install
-cd ..
+time (cd build ; cmake --config Release -DCMAKE_INSTALL_PREFIX=${OCIOINSTALLDIR} -DCMAKE_CXX_FLAGS="${OCIOCXXFLAGS}" ${OCIO_BUILDOPTS} .. && make clean && make -j 4 && make install)
 popd
 
 ls -R ${OCIOINSTALLDIR}


### PR DESCRIPTION
We only need the OCIO libraries, can exclude building binary utilities, python and java bindings, docs, etc., to reduce the time needed to build OCIO and thus shave a minute or so off of every Travis test.
