### PR TITLE
Spruce up ASSERT macros

### DIFF
--- a/src/include/OpenImageIO/dassert.h
+++ b/src/include/OpenImageIO/dassert.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <cstdio>
 #include <cstdlib>
 
@@ -65,25 +66,28 @@
 
 /// ASSERT(condition) checks if the condition is met, and if not, prints
 /// an error message indicating the module and line where the error
-/// occurred and then aborts.
+/// occurred and then aborts. Beware: this happens even for release/NODEBUG
+/// builds!
 
 #ifndef ASSERT
 #    define ASSERT(x)                                                          \
         (OIIO_LIKELY(x)                                                        \
              ? ((void)0)                                                       \
-             : (std::fprintf(stderr, "%s:%u: failed assertion '%s'\n",         \
-                             __FILE__, __LINE__, #x),                          \
+             : (std::fprintf(stderr, "%s:%u: %s: Assertion '%s' failed.\n",    \
+                             __FILE__, __LINE__, OIIO_PRETTY_FUNCTION, #x),    \
                 abort()))
 #endif
 
 /// ASSERT_MSG(condition,msg,...) is like ASSERT, but lets you add
 /// formatted output (a la printf) to the failure message.
 #ifndef ASSERT_MSG
-#    define ASSERT_MSG(x, msg, ...)                                             \
-        (OIIO_LIKELY(x)                                                         \
-             ? ((void)0)                                                        \
-             : (std::fprintf(stderr, "%s:%u: failed assertion '%s': " msg "\n", \
-                             __FILE__, __LINE__, #x, __VA_ARGS__),              \
+#    define ASSERT_MSG(x, msg, ...)                                            \
+        (OIIO_LIKELY(x)                                                        \
+             ? ((void)0)                                                       \
+             : (std::fprintf(stderr,                                           \
+                             "%s:%u: %s: Assertion '%s' failed: " msg "\n",    \
+                             __FILE__, __LINE__, OIIO_PRETTY_FUNCTION, #x,     \
+                             __VA_ARGS__),                                     \
                 abort()))
 #endif
 
@@ -92,11 +96,10 @@
 #endif
 
 
-/// DASSERT(condition) is just like ASSERT, except that it only is
-/// functional in DEBUG mode, but does nothing when in a non-DEBUG
-/// (optimized, shipping) build.
+/// DASSERT(condition) is just an alias for the usual assert() macro.
+/// It does nothing when in a non-DEBUG (optimized, shipping) build.
 #ifndef NDEBUG
-#    define DASSERT(x) ASSERT(x)
+#    define DASSERT(x) assert(x)
 #else
 /* DASSERT does nothing when not debugging; sizeof trick prevents warnings */
 #    define DASSERT(x) ((void)sizeof(x)) /*NOLINT*/

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -363,6 +363,17 @@
 #endif
 
 
+
+// OIIO_PRETTY_FUNCTION gives a text string of the current function
+// declaration.
+#ifndef _MSC_VER
+#    define OIIO_PRETTY_FUNCTION __PRETTY_FUNCTION__ /* gcc, clang */
+#else
+#    define OIIO_PRETTY_FUNCTION __FUNCSIG__ /* MS gotta be different */
+#endif
+
+
+
 OIIO_NAMESPACE_BEGIN
 
 /// Class for describing endianness. Test for endianness as


### PR DESCRIPTION
* Use pretty function printing to show what func it failed in.

* Changing wording to more closely match built in assert().

* Make DASSERT simply define to built in assert(), which has the
 advantage compiling without warnings and running correctly with Cuda!
 The ASSERT (works in debug mode as well) and [D]ASSERT_MSG macros
 still are not Cuda friendly because they specifically mention stderr.

