### PR TITLE
Add missing include of dassert.h to refcnt.h

### DIFF
--- a/src/include/OpenImageIO/refcnt.h
+++ b/src/include/OpenImageIO/refcnt.h
@@ -15,6 +15,7 @@
 #include <memory>
 
 #include <OpenImageIO/atomic.h>
+#include <OpenImageIO/dassert.h>
 
 
 OIIO_NAMESPACE_BEGIN


### PR DESCRIPTION
We used the assertion macros, but didn't include the header. I guess
coincidentally, all other files that included refcnt happened to have
included dassert first? But 3rd party code that wants to use refcnt
for some reason shouldn't have this pop up as an error

