### PR TITLE
Convert old style asserts to new style

### DIFF
--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -141,7 +141,7 @@ BmpOutput::close(void)
     bool ok = true;
     if (m_spec.tile_width) {
         // Handle tile emulation -- output the buffered pixels
-        ASSERT(m_tilebuffer.size());
+        OIIO_DASSERT(m_tilebuffer.size());
         ok &= write_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
                               m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap(m_tilebuffer);

--- a/src/dicom.imageio/dicominput.cpp
+++ b/src/dicom.imageio/dicominput.cpp
@@ -261,7 +261,7 @@ DICOMInput::read_metadata()
         DcmStack stack;
         while (dcm->nextObject(stack, OFTrue).good()) {
             DcmObject* object = stack.top();
-            ASSERT(object);
+            OIIO_ASSERT(object);
             DcmTag& tag         = const_cast<DcmTag&>(object->getTag());
             std::string tagname = tag.getTagName();
             if (ignore_tags.find(tagname) != ignore_tags.end())
@@ -329,7 +329,7 @@ DICOMInput::read_native_scanline(int subimage, int miplevel, int y, int z,
     if (y < 0 || y >= m_spec.height)  // out of range scanline
         return false;
 
-    ASSERT(m_internal_data);
+    OIIO_DASSERT(m_internal_data);
     size_t size = m_spec.scanline_bytes();
     memcpy(data, m_internal_data + y * size, size);
 

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -186,7 +186,7 @@ DPXOutput::open(const std::string& name, const ImageSpec& userspec,
     }
 
     // From here out, all the heavy lifting is done for Create
-    ASSERT(mode == Create);
+    OIIO_DASSERT(mode == Create);
 
     if (is_opened())
         close();  // Close any already-opened file
@@ -596,7 +596,7 @@ DPXOutput::close()
     bool ok = true;
     if (m_spec.tile_width) {
         // Handle tile emulation -- output the buffered pixels
-        ASSERT(m_tilebuffer.size());
+        OIIO_DASSERT(m_tilebuffer.size());
         ok &= write_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
                               m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap(m_tilebuffer);

--- a/src/field3d.imageio/field3dinput.cpp
+++ b/src/field3d.imageio/field3dinput.cpp
@@ -75,7 +75,7 @@ private:
     void init()
     {
         m_name.clear();
-        ASSERT(!m_input);
+        OIIO_ASSERT(!m_input);
         m_subimage   = -1;
         m_nsubimages = 0;
         m_layers.clear();
@@ -128,7 +128,7 @@ template<typename T>
 inline int
 blocksize(FieldRes::Ptr& f)
 {
-    ASSERT(f && "taking blocksize of null ptr");
+    OIIO_DASSERT(f && "taking blocksize of null ptr");
     typename SparseField<T>::Ptr sf(field_dynamic_cast<SparseField<T>>(f));
     if (sf)
         return sf->blockSize();
@@ -248,8 +248,8 @@ Field3DInput::read_one_layer(FieldRes::Ptr field, layerrecord& lay,
         lay.spec.tile_height = lay.spec.height;
         lay.spec.tile_depth  = lay.spec.depth;
     }
-    ASSERT(lay.spec.tile_width > 0 && lay.spec.tile_height > 0
-           && lay.spec.tile_depth > 0);
+    OIIO_ASSERT(lay.spec.tile_width > 0 && lay.spec.tile_height > 0
+                && lay.spec.tile_depth > 0);
 
     lay.spec.attribute("ImageDescription", lay.unique_name);
     lay.spec.attribute("oiio:subimagename", lay.unique_name);
@@ -302,7 +302,7 @@ Field3DInput::read_layers(TypeDesc datatype)
             else if (field_dynamic_cast<SparseField<Data_T>>(*i))
                 lay.fieldtype = f3dpvt::Sparse;
             else
-                ASSERT(0 && "unknown field type");
+                OIIO_ASSERT(0 && "unknown field type");
             read_one_layer(*i, lay, datatype, layernum);
         }
     }
@@ -324,7 +324,7 @@ Field3DInput::read_layers(TypeDesc datatype)
             else if (field_dynamic_cast<MACField<VecData_T>>(*i))
                 lay.fieldtype = f3dpvt::MAC;
             else
-                ASSERT(0 && "unknown field type");
+                OIIO_ASSERT(0 && "unknown field type");
             lay.vecfield = true;
             read_one_layer(*i, lay, datatype, layernum);
         }

--- a/src/field3d.imageio/field3doutput.cpp
+++ b/src/field3d.imageio/field3doutput.cpp
@@ -151,7 +151,7 @@ Field3DOutput::open(const std::string& name, const ImageSpec& userspec,
         return false;
     }
 
-    ASSERT(mode == AppendSubimage && "invalid open() mode");
+    OIIO_ASSERT(mode == AppendSubimage && "invalid open() mode");
 
     write_current_subimage();
 
@@ -342,7 +342,7 @@ Field3DOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
             return write_scanline_specialized(
                 y, z, (const FIELD3D_VEC3_T<FIELD3D_NS::half>*)data);
     } else {
-        ASSERT(0 && "Unsupported data format for field3d");
+        OIIO_ASSERT(0 && "Unsupported data format for field3d");
     }
 
     return false;
@@ -422,7 +422,7 @@ Field3DOutput::write_tile(int x, int y, int z, TypeDesc format,
             return write_tile_specialized(
                 x, y, z, (const FIELD3D_VEC3_T<FIELD3D_NS::half>*)data);
     } else {
-        ASSERT(0 && "Unsupported data format for field3d");
+        OIIO_ASSERT(0 && "Unsupported data format for field3d");
     }
 
     return false;
@@ -435,7 +435,7 @@ bool
 Field3DOutput::prep_subimage_specialized()
 {
     m_spec = m_specs[m_subimage];
-    ASSERT(m_spec.nchannels == 1 || m_spec.nchannels == 3);
+    OIIO_ASSERT(m_spec.nchannels == 1 || m_spec.nchannels == 3);
 
     Box3i extents(V3i(m_spec.full_x, m_spec.full_y, m_spec.full_z),
                   V3i(m_spec.full_x + m_spec.full_width - 1,
@@ -453,7 +453,7 @@ Field3DOutput::prep_subimage_specialized()
         m_field.reset(f);
     } else if (Strutil::iequals(fieldtype, "MAC")) {
         // FIXME
-        ASSERT(0 && "MAC fields not yet supported");
+        OIIO_ASSERT(0 && "MAC fields not yet supported");
     } else {
         // Dense
         DenseField<T>* f(new DenseField<T>);
@@ -518,7 +518,7 @@ bool
 Field3DOutput::prep_subimage()
 {
     m_spec = m_specs[m_subimage];
-    ASSERT(m_spec.nchannels == 1 || m_spec.nchannels == 3);
+    OIIO_ASSERT(m_spec.nchannels == 1 || m_spec.nchannels == 3);
     if (m_spec.format == TypeDesc::FLOAT) {
         if (m_spec.nchannels == 1)
             prep_subimage_specialized<float>();
@@ -535,7 +535,7 @@ Field3DOutput::prep_subimage()
         else
             prep_subimage_specialized<FIELD3D_VEC3_T<FIELD3D_NS::half>>();
     } else {
-        ASSERT(0 && "Unsupported data format for field3d");
+        OIIO_ASSERT(0 && "Unsupported data format for field3d");
     }
 
     m_writepending = true;

--- a/src/fits.imageio/fitsoutput.cpp
+++ b/src/fits.imageio/fitsoutput.cpp
@@ -154,7 +154,7 @@ FitsOutput::close(void)
     bool ok = true;
     if (m_spec.tile_width) {
         // Handle tile emulation -- output the buffered pixels
-        ASSERT(m_tilebuffer.size());
+        OIIO_ASSERT(m_tilebuffer.size());
         ok &= write_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
                               m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap(m_tilebuffer);

--- a/src/gif.imageio/gifoutput.cpp
+++ b/src/gif.imageio/gifoutput.cpp
@@ -100,7 +100,7 @@ GIFOutput::open(const std::string& name, const ImageSpec& newspec,
         return start_subimage();
     }
 
-    ASSERTMSG(0, "Unknown open mode %d", int(mode));
+    OIIO_ASSERT_MSG(0, "Unknown open mode %d", int(mode));
     return false;
 }
 

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -163,7 +163,7 @@ HdrOutput::close()
     bool ok = true;
     if (m_spec.tile_width) {
         // We've been emulating tiles; now dump as scanlines.
-        ASSERT(m_tilebuffer.size());
+        OIIO_ASSERT(m_tilebuffer.size());
         ok &= write_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
                               m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap(m_tilebuffer);

--- a/src/heif.imageio/heifoutput.cpp
+++ b/src/heif.imageio/heifoutput.cpp
@@ -187,7 +187,7 @@ HeifOutput::close()
     bool ok = true;
     if (m_spec.tile_width) {
         // We've been emulating tiles; now dump as scanlines.
-        ASSERT(m_tilebuffer.size());
+        OIIO_ASSERT(m_tilebuffer.size());
         ok &= write_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
                               m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap(m_tilebuffer);

--- a/src/ico.imageio/icoinput.cpp
+++ b/src/ico.imageio/icoinput.cpp
@@ -288,7 +288,7 @@ ICOInput::readimg()
     }
 
     // otherwise we're dealing with a DIB
-    DASSERT(m_spec.scanline_bytes() == ((size_t)m_spec.width * 4));
+    OIIO_DASSERT(m_spec.scanline_bytes() == ((size_t)m_spec.width * 4));
     m_buf.resize(m_spec.image_bytes());
 
     //std::cerr << "[ico] DIB buffer size = " << m_buf.size () << "\n";

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -412,7 +412,7 @@ ICOOutput::close()
     bool ok = true;
     if (m_spec.tile_width) {
         // Handle tile emulation -- output the buffered pixels
-        ASSERT(m_tilebuffer.size());
+        OIIO_ASSERT(m_tilebuffer.size());
         ok &= write_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
                               m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap(m_tilebuffer);

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -244,7 +244,7 @@ main(int argc, char* argv[])
                         * img0.spec().depth;
             if (npels == 0)
                 npels = 1;  // Avoid divide by zero for 0x0 images
-            ASSERT(img0.spec().format == TypeFloat);
+            OIIO_ASSERT(img0.spec().format == TypeFloat);
 
             // Compare the two images.
             //

--- a/src/iff.imageio/iff_pvt.cpp
+++ b/src/iff.imageio/iff_pvt.cpp
@@ -108,7 +108,7 @@ IffFileHeader::read_header(FILE* fd, std::string& err)
                         // test format.
                         if (flags & RGBA) {
                             // test if black is set
-                            DASSERT(!(flags & BLACK));
+                            OIIO_DASSERT(!(flags & BLACK));
 
                             // test for RGB channels.
                             if (flags & RGB)
@@ -128,7 +128,7 @@ IffFileHeader::read_header(FILE* fd, std::string& err)
                             pixel_channels = 1;
                             pixel_bits     = 32;  // 32bit
                             // NOTE: Z_F32 support - not supported
-                            DASSERT(bytes == 0);
+                            OIIO_DASSERT(bytes == 0);
                         }
 
                         // read AUTH, DATE or FOR4

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -183,12 +183,12 @@ inline OIIO_HOSTDEVICE V round_to_multiple (V value, M multiple)
 /// Round up to the next whole multiple of m, for the special case where
 /// m is definitely a power of 2 (somewhat simpler than the more general
 /// round_to_multiple). This is a template that should work for any
-// integer type.
+/// integer type.
 template<typename T>
 inline OIIO_HOSTDEVICE T
 round_to_multiple_of_pow2(T x, T m)
 {
-    DASSERT(ispow2(m));
+    OIIO_DASSERT(ispow2(m));
     return (x + m - 1) & (~(m - 1));
 }
 
@@ -1025,7 +1025,7 @@ bitstring_add_n_bits (T* &out, int& filled, uint32_t val, int n)
         }
         *out |= b;
         filled += nb;
-        DASSERT (filled <= Tbits);
+        OIIO_DASSERT (filled <= Tbits);
         n -= nb;
         if (filled == Tbits) {
             ++out;
@@ -1067,7 +1067,7 @@ bit_unpack(int n, const unsigned char* in, int inbits, T* out)
                   std::is_same<T,uint16_t>::value ||
                   std::is_same<T,uint32_t>::value,
                   "bit_unpack must be unsigned int 8/16/32");
-    DASSERT(inbits >= 1 && inbits < 32);  // surely bugs if not
+    OIIO_DASSERT(inbits >= 1 && inbits < 32);  // surely bugs if not
     // int highest = (1 << inbits) - 1;
     int B = 0, b = 0;
     // Invariant:

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -980,7 +980,7 @@ public:
                 m_x = x_;
                 pos_xincr();
                 // Not necessary? m_exists = (x_ < m_img_xend);
-                DASSERT((x_ < m_img_xend) == m_exists);
+                OIIO_DASSERT((x_ < m_img_xend) == m_exists);
                 return;
             }
             bool v = valid(x_, y_, z_);
@@ -1132,8 +1132,8 @@ public:
         // Note: called *after* m_x was incremented!
         OIIO_FORCEINLINE void pos_xincr()
         {
-            DASSERT(m_exists && m_valid);   // precondition
-            DASSERT(valid(m_x, m_y, m_z));  // should be true by definition
+            OIIO_DASSERT(m_exists && m_valid);   // precondition
+            OIIO_DASSERT(valid(m_x, m_y, m_z));  // should be true by definition
             m_proxydata += m_pixel_bytes;
             if (m_localpixels) {
                 if (OIIO_UNLIKELY(m_x >= m_img_xend)) {
@@ -1180,7 +1180,7 @@ public:
         {
             if (!m_localpixels) {
                 const_cast<ImageBuf*>(m_ib)->make_writeable(true);
-                DASSERT(m_ib->storage() != IMAGECACHE);
+                OIIO_DASSERT(m_ib->storage() != IMAGECACHE);
                 m_tile      = NULL;
                 m_proxydata = NULL;
                 init_ib(m_wrap);

--- a/src/include/OpenImageIO/refcnt.h
+++ b/src/include/OpenImageIO/refcnt.h
@@ -116,7 +116,7 @@ public:
         T* p = m_ptr;
         if (p) {
             if (!p->_decref())
-                DASSERT(0 && "release() when you aren't the sole owner");
+                OIIO_DASSERT(0 && "release() when you aren't the sole owner");
             m_ptr = nullptr;
         }
         return p;
@@ -133,14 +133,14 @@ public:
     /// Dereference
     T& operator*() const
     {
-        DASSERT(m_ptr);
+        OIIO_DASSERT(m_ptr);
         return *m_ptr;
     }
 
     /// Dereference
     T* operator->() const
     {
-        DASSERT(m_ptr);
+        OIIO_DASSERT(m_ptr);
         return m_ptr;
     }
 

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -3064,7 +3064,7 @@ inline bool get_denorms_zero_mode () {
 
 
 OIIO_FORCEINLINE int vbool4::operator[] (int i) const {
-    DASSERT(i >= 0 && i < elements);
+    OIIO_DASSERT(i >= 0 && i < elements);
 #if OIIO_SIMD_SSE
     return ((_mm_movemask_ps(m_simd) >> i) & 1) ? -1 : 0;
 #else
@@ -3073,13 +3073,13 @@ OIIO_FORCEINLINE int vbool4::operator[] (int i) const {
 }
 
 OIIO_FORCEINLINE int& vbool4::operator[] (int i) {
-    DASSERT(i >= 0 && i < elements);
+    OIIO_DASSERT(i >= 0 && i < elements);
     return m_val[i];
 }
 
 
 OIIO_FORCEINLINE void vbool4::setcomp (int i, bool value) {
-    DASSERT(i >= 0 && i < elements);
+    OIIO_DASSERT(i >= 0 && i < elements);
     m_val[i] = value ? -1 : 0;
 }
 
@@ -3181,7 +3181,7 @@ OIIO_FORCEINLINE void vbool4::store (bool *values) const {
 }
 
 OIIO_FORCEINLINE void vbool4::store (bool *values, int n) const {
-    DASSERT (n >= 0 && n <= elements);
+    OIIO_DASSERT (n >= 0 && n <= elements);
     for (int i = 0; i < n; ++i)
         values[i] = m_val[i] ? true : false;
 }
@@ -3375,7 +3375,7 @@ OIIO_FORCEINLINE bool none (const vbool4& v) { return reduce_or(v) == false; }
 
 
 OIIO_FORCEINLINE int vbool8::operator[] (int i) const {
-    DASSERT(i >= 0 && i < elements);
+    OIIO_DASSERT(i >= 0 && i < elements);
 #if OIIO_SIMD_AVX
     return ((_mm256_movemask_ps(m_simd) >> i) & 1) ? -1 : 0;
 #else
@@ -3384,12 +3384,12 @@ OIIO_FORCEINLINE int vbool8::operator[] (int i) const {
 }
 
 OIIO_FORCEINLINE void vbool8::setcomp (int i, bool value) {
-    DASSERT(i >= 0 && i < elements);
+    OIIO_DASSERT(i >= 0 && i < elements);
     m_val[i] = value ? -1 : 0;
 }
 
 OIIO_FORCEINLINE int& vbool8::operator[] (int i) {
-    DASSERT(i >= 0 && i < elements);
+    OIIO_DASSERT(i >= 0 && i < elements);
     return m_val[i];
 }
 
@@ -3510,7 +3510,7 @@ OIIO_FORCEINLINE void vbool8::store (bool *values) const {
 }
 
 OIIO_FORCEINLINE void vbool8::store (bool *values, int n) const {
-    DASSERT (n >= 0 && n <= elements);
+    OIIO_DASSERT (n >= 0 && n <= elements);
     for (int i = 0; i < n; ++i)
         values[i] = m_val[i] ? true : false;
 }
@@ -3687,7 +3687,7 @@ OIIO_FORCEINLINE bool none (const vbool8& v) { return reduce_or(v) == false; }
 
 
 OIIO_FORCEINLINE int vbool16::operator[] (int i) const {
-    DASSERT(i >= 0 && i < elements);
+    OIIO_DASSERT(i >= 0 && i < elements);
 #if OIIO_SIMD_AVX >= 512
     return (int(m_simd) >> i) & 1;
 #else
@@ -3696,7 +3696,7 @@ OIIO_FORCEINLINE int vbool16::operator[] (int i) const {
 }
 
 OIIO_FORCEINLINE void vbool16::setcomp (int i, bool value) {
-    DASSERT(i >= 0 && i < elements);
+    OIIO_DASSERT(i >= 0 && i < elements);
     int bits = m_bits;
     bits &= (0xffff ^ (1<<i));
     bits |= (int(value)<<i);
@@ -3810,7 +3810,7 @@ OIIO_FORCEINLINE void vbool16::store (bool *values) const {
 }
 
 OIIO_FORCEINLINE void vbool16::store (bool *values, int n) const {
-    DASSERT (n >= 0 && n <= elements);
+    OIIO_DASSERT (n >= 0 && n <= elements);
     for (int i = 0; i < n; ++i)
         values[i] = m_bits & (1<<i);
 }
@@ -3942,17 +3942,17 @@ OIIO_FORCEINLINE const vint4 & vint4::operator= (const vint4& other) {
 }
 
 OIIO_FORCEINLINE int vint4::operator[] (int i) const {
-    DASSERT(i<elements);
+    OIIO_DASSERT(i<elements);
     return m_val[i];
 }
 
 OIIO_FORCEINLINE int& vint4::operator[] (int i) {
-    DASSERT(i<elements);
+    OIIO_DASSERT(i<elements);
     return m_val[i];
 }
 
 OIIO_FORCEINLINE void vint4::setcomp (int i, int val) {
-    DASSERT(i<elements);
+    OIIO_DASSERT(i<elements);
     m_val[i] = val;
 }
 
@@ -3997,7 +3997,7 @@ OIIO_FORCEINLINE void vint4::load (const int *values) {
 
 OIIO_FORCEINLINE void vint4::load (const int *values, int n)
 {
-    DASSERT (n >= 0 && n <= elements);
+    OIIO_DASSERT (n >= 0 && n <= elements);
 #if OIIO_SIMD_AVX >= 512 && OIIO_AVX512VL_ENABLED
     m_simd = _mm_maskz_loadu_epi32 (__mmask8(~(0xf << n)), values);
 #elif OIIO_SIMD_SSE
@@ -4470,7 +4470,7 @@ inline std::ostream& operator<< (std::ostream& cout, const vint4& val) {
 
 
 OIIO_FORCEINLINE void vint4::store (int *values, int n) const {
-    DASSERT (n >= 0 && n <= elements);
+    OIIO_DASSERT (n >= 0 && n <= elements);
 #if 0 && OIIO_SIMD_AVX >= 512 && OIIO_AVX512VL_ENABLED
     // This SHOULD be fast, but in my benchmarks, it is slower!
     // (At least on the AVX512 hardware I have, Xeon Silver 4110.)
@@ -4776,17 +4776,17 @@ OIIO_FORCEINLINE const vint8 & vint8::operator= (const vint8& other) {
 }
 
 OIIO_FORCEINLINE int vint8::operator[] (int i) const {
-    DASSERT(i<elements);
+    OIIO_DASSERT(i<elements);
     return m_val[i];
 }
 
 OIIO_FORCEINLINE int& vint8::operator[] (int i) {
-    DASSERT(i<elements);
+    OIIO_DASSERT(i<elements);
     return m_val[i];
 }
 
 OIIO_FORCEINLINE void vint8::setcomp (int i, int val) {
-    DASSERT(i<elements);
+    OIIO_DASSERT(i<elements);
     m_val[i] = val;
 }
 
@@ -4828,7 +4828,7 @@ OIIO_FORCEINLINE void vint8::load (const int *values) {
 
 OIIO_FORCEINLINE void vint8::load (const int *values, int n)
 {
-    DASSERT (n >= 0 && n <= elements);
+    OIIO_DASSERT (n >= 0 && n <= elements);
 #if OIIO_SIMD_AVX >= 512 && OIIO_AVX512VL_ENABLED
     m_simd = _mm256_maskz_loadu_epi32 ((~(0xff << n)), values);
 #elif OIIO_SIMD_SSE
@@ -5288,7 +5288,7 @@ inline std::ostream& operator<< (std::ostream& cout, const vint8& val) {
 
 
 OIIO_FORCEINLINE void vint8::store (int *values, int n) const {
-    DASSERT (n >= 0 && n <= elements);
+    OIIO_DASSERT (n >= 0 && n <= elements);
 #if 0 && OIIO_SIMD_AVX >= 512 && OIIO_AVX512VL_ENABLED
     // This SHOULD be fast, but in my benchmarks, it is slower!
     // (At least on the AVX512 hardware I have, Xeon Silver 4110.)
@@ -5575,17 +5575,17 @@ OIIO_FORCEINLINE const vint16 & vint16::operator= (const vint16& other) {
 }
 
 OIIO_FORCEINLINE int vint16::operator[] (int i) const {
-    DASSERT(i<elements);
+    OIIO_DASSERT(i<elements);
     return m_val[i];
 }
 
 OIIO_FORCEINLINE int& vint16::operator[] (int i) {
-    DASSERT(i<elements);
+    OIIO_DASSERT(i<elements);
     return m_val[i];
 }
 
 OIIO_FORCEINLINE void vint16::setcomp (int i, int val) {
-    DASSERT(i<elements);
+    OIIO_DASSERT(i<elements);
     m_val[i] = val;
 }
 
@@ -6083,7 +6083,7 @@ inline std::ostream& operator<< (std::ostream& cout, const vint16& val) {
 
 
 OIIO_FORCEINLINE void vint16::store (int *values, int n) const {
-    DASSERT (n >= 0 && n <= elements);
+    OIIO_DASSERT (n >= 0 && n <= elements);
 #if 0 && OIIO_SIMD_AVX >= 512
     // This SHOULD be fast, but in my benchmarks, it is slower!
     // (At least on the AVX512 hardware I have, Xeon Silver 4110.)
@@ -6410,12 +6410,12 @@ OIIO_FORCEINLINE const vfloat4 & vfloat4::operator= (const Imath::V3f &v) {
 }
 
 OIIO_FORCEINLINE float& vfloat4::operator[] (int i) {
-    DASSERT(i<elements);
+    OIIO_DASSERT(i<elements);
     return m_val[i];
 }
 
 OIIO_FORCEINLINE float vfloat4::operator[] (int i) const {
-    DASSERT(i<elements);
+    OIIO_DASSERT(i<elements);
     return m_val[i];
 }
 
@@ -6457,7 +6457,7 @@ OIIO_FORCEINLINE void vfloat4::load (const float *values) {
 
 
 OIIO_FORCEINLINE void vfloat4::load (const float *values, int n) {
-    DASSERT (n >= 0 && n <= elements);
+    OIIO_DASSERT (n >= 0 && n <= elements);
 #if OIIO_SIMD_AVX >= 512 && OIIO_AVX512VL_ENABLED
     m_simd = _mm_maskz_loadu_ps (__mmask8(~(0xf << n)), values);
 #elif OIIO_SIMD_SSE
@@ -6591,7 +6591,7 @@ OIIO_FORCEINLINE void vfloat4::store (float *values) const {
 }
 
 OIIO_FORCEINLINE void vfloat4::store (float *values, int n) const {
-    DASSERT (n >= 0 && n <= 4);
+    OIIO_DASSERT (n >= 0 && n <= 4);
 #if 0 && OIIO_SIMD_AVX >= 512 && OIIO_AVX512VL_ENABLED
     // This SHOULD be fast, but in my benchmarks, it is slower!
     // (At least on the AVX512 hardware I have, Xeon Silver 4110.)
@@ -8129,12 +8129,12 @@ OIIO_FORCEINLINE vfloat3 transformvT (const Imath::M44f &M, const vfloat3 &V)
 // vfloat8 implementation
 
 OIIO_FORCEINLINE float& vfloat8::operator[] (int i) {
-    DASSERT(i<elements);
+    OIIO_DASSERT(i<elements);
     return m_val[i];
 }
 
 OIIO_FORCEINLINE float vfloat8::operator[] (int i) const {
-    DASSERT(i<elements);
+    OIIO_DASSERT(i<elements);
     return m_val[i];
 }
 
@@ -8252,7 +8252,7 @@ OIIO_FORCEINLINE void vfloat8::load (const float *values) {
 
 
 OIIO_FORCEINLINE void vfloat8::load (const float *values, int n) {
-    DASSERT (n >= 0 && n <= elements);
+    OIIO_DASSERT (n >= 0 && n <= elements);
 #if 0 && OIIO_AVX512VL_ENABLED
     // This SHOULD be fast, but in my benchmarks, it is slower!
     // (At least on the AVX512 hardware I have, Xeon Silver 4110.)
@@ -8347,7 +8347,7 @@ OIIO_FORCEINLINE void vfloat8::store (float *values) const {
 
 
 OIIO_FORCEINLINE void vfloat8::store (float *values, int n) const {
-    DASSERT (n >= 0 && n <= elements);
+    OIIO_DASSERT (n >= 0 && n <= elements);
 #if 0 && OIIO_AVX512VL_ENABLED
     // This SHOULD be fast, but in my benchmarks, it is slower!
     // (At least on the AVX512 hardware I have, Xeon Silver 4110.)
@@ -8955,12 +8955,12 @@ OIIO_FORCEINLINE vfloat8 nmsub (const simd::vfloat8& a, const simd::vfloat8& b,
 // vfloat16 implementation
 
 OIIO_FORCEINLINE float& vfloat16::operator[] (int i) {
-    DASSERT(i<elements);
+    OIIO_DASSERT(i<elements);
     return m_val[i];
 }
 
 OIIO_FORCEINLINE float vfloat16::operator[] (int i) const {
-    DASSERT(i<elements);
+    OIIO_DASSERT(i<elements);
     return m_val[i];
 }
 
@@ -9109,7 +9109,7 @@ OIIO_FORCEINLINE void vfloat16::load (const float *values) {
 
 OIIO_FORCEINLINE void vfloat16::load (const float *values, int n)
 {
-    DASSERT (n >= 0 && n <= elements);
+    OIIO_DASSERT (n >= 0 && n <= elements);
 #if OIIO_SIMD_AVX >= 512
     m_simd = _mm512_maskz_loadu_ps (__mmask16(~(0xffff << n)), values);
 #else
@@ -9195,7 +9195,7 @@ OIIO_FORCEINLINE void vfloat16::store (float *values) const {
 
 
 OIIO_FORCEINLINE void vfloat16::store (float *values, int n) const {
-    DASSERT (n >= 0 && n <= elements);
+    OIIO_DASSERT (n >= 0 && n <= elements);
     // FIXME: is this faster with AVX masked stores?
 #if 0 && OIIO_SIMD_AVX >= 512
     // This SHOULD be fast, but in my benchmarks, it is slower!

--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -813,7 +813,7 @@ public:
     // of this task set.
     void push(std::future<void>&& f)
     {
-        DASSERT(
+        OIIO_DASSERT(
             std::this_thread::get_id() == submitter()
             && "All tasks in a tast_set should be added by the same thread");
         m_futures.emplace_back(std::move(f));
@@ -838,7 +838,7 @@ public:
     {
         const std::chrono::milliseconds wait_time(0);
         for (auto&& f : m_futures)
-            ASSERT(f.wait_for(wait_time) == std::future_status::ready);
+            OIIO_ASSERT(f.wait_for(wait_time) == std::future_status::ready);
     }
 
 private:

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -173,8 +173,8 @@ struct OIIO_API TypeDesc {
     /// Return the number of elements: 1 if not an array, or the array
     /// length. Invalid to call this for arrays of undetermined size.
     OIIO_CONSTEXPR14 size_t numelements () const noexcept {
-        DASSERT_MSG (arraylen >= 0, "Called numelements() on TypeDesc "
-                     "of array with unspecified length (%d)", arraylen);
+        OIIO_DASSERT_MSG (arraylen >= 0, "Called numelements() on TypeDesc "
+                          "of array with unspecified length (%d)", arraylen);
         return (arraylen >= 1 ? arraylen : 1);
     }
 
@@ -198,8 +198,8 @@ struct OIIO_API TypeDesc {
     /// Return the size, in bytes, of this type.
     ///
     size_t size () const noexcept {
-        DASSERT_MSG (arraylen >= 0, "Called size() on TypeDesc "
-                     "of array with unspecified length (%d)", arraylen);
+        OIIO_DASSERT_MSG (arraylen >= 0, "Called size() on TypeDesc "
+                          "of array with unspecified length (%d)", arraylen);
         size_t a = (size_t) (arraylen > 0 ? arraylen : 1);
         if (sizeof(size_t) > sizeof(int)) {
             // size_t has plenty of room for this multiplication

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -699,7 +699,7 @@ public:
     /// again. Use with extreme caution!!!
     static ustring from_unique(const char* unique)
     {
-        DASSERT(is_unique(unique));  // DEBUG builds -- check it!
+        OIIO_DASSERT(is_unique(unique));  // DEBUG builds -- check it!
         ustring u;
         u.m_chars = unique;
         return u;

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -778,7 +778,6 @@ ImageViewer::add_image(const std::string& filename)
     if (rawcolor())
         config.attribute("oiio:RawColor", 1);
     IvImage* newimage = new IvImage(filename, &config);
-    ASSERT(newimage);
     newimage->gamma(m_default_gamma);
     m_images.push_back(newimage);
     addRecentFile(filename);

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -446,7 +446,7 @@ JpgInput::read_native_scanline(int subimage, int miplevel, int y, int z,
         if (!close() || !open(m_filename, dummyspec)
             || !seek_subimage(subimage, 0))
             return false;  // Somehow, the re-open failed
-        assert(m_next_scanline == 0 && current_subimage() == subimage);
+        OIIO_DASSERT(m_next_scanline == 0 && current_subimage() == subimage);
     }
 
     // Set up our custom error handler
@@ -461,7 +461,7 @@ JpgInput::read_native_scanline(int subimage, int miplevel, int y, int z,
         // we'll have to convert.
         m_cmyk_buf.resize(m_spec.width * 4);
         readdata = &m_cmyk_buf[0];
-        ASSERT(m_spec.nchannels == 3);
+        OIIO_DASSERT(m_spec.nchannels == 3);
     }
 
     for (; m_next_scanline <= y; ++m_next_scanline) {

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -404,7 +404,7 @@ JpgOutput::close()
 
     if (m_spec.tile_width) {
         // We've been emulating tiles; now dump as scanlines.
-        ASSERT(m_tilebuffer.size());
+        OIIO_DASSERT(m_tilebuffer.size());
         ok &= write_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
                               m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap(m_tilebuffer);  // free it

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -217,7 +217,7 @@ Jpeg2000Input::open(const std::string& p_name, ImageSpec& p_spec)
         return false;
     }
 
-    ASSERT(m_image == NULL);
+    OIIO_ASSERT(m_image == nullptr);
     if (!opj_read_header(m_stream, m_codec, &m_image)) {
         errorf("Could not read Jpeg2000 header");
         close();

--- a/src/jpeg2000.imageio/jpeg2000output-v1.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output-v1.cpp
@@ -242,7 +242,7 @@ Jpeg2000Output::close()
     bool ok = true;
     if (m_spec.tile_width) {
         // We've been emulating tiles; now dump as scanlines.
-        ASSERT(m_tilebuffer.size());
+        OIIO_ASSERT(m_tilebuffer.size());
         ok &= write_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
                               m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap(m_tilebuffer);

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -275,7 +275,7 @@ Jpeg2000Output::close()
     bool ok = true;
     if (m_spec.tile_width) {
         // We've been emulating tiles; now dump as scanlines.
-        ASSERT(m_tilebuffer.size());
+        OIIO_ASSERT(m_tilebuffer.size());
         ok &= write_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
                               m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap(m_tilebuffer);

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1418,9 +1418,9 @@ colorconvert_impl_float_rgba(ImageBuf& R, const ImageBuf& A,
 {
     using namespace ImageBufAlgo;
     using namespace simd;
-    ASSERT(R.localpixels() && A.localpixels() && R.spec().format == TypeFloat
-           && A.spec().format == TypeFloat && R.nchannels() == 4
-           && A.nchannels() == 4);
+    OIIO_ASSERT(R.localpixels() && A.localpixels()
+                && R.spec().format == TypeFloat && A.spec().format == TypeFloat
+                && R.nchannels() == 4 && A.nchannels() == 4);
     parallel_image(roi, parallel_image_options(nthreads), [&](ROI roi) {
         int width = roi.width();
         // Temporary space to hold one RGBA scanline

--- a/src/libOpenImageIO/compute_test.cpp
+++ b/src/libOpenImageIO/compute_test.cpp
@@ -47,11 +47,11 @@ static void
 test_arrays(ROI roi)
 {
     const float* a = (const float*)imgA.localpixels();
-    ASSERT(a);
+    OIIO_DASSERT(a);
     const float* b = (const float*)imgB.localpixels();
-    ASSERT(b);
+    OIIO_DASSERT(b);
     float* r = (float*)imgR.localpixels();
-    ASSERT(r);
+    OIIO_DASSERT(r);
     for (int x = 0; x < size; ++x)
         r[x] = a[x] * a[x] + b[x];
 }
@@ -62,11 +62,11 @@ static void
 test_arrays_like_image(ROI roi)
 {
     const float* a = (const float*)imgA.localpixels();
-    ASSERT(a);
+    OIIO_DASSERT(a);
     const float* b = (const float*)imgB.localpixels();
-    ASSERT(b);
+    OIIO_DASSERT(b);
     float* r = (float*)imgR.localpixels();
-    ASSERT(r);
+    OIIO_DASSERT(r);
     int nchannels = imgA.nchannels();
     for (int y = roi.ybegin; y < roi.yend; ++y) {
         for (int x = roi.xbegin; x < roi.xend; ++x) {
@@ -83,11 +83,11 @@ static void
 test_arrays_simd4(ROI roi)
 {
     const float* a = (const float*)imgA.localpixels();
-    ASSERT(a);
+    OIIO_DASSERT(a);
     const float* b = (const float*)imgB.localpixels();
-    ASSERT(b);
+    OIIO_DASSERT(b);
     float* r = (float*)imgR.localpixels();
-    ASSERT(r);
+    OIIO_DASSERT(r);
     int x, end4 = size - (size & 3);
     for (x = 0; x < end4; x += 4, a += 4, b += 4, r += 4) {
         simd::vfloat4 a_simd(a), b_simd(b);
@@ -104,11 +104,11 @@ static void
 test_arrays_like_image_simd(ROI roi)
 {
     const float* a = (const float*)imgA.localpixels();
-    ASSERT(a);
+    OIIO_DASSERT(a);
     const float* b = (const float*)imgB.localpixels();
-    ASSERT(b);
+    OIIO_DASSERT(b);
     float* r = (float*)imgR.localpixels();
-    ASSERT(r);
+    OIIO_DASSERT(r);
     int nchannels = imgA.nchannels();
     for (int y = roi.ybegin; y < roi.yend; ++y) {
         for (int x = roi.xbegin; x < roi.xend; ++x) {

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -103,8 +103,8 @@ public:
 
     size_t data_offset(int64_t pixel, int channel, int sample)
     {
-        DASSERT(int(m_cumcapacity.size()) > pixel);
-        DASSERT(m_capacity[pixel] >= m_nsamples[pixel]);
+        OIIO_DASSERT(int(m_cumcapacity.size()) > pixel);
+        OIIO_DASSERT(m_capacity[pixel] >= m_nsamples[pixel]);
         return (m_cumcapacity[pixel] + sample) * m_samplesize
                + m_channeloffsets[channel];
     }
@@ -112,7 +112,7 @@ public:
     void* data_ptr(int64_t pixel, int channel, int sample)
     {
         size_t offset = data_offset(pixel, channel, sample);
-        DASSERT(offset < m_data.size());
+        OIIO_DASSERT(offset < m_data.size());
         return &m_data[offset];
     }
 
@@ -124,19 +124,19 @@ public:
     inline void sanity() const
     {
         // int nchannels = int (m_channeltypes.size());
-        ASSERT(m_channeltypes.size() == m_channelsizes.size());
-        ASSERT(m_channeltypes.size() == m_channeloffsets.size());
+        OIIO_ASSERT(m_channeltypes.size() == m_channelsizes.size());
+        OIIO_ASSERT(m_channeltypes.size() == m_channeloffsets.size());
         int64_t npixels = int64_t(m_capacity.size());
-        ASSERT(m_nsamples.size() == m_capacity.size());
-        ASSERT(m_cumcapacity.size() == m_capacity.size());
+        OIIO_ASSERT(m_nsamples.size() == m_capacity.size());
+        OIIO_ASSERT(m_cumcapacity.size() == m_capacity.size());
         if (m_allocated) {
             size_t totalcapacity = 0;
             for (int64_t p = 0; p < npixels; ++p) {
-                ASSERT(m_cumcapacity[p] == totalcapacity);
+                OIIO_ASSERT(m_cumcapacity[p] == totalcapacity);
                 totalcapacity += m_capacity[p];
-                ASSERT(m_capacity[p] >= m_nsamples[p]);
+                OIIO_ASSERT(m_capacity[p] >= m_nsamples[p]);
             }
-            ASSERT(totalcapacity * m_samplesize == m_data.size());
+            OIIO_ASSERT(totalcapacity * m_samplesize == m_data.size());
         }
     }
 };
@@ -266,7 +266,7 @@ DeepData::AB_channel() const
 string_view
 DeepData::channelname(int c) const
 {
-    DASSERT(m_impl);
+    OIIO_DASSERT(m_impl);
     return (c >= 0 && c < m_nchannels) ? string_view(m_impl->m_channelnames[c])
                                        : string_view();
 }
@@ -276,7 +276,7 @@ DeepData::channelname(int c) const
 TypeDesc
 DeepData::channeltype(int c) const
 {
-    DASSERT(m_impl);
+    OIIO_DASSERT(m_impl);
     return (c >= 0 && c < m_nchannels) ? m_impl->m_channeltypes[c] : TypeDesc();
 }
 
@@ -285,7 +285,7 @@ DeepData::channeltype(int c) const
 size_t
 DeepData::channelsize(int c) const
 {
-    DASSERT(m_impl);
+    OIIO_DASSERT(m_impl);
     return (c >= 0 && c < m_nchannels) ? m_impl->m_channelsizes[c] : 0;
 }
 
@@ -317,7 +317,7 @@ DeepData::init(int64_t npix, int nchan, cspan<TypeDesc> channeltypes,
     clear();
     m_npixels   = npix;
     m_nchannels = nchan;
-    ASSERT(channeltypes.size() >= 1);
+    OIIO_ASSERT(channeltypes.size() >= 1);
     if (!m_impl)
         m_impl = new Impl;
     if (int(channeltypes.size()) >= nchan) {
@@ -458,7 +458,7 @@ DeepData::capacity(int64_t pixel) const
 {
     if (pixel < 0 || pixel >= m_npixels)
         return 0;
-    DASSERT(m_impl && m_impl->m_capacity.size() > size_t(pixel));
+    OIIO_DASSERT(m_impl && m_impl->m_capacity.size() > size_t(pixel));
     return m_impl->m_capacity[pixel];
 }
 
@@ -469,7 +469,7 @@ DeepData::set_capacity(int64_t pixel, int samps)
 {
     if (pixel < 0 || pixel >= m_npixels)
         return;
-    ASSERT(m_impl);
+    OIIO_DASSERT(m_impl);
     spin_lock lock(m_impl->m_mutex);
     if (m_impl->m_allocated) {
         // Data already allocated. Expand capacity if necessary, don't
@@ -502,7 +502,7 @@ DeepData::samples(int64_t pixel) const
 {
     if (pixel < 0 || pixel >= m_npixels)
         return 0;
-    DASSERT(m_impl);
+    OIIO_DASSERT(m_impl);
     return m_impl->m_nsamples[pixel];
 }
 
@@ -513,7 +513,7 @@ DeepData::set_samples(int64_t pixel, int samps)
 {
     if (pixel < 0 || pixel >= m_npixels)
         return;
-    ASSERT(m_impl);
+    OIIO_DASSERT(m_impl);
     if (m_impl->m_allocated) {
         // Data already allocated. Turn it into an insert or delete
         int n = (int)m_impl->m_nsamples[pixel];
@@ -535,7 +535,7 @@ DeepData::set_all_samples(cspan<unsigned int> samples)
 {
     if (samples.size() != m_npixels)
         return;
-    ASSERT(m_impl);
+    OIIO_DASSERT(m_impl);
     if (m_impl->m_allocated) {
         // Data already allocated: set pixels individually
         for (int64_t p = 0; p < m_npixels; ++p)
@@ -650,8 +650,8 @@ DeepData::deep_value(int64_t pixel, int channel, int sample) const
     case TypeDesc::INT64:
         return ConstDataArrayProxy<long long, float>((const long long*)ptr)[0];
     default:
-        ASSERT_MSG(0, "Unknown/unsupported data type %d",
-                   channeltype(channel).basetype);
+        OIIO_ASSERT_MSG(0, "Unknown/unsupported data type %d",
+                        channeltype(channel).basetype);
         return 0.0f;
     }
 }
@@ -689,8 +689,8 @@ DeepData::deep_value_uint(int64_t pixel, int channel, int sample) const
         return ConstDataArrayProxy<long long, uint32_t>(
             (const long long*)ptr)[0];
     default:
-        ASSERT_MSG(0, "Unknown/unsupported data type %d",
-                   channeltype(channel).basetype);
+        OIIO_ASSERT_MSG(0, "Unknown/unsupported data type %d",
+                        channeltype(channel).basetype);
         return 0;
     }
 }
@@ -733,8 +733,8 @@ DeepData::set_deep_value(int64_t pixel, int channel, int sample, float value)
         DataArrayProxy<int64_t, float>((int64_t*)ptr)[0] = value;
         break;
     default:
-        ASSERT_MSG(0, "Unknown/unsupported data type %d",
-                   channeltype(channel).basetype);
+        OIIO_ASSERT_MSG(0, "Unknown/unsupported data type %d",
+                        channeltype(channel).basetype);
     }
 }
 
@@ -779,8 +779,8 @@ DeepData::set_deep_value(int64_t pixel, int channel, int sample, uint32_t value)
         DataArrayProxy<int64_t, uint32_t>((int64_t*)ptr)[0] = value;
         break;
     default:
-        ASSERT_MSG(0, "Unknown/unsupported data type %d",
-                   channeltype(channel).basetype);
+        OIIO_ASSERT_MSG(0, "Unknown/unsupported data type %d",
+                        channeltype(channel).basetype);
     }
 }
 
@@ -789,7 +789,7 @@ DeepData::set_deep_value(int64_t pixel, int channel, int sample, uint32_t value)
 cspan<TypeDesc>
 DeepData::all_channeltypes() const
 {
-    ASSERT(m_impl);
+    OIIO_DASSERT(m_impl);
     return m_impl->m_channeltypes;
 }
 
@@ -798,7 +798,7 @@ DeepData::all_channeltypes() const
 cspan<unsigned int>
 DeepData::all_samples() const
 {
-    ASSERT(m_impl);
+    OIIO_DASSERT(m_impl);
     return m_impl->m_nsamples;
 }
 
@@ -807,7 +807,7 @@ DeepData::all_samples() const
 cspan<char>
 DeepData::all_data() const
 {
-    ASSERT(m_impl);
+    OIIO_DASSERT(m_impl);
     m_impl->alloc(m_npixels);
     return m_impl->m_data;
 }
@@ -817,7 +817,7 @@ DeepData::all_data() const
 void
 DeepData::get_pointers(std::vector<void*>& pointers) const
 {
-    ASSERT(m_impl);
+    OIIO_DASSERT(m_impl);
     m_impl->alloc(m_npixels);
     pointers.resize(pixels() * channels());
     for (int64_t i = 0; i < m_npixels; ++i) {
@@ -862,7 +862,7 @@ DeepData::copy_deep_pixel(int64_t pixel, const DeepData& src, int64_t srcpixel)
 {
     if (pixel < 0 || pixel >= pixels()) {
         // std::cout << "dst pixel was " << pixel << "\n";
-        DASSERT(0 && "Out of range pixel index");
+        OIIO_DASSERT(0 && "Out of range pixel index");
         return false;
     }
     if (srcpixel < 0 || srcpixel >= src.pixels()) {
@@ -873,7 +873,7 @@ DeepData::copy_deep_pixel(int64_t pixel, const DeepData& src, int64_t srcpixel)
     }
     int nchans = channels();
     if (nchans != src.channels()) {
-        DASSERT(0 && "Number of channels don't match.");
+        OIIO_DASSERT(0 && "Number of channels don't match.");
         return false;
     }
     int nsamples = src.samples(srcpixel);

--- a/src/libOpenImageIO/exif-canon.cpp
+++ b/src/libOpenImageIO/exif-canon.cpp
@@ -631,7 +631,8 @@ array_to_spec (ImageSpec& spec,                 // spec to put attribs into
             return;
     }
     else {
-        ASSERT(0 && "unsupported type");
+        OIIO_ASSERT(0 && "unsupported type");
+        return;
     }
     const T *s = (const T *) pvt::dataptr (dir, buf, offset_adjustment);
     if (!s)

--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -635,7 +635,7 @@ add_exif_item_to_spec(ImageSpec& spec, const char* name,
                       const TIFFDirEntry* dirp, cspan<uint8_t> buf, bool swab,
                       int offset_adjustment = 0)
 {
-    ASSERT(dirp);
+    OIIO_ASSERT(dirp);
     const uint8_t* dataptr = (const uint8_t*)pvt::dataptr(*dirp, buf,
                                                           offset_adjustment);
     if (!dataptr)
@@ -1352,7 +1352,7 @@ encode_exif(const ImageSpec& spec, std::vector<char>& blob,
 
     // If any Maker info was found, add a MakerNote tag to the Exif dirs
     if (makerdirs.size()) {
-        ASSERT(exifdirs.size());
+        OIIO_ASSERT(exifdirs.size());
         // unsigned int size = (unsigned int) makerdirs_offset;
         append_tiff_dir_entry(exifdirs, blob, EXIF_MAKERNOTE, TIFF_BYTE,
                               makerdirs_size, nullptr, 0, makerdirs_offset,
@@ -1395,19 +1395,19 @@ encode_exif(const ImageSpec& spec, std::vector<char>& blob,
     appendvec(blob, tiffdirs);                           // tiff dirs
     append(blob, uint32_t(0));  // addr of next IFD (none)
     if (exifdirs.size()) {
-        ASSERT(blob.size() == exifdirs_offset + tiffstart);
+        OIIO_ASSERT(blob.size() == exifdirs_offset + tiffstart);
         append(blob, uint16_t(exifdirs.size()), endianreq);  // ndirs for exif
         appendvec(blob, exifdirs);                           // exif dirs
         append(blob, uint32_t(0));  // addr of next IFD (none)
     }
     if (gpsdirs.size()) {
-        ASSERT(blob.size() == gpsdirs_offset + tiffstart);
+        OIIO_ASSERT(blob.size() == gpsdirs_offset + tiffstart);
         append(blob, uint16_t(gpsdirs.size()), endianreq);  // ndirs for gps
         appendvec(blob, gpsdirs);                           // gps dirs
         append(blob, uint32_t(0));  // addr of next IFD (none)
     }
     if (makerdirs.size()) {
-        ASSERT(blob.size() == makerdirs_offset + tiffstart);
+        OIIO_ASSERT(blob.size() == makerdirs_offset + tiffstart);
         append(blob, uint16_t(makerdirs.size()), endianreq);  // ndirs for canon
         appendvec(blob, makerdirs);                           // canon dirs
         append(blob, uint32_t(0));  // addr of next IFD (none)

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -98,7 +98,7 @@ pvt::get_default_quantize(TypeDesc format, long long& quant_min,
     case TypeDesc::DOUBLE:
         get_default_quantize_<double>(quant_min, quant_max);
         break;
-    default: ASSERT_MSG(0, "Unknown data format %d", format.basetype);
+    default: OIIO_ASSERT_MSG(0, "Unknown data format %d", format.basetype);
     }
 }
 
@@ -560,7 +560,7 @@ ImageSpec::get_string_attribute(string_view name, string_view defaultval) const
 int
 ImageSpec::channelindex(string_view name) const
 {
-    ASSERT(nchannels == int(channelnames.size()));
+    OIIO_DASSERT(nchannels == int(channelnames.size()));
     for (int i = 0; i < nchannels; ++i)
         if (channelnames[i] == name)
             return i;

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -340,7 +340,7 @@ ImageBufImpl::ImageBufImpl(string_view filename, int subimage, int miplevel,
         }
         m_spec_valid = true;
     } else if (filename.length() > 0) {
-        ASSERT(buffer == NULL);
+        OIIO_DASSERT(buffer == nullptr);
         // If a filename was given, read the spec and set it up as an
         // ImageCache-backed image.  Reallocate later if an explicit read()
         // is called to force read into a local buffer.
@@ -350,7 +350,7 @@ ImageBufImpl::ImageBufImpl(string_view filename, int subimage, int miplevel,
         // FIXME: investigate if the above read is really necessary, or if
         // it can be eliminated and done fully lazily.
     } else {
-        ASSERT(buffer == NULL);
+        OIIO_DASSERT(buffer == nullptr);
     }
 }
 
@@ -583,8 +583,9 @@ void
 ImageBufImpl::error(const std::string& message) const
 {
     spin_lock lock(err_mutex);
-    ASSERT(m_err.size() < 1024 * 1024 * 16
-           && "Accumulated error messages > 16MB. Try checking return codes!");
+    OIIO_ASSERT(
+        m_err.size() < 1024 * 1024 * 16
+        && "Accumulated error messages > 16MB. Try checking return codes!");
     if (m_err.size() && m_err[m_err.size() - 1] != '\n')
         m_err += '\n';
     m_err += message;
@@ -1194,7 +1195,6 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
     // cache holds an open file handle for reading, we will not be able to
     // open the same file for writing.
     ImageCache* shared_imagecache = ImageCache::create(true);
-    ASSERT(shared_imagecache);
     ustring ufilename(filename);
     shared_imagecache->invalidate(ufilename);  // the shared IC
     if (imagecache() && imagecache() != shared_imagecache)
@@ -1544,7 +1544,7 @@ copy_pixels_impl(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads = 0)
                         D* draw       = (D*)dst.pixeladdr(roi.xbegin, y, z);
                         const S* sraw = (const S*)src.pixeladdr(roi.xbegin, y,
                                                                 z);
-                        DASSERT(draw && sraw);
+                        OIIO_DASSERT(draw && sraw);
                         for (int x = 0; x < nxvalues; ++x)
                             draw[x] = sraw[x];
                     }
@@ -1879,8 +1879,8 @@ ImageBuf::setpixel(int x, int y, int z, const float* pixel, int maxchannels)
         break;
     case TypeDesc::INT64: setpixel_<long long>(*this, x, y, z, pixel, n); break;
     default:
-        ASSERTMSG(0, "Unknown/unsupported data type %d",
-                  spec().format.basetype);
+        OIIO_ASSERT_MSG(0, "Unknown/unsupported data type %d",
+                        spec().format.basetype);
     }
 }
 
@@ -2416,9 +2416,9 @@ ImageBufImpl::do_wrap(int& x, int& y, int& z, ImageBuf::WrapMode wrap) const
 
     // Double check that we're outside the data window -- supposedly a
     // precondition of calling this method.
-    DASSERT(!(x >= m_spec.x && x < m_spec.x + m_spec.width && y >= m_spec.y
-              && y < m_spec.y + m_spec.height && z >= m_spec.z
-              && z < m_spec.z + m_spec.depth));
+    OIIO_DASSERT(!(x >= m_spec.x && x < m_spec.x + m_spec.width && y >= m_spec.y
+                   && y < m_spec.y + m_spec.height && z >= m_spec.z
+                   && z < m_spec.z + m_spec.depth));
 
     // Wrap based on the display window
     if (wrap == ImageBuf::WrapBlack) {
@@ -2440,7 +2440,7 @@ ImageBufImpl::do_wrap(int& x, int& y, int& z, ImageBuf::WrapMode wrap) const
         wrap_mirror(y, m_spec.full_y, m_spec.full_height);
         wrap_mirror(z, m_spec.full_z, m_spec.full_depth);
     } else {
-        ASSERT_MSG(0, "unknown wrap mode %d", (int)wrap);
+        OIIO_ASSERT_MSG(0, "unknown wrap mode %d", (int)wrap);
     }
 
     // Now determine if the new position is within the data window
@@ -2491,14 +2491,14 @@ ImageBufImpl::retile(int x, int y, int z, ImageCache::Tile*& tile,
         // tile.
     }
 
-    DASSERT(x >= m_spec.x && x < m_spec.x + m_spec.width && y >= m_spec.y
-            && y < m_spec.y + m_spec.height && z >= m_spec.z
-            && z < m_spec.z + m_spec.depth);
+    OIIO_DASSERT(x >= m_spec.x && x < m_spec.x + m_spec.width && y >= m_spec.y
+                 && y < m_spec.y + m_spec.height && z >= m_spec.z
+                 && z < m_spec.z + m_spec.depth);
 
     int tw = m_spec.tile_width, th = m_spec.tile_height;
     int td = m_spec.tile_depth;
-    DASSERT(m_spec.tile_depth >= 1);
-    DASSERT(tile == NULL || tilexend == (tilexbegin + tw));
+    OIIO_DASSERT(m_spec.tile_depth >= 1);
+    OIIO_DASSERT(tile == NULL || tilexend == (tilexbegin + tw));
     if (tile == NULL || x < tilexbegin || x >= tilexend || y < tileybegin
         || y >= (tileybegin + th) || z < tilezbegin || z >= (tilezbegin + td)) {
         // not the same tile as before
@@ -2525,8 +2525,8 @@ ImageBufImpl::retile(int x, int y, int z, ImageCache::Tile*& tile,
                         * (size_t)tw
                     + (x - tilexbegin);
     offset *= m_spec.pixel_bytes();
-    DASSERTMSG(m_spec.pixel_bytes() == m_pixel_bytes, "%d vs %d",
-               (int)m_spec.pixel_bytes(), (int)m_pixel_bytes);
+    OIIO_DASSERT_MSG(m_spec.pixel_bytes() == m_pixel_bytes, "%d vs %d",
+                     (int)m_spec.pixel_bytes(), (int)m_pixel_bytes);
 
     TypeDesc format;
     const void* pixeldata = m_imagecache->tile_pixels(tile, format);

--- a/src/libOpenImageIO/imagebuf_test.cpp
+++ b/src/libOpenImageIO/imagebuf_test.cpp
@@ -245,7 +245,7 @@ test_empty_iterator()
 void
 print(const ImageBuf& A)
 {
-    ASSERT(A.spec().format == TypeDesc::FLOAT);
+    OIIO_DASSERT(A.spec().format == TypeDesc::FLOAT);
     for (ImageBuf::ConstIterator<float> p(A); !p.done(); ++p) {
         std::cout << "   @" << p.x() << ',' << p.y() << "=(";
         for (int c = 0; c < A.nchannels(); ++c)

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -64,7 +64,7 @@ ImageBufAlgo::IBAprep(ROI& roi, ImageBuf* dst, const ImageBuf* A,
                       const ImageBuf* B, const ImageBuf* C,
                       ImageSpec* force_spec, int prepflags)
 {
-    ASSERT(dst);
+    OIIO_DASSERT(dst);
     if ((A && !A->initialized()) || (B && !B->initialized())
         || (C && !C->initialized())) {
         dst->errorf("Uninitialized input image");
@@ -385,9 +385,9 @@ convolve_(ImageBuf& dst, const ImageBuf& src, const ImageBuf& kernel,
           bool normalize, ROI roi, int nthreads)
 {
     using namespace ImageBufAlgo;
+    OIIO_DASSERT(kernel.spec().format == TypeDesc::FLOAT && kernel.localpixels()
+                 && "kernel should be float and in local memory");
     parallel_image(roi, nthreads, [&](ROI roi) {
-        ASSERT(kernel.spec().format == TypeDesc::FLOAT && kernel.localpixels()
-               && "kernel should be float and in local memory");
         ROI kroi   = kernel.roi();
         int kchans = kernel.nchannels();
 
@@ -549,7 +549,7 @@ ImageBufAlgo::make_kernel(string_view name, float width, float height,
 static bool
 threshold_to_zero(ImageBuf& dst, float threshold, ROI roi, int nthreads)
 {
-    ASSERT(dst.spec().format.basetype == TypeDesc::FLOAT);
+    OIIO_DASSERT(dst.spec().format.basetype == TypeDesc::FLOAT);
 
     ImageBufAlgo::parallel_image(roi, nthreads, [&](ROI roi) {
         for (ImageBuf::Iterator<float> p(dst, roi); !p.done(); ++p)
@@ -783,7 +783,7 @@ morph_impl(ImageBuf& R, const ImageBuf& A, int width, int height, MorphOp op,
                     }
                 }
             } else {
-                ASSERT(0 && "Unknown morphological operator");
+                OIIO_ASSERT(0 && "Unknown morphological operator");
             }
             for (int c = 0; c < nchannels; ++c)
                 r[c] = vals[c];
@@ -861,14 +861,14 @@ static bool
 hfft_(ImageBuf& dst, const ImageBuf& src, bool inverse, bool unitary, ROI roi,
       int nthreads)
 {
-    ASSERT(dst.spec().format.basetype == TypeDesc::FLOAT
-           && src.spec().format.basetype == TypeDesc::FLOAT
-           && dst.spec().nchannels == 2 && src.spec().nchannels == 2
-           && dst.roi() == src.roi()
-           && (dst.storage() == ImageBuf::LOCALBUFFER
-               || dst.storage() == ImageBuf::APPBUFFER)
-           && (src.storage() == ImageBuf::LOCALBUFFER
-               || src.storage() == ImageBuf::APPBUFFER));
+    OIIO_ASSERT(dst.spec().format.basetype == TypeDesc::FLOAT
+                && src.spec().format.basetype == TypeDesc::FLOAT
+                && dst.spec().nchannels == 2 && src.spec().nchannels == 2
+                && dst.roi() == src.roi()
+                && (dst.storage() == ImageBuf::LOCALBUFFER
+                    || dst.storage() == ImageBuf::APPBUFFER)
+                && (src.storage() == ImageBuf::LOCALBUFFER
+                    || src.storage() == ImageBuf::APPBUFFER));
 
     ImageBufAlgo::parallel_image(roi, nthreads, [&](ROI roi) {
         int width     = roi.width();
@@ -1166,9 +1166,9 @@ ImageBufAlgo::complex_to_polar(const ImageBuf& src, ROI roi, int nthreads)
 static bool
 divide_by_alpha(ImageBuf& dst, ROI roi, int nthreads)
 {
+    OIIO_ASSERT(dst.spec().format == TypeDesc::FLOAT);
     ImageBufAlgo::parallel_image(roi, nthreads, [&](ROI roi) {
         const ImageSpec& spec(dst.spec());
-        ASSERT(spec.format == TypeDesc::FLOAT);
         int nc = spec.nchannels;
         int ac = spec.alpha_channel;
         for (ImageBuf::Iterator<float> d(dst, roi); !d.done(); ++d) {

--- a/src/libOpenImageIO/imagebufalgo_addsub.cpp
+++ b/src/libOpenImageIO/imagebufalgo_addsub.cpp
@@ -62,7 +62,7 @@ static bool
 add_impl_deep(ImageBuf& R, const ImageBuf& A, cspan<float> b, ROI roi,
               int nthreads)
 {
-    ASSERT(R.deep());
+    OIIO_ASSERT(R.deep());
     ImageBufAlgo::parallel_image(roi, nthreads, [&](ROI roi) {
         cspan<TypeDesc> channeltypes(R.deepdata()->all_channeltypes());
         ImageBuf::Iterator<float> r(R, roi);
@@ -104,7 +104,7 @@ ImageBufAlgo::add(ImageBuf& dst, Image_or_Const A_, Image_or_Const B_, ROI roi,
             // the bigger of them, but adjusted roi to be the lesser. Now handle
             // the channels that got left out because they were not common to
             // all the inputs.
-            ASSERT(roi.chend <= dst.nchannels());
+            OIIO_ASSERT(roi.chend <= dst.nchannels());
             roi.chbegin = roi.chend;
             roi.chend   = origroi.chend;
             if (A.nchannels() > B.nchannels()) {  // A exists
@@ -191,7 +191,7 @@ ImageBufAlgo::sub(ImageBuf& dst, Image_or_Const A_, Image_or_Const B_, ROI roi,
             // the bigger of them, but adjusted roi to be the lesser. Now handle
             // the channels that got left out because they were not common to
             // all the inputs.
-            ASSERT(roi.chend <= dst.nchannels());
+            OIIO_ASSERT(roi.chend <= dst.nchannels());
             roi.chbegin = roi.chend;
             roi.chend   = origroi.chend;
             if (A.nchannels() > B.nchannels()) {  // A exists

--- a/src/libOpenImageIO/imagebufalgo_channels.cpp
+++ b/src/libOpenImageIO/imagebufalgo_channels.cpp
@@ -140,7 +140,7 @@ ImageBufAlgo::channels(ImageBuf& dst, const ImageBuf& src, int nchannels,
 
     if (dst.deep()) {
         // Deep case:
-        ASSERT(src.deep() && src.deepdata() && dst.deepdata());
+        OIIO_DASSERT(src.deep() && src.deepdata() && dst.deepdata());
         const DeepData& srcdata(*src.deepdata());
         DeepData& dstdata(*dst.deepdata());
         // The earlier dst.alloc() already called dstdata.init()

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -46,7 +46,7 @@ ImageBufAlgo::PixelStats::reset(int nchannels)
 void
 ImageBufAlgo::PixelStats::merge(const ImageBufAlgo::PixelStats& p)
 {
-    ASSERT(min.size() == p.min.size());
+    OIIO_DASSERT(min.size() == p.min.size());
     for (size_t c = 0, e = min.size(); c < e; ++c) {
         min[c] = std::min(min[c], p.min[c]);
         max[c] = std::max(max[c], p.max[c]);
@@ -696,7 +696,7 @@ ImageBufAlgo::color_range_check(const ImageBuf& src, imagesize_t* lowcount,
 static ROI
 deep_nonempty_region(const ImageBuf& src, ROI roi)
 {
-    DASSERT(src.deep());
+    OIIO_DASSERT(src.deep());
     ROI r;  // Initially undefined
     for (int z = roi.zbegin; z < roi.zend; ++z)
         for (int y = roi.ybegin; y < roi.yend; ++y)
@@ -792,7 +792,7 @@ simplePixelHashSHA1(const ImageBuf& src, string_view extrainfo, ROI roi)
 
     bool localpixels           = src.localpixels();
     imagesize_t scanline_bytes = roi.width() * src.spec().pixel_bytes();
-    ASSERT(scanline_bytes < std::numeric_limits<unsigned int>::max());
+    OIIO_ASSERT(scanline_bytes < std::numeric_limits<unsigned int>::max());
     // Do it a few scanlines at a time
     int chunk = std::max(1, int(16 * 1024 * 1024 / scanline_bytes));
 
@@ -846,7 +846,7 @@ ImageBufAlgo::computePixelHashSHA1(const ImageBuf& src, string_view extrainfo,
 
     // clang-format off
     int nblocks = (roi.height() + blocksize - 1) / blocksize;
-    ASSERT(nblocks > 1);
+    OIIO_ASSERT(nblocks > 1);
     std::vector<std::string> results(nblocks);
     parallel_for_chunked(roi.ybegin, roi.yend, blocksize,
                          [&](int64_t ybegin, int64_t yend) {

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -61,7 +61,7 @@ static bool
 deep_paste_(ImageBuf& dst, const ImageBuf& src, ROI dstroi, ROI srcroi,
             int nthreads)
 {
-    ASSERT(dst.deep() && src.deep());
+    OIIO_ASSERT(dst.deep() && src.deep());
     int relative_x = dstroi.xbegin - srcroi.xbegin;
     int relative_y = dstroi.ybegin - srcroi.ybegin;
     int relative_z = dstroi.zbegin - srcroi.zbegin;
@@ -159,7 +159,7 @@ copy_(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads = 1)
 static bool
 copy_deep(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads = 1)
 {
-    ASSERT(dst.deep() && src.deep());
+    OIIO_ASSERT(dst.deep() && src.deep());
     using namespace ImageBufAlgo;
     parallel_image(roi, nthreads, [&](ROI roi) {
         DeepData& dstdeep(*dst.deepdata());
@@ -170,7 +170,7 @@ copy_deep(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads = 1)
             // The caller should ALREADY have set the samples, since that
             // is not thread-safe against the copying below.
             // d.set_deep_samples (samples);
-            DASSERT(d.deep_samples() == samples);
+            OIIO_DASSERT(d.deep_samples() == samples);
             if (samples == 0)
                 continue;
             for (int c = roi.chbegin; c < roi.chend; ++c) {

--- a/src/libOpenImageIO/imagebufalgo_deep.cpp
+++ b/src/libOpenImageIO/imagebufalgo_deep.cpp
@@ -336,10 +336,10 @@ ImageBufAlgo::deep_merge(ImageBuf& dst, const ImageBuf& A, const ImageBuf& B,
             for (int x = roi.xbegin; x < roi.xend; ++x) {
                 int dstpixel = dst.pixelindex(x, y, z, true);
                 int Bpixel   = B.pixelindex(x, y, z, true);
-                DASSERT(dstpixel >= 0);
+                OIIO_DASSERT(dstpixel >= 0);
                 // OIIO_UNUSED_OK int oldcap = dstdd.capacity (dstpixel);
                 dstdd.merge_deep_pixels(dstpixel, Bdd, Bpixel);
-                // DASSERT (oldcap == dstdd.capacity(dstpixel) &&
+                // OIIO_DASSERT (oldcap == dstdd.capacity(dstpixel) &&
                 //          "Broken: we did not preallocate enough capacity");
                 if (occlusion_cull)
                     dstdd.occlusion_cull(dstpixel);

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -800,7 +800,6 @@ resolve_font(int fontsize, string_view font_, std::string& result)
         font = f;
     }
 
-    ASSERT(!font.empty());
     if (!Filesystem::is_regular(font)) {
         result = Strutil::sprintf("Could not find font \"%s\"", font);
         return false;

--- a/src/libOpenImageIO/imagebufalgo_mad.cpp
+++ b/src/libOpenImageIO/imagebufalgo_mad.cpp
@@ -55,7 +55,7 @@ mad_impl(ImageBuf& R, const ImageBuf& A, const ImageBuf& B, const ImageBuf& C,
                         = (const ABCtype*)B.pixeladdr(roi.xbegin, y, z);
                     const ABCtype* craw
                         = (const ABCtype*)C.pixeladdr(roi.xbegin, y, z);
-                    DASSERT(araw && braw && craw);
+                    OIIO_DASSERT(araw && braw && craw);
                     // The straightforward loop auto-vectorizes very well,
                     // there's no benefit to using explicit SIMD here.
                     for (int x = 0; x < nxvalues; ++x)

--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -132,7 +132,7 @@ ImageBufAlgo::to_IplImage(const ImageBuf& src)
 
     // Make sure the image buffer is initialized.
     if (!tmp.initialized() && !tmp.read(tmp.subimage(), tmp.miplevel(), true)) {
-        DASSERT(0 && "Could not initialize ImageBuf.");
+        OIIO_DASSERT(0 && "Could not initialize ImageBuf.");
         return NULL;
     }
 
@@ -161,13 +161,13 @@ ImageBufAlgo::to_IplImage(const ImageBuf& src)
         dstFormat     = IPL_DEPTH_64F;
         dstSpecFormat = spec.format;
     } else {
-        DASSERT(0 && "Unknown data format in ImageBuf.");
+        OIIO_DASSERT(0 && "Unknown data format in ImageBuf.");
         return NULL;
     }
     IplImage* ipl = cvCreateImage(cvSize(spec.width, spec.height), dstFormat,
                                   spec.nchannels);
     if (!ipl) {
-        DASSERT(0 && "Unable to create IplImage.");
+        OIIO_DASSERT(0 && "Unable to create IplImage.");
         return NULL;
     }
 
@@ -183,7 +183,7 @@ ImageBufAlgo::to_IplImage(const ImageBuf& src)
                                    linestep, 0);
 
     if (!converted) {
-        DASSERT(0 && "convert_image failed.");
+        OIIO_DASSERT(0 && "convert_image failed.");
         cvReleaseImage(&ipl);
         return NULL;
     }
@@ -307,12 +307,12 @@ ImageBufAlgo::to_OpenCV(cv::Mat& dst, const ImageBuf& src, ROI roi,
     } else if (spec.format == TypeDesc(TypeDesc::DOUBLE)) {
         dstFormat = CV_MAKETYPE(CV_64F, chans);
     } else {
-        DASSERT(0 && "Unknown data format in ImageBuf.");
+        OIIO_DASSERT(0 && "Unknown data format in ImageBuf.");
         return false;
     }
     cv::Mat mat(roi.height(), roi.width(), dstFormat);
     if (mat.empty()) {
-        DASSERT(0 && "Unable to create cv::Mat.");
+        OIIO_DASSERT(0 && "Unable to create cv::Mat.");
         return false;
     }
 
@@ -325,7 +325,7 @@ ImageBufAlgo::to_OpenCV(cv::Mat& dst, const ImageBuf& src, ROI roi,
         dstSpecFormat, pixelsize, linestep, 0, -1, -1, nthreads);
 
     if (!converted) {
-        DASSERT(0 && "convert_image failed.");
+        OIIO_DASSERT(0 && "convert_image failed.");
         return false;
     }
 

--- a/src/libOpenImageIO/imagebufalgo_orient.cpp
+++ b/src/libOpenImageIO/imagebufalgo_orient.cpp
@@ -58,8 +58,8 @@ ImageBufAlgo::flip(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
     int start        = src_roi_full.yend - offset - src_roi.height();
     ROI dst_roi(src_roi.xbegin, src_roi.xend, start, start + src_roi.height(),
                 src_roi.zbegin, src_roi.zend, src_roi.chbegin, src_roi.chend);
-    ASSERT(dst_roi.width() == src_roi.width()
-           && dst_roi.height() == src_roi.height());
+    OIIO_DASSERT(dst_roi.width() == src_roi.width()
+                 && dst_roi.height() == src_roi.height());
 
     // Compute the destination ROI, it's the source ROI reflected across
     // the midline of the display window.
@@ -107,8 +107,8 @@ ImageBufAlgo::flop(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
     int start        = src_roi_full.xend - offset - src_roi.width();
     ROI dst_roi(start, start + src_roi.width(), src_roi.ybegin, src_roi.yend,
                 src_roi.zbegin, src_roi.zend, src_roi.chbegin, src_roi.chend);
-    ASSERT(dst_roi.width() == src_roi.width()
-           && dst_roi.height() == src_roi.height());
+    OIIO_DASSERT(dst_roi.width() == src_roi.width()
+                 && dst_roi.height() == src_roi.height());
 
     // Compute the destination ROI, it's the source ROI reflected across
     // the midline of the display window.
@@ -189,8 +189,8 @@ ImageBufAlgo::rotate90(ImageBuf& dst, const ImageBuf& src, ROI roi,
                 src_roi_full.yend - src_roi.ybegin, src_roi.xbegin,
                 src_roi.xend, src_roi.zbegin, src_roi.zend, src_roi.chbegin,
                 src_roi.chend);
-    ASSERT(dst_roi.width() == src_roi.height()
-           && dst_roi.height() == src_roi.width());
+    OIIO_DASSERT(dst_roi.width() == src_roi.height()
+                 && dst_roi.height() == src_roi.width());
 
     bool dst_initialized = dst.initialized();
     if (!IBAprep(dst_roi, &dst, &src))
@@ -245,8 +245,8 @@ ImageBufAlgo::rotate180(ImageBuf& dst, const ImageBuf& src, ROI roi,
     ROI dst_roi(xstart, xstart + src_roi.width(), ystart,
                 ystart + src_roi.height(), src_roi.zbegin, src_roi.zend,
                 src_roi.chbegin, src_roi.chend);
-    ASSERT(dst_roi.width() == src_roi.width()
-           && dst_roi.height() == src_roi.height());
+    OIIO_DASSERT(dst_roi.width() == src_roi.width()
+                 && dst_roi.height() == src_roi.height());
 
     // Compute the destination ROI, it's the source ROI reflected across
     // the midline of the display window.
@@ -303,8 +303,8 @@ ImageBufAlgo::rotate270(ImageBuf& dst, const ImageBuf& src, ROI roi,
                 src_roi_full.xend - src_roi.xbegin, src_roi.zbegin,
                 src_roi.zend, src_roi.chbegin, src_roi.chend);
 
-    ASSERT(dst_roi.width() == src_roi.height()
-           && dst_roi.height() == src_roi.width());
+    OIIO_DASSERT(dst_roi.width() == src_roi.height()
+                 && dst_roi.height() == src_roi.width());
 
     bool dst_initialized = dst.initialized();
     if (!IBAprep(dst_roi, &dst, &src))

--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -137,7 +137,7 @@ ImageBufAlgo::absdiff(ImageBuf& dst, Image_or_Const A_, Image_or_Const B_,
             // the bigger of them, but adjusted roi to be the lesser. Now handle
             // the channels that got left out because they were not common to
             // all the inputs.
-            ASSERT(roi.chend <= dst.nchannels());
+            OIIO_DASSERT(roi.chend <= dst.nchannels());
             roi.chbegin = roi.chend;
             roi.chend   = origroi.chend;
             if (A.nchannels() > B.nchannels()) {  // A exists
@@ -1371,11 +1371,11 @@ over_impl_rgbafloat(ImageBuf& R, const ImageBuf& A, const ImageBuf& B, ROI roi,
                     int nthreads)
 {
     using namespace simd;
-    ASSERT(A.localpixels() && B.localpixels() && A.spec().format == TypeFloat
-           && A.nchannels() == 4 && B.spec().format == TypeFloat
-           && B.nchannels() == 4 && A.spec().alpha_channel == 3
-           && A.spec().z_channel < 0 && B.spec().alpha_channel == 3
-           && B.spec().z_channel < 0);
+    OIIO_DASSERT(A.localpixels() && B.localpixels()
+                 && A.spec().format == TypeFloat && A.nchannels() == 4
+                 && B.spec().format == TypeFloat && B.nchannels() == 4
+                 && A.spec().alpha_channel == 3 && A.spec().z_channel < 0
+                 && B.spec().alpha_channel == 3 && B.spec().z_channel < 0);
     // const int nchannels = 4, alpha_channel = 3;
     ImageBufAlgo::parallel_image(roi, nthreads, [=, &R, &A, &B](ROI roi) {
         vfloat4 zero = vfloat4::Zero();

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -150,7 +150,7 @@ filtered_sample(const ImageBuf& src, float s, float t, float dsdx, float dtdx,
                 float dsdy, float dtdy, const Filter2D* filter,
                 ImageBuf::WrapMode wrap, float* result)
 {
-    DASSERT(filter);
+    OIIO_DASSERT(filter);
     // Just use isotropic filtering
     float ds          = std::max(1.0f, std::max(fabsf(dsdx), fabsf(dsdy)));
     float dt          = std::max(1.0f, std::max(fabsf(dtdx), fabsf(dtdy)));
@@ -354,7 +354,7 @@ resize_(ImageBuf& dst, const ImageBuf& src, Filter2D* filter, ROI roi,
                         }
                     }
                     // Copy the pixel value (already normalized) to the output.
-                    DASSERT(out.x() == x && out.y() == y);
+                    OIIO_DASSERT(out.x() == x && out.y() == y);
                     if (totalweight_y == 0.0f) {
                         // zero it out
                         for (int c = 0; c < nchannels; ++c)
@@ -387,7 +387,7 @@ resize_(ImageBuf& dst, const ImageBuf& src, Filter2D* filter, ROI roi,
                                    src_y + radi + 1, 0, 1, ImageBuf::WrapClamp);
                     for (int j = -radj; j <= radj; ++j) {
                         for (int i = -radi; i <= radi; ++i, ++srcpel) {
-                            DASSERT(!srcpel.done());
+                            OIIO_DASSERT(!srcpel.done());
                             float w
                                 = (*filter)(xratio * (i - (src_xf_frac - 0.5f)),
                                             yratio
@@ -399,10 +399,10 @@ resize_(ImageBuf& dst, const ImageBuf& src, Filter2D* filter, ROI roi,
                             }
                         }
                     }
-                    DASSERT(srcpel.done());
+                    OIIO_DASSERT(srcpel.done());
                     // Rescale pel to normalize the filter and write it to the
                     // output image.
-                    DASSERT(out.x() == x && out.y() == y);
+                    OIIO_DASSERT(out.x() == x && out.y() == y);
                     if (totalweight == 0.0f) {
                         // zero it out
                         for (int c = 0; c < nchannels; ++c)
@@ -695,12 +695,12 @@ static bool
 resample_(ImageBuf& dst, const ImageBuf& src, bool interpolate, ROI roi,
           int nthreads)
 {
+    OIIO_ASSERT(src.deep() == dst.deep());
     ImageBufAlgo::parallel_image(roi, nthreads, [&](ROI roi) {
         const ImageSpec& srcspec(src.spec());
         const ImageSpec& dstspec(dst.spec());
         int nchannels = src.nchannels();
         bool deep     = src.deep();
-        ASSERT(deep == dst.deep());
 
         // Local copies of the source image window, converted to float
         float srcfx = srcspec.full_x;
@@ -732,8 +732,8 @@ resample_(ImageBuf& dst, const ImageBuf& src, bool interpolate, ROI roi,
                 if (deep) {
                     srcpel.pos(src_x, src_y, 0);
                     int nsamps = srcpel.deep_samples();
-                    ASSERT(nsamps == out.deep_samples());
-                    if (!nsamps)
+                    OIIO_DASSERT(nsamps == out.deep_samples());
+                    if (!nsamps || nsamps != out.deep_samples())
                         continue;
                     for (int c = 0; c < nchannels; ++c) {
                         if (dstspec.channelformat(c) == TypeDesc::UINT32)

--- a/src/libOpenImageIO/imagebufalgo_yee.cpp
+++ b/src/libOpenImageIO/imagebufalgo_yee.cpp
@@ -59,13 +59,13 @@ public:
 
     ImageBuf& operator[](int lev)
     {
-        DASSERT(lev < PYRAMID_MAX_LEVELS);
+        OIIO_DASSERT(lev < PYRAMID_MAX_LEVELS);
         return level[lev];
     }
 
     float operator()(int x, int y, int lev) const
     {
-        DASSERT(lev < PYRAMID_MAX_LEVELS);
+        OIIO_DASSERT(lev < PYRAMID_MAX_LEVELS);
         return level[lev].getchannel(x, y, 0, 1);
     }
 

--- a/src/libOpenImageIO/imageinout_test.cpp
+++ b/src/libOpenImageIO/imageinout_test.cpp
@@ -25,7 +25,7 @@ make_test_image(string_view formatname)
 {
     ImageBuf buf;
     auto out = ImageOutput::create(formatname);
-    ASSERT(out);
+    OIIO_DASSERT(out);
     ImageSpec spec(64, 64, 4, TypeFloat);
     if (formatname == "zfile" || formatname == "fits")
         spec.nchannels = 1;  // these formats are single channel

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -186,7 +186,7 @@ ImageInput::read_scanline(int y, int z, TypeDesc format, void* data,
                                         xstride, AutoStride, AutoStride);
     } else {
         // Per-channel formats -- have to convert/copy channels individually
-        ASSERT(m_spec.channelformats.size() == (size_t)m_spec.nchannels);
+        OIIO_DASSERT(m_spec.channelformats.size() == (size_t)m_spec.nchannels);
         size_t offset = 0;
         for (int c = 0; ok && c < m_spec.nchannels; ++c) {
             TypeDesc chanformat = m_spec.channelformats[c];
@@ -459,7 +459,7 @@ ImageInput::read_tile(int x, int y, int z, TypeDesc format, void* data,
                                         xstride, ystride, zstride);
     } else {
         // Per-channel formats -- have to convert/copy channels individually
-        ASSERT(m_spec.channelformats.size() == (size_t)m_spec.nchannels);
+        OIIO_DASSERT(m_spec.channelformats.size() == (size_t)m_spec.nchannels);
         size_t offset = 0;
         for (int c = 0; c < m_spec.nchannels; ++c) {
             TypeDesc chanformat = m_spec.channelformats[c];
@@ -1001,8 +1001,9 @@ void
 ImageInput::append_error(const std::string& message) const
 {
     lock_guard lock(m_mutex);
-    ASSERT(m_errmessage.size() < 1024 * 1024 * 16
-           && "Accumulated error messages > 16MB. Try checking return codes!");
+    OIIO_DASSERT(
+        m_errmessage.size() < 1024 * 1024 * 16
+        && "Accumulated error messages > 16MB. Try checking return codes!");
     if (m_errmessage.size())
         m_errmessage += '\n';
     m_errmessage += message;

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -245,7 +245,9 @@ debug(string_view message)
             const char* filename = getenv("OPENIMAGEIO_DEBUG_FILE");
             oiio_debug_file = filename && filename[0] ? fopen(filename, "a")
                                                       : stderr;
-            ASSERT(oiio_debug_file);
+            OIIO_ASSERT(oiio_debug_file);
+            if (!oiio_debug_file)
+                return;
         }
         Strutil::fprintf(oiio_debug_file, "OIIO DEBUG: %s", message);
     }
@@ -498,7 +500,7 @@ pvt::contiguize(const void* src, int nchannels, stride_t xstride,
     case TypeDesc::UINT8:
         return _contiguize((const char*)src, nchannels, xstride, ystride,
                            zstride, (char*)dst, width, height, depth);
-    case TypeDesc::HALF: DASSERT(sizeof(half) == sizeof(short));
+    case TypeDesc::HALF: OIIO_DASSERT(sizeof(half) == sizeof(short));
     case TypeDesc::INT16:
     case TypeDesc::UINT16:
         return _contiguize((const short*)src, nchannels, xstride, ystride,
@@ -514,7 +516,9 @@ pvt::contiguize(const void* src, int nchannels, stride_t xstride,
     case TypeDesc::DOUBLE:
         return _contiguize((const double*)src, nchannels, xstride, ystride,
                            zstride, (double*)dst, width, height, depth);
-    default: ASSERT(0 && "OpenImageIO::contiguize : bad format"); return NULL;
+    default:
+        OIIO_ASSERT(0 && "OpenImageIO::contiguize : bad format");
+        return NULL;
     }
 }
 
@@ -545,7 +549,7 @@ pvt::convert_to_float(const void* src, float* dst, int nvals, TypeDesc format)
         convert_type((const unsigned long long*)src, dst, nvals);
         break;
     case TypeDesc::DOUBLE: convert_type((const double*)src, dst, nvals); break;
-    default: ASSERT(0 && "ERROR to_float: bad format"); return NULL;
+    default: OIIO_ASSERT(0 && "ERROR to_float: bad format"); return NULL;
     }
     return dst;
 }
@@ -601,7 +605,7 @@ pvt::convert_from_float(const float* src, void* dst, size_t nvals,
     case TypeDesc::INT64: return _from_float(src, (long long*)dst, nvals);
     case TypeDesc::UINT64:
         return _from_float(src, (unsigned long long*)dst, nvals);
-    default: ASSERT(0 && "ERROR from_float: bad format"); return NULL;
+    default: OIIO_ASSERT(0 && "ERROR from_float: bad format"); return NULL;
     }
 }
 
@@ -926,7 +930,7 @@ premult(int nchannels, int width, int height, int depth, int chbegin, int chend,
                      (double*)data, xstride, ystride, zstride, alpha_channel,
                      z_channel);
         break;
-    default: ASSERT(0 && "OIIO::premult() of an unsupported type"); break;
+    default: OIIO_ASSERT(0 && "OIIO::premult() of an unsupported type"); break;
     }
 }
 
@@ -965,7 +969,7 @@ wrap_periodic(int& coord, int origin, int width)
 bool
 wrap_periodic_pow2(int& coord, int origin, int width)
 {
-    DASSERT(ispow2(width));
+    OIIO_DASSERT(ispow2(width));
     coord -= origin;
     coord &= (width - 1);  // Shortcut periodic if we're sure it's a pow of 2
     coord += origin;
@@ -983,8 +987,8 @@ wrap_mirror(int& coord, int origin, int width)
     coord -= iter * width;
     if (iter & 1)  // Odd iterations -- flip the sense
         coord = width - 1 - coord;
-    DASSERT_MSG(coord >= 0 && coord < width, "width=%d, origin=%d, result=%d",
-                width, origin, coord);
+    OIIO_DASSERT_MSG(coord >= 0 && coord < width,
+                     "width=%d, origin=%d, result=%d", width, origin, coord);
     coord += origin;
     return true;
 }

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -497,7 +497,7 @@ ImageOutput::create(string_view filename, Filesystem::IOProxy* ioproxy,
         }
     }
 
-    ASSERT(create_function != nullptr);
+    OIIO_ASSERT(create_function != nullptr);
     try {
         out = std::unique_ptr<ImageOutput>(create_function());
     } catch (...) {
@@ -729,7 +729,7 @@ ImageInput::create(string_view filename, bool do_open, const ImageSpec* config,
             OIIO::pvt::errorf(
                 "Image \"%s\" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.\n",
                 filename);
-        DASSERT(!in);
+        OIIO_DASSERT(!in);
         return in;
     }
 

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -225,8 +225,9 @@ ImageOutput::send_to_client(const char* format, ...)
 void
 ImageOutput::append_error(const std::string& message) const
 {
-    ASSERT(m_errmessage.size() < 1024 * 1024 * 16
-           && "Accumulated error messages > 16MB. Try checking return codes!");
+    OIIO_ASSERT(
+        m_errmessage.size() < 1024 * 1024 * 16
+        && "Accumulated error messages > 16MB. Try checking return codes!");
     if (m_errmessage.size())
         m_errmessage += '\n';
     m_errmessage += message;
@@ -339,12 +340,11 @@ ImageOutput::to_native_rectangle(int xbegin, int xend, int ybegin, int yend,
     // Handle the per-channel format case (#2) where the user is passing
     // a non-native buffer.
     if (perchanfile) {
-        if (native_data) {
-            ASSERT(contiguous
-                   && "Per-channel native output requires contiguous strides");
-        }
-        ASSERT(format != TypeDesc::UNKNOWN);
-        ASSERT(m_spec.channelformats.size() == (size_t)m_spec.nchannels);
+        OIIO_DASSERT(
+            (contiguous || !native_data)
+            && "Per-channel native output requires contiguous strides");
+        OIIO_DASSERT(format != TypeDesc::UNKNOWN);
+        OIIO_DASSERT(m_spec.channelformats.size() == (size_t)m_spec.nchannels);
         scratch.resize(native_rectangle_bytes);
         size_t offset = 0;
         for (int c = 0; c < m_spec.nchannels; ++c) {
@@ -366,7 +366,7 @@ ImageOutput::to_native_rectangle(int xbegin, int xend, int ybegin, int yend,
                                      : rectangle_values * input_pixel_bytes;
     contiguoussize = (contiguoussize + 3)
                      & (~3);  // Round up to 4-byte boundary
-    DASSERT((contiguoussize & 3) == 0);
+    OIIO_DASSERT((contiguoussize & 3) == 0);
     imagesize_t floatsize = rectangle_values * sizeof(float);
     bool do_dither        = (dither && format.is_floating_point()
                       && m_spec.format.basetype == TypeDesc::UINT8);

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -93,7 +93,7 @@ time_read_image()
 {
     for (ustring filename : input_filename) {
         auto in = ImageInput::open(filename.c_str());
-        ASSERT(in);
+        OIIO_ASSERT(in);
         in->read_image(conversion, &buffer[0]);
         in->close();
     }
@@ -106,7 +106,7 @@ time_read_scanline_at_a_time()
 {
     for (ustring filename : input_filename) {
         auto in = ImageInput::open(filename.c_str());
-        ASSERT(in);
+        OIIO_ASSERT(in);
         const ImageSpec& spec(in->spec());
         size_t pixelsize = spec.nchannels * conversion.size();
         if (!pixelsize)
@@ -127,7 +127,7 @@ time_read_64_scanlines_at_a_time()
 {
     for (ustring filename : input_filename) {
         auto in = ImageInput::open(filename.c_str());
-        ASSERT(in);
+        OIIO_ASSERT(in);
         const ImageSpec& spec(in->spec());
         size_t pixelsize = spec.nchannels * conversion.size();
         if (!pixelsize)
@@ -191,9 +191,9 @@ static void
 time_write_image()
 {
     auto out = ImageOutput::create(output_filename);
-    ASSERT(out);
+    OIIO_ASSERT(out);
     bool ok = out->open(output_filename, outspec);
-    ASSERT(ok);
+    OIIO_ASSERT(ok);
     out->write_image(bufspec.format, &buffer[0]);
 }
 
@@ -203,9 +203,9 @@ static void
 time_write_scanline_at_a_time()
 {
     auto out = ImageOutput::create(output_filename);
-    ASSERT(out);
+    OIIO_ASSERT(out);
     bool ok = out->open(output_filename, outspec);
-    ASSERT(ok);
+    OIIO_ASSERT(ok);
 
     size_t pixelsize         = outspec.nchannels * sizeof(float);
     imagesize_t scanlinesize = outspec.width * pixelsize;
@@ -221,9 +221,9 @@ static void
 time_write_64_scanlines_at_a_time()
 {
     auto out = ImageOutput::create(output_filename);
-    ASSERT(out);
+    OIIO_ASSERT(out);
     bool ok = out->open(output_filename, outspec);
-    ASSERT(ok);
+    OIIO_ASSERT(ok);
 
     size_t pixelsize         = outspec.nchannels * sizeof(float);
     imagesize_t scanlinesize = outspec.width * pixelsize;
@@ -242,9 +242,9 @@ static void
 time_write_tile_at_a_time()
 {
     auto out = ImageOutput::create(output_filename);
-    ASSERT(out);
+    OIIO_ASSERT(out);
     bool ok = out->open(output_filename, outspec);
-    ASSERT(ok);
+    OIIO_ASSERT(ok);
 
     size_t pixelsize         = outspec.nchannels * sizeof(float);
     imagesize_t scanlinesize = outspec.width * pixelsize;
@@ -267,9 +267,9 @@ static void
 time_write_tiles_row_at_a_time()
 {
     auto out = ImageOutput::create(output_filename);
-    ASSERT(out);
+    OIIO_ASSERT(out);
     bool ok = out->open(output_filename, outspec);
-    ASSERT(ok);
+    OIIO_ASSERT(ok);
 
     size_t pixelsize         = outspec.nchannels * sizeof(float);
     imagesize_t scanlinesize = outspec.width * pixelsize;
@@ -291,9 +291,9 @@ time_write_imagebuf()
 {
     ImageBuf ib(output_filename, bufspec, &buffer[0]);  // wrap the buffer
     auto out = ImageOutput::create(output_filename);
-    ASSERT(out);
+    OIIO_ASSERT(out);
     bool ok = out->open(output_filename, outspec);
-    ASSERT(ok);
+    OIIO_ASSERT(ok);
     ib.write(out.get());
 }
 
@@ -317,14 +317,14 @@ test_write(const std::string& explanation, void (*func)(), int tilesize = 0)
 static float
 time_loop_pixels_1D(ImageBuf& ib, int iters)
 {
-    ASSERT(ib.localpixels() && ib.pixeltype() == TypeFloat);
+    OIIO_ASSERT(ib.localpixels() && ib.pixeltype() == TypeFloat);
     const ImageSpec& spec(ib.spec());
     imagesize_t npixels = spec.image_pixels();
     int nchannels       = spec.nchannels;
     double sum          = 0.0f;
     for (int i = 0; i < iters; ++i) {
         const float* f = (const float*)ib.pixeladdr(spec.x, spec.y, spec.z);
-        ASSERT(f);
+        OIIO_DASSERT(f);
         for (imagesize_t p = 0; p < npixels; ++p) {
             sum += f[0];
             f += nchannels;
@@ -339,14 +339,14 @@ time_loop_pixels_1D(ImageBuf& ib, int iters)
 static float
 time_loop_pixels_3D(ImageBuf& ib, int iters)
 {
-    ASSERT(ib.localpixels() && ib.pixeltype() == TypeFloat);
+    OIIO_ASSERT(ib.localpixels() && ib.pixeltype() == TypeFloat);
     const ImageSpec& spec(ib.spec());
     imagesize_t npixels = spec.image_pixels();
     int nchannels       = spec.nchannels;
     double sum          = 0.0f;
     for (int i = 0; i < iters; ++i) {
         const float* f = (const float*)ib.pixeladdr(spec.x, spec.y, spec.z);
-        ASSERT(f);
+        OIIO_DASSERT(f);
         for (int z = spec.z, ze = spec.z + spec.depth; z < ze; ++z) {
             for (int y = spec.y, ye = spec.y + spec.height; y < ye; ++y) {
                 for (int x = spec.x, xe = spec.x + spec.width; x < xe; ++x) {
@@ -365,7 +365,7 @@ time_loop_pixels_3D(ImageBuf& ib, int iters)
 static float
 time_loop_pixels_3D_getchannel(ImageBuf& ib, int iters)
 {
-    ASSERT(ib.pixeltype() == TypeFloat);
+    OIIO_DASSERT(ib.pixeltype() == TypeFloat);
     const ImageSpec& spec(ib.spec());
     imagesize_t npixels = spec.image_pixels();
     double sum          = 0.0f;
@@ -387,7 +387,7 @@ time_loop_pixels_3D_getchannel(ImageBuf& ib, int iters)
 static float
 time_iterate_pixels(ImageBuf& ib, int iters)
 {
-    ASSERT(ib.pixeltype() == TypeFloat);
+    OIIO_DASSERT(ib.pixeltype() == TypeFloat);
     const ImageSpec& spec(ib.spec());
     imagesize_t npixels = spec.image_pixels();
     double sum          = 0.0f;
@@ -405,7 +405,7 @@ time_iterate_pixels(ImageBuf& ib, int iters)
 static float
 time_iterate_pixels_slave_pos(ImageBuf& ib, int iters)
 {
-    ASSERT(ib.pixeltype() == TypeFloat);
+    OIIO_DASSERT(ib.pixeltype() == TypeFloat);
     const ImageSpec& spec(ib.spec());
     imagesize_t npixels = spec.image_pixels();
     double sum          = 0.0f;
@@ -425,7 +425,7 @@ time_iterate_pixels_slave_pos(ImageBuf& ib, int iters)
 static float
 time_iterate_pixels_slave_incr(ImageBuf& ib, int iters)
 {
-    ASSERT(ib.pixeltype() == TypeFloat);
+    OIIO_DASSERT(ib.pixeltype() == TypeFloat);
     const ImageSpec& spec(ib.spec());
     imagesize_t npixels = spec.image_pixels();
     double sum          = 0.0f;
@@ -559,7 +559,7 @@ main(int argc, char** argv)
     if (output_filename.size()) {
         // Use the first image
         auto in = ImageInput::open(input_filename[0].c_str());
-        ASSERT(in);
+        OIIO_ASSERT(in);
         bufspec = in->spec();
         in->read_image(conversion, &buffer[0]);
         in->close();
@@ -567,7 +567,7 @@ main(int argc, char** argv)
         std::cout << "Timing ways of writing images:\n";
         // imagecache->get_imagespec (input_filename[0], bufspec, 0, 0, true);
         auto out = ImageOutput::create(output_filename);
-        ASSERT(out);
+        OIIO_ASSERT(out);
         bool supports_tiles = out->supports("tiles");
         out.reset();
         outspec = bufspec;

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -232,7 +232,7 @@ ImageCacheFile::LevelInfo::LevelInfo(const ImageSpec& spec_,
         nztiles = (spec.depth + spec.tile_depth - 1) / spec.tile_depth;
     }
     int total_tiles = nxtiles * nytiles * nztiles;
-    ASSERT(total_tiles >= 1);
+    OIIO_DASSERT(total_tiles >= 1);
     const int sz = round_to_multiple(total_tiles, 64) / 64;
     tiles_read   = new atomic_ll[sz];
     for (int i = 0; i < sz; i++)
@@ -476,7 +476,6 @@ ImageCacheFile::open(ImageCachePerThreadInfo* thread_info)
         return {};
     if (inp)
         return inp;
-    ASSERT(inp.get() == nullptr);
 
     ImageSpec configspec;
     if (m_configspec)
@@ -670,7 +669,7 @@ ImageCacheFile::open(ImageCachePerThreadInfo* thread_info)
         si.min_mip_level = std::min(si.min_mip_level, nmip - 1);
         ++nsubimages;
     } while (inp->seek_subimage(nsubimages, 0, nativespec));
-    ASSERT((size_t)nsubimages == m_subimages.size());
+    OIIO_DASSERT((size_t)nsubimages == m_subimages.size());
 
     m_total_imagesize_ondisk = imagesize_t(Filesystem::file_size(m_filename));
 
@@ -771,7 +770,7 @@ ImageCacheFile::init_from_spec()
     m_mipreadcount.clear();
     m_mipreadcount.resize(maxmip, 0);
 
-    DASSERT(!m_broken);
+    OIIO_DASSERT(!m_broken);
     m_validspec = true;
 }
 
@@ -782,7 +781,7 @@ ImageCacheFile::read_tile(ImageCachePerThreadInfo* thread_info, int subimage,
                           int miplevel, int x, int y, int z, int chbegin,
                           int chend, TypeDesc format, void* data)
 {
-    ASSERT(chend > chbegin);
+    OIIO_DASSERT(chend > chbegin);
     std::shared_ptr<ImageInput> inp = open(thread_info);
     if (!inp)
         return false;
@@ -864,7 +863,7 @@ ImageCacheFile::read_unmipped(ImageCachePerThreadInfo* thread_info,
     const ImageSpec& spec(this->spec(subimage, miplevel));
     int tw = spec.tile_width;
     int th = spec.tile_height;
-    ASSERT(chend > chbegin);
+    OIIO_DASSERT(chend > chbegin);
     int nchans = chend - chbegin;
     ImageSpec lospec(tw, th, nchans, TypeDesc::FLOAT);
     ImageBuf lores(lospec);
@@ -948,7 +947,7 @@ ImageCacheFile::read_untiled(ImageCachePerThreadInfo* thread_info,
     const ImageSpec& spec(this->spec(subimage, miplevel));
     int tw = spec.tile_width;
     int th = spec.tile_height;
-    ASSERT(chend > chbegin);
+    OIIO_DASSERT(chend > chbegin);
     int nchans       = chend - chbegin;
     stride_t xstride = AutoStride, ystride = AutoStride, zstride = AutoStride;
     spec.auto_stride(xstride, ystride, zstride, format, nchans, tw, th);
@@ -1239,7 +1238,7 @@ ImageCacheImpl::verify_file(ImageCacheFile* tf,
         tf->m_mutex_wait_time += input_mutex_timer();
         if (!tf->validspec()) {
             tf->open(thread_info);
-            DASSERT(tf->m_broken || tf->validspec());
+            OIIO_DASSERT(tf->m_broken || tf->validspec());
             double createtime = timer();
             ImageCacheStatistics& stats(thread_info->m_stats);
             stats.fileio_time += createtime;
@@ -1380,7 +1379,7 @@ ImageCacheImpl::check_max_files(ImageCachePerThreadInfo* thread_info)
         // cache is empty.  So just declare ourselves done.
         if (!sweep)
             break;
-        DASSERT(sweep->second);
+        OIIO_DASSERT(sweep->second);
         sweep->second->release();  // May reduce open files
         ++sweep;
         // Note: This loop is a lot less complicated than the one in
@@ -1433,8 +1432,10 @@ ImageCacheTile::ImageCacheTile(const TileID& id, const void* pels,
     m_pixelsize   = id.nchannels() * m_channelsize;
     if (copy) {
         size_t size = memsize_needed();
-        ASSERT_MSG(size > 0 && memsize() == 0, "size was %llu, memsize = %llu",
-                   (unsigned long long)size, (unsigned long long)memsize());
+        OIIO_ASSERT_MSG(size > 0 && memsize() == 0,
+                        "size was %llu, memsize = %llu",
+                        (unsigned long long)size,
+                        (unsigned long long)memsize());
         m_pixels_size = size;
         m_pixels.reset(new char[m_pixels_size]);
         m_valid
@@ -1485,7 +1486,7 @@ ImageCacheTile::read(ImageCachePerThreadInfo* thread_info)
     m_channelsize = file.datatype(id().subimage()).size();
     m_pixelsize   = m_id.nchannels() * m_channelsize;
     size_t size   = memsize_needed();
-    ASSERT(memsize() == 0 && size > OIIO_SIMD_MAX_SIZE_BYTES);
+    OIIO_ASSERT(memsize() == 0 && size > OIIO_SIMD_MAX_SIZE_BYTES);
     m_pixels.reset(new char[m_pixels_size = size]);
     // Clear the end pad values so there aren't NaNs sucked up by simd loads
     memset(m_pixels.get() + size - OIIO_SIMD_MAX_SIZE_BYTES, 0,
@@ -1548,7 +1549,7 @@ ImageCacheTile::data(int x, int y, int z, int c) const
     size_t w              = spec.tile_width;
     size_t h              = spec.tile_height;
     size_t d              = spec.tile_depth;
-    DASSERT(d >= 1);
+    OIIO_DASSERT(d >= 1);
     x -= m_id.x();
     y -= m_id.y();
     z -= m_id.z();
@@ -1891,7 +1892,7 @@ ImageCacheImpl::getstats(int level) const
         std::sort(files.begin(), files.end(), filename_compare);
         for (size_t i = 0; i < files.size(); ++i) {
             const ImageCacheFileRef& file(files[i]);
-            ASSERT(file);
+            OIIO_DASSERT(file);
             if (file->is_udim())
                 continue;
             if (file->broken() || file->subimages() == 0) {
@@ -2078,8 +2079,7 @@ ImageCacheImpl::attribute(string_view name, TypeDesc type, const void* val)
 #else
         size = std::max(size, 1.0f);  // But let developers debugging do it
 #endif
-        m_max_memory_bytes = (long long)size * (long long)(1024 * 1024);
-        ASSERT(m_max_memory_bytes >= (1024 * 1024));
+        m_max_memory_bytes = (long long)(size * (long long)(1024 * 1024));
     } else if (name == "max_memory_MB" && type == TypeDesc::INT) {
         float size = *(const int*)val;
 #ifdef NDEBUG
@@ -2087,8 +2087,7 @@ ImageCacheImpl::attribute(string_view name, TypeDesc type, const void* val)
 #else
         size = std::max(size, 1.0f);  // But let developers debugging do it
 #endif
-        m_max_memory_bytes = (long long)size * (long long)(1024 * 1024);
-        ASSERT(m_max_memory_bytes >= (1024 * 1024));
+        m_max_memory_bytes = (long long)(size * (long long)(1024 * 1024));
     } else if (name == "searchpath" && type == TypeDesc::STRING) {
         std::string s = std::string(*(const char**)val);
         if (s != m_searchpath) {
@@ -2303,7 +2302,7 @@ bool
 ImageCacheImpl::find_tile_main_cache(const TileID& id, ImageCacheTileRef& tile,
                                      ImageCachePerThreadInfo* thread_info)
 {
-    DASSERT(!id.file().broken());
+    OIIO_DASSERT(!id.file().broken());
     ImageCacheStatistics& stats(thread_info->m_stats);
 
     ++stats.find_tile_microcache_misses;
@@ -2324,8 +2323,8 @@ ImageCacheImpl::find_tile_main_cache(const TileID& id, ImageCacheTileRef& tile,
             // pixels needs to lock the cache because it's doing automip.
             tile->wait_pixels_ready();
             tile->use();
-            DASSERT(id == tile->id());
-            DASSERT(tile);
+            OIIO_DASSERT(id == tile->id());
+            OIIO_DASSERT(tile);
             return true;
         }
     }
@@ -2341,11 +2340,11 @@ ImageCacheImpl::find_tile_main_cache(const TileID& id, ImageCacheTileRef& tile,
     // no other non-threadsafe side effects.
     tile = new ImageCacheTile(id);
     // N.B. the ImageCacheTile ctr starts the tile out as 'used'
-    DASSERT(tile);
-    DASSERT(id == tile->id());
+    OIIO_DASSERT(tile);
+    OIIO_DASSERT(id == tile->id());
 
     add_tile_to_cache(tile, thread_info);
-    DASSERT(id == tile->id());
+    OIIO_DASSERT(id == tile->id());
     return tile->valid();
 }
 
@@ -2396,7 +2395,7 @@ ImageCacheImpl::add_tile_to_cache(ImageCacheTileRef& tile,
 void
 ImageCacheImpl::check_max_mem(ImageCachePerThreadInfo* thread_info)
 {
-    DASSERT(m_mem_used < (long long)m_max_memory_bytes * 10);  // sanity
+    OIIO_DASSERT(m_mem_used < (long long)m_max_memory_bytes * 10);  // sanity
 #if 0
     static atomic_int n;
     if (! (n++ % 64) || m_mem_used >= (long long)m_max_memory_bytes)
@@ -2450,7 +2449,7 @@ ImageCacheImpl::check_max_mem(ImageCachePerThreadInfo* thread_info)
         // cache is empty.  So just declare ourselves done.
         if (!sweep)
             break;
-        DASSERT(sweep->second);
+        OIIO_DASSERT(sweep->second);
 
         if (!sweep->second->release()) {
             // This is a tile we should delete.  To keep iterating
@@ -2458,7 +2457,7 @@ ImageCacheImpl::check_max_mem(ImageCachePerThreadInfo* thread_info)
             // 1. remember the TileID of the tile to delete
             TileID todelete = sweep->first;
             size_t size     = sweep->second->memsize();
-            ASSERT(m_mem_used >= (long long)size);
+            OIIO_DASSERT(m_mem_used >= (long long)size);
             // 2. Find the TileID of the NEXT item. We do this by
             // incrementing the sweep iterator and grabbing its id.
             ++sweep;
@@ -2997,7 +2996,7 @@ ImageCacheImpl::get_pixels(ImageCacheFile* file,
                     && result_nchans == cache_nchans);
     stride_t scanlinesize       = (xend - xbegin) * result_pixelsize;
     stride_t zplanesize         = (yend - ybegin) * scanlinesize;
-    DASSERT(spec.depth >= 1 && spec.tile_depth >= 1);
+    OIIO_DASSERT(spec.depth >= 1 && spec.tile_depth >= 1);
 
     imagesize_t npixelsread = 0;
     char* zptr              = (char*)result;
@@ -3067,9 +3066,9 @@ ImageCacheImpl::get_pixels(ImageCacheFile* file,
                 }
                 if (!data) {
                     ImageCacheTileRef& tile(thread_info->tile);
-                    ASSERT(tile);
+                    OIIO_DASSERT(tile);
                     data = (const char*)tile->data(x, y, z, chbegin);
-                    ASSERT(data);
+                    OIIO_DASSERT(data);
                 }
                 if (xcontig) {
                     // Special case for a contiguous span within one tile
@@ -3588,9 +3587,10 @@ ImageCacheImpl::append_error(const std::string& message) const
         errptr = new std::string;
         m_errormessage.reset(errptr);
     }
-    ASSERT(errptr != NULL);
-    ASSERT(errptr->size() < 1024 * 1024 * 16
-           && "Accumulated error messages > 16MB. Try checking return codes!");
+    OIIO_DASSERT(errptr != NULL);
+    OIIO_DASSERT(
+        errptr->size() < 1024 * 1024 * 16
+        && "Accumulated error messages > 16MB. Try checking return codes!");
     if (errptr->size())
         *errptr += '\n';
     *errptr += message;

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -290,22 +290,22 @@ public:
 
     const LevelInfo& levelinfo(int subimage, int miplevel) const
     {
-        DASSERT((int)m_subimages.size() > subimage);
-        DASSERT((int)m_subimages[subimage].levels.size() > miplevel);
+        OIIO_DASSERT((int)m_subimages.size() > subimage);
+        OIIO_DASSERT((int)m_subimages[subimage].levels.size() > miplevel);
         return m_subimages[subimage].levels[miplevel];
     }
     LevelInfo& levelinfo(int subimage, int miplevel)
     {
-        DASSERT((int)m_subimages.size() > subimage);
-        DASSERT((int)m_subimages[subimage].levels.size() > miplevel);
+        OIIO_DASSERT((int)m_subimages.size() > subimage);
+        OIIO_DASSERT((int)m_subimages[subimage].levels.size() > miplevel);
         return m_subimages[subimage].levels[miplevel];
     }
 
     /// Do we currently have a valid spec?
     bool validspec() const
     {
-        DASSERT((m_validspec == false || m_subimages.size() > 0)
-                && "validspec is true, but subimages are empty");
+        OIIO_DASSERT((m_validspec == false || m_subimages.size() > 0)
+                     && "validspec is true, but subimages are empty");
         return m_validspec;
     }
 
@@ -1010,7 +1010,7 @@ public:
     {
         --m_stat_tiles_current;
         m_mem_used -= size;
-        DASSERT(m_mem_used >= 0);
+        OIIO_DASSERT(m_mem_used >= 0);
     }
 
     /// Internal error reporting routine, with printf-like arguments.

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -187,7 +187,10 @@ TextureSystemImpl::texture3d(TextureHandle* texture_handle_,
         // transforms procedurally, but we have to use a back door.
         auto input                   = texturefile->open(thread_info);
         Field3DInput_Interface* f3di = (Field3DInput_Interface*)input.get();
-        ASSERT(f3di);
+        if (!f3di) {
+            errorf("Unable to open texture \"%s\"", texturefile->filename());
+            return false;
+        }
         f3di->worldToLocal(P, Plocal, options.time);
     } else {
         // If no world-to-local matrix could be discerned, just use the
@@ -276,7 +279,7 @@ TextureSystemImpl::texture3d_lookup_nomip(
     for (int c = 0; c < nchannels_result; ++c)
         result[c] = 0;
     if (dresultds) {
-        DASSERT(dresultdt && dresultdr);
+        OIIO_DASSERT(dresultdt && dresultdr);
         for (int c = 0; c < nchannels_result; ++c)
             dresultds[c] = 0;
         for (int c = 0; c < nchannels_result; ++c)
@@ -376,7 +379,7 @@ TextureSystemImpl::accum3d_sample_closest(
                   + tile_s;
     int startchan_in_tile = options.firstchannel - id.chbegin();
     int offset            = spec.nchannels * tilepel + startchan_in_tile;
-    DASSERT((size_t)offset < spec.nchannels * spec.tile_pixels());
+    OIIO_DASSERT((size_t)offset < spec.nchannels * spec.tile_pixels());
     if (pixeltype == TypeDesc::UINT8) {
         const unsigned char* texel = tile->bytedata() + offset;
         for (int c = 0; c < actualchannels; ++c)
@@ -390,7 +393,7 @@ TextureSystemImpl::accum3d_sample_closest(
         for (int c = 0; c < actualchannels; ++c)
             accum[c] += weight * half2float(texel[c]);
     } else {
-        DASSERT(pixeltype == TypeDesc::FLOAT);
+        OIIO_DASSERT(pixeltype == TypeDesc::FLOAT);
         const float* texel = tile->floatdata() + offset;
         for (int c = 0; c < actualchannels; ++c)
             accum[c] += weight * texel[c];
@@ -452,7 +455,7 @@ TextureSystemImpl::accum3d_sample_bilinear(
         unsigned long long ivalid;
     } valid_storage;
     valid_storage.ivalid = 0;
-    DASSERT(sizeof(valid_storage) == 8);
+    OIIO_DASSERT(sizeof(valid_storage) == 8);
     const unsigned long long none_valid = 0;
     const unsigned long long all_valid  = littleendian() ? 0x010101010101LL
                                                         : 0x01010101010100LL;
@@ -516,8 +519,8 @@ TextureSystemImpl::accum3d_sample_bilinear(
                          + tile_s;
         size_t offset = (spec.nchannels * tilepel + startchan_in_tile)
                         * channelsize;
-        DASSERT((size_t)offset < spec.tile_width * spec.tile_height
-                                     * spec.tile_depth * pixelsize);
+        OIIO_DASSERT((size_t)offset < spec.tile_width * spec.tile_height
+                                          * spec.tile_depth * pixelsize);
 
         const unsigned char* b = tile->bytedata() + offset;
         texel[0][0][0]         = b;
@@ -565,10 +568,11 @@ TextureSystemImpl::accum3d_sample_bilinear(
                                   << ' ' << spec.tile_depth << " pixsize "
                                   << pixelsize << "\n";
 #endif
-                    DASSERT((size_t)offset < spec.tile_width * spec.tile_height
-                                                 * spec.tile_depth * pixelsize);
+                    OIIO_DASSERT((size_t)offset
+                                 < spec.tile_width * spec.tile_height
+                                       * spec.tile_depth * pixelsize);
                     texel[k][j][i] = tile->bytedata() + offset;
-                    DASSERT(tile->id() == id);
+                    OIIO_DASSERT(tile->id() == id);
                 }
             }
         }

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -101,12 +101,12 @@ public:
     }
     virtual Perthread* create_thread_info()
     {
-        ASSERT(m_imagecache);
+        OIIO_ASSERT(m_imagecache);
         return (Perthread*)m_imagecache->create_thread_info();
     }
     virtual void destroy_thread_info(Perthread* threadinfo)
     {
-        ASSERT(m_imagecache);
+        OIIO_ASSERT(m_imagecache);
         m_imagecache->destroy_thread_info((ImageCachePerThreadInfo*)threadinfo);
     }
 

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -223,7 +223,7 @@ wrap_periodic_pow2_simd(simd::vint4& coord_, const simd::vint4& origin,
                         const simd::vint4& width)
 {
     simd::vint4 coord(coord_);
-    //    DASSERT (ispow2(width));
+    // OIIO_DASSERT (ispow2(width));
     coord = coord - origin;
     coord = coord
             & (width - 1);  // Shortcut periodic if we're sure it's a pow of 2
@@ -244,7 +244,7 @@ wrap_mirror_simd(simd::vint4& coord_, const simd::vint4& origin,
     coord -= iter * width;
     // Odd iterations -- flip the sense
     coord = blend(coord, (width - 1) - coord, (iter & 1) != 0);
-    // DASSERT_MSG (coord >= 0 && coord < width,
+    // OIIO_DASSERT_MSG (coord >= 0 && coord < width,
     //              "width=%d, origin=%d, result=%d", width, origin, coord);
     coord += origin;
     coord_ = coord;
@@ -437,7 +437,7 @@ TextureSystemImpl::printstats() const
 void
 TextureSystemImpl::reset_stats()
 {
-    ASSERT(m_imagecache);
+    OIIO_DASSERT(m_imagecache);
     m_imagecache->reset_stats();
 }
 
@@ -783,9 +783,9 @@ TextureSystemImpl::append_error(const std::string& message) const
         errptr = new std::string;
         m_errormessage.reset(errptr);
     }
-    ASSERT(errptr != NULL);
-    ASSERT(errptr->size() < 1024 * 1024 * 16
-           && "Accumulated error messages > 16MB. Try checking return codes!");
+    OIIO_DASSERT(
+        errptr->size() < 1024 * 1024 * 16
+        && "Accumulated error messages > 16MB. Try checking return codes!");
     if (errptr->size())
         *errptr += '\n';
     *errptr += message;
@@ -1214,7 +1214,7 @@ TextureSystemImpl::texture_lookup_nomip(
     float* dresultdt)
 {
     // Initialize results to 0.  We'll add from here on as we sample.
-    DASSERT((dresultds == NULL) == (dresultdt == NULL));
+    OIIO_DASSERT((dresultds == NULL) == (dresultdt == NULL));
     ((simd::vfloat4*)result)->clear();
     if (dresultds) {
         ((simd::vfloat4*)dresultds)->clear();
@@ -1329,7 +1329,7 @@ adjust_blur(float& majorlength, float& minorlength, float& theta, float sblur,
         // Carefully add blur to the right derivative components in the
         // right proportions -- merely adding the same amount of blur
         // to all four derivatives blurs too much at some angles.
-        DASSERT(majorlength > 0.0f && minorlength > 0.0f);
+        OIIO_DASSERT(majorlength > 0.0f && minorlength > 0.0f);
         float sintheta, costheta;
 #ifdef TEX_FAST_MATH
         fast_sincos(theta, &sintheta, &costheta);
@@ -1444,7 +1444,7 @@ TextureSystemImpl::texture_lookup_trilinear_mipmap(
     float* dresultdt)
 {
     // Initialize results to 0.  We'll add from here on as we sample.
-    DASSERT((dresultds == NULL) == (dresultdt == NULL));
+    OIIO_DASSERT((dresultds == NULL) == (dresultdt == NULL));
     ((simd::vfloat4*)result)->clear();
     if (dresultds) {
         ((simd::vfloat4*)dresultds)->clear();
@@ -1650,7 +1650,7 @@ TextureSystemImpl::texture_lookup(TextureFile& texturefile,
                                   float dtdy, float* result, float* dresultds,
                                   float* dresultdt)
 {
-    DASSERT((dresultds == NULL) == (dresultdt == NULL));
+    OIIO_DASSERT((dresultds == NULL) == (dresultdt == NULL));
 
     // Compute the natural resolution we want for the bare derivs, this
     // will be the threshold for knowing we're maxifying (and therefore
@@ -1830,10 +1830,10 @@ TextureSystemImpl::pole_color(TextureFile& texturefile,
         static spin_mutex mutex;  // Protect everybody's polecolor
         spin_lock lock(mutex);
         if (!levelinfo.polecolorcomputed) {
-            DASSERT(levelinfo.polecolor.size() == 0);
+            OIIO_DASSERT(levelinfo.polecolor.size() == 0);
             levelinfo.polecolor.resize(2 * spec.nchannels);
-            ASSERT(tile->id().nchannels() == spec.nchannels
-                   && "pole_color doesn't work for channel subsets");
+            OIIO_DASSERT(tile->id().nchannels() == spec.nchannels
+                         && "pole_color doesn't work for channel subsets");
             int pixelsize                = tile->pixelsize();
             TypeDesc::BASETYPE pixeltype = texturefile.pixeltype(subimage);
             // We store north and south poles adjacently in polecolor
@@ -1856,7 +1856,7 @@ TextureSystemImpl::pole_color(TextureFile& texturefile,
                         else if (pixeltype == TypeDesc::HALF)
                             p[c] += ((const half*)texel)[c];
                         else {
-                            DASSERT(pixeltype == TypeDesc::FLOAT);
+                            OIIO_DASSERT(pixeltype == TypeDesc::FLOAT);
                             p[c] += ((const float*)texel)[c];
                         }
                     }
@@ -1973,7 +1973,7 @@ TextureSystemImpl::sample_closest(
         }
         int offset = id.nchannels() * (tile_t * spec.tile_width + tile_s)
                      + (firstchannel - id.chbegin());
-        DASSERT((size_t)offset < spec.nchannels * spec.tile_pixels());
+        OIIO_DASSERT((size_t)offset < spec.nchannels * spec.tile_pixels());
         simd::vfloat4 texel_simd;
         if (pixeltype == TypeDesc::UINT8) {
             // special case for 8-bit tiles
@@ -1983,7 +1983,7 @@ TextureSystemImpl::sample_closest(
         } else if (pixeltype == TypeDesc::HALF) {
             texel_simd = half2float4(tile->halfdata() + offset);
         } else {
-            DASSERT(pixeltype == TypeDesc::FLOAT);
+            OIIO_DASSERT(pixeltype == TypeDesc::FLOAT);
             texel_simd.load(tile->floatdata() + offset);
         }
 
@@ -2179,7 +2179,7 @@ TextureSystemImpl::sample_bilinear(
                 texel_simd[1][0] = half2float4((half*)p);
                 texel_simd[1][1] = half2float4((half*)(p + pixelsize));
             } else {
-                DASSERT(pixeltype == TypeDesc::FLOAT);
+                OIIO_DASSERT(pixeltype == TypeDesc::FLOAT);
                 texel_simd[0][0].load((const float*)p);
                 texel_simd[0][1].load((const float*)(p + pixelsize));
                 p += pixelsize * spec.tile_width;
@@ -2215,15 +2215,15 @@ TextureSystemImpl::sample_bilinear(
                         if (!thread_info->tile->valid()) {
                             return false;
                         }
-                        DASSERT(thread_info->tile->id() == id);
+                        OIIO_DASSERT(thread_info->tile->id() == id);
                     }
                     TileRef& tile(thread_info->tile);
                     int pixelsize = tile->pixelsize();
                     int offset    = pixelsize
                                  * (tile_t * spec.tile_width + tile_s);
                     offset += (firstchannel - id.chbegin()) * channelsize;
-                    DASSERT(offset < spec.tile_width * spec.tile_height
-                                         * spec.tile_depth * pixelsize);
+                    OIIO_DASSERT(offset < spec.tile_width * spec.tile_height
+                                              * spec.tile_depth * pixelsize);
                     if (pixeltype == TypeDesc::UINT8)
                         texel_simd[j][i] = uchar2float4(
                             (const unsigned char*)(tile->bytedata() + offset));
@@ -2234,7 +2234,7 @@ TextureSystemImpl::sample_bilinear(
                         texel_simd[j][i] = half2float4(
                             (const half*)(tile->bytedata() + offset));
                     else {
-                        DASSERT(pixeltype == TypeDesc::FLOAT);
+                        OIIO_DASSERT(pixeltype == TypeDesc::FLOAT);
                         texel_simd[j][i].load(
                             (const float*)(tile->bytedata() + offset));
                     }
@@ -2525,7 +2525,7 @@ TextureSystemImpl::sample_bicubic(
             int offset = pixelsize * (tile_t * spec.tile_width + tile_s);
             const unsigned char* base = tile->bytedata() + offset
                                         + firstchannel_offset_bytes;
-            DASSERT(tile->data());
+            OIIO_DASSERT(tile->data());
             if (pixeltype == TypeDesc::UINT8) {
                 for (int j = 0, j_offset = 0; j < 4;
                      ++j, j_offset += pixelsize * spec.tile_width)
@@ -2586,12 +2586,12 @@ TextureSystemImpl::sample_bicubic(
                         bool ok = find_tile(id, thread_info, sample == 0);
                         if (!ok)
                             errorf("%s", m_imagecache->geterror());
-                        DASSERT(thread_info->tile->id() == id);
+                        OIIO_DASSERT(thread_info->tile->id() == id);
                         if (!thread_info->tile->valid())
                             return false;
                     }
                     TileRef& tile(thread_info->tile);
-                    DASSERT(tile->data());
+                    OIIO_DASSERT(tile->data());
                     int offset = row_offset_bytes + column_offset_bytes[i];
                     // const unsigned char *pixelptr = tile->bytedata() + offset[i];
                     if (pixeltype == TypeDesc::UINT8)

--- a/src/libutil/SHA1.cpp
+++ b/src/libutil/SHA1.cpp
@@ -67,7 +67,7 @@ SHA1::~SHA1 ()
 void
 SHA1::append (const void *data, size_t size)
 {
-    ASSERT (!m_final && "Called SHA1() after already getting digest");
+    OIIO_ASSERT (!m_final && "Called SHA1() after already getting digest");
     if (data && size)
         m_csha1->Update ((const unsigned char *)data, (unsigned int)size);
 }

--- a/src/libutil/argparse.cpp
+++ b/src/libutil/argparse.cpp
@@ -391,7 +391,7 @@ ArgParse::Impl::parse(int xargc, const char** xargv)
                 if (option->has_callback())
                     option->invoke_callback(1, m_argv + i);
             } else {
-                ASSERT(option->is_regular());
+                assert(option->is_regular());
                 for (int j = 0; j < option->parameter_count(); j++) {
                     if (j + i + 1 >= m_argc) {
                         errorf("Missing parameter %d from option "

--- a/src/libutil/benchmark.cpp
+++ b/src/libutil/benchmark.cpp
@@ -63,7 +63,7 @@ void
 Benchmarker::compute_stats(std::vector<double>& times, size_t iterations)
 {
     size_t trials = times.size();
-    ASSERT(trials >= 1);
+    OIIO_ASSERT(trials >= 1);
 #if 0
     // Debugging: print all the trial times
     for (auto v : times)

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -712,7 +712,7 @@ Filesystem::enumerate_file_sequence(const std::string& pattern,
                                     const std::vector<string_view>& views,
                                     std::vector<std::string>& filenames)
 {
-    ASSERT(views.size() == 0 || views.size() == numbers.size());
+    OIIO_ASSERT(views.size() == 0 || views.size() == numbers.size());
     filenames.clear();
     for (size_t i = 0, e = numbers.size(); i < e; ++i) {
         std::string f = pattern;

--- a/src/libutil/filter.cpp
+++ b/src/libutil/filter.cpp
@@ -844,7 +844,7 @@ Filter1D::num_filters()
 const FilterDesc&
 Filter1D::get_filterdesc(int filternum)
 {
-    ASSERT(filternum >= 0 && filternum < num_filters());
+    OIIO_DASSERT(filternum >= 0 && filternum < num_filters());
     return filter1d_list[filternum];
 }
 
@@ -937,7 +937,7 @@ Filter2D::num_filters()
 const FilterDesc&
 Filter2D::get_filterdesc(int filternum)
 {
-    ASSERT(filternum >= 0 && filternum < num_filters());
+    OIIO_DASSERT(filternum >= 0 && filternum < num_filters());
     return filter2d_list[filternum];
 }
 

--- a/src/libutil/parallel_test.cpp
+++ b/src/libutil/parallel_test.cpp
@@ -161,7 +161,7 @@ test_empty_thread_pool()
     task_set ts(pool);
     for (int i = 0; i < ntasks; ++i)
         ts.push(pool->push([&](int id) {
-            ASSERT(id == -1 && "Must be run by calling thread");
+            OIIO_ASSERT(id == -1 && "Must be run by calling thread");
             count += 1;
         }));
     ts.wait();

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -521,7 +521,7 @@ Strutil::strip(string_view str, string_view chars)
     if (b == std::string::npos)
         return string_view();
     size_t e = str.find_last_not_of(chars);
-    DASSERT(e != std::string::npos);
+    OIIO_DASSERT(e != std::string::npos);
     return str.substr(b, e - b + 1);
 }
 
@@ -990,7 +990,7 @@ Strutil::parse_nested(string_view& str, bool eat) noexcept
     if (nesting)
         return string_view();  // No proper closing
 
-    ASSERT(p[len - 1] == closing);
+    OIIO_ASSERT(p[len - 1] == closing);
 
     // The result is the first len characters
     string_view result = str.substr(0, len);

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -131,7 +131,7 @@ Sysutil::memory_used(bool resident)
     return 0;  // Punt
 #else
     // No idea what platform this is
-    ASSERT(0 && "Need to implement Sysutil::memory_used on this platform");
+    OIIO_ASSERT(0 && "Need to implement Sysutil::memory_used on this platform");
     return 0;  // Punt
 #endif
 }
@@ -196,7 +196,8 @@ Sysutil::physical_memory()
 
 #else
     // No idea what platform this is
-    ASSERT(0 && "Need to implement Sysutil::physical_memory on this platform");
+    OIIO_ASSERT(
+        0 && "Need to implement Sysutil::physical_memory on this platform");
     return 0;  // Punt
 #endif
 }
@@ -232,7 +233,7 @@ Sysutil::this_program_path()
     unsigned int size = sizeof(filename);
     int r             = readlink("/proc/self/exe", filename, size);
     // user won't get the right answer if the filename is too long to store
-    ASSERT(r < int(size));
+    OIIO_ASSERT(r < int(size));
     if (r > 0)
         filename[r] = 0;  // readlink does not fill in the 0 byte
 #elif defined(__APPLE__)

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -111,7 +111,7 @@ public:
     // get the number of running threads in the pool
     int size() const
     {
-        DASSERT(m_size == static_cast<int>(this->threads.size()));
+        OIIO_DASSERT(m_size == static_cast<int>(this->threads.size()));
         return m_size;
     }
 
@@ -251,14 +251,14 @@ public:
         std::function<void(int)>* f = nullptr;
         bool isPop                  = this->q.pop(f);
         if (isPop) {
-            DASSERT(f);
+            OIIO_DASSERT(f);
             std::unique_ptr<std::function<void(int id)>> func(
                 f);  // at return, delete the function even if an exception occurred
             register_worker(id);
             (*f)(-1);
             deregister_worker(id);
         } else {
-            DASSERT(f == nullptr);
+            OIIO_DASSERT(f == nullptr);
         }
         return isPop;
     }
@@ -469,7 +469,7 @@ default_thread_pool()
 void
 task_set::wait_for_task(size_t taskindex, bool block)
 {
-    DASSERT(submitter() == std::this_thread::get_id());
+    OIIO_DASSERT(submitter() == std::this_thread::get_id());
     if (taskindex >= m_futures.size())
         return;  // nothing to wait for
     auto& f(m_futures[taskindex]);
@@ -507,7 +507,7 @@ task_set::wait_for_task(size_t taskindex, bool block)
 void
 task_set::wait(bool block)
 {
-    DASSERT(submitter() == std::this_thread::get_id());
+    OIIO_DASSERT(submitter() == std::this_thread::get_id());
     const std::chrono::milliseconds wait_time(0);
     if (m_pool->is_worker(m_submitter_thread))
         block = true;  // don't get into recursive work stealing

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -56,7 +56,7 @@ TypeDesc::basesize() const noexcept
 {
     if (basetype >= TypeDesc::LASTBASE)
         return 0;
-    DASSERT(basetype < TypeDesc::LASTBASE);
+    OIIO_DASSERT(basetype < TypeDesc::LASTBASE);
     return basetype_size[basetype];
 }
 
@@ -82,7 +82,7 @@ TypeDesc::is_floating_point() const noexcept
         0,  // STRING
         0   // PTR
     };
-    DASSERT(basetype < TypeDesc::LASTBASE);
+    OIIO_DASSERT(basetype < TypeDesc::LASTBASE);
     return isfloat[basetype];
 }
 
@@ -108,7 +108,7 @@ TypeDesc::is_signed() const noexcept
         0,  // STRING
         0   // PTR
     };
-    DASSERT(basetype < TypeDesc::LASTBASE);
+    OIIO_DASSERT(basetype < TypeDesc::LASTBASE);
     return issigned[basetype];
 }
 
@@ -195,7 +195,7 @@ TypeDesc::c_str() const
         case VECTOR: vec = "vector"; break;
         case NORMAL: vec = "normal"; break;
         case RATIONAL: vec = "rational"; break;
-        default: DASSERT(0 && "Invalid vector semantics");
+        default: OIIO_DASSERT(0 && "Invalid vector semantics");
         }
         const char* agg = "";
         switch (aggregate) {

--- a/src/libutil/ustring.cpp
+++ b/src/libutil/ustring.cpp
@@ -358,7 +358,7 @@ ustring::TableRep::TableRep(string_view strref, size_t hash)
     dummy_capacity      = length;
     dummy_refcount      = 1;  // so it never frees
     *(const char**)&str = c_str();
-    DASSERT(str.c_str() == c_str() && str.size() == length);
+    OIIO_DASSERT(str.c_str() == c_str() && str.size() == length);
     return;
 
 #elif defined(_LIBCPP_VERSION)
@@ -378,7 +378,7 @@ ustring::TableRep::TableRep(string_view strref, size_t hash)
                                                | (length + 1);
         ((libcpp_string__long*)&str)->__size_ = length;
         ((libcpp_string__long*)&str)->__data_ = (char*)c_str();
-        DASSERT(str.c_str() == c_str() && str.size() == length);
+        OIIO_DASSERT(str.c_str() == c_str() && str.size() == length);
         return;
     }
 #endif

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -34,7 +34,7 @@ static std::vector<std::array<char, 16>> strings;
 static void
 create_lotso_ustrings(int iterations)
 {
-    DASSERT(size_t(iterations) <= strings.size());
+    OIIO_DASSERT(size_t(iterations) <= strings.size());
     if (verbose)
         Strutil::printf("thread %d\n", std::this_thread::get_id());
     size_t h = 0;

--- a/src/oiiotool/diff.cpp
+++ b/src/oiiotool/diff.cpp
@@ -95,7 +95,7 @@ OiioTool::do_action_diff(ImageRec& ir0, ImageRec& ir1, Oiiotool& ot,
                         * img0.spec().depth;
             if (npels == 0)
                 npels = 1;  // Avoid divide by zero for 0x0 images
-            ASSERT(img0.spec().format == TypeDesc::FLOAT);
+            OIIO_ASSERT(img0.spec().format == TypeDesc::FLOAT);
 
             // Compare the two images.
             //

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -84,7 +84,7 @@ ImageRec::ImageRec(ImageRec& img, int subimage_to_copy, int miplevel_to_copy,
                 ib      = new ImageBuf(img.name(), srcib.imagecache());
                 bool ok = ib->read(srcsub, srcmip, false /*force*/,
                                    img.m_input_dataformat /*convert*/);
-                ASSERT(ok);
+                OIIO_ASSERT(ok);
             }
             m_subimages[s].m_miplevels[m].reset(ib);
             m_subimages[s].m_specs[m] = srcspec;
@@ -395,8 +395,9 @@ void
 ImageRec::append_error(string_view message) const
 {
     spin_lock lock(err_mutex);
-    ASSERT(m_err.size() < 1024 * 1024 * 16
-           && "Accumulated error messages > 16MB. Try checking return codes!");
+    OIIO_ASSERT(
+        m_err.size() < 1024 * 1024 * 16
+        && "Accumulated error messages > 16MB. Try checking return codes!");
     if (m_err.size() && m_err[m_err.size() - 1] != '\n')
         m_err += '\n';
     m_err += message;

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -73,7 +73,7 @@ static Oiiotool ot;
         const int nargs = 1, ninputs = 1;                                      \
         if (ot.postpone_callback(ninputs, action_##name, argc, argv))          \
             return 0;                                                          \
-        ASSERT(argc == nargs);                                                 \
+        OIIO_ASSERT(argc == nargs);                                            \
         OiiotoolSimpleUnaryOp<IBAunary> op(impl, ot, #name, argc, argv,        \
                                            ninputs);                           \
         return op();                                                           \
@@ -86,7 +86,7 @@ static Oiiotool ot;
         const int nargs = 1, ninputs = 2;                                      \
         if (ot.postpone_callback(ninputs, action_##name, argc, argv))          \
             return 0;                                                          \
-        ASSERT(argc == nargs);                                                 \
+        OIIO_ASSERT(argc == nargs);                                            \
         OiiotoolSimpleBinaryOp<IBAbinary> op(impl, ot, #name, argc, argv,      \
                                              ninputs);                         \
         return op();                                                           \
@@ -99,7 +99,7 @@ static Oiiotool ot;
         const int nargs = 1, ninputs = 2;                                      \
         if (ot.postpone_callback(ninputs, action_##name, argc, argv))          \
             return 0;                                                          \
-        ASSERT(argc == nargs);                                                 \
+        OIIO_ASSERT(argc == nargs);                                            \
         OiiotoolSimpleBinaryOp<IBAbinary_> op(impl, ot, #name, argc, argv,     \
                                               ninputs);                        \
         return op();                                                           \
@@ -112,7 +112,7 @@ static Oiiotool ot;
         const int nargs = 2, ninputs = 1;                                      \
         if (ot.postpone_callback(ninputs, action_##name, argc, argv))          \
             return 0;                                                          \
-        ASSERT(argc == nargs);                                                 \
+        OIIO_ASSERT(argc == nargs);                                            \
         OiiotoolImageColorOp<IBAbinary_img_col> op(impl, ot, #name, argc,      \
                                                    argv, ninputs);             \
         return op();                                                           \
@@ -389,7 +389,7 @@ Oiiotool::extract_options(string_view command)
 static int
 set_threads(int argc, const char* argv[])
 {
-    ASSERT(argc == 2);
+    OIIO_DASSERT(argc == 2);
     int nthreads = Strutil::stoi(argv[1]);
     OIIO::attribute("threads", nthreads);
     OIIO::attribute("exr_threads", nthreads);
@@ -401,7 +401,7 @@ set_threads(int argc, const char* argv[])
 static int
 set_cachesize(int argc, const char* argv[])
 {
-    ASSERT(argc == 2);
+    OIIO_DASSERT(argc == 2);
     ot.cachesize = Strutil::stoi(argv[1]);
     ot.imagecache->attribute("max_memory_MB", float(ot.cachesize));
     return 0;
@@ -412,7 +412,7 @@ set_cachesize(int argc, const char* argv[])
 static int
 set_autotile(int argc, const char* argv[])
 {
-    ASSERT(argc == 2);
+    OIIO_DASSERT(argc == 2);
     ot.autotile = Strutil::stoi(argv[1]);
     ot.imagecache->attribute("autotile", ot.autotile);
     ot.imagecache->attribute("autoscanline", int(ot.autotile ? 1 : 0));
@@ -424,7 +424,7 @@ set_autotile(int argc, const char* argv[])
 static int
 set_native(int argc, const char* argv[])
 {
-    ASSERT(argc == 1);
+    OIIO_DASSERT(argc == 1);
     ot.nativeread = true;
     ot.imagecache->attribute("forcefloat", 0);
     return 0;
@@ -435,7 +435,7 @@ set_native(int argc, const char* argv[])
 static int
 set_dumpdata(int argc, const char* argv[])
 {
-    ASSERT(argc == 1);
+    OIIO_DASSERT(argc == 1);
     string_view command   = ot.express(argv[0]);
     auto options          = ot.extract_options(command);
     ot.dumpdata           = true;
@@ -448,7 +448,7 @@ set_dumpdata(int argc, const char* argv[])
 static int
 set_printinfo(int argc, const char* argv[])
 {
-    ASSERT(argc == 1);
+    OIIO_DASSERT(argc == 1);
     string_view command  = ot.express(argv[0]);
     ot.printinfo         = true;
     auto options         = ot.extract_options(command);
@@ -462,7 +462,7 @@ set_printinfo(int argc, const char* argv[])
 static int
 set_autopremult(int argc, const char* argv[])
 {
-    ASSERT(argc == 1);
+    OIIO_DASSERT(argc == 1);
     ot.autopremult = true;
     ot.imagecache->attribute("unassociatedalpha", 0);
     ot.input_config.erase_attribute("oiio:UnassociatedAlpha");
@@ -474,7 +474,7 @@ set_autopremult(int argc, const char* argv[])
 static int
 unset_autopremult(int argc, const char* argv[])
 {
-    ASSERT(argc == 1);
+    OIIO_DASSERT(argc == 1);
     ot.autopremult = false;
     ot.imagecache->attribute("unassociatedalpha", 1);
     ot.input_config.attribute("oiio:UnassociatedAlpha", 1);
@@ -487,7 +487,7 @@ unset_autopremult(int argc, const char* argv[])
 static int
 enable_eval(int argc, const char* argv[])
 {
-    ASSERT(argc == 1);
+    OIIO_DASSERT(argc == 1);
     ot.eval_enable = true;
     return 0;
 }
@@ -497,7 +497,7 @@ enable_eval(int argc, const char* argv[])
 static int
 disable_eval(int argc, const char* argv[])
 {
-    ASSERT(argc == 1);
+    OIIO_DASSERT(argc == 1);
     ot.eval_enable = false;
     return 0;
 }
@@ -828,7 +828,7 @@ parse_channels(const ImageSpec& spec, string_view chanlist,
 static int
 set_dataformat(int argc, const char* argv[])
 {
-    ASSERT(argc == 2);
+    OIIO_DASSERT(argc == 2);
     string_view command = ot.express(argv[0]);
     std::vector<std::string> chans;
     Strutil::split(ot.express(argv[1]), chans, ",");
@@ -870,7 +870,7 @@ set_dataformat(int argc, const char* argv[])
 static int
 set_string_attribute(int argc, const char* argv[])
 {
-    ASSERT(argc == 3);
+    OIIO_DASSERT(argc == 3);
     if (!ot.curimg.get()) {
         ot.warning(argv[0], "no current image available to modify");
         return 0;
@@ -889,7 +889,7 @@ set_string_attribute(int argc, const char* argv[])
 static int
 set_any_attribute(int argc, const char* argv[])
 {
-    ASSERT(argc == 3);
+    OIIO_DASSERT(argc == 3);
     if (!ot.curimg.get()) {
         ot.warning(argv[0], "no current image available to modify");
         return 0;
@@ -919,7 +919,7 @@ do_erase_attribute(ImageSpec& spec, string_view attribname)
 static int
 erase_attribute(int argc, const char* argv[])
 {
-    ASSERT(argc == 2);
+    OIIO_DASSERT(argc == 2);
     if (!ot.curimg.get()) {
         ot.warning(argv[0], "no current image available to modify");
         return 0;
@@ -1387,7 +1387,7 @@ Oiiotool::express(string_view str)
     if (expr.empty())
         return str;  // No corresponding close brace found -- give up
     // eg. prefix="ab", expr="{cde}", s="fg", prefix="ab"
-    ASSERT(expr.front() == '{' && expr.back() == '}');
+    OIIO_ASSERT(expr.front() == '{' && expr.back() == '}');
     expr.remove_prefix(1);
     expr.remove_suffix(1);
     // eg. expr="cde"
@@ -1404,7 +1404,7 @@ Oiiotool::express(string_view str)
 static int
 set_input_attribute(int argc, const char* argv[])
 {
-    ASSERT(argc == 3);
+    OIIO_DASSERT(argc == 3);
 
     string_view command = ot.express(argv[0]);
     auto options        = ot.extract_options(command);
@@ -1625,7 +1625,7 @@ OiioTool::set_attribute(ImageRecRef img, string_view attribname, TypeDesc type,
 static int
 set_caption(int argc, const char* argv[])
 {
-    ASSERT(argc == 2);
+    OIIO_DASSERT(argc == 2);
     const char* newargs[3] = { argv[0], "ImageDescription", argv[1] };
     return set_string_attribute(3, newargs);
     // N.B. set_string_attribute does expression expansion on its args
@@ -1657,7 +1657,7 @@ do_set_keyword(ImageSpec& spec, const std::string& keyword)
 static int
 set_keyword(int argc, const char* argv[])
 {
-    ASSERT(argc == 2);
+    OIIO_DASSERT(argc == 2);
     if (!ot.curimg.get()) {
         ot.warning(argv[0], "no current image available to modify");
         return 0;
@@ -1675,7 +1675,7 @@ set_keyword(int argc, const char* argv[])
 static int
 clear_keywords(int argc, const char* argv[])
 {
-    ASSERT(argc == 1);
+    OIIO_DASSERT(argc == 1);
     const char* newargs[3];
     newargs[0] = argv[0];
     newargs[1] = "Keywords";
@@ -1688,7 +1688,7 @@ clear_keywords(int argc, const char* argv[])
 static int
 set_orientation(int argc, const char* argv[])
 {
-    ASSERT(argc == 2);
+    OIIO_DASSERT(argc == 2);
     if (!ot.curimg.get()) {
         ot.warning(argv[0], "no current image available to modify");
         return 0;
@@ -1733,7 +1733,7 @@ do_rotate_orientation(ImageSpec& spec, string_view cmd)
 static int
 rotate_orientation(int argc, const char* argv[])
 {
-    ASSERT(argc == 1);
+    OIIO_DASSERT(argc == 1);
     string_view command = ot.express(argv[0]);
     if (!ot.curimg.get()) {
         ot.warning(command, "no current image available to modify");
@@ -1926,7 +1926,7 @@ set_full_to_pixels(int argc, const char* argv[])
 static int
 set_colorconfig(int argc, const char* argv[])
 {
-    ASSERT(argc == 2);
+    OIIO_DASSERT(argc == 2);
     ot.colorconfig.reset(argv[1]);
     return 0;
 }
@@ -1936,7 +1936,7 @@ set_colorconfig(int argc, const char* argv[])
 static int
 set_colorspace(int argc, const char* argv[])
 {
-    ASSERT(argc == 2);
+    OIIO_DASSERT(argc == 2);
     const char* args[3] = { argv[0], "oiio:ColorSpace", argv[1] };
     return set_string_attribute(3, args);
     // N.B. set_string_attribute does expression expansion on its args
@@ -2004,7 +2004,7 @@ static int
 action_tocolorspace(int argc, const char* argv[])
 {
     // Don't time -- let it get accounted by colorconvert
-    ASSERT(argc == 2);
+    OIIO_DASSERT(argc == 2);
     if (!ot.curimg.get()) {
         ot.warning(argv[0], "no current image available to modify");
         return 0;
@@ -3069,7 +3069,7 @@ OP_CUSTOMCLASS(cshift, OpCshift, 1);
 static int
 action_pop(int argc, const char* argv[])
 {
-    ASSERT(argc == 1);
+    OIIO_DASSERT(argc == 1);
     ot.pop();
     return 0;
 }
@@ -3079,7 +3079,7 @@ action_pop(int argc, const char* argv[])
 static int
 action_dup(int argc, const char* argv[])
 {
-    ASSERT(argc == 1);
+    OIIO_DASSERT(argc == 1);
     ot.push(ot.curimg);
     return 0;
 }
@@ -3088,7 +3088,7 @@ action_dup(int argc, const char* argv[])
 static int
 action_swap(int argc, const char* argv[])
 {
-    ASSERT(argc == 1);
+    OIIO_DASSERT(argc == 1);
     string_view command = ot.express(argv[0]);
     if (ot.image_stack.size() < 1) {
         ot.errorf(command, "requires at least two loaded images");
@@ -3105,7 +3105,7 @@ action_swap(int argc, const char* argv[])
 static int
 action_create(int argc, const char* argv[])
 {
-    ASSERT(argc == 3);
+    OIIO_DASSERT(argc == 3);
     Timer timer(ot.enable_function_timing);
     string_view command = ot.express(argv[0]);
     auto options        = ot.extract_options(command);
@@ -3141,7 +3141,7 @@ action_create(int argc, const char* argv[])
 static int
 action_pattern(int argc, const char* argv[])
 {
-    ASSERT(argc == 4);
+    OIIO_DASSERT(argc == 4);
     Timer timer(ot.enable_function_timing);
     string_view command = ot.express(argv[0]);
     auto options        = ot.extract_options(command);
@@ -3273,7 +3273,7 @@ OP_CUSTOMCLASS(kernel, OpKernel, 0);
 static int
 action_capture(int argc, const char* argv[])
 {
-    ASSERT(argc == 1);
+    OIIO_DASSERT(argc == 1);
     Timer timer(ot.enable_function_timing);
     string_view command = ot.express(argv[0]);
     auto options        = ot.extract_options(command);
@@ -4638,7 +4638,7 @@ OP_CUSTOMCLASS(text, OpText, 1);
 static int
 action_histogram(int argc, const char* argv[])
 {
-    ASSERT(argc == 3);
+    OIIO_DASSERT(argc == 3);
     if (ot.postpone_callback(1, action_histogram, argc, argv))
         return 0;
     Timer timer(ot.enable_function_timing);
@@ -5331,7 +5331,7 @@ output_file(int argc, const char* argv[])
 static int
 do_echo(int argc, const char* argv[])
 {
-    ASSERT(argc == 2);
+    OIIO_DASSERT(argc == 2);
 
     string_view command = ot.express(argv[0]);
     string_view message = ot.express(argv[1]);
@@ -6110,7 +6110,7 @@ main(int argc, char* argv[])
     std::locale::global(std::locale::classic());
 
     ot.imagecache = ImageCache::create();
-    ASSERT(ot.imagecache);
+    OIIO_DASSERT(ot.imagecache);
     ot.imagecache->attribute("forcefloat", 1);
     ot.imagecache->attribute("max_memory_MB", float(ot.cachesize));
     ot.imagecache->attribute("autotile", ot.autotile);

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -90,7 +90,7 @@ public:
     }
     virtual bool read(char c[], int n)
     {
-        ASSERT(m_io);
+        OIIO_DASSERT(m_io);
         if (m_io->read(c, n) != size_t(n))
             throw Iex::IoExc("Unexpected end of file.");
         return n;
@@ -510,7 +510,7 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
         return ok;
 
     ImageInput::lock_guard lock(in->m_mutex);
-    ASSERT(header);
+    OIIO_DASSERT(header);
     spec = ImageSpec();
 
     top_datawindow    = header->dataWindow();
@@ -827,7 +827,9 @@ TypeDesc_from_ImfPixelType(Imf::PixelType ptype)
     case Imf::UINT: return TypeDesc::UINT; break;
     case Imf::HALF: return TypeDesc::HALF; break;
     case Imf::FLOAT: return TypeDesc::FLOAT; break;
-    default: ASSERT_MSG(0, "Unknown Imf::PixelType %d", int(ptype));
+    default:
+        OIIO_ASSERT_MSG(0, "Unknown Imf::PixelType %d", int(ptype));
+        return TypeUnknown;
     }
 }
 
@@ -896,7 +898,7 @@ bool
 OpenEXRInput::PartInfo::query_channels(OpenEXRInput* in,
                                        const Imf::Header* header)
 {
-    ASSERT(!initialized);
+    OIIO_DASSERT(!initialized);
     bool ok        = true;
     spec.nchannels = 0;
     const Imf::ChannelList& channels(header->channels());
@@ -936,8 +938,8 @@ OpenEXRInput::PartInfo::query_channels(OpenEXRInput* in,
             // FIXME: Some day, we should handle channel subsampling.
         }
     }
-    ASSERT((int)spec.channelnames.size() == spec.nchannels);
-    ASSERT(spec.format != TypeDesc::UNKNOWN);
+    OIIO_DASSERT((int)spec.channelnames.size() == spec.nchannels);
+    OIIO_DASSERT(spec.format != TypeDesc::UNKNOWN);
     if (all_one_format)
         spec.channelformats.clear();
     return ok;
@@ -971,7 +973,7 @@ OpenEXRInput::PartInfo::compute_mipres(int miplevel, ImageSpec& spec) const
     } else if (levelmode == Imf::RIPMAP_LEVELS) {
         // FIXME
     } else {
-        ASSERT_MSG(0, "Unknown levelmode %d", int(levelmode));
+        OIIO_ASSERT_MSG(0, "Unknown levelmode %d", int(levelmode));
     }
 
     spec.width  = w;

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -581,7 +581,7 @@ OpenEXROutput::compute_pixeltypes(const ImageSpec& spec)
         }
         m_pixeltype.push_back(ptype);
     }
-    ASSERT(m_pixeltype.size() == size_t(spec.nchannels));
+    OIIO_ASSERT(m_pixeltype.size() == size_t(spec.nchannels));
 }
 
 

--- a/src/openvdb.imageio/CMakeLists.txt
+++ b/src/openvdb.imageio/CMakeLists.txt
@@ -6,11 +6,4 @@ if (OPENVDB_FOUND)
     add_oiio_plugin (openvdbinput.cpp
                      INCLUDE_DIRS ${OPENVDB_INCLUDE_DIRS} ${TBB_INCLUDE_DIRS}
                      LINK_LIBRARIES ${OPENVDB_LIBRARIES} ${TBB_LIBRARIES} ${BOOST_LIBRARIES})
-
-    if (CMAKE_COMPILER_IS_GNUCC AND ${GCC_VERSION} VERSION_GREATER_EQUAL 6.0
-        AND ${GCC_VERSION} VERSION_LESS 7.0)
-        set_source_files_properties (openvdbinput.cpp
-                                     PROPERTIES COMPILE_FLAGS -Wno-error=strict-overflow)
-    endif ()
-
 endif()

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -285,7 +285,7 @@ read_into_buffer(png_structp& sp, png_infop& ip, ImageSpec& spec,
     // }
 #endif
 
-    DASSERT(spec.scanline_bytes() == png_get_rowbytes(sp, ip));
+    OIIO_DASSERT(spec.scanline_bytes() == png_get_rowbytes(sp, ip));
     buffer.resize(spec.image_bytes());
 
     std::vector<unsigned char*> row_pointers(spec.height);

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -84,7 +84,7 @@ private:
                                 png_size_t length)
     {
         PNGInput* pnginput = (PNGInput*)png_get_io_ptr(png_ptr);
-        DASSERT(pnginput);
+        OIIO_DASSERT(pnginput);
         size_t bytes = pnginput->m_io->read(data, length);
         if (bytes != length) {
             pnginput->errorf("Read error: requested %d got %d", length, bytes);

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -75,7 +75,7 @@ private:
                                  png_size_t length)
     {
         PNGOutput* pngoutput = (PNGOutput*)png_get_io_ptr(png_ptr);
-        DASSERT(pngoutput);
+        OIIO_DASSERT(pngoutput);
         size_t bytes = pngoutput->m_io->write(data, length);
         if (bytes != length) {
             pngoutput->errorf("Write error");
@@ -86,7 +86,7 @@ private:
     static void PngFlushCallback(png_structp png_ptr)
     {
         PNGOutput* pngoutput = (PNGOutput*)png_get_io_ptr(png_ptr);
-        DASSERT(pngoutput);
+        OIIO_DASSERT(pngoutput);
         pngoutput->m_io->flush();
     }
 };
@@ -216,7 +216,7 @@ PNGOutput::close()
     bool ok = true;
     if (m_spec.tile_width) {
         // Handle tile emulation -- output the buffered pixels
-        ASSERT(m_tilebuffer.size());
+        OIIO_ASSERT(m_tilebuffer.size());
         ok &= write_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
                               m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap(m_tilebuffer);

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -195,7 +195,7 @@ PNMOutput::close()
     bool ok = true;
     if (m_spec.tile_width) {
         // Handle tile emulation -- output the buffered pixels
-        ASSERT(m_tilebuffer.size());
+        OIIO_DASSERT(m_tilebuffer.size());
         ok &= write_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
                               m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap(m_tilebuffer);

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -724,7 +724,7 @@ PSDInput::read_native_scanline(int subimage, int miplevel, int y, int z,
         m_channel_buffers.resize(m_channels[m_subimage].size());
 
     int bps = (m_header.depth + 7) / 8;  // bytes per sample
-    ASSERT(bps == 1 || bps == 2 || bps == 4);
+    OIIO_DASSERT(bps == 1 || bps == 2 || bps == 4);
     std::vector<ChannelInfo*>& channels = m_channels[m_subimage];
     int channel_count                   = (int)channels.size();
     for (int c = 0; c < channel_count; ++c) {
@@ -784,7 +784,8 @@ PSDInput::read_native_scanline(int subimage, int miplevel, int y, int z,
         if (!bitmap_to_rgb(dst))
             return false;
     } else {
-        ASSERT(0 && "unknown color mode");
+        OIIO_ASSERT(0 && "unknown color mode");
+        return false;
     }
 
     // PSD specifically dictates unassociated (un-"premultiplied") alpha.
@@ -1896,7 +1897,7 @@ template<typename T>
 void
 PSDInput::interleave_row(T* dst, size_t nchans)
 {
-    ASSERT(nchans <= m_channels[m_subimage].size());
+    OIIO_DASSERT(nchans <= m_channels[m_subimage].size());
     for (size_t c = 0; c < nchans; ++c) {
         const T* cbuf = (const T*)&(m_channel_buffers[c][0]);
         for (int x = 0; x < m_spec.width; ++x)

--- a/src/ptex.imageio/ptexinput.cpp
+++ b/src/ptex.imageio/ptexinput.cpp
@@ -207,7 +207,7 @@ PtexInput::seek_subimage(int subimage, int miplevel)
             const char* key = NULL;
             Ptex::MetaDataType ptype;
             pmeta->getKey(i, key, ptype);
-            ASSERT(key);
+            OIIO_DASSERT(key);
             const char* vchar;
             const void* value;
             TypeDesc typedesc;

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -42,7 +42,7 @@ IBA_fill(ImageBuf& dst, py::object values_tuple, ROI roi = ROI::All(),
         values.resize(roi.nchannels(), values.size() ? values.back() : 0.0f);
     else
         return false;
-    ASSERT(values.size() > 0);
+    OIIO_ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
     return ImageBufAlgo::fill(dst, values, roi, nthreads);
 }
@@ -63,7 +63,7 @@ IBA_fill2(ImageBuf& dst, py::object top_tuple, py::object bottom_tuple,
         bottom.resize(roi.nchannels(), 0.0f);
     } else
         return false;
-    ASSERT(top.size() > 0 && bottom.size() > 0);
+    OIIO_ASSERT(top.size() > 0 && bottom.size() > 0);
     py::gil_scoped_release gil;
     return ImageBufAlgo::fill(dst, top, bottom, roi, nthreads);
 }
@@ -91,8 +91,8 @@ IBA_fill4(ImageBuf& dst, py::object top_left_tuple, py::object top_right_tuple,
         bottom_right.resize(roi.nchannels(), 0.0f);
     } else
         return false;
-    ASSERT(top_left.size() > 0 && top_right.size() > 0 && bottom_left.size() > 0
-           && bottom_right.size() > 0);
+    OIIO_ASSERT(top_left.size() > 0 && top_right.size() > 0
+                && bottom_left.size() > 0 && bottom_right.size() > 0);
     py::gil_scoped_release gil;
     return ImageBufAlgo::fill(dst, top_left, top_right, bottom_left,
                               bottom_right, roi, nthreads);
@@ -544,7 +544,7 @@ IBA_add_color(ImageBuf& dst, const ImageBuf& A, py::object values_tuple,
         values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
     else
         return false;
-    ASSERT(values.size() > 0);
+    OIIO_ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
     return ImageBufAlgo::add(dst, A, &values[0], roi, nthreads);
 }
@@ -570,7 +570,7 @@ IBA_add_color_ret(const ImageBuf& A, py::object values_tuple,
         values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
     else
         return result;
-    ASSERT(values.size() > 0);
+    OIIO_ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
     result = ImageBufAlgo::add(A, values, roi, nthreads);
     return result;
@@ -599,7 +599,7 @@ IBA_sub_color(ImageBuf& dst, const ImageBuf& A, py::object values_tuple,
         values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
     else
         return false;
-    ASSERT(values.size() > 0);
+    OIIO_ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
     return ImageBufAlgo::sub(dst, A, &values[0], roi, nthreads);
 }
@@ -625,7 +625,7 @@ IBA_sub_color_ret(const ImageBuf& A, py::object values_tuple,
         values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
     else
         return result;
-    ASSERT(values.size() > 0);
+    OIIO_ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
     result = ImageBufAlgo::sub(A, values, roi, nthreads);
     return result;
@@ -653,7 +653,7 @@ IBA_absdiff_color(ImageBuf& dst, const ImageBuf& A, py::object values_tuple,
         values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
     else
         return false;
-    ASSERT(values.size() > 0);
+    OIIO_ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
     return ImageBufAlgo::absdiff(dst, A, &values[0], roi, nthreads);
 }
@@ -679,7 +679,7 @@ IBA_absdiff_color_ref(const ImageBuf& A, py::object values_tuple,
         values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
     else
         return result;
-    ASSERT(values.size() > 0);
+    OIIO_ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
     result = ImageBufAlgo::absdiff(A, values, roi, nthreads);
     return result;
@@ -726,7 +726,7 @@ IBA_mul_color(ImageBuf& dst, const ImageBuf& A, py::object values_tuple,
         values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
     else
         return false;
-    ASSERT(values.size() > 0);
+    OIIO_ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
     return ImageBufAlgo::mul(dst, A, &values[0], roi, nthreads);
 }
@@ -752,7 +752,7 @@ IBA_mul_color_ret(const ImageBuf& A, py::object values_tuple,
         values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
     else
         return result;
-    ASSERT(values.size() > 0);
+    OIIO_ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
     result = ImageBufAlgo::mul(A, values, roi, nthreads);
     return result;
@@ -780,7 +780,7 @@ IBA_div_color(ImageBuf& dst, const ImageBuf& A, py::object values_tuple,
         values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
     else
         return false;
-    ASSERT(values.size() > 0);
+    OIIO_ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
     return ImageBufAlgo::div(dst, A, &values[0], roi, nthreads);
 }
@@ -808,7 +808,7 @@ IBA_div_color_ret(const ImageBuf& A, py::object values_tuple,
         values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
     else
         return result;
-    ASSERT(values.size() > 0);
+    OIIO_ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
     result = ImageBufAlgo::div(A, values, roi, nthreads);
     return result;
@@ -843,7 +843,7 @@ IBA_mad_color(ImageBuf& dst, const ImageBuf& A, py::object Bvalues_tuple,
         Cvalues.resize(A.nchannels(), Cvalues.size() ? Cvalues.back() : 0.0f);
     else
         return false;
-    ASSERT(Bvalues.size() > 0 && Cvalues.size() > 0);
+    OIIO_ASSERT(Bvalues.size() > 0 && Cvalues.size() > 0);
     py::gil_scoped_release gil;
     return ImageBufAlgo::mad(dst, A, Bvalues, Cvalues, roi, nthreads);
 }
@@ -860,7 +860,7 @@ IBA_mad_ici(ImageBuf& dst, const ImageBuf& A, py::object Bvalues_tuple,
         Bvalues.resize(A.nchannels(), Bvalues.size() ? Bvalues.back() : 0.0f);
     else
         return false;
-    ASSERT(Bvalues.size() > 0);
+    OIIO_ASSERT(Bvalues.size() > 0);
     py::gil_scoped_release gil;
     return ImageBufAlgo::mad(dst, A, Bvalues, C, roi, nthreads);
 }
@@ -903,7 +903,7 @@ IBA_mad_color_ret(const ImageBuf& A, py::object Bvalues_tuple,
         Cvalues.resize(A.nchannels(), Cvalues.size() ? Cvalues.back() : 0.0f);
     else
         return result;
-    ASSERT(Bvalues.size() > 0 && Cvalues.size() > 0);
+    OIIO_ASSERT(Bvalues.size() > 0 && Cvalues.size() > 0);
     py::gil_scoped_release gil;
     result = ImageBufAlgo::mad(A, Bvalues, Cvalues, roi, nthreads);
     return result;
@@ -922,7 +922,7 @@ IBA_mad_ici_ret(const ImageBuf& A, py::object Bvalues_tuple, const ImageBuf& C,
         Bvalues.resize(A.nchannels(), Bvalues.size() ? Bvalues.back() : 0.0f);
     else
         return result;
-    ASSERT(Bvalues.size() > 0);
+    OIIO_ASSERT(Bvalues.size() > 0);
     py::gil_scoped_release gil;
     result = ImageBufAlgo::mad(A, Bvalues, C, roi, nthreads);
     return result;
@@ -975,7 +975,7 @@ IBA_pow_color(ImageBuf& dst, const ImageBuf& A, py::object values_tuple,
         values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
     else
         return false;
-    ASSERT(values.size() > 0);
+    OIIO_ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
     return ImageBufAlgo::pow(dst, A, values, roi, nthreads);
 }
@@ -994,7 +994,7 @@ IBA_pow_color_ret(const ImageBuf& A, py::object values_tuple,
         values.resize(A.nchannels(), values.size() ? values.back() : 0.0f);
     else
         return result;
-    ASSERT(values.size() > 0);
+    OIIO_ASSERT(values.size() > 0);
     py::gil_scoped_release gil;
     result = ImageBufAlgo::pow(A, values, roi, nthreads);
     return result;

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -129,7 +129,8 @@ template<typename T, typename PYT>
 inline bool
 py_indexable_pod_to_stdvector(std::vector<T>& vals, const PYT& obj)
 {
-    ASSERT(py::isinstance<py::tuple>(obj) || py::isinstance<py::list>(obj));
+    OIIO_ASSERT(py::isinstance<py::tuple>(obj)
+                || py::isinstance<py::list>(obj));
     bool ok             = true;
     const size_t length = py::len(obj);
     vals.reserve(length);
@@ -158,7 +159,8 @@ template<typename PYT>
 inline bool
 py_indexable_pod_to_stdvector(std::vector<std::string>& vals, const PYT& obj)
 {
-    ASSERT(py::isinstance<py::tuple>(obj) || py::isinstance<py::list>(obj));
+    OIIO_ASSERT(py::isinstance<py::tuple>(obj)
+                || py::isinstance<py::list>(obj));
     bool ok             = true;
     const size_t length = py::len(obj);
     vals.reserve(length);
@@ -181,7 +183,8 @@ template<typename PYT>
 inline bool
 py_indexable_pod_to_stdvector(std::vector<TypeDesc>& vals, const PYT& obj)
 {
-    ASSERT(py::isinstance<py::tuple>(obj) || py::isinstance<py::list>(obj));
+    OIIO_ASSERT(py::isinstance<py::tuple>(obj)
+                || py::isinstance<py::list>(obj));
     bool ok             = true;
     const size_t length = py::len(obj);
     vals.reserve(length);

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -358,7 +358,7 @@ RawInput::open_raw(bool unpack, const std::string& name,
         return false;
     }
 
-    ASSERT(!m_unpacked);
+    OIIO_ASSERT(!m_unpacked);
     if (unpack) {
         if ((ret = m_processor->unpack()) != LIBRAW_SUCCESS) {
             errorf("Could not unpack \"%s\", %s", m_filename,

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -103,7 +103,7 @@ private:
     // debugging aid
     void preview(std::ostream& out)
     {
-        ASSERT(!feof(m_file));
+        OIIO_DASSERT(!feof(m_file));
         long pos = ftell(m_file);
         out << "@" << pos << ", next 4 bytes are ";
         union {  // trickery to avoid punned pointer warnings
@@ -177,7 +177,7 @@ RLAInput::read_header()
 {
     // Read the image header, which should have the same exact layout as
     // the m_rla structure (except for endianness issues).
-    ASSERT(sizeof(m_rla) == 740 && "Bad RLA struct size");
+    static_assert(sizeof(m_rla) == 740, "Bad RLA struct size");
     if (!read(&m_rla)) {
         errorf("RLA could not read the image header");
         return false;
@@ -678,14 +678,14 @@ RLAInput::get_channel_typedesc(short chan_type, short chan_bits)
             case 2: return TypeDesc::UINT16;
             case 3:
             case 4: return TypeDesc::UINT32;
-            default: ASSERT(!"Invalid colour channel type");
+            default: OIIO_ASSERT(!"Invalid colour channel type");
             }
         } else
             return TypeDesc::UINT8;
     case CT_WORD: return TypeDesc::UINT16;
     case CT_DWORD: return TypeDesc::UINT32;
     case CT_FLOAT: return TypeDesc::FLOAT;
-    default: ASSERT(!"Invalid colour channel type");
+    default: OIIO_ASSERT(!"Invalid colour channel type");
     }
     // shut up compiler
     return TypeDesc::UINT8;

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -415,7 +415,7 @@ RLAOutput::close()
     bool ok = true;
     if (m_spec.tile_width) {
         // Handle tile emulation -- output the buffered pixels
-        ASSERT(m_tilebuffer.size());
+        OIIO_DASSERT(m_tilebuffer.size());
         ok &= write_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
                               m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap(m_tilebuffer);
@@ -493,7 +493,7 @@ RLAOutput::encode_channel(unsigned char* data, stride_t xstride,
             } else {  // Have not been repeating
                 if (newval == lastval) {
                     // starting a repetition?  Output previous
-                    ASSERT(count > 1);
+                    OIIO_DASSERT(count > 1);
                     // write everything but the last char
                     --count;
                     m_rle.push_back(-count);
@@ -523,7 +523,7 @@ RLAOutput::encode_channel(unsigned char* data, stride_t xstride,
             }
             lastval = newval;
         }
-        ASSERT(count == 0);
+        OIIO_ASSERT(count == 0);
     }
 
     // Now that we know the size of the encoded buffer, save it at the
@@ -545,7 +545,7 @@ RLAOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
     m_spec.auto_stride(xstride, format, spec().nchannels);
     const void* origdata = data;
     data = to_native_scanline(format, data, xstride, m_scratch, m_dither, y, z);
-    ASSERT(data != NULL);
+    OIIO_DASSERT(data != nullptr);
     if (data == origdata) {
         m_scratch.assign((unsigned char*)data,
                          (unsigned char*)data + m_spec.scanline_bytes());

--- a/src/sgi.imageio/sgiinput.cpp
+++ b/src/sgi.imageio/sgiinput.cpp
@@ -200,7 +200,7 @@ SgiInput::uncompress_rle_channel(int scanline_off, int scanline_len,
             // If the high bit is set, we just copy the next 'count' values
             if (value & 0x80) {
                 while (count--) {
-                    DASSERT(i < scanline_len && limit > 0);
+                    OIIO_DASSERT(i < scanline_len && limit > 0);
                     *(out++) = rle_scanline[i++];
                     --limit;
                 }
@@ -209,15 +209,14 @@ SgiInput::uncompress_rle_channel(int scanline_off, int scanline_len,
             else {
                 value = rle_scanline[i++];
                 while (count--) {
-                    DASSERT(limit > 0);
+                    OIIO_DASSERT(limit > 0);
                     *(out++) = value;
                     --limit;
                 }
             }
         }
-    } else {
+    } else if (bpc == 2) {
         // 2 bits per channel
-        ASSERT(bpc == 2);
         while (i < scanline_len) {
             // Read a byte, it is the count.
             unsigned short value = (rle_scanline[i] << 8) | rle_scanline[i + 1];
@@ -229,7 +228,7 @@ SgiInput::uncompress_rle_channel(int scanline_off, int scanline_len,
             // If the high bit is set, we just copy the next 'count' values
             if (value & 0x80) {
                 while (count--) {
-                    DASSERT(i + 1 < scanline_len && limit > 0);
+                    OIIO_DASSERT(i + 1 < scanline_len && limit > 0);
                     *(out++) = rle_scanline[i++];
                     *(out++) = rle_scanline[i++];
                     --limit;
@@ -238,7 +237,7 @@ SgiInput::uncompress_rle_channel(int scanline_off, int scanline_len,
             // If the high bit is zero, we copy the NEXT value, count times
             else {
                 while (count--) {
-                    DASSERT(limit > 0);
+                    OIIO_DASSERT(limit > 0);
                     *(out++) = rle_scanline[i];
                     *(out++) = rle_scanline[i + 1];
                     --limit;
@@ -246,6 +245,9 @@ SgiInput::uncompress_rle_channel(int scanline_off, int scanline_len,
                 i += 2;
             }
         }
+    } else {
+        errorf("Unknown bytes per channel %d", bpc);
+        return false;
     }
     if (i != scanline_len || limit != 0) {
         errorf("Corrupt RLE data");

--- a/src/sgi.imageio/sgioutput.cpp
+++ b/src/sgi.imageio/sgioutput.cpp
@@ -137,7 +137,7 @@ SgiOutput::close()
     bool ok = true;
     if (m_spec.tile_width) {
         // Handle tile emulation -- output the buffered pixels
-        ASSERT(m_tilebuffer.size());
+        OIIO_ASSERT(m_tilebuffer.size());
         ok &= write_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
                               m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap(m_tilebuffer);

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -449,7 +449,7 @@ TGAOutput::close()
     bool ok = true;
     if (m_spec.tile_width) {
         // Handle tile emulation -- output the buffered pixels
-        ASSERT(m_tilebuffer.size());
+        OIIO_ASSERT(m_tilebuffer.size());
         ok &= write_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
                               m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap(m_tilebuffer);

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -649,9 +649,11 @@ plain_tex_region_batch(ImageBuf& image, ustring filename, Mapping2DWide mapping,
         filename);
     int nchannels_img = image.nchannels();
     int nchannels = nchannels_override ? nchannels_override : image.nchannels();
-    DASSERT(image.spec().format == TypeDesc::FLOAT);
-    DASSERT(image_ds == nullptr || image_ds->spec().format == TypeDesc::FLOAT);
-    DASSERT(image_dt == nullptr || image_dt->spec().format == TypeDesc::FLOAT);
+    OIIO_DASSERT(image.spec().format == TypeDesc::FLOAT);
+    OIIO_DASSERT(image_ds == nullptr
+                 || image_ds->spec().format == TypeDesc::FLOAT);
+    OIIO_DASSERT(image_dt == nullptr
+                 || image_dt->spec().format == TypeDesc::FLOAT);
 
     TextureOptBatch opt;
     initialize_opt(opt, nchannels);
@@ -1215,7 +1217,8 @@ do_tex_thread_workout(int iterations, int mythread)
                 pixel += 57557 * mythread;
             }
             break;
-        default: ASSERT_MSG(0, "Unkonwn thread work pattern %d", threadtimes);
+        default:
+            OIIO_ASSERT_MSG(0, "Unkonwn thread work pattern %d", threadtimes);
         }
         if (!ok && spec0.width && spec0.height) {
             s = (((2 * pixel) % spec0.width) + 0.5f) / spec0.width;
@@ -1245,7 +1248,7 @@ do_tex_thread_workout(int iterations, int mythread)
     }
     // Force the compiler to not optimize away the "other work"
     for (int c = 0; c < nchannels; ++c)
-        ASSERT(!isnan(result[c]));
+        OIIO_ASSERT(!isnan(result[c]));
 }
 
 
@@ -1261,7 +1264,7 @@ launch_tex_threads(int numthreads, int iterations)
     for (int i = 0; i < numthreads; ++i) {
         threads.create_thread(std::bind(do_tex_thread_workout, iterations, i));
     }
-    ASSERT((int)threads.size() == numthreads);
+    OIIO_ASSERT((int)threads.size() == numthreads);
     threads.join_all();
 }
 
@@ -1365,9 +1368,10 @@ test_icwrite(int testicwrite)
     spec.tile_depth  = 1;
     ustring filename(filenames[0]);
     bool ok = ic->add_file(filename, make_grid_input);
-    if (!ok)
+    if (!ok) {
         std::cout << "ic->add_file error: " << ic->geterror() << "\n";
-    ASSERT(ok);
+        OIIO_ASSERT(ok);
+    }
 
     // Now add all the tiles if it's a seeded map
     // testicwrite == 1 means to seed the first MIP level using add_tile.
@@ -1395,7 +1399,6 @@ test_icwrite(int testicwrite)
                                      ic->geterror());
                     return;
                 }
-                ASSERT(ok);
             }
         }
     }

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -357,8 +357,8 @@ private:
                               int channels, int width, int height,
                               int compression, bool* ok)
     {
-        ASSERT (compression == COMPRESSION_ADOBE_DEFLATE /*||
-                compression == COMPRESSION_NONE*/);
+        OIIO_DASSERT (compression == COMPRESSION_ADOBE_DEFLATE /*||
+                      compression == COMPRESSION_NONE*/);
         if (compression == COMPRESSION_NONE) {
             // just copy if there's no compression
             memcpy(uncompressed_buf, compressed_buf, csize);
@@ -942,7 +942,7 @@ TIFFInput::readspec(bool read_meta)
                 if (m_keep_unassociated_alpha)
                     m_spec.attribute("oiio:UnassociatedAlpha", 1);
             } else {
-                DASSERT(sampleinfo[i] == EXTRASAMPLE_UNSPECIFIED);
+                OIIO_DASSERT(sampleinfo[i] == EXTRASAMPLE_UNSPECIFIED);
                 // This extra channel is not alpha at all.  Undo any
                 // assumptions we previously made about this channel.
                 if (m_spec.alpha_channel == c) {
@@ -1219,7 +1219,7 @@ TIFFInput::readspec_photometric()
         // Read the color map
         unsigned short *r = NULL, *g = NULL, *b = NULL;
         TIFFGetField(m_tif, TIFFTAG_COLORMAP, &r, &g, &b);
-        ASSERT(r != NULL && g != NULL && b != NULL);
+        OIIO_ASSERT(r != NULL && g != NULL && b != NULL);
         m_colormap.clear();
         m_colormap.insert(m_colormap.end(), r, r + (1 << m_bitspersample));
         m_colormap.insert(m_colormap.end(), g, g + (1 << m_bitspersample));
@@ -1280,8 +1280,8 @@ TIFFInput::palette_to_rgb(int n, const unsigned char* palettepels,
     size_t vals_per_byte = 8 / m_bitspersample;
     size_t entries       = 1 << m_bitspersample;
     int highest          = entries - 1;
-    DASSERT(m_spec.nchannels == 3);
-    DASSERT(m_colormap.size() == 3 * entries);
+    OIIO_DASSERT(m_spec.nchannels == 3);
+    OIIO_DASSERT(m_colormap.size() == 3 * entries);
     for (int x = 0; x < n; ++x) {
         int i = palettepels[x / vals_per_byte];
         i >>= (m_bitspersample * (vals_per_byte - 1 - (x % vals_per_byte)));
@@ -1298,7 +1298,7 @@ void
 TIFFInput::bit_convert(int n, const unsigned char* in, int inbits, void* out,
                        int outbits)
 {
-    ASSERT(inbits >= 1 && inbits < 32);  // surely bugs if not
+    OIIO_DASSERT(inbits >= 1 && inbits < 32);  // surely bugs if not
     uint32_t highest = (1 << inbits) - 1;
     int B = 0, b = 0;
     // Invariant:
@@ -1440,8 +1440,9 @@ TIFFInput::read_native_scanline(int subimage, int miplevel, int y, int z,
                 || !seek_subimage(old_subimage, old_miplevel)) {
                 return false;  // Somehow, the re-open failed
             }
-            ASSERT(m_next_scanline == 0 && current_subimage() == old_subimage
-                   && current_miplevel() == old_miplevel);
+            OIIO_DASSERT(m_next_scanline == 0
+                         && current_subimage() == old_subimage
+                         && current_miplevel() == old_miplevel);
         }
         while (m_next_scanline < y) {
             // Keep reading until we're read the scanline we really need
@@ -1858,7 +1859,7 @@ TIFFInput::read_native_tiles(int subimage, int miplevel, int xbegin, int xend,
     // bother trying to handle any of the uncommon cases with strips. This
     // covers most real-world cases.
     thread_pool* pool = default_thread_pool();
-    ASSERT(m_spec.tile_depth >= 1);
+    OIIO_DASSERT(m_spec.tile_depth >= 1);
     size_t ntiles = size_t(
         (xend - xbegin + m_spec.tile_width - 1) / m_spec.tile_width
         * (yend - ybegin + m_spec.tile_height - 1) / m_spec.tile_height

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -987,7 +987,7 @@ TIFFOutput::convert_to_cmyk(int npixels, const void* data,
         rgb_to_cmyk(npixels, (unsigned short*)data, m_spec.nchannels,
                     (unsigned short*)&cmyk[0], m_outputchans);
     } else {
-        ASSERT(0 && "CMYK should be forced to UINT8 or UINT16");
+        OIIO_ASSERT(0 && "CMYK should be forced to UINT8 or UINT16");
     }
     return cmyk.data();
 }
@@ -1268,7 +1268,7 @@ TIFFOutput::write_tile(int x, int y, int z, TypeDesc format, const void* data,
         // Convert from contiguous (RGBRGBRGB) to separate (RRRGGGBBB)
         imagesize_t tile_pixels = m_spec.tile_pixels();
         imagesize_t plane_bytes = tile_pixels * m_spec.format.size();
-        DASSERT(plane_bytes * m_spec.nchannels == m_spec.tile_bytes());
+        OIIO_DASSERT(plane_bytes * m_spec.nchannels == m_spec.tile_bytes());
 
         std::unique_ptr<char[]> separate_heap;
         char* separate            = NULL;
@@ -1339,7 +1339,7 @@ TIFFOutput::write_tiles(int xbegin, int xend, int ybegin, int yend, int zbegin,
     // (compressed) strips. Don't bother trying to handle any of the
     // uncommon cases with strips. This covers most real-world cases.
     thread_pool* pool = default_thread_pool();
-    ASSERT(m_spec.tile_depth >= 1);
+    OIIO_DASSERT(m_spec.tile_depth >= 1);
     size_t ntiles = size_t(
         (xend - xbegin + m_spec.tile_width - 1) / m_spec.tile_width
         * (yend - ybegin + m_spec.tile_height - 1) / m_spec.tile_height
@@ -1529,7 +1529,7 @@ TIFFOutput::source_is_rgb(const ImageSpec& spec)
 void
 TIFFOutput::fix_bitdepth(void* data, int nvals)
 {
-    ASSERT(spec().format.size() * 8 != m_bitspersample);
+    OIIO_DASSERT(spec().format.size() * 8 != m_bitspersample);
 
     if (spec().format == TypeDesc::UINT16 && m_bitspersample == 10) {
         unsigned short* v = (unsigned short*)data;
@@ -1567,7 +1567,7 @@ TIFFOutput::fix_bitdepth(void* data, int nvals)
             v[i] = bit_range_convert<32, 24>(v[i]);
         bit_pack(cspan<unsigned int>(v, v + nvals), v, 24);
     } else {
-        ASSERT(0 && "unsupported bit conversion -- shouldn't reach here");
+        OIIO_ASSERT(0 && "unsupported bit conversion -- shouldn't reach here");
     }
 }
 

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -195,7 +195,7 @@ WebpOutput::close()
     bool ok = true;
     if (m_spec.tile_width) {
         // We've been emulating tiles; now dump as scanlines.
-        ASSERT(m_uncompressed_image.size());
+        OIIO_DASSERT(m_uncompressed_image.size());
         ok &= write_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
                               m_spec.format, &m_uncompressed_image[0]);
         std::vector<uint8_t>().swap(m_uncompressed_image);

--- a/src/zfile.imageio/zfile.cpp
+++ b/src/zfile.imageio/zfile.cpp
@@ -235,7 +235,7 @@ ZfileInput::read_native_scanline(int subimage, int miplevel, int y, int z,
         if (!close() || !open(m_filename, dummyspec)
             || !seek_subimage(subimage, miplevel))
             return false;  // Somehow, the re-open failed
-        ASSERT(m_next_scanline == 0 && current_subimage() == subimage);
+        OIIO_DASSERT(m_next_scanline == 0 && current_subimage() == subimage);
     }
     while (m_next_scanline <= y) {
         // Keep reading until we're read the scanline we really need
@@ -343,7 +343,7 @@ ZfileOutput::close()
     bool ok = true;
     if (m_spec.tile_width) {
         // We've been emulating tiles; now dump as scanlines.
-        ASSERT(m_tilebuffer.size());
+        OIIO_DASSERT(m_tilebuffer.size());
         ok &= write_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
                               m_spec.format, &m_tilebuffer[0]);
         std::vector<unsigned char>().swap(m_tilebuffer);


### PR DESCRIPTION
Lots of changes, a combination of:

* DASSERT -> OIIO_DASSERT (better name with no namespace pollution,
  same behavior as before)

* ASSERT -> OIIO_ASSERT (better name and better behavior -- no abort
  when in release mode, but error still printed; does both error and
  abort when in debug mode)

* Many cases of ASSERT -> OIIO_DASSERT, downgrading to checks that only
  need to happen in debug mode.

* Removal of a few assertions that are just not necessary nor helpful
  (e.g, return if x is null, then immediately pointlessly assert that
  x is not null).

* Change a few assertions to just plain old error handling, no assertion
  needed.

