### PR TITLE
Bump the minimum pybind11 that we need

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,10 +41,8 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you are building the Python bindings or running the testsuite:
      * Python >= 2.7 (tested against 2.7, 3.6, 3.7)
      * NumPy
-     * pybind11 >= 2.2.0 (Tested through 2.4.2. It is known that 2.4.0
-       and 2.4.1 have bugs and don't build properly for C++11. For this
-       case, or if no pybind11 is found already on the system, OIIO will
-       auto-download it.)
+     * pybind11 >= 2.4.2 (Tested through 2.4.3. If no adequate pybind11 is
+       found already on the system, OIIO will auto-download it.
  * If you want support for camera "RAW" formats:
      * libRaw >= 0.15 (tested 0.15 - 0.19; libRaw >= 0.18 is necessary for
        ACES support and much better recognition of camera metadata)

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -281,7 +281,7 @@ macro (find_or_download_robin_map)
     # packages be built, or we we are forcing a local copy to be built, then
     # download and build it.
     # Download the headers from github
-    if ((BUILD_MISSING_ROBINMAP AND NOT ROBINMAP_INCLUDES) OR BUILD_ROBINMAP_FORCE)
+    if ((BUILD_MISSING_ROBINMAP AND NOT ROBINMAP_FOUND) OR BUILD_ROBINMAP_FORCE)
         message (STATUS "Downloading local Tessil/robin-map")
         set (ROBINMAP_INSTALL_DIR "${PROJECT_SOURCE_DIR}/ext/robin-map")
         set (ROBINMAP_GIT_REPOSITORY "https://github.com/Tessil/robin-map")

--- a/src/cmake/modules/FindPybind11.cmake
+++ b/src/cmake/modules/FindPybind11.cmake
@@ -11,7 +11,6 @@ find_path (PYBIND11_INCLUDE_DIR pybind11/pybind11.h
            )
 
 if (PYBIND11_INCLUDE_DIR)
-    set (PYBIND11_INCLUDES ${PYBIND11_INCLUDE_DIR})
     set (PYBIND11_COMMON_FILE "${PYBIND11_INCLUDE_DIR}/pybind11/detail/common.h")
     IF (NOT EXISTS ${PYBIND11_COMMON_FILE})
         set (PYBIND11_COMMON_FILE "${PYBIND11_INCLUDE_DIR}/pybind11/common.h")
@@ -31,4 +30,9 @@ include (FindPackageHandleStandardArgs)
 find_package_handle_standard_args (Pybind11
                                    VERSION_VAR   PYBIND11_VERSION
                                    REQUIRED_VARS PYBIND11_INCLUDE_DIR)
+
+if (PYBIND11_FOUND)
+    set (PYBIND11_INCLUDES ${PYBIND11_INCLUDE_DIR})
+endif ()
+
 mark_as_advanced (PYBIND11_INCLUDE_DIR)

--- a/src/cmake/pythonutils.cmake
+++ b/src/cmake/pythonutils.cmake
@@ -67,19 +67,10 @@ macro (find_or_download_pybind11)
     if (NOT BUILD_PYBIND11_FORCE)
         find_package (Pybind11 ${BUILD_PYBIND11_MINIMUM_VERSION} QUIET)
     endif ()
-    # Check for certain buggy versions
-    if (PYBIND11_FOUND AND (${CMAKE_CXX_STANDARD} VERSION_LESS_EQUAL 11) AND
-        ("${PYBIND11_VERSION}" VERSION_EQUAL "2.4.0" OR
-         "${PYBIND11_VERSION}" VERSION_EQUAL "2.4.1"))
-        message (WARNING "pybind11 ${PYBIND11_VERSION} is buggy and not compatible with C++11, downloading our own.")
-        unset (PYBIND11_INCLUDES)
-        unset (PYBIND11_INCLUDE_DIR)
-        unset (PYBIND11_FOUND)
-    endif ()
-    # If an external copy wasn't found and we requested that missing
-    # packages be built, or we we are forcing a local copy to be built, then
-    # download and build it.
-    if ((BUILD_MISSING_PYBIND11 AND NOT PYBIND11_INCLUDES) OR BUILD_PYBIND11_FORCE)
+    # If an external copy wasn't found (and of an adequate version) and we
+    # requested that missing packages be built, or we we are forcing a local
+    # copy to be built unconditionally, then download and build it.
+    if ((BUILD_MISSING_PYBIND11 AND NOT PYBIND11_FOUND) OR BUILD_PYBIND11_FORCE)
         message (STATUS "Building local Pybind11")
         set (PYBIND11_INSTALL_DIR "${PROJECT_SOURCE_DIR}/ext/pybind11")
         set (PYBIND11_GIT_REPOSITORY "https://github.com/pybind/pybind11")
@@ -101,7 +92,14 @@ macro (find_or_download_pybind11)
     endif ()
     checked_find_package (Pybind11 ${BUILD_PYBIND11_MINIMUM_VERSION})
 
-    if (NOT PYBIND11_INCLUDES)
+    if (NOT PYBIND11_FOUND)
+        if (PYBIND11_INCLUDE_DIR)
+            message (STATUS "Pybind11 was found in ${PYBIND11_INCLUDE_DIR}")
+            message (STATUS "... but was version ${PYBIND11_VERSION} (minimum is ${BUILD_PYBIND11_MINIMUM_VERSION})")
+            if (PYBIND11_INCLUDE_DIR MATCHES "/ext/pybind11")
+                message (STATUS "Try removing ext/pybind11 and let me download a newer version.")
+            endif ()
+        endif ()
         message (FATAL_ERROR "pybind11 is missing! If it's not on your "
                  "system, you need to install it, or build with either "
                  "-DBUILD_MISSING_DEPS=ON or -DBUILD_PYBIND11_FORCE=ON. "

--- a/src/cmake/pythonutils.cmake
+++ b/src/cmake/pythonutils.cmake
@@ -58,7 +58,7 @@ endmacro()
 option (BUILD_PYBIND11_FORCE "Force local download/build of Pybind11 even if installed" OFF)
 option (BUILD_MISSING_PYBIND11 "Local download/build of Pybind11 if not installed" ON)
 set (BUILD_PYBIND11_VERSION "v2.4.3" CACHE STRING "Preferred pybind11 version, of downloading/building our own")
-set (BUILD_PYBIND11_MINIMUM_VERSION "2.2.0")
+set (BUILD_PYBIND11_MINIMUM_VERSION "2.4.2")
 
 macro (find_or_download_pybind11)
     # If we weren't told to force our own download/build of pybind11, look


### PR DESCRIPTION
Recent changes (2347) seem to rely on some pybind declarations that
are newer than the minimum version we checked for. Bump the pybind11
required version.
