### PR TITLE
More fixes for problems found by -Wextra

### DIFF
--- a/src/ico.imageio/icoinput.cpp
+++ b/src/ico.imageio/icoinput.cpp
@@ -274,8 +274,7 @@ ICOInput::readimg()
 {
     if (m_png) {
         // subimage is a PNG
-        std::string s = PNG_pvt::read_into_buffer(m_png, m_info, m_spec, m_bpp,
-                                                  m_color_type, m_buf);
+        std::string s = PNG_pvt::read_into_buffer(m_png, m_info, m_spec, m_buf);
 
         //std::cerr << "[ico] PNG buffer size = " << m_buf.size () << "\n";
 

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -589,7 +589,7 @@ IvGL::paintGL()
             // FIXME: This can get too slow. Some ideas: avoid sending the tex
             // images more than necessary, figure an optimum texture size, use
             // multiple texture objects.
-            load_texture(xstart, ystart, tile_width, tile_height, percent);
+            load_texture(xstart, ystart, tile_width, tile_height);
             gl_rect(xstart, ystart, xstart + tile_width, ystart + tile_height,
                     0, smin, tmin, smax, tmax);
             percent += tile_advance;
@@ -1440,7 +1440,7 @@ IvGL::typespec_to_opengl(const ImageSpec& spec, int nchannels, GLenum& gltype,
 
 
 void
-IvGL::load_texture(int x, int y, int width, int height, float percent)
+IvGL::load_texture(int x, int y, int width, int height)
 {
     const ImageSpec& spec = m_current_image->spec();
     // Find if this has already been loaded.
@@ -1452,11 +1452,6 @@ IvGL::load_texture(int x, int y, int width, int height, float percent)
         }
     }
 
-    // Disabling progress report. Seems clear after some research that we cannot
-    // update the bar (not even with a signal) within a paint function without
-    // messing up the openGL context
-    //m_viewer.statusProgress->setValue ((int)(percent*100));
-    //m_viewer.statusProgress->update ();
     setCursor(Qt::WaitCursor);
 
     int nchannels = spec.nchannels;

--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -193,7 +193,7 @@ private:
 
     /// Loads the given patch of the image, but first figures if it's already
     /// been loaded.
-    void load_texture(int x, int y, int width, int height, float percent);
+    void load_texture(int x, int y, int width, int height);
 
     /// Destroys shaders and selects fixed-function pipeline
     void create_shaders_abort(void);

--- a/src/libOpenImageIO/exif-canon.cpp
+++ b/src/libOpenImageIO/exif-canon.cpp
@@ -619,6 +619,7 @@ array_to_spec (ImageSpec& spec,                 // spec to put attribs into
                cspan<uint8_t> buf,              // raw buffer blob
                cspan<LabelIndex> indices,       // LabelIndex table
                int offset_adjustment,
+               bool swapendian,
                int na_value = std::numeric_limits<int>::max())
 {
     // Make sure it's the right tag type. Be tolerant of signed/unsigned
@@ -639,7 +640,9 @@ array_to_spec (ImageSpec& spec,                 // spec to put attribs into
         return;
     for (auto&& attr : indices) {
         if (attr.value < int(dir.tdir_count)) {
-            T ival = int (s[attr.value]);
+            T ival = s[attr.value];
+            if (swapendian)
+                swap_endian(&ival, 1);
             if (ival != na_value)
                 spec.attribute (attr.label, ival);
         }
@@ -693,7 +696,7 @@ canon_camerasettings_handler (const TagInfo& /*taginfo*/, const TIFFDirEntry& di
                               bool swapendian, int offset_adjustment)
 {
     array_to_spec<int16_t> (spec, dir, buf, canon_camerasettings_indices,
-                            offset_adjustment, -1);
+                            offset_adjustment, swapendian, -1);
 }
 
 
@@ -710,7 +713,8 @@ canon_focallength_handler (const TagInfo& /*taginfo*/, const TIFFDirEntry& dir,
                            cspan<uint8_t> buf, ImageSpec& spec,
                            bool swapendian, int offset_adjustment)
 {
-    array_to_spec<uint16_t> (spec, dir, buf, canon_focallength_indices, offset_adjustment);
+    array_to_spec<uint16_t> (spec, dir, buf, canon_focallength_indices,
+                             offset_adjustment, swapendian);
 }
 
 
@@ -751,7 +755,8 @@ canon_shotinfo_handler (const TagInfo& /*taginfo*/, const TIFFDirEntry& dir,
                         cspan<uint8_t> buf, ImageSpec& spec,
                         bool swapendian, int offset_adjustment)
 {
-    array_to_spec<int16_t> (spec, dir, buf, canon_shotinfo_indices, offset_adjustment);
+    array_to_spec<int16_t> (spec, dir, buf, canon_shotinfo_indices,
+                            offset_adjustment, swapendian);
 }
 
 
@@ -765,7 +770,8 @@ canon_panorama_handler (const TagInfo& /*taginfo*/, const TIFFDirEntry& dir,
                         cspan<uint8_t> buf, ImageSpec& spec,
                         bool swapendian, int offset_adjustment)
 {
-    array_to_spec<int16_t> (spec, dir, buf, canon_panorama_indices, offset_adjustment);
+    array_to_spec<int16_t> (spec, dir, buf, canon_panorama_indices,
+                            offset_adjustment, swapendian);
 }
 
 static LabelIndex canon_sensorinfo_indices[] = {
@@ -786,7 +792,8 @@ canon_sensorinfo_handler (const TagInfo& /*taginfo*/, const TIFFDirEntry& dir,
                           cspan<uint8_t> buf, ImageSpec& spec,
                           bool swapendian, int offset_adjustment)
 {
-    array_to_spec<uint16_t> (spec, dir, buf, canon_sensorinfo_indices, offset_adjustment);
+    array_to_spec<uint16_t> (spec, dir, buf, canon_sensorinfo_indices,
+                             offset_adjustment, swapendian);
 }
 
 

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -841,9 +841,9 @@ add_dither(int nchannels, int width, int height, int depth, float* data,
 
 template<typename T>
 static void
-premult_impl(int nchannels, int width, int height, int depth, int chbegin,
-             int chend, T* data, stride_t xstride, stride_t ystride,
-             stride_t zstride, int alpha_channel, int z_channel)
+premult_impl(int width, int height, int depth, int chbegin, int chend, T* data,
+             stride_t xstride, stride_t ystride, stride_t zstride,
+             int alpha_channel, int z_channel)
 {
     char* plane = (char*)data;
     for (int z = 0; z < depth; ++z, plane += zstride) {
@@ -876,59 +876,49 @@ premult(int nchannels, int width, int height, int depth, int chbegin, int chend,
                            nchannels, width, height);
     switch (datatype.basetype) {
     case TypeDesc::FLOAT:
-        premult_impl(nchannels, width, height, depth, chbegin, chend,
-                     (float*)data, xstride, ystride, zstride, alpha_channel,
-                     z_channel);
+        premult_impl(width, height, depth, chbegin, chend, (float*)data,
+                     xstride, ystride, zstride, alpha_channel, z_channel);
         break;
     case TypeDesc::UINT8:
-        premult_impl(nchannels, width, height, depth, chbegin, chend,
-                     (unsigned char*)data, xstride, ystride, zstride,
-                     alpha_channel, z_channel);
+        premult_impl(width, height, depth, chbegin, chend, (unsigned char*)data,
+                     xstride, ystride, zstride, alpha_channel, z_channel);
         break;
     case TypeDesc::UINT16:
-        premult_impl(nchannels, width, height, depth, chbegin, chend,
+        premult_impl(width, height, depth, chbegin, chend,
                      (unsigned short*)data, xstride, ystride, zstride,
                      alpha_channel, z_channel);
         break;
     case TypeDesc::HALF:
-        premult_impl(nchannels, width, height, depth, chbegin, chend,
-                     (half*)data, xstride, ystride, zstride, alpha_channel,
-                     z_channel);
+        premult_impl(width, height, depth, chbegin, chend, (half*)data, xstride,
+                     ystride, zstride, alpha_channel, z_channel);
         break;
     case TypeDesc::INT8:
-        premult_impl(nchannels, width, height, depth, chbegin, chend,
-                     (char*)data, xstride, ystride, zstride, alpha_channel,
-                     z_channel);
+        premult_impl(width, height, depth, chbegin, chend, (char*)data, xstride,
+                     ystride, zstride, alpha_channel, z_channel);
         break;
     case TypeDesc::INT16:
-        premult_impl(nchannels, width, height, depth, chbegin, chend,
-                     (short*)data, xstride, ystride, zstride, alpha_channel,
-                     z_channel);
+        premult_impl(width, height, depth, chbegin, chend, (short*)data,
+                     xstride, ystride, zstride, alpha_channel, z_channel);
         break;
     case TypeDesc::INT:
-        premult_impl(nchannels, width, height, depth, chbegin, chend,
-                     (int*)data, xstride, ystride, zstride, alpha_channel,
-                     z_channel);
+        premult_impl(width, height, depth, chbegin, chend, (int*)data, xstride,
+                     ystride, zstride, alpha_channel, z_channel);
         break;
     case TypeDesc::UINT:
-        premult_impl(nchannels, width, height, depth, chbegin, chend,
-                     (unsigned int*)data, xstride, ystride, zstride,
-                     alpha_channel, z_channel);
+        premult_impl(width, height, depth, chbegin, chend, (unsigned int*)data,
+                     xstride, ystride, zstride, alpha_channel, z_channel);
         break;
     case TypeDesc::INT64:
-        premult_impl(nchannels, width, height, depth, chbegin, chend,
-                     (int64_t*)data, xstride, ystride, zstride, alpha_channel,
-                     z_channel);
+        premult_impl(width, height, depth, chbegin, chend, (int64_t*)data,
+                     xstride, ystride, zstride, alpha_channel, z_channel);
         break;
     case TypeDesc::UINT64:
-        premult_impl(nchannels, width, height, depth, chbegin, chend,
-                     (uint64_t*)data, xstride, ystride, zstride, alpha_channel,
-                     z_channel);
+        premult_impl(width, height, depth, chbegin, chend, (uint64_t*)data,
+                     xstride, ystride, zstride, alpha_channel, z_channel);
         break;
     case TypeDesc::DOUBLE:
-        premult_impl(nchannels, width, height, depth, chbegin, chend,
-                     (double*)data, xstride, ystride, zstride, alpha_channel,
-                     z_channel);
+        premult_impl(width, height, depth, chbegin, chend, (double*)data,
+                     xstride, ystride, zstride, alpha_channel, z_channel);
         break;
     default: OIIO_ASSERT(0 && "OIIO::premult() of an unsupported type"); break;
     }

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -409,9 +409,9 @@ private:
     /// Load the requested tile, from a file that's not really MIPmapped.
     /// Preconditions: the ImageInput is already opened, and we already did
     /// a seek_subimage to the right subimage.
-    bool read_unmipped(ImageCachePerThreadInfo* thread_info, ImageInput* inp,
-                       int subimage, int miplevel, int x, int y, int z,
-                       int chbegin, int chend, TypeDesc format, void* data);
+    bool read_unmipped(ImageCachePerThreadInfo* thread_info, int subimage,
+                       int miplevel, int x, int y, int z, int chbegin,
+                       int chend, TypeDesc format, void* data);
 
     // Initialize a bunch of fields based on the ImageSpec.
     // FIXME -- this is actually deeply flawed, many of these things only
@@ -868,10 +868,11 @@ public:
     /// If header_only is true, we are finding the file only for the sake
     /// of header information (e.g., called by get_image_info).
     /// A call to verify_file() is still needed after find_file().
-    ImageCacheFile*
-    find_file(ustring filename, ImageCachePerThreadInfo* thread_info,
-              ImageInput::Creator creator = nullptr, bool header_only = false,
-              const ImageSpec* config = nullptr, bool replace = false);
+    ImageCacheFile* find_file(ustring filename,
+                              ImageCachePerThreadInfo* thread_info,
+                              ImageInput::Creator creator = nullptr,
+                              const ImageSpec* config     = nullptr,
+                              bool replace                = false);
 
     /// Verify & prep the ImageCacheFile record for the named image,
     /// return the pointer (which may have changed for deduplication),

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4814,9 +4814,8 @@ input_file(int argc, const char* argv[])
             pio.metamatch          = ot.printinfo_metamatch;
             pio.nometamatch        = ot.printinfo_nometamatch;
             pio.infoformat         = infoformat;
-            long long totalsize    = 0;
             std::string error;
-            bool ok = OiioTool::print_info(ot, filename, pio, totalsize, error);
+            bool ok = OiioTool::print_info(ot, filename, pio, error);
             if (!ok)
                 ot.error("read", error);
             ot.printed_info = true;

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -526,8 +526,7 @@ struct print_info_options {
 // an error (in which case the error message will be stored in 'error').
 bool
 print_info(Oiiotool& ot, const std::string& filename,
-           const print_info_options& opt, long long& totalsize,
-           std::string& error);
+           const print_info_options& opt, std::string& error);
 
 
 // Set an attribute of the given image.  The type should be one of

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -723,8 +723,7 @@ print_info_subimage(Oiiotool& ot, int current_subimage, int num_of_subimages,
 
 bool
 OiioTool::print_info(Oiiotool& ot, const std::string& filename,
-                     const print_info_options& opt, long long& totalsize,
-                     std::string& error)
+                     const print_info_options& opt, std::string& error)
 {
     error.clear();
     auto input = ImageInput::open(filename, &ot.input_config);

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -266,7 +266,6 @@ read_info(png_structp& sp, png_infop& ip, int& bit_depth, int& color_type,
 ///
 inline const std::string
 read_into_buffer(png_structp& sp, png_infop& ip, ImageSpec& spec,
-                 int& bit_depth, int& color_type,
                  std::vector<unsigned char>& buffer)
 {
     // Must call this setjmp in every function that does PNG reads

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -202,8 +202,7 @@ PNGInput::open(const std::string& name, ImageSpec& newspec,
 bool
 PNGInput::readimg()
 {
-    std::string s = PNG_pvt::read_into_buffer(m_png, m_info, m_spec,
-                                              m_bit_depth, m_color_type, m_buf);
+    std::string s = PNG_pvt::read_into_buffer(m_png, m_info, m_spec, m_buf);
     if (s.length()) {
         close();
         errorf("%s", s);

--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -59,8 +59,8 @@ private:
 
     /// Helper function: decode a pixel.
     inline void decode_pixel(unsigned char* in, unsigned char* out,
-                             unsigned char* palette, int& bytespp,
-                             int& palbytespp, int& alphabits);
+                             unsigned char* palette, int bytespp,
+                             int palbytespp);
 
     /// Helper: read, with error detection
     ///
@@ -437,7 +437,7 @@ TGAInput::open(const std::string& name, ImageSpec& newspec)
                         if (!fread(in, bytespp, 1))
                             return false;
                         decode_pixel(in, pixel, palette.get(), bytespp,
-                                     palbytespp, alphabits);
+                                     palbytespp);
                         memcpy(&m_buf[y * buf.c[0] * m_spec.nchannels
                                       + x * m_spec.nchannels],
                                pixel, m_spec.nchannels);
@@ -483,8 +483,7 @@ TGAInput::open(const std::string& name, ImageSpec& newspec,
 
 inline void
 TGAInput::decode_pixel(unsigned char* in, unsigned char* out,
-                       unsigned char* palette, int& bytespp, int& palbytespp,
-                       int& alphabits)
+                       unsigned char* palette, int bytespp, int palbytespp)
 {
     unsigned int k = 0;
     // I hate nested switches...
@@ -642,8 +641,7 @@ TGAInput::readimg()
             for (int64_t x = 0; x < m_spec.width; x++) {
                 if (!fread(in, bytespp, 1))
                     return false;
-                decode_pixel(in, pixel, palette, bytespp, palbytespp,
-                             alphabits);
+                decode_pixel(in, pixel, palette, bytespp, palbytespp);
                 memcpy(&m_buf[y * m_spec.width * m_spec.nchannels
                               + x * m_spec.nchannels],
                        pixel, m_spec.nchannels);
@@ -658,8 +656,7 @@ TGAInput::readimg()
                 if (!fread(in, 1 + bytespp, 1))
                     return false;
                 packet_size = 1 + (in[0] & 0x7f);
-                decode_pixel(&in[1], pixel, palette, bytespp, palbytespp,
-                             alphabits);
+                decode_pixel(&in[1], pixel, palette, bytespp, palbytespp);
                 if (in[0] & 0x80) {  // run length packet
                     /*std::cerr << "[tga] run length packet "
                               << packet_size << "\n";*/
@@ -700,7 +697,7 @@ TGAInput::readimg()
                             if (!fread(&in[1], bytespp, 1))
                                 return false;
                             decode_pixel(&in[1], pixel, palette, bytespp,
-                                         palbytespp, alphabits);
+                                         palbytespp);
                         }
                     }
                 }

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -204,7 +204,7 @@ getargs(int argc, const char* argv[])
 
 
 static void
-initialize_opt(TextureOpt& opt, int nchannels)
+initialize_opt(TextureOpt& opt)
 {
     opt.sblur  = sblur;
     opt.tblur  = tblur >= 0.0f ? tblur : sblur;
@@ -212,8 +212,7 @@ initialize_opt(TextureOpt& opt, int nchannels)
     opt.swidth = width;
     opt.twidth = width;
     opt.rwidth = width;
-    //    opt.nchannels = nchannels;
-    opt.fill = (fill >= 0.0f) ? fill : 1.0f;
+    opt.fill   = (fill >= 0.0f) ? fill : 1.0f;
     if (missing[0] >= 0)
         opt.missingcolor = (float*)&missing;
     TextureOpt::parse_wrapmodes(wrapmodes.c_str(), opt.swrap, opt.twrap);
@@ -226,7 +225,7 @@ initialize_opt(TextureOpt& opt, int nchannels)
 
 
 static void
-initialize_opt(TextureOptBatch& opt, int nchannels)
+initialize_opt(TextureOptBatch& opt)
 {
     using namespace Tex;
     FloatWide sb(sblur);
@@ -541,7 +540,7 @@ plain_tex_region(ImageBuf& image, ustring filename, Mapping2D mapping,
     int nchannels = nchannels_override ? nchannels_override : image.nchannels();
 
     TextureOpt opt;
-    initialize_opt(opt, nchannels);
+    initialize_opt(opt);
 
     float* result    = OIIO_ALLOCA(float, std::max(3, nchannels));
     float* dresultds = test_derivs ? OIIO_ALLOCA(float, nchannels) : NULL;
@@ -656,7 +655,7 @@ plain_tex_region_batch(ImageBuf& image, ustring filename, Mapping2DWide mapping,
                  || image_dt->spec().format == TypeDesc::FLOAT);
 
     TextureOptBatch opt;
-    initialize_opt(opt, nchannels);
+    initialize_opt(opt);
 
     int nc               = std::max(3, nchannels);
     FloatWide* result    = OIIO_ALLOCA(FloatWide, nc);
@@ -780,7 +779,7 @@ tex3d_region(ImageBuf& image, ustring filename, Mapping3D mapping, ROI roi)
     int nchannels = nchannels_override ? nchannels_override : image.nchannels();
 
     TextureOpt opt;
-    initialize_opt(opt, nchannels);
+    initialize_opt(opt);
     opt.fill = (fill >= 0.0f) ? fill : 0.0f;
     //    opt.swrap = opt.twrap = opt.rwrap = TextureOpt::WrapPeriodic;
 
@@ -823,7 +822,7 @@ tex3d_region_batch(ImageBuf& image, ustring filename, Mapping3DWide mapping,
     int nchannels = nchannels_override ? nchannels_override : image.nchannels();
 
     TextureOptBatch opt;
-    initialize_opt(opt, nchannels);
+    initialize_opt(opt);
     opt.fill = (fill >= 0.0f) ? fill : 0.0f;
     //    opt.swrap = opt.twrap = opt.rwrap = TextureOpt::WrapPeriodic;
 
@@ -967,7 +966,7 @@ test_getimagespec_gettexels(ustring filename)
     ImageSpec postagespec(w, h, nchannels, TypeDesc::FLOAT);
     ImageBuf buf(postagespec);
     TextureOpt opt;
-    initialize_opt(opt, nchannels);
+    initialize_opt(opt);
     std::vector<float> tmp(w * h * nchannels);
     int x = spec.x + spec.width / 2 - w / 2;
     int y = spec.y + spec.height / 2 - h / 2;
@@ -1130,7 +1129,7 @@ do_tex_thread_workout(int iterations, int mythread)
     int nchannels = nchannels_override ? nchannels_override : 3;
     float* result = OIIO_ALLOCA(float, nchannels);
     TextureOpt opt;
-    initialize_opt(opt, nchannels);
+    initialize_opt(opt);
     float* dresultds = test_derivs ? OIIO_ALLOCA(float, nchannels) : NULL;
     float* dresultdt = test_derivs ? OIIO_ALLOCA(float, nchannels) : NULL;
     TextureSystem::Perthread* perthread_info = texsys->get_perthread_info();


### PR DESCRIPTION
More actual (unreported) buglets revealed by -Wextra pointing out function
parameters that were unused.

* Failed to properly swap endianness when decoding Canon camera info.

* ColorProcessor::apply methods were not using chanstride param.

* texture3d fixes: some deriv results dropped on the floor

* Get rid of unused parameters in some internal functions. Not a bug
  per se, but could be misleading about how the functions operate.

