### PR TITLE
Changes to SPI custom build scripts, versioning/disting policy changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,13 @@
 cmake_minimum_required (VERSION 3.2.2)
 cmake_policy (SET CMP0048 NEW)  # Allow VERSION specifier in project()
-project (OpenImageIO VERSION 2.1.3
+project (OpenImageIO VERSION 2.1.3.0
          LANGUAGES CXX C)
 set (PROJ_NAME OIIO)    # short name, caps
 string (TOLOWER ${PROJ_NAME} PROJ_NAME_LOWER)  # short name lower case
 set (PROJECT_VERSION_RELEASE_TYPE "dev")   # "dev", "betaX", "RCY", ""
 set (${PROJECT_NAME}_VERSION_RELEASE_TYPE ${PROJECT_VERSION_RELEASE_TYPE})
 set (PROJECT_AUTHORS "Contributors to the OpenImageIO project")
-set (PROJECT_URL "http://openimageio.org")
+set (PROJECT_URL "https://openimageio.org")
 
 message (STATUS "CMake version is ${CMAKE_VERSION}")
 cmake_policy (SET CMP0017 NEW)  # Prefer files from the CMake module directory when including from there.
@@ -16,9 +16,10 @@ cmake_policy (SET CMP0046 OLD)  # Don't error on non-existent dependency in add_
 set (CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS TRUE)
 
 # Alternate names
-set (OIIO_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set (OIIO_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set (OIIO_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+set (OIIO_VERSION_MINOR ${PROJECT_VERSION_MINOR})
+set (OIIO_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+set (OIIO_VERSION_TWEAK ${PROJECT_VERSION_TWEAK})
 set (OIIO_VERSION_RELEASE_TYPE ${PROJECT_VERSION_RELEASE_TYPE})
 
 # N.B./FIXME - after CMake 3.0 is our minimum, we should change many of the
@@ -63,6 +64,7 @@ include (compiler)   # All the C++ and compiler related options live here
 option (VERBOSE "Print lots of messages while compiling" OFF)
 set (${PROJ_NAME}_NAMESPACE ${PROJECT_NAME} CACHE STRING
       "Customized outer namespace base name (version will be added)")
+option (OIIO_NAMESPACE_INCLUDE_PATCH "Should the inner namespace include the patch number" OFF)
 option (EMBEDPLUGINS "Embed format plugins in libOpenImageIO" ON)
 option (OIIO_BUILD_TOOLS "Build the command-line tools" ON)
 option (OIIO_BUILD_TESTS "Build the unit tests" ON)
@@ -130,6 +132,9 @@ endif ()
 # Set the default namespace
 set (PROJ_NAMESPACE "${${PROJ_NAME}_NAMESPACE}")
 set (PROJ_NAMESPACE_V "${PROJ_NAMESPACE}_v${PROJECT_VERSION_MAJOR}_${PROJECT_VERSION_MINOR}")
+if (OIIO_NAMESPACE_INCLUDE_PATCH)
+    set (PROJ_NAMESPACE_V "${PROJ_NAMESPACE_V}_${PROJECT_VERSION_PATCH}")
+endif ()
 message(STATUS "Setting Namespace to: ${PROJ_NAMESPACE_V}")
 
 
@@ -214,6 +219,11 @@ if (BUILD_DOCS)
 endif ()
 add_subdirectory (src/fonts)
 add_subdirectory (src/nuke)
+
+# Last minute site-specific instructions, if they exist
+if (OIIO_SITE AND EXISTS "${PROJECT_SOURCE_DIR}/site/${OIIO_SITE}/cmake/sitecustom.cmake")
+    include ("${PROJECT_SOURCE_DIR}/site/${OIIO_SITE}/cmake/sitecustom.cmake")
+endif ()
 
 # install pkgconfig file
 IF ( NOT MSVC )

--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -3,18 +3,30 @@ ifneq (${VERBOSE},)
 $(info Including spi/Makefile-bits)
 endif
 
-# For SpComp2 builds, set env OIIO_SPCOMP2=1, and either
+# For SpComp2 builds, do:
+#
 #     make OIIO_SPCOMP2=1 spcomp2_install
 # or
 #     make OIIO_SPCOMP2=1 SPCOMP2_LOCAL_PATH=/test/path spcomp2_install_local
 #
-# For Arnold builds, set env OIIO_ARNOLD=1 and just do a regular
-# "make". We make this the default, so if you want neither an Arnold nor
-# a SpComp2, you have to set OIIO_ARNOLD=0.  If both are set, SpComp2
-# takes precedence.
+# For Arnold builds, do:
+#
+#     make OIIO_ARNOLD=1
+#
+# For a Rez-bound build, do:
+#
+#     make OIIO_SPIREZ=1
+#
+#     (Options: OIIO_REZ_NAME=blah REZ_PACKAGE_ROOT=path)
+#
+# Otherwise a default 'make' will make a fully generic OIIO build.
 OIIO_SPCOMP2 ?= 0
-OIIO_ARNOLD ?= 1
-OPENIMAGEIO_SPCOMP2_VERSION ?= 49
+OIIO_ARNOLD ?= 0
+OIIO_SPIREZ ?= 0
+OIIO_REZ_NAME ?= OpenImageIO
+OIIO_VERS = $(shell grep "OpenImageIO VERSION" CMakeLists.txt | egrep -o "[0-9.]+")
+ONEVERS = $(shell site/spi/format_version.py ${OIIO_VERS})
+OPENIMAGEIO_SPCOMP2_VERSION ?= ${ONEVERS}
 ifeq (${OIIO_SPCOMP2},1)
     $(info Building for SpComp2)
     OIIO_ARNOLD := 0
@@ -27,13 +39,19 @@ else ifeq (${OIIO_ARNOLD},1)
     NAMESPACE ?= 'OpenImageIO_Arnold'
     PYLIB_LIB_PREFIX ?= 0
     PYLIB_INCLUDE_SONAME ?= 0
+else ifeq (${OIIO_SPIREZ},1)
+    $(info Building OpenImageIO for Rez distribution)
+    NAMESPACE ?= 'OpenImageIO'
+    PYLIB_LIB_PREFIX ?= 0
+    PYLIB_INCLUDE_SONAME ?= 0
+    MY_CMAKE_FLAGS += -DOIIO_SPIREZ=1 -DOIIO_REZ_PACKAGE_NAME=${OIIO_REZ_NAME}
+else
+    $(info Building generic OpenImageIO)
+    NAMESPACE ?= 'OpenImageIO'
+    PYLIB_LIB_PREFIX ?= 0
+    PYLIB_INCLUDE_SONAME ?= 0
 endif
 #$(info MAKECMDGOALS = $(MAKECMDGOALS))
-
-
-MY_CMAKE_FLAGS += -DEXTRA_CPP_ARGS:STRING="-DOIIO_SPI=1" -DOIIO_SITE:STRING=SPI
-MY_CMAKE_FLAGS += -DSPI_TESTS=1
-SPCOMP2_ROOT ?= /shots/spi/home/lib/SpComp2
 
 
 ## Detect which SPI platform and set $platform, $COMPILER, $SPCOMP2_COMPILER,
@@ -47,11 +65,20 @@ else ifeq (${platform}, macosx)
     COMPILER ?= clang
     SPCOMP2_COMPILER ?= clang
     PYTHON_VERSION ?= 2.6
+    SP_OS ?= macosx
 else
     $(error Unknown SP_OS=${SP_OS} platform=${platform})
 endif  # endif ${SP_OS}
 
 PYTHON_VERSION ?= 2.7
+SPI_COMPILER_PLATFORM ?= gcc-4.8
+MY_CMAKE_FLAGS += -DSP_OS=${SP_OS}
+MY_CMAKE_FLAGS += -DSPI_COMPILER_PLATFORM=${SPI_COMPILER_PLATFORM}
+MY_CMAKE_FLAGS += -DEXTRA_CPP_ARGS:STRING="-DOIIO_SPI=1" -DOIIO_SITE:STRING=spi
+MY_CMAKE_FLAGS += -DSPI_TESTS=1
+MY_CMAKE_FLAGS += -DOIIO_NAMESPACE_INCLUDE_PATCH=1
+SPCOMP2_ROOT ?= /shots/spi/home/lib/SpComp2
+REZ_PACKAGE_ROOT ?= /shots/spi/home/software/packages
 
 
 ## Rhel7 (current)
@@ -68,6 +95,8 @@ ifeq (${SP_OS}, rhel7)
     # Override lib64 and use SPI convention of lib
     MY_CMAKE_FLAGS += -DCMAKE_INSTALL_LIBDIR="${INSTALL_PREFIX}/lib"
     ifeq (${OIIO_SPCOMP2},1)
+        MY_CMAKE_FLAGS += -DPYTHON_SITE_DIR="${INSTALL_PREFIX}/python"
+    else ifeq (${OIIO_SPIREZ},1)
         MY_CMAKE_FLAGS += -DPYTHON_SITE_DIR="${INSTALL_PREFIX}/python"
     else ifeq (${OIIO_ARNOLD},1)
         OIIO_LIBNAME_SUFFIX=_Arnold
@@ -114,6 +143,7 @@ ifeq (${SP_OS}, rhel7)
     BOOSTVERS ?= 1.55
     BOOSTSPSUFFIX ?=
     BOOSTVERSSP=${BOOSTVERS}${BOOSTSPSUFFIX}
+    MY_CMAKE_FLAGS += -DBOOST_VERS_SP=${BOOSTVERSSP}
     # $(info BOOSTVERSSP ${BOOSTVERSSP})
     ifeq (${BOOSTVERS},1.55)
         SPBOOST_INC_DIR ?= /usr/include/boost_${BOOSTVERSSP}
@@ -156,8 +186,7 @@ ifeq (${SP_OS}, rhel7)
             -DPYTHON_VERSION_MINOR=6 \
             -DPYTHON_VERSION_PATCH=3 \
             -DPython_ADDITIONAL_VERSIONS="${PYTHON_VERSION}"
-    endif
-    ifeq (${PYTHON_VERSION},3.7)
+    else ifeq (${PYTHON_VERSION},3.7)
         # Special sauce for Python 3.7
         PYTHON_INCLUDE_DIR := /usr/include/python${PYTHON_VERSION}m
         PYTHON_LIBRARY := ${PYTHON_LIBRARY_DIR}/libpython${PYTHON_VERSION}m.so
@@ -167,6 +196,17 @@ ifeq (${SP_OS}, rhel7)
             -DPYTHON_VERSION_MAJOR=3 \
             -DPYTHON_VERSION_MINOR=7 \
             -DPYTHON_VERSION_PATCH=3 \
+            -DPython_ADDITIONAL_VERSIONS="${PYTHON_VERSION}"
+    else ifeq (${PYTHON_VERSION},2.7)
+        # Special sauce for Python 2.7
+        PYTHON_INCLUDE_DIR := /usr/include/python${PYTHON_VERSION}
+        PYTHON_LIBRARY := ${PYTHON_LIBRARY_DIR}/libpython${PYTHON_VERSION}.so
+        MY_CMAKE_FLAGS += \
+            -DPYTHONINTERP_FOUND=1 \
+            -DPYTHON_VERSION_STRING=2.7.5 \
+            -DPYTHON_VERSION_MAJOR=2 \
+            -DPYTHON_VERSION_MINOR=7 \
+            -DPYTHON_VERSION_PATCH=5 \
             -DPython_ADDITIONAL_VERSIONS="${PYTHON_VERSION}"
     endif
     MY_CMAKE_FLAGS += \
@@ -271,13 +311,29 @@ endif  # endif ${SP_OS}
 
 
 
+ifeq (${OIIO_SPIREZ},1)
+    # Rpath touch-ups
+    # NOTE: This MUST match the order and naming of the Rez variants
+    # set in rez/package.py.in
+    REZ_INSTALL_PATH := ${REZ_PACKAGE_ROOT}/${OIIO_REZ_NAME}/${OIIO_VERS}/${SPI_COMPILER_PLATFORM}/python-${PYTHON_VERSION}/boost-${BOOSTVERSSP}
+    MY_CMAKE_FLAGS += -DOIIO_REZ_INSTALL_PATH=${REZ_INSTALL_PATH}
+    MY_CMAKE_FLAGS += -DCMAKE_INSTALL_RPATH=${REZ_INSTALL_PATH}/lib
+endif
+
+
+
 ############################################################################
 # SpComp2 magic incantations follow. Here be dragons.
 ############################################################################
 
 
 CPPSTDSUFFIX=
+SPCOMP2_INSTALL_ROOT ?= $(SPCOMP2_ROOT)
+BOOSTVERSSP?=${BOOSTVERS}${BOOSTSPSUFFIX}
 SPARCH=${SP_OS}-$(SPCOMP2_COMPILER)$(CPPSTDSUFFIX)-boost$(subst .,,$(BOOSTVERSSP))
+OIIO_SPCOMP2_PATH := ${SPCOMP2_INSTALL_ROOT}/OpenImageIO/${SPARCH}/v${OPENIMAGEIO_SPCOMP2_VERSION}
+# $(info New rhel7 OIIO_SPCOMP2_PATH is ${OIIO_SPCOMP2_PATH})
+
 PYVERNOSPACE=${shell echo ${PYTHON_VERSION} | sed "s/\\.//"}
 SPPYARCH=$(SPARCH)-py$(PYVERNOSPACE)
 
@@ -285,30 +341,27 @@ SPPYARCH=$(SPARCH)-py$(PYVERNOSPACE)
 
 all: dist
 
+local: dist
+
 .PHONY: spcomp2_install spcomp2_install_local clean all
 
 comma:= ,
 empty:=
 space:= $(empty) $(empty)
 
-INSTALL_BIN_LOCATION = /shots/spi/home/bin/${SP_OS}
-SPCOMP2_INSTALL_ROOT ?= $(SPCOMP2_ROOT)
-OIIO_SPCOMP2_PATH := ${SPCOMP2_INSTALL_ROOT}/OpenImageIO/$(SPARCH)/v${OPENIMAGEIO_SPCOMP2_VERSION}
 INSTALL_SPCOMP2_CURRENT = $(SPCOMP2_INSTALL_ROOT)/OpenImageIO/$(SPARCH)/v$(OPENIMAGEIO_SPCOMP2_VERSION)
-# $(info New rhel7 OIIO_SPCOMP2_PATH is ${OIIO_SPCOMP2_PATH})
+INSTALL_BIN_LOCATION = $(INSTALL_SPCOMP2_CURRENT)/bin
 SPCOMP2_LOCAL_PATH ?= /net/soft_scratch/users/$(USER)/SpComp2_test
+
+spcomp2_install_local: SPCOMP2_INSTALL_ROOT = $(SPCOMP2_LOCAL_PATH)
+spcomp2_install_local: INSTALL_BIN_LOCATION = $(INSTALL_SPCOMP2_CURRENT)/bin
+spcomp2_install_local: spcomp2_install
 
 SPCOMP2_RPATH_OPT ?= ${OCIO_PATH}/lib:${FIELD3D_HOME}/lib:/usr/lib64/libraw-0.18.11:${OPENVDB_ROOT_DIR}/lib:/shots/spi/home/lib/arnold/rhel7/libheif-1.3.2/lib:shots/spi/home/lib/arnold/rhel7/libde265-1.0.3/lib:/net/apps/rhel7/intel/tbb/lib/intel64/gcc4.7:${SPBOOST_LIB_DIR}
 SPCOMP2_RPATH_DEBUG ?= ${OCIO_PATH}/lib/debug:${FIELD3D_HOME}/lib/debug:/usr/lib64/libraw-0.18.11:${OPENVDB_ROOT_DIR}/lib/debug:/shots/spi/home/lib/arnold/rhel7/libheif-1.3.2/lib:shots/spi/home/lib/arnold/rhel7/libde265-1.0.3/lib:/net/apps/rhel7/intel/tbb/lib/intel64/gcc4.7:${SPBOOST_LIB_DIR}
 PYSPCOMP2_RPATH_OPT ?= ${SPCOMP2_RPATH_OPT}:${OIIO_SPCOMP2_PATH}/lib:${PYTHON_LIBRARY_DIR}
 PYSPCOMP2_RPATH_DEBUG ?= ${SPCOMP2_RPATH_DEBUG}:${OIIO_SPCOMP2_PATH}/lib/debug:${PYTHON_LIBRARY_DIR}
 
-
-spcomp2_install_local: SPCOMP2_INSTALL_ROOT = $(SPCOMP2_LOCAL_PATH)
-spcomp2_install_local: INSTALL_BIN_LOCATION = $(INSTALL_SPCOMP2_CURRENT)/bin
-spcomp2_install_local: spcomp2_install
-
-local: dist
 
 spcomp2: MY_CMAKE_FLAGS += \
 		-DCMAKE_SKIP_BUILD_RPATH:BOOL=ON \
@@ -338,6 +391,9 @@ spcomp2_install_fixup_rhel7: spcomp2 spcomp2_debug
 	patchelf --set-rpath ${SPCOMP2_RPATH_DEBUG} ${dist_dir}.debug/lib/libOpenImageIO_Util$(OIIO_LIBNAME_SUFFIX).so
 	patchelf --set-rpath ${PYSPCOMP2_RPATH_OPT} ${dist_dir}/python/libPyOpenImageIO.so
 	patchelf --set-rpath ${PYSPCOMP2_RPATH_DEBUG} ${dist_dir}.debug/python/libPyOpenImageIO.so
+	patchelf --set-rpath $(INSTALL_SPCOMP2_CURRENT)/lib:${SPCOMP2_RPATH_OPT} ${dist_dir}/bin/oiiotool
+	patchelf --set-rpath $(INSTALL_SPCOMP2_CURRENT)/lib:${SPCOMP2_RPATH_OPT} ${dist_dir}/bin/maketx
+	patchelf --set-rpath $(INSTALL_SPCOMP2_CURRENT)/lib:${SPCOMP2_RPATH_OPT} ${dist_dir}/bin/iv
 
 # This goal can't start with 'install' because something elsewhere picks
 # it up and starts doing bad things
@@ -374,4 +430,7 @@ spcomp2_install: spcomp2_install_fixup_${SP_OS}
 	  --srcdir=${dist_dir}/python \
 	  --builddir_o=${dist_dir}/python \
 	  --builddir_d=${dist_dir}.debug/python
-
+	mkdir -p $(INSTALL_BIN_LOCATION)
+	cp ${dist_dir}/bin/oiiotool $(INSTALL_BIN_LOCATION)
+	cp ${dist_dir}/bin/maketx $(INSTALL_BIN_LOCATION)
+	cp ${dist_dir}/bin/iv $(INSTALL_BIN_LOCATION)

--- a/site/spi/README-SPI.md
+++ b/site/spi/README-SPI.md
@@ -1,0 +1,102 @@
+Build a variant for Rez/general use
+-----------------------------------
+
+Skip this section if you are instead building for SpComp2.
+
+Note: For testing or to make your own local rez package, you can customize
+either the rez package name, or the rez install location name, with make
+flags `OIIO_REZ_NAME=blah REZ_PACKAGE_ROOT=/path/to/my/rez/pkgs` appended
+to the `make` commands of any of the variants listed below. For example,
+
+    make OIIO_SPIREZ=1 OIIO_REZ_NAME=oiio_test REZ_PACKAGE_ROOT=/path/to/my/rez/pkgs
+
+
+Variants:
+
+    # Python 2.7, Boost 1.55, C++11/gcc4.8 compat
+    make nuke
+    make OIIO_SPIREZ=1
+
+    # Python 2.7, Boost 1.55 sp namespaced, C++11/gcc4.8 compat
+    make nuke
+    make OIIO_SPIREZ=1 BOOSTVERS=1.55sp
+
+    # Python 3.7, Boost 1.66, C++11/gcc4.8 compat
+    make nuke
+    make OIIO_SPIREZ=1 BOOSTVERS=1.66 PYTHON_VERSION=3.7
+
+    # Python 3.6, Boost 1.55, C++11/gcc4.8 compat (for Jon Ware)
+    make nuke
+    make OIIO_SPIREZ=1 PYTHON_VERSION=3.6
+
+You can do any of these on your local machine.
+
+
+Rez/general release (do for each variant)
+-----------------------------------------
+
+This must be done from compile40 or compile42 (for correct write
+permissions on certain shared directories), even if you did the build
+itself locally.
+
+First:
+
+    ss spi/home
+    cd /the/oiio/src/area
+    cd dist/rhel7
+
+For any of the variants that you built above:
+
+    rez release --skip-repo-errors
+
+That command will release the dist to the studio.
+
+
+Appwrapper binary releases
+--------------------------
+
+This step is for the ONE general/rez variant that we believe is the
+canonical source of command line oiiotool and maketx. After building and
+releasing as above,
+
+    cp OpenImageIO_*.xml /shots/spi/home/lib/app_cfg/OpenImageIO
+
+That will make appcfg aware of the release.
+
+To also make this release the new facility default:
+
+    db-any spi/home/OpenImageIO.bin highest /shots/spi/home/lib/app_cfg/OpenImageIO_A.B.C.D.xml
+
+where A.B.C.D is the version.
+
+
+SpComp2 build and release
+-------------------------
+
+If you are trying to do an SpComp2 release, forget all the steps above, you
+will need some different flags.
+
+First, to make a TEST build and release to your local spcomp2 mock-up:
+
+    make OIIO_SPCOMP2=1 SPCOMP2_LOCAL_PATH=/test/path spcomp2_install_local
+
+When you are ready for the real thing, you will want to build each of the
+following variants:
+
+    # Python 2.7, Boost 1.55, C++11/gcc4.8 compat
+    make nuke
+    make OIIO_SPCOMP2=1 spcomp2_install
+
+    # Python 2.7, Boost 1.55 sp namespaced, C++11/gcc4.8 compat
+    make nuke
+    make OIIO_SPCOMP2=1 BOOSTVERS=1.55sp spcomp2_install
+
+    # Python 3.7, Boost 1.66, C++11/gcc4.8 compat
+    make nuke
+    make OIIO_SPCOMP2=1 BOOSTVERS=1.66 PYTHON_VERSION=3.7 spcomp2_install
+
+    # Python 3.6, Boost 1.55, C++11/gcc4.8 compat (for Jon Ware)
+    make nuke
+    make OIIO_SPCOMP2=1 PYTHON_VERSION=3.6 spcomp2_install
+
+Nobody should do this but lg, except in extraordinary circumstances.

--- a/site/spi/appcfg.xml.in
+++ b/site/spi/appcfg.xml.in
@@ -1,0 +1,6 @@
+<cfg>
+  <version>@OIIO_VERSION_MAJOR@.@OIIO_VERSION_MINOR@.@OIIO_VERSION_PATCH@.@OIIO_VERSION_TWEAK@</version>
+  <appdir architecture="@SP_OS@">@OIIO_REZ_INSTALL_PATH@</appdir>
+  <launchprogram></launchprogram>
+  <setup></setup>
+</cfg>

--- a/site/spi/cmake/sitecustom.cmake
+++ b/site/spi/cmake/sitecustom.cmake
@@ -1,0 +1,16 @@
+option (OIIO_SPIREZ "Enable extra bits for building for SPI Rez install" OFF)
+set (OIIO_REZ_PACKAGE_NAME CACHE STRING "${PROJECT_NAME}")
+
+if (OIIO_SPIREZ)
+    message (STATUS "Creating package.py from package.py.in")
+    configure_file ("${PROJECT_SOURCE_DIR}/site/spi/rez/package.py.in" "${CMAKE_BINARY_DIR}/package.py")
+
+    set (appcfg_filename "${CMAKE_BINARY_DIR}/OpenImageIO_${OIIO_VERSION_MAJOR}.${OIIO_VERSION_MINOR}.${OIIO_VERSION_PATCH}.${OIIO_VERSION_TWEAK}.xml")
+    configure_file ("${PROJECT_SOURCE_DIR}/site/spi/appcfg.xml.in" "${appcfg_filename}")
+
+    install (FILES ${CMAKE_BINARY_DIR}/package.py
+                   "${PROJECT_SOURCE_DIR}/site/spi/rez/build.py"
+                   ${appcfg_filename}
+             DESTINATION ${CMAKE_INSTALL_PREFIX}
+             COMPONENT developer)
+endif ()

--- a/site/spi/format_version.py
+++ b/site/spi/format_version.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+# This helper script takes a major.minor.patch semantic version string
+# ("2.1.1") and reformats it into the dot-less zero-padded version like
+# "20101".  This is necessary to turn external release designations into
+# integer SpComp2 version numbers.
+
+from __future__ import print_function
+import sys
+
+if len(sys.argv) != 2 :
+    print('Need 1 argument: version number with dots')
+    exit(1)
+
+vers = sys.argv[1]
+parts = vers.split('.')
+print ('{:d}{:02d}{:02d}'.format(int(parts[0]), int(parts[1]), int(parts[2])))

--- a/site/spi/rez/build.py
+++ b/site/spi/rez/build.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+import shutil
+import os
+
+folders = [
+    'bin',
+    'include',
+    'lib',
+    'python',
+    'share',
+]
+
+src = os.environ['REZ_BUILD_SOURCE_PATH']
+dest = os.environ['REZ_BUILD_INSTALL_PATH']
+
+for folder in folders:
+    shutil.copytree(os.path.join(src, folder), os.path.join(dest, folder))

--- a/site/spi/rez/package.py.in
+++ b/site/spi/rez/package.py.in
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Documentation on packages and available attributes can be found at:
+# https://github.com/nerdvegas/rez/wiki/Package-Definition-Guide
+
+name = '@OIIO_REZ_PACKAGE_NAME@'
+
+version = '@OIIO_VERSION_MAJOR@.@OIIO_VERSION_MINOR@.@OIIO_VERSION_PATCH@.@OIIO_VERSION_TWEAK@'
+
+description = \
+    """
+    Rez package of OpenImageIO
+    """
+
+authors = ['Larry Gritz <lg@imageworks.com>']
+
+# Add dependencies to other Rez packages here
+requires = []
+
+build_command = 'python {root}/build.py'
+
+build_requires = ['buildTools']
+
+# Rez has a limitation where it is not possible to add variants to a package that
+# does not have any: https://github.com/nerdvegas/rez/wiki/Variants#single-variants.
+# Unless you are 100% certain that your package will NEVER require any variants,
+# you should define your package with at least one variant.
+variants = [
+    [
+        '@SPI_COMPILER_PLATFORM@',
+        'python-@PYTHON_VERSION_MAJOR@.@PYTHON_VERSION_MINOR@',
+        'boost-@BOOST_VERS_SP@'
+    ],
+]
+
+def commands():
+    # Add import statements here, not at the top of the file!
+
+    # Uncomment if you have executables under bin/
+    env.PATH.append("{root}/bin")
+    env.LD_LIBRARY_PATH.append("{root}/lib")
+
+    # Uncomment if you have Python code under python/
+    env.PYTHONPATH.append("{root}/python")
+
+    # For SpImport.Packages, append the python directory
+    #env.SPIMPORT_PACKAGES.append("{root}/python")
+
+    #if building:
+    #    Add env vars or custom code you want executed only at build time
+
+
+uuid = '1db87605-b172-4e23-a6cb-7b9ff72a46ae'

--- a/src/cmake/install.cmake
+++ b/src/cmake/install.cmake
@@ -10,7 +10,9 @@ if (CMAKE_SKIP_RPATH)
     set (CMAKE_SKIP_RPATH FALSE)
     unset (CMAKE_INSTALL_RPATH)
 else ()
-    set (CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
+    if (NOT CMAKE_INSTALL_RPATH)
+        set (CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
+    endif ()
     # add the automatically determined parts of the RPATH that
     # point to directories outside the build tree to the install RPATH
     set (CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)


### PR DESCRIPTION
This mostly concerns builds at SPI, but a tiny bit touches the generic
build scripts. Most of you will want to tune out now, unless you're
especially curious.

Changes for everybody:

* Switching to a 4-part formal version number (e.g. 2.1.3.0), so there
  is an additional (rarely used) CMake variable
  OPENIMAGEIO_VERSION_TWEAK. This gives me a little more flexibility
  with certain tags and releases in the master branch but there are
  very few contexts in which anybody will care about or refer to the
  last tweak number, and in practice we may rarely or never use it.

* New CMake option `OIIO_NAMESPACE_INCLUDE_PATCH`, if turned on, will
  make the "inner namespace" include the patch number (such as
  namespace OpenImageIO_v2_1_3), whereas the default is the usual
  major/minor (OpenImageIO_v2_1). In general, for external/supported
  releases, we want just major/minor, since within a major/minor
  family we guarantee link compatibility and specifically DON'T want
  to force a recompile for patch updates only. But for studios like
  ours who build for production directly from master, link
  compatibility is not guaranteed at any time, so we make sure even
  down to the patch level is carefully namespaced.

Changes that only have an effect if you're building at SPI:

* The *default* build (regular old "make") now uses the generic
  default namespace. If you want to make the special namespaced
  version we use for Arnold, build with `make OIIO_ARNOLD=1`.

* Change SpComp2 versioning from consecutive low integer SpComp2
  versions (like v47, v48) to canonical multidigit numbers
  corresponding to external releases, such as v20101 for OIIO 2.1.1.
  Also install the bins in the same place (even though it's
  nonstandard SpComp2 practice).

* A new build mode enabled by `make OIIO_SPIREZ=1` does the kind of
  build we want for an experimental Rez packaging. Some notable details
  and options:

    - `REZ_PACKAGE_ROOT=path` overrides the usual root area where we
      store the packages.
    - `OIIO_REZ_NAME=name` overrides the default package name for the
      Rez distribution (default is "OpenImageIO").
    - An appropriate package.py is automatically generated.
    - The Rez variants fold in the SPI compiler compatibility platform,
      Python major/minor version, and Boost version.
    - The build automatically sets the Rpath for the Rez install area
      so that nobody needs to mess with their LD_LIBRARY_PATH to get
      the libraries to be found (especially if you're just importing the
      Python module).

