### PR TITLE
Added half_size and user_mul options to rawinput plugin

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1370,6 +1370,13 @@ options are supported:
        decoding the raw image. The default (1,1) means to perform no
        correction. This is an overall spatial scale, sensible values will be
        very close to 1.0.
+   * - ``raw:half_size``
+     - int
+     - If nonzero, outputs the image in half size. (Default: 0)
+   * - ``raw:user_mul``
+     - float[4]
+     - Sets user white balance coefficients. Only applies if ``raw:use_camera_wb``
+       is not equal to 0.
    * - ``raw:ColorSpace``
      - string
      - Which color primaries to use: ``raw``, ``sRGB``, ``Adobe``, ``Wide``,


### PR DESCRIPTION
## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

Added two LibRaw options to the RAW plugin.

half_size: Processes image at 50% size.

user_mul: Allows the input of white balance coefficients to set a custom WB.

I have added some lines to builtinplugins.rst, not sure if that is sufficient for the documentation?

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

