### PR TITLE
iv: Add -rawcolor option to skip auto-convert to RGB

### DIFF
--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -774,7 +774,10 @@ ImageViewer::add_image(const std::string& filename)
 {
     if (filename.empty())
         return;
-    IvImage* newimage = new IvImage(filename);
+    ImageSpec config;
+    if (rawcolor())
+        config.attribute("oiio:RawColor", 1);
+    IvImage* newimage = new IvImage(filename, &config);
     ASSERT(newimage);
     newimage->gamma(m_default_gamma);
     m_images.push_back(newimage);

--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -51,11 +51,13 @@ class IvInfoWindow;
 class IvPreferenceWindow;
 class IvCanvas;
 class IvGL;
-class IvImage;
+class ImageViewer;
+
 
 class IvImage : public ImageBuf {
 public:
-    IvImage(const std::string& filename);
+    IvImage(const std::string& filename,
+            const ImageSpec* input_config = nullptr);
     virtual ~IvImage();
 
     /// Read the image into ram.
@@ -230,6 +232,9 @@ public:
 
     QPalette palette(void) const { return m_palette; }
 
+    void rawcolor(bool val) { m_rawcolor = val; }
+    bool rawcolor() const { return m_rawcolor; }
+
 private slots:
     void open();                ///< Dialog to open new image from file
     void reload();              ///< Reread current image from disk
@@ -381,6 +386,7 @@ private:
     float m_default_gamma;                    // Default gamma of the display
     QPalette m_palette;                       // Custom palette
     bool m_darkPalette;                       // Use dark palette?
+    bool m_rawcolor = false;                  // Use raw color mode
 
     // The default width and height of the window:
     static const int m_default_width  = 640;

--- a/src/iv/ivimage.cpp
+++ b/src/iv/ivimage.cpp
@@ -12,8 +12,8 @@
 #include <OpenImageIO/strutil.h>
 
 
-IvImage::IvImage(const std::string& filename)
-    : ImageBuf(filename)
+IvImage::IvImage(const std::string& filename, const ImageSpec* input_config)
+    : ImageBuf(filename, 0, 0, nullptr, input_config)
     , m_thumbnail(NULL)
     , m_thumbnail_valid(false)
     , m_gamma(1)

--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -34,6 +34,7 @@ using namespace OIIO;
 static bool verbose         = false;
 static bool foreground_mode = false;
 static bool autopremult     = true;
+static bool rawcolor        = false;
 static std::vector<std::string> filenames;
 
 
@@ -63,6 +64,8 @@ getargs(int argc, char* argv[])
                 "-F", &foreground_mode, "Foreground mode",
                 "--no-autopremult %!", &autopremult,
                     "Turn off automatic premultiplication of images with unassociated alpha",
+                "--rawcolor", &rawcolor,
+                    "Do not automatically transform to RGB",
                 nullptr);
     // clang-format on
     if (ap.parse(argc, (const char**)argv) < 0) {
@@ -112,6 +115,8 @@ main(int argc, char* argv[])
     imagecache->attribute("deduplicate", (int)0);
     if (!autopremult)
         imagecache->attribute("unassociatedalpha", 1);
+    if (rawcolor)
+        mainWin->rawcolor(true);
 
     // Make sure we are the top window with the focus.
     mainWin->raise();


### PR DESCRIPTION
For better inspection of raw values of CMYK or other non-RGB color
spaces that would ordinarily be automatically converted.

