### PR TITLE
Straighten out construction of ImageBuf from spec -- zero or not?

### DIFF
--- a/src/doc/imagebuf.tex
+++ b/src/doc/imagebuf.tex
@@ -60,12 +60,15 @@ constructed \ImageBuf using the default constructor.
 
 \subsection*{Constructing and initializing a writeable \ImageBuf}
 
-\apiitem{{\ce ImageBuf} (const ImageSpec \&spec, bool zero = true) \\
-{\ce ImageBuf} (string_view name, const ImageSpec \&spec, bool zero = true)}
+\apiitem{{\ce ImageBuf} (const ImageSpec \&spec, \\
+\big\big InitializePixels zero = InitializePixels::Yes) \\
+{\ce ImageBuf} (string_view name, const ImageSpec \&spec,
+\big\big InitializePixels zero = InitializePixels::Yes)}
 Constructs a writeable \ImageBuf with the given specification (including
 resolution, data type, metadata, etc.).
-The pixels will be initialized to black/empty if `zero` is true, otherwise the
-pixel values will remain uninitialized.
+The {\cf zero} parameter controls whether the pixel values are filled with
+black/empty, or are left uninitialized after being allocated (if set to
+{\cf InitializePixels::No}).
 Optionally, you may name the \ImageBuf.
 \apiend
 
@@ -74,8 +77,9 @@ void {\ce reset} (string_view name, const ImageSpec \&spec, bool zero = true)}
 Destroys any previous contents of the \ImageBuf and re-initializes it
 as a writeable all-black \ImageBuf with the given specification (including
 resolution, data type, metadata, etc.).
-The pixels will be initialized to black/empty if `zero` is true, otherwise the
-pixel values will remain uninitialized.
+The {\cf zero} parameter controls whether the pixel values are filled with
+black/empty, or are left uninitialized after being allocated (if set to
+{\cf InitializePixels::No}).
 Optionally, you may name the \ImageBuf.
 \ImageBuf.
 \apiend

--- a/src/doc/imagebuf.tex
+++ b/src/doc/imagebuf.tex
@@ -60,18 +60,23 @@ constructed \ImageBuf using the default constructor.
 
 \subsection*{Constructing and initializing a writeable \ImageBuf}
 
-\apiitem{{\ce ImageBuf} (const ImageSpec \&spec) \\
-{\ce ImageBuf} (string_view name, const ImageSpec \&spec)}
+\apiitem{{\ce ImageBuf} (const ImageSpec \&spec, bool zero = true) \\
+{\ce ImageBuf} (string_view name, const ImageSpec \&spec, bool zero = true)}
 Constructs a writeable \ImageBuf with the given specification (including
-resolution, data type, metadata, etc.), initially set to all black pixels.
+resolution, data type, metadata, etc.).
+The pixels will be initialized to black/empty if `zero` is true, otherwise the
+pixel values will remain uninitialized.
 Optionally, you may name the \ImageBuf.
 \apiend
 
-\apiitem{void {\ce reset} (const ImageSpec \&spec) \\
-void {\ce reset} (string_view name, const ImageSpec \&spec)}
+\apiitem{void {\ce reset} (const ImageSpec \&spec, bool zero = true) \\
+void {\ce reset} (string_view name, const ImageSpec \&spec, bool zero = true)}
 Destroys any previous contents of the \ImageBuf and re-initializes it
 as a writeable all-black \ImageBuf with the given specification (including
-resolution, data type, metadata, etc.).  Optionally, you may name the
+resolution, data type, metadata, etc.).
+The pixels will be initialized to black/empty if `zero` is true, otherwise the
+pixel values will remain uninitialized.
+Optionally, you may name the \ImageBuf.
 \ImageBuf.
 \apiend
 

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -1365,10 +1365,12 @@ Optionally, a specific subimage or MIP level may be specified (defaulting to
 \end{code}
 \apiend
 
-\apiitem{ImageBuf {\ce ImageBuf} (imagespec)}
+\apiitem{ImageBuf {\ce ImageBuf} (imagespec, zero = True)}
 
 Construct a writeable \ImageBuf of the dimensions and data format specified
-by an \ImageSpec.
+by an \ImageSpec. 
+The pixels will be set to 0 values if {\cf zero} is True, otherwise the
+pixel values will remain uninitialized.
 
 \noindent Example:
 \begin{code}
@@ -1378,7 +1380,8 @@ by an \ImageSpec.
 \apiend
 
 \apiitem{ImageBuf.{\ce clear} ()}
-Return the \ImageBuf to its pristine, uninitialized state.
+Resets the \ImageBuf to a pristine state identical to that of a freshly
+constructed \ImageBuf using the default constructor.
 
 \noindent Example:
 \begin{code}
@@ -1396,9 +1399,11 @@ a filename (optionally specifying a subimage, MIP level, and/or
 a ``configuration'' \ImageSpec).
 \apiend
 
-\apiitem{ImageBuf.{\ce reset} (imagespec)}
-Restore the \ImageBuf to the newly-constructed state of a blank, writeable
+\apiitem{ImageBuf.{\ce reset} (imagespec, zero = True)}
+Restore the \ImageBuf to the newly-constructed state of a writeable
 \ImageBuf specified by an \ImageSpec.
+The pixels will be iniialized to black/empty if {\cf zero} is True,
+otherwise the pixel values will remain uninitialized.
 \apiend
 
 \apiitem{bool ImageBuf.{\ce read} (subimage=0, miplevel=0, force=False, convert=oiio.UNKNOWN) \\

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -1368,9 +1368,8 @@ Optionally, a specific subimage or MIP level may be specified (defaulting to
 \apiitem{ImageBuf {\ce ImageBuf} (imagespec, zero = True)}
 
 Construct a writeable \ImageBuf of the dimensions and data format specified
-by an \ImageSpec. 
-The pixels will be set to 0 values if {\cf zero} is True, otherwise the
-pixel values will remain uninitialized.
+by an \ImageSpec. The pixels will be initialized to black/empty values if
+{\cf zero} is True, otherwise the pixel values will remain uninitialized.
 
 \noindent Example:
 \begin{code}

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -78,6 +78,7 @@ set_roi_full(ImageSpec& spec, const ROI& newroi);
 
 
 class ImageBufImpl;  // Opaque pointer
+enum class InitializePixels { No = 0, Yes = 1 };
 
 
 
@@ -116,16 +117,18 @@ public:
 
     /// Construct an Imagebuf given a proposed spec describing the image
     /// size and type, and allocate storage for the pixels of the image. The
-    /// pixels will be initialized to black/empty if `zero` is true,
-    /// otherwise the pixel values will remain uninitialized.
-    explicit ImageBuf(const ImageSpec& spec, bool zero=true);
+    /// `zero` parameter controls whether the pixel values are filled with
+    /// black/empty, or are left uninitialized after being allocated.
+    explicit ImageBuf(const ImageSpec& spec,
+                      InitializePixels zero = InitializePixels::Yes);
 
     /// Construct an Imagebuf given both a name and a proposed spec
     /// describing the image size and type, and allocate storage for the
-    /// pixels of the image. The pixels will be initialized to black/empty
-    /// if `zero` is true, otherwise the pixel values will remain
-    /// uninitialized.
-    ImageBuf(string_view name, const ImageSpec& spec, bool zero=true);
+    /// pixels of the image. The `zero` parameter controls whether the pixel
+    /// values are filled with black/empty, or are left uninitialized after
+    /// being allocated.
+    ImageBuf(string_view name, const ImageSpec& spec,
+             InitializePixels zero = InitializePixels::Yes);
 
     /// Construct an ImageBuf that "wraps" a memory buffer owned by the
     /// calling application.  It can write pixels to this buffer, but
@@ -174,16 +177,18 @@ public:
     void reset(string_view name, ImageCache* imagecache = NULL);
 
     /// Forget all previous info, reset this ImageBuf to a blank image of
-    /// the given dimensions. The pixels will be initialized to black/empty
-    /// if `zero` is true, otherwise the pixel values will remain
-    /// uninitialized.
-    void reset(const ImageSpec& spec, bool zero = true);
+    /// the given dimensions. The `zero` parameter controls whether the
+    /// pixel values are filled with black/empty, or are left uninitialized
+    /// after being allocated.
+    void reset(const ImageSpec& spec,
+               InitializePixels zero = InitializePixels::Yes);
 
     /// Forget all previous info, reset this ImageBuf to a blank image of
-    /// the given name and dimensions. The pixels will be set to 0 values if
-    /// `zero` is true, otherwise the pixel values will remain
-    /// uninitialized.
-    void reset(string_view name, const ImageSpec& spec, bool zero = true);
+    /// the given name and dimensions. The `zero` parameter controls whether
+    /// the pixel values are filled with black/empty, or are left
+    /// uninitialized after being allocated.
+    void reset(string_view name, const ImageSpec& spec,
+               InitializePixels zero = InitializePixels::Yes);
 
     // Copy assignment
     const ImageBuf& operator=(const ImageBuf& src);

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -115,14 +115,17 @@ public:
     ImageBuf(string_view name, ImageCache* imagecache);
 
     /// Construct an Imagebuf given a proposed spec describing the image
-    /// size and type, and allocate storage for the pixels of the image
-    /// (whose values will be uninitialized).
-    explicit ImageBuf(const ImageSpec& spec);
+    /// size and type, and allocate storage for the pixels of the image. The
+    /// pixels will be initialized to black/empty if `zero` is true,
+    /// otherwise the pixel values will remain uninitialized.
+    explicit ImageBuf(const ImageSpec& spec, bool zero=true);
 
     /// Construct an Imagebuf given both a name and a proposed spec
-    /// describing the image size and type, and allocate storage for
-    /// the pixels of the image (whose values will be undefined).
-    ImageBuf(string_view name, const ImageSpec& spec);
+    /// describing the image size and type, and allocate storage for the
+    /// pixels of the image. The pixels will be initialized to black/empty
+    /// if `zero` is true, otherwise the pixel values will remain
+    /// uninitialized.
+    ImageBuf(string_view name, const ImageSpec& spec, bool zero=true);
 
     /// Construct an ImageBuf that "wraps" a memory buffer owned by the
     /// calling application.  It can write pixels to this buffer, but
@@ -170,13 +173,17 @@ public:
     /// that is uninitialized (no pixel values, no size or spec).
     void reset(string_view name, ImageCache* imagecache = NULL);
 
-    /// Forget all previous info, reset this ImageBuf to a blank
-    /// image of the given dimensions.
-    void reset(const ImageSpec& spec);
+    /// Forget all previous info, reset this ImageBuf to a blank image of
+    /// the given dimensions. The pixels will be initialized to black/empty
+    /// if `zero` is true, otherwise the pixel values will remain
+    /// uninitialized.
+    void reset(const ImageSpec& spec, bool zero = true);
 
-    /// Forget all previous info, reset this ImageBuf to a blank
-    /// image of the given name and dimensions.
-    void reset(string_view name, const ImageSpec& spec);
+    /// Forget all previous info, reset this ImageBuf to a blank image of
+    /// the given name and dimensions. The pixels will be set to 0 values if
+    /// `zero` is true, otherwise the pixel values will remain
+    /// uninitialized.
+    void reset(string_view name, const ImageSpec& spec, bool zero = true);
 
     // Copy assignment
     const ImageBuf& operator=(const ImageBuf& src);

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -453,18 +453,22 @@ ImageBuf::ImageBuf(string_view filename, ImageCache* imagecache)
 
 
 
-ImageBuf::ImageBuf(const ImageSpec& spec)
+ImageBuf::ImageBuf(const ImageSpec& spec, bool zero)
     : m_impl(new ImageBufImpl("", 0, 0, NULL, &spec))
 {
     m_impl->alloc(spec);
+    if (zero && !deep())
+        ImageBufAlgo::zero (*this);
 }
 
 
 
-ImageBuf::ImageBuf(string_view filename, const ImageSpec& spec)
+ImageBuf::ImageBuf(string_view filename, const ImageSpec& spec, bool zero)
     : m_impl(new ImageBufImpl(filename, 0, 0, NULL, &spec))
 {
     m_impl->alloc(spec);
+    if (zero && !deep())
+        ImageBufAlgo::zero (*this);
 }
 
 
@@ -701,17 +705,21 @@ ImageBufImpl::reset(string_view filename, const ImageSpec& spec,
 
 
 void
-ImageBuf::reset(string_view filename, const ImageSpec& spec)
+ImageBuf::reset(string_view filename, const ImageSpec& spec, bool zero)
 {
     impl()->reset(filename, spec);
+    if (zero && !deep())
+        ImageBufAlgo::zero (*this);
 }
 
 
 
 void
-ImageBuf::reset(const ImageSpec& spec)
+ImageBuf::reset(const ImageSpec& spec, bool zero)
 {
     impl()->reset("", spec);
+    if (zero && ! deep())
+        ImageBufAlgo::zero (*this);
 }
 
 

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -453,22 +453,23 @@ ImageBuf::ImageBuf(string_view filename, ImageCache* imagecache)
 
 
 
-ImageBuf::ImageBuf(const ImageSpec& spec, bool zero)
+ImageBuf::ImageBuf(const ImageSpec& spec, InitializePixels zero)
     : m_impl(new ImageBufImpl("", 0, 0, NULL, &spec))
 {
     m_impl->alloc(spec);
-    if (zero && !deep())
-        ImageBufAlgo::zero (*this);
+    if (zero == InitializePixels::Yes && !deep())
+        ImageBufAlgo::zero(*this);
 }
 
 
 
-ImageBuf::ImageBuf(string_view filename, const ImageSpec& spec, bool zero)
+ImageBuf::ImageBuf(string_view filename, const ImageSpec& spec,
+                   InitializePixels zero)
     : m_impl(new ImageBufImpl(filename, 0, 0, NULL, &spec))
 {
     m_impl->alloc(spec);
-    if (zero && !deep())
-        ImageBufAlgo::zero (*this);
+    if (zero == InitializePixels::Yes && !deep())
+        ImageBufAlgo::zero(*this);
 }
 
 
@@ -705,21 +706,22 @@ ImageBufImpl::reset(string_view filename, const ImageSpec& spec,
 
 
 void
-ImageBuf::reset(string_view filename, const ImageSpec& spec, bool zero)
+ImageBuf::reset(string_view filename, const ImageSpec& spec,
+                InitializePixels zero)
 {
     impl()->reset(filename, spec);
-    if (zero && !deep())
-        ImageBufAlgo::zero (*this);
+    if (zero == InitializePixels::Yes && !deep())
+        ImageBufAlgo::zero(*this);
 }
 
 
 
 void
-ImageBuf::reset(const ImageSpec& spec, bool zero)
+ImageBuf::reset(const ImageSpec& spec, InitializePixels zero)
 {
     impl()->reset("", spec);
-    if (zero && ! deep())
-        ImageBufAlgo::zero (*this);
+    if (zero == InitializePixels::Yes && !deep())
+        ImageBufAlgo::zero(*this);
 }
 
 

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -210,6 +210,10 @@ declare_imagebuf(py::module& m)
         .def(py::init<const std::string&>())
         .def(py::init<const std::string&, int, int>())
         .def(py::init<const ImageSpec&>())
+        .def(py::init([](const ImageSpec& spec, bool zero) {
+            auto z = zero ? InitializePixels::Yes : InitializePixels::No;
+            return ImageBuf(spec, z);
+        }))
         .def("clear", &ImageBuf::clear)
         .def(
             "reset",
@@ -226,8 +230,11 @@ declare_imagebuf(py::module& m)
             "config"_a = ImageSpec())
         .def(
             "reset",
-            [](ImageBuf& self, const ImageSpec& spec) { self.reset(spec); },
-            "spec"_a)
+            [](ImageBuf& self, const ImageSpec& spec, bool zero) {
+                auto z = zero ? InitializePixels::Yes : InitializePixels::No;
+                self.reset(spec, z);
+            },
+            "spec"_a, "zero"_a = true)
         .def_property_readonly("initialized",
                                [](const ImageBuf& self) {
                                    return self.initialized();


### PR DESCRIPTION
* Docs, header, and implementation were not all consistent about
  whether the ImageBuf construct-from-ImageSpec (or the `reset()` call
  of the same flavor) zeroes out the newly allocated buffer, or if the
  pixel values are left uninitialized.

* Change the call signature to take an optional `zero` parameter -- which
  defaults to true, meaning that the pixels are zeroed out when allocated
  (this is the foolproof approach, at the cost of writing all the memory
  of the buffer). If zero==false, the newly allocated pixels will remain
  uninitialized (this is for power users who want to maximize performance
  when they know that they will soon overwrite all the vaues in the buffer
  and want to avoid any unnecessary writes).

* Touch up the docs and header comments to be consistent and explain the
  behavior correctly.

