### PR TITLE
upgrade to 3 channels when doing color conversions

### DIFF
--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1363,6 +1363,8 @@ colorconvert_impl(ImageBuf& R, const ImageBuf& A,
                         vfloat4 v(0.0f);
                         for (int c = 0; c < channelsToCopy; ++c)
                             v[c] = a[c];
+                        if (channelsToCopy == 1)
+                            v[2] = v[1] = v[0];
                         scanline[i] = v;
                     }
 

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1492,6 +1492,8 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
         }
 
         if (isConstantColor) {
+            if (constantColor.size() < 3)
+                constantColor.resize(3, constantColor[0]);
             if (!ImageBufAlgo::colorconvert(
                     &constantColor[0], static_cast<int>(constantColor.size()),
                     processor.get(), unpremult)) {
@@ -1502,6 +1504,8 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
         }
 
         if (compute_average_color) {
+            if (pixel_stats.avg.size() < 3)
+                pixel_stats.avg.resize(3, pixel_stats.avg[0]);
             if (!ImageBufAlgo::colorconvert(&pixel_stats.avg[0],
                                             static_cast<int>(
                                                 pixel_stats.avg.size()),


### PR DESCRIPTION
When color correcting single channel images, oiio just color corrects them as (y, 0, 0), it's better to use (y, y, y). We also fix a couple of spots in maketx with the same issue.