### PR TITLE
ImageCache per-thread file cache to deal with thread contention

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1197,7 +1197,7 @@ ImageCacheImpl::find_file(ustring filename,
             if (!tf->duplicate())
                 ++thread_info->m_stats.unique_files;
         }
-        thread_info->filename(filename, tf);  // add to the microcache
+        thread_info->remember_filename(filename, tf);  // add to the microcache
 #if IMAGECACHE_TIME_STATS
         thread_info->m_stats.find_file_time += timer();
 #endif
@@ -3497,10 +3497,14 @@ ImageCacheImpl::get_perthread_info(ImageCachePerThreadInfo* p)
         p->tile     = NULL;
         p->lasttile = NULL;
         p->purge    = 0;
+#if FILE_CACHE_USE_PERTHREAD_MAP
+        p->m_thread_files.clear();
+#else
         for (int i = 0; i < ImageCachePerThreadInfo::nlastfile; ++i) {
             p->last_filename[i] = ustring();
             p->last_file[i]     = NULL;
         }
+#endif
     }
     return p;
 }

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3497,14 +3497,7 @@ ImageCacheImpl::get_perthread_info(ImageCachePerThreadInfo* p)
         p->tile     = NULL;
         p->lasttile = NULL;
         p->purge    = 0;
-#if FILE_CACHE_USE_PERTHREAD_MAP
         p->m_thread_files.clear();
-#else
-        for (int i = 0; i < ImageCachePerThreadInfo::nlastfile; ++i) {
-            p->last_filename[i] = ustring();
-            p->last_file[i]     = NULL;
-        }
-#endif
     }
     return p;
 }

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -710,7 +710,7 @@ public:
     // Add a new filename/fileptr pair to our microcache
     void remember_filename(ustring n, ImageCacheFile* f)
     {
-        m_thread_files[n] = f;
+        m_thread_files.emplace(n, f);
     }
 
     // See if a filename has a fileptr in the microcache

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -43,8 +43,6 @@ namespace pvt {
 #define FILE_CACHE_SHARDS 64
 #define TILE_CACHE_SHARDS 128
 
-#define FILE_CACHE_USE_PERTHREAD_MAP 1
-
 using boost::thread_specific_ptr;
 
 class ImageCacheImpl;
@@ -684,7 +682,6 @@ typedef unordered_map_concurrent<
 /// even if you are using only ImageCache but not TextureSystem.
 class ImageCachePerThreadInfo {
 public:
-#if FILE_CACHE_USE_PERTHREAD_MAP
     // Keep a per-thread unlocked map of filenames to ImageCacheFile*'s.
     // Fall back to the shared map only when not found locally.
     // This is safe because no ImageCacheFile is ever truly deleted from
@@ -692,27 +689,16 @@ public:
     using ThreadFilenameMap
         = tsl::robin_map<ustring, ImageCacheFile*, ustringHash>;
     ThreadFilenameMap m_thread_files;
-#else
-    // Store just a few filename/fileptr pairs
-    static const int nlastfile = 4;
-    ustring last_filename[nlastfile];
-    ImageCacheFile* last_file[nlastfile];
-    int next_last_file = 0;
-#endif
+
     // We have a two-tile "microcache", storing the last two tiles needed.
     ImageCacheTileRef tile, lasttile;
     atomic_int purge;  // If set, tile ptrs need purging!
     ImageCacheStatistics m_stats;
-    bool shared
-        = false;  // Pointed to both by the IC and the thread_specific_ptr
+    bool shared = false;  // Pointed to by the IC and thread_specific_ptr
 
     ImageCachePerThreadInfo()
     {
         // std::cout << "Creating PerThreadInfo " << (void*)this << "\n";
-#if !FILE_CACHE_USE_PERTHREAD_MAP
-        for (auto& f : last_file)
-            f = nullptr;
-#endif
         purge = 0;
     }
 
@@ -724,28 +710,14 @@ public:
     // Add a new filename/fileptr pair to our microcache
     void remember_filename(ustring n, ImageCacheFile* f)
     {
-#if FILE_CACHE_USE_PERTHREAD_MAP
         m_thread_files[n] = f;
-#else
-        last_filename[next_last_file] = n;
-        last_file[next_last_file]     = f;
-        ++next_last_file;
-        next_last_file %= nlastfile;
-#endif
     }
 
     // See if a filename has a fileptr in the microcache
     ImageCacheFile* find_file(ustring n) const
     {
-#if FILE_CACHE_USE_PERTHREAD_MAP
         auto f = m_thread_files.find(n);
         return f == m_thread_files.end() ? nullptr : f->second;
-#else
-        for (int i = 0; i < nlastfile; ++i)
-            if (last_filename[i] == n)
-                return last_file[i];
-        return NULL;
-#endif
     }
 };
 


### PR DESCRIPTION
It's a wash for small thread counts, but for highly threaded renders,
I'm seeing 1-2% speedups across real world scenes.
