### PR TITLE
Reduce tile cache entry 'used' contention

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3033,7 +3033,8 @@ ImageCacheImpl::get_pixels(ImageCacheFile* file,
             // int ty = y - ((y - spec.y) % spec.tile_height);
             char* xptr       = yptr;
             const char* data = NULL;
-            for (int x = xbegin; x < xend; ++x, xptr += xstride) {
+            for (int x = xbegin; x < xend;
+                 ++x, xptr += xstride, ++npixelsread) {
                 if (x < spec.x || x >= (spec.x + spec.width)) {
                     // nonexistant columns
                     memset(xptr, 0, result_pixelsize);
@@ -3048,7 +3049,6 @@ ImageCacheImpl::get_pixels(ImageCacheFile* file,
                     ok &= find_tile(tileid, thread_info, npixelsread == 0);
                     if (!ok)
                         return false;  // Just stop if file read failed
-                    ++npixelsread;
                     old_tx = tx;
                     old_ty = ty;
                     old_tz = tz;

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -916,14 +916,18 @@ public:
     /// Try to avoid looking to the big cache (and locking) most of the
     /// time for fairly coherent tile access patterns, by using the
     /// per-thread microcache to boost our hit rate over the big cache.
-    /// Inlined for speed.  The tile is marked as 'used'.
-    bool find_tile(const TileID& id, ImageCachePerThreadInfo* thread_info)
+    /// Inlined for speed.  The tile is marked as 'used' if it wasn't the
+    /// very last one used, or if it was the same as the last used and
+    /// mark_same_tile_used is true.
+    bool find_tile(const TileID& id, ImageCachePerThreadInfo* thread_info,
+                   bool mark_same_tile_used)
     {
         ++thread_info->m_stats.find_tile_calls;
         ImageCacheTileRef& tile(thread_info->tile);
         if (tile) {
             if (tile->id() == id) {
-                tile->use();
+                if (mark_same_tile_used)
+                    tile->use();
                 return true;  // already have the tile we want
             }
             // Tile didn't match, maybe lasttile will?  Swap tile

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -366,7 +366,7 @@ TextureSystemImpl::accum3d_sample_closest(
     int tile_r = (rtex - spec.z) % spec.tile_depth;
     TileID id(texturefile, options.subimage, miplevel, stex - tile_s,
               ttex - tile_t, rtex - tile_r, tile_chbegin, tile_chend);
-    bool ok = find_tile(id, thread_info);
+    bool ok = find_tile(id, thread_info, true);
     if (!ok)
         errorf("%s", m_imagecache->geterror());
     TileRef& tile(thread_info->tile);
@@ -506,7 +506,7 @@ TextureSystemImpl::accum3d_sample_bilinear(
     if (onetile && valid_storage.ivalid == all_valid) {
         // Shortcut if all the texels we need are on the same tile
         id.xyz(stex[0] - tile_s, ttex[0] - tile_t, rtex[0] - tile_r);
-        bool ok = find_tile(id, thread_info);
+        bool ok = find_tile(id, thread_info, true);
         if (!ok)
             errorf("%s", m_imagecache->geterror());
         TileRef& tile(thread_info->tile);
@@ -530,6 +530,7 @@ TextureSystemImpl::accum3d_sample_bilinear(
         texel[1][1][0] = b + pixelsize * spec.tile_width;
         texel[1][1][1] = b + pixelsize * spec.tile_width + pixelsize;
     } else {
+        bool firstsample = true;
         for (int k = 0; k < 2; ++k) {
             for (int j = 0; j < 2; ++j) {
                 for (int i = 0; i < 2; ++i) {
@@ -542,9 +543,10 @@ TextureSystemImpl::accum3d_sample_bilinear(
                     tile_r = (rtex[k] - spec.z) % spec.tile_depth;
                     id.xyz(stex[i] - tile_s, ttex[j] - tile_t,
                            rtex[k] - tile_r);
-                    bool ok = find_tile(id, thread_info);
+                    bool ok = find_tile(id, thread_info, firstsample);
                     if (!ok)
                         errorf("%s", m_imagecache->geterror());
+                    firstsample = false;
                     TileRef& tile(thread_info->tile);
                     if (!tile->valid())
                         return false;

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -374,16 +374,12 @@ private:
         return texturefile;
     }
 
-    /// Find the tile specified by id.  If found, return true and place
-    /// the tile ref in thread_info->tile; if not found, return false.
-    /// This is more efficient than find_tile_main_cache() because it
-    /// avoids looking to the big cache (and locking) most of the time
-    /// for fairly coherent tile access patterns, by using the
-    /// per-thread microcache to boost our hit rate over the big cache.
-    /// Inlined for speed.
-    bool find_tile(const TileID& id, PerThreadInfo* thread_info)
+    /// Find the tile specified by id.  Just a pass-through to the
+    /// underlying ImageCache.
+    bool find_tile(const TileID& id, PerThreadInfo* thread_info,
+                   bool mark_same_tile_used = true)
     {
-        return m_imagecache->find_tile(id, thread_info);
+        return m_imagecache->find_tile(id, thread_info, mark_same_tile_used);
     }
 
     // Define a prototype of a member function pointer for texture

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -377,7 +377,7 @@ private:
     /// Find the tile specified by id.  Just a pass-through to the
     /// underlying ImageCache.
     bool find_tile(const TileID& id, PerThreadInfo* thread_info,
-                   bool mark_same_tile_used = true)
+                   bool mark_same_tile_used)
     {
         return m_imagecache->find_tile(id, thread_info, mark_same_tile_used);
     }

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -708,6 +708,7 @@ TextureSystemImpl::get_texels(TextureHandle* texture_handle_,
     size_t formatpixelsize   = nchannels * formatchannelsize;
     size_t scanlinesize      = (xend - xbegin) * formatpixelsize;
     size_t zplanesize        = (yend - ybegin) * scanlinesize;
+    imagesize_t npixelsread  = 0;
     bool ok                  = true;
     for (int z = zbegin; z < zend; ++z) {
         if (z < spec.z || z >= (spec.z + std::max(spec.depth, 1))) {
@@ -725,7 +726,7 @@ TextureSystemImpl::get_texels(TextureHandle* texture_handle_,
                 continue;
             }
             tileid.y(y - ((y - spec.y) % spec.tile_height));
-            for (int x = xbegin; x < xend; ++x) {
+            for (int x = xbegin; x < xend; ++x, ++npixelsread) {
                 if (x < spec.x || x >= (spec.x + spec.width)) {
                     // nonexistant columns
                     memset(result, 0, formatpixelsize);
@@ -733,7 +734,7 @@ TextureSystemImpl::get_texels(TextureHandle* texture_handle_,
                     continue;
                 }
                 tileid.x(x - ((x - spec.x) % spec.tile_width));
-                ok &= find_tile(tileid, thread_info);
+                ok &= find_tile(tileid, thread_info, npixelsread == 0);
                 TileRef& tile(thread_info->tile);
                 const char* data;
                 if (tile
@@ -1962,7 +1963,7 @@ TextureSystemImpl::sample_closest(
         int tile_s = (stex - spec.x) % spec.tile_width;
         int tile_t = (ttex - spec.y) % spec.tile_height;
         id.xy(stex - tile_s, ttex - tile_t);
-        bool ok = find_tile(id, thread_info);
+        bool ok = find_tile(id, thread_info, sample == 0);
         if (!ok)
             errorf("%s", m_imagecache->geterror());
         TileRef& tile(thread_info->tile);
@@ -2512,7 +2513,7 @@ TextureSystemImpl::sample_bicubic(
         if (onetile & allvalid) {
             // Shortcut if all the texels we need are on the same tile
             id.xy(stex[0] - tile_s, ttex[0] - tile_t);
-            bool ok = find_tile(id, thread_info);
+            bool ok = find_tile(id, thread_info, sample == 0);
             if (!ok)
                 errorf("%s", m_imagecache->geterror());
             TileRef& tile(thread_info->tile);
@@ -2582,7 +2583,7 @@ TextureSystemImpl::sample_bicubic(
                     if (i == 0 || tile_s[i] == 0
                         || options.swrap == TextureOpt::WrapMirror) {
                         id.xy(tile_s_edge[i], tile_t_edge[j]);
-                        bool ok = find_tile(id, thread_info);
+                        bool ok = find_tile(id, thread_info, sample == 0);
                         if (!ok)
                             errorf("%s", m_imagecache->geterror());
                         DASSERT(thread_info->tile->id() == id);

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -2147,7 +2147,7 @@ TextureSystemImpl::sample_bilinear(
         if (onetile && all(stvalid)) {
             // Shortcut if all the texels we need are on the same tile
             id.xy(sttex[S0] - tile_st[S0], sttex[T0] - tile_st[T0]);
-            bool ok = find_tile(id, thread_info);
+            bool ok = find_tile(id, thread_info, sample == 0);
             if (!ok)
                 errorf("%s", m_imagecache->geterror());
             TileRef& tile(thread_info->tile);
@@ -2208,7 +2208,7 @@ TextureSystemImpl::sample_bilinear(
                     // iteration, as long as we aren't using mirror wrap mode!
                     if (i == 0 || tile_s == 0 || noreusetile) {
                         id.xy(tile_edge[S0 + i], tile_edge[T0 + j]);
-                        bool ok = find_tile(id, thread_info);
+                        bool ok = find_tile(id, thread_info, sample == 0);
                         if (!ok)
                             errorf("%s", m_imagecache->geterror());
                         if (!thread_info->tile->valid()) {


### PR DESCRIPTION
Each texture query may perform many samples, and each sample may fetch a
tile (or more). EVERY time it was making sure that the 'used' atomic int
was set to 1. That's potentially a lot of contention.

Idea: Only set it once for all those samples. We really only need to mark
it 'used' per texture call, not per sample.

So I augmented find_tile() with an optional parameter mark_same_tile_used
(defaulting to true), and the effect is that if it happens to be the
most recently used tile in the microcache, it will only call use() if
mark_same_tile_used is true. So then, when looping over sampling, it
passes sample==1 for that param, having the effect that for the first
sample only (or of course if any other tile is needed than the last one)
will it mark used and diddle the atomic variable.

In our production scene benchmarks at SGI, when run in a highly
threaded configuration with 52 cores, I'm seeing a 2% average speedup
in overall rendering time (geometric mean of many tests; on a few
tests I'm seeing up to 20% gain, which is crazy, but many other scenes
merely break even).
