### PR TITLE
BMP safety for big files and int32 overflow for offsets, and speedups

### DIFF
--- a/src/bmp.imageio/bmp_pvt.h
+++ b/src/bmp.imageio/bmp_pvt.h
@@ -136,7 +136,7 @@ private:
     bmp_pvt::DibInformationHeader m_dib_header;
     std::string m_filename;
     std::vector<bmp_pvt::color_table> m_colortable;
-    fpos_t m_image_start;
+    int64_t m_image_start;
     void init(void)
     {
         m_padded_scanline_size = 0;
@@ -172,7 +172,7 @@ private:
     std::string m_filename;
     bmp_pvt::BmpFileHeader m_bmp_header;
     bmp_pvt::DibInformationHeader m_dib_header;
-    fpos_t m_image_start;
+    int64_t m_image_start;
     unsigned int m_dither;
     std::vector<unsigned char> m_tilebuffer;
 

--- a/src/bmp.imageio/bmp_pvt.h
+++ b/src/bmp.imageio/bmp_pvt.h
@@ -129,7 +129,7 @@ public:
                                       void* data) override;
 
 private:
-    int m_padded_scanline_size;
+    int64_t m_padded_scanline_size;
     int m_pad_size;
     FILE* m_fd;
     bmp_pvt::BmpFileHeader m_bmp_header;
@@ -167,7 +167,7 @@ public:
                             stride_t ystride, stride_t zstride) override;
 
 private:
-    int m_padded_scanline_size;
+    int64_t m_padded_scanline_size;
     FILE* m_fd;
     std::string m_filename;
     bmp_pvt::BmpFileHeader m_bmp_header;

--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -114,7 +114,7 @@ BmpInput::open(const std::string& name, ImageSpec& spec)
 
     // file pointer is set to the beginning of image data
     // we save this position - it will be helpfull in read_native_scanline
-    fgetpos(m_fd, &m_image_start);
+    m_image_start = Filesystem::ftell(m_fd);
 
     spec = m_spec;
     return true;
@@ -140,8 +140,7 @@ BmpInput::read_native_scanline(int subimage, int miplevel, int y, int z,
 
     std::unique_ptr<unsigned char[]> fscanline(
         new unsigned char[m_padded_scanline_size]);
-    fsetpos(m_fd, &m_image_start);
-    Filesystem::fseek(m_fd, scanline_off, SEEK_CUR);
+    Filesystem::fseek(m_fd, m_image_start + scanline_off, SEEK_SET);
     size_t n = fread(fscanline.get(), 1, m_padded_scanline_size, m_fd);
     if (n != (size_t)m_padded_scanline_size) {
         if (feof(m_fd))

--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -73,7 +73,7 @@ BmpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
 
     // Scanline size is rounded up to align to 4-byte boundary
     m_padded_scanline_size = ((m_spec.width * m_spec.nchannels) + 3) & ~3;
-    fgetpos(m_fd, &m_image_start);
+    m_image_start          = Filesystem::ftell(m_fd);
 
     // If user asked for tiles -- which this format doesn't support, emulate
     // it by buffering the whole image.
@@ -98,8 +98,7 @@ BmpOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
     if (m_spec.width >= 0)
         y = (m_spec.height - y - 1);
     int64_t scanline_off = y * m_padded_scanline_size;
-    fsetpos(m_fd, &m_image_start);
-    Filesystem::fseek(m_fd, scanline_off, SEEK_CUR);
+    Filesystem::fseek(m_fd, m_image_start + scanline_off, SEEK_SET);
 
     std::vector<unsigned char> scratch;
     data = to_native_scanline(format, data, xstride, scratch, m_dither, y, z);

--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -52,6 +52,16 @@ BmpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
         return false;
     }
 
+    // Only support 8 bit channels for now.
+    m_spec.set_format(TypeDesc::UINT8);
+    m_dither = m_spec.get_int_attribute("oiio:dither", 0);
+
+    int64_t file_size = m_spec.image_bytes() + BMP_HEADER_SIZE + WINDOWS_V3;
+    if (file_size >= int64_t(1) << 32) {
+        errorf("%s does not support files over 4GB in size\n", format_name());
+        return false;
+    }
+
     m_fd = Filesystem::fopen(m_filename, "wb");
     if (!m_fd) {
         errorf("Could not open \"%s\"", m_filename);
@@ -64,10 +74,6 @@ BmpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
     // Scanline size is rounded up to align to 4-byte boundary
     m_padded_scanline_size = ((m_spec.width * m_spec.nchannels) + 3) & ~3;
     fgetpos(m_fd, &m_image_start);
-
-    // Only support 8 bit channels for now.
-    m_spec.set_format(TypeDesc::UINT8);
-    m_dither = m_spec.get_int_attribute("oiio:dither", 0);
 
     // If user asked for tiles -- which this format doesn't support, emulate
     // it by buffering the whole image.
@@ -91,14 +97,15 @@ BmpOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
 
     if (m_spec.width >= 0)
         y = (m_spec.height - y - 1);
-    int scanline_off = y * m_padded_scanline_size;
+    int64_t scanline_off = y * m_padded_scanline_size;
     fsetpos(m_fd, &m_image_start);
-    fseek(m_fd, scanline_off, SEEK_CUR);
+    Filesystem::fseek(m_fd, scanline_off, SEEK_CUR);
 
     std::vector<unsigned char> scratch;
     data = to_native_scanline(format, data, xstride, scratch, m_dither, y, z);
-    std::vector<unsigned char> buf(m_padded_scanline_size);
-    memcpy(&buf[0], data, m_spec.scanline_bytes());
+    std::vector<unsigned char> buf((const unsigned char*)data,
+                                   (const unsigned char*)data
+                                       + m_padded_scanline_size);
 
     // Swap RGB pixels into BGR format
     if (m_spec.nchannels >= 3)
@@ -148,9 +155,10 @@ BmpOutput::close(void)
 void
 BmpOutput::create_and_write_file_header(void)
 {
-    m_bmp_header.magic  = MAGIC_BM;
-    const int data_size = m_spec.width * m_spec.height * m_spec.nchannels;
-    const int file_size = data_size + BMP_HEADER_SIZE + WINDOWS_V3;
+    m_bmp_header.magic = MAGIC_BM;
+    int64_t data_size  = int64_t(m_spec.width) * m_spec.height
+                        * m_spec.nchannels;
+    int64_t file_size   = data_size + BMP_HEADER_SIZE + WINDOWS_V3;
     m_bmp_header.fsize  = file_size;
     m_bmp_header.res1   = 0;
     m_bmp_header.res2   = 0;


### PR DESCRIPTION
* Fix places that could overflow int32.

* Speed up read/write by about 40%, mostly by avoiding the pointless
  zeroing out of allocated memory in cerain std::vector temporary buffers.

