### PR TITLE
IC/TS option "trust_file_extensions"

### DIFF
--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -204,6 +204,12 @@ public:
     ///           aren't getting any helpful additional information, this
     ///           can cut down on the clutter and the runtime. (default:
     ///           100)
+    /// - `int trust_file_extensions` :
+    ///           When nonzero, assume that the file extensions of any
+    ///           texture requests correctly indicates the file format (when
+    ///           enabled, this reduces the number of file opens, at the
+    ///           expense of not being able to open files if their format do
+    ///           not actually match their filename extension). Default: 0
     ///
     /// - `string options`
     ///           This catch-all is simply a comma-separated list of

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -795,6 +795,7 @@ public:
     bool accept_untiled() const { return m_accept_untiled; }
     bool accept_unmipped() const { return m_accept_unmipped; }
     bool unassociatedalpha() const { return m_unassociatedalpha; }
+    bool trust_file_extensions() const { return m_trust_file_extensions; }
     int failure_retries() const { return m_failure_retries; }
     bool latlong_y_up_default() const { return m_latlong_y_up_default; }
     void get_commontoworld(Imath::M44f& result) const { result = m_Mc2w; }
@@ -1105,8 +1106,9 @@ private:
     bool m_accept_unmipped;    ///< Accept unmipped images?
     bool m_deduplicate;        ///< Detect duplicate files?
     bool m_unassociatedalpha;  ///< Keep unassociated alpha files as they are?
-    int m_failure_retries;     ///< Times to re-try disk failures
     bool m_latlong_y_up_default;  ///< Is +y the default "up" for latlong?
+    bool m_trust_file_extensions = false;  ///< Assume file extensions don't lie?
+    int m_failure_retries;                 ///< Times to re-try disk failures
     int m_max_mip_res = 1 << 30;  ///< Don't use MIP levels higher than this
     Imath::M44f m_Mw2c;           ///< world-to-"common" matrix
     Imath::M44f m_Mc2w;           ///< common-to-world matrix


### PR DESCRIPTION
The default is 0, old behavior. If you set to nonzero, you are
promising the ImageCache that it will always be able to identify a
texture file's format based on the filename extension (e.g. ".exr"
always means it's an openexr file, ".tif" or "tx" for TIFF files, and
you will NEVER call a file ".tx" if it's really openexr, or if you do,
you are ok with it being unable to open it). When you enable it with
that promise, it can eliminate a few redundant file opens and header
reads, by not needing to verify file format types at certain stages of
processing.

I'm not sure I would recommend enabling this in general. But if you
are operating in a closed environment where you are sure that file
extensions will match their types (such as a studio with rigid naming
conventions, where all possible textures have been converted with
maketx), this can eliminate some unnecessary network traffic and file
server workload.

