### PR TITLE
oiiotool: -evaloff -evalon to temporarily disable expression evaluation.

### DIFF
--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -265,6 +265,19 @@ original image:
         -o cropped_{TOP.filename}
 \end{smallcode}
 
+\NEW % 2.0
+If you should come across filenames that contain braces (these are vary
+rare, but have been known to happen), you temporarily disable expression
+evaluation with the {\cf --evaloff} end {\cf --evalon} flags. For example:
+
+\begin{smallcode}
+    $ oiiotool --info "{weird}.exr"
+    > oiiotool ERROR: expression : syntax error at char 1 of `weird'
+
+    $ oiiotool --info --evaloff "{weird}.exr"
+    > weird.exr            : 2048 x 1536, 3 channel, half openexr
+\end{smallcode}
+
 \section{\oiiotool Tutorial / Recipes}
 
 This section will give quick examples of common uses of \oiiotool to get
@@ -952,6 +965,15 @@ and {\cf \%v}). If not supplied, the view list will be {\cf left,right}.
 Turns off (or on) numeric wildcard expansion for subsequent command
 line arguments. This can be useful in selectively disabling numeric wildcard
 expansion for a subset of the command line.
+\apiend
+
+\apiitem{\ce --evaloff \\
+--evalon}
+\NEW % 2.0
+Turns off (or on) expression evaluation (things with {\cf \{\}})  for
+subsequent command line arguments. This can be useful in selectively
+disabling expression evaluation expansion for a subset of the command line,
+for example if you actually have filenames containing curly braces.
 \apiend
 
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -177,6 +177,7 @@ Oiiotool::clear_options()
     // in combination with autotile. When the deadlock possibility is fixed,
     // maybe we'll turn it back to on by default.
     frame_padding = 0;
+    eval_enable   = true;
     full_command_line.clear();
     printinfo_metamatch.clear();
     printinfo_nometamatch.clear();
@@ -486,6 +487,26 @@ unset_autopremult(int argc, const char* argv[])
     ot.imagecache->attribute("unassociatedalpha", 1);
     ot.input_config.attribute("oiio:UnassociatedAlpha", 1);
     ot.input_config_set = true;
+    return 0;
+}
+
+
+
+static int
+enable_eval(int argc, const char* argv[])
+{
+    ASSERT(argc == 1);
+    ot.eval_enable = true;
+    return 0;
+}
+
+
+
+static int
+disable_eval(int argc, const char* argv[])
+{
+    ASSERT(argc == 1);
+    ot.eval_enable = false;
     return 0;
 }
 
@@ -1314,6 +1335,9 @@ Oiiotool::express_impl(string_view s)
 string_view
 Oiiotool::express(string_view str)
 {
+    if (!eval_enable)
+        return str;  // Expression evaluation disabled
+
     string_view s = str;
     // eg. s="ab{cde}fg"
     size_t openbrace = s.find('{');
@@ -5450,6 +5474,8 @@ getargs(int argc, char* argv[])
                 "--views %s", NULL, "Views for %V/%v wildcards (comma-separated, defaults to left,right)",
                 "--wildcardoff", NULL, "Disable numeric wildcard expansion for subsequent command line arguments",
                 "--wildcardon", NULL, "Enable numeric wildcard expansion for subsequent command line arguments",
+                "--evaloff %@", disable_eval, nullptr, "Disable {expression} evaluation for subsequent command line arguments",
+                "--evalon %@", enable_eval, nullptr, "Enable {expression} evaluation for subsequent command line arguments",
                 "--no-autopremult %@", unset_autopremult, NULL, "Turn off automatic premultiplication of images with unassociated alpha",
                 "--autopremult %@", set_autopremult, NULL, "Turn on automatic premultiplication of images with unassociated alpha",
                 "--autoorient", &ot.autoorient, "Automatically --reorient all images upon input",

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -85,6 +85,7 @@ public:
     int cachesize;
     int autotile;
     int frame_padding;
+    bool eval_enable;  // Enable evaluation of expressions
     std::string full_command_line;
     std::string printinfo_metamatch;
     std::string printinfo_nometamatch;

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -75,6 +75,9 @@ Sequence -5--2:  -3
 Sequence -5--2:  -2
 xyz should say xyz
 timecode is 01:02:03:04
+2
+{3+4}
+4
 Reading black.tif
     oiio:DebugOpenConfig!: 42
 Reading add_rgb_rgba.exr

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -225,6 +225,8 @@ command += oiiotool ("src/tahoe-tiny.tif -subc '{TOP.MINCOLOR}' -divc '{TOP.MAXC
 # 'foo/bar'.
 command += oiiotool ("-create 16x16 3 -attrib \"foo/bar\" \"xyz\" -echo \"{TOP.'foo/bar'} should say xyz\"")
 command += oiiotool ("-create 16x16 3 -attrib smpte:TimeCode \"01:02:03:04\" -echo \"timecode is {TOP.'smpte:TimeCode'}\"")
+# Ensure that --evaloff/--evalon work
+command += oiiotool ("-echo \"{1+1}\" --evaloff -echo \"{3+4}\" --evalon -echo \"{2*2}\"")
 
 # test --iconfig
 command += oiiotool ("--info -v -metamatch Debug --iconfig oiio:DebugOpenConfig! 1 black.tif")


### PR DESCRIPTION
Because what if some loon has curly braces in a filename? It must be
rare because nobody has come across this problem in the years since
OIIO 1.6 added expression evaluation. But it happened today!

So you can do this:

    oiiotool -echo {3+4} -evaloff -echo {1+1} -evalon -echo {8*2}

And you will see ouput

    7
    {1+1}
    16

