### PR TITLE
Better error messages when overscan texture is not possible

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1776,7 +1776,7 @@ public:
     ///         origin (i.e., nonzero ImageSpec `x`, `y`, `z`)?
     ///
     ///  - `"negativeorigin"` :
-    ///         Does the image format allow pixel and data window origins
+    ///         Does the image format allow data and display window origins
     ///         (i.e., ImageSpec `x`, `y`, `z`, `full_x`, `full_y`, `full_z`)
     ///         to have negative values?
     ///

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -603,7 +603,8 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
     bool envlatlmode       = (mode == ImageBufAlgo::MakeTxEnvLatl);
     bool orig_was_overscan = (img->spec().x || img->spec().y || img->spec().z
                               || img->spec().full_x || img->spec().full_y
-                              || img->spec().full_z);
+                              || img->spec().full_z
+                              || img->spec().roi() != img->spec().roi_full());
     ImageSpec outspec      = outspec_template;
     outspec.set_format(outputdatatype);
 
@@ -1555,12 +1556,12 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
             || Strutil::iends_with(outputfilename, ".exr")))
         do_resize = true;
 
-    if (do_resize && orig_was_overscan && out
-        && !out->supports("displaywindow")) {
-        outstream << "maketx ERROR: format " << out->format_name()
-                  << " does not support separate display windows,\n"
-                  << "              which is necessary when combining resizing"
-                  << " and an input image with overscan.";
+    if (orig_was_overscan && out && !out->supports("displaywindow")) {
+        outstream << Strutil::sprintf(
+            "maketx ERROR: format \"%s\" does not support separate display "
+            "windows, which is necessary for textures with overscan. OpenEXR "
+            " is a format that allows overscan textures.\n",
+            out->format_name());
         return false;
     }
     std::string filtername

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -286,8 +286,8 @@ TIFFOutput::supports(string_view feature) const
         return true;
     if (feature == "nchannels")
         return true;
-    if (feature == "displaywindow")
-        return true;
+    // N.B. TIFF doesn't support "displaywindow", since it has no tags for
+    // the equivalent of full_x, full_y.
     if (feature == "origin")
         return true;
     // N.B. TIFF doesn't support "negativeorigin"


### PR DESCRIPTION
Sometimes people try to make a texture from a source image that has
"overscan" (that is, when the pixel data window goes outside the
bounds of the "display" window that is assumed to be the 0-1 texture
space). Thiago Ize in particular noticed that this works fine when
outputting the texture as exr, but not as the default TIFF-based
mipmapped textures.

Alas, the only way this can work is if the texture file format has a
way to represent fully general display windows, and TIFF does not. So
it should never have been allowed, but there was no error message, just
strange runtime behavior.

This patch:

1. Tightens up some of the tests for whether the user is requesting an
overscan texture, so that it is an error to use overscan and the
output file type doesn't support display windows (previously this was
only checked if the sequence of operations also required an initial
resize, which was not stringent enough).

2. Fixes the TIFF output which I now believe should never have had
`supports("displaywindow")` return true; it should always have been
false.
