### PR TITLE
Allow optional library name suffix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,8 @@ option (USE_DICOM "Use DICOM if DCMTK is found" ON)
 set (TEX_BATCH_SIZE "" CACHE STRING "Force TextureSystem SIMD batch size (e.g. 16)")
 set (SOVERSION ${OIIO_VERSION_MAJOR}.${OIIO_VERSION_MINOR}
      CACHE STRING "Set the SO version in the SO name of the output library")
+set (OIIO_LIBNAME_SUFFIX "" CACHE STRING
+     "Optional name appended to ${PROJECT_NAME} libraries that are built")
 option (BUILD_OIIOUTIL_ONLY "If ON, will build *only* libOpenImageIO_Util" OFF)
 option (BUILD_DOCS "If ON, build documentation and man pages." ON)
 option (INSTALL_DOCS "If ON, install documentation and man pages." ON)

--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,10 @@ ifneq (${SOVERSION},)
 MY_CMAKE_FLAGS += -DSOVERSION:STRING=${SOVERSION}
 endif
 
+ifneq (${OIIO_LIBNAME_SUFFIX},)
+MY_CMAKE_FLAGS += -DOIIO_LIBNAME_SUFFIX:STRING=${OIIO_LIBNAME_SUFFIX}
+endif
+
 ifneq (${BUILD_OIIOUTIL_ONLY},)
 MY_CMAKE_FLAGS += -DBUILD_OIIOUTIL_ONLY:BOOL=${BUILD_OIIOUTIL_ONLY}
 endif
@@ -502,6 +506,7 @@ help:
 	@echo "      HIDE_SYMBOLS=1           Hide symbols not in the public API"
 	@echo "      SOVERSION=nn             Include the specifed major version number "
 	@echo "                                  in the shared object metadata"
+	@echo "      OIIO_LIBNAME_SUFFIX=name Optional name appended to library names"
 	@echo "      BUILDSTATIC=1            Build static library instead of shared"
 	@echo "      LINKSTATIC=1             Link with static external libs when possible"
 	@echo "  Finding and Using Dependencies:"

--- a/site/spi/Makefile-bits-arnold
+++ b/site/spi/Makefile-bits-arnold
@@ -51,6 +51,7 @@ ifeq (${SP_OS}, rhel7)
         MY_CMAKE_FLAGS += -DCMAKE_MAKE_PROGRAM=${NINJA}
     endif
     export CCACHE_CPP2 ?= 1
+    OIIO_LIBNAME_SUFFIX=_Arnold
     # Override lib64 and use SPI convention of lib
     MY_CMAKE_FLAGS += -DCMAKE_INSTALL_LIBDIR="${INSTALL_PREFIX}/lib"
     BOOSTVERS ?= 1.55

--- a/src/cmake/modules/FindOpenImageIO.cmake
+++ b/src/cmake/modules/FindOpenImageIO.cmake
@@ -25,6 +25,7 @@
 #   OPENIMAGEIO_ROOT_DIR - custom "prefix" location of OIIO installation
 #                          (expecting bin, lib, include subdirectories)
 #   OpenImageIO_FIND_QUIETLY - if set, print minimal console output
+#   OIIO_LIBNAME_SUFFIX - if set, optional nonstandard library suffix
 #
 ###########################################################################
 
@@ -40,7 +41,7 @@ if (NOT OpenImageIO_FIND_QUIETLY)
 endif ()
 
 find_library ( OPENIMAGEIO_LIBRARY
-               NAMES OpenImageIO
+               NAMES OpenImageIO${OIIO_LIBNAME_SUFFIX}
                HINTS ${OPENIMAGEIO_ROOT_DIR}/lib
                PATH_SUFFIXES lib64 lib
                PATHS "${OPENIMAGEIO_ROOT_DIR}/lib" )

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -183,6 +183,7 @@ set_target_properties(OpenImageIO
                          PROPERTIES
                          VERSION ${OIIO_VERSION_MAJOR}.${OIIO_VERSION_MINOR}.${OIIO_VERSION_PATCH}
                          SOVERSION ${SOVERSION}
+                         OUTPUT_NAME OpenImageIO${OIIO_LIBNAME_SUFFIX}
                      )
 if (VISIBILITY_COMMAND)
     set_target_properties (OpenImageIO

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -24,6 +24,7 @@ set_target_properties(OpenImageIO_Util
                          PROPERTIES
                          VERSION ${OIIO_VERSION_MAJOR}.${OIIO_VERSION_MINOR}.${OIIO_VERSION_PATCH}
                          SOVERSION ${SOVERSION}
+                         OUTPUT_NAME OpenImageIO_Util${OIIO_LIBNAME_SUFFIX}
                      )
 
 if (VISIBILITY_COMMAND)


### PR DESCRIPTION
This patch allows an optional suffix to be specified that will let you
produce something like libOpenImageIO_CIA.so or whatever. Use with
caution, or preferably not at all, if you don't absolutely need it).

Example of how it's used: Suppose you're at a facility that needs (don't
ask why) multiple versions of OpenImageIO to be built. And namespacing
is not enough, because if you have two copies of libOpenImageIO.so, you
can't separately rpath them.
