### PR TITLE
IBA::resize -- fix precision for double images

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -52,6 +52,13 @@ OIIO_NAMESPACE_BEGIN
 
 namespace {
 
+// Define a templated Accumulator type that's float, except in the case
+// of double input, in which case it's double.
+template <typename T> struct Accum_t { typedef float  type; };
+template<> struct Accum_t<double>    { typedef double type; };
+
+
+
 // Poor man's Dual2<float> makes it easy to compute with differentials. For
 // a rich man's implementation and full documentation, see
 // OpenShadingLanguage (dual2.h).
@@ -232,7 +239,6 @@ resize_(ImageBuf& dst, const ImageBuf& src, Filter2D* filter, ROI roi,
         float dstfh          = float(dstspec.full_height);
         float dstpixelwidth  = 1.0f / dstfw;
         float dstpixelheight = 1.0f / dstfh;
-        float* pel           = ALLOCA(float, nchannels);
         float filterrad      = filter->width() / 2.0f;
 
         // radi,radj is the filter radius, as an integer, in source pixels.  We
@@ -257,8 +263,6 @@ resize_(ImageBuf& dst, const ImageBuf& src, Filter2D* filter, ROI roi,
                 float src_xf    = srcfx + s * srcfw;
                 int src_x;
                 float src_xf_frac = floorfrac(src_xf, &src_x);
-                for (int c = 0; c < nchannels; ++c)
-                    pel[c] = 0.0f;
                 float totalweight_x = 0.0f;
                 for (int i = 0; i < xtaps; ++i) {
                     float w = filter->xfilt(
@@ -282,6 +286,11 @@ resize_(ImageBuf& dst, const ImageBuf& src, Filter2D* filter, ROI roi,
     std::cerr << "dst range " << roi << "\n";
     std::cerr << "separable filter\n";
 #endif
+
+        // Accumulate the weighted results in pel[]. We select a type big
+        // enough to hold with required precision.
+        typedef typename Accum_t<DSTTYPE>::type Acc_t;
+        Acc_t* pel = ALLOCA(Acc_t, nchannels);
 
 #define USE_SPECIAL 0
 #if USE_SPECIAL


### PR DESCRIPTION
The innards of IBA::resize() has to accumulate the weighted
contributions of source pixels under the filter window, and that
accumulator used 'float'. This is fine except when the input image is
'double', in which case you might want just a touch more precision.

So we define an Accum_t typedef template that is double when double is
needed, and float for all other cases. Adds the precision that double
image resize needs, but retains the speed and precision of the prior
float behavior in all other cases.

Fixes #2210 