### PR TITLE
Fix ffmpeg package availability problem on Travis

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,8 +7,8 @@ on: [push, pull_request]
 
 
 jobs:
-  linux-gcc6:
-    name: "Linux VFX 2019-ish: gcc6, C++11, sse2, exr2.3"
+  linux-gcc6-cpp11:
+    name: "Linux VFX 2019-ish: gcc6/C++11, sse2, exr2.3"
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
@@ -16,6 +16,21 @@ jobs:
         env:
           CXX: g++-6
           CMAKE_CXX_STANDARD: 11
+        run: |
+            source src/build-scripts/ci-startup.bash
+            source src/build-scripts/gh-installdeps.bash
+            source src/build-scripts/ci-build-and-test.bash
+
+  linux-gcc6-cpp14:
+    name: "Linux VFX 2019-ish: gcc6/C++14, sse4.2, exr2.3"
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: all
+        env:
+          CXX: g++-6
+          CMAKE_CXX_STANDARD: 14
+          USE_SIMD: sse4.2
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps.bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ addons:
   apt:
    sources: &add-sources
       - ubuntu-toolchain-r-test
-      - sourceline: 'ppa:jonathonf/ffmpeg-4'
    packages: &common-packages
       - libgif-dev
       - libopenjpeg-dev
@@ -25,10 +24,6 @@ addons:
       - libfreetype6-dev
       - libjpeg-turbo8-dev
       - dcmtk
-      - libavcodec-dev
-      - libavformat-dev
-      - libswscale-dev
-      - libavutil-dev
       - locales
       - python-numpy
       - libraw-dev
@@ -115,19 +110,6 @@ matrix:
         env: PYTHON_VERSION=2.7
         if: branch =~ /(master|RB|travis|python)/ OR type = pull_request
 
-    # test with C++14, gcc 6, SSE 4.2
-      - name: "VFX Platform 2018 (gcc6, cpp14, exr2.2), sse4.2"
-        os: linux
-        compiler: gcc
-        env: WHICHGCC=6 CMAKE_CXX_STANDARD=14 USE_SIMD=sse4.2 OPENEXR_BRANCH=v2.2.0
-        addons:
-          apt:
-            sources: *add-sources
-            packages:
-              - *common-packages
-              - *common-boost-packages
-              - g++-6
-
     # One more, just for the heck of it, turn all SIMD off, and also make
     # sure we're falling back on libjpeg, not jpeg-turbo, no OCIO support,
     # and don't embed the plugins (to make sure that doesn't rust away).  I
@@ -149,13 +131,6 @@ matrix:
               - *common-packages
               - *old-boost-packages
               - g++-4.8
-
-    # Just run clang-format, this test only checks formatting rule conformance
-      - name: "clang-format format verification"
-        os: osx
-        compiler: clang
-        env: BUILDTARGET=clang-format SKIP_TESTS=1 BUILD_MISSING_DEPS=0
-        #if: branch =~ /(master|RB|travis|simd)/ OR type = pull_request
 
     # Static analysis: build with clang-tidy.
     # Disabled -- this takes so long to run, it can't complete in Travis's


### PR DESCRIPTION
The ffmpeg we were using was from a repo whose owner just took it offline.
This was making our TravisCI Linux builds fail. But it's well tested in
the GitHub CI matrix, so just remove it here.

Also... remove another Linux test from Travis that seems redundant, as
it is nearly an identical configuration to one in the GH test matrix.
And for that matter, we don't need to do the clang-format check on
both testing platforms, so remove it from Travis, too. Now we only use
Travis for the gcc 4.8 tests and Mac with Python 2.7 (I've had trouble
getting both of those working on GH CI).
