### PR TITLE
Fix possible div-by-0 bug in texturesystem

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -257,6 +257,15 @@ rotl64(uint64_t x, int k)
 }
 
 
+
+// safe_mod is like integer a%b, but safely returns 0 when b==0.
+template <class T>
+inline OIIO_HOSTDEVICE T
+safe_mod(T a, T b)
+{
+    return b ? (a % b) : T(0);
+}
+
 // (end of integer helper functions)
 ////////////////////////////////////////////////////////////////////////////
 

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -1154,6 +1154,10 @@ void transpose (const vint4& a, const vint4& b, const vint4& c, const vint4& d,
 
 vint4 AxBxCxDx (const vint4& a, const vint4& b, const vint4& c, const vint4& d);
 
+// safe_mod(a,b) is like a%b, but safely returns 0 when b==0.
+vint4 safe_mod (const vint4& a, const vint4& b);
+vint4 safe_mod (const vint4& a, int b);
+
 
 
 
@@ -1441,6 +1445,10 @@ vint8 andnot (const vint8& a, const vint8& b);
 vint8 bitcast_to_int (const vbool8& x);
 vint8 bitcast_to_int (const vfloat8& x);
 vfloat8 bitcast_to_float (const vint8& x);
+
+// safe_mod(a,b) is like a%b, but safely returns 0 when b==0.
+vint8 safe_mod (const vint8& a, const vint8& b);
+vint8 safe_mod (const vint8& a, int b);
 
 
 
@@ -1742,6 +1750,10 @@ vint16 andnot (const vint16& a, const vint16& b);
 vint16 bitcast_to_int (const vbool16& x);
 vint16 bitcast_to_int (const vfloat16& x);
 vfloat16 bitcast_to_float (const vint16& x);
+
+// safe_mod(a,b) is like a%b, but safely returns 0 when b==0.
+vint16 safe_mod (const vint16& a, const vint16& b);
+vint16 safe_mod (const vint16& a, int b);
 
 
 
@@ -4710,6 +4722,17 @@ OIIO_FORCEINLINE vbool4::vbool4 (const vint4& ival) {
 
 
 
+OIIO_FORCEINLINE vint4 safe_mod (const vint4& a, const vint4& b) {
+    // NO INTEGER MODULUS IN SSE!
+    SIMD_RETURN (vint4, b[i] ? a[i] % b[i] : 0);
+}
+
+OIIO_FORCEINLINE vint4 safe_mod (const vint4& a, int b) {
+    return b ? (a % b) : vint4::Zero();
+}
+
+
+
 
 //////////////////////////////////////////////////////////////////////
 // vint8 implementation
@@ -5485,6 +5508,17 @@ OIIO_FORCEINLINE vbool8::vbool8 (const vint8& ival) {
 
 
 
+OIIO_FORCEINLINE vint8 safe_mod (const vint8& a, const vint8& b) {
+    // NO INTEGER MODULUS IN SSE!
+    SIMD_RETURN (vint8, b[i] ? a[i] % b[i] : 0);
+}
+
+OIIO_FORCEINLINE vint8 safe_mod (const vint8& a, int b) {
+    return b ? (a % b) : vint8::Zero();
+}
+
+
+
 
 //////////////////////////////////////////////////////////////////////
 // vint16 implementation
@@ -6251,6 +6285,17 @@ OIIO_FORCEINLINE vint16 andnot (const vint16& a, const vint16& b) {
 #else
     return vint16 (andnot(a.lo(), b.lo()), andnot(a.hi(), b.hi()));
 #endif
+}
+
+
+
+OIIO_FORCEINLINE vint16 safe_mod (const vint16& a, const vint16& b) {
+    // NO INTEGER MODULUS IN SSE!
+    SIMD_RETURN (vint16, b[i] ? a[i] % b[i] : 0);
+}
+
+OIIO_FORCEINLINE vint16 safe_mod (const vint16& a, int b) {
+    return b ? (a % b) : vint16::Zero();
 }
 
 

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -186,15 +186,12 @@ TextureSystemImpl::wrap_periodic_sharedborder(int& coord, int origin, int width)
     // Like periodic, but knowing that the first column and last are
     // actually the same position, so we essentially skip the last
     // column in the next cycle.
-    if (width <= 2) {
-        coord = origin;  // special case -- just 1 pixel wide
-    } else {
-        coord -= origin;
-        coord %= (width - 1);
-        if (coord < 0)  // Fix negative values
-            coord += width;
-        coord += origin;
-    }
+    width = std::max(width, 2);  // avoid %0 for width=1
+    coord -= origin;
+    coord = safe_mod(coord, width - 1);
+    if (coord < 0)  // Fix negative values
+        coord += width;
+    coord += origin;
     return true;
 }
 
@@ -290,11 +287,9 @@ wrap_periodic_sharedborder_simd(simd::vint4& coord_, const simd::vint4& origin,
     // column in the next cycle.
     simd::vint4 coord(coord_);
     coord = coord - origin;
-    coord = coord % (width - 1);
+    coord = safe_mod(coord, (width - 1));
     coord += blend(simd::vint4(origin), width + origin,
                    coord < 0);  // Fix negative values
-    coord  = blend(coord, origin,
-                  width <= 2);  // special case -- just 1 pixel wide
     coord_ = coord;
     return true;
 }


### PR DESCRIPTION
`wrap_periodic_sharedborder_simd` had a `%` that could divide by zero when width=1 (top level MIPmap). It tried to protect about it, but it did so after the fact, so on some platforms the `%0` would create an exception.

Elegant fix required adding scalar and simd function `safe_mod` that protects against this case.
