### PR TITLE
Fix bugs in Strutil::parse_string that would fail for escaped quotes

### DIFF
--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -771,13 +771,13 @@ Strutil::parse_string(string_view& str, string_view& val, bool eat,
     char lead_char    = p.front();
     bool quoted       = parse_char(p, '\"') || parse_char(p, '\'');
     const char *begin = p.begin(), *end = p.begin();
-    bool escaped = false;
+    bool escaped = false;  // was the prior character a backslash
     while (end != p.end()) {
         if (isspace(*end) && !quoted)
             break;  // not quoted and we hit whitespace: we're done
         if (quoted && *end == lead_char && !escaped)
-            break;  // closing quite -- we're done (beware embedded quote)
-        escaped = (p[0] == '\\');
+            break;  // closing quote -- we're done (beware embedded quote)
+        escaped = (end[0] == '\\') && (!escaped);
         ++end;
     }
     if (quoted && keep_quotes == KeepQuotes) {

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -166,11 +166,20 @@ test_get_rest_arguments()
 
 
 void
+test_escape(string_view raw, string_view escaped)
+{
+    Strutil::printf ("escape '%s' <-> '%s'\n", raw, escaped);
+    OIIO_CHECK_EQUAL(Strutil::escape_chars(raw), escaped);
+    OIIO_CHECK_EQUAL(Strutil::unescape_chars(escaped), raw);
+}
+
+
+
+void
 test_escape_sequences()
 {
-    OIIO_CHECK_EQUAL(Strutil::unescape_chars("\\\\ \\n \\r \\017"),
-                     "\\ \n \r \017");
-    OIIO_CHECK_EQUAL(Strutil::escape_chars("\\ \n \r"), "\\\\ \\n \\r");
+    test_escape ("\\ \n \r \t", "\\\\ \\n \\r \\t");
+    test_escape (" \"quoted\" ",  " \\\"quoted\\\" ");
 }
 
 
@@ -789,6 +798,17 @@ void test_parse ()
     parse_string (s, ss, true, DeleteQuotes);
     OIIO_CHECK_EQUAL (ss, "foo bar");
     OIIO_CHECK_EQUAL (s, " baz");
+    s = "'foo bar' baz";
+
+    s = "\"foo \\\"bar\\\" baz\" blort";
+    parse_string (s, ss, true, DeleteQuotes);
+    OIIO_CHECK_EQUAL (ss, "foo \\\"bar\\\" baz");
+    OIIO_CHECK_EQUAL (s, " blort");
+    s = "\"foo \\\"bar\\\" baz\" blort";
+    parse_string (s, ss, true, KeepQuotes);
+    OIIO_CHECK_EQUAL (ss, "\"foo \\\"bar\\\" baz\"");
+    OIIO_CHECK_EQUAL (s, " blort");
+
     s = "'foo bar' baz";
     parse_string (s, ss, true, KeepQuotes);
     OIIO_CHECK_EQUAL (ss, "'foo bar'");


### PR DESCRIPTION
Two subtle bugs in Strutil::parse_string:

1. Toggling whether we are in an escape code based on the first
   character in the original string, rather than the next character to
   scan.  Big oops!

2. Not realizing that a second backslash in a row should *clear* the
   flag (i.e. `\\` does not leave you in an escaped state).

I beefed up the unit tests, looking at the example I added should
explain the edge case where this crops up -- a double-quoted string
with embedded \\\" within it, if you catch my drift. Just look at the
unit test, it explains better than I can do here. It's very hard to
talk and write (and reason correctly) about escaped strings with
embedded quotes!

