### PR TITLE
Fix MIA ImageCache errors from missing udim tiles

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -2589,8 +2589,12 @@ ImageCacheImpl::get_image_info(ImageCacheFile* file,
                 concretefile = verify_file(concretefile, thread_info, true);
                 if (concretefile && !concretefile->broken()) {
                     // Recurse to try again with the concrete file
-                    return get_image_info(concretefile, thread_info, subimage,
-                                          miplevel, dataname, datatype, data);
+                    bool r = get_image_info(concretefile, thread_info, subimage,
+                                            miplevel, dataname, datatype, data);
+                    // suppress errors from missing tiles we encountered
+                    // prior to finding the one that worked.
+                    (void)geterror();
+                    return r;
                 }
             }
         }


### PR DESCRIPTION
When performing get_image_info() on udim files, we may have to try
out several individual tiles until we find one that exists (the set
is allowed to be sparse). We were not properly suppressing any error
messages set for the missing files, once we hit one that worked.

