### PR TITLE
Exif read: guard better against out of range offests

### DIFF
--- a/src/libOpenImageIO/exif-canon.cpp
+++ b/src/libOpenImageIO/exif-canon.cpp
@@ -634,6 +634,8 @@ array_to_spec (ImageSpec& spec,                 // spec to put attribs into
         ASSERT(0 && "unsupported type");
     }
     const T *s = (const T *) pvt::dataptr (dir, buf, offset_adjustment);
+    if (!s)
+        return;
     for (auto&& attr : indices) {
         if (attr.value < int(dir.tdir_count)) {
             T ival = int (s[attr.value]);


### PR DESCRIPTION
The dataptr() function returns nullptr if the offset is out of proper
range. But the array_to_spec function calling dataptr did not check for
a nullptr return, ended up segfaulting.

