### PR TITLE
Sprinkle noexcept widely over many of the core utility classes

### DIFF
--- a/src/include/OpenImageIO/errorhandler.h
+++ b/src/include/OpenImageIO/errorhandler.h
@@ -77,17 +77,17 @@ public:
         VERBOSE = 2   ///< Like NORMAL, but also show INFO
     };
 
-    ErrorHandler()
+    ErrorHandler() noexcept
         : m_verbosity(NORMAL)
     {
     }
     virtual ~ErrorHandler() {}
 
     /// Set desired verbosity level.
-    void verbosity(int v) { m_verbosity = v; }
+    void verbosity(int v) noexcept { m_verbosity = v; }
 
     /// Return the current verbosity level.
-    int verbosity() const { return m_verbosity; }
+    int verbosity() const noexcept { return m_verbosity; }
 
     /// The main (or "full detail") method -- takes a code (with high
     /// bits being an ErrCode) and writes the message, with a prefix

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -1045,11 +1045,11 @@ private:
 template <class T=float>
 class EightBitConverter {
 public:
-    EightBitConverter () { init(); }
-    T operator() (unsigned char c) const { return val[c]; }
+    EightBitConverter () noexcept { init(); }
+    T operator() (unsigned char c) const noexcept { return val[c]; }
 private:
     T val[256];
-    void init () {
+    void init () noexcept {
         float scale = 1.0f / 255.0f;
         if (std::numeric_limits<T>::is_integer)
             scale *= (float)std::numeric_limits<T>::max();

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -118,33 +118,33 @@ struct ROI {
 
     /// Default constructor is an undefined region. Note that this is also
     /// interpreted as All().
-    constexpr ROI () : xbegin(std::numeric_limits<int>::min()), xend(0),
+    constexpr ROI () noexcept : xbegin(std::numeric_limits<int>::min()), xend(0),
              ybegin(0), yend(0), zbegin(0), zend(0), chbegin(0), chend(0)
     { }
 
     /// Constructor with an explicitly defined region.
     ///
     constexpr ROI (int xbegin, int xend, int ybegin, int yend,
-         int zbegin=0, int zend=1, int chbegin=0, int chend=10000)
+         int zbegin=0, int zend=1, int chbegin=0, int chend=10000) noexcept
         : xbegin(xbegin), xend(xend), ybegin(ybegin), yend(yend),
           zbegin(zbegin), zend(zend), chbegin(chbegin), chend(chend)
     { }
 
     /// Is a region defined?
-    constexpr bool defined () const { return (xbegin != std::numeric_limits<int>::min()); }
+    constexpr bool defined () const noexcept { return (xbegin != std::numeric_limits<int>::min()); }
 
     // Region dimensions.
-    constexpr int width () const { return xend - xbegin; }
-    constexpr int height () const { return yend - ybegin; }
-    constexpr int depth () const { return zend - zbegin; }
+    constexpr int width () const noexcept { return xend - xbegin; }
+    constexpr int height () const noexcept { return yend - ybegin; }
+    constexpr int depth () const noexcept { return zend - zbegin; }
 
     /// Number of channels in the region.  Beware -- this defaults to a
     /// huge number, and to be meaningful you must consider
     /// std::min (imagebuf.nchannels(), roi.nchannels()).
-    constexpr int nchannels () const { return chend - chbegin; }
+    constexpr int nchannels () const noexcept { return chend - chbegin; }
 
     /// Total number of pixels in the region.
-    constexpr imagesize_t npixels () const {
+    constexpr imagesize_t npixels () const noexcept {
         return defined()
             ? imagesize_t(width()) * imagesize_t(height()) * imagesize_t(depth())
             : 0;
@@ -155,17 +155,17 @@ struct ROI {
     ///     float myfunc (ImageBuf &buf, ROI roi = ROI::All());
     /// Note that this is equivalent to:
     ///     float myfunc (ImageBuf &buf, ROI roi = {});
-    static constexpr ROI All () { return ROI(); }
+    static constexpr ROI All () noexcept { return ROI(); }
 
     /// Test equality of two ROIs
-    friend constexpr bool operator== (const ROI &a, const ROI &b) {
+    friend constexpr bool operator== (const ROI &a, const ROI &b) noexcept {
         return (a.xbegin == b.xbegin && a.xend == b.xend &&
                 a.ybegin == b.ybegin && a.yend == b.yend &&
                 a.zbegin == b.zbegin && a.zend == b.zend &&
                 a.chbegin == b.chbegin && a.chend == b.chend);
     }
     /// Test inequality of two ROIs
-    friend constexpr bool operator!= (const ROI &a, const ROI &b) {
+    friend constexpr bool operator!= (const ROI &a, const ROI &b) noexcept {
         return (a.xbegin != b.xbegin || a.xend != b.xend ||
                 a.ybegin != b.ybegin || a.yend != b.yend ||
                 a.zbegin != b.zbegin || a.zend != b.zend ||
@@ -173,13 +173,13 @@ struct ROI {
     }
 
     /// Test if the coordinate is within the ROI.
-    constexpr bool contains (int x, int y, int z=0, int ch=0) const {
+    constexpr bool contains (int x, int y, int z=0, int ch=0) const noexcept {
         return x >= xbegin && x < xend && y >= ybegin && y < yend
             && z >= zbegin && z < zend && ch >= chbegin && ch < chend;
     }
 
     /// Test if another ROI is entirely within our ROI.
-    constexpr bool contains (const ROI& other) const {
+    constexpr bool contains (const ROI& other) const noexcept {
         return (other.xbegin >= xbegin && other.xend <= xend &&
                 other.ybegin >= ybegin && other.yend <= yend &&
                 other.zbegin >= zbegin && other.zend <= zend &&
@@ -198,7 +198,7 @@ struct ROI {
 
 
 /// Union of two regions, the smallest region containing both.
-inline constexpr ROI roi_union (const ROI &A, const ROI &B) {
+inline constexpr ROI roi_union (const ROI &A, const ROI &B) noexcept {
     return (A.defined() && B.defined())
         ? ROI (std::min (A.xbegin,  B.xbegin),  std::max (A.xend,  B.xend),
                std::min (A.ybegin,  B.ybegin),  std::max (A.yend,  B.yend),
@@ -208,7 +208,7 @@ inline constexpr ROI roi_union (const ROI &A, const ROI &B) {
 }
 
 /// Intersection of two regions.
-inline constexpr ROI roi_intersection (const ROI &A, const ROI &B) {
+inline constexpr ROI roi_intersection (const ROI &A, const ROI &B) noexcept {
     return (A.defined() && B.defined())
         ? ROI (std::max (A.xbegin,  B.xbegin),  std::min (A.xend,  B.xend),
                std::max (A.ybegin,  B.ybegin),  std::min (A.yend,  B.yend),

--- a/src/include/OpenImageIO/string_view.h
+++ b/src/include/OpenImageIO/string_view.h
@@ -103,15 +103,15 @@ public:
     static const size_type npos = ~size_type(0);
 
     /// Default ctr
-    string_view() { init(NULL, 0); }
+    string_view() noexcept { init(nullptr, 0); }
     /// Copy ctr
-    string_view(const string_view& copy) { init(copy.m_chars, copy.m_len); }
+    string_view(const string_view& copy) noexcept { init(copy.m_chars, copy.m_len); }
     /// Construct from char* and length.
     string_view(const charT* chars, size_t len) { init(chars, len); }
     /// Construct from char*, use strlen to determine length.
     string_view(const charT* chars) { init(chars, chars ? strlen(chars) : 0); }
     /// Construct from std::string.
-    string_view(const std::string& str) { init(str.data(), str.size()); }
+    string_view(const std::string& str) noexcept { init(str.data(), str.size()); }
 
     std::string str() const
     {
@@ -139,7 +139,7 @@ public:
     const char* c_str() const;
 
     // assignments
-    string_view& operator=(const string_view& copy)
+    string_view& operator=(const string_view& copy) noexcept
     {
         init(copy.data(), copy.length());
         return *this;
@@ -148,20 +148,20 @@ public:
     operator std::string() const { return str(); }
 
     // iterators
-    const_iterator begin() const { return m_chars; }
-    const_iterator end() const { return m_chars + m_len; }
-    const_iterator cbegin() const { return m_chars; }
-    const_iterator cend() const { return m_chars + m_len; }
-    const_reverse_iterator rbegin() const { return const_reverse_iterator (end()); }
-    const_reverse_iterator rend() const { return const_reverse_iterator (begin()); }
-    const_reverse_iterator crbegin() const { return const_reverse_iterator (end()); }
-    const_reverse_iterator crend() const { return const_reverse_iterator (begin()); }
+    const_iterator begin() const noexcept { return m_chars; }
+    const_iterator end() const noexcept { return m_chars + m_len; }
+    const_iterator cbegin() const noexcept { return m_chars; }
+    const_iterator cend() const noexcept { return m_chars + m_len; }
+    const_reverse_iterator rbegin() const noexcept { return const_reverse_iterator (end()); }
+    const_reverse_iterator rend() const noexcept { return const_reverse_iterator (begin()); }
+    const_reverse_iterator crbegin() const noexcept { return const_reverse_iterator (end()); }
+    const_reverse_iterator crend() const noexcept { return const_reverse_iterator (begin()); }
 
     // capacity
-    size_type size() const { return m_len; }
-    size_type length() const { return m_len; }
-    size_type max_size() const { return m_len; }
-    bool empty() const { return m_len == 0; }
+    size_type size() const noexcept { return m_len; }
+    size_type length() const noexcept { return m_len; }
+    size_type max_size() const noexcept { return m_len; }
+    bool empty() const noexcept { return m_len == 0; }
 
     // element access
     const charT& operator[](size_type pos) const { return m_chars[pos]; }
@@ -173,25 +173,25 @@ public:
     }
     const charT& front() const { return m_chars[0]; }
     const charT& back() const { return m_chars[m_len - 1]; }
-    const charT* data() const { return m_chars; }
+    const charT* data() const noexcept { return m_chars; }
 
     // modifiers
-    void clear() { init(NULL, 0); }
-    void remove_prefix(size_type n)
+    void clear() noexcept { init(nullptr, 0); }
+    void remove_prefix(size_type n) noexcept
     {
         if (n > m_len)
             n = m_len;
         m_chars += n;
         m_len -= n;
     }
-    void remove_suffix(size_type n)
+    void remove_suffix(size_type n) noexcept
     {
         if (n > m_len)
             n = m_len;
         m_len -= n;
     }
 
-    string_view substr(size_type pos, size_type n = npos) const
+    string_view substr(size_type pos, size_type n = npos) const noexcept
     {
         if (pos > size())
             return string_view();  // start past end -> return empty
@@ -200,7 +200,7 @@ public:
         return string_view(data() + pos, n);
     }
 
-    int compare (string_view x) const {
+    int compare (string_view x) const noexcept {
         const int cmp = std::char_traits<char>::compare (m_chars, x.m_chars, (std::min)(m_len, x.m_len));
         return cmp != 0 ? cmp : int(m_len - x.m_len);
         // Equivalent to:
@@ -209,13 +209,14 @@ public:
 
 #if 0
     // Do these later if anybody needs them
-    bool starts_with(string_view x) const;
-    bool ends_with(string_view x) const;
+    bool starts_with(string_view x) const noexcept;
+    bool ends_with(string_view x) const noexcept;
+    size_type copy(CharT* dest, size_type count, size_type pos = 0) const;
 #endif
 
     /// Find the first occurrence of substring s in *this, starting at
     /// position pos.
-    size_type find(string_view s, size_t pos = 0) const
+    size_type find(string_view s, size_t pos = 0) const noexcept
     {
         if (pos > size())
             pos = size();
@@ -226,7 +227,7 @@ public:
 
     /// Find the first occurrence of character c in *this, starting at
     /// position pos.
-    size_type find (charT c, size_t pos=0) const {
+    size_type find (charT c, size_t pos=0) const noexcept {
         if (pos > size())
             pos = size();
         const_iterator i = std::find_if (this->cbegin()+pos, this->cend(),
@@ -236,7 +237,7 @@ public:
 
     /// Find the last occurrence of substring s *this, but only those
     /// occurrences earlier than position pos.
-    size_type rfind (string_view s, size_t pos=npos) const {
+    size_type rfind (string_view s, size_t pos=npos) const noexcept {
         if (pos > size())
             pos = size();
         const_reverse_iterator b = this->crbegin()+(size()-pos);
@@ -247,7 +248,7 @@ public:
 
     /// Find the last occurrence of character c in *this, but only those
     /// occurrences earlier than position pos.
-    size_type rfind (charT c, size_t pos=npos) const {
+    size_type rfind (charT c, size_t pos=npos) const noexcept {
         if (pos > size())
             pos = size();
         const_reverse_iterator b = this->crbegin()+(size()-pos);
@@ -256,11 +257,11 @@ public:
         return i == e ? npos : reverse_distance (this->crbegin(),i);
     }
 
-    size_type find_first_of (charT c, size_t pos=0) const { return find (c, pos); }
+    size_type find_first_of (charT c, size_t pos=0) const noexcept { return find (c, pos); }
 
-    size_type find_last_of (charT c, size_t pos=npos) const { return rfind (c, pos); }
+    size_type find_last_of (charT c, size_t pos=npos) const noexcept { return rfind (c, pos); }
 
-    size_type find_first_of (string_view s, size_t pos=0) const {
+    size_type find_first_of (string_view s, size_t pos=0) const noexcept {
         if (pos >= size())
             return npos;
         const_iterator i = std::find_first_of (this->cbegin()+pos, this->cend(),
@@ -268,7 +269,7 @@ public:
         return i == this->cend() ? npos : std::distance (this->cbegin(), i);
     }
 
-    size_type find_last_of (string_view s, size_t pos=npos) const {
+    size_type find_last_of (string_view s, size_t pos=npos) const noexcept {
         if (pos > size())
             pos = size();
         size_t off = size()-pos;
@@ -277,14 +278,14 @@ public:
         return i == this->crend() ? npos : reverse_distance (this->crbegin(), i);
     }
 
-    size_type find_first_not_of (string_view s, size_t pos=0) const {
+    size_type find_first_not_of (string_view s, size_t pos=0) const noexcept {
         if (pos >= size())
             return npos;
         const_iterator i = find_not_of (this->cbegin()+pos, this->cend(), s);
         return i == this->cend() ? npos : std::distance (this->cbegin(), i);
     }
 
-    size_type find_first_not_of (charT c, size_t pos=0) const {
+    size_type find_first_not_of (charT c, size_t pos=0) const noexcept {
         if (pos >= size())
             return npos;
         for (const_iterator i = this->cbegin()+pos; i != this->cend(); ++i)
@@ -293,7 +294,7 @@ public:
         return npos;
     }
 
-    size_type find_last_not_of (string_view s, size_t pos=npos) const {
+    size_type find_last_not_of (string_view s, size_t pos=npos) const noexcept {
         if (pos > size())
             pos = size();
         size_t off = size()-pos;
@@ -301,7 +302,7 @@ public:
         return i == this->crend() ? npos : reverse_distance (this->crbegin(), i);
     }
 
-    size_type find_last_not_of (charT c, size_t pos=npos) const {
+    size_type find_last_not_of (charT c, size_t pos=npos) const noexcept {
         if (pos > size())
             pos = size();
         size_t off = size()-pos;
@@ -315,20 +316,20 @@ private:
     const charT* m_chars;
     size_t m_len;
 
-    void init(const charT* chars, size_t len)
+    void init(const charT* chars, size_t len) noexcept
     {
         m_chars = chars;
         m_len   = len;
     }
 
     template<typename r_iter>
-    size_type reverse_distance(r_iter first, r_iter last) const
+    size_type reverse_distance(r_iter first, r_iter last) const noexcept
     {
         return m_len - 1 - std::distance(first, last);
     }
 
     template<typename iter>
-    iter find_not_of(iter first, iter last, string_view s) const
+    iter find_not_of(iter first, iter last, string_view s) const noexcept
     {
         for (; first != last; ++first)
             if (!traits::find(s.data(), s.length(), *first))
@@ -338,8 +339,8 @@ private:
 
     class traits_eq {
     public:
-        traits_eq (charT ch) : ch(ch) {}
-        bool operator () (charT val) const { return traits::eq (ch, val); }
+        traits_eq (charT ch) noexcept : ch(ch) {}
+        bool operator () (charT val) const noexcept { return traits::eq (ch, val); }
         charT ch;
     };
 };
@@ -347,37 +348,37 @@ private:
 
 
 inline bool
-operator==(string_view x, string_view y)
+operator==(string_view x, string_view y) noexcept
 {
     return x.size() == y.size() ? (x.compare(y) == 0) : false;
 }
 
 inline bool
-operator!=(string_view x, string_view y)
+operator!=(string_view x, string_view y) noexcept
 {
     return x.size() == y.size() ? (x.compare(y) != 0) : true;
 }
 
 inline bool
-operator<(string_view x, string_view y)
+operator<(string_view x, string_view y) noexcept
 {
     return x.compare(y) < 0;
 }
 
 inline bool
-operator>(string_view x, string_view y)
+operator>(string_view x, string_view y) noexcept
 {
     return x.compare(y) > 0;
 }
 
 inline bool
-operator<=(string_view x, string_view y)
+operator<=(string_view x, string_view y) noexcept
 {
     return x.compare(y) <= 0;
 }
 
 inline bool
-operator>=(string_view x, string_view y)
+operator>=(string_view x, string_view y) noexcept
 {
     return x.compare(y) >= 0;
 }

--- a/src/include/OpenImageIO/sysutil.h
+++ b/src/include/OpenImageIO/sysutil.h
@@ -132,7 +132,7 @@ terminal_rows();
 class OIIO_API Term {
 public:
     /// Default ctr: assume ANSI escape sequences are ok.
-    Term() {}
+    Term() noexcept {}
     /// Construct from a FILE*: ANSI codes ok if the file describes a
     /// live console, otherwise they will be supressed.
     Term(FILE* file);
@@ -162,7 +162,7 @@ public:
     std::string ansi_fgcolor(int r, int g, int b);
     std::string ansi_bgcolor(int r, int g, int b);
 
-    bool is_console() const { return m_is_console; }
+    bool is_console() const noexcept { return m_is_console; }
 
 private:
     bool m_is_console = true;  // Default: assume ANSI escape sequences ok.

--- a/src/include/OpenImageIO/tiffutils.h
+++ b/src/include/OpenImageIO/tiffutils.h
@@ -249,7 +249,7 @@ struct TagInfo {
                                 bool swapendian, int offset_adjustment);
 
     TagInfo (int tag, const char *name, TIFFDataType type,
-             int count, HandlerFunc handler = nullptr)
+             int count, HandlerFunc handler = nullptr) noexcept
         : tifftag(tag), name(name), tifftype(type), tiffcount(count),
           handler(handler) {}
 

--- a/src/include/OpenImageIO/tinyformat.h
+++ b/src/include/OpenImageIO/tinyformat.h
@@ -177,9 +177,9 @@ struct is_convertible
         struct fail { char dummy[2]; };
         struct succeed { char dummy; };
         // Try to convert a T1 to a T2 by plugging into tryConvert
-        static fail tryConvert(...);
-        static succeed tryConvert(const T2&);
-        static const T1& makeT1();
+        static fail tryConvert(...) noexcept;
+        static succeed tryConvert(const T2&) noexcept;
+        static const T1& makeT1() noexcept;
     public:
 #       ifdef _MSC_VER
         // Disable spurious loss of precision warnings in tryConvert(makeT1())

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -113,7 +113,7 @@ struct OIIO_API TypeDesc {
     /// Construct from a BASETYPE and optional aggregateness and
     /// transformation rules.
     constexpr TypeDesc (BASETYPE btype=UNKNOWN, AGGREGATE agg=SCALAR,
-                        VECSEMANTICS xform=NOXFORM)
+                        VECSEMANTICS xform=NOXFORM) noexcept
         : basetype(static_cast<unsigned char>(btype)),
           aggregate(static_cast<unsigned char>(agg)),
           vecsemantics(static_cast<unsigned char>(xform)), reserved(0),
@@ -122,7 +122,7 @@ struct OIIO_API TypeDesc {
 
     /// Construct an array of a non-aggregate BASETYPE.
     ///
-    constexpr TypeDesc (BASETYPE btype, int arraylength)
+    constexpr TypeDesc (BASETYPE btype, int arraylength) noexcept
         : basetype(static_cast<unsigned char>(btype)),
           aggregate(SCALAR), vecsemantics(NOXFORM),
           reserved(0), arraylen(arraylength)
@@ -130,7 +130,7 @@ struct OIIO_API TypeDesc {
 
     /// Construct an array from BASETYPE, AGGREGATE, and array length,
     /// with unspecified (or moot) vector transformation semantics.
-    constexpr TypeDesc (BASETYPE btype, AGGREGATE agg, int arraylength)
+    constexpr TypeDesc (BASETYPE btype, AGGREGATE agg, int arraylength) noexcept
         : basetype(static_cast<unsigned char>(btype)),
           aggregate(static_cast<unsigned char>(agg)),
           vecsemantics(NOXFORM), reserved(0),
@@ -140,7 +140,7 @@ struct OIIO_API TypeDesc {
     /// Construct an array from BASETYPE, AGGREGATE, VECSEMANTICS, and
     /// array length.
     constexpr TypeDesc (BASETYPE btype, AGGREGATE agg,
-                        VECSEMANTICS xform, int arraylength)
+                        VECSEMANTICS xform, int arraylength) noexcept
         : basetype(static_cast<unsigned char>(btype)),
           aggregate(static_cast<unsigned char>(agg)),
           vecsemantics(static_cast<unsigned char>(xform)),
@@ -152,7 +152,7 @@ struct OIIO_API TypeDesc {
     TypeDesc (string_view typestring);
 
     /// Copy constructor.
-    constexpr TypeDesc (const TypeDesc &t)
+    constexpr TypeDesc (const TypeDesc &t) noexcept
         : basetype(t.basetype), aggregate(t.aggregate),
           vecsemantics(t.vecsemantics), reserved(0), arraylen(t.arraylen)
           { }
@@ -168,7 +168,7 @@ struct OIIO_API TypeDesc {
 
     /// Return the number of elements: 1 if not an array, or the array
     /// length. Invalid to call this for arrays of undetermined size.
-    OIIO_CONSTEXPR14 size_t numelements () const {
+    OIIO_CONSTEXPR14 size_t numelements () const noexcept {
         DASSERT_MSG (arraylen >= 0, "Called numelements() on TypeDesc "
                      "of array with unspecified length (%d)", arraylen);
         return (arraylen >= 1 ? arraylen : 1);
@@ -177,23 +177,23 @@ struct OIIO_API TypeDesc {
     /// Return the number of basetype values: the aggregate count multiplied
     /// by the array length (or 1 if not an array). Invalid to call this
     /// for arrays of undetermined size.
-    OIIO_CONSTEXPR14 size_t basevalues () const {
+    OIIO_CONSTEXPR14 size_t basevalues () const noexcept {
         return numelements() * aggregate;
     }
 
     /// Does this TypeDesc describe an array?
-    constexpr bool is_array () const { return (arraylen != 0); }
+    constexpr bool is_array () const noexcept { return (arraylen != 0); }
 
     /// Does this TypeDesc describe an array, but whose length is not
     /// specified?
-    constexpr bool is_unsized_array () const { return (arraylen < 0); }
+    constexpr bool is_unsized_array () const noexcept { return (arraylen < 0); }
 
     /// Does this TypeDesc describe an array, whose length is specified?
-    constexpr bool is_sized_array () const { return (arraylen > 0); }
+    constexpr bool is_sized_array () const noexcept { return (arraylen > 0); }
 
     /// Return the size, in bytes, of this type.
     ///
-    size_t size () const {
+    size_t size () const noexcept {
         DASSERT_MSG (arraylen >= 0, "Called size() on TypeDesc "
                      "of array with unspecified length (%d)", arraylen);
         size_t a = (size_t) (arraylen > 0 ? arraylen : 1);
@@ -210,13 +210,13 @@ struct OIIO_API TypeDesc {
 
     /// Return the type of one element, i.e., strip out the array-ness.
     ///
-    OIIO_CONSTEXPR14 TypeDesc elementtype () const {
+    OIIO_CONSTEXPR14 TypeDesc elementtype () const noexcept {
         TypeDesc t (*this);  t.arraylen = 0;  return t;
     }
 
     /// Return the size, in bytes, of one element of this type (that is,
     /// ignoring whether it's an array).
-    size_t elementsize () const { return aggregate * basesize(); }
+    size_t elementsize () const noexcept { return aggregate * basesize(); }
 
     // /// Return just the underlying C scalar type, i.e., strip out the
     // /// array-ness and the aggregateness.
@@ -224,20 +224,20 @@ struct OIIO_API TypeDesc {
 
     /// Return the base type size, i.e., stripped of both array-ness
     /// and aggregateness.
-    size_t basesize () const;
+    size_t basesize () const noexcept;
 
     /// True if it's a floating-point type (versus a fundamentally
     /// integral type or something else like a string).
-    bool is_floating_point () const;
+    bool is_floating_point () const noexcept;
 
     /// True if it's a signed type that allows for negative values.
-    bool is_signed () const;
+    bool is_signed () const noexcept;
 
     /// Shortcut: is it UNKNOWN?
-    constexpr bool is_unknown () const { return (basetype == UNKNOWN); }
+    constexpr bool is_unknown () const noexcept { return (basetype == UNKNOWN); }
 
     /// if (typespec) is the same as asking whether it's not UNKNOWN.
-    constexpr operator bool () const { return (basetype != UNKNOWN); }
+    constexpr operator bool () const noexcept { return (basetype != UNKNOWN); }
 
     /// Set *this to the type described in the string.  Return the
     /// length of the part of the string that describes the type.  If
@@ -247,64 +247,64 @@ struct OIIO_API TypeDesc {
 
     /// Compare two TypeDesc values for equality.
     ///
-    constexpr bool operator== (const TypeDesc &t) const {
+    constexpr bool operator== (const TypeDesc &t) const noexcept {
         return basetype == t.basetype && aggregate == t.aggregate &&
             vecsemantics == t.vecsemantics && arraylen == t.arraylen;
     }
 
     /// Compare two TypeDesc values for inequality.
     ///
-    constexpr bool operator!= (const TypeDesc &t) const { return ! (*this == t); }
+    constexpr bool operator!= (const TypeDesc &t) const noexcept { return ! (*this == t); }
 
     /// Compare a TypeDesc to a basetype (it's the same if it has the
     /// same base type and is not an aggregate or an array).
-    friend constexpr bool operator== (const TypeDesc &t, BASETYPE b) {
+    friend constexpr bool operator== (const TypeDesc &t, BASETYPE b) noexcept {
         return (BASETYPE)t.basetype == b && (AGGREGATE)t.aggregate == SCALAR && !t.is_array();
     }
-    friend constexpr bool operator== (BASETYPE b, const TypeDesc &t) {
+    friend constexpr bool operator== (BASETYPE b, const TypeDesc &t) noexcept {
         return (BASETYPE)t.basetype == b && (AGGREGATE)t.aggregate == SCALAR && !t.is_array();
     }
 
     /// Compare a TypeDesc to a basetype (it's the same if it has the
     /// same base type and is not an aggregate or an array).
-    friend constexpr bool operator!= (const TypeDesc &t, BASETYPE b) {
+    friend constexpr bool operator!= (const TypeDesc &t, BASETYPE b) noexcept {
         return (BASETYPE)t.basetype != b || (AGGREGATE)t.aggregate != SCALAR || t.is_array();
     }
-    friend constexpr bool operator!= (BASETYPE b, const TypeDesc &t) {
+    friend constexpr bool operator!= (BASETYPE b, const TypeDesc &t) noexcept {
         return (BASETYPE)t.basetype != b || (AGGREGATE)t.aggregate != SCALAR || t.is_array();
     }
 
     /// TypeDesc's are equivalent if they are equal, or if their only
     /// inequality is differing vector semantics.
-    friend constexpr bool equivalent (const TypeDesc &a, const TypeDesc &b) {
+    friend constexpr bool equivalent (const TypeDesc &a, const TypeDesc &b) noexcept {
         return a.basetype == b.basetype && a.aggregate == b.aggregate &&
                (a.arraylen == b.arraylen || (a.is_unsized_array() && b.is_sized_array())
                                          || (a.is_sized_array()   && b.is_unsized_array()));
     }
     /// Member version of equivalent
-    constexpr bool equivalent (const TypeDesc &b) const {
+    constexpr bool equivalent (const TypeDesc &b) const noexcept {
         return this->basetype == b.basetype && this->aggregate == b.aggregate &&
                (this->arraylen == b.arraylen || (this->is_unsized_array() && b.is_sized_array())
                                              || (this->is_sized_array()   && b.is_unsized_array()));
     }
 
     /// Is this a 3-vector aggregate (of the given type, float by default)?
-    constexpr bool is_vec3 (BASETYPE b=FLOAT) const {
+    constexpr bool is_vec3 (BASETYPE b=FLOAT) const noexcept {
         return this->aggregate == VEC3 && this->basetype == b && !is_array();
     }
 
     /// Is this a 4-vector aggregate (of the given type, float by default)?
-    constexpr bool is_vec4 (BASETYPE b=FLOAT) const {
+    constexpr bool is_vec4 (BASETYPE b=FLOAT) const noexcept {
         return this->aggregate == VEC4 && this->basetype == b && !is_array();
     }
 
     /// Demote the type to a non-array
     ///
-    void unarray (void) { arraylen = 0; }
+    void unarray (void) noexcept { arraylen = 0; }
 
     /// Test for lexicographic 'less', comes in handy for lots of STL
     /// containers and algorithms.
-    bool operator< (const TypeDesc &x) const;
+    bool operator< (const TypeDesc &x) const noexcept;
 
     // DEPRECATED(1.8): These static const member functions were mildly
     // problematic because they required external linkage (and possibly

--- a/src/include/OpenImageIO/unittest.h
+++ b/src/include/OpenImageIO/unittest.h
@@ -59,7 +59,7 @@ namespace pvt {
 
 class UnitTestFailureCounter {
 public:
-    UnitTestFailureCounter()
+    UnitTestFailureCounter() noexcept
         : m_failures(0)
     {
     }
@@ -72,18 +72,18 @@ public:
             std::cout << Sysutil::Term(std::cout).ansi("green", "OK\n");
         }
     }
-    const UnitTestFailureCounter& operator++()
+    const UnitTestFailureCounter& operator++() noexcept  // prefix
     {
         ++m_failures;
         return *this;
-    }                                             // prefix
-    int operator++(int) { return m_failures++; }  // postfix
-    UnitTestFailureCounter operator+=(int i)
+    }
+    int operator++(int) noexcept { return m_failures++; }  // postfix
+    UnitTestFailureCounter operator+=(int i) noexcept
     {
         m_failures += i;
         return *this;
     }
-    operator int() const { return m_failures; }
+    operator int() const noexcept { return m_failures; }
 
 private:
     int m_failures = 0;

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -155,7 +155,7 @@ public:
 
     /// Default ctr for ustring -- make an empty string.
     ///
-    ustring(void)
+    ustring(void) noexcept
         : m_chars(nullptr)
     {
     }
@@ -207,7 +207,7 @@ public:
 
     /// Copy construct a ustring from another ustring.
     ///
-    ustring(const ustring& str)
+    ustring(const ustring& str) noexcept
         : m_chars(str.m_chars)
     {
     }
@@ -223,10 +223,13 @@ public:
 
     /// ustring destructor.
     ///
-    ~ustring() {}
+    ~ustring() noexcept {}
 
     /// Conversion to string_view
-    operator string_view() const { return string_view(c_str(), length()); }
+    operator string_view() const noexcept
+    {
+        return string_view(c_str(), length());
+    }
 
     /// Assign a ustring to *this.
     ///
@@ -321,15 +324,15 @@ public:
 
     /// Return a C string representation of a ustring.
     ///
-    const char* c_str() const { return m_chars; }
+    const char* c_str() const noexcept { return m_chars; }
 
     /// Return a C string representation of a ustring.
     ///
-    const char* data() const { return c_str(); }
+    const char* data() const noexcept { return c_str(); }
 
     /// Return a C++ std::string representation of a ustring.
     ///
-    const std::string& string() const
+    const std::string& string() const noexcept
     {
         if (m_chars) {
             const TableRep* rep = (const TableRep*)m_chars - 1;
@@ -340,11 +343,11 @@ public:
 
     /// Reset to an empty string.
     ///
-    void clear(void) { m_chars = nullptr; }
+    void clear(void) noexcept { m_chars = nullptr; }
 
     /// Return the number of characters in the string.
     ///
-    size_t length(void) const
+    size_t length(void) const noexcept
     {
         if (!m_chars)
             return 0;
@@ -354,7 +357,7 @@ public:
 
     /// Return a hashed version of the string
     ///
-    size_t hash(void) const
+    size_t hash(void) const noexcept
     {
         if (!m_chars)
             return 0;
@@ -364,32 +367,35 @@ public:
 
     /// Return the number of characters in the string.
     ///
-    size_t size(void) const { return length(); }
+    size_t size(void) const noexcept { return length(); }
 
     /// Is the string empty -- i.e., is it nullptr or does it point to an
     /// empty string?
-    bool empty(void) const { return (size() == 0); }
+    bool empty(void) const noexcept { return (size() == 0); }
 
     /// Return a const_iterator that references the first character of
     /// the string.
-    const_iterator begin() const { return string().begin(); }
+    const_iterator begin() const noexcept { return string().begin(); }
 
     /// Return a const_iterator that references the end of a traversal
     /// of the characters of the string.
-    const_iterator end() const { return string().end(); }
+    const_iterator end() const noexcept { return string().end(); }
 
     /// Return a const_reverse_iterator that references the last
     /// character of the string.
-    const_reverse_iterator rbegin() const { return string().rbegin(); }
+    const_reverse_iterator rbegin() const noexcept { return string().rbegin(); }
 
     /// Return a const_reverse_iterator that references the end of
     /// a reverse traversal of the characters of the string.
-    const_reverse_iterator rend() const { return string().rend(); }
+    const_reverse_iterator rend() const noexcept { return string().rend(); }
 
     /// Return a reference to the character at the given position.
     /// Note that it's up to the caller to be sure pos is within the
     /// size of the string.
-    const_reference operator[](size_type pos) const { return c_str()[pos]; }
+    const_reference operator[](size_type pos) const noexcept
+    {
+        return c_str()[pos];
+    }
 
     /// Dump into character array s the characters of this ustring,
     /// beginning with position pos and copying at most n characters.
@@ -412,12 +418,12 @@ public:
 
     // FIXME: implement compare.
 
-    size_type find(const ustring& str, size_type pos = 0) const
+    size_type find(const ustring& str, size_type pos = 0) const noexcept
     {
         return string().find(str.string(), pos);
     }
 
-    size_type find(const std::string& str, size_type pos = 0) const
+    size_type find(const std::string& str, size_type pos = 0) const noexcept
     {
         return string().find(str, pos);
     }
@@ -432,17 +438,17 @@ public:
         return string().find(s, pos);
     }
 
-    size_type find(char c, size_type pos = 0) const
+    size_type find(char c, size_type pos = 0) const noexcept
     {
         return string().find(c, pos);
     }
 
-    size_type rfind(const ustring& str, size_type pos = npos) const
+    size_type rfind(const ustring& str, size_type pos = npos) const noexcept
     {
         return string().rfind(str.string(), pos);
     }
 
-    size_type rfind(const std::string& str, size_type pos = npos) const
+    size_type rfind(const std::string& str, size_type pos = npos) const noexcept
     {
         return string().rfind(str, pos);
     }
@@ -457,17 +463,19 @@ public:
         return string().rfind(s, pos);
     }
 
-    size_type rfind(char c, size_type pos = npos) const
+    size_type rfind(char c, size_type pos = npos) const noexcept
     {
         return string().rfind(c, pos);
     }
 
     size_type find_first_of(const ustring& str, size_type pos = 0) const
+        noexcept
     {
         return string().find_first_of(str.string(), pos);
     }
 
     size_type find_first_of(const std::string& str, size_type pos = 0) const
+        noexcept
     {
         return string().find_first_of(str, pos);
     }
@@ -482,17 +490,19 @@ public:
         return string().find_first_of(s, pos);
     }
 
-    size_type find_first_of(char c, size_type pos = 0) const
+    size_type find_first_of(char c, size_type pos = 0) const noexcept
     {
         return string().find_first_of(c, pos);
     }
 
     size_type find_last_of(const ustring& str, size_type pos = npos) const
+        noexcept
     {
         return string().find_last_of(str.string(), pos);
     }
 
     size_type find_last_of(const std::string& str, size_type pos = npos) const
+        noexcept
     {
         return string().find_last_of(str, pos);
     }
@@ -507,17 +517,19 @@ public:
         return string().find_last_of(s, pos);
     }
 
-    size_type find_last_of(char c, size_type pos = npos) const
+    size_type find_last_of(char c, size_type pos = npos) const noexcept
     {
         return string().find_last_of(c, pos);
     }
 
     size_type find_first_not_of(const ustring& str, size_type pos = 0) const
+        noexcept
     {
         return string().find_first_not_of(str.string(), pos);
     }
 
     size_type find_first_not_of(const std::string& str, size_type pos = 0) const
+        noexcept
     {
         return string().find_first_not_of(str, pos);
     }
@@ -532,18 +544,19 @@ public:
         return string().find_first_not_of(s, pos);
     }
 
-    size_type find_first_not_of(char c, size_type pos = 0) const
+    size_type find_first_not_of(char c, size_type pos = 0) const noexcept
     {
         return string().find_first_not_of(c, pos);
     }
 
     size_type find_last_not_of(const ustring& str, size_type pos = npos) const
+        noexcept
     {
         return string().find_last_not_of(str.string(), pos);
     }
 
     size_type find_last_not_of(const std::string& str,
-                               size_type pos = npos) const
+                               size_type pos = npos) const noexcept
     {
         return string().find_last_not_of(str, pos);
     }
@@ -558,7 +571,7 @@ public:
         return string().find_last_not_of(s, pos);
     }
 
-    size_type find_last_not_of(char c, size_type pos = npos) const
+    size_type find_last_not_of(char c, size_type pos = npos) const noexcept
     {
         return string().find_last_not_of(c, pos);
     }
@@ -567,7 +580,7 @@ public:
     /// *this is lexicographically earlier than str, 1 if *this is
     /// lexicographically after str.
 
-    int compare(const ustring& str) const
+    int compare(const ustring& str) const noexcept
     {
         return (c_str() == str.c_str())
                    ? 0
@@ -578,7 +591,7 @@ public:
     /// Return 0 if *this is lexicographically equal to str, -1 if
     /// *this is lexicographically earlier than str, 1 if *this is
     /// lexicographically after str.
-    int compare(const std::string& str) const
+    int compare(const std::string& str) const noexcept
     {
         return strcmp(c_str() ? c_str() : "", str.c_str());
     }
@@ -586,7 +599,7 @@ public:
     /// Return 0 if *this is lexicographically equal to str, -1 if
     /// *this is lexicographically earlier than str, 1 if *this is
     /// lexicographically after str.
-    int compare(string_view str) const
+    int compare(string_view str) const noexcept
     {
         return strncmp(c_str() ? c_str() : "", str.data() ? str.data() : "",
                        str.length());
@@ -595,7 +608,7 @@ public:
     /// Return 0 if *this is lexicographically equal to str, -1 if
     /// *this is lexicographically earlier than str, 1 if *this is
     /// lexicographically after str.
-    int compare(const char* str) const
+    int compare(const char* str) const noexcept
     {
         return strcmp(c_str() ? c_str() : "", str ? str : "");
     }
@@ -603,7 +616,7 @@ public:
     /// Return 0 if a is lexicographically equal to b, -1 if a is
     /// lexicographically earlier than b, 1 if a is lexicographically
     /// after b.
-    friend int compare(const std::string& a, const ustring& b)
+    friend int compare(const std::string& a, const ustring& b) noexcept
     {
         return strcmp(a.c_str(), b.c_str() ? b.c_str() : "");
     }
@@ -612,82 +625,94 @@ public:
     /// sequence of characters.  Note that because ustrings are unique,
     /// this is a trivial pointer comparison, not a char-by-char loop as
     /// would be the case with a char* or a std::string.
-    bool operator==(const ustring& str) const { return c_str() == str.c_str(); }
+    bool operator==(const ustring& str) const noexcept
+    {
+        return c_str() == str.c_str();
+    }
 
     /// Test two ustrings for inequality -- are they comprised of different
     /// sequences of characters.  Note that because ustrings are unique,
     /// this is a trivial pointer comparison, not a char-by-char loop as
     /// would be the case with a char* or a std::string.
-    bool operator!=(const ustring& str) const { return c_str() != str.c_str(); }
+    bool operator!=(const ustring& str) const noexcept
+    {
+        return c_str() != str.c_str();
+    }
 
     /// Test a ustring (*this) for lexicographic equality with std::string
     /// x.
-    bool operator==(const std::string& x) const { return compare(x) == 0; }
+    bool operator==(const std::string& x) const noexcept
+    {
+        return compare(x) == 0;
+    }
 
     /// Test a ustring (*this) for lexicographic equality with string_view
     /// x.
-    bool operator==(string_view x) const { return compare(x) == 0; }
+    bool operator==(string_view x) const noexcept { return compare(x) == 0; }
 
     /// Test a ustring (*this) for lexicographic equality with char* x.
-    bool operator==(const char* x) const { return compare(x) == 0; }
+    bool operator==(const char* x) const noexcept { return compare(x) == 0; }
 
     /// Test for lexicographic equality between std::string a and ustring
     /// b.
-    friend bool operator==(const std::string& a, const ustring& b)
+    friend bool operator==(const std::string& a, const ustring& b) noexcept
     {
         return b.compare(a) == 0;
     }
 
     /// Test for lexicographic equality between string_view a and ustring
     /// b.
-    friend bool operator==(string_view a, const ustring& b)
+    friend bool operator==(string_view a, const ustring& b) noexcept
     {
         return b.compare(a) == 0;
     }
 
     /// Test for lexicographic equality between char* a and ustring
     /// b.
-    friend bool operator==(const char* a, const ustring& b)
+    friend bool operator==(const char* a, const ustring& b) noexcept
     {
         return b.compare(a) == 0;
     }
 
     /// Test a ustring (*this) for lexicographic inequality with
     /// std::string x.
-    bool operator!=(const std::string& x) const { return compare(x) != 0; }
+    bool operator!=(const std::string& x) const noexcept
+    {
+        return compare(x) != 0;
+    }
 
     /// Test a ustring (*this) for lexicographic inequality with
     /// string_view x.
-    bool operator!=(string_view x) const { return compare(x) != 0; }
+    bool operator!=(string_view x) const noexcept { return compare(x) != 0; }
 
     /// Test a ustring (*this) for lexicographic inequality with
     /// char* x.
-    bool operator!=(const char* x) const { return compare(x) != 0; }
+    bool operator!=(const char* x) const noexcept { return compare(x) != 0; }
 
     /// Test for lexicographic inequality between std::string a and
     /// ustring b.
-    friend bool operator!=(const std::string& a, const ustring& b)
+    friend bool operator!=(const std::string& a, const ustring& b) noexcept
     {
         return b.compare(a) != 0;
     }
 
     /// Test for lexicographic inequality between string_view a and
     /// ustring b.
-    friend bool operator!=(string_view a, const ustring& b)
+    friend bool operator!=(string_view a, const ustring& b) noexcept
     {
         return b.compare(a) != 0;
     }
 
     /// Test for lexicographic inequality between char* a and
     /// ustring b.
-    friend bool operator!=(const char* a, const ustring& b)
+    friend bool operator!=(const char* a, const ustring& b) noexcept
     {
         return b.compare(a) != 0;
     }
 
     /// Test for lexicographic 'less', comes in handy for lots of STL
     /// containers and algorithms.
-    bool operator<(const ustring& x) const { return compare(x) < 0; }
+    bool operator<(const ustring& x) const noexcept { return compare(x) < 0; }
 
     /// Construct a ustring in a printf-like fashion.  In other words,
     /// something like:
@@ -784,7 +809,7 @@ public:
         int dummy_refcount;     // Dummy field! must be right before chars
         TableRep(string_view strref, size_t hash);
         ~TableRep();
-        const char* c_str() const { return (const char*)(this + 1); }
+        const char* c_str() const noexcept { return (const char*)(this + 1); }
     };
 
 private:
@@ -797,7 +822,7 @@ private:
 /// hash_set using ustring as a key.
 class ustringHash {
 public:
-    size_t operator()(const ustring& s) const { return s.hash(); }
+    size_t operator()(const ustring& s) const noexcept { return s.hash(); }
 };
 
 
@@ -806,7 +831,7 @@ public:
 /// want the strings sorted lexicographically.
 class ustringLess {
 public:
-    size_t operator()(ustring a, ustring b) const { return a < b; }
+    size_t operator()(ustring a, ustring b) const noexcept { return a < b; }
 };
 
 
@@ -817,7 +842,7 @@ public:
 /// sorting order may vary from run to run!
 class ustringPtrIsLess {
 public:
-    size_t operator()(ustring a, ustring b) const
+    size_t operator()(ustring a, ustring b) const noexcept
     {
         return size_t(a.data()) < size_t(b.data());
     }

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -100,7 +100,7 @@ public:
     spin_mutex mutex;
     std::map<std::string, std::pair<double, size_t>> timing_map;
 
-    TimingLog() {}
+    TimingLog() noexcept {}
 
     // Destructor prints the timing report if oiio_log_times >= 2
     ~TimingLog()

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -78,7 +78,7 @@ static int basetype_size[TypeDesc::LASTBASE] = {
 }
 
 size_t
-TypeDesc::basesize() const
+TypeDesc::basesize() const noexcept
 {
     if (basetype >= TypeDesc::LASTBASE)
         return 0;
@@ -89,7 +89,7 @@ TypeDesc::basesize() const
 
 
 bool
-TypeDesc::is_floating_point() const
+TypeDesc::is_floating_point() const noexcept
 {
     static bool isfloat[TypeDesc::LASTBASE] = {
         0,  // UNKNOWN
@@ -115,7 +115,7 @@ TypeDesc::is_floating_point() const
 
 
 bool
-TypeDesc::is_signed() const
+TypeDesc::is_signed() const noexcept
 {
     static bool issigned[TypeDesc::LASTBASE] = {
         0,  // UNKNOWN
@@ -415,7 +415,7 @@ tostring(TypeDesc type, const void* data, const char* float_fmt,
 
 
 bool
-TypeDesc::operator<(const TypeDesc& x) const
+TypeDesc::operator<(const TypeDesc& x) const noexcept
 {
     if (basetype != x.basetype)
         return basetype < x.basetype;


### PR DESCRIPTION
It shouldn't change anything about how you use these. Just marking a bunch
of things that already didn't/couldn't throw exceptions as 'noexcept'.

There will be more of this moving forward, I'm just getting some basic
classes now.

