### PR TITLE
sgi: big file safety

### DIFF
--- a/src/sgi.imageio/sgiinput.cpp
+++ b/src/sgi.imageio/sgiinput.cpp
@@ -126,15 +126,15 @@ SgiInput::read_native_scanline(int subimage, int miplevel, int y, int z,
 
     y = m_spec.height - y - 1;
 
-    int bpc = m_sgi_header.bpc;
+    ptrdiff_t bpc = m_sgi_header.bpc;
     std::vector<std::vector<unsigned char>> channeldata(m_spec.nchannels);
     if (m_sgi_header.storage == sgi_pvt::RLE) {
         // reading and uncompressing first channel (red in RGBA images)
         for (int c = 0; c < m_spec.nchannels; ++c) {
-            int off = y
-                      + c * m_spec.height;  // offset for this scanline/channel
-            int scanline_offset = start_tab[off];
-            int scanline_length = length_tab[off];
+            // offset for this scanline/channel
+            ptrdiff_t off             = y + c * m_spec.height;
+            ptrdiff_t scanline_offset = start_tab[off];
+            ptrdiff_t scanline_length = length_tab[off];
             channeldata[c].resize(m_spec.width * bpc);
             uncompress_rle_channel(scanline_offset, scanline_length,
                                    &(channeldata[c][0]));
@@ -142,11 +142,11 @@ SgiInput::read_native_scanline(int subimage, int miplevel, int y, int z,
     } else {
         // non-RLE case -- just read directly into our channel data
         for (int c = 0; c < m_spec.nchannels; ++c) {
-            int off = y
-                      + c * m_spec.height;  // offset for this scanline/channel
-            int scanline_offset = sgi_pvt::SGI_HEADER_LEN
-                                  + off * m_spec.width * bpc;
-            fseek(m_fd, scanline_offset, SEEK_SET);
+            // offset for this scanline/channel
+            ptrdiff_t off             = y + c * m_spec.height;
+            ptrdiff_t scanline_offset = sgi_pvt::SGI_HEADER_LEN
+                                        + off * m_spec.width * bpc;
+            Filesystem::fseek(m_fd, scanline_offset, SEEK_SET);
             channeldata[c].resize(m_spec.width * bpc);
             if (!fread(&(channeldata[c][0]), 1, m_spec.width * bpc))
                 return false;
@@ -182,7 +182,7 @@ SgiInput::uncompress_rle_channel(int scanline_off, int scanline_len,
 {
     int bpc = m_sgi_header.bpc;
     std::vector<unsigned char> rle_scanline(scanline_len);
-    fseek(m_fd, scanline_off, SEEK_SET);
+    Filesystem::fseek(m_fd, scanline_off, SEEK_SET);
     if (!fread(&rle_scanline[0], 1, scanline_len))
         return false;
     int limit = m_spec.width;
@@ -288,7 +288,7 @@ SgiInput::read_header()
         return false;
 
     //don't read dummy bytes
-    fseek(m_fd, 404, SEEK_CUR);
+    Filesystem::fseek(m_fd, 404, SEEK_CUR);
 
     if (littleendian()) {
         swap_endian(&m_sgi_header.magic);

--- a/src/sgi.imageio/sgiinput.cpp
+++ b/src/sgi.imageio/sgiinput.cpp
@@ -181,7 +181,8 @@ SgiInput::uncompress_rle_channel(int scanline_off, int scanline_len,
                                  unsigned char* out)
 {
     int bpc = m_sgi_header.bpc;
-    std::vector<unsigned char> rle_scanline(scanline_len);
+    std::unique_ptr<unsigned char[]> rle_scanline(
+        new unsigned char[scanline_len]);
     Filesystem::fseek(m_fd, scanline_off, SEEK_SET);
     if (!fread(&rle_scanline[0], 1, scanline_len))
         return false;

--- a/src/sgi.imageio/sgioutput.cpp
+++ b/src/sgi.imageio/sgioutput.cpp
@@ -88,7 +88,8 @@ SgiOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
     // attempt to write with RLE encoding.
 
     size_t bpc = m_spec.format.size();  // bytes per channel
-    std::vector<unsigned char> channeldata(m_spec.width * bpc);
+    std::unique_ptr<unsigned char[]> channeldata(
+        new unsigned char[m_spec.width * bpc]);
 
     for (int64_t c = 0; c < m_spec.nchannels; ++c) {
         unsigned char* cdata = (unsigned char*)data + c * bpc;

--- a/src/sgi.imageio/sgioutput.cpp
+++ b/src/sgi.imageio/sgioutput.cpp
@@ -41,6 +41,11 @@ SgiOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
     m_filename = name;
     m_spec     = spec;
 
+    if (m_spec.width >= 65535 || m_spec.height >= 65535) {
+        errorf("Exceeds the maximum resolution (65535)");
+        return false;
+    }
+
     m_fd = Filesystem::fopen(m_filename, "wb");
     if (!m_fd) {
         errorf("Could not open \"%s\"", name);
@@ -82,12 +87,12 @@ SgiOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
     // content ourselves with only writing uncompressed data, and don't
     // attempt to write with RLE encoding.
 
-    int bpc = m_spec.format.size();  // bytes per channel
+    size_t bpc = m_spec.format.size();  // bytes per channel
     std::vector<unsigned char> channeldata(m_spec.width * bpc);
 
-    for (int c = 0; c < m_spec.nchannels; ++c) {
+    for (int64_t c = 0; c < m_spec.nchannels; ++c) {
         unsigned char* cdata = (unsigned char*)data + c * bpc;
-        for (int x = 0; x < m_spec.width; ++x) {
+        for (int64_t x = 0; x < m_spec.width; ++x) {
             channeldata[x * bpc] = cdata[0];
             if (bpc == 2)
                 channeldata[x * bpc + 1] = cdata[1];
@@ -95,9 +100,10 @@ SgiOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
         }
         if (bpc == 2 && littleendian())
             swap_endian((unsigned short*)&channeldata[0], m_spec.width);
-        long scanline_offset = sgi_pvt::SGI_HEADER_LEN
-                               + (c * m_spec.height + y) * m_spec.width * bpc;
-        fseek(m_fd, scanline_offset, SEEK_SET);
+        ptrdiff_t scanline_offset = sgi_pvt::SGI_HEADER_LEN
+                                    + ptrdiff_t(c * m_spec.height + y)
+                                          * m_spec.width * bpc;
+        Filesystem::fseek(m_fd, scanline_offset, SEEK_SET);
         if (!fwrite(&channeldata[0], 1, m_spec.width * bpc)) {
             return false;
         }


### PR DESCRIPTION
Watch out for int32 overflows, practice 64 bit seeking.
