### PR TITLE
Extend Python ParamValueList to take lists and numpy arrays

### DIFF
--- a/testsuite/python-paramlist/ref/out.txt
+++ b/testsuite/python-paramlist/ref/out.txt
@@ -4,12 +4,16 @@ Testing individual ParamValue:
   item c string xyzpdq
   item d float[4] (3.5, 4.5, 5.5, 6.5)
   item e float (1.0, 3.0, 5.0, 7.0)
+  item f point (3.5, 4.5, 5.5)
+  item g color (0.25, 0.5, 0.75)
 
 Testing ParamValueList:
-pl length is 6
+pl length is 8
   item i int 1
   item s string Bob
   item e float 2.71828
+  item P point (2.0, 42.0, 1.0)
+  item pressure float (98.0, 98.5, 99.0, 99.5)
   item j int 42
   item foo string bar
   item pi float 3.14159
@@ -19,24 +23,28 @@ pl[1] = s string Bob
 pl['e'] = 2.71828
 pl['pi'] = 3.14159
 pl['foo'] = bar
-after removing 'e', len= 5 pl.contains('e')= False
+after removing 'e', len= 7 pl.contains('e')= False
 pl2 =
   item a string aval
   item m int 1
 After merge, pl =
   item i int 1
   item s string Bob
+  item P point (2.0, 42.0, 1.0)
+  item pressure float (98.0, 98.5, 99.0, 99.5)
   item j int 42
   item foo string bar
   item pi float 3.14159
   item a string aval
   item m int 1
 after sorting:
+  item P point (2.0, 42.0, 1.0)
   item a string aval
   item foo string bar
   item i int 1
   item j int 42
   item m int 1
   item pi float 3.14159
+  item pressure float (98.0, 98.5, 99.0, 99.5)
   item s string Bob
 Done.

--- a/testsuite/python-paramlist/src/test_paramlist.py
+++ b/testsuite/python-paramlist/src/test_paramlist.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 from __future__ import absolute_import
+import numpy
 import OpenImageIO as oiio
 
 
@@ -22,16 +23,27 @@ def print_param_list(pl) :
 
 try:
     print ("Testing individual ParamValue:")
+    # Construct from scalars
     pv = oiio.ParamValue("a", 42)
     print_param_value(pv)
     pv = oiio.ParamValue("b", 3.5)
     print_param_value(pv)
     pv = oiio.ParamValue("c", "xyzpdq")
     print_param_value(pv)
+    # Construct from tuple
     pv = oiio.ParamValue("d", "float[4]", (3.5, 4.5, 5.5, 6.5))
     print_param_value(pv)
-    pv = oiio.ParamValue("e", "float", 4, oiio.Interp.INTERP_LINEAR, (1, 3, 5, 7))
+    # Construct from tuple with nvalues/interp
+    pv = oiio.ParamValue("e", "float", 4, oiio.Interp.LINEAR, (1, 3, 5, 7))
     print_param_value(pv)
+    # Construct from a list
+    pv = oiio.ParamValue("f", "point", [3.5, 4.5, 5.5, 6.5])
+    print_param_value(pv)
+    # Construct from a numpy array
+    pv = oiio.ParamValue("g", "color",
+                         numpy.array([0.25, 0.5, 0.75], dtype='f'))
+    print_param_value(pv)
+
     print ("")
 
     print ("Testing ParamValueList:")
@@ -39,6 +51,8 @@ try:
     pl.attribute ("i", 1)
     pl.attribute ("s", "Bob")
     pl.attribute ("e", 2.718281828459045)
+    pl.attribute ("P", "point", (2.0, 42.0, 1.0))
+    pl.attribute ("pressure", "float", 4, [98.0, 98.5, 99.0, 99.5])
     pl["j"] = 42
     pl["foo"] = "bar"
     pl["pi"] = 3.141592653589793


### PR DESCRIPTION
Previously the data passed had to be tuples.

Also add ParamValueList.attribute() variety that takes an nvalues
parameter.

