### PR TITLE
Add concat function to ustring and Strutil

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -448,6 +448,12 @@ std::string join (const Sequence& seq, string_view sep /*= ""*/, size_t len)
     return out.str();
 }
 
+/// Concatenate two strings, returning a std::string, implemented carefully
+/// to not perform any redundant copies or allocations. This is
+/// semantically equivalent to `Strutil::sprintf("%s%s", s, t)`, but is
+/// more efficient.
+std::string OIIO_API concat(string_view s, string_view t);
+
 /// Repeat a string formed by concatenating str n times.
 std::string OIIO_API repeat (string_view str, int n);
 

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -665,6 +665,12 @@ public:
         return ustring(Strutil::format(fmt, args...));
     }
 
+    /// Concatenate two strings, returning a ustring, implemented carefully
+    /// to not perform any redundant copies or allocations. This is
+    /// semantically equivalent to `ustring::sprintf("%s%s", s, t)`, but is
+    /// more efficient.
+    static ustring concat(string_view s, string_view t);
+
     /// Generic stream output of a ustring.
     friend std::ostream& operator<<(std::ostream& out, const ustring& str)
     {

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -629,7 +629,7 @@ Strutil::concat(string_view s, string_view t)
     }
     memcpy(buf, s.data(), sl);
     memcpy(buf + sl, t.data(), tl);
-    return std::string(local_buf, len);
+    return std::string(buf, len);
 }
 
 
@@ -648,7 +648,7 @@ Strutil::repeat(string_view str, int n)
     }
     for (int i = 0; i < n; ++i)
         memcpy(buf + i * sl, str.data(), sl);
-    return std::string(local_buf, len);
+    return std::string(buf, len);
 }
 
 

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -615,12 +615,40 @@ Strutil::split(string_view str, std::vector<string_view>& result,
 
 
 std::string
+Strutil::concat(string_view s, string_view t)
+{
+    size_t sl  = s.size();
+    size_t tl  = t.size();
+    size_t len = sl + tl;
+    std::unique_ptr<char[]> heap_buf;
+    char local_buf[256];
+    char* buf = local_buf;
+    if (len > sizeof(local_buf)) {
+        heap_buf.reset(new char[len]);
+        buf = heap_buf.get();
+    }
+    memcpy(buf, s.data(), sl);
+    memcpy(buf + sl, t.data(), tl);
+    return std::string(local_buf, len);
+}
+
+
+
+std::string
 Strutil::repeat(string_view str, int n)
 {
-    std::ostringstream out;
-    while (n-- > 0)
-        out << str;
-    return out.str();
+    size_t sl  = str.size();
+    size_t len = sl * std::max(0, n);
+    std::unique_ptr<char[]> heap_buf;
+    char local_buf[256];
+    char* buf = local_buf;
+    if (len > sizeof(local_buf)) {
+        heap_buf.reset(new char[len]);
+        buf = heap_buf.get();
+    }
+    for (int i = 0; i < n; ++i)
+        memcpy(buf + i * sl, str.data(), sl);
+    return std::string(local_buf, len);
 }
 
 

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -415,6 +415,18 @@ test_join()
 
 
 void
+test_concat()
+{
+    std::cout << "Testing concat\n";
+    OIIO_CHECK_EQUAL(Strutil::concat("foo", "bar"), "foobar");
+    OIIO_CHECK_EQUAL(Strutil::concat("foo", ""), "foo");
+    OIIO_CHECK_EQUAL(Strutil::concat("", "foo"), "foo");
+    OIIO_CHECK_EQUAL(Strutil::concat("", ""), "");
+}
+
+
+
+void
 test_repeat()
 {
     std::cout << "Testing repeat\n";
@@ -1045,6 +1057,7 @@ main(int /*argc*/, char* /*argv*/[])
     test_strip();
     test_split();
     test_join();
+    test_concat();
     test_repeat();
     test_replace();
     test_excise_string_after_head();

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -422,6 +422,9 @@ test_concat()
     OIIO_CHECK_EQUAL(Strutil::concat("foo", ""), "foo");
     OIIO_CHECK_EQUAL(Strutil::concat("", "foo"), "foo");
     OIIO_CHECK_EQUAL(Strutil::concat("", ""), "");
+    std::string longstring(Strutil::repeat("01234567890", 100));
+    OIIO_CHECK_EQUAL(Strutil::concat(longstring, longstring),
+                     Strutil::sprintf("%s%s", longstring, longstring));
 }
 
 
@@ -434,6 +437,8 @@ test_repeat()
     OIIO_CHECK_EQUAL(Strutil::repeat("foo", 1), "foo");
     OIIO_CHECK_EQUAL(Strutil::repeat("foo", 0), "");
     OIIO_CHECK_EQUAL(Strutil::repeat("foo", -1), "");
+    OIIO_CHECK_EQUAL(Strutil::repeat("0123456789", 100),
+                     Strutil::repeat("01234567890123456789", 50));
 }
 
 

--- a/src/libutil/ustring.cpp
+++ b/src/libutil/ustring.cpp
@@ -436,7 +436,7 @@ ustring::concat(string_view s, string_view t)
     }
     memcpy(buf, s.data(), sl);
     memcpy(buf + sl, t.data(), tl);
-    return ustring(local_buf, len);
+    return ustring(buf, len);
 }
 
 

--- a/src/libutil/ustring.cpp
+++ b/src/libutil/ustring.cpp
@@ -419,6 +419,28 @@ ustring::make_unique(string_view strref)
     return result ? result : table.insert(strref, hash);
 }
 
+
+
+ustring
+ustring::concat(string_view s, string_view t)
+{
+    size_t sl  = s.size();
+    size_t tl  = t.size();
+    size_t len = sl + tl;
+    std::unique_ptr<char[]> heap_buf;
+    char local_buf[256];
+    char* buf = local_buf;
+    if (len > sizeof(local_buf)) {
+        heap_buf.reset(new char[len]);
+        buf = heap_buf.get();
+    }
+    memcpy(buf, s.data(), sl);
+    memcpy(buf + sl, t.data(), tl);
+    return ustring(local_buf, len);
+}
+
+
+
 std::string
 ustring::getstats(bool verbose)
 {

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -95,6 +95,9 @@ main(int argc, char* argv[])
     OIIO_CHECK_EQUAL(ustring::concat(foo, "bar"), "foobar");
     OIIO_CHECK_EQUAL(ustring::concat(foo, ""), "foo");
     OIIO_CHECK_EQUAL(ustring::concat("", foo), "foo");
+    ustring longstring(Strutil::repeat("01234567890", 100));
+    OIIO_CHECK_EQUAL(ustring::concat(longstring, longstring),
+                     ustring::sprintf("%s%s", longstring, longstring));
 
     const int nhw_threads = Sysutil::hardware_concurrency();
     std::cout << "hw threads = " << nhw_threads << "\n";

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -90,6 +90,11 @@ main(int argc, char* argv[])
     OIIO_CHECK_ASSERT(ustring("bar") != ustring("foo"));
     ustring foo("foo");
     OIIO_CHECK_ASSERT(foo.string() == "foo");
+    ustring bar("bar");
+    OIIO_CHECK_EQUAL(ustring::concat(foo, bar), "foobar");
+    OIIO_CHECK_EQUAL(ustring::concat(foo, "bar"), "foobar");
+    OIIO_CHECK_EQUAL(ustring::concat(foo, ""), "foo");
+    OIIO_CHECK_EQUAL(ustring::concat("", foo), "foo");
 
     const int nhw_threads = Sysutil::hardware_concurrency();
     std::cout << "hw threads = " << nhw_threads << "\n";


### PR DESCRIPTION
`concat(s,t)` is semantically equivalent to `sprintf("%s%s",s,t)`, but
concat carefully avoids copying any of the characters more than once,
and it performs at most one temporary allocation (typically it does
not allocate temp memory from the heap at all, if the sum of the
strings' lengths are not too long).

Added both a std::string-returning and a ustring-returning version.

Also reworked the implementation of `Strutil::repeat()` to similarly
perform at most one one temporary allocation (typically none) and
not perform any unnecessary copies.

Inspired by work Chris Kulla did in OSL.
