### PR TITLE
Fix clang 10.x warnings

### DIFF
--- a/src/cineon.imageio/libcineon/CineonHeader.cpp
+++ b/src/cineon.imageio/libcineon/CineonHeader.cpp
@@ -159,10 +159,10 @@ void cineon::IndustryHeader::Reset()
 
 cineon::ImageElement::ImageElement()
 {
-	this->lowData = 0xffffffff;
-	this->lowQuantity = 0xffffffff;
-	this->highData = 0xffffffff;
-	this->highQuantity = 0xffffffff;
+	this->lowData = R32(0xffffffff);
+	this->lowQuantity = R32(0xffffffff);
+	this->highData = R32(0xffffffff);
+	this->highQuantity = R32(0xffffffff);
 	this->bitDepth = 0xff;
 }
 

--- a/src/dpx.imageio/libdpx/DPXHeader.cpp
+++ b/src/dpx.imageio/libdpx/DPXHeader.cpp
@@ -166,9 +166,9 @@ dpx::ImageElement::ImageElement()
 {
 	this->dataSign = 0xffffffff;
 	this->lowData = 0xffffffff;
-	this->lowQuantity = 0xffffffff;
+	this->lowQuantity = R32(0xffffffff);
 	this->highData = 0xffffffff;
-	this->highQuantity = 0xffffffff;
+	this->highQuantity = R32(0xffffffff);
 	this->descriptor = kUndefinedDescriptor;
 	this->transfer = kUndefinedCharacteristic;	
 	this->colorimetric = kUndefinedCharacteristic;

--- a/src/dpx.imageio/libdpx/DPXHeader.h
+++ b/src/dpx.imageio/libdpx/DPXHeader.h
@@ -1714,7 +1714,7 @@ namespace dpx
 	inline R32 GenericHeader::LowQuantity(const int i) const
 	{
 		if (i < 0 || i >= MAX_ELEMENTS)
-			return 0xffffffff;
+			return R32(0xffffffff);
 		return this->chan[i].lowQuantity;
 	}
 
@@ -1742,7 +1742,7 @@ namespace dpx
 	inline R32 GenericHeader::HighQuantity(const int i) const
 	{
 		if (i < 0 || i >= MAX_ELEMENTS)
-			return 0xffffffff;
+			return R32(0xffffffff);
 		return this->chan[i].highQuantity;
 	}
 

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -838,7 +838,7 @@ void convert_type (const S *src, D *dst, size_t n, D _min, D _max)
     }
     typedef typename big_enough_float<D>::float_t F;
     F scale = std::numeric_limits<S>::is_integer ?
-        ((F)1.0)/std::numeric_limits<S>::max() : (F)1.0;
+        (F(1)) / F(std::numeric_limits<S>::max()) : F(1);
     if (std::numeric_limits<D>::is_integer) {
         // Converting to an integer-like type.
         F min = (F)_min;  // std::numeric_limits<D>::min();
@@ -1050,7 +1050,7 @@ convert_type (const S &src)
     }
     typedef typename big_enough_float<D>::float_t F;
     F scale = std::numeric_limits<S>::is_integer ?
-        ((F)1.0)/std::numeric_limits<S>::max() : (F)1.0;
+        F(1) / F(std::numeric_limits<S>::max()) : F(1);
     if (std::numeric_limits<D>::is_integer) {
         // Converting to an integer-like type.
         F min = (F) std::numeric_limits<D>::min();

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -304,7 +304,7 @@ private:
     {
         // RGB = CompRGB - (1 - alpha) * Background;
         double scale = std::numeric_limits<T>::is_integer
-                           ? 1.0 / std::numeric_limits<T>::max()
+                           ? 1.0 / double(std::numeric_limits<T>::max())
                            : 1.0;
 
         for (; size; --size, data += nchannels)
@@ -323,7 +323,7 @@ private:
     {
         // RGB = (CompRGB - (1 - alpha) * Background) / alpha
         double scale = std::numeric_limits<T>::is_integer
-                           ? 1.0 / std::numeric_limits<T>::max()
+                           ? 1.0 / double(std::numeric_limits<T>::max())
                            : 1.0;
 
         for (; size; --size, data += nchannels)
@@ -345,7 +345,7 @@ private:
     void associateAlpha(T* data, int size, int nchannels, int alpha_channel)
     {
         double scale = std::numeric_limits<T>::is_integer
-                           ? 1.0 / std::numeric_limits<T>::max()
+                           ? 1.0 / double(std::numeric_limits<T>::max())
                            : 1.0;
         for (; size; --size, data += nchannels)
             for (int c = 0; c < nchannels; c++)


### PR DESCRIPTION
Note that some of the warnings related to the dpx/cineon readers highlight suspicious code, but I've opted to retain the existing behavior. The offending variables to not appear to actually do anything, they are just carried around as metadata.

