### PR TITLE
Fix oiiotool --dumpdata for uint8 pixels

### DIFF
--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -129,7 +129,7 @@ print_nums(int n, const T* val, string_view sep = " ")
     } else {
         // not floating point -- print the int values, then float equivalents
         for (int i = 0; i < n; ++i) {
-            Strutil::printf("%s%g", i ? sep : "", val[i]);
+            Strutil::printf("%s%d", i ? sep : "", int64_t(val[i]));
         }
         Strutil::printf(" (");
         for (int i = 0; i < n; ++i) {


### PR DESCRIPTION
Sloppiness printed uint8 vals as characters themselves intead of
integer values.

