### PR TITLE
Fix bug in IC::invalidate()

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3344,7 +3344,7 @@ ImageCacheImpl::invalidate_all(bool force)
     // Now, invalidate all the files in our "needs invalidation" list
     for (auto f : all_files) {
         // fprintf (stderr, "Invalidating %s\n", f.c_str());
-        invalidate(f, force);
+        invalidate(f, true);
     }
 
     // Mark the per-thread microcaches as invalid


### PR DESCRIPTION
When we recently made invalidate(file) have a 'force' parameter, we
botched it by not so forcing a particular call in invalidate_all().
In the line being changed here, we're dealing with a list of files
that definitely need invalidation due to special tests, so once
we've established that, we want to force it.

Pointed out by @ThiagoIze in a post-merge comment in #2133 
