### PR TITLE
linking with rt is required on older linux distros

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -100,6 +100,11 @@ else ()
                   COMPONENTS ${Boost_COMPONENTS})
 endif ()
 
+# On Linux, Boost 1.55 and higher seems to need to link against -lrt
+if (CMAKE_SYSTEM_NAME MATCHES "Linux" AND ${Boost_VERSION} GREATER 105499)
+    list (APPEND Boost_LIBRARIES "rt")
+endif ()
+
 message (STATUS "Boost version ${Boost_VERSION}")
 if (NOT Boost_FIND_QUIETLY)
     message (STATUS "Boost found        ${Boost_FOUND} ")


### PR DESCRIPTION
## Description
Building on centos 6, I get errors such as:
```
[ 90%] Linking CXX executable iconvert
../../../../external/dist/linux64/lib/boost_1_64_0/libboost_thread.a(thread.o):libs/thread/src/pthread/thread.cpp:function boost::this_thread::no_interruption_point::hidden::sleep_until(timespec const&): error: undefined reference to 'clock_gettime'
../../../../external/dist/linux64/lib/boost_1_64_0/libboost_thread.a(thread.o):libs/thread/src/pthread/thread.cpp:function boost::this_thread::no_interruption_point::hidden::sleep_until(timespec const&): error: undefined reference to 'clock_gettime'
../../../../external/dist/linux64/lib/boost_1_64_0/libboost_thread.a(thread.o):libs/thread/src/pthread/thread.cpp:function boost::this_thread::no_interruption_point::hidden::sleep_until(timespec const&): error: undefined reference to 'clock_gettime'
../../../../external/dist/linux64/lib/boost_1_64_0/libboost_thread.a(thread.o):libs/thread/src/pthread/thread.cpp:function boost::this_thread::no_interruption_point::hidden::sleep_until(timespec const&): error: undefined reference to 'clock_gettime'
clang-5.0: error: linker command failed with exit code 1 (use -v to see invocation)
make[3]: *** [src/iconvert/iconvert] Error 1
```
This used to work until 5b65b3e3 removed the linking to rt, which is fine for newer linux distros, such as centos 7, but not older ones that use a glibc older than 2.17, such as centos 6. https://stackoverflow.com/a/32649327 contains some information about this. 

This PR reverts the removal of -lrt. Since OIIO is multi-threaded, I don't think there's any downside to linking with rt on newer distros?
<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

I suppose this could be tested through CI that uses an older linux distro?

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

