### PR TITLE
Minor fixups of including windows.h

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -48,6 +48,7 @@
 #include <OpenImageIO/export.h>
 #include <OpenImageIO/hash.h>
 #include <OpenImageIO/oiioversion.h>
+#include <OpenImageIO/platform.h>
 #include <OpenImageIO/string_view.h>
 
 // For now, let a prior set of OIIO_USE_FMT=0 cause us to fall back to

--- a/src/include/OpenImageIO/timer.h
+++ b/src/include/OpenImageIO/timer.h
@@ -35,6 +35,7 @@
 
 #pragma once
 
+#include <ctime>
 #include <functional>
 #include <iostream>
 
@@ -49,10 +50,8 @@
 #elif defined(__APPLE__)
 #    include <mach/mach_time.h>
 #else
-#    include <cstdlib>  // Just for NULL definition
 #    include <sys/time.h>
 #endif
-#include <iostream>
 
 
 OIIO_NAMESPACE_BEGIN

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -69,7 +69,6 @@
 #    include <cstdio>
 #    include <io.h>
 #    include <malloc.h>
-#    include <windows.h>
 #else
 #    include <sys/resource.h>
 #endif

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -44,10 +44,6 @@
 #    define _ENABLE_ATOMIC_ALIGNMENT_FIX /* Avoid MSVS error, ugh */
 #endif
 
-#if defined(WIN32)
-#    include <windows.h>
-#endif
-
 #include <exception>
 #include <functional>
 #include <future>


### PR DESCRIPTION
Since <windows.h> is included in platform.h, and with great care about
certain symbols being defined beforehand (such as `WIN32_LEAN_AND_MEAN`
and `NOMINMAX`), rely on that one and eliminate other places where we
may include windows.h. This ensures that we don't forget to define those
symbols in other places or get confused by include order.

