### PR TITLE
Clean up Python ability to iterate over ParamValueList

### DIFF
--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -80,6 +80,8 @@ static int basetype_size[TypeDesc::LASTBASE] = {
 size_t
 TypeDesc::basesize() const
 {
+    if (basetype >= TypeDesc::LASTBASE)
+        return 0;
     DASSERT(basetype < TypeDesc::LASTBASE);
     return basetype_size[basetype];
 }

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -142,6 +142,8 @@ declare_imagespec(py::module& m)
         .def(py::init<const ROI&, TypeDesc>())
         .def(py::init<TypeDesc>())
         .def(py::init<const ImageSpec&>())
+        .def("copy", [](const ImageSpec& self) { return ImageSpec(self); },
+             py::return_value_policy::reference_internal)
         .def("set_format", &ImageSpec::set_format)
         .def("default_channel_names", &ImageSpec::default_channel_names)
         .def("channel_bytes",

--- a/src/python/py_paramvalue.cpp
+++ b/src/python/py_paramvalue.cpp
@@ -103,13 +103,19 @@ declare_paramvalue(py::module& m)
 
     py::class_<ParamValueList>(m, "ParamValueList")
         .def(py::init<>())
-        .def("__getitem__", [](ParamValueList& self, int i) { return self[i]; },
+        .def("__getitem__",
+             [](const ParamValueList& self, size_t i) {
+                 if (i >= self.size())
+                     throw py::index_error();
+                 return self[i];
+             },
              py::return_value_policy::reference_internal)
-
-        // .def("__iter__", boost::python::iterator<ParamValueList>())
         .def("__len__", [](const ParamValueList& p) { return p.size(); })
-        // .def("grow",        &ParamValueList::grow,
-        //     py::return_value_policy::reference_internal)
+        .def("__iter__",
+             [](const ParamValueList& self) {
+                 return py::make_iterator(self.begin(), self.end());
+             },
+             py::keep_alive<0, 1>())
         .def("append", [](ParamValueList& p,
                           const ParamValue& v) { return p.push_back(v); })
         .def("clear", &ParamValueList::clear)

--- a/testsuite/python-imagebuf/src/test_imagebuf.py
+++ b/testsuite/python-imagebuf/src/test_imagebuf.py
@@ -33,11 +33,17 @@ def print_imagespec (spec, subimage=0, mip=0, msg="") :
     print ("  alpha channel = ", spec.alpha_channel)
     print ("  z channel = ", spec.z_channel)
     print ("  deep = ", spec.deep)
-    for i in range(len(spec.extra_attribs)) :
-        if type(spec.extra_attribs[i].value) == str :
-            print (" ", spec.extra_attribs[i].name, "= \"" + spec.extra_attribs[i].value + "\"")
+    for attrib in spec.extra_attribs :
+        if type(attrib.value) == str :
+            print (" ", attrib.name, "= \"" + attrib.value + "\"")
         else :
-            print (" ", spec.extra_attribs[i].name, "=", spec.extra_attribs[i].value)
+            print (" ", attrib.name, "=", attrib.value)
+    # Equivalent, using indexing rather than iterating:
+    #for i in range(len(spec.extra_attribs)) :
+    #    if type(spec.extra_attribs[i].value) == str :
+    #        print (" ", spec.extra_attribs[i].name, "= \"" + spec.extra_attribs[i].value + "\"")
+    #    else :
+    #        print (" ", spec.extra_attribs[i].name, "=", spec.extra_attribs[i].value)
 
 
 def write (image, filename, format=oiio.UNKNOWN) :


### PR DESCRIPTION
The most important change is that we were missing the `__iter__` method.
That was preventing proper iteration over the entries in a
ParamValueList (you could still iterate over the length and index like
an array to retrieve the entries). I did some other cleanup as well, to
conform to the pybind11 examples that handle similar cases.  Also added
a `copy` method to ImageSpec, which it was lacking.

Iterating still seems to fail for me on OSX, only for some image files,
dumps core after visiting the last item in the list (I guess, as it
iterates past the end).  Works on Linux, works on TravisCI (both Linux
and OSX).  I've struggled with this for a few days and I'm not sure what
to try next.  Maybe the problem is sensitive to particular python
versions?

In any case, if you can't get this to work:

    for attr in myparamvaluelist :
        print attr.name

Try this, which I'm sure works:

    for i in range(len(myparamvaluelist)) :
        print myparamvaluelist[i].name

Meanwhile I will continue to investigate. But for now, these are all
the fixes that I know to make.
