### PR TITLE
Reorder includes for Python.h and POSIX_C_SOURCE macro

### DIFF
--- a/src/python/py_colorconfig.cpp
+++ b/src/python/py_colorconfig.cpp
@@ -28,10 +28,9 @@
   (This is the Modified BSD License)
 */
 
-#include <utility>
-
 #include "py_oiio.h"
 #include <OpenImageIO/color.h>
+#include <utility>
 
 namespace PyOpenImageIO {
 

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -12,6 +12,9 @@
 #endif
 
 // Must include Python.h first to avoid certain warnings
+#ifdef _POSIX_C_SOURCE
+#  error "You must include Python.h (and therefore py_oiio.h) BEFORE anything that defines _POSIX_C_SOURCE"
+#endif 
 #include <Python.h>
 
 #include <memory>


### PR DESCRIPTION
## Description
Python.h will set POSIX_C_SOURCE it was built with and py_oiio.h includes that first
