### PR TITLE
Small improvements concurrent map

### DIFF
--- a/src/include/OpenImageIO/unordered_map_concurrent.h
+++ b/src/include/OpenImageIO/unordered_map_concurrent.h
@@ -265,7 +265,7 @@ public:
     iterator find(const KEY& key, bool do_lock = true)
     {
         size_t hash = m_hash(key);
-        size_t b = whichbin(hash);
+        size_t b    = whichbin(hash);
         Bin& bin(m_bins[b]);
         if (do_lock)
             bin.lock();
@@ -292,7 +292,7 @@ public:
     bool retrieve(const KEY& key, VALUE& value, bool do_lock = true)
     {
         size_t hash = m_hash(key);
-        size_t b = whichbin(hash);
+        size_t b    = whichbin(hash);
         Bin& bin(m_bins[b]);
         if (do_lock)
             bin.lock();
@@ -313,7 +313,7 @@ public:
     bool insert(const KEY& key, const VALUE& value, bool do_lock = true)
     {
         size_t hash = m_hash(key);
-        size_t b = whichbin(hash);
+        size_t b    = whichbin(hash);
         Bin& bin(m_bins[b]);
         if (do_lock)
             bin.lock();
@@ -334,7 +334,7 @@ public:
     void erase(const KEY& key, bool do_lock = true)
     {
         size_t hash = m_hash(key);
-        size_t b = whichbin(hash);
+        size_t b    = whichbin(hash);
         Bin& bin(m_bins[b]);
         if (do_lock)
             bin.lock();
@@ -355,7 +355,7 @@ public:
     size_t lock_bin(const KEY& key)
     {
         size_t hash = m_hash(key);
-        size_t b = whichbin(hash);
+        size_t b    = whichbin(hash);
         m_bins[b].lock();
         return b;
     }

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -436,8 +436,7 @@ typedef unordered_map_concurrent<
     ustring, ImageCacheFileRef, ustringHash, std::equal_to<ustring>,
     FILE_CACHE_SHARDS, tsl::robin_map<ustring, ImageCacheFileRef, ustringHash>>
     FilenameMap;
-typedef tsl::robin_map<ustring, ImageCacheFileRef, ustringHash>
-    FingerprintMap;
+typedef tsl::robin_map<ustring, ImageCacheFileRef, ustringHash> FingerprintMap;
 
 
 

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -436,7 +436,7 @@ typedef unordered_map_concurrent<
     ustring, ImageCacheFileRef, ustringHash, std::equal_to<ustring>,
     FILE_CACHE_SHARDS, tsl::robin_map<ustring, ImageCacheFileRef, ustringHash>>
     FilenameMap;
-typedef std::unordered_map<ustring, ImageCacheFileRef, ustringHash>
+typedef tsl::robin_map<ustring, ImageCacheFileRef, ustringHash>
     FingerprintMap;
 
 


### PR DESCRIPTION
The hash table underlying `unordered_map_concurrent` has support for queries using a precomputed hash value.

Since we need to hash once to figure out which bin to use, we may as well re-use that value for the lookup when possible, which avoids an extra hash operation while we are holding the lock.

Benchmarks show a 1-2% speedup in some cases (as part of a whole renderer).

Also swapped the `FingerprintMap` to  `tsl::robin_map` while I was in there, there's no good reason to use `std:unordered_map`.