### PR TITLE
Fix embarrassing ustring::compare(string_view) bug

### DIFF
--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -515,30 +515,9 @@ public:
     /// Return 0 if *this is lexicographically equal to str, -1 if
     /// *this is lexicographically earlier than str, 1 if *this is
     /// lexicographically after str.
-
-    int compare(const ustring& str) const noexcept
-    {
-        return (c_str() == str.c_str())
-                   ? 0
-                   : strcmp(c_str() ? c_str() : "",
-                            str.c_str() ? str.c_str() : "");
-    }
-
-    /// Return 0 if *this is lexicographically equal to str, -1 if
-    /// *this is lexicographically earlier than str, 1 if *this is
-    /// lexicographically after str.
-    int compare(const std::string& str) const noexcept
-    {
-        return strcmp(c_str() ? c_str() : "", str.c_str());
-    }
-
-    /// Return 0 if *this is lexicographically equal to str, -1 if
-    /// *this is lexicographically earlier than str, 1 if *this is
-    /// lexicographically after str.
     int compare(string_view str) const noexcept
     {
-        return strncmp(c_str() ? c_str() : "", str.data() ? str.data() : "",
-                       str.length());
+        return string_view(*this).compare(str);
     }
 
     /// Return 0 if *this is lexicographically equal to str, -1 if
@@ -554,7 +533,7 @@ public:
     /// after b.
     friend int compare(const std::string& a, const ustring& b) noexcept
     {
-        return strcmp(a.c_str(), b.c_str() ? b.c_str() : "");
+        return string_view(a).compare(b);
     }
 
     /// Test two ustrings for equality -- are they comprised of the same

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -915,6 +915,43 @@ test_float_formatting()
 
 
 
+template<typename S, typename T>
+void
+test_string_compare_function_impl()
+{
+    S foo("foo");
+    // Test same string
+    OIIO_CHECK_EQUAL(foo.compare(T("foo")), 0);
+    // Test different string of same length
+    OIIO_CHECK_GE(foo.compare(T("bar")), 0);
+    OIIO_CHECK_GE(foo.compare(T("fon")), 0);
+    OIIO_CHECK_LE(foo.compare(T("fop")), 0);
+    // Test against shorter
+    OIIO_CHECK_GE(foo.compare(T("a")), 0);
+    OIIO_CHECK_GE(foo.compare(T("fo")), 0); // common sub, ing
+    OIIO_CHECK_LE(foo.compare(T("foobar")), 0); // common substring
+    OIIO_CHECK_GE(foo.compare(T("bart")), 0);
+    // Test against empty string
+    OIIO_CHECK_GE(foo.compare(""), 0);
+}
+
+
+void
+test_string_compare_function()
+{
+    test_string_compare_function_impl<ustring, const char*>();
+    test_string_compare_function_impl<ustring, string_view>();
+    test_string_compare_function_impl<ustring, ustring>();
+    test_string_compare_function_impl<ustring, std::string>();
+
+    test_string_compare_function_impl<string_view, const char*>();
+    test_string_compare_function_impl<string_view, string_view>();
+    test_string_compare_function_impl<string_view, ustring>();
+    test_string_compare_function_impl<string_view, std::string>();
+}
+
+
+
 int
 main(int argc, char* argv[])
 {
@@ -941,6 +978,7 @@ main(int argc, char* argv[])
     test_parse();
     test_locale();
     // test_float_formatting ();
+    test_string_compare_function();
 
     return unit_test_failures;
 }


### PR DESCRIPTION
The logic was wrong in cases where the string_view was longer than the
ustring, but they has the same character sequence up to the length of
the ustring.

Add some unit tests to ferret out this case.

To do: fully flesh out unit tests for every last bit of functionality
of ustring and string_view.
