### PR TITLE
Fix misdesign in unordered_map_concurrent that broke it for unordered_map

### DIFF
--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <type_traits>
 #include <utility>  // std::forward
 
 // Make sure all platforms have the explicit sized integer types
@@ -457,6 +458,21 @@ inline void aligned_delete(T* t) {
         aligned_free(t);
     }
 }
+
+
+
+#if OIIO_CPLUSPLUS_VERSION >= 14
+    using std::enable_if_t;    // Use C++14 std::enable_if_t
+#else
+    // Define enable_if_t for C++11
+    template <bool B, class T = void>
+    using enable_if_t = typename std::enable_if<B, T>::type;
+#endif
+
+// An enable_if helper to be used in template parameters which results in
+// much shorter symbols: https://godbolt.org/z/sWw4vP
+// Borrowed from fmtlib.
+#define OIIO_ENABLE_IF(...) OIIO::enable_if_t<(__VA_ARGS__), int> = 0
 
 
 OIIO_NAMESPACE_END


### PR DESCRIPTION
Background: unordered_concurrent_map<> is a thread-safe map that is
parameterized by the type of the underlying "shard" maps. The default
underlying map type is std::unordered map. Though for a while, as used
by ImageCache, we have been using robin_map as the underlying map
type, having found it has superior performance.

PR #2314 improved performance even more by taking advantage of the fact
that robin_map has a find(key,hash) that lets you supply the
precomputed hash value (in situations where you already had it), thus
avoiding redundant hash computations.

BUT... we failed to notice that unordered_map doesn't have this kind
of find() variety, and so even though the u_c_m is templated on the
map type, this meant that it would no longer work with
std::unordered_map. That's especially painful since the underlying
type defaults to this.

The solution, in this patch, is to make a helper function
`find_with_hash(map, key, hash)` that uses the hash if the map type
has a find(key,hash) method, and otherwise falls back to the standard
find(key).

There is some template metaprogramming involved, and we add a couple
of handy idioms to platform.h (it sort of belongs there because the way
to express the idioms there depends on whether it's C++ 11 or 14+, and
platform.h is where we sort that kind of thing out).
