### PR TITLE
Use more standard convention for plugin_extension on OSX

### DIFF
--- a/src/include/OpenImageIO/plugin.h
+++ b/src/include/OpenImageIO/plugin.h
@@ -27,7 +27,7 @@ namespace Plugin {
 typedef void* Handle;
 
 /// Return the platform-dependent suffix for plug-ins ("dll" on
-/// Windows, "so" on Linux, "dylib" on Mac OS X.
+/// Windows, "so" on Linux and Mac OS X.
 OIIO_API const char*
 plugin_extension(void);
 

--- a/src/libutil/plugin.cpp
+++ b/src/libutil/plugin.cpp
@@ -33,8 +33,6 @@ Plugin::plugin_extension(void)
 {
 #if defined(_WIN32)
     return "dll";
-#elif defined(__APPLE__)
-    return "dylib";
 #else
     return "so";
 #endif


### PR DESCRIPTION
On OSX, Plugin::plugin_extension() returned "dylib". But actually, OSX
distinguishes between true shared libraries ("dylib") and what they
call "bundles" -- the latter is what we think of as a runtime-loadable
plugin and is traditionally given the extension "so".  This choice
also corresponds to what is chosen by new CMake conventions where we
use "MODULE" as the argument to add_library() when making plugins.

I apologize for not understanding this distinction previously.
