### PR TITLE
Add imported library to FindOpenImageIO.cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 testsuite/runtest.pyc
 .cproject
 .project
+.DS_Store
+

--- a/src/cmake/modules/FindOpenImageIO.cmake
+++ b/src/cmake/modules/FindOpenImageIO.cmake
@@ -93,6 +93,21 @@ if (OPENIMAGEIO_FOUND)
         message ( STATUS "OpenImageIO library_dirs = ${OPENIMAGEIO_LIBRARY_DIRS}" )
         message ( STATUS "OpenImageIO oiiotool     = ${OIIOTOOL_BIN}" )
     endif ()
+
+    if(NOT TARGET OpenImageIO::OpenImageIO)
+        add_library(OpenImageIO::OpenImageIO UNKNOWN IMPORTED)
+        set_target_properties(OpenImageIO::OpenImageIO PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${OPENIMAGEIO_INCLUDES}")
+
+        set_property(TARGET OpenImageIO::OpenImageIO APPEND PROPERTY
+            IMPORTED_LOCATION "${OPENIMAGEIO_LIBRARIES}")
+    endif()
+
+    if(NOT TARGET OpenImageIO::oiiotool AND EXISTS "${OIIOTOOL_BIN}")
+        add_executable(OpenImageIO::oiiotool IMPORTED)
+        set_target_properties(OpenImageIO::oiiotool PROPERTIES
+            IMPORTED_LOCATION "${OIIOTOOL_BIN}")
+    endif()
 endif ()
 
 mark_as_advanced (


### PR DESCRIPTION
* Covers #2331

## Description

This adds two imported targets to the default OIIO cmake finder `OpenImageIO::OpenImageIO` and `OpenImageIO::oiiotool`.

## Tests

None

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.