### PR TITLE
Asan-revealed bug touched beyond the bound of allocation

### DIFF
--- a/src/hdr.imageio/rgbe.cpp
+++ b/src/hdr.imageio/rgbe.cpp
@@ -317,10 +317,10 @@ static int RGBE_WriteBytes_RLE(FILE *fp, unsigned char *data, int numbytes,
       beg_run += run_count;
       old_run_count = run_count;
       run_count = 1;
-      while((data[beg_run] == data[beg_run + run_count]) 
-	    && (beg_run + run_count < numbytes) && (run_count < 127))
-	run_count++;
-    }
+      while((beg_run + run_count < numbytes) && (run_count < 127)
+            && (data[beg_run] == data[beg_run + run_count]))
+          run_count++;
+      }
     /* if data before next big run is a short run then write it as such */
     if ((old_run_count > 1)&&(old_run_count == beg_run - cur)) {
       buf[0] = 128 + old_run_count;   /*write short run*/


### PR DESCRIPTION
Switching the relative order of the is-it-past-the-end test with the whats-the-value test fixes it.