### PR TITLE
New attrib "oiio:subimages" says number of subimages, if known

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -819,6 +819,12 @@ Some special attributes are used for movie files:
    * - ``oiio:Movie``
      - int
      - Nonzero value for movie files
+   * - ``oiio:subimages``
+     - int
+     - The number of frames in the movie, positive if it can be known
+       without reading the entire file. Zero or not present if the number
+       of frames cannot be determinend from reading from just the file
+       header.
    * - ``FramesPerSecond``
      - int[2] (rational)
      - Frames per second

--- a/src/doc/stdmetadata.rst
+++ b/src/doc/stdmetadata.rst
@@ -106,6 +106,15 @@ Display hints
     If nonzero, a hint that a multi-image file is meant to be interpreted as
     an animation (i.e., that the subimages are a time sequence).
 
+.. option:: "oiio:subimages" : int
+
+    If nonzero, the number of subimages in the file. Not all image file
+    formats can know this without reading the entire file, and in such
+    cases, this attribute will not be set or will be 0. If the value is
+    present and greater than zero, it can be trusted, but if not, nothing
+    should be inferred and you will have to repeatedly seek to subimages
+    to find out how many there are.
+
 .. option:: "FramesPerSecond" : rational
 
     For a multi-image file intended to be played back as an animation, the

--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -409,6 +409,7 @@ FFmpegInput::open(const std::string& name, ImageSpec& spec)
     int rat[2] = { m_frame_rate.num, m_frame_rate.den };
     m_spec.attribute("FramesPerSecond", TypeRational, &rat);
     m_spec.attribute("oiio:Movie", true);
+    m_spec.attribute("oiio:subimages", int(m_frames));
     m_spec.attribute("oiio:BitsPerSample",
                      m_codec_context->bits_per_raw_sample);
     m_nsubimages = m_frames;

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -799,6 +799,8 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
     if (header->hasName() && header->name() != "")
         spec.attribute("oiio:subimagename", header->name());
 
+    spec.attribute("oiio:subimages", in->m_nsubimages);
+
     // Squash some problematic texture metadata if we suspect it's wrong
     pvt::check_texture_metadata_sanity(spec);
 

--- a/testsuite/dup-channels/ref/out.txt
+++ b/testsuite/dup-channels/ref/out.txt
@@ -7,6 +7,7 @@ out.exr              :   64 x   64, 6 channel, half openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Reading out2.exr
 out2.exr             :   64 x   64, 6 channel, half openexr
     SHA-1: 6FECD5769C727E137B7580AE3B1823B06EE6F9D9
@@ -18,4 +19,5 @@ out2.exr             :   64 x   64, 6 channel, half openexr
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
     oiio:subimagename: "Aimg"
+    oiio:subimages: 1
     openexr:chunkCount: 4

--- a/testsuite/maketx/ref/out.txt
+++ b/testsuite/maketx/ref/out.txt
@@ -278,6 +278,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     oiio:AverageColor: "0.5,0.5,0.5"
     oiio:ColorSpace: "Linear"
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
+    oiio:subimages: 1
     openexr:levelmode: 0
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
@@ -305,6 +306,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     oiio:AverageColor: "0.5,0.5,0.5,1"
     oiio:ColorSpace: "Linear"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    oiio:subimages: 1
     openexr:roundingmode: 0
 Reading small.tif
 small.tif            :   64 x   64, 3 channel, uint8 tiff
@@ -395,4 +397,5 @@ bumpslope.exr        :   64 x   64, 6 channel, half openexr
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
     oiio:ColorSpace: "Linear"
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
+    oiio:subimages: 1
     openexr:roundingmode: 0

--- a/testsuite/oiiotool-copy/ref/out.txt
+++ b/testsuite/oiiotool-copy/ref/out.txt
@@ -30,6 +30,7 @@ nometamerge.exr      :   64 x   64, 6 channel, float openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Reading metamerge.exr
 metamerge.exr        :   64 x   64, 6 channel, float openexr
     SHA-1: 9F13A523321C66208E90D45F87FA0CD9B370E111
@@ -41,3 +42,4 @@ metamerge.exr        :   64 x   64, 6 channel, float openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1

--- a/testsuite/oiiotool-fixnan/ref/out.txt
+++ b/testsuite/oiiotool-fixnan/ref/out.txt
@@ -7,6 +7,7 @@ src/bad.exr          :   64 x   64, 3 channel, half openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
     Stats Avg: 0.500000 0.500000 0.500000 (float)
@@ -25,6 +26,7 @@ black.exr            :   64 x   64, 3 channel, half openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
     Stats Avg: 0.499756 0.500000 0.500000 (float)
@@ -43,6 +45,7 @@ box3.exr             :   64 x   64, 3 channel, half openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
     Stats Avg: 0.500000 0.500000 0.500000 (float)

--- a/testsuite/oiiotool-maketx/ref/out.txt
+++ b/testsuite/oiiotool-maketx/ref/out.txt
@@ -278,6 +278,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     oiio:AverageColor: "0.5,0.5,0.5"
     oiio:ColorSpace: "Linear"
     oiio:SHA-1: "44B96A7C3AFBF8D7621E7C6453266E5DD1962D36"
+    oiio:subimages: 1
     openexr:levelmode: 0
     Stats Min: 0.000000 0.000000 0.000000 (float)
     Stats Max: 1.000000 1.000000 1.000000 (float)
@@ -305,6 +306,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     oiio:AverageColor: "0.5,0.5,0.5,1"
     oiio:ColorSpace: "Linear"
     oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    oiio:subimages: 1
     openexr:roundingmode: 0
 Reading grid.tx
     oiio:SHA-1: "9B24D4CC05313A43973AC384718D81D19183B691"

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -17,6 +17,7 @@ chname.exr           :   38 x   38, 5 channel, float openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Reading allhalf.exr
 allhalf.exr          :   38 x   38, 5 channel, half openexr
     SHA-1: 1C71682E8D8F6DCDC2A7A7B23842DFEEC51438F2
@@ -30,6 +31,7 @@ allhalf.exr          :   38 x   38, 5 channel, half openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Reading rgbahalf-zfloat.exr
 rgbahalf-zfloat.exr  :   38 x   38, 5 channel, half/half/half/half/float openexr
     SHA-1: 9324AFD44451321A8D87E09F656C7B86E827E5CD
@@ -43,6 +45,7 @@ rgbahalf-zfloat.exr  :   38 x   38, 5 channel, half/half/half/half/float openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 copyA.0001.jpg       :  128 x   96, 3 channel, uint8 jpeg
 copyA.0002.jpg       :  128 x   96, 3 channel, uint8 jpeg
 copyA.0003.jpg       :  128 x   96, 3 channel, uint8 jpeg
@@ -89,6 +92,7 @@ add_rgb_rgba.exr     :   64 x   64, 4 channel, float openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "filled.tif" and "ref/filled.tif"
 PASS
 Comparing "autotrim.tif" and "ref/autotrim.tif"

--- a/testsuite/openexr-chroma/ref/out.txt
+++ b/testsuite/openexr-chroma/ref/out.txt
@@ -9,5 +9,6 @@ Reading ../../../../../openexr-images/LuminanceChroma/Garden.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/LuminanceChroma/Garden.exr" and "Garden.exr"
 PASS

--- a/testsuite/openexr-multires/ref/out.txt
+++ b/testsuite/openexr-multires/ref/out.txt
@@ -13,6 +13,7 @@ Reading ../../../../../openexr-images/MultiResolution/Bonita.exr
     textureformat: "Plain Texture"
     wrapmodes: "clamp,clamp"
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
     openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/Bonita.exr" and "Bonita.exr"
 PASS
@@ -31,6 +32,7 @@ Reading ../../../../../openexr-images/MultiResolution/ColorCodedLevels.exr
     textureformat: "Plain Texture"
     wrapmodes: "periodic,periodic"
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
     openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/ColorCodedLevels.exr" and "ColorCodedLevels.exr"
 PASS
@@ -50,6 +52,7 @@ Reading ../../../../../openexr-images/MultiResolution/KernerEnvCube.exr
     textureformat: "CubeFace Environment"
     oiio:ColorSpace: "Linear"
     oiio:sampleborder: 1
+    oiio:subimages: 1
     openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/KernerEnvCube.exr" and "KernerEnvCube.exr"
 PASS
@@ -67,6 +70,7 @@ Reading ../../../../../openexr-images/MultiResolution/KernerEnvLatLong.exr
     textureformat: "LatLong Environment"
     oiio:ColorSpace: "Linear"
     oiio:sampleborder: 1
+    oiio:subimages: 1
     oiio:updirection: "y"
     openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/KernerEnvLatLong.exr" and "KernerEnvLatLong.exr"
@@ -85,6 +89,7 @@ Reading ../../../../../openexr-images/MultiResolution/MirrorPattern.exr
     textureformat: "Plain Texture"
     wrapmodes: "mirror,mirror"
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
     openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/MirrorPattern.exr" and "MirrorPattern.exr"
 PASS
@@ -104,6 +109,7 @@ Reading ../../../../../openexr-images/MultiResolution/OrientationCube.exr
     textureformat: "CubeFace Environment"
     oiio:ColorSpace: "Linear"
     oiio:sampleborder: 1
+    oiio:subimages: 1
     openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/OrientationCube.exr" and "OrientationCube.exr"
 PASS
@@ -121,6 +127,7 @@ Reading ../../../../../openexr-images/MultiResolution/OrientationLatLong.exr
     textureformat: "LatLong Environment"
     oiio:ColorSpace: "Linear"
     oiio:sampleborder: 1
+    oiio:subimages: 1
     oiio:updirection: "y"
     openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/OrientationLatLong.exr" and "OrientationLatLong.exr"
@@ -139,6 +146,7 @@ Reading ../../../../../openexr-images/MultiResolution/PeriodicPattern.exr
     textureformat: "Plain Texture"
     wrapmodes: "periodic,periodic"
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
     openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/PeriodicPattern.exr" and "PeriodicPattern.exr"
 PASS
@@ -158,6 +166,7 @@ Reading ../../../../../openexr-images/MultiResolution/StageEnvCube.exr
     textureformat: "CubeFace Environment"
     oiio:ColorSpace: "Linear"
     oiio:sampleborder: 1
+    oiio:subimages: 1
     openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/StageEnvCube.exr" and "StageEnvCube.exr"
 PASS
@@ -175,6 +184,7 @@ Reading ../../../../../openexr-images/MultiResolution/StageEnvLatLong.exr
     textureformat: "LatLong Environment"
     oiio:ColorSpace: "Linear"
     oiio:sampleborder: 1
+    oiio:subimages: 1
     oiio:updirection: "y"
     openexr:roundingmode: 1
 Comparing "../../../../../openexr-images/MultiResolution/StageEnvLatLong.exr" and "StageEnvLatLong.exr"
@@ -195,6 +205,7 @@ Reading ../../../../../openexr-images/MultiResolution/WavyLinesCube.exr
     textureformat: "CubeFace Environment"
     oiio:ColorSpace: "Linear"
     oiio:sampleborder: 1
+    oiio:subimages: 1
     openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/WavyLinesCube.exr" and "WavyLinesCube.exr"
 PASS
@@ -212,6 +223,7 @@ Reading ../../../../../openexr-images/MultiResolution/WavyLinesLatLong.exr
     textureformat: "LatLong Environment"
     oiio:ColorSpace: "Linear"
     oiio:sampleborder: 1
+    oiio:subimages: 1
     oiio:updirection: "y"
     openexr:roundingmode: 0
 Comparing "../../../../../openexr-images/MultiResolution/WavyLinesLatLong.exr" and "WavyLinesLatLong.exr"
@@ -226,5 +238,6 @@ Reading ../../../../../openexr-images/MultiResolution/WavyLinesSphere.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/MultiResolution/WavyLinesSphere.exr" and "WavyLinesSphere.exr"
 PASS

--- a/testsuite/openexr-suite/ref/out.txt
+++ b/testsuite/openexr-suite/ref/out.txt
@@ -7,6 +7,7 @@ Reading ../../../../../openexr-images/ScanLines/Desk.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/ScanLines/Desk.exr" and "Desk.exr"
 PASS
 Reading ../../../../../openexr-images/ScanLines/MtTamWest.exr
@@ -25,6 +26,7 @@ Reading ../../../../../openexr-images/ScanLines/MtTamWest.exr
     screenWindowWidth: 1
     utcOffset: 25200
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/ScanLines/MtTamWest.exr" and "MtTamWest.exr"
 PASS
 Reading ../../../../../openexr-images/ScanLines/Cannon.exr
@@ -37,6 +39,7 @@ Reading ../../../../../openexr-images/ScanLines/Cannon.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/ScanLines/Cannon.exr" and "Cannon.exr"
 PASS
 Reading ../../../../../openexr-images/ScanLines/StillLife.exr
@@ -51,6 +54,7 @@ Reading ../../../../../openexr-images/ScanLines/StillLife.exr
     screenWindowWidth: 0.45
     utcOffset: 25200
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/ScanLines/StillLife.exr" and "StillLife.exr"
 PASS
 Reading ../../../../../openexr-images/ScanLines/Tree.exr
@@ -68,6 +72,7 @@ Reading ../../../../../openexr-images/ScanLines/Tree.exr
     utcOffset: 25200
     whiteLuminance: 621
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/ScanLines/Tree.exr" and "Tree.exr"
 PASS
 Reading ../../../../../openexr-images/ScanLines/Blobbies.exr
@@ -87,6 +92,7 @@ Reading ../../../../../openexr-images/ScanLines/Blobbies.exr
     utcOffset: 28800
     whiteLuminance: 50
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/ScanLines/Blobbies.exr" and "Blobbies.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/AllHalfValues.exr
@@ -98,6 +104,7 @@ Reading ../../../../../openexr-images/TestImages/AllHalfValues.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/TestImages/AllHalfValues.exr" and "AllHalfValues.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/BrightRings.exr
@@ -109,6 +116,7 @@ Reading ../../../../../openexr-images/TestImages/BrightRings.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/TestImages/BrightRings.exr" and "BrightRings.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/BrightRingsNanInf.exr
@@ -120,6 +128,7 @@ Reading ../../../../../openexr-images/TestImages/BrightRingsNanInf.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/TestImages/BrightRingsNanInf.exr" and "BrightRingsNanInf.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/GammaChart.exr
@@ -131,6 +140,7 @@ Reading ../../../../../openexr-images/TestImages/GammaChart.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/TestImages/GammaChart.exr" and "GammaChart.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/GrayRampsDiagonal.exr
@@ -142,6 +152,7 @@ Reading ../../../../../openexr-images/TestImages/GrayRampsDiagonal.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/TestImages/GrayRampsDiagonal.exr" and "GrayRampsDiagonal.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/GrayRampsHorizontal.exr
@@ -153,6 +164,7 @@ Reading ../../../../../openexr-images/TestImages/GrayRampsHorizontal.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/TestImages/GrayRampsHorizontal.exr" and "GrayRampsHorizontal.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/RgbRampsDiagonal.exr
@@ -164,6 +176,7 @@ Reading ../../../../../openexr-images/TestImages/RgbRampsDiagonal.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/TestImages/RgbRampsDiagonal.exr" and "RgbRampsDiagonal.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/SquaresSwirls.exr
@@ -175,6 +188,7 @@ Reading ../../../../../openexr-images/TestImages/SquaresSwirls.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/TestImages/SquaresSwirls.exr" and "SquaresSwirls.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/WideColorGamut.exr
@@ -187,6 +201,7 @@ Reading ../../../../../openexr-images/TestImages/WideColorGamut.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/TestImages/WideColorGamut.exr" and "WideColorGamut.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/WideFloatRange.exr
@@ -198,6 +213,7 @@ Reading ../../../../../openexr-images/TestImages/WideFloatRange.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/TestImages/WideFloatRange.exr" and "WideFloatRange.exr"
 PASS
 Reading ../../../../../openexr-images/Tiles/GoldenGate.exr
@@ -221,6 +237,7 @@ Reading ../../../../../openexr-images/Tiles/GoldenGate.exr
     screenWindowWidth: 1.15
     utcOffset: 28800
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/Tiles/GoldenGate.exr" and "GoldenGate.exr"
 PASS
 Reading ../../../../../openexr-images/Tiles/Ocean.exr
@@ -235,6 +252,7 @@ Reading ../../../../../openexr-images/Tiles/Ocean.exr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/Tiles/Ocean.exr" and "Ocean.exr"
 PASS
 Reading ../../../../../openexr-images/Tiles/Spirals.exr
@@ -255,5 +273,6 @@ Reading ../../../../../openexr-images/Tiles/Spirals.exr
     utcOffset: 28800
     whiteLuminance: 90
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
 Comparing "../../../../../openexr-images/Tiles/Spirals.exr" and "Spirals.exr"
 PASS

--- a/testsuite/openexr-v2/ref/out.txt
+++ b/testsuite/openexr-v2/ref/out.txt
@@ -17,6 +17,7 @@ Reading ../../../../../openexr-images/v2/Stereo/composited.exr
     view: "left"
     oiio:ColorSpace: "Linear"
     oiio:subimagename: "rgba.left"
+    oiio:subimages: 4
     openexr:chunkCount: 1078
  subimage  1: 1918 x 1078, 1 channel, half openexr
     SHA-1: 5FAE17E1E8BDB2E7C3A6B3EBCA8E0CA15A07B80A
@@ -33,6 +34,7 @@ Reading ../../../../../openexr-images/v2/Stereo/composited.exr
     view: "left"
     oiio:ColorSpace: "Linear"
     oiio:subimagename: "depth.left"
+    oiio:subimages: 4
     openexr:chunkCount: 1078
  subimage  2: 1918 x 1078, 4 channel, half openexr
     SHA-1: 3CC2362892007C6AACABE356DF93F87408C988B3
@@ -49,6 +51,7 @@ Reading ../../../../../openexr-images/v2/Stereo/composited.exr
     view: "right"
     oiio:ColorSpace: "Linear"
     oiio:subimagename: "rgba.right"
+    oiio:subimages: 4
     openexr:chunkCount: 1078
  subimage  3: 1918 x 1078, 1 channel, half openexr
     SHA-1: FBB31FC1CD9EC4759703F033C8D0E14E5806AE92
@@ -65,6 +68,7 @@ Reading ../../../../../openexr-images/v2/Stereo/composited.exr
     view: "right"
     oiio:ColorSpace: "Linear"
     oiio:subimagename: "depth.right"
+    oiio:subimages: 4
     openexr:chunkCount: 1078
 ../../../../../openexr-images/v2/Stereo/composited.exr : 1918 x 1078, 4 channel, half openexr (4 subimages)
     Stats Min: 0.000000 0.000000 0.000000 0.000000 (float)
@@ -96,6 +100,7 @@ Reading ../../../../../openexr-images/v2/Stereo/Balls.exr
     view: "left"
     oiio:ColorSpace: "Linear"
     oiio:subimagename: "rgba.left"
+    oiio:subimages: 2
     openexr:chunkCount: 761
     openexr:version: 1
  subimage  1: 1452 x  761, 5 channel, deep half/half/half/half/float openexr
@@ -113,6 +118,7 @@ Reading ../../../../../openexr-images/v2/Stereo/Balls.exr
     view: "right"
     oiio:ColorSpace: "Linear"
     oiio:subimagename: "rgba.right"
+    oiio:subimages: 2
     openexr:chunkCount: 761
     openexr:version: 1
 ../../../../../openexr-images/v2/Stereo/Balls.exr : 1431 x  761, 5 channel, deep half/half/half/half/float openexr (2 subimages)
@@ -153,6 +159,7 @@ Reading ../../../../../openexr-images/v2/Stereo/Leaves.exr
     view: "left"
     oiio:ColorSpace: "Linear"
     oiio:subimagename: "rgba.left"
+    oiio:subimages: 2
     openexr:chunkCount: 1080
     openexr:version: 1
  subimage  1: 1920 x 1080, 5 channel, deep half/half/half/half/float openexr
@@ -167,6 +174,7 @@ Reading ../../../../../openexr-images/v2/Stereo/Leaves.exr
     view: "right"
     oiio:ColorSpace: "Linear"
     oiio:subimagename: "rgba.right"
+    oiio:subimages: 2
     openexr:chunkCount: 1080
     openexr:version: 1
 ../../../../../openexr-images/v2/Stereo/Leaves.exr : 1920 x 1080, 5 channel, deep half/half/half/half/float openexr (2 subimages)

--- a/testsuite/rational/ref/out.txt
+++ b/testsuite/rational/ref/out.txt
@@ -63,6 +63,7 @@ src/test.exr         :   64 x   64, 3 channel, half openexr
     timecodeRate: 24
     Exif:ImageHistory: "oiiotool cropped-stripped-Isabella.0.exr -cut 64x64+0+0 -o test.exr"
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
     smpte:TimeCode: 01:18:19:06
 Comparing "src/test.exr" and "test.exr"
 PASS
@@ -76,3 +77,4 @@ rat2.exr             :   64 x   64, 3 channel, float openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
+    oiio:subimages: 1


### PR DESCRIPTION
It's the number of frames for movie files, number of subimages for
other files.

Set and positive only if it can be known inexpensively from the file
header. If absent or zero, it means there was no easy way to determine
the number of frames or subimages from just reading the header (in that
case, you'll have to discover the subimages the old fashioned way,
repeatedly seeking to subimages until you fail).

