### PR TITLE
TS: Fix possible nullptr dereference

### DIFF
--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -943,6 +943,8 @@ public:
     get_image_handle(ustring filename,
                      ImageCachePerThreadInfo* thread_info = NULL)
     {
+        if (!thread_info)
+            thread_info = get_perthread_info();
         ImageCacheFile* file = find_file(filename, thread_info);
         return verify_file(file, thread_info);
     }


### PR DESCRIPTION
find_file() assumes a non-null thread_info parameter.  But it's called
from get_image_handle in a way that could pass a null pointer. Fix.

Fixes #2179

