### PR TITLE
ImageBufAlgo: Fix implicit float/double casts to half incorrectly flagging values as non-finite

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -998,9 +998,17 @@ ImageBufAlgo::color_map(const ImageBuf& src, int srcchannel,
 
 namespace {
 
-// Make sure isfinite is defined for 'half'
+template<typename T>
 inline bool
-isfinite(half h)
+isfinite_(T v)
+{
+    return std::isfinite(v);
+}
+
+// Make sure isfinite is defined for 'half'
+template<>
+inline bool
+isfinite_<half>(half h)
 {
     return h.isFinite();
 }
@@ -1022,7 +1030,7 @@ fixNonFinite_(ImageBuf& dst, ImageBufAlgo::NonFiniteFixMode mode,
                  ++pixel) {
                 for (int c = roi.chbegin; c < roi.chend; ++c) {
                     T value = pixel[c];
-                    if (!isfinite(value)) {
+                    if (!isfinite_(value)) {
                         ++count;
                         break;  // only count one per pixel
                     }
@@ -1035,7 +1043,7 @@ fixNonFinite_(ImageBuf& dst, ImageBufAlgo::NonFiniteFixMode mode,
                 bool fixed = false;
                 for (int c = roi.chbegin; c < roi.chend; ++c) {
                     T value = pixel[c];
-                    if (!isfinite(value)) {
+                    if (!isfinite_(value)) {
                         pixel[c] = T(0.0);
                         fixed    = true;
                     }
@@ -1051,7 +1059,7 @@ fixNonFinite_(ImageBuf& dst, ImageBufAlgo::NonFiniteFixMode mode,
                 bool fixed = false;
                 for (int c = roi.chbegin; c < roi.chend; ++c) {
                     T value = pixel[c];
-                    if (!isfinite(value)) {
+                    if (!isfinite_(value)) {
                         int numvals = 0;
                         T sum(0.0);
                         ROI roi2(pixel.x() - 1, pixel.x() + 2, pixel.y() - 1,
@@ -1060,7 +1068,7 @@ fixNonFinite_(ImageBuf& dst, ImageBufAlgo::NonFiniteFixMode mode,
                         for (ImageBuf::Iterator<T, T> i(dst, roi2); !i.done();
                              ++i) {
                             T v = i[c];
-                            if (isfinite(v)) {
+                            if (isfinite_(v)) {
                                 sum += v;
                                 ++numvals;
                             }
@@ -1102,7 +1110,7 @@ fixNonFinite_deep_(ImageBuf& dst, ImageBufAlgo::NonFiniteFixMode mode,
                 for (int samp = 0; samp < samples && !bad; ++samp)
                     for (int c = roi.chbegin; c < roi.chend; ++c) {
                         float value = pixel.deep_value(c, samp);
-                        if (!isfinite(value)) {
+                        if (!isfinite_(value)) {
                             ++count;
                             bad = true;
                             break;
@@ -1121,7 +1129,7 @@ fixNonFinite_deep_(ImageBuf& dst, ImageBufAlgo::NonFiniteFixMode mode,
                 for (int samp = 0; samp < samples; ++samp)
                     for (int c = roi.chbegin; c < roi.chend; ++c) {
                         float value = pixel.deep_value(c, samp);
-                        if (!isfinite(value)) {
+                        if (!isfinite_(value)) {
                             pixel.set_deep_value(c, samp, 0.0f);
                             fixed = true;
                         }


### PR DESCRIPTION
## Description

I recently discovered that, when running `maketx` on an HDR that included the sun, the extremely high channel values (> 145,000) were being rolled off to just over 65,000. Eventually, I was able to track the cause of the "rolloff" down to the use of `--fixnan box3`, and from there, I found that float/double values were being incorrectly flagged as non-finite due to an implicit cast to half.

Basically, because a cast to half is possible, the local `isfinite` [in `imagebufalgo_pixelmath.cpp`](https://github.com/OpenImageIO/oiio/blob/master/src/libOpenImageIO/imagebufalgo_pixelmath.cpp#L1003) is being preferred over `std::isfinite` for float and double values.

The fix uses a templated shim around `std::isfinite`, with an explicit specialization for `half`.

## Tests

I can add an additional `oiiotool-fixnan` test if you think it's valuable.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.