### PR TITLE
ParamValueList enhancements

### DIFF
--- a/src/include/OpenImageIO/paramlist.h
+++ b/src/include/OpenImageIO/paramlist.h
@@ -258,6 +258,22 @@ public:
     const_iterator find(ustring name, TypeDesc type = TypeDesc::UNKNOWN,
                         bool casesensitive = true) const;
 
+    /// Search for the first entry with matching name, etc., and return
+    /// a pointer to it, or nullptr if it is not found.
+    ParamValue* find_pv(string_view name, TypeDesc type = TypeDesc::UNKNOWN,
+                        bool casesensitive = true)
+    {
+        iterator f = find(name, type, casesensitive);
+        return f != end() ? &(*f) : nullptr;
+    }
+    const ParamValue* find_pv(string_view name,
+                              TypeDesc type      = TypeDesc::UNKNOWN,
+                              bool casesensitive = true) const
+    {
+        const_iterator f = find(name, type, casesensitive);
+        return f != cend() ? &(*f) : nullptr;
+    }
+
     /// Case insensitive search for an integer, with default if not found.
     /// Automatically will return an int even if the data is really
     /// unsigned, short, or byte, but not float. It will retrive from a

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -545,7 +545,7 @@ ParamValueList::contains(string_view name, TypeDesc type,
 void
 ParamValueList::add_or_replace(const ParamValue& pv, bool casesensitive)
 {
-    iterator p = find(pv.name(), pv.type(), casesensitive);
+    iterator p = find(pv.name(), TypeUnknown, casesensitive);
     if (p != end())
         *p = pv;
     else
@@ -556,7 +556,7 @@ ParamValueList::add_or_replace(const ParamValue& pv, bool casesensitive)
 void
 ParamValueList::add_or_replace(ParamValue&& pv, bool casesensitive)
 {
-    iterator p = find(pv.name(), pv.type(), casesensitive);
+    iterator p = find(pv.name(), TypeUnknown, casesensitive);
     if (p != end())
         *p = pv;
     else


### PR DESCRIPTION
* New `find_pv()` method wraps `find()` but returns a pointer rather than
  an iterator, and nullptr if the attribute is not found.

* Fix `add_or_replace()` -- it was previously failing to "replace" if the
  new attribute had a different type than the existing one.
