### PR TITLE
Work around find_package() failure for boost versions with cmake output

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -96,8 +96,21 @@ else ()
     if (NOT USE_STD_REGEX)
         list (APPEND Boost_COMPONENTS regex)
     endif ()
+    # The FindBoost.cmake interface is broken if it uses boost's installed
+    # cmake output (e.g. boost 1.70.0, cmake <= 3.14). Specifically it fails
+    # to set the expected variables printed below. So until that's fixed
+    # force FindBoost.cmake to use the original brute force path.
+    set (Boost_NO_BOOST_CMAKE ON)
     find_package (Boost 1.53 REQUIRED
                   COMPONENTS ${Boost_COMPONENTS})
+    if (Boost_FOUND)
+        message (STATUS "Boost include      ${Boost_INCLUDE_DIR} ")
+        message (STATUS "Boost lib debug    ${Boost_LIBRARY_DIR_DEBUG} ")
+        message (STATUS "Boost lib release  ${Boost_LIBRARY_DIR_RELEASE} ")
+        message (STATUS "Boost include dirs ${Boost_INCLUDE_DIRS}")
+        message (STATUS "Boost library dirs ${Boost_LIBRARY_DIRS}")
+        message (STATUS "Boost libraries    ${Boost_LIBRARIES}")
+    endif ()
 endif ()
 
 # On Linux, Boost 1.55 and higher seems to need to link against -lrt


### PR DESCRIPTION
The FindBoost.cmake interface is broken if it uses boost's installed cmake
output (e.g. boost 1.70.0, cmake <= 3.14) at least in the case that boost
was installed to a non-standard prefix. Specifically it fails to set
variables as indicated in FindBoost.cmake documentation. So until that's
fixed force FindBoost.cmake to use the original path which is consistent
with its docs.


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

