### PR TITLE
Rig exr texture output to avoid dwa compression for 1-channel images

### DIFF
--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -611,6 +611,7 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
         return false;
     }
 
+    bool verbose = configspec.get_int_attribute("maketx:verbose") != 0;
     bool src_samples_border = false;
 
     // Some special constraints for OpenEXR
@@ -633,6 +634,9 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
         if (outspec.nchannels == 1
             && Strutil::istarts_with(outspec["compression"].get(), "dwa")) {
             outspec.attribute("compression", "zip");
+            if (verbose)
+                outstream
+                    << "WARNING: Changing unsupported DWA compression for this case to zip.\n";
         }
     }
 
@@ -662,7 +666,6 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
     }
 
     // Write out the image
-    bool verbose = configspec.get_int_attribute("maketx:verbose") != 0;
     if (verbose) {
         outstream << "  Writing file: " << outputfilename << std::endl;
         outstream << "  Filter \"" << filtername << "\"\n";

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -611,22 +611,31 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
         return false;
     }
 
-    if (!mipmap && !strcmp(out->format_name(), "openexr")) {
-        // Send hint to OpenEXR driver that we won't specify a MIPmap
-        outspec.attribute("openexr:levelmode", 0 /* ONE_LEVEL */);
-    }
-
-    if (mipmap && !strcmp(out->format_name(), "openexr")) {
-        outspec.attribute("openexr:roundingmode", 0 /* ROUND_DOWN */);
-    }
-
-    // OpenEXR always uses border sampling for environment maps
     bool src_samples_border = false;
-    if (envlatlmode && !strcmp(out->format_name(), "openexr")) {
-        src_samples_border = true;
-        outspec.attribute("oiio:updirection", "y");
-        outspec.attribute("oiio:sampleborder", 1);
+
+    // Some special constraints for OpenEXR
+    if (!strcmp(out->format_name(), "openexr")) {
+        // Always use "round down" mode
+        outspec.attribute("openexr:roundingmode", 0 /* ROUND_DOWN */);
+        if (!mipmap) {
+            // Send hint to OpenEXR driver that we won't specify a MIPmap
+            outspec.attribute("openexr:levelmode", 0 /* ONE_LEVEL */);
+        }
+        // OpenEXR always uses border sampling for environment maps
+        if (envlatlmode) {
+            src_samples_border = true;
+            outspec.attribute("oiio:updirection", "y");
+            outspec.attribute("oiio:sampleborder", 1);
+        }
+        // For single channel images, dwaa/b compression only seems to work
+        // reliably when size > 16 and size is a power of two. Bug?
+        // FIXME: watch future OpenEXR releases to see if this gets fixed.
+        if (outspec.nchannels == 1
+            && Strutil::istarts_with(outspec["compression"].get(), "dwa")) {
+            outspec.attribute("compression", "zip");
+        }
     }
+
     if (envlatlmode && src_samples_border)
         fix_latl_edges(*img);
 
@@ -1708,7 +1717,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     double misc_time_5 = alltime.lap();
     STATUS("misc4", misc_time_5);
 
-    // Write out, and compute, the mipmap levels for the speicifed image
+    // Write out, and compute, the mipmap levels for the specified image
     bool nomipmap = configspec.get_int_attribute("maketx:nomipmap") != 0;
     bool ok = write_mipmap(mode, toplevel, dstspec, tmpfilename, out.get(),
                            out_dataformat, !shadowmode && !nomipmap, filtername,

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -815,8 +815,7 @@ static ExrMeta exr_meta_translation[] = {
     // user or from a file we read.
     ExrMeta("YResolution"), ExrMeta("planarconfig"), ExrMeta("type"),
     ExrMeta("tiles"), ExrMeta("version"), ExrMeta("chunkCount"),
-    ExrMeta("maxSamplesPerPixel"),
-    ExrMeta()  // empty name signifies end of list
+    ExrMeta("maxSamplesPerPixel"), ExrMeta("openexr:roundingmode")
 };
 
 
@@ -831,8 +830,7 @@ OpenEXROutput::put_parameter(const std::string& name, TypeDesc type,
     std::string xname = name;
     TypeDesc exrtype  = TypeUnknown;
 
-    for (int i = 0; exr_meta_translation[i].oiioname; ++i) {
-        const ExrMeta& e(exr_meta_translation[i]);
+    for (const auto& e : exr_meta_translation) {
         if (Strutil::iequals(xname, e.oiioname)
             || (e.exrname && Strutil::iequals(xname, e.exrname))) {
             xname   = std::string(e.exrname ? e.exrname : "");


### PR DESCRIPTION
We've run into bugs with DWAA/DWAB compression of OpenEXR images in
the specific case of 1-channel images where tile size is either < 16
or not a power of 2.  There was already special logic in the exr
output module that notices this problem case and switches to zip
compression.

However, in the case of outputting MIPmaps, the top level may satisfy
the conditions under which DWA compression works fine (power of 2,
tile size >= 16). But in the course of outputting the MIP levels, we
will eventually reach a tile size < 16, and the OpenEXR format doesn't
allow us to select a different tile size per MIP level (it's just
stored once in the header for the whole file).

So add some logic to our MIPmap generation (maketx, etc), so that
single channel exr texture maps preemptively switch from dwaa/dwab to
something safe. This still only affects 1-channel images, multiple
channels don't appear to tickle the bug.

I couldn't help myself, along the way I did a little refactoring,
coalescing several "if the texture is an exr..." clauses together
under one conditional, and also modernizing an initialization loop
and fixing a typo.

