### PR TITLE
Use external libsquish if found

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,6 +65,9 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you want support for HEIF/HEIC images:
      * libheif >= 1.3 (tested through 1.6; older versions may also work, we
        haven't tested)
+* If you want support for DDS files:
+     * libsquish >= 1.13
+     * But... if not found on the system, an embedded version will be used.
 
 
 Dependency control and disabling components

--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -43,6 +43,7 @@ vcpkg install freetype:x64-windows
 
 vcpkg install libraw:x64-windows
 vcpkg install openjpeg:x64-windows
+vcpkg install libsquish:x64-windows
 # vcpkg install ffmpeg:x64-windows   # takes FOREVER!
 # vcpkg install webp:x64-windows  # No such vcpkg package?a
 

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -40,7 +40,8 @@ else
     brew install --display-times libtiff ilmbase openexr opencolorio
     brew install --display-times libpng giflib webp jpeg-turbo openjpeg
     brew install --display-times freetype libraw dcmtk pybind11 numpy
-    brew install --display-times field3d ffmpeg libheif openvdb tbb
+    brew install --display-times field3d ffmpeg libheif libsquish
+    brew install --display-times openvdb tbb
     brew install --display-times opencv qt ptex
 fi
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -301,3 +301,13 @@ macro (find_or_download_robin_map)
     endif ()
     checked_find_package (Robinmap REQUIRED)
 endmacro()
+
+
+###########################################################################
+# libsquish
+
+option (USE_EMBEDDED_LIBSQUISH
+        "Force use of embedded Libsquish, even if external is found" OFF)
+if (NOT USE_EMBEDDED_LIBSQUISH)
+    checked_find_package (Libsquish)
+endif ()

--- a/src/cmake/modules/FindLibsquish.cmake
+++ b/src/cmake/modules/FindLibsquish.cmake
@@ -1,0 +1,50 @@
+# Module to find Libsquish
+#
+# This module will first look into the directories defined by the variables:
+#   - Libsquish_ROOT, LIBSQUISH_INCLUDE_PATH, LIBSQUISH_LIBRARY_PATH
+#
+# This module defines the following variables:
+#
+# LIBSQUISH_FOUND            True if Libsquish was found.
+# LIBSQUISH_INCLUDES         Where to find Libsquish headers
+# LIBSQUISH_LIBRARIES        List of libraries to link against when using Libsquish
+# LIBSQUISH_VERSION          Version of Libsquish (e.g., 3.6.2)
+
+include (FindPackageHandleStandardArgs)
+
+find_path (LIBSQUISH_INCLUDE_DIR squish.h
+           HINTS
+               ${LIBSQUISH_INCLUDE_PATH}
+               ENV LIBSQUISH_INCLUDE_PATH
+           DOC "The directory where Libsquish headers reside")
+
+find_library (LIBSQUISH_LIBRARY squish
+              HINTS
+                  ${LIBSQUISH_LIBRARY_PATH}
+                  ENV LIBSQUISH_LIBRARY_PATH
+              DOC "The Libsquish libraries")
+
+find_package_handle_standard_args (LIBSQUISH
+    REQUIRED_VARS
+        LIBSQUISH_INCLUDE_DIR
+        LIBSQUISH_LIBRARY
+    )
+
+if (LIBSQUISH_FOUND)
+    set (LIBSQUISH_INCLUDES ${LIBSQUISH_INCLUDE_DIR})
+    set (LIBSQUISH_LIBRARIES ${LIBSQUISH_LIBRARY})
+
+    if (NOT TARGET Libsquish::Libsquish)
+        add_library(Libsquish::Libsquish UNKNOWN IMPORTED)
+        set_target_properties(Libsquish::Libsquish PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${LIBSQUISH_INCLUDES}")
+
+        set_property(TARGET Libsquish::Libsquish APPEND PROPERTY
+            IMPORTED_LOCATION "${LIBSQUISH_LIBRARIES}")
+    endif ()
+endif ()
+
+mark_as_advanced (
+    LIBSQUISH_INCLUDE_DIR
+    LIBSQUISH_LIBRARY
+    )

--- a/src/dds.imageio/CMakeLists.txt
+++ b/src/dds.imageio/CMakeLists.txt
@@ -2,7 +2,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
-add_oiio_plugin (ddsinput.cpp squish/alpha.cpp squish/clusterfit.cpp
+if (LIBSQUISH_FOUND)
+    # External libsquish was found -- use it
+    add_oiio_plugin (ddsinput.cpp
+                     LINK_LIBRARIES Libsquish::Libsquish
+                     )
+else ()
+    # No external libsquish was found -- use the embedded version.
+    add_oiio_plugin (ddsinput.cpp squish/alpha.cpp squish/clusterfit.cpp
                  squish/colourblock.cpp squish/colourfit.cpp squish/colourset.cpp
                  squish/maths.cpp squish/rangefit.cpp squish/singlecolourfit.cpp
-                 squish/squish.cpp)
+                 squish/squish.cpp
+        INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/squish")
+endif ()

--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -13,7 +13,7 @@
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/typedesc.h>
 
-#include "squish/squish.h"
+#include "squish.h"
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 


### PR DESCRIPTION
This patch checks for libsquish already on the system, and if found,
uses it. If not found on the system, it falls back on the embedded
version in src/dds.imageio/squish. CMake option USE_EMBEDDED_LIBSQUISH
can be used to force use of the embedded version even if found on the
system.

Background: Our DDS support (by Leszek Godlewski in 2010, as a GSoC
student) relies on an embedded copy of libsquish (MIT license) for DXT
compression.  Embedding was a reasonable choice at the time, but in
2020 it's easily installed an Ubuntu, Homebrew, Vcpkg.  Furthermore,
it's also a Debian package and runs up against their rule that we
should never embed code that is available from other Debian packages
that can be used as dependencies.

This is all I want to do in this patch -- comply with Debian rules,
and also reduce OIIO build time by relying on a prebuilt libsquish if
found on the system. This won't break anybody's builds at this time if
they don't have libsquish already installed, and should be safe to
backport to 2.1 for Debian compliance.

But in the future, we might make it a purely external dependency --
expect it on the system, and if not found, simply disable DDS support
(like we do with many other optional dependency such as libwebp or
libheif).
