### PR TITLE
Avoid std::regex_replace

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -820,6 +820,15 @@ string_view OIIO_API parse_while (string_view &str,
 string_view OIIO_API parse_nested (string_view &str, bool eat=true);
 
 
+/// Look within `str` for the pattern:
+///     head nonwhitespace_chars whitespace
+/// Remove that full pattern from `str` and return the nonwhitespace
+/// part that followed the head (or return the empty string and leave `str`
+/// unmodified, if the head was never found).
+OIIO_API std::string
+excise_string_after_head (std::string& str, string_view head);
+
+
 /// Converts utf-8 string to vector of unicode codepoints. This function
 /// will not stop on invalid sequences. It will let through some invalid
 /// utf-8 sequences like: 0xfdd0-0xfdef, 0x??fffe/0x??ffff. It does not

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -45,12 +45,6 @@
 
 #include "kissfft.hh"
 
-#ifdef USE_BOOST_REGEX
-#    include <boost/regex.hpp>
-#else
-#    include <regex>
-#endif
-
 
 
 ///////////////////////////////////////////////////////////////////////////
@@ -256,15 +250,8 @@ ImageBufAlgo::IBAprep(ROI& roi, ImageBuf* dst, const ImageBuf* A,
             spec.erase_attribute("oiio:SHA-1");
             std::string desc = spec.get_string_attribute("ImageDescription");
             if (desc.size()) {
-#ifdef USE_BOOST_REGEX
-                static boost::regex regex_sha("SHA-1=[[:xdigit:]]*[ ]*");
-                spec.attribute("ImageDescription",
-                               boost::regex_replace(desc, regex_sha, ""));
-#else
-                static std::regex regex_sha("SHA-1=[[:xdigit:]]*[ ]*");
-                spec.attribute("ImageDescription",
-                               std::regex_replace(desc, regex_sha, ""));
-#endif
+                Strutil::excise_string_after_head(desc, "oiio:SHA-1=");
+                spec.attribute("ImageDescription", desc);
             }
         }
 

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -58,16 +58,6 @@
 
 #include "imageio_pvt.h"
 
-#ifdef USE_BOOST_REGEX
-#    include <boost/regex.hpp>
-using boost::regex;
-using boost::regex_replace;
-#else
-#    include <regex>
-using std::regex;
-using std::regex_replace;
-#endif
-
 using namespace OIIO;
 
 
@@ -1640,17 +1630,12 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
 
     // Eliminate any SHA-1 or ConstantColor hints in the ImageDescription.
     if (desc.size()) {
-        desc = regex_replace(desc, regex("SHA-1=[[:xdigit:]]*[ ]*"), "");
-        static const char* fp_number_pattern
-            = "([+-]?((?:(?:[[:digit:]]*\\.)?[[:digit:]]+(?:[eE][+-]?[[:digit:]]+)?)))";
-        const std::string constcolor_pattern
-            = std::string("ConstantColor=(\\[?") + fp_number_pattern
-              + ",?)+\\]?[ ]*";
-        const std::string average_pattern = std::string("AverageColor=(\\[?")
-                                            + fp_number_pattern
-                                            + ",?)+\\]?[ ]*";
-        desc        = regex_replace(desc, regex(constcolor_pattern), "");
-        desc        = regex_replace(desc, regex(average_pattern), "");
+        Strutil::excise_string_after_head(desc, "oiio:ConstantColor=");
+        Strutil::excise_string_after_head(desc, "ConstantColor=");
+        Strutil::excise_string_after_head(desc, "oiio:AverageColor=");
+        Strutil::excise_string_after_head(desc, "AverageColor=");
+        Strutil::excise_string_after_head(desc, "oiio:SHA-1=");
+        Strutil::excise_string_after_head(desc, "SHA-1=");
         updatedDesc = true;
     }
 

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -56,13 +56,11 @@
 #    include <boost/regex.hpp>
 using boost::match_results;
 using boost::regex;
-using boost::regex_replace;
 using boost::regex_search;
 #else
 #    include <regex>
 using std::match_results;
 using std::regex;
-using std::regex_replace;
 using std::regex_search;
 #endif
 
@@ -748,15 +746,12 @@ Filesystem::enumerate_file_sequence(const std::string& pattern,
                                     std::vector<std::string>& filenames)
 {
     ASSERT(views.size() == 0 || views.size() == numbers.size());
-    static regex view_re("%V"), short_view_re("%v");
-
     filenames.clear();
     for (size_t i = 0, e = numbers.size(); i < e; ++i) {
         std::string f = pattern;
         if (views.size() > 0 && !views[i].empty()) {
-            f = regex_replace(f, view_re, std::string(views[i]));
-            f = regex_replace(f, short_view_re,
-                              std::string(views[i].substr(0, 1)));
+            f = Strutil::replace(f, "%V", views[i], true);
+            f = Strutil::replace(f, "%v", views[i].substr(0, 1), true);
         }
         f = Strutil::sprintf(f.c_str(), numbers[i]);
         filenames.push_back(f);
@@ -794,10 +789,9 @@ Filesystem::scan_for_matching_filenames(const std::string& pattern,
                 std::vector<std::string> view_filenames;
 
                 std::string view_pattern = pattern;
-                view_pattern             = regex_replace(view_pattern, view_re,
-                                             std::string(view));
-                view_pattern = regex_replace(view_pattern, short_view_re,
-                                             std::string(short_view));
+                view_pattern = Strutil::replace(view_pattern, "%V", view, true);
+                view_pattern = Strutil::replace(view_pattern, "%v", short_view,
+                                                true);
 
                 if (!scan_for_matching_filenames(view_pattern, view_numbers,
                                                  view_filenames))
@@ -823,13 +817,10 @@ Filesystem::scan_for_matching_filenames(const std::string& pattern,
             std::vector<std::pair<string_view, std::string>> matches;
             for (const auto& view : views) {
                 const string_view short_view = view.substr(0, 1);
-
-                std::string view_pattern = pattern;
-                view_pattern             = regex_replace(view_pattern, view_re,
-                                             std::string(view));
-                view_pattern = regex_replace(view_pattern, short_view_re,
-                                             std::string(short_view));
-
+                std::string view_pattern     = pattern;
+                view_pattern = Strutil::replace(view_pattern, "%V", view, true);
+                view_pattern = Strutil::replace(view_pattern, "%v", short_view,
+                                                true);
                 if (exists(view_pattern))
                     matches.push_back(std::make_pair(view, view_pattern));
             }

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -970,6 +970,25 @@ Strutil::parse_nested(string_view& str, bool eat)
 
 
 
+std::string
+Strutil::excise_string_after_head(std::string& str, string_view head)
+{
+    std::string result;
+    string_view s(str);
+    size_t pattern_start = s.find(head);
+    if (pattern_start != string_view::npos) {
+        // Reposition s to be after the head
+        s.remove_prefix(pattern_start + head.size());
+        string_view m = Strutil::parse_until(s, " \t\r\n");
+        Strutil::skip_whitespace(s);
+        result = m;
+        str    = str.substr(0, pattern_start) + std::string(s);
+    }
+    return result;
+}
+
+
+
 /*
 Copyright for decode function:
 See http://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details.

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -429,6 +429,31 @@ test_replace()
 
 
 void
+test_excise_string_after_head()
+{
+    std::cout << "Testing excise_string_after_head\n";
+    std::string pattern = "Red rose, red rose, end.";
+
+    // test non-match
+    {
+        std::string p = pattern;
+        auto m = Strutil::excise_string_after_head(p, "blue");
+        OIIO_CHECK_EQUAL(p, pattern);
+        OIIO_CHECK_EQUAL(m, "");
+    }
+
+    // test match: head is "ro", match subsequent chars to the next space
+    {
+        std::string p = pattern;
+        auto m = Strutil::excise_string_after_head(p, "ro");
+        OIIO_CHECK_EQUAL(p, "Red red rose, end.");
+        OIIO_CHECK_EQUAL(m, "se,");
+    }
+}
+
+
+
+void
 test_numeric_conversion()
 {
     std::cout << "Testing string_is, string_from conversions\n";
@@ -929,6 +954,7 @@ main(int argc, char* argv[])
     test_join();
     test_repeat();
     test_replace();
+    test_excise_string_after_head();
     test_numeric_conversion();
     test_to_string();
     test_extract();

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -48,12 +48,6 @@
 
 #include "oiiotool.h"
 
-#ifdef USE_BOOST_REGEX
-#    include <boost/regex.hpp>
-#else
-#    include <regex>
-#endif
-
 using namespace OIIO;
 using namespace OiioTool;
 using namespace ImageBufAlgo;
@@ -327,16 +321,8 @@ ImageRec::read(ReadPolicy readpolicy, string_view channel_set)
             std::string desc = ib->spec().get_string_attribute(
                 "ImageDescription");
             if (desc.size()) {
-#ifdef USE_BOOST_REGEX
-                static boost::regex regex_sha("SHA-1=[[:xdigit:]]*[ ]*");
-                ib->specmod().attribute("ImageDescription",
-                                        boost::regex_replace(desc, regex_sha,
-                                                             ""));
-#else
-                static std::regex regex_sha("SHA-1=[[:xdigit:]]*[ ]*");
-                ib->specmod().attribute("ImageDescription",
-                                        std::regex_replace(desc, regex_sha, ""));
-#endif
+                Strutil::excise_string_after_head(desc, "oiio:SHA-1=");
+                ib->specmod().attribute("ImageDescription", desc);
             }
 
             m_subimages[s].m_miplevels[m] = ib;

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -63,13 +63,11 @@
 #    include <boost/regex.hpp>
 using boost::match_results;
 using boost::regex;
-using boost::regex_replace;
 using boost::regex_search;
 #else
 #    include <regex>
 using std::match_results;
 using std::regex;
-using std::regex_replace;
 using std::regex_search;
 #endif
 
@@ -4818,6 +4816,21 @@ prep_texture_config(ImageSpec& configspec,
 
 
 
+// Helper: Remove ":all=[0-9]+" from str
+static void
+remove_all_cmd(std::string& str)
+{
+    std::string result;
+    size_t start = str.find(":all=");
+    if (start != std::string::npos) {
+        size_t end = start + 5;  // : a l l =
+        end = std::min(str.find_first_not_of("0123456789", end), str.size());
+        str = std::string(str, 0, start) + std::string(str, end);
+    }
+}
+
+
+
 static int
 output_file(int argc, const char* argv[])
 {
@@ -4856,10 +4869,9 @@ output_file(int argc, const char* argv[])
         const char* new_argv[2];
         // Git rid of the ":all=" part of the command so we don't infinitely
         // recurse.
-        std::string newcmd = regex_replace(command.str(), regex(":all=[0-9]+"),
-                                           "");
-        new_argv[0]        = newcmd.c_str();
-        ;
+        std::string newcmd = command;
+        remove_all_cmd(newcmd);
+        new_argv[0]              = newcmd.c_str();
         ImageRecRef saved_curimg = ot.curimg;  // because we'll overwrite it
         for (int i = 0; i < nimages; ++i) {
             if (i < nimages - 1)


### PR DESCRIPTION
Certain regex_replace tasks seem to crash on Windows with MSVS's implementation of std::regex.

After considering a more sophisticated test for when we should use boost.regex instead, I instead settled on just replacing the few uses of regex_replace with our own string processing. None were very    sophisticated or truly needed regex functionality.