### PR TITLE
SPI build script revisions, mostly for boost

### DIFF
--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -34,9 +34,6 @@ endif
 MY_CMAKE_FLAGS += -DEXTRA_CPP_ARGS:STRING="-DOIIO_SPI=1" -DOIIO_SITE:STRING=SPI
 MY_CMAKE_FLAGS += -DSPI_TESTS=1
 SPCOMP2_ROOT ?= /shots/spi/home/lib/SpComp2
-SPCOMP2_INSTALL_ROOT ?= $(SPCOMP2_ROOT)
-SPCOMP2_LOCAL_PATH ?= /net/soft_scratch/users/$(USER)/SpComp2_test
-CPPSTDSUFFIX=
 
 
 ## Detect which SPI platform and set $platform, $COMPILER, $SPCOMP2_COMPILER,
@@ -55,12 +52,6 @@ else
 endif  # endif ${SP_OS}
 
 PYTHON_VERSION ?= 2.7
-PYTHON_LIBRARY_DIR ?= /usr/lib64
-PYTHON_LIBRARY ?= ${PYTHON_LIBRARY_DIR}/libpython${PYTHON_VERSION}.so
-PYTHON_INCLUDE_DIR ?= /usr/include/python${PYTHON_VERSION}
-OCIO_SPCOMP_VERSION ?= 2
-OPENVDB_SPCOMP2_VERSION ?= v5020000
-NUKE_VERSION ?= 11.2v3
 
 
 ## Rhel7 (current)
@@ -82,42 +73,13 @@ ifeq (${SP_OS}, rhel7)
         OIIO_LIBNAME_SUFFIX=_Arnold
     endif
 
-    BOOSTVERS ?= 1.55
-    SPCOMP2_USE_BOOSTVERS ?= 1
-    BOOSTSPSUFFIX ?=
-    BOOSTVERSSP=${BOOSTVERS}${BOOSTSPSUFFIX}
-    BOOSTVERS_SUFFIX = -${shell echo ${BOOSTVERS} | sed "s/\\./_/"}
-    BOOSTVERS_PREFIX = ${shell echo ${BOOSTVERS} | sed "s/\\./_/"}_0
-    CONSTRUCTED_BOOSTVERS = ${shell echo ${BOOSTVERS} | sed "s/\\./0/"}00
-    SPCOMP2_BOOSTVERS_SUFFIX = ${shell echo ${BOOSTVERSSP} | sed "s/\\.//"}
-    SPCOMP2_FULLBOOST_SUFFIX = ${SP_OS}-${SPCOMP2_COMPILER}-boost${shell echo ${BOOSTVERSSP} | sed "s/\\.//"}
-    # $(info BOOSTVERSSP ${BOOSTVERSSP})
-    # $(info BOOSTVERS_SUFFIX ${BOOSTVERS_SUFFIX})
-    # $(info BOOSTVERS_PREFIX ${BOOSTVERS_PREFIX})
-    # $(info CONSTRUCTED_BOOSTVERS ${CONSTRUCTED_BOOSTVERS})
-    # $(info SPCOMP2_BOOSTVERS_SUFFIX ${SPCOMP2_BOOSTVERS_SUFFIX})
-    # $(info SPCOMP2_FULLBOOST_SUFFIX ${SPCOMP2_FULLBOOST_SUFFIX})
-    OCIO_PATH ?= ${SPCOMP2_ROOT}/OpenColorIO/${SP_OS}-${SPCOMP2_COMPILER}/v${OCIO_SPCOMP_VERSION}
-    ifneq (${OIIO_SPCOMP2},1)
-        # Anybody remember why we needed Field3d disabled for SpComp2?
-        FIELD3D_HOME ?= ${SPCOMP2_ROOT}/Field3D/${SPCOMP2_FULLBOOST_SUFFIX}/v412
-    endif
-    TBB_ROOT_DIR ?= /net/apps/rhel7/intel/tbb
-    OPENVDB_ROOT_DIR ?= ${SPCOMP2_ROOT}/openvdb/${SPCOMP2_FULLBOOST_SUFFIX}/${OPENVDB_SPCOMP2_VERSION}
-    OIIO_SPCOMP2_PATH := ${SPCOMP2_INSTALL_ROOT}/OpenImageIO/${SP_OS}-${SPCOMP2_COMPILER}$(CPPSTDSUFFIX)-boost${SPCOMP2_BOOSTVERS_SUFFIX}/v${OPENIMAGEIO_SPCOMP2_VERSION}
-    # $(info New rhel7 OIIO_SPCOMP2_PATH is ${OIIO_SPCOMP2_PATH})
-
-    ## If not overridden, here is our preferred LLVM installation
-    ## (may be changed as new versions are rolled out to the facility)
-    LLVM_DIRECTORY ?= /shots/spi/home/lib/arnold/rhel7/llvm_7.0.1
-
+    #
+    # Compilers:
+    #
     # A variety of tags can be used to try specific versions of gcc or
     # clang from the site-specific places we have installed them.
-    ifeq (${COMPILER},clang5)
-        LLVM_DIRECTORY := /shots/spi/home/lib/arnold/rhel7/llvm_5.0.1
-        MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
-        MY_CMAKE_FLAGS += -DCMAKE_C_FLAGS="--gcc-toolchain=/usr" -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr"
-    else ifeq (${COMPILER},clang6)
+    LLVM_DIRECTORY ?= /shots/spi/home/lib/arnold/rhel7/llvm_7.0.1
+    ifeq (${COMPILER},clang6)
 	    LLVM_DIRECTORY := /shots/spi/home/lib/arnold/rhel7/llvm_6.0.1
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
         MY_CMAKE_FLAGS += -DCMAKE_C_FLAGS="--gcc-toolchain=/usr" -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr"
@@ -128,10 +90,6 @@ ifeq (${SP_OS}, rhel7)
     else ifeq (${COMPILER},clang)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
         MY_CMAKE_FLAGS += -DCMAKE_C_FLAGS="--gcc-toolchain=/usr" -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr"
-    else ifeq (${COMPILER}, gcc490)
-      MY_CMAKE_FLAGS += \
-         -DCMAKE_C_COMPILER=/net/soft_scratch/apps/arnold/tools/gcc-4.9-20130512-test/bin/gcc \
-         -DCMAKE_CXX_COMPILER=/net/soft_scratch/apps/arnold/tools/gcc-4.9-20130512-test/bin/g++
     else ifeq (${COMPILER}, gcc6)
         MY_CMAKE_FLAGS += \
            -DCMAKE_C_COMPILER=/opt/rh/devtoolset-6/root/usr/bin/gcc \
@@ -146,29 +104,44 @@ ifeq (${SP_OS}, rhel7)
         MY_CMAKE_FLAGS += -DCMAKE_C_FLAGS="--gcc-toolchain=/usr" -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr"
     endif
 
-    # Set our preferred OpenEXR path, but allow env variable to override
-    # with custom/test version.
-    ifeq (${OPENEXR_ROOT_DIR},)
-	MY_CMAKE_FLAGS += \
-	    -DOPENEXR_INCLUDE_DIR=/usr/include/OpenEXR2 \
-	    -DOPENEXR_LIBRARY_DIR=/usr/lib64/OpenEXR2
+    #
+    # Boost
+    #
+    BOOSTVERS ?= 1.55
+    BOOSTSPSUFFIX ?=
+    BOOSTVERSSP=${BOOSTVERS}${BOOSTSPSUFFIX}
+    # $(info BOOSTVERSSP ${BOOSTVERSSP})
+    ifeq (${BOOSTVERS},1.55)
+        SPBOOST_INC_DIR ?= /usr/include/boost_${BOOSTVERSSP}
+        SPBOOST_LIB_DIR ?= /usr/lib64/boost_${BOOSTVERSSP}
+        ifeq (${BOOSTSPSUFFIX}, sp)
+            SPBOOST_LIBNAMESTART ?= lib${BOOSTSPSUFFIX}boost_${shell echo ${BOOSTVERS} | sed "s/\\./_/"}_0
+        else
+            SPBOOST_LIBNAMESTART ?= lib${BOOSTSPSUFFIX}boost
+        endif
+        SPBOOST_LIBNAMEEND ?= -gcc48-mt-${shell echo ${BOOSTVERS} | sed "s/\\./_/"}
+        MY_CMAKE_FLAGS += \
+            -DBOOST_CUSTOM=1 \
+            -DBoost_VERSION=${BOOSTVERS} \
+            -DBoost_INCLUDE_DIRS=${SPBOOST_INC_DIR} \
+            -DBoost_LIBRARY_DIRS=${SPBOOST_LIB_DIR} \
+            -DBoost_LIBRARIES:STRING="${SPBOOST_LIB_DIR}/${SPBOOST_LIBNAMESTART}_filesystem${SPBOOST_LIBNAMEEND}.so;${SPBOOST_LIB_DIR}/${SPBOOST_LIBNAMESTART}_regex${SPBOOST_LIBNAMEEND}.so;${SPBOOST_LIB_DIR}/${SPBOOST_LIBNAMESTART}_system${SPBOOST_LIBNAMEEND}.so;${SPBOOST_LIB_DIR}/${SPBOOST_LIBNAMESTART}_thread${SPBOOST_LIBNAMEEND}.so"
+    else
+        # Our Boost >= 1.61 setup is MUCH simpler and more standard
+        MY_CMAKE_FLAGS += \
+            -DBOOST_INCLUDEDIR=/usr/include/boostroot/boost${BOOSTVERSSP} \
+            -DBOOST_LIBRARYDIR=/usr/lib64/boostroot/boost${BOOSTVERSSP}
     endif
 
-    MY_CMAKE_FLAGS += \
-	-DOCIO_PATH=${OCIO_PATH} \
-	-DFIELD3D_HOME=${FIELD3D_HOME} \
-	-DOPENVDB_ROOT_DIR=${OPENVDB_ROOT_DIR} \
-	-DTBB_ROOT_DIR=${TBB_ROOT_DIR} \
-	-DHDF5_CUSTOM=1 \
-	-DHDF5_LIBRARIES=/usr/lib64/libhdf5.so \
-	-DNuke_ROOT=/net/apps/rhel7/foundry/nuke${NUKE_VERSION} \
-	-DLIBRAW_INCLUDEDIR_HINT=/usr/include/libraw-0.18.11 \
-	-DLIBRAW_LIBDIR_HINT=/usr/lib64/libraw-0.18.11 \
-	-DLIBHEIF_PATH=/shots/spi/home/lib/arnold/rhel7/libheif-1.3.2
-
-    # Special sauce for Python 3.6
+    #
+    # Python
+    #
+    PYTHON_INCLUDE_DIR ?= /usr/include/python${PYTHON_VERSION}
+    PYTHON_LIBRARY_DIR ?= /usr/lib64
+    PYTHON_LIBRARY ?= ${PYTHON_LIBRARY_DIR}/libpython${PYTHON_VERSION}.so
     ifeq (${PYTHON_VERSION},3.6)
-	PYTHON_INCLUDE_DIR := /usr/include/python${PYTHON_VERSION}m
+        # Special sauce for Python 3.6
+        PYTHON_INCLUDE_DIR := /usr/include/python${PYTHON_VERSION}m
         PYTHON_LIBRARY := ${PYTHON_LIBRARY_DIR}/libpython${PYTHON_VERSION}m.so
         MY_CMAKE_FLAGS += \
             -DPYTHONINTERP_FOUND=1 \
@@ -178,28 +151,55 @@ ifeq (${SP_OS}, rhel7)
             -DPYTHON_VERSION_PATCH=3 \
             -DPython_ADDITIONAL_VERSIONS="${PYTHON_VERSION}"
     endif
-
     MY_CMAKE_FLAGS += \
-        -DBOOST_CUSTOM=1 \
-        -DBoost_VERSION=${CONSTRUCTED_BOOSTVERS} \
-        -DBoost_INCLUDE_DIRS=/usr/include/boost_${BOOSTVERSSP} \
-        -DBoost_LIBRARY_DIRS=/usr/lib64/boost_${BOOSTVERSSP} \
         -DPYTHON_INCLUDE_DIR:STRING=${PYTHON_INCLUDE_DIR} \
         -DPYTHON_LIBRARY:STRING=${PYTHON_LIBRARY}
 
-    ifeq (${BOOSTSPSUFFIX}, sp)
-        MY_CMAKE_FLAGS += -DBoost_LIBRARIES:STRING="/usr/lib64/boost_${BOOSTVERSSP}/lib${BOOSTSPSUFFIX}boost_${BOOSTVERS_PREFIX}_filesystem-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/lib${BOOSTSPSUFFIX}boost_${BOOSTVERS_PREFIX}_regex-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/lib${BOOSTSPSUFFIX}boost_${BOOSTVERS_PREFIX}_system-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/lib${BOOSTSPSUFFIX}boost_${BOOSTVERS_PREFIX}_thread-gcc48-mt${BOOSTVERS_SUFFIX}.so"
-    else
-        MY_CMAKE_FLAGS += -DBoost_LIBRARIES:STRING="/usr/lib64/boost_${BOOSTVERSSP}/lib${BOOSTSPSUFFIX}boost_filesystem-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/lib${BOOSTSPSUFFIX}boost_regex-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/lib${BOOSTSPSUFFIX}boost_system-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/lib${BOOSTSPSUFFIX}boost_thread-gcc48-mt${BOOSTVERS_SUFFIX}.so"
+    # Set our preferred OpenEXR path, but allow env variable to override
+    # with custom/test version.
+    ifeq (${OPENEXR_ROOT_DIR},)
+        MY_CMAKE_FLAGS += \
+            -DOPENEXR_INCLUDE_DIR=/usr/include/OpenEXR2 \
+            -DOPENEXR_LIBRARY_DIR=/usr/lib64/OpenEXR2
     endif
 
+    #
+    # SpComp2 and other weird SPI-installed packages
+    #
+    OCIO_SPCOMP_VERSION ?= 2
+    OPENVDB_SPCOMP2_VERSION ?= v5020000
+    NUKE_VERSION ?= 11.2v3
+    SPCOMP2_BOOSTVERS_SUFFIX = ${shell echo ${BOOSTVERSSP} | sed "s/\\.//"}
+    SPCOMP2_FULLBOOST_SUFFIX = ${SP_OS}-${SPCOMP2_COMPILER}-boost${shell echo ${BOOSTVERSSP} | sed "s/\\.//"}
+    # $(info SPCOMP2_BOOSTVERS_SUFFIX ${SPCOMP2_BOOSTVERS_SUFFIX})
+    # $(info SPCOMP2_FULLBOOST_SUFFIX ${SPCOMP2_FULLBOOST_SUFFIX})
+    OCIO_PATH ?= ${SPCOMP2_ROOT}/OpenColorIO/${SP_OS}-${SPCOMP2_COMPILER}/v${OCIO_SPCOMP_VERSION}
+    ifneq (${OIIO_SPCOMP2},1)
+        # Anybody remember why we needed Field3d disabled for SpComp2?
+        FIELD3D_HOME ?= ${SPCOMP2_ROOT}/Field3D/${SPCOMP2_FULLBOOST_SUFFIX}/v412
+    endif
+    OPENVDB_ROOT_DIR ?= ${SPCOMP2_ROOT}/openvdb/${SPCOMP2_FULLBOOST_SUFFIX}/${OPENVDB_SPCOMP2_VERSION}
+    TBB_ROOT_DIR ?= /net/apps/rhel7/intel/tbb
+    MY_CMAKE_FLAGS += \
+        -DOCIO_PATH=${OCIO_PATH} \
+        -DFIELD3D_HOME=${FIELD3D_HOME} \
+        -DOPENVDB_ROOT_DIR=${OPENVDB_ROOT_DIR} \
+        -DTBB_ROOT_DIR=${TBB_ROOT_DIR} \
+        -DHDF5_CUSTOM=1 \
+        -DHDF5_LIBRARIES=/usr/lib64/libhdf5.so \
+        -DNuke_ROOT=/net/apps/rhel7/foundry/nuke${NUKE_VERSION} \
+        -DLIBRAW_INCLUDEDIR_HINT=/usr/include/libraw-0.18.11 \
+        -DLIBRAW_LIBDIR_HINT=/usr/lib64/libraw-0.18.11 \
+        -DLIBHEIF_PATH=/shots/spi/home/lib/arnold/rhel7/libheif-1.3.2 \
+        -DUSE_OPENCV=0 \
+        -DHIDE_SYMBOLS=1 \
+        -DVISIBILITY_MAP_FILE:STRING="${working_dir}/site/spi/hidesymbols.map"
+
     # Use libtiff I built myself, static, and try to hide its symbols.
-    MY_CMAKE_FLAGS += -DTIFF_INCLUDE_DIR:STRING=/usr/include \
-                      -DTIFF_LIBRARIES:STRING=/net/soft_scratch/users/lg/tiff-4.0.3/rhel7/lib/libtiff.a
-    MY_CMAKE_FLAGS += -DHIDE_SYMBOLS=1
-    MY_CMAKE_FLAGS += -DVISIBILITY_MAP_FILE:STRING="${working_dir}/site/spi/hidesymbols.map"
-    MY_CMAKE_FLAGS += -DEXTRA_DSO_LINK_ARGS:STRING="-Wl,--exclude-libs,libtiff.a"
-    MY_CMAKE_FLAGS += -DUSE_OPENCV=0
+    MY_CMAKE_FLAGS += \
+        -DTIFF_INCLUDE_DIR:STRING=/usr/include \
+        -DTIFF_LIBRARIES:STRING=/net/soft_scratch/users/lg/tiff-4.0.3/rhel7/lib/libtiff.a \
+        -DEXTRA_DSO_LINK_ARGS:STRING="-Wl,--exclude-libs,libtiff.a"
 
     # end rhel7
 
@@ -215,10 +215,6 @@ else ifeq (${platform}, macosx)
     ifeq (${COMPILER}, gcc48)
         MY_CMAKE_FLAGS += \
            -DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8
-        USE_LIBCPLUSPLUS := 0
-    else ifeq (${COMPILER}, gcc49)
-        MY_CMAKE_FLAGS += \
-           -DCMAKE_C_COMPILER=gcc-4.9 -DCMAKE_CXX_COMPILER=g++-4.9
         USE_LIBCPLUSPLUS := 0
     else ifeq (${COMPILER}, gcc5)
         MY_CMAKE_FLAGS += \
@@ -260,13 +256,8 @@ endif  # endif ${SP_OS}
 ############################################################################
 
 
-SPARCH=${SP_OS}-$(SPCOMP2_COMPILER)$(CPPSTDSUFFIX)
-BOOSTVERSSP?=${BOOSTVERS}${BOOSTSPSUFFIX}
-ifdef SPCOMP2_USE_BOOSTVERS
-	ifneq ($(BOOSTVERS),1.42)
-        SPARCH=${SP_OS}-$(SPCOMP2_COMPILER)$(CPPSTDSUFFIX)-boost$(subst .,,$(BOOSTVERSSP))
-	endif
-endif
+CPPSTDSUFFIX=
+SPARCH=${SP_OS}-$(SPCOMP2_COMPILER)$(CPPSTDSUFFIX)-boost$(subst .,,$(BOOSTVERSSP))
 PYVERNOSPACE=${shell echo ${PYTHON_VERSION} | sed "s/\\.//"}
 SPPYARCH=$(SPARCH)-py$(PYVERNOSPACE)
 
@@ -281,7 +272,11 @@ empty:=
 space:= $(empty) $(empty)
 
 INSTALL_BIN_LOCATION = /shots/spi/home/bin/${SP_OS}
+SPCOMP2_INSTALL_ROOT ?= $(SPCOMP2_ROOT)
+OIIO_SPCOMP2_PATH := ${SPCOMP2_INSTALL_ROOT}/OpenImageIO/$(SPARCH)/v${OPENIMAGEIO_SPCOMP2_VERSION}
 INSTALL_SPCOMP2_CURRENT = $(SPCOMP2_INSTALL_ROOT)/OpenImageIO/$(SPARCH)/v$(OPENIMAGEIO_SPCOMP2_VERSION)
+# $(info New rhel7 OIIO_SPCOMP2_PATH is ${OIIO_SPCOMP2_PATH})
+SPCOMP2_LOCAL_PATH ?= /net/soft_scratch/users/$(USER)/SpComp2_test
 
 SPCOMP2_RPATH_OPT ?= ${OCIO_PATH}/lib:${FIELD3D_HOME}/lib:/usr/lib64/libraw-0.18.11:${OPENVDB_ROOT_DIR}/lib:/shots/spi/home/lib/arnold/rhel7/libheif-1.3.2/lib:shots/spi/home/lib/arnold/rhel7/libde265-1.0.3/lib
 SPCOMP2_RPATH_DEBUG ?= ${OCIO_PATH}/lib/debug:${FIELD3D_HOME}/lib/debug:/usr/lib64/libraw-0.18.11:${OPENVDB_ROOT_DIR}/lib/debug:/shots/spi/home/lib/arnold/rhel7/libheif-1.3.2/lib:shots/spi/home/lib/arnold/rhel7/libde265-1.0.3/lib

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -84,10 +84,6 @@ endif ()
 ###########################################################################
 # Boost setup
 
-if (NOT Boost_FIND_QUIETLY)
-    message (STATUS "BOOST_ROOT ${BOOST_ROOT}")
-endif ()
-
 if (LINKSTATIC)
     set (Boost_USE_STATIC_LIBS   ON)
 endif ()
@@ -105,15 +101,10 @@ else ()
                   COMPONENTS ${Boost_COMPONENTS})
 endif ()
 
-# On Linux, Boost 1.55 and higher seems to need to link against -lrt
-if (CMAKE_SYSTEM_NAME MATCHES "Linux" AND ${Boost_VERSION} GREATER 105499)
-    list (APPEND Boost_LIBRARIES "rt")
-endif ()
-
+message (STATUS "Boost version ${Boost_VERSION}")
 if (NOT Boost_FIND_QUIETLY)
-    message (STATUS "BOOST_ROOT ${BOOST_ROOT}")
-    message (STATUS "Boost found ${Boost_FOUND} ")
-    message (STATUS "Boost version      ${Boost_VERSION}")
+    message (STATUS "Boost found        ${Boost_FOUND} ")
+    message (STATUS "BOOST_ROOT         ${BOOST_ROOT}")
     message (STATUS "Boost include dirs ${Boost_INCLUDE_DIRS}")
     message (STATUS "Boost library dirs ${Boost_LIBRARY_DIRS}")
     message (STATUS "Boost libraries    ${Boost_LIBRARIES}")


### PR DESCRIPTION
Non-SPI people can ignore this.

The motivation was to let us switch between several Boost versions,
including a new layout for our local boost install. But I took the
time to do a bunch of cleanup on the spi Makefile-bits, mostly just
regrouping so all the compiler stuff is together, all the python stuff
is together, all the spcomp2 stuff is together.

