### PR TITLE
Fix broken TIFF with JPEG compression

### DIFF
--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -685,11 +685,12 @@ TIFFInput::seek_subimage(int subimage, int miplevel)
                                || m_photometric == PHOTOMETRIC_ITULAB
                                || m_photometric == PHOTOMETRIC_LOGL
                                || m_photometric == PHOTOMETRIC_LOGLUV);
-        if (is_jpeg || (is_nonspectral && !m_raw_color)) {
+        if ((is_jpeg && m_spec.nchannels != 3)
+            || (is_nonspectral && !m_raw_color)) {
             char emsg[1024];
             m_use_rgba_interface = true;
             if (!TIFFRGBAImageOK(m_tif, emsg)) {
-                error("No support for this flavor of TIFF file");
+                errorf("No support for this flavor of TIFF file (%s)", emsg);
                 return false;
             }
             // This falls back to looking like uint8 images


### PR DESCRIPTION
JPEG compression was one of the cases where we fell back on the TIFFRGBAImage interface of libtiff. This worked for some JPEG images, but crashed on others, inside the TIFF library. Never did figure out why.

But do we really need to to use the RGBAImage interface?  Turns out, no! At least, not if it's still a spectral RGB image.

So just using the regular interface for ordinary RGB JPEG-compressed TIFF images is fine, fixes the problem.

Also improved an error message while I was in there.
