### PR TITLE
Cleanup and refinement of our "clang-tidy" pipeline.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,11 @@
+Checks:          '-*,clang-analyzer-security*'
+WarningsAsErrors: ''
+HeaderFilterRegex: '(OpenImageIO/[a-zA-Z0-9_]+\.h)|(imageio)|(oiio)|(iv/)|(_pvt\.h)'
+AnalyzeTemporaryDtors: false
+User:            lg
+CheckOptions:
+  - key:            modernize-use-nullptr.NullMacros
+    value:          'NULL'
+  - key:            modernize-use-emplace.SmartPointers
+    value:          'OIIO::intrusive_ptr'
+...

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,10 @@ install:
           export PATH=/usr/local/opt/qt5/bin:$PATH ;
           export PATH=/usr/local/opt/python/libexec/bin:$PATH ;
           export PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages:$PYTHONPATH ;
+          if [ "${CLANG_TIDY}" != "" ] ; then
+              export PATH=/usr/local/Cellar/llvm/7.0.0_1/bin:$PATH ;
+              echo $PATH ;
+          fi ;
       elif [ $TRAVIS_OS_NAME == linux ] ; then
           CXX="ccache $CXX" CCACHE_CPP2=1 src/build-scripts/build_openexr.bash ;
           export ILMBASE_ROOT_DIR=$PWD/ext/openexr-install ;
@@ -78,6 +82,16 @@ install:
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OPENEXR_ROOT_DIR/lib ;
           CXX="ccache $CXX" CCACHE_CPP2=1 src/build-scripts/build_ocio.bash ;
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/ext/OpenColorIO/dist/lib ;
+          if [ "${CLANG_TIDY}" != "" ] ; then
+              export LLVM_VERSION=7.0.0 ;
+              export LLVMTAR=clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-14.04.tar.xz ;
+              time wget http://releases.llvm.org/${LLVM_VERSION}/${LLVMTAR} ;
+              tar xf $LLVMTAR ;
+              rm -f $LLVMTAR ;
+              mv clang+llvm* llvm-install ;
+              export LLVM_DIRECTORY=$PWD/llvm-install ;
+              export PATH=$LLVM_DIRECTORY/bin:$PATH ;
+          fi
       fi
     - src/build-scripts/install_test_images.bash
 
@@ -99,7 +113,7 @@ script:
     - git diff --color ;
       THEDIFF=`git diff` ;
       if [ "$THEDIFF" != "" ] ; then
-          echo "git diff was not empty. Failing clang-format check." ;
+          echo "git diff was not empty. Failing clang-format or clang-tidy check." ;
           exit 1 ;
       fi
 
@@ -172,7 +186,7 @@ matrix:
       ##  osx_image: xcode8.3
       ##  compiler: clang
       ##  env: LINKSTATIC=1 USE_FFMPEG=0 USE_OCIO=0 USE_OPENCV=0
-    # Build with sanitizers
+    # Dynamic analysis: build with sanitizers and run most tests.
     # Because this test takes so long to run, only build for PRs, direct
     # pushes to master or RB branches, or if the branch name includes
     # "sanitize". Other ordinary work branch pushes don't need to run this
@@ -239,6 +253,14 @@ matrix:
         compiler: clang
         env: OIIOTARGET=clang-format SKIP_TESTS=1 BUILD_MISSING_DEPS=0
         #if: branch =~ /(master|RB|travis|simd)/ OR type = pull_request
+    # Static analysis: build with clang-tidy.
+    # Disabled -- this takes so long to run, it can't complete in Travis's
+    # 50 minute time limit. Left here just to show how it should work.
+      #  - name: "Static analysis / clang-tidy"
+      #    os: linux
+      #    compiler: gcc
+      #    env: CLANG_TIDY=1 CLANG_TIDY_FIX=1 SKIP_TESTS=1
+      #    if: branch =~ /(master|RB|travis|tidy)/ OR type = pull_request
     # Build with EMBEDPLUGINS=0, both platforms.
       # FIXME: doesn't work yet on Travis
       # - os: linux

--- a/site/spi/Makefile-bits-arnold
+++ b/site/spi/Makefile-bits-arnold
@@ -199,8 +199,10 @@ else ifeq (${platform}, macosx)
         MY_CMAKE_FLAGS += \
            -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8
         USE_LIBCPLUSPLUS := 0
+    else ifeq (${COMPILER},clang6)
+        MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=/usr/local/Cellar/llvm@6/6.0.1_1/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/Cellar/llvm@6/6.0.1_1/bin/clang++
     else ifeq (${COMPILER},clang7)
-        MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=/usr/local/Cellar/llvm/7.0.0/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/Cellar/llvm/7.0.0/bin/clang++
+        MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=/usr/local/Cellar/llvm/7.0.0_1/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/Cellar/llvm/7.0.0_1/bin/clang++
     else ifeq (${COMPILER},clang)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
     else ifeq (${COMPILER},gcc)

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -51,6 +51,12 @@ if [ "$LINKSTATIC" == "1" ] ; then
     brew install homebrew/dupes/bzip2
     brew install yaml-cpp --with-static-lib
 fi
+if [ "$CLANG_TIDY" != "" ] ; then
+    # If we are running for the sake of clang-tidy only, we will need
+    # a modern clang version not just the xcode one.
+    brew install llvm
+fi
+
 echo ""
 echo "After brew installs:"
 brew list --versions


### PR DESCRIPTION
Clang-tidy is part of clang tooling that's a static analyzer of
everything from "unsafe" code that violates security guidelines, to
stylistic fixes.  There are dozens and dozens of tests. Initially we are
just enabling some basic security and correctness tests. Will add more
later.

All you need to do to run it is

    make CLANG_TIDY=1

Or if running cmake directly, use -DCLANG_TIDY=1

Warning: it is a long compile.

Set up a Travis test to run clang-tidy for static analysis. But after
much trial and error, I just couldn't get it to run in the 50 minutes
that Travis allows. So for now it's disabled. But if we ever have a CI
solution that executes faster or has longer time limits, I would love to
do a full static analysis on every PR. For now, I will have to be
content running it by hand on my own machine from time to time (and for
every tagged release).
