### PR TITLE
Fix ZLIB references

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -54,7 +54,6 @@ endif ()
 ###########################################################################
 # Several packages need Zlib
 find_package (ZLIB REQUIRED)
-include_directories (${ZLIB_INCLUDE_DIR})
 
 
 ###########################################################################

--- a/src/ico.imageio/CMakeLists.txt
+++ b/src/ico.imageio/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (PNG_FOUND)
     add_oiio_plugin (icoinput.cpp icooutput.cpp
-                     INCLUDE_DIRS ${PNG_INCLUDE_DIR}
-                     LINK_LIBRARIES ${PNG_LIBRARIES})
+                     INCLUDE_DIRS ${PNG_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS}
+                     LINK_LIBRARIES ${PNG_LIBRARIES} ${ZLIB_LIBRARIES})
 else ()
     message (WARNING "libpng not found, so ICO support will not work")
 endif ()

--- a/src/png.imageio/CMakeLists.txt
+++ b/src/png.imageio/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (PNG_FOUND)
     add_oiio_plugin (pnginput.cpp pngoutput.cpp
-                     INCLUDE_DIRS ${PNG_INCLUDE_DIR}
-                     LINK_LIBRARIES ${PNG_LIBRARIES})
+                     INCLUDE_DIRS ${PNG_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS}
+                     LINK_LIBRARIES ${PNG_LIBRARIES} ${ZLIB_LIBRARIES})
 else ()
     message (WARNING "libpng not found, so PNG support will not work")
 endif ()

--- a/src/ptex.imageio/CMakeLists.txt
+++ b/src/ptex.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 if (USE_PTEX AND PTEX_FOUND)
     add_oiio_plugin (ptexinput.cpp
-                     INCLUDE_DIRS ${ZLIB_INCLUDE_DIR} ${PTEX_INCLUDE_DIR}
+                     INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS} ${PTEX_INCLUDE_DIR}
                      LINK_LIBRARIES ${PTEX_LIBRARIES} ${ZLIB_LIBRARIES}
                      DEFINITIONS "-DUSE_PTEX")
 endif ()

--- a/src/tiff.imageio/CMakeLists.txt
+++ b/src/tiff.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_oiio_plugin (tiffinput.cpp tiffoutput.cpp
-                 INCLUDE_DIRS ${TIFF_INCLUDE_DIR}
+                 INCLUDE_DIRS ${TIFF_INCLUDE_DIR} ${ZLIB_INCLUDE_DIRS}
                  LINK_LIBRARIES ${TIFF_LIBRARIES} ${JPEG_LIBRARIES}
                                 ${ZLIB_LIBRARIES})

--- a/src/zfile.imageio/CMakeLists.txt
+++ b/src/zfile.imageio/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_oiio_plugin (zfile.cpp
-                 INCLUDE_DIRS ${ZLIB_INCLUDE_DIR}
+                 INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS}
                  LINK_LIBRARIES ${ZLIB_LIBRARIES})

--- a/src/zfile.imageio/zfile.cpp
+++ b/src/zfile.imageio/zfile.cpp
@@ -32,7 +32,7 @@
 #include <cstdio>
 #include <cstdlib>
 
-#include "zlib.h"
+#include <zlib.h>
 
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filesystem.h>


### PR DESCRIPTION
* Correct use of ZLIB_INCLUDE_DIRS (not ZLIB_INCLUDE_DIR!).
* Only add include dirs for modules that need it.
* Also, change from obsolete PNG_INCLUDE_DIR to correct PNG_INCLUDE_DIRS.
