### PR TITLE
Tested fine against clang 9

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,7 +26,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
 ### Required dependencies -- OIIO will not build at all without these
 
  * C++11 (also builds with C++14 and C++17)
- * Compilers: gcc 4.8.2 - 9.1, clang 3.3 - 8.0, **MSVS 2015 - 2019**,
+ * Compilers: gcc 4.8.2 - 9.1, clang 3.3 - 9.0, **MSVS 2015 - 2019**,
    icc version 13 or higher
  * Boost >= 1.53 (tested up through 1.71)
  * CMake >= 3.2.2 (tested up through 3.15)

--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -128,6 +128,10 @@ ifeq (${SP_OS}, rhel7)
         LLVM_DIRECTORY := /shots/spi/home/lib/arnold/rhel7/llvm_8.0.0
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
         MY_CMAKE_FLAGS += -DCMAKE_C_FLAGS="--gcc-toolchain=/usr" -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr"
+    else ifeq (${COMPILER},clang9)
+        LLVM_DIRECTORY := /shots/spi/home/lib/arnold/rhel7/llvm_9.0.0_rc4
+        MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
+        MY_CMAKE_FLAGS += -DCMAKE_C_FLAGS="--gcc-toolchain=/usr" -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr"
     else ifeq (${COMPILER},clang)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
         MY_CMAKE_FLAGS += -DCMAKE_C_FLAGS="--gcc-toolchain=/usr" -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr"


### PR DESCRIPTION
Nothing to see here, folks. It build and tested fine the first time against clang 9.0.0_rc4, so I'm just updating the docs to say so.
