### PR TITLE
Add Filesystem fseek & ftell, always are 64 bit offsets

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -189,6 +189,12 @@ OIIO_API std::string unique_path (string_view model="%%%%-%%%%-%%%%-%%%%");
 ///
 OIIO_API FILE *fopen (string_view path, string_view mode);
 
+/// Version of fseek that works with 64 bit offsets on all systems.
+OIIO_API int fseek (FILE *file, int64_t offset, int whence);
+
+/// Version of ftell that works with 64 bit offsets on all systems.
+OIIO_API int64_t ftell (FILE *file);
+
 /// Return the current (".") directory path.
 ///
 OIIO_API std::string current_path ();

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -430,6 +430,30 @@ Filesystem::fopen(string_view path, string_view mode)
 
 
 
+int
+Filesystem::fseek(FILE* file, int64_t offset, int whence)
+{
+#ifdef _MSC_VER
+    return _fseeki64(file, __int64(offset), whence);
+#else
+    return fseeko(file, offset, whence);
+#endif
+}
+
+
+
+int64_t
+Filesystem::ftell(FILE* file)
+{
+#ifdef _MSC_VER
+    return _ftelli64(file);
+#else
+    return ftello(file);
+#endif
+}
+
+
+
 void
 Filesystem::open(OIIO::ifstream& stream, string_view path,
                  std::ios_base::openmode mode)
@@ -491,11 +515,7 @@ Filesystem::read_bytes(string_view path, void* buffer, size_t n, size_t pos)
 {
     size_t ret = 0;
     if (FILE* file = Filesystem::fopen(path, "rb")) {
-#ifdef _MSC_VER
-        _fseeki64(file, __int64(pos), SEEK_SET);
-#else
-        fseeko(file, pos, SEEK_SET);
-#endif
+        Filesystem::fseek(file, pos, SEEK_SET);
         ret = fread(buffer, 1, n, file);
         fclose(file);
     }
@@ -883,10 +903,10 @@ Filesystem::IOFile::IOFile(FILE* file, Mode mode)
     , m_file(file)
 {
     if (m_mode == Read) {
-        m_pos = ftell(m_file);           // save old position
-        fseek(m_file, 0, SEEK_END);      // seek to end
-        m_size = size_t(ftell(m_file));  // size is end position
-        fseek(m_file, m_pos, SEEK_SET);  // restore old position
+        m_pos = Filesystem::ftell(m_file);           // save old position
+        Filesystem::fseek(m_file, 0, SEEK_END);      // seek to end
+        m_size = size_t(Filesystem::ftell(m_file));  // size is end position
+        Filesystem::fseek(m_file, m_pos, SEEK_SET);  // restore old position
     }
 }
 
@@ -912,11 +932,7 @@ Filesystem::IOFile::seek(int64_t offset)
     if (!m_file)
         return false;
     m_pos = offset;
-#ifdef _MSC_VER
-    return _fseeki64(m_file, __int64(offset), SEEK_SET) == 0;
-#else
-    return fseeko(m_file, offset, SEEK_SET) == 0;
-#endif
+    return Filesystem::fseek(m_file, offset, SEEK_SET) == 0;
 }
 
 size_t


### PR DESCRIPTION
These utility functions are natively 64 bits, so you don't need to
worry about what nonstandard functions to call. Prefer Filesystem::fseek
and ftell over std to guarantee safety for enormous files.

