### PR TITLE
Enhancements to the syntax for setting and retrieving attributes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,7 +319,8 @@ endif()
 if (USE_PYTHON AND NOT BUILD_OIIOUTIL_ONLY)
     if (NOT SANITIZE_ON_LINUX)
         oiio_add_tests (
-                python-typedesc python-imagespec python-roi python-deep
+                python-typedesc python-paramlist
+                python-imagespec python-roi python-deep
                 python-imageinput python-imageoutput
                 python-imagebuf python-imagebufalgo
                 IMAGEDIR oiio-images

--- a/src/doc/imageioapi.tex
+++ b/src/doc/imageioapi.tex
@@ -869,6 +869,51 @@ The extra names it understands are:
 
 \apiend
 
+
+\apiitem{TypeDesc {\ce getattributetype} (string_view name, \\
+\bigspc\bigspc                     bool casesensitive=false) const}
+\indexapi{getattributetype}
+\NEW % 2.1
+If the named attribute can be found in the \ImageSpec, return its data type.
+If no such attribute exists, return {\cf TypeUnknown}.
+\apiend
+
+\apiitem{bool {\ce getattribute} (string_view name, TypeDesc type,
+  void *val,
+\bigspc\bigspc                     bool casesensitive=false) const}
+\indexapi{getattribute}
+\NEW % 2.1
+If the \ImageSpec contains the named attribute and its type matches
+{\cf type}, copy the attribute value into the memory pointed to by {\cf val}
+(it is up to the caller to ensure there is enough space) and return {\cf true}.
+If no such attribute is found, or if it doesn't match the type, return
+{\cf false} and do not modify {\cf val}.
+
+\noindent Here are examples:
+
+\begin{code}
+      ImageSpec spec;
+      ...
+      // Retrieving an integer attribute:
+      int orientation = 0;
+      spec.getattribute ("orientation", TypeInt, &orientation);
+
+      // Retrieving a string attribute with a char*:
+      const char* compression = nullptr;
+      spec.getattribute ("compression", TypeString, &compression);
+
+      // Alternately, retrieving a string with a ustring:
+      ustring compression;
+      spec.getattribute ("compression", TypeString, &compression);
+\end{code}
+
+Note that when passing a string, you need to pass a pointer to the {\cf
+  char*}, not a pointer to the first character.  Also, the {\cf char*}
+will end up pointing to characters owned by the \ImageSpec; the
+caller does not need to ever free the memory that contains the
+characters.
+\apiend
+
 \apiitem{int {\ce get_int_attribute} (string_view name, int defaultval=0) const}
 Gets an integer metadata attribute (silently converting to {\cf int}
 even if if the data is really int8, uint8, int16, uint16, or uint32),
@@ -889,6 +934,34 @@ function for when you know you are just looking for a simple float value.
 Gets a string metadata attribute, simply substituting the supplied
 default value if no such metadata exists.  This is a convenience
 function for when you know you are just looking for a simple string value.
+\apiend
+
+\apiitem{AttrDelegate {\ce operator[]} (string_view name)}
+\NEW % 2.1
+Metadata inside an \ImageSpec can be set and retrieved using an array-access
+notation with the metadata name as the ``index.'' Technically, the {\cf [name]}
+operator is returning a temporary structure called an {\cf AttrDelegate},
+which you can assign to or from.
+
+\noindent To set metadata, simply assign:
+
+\begin{code}
+    ImageSpec spec;
+    spec["foo"] = 42;                   // int
+    spec["pi"] = float(M_PI);           // float
+    spec["oiio:ColorSpace"] = "sRGB";   // string
+    spec["cameratoworld"] = Imath::Matrix44(...);  // matrix
+\end{code}
+
+\noindent Be very careful, the data type of the metadata will be whatever
+is implied by the C++ type you are ``assigning.''
+
+Retrieval is also simple, but requires you to say what data type you want:
+
+\begin{code}
+    float bar = spec["bar"].get<float>();
+    int x = spec["FrameNumber"].get<int>(1000); // optional default
+\end{code}
 \apiend
 
 

--- a/src/doc/openimageio.tex
+++ b/src/doc/openimageio.tex
@@ -95,7 +95,7 @@
  \bigskip \\
 }
 \date{{\large
-Date: 17 Feb 2019
+Date: 19 Apr 2019
 %\\ (with corrections, 18 Dec 2018)
 }}
 

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -535,6 +535,21 @@ value) if not found.
 \end{code}
 \apiend
 
+\apiitem{ImageSpec{\ce [name]}}
+\NEW % 2.1
+Retrieve or set metadata using a dictionary-like syntax, rather than
+{\cf attribute()} and {\cf getattribute()}. This is best illustrated by
+example:
+
+\begin{code}
+    comp = spec["Compression"]
+    # Same as:  comp = spec.getattribute("Compression")
+
+    spec["Compression"] = comp
+    # Same as: spec.attribute("Compression", comp)
+\end{code}
+\apiend
+
 %\apiitem{static ImageSpec.{\ce metadata_val} (paramval, human=False)}
 %For a \ParamValue, format its value as a string.
 %\apiend

--- a/src/include/OpenImageIO/attrdelegate.h
+++ b/src/include/OpenImageIO/attrdelegate.h
@@ -1,0 +1,209 @@
+/*
+  Copyright 2019 Larry Gritz and the other authors and contributors.
+  All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the software's owners nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  (This is the Modified BSD License)
+*/
+
+
+#pragma once
+
+#include <vector>
+
+#include <OpenImageIO/export.h>
+#include <OpenImageIO/string_view.h>
+#include <OpenImageIO/typedesc.h>
+#include <OpenImageIO/ustring.h>
+
+
+OIIO_NAMESPACE_BEGIN
+
+
+namespace pvt {
+
+// Helper template to detect if a type is one if the string types that
+// OIIO tends to use.
+// clang-format off
+template<typename T> struct is_string : std::false_type {};
+template<> struct is_string<ustring> : std::true_type {};
+template<> struct is_string<string_view> : std::true_type {};
+template<> struct is_string<std::string> : std::true_type {};
+// clang-format on
+
+}  // namespace pvt
+
+
+
+// AttrDelegate should not be used directly in user code!
+//
+// This is a helper template that allows the notation
+//    Class object;
+//    object["name"] = value;
+// to work as a shorthand for
+//    object.attribute ("name", TypeDesc_of_value, &value);
+// and for
+//    value = object["name"].get<type>();
+// to work as a shorthand for extracting the named attribute via
+// object.getattribute() and assigning it to the result.
+//
+// Basically, the class in question needs to posess these three methods,
+// working in the usual idiomatic way for OIIO:
+//
+//      void attribute (string_view name, TypeDesc type, void* data);
+//      bool getattribute (string_view name, TypeDesc type, void *data);
+//      TypeDesc getattributetype (string_view name);
+//
+// Then the array access notation can be added with the following members
+// of the class C:
+//
+//     AttrDelegate<const C> operator[](string_view name) const
+//     {
+//         return { this, name };
+//     }
+//     AttrDelegate<C> operator[](string_view name) {
+//         return { this, name };
+//     }
+//
+// This allows the following convenient notation:
+//
+// 1. Adding attributes, type implied by the C++ type of what's assigned:
+//        C obj;
+//        obj["foo"] = 42;       // adds integer
+//        obj["bar"] = 39.8f;    // adds float
+//        obj["baz"] = "hello";  // adds string
+// 2. Retrieving attributes:
+//         int i = obj["foo"].get<int>();
+//         float f = obj["bar"].get<float>();
+//         std::string s = obj["baz"].get<std::string>();
+//    If the object does not posess an attribute of that name (and/or of
+//    that type), it will instead return the default value for that type.
+//    A specific default value override may be provided as an argument to
+//    the get() method:
+//         float aspect = obj["aspectratio"].get<float>(1.0f);
+//
+
+template<class C> class AttrDelegate {
+public:
+    AttrDelegate(C* obj, string_view name)
+        : m_obj(obj)
+        , m_name(name)
+        , m_readonly(std::is_const<C>::value)
+    {
+    }
+
+    // Assignment to a delegate should copy the value into an attribute,
+    // calling attribute(name,typedesc,&data). Except for strings, which are
+    // handled separately.
+    template<typename T,
+             typename std::enable_if<!pvt::is_string<T>::value, int>::type = 0>
+    inline const T& operator=(const T& val)
+    {
+        if (!m_readonly)
+            const_cast<C*>(m_obj)->attribute(m_name, TypeDescFromC<T>::value(),
+                                             &val);
+        return val;
+    }
+
+    // String types are a special case because we don't directly copy their
+    // data, instead call the attribute(name,string_view) variant.
+    template<typename T,
+             typename std::enable_if<pvt::is_string<T>::value, int>::type = 1>
+    inline const T& operator=(const T& val)
+    {
+        if (!m_readonly)
+            const_cast<C*>(m_obj)->attribute(m_name, string_view(val));
+        return val;
+    }
+    // char arrays are special
+    inline const char* operator=(const char* val)
+    {
+        if (!m_readonly)
+            const_cast<C*>(m_obj)->attribute(m_name, string_view(val));
+        return val;
+    }
+
+
+    // `Delegate->type()` returns the TypeDesc describing the data, or
+    // TypeUnknown if no such attribute exists.
+    TypeDesc type() const { return m_obj->getattributetype(m_name); }
+
+    // `Delegate->get<T>(defaultval=T())` retrieves the data as type T,
+    // or the defaultval if no such named data exists or is not the
+    // designated type.
+    template<typename T,
+             typename std::enable_if<!pvt::is_string<T>::value, int>::type = 0>
+    inline T get(const T& defaultval = T()) const
+    {
+        T result;
+        if (!m_obj->getattribute(m_name, TypeDescFromC<T>::value(), &result))
+            result = defaultval;
+        return result;
+    }
+
+    // Using enable_if, make a slightly different version of get<> for
+    // strings, which need to do some ustring magic because we can't
+    // directly store in a std::string or string_view.
+    template<typename T,
+             typename std::enable_if<pvt::is_string<T>::value, int>::type = 1>
+    inline T get(const T& defaultval = T()) const
+    {
+        ustring s;
+        return m_obj->getattribute(m_name, TypeString, &s) ? T(s.string())
+                                                           : defaultval;
+    }
+
+    // `Delegate->as_string(defaultval="")` returns the data, no matter its
+    // type, as a string. Returns the defaultval if no such data exists at
+    // all.
+    inline std::string as_string(const std::string& defaultval = std::string())
+    {
+        std::string s;
+        TypeDesc t = m_obj->getattributetype(m_name);
+        if (t == TypeString) {  // Attrib is a string? Return it.
+            s = get<std::string>();
+        } else if (t != TypeUnknown) {  // Non-string attrib? Convert.
+            char* buffer = new char[t.size()];
+            if (m_obj->getattribute(m_name, t, buffer))
+                s = tostring(t, buffer);
+            else
+                s = defaultval;
+        } else {  // No attrib? Return default.
+            s = defaultval;
+        }
+        return s;
+    }
+
+    // Allow direct assignment to string, equivalent to calling as_string().
+    inline operator std::string() { return as_string(); }
+
+protected:
+    C* m_obj;
+    string_view m_name;
+    bool m_readonly = false;
+};
+
+
+OIIO_NAMESPACE_END

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -454,6 +454,18 @@ public:
                          TypeDesc searchtype=TypeDesc::UNKNOWN,
                          bool casesensitive=false) const;
 
+    /// Search for named attribute, return its type or TypeUnknnown if not
+    /// found.
+    TypeDesc getattributetype (string_view name,
+                               bool casesensitive = false) const;
+
+    /// Retrieve attribute: If found and its data type is reasonably
+    /// convertible to `type`, copy/convert the value into val[...] and
+    /// return true. Otherwise, return false and don't modify what val
+    /// points to.
+    bool getattribute (string_view name, TypeDesc type, void* value,
+                       bool casesensitive = false) const;
+
     /// Simple way to get an integer attribute, with default provided.
     /// Automatically will return an int even if the data is really
     /// unsigned, short, or byte.
@@ -605,6 +617,29 @@ public:
     /// purposefully made.)
     bool undefined () const {
         return nchannels == 0 && format == TypeUnknown;
+    }
+
+    /// Array indexing by string will create a "Delegate" that enables a
+    /// convenient shorthand for adding and retrieving values from the spec:
+    ///
+    /// 1. Assigning to the delegate adds a metadata attribute:
+    ///        ImageSpec spec;
+    ///        spec["compression"] = "zip";
+    ///        spec["PixelAspectRatio"] = 1.0f;
+    ///    Be very careful, the attribute's type will be implied by the C++
+    ///    type of what you assign.
+    ///
+    /// 2. The delegate supports a get<T>() that retrieves an item of type T:
+    ///         std::string colorspace = spec["oiio:ColorSpace"];
+    ///         int dither = spec["oiio:dither"].get<int>();
+    ///
+    AttrDelegate<const ImageSpec> operator[](string_view name) const
+    {
+        return { this, name };
+    }
+    AttrDelegate<ImageSpec> operator[](string_view name)
+    {
+        return { this, name };
     }
 };
 

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -525,6 +525,31 @@ ImageSpec::find_attribute(string_view name, ParamValue& tmpparam,
 
 
 
+TypeDesc
+ImageSpec::getattributetype(string_view name, bool casesensitive) const
+{
+    ParamValue pv;
+    auto p = find_attribute(name, pv, TypeUnknown, casesensitive);
+    return p ? p->type() : TypeUnknown;
+}
+
+
+
+bool
+ImageSpec::getattribute(string_view name, TypeDesc type, void* value,
+                        bool casesensitive) const
+{
+    ParamValue pv;
+    auto p = find_attribute(name, pv, TypeUnknown, casesensitive);
+    if (p) {
+        return convert_type(p->type(), p->data(), type, value);
+    } else {
+        return false;
+    }
+}
+
+
+
 int
 ImageSpec::get_int_attribute(string_view name, int defaultval) const
 {

--- a/src/libOpenImageIO/imagespec_test.cpp
+++ b/src/libOpenImageIO/imagespec_test.cpp
@@ -146,13 +146,15 @@ test_imagespec_metadata_val()
         { 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 }
     };
     metadata_val_test(&matrix16[0], 1, TypeMatrix, ret);
-    OIIO_CHECK_EQUAL(ret, "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16");
-    OIIO_CHECK_NE(ret, "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16,");
+    OIIO_CHECK_EQUAL(ret,
+                     "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16");
+    OIIO_CHECK_NE(ret,
+                  "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,");
     metadata_val_test(matrix16, sizeof(matrix16) / (16 * sizeof(float)),
                       TypeMatrix, ret);
     OIIO_CHECK_EQUAL(
         ret,
-        "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16, 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25");
+        "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25");
 }
 
 
@@ -194,7 +196,7 @@ test_imagespec_attribute_from_string()
     OIIO_CHECK_EQUAL(ret, data);
 
     type = TypeMatrix;
-    data = "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16";
+    data = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16";
     attribute_test(data, type, ret);
     OIIO_CHECK_EQUAL(ret, data);
 
@@ -222,6 +224,7 @@ test_get_attribute()
     spec.attribute("foo", int(42));
     spec.attribute("pi", float(M_PI));
     spec.attribute("bar", "barbarbar?");
+    spec["baz"] = (unsigned int)14;
 
     OIIO_CHECK_EQUAL(spec.get_int_attribute("width"), 640);
     OIIO_CHECK_EQUAL(spec.get_int_attribute("height"), 480);
@@ -268,6 +271,13 @@ test_get_attribute()
     p  = spec.find_attribute("displaywindow", tmp);
     ok = cspan<int>((const int*)p->data(), 4) == cspan<int>(dispwin);
     OIIO_CHECK_ASSERT(ok);
+
+    // Check [] syntax using AttribDelegate
+    OIIO_CHECK_EQUAL(spec["pi"].get<float>(), float(M_PI));
+    OIIO_CHECK_EQUAL(spec["foo"].get<int>(), 42);
+    OIIO_CHECK_EQUAL(spec["foo"].get<std::string>(), "42");
+    OIIO_CHECK_EQUAL(spec.getattributetype("baz"), TypeUInt32);
+    OIIO_CHECK_EQUAL(spec["baz"].get<unsigned int>(), (unsigned int)14);
 }
 
 

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -325,91 +325,375 @@ TypeDesc::fromstring(string_view typestring)
 
 
 
+tostring_formatting::tostring_formatting(
+    const char* int_fmt, const char* float_fmt, const char* string_fmt,
+    const char* ptr_fmt, const char* aggregate_begin, const char* aggregate_end,
+    const char* aggregate_sep, const char* array_begin, const char* array_end,
+    const char* array_sep, int flags)
+    : int_fmt(int_fmt)
+    , float_fmt(float_fmt)
+    , string_fmt(string_fmt)
+    , ptr_fmt(ptr_fmt)
+    , aggregate_begin(aggregate_begin)
+    , aggregate_end(aggregate_end)
+    , aggregate_sep(aggregate_sep)
+    , array_begin(array_begin)
+    , array_end(array_end)
+    , array_sep(array_sep)
+    , flags(flags)
+{
+}
+
+
+
 template<class T>
 inline std::string
-sprintt(TypeDesc type, const char* format, const char* aggregate_delim,
-        const char* aggregate_sep, const char* array_delim,
-        const char* array_sep, T* v)
+sprintt(TypeDesc type, const char* format, const tostring_formatting& fmt,
+        const T* v)
 {
     std::string val;
     if (type.arraylen)
-        val += array_delim[0];
+        val += fmt.array_begin;
     const size_t n = type.arraylen ? type.arraylen : 1;
     for (size_t i = 0; i < n; ++i) {
         if (type.aggregate > 1)
-            val += aggregate_delim[0];
+            val += fmt.aggregate_begin;
         for (int j = 0; j < (int)type.aggregate; ++j, ++v) {
             val += Strutil::sprintf(format, *v);
             if (type.aggregate > 1 && j < type.aggregate - 1)
-                val += aggregate_sep;
+                val += fmt.aggregate_sep;
         }
         if (type.aggregate > 1)
-            val += aggregate_delim[1];
+            val += fmt.aggregate_end;
         if (i < n - 1)
-            val += array_sep;
+            val += fmt.array_sep;
     }
     if (type.arraylen)
-        val += array_delim[1];
+        val += fmt.array_end;
     return val;
 }
 
 
 
+inline std::string
+sprintt(TypeDesc type, const char* format, const tostring_formatting& fmt,
+        const char** v)
+{
+    std::string val;
+    if (type.arraylen)
+        val += fmt.array_begin;
+    const size_t n = type.arraylen ? type.arraylen : 1;
+    for (size_t i = 0; i < n; ++i) {
+        if (type.aggregate > 1)
+            val += fmt.aggregate_begin;
+        for (int j = 0; j < (int)type.aggregate; ++j, ++v) {
+            if (fmt.flags & tostring_formatting::escape_strings)
+                val += Strutil::sprintf(format, *v ? Strutil::escape_chars(*v)
+                                                   : std::string());
+            else
+                val += Strutil::sprintf(format, *v ? *v : "");
+            if (type.aggregate > 1 && j < type.aggregate - 1)
+                val += fmt.aggregate_sep;
+        }
+        if (type.aggregate > 1)
+            val += fmt.aggregate_end;
+        if (i < n - 1)
+            val += fmt.array_sep;
+    }
+    if (type.arraylen)
+        val += fmt.array_end;
+    return val;
+}
+
+
+
+// From OpenEXR
+inline unsigned int
+bitField(unsigned int value, int minBit, int maxBit)
+{
+    int shift         = minBit;
+    unsigned int mask = (~(~0U << (maxBit - minBit + 1)) << minBit);
+    return (value & mask) >> shift;
+}
+
+
+// From OpenEXR
+inline int
+bcdToBinary(unsigned int bcd)
+{
+    return int((bcd & 0x0f) + 10 * ((bcd >> 4) & 0x0f));
+}
+
+
+
 std::string
-tostring(TypeDesc type, const void* data, const char* float_fmt,
-         const char* string_fmt, const char* aggregate_delim,
-         const char* aggregate_sep, const char* array_delim,
-         const char* array_sep)
+tostring(TypeDesc type, const void* data, const tostring_formatting& fmt)
 {
     // Perhaps there is a way to use CType<> with a dynamic argument?
     switch (type.basetype) {
     case TypeDesc::UNKNOWN:
-        return sprintt(type, "%p", aggregate_delim, aggregate_sep, array_delim,
-                       array_sep, (void**)data);
-    case TypeDesc::NONE:
-        return sprintt(type, "None", aggregate_delim, aggregate_sep,
-                       array_delim, array_sep, (void**)data);
+        return sprintt(type, fmt.ptr_fmt, fmt, (void**)data);
+    case TypeDesc::NONE: return sprintt(type, "None", fmt, (void**)data);
     case TypeDesc::UCHAR:
-        return sprintt(type, "%uhh", aggregate_delim, aggregate_sep,
-                       array_delim, array_sep, (unsigned char*)data);
-    case TypeDesc::CHAR:
-        return sprintt(type, "%dhh", aggregate_delim, aggregate_sep,
-                       array_delim, array_sep, (char*)data);
+        return sprintt(type, fmt.int_fmt, fmt, (unsigned char*)data);
+    case TypeDesc::CHAR: return sprintt(type, fmt.int_fmt, fmt, (char*)data);
     case TypeDesc::USHORT:
-        return sprintt(type, "%uh", aggregate_delim, aggregate_sep, array_delim,
-                       array_sep, (unsigned short*)data);
-    case TypeDesc::SHORT:
-        return sprintt(type, "%dh", aggregate_delim, aggregate_sep, array_delim,
-                       array_sep, (short*)data);
+        return sprintt(type, fmt.int_fmt, fmt, (uint16_t*)data);
+    case TypeDesc::SHORT: return sprintt(type, fmt.int_fmt, fmt, (short*)data);
     case TypeDesc::UINT:
-        return sprintt(type, "%u", aggregate_delim, aggregate_sep, array_delim,
-                       array_sep, (unsigned int*)data);
+        if (type.vecsemantics == TypeDesc::RATIONAL
+            && type.aggregate == TypeDesc::VEC2) {
+            std::string out;
+            const uint32_t* val = (const uint32_t*)data;
+            for (size_t i = 0, e = type.numelements(); i < e; ++i, val += 2) {
+                if (i)
+                    out += ", ";
+                out += Strutil::sprintf("%d/%d", val[0], val[1]);
+            }
+            return out;
+        } else if (type == TypeTimeCode) {
+            // Replicating the logic in OpenEXR, but this prevents us from
+            // needing to link to libIlmImf just to do this.
+            unsigned int t = *(unsigned int*)data;
+            int hours      = bcdToBinary(bitField(t, 24, 29));
+            int minutes    = bcdToBinary(bitField(t, 16, 22));
+            int seconds    = bcdToBinary(bitField(t, 8, 14));
+            int frame      = bcdToBinary(bitField(t, 0, 5));
+            return Strutil::sprintf("%02d:%02d:%02d:%02d", hours, minutes,
+                                    seconds, frame);
+        }
+        return sprintt(type, fmt.int_fmt, fmt, (unsigned int*)data);
     case TypeDesc::INT:
-        return sprintt(type, "%d", aggregate_delim, aggregate_sep, array_delim,
-                       array_sep, (int*)data);
+        if (type.elementtype() == TypeRational) {
+            std::string out;
+            const int* val = (const int*)data;
+            for (size_t i = 0, e = type.numelements(); i < e; ++i, val += 2) {
+                if (i)
+                    out += ", ";
+                out += Strutil::sprintf("%d/%d", val[0], val[1]);
+            }
+            return out;
+        }
+        return sprintt(type, fmt.int_fmt, fmt, (int*)data);
     case TypeDesc::ULONGLONG:
-        return sprintt(type, "%ull", aggregate_delim, aggregate_sep,
-                       array_delim, array_sep, (unsigned long long*)data);
+        return sprintt(type, fmt.int_fmt, fmt, (const uint64_t*)data);
     case TypeDesc::LONGLONG:
-        return sprintt(type, "%dll", aggregate_delim, aggregate_sep,
-                       array_delim, array_sep, (long long*)data);
+        return sprintt(type, fmt.int_fmt, fmt, (const int64_t*)data);
     case TypeDesc::HALF:
-        return sprintt(type, float_fmt, aggregate_delim, aggregate_sep,
-                       array_delim, array_sep, (half*)data);
+        return sprintt(type, fmt.float_fmt, fmt, (const half*)data);
     case TypeDesc::FLOAT:
-        return sprintt(type, float_fmt, aggregate_delim, aggregate_sep,
-                       array_delim, array_sep, (float*)data);
+        return sprintt(type, fmt.float_fmt, fmt, (const float*)data);
     case TypeDesc::DOUBLE:
-        return sprintt(type, float_fmt, aggregate_delim, aggregate_sep,
-                       array_delim, array_sep, (double*)data);
+        return sprintt(type, fmt.float_fmt, fmt, (const double*)data);
     case TypeDesc::STRING:
-        return sprintt(type, string_fmt, aggregate_delim, aggregate_sep,
-                       array_delim, array_sep, (char**)data);
-    case TypeDesc::PTR:
-        return sprintt(type, "%p", aggregate_delim, aggregate_sep, array_delim,
-                       array_sep, (void**)data);
-    default: return "";
+        if (!type.is_array()
+            && !(fmt.flags & tostring_formatting::quote_single_string))
+            return *(const char**)data;
+        return sprintt(type, fmt.string_fmt, fmt, (const char**)data);
+    case TypeDesc::PTR: return sprintt(type, fmt.ptr_fmt, fmt, (void**)data);
+    default:
+#ifndef NDEBUG
+        return Strutil::sprintf("<unknown data type> (base %d, agg %d vec %d)",
+                                type.basetype, type.aggregate,
+                                type.vecsemantics);
+#endif
+        break;
     }
+    return "";
+}
+
+
+
+// Old deprecated one
+std::string
+tostring(TypeDesc type, const void* data, const char* float_fmt,
+         const char* string_fmt, const char aggregate_delim[2],
+         const char* aggregate_sep, const char array_delim[2],
+         const char* array_sep)
+{
+    tostring_formatting fmt("%d", float_fmt, string_fmt, "%p",
+                            std::string(aggregate_delim + 0, 1).c_str(),
+                            std::string(aggregate_delim + 1, 1).c_str(),
+                            aggregate_sep,
+                            std::string(array_delim + 0, 1).c_str(),
+                            std::string(array_delim + 1, 1).c_str(), array_sep);
+    return tostring(type, data, fmt);
+}
+
+
+
+namespace {
+
+template<typename T = int>
+static bool
+to_ints(TypeDesc srctype, const void* src, T* dst, size_t n = 1)
+{
+    if (srctype.basetype == TypeDesc::UINT) {
+        for (size_t i = 0; i < n; ++i)
+            dst[i] = T(((const unsigned int*)src)[i]);
+        return true;
+    }
+    if (srctype.basetype == TypeDesc::INT16) {
+        for (size_t i = 0; i < n; ++i)
+            dst[i] = T(((const short*)src)[i]);
+        return true;
+    }
+    if (srctype.basetype == TypeDesc::UINT16) {
+        for (size_t i = 0; i < n; ++i)
+            dst[i] = T(((const unsigned short*)src)[i]);
+        return true;
+    }
+    if (srctype.basetype == TypeDesc::INT8) {
+        for (size_t i = 0; i < n; ++i)
+            dst[i] = T(((const char*)src)[i]);
+        return true;
+    }
+    if (srctype.basetype == TypeDesc::UINT8) {
+        for (size_t i = 0; i < n; ++i)
+            dst[i] = T(((const unsigned char*)src)[i]);
+        return true;
+    }
+    if (srctype.basetype == TypeDesc::INT64) {
+        for (size_t i = 0; i < n; ++i)
+            dst[i] = T(((const long long*)src)[i]);
+        return true;
+    }
+    if (srctype.basetype == TypeDesc::UINT64) {
+        for (size_t i = 0; i < n; ++i)
+            dst[i] = T(((const unsigned long long*)src)[i]);
+        return true;
+    }
+    return false;
+}
+
+
+template<typename T = float>
+static bool
+to_floats(TypeDesc srctype, const void* src, T* dst, size_t n = 1)
+{
+    if (srctype.basetype == TypeDesc::FLOAT) {
+        for (size_t i = 0; i < n; ++i)
+            dst[i] = T(((const float*)src)[i]);
+        return true;
+    }
+    if (srctype.basetype == TypeDesc::HALF) {
+        for (size_t i = 0; i < n; ++i)
+            dst[i] = T(((const half*)src)[i]);
+        return true;
+    }
+    if (srctype.basetype == TypeDesc::DOUBLE) {
+        for (size_t i = 0; i < n; ++i)
+            dst[i] = T(((const double*)src)[i]);
+        return true;
+    }
+    if (srctype.basetype == TypeDesc::UINT) {
+        for (size_t i = 0; i < n; ++i)
+            dst[i] = T(((const unsigned int*)src)[i]);
+        return true;
+    }
+    if (srctype.basetype == TypeDesc::INT16) {
+        for (size_t i = 0; i < n; ++i)
+            dst[i] = T(((const short*)src)[i]);
+        return true;
+    }
+    if (srctype.basetype == TypeDesc::UINT16) {
+        for (size_t i = 0; i < n; ++i)
+            dst[i] = T(((const unsigned short*)src)[i]);
+        return true;
+    }
+    if (srctype.basetype == TypeDesc::INT8) {
+        for (size_t i = 0; i < n; ++i)
+            dst[i] = T(((const char*)src)[i]);
+        return true;
+    }
+    if (srctype.basetype == TypeDesc::UINT8) {
+        for (size_t i = 0; i < n; ++i)
+            dst[i] = T(((const unsigned char*)src)[i]);
+        return true;
+    }
+    if (srctype.basetype == TypeDesc::INT64) {
+        for (size_t i = 0; i < n; ++i)
+            dst[i] = T(((const long long*)src)[i]);
+        return true;
+    }
+    if (srctype.basetype == TypeDesc::UINT64) {
+        for (size_t i = 0; i < n; ++i)
+            dst[i] = T(((const unsigned long long*)src)[i]);
+        return true;
+    }
+    return false;
+}
+
+}  // namespace
+
+
+
+bool
+convert_type(TypeDesc srctype, const void* src, TypeDesc dsttype, void* dst)
+{
+    if (srctype.basetype == dsttype.basetype
+        && srctype.basevalues() == dsttype.basevalues()) {
+        size_t size = srctype.size();
+        memcpy(dst, src, size);
+        return size;
+    }
+
+    if (dsttype == TypeString) {
+        (*(ustring*)dst) = ustring(tostring(srctype, src));
+        return true;
+    }
+
+    if (dsttype.basetype == TypeDesc::INT
+        && dsttype.basevalues() == srctype.basevalues()) {
+        if (to_ints<int>(srctype, src, (int*)dst, dsttype.basevalues()))
+            return true;
+    }
+    if (dsttype == TypeInt && srctype == TypeString) {
+        // Only succeed for a string if it exactly holds something that
+        // excatly parses to an int value.
+        string_view str(((const char**)src)[0]);
+        int val = 0;
+        if (Strutil::parse_int(str, val) && str.empty()) {
+            ((int*)dst)[0] = val;
+            return true;
+        }
+    }
+    if (dsttype.basetype == TypeDesc::UINT
+        && dsttype.basevalues() == srctype.basevalues()) {
+        if (to_ints<uint32_t>(srctype, src, (uint32_t*)dst,
+                              dsttype.basevalues()))
+            return true;
+    }
+    // N.B. No uint inversion from string
+
+    if (dsttype.basetype == TypeDesc::FLOAT
+        && dsttype.basevalues() == srctype.basevalues()) {
+        if (to_floats<float>(srctype, src, (float*)dst, dsttype.basevalues()))
+            return true;
+    }
+    if (dsttype == TypeFloat && srctype == TypeRational) {
+        int num          = ((const int*)src)[0];
+        int den          = ((const int*)src)[1];
+        ((float*)dst)[0] = den ? float(num) / float(den) : 0.0f;
+        return true;
+    }
+    if (dsttype == TypeFloat && srctype == TypeString) {
+        // Only succeed for a string if it exactly holds something that
+        // excatly parses to a float value.
+        string_view str(((const char**)src)[0]);
+        float val = 0;
+        if (Strutil::parse_float(str, val) && str.empty()) {
+            ((float*)dst)[0] = val;
+            return true;
+        }
+    }
+
+    if (dsttype.basetype == TypeDesc::DOUBLE
+        && dsttype.basevalues() == srctype.basevalues()) {
+        if (to_floats<double>(srctype, src, (double*)dst, dsttype.basevalues()))
+            return true;
+    }
+    return false;
 }
 
 

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -283,7 +283,19 @@ declare_imagespec(py::module& m)
         .def("from_xml", &ImageSpec::from_xml)
         .def("valid_tile_range", &ImageSpec::valid_tile_range, "xbegin"_a,
              "xend"_a, "ybegin"_a, "yend"_a, "zbegin"_a, "zend"_a)
-        .def("copy_dimensions", &ImageSpec::copy_dimensions, "other"_a);
+        .def("copy_dimensions", &ImageSpec::copy_dimensions, "other"_a)
+        .def("__getitem__",
+             [](const ImageSpec& self, const std::string& key) {
+                 ParamValue tmpparam;
+                 auto p = self.find_attribute(key, tmpparam);
+                 if (p == nullptr)
+                     throw py::key_error("key '" + key + "' does not exist");
+                 return ParamValue_getitem(*p);
+             })
+        .def("__setitem__",
+             [](ImageSpec& self, const std::string& key, py::object val) {
+                 delegate_setitem(self, key, val);
+             });
 }
 
 }  // namespace PyOpenImageIO

--- a/testsuite/dup-channels/ref/out.txt
+++ b/testsuite/dup-channels/ref/out.txt
@@ -4,7 +4,7 @@ out.exr              :   64 x   64, 6 channel, half openexr
     channel list: R, G, B, channel3, channel4, channel5
     compression: "zip"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Reading out2.exr
@@ -14,7 +14,7 @@ out2.exr             :   64 x   64, 6 channel, half openexr
     compression: "zip"
     name: "Aimg"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
     oiio:subimagename: "Aimg"

--- a/testsuite/field3d/ref/out.txt
+++ b/testsuite/field3d/ref/out.txt
@@ -6,11 +6,11 @@ Reading ../texture-field3d/src/dense_float.f3d
     field_type: 0
     ImageDescription: "sphere:density"
     storage_type: 2
-    worldtocamera: 0.5 0 0 0 0 0.5 0 0 0 0 0.5 0 0.5 0.5 0.5 1
-    worldtolocal: 0.5 0 0 0 0 0.5 0 0 0 0 0.5 0 0.5 0.5 0.5 1
+    worldtocamera: 0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.5, 0, 0.5, 0.5, 0.5, 1
+    worldtolocal: 0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.5, 0, 0.5, 0.5, 0.5, 1
     field3d:fieldtype: "DenseField"
     field3d:layer: "density"
-    field3d:localtoworld: 2 0 0 0 0 2 0 0 0 0 2 0 -1 -1 -1 1
+    field3d:localtoworld: 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, -1, -1, -1, 1
     field3d:mapping: "MatrixFieldMapping"
     field3d:partition: "sphere"
     oiio:subimagename: "sphere:density"
@@ -24,11 +24,11 @@ Reading ../texture-field3d/src/sparse_float.f3d
     field_type: 1
     ImageDescription: "sphere:density"
     storage_type: 2
-    worldtocamera: 0.5 0 0 0 0 0.5 0 0 0 0 0.5 0 0.5 0.5 0.5 1
-    worldtolocal: 0.5 0 0 0 0 0.5 0 0 0 0 0.5 0 0.5 0.5 0.5 1
+    worldtocamera: 0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.5, 0, 0.5, 0.5, 0.5, 1
+    worldtolocal: 0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.5, 0, 0.5, 0.5, 0.5, 1
     field3d:fieldtype: "SparseField"
     field3d:layer: "density"
-    field3d:localtoworld: 2 0 0 0 0 2 0 0 0 0 2 0 -1 -1 -1 1
+    field3d:localtoworld: 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, -1, -1, -1, 1
     field3d:mapping: "MatrixFieldMapping"
     field3d:partition: "sphere"
     oiio:subimagename: "sphere:density"
@@ -42,11 +42,11 @@ Reading ../texture-field3d/src/dense_half.f3d
     field_type: 0
     ImageDescription: "sphere:density"
     storage_type: 1
-    worldtocamera: 0.5 0 0 0 0 0.5 0 0 0 0 0.5 0 0.5 0.5 0.5 1
-    worldtolocal: 0.5 0 0 0 0 0.5 0 0 0 0 0.5 0 0.5 0.5 0.5 1
+    worldtocamera: 0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.5, 0, 0.5, 0.5, 0.5, 1
+    worldtolocal: 0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.5, 0, 0.5, 0.5, 0.5, 1
     field3d:fieldtype: "DenseField"
     field3d:layer: "density"
-    field3d:localtoworld: 2 0 0 0 0 2 0 0 0 0 2 0 -1 -1 -1 1
+    field3d:localtoworld: 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, -1, -1, -1, 1
     field3d:mapping: "MatrixFieldMapping"
     field3d:partition: "sphere"
     oiio:subimagename: "sphere:density"
@@ -60,11 +60,11 @@ Reading ../texture-field3d/src/sparse_half.f3d
     field_type: 1
     ImageDescription: "sphere:density"
     storage_type: 1
-    worldtocamera: 0.5 0 0 0 0 0.5 0 0 0 0 0.5 0 0.5 0.5 0.5 1
-    worldtolocal: 0.5 0 0 0 0 0.5 0 0 0 0 0.5 0 0.5 0.5 0.5 1
+    worldtocamera: 0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.5, 0, 0.5, 0.5, 0.5, 1
+    worldtolocal: 0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.5, 0, 0.5, 0.5, 0.5, 1
     field3d:fieldtype: "SparseField"
     field3d:layer: "density"
-    field3d:localtoworld: 2 0 0 0 0 2 0 0 0 0 2 0 -1 -1 -1 1
+    field3d:localtoworld: 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, -1, -1, -1, 1
     field3d:mapping: "MatrixFieldMapping"
     field3d:partition: "sphere"
     oiio:subimagename: "sphere:density"

--- a/testsuite/maketx/ref/out.txt
+++ b/testsuite/maketx/ref/out.txt
@@ -180,8 +180,8 @@ checker-camera.tx    :  128 x  128, 4 channel, uint8 tiff
     Orientation: 1 (normal)
     planarconfig: "contig"
     textureformat: "Plain Texture"
-    worldtocamera: 1 0 0 0 0 2 0 0 0 0 1 0 0 0 0 1
-    worldtoscreen: 3 0 0 0 0 3 0 0 0 0 3 0 1 2 3 1
+    worldtocamera: 1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1
+    worldtoscreen: 3, 0, 0, 0, 0, 3, 0, 0, 0, 0, 3, 0, 1, 2, 3, 1
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
     oiio:BitsPerSample: 8
@@ -271,7 +271,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     compression: "zip"
     fovcot: 1
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -298,7 +298,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     fovcot: 1
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -388,7 +388,7 @@ bumpslope.exr        :   64 x   64, 6 channel, half openexr
     compression: "zip"
     fovcot: 1
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "black,black"

--- a/testsuite/oiiotool-fixnan/ref/out.txt
+++ b/testsuite/oiiotool-fixnan/ref/out.txt
@@ -4,7 +4,7 @@ src/bad.exr          :   64 x   64, 3 channel, half openexr
     channel list: R, G, B
     compression: "zip"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
     Stats Min: 0.000000 0.000000 0.000000 (float)
@@ -22,7 +22,7 @@ black.exr            :   64 x   64, 3 channel, half openexr
     channel list: R, G, B
     compression: "zip"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
     Stats Min: 0.000000 0.000000 0.000000 (float)
@@ -40,7 +40,7 @@ box3.exr             :   64 x   64, 3 channel, half openexr
     channel list: R, G, B
     compression: "zip"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
     Stats Min: 0.000000 0.000000 0.000000 (float)

--- a/testsuite/oiiotool-maketx/ref/out-rhel7.txt
+++ b/testsuite/oiiotool-maketx/ref/out-rhel7.txt
@@ -180,8 +180,8 @@ checker-camera.tx    :  128 x  128, 4 channel, uint8 tiff
     Orientation: 1 (normal)
     planarconfig: "contig"
     textureformat: "Plain Texture"
-    worldtocamera: 1 0 0 0 0 2 0 0 0 0 1 0 0 0 0 1
-    worldtoscreen: 3 0 0 0 0 3 0 0 0 0 3 0 1 2 3 1
+    worldtocamera: 1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1
+    worldtoscreen: 3, 0, 0, 0, 0, 3, 0, 0, 0, 0, 3, 0, 1, 2, 3, 1
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
     oiio:BitsPerSample: 8
@@ -271,7 +271,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     compression: "zip"
     fovcot: 1
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -298,7 +298,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     fovcot: 1
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "black,black"

--- a/testsuite/oiiotool-maketx/ref/out.txt
+++ b/testsuite/oiiotool-maketx/ref/out.txt
@@ -180,8 +180,8 @@ checker-camera.tx    :  128 x  128, 4 channel, uint8 tiff
     Orientation: 1 (normal)
     planarconfig: "contig"
     textureformat: "Plain Texture"
-    worldtocamera: 1 0 0 0 0 2 0 0 0 0 1 0 0 0 0 1
-    worldtoscreen: 3 0 0 0 0 3 0 0 0 0 3 0 1 2 3 1
+    worldtocamera: 1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1
+    worldtoscreen: 3, 0, 0, 0, 0, 3, 0, 0, 0, 0, 3, 0, 1, 2, 3, 1
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
     oiio:BitsPerSample: 8
@@ -271,7 +271,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     compression: "zip"
     fovcot: 1
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "black,black"
@@ -298,7 +298,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     fovcot: 1
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "black,black"

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -14,7 +14,7 @@ chname.exr           :   38 x   38, 5 channel, float openexr
     nuke/node_hash: ""
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Reading allhalf.exr
@@ -27,7 +27,7 @@ allhalf.exr          :   38 x   38, 5 channel, half openexr
     nuke/node_hash: ""
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Reading rgbahalf-zfloat.exr
@@ -40,7 +40,7 @@ rgbahalf-zfloat.exr  :   38 x   38, 5 channel, half/half/half/half/float openexr
     nuke/node_hash: ""
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 copyA.0001.jpg       :  128 x   96, 3 channel, uint8 jpeg
@@ -86,7 +86,7 @@ add_rgb_rgba.exr     :   64 x   64, 4 channel, float openexr
     channel list: R, G, B, A
     compression: "zip"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Comparing "filled.tif" and "ref/filled.tif"

--- a/testsuite/openexr-chroma/ref/out.txt
+++ b/testsuite/openexr-chroma/ref/out.txt
@@ -6,7 +6,7 @@ Reading ../../../../../openexr-images/LuminanceChroma/Garden.exr
     compression: "piz"
     Copyright: "Copyright 2004 Industrial Light & Magic"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/LuminanceChroma/Garden.exr" and "Garden.exr"

--- a/testsuite/openexr-multires/ref/out.txt
+++ b/testsuite/openexr-multires/ref/out.txt
@@ -8,7 +8,7 @@ Reading ../../../../../openexr-images/MultiResolution/Bonita.exr
     Copyright: "Copyright 2004 Industrial Light & Magic"
     ImageDescription: "Point Bonita, Marin County, California"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "clamp,clamp"
@@ -26,7 +26,7 @@ Reading ../../../../../openexr-images/MultiResolution/ColorCodedLevels.exr
     Copyright: "Copyright 2005 Industrial Light & Magic"
     ImageDescription: "a mip-map image with color-coded levels"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "periodic,periodic"
@@ -45,7 +45,7 @@ Reading ../../../../../openexr-images/MultiResolution/KernerEnvCube.exr
     compression: "zip"
     Copyright: "Copyright 2005 Industrial Light & Magic"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "CubeFace Environment"
     oiio:ColorSpace: "Linear"
@@ -62,7 +62,7 @@ Reading ../../../../../openexr-images/MultiResolution/KernerEnvLatLong.exr
     compression: "zip"
     Copyright: "Copyright 2005 Industrial Light & Magic"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "LatLong Environment"
     oiio:ColorSpace: "Linear"
@@ -80,7 +80,7 @@ Reading ../../../../../openexr-images/MultiResolution/MirrorPattern.exr
     compression: "zip"
     Copyright: "Copyright 2004 Industrial Light & Magic"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "mirror,mirror"
@@ -99,7 +99,7 @@ Reading ../../../../../openexr-images/MultiResolution/OrientationCube.exr
     compression: "zip"
     Copyright: "Copyright 2005 Industrial Light & Magic"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "CubeFace Environment"
     oiio:ColorSpace: "Linear"
@@ -116,7 +116,7 @@ Reading ../../../../../openexr-images/MultiResolution/OrientationLatLong.exr
     compression: "zip"
     Copyright: "Copyright 2005 Industrial Light & Magic"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "LatLong Environment"
     oiio:ColorSpace: "Linear"
@@ -134,7 +134,7 @@ Reading ../../../../../openexr-images/MultiResolution/PeriodicPattern.exr
     compression: "zip"
     Copyright: "Copyright 2004 Industrial Light & Magic"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
     wrapmodes: "periodic,periodic"
@@ -153,7 +153,7 @@ Reading ../../../../../openexr-images/MultiResolution/StageEnvCube.exr
     compression: "zip"
     Copyright: "Copyright 2004 Industrial Light & Magic"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "CubeFace Environment"
     oiio:ColorSpace: "Linear"
@@ -170,7 +170,7 @@ Reading ../../../../../openexr-images/MultiResolution/StageEnvLatLong.exr
     compression: "zip"
     Copyright: "Copyright 2004 Industrial Light & Magic"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "LatLong Environment"
     oiio:ColorSpace: "Linear"
@@ -190,7 +190,7 @@ Reading ../../../../../openexr-images/MultiResolution/WavyLinesCube.exr
     compression: "zip"
     Copyright: "Copyright 2005 Industrial Light & Magic"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "CubeFace Environment"
     oiio:ColorSpace: "Linear"
@@ -207,7 +207,7 @@ Reading ../../../../../openexr-images/MultiResolution/WavyLinesLatLong.exr
     compression: "zip"
     Copyright: "Copyright 2005 Industrial Light & Magic"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "LatLong Environment"
     oiio:ColorSpace: "Linear"
@@ -223,7 +223,7 @@ Reading ../../../../../openexr-images/MultiResolution/WavyLinesSphere.exr
     compression: "piz"
     Copyright: "Copyright 2005 Industrial Light & Magic"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/MultiResolution/WavyLinesSphere.exr" and "WavyLinesSphere.exr"

--- a/testsuite/openexr-suite/ref/out.txt
+++ b/testsuite/openexr-suite/ref/out.txt
@@ -4,7 +4,7 @@ Reading ../../../../../openexr-images/ScanLines/Desk.exr
     channel list: R, G, B, A
     compression: "piz"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/ScanLines/Desk.exr" and "Desk.exr"
@@ -21,7 +21,7 @@ Reading ../../../../../openexr-images/ScanLines/MtTamWest.exr
     latitude: 37.929
     longitude: -122.579
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     utcOffset: 25200
     oiio:ColorSpace: "Linear"
@@ -34,7 +34,7 @@ Reading ../../../../../openexr-images/ScanLines/Cannon.exr
     compression: "b44"
     Copyright: "Copyright 2006 Industrial Light & Magic"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/ScanLines/Cannon.exr" and "Cannon.exr"
@@ -47,7 +47,7 @@ Reading ../../../../../openexr-images/ScanLines/StillLife.exr
     Copyright: "Copyright 2002 Industrial Light & Magic"
     DateTime: "2002:06:23 21:30:10"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 0.45
     utcOffset: 25200
     oiio:ColorSpace: "Linear"
@@ -63,7 +63,7 @@ Reading ../../../../../openexr-images/ScanLines/Tree.exr
     DateTime: "2002:06:23 15:00:00"
     focus: 3.5
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 0.48
     utcOffset: 25200
     whiteLuminance: 621
@@ -82,7 +82,7 @@ Reading ../../../../../openexr-images/ScanLines/Blobbies.exr
     Copyright: "Copyright 2004 Industrial Light & Magic"
     DateTime: "2004:01:19 12:55:33"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     utcOffset: 28800
     whiteLuminance: 50
@@ -95,7 +95,7 @@ Reading ../../../../../openexr-images/TestImages/AllHalfValues.exr
     channel list: R, G, B
     compression: "piz"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/AllHalfValues.exr" and "AllHalfValues.exr"
@@ -106,7 +106,7 @@ Reading ../../../../../openexr-images/TestImages/BrightRings.exr
     channel list: R, G, B
     compression: "zip"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/BrightRings.exr" and "BrightRings.exr"
@@ -117,7 +117,7 @@ Reading ../../../../../openexr-images/TestImages/BrightRingsNanInf.exr
     channel list: R, G, B
     compression: "zip"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/BrightRingsNanInf.exr" and "BrightRingsNanInf.exr"
@@ -128,7 +128,7 @@ Reading ../../../../../openexr-images/TestImages/GammaChart.exr
     channel list: R, G, B
     compression: "pxr24"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/GammaChart.exr" and "GammaChart.exr"
@@ -139,7 +139,7 @@ Reading ../../../../../openexr-images/TestImages/GrayRampsDiagonal.exr
     channel list: Y
     compression: "pxr24"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/GrayRampsDiagonal.exr" and "GrayRampsDiagonal.exr"
@@ -150,7 +150,7 @@ Reading ../../../../../openexr-images/TestImages/GrayRampsHorizontal.exr
     channel list: Y
     compression: "pxr24"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/GrayRampsHorizontal.exr" and "GrayRampsHorizontal.exr"
@@ -161,7 +161,7 @@ Reading ../../../../../openexr-images/TestImages/RgbRampsDiagonal.exr
     channel list: R, G, B
     compression: "pxr24"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/RgbRampsDiagonal.exr" and "RgbRampsDiagonal.exr"
@@ -172,7 +172,7 @@ Reading ../../../../../openexr-images/TestImages/SquaresSwirls.exr
     channel list: R, G, B
     compression: "pxr24"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/SquaresSwirls.exr" and "SquaresSwirls.exr"
@@ -184,7 +184,7 @@ Reading ../../../../../openexr-images/TestImages/WideColorGamut.exr
     chromaticities: 0.64, 0.33, 0.3, 0.6, 0.15, 0.06, 0.3127, 0.329
     compression: "zip"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/WideColorGamut.exr" and "WideColorGamut.exr"
@@ -195,7 +195,7 @@ Reading ../../../../../openexr-images/TestImages/WideFloatRange.exr
     channel list: G
     compression: "pxr24"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/TestImages/WideFloatRange.exr" and "WideFloatRange.exr"
@@ -217,7 +217,7 @@ Reading ../../../../../openexr-images/Tiles/GoldenGate.exr
     latitude: 37.8277
     longitude: -122.5
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1.15
     utcOffset: 28800
     oiio:ColorSpace: "Linear"
@@ -232,7 +232,7 @@ Reading ../../../../../openexr-images/Tiles/Ocean.exr
     Copyright: "Copyright 2004 Industrial Light & Magic"
     focus: inf
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
 Comparing "../../../../../openexr-images/Tiles/Ocean.exr" and "Ocean.exr"
@@ -250,7 +250,7 @@ Reading ../../../../../openexr-images/Tiles/Spirals.exr
     Copyright: "Copyright 2004 Industrial Light & Magic"
     DateTime: "2004:01:19 10:25:14"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     utcOffset: 28800
     whiteLuminance: 90

--- a/testsuite/openexr-v2/ref/out.txt
+++ b/testsuite/openexr-v2/ref/out.txt
@@ -12,7 +12,7 @@ Reading ../../../../../openexr-images/v2/Stereo/composited.exr
     name: "rgba.left"
     nuke/node_hash: "b4ea9f917764b762"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "left"
     oiio:ColorSpace: "Linear"
@@ -28,7 +28,7 @@ Reading ../../../../../openexr-images/v2/Stereo/composited.exr
     Copyright: "Copyright 2012 Weta Digital Ltd"
     name: "depth.left"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "left"
     oiio:ColorSpace: "Linear"
@@ -44,7 +44,7 @@ Reading ../../../../../openexr-images/v2/Stereo/composited.exr
     Copyright: "Copyright 2012 Weta Digital Ltd"
     name: "rgba.right"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "right"
     oiio:ColorSpace: "Linear"
@@ -60,7 +60,7 @@ Reading ../../../../../openexr-images/v2/Stereo/composited.exr
     Copyright: "Copyright 2012 Weta Digital Ltd"
     name: "depth.right"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "right"
     oiio:ColorSpace: "Linear"
@@ -91,7 +91,7 @@ Reading ../../../../../openexr-images/v2/Stereo/Balls.exr
     Copyright: "Copyright 2012 Weta Digital Ltd"
     name: "rgba.left"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "left"
     oiio:ColorSpace: "Linear"
@@ -108,7 +108,7 @@ Reading ../../../../../openexr-images/v2/Stereo/Balls.exr
     Copyright: "Copyright 2012 Weta Digital Ltd"
     name: "rgba.right"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "right"
     oiio:ColorSpace: "Linear"
@@ -148,7 +148,7 @@ Reading ../../../../../openexr-images/v2/Stereo/Leaves.exr
     Copyright: "Copyright 2012 Weta Digital Ltd"
     name: "rgba.left"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "left"
     oiio:ColorSpace: "Linear"
@@ -162,7 +162,7 @@ Reading ../../../../../openexr-images/v2/Stereo/Leaves.exr
     Copyright: "Copyright 2012 Weta Digital Ltd"
     name: "rgba.right"
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     view: "right"
     oiio:ColorSpace: "Linear"

--- a/testsuite/python-imagespec/ref/out-python3.txt
+++ b/testsuite/python-imagespec/ref/out-python3.txt
@@ -87,8 +87,11 @@ getattribute('foo_str') retrieves blah
 getattribute('foo_vector') retrieves (1.0, 0.0, 11.0)
 getattribute('foo_matrix') retrieves (1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0, 1.0)
 getattribute('foo_no') retrieves None
+s['delfoo_float'] = 99.5
+s['delfoo_int'] = 29
+s['delfoo_str'] = egg
 
-extra_attribs size is 5
+extra_attribs size is 8
 0 foo_str string blah
 "blah"
 1 foo_int int 14
@@ -96,9 +99,15 @@ extra_attribs size is 5
 2 foo_float float 3.140000104904175
 3.14
 3 foo_vector vector (1.0, 0.0, 11.0)
-1 0 11
+1, 0, 11
 4 foo_matrix matrix (1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0, 1.0)
-1 0 0 0 0 2 0 0 0 0 1 0 1 2 3 1
+1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1
+5 delfoo_str string egg
+"egg"
+6 delfoo_int int 29
+29
+7 delfoo_float float 99.5
+99.5
 
 seralize(xml):
 <ImageSpec version="22">
@@ -132,8 +141,11 @@ seralize(xml):
 <attrib name="foo_str" type="string">blah</attrib>
 <attrib name="foo_int" type="int">14</attrib>
 <attrib name="foo_float" type="float">3.14</attrib>
-<attrib name="foo_vector" type="vector">1 0 11</attrib>
-<attrib name="foo_matrix" type="matrix">1 0 0 0 0 2 0 0 0 0 1 0 1 2 3 1</attrib>
+<attrib name="foo_vector" type="vector">1, 0, 11</attrib>
+<attrib name="foo_matrix" type="matrix">1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1</attrib>
+<attrib name="delfoo_str" type="string">egg</attrib>
+<attrib name="delfoo_int" type="int">29</attrib>
+<attrib name="delfoo_float" type="float">99.5</attrib>
 </ImageSpec>
 
 serialize(text, human):
@@ -143,11 +155,14 @@ serialize(text, human):
     full/display size: 1280 x 960
     full/display origin: 4, 5
     tile size: 32 x 64
+    delfoo_float: 99.5
+    delfoo_int: 29
+    delfoo_str: "egg"
     foo_float: 3.14
     foo_int: 14
-    foo_matrix: 1 0 0 0 0 2 0 0 0 0 1 0 1 2 3 1
+    foo_matrix: 1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1
     foo_str: "blah"
-    foo_vector: 1 0 11
+    foo_vector: 1, 0, 11
 
 Testing construction from ROI:
   resolution (width,height,depth) =  640 480 1

--- a/testsuite/python-imagespec/ref/out.txt
+++ b/testsuite/python-imagespec/ref/out.txt
@@ -87,8 +87,11 @@ getattribute('foo_str') retrieves blah
 getattribute('foo_vector') retrieves (1.0, 0.0, 11.0)
 getattribute('foo_matrix') retrieves (1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0, 1.0)
 getattribute('foo_no') retrieves None
+s['delfoo_float'] = 99.5
+s['delfoo_int'] = 29
+s['delfoo_str'] = egg
 
-extra_attribs size is 5
+extra_attribs size is 8
 0 foo_str string blah
 "blah"
 1 foo_int int 14
@@ -96,9 +99,15 @@ extra_attribs size is 5
 2 foo_float float 3.1400001049
 3.14
 3 foo_vector vector (1.0, 0.0, 11.0)
-1 0 11
+1, 0, 11
 4 foo_matrix matrix (1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0, 1.0)
-1 0 0 0 0 2 0 0 0 0 1 0 1 2 3 1
+1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1
+5 delfoo_str string egg
+"egg"
+6 delfoo_int int 29
+29
+7 delfoo_float float 99.5
+99.5
 
 seralize(xml):
 <ImageSpec version="22">
@@ -132,8 +141,11 @@ seralize(xml):
 <attrib name="foo_str" type="string">blah</attrib>
 <attrib name="foo_int" type="int">14</attrib>
 <attrib name="foo_float" type="float">3.14</attrib>
-<attrib name="foo_vector" type="vector">1 0 11</attrib>
-<attrib name="foo_matrix" type="matrix">1 0 0 0 0 2 0 0 0 0 1 0 1 2 3 1</attrib>
+<attrib name="foo_vector" type="vector">1, 0, 11</attrib>
+<attrib name="foo_matrix" type="matrix">1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1</attrib>
+<attrib name="delfoo_str" type="string">egg</attrib>
+<attrib name="delfoo_int" type="int">29</attrib>
+<attrib name="delfoo_float" type="float">99.5</attrib>
 </ImageSpec>
 
 serialize(text, human):
@@ -143,11 +155,14 @@ serialize(text, human):
     full/display size: 1280 x 960
     full/display origin: 4, 5
     tile size: 32 x 64
+    delfoo_float: 99.5
+    delfoo_int: 29
+    delfoo_str: "egg"
     foo_float: 3.14
     foo_int: 14
-    foo_matrix: 1 0 0 0 0 2 0 0 0 0 1 0 1 2 3 1
+    foo_matrix: 1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1
     foo_str: "blah"
-    foo_vector: 1 0 11
+    foo_vector: 1, 0, 11
 
 Testing construction from ROI:
   resolution (width,height,depth) =  640 480 1

--- a/testsuite/python-imagespec/src/test_imagespec.py
+++ b/testsuite/python-imagespec/src/test_imagespec.py
@@ -89,6 +89,9 @@ try:
     s.attribute ("foo_vector", oiio.TypeDesc.TypeVector, (1, 0, 11))
     s.attribute ("foo_matrix", oiio.TypeDesc.TypeMatrix,
                  (1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1))
+    s["delfoo_str"] =  "egg"
+    s["delfoo_int"] = 29
+    s["delfoo_float"] = 99.5
     print ("get_int_attribute('foo_int') retrieves", s.get_int_attribute ("foo_int"))
     print ("get_int_attribute('foo_int',21) with default retrieves", s.get_int_attribute ("foo_int", 21))
     print ("get_int_attribute('foo_no',23) retrieves", s.get_int_attribute ("foo_no", 23))
@@ -105,6 +108,9 @@ try:
     print ("getattribute('foo_vector') retrieves", s.getattribute("foo_vector"))
     print ("getattribute('foo_matrix') retrieves", s.getattribute("foo_matrix"))
     print ("getattribute('foo_no') retrieves", s.getattribute("foo_no"))
+    print ("s['delfoo_float'] =", s['delfoo_float'])
+    print ("s['delfoo_int'] =", s['delfoo_int'])
+    print ("s['delfoo_str'] =", s['delfoo_str'])
     print ()
 
     print ("extra_attribs size is", len(s.extra_attribs))

--- a/testsuite/python-paramlist/ref/out.txt
+++ b/testsuite/python-paramlist/ref/out.txt
@@ -1,0 +1,21 @@
+pl length is 6
+  item i int 1
+  item s string Bob
+  item e float 2.71828174591
+  item j int 42
+  item foo string bar
+  item pi float 3.14159274101
+pl.contains('e') = True
+pl.contains('f') = False
+pl[1] = s string Bob
+pl['e'] = 2.71828174591
+pl['pi'] = 3.14159274101
+pl['foo'] = bar
+after removing 'e', len= 5 pl.contains('e')= False
+after sorting:
+  item foo string bar
+  item i int 1
+  item j int 42
+  item pi float 3.14159274101
+  item s string Bob
+Done.

--- a/testsuite/python-paramlist/run.py
+++ b/testsuite/python-paramlist/run.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python 
+
+command += pythonbin + " src/test_paramlist.py > out.txt"
+

--- a/testsuite/python-paramlist/src/test_paramlist.py
+++ b/testsuite/python-paramlist/src/test_paramlist.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import OpenImageIO as oiio
+
+
+
+
+
+######################################################################
+# main test starts here
+
+try:
+    pl = oiio.ParamValueList()
+    pl.attribute ("i", 1)
+    pl.attribute ("s", "Bob")
+    pl.attribute ("e", 2.718281828459045)
+    pl["j"] = 42
+    pl["foo"] = "bar"
+    pl["pi"] = 3.141592653589793
+
+    print ("pl length is", len(pl))
+    for p in pl :
+        print ("  item", p.name, p.type, p.value)
+
+    print ("pl.contains('e') =", pl.contains('e'))
+    print ("pl.contains('f') =", pl.contains('f'))
+    print ("pl[1] =", pl[1].name, pl[1].type, pl[1].value)
+    print ("pl['e'] =", pl['e'])
+    print ("pl['pi'] =", pl['pi'])
+    print ("pl['foo'] =", pl['foo'])
+
+    pl.remove('e')
+    print ("after removing 'e', len=", len(pl), "pl.contains('e')=", pl.contains('e'))
+
+    pl.sort()
+    print ("after sorting:")
+    for p in pl :
+        print ("  item", p.name, p.type, p.value)
+
+    print ("Done.")
+except Exception as detail:
+    print ("Unknown exception:", detail)
+

--- a/testsuite/rational/ref/out.txt
+++ b/testsuite/rational/ref/out.txt
@@ -3,7 +3,7 @@ src/test.exr         :   64 x   64, 3 channel, half openexr
     SHA-1: 8B72B6EA35D9E5CFBD3AAE08D7204FBEF3895FAA
     channel list: R, G, B
     acesImageContainerFlag: 1
-    adoptedNeutral: 0.32168 0.33767
+    adoptedNeutral: 0.32168, 0.33767
     cameraFirmwareVersion: "23192"
     cameraIdentifier: "ARRI-Alexa_EV-SN_R23J"
     cameraLabel: "A"
@@ -30,7 +30,7 @@ src/test.exr         :   64 x   64, 3 channel, half openexr
     com.arri.camera.TimeBase: 24
     com.arri.camera.UnitPref: "Metric"
     com.arri.camera.Variframe: 0
-    com.arri.camera.WbFactor: 1.68334 1 1.42
+    com.arri.camera.WbFactor: 1.68334, 1, 1.42
     com.arri.camera.WbTintCc: -1
     compression: "none"
     DateTime: "2000-01-01 01:00:17"
@@ -57,7 +57,7 @@ src/test.exr         :   64 x   64, 3 channel, half openexr
     recorderModel: "Outboard"
     recorderSerialNumber: "1093"
     reelName: "A004R23J"
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     Software: "OpenImageIO 1.8.5dev : oiiotool cropped-stripped-Isabella.0.exr -cut 64x64+0+0 -o test.exr"
     timecodeRate: 24
@@ -73,6 +73,6 @@ rat2.exr             :   64 x   64, 3 channel, float openexr
     compression: "zip"
     onehalf: 50/100 (0.5)
     PixelAspectRatio: 1
-    screenWindowCenter: 0 0
+    screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"

--- a/testsuite/zfile/ref/out.txt
+++ b/testsuite/zfile/ref/out.txt
@@ -2,8 +2,8 @@ Reading out.zfile
 out.zfile            :   64 x   64, 1 channel, float zfile
     SHA-1: 5CFBFC862EC731262ABDDF70D684BAE2E3FC54FC
     channel list: z
-    worldtocamera: 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
-    worldtoscreen: 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
+    worldtocamera: 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1
+    worldtoscreen: 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1
     Stats Min: 0.100000 (float)
     Stats Max: 1.000000 (float)
     Stats Avg: 0.475000 (float)


### PR DESCRIPTION
Lots of important classes have "attributes", which are used as option
settings and the like, basically any kind of named/typed data that
objects carry around. The prototypical way we set and retrieve them
is:

    obj.attribute (name, typedesc, &data);
    found_ok = obj.getattribute (name, typedesc, &data);

This is very general, but it's kind of a wonky syntax. So this patch
introduces an additional synax that is super handy and aesthetically
pleasing:

    obj[name] = data;     // set, works for nearly any data!

    data = obj[name]->get<type>();   // any type
    mystring = obj[name];            // turns any data into a string

This magic is accomplished with a helper template called an
AttrDelegate, which we define in attrdelegate.h. This is pretty handy
and we anticipate using it more widely over time, as we add this syntax
to additional classes.

The first class we rig up in this way is ParamValueList, which
necessitates adding attribute() and getattribute() methods to begin
with. It's a natural fit, and you can get a feel for how it looks when
used by examining the new unit tests in paramlist_test.cpp.

Also added to ImageSpec, for which I think this will be a handy new
way to set and retrieve metadata.

There's a bunch more cleanup that should be fairly straightforward to
understand.

Also, we expose two new functions (pieces of which were used internally
before, though we have now made them public and refactored them):

    std::string tostring (typedesc, void* data,
                          const tostring_foratting& fmt={})

        Turns any data (described by the typedesc) into a string,
        with optional fine-grained control over the formatting.

    bool convert_type (TypeDesc srctype, const void* src,
                       TypeDesc dsttype, void* dst)

        Copies with data conversion.

