### PR TITLE
Allow rw locking of texture caches

### DIFF
--- a/src/include/OpenImageIO/refcnt.h
+++ b/src/include/OpenImageIO/refcnt.h
@@ -149,6 +149,15 @@ public:
     /// Cast to bool to detect whether it points to anything
     operator bool() const noexcept { return m_ptr != NULL; }
 
+    friend bool operator==(const intrusive_ptr& a, const T* b)
+    {
+        return a.get() == b;
+    }
+    friend bool operator==(const T* b, const intrusive_ptr& a)
+    {
+        return a.get() == b;
+    }
+
 private:
     T* m_ptr;  // the raw pointer
 };

--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -468,6 +468,12 @@ public:
         m_bits.fetch_sub(WRITER, std::memory_order_release);
     }
 
+    /// lock() is a synonym for exclusive (write) lock.
+    void lock() { write_lock(); }
+
+    /// unlock() is a synonym for exclusive (write) unlock.
+    void unlock() { write_unlock(); }
+
     /// Helper class: scoped read lock for a spin_rw_mutex -- grabs the
     /// read lock upon construction, releases the lock when it exits scope.
     class read_lock_guard {


### PR DESCRIPTION
To reduce thread contention on the IC/TS caches, change from unique
locks to reader-writer locks.

* unordered_map_concurrent: Change the shards from spin_lock to
  spin_rw_lock. Most operations (insert, erase, holding an iterator,
  and find, which returns an iterator) are unique (write) locks. But
  the underappreciated retrieve() method is stateless and can be a reader
  lock!

* In imagecache.cpp, change a bunch of the find() calls and fiddling
  with iterators into simpler calls to retrieve(), which should be
  able to happen concurrently.

On a highly threaded machine (52 cores) this resulted in a 6% gain
(geometric mean) across a set of production render frames that we like
to test with, but that disguises what's really happening.  Most of the
individual tests in that suite don't change at all (or vary within the
+/- ~1% we expect from timing noise and run-to-run variation.  But a
handful of the tests sped up by 20-40%! So I think you are unlikely
to see any change for a few threads, or even many threads for most
situations. But for highly threaded renderings where the access pattern
really results in the cache locks as a major rendering bottleneck,
this should help a lot.

