### PR TITLE
IC/TS: Detect failure due to updated texture file

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1523,6 +1523,11 @@ ImageCacheTile::read(ImageCachePerThreadInfo* thread_info)
     } else {
         // (! m_valid)
         m_used = false;  // Don't let it hold mem if invalid
+        if (file.mod_time()
+            != Filesystem::last_write_time(file.filename().string()))
+            file.imagecache().errorf(
+                "File \"%s\" was modified after being opened by OIIO",
+                file.filename());
 #if 0
         std::cerr << "(1) error reading tile " << m_id.x() << ' ' << m_id.y()
                   << ' ' << m_id.z()


### PR DESCRIPTION
At the suggestion of Thiago Ize: After read errors on texture tiles,
check if the file it's reading from appears to have a different
modification time than when we first opened it, in which case being
overwritten by some other process is probably the source of the error,
so issue a message saying so.

