### PR TITLE
oiiotool: use a shared IC

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -6068,7 +6068,7 @@ main(int argc, char* argv[])
     // internationalization, for the entire oiiotool application.
     std::locale::global(std::locale::classic());
 
-    ot.imagecache = ImageCache::create(false);
+    ot.imagecache = ImageCache::create();
     ASSERT(ot.imagecache);
     ot.imagecache->attribute("forcefloat", 1);
     ot.imagecache->attribute("max_memory_MB", float(ot.cachesize));


### PR DESCRIPTION
I can't think of any reason why the old code was making a custom
cache, but it interfered with setting certain cache options from
the command line.

