### PR TITLE
Fix: somehow forgot to add crash stacktrace to oiiotool

### DIFF
--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -86,7 +86,9 @@
 
 #include <boost/version.hpp>
 #if BOOST_VERSION >= 106500
-#    define _GNU_SOURCE
+#    ifndef _GNU_SOURCE
+#        define _GNU_SOURCE
+#    endif
 #    include <boost/stacktrace.hpp>
 #endif
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -6081,6 +6081,10 @@ main(int argc, char* argv[])
                              bad[0], h[0], vf[0]);
     }
 
+    // Helpful for debugging to make sure that any crashes dump a stack
+    // trace.
+    Sysutil::setup_crash_stacktrace("stdout");
+
     // Globally force classic "C" locale, and turn off all formatting
     // internationalization, for the entire oiiotool application.
     std::locale::global(std::locale::classic());


### PR DESCRIPTION
Also fix warning if symbol is already defined.

I added it to all the other command line utils. And I must have had it working in oiiotool at some point because that's where I put the hidden `--crash` option to test it. I might have had accidentally deleted those couple line before merging somehow.
