### PR TITLE
Update pybind11 version logic to work around bugs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,7 +41,10 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you are building the Python bindings or running the testsuite:
      * Python >= 2.7 (tested against 2.7, 3.6, 3.7)
      * **NumPy**
-     * **pybind11 >= 2.2.0** (but OIIO will auto-download it if not found)
+     * **pybind11 >= 2.2.0** (Tested through 2.4.2. It is known that 2.4.0
+       and 2.4.1 have bugs and don't build properly for C++11. For this
+       case, or if no pybind11 is found already on the system, OIIO will
+       auto-download it.)
  * If you want support for camera "RAW" formats:
      * libRaw >= 0.15 (tested 0.15 - 0.19; libRaw >= 0.18 is necessary for
        ACES support and much better recognition of camera metadata)

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -568,8 +568,9 @@ endif()
 
 option (BUILD_PYBIND11_FORCE "Force local download/build of Pybind11 even if installed" OFF)
 option (BUILD_MISSING_PYBIND11 "Local download/build of Pybind11 if not installed" ON)
-set (BUILD_PYBIND11_VERSION "v2.2.4" CACHE STRING "Preferred pybind11 version, of downloading/building our own")
-set (PYBIND11_HOME "" CACHE STRING "Installed pybind11 location hint")
+set (BUILD_PYBIND11_VERSION "v2.4.2" CACHE STRING "Preferred pybind11 version, of downloading/building our own")
+set (PYBIND11_HOME "" CACHE STRING "Installed pybind11 location hint (deprecated)")
+set (PYBIND11_ROOT "" CACHE STRING "Installed pybind11 location hint")
 set (BUILD_PYBIND11_MINIMUM_VERSION "2.2.0")
 
 macro (find_or_download_pybind11)
@@ -578,9 +579,12 @@ macro (find_or_download_pybind11)
     # locally installed in this tree.
     if (NOT BUILD_PYBIND11_FORCE)
         find_path (PYBIND11_INCLUDE_DIR pybind11/pybind11.h
-               "${PROJECT_SOURCE_DIR}/ext/pybind11/include"
-               "${PYBIND11_HOME}"
-               "$ENV{PYBIND11_HOME}"
+               HINTS
+                   "${PROJECT_SOURCE_DIR}/ext/pybind11/include"
+                   "${PYBIND11_ROOT}"
+                   ENV PYBIND11_HOME
+                   "${PYBIND11_HOME}"
+                   ENV PYBIND11_HOME
                )
     endif ()
     # Check the version -- if it's too old, download a local copy.
@@ -593,9 +597,17 @@ macro (find_or_download_pybind11)
         string (REGEX MATCHALL "[0-9]+$" PYBIND11_VERSION_MAJOR ${TMP})
         file(STRINGS "${PYBIND11_COMMON_FILE}" TMP REGEX "^#define PYBIND11_VERSION_MINOR .*$")
         string (REGEX MATCHALL "[0-9]+$" PYBIND11_VERSION_MINOR ${TMP})
-        set (PYBIND11_VERSION "${PYBIND11_VERSION_MAJOR}.${PYBIND11_VERSION_MINOR}")
+        file(STRINGS "${PYBIND11_COMMON_FILE}" TMP REGEX "^#define PYBIND11_VERSION_PATCH .*$")
+        string (REGEX MATCHALL "[0-9]+$" PYBIND11_VERSION_PATCH ${TMP})
+        set (PYBIND11_VERSION "${PYBIND11_VERSION_MAJOR}.${PYBIND11_VERSION_MINOR}.${PYBIND11_VERSION_PATCH}")
         if ("${PYBIND11_VERSION}" VERSION_LESS BUILD_PYBIND11_MINIMUM_VERSION)
             message (WARNING "pybind11 from ${PYBIND11_INCLUDE_DIR} is too old (${PYBIND11_VERSION}), minimum is ${BUILD_PYBIND11_MINIMUM_VERSION}, downloading our own.")
+            set (PYBIND11_INCLUDE_DIR "")
+        endif ()
+        if (${USE_CPP} STREQUAL "11" AND
+            ("${PYBIND11_VERSION}" VERSION_EQUAL "2.4.0" OR
+             "${PYBIND11_VERSION}" VERSION_EQUAL "2.4.1"))
+            message (WARNING "pybind11 ${PYBIND11_VERSION} is buggy and not compatible with C++11, downloading our own.")
             set (PYBIND11_INCLUDE_DIR "")
         endif ()
     endif ()
@@ -629,7 +641,9 @@ macro (find_or_download_pybind11)
         string (REGEX MATCHALL "[0-9]+$" PYBIND11_VERSION_MAJOR ${TMP})
         file(STRINGS "${PYBIND11_COMMON_FILE}" TMP REGEX "^#define PYBIND11_VERSION_MINOR .*$")
         string (REGEX MATCHALL "[0-9]+$" PYBIND11_VERSION_MINOR ${TMP})
-        set (PYBIND11_VERSION "${PYBIND11_VERSION_MAJOR}.${PYBIND11_VERSION_MINOR}")
+        file(STRINGS "${PYBIND11_COMMON_FILE}" TMP REGEX "^#define PYBIND11_VERSION_PATCH .*$")
+        string (REGEX MATCHALL "[0-9]+$" PYBIND11_VERSION_PATCH ${TMP})
+        set (PYBIND11_VERSION "${PYBIND11_VERSION_MAJOR}.${PYBIND11_VERSION_MINOR}.${PYBIND11_VERSION_PATCH}")
     endif ()
 
     if ("${PYBIND11_VERSION}" VERSION_LESS BUILD_PYBIND11_MINIMUM_VERSION)

--- a/testsuite/python-imagebufalgo/ref/out-freetype2.4.11-py2.7-pybind2.3.txt
+++ b/testsuite/python-imagebufalgo/ref/out-freetype2.4.11-py2.7-pybind2.3.txt
@@ -1,0 +1,183 @@
+
+Testing color conversions:
+linear src=[0.000 0.000 0.000 1.000 ] [0.250 0.250 0.250 1.000 ] 
+[0.500 0.500 0.500 1.000 ] [1.000 1.000 1.000 1.000 ] 
+to srgb =[0.000 0.000 0.000 1.000 ] [0.537 0.537 0.537 1.000 ] 
+[0.735 0.735 0.735 1.000 ] [1.000 1.000 1.000 1.000 ] 
+back to linear =[0.000 0.000 0.000 1.000 ] [0.250 0.250 0.250 1.000 ] 
+[0.500 0.500 0.500 1.000 ] [1.000 1.000 1.000 1.000 ] 
+after *M =[0.000 0.000 0.100 1.000 ] [0.125 0.500 0.350 1.000 ] 
+[0.250 1.000 0.600 1.000 ] [0.500 2.000 1.100 1.000 ] 
+Stats for tahoe-small.tif:
+  min         =  [0.0, 0.003921568859368563, 0.007843137718737125]
+  max         =  [0.8784314393997192, 1.0, 1.0]
+  avg         =  [0.10193096846342087, 0.21669696271419525, 0.4254732131958008]
+  stddev      =  [0.13176831603050232, 0.23792722821235657, 0.3826749324798584]
+  nancount    =  [0, 0, 0]
+  infcount    =  [0, 0, 0]
+  finitecount =  [196608, 196608, 196608]
+Comparison: of flip.tif and flop.tif
+  mean = 0.0068759
+  rms  = 0.051175
+  PSNR = 25.819
+  max  = 0.45098
+  max @ (214, 88, 0, 0)
+  warns 2034 fails 2034
+isConstantColor on pink image is (1 0.50196 0.50196)
+isConstantColor on checker is  None
+Is cmul1.exr monochrome?  True
+Is cmul2.exr monochrome?  False
+Nonzero region is:  100 180 100 180 0 1 0 3
+SHA-1 of bsplinekernel.exr is: D5826B66A5313F9A32D42C5CF49C90EC4E7F84BF
+R hist:  (10000L, 0L, 0L, 0L)
+G hist:  (10000L, 0L, 0L, 0L)
+B hist:  (0L, 10000L, 0L, 0L)
+Done.
+Comparing "black.tif" and "ref/black.tif"
+PASS
+Comparing "filled.tif" and "../../../../testsuite/oiiotool/ref/filled.tif"
+PASS
+Comparing "checker.tif" and "ref/checker.tif"
+PASS
+Comparing "noise-uniform3.tif" and "../../../../testsuite/oiiotool-pattern/ref/noise-uniform3.tif"
+PASS
+Comparing "noise-gauss.tif" and "../../../../testsuite/oiiotool-pattern/ref/noise-gauss.tif"
+PASS
+Comparing "noise-salt.tif" and "../../../../testsuite/oiiotool-pattern/ref/noise-salt.tif"
+PASS
+Comparing "chanshuffle.tif" and "../../../../testsuite/oiiotool/ref/chanshuffle.tif"
+PASS
+Comparing "ch-rgba.exr" and "../../../../testsuite/oiiotool/ref/ch-rgba.exr"
+PASS
+Comparing "ch-z.exr" and "../../../../testsuite/oiiotool/ref/ch-z.exr"
+PASS
+Comparing "chappend-rgbaz.exr" and "../../../../testsuite/oiiotool/ref/chappend-rgbaz.exr"
+PASS
+Comparing "flat.exr" and "../../../../testsuite/oiiotool-deep/ref/flat.exr"
+PASS
+Comparing "deepen.exr" and "../../../../testsuite/oiiotool-deep/ref/deepen.exr"
+PASS
+Comparing "crop.tif" and "../../../../testsuite/oiiotool/ref/crop.tif"
+PASS
+Comparing "cut.tif" and "../../../../testsuite/oiiotool/ref/cut.tif"
+PASS
+Comparing "pasted.tif" and "../../../../testsuite/oiiotool/ref/pasted.tif"
+PASS
+Comparing "rotate90.tif" and "../../../../testsuite/oiiotool-xform/ref/rotate90.tif"
+PASS
+Comparing "rotate180.tif" and "../../../../testsuite/oiiotool/ref/rotate180.tif"
+PASS
+Comparing "rotate270.tif" and "../../../../testsuite/oiiotool-xform/ref/rotate270.tif"
+PASS
+Comparing "rotated.tif" and "../../../../testsuite/oiiotool-xform/ref/rotated.tif"
+PASS
+Comparing "rotated-offcenter.tif" and "../../../../testsuite/oiiotool-xform/ref/rotated-offcenter.tif"
+PASS
+Comparing "warped.tif" and "../../../../testsuite/oiiotool-xform/ref/warped.tif"
+PASS
+Comparing "flip.tif" and "../../../../testsuite/oiiotool-xform/ref/flip.tif"
+PASS
+Comparing "flop.tif" and "../../../../testsuite/oiiotool-xform/ref/flop.tif"
+PASS
+Comparing "reorient1.tif" and "../../../../testsuite/oiiotool-xform/ref/reorient1.tif"
+PASS
+Comparing "transpose.tif" and "../../../../testsuite/oiiotool-xform/ref/transpose.tif"
+PASS
+Comparing "cshift.tif" and "../../../../testsuite/oiiotool-xform/ref/cshift.tif"
+PASS
+Comparing "cadd1.exr" and "../../../../testsuite/oiiotool/ref/cadd1.exr"
+PASS
+Comparing "cadd2.exr" and "../../../../testsuite/oiiotool/ref/cadd2.exr"
+PASS
+Comparing "add.exr" and "../../../../testsuite/oiiotool/ref/add.exr"
+PASS
+Comparing "sub.exr" and "../../../../testsuite/oiiotool/ref/sub.exr"
+PASS
+Comparing "abs.exr" and "../../../../testsuite/oiiotool/ref/abs.exr"
+PASS
+Comparing "absdiff.exr" and "../../../../testsuite/oiiotool/ref/absdiff.exr"
+PASS
+Comparing "mul.exr" and "../../../../testsuite/oiiotool/ref/mul.exr"
+PASS
+Comparing "cmul1.exr" and "../../../../testsuite/oiiotool/ref/cmul1.exr"
+PASS
+Comparing "cmul2.exr" and "../../../../testsuite/oiiotool/ref/cmul2.exr"
+PASS
+Comparing "mad.exr" and "../../../../testsuite/oiiotool/ref/mad.exr"
+PASS
+Comparing "mad2.exr" and "ref/mad2.exr"
+PASS
+Comparing "mad3.exr" and "ref/mad3.exr"
+PASS
+Comparing "cpow1.exr" and "../../../../testsuite/oiiotool/ref/cpow1.exr"
+PASS
+Comparing "cpow2.exr" and "../../../../testsuite/oiiotool/ref/cpow2.exr"
+PASS
+Comparing "div.exr" and "../../../../testsuite/oiiotool/ref/div.exr"
+PASS
+Comparing "divc1.exr" and "../../../../testsuite/oiiotool/ref/divc1.exr"
+PASS
+Comparing "divc2.exr" and "../../../../testsuite/oiiotool/ref/divc2.exr"
+PASS
+Comparing "invert.tif" and "../../../../testsuite/oiiotool/ref/invert.tif"
+PASS
+Comparing "chsum.tif" and "../../../../testsuite/oiiotool/ref/chsum.tif"
+PASS
+Comparing "colormap-inferno.tif" and "../../../../testsuite/oiiotool-color/ref/colormap-inferno.tif"
+PASS
+Comparing "colormap-custom.tif" and "../../../../testsuite/oiiotool-color/ref/colormap-custom.tif"
+PASS
+Comparing "grid-clamped.tif" and "../../../../testsuite/oiiotool/ref/grid-clamped.tif"
+PASS
+Comparing "rangecompress.tif" and "../../../../testsuite/oiiotool/ref/rangecompress.tif"
+PASS
+Comparing "rangeexpand.tif" and "../../../../testsuite/oiiotool/ref/rangeexpand.tif"
+PASS
+Comparing "contrast-stretch.tif" and "../../../../testsuite/oiiotool-color/ref/contrast-stretch.tif"
+PASS
+Comparing "contrast-shrink.tif" and "../../../../testsuite/oiiotool-color/ref/contrast-shrink.tif"
+PASS
+Comparing "contrast-sigmoid5.tif" and "../../../../testsuite/oiiotool-color/ref/contrast-sigmoid5.tif"
+PASS
+Comparing "resize.tif" and "../../../../testsuite/oiiotool-xform/ref/resize.tif"
+PASS
+Comparing "resample.tif" and "../../../../testsuite/oiiotool-xform/ref/resample.tif"
+PASS
+Comparing "fit.tif" and "../../../../testsuite/oiiotool-xform/ref/fit.tif"
+PASS
+Comparing "bsplinekernel.exr" and "../../../../testsuite/oiiotool/ref/bsplinekernel.exr"
+PASS
+Comparing "bspline-blur.tif" and "../../../../testsuite/oiiotool/ref/bspline-blur.tif"
+PASS
+Comparing "tahoe-median.tif" and "../../../../testsuite/oiiotool/ref/tahoe-median.tif"
+PASS
+Comparing "dilate.tif" and "../../../../testsuite/oiiotool/ref/dilate.tif"
+PASS
+Comparing "erode.tif" and "../../../../testsuite/oiiotool/ref/erode.tif"
+PASS
+Comparing "unsharp.tif" and "../../../../testsuite/oiiotool/ref/unsharp.tif"
+PASS
+Comparing "unsharp-median.tif" and "../../../../testsuite/oiiotool/ref/unsharp-median.tif"
+PASS
+Comparing "tahoe-laplacian.tif" and "../../../../testsuite/oiiotool/ref/tahoe-laplacian.tif"
+PASS
+Comparing "fft.exr" and "../../../../testsuite/oiiotool/ref/fft.exr"
+PASS
+Comparing "ifft.exr" and "../../../../testsuite/oiiotool/ref/ifft.exr"
+PASS
+Comparing "polar.exr" and "../../../../testsuite/oiiotool/ref/polar.exr"
+PASS
+Comparing "unpolar.exr" and "../../../../testsuite/oiiotool/ref/unpolar.exr"
+PASS
+Comparing "tahoe-filled.tif" and "../../../../testsuite/oiiotool/ref/tahoe-filled.tif"
+PASS
+Comparing "box3.exr" and "../../../../testsuite/oiiotool-fixnan/ref/box3.exr"
+PASS
+Comparing "a_over_b.exr" and "../../../../testsuite/oiiotool-composite/ref/a_over_b.exr"
+PASS
+Comparing "tahoe-small.tx" and "ref/tahoe-small.tx"
+PASS
+Comparing "text.tif" and "../../../../testsuite/oiiotool-text/ref/text.tif"
+PASS
+Comparing "textcentered.tif" and "ref/textcentered-freetype2.4.11.tif"
+PASS

--- a/testsuite/python-imageinput/ref/out-travis-py2.7-pybind2.3.txt
+++ b/testsuite/python-imageinput/ref/out-travis-py2.7-pybind2.3.txt
@@ -1,0 +1,208 @@
+Could not open "badname.tif"
+	Error:  Could not open file: badname.tif: No such file or directory
+Opened "../../../../../oiio-images/tahoe-gps.jpg" as a jpeg
+  resolution 2048x1536+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  oiio:ColorSpace = "sRGB"
+  jpeg:subsampling = "4:2:0"
+  Make = "HTC"
+  Model = "T-Mobile G1"
+  Orientation = 1
+  XResolution = 72.0
+  YResolution = 72.0
+  ResolutionUnit = "none"
+  Software = "title;va"
+  Exif:YCbCrPositioning = 1
+  Exif:ExifVersion = "0220"
+  Exif:DateTimeOriginal = "2009:02:21 08:32:04"
+  Exif:DateTimeDigitized = "2009:02:21 08:32:04"
+  Exif:FlashPixVersion = "0100"
+  Exif:ColorSpace = 1
+  Exif:PixelXDimension = 2048
+  Exif:PixelYDimension = 1536
+  Exif:WhiteBalance = 0
+  GPS:VersionID = None
+  GPS:LatitudeRef = "N"
+  GPS:Latitude = (39.0, 18.0, 24.399999618530273)
+  GPS:LongitudeRef = "W"
+  GPS:Longitude = (120.0, 20.0, 6.25)
+  GPS:AltitudeRef = 0
+  GPS:Altitude = 0.0
+  GPS:TimeStamp = (17.0, 56.0, 33.0)
+  GPS:MapDatum = "WGS-84"
+  GPS:DateStamp = "1915:08:08"
+
+Opened "grid.tx" as a tiff
+  resolution 1024x1024+0+0
+  tile size  64x64x1
+  4 channels: ('R', 'G', 'B', 'A')
+  format =  uint8
+  alpha channel =  3
+  z channel =  -1
+  deep =  False
+  oiio:BitsPerSample = 8
+  Orientation = 1
+  XResolution = 72.0
+  YResolution = 72.0
+  ResolutionUnit = "in"
+  Software = "OpenImageIO 1.5.7dev : maketx -filter lanczos3 --resize grid.tif -o grid.tx"
+  DateTime = "2014:11:29 23:20:23"
+  DocumentName = "g.tif"
+  textureformat = "Plain Texture"
+  wrapmodes = "black,black"
+  fovcot = 1.0
+  tiff:PhotometricInterpretation = 2
+  tiff:PlanarConfiguration = 1
+  planarconfig = "contig"
+  tiff:Compression = 8
+  compression = "zip"
+  PixelAspectRatio = 1.0
+  oiio:AverageColor = "0.608983,0.608434,0.608728,1"
+  oiio:SHA-1 = "233A1D3412A54A5F49814AB7BFFD04F56F46D3D7"
+Subimage 0 MIP level 1 :
+  resolution 512x512+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 2 :
+  resolution 256x256+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 3 :
+  resolution 128x128+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 4 :
+  resolution 64x64+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 5 :
+  resolution 32x32+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 6 :
+  resolution 16x16+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 7 :
+  resolution 8x8+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 8 :
+  resolution 4x4+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 9 :
+  resolution 2x2+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 10 :
+  resolution 1x1+0+0
+  tile size  64x64x1
+
+Testing read_image:
+Opened "../../../../../oiio-images/tahoe-gps.jpg" as a jpeg
+@ (0, 0) = [40 35 57]
+@ (2047, 1535) = [37 56 89]
+@ (1024, 768) = [137 183 233]
+
+Opened "../../../../../oiio-images/tahoe-gps.jpg" as a jpeg
+@ (0, 0) = [ 0.15686275  0.13725491  0.22352943]
+@ (2047, 1535) = [ 0.14509805  0.21960786  0.34901962]
+@ (1024, 768) = [ 0.53725493  0.71764708  0.91372555]
+
+Opened "../../../../../oiio-images/tahoe-gps.jpg" as a jpeg
+@ (0, 0) = [40]
+@ (2047, 1535) = [37]
+@ (1024, 768) = [137]
+
+Testing read_scanline:
+Opened "../../../../../oiio-images/tahoe-gps.jpg" as a jpeg
+@ (0, 0) = [40 35 57]
+@ (0, 1535) = [ 82  94 136]
+
+Testing read_tile:
+Opened "grid.tx" as a tiff
+@ (32, 32) = [  1   1   1 255]
+@ (32, 32) = [255 127 127 255]
+
+Testing read_scanlines:
+Opened "../../../../../oiio-images/tahoe-gps.jpg" as a jpeg
+@ (0, 0) = [40 35 57]
+@ (2047, 1535) = [37 56 89]
+@ (1024, 768) = [137 183 233]
+
+Testing read_tiles:
+Opened "grid.tx" as a tiff
+@ (0, 0) = [  0   0   0 255]
+@ (1023, 1023) = [  0   0   0 255]
+@ (512, 512) = [  0   0   0 255]
+
+Test read_image native u16:
+Opened "testu16.tif" as a tiff
+Read array typecode uint16  [ 12288 ]
+
+Test read_scanlines native u16:
+Opened "testu16.tif" as a tiff
+Read array typecode uint16  [ 12288 ]
+
+Test read_tiles native half:
+Opened "testf16.exr" as a openexr
+Read array typecode uint16  [ 12288 ]
+
+Test read_image into half:
+Opened "testu16.tif" as a tiff
+Read array typecode uint16  [ 12288 ]
+
+Test read_image into FLOAT:
+Opened "testu16.tif" as a tiff
+Read array typecode float32  [ 12288 ]
+
+Testing write and read of unassociated:
+  writing:  [[[ 0.5  0.5  0.5  0.5]
+  [ 0.5  0.5  0.5  0.5]]
+
+ [[ 0.5  0.5  0.5  0.5]
+  [ 0.5  0.5  0.5  0.5]]]
+
+  default reading as IB:  [[[ 0.25  0.25  0.25  0.5 ]
+  [ 0.25  0.25  0.25  0.5 ]]
+
+ [[ 0.25  0.25  0.25  0.5 ]
+  [ 0.25  0.25  0.25  0.5 ]]]
+
+  reading as IB with unassoc hint:  [[[ 0.5  0.5  0.5  0.5]
+  [ 0.5  0.5  0.5  0.5]]
+
+ [[ 0.5  0.5  0.5  0.5]
+  [ 0.5  0.5  0.5  0.5]]]
+
+  reading as II with hint, read scanlines backward: 
+    [1] =  [[ 0.5  0.5  0.5  0.5]
+ [ 0.5  0.5  0.5  0.5]]
+    [0] =  [[ 0.5  0.5  0.5  0.5]
+ [ 0.5  0.5  0.5  0.5]]
+
+
+Testing write and read of TIFF CMYK with auto RGB translation:
+  writing:  [[[ 0.50196081  0.          0.          0.50196081]
+  [ 0.50196081  0.          0.          0.50196081]]
+
+ [[ 0.50196081  0.          0.          0.50196081]
+  [ 0.50196081  0.          0.          0.50196081]]]
+
+  default reading as IB:  [[[ 0.24705884  0.49803925  0.49803925]
+  [ 0.24705884  0.49803925  0.49803925]]
+
+ [[ 0.24705884  0.49803925  0.49803925]
+  [ 0.24705884  0.49803925  0.49803925]]]
+
+  reading as IB with rawcolor=1:  [[[ 0.50196081  0.          0.          0.50196081]
+  [ 0.50196081  0.          0.          0.50196081]]
+
+ [[ 0.50196081  0.          0.          0.50196081]
+  [ 0.50196081  0.          0.          0.50196081]]]
+
+  reading as II with rawcolor=0, read scanlines backward: 
+    [1] =  [[ 0.24705884  0.49803925  0.49803925]
+ [ 0.24705884  0.49803925  0.49803925]]
+    [0] =  [[ 0.24705884  0.49803925  0.49803925]
+ [ 0.24705884  0.49803925  0.49803925]]
+
+
+Done.


### PR DESCRIPTION
The newly released pybind11 v2.4.0 and v2.4.1 are actually broken for
C++11 (accidentally used constexpr in a place where it's only valid
for C++14). Communication with the pybind11 team quickly resulted in a
v2.4.2 release that fixes the problem.

This patch adds logic to our build scripts so that if one of the two
broken versions are found on the system and we're building for C++11,
it falls back to our "download our own copy" logic. The new default
for downloading our own is updated to 2.3.0 (including updating some
ref output).

