### PR TITLE
TIFF improvements fixing some edge cases of tag retrieval

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -465,7 +465,8 @@ public:
 
     /// Add a string attribute to `extra_attribs`.
     void attribute (string_view name, string_view value) {
-        const char *s = value.c_str();
+        std::string str(value);
+        const char *s = str.c_str();
         attribute (name, TypeDesc::STRING, &s);
     }
 

--- a/src/include/OpenImageIO/tiffutils.h
+++ b/src/include/OpenImageIO/tiffutils.h
@@ -133,8 +133,8 @@ enum TIFFTAG {
 
 
 /// Given a TIFF data type code (defined in tiff.h) and a count, return the
-/// equivalent TypeDesc where one exists. .Return TypeUndefined if there
-/// is no obvious equivalent.
+/// equivalent TypeDesc where one exists. Return TypeUnknown if there is no
+/// obvious equivalent.
 OIIO_API TypeDesc tiff_datatype_to_typedesc (TIFFDataType tifftype, size_t tiffcount=1);
 
 inline TypeDesc tiff_datatype_to_typedesc (const TIFFDirEntry& dir) {


### PR DESCRIPTION
Replace black magic with what I think is more principled and correct code,
deduced by carefully reading internals of TIFFGetField.

Closes #2500 
