### PR TITLE
CI enhancements and cleanup

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -154,6 +154,25 @@ jobs:
             source src/build-scripts/gh-installdeps.bash
             source src/build-scripts/ci-build-and-test.bash
 
+  linux-clang:
+    name: "Linux clang: clang9, C++14, avx2, exr2.4"
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: all
+        env:
+          CXX: clang++
+          LLVM_VERSION: 9.0.0
+          CMAKE_CXX_STANDARD: 14
+          USE_SIMD: avx2,f16c
+          OPENEXR_BRANCH: v2.4.0
+          OCIO_BRANCH: 1c624651b7
+          # Pick an OCIO commit that includes a warning fix we need for clang
+        run: |
+            source src/build-scripts/ci-startup.bash
+            source src/build-scripts/gh-installdeps.bash
+            source src/build-scripts/ci-build-and-test.bash
+
   linux-static:
     name: "Linux static libs: gcc7, C++14, exr2.3"
     runs-on: ubuntu-18.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ matrix:
         os: osx
         compiler: clang
         env: PYTHON_VERSION=2.7
-        if: branch =~ /(master|RB|travis|python)/ OR type = pull_request
+        # if: branch =~ /(master|RB|travis|python)/ OR type = pull_request
 
     # One more, just for the heck of it, turn all SIMD off, and also make
     # sure we're falling back on libjpeg, not jpeg-turbo, no OCIO support,
@@ -123,7 +123,7 @@ matrix:
         dist: trusty
         compiler: gcc
         env: WHICHGCC=4.8 USE_SIMD=0 USE_JPEGTURBO=0 USE_OPENCOLORIO=0 EMBEDPLUGINS=0 OPENEXR_BRANCH=v2.2.0 BUILD_CMAKE=1
-        if: branch =~ /(master|RB|travis|simd)/ OR type = pull_request
+        # if: branch =~ /(master|RB|travis|simd)/ OR type = pull_request
         addons:
           apt:
             sources: *add-sources

--- a/src/build-scripts/build_llvm.bash
+++ b/src/build-scripts/build_llvm.bash
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+echo "Building LLVM"
+uname
+
+
+if [[ `uname` == "Linux" ]] ; then
+    LLVM_VERSION=${LLVM_VERSION:=8.0.0}
+    LLVM_INSTALL_DIR=${LLVM_INSTALL_DIR:=${PWD}/llvm-install}
+    if [[ "$GITHUB_WORKFLOW" != "" ]] ; then
+        LLVM_DISTRO_NAME=${LLVM_DISTRO_NAME:=ubuntu-18.04}
+    elif [[ "$TRAVIS_DIST" == "trusty" ]] ; then
+        LLVM_DISTRO_NAME=${LLVM_DISTRO_NAME:=ubuntu-14.04}
+    elif [[ "$TRAVIS_DIST" == "xenial" ]] ; then
+        LLVM_DISTRO_NAME=${LLVM_DISTRO_NAME:=ubuntu-16.04}
+    elif [[ "$TRAVIS_DIST" == "bionic" ]] ; then
+        LLVM_DISTRO_NAME=${LLVM_DISTRO_NAME:=ubuntu-18.04}
+    else
+        LLVM_DISTRO_NAME=${LLVM_DISTRO_NAME:=error}
+    fi
+    if [ "$LLVM_VERSION" == "5.0.0" ] ; then
+        LLVMTAR=clang+llvm-${LLVM_VERSION}-linux-x86_64-${LLVM_DISTRO_NAME}.tar.xz
+    else
+        LLVMTAR=clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-${LLVM_DISTRO_NAME}.tar.xz
+    fi
+    echo LLVMTAR = $LLVMTAR
+    curl --location http://releases.llvm.org/${LLVM_VERSION}/${LLVMTAR} -o $LLVMTAR
+    ls -l $LLVMTAR
+    tar xf $LLVMTAR
+    rm -f $LLVMTAR
+    echo "Installed ${LLVM_VERSION} in ${LLVM_INSTALL_DIR}"
+    mkdir -p $LLVM_INSTALL_DIR && true
+    mv clang+llvm*/* $LLVM_INSTALL_DIR
+    export LLVM_DIRECTORY=$LLVM_INSTALL_DIR
+    export PATH=${LLVM_INSTALL_DIR}/bin:$PATH
+    ls -a $LLVM_DIRECTORY
+fi

--- a/src/build-scripts/build_ocio.bash
+++ b/src/build-scripts/build_ocio.bash
@@ -1,42 +1,44 @@
 #!/bin/bash
 
-OCIOREPO=${OCIOREPO:=https://github.com/imageworks/OpenColorIO.git}
-OCIOBUILDDIR=${OCIOBUILDDIR:=${PWD}/ext/OpenColorIO}
-OCIOINSTALLDIR=${OCIOINSTALLDIR:=${PWD}/ext/OpenColorIO/dist}
-OCIOBRANCH=${OCIOBRANCH:=v1.1.1}
-OCIOCXXFLAGS=${OCIOCXXFLAGS:="-Wno-unused-function -Wno-deprecated-declarations -Wno-cast-qual -Wno-write-strings"}
+OCIO_REPO=${OCIO_REPO:=https://github.com/imageworks/OpenColorIO.git}
+OCIO_BUILD_DIR=${OCIO_BUILD_DIR:=${PWD}/ext/OpenColorIO}
+OCIO_INSTALL_DIR=${OCIO_INSTALL_DIR:=${PWD}/ext/OpenColorIO/dist}
+OCIO_VERSION=${OCIO_VERSION:=1.1.1}
+OCIO_BRANCH=${OCIO_BRANCH:=v${OCIO_VERSION}}
+OCIO_CXX_FLAGS=${OCIO_CXX_FLAGS:="-Wno-unused-function -Wno-deprecated-declarations -Wno-cast-qual -Wno-write-strings"}
 # Just need libs:
 OCIO_BUILDOPTS="-DOCIO_BUILD_APPS=OFF -DOCIO_BUILD_NUKE=OFF \
                -DOCIO_BUILD_DOCS=OFF -DOCIO_BUILD_TESTS=OFF \
                -DOCIO_BUILD_PYTHON=OFF -DOCIO_BUILD_PYGLUE=OFF \
-               -DOCIO_BUILD_JAVA=OFF"
+               -DOCIO_BUILD_JAVA=OFF \
+               -DOCIO_BUILD_STATIC=${OCIO_BUILD_STATIC:=OFF}"
 BASEDIR=`pwd`
 pwd
-echo "OpenColorIO install dir will be: ${OCIOINSTALLDIR}"
+echo "OpenColorIO install dir will be: ${OCIO_INSTALL_DIR}"
 
 mkdir -p ./ext
 pushd ./ext
 
 # Clone OpenColorIO project from GitHub and build
 if [[ ! -e OpenColorIO ]] ; then
-    echo "git clone ${OCIOREPO} OpenColorIO"
-    git clone ${OCIOREPO} OpenColorIO
+    echo "git clone ${OCIO_REPO} OpenColorIO"
+    git clone ${OCIO_REPO} OpenColorIO
 fi
 cd OpenColorIO
 
-echo "git checkout ${OCIOBRANCH} --force"
-git checkout ${OCIOBRANCH} --force
+echo "git checkout ${OCIO_BRANCH} --force"
+git checkout ${OCIO_BRANCH} --force
 mkdir -p build
-time (cd build ; cmake --config Release -DCMAKE_INSTALL_PREFIX=${OCIOINSTALLDIR} -DCMAKE_CXX_FLAGS="${OCIOCXXFLAGS}" ${OCIO_BUILDOPTS} .. && make clean && make -j 4 && make install)
+time (cd build ; cmake --config Release -DCMAKE_INSTALL_PREFIX=${OCIO_INSTALL_DIR} -DCMAKE_CXX_FLAGS="${OCIO_CXX_FLAGS}" ${OCIO_BUILDOPTS} .. && make clean && make -j 4 && make install)
 popd
 
-ls -R ${OCIOINSTALLDIR}
+ls -R ${OCIO_INSTALL_DIR}
 
 #echo "listing .."
 #ls ..
 
 # Set up paths. These will only affect the caller if this script is
 # run with 'source' rather than in a separate shell.
-export OpenColorIO_ROOT=$OCIOINSTALLDIR
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${OCIOINSTALLDIR}/lib
+export OpenColorIO_ROOT=$OCIO_INSTALL_DIR
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${OCIO_INSTALL_DIR}/lib
 

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -33,6 +33,8 @@ time sudo apt-get -q install -y \
     libopencv-dev \
     ptex-base \
     dcmtk \
+    libsquish-dev \
+    qt5-default \
     libhdf5-dev
 
 # Disable libheif on CI for now... seems to make crashes in CI tests.
@@ -42,6 +44,8 @@ time sudo apt-get -q install -y \
 #    sudo add-apt-repository ppa:strukturag/libheif
 #    time sudo apt-get -q install -y libheif-dev
 #fi
+
+export CMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu:$CMAKE_PREFIX_PATH
 
 if [[ "$CXX" == "g++-4.8" ]] ; then
     time sudo apt-get install -y g++-4.8
@@ -62,7 +66,10 @@ fi
 
 #dpkg --list
 
-export CMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu:$CMAKE_PREFIX_PATH
+if [[ "$CXX" == "clang++" ]] ; then
+    source src/build-scripts/build_llvm.bash
+fi
+
 
 src/build-scripts/install_test_images.bash
 


### PR DESCRIPTION
* Add GH CI test for Linux + clang

* Needed to port build_llvm.bash from OSL to get the right clang.

* Some cleanup of build_ocio.bash, including renaming varibles more
  clearly and instructing the OCIO build to only make static libs if
  requested.

* Also touched up the travis -- we have recently pared the travis tests
  to just a few, so there's no perf-related reason to restrict some tests
  to just PRs, may as well do them on every push.

* GH CI: install libsquish & qt5 to get a more thorough build a tests.

