### PR TITLE
Allow ImageSpec::find_attribute of "datawindow" and "displaywindow"

### DIFF
--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -827,6 +827,46 @@ part of the \ImageSpec, but not in {\cf extra_attribs}. The {\cf tmpparam}
 is a temporary storage area owned by the caller, which is used as temporary
 buffer in cases where the information does not correspond to an actual
 {\cf extra_attribs} (in this case, the return value will be {\cf \&tmpparam}).
+The extra names it understands are:
+\begin{description}
+\item[\spc]
+\item[\rm \qkw{x}, \qkw{y}, \qkw{z}, \qkw{width}, \qkw{height}, \qkw{depth}]
+\item[\rm \qkw{full_x}, \qkw{full_y}, \qkw{full_z},
+  \qkw{full_width}, \qkw{full_height}, \qkw{full_depth}] \spc\\
+  Returns the {\cf ImageSpec} fields of those names (despite the fact that
+  they are technically not arbitrary named attributes in {\cf extra_attribs}).
+  All are of type {\cf int}.
+\item[\rm \qkw{datawindow}] \spc\\
+  Without a type, or if requested explicitly as an {\cf int[4]}, returns the
+  OpenEXR-like pixel data min and max coordinates, as a 4-element integer
+  array: {\cf \{ x, y, x+width-1, y+height-1 \}}.  If instead you specifically
+  request as an {\cf int[6]}, it will return the volumetric data window,
+  {\cf \{ x, y, z, x+width-1, y+height-1, z+depth-1 \}}.
+\item[\rm \qkw{displaywindow}] \spc\\
+  Without a type, or if requested explicitly as an {\cf int[4]}, returns the
+  OpenEXR-like pixel display min and max coordinates, as a 4-element integer
+  array: {\cf \{ full_x, full_y, full_x+full_width-1, full_y+full_height-1 \}}.
+  If instead you specifically
+  request as an {\cf int[6]}, it will return the volumetric display window,
+  {\cf \{ full_x, full_y, full_z, full_x+full_width-1, full_y+full_height-1, full_z+full_depth-1 \}}.
+\end{description}
+
+\EXAMPLES
+\begin{code}
+    ImageSpec spec;           // has the info
+    Imath::Box2i dw;          // we want the displaywindow here
+    ParamValue tmp;           // so we can retrieve pseudo-values
+    TypeDesc int4("int[4]");  // Equivalent: TypeDesc int4(TypeDesc::INT,4);
+    const ParamValue* p = spec.find_attribute ("displaywindow", int4);
+    if (p)
+        dw = Imath::Box2i(p->get<int>(0), p->get<int>(1),
+                          p->get<int>(2), p->get<int>(3));
+
+    p = spec.find_attribute("temperature", TypeFloat);
+    if (p)
+        float temperature = p->get<float>();
+\end{code}
+
 \apiend
 
 \apiitem{int {\ce get_int_attribute} (string_view name, int defaultval=0) const}

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -97,7 +97,7 @@
 }
 \date{{\large
 Date: 1 Dec 2018
-%\\ (with corrections, 19 Mar 2018)
+\\ (with corrections, 18 Dec 2018)
 }}
 
 

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -470,7 +470,8 @@ ImageSpec::find_attribute(string_view name, ParamValue& tmpparam,
     GETINT(tile_depth);
     GETINT(alpha_channel);
     GETINT(z_channel);
-    // some special cases
+
+    // some special cases -- assemblies of multiple fields or attributes
     if (MATCH("geom", TypeString)) {
         ustring s = (depth <= 1 && full_depth <= 1)
                         ? ustring::sprintf("%dx%d%+d%+d", width, height, x, y)
@@ -487,6 +488,34 @@ ImageSpec::find_attribute(string_view name, ParamValue& tmpparam,
                                            full_height, full_depth, full_x,
                                            full_y, full_z);
         tmpparam.init("full_geom", TypeString, 1, &s);
+        return &tmpparam;
+    }
+    static constexpr TypeDesc TypeInt_4(TypeDesc::INT, 4);
+    static constexpr TypeDesc TypeInt_6(TypeDesc::INT, 6);
+    if (MATCH("datawindow", TypeInt_4)) {
+        int val[] = { x, y, x + width - 1, y + height - 1 };
+        tmpparam.init(name, TypeInt_4, 1, &val);
+        return &tmpparam;
+    }
+    if (MATCH("datawindow", TypeInt_6)) {
+        int val[] = { x, y, z, x + width - 1, y + height - 1, z + depth - 1 };
+        tmpparam.init(name, TypeInt_6, 1, &val);
+        return &tmpparam;
+    }
+    if (MATCH("displaywindow", TypeInt_4)) {
+        int val[] = { full_x, full_y, full_x + full_width - 1,
+                      full_y + full_height - 1 };
+        tmpparam.init(name, TypeInt_4, 1, &val);
+        return &tmpparam;
+    }
+    if (MATCH("displaywindow", TypeInt_6)) {
+        int val[] = { full_x,
+                      full_y,
+                      full_z,
+                      full_x + full_width - 1,
+                      full_y + full_height - 1,
+                      full_z + full_depth - 1 };
+        tmpparam.init(name, TypeInt_6, 1, &val);
         return &tmpparam;
     }
 #undef GETINT

--- a/src/libOpenImageIO/imagespec_test.cpp
+++ b/src/libOpenImageIO/imagespec_test.cpp
@@ -256,6 +256,18 @@ test_get_attribute()
                       == NULL);
     OIIO_CHECK_ASSERT(spec.find_attribute("foo", TypeDesc::INT) != NULL);
     OIIO_CHECK_ASSERT(spec.find_attribute("foo", TypeDesc::FLOAT) == NULL);
+
+    ParamValue tmp;
+    const ParamValue* p;
+    int datawin[] = { 10, 12, 649, 491 };
+    int dispwin[] = { -5, -8, 1018, 791 };
+    bool ok;
+    p  = spec.find_attribute("datawindow", tmp);
+    ok = cspan<int>((const int*)p->data(), 4) == cspan<int>(datawin);
+    OIIO_CHECK_ASSERT(ok);
+    p  = spec.find_attribute("displaywindow", tmp);
+    ok = cspan<int>((const int*)p->data(), 4) == cspan<int>(dispwin);
+    OIIO_CHECK_ASSERT(ok);
 }
 
 

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -2730,7 +2730,8 @@ ImageCacheImpl::get_image_info(ImageCacheFile* file,
 
     // general case -- handle anything else that's able to be found by
     // spec.find_attribute().
-    const ParamValue* p = spec.find_attribute(dataname);
+    ParamValue tmpparam;
+    const ParamValue* p = spec.find_attribute(dataname, tmpparam);
     if (p && p->type().basevalues() == datatype.basevalues()) {
         // First test for exact base type match
         if (p->type().basetype == datatype.basetype) {


### PR DESCRIPTION
These are "pseudo-attributes", they aren't metadata themselves as we store them in an ImageSpec, but
aggreagate from x,y,z,width,height,depth (and the full_ versions). The "datawindow" and "displaywindow" are OpenEXR nomenclature, but it's likely that people will want to refer to them that way.

Also, minor fix to `ImageCache::get_image_info` and `TextureSystem::get_texture_info`, to make the right kind of ImageSpec::find call to retrieve the pseudo-attributes.