### PR TITLE
DPXInput::read_image

### DIFF
--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -34,6 +34,15 @@ public:
     virtual bool read_native_scanline(int subimage, int miplevel, int y, int z,
                                       void* data) override;
 
+    /*
+        Custom read_image for slurping the whole thing
+    */
+    virtual bool read_image(int subimage, int miplevel, int chbegin, int chend,
+                            TypeDesc format, void* data, stride_t xstride,
+                            stride_t ystride, stride_t zstride,
+                            ProgressCallback progress_callback,
+                            void* progress_callback_data) override;
+
 private:
     int m_subimage;
     InStream* m_stream = nullptr;
@@ -591,6 +600,54 @@ DPXInput::read_native_scanline(int subimage, int miplevel, int y, int z,
 }
 
 
+bool
+DPXInput::read_image(int subimage, int miplevel, int chbegin, int chend,
+                     TypeDesc format, void* data, stride_t xstride,
+                     stride_t ystride, stride_t zstride,
+                     ProgressCallback progress_callback,
+                     void* progress_callback_data)
+{
+    lock_guard lock(m_mutex);
+    if (!seek_subimage(subimage, miplevel))
+        return false;
+
+    dpx::Block block(0, 0, m_dpx.header.Width() - 1, m_dpx.header.Height() - 1);
+
+    if (m_rawcolor) {
+        if (!m_dpx.ReadBlock(m_subimage, (unsigned char*)data, block))
+        {
+            return false;
+        }
+    } else {
+        std::unique_ptr<unsigned char> storage = nullptr;
+
+        int bufsize = dpx::QueryRGBBufferSize(m_dpx.header, subimage, block);
+
+        if (bufsize == 0 && !m_rawcolor) {
+            error("Unable to deliver RGB data from source data");
+            return false;
+        }
+
+        void *ptr;
+        if (bufsize > 0)
+        {
+            storage.reset(new unsigned char[bufsize]);
+            ptr = (void *)storage.get();
+        }
+        else
+        {
+            ptr = data;
+        }
+
+        if (!m_dpx.ReadBlock(m_subimage, (unsigned char *)ptr, block))
+            return false;
+
+        if (!dpx::ConvertToRGB(m_dpx.header, m_subimage, ptr, data, block))
+            return false;
+    }
+
+    return true;
+}
 
 std::string
 DPXInput::get_characteristic_string(dpx::Characteristic c)

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -34,9 +34,6 @@ public:
     virtual bool read_native_scanline(int subimage, int miplevel, int y, int z,
                                       void* data) override;
 
-    /*
-        Custom read_image for slurping the whole thing
-    */
     virtual bool read_image(int subimage, int miplevel, int chbegin, int chend,
                             TypeDesc format, void* data, stride_t xstride,
                             stride_t ystride, stride_t zstride,


### PR DESCRIPTION
## Description
From this [mail thread](
http://lists.openimageio.org/pipermail/oiio-dev-openimageio.org/2019-September/thread.html#1708)

The reading of DPX files one scanline at a time bogs down by reading the image opposite of the way it was laid out on disk. So by the end of the image you've permuted each scanline multiple times. It's extremely prevalent over a network connection. Where possible, we should read in chunks. This will slurp the entire image when calling `read_image(...)`.

I have no reservations on the code - only that it works quite well for grepping the whole image. If someone wishes to reinvent this to better fit the OIIO spec I'm happy to relinquish control over it. This was mainly just a "it worked for us" fix.

> A special thanks to @menssimia and his brain for identifying where the performance killer was. If anyone has questions, he may be the best one to answer the nitty-gritty of the dpx code.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.
