### PR TITLE
Clean up warning suppression a bit

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -145,18 +145,11 @@ endif ()
 
 # gcc specific options
 if (CMAKE_COMPILER_IS_GNUCC AND NOT (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_APPLECLANG))
-    if (NOT ${GCC_VERSION} VERSION_LESS 4.8)
-        # suppress a warning that Boost::Python hits in g++ 4.8
-        add_definitions ("-Wno-error=unused-local-typedefs")
-        add_definitions ("-Wno-unused-local-typedefs")
-    endif ()
+    add_definitions ("-Wno-unused-local-typedefs")
     add_definitions ("-Wno-unused-result")
-    if (NOT ${GCC_VERSION} VERSION_LESS 6.0)
-        add_definitions ("-Wno-error=misleading-indentation")
-    endif ()
     if (NOT ${GCC_VERSION} VERSION_LESS 7.0)
         add_definitions ("-Wno-aligned-new")
-        add_definitions ("-Wno-error=noexcept-type")
+        add_definitions ("-Wno-noexcept-type")
     endif ()
 endif ()
 


### PR DESCRIPTION
* Don't need to condition things on whether they are gcc >= 4.8; gcc 4.8 is the minimum these days.

* Fix some confusion between -Wno-blah and -Wno-error=blah

* Get rid of the misleading-indentation warning suppression, I that now that we use clang-format, we shouldn't have any weird indentation.
