### PR TITLE
TIFF fixes: enhance r/w of 6, 14, and 24 bit per sample images.

### DIFF
--- a/testsuite/tiff-depths/ref/out.txt
+++ b/testsuite/tiff-depths/ref/out.txt
@@ -18,6 +18,10 @@ Reading ../../../../../libtiffpic/depth/flower-minisblack-02.tif
     tiff:RowsPerStrip: 431
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-02.tif" and "flower-minisblack-02.tif"
 PASS
+flower-minisblack-02.tif :   73 x   43, 1 channel, uint2 tiff
+    SHA-1: F6BD9D10FB0DD8E9AC62DEBBB743A78FC48D3C9B
+../../../../../libtiffpic/depth/flower-minisblack-02.tif :   73 x   43, 1 channel, uint2 tiff
+    SHA-1: F6BD9D10FB0DD8E9AC62DEBBB743A78FC48D3C9B
 Reading ../../../../../libtiffpic/depth/flower-minisblack-04.tif
 ../../../../../libtiffpic/depth/flower-minisblack-04.tif :   73 x   43, 1 channel, uint4 tiff
     SHA-1: 8C0CF14B3B585F4B1F249C681BEDEA4CB63E3EDD
@@ -38,6 +42,10 @@ Reading ../../../../../libtiffpic/depth/flower-minisblack-04.tif
     tiff:RowsPerStrip: 221
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-04.tif" and "flower-minisblack-04.tif"
 PASS
+flower-minisblack-04.tif :   73 x   43, 1 channel, uint4 tiff
+    SHA-1: 8C0CF14B3B585F4B1F249C681BEDEA4CB63E3EDD
+../../../../../libtiffpic/depth/flower-minisblack-04.tif :   73 x   43, 1 channel, uint4 tiff
+    SHA-1: 8C0CF14B3B585F4B1F249C681BEDEA4CB63E3EDD
 Reading ../../../../../libtiffpic/depth/flower-minisblack-06.tif
 ../../../../../libtiffpic/depth/flower-minisblack-06.tif :   73 x   43, 1 channel, uint6 tiff
     SHA-1: AE809BFEF36E3E0047343655231200A916D83492
@@ -58,6 +66,10 @@ Reading ../../../../../libtiffpic/depth/flower-minisblack-06.tif
     tiff:RowsPerStrip: 148
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-06.tif" and "flower-minisblack-06.tif"
 PASS
+flower-minisblack-06.tif :   73 x   43, 1 channel, uint6 tiff
+    SHA-1: AE809BFEF36E3E0047343655231200A916D83492
+../../../../../libtiffpic/depth/flower-minisblack-06.tif :   73 x   43, 1 channel, uint6 tiff
+    SHA-1: AE809BFEF36E3E0047343655231200A916D83492
 Reading ../../../../../libtiffpic/depth/flower-minisblack-08.tif
 ../../../../../libtiffpic/depth/flower-minisblack-08.tif :   73 x   43, 1 channel, uint8 tiff
     SHA-1: 1A909C8E70CC479D8A35BAA9BFEDDCBF4BF46FDC
@@ -78,6 +90,10 @@ Reading ../../../../../libtiffpic/depth/flower-minisblack-08.tif
     tiff:RowsPerStrip: 112
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-08.tif" and "flower-minisblack-08.tif"
 PASS
+flower-minisblack-08.tif :   73 x   43, 1 channel, uint8 tiff
+    SHA-1: 1A909C8E70CC479D8A35BAA9BFEDDCBF4BF46FDC
+../../../../../libtiffpic/depth/flower-minisblack-08.tif :   73 x   43, 1 channel, uint8 tiff
+    SHA-1: 1A909C8E70CC479D8A35BAA9BFEDDCBF4BF46FDC
 Reading ../../../../../libtiffpic/depth/flower-minisblack-10.tif
 ../../../../../libtiffpic/depth/flower-minisblack-10.tif :   73 x   43, 1 channel, uint10 tiff
     SHA-1: E9240FEF19CC8EF5EBBF2EE4A10EDF25E51C67B4
@@ -98,6 +114,10 @@ Reading ../../../../../libtiffpic/depth/flower-minisblack-10.tif
     tiff:RowsPerStrip: 89
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-10.tif" and "flower-minisblack-10.tif"
 PASS
+flower-minisblack-10.tif :   73 x   43, 1 channel, uint10 tiff
+    SHA-1: E9240FEF19CC8EF5EBBF2EE4A10EDF25E51C67B4
+../../../../../libtiffpic/depth/flower-minisblack-10.tif :   73 x   43, 1 channel, uint10 tiff
+    SHA-1: E9240FEF19CC8EF5EBBF2EE4A10EDF25E51C67B4
 Reading ../../../../../libtiffpic/depth/flower-minisblack-12.tif
 ../../../../../libtiffpic/depth/flower-minisblack-12.tif :   73 x   43, 1 channel, uint12 tiff
     SHA-1: AAE977957ED6AAC647967192A74E4AD55FF75811
@@ -118,6 +138,10 @@ Reading ../../../../../libtiffpic/depth/flower-minisblack-12.tif
     tiff:RowsPerStrip: 74
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-12.tif" and "flower-minisblack-12.tif"
 PASS
+flower-minisblack-12.tif :   73 x   43, 1 channel, uint12 tiff
+    SHA-1: AAE977957ED6AAC647967192A74E4AD55FF75811
+../../../../../libtiffpic/depth/flower-minisblack-12.tif :   73 x   43, 1 channel, uint12 tiff
+    SHA-1: AAE977957ED6AAC647967192A74E4AD55FF75811
 Reading ../../../../../libtiffpic/depth/flower-minisblack-14.tif
 ../../../../../libtiffpic/depth/flower-minisblack-14.tif :   73 x   43, 1 channel, uint14 tiff
     SHA-1: C1B9CA21C227EF11626EF0C58BD49769EEF48363
@@ -138,6 +162,10 @@ Reading ../../../../../libtiffpic/depth/flower-minisblack-14.tif
     tiff:RowsPerStrip: 64
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-14.tif" and "flower-minisblack-14.tif"
 PASS
+flower-minisblack-14.tif :   73 x   43, 1 channel, uint14 tiff
+    SHA-1: C1B9CA21C227EF11626EF0C58BD49769EEF48363
+../../../../../libtiffpic/depth/flower-minisblack-14.tif :   73 x   43, 1 channel, uint14 tiff
+    SHA-1: C1B9CA21C227EF11626EF0C58BD49769EEF48363
 Reading ../../../../../libtiffpic/depth/flower-minisblack-16.tif
 ../../../../../libtiffpic/depth/flower-minisblack-16.tif :   73 x   43, 1 channel, uint16 tiff
     SHA-1: 7EBB74E46C869CA0D6D091183732214B6A75173A
@@ -158,6 +186,34 @@ Reading ../../../../../libtiffpic/depth/flower-minisblack-16.tif
     tiff:RowsPerStrip: 56
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-16.tif" and "flower-minisblack-16.tif"
 PASS
+flower-minisblack-16.tif :   73 x   43, 1 channel, uint16 tiff
+    SHA-1: 7EBB74E46C869CA0D6D091183732214B6A75173A
+../../../../../libtiffpic/depth/flower-minisblack-16.tif :   73 x   43, 1 channel, uint16 tiff
+    SHA-1: 7EBB74E46C869CA0D6D091183732214B6A75173A
+Reading ../../../../../libtiffpic/depth/flower-minisblack-24.tif
+../../../../../libtiffpic/depth/flower-minisblack-24.tif :   73 x   43, 1 channel, uint24 tiff
+    SHA-1: BBFA6633ECF3FF686DB36F6DD00F8A359D2B1DAF
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-24.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q8 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 24
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 37
+Comparing "../../../../../libtiffpic/depth/flower-minisblack-24.tif" and "flower-minisblack-24.tif"
+PASS
+flower-minisblack-24.tif :   73 x   43, 1 channel, uint24 tiff
+    SHA-1: BBFA6633ECF3FF686DB36F6DD00F8A359D2B1DAF
+../../../../../libtiffpic/depth/flower-minisblack-24.tif :   73 x   43, 1 channel, uint24 tiff
+    SHA-1: BBFA6633ECF3FF686DB36F6DD00F8A359D2B1DAF
 Reading ../../../../../libtiffpic/depth/flower-minisblack-32.tif
 ../../../../../libtiffpic/depth/flower-minisblack-32.tif :   73 x   43, 1 channel, uint tiff
     SHA-1: C98FB1125C7210E380E3F86DFCAEFF49A16742E0
@@ -178,6 +234,10 @@ Reading ../../../../../libtiffpic/depth/flower-minisblack-32.tif
     tiff:RowsPerStrip: 28
 Comparing "../../../../../libtiffpic/depth/flower-minisblack-32.tif" and "flower-minisblack-32.tif"
 PASS
+flower-minisblack-32.tif :   73 x   43, 1 channel, uint tiff
+    SHA-1: C98FB1125C7210E380E3F86DFCAEFF49A16742E0
+../../../../../libtiffpic/depth/flower-minisblack-32.tif :   73 x   43, 1 channel, uint tiff
+    SHA-1: C98FB1125C7210E380E3F86DFCAEFF49A16742E0
 Reading ../../../../../libtiffpic/depth/flower-palette-02.tif
 ../../../../../libtiffpic/depth/flower-palette-02.tif :   73 x   43, 3 channel, uint8 tiff
     SHA-1: 52B3033465AA01129BAE149FF96CBB49877DAB7C
@@ -200,6 +260,10 @@ Reading ../../../../../libtiffpic/depth/flower-palette-02.tif
     tiff:RowsPerStrip: 431
 Comparing "../../../../../libtiffpic/depth/flower-palette-02.tif" and "flower-palette-02.tif"
 PASS
+flower-palette-02.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 52B3033465AA01129BAE149FF96CBB49877DAB7C
+../../../../../libtiffpic/depth/flower-palette-02.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 52B3033465AA01129BAE149FF96CBB49877DAB7C
 Reading ../../../../../libtiffpic/depth/flower-palette-04.tif
 ../../../../../libtiffpic/depth/flower-palette-04.tif :   73 x   43, 3 channel, uint8 tiff
     SHA-1: C6E40A3D134F1A29E153FE15459D8DE657CB7F9C
@@ -222,6 +286,10 @@ Reading ../../../../../libtiffpic/depth/flower-palette-04.tif
     tiff:RowsPerStrip: 221
 Comparing "../../../../../libtiffpic/depth/flower-palette-04.tif" and "flower-palette-04.tif"
 PASS
+flower-palette-04.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: C6E40A3D134F1A29E153FE15459D8DE657CB7F9C
+../../../../../libtiffpic/depth/flower-palette-04.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: C6E40A3D134F1A29E153FE15459D8DE657CB7F9C
 Reading ../../../../../libtiffpic/depth/flower-palette-08.tif
 ../../../../../libtiffpic/depth/flower-palette-08.tif :   73 x   43, 3 channel, uint8 tiff
     SHA-1: 0ADA355BABFE9866F3D88AF7CA3AAC69D7DC036D
@@ -243,6 +311,10 @@ Reading ../../../../../libtiffpic/depth/flower-palette-08.tif
     tiff:RowsPerStrip: 112
 Comparing "../../../../../libtiffpic/depth/flower-palette-08.tif" and "flower-palette-08.tif"
 PASS
+flower-palette-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 0ADA355BABFE9866F3D88AF7CA3AAC69D7DC036D
+../../../../../libtiffpic/depth/flower-palette-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 0ADA355BABFE9866F3D88AF7CA3AAC69D7DC036D
 Reading ../../../../../libtiffpic/depth/flower-rgb-contig-02.tif
 ../../../../../libtiffpic/depth/flower-rgb-contig-02.tif :   73 x   43, 3 channel, uint2 tiff
     SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
@@ -263,6 +335,10 @@ Reading ../../../../../libtiffpic/depth/flower-rgb-contig-02.tif
     tiff:RowsPerStrip: 148
 Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-02.tif" and "flower-rgb-contig-02.tif"
 PASS
+flower-rgb-contig-02.tif :   73 x   43, 3 channel, uint2 tiff
+    SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
+../../../../../libtiffpic/depth/flower-rgb-contig-02.tif :   73 x   43, 3 channel, uint2 tiff
+    SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
 Reading ../../../../../libtiffpic/depth/flower-rgb-contig-04.tif
 ../../../../../libtiffpic/depth/flower-rgb-contig-04.tif :   73 x   43, 3 channel, uint4 tiff
     SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
@@ -283,6 +359,10 @@ Reading ../../../../../libtiffpic/depth/flower-rgb-contig-04.tif
     tiff:RowsPerStrip: 74
 Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-04.tif" and "flower-rgb-contig-04.tif"
 PASS
+flower-rgb-contig-04.tif :   73 x   43, 3 channel, uint4 tiff
+    SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
+../../../../../libtiffpic/depth/flower-rgb-contig-04.tif :   73 x   43, 3 channel, uint4 tiff
+    SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
 Reading ../../../../../libtiffpic/depth/flower-rgb-contig-08.tif
 ../../../../../libtiffpic/depth/flower-rgb-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
     SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
@@ -303,6 +383,10 @@ Reading ../../../../../libtiffpic/depth/flower-rgb-contig-08.tif
     tiff:RowsPerStrip: 37
 Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-08.tif" and "flower-rgb-contig-08.tif"
 PASS
+flower-rgb-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
+../../../../../libtiffpic/depth/flower-rgb-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
 Reading ../../../../../libtiffpic/depth/flower-rgb-contig-10.tif
 ../../../../../libtiffpic/depth/flower-rgb-contig-10.tif :   73 x   43, 3 channel, uint10 tiff
     SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
@@ -323,6 +407,10 @@ Reading ../../../../../libtiffpic/depth/flower-rgb-contig-10.tif
     tiff:RowsPerStrip: 29
 Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-10.tif" and "flower-rgb-contig-10.tif"
 PASS
+flower-rgb-contig-10.tif :   73 x   43, 3 channel, uint10 tiff
+    SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
+../../../../../libtiffpic/depth/flower-rgb-contig-10.tif :   73 x   43, 3 channel, uint10 tiff
+    SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
 Reading ../../../../../libtiffpic/depth/flower-rgb-contig-12.tif
 ../../../../../libtiffpic/depth/flower-rgb-contig-12.tif :   73 x   43, 3 channel, uint12 tiff
     SHA-1: E61083B50548C7D304A45735452FD05C1814677B
@@ -343,6 +431,10 @@ Reading ../../../../../libtiffpic/depth/flower-rgb-contig-12.tif
     tiff:RowsPerStrip: 24
 Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-12.tif" and "flower-rgb-contig-12.tif"
 PASS
+flower-rgb-contig-12.tif :   73 x   43, 3 channel, uint12 tiff
+    SHA-1: E61083B50548C7D304A45735452FD05C1814677B
+../../../../../libtiffpic/depth/flower-rgb-contig-12.tif :   73 x   43, 3 channel, uint12 tiff
+    SHA-1: E61083B50548C7D304A45735452FD05C1814677B
 Reading ../../../../../libtiffpic/depth/flower-rgb-contig-14.tif
 ../../../../../libtiffpic/depth/flower-rgb-contig-14.tif :   73 x   43, 3 channel, uint14 tiff
     SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
@@ -363,6 +455,10 @@ Reading ../../../../../libtiffpic/depth/flower-rgb-contig-14.tif
     tiff:RowsPerStrip: 21
 Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-14.tif" and "flower-rgb-contig-14.tif"
 PASS
+flower-rgb-contig-14.tif :   73 x   43, 3 channel, uint14 tiff
+    SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
+../../../../../libtiffpic/depth/flower-rgb-contig-14.tif :   73 x   43, 3 channel, uint14 tiff
+    SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
 Reading ../../../../../libtiffpic/depth/flower-rgb-contig-16.tif
 ../../../../../libtiffpic/depth/flower-rgb-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
     SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
@@ -383,6 +479,34 @@ Reading ../../../../../libtiffpic/depth/flower-rgb-contig-16.tif
     tiff:RowsPerStrip: 18
 Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-16.tif" and "flower-rgb-contig-16.tif"
 PASS
+flower-rgb-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
+../../../../../libtiffpic/depth/flower-rgb-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
+Reading ../../../../../libtiffpic/depth/flower-rgb-contig-24.tif
+../../../../../libtiffpic/depth/flower-rgb-contig-24.tif :   73 x   43, 3 channel, uint24 tiff
+    SHA-1: 6234B3CE28DFDF0FE6B1BCC29F62393696AF79A5
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-24.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q8 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 24
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 12
+Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-24.tif" and "flower-rgb-contig-24.tif"
+PASS
+flower-rgb-contig-24.tif :   73 x   43, 3 channel, uint24 tiff
+    SHA-1: 6234B3CE28DFDF0FE6B1BCC29F62393696AF79A5
+../../../../../libtiffpic/depth/flower-rgb-contig-24.tif :   73 x   43, 3 channel, uint24 tiff
+    SHA-1: 6234B3CE28DFDF0FE6B1BCC29F62393696AF79A5
 Reading ../../../../../libtiffpic/depth/flower-rgb-contig-32.tif
 ../../../../../libtiffpic/depth/flower-rgb-contig-32.tif :   73 x   43, 3 channel, uint tiff
     SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
@@ -403,6 +527,10 @@ Reading ../../../../../libtiffpic/depth/flower-rgb-contig-32.tif
     tiff:RowsPerStrip: 9
 Comparing "../../../../../libtiffpic/depth/flower-rgb-contig-32.tif" and "flower-rgb-contig-32.tif"
 PASS
+flower-rgb-contig-32.tif :   73 x   43, 3 channel, uint tiff
+    SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
+../../../../../libtiffpic/depth/flower-rgb-contig-32.tif :   73 x   43, 3 channel, uint tiff
+    SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
 Reading ../../../../../libtiffpic/depth/flower-rgb-planar-02.tif
 ../../../../../libtiffpic/depth/flower-rgb-planar-02.tif :   73 x   43, 3 channel, uint2 tiff
     SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
@@ -423,6 +551,10 @@ Reading ../../../../../libtiffpic/depth/flower-rgb-planar-02.tif
     tiff:RowsPerStrip: 431
 Comparing "../../../../../libtiffpic/depth/flower-rgb-planar-02.tif" and "flower-rgb-planar-02.tif"
 PASS
+flower-rgb-planar-02.tif :   73 x   43, 3 channel, uint2 tiff
+    SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
+../../../../../libtiffpic/depth/flower-rgb-planar-02.tif :   73 x   43, 3 channel, uint2 tiff
+    SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
 Reading ../../../../../libtiffpic/depth/flower-rgb-planar-04.tif
 ../../../../../libtiffpic/depth/flower-rgb-planar-04.tif :   73 x   43, 3 channel, uint4 tiff
     SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
@@ -443,6 +575,10 @@ Reading ../../../../../libtiffpic/depth/flower-rgb-planar-04.tif
     tiff:RowsPerStrip: 221
 Comparing "../../../../../libtiffpic/depth/flower-rgb-planar-04.tif" and "flower-rgb-planar-04.tif"
 PASS
+flower-rgb-planar-04.tif :   73 x   43, 3 channel, uint4 tiff
+    SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
+../../../../../libtiffpic/depth/flower-rgb-planar-04.tif :   73 x   43, 3 channel, uint4 tiff
+    SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
 Reading ../../../../../libtiffpic/depth/flower-rgb-planar-08.tif
 ../../../../../libtiffpic/depth/flower-rgb-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
     SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
@@ -463,6 +599,10 @@ Reading ../../../../../libtiffpic/depth/flower-rgb-planar-08.tif
     tiff:RowsPerStrip: 112
 Comparing "../../../../../libtiffpic/depth/flower-rgb-planar-08.tif" and "flower-rgb-planar-08.tif"
 PASS
+flower-rgb-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
+../../../../../libtiffpic/depth/flower-rgb-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
 Reading ../../../../../libtiffpic/depth/flower-rgb-planar-10.tif
 ../../../../../libtiffpic/depth/flower-rgb-planar-10.tif :   73 x   43, 3 channel, uint10 tiff
     SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
@@ -483,6 +623,10 @@ Reading ../../../../../libtiffpic/depth/flower-rgb-planar-10.tif
     tiff:RowsPerStrip: 89
 Comparing "../../../../../libtiffpic/depth/flower-rgb-planar-10.tif" and "flower-rgb-planar-10.tif"
 PASS
+flower-rgb-planar-10.tif :   73 x   43, 3 channel, uint10 tiff
+    SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
+../../../../../libtiffpic/depth/flower-rgb-planar-10.tif :   73 x   43, 3 channel, uint10 tiff
+    SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
 Reading ../../../../../libtiffpic/depth/flower-rgb-planar-12.tif
 ../../../../../libtiffpic/depth/flower-rgb-planar-12.tif :   73 x   43, 3 channel, uint12 tiff
     SHA-1: E61083B50548C7D304A45735452FD05C1814677B
@@ -503,6 +647,10 @@ Reading ../../../../../libtiffpic/depth/flower-rgb-planar-12.tif
     tiff:RowsPerStrip: 74
 Comparing "../../../../../libtiffpic/depth/flower-rgb-planar-12.tif" and "flower-rgb-planar-12.tif"
 PASS
+flower-rgb-planar-12.tif :   73 x   43, 3 channel, uint12 tiff
+    SHA-1: E61083B50548C7D304A45735452FD05C1814677B
+../../../../../libtiffpic/depth/flower-rgb-planar-12.tif :   73 x   43, 3 channel, uint12 tiff
+    SHA-1: E61083B50548C7D304A45735452FD05C1814677B
 Reading ../../../../../libtiffpic/depth/flower-rgb-planar-14.tif
 ../../../../../libtiffpic/depth/flower-rgb-planar-14.tif :   73 x   43, 3 channel, uint14 tiff
     SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
@@ -523,6 +671,10 @@ Reading ../../../../../libtiffpic/depth/flower-rgb-planar-14.tif
     tiff:RowsPerStrip: 64
 Comparing "../../../../../libtiffpic/depth/flower-rgb-planar-14.tif" and "flower-rgb-planar-14.tif"
 PASS
+flower-rgb-planar-14.tif :   73 x   43, 3 channel, uint14 tiff
+    SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
+../../../../../libtiffpic/depth/flower-rgb-planar-14.tif :   73 x   43, 3 channel, uint14 tiff
+    SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
 Reading ../../../../../libtiffpic/depth/flower-rgb-planar-16.tif
 ../../../../../libtiffpic/depth/flower-rgb-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
     SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
@@ -543,6 +695,58 @@ Reading ../../../../../libtiffpic/depth/flower-rgb-planar-16.tif
     tiff:RowsPerStrip: 56
 Comparing "../../../../../libtiffpic/depth/flower-rgb-planar-16.tif" and "flower-rgb-planar-16.tif"
 PASS
+flower-rgb-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
+../../../../../libtiffpic/depth/flower-rgb-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
+Reading ../../../../../libtiffpic/depth/flower-rgb-planar-24.tif
+../../../../../libtiffpic/depth/flower-rgb-planar-24.tif :   73 x   43, 3 channel, uint24 tiff
+    SHA-1: 6234B3CE28DFDF0FE6B1BCC29F62393696AF79A5
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-24.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q8 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 24
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 37
+Comparing "../../../../../libtiffpic/depth/flower-rgb-planar-24.tif" and "flower-rgb-planar-24.tif"
+PASS
+flower-rgb-planar-24.tif :   73 x   43, 3 channel, uint24 tiff
+    SHA-1: 6234B3CE28DFDF0FE6B1BCC29F62393696AF79A5
+../../../../../libtiffpic/depth/flower-rgb-planar-24.tif :   73 x   43, 3 channel, uint24 tiff
+    SHA-1: 6234B3CE28DFDF0FE6B1BCC29F62393696AF79A5
+Reading ../../../../../libtiffpic/depth/flower-rgb-planar-32.tif
+../../../../../libtiffpic/depth/flower-rgb-planar-32.tif :   73 x   43, 3 channel, uint tiff
+    SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-32.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 32
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 28
+Comparing "../../../../../libtiffpic/depth/flower-rgb-planar-32.tif" and "flower-rgb-planar-32.tif"
+PASS
+flower-rgb-planar-32.tif :   73 x   43, 3 channel, uint tiff
+    SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
+../../../../../libtiffpic/depth/flower-rgb-planar-32.tif :   73 x   43, 3 channel, uint tiff
+    SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
 Reading ../../../../../libtiffpic/depth/flower-separated-contig-08.tif
 ../../../../../libtiffpic/depth/flower-separated-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
     SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
@@ -564,6 +768,10 @@ Reading ../../../../../libtiffpic/depth/flower-separated-contig-08.tif
     tiff:RowsPerStrip: 28
 Comparing "../../../../../libtiffpic/depth/flower-separated-contig-08.tif" and "flower-separated-contig-08.tif"
 PASS
+flower-separated-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
+../../../../../libtiffpic/depth/flower-separated-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
 Reading ../../../../../libtiffpic/depth/flower-separated-contig-16.tif
 ../../../../../libtiffpic/depth/flower-separated-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
     SHA-1: A5C53C7628B01F12DCAE09A42D8B15433644C54C
@@ -585,6 +793,10 @@ Reading ../../../../../libtiffpic/depth/flower-separated-contig-16.tif
     tiff:RowsPerStrip: 14
 Comparing "../../../../../libtiffpic/depth/flower-separated-contig-16.tif" and "flower-separated-contig-16.tif"
 PASS
+flower-separated-contig-16.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: E55335D12E9A20EFB0A5EAE80F1801DF5A9BEE12
+../../../../../libtiffpic/depth/flower-separated-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: A5C53C7628B01F12DCAE09A42D8B15433644C54C
 Reading ../../../../../libtiffpic/depth/flower-separated-planar-08.tif
 ../../../../../libtiffpic/depth/flower-separated-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
     SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
@@ -606,6 +818,10 @@ Reading ../../../../../libtiffpic/depth/flower-separated-planar-08.tif
     tiff:RowsPerStrip: 112
 Comparing "../../../../../libtiffpic/depth/flower-separated-planar-08.tif" and "flower-separated-planar-08.tif"
 PASS
+flower-separated-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
+../../../../../libtiffpic/depth/flower-separated-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
 Reading ../../../../../libtiffpic/depth/flower-separated-planar-16.tif
 ../../../../../libtiffpic/depth/flower-separated-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
     SHA-1: A5C53C7628B01F12DCAE09A42D8B15433644C54C
@@ -627,5 +843,9 @@ Reading ../../../../../libtiffpic/depth/flower-separated-planar-16.tif
     tiff:RowsPerStrip: 56
 Comparing "../../../../../libtiffpic/depth/flower-separated-planar-16.tif" and "flower-separated-planar-16.tif"
 PASS
+flower-separated-planar-16.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: E55335D12E9A20EFB0A5EAE80F1801DF5A9BEE12
+../../../../../libtiffpic/depth/flower-separated-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: A5C53C7628B01F12DCAE09A42D8B15433644C54C
 Comparing "cmyk_as_cmyk.tif" and "ref/cmyk_as_cmyk.tif"
 PASS

--- a/testsuite/tiff-depths/run.py
+++ b/testsuite/tiff-depths/run.py
@@ -13,7 +13,7 @@ files = [
     "flower-minisblack-12.tif",   #  73x43 12-bit minisblack gray image
     "flower-minisblack-14.tif",   #  73x43 14-bit minisblack gray image
     "flower-minisblack-16.tif",   # 73x43 16-bit minisblack gray image
-    #FIXME "flower-minisblack-24.tif",   #  73x43 24-bit minisblack gray image
+    "flower-minisblack-24.tif",   #  73x43 24-bit minisblack gray image
     "flower-minisblack-32.tif",   #  73x43 32-bit minisblack gray image
     "flower-palette-02.tif",   #73x43 4-entry colormapped image
     "flower-palette-04.tif",   #73x43 16-entry colormapped image
@@ -26,7 +26,7 @@ files = [
     "flower-rgb-contig-12.tif",   #  73x43 12-bit contiguous RGB image
     "flower-rgb-contig-14.tif",   #  73x43 14-bit contiguous RGB image
     "flower-rgb-contig-16.tif",   #  73x43 16-bit contiguous RGB image
-    #FIXME "flower-rgb-contig-24.tif",   #  73x43 24-bit contiguous RGB image
+    "flower-rgb-contig-24.tif",   #  73x43 24-bit contiguous RGB image
     "flower-rgb-contig-32.tif",   #  73x43 32-bit contiguous RGB image
     "flower-rgb-planar-02.tif",   #  73x43 2-bit seperated RGB image
     "flower-rgb-planar-04.tif",   #  73x43 4-bit seperated RGB image
@@ -35,8 +35,8 @@ files = [
     "flower-rgb-planar-12.tif",   #  73x43 12-bit seperated RGB image
     "flower-rgb-planar-14.tif",   #  73x43 14-bit seperated RGB image
     "flower-rgb-planar-16.tif",   #  73x43 16-bit seperated RGB image
-    #FIXME "flower-rgb-planar-24.tif",   #  73x43 24-bit seperated RGB image
-    #FIXME "flower-rgb-planar-32.tif",   #  73x43 32-bit seperated RGB image
+    "flower-rgb-planar-24.tif",   #  73x43 24-bit seperated RGB image
+    "flower-rgb-planar-32.tif",   #  73x43 32-bit seperated RGB image
     "flower-separated-contig-08.tif",  # 73x43 8-bit contiguous CMYK image
     "flower-separated-contig-16.tif",  # 73x43 16-bit contiguous CMYK image
     "flower-separated-planar-08.tif",  # 73x43 8-bit separated CMYK image
@@ -44,7 +44,8 @@ files = [
     ]
 
 for f in files:
-    command += rw_command (imagedir, f)
+    command += rw_command (imagedir, f, use_oiiotool=True, preargs="-native")
+    command += info_command (imagedir+'/'+f, f, verbose=False)
 
 # Test CMYK without conversion to RGB
 command += oiiotool ("-iconfig oiio:RawColor 1 " +

--- a/testsuite/tiff-suite/ref/out-alt.txt
+++ b/testsuite/tiff-suite/ref/out-alt.txt
@@ -1,3 +1,16 @@
+Reading ../../../../../libtiffpic/caspian.tif
+../../../../../libtiffpic/caspian.tif :  279 x  220, 3 channel, double tiff
+    SHA-1: 53F0C0A71BCACCDA213DA73DC23B0CA0CD629D9A
+    channel list: R, G, B
+    compression: "zip"
+    planarconfig: "separate"
+    oiio:BitsPerSample: 64
+    tiff:Compression: 32946
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 3
+Comparing "../../../../../libtiffpic/caspian.tif" and "caspian.tif"
+PASS
 Reading ../../../../../libtiffpic/cramps.tif
 ../../../../../libtiffpic/cramps.tif :  800 x  607, 1 channel, uint8 tiff
     SHA-1: A1CA337CBB22D84410BBE710BB31D5D6646CF839

--- a/testsuite/tiff-suite/ref/out-jpeg9b.txt
+++ b/testsuite/tiff-suite/ref/out-jpeg9b.txt
@@ -1,3 +1,16 @@
+Reading ../../../../../libtiffpic/caspian.tif
+../../../../../libtiffpic/caspian.tif :  279 x  220, 3 channel, double tiff
+    SHA-1: 53F0C0A71BCACCDA213DA73DC23B0CA0CD629D9A
+    channel list: R, G, B
+    compression: "zip"
+    planarconfig: "separate"
+    oiio:BitsPerSample: 64
+    tiff:Compression: 32946
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 3
+Comparing "../../../../../libtiffpic/caspian.tif" and "caspian.tif"
+PASS
 Reading ../../../../../libtiffpic/cramps.tif
 ../../../../../libtiffpic/cramps.tif :  800 x  607, 1 channel, uint8 tiff
     SHA-1: A1CA337CBB22D84410BBE710BB31D5D6646CF839

--- a/testsuite/tiff-suite/ref/out.txt
+++ b/testsuite/tiff-suite/ref/out.txt
@@ -1,3 +1,16 @@
+Reading ../../../../../libtiffpic/caspian.tif
+../../../../../libtiffpic/caspian.tif :  279 x  220, 3 channel, double tiff
+    SHA-1: 53F0C0A71BCACCDA213DA73DC23B0CA0CD629D9A
+    channel list: R, G, B
+    compression: "zip"
+    planarconfig: "separate"
+    oiio:BitsPerSample: 64
+    tiff:Compression: 32946
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 3
+Comparing "../../../../../libtiffpic/caspian.tif" and "caspian.tif"
+PASS
 Reading ../../../../../libtiffpic/cramps.tif
 ../../../../../libtiffpic/cramps.tif :  800 x  607, 1 channel, uint8 tiff
     SHA-1: A1CA337CBB22D84410BBE710BB31D5D6646CF839

--- a/testsuite/tiff-suite/run.py
+++ b/testsuite/tiff-suite/run.py
@@ -2,9 +2,7 @@
 
 
 # caspian.tif	279x220 64-bit floating point (deflate) Caspian Sea from space
-#   I can't get this to work with OIIO, but I can't get it to read with 
-#     ImageMagick or OSX preview, either.
-#   FIXME?
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "caspian.tif")
 
 # cramps.tif	800x607 8-bit b&w (packbits) "cramps poster"
 #    This tests 1-bit images, and packbits compression


### PR DESCRIPTION
In the process, move some bit depth serializing functions into fmath.h so
we can reuse it. (It's not float math exactly, but it is bit depth conversion,
which for historical reasons we also have here.)
