### PR TITLE
Switch Filesystem API to use string_view more consistently

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -119,21 +119,21 @@ OIIO_API bool get_directory_entries (const std::string &dirname,
 
 /// Return true if the path is an "absolute" (not relative) path.
 /// If 'dot_is_absolute' is true, consider "./foo" absolute.
-OIIO_API bool path_is_absolute (const std::string &path,
+OIIO_API bool path_is_absolute (string_view path,
                                 bool dot_is_absolute=false);
 
 /// Return true if the file exists.
 ///
-OIIO_API bool exists (const std::string &path) noexcept;
+OIIO_API bool exists (string_view path) noexcept;
 
 
 /// Return true if the file exists and is a directory.
 ///
-OIIO_API bool is_directory (const std::string &path) noexcept;
+OIIO_API bool is_directory (string_view path) noexcept;
 
 /// Return true if the file exists and is a regular file.
 ///
-OIIO_API bool is_regular (const std::string &path) noexcept;
+OIIO_API bool is_regular (string_view path) noexcept;
 
 /// Create the directory. Return true for success, false for failure and
 /// place an error message in err.
@@ -218,11 +218,11 @@ OIIO_API size_t read_bytes (string_view path, void *buffer, size_t n,
 
 /// Get last modified time of file
 ///
-OIIO_API std::time_t last_write_time (const std::string& path) noexcept;
+OIIO_API std::time_t last_write_time (string_view path) noexcept;
 
 /// Set last modified time on file
 ///
-OIIO_API void last_write_time (const std::string& path, std::time_t time) noexcept;
+OIIO_API void last_write_time (string_view path, std::time_t time) noexcept;
 
 /// Return the size of the file (in bytes), or uint64_t(-1) if there is any
 /// error.

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -303,7 +303,7 @@ ImageCacheFile::ImageCacheFile(ImageCacheImpl& imagecache,
                  || m_filename.find("<V>") != m_filename.npos
                  || m_filename.find("<u>") != m_filename.npos
                  || m_filename.find("<v>") != m_filename.npos)
-                && !Filesystem::exists(m_filename.string());
+                && !Filesystem::exists(m_filename);
 }
 
 
@@ -752,7 +752,7 @@ ImageCacheFile::init_from_spec()
     if (fing.length())
         m_fingerprint = ustring(fing);
 
-    m_mod_time = Filesystem::last_write_time(m_filename.string());
+    m_mod_time = Filesystem::last_write_time(m_filename);
 
     // Set all mipmap level read counts to zero
     int maxmip = 1;
@@ -1502,8 +1502,7 @@ ImageCacheTile::read(ImageCachePerThreadInfo* thread_info)
     } else {
         // (! m_valid)
         m_used = false;  // Don't let it hold mem if invalid
-        if (file.mod_time()
-            != Filesystem::last_write_time(file.filename().string()))
+        if (file.mod_time() != Filesystem::last_write_time(file.filename()))
             file.imagecache().errorf(
                 "File \"%s\" was modified after being opened by OIIO",
                 file.filename());
@@ -3239,7 +3238,7 @@ ImageCacheImpl::invalidate(ustring filename, bool force)
         // If not in force mode, we don't do anything if the modification
         // time of the file has not changed since we opened it.
         recursive_lock_guard guard(file->m_input_mutex);
-        if (file->mod_time() == Filesystem::last_write_time(filename.string())
+        if (file->mod_time() == Filesystem::last_write_time(filename)
             && !file->broken())
             return;
     }
@@ -3314,13 +3313,13 @@ ImageCacheImpl::invalidate_all(bool force)
         f->m_mutex_wait_time += input_mutex_timer();
         // If the file was broken when we opened it, or if it no longer
         // exists, definitely invalidate it.
-        if (f->broken() || !Filesystem::exists(name.string())) {
+        if (f->broken() || !Filesystem::exists(name)) {
             all_files.push_back(name);
             continue;
         }
         // Invalidate the file if it has been modified since it was
         // last opened.
-        std::time_t t = Filesystem::last_write_time(name.string());
+        std::time_t t = Filesystem::last_write_time(name);
         if (t != f->mod_time()) {
             all_files.push_back(name);
             continue;


### PR DESCRIPTION
A number of calls in the Filesystem API were using std::string instead of
the more efficient string_view. This was leading to extra conversions in a few places in the code.

Also mask the usage of boost::system::error_code behind an alias so we can (one day) move to std::filesystem more easily.

Fix some internal roundtrip between string and path representations in the Filesystem module.
