### PR TITLE
Travis: Fix clang-format test

### DIFF
--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -24,39 +24,40 @@ brew list --versions
 if [[ "$BUILDTARGET" == "clang-format" ]] ; then
     # If we are running for the sake of clang-format only, just install the
     # bare minimum packages and return.
-    brew install ilmbase openexr llvm
-    exit 0
+    time brew install ilmbase openexr llvm
+else
+    # All cases except for clang-format target, we need the dependencies.
+    time brew install gcc
+    time brew link --overwrite gcc
+    time brew install ccache cmake ninja
+    time brew install ilmbase openexr
+    time brew install opencolorio
+    time brew install freetype
+    time brew install libraw
+    time brew install libpng webp jpeg-turbo
+    time brew install openjpeg
+    time brew install dcmtk
+    time brew install qt
+    time brew install -s field3d
+    # Note: field3d must be build from source to fix boost mismatch as of
+    # Nov 2018. Maybe it will be fixed soon? Check later.
+    time brew install ffmpeg
+    time brew install opencv
+    time brew install tbb
+    time brew install openvdb
+    time brew install pybind11
+    time brew install libheif
 fi
 
-brew install gcc
-brew link --overwrite gcc
-brew install ccache cmake ninja
-brew install ilmbase openexr
-brew install opencolorio
-brew install freetype
-brew install libraw
-brew install libpng webp jpeg-turbo
-brew install openjpeg
-brew install dcmtk
-brew install qt
-brew install -s field3d
-# Note: field3d must be build from source to fix boost mismatch as of
-# Nov 2018. Maybe it will be fixed soon? Check later.
-brew install ffmpeg
-brew install opencv
-brew install tbb
-brew install openvdb
-brew install pybind11
-brew install libheif
 if [[ "$LINKSTATIC" == "1" ]] ; then
-    brew install little-cms2 tinyxml szip
-    brew install homebrew/dupes/bzip2
-    brew install yaml-cpp --with-static-lib
+    time brew install little-cms2 tinyxml szip
+    time brew install homebrew/dupes/bzip2
+    time brew install yaml-cpp --with-static-lib
 fi
 if [[ "$CLANG_TIDY" != "" ]] ; then
     # If we are running for the sake of clang-tidy only, we will need
     # a modern clang version not just the xcode one.
-    brew install llvm
+    time brew install llvm
 fi
 
 echo ""

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -54,8 +54,12 @@ namespace {
 
 // Define a templated Accumulator type that's float, except in the case
 // of double input, in which case it's double.
-template <typename T> struct Accum_t { typedef float  type; };
-template<> struct Accum_t<double>    { typedef double type; };
+template<typename T> struct Accum_t {
+    typedef float type;
+};
+template<> struct Accum_t<double> {
+    typedef double type;
+};
 
 
 
@@ -262,7 +266,7 @@ resize_(ImageBuf& dst, const ImageBuf& src, Filter2D* filter, ROI roi,
                 float s         = (x - dstfx + 0.5f) * dstpixelwidth;
                 float src_xf    = srcfx + s * srcfw;
                 int src_x;
-                float src_xf_frac = floorfrac(src_xf, &src_x);
+                float src_xf_frac   = floorfrac(src_xf, &src_x);
                 float totalweight_x = 0.0f;
                 for (int i = 0; i < xtaps; ++i) {
                     float w = filter->xfilt(

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -922,7 +922,7 @@ TIFFInput::readspec(bool read_meta)
     if (const char* compressname = tiff_compression_name(m_compression))
         m_spec.attribute("compression", compressname);
     m_predictor = PREDICTOR_NONE;
-    if (! safe_tiffgetfield("Predictor", TIFFTAG_PREDICTOR, &m_predictor))
+    if (!safe_tiffgetfield("Predictor", TIFFTAG_PREDICTOR, &m_predictor))
         m_predictor = PREDICTOR_NONE;
 
     m_rowsperstrip = -1;


### PR DESCRIPTION
Oops, a few merges ago I changed the .travis.yml to "source" the
install_homebrew_deps.bash script (instead of making a subshell)
and this caused the "exit 0" early out in it to not just terminate
that script as intended, but to terminate the entire Travis test,
making it look like it passed even though it never got around to
running clang-format at all. Oh dear.

This fixes it. It also uncovers a few minor formatting changes
we should have made over the last few days, but missed.

