### PR TITLE
repremult: Fix subtle edge case in color conversion with unpremult=1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,7 +340,7 @@ if (USE_PYTHON AND NOT BUILD_OIIOUTIL_ONLY AND NOT SANITIZE_ON_LINUX)
 endif ()
 
 # Add tests that require OCIO
-if (OCIO_FOUND)
+if (OPENCOLORIO_FOUND)
     oiio_add_tests (oiiotool-color)
 endif ()
 

--- a/src/doc/imagebufalgo.rst
+++ b/src/doc/imagebufalgo.rst
@@ -1622,13 +1622,20 @@ Color space conversion
 
   Examples::
 
-    // Convert in-place from associated alpha to unassociated alpha
-    ImageBuf A ("a.exr");
+    // Convert from unassociated alpha to associated alpha by
+    // straightforward multiplication of color by alpha.
+    ImageBuf Unassoc;  // Assume somehow this has unassociated alpha
+    ImageBuf Assoc = ImageBufAlgo::premult (Unassoc);
+
+    // Convert in-place from associated alpha to unassociated alpha,
+    // preserving the color of alpha==0 pixels.
+    ImageBuf A;
     ImageBufAlgo::unpremult (A, A);
 
-    // Convert in-place from unassociated alpha to associated alpha
-    ImageBufAlgo::premult (A, A);
-
+    // Finish the round-trip back to associated, still preserving the
+    // color of alpha==0 pixels. This should result in exactly the same
+    // pixel values we started with (within precision limits).
+    ImageBufAlgo::repremult (A, A);
 
 
 .. _sec-iba-importexport:

--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -3082,9 +3082,16 @@ Color manipulation
                bool ImageBufAlgo.unpremult (dst, src, roi=ROI.All, nthreads=0)
                ImageBuf ImageBufAlgo.premult (src, roi=ROI.All, nthreads=0)
                bool ImageBufAlgo.premult (dst, src, roi=ROI.All, nthreads=0)
+               ImageBuf ImageBufAlgo.repremult (src, roi=ROI.All, nthreads=0)
+               bool ImageBufAlgo.repremult (dst, src, roi=ROI.All, nthreads=0)
 
-    Copy pixels from `src` to `dst`, and un-premultiply (or
-    premultiply) the colors by alpha.
+    Copy pixels from `src` to `dst`, and un-premultiply, premultiply, or
+    re-premultiply the colors by alpha.
+
+    `unpremult` divides colors by alpha, but preserves original color if
+    alpha is 0. `premult` multiplies colors by alpha (even if alpha is 0).
+    `repreumlt` is the true inverse of `unpremult`, multiplying color by
+    alpha, but preserving color values in the alpha = 0 case.
 
     Examples::
 

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -1220,6 +1220,23 @@ IBA_unpremult_ret(const ImageBuf& src, ROI roi = ROI::All(), int nthreads = 0)
 }
 
 
+bool
+IBA_repremult(ImageBuf& dst, const ImageBuf& src, ROI roi = ROI::All(),
+              int nthreads = 0)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::repremult(dst, src, roi, nthreads);
+}
+
+
+ImageBuf
+IBA_repremult_ret(const ImageBuf& src, ROI roi = ROI::All(), int nthreads = 0)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::repremult(src, roi, nthreads);
+}
+
+
 
 bool
 IBA_contrast_remap(ImageBuf& dst, const ImageBuf& src, py::object black_,
@@ -2475,6 +2492,11 @@ declare_imagebufalgo(py::module& m)
         .def_static("unpremult", &IBA_unpremult, "dst"_a, "src"_a,
                     "roi"_a = ROI::All(), "nthreads"_a = 0)
         .def_static("unpremult", &IBA_unpremult_ret, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+
+        .def_static("repremult", &IBA_repremult, "dst"_a, "src"_a,
+                    "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("repremult", &IBA_repremult_ret, "src"_a,
                     "roi"_a = ROI::All(), "nthreads"_a = 0)
 
         .def_static("clamp", &IBA_clamp, "dst"_a, "src"_a, "min"_a, "max"_a,


### PR DESCRIPTION
Troy Sobotka pointed out to me that the implementation of colorconvert
where unpremult=1 (i.e., unpremult, then transform, then premult) was
wrong: the unpremult operation was careful to preserve the color value
of pixels where alpha==0, but the premult we did at the end was just a
straight multiply of the color by the alpha. This would have the
effect of crushing those "glow" (A==0, RGB > 0) pixels to black in
their round trip, whereas we want the original glow to be preserved.

So really, the kind of premult we want for a one-time conversion of
unpremultiplied to premultiplied is subtly different from the "re-premult"
that we want as part of a round-trip operation.

The fix in this patch is to add IBA::repremult() to do this modified
operation (multiply color by alpha, unless alpha is 0), and also that is
the correct operation to use in the unpremult-transform-repremult round
trip that we do as `colorconvert(unpremult=true)`.

Also noticed that the recent CMake overhaul inadvertently left
testsuite/oiiotool-color un-tested, so re-enable that (which also lets
us test this fix).

