### PR TITLE
Tests: remove order dependency of some tests

### DIFF
--- a/testsuite/gif/run.py
+++ b/testsuite/gif/run.py
@@ -9,5 +9,5 @@ for f in files:
     command += info_command (OIIO_TESTSUITE_IMAGEDIR + "/" + f)
 
 # Test write / conversion to GIF
-command += oiiotool ("../oiiotool/src/tahoe-tiny.tif -o tahoe-tiny.gif")
+command += oiiotool (OIIO_TESTSUITE_ROOT+"/oiiotool/src/tahoe-tiny.tif -o tahoe-tiny.gif")
 command += info_command ("tahoe-tiny.gif")

--- a/testsuite/maketx/run.py
+++ b/testsuite/maketx/run.py
@@ -73,7 +73,7 @@ command += maketx_command ("checker.tif", "checker-prman.tx",
 # testsuite/oiiotool-fixnan.  (Use --nomipmap to cut down on stats output)
 # FIXME: would also like to test --checknan, but the problem with that is
 # that is actually FAILS if there's a nan.
-command += maketx_command ("../oiiotool-fixnan/src/bad.exr",
+command += maketx_command (OIIO_TESTSUITE_ROOT+"/oiiotool-fixnan/src/bad.exr",
                            "nan.exr", "--fixnan box3 --nomipmap",
                            showinfo=True, showinfo_extra="--stats")
 

--- a/testsuite/oiiotool-color/run.py
+++ b/testsuite/oiiotool-color/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+import os
+
+oiiotoolsrcdir = os.path.join(OIIO_TESTSUITE_ROOT, "oiiotool", "src")
+
 # Make test pattern with increasing intensity left to right, decreasing
 # alpha going down. Carefully done so that the first pixel is 0.0, last
 # pixel is 1.0 (correcting for the half pixel offset).
@@ -8,9 +13,11 @@ command += oiiotool ("-pattern fill:topleft=0,0,0,1:topright=1,1,1,1:bottomleft=
 
 
 # test --colormap
-command += oiiotool ("--autocc ../oiiotool/src/tahoe-tiny.tif --colormap inferno "
+command += oiiotool ("--autocc " + oiiotoolsrcdir+"/tahoe-tiny.tif" +
+                     " --colormap inferno "
             + "-d uint8 -o colormap-inferno.tif")
-command += oiiotool ("--autocc ../oiiotool/src/tahoe-tiny.tif --colormap .25,.25,.25,0,.5,0,1,0,0 "
+command += oiiotool ("--autocc " + oiiotoolsrcdir+"/tahoe-tiny.tif" +
+                     " --colormap .25,.25,.25,0,.5,0,1,0,0 "
             + "-d uint8 -o colormap-custom.tif")
 
 # test unpremult/premult
@@ -24,16 +31,16 @@ command += oiiotool ("unpremult.exr --premult -o premult.exr")
 command += oiiotool ("--no-autopremult src/rgba.tga --ch R,G,B -o rgbfromtga.png")
 
 # test --contrast
-command += oiiotool ("--autocc ../oiiotool/src/tahoe-tiny.tif "
-                     + "-contrast:black=0.1:white=0.75 -d uint8 -o contrast-stretch.tif")
-command += oiiotool ("--autocc ../oiiotool/src/tahoe-tiny.tif "
-                     + "-contrast:min=0.1:max=0.75 -d uint8 -o contrast-shrink.tif")
-command += oiiotool ("--autocc ../oiiotool/src/tahoe-tiny.tif "
-                     + "-contrast:black=1:white=0 -d uint8 -o contrast-inverse.tif")
-command += oiiotool ("--autocc ../oiiotool/src/tahoe-tiny.tif "
-                     + "-contrast:black=1,1,.25:white=1,1,0.25 -d uint8 -o contrast-threshold.tif")
-command += oiiotool ("--autocc ../oiiotool/src/tahoe-tiny.tif "
-                     + "-contrast:scontrast=5 -d uint8 -o contrast-sigmoid5.tif")
+command += oiiotool ("--autocc " + oiiotoolsrcdir+"/tahoe-tiny.tif" +
+                     " -contrast:black=0.1:white=0.75 -d uint8 -o contrast-stretch.tif")
+command += oiiotool ("--autocc " + oiiotoolsrcdir+"/tahoe-tiny.tif" +
+                     " -contrast:min=0.1:max=0.75 -d uint8 -o contrast-shrink.tif")
+command += oiiotool ("--autocc " + oiiotoolsrcdir+"/tahoe-tiny.tif" +
+                     " -contrast:black=1:white=0 -d uint8 -o contrast-inverse.tif")
+command += oiiotool ("--autocc " + oiiotoolsrcdir+"/tahoe-tiny.tif" +
+                     " -contrast:black=1,1,.25:white=1,1,0.25 -d uint8 -o contrast-threshold.tif")
+command += oiiotool ("--autocc " + oiiotoolsrcdir+"/tahoe-tiny.tif" +
+                     " -contrast:scontrast=5 -d uint8 -o contrast-sigmoid5.tif")
 
 
 
@@ -50,7 +57,8 @@ command += oiiotool ("greyalpha_linear.tif --colorconvert:unpremult=1 linear sRG
 command += oiiotool ("greyalpha_linear.tif --colorconvert:unpremult=1 linear Cineon -o greyalpha_Cineon_un.tif")
 
 # test color convert by matrix
-command += oiiotool ("--autocc ../oiiotool/src/tahoe-tiny.tif "
+command += oiiotool ("--autocc " + oiiotoolsrcdir+"/tahoe-tiny.tif"+
+                     " "
                      + "--ccmatrix 0.805,0.506,-0.311,0,-0.311,0.805,0.506,0,0.506,-0.311,0.805,0,0,0,0,1 "
                      + "-d uint8 -o tahoe-ccmatrix.tif")
 

--- a/testsuite/oiiotool-maketx/run.py
+++ b/testsuite/oiiotool-maketx/run.py
@@ -93,7 +93,7 @@ command += omaketx_command ("checker.tif", "checker-prman.tx",
 # testsuite/oiiotool-fixnan.  (Use --nomipmap to cut down on stats output)
 # FIXME: would also like to test --checknan, but the problem with that is
 # that is actually FAILS if there's a nan.
-command += omaketx_command ("../oiiotool-fixnan/src/bad.exr", "nan.exr",
+command += omaketx_command (OIIO_TESTSUITE_ROOT+"/oiiotool-fixnan/src/bad.exr", "nan.exr",
                             "--fixnan box3", options=":nomipmap=1",
                             showinfo=True, showinfo_extra="--stats")
 

--- a/testsuite/oiiotool-text/run.py
+++ b/testsuite/oiiotool-text/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+import os
+
+oiiotoolsrcdir = os.path.join(OIIO_TESTSUITE_ROOT, "oiiotool", "src")
 
 # test --text
 command += oiiotool ("--create 320x240 3 "
@@ -20,7 +24,7 @@ command += oiiotool ("--create 320x320 3 "
             "-d uint8 -o aligned.tif >> out.txt")
 
 # test shadow
-command += oiiotool ("../oiiotool/src/tahoe-tiny.tif "
+command += oiiotool (oiiotoolsrcdir + "/tahoe-tiny.tif "
             "--text:x=64:y=20:xalign=center:size=20:shadow=0 'shadow = 0' "
             "--text:x=64:y=40:xalign=center:size=20:shadow=1 'shadow = 1' "
             "--text:x=64:y=60:xalign=center:size=20:shadow=2 'shadow = 2' "

--- a/testsuite/oiiotool-xform/run.py
+++ b/testsuite/oiiotool-xform/run.py
@@ -3,6 +3,7 @@
 from __future__ import division
 from __future__ import absolute_import
 import shutil
+import os
 
 ## This testsuite entry tests oiiotool features related to image
 ## transformations (moving pixels around and resampling).
@@ -29,9 +30,10 @@ def make_test_pattern1 (filename, xres=288, yres=216) :
 # No need to do this every time, we stashed it in src
 #make_test_pattern1 ("src/target1.exr", 288, 216)
 
-shutil.copy ("../oiiotool/src/tahoe-tiny.tif", "./tahoe-tiny.tif")
-shutil.copy ("../oiiotool/src/tahoe-small.tif", "./tahoe-small.tif")
-shutil.copy ("../oiiotool/src/image.tif", "./image.tif")
+oiiotoolsrcdir = os.path.join(OIIO_TESTSUITE_ROOT, "oiiotool", "src")
+shutil.copy (oiiotoolsrcdir + "/tahoe-tiny.tif", "./tahoe-tiny.tif")
+shutil.copy (oiiotoolsrcdir + "/tahoe-small.tif", "./tahoe-small.tif")
+shutil.copy (oiiotoolsrcdir + "/image.tif", "./image.tif")
 
 
 # test resample


### PR DESCRIPTION
After a fresh build, sometimes a parallel test would fail because
certain tests tried to get ../oiiotool/src/... but that link is not
set up until oiiotool test runs. It is listed first, but sometimes
when doing parallel test runs (via CTEST_PARALLEL_LEVEL=...) the
timing can be just right to fail.

