### PR TITLE
clang-format fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,10 +71,7 @@ install:
           export PATH=/usr/local/opt/qt5/bin:$PATH ;
           export PATH=/usr/local/opt/python/libexec/bin:$PATH ;
           export PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages:$PYTHONPATH ;
-          if [ "${CLANG_TIDY}" != "" ] ; then
-              export PATH=/usr/local/Cellar/llvm/7.0.0_1/bin:$PATH ;
-              echo $PATH ;
-          fi ;
+          export PATH=/usr/local/Cellar/llvm/7.0.1/bin:$PATH ;
       elif [ $TRAVIS_OS_NAME == linux ] ; then
           CXX="ccache $CXX" CCACHE_CPP2=1 src/build-scripts/build_openexr.bash ;
           export ILMBASE_ROOT_DIR=$PWD/ext/openexr-install ;

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -16,17 +16,18 @@ if [ `which brew` == "" ] ; then
 fi
 
 
-if [ "$OIIOTARGET" == "clang-format" ] ; then
-    # If we are running for the sake of clang-format only, just install the
-    # bare minimum packages and return.
-    brew install ilmbase openexr clang-format
-    exit 0
-fi
-
 brew update >/dev/null
 echo ""
 echo "Before my brew installs:"
 brew list --versions
+
+if [ "$OIIOTARGET" == "clang-format" ] ; then
+    # If we are running for the sake of clang-format only, just install the
+    # bare minimum packages and return.
+    brew install ilmbase openexr llvm
+    exit 0
+fi
+
 brew install gcc
 brew link --overwrite gcc
 brew install ccache cmake

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -21,6 +21,7 @@ option (CLANG_TIDY "Enable clang-tidy" OFF)
 set (CLANG_TIDY_CHECKS "" CACHE STRING "clang-tidy checks to perform (none='-*')")
 set (CLANG_TIDY_ARGS "" CACHE STRING "clang-tidy args")
 option (CLANG_TIDY_FIX "Have clang-tidy fix source" OFF)
+set (CLANG_FORMAT_EXE_HINT "" CACHE STRING "clang-format executable's directory (will search if not specified")
 set (CLANG_FORMAT_INCLUDES "src/*.h" "src/*.cpp"
     CACHE STRING "Glob patterns to include for clang-format")
     # Eventually: want this to be: "src/*.h;src/*.cpp"
@@ -346,8 +347,12 @@ endif ()
 
 # clang-format
 find_program (CLANG_FORMAT_EXE
-              NAMES "clang-format"
+              NAMES clang-format bin/clang-format
+              HINTS ${CLANG_FORMAT_EXE_HINT} ENV CLANG_FORMAT_EXE_HINT
+                    ENV LLVM_DIRECTORY
+              NO_DEFAULT_PATH
               DOC "Path to clang-format executable")
+find_program (CLANG_FORMAT_EXE NAMES clang-format bin/clang-format)
 if (CLANG_FORMAT_EXE)
     message (STATUS "clang-format found: ${CLANG_FORMAT_EXE}")
     # Start with the list of files to include when formatting...

--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -467,8 +467,8 @@ print_info_subimage(int current_subimage, int max_subimages, ImageSpec& spec,
 
     if (!metamatch.empty()
         && !regex_search(
-            "resolution, width, height, depth, channels, sha-1, stats",
-            field_re)) {
+               "resolution, width, height, depth, channels, sha-1, stats",
+               field_re)) {
         // nothing to do here
         return;
     }


### PR DESCRIPTION
Homebrew updated its copy of clang-format several days ago. Something
in it changed formatting rules and caused our builds to break on the
formatting verification test.

This patch changes the way we look for the clang-format binary -- you
can supply a hint about which directory it's in as
`CLANG_FORMAT_EXE_HINT` cmake variable, or an env variable of the same
name, or it will also try to find a clang-format in your LLVM distro if
you have a LLVM_DIRECTORY env variable set.

This lets us more easily lock down the clang-format to the one with llvm,
not separately installed, so it should get changed less frequenty and is
easier to standardize across users and platforms. Currently, then, we're
trying to tie it to clang 7.

