### PR TITLE
Change remaining atoi/atof to use Strutil::stoi/stof

### DIFF
--- a/src/cineon.imageio/libcineon/CineonHeader.cpp
+++ b/src/cineon.imageio/libcineon/CineonHeader.cpp
@@ -522,19 +522,19 @@ void cineon::IndustryHeader::SetFilmEdgeCode(const char *edge)
 	char buf[7];
 
 	strncpy(buf, edge, 2);
-	this->filmManufacturingIdCode = atoi(buf);
+	this->filmManufacturingIdCode = OIIO::Strutil::stoi(buf);
 
 	strncpy(buf, edge + 2, 2);
-	this->filmType = atoi(buf);
+	this->filmType = OIIO::Strutil::stoi(buf);
 
 	strncpy(buf, edge + 4, 2);
-	this->perfsOffset = atoi(buf);
+	this->perfsOffset = OIIO::Strutil::stoi(buf);
 
 	strncpy(buf, edge + 6, 6);
-	this->prefix = atoi(buf);
+	this->prefix = OIIO::Strutil::stoi(buf);
 
 	strncpy(buf, edge + 12, 4);
-	this->count = atoi(buf);
+	this->count = OIIO::Strutil::stoi(buf);
 }
 
 

--- a/src/fits.imageio/fitsinput.cpp
+++ b/src/fits.imageio/fitsinput.cpp
@@ -284,22 +284,22 @@ FitsInput::read_fits_header(void)
         // m_naxes - number of axes
         // width, height and depth of the image
         if (keyname == "BITPIX") {
-            m_bitpix = atoi(&card[10]);
+            m_bitpix = Strutil::stoi(&card[10]);
             continue;
         }
         if (keyname == "NAXIS") {
-            m_naxes = atoi(&card[10]);
+            m_naxes = Strutil::stoi(&card[10]);
             if (m_naxes == 1)  // 1 axis is w x 1 image
                 m_spec.height = m_spec.full_height = 1;
             continue;
         }
         if (keyname == "NAXIS1") {
-            m_spec.width      = atoi(&card[10]);
+            m_spec.width      = Strutil::stoi(&card[10]);
             m_spec.full_width = m_spec.width;
             continue;
         }
         if (keyname == "NAXIS2") {
-            m_spec.height      = atoi(&card[10]);
+            m_spec.height      = Strutil::stoi(&card[10]);
             m_spec.full_height = m_spec.height;
             continue;
         }
@@ -401,21 +401,22 @@ FitsInput::subimage_search()
 std::string
 FitsInput::convert_date(const std::string& date)
 {
+    using Strutil::stoi;
     std::string ndate;
     if (date[4] == '-') {
         // YYYY-MM-DDThh:mm:ss convention is used since 1 January 2000
-        ndate = Strutil::sprintf("%04u:%02u:%02u", atoi(&date[0]),
-                                 atoi(&date[5]), atoi(&date[8]));
+        ndate = Strutil::sprintf("%04u:%02u:%02u", stoi(&date[0]),
+                                 stoi(&date[5]), stoi(&date[8]));
         if (date.size() >= 11 && date[10] == 'T')
-            ndate += Strutil::sprintf(" %02u:%02u:%02u", atoi(&date[11]),
-                                      atoi(&date[14]), atoi(&date[17]));
+            ndate += Strutil::sprintf(" %02u:%02u:%02u", stoi(&date[11]),
+                                      stoi(&date[14]), stoi(&date[17]));
         return ndate;
     }
 
     if (date[2] == '/') {
         // DD/MM/YY convention was used before 1 January 2000
-        ndate = Strutil::sprintf("19%02u:%02u:%02u 00:00:00", atoi(&date[6]),
-                                 atoi(&date[3]), atoi(&date[0]));
+        ndate = Strutil::sprintf("19%02u:%02u:%02u 00:00:00", stoi(&date[6]),
+                                 stoi(&date[3]), stoi(&date[0]));
         return ndate;
     }
     // unrecognized format

--- a/src/fits.imageio/fitsoutput.cpp
+++ b/src/fits.imageio/fitsoutput.cpp
@@ -220,11 +220,12 @@ FitsOutput::create_fits_header(void)
         // FITS use Date keyword for dates so we convert our DateTime attribute
         // to Date format before adding it to the FITS file
         if (keyname == "DateTime") {
+            using Strutil::stoi;
             keyname = "Date";
             value   = Strutil::sprintf("%04u-%02u-%02uT%02u:%02u:%02u",
-                                     atoi(&value[0]), atoi(&value[5]),
-                                     atoi(&value[8]), atoi(&value[11]),
-                                     atoi(&value[14]), atoi(&value[17]));
+                                     stoi(&value[0]), stoi(&value[5]),
+                                     stoi(&value[8]), stoi(&value[11]),
+                                     stoi(&value[14]), stoi(&value[17]));
         }
 
         header += create_card(keyname, value);

--- a/src/include/OpenImageIO/pugixml.cpp
+++ b/src/include/OpenImageIO/pugixml.cpp
@@ -8075,7 +8075,7 @@ PUGI__NS_BEGIN
 		char* exponent_string = strchr(buffer, 'e');
 		assert(exponent_string);
 
-		int exponent = atoi(exponent_string + 1);
+		int exponent = atoi(exponent_string + 1); // NOLINT(cert-err34-c)
 
 		// extract mantissa string: skip sign
 		char* mantissa = buffer[0] == '-' ? buffer + 1 : buffer;

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -1088,27 +1088,27 @@ ImageSpec::from_xml(const char* xml)
     //int version = n.attribute ("version").as_int();
 
     // Fields for version == 10 (current)
-    x           = atoi(n.child_value("x"));
-    y           = atoi(n.child_value("y"));
-    z           = atoi(n.child_value("z"));
-    width       = atoi(n.child_value("width"));
-    height      = atoi(n.child_value("height"));
-    depth       = atoi(n.child_value("depth"));
-    full_x      = atoi(n.child_value("full_x"));
-    full_y      = atoi(n.child_value("full_y"));
-    full_z      = atoi(n.child_value("full_z"));
-    full_width  = atoi(n.child_value("full_width"));
-    full_height = atoi(n.child_value("full_height"));
-    full_depth  = atoi(n.child_value("full_depth"));
-    tile_width  = atoi(n.child_value("tile_width"));
-    tile_height = atoi(n.child_value("tile_height"));
-    tile_depth  = atoi(n.child_value("tile_depth"));
+    x           = Strutil::stoi(n.child_value("x"));
+    y           = Strutil::stoi(n.child_value("y"));
+    z           = Strutil::stoi(n.child_value("z"));
+    width       = Strutil::stoi(n.child_value("width"));
+    height      = Strutil::stoi(n.child_value("height"));
+    depth       = Strutil::stoi(n.child_value("depth"));
+    full_x      = Strutil::stoi(n.child_value("full_x"));
+    full_y      = Strutil::stoi(n.child_value("full_y"));
+    full_z      = Strutil::stoi(n.child_value("full_z"));
+    full_width  = Strutil::stoi(n.child_value("full_width"));
+    full_height = Strutil::stoi(n.child_value("full_height"));
+    full_depth  = Strutil::stoi(n.child_value("full_depth"));
+    tile_width  = Strutil::stoi(n.child_value("tile_width"));
+    tile_height = Strutil::stoi(n.child_value("tile_height"));
+    tile_depth  = Strutil::stoi(n.child_value("tile_depth"));
     format      = TypeDesc(n.child_value("format"));
-    nchannels   = atoi(n.child_value("nchannels"));
+    nchannels   = Strutil::stoi(n.child_value("nchannels"));
     get_channelnames(n, channelnames);
-    alpha_channel = atoi(n.child_value("alpha_channel"));
-    z_channel     = atoi(n.child_value("z_channel"));
-    deep          = atoi(n.child_value("deep"));
+    alpha_channel = Strutil::stoi(n.child_value("alpha_channel"));
+    z_channel     = Strutil::stoi(n.child_value("z_channel"));
+    deep          = Strutil::stoi(n.child_value("deep"));
 
     // FIXME: What about extra attributes?
 

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -76,9 +76,9 @@ std::string extension_list;      // list of all extensions for all formats
 std::string library_list;        // list of all libraries for all formats
 static const char* oiio_debug_env = getenv("OPENIMAGEIO_DEBUG");
 #ifdef NDEBUG
-int oiio_print_debug(oiio_debug_env ? atoi(oiio_debug_env) : 0);
+int oiio_print_debug(oiio_debug_env ? Strutil::stoi(oiio_debug_env) : 0);
 #else
-int oiio_print_debug(oiio_debug_env ? atoi(oiio_debug_env) : 1);
+int oiio_print_debug(oiio_debug_env ? Strutil::stoi(oiio_debug_env) : 1);
 #endif
 int oiio_log_times = Strutil::from_string<int>(
     Sysutil::getenv("OPENIMAGEIO_LOG_TIMES"));

--- a/src/libOpenImageIO/xmp.cpp
+++ b/src/libOpenImageIO/xmp.cpp
@@ -346,16 +346,16 @@ add_attrib(ImageSpec& spec, const char* xmlname, const char* xmlvalue)
         if (special & IsBool)
             spec.attribute(oiioname, (int)Strutil::iequals(xmlvalue, "true"));
         else  // ordinary int
-            spec.attribute(oiioname, (int)atoi(xmlvalue));
+            spec.attribute(oiioname, (int)Strutil::stoi(xmlvalue));
         return;
     } else if (oiiotype == TypeDesc::UINT) {
         spec.attribute(oiioname, Strutil::from_string<unsigned int>(xmlvalue));
         return;
     } else if (oiiotype == TypeDesc::FLOAT) {
-        float f           = atoi(xmlvalue);
+        float f           = Strutil::stoi(xmlvalue);
         const char* slash = strchr(xmlvalue, '/');
         if (slash)  // It's rational!
-            f /= (float)atoi(slash + 1);
+            f /= (float)Strutil::stoi(slash + 1);
         spec.attribute(oiioname, f);
         return;
     }

--- a/src/libutil/argparse.cpp
+++ b/src/libutil/argparse.cpp
@@ -279,7 +279,7 @@ ArgOption::set_parameter(int i, const char* argv)
         return;       // don't write anything.
 
     switch (m_code[i]) {
-    case 'd': *(int*)m_param[i] = atoi(argv); break;
+    case 'd': *(int*)m_param[i] = Strutil::stoi(argv); break;
 
     case 'f':
     case 'g': *(float*)m_param[i] = Strutil::stof(argv); break;

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -535,10 +535,10 @@ test_numeric_conversion()
     std::string numstring (numcstr);
     bench ("get default locale", [](){ std::locale loc; DoNotOptimize (loc); });
     bench ("ref classic locale", [](){ DoNotOptimize (std::locale::classic()); });
-    bench ("std atoi", [&](){ DoNotOptimize(atoi(numcstr));});
+    bench ("std atoi", [&](){ DoNotOptimize(atoi(numcstr));}); // NOLINT(cert-err34-c)
     bench ("Strutil::stoi(string) ", [&](){ return DoNotOptimize(Strutil::stoi(numstring)); });
     bench ("Strutil::stoi(char*) ", [&](){ return DoNotOptimize(Strutil::stoi(numcstr)); });
-    bench ("std atof", [&](){ DoNotOptimize(atof(numcstr));});
+    bench ("std atof", [&](){ DoNotOptimize(atof(numcstr));}); // NOLINT(cert-err34-c)
     bench ("std strtod", [&](){ DoNotOptimize(::strtod(numcstr, nullptr));});
     bench ("Strutil::from_string<float>", [&](){ DoNotOptimize(Strutil::from_string<float>(numstring));});
     bench ("Strutil::stof(string) - locale-independent", [&](){ return DoNotOptimize(Strutil::stof(numstring)); });
@@ -822,8 +822,8 @@ test_locale()
               << Strutil::stof(numcstr) << "\n";
     OIIO_CHECK_EQUAL_APPROX(Strutil::stof(numcstr), 123.45f);
     std::cout << "unsafe float convert (default locale) " << numcstr << " = "
-              << atof(numcstr) << "\n";
-    OIIO_CHECK_EQUAL_APPROX(atof(numcstr), 123.0f);
+              << atof(numcstr) << "\n"; // NOLINT(cert-err34-c)
+    OIIO_CHECK_EQUAL_APPROX(atof(numcstr), 123.0f); // NOLINT(cert-err34-c)
 
     // Verify that Strutil::sprintf does the right thing, even when in a
     // comma-based locale.

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -394,7 +394,7 @@ static int
 set_threads(int argc, const char* argv[])
 {
     ASSERT(argc == 2);
-    int nthreads = atoi(argv[1]);
+    int nthreads = Strutil::stoi(argv[1]);
     OIIO::attribute("threads", nthreads);
     OIIO::attribute("exr_threads", nthreads);
     return 0;
@@ -406,7 +406,7 @@ static int
 set_cachesize(int argc, const char* argv[])
 {
     ASSERT(argc == 2);
-    ot.cachesize = atoi(argv[1]);
+    ot.cachesize = Strutil::stoi(argv[1]);
     ot.imagecache->attribute("max_memory_MB", float(ot.cachesize));
     return 0;
 }
@@ -417,7 +417,7 @@ static int
 set_autotile(int argc, const char* argv[])
 {
     ASSERT(argc == 2);
-    ot.autotile = atoi(argv[1]);
+    ot.autotile = Strutil::stoi(argv[1]);
     ot.imagecache->attribute("autotile", ot.autotile);
     ot.imagecache->attribute("autoscanline", int(ot.autotile ? 1 : 0));
     return 0;
@@ -4055,7 +4055,7 @@ action_zover(int argc, const char* argv[])
     while ((pos = cmd.find_first_of(":")) != std::string::npos) {
         cmd = cmd.substr(pos + 1, std::string::npos);
         if (Strutil::istarts_with(cmd, "zeroisinf="))
-            z_zeroisinf = (atoi(cmd.c_str() + 10) != 0);
+            z_zeroisinf = (Strutil::stoi(cmd.c_str() + 10) != 0);
     }
 
     ImageRecRef B(ot.pop());
@@ -5739,7 +5739,7 @@ handle_sequence(int argc, const char** argv)
             // std::cout << "Frame range " << framespec << "\n";
         } else if ((strarg == "--framepadding" || strarg == "-framepadding")
                    && a < argc - 1) {
-            int f = atoi(argv[++a]);
+            int f = Strutil::stoi(argv[++a]);
             if (f >= 1 && f < 10)
                 framepadding = f;
         } else if ((strarg == "--views" || strarg == "-views")

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -365,13 +365,14 @@ RLAOutput::open(const std::string& name, const ImageSpec& userspec,
     time_t t = time(NULL);
     strftime(m_rla.DateCreated, sizeof(m_rla.DateCreated), "%m  %d %H:%M %Y",
              localtime(&t));
-    // nice little trick - atoi() will convert the month number to integer,
+    // nice little trick - stoi() will convert the month number to integer,
     // which we then use to index this array of constants, and copy the
     // abbreviation back into the date string
+    int m = clamp(Strutil::stoi(m_rla.DateCreated), 1, 12);
     static const char months[12][4] = { "JAN", "FEB", "MAR", "APR",
                                         "MAY", "JUN", "JUL", "AUG",
                                         "SEP", "OCT", "NOV", "DEC" };
-    memcpy(m_rla.DateCreated, months[atoi(m_rla.DateCreated) - 1], 3);
+    memcpy(m_rla.DateCreated, months[m - 1], 3);
 
     // FIXME: it appears that Wavefront have defined a set of aspect names;
     // I think it's safe not to care until someone complains

--- a/src/socket.imageio/socketinput.cpp
+++ b/src/socket.imageio/socketinput.cpp
@@ -181,7 +181,7 @@ SocketInput::accept_connection(const std::string& name)
         return false;
     }
 
-    int port = atoi(rest_args["port"].c_str());
+    int port = Strutil::stoi(rest_args["port"]);
 
     try {
         acceptor = std::shared_ptr<ip::tcp::acceptor>(


### PR DESCRIPTION
atoi/atof are frowned upon because they don't have ways to report errors, so are typically flagged as unsafe by static analysis, they have the "pipe-fitting" issue of taking only a `const char*`, and for atof in particular can have is behavior changed by the system's current locale. Instead, we prefer our Strutil::stoi and stof which take string_view and are guaranteed locale-independent.

There are just a couple places where we keep the old functions -- one is pugixml (because it's an import and we don't want to diverge from the upstream source), and the other is in strutil_test where we are specifically trying to benchmark our functions against atoi/atof (and so therefore must call them). In these instances, we at least mark them as exceptions for the static analyzer to not complain about.
