### PR TITLE
Fix occasional static destructor order fiasco.

### DIFF
--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -497,5 +497,10 @@ main(int argc, char* argv[])
         ok = convert_file(filenames[0], filenames[1]);
     }
 
+    // Force all files to close, ugh, it's the only way I can find to solve
+    // an occasional problem with static destructor order fiasco with
+    // field3dwhen building with EMBEDPLUGINS=0 on MacOS.
+    ImageCache::create()->close_all();
+
     return ok ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -6166,5 +6166,10 @@ main(int argc, char* argv[])
         std::cout << "\n" << ot.imagecache->getstats(2) << "\n";
     }
 
+    // Force all files to close, ugh, it's the only way I can find to solve
+    // an occasional problem with static destructor order fiasco with
+    // field3dwhen building with EMBEDPLUGINS=0 on MacOS.
+    ot.imagecache->close_all();
+
     return ot.return_value;
 }

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -1618,6 +1618,11 @@ main(int argc, const char* argv[])
     std::cout << texsys->getstats(verbose ? 2 : 0) << "\n";
     TextureSystem::destroy(texsys);
 
+    // Force all files to close, ugh, it's the only way I can find to solve
+    // an occasional problem with static destructor order fiasco with
+    // field3dwhen building with EMBEDPLUGINS=0 on MacOS.
+    ImageCache::create()->close_all();
+
     if (verbose)
         std::cout << "\nustrings: " << ustring::getstats(false) << "\n\n";
     return 0;


### PR DESCRIPTION
Never reported, not on CI tests, but I've seen it happen. Only on MacOS, only
for builds with EMBEDPLUGINS=0, only for tests involving Field3D files.

I seem to be able to fix it (or at least make it asymptomatic when I
run tests) by forcing all the open texture file handles to close
before the DSOs are unloaded, for a few of the utilities.