### PR TITLE
Add ImageBuf::setpixel() methods that use cspan instead of ptr/len.

### DIFF
--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -458,6 +458,31 @@ public:
                                  WrapMode wrap = WrapBlack) const;
 
 
+    /// Set the pixel with coordinates (x,y,0) to have the values in span
+    /// `pixel[]`.  The number of channels copied is the minimum of the span
+    /// length and the actual number of channels in the image.
+    void setpixel(int x, int y, cspan<float> pixel)
+    {
+        setpixel(x, y, 0, pixel);
+    }
+
+    /// Set the pixel with coordinates (x,y,z) to have the values in span
+    /// `pixel[]`.  The number of channels copied is the minimum of the span
+    /// length and the actual number of channels in the image.
+    void setpixel(int x, int y, int z, cspan<float> pixel)
+    {
+        setpixel(x, y, z, pixel.data(), int(pixel.size()));
+    }
+
+    /// Set the `i`-th pixel value of the image (out of width*height*depth),
+    /// from floating-point values in span `pixel[]`.  The number of
+    /// channels copied is the minimum of the span length and the actual
+    /// number of channels in the image.
+    void setpixel(int i, cspan<float> pixel)
+    {
+        setpixel(i, pixel.data(), int(pixel.size()));
+    }
+
     /// Set the pixel with coordinates (x,y,0) to have the values in
     /// pixel[0..n-1].  The number of channels copied, n, is the minimum
     /// of maxchannels and the actual number of channels in the image.

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -84,7 +84,7 @@ ImageBuf_setpixel(ImageBuf& buf, int x, int y, int z, py::object p)
     std::vector<float> pixel;
     py_to_stdvector(pixel, p);
     if (pixel.size())
-        buf.setpixel(x, y, z, &pixel[0], pixel.size());
+        buf.setpixel(x, y, z, pixel);
 }
 
 void
@@ -100,7 +100,7 @@ ImageBuf_setpixel1(ImageBuf& buf, int i, py::object p)
     std::vector<float> pixel;
     py_to_stdvector(pixel, p);
     if (pixel.size())
-        buf.setpixel(i, &pixel[0], pixel.size());
+        buf.setpixel(i, pixel);
 }
 
 


### PR DESCRIPTION
Convenience function. Preferred to use spans over ptr+length. Also, this matches the Python interface.
