### PR TITLE
OpenEXROutput: skip dwa compression for single channel small tile images

### DIFF
--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -681,9 +681,9 @@ OpenEXROutput::spec_to_header(ImageSpec& spec, int subimage,
         comp = "zips";
     // For single channel images, dwaa/b compression only seems to work reliably
     // when size > 16 and size is a power of two
-    if (spec.nchannels == 1 && Strutil::istarts_with(comp, "dwa") &&
-        ((spec.tile_width < 16 && spec.tile_height < 16) ||
-         !ispow2(spec.tile_width) || !ispow2(spec.tile_height))) {
+    if (spec.nchannels == 1 && Strutil::istarts_with(comp, "dwa")
+        && ((spec.tile_width < 16 && spec.tile_height < 16)
+            || !ispow2(spec.tile_width) || !ispow2(spec.tile_height))) {
         comp = "zip";
     }
     spec.attribute("compression", comp);

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -679,9 +679,11 @@ OpenEXROutput::spec_to_header(ImageSpec& spec, int subimage,
     // on deep files (but allow "none" as well)
     if (spec.deep && comp != "none")
         comp = "zips";
-    // Currently dwaa/b compression does not work on single channel with tile < 16
-    if (spec.nchannels == 1 && spec.tile_width < 16 && spec.tile_height < 16 &&
-        Strutil::istarts_with(comp, "dwa")) {
+    // For single channel images, dwaa/b compression only seems to work reliably
+    // when size > 16 and size is a power of two
+    if (spec.nchannels == 1 && Strutil::istarts_with(comp, "dwa") &&
+        ((spec.tile_width < 16 && spec.tile_height < 16) ||
+         !ispow2(spec.tile_width) || !ispow2(spec.tile_height))) {
         comp = "zip";
     }
     spec.attribute("compression", comp);

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -679,6 +679,11 @@ OpenEXROutput::spec_to_header(ImageSpec& spec, int subimage,
     // on deep files (but allow "none" as well)
     if (spec.deep && comp != "none")
         comp = "zips";
+    // Currently dwaa/b compression does not work on single channel with tile < 16
+    if (spec.nchannels == 1 && spec.tile_width < 16 && spec.tile_height < 16 &&
+        Strutil::istarts_with(comp, "dwa")) {
+        comp = "zip";
+    }
     spec.attribute("compression", comp);
     if (Strutil::istarts_with(comp, "dwa")) {
         spec.attribute("openexr:dwaCompressionLevel",


### PR DESCRIPTION
dwa? compression fails when saving single channel files with small tile sizes (< 16)

Larry determined in #1844 that the underlying issue is in OpenEXR.

While that gets fixed we should skip dwa compression for the failure cases. This patch replaces dwa compression with the default zip for the failing cases.