### PR TITLE
Adjust boost gcd based on version

### DIFF
--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -37,7 +37,14 @@
 #include <memory>
 #include <numeric>
 
-#include <boost/math/common_factor_rt.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 106900
+#    include <boost/integer/common_factor_rt.hpp>
+using boost::integer::gcd;
+#else
+#    include <boost/math/common_factor_rt.hpp>
+using boost::math::gcd;
+#endif
 
 #include <OpenEXR/ImfChannelList.h>
 #include <OpenEXR/ImfEnvmap.h>
@@ -787,8 +794,7 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
                 r[1] = static_cast<int>(d);
                 spec.attribute(oname, TypeRational, r);
             } else if (int f = static_cast<int>(
-                                   boost::math::gcd<long int>(rational[0],
-                                                              rational[1]))
+                                   gcd<long int>(rational[0], rational[1]))
                                > 1) {
                 int r[2];
                 r[0] = n / f;


### PR DESCRIPTION
The GCD functionality moved several versions ago, from boost::math to
boost::integer. It's been "replicated" in both places for a while, but
at least on 1.69, it issues warnings. At some point it will be
permanently moved. So let's get out ahead of that potential breakage.

