### PR TITLE
Fix DPX performance regression

### DIFF
--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -33,6 +33,8 @@ public:
     virtual bool seek_subimage(int subimage, int miplevel) override;
     virtual bool read_native_scanline(int subimage, int miplevel, int y, int z,
                                       void* data) override;
+    virtual bool read_native_scanlines(int subimage, int miplevel, int ybegin,
+                                       int yend, int z, void* data) override;
 
 private:
     int m_subimage;
@@ -40,19 +42,18 @@ private:
     dpx::Reader m_dpx;
     std::vector<unsigned char> m_userBuf;
     bool m_rawcolor;
-    unsigned char* m_dataPtr = nullptr;
+    std::vector<unsigned char> m_decodebuf;  // temporary decode buffer
 
     /// Reset everything to initial state
     ///
     void init()
     {
+        m_subimage = -1;
         if (m_stream) {
             m_stream->Close();
             delete m_stream;
             m_stream = nullptr;
         }
-        delete[] m_dataPtr;
-        m_dataPtr = nullptr;
         m_userBuf.clear();
         m_rawcolor = false;
     }
@@ -163,6 +164,8 @@ DPXInput::seek_subimage(int subimage, int miplevel)
 {
     if (miplevel != 0)
         return false;
+    if (subimage == m_subimage)
+        return true;
     if (subimage < 0 || subimage >= m_dpx.header.ImageElementCount())
         return false;
 
@@ -537,17 +540,6 @@ DPXInput::seek_subimage(int subimage, int miplevel)
     if (m_spec.nchannels == 1)
         m_rawcolor = true;
 
-    dpx::Block block(0, 0, m_dpx.header.Width() - 1, m_dpx.header.Height() - 1);
-    int bufsize = dpx::QueryRGBBufferSize(m_dpx.header, subimage, block);
-    if (bufsize == 0 && !m_rawcolor) {
-        error("Unable to deliver RGB data from source data");
-        return false;
-    } else if (!m_rawcolor && bufsize > 0)
-        m_dataPtr = new unsigned char[bufsize];
-    else
-        // no need to allocate another buffer
-        m_dataPtr = NULL;
-
     return true;
 }
 
@@ -566,24 +558,38 @@ bool
 DPXInput::read_native_scanline(int subimage, int miplevel, int y, int z,
                                void* data)
 {
+    return read_native_scanlines(subimage, miplevel, y, y + 1, z, data);
+}
+
+
+
+bool
+DPXInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
+                                int yend, int z, void* data)
+{
     lock_guard lock(m_mutex);
     if (!seek_subimage(subimage, miplevel))
         return false;
 
-    dpx::Block block(0, y - m_spec.y, m_dpx.header.Width() - 1, y - m_spec.y);
+    dpx::Block block(0, ybegin - m_spec.y, m_dpx.header.Width() - 1,
+                     yend - 1 - m_spec.y);
 
     if (m_rawcolor) {
         // fast path - just read the scanline in
-        if (!m_dpx.ReadBlock(m_subimage, (unsigned char*)data, block))
+        if (!m_dpx.ReadBlock(subimage, (unsigned char*)data, block))
             return false;
     } else {
         // read the scanline and convert to RGB
-        void* ptr = m_dataPtr == NULL ? data : (void*)m_dataPtr;
+        unsigned char* ptr = (unsigned char*)data;
+        int bufsize = dpx::QueryRGBBufferSize(m_dpx.header, subimage, block);
+        if (bufsize > 0) {
+            m_decodebuf.resize(bufsize);
+            ptr = m_decodebuf.data();
+        }
 
-        if (!m_dpx.ReadBlock(m_subimage, (unsigned char*)ptr, block))
+        if (!m_dpx.ReadBlock(subimage, ptr, block))
             return false;
-
-        if (!dpx::ConvertToRGB(m_dpx.header, m_subimage, ptr, data, block))
+        if (!dpx::ConvertToRGB(m_dpx.header, subimage, ptr, data, block))
             return false;
     }
 

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -619,7 +619,8 @@ PSDInput::seek_subimage(int subimage, int miplevel)
 {
     if (miplevel != 0)
         return false;
-
+    if (subimage == m_subimage)
+        return true;  // Early return when not changing subimages
     if (subimage < 0 || subimage >= m_subimage_count)
         return false;
 


### PR DESCRIPTION
Quite some time ago (early in OIIO 2.0 development, after it was
separated from 1.8), we changed the ImageInput::read_native functions
to be thread-safe and stateless. This meant that a seek_subimage would
be called inside the read (which now had a lock) whereas it was
previously assumed that the user had already called it.

All good, as long as your seek_subimage checks whether it's seeking to the
subimage it's already on, in which case no work need be done.

DPX failed to do this, so every scanline read involved a costly header
examination.  Somehow nobody noticed this until now, but it's fairly
icky. It can slow down DPX reads by 2x, and this is greatly exacerbated
in a heavily multithreaded environment.

I found and fixed a similar error for psd files.

While I was at it, I also added a read_native_scanlines so it can read
multiple scanlines (the building block of read_image working efficiently)
with less work, though in my timings it's only barely worth it.

