### PR TITLE
Improve the hash function for the tile ID

### DIFF
--- a/src/include/OpenImageIO/unordered_map_concurrent.h
+++ b/src/include/OpenImageIO/unordered_map_concurrent.h
@@ -416,19 +416,16 @@ private:
     size_t whichbin(size_t hash)
     {
         constexpr int LOG2_BINS = log2(BINS);
-        constexpr int BIN_SHIFT = 32 - LOG2_BINS;
+        constexpr int BIN_SHIFT = 8 * sizeof(size_t) - LOG2_BINS;
 
         static_assert(1 << LOG2_BINS == BINS,
                       "Number of bins must be a power of two");
-        static_assert(~uint32_t(0) >> BIN_SHIFT == (BINS - 1), "Hash overflow");
+        static_assert(~size_t(0) >> BIN_SHIFT == (BINS - 1), "Hash overflow");
 
         // Use the high order bits of the hash to index the bin. We assume that the
         // low-order bits of the hash will directly be used to index the hash table,
         // so using those would lead to collisions.
-        // To avoid mixups between size_t among platforms, we always cast to a 32-bit
-        // integer first. Its quite possible the hash function only gave us a uint32_t
-        // even though the API technically wants a size_t.
-        unsigned bin = uint32_t(hash) >> BIN_SHIFT;
+        size_t bin = hash >> BIN_SHIFT;
         DASSERT(bin < BINS);
         return bin;
     }

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -2422,7 +2422,7 @@ ImageCacheImpl::check_max_mem(ImageCachePerThreadInfo* thread_info)
 
     // Get a (locked) iterator for the next tile to be examined.
     TileCache::iterator sweep;
-    if (m_tile_sweep_id) {
+    if (!m_tile_sweep_id.empty()) {
         // We saved the sweep_id. Find the iterator corresponding to it.
         sweep = m_tilecache.find(m_tile_sweep_id);
         // Note: if the sweep_id is no longer in the table, sweep will be an
@@ -2463,7 +2463,7 @@ ImageCacheImpl::check_max_mem(ImageCachePerThreadInfo* thread_info)
             m_tilecache.erase(todelete);
             // 4. Re-establish a locked iterator for the next item, since
             // the old iterator may have been invalidated by the erasure.
-            if (m_tile_sweep_id)
+            if (!m_tile_sweep_id.empty())
                 sweep = m_tilecache.find(m_tile_sweep_id);
         } else {
             ++sweep;


### PR DESCRIPTION
Use all bits of the hash to pick the bin in unordered concurrent map instead of just the low 32 bits we used before (because the previous hash function was 32 bits only).

Minor cleanups to the TileID struct


In preliminary benchmarks, this simple change has a dramatic impact on some scenes (from 10% to close to 2x faster), while having a relatively no measurable impact on scene that are not stressing the texture system.

Something I've yet to play with: instead of mixing in the filename hash, just use the file pointer itself (which should be unique as well). This would avoid the two caches misses it takes to lookup the filename's hash at the expense of making the hash function non-deterministic.
