### PR TITLE
Strutil::lstrip, rstrip

### DIFF
--- a/src/include/OpenImageIO/string_view.h
+++ b/src/include/OpenImageIO/string_view.h
@@ -174,7 +174,7 @@ public:
 
     string_view substr(size_type pos, size_type n = npos) const noexcept
     {
-        if (pos > size())
+        if (pos >= size())
             return string_view();  // start past end -> return empty
         if (n == npos || pos + n > size())
             n = size() - pos;

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -356,6 +356,17 @@ void OIIO_API to_upper (std::string &a);
 /// empty, it will be interpreted as " \t\n\r\f\v" (whitespace).
 string_view OIIO_API strip (string_view str, string_view chars=string_view());
 
+/// Return a reference to the section of str that has all consecutive
+/// characters in chars removed from the beginning (left side).  If chars is
+/// empty, it will be interpreted as " \t\n\r\f\v" (whitespace).
+string_view OIIO_API lstrip (string_view str, string_view chars=string_view());
+
+/// Return a reference to the section of str that has all consecutive
+/// characters in chars removed from the ending (right side).  If chars is
+/// empty, it will be interpreted as " \t\n\r\f\v" (whitespace).
+string_view OIIO_API rstrip (string_view str, string_view chars=string_view());
+
+
 /// Fills the "result" list with the words in the string, using sep as
 /// the delimiter string.  If maxsplit is > -1, at most maxsplit splits
 /// are done. If sep is "", any whitespace string is a separator.

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -489,6 +489,28 @@ Strutil::StringILess::operator()(const char* a, const char* b) const noexcept
 
 
 string_view
+Strutil::lstrip(string_view str, string_view chars)
+{
+    if (chars.empty())
+        chars = string_view(" \t\n\r\f\v", 6);
+    size_t b = str.find_first_not_of(chars);
+    return str.substr(b, string_view::npos);
+}
+
+
+
+string_view
+Strutil::rstrip(string_view str, string_view chars)
+{
+    if (chars.empty())
+        chars = string_view(" \t\n\r\f\v", 6);
+    size_t e = str.find_last_not_of(chars);
+    return e != string_view::npos ? str.substr(0, e + 1) : string_view();
+}
+
+
+
+string_view
 Strutil::strip(string_view str, string_view chars)
 {
     if (chars.empty())

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -314,6 +314,18 @@ test_strip()
     OIIO_CHECK_EQUAL(Strutil::strip("  \tHello, world\n"), "Hello, world");
     OIIO_CHECK_EQUAL(Strutil::strip(" \t"), "");
     OIIO_CHECK_EQUAL(Strutil::strip(""), "");
+
+    OIIO_CHECK_EQUAL(Strutil::lstrip("abcdefbac", "abc"), "defbac");
+    OIIO_CHECK_EQUAL(Strutil::lstrip("defghi", "abc"), "defghi");
+    OIIO_CHECK_EQUAL(Strutil::lstrip("  \tHello, world\n"), "Hello, world\n");
+    OIIO_CHECK_EQUAL(Strutil::lstrip(" \t"), "");
+    OIIO_CHECK_EQUAL(Strutil::lstrip(""), "");
+
+    OIIO_CHECK_EQUAL(Strutil::rstrip("abcdefbac", "abc"), "abcdef");
+    OIIO_CHECK_EQUAL(Strutil::rstrip("defghi", "abc"), "defghi");
+    OIIO_CHECK_EQUAL(Strutil::rstrip("  \tHello, world\n"), "  \tHello, world");
+    OIIO_CHECK_EQUAL(Strutil::rstrip(" \t"), "");
+    OIIO_CHECK_EQUAL(Strutil::rstrip(""), "");
 }
 
 
@@ -585,6 +597,7 @@ test_to_string()
 void
 test_extract()
 {
+    std::cout << "Testing extract_from_list_string\n";
     std::vector<int> vals;
     int n;
 
@@ -646,6 +659,7 @@ test_extract()
 void
 test_safe_strcpy()
 {
+    std::cout << "Testing safe_strcpy\n";
     {  // test in-bounds copy
         char result[4] = { '0', '1', '2', '3' };
         Strutil::safe_strcpy(result, "A", 3);
@@ -686,8 +700,18 @@ test_safe_strcpy()
 void
 test_string_view()
 {
+    std::cout << "Testing string_view methods\n";
     std::string s("0123401234");
     string_view sr(s);
+
+    OIIO_CHECK_EQUAL(sr.substr(0), sr); // whole string
+    OIIO_CHECK_EQUAL(sr.substr(2), "23401234"); // nonzero pos, default n
+    OIIO_CHECK_EQUAL(sr.substr(2, 3), "234"); // true substrng
+    OIIO_CHECK_EQUAL(sr.substr(string_view::npos, 3), ""); // npos start
+    OIIO_CHECK_EQUAL(sr.substr(3, 0), ""); // zero length
+    OIIO_CHECK_EQUAL(sr.substr(10, 3), ""); // start at end
+    OIIO_CHECK_EQUAL(sr.substr(18, 3), ""); // start past end
+    OIIO_CHECK_EQUAL(sr.substr(4, 18), "401234"); // end too big
 
     OIIO_CHECK_EQUAL(sr.find("123"), s.find("123"));
     OIIO_CHECK_EQUAL(sr.find("123"), 1);
@@ -742,7 +766,8 @@ test_string_view()
     OIIO_CHECK_EQUAL(sr.find_last_not_of("234"), 6);
     OIIO_CHECK_EQUAL(sr.find_last_not_of('4', 5), 3);
     OIIO_CHECK_EQUAL(sr.find_last_not_of("234", 5), 1);
-    OIIO_CHECK_EQUAL(sr.find_last_of("xyz"), string_view::npos);
+    OIIO_CHECK_EQUAL(sr.find_last_not_of("xyz"), 9);
+    OIIO_CHECK_EQUAL(sr.find_last_not_of("01234"), string_view::npos);
 }
 
 


### PR DESCRIPTION
We already had strip, which trims chars from both sides. Sometimes you
just want to strip the left or right.

Also add some missing unit tests. And saw a > vs >= improvement in
in string_view::substr().  (I don't think it was wrong before, just
failed to take an early out for an empty substring.)
