### PR TITLE
oiiotool & ImageBuf improvements for huge images

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -1074,7 +1074,7 @@ Writing images
 
     Optional appended arguments include:
     
-    - `datatype=` *name* : Set the pixel data type (like `-d`) for this
+    - `type=` *name* : Set the pixel data type (like `-d`) for this
       output image (e.g., `uint8`, `uint16`, `half`, `float`, etc.).
     - `bits=` *int* : Set the bits per pixel (if nonstandard for the
       datatype) for this output image.
@@ -1565,12 +1565,17 @@ current top image.
     
         *width* x *height* [+-] *xoffset* [+-] *yoffset*
 
-    If the offset is omitted, it will be x=0, y=0.
+    If the offset is omitted, it will be x=0, y=0. Optional appended
+    arguments include:
+
+    - `type=` *name* : Create the image in memory with the named data type
+      (default: float).
 
     Examples::
 
         --create 1920x1080 3         # RGB with w=1920, h=1080, x=0, y=0
         --create 1024x768+100+0 4    # RGBA with w=1024, h=768, x=100, y=0
+        --create:type=uint8 1920x1080 3  # RGB, store internally as uint8
 
 
 .. option:: --pattern <patternname> <size> <channels>
@@ -1583,7 +1588,11 @@ current top image.
 
         *width* x *height* [+-] *xoffset* [+-] *yoffset*
 
-    If the offset is omitted, it will be x=0, y=0.
+    If the offset is omitted, it will be x=0, y=0. Optional appended
+    arguments include:
+
+    - `type=` *name* : Create the image in memory with the named data type
+      (default: float).
 
     The patterns recognized include the following:
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -643,7 +643,10 @@ adjust_output_options(string_view filename, ImageSpec& spec,
     //   that way.
     TypeDesc requested_output_dataformat = ot.output_dataformat;
     auto requested_output_channelformats = ot.output_channelformats;
-    if (fileoptions.contains("datatype")) {
+    if (fileoptions.contains("type")) {
+        requested_output_dataformat.fromstring(fileoptions.get_string("type"));
+        requested_output_channelformats.clear();
+    } else if (fileoptions.contains("datatype")) {
         requested_output_dataformat.fromstring(
             fileoptions.get_string("datatype"));
         requested_output_channelformats.clear();
@@ -3105,13 +3108,15 @@ action_create(int argc, const char* argv[])
     ASSERT(argc == 3);
     Timer timer(ot.enable_function_timing);
     string_view command = ot.express(argv[0]);
+    auto options        = ot.extract_options(command);
     string_view size    = ot.express(argv[1]);
     int nchans          = Strutil::from_string<int>(ot.express(argv[2]));
     if (nchans < 1 || nchans > 1024) {
         ot.warningf(argv[0], "Invalid number of channels: %d", nchans);
         nchans = 3;
     }
-    ImageSpec spec(64, 64, nchans, TypeDesc::FLOAT);
+    ImageSpec spec(64, 64, nchans,
+                   TypeDesc(options["type"].as_string("float")));
     ot.adjust_geometry(argv[0], spec.width, spec.height, spec.x, spec.y,
                        size.c_str());
     spec.full_x      = spec.x;
@@ -3139,6 +3144,7 @@ action_pattern(int argc, const char* argv[])
     ASSERT(argc == 4);
     Timer timer(ot.enable_function_timing);
     string_view command = ot.express(argv[0]);
+    auto options        = ot.extract_options(command);
     std::string pattern = ot.express(argv[1]);
     std::string size    = ot.express(argv[2]);
     int nchans          = Strutil::from_string<int>(ot.express(argv[3]));
@@ -3146,7 +3152,8 @@ action_pattern(int argc, const char* argv[])
         ot.warningf(argv[0], "Invalid number of channels: %d", nchans);
         nchans = 3;
     }
-    ImageSpec spec(64, 64, nchans, TypeDesc::FLOAT);
+    ImageSpec spec(64, 64, nchans,
+                   TypeDesc(options["type"].as_string("float")));
     ot.adjust_geometry(argv[0], spec.width, spec.height, spec.x, spec.y,
                        size.c_str());
     spec.full_x      = spec.x;


### PR DESCRIPTION
* Detect failed allocations when ImageBuf tries to allocate local memory
  but there is not enough memory -- catch the exception, leave the IB
  uninitialized, set an error in the IB. This at least allows oiiotool
  to issue an understandable error message if --create or --pattern fail
  because too high a resolution was specified.

* oiiotool --create and --pattern take a new optional parameter:
  `:type=name` that overrides the default behavior of allocating all
  internal buffers as float. An important application of this might be
  if you are creating a huge image that would not usually fit in memory
  as floats, might as a half or uint8. For example,

      oiiotool -pattern checker 64000x32000 3 -o big.exr

  writes a really big checkerboard, but will fail on a machine that can't
  muster an allocation of 23 GB RAM. However,

      oiiotool -pattern:type=uint8 checker 64000x32000 3 -o big.exr

  will create and write the same checkerboard using only 6 GB RAM.

* Noticed that oiiotool -o is the only command that used `:datatype=`
  as an optional type override. All others use `type=`, so change to
  that. (The old one is silently accepted as well.)

