### PR TITLE
BMP fix uninitialized data in output

### DIFF
--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -102,9 +102,11 @@ BmpOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
 
     std::vector<unsigned char> scratch;
     data = to_native_scanline(format, data, xstride, scratch, m_dither, y, z);
-    std::vector<unsigned char> buf((const unsigned char*)data,
-                                   (const unsigned char*)data
-                                       + m_padded_scanline_size);
+    std::vector<unsigned char> buf;
+    buf.reserve(m_padded_scanline_size);  // reserve enough for padded scanline
+    buf.assign((const unsigned char*)data,
+               (const unsigned char*)data + m_spec.scanline_bytes());
+    buf.resize(m_padded_scanline_size, 0);  // pad with zeroes if needed
 
     // Swap RGB pixels into BGR format
     if (m_spec.nchannels >= 3)


### PR DESCRIPTION
Difference between padded scanline width and number of pixel values was
not properly considered or zeroed out. This was (nondeterministically)
botching occasional CI tests.

