### PR TITLE
Timer dtr print, change from stream I/O to Strutil::printf

### DIFF
--- a/src/include/OpenImageIO/timer.h
+++ b/src/include/OpenImageIO/timer.h
@@ -120,8 +120,8 @@ public:
     ~Timer()
     {
         if (m_printdtr == PrintDtr)
-            std::cout << "Timer " << (m_name ? m_name : "") << ": "
-                      << seconds(ticks()) << "s\n";
+            Strutil::printf("Timer %s: %gs\n", (m_name ? m_name : ""),
+                            seconds(ticks()));
     }
 
     /// Start (or restart) ticking, if we are not currently.


### PR DESCRIPTION
Strutil::printf does its underlying output atomically, so if these
destructors are triggered from multiple threads, they won't get
"interleaved" on the terminal, making them unreadable, as they would be
with ordinary stream output.

