### PR TITLE
Replace most uses of boost::thread_specific_ptr with C++11 thread_local

### DIFF
--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -29,7 +29,6 @@
 #include <OpenImageIO/thread.h>
 
 #include <boost/container/flat_map.hpp>
-#include <boost/thread/tss.hpp>
 
 #if 0
 

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -8,14 +8,6 @@
 #include <cstdio>
 #include <cstdlib>
 
-// Experimental: can we substitute C++11 thread_local for boost::tsp
-// reliably on all platforms?
-#define USE_CPP11_TLS 1
-
-#ifndef USE_CPP11_TLS
-#    include <boost/thread/tss.hpp>
-#endif
-
 #include <tiffio.h>
 #include <zlib.h>
 
@@ -433,11 +425,7 @@ OIIO_PLUGIN_EXPORTS_END
 // Someplace to store an error message from the TIFF error handler
 // To avoid thread oddities, we have the storage area buffering error
 // messages for seterror()/geterror() be thread-specific.
-#ifdef USE_CPP11_TLS
 static thread_local std::string thread_error_msg;
-#else
-static boost::thread_specific_ptr<std::string> thread_error_msg;
-#endif
 static atomic_int handler_set;
 static spin_mutex handler_mutex;
 
@@ -446,16 +434,7 @@ static spin_mutex handler_mutex;
 std::string&
 oiio_tiff_last_error()
 {
-#ifdef USE_CPP11_TLS
     return thread_error_msg;
-#else
-    std::string* e = thread_error_msg.get();
-    if (!e) {
-        e = new std::string;
-        thread_error_msg.reset(e);
-    }
-    return *e;
-#endif
 }
 
 


### PR DESCRIPTION
There is still one use left, in ImageCache. I'm not sure how to get rid
of that yet, because the C++11 std version only works for global or static
variables, but we are using it in a class. We'll come back to that later.
In the mean time, this gets rid of all other uses.

One thing this does is fix a link error I get on MacOS when building
with EMBEDPLUGINS=0.

