### PR TITLE
Fix potential deadlock in TIFF I/O: minor flaw with threadpool method

### DIFF
--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -715,7 +715,10 @@ public:
     /// Return true if the calling thread is part of the thread pool. This
     /// can be used to limit a pool thread from inadvisedly adding its own
     /// subtasks to clog up the pool.
-    bool this_thread_is_in_pool() const;
+    /// DEPRECATED(2.1) -- use is_worker() instead.
+    bool this_thread_is_in_pool() const {
+        return is_worker();
+    }
 
     /// Register a thread (not already in the thread pool itself) as working
     /// on tasks in the pool. This is used to avoid recursion.
@@ -725,8 +728,10 @@ public:
     void deregister_worker(std::thread::id id);
     /// Is the thread in the pool or currently engaged in taking tasks from
     /// the pool?
+    bool is_worker(std::thread::id id) const;
+    bool is_worker() const { return is_worker(std::this_thread::get_id()); }
+    // Non-const versions: DEPRECATED(2.1)
     bool is_worker(std::thread::id id);
-    bool is_worker() { return is_worker(std::this_thread::get_id()); }
 
     /// How many jobs are waiting to run?  (Use with caution! Can be out of
     /// date by the time you look at it.)

--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -716,9 +716,7 @@ public:
     /// can be used to limit a pool thread from inadvisedly adding its own
     /// subtasks to clog up the pool.
     /// DEPRECATED(2.1) -- use is_worker() instead.
-    bool this_thread_is_in_pool() const {
-        return is_worker();
-    }
+    bool this_thread_is_in_pool() const;
 
     /// Register a thread (not already in the thread pool itself) as working
     /// on tasks in the pool. This is used to avoid recursion.

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -414,6 +414,15 @@ thread_pool::push_queue_and_notify(std::function<void(int id)>* f)
 
 
 
+/// DEPRECATED(2.1) -- use is_worker() instead.
+bool
+thread_pool::this_thread_is_in_pool() const
+{
+    return is_worker();
+}
+
+
+
 void
 thread_pool::register_worker(std::thread::id id)
 {

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -1128,7 +1128,7 @@ TIFFOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
         && (m_spec.format == TypeUInt8 || m_spec.format == TypeUInt16)
         // only if we're threading and don't enter the thread pool recursively!
         && pool->size() > 1
-        && !pool->this_thread_is_in_pool()
+        && !pool->is_worker()
         // and not if the feature is turned off
         && m_spec.get_int_attribute("tiff:multithread",
                                     OIIO::get_int_attribute("tiff:multithread"));
@@ -1361,7 +1361,7 @@ TIFFOutput::write_tiles(int xbegin, int xend, int ybegin, int yend, int zbegin,
         && (m_spec.format == TypeUInt8 || m_spec.format == TypeUInt16)
         // only if we're threading and don't enter the thread pool recursively!
         && pool->size() > 1
-        && !pool->this_thread_is_in_pool()
+        && !pool->is_worker()
         // and not if the feature is turned off
         && m_spec.get_int_attribute("tiff:multithread",
                                     OIIO::get_int_attribute("tiff:multithread"));


### PR DESCRIPTION
This has *very* occasionally popped up for a while. I've only seen it
on OSX for some reason, too hard to reproduce but once every several
days.  But a totally unrelated set of changes caused me to see it
happen quite regularly and it's icky.

Long story short, our thread pool seemed to have two different ways of
finding out whether the current thread is a member of the pool, one of
them only used from the TIFF reader/writer, and they didn't match!
Specifically, the correct one tried to know if the calling thread was
doing work for the pool, either being a member of the pool itself or a
nonmember that was stealing work because the pool was too full to add
to. The other one merely said whether it was a fully fledged pool
worker thread. Turns out this difference could get you into trouble,
because you don't want to spawn new tasks from a work stealer, either.

It took me hours of debugging to isolate the trouble, it's too hard to
summarize the specific set of coincidences necessary for this
circumstance to lead to a deadlock.

I also simplified some of the TIFF code just a hair, was a redundant
check for read_raw_strips.