### PR TITLE
gcc9 Travis build and warning fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,16 +53,6 @@ before_install:
     - source src/build-scripts/ci-startup.bash
     - export WHICHGCC=${WHICHGCC:="4.8"}
     - if [ "$CXX" == "g++" ]; then export CXX="g++-${WHICHGCC}" ; fi
-    - |
-      # If linux and gcc-9 install gcc-9.
-      if [[ "${CXX}" == "g++-9" ]]; then
-        wget http://kayari.org/gcc-latest/gcc-latest.deb
-        sudo dpkg -i gcc-latest.deb
-        sudo ln -s /opt/gcc-latest/bin/gcc /usr/bin/gcc-9
-        sudo ln -s /opt/gcc-latest/bin/g++ /usr/bin/g++-9
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90 --slave /usr/bin/g++ g++ /usr/bin/g++-9
-        sudo ldconfig /opt/gcc-latest/lib64
-      fi
 
 install:
     - if [ $TRAVIS_OS_NAME == osx ] ; then
@@ -251,6 +241,7 @@ matrix:
             packages:
               - *common-packages
               - *common-boost-packages
+              - g++-9
         if: branch =~ /(master|RB|travis|gcc|17)/ OR type = pull_request
 
     # Note: builds for AVX2, AVX512 happen on CircleCI

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 
 if (CMAKE_COMPILER_IS_GNUCC AND NOT ${GCC_VERSION} VERSION_LESS 9.0)
     set_source_files_properties (../libutil/SHA1.cpp
-                                 PROPERTIES COMPILE_FLAGS -Wno-error=stringop-truncation)
+                                 PROPERTIES COMPILE_FLAGS -Wno-stringop-truncation)
 endif ()
 
 set (libOpenImageIO_srcs

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -35,7 +35,7 @@ endif ()
 
 if (CMAKE_COMPILER_IS_GNUCC AND NOT ${GCC_VERSION} VERSION_LESS 9.0)
     set_source_files_properties (SHA1.cpp
-                                 PROPERTIES COMPILE_FLAGS -Wno-error=stringop-truncation)
+                                 PROPERTIES COMPILE_FLAGS -Wno-stringop-truncation)
 endif ()
 
 # For consistency with the linux SpComp2s, create Mac OS X SpComp2s


### PR DESCRIPTION
* Switch where I get gcc9 from in the Travis setup, the previous one has
  broken (it was a "gcc-latest", which is now an in-progress gcc10).

* Fix a gcc9 warning

