### PR TITLE
Compression convenience - improved notation

### DIFF
--- a/src/doc/builtinplugins.tex
+++ b/src/doc/builtinplugins.tex
@@ -452,7 +452,7 @@ OIIO Attribute & Type & DPX header data or explanation \\
 \hline
 \qkw{Artist} & string & The IFF ``author'' \\
 \qkw{DateTime} & string & Creation date/time \\
-\qkw{compression} & string & The compression type \\
+\qkw{compression} & string & The compression type (\qkw{none} or \qkw{rle} [default]) \\
 \qkw{oiio:BitsPerSample} & int & the true bits per sample of the IFF file. \\
 \end{tabular}
 
@@ -498,7 +498,9 @@ anywhere near the acceptance of the original JPEG/JFIF format.
 \qkw{Orientation} & int & the image orientation \\[2ex]
 \qkw{XResolution}, \qkw{YResolution},
 \qkw{ResolutionUnit} & & The resolution and units from the Exif header \\[2ex]
-\qkw{CompressionQuality} & int & Quality of compression (1-100) \\[2ex]
+\qkw{Compression} & string & If supplied, must be \qkw{jpeg}, but may
+     optionally have a quality value appended, like \qkw{jpeg:90}.
+     Quality can be 1-100, with 100 meaning lossless. \\[2ex]
 \qkw{ICCProfile} & uint8[] & The ICC color profile \\[2ex]
 \qkw{jpeg:subsampling} & string & Describes the chroma subsampling,
     e.g., \qkw{4:2:0} (the default), \qkw{4:4:4}, \qkw{4:2:2},
@@ -687,7 +689,8 @@ The official OpenEXR site is \url{http://www.openexr.com/}.
   recognize or is not supported by the version of OpenEXR on the system,
   it will use \qkw{zip} by default. For \qkw{dwaa} and \qkw{dwab}, the
   dwaCompressionLevel may be optionally appended to the compression name
-  after a colon, like this: \qkw{dwaa:200}. \\
+  after a colon, like this: \qkw{dwaa:200}. (The default DWA compression
+  value is 45.) \\
 \qkw{textureformat} & string & \qkw{Plain Texture} for
   MIP-mapped OpenEXR files, \qkw{CubeFace Environment} or \qkw{Latlong
     Environment} for OpenEXR environment maps.  Non-environment
@@ -1092,7 +1095,7 @@ and 16-bit integer pixels (no floating point), only 1-4 channels.
 \ImageSpec Attribute & Type & SGI header data or explanation \\
 \hline
 \qkw{ImageDescription} & string & image name \\
-\qkw{Compression} & string & thee compression of the SGI file (\qkw{rle}, if
+\qkw{Compression} & string & the compression of the SGI file (\qkw{rle}, if
   RLE compression is used).
 \end{tabular}
 

--- a/src/doc/iconvert.tex
+++ b/src/doc/iconvert.tex
@@ -75,11 +75,12 @@ LZW compression:
     iconvert --compression lzw in.tif out.tif
 \end{code}
 
-The following command writes its results as a JPEG file at a 
-compression quality of 50 (pretty severe compression):
+The following command writes its results as a JPEG file at a compression
+quality of 50 (pretty severe compression), illustrating how some compression
+methods allow a quality metric to be optionally appended to the name:
 
 \begin{code}
-    iconvert --quality 50 big.jpg small.jpg
+    iconvert --compression jpeg:50 50 big.jpg small.jpg
 \end{code}
 
 \subsection*{Gamma-correcting an image}
@@ -241,20 +242,26 @@ if the output file format does not support a choice or does not support
 the particular choice requested.
 \apiend
 
-\apiitem{--compression {\rm \emph{method}}}
-Sets the compression method for the output image.  Each \ImageOutput
-plugin will have its own set of methods that it supports.
+\apiitem{--compression {\rm \emph{method}} \\
+--compression {\rm \emph{method}{\cf :}\emph{quality}}}
+Sets the compression method, and optionally a quality setting, for the
+output image.  Each \ImageOutput plugin will have its own set of methods
+that it supports.
 
 By default, the output image will use the same compression technique as
 the input image (assuming it is supported by the output format,
 otherwise it will use the default compression method of the output
-plugin).  
+plugin).
 \apiend
 
 \apiitem{--quality {\rm \emph{q}}}
 Sets the compression quality, on a 1--100 floating-point scale.
 This only has an effect if the particular compression method supports
 a quality metric (as JPEG does).
+
+% DEPRECATED(2.1)
+This is considered deprecated, and in general we now recommend just
+appending the quality metric to the {\cf compression name:qual}.
 \apiend
 
 \apiitem{--no-copy-image}

--- a/src/doc/maketx.tex
+++ b/src/doc/maketx.tex
@@ -108,8 +108,10 @@ RGBRGBRGB...) packing of channels will be used for those file formats
 that support it.
 \apiend
 
-\apiitem{--compression {\rm \emph{method}}}
-Sets the compression method for the output image (the default is to try
+\apiitem{--compression {\rm \emph{method}} \\
+--compression {\rm \emph{method}{\cf :}\emph{quality}}}
+Sets the compression method, and optionally a quality setting,
+for the output image (the default is to try
 to use \qkw{zip} compression, if it is available).
 \apiend
 

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -411,13 +411,13 @@ LZW compression:
     oiiotool in.tif --compression lzw -o compressed.tif
 \end{code}
 
-The following command writes its results as a JPEG file at a 
-compression quality of 50 (pretty severe compression):
+The following command writes its results as a JPEG file at a compression
+quality of 50 (pretty severe compression), illustrating how some compression
+methods allow a quality metric to be optionally appended to the name:
 
 \begin{code}
-    oiiotool big.jpg --quality 50 -o small.jpg
+    iconvert --compression jpeg:50 50 big.jpg small.jpg
 \end{code}
-
 
 
 \subsection*{Converting between scanline and tiled images}
@@ -1314,19 +1314,26 @@ By default, the output file will take on the tiledness and tile size
 of the input file.
 \apiend
 
-\apiitem{\ce --compression {\rm \emph{method}}}
-Sets the compression method for subsequent output images.  Each
-\ImageOutput plugin will have its own set of methods that it supports.
+\apiitem{--compression {\rm \emph{method}} \\
+--compression {\rm \emph{method}{\cf :}\emph{quality}}}
+Sets the compression method, and optionally a quality setting, for the
+output image.  Each \ImageOutput plugin will have its own set of methods
+that it supports.
+
 By default, the output image will use the same compression technique as
 the input image (assuming it is supported by the output format,
 otherwise it will use the default compression method of the output
-plugin).  
+plugin).
 \apiend
 
 \apiitem{\ce --quality {\rm \emph{q}}}
 Sets the compression quality, on a 1--100 floating-point scale.
 This only has an effect if the particular compression method supports
 a quality metric (as JPEG does).
+
+% DEPRECATED(2.1)
+This is considered deprecated, and in general we now recommend just
+appending the quality metric to the {\cf compression name:qual}.
 \apiend
 
 \apiitem{\ce --dither}

--- a/src/doc/stdmetadata.tex
+++ b/src/doc/stdmetadata.tex
@@ -186,15 +186,24 @@ file, if possible.
 
 \apiitem{"compression" : string}
 Indicates the type of compression the file uses.  Supported compression
-modes will vary from \ImageInput plugin to plugin, and each plugin
-should document the modes it supports.  If {\cf ImageInput::open} is
-called with an \ImageSpec that specifies an compression mode not
-supported by that \ImageInput, it will choose a reasonable default.
-As an example, the TIFF \ImageInput plugin supports \qkw{none},
-\qkw{lzw}, \qkw{ccittrle}, \qkw{zip} (the default), \qkw{packbits}.
+modes will vary from file format to file format, and each reader/writer
+plugin should document the modes it supports.  If {\cf ImageOutput::open} is
+called with an \ImageSpec that specifies an compression mode not supported
+by that \ImageOutput, it will choose a reasonable default. As an example,
+the OpenEXR writer supports \qkw{none}, \qkw{rle}, \qkw{zip}, \qkw{zips},
+\qkw{piz}, \qkw{pxr24}, \qkw{b44}, \qkw{b44a}, \qkw{dwaa}, or \qkw{dwab}.
+
+The compression name is permitted to have a quality value to be appended
+after a colon, for example \qkw{dwaa:60}.  The exact meaning and range of
+the quality value can vary between different file formats and compression
+modes, and some don't support quality values at all (it will be ignored if
+not supported, or if out of range).
 \apiend
 
 \apiitem{"CompressionQuality" : int}
+% DEPRECATED(2.1)
+This is a deprecated methods of separately specifying the compression
+quality.
 Indicates the quality of compression to use (0--100), for those 
 plugins and compression methods that allow a variable amount of 
 compression, with higher numbers indicating higher image fidelity.

--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -104,8 +104,9 @@ getargs(int argc, char* argv[])
                 "-g %f", &gammaval, "Set gamma correction (default = 1)",
                 "--tile %d %d", &tile[0], &tile[1], "Output as a tiled image",
                 "--scanline", &scanline, "Output as a scanline image",
-                "--compression %s", &compression, "Set the compression method (default = same as input)",
-                "--quality %d", &quality, "Set the compression quality, 1-100",
+                "--compression %s", &compression, "Set the compression method (default = same as input)."
+                                    " Note: may be in the form \"name:quality\"",
+                "--quality %d", &quality, "", // DEPRECATED(2.1)
                 "--no-copy-image", &no_copy_image, "Do not use ImageOutput copy_image functionality (dbg)",
                 "--adjust-time", &adjust_time, "Adjust file times to match DateTime metadata",
                 "--caption %s", &caption, "Set caption (ImageDescription)",

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -489,6 +489,13 @@ public:
     ///
     void from_xml (const char *xml);
 
+    /// Hunt for the "Compression" and "CompressionQuality" settings in the
+    /// spec and turn them into the compression name and quality. This
+    /// handles compression name/qual combos of the form "name:quality".
+    std::pair<string_view, int>
+    decode_compression_metadata(string_view defaultcomp = "",
+                                int defaultqual = -1) const;
+
     /// Helper function to verify that the given pixel range exactly covers
     /// a set of tiles.  Also returns false if the spec indicates that the
     /// image isn't tiled at all.

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -200,9 +200,12 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
         // Careful -- jpeg_set_defaults overwrites density
         resmeta_to_density();
         DBG std::cout << "out open: set_defaults\n";
-        int quality = newspec.get_int_attribute("CompressionQuality", 98);
-        jpeg_set_quality(&m_cinfo, quality, TRUE);  // baseline values
-        DBG std::cout << "out open: set_quality\n";
+
+        auto compqual = m_spec.decode_compression_metadata("jpeg", 98);
+        if (Strutil::iequals(compqual.first, "jpeg"))
+            jpeg_set_quality(&m_cinfo, clamp(compqual.second, 1, 100), TRUE);
+        else
+            jpeg_set_quality(&m_cinfo, 98, TRUE);  // not jpeg? default qual
 
         if (m_cinfo.input_components == 3) {
             std::string subsampling = m_spec.get_string_attribute(

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -1117,6 +1117,22 @@ ImageSpec::from_xml(const char* xml)
 
 
 
+std::pair<string_view, int>
+ImageSpec::decode_compression_metadata(string_view defaultcomp,
+                                       int defaultqual) const
+{
+    string_view comp   = get_string_attribute("Compression", defaultcomp);
+    int qual           = get_int_attribute("CompressionQuality", defaultqual);
+    auto comp_and_qual = Strutil::splitsv(comp, ":");
+    if (comp_and_qual.size() >= 1)
+        comp = comp_and_qual[0];
+    if (comp_and_qual.size() >= 2)
+        qual = Strutil::stoi(comp_and_qual[1]);
+    return { comp, qual };
+}
+
+
+
 bool
 pvt::check_texture_metadata_sanity(ImageSpec& spec)
 {

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -714,8 +714,10 @@ adjust_output_options(string_view filename, ImageSpec& spec,
         spec.tile_width = spec.tile_height = spec.tile_depth = 0;
     }
 
-    if (!ot.output_compression.empty())
+    if (!ot.output_compression.empty()) {
+        // Note: may be in the form "name:quality"
         spec.attribute("compression", ot.output_compression);
+    }
     if (ot.output_quality > 0)
         spec.attribute("CompressionQuality", ot.output_quality);
 
@@ -5502,8 +5504,8 @@ getargs(int argc, char* argv[])
                 "--tile %@ %d %d", output_tiles, &ot.output_tilewidth, &ot.output_tileheight,
                     "Output tiled images (tilewidth, tileheight)",
                 "--force-tiles", &ot.output_force_tiles, "", // undocumented
-                "--compression %s", &ot.output_compression, "Set the compression method",
-                "--quality %d", &ot.output_quality, "Set the compression quality, 1-100",
+                "--compression %s", &ot.output_compression, "Set the compression method (in the form \"name\" or \"name:quality\")",
+                "--quality %d", &ot.output_quality, "", // DEPRECATED(2.1)
                 "--dither", &ot.output_dither, "Add dither to 8-bit output",
                 "--planarconfig %s", &ot.output_planarconfig,
                     "Force planarconfig (contig, separate, default)",

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -138,14 +138,16 @@ WebpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
         return false;
     }
 
-    m_webp_config.method    = 6;
-    int compression_quality = 100;
-    const ParamValue* qual  = m_spec.find_attribute("CompressionQuality",
-                                                   TypeDesc::INT);
-    if (qual) {
-        compression_quality = *static_cast<const int*>(qual->data());
+    auto compqual = m_spec.decode_compression_metadata("webp", 100);
+    if (Strutil::iequals(compqual.first, "webp")) {
+        m_webp_config.method  = 6;
+        m_webp_config.quality = OIIO::clamp(compqual.second, 1, 100);
+    } else {
+        // If compression name wasn't "webp", don't trust the quality
+        // metric, just use the default.
+        m_webp_config.method  = 6;
+        m_webp_config.quality = 100;
     }
-    m_webp_config.quality = compression_quality;
 
     // forcing UINT8 format
     m_spec.set_format(TypeDesc::UINT8);


### PR DESCRIPTION
Many of the file format writers have options for compression, expressed
as metadata "Compression" (e.g., "zip"), and a few of them also take
a second control called "CompressionQuality" (some compression methods
have size/quality or time/quality tradeoffs).

As a special case, the OpenEXR writer allowed the compression for dwaa
and dwab to be able to embed the compression amount in the name, like
"dwaa:100".

With some more thought, I realized that this is a superior notation and
that all of the writers should support this. This has two really nice
consequences:

1. Express compression method and amount in a single option.

2. Avoid possible bugs of "CompressionQuality" being inappropriately
passed from one method to another. For example, zip, jpeg, and dwaa have
totally different meanings to their scales. Making the compression scale
part of the name prevents some silly user errors.

For back compatibility, this patch still allows an explicitly set
"CompressionQuality" to function as it did before. But I'm changing all
the docs to favor the new notation.

