### PR TITLE
Filter selection enhancements

### DIFF
--- a/src/doc/imagebufalgo.tex
+++ b/src/doc/imagebufalgo.tex
@@ -1818,7 +1818,8 @@ caution!
 
 Kernel names can be: \qkw{gaussian}, \qkw{sharp-gaussian}, \qkw{box},
 \qkw{triangle}, \qkw{mitchell}, \qkw{blackman-harris}, \qkw{b-spline},
-\qkw{catmull-rom}, \qkw{lanczos3}, \qkw{cubic}, \qkw{keys}, \qkw{simon},
+\qkw{catmull-rom}, \qkw{lanczos3} (synonym: \qkw{nuke-lanczos6}),
+\qkw{cubic}, \qkw{keys}, \qkw{simon},
 \qkw{rifman}, \qkw{disk}, \qkw{binomial}, \qkw{laplacian}. Note that
 \qkw{catmull-rom} and \qkw{lanczos3} are fixed-size kernels that don't
 scale with the width, and are therefore probably less useful in most

--- a/src/doc/oiiotool.tex
+++ b/src/doc/oiiotool.tex
@@ -718,7 +718,7 @@ and output each one to a different file, with names \qkw{sub0001.tif},
 
 \apiitem{\ce --help}
 Prints full usage information to the terminal, as well as information
-about image formats supported, known color spaces, OIIO build options
+about image formats supported, known color spaces, filters, OIIO build options
 and library dependencies.
 \apiend
 
@@ -1772,7 +1772,8 @@ of all pixel values will be 1.0).
 Kernel names can be: {\cf gaussian}, {\cf sharp-gaussian}, {\cf box},
 {\cf triangle}, {\cf blackman-harris}, {\cf mitchell}, {\cf b-spline},
 \qkw{cubic}, \qkw{keys}, \qkw{simon}, \qkw{rifman}, {\cf disk}.
-There are also {\cf catmull-rom} and {\cf lanczos3}, but
+There are also {\cf catmull-rom} and {\cf lanczos3} (and its synonym,
+{\cf nuke-lanczos6}), but
 they are fixed-size kernels that don't scale with the width, and are
 therefore probably less useful in most cases.
 

--- a/src/include/OpenImageIO/filter.h
+++ b/src/include/OpenImageIO/filter.h
@@ -86,6 +86,7 @@ public:
     static int num_filters();
     /// Get the info for a particular index (0..num_filters()-1).
     static void get_filterdesc(int filternum, FilterDesc* filterdesc);
+    static const FilterDesc& get_filterdesc(int filternum);
 
 protected:
     float m_w;
@@ -143,6 +144,7 @@ public:
     static int num_filters();
     /// Get the info for a particular index (0..num_filters()-1).
     static void get_filterdesc(int filternum, FilterDesc* filterdesc);
+    static const FilterDesc& get_filterdesc(int filternum);
 
 protected:
     float m_w, m_h;

--- a/src/libutil/filter.cpp
+++ b/src/libutil/filter.cpp
@@ -36,7 +36,9 @@
 //     - prman 16.0 txmake
 //
 // box: oiio, prman, katana, imagemagick match
-// lanczos3: oiio, katana, imagemagick match.  prman is far sharper (perhaps lanczos2?)
+// lanczos3: oiio, katana, imagemagick match.  prman is far sharper
+//   (perhaps lanczos2?). Note that Nuke calls this filter "lanczos6" (they
+//   measure full width).
 // sinc: oiio, prman match.  Katana is slighly softer. imagemagick is much softer
 // blackman harris:  all differ. In order of decreasing sharpness... imagemagick, oiio, prman
 // catrom: oiio, imagemagick, prman match
@@ -848,6 +850,7 @@ FilterDesc filter1d_list[] = {
     { "blackman-harris", 1,   3,    false,    true,     true },
     { "sinc",            1,   4,    false,    true,     true },
     { "lanczos3",        1,   6,    false,    true,     true },
+    { "nuke-lanczos6",   1,   6,    false,    true,     true },
     { "mitchell",        1,   4,    false,    true,     true },
     { "bspline",         1,   4,    false,    true,     true },
     { "cubic",           1,   4,    false,    true,     true },
@@ -864,11 +867,17 @@ Filter1D::num_filters()
     return sizeof(filter1d_list) / sizeof(filter1d_list[0]);
 }
 
+const FilterDesc&
+Filter1D::get_filterdesc(int filternum)
+{
+    ASSERT(filternum >= 0 && filternum < num_filters());
+    return filter1d_list[filternum];
+}
+
 void
 Filter1D::get_filterdesc(int filternum, FilterDesc* filterdesc)
 {
-    ASSERT(filternum >= 0 && filternum < num_filters());
-    *filterdesc = filter1d_list[filternum];
+    *filterdesc = get_filterdesc(filternum);
 }
 
 
@@ -894,7 +903,8 @@ Filter1D::create(string_view filtername, float width)
         return new FilterBlackmanHarris1D(width);
     if (filtername == "sinc")
         return new FilterSinc1D(width);
-    if (filtername == "lanczos3" || filtername == "lanczos")
+    if (filtername == "lanczos3" || filtername == "lanczos"
+        || filtername == "nuke-lanczos6")
         return new FilterLanczos3_1D(width);
     if (filtername == "mitchell")
         return new FilterMitchell1D(width);
@@ -933,6 +943,7 @@ static FilterDesc filter2d_list[] = {
     { "sinc",            2,   4,    false,    true,     true  },
     { "lanczos3",        2,   6,    false,    true,     true  },
     { "radial-lanczos3", 2,   6,    false,    true,     false },
+    { "nuke-lanczos6",   2,   6,    false,    true,     false },
     { "mitchell",        2,   4,    false,    true,     true  },
     { "bspline",         2,   4,    false,    true,     true  },
     { "disk",            2,   1,    false,    true,     false },
@@ -949,11 +960,17 @@ Filter2D::num_filters()
     return sizeof(filter2d_list) / sizeof(filter2d_list[0]);
 }
 
+const FilterDesc&
+Filter2D::get_filterdesc(int filternum)
+{
+    ASSERT(filternum >= 0 && filternum < num_filters());
+    return filter2d_list[filternum];
+}
+
 void
 Filter2D::get_filterdesc(int filternum, FilterDesc* filterdesc)
 {
-    ASSERT(filternum >= 0 && filternum < num_filters());
-    *filterdesc = filter2d_list[filternum];
+    *filterdesc = get_filterdesc(filternum);
 }
 
 
@@ -980,7 +997,8 @@ Filter2D::create(string_view filtername, float width, float height)
         return new FilterBlackmanHarris2D(width, height);
     if (filtername == "sinc")
         return new FilterSinc2D(width, height);
-    if (filtername == "lanczos3" || filtername == "lanczos")
+    if (filtername == "lanczos3" || filtername == "lanczos"
+        || filtername == "nuke-lanczos6")
         return new FilterLanczos3_2D(width, height);
     if (filtername == "radial-lanczos3" || filtername == "radial-lanczos")
         return new FilterRadialLanczos3_2D(width, height);

--- a/src/libutil/filter_test.cpp
+++ b/src/libutil/filter_test.cpp
@@ -60,8 +60,8 @@ getargs(int argc, char* argv[])
     ArgParse ap;
     // clang-format off
     ap.options(
-        "fmath_test\n" OIIO_INTRO_STRING "\n"
-        "Usage:  fmath_test [options]",
+        "filter_test\n" OIIO_INTRO_STRING "\n"
+        "Usage:  filter_test [options]",
         // "%*", parse_files, "",
         "--help", &help, "Print help message",
         "-v", &verbose, "Verbose mode",

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5370,6 +5370,15 @@ print_help_end(const ArgParse& ap, std::ostream& out)
     }
     if (!ot.colorconfig.supportsOpenColorIO())
         out << "No OpenColorIO support was enabled at build time.\n";
+
+    std::vector<string_view> filternames;
+    for (int i = 0, e = Filter2D::num_filters(); i < e; ++i)
+        filternames.emplace_back(Filter2D::get_filterdesc(i).name);
+    out << Strutil::wordwrap("Filters available: "
+                                 + Strutil::join(filternames, ", "),
+                             columns, 4)
+        << "\n";
+
     std::string libs = OIIO::get_string_attribute("library_list");
     if (libs.size()) {
         std::vector<string_view> libvec;


### PR DESCRIPTION
* Main event: add "nuke-lanczos6" as an alias for our "lanczos3" filter.
  (Nuke names it according to the full width, which makes sense but is
  different than our more conventional lanczos3 nomenclature. Made the
  alias to make it more obvious which to choose if you want to exactly
  replicate what Nuke calls lanczos6.)

* Added new flavor of get_filterdesc() that returns a const ref,
  instead of copying into a parameter by pointer. (In retrospect, I'm
  not even sure why I did it that way.)

* Made `oiiotool --help -v` print the available filters, for handy
  reference.
