### PR TITLE
Modify ImageInput/ImageOutput APIs to directly support IOProxy

### DIFF
--- a/src/doc/imageinput.rst
+++ b/src/doc/imageinput.rst
@@ -662,13 +662,9 @@ buffer::
 
     const void *buf = ...;   // pointer to memory block
     size_t size = ...;       // length of memory block
-
-    ImageSpec config; // ImageSpec describing input configuration options
     Filesystem::IOMemReader memreader (buf, size);  // I/O proxy object
-    void *ptr = &memreader;
-    config.attribute ("oiio:ioproxy", TypeDesc::PTR, &ptr);
 
-    auto in = ImageInput::open ("in.exr", &config);
+    auto in = ImageInput::open ("in.exr", nullptr, &memreader);
     in->read_image (...);
     in->close();
 

--- a/src/doc/imageoutput.rst
+++ b/src/doc/imageoutput.rst
@@ -1090,10 +1090,8 @@ Here is an example of using a proxy that writes the "file" to a
 
     std::vector<unsigned char> file_buffer;  // bytes will go here
     Filesystem::IOVecOutput vecout (file_buffer);  // I/O proxy object
-    void *ptr = &vecout;
-    spec.attribute ("oiio:ioproxy", TypeDesc::PTR, &ptr);
 
-    auto out = ImageOutput::create ("out.exr");
+    auto out = ImageOutput::create ("out.exr", &vecout);
     out->open ("out.exr", spec);
     out->write_image (...);
     out->close ();

--- a/src/include/OpenImageIO/oiioversion.h.in
+++ b/src/include/OpenImageIO/oiioversion.h.in
@@ -72,11 +72,13 @@ namespace @PROJ_NAME@ = @PROJ_NAMESPACE_V@;
 ///     subimage,miplevel params to many read_*() methods; changed thread
 ///     safety expectations; removed newspec param from seek_subimage;
 ///     added spec(subimage,miplevel) and spec_dimensions(subimage,miplevel).
-///     (OIIO 1.9)
+///     (OIIO 2.0)
 /// Version 22 changed the signatures of ImageInput/ImageOutput create()
-///     to return unique_ptr. (OIIO 1.9)
+///     to return unique_ptr. (OIIO 2.0)
+/// Version 23 added set_ioproxy() methods to ImageInput & ImageOutput
+///     (OIIO 2.2).
 
-#define OIIO_PLUGIN_VERSION 22
+#define OIIO_PLUGIN_VERSION 23
 
 #define OIIO_PLUGIN_NAMESPACE_BEGIN OIIO_NAMESPACE_BEGIN
 #define OIIO_PLUGIN_NAMESPACE_END OIIO_NAMESPACE_END

--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -61,6 +61,11 @@ public:
     virtual bool read_native_scanline(int subimage, int miplevel, int y, int z,
                                       void* data) override;
     virtual bool close() override;
+    virtual bool set_ioproxy(Filesystem::IOProxy* ioproxy) override
+    {
+        m_io = ioproxy;
+        return true;
+    }
     const std::string& filename() const { return m_filename; }
     void* coeffs() const { return m_coeffs; }
     struct my_error_mgr {

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -169,7 +169,8 @@ JpgInput::open(const std::string& name, ImageSpec& newspec,
     auto p = config.find_attribute("_jpeg:raw", TypeInt);
     m_raw  = p && *(int*)p->data();
     p      = config.find_attribute("oiio:ioproxy", TypeDesc::PTR);
-    m_io   = p ? p->get<Filesystem::IOProxy*>() : nullptr;
+    if (p)
+        m_io = p->get<Filesystem::IOProxy*>();
     return open(name, newspec);
 }
 

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -10,6 +10,7 @@
 
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
+#include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/parallel.h>
@@ -73,15 +74,16 @@ ImageInput::valid_file(const std::string& filename) const
 
 
 std::unique_ptr<ImageInput>
-ImageInput::open(const std::string& filename, const ImageSpec* config)
+ImageInput::open(const std::string& filename, const ImageSpec* config,
+                 Filesystem::IOProxy* ioproxy)
 {
     if (!config) {
         // Without config, this is really just a call to create-with-open.
-        return ImageInput::create(filename, true, nullptr, std::string());
+        return ImageInput::create(filename, true, nullptr, ioproxy);
     }
 
     // With config, create without open, then try to open with config.
-    auto in = ImageInput::create(filename, false, config, std::string());
+    auto in = ImageInput::create(filename, false, config, ioproxy);
     if (!in)
         return in;  // create() failed, return the empty ptr
     ImageSpec newspec;

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -159,6 +159,12 @@ public:
                                         int zbegin, int zend, int chbegin,
                                         int chend, DeepData& deepdata) override;
 
+    virtual bool set_ioproxy(Filesystem::IOProxy* ioproxy) override
+    {
+        m_io = ioproxy;
+        return true;
+    }
+
 private:
     struct PartInfo {
         std::atomic_bool initialized;
@@ -396,7 +402,8 @@ OpenEXRInput::open(const std::string& name, ImageSpec& newspec,
 {
     const ParamValue* param = config.find_attribute("oiio:ioproxy",
                                                     TypeDesc::PTR);
-    m_io = param ? param->get<Filesystem::IOProxy*>() : nullptr;
+    if (param)
+        m_io = param->get<Filesystem::IOProxy*>();
 
     // Quick check to reject non-exr files. Don't perform these tests for
     // the IOProxy case.

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -117,6 +117,11 @@ public:
     virtual bool write_deep_tiles(int xbegin, int xend, int ybegin, int yend,
                                   int zbegin, int zend,
                                   const DeepData& deepdata) override;
+    virtual bool set_ioproxy(Filesystem::IOProxy* ioproxy) override
+    {
+        m_io = ioproxy;
+        return true;
+    }
 
 private:
     std::unique_ptr<OpenEXROutputStream>
@@ -320,7 +325,8 @@ OpenEXROutput::open(const std::string& name, const ImageSpec& userspec,
         sanity_check_channelnames();
         const ParamValue* param = m_spec.find_attribute("oiio:ioproxy",
                                                         TypeDesc::PTR);
-        m_io = param ? param->get<Filesystem::IOProxy*>() : nullptr;
+        if (param)
+            m_io = param->get<Filesystem::IOProxy*>();
 
         if (!spec_to_header(m_spec, m_subimage, m_headers[m_subimage]))
             return false;

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -34,6 +34,11 @@ public:
     }
     virtual bool read_native_scanline(int subimage, int miplevel, int y, int z,
                                       void* data) override;
+    virtual bool set_ioproxy(Filesystem::IOProxy* ioproxy) override
+    {
+        m_io = ioproxy;
+        return true;
+    }
 
 private:
     std::string m_filename;            ///< Stash the filename
@@ -59,6 +64,7 @@ private:
         m_subimage = -1;
         m_png      = nullptr;
         m_info     = nullptr;
+        m_io       = nullptr;
         m_buf.clear();
         m_next_scanline           = 0;
         m_keep_unassociated_alpha = false;
@@ -184,9 +190,10 @@ PNGInput::open(const std::string& name, ImageSpec& newspec,
     // Check 'config' for any special requests
     if (config.get_int_attribute("oiio:UnassociatedAlpha", 0) == 1)
         m_keep_unassociated_alpha = true;
-    auto ioparam = config.find_attribute("oiio:ioproxy", TypeDesc::PTR);
     m_io_local.reset();
-    m_io = ioparam ? ioparam->get<Filesystem::IOProxy*>() : nullptr;
+    auto ioparam = config.find_attribute("oiio:ioproxy", TypeDesc::PTR);
+    if (ioparam)
+        m_io = ioparam->get<Filesystem::IOProxy*>();
     return open(name, newspec);
 }
 

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -31,6 +31,11 @@ public:
     virtual bool write_tile(int x, int y, int z, TypeDesc format,
                             const void* data, stride_t xstride,
                             stride_t ystride, stride_t zstride) override;
+    virtual bool set_ioproxy(Filesystem::IOProxy* ioproxy) override
+    {
+        m_io = ioproxy;
+        return true;
+    }
 
 private:
     std::string m_filename;  ///< Stash the filename
@@ -126,7 +131,6 @@ PNGOutput::open(const std::string& name, const ImageSpec& userspec,
         return false;
     }
 
-    close();            // Close any already-opened file
     m_spec = userspec;  // Stash the spec
 
     // If not uint8 or uint16, default to uint8
@@ -136,7 +140,8 @@ PNGOutput::open(const std::string& name, const ImageSpec& userspec,
     // See if we were requested to write to a memory buffer, and if so,
     // extract the pointer.
     auto ioparam = m_spec.find_attribute("oiio:ioproxy", TypeDesc::PTR);
-    m_io         = ioparam ? ioparam->get<Filesystem::IOProxy*>() : nullptr;
+    if (ioparam)
+        m_io = ioparam->get<Filesystem::IOProxy*>();
     if (!m_io) {
         // If no proxy was supplied, create a file writer
         m_io = new Filesystem::IOFile(name, Filesystem::IOProxy::Mode::Write);

--- a/testsuite/python-imagespec/ref/out-python3.txt
+++ b/testsuite/python-imagespec/ref/out-python3.txt
@@ -113,7 +113,7 @@ extra_attribs size is 9
 99.5
 
 seralize(xml):
-<ImageSpec version="22">
+<ImageSpec version="23">
 <x>1</x>
 <y>2</y>
 <z>3</z>

--- a/testsuite/python-imagespec/ref/out.txt
+++ b/testsuite/python-imagespec/ref/out.txt
@@ -113,7 +113,7 @@ extra_attribs size is 9
 99.5
 
 seralize(xml):
-<ImageSpec version="22">
+<ImageSpec version="23">
 <x>1</x>
 <y>2</y>
 <z>3</z>


### PR DESCRIPTION
Make it a first class thing the API knows about, not the very weird back
door of passing via configuration hint.

For the sake of backward compatibility, the "old" method of passing
config attribute "oiio:ioproxy" with a PTR data will continue to be
supported for at least a couple major releases.  But moving forward
for 2.2+ (which, remember, won't be a supported release for many
months), the preferred and documented way will be through these new
API calls.

It is still the case that only some format readers/writers support
IOProxies -- it is not only lots of work to extend support to more
formats (volunteers?) but since we rely on 3rd party libraries for
some of our important formats, if they don't have support for some way
to supply custom low level I/O function overrides, it would be very
hard to have a way for OIIO client applications to use proxies for
those formats.  So callers should always check supports("ioproxy") on
the format before relying on it.
