### PR TITLE
Fix instances of possibly unsafe string copying

### DIFF
--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -73,13 +73,14 @@ private:
     FILE* m_fd;              ///< The open file handle
     int m_subimage;          ///< What subimage are we looking at?
     int m_next_scanline;     ///< Next scanline to read
-    char rgbe_error[1024];   ///< Buffer for RGBE library error msgs
+    std::string rgbe_error;  ///< Buffer for RGBE library error msgs
 
     void init()
     {
         m_fd            = NULL;
         m_subimage      = -1;
         m_next_scanline = 0;
+        rgbe_error.clear();
     }
 };
 

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -58,10 +58,14 @@ public:
 private:
     FILE* m_fd;
     std::vector<unsigned char> scratch;
-    char rgbe_error[1024];  ///< Buffer for RGBE library error msgs
+    std::string rgbe_error;  // Buffer for RGBE library error msgs
     std::vector<unsigned char> m_tilebuffer;
 
-    void init(void) { m_fd = NULL; }
+    void init(void)
+    {
+        m_fd = NULL;
+        rgbe_error.clear();
+    }
 };
 
 

--- a/src/hdr.imageio/rgbe.h
+++ b/src/hdr.imageio/rgbe.h
@@ -47,23 +47,23 @@ typedef struct {
 /* read or write headers */
 /* you may set rgbe_header_info to null if you want to */
 int RGBE_WriteHeader(FILE *fp, int width, int height, rgbe_header_info *info,
-                     char *errbuf=NULL);
+                     std::string &errbuf);
 int RGBE_ReadHeader(FILE *fp, int *width, int *height, rgbe_header_info *info,
-                    char *errbuf=NULL);
+                    std::string &errbuf);
 
 /* read or write pixels */
 /* can read or write pixels in chunks of any size including single pixels*/
 int RGBE_WritePixels(FILE *fp, float *data, int numpixels,
-                     char *errbuf=NULL);
+                     std::string &errbuf);
 int RGBE_ReadPixels(FILE *fp, float *data, int numpixels,
-                    char *errbuf=NULL);
+                    std::string &errbuf);
 
 /* read or write run length encoded files */
 /* must be called to read or write whole scanlines */
 int RGBE_WritePixels_RLE(FILE *fp, float *data, int scanline_width,
-			 int num_scanlines, char *errbuf=NULL);
+			 int num_scanlines, std::string &errbuf);
 int RGBE_ReadPixels_RLE(FILE *fp, float *data, int scanline_width,
-			int num_scanlines, char *errbuf=NULL);
+			int num_scanlines, std::string &errbuf);
 
 OIIO_PLUGIN_NAMESPACE_END
 

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -293,9 +293,9 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
             if ((unsigned int)(num_markers * MAX_DATA_BYTES_IN_MARKER)
                 != icc_profile_length)
                 num_markers++;
-            int curr_marker = 1; /* per spec, count strarts at 1*/
-            std::vector<unsigned char> profile(MAX_DATA_BYTES_IN_MARKER
-                                               + ICC_HEADER_SIZE);
+            int curr_marker     = 1; /* per spec, count strarts at 1*/
+            size_t profile_size = MAX_DATA_BYTES_IN_MARKER + ICC_HEADER_SIZE;
+            std::vector<unsigned char> profile(profile_size);
             while (icc_profile_length > 0) {
                 // length of profile to put in this marker
                 unsigned int length
@@ -303,7 +303,7 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
                                (unsigned int)MAX_DATA_BYTES_IN_MARKER);
                 icc_profile_length -= length;
                 // Write the JPEG marker header (APP2 code and marker length)
-                strcpy((char*)&profile[0], "ICC_PROFILE");
+                strncpy((char*)&profile[0], "ICC_PROFILE", profile_size);
                 profile[11] = 0;
                 profile[12] = curr_marker;
                 profile[13] = (unsigned char)num_markers;

--- a/src/libutil/SHA1.cpp
+++ b/src/libutil/SHA1.cpp
@@ -270,24 +270,24 @@ bool CSHA1::ReportHash(char* szReport, REPORT_TYPE rtReportType) const
 	if((rtReportType == REPORT_HEX) || (rtReportType == REPORT_HEX_SHORT))
 	{
 		_sntprintf(szTemp, 15, "%02X", m_digest[0]);
-		strcpy(szReport, szTemp);
+		strncpy(szReport, szTemp, 15);
 
 		const char* lpFmt = ((rtReportType == REPORT_HEX) ? " %02X" : "%02X");
 		for(size_t i = 1; i < 20; ++i)
 		{
 			_sntprintf(szTemp, 15, lpFmt, m_digest[i]);
-			strcat(szReport, szTemp);
+			strncat(szReport, szTemp, 15);
 		}
 	}
 	else if(rtReportType == REPORT_DIGIT)
 	{
 		_sntprintf(szTemp, 15, "%u", m_digest[0]);
-		strcpy(szReport, szTemp);
+		strncpy(szReport, szTemp, 15);
 
 		for(size_t i = 1; i < 20; ++i)
 		{
 			_sntprintf(szTemp, 15, " %u", m_digest[i]);
-			strcat(szReport, szTemp);
+			strncat(szReport, szTemp, 15);
 		}
 	}
 	else return false;


### PR DESCRIPTION
Use of clang-tidy found several instances of "unsafe" string copy or concatenation -- using functions that don't take a buffer length.

In truth, we humans know that these were probably fine in their context, but it's true that those unsafe string functions should be avoided and it's desirable to get clean static analysis on all the security-related tests.

It's worth noting that these changes in rgba.{h,cpp} diverge us from the original sources (they were imported from code by Greg Ward and Bruce Walter). I usually prefer that when we import entire modules of code from elsewhere, we don't make any changes at all, or even reformat to our conventions, so that we can easily integrate future improvements to the upstream sources. But after mulling this over, I think that in this case, it's not actively maintained code, and in 10 years we have never had to integrate fixes. So let's just consider these fully absorbed and able to change at will for our own purposes.
