### PR TITLE
Strutil::wordwrap enhancement

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -313,13 +313,21 @@ std::string OIIO_API escape_chars (string_view unescaped);
 /// and collapse them into the 'real' characters.
 std::string OIIO_API unescape_chars (string_view escaped);
 
-/// Word-wrap string 'src' to no more than columns width, splitting at
-/// space characters.  It assumes that 'prefix' characters are already
-/// printed, and furthermore, if it should need to wrap, it prefixes that
-/// number of spaces in front of subsequent lines.  By illustration, 
-/// wordwrap("0 1 2 3 4 5 6 7 8", 4, 10) should return:
-/// "0 1 2\n    3 4 5\n    6 7 8"
-std::string OIIO_API wordwrap (string_view src, int columns=80, int prefix=0);
+/// Word-wrap string `src` to no more than `columns` width, starting with an
+/// assumed position of `prefix` on the first line and intending by `prefix`
+/// blanks before all lines other than the first.
+///
+/// Words may be split AT any characters in `sep` or immediately AFTER any
+/// characters in `presep`. After the break, any extra `sep` characters will
+/// be deleted.
+///
+/// By illustration,
+///     wordwrap("0 1 2 3 4 5 6 7 8", 10, 4)
+/// should return:
+///     "0 1 2\n    3 4 5\n    6 7 8"
+std::string OIIO_API wordwrap (string_view src, int columns = 80,
+                               int prefix = 0, string_view sep = " ",
+                               string_view presep = "");
 
 /// Hash a string_view.
 inline size_t

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -209,6 +209,12 @@ test_wordwrap()
     OIIO_CHECK_EQUAL(Strutil::wordwrap(words, 24), "Now is the time for all\n"
                                                    "good men to come to the\n"
                                                    "aid of their party.");
+    std::string densewords
+        = "Now is the,time,for,all,good,men,to,come to the aid of their party.";
+    OIIO_CHECK_EQUAL(Strutil::wordwrap(densewords, 24, 0, " ", ","),
+                     "Now is the,time,for,all,\n"
+                     "good,men,to,come to the\n"
+                     "aid of their party.");
 }
 
 


### PR DESCRIPTION
Allow caller to specify the separation characters instead of hard-coding to just ' '.  There are separate ordinary separators (default " ", break on the separator), and pre-separators (default: none, break AFTER the separator).

An example if when you might want to use the pre-separator is for sep=" " and presep=",". That would mean to split at any blank, but if there are areas with no blanks separated by commas, it's ok to break immediately after a comma.

