### PR TITLE
Build correctly against OCIO 2.x (in progress)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -69,7 +69,7 @@ jobs:
             source src/build-scripts/ci-build-and-test.bash
 
   linux-bleeding:
-    name: "Linux bleeding edge: gcc9, C++17, avx2, exr 2.4"
+    name: "Linux bleeding edge: gcc9, C++17, avx2, exr 2.4, OCIO master"
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
@@ -79,6 +79,7 @@ jobs:
           CMAKE_CXX_STANDARD: 17
           USE_SIMD: avx2,f16c
           OPENEXR_BRANCH: v2.4.0
+          OCIO_BRANCH: master
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps.bash

--- a/testsuite/python-colorconfig/ref/out-ocio2-python27.txt
+++ b/testsuite/python-colorconfig/ref/out-ocio2-python27.txt
@@ -1,0 +1,12 @@
+getNumColorSpaces = 14
+getColorSpaceNames = [u'linear', u'sRGB', u'sRGBf', u'rec709', u'Cineon', u'Gamma1.8', u'Gamma2.2', u'Panalog', u'REDLog', u'ViperLog', u'AlexaV3LogC', u'PLogLin', u'SLog', u'raw']
+getNumLooks = 0
+getLookNames = []
+getNumDisplays = 1
+getDisplayNames = [u'default']
+getDefaultDisplayName = default
+getNumViews = 1
+getViewNames = [u'sRGB']
+getDefaultViewName = 
+
+Done.

--- a/testsuite/python-colorconfig/ref/out-ocio2.txt
+++ b/testsuite/python-colorconfig/ref/out-ocio2.txt
@@ -1,0 +1,12 @@
+getNumColorSpaces = 14
+getColorSpaceNames = ['linear', 'sRGB', 'sRGBf', 'rec709', 'Cineon', 'Gamma1.8', 'Gamma2.2', 'Panalog', 'REDLog', 'ViperLog', 'AlexaV3LogC', 'PLogLin', 'SLog', 'raw']
+getNumLooks = 0
+getLookNames = []
+getNumDisplays = 1
+getDisplayNames = ['default']
+getDefaultDisplayName = default
+getNumViews = 1
+getViewNames = ['sRGB']
+getDefaultViewName = 
+
+Done.


### PR DESCRIPTION
And incorporate a build against OCIO master into the "bleeding edge" CI test, so we don't drift out of sync again.
