### PR TITLE
exr read: suppress empty string submage name

### DIFF
--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -816,7 +816,7 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
     }
 
     // EXR "name" also gets passed along as "oiio:subimagename".
-    if (header->hasName())
+    if (header->hasName() && header->name() != "")
         spec.attribute("oiio:subimagename", header->name());
 
     // Squash some problematic texture metadata if we suspect it's wrong


### PR DESCRIPTION
It's been reported that V-Ray writes images with this metadata field
present but empty. If you happen to take those images (and their
metadata) and turn them into a multi-part exr, the names all being the
same is problematic. The expedient fix is just to ignore empty names
on input.  Suggested by Chris Allen.

