### PR TITLE
Make sure all build_foo.bash scripts exit upon any error.

### DIFF
--- a/src/build-scripts/build_cmake.bash
+++ b/src/build-scripts/build_cmake.bash
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Utility script to download and build cmake
+
+# Exit the whole sscript if any command fails.
+set -ex
+
 echo "Building cmake"
 uname
 

--- a/src/build-scripts/build_libraw.bash
+++ b/src/build-scripts/build_libraw.bash
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Utility script to download and build LibRaw
+
+# Exit the whole sscript if any command fails.
+set -ex
+
 # Which LibRaw to retrieve, how to build it
 LIBRAW_REPO=${LIBRAW_REPO:=https://github.com/LibRaw/LibRaw.git}
 LIBRAW_VERSION=${LIBRAW_VERSION:=0.19.5}

--- a/src/build-scripts/build_llvm.bash
+++ b/src/build-scripts/build_llvm.bash
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Utility script to download and build LLVM & clang
+
+# Exit the whole sscript if any command fails.
+set -ex
+
 echo "Building LLVM"
 uname
 

--- a/src/build-scripts/build_ocio.bash
+++ b/src/build-scripts/build_ocio.bash
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Utility script to download and build OpenColorIO
+
+# Exit the whole sscript if any command fails.
+set -ex
+
 OCIO_REPO=${OCIO_REPO:=https://github.com/AcademySoftwareFoundation/OpenColorIO.git}
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}
 OCIO_BUILD_DIR=${OCIO_BUILD_DIR:=${LOCAL_DEPS_DIR}/OpenColorIO}

--- a/src/build-scripts/build_openexr.bash
+++ b/src/build-scripts/build_openexr.bash
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Utility script to download and build OpenEXR & IlmBase
+
+# Exit the whole sscript if any command fails.
+set -ex
+
 # Which OpenEXR to retrieve, how to build it
 OPENEXR_REPO=${OPENEXR_REPO:=https://github.com/openexr/openexr.git}
 OPENEXR_VERSION=${OPENEXR_VERSION:=2.4.0}

--- a/src/build-scripts/build_pybind11.bash
+++ b/src/build-scripts/build_pybind11.bash
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-# Utility script to download and build pybind11 if it doesn't exist on the
-# system.
+# Utility script to download and build pybind11
 
+# Exit the whole sscript if any command fails.
+set -ex
 
 # Repo and branch/tag/commit of pybind11 to download if we don't have it yet
 PYBIND11_REPO=${PYBIND11_REPO:=https://github.com/pybind/pybind11.git}


### PR DESCRIPTION
`set -ex` exists the whole script if any individual command fails.  I
think this will help ensure that people know when these dependency
building scripts have errors, instead of (hypothesized) seeming to
execute fully but actually the installation of that dependency was not
complete.
