### PR TITLE
Adjustment to convert_type/convert_types functions

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1760,13 +1760,25 @@ OIIO_API void declare_imageio_format (const std::string &format_name,
                                       const char **output_extensions,
                                       const char *lib_version);
 
-/// Helper function: convert contiguous arbitrary data between two
-/// arbitrary types (specified by TypeDesc's)
-/// Return true if ok, false if it didn't know how to do the
-/// conversion.  If dst_type is UNKNOWN, it will be assumed to be the
-/// same as src_type.
-OIIO_API bool convert_types (TypeDesc src_type, const void *src,
-                              TypeDesc dst_type, void *dst, int n);
+/// Helper function: convert contiguous data between two arbitrary pixel
+/// data types (specified by TypeDesc's). Return true if ok, false if it
+/// didn't know how to do the conversion.  If dst_type is UNKNOWN, it will
+/// be assumed to be the same as src_type.
+///
+/// The conversion is of normalized (pixel-like) values -- for example
+/// 'UINT8' 255 will convert to float 1.0 and vice versa, not float 255.0.
+/// If you want a straight C-like data cast convertion (e.g., uint8 255 ->
+/// float 255.0), then you should prefer the un-normalized convert_type()
+/// utility function found in typedesc.h.
+OIIO_API bool convert_pixel_values (TypeDesc src_type, const void *src,
+                                    TypeDesc dst_type, void *dst, int n = 1);
+
+/// DEPRECATED(2.1): old name
+inline bool convert_types (TypeDesc src_type, const void *src,
+                           TypeDesc dst_type, void *dst, int n = 1) {
+    return convert_pixel_values (src_type, src, dst_type, dst, n);
+}
+
 
 /// Helper routine for data conversion: Convert an image of nchannels x
 /// width x height x depth from src to dst.  The src and dst may have

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -498,8 +498,8 @@ tostring(TypeDesc type, const void* data, const tostring_formatting& fmt = {});
 ///   their best conversion; strings will convert if and only if their
 ///   characters form a valid float number.
 OIIO_API bool
-convert_type (TypeDesc srctype, const void* src,
-              TypeDesc dsttype, void* dst);
+convert_type(TypeDesc srctype, const void* src,
+             TypeDesc dsttype, void* dst, int n = 1);
 
 
 OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -665,8 +665,8 @@ pvt::parallel_convert_from_float(const float* src, void* dst, size_t nvals,
 
 
 bool
-convert_types(TypeDesc src_type, const void* src, TypeDesc dst_type, void* dst,
-              int n)
+convert_pixel_values(TypeDesc src_type, const void* src, TypeDesc dst_type,
+                     void* dst, int n)
 {
     // If no conversion is necessary, just memcpy
     if ((src_type == dst_type || dst_type.basetype == TypeDesc::UNKNOWN)) {
@@ -747,15 +747,15 @@ convert_image(int nchannels, int width, int height, int depth, const void* src,
                 // Special case: pixels within each row are contiguous
                 // in both src and dst and we're copying all channels.
                 // Be efficient by converting each scanline as a single
-                // unit.  (Note that within convert_types, a memcpy will
-                // be used if the formats are identical.)
-                result &= convert_types(src_type, f, dst_type, t,
-                                        nchannels * width);
+                // unit.  (Note that within convert_pixel_values, a memcpy
+                // will be used if the formats are identical.)
+                result &= convert_pixel_values(src_type, f, dst_type, t,
+                                               nchannels * width);
             } else {
                 // General case -- anything goes with strides.
                 for (int x = 0; x < width; ++x) {
-                    result &= convert_types(src_type, f, dst_type, t,
-                                            nchannels);
+                    result &= convert_pixel_values(src_type, f, dst_type, t,
+                                                   nchannels);
                     f += src_xstride;
                     t += dst_xstride;
                 }

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -629,8 +629,15 @@ to_floats(TypeDesc srctype, const void* src, T* dst, size_t n = 1)
 
 
 bool
-convert_type(TypeDesc srctype, const void* src, TypeDesc dsttype, void* dst)
+convert_type(TypeDesc srctype, const void* src, TypeDesc dsttype, void* dst,
+             int n)
 {
+    if (n > 1) {
+        // Handle multiple values by turning into or expanding array length
+        srctype.arraylen = srctype.numelements() * n;
+        dsttype.arraylen = dsttype.numelements() * n;
+    }
+
     if (srctype.basetype == dsttype.basetype
         && srctype.basevalues() == dsttype.basevalues()) {
         size_t size = srctype.size();


### PR DESCRIPTION
I realized that there is a convert_type function in typedesc.h and a
convert_types function in imageio.h that are subtly and confusinginly
different in their meaning and arguments.

* Expand typedesc.h `convert_type()` to take an optional number of
  values parameter (defaulting to 1, old behavior of converting one
  value).

* Rename imageio.h `convert_types()` to `convert_pixel_values()` and
  clarify comments to emphasize the important differece -- that this
  one is dealing with pixel-like normalized values (e.g., the max
  value of an int-like type corresponds to float 1.0).

So you should use convert_type to do a straightforward "cast" of the
value from one data type to the same value in another data type, but
convert_pixel_values to convert a pixel-like intensity to the
equivalent normalized intensity in a different pixel data type.

