### PR TITLE
Fixes to cmake config generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,7 @@ set (OIIO_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 write_basic_package_version_file (
         ${OIIO_VERSION_CONFIG}
         VERSION ${PROJECT_VERSION}
-        COMPATIBILITY SameMinorVersion)
+        COMPATIBILITY SameMajorVersion)
 
 # generate the Targets file in the binary dir using the targets collected in OIIO_EXPORTED_TARGETS
 # each target is added to OIIO_EXPORTED_TARGETS through the oiio macro install_target()

--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -1,4 +1,4 @@
-@PACKAGE_INIT@.
+@PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
 
@@ -6,5 +6,13 @@ include(CMakeFindDependencyMacro)
 # e.g. if switching to Boost::Boost instead of using ${Boost_LIBRARY_DIRS} the add:
 # find_dependency(Boost @Boost_VERSION@)
 
-include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
-check_required_components("@PROJECT_NAME@")
+set_and_check (@PROJECT_NAME@_INCLUDE_DIR "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
+set_and_check (@PROJECT_NAME@_INCLUDES    "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
+set_and_check (@PROJECT_NAME@_LIB_DIR     "@CMAKE_INSTALL_FULL_LIBDIR@")
+
+#...logic to determine installedPrefix from the own location...
+#set (@PROJECT_NAME@_CONFIG_DIR  "${installedPrefix}/@CONFIG_INSTALL_DIR@")
+
+include ("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+
+check_required_components ("@PROJECT_NAME@")

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -15,14 +15,14 @@ endif ()
 option (USE_GENERATED_EXPORT_HEADER "Use CMake-generated export header" OFF)
 if (USE_GENERATED_EXPORT_HEADER)
     include (GenerateExportHeader)
-    set (exportextras "\n#define OIIO_EXPORT OIIO_API\n")
-    generate_export_header (OpenImageIO
+    set (exportextras "\n#define ${PROJ_NAME}_EXPORT ${PROJ_NAME}_API\n")
+    generate_export_header (${PROJECT_NAME}
           # [BASE_NAME baseName]
           EXPORT_FILE_NAME export.h
-          EXPORT_MACRO_NAME OIIO_API
-          NO_EXPORT_MACRO_NAME OIIO_LOCAL
-          STATIC_DEFINE OIIO_STATIC_DEFINE
-          DEPRECATED_MACRO_NAME OPENIMAGEIO_DEPRECATED
+          EXPORT_MACRO_NAME ${PROJ_NAME}_API
+          NO_EXPORT_MACRO_NAME ${PROJ_NAME}_LOCAL
+          STATIC_DEFINE ${PROJ_NAME}_STATIC_DEFINE
+          DEPRECATED_MACRO_NAME ${PROJ_NAME}_DEPRECATED
           # [NO_DEPRECATED_MACRO_NAME noDeprecatedMacroName]
           # [DEFINE_NO_DEPRECATED]
           # [PREFIX_NAME prefix]
@@ -33,16 +33,20 @@ if (USE_GENERATED_EXPORT_HEADER)
 endif()
 
 
-set (versionfile oiioversion.h)
-if (VERBOSE)
-    message(STATUS "Create ${versionfile} from ${versionfile}.in")
-endif ()
 # Mangle the SOVERSION so that it's a valid C++ identifier for the
 # versioning namespace defined in ${versionfile}
 string (REGEX REPLACE "\\." "_" MANGLED_SOVERSION ${SOVERSION})
 set (OIIO_VERSION_NS "v${MANGLED_SOVERSION}")
-configure_file(${PROJECT_NAME}/${versionfile}.in "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${versionfile}" @ONLY)
-list(APPEND public_headers "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${versionfile}")
+
+
+# Generate version.h
+set (versionfile oiioversion.h)
+if (VERBOSE)
+    message(STATUS "Create ${versionfile} from ${versionfile}.in")
+endif ()
+configure_file (${PROJECT_NAME}/${versionfile}.in "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${versionfile}" @ONLY)
+list (APPEND public_headers "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${versionfile}")
+
 
 install (FILES ${public_headers}
          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -122,12 +122,17 @@ source_group ("libtexture" REGULAR_EXPRESSION ".+/libtexture/.+")
 
 target_include_directories (OpenImageIO
                             PUBLIC
+                                ${CMAKE_INSTALL_FULL_INCLUDEDIR}
                                 ${OpenCV_INCLUDES}
                             PRIVATE
                                 ${ROBINMAP_INCLUDES}
                                 ${OPENCOLORIO_INCLUDES}
                                 ${FREETYPE_INCLUDE_DIRS}
                             )
+
+if (NOT BUILD_SHARED_LIBS)
+    target_compile_definitions (OpenImageIO PUBLIC OIIO_STATIC_DEFINE=1)
+endif ()
 
 target_link_libraries (OpenImageIO
         PUBLIC

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -6,6 +6,9 @@ set (libOpenImageIO_Util_srcs argparse.cpp benchmark.cpp
                   typedesc.cpp ustring.cpp xxhash.cpp)
 
 add_library (OpenImageIO_Util ${libOpenImageIO_Util_srcs})
+target_include_directories (OpenImageIO_Util
+        PUBLIC ${CMAKE_INSTALL_FULL_INCLUDEDIR}
+        )
 target_link_libraries (OpenImageIO_Util
         PUBLIC
             ${ILMBASE_LIBRARIES}
@@ -20,6 +23,9 @@ if (WIN32)
 endif()
 
 target_compile_definitions (OpenImageIO_Util PRIVATE OpenImageIO_EXPORTS)
+if (NOT BUILD_SHARED_LIBS)
+    target_compile_definitions (OpenImageIO_Util PUBLIC OIIO_STATIC_DEFINE=1)
+endif ()
 
 if (VERBOSE)
     message(STATUS "Setting SOVERSION to: ${SOVERSION}")


### PR DESCRIPTION
* Relax version compatibility specification to just matching major version.
* Specify targets cmake name correctly.
* Make sure install include dir is listed in the public include dirs of the
  libraries.
* Some other cleanup and genericization.

I believe this corrects some deficiencies in the generated OpenImageIOConfig.cmake that projects can use that exclusively (with imported targets) and have no need for a copy of FindOpenImageIO.cmake.

Unless objections are raised, I will also backport this to 2.1 for the patch release that's coming in a few days.
