### PR TITLE
Fix dst-strides not begin honored for format conversion.

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -2003,8 +2003,7 @@ ImageBuf::get_pixels(ROI roi, TypeDesc format, void* result, stride_t xstride,
             roi.nchannels(), roi.width(), roi.height(), roi.depth(),
             pixeladdr(roi.xbegin, roi.ybegin, roi.zbegin, roi.chbegin),
             spec().format, pixel_stride(), scanline_stride(), z_stride(),
-            result, format, roi.nchannels() * format.size(), AutoStride,
-            AutoStride, threads());
+            result, format, xstride, ystride, zstride, threads());
     }
 
     // General case -- can handle IC-backed images.


### PR DESCRIPTION
## Description
The dst-stride parameters are being silently ignored, making RGB -> RGBA conversion fail.
