### PR TITLE
Improve Python error reporting for ImageOutput and IB.set_pixels

### DIFF
--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -180,8 +180,9 @@ ImageBuf_set_pixels_buffer(ImageBuf& self, ROI roi, py::buffer& buffer)
     }
     oiio_bufinfo buf(buffer.request(), roi.nchannels(), roi.width(),
                      roi.height(), roi.depth(), self.spec().depth > 1 ? 3 : 2);
-    if (!buf.data) {
-        self.error("set_pixels unspecified error decoding the Python buffer");
+    if (!buf.data || buf.error.size()) {
+        self.errorf("set_pixels error: %s",
+                    buf.error.size() ? buf.error.c_str() : "unspecified");
         return false;  // failed sanity checks
     }
     if (!buf.data || buf.size != size) {

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -390,6 +390,7 @@ struct oiio_bufinfo {
     void* data       = nullptr;
     stride_t xstride = AutoStride, ystride = AutoStride, zstride = AutoStride;
     size_t size = 0;
+    std::string error;
 
     oiio_bufinfo(const py::buffer_info& pybuf, int nchans, int width,
                  int height, int depth, int pixeldims);


### PR DESCRIPTION
The underlying decoding of pixel value arrays -- used by some of the
ImageOutput methods and ImageBuf.set_pixels -- threw exceptions when
the pixel array didn't conform to expectations. This led to very
confusing behavior, and crashes if the python program didn't carefully
catch them. Instead of throwing exceptions, bubble up an error message
for the usual OIIO error reporting, so wrongly-shaped pixel data arrays
are treated similarly to other kinds of error.

Also, detect with a better error message cases where user tries to write
scanlines to a tiled file or vice versa -- it was handled well in C++,
but the Python would start by parsing the pixel array, then have a
confusing error that it was the wrong shape, instead of the more clear
error message about using tiles instead of scanlines.
