### PR TITLE
Address strict warnings about unused parameters to functions (pt 2)

### DIFF
--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -123,7 +123,7 @@ BmpInput::open(const std::string& name, ImageSpec& spec)
 
 
 bool
-BmpInput::read_native_scanline(int subimage, int miplevel, int y, int z,
+BmpInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
     lock_guard lock(m_mutex);

--- a/src/cineon.imageio/cineoninput.cpp
+++ b/src/cineon.imageio/cineoninput.cpp
@@ -365,7 +365,7 @@ CineonInput::close()
 
 
 bool
-CineonInput::read_native_scanline(int subimage, int miplevel, int y, int z,
+CineonInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                   void* data)
 {
     lock_guard lock(m_mutex);

--- a/src/cineon.imageio/libcineon/Writer.cpp
+++ b/src/cineon.imageio/libcineon/Writer.cpp
@@ -35,6 +35,10 @@
 #include <cstring>
 #include <ctime>
 
+#if defined(__GNUC__)
+#    pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+
 #include "Cineon.h"
 #include "CineonStream.h"
 #include "EndianSwap.h"

--- a/src/dicom.imageio/dicominput.cpp
+++ b/src/dicom.imageio/dicominput.cpp
@@ -37,7 +37,10 @@ public:
     DICOMInput() {}
     virtual ~DICOMInput() { close(); }
     virtual const char* format_name(void) const override { return "dicom"; }
-    virtual int supports(string_view feature) const override { return false; }
+    virtual int supports(string_view /*feature*/) const override
+    {
+        return false;  // we don't support any optional features
+    }
     virtual bool open(const std::string& name, ImageSpec& newspec) override;
     virtual bool open(const std::string& name, ImageSpec& newspec,
                       const ImageSpec& config) override;
@@ -95,7 +98,7 @@ DICOMInput::open(const std::string& name, ImageSpec& newspec)
 
 bool
 DICOMInput::open(const std::string& name, ImageSpec& newspec,
-                 const ImageSpec& config)
+                 const ImageSpec& /*config*/)
 {
     m_filename = name;
     m_subimage = -1;
@@ -211,7 +214,7 @@ DICOMInput::seek_subimage(int subimage, int miplevel)
         { EPI_YBR_Full, "YBR_Full", 3 },                /// YCbCr full
         { EPI_YBR_Full_422, "YBR_Full_422", 3 },        /// YCbCr full 4:2:2
         { EPI_YBR_Partial_422, "YBR_Partial_422", 3 },  /// YCbCr partial 4:2:2
-        { EPI_Unknown, NULL }
+        { EPI_Unknown, NULL, 0 }
     };
     int nchannels         = 1;
     const char* photoname = NULL;
@@ -320,7 +323,7 @@ DICOMInput::read_metadata()
 
 
 bool
-DICOMInput::read_native_scanline(int subimage, int miplevel, int y, int z,
+DICOMInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                  void* data)
 {
     lock_guard lock(m_mutex);

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -565,7 +565,7 @@ DPXInput::read_native_scanline(int subimage, int miplevel, int y, int z,
 
 bool
 DPXInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
-                                int yend, int z, void* data)
+                                int yend, int /*z*/, void* data)
 {
     lock_guard lock(m_mutex);
     if (!seek_subimage(subimage, miplevel))

--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -569,7 +569,7 @@ FFmpegInput::seek_subimage(int subimage, int miplevel)
 
 
 bool
-FFmpegInput::read_native_scanline(int subimage, int miplevel, int y, int z,
+FFmpegInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                   void* data)
 {
     lock_guard lock(m_mutex);

--- a/src/fits.imageio/fitsinput.cpp
+++ b/src/fits.imageio/fitsinput.cpp
@@ -91,7 +91,7 @@ FitsInput::open(const std::string& name, ImageSpec& spec)
 
 
 bool
-FitsInput::read_native_scanline(int subimage, int miplevel, int y, int z,
+FitsInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                 void* data)
 {
     lock_guard lock(m_mutex);

--- a/src/fits.imageio/fitsoutput.cpp
+++ b/src/fits.imageio/fitsoutput.cpp
@@ -86,7 +86,7 @@ FitsOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
 
 
 bool
-FitsOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
+FitsOutput::write_scanline(int y, int /*z*/, TypeDesc format, const void* data,
                            stride_t xstride)
 {
     if (m_spec.width == 0 && m_spec.height == 0)

--- a/src/gif.imageio/gifinput.cpp
+++ b/src/gif.imageio/gifinput.cpp
@@ -161,7 +161,7 @@ GIFInput::decode_line_number(int line_number, int height)
 
 
 bool
-GIFInput::read_native_scanline(int subimage, int miplevel, int y, int z,
+GIFInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
     lock_guard lock(m_mutex);

--- a/src/gif.imageio/gifoutput.cpp
+++ b/src/gif.imageio/gifoutput.cpp
@@ -196,7 +196,7 @@ GIFOutput::finish_subimage()
 
 
 bool
-GIFOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
+GIFOutput::write_scanline(int y, int /*z*/, TypeDesc format, const void* data,
                           stride_t xstride)
 {
     return convert_image(spec().nchannels, spec().width, 1 /*1 scanline*/, 1,

--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -158,7 +158,7 @@ HdrInput::seek_subimage(int subimage, int miplevel)
 
 
 bool
-HdrInput::read_native_scanline(int subimage, int miplevel, int y, int z,
+HdrInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
     lock_guard lock(m_mutex);

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -128,8 +128,8 @@ HdrOutput::open(const std::string& name, const ImageSpec& newspec,
 
 
 bool
-HdrOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
-                          stride_t xstride)
+HdrOutput::write_scanline(int /*y*/, int /*z*/, TypeDesc format,
+                          const void* data, stride_t xstride)
 {
     data  = to_native_scanline(format, data, xstride, scratch);
     int r = RGBE_WritePixels_RLE(m_fd, (float*)data, m_spec.width, 1,

--- a/src/heif.imageio/heifinput.cpp
+++ b/src/heif.imageio/heifinput.cpp
@@ -105,7 +105,7 @@ HeifInput::open(const std::string& name, ImageSpec& newspec)
 
 bool
 HeifInput::open(const std::string& name, ImageSpec& newspec,
-                const ImageSpec& config)
+                const ImageSpec& /*config*/)
 {
     m_filename = name;
     m_subimage = -1;
@@ -235,7 +235,7 @@ HeifInput::seek_subimage(int subimage, int miplevel)
 
 
 bool
-HeifInput::read_native_scanline(int subimage, int miplevel, int y, int z,
+HeifInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                 void* data)
 {
     lock_guard lock(m_mutex);

--- a/src/heif.imageio/heifoutput.cpp
+++ b/src/heif.imageio/heifoutput.cpp
@@ -153,7 +153,7 @@ HeifOutput::open(const std::string& name, const ImageSpec& newspec,
 
 
 bool
-HeifOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
+HeifOutput::write_scanline(int y, int /*z*/, TypeDesc format, const void* data,
                            stride_t xstride)
 {
     data           = to_native_scanline(format, data, xstride, scratch);

--- a/src/ico.imageio/icoinput.cpp
+++ b/src/ico.imageio/icoinput.cpp
@@ -419,7 +419,7 @@ ICOInput::close()
 
 
 bool
-ICOInput::read_native_scanline(int subimage, int miplevel, int y, int z,
+ICOInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
     lock_guard lock(m_mutex);

--- a/src/iff.imageio/iffinput.cpp
+++ b/src/iff.imageio/iffinput.cpp
@@ -128,8 +128,8 @@ IffInput::open(const std::string& name, ImageSpec& spec)
 
 
 bool
-IffInput::read_native_scanline(int subimage, int miplevel, int y, int z,
-                               void* data)
+IffInput::read_native_scanline(int /*subimage*/, int /*miplevel*/, int /*y*/,
+                               int /*z*/, void* /*data*/)
 {
     // scanline not used for Maya IFF, uses tiles instead.
     return false;
@@ -138,7 +138,7 @@ IffInput::read_native_scanline(int subimage, int miplevel, int y, int z,
 
 
 bool
-IffInput::read_native_tile(int subimage, int miplevel, int x, int y, int z,
+IffInput::read_native_tile(int subimage, int miplevel, int x, int y, int /*z*/,
                            void* data)
 {
     lock_guard lock(m_mutex);

--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -328,12 +328,12 @@ public:
     virtual bool opened () const { return mode() != Closed; }
     virtual int64_t tell () { return m_pos; }
     virtual bool seek (int64_t offset) { m_pos = offset; return true; }
-    virtual size_t read (void *buf, size_t size) { return 0; }
-    virtual size_t write (const void *buf, size_t size) { return 0; }
+    virtual size_t read (void *buf, size_t size);
+    virtual size_t write (const void *buf, size_t size);
     // pread(), pwrite() are stateless, do not alter the current file
     // position, and are thread-safe (against each other).
-    virtual size_t pread (void *buf, size_t size, int64_t offset) { return 0; }
-    virtual size_t pwrite (const void *buf, size_t size, int64_t offset) { return 0; }
+    virtual size_t pread (void *buf, size_t size, int64_t offset);
+    virtual size_t pwrite (const void *buf, size_t size, int64_t offset);
     virtual size_t size () const { return 0; }
     virtual void flush () const { }
 

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -120,7 +120,7 @@ comp_info_to_attr(const jpeg_decompress_struct& cinfo)
 
 
 void
-JpgInput::jpegerror(my_error_ptr myerr, bool fatal)
+JpgInput::jpegerror(my_error_ptr /*myerr*/, bool fatal)
 {
     // Send the error message to the ImageInput
     char errbuf[JMSG_LENGTH_MAX];
@@ -429,7 +429,7 @@ cmyk_to_rgb(int n, const unsigned char* cmyk, size_t cmyk_stride,
 
 
 bool
-JpgInput::read_native_scanline(int subimage, int miplevel, int y, int z,
+JpgInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
     if (!seek_subimage(subimage, miplevel))

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -30,7 +30,7 @@ openjpeg_error_callback(const char* msg, void* data)
 
 
 static void
-openjpeg_dummy_callback(const char* msg, void* data)
+openjpeg_dummy_callback(const char* /*msg*/, void* /*data*/)
 {
 }
 
@@ -78,7 +78,7 @@ public:
     Jpeg2000Input() { init(); }
     virtual ~Jpeg2000Input() { close(); }
     virtual const char* format_name(void) const override { return "jpeg2000"; }
-    virtual int supports(string_view feature) const override
+    virtual int supports(string_view /*feature*/) const override
     {
         return false;
         // FIXME: we should support Exif/IPTC, but currently don't.
@@ -400,7 +400,7 @@ Jpeg2000Input::destroy_decompressor()
 
 template<typename T>
 void
-Jpeg2000Input::read_scanline(int y, int z, void* data)
+Jpeg2000Input::read_scanline(int y, int /*z*/, void* data)
 {
     T* scanline = static_cast<T*>(data);
     int nc      = m_spec.nchannels;

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -26,7 +26,7 @@ openjpeg_error_callback(const char* msg, void* data)
 
 
 static void
-openjpeg_dummy_callback(const char* msg, void* data)
+openjpeg_dummy_callback(const char* /*msg*/, void* /*data*/)
 {
 }
 
@@ -421,7 +421,7 @@ Jpeg2000Output::create_compressor()
 
 template<typename T>
 void
-Jpeg2000Output::write_scanline(int y, int z, const void* data)
+Jpeg2000Output::write_scanline(int y, int /*z*/, const void* data)
 {
     int bits                  = sizeof(T) * 8;
     const T* scanline         = static_cast<const T*>(data);

--- a/src/libOpenImageIO/exif-canon.cpp
+++ b/src/libOpenImageIO/exif-canon.cpp
@@ -747,7 +747,7 @@ static LabelIndex canon_shotinfo_indices[] = {
 };
 
 static void
-canon_shotinfo_handler (const TagInfo& taginfo, const TIFFDirEntry& dir,
+canon_shotinfo_handler (const TagInfo& /*taginfo*/, const TIFFDirEntry& dir,
                         cspan<uint8_t> buf, ImageSpec& spec,
                         bool swapendian, int offset_adjustment)
 {
@@ -761,7 +761,7 @@ static LabelIndex canon_panorama_indices[] = {
 };
 
 static void
-canon_panorama_handler (const TagInfo& taginfo, const TIFFDirEntry& dir,
+canon_panorama_handler (const TagInfo& /*taginfo*/, const TIFFDirEntry& dir,
                         cspan<uint8_t> buf, ImageSpec& spec,
                         bool swapendian, int offset_adjustment)
 {
@@ -782,7 +782,7 @@ static LabelIndex canon_sensorinfo_indices[] = {
 };
 
 static void
-canon_sensorinfo_handler (const TagInfo& taginfo, const TIFFDirEntry& dir,
+canon_sensorinfo_handler (const TagInfo& /*taginfo*/, const TIFFDirEntry& dir,
                           cspan<uint8_t> buf, ImageSpec& spec,
                           bool swapendian, int offset_adjustment)
 {

--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -327,7 +327,7 @@ dumpdata(cspan<uint8_t> blob, cspan<size_t> ifdoffsets, size_t start,
 static void
 version4char_handler(const TagInfo& taginfo, const TIFFDirEntry& dir,
                      cspan<uint8_t> buf, ImageSpec& spec,
-                     bool swapendian = false, int offset_adjustment = 0)
+                     bool /*swapendian*/ = false, int offset_adjustment = 0)
 {
     const char* data = (const char*)dataptr(dir, buf, offset_adjustment);
     if (tiff_data_size(dir) == 4 && data != nullptr)  // sanity check
@@ -338,7 +338,7 @@ version4char_handler(const TagInfo& taginfo, const TIFFDirEntry& dir,
 static void
 version4uint8_handler(const TagInfo& taginfo, const TIFFDirEntry& dir,
                       cspan<uint8_t> buf, ImageSpec& spec,
-                      bool swapendian = false, int offset_adjustment = 0)
+                      bool /*swapendian*/ = false, int offset_adjustment = 0)
 {
     const char* data = (const char*)dataptr(dir, buf, offset_adjustment);
     if (tiff_data_size(dir) == 4 && data != nullptr)  // sanity check
@@ -348,7 +348,7 @@ version4uint8_handler(const TagInfo& taginfo, const TIFFDirEntry& dir,
 
 
 static void
-makernote_handler(const TagInfo& taginfo, const TIFFDirEntry& dir,
+makernote_handler(const TagInfo& /*taginfo*/, const TIFFDirEntry& dir,
                   cspan<uint8_t> buf, ImageSpec& spec, bool swapendian = false,
                   int offset_adjustment = 0)
 {

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -696,7 +696,7 @@ text_size_from_unicode(std::vector<uint32_t>& utext, FT_Face face)
 // If not found, return false and put an error message in result.
 // Not thread-safe! The caller must use the mutex.
 static bool
-resolve_font(int fontsize, string_view font_, std::string& result)
+resolve_font(string_view font_, std::string& result)
 {
     result.clear();
 
@@ -825,7 +825,7 @@ ImageBufAlgo::text_size(string_view text, int fontsize, string_view font_)
     lock_guard ft_lock(ft_mutex);
 
     std::string font;
-    bool ok = resolve_font(fontsize, font_, font);
+    bool ok = resolve_font(font_, font);
     if (!ok) {
         return size;
     }
@@ -894,7 +894,7 @@ ImageBufAlgo::render_text(ImageBuf& R, int x, int y, string_view text,
     lock_guard ft_lock(ft_mutex);
 
     std::string font;
-    bool ok = resolve_font(fontsize, font_, font);
+    bool ok = resolve_font(font_, font);
     if (!ok) {
         std::string err = font.size() ? font : "Font error";
         R.errorf("%s", err);

--- a/src/libOpenImageIO/imageinout_test.cpp
+++ b/src/libOpenImageIO/imageinout_test.cpp
@@ -173,8 +173,7 @@ test_read_proxy(string_view formatname, string_view extension,
 // Test writer's ability to detect and recover from errors when asked to
 // write an unwriteable file (such as in a nonexistent directory).
 static bool
-test_write_unwriteable(string_view formatname, string_view extension,
-                       const ImageBuf& buf)
+test_write_unwriteable(string_view extension, const ImageBuf& buf)
 {
     bool ok = true;
     Sysutil::Term term(stdout);
@@ -278,7 +277,7 @@ test_all_formats()
         // directory. It should not crash! But appropriately return some
         // error.
         //
-        test_write_unwriteable(formatname, extensions[0], buf);
+        test_write_unwriteable(extensions[0], buf);
 
         Filesystem::remove(filename);
     }

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -681,8 +681,8 @@ ImageInput::read_tiles(int subimage, int miplevel, int xbegin, int xend,
 
 
 bool
-ImageInput::read_native_tile(int subimage, int miplevel, int x, int y, int z,
-                             void* data)
+ImageInput::read_native_tile(int /*subimage*/, int /*miplevel*/, int /*x*/,
+                             int /*y*/, int /*z*/, void* /*data*/)
 {
     // The base class read_native_tile fails. A format reader that supports
     // tiles MUST overload this virtual method that reads a single tile
@@ -926,9 +926,10 @@ ImageInput::read_image(int subimage, int miplevel, int chbegin, int chend,
 
 
 bool
-ImageInput::read_native_deep_scanlines(int subimage, int miplevel, int ybegin,
-                                       int yend, int z, int chbegin, int chend,
-                                       DeepData& deepdata)
+ImageInput::read_native_deep_scanlines(int /*subimage*/, int /*miplevel*/,
+                                       int /*ybegin*/, int /*yend*/, int /*z*/,
+                                       int /*chbegin*/, int /*chend*/,
+                                       DeepData& /*deepdata*/)
 {
     return false;  // default: doesn't support deep images
 }
@@ -936,10 +937,11 @@ ImageInput::read_native_deep_scanlines(int subimage, int miplevel, int ybegin,
 
 
 bool
-ImageInput::read_native_deep_tiles(int subimage, int miplevel, int xbegin,
-                                   int xend, int ybegin, int yend, int zbegin,
-                                   int zend, int chbegin, int chend,
-                                   DeepData& deepdata)
+ImageInput::read_native_deep_tiles(int /*subimage*/, int /*miplevel*/,
+                                   int /*xbegin*/, int /*xend*/, int /*ybegin*/,
+                                   int /*yend*/, int /*zbegin*/, int /*zend*/,
+                                   int /*chbegin*/, int /*chend*/,
+                                   DeepData& /*deepdata*/)
 {
     return false;  // default: doesn't support deep images
 }
@@ -980,7 +982,7 @@ ImageInput::read_native_deep_image(int subimage, int miplevel,
 
 
 int
-ImageInput::send_to_input(const char* format, ...)
+ImageInput::send_to_input(const char* /*format*/, ...)
 {
     // FIXME -- I can't remember how this is supposed to work
     return 0;
@@ -989,7 +991,7 @@ ImageInput::send_to_input(const char* format, ...)
 
 
 int
-ImageInput::send_to_client(const char* format, ...)
+ImageInput::send_to_client(const char* /*format*/, ...)
 {
     // FIXME -- I can't remember how this is supposed to work
     return 0;

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -56,8 +56,8 @@ ImageOutput::~ImageOutput() {}
 
 
 bool
-ImageOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
-                            stride_t xstride)
+ImageOutput::write_scanline(int /*y*/, int /*z*/, TypeDesc /*format*/,
+                            const void* /*data*/, stride_t /*xstride*/)
 {
     // Default implementation: don't know how to write scanlines
     return false;
@@ -88,8 +88,9 @@ ImageOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
 
 
 bool
-ImageOutput::write_tile(int x, int y, int z, TypeDesc format, const void* data,
-                        stride_t xstride, stride_t ystride, stride_t zstride)
+ImageOutput::write_tile(int /*x*/, int /*y*/, int /*z*/, TypeDesc /*format*/,
+                        const void* /*data*/, stride_t /*xstride*/,
+                        stride_t /*ystride*/, stride_t /*zstride*/)
 {
     // Default implementation: don't know how to write tiles
     return false;
@@ -152,10 +153,11 @@ ImageOutput::write_tiles(int xbegin, int xend, int ybegin, int yend, int zbegin,
 
 
 bool
-ImageOutput::write_rectangle(int xbegin, int xend, int ybegin, int yend,
-                             int zbegin, int zend, TypeDesc format,
-                             const void* data, stride_t xstride,
-                             stride_t ystride, stride_t zstride)
+ImageOutput::write_rectangle(int /*xbegin*/, int /*xend*/, int /*ybegin*/,
+                             int /*yend*/, int /*zbegin*/, int /*zend*/,
+                             TypeDesc /*format*/, const void* /*data*/,
+                             stride_t /*xstride*/, stride_t /*ystride*/,
+                             stride_t /*zstride*/)
 {
     return false;
 }
@@ -163,8 +165,8 @@ ImageOutput::write_rectangle(int xbegin, int xend, int ybegin, int yend,
 
 
 bool
-ImageOutput::write_deep_scanlines(int ybegin, int yend, int z,
-                                  const DeepData& deepdata)
+ImageOutput::write_deep_scanlines(int /*ybegin*/, int /*yend*/, int /*z*/,
+                                  const DeepData& /*deepdata*/)
 {
     return false;  // default: doesn't support deep images
 }
@@ -172,8 +174,9 @@ ImageOutput::write_deep_scanlines(int ybegin, int yend, int z,
 
 
 bool
-ImageOutput::write_deep_tiles(int xbegin, int xend, int ybegin, int yend,
-                              int zbegin, int zend, const DeepData& deepdata)
+ImageOutput::write_deep_tiles(int /*xbegin*/, int /*xend*/, int /*ybegin*/,
+                              int /*yend*/, int /*zbegin*/, int /*zend*/,
+                              const DeepData& /*deepdata*/)
 {
     return false;  // default: doesn't support deep images
 }
@@ -205,7 +208,7 @@ ImageOutput::write_deep_image(const DeepData& deepdata)
 
 
 int
-ImageOutput::send_to_output(const char* format, ...)
+ImageOutput::send_to_output(const char* /*format*/, ...)
 {
     // FIXME -- I can't remember how this is supposed to work
     return 0;
@@ -214,7 +217,7 @@ ImageOutput::send_to_output(const char* format, ...)
 
 
 int
-ImageOutput::send_to_client(const char* format, ...)
+ImageOutput::send_to_client(const char* /*format*/, ...)
 {
     // FIXME -- I can't remember how this is supposed to work
     return 0;

--- a/src/libOpenImageIO/xmp.cpp
+++ b/src/libOpenImageIO/xmp.cpp
@@ -52,6 +52,15 @@ struct XMPtag {
     const char* oiioname;  // Attribute name we use
     TypeDesc oiiotype;     // Type we use
     int special;           // Special handling
+
+    XMPtag(const char* xname, const char* oname, TypeDesc type = TypeUnknown,
+           int spec = 0)
+        : xmpname(xname)
+        , oiioname(oname)
+        , oiiotype(type)
+        , special(spec)
+    {
+    }
 };
 
 static XMPtag xmptag[] = {
@@ -390,7 +399,7 @@ extract_middle(string_view str, size_t pos, string_view startmarker,
 
 static void
 decode_xmp_node(pugi::xml_node node, ImageSpec& spec, int level = 1,
-                const char* parentname = NULL, bool isList = false)
+                const char* parentname = NULL, bool /*isList*/ = false)
 {
     std::string mylist;  // will accumulate for list items
     for (; node; node = node.next_sibling()) {

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -261,7 +261,7 @@ ImageCacheFile::LevelInfo::LevelInfo(const LevelInfo& src)
 
 
 ImageCacheFile::ImageCacheFile(ImageCacheImpl& imagecache,
-                               ImageCachePerThreadInfo* thread_info,
+                               ImageCachePerThreadInfo* /*thread_info*/,
                                ustring filename, ImageInput::Creator creator,
                                const ImageSpec* config)
     : m_filename(filename)
@@ -322,7 +322,7 @@ ImageCacheFile::reset(ImageInput::Creator creator, const ImageSpec* config)
 
 
 std::shared_ptr<ImageInput>
-ImageCacheFile::get_imageinput(ImageCachePerThreadInfo* thread_info)
+ImageCacheFile::get_imageinput(ImageCachePerThreadInfo* /*thread_info*/)
 {
 #if defined(__GLIBCXX__) && __GLIBCXX__ < 20160822
     // Older gcc libstdc++ does not properly support std::atomic
@@ -1325,7 +1325,7 @@ ImageCacheImpl::clear_fingerprints()
 
 
 void
-ImageCacheImpl::check_max_files(ImageCachePerThreadInfo* thread_info)
+ImageCacheImpl::check_max_files(ImageCachePerThreadInfo* /*thread_info*/)
 {
 #if 0
     if (! (m_stat_open_files_created % 16) || m_stat_open_files_current >= m_max_open_files) {
@@ -2393,7 +2393,7 @@ ImageCacheImpl::add_tile_to_cache(ImageCacheTileRef& tile,
 
 
 void
-ImageCacheImpl::check_max_mem(ImageCachePerThreadInfo* thread_info)
+ImageCacheImpl::check_max_mem(ImageCachePerThreadInfo* /*thread_info*/)
 {
     OIIO_DASSERT(m_mem_used < (long long)m_max_memory_bytes * 10);  // sanity
 #if 0

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -901,7 +901,8 @@ public:
     }
 
     /// Is the tile specified by the TileID already in the cache?
-    bool tile_in_cache(const TileID& id, ImageCachePerThreadInfo* thread_info)
+    bool tile_in_cache(const TileID& id,
+                       ImageCachePerThreadInfo* /*thread_info*/)
     {
         TileCache::iterator found = m_tilecache.find(id);
         return (found != m_tilecache.end());

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -272,8 +272,9 @@ bool
 TextureSystemImpl::texture3d_lookup_nomip(
     TextureFile& texturefile, PerThreadInfo* thread_info, TextureOpt& options,
     int nchannels_result, int actualchannels, const Imath::V3f& P,
-    const Imath::V3f& dPdx, const Imath::V3f& dPdy, const Imath::V3f& dPdz,
-    float* result, float* dresultds, float* dresultdt, float* dresultdr)
+    const Imath::V3f& /*dPdx*/, const Imath::V3f& /*dPdy*/,
+    const Imath::V3f& /*dPdz*/, float* result, float* dresultds,
+    float* dresultdt, float* dresultdr)
 {
     // Initialize results to 0.  We'll add from here on as we sample.
     for (int c = 0; c < nchannels_result; ++c)

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -205,50 +205,54 @@ public:
                            float* result, float* dresultds = NULL,
                            float* dresultdt = NULL, float* dresultdr = NULL);
 
-    virtual bool shadow(ustring filename, TextureOpt& options,
-                        const Imath::V3f& P, const Imath::V3f& dPdx,
-                        const Imath::V3f& dPdy, float* result,
-                        float* dresultds = NULL, float* dresultdt = NULL)
+    virtual bool shadow(ustring /*filename*/, TextureOpt& /*options*/,
+                        const Imath::V3f& /*P*/, const Imath::V3f& /*dPdx*/,
+                        const Imath::V3f& /*dPdy*/, float* /*result*/,
+                        float* /*dresultds*/, float* /*dresultdt*/)
     {
         return false;
     }
-    virtual bool shadow(TextureHandle* texture_handle, Perthread* thread_info,
-                        TextureOpt& options, const Imath::V3f& P,
-                        const Imath::V3f& dPdx, const Imath::V3f& dPdy,
-                        float* result, float* dresultds = NULL,
-                        float* dresultdt = NULL)
+    virtual bool shadow(TextureHandle* /*texture_handle*/,
+                        Perthread* /*thread_info*/, TextureOpt& /*options*/,
+                        const Imath::V3f& /*P*/, const Imath::V3f& /*dPdx*/,
+                        const Imath::V3f& /*dPdy*/, float* /*result*/,
+                        float* /*dresultds*/, float* /*dresultdt*/)
     {
         return false;
     }
-    virtual bool shadow(ustring filename, TextureOptBatch& options,
-                        Tex::RunMask mask, const float* P, const float* dPdx,
-                        const float* dPdy, float* result,
-                        float* dresultds = nullptr, float* dresultdt = nullptr)
+    virtual bool shadow(ustring /*filename*/, TextureOptBatch& /*options*/,
+                        Tex::RunMask /*mask*/, const float* /*P*/,
+                        const float* /*dPdx*/, const float* /*dPdy*/,
+                        float* /*result*/, float* /*dresultds*/,
+                        float* /*dresultdt*/)
     {
         return false;
     }
-    virtual bool shadow(TextureHandle* texture_handle, Perthread* thread_info,
-                        TextureOptBatch& options, Tex::RunMask mask,
-                        const float* P, const float* dPdx, const float* dPdy,
-                        float* result, float* dresultds = nullptr,
-                        float* dresultdt = nullptr)
+    virtual bool shadow(TextureHandle* /*texture_handle*/,
+                        Perthread* /*thread_info*/,
+                        TextureOptBatch& /*options*/, Tex::RunMask /*mask*/,
+                        const float* /*P*/, const float* /*dPdx*/,
+                        const float* /*dPdy*/, float* /*result*/,
+                        float* /*dresultds*/, float* /*dresultdt*/)
     {
         return false;
     }
-    virtual bool shadow(ustring filename, TextureOptions& options,
-                        Runflag* runflags, int beginactive, int endactive,
-                        VaryingRef<Imath::V3f> P, VaryingRef<Imath::V3f> dPdx,
-                        VaryingRef<Imath::V3f> dPdy, float* result,
-                        float* dresultds = NULL, float* dresultdt = NULL)
+    virtual bool shadow(ustring /*filename*/, TextureOptions& /*options*/,
+                        Runflag* /*runflags*/, int /*beginactive*/,
+                        int /*endactive*/, VaryingRef<Imath::V3f> /*P*/,
+                        VaryingRef<Imath::V3f> /*dPdx*/,
+                        VaryingRef<Imath::V3f> /*dPdy*/, float* /*result*/,
+                        float* /*dresultds*/, float* /*dresultdt*/)
     {
         return false;
     }
-    virtual bool shadow(TextureHandle* texture_handle, Perthread* thread_info,
-                        TextureOptions& options, Runflag* runflags,
-                        int beginactive, int endactive,
-                        VaryingRef<Imath::V3f> P, VaryingRef<Imath::V3f> dPdx,
-                        VaryingRef<Imath::V3f> dPdy, float* result,
-                        float* dresultds = NULL, float* dresultdt = NULL)
+    virtual bool shadow(TextureHandle* /*texture_handle*/,
+                        Perthread* /*thread_info*/, TextureOptions& /*options*/,
+                        Runflag* /*runflags*/, int /*beginactive*/,
+                        int /*endactive*/, VaryingRef<Imath::V3f> /*P*/,
+                        VaryingRef<Imath::V3f> /*dPdx*/,
+                        VaryingRef<Imath::V3f> /*dPdy*/, float* /*result*/,
+                        float* /*dresultds*/, float* /*dresultdt*/)
     {
         return false;
     }

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -891,6 +891,36 @@ Filesystem::scan_for_matching_filenames(const std::string& pattern_,
 
 
 
+size_t
+Filesystem::IOProxy::read(void* /*buf*/, size_t /*size*/)
+{
+    return 0;
+}
+
+
+size_t
+Filesystem::IOProxy::write(const void* /*buf*/, size_t /*size*/)
+{
+    return 0;
+}
+
+
+size_t
+Filesystem::IOProxy::pread(void* /*buf*/, size_t /*size*/, int64_t /*offset*/)
+{
+    return 0;
+}
+
+
+size_t
+Filesystem::IOProxy::pwrite(const void* /*buf*/, size_t /*size*/,
+                            int64_t /*offset*/)
+{
+    return 0;
+}
+
+
+
 Filesystem::IOFile::IOFile(string_view filename, Mode mode)
     : IOProxy(filename, mode)
 {

--- a/src/null.imageio/nullimageio.cpp
+++ b/src/null.imageio/nullimageio.cpp
@@ -24,22 +24,27 @@ public:
     NullOutput() {}
     virtual ~NullOutput() {}
     virtual const char* format_name(void) const override { return "null"; }
-    virtual int supports(string_view feature) const override { return true; }
-    virtual bool open(const std::string& name, const ImageSpec& spec,
-                      OpenMode mode = Create) override
+    virtual int supports(string_view /*feature*/) const override
+    {
+        return true;
+    }
+    virtual bool open(const std::string& /*name*/, const ImageSpec& spec,
+                      OpenMode /*mode*/) override
     {
         m_spec = spec;
         return true;
     }
     virtual bool close() override { return true; }
-    virtual bool write_scanline(int y, int z, TypeDesc format, const void* data,
-                                stride_t xstride) override
+    virtual bool write_scanline(int /*y*/, int /*z*/, TypeDesc /*format*/,
+                                const void* /*data*/,
+                                stride_t /*xstride*/) override
     {
         return true;
     }
-    virtual bool write_tile(int x, int y, int z, TypeDesc format,
-                            const void* data, stride_t xstride,
-                            stride_t ystride, stride_t zstride) override
+    virtual bool write_tile(int /*x*/, int /*y*/, int /*z*/,
+                            TypeDesc /*format*/, const void* /*data*/,
+                            stride_t /*xstride*/, stride_t /*ystride*/,
+                            stride_t /*zstride*/) override
     {
         return true;
     }
@@ -56,7 +61,10 @@ public:
     virtual ~NullInput() {}
     virtual const char* format_name(void) const override { return "null"; }
     virtual bool valid_file(const std::string& filename) const override;
-    virtual int supports(string_view feature) const override { return true; }
+    virtual int supports(string_view /*feature*/) const override
+    {
+        return true;
+    }
     virtual bool open(const std::string& name, ImageSpec& newspec) override;
     virtual bool open(const std::string& name, ImageSpec& newspec,
                       const ImageSpec& config) override;
@@ -362,8 +370,8 @@ NullInput::seek_subimage(int subimage, int miplevel)
 
 
 bool
-NullInput::read_native_scanline(int subimage, int miplevel, int y, int z,
-                                void* data)
+NullInput::read_native_scanline(int /*subimage*/, int /*miplevel*/, int /*y*/,
+                                int /*z*/, void* data)
 {
     if (m_value.size()) {
         size_t s = m_spec.pixel_bytes();
@@ -378,8 +386,8 @@ NullInput::read_native_scanline(int subimage, int miplevel, int y, int z,
 
 
 bool
-NullInput::read_native_tile(int subimage, int miplevel, int x, int y, int z,
-                            void* data)
+NullInput::read_native_tile(int /*subimage*/, int /*miplevel*/, int /*x*/,
+                            int /*y*/, int /*z*/, void* data)
 {
     if (m_value.size()) {
         size_t s = m_spec.pixel_bytes();

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -762,7 +762,7 @@ template<typename IBLIMPL = IBAunary>
 class OiiotoolSimpleUnaryOp : public OiiotoolOp {
 public:
     OiiotoolSimpleUnaryOp(IBLIMPL opimpl, Oiiotool& ot, string_view opname,
-                          int argc, const char* argv[], int ninputs)
+                          int argc, const char* argv[], int /*ninputs*/)
         : OiiotoolOp(ot, opname, argc, argv, 1)
         , opimpl(opimpl)
     {
@@ -780,7 +780,7 @@ template<typename IBLIMPL = IBAbinary>
 class OiiotoolSimpleBinaryOp : public OiiotoolOp {
 public:
     OiiotoolSimpleBinaryOp(IBLIMPL opimpl, Oiiotool& ot, string_view opname,
-                           int argc, const char* argv[], int ninputs)
+                           int argc, const char* argv[], int /*ninputs*/)
         : OiiotoolOp(ot, opname, argc, argv, 2)
         , opimpl(opimpl)
     {
@@ -798,7 +798,7 @@ template<typename IBLIMPL = IBAbinary_img_col>
 class OiiotoolImageColorOp : public OiiotoolOp {
 public:
     OiiotoolImageColorOp(IBLIMPL opimpl, Oiiotool& ot, string_view opname,
-                         int argc, const char* argv[], int ninputs,
+                         int argc, const char* argv[], int /*ninputs*/,
                          float defaultval = 0.0f)
         : OiiotoolOp(ot, opname, argc, argv, 1)
         , opimpl(opimpl)

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -1190,7 +1190,7 @@ OpenEXRInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
 
 bool
 OpenEXRInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
-                                    int yend, int z, int chbegin, int chend,
+                                    int yend, int /*z*/, int chbegin, int chend,
                                     void* data)
 {
     lock_guard lock(m_mutex);

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -1286,8 +1286,8 @@ OpenEXROutput::close()
 
 
 bool
-OpenEXROutput::write_scanline(int y, int z, TypeDesc format, const void* data,
-                              stride_t xstride)
+OpenEXROutput::write_scanline(int y, int /*z*/, TypeDesc format,
+                              const void* data, stride_t xstride)
 {
     if (!(m_output_scanline || m_scanline_output_part)) {
         errorf("called OpenEXROutput::write_scanline without an open file");
@@ -1545,7 +1545,7 @@ OpenEXROutput::write_tiles(int xbegin, int xend, int ybegin, int yend,
 
 
 bool
-OpenEXROutput::write_deep_scanlines(int ybegin, int yend, int z,
+OpenEXROutput::write_deep_scanlines(int ybegin, int yend, int /*z*/,
                                     const DeepData& deepdata)
 {
     if (m_deep_scanline_output_part == NULL) {

--- a/src/openvdb.imageio/openvdbinput.cpp
+++ b/src/openvdb.imageio/openvdbinput.cpp
@@ -546,8 +546,8 @@ OpenVDBInput::open(const std::string& filename, ImageSpec& newspec)
 
 
 bool
-OpenVDBInput::read_native_scanline(int subimage, int miplevel, int y, int z,
-                                   void* data)
+OpenVDBInput::read_native_scanline(int /*subimage*/, int /*miplevel*/,
+                                   int /*y*/, int /*z*/, void* /*data*/)
 {
     // scanlines not supported
     return false;

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -53,10 +53,7 @@ rderr_handler(png_structp png, png_const_charp data)
 }
 
 
-static void
-rdwarn_handler(png_structp png, png_const_charp data)
-{
-}
+static void rdwarn_handler(png_structp /*png*/, png_const_charp /*data*/) {}
 
 
 
@@ -332,8 +329,8 @@ destroy_read_struct(png_structp& sp, png_infop& ip)
 }
 
 
-inline void
-null_png_errhandler(png_structp png, png_const_charp message)
+inline void null_png_errhandler(png_structp /*png*/,
+                                png_const_charp /*message*/)
 {
     // ignore
 }

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -270,7 +270,7 @@ associateAlpha(T* data, int size, int channels, int alpha_channel, float gamma)
 
 
 bool
-PNGInput::read_native_scanline(int subimage, int miplevel, int y, int z,
+PNGInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
     lock_guard lock(m_mutex);

--- a/src/psd.imageio/jpeg_memory_src.cpp
+++ b/src/psd.imageio/jpeg_memory_src.cpp
@@ -11,17 +11,11 @@
 
 namespace {
 
-void
-init_memory_source(j_decompress_ptr cinfo)
-{
-}
+void init_memory_source(j_decompress_ptr /*cinfo*/) {}
 
 
 
-void
-term_memory_source(j_decompress_ptr cinfo)
-{
-}
+void term_memory_source(j_decompress_ptr /*cinfo*/) {}
 
 
 

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -709,7 +709,7 @@ PSDInput::unassalpha_to_assocalpha(int n, void* data)
 
 
 bool
-PSDInput::read_native_scanline(int subimage, int miplevel, int y, int z,
+PSDInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
     lock_guard lock(m_mutex);
@@ -1067,8 +1067,7 @@ PSDInput::handle_resources(ImageResourceMap& resources)
     return true;
 }
 
-bool
-PSDInput::load_resource_1005(uint32_t length)
+bool PSDInput::load_resource_1005(uint32_t /*length*/)
 {
     ResolutionInfo resinfo;
     // Fixed 16.16
@@ -1131,8 +1130,7 @@ PSDInput::load_resource_1006(uint32_t length)
 
 
 
-bool
-PSDInput::load_resource_1010(uint32_t length)
+bool PSDInput::load_resource_1010(uint32_t /*length*/)
 {
     const double int8_to_dbl = 1.0 / 0xFF;
     int8_t color_id;
@@ -1167,8 +1165,7 @@ PSDInput::load_resource_1036(uint32_t length)
 
 
 
-bool
-PSDInput::load_resource_1047(uint32_t length)
+bool PSDInput::load_resource_1047(uint32_t /*length*/)
 {
     read_bige<int16_t>(m_transparency_index);
     if (m_transparency_index < 0 || m_transparency_index >= 768) {
@@ -1224,8 +1221,7 @@ PSDInput::load_resource_1060(uint32_t length)
 
 
 
-bool
-PSDInput::load_resource_1064(uint32_t length)
+bool PSDInput::load_resource_1064(uint32_t /*length*/)
 {
     uint32_t version;
     if (!read_bige<uint32_t>(version))

--- a/src/ptex.imageio/ptexinput.cpp
+++ b/src/ptex.imageio/ptexinput.cpp
@@ -255,8 +255,8 @@ PtexInput::close()
 
 
 bool
-PtexInput::read_native_scanline(int subimage, int miplevel, int y, int z,
-                                void* data)
+PtexInput::read_native_scanline(int /*subimage*/, int /*miplevel*/, int /*y*/,
+                                int /*z*/, void* /*data*/)
 {
     return false;  // Not scanline oriented
 }
@@ -264,7 +264,7 @@ PtexInput::read_native_scanline(int subimage, int miplevel, int y, int z,
 
 
 bool
-PtexInput::read_native_tile(int subimage, int miplevel, int x, int y, int z,
+PtexInput::read_native_tile(int subimage, int miplevel, int x, int y, int /*z*/,
                             void* data)
 {
     lock_guard lock(m_mutex);

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -110,7 +110,7 @@ private:
             m_spec.attribute(prefixedname(prefix, name), data);
     }
     void add(string_view prefix, std::string name, string_view data,
-             bool force = true, int ignval = 0)
+             bool force = true, int /*ignval*/ = 0)
     {
         if (force || (data.size() && data[0]))
             m_spec.attribute(prefixedname(prefix, name), data);
@@ -1156,7 +1156,7 @@ RawInput::process()
 
 
 bool
-RawInput::read_native_scanline(int subimage, int miplevel, int y, int z,
+RawInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
     lock_guard lock(m_mutex);

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -482,7 +482,7 @@ RLAInput::decode_rle_span(unsigned char* buf, int n, int stride,
 
 bool
 RLAInput::decode_channel_group(int first_channel, short num_channels,
-                               short num_bits, int y)
+                               short num_bits, int /*y*/)
 {
     // Some preliminaries -- figure out various sizes and offsets
     int chsize;         // size of the channels in this group, in bytes
@@ -608,7 +608,7 @@ RLAInput::decode_channel_group(int first_channel, short num_channels,
 
 
 bool
-RLAInput::read_native_scanline(int subimage, int miplevel, int y, int z,
+RLAInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
     lock_guard lock(m_mutex);

--- a/src/sgi.imageio/sgiinput.cpp
+++ b/src/sgi.imageio/sgiinput.cpp
@@ -114,7 +114,7 @@ SgiInput::open(const std::string& name, ImageSpec& spec)
 
 
 bool
-SgiInput::read_native_scanline(int subimage, int miplevel, int y, int z,
+SgiInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
     lock_guard lock(m_mutex);

--- a/src/socket.imageio/socket_pvt.cpp
+++ b/src/socket.imageio/socket_pvt.cpp
@@ -19,7 +19,7 @@ using namespace boost::asio;
 namespace socket_pvt {
 
 std::size_t
-socket_write(ip::tcp::socket& s, TypeDesc& type, const void* data, int size)
+socket_write(ip::tcp::socket& s, TypeDesc& /*type*/, const void* data, int size)
 {
     std::size_t bytes;
 

--- a/src/socket.imageio/socketinput.cpp
+++ b/src/socket.imageio/socketinput.cpp
@@ -88,8 +88,8 @@ SocketInput::open(const std::string& name, ImageSpec& newspec,
 
 
 bool
-SocketInput::read_native_scanline(int subimage, int miplevel, int y, int z,
-                                  void* data)
+SocketInput::read_native_scanline(int subimage, int miplevel, int /*y*/,
+                                  int /*z*/, void* data)
 {
     lock_guard lock(m_mutex);
     if (!seek_subimage(subimage, miplevel))
@@ -111,8 +111,8 @@ SocketInput::read_native_scanline(int subimage, int miplevel, int y, int z,
 
 
 bool
-SocketInput::read_native_tile(int subimage, int miplevel, int x, int y, int z,
-                              void* data)
+SocketInput::read_native_tile(int subimage, int miplevel, int /*x*/, int /*y*/,
+                              int /*z*/, void* data)
 {
     lock_guard lock(m_mutex);
     if (!seek_subimage(subimage, miplevel))

--- a/src/socket.imageio/socketoutput.cpp
+++ b/src/socket.imageio/socketoutput.cpp
@@ -41,7 +41,7 @@ SocketOutput::supports(string_view feature) const
 
 bool
 SocketOutput::open(const std::string& name, const ImageSpec& newspec,
-                   OpenMode mode)
+                   OpenMode /*mode*/)
 {
     if (!(connect_to_server(name) && send_spec_to_server(newspec))) {
         return false;
@@ -58,8 +58,8 @@ SocketOutput::open(const std::string& name, const ImageSpec& newspec,
 
 
 bool
-SocketOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
-                             stride_t xstride)
+SocketOutput::write_scanline(int /*y*/, int /*z*/, TypeDesc format,
+                             const void* data, stride_t xstride)
 {
     data = to_native_scanline(format, data, xstride, m_scratch);
 
@@ -81,8 +81,9 @@ SocketOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
 
 
 bool
-SocketOutput::write_tile(int x, int y, int z, TypeDesc format, const void* data,
-                         stride_t xstride, stride_t ystride, stride_t zstride)
+SocketOutput::write_tile(int /*x*/, int /*y*/, int /*z*/, TypeDesc format,
+                         const void* data, stride_t xstride, stride_t ystride,
+                         stride_t zstride)
 {
     data = to_native_tile(format, data, xstride, ystride, zstride, m_scratch);
 
@@ -111,7 +112,7 @@ SocketOutput::close()
 
 
 bool
-SocketOutput::copy_image(ImageInput* in)
+SocketOutput::copy_image(ImageInput* /*in*/)
 {
     return true;
 }

--- a/src/softimage.imageio/softimageinput.cpp
+++ b/src/softimage.imageio/softimageinput.cpp
@@ -151,8 +151,8 @@ SoftimageInput::open(const std::string& name, ImageSpec& spec)
 
 
 bool
-SoftimageInput::read_native_scanline(int subimage, int miplevel, int y, int z,
-                                     void* data)
+SoftimageInput::read_native_scanline(int subimage, int miplevel, int y,
+                                     int /*z*/, void* data)
 {
     lock_guard lock(m_mutex);
     if (!seek_subimage(subimage, miplevel))


### PR DESCRIPTION
More warning suppression: no code changes, just comment out names of unused params.