### PR TITLE
Make all command line utilities --help return 0 exit code

### DIFF
--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -107,7 +107,7 @@ getargs(int argc, char* argv[])
     }
     if (help) {
         ap.usage();
-        exit(EXIT_FAILURE);
+        exit(EXIT_SUCCESS);
     }
 
     if (filenames.size() != 2 && !inplace) {

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -101,7 +101,7 @@ getargs(int argc, char* argv[])
     }
     if (help) {
         ap.usage ();
-        exit (EXIT_FAILURE);
+        exit (EXIT_SUCCESS);
     }
 
     if (filenames.size() != 2) {

--- a/src/igrep/igrep.cpp
+++ b/src/igrep/igrep.cpp
@@ -166,7 +166,7 @@ main(int argc, const char* argv[])
     }
     if (help) {
         ap.usage();
-        exit(EXIT_FAILURE);
+        exit(EXIT_SUCCESS);
     }
 
 #if USE_BOOST_REGEX

--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -655,7 +655,7 @@ main(int argc, const char* argv[])
     }
     if (help) {
         ap.usage();
-        exit(EXIT_FAILURE);
+        exit(EXIT_SUCCESS);
     }
 
     if (!metamatch.empty()) {

--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -75,7 +75,7 @@ getargs(int argc, char* argv[])
     }
     if (help) {
         ap.usage();
-        exit(EXIT_FAILURE);
+        exit(EXIT_SUCCESS);
     }
 }
 

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -281,7 +281,7 @@ getargs(int argc, char* argv[], ImageSpec& configspec)
     }
     if (help) {
         ap.usage();
-        exit(EXIT_FAILURE);
+        exit(EXIT_SUCCESS);
     }
     if (filenames.empty()) {
         ap.briefusage();


### PR DESCRIPTION
`command --help` is a well-formed command that should have a "success"
error code of 0. Most of the command line utilities returned a failure
code. (Only oiiotool got it right.)

