### PR TITLE
Protect simd.h against stray #define of True or False

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -226,6 +226,15 @@
 #define OIIO_SIMD_HAS_SIMD16 1   /* vfloat16, vint16, vbool16 defined */
 
 
+// Embarrassing hack: Xlib.h #define's True and False!
+#ifdef True
+#    undef True
+#endif
+#ifdef False
+#    undef False
+#endif
+
+
 
 OIIO_NAMESPACE_BEGIN
 


### PR DESCRIPTION
This proposed patch just #undef's it. 

Optionally, I could also re-define it at the end, like:

    #ifdef _X11_XLIB_H_ /* regrettable */
        #define True 1
        #define False 1
    #endif 

I'm not sure if that's clever, or "too clever" and will cause more trouble.
