### PR TITLE
Fix runtest.py copy when OIIO is a submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,15 +225,15 @@ install (FILES src/cmake/modules/FindOpenImageIO.cmake
 
 # Make a build/platform/testsuite directory, and copy the master runtest.py
 # there. The rest is up to the tests themselves.
-file (MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/testsuite")
-file (COPY "${CMAKE_SOURCE_DIR}/testsuite/common"
-      DESTINATION "${CMAKE_BINARY_DIR}/testsuite")
-add_custom_command (OUTPUT "${CMAKE_BINARY_DIR}/testsuite/runtest.py"
+file (MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/testsuite")
+file (COPY "${CMAKE_CURRENT_SOURCE_DIR}/testsuite/common"
+      DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/testsuite")
+add_custom_command (OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/testsuite/runtest.py"
                     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                        "${CMAKE_SOURCE_DIR}/testsuite/runtest.py"
-                        "${CMAKE_BINARY_DIR}/testsuite/runtest.py"
-                    MAIN_DEPENDENCY "${CMAKE_SOURCE_DIR}/testsuite/runtest.py")
-add_custom_target ( CopyFiles ALL DEPENDS "${CMAKE_BINARY_DIR}/testsuite/runtest.py" )
+                        "${CMAKE_CURRENT_SOURCE_DIR}/testsuite/runtest.py"
+                        "${CMAKE_CURRENT_BINARY_DIR}/testsuite/runtest.py"
+                    MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/testsuite/runtest.py")
+add_custom_target ( CopyFiles ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/testsuite/runtest.py" )
 
 # Basic tests that apply even to continuous integration tests:
 


### PR DESCRIPTION
## Description

Hi. We use OIIO as a submodule. The CMake build did not work because the step that copies the runtest.py file used CMAKE_SOURCE_DIR/CMAKE_BINARY_DIR instead of CMAKE_CURRENT_SOURCE_DIR/CMAKE_CURRENT_BINARY_DIR, which resulted in invalid paths in our case.

Now this step works whatever the location of OIIO with respect to the root project's location.

## Checklist:

- [X ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [X ] I have updated the documentation, if applicable.
- [X ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ X] My code follows the prevailing code style of this project.

