### PR TITLE
Get rid of confusing/bogus ImageInput error

### DIFF
--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -698,9 +698,6 @@ ImageInput::read_tiles(int subimage, int miplevel, int xbegin, int xend,
         }
     }
 
-    if (!ok)
-        errorf("ImageInput::read_tiles : no support for format %s",
-               spec.format);
     return ok;
 }
 


### PR DESCRIPTION
read_tiles was calling all errors "no support for format", but that's
really weird. If it's a bad tile read, the error will already have
been set by the underlying read_native_tiles.

