### PR TITLE
Fix broken ability to specify compression of multipart exr files

### DIFF
--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -674,7 +674,7 @@ OpenEXROutput::spec_to_header(ImageSpec& spec, int subimage,
 
     string_view comp;
     int qual;
-    std::tie(comp, qual) = m_spec.decode_compression_metadata("zip");
+    std::tie(comp, qual) = spec.decode_compression_metadata("zip");
     // It seems that zips is the only compression that can reliably work
     // on deep files (but allow "none" as well)
     if (spec.deep && comp != "none")


### PR DESCRIPTION
Typo! Was grabbing from this->spec before it was assigned, should have
looked in the parameter spec (to OpenEXROutput::spec_to_header).

Fixes #2251 
