### PR TITLE
Improvements to Strutil::join()

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -384,11 +384,44 @@ template<class Sequence>
 std::string join (const Sequence& seq, string_view sep="")
 {
     std::ostringstream out;
+    out.imbue(std::locale::classic());  // Force "C" locale
     bool first = true;
     for (auto&& s : seq) {
         if (! first && sep.size())
             out << sep;
         out << s;
+        first = false;
+    }
+    return out.str();
+}
+
+/// Join all the strings in 'seq' into one big string, separated by the
+/// 'sep' string. The Sequence can be any iterable collection of items that
+/// are able to convert to string via stream output. Examples include:
+/// std::vector<string_view>, std::vector<std::string>, std::set<ustring>,
+/// std::vector<int>, etc. Values will be rendered into the string in a
+/// locale-independent manner (i.e., '.' for decimal in floats). If the
+/// optional `len` is nonzero, exactly that number of elements will be
+/// output (truncating or default-value-padding the sequence).
+template<class Sequence>
+std::string join (const Sequence& seq, string_view sep /*= ""*/, size_t len)
+{
+    using E = typename std::remove_reference<decltype(*std::begin(seq))>::type;
+    std::ostringstream out;
+    out.imbue(std::locale::classic());  // Force "C" locale
+    bool first = true;
+    for (auto&& s : seq) {
+        if (! first)
+            out << sep;
+        out << s;
+        first = false;
+        if (len && (--len == 0))
+            break;
+    }
+    while (len--) {
+        if (! first)
+            out << sep;
+        out << E();
         first = false;
     }
     return out.str();

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1668,47 +1668,33 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     STATUS("SHA-1 hash", stat_hashtime);
 
     if (isConstantColor) {
-        std::ostringstream os;             // Emulate a JSON array
-        os.imbue(std::locale::classic());  // Force "C" locale with '.' decimal
-        for (int i = 0; i < dstspec.nchannels; ++i) {
-            if (i != 0)
-                os << ",";
-            os << (i < (int)constantColor.size() ? constantColor[i] : 0.0f);
-        }
+        std::string colstr = Strutil::join(constantColor, ",",
+                                           dstspec.nchannels);
         if (out->supports("arbitrary_metadata")) {
-            dstspec.attribute("oiio:ConstantColor", os.str());
+            dstspec.attribute("oiio:ConstantColor", colstr);
         } else {
-            if (desc.length())
-                desc += " ";
-            desc += "oiio:ConstantColor=";
-            desc += os.str();
+            desc += Strutil::sprintf("%soiio:ConstantColor=%s",
+                                     desc.length() ? " " : "", colstr);
             updatedDesc = true;
         }
         if (verbose)
-            outstream << "  ConstantColor: " << os.str() << std::endl;
+            outstream << "  ConstantColor: " << colstr << std::endl;
     }
 
     if (compute_average_color) {
-        std::ostringstream os;             // Emulate a JSON array
-        os.imbue(std::locale::classic());  // Force "C" locale with '.' decimal
-        for (int i = 0; i < dstspec.nchannels; ++i) {
-            if (i != 0)
-                os << ",";
-            os << (i < (int)pixel_stats.avg.size() ? pixel_stats.avg[i] : 0.0f);
-        }
+        std::string avgstr = Strutil::join(pixel_stats.avg, ",",
+                                           dstspec.nchannels);
         if (out->supports("arbitrary_metadata")) {
-            dstspec.attribute("oiio:AverageColor", os.str());
+            dstspec.attribute("oiio:AverageColor", avgstr);
         } else {
             // if arbitrary metadata is not supported, cram it into the
             // ImageDescription.
-            if (desc.length())
-                desc += " ";
-            desc += "oiio:AverageColor=";
-            desc += os.str();
+            desc += Strutil::sprintf("%soiio:AverageColor=%s",
+                                     desc.length() ? " " : "", avgstr);
             updatedDesc = true;
         }
         if (verbose)
-            outstream << "  AverageColor: " << os.str() << std::endl;
+            outstream << "  AverageColor: " << avgstr << std::endl;
     }
 
     if (updatedDesc) {

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -372,6 +372,11 @@ test_join()
 
     int intarr[] = { 4, 2 };
     OIIO_CHECK_EQUAL(Strutil::join(intarr, ","), "4,2");
+
+    // Test join's `len` parameter.
+    float farr[] = { 1, 2, 3.5, 4, 5 };
+    OIIO_CHECK_EQUAL(Strutil::join(farr, ",", 3), "1,2,3.5");
+    OIIO_CHECK_EQUAL(Strutil::join(farr, ",", 7), "1,2,3.5,4,5,0,0");
 }
 
 


### PR DESCRIPTION
* Since it uses an ostrstream internally, make sure it is set up to be
  locale-independent (floats will always render with '.' decimal).

* Add a version with a parameter that allows you to set the number of
  items joined to something other than the length of the sequence,
  truncating or padding with default values as needed.

And I illustrate its use in make_texture.
