### PR TITLE
Relax channel restrictions on IBA::resize, fit, resample.

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -473,8 +473,7 @@ ImageBufAlgo::resize(ImageBuf& dst, const ImageBuf& src, Filter2D* filter,
 {
     pvt::LoggedTimer logtime("IBA::resize");
     if (!IBAprep(roi, &dst, &src,
-                 IBAprep_REQUIRE_SAME_NCHANNELS | IBAprep_NO_SUPPORT_VOLUME
-                     | IBAprep_NO_COPY_ROI_FULL))
+                 IBAprep_NO_SUPPORT_VOLUME | IBAprep_NO_COPY_ROI_FULL))
         return false;
 
     // Set up a shared pointer with custom deleter to make sure any
@@ -507,8 +506,7 @@ ImageBufAlgo::resize(ImageBuf& dst, const ImageBuf& src, string_view filtername,
 {
     pvt::LoggedTimer logtime("IBA::resize");
     if (!IBAprep(roi, &dst, &src,
-                 IBAprep_REQUIRE_SAME_NCHANNELS | IBAprep_NO_SUPPORT_VOLUME
-                     | IBAprep_NO_COPY_ROI_FULL))
+                 IBAprep_NO_SUPPORT_VOLUME | IBAprep_NO_COPY_ROI_FULL))
         return false;
     const ImageSpec& srcspec(src.spec());
     const ImageSpec& dstspec(dst.spec());
@@ -560,8 +558,7 @@ ImageBufAlgo::fit(ImageBuf& dst, const ImageBuf& src, Filter2D* filter,
 {
     // No time logging, it will be accounted in the underlying warp/resize
     if (!IBAprep(roi, &dst, &src,
-                 IBAprep_REQUIRE_SAME_NCHANNELS | IBAprep_NO_SUPPORT_VOLUME
-                     | IBAprep_NO_COPY_ROI_FULL))
+                 IBAprep_NO_SUPPORT_VOLUME | IBAprep_NO_COPY_ROI_FULL))
         return false;
 
     const ImageSpec& srcspec(src.spec());
@@ -661,8 +658,7 @@ ImageBufAlgo::fit(ImageBuf& dst, const ImageBuf& src, string_view filtername,
 {
     pvt::LoggedTimer logtime("IBA::fit");
     if (!IBAprep(roi, &dst, &src,
-                 IBAprep_REQUIRE_SAME_NCHANNELS | IBAprep_NO_SUPPORT_VOLUME
-                     | IBAprep_NO_COPY_ROI_FULL))
+                 IBAprep_NO_SUPPORT_VOLUME | IBAprep_NO_COPY_ROI_FULL))
         return false;
     const ImageSpec& srcspec(src.spec());
     const ImageSpec& dstspec(dst.spec());
@@ -787,8 +783,8 @@ ImageBufAlgo::resample(ImageBuf& dst, const ImageBuf& src, bool interpolate,
 {
     pvt::LoggedTimer logtime("IBA::resample");
     if (!IBAprep(roi, &dst, &src,
-                 IBAprep_REQUIRE_SAME_NCHANNELS | IBAprep_NO_SUPPORT_VOLUME
-                     | IBAprep_NO_COPY_ROI_FULL | IBAprep_SUPPORT_DEEP))
+                 IBAprep_NO_SUPPORT_VOLUME | IBAprep_NO_COPY_ROI_FULL
+                     | IBAprep_SUPPORT_DEEP))
         return false;
 
     if (dst.deep()) {


### PR DESCRIPTION
They had previously outright rejected if the destination and source
images didn't have the same number of channels.

But actually, it doesn't matter. If they differ, it will only operate on
the minimum channel count in the two images. If dst has more channels
than src, that's fine, it just won't fill in the "missing" channels.  If
dst has fewer channels than src, then that's also fine, and in fact it
is totally reasonable to want to resize an RGBA image into an RGB
buffer, resizing while only copying the first 3 channels.

