### PR TITLE
CI: allow homebrew field3d installation failure

### DIFF
--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -40,9 +40,11 @@ else
     brew install --display-times libtiff ilmbase openexr opencolorio
     brew install --display-times libpng giflib webp jpeg-turbo openjpeg
     brew install --display-times freetype libraw dcmtk pybind11 numpy
-    brew install --display-times field3d ffmpeg libheif libsquish
+    brew install --display-times ffmpeg libheif libsquish
     brew install --display-times openvdb tbb
     brew install --display-times opencv qt ptex
+    # N.B.: seems that Homebrew has removed field3d, allow failure
+    brew install --display-times field3d && true
 fi
 
 if [[ "$LINKSTATIC" == "1" ]] ; then


### PR DESCRIPTION
Seems that Homebrew has removed the field3d package, as its scons
build system needs discontinued python2.7 and other parts have fallen
into disrepair and are having trouble on modern compilers and cmake.
