### PR TITLE
Fix resolution unit not properly set in JPEG export

### DIFF
--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -307,7 +307,7 @@ JpgOutput::resmeta_to_density()
         m_cinfo.density_unit = 2;
     else
         m_cinfo.density_unit = 0;
-    
+
     int X_density = int(m_spec.get_float_attribute("XResolution"));
     int Y_density = int(m_spec.get_float_attribute("YResolution", X_density));
     const float aspect = m_spec.get_float_attribute("PixelAspectRatio", 1.0f);

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -148,16 +148,6 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
         m_cinfo.in_color_space   = JCS_GRAYSCALE;
     }
 
-    string_view resunit = m_spec.get_string_attribute("ResolutionUnit");
-    if (Strutil::iequals(resunit, "none"))
-        m_cinfo.density_unit = 0;
-    else if (Strutil::iequals(resunit, "in"))
-        m_cinfo.density_unit = 1;
-    else if (Strutil::iequals(resunit, "cm"))
-        m_cinfo.density_unit = 2;
-    else
-        m_cinfo.density_unit = 0;
-
     resmeta_to_density();
 
     m_cinfo.write_JFIF_header = TRUE;
@@ -308,6 +298,16 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
 void
 JpgOutput::resmeta_to_density()
 {
+    string_view resunit = m_spec.get_string_attribute("ResolutionUnit");
+    if (Strutil::iequals(resunit, "none"))
+        m_cinfo.density_unit = 0;
+    else if (Strutil::iequals(resunit, "in"))
+        m_cinfo.density_unit = 1;
+    else if (Strutil::iequals(resunit, "cm"))
+        m_cinfo.density_unit = 2;
+    else
+        m_cinfo.density_unit = 0;
+    
     int X_density = int(m_spec.get_float_attribute("XResolution"));
     int Y_density = int(m_spec.get_float_attribute("YResolution", X_density));
     const float aspect = m_spec.get_float_attribute("PixelAspectRatio", 1.0f);


### PR DESCRIPTION
## Description
To give an indication of the physical dimensions (pixels per inch, pixels per mm,...) of the image we can set the "ResolutionUnit", "XResolution" and "YResolution" attributes in the image spec.
For instance for PNG and TIFF this works perfectly, for JPEG however the resolution unit is not properly written.

In jpegoutput.cpp in the open() function the "ResolutionUnit" attribute was read and set in the m_cinfo.density_unit entry. 
However this was overwritten by the jpeg_set_defaults(&m_cinfo) call. 
As a fix I moved the "ResolutionUnit" code to resmeta_to_density().

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

