### PR TITLE
Improve fmath.h madd function

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -343,37 +343,42 @@ clamp (const simd::vfloat16& a, const simd::vfloat16& low, const simd::vfloat16&
 
 
 
+// For the multply+add (or sub) operations below, note that the results may
+// differ slightly on different hardware, depending on whether true fused
+// multiply and add is available or if the code generated just does an old
+// fashioned multiply followed by a separate add. So please interpret these
+// as "do a multiply and add as fast as possible for this hardware, with at
+// least as much precision as a multiply followed by a separate add."
+
 /// Fused multiply and add: (a*b + c)
-inline OIIO_HOSTDEVICE float madd (float a, float b, float c) {
-#if OIIO_FMA_ENABLED
-    // C++11 defines std::fma, which we assume is implemented using an
-    // intrinsic.
-    return std::fma (a, b, c);
-#else
+OIIO_FORCEINLINE OIIO_HOSTDEVICE float madd (float a, float b, float c) {
     // NOTE: GCC/ICC will turn this (for float) into a FMA unless
     // explicitly asked not to, clang will do so if -ffp-contract=fast.
+    OIIO_CLANG_PRAGMA(clang fp contract(fast))
     return a * b + c;
-#endif
 }
 
 
-/// Fused multiply and subtract: -(a*b - c)
-inline OIIO_HOSTDEVICE float msub (float a, float b, float c) {
-    return a * b - c; // Hope for the best
+/// Fused multiply and subtract: (a*b - c)
+OIIO_FORCEINLINE OIIO_HOSTDEVICE float msub (float a, float b, float c) {
+    OIIO_CLANG_PRAGMA(clang fp contract(fast))
+    return a * b - c;
 }
 
 
 
 /// Fused negative multiply and add: -(a*b) + c
-inline OIIO_HOSTDEVICE float nmadd (float a, float b, float c) {
-    return c - (a * b); // Hope for the best
+OIIO_FORCEINLINE OIIO_HOSTDEVICE float nmadd (float a, float b, float c) {
+    OIIO_CLANG_PRAGMA(clang fp contract(fast))
+    return c - (a * b);
 }
 
 
 
 /// Negative fused multiply and subtract: -(a*b) - c
-inline OIIO_HOSTDEVICE float nmsub (float a, float b, float c) {
-    return -(a * b) - c; // Hope for the best
+OIIO_FORCEINLINE OIIO_HOSTDEVICE float nmsub (float a, float b, float c) {
+    OIIO_CLANG_PRAGMA(clang fp contract(fast))
+    return -(a * b) - c;
 }
 
 

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -165,6 +165,18 @@ test_math_functions()
     OIIO_CHECK_EQUAL(sign(3.1f), 1.0f);
     OIIO_CHECK_EQUAL(sign(-3.1f), -1.0f);
     OIIO_CHECK_EQUAL(sign(0.0f), 0.0f);
+
+    {
+        float a = 2.5f, b = 1.5f, c = 8.5f;
+        clobber(a);
+        clobber(b);
+        clobber(c);
+        bench("madd fake a*b+c", [&]() { return DoNotOptimize(a * b + c); });
+        bench("madd(a,b,c)",
+              [&]() { return DoNotOptimize(OIIO::madd(a, b, c)); });
+        bench("std::fma(a,b,c)",
+              [&]() { return DoNotOptimize(std::fma(a, b, c)); });
+    }
     {
         float a = 2.5f, b = 1.5f, c = 8.5f;
         OIIO_CHECK_EQUAL(clamp(2.5f, 1.5f, 8.5f), 2.5f);


### PR DESCRIPTION
I was previously trying to use std::fma, but upon further investigation
it was turning into a single vfmadd instruction a lot less than I thought,
in many cases ending up as a function call (which itself was extra slow
when emulating fma on hardware that lacked it).

The better strategy seems to be just saying `a*b+c`, which on gcc &
icc compilers automatically turns into vfmadd when available on the
hardware, and adding a clang-specific pragma ensures this behavior for
clang as well.

Thanks to Alex Wells of Intel for pointing this out to me (in OSL land).
