### PR TITLE
Updates after release of libheif 1.5

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -638,6 +638,7 @@ macro (find_or_download_robin_map)
     # locally installed in this tree.
     if (NOT BUILD_ROBINMAP_FORCE)
         find_path (ROBINMAP_INCLUDE_DIR tsl/robin_map.h
+               HINTS
                "${PROJECT_SOURCE_DIR}/ext/robin-map/tsl/"
                "${ROBINMAP_HOME}"
                "$ENV{ROBINMAP_HOME}"

--- a/src/cmake/modules/FindLibheif.cmake
+++ b/src/cmake/modules/FindLibheif.cmake
@@ -15,13 +15,19 @@ include (FindPackageMessage)
 
 find_path (LIBHEIF_INCLUDE_DIR
     libheif/heif_version.h
-    PATHS
+    HINTS
     ${LIBHEIF_INCLUDE_PATH}
-    ${LIBHEIF_PATH}/include/
+    ENV LIBHEIF_INCLUDE_PATH
+    PATH_SUFFIXES include
     DOC "The directory where libheif headers reside")
 
+message(STATUS "LIBHEIF_PATH ${LIBHEIF_PATH}")
 find_library (LIBHEIF_LIBRARY heif
-              PATHS ${LIBHEIF_PATH}/lib ${LIBHEIF_LIBRARY_PATH})
+              HINTS
+              ${LIBHEIF_LIBRARY_PATH}
+              ENV LIBHEIF_LIBRARY_PATH
+              PATH_SUFFIXES lib
+              DOC "The directory where libheif libraries reside")
 
 message (STATUS "LIBHEIF_INCLUDE_DIR = ${LIBHEIF_INCLUDE_DIR}")
 if (LIBHEIF_INCLUDE_DIR)
@@ -44,13 +50,13 @@ endif()
 
 include (FindPackageHandleStandardArgs)
 find_package_handle_standard_args (LIBHEIF
-    REQUIRED_VARS   LIBHEIF_INCLUDE_DIR
+    REQUIRED_VARS   LIBHEIF_INCLUDES
                     LIBHEIF_LIBRARIES
     VERSION_VAR     LIBHEIF_VERSION
     )
 
 mark_as_advanced (
-    LIBHEIF_INCLUDE_DIR
+    LIBHEIF_INCLUDES
     LIBHEIF_LIBRARIES
     LIBHEIF_VERSION
     )

--- a/testsuite/heif/ref/out-libheif1.4.txt
+++ b/testsuite/heif/ref/out-libheif1.4.txt
@@ -1,6 +1,6 @@
 Reading ref/IMG_7702_small.heic
 ref/IMG_7702_small.heic :  512 x  300, 3 channel, uint8 heif
-    SHA-1: A189F078254B21C9F918207D6DD5433DD5D2382D
+    SHA-1: C681C957FE12AEFBAED8F40DCC74E276C38D8165
     channel list: R, G, B
     DateTime: "2019:01:21 16:10:54"
     ExposureTime: 0.030303


### PR DESCRIPTION
A little more flexibility in overriding where to find libheif

Update ref output after libheif 1.5 release
