### PR TITLE
Backport fmath performance and other fixes from OSL

### DIFF
--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -163,6 +163,22 @@
 #  define OIIO_APPLE_CLANG_VERSION 0
 #endif
 
+// Define OIIO_INTEL_COMPILER_VERSION to hold an encoded Intel compiler
+// version (e.g. 1900), or 0 if not an Intel compiler.
+#if defined(__INTEL_COMPILER)
+#  define OIIO_INTEL_COMPILER_VERSION __INTEL_COMPILER
+#else
+#  define OIIO_INTEL_COMPILER_VERSION 0
+#endif
+
+// Intel's compiler on OSX may still define __clang__ and we have need to
+// know when using a true clang compiler.
+#if !defined(__INTEL_COMPILER) && defined(__clang__)
+#  define OIIO_NON_INTEL_CLANG  __clang__
+#else
+#  define OIIO_NON_INTEL_CLANG  0
+#endif
+
 // Tests for MSVS versions, always 0 if not MSVS at all.
 #if defined(_MSC_VER)
 #  if _MSC_VER < 1900

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -19,6 +19,9 @@
 
 using namespace OIIO;
 
+// Aid for things that are too short to benchmark accurately
+#define REP10(x) x, x, x, x, x, x, x, x, x, x
+
 static int iterations = 1000000;
 static int ntrials    = 5;
 static bool verbose   = false;
@@ -139,9 +142,12 @@ test_math_functions()
     OIIO_CHECK_EQUAL(ifloor(0.999f), 0);
     OIIO_CHECK_EQUAL(ifloor(1.0f), 1);
     OIIO_CHECK_EQUAL(ifloor(1.001f), 1);
-    float fval = 1.1;
+    float fval = 1.1f;
     clobber(fval);
     bench("ifloor", [&]() { return DoNotOptimize(ifloor(fval)); });
+    fval = -1.1f;
+    clobber(fval);
+    bench("ifloor (neg)", [&]() { return DoNotOptimize(ifloor(fval)); });
 
     int ival;
     OIIO_CHECK_EQUAL_APPROX(floorfrac(0.0f, &ival), 0.0f);
@@ -165,6 +171,18 @@ test_math_functions()
     OIIO_CHECK_EQUAL(sign(3.1f), 1.0f);
     OIIO_CHECK_EQUAL(sign(-3.1f), -1.0f);
     OIIO_CHECK_EQUAL(sign(0.0f), 0.0f);
+
+    {
+        OIIO_CHECK_EQUAL(fast_neg(1.5f), -1.5f);
+        OIIO_CHECK_EQUAL(fast_neg(-1.5f), 1.5f);
+        OIIO_CHECK_EQUAL(fast_neg(0.0f), 0.0f);
+        OIIO_CHECK_EQUAL(fast_neg(-0.0f), 0.0f);
+        float x = -3.5f;
+        clobber(x);
+        bench("-float x10", [&]() { return REP10(DoNotOptimize(-x)); });
+        bench("fast_neg(float) x10",
+              [&]() { return REP10(DoNotOptimize(fast_neg(x))); });
+    }
 
     {
         float a = 2.5f, b = 1.5f, c = 8.5f;
@@ -191,6 +209,73 @@ test_math_functions()
               [&]() { return DoNotOptimize(clamp(b, a, c)); });
         bench("clamp(f,f,f) high",
               [&]() { return DoNotOptimize(clamp(c, b, a)); });
+    }
+
+    {
+        float x = 1.3f, y = 2.5f;
+        clobber(x, y);
+        bench("std::cos", [&]() { return DoNotOptimize(std::cos(x)); });
+        bench("fast_cos", [&]() { return DoNotOptimize(fast_cos(x)); });
+        bench("fast_cospi", [&]() { return DoNotOptimize(fast_cospi(x)); });
+        bench("std::sin", [&]() { return DoNotOptimize(std::sin(x)); });
+        bench("fast_sin", [&]() { return DoNotOptimize(fast_sin(x)); });
+        bench("fast_sinpi", [&]() { return DoNotOptimize(fast_sinpi(x)); });
+        bench("std::tan", [&]() { return DoNotOptimize(std::tan(x)); });
+        bench("fast_tan", [&]() { return DoNotOptimize(fast_tan(x)); });
+        bench("std::acos", [&]() { return DoNotOptimize(std::acos(x)); });
+        bench("fast_acos", [&]() { return DoNotOptimize(fast_acos(x)); });
+        bench("std::asin", [&]() { return DoNotOptimize(std::asin(x)); });
+        bench("fast_asin", [&]() { return DoNotOptimize(fast_asin(x)); });
+        bench("std::atan2", [&]() { return DoNotOptimize(std::atan2(y, x)); });
+        bench("fast_atan2", [&]() { return DoNotOptimize(fast_atan2(y, x)); });
+
+        bench("std::log2", [&]() { return DoNotOptimize(std::log2(x)); });
+        bench("fast_log2", [&]() { return DoNotOptimize(fast_log2(x)); });
+        bench("std::log", [&]() { return DoNotOptimize(std::log(x)); });
+        bench("fast_log", [&]() { return DoNotOptimize(fast_log(x)); });
+        bench("std::log10", [&]() { return DoNotOptimize(std::log10(x)); });
+        bench("fast_log10", [&]() { return DoNotOptimize(fast_log10(x)); });
+        bench("std::exp", [&]() { return DoNotOptimize(std::exp(x)); });
+        bench("fast_exp", [&]() { return DoNotOptimize(fast_exp(x)); });
+        bench("fast_correct_exp",
+              [&]() { return DoNotOptimize(fast_correct_exp(x)); });
+        bench("std::exp2", [&]() { return DoNotOptimize(std::exp2(x)); });
+        bench("fast_exp2", [&]() { return DoNotOptimize(fast_exp2(x)); });
+
+        OIIO_CHECK_EQUAL(safe_fmod(5.0f, 2.5f), 0.0f);
+        OIIO_CHECK_EQUAL(safe_fmod(-5.0f, 2.5f), 0.0f);
+        OIIO_CHECK_EQUAL(safe_fmod(-5.0f, -2.5f), 0.0f);
+        OIIO_CHECK_EQUAL(safe_fmod(5.5f, 2.5f), 0.5f);
+        OIIO_CHECK_EQUAL(safe_fmod(-5.5f, 2.5f), -0.5f);
+        OIIO_CHECK_EQUAL(safe_fmod(-5.5f, -2.5f), -0.5f);
+        OIIO_CHECK_EQUAL(safe_fmod(5.5f, 0.0f), 0.0f);
+        bench("std::fmod", [&]() { return DoNotOptimize(std::fmod(y, x)); });
+        bench("safe_fmod", [&]() { return DoNotOptimize(safe_fmod(y, x)); });
+    }
+
+    {
+        OIIO_CHECK_EQUAL(fast_rint(0.0f), 0);
+        OIIO_CHECK_EQUAL(fast_rint(-1.0f), -1);
+        OIIO_CHECK_EQUAL(fast_rint(-1.2f), -1);
+        OIIO_CHECK_EQUAL(fast_rint(-0.8f), -1);
+        OIIO_CHECK_EQUAL(fast_rint(-1.49f), -1);
+        OIIO_CHECK_EQUAL(fast_rint(-1.50f), -2);
+        OIIO_CHECK_EQUAL(fast_rint(-1.51f), -2);
+        OIIO_CHECK_EQUAL(fast_rint(1.0f), 1);
+        OIIO_CHECK_EQUAL(fast_rint(1.2f), 1);
+        OIIO_CHECK_EQUAL(fast_rint(0.8f), 1);
+        OIIO_CHECK_EQUAL(fast_rint(1.49f), 1);
+        OIIO_CHECK_EQUAL(fast_rint(1.50f), 2);
+        OIIO_CHECK_EQUAL(fast_rint(1.51f), 2);
+        float a = 1.5f;
+        clobber(a);
+        bench("fast_rint", [&]() { return DoNotOptimize(fast_rint(a)); });
+        bench("std::lrint", [&]() { return DoNotOptimize(std::lrint(a)); });
+        bench("int(std::rint)",
+              [&]() { return DoNotOptimize(static_cast<int>(std::rint(a))); });
+        bench("int(x+copysignf(0.5f,x))", [&]() {
+            return DoNotOptimize(static_cast<int>(a + copysignf(0.5f, a)));
+        });
     }
 }
 


### PR DESCRIPTION
A variety of minor rewrites of certain math functions to ensure they
generate better machine code and auto-vectorize more cleanly.

* Lots of inline -> OIIO_FORCEINLINE

* Improve clamp used in fast_sin and cos

* fast_safe_pow improve code gen with OIIO_UNLIKELY

* Introduce `OIIO_FMATH_SIMD_FRIENDLY` to allow application switching
  between implementations that give the best scalar performance versus
  sacrificing scalar perf to have the best SIMD vectorization of loops
  containing the fmath function. This is anticipated to be very rare,
  and of course we strive to be simultaneously fastest on scalar & simd,
  but we have one or two cases where such a tradeoff exists.

* Lots of additional fmath benchmarks to help us judge how good they are
  compared to std functions.

* New safe_fmod which not only prevents division by zero but even in other
  cases is much faster than std::fmod.

* New fast_neg is faster than `-float`, in cases where you are ok with
  -(0.0f) being 0.0f instead of actual floating point -0.0f. If you have
  no idea what I'm talking about or why it matters, you definitely will
  like this function!

* Most of these improvements were backported from OSL, made by Alex Wells,
  Intel.
