### PR TITLE
OSX Mojave gives rude messages about OpenGL being deprecated

### DIFF
--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -41,6 +41,9 @@
 #    pragma warning(disable : 4127 4512)
 #endif
 
+// Thanks, Apple, dammit:
+#define GL_SILENCE_DEPRECATION 1
+
 // included to remove std::min/std::max errors
 #include <OpenImageIO/platform.h>
 


### PR DESCRIPTION
Defining this symbol turns it off. Somewhere on my list is to remove the
OGL dependency from iv, but this band-aid will help until I get some
free time for that.

