### PR TITLE
Add IOProxy interface to ImageBuf

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -191,7 +191,7 @@ jobs:
 
   clang-format:
     name: "clang-format verification"
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v1
       - name: all

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,21 @@ New minimum dependencies:
 New file format support:
 
 Public API changes:
+* ImageInput and ImageOutput now have direct API level support for IOProxy
+  in their `open()` and `create()` calls, as well as a new `set_ioproxy()`
+  method in these classes.
+* ImageBuf:
+    - Easier direct use of IOProxy with ImageBuf: constructor and reset()
+      for file-reading ImageBuf now take an optional `IProxy*` parameter,
+      and a new `set_write_ioproxy()` method can supply an IOProxy for
+      subsequent `write()`. #2477 (2.2.1)
+    - Add `ImageBuf::setpixel()` methods that use cspan instead of ptr/len.
+      #2443 (2.1.10/2.2.0)
+    - Add "missing" `reset()` varieties so that every IB constructor has a
+      corresponding `reset()` with the same parameters and vice versa. #2460
+* ImageBufAlgo:
+    - New `repremult()` is like premult, but will not premult when alpha is
+      zero. #2447 (2.2.0)
 * Python bindings have been added for missing ParamValue constructors. We
   previously exposed the PV constructors from just a plain int, float, or
   string, but there wasn't an easy way to construct from arbitrary data like
@@ -14,17 +29,6 @@ Public API changes:
   attributes containing multiple values, now can have those values passed
   as Python lists and numpy arrays (previously they had to be tuples).
   #2437 (2.1.11/2.2.0)
-* ImageBuf:
-    - Add `ImageBuf::setpixel()` methods that use cspan instead of ptr/len.
-      #2443 (2.1.10/2.2.0)
-    - Add "missing" `reset()` varieties so that every IB constructor has a
-      corresponding `reset()` with the same parameters and vice versa. #2460
-* ImageBufAlgo:
-    - New `repremult()` is like premult, but will not premult when alpha is
-      zero. #2447 (2.2.0)
-* ImageInput and ImageOutput now have direct API level support for IOProxy
-  in their `open()` and `create()` calls, as well as a new `set_ioproxy()`
-  method in these classes.
 
 Performance improvements:
 * Greatly improved TextureSystem/ImageCache performance in highly threaded

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
 cmake_minimum_required (VERSION 3.12)
-project (OpenImageIO VERSION 2.2.0.1
+project (OpenImageIO VERSION 2.2.1.0
          HOMEPAGE_URL "https://openimageio.org"
          LANGUAGES CXX C)
 set (PROJ_NAME OIIO)    # short name, caps

--- a/src/doc/imagebuf.rst
+++ b/src/doc/imagebuf.rst
@@ -42,8 +42,8 @@ Making an empty or uninitialized ImageBuf
 Constructing a readable ImageBuf
 --------------------------------
 
-.. doxygenfunction:: OIIO::ImageBuf::ImageBuf(string_view, int, int, ImageCache *, const ImageSpec *)
-.. doxygenfunction:: OIIO::ImageBuf::reset(string_view, int, int, ImageCache *, const ImageSpec *)
+.. doxygenfunction:: OIIO::ImageBuf::ImageBuf(string_view, int, int, ImageCache *, const ImageSpec *, Filesystem::IOProxy *)
+.. doxygenfunction:: OIIO::ImageBuf::reset(string_view, int, int, ImageCache *, const ImageSpec *, Filesystem::IOProxy *)
 
 
 Constructing a writeable ImageBuf
@@ -74,6 +74,7 @@ Reading and Writing disk images
 .. doxygenfunction:: OIIO::ImageBuf::set_write_format(TypeDesc)
 .. doxygenfunction:: OIIO::ImageBuf::set_write_format(cspan<TypeDesc>)
 .. doxygenfunction:: OIIO::ImageBuf::set_write_tiles
+.. doxygenfunction:: OIIO::ImageBuf::set_write_ioproxy
 
 
 

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -122,10 +122,14 @@ public:
     ///             Optionally, a pointer to an ImageSpec whose metadata
     ///             contains configuration hints that set options related
     ///             to the opening and reading of the file.
+    /// @param ioproxy
+    ///         Optional pointer to an IOProxy to use when reading from the
+    ///         file. The caller retains ownership of the proxy.
     ///
     explicit ImageBuf(string_view name, int subimage = 0, int miplevel = 0,
-                      ImageCache* imagecache  = nullptr,
-                      const ImageSpec* config = nullptr);
+                      ImageCache* imagecache       = nullptr,
+                      const ImageSpec* config      = nullptr,
+                      Filesystem::IOProxy* ioproxy = nullptr);
 
     // Deprecated synonym for `ImageBuf(name, 0, 0, imagecache, nullptr)`.
     ImageBuf(string_view name, ImageCache* imagecache);
@@ -207,8 +211,9 @@ public:
     /// as if newly constructed with the same arguments, as a read-only
     /// representation of an existing image file.
     void reset(string_view name, int subimage, int miplevel,
-               ImageCache* imagecache  = nullptr,
-               const ImageSpec* config = nullptr);
+               ImageCache* imagecache       = nullptr,
+               const ImageSpec* config      = nullptr,
+               Filesystem::IOProxy* ioproxy = nullptr);
 
     /// Destroy any previous contents of the ImageBuf and re-initialize it
     /// as if newly constructed with the same arguments, as a read/write
@@ -475,6 +480,13 @@ public:
     /// tiling, or the tile dimensions requested, a suitable supported
     /// tiling choice will be made automatically.
     void set_write_tiles(int width = 0, int height = 0, int depth = 0);
+
+    /// Supply an IOProxy to use for a subsequent call to `write()`.
+    ///
+    /// If a proxy is set but it later turns out that the file format
+    /// selected does not support write proxies, then `write()` will fail
+    /// with an error.
+    void set_write_ioproxy(Filesystem::IOProxy* ioproxy);
 
     /// Write the pixels of the ImageBuf to an open ImageOutput. The
     /// ImageOutput must have already been opened with a spec that indicates

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -148,7 +148,7 @@ PNGInput::open(const std::string& name, ImageSpec& newspec)
         errorf("Could not open file \"%s\"", name);
         return false;
     }
-    m_io_offset = m_io->tell();
+    m_io->seek(0);
 
     unsigned char sig[8];
     if (m_io->pread(sig, sizeof(sig), 0) != sizeof(sig)
@@ -223,11 +223,6 @@ PNGInput::close()
         // If we allocated our own ioproxy, close it.
         m_io_local.reset();
         m_io = nullptr;
-    } else if (m_io) {
-        // We were passed an ioproxy from the user. Don't actually close it,
-        // just reset it to the original position. This makes it possible to
-        // "re-open".
-        m_io->seek(m_io_offset);
     }
     init();  // Reset to initial state
     return true;


### PR DESCRIPTION
Pass an optional IOProxy* to ImageBuf ctr for reading, supply via new
call set_write_ioproxy() to set one up for subsequent write().

This is much easier than fumbling around with a PTR attribute in the
configuration hints.

Add tests to imageinout_test to check that proxy reads and writes via
ImageBuf works for all the same file types as they did for ImageInput
and ImageOutput.

In the process, found some subtle bugs in the PNG proxy support, needs
to ensure it starts at the beginning when we open, or else multiple
open/close cycles (as will happen in some cases for ImageBuf) will
get all confused.
