### PR TITLE
Fix occasional CI failure in imageinout_test

### DIFF
--- a/src/libOpenImageIO/imageinout_test.cpp
+++ b/src/libOpenImageIO/imageinout_test.cpp
@@ -26,12 +26,15 @@ make_test_image(string_view formatname)
     ImageBuf buf;
     auto out = ImageOutput::create(formatname);
     ASSERT(out);
+    ImageSpec spec(64, 64, 4, TypeFloat);
     if (formatname == "zfile" || formatname == "fits")
-        buf.reset(ImageSpec(64, 64, 1, TypeFloat));
+        spec.nchannels = 1;  // these formats are single channel
     else if (!out->supports("alpha"))
-        buf.reset(ImageSpec(64, 64, 3, TypeFloat));
-    else
-        buf.reset(ImageSpec(64, 64, 4, TypeFloat));
+        spec.nchannels = 3;  // this channel doesn't support alpha
+    // Force a fixed datetime metadata so it can't differ between writes
+    // and make different file patterns for these tests.
+    spec.attribute("DateTime", "01/01/2000 00:00:00");
+    buf.reset(spec);
     ImageBufAlgo::fill(buf, { 1.0f, 1.0f, 1.0f, 1.0f });
     return buf;
 }


### PR DESCRIPTION
One test is to write an image file to disk, then write the same image
as a "file" to an in-memory buffer, and make sure resulting bit patterns
match exactly.

Every once in a while, it would spuriously fail. I'm pretty sure it's
because of metadata not matching exactly if the two writes happen on
opposite sides of a minute boundary!

This patch attempts to preempt that by setting "DateTime" metadata to
a fixed value, so that individual format writers don't, in its absence,
supply the "now" value, which could vary from run to run.

