### PR TITLE
Turn off openjpeg < 2.0 when EMBEDPLUGINS=0 -- buggy

### DIFF
--- a/src/jpeg2000.imageio/CMakeLists.txt
+++ b/src/jpeg2000.imageio/CMakeLists.txt
@@ -1,10 +1,18 @@
 if (USE_OPENJPEG AND OPENJPEG_FOUND)
     if (${OPENJPEG_VERSION} VERSION_LESS 2.0)
         # Old OpenJpeg 1.5. Remove this eventually.
-        add_oiio_plugin (jpeg2000input-v1.cpp jpeg2000output-v1.cpp
-                         INCLUDE_DIRS ${OPENJPEG_INCLUDE_DIR}
-                         LINK_LIBRARIES ${OPENJPEG_LIBRARIES}
-                         DEFINITIONS "-DUSE_OPENJPEG")
+        #
+        # For reasons I don't understand, OpenJPEG 1.5 fails imageinout_test
+        # when we build in EMBEDPLUGINS=0 mode (works fine for
+        # EMBEDPLUGINS=1). I don't care to do the work to figure out why,
+        # for a rarely used build mode and an obsolete library version. So
+        # for now, I'm just disabling jpeg2000 support for that combination.
+        if (EMBEDPLUGINS)
+            add_oiio_plugin (jpeg2000input-v1.cpp jpeg2000output-v1.cpp
+                             INCLUDE_DIRS ${OPENJPEG_INCLUDE_DIR}
+                             LINK_LIBRARIES ${OPENJPEG_LIBRARIES}
+                             DEFINITIONS "-DUSE_OPENJPEG")
+        endif()
     else ()
         # OpenJpeg 2.x. Eventually this should be the only one we need.
         add_oiio_plugin (jpeg2000input.cpp jpeg2000output.cpp


### PR DESCRIPTION
Some new unit tests show crashes inside libopenjpeg, but only for
libjpeg<2.0 and only when we build with EMBEDPLUGINS=0 (apparently
it's fine when =1, which is the default, I don't know why).

I have no particular desire to try to track this down, especially
since it requires the combination of an obsolete version of libjpeg,
and a build mode that probably very few people use. So I'm taking the
easy way out: just disable jpeg2000 suppor for this unusual
combination.  If you need EMBEDPLUGINS=0 and care about openjpeg,
upgrade to 2.0.

