### PR TITLE
Adjust testsuite after adding tga samples to oiio-images

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,7 +298,7 @@ oiio_add_tests (gpsread
                 maketx oiiotool-maketx
                 misnamed-file
                 missingcolor
-                dpx ico iff png psd rla sgi zfile
+                dpx ico iff png pnm psd rla sgi targa-tgautils zfile
                 texture-interp-bicubic
                 texture-blurtube
                 texture-crop texture-cropover
@@ -312,6 +312,7 @@ oiio_add_tests (gpsread
                 texture-missing texture-res texture-maxres
                 texture-udim texture-udim2
                 IMAGEDIR oiio-images
+                URL "Recent checkout of oiio-images"
                )
 
 #   Tests that require openexr-images:
@@ -398,18 +399,10 @@ oiio_add_tests (jpeg2000
     IMAGEDIR j2kp4files_v1_5
     URL http://www.itu.int/net/ITU-T/sigdb/speimage/ImageForm-s.aspx?val=10100803)
 
-oiio_add_tests (pnm
-    IMAGEDIR oiio-images/pnm
-    URL "Recent checkout of oiio-images")
-
 oiio_add_tests (raw
     FOUNDVAR LIBRAW_FOUND
     IMAGEDIR oiio-images/raw
     URL "Recent checkout of oiio-images")
-
-oiio_add_tests (targa-tgautils
-    IMAGEDIR TGAUTILS
-    URL http://tgautils.inequation.org/)
 
 oiio_add_tests (fits
     IMAGEDIR fits-images

--- a/testsuite/pnm/run.py
+++ b/testsuite/pnm/run.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python
 
-
-#files = [ "oiio-logo-no-alpha.png",  "oiio-logo-with-alpha.png" ]
-#for f in files:
-#    command += rw_command (OIIO_TESTSUITE_IMAGEDIR,  f)
-
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/pnm"
 
 # We can't yet write PFM files, so just get the hashes and call it a day
 files = [ "test-1.pfm", "test-2.pfm", "test-3.pfm" ]
 for f in files:
-    command += info_command (OIIO_TESTSUITE_IMAGEDIR + "/" + f,
+    command += info_command (imagedir + "/" + f,
                              safematch=True, hash=True)
-    #command += rw_command (OIIO_TESTSUITE_IMAGEDIR,  f)

--- a/testsuite/targa-tgautils/ref/out.txt
+++ b/testsuite/targa-tgautils/ref/out.txt
@@ -1,5 +1,5 @@
-Reading ../../../../../TGAUTILS/CBW8.TGA
-../../../../../TGAUTILS/CBW8.TGA :  128 x  128, 1 channel, uint8 targa
+Reading ../../../../../oiio-images/targa/CBW8.TGA
+../../../../../oiio-images/targa/CBW8.TGA :  128 x  128, 1 channel, uint8 targa
     SHA-1: E157488A1D82536C6CC5F38CA2BF3CAA397BE69A
     channel list: Y
     Artist: "Ricky True"
@@ -14,10 +14,10 @@ Reading ../../../../../TGAUTILS/CBW8.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 8
     targa:ImageID: "Truevision(R) Sample Image"
-Comparing "../../../../../TGAUTILS/CBW8.TGA" and "CBW8.TGA"
+Comparing "../../../../../oiio-images/targa/CBW8.TGA" and "CBW8.TGA"
 PASS
-Reading ../../../../../TGAUTILS/CCM8.TGA
-../../../../../TGAUTILS/CCM8.TGA :  128 x  128, 3 channel, uint2 targa
+Reading ../../../../../oiio-images/targa/CCM8.TGA
+../../../../../oiio-images/targa/CCM8.TGA :  128 x  128, 3 channel, uint2 targa
     SHA-1: C3CFE6424C5A9D88BB212BFE230F5B9875F434C4
     channel list: R, G, B
     Artist: "Ricky True"
@@ -32,10 +32,10 @@ Reading ../../../../../TGAUTILS/CCM8.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 2
     targa:ImageID: "Truevision(R) Sample Image"
-Comparing "../../../../../TGAUTILS/CCM8.TGA" and "CCM8.TGA"
+Comparing "../../../../../oiio-images/targa/CCM8.TGA" and "CCM8.TGA"
 PASS
-Reading ../../../../../TGAUTILS/CTC16.TGA
-../../../../../TGAUTILS/CTC16.TGA :  128 x  128, 3 channel, uint5 targa
+Reading ../../../../../oiio-images/targa/CTC16.TGA
+../../../../../oiio-images/targa/CTC16.TGA :  128 x  128, 3 channel, uint5 targa
     SHA-1: C3CFE6424C5A9D88BB212BFE230F5B9875F434C4
     channel list: R, G, B
     Artist: "Ricky True"
@@ -50,10 +50,10 @@ Reading ../../../../../TGAUTILS/CTC16.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 5
     targa:ImageID: "Truevision(R) Sample Image"
-Comparing "../../../../../TGAUTILS/CTC16.TGA" and "CTC16.TGA"
+Comparing "../../../../../oiio-images/targa/CTC16.TGA" and "CTC16.TGA"
 PASS
-Reading ../../../../../TGAUTILS/CTC24.TGA
-../../../../../TGAUTILS/CTC24.TGA :  128 x  128, 3 channel, uint8 targa
+Reading ../../../../../oiio-images/targa/CTC24.TGA
+../../../../../oiio-images/targa/CTC24.TGA :  128 x  128, 3 channel, uint8 targa
     SHA-1: C3CFE6424C5A9D88BB212BFE230F5B9875F434C4
     channel list: R, G, B
     Artist: "Ricky True"
@@ -68,10 +68,10 @@ Reading ../../../../../TGAUTILS/CTC24.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 8
     targa:ImageID: "Truevision(R) Sample Image"
-Comparing "../../../../../TGAUTILS/CTC24.TGA" and "CTC24.TGA"
+Comparing "../../../../../oiio-images/targa/CTC24.TGA" and "CTC24.TGA"
 PASS
-Reading ../../../../../TGAUTILS/CTC32.TGA
-../../../../../TGAUTILS/CTC32.TGA :  128 x  128, 4 channel, uint8 targa
+Reading ../../../../../oiio-images/targa/CTC32.TGA
+../../../../../oiio-images/targa/CTC32.TGA :  128 x  128, 4 channel, uint8 targa
     SHA-1: 1ADC95BEBE9EEA8C112D40CD04AB7A8D75C4F961
     channel list: R, G, B, A
     Artist: "Ricky True"
@@ -86,10 +86,10 @@ Reading ../../../../../TGAUTILS/CTC32.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 8
     targa:ImageID: "Truevision(R) Sample Image"
-Comparing "../../../../../TGAUTILS/CTC32.TGA" and "CTC32.TGA"
+Comparing "../../../../../oiio-images/targa/CTC32.TGA" and "CTC32.TGA"
 PASS
-Reading ../../../../../TGAUTILS/UBW8.TGA
-../../../../../TGAUTILS/UBW8.TGA :  128 x  128, 1 channel, uint8 targa
+Reading ../../../../../oiio-images/targa/UBW8.TGA
+../../../../../oiio-images/targa/UBW8.TGA :  128 x  128, 1 channel, uint8 targa
     SHA-1: E157488A1D82536C6CC5F38CA2BF3CAA397BE69A
     channel list: Y
     Artist: "Ricky True"
@@ -103,10 +103,10 @@ Reading ../../../../../TGAUTILS/UBW8.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 8
     targa:ImageID: "Truevision(R) Sample Image"
-Comparing "../../../../../TGAUTILS/UBW8.TGA" and "UBW8.TGA"
+Comparing "../../../../../oiio-images/targa/UBW8.TGA" and "UBW8.TGA"
 PASS
-Reading ../../../../../TGAUTILS/UCM8.TGA
-../../../../../TGAUTILS/UCM8.TGA :  128 x  128, 3 channel, uint2 targa
+Reading ../../../../../oiio-images/targa/UCM8.TGA
+../../../../../oiio-images/targa/UCM8.TGA :  128 x  128, 3 channel, uint2 targa
     SHA-1: C3CFE6424C5A9D88BB212BFE230F5B9875F434C4
     channel list: R, G, B
     Artist: "Ricky True"
@@ -120,10 +120,10 @@ Reading ../../../../../TGAUTILS/UCM8.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 2
     targa:ImageID: "Truevision(R) Sample Image"
-Comparing "../../../../../TGAUTILS/UCM8.TGA" and "UCM8.TGA"
+Comparing "../../../../../oiio-images/targa/UCM8.TGA" and "UCM8.TGA"
 PASS
-Reading ../../../../../TGAUTILS/UTC16.TGA
-../../../../../TGAUTILS/UTC16.TGA :  128 x  128, 3 channel, uint5 targa
+Reading ../../../../../oiio-images/targa/UTC16.TGA
+../../../../../oiio-images/targa/UTC16.TGA :  128 x  128, 3 channel, uint5 targa
     SHA-1: C3CFE6424C5A9D88BB212BFE230F5B9875F434C4
     channel list: R, G, B
     Artist: "Ricky True"
@@ -137,10 +137,10 @@ Reading ../../../../../TGAUTILS/UTC16.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 5
     targa:ImageID: "Truevision(R) Sample Image"
-Comparing "../../../../../TGAUTILS/UTC16.TGA" and "UTC16.TGA"
+Comparing "../../../../../oiio-images/targa/UTC16.TGA" and "UTC16.TGA"
 PASS
-Reading ../../../../../TGAUTILS/UTC24.TGA
-../../../../../TGAUTILS/UTC24.TGA :  128 x  128, 3 channel, uint8 targa
+Reading ../../../../../oiio-images/targa/UTC24.TGA
+../../../../../oiio-images/targa/UTC24.TGA :  128 x  128, 3 channel, uint8 targa
     SHA-1: C3CFE6424C5A9D88BB212BFE230F5B9875F434C4
     channel list: R, G, B
     Artist: "Ricky True"
@@ -154,10 +154,10 @@ Reading ../../../../../TGAUTILS/UTC24.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 8
     targa:ImageID: "Truevision(R) Sample Image"
-Comparing "../../../../../TGAUTILS/UTC24.TGA" and "UTC24.TGA"
+Comparing "../../../../../oiio-images/targa/UTC24.TGA" and "UTC24.TGA"
 PASS
-Reading ../../../../../TGAUTILS/UTC32.TGA
-../../../../../TGAUTILS/UTC32.TGA :  128 x  128, 4 channel, uint8 targa
+Reading ../../../../../oiio-images/targa/UTC32.TGA
+../../../../../oiio-images/targa/UTC32.TGA :  128 x  128, 4 channel, uint8 targa
     SHA-1: 1ADC95BEBE9EEA8C112D40CD04AB7A8D75C4F961
     channel list: R, G, B, A
     Artist: "Ricky True"
@@ -171,5 +171,5 @@ Reading ../../../../../TGAUTILS/UTC32.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 8
     targa:ImageID: "Truevision(R) Sample Image"
-Comparing "../../../../../TGAUTILS/UTC32.TGA" and "UTC32.TGA"
+Comparing "../../../../../oiio-images/targa/UTC32.TGA" and "UTC32.TGA"
 PASS

--- a/testsuite/targa-tgautils/run.py
+++ b/testsuite/targa-tgautils/run.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/targa"
+
 files = [ "CBW8.TGA", "CCM8.TGA", "CTC16.TGA", "CTC24.TGA", "CTC32.TGA",
           "UBW8.TGA", "UCM8.TGA", "UTC16.TGA", "UTC24.TGA", "UTC32.TGA" ]
 for f in files:
-    command += rw_command (OIIO_TESTSUITE_IMAGEDIR, f)
+    command += rw_command (imagedir, f)


### PR DESCRIPTION
The place where the TGAUTILS samples were stored seems to have disappeared
from the web. So put them in oiio-images. Adjusted the targa-tgautils test
for the new location.

Also took the opportunity to clean up the pnm test and simplify how it's
declared.
