### PR TITLE
Protect against double definition of FMT_USE_GRISU

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -41,7 +41,9 @@
 #ifndef FMT_EXCEPTIONS
 #    define FMT_EXCEPTIONS 0
 #endif
-#define FMT_USE_GRISU 1
+#ifndef FMT_USE_GRISU
+#    define FMT_USE_GRISU 1
+#endif
 #if OIIO_USE_FMT
 #    include "fmt/ostream.h"
 #    include "fmt/format.h"


### PR DESCRIPTION
Otherwise it would be an error if another (non-OIIO) header includes any fmt headers on its own before it includes strutil.h.
