### PR TITLE
Fixes that make multi-subimage and movie files faster

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1025,9 +1025,10 @@ ImageCacheFile::read_untiled(ImageCachePerThreadInfo* thread_info,
         thread_info->m_stats.bytes_read += b;
         m_bytesread += b;
         ++m_tilesread;
-        // If we read the whole image, presumably we're done, so release
-        // the file handle.
-        close();
+        // If we read the whole image (and there are no other subimages),
+        // presumably we're done, so release the file handle.
+        if (subimages() == 1)
+            close();
         // FIXME: ^^^ is that a good idea or not?
     }
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4579,7 +4579,8 @@ input_file(int argc, const char* argv[])
         if (ot.debug || ot.verbose)
             std::cout << "Reading " << filename << "\n";
         ot.push(ImageRecRef(new ImageRec(filename, ot.imagecache)));
-        ot.curimg->configspec(ot.input_config);
+        if (ot.input_config_set)
+            ot.curimg->configspec(ot.input_config);
         ot.curimg->input_dataformat(input_dataformat);
         if (readnow) {
             ot.curimg->read(ReadNoCache, channel_set);
@@ -4796,6 +4797,7 @@ output_file(int argc, const char* argv[])
                 ot.curimg
                     = saved_curimg;  // note: last iteration also restores it!
             // Skip 0x0 images. Yes, this can happen.
+            ot.curimg->read();
             const ImageSpec* spec(ot.curimg->spec());
             if (spec->width < 1 || spec->height < 1 || spec->depth < 1)
                 continue;

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -439,9 +439,12 @@ public:
 
     // Get or set the configuration spec that will be used any time the
     // image is opened.
-    const ImageSpec* configspec() const { return &m_configspec; }
-    void configspec(const ImageSpec& spec) { m_configspec = spec; }
-    void clear_configspec() { configspec(ImageSpec()); }
+    const ImageSpec* configspec() const { return m_configspec.get(); }
+    void configspec(const ImageSpec& spec)
+    {
+        m_configspec.reset(new ImageSpec(spec));
+    }
+    void clear_configspec() { m_configspec.reset(); }
 
     /// Error reporting for ImageRec: call this with printf-like arguments.
     /// Note however that this is fully typesafe!
@@ -471,7 +474,7 @@ private:
     TypeDesc m_input_dataformat;
     ImageCache* m_imagecache = nullptr;
     mutable std::string m_err;
-    ImageSpec m_configspec;
+    std::unique_ptr<ImageSpec> m_configspec;
 
     // Add to the error message
     void append_error(string_view message) const;


### PR DESCRIPTION
Several small, subtle, interacting issues were making it particularly
difficult for oiiotool to process frames within movie files (and,
less noticeably, other multi-subimage files). The fixes:

* The ffmpeg reader had no valid_file() method, which meant it fell
  back to the default of doing a full open() and looking for success,
  which is expensive in this case. Replace it with the cheap and naive
  test of just ensuring that the file exists and its name has one of
  the proper file extensions.

* ImageCache::read_untiled(), when reading an untiled image as one
  single tile, closed the file immediately thereafter, which seems
  like a prudent thing to do because once you have read the whole
  image into the cache, you may as well free the resources associated
  with the open file, since you don't need to read any more from
  it. Except... if it's a multi-subimage file, you may need to read
  other subimages.  Especially for a movie file with many frames, you
  don't want to do a full open/close cycle for every frame
  individually just because you are using an ImageCache.

* In oiiotool, ImageRec::read was applying a heuristic to directly and
  fully read "small" images, but fall back on the ImageCache to manage
  "large" images. But it was just looking at the each subimage
  individually. For a movie file, that means that it will force read
  all the frames up front, which is silly. So adjust the heuristic to
  multiply the frame size by number of frames as a better estimate for
  the memory cost of the up-front read. This results in most movie
  files of moderate size falling back to the cache, and thus deferring
  the read until the frames are actually needed (especially helpful if
  not all frames will eventually need to be read).

* Oh boy, oiiotool was always keeping handy a config spec to pass to
  the image open, whether it was needed or not. But also some logic in
  the ImageCache was causing certain kinds of "find file" operations
  (which when asked to find an already in-cache file should just
  return it) to invalidate that previously read file and close+reopen
  when a config spec was supplied (in case the configuration hints
  were meant to change the read behavior or interpretation of the
  file from how it was opened before). These combine badly. So we
  change oiiotool to only pass the config spec when opening via the
  cache if there was a user option to actually set a configuration
  hint, and therefore when that doesn't happen, many needless cache
  invalidations were avoided.
