### PR TITLE
Address strict warnings about unused parameters to functions

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -81,8 +81,12 @@ endif ()
 # Turn on more detailed warnings and optionally consider warnings as errors
 #
 option (STOP_ON_WARNING "Stop building if there are any compiler warnings" ON)
+option (EXTRA_WARNINGS "Enable lots of extra pedantic warnings" OFF)
 if (NOT MSVC)
     add_compile_options ("-Wall")
+    if (EXTRA_WARNINGS)
+        add_compile_options ("-Wextra")
+    endif ()
     if (STOP_ON_WARNING OR DEFINED ENV{CI})
         add_compile_options ("-Werror")
         # N.B. Force CI builds (Travis defines $CI) to use -Werror, even if

--- a/src/doc/Doxyfile
+++ b/src/doc/Doxyfile
@@ -2169,7 +2169,9 @@ PREDEFINED             = DOXYGEN_SHOULD_SKIP_THIS \
                          OIIO_API:= \
                          OIIO_NAMESPACE_BEGIN="namespace OIIO {" \
                          OIIO_NAMESPACE_END="}" \
-                         OIIO_CONSTEXPR14=constexpr
+                         OIIO_CONSTEXPR14=constexpr \
+                         OIIO_CONSTEXPR20=constexpr \
+                         OIIO_MAYBE_UNUSED=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/src/field3d.imageio/field3dinput.cpp
+++ b/src/field3d.imageio/field3dinput.cpp
@@ -459,10 +459,11 @@ Field3DInput::close()
 
 
 bool
-Field3DInput::read_native_scanline(int subimage, int miplevel, int y, int z,
-                                   void* data)
+Field3DInput::read_native_scanline(int /*subimage*/, int /*miplevel*/,
+                                   int /*y*/, int /*z*/, void* /*data*/)
 {
     // scanlines not supported
+    error("Field3D does not support scanline I/O");
     return false;
 }
 

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -268,7 +268,9 @@ public:
     std::string configname() const;
 
     // DEPRECATED(1.9) -- no longer necessary, because it's a shared ptr
-    static void deleteColorProcessor(const ColorProcessorHandle& processor) {}
+    static void deleteColorProcessor(const ColorProcessorHandle& /*processor*/)
+    {
+    }
 
     /// Return if OpenImageIO was built with OCIO support
     static bool supportsOpenColorIO();

--- a/src/include/OpenImageIO/errorhandler.h
+++ b/src/include/OpenImageIO/errorhandler.h
@@ -133,7 +133,8 @@ public:
     /// This will not produce any output if not in DEBUG mode, or
     /// if verbosity is QUIET.
     template<typename... Args>
-    void debug(const char* format, const Args&... args)
+    void debug(const char* format OIIO_MAYBE_UNUSED,
+               const Args&... args OIIO_MAYBE_UNUSED)
     {
 #ifndef NDEBUG
         debug(Strutil::format(format, args...));
@@ -179,7 +180,8 @@ public:
     }
 
     template<typename... Args>
-    void debugf(const char* format, const Args&... args)
+    void debugf(const char* format OIIO_MAYBE_UNUSED,
+                const Args&... args OIIO_MAYBE_UNUSED)
     {
 #ifndef NDEBUG
         debug(Strutil::sprintf(format, args...));

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -781,7 +781,7 @@ void convert_type (const S *src, D *dst, size_t n, D _min, D _max)
 template<>
 inline void convert_type<uint8_t,float> (const uint8_t *src,
                                          float *dst, size_t n,
-                                         float _min, float _max)
+                                         float /*_min*/, float /*_max*/)
 {
     float scale (1.0f/std::numeric_limits<uint8_t>::max());
     simd::vfloat4 scale_simd (scale);
@@ -799,7 +799,7 @@ inline void convert_type<uint8_t,float> (const uint8_t *src,
 template<>
 inline void convert_type<uint16_t,float> (const uint16_t *src,
                                           float *dst, size_t n,
-                                          float _min, float _max)
+                                          float /*_min*/, float /*_max*/)
 {
     float scale (1.0f/std::numeric_limits<uint16_t>::max());
     simd::vfloat4 scale_simd (scale);
@@ -817,7 +817,7 @@ inline void convert_type<uint16_t,float> (const uint16_t *src,
 template<>
 inline void convert_type<half,float> (const half *src,
                                       float *dst, size_t n,
-                                      float _min, float _max)
+                                      float /*_min*/, float /*_max*/)
 {
 #if OIIO_SIMD >= 8 && OIIO_F16C_ENABLED
     // If f16c ops are enabled, it's worth doing this by 8's
@@ -842,7 +842,7 @@ inline void convert_type<half,float> (const half *src,
 template<>
 inline void
 convert_type<float,uint16_t> (const float *src, uint16_t *dst, size_t n,
-                              uint16_t _min, uint16_t _max)
+                              uint16_t /*_min*/, uint16_t /*_max*/)
 {
     float min = std::numeric_limits<uint16_t>::min();
     float max = std::numeric_limits<uint16_t>::max();
@@ -863,7 +863,7 @@ convert_type<float,uint16_t> (const float *src, uint16_t *dst, size_t n,
 template<>
 inline void
 convert_type<float,uint8_t> (const float *src, uint8_t *dst, size_t n,
-                             uint8_t _min, uint8_t _max)
+                             uint8_t /*_min*/, uint8_t /*_max*/)
 {
     float min = std::numeric_limits<uint8_t>::min();
     float max = std::numeric_limits<uint8_t>::max();
@@ -885,7 +885,7 @@ convert_type<float,uint8_t> (const float *src, uint8_t *dst, size_t n,
 template<>
 inline void
 convert_type<float,half> (const float *src, half *dst, size_t n,
-                          half _min, half _max)
+                          half /*_min*/, half /*_max*/)
 {
 #if OIIO_SIMD >= 8 && OIIO_F16C_ENABLED
     // If f16c ops are enabled, it's worth doing this by 8's

--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -82,7 +82,7 @@ parallel_image (ROI roi, parallel_image_options opt,
         xchunk = ychunk = std::max (int64_t(1), int64_t(std::sqrt(opt.maxthreads))/2);
     }
 
-    auto task = [&](int id, int64_t xbegin, int64_t xend,
+    auto task = [&](int /*id*/, int64_t xbegin, int64_t xend,
                     int64_t ybegin, int64_t yend) {
         f (ROI (xbegin, xend, ybegin, yend, roi.zbegin, roi.zend,
                 roi.chbegin, roi.chend));

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -943,7 +943,9 @@ public:
     /// require any new API entry points, addition of support for new
     /// queries does not break ``link compatibility'' with
     /// previously-compiled plugins.
-    virtual int supports (string_view feature) const { return false; }
+    virtual int supports (string_view feature OIIO_MAYBE_UNUSED) const {
+        return false;
+    }
 
     /// Return true if the `filename` names a file of the type for this
     /// ImageInput.  The implementation will try to determine this as
@@ -998,7 +1000,9 @@ public:
     /// @returns
     ///         `true` if the file was found and opened successfully.
     virtual bool open (const std::string& name, ImageSpec &newspec,
-                       const ImageSpec& config) { return open(name,newspec); }
+                       const ImageSpec& config OIIO_MAYBE_UNUSED) {
+        return open(name,newspec);
+    }
 
     /// Return a reference to the image specification of the current
     /// subimage/MIPlevel.  Note that the contents of the spec are invalid
@@ -1802,7 +1806,9 @@ public:
     /// require any new API entry points, addition of support for new
     /// queries does not break ``link compatibility'' with
     /// previously-compiled plugins.
-    virtual int supports (string_view feature) const { return false; }
+    virtual int supports (string_view feature OIIO_MAYBE_UNUSED) const {
+        return false;
+    }
 
     /// Modes passed to the `open()` call.
     enum OpenMode { Create, AppendSubimage, AppendMIPLevel };

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1854,7 +1854,8 @@ public:
     ///                      Pointer to an array of `ImageSpec` objects
     ///                      describing each of the expected subimages.
     /// @returns            `true` upon success, or `false` upen failure.
-    virtual bool open (const std::string &name, int subimages,
+    virtual bool open (const std::string &name,
+                       int subimages OIIO_MAYBE_UNUSED,
                        const ImageSpec *specs) {
         // Default implementation: just a regular open, assume that
         // appending will work.
@@ -2604,7 +2605,7 @@ inline bool convert_image(int nchannels, int width, int height, int depth,
             stride_t src_xstride, stride_t src_ystride, stride_t src_zstride,
             void *dst, TypeDesc dst_type,
             stride_t dst_xstride, stride_t dst_ystride, stride_t dst_zstride,
-            int alpha_channel, int z_channel = -1)
+            int /*alpha_channel*/, int /*z_channel*/ = -1)
 {
     return convert_image(nchannels, width, height, depth, src, src_type,
                          src_xstride, src_ystride, src_zstride, dst, dst_type,
@@ -2629,7 +2630,7 @@ inline bool parallel_convert_image(
             stride_t src_xstride, stride_t src_ystride, stride_t src_zstride,
             void *dst, TypeDesc dst_type,
             stride_t dst_xstride, stride_t dst_ystride, stride_t dst_zstride,
-            int alpha_channel, int z_channel, int nthreads=0)
+            int /*alpha_channel*/, int /*z_channel*/, int nthreads=0)
 {
     return parallel_convert_image (nchannels, width, height, depth,
            src, src_type, src_xstride, src_ystride, src_zstride,

--- a/src/include/OpenImageIO/parallel.h
+++ b/src/include/OpenImageIO/parallel.h
@@ -104,7 +104,7 @@ parallel_for_chunked(int64_t start, int64_t end, int64_t chunksize,
                      std::function<void(int64_t, int64_t)>&& task,
                      parallel_options opt = parallel_options(0, Split_Y, 1))
 {
-    auto wrapper = [&](int id, int64_t b, int64_t e) { task(b, e); };
+    auto wrapper = [&](int /*id*/, int64_t b, int64_t e) { task(b, e); };
     parallel_for_chunked(start, end, chunksize, wrapper, opt);
 }
 
@@ -128,7 +128,7 @@ parallel_for (int64_t start, int64_t end,
               std::function<void(int64_t index)>&& task,
               parallel_options opt=parallel_options(0,Split_Y,1))
 {
-    parallel_for_chunked (start, end, 0, [&task](int id, int64_t i, int64_t e) {
+    parallel_for_chunked (start, end, 0, [&task](int /*id*/, int64_t i, int64_t e) {
         for ( ; i < e; ++i)
             task (i);
     }, opt);
@@ -170,7 +170,7 @@ parallel_for_each (InputIt first, InputIt last, UnaryFunction f,
             // queue or handing off between threads.
             f (*first);
         } else {
-            ts.push (opt.pool->push ([&](int id){ f(*first); }));
+            ts.push (opt.pool->push ([&](int /*id*/){ f(*first); }));
         }
     }
     return std::move(f);
@@ -212,7 +212,7 @@ parallel_for_chunked_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
                                             int64_t, int64_t)>&& task,
                          parallel_options opt=0)
 {
-    auto wrapper = [&](int id, int64_t xb, int64_t xe,
+    auto wrapper = [&](int /*id*/, int64_t xb, int64_t xe,
                        int64_t yb, int64_t ye) { task(xb,xe,yb,ye); };
     parallel_for_chunked_2D (xstart, xend, xchunksize,
                              ystart, yend, ychunksize, wrapper, opt);
@@ -261,7 +261,7 @@ parallel_for_2D (int64_t xstart, int64_t xend,
                  parallel_options opt=0)
 {
     parallel_for_chunked_2D (xstart, xend, 0, ystart, yend, 0,
-            [&task](int id, int64_t xb, int64_t xe, int64_t yb, int64_t ye) {
+            [&task](int /*id*/, int64_t xb, int64_t xe, int64_t yb, int64_t ye) {
         for (auto y = yb; y < ye; ++y)
             for (auto x = xb; x < xe; ++x)
                 task (x, y);
@@ -274,8 +274,8 @@ parallel_for_2D (int64_t xstart, int64_t xend,
 // weren't used. Preserve for a version to not break 3rd party apps.
 OIIO_DEPRECATED("Use the version without chunk sizes (1.8)")
 inline void
-parallel_for_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
-                 int64_t ystart, int64_t yend, int64_t ychunksize,
+parallel_for_2D (int64_t xstart, int64_t xend, int64_t /*xchunksize*/,
+                 int64_t ystart, int64_t yend, int64_t /*ychunksize*/,
                  std::function<void(int id, int64_t i, int64_t j)>&& task)
 {
     parallel_for_2D (xstart, xend, ystart, yend,

--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -74,7 +74,7 @@ public:
 /// overhead is associated with a particular lock.
 template<typename T> class null_lock {
 public:
-    null_lock(T& m) noexcept {}
+    null_lock(T& /*m*/) noexcept {}
 };
 
 

--- a/src/include/OpenImageIO/unordered_map_concurrent.h
+++ b/src/include/OpenImageIO/unordered_map_concurrent.h
@@ -53,7 +53,7 @@ find_with_hash(Map& map, const Key& key, size_t hash)
 template<class Map, class Key,
          OIIO_ENABLE_IF(!pvt::has_find_with_hash<Map>::value)>
 typename Map::iterator
-find_with_hash(Map& map, const Key& key, size_t hash)
+find_with_hash(Map& map, const Key& key, size_t /*hash*/)
 {
     return map.find(key);
 }

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -785,9 +785,9 @@ public:
     {
     }
     ~ColorProcessor_Ident() {}
-    virtual void apply(float* data, int width, int height, int channels,
-                       stride_t chanstride, stride_t xstride,
-                       stride_t ystride) const
+    virtual void apply(float* /*data*/, int /*width*/, int /*height*/,
+                       int /*channels*/, stride_t /*chanstride*/,
+                       stride_t /*xstride*/, stride_t /*ystride*/) const
     {
     }
 };

--- a/src/libOpenImageIO/compute_test.cpp
+++ b/src/libOpenImageIO/compute_test.cpp
@@ -43,8 +43,7 @@ static ImageBuf imgA, imgB, imgR;
 
 
 
-static void
-test_arrays(ROI roi)
+static void test_arrays(ROI)
 {
     const float* a = (const float*)imgA.localpixels();
     OIIO_DASSERT(a);
@@ -79,8 +78,7 @@ test_arrays_like_image(ROI roi)
 
 
 
-static void
-test_arrays_simd4(ROI roi)
+static void test_arrays_simd4(ROI)
 {
     const float* a = (const float*)imgA.localpixels();
     OIIO_DASSERT(a);

--- a/src/libOpenImageIO/exif-canon.cpp
+++ b/src/libOpenImageIO/exif-canon.cpp
@@ -126,7 +126,7 @@ static LabelIndex canon_exposuremode_table[] = {
 };
 
 static std::string
-explain_canon_flashbits (const ParamValue &p, const void *extradata)
+explain_canon_flashbits (const ParamValue &p, const void* /*extradata*/)
 {
     int val = p.get_int();
     if (val == 0)
@@ -688,7 +688,7 @@ static LabelIndex canon_camerasettings_indices[] = {
 };
 
 static void
-canon_camerasettings_handler (const TagInfo& taginfo, const TIFFDirEntry& dir,
+canon_camerasettings_handler (const TagInfo& /*taginfo*/, const TIFFDirEntry& dir,
                               cspan<uint8_t> buf, ImageSpec& spec,
                               bool swapendian, int offset_adjustment)
 {
@@ -706,7 +706,7 @@ static LabelIndex canon_focallength_indices[] = {
 
 
 static void
-canon_focallength_handler (const TagInfo& taginfo, const TIFFDirEntry& dir,
+canon_focallength_handler (const TagInfo& /*taginfo*/, const TIFFDirEntry& dir,
                            cspan<uint8_t> buf, ImageSpec& spec,
                            bool swapendian, int offset_adjustment)
 {

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -600,7 +600,7 @@ namespace {  // make an anon namespace
 // clang-format off
 
 static std::string
-explain_shutterapex(const ParamValue& p, const void* extradata)
+explain_shutterapex(const ParamValue& p, const void* /*extradata*/)
 {
     if (p.type() == TypeDesc::FLOAT) {
         double val = pow(2.0, -(double)*(float*)p.data());
@@ -613,7 +613,7 @@ explain_shutterapex(const ParamValue& p, const void* extradata)
 }
 
 static std::string
-explain_apertureapex(const ParamValue& p, const void* extradata)
+explain_apertureapex(const ParamValue& p, const void* /*extradata*/)
 {
     if (p.type() == TypeDesc::FLOAT)
         return Strutil::sprintf("f/%2.1f", powf(2.0f, *(float*)p.data() / 2.0f));
@@ -621,7 +621,7 @@ explain_apertureapex(const ParamValue& p, const void* extradata)
 }
 
 static std::string
-explain_ExifFlash(const ParamValue& p, const void* extradata)
+explain_ExifFlash(const ParamValue& p, const void* /*extradata*/)
 {
     int val = p.get_int();
     return Strutil::sprintf("%s%s%s%s%s%s%s%s",

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1920,7 +1920,7 @@ ImageBuf::setpixel(int i, const float* pixel, int maxchannels)
 
 template<typename D, typename S>
 static bool
-get_pixels_(const ImageBuf& buf, const ImageBuf& dummyarg, ROI whole_roi,
+get_pixels_(const ImageBuf& buf, const ImageBuf& /*dummy*/, ROI whole_roi,
             ROI roi, void* r_, stride_t xstride, stride_t ystride,
             stride_t zstride, int nthreads = 0)
 {

--- a/src/libOpenImageIO/imagebuf_test.cpp
+++ b/src/libOpenImageIO/imagebuf_test.cpp
@@ -380,7 +380,7 @@ test_roi()
 
 
 int
-main(int argc, char** argv)
+main(int /*argc*/, char* /*argv*/[])
 {
     test_wrapmodes();
     test_roi();

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -137,7 +137,7 @@ computePixelStats_(const ImageBuf& src, ImageBufAlgo::PixelStats& stats,
     parallel_options opt(nthreads);
     if (src.deep()) {
         parallel_for_chunked(roi.ybegin, roi.yend, 64,
-                             [&](int id, int64_t ybegin, int64_t yend) {
+                             [&](int /*id*/, int64_t ybegin, int64_t yend) {
             ROI subroi(roi.xbegin, roi.xend, ybegin, yend, roi.zbegin,
                        roi.zend, roi.chbegin, roi.chend);
             ImageBufAlgo::PixelStats tmp(nchannels);
@@ -159,7 +159,7 @@ computePixelStats_(const ImageBuf& src, ImageBufAlgo::PixelStats& stats,
 
     } else {  // Non-deep case
         parallel_for_chunked(roi.ybegin, roi.yend, 64,
-                             [&](int id, int64_t ybegin, int64_t yend) {
+                             [&](int /*id*/, int64_t ybegin, int64_t yend) {
             ROI subroi(roi.xbegin, roi.xend, ybegin, yend, roi.zbegin,
                        roi.zend, roi.chbegin, roi.chend);
             ImageBufAlgo::PixelStats tmp(nchannels);
@@ -270,7 +270,7 @@ template<class Atype, class Btype>
 static bool
 compare_(const ImageBuf& A, const ImageBuf& B, float failthresh,
          float warnthresh, ImageBufAlgo::CompareResults& result, ROI roi,
-         int nthreads)
+         int /*nthreads*/)
 {
     imagesize_t npels = roi.npixels();
     imagesize_t nvals = npels * roi.nchannels();

--- a/src/libOpenImageIO/imagebufalgo_deep.cpp
+++ b/src/libOpenImageIO/imagebufalgo_deep.cpp
@@ -136,7 +136,7 @@ ImageBufAlgo::flatten(const ImageBuf& src, ROI roi, int nthreads)
 
 bool
 ImageBufAlgo::deepen(ImageBuf& dst, const ImageBuf& src, float zvalue, ROI roi,
-                     int nthreads)
+                     int /*nthreads*/)
 {
     pvt::LoggedTimer logtime("IBA::deepen");
     if (src.deep()) {
@@ -364,7 +364,7 @@ ImageBufAlgo::deep_merge(const ImageBuf& A, const ImageBuf& B,
 
 bool
 ImageBufAlgo::deep_holdout(ImageBuf& dst, const ImageBuf& src,
-                           const ImageBuf& thresh, ROI roi, int nthreads)
+                           const ImageBuf& thresh, ROI roi, int /*nthreads*/)
 {
     pvt::LoggedTimer logtime("IBA::deep_holdout");
     if (!src.deep() || !thresh.deep()) {

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -210,7 +210,7 @@ ImageBufAlgo::zero(ROI roi, int nthreads)
 template<typename T>
 static bool
 render_point_(ImageBuf& dst, int x, int y, const float* color, float alpha,
-              ROI roi, int nthreads)
+              ROI roi, int /*nthreads*/)
 {
     ImageBuf::Iterator<T> r(dst, x, y);
     for (int c = roi.chbegin; c < roi.chend; ++c)
@@ -334,7 +334,7 @@ template<typename T> struct IB_drawer {
 template<typename T>
 static bool
 render_line_(ImageBuf& dst, int x1, int y1, int x2, int y2, cspan<float> color,
-             float alpha, bool skip_first, ROI roi, int nthreads)
+             float alpha, bool skip_first, ROI roi, int /*nthreads*/)
 {
     ImageBuf::Iterator<T> r(dst, roi);
     IB_drawer<T> draw(r, color, alpha, roi);
@@ -880,7 +880,8 @@ bool
 ImageBufAlgo::render_text(ImageBuf& R, int x, int y, string_view text,
                           int fontsize, string_view font_,
                           cspan<float> textcolor, TextAlignX alignx,
-                          TextAlignY aligny, int shadow, ROI roi, int nthreads)
+                          TextAlignY aligny, int shadow, ROI roi,
+                          int /*nthreads*/)
 {
     pvt::LoggedTimer logtime("IBA::render_text");
     if (R.spec().depth > 1) {

--- a/src/libOpenImageIO/imagebufalgo_orient.cpp
+++ b/src/libOpenImageIO/imagebufalgo_orient.cpp
@@ -26,7 +26,7 @@ OIIO_NAMESPACE_BEGIN
 
 template<class D, class S = D>
 static bool
-flip_(ImageBuf& dst, const ImageBuf& src, ROI dst_roi, int nthreads)
+flip_(ImageBuf& dst, const ImageBuf& src, ROI dst_roi, int /*nthreads*/)
 {
     ROI src_roi_full = src.roi_full();
     ROI dst_roi_full = dst.roi_full();
@@ -75,7 +75,7 @@ ImageBufAlgo::flip(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
 
 template<class D, class S = D>
 static bool
-flop_(ImageBuf& dst, const ImageBuf& src, ROI dst_roi, int nthreads)
+flop_(ImageBuf& dst, const ImageBuf& src, ROI dst_roi, int /*nthreads*/)
 {
     ROI src_roi_full = src.roi_full();
     ROI dst_roi_full = dst.roi_full();
@@ -148,7 +148,7 @@ ImageBufAlgo::flop(const ImageBuf& src, ROI roi, int nthreads)
 
 template<class D, class S = D>
 static bool
-rotate90_(ImageBuf& dst, const ImageBuf& src, ROI dst_roi, int nthreads)
+rotate90_(ImageBuf& dst, const ImageBuf& src, ROI dst_roi, int /*nthreads*/)
 {
     ROI dst_roi_full = dst.roi_full();
     ImageBuf::ConstIterator<S, D> s(src);
@@ -208,7 +208,7 @@ ImageBufAlgo::rotate90(ImageBuf& dst, const ImageBuf& src, ROI roi,
 
 template<class D, class S = D>
 static bool
-rotate180_(ImageBuf& dst, const ImageBuf& src, ROI dst_roi, int nthreads)
+rotate180_(ImageBuf& dst, const ImageBuf& src, ROI dst_roi, int /*nthreads*/)
 {
     ROI src_roi_full = src.roi_full();
     ROI dst_roi_full = dst.roi_full();
@@ -262,7 +262,7 @@ ImageBufAlgo::rotate180(ImageBuf& dst, const ImageBuf& src, ROI roi,
 
 template<class D, class S = D>
 static bool
-rotate270_(ImageBuf& dst, const ImageBuf& src, ROI dst_roi, int nthreads)
+rotate270_(ImageBuf& dst, const ImageBuf& src, ROI dst_roi, int /*nthreads*/)
 {
     ROI dst_roi_full = dst.roi_full();
     ImageBuf::ConstIterator<S, D> s(src);

--- a/src/libOpenImageIO/imagecache_test.cpp
+++ b/src/libOpenImageIO/imagecache_test.cpp
@@ -135,7 +135,7 @@ test_app_buffer()
 
 
 int
-main(int argc, char** argv)
+main(int /*argc*/, char* /*argv*/[])
 {
     test_get_pixels_cachechannels(0, 10);
     test_get_pixels_cachechannels(0, 4);

--- a/src/libOpenImageIO/imageinout_test.cpp
+++ b/src/libOpenImageIO/imageinout_test.cpp
@@ -375,7 +375,7 @@ test_read_tricky_sizes()
 
 
 int
-main(int argc, char** argv)
+main(int /*argc*/, char** /*argv*/)
 {
     test_all_formats();
     test_read_tricky_sizes();

--- a/src/libOpenImageIO/imageinout_test.cpp
+++ b/src/libOpenImageIO/imageinout_test.cpp
@@ -375,7 +375,7 @@ test_read_tricky_sizes()
 
 
 int
-main(int /*argc*/, char** /*argv*/)
+main(int /*argc*/, char* /*argv*/[])
 {
     test_all_formats();
     test_read_tricky_sizes();

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -753,7 +753,7 @@ parallel_convert_image(int nchannels, int width, int height, int depth,
 
     int blocksize = std::max(1, height / nthreads);
     parallel_for_chunked(
-        0, height, blocksize, [=](int id, int64_t ybegin, int64_t yend) {
+        0, height, blocksize, [=](int /*id*/, int64_t ybegin, int64_t yend) {
             convert_image(nchannels, width, yend - ybegin, depth,
                           (const char*)src + src_ystride * ybegin, src_type,
                           src_xstride, src_ystride, src_zstride,

--- a/src/libOpenImageIO/imagespec_test.cpp
+++ b/src/libOpenImageIO/imagespec_test.cpp
@@ -272,7 +272,7 @@ test_imagespec_from_ROI()
 
 
 int
-main(int argc, char* argv[])
+main(int /*argc*/, char* /*argv*/[])
 {
     test_imagespec_pixels();
     test_imagespec_metadata_val();

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -40,7 +40,7 @@ static float cache_size               = 0;
 
 
 static int
-parse_files(int argc, const char* argv[])
+parse_files(int /*argc*/, const char* argv[])
 {
     input_filename.emplace_back(argv[0]);
     return 0;

--- a/src/libOpenImageIO/iptc.cpp
+++ b/src/libOpenImageIO/iptc.cpp
@@ -159,7 +159,7 @@ decode_iptc_iim(const void* iptc, int length, ImageSpec& spec)
 
 
 static void
-encode_iptc_iim_one_tag(int tag, const char* name, TypeDesc type,
+encode_iptc_iim_one_tag(int tag, const char* /*name*/, TypeDesc type,
                         const void* data, std::vector<char>& iptc)
 {
     if (type == TypeDesc::STRING) {

--- a/src/libutil/argparse.cpp
+++ b/src/libutil/argparse.cpp
@@ -93,8 +93,8 @@ public:
         = nullptr;  // option for pre-switch cmd line arguments
     std::string m_intro;
     std::vector<std::unique_ptr<ArgOption>> m_option;
-    callback_t m_preoption_help  = [](const ArgParse& ap, std::ostream&) {};
-    callback_t m_postoption_help = [](const ArgParse& ap, std::ostream&) {};
+    callback_t m_preoption_help  = [](const ArgParse&, std::ostream&) {};
+    callback_t m_postoption_help = [](const ArgParse&, std::ostream&) {};
 
     Impl(int argc, const char** argv)
         : m_argc(argc)

--- a/src/libutil/argparse_test.cpp
+++ b/src/libutil/argparse_test.cpp
@@ -127,7 +127,7 @@ test_basic()
 
 
 int
-main(int argc, char* argv[])
+main(int /*argc*/, char* /*argv*/[])
 {
     test_basic();
 

--- a/src/libutil/benchmark.cpp
+++ b/src/libutil/benchmark.cpp
@@ -31,7 +31,7 @@ void OIIO_API
 #if __has_attribute(__optnone__)
     __attribute__((__optnone__))
 #endif
-    clobber(void* p)
+    clobber(void*)
 {
 }
 

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -554,7 +554,8 @@ Filesystem::file_size(string_view path) noexcept
 
 
 void
-Filesystem::convert_native_arguments(int argc, const char* argv[])
+Filesystem::convert_native_arguments(int argc OIIO_MAYBE_UNUSED,
+                                     const char* argv OIIO_MAYBE_UNUSED[])
 {
 #ifdef _WIN32
     // Windows only, standard main() entry point does not accept unicode file

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -555,7 +555,7 @@ Filesystem::file_size(string_view path) noexcept
 
 void
 Filesystem::convert_native_arguments(int argc OIIO_MAYBE_UNUSED,
-                                     const char* argv OIIO_MAYBE_UNUSED[])
+                                     const char* argv[])
 {
 #ifdef _WIN32
     // Windows only, standard main() entry point does not accept unicode file
@@ -573,6 +573,12 @@ Filesystem::convert_native_arguments(int argc OIIO_MAYBE_UNUSED,
         std::string utf8_arg = Strutil::utf16_to_utf8(native_argv[i]);
         argv[i]              = ustring(utf8_arg).c_str();
     }
+#else
+    // I hate that we have to do this, but gcc gets confused about the
+    //    const char* argv OIIO_MAYBE_UNUSED []
+    // This seems to be the way around the problem, make it look like it's
+    // used.
+    (void)argv;
 #endif
 }
 

--- a/src/libutil/filesystem_test.cpp
+++ b/src/libutil/filesystem_test.cpp
@@ -510,7 +510,7 @@ test_mem_proxies()
 
 
 int
-main(int argc, char* argv[])
+main(int /*argc*/, char* /*argv*/[])
 {
     test_filename_decomposition();
     test_filename_searchpath_find();

--- a/src/libutil/optparser_test.cpp
+++ b/src/libutil/optparser_test.cpp
@@ -89,7 +89,7 @@ test_optparser()
 
 
 int
-main(int argc, char* argv[])
+main(int /*argc*/, char* /*argv*/[])
 {
     test_optparser();
 

--- a/src/libutil/parallel_test.cpp
+++ b/src/libutil/parallel_test.cpp
@@ -74,7 +74,7 @@ time_parallel_for()
         // make a lambda function that spawns a bunch of threads, calls a
         // trivial function, then waits for them to finish and tears down
         // the group.
-        auto func = [=]() { parallel_for(0, nt, [](int64_t i) { /*empty*/ }); };
+        auto func = [=]() { parallel_for(0, nt, [](int64_t) { /*empty*/ }); };
 
         double range;
         double t = time_trial(func, ntrials, its, &range);

--- a/src/libutil/parallel_test.cpp
+++ b/src/libutil/parallel_test.cpp
@@ -132,13 +132,13 @@ test_thread_pool_recursion()
     static spin_mutex print_mutex;
     thread_pool* pool(default_thread_pool());
     pool->resize(2);
-    parallel_for(0, 10, [&](int id, int64_t i) {
+    parallel_for(0, 10, [&](int /*id*/, int64_t /*i*/) {
         // sleep long enough that we can push all the jobs before any get
         // done.
         Sysutil::usleep(10);
         // then run something else that itself will push jobs onto the
         // thread pool queue.
-        parallel_for(0, 10, [&](int id, int64_t i) {
+        parallel_for(0, 10, [&](int /*id*/, int64_t /*i*/) {
             Sysutil::usleep(2);
             spin_lock lock(print_mutex);
             // std::cout << "  recursive running thread " << id << std::endl;

--- a/src/libutil/paramlist_test.cpp
+++ b/src/libutil/paramlist_test.cpp
@@ -366,7 +366,7 @@ test_delegates()
 
 
 int
-main(int argc, char* argv[])
+main(int /*argc*/, char* /*argv*/[])
 {
     std::cout << "ParamValue size = " << sizeof(ParamValue) << "\n";
     test_value_types();

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -151,7 +151,7 @@ mkvec(typename VEC::value_t a, typename VEC::value_t b, typename VEC::value_t c,
 
 template<>
 inline vfloat3
-mkvec<vfloat3>(float a, float b, float c, float d)
+mkvec<vfloat3>(float a, float b, float c, float /*d*/)
 {
     return vfloat3(a, b, c);
 }
@@ -259,7 +259,7 @@ mkvec<vfloat16>(float a, float b, float c, float d, float e, float f, float g,
 
 template<typename VEC>
 inline int
-loadstore_vec(int dummy)
+loadstore_vec(int /*dummy*/)
 {
     typedef typename VEC::value_t ELEM;
     ELEM B[VEC::elements];
@@ -274,7 +274,7 @@ loadstore_vec(int dummy)
 
 template<typename VEC>
 inline VEC
-load_vec(int dummy)
+load_vec(int /*dummy*/)
 {
     typedef typename VEC::value_t ELEM;
     VEC v;
@@ -293,7 +293,7 @@ store_vec(const VEC& v)
 
 template<typename VEC, int N>
 inline VEC
-load_vec_N(typename VEC::value_t* B)
+load_vec_N(typename VEC::value_t* /*B*/)
 {
     typedef typename VEC::value_t ELEM;
     VEC v;
@@ -771,10 +771,10 @@ test_component_access()
 #endif
 
     benchmark2 ("operator[i]", [&](const VEC& v, int i){ return v[i]; },  b, 2, 1 /*work*/);
-    benchmark2 ("operator[2]", [&](const VEC& v, int i){ return v[2]; },  b, 2, 1 /*work*/);
-    benchmark2 ("operator[0]", [&](const VEC& v, int i){ return v[0]; },  b, 0, 1 /*work*/);
-    benchmark2 ("extract<2> ", [&](const VEC& v, int i){ return extract<2>(v); },  b, 2, 1 /*work*/);
-    benchmark2 ("extract<0> ", [&](const VEC& v, int i){ return extract<0>(v); },  b, 0, 1 /*work*/);
+    benchmark2 ("operator[2]", [&](const VEC& v, int /*i*/){ return v[2]; },  b, 2, 1 /*work*/);
+    benchmark2 ("operator[0]", [&](const VEC& v, int /*i*/){ return v[0]; },  b, 0, 1 /*work*/);
+    benchmark2 ("extract<2> ", [&](const VEC& v, int /*i*/){ return extract<2>(v); },  b, 2, 1 /*work*/);
+    benchmark2 ("extract<0> ", [&](const VEC& v, int /*i*/){ return extract<0>(v); },  b, 0, 1 /*work*/);
     benchmark2 ("insert<2> ", [&](const VEC& v, ELEM i){ return insert<2>(v, i); }, b, ELEM(1), 1 /*work*/);
 }
 

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -212,14 +212,14 @@ mkvec(typename VEC::value_t a, typename VEC::value_t b, typename VEC::value_t c,
 
 template<>
 inline vbool4
-mkvec<vbool4>(bool a, bool b, bool c, bool d, bool e, bool f, bool g, bool h)
+mkvec<vbool4>(bool a, bool b, bool c, bool d, bool, bool, bool, bool)
 {
     return vbool4(a, b, c, d);
 }
 
 template<>
 inline vint4
-mkvec<vint4>(int a, int b, int c, int d, int e, int f, int g, int h)
+mkvec<vint4>(int a, int b, int c, int d, int, int, int, int)
 {
     return vint4(a, b, c, d);
 }
@@ -234,16 +234,14 @@ mkvec<vint16>(int a, int b, int c, int d, int e, int f, int g, int h)
 
 template<>
 inline vfloat4
-mkvec<vfloat4>(float a, float b, float c, float d, float e, float f, float g,
-               float h)
+mkvec<vfloat4>(float a, float b, float c, float d, float, float, float, float)
 {
     return vfloat4(a, b, c, d);
 }
 
 template<>
 inline vfloat3
-mkvec<vfloat3>(float a, float b, float c, float d, float e, float f, float g,
-               float h)
+mkvec<vfloat3>(float a, float b, float c, float, float, float, float, float)
 {
     return vfloat3(a, b, c);
 }

--- a/src/libutil/span_test.cpp
+++ b/src/libutil/span_test.cpp
@@ -308,7 +308,7 @@ test_image_view_mutable()
 
 
 int
-main(int argc, char* argv[])
+main(int /*argc*/, char* /*argv*/[])
 {
     test_span();
     test_span_mutable();

--- a/src/libutil/stb_sprintf.h
+++ b/src/libutil/stb_sprintf.h
@@ -1371,7 +1371,7 @@ static char *stbsp__clamp_callback(char *buf, void *user, int len)
    return (c->count >= STB_SPRINTF_MIN) ? c->buf : c->tmp; // go direct into buffer if you can
 }
 
-static char * stbsp__count_clamp_callback( char * buf, void * user, int len )
+static char * stbsp__count_clamp_callback( char * /*buf*/, void * user, int len )
 {
    stbsp__context * c = (stbsp__context*)user;
 

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -1031,7 +1031,7 @@ test_string_compare_function()
 
 
 int
-main(int argc, char* argv[])
+main(int /*argc*/, char* /*argv*/[])
 {
     test_format();
     test_memformat();

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -44,7 +44,7 @@ namespace {
 
 template<typename T> class Queue {
 public:
-    Queue(int size) {}
+    Queue(int /*size*/) {}
     bool push(T const& value)
     {
         std::unique_lock<Mutex> lock(this->mutex);

--- a/src/libutil/thread_test.cpp
+++ b/src/libutil/thread_test.cpp
@@ -61,7 +61,7 @@ getargs(int argc, char* argv[])
 
 
 void
-do_nothing(int thread_id)
+do_nothing(int /*thread_id*/)
 {
 }
 

--- a/src/libutil/timer_test.cpp
+++ b/src/libutil/timer_test.cpp
@@ -18,7 +18,7 @@ using namespace OIIO;
 
 
 static int
-parse_files(int argc, const char* argv[])
+parse_files(int /*argc*/, const char* /*argv*/[])
 {
     //    input_filename = ustring(argv[0]);
     return 0;

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -293,7 +293,8 @@ py_buffer_to_stdvector(std::vector<T>& vals, const py::buffer& obj)
 // Specialization for reading strings
 template<>
 inline bool
-py_buffer_to_stdvector(std::vector<std::string>& vals, const py::buffer& obj)
+py_buffer_to_stdvector(std::vector<std::string>& /*vals*/,
+                       const py::buffer& /*obj*/)
 {
     return false;  // not supported
 }
@@ -302,7 +303,8 @@ py_buffer_to_stdvector(std::vector<std::string>& vals, const py::buffer& obj)
 // Specialization for reading TypeDesc
 template<>
 inline bool
-py_buffer_to_stdvector(std::vector<TypeDesc>& vals, const py::buffer& obj)
+py_buffer_to_stdvector(std::vector<TypeDesc>& /*vals*/,
+                       const py::buffer& /*obj*/)
 {
     return false;  // not supported
 }


### PR DESCRIPTION
Fool around with -Wextra (optional, off by default for now), see what
turns up.

No code changes in this batch -- just suppress warnings by commenting
out param names for functions where they are not used (often because
they are base class stubs and the like). For functions that are part
of the public API where we use Doxygen to extract the declarations, we
can't comment out the param names, so instead mark them with
OIIO_MAYBE_UNUSED (and tell Doxygen to make that word go away in the
docs).

