### PR TITLE
Fix undefined symbols when USE_PNG is disabled

### DIFF
--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -310,8 +310,10 @@ catalog_builtin_plugins()
 #if !defined(DISABLE_HDR)
     DECLAREPLUG (hdr);
 #endif
+#ifdef USE_PNG
 #if !defined(DISABLE_ICO)
     DECLAREPLUG (ico);
+#endif
 #endif
 #if !defined(DISABLE_IFF)
     DECLAREPLUG (iff);
@@ -335,8 +337,10 @@ catalog_builtin_plugins()
     DECLAREPLUG_RO (openvdb);
 #endif
 #endif
+#ifdef USE_PNG
 #if !defined(DISABLE_PNG)
     DECLAREPLUG (png);
+#endif
 #endif
 #if !defined(DISABLE_PNM)
     DECLAREPLUG (pnm);


### PR DESCRIPTION
## Description

Fix undefined symbols when building ALL_PROJECTS in Visual Studios with USE_PNG disabled by disabling PNG and ICO (which requires libpng) plugins.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

