### PR TITLE
Sysutil: add utilities to get stack traces

### DIFF
--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -505,6 +505,10 @@ convert_file(const std::string& in_filename, const std::string& out_filename)
 int
 main(int argc, char* argv[])
 {
+    // Helpful for debugging to make sure that any crashes dump a stack
+    // trace.
+    Sysutil::setup_crash_stacktrace("stdout");
+
     Filesystem::convert_native_arguments(argc, (const char**)argv);
     getargs(argc, argv);
 

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -45,6 +45,7 @@
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/imagecache.h>
 #include <OpenImageIO/imageio.h>
+#include <OpenImageIO/sysutil.h>
 
 
 using namespace OIIO;
@@ -195,6 +196,10 @@ print_subimage(ImageBuf& img0, int subimage, int miplevel)
 int
 main(int argc, char* argv[])
 {
+    // Helpful for debugging to make sure that any crashes dump a stack
+    // trace.
+    Sysutil::setup_crash_stacktrace("stdout");
+
     Filesystem::convert_native_arguments(argc, (const char**)argv);
     getargs(argc, argv);
 

--- a/src/igrep/igrep.cpp
+++ b/src/igrep/igrep.cpp
@@ -41,6 +41,7 @@
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/strutil.h>
+#include <OpenImageIO/sysutil.h>
 
 #ifdef USE_BOOST_REGEX
 #    include <boost/regex.hpp>
@@ -162,6 +163,10 @@ parse_files(int argc, const char* argv[])
 int
 main(int argc, const char* argv[])
 {
+    // Helpful for debugging to make sure that any crashes dump a stack
+    // trace.
+    Sysutil::setup_crash_stacktrace("stdout");
+
     Filesystem::convert_native_arguments(argc, argv);
     ArgParse ap;
     // clang-format off

--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -45,6 +45,7 @@
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/strutil.h>
+#include <OpenImageIO/sysutil.h>
 
 #ifdef USE_BOOST_REGEX
 #    include <boost/regex.hpp>
@@ -652,6 +653,10 @@ parse_files(int argc, const char* argv[])
 int
 main(int argc, const char* argv[])
 {
+    // Helpful for debugging to make sure that any crashes dump a stack
+    // trace.
+    Sysutil::setup_crash_stacktrace("stdout");
+
     Filesystem::convert_native_arguments(argc, (const char**)argv);
     ArgParse ap;
     // clang-format off

--- a/src/include/OpenImageIO/sysutil.h
+++ b/src/include/OpenImageIO/sysutil.h
@@ -51,6 +51,10 @@
 #include <OpenImageIO/platform.h>
 #include <OpenImageIO/string_view.h>
 
+// Allow client software to know if this version has Sysutil::stacktrace().
+#define OIIO_HAS_STACKTRACE 1
+
+
 
 OIIO_NAMESPACE_BEGIN
 
@@ -115,6 +119,19 @@ physical_concurrency();
 /// Get the maximum number of open file handles allowed on this system.
 OIIO_API size_t
 max_open_files();
+
+/// Return a string containing a readable stack trace from the point where
+/// it was called. Return an empty string if not supported on this platform.
+OIIO_API std::string
+stacktrace();
+
+/// Turn on automatic stacktrace dump to the named file if the program
+/// crashes. Return true if this is properly set up, false if it is not
+/// possible on this platform. The name may be "stdout" or "stderr" to
+/// merely print the trace to stdout or stderr, respectively. If the name
+/// is "", it will disable the auto-stacktrace printing.
+OIIO_API bool
+setup_crash_stacktrace(string_view filename);
 
 /// Try to figure out how many columns wide the terminal window is. May not
 /// be correct on all systems, will default to 80 if it can't figure it out.

--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -116,6 +116,10 @@ getargs(int argc, char* argv[])
 int
 main(int argc, char* argv[])
 {
+    // Helpful for debugging to make sure that any crashes dump a stack
+    // trace.
+    Sysutil::setup_crash_stacktrace("stdout");
+
     Filesystem::convert_native_arguments(argc, (const char**)argv);
     getargs(argc, argv);
 

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -37,8 +37,6 @@
 #include <memory>
 #include <sstream>
 
-#include <boost/version.hpp>
-
 #include <OpenEXR/ImathMatrix.h>
 #include <OpenEXR/half.h>
 

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -40,7 +40,6 @@
 
 #include <boost/container/flat_map.hpp>
 #include <boost/thread/tss.hpp>
-#include <boost/version.hpp>
 
 #include <OpenEXR/half.h>
 

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -47,6 +47,7 @@
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/strutil.h>
+#include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/thread.h>
 #include <OpenImageIO/timer.h>
 
@@ -464,6 +465,10 @@ int
 main(int argc, char* argv[])
 {
     Timer alltimer;
+
+    // Helpful for debugging to make sure that any crashes dump a stack
+    // trace.
+    Sysutil::setup_crash_stacktrace("stdout");
 
     // Globally force classic "C" locale, and turn off all formatting
     // internationalization, for the entire maketx application.

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5315,6 +5315,17 @@ do_echo(int argc, const char* argv[])
 
 
 
+static int
+crash_me(int argc, const char* argv[])
+{
+    size_t a   = 37;
+    char* addr = (char*)a;
+    *addr      = 0;  // This should crash
+    return 0;
+}
+
+
+
 // Concatenate the command line into one string, optionally filtering out
 // verbose attribute commands. Escape control chars in the arguments, and
 // double-quote any that contain spaces.
@@ -5620,6 +5631,7 @@ getargs(int argc, char* argv[])
                 "--native %@", set_native, &ot.nativeread, "Keep native pixel data type (bypass cache if necessary)",
                 "--cache %@ %d", set_cachesize, &ot.cachesize, "ImageCache size (in MB: default=4096)",
                 "--autotile %@ %d", set_autotile, &ot.autotile, "Autotile size for cached images (default=4096)",
+                "--crash %@", crash_me, nullptr, "", // hidden option
                 "<SEPARATOR>", "Commands that read images:",
                 "-i %@ %s", input_file, NULL, "Input file (argument: filename) (options: now=, printinfo=, autocc=, type=, ch=)",
                 "--iconfig %@ %s %s", set_input_attribute, NULL, NULL, "Sets input config attribute (name, value) (options: type=...)",


### PR DESCRIPTION
Set up signal handlers in all the command line utils so that if they
crash, they will print stack traces that will help track down CI or
user-side failure cases.

This relies on Boost >= 1.65 for its stacktrace library. When built
against older versions of boost, stacktrace() will return an empty
string and the stacktrace-printing signal handles will have no effect.
C'est la vie.

