### PR TITLE
Fix inability for python to set timecode

### DIFF
--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -130,9 +130,12 @@ py_indexable_pod_to_stdvector(std::vector<T>& vals, const PYT& obj)
         } else if ((std::is_same<T, float>::value || std::is_same<T, int>::value)
                    && py::isinstance<py::int_>(elem)) {
             vals.emplace_back(elem.template cast<int>());
+        } else if (std::is_same<T, unsigned int>::value
+                   && py::isinstance<py::int_>(elem)) {
+            vals.emplace_back(elem.template cast<unsigned int>());
         } else {
             // FIXME? Other cases?
-            vals.emplace_back(T(0));
+            vals.emplace_back(T(42));
             ok = false;
         }
     }
@@ -324,6 +327,13 @@ attribute_typed(T& myobj, string_view name, TypeDesc type, const POBJ& dataobj)
 {
     if (type.basetype == TypeDesc::INT) {
         std::vector<int> vals;
+        py_to_stdvector(vals, dataobj);
+        if (vals.size() == type.numelements() * type.aggregate)
+            myobj.attribute(name, type, &vals[0]);
+        return;
+    }
+    if (type.basetype == TypeDesc::UINT) {
+        std::vector<unsigned int> vals;
         py_to_stdvector(vals, dataobj);
         if (vals.size() == type.numelements() * type.aggregate)
             myobj.attribute(name, type, &vals[0]);

--- a/testsuite/python-imagespec/ref/out-python3.txt
+++ b/testsuite/python-imagespec/ref/out-python3.txt
@@ -87,8 +87,9 @@ getattribute('foo_str') retrieves blah
 getattribute('foo_vector') retrieves (1.0, 0.0, 11.0)
 getattribute('foo_matrix') retrieves (1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0, 1.0)
 getattribute('foo_no') retrieves None
+getattribute('smpte:TimeCode') retrieves (18356486, 4294967295)
 
-extra_attribs size is 5
+extra_attribs size is 6
 0 foo_str string blah
 "blah"
 1 foo_int int 14
@@ -99,6 +100,8 @@ extra_attribs size is 5
 1 0 11
 4 foo_matrix matrix (1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0, 1.0)
 1 0 0 0 0 2 0 0 0 0 1 0 1 2 3 1
+5 smpte:TimeCode timecode (18356486, 4294967295)
+01:18:19:06
 
 seralize(xml):
 <ImageSpec version="22">
@@ -134,6 +137,7 @@ seralize(xml):
 <attrib name="foo_float" type="float">3.14</attrib>
 <attrib name="foo_vector" type="vector">1 0 11</attrib>
 <attrib name="foo_matrix" type="matrix">1 0 0 0 0 2 0 0 0 0 1 0 1 2 3 1</attrib>
+<attrib name="smpte:TimeCode" type="timecode" description="01:18:19:06">01:18:19:06</attrib>
 </ImageSpec>
 
 serialize(text, human):
@@ -148,6 +152,7 @@ serialize(text, human):
     foo_matrix: 1 0 0 0 0 2 0 0 0 0 1 0 1 2 3 1
     foo_str: "blah"
     foo_vector: 1 0 11
+    smpte:TimeCode: 01:18:19:06
 
 Testing construction from ROI:
   resolution (width,height,depth) =  640 480 1

--- a/testsuite/python-imagespec/ref/out.txt
+++ b/testsuite/python-imagespec/ref/out.txt
@@ -87,8 +87,9 @@ getattribute('foo_str') retrieves blah
 getattribute('foo_vector') retrieves (1.0, 0.0, 11.0)
 getattribute('foo_matrix') retrieves (1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0, 1.0)
 getattribute('foo_no') retrieves None
+getattribute('smpte:TimeCode') retrieves (18356486L, 4294967295L)
 
-extra_attribs size is 5
+extra_attribs size is 6
 0 foo_str string blah
 "blah"
 1 foo_int int 14
@@ -99,6 +100,8 @@ extra_attribs size is 5
 1 0 11
 4 foo_matrix matrix (1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0, 1.0)
 1 0 0 0 0 2 0 0 0 0 1 0 1 2 3 1
+5 smpte:TimeCode timecode (18356486L, 4294967295L)
+01:18:19:06
 
 seralize(xml):
 <ImageSpec version="22">
@@ -134,6 +137,7 @@ seralize(xml):
 <attrib name="foo_float" type="float">3.14</attrib>
 <attrib name="foo_vector" type="vector">1 0 11</attrib>
 <attrib name="foo_matrix" type="matrix">1 0 0 0 0 2 0 0 0 0 1 0 1 2 3 1</attrib>
+<attrib name="smpte:TimeCode" type="timecode" description="01:18:19:06">01:18:19:06</attrib>
 </ImageSpec>
 
 serialize(text, human):
@@ -148,6 +152,7 @@ serialize(text, human):
     foo_matrix: 1 0 0 0 0 2 0 0 0 0 1 0 1 2 3 1
     foo_str: "blah"
     foo_vector: 1 0 11
+    smpte:TimeCode: 01:18:19:06
 
 Testing construction from ROI:
   resolution (width,height,depth) =  640 480 1

--- a/testsuite/python-imagespec/src/test_imagespec.py
+++ b/testsuite/python-imagespec/src/test_imagespec.py
@@ -89,6 +89,7 @@ try:
     s.attribute ("foo_vector", oiio.TypeDesc.TypeVector, (1, 0, 11))
     s.attribute ("foo_matrix", oiio.TypeDesc.TypeMatrix,
                  (1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1))
+    s.attribute ("smpte:TimeCode", oiio.TypeDesc.TypeTimeCode, (18356486, 4294967295))
     print ("get_int_attribute('foo_int') retrieves", s.get_int_attribute ("foo_int"))
     print ("get_int_attribute('foo_int',21) with default retrieves", s.get_int_attribute ("foo_int", 21))
     print ("get_int_attribute('foo_no',23) retrieves", s.get_int_attribute ("foo_no", 23))
@@ -105,6 +106,7 @@ try:
     print ("getattribute('foo_vector') retrieves", s.getattribute("foo_vector"))
     print ("getattribute('foo_matrix') retrieves", s.getattribute("foo_matrix"))
     print ("getattribute('foo_no') retrieves", s.getattribute("foo_no"))
+    print ("getattribute('smpte:TimeCode') retrieves", s.getattribute("smpte:TimeCode"))
     print ()
 
     print ("extra_attribs size is", len(s.extra_attribs))


### PR DESCRIPTION
It actually boiled down to trouble with setting unsigned int array attribute
from Python int tuples.

Make sure to test this in testsuite/python-imagespec

Fixes #2275 
