### PR TITLE
Improve docs for ImageBuf, and some error detection and missing methods

### DIFF
--- a/src/doc/imagebuf.rst
+++ b/src/doc/imagebuf.rst
@@ -11,38 +11,32 @@ ImageBuf is a utility class that stores an entire image.  It provides a
 nice API for reading, writing, and manipulating images as a single unit,
 without needing to worry about any of the details of storage or I/O.
 
-An ImageBuf can store its pixels in one of several ways:
-
-* Allocate "local storage" to hold the image pixels internal to the
-  ImageBuf.  This storage will be freed when the ImageBuf is destroyed.
-* "Wrap" pixel memory already allocated by the calling application, which
-  will continue to own that memory and be responsible for freeing it after
-  the ImageBuf is destroyed.
-* Be "backed" by an ImageCache, which will automatically be used to
-  retreive pixels when requested, but the ImageBuf will not allocate
-  separate storage for it.  This brings all the advantages of the
-  ImageCache, but can only be used for read-only ImageBuf's that reference a
-  stored image file.
-
-All I/O involving ImageBuf (that is, calls to `read` or `write`)
-are implemented in terms of ImageCache, ImageInput,
-and ImageOutput underneath, and so support all of the image file
-formats supported by OIIO.
+All I/O involving ImageBuf (that is, calls to `read` or `write`) are
+implemented underneath in terms of ImageCache, ImageInput, and ImageOutput,
+and so support all of the image file formats supported by OIIO.
 
 The ImageBuf class definition requires that you::
 
     #include <OpenImageIO/imagebuf.h>
 
 
+.. doxygenenum:: OIIO::ImageBuf::IBStorage
+
 
 Constructing, destructing, resetting an ImageBuf
 ================================================
+
+There are several ways to construct an ImageBuf. Each constructor has a
+corresponding `reset` method that takes the same arguments. Calling `reset`
+on an existing ImageBuf is equivalent to constructing a new ImageBuf from
+scratch (even if the ImageBuf, prior to reset, previously held an image).
+
 
 Making an empty or uninitialized ImageBuf
 -----------------------------------------
 
 .. doxygenfunction:: OIIO::ImageBuf::ImageBuf()
-.. doxygenfunction:: OIIO::ImageBuf::clear()
+.. doxygenfunction:: OIIO::ImageBuf::reset()
 
 
 Constructing a readable ImageBuf
@@ -64,6 +58,7 @@ Constructing an ImageBuf that "wraps" an application buffer
 -------------------------------------------------------------
 
 .. doxygenfunction:: OIIO::ImageBuf::ImageBuf(const ImageSpec&, void *)
+.. doxygenfunction:: OIIO::ImageBuf::reset(const ImageSpec&, void *)
 
 
 
@@ -531,5 +526,5 @@ chapter).  You could rewrite the example even more simply::
     }
 
 This other type-dispatching helper macros will be discussed in more
-detail in Chapter `Image Processing`_.
+detail in Chapter :ref:`chap-imagebufalgo`.
 


### PR DESCRIPTION
* Tried to expand and clarify explanations of the constructors and
  reset methods in particular, after an issue was filed with some
  confusion.

* Added checks to ensure that for the ctrs and reset methods that take
  an ImageSpec and allocate (or wrap) a buffer, if the spec doesn't
  have enough information to do the allocation or know the size of the
  wrapped memory (spec lacking nonzero width, height, depth,
  nchannels, and a concrete data format), the buffer stays marked as
  UNINITIALIZED.

* Added `ImageBuf::reset()` as a synonym for `clear()` and a reset
  variety corresponding to the "wrapped app buffer" constructor.
  This makes it so that every ctr has a corresponding reset method, and
  vice versa. As I was clarifying the docs, I realized that this would
  be better if fully symmetric. Because these are not virtual functions,
  these changes should not break ABI compatibility and should be safe to
  backport.

* In a few spots nearby I renamed NULL to nullptr, couldn't help myself.

