### PR TITLE
libatomic linkage fixes

### DIFF
--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -139,6 +139,7 @@ target_link_libraries (OpenImageIO
             ${ILMBASE_LIBRARIES}
             ${OPENEXR_LIBRARIES}
             ${OpenCV_LIBRARIES}
+            ${GCC_ATOMIC_LIBRARIES}
         PRIVATE
             ${SANITIZE_LIBRARIES}
             ${format_plugin_libs} # Add all the target link libraries from the plugins
@@ -147,7 +148,6 @@ target_link_libraries (OpenImageIO
             ${ZLIB_LIBRARIES}
             ${Boost_LIBRARIES}
             ${CMAKE_DL_LIBS}
-            ${GCC_ATOMIC_LIBRARIES}
         )
 
 if (USE_EXTERNAL_PUGIXML)

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -12,11 +12,11 @@ target_include_directories (OpenImageIO_Util
 target_link_libraries (OpenImageIO_Util
         PUBLIC
             ${ILMBASE_LIBRARIES}
+            ${GCC_ATOMIC_LIBRARIES}
         PRIVATE
             ${SANITIZE_LIBRARIES}
             ${Boost_LIBRARIES}
             ${CMAKE_DL_LIBS}
-            ${GCC_ATOMIC_LIBRARIES}
         )
 
 if (WIN32)


### PR DESCRIPTION
For apps using atomic.h, on architectures where certain atomic operations
need libatomic, they'll need to know about it. The `${GCC_ATOMIC_LIBRARIES}`
should have been a "PUBLIC" designaton for target_link_libraries, not a
private one (since atomic.h, which calls them, are public).

