### PR TITLE
oiiotool --ch did not honor `allsubimages=1` modifier

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -2288,6 +2288,11 @@ action_channels(int argc, const char* argv[])
     string_view command  = ot.express(argv[0]);
     string_view chanlist = ot.express(argv[1]);
 
+    std::map<std::string, std::string> options;
+    options["allsubimages"] = std::to_string(ot.allsubimages);
+    ot.extract_options(options, command);
+    int allsubimages = Strutil::from_string<int>(options["allsubimages"]);
+
     ImageRecRef A(ot.pop());
     ot.read(A);
 
@@ -2300,7 +2305,7 @@ action_channels(int argc, const char* argv[])
     // need to describe the new ImageRec with the altered channels.
     std::vector<int> allmiplevels;
     std::vector<ImageSpec> allspecs;
-    for (int s = 0, subimages = ot.allsubimages ? A->subimages() : 1;
+    for (int s = 0, subimages = allsubimages ? A->subimages() : 1;
          s < subimages; ++s) {
         std::vector<std::string> newchannelnames;
         std::vector<int> channels;


### PR DESCRIPTION
It worked with the global -a, but not the customary `:allsubimages=1`
modifier to that individual command. Either is supposed to make it
apply the channel shuffling to all subimages of a multi-subimage file
(for example, a multipart exr file).

