### PR TITLE
Fix possible uncaught exceptions in Filesystem utils

### DIFF
--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -201,12 +201,11 @@ Filesystem::searchpath_find(const std::string& filename_utf8,
             return pathstr(f);
         }
 
-
         if (recursive && filesystem::is_directory(d, ec)) {
             std::vector<std::string> subdirs;
-            for (filesystem::directory_iterator s(d), end_iter; s != end_iter;
-                 ++s) {
-                if (filesystem::is_directory(s->status())) {
+            for (filesystem::directory_iterator s(d, ec), end_iter;
+                 !ec && s != end_iter; ++s) {
+                if (filesystem::is_directory(s->path(), ec)) {
                     subdirs.push_back(pathstr(s->path()));
                 }
             }
@@ -240,15 +239,17 @@ Filesystem::get_directory_entries(const std::string& dirname,
     }
 
     if (recursive) {
-        for (filesystem::recursive_directory_iterator s(dirpath);
-             s != filesystem::recursive_directory_iterator(); ++s) {
+        error_code ec;
+        for (filesystem::recursive_directory_iterator s(dirpath, ec);
+             !ec && s != filesystem::recursive_directory_iterator(); ++s) {
             std::string file = pathstr(s->path());
             if (!filter_regex.size() || regex_search(file, re))
                 filenames.push_back(file);
         }
     } else {
-        for (filesystem::directory_iterator s(dirpath);
-             s != filesystem::directory_iterator(); ++s) {
+        error_code ec;
+        for (filesystem::directory_iterator s(dirpath, ec);
+             !ec && s != filesystem::directory_iterator(); ++s) {
             std::string file = pathstr(s->path());
             if (!filter_regex.size() || regex_search(file, re))
                 filenames.push_back(file);
@@ -858,9 +859,9 @@ Filesystem::scan_for_matching_filenames(const std::string& pattern_,
     try {
         regex pattern_re(pattern_re_str);
 
-        for (filesystem::directory_iterator it(u8path(directory)), end_it;
-             it != end_it; ++it) {
-            error_code ec;
+        error_code ec;
+        for (filesystem::directory_iterator it(u8path(directory), ec), end_it;
+             !ec && it != end_it; ++it) {
             if (filesystem::is_regular(it->path(), ec)) {
                 const std::string f = pathstr(it->path());
                 match_results<std::string::const_iterator> frame_match;


### PR DESCRIPTION
It is possible for the constructor for filesystem::directory_iterator
to throw an exception. Switch those to the ones that take an error code
reference and do not throw exceptions.

Also fix what must be a bug (how did it ever compile?) at line 208,
where we tried to find out if the status() (!!!) was a diretory, rather
than the path. Huh?

Closes #2517

