### PR TITLE
Rename pow2roundup/pow2rounddown -> ceil2, floor2

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -136,8 +136,8 @@ using std::isnan;
 /// Quick test for whether an integer is a power of 2.
 ///
 template<typename T>
-inline OIIO_HOSTDEVICE bool
-ispow2(T x)
+inline OIIO_HOSTDEVICE OIIO_CONSTEXPR14 bool
+ispow2(T x) noexcept
 {
     // Numerous references for this bit trick are on the web.  The
     // principle is that x is a power of 2 <=> x == 1<<b <=> x-1 is
@@ -149,8 +149,8 @@ ispow2(T x)
 
 /// Round up to next higher power of 2 (return x if it's already a power
 /// of 2).
-inline OIIO_HOSTDEVICE int
-pow2roundup(int x)
+inline OIIO_HOSTDEVICE OIIO_CONSTEXPR14 int
+ceil2(int x) noexcept
 {
     // Here's a version with no loops.
     if (x < 0)
@@ -172,8 +172,8 @@ pow2roundup(int x)
 
 /// Round down to next lower power of 2 (return x if it's already a power
 /// of 2).
-inline OIIO_HOSTDEVICE int
-pow2rounddown(int x)
+inline OIIO_HOSTDEVICE OIIO_CONSTEXPR14 int
+floor2(int x) noexcept
 {
     // Make all bits past the first 1 also be 1, i.e. 0001xxxx -> 00011111
     x |= x >> 1;
@@ -185,6 +185,11 @@ pow2rounddown(int x)
     // That's the power of two <= the original x
     return x & ~(x >> 1);
 }
+
+
+// Old names -- DEPRECATED(2.1)
+inline OIIO_HOSTDEVICE int pow2roundup(int x) { return ceil2(x); }
+inline OIIO_HOSTDEVICE int pow2rounddown(int x) { return floor2(x); }
 
 
 

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -1837,7 +1837,7 @@ ImageViewer::zoomIn()
     if (zoom() >= 64)
         return;
     float oldzoom = zoom();
-    float newzoom = pow2roundupf(oldzoom);
+    float newzoom = ceil2f(oldzoom);
 
     float xc, yc;  // Center view position
     glwin->get_center(xc, yc);
@@ -1872,7 +1872,7 @@ ImageViewer::zoomOut()
     if (zoom() <= 1.0f / 64)
         return;
     float oldzoom = zoom();
-    float newzoom = pow2rounddownf(oldzoom);
+    float newzoom = floor2f(oldzoom);
 
     float xcpel, ycpel;  // Center view position
     glwin->get_center(xcpel, ycpel);

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -997,8 +997,8 @@ IvGL::update()
     GLenum glinternalformat = GL_RGB;
     typespec_to_opengl(spec, nchannels, gltype, glformat, glinternalformat);
 
-    m_texture_width  = clamp(pow2roundup(spec.width), 1, m_max_texture_size);
-    m_texture_height = clamp(pow2roundup(spec.height), 1, m_max_texture_size);
+    m_texture_width  = clamp(ceil2(spec.width), 1, m_max_texture_size);
+    m_texture_height = clamp(ceil2(spec.height), 1, m_max_texture_size);
 
     glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
 
@@ -1230,8 +1230,8 @@ IvGL::wheelEvent(QWheelEvent* event)
     if (event->orientation() == Qt::Vertical) {
         // TODO: Update this to keep the zoom centered on the event .x, .y
         float oldzoom = m_viewer.zoom();
-        float newzoom = (event->delta() > 0) ? pow2roundupf(oldzoom)
-                                             : pow2rounddownf(oldzoom);
+        float newzoom = (event->delta() > 0) ? ceil2f(oldzoom)
+                                             : floor2f(oldzoom);
         m_viewer.zoom(newzoom);
         event->accept();
     }

--- a/src/iv/ivutils.h
+++ b/src/iv/ivutils.h
@@ -10,7 +10,7 @@ OIIO_NAMESPACE_BEGIN
 /// representation.  Once optimized and tested, move to fmath.h
 
 inline float
-pow2roundupf(float f)
+ceil2f(float f)
 {
     float logval = logf(f) / logf(2.0f);
     logval += 1e-6f;  // add floating point slop. this supports [0.00012207,8192]
@@ -22,7 +22,7 @@ pow2roundupf(float f)
 /// representation.  Once optimized and tested, move to fmath.h
 
 inline float
-pow2rounddownf(float f)
+floor2f(float f)
 {
     float logval = logf(f) / logf(2.0f);
     logval -= 1e-6f;  // add floating point slop. this supports [0.00012207,8192]

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1546,8 +1546,8 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
 
     // Handle resize to power of two, if called for
     if (configspec.get_int_attribute("maketx:resize") && !shadowmode) {
-        dstspec.width       = pow2roundup(dstspec.width);
-        dstspec.height      = pow2roundup(dstspec.height);
+        dstspec.width       = ceil2(dstspec.width);
+        dstspec.height      = ceil2(dstspec.height);
         dstspec.full_width  = dstspec.width;
         dstspec.full_height = dstspec.height;
     }

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -2124,7 +2124,7 @@ ImageCacheImpl::attribute(string_view name, TypeDesc type, const void* val)
     } else if (name == "max_errors_per_file" && type == TypeDesc::INT) {
         m_max_errors_per_file = *(const int*)val;
     } else if (name == "autotile" && type == TypeDesc::INT) {
-        int a = pow2roundup(*(const int*)val);  // guarantee pow2
+        int a = ceil2(*(const int*)val);  // guarantee pow2
         // Clamp to minimum 8x8 tiles to protect against stupid user who
         // think this is a boolean rather than the tile size.  Unless
         // we're in DEBUG mode, then allow developers to play with fire.

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -106,19 +106,19 @@ test_int_helpers()
     }
     OIIO_CHECK_ASSERT(ispow2((unsigned int)0));
 
-    // pow2roundup
-    OIIO_CHECK_EQUAL(pow2roundup(4), 4);
-    OIIO_CHECK_EQUAL(pow2roundup(5), 8);
-    OIIO_CHECK_EQUAL(pow2roundup(6), 8);
-    OIIO_CHECK_EQUAL(pow2roundup(7), 8);
-    OIIO_CHECK_EQUAL(pow2roundup(8), 8);
+    // ceil2
+    OIIO_CHECK_EQUAL(ceil2(4), 4);
+    OIIO_CHECK_EQUAL(ceil2(5), 8);
+    OIIO_CHECK_EQUAL(ceil2(6), 8);
+    OIIO_CHECK_EQUAL(ceil2(7), 8);
+    OIIO_CHECK_EQUAL(ceil2(8), 8);
 
-    // pow2rounddown
-    OIIO_CHECK_EQUAL(pow2rounddown(4), 4);
-    OIIO_CHECK_EQUAL(pow2rounddown(5), 4);
-    OIIO_CHECK_EQUAL(pow2rounddown(6), 4);
-    OIIO_CHECK_EQUAL(pow2rounddown(7), 4);
-    OIIO_CHECK_EQUAL(pow2rounddown(8), 8);
+    // floor2
+    OIIO_CHECK_EQUAL(floor2(4), 4);
+    OIIO_CHECK_EQUAL(floor2(5), 4);
+    OIIO_CHECK_EQUAL(floor2(6), 4);
+    OIIO_CHECK_EQUAL(floor2(7), 4);
+    OIIO_CHECK_EQUAL(floor2(8), 8);
 
     // round_to_multiple
     OIIO_CHECK_EQUAL(round_to_multiple(0, 5), 0);


### PR DESCRIPTION
This is in keeping with the nomenclature of the C++20 `<bit>` header which
contains the equivalent functions.

Also give them the constexpr and noexcept treatment.

