### PR TITLE
rotl template, instead of rotl32/rotl64

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -1134,7 +1134,9 @@ vint4 abs (const vint4& a);
 vint4 min (const vint4& a, const vint4& b);
 vint4 max (const vint4& a, const vint4& b);
 
-// Circular bit rotate by k bits, for N values at once.
+/// Circular bit rotate by s bits, for N values at once.
+vint4 rotl (const vint4& x, const int s);
+// DEPRECATED(2.1)
 vint4 rotl32 (const vint4& x, const unsigned int k);
 
 /// andnot(a,b) returns ((~a) & b)
@@ -1432,7 +1434,9 @@ vint8 abs (const vint8& a);
 vint8 min (const vint8& a, const vint8& b);
 vint8 max (const vint8& a, const vint8& b);
 
-// Circular bit rotate by k bits, for N values at once.
+/// Circular bit rotate by s bits, for N values at once.
+vint8 rotl (const vint8& x, const int s);
+// DEPRECATED(2.1)
 vint8 rotl32 (const vint8& x, const unsigned int k);
 
 /// andnot(a,b) returns ((~a) & b)
@@ -1737,7 +1741,9 @@ vint16 abs (const vint16& a);
 vint16 min (const vint16& a, const vint16& b);
 vint16 max (const vint16& a, const vint16& b);
 
-// Circular bit rotate by k bits, for N values at once.
+/// Circular bit rotate by s bits, for N values at once.
+vint16 rotl (const vint16& x, const int s);
+// DEPRECATED(2.1)
 vint16 rotl32 (const vint16& x, const unsigned int k);
 
 /// andnot(a,b) returns ((~a) & b)
@@ -4711,8 +4717,17 @@ OIIO_FORCEINLINE vint4 max (const vint4& a, const vint4& b) {
 }
 
 
+OIIO_FORCEINLINE vint4 rotl(const vint4& x, int s) {
+#if OIIO_SIMD_AVX >= 512 && OIIO_AVX512VL_ENABLED
+    return _mm_rol_epi32 (x, s);
+#else
+    return (x<<s) | srl(x,32-s);
+#endif
+}
+
+// DEPRECATED (2.1)
 OIIO_FORCEINLINE vint4 rotl32 (const vint4& x, const unsigned int k) {
-    return (x<<k) | srl(x,32-k);
+    return rotl(x, k);
 }
 
 
@@ -5495,8 +5510,17 @@ OIIO_FORCEINLINE vint8 max (const vint8& a, const vint8& b) {
 }
 
 
+OIIO_FORCEINLINE vint8 rotl(const vint8& x, int s) {
+#if OIIO_SIMD_AVX >= 512 && OIIO_AVX512VL_ENABLED
+    return _mm256_rol_epi32 (x, s);
+#else
+    return (x<<s) | srl(x,32-s);
+#endif
+}
+
+// DEPRECATED (2.1)
 OIIO_FORCEINLINE vint8 rotl32 (const vint8& x, const unsigned int k) {
-    return (x<<k) | srl(x,32-k);
+    return rotl(x, k);
 }
 
 
@@ -6284,8 +6308,17 @@ OIIO_FORCEINLINE vint16 max (const vint16& a, const vint16& b) {
 }
 
 
+OIIO_FORCEINLINE vint16 rotl(const vint16& x, int s) {
+#if OIIO_SIMD_AVX >= 512 && OIIO_AVX512VL_ENABLED
+    return _mm512_rol_epi32 (x, s);
+#else
+    return (x<<s) | srl(x,32-s);
+#endif
+}
+
+// DEPRECATED (2.1)
 OIIO_FORCEINLINE vint16 rotl32 (const vint16& x, const unsigned int k) {
-    return (x<<k) | srl(x,32-k);
+    return rotl(x, k);
 }
 
 

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -118,6 +118,10 @@ test_int_helpers()
     OIIO_CHECK_EQUAL(round_to_multiple_of_pow2(size_t(3), size_t(4)), 4);
     OIIO_CHECK_EQUAL(round_to_multiple_of_pow2(size_t(4), size_t(4)), 4);
     OIIO_CHECK_EQUAL(round_to_multiple_of_pow2(size_t(5), size_t(4)), 8);
+
+    OIIO_CHECK_EQUAL(rotl(uint32_t(0x12345678), 4), uint32_t(0x23456781));
+    OIIO_CHECK_EQUAL(rotl(uint64_t(0x123456789abcdef0ULL), 4),
+                     uint64_t(0x23456789abcdef01ULL));
 }
 
 

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -1331,6 +1331,7 @@ test_transpose4()
 template<typename T> inline T do_shl (const T &a, int b) { return a<<b; }
 template<typename T> inline T do_shr (const T &a, int b) { return a>>b; }
 template<typename T> inline T do_srl (const T &a, int b) { return srl(a,b); }
+template<typename T> inline T do_rotl (const T &a, int b) { return rotl(a,b); }
 
 
 template<typename VEC>
@@ -1363,10 +1364,18 @@ test_shift()
     i = VEC::Iota (10, 10);   i >>= 1;
     OIIO_CHECK_SIMD_EQUAL (i, VEC::Iota(5, 5));
 
+    // Test rotl
+    {
+        vint4 v (0x12345678, 0xabcdef01, 0x98765432, 0x31415926);
+        vint4 r (0x23456781, 0xbcdef01a, 0x87654329, 0x14159263);
+        OIIO_CHECK_SIMD_EQUAL (rotl(v,4), r);
+    }
+
     // Benchmark
     benchmark2 ("operator<<", do_shl<VEC>, i, 2);
     benchmark2 ("operator>>", do_shr<VEC>, i, 2);
     benchmark2 ("srl       ", do_srl<VEC>, i, 2);
+    benchmark2 ("rotl      ", do_rotl<VEC>, i, 2);
 }
 
 


### PR DESCRIPTION
This matches the C++20 std notation.
