### PR TITLE
cmake: Additional controls to customize required/optional dependencies

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -21,6 +21,11 @@ message (STATUS "*   - To exclude an optional dependency (even if found),")
 message (STATUS "*     -DUSE_Package=OFF or set environment var USE_Package=OFF ")
 message (STATUS "${ColorReset}")
 
+set (REQUIED_DEPS "" CACHE STRING
+     "Additional dependencies to consider required (semicolon-separated list, or ALL)")
+set (OPTIONAL_DEPS "" CACHE STRING
+     "Additional dependencies to consider optional (semicolon-separated list, or ALL)")
+
 
 # checked_find_package(pkgname ..) is a wrapper for find_package, with the
 # following extra features:
@@ -55,12 +60,19 @@ macro (checked_find_package pkgname)
         set (${pkgname}_FIND_QUIETLY true)
         set (${pkgname_upper}_FIND_QUIETLY true)
     endif ()
+    if ("${pkgname}" IN_LIST REQUIRED_DEPS OR "ALL" IN_LIST REQUIRED_DEPS)
+        set (_pkg_REQUIRED 1)
+    endif ()
+    if ("${pkgname}" IN_LIST OPTIONAL_DEPS OR "ALL" IN_LIST OPTIONAL_DEPS)
+        set (_pkg_REQUIRED 0)
+    endif ()
     set (_quietskip false)
     check_is_enabled (${pkgname} _enable)
     set (_disablereason "")
     foreach (_dep ${_pkg_DEPS})
         if (_enable AND NOT ${_dep}_FOUND)
             set (_enable false)
+            set (${pkgname}_ENABLED OFF PARENT_SCOPE)
             set (_disablereason "(because ${_dep} was not found)")
         endif ()
     endforeach ()
@@ -173,7 +185,6 @@ link_directories ("${Boost_LIBRARY_DIRS}")
 # that we will not complete the build if they are not found.
 
 checked_find_package (ZLIB REQUIRED)  # Needed by several packages
-checked_find_package (PNG REQUIRED)
 checked_find_package (TIFF 3.0 REQUIRED)
 
 # IlmBase & OpenEXR
@@ -212,6 +223,8 @@ endif()
 ###########################################################################
 # Dependencies for optional formats and features. If these are not found,
 # we will continue building, but the related functionality will be disabled.
+
+checked_find_package (PNG)
 
 checked_find_package (BZip2)   # Used by ffmpeg and freetype
 if (NOT BZIP2_FOUND)

--- a/src/ico.imageio/CMakeLists.txt
+++ b/src/ico.imageio/CMakeLists.txt
@@ -8,5 +8,6 @@ if (PNG_FOUND)
                      LINK_LIBRARIES ${PNG_LIBRARIES} ${ZLIB_LIBRARIES})
 else ()
     message (WARNING "libpng not found, so ICO support will not work")
+    set (format_plugin_definitions ${format_plugin_definitions} DISABLE_ICO=1 PARENT_SCOPE)
 endif ()
 

--- a/src/png.imageio/CMakeLists.txt
+++ b/src/png.imageio/CMakeLists.txt
@@ -8,5 +8,6 @@ if (PNG_FOUND)
                      LINK_LIBRARIES ${PNG_LIBRARIES} ${ZLIB_LIBRARIES})
 else ()
     message (WARNING "libpng not found, so PNG support will not work")
+    set (format_plugin_definitions ${format_plugin_definitions} DISABLE_PNG=1 PARENT_SCOPE)
 endif ()
 


### PR DESCRIPTION
New cmake variables `REQUIRED_DEPS` and `OPTIONAL_DEPS`.

`REQUIRED_DEPS` is a list of individual package dependencies that are
ordinarily optional (meaning, if not found, the build continues,
possibly disabling some functionality or format support), and forcing
them to be required (build failure if not found). Note that "ALL"
means everying.

`OPTIONAL_DEPS` is a list of individual package dependencies that
makes them optional even if ordinarily (or via `REQUIRED_DEPS`) would
be treated as optional. **Extreme caution necessary!** If you take
something required and force it to be optional, there's no telling
what else in the build might break as a result.

A typical use case might be if you have automated builds and want to be
sure that if for some reason they can't find all the dependencies (even the
optional ones), you will definitely fail the build. But maybe you have some
exceptions. For example,

    cmake ... -DREQUIRED_DEPS=ALL -DOPTIONAL_DEPS="DCMTK;R3DSDK"

That means that you want any missing package dependencies to cause the build
to fail, *except* for missing DCMTK and R3DSDK, which you don't care about.

Also did some cleanup to turn PNG into an optional dependency, including
graceful disabling of ICO if libpng is not found.

