### PR TITLE
Adjust how maketx -u compares command lines

### DIFF
--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -139,7 +139,8 @@ parse_files(int argc, const char* argv[])
 
 
 // Concatenate the command line into one string, optionally filtering out
-// verbose attribute commands.
+// verbose attribute commands. Escape control chars in the arguments, and
+// double-quote any that contain spaces.
 static std::string
 command_line_string(int argc, char* argv[], bool sansattrib)
 {
@@ -158,12 +159,15 @@ command_line_string(int argc, char* argv[], bool sansattrib)
                 continue;
             }
         }
-        if (strchr(argv[i], ' ')) {  // double quote args with spaces
+        std::string a = Strutil::escape_chars(argv[i]);
+        // If the string contains spaces
+        if (a.find(' ') != std::string::npos) {
+            // double quote args with spaces
             s += '\"';
-            s += argv[i];
+            s += a;
             s += '\"';
         } else {
-            s += argv[i];
+            s += a;
         }
         if (i < argc - 1)
             s += ' ';

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5169,7 +5169,8 @@ do_echo(int argc, const char* argv[])
 
 
 // Concatenate the command line into one string, optionally filtering out
-// verbose attribute commands.
+// verbose attribute commands. Escape control chars in the arguments, and
+// double-quote any that contain spaces.
 static std::string
 command_line_string(int argc, char* argv[], bool sansattrib)
 {
@@ -5177,24 +5178,26 @@ command_line_string(int argc, char* argv[], bool sansattrib)
     for (int i = 0; i < argc; ++i) {
         if (sansattrib) {
             // skip any filtered attributes
-            if (Strutil::starts_with(argv[i], "--attrib")
-                || Strutil::starts_with(argv[i], "-attrib")
-                || Strutil::starts_with(argv[i], "--sattrib")
-                || Strutil::starts_with(argv[i], "-sattrib")) {
+            if (!strcmp(argv[i], "--attrib") || !strcmp(argv[i], "-attrib")
+                || !strcmp(argv[i], "--sattrib")
+                || !strcmp(argv[i], "-sattrib")) {
                 i += 2;  // also skip the following arguments
                 continue;
             }
-            if (Strutil::starts_with(argv[i], "--sansattrib")
-                || Strutil::starts_with(argv[i], "-sansattrib")) {
+            if (!strcmp(argv[i], "--sansattrib")
+                || !strcmp(argv[i], "-sansattrib")) {
                 continue;
             }
         }
-        if (strchr(argv[i], ' ')) {  // double quote args with spaces
+        std::string a = Strutil::escape_chars(argv[i]);
+        // If the string contains spaces
+        if (a.find(' ') != std::string::npos) {
+            // double quote args with spaces
             s += '\"';
-            s += argv[i];
+            s += a;
             s += '\"';
         } else {
-            s += argv[i];
+            s += a;
         }
         if (i < argc - 1)
             s += ' ';


### PR DESCRIPTION
maketx -u means "update mode", wherein if it looks like there's already
a texture in place that's the result of the same maketx command, it
won't re-make the texture.

The primary way of doing this is to compare file dates: when using -u,
the output texture will be given the same timestamp as the input source
image. So the next time it runs, it checks the two dates, and if they are
identical, the texture is presumed already made.

But wait, what if they used a different version of OIIO, or had
different command line args, such as choosing a different fileter? Then
you DO want to remake the texture. So we also compare the metadata that
gives the command from last time, with the command line from this time.

But... that can have false negatives, because what if they used an
absolute path one time and a relative path another time?

So in this patch, we add a little trick: before comparing the two
command lines, we take each of them and for any argument that looks like
a file path (has a directory separator in it), we strip out everything
before the last directory separator.  So

    /my/bin/maketx foo.exr -o ./foo.tx
    makex /path/to/foo.exr -o foo.tx

Used to look different, but now look the same.

How do we know that the things we strip are actual file paths? We don't,
and we do not care. No arguments to maketx that we care about are going
to have slashes in them. That won't be part of the filter name or any of
the other things we were trying to distinguish between.

To make this work right, we also modified the `command_line_string` function
in maketx.cpp and oiiotool.cpp, to make it double-quote any arguments with
spaces.

Fixes #1472

