### PR TITLE
Several small improvements to the ParamValueList / delegate interface

### DIFF
--- a/src/include/OpenImageIO/attrdelegate.h
+++ b/src/include/OpenImageIO/attrdelegate.h
@@ -141,13 +141,12 @@ public:
     // Using enable_if, make a slightly different version of get<> for
     // strings, which need to do some ustring magic because we can't
     // directly store in a std::string or string_view.
-    template<typename T,
+    template<typename T = string_view,
              typename std::enable_if<pvt::is_string<T>::value, int>::type = 1>
     inline T get(const T& defaultval = T()) const
     {
         ustring s;
-        return m_obj->getattribute(m_name, TypeString, &s) ? T(s.string())
-                                                           : defaultval;
+        return m_obj->getattribute(m_name, TypeString, &s) ? T(s) : defaultval;
     }
 
     // `Delegate->as_string(defaultval="")` returns the data, no matter its

--- a/src/include/OpenImageIO/paramlist.h
+++ b/src/include/OpenImageIO/paramlist.h
@@ -288,7 +288,7 @@ public:
 
     /// Does the list contain the named attribute?
     bool contains(string_view name, TypeDesc type = TypeDesc::UNKNOWN,
-                  bool casesensitive = true);
+                  bool casesensitive = true) const;
 
     // Add the param to the list, replacing in-place any existing one with
     // the same name.

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -186,6 +186,9 @@ public:
         return string_view(c_str(), length());
     }
 
+    /// Conversion to std::string (explicit only!).
+    explicit operator std::string() const noexcept { return string(); }
+
     /// Assign a ustring to *this.
     const ustring& assign(const ustring& str)
     {

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -613,7 +613,8 @@ ParamValueList::remove(string_view name, TypeDesc type, bool casesensitive)
 
 
 bool
-ParamValueList::contains(string_view name, TypeDesc type, bool casesensitive)
+ParamValueList::contains(string_view name, TypeDesc type,
+                         bool casesensitive) const
 {
     auto p = find(name, type, casesensitive);
     return (p != end());
@@ -662,11 +663,16 @@ bool
 ParamValueList::getattribute(string_view name, std::string& value,
                              bool casesensitive) const
 {
-    ustring s;
-    bool ok = getattribute(name, TypeString, &s, casesensitive);
-    if (ok)
-        value = s.string();
-    return ok;
+    auto p = find(name, TypeUnknown, casesensitive);
+    if (p != cend()) {
+        ustring s;
+        bool ok = convert_type(p->type(), p->data(), TypeString, &s);
+        if (ok)
+            value = s.string();
+        return ok;
+    } else {
+        return false;
+    }
 }
 
 

--- a/src/libutil/paramlist_test.cpp
+++ b/src/libutil/paramlist_test.cpp
@@ -302,6 +302,9 @@ test_delegates()
     std::string s = pl["foo"];
     OIIO_CHECK_EQUAL(s, "42");
 
+    string_view sv = pl["foo"].get();
+    OIIO_CHECK_EQUAL(sv, "42");
+
     Strutil::printf("Delegate-loaded array is\n");
     for (auto&& p : pl)
         Strutil::printf(" %16s : %s\n", p.name(), p.get_string());


### PR DESCRIPTION
* ParamValueList::contains() should be const

* ustring: make an explicit conversion to std::string

* AttrDelegate: make `get<string_view>()` work correctly without
  improperly referencing a temp string whose lifetime is shorter than
  the string_view.

* AttrDelegate: allow default `get()` template to return a string_view. You need
  `get<T>()` to retrieve/convert some other type.

* ParamValueList: have getattribute of string do auto conversion. 
  If you getattribute() of any non-string type (like an int or float),
  it will try hard to convert whatever it finds to that type, even if it
  was stored as a different type internally. But if you asked for a
  string, it would fail unless it was stored internally as a
  string. Make these symmetric by always converting if possible.

