### PR TITLE
IBA::computePixelStats was not properly controlling the number of threads

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -134,6 +134,7 @@ computePixelStats_(const ImageBuf& src, ImageBufAlgo::PixelStats& stats,
     stats.reset(nchannels);
     OIIO::spin_mutex mutex;  // protect the shared stats when merging
 
+    parallel_options opt(nthreads);
     if (src.deep()) {
         parallel_for_chunked(roi.ybegin, roi.yend, 64,
                              [&](int id, int64_t ybegin, int64_t yend) {
@@ -154,7 +155,7 @@ computePixelStats_(const ImageBuf& src, ImageBufAlgo::PixelStats& stats,
             }
             std::lock_guard<OIIO::spin_mutex> lock(mutex);
             stats.merge(tmp);
-        });
+        }, opt);
 
     } else {  // Non-deep case
         parallel_for_chunked(roi.ybegin, roi.yend, 64,
@@ -171,7 +172,7 @@ computePixelStats_(const ImageBuf& src, ImageBufAlgo::PixelStats& stats,
             }
             std::lock_guard<OIIO::spin_mutex> lock(mutex);
             stats.merge(tmp);
-        });
+        }, opt);
     }
 
     // Compute final results


### PR DESCRIPTION
By not passing the nthreads param to the parallel_for_chunked loop,
it was always running fully threaded instead of being controlled by
the nthreads passed to it.
