### PR TITLE
[OpenVDB] Don't allow any exceptions to escape and use Filesystem::fopen

### DIFF
--- a/src/openvdb.imageio/openvdbinput.cpp
+++ b/src/openvdb.imageio/openvdbinput.cpp
@@ -348,6 +348,7 @@ openVDB(const std::string& filename, const ImageInput* errReport)
 
     } catch (const std::exception& e) {
         errReport->error("Could not open '%s': %s", filename, e.what());
+        return nullptr;
     } catch(...) {
         errhint = "Unknown exception thrown";
     }


### PR DESCRIPTION
## Description
Changes for fopen on Windows and containing all exceptions that may be thrown.
