### PR TITLE
IC/TS: add optional `force` argument to `invalidate()` method

### DIFF
--- a/src/doc/imagecache.tex
+++ b/src/doc/imagecache.tex
@@ -844,7 +844,7 @@ only be called on a tile that has been requested by
 {\cf get_tile()} but has not yet been released with {\cf release_tile()}.
 \apiend
 
-\apiitem{void {\ce invalidate} (ustring filename)}
+\apiitem{void {\ce invalidate} (ustring filename, bool force=true)}
 Invalidate any loaded tiles or open file handles associated with
 the filename, so that any subsequent queries will be forced to
 re-open the file or re-load any tiles (even those that were
@@ -855,6 +855,10 @@ to do even if other procedures are currently holding
 reference-counted tile pointers from the named image, but those 
 procedures will not get updated pixels until they release the 
 tiles they are holding.
+
+If {\cf force} is true, this invalidation will happen unconditionally; if
+false, the file will only be invalidated if it has been changed since it was
+first opened by the ImageCache.
 \apiend
 
 \apiitem{void {\ce invalidate_all} (bool force=false)}

--- a/src/doc/texturesys.tex
+++ b/src/doc/texturesys.tex
@@ -1334,7 +1334,7 @@ requests will not match the number of tile reads, etc., that
 would have resulted from a new \ImageCache.
 \apiend
 
-\apiitem{void {\ce invalidate} (ustring filename)}
+\apiitem{void {\ce invalidate} (ustring filename, bool force=true)}
 Invalidate any loaded tiles or open file handles associated with
 the filename, so that any subsequent queries will be forced to
 re-open the file or re-load any tiles (even those that were
@@ -1345,6 +1345,10 @@ to do even if other procedures are currently holding
 reference-counted tile pointers from the named image, but those 
 procedures will not get updated pixels until they release the 
 tiles they are holding.
+
+If {\cf force} is true, this invalidation will happen unconditionally; if
+false, the file will only be invalidated if it has been changed since it was
+first opened by the ImageCache.
 \apiend
 
 \apiitem{void {\ce invalidate_all} (bool force=false)}

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -43,7 +43,12 @@
 
 // Define symbols that let client applications determine if newly added
 // features are supported.
+
+// Is the close() method present?
 #define OIIO_IMAGECACHE_SUPPORTS_CLOSE 1
+
+// Does invalidate() support the optional `force` flag?
+#define OIIO_IMAGECACHE_INVALIDATE_FORCE 1
 
 
 
@@ -394,8 +399,10 @@ public:
     /// to do even if other procedures are currently holding
     /// reference-counted tile pointers from the named image, but those
     /// procedures will not get updated pixels until they release the
-    /// tiles they are holding.
-    virtual void invalidate(ustring filename) = 0;
+    /// tiles they are holding.  If `force` is true, this invalidation will
+    /// happen unconditionally; if false, the file will only be invalidated
+    /// if it has been changed since it was first opened by the ImageCache.
+    virtual void invalidate(ustring filename, bool force = true) = 0;
 
     /// Invalidate all loaded tiles and open file handles.  This is safe
     /// to do even if other procedures are currently holding

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -892,7 +892,10 @@ public:
     /// Invalidate any cached information about the named file. A client
     /// might do this if, for example, they are aware that an image
     /// being held in the cache has been updated on disk.
-    virtual void invalidate (ustring filename) = 0;
+    /// If force is true, this invalidation will happen unconditionally; if
+    /// false, the file will only be invalidated if it has been changed
+    /// since it was first opened by the underlying image cache.
+    virtual void invalidate (ustring filename, bool force = true) = 0;
 
     /// Invalidate all cached data for all textures.  If force is true,
     /// everything will be invalidated, no matter how wasteful it is,

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -1015,7 +1015,7 @@ public:
     virtual std::string geterror() const;
     virtual std::string getstats(int level = 1) const;
     virtual void reset_stats();
-    virtual void invalidate(ustring filename);
+    virtual void invalidate(ustring filename, bool force);
     virtual void invalidate_all(bool force = false);
     virtual void close(ustring filename);
     virtual void close_all();

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -354,7 +354,7 @@ public:
     virtual std::string getstats(int level = 1, bool icstats = true) const;
     virtual void reset_stats();
 
-    virtual void invalidate(ustring filename);
+    virtual void invalidate(ustring filename, bool force);
     virtual void invalidate_all(bool force = false);
     virtual void close(ustring filename);
     virtual void close_all();

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -822,9 +822,9 @@ TextureSystemImpl::append_error(const std::string& message) const
 
 // Implementation of invalidate -- just invalidate the image cache.
 void
-TextureSystemImpl::invalidate(ustring filename)
+TextureSystemImpl::invalidate(ustring filename, bool force)
 {
-    m_imagecache->invalidate(filename);
+    m_imagecache->invalidate(filename, force);
 }
 
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4572,7 +4572,7 @@ input_file(int argc, const char* argv[])
             // User has set some input configuration, so seed the cache with
             // that information.
             ustring fn(filename);
-            ot.imagecache->invalidate(fn);
+            ot.imagecache->invalidate(fn, true);
             bool ok = ot.imagecache->add_file(fn, nullptr, &ot.input_config);
             if (!ok) {
                 std::string err = ot.imagecache->geterror();
@@ -5141,7 +5141,7 @@ output_file(int argc, const char* argv[])
 
     // Make sure to invalidate any IC entries that think they are the
     // file we just wrote.
-    ot.imagecache->invalidate(ustring(filename));
+    ot.imagecache->invalidate(ustring(filename), true);
 
     if (ot.output_adjust_time && ok) {
         std::string metadatatime = ir->spec(0, 0)->get_string_attribute(

--- a/src/python/py_imagecache.cpp
+++ b/src/python/py_imagecache.cpp
@@ -153,11 +153,11 @@ declare_imagecache(py::module& m)
              },
              "level"_a = 1)
         .def("invalidate",
-             [](ImageCacheWrap& ic, const std::string& filename) {
+             [](ImageCacheWrap& ic, const std::string& filename, bool force) {
                  py::gil_scoped_release gil;
-                 ic.m_cache->invalidate(ustring(filename));
+                 ic.m_cache->invalidate(ustring(filename), force);
              },
-             "filename"_a)
+             "filename"_a, "force"_a = true)
         .def("invalidate_all",
              [](ImageCacheWrap& ic, bool force) {
                  py::gil_scoped_release gil;


### PR DESCRIPTION
This works the same way as the `force` argument to `invalidate_all()` --
if true, invalidates unconditionally; if false, invalidates only if the
file's modifiation date has changes since the cache first opened it.

The default is true for back compatibility, but probably you will often
want `false`, only invalidating if the file has changed.

