### PR TITLE
Fix IOProxy::pread on Windows that botched PNG & JPEG read

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -420,6 +420,7 @@ protected:
     FILE* m_file      = nullptr;
     size_t m_size     = 0;
     bool m_auto_close = false;
+    std::mutex m_mutex;
 };
 
 


### PR DESCRIPTION
We've been plagued by recently-introduced bugs with PNG and JPEG
reading that stemmed from the first IOProxy-related patch.  The
problem was our use of the Windows ReadFile call, which seems to not
preserve the file pointer as we'd assumed (the MSDN docs are ambiguous
about this). I also began to doubt its thread safety, so in the end I
just replace the code with a simpler approach with a mutex and calls
to tell/seek/read.
