### PR TITLE
Revise raw processing

### DIFF
--- a/testsuite/raw/ref/out-libraw0.17.1.txt
+++ b/testsuite/raw/ref/out-libraw0.17.1.txt
@@ -123,7 +123,7 @@
     Exif:SubsecTimeDigitized: "00"
     Exif:SubsecTimeOriginal: "00"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
@@ -169,7 +169,7 @@
     Exif:SubsecTimeOriginal: "00"
     Exif:WhiteBalance: 1 (manual)
     Exif:YCbCrPositioning: 2
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:Orientation: 8
@@ -218,7 +218,7 @@
     Exif:SubjectDistanceRange: 0 (unknown)
     Exif:WhiteBalance: 0 (auto)
     Exif:YCbCrPositioning: 2
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
@@ -265,7 +265,7 @@
     Exif:SubsecTimeOriginal: "00"
     Exif:WhiteBalance: 1 (manual)
     Exif:YCbCrPositioning: 2
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:Orientation: 8
@@ -308,7 +308,7 @@
     Exif:Sharpness: 1 (soft)
     Exif:ShutterSpeedValue: 8.32193 (1/319 s)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_PENTAX_K200D.PEF : 2616 x 3896, 3 channel, uint16 raw
@@ -345,7 +345,7 @@
     Exif:ShutterSpeedValue: 7.96578 (1/249 s)
     Exif:SubjectDistanceRange: 3 (distant)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:Orientation: 8
@@ -391,7 +391,7 @@
     Exif:Sharpness: 0 (normal)
     Exif:ShutterSpeedValue: 5.90689 (1/59 s)
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
 Comparing "RAW_CANON_EOS_7D.CR2.tif" and "ref/RAW_CANON_EOS_7D.CR2.tif"

--- a/testsuite/raw/ref/out-libraw0.17.2-circle.txt
+++ b/testsuite/raw/ref/out-libraw0.17.2-circle.txt
@@ -123,7 +123,7 @@
     Exif:SubsecTimeDigitized: "00"
     Exif:SubsecTimeOriginal: "00"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
@@ -169,7 +169,7 @@
     Exif:SubsecTimeOriginal: "00"
     Exif:WhiteBalance: 1 (manual)
     Exif:YCbCrPositioning: 2
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:Orientation: 8
@@ -218,7 +218,7 @@
     Exif:SubjectDistanceRange: 0 (unknown)
     Exif:WhiteBalance: 0 (auto)
     Exif:YCbCrPositioning: 2
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
@@ -265,7 +265,7 @@
     Exif:SubsecTimeOriginal: "00"
     Exif:WhiteBalance: 1 (manual)
     Exif:YCbCrPositioning: 2
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:Orientation: 8
@@ -308,7 +308,7 @@
     Exif:Sharpness: 1 (soft)
     Exif:ShutterSpeedValue: 8.32193 (1/319 s)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_PENTAX_K200D.PEF : 2616 x 3896, 3 channel, uint16 raw
@@ -345,7 +345,7 @@
     Exif:ShutterSpeedValue: 7.96578 (1/249 s)
     Exif:SubjectDistanceRange: 3 (distant)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:Orientation: 8
@@ -391,7 +391,7 @@
     Exif:Sharpness: 0 (normal)
     Exif:ShutterSpeedValue: 5.90689 (1/59 s)
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
 Comparing "RAW_CANON_EOS_7D.CR2.tif" and "ref/RAW_CANON_EOS_7D.CR2.tif"

--- a/testsuite/raw/ref/out-libraw0.18.11.txt
+++ b/testsuite/raw/ref/out-libraw0.18.11.txt
@@ -149,7 +149,7 @@
     Exif:SubsecTimeDigitized: "00"
     Exif:SubsecTimeOriginal: "00"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
@@ -216,7 +216,7 @@
     Nikon:MaxFocal: 70
     Nikon:MCUVersion: 99
     Nikon:MinFocal: 28
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:Orientation: 8
@@ -288,7 +288,7 @@
     Fujifilm:Rating: 0
     Fujifilm:ShutterType: 0
     Fujifilm:WB_Preset: 0
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
@@ -356,7 +356,7 @@
     Nikon:MaxFocal: 70
     Nikon:MCUVersion: 99
     Nikon:MinFocal: 28
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:Orientation: 8
@@ -399,7 +399,7 @@
     Exif:Sharpness: 1 (soft)
     Exif:ShutterSpeedValue: 8.32193 (1/319 s)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     Olympus:AFPoint: 0
     Olympus:AFPointSelected: 0, 0, 0, 0, 0
@@ -450,7 +450,7 @@
     Exif:MaxApertureValue: 925/256 (3.61328)
     Exif:MeteringMode: 5 (pattern)
     Exif:ShutterSpeedValue: 8.64386 (1/399 s)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     Panasonic:AFPoint: -1
     Panasonic:CanonFocalUnits: 1
     Panasonic:EXIF_MaxAp: 3.49827
@@ -491,7 +491,7 @@
     Exif:ShutterSpeedValue: 7.96578 (1/249 s)
     Exif:SubjectDistanceRange: 3 (distant)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     Pentax:AFPoint: -1
     Pentax:BodySerial: "0"
@@ -556,7 +556,7 @@
     Exif:Sharpness: 0 (normal)
     Exif:ShutterSpeedValue: 5.90689 (1/59 s)
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     Sony:AFPoint: -1

--- a/testsuite/raw/ref/out-oldlibraw0.15.txt
+++ b/testsuite/raw/ref/out-oldlibraw0.15.txt
@@ -13,7 +13,7 @@
     Exif:FocalLength: 200 (200 mm)
     Exif:ISOSpeedRatings: 100
     Exif:ShutterSpeedValue: 8.375 (1/331 s)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
@@ -30,7 +30,7 @@
     Exif:FocalLength: 70 (70 mm)
     Exif:ISOSpeedRatings: 100
     Exif:ShutterSpeedValue: 5.64386 (1/49 s)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_FUJI_F700.RAF : 2035 x 1533, 3 channel, uint16 raw
     channel list: R, G, B
@@ -46,7 +46,7 @@
     Exif:FocalLength: 8.5 (8.5 mm)
     Exif:ISOSpeedRatings: 200
     Exif:ShutterSpeedValue: 9.7 (1/831 s)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
@@ -63,7 +63,7 @@
     Exif:FocalLength: 70 (70 mm)
     Exif:ISOSpeedRatings: 100
     Exif:ShutterSpeedValue: 5.64386 (1/49 s)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_OLYMPUS_E3.ORF : 3720 x 2800, 3 channel, uint16 raw
     channel list: R, G, B
@@ -80,7 +80,7 @@
     Exif:FocalLength: 50 (50 mm)
     Exif:ISOSpeedRatings: 200
     Exif:ShutterSpeedValue: 8.32193 (1/319 s)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_PENTAX_K200D.PEF : 2616 x 3896, 3 channel, uint16 raw
     channel list: R, G, B
@@ -96,7 +96,7 @@
     Exif:FocalLength: 42.5 (42.5 mm)
     Exif:ISOSpeedRatings: 100
     Exif:ShutterSpeedValue: 7.96578 (1/249 s)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_SONY_A300.ARW : 3880 x 2608, 3 channel, uint16 raw
     channel list: R, G, B
@@ -113,7 +113,7 @@
     Exif:FocalLength: 35 (35 mm)
     Exif:ISOSpeedRatings: 400
     Exif:ShutterSpeedValue: 5.90689 (1/59 s)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     raw:Demosaic: "AHD"
 Comparing "RAW_CANON_EOS_7D.CR2.tif" and "ref/RAW_CANON_EOS_7D.CR2.tif"
 PASS

--- a/testsuite/raw/ref/out.txt
+++ b/testsuite/raw/ref/out.txt
@@ -74,7 +74,7 @@
     Exif:SubsecTimeDigitized: "00"
     Exif:SubsecTimeOriginal: "00"
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
@@ -159,7 +159,7 @@
     Nikon:PhaseDetectAF: 0
     Nikon:ShootingMode: 0
     Nikon:VRMode: 0
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_FUJI_F700.RAF : 2035 x 1533, 3 channel, uint16 raw
@@ -225,7 +225,7 @@
     Fujifilm:Rating: 0
     Fujifilm:ShutterType: 0
     Fujifilm:WB_Preset: 0
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
@@ -310,7 +310,7 @@
     Nikon:PhaseDetectAF: 0
     Nikon:ShootingMode: 0
     Nikon:VRMode: 0
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
 ../../../../../oiio-images/raw/RAW_OLYMPUS_E3.ORF : 3720 x 2800, 3 channel, uint16 raw
@@ -349,7 +349,7 @@
     Exif:Sharpness: 1 (soft)
     Exif:ShutterSpeedValue: 8.32193 (1/319 s)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     Olympus:AFFineTune: 0
     Olympus:AFPoint: 0
@@ -400,7 +400,7 @@
     Exif:MaxApertureValue: 925/256 (3.61328)
     Exif:MeteringMode: 5 (pattern)
     Exif:ShutterSpeedValue: 8.64386 (1/399 s)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     Panasonic:AFPoint: -1
     Panasonic:BlackLevel: 0, 0, 0, 0, 0, 0, 0, 0
     Panasonic:CanonFocalUnits: 1
@@ -440,7 +440,7 @@
     Exif:ShutterSpeedValue: 7.96578 (1/249 s)
     Exif:SubjectDistanceRange: 3 (distant)
     Exif:WhiteBalance: 1 (manual)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     Pentax:AFAdjustment: 0
     Pentax:AFPoint: -1
@@ -507,7 +507,7 @@
     Exif:Sharpness: 0 (normal)
     Exif:ShutterSpeedValue: 5.90689 (1/59 s)
     Exif:WhiteBalance: 0 (auto)
-    oiio:ColorSpace: "sRGB"
+    oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     Sony:AFMicroAdjOn: 0

--- a/testsuite/raw/run.py
+++ b/testsuite/raw/run.py
@@ -29,7 +29,8 @@ if (os.environ.get('CIRCLECI') == 'true' or
 # the ref images small) and compared to the reference.
 for f in files:
     outputname = f+".tif"
-    command += oiiotool ("-i:info=2 " + OIIO_TESTSUITE_IMAGEDIR + "/" + f
+    command += oiiotool ("-iconfig raw:ColorSpace linear "
+                         + "-i:info=2 " + OIIO_TESTSUITE_IMAGEDIR + "/" + f
                          + " -resample '5%' -d uint8 "
                          + "-o " + outputname)
     outputs += [ outputname ]


### PR DESCRIPTION
We were not using certain libraw parameters correctly.

New default behavior is to decode to sRGB (both primaries and
response) -- because for a naive user that just reads a raw file and
slaps it up for display, this behaves like a jpeg.

But configuration hints "raw:ColorSpace" can request various other
things, like "ACES" (linear ACES), "Adobe" (Adobe gamut with 1.8
gamma), and so on. Asking for "linear" gives you sRGB primaries
with linear response.

Fixes #2256 
