### PR TITLE
Fixes related to unused parameters.

### DIFF
--- a/src/include/OpenImageIO/plugin.h
+++ b/src/include/OpenImageIO/plugin.h
@@ -62,7 +62,7 @@ inline void*
 getsym(Handle plugin_handle, const std::string& symbol_name,
        bool report_error = true)
 {
-    return getsym(plugin_handle, symbol_name.c_str());
+    return getsym(plugin_handle, symbol_name.c_str(), report_error);
 }
 
 /// Return any error messages associated with the last call to any of

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -374,7 +374,8 @@ ImageSpec::erase_attribute(string_view name, TypeDesc searchtype,
 #endif
         regex re     = regex(name.str(), flag);
         auto matcher = [&](const ParamValue& p) {
-            return regex_match(p.name().string(), re);
+            return regex_match(p.name().string(), re)
+                   && (searchtype == TypeUnknown || searchtype == p.type());
         };
         auto del = std::remove_if(extra_attribs.begin(), extra_attribs.end(),
                                   matcher);

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1669,7 +1669,7 @@ static inline float
 getchannel_(const ImageBuf& buf, int x, int y, int z, int c,
             ImageBuf::WrapMode wrap)
 {
-    ImageBuf::ConstIterator<T> pixel(buf, x, y, z);
+    ImageBuf::ConstIterator<T> pixel(buf, x, y, z, wrap);
     return pixel[c];
 }
 

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -855,7 +855,7 @@ ImageBufAlgo::computePixelHashSHA1(const ImageBuf& src, string_view extrainfo,
         broi.ybegin = ybegin;
         broi.yend   = yend;
         results[b]  = simplePixelHashSHA1(src, "", broi);
-    });
+    }, nthreads);
     // clang-format on
 
     // If there are multiple blocks, hash the block digests to get a final

--- a/src/libOpenImageIO/imagebufalgo_orient.cpp
+++ b/src/libOpenImageIO/imagebufalgo_orient.cpp
@@ -363,25 +363,25 @@ ImageBufAlgo::reorient(ImageBuf& dst, const ImageBuf& src, int nthreads)
     bool ok = false;
     switch (src.orientation()) {
     case 1: ok = dst.copy(src); break;
-    case 2: ok = ImageBufAlgo::flop(dst, src); break;
-    case 3: ok = ImageBufAlgo::rotate180(dst, src); break;
-    case 4: ok = ImageBufAlgo::flip(dst, src); break;
+    case 2: ok = ImageBufAlgo::flop(dst, src, ROI(), nthreads); break;
+    case 3: ok = ImageBufAlgo::rotate180(dst, src, ROI(), nthreads); break;
+    case 4: ok = ImageBufAlgo::flip(dst, src, ROI(), nthreads); break;
     case 5:
-        ok = ImageBufAlgo::rotate270(tmp, src);
+        ok = ImageBufAlgo::rotate270(tmp, src, ROI(), nthreads);
         if (ok)
-            ok = ImageBufAlgo::flop(dst, tmp);
+            ok = ImageBufAlgo::flop(dst, tmp, ROI(), nthreads);
         else
             dst.errorf("%s", tmp.geterror());
         break;
-    case 6: ok = ImageBufAlgo::rotate90(dst, src); break;
+    case 6: ok = ImageBufAlgo::rotate90(dst, src, ROI(), nthreads); break;
     case 7:
-        ok = ImageBufAlgo::flip(tmp, src);
+        ok = ImageBufAlgo::flip(tmp, src, ROI(), nthreads);
         if (ok)
-            ok = ImageBufAlgo::rotate90(dst, tmp);
+            ok = ImageBufAlgo::rotate90(dst, tmp, ROI(), nthreads);
         else
             dst.errorf("%s", tmp.geterror());
         break;
-    case 8: ok = ImageBufAlgo::rotate270(dst, src); break;
+    case 8: ok = ImageBufAlgo::rotate270(dst, src, ROI(), nthreads); break;
     }
     dst.set_orientation(1);
     return ok;

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -75,9 +75,9 @@ ParamValue::init_noclear(ustring _name, TypeDesc _type, int _nvalues,
 // helper to parse a list from a string
 template<class T>
 static void
-parse_elements(string_view name, TypeDesc type, const char* type_code,
-               string_view value, ParamValue& p)
+parse_elements(const char* type_code, string_view value, ParamValue& p)
 {
+    TypeDesc type = p.type();
     int num_items = type.numelements() * type.aggregate;
     T* data       = (T*)p.data();
     // Erase any leading whitespace
@@ -103,21 +103,21 @@ ParamValue::ParamValue(string_view name, TypeDesc type, string_view value)
     : ParamValue(name, type, 1, nullptr)
 {
     if (type.basetype == TypeDesc::INT) {
-        parse_elements<int>(name, type, "%d", value, *this);
+        parse_elements<int>("%d", value, *this);
     } else if (type.basetype == TypeDesc::UINT) {
-        parse_elements<unsigned int>(name, type, "%u", value, *this);
+        parse_elements<unsigned int>("%u", value, *this);
     } else if (type.basetype == TypeDesc::FLOAT) {
-        parse_elements<float>(name, type, "%f", value, *this);
+        parse_elements<float>("%f", value, *this);
     } else if (type.basetype == TypeDesc::DOUBLE) {
-        parse_elements<double>(name, type, "%lf", value, *this);
+        parse_elements<double>("%lf", value, *this);
     } else if (type.basetype == TypeDesc::INT64) {
-        parse_elements<long long>(name, type, "%lld", value, *this);
+        parse_elements<long long>("%lld", value, *this);
     } else if (type.basetype == TypeDesc::UINT64) {
-        parse_elements<unsigned long long>(name, type, "%llu", value, *this);
+        parse_elements<unsigned long long>("%llu", value, *this);
     } else if (type.basetype == TypeDesc::INT16) {
-        parse_elements<short>(name, type, "%hd", value, *this);
+        parse_elements<short>("%hd", value, *this);
     } else if (type.basetype == TypeDesc::UINT16) {
-        parse_elements<unsigned short>(name, type, "%hu", value, *this);
+        parse_elements<unsigned short>("%hu", value, *this);
     } else if (type == TypeDesc::STRING) {
         ustring s(value);
         init(name, type, 1, &s);


### PR DESCRIPTION
More exploring what -Wextra turns up.

Found several buglets!

* The string version of getsym didn't pass along report_error.

* ImageBuf::getchannel did not honor its wrap parameter.

* ImageSpec::erase_attribute did not honor its 'searchtype' parameter.

* IBA::reorient did not pass its nthreads params to its children.

* IBA::computePixelHashSHA1 did not honor its nthreads parameter.

* Get rid of useless parameter in internal helper function parse_elements.

