### PR TITLE
strided_ptr: fix subtly incorrect semantics of increment/decrement

### DIFF
--- a/src/include/OpenImageIO/strided_ptr.h
+++ b/src/include/OpenImageIO/strided_ptr.h
@@ -94,7 +94,7 @@ public:
 
     // Increment and decrement moves the pointer to the next element
     // one stride length away.
-    const strided_ptr& operator++()
+    strided_ptr& operator++()
     {  // prefix
         m_ptr = getptr(1);
         return *this;
@@ -105,7 +105,7 @@ public:
         ++(*this);
         return r;
     }
-    const strided_ptr& operator--()
+    strided_ptr& operator--()
     {  // prefix
         m_ptr = getptr(-1);
         return *this;


### PR DESCRIPTION
This is a very small nit to pick, but pre-increment and pre-decrement is
supposed to return a ref, not a const ref.

