### PR TITLE
Systematically test output formats for writing unwriteable file

### DIFF
--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -80,7 +80,7 @@ BmpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
 
     m_fd = Filesystem::fopen(m_filename, "wb");
     if (!m_fd) {
-        error("Unable to open file \"%s\"", m_filename.c_str());
+        errorf("Could not open \"%s\"", m_filename);
         return false;
     }
 

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -218,7 +218,7 @@ DPXOutput::open(const std::string& name, const ImageSpec& userspec,
         close();  // Close any already-opened file
     m_stream = new OutStream();
     if (!m_stream->Open(name.c_str())) {
-        error("Could not open file \"%s\"", name.c_str());
+        errorf("Could not open \"%s\"", name);
         delete m_stream;
         m_stream = nullptr;
         return false;

--- a/src/fits.imageio/fitsoutput.cpp
+++ b/src/fits.imageio/fitsoutput.cpp
@@ -86,7 +86,7 @@ FitsOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
     // checking if the file exists and can be opened in WRITE mode
     m_fd = Filesystem::fopen(m_filename, mode == AppendSubimage ? "r+b" : "wb");
     if (!m_fd) {
-        errorf("Unable to open file \"%s\"", m_filename);
+        errorf("Could not open \"%s\"", m_filename);
         return false;
     }
 

--- a/src/gif.imageio/gifoutput.cpp
+++ b/src/gif.imageio/gifoutput.cpp
@@ -193,7 +193,7 @@ GIFOutput::start_subimage()
                            m_spec.height, m_delay, 8 /*bit depth*/,
                            true /*dither*/);
         if (!ok) {
-            error("Could not open file %s", m_filename);
+            errorf("Could not open \"%s\"", m_filename);
             return false;
         }
     }

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -117,7 +117,7 @@ HdrOutput::open(const std::string& name, const ImageSpec& newspec,
 
     m_fd = Filesystem::fopen(name, "wb");
     if (m_fd == NULL) {
-        error("Unable to open file");
+        errorf("Could not open \"%s\"", name);
         return false;
     }
 

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -229,7 +229,7 @@ ICOOutput::open(const std::string& name, const ImageSpec& userspec,
 
     m_file = Filesystem::fopen(name, mode == AppendSubimage ? "r+b" : "wb");
     if (!m_file) {
-        error("Could not open file \"%s\"", name.c_str());
+        errorf("Could not open \"%s\"", name);
         return false;
     }
 

--- a/src/iff.imageio/iffoutput.cpp
+++ b/src/iff.imageio/iffoutput.cpp
@@ -100,7 +100,7 @@ IffOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
 
     m_fd = Filesystem::fopen(m_filename, "wb");
     if (!m_fd) {
-        error("Unable to open file \"%s\"", m_filename.c_str());
+        errorf("Could not open \"%s\"", m_filename);
         return false;
     }
 

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -151,7 +151,7 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
 
     m_fd = Filesystem::fopen(name, "wb");
     if (m_fd == NULL) {
-        error("Unable to open file \"%s\"", name.c_str());
+        errorf("Could not open \"%s\"", name);
         return false;
     }
 

--- a/src/jpeg2000.imageio/jpeg2000output-v1.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output-v1.cpp
@@ -157,7 +157,7 @@ Jpeg2000Output::open(const std::string& name, const ImageSpec& spec,
 
     m_file = Filesystem::fopen(m_filename, "wb");
     if (m_file == NULL) {
-        error("Unable to open file \"%s\"", m_filename.c_str());
+        errorf("Could not open \"%s\"", m_filename);
         return false;
     }
 

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -191,7 +191,7 @@ Jpeg2000Output::open(const std::string& name, const ImageSpec& spec,
 
     m_file = Filesystem::fopen(m_filename, "wb");
     if (m_file == NULL) {
-        error("Unable to open file \"%s\"", m_filename.c_str());
+        errorf("Could not open \"%s\"", m_filename);
         return false;
     }
 

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -367,12 +367,12 @@ OpenEXROutput::open(const std::string& name, const ImageSpec& userspec,
                                         m_headers[m_subimage]));
             }
         } catch (const std::exception& e) {
-            error("OpenEXR exception: %s", e.what());
+            errorf("Could not open \"%s\" (%s)", name, e.what());
             m_output_scanline = NULL;
             m_output_tiled    = NULL;
             return false;
         } catch (...) {  // catch-all for edge cases or compiler bugs
-            error("OpenEXR exception: unknown");
+            errorf("Could not open \"%s\" (unknown exception)", name);
             m_output_scanline = NULL;
             m_output_tiled    = NULL;
             return false;

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -169,7 +169,7 @@ PNGOutput::open(const std::string& name, const ImageSpec& userspec,
         m_local_io.reset(m_io);
     }
     if (!m_io || m_io->mode() != Filesystem::IOProxy::Mode::Write) {
-        errorf("Could not open file \"%s\"", name);
+        errorf("Could not open \"%s\"", name);
         return false;
     }
 

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -189,8 +189,10 @@ PNMOutput::open(const std::string& name, const ImageSpec& userspec,
         Filesystem::open(m_file, name, std::ios::out | std::ios::binary);
     }
 
-    if (!m_file)
+    if (!m_file) {
+        errorf("Could not open \"%s\"", name);
         return false;
+    }
 
     m_max_val = (1 << bits_per_sample) - 1;
     // Write header

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -189,7 +189,7 @@ RLAOutput::open(const std::string& name, const ImageSpec& userspec,
 
     m_file = Filesystem::fopen(name, "wb");
     if (!m_file) {
-        error("Could not open file \"%s\"", name.c_str());
+        errorf("Could not open \"%s\"", name);
         return false;
     }
 

--- a/src/sgi.imageio/sgioutput.cpp
+++ b/src/sgi.imageio/sgioutput.cpp
@@ -69,7 +69,7 @@ SgiOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
 
     m_fd = Filesystem::fopen(m_filename, "wb");
     if (!m_fd) {
-        error("Unable to open file \"%s\"", m_filename.c_str());
+        errorf("Could not open \"%s\"", name);
         return false;
     }
 

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -200,7 +200,7 @@ TGAOutput::open(const std::string& name, const ImageSpec& userspec,
 
     m_file = Filesystem::fopen(name, "wb");
     if (!m_file) {
-        error("Could not open file \"%s\"", name.c_str());
+        errorf("Could not open \"%s\"", name);
         return false;
     }
 

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -442,7 +442,7 @@ tiff_input_imageio_create()
 // OIIO_EXPORT int tiff_imageio_version = OIIO_PLUGIN_VERSION; // it's in tiffoutput.cpp
 
 OIIO_EXPORT const char* tiff_input_extensions[]
-    = { "tiff", "tif", "tx", "env", "sm", "vsm", nullptr };
+    = { "tif", "tiff", "tx", "env", "sm", "vsm", nullptr };
 
 OIIO_PLUGIN_EXPORTS_END
 

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -380,7 +380,7 @@ TIFFOutput::open(const std::string& name, const ImageSpec& userspec,
     m_tif = TIFFOpen(name.c_str(), mode == AppendSubimage ? "a" : "w");
 #endif
     if (!m_tif) {
-        error("Can't open \"%s\" for output.", name.c_str());
+        errorf("Could not open \"%s\"", name);
         return false;
     }
 

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -118,7 +118,7 @@ WebpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
 
     m_file = Filesystem::fopen(m_filename, "wb");
     if (!m_file) {
-        error("Unable to open file \"%s\"", m_filename.c_str());
+        errorf("Could not open \"%s\"", m_filename);
         return false;
     }
 

--- a/src/zfile.imageio/zfile.cpp
+++ b/src/zfile.imageio/zfile.cpp
@@ -192,7 +192,7 @@ ZfileInput::open(const std::string& name, ImageSpec& newspec)
     m_filename = name;
     m_gz       = open_gz(name, "rb");
     if (!m_gz) {
-        error("Could not open file \"%s\"", name);
+        errorf("Could not open \"%s\"", name);
         return false;
     }
 
@@ -334,7 +334,7 @@ ZfileOutput::open(const std::string& name, const ImageSpec& userspec,
         m_file = Filesystem::fopen(name, "wb");
     }
     if (!m_file && !m_gz) {
-        error("Could not open file \"%s\"", name);
+        errorf("Could not open \"%s\"", name);
         return false;
     }
 


### PR DESCRIPTION
Augment imageinout_test to try to write each format to a path that
includes a nonexistant directory (to test generally what happens when
asked to write to a place that doesn't exist or doesn't have write
permissions).

Also a bunch of other refacoring of imageinout_test.

This turned up failures in several format writers:
* DPX crashed (solved with PR 2186)
* HEIF silently failed, not returning any errors for this condition
  (solved with PR 2188)
* PNG silently failed (solved with PR 2187)
* JPG silently failed and sometimes crashed (solved with PR 2187)

Also this made me notice that the error messages for open failures
were not uniform across the various file formats, so I picked one
phrasing I liked best and made the others conform.

(Note: to make this test succeed and for reviewers to see the bugs identified and fixed as a result of this new test, I have combined PR's 2186, 2187, 2188 into this branch. But I'm going to merge them separately, so by the time this one is merged, it will only be the test and message changes, not the bug fixes to individual writers.)
