### PR TITLE
error -> errorf

### DIFF
--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -51,24 +51,24 @@ BmpInput::open(const std::string& name, ImageSpec& spec)
 
     m_fd = Filesystem::fopen(m_filename, "rb");
     if (!m_fd) {
-        error("Could not open file \"%s\"", name.c_str());
+        errorf("Could not open file \"%s\"", name);
         return false;
     }
 
     // we read header of the file that we think is BMP file
     if (!m_bmp_header.read_header(m_fd)) {
-        error("\"%s\": wrong bmp header size", m_filename.c_str());
+        errorf("\"%s\": wrong bmp header size", m_filename);
         close();
         return false;
     }
     if (!m_bmp_header.isBmp()) {
-        error("\"%s\" is not a BMP file, magic number doesn't match",
-              m_filename.c_str());
+        errorf("\"%s\" is not a BMP file, magic number doesn't match",
+               m_filename);
         close();
         return false;
     }
     if (!m_dib_header.read_header(m_fd)) {
-        error("\"%s\": wrong bitmap header size", m_filename.c_str());
+        errorf("\"%s\": wrong bitmap header size", m_filename);
         close();
         return false;
     }
@@ -144,9 +144,9 @@ BmpInput::read_native_scanline(int subimage, int miplevel, int y, int z,
     size_t n = fread(&fscanline[0], 1, m_padded_scanline_size, m_fd);
     if (n != (size_t)m_padded_scanline_size) {
         if (feof(m_fd))
-            error("Hit end of file unexpectedly");
+            errorf("Hit end of file unexpectedly");
         else
-            error("read error");
+            errorf("read error");
         return false;  // Read failed
     }
 
@@ -245,9 +245,10 @@ BmpInput::read_color_table(void)
         size_t n = fread(&m_colortable[i], 1, entry_size, m_fd);
         if (n != entry_size) {
             if (feof(m_fd))
-                error("Hit end of file unexpectedly while reading color table");
+                errorf(
+                    "Hit end of file unexpectedly while reading color table");
             else
-                error("read error while reading color table");
+                errorf("read error while reading color table");
             return false;  // Read failed
         }
     }

--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -38,7 +38,7 @@ bool
 BmpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
 {
     if (mode != Create) {
-        error("%s does not support subimages or MIP levels", format_name());
+        errorf("%s does not support subimages or MIP levels", format_name());
         return false;
     }
 
@@ -47,8 +47,8 @@ BmpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
     m_spec     = spec;
 
     if (m_spec.nchannels != 3 && m_spec.nchannels != 4) {
-        error("%s does not support %d-channel images\n", format_name(),
-              m_spec.nchannels);
+        errorf("%s does not support %d-channel images\n", format_name(),
+               m_spec.nchannels);
         return false;
     }
 
@@ -84,7 +84,7 @@ BmpOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
                           stride_t xstride)
 {
     if (y > m_spec.height) {
-        error("Attempt to write too many scanlines to %s", m_filename.c_str());
+        errorf("Attempt to write too many scanlines to %s", m_filename);
         close();
         return false;
     }

--- a/src/cineon.imageio/cineoninput.cpp
+++ b/src/cineon.imageio/cineoninput.cpp
@@ -78,13 +78,13 @@ CineonInput::open(const std::string& name, ImageSpec& newspec)
     // open the image
     m_stream = new InStream();
     if (!m_stream->Open(name.c_str())) {
-        error("Could not open file \"%s\"", name.c_str());
+        errorf("Could not open file \"%s\"", name);
         return false;
     }
 
     m_cin.SetInStream(m_stream);
     if (!m_cin.ReadHeader()) {
-        error("Could not read header");
+        errorf("Could not read header");
         return false;
     }
 
@@ -100,7 +100,7 @@ CineonInput::open(const std::string& name, ImageSpec& newspec)
     case 2: typedesc = TypeDesc::UINT16; break;
     case 3:
     case 4: typedesc = TypeDesc::UINT32; break;
-    default: error("Unsupported bit depth %d", maxbits); return false;
+    default: errorf("Unsupported bit depth %d", maxbits); return false;
     }
     m_spec = ImageSpec(m_cin.header.Width(), m_cin.header.Height(),
                        m_cin.header.NumberOfElements(), typedesc);

--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -97,7 +97,7 @@ private:
     {
         size_t n = ::fread(buf, itemsize, nitems, m_file);
         if (n != nitems)
-            error("Read error");
+            errorf("Read error");
         return n == nitems;
     }
 };
@@ -134,7 +134,7 @@ DDSInput::open(const std::string& name, ImageSpec& newspec)
 
     m_file = Filesystem::fopen(name, "rb");
     if (!m_file) {
-        error("Could not open file \"%s\"", name.c_str());
+        errorf("Could not open file \"%s\"", name);
         return false;
     }
 
@@ -223,7 +223,7 @@ DDSInput::open(const std::string& name, ImageSpec& newspec)
                  && m_dds.flags & DDS_DEPTH))
         || (m_dds.caps.flags2 & DDS_CAPS2_CUBEMAP
             && !(m_dds.caps.flags1 & DDS_CAPS1_COMPLEX))) {
-        error("Invalid DDS header, possibly corrupt file");
+        errorf("Invalid DDS header, possibly corrupt file");
         return false;
     }
 
@@ -236,7 +236,7 @@ DDSInput::open(const std::string& name, ImageSpec& newspec)
             && !((m_dds.fmt.flags & DDS_PF_RGB)
                  | (m_dds.fmt.flags & DDS_PF_LUMINANCE)
                  | (m_dds.fmt.flags & DDS_PF_ALPHA)))) {
-        error("Image with no data");
+        errorf("Image with no data");
         return false;
     }
 
@@ -246,7 +246,7 @@ DDSInput::open(const std::string& name, ImageSpec& newspec)
         && m_dds.fmt.fourCC != DDS_4CC_DXT2 && m_dds.fmt.fourCC != DDS_4CC_DXT3
         && m_dds.fmt.fourCC != DDS_4CC_DXT4
         && m_dds.fmt.fourCC != DDS_4CC_DXT5) {
-        error("Unsupported compression type");
+        errorf("Unsupported compression type");
         return false;
     }
 

--- a/src/dicom.imageio/dicominput.cpp
+++ b/src/dicom.imageio/dicominput.cpp
@@ -154,7 +154,7 @@ DICOMInput::seek_subimage(int subimage, int miplevel)
         m_subimage = 0;
         if (m_img->getStatus() != EIS_Normal) {
             m_img.reset();
-            error("Unable to open DICOM file %s", m_filename);
+            errorf("Unable to open DICOM file %s", m_filename);
             return false;
         }
         m_framecount = m_img->getFrameCount();
@@ -162,7 +162,7 @@ DICOMInput::seek_subimage(int subimage, int miplevel)
     }
 
     if (subimage >= m_firstframe + m_framecount) {
-        error("Unable to seek to subimage %d", subimage);
+        errorf("Unable to seek to subimage %d", subimage);
         return false;
     }
 
@@ -171,7 +171,7 @@ DICOMInput::seek_subimage(int subimage, int miplevel)
         m_img->processNextFrames(1);
         if (m_img->getStatus() != EIS_Normal) {
             m_img.reset();
-            error("Unable to seek to subimage %d", subimage);
+            errorf("Unable to seek to subimage %d", subimage);
             return false;
         }
         ++m_subimage;

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -131,7 +131,7 @@ DPXInput::open(const std::string& name, ImageSpec& newspec)
 
     m_dpx.SetInStream(m_stream);
     if (!m_dpx.ReadHeader()) {
-        error("Could not read header");
+        errorf("Could not read header");
         close();
         return false;
     }
@@ -188,7 +188,7 @@ DPXInput::seek_subimage(int subimage, int miplevel)
         break;
     case dpx::kFloat: typedesc = TypeDesc::FLOAT; break;
     case dpx::kDouble: typedesc = TypeDesc::DOUBLE; break;
-    default: error("Invalid component data size"); return false;
+    default: errorf("Invalid component data size"); return false;
     }
     m_spec = ImageSpec(m_dpx.header.Width(), m_dpx.header.Height(),
                        m_dpx.header.ImageElementComponentCount(subimage),

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -181,7 +181,7 @@ DPXOutput::open(const std::string& name, const ImageSpec& userspec,
         // Nothing else to do, the header taken care of when we opened with
         // Create.
     } else if (mode == AppendMIPLevel) {
-        error("DPX does not support MIP-maps");
+        errorf("DPX does not support MIP-maps");
         return false;
     }
 
@@ -213,7 +213,7 @@ DPXOutput::open(const std::string& name, const ImageSpec& userspec,
     if (m_spec.depth < 1)
         m_spec.depth = 1;
     else if (m_spec.depth > 1) {
-        error("DPX does not support volume images (depth > 1)");
+        errorf("DPX does not support volume images (depth > 1)");
         return false;
     }
 
@@ -413,14 +413,14 @@ DPXOutput::open(const std::string& name, const ImageSpec& userspec,
 
     // commit!
     if (!m_dpx.WriteHeader()) {
-        error("Failed to write DPX header");
+        errorf("Failed to write DPX header");
         return false;
     }
 
     // write the user data
     if (user && user->datasize() > 0 && user->datasize() <= 1024 * 1024) {
         if (!m_dpx.WriteUserData((void*)user->data())) {
-            error("Failed to write user data");
+            errorf("Failed to write user data");
             return false;
         }
     }
@@ -545,7 +545,7 @@ DPXOutput::prep_subimage(int s, bool allocate)
         m_bytes = dpx::QueryNativeBufferSize(m_desc, m_datasize, m_spec.width,
                                              1);
         if (m_bytes == 0 && !m_rawcolor) {
-            error("Unable to deliver native format data from source data");
+            errorf("Unable to deliver native format data from source data");
             return false;
         } else if (m_bytes < 0) {
             // no need to allocate another buffer

--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -261,7 +261,7 @@ FFmpegInput::open(const std::string& name, ImageSpec& spec)
             break;
         }
     if (!valid_extension) {
-        error("\"%s\" could not open input", name);
+        errorf("\"%s\" could not open input", name);
         return false;
     }
 
@@ -271,11 +271,11 @@ FFmpegInput::open(const std::string& name, ImageSpec& spec)
     av_log_set_level(AV_LOG_FATAL);
     if (avformat_open_input(&m_format_context, file_name, NULL, NULL) != 0) {
         // avformat_open_input allocs format_context
-        error("\"%s\" could not open input", file_name);
+        errorf("\"%s\" could not open input", file_name);
         return false;
     }
     if (avformat_find_stream_info(m_format_context, NULL) < 0) {
-        error("\"%s\" could not find stream info", file_name);
+        errorf("\"%s\" could not find stream info", file_name);
         return false;
     }
     m_video_stream = -1;
@@ -289,7 +289,7 @@ FFmpegInput::open(const std::string& name, ImageSpec& spec)
         }
     }
     if (m_video_stream == -1) {
-        error("\"%s\" could not find a valid videostream", file_name);
+        errorf("\"%s\" could not find a valid videostream", file_name);
         return false;
     }
 
@@ -299,13 +299,13 @@ FFmpegInput::open(const std::string& name, ImageSpec& spec)
 
     m_codec = avcodec_find_decoder(par->codec_id);
     if (!m_codec) {
-        error("\"%s\" can't find decoder", file_name);
+        errorf("\"%s\" can't find decoder", file_name);
         return false;
     }
 
     m_codec_context = avcodec_alloc_context3(m_codec);
     if (!m_codec_context) {
-        error("\"%s\" can't allocate decoder context", file_name);
+        errorf("\"%s\" can't allocate decoder context", file_name);
         return false;
     }
 
@@ -313,7 +313,7 @@ FFmpegInput::open(const std::string& name, ImageSpec& spec)
 
     ret = avcodec_parameters_to_context(m_codec_context, par);
     if (ret < 0) {
-        error("\"%s\" unsupported codec", file_name);
+        errorf("\"%s\" unsupported codec", file_name);
         return false;
     }
 #else
@@ -321,13 +321,13 @@ FFmpegInput::open(const std::string& name, ImageSpec& spec)
 
     m_codec = avcodec_find_decoder(m_codec_context->codec_id);
     if (!m_codec) {
-        error("\"%s\" unsupported codec", file_name);
+        errorf("\"%s\" unsupported codec", file_name);
         return false;
     }
 #endif
 
     if (avcodec_open2(m_codec_context, m_codec, NULL) < 0) {
-        error("\"%s\" could not open codec", file_name);
+        errorf("\"%s\" could not open codec", file_name);
         return false;
     }
     if (!strcmp(m_codec_context->codec->name, "mjpeg")

--- a/src/field3d.imageio/field3doutput.cpp
+++ b/src/field3d.imageio/field3doutput.cpp
@@ -147,7 +147,7 @@ Field3DOutput::open(const std::string& name, const ImageSpec& userspec,
         return open(name, 1, &userspec);
 
     if (mode == AppendMIPLevel) {
-        error("%s does not support MIP-mapping", format_name());
+        errorf("%s does not support MIP-mapping", format_name());
         return false;
     }
 
@@ -157,8 +157,8 @@ Field3DOutput::open(const std::string& name, const ImageSpec& userspec,
 
     ++m_subimage;
     if (m_subimage >= m_nsubimages) {
-        error("Appending past the pre-declared number of subimages (%d)",
-              m_nsubimages);
+        errorf("Appending past the pre-declared number of subimages (%d)",
+               m_nsubimages);
         return false;
     }
 
@@ -178,7 +178,7 @@ Field3DOutput::open(const std::string& name, int subimages,
         close();
 
     if (subimages < 1) {
-        error("%s does not support %d subimages.", format_name(), subimages);
+        errorf("%s does not support %d subimages.", format_name(), subimages);
         return false;
     }
 
@@ -212,8 +212,8 @@ Field3DOutput::open(const std::string& name, int subimages,
             spec.format = TypeDesc::FLOAT;
         }
         if (spec.nchannels != 1 && spec.nchannels != 3) {
-            error("%s does not allow %d channels in a field (subimage %d)",
-                  format_name(), spec.nchannels, s);
+            errorf("%s does not allow %d channels in a field (subimage %d)",
+                   format_name(), spec.nchannels, s);
             return false;
         }
     }
@@ -309,7 +309,7 @@ Field3DOutput::write_scanline_specialized(int y, int z, const T* data)
         return true;
     }
 
-    error("Unknown field type");
+    errorf("Unknown field type");
     return false;
 }
 
@@ -386,7 +386,7 @@ Field3DOutput::write_tile_specialized(int x, int y, int z, const T* data)
         return true;
     }
 
-    error("Unknown field type");
+    errorf("Unknown field type");
     return false;
 }
 

--- a/src/gif.imageio/gifinput.cpp
+++ b/src/gif.imageio/gifinput.cpp
@@ -292,7 +292,7 @@ GIFInput::read_subimage_data()
     } else if (m_gif_file->SColorMap) {  // global colormap
         colormap = m_gif_file->SColorMap->Colors;
     } else {
-        error("Neither local nor global colormap present.");
+        errorf("Neither local nor global colormap present.");
         return false;
     }
 
@@ -361,12 +361,12 @@ GIFInput::seek_subimage(int subimage, int miplevel)
         int giflib_error;
         if (!(m_gif_file = DGifOpenFileName(m_filename.c_str(),
                                             &giflib_error))) {
-            error(GifErrorString(giflib_error));
+            errorf("%s", GifErrorString(giflib_error));
             return false;
         }
 #else
         if (!(m_gif_file = DGifOpenFileName(m_filename.c_str()))) {
-            error("Error trying to open the file.");
+            errorf("Error trying to open the file.");
             return false;
         }
 #endif
@@ -421,13 +421,13 @@ GIFInput::report_last_error(void)
     // error was for *this* file.  So if you're using giflib prior to
     // version 5, beware.
 #if GIFLIB_MAJOR >= 5
-    error("%s", GifErrorString(m_gif_file->Error));
+    errorf("%s", GifErrorString(m_gif_file->Error));
 #elif GIFLIB_MAJOR == 4 && GIFLIB_MINOR >= 2
     spin_lock lock(gif_error_mutex);
-    error("%s", GifErrorString());
+    errorf("%s", GifErrorString());
 #else
     spin_lock lock(gif_error_mutex);
-    error("GIF error %d", GifLastError());
+    errorf("GIF error %d", GifLastError());
 #endif
 }
 
@@ -442,7 +442,7 @@ GIFInput::close(void)
 #else
         if (DGifCloseFile(m_gif_file) == GIF_ERROR) {
 #endif
-            error("Error trying to close the file.");
+            errorf("Error trying to close the file.");
             return false;
         }
         m_gif_file = NULL;

--- a/src/gif.imageio/gifoutput.cpp
+++ b/src/gif.imageio/gifoutput.cpp
@@ -88,7 +88,7 @@ GIFOutput::open(const std::string& name, const ImageSpec& newspec,
     }
 
     if (mode == AppendMIPLevel) {
-        error("%s does not support MIP levels", format_name());
+        errorf("%s does not support MIP levels", format_name());
         return false;
     }
 
@@ -110,7 +110,7 @@ bool
 GIFOutput::open(const std::string& name, int subimages, const ImageSpec* specs)
 {
     if (subimages < 1) {
-        error("%s does not support %d subimages.", format_name(), subimages);
+        errorf("%s does not support %d subimages.", format_name(), subimages);
         return false;
     }
 
@@ -144,19 +144,19 @@ GIFOutput::start_subimage()
 {
     // Check for things this format doesn't support
     if (m_spec.width < 1 || m_spec.height < 1) {
-        error("Image resolution must be at least 1x1, you asked for %d x %d",
-              m_spec.width, m_spec.height);
+        errorf("Image resolution must be at least 1x1, you asked for %d x %d",
+               m_spec.width, m_spec.height);
         return false;
     }
     if (m_spec.depth < 1)
         m_spec.depth = 1;
     if (m_spec.depth > 1) {
-        error("%s does not support volume images (depth > 1)", format_name());
+        errorf("%s does not support volume images (depth > 1)", format_name());
         return false;
     }
     if (m_spec.nchannels != 3 && m_spec.nchannels != 4) {
-        error("%s does not support %d-channel images", format_name(),
-              m_spec.nchannels);
+        errorf("%s does not support %d-channel images", format_name(),
+               m_spec.nchannels);
         return false;
     }
 

--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -112,7 +112,7 @@ HdrInput::seek_subimage(int subimage, int miplevel)
     // Check that file exists and can be opened
     m_fd = Filesystem::fopen(m_filename, "rb");
     if (m_fd == NULL) {
-        error("Could not open file \"%s\"", m_filename.c_str());
+        errorf("Could not open file \"%s\"", m_filename);
         return false;
     }
 
@@ -120,7 +120,7 @@ HdrInput::seek_subimage(int subimage, int miplevel)
     int width, height;
     int r = RGBE_ReadHeader(m_fd, &width, &height, &h, rgbe_error);
     if (r != RGBE_RETURN_SUCCESS) {
-        error("%s", rgbe_error);
+        errorf("%s", rgbe_error);
         close();
         return false;
     }
@@ -183,7 +183,7 @@ HdrInput::read_native_scanline(int subimage, int miplevel, int y, int z,
                                     rgbe_error);
         ++m_next_scanline;
         if (r != RGBE_RETURN_SUCCESS) {
-            error("%s", rgbe_error);
+            errorf("%s", rgbe_error);
             return false;
         }
     }

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -61,7 +61,7 @@ HdrOutput::open(const std::string& name, const ImageSpec& newspec,
                 OpenMode mode)
 {
     if (mode != Create) {
-        error("%s does not support subimages or MIP levels", format_name());
+        errorf("%s does not support subimages or MIP levels", format_name());
         return false;
     }
 
@@ -72,18 +72,18 @@ HdrOutput::open(const std::string& name, const ImageSpec& newspec,
 
     // Check for things HDR can't support
     if (m_spec.nchannels != 3) {
-        error("HDR can only support 3-channel images");
+        errorf("HDR can only support 3-channel images");
         return false;
     }
     if (m_spec.width < 1 || m_spec.height < 1) {
-        error("Image resolution must be at least 1x1, you asked for %d x %d",
-              m_spec.width, m_spec.height);
+        errorf("Image resolution must be at least 1x1, you asked for %d x %d",
+               m_spec.width, m_spec.height);
         return false;
     }
     if (m_spec.depth < 1)
         m_spec.depth = 1;
     if (m_spec.depth > 1) {
-        error("%s does not support volume images (depth > 1)", format_name());
+        errorf("%s does not support volume images (depth > 1)", format_name());
         return false;
     }
 
@@ -115,7 +115,7 @@ HdrOutput::open(const std::string& name, const ImageSpec& newspec,
 
     int r = RGBE_WriteHeader(m_fd, m_spec.width, m_spec.height, &h, rgbe_error);
     if (r != RGBE_RETURN_SUCCESS)
-        error("%s", rgbe_error);
+        errorf("%s", rgbe_error);
 
     // If user asked for tiles -- which this format doesn't support, emulate
     // it by buffering the whole image.
@@ -135,7 +135,7 @@ HdrOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
     int r = RGBE_WritePixels_RLE(m_fd, (float*)data, m_spec.width, 1,
                                  rgbe_error);
     if (r != RGBE_RETURN_SUCCESS)
-        error("%s", rgbe_error);
+        errorf("%s", rgbe_error);
     return (r == RGBE_RETURN_SUCCESS);
 }
 

--- a/src/ico.imageio/icoinput.cpp
+++ b/src/ico.imageio/icoinput.cpp
@@ -75,7 +75,7 @@ private:
     {
         size_t n = ::fread(buf, itemsize, nitems, m_file);
         if (n != nitems)
-            error("Read error");
+            errorf("Read error");
         return n == nitems;
     }
 };
@@ -112,7 +112,7 @@ ICOInput::open(const std::string& name, ImageSpec& newspec)
 
     m_file = Filesystem::fopen(name, "rb");
     if (!m_file) {
-        error("Could not open file \"%s\"", name.c_str());
+        errorf("Could not open file \"%s\"", name);
         return false;
     }
 
@@ -126,7 +126,7 @@ ICOInput::open(const std::string& name, ImageSpec& newspec)
         swap_endian(&m_ico.count);
     }
     if (m_ico.reserved != 0 || m_ico.type != 1) {
-        error("File failed ICO header check");
+        errorf("File failed ICO header check");
         return false;
     }
 
@@ -188,7 +188,7 @@ ICOInput::seek_subimage(int subimage, int miplevel)
     if (temp[1] == 'P' && temp[2] == 'N' && temp[3] == 'G') {
         // standard PNG initalization
         if (png_sig_cmp((png_bytep)temp, 0, 7)) {
-            error("Subimage failed PNG signature check");
+            errorf("Subimage failed PNG signature check");
             return false;
         }
 
@@ -196,7 +196,7 @@ ICOInput::seek_subimage(int subimage, int miplevel)
 
         std::string s = PNG_pvt::create_read_struct(m_png, m_info, this);
         if (s.length()) {
-            error("%s", s.c_str());
+            errorf("%s", s);
             return false;
         }
 
@@ -243,7 +243,7 @@ ICOInput::seek_subimage(int subimage, int miplevel)
         && m_bpp != 8
         /*&& m_bpp != 16*/
         && m_bpp != 24 && m_bpp != 32) {
-        error("Unsupported image color depth, probably corrupt file");
+        errorf("Unsupported image color depth, probably corrupt file");
         return false;
     }
     m_offset        = subimg.ofs;
@@ -280,7 +280,7 @@ ICOInput::readimg()
         //std::cerr << "[ico] PNG buffer size = " << m_buf.size () << "\n";
 
         if (s.length()) {
-            error("%s", s.c_str());
+            errorf("%s", s);
             return false;
         }
 

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -76,7 +76,7 @@ private:
     {
         size_t n = ::fwrite(buf, itemsize, nitems, m_file);
         if (n != nitems)
-            error("Write error");
+            errorf("Write error");
         return n == nitems;
     }
 
@@ -87,7 +87,7 @@ private:
     {
         size_t n = ::fread(buf, itemsize, nitems, m_file);
         if (n != nitems)
-            error("Read error");
+            errorf("Read error");
         return n == nitems;
     }
 };
@@ -128,7 +128,7 @@ ICOOutput::open(const std::string& name, const ImageSpec& userspec,
                 OpenMode mode)
 {
     if (mode == AppendMIPLevel) {
-        error("%s does not support MIP levels", format_name());
+        errorf("%s does not support MIP levels", format_name());
         return false;
     }
 
@@ -139,18 +139,18 @@ ICOOutput::open(const std::string& name, const ImageSpec& userspec,
 
     // Check for things this format doesn't support
     if (m_spec.width < 1 || m_spec.height < 1) {
-        error("Image resolution must be at least 1x1, you asked for %d x %d",
-              m_spec.width, m_spec.height);
+        errorf("Image resolution must be at least 1x1, you asked for %d x %d",
+               m_spec.width, m_spec.height);
         return false;
     } else if (m_spec.width > 256 || m_spec.height > 256) {
-        error("Image resolution must be at most 256x256, you asked for %d x %d",
-              m_spec.width, m_spec.height);
+        errorf("Image resolution must be at most 256x256, you asked for %d x %d",
+               m_spec.width, m_spec.height);
         return false;
     }
     if (m_spec.depth < 1)
         m_spec.depth = 1;
     if (m_spec.depth > 1) {
-        error("%s does not support volume images (depth > 1)", format_name());
+        errorf("%s does not support volume images (depth > 1)", format_name());
         return false;
     }
 
@@ -165,7 +165,7 @@ ICOOutput::open(const std::string& name, const ImageSpec& userspec,
         std::string s = PNG_pvt::create_write_struct(m_png, m_info,
                                                      m_color_type, m_spec);
         if (s.length()) {
-            error("%s", s.c_str());
+            errorf("%s", s);
             return false;
         }
     } else {
@@ -176,7 +176,7 @@ ICOOutput::open(const std::string& name, const ImageSpec& userspec,
         case 3: m_color_type = PNG_COLOR_TYPE_RGB; break;
         case 4: m_color_type = PNG_COLOR_TYPE_RGB_ALPHA; break;
         default:
-            error("ICO only supports 1-4 channels, not %d", m_spec.nchannels);
+            errorf("ICO only supports 1-4 channels, not %d", m_spec.nchannels);
             return false;
         }
 
@@ -236,7 +236,7 @@ ICOOutput::open(const std::string& name, const ImageSpec& userspec,
                   << ico.type << " count = " << ico.count << "\n";*/
 
         if (ico.reserved != 0 || ico.type != 1) {
-            error("File failed ICO header check");
+            errorf("File failed ICO header check");
             return false;
         }
 
@@ -444,7 +444,7 @@ ICOOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
 
     if (m_want_png) {
         if (!PNG_pvt::write_row(m_png, (png_byte*)data)) {
-            error("PNG library error");
+            errorf("PNG library error");
             return false;
         }
     } else {

--- a/src/iff.imageio/iffinput.cpp
+++ b/src/iff.imageio/iffinput.cpp
@@ -62,7 +62,7 @@ IffInput::open(const std::string& name, ImageSpec& spec)
 
     m_fd = Filesystem::fopen(m_filename, "rb");
     if (!m_fd) {
-        error("Could not open file \"%s\"", name.c_str());
+        errorf("Could not open file \"%s\"", name);
         return false;
     }
 
@@ -95,7 +95,7 @@ IffInput::open(const std::string& name, ImageSpec& spec)
         // only 1 subimage for IFF
         m_spec.tile_depth = 1;
     } else {
-        error("\"%s\": wrong tile size", m_filename.c_str());
+        errorf("\"%s\": wrong tile size", m_filename);
         close();
         return false;
     }
@@ -421,8 +421,8 @@ IffInput::readimg()
                 }
 
             } else {
-                error("\"%s\": unsupported number of bits per pixel for tile",
-                      m_filename.c_str());
+                errorf("\"%s\": unsupported number of bits per pixel for tile",
+                       m_filename);
                 return false;
             }
 

--- a/src/iff.imageio/iffoutput.cpp
+++ b/src/iff.imageio/iffoutput.cpp
@@ -58,7 +58,7 @@ IffOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
     //       ...
 
     if (mode != Create) {
-        error("%s does not support subimages or MIP levels", format_name());
+        errorf("%s does not support subimages or MIP levels", format_name());
         return false;
     }
 
@@ -116,7 +116,7 @@ IffOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
     m_iff_header.date           = m_spec.get_string_attribute("DateTime");
 
     if (!write_header(m_iff_header)) {
-        error("\"%s\": could not write iff header", m_filename.c_str());
+        errorf("\"%s\": could not write iff header", m_filename);
         close();
         return false;
     }

--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -203,7 +203,7 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
     case TypeDesc::DOUBLE:                                              \
         ret = func<double> (R, __VA_ARGS__); break;                     \
     default:                                                            \
-        (R).error ("%s: Unsupported pixel data format '%s'", name, type); \
+        (R).errorf("%s: Unsupported pixel data format '%s'", name, type); \
         ret = false;                                                    \
     }
 
@@ -229,7 +229,7 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
     case TypeDesc::DOUBLE :                                             \
         ret = func<Rtype,double> (R, __VA_ARGS__); break;               \
     default:                                                            \
-        (R).error ("%s: Unsupported pixel data format '%s'", name, Atype); \
+        (R).errorf("%s: Unsupported pixel data format '%s'", name, Atype); \
         ret = false;                                                    \
     }
 
@@ -264,7 +264,7 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
         OIIO_DISPATCH_TYPES2_HELP(ret,name,func,double,Atype,R,__VA_ARGS__);\
         break;                                                          \
     default:                                                            \
-        (R).error ("%s: Unsupported pixel data format '%s'", name, Rtype); \
+        (R).errorf("%s: Unsupported pixel data format '%s'", name, Rtype); \
         ret = false;                                                    \
     }
 
@@ -290,7 +290,7 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
         if (ret)                                                        \
             (R).copy (Rtmp);                                            \
         else                                                            \
-            (R).error ("%s", Rtmp.geterror());                          \
+            (R).errorf("%s", Rtmp.geterror());                          \
         }                                                               \
     }
 
@@ -339,7 +339,7 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
         case TypeDesc::DOUBLE :                                         \
             ret = func<double,double> (R, A, __VA_ARGS__); break;       \
         default:                                                        \
-            (R).error ("%s: Unsupported pixel data format '%s'", name, Atype); \
+            (R).errorf("%s: Unsupported pixel data format '%s'", name, Atype); \
             ret = false;                                                \
         }                                                               \
     } else {                                                            \
@@ -366,7 +366,7 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
             if (ret)                                                    \
                 (R).copy (Rtmp);                                        \
             else                                                        \
-                (R).error ("%s", Rtmp.geterror());                      \
+                (R).errorf("%s", Rtmp.geterror());                      \
             }                                                           \
         }                                                               \
     }
@@ -418,7 +418,7 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
         if (ret)                                                        \
             (R).copy (Rtmp);                                            \
         else                                                            \
-            (R).error ("%s", Rtmp.geterror());                          \
+            (R).errorf("%s", Rtmp.geterror());                          \
         }                                                               \
     }
 
@@ -471,7 +471,7 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
         case TypeDesc::DOUBLE :                                         \
             ret = func<double,double,double> (R, A, B, __VA_ARGS__); break; \
         default:                                                        \
-            (R).error ("%s: Unsupported pixel data format '%s'", name, Atype); \
+            (R).errorf("%s: Unsupported pixel data format '%s'", name, Atype); \
             ret = false;                                                \
         }                                                               \
     } else {                                                            \

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -102,7 +102,7 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
                 OpenMode mode)
 {
     if (mode != Create) {
-        error("%s does not support subimages or MIP levels", format_name());
+        errorf("%s does not support subimages or MIP levels", format_name());
         return false;
     }
 
@@ -112,14 +112,14 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
 
     // Check for things this format doesn't support
     if (m_spec.width < 1 || m_spec.height < 1) {
-        error("Image resolution must be at least 1x1, you asked for %d x %d",
-              m_spec.width, m_spec.height);
+        errorf("Image resolution must be at least 1x1, you asked for %d x %d",
+               m_spec.width, m_spec.height);
         return false;
     }
     if (m_spec.depth < 1)
         m_spec.depth = 1;
     if (m_spec.depth > 1) {
-        error("%s does not support volume images (depth > 1)", format_name());
+        errorf("%s does not support volume images (depth > 1)", format_name());
         return false;
     }
 
@@ -347,12 +347,11 @@ JpgOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
 {
     y -= m_spec.y;
     if (y != m_next_scanline) {
-        error("Attempt to write scanlines out of order to %s",
-              m_filename.c_str());
+        errorf("Attempt to write scanlines out of order to %s", m_filename);
         return false;
     }
     if (y >= (int)m_cinfo.image_height) {
-        error("Attempt to write too many scanlines to %s", m_filename.c_str());
+        errorf("Attempt to write too many scanlines to %s", m_filename);
         return false;
     }
     assert(y == (int)m_cinfo.next_scanline);

--- a/src/jpeg2000.imageio/jpeg2000input-v1.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input-v1.cpp
@@ -138,7 +138,7 @@ private:
     {
         size_t n = ::fread(p_buf, p_itemSize, p_nitems, m_file);
         if (n != p_nitems)
-            error("Read error");
+            errorf("Read error");
         return n == p_nitems;
     }
 };
@@ -179,13 +179,13 @@ Jpeg2000Input::open(const std::string& p_name, ImageSpec& p_spec)
     m_filename = p_name;
     m_file     = Filesystem::fopen(m_filename, "rb");
     if (!m_file) {
-        error("Could not open file \"%s\"", m_filename.c_str());
+        errorf("Could not open file \"%s\"", m_filename);
         return false;
     }
 
     opj_dinfo_t* decompressor = create_decompressor();
     if (!decompressor) {
-        error("Could not create Jpeg2000 stream decompressor");
+        errorf("Could not create Jpeg2000 stream decompressor");
         close();
         return false;
     }
@@ -204,7 +204,7 @@ Jpeg2000Input::open(const std::string& p_name, ImageSpec& p_spec)
     opj_cio_t* cio = opj_cio_open((opj_common_ptr)decompressor, &fileContent[0],
                                   (int)fileLength);
     if (!cio) {
-        error("Could not open Jpeg2000 stream");
+        errorf("Could not open Jpeg2000 stream");
         opj_destroy_decompress(decompressor);
         close();
         return false;
@@ -214,7 +214,7 @@ Jpeg2000Input::open(const std::string& p_name, ImageSpec& p_spec)
     opj_cio_close(cio);
     opj_destroy_decompress(decompressor);
     if (!m_image) {
-        error("Could not decode Jpeg2000 stream");
+        errorf("Could not decode Jpeg2000 stream");
         close();
         return false;
     }
@@ -222,7 +222,7 @@ Jpeg2000Input::open(const std::string& p_name, ImageSpec& p_spec)
     // we support only one, three or four components in image
     const int channelCount = m_image->numcomps;
     if (channelCount != 1 && channelCount != 3 && channelCount != 4) {
-        error("Only images with one, three or four components are supported");
+        errorf("Only images with one, three or four components are supported");
         close();
         return false;
     }
@@ -361,7 +361,7 @@ Jpeg2000Input::create_decompressor()
 {
     int magic[3];
     if (::fread(&magic, 4, 3, m_file) != 3) {
-        error("Empty file \"%s\"", m_filename.c_str());
+        errorf("Empty file \"%s\"", m_filename);
         return NULL;
     }
     opj_dinfo_t* dinfo = NULL;

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -24,7 +24,7 @@ openjpeg_error_callback(const char* msg, void* data)
     if (ImageInput* input = (ImageInput*)data) {
         if (!msg || !msg[0])
             msg = "Unknown OpenJpeg error";
-        input->error("%s", msg);
+        input->errorf("%s", msg);
     }
 }
 
@@ -186,13 +186,13 @@ Jpeg2000Input::open(const std::string& p_name, ImageSpec& p_spec)
 {
     m_filename = p_name;
     if (!Filesystem::exists(m_filename)) {
-        error("Could not open file \"%s\"", m_filename);
+        errorf("Could not open file \"%s\"", m_filename);
         return false;
     }
 
     m_codec = create_decompressor();
     if (!m_codec) {
-        error("Could not create Jpeg2000 stream decompressor");
+        errorf("Could not create Jpeg2000 stream decompressor");
         close();
         return false;
     }
@@ -212,14 +212,14 @@ Jpeg2000Input::open(const std::string& p_name, ImageSpec& p_spec)
     m_stream = opj_stream_create_default_file_stream(m_file, true);
 #endif
     if (!m_stream) {
-        error("Could not open Jpeg2000 stream");
+        errorf("Could not open Jpeg2000 stream");
         close();
         return false;
     }
 
     ASSERT(m_image == NULL);
     if (!opj_read_header(m_stream, m_codec, &m_image)) {
-        error("Could not read Jpeg2000 header");
+        errorf("Could not read Jpeg2000 header");
         close();
         return false;
     }
@@ -231,7 +231,7 @@ Jpeg2000Input::open(const std::string& p_name, ImageSpec& p_spec)
     // we support only one, three or four components in image
     const int channelCount = m_image->numcomps;
     if (channelCount != 1 && channelCount != 3 && channelCount != 4) {
-        error("Only images with one, three or four components are supported");
+        errorf("Only images with one, three or four components are supported");
         close();
         return false;
     }
@@ -373,7 +373,7 @@ Jpeg2000Input::create_decompressor()
     int magic[3];
     size_t r = Filesystem::read_bytes(m_filename, magic, sizeof(magic));
     if (r != 3 * sizeof(int)) {
-        error("Empty file \"%s\"", m_filename);
+        errorf("Empty file \"%s\"", m_filename);
         return NULL;
     }
 

--- a/src/jpeg2000.imageio/jpeg2000output-v1.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output-v1.cpp
@@ -92,7 +92,7 @@ Jpeg2000Output::open(const std::string& name, const ImageSpec& spec,
                      OpenMode mode)
 {
     if (mode != Create) {
-        error("%s does not support subimages or MIP levels", format_name());
+        errorf("%s does not support subimages or MIP levels", format_name());
         return false;
     }
 
@@ -101,21 +101,21 @@ Jpeg2000Output::open(const std::string& name, const ImageSpec& spec,
 
     // Check for things this format doesn't support
     if (m_spec.width < 1 || m_spec.height < 1) {
-        error("Image resolution must be at least 1x1, you asked for %d x %d",
-              m_spec.width, m_spec.height);
+        errorf("Image resolution must be at least 1x1, you asked for %d x %d",
+               m_spec.width, m_spec.height);
         return false;
     }
     if (m_spec.depth < 1)
         m_spec.depth = 1;
     if (m_spec.depth > 1) {
-        error("%s does not support volume images (depth > 1)", format_name());
+        errorf("%s does not support volume images (depth > 1)", format_name());
         return false;
     }
 
     if (m_spec.nchannels != 1 && m_spec.nchannels != 3
         && m_spec.nchannels != 4) {
-        error("%s does not support %d-channel images\n", format_name(),
-              m_spec.nchannels);
+        errorf("%s does not support %d-channel images\n", format_name(),
+               m_spec.nchannels);
         return false;
     }
 
@@ -183,7 +183,7 @@ Jpeg2000Output::write_scanline(int y, int z, TypeDesc format, const void* data,
 {
     y -= m_spec.y;
     if (y > m_spec.height) {
-        error("Attempt to write too many scanlines to %s", m_filename);
+        errorf("Attempt to write too many scanlines to %s", m_filename);
         return false;
     }
 
@@ -280,7 +280,7 @@ Jpeg2000Output::save_image()
 
     size_t wb = fwrite(cio->buffer, 1, cio_tell(cio), m_file);
     if (wb != (size_t)cio_tell(cio)) {
-        error("Failed write jpeg2000::save_image (err: %d)", wb);
+        errorf("Failed write jpeg2000::save_image (err: %d)", wb);
         return false;
     }
 

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -20,7 +20,7 @@ openjpeg_error_callback(const char* msg, void* data)
     if (ImageOutput* input = (ImageOutput*)data) {
         if (!msg || !msg[0])
             msg = "Unknown OpenJpeg error";
-        input->error("%s", msg);
+        input->errorf("%s", msg);
     }
 }
 
@@ -126,7 +126,7 @@ Jpeg2000Output::open(const std::string& name, const ImageSpec& spec,
                      OpenMode mode)
 {
     if (mode != Create) {
-        error("%s does not support subimages or MIP levels", format_name());
+        errorf("%s does not support subimages or MIP levels", format_name());
         return false;
     }
 
@@ -135,21 +135,21 @@ Jpeg2000Output::open(const std::string& name, const ImageSpec& spec,
 
     // Check for things this format doesn't support
     if (m_spec.width < 1 || m_spec.height < 1) {
-        error("Image resolution must be at least 1x1, you asked for %d x %d",
-              m_spec.width, m_spec.height);
+        errorf("Image resolution must be at least 1x1, you asked for %d x %d",
+               m_spec.width, m_spec.height);
         return false;
     }
     if (m_spec.depth < 1)
         m_spec.depth = 1;
     if (m_spec.depth > 1) {
-        error("%s does not support volume images (depth > 1)", format_name());
+        errorf("%s does not support volume images (depth > 1)", format_name());
         return false;
     }
 
     if (m_spec.nchannels != 1 && m_spec.nchannels != 3
         && m_spec.nchannels != 4) {
-        error("%s does not support %d-channel images\n", format_name(),
-              m_spec.nchannels);
+        errorf("%s does not support %d-channel images\n", format_name(),
+               m_spec.nchannels);
         return false;
     }
 
@@ -217,7 +217,7 @@ Jpeg2000Output::write_scanline(int y, int z, TypeDesc format, const void* data,
 {
     y -= m_spec.y;
     if (y > m_spec.height) {
-        error("Attempt to write too many scanlines to %s", m_filename);
+        errorf("Attempt to write too many scanlines to %s", m_filename);
         return false;
     }
 
@@ -318,14 +318,14 @@ Jpeg2000Output::save_image()
     m_stream = opj_stream_create_default_file_stream(m_file, false);
 #endif
     if (!m_stream) {
-        error("Failed write jpeg2000::save_image");
+        errorf("Failed write jpeg2000::save_image");
         return false;
     }
 
     if (!opj_start_compress(m_codec, m_image, m_stream)
         || !opj_encode(m_codec, m_stream)
         || !opj_end_compress(m_codec, m_stream)) {
-        error("Failed write jpeg2000::save_image");
+        errorf("Failed write jpeg2000::save_image");
         return false;
     }
 

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1248,7 +1248,7 @@ ImageBufAlgo::colorconvert(ImageBuf& dst, const ImageBuf& src, string_view from,
         from = src.spec().get_string_attribute("oiio:Colorspace", "Linear");
     }
     if (from.empty() || to.empty()) {
-        dst.error("Unknown color space name");
+        dst.errorf("Unknown color space name");
         return false;
     }
     ColorProcessorHandle processor;
@@ -1262,10 +1262,10 @@ ImageBufAlgo::colorconvert(ImageBuf& dst, const ImageBuf& src, string_view from,
                                                       context_value);
         if (!processor) {
             if (colorconfig->error())
-                dst.error("%s", colorconfig->geterror());
+                dst.errorf("%s", colorconfig->geterror());
             else
-                dst.error("Could not construct the color transform %s -> %s",
-                          from, to);
+                dst.errorf("Could not construct the color transform %s -> %s",
+                           from, to);
             return false;
         }
     }
@@ -1289,7 +1289,7 @@ ImageBufAlgo::colorconvert(const ImageBuf& src, string_view from,
     bool ok = colorconvert(result, src, from, to, unpremult, context_key,
                            context_value, colorconfig, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::colorconvert() error");
+        result.errorf("ImageBufAlgo::colorconvert() error");
     return result;
 }
 
@@ -1324,7 +1324,7 @@ ImageBufAlgo::colormatrixtransform(const ImageBuf& src, const Imath::M44f& M,
     ImageBuf result;
     bool ok = colormatrixtransform(result, src, M, unpremult, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::colormatrixtransform() error");
+        result.errorf("ImageBufAlgo::colormatrixtransform() error");
     return result;
 }
 
@@ -1520,7 +1520,7 @@ ImageBufAlgo::colorconvert(const ImageBuf& src, const ColorProcessor* processor,
     ImageBuf result;
     bool ok = colorconvert(result, src, processor, unpremult, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::colorconvert() error");
+        result.errorf("ImageBufAlgo::colorconvert() error");
     return result;
 }
 
@@ -1540,7 +1540,7 @@ ImageBufAlgo::ociolook(ImageBuf& dst, const ImageBuf& src, string_view looks,
         to = src.spec().get_string_attribute("oiio:Colorspace", "Linear");
     }
     if (from.empty() || to.empty()) {
-        dst.error("Unknown color space name");
+        dst.errorf("Unknown color space name");
         return false;
     }
     ColorProcessorHandle processor;
@@ -1554,9 +1554,9 @@ ImageBufAlgo::ociolook(ImageBuf& dst, const ImageBuf& src, string_view looks,
                                                      key, value);
         if (!processor) {
             if (colorconfig->error())
-                dst.error("%s", colorconfig->geterror());
+                dst.errorf("%s", colorconfig->geterror());
             else
-                dst.error("Could not construct the color transform");
+                dst.errorf("Could not construct the color transform");
             return false;
         }
     }
@@ -1580,7 +1580,7 @@ ImageBufAlgo::ociolook(const ImageBuf& src, string_view looks, string_view from,
     bool ok = ociolook(result, src, looks, from, to, inverse, unpremult, key,
                        value, colorconfig, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::ociolook() error");
+        result.errorf("ImageBufAlgo::ociolook() error");
     return result;
 }
 
@@ -1607,16 +1607,16 @@ ImageBufAlgo::ociodisplay(ImageBuf& dst, const ImageBuf& src,
                                                    linearspace);
         }
         if (from.empty()) {
-            dst.error("Unknown color space name");
+            dst.errorf("Unknown color space name");
             return false;
         }
         processor = colorconfig->createDisplayTransform(display, view, from,
                                                         looks, key, value);
         if (!processor) {
             if (colorconfig->error())
-                dst.error("%s", colorconfig->geterror());
+                dst.errorf("%s", colorconfig->geterror());
             else
-                dst.error("Could not construct the color transform");
+                dst.errorf("Could not construct the color transform");
             return false;
         }
     }
@@ -1638,7 +1638,7 @@ ImageBufAlgo::ociodisplay(const ImageBuf& src, string_view display,
     bool ok = ociodisplay(result, src, display, view, from, looks, unpremult,
                           key, value, colorconfig, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::ociodisplay() error");
+        result.errorf("ImageBufAlgo::ociodisplay() error");
     return result;
 }
 
@@ -1651,7 +1651,7 @@ ImageBufAlgo::ociofiletransform(ImageBuf& dst, const ImageBuf& src,
 {
     pvt::LoggedTimer logtime("IBA::ociofiletransform");
     if (name.empty()) {
-        dst.error("Unknown filetransform name");
+        dst.errorf("Unknown filetransform name");
         return false;
     }
     ColorProcessorHandle processor;
@@ -1664,9 +1664,9 @@ ImageBufAlgo::ociofiletransform(ImageBuf& dst, const ImageBuf& src,
         processor = colorconfig->createFileTransform(name, inverse);
         if (!processor) {
             if (colorconfig->error())
-                dst.error("%s", colorconfig->geterror());
+                dst.errorf("%s", colorconfig->geterror());
             else
-                dst.error("Could not construct the color transform");
+                dst.errorf("Could not construct the color transform");
             return false;
         }
     }
@@ -1689,7 +1689,7 @@ ImageBufAlgo::ociofiletransform(const ImageBuf& src, string_view name,
     bool ok = ociofiletransform(result, src, name, inverse, unpremult,
                                 colorconfig, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::ociofiletransform() error");
+        result.errorf("ImageBufAlgo::ociofiletransform() error");
     return result;
 }
 

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -871,12 +871,12 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
     if (m_spec.deep) {
         auto input = ImageInput::open(m_name.string(), m_configspec.get());
         if (!input) {
-            error("%s", OIIO::geterror());
+            errorf("%s", OIIO::geterror());
             return false;
         }
         input->threads(threads());  // Pass on our thread policy
         if (!input->read_native_deep_image(subimage, miplevel, m_deepdata)) {
-            error("%s", input->geterror());
+            errorf("%s", input->geterror());
             return false;
         }
         m_spec         = m_nativespec;  // Deep images always use native data
@@ -982,11 +982,11 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
                 m_pixels_valid = true;
             } else {
                 m_pixels_valid = false;
-                error("%s", in->geterror());
+                errorf("%s", in->geterror());
             }
         } else {
             m_pixels_valid = false;
-            error("%s", OIIO::geterror());
+            errorf("%s", OIIO::geterror());
         }
         return m_pixels_valid;
     }
@@ -1001,7 +1001,7 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
         m_pixels_valid = true;
     } else {
         m_pixels_valid = false;
-        error("%s", m_imagecache->geterror());
+        errorf("%s", m_imagecache->geterror());
     }
 
     return m_pixels_valid;
@@ -1144,7 +1144,7 @@ ImageBuf::write(ImageOutput* out, ProgressCallback progress_callback,
         }
     }
     if (!ok)
-        error("%s", out->geterror());
+        errorf("%s", out->geterror());
     return ok;
 }
 
@@ -1158,7 +1158,7 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
     string_view filename   = _filename.size() ? _filename : name();
     string_view fileformat = _fileformat.size() ? _fileformat : filename;
     if (filename.size() == 0) {
-        error("ImageBuf::write() called with no filename");
+        errorf("ImageBuf::write() called with no filename");
         return false;
     }
     m_impl->validate_pixels();
@@ -1172,7 +1172,7 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
         m_impl->read(subimage(), miplevel(), 0, -1, true /*force*/,
                      spec().format, nullptr, nullptr);
         if (storage() != LOCALBUFFER) {
-            error("ImageBuf overwriting %s but could not force read", name());
+            errorf("ImageBuf overwriting %s but could not force read", name());
             return false;
         }
     }
@@ -1190,7 +1190,7 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
 
     auto out = ImageOutput::create(fileformat.c_str(), "" /* searchpath */);
     if (!out) {
-        error("%s", geterror());
+        errorf("%s", geterror());
         return false;
     }
     out->threads(threads());  // Pass on our thread policy
@@ -1233,7 +1233,7 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
     }
 
     if (!out->open(filename.c_str(), newspec)) {
-        error("%s", out->geterror());
+        errorf("%s", out->geterror());
         return false;
     }
     if (!write(out.get(), progress_callback, progress_callback_data))
@@ -1968,7 +1968,7 @@ ImageBuf::set_pixels(ROI roi, TypeDesc format, const void* data,
                      stride_t xstride, stride_t ystride, stride_t zstride)
 {
     if (!initialized()) {
-        error("Cannot set_pixels() on an uninitialized ImageBuf");
+        errorf("Cannot set_pixels() on an uninitialized ImageBuf");
         return false;
     }
     bool ok;
@@ -2504,7 +2504,7 @@ ImageBufImpl::retile(int x, int y, int z, ImageCache::Tile*& tile,
         if (!tile) {
             // Even though tile is NULL, ensure valid black pixel data
             std::string e = m_imagecache->geterror();
-            error("%s", e.size() ? e : "unspecified ImageCache error");
+            errorf("%s", e.size() ? e : "unspecified ImageCache error");
             return &m_blackpixel[0];
         }
     }

--- a/src/libOpenImageIO/imagebufalgo_addsub.cpp
+++ b/src/libOpenImageIO/imagebufalgo_addsub.cpp
@@ -135,7 +135,7 @@ ImageBufAlgo::add(ImageBuf& dst, Image_or_Const A_, Image_or_Const B_, ROI roi,
         return ok;
     }
     // Remaining cases: error
-    dst.error("ImageBufAlgo::add(): at least one argument must be an image");
+    dst.errorf("ImageBufAlgo::add(): at least one argument must be an image");
     return false;
 }
 
@@ -147,7 +147,7 @@ ImageBufAlgo::add(Image_or_Const A, Image_or_Const B, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = add(result, A, B, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::add() error");
+        result.errorf("ImageBufAlgo::add() error");
     return result;
 }
 
@@ -228,7 +228,7 @@ ImageBufAlgo::sub(ImageBuf& dst, Image_or_Const A_, Image_or_Const B_, ROI roi,
         return ok;
     }
     // Remaining cases: error
-    dst.error("ImageBufAlgo::sub(): at least one argument must be an image");
+    dst.errorf("ImageBufAlgo::sub(): at least one argument must be an image");
     return false;
 }
 
@@ -240,7 +240,7 @@ ImageBufAlgo::sub(Image_or_Const A, Image_or_Const B, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = sub(result, A, B, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::sub() error");
+        result.errorf("ImageBufAlgo::sub() error");
     return result;
 }
 

--- a/src/libOpenImageIO/imagebufalgo_channels.cpp
+++ b/src/libOpenImageIO/imagebufalgo_channels.cpp
@@ -64,13 +64,13 @@ ImageBufAlgo::channels(ImageBuf& dst, const ImageBuf& src, int nchannels,
     pvt::LoggedTimer logtime("IBA::channels");
     // Not intended to create 0-channel images.
     if (nchannels <= 0) {
-        dst.error("%d-channel images not supported", nchannels);
+        dst.errorf("%d-channel images not supported", nchannels);
         return false;
     }
     // If we dont have a single source channel,
     // hard to know how big to make the additional channels
     if (src.spec().nchannels == 0) {
-        dst.error("%d-channel images not supported", src.spec().nchannels);
+        dst.errorf("%d-channel images not supported", src.spec().nchannels);
         return false;
     }
 
@@ -192,7 +192,7 @@ ImageBufAlgo::channels(const ImageBuf& src, int nchannels,
     bool ok = channels(result, src, nchannels, channelorder, channelvalues,
                        newchannelnames, shuffle_channel_names, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::channels() error");
+        result.errorf("ImageBufAlgo::channels() error");
     return result;
 }
 
@@ -285,7 +285,7 @@ ImageBufAlgo::channel_append(const ImageBuf& A, const ImageBuf& B, ROI roi,
     ImageBuf result;
     bool ok = channel_append(result, A, B, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("channel_append error");
+        result.errorf("channel_append error");
     return result;
 }
 

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -195,7 +195,7 @@ ImageBufAlgo::computePixelStats(const ImageBuf& src, ROI roi, int nthreads)
         roi.chend = std::min(roi.chend, src.nchannels());
     int nchannels = src.spec().nchannels;
     if (nchannels == 0) {
-        src.error("%d-channel images not supported", nchannels);
+        src.errorf("%d-channel images not supported", nchannels);
         return stats;
     }
 
@@ -343,7 +343,7 @@ ImageBufAlgo::compare(const ImageBuf& A, const ImageBuf& B, float failthresh,
 
     // Deep and non-deep images cannot be compared
     if (B.deep() != A.deep()) {
-        A.error("deep and non-deep images cannot be compared");
+        A.errorf("deep and non-deep images cannot be compared");
         return result;
     }
 
@@ -608,7 +608,7 @@ ImageBufAlgo::color_count(const ImageBuf& src, imagesize_t* count, int ncolors,
     roi.chend = std::min(roi.chend, src.nchannels());
 
     if (color.size() < ncolors * src.nchannels()) {
-        src.error(
+        src.errorf(
             "ImageBufAlgo::color_count: not enough room in 'color' array");
         return false;
     }
@@ -883,7 +883,7 @@ histogram_impl(const ImageBuf& src, int channel, std::vector<imagesize_t>& hist,
 {
     // Double check A's type.
     if (src.spec().format != BaseTypeFromC<Atype>::value) {
-        src.error("Unsupported pixel data format '%s'", src.spec().format);
+        src.errorf("Unsupported pixel data format '%s'", src.spec().format);
         return false;
     }
 
@@ -928,20 +928,20 @@ ImageBufAlgo::histogram(const ImageBuf& src, int channel, int bins, float min,
 
     // Sanity checks
     if (src.nchannels() == 0) {
-        src.error("Input image must have at least 1 channel");
+        src.errorf("Input image must have at least 1 channel");
         return h;
     }
     if (channel < 0 || channel >= src.nchannels()) {
-        src.error("Invalid channel %d for input image with channels 0 to %d",
-                  channel, src.nchannels() - 1);
+        src.errorf("Invalid channel %d for input image with channels 0 to %d",
+                   channel, src.nchannels() - 1);
         return h;
     }
     if (bins < 1) {
-        src.error("The number of bins must be at least 1");
+        src.errorf("The number of bins must be at least 1");
         return h;
     }
     if (max <= min) {
-        src.error("Invalid range, min must be strictly smaller than max");
+        src.errorf("Invalid range, min must be strictly smaller than max");
         return h;
     }
 
@@ -980,7 +980,7 @@ histogram_impl_old(const ImageBuf& A, int channel,
 {
     // Double check A's type.
     if (A.spec().format != BaseTypeFromC<Atype>::value) {
-        A.error("Unsupported pixel data format '%s'", A.spec().format);
+        A.errorf("Unsupported pixel data format '%s'", A.spec().format);
         return false;
     }
 
@@ -1024,28 +1024,28 @@ ImageBufAlgo::histogram(const ImageBuf& A, int channel,
 {
     pvt::LoggedTimer logtimer("IBA::histogram");
     if (A.spec().format != TypeFloat) {
-        A.error("Unsupported pixel data format '%s'", A.spec().format);
+        A.errorf("Unsupported pixel data format '%s'", A.spec().format);
         return false;
     }
 
     if (A.nchannels() == 0) {
-        A.error("Input image must have at least 1 channel");
+        A.errorf("Input image must have at least 1 channel");
         return false;
     }
 
     if (channel < 0 || channel >= A.nchannels()) {
-        A.error("Invalid channel %d for input image with channels 0 to %d",
-                channel, A.nchannels() - 1);
+        A.errorf("Invalid channel %d for input image with channels 0 to %d",
+                 channel, A.nchannels() - 1);
         return false;
     }
 
     if (bins < 1) {
-        A.error("The number of bins must be at least 1");
+        A.errorf("The number of bins must be at least 1");
         return false;
     }
 
     if (max <= min) {
-        A.error("Invalid range, min must be strictly smaller than max");
+        A.errorf("Invalid range, min must be strictly smaller than max");
         return false;
     }
 
@@ -1069,7 +1069,7 @@ ImageBufAlgo::histogram_draw(ImageBuf& R,
     // Fail if there are no bins to draw.
     int bins = histogram.size();
     if (bins == 0) {
-        R.error("There are no bins to draw, the histogram is empty");
+        R.errorf("There are no bins to draw, the histogram is empty");
         return false;
     }
 

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -249,7 +249,7 @@ ImageBufAlgo::copy(const ImageBuf& src, TypeDesc convert, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = copy(result, src, convert, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::copy() error");
+        result.errorf("ImageBufAlgo::copy() error");
     return result;
 }
 
@@ -303,7 +303,7 @@ ImageBufAlgo::crop(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = crop(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::crop() error");
+        result.errorf("ImageBufAlgo::crop() error");
     return result;
 }
 
@@ -334,7 +334,7 @@ ImageBufAlgo::cut(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = cut(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::cut() error");
+        result.errorf("ImageBufAlgo::cut() error");
     return result;
 }
 
@@ -393,7 +393,7 @@ ImageBufAlgo::circular_shift(const ImageBuf& src, int xshift, int yshift,
     bool ok = circular_shift(result, src, xshift, yshift, zshift, roi,
                              nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::circular_shift() error");
+        result.errorf("ImageBufAlgo::circular_shift() error");
     return result;
 }
 

--- a/src/libOpenImageIO/imagebufalgo_deep.cpp
+++ b/src/libOpenImageIO/imagebufalgo_deep.cpp
@@ -104,13 +104,13 @@ ImageBufAlgo::flatten(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
                  IBAprep_SUPPORT_DEEP | IBAprep_DEEP_MIXED))
         return false;
     if (dst.spec().deep) {
-        dst.error("Cannot flatten to a deep image");
+        dst.errorf("Cannot flatten to a deep image");
         return false;
     }
 
     const DeepData* dd = src.deepdata();
     if (dd->AR_channel() < 0 || dd->AG_channel() < 0 || dd->AB_channel() < 0) {
-        dst.error("No alpha channel could be identified");
+        dst.errorf("No alpha channel could be identified");
         return false;
     }
 
@@ -128,7 +128,7 @@ ImageBufAlgo::flatten(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = flatten(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::flatten error");
+        result.errorf("ImageBufAlgo::flatten error");
     return result;
 }
 
@@ -173,7 +173,7 @@ ImageBufAlgo::deepen(ImageBuf& dst, const ImageBuf& src, float zvalue, ROI roi,
                  IBAprep_SUPPORT_DEEP | IBAprep_DEEP_MIXED))
         return false;
     if (!dst.deep()) {
-        dst.error("Cannot deepen to a flat image");
+        dst.errorf("Cannot deepen to a flat image");
         return false;
     }
 
@@ -232,7 +232,7 @@ ImageBufAlgo::deepen(const ImageBuf& src, float zvalue, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = deepen(result, src, zvalue, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::deepen error");
+        result.errorf("ImageBufAlgo::deepen error");
     return result;
 }
 
@@ -245,14 +245,14 @@ ImageBufAlgo::deep_merge(ImageBuf& dst, const ImageBuf& A, const ImageBuf& B,
     pvt::LoggedTimer logtime("IBA::deep_merge");
     if (!A.deep() || !B.deep()) {
         // For some reason, we were asked to merge a flat image.
-        dst.error("deep_merge can only be performed on deep images");
+        dst.errorf("deep_merge can only be performed on deep images");
         return false;
     }
     if (!IBAprep(roi, &dst, &A, &B, NULL,
                  IBAprep_SUPPORT_DEEP | IBAprep_REQUIRE_MATCHING_CHANNELS))
         return false;
     if (!dst.deep()) {
-        dst.error("Cannot deep_merge to a flat image");
+        dst.errorf("Cannot deep_merge to a flat image");
         return false;
     }
 
@@ -356,7 +356,7 @@ ImageBufAlgo::deep_merge(const ImageBuf& A, const ImageBuf& B,
     ImageBuf result;
     bool ok = deep_merge(result, A, B, occlusion_cull, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::deep_merge error");
+        result.errorf("ImageBufAlgo::deep_merge error");
     return result;
 }
 
@@ -368,13 +368,13 @@ ImageBufAlgo::deep_holdout(ImageBuf& dst, const ImageBuf& src,
 {
     pvt::LoggedTimer logtime("IBA::deep_holdout");
     if (!src.deep() || !thresh.deep()) {
-        dst.error("deep_holdout can only be performed on deep images");
+        dst.errorf("deep_holdout can only be performed on deep images");
         return false;
     }
     if (!IBAprep(roi, &dst, &src, &thresh, NULL, IBAprep_SUPPORT_DEEP))
         return false;
     if (!dst.deep()) {
-        dst.error("Cannot deep_holdout into a flat image");
+        dst.errorf("Cannot deep_holdout into a flat image");
         return false;
     }
 
@@ -439,7 +439,7 @@ ImageBufAlgo::deep_holdout(const ImageBuf& src, const ImageBuf& thresh, ROI roi,
     ImageBuf result;
     bool ok = deep_holdout(result, src, thresh, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::deep_holdout error");
+        result.errorf("ImageBufAlgo::deep_holdout error");
     return result;
 }
 

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -149,7 +149,7 @@ ImageBufAlgo::fill(cspan<float> pixel, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = fill(result, pixel, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("fill error");
+        result.errorf("fill error");
     return result;
 }
 
@@ -160,7 +160,7 @@ ImageBufAlgo::fill(cspan<float> top, cspan<float> bottom, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = fill(result, top, bottom, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("fill error");
+        result.errorf("fill error");
     return result;
 }
 
@@ -174,7 +174,7 @@ ImageBufAlgo::fill(cspan<float> topleft, cspan<float> topright,
     bool ok = fill(result, topleft, topright, bottomleft, bottomright, roi,
                    nthreads);
     if (!ok && !result.has_error())
-        result.error("fill error");
+        result.errorf("fill error");
     return result;
 }
 
@@ -201,7 +201,7 @@ ImageBufAlgo::zero(ROI roi, int nthreads)
     ImageBuf result;
     bool ok = zero(result, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("zero error");
+        result.errorf("zero error");
     return result;
 }
 
@@ -509,7 +509,7 @@ ImageBufAlgo::checker(int width, int height, int depth, cspan<float> color1,
     bool ok = checker(result, width, height, depth, color1, color2, xoffset,
                       yoffset, zoffset, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("checker error");
+        result.errorf("checker error");
     return result;
 }
 
@@ -634,7 +634,7 @@ ImageBufAlgo::noise(ImageBuf& dst, string_view noisetype, float A, float B,
                                    roi, nthreads);
     } else {
         ok = false;
-        dst.error("noise", "unknown noise type \"%s\"", noisetype);
+        dst.errorf("noise", "unknown noise type \"%s\"", noisetype);
     }
     return ok;
 }
@@ -649,7 +649,7 @@ ImageBufAlgo::noise(string_view noisetype, float A, float B, bool mono,
     bool ok         = true;
     ok              = noise(result, noisetype, A, B, mono, seed, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("noise error");
+        result.errorf("noise error");
     return result;
 }
 
@@ -885,7 +885,7 @@ ImageBufAlgo::render_text(ImageBuf& R, int x, int y, string_view text,
 {
     pvt::LoggedTimer logtime("IBA::render_text");
     if (R.spec().depth > 1) {
-        R.error("ImageBufAlgo::render_text does not support volume images");
+        R.errorf("ImageBufAlgo::render_text does not support volume images");
         return false;
     }
 
@@ -897,7 +897,7 @@ ImageBufAlgo::render_text(ImageBuf& R, int x, int y, string_view text,
     bool ok = resolve_font(fontsize, font_, font);
     if (!ok) {
         std::string err = font.size() ? font : "Font error";
-        R.error("%s", err);
+        R.errorf("%s", err);
         return false;
     }
 
@@ -905,7 +905,7 @@ ImageBufAlgo::render_text(ImageBuf& R, int x, int y, string_view text,
     FT_Face face;  // handle to face object
     error = FT_New_Face(ft_library, font.c_str(), 0 /* face index */, &face);
     if (error) {
-        R.error("Could not set font face to \"%s\"", font);
+        R.errorf("Could not set font face to \"%s\"", font);
         return false;  // couldn't open the face
     }
 
@@ -913,7 +913,7 @@ ImageBufAlgo::render_text(ImageBuf& R, int x, int y, string_view text,
                                fontsize /*height*/);
     if (error) {
         FT_Done_Face(face);
-        R.error("Could not set font size to %d", fontsize);
+        R.errorf("Could not set font size to %d", fontsize);
         return false;  // couldn't set the character size
     }
 
@@ -1007,7 +1007,7 @@ ImageBufAlgo::render_text(ImageBuf& R, int x, int y, string_view text,
     return true;
 
 #else
-    R.error("OpenImageIO was not compiled with FreeType for font rendering");
+    R.errorf("OpenImageIO was not compiled with FreeType for font rendering");
     return false;  // Font rendering not supported
 #endif
 }

--- a/src/libOpenImageIO/imagebufalgo_mad.cpp
+++ b/src/libOpenImageIO/imagebufalgo_mad.cpp
@@ -153,14 +153,14 @@ ImageBufAlgo::mad(ImageBuf& dst, Image_or_Const A_, Image_or_Const B_,
     // Get pointers to any image. At least one of A or B must be an image.
     const ImageBuf *A = A_.imgptr(), *B = B_.imgptr(), *C = C_.imgptr();
     if (!A && !B) {
-        dst.error(
+        dst.errorf(
             "ImageBufAlgo::mad(): at least one of the first two arguments must be an image");
         return false;
     }
     // All of the arguments that are images need to be initialized
     if ((A && !A->initialized()) || (B && !B->initialized())
         || (C && !C->initialized())) {
-        dst.error("Uninitialized input image");
+        dst.errorf("Uninitialized input image");
         return false;
     }
 
@@ -228,7 +228,7 @@ ImageBufAlgo::mad(Image_or_Const A, Image_or_Const B, Image_or_Const C, ROI roi,
     ImageBuf result;
     bool ok = mad(result, A, B, C, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::mad() error");
+        result.errorf("ImageBufAlgo::mad() error");
     return result;
 }
 
@@ -248,7 +248,7 @@ ImageBufAlgo::invert(const ImageBuf& A, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = invert(result, A, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("invert error");
+        result.errorf("invert error");
     return result;
 }
 

--- a/src/libOpenImageIO/imagebufalgo_muldiv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_muldiv.cpp
@@ -119,7 +119,7 @@ ImageBufAlgo::mul(ImageBuf& dst, Image_or_Const A_, Image_or_Const B_, ROI roi,
         return ok;
     }
     // Remaining cases: error
-    dst.error("ImageBufAlgo::mul(): at least one argument must be an image");
+    dst.errorf("ImageBufAlgo::mul(): at least one argument must be an image");
     return false;
 }
 
@@ -131,7 +131,7 @@ ImageBufAlgo::mul(Image_or_Const A, Image_or_Const B, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = mul(result, A, B, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::mul() error");
+        result.errorf("ImageBufAlgo::mul() error");
     return result;
 }
 
@@ -199,7 +199,7 @@ ImageBufAlgo::div(ImageBuf& dst, Image_or_Const A_, Image_or_Const B_, ROI roi,
         return ok;
     }
     // Remaining cases: error
-    dst.error("ImageBufAlgo::div(): at least one argument must be an image");
+    dst.errorf("ImageBufAlgo::div(): at least one argument must be an image");
     return false;
 }
 
@@ -211,7 +211,7 @@ ImageBufAlgo::div(Image_or_Const A, Image_or_Const B, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = div(result, A, B, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::div() error");
+        result.errorf("ImageBufAlgo::div() error");
     return result;
 }
 

--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -54,7 +54,7 @@ ImageBufAlgo::from_IplImage(const IplImage* ipl, TypeDesc convert)
     pvt::LoggedTimer logtime("IBA::from_IplImage");
     ImageBuf dst;
     if (!ipl) {
-        dst.error("Passed NULL source IplImage");
+        dst.errorf("Passed NULL source IplImage");
         return dst;
     }
 #ifdef USE_OPENCV
@@ -67,7 +67,7 @@ ImageBufAlgo::from_IplImage(const IplImage* ipl, TypeDesc convert)
     case int(IPL_DEPTH_32F): srcformat = TypeDesc::FLOAT; break;
     case int(IPL_DEPTH_64F): srcformat = TypeDesc::DOUBLE; break;
     default:
-        dst.error("Unsupported IplImage depth %d", (int)ipl->depth);
+        dst.errorf("Unsupported IplImage depth %d", (int)ipl->depth);
         return dst;
     }
 
@@ -78,7 +78,7 @@ ImageBufAlgo::from_IplImage(const IplImage* ipl, TypeDesc convert)
 
     if (ipl->dataOrder != IPL_DATA_ORDER_PIXEL) {
         // We don't handle separate color channels, and OpenCV doesn't either
-        dst.error("Unsupported IplImage data order %d", (int)ipl->dataOrder);
+        dst.errorf("Unsupported IplImage data order %d", (int)ipl->dataOrder);
         return dst;
     }
 
@@ -112,7 +112,7 @@ ImageBufAlgo::from_IplImage(const IplImage* ipl, TypeDesc convert)
     // probably templated by type.
 
 #else
-    dst.error(
+    dst.errorf(
         "fromIplImage not supported -- no OpenCV support at compile time");
 #endif
 
@@ -263,7 +263,7 @@ ImageBufAlgo::from_OpenCV(const cv::Mat& mat, TypeDesc convert, ROI roi,
     }
 
 #else
-    dst.error(
+    dst.errorf(
         "from_OpenCV() not supported -- no OpenCV support at compile time");
 #endif
 
@@ -389,12 +389,12 @@ ImageBufAlgo::capture_image(int cameranum, TypeDesc convert)
         lock_guard lock(opencv_mutex);
         auto cvcam = cameras[cameranum];
         if (!cvcam) {
-            dst.error("Could not create a capture camera (OpenCV error)");
+            dst.errorf("Could not create a capture camera (OpenCV error)");
             return dst;  // failed somehow
         }
         (*cvcam) >> frame;
         if (frame.empty()) {
-            dst.error("Could not cvQueryFrame (OpenCV error)");
+            dst.errorf("Could not cvQueryFrame (OpenCV error)");
             return dst;  // failed somehow
         }
     }
@@ -415,7 +415,7 @@ ImageBufAlgo::capture_image(int cameranum, TypeDesc convert)
         dst.specmod().attribute("DateTime", datetime);
     }
 #else
-    dst.error(
+    dst.errorf(
         "capture_image not supported -- no OpenCV support at compile time");
 #endif
     return dst;

--- a/src/libOpenImageIO/imagebufalgo_orient.cpp
+++ b/src/libOpenImageIO/imagebufalgo_orient.cpp
@@ -128,7 +128,7 @@ ImageBufAlgo::flip(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = flip(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::flip() error");
+        result.errorf("ImageBufAlgo::flip() error");
     return result;
 }
 
@@ -140,7 +140,7 @@ ImageBufAlgo::flop(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = flop(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::flop() error");
+        result.errorf("ImageBufAlgo::flop() error");
     return result;
 }
 
@@ -326,7 +326,7 @@ ImageBufAlgo::rotate90(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = rotate90(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::rotate90() error");
+        result.errorf("ImageBufAlgo::rotate90() error");
     return result;
 }
 
@@ -338,7 +338,7 @@ ImageBufAlgo::rotate180(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = rotate180(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::rotate180() error");
+        result.errorf("ImageBufAlgo::rotate180() error");
     return result;
 }
 
@@ -350,7 +350,7 @@ ImageBufAlgo::rotate270(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = rotate270(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::rotate270() error");
+        result.errorf("ImageBufAlgo::rotate270() error");
     return result;
 }
 
@@ -371,7 +371,7 @@ ImageBufAlgo::reorient(ImageBuf& dst, const ImageBuf& src, int nthreads)
         if (ok)
             ok = ImageBufAlgo::flop(dst, tmp);
         else
-            dst.error("%s", tmp.geterror());
+            dst.errorf("%s", tmp.geterror());
         break;
     case 6: ok = ImageBufAlgo::rotate90(dst, src); break;
     case 7:
@@ -379,7 +379,7 @@ ImageBufAlgo::reorient(ImageBuf& dst, const ImageBuf& src, int nthreads)
         if (ok)
             ok = ImageBufAlgo::rotate90(dst, tmp);
         else
-            dst.error("%s", tmp.geterror());
+            dst.errorf("%s", tmp.geterror());
         break;
     case 8: ok = ImageBufAlgo::rotate270(dst, src); break;
     }
@@ -395,7 +395,7 @@ ImageBufAlgo::reorient(const ImageBuf& src, int nthreads)
     ImageBuf result;
     bool ok = reorient(result, src, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::reorient() error");
+        result.errorf("ImageBufAlgo::reorient() error");
     return result;
 }
 
@@ -459,7 +459,7 @@ ImageBufAlgo::transpose(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = transpose(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::transpose() error");
+        result.errorf("ImageBufAlgo::transpose() error");
     return result;
 }
 

--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -76,7 +76,7 @@ ImageBufAlgo::clamp(const ImageBuf& src, cspan<float> min, cspan<float> max,
     ImageBuf result;
     bool ok = clamp(result, src, min, max, clampalpha01, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::clamp error");
+        result.errorf("ImageBufAlgo::clamp error");
     return result;
 }
 
@@ -161,7 +161,7 @@ ImageBufAlgo::absdiff(ImageBuf& dst, Image_or_Const A_, Image_or_Const B_,
         return ok;
     }
     // Remaining cases: error
-    dst.error(
+    dst.errorf(
         "ImageBufAlgo::absdiff(): at least one argument must be an image");
     return false;
 }
@@ -174,7 +174,7 @@ ImageBufAlgo::absdiff(Image_or_Const A, Image_or_Const B, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = absdiff(result, A, B, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::absdiff() error");
+        result.errorf("ImageBufAlgo::absdiff() error");
     return result;
 }
 
@@ -195,7 +195,7 @@ ImageBufAlgo::abs(const ImageBuf& A, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = abs(result, A, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("abs error");
+        result.errorf("abs error");
     return result;
 }
 
@@ -236,7 +236,7 @@ ImageBufAlgo::pow(const ImageBuf& A, cspan<float> b, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = pow(result, A, b, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("pow error");
+        result.errorf("pow error");
     return result;
 }
 
@@ -293,7 +293,7 @@ ImageBufAlgo::channel_sum(const ImageBuf& src, cspan<float> weights, ROI roi,
     ImageBuf result;
     bool ok = channel_sum(result, src, weights, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("channel_sum error");
+        result.errorf("channel_sum error");
     return result;
 }
 
@@ -519,7 +519,7 @@ ImageBufAlgo::rangecompress(const ImageBuf& src, bool useluma, ROI roi,
     ImageBuf result;
     bool ok = rangecompress(result, src, useluma, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::rangecompress() error");
+        result.errorf("ImageBufAlgo::rangecompress() error");
     return result;
 }
 
@@ -532,7 +532,7 @@ ImageBufAlgo::rangeexpand(const ImageBuf& src, bool useluma, ROI roi,
     ImageBuf result;
     bool ok = rangeexpand(result, src, useluma, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::rangeexpand() error");
+        result.errorf("ImageBufAlgo::rangeexpand() error");
     return result;
 }
 
@@ -609,7 +609,7 @@ ImageBufAlgo::unpremult(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = unpremult(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::unpremult() error");
+        result.errorf("ImageBufAlgo::unpremult() error");
     return result;
 }
 
@@ -676,7 +676,7 @@ ImageBufAlgo::premult(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = premult(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::premult() error");
+        result.errorf("ImageBufAlgo::premult() error");
     return result;
 }
 
@@ -804,7 +804,7 @@ ImageBufAlgo::contrast_remap(const ImageBuf& src, cspan<float> black,
     bool ok = contrast_remap(result, src, black, white, min, max, scontrast,
                              sthresh, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::contrast_remap error");
+        result.errorf("ImageBufAlgo::contrast_remap error");
     return result;
 }
 
@@ -843,11 +843,11 @@ ImageBufAlgo::color_map(ImageBuf& dst, const ImageBuf& src, int srcchannel,
 {
     pvt::LoggedTimer logtime("IBA::color_map");
     if (srcchannel >= src.nchannels()) {
-        dst.error("invalid source channel selected");
+        dst.errorf("invalid source channel selected");
         return false;
     }
     if (nknots < 2 || knots.size() < (nknots * channels)) {
-        dst.error("not enough knot values supplied");
+        dst.errorf("not enough knot values supplied");
         return false;
     }
     if (!roi.defined())
@@ -877,7 +877,7 @@ ImageBufAlgo::color_map(const ImageBuf& src, int srcchannel, int nknots,
     bool ok = color_map(result, src, srcchannel, nknots, channels, knots, roi,
                         nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::color_map() error");
+        result.errorf("ImageBufAlgo::color_map() error");
     return result;
 }
 
@@ -971,7 +971,7 @@ ImageBufAlgo::color_map(ImageBuf& dst, const ImageBuf& src, int srcchannel,
 {
     pvt::LoggedTimer logtime("IBA::color_map");
     if (srcchannel >= src.nchannels()) {
-        dst.error("invalid source channel selected");
+        dst.errorf("invalid source channel selected");
         return false;
     }
     cspan<float> knots;
@@ -1000,7 +1000,7 @@ ImageBufAlgo::color_map(ImageBuf& dst, const ImageBuf& src, int srcchannel,
                                    0.75f, 0.0f,  1.0f, 1.0f,  1.0f };
         knots                  = cspan<float>(k);
     } else {
-        dst.error("Unknown map name \"%s\"", mapname);
+        dst.errorf("Unknown map name \"%s\"", mapname);
         return false;
     }
     return color_map(dst, src, srcchannel, int(knots.size() / 3), 3, knots, roi,
@@ -1015,7 +1015,7 @@ ImageBufAlgo::color_map(const ImageBuf& src, int srcchannel,
     ImageBuf result;
     bool ok = color_map(result, src, srcchannel, mapname, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::color_map() error");
+        result.errorf("ImageBufAlgo::color_map() error");
     return result;
 }
 
@@ -1188,7 +1188,7 @@ ImageBufAlgo::fixNonFinite(ImageBuf& dst, const ImageBuf& src,
         && mode != ImageBufAlgo::NONFINITE_BOX3
         && mode != ImageBufAlgo::NONFINITE_ERROR) {
         // Something went wrong
-        dst.error("fixNonFinite: unknown repair mode");
+        dst.errorf("fixNonFinite: unknown repair mode");
         return false;
     }
 
@@ -1218,7 +1218,7 @@ ImageBufAlgo::fixNonFinite(ImageBuf& dst, const ImageBuf& src,
     // pixel values, so the copy was enough.
 
     if (mode == ImageBufAlgo::NONFINITE_ERROR && *pixelsFixed) {
-        dst.error("Nonfinite pixel values found");
+        dst.errorf("Nonfinite pixel values found");
         ok = false;
     }
     return ok;
@@ -1233,7 +1233,7 @@ ImageBufAlgo::fixNonFinite(const ImageBuf& src, NonFiniteFixMode mode,
     ImageBuf result;
     bool ok = fixNonFinite(result, src, mode, pixelsFixed, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::fixNonFinite() error");
+        result.errorf("ImageBufAlgo::fixNonFinite() error");
     return result;
 }
 
@@ -1400,7 +1400,7 @@ ImageBufAlgo::over(const ImageBuf& A, const ImageBuf& B, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = over(result, A, B, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::over() error");
+        result.errorf("ImageBufAlgo::over() error");
     return result;
 }
 
@@ -1431,7 +1431,7 @@ ImageBufAlgo::zover(const ImageBuf& A, const ImageBuf& B, bool z_zeroisinf,
     ImageBuf result;
     bool ok = zover(result, A, B, z_zeroisinf, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::zover() error");
+        result.errorf("ImageBufAlgo::zover() error");
     return result;
 }
 

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -447,7 +447,7 @@ get_resize_filter(string_view filtername, float fwidth, ImageBuf& dst,
         }
     }
     if (!filter) {
-        dst.error("Filter \"%s\" not recognized", filtername);
+        dst.errorf("Filter \"%s\" not recognized", filtername);
     }
     return filter;
 }
@@ -521,7 +521,7 @@ ImageBufAlgo::resize(const ImageBuf& src, Filter2D* filter, ROI roi,
     ImageBuf result;
     bool ok = resize(result, src, filter, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::resize() error");
+        result.errorf("ImageBufAlgo::resize() error");
     return result;
 }
 
@@ -533,7 +533,7 @@ ImageBufAlgo::resize(const ImageBuf& src, string_view filtername,
     ImageBuf result;
     bool ok = resize(result, src, filtername, filterwidth, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::resize() error");
+        result.errorf("ImageBufAlgo::resize() error");
     return result;
 }
 
@@ -672,7 +672,7 @@ ImageBufAlgo::fit(const ImageBuf& src, Filter2D* filter, bool exact, ROI roi,
     ImageBuf result;
     bool ok = fit(result, src, filter, exact, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::fit() error");
+        result.errorf("ImageBufAlgo::fit() error");
     return result;
 }
 
@@ -684,7 +684,7 @@ ImageBufAlgo::fit(const ImageBuf& src, string_view filtername,
     ImageBuf result;
     bool ok = fit(result, src, filtername, filterwidth, exact, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::fit() error");
+        result.errorf("ImageBufAlgo::fit() error");
     return result;
 }
 
@@ -814,7 +814,7 @@ ImageBufAlgo::resample(const ImageBuf& src, bool interpolate, ROI roi,
     ImageBuf result;
     bool ok = resample(result, src, interpolate, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::resample() error");
+        result.errorf("ImageBufAlgo::resample() error");
     return result;
 }
 
@@ -931,7 +931,7 @@ ImageBufAlgo::warp(ImageBuf& dst, const ImageBuf& src, const Imath::M33f& M,
         }
     }
     if (!filter) {
-        dst.error("Filter \"%s\" not recognized", filtername);
+        dst.errorf("Filter \"%s\" not recognized", filtername);
         return false;
     }
 
@@ -948,7 +948,7 @@ ImageBufAlgo::warp(const ImageBuf& src, const Imath::M33f& M,
     ImageBuf result;
     bool ok = warp(result, src, M, filter, recompute_roi, wrap, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::warp() error");
+        result.errorf("ImageBufAlgo::warp() error");
     return result;
 }
 
@@ -964,7 +964,7 @@ ImageBufAlgo::warp(const ImageBuf& src, const Imath::M33f& M,
     bool ok = warp(result, src, M, filtername, filterwidth, recompute_roi, wrap,
                    roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::warp() error");
+        result.errorf("ImageBufAlgo::warp() error");
     return result;
 }
 
@@ -1041,7 +1041,7 @@ ImageBufAlgo::rotate(const ImageBuf& src, float angle, float center_x,
     bool ok = rotate(result, src, angle, center_x, center_y, filter,
                      recompute_roi, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::rotate() error");
+        result.errorf("ImageBufAlgo::rotate() error");
     return result;
 }
 
@@ -1056,7 +1056,7 @@ ImageBufAlgo::rotate(const ImageBuf& src, float angle, float center_x,
     bool ok = rotate(result, src, angle, center_x, center_y, filtername,
                      filterwidth, recompute_roi, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::rotate() error");
+        result.errorf("ImageBufAlgo::rotate() error");
     return result;
 }
 
@@ -1069,7 +1069,7 @@ ImageBufAlgo::rotate(const ImageBuf& src, float angle, Filter2D* filter,
     ImageBuf result;
     bool ok = rotate(result, src, angle, filter, recompute_roi, roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::rotate() error");
+        result.errorf("ImageBufAlgo::rotate() error");
     return result;
 }
 
@@ -1084,7 +1084,7 @@ ImageBufAlgo::rotate(const ImageBuf& src, float angle, string_view filtername,
     bool ok = rotate(result, src, angle, filtername, filterwidth, recompute_roi,
                      roi, nthreads);
     if (!ok && !result.has_error())
-        result.error("ImageBufAlgo::rotate() error");
+        result.errorf("ImageBufAlgo::rotate() error");
     return result;
 }
 

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -953,7 +953,7 @@ ImageInput::read_native_deep_image(int subimage, int miplevel,
         return false;
 
     if (spec.depth > 1) {
-        error(
+        errorf(
             "read_native_deep_image is not supported for volume (3D) images.");
         return false;
         // FIXME? - not implementing 3D deep images for now.  The only

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -184,7 +184,7 @@ bool
 ImageOutput::write_deep_image(const DeepData& deepdata)
 {
     if (m_spec.depth > 1) {
-        error("write_deep_image is not supported for volume (3D) images.");
+        errorf("write_deep_image is not supported for volume (3D) images.");
         return false;
         // FIXME? - not implementing 3D deep images for now.  The only
         // format that supports deep images at this time is OpenEXR, and
@@ -501,7 +501,7 @@ bool
 ImageOutput::copy_image(ImageInput* in)
 {
     if (!in) {
-        error("copy_image: no input supplied");
+        errorf("copy_image: no input supplied");
         return false;
     }
 
@@ -510,9 +510,9 @@ ImageOutput::copy_image(ImageInput* in)
     if (inspec.width != spec().width || inspec.height != spec().height
         || inspec.depth != spec().depth
         || inspec.nchannels != spec().nchannels) {
-        error("Could not copy %d x %d x %d channels to %d x %d x %d channels",
-              inspec.width, inspec.height, inspec.nchannels, spec().width,
-              spec().height, spec().nchannels);
+        errorf("Could not copy %d x %d x %d channels to %d x %d x %d channels",
+               inspec.width, inspec.height, inspec.nchannels, spec().width,
+               spec().height, spec().nchannels);
         return false;
     }
 
@@ -532,7 +532,7 @@ ImageOutput::copy_image(ImageInput* in)
         if (ok)
             ok = write_deep_image(deepdata);
         else
-            error("%s", in->geterror());  // copy err from in to out
+            errorf("%s", in->geterror());  // copy err from in to out
         return ok;
     }
 
@@ -546,7 +546,7 @@ ImageOutput::copy_image(ImageInput* in)
     if (ok)
         ok = write_image(format, &pixels[0]);
     else
-        error("%s", in->geterror());  // copy err from in to out
+        errorf("%s", in->geterror());  // copy err from in to out
     return ok;
 }
 
@@ -614,7 +614,7 @@ ImageOutput::copy_tile_to_image_buffer(int x, int y, int z, TypeDesc format,
                                        void* image_buffer, TypeDesc buf_format)
 {
     if (!m_spec.tile_width || !m_spec.tile_height) {
-        error("Called write_tile for non-tiled image.");
+        errorf("Called write_tile for non-tiled image.");
         return false;
     }
     const ImageSpec& spec(this->spec());

--- a/src/libutil/argparse.cpp
+++ b/src/libutil/argparse.cpp
@@ -112,6 +112,11 @@ public:
     {
         m_errmessage = Strutil::sprintf(fmt, args...);
     }
+    template<typename... Args>
+    void errorf(const char* fmt, const Args&... args) const
+    {
+        m_errmessage = Strutil::sprintf(fmt, args...);
+    }
 };
 
 
@@ -375,7 +380,7 @@ ArgParse::Impl::parse(int xargc, const char** xargv)
                 argname.erase(colon, std::string::npos);
             ArgOption* option = find_option(argname.c_str());
             if (option == NULL) {
-                error("Invalid option \"%s\"", m_argv[i]);
+                errorf("Invalid option \"%s\"", m_argv[i]);
                 return -1;
             }
 
@@ -389,9 +394,9 @@ ArgParse::Impl::parse(int xargc, const char** xargv)
                 ASSERT(option->is_regular());
                 for (int j = 0; j < option->parameter_count(); j++) {
                     if (j + i + 1 >= m_argc) {
-                        error("Missing parameter %d from option "
-                              "\"%s\"",
-                              j + 1, option->name());
+                        errorf("Missing parameter %d from option "
+                               "\"%s\"",
+                               j + 1, option->name());
                         return -1;
                     }
                     option->set_parameter(j, m_argv[i + j + 1]);
@@ -410,9 +415,9 @@ ArgParse::Impl::parse(int xargc, const char** xargv)
             else if (m_global)
                 m_global->invoke_callback(1, m_argv + i);
             else {
-                error("Argument \"%s\" does not have an associated "
-                      "option",
-                      m_argv[i]);
+                errorf("Argument \"%s\" does not have an associated "
+                       "option",
+                       m_argv[i]);
                 return -1;
             }
         }
@@ -440,7 +445,7 @@ ArgParse::options(const char* intro, ...)
     m_impl->m_intro += intro;
     for (const char* cur = va_arg(ap, char*); cur; cur = va_arg(ap, char*)) {
         if (m_impl->find_option(cur) && strcmp(cur, "<SEPARATOR>")) {
-            m_impl->error("Option \"%s\" is multiply defined", cur);
+            m_impl->errorf("Option \"%s\" is multiply defined", cur);
             return -1;
         }
 

--- a/src/openvdb.imageio/openvdbinput.cpp
+++ b/src/openvdb.imageio/openvdbinput.cpp
@@ -320,13 +320,13 @@ openVDB(const std::string& filename, const ImageInput* errReport)
             return file;
 
     } catch (const std::exception& e) {
-        errReport->error("Could not open '%s': %s", filename, e.what());
+        errReport->errorf("Could not open '%s': %s", filename, e.what());
         return nullptr;
     } catch (...) {
         errhint = "Unknown exception thrown";
     }
 
-    errReport->error("Could not open '%s': %s", filename, errhint);
+    errReport->errorf("Could not open '%s': %s", filename, errhint);
     return nullptr;
 }
 
@@ -530,7 +530,7 @@ OpenVDBInput::open(const std::string& filename, ImageSpec& newspec)
         }
     } catch (const std::exception& e) {
         init();  // Reset to initial state
-        error("Could not open '%s': %s", filename, e.what());
+        errorf("Could not open '%s': %s", filename, e.what());
         return false;
     }
     m_name       = filename;

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -73,7 +73,7 @@ private:
         DASSERT(pngoutput);
         size_t bytes = pngoutput->m_io->write(data, length);
         if (bytes != length) {
-            pngoutput->error("Write error");
+            pngoutput->errorf("Write error");
             pngoutput->m_err = true;
         }
     }
@@ -287,7 +287,7 @@ PNGOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
         swap_endian((unsigned short*)data, m_spec.width * m_spec.nchannels);
 
     if (!PNG_pvt::write_row(m_png, (png_byte*)data)) {
-        error("PNG library error");
+        errorf("PNG library error");
         return false;
     }
 

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -302,7 +302,7 @@ PNMInput::read_file_scanline(void* data, int y)
         return good;
 
     } catch (const std::exception& e) {
-        error("PNM exception: %s", e.what());
+        errorf("PNM exception: %s", e.what());
         return false;
     }
 }
@@ -405,7 +405,7 @@ PNMInput::read_file_header()
             return true;
         }
     } catch (const std::exception& e) {
-        error("PNM exception: %s", e.what());
+        errorf("PNM exception: %s", e.what());
         return false;
     }
 }

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -131,7 +131,7 @@ PNMOutput::open(const std::string& name, const ImageSpec& userspec,
                 OpenMode mode)
 {
     if (mode != Create) {
-        error("%s does not support subimages or MIP levels", format_name());
+        errorf("%s does not support subimages or MIP levels", format_name());
         return false;
     }
 
@@ -144,8 +144,8 @@ PNMOutput::open(const std::string& name, const ImageSpec& userspec,
                    : 0;
 
     if (m_spec.nchannels != 1 && m_spec.nchannels != 3) {
-        error("%s does not support %d-channel images\n", format_name(),
-              m_spec.nchannels);
+        errorf("%s does not support %d-channel images\n", format_name(),
+               m_spec.nchannels);
         return false;
     }
 

--- a/src/ptex.imageio/ptexinput.cpp
+++ b/src/ptex.imageio/ptexinput.cpp
@@ -106,7 +106,7 @@ PtexInput::open(const std::string& name, ImageSpec& newspec)
             m_ptex->release();
             m_ptex = NULL;
         }
-        error("%s", perr.c_str());
+        errorf("%s", perr);
         return false;
     }
 
@@ -145,7 +145,7 @@ PtexInput::seek_subimage(int subimage, int miplevel)
     case Ptex::dt_uint16: format = TypeDesc::UINT16; break;
     case Ptex::dt_half: format = TypeDesc::HALF; break;
     case Ptex::dt_float: format = TypeDesc::FLOAT; break;
-    default: error("Ptex with unknown data format"); return false;
+    default: errorf("Ptex with unknown data format"); return false;
     }
 
     m_spec = ImageSpec(std::max(1, m_faceres.u() >> miplevel),

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -353,16 +353,16 @@ RawInput::open_raw(bool unpack, const std::string& name,
 
     int ret;
     if ((ret = m_processor->open_file(name.c_str())) != LIBRAW_SUCCESS) {
-        error("Could not open file \"%s\", %s", m_filename,
-              libraw_strerror(ret));
+        errorf("Could not open file \"%s\", %s", m_filename,
+               libraw_strerror(ret));
         return false;
     }
 
     ASSERT(!m_unpacked);
     if (unpack) {
         if ((ret = m_processor->unpack()) != LIBRAW_SUCCESS) {
-            error("Could not unpack \"%s\", %s", m_filename,
-                  libraw_strerror(ret));
+            errorf("Could not unpack \"%s\", %s", m_filename,
+                   libraw_strerror(ret));
             return false;
         }
     }
@@ -500,7 +500,7 @@ RawInput::open_raw(bool unpack, const std::string& name,
     float exposure = config.get_float_attribute("raw:Exposure", -1.0f);
     if (exposure >= 0.0f) {
         if (exposure < 0.25f || exposure > 8.0f) {
-            error("raw:Exposure invalid value. range 0.25f - 8.0f");
+            errorf("raw:Exposure invalid value. range 0.25f - 8.0f");
             return false;
         }
         m_processor->imgdata.params.exp_correc
@@ -515,7 +515,7 @@ RawInput::open_raw(bool unpack, const std::string& name,
     int highlight_mode = config.get_int_attribute("raw:HighlightMode", 0);
     if (highlight_mode != 0) {
         if (highlight_mode < 0 || highlight_mode > 9) {
-            error("raw:HighlightMode invalid value. range 0-9");
+            errorf("raw:HighlightMode invalid value. range 0-9");
             return false;
         }
         m_processor->imgdata.params.highlight = highlight_mode;
@@ -559,8 +559,8 @@ RawInput::open_raw(bool unpack, const std::string& name,
             libraw_decoder_info_t decoder_info;
             m_processor->get_decoder_info(&decoder_info);
             if (!(decoder_info.decoder_flags & LIBRAW_DECODER_FLATFIELD)) {
-                error("Unable to extract unbayered data from file \"%s\"",
-                      name.c_str());
+                errorf("Unable to extract unbayered data from file \"%s\"",
+                       name);
                 return false;
             }
 
@@ -578,7 +578,7 @@ RawInput::open_raw(bool unpack, const std::string& name,
             m_spec.erase_attribute("raw:Colorspace");
             m_spec.erase_attribute("raw:Exposure");
         } else {
-            error("raw:Demosaic set to unknown value");
+            errorf("raw:Demosaic set to unknown value");
             return false;
         }
         // Set the attribute in the output spec
@@ -1130,23 +1130,23 @@ RawInput::process()
     if (!m_image) {
         int ret = m_processor->dcraw_process();
         if (ret != LIBRAW_SUCCESS) {
-            error("Processing image failed, %s", libraw_strerror(ret));
+            errorf("Processing image failed, %s", libraw_strerror(ret));
             return false;
         }
 
         m_image = m_processor->dcraw_make_mem_image(&ret);
         if (!m_image) {
-            error("LibRaw failed to create in memory image");
+            errorf("LibRaw failed to create in memory image");
             return false;
         }
 
         if (m_image->type != LIBRAW_IMAGE_BITMAP) {
-            error("LibRaw did not return expected image type");
+            errorf("LibRaw did not return expected image type");
             return false;
         }
 
         if (m_image->colors != 3) {
-            error("LibRaw did not return 3 channel image");
+            errorf("LibRaw did not return 3 channel image");
             return false;
         }
     }

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -71,7 +71,7 @@ private:
     {
         size_t n = ::fwrite(buf, itemsize, nitems, m_file);
         if (n != nitems)
-            error("Write error: wrote %d records of %d", (int)n, (int)nitems);
+            errorf("Write error: wrote %d records of %d", (int)n, (int)nitems);
         return n == nitems;
     }
 
@@ -148,7 +148,7 @@ RLAOutput::open(const std::string& name, const ImageSpec& userspec,
                 OpenMode mode)
 {
     if (mode != Create) {
-        error("%s does not support subimages or MIP levels", format_name());
+        errorf("%s does not support subimages or MIP levels", format_name());
         return false;
         // FIXME -- the RLA format supports subimages, but our writer
         // doesn't.  I'm not sure if it's worth worrying about for an
@@ -169,12 +169,12 @@ RLAOutput::open(const std::string& name, const ImageSpec& userspec,
 
     // Check for things this format doesn't support
     if (m_spec.width < 1 || m_spec.height < 1) {
-        error("Image resolution must be at least 1x1, you asked for %d x %d",
-              m_spec.width, m_spec.height);
+        errorf("Image resolution must be at least 1x1, you asked for %d x %d",
+               m_spec.width, m_spec.height);
         return false;
     }
     if (m_spec.width > 65535 || m_spec.height > 65535) {
-        error(
+        errorf(
             "Image resolution %d x %d too large for RLA (maxiumum 65535x65535)",
             m_spec.width, m_spec.height);
         return false;
@@ -183,7 +183,7 @@ RLAOutput::open(const std::string& name, const ImageSpec& userspec,
     if (m_spec.depth < 1)
         m_spec.depth = 1;
     else if (m_spec.depth > 1) {
-        error("%s does not support volume images (depth > 1)", format_name());
+        errorf("%s does not support volume images (depth > 1)", format_name());
         return false;
     }
 

--- a/src/sgi.imageio/sgi_pvt.h
+++ b/src/sgi.imageio/sgi_pvt.h
@@ -108,7 +108,7 @@ private:
     {
         size_t n = ::fread(buf, itemsize, nitems, m_fd);
         if (n != nitems)
-            error("Read error");
+            errorf("Read error");
         return n == nitems;
     }
 };
@@ -147,8 +147,8 @@ private:
     {
         size_t n = std::fwrite(buf, itemsize, nitems, m_fd);
         if (n != nitems)
-            error("Error writing \"%s\" (wrote %d/%d records)", m_filename,
-                  (int)n, (int)nitems);
+            errorf("Error writing \"%s\" (wrote %d/%d records)", m_filename,
+                   (int)n, (int)nitems);
         return n == nitems;
     }
 };

--- a/src/sgi.imageio/sgiinput.cpp
+++ b/src/sgi.imageio/sgiinput.cpp
@@ -53,7 +53,7 @@ SgiInput::open(const std::string& name, ImageSpec& spec)
 
     m_fd = Filesystem::fopen(m_filename, "rb");
     if (!m_fd) {
-        error("Could not open file \"%s\"", name.c_str());
+        errorf("Could not open file \"%s\"", name);
         return false;
     }
 
@@ -61,8 +61,8 @@ SgiInput::open(const std::string& name, ImageSpec& spec)
         return false;
 
     if (m_sgi_header.magic != sgi_pvt::SGI_MAGIC) {
-        error("\"%s\" is not a SGI file, magic number doesn't match",
-              m_filename.c_str());
+        errorf("\"%s\" is not a SGI file, magic number doesn't match",
+               m_filename);
         close();
         return false;
     }
@@ -83,14 +83,14 @@ SgiInput::open(const std::string& name, ImageSpec& spec)
         nchannels = m_sgi_header.zsize;
         break;
     default:
-        error("Bad dimension: %d", m_sgi_header.dimension);
+        errorf("Bad dimension: %d", m_sgi_header.dimension);
         close();
         return false;
     }
 
     if (m_sgi_header.colormap == sgi_pvt::COLORMAP
         || m_sgi_header.colormap == sgi_pvt::SCREEN) {
-        error("COLORMAP and SCREEN color map types aren't supported");
+        errorf("COLORMAP and SCREEN color map types aren't supported");
         close();
         return false;
     }
@@ -248,7 +248,7 @@ SgiInput::uncompress_rle_channel(int scanline_off, int scanline_len,
         }
     }
     if (i != scanline_len || limit != 0) {
-        error("Corrupt RLE data");
+        errorf("Corrupt RLE data");
         return false;
     }
 

--- a/src/sgi.imageio/sgioutput.cpp
+++ b/src/sgi.imageio/sgioutput.cpp
@@ -32,7 +32,7 @@ bool
 SgiOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
 {
     if (mode != Create) {
-        error("%s does not support subimages or MIP levels", format_name());
+        errorf("%s does not support subimages or MIP levels", format_name());
         return false;
     }
 
@@ -201,7 +201,7 @@ SgiOutput::create_and_write_header()
         || !fwrite(&sgi_header.pixmax) || !fwrite(&sgi_header.dummy)
         || !fwrite(sgi_header.imagename, 1, 80) || !fwrite(&sgi_header.colormap)
         || !fwrite(dummy, 404, 1)) {
-        error("Error writing to \"%s\"", m_filename);
+        errorf("Error writing to \"%s\"", m_filename);
         return false;
     }
     return true;

--- a/src/socket.imageio/socketinput.cpp
+++ b/src/socket.imageio/socketinput.cpp
@@ -98,10 +98,10 @@ SocketInput::read_native_scanline(int subimage, int miplevel, int y, int z,
         boost::asio::read(socket, buffer(reinterpret_cast<char*>(data),
                                          m_spec.scanline_bytes()));
     } catch (boost::system::system_error& err) {
-        error("Error while reading: %s", err.what());
+        errorf("Error while reading: %s", err.what());
         return false;
     } catch (...) {
-        error("Error while reading: unknown exception");
+        errorf("Error while reading: unknown exception");
         return false;
     }
 
@@ -121,10 +121,10 @@ SocketInput::read_native_tile(int subimage, int miplevel, int x, int y, int z,
         boost::asio::read(socket, buffer(reinterpret_cast<char*>(data),
                                          m_spec.tile_bytes()));
     } catch (boost::system::system_error& err) {
-        error("Error while reading: %s", err.what());
+        errorf("Error while reading: %s", err.what());
         return false;
     } catch (...) {
-        error("Error while reading: unknown exception");
+        errorf("Error while reading: unknown exception");
         return false;
     }
 
@@ -151,7 +151,7 @@ SocketInput::accept_connection(const std::string& name)
     rest_args["host"] = socket_pvt::default_host;
 
     if (!Strutil::get_rest_arguments(name, baseurl, rest_args)) {
-        error("Invalid 'open ()' argument: %s", name.c_str());
+        errorf("Invalid 'open ()' argument: %s", name);
         return false;
     }
 
@@ -162,10 +162,10 @@ SocketInput::accept_connection(const std::string& name)
             new ip::tcp::acceptor(io, ip::tcp::endpoint(ip::tcp::v4(), port)));
         acceptor->accept(socket);
     } catch (boost::system::system_error& err) {
-        error("Error while accepting: %s", err.what());
+        errorf("Error while accepting: %s", err.what());
         return false;
     } catch (...) {
-        error("Error while accepting: unknown exception");
+        errorf("Error while accepting: unknown exception");
         return false;
     }
 
@@ -189,10 +189,10 @@ SocketInput::get_spec_from_client(ImageSpec& spec)
         spec.from_xml(spec_xml);
         delete[] spec_xml;
     } catch (boost::system::system_error& err) {
-        error("Error while get_spec_from_client: %s", err.what());
+        errorf("Error while get_spec_from_client: %s", err.what());
         return false;
     } catch (...) {
-        error("Error while get_spec_from_client: unknown exception");
+        errorf("Error while get_spec_from_client: unknown exception");
         return false;
     }
 

--- a/src/socket.imageio/socketoutput.cpp
+++ b/src/socket.imageio/socketoutput.cpp
@@ -66,10 +66,10 @@ SocketOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
     try {
         socket_pvt::socket_write(socket, format, data, m_spec.scanline_bytes());
     } catch (boost::system::system_error& err) {
-        error("Error while writing: %s", err.what());
+        errorf("Error while writing: %s", err.what());
         return false;
     } catch (...) {
-        error("Error while writing: unknown exception");
+        errorf("Error while writing: unknown exception");
         return false;
     }
 
@@ -89,10 +89,10 @@ SocketOutput::write_tile(int x, int y, int z, TypeDesc format, const void* data,
     try {
         socket_pvt::socket_write(socket, format, data, m_spec.tile_bytes());
     } catch (boost::system::system_error& err) {
-        error("Error while writing: %s", err.what());
+        errorf("Error while writing: %s", err.what());
         return false;
     } catch (...) {
-        error("Error while writing: unknown exception");
+        errorf("Error while writing: unknown exception");
         return false;
     }
 
@@ -130,10 +130,10 @@ SocketOutput::send_spec_to_server(const ImageSpec& spec)
                                   sizeof(boost::uint32_t)));
         boost::asio::write(socket, buffer(spec_xml.c_str(), spec_xml.length()));
     } catch (boost::system::system_error& err) {
-        error("Error while send_spec_to_server: %s", err.what());
+        errorf("Error while send_spec_to_server: %s", err.what());
         return false;
     } catch (...) {
-        error("Error while send_spec_to_server: unknown exception");
+        errorf("Error while send_spec_to_server: unknown exception");
         return false;
     }
 
@@ -151,7 +151,7 @@ SocketOutput::connect_to_server(const std::string& name)
     rest_args["host"] = socket_pvt::default_host;
 
     if (!Strutil::get_rest_arguments(name, baseurl, rest_args)) {
-        error("Invalid 'open ()' argument: %s", name.c_str());
+        errorf("Invalid 'open ()' argument: %s", name);
         return false;
     }
 
@@ -168,14 +168,14 @@ SocketOutput::connect_to_server(const std::string& name)
             socket.connect(*endpoint_iterator++, err);
         }
         if (err) {
-            error("Host \"%s\" not found", rest_args["host"].c_str());
+            errorf("Host \"%s\" not found", rest_args["host"]);
             return false;
         }
     } catch (boost::system::system_error& err) {
-        error("Error while connecting: %s", err.what());
+        errorf("Error while connecting: %s", err.what());
         return false;
     } catch (...) {
-        error("Error while connecting: unknown exception");
+        errorf("Error while connecting: unknown exception");
         return false;
     }
 

--- a/src/softimage.imageio/softimageinput.cpp
+++ b/src/softimage.imageio/softimageinput.cpp
@@ -85,22 +85,22 @@ SoftimageInput::open(const std::string& name, ImageSpec& spec)
 
     m_fd = Filesystem::fopen(m_filename, "rb");
     if (!m_fd) {
-        error("Could not open file \"%s\"", name.c_str());
+        errorf("Could not open file \"%s\"", name);
         return false;
     }
 
     // Try read the header
     if (!m_pic_header.read_header(m_fd)) {
-        error("\"%s\": failed to read header", m_filename.c_str());
+        errorf("\"%s\": failed to read header", m_filename);
         close();
         return false;
     }
 
     // Check whether it has the pic magic number
     if (m_pic_header.magic != 0x5380f634) {
-        error(
+        errorf(
             "\"%s\" is not a Softimage Pic file, magic number of 0x%X is not Pic",
-            m_filename.c_str(), m_pic_header.magic);
+            m_filename, m_pic_header.magic);
         close();
         return false;
     }
@@ -112,7 +112,7 @@ SoftimageInput::open(const std::string& name, ImageSpec& spec)
         // Read the next packet into curPacket and store it off
         if (fread(&curPacket, 1, sizeof(ChannelPacket), m_fd)
             != sizeof(ChannelPacket)) {
-            error("Unexpected end of file \"%s\".", m_filename.c_str());
+            errorf("Unexpected end of file \"%s\".", m_filename);
             close();
             return false;
         }
@@ -189,8 +189,7 @@ SoftimageInput::read_native_scanline(int subimage, int miplevel, int y, int z,
 
         // Let's seek to the scanline's data
         if (fsetpos(m_fd, &m_scanline_markers[y])) {
-            error("Failed to seek to scanline %d in \"%s\"", y,
-                  m_filename.c_str());
+            errorf("Failed to seek to scanline %d in \"%s\"", y, m_filename);
             close();
             return false;
         }
@@ -201,9 +200,9 @@ SoftimageInput::read_native_scanline(int subimage, int miplevel, int y, int z,
         if (m_scanline_markers.size() < m_pic_header.height) {
             if (fsetpos(m_fd,
                         &m_scanline_markers[m_scanline_markers.size() - 1])) {
-                error("Failed to restore to scanline %llu in \"%s\"",
-                      (long long unsigned int)m_scanline_markers.size() - 1,
-                      m_filename.c_str());
+                errorf("Failed to restore to scanline %llu in \"%s\"",
+                       (long long unsigned int)m_scanline_markers.size() - 1,
+                       m_filename);
                 close();
                 return false;
             }
@@ -236,24 +235,24 @@ SoftimageInput::read_next_scanline(void* data)
     for (auto& cp : m_channel_packets) {
         if (cp.type & UNCOMPRESSED) {
             if (!read_pixels_uncompressed(cp, data)) {
-                error("Failed to read uncompressed pixel data from \"%s\"",
-                      m_filename.c_str());
+                errorf("Failed to read uncompressed pixel data from \"%s\"",
+                       m_filename);
                 close();
                 return false;
             }
         } else if (cp.type & PURE_RUN_LENGTH) {
             if (!read_pixels_pure_run_length(cp, data)) {
-                error(
+                errorf(
                     "Failed to read pure run length encoded pixel data from \"%s\"",
-                    m_filename.c_str());
+                    m_filename);
                 close();
                 return false;
             }
         } else if (cp.type & MIXED_RUN_LENGTH) {
             if (!read_pixels_mixed_run_length(cp, data)) {
-                error(
+                errorf(
                     "Failed to read mixed run length encoded pixel data from \"%s\"",
-                    m_filename.c_str());
+                    m_filename);
                 close();
                 return false;
             }

--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -68,7 +68,7 @@ private:
     {
         size_t n = ::fread(buf, itemsize, nitems, m_file);
         if (n != nitems)
-            error("Read error");
+            errorf("Read error");
         return n == nitems;
     }
 };
@@ -105,7 +105,7 @@ TGAInput::open(const std::string& name, ImageSpec& newspec)
 
     m_file = Filesystem::fopen(name, "rb");
     if (!m_file) {
-        error("Could not open file \"%s\"", name.c_str());
+        errorf("Could not open file \"%s\"", name);
         return false;
     }
 
@@ -147,18 +147,18 @@ TGAInput::open(const std::string& name, ImageSpec& newspec)
 
     if (m_tga.bpp != 8 && m_tga.bpp != 15 && m_tga.bpp != 16 && m_tga.bpp != 24
         && m_tga.bpp != 32) {
-        error("Illegal pixel size: %d bits per pixel", m_tga.bpp);
+        errorf("Illegal pixel size: %d bits per pixel", m_tga.bpp);
         return false;
     }
 
     if (m_tga.type == TYPE_NODATA) {
-        error("Image with no data");
+        errorf("Image with no data");
         return false;
     }
     if (m_tga.type != TYPE_PALETTED && m_tga.type != TYPE_RGB
         && m_tga.type != TYPE_GRAY && m_tga.type != TYPE_PALETTED_RLE
         && m_tga.type != TYPE_RGB_RLE && m_tga.type != TYPE_GRAY_RLE) {
-        error("Illegal image type: %d", m_tga.type);
+        errorf("Illegal image type: %d", m_tga.type);
         return false;
     }
 
@@ -166,14 +166,14 @@ TGAInput::open(const std::string& name, ImageSpec& newspec)
         && (m_tga.type == TYPE_GRAY || m_tga.type == TYPE_GRAY_RLE)) {
         // it should be an error for TYPE_RGB* as well, but apparently some
         // *very* old TGAs can be this way, so we'll hack around it
-        error("Palette defined for grayscale image");
+        errorf("Palette defined for grayscale image");
         return false;
     }
 
     if (m_tga.cmap_type
         && (m_tga.cmap_size != 15 && m_tga.cmap_size != 16
             && m_tga.cmap_size != 24 && m_tga.cmap_size != 32)) {
-        error("Illegal palette entry size: %d bits", m_tga.cmap_size);
+        errorf("Illegal palette entry size: %d bits", m_tga.cmap_size);
         return false;
     }
 

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -76,7 +76,7 @@ private:
             return true;
         size_t n = std::fwrite(buf, itemsize, nitems, m_file);
         if (n != nitems)
-            error("Write error: wrote %d records of %d", (int)n, (int)nitems);
+            errorf("Write error: wrote %d records of %d", (int)n, (int)nitems);
         return n == nitems;
     }
 
@@ -146,7 +146,7 @@ TGAOutput::open(const std::string& name, const ImageSpec& userspec,
                 OpenMode mode)
 {
     if (mode != Create) {
-        error("%s does not support subimages or MIP levels", format_name());
+        errorf("%s does not support subimages or MIP levels", format_name());
         return false;
     }
 
@@ -155,20 +155,20 @@ TGAOutput::open(const std::string& name, const ImageSpec& userspec,
 
     // Check for things this format doesn't support
     if (m_spec.width < 1 || m_spec.height < 1) {
-        error("Image resolution must be at least 1x1, you asked for %d x %d",
-              m_spec.width, m_spec.height);
+        errorf("Image resolution must be at least 1x1, you asked for %d x %d",
+               m_spec.width, m_spec.height);
         return false;
     }
 
     if (m_spec.depth < 1)
         m_spec.depth = 1;
     else if (m_spec.depth > 1) {
-        error("TGA does not support volume images (depth > 1)");
+        errorf("TGA does not support volume images (depth > 1)");
         return false;
     }
 
     if (m_spec.nchannels < 1 || m_spec.nchannels > 4) {
-        error("TGA only supports 1-4 channels, not %d", m_spec.nchannels);
+        errorf("TGA only supports 1-4 channels, not %d", m_spec.nchannels);
         return false;
     }
 

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -50,24 +50,25 @@ WebpInput::open(const std::string& name, ImageSpec& spec)
 
     // Perform preliminary test on file type.
     if (!Filesystem::is_regular(m_filename)) {
-        error("Not a regular file \"%s\"", m_filename.c_str());
+        errorf("Not a regular file \"%s\"", m_filename);
         return false;
     }
 
     // Get file size and check we've got enough data to decode WebP.
     m_image_size = Filesystem::file_size(name);
     if (m_image_size == uint64_t(-1)) {
-        error("Failed to get size for \"%s\"", m_filename);
+        errorf("Failed to get size for \"%s\"", m_filename);
         return false;
     }
     if (m_image_size < 12) {
-        error("File size is less than WebP header for file \"%s\"", m_filename);
+        errorf("File size is less than WebP header for file \"%s\"",
+               m_filename);
         return false;
     }
 
     m_file = Filesystem::fopen(m_filename, "rb");
     if (!m_file) {
-        error("Could not open file \"%s\"", m_filename.c_str());
+        errorf("Could not open file \"%s\"", m_filename);
         return false;
     }
 
@@ -77,15 +78,15 @@ WebpInput::open(const std::string& name, ImageSpec& spec)
     size_t numRead = fread(&image_header[0], sizeof(uint8_t),
                            image_header.size(), m_file);
     if (numRead != image_header.size()) {
-        error("Read failure for header of \"%s\" (expected %d bytes, read %d)",
-              m_filename, image_header.size(), numRead);
+        errorf("Read failure for header of \"%s\" (expected %d bytes, read %d)",
+               m_filename, image_header.size(), numRead);
         close();
         return false;
     }
 
     int width = 0, height = 0;
     if (!WebPGetInfo(&image_header[0], image_header.size(), &width, &height)) {
-        error("%s is not a WebP image file", m_filename.c_str());
+        errorf("%s is not a WebP image file", m_filename);
         close();
         return false;
     }
@@ -97,8 +98,8 @@ WebpInput::open(const std::string& name, ImageSpec& spec)
     numRead = fread(&encoded_image[0], sizeof(uint8_t), encoded_image.size(),
                     m_file);
     if (numRead != encoded_image.size()) {
-        error("Read failure for \"%s\" (expected %d bytes, read %d)",
-              m_filename, encoded_image.size(), numRead);
+        errorf("Read failure for \"%s\" (expected %d bytes, read %d)",
+               m_filename, encoded_image.size(), numRead);
         close();
         return false;
     }
@@ -112,7 +113,7 @@ WebpInput::open(const std::string& name, ImageSpec& spec)
     if (!(m_decoded_image = WebPDecodeRGBA(&encoded_image[0],
                                            encoded_image.size(), &m_spec.width,
                                            &m_spec.height))) {
-        error("Couldn't decode %s", m_filename.c_str());
+        errorf("Couldn't decode %s", m_filename);
         close();
         return false;
     }

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -76,7 +76,7 @@ bool
 WebpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
 {
     if (mode != Create) {
-        error("%s does not support subimages or MIP levels", format_name());
+        errorf("%s does not support subimages or MIP levels", format_name());
         return false;
     }
 
@@ -85,8 +85,8 @@ WebpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
     m_spec     = spec;
 
     if (m_spec.nchannels != 3 && m_spec.nchannels != 4) {
-        error("%s does not support %d-channel images\n", format_name(),
-              m_spec.nchannels);
+        errorf("%s does not support %d-channel images\n", format_name(),
+               m_spec.nchannels);
         return false;
     }
 
@@ -97,7 +97,7 @@ WebpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
     }
 
     if (!WebPPictureInit(&m_webp_picture)) {
-        error("Couldn't initialize WebPPicture\n");
+        errorf("Couldn't initialize WebPPicture\n");
         close();
         return false;
     }
@@ -108,7 +108,7 @@ WebpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
     m_webp_picture.custom_ptr = (void*)m_file;
 
     if (!WebPConfigInit(&m_webp_config)) {
-        error("Couldn't initialize WebPPicture\n");
+        errorf("Couldn't initialize WebPPicture\n");
         close();
         return false;
     }
@@ -140,7 +140,7 @@ WebpOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
                            stride_t xstride)
 {
     if (y > m_spec.height) {
-        error("Attempt to write too many scanlines to %s", m_filename.c_str());
+        errorf("Attempt to write too many scanlines to %s", m_filename);
         close();
         return false;
     }
@@ -165,7 +165,7 @@ WebpOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
                                  m_scanline_size);
         }
         if (!WebPEncode(&m_webp_config, &m_webp_picture)) {
-            error("Failed to encode %s as WebP image", m_filename.c_str());
+            errorf("Failed to encode %s as WebP image", m_filename);
             close();
             return false;
         }

--- a/src/zfile.imageio/zfile.cpp
+++ b/src/zfile.imageio/zfile.cpp
@@ -175,7 +175,7 @@ ZfileInput::open(const std::string& name, ImageSpec& newspec)
     gzread(m_gz, &header, sizeof(header));
 
     if (header.magic != zfile_magic && header.magic != zfile_magic_endian) {
-        error("Not a valid Zfile");
+        errorf("Not a valid Zfile");
         return false;
     }
 
@@ -254,7 +254,7 @@ ZfileOutput::open(const std::string& name, const ImageSpec& userspec,
                   OpenMode mode)
 {
     if (mode != Create) {
-        error("%s does not support subimages or MIP levels", format_name());
+        errorf("%s does not support subimages or MIP levels", format_name());
         return false;
     }
 
@@ -265,8 +265,8 @@ ZfileOutput::open(const std::string& name, const ImageSpec& userspec,
 
     // Check for things this format doesn't support
     if (m_spec.width < 1 || m_spec.height < 1) {
-        error("Image resolution must be at least 1x1, you asked for %d x %d",
-              m_spec.width, m_spec.height);
+        errorf("Image resolution must be at least 1x1, you asked for %d x %d",
+               m_spec.width, m_spec.height);
         return false;
     }
     if (m_spec.width > 32767 || m_spec.height > 32767) {
@@ -277,12 +277,12 @@ ZfileOutput::open(const std::string& name, const ImageSpec& userspec,
     if (m_spec.depth < 1)
         m_spec.depth = 1;
     if (m_spec.depth > 1) {
-        error("%s does not support volume images (depth > 1)", format_name());
+        errorf("%s does not support volume images (depth > 1)", format_name());
         return false;
     }
 
     if (m_spec.nchannels != 1) {
-        error("Zfile only supports 1 channel, not %d", m_spec.nchannels);
+        errorf("Zfile only supports 1 channel, not %d", m_spec.nchannels);
         return false;
     }
 
@@ -323,7 +323,7 @@ ZfileOutput::open(const std::string& name, const ImageSpec& userspec,
         b = fwrite(&header, sizeof(header), 1, m_file);
     }
     if (!b) {
-        error("Failed write zfile::open (err: %d)", b);
+        errorf("Failed write zfile::open (err: %d)", b);
         return false;
     }
 
@@ -383,7 +383,7 @@ ZfileOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
     else {
         size_t b = fwrite(data, sizeof(float), m_spec.width, m_file);
         if (b != (size_t)m_spec.width) {
-            error("Failed write zfile::open (err: %d)", b);
+            errorf("Failed write zfile::open (err: %d)", b);
             return false;
         }
     }


### PR DESCRIPTION
A while back we added errorf() in various places, which henceforth
will be the place to do printf-style formatting, trying to migrate to
a point where the "non-f" error() will eventually follow std::format
(python-like) formatting codes. But for now, error() and errorf() do
the same thing, we will only change the meaning of error() down the
road when it's safe.

This patch just rounds up a lot more places in the internals where
we use error() and changed to errorf().

