### PR TITLE
Fix relative path for oiiotool binary

### DIFF
--- a/src/doc/Makefile
+++ b/src/doc/Makefile
@@ -3,10 +3,10 @@
 include ../make/detectplatform.mk
 BUILDDIR := ../../build/${platform}
 ifeq (${OIIOTOOL},)
-  ifneq (${shell ls ${BUILDDIR}/src/oiiotool/oiiotool},)
-    OIIOTOOL := "${BUILDDIR}/src/oiiotool/oiiotool"
+  ifneq (${shell ls ${BUILDDIR}/bin/oiiotool},)
+    OIIOTOOL := "${BUILDDIR}/bin/oiiotool"
   else
-    OIIOTOOL := "../../build/src/oiiotool/oiiotool"
+    OIIOTOOL := "../../build/bin/oiiotool"
   endif
 endif
 


### PR DESCRIPTION
## Description
On latest release, relative path for 'oiiotool' binary on build has changed but the documentation Makefile doesn't reflect this change and it would fail on the doc creation stage.
