### PR TITLE
Defensive programming to prevent integer overflow for large images

### DIFF
--- a/src/cineon.imageio/libcineon/Writer.cpp
+++ b/src/cineon.imageio/libcineon/Writer.cpp
@@ -304,7 +304,7 @@ bool cineon::Writer::WriteElement(const int element, void *data, const DataSize 
 bool cineon::Writer::WriteThrough(void *data, const U32 width, const U32 height, const int noc, const int bytes, const U32 eolnPad, const U32 eoimPad, char *blank)
 {
 	bool status = true;
-	const int count = width * height * noc;
+	const size_t count = size_t(width) * size_t(height) * noc;
 	unsigned int i;
 	unsigned char *imageBuf = reinterpret_cast<unsigned char*>(data);
 

--- a/src/dpx.imageio/libdpx/RunLengthEncoding.cpp
+++ b/src/dpx.imageio/libdpx/RunLengthEncoding.cpp
@@ -123,7 +123,7 @@ bool dpx::RunLengthEncoding::Read(const Header &dpxHeader, ElementReadStream *fd
 
 
 		// size of the image
-		const size_t imageSize = width * height * numberOfComponents;
+		const size_t imageSize = size_t(width) * size_t(height) * numberOfComponents;
 		const size_t imageByteSize = imageSize * byteCount;
 		
 		// allocate the buffer that will store the entire image

--- a/src/dpx.imageio/libdpx/Writer.cpp
+++ b/src/dpx.imageio/libdpx/Writer.cpp
@@ -369,7 +369,7 @@ bool dpx::Writer::WriteElement(const int element, void *data, const DataSize siz
 bool dpx::Writer::WriteThrough(void *data, const U32 width, const U32 height, const int noc, const int bytes, const U32 eolnPad, const U32 eoimPad, char *blank)
 {
 	bool status = true;
-	const int count = width * height * noc;
+	const size_t count = size_t(width) * size_t(height) * noc;
 	unsigned int i;
 	unsigned char *imageBuf = reinterpret_cast<unsigned char*>(data);
 	

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -397,11 +397,11 @@ ImageInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
     // copies the appropriate subset.
     size_t prefix_bytes   = spec.pixel_bytes(0, chbegin, true);
     size_t subset_bytes   = spec.pixel_bytes(chbegin, chend, true);
-    size_t subset_ystride = spec.width * subset_bytes;
+    size_t subset_ystride = size_t(spec.width) * subset_bytes;
 
     // Read all channels of the scanlines into a temp buffer.
     size_t native_pixel_bytes = spec.pixel_bytes(true);
-    size_t native_ystride     = spec.width * native_pixel_bytes;
+    size_t native_ystride     = size_t(spec.width) * native_pixel_bytes;
     std::unique_ptr<char[]> buf(new char[native_ystride * (yend - ybegin)]);
     yend    = std::min(yend, spec.y + spec.height);
     bool ok = read_native_scanlines(subimage, miplevel, ybegin, yend, z,

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -350,8 +350,8 @@ ImageOutput::to_native_rectangle(int xbegin, int xend, int ybegin, int yend,
         return data;
     }
 
-    imagesize_t rectangle_pixels       = width * height * depth;
-    imagesize_t rectangle_values       = rectangle_pixels * m_spec.nchannels;
+    imagesize_t rectangle_pixels = stride_t(width) * stride_t(height) * depth;
+    imagesize_t rectangle_values = rectangle_pixels * m_spec.nchannels;
     imagesize_t native_rectangle_bytes = rectangle_pixels * native_pixel_bytes;
 
     // Cases to handle:
@@ -435,10 +435,10 @@ ImageOutput::to_native_rectangle(int xbegin, int xend, int ybegin, int yend,
     if (do_dither) {
         stride_t pixelsize = m_spec.nchannels * sizeof(float);
         OIIO::add_dither(m_spec.nchannels, width, height, depth, (float*)buf,
-                         pixelsize, pixelsize * width,
-                         pixelsize * width * height, 1.0f / 255.0f,
-                         m_spec.alpha_channel, m_spec.z_channel, dither, 0,
-                         xorigin, yorigin, zorigin);
+                         pixelsize, pixelsize * stride_t(width),
+                         pixelsize * stride_t(width) * stride_t(height),
+                         1.0f / 255.0f, m_spec.alpha_channel, m_spec.z_channel,
+                         dither, 0, xorigin, yorigin, zorigin);
     }
 
     // Convert from float to native format.
@@ -610,7 +610,7 @@ ImageOutput::copy_to_image_buffer(int xbegin, int xend, int ybegin, int yend,
         OIIO::convert_image(spec.nchannels, width, height, depth, data, format,
                             xstride, ystride, zstride, ditherarea.get(),
                             TypeDesc::FLOAT, pixelsize, pixelsize * width,
-                            pixelsize * width * height);
+                            pixelsize * stride_t(width) * stride_t(height));
         data            = ditherarea.get();
         format          = TypeDesc::FLOAT;
         xstride         = pixelsize;
@@ -619,10 +619,10 @@ ImageOutput::copy_to_image_buffer(int xbegin, int xend, int ybegin, int yend,
         float ditheramp = spec.get_float_attribute("oiio:ditheramplitude",
                                                    1.0f / 255.0f);
         OIIO::add_dither(spec.nchannels, width, height, depth, (float*)data,
-                         pixelsize, pixelsize * width,
-                         pixelsize * width * height, ditheramp,
-                         spec.alpha_channel, spec.z_channel, dither, 0, xbegin,
-                         ybegin, zbegin);
+                         pixelsize, pixelsize * stride_t(width),
+                         pixelsize * stride_t(width) * stride_t(height),
+                         ditheramp, spec.alpha_channel, spec.z_channel, dither,
+                         0, xbegin, ybegin, zbegin);
     }
 
     return OIIO::convert_image(spec.nchannels, width, height, depth, data,

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -1499,8 +1499,8 @@ OpenEXROutput::write_tiles(int xbegin, int xend, int ybegin, int yend,
     int nytiles = (yend - ybegin + m_spec.tile_height - 1) / m_spec.tile_height;
 
     std::vector<char> padded;
-    int width           = nxtiles * m_spec.tile_width;
-    int height          = nytiles * m_spec.tile_height;
+    stride_t width      = nxtiles * m_spec.tile_width;
+    stride_t height     = nytiles * m_spec.tile_height;
     stride_t widthbytes = width * pixelbytes;
     if (width != (xend - xbegin) || height != (yend - ybegin)) {
         // If the image region is not an even multiple of the tile size,


### PR DESCRIPTION
Sometimes for very large images, either the number of pixels (w * h * d)
or the total data size (npixels * pixelbytes) can overflow int32 math.
Find several places where this may be a problem and use casts to ensure
64 bit multiplication.

I don't claim this is a comprehensive fix, but I did a cursory check of
some obvious places and found these to squash.

