### PR TITLE
Python3 safety

### DIFF
--- a/site/spi/format_version.py
+++ b/site/spi/format_version.py
@@ -6,6 +6,7 @@
 # integer SpComp2 version numbers.
 
 from __future__ import print_function
+from __future__ import absolute_import
 import sys
 
 if len(sys.argv) != 2 :

--- a/src/doc/conf.py
+++ b/src/doc/conf.py
@@ -16,6 +16,7 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+from __future__ import absolute_import
 import sys
 import os
 import shlex

--- a/src/doc/help2man_preformat.py
+++ b/src/doc/help2man_preformat.py
@@ -5,6 +5,7 @@
 # formatting.
 
 from __future__ import print_function
+from __future__ import absolute_import
 import sys
 
 lines = [l.rstrip().replace('\t', ' '*8) for l in sys.stdin.readlines()]

--- a/testsuite/misnamed-file/run.py
+++ b/testsuite/misnamed-file/run.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import shutil
 
 # Make a copy called "misnamed.exr" that's actually a TIFF file

--- a/testsuite/missingcolor/src/makepartialexr.py
+++ b/testsuite/missingcolor/src/makepartialexr.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from __future__ import absolute_import
 import OpenImageIO as oiio
 import numpy as np
 

--- a/testsuite/oiiotool-xform/run.py
+++ b/testsuite/oiiotool-xform/run.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #import OpenImageIO as oiio
 from __future__ import division
+from __future__ import absolute_import
 import shutil
 
 ## This testsuite entry tests oiiotool features related to image

--- a/testsuite/python-colorconfig/run.py
+++ b/testsuite/python-colorconfig/run.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import os
 
 os.putenv('OCIO', colorconfig_file)

--- a/testsuite/python-colorconfig/src/test_colorconfig.py
+++ b/testsuite/python-colorconfig/src/test_colorconfig.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from __future__ import absolute_import
 import os
 import OpenImageIO as oiio
 

--- a/testsuite/python-deep/src/test_deep.py
+++ b/testsuite/python-deep/src/test_deep.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 from __future__ import division
+from __future__ import absolute_import
 import OpenImageIO as oiio
 
 test_xres = 3

--- a/testsuite/python-imagebuf/src/test_imagebuf.py
+++ b/testsuite/python-imagebuf/src/test_imagebuf.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from __future__ import absolute_import
 import array
 import numpy
 import OpenImageIO as oiio

--- a/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
+++ b/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from __future__ import absolute_import
 import math, os
 import OpenImageIO as oiio
 from OpenImageIO import ImageBuf, ImageSpec, ImageBufAlgo, ROI

--- a/testsuite/python-imageinput/src/test_imageinput.py
+++ b/testsuite/python-imageinput/src/test_imageinput.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from __future__ import absolute_import
 import OpenImageIO as oiio
 import os
 

--- a/testsuite/python-imageoutput/src/test_imageoutput.py
+++ b/testsuite/python-imageoutput/src/test_imageoutput.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from __future__ import absolute_import
 import OpenImageIO as oiio
 import numpy as np
 

--- a/testsuite/python-imagespec/src/test_imagespec.py
+++ b/testsuite/python-imagespec/src/test_imagespec.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from __future__ import absolute_import
 import OpenImageIO as oiio
 
 

--- a/testsuite/python-paramlist/src/test_paramlist.py
+++ b/testsuite/python-paramlist/src/test_paramlist.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from __future__ import absolute_import
 import OpenImageIO as oiio
 
 

--- a/testsuite/python-roi/src/test_roi.py
+++ b/testsuite/python-roi/src/test_roi.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from __future__ import absolute_import
 import OpenImageIO as oiio
 
 

--- a/testsuite/python-typedesc/src/test_typedesc.py
+++ b/testsuite/python-typedesc/src/test_typedesc.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from __future__ import absolute_import
 import OpenImageIO as oiio
 
 

--- a/testsuite/raw/run.py
+++ b/testsuite/raw/run.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import os
 
 files = [ "RAW_CANON_EOS_7D.CR2",

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from __future__ import absolute_import
 import os
 import glob
 import sys


### PR DESCRIPTION
With this additional set of changes, we now have a 100% clean bill of
health from pylint --py3k.

