### PR TITLE
Adjustments from clang-format update

### DIFF
--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -78,7 +78,7 @@ ifeq (${SP_OS}, rhel7)
     #
     # A variety of tags can be used to try specific versions of gcc or
     # clang from the site-specific places we have installed them.
-    LLVM_DIRECTORY ?= /shots/spi/home/lib/arnold/rhel7/llvm_7.0.1
+    LLVM_DIRECTORY ?= /shots/spi/home/lib/arnold/rhel7/llvm_8.0.0
     ifeq (${COMPILER},clang6)
 	    LLVM_DIRECTORY := /shots/spi/home/lib/arnold/rhel7/llvm_6.0.1
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
@@ -86,7 +86,11 @@ ifeq (${SP_OS}, rhel7)
     else ifeq (${COMPILER},clang7)
         LLVM_DIRECTORY := /shots/spi/home/lib/arnold/rhel7/llvm_7.0.1
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
-	MY_CMAKE_FLAGS += -DCMAKE_C_FLAGS="--gcc-toolchain=/usr" -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr"
+        MY_CMAKE_FLAGS += -DCMAKE_C_FLAGS="--gcc-toolchain=/usr" -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr"
+    else ifeq (${COMPILER},clang7)
+        LLVM_DIRECTORY := /shots/spi/home/lib/arnold/rhel7/llvm_8.0.0
+        MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
+        MY_CMAKE_FLAGS += -DCMAKE_C_FLAGS="--gcc-toolchain=/usr" -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr"
     else ifeq (${COMPILER},clang)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
         MY_CMAKE_FLAGS += -DCMAKE_C_FLAGS="--gcc-toolchain=/usr" -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr"
@@ -231,7 +235,9 @@ else ifeq (${platform}, macosx)
     else ifeq (${COMPILER},clang6)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=/usr/local/Cellar/llvm@6/6.0.1_1/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/Cellar/llvm@6/6.0.1_1/bin/clang++
     else ifeq (${COMPILER},clang7)
-        MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=/usr/local/Cellar/llvm/7.0.1/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/Cellar/llvm/7.0.1/bin/clang++
+        MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=/usr/local/Cellar/llvm@7/7.0.1/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/Cellar/llvm@7/7.0.1/bin/clang++
+    else ifeq (${COMPILER},clang8)
+        MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=/usr/local/Cellar/llvm/8.0.0/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/Cellar/llvm/8.0.0/bin/clang++
     else ifeq (${COMPILER},clang)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
     else ifeq (${COMPILER},gcc)

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -68,5 +68,5 @@ brew list --versions
 export PATH=/usr/local/opt/qt5/bin:$PATH ;
 export PATH=/usr/local/opt/python/libexec/bin:$PATH ;
 export PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages:$PYTHONPATH ;
-export PATH=/usr/local/Cellar/llvm/7.0.1/bin:$PATH ;
+export PATH=/usr/local/Cellar/llvm/8.0.0/bin:$PATH ;
 

--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -467,8 +467,8 @@ print_info_subimage(int current_subimage, int max_subimages, ImageSpec& spec,
 
     if (!metamatch.empty()
         && !regex_search(
-               "resolution, width, height, depth, channels, sha-1, stats",
-               field_re)) {
+            "resolution, width, height, depth, channels, sha-1, stats",
+            field_re)) {
         // nothing to do here
         return;
     }

--- a/src/libutil/benchmark.cpp
+++ b/src/libutil/benchmark.cpp
@@ -251,8 +251,9 @@ OIIO_API void
 timed_thread_wedge(function_view<void(int)> task, int maxthreads,
                    int total_iterations, int ntrials, cspan<int> threadcounts)
 {
-    timed_thread_wedge(task, []() {}, []() {}, &std::cout, maxthreads,
-                       total_iterations, ntrials, threadcounts);
+    timed_thread_wedge(
+        task, []() {}, []() {}, &std::cout, maxthreads, total_iterations,
+        ntrials, threadcounts);
 }
 
 OIIO_NAMESPACE_END

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -180,8 +180,9 @@ test_math_functions()
     OIIO_CHECK_EQUAL(ival, 1);
     OIIO_CHECK_EQUAL_APPROX(floorfrac(1.001f, &ival), 0.001f);
     OIIO_CHECK_EQUAL(ival, 1);
-    bench("floorfrac",
-          [&](float x) { return DoNotOptimize(floorfrac(x, &ival)); }, fval);
+    bench(
+        "floorfrac",
+        [&](float x) { return DoNotOptimize(floorfrac(x, &ival)); }, fval);
 
     OIIO_CHECK_EQUAL(sign(3.1f), 1.0f);
     OIIO_CHECK_EQUAL(sign(-3.1f), -1.0f);

--- a/src/python/py_deepdata.cpp
+++ b/src/python/py_deepdata.cpp
@@ -117,17 +117,17 @@ declare_deepdata(py::module& m)
         .def("initialized", &DeepData::initialized)
         .def("allocated", &DeepData::allocated)
 
-        .def("samples",
-             [](const DeepData& dd, int pixel) {
-                 return (int)dd.samples(pixel);
-             },
-             "pixel"_a)
+        .def(
+            "samples",
+            [](const DeepData& dd, int pixel) { return (int)dd.samples(pixel); },
+            "pixel"_a)
         .def("set_samples", &DeepData::set_samples, "pixel"_a, "nsamples"_a)
-        .def("capacity",
-             [](const DeepData& dd, int pixel) {
-                 return (int)dd.capacity(pixel);
-             },
-             "pixel"_a)
+        .def(
+            "capacity",
+            [](const DeepData& dd, int pixel) {
+                return (int)dd.capacity(pixel);
+            },
+            "pixel"_a)
         .def("set_capacity", &DeepData::set_capacity, "pixel"_a, "nsamples"_a)
         .def("insert_samples", &DeepData::insert_samples, "pixel"_a,
              "samplepos"_a, "nsamples"_a = 1)

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -211,70 +211,79 @@ declare_imagebuf(py::module& m)
         .def(py::init<const std::string&, int, int>())
         .def(py::init<const ImageSpec&>())
         .def("clear", &ImageBuf::clear)
-        .def("reset",
-             [](ImageBuf& self, const std::string& name, int subimage,
-                int miplevel) { self.reset(name, subimage, miplevel); },
-             "name"_a, "subimage"_a = 0, "miplevel"_a = 0)
-        .def("reset",
-             [](ImageBuf& self, const std::string& name, int subimage,
-                int miplevel, const ImageSpec& config) {
-                 self.reset(name, subimage, miplevel, nullptr, &config);
-             },
-             "name"_a, "subimage"_a = 0, "miplevel"_a = 0,
-             "config"_a = ImageSpec())
-        .def("reset",
-             [](ImageBuf& self, const ImageSpec& spec) { self.reset(spec); },
-             "spec"_a)
+        .def(
+            "reset",
+            [](ImageBuf& self, const std::string& name, int subimage,
+               int miplevel) { self.reset(name, subimage, miplevel); },
+            "name"_a, "subimage"_a = 0, "miplevel"_a = 0)
+        .def(
+            "reset",
+            [](ImageBuf& self, const std::string& name, int subimage,
+               int miplevel, const ImageSpec& config) {
+                self.reset(name, subimage, miplevel, nullptr, &config);
+            },
+            "name"_a, "subimage"_a = 0, "miplevel"_a = 0,
+            "config"_a = ImageSpec())
+        .def(
+            "reset",
+            [](ImageBuf& self, const ImageSpec& spec) { self.reset(spec); },
+            "spec"_a)
         .def_property_readonly("initialized",
                                [](const ImageBuf& self) {
                                    return self.initialized();
                                })
-        .def("init_spec",
-             [](ImageBuf& self, std::string filename, int subimage,
-                int miplevel) {
-                 py::gil_scoped_release gil;
-                 self.init_spec(filename, subimage, miplevel);
-             },
-             "filename"_a, "subimage"_a = 0, "miplevel"_a = 0)
-        .def("read",
-             [](ImageBuf& self, int subimage, int miplevel, int chbegin,
-                int chend, bool force, TypeDesc convert) {
-                 py::gil_scoped_release gil;
-                 return self.read(subimage, miplevel, chbegin, chend, force,
-                                  convert);
-             },
-             "subimage"_a, "miplevel"_a, "chbegin"_a, "chend"_a, "force"_a,
-             "convert"_a)
-        .def("read",
-             [](ImageBuf& self, int subimage, int miplevel, bool force,
-                TypeDesc convert) {
-                 py::gil_scoped_release gil;
-                 return self.read(subimage, miplevel, force, convert);
-             },
-             "subimage"_a = 0, "miplevel"_a = 0, "force"_a = false,
-             "convert"_a = TypeUnknown)
+        .def(
+            "init_spec",
+            [](ImageBuf& self, std::string filename, int subimage,
+               int miplevel) {
+                py::gil_scoped_release gil;
+                self.init_spec(filename, subimage, miplevel);
+            },
+            "filename"_a, "subimage"_a = 0, "miplevel"_a = 0)
+        .def(
+            "read",
+            [](ImageBuf& self, int subimage, int miplevel, int chbegin,
+               int chend, bool force, TypeDesc convert) {
+                py::gil_scoped_release gil;
+                return self.read(subimage, miplevel, chbegin, chend, force,
+                                 convert);
+            },
+            "subimage"_a, "miplevel"_a, "chbegin"_a, "chend"_a, "force"_a,
+            "convert"_a)
+        .def(
+            "read",
+            [](ImageBuf& self, int subimage, int miplevel, bool force,
+               TypeDesc convert) {
+                py::gil_scoped_release gil;
+                return self.read(subimage, miplevel, force, convert);
+            },
+            "subimage"_a = 0, "miplevel"_a = 0, "force"_a = false,
+            "convert"_a = TypeUnknown)
 
-        .def("write",
-             [](ImageBuf& self, const std::string& filename, TypeDesc dtype,
-                const std::string& fileformat) {
-                 py::gil_scoped_release gil;
-                 return self.write(filename, dtype, fileformat);
-             },
-             "filename"_a, "dtype"_a = TypeUnknown, "fileformat"_a = "")
+        .def(
+            "write",
+            [](ImageBuf& self, const std::string& filename, TypeDesc dtype,
+               const std::string& fileformat) {
+                py::gil_scoped_release gil;
+                return self.write(filename, dtype, fileformat);
+            },
+            "filename"_a, "dtype"_a = TypeUnknown, "fileformat"_a = "")
         // deprecated version:
-        .def("write",
-             [](ImageBuf& self, const std::string& filename,
-                const std::string& fileformat) {
-                 py::gil_scoped_release gil;
-                 return self.write(filename, fileformat);
-             },
-             "filename"_a, "fileformat"_a)
-        .def("make_writeable",
-             [](ImageBuf& self, bool keep_cache_type) {
-                 py::gil_scoped_release gil;
-                 return self.make_writeable(keep_cache_type);
-             },
-             "keep_cache_type"_a = false)
+        .def(
+            "write",
+            [](ImageBuf& self, const std::string& filename,
+               const std::string& fileformat) {
+                py::gil_scoped_release gil;
+                return self.write(filename, fileformat);
+            },
+            "filename"_a, "fileformat"_a)
+        .def(
+            "make_writeable",
+            [](ImageBuf& self, bool keep_cache_type) {
+                py::gil_scoped_release gil;
+                return self.make_writeable(keep_cache_type);
+            },
+            "keep_cache_type"_a = false)
         .def("set_write_format", &ImageBuf::set_write_format)
         // FIXME -- write(ImageOut&)
         .def("set_write_tiles", &ImageBuf::set_write_tiles, "width"_a = 0,
@@ -336,18 +345,20 @@ declare_imagebuf(py::module& m)
              "check_range"_a = false)
         .def("copy_metadata", &ImageBuf::copy_metadata)
         .def("copy_pixels", &ImageBuf::copy_pixels)
-        .def("copy",
-             [](ImageBuf& self, const ImageBuf& src, TypeDesc format) {
-                 py::gil_scoped_release gil;
-                 return self.copy(src, format);
-             },
-             "src"_a, "format"_a = TypeUnknown)
-        .def("copy",
-             [](const ImageBuf& src, TypeDesc format) {
-                 py::gil_scoped_release gil;
-                 return src.copy(format);
-             },
-             "format"_a = TypeUnknown)
+        .def(
+            "copy",
+            [](ImageBuf& self, const ImageBuf& src, TypeDesc format) {
+                py::gil_scoped_release gil;
+                return self.copy(src, format);
+            },
+            "src"_a, "format"_a = TypeUnknown)
+        .def(
+            "copy",
+            [](const ImageBuf& src, TypeDesc format) {
+                py::gil_scoped_release gil;
+                return src.copy(format);
+            },
+            "format"_a = TypeUnknown)
         .def("swap", &ImageBuf::swap)
         .def("getchannel", &ImageBuf::getchannel, "x"_a, "y"_a, "z"_a, "c"_a,
              "wrap"_a = "black")
@@ -387,8 +398,9 @@ declare_imagebuf(py::module& m)
              "channel"_a, "sample"_a, "value"_a = 0.0f)
         .def("set_deep_value_uint", &ImageBuf_set_deep_value_uint, "x"_a, "y"_a,
              "z"_a, "channel"_a, "sample"_a, "value"_a = 0)
-        .def("deepdata", [](ImageBuf& self) { return *self.deepdata(); },
-             py::return_value_policy::reference_internal)
+        .def(
+            "deepdata", [](ImageBuf& self) { return *self.deepdata(); },
+            py::return_value_policy::reference_internal)
 
         // FIXME -- do we want to provide pixel iterators?
         ;

--- a/src/python/py_imagecache.cpp
+++ b/src/python/py_imagecache.cpp
@@ -125,12 +125,13 @@ declare_imagecache(py::module& m)
                  if (ic.m_cache)
                      attribute_typed(*ic.m_cache, name, type, obj);
              })
-        .def("getattribute",
-             [](const ImageCacheWrap& ic, const std::string& name,
-                TypeDesc type) {
-                 return getattribute_typed(*ic.m_cache, name, type);
-             },
-             "name"_a, "type"_a = TypeUnknown)
+        .def(
+            "getattribute",
+            [](const ImageCacheWrap& ic, const std::string& name,
+               TypeDesc type) {
+                return getattribute_typed(*ic.m_cache, name, type);
+            },
+            "name"_a, "type"_a = TypeUnknown)
         .def("resolve_filename",
              [](ImageCacheWrap& ic, const std::string& filename) {
                  py::gil_scoped_release gil;
@@ -146,24 +147,27 @@ declare_imagecache(py::module& m)
 
         .def("geterror",
              [](ImageCacheWrap& ic) { return PY_STR(ic.m_cache->geterror()); })
-        .def("getstats",
-             [](ImageCacheWrap& ic, int level) {
-                 py::gil_scoped_release gil;
-                 return PY_STR(ic.m_cache->getstats(level));
-             },
-             "level"_a = 1)
-        .def("invalidate",
-             [](ImageCacheWrap& ic, const std::string& filename, bool force) {
-                 py::gil_scoped_release gil;
-                 ic.m_cache->invalidate(ustring(filename), force);
-             },
-             "filename"_a, "force"_a = true)
-        .def("invalidate_all",
-             [](ImageCacheWrap& ic, bool force) {
-                 py::gil_scoped_release gil;
-                 ic.m_cache->invalidate_all(force);
-             },
-             "force"_a = false);
+        .def(
+            "getstats",
+            [](ImageCacheWrap& ic, int level) {
+                py::gil_scoped_release gil;
+                return PY_STR(ic.m_cache->getstats(level));
+            },
+            "level"_a = 1)
+        .def(
+            "invalidate",
+            [](ImageCacheWrap& ic, const std::string& filename, bool force) {
+                py::gil_scoped_release gil;
+                ic.m_cache->invalidate(ustring(filename), force);
+            },
+            "filename"_a, "force"_a = true)
+        .def(
+            "invalidate_all",
+            [](ImageCacheWrap& ic, bool force) {
+                py::gil_scoped_release gil;
+                ic.m_cache->invalidate_all(force);
+            },
+            "force"_a = false);
 }
 
 }  // namespace PyOpenImageIO

--- a/src/python/py_imageinput.cpp
+++ b/src/python/py_imageinput.cpp
@@ -216,39 +216,44 @@ declare_imageinput(py::module& m)
     using namespace pybind11::literals;
 
     py::class_<ImageInput>(m, "ImageInput")
-        .def_static("create",
-                    [](const std::string& filename,
-                       const std::string& searchpath) -> py::object {
-                        auto in = ImageInput::create(filename, searchpath);
-                        return in ? py::cast(in.release()) : py::none();
-                    },
-                    "filename"_a, "plugin_searchpath"_a = "")
-        .def_static("open",
-                    [](const std::string& filename) -> py::object {
-                        auto in = ImageInput::open(filename);
-                        return in ? py::cast(in.release()) : py::none();
-                    },
-                    "filename"_a)
-        .def_static("open",
-                    [](const std::string& filename,
-                       const ImageSpec& config) -> py::object {
-                        auto in = ImageInput::open(filename, &config);
-                        return in ? py::cast(in.release()) : py::none();
-                    },
-                    "filename"_a, "config"_a)
+        .def_static(
+            "create",
+            [](const std::string& filename,
+               const std::string& searchpath) -> py::object {
+                auto in = ImageInput::create(filename, searchpath);
+                return in ? py::cast(in.release()) : py::none();
+            },
+            "filename"_a, "plugin_searchpath"_a = "")
+        .def_static(
+            "open",
+            [](const std::string& filename) -> py::object {
+                auto in = ImageInput::open(filename);
+                return in ? py::cast(in.release()) : py::none();
+            },
+            "filename"_a)
+        .def_static(
+            "open",
+            [](const std::string& filename,
+               const ImageSpec& config) -> py::object {
+                auto in = ImageInput::open(filename, &config);
+                return in ? py::cast(in.release()) : py::none();
+            },
+            "filename"_a, "config"_a)
         .def("format_name", &ImageInput::format_name)
         .def("valid_file", &ImageInput::valid_file)
         .def("spec", [](ImageInput& self) { return self.spec(); })
-        .def("spec",
-             [](ImageInput& self, int subimage, int miplevel) {
-                 return self.spec(subimage, miplevel);
-             },
-             "subimage"_a, "miplevel"_a = 0)
-        .def("spec_dimensions",
-             [](ImageInput& self, int subimage, int miplevel) {
-                 return self.spec_dimensions(subimage, miplevel);
-             },
-             "subimage"_a, "miplevel"_a = 0)
+        .def(
+            "spec",
+            [](ImageInput& self, int subimage, int miplevel) {
+                return self.spec(subimage, miplevel);
+            },
+            "subimage"_a, "miplevel"_a = 0)
+        .def(
+            "spec_dimensions",
+            [](ImageInput& self, int subimage, int miplevel) {
+                return self.spec_dimensions(subimage, miplevel);
+            },
+            "subimage"_a, "miplevel"_a = 0)
         .def("supports",
              [](const ImageInput& self, const std::string& feature) {
                  return self.supports(feature);
@@ -261,108 +266,117 @@ declare_imageinput(py::module& m)
                  py::gil_scoped_release gil;
                  return self.seek_subimage(subimage, miplevel);
              })
-        .def("read_image",
-             [](ImageInput& self, int subimage, int miplevel, int chbegin,
-                int chend, TypeDesc format) -> py::object {
-                 return ImageInput_read_image(self, subimage, miplevel, chbegin,
-                                              chend, format);
-             },
-             "subimage"_a, "miplevel"_a, "chbegin"_a, "chend"_a,
-             "format"_a = TypeFloat)
-        .def("read_image",
-             [](ImageInput& self, TypeDesc format) -> py::object {
-                 return ImageInput_read_image(self, self.current_subimage(),
-                                              self.current_miplevel(), 0, 10000,
-                                              format);
-             },
-             "format"_a = TypeFloat)
-        .def("read_scanline",
-             [](ImageInput& self, int y, int z, TypeDesc format) -> py::object {
-                 return ImageInput_read_scanlines(self, self.current_subimage(),
-                                                  self.current_miplevel(), y,
-                                                  y + 1, z, 0, 10000, format,
-                                                  2);
-             },
-             "y"_a, "z"_a = 0, "format"_a = TypeFloat)
-        .def("read_scanlines",
-             [](ImageInput& self, int subimage, int miplevel, int ybegin,
-                int yend, int z, int chbegin, int chend,
-                TypeDesc format) -> py::object {
-                 return ImageInput_read_scanlines(self, subimage, miplevel,
-                                                  ybegin, yend, z, chbegin,
-                                                  chend, format, 3);
-             },
-             "subimage"_a, "miplevel"_a, "ybegin"_a, "yend"_a, "z"_a,
-             "chbegin"_a, "chend"_a, "format"_a = TypeFloat)
-        .def("read_scanlines",
-             [](ImageInput& self, int ybegin, int yend, int z, int chbegin,
-                int chend, TypeDesc format) -> py::object {
-                 return ImageInput_read_scanlines(self, self.current_subimage(),
-                                                  self.current_miplevel(),
-                                                  ybegin, yend, z, chbegin,
-                                                  chend, format, 3);
-             },
-             "ybegin"_a, "yend"_a, "z"_a, "chbegin"_a, "chend"_a,
-             "format"_a = TypeFloat)
-        .def("read_tiles",
-             [](ImageInput& self, int subimage, int miplevel, int xbegin,
-                int xend, int ybegin, int yend, int zbegin, int zend,
-                int chbegin, int chend, TypeDesc format) -> py::object {
-                 return ImageInput_read_tiles(self, subimage, miplevel, xbegin,
-                                              xend, ybegin, yend, zbegin, zend,
-                                              chbegin, chend, format);
-             },
-             "subimage"_a, "miplevel"_a, "xbegin"_a, "xend"_a, "ybegin"_a,
-             "yend"_a, "zbegin"_a, "zend"_a, "chbegin"_a, "chend"_a,
-             "format"_a = TypeFloat)
-        .def("read_tiles",
-             [](ImageInput& self, int xbegin, int xend, int ybegin, int yend,
-                int zbegin, int zend, int chbegin, int chend,
-                TypeDesc format) -> py::object {
-                 return ImageInput_read_tiles(self, self.current_subimage(),
-                                              self.current_miplevel(), xbegin,
-                                              xend, ybegin, yend, zbegin, zend,
-                                              chbegin, chend, format);
-             },
-             "xbegin"_a, "xend"_a, "ybegin"_a, "yend"_a, "zbegin"_a, "zend"_a,
-             "chbegin"_a, "chend"_a, "format"_a = TypeFloat)
-        .def("read_tile",
-             [](ImageInput& self, int x, int y, int z,
-                TypeDesc format) -> py::object {
-                 const ImageSpec& spec(self.spec());
-                 return ImageInput_read_tiles(self, self.current_subimage(),
-                                              self.current_miplevel(), x,
-                                              x + spec.tile_width, y,
-                                              y + spec.tile_height, z,
-                                              z + std::max(1, spec.tile_depth),
-                                              0, spec.nchannels, format);
-             },
-             "x"_a, "y"_a, "z"_a, "format"_a = TypeFloat)
+        .def(
+            "read_image",
+            [](ImageInput& self, int subimage, int miplevel, int chbegin,
+               int chend, TypeDesc format) -> py::object {
+                return ImageInput_read_image(self, subimage, miplevel, chbegin,
+                                             chend, format);
+            },
+            "subimage"_a, "miplevel"_a, "chbegin"_a, "chend"_a,
+            "format"_a = TypeFloat)
+        .def(
+            "read_image",
+            [](ImageInput& self, TypeDesc format) -> py::object {
+                return ImageInput_read_image(self, self.current_subimage(),
+                                             self.current_miplevel(), 0, 10000,
+                                             format);
+            },
+            "format"_a = TypeFloat)
+        .def(
+            "read_scanline",
+            [](ImageInput& self, int y, int z, TypeDesc format) -> py::object {
+                return ImageInput_read_scanlines(self, self.current_subimage(),
+                                                 self.current_miplevel(), y,
+                                                 y + 1, z, 0, 10000, format, 2);
+            },
+            "y"_a, "z"_a = 0, "format"_a = TypeFloat)
+        .def(
+            "read_scanlines",
+            [](ImageInput& self, int subimage, int miplevel, int ybegin,
+               int yend, int z, int chbegin, int chend,
+               TypeDesc format) -> py::object {
+                return ImageInput_read_scanlines(self, subimage, miplevel,
+                                                 ybegin, yend, z, chbegin,
+                                                 chend, format, 3);
+            },
+            "subimage"_a, "miplevel"_a, "ybegin"_a, "yend"_a, "z"_a,
+            "chbegin"_a, "chend"_a, "format"_a = TypeFloat)
+        .def(
+            "read_scanlines",
+            [](ImageInput& self, int ybegin, int yend, int z, int chbegin,
+               int chend, TypeDesc format) -> py::object {
+                return ImageInput_read_scanlines(self, self.current_subimage(),
+                                                 self.current_miplevel(),
+                                                 ybegin, yend, z, chbegin,
+                                                 chend, format, 3);
+            },
+            "ybegin"_a, "yend"_a, "z"_a, "chbegin"_a, "chend"_a,
+            "format"_a = TypeFloat)
+        .def(
+            "read_tiles",
+            [](ImageInput& self, int subimage, int miplevel, int xbegin,
+               int xend, int ybegin, int yend, int zbegin, int zend,
+               int chbegin, int chend, TypeDesc format) -> py::object {
+                return ImageInput_read_tiles(self, subimage, miplevel, xbegin,
+                                             xend, ybegin, yend, zbegin, zend,
+                                             chbegin, chend, format);
+            },
+            "subimage"_a, "miplevel"_a, "xbegin"_a, "xend"_a, "ybegin"_a,
+            "yend"_a, "zbegin"_a, "zend"_a, "chbegin"_a, "chend"_a,
+            "format"_a = TypeFloat)
+        .def(
+            "read_tiles",
+            [](ImageInput& self, int xbegin, int xend, int ybegin, int yend,
+               int zbegin, int zend, int chbegin, int chend,
+               TypeDesc format) -> py::object {
+                return ImageInput_read_tiles(self, self.current_subimage(),
+                                             self.current_miplevel(), xbegin,
+                                             xend, ybegin, yend, zbegin, zend,
+                                             chbegin, chend, format);
+            },
+            "xbegin"_a, "xend"_a, "ybegin"_a, "yend"_a, "zbegin"_a, "zend"_a,
+            "chbegin"_a, "chend"_a, "format"_a = TypeFloat)
+        .def(
+            "read_tile",
+            [](ImageInput& self, int x, int y, int z,
+               TypeDesc format) -> py::object {
+                const ImageSpec& spec(self.spec());
+                return ImageInput_read_tiles(self, self.current_subimage(),
+                                             self.current_miplevel(), x,
+                                             x + spec.tile_width, y,
+                                             y + spec.tile_height, z,
+                                             z + std::max(1, spec.tile_depth),
+                                             0, spec.nchannels, format);
+            },
+            "x"_a, "y"_a, "z"_a, "format"_a = TypeFloat)
         .def("read_native_deep_scanlines",
              &ImageInput_read_native_deep_scanlines, "subimage"_a, "miplevel"_a,
              "ybegin"_a, "yend"_a, "z"_a, "chbegin"_a, "chend"_a)
-        .def("read_native_deep_scanlines",  // DEPRECATED(1.9), keep for back compatibility
-             [](ImageInput& self, int ybegin, int yend, int z, int chbegin,
-                int chend) {
-                 return ImageInput_read_native_deep_scanlines_old(self, ybegin,
-                                                                  yend, z,
-                                                                  chbegin,
-                                                                  chend);
-             },
-             "ybegin"_a, "yend"_a, "z"_a, "chbegin"_a, "chend"_a)
+        .def(
+            "read_native_deep_scanlines",  // DEPRECATED(1.9), keep for back compatibility
+            [](ImageInput& self, int ybegin, int yend, int z, int chbegin,
+               int chend) {
+                return ImageInput_read_native_deep_scanlines_old(self, ybegin,
+                                                                 yend, z,
+                                                                 chbegin,
+                                                                 chend);
+            },
+            "ybegin"_a, "yend"_a, "z"_a, "chbegin"_a, "chend"_a)
         .def("read_native_deep_tiles", &ImageInput_read_native_deep_tiles,
              "subimage"_a, "miplevel"_a, "xbegin"_a, "xend"_a, "ybegin"_a,
              "yend"_a, "zbegin"_a, "zend"_a, "chbegin"_a, "chend"_a)
-        .def("read_native_deep_tiles",  // DEPRECATED(1.9), keep for back compatibility
-             [](ImageInput& self, int xbegin, int xend, int ybegin, int yend,
-                int zbegin, int zend, int chbegin, int chend) {
-                 return ImageInput_read_native_deep_tiles(self, 0, 0, xbegin,
-                                                          xend, ybegin, yend,
-                                                          zbegin, zend, chbegin,
-                                                          chend);
-             },
-             "xbegin"_a, "xend"_a, "ybegin"_a, "yend"_a, "zbegin"_a, "zend"_a,
-             "chbegin"_a, "chend"_a)
+        .def(
+            "read_native_deep_tiles",  // DEPRECATED(1.9), keep for back compatibility
+            [](ImageInput& self, int xbegin, int xend, int ybegin, int yend,
+               int zbegin, int zend, int chbegin, int chend) {
+                return ImageInput_read_native_deep_tiles(self, 0, 0, xbegin,
+                                                         xend, ybegin, yend,
+                                                         zbegin, zend, chbegin,
+                                                         chend);
+            },
+            "xbegin"_a, "xend"_a, "ybegin"_a, "yend"_a, "zbegin"_a, "zend"_a,
+            "chbegin"_a, "chend"_a)
         .def("read_native_deep_image", &ImageInput_read_native_deep_image,
              "subimage"_a = 0, "miplevel"_a = 0)
         .def("geterror",

--- a/src/python/py_imageoutput.cpp
+++ b/src/python/py_imageoutput.cpp
@@ -220,39 +220,42 @@ declare_imageoutput(py::module& m)
     using namespace pybind11::literals;
 
     py::class_<ImageOutput>(m, "ImageOutput")
-        .def_static("create",
-                    [](const std::string& filename,
-                       const std::string& searchpath) -> py::object {
-                        auto out(ImageOutput::create(filename, searchpath));
-                        return out ? py::cast(out.release()) : py::none();
-                    },
-                    "filename"_a, "plugin_searchpath"_a = "")
+        .def_static(
+            "create",
+            [](const std::string& filename,
+               const std::string& searchpath) -> py::object {
+                auto out(ImageOutput::create(filename, searchpath));
+                return out ? py::cast(out.release()) : py::none();
+            },
+            "filename"_a, "plugin_searchpath"_a = "")
         .def("format_name", &ImageOutput::format_name)
         .def("supports",
              [](const ImageOutput& self, const std::string& feature) {
                  return self.supports(feature);
              })
         .def("spec", &ImageOutput::spec)
-        .def("open",
-             [](ImageOutput& self, const std::string& name,
-                const ImageSpec& newspec, const std::string& modestr) {
-                 ImageOutput::OpenMode mode = ImageOutput::Create;
-                 if (Strutil::iequals(modestr, "AppendSubimage"))
-                     mode = ImageOutput::AppendSubimage;
-                 else if (Strutil::iequals(modestr, "AppendMIPLevel"))
-                     mode = ImageOutput::AppendMIPLevel;
-                 else if (!Strutil::iequals(modestr, "Create"))
-                     throw std::invalid_argument(
-                         Strutil::sprintf("Unknown open mode '%s'", modestr));
-                 return self.open(name, newspec, mode);
-             },
-             "filename"_a, "spec"_a, "mode"_a = "Create")
-        .def("open",
-             [](ImageOutput& self, const std::string& name,
-                const std::vector<ImageSpec>& specs) {
-                 return self.open(name, (int)specs.size(), &specs[0]);
-             },
-             "filename"_a, "specs"_a)
+        .def(
+            "open",
+            [](ImageOutput& self, const std::string& name,
+               const ImageSpec& newspec, const std::string& modestr) {
+                ImageOutput::OpenMode mode = ImageOutput::Create;
+                if (Strutil::iequals(modestr, "AppendSubimage"))
+                    mode = ImageOutput::AppendSubimage;
+                else if (Strutil::iequals(modestr, "AppendMIPLevel"))
+                    mode = ImageOutput::AppendMIPLevel;
+                else if (!Strutil::iequals(modestr, "Create"))
+                    throw std::invalid_argument(
+                        Strutil::sprintf("Unknown open mode '%s'", modestr));
+                return self.open(name, newspec, mode);
+            },
+            "filename"_a, "spec"_a, "mode"_a = "Create")
+        .def(
+            "open",
+            [](ImageOutput& self, const std::string& name,
+               const std::vector<ImageSpec>& specs) {
+                return self.open(name, (int)specs.size(), &specs[0]);
+            },
+            "filename"_a, "specs"_a)
         .def("open", &ImageOutput_open_specs)
         .def("close", [](ImageOutput& self) { return self.close(); })
         .def("write_image", &ImageOutput_write_image)

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -121,11 +121,12 @@ declare_imagespec(py::module& m)
         .def_readwrite("tile_depth", &ImageSpec::tile_depth)
         .def_readwrite("nchannels", &ImageSpec::nchannels)
         .def_readwrite("format", &ImageSpec::format)
-        .def_property("channelformats",
-                      [](const ImageSpec& spec) {
-                          return ImageSpec_get_channelformats(spec);
-                      },
-                      &ImageSpec_set_channelformats)
+        .def_property(
+            "channelformats",
+            [](const ImageSpec& spec) {
+                return ImageSpec_get_channelformats(spec);
+            },
+            &ImageSpec_set_channelformats)
         .def_property("channelnames", &ImageSpec_get_channelnames,
                       &ImageSpec_set_channelnames)
         .def_readwrite("alpha_channel", &ImageSpec::alpha_channel)
@@ -142,50 +143,57 @@ declare_imagespec(py::module& m)
         .def(py::init<const ROI&, TypeDesc>())
         .def(py::init<TypeDesc>())
         .def(py::init<const ImageSpec&>())
-        .def("copy", [](const ImageSpec& self) { return ImageSpec(self); },
-             py::return_value_policy::reference_internal)
+        .def(
+            "copy", [](const ImageSpec& self) { return ImageSpec(self); },
+            py::return_value_policy::reference_internal)
         .def("set_format", &ImageSpec::set_format)
         .def("default_channel_names", &ImageSpec::default_channel_names)
         .def("channel_bytes",
              [](const ImageSpec& spec) { return spec.channel_bytes(); })
-        .def("channel_bytes",
-             [](const ImageSpec& spec, int chan, bool native) {
-                 return spec.channel_bytes(chan, native);
-             },
-             "channel"_a, "native"_a = false)
+        .def(
+            "channel_bytes",
+            [](const ImageSpec& spec, int chan, bool native) {
+                return spec.channel_bytes(chan, native);
+            },
+            "channel"_a, "native"_a = false)
         // .def("pixel_bytes",
         //      [](const ImageSpec &spec){ return spec.pixel_bytes(); })
-        .def("pixel_bytes",
-             [](const ImageSpec& spec, bool native) {
-                 return spec.pixel_bytes(native);
-             },
-             "native"_a = false)
-        .def("pixel_bytes",
-             [](const ImageSpec& spec, int chbegin, int chend, bool native) {
-                 return spec.pixel_bytes(chbegin, chend, native);
-             },
-             "chbegin"_a, "chend"_a, "native"_a = false)
+        .def(
+            "pixel_bytes",
+            [](const ImageSpec& spec, bool native) {
+                return spec.pixel_bytes(native);
+            },
+            "native"_a = false)
+        .def(
+            "pixel_bytes",
+            [](const ImageSpec& spec, int chbegin, int chend, bool native) {
+                return spec.pixel_bytes(chbegin, chend, native);
+            },
+            "chbegin"_a, "chend"_a, "native"_a = false)
         // .def("scanline_bytes",
         //      [](const ImageSpec &spec){ return spec.scanline_bytes(); })
-        .def("scanline_bytes",
-             [](const ImageSpec& spec, bool native) {
-                 return spec.scanline_bytes(native);
-             },
-             "native"_a = false)
+        .def(
+            "scanline_bytes",
+            [](const ImageSpec& spec, bool native) {
+                return spec.scanline_bytes(native);
+            },
+            "native"_a = false)
         // .def("tile_bytes",
         //      [](const ImageSpec &spec){ return spec.tile_bytes(); })
-        .def("tile_bytes",
-             [](const ImageSpec& spec, bool native) {
-                 return spec.tile_bytes(native);
-             },
-             "native"_a = false)
+        .def(
+            "tile_bytes",
+            [](const ImageSpec& spec, bool native) {
+                return spec.tile_bytes(native);
+            },
+            "native"_a = false)
         // .def("image_bytes",
         //      [](const ImageSpec &spec){ return spec.image_bytes(); })
-        .def("image_bytes",
-             [](const ImageSpec& spec, bool native) {
-                 return spec.image_bytes(native);
-             },
-             "native"_a = false)
+        .def(
+            "image_bytes",
+            [](const ImageSpec& spec, bool native) {
+                return spec.image_bytes(native);
+            },
+            "native"_a = false)
         .def("tile_pixels", &ImageSpec::tile_pixels)
         .def("image_pixels", &ImageSpec::image_pixels)
         .def("size_t_safe", &ImageSpec::size_t_safe)
@@ -222,49 +230,54 @@ declare_imagespec(py::module& m)
         // .def("attribute", [](ImageSpec &spec, const std::string &name, TypeDesc type, const py::list &obj) {
         //         attribute_typed (spec, name, type, obj);
         //     })
-        .def("get_int_attribute",
-             [](const ImageSpec& spec, const std::string& name, int def) {
-                 return spec.get_int_attribute(name, def);
-             },
-             "name"_a, "defaultval"_a = 0)
-        .def("get_float_attribute",
-             [](const ImageSpec& spec, const std::string& name, float def) {
-                 return spec.get_float_attribute(name, def);
-             },
-             "name"_a, "defaultval"_a = 0.0f)
-        .def("get_string_attribute",
-             [](const ImageSpec& spec, const std::string& name,
-                const std::string& def) {
-                 return PY_STR(
-                     std::string(spec.get_string_attribute(name, def)));
-             },
-             "name"_a, "defaultval"_a = "")
+        .def(
+            "get_int_attribute",
+            [](const ImageSpec& spec, const std::string& name, int def) {
+                return spec.get_int_attribute(name, def);
+            },
+            "name"_a, "defaultval"_a = 0)
+        .def(
+            "get_float_attribute",
+            [](const ImageSpec& spec, const std::string& name, float def) {
+                return spec.get_float_attribute(name, def);
+            },
+            "name"_a, "defaultval"_a = 0.0f)
+        .def(
+            "get_string_attribute",
+            [](const ImageSpec& spec, const std::string& name,
+               const std::string& def) {
+                return PY_STR(
+                    std::string(spec.get_string_attribute(name, def)));
+            },
+            "name"_a, "defaultval"_a = "")
         .def("getattribute", &ImageSpec_getattribute_typed, "name"_a,
              "type"_a = TypeUnknown)
         .def("erase_attribute", &ImageSpec::erase_attribute, "name"_a = "",
              "type"_a = TypeUnknown, "casesensitive"_a = false)
 
-        .def_static("metadata_val",
-                    [](const ParamValue& p, bool human) {
-                        return PY_STR(ImageSpec::metadata_val(p, human));
-                    },
-                    "param"_a, "human"_a = false)
-        .def("serialize",
-             [](const ImageSpec& spec, const std::string& format,
-                const std::string& verbose) {
-                 ImageSpec::SerialFormat fmt = ImageSpec::SerialText;
-                 if (Strutil::iequals(format, "xml"))
-                     fmt = ImageSpec::SerialXML;
-                 ImageSpec::SerialVerbose verb = ImageSpec::SerialDetailed;
-                 if (Strutil::iequals(verbose, "brief"))
-                     verb = ImageSpec::SerialBrief;
-                 else if (Strutil::iequals(verbose, "detailed"))
-                     verb = ImageSpec::SerialDetailed;
-                 else if (Strutil::iequals(verbose, "detailedhuman"))
-                     verb = ImageSpec::SerialDetailedHuman;
-                 return PY_STR(spec.serialize(fmt, verb));
-             },
-             "format"_a = "text", "verbose"_a = "detailed")
+        .def_static(
+            "metadata_val",
+            [](const ParamValue& p, bool human) {
+                return PY_STR(ImageSpec::metadata_val(p, human));
+            },
+            "param"_a, "human"_a = false)
+        .def(
+            "serialize",
+            [](const ImageSpec& spec, const std::string& format,
+               const std::string& verbose) {
+                ImageSpec::SerialFormat fmt = ImageSpec::SerialText;
+                if (Strutil::iequals(format, "xml"))
+                    fmt = ImageSpec::SerialXML;
+                ImageSpec::SerialVerbose verb = ImageSpec::SerialDetailed;
+                if (Strutil::iequals(verbose, "brief"))
+                    verb = ImageSpec::SerialBrief;
+                else if (Strutil::iequals(verbose, "detailed"))
+                    verb = ImageSpec::SerialDetailed;
+                else if (Strutil::iequals(verbose, "detailedhuman"))
+                    verb = ImageSpec::SerialDetailedHuman;
+                return PY_STR(spec.serialize(fmt, verb));
+            },
+            "format"_a = "text", "verbose"_a = "detailed")
         .def("to_xml",
              [](const ImageSpec& spec) { return PY_STR(spec.to_xml()); })
         .def("from_xml", &ImageSpec::from_xml)

--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -273,21 +273,24 @@ OIIO_DECLARE_PYMODULE(OIIO_PYMODULE_NAME)
               oiio_attribute_typed(name, type, obj);
           });
 
-    m.def("get_int_attribute",
-          [](const std::string& name, int def) {
-              return OIIO::get_int_attribute(name, def);
-          },
-          py::arg("name"), py::arg("defaultval") = 0);
-    m.def("get_float_attribute",
-          [](const std::string& name, float def) {
-              return OIIO::get_float_attribute(name, def);
-          },
-          py::arg("name"), py::arg("defaultval") = 0.0f);
-    m.def("get_string_attribute",
-          [](const std::string& name, const std::string& def) {
-              return PY_STR(std::string(OIIO::get_string_attribute(name, def)));
-          },
-          py::arg("name"), py::arg("defaultval") = "");
+    m.def(
+        "get_int_attribute",
+        [](const std::string& name, int def) {
+            return OIIO::get_int_attribute(name, def);
+        },
+        py::arg("name"), py::arg("defaultval") = 0);
+    m.def(
+        "get_float_attribute",
+        [](const std::string& name, float def) {
+            return OIIO::get_float_attribute(name, def);
+        },
+        py::arg("name"), py::arg("defaultval") = 0.0f);
+    m.def(
+        "get_string_attribute",
+        [](const std::string& name, const std::string& def) {
+            return PY_STR(std::string(OIIO::get_string_attribute(name, def)));
+        },
+        py::arg("name"), py::arg("defaultval") = "");
     m.def("getattribute", &oiio_getattribute_typed);
     m.attr("AutoStride")          = AutoStride;
     m.attr("openimageio_version") = OIIO_VERSION;

--- a/src/python/py_paramvalue.cpp
+++ b/src/python/py_paramvalue.cpp
@@ -103,39 +103,44 @@ declare_paramvalue(py::module& m)
 
     py::class_<ParamValueList>(m, "ParamValueList")
         .def(py::init<>())
-        .def("__getitem__",
-             [](const ParamValueList& self, size_t i) {
-                 if (i >= self.size())
-                     throw py::index_error();
-                 return self[i];
-             },
-             py::return_value_policy::reference_internal)
+        .def(
+            "__getitem__",
+            [](const ParamValueList& self, size_t i) {
+                if (i >= self.size())
+                    throw py::index_error();
+                return self[i];
+            },
+            py::return_value_policy::reference_internal)
         .def("__len__", [](const ParamValueList& p) { return p.size(); })
-        .def("__iter__",
-             [](const ParamValueList& self) {
-                 return py::make_iterator(self.begin(), self.end());
-             },
-             py::keep_alive<0, 1>())
+        .def(
+            "__iter__",
+            [](const ParamValueList& self) {
+                return py::make_iterator(self.begin(), self.end());
+            },
+            py::keep_alive<0, 1>())
         .def("append", [](ParamValueList& p,
                           const ParamValue& v) { return p.push_back(v); })
         .def("clear", &ParamValueList::clear)
         .def("free", &ParamValueList::free)
         .def("resize", [](ParamValueList& p, size_t s) { return p.resize(s); })
-        .def("remove",
-             [](ParamValueList& p, const std::string& name, TypeDesc type,
-                bool casesensitive) { p.remove(name, type, casesensitive); },
-             "name"_a, "type"_a = TypeUnknown, "casesensitive"_a = true)
-        .def("contains",
-             [](ParamValueList& p, const std::string& name, TypeDesc type,
-                bool casesensitive) {
-                 return p.contains(name, type, casesensitive);
-             },
-             "name"_a, "type"_a = TypeUnknown, "casesensitive"_a = true)
-        .def("add_or_replace",
-             [](ParamValueList& p, const ParamValue& pv, bool casesensitive) {
-                 return p.add_or_replace(pv, casesensitive);
-             },
-             "value"_a, "casesensitive"_a = true)
+        .def(
+            "remove",
+            [](ParamValueList& p, const std::string& name, TypeDesc type,
+               bool casesensitive) { p.remove(name, type, casesensitive); },
+            "name"_a, "type"_a = TypeUnknown, "casesensitive"_a = true)
+        .def(
+            "contains",
+            [](ParamValueList& p, const std::string& name, TypeDesc type,
+               bool casesensitive) {
+                return p.contains(name, type, casesensitive);
+            },
+            "name"_a, "type"_a = TypeUnknown, "casesensitive"_a = true)
+        .def(
+            "add_or_replace",
+            [](ParamValueList& p, const ParamValue& pv, bool casesensitive) {
+                return p.add_or_replace(pv, casesensitive);
+            },
+            "value"_a, "casesensitive"_a = true)
         .def("sort", &ParamValueList::sort, "casesensitive"_a = true);
 }
 

--- a/src/python/py_typedesc.cpp
+++ b/src/python/py_typedesc.cpp
@@ -92,25 +92,20 @@ declare_typedesc(py::module& m)
         // char, def_readwrite() doesn't do the right thing. Instead, we
         // use set_foo/get_foo wrappers, but from Python it looks like
         // regular member access.
-        .def_property("basetype",
-                      [](TypeDesc t) { return TypeDesc::BASETYPE(t.basetype); },
-                      [](TypeDesc& t, TypeDesc::BASETYPE b) {
-                          return t.basetype = b;
-                      })
-        .def_property("aggregate",
-                      [](TypeDesc t) {
-                          return TypeDesc::AGGREGATE(t.aggregate);
-                      },
-                      [](TypeDesc& t, TypeDesc::AGGREGATE b) {
-                          return t.aggregate = b;
-                      })
-        .def_property("vecsemantics",
-                      [](TypeDesc t) {
-                          return TypeDesc::VECSEMANTICS(t.vecsemantics);
-                      },
-                      [](TypeDesc& t, TypeDesc::VECSEMANTICS b) {
-                          return t.vecsemantics = b;
-                      })
+        .def_property(
+            "basetype",
+            [](TypeDesc t) { return TypeDesc::BASETYPE(t.basetype); },
+            [](TypeDesc& t, TypeDesc::BASETYPE b) { return t.basetype = b; })
+        .def_property(
+            "aggregate",
+            [](TypeDesc t) { return TypeDesc::AGGREGATE(t.aggregate); },
+            [](TypeDesc& t, TypeDesc::AGGREGATE b) { return t.aggregate = b; })
+        .def_property(
+            "vecsemantics",
+            [](TypeDesc t) { return TypeDesc::VECSEMANTICS(t.vecsemantics); },
+            [](TypeDesc& t, TypeDesc::VECSEMANTICS b) {
+                return t.vecsemantics = b;
+            })
         .def_readwrite("arraylen", &TypeDesc::arraylen)
         // Constructors: () [defined implicitly], (base), (base, agg),
         // (base,agg,vecsem), (base,agg,vecsem,arraylen), string.


### PR DESCRIPTION
The recent upgrade to clang 8 (via homebrew on the TravisCI configuration that we use to verify formatting) brought some minor changes to what clang-format wants to do.
I think it's easier to just accept these occasional arbitrary changes with major clang releases rather than to try to painfully adjust the clang-format parameters to exactly preserve the old behavior.