### PR TITLE
iv info window: sort metadata, like we do for 'oiiotool -info'

### DIFF
--- a/src/iv/ivimage.cpp
+++ b/src/iv/ivimage.cpp
@@ -213,7 +213,12 @@ IvImage::longinfo() const
         if (m_spec.z_channel >= 0)
             m_longinfo += html_table_row("Depth (z) channel", m_spec.z_channel);
 
-        for (auto&& p : m_spec.extra_attribs) {
+        // Sort the metadata alphabetically, case-insensitive, but making
+        // sure that all non-namespaced attribs appear before namespaced
+        // attribs.
+        ParamValueList attribs = m_spec.extra_attribs;
+        attribs.sort(false /* sort case-insensitively */);
+        for (auto&& p : attribs) {
             std::string s = m_spec.metadata_val(p, true);
             m_longinfo += html_table_row(p.name().c_str(), s);
         }


### PR DESCRIPTION
The sorting makes it a lot easier to compare the lists of metadata of two images.
