### PR TITLE
FindOpenEXR.cmake: Add detection of debug builds

### DIFF
--- a/src/cmake/modules/FindOpenEXR.cmake
+++ b/src/cmake/modules/FindOpenEXR.cmake
@@ -121,6 +121,8 @@ foreach (COMPONENT ${_openexr_components})
     find_library (OPENEXR_${UPPERCOMPONENT}_LIBRARY
                   NAMES ${COMPONENT}-${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR}
                         ${COMPONENT}
+                        ${COMPONENT}-${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR}_d
+                        ${COMPONENT}_d
                   HINTS ${OPENEXR_LIBRARY_DIR} $ENV{OPENEXR_LIBRARY_DIR}
                         ${GENERIC_LIBRARY_PATHS} )
 endforeach ()


### PR DESCRIPTION
## Description

Debug builds of OpenEXR have an _d suffix (on Windows at least). This patch adds these file names to the searched library names.

## Tests

Built the code on Windows and linked against both Release and Debug builds of OpenEXR 2.4.1

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

