### PR TITLE
Overhaul ArgParse to make it more like python argparse

### DIFF
--- a/src/igrep/igrep.cpp
+++ b/src/igrep/igrep.cpp
@@ -31,15 +31,13 @@ using namespace std::regex_constants;
 
 using namespace OIIO;
 
-static bool help           = false;
-static bool invert_match   = false;
-static bool ignore_case    = false;
-static bool list_files     = false;
-static bool recursive      = false;
-static bool file_match     = false;
-static bool print_dirs     = false;
-static bool all_subimages  = false;
-static bool extended_regex = false;
+static bool help          = false;
+static bool invert_match  = false;
+static bool list_files    = false;
+static bool recursive     = false;
+static bool file_match    = false;
+static bool print_dirs    = false;
+static bool all_subimages = false;
 static std::string pattern;
 static std::vector<std::string> filenames;
 
@@ -142,24 +140,34 @@ main(int argc, const char* argv[])
     Sysutil::setup_crash_stacktrace("stdout");
 
     Filesystem::convert_native_arguments(argc, argv);
-    ArgParse ap;
     // clang-format off
-    ap.options ("igrep -- search images for matching metadata\n"
-                OIIO_INTRO_STRING "\n"
-                "Usage:  igrep [options] pattern filename...",
-                "%*", parse_files, "",
-                "-i", &ignore_case, "Ignore upper/lower case distinctions",
-                "-v", &invert_match, "Invert match (select non-matching files)",
-                "-E", &extended_regex, "Pattern is an extended regular expression",
-                "-f", &file_match, "Match against file name as well as metadata",
-                "-l", &list_files, "List the matching files (no detail)",
-                "-r", &recursive, "Recurse into directories",
-                "-d", &print_dirs, "Print directories (when recursive)",
-                "-a", &all_subimages, "Search all subimages of each file",
-                "--help", &help, "Print help message",
-                NULL);
+    ArgParse ap;
+    ap.intro("igrep -- search images for matching metadata\n"
+             OIIO_INTRO_STRING)
+      .usage("igrep [options] pattern filename...");
+    ap.arg("filename")
+      .hidden()
+      .action(parse_files);
+    ap.arg("-i")
+      .help("Ignore upper/lower case distinctions");
+    ap.arg("-v", &invert_match)
+      .help("Invert match (select non-matching files)");
+    ap.arg("-E")
+      .help( "Pattern is an extended regular expression");
+    ap.arg("-f", &file_match)
+      .help("Match against file name as well as metadata");
+    ap.arg("-l", &list_files)
+      .help("List the matching files (no detail)");
+    ap.arg("-r", &recursive)
+      .help("Recurse into directories");
+    ap.arg("-d", &print_dirs)
+      .help("Print directories (when recursive)");
+    ap.arg("-a", &all_subimages)
+      .help("Search all subimages of each file");
+
     // clang-format on
-    if (ap.parse(argc, argv) < 0 || pattern.empty() || filenames.empty()) {
+    ap.parse(argc, argv);
+    if (pattern.empty() || filenames.empty()) {
         std::cerr << ap.geterror() << std::endl;
         ap.usage();
         return help ? EXIT_SUCCESS : EXIT_FAILURE;
@@ -168,15 +176,15 @@ main(int argc, const char* argv[])
 #if USE_BOOST_REGEX
     boost::regex_constants::syntax_option_type flag
         = boost::regex_constants::grep;
-    if (extended_regex)
+    if (ap["E"].get<int>())
         flag = boost::regex::extended;
-    if (ignore_case)
+    if (ap["i"].get<int>())
         flag |= boost::regex_constants::icase;
 #else
     auto flag = std::regex_constants::grep;
-    if (extended_regex)
+    if (ap["E"].get<int>())
         flag = std::regex_constants::extended;
-    if (ignore_case)
+    if (ap["i"].get<int>())
         flag |= std::regex_constants::icase;
 #endif
     regex re(pattern, flag);

--- a/src/include/OpenImageIO/argparse.h
+++ b/src/include/OpenImageIO/argparse.h
@@ -3,9 +3,6 @@
 // https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
 
-/// \file
-/// \brief Simple parsing of program command-line arguments.
-
 #pragma once
 
 #if defined(_MSC_VER)
@@ -20,163 +17,718 @@
 
 #include <OpenImageIO/export.h>
 #include <OpenImageIO/oiioversion.h>
+#include <OpenImageIO/paramlist.h>
 #include <OpenImageIO/strutil.h>
 
 
 OIIO_NAMESPACE_BEGIN
 
 
-class ArgOption;  // Forward declaration
-
-
-
 /////////////////////////////////////////////////////////////////////////////
 ///
 /// \class ArgParse
 ///
-/// Argument Parsing
+/// Argument Parsing. Kind of resembles Python argparse library.
 ///
-/// The parse function takes a list of options and variables or functions
-/// for storing option values and return <0 on failure:
+/// Set up argument parser:
 ///
-/// \code
-///    static int parse_files (int argc, const char *argv[])
-///    {
-///        for (int i = 0;  i < argc;  i++)
-///            filenames.push_back (argv[i]);
-///        return 0;
-///    }
+///     ArgParse ap;
+///     ap.intro("myapp does good things")
+///       .usage("myapp [options] filename...");
+///     ap.arg("filename")
+///       .hidden()
+///       .action([&](cspan<const char*> argv){ filenames.emplace_back(argv[0]); });
 ///
-///    static int blah_callback (int argc, const char *argv[])
-///    {
-///        std::cout << "blah argument was " << argv[1] << "\n";
-///        return 0;
-///    }
+/// Declare arguments. Some examples of common idioms:
 ///
-///    ...
+///     // Boolean option (no arguments)
+///     ap.arg("-v")
+///       .help("verbose mode")
+///       .action(ArgParse::store_true());
 ///
-///    ArgParse ap;
+///     // integer option
+///     ap.arg("-passes NPASSES")
+///        .help("number of passes")
+///        .defaultval(1)
+///        .action(ArgParse::store<int>);
 ///
-///    ap.options ("Usage: myapp [options] filename...",
-///            "%*", parse_objects, "",
-///            "-camera %f %f %f", &camera[0], &camera[1], &camera[2],
-///                  "set the camera position",
-///            "-lookat %f %f %f", &lx, &ly, &lz,
-///                  "set the position of interest",
-///            "-oversampling %d", &oversampling,  "oversamping rate",
-///            "-passes %d", &passes, "number of passes",
-///            "-lens %f %f %f", &aperture, &focalDistance, &focalLength,
-///                   "set aperture, focal distance, focal length",
-///            "-format %d %d %f", &width, &height, &aspect,
-///                   "set width, height, aspect ratio",
-///            "-v", &verbose, "verbose output",
-///            "-q %!", &verbose, "quiet mode",
-///            "--blah %@ %s", blahcallback, "Make the callback",
-///            NULL);
+///     // An option that takes 3 float arguments, like a V3f
+///     ap.arg("-camera X Y Z")
+///       .help("set the camera position")
+///       .defaultval(Imath::V3f(0.0f, 0.0f, -1.0f))
+///       .action(ArgParse::store<float>());
 ///
-///    if (ap.parse (argc, argv) < 0) {
-///        std::cerr << ap.geterror() << std::endl;
-///        ap.usage ();
-///        return EXIT_FAILURE;
-///    }
-/// \endcode
+///     // Potitional argument -- append strings
+///     ap.arg("filename")
+///       .action(ArgParse::append())
+///       .hidden();
 ///
-/// The available argument types are:
-///    - no \% argument - bool flag
-///    - \%! - a bool flag, but set it to false if the option is set
-///    - \%d - 32bit integer
-///    - \%f - 32bit float
-///    - \%F - 64bit float (double)
-///    - \%s - std::string
-///    - \%L - std::vector<std::string>  (takes 1 arg, appends to list)
-///    - \%@ - a function pointer for a callback function will be invoked
-///            immediately.  The prototype for the callback is
-///                  int callback (int argc, char *argv[])
-///    - \%* - catch all non-options and pass individually as an (argc,argv)
-///            sublist to a callback, each immediately after it's found
-///    - \%1 - catch all non-options that occur before any option is
-///            encountered (like %*, but only for those prior to the first
-///            real option.
+/// Parse the command line:
 ///
-/// The argument type specifier may be followed by an optional colon (:) and
-/// then a human-readable parameter that will be printed in the help
-/// message. For example,
+///     ap.parse (argc, argv);
 ///
-///     "--foo %d:WIDTH %d:HEIGHT", ...
+/// Extract the values like they are attributes in a ParamValueList:
 ///
-/// indicates that `--foo` takes two integer arguments, and the help message
-/// will be rendered as:
+///     int passes = ap["passes"].get<int>();
+///     bool verbose = ap["verbose"].get<int>();
+///     Imath::V3f camera = ap["camera"].get<Imath::V3f>();
 ///
-///     --foo WIDTH HEIGHT    Set the foo size
-///
-/// There are several special format tokens:
-///    - "<SEPARATOR>" - not an option at all, just a description to print
-///                     in the usage output.
-///
-/// Notes:
-///   - If an option doesn't have any arguments, a bool flag argument is
-///     assumed.
-///   - No argument destinations are initialized.
-///   - The empty string, "", is used as a global sublist (ie. "%*").
-///   - Sublist functions are all of the form "int func(int argc, char **argv)".
-///   - If a sublist function returns -1, parse() will terminate early.
-///   - It is perfectly legal for the user to append ':' and more characters
-///     to the end of an option name, it will match only the portion before
-///     the semicolon (but a callback can detect the full string, this is
-///     useful for making arguments:  myprog --flag:myopt=1 foobar
-///
+//
+// ------------------------------------------------------------------
+//
+// Old syntax
+// ----------
+//
+// We still support this old syntax as well:
+//
+// The parse function takes a list of options and variables or functions
+// for storing option values and return <0 on failure:
+//
+//     static int parse_files (int argc, const char *argv[])
+//     {
+//         for (int i = 0;  i < argc;  i++)
+//             filenames.push_back (argv[i]);
+//         return 0;
+//     }
+//
+//     static int blah_callback (int argc, const char *argv[])
+//     {
+//         std::cout << "blah argument was " << argv[1] << "\n";
+//         return 0;
+//     }
+//
+//     ...
+//
+//     ArgParse ap;
+//
+//     ap.options ("Usage: myapp [options] filename...",
+//             "%*", parse_objects, "",
+//             "-camera %f %f %f", &camera[0], &camera[1], &camera[2],
+//                   "set the camera position",
+//             "-lookat %f %f %f", &lx, &ly, &lz,
+//                   "set the position of interest",
+//             "-oversampling %d", &oversampling,  "oversamping rate",
+//             "-passes %d", &passes, "number of passes",
+//             "-lens %f %f %f", &aperture, &focalDistance, &focalLength,
+//                    "set aperture, focal distance, focal length",
+//             "-format %d %d %f", &width, &height, &aspect,
+//                    "set width, height, aspect ratio",
+//             "-v", &verbose, "verbose output",
+//             "-q %!", &verbose, "quiet mode",
+//             "--blah %@ %s", blahcallback, "Make the callback",
+//             NULL);
+//
+//     if (ap.parse (argc, argv) < 0) {
+//         std::cerr << ap.geterror() << std::endl;
+//         ap.usage ();
+//         return EXIT_FAILURE;
+//     }
+//
+// The available argument types are:
+//    - no \% argument - bool flag
+//    - \%! - a bool flag, but set it to false if the option is set
+//    - \%d - 32bit integer
+//    - \%f - 32bit float
+//    - \%F - 64bit float (double)
+//    - \%s - std::string
+//    - \%L - std::vector<std::string>  (takes 1 arg, appends to list)
+//    - \%@ - a function pointer for a callback function will be invoked
+//            immediately.  The prototype for the callback is
+//                  int callback (int argc, char *argv[])
+//    - \%* - catch all non-options and pass individually as an (argc,argv)
+//            sublist to a callback, each immediately after it's found
+//    - \%1 - catch all non-options that occur before any option is
+//            encountered (like %*, but only for those prior to the first
+//            real option.
+//
+// The argument type specifier may be followed by an optional colon (:) and
+// then a human-readable parameter that will be printed in the help
+// message. For example,
+//
+//     "--foo %d:WIDTH %d:HEIGHT", ...
+//
+// indicates that `--foo` takes two integer arguments, and the help message
+// will be rendered as:
+//
+//     --foo WIDTH HEIGHT    Set the foo size
+//
+// There are several special format tokens:
+//    - "<SEPARATOR>" - not an option at all, just a description to print
+//                     in the usage output.
+//
+// Notes:
+//   - If an option doesn't have any arguments, a bool flag argument is
+//     assumed.
+//   - No argument destinations are initialized.
+//   - The empty string, "", is used as a global sublist (ie. "%*").
+//   - Sublist functions are all of the form "int func(int argc, char **argv)".
+//   - If a sublist function returns -1, parse() will terminate early.
+//   - It is perfectly legal for the user to append ':' and more characters
+//     to the end of an option name, it will match only the portion before
+//     the semicolon (but a callback can detect the full string, this is
+//     useful for making arguments:  myprog --flag:myopt=1 foobar
+//
 /////////////////////////////////////////////////////////////////////////////
 
 
 class OIIO_API ArgParse {
 public:
-    ArgParse(int argc = 0, const char** argv = NULL);
+    class Arg;  // Forward declarion of Arg
+
+    // ------------------------------------------------------------------
+    /// @defgroup Setting up an ArgParse
+    /// @{
+
+    /// Construct an ArgParse.
+    ArgParse();
+
+    /// Destroy an ArgParse.
     ~ArgParse();
 
-    /// Declare the command line options.  After the introductory
-    /// message, parameters are a set of format strings and variable
-    /// pointers.  Each string contains an option name and a scanf-like
-    /// format string to enumerate the arguments of that option
-    /// (eg. "-option %d %f %s").  The format string is followed by a
-    /// list of pointers to the argument variables, just like scanf.  A
-    /// NULL terminates the list.  Multiple calls to options() will
-    /// append additional options.
-    int options(const char* intro, ...);
+    // Old ctr. Don't use this. Instead, pass argc/argv to parse_args().
+    ArgParse(int argc, const char** argv);
 
-    /// With the options already set up, parse the command line.
-    /// Return 0 if ok, -1 if it's a malformed command line.
-    int parse(int argc, const char** argv);
+    // Disallow copy ctr and assignment
+    ArgParse(const ArgParse&) = delete;
+    const ArgParse& operator=(const ArgParse&) = delete;
+
+    /// Move constructor
+    ArgParse(ArgParse&& other)
+        : m_impl(std::move(other.m_impl))
+    {
+    }
+
+    /// Set an optional "intro" message, printed first when --help is used
+    /// or an error is found in the program arguments.
+    ArgParse& intro(string_view str);
+
+    /// Set the "usage" string, which will be printed after the intro, and
+    /// preceded by the message "Usage: ".
+    ArgParse& usage(string_view str);
+
+    /// Set an optional description of the program, to be printed after the
+    /// usage but before the detailed argument help.
+    ArgParse& description(string_view str);
+
+    /// Set an optional epilog to be printed after the detailed argument
+    /// help.
+    ArgParse& epilog(string_view str);
+
+    /// Optionally override the name of the program, as understood by
+    /// ArgParse. If not supplied, it will be derived from the original
+    /// command line.
+    ArgParse& prog(string_view str);
+
+    /// If true, this will cause the detailed help message to print the
+    /// default value of all options for which it was supplied (the default
+    /// is false).
+    ArgParse& print_defaults(bool print);
+
+    /// By default, every ArgParse automatically adds a `--help` argument
+    /// that, if invoked, prints the full explanatory help message (i.e.,
+    /// calls `print_help()`) and then exits the application with a success
+    /// return code of 0.
+    ///
+    /// Calling `add_help(false)` disable the automatic `--help` argument.
+    /// If you do this but want a help option (for example, you want to call
+    /// it something different, or not exit the application, or have some
+    /// other behavior), it's up to the user to add it and its behavior just
+    /// like any other argument.
+    ArgParse& add_help(bool add_help);
+
+    /// By default, if the command line arguments do not conform to what is
+    /// declared to ArgParse (for example, if unknown commands are
+    /// encountered, required arguments are not found, etc.), the ArgParse
+    /// (during `parse_args()` will print an error message, the full help
+    /// guide, and then exit the application with a failure return code.
+    ///
+    /// Calling `exit_on_error(false)` disables this behavior. In this case,
+    /// the application is responsible for checking the return code of
+    /// `parse_args()` and responding appropriately.
+    ArgParse& exit_on_error(bool exit_on_error);
+
+    /// @}
+
+    // ------------------------------------------------------------------
+    /// @defgroup Parsing arguments
+    /// @{
+
+    /// With the options already set up, parse the command line. Return 0 if
+    /// ok, -1 if it's a malformed command line.
+    int parse_args(int argc, const char** argv);
 
     /// Return any error messages generated during the course of parse()
     /// (and clear any error flags).  If no error has occurred since the
     /// last time geterror() was called, it will return an empty string.
     std::string geterror() const;
 
-    /// Print the usage message to stdout.  The usage message is
-    /// generated and formatted automatically based on the command and
-    /// description arguments passed to parse().
-    void usage() const;
+    /// Return the name of the program. This will be either derived from the
+    /// original command line that launched this application, or else
+    /// overridden by a prior call to `prog()`.
+    std::string prog_name() const;
+
+    /// Print the full help message to stdout.  The usage message is
+    /// generated and formatted automatically based on the arguments
+    /// declared.
+    void print_help() const;
 
     /// Print a brief usage message to stdout.  The usage message is
-    /// generated and formatted automatically based on the command and
-    /// description arguments passed to parse().
+    /// generated and formatted automatically based on the arguments
+    /// declared.
     void briefusage() const;
 
     /// Return the entire command-line as one string.
-    ///
     std::string command_line() const;
+
+    /// @}
+
+    // ------------------------------------------------------------------
+    /// @defgroup Declaring arguments
+    /// @{
+
+    /// Add an argument declaration. Ordinary arguments start with a leading
+    /// `-` character (or `--`, either will be accepted). Positional
+    /// arguments lack a leading `-`.
+    ///
+    /// The argname consists of any of these options:
+    ///
+    ///   * "name" : a positional argument.
+    ///
+    ///   * "-name" or "--name" : an ordinary flag argument. If this argument
+    ///     should be followed by parameters, they will later be declared
+    ///     using some combination of `Arg::nargs()` and `Arg::metavar()`.
+    ///
+    ///   * "--name A B C" : including the names of parameters following the
+    ///     flag itself implicitly means the same thing as calling `nargs()`
+    ///     and `metavar()`, and there is no need to call them separately.
+    ///
+    /// This method returns an `Arg&`, so it is permissible to chain Arg
+    /// method calls. Those chained calls are what communicates the number
+    /// of parameters, help message, action, etc. See the `Arg` class for
+    /// all the possible Arg methods.
+    ///
+    Arg& add_argument(const char* argname);
+
+    /// Alternate way to add an argument, specifying external storage
+    /// destinations for the parameters. This is more reminiscent of the
+    /// older, pre-2.2 API, and also can be convenient as an alternative to
+    /// extracting every parameter and putting them into variables.
+    ///
+    /// Flags with no parameters are followed by a `bool*`. Args with
+    /// parameters must declare them as "%T:NAME", where the "%T" part
+    /// corresponds to the storage type, `%d` for int, `%f` for float, `%s`
+    /// for std::string, and `%L` for `std::vector<std::string>`.
+    ///
+    /// Examples:
+    ///
+    ///     ArgParse ap;
+    ///     bool verbose = false;
+    ///     ap.add_argument("-v", &verbose)
+    ///       .help("verbose mode");
+    ///
+    ///     float r = 0, g = 0, b = 0;
+    ///     ap.add_argument("--color %f:R %f:G %f:B", &r, &g, &b)
+    ///       .help("diffuse color")
+    ///       .action(ArgParse::store<float>());
+    ///
+    template<typename... T> Arg& add_argument(const char* argname, T... args)
+    {
+        return argx(argname, args...);
+    }
+
+    /// Shorter synonym for add_argument().
+    Arg& arg(const char* argname) { return add_argument(argname); }
+
+    /// Shorter synonym for add_argument().
+    template<typename... T> Arg& arg(const char* argname, T... args)
+    {
+        return argx(argname, args...);
+    }
+
+    /// Add a separator with a text message. This can be used to group
+    /// arguments with section headings.
+    ///
+    /// Example:
+    ///
+    ///     ArgParse ap;
+    ///     ap.separator("Basic arguments:");
+    ///     ap.add_argument("-v");
+    ///     ap.add_argument("-a");
+    ///     ap.separator("Advanced arguments:");
+    ///     ap.add_argument("-b");
+    ///     ap.add_argument("-c");
+    ///
+    /// Will print the help section like:
+    ///
+    ///     Basic arguments:
+    ///         -v
+    ///         -a
+    ///     Advanced arguments:
+    ///         -b
+    ///         -c
+    ///
+    Arg& separator(string_view text);
+
+
+    /// Holder for a callback that takes a span of C strings as arguments.
+    // typedef std::function<void(cspan<const char*> myargs)> Action;
+    using Action = std::function<void(cspan<const char*> myargs)>;
+
+    /// Holder for a callback that takes an Arg ref and a span of C strings
+    /// as arguments.
+    using ArgAction = std::function<void(Arg& arg, cspan<const char*> myargs)>;
+
+
+    /// A call to `ArgParse::arg()` returns an `Arg&`. There are lots of
+    /// things you can do to that reference to modify it. Nearly all
+    /// Arg methods return an `Arg&` so you can chain the calls, like this:
+    ///
+    ///     ArgParse ap;
+    ///     ...
+    ///     ap.add_argument("-v")
+    ///       .help("Verbose mode")
+    ///       .action(Arg::store_true());
+    ///
+    class Arg {
+    public:
+        // Arg constructor. This should only be called by
+        // ArgParse::add_argument().
+        Arg(ArgParse& ap)
+            : m_argparse(ap)
+        {
+        }
+        // Disallow copy ctr and assignment
+        Arg(const Arg&)    = delete;
+        const Arg& operator=(const Arg&) = delete;
+
+        /// Set the help / description of this command line argument.
+        Arg& help(string_view help);
+
+        /// Set the number of subsequent parameters to this argument.
+        /// Setting `nargs(0)` means it is a flag only, with no parameters.
+        Arg& nargs(int n);
+
+        // TODO:
+        // Set the number of subequent parameters to this arguments. "?"
+        // means a single optional value, "*" means any number of optional
+        // values (and implies action(append)), "+" means one or more
+        // optional values (just like "*", but will be an error if none are
+        // supplied at all).
+        // Arg& nargs(string_view n);
+
+
+        /// Set the name(s) of any argument parameters as they are printed
+        /// in the help message. For arguments that take multiple
+        /// parameters, just put spaces between them. Note that the number
+        /// of arguments is inferred by the number of metavar names, so
+        /// there is no need to set nargs separately if metavar() is called
+        /// properly.
+        ///
+        /// Examples:
+        ///
+        ///     ArgParse ap;
+        ///     ap.add_argument("--aa")
+        ///       .help("set sampling rate (per pixel)")
+        ///       .metavar("SAMPLES");
+        ///     ap.add_argument("--color")
+        ///       .help("set the diffuse color")
+        ///       .metavar("R G B");
+        ///
+        /// Will print help like:
+        ///
+        ///     --aa SAMPLES       set sampling rate (per pixel)
+        ///     --color R G B      set the diffuse color
+        ///
+        Arg& metavar(string_view name);
+
+        /// Override the destination attribtute name (versus the default
+        /// which is simply the name of the command line option with the
+        /// leading dashes stripped away). The main use case is if you want
+        /// two differently named command line options to both store values
+        /// into the same attribute. It is very important that if you use
+        /// dest(), you call it before setting the action.
+        ///
+        /// Example:
+        ///
+        ///     // Add -v argument, but store its result in `ap["verbose"]`
+        ///     // rather than the default `ap["v"]`.
+        ///     ap.add_argument("-v")
+        ///       .help("verbose mode")
+        ///       .dest("verbose")
+        ///       .action(ArgParse::store_true());
+        ///
+        Arg& dest(string_view dest);
+
+        /// Initialize the destination attribute with a default value. Do
+        /// not call `.dest("name")` on the agrument after calling
+        /// defaultval, of it will end up with the default value in the
+        /// wrong attribute.
+        template<typename T> Arg& defaultval(const T& val)
+        {
+            m_argparse.params()[dest()] = val;
+            return *this;
+        }
+
+        /// Mark the argument as hidden from the help message.
+        Arg& hidden();
+
+        /// Set the action for this argument to store 1 in the destination
+        /// attribute. Initialize the destination attribute to 0 now. Do not
+        /// call `.dest("name")` on the agrument after calling store_true,
+        /// you must override the destination first!
+        Arg& store_true()
+        {
+            m_argparse.params()[dest()] = 0;
+            action(ArgParse::store_true());
+            return *this;
+        }
+
+        /// Set the action for this argument to store 0 in the destination
+        /// attribute. Initialize the destination attribute to 1 now. Do not
+        /// call `.dest("name")` on the agrument after calling store_false,
+        /// you must override the destination first!
+        Arg& store_false()
+        {
+            m_argparse.params()[dest()] = 1;
+            action(ArgParse::store_false());
+            return *this;
+        }
+
+        /// Add an arbitrary action:   `func(Act&, cspan<const char*>)`
+        Arg& action(ArgAction&& func);
+
+        /// Add an arbitrary action:   `func(cspan<const char*>)`
+        Arg& action(Action&& func)
+        {
+            // Implemented with a lambda that applies a wrapper to turn
+            // it into func(Arg&,cspan<const char*>).
+            return action([=](Arg&, cspan<const char*> a) { func(a); });
+        }
+
+        /// Add an arbitrary action:  `func()`
+        Arg& action(std::function<void()>&& func)
+        {
+            return action([=](Arg&, cspan<const char*>) { func(); });
+        }
+
+        // Old style action for compatibility
+        Arg& action(int (*func)(int, const char**))
+        {
+            return action([=](Arg&, cspan<const char*> a) {
+                func(int(a.size()), (const char**)a.data());
+            });
+        }
+
+        /// Return the name of the argument.
+        string_view name() const;
+
+        /// Return the "destination", the name of the attribute in which
+        /// the argument value will be stored.
+        string_view dest() const;
+
+        /// Get a reference to the ArgParse that owns this Arg.
+        ArgParse& argparse() { return m_argparse; }
+
+    protected:
+        ArgParse& m_argparse;
+    };
+
+    /// @}
+
+    // ------------------------------------------------------------------
+    /// @defgroup Action library
+    /// @{
+    ///
+    /// These are actions provided for convenience.
+    /// Examples of their use:
+    ///
+    ///     ArgParse ap;
+    ///     ...
+    ///
+    ///     // Flag, just store 1 if set (default to 0)
+    ///     ap.add_argument("-v")
+    ///       .action(ArgParse::store_true());
+    ///
+    ///     // Store 42 if the flag is encountered (default is 1)
+    ///     ap.add_argument("--foo")
+    ///       .defaultval(1)
+    ///       .action(ArgParse::store_const(42));
+    ///
+    ///     // Take an integer argument and store it
+    ///     ap.add_argument("--bar")
+    ///       .action(ArgParse::store<int>());
+    ///
+    ///     // Take 3 floating point arguments, pass default as Color3f.
+    ///     ap.add_argument("--color")
+    ///       .nargs(3)
+    ///       .metavar("R G B")
+    ///       .action(ArgParse::store<float>)
+    ///       .defaultval(Imath::Color3f(0.5f, 0.5f, 0.5f));
+    ///
+    ///     // Take a single string argument, but *append* it, so if the
+    ///     // option appears multiple time, you get a list of strings.
+    ///     ap.add_argument("-o")
+    ///       .action(ArgParse::append());
+    ///
+    ///     // Another string appending example, but using a positional
+    ///     // argument.
+    ///     ap.add_argument("filename")
+    ///       .action(ArgParse::append());
+    ///
+
+    /// Return an action that stores 1 into its destination attribute.
+    static ArgAction store_true();
+
+    /// Return an action that stores 0 into its destination attribute.
+    static ArgAction store_false();
+
+    /// Return an action that stores a constant value into its destination
+    /// attribute.
+    template<typename T> static ArgAction store_const(const T& value)
+    {
+        return [&, value](Arg& arg, cspan<const char*> myarg) {
+            arg.argparse().params()[arg.dest()] = value;
+        };
+    }
+
+    /// Return an action that stores into its destination attribute the
+    /// following `n` command line arguments (where `n` is the number of
+    /// additional command line arguments that this option requires).
+    template<typename T = ustring> static ArgAction store()
+    {
+        return [&](Arg& arg, cspan<const char*> myarg) {
+            if (myarg[0][0] == '-')  // Skip command itself
+                myarg = myarg.subspan(1);
+            ParamValueList& pl(arg.argparse().params());
+            int n   = int(myarg.size());
+            T* vals = OIIO_ALLOCA(T, n);
+            for (int i = 0; i < n; ++i)
+                vals[i] = Strutil::from_string<T>(myarg[i]);
+            if (n == 1) {
+                pl[arg.dest()] = vals[0];
+            } else {  // array case -- always store as strings
+                pl.attribute(arg.dest(), TypeDesc(BaseTypeFromC<T>::value, n),
+                             vals);
+            }
+        };
+    }
+
+    /// Return an action that appends into its destination attribute the
+    /// following `n` command line arguments (where `n` is the number of
+    /// additional command line arguments that this option requires).
+    template<typename T = ustring> static ArgAction append()
+    {
+        return [&](Arg& arg, cspan<const char*> myarg) {
+            if (myarg[0][0] == '-')  // Skip command itself
+                myarg = myarg.subspan(1);
+            ParamValueList& pl(arg.argparse().params());
+            ParamValue* pv = pl.find_pv(arg.dest());
+            // TypeDesc t = pv ? pv->type() : TypeUnknown;
+            int nold = pv ? pv->type().basevalues() : 0;
+            int n    = int(myarg.size()) + nold;
+            T* vals  = OIIO_ALLOCA(T, n);
+            for (int i = 0; i < nold; ++i)
+                vals[i] = Strutil::from_string<T>(pv->get_string_indexed(i));
+            for (int i = 0; i < n; ++i)
+                vals[i + nold] = Strutil::from_string<T>(myarg[i]);
+            if (n == 1) {
+                pl[arg.dest()] = vals[0];
+            } else {  // array case -- always store as strings
+                pl.attribute(arg.dest(), TypeDesc(BaseTypeFromC<T>::value, n),
+                             vals);
+            }
+        };
+    }
+
+    /// Return an action that does nothing. I guess you could use use this
+    /// for an argument that is obsolete and is still accepted, but no
+    /// longer has any function.
+    static Action do_nothing();
+
+    /// @}
+
+
+    // ------------------------------------------------------------------
+    /// @defgroup Retrieving values of parsed arguments
+    /// @{
+    ///
+    /// Retrieve arguments in the same manner that you would access them
+    /// from a OIIO::ParamValueList.
+    ///
+    /// Examples:
+    ///
+    ///     // Please see the code example in the "Action library" section above
+    ///     // for the argument declarations.
+    ///
+    ///     // retrieve whether -v flag was set
+    ///     bool verbose = ap["v"].get<int>();
+    ///
+    ///     // Retrieve the parameter passed to --bar, defaulting to 13 if
+    ///     // never set on the command line:
+    ///     int bar = ap["bar"].get<int>(13);
+    ///
+    ///     // Retrieve the color, which had 3 float parameters. Extract
+    ///     // it as an Imath::Color3f.
+    ///     Imath::Color3f diffuse = ap["color"].get<Imath::Color3f>();
+    ///
+    ///     // Retrieve the filename list as a vector:
+    ///     auto filenames = ap["filename"].as_vec<std::string>();
+    ///     for (auto& f : filenames)
+    ///         Strutil::printf("  file: \"%s\"\n", f);
+    ///
+
+    /// Access a single argument result by name.
+    AttrDelegate<const ParamValueList> operator[](string_view name) const
+    {
+        return { &cparams(), name };
+    }
+    /// Access a single argument result by name.
+    AttrDelegate<ParamValueList> operator[](string_view name)
+    {
+        return { &params(), name };
+    }
+
+    /// Directly access the ParamValueList that holds the argument results.
+    ParamValueList& params();
+    /// Directly access the ParamValueList that holds the argument results
+    /// (const version).
+    const ParamValueList& cparams() const;
+
+    /// @}
+
+
+private:
+    class Impl;
+    std::shared_ptr<Impl> m_impl;  // PIMPL pattern
+    Arg& argx(const char* argname, ...);
+    friend class ArgOption;
+
+public:
+    // ------------------------------------------------------------------
+    // Old API.  DEPRECATED(2.2)
+
+    // Declare the command line options.  After the introductory message,
+    // parameters are a set of format strings and variable pointers.  Each
+    // string contains an option name and a scanf-like format string to
+    // enumerate the arguments of that option (eg. `"-option %d %f %s"`).
+    // The format string is followed by a list of pointers to the argument
+    // variables, just like scanf.  A NULL terminates the list.  Multiple
+    // calls to options() will append additional options.
+    int options(const char* intro, ...);
+
+    // old name
+    // DEPRECATED(2.2)
+    int parse(int argc, const char** argv) { return parse_args(argc, argv); }
 
     // Type for a callback that writes something to the output stream.
     typedef std::function<void(const ArgParse& ap, std::ostream&)> callback_t;
-
     // Set callbacks to run that will print any matter you want as part
     // of the verbose usage, before and after the options are detailed.
     void set_preoption_help(callback_t callback);
     void set_postoption_help(callback_t callback);
 
-private:
-    class Impl;
-    std::unique_ptr<Impl> m_impl;  // PIMPL pattern
+    // DEPRECATED(2.2) synonym for `print_help()`.
+    void usage() const { print_help(); }
 };
 
 

--- a/src/include/OpenImageIO/argparse.h
+++ b/src/include/OpenImageIO/argparse.h
@@ -389,7 +389,7 @@ public:
     ///       .help("Verbose mode")
     ///       .action(Arg::store_true());
     ///
-    class Arg {
+    class OIIO_API Arg {
     public:
         // Arg constructor. This should only be called by
         // ArgParse::add_argument().

--- a/src/include/OpenImageIO/argparse.h
+++ b/src/include/OpenImageIO/argparse.h
@@ -625,11 +625,12 @@ public:
             ParamValue* pv = pl.find_pv(arg.dest());
             // TypeDesc t = pv ? pv->type() : TypeUnknown;
             int nold = pv ? pv->type().basevalues() : 0;
-            int n    = int(myarg.size()) + nold;
+            int nnew = int(myarg.size());
+            int n    = nold + nnew;
             T* vals  = OIIO_ALLOCA(T, n);
             for (int i = 0; i < nold; ++i)
                 vals[i] = Strutil::from_string<T>(pv->get_string_indexed(i));
-            for (int i = 0; i < n; ++i)
+            for (int i = 0; i < nnew; ++i)
                 vals[i + nold] = Strutil::from_string<T>(myarg[i]);
             if (n == 1) {
                 pl[arg.dest()] = vals[0];

--- a/src/libOpenImageIO/compute_test.cpp
+++ b/src/libOpenImageIO/compute_test.cpp
@@ -223,33 +223,26 @@ test_compute()
 static void
 getargs(int argc, char* argv[])
 {
-    bool help = false;
     ArgParse ap;
     // clang-format off
-    ap.options(
-        "compute_test\n" OIIO_INTRO_STRING "\n"
-        "Usage:  compute_test [options]",
-        // "%*", parse_files, "",
-        "--help", &help, "Print help message",
-        "-v", &verbose, "Verbose mode",
-        "--threads %d", &numthreads,
-            ustring::sprintf("Number of threads (default: %d)", numthreads).c_str(),
-        "--iterations %d", &iterations,
-            ustring::sprintf("Number of iterations (default: %d)", iterations).c_str(),
-        "--trials %d", &ntrials, "Number of trials",
-        "--allgpus", &allgpus, "Run OpenCL tests on all devices, not just default",
-        "--wedge", &wedge, "Do a wedge test",
-        nullptr);
+    ap.intro("compute_test\n" OIIO_INTRO_STRING)
+      .usage("compute_test [options]");
+
+    ap.arg("-v", &verbose)
+      .help("Verbose mode");
+    ap.arg("--threads %d", &numthreads)
+      .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+    ap.arg("--iters %d", &iterations)
+      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+    ap.arg("--trials %d", &ntrials)
+      .help("Number of trials");
+    ap.arg("--allgpus", &allgpus)
+      .help("Run OpenCL tests on all devices, not just default");
+    ap.arg("--wedge", &wedge)
+      .help("Do a wedge test");
     // clang-format on
-    if (ap.parse(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-    if (help) {
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
+
+    ap.parse(argc, (const char**)argv);
 }
 
 

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -36,32 +36,24 @@ static int threadcounts[] = { 1,  2,  4,  8,  12,  16,   20,
 static void
 getargs(int argc, char* argv[])
 {
-    bool help = false;
     ArgParse ap;
     // clang-format off
-    ap.options(
-        "imagebufalgo_test\n" OIIO_INTRO_STRING "\n"
-        "Usage:  imagebufalgo_test [options]",
-        // "%*", parse_files, "",
-        "--help", &help, "Print help message",
-        "-v", &verbose, "Verbose mode",
-        "--threads %d", &numthreads,
-            ustring::sprintf("Number of threads (default: %d)", numthreads).c_str(),
-        "--iters %d", &iterations,
-            ustring::sprintf("Number of iterations (default: %d)", iterations).c_str(),
-        "--trials %d", &ntrials, "Number of trials",
-        "--wedge", &wedge, "Do a wedge test",
-        nullptr);
+    ap.intro("imagebufalgo_test\n" OIIO_INTRO_STRING)
+      .usage("imagebufalgo_test [options]");
+
+    ap.arg("-v", &verbose)
+      .help("Verbose mode");
+    ap.arg("--threads %d", &numthreads)
+      .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+    ap.arg("--iters %d", &iterations)
+      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+    ap.arg("--trials %d", &ntrials)
+      .help("Number of trials");
+    ap.arg("--wedge", &wedge)
+      .help("Do a wedge test");
     // clang-format on
-    if (ap.parse(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-    if (help) {
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
+
+    ap.parse(argc, (const char**)argv);
 }
 
 

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -39,51 +39,42 @@ static float cache_size               = 0;
 
 
 
-static int
-parse_files(int /*argc*/, const char* argv[])
-{
-    input_filename.emplace_back(argv[0]);
-    return 0;
-}
-
-
-
 static void
 getargs(int argc, char* argv[])
 {
-    bool help = false;
     ArgParse ap;
     // clang-format off
-    ap.options(
-        "imagespeed_test\n" OIIO_INTRO_STRING "\n"
-        "Usage:  imagespeed_test [options] filename...",
-        "%*", parse_files, "",
-        "--help", &help, "Print help message",
-        "-v", &verbose, "Verbose mode",
-        "--threads %d", &numthreads,
-            ustring::sprintf("Number of threads (default: %d)", numthreads).c_str(),
-        "--iters %d", &iterations,
-            ustring::sprintf("Number of iterations (default: %d)", iterations).c_str(),
-        "--trials %d", &ntrials, "Number of trials",
-        "--autotile %d", &autotile_size,
-            ustring::sprintf("Autotile size (when used; default: %d)", autotile_size).c_str(),
-        "--iteronly", &iter_only, "Run ImageBuf iteration tests only (not read tests)",
-        "--noiter", &no_iter, "Don't run ImageBuf iteration tests",
-        "--convert %s", &conversionname, "Convert to named type upon read (default: native)",
-        "--cache %f", &cache_size, "Specify ImageCache size, in MB",
-        "-o %s", &output_filename, "Test output by writing to this file",
-        "-od %s", &output_format, "Requested output format",
-        nullptr);
+    ap.intro("imagespeed_test\n" OIIO_INTRO_STRING)
+      .usage("imagespeed_test [options]");
+
+    ap.arg("filename")
+      .hidden()
+      .action([&](cspan<const char*> argv){ input_filename.emplace_back(argv[0]); });
+    ap.arg("-v", &verbose)
+      .help("Verbose mode");
+    ap.arg("--threads %d", &numthreads)
+      .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+    ap.arg("--iters %d", &iterations)
+      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+    ap.arg("--trials %d", &ntrials)
+      .help("Number of trials");
+    ap.arg("--autotile %d", &autotile_size)
+      .help(Strutil::sprintf("Autotile size (when used; default: %d)", autotile_size));
+    ap.arg("--iteronly", &iter_only)
+      .help("Run ImageBuf iteration tests only (not read tests)");
+    ap.arg("--noiter", &no_iter)
+      .help("Don't run ImageBuf iteration tests");
+    ap.arg("--convert %s", &conversionname)
+      .help("Convert to named type upon read (default: native)");
+    ap.arg("--cache %f", &cache_size)
+      .help("Specify ImageCache size, in MB");
+    ap.arg("-o %s", &output_filename)
+      .help("Test output by writing to this file");
+    ap.arg("-od %s", &output_format)
+      .help("Requested output format");
     // clang-format on
-    if (ap.parse(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-    if (help) {
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
+
+    ap.parse(argc, (const char**)argv);
 }
 
 

--- a/src/libutil/argparse.cpp
+++ b/src/libutil/argparse.cpp
@@ -15,26 +15,49 @@
 
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/dassert.h>
+#include <OpenImageIO/filesystem.h>
+#include <OpenImageIO/paramlist.h>
 #include <OpenImageIO/platform.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/sysutil.h>
 
 OIIO_NAMESPACE_BEGIN
 
-class ArgOption {
+class ArgOption : public ArgParse::Arg {
 public:
     typedef int (*callback_t)(int, const char**);
 
-    ArgOption(const char* str);
+    ArgOption(ArgParse& ap, const char* argspec);
     ~ArgOption() {}
 
     int initialize();
 
-    int parameter_count() const { return m_count; }
-    const std::string& name() const { return m_flag; }
+    int nargs() const { return m_count; }
+    void nargs(int n);
 
-    const std::string& fmt() const { return m_format; }
+    string_view metavar() const { return Strutil::join(m_prettyargs, " "); }
+    void metavar(string_view name)
+    {
+        m_prettyargs = Strutil::splits(name);
+        m_count      = 0;
+        nargs(int(m_prettyargs.size()));
+        compute_prettyformat();
+    }
+
+    const std::string& flag() const { return m_flag; }
+    const std::string& name() const { return m_name; }
+    const std::string& dest() const { return m_dest; }
+
+    const std::string& argspec() const { return m_argspec; }
     const std::string& prettyformat() const { return m_prettyformat; }
+    void compute_prettyformat()
+    {
+        m_prettyformat = flag();
+        if (m_prettyargs.size()) {
+            m_prettyformat += " ";
+            m_prettyformat += Strutil::join(m_prettyargs, " ");
+        }
+    }
 
     bool is_flag() const { return m_type == Flag; }
     bool is_reverse_flag() const { return m_type == ReverseFlag; }
@@ -46,9 +69,6 @@ public:
 
     void set_parameter(int i, const char* argv);
 
-    void add_argument(const char* argv);
-    int invoke_callback() const;
-
     int invoke_callback(int argc, const char** argv) const
     {
         return m_callback ? m_callback(argc, argv) : 0;
@@ -59,59 +79,87 @@ public:
     void found_on_command_line() { m_repetitions++; }
     int parsed_count() const { return m_repetitions; }
 
-    void description(const char* d) { m_descript = d; }
-    const std::string& description() const { return m_descript; }
+    void help(std::string h) { m_help = std::move(h); }
+    const std::string& help() const { return m_help; }
 
-    bool is_separator() const { return fmt() == "<SEPARATOR>"; }
+    bool is_separator() const { return argspec() == "<SEPARATOR>"; }
+    bool hidden() const { return m_hidden; }
+
+    bool had_error() const { return m_error; }
+    void had_error(bool e) { m_error = e; }
+
+    ArgParse::ArgAction& action() { return m_action; }
 
 private:
     enum OptionType { None, Regular, Flag, ReverseFlag, Sublist };
 
-    std::string m_format;        // original format string
+    std::string m_argspec;       // original format string specification
     std::string m_prettyformat;  // human readable format
     std::string m_flag;          // just the -flag_foo part
+    std::string m_name;          // just the 'flat_foo' part
+    std::string m_dest;          // destination parameter name
     std::string m_code;          // paramter types, eg "df"
-    std::string m_descript;
+    std::string m_help;
     OptionType m_type = None;
-    int m_count       = 0;       // number of parameters
-    std::vector<void*> m_param;  // pointers to app data vars
-    callback_t m_callback = nullptr;
-    int m_repetitions     = 0;      // number of times on cmd line
-    bool m_has_callback   = false;  // needs a callback?
-    std::vector<std::string> m_argv;
+    int m_count       = 0;               // number of parameters
+    std::vector<void*> m_param;          // pointers to app data vars
+    std::vector<TypeDesc> m_paramtypes;  // Expected param types
+    std::vector<std::string> m_prettyargs;
+    ArgParse::ArgAction m_action = nullptr;
+    callback_t m_callback        = nullptr;
+    int m_repetitions            = 0;      // number of times on cmd line
+    bool m_has_callback          = false;  // needs a callback?
+    bool m_hidden                = false;  // hidden?
+    bool m_error                 = false;  // invalid option, had an error
+    friend class ArgParse;
+    friend class ArgParse::Arg;
+    friend class ArgParse::Impl;
 };
 
 
 
 class ArgParse::Impl {
 public:
+    ArgParse& m_argparse;
     int m_argc;                        // a copy of the command line argc
     const char** m_argv;               // a copy of the command line argv
     mutable std::string m_errmessage;  // error message
-    ArgOption* m_global = nullptr;     // option for extra cmd line arguments
-    ArgOption* m_preoption
-        = nullptr;  // option for pre-switch cmd line arguments
+    ArgOption* m_global    = nullptr;  // option for extra cmd line arguments
+    ArgOption* m_preoption = nullptr;  // pre-switch cmd line arguments
     std::string m_intro;
+    std::string m_usage;
+    std::string m_description;
+    std::string m_epilog;
+    std::string m_prog;
+    bool m_print_defaults = false;
+    bool m_add_help       = true;
+    bool m_exit_on_error  = true;
     std::vector<std::unique_ptr<ArgOption>> m_option;
     callback_t m_preoption_help  = [](const ArgParse&, std::ostream&) {};
     callback_t m_postoption_help = [](const ArgParse&, std::ostream&) {};
+    ParamValueList m_params;
 
-    Impl(int argc, const char** argv)
-        : m_argc(argc)
+    Impl(ArgParse& parent, int argc, const char** argv)
+        : m_argparse(parent)
+        , m_argc(argc)
         , m_argv(argv)
+        , m_prog(Filesystem::filename(Sysutil::this_program_path()))
     {
     }
 
-    int parse(int argc, const char** argv);
+    int parse_args(int argc, const char** argv);
 
     ArgOption* find_option(const char* name);
     int found(const char* option);  // number of times option was parsed
 
+    // Error with std::fmt-like formatting
     template<typename... Args>
-    void error(const char* fmt, const Args&... args) const
+    void errorfmt(const char* fmt, const Args&... args) const
     {
-        m_errmessage = Strutil::sprintf(fmt, args...);
+        m_errmessage = Strutil::fmt::format(fmt, args...);
     }
+
+    // Error with printf-like formatting
     template<typename... Args>
     void errorf(const char* fmt, const Args&... args) const
     {
@@ -126,29 +174,33 @@ public:
 // The format may look like this: "%g:FOO", and in that case split
 // the formatting part (e.g. "%g") from the self-documenting
 // human-readable argument name ("FOO")
-ArgOption::ArgOption(const char* str)
+ArgOption::ArgOption(ArgParse& ap, const char* argspec)
+    : ArgParse::Arg(ap)
 {
-    std::vector<string_view> prettyargs;
-    std::vector<string_view> uglyargs;
-    auto args = Strutil::splits(str, " ");
+    std::vector<std::string> uglyargs;
+    auto args = Strutil::splits(argspec, " ");
+    int i     = 0;
     for (auto&& a : args) {
+        if (i == 0)
+            m_flag = a;
         auto parts     = Strutil::splitsv(a, ":", 2);
         string_view ug = a, pr = a;
         if (parts.size() == 2) {
             ug = parts[0];
             pr = parts[1];
         }
+        if (i && parts.size() == 1 && ug.size() && ug[0] != '%')
+            ug = "%s";  // If no type spec, just assume string
         uglyargs.push_back(ug);
         if (pr == "%L")
             pr = "%s";
         if (pr != "%!" && pr != "%@")
-            prettyargs.push_back(pr);
+            if (i)
+                m_prettyargs.push_back(pr);
+        ++i;
     }
-    m_format       = Strutil::join(uglyargs, " ");
-    m_prettyformat = Strutil::join(prettyargs, " ");
-    // std::cout << "Arg str = " << str << "\n";
-    // std::cout << "   pretty = " << m_prettyformat << "\n";
-    // std::cout << "   ugly   = " << m_format << "\n";
+    m_argspec = Strutil::join(uglyargs, " ");
+    compute_prettyformat();
 }
 
 
@@ -163,23 +215,27 @@ ArgOption::initialize()
     size_t n;
     const char* s;
 
-    if (m_format.empty() || m_format == "%*") {
+    if (m_argspec.empty() || m_argspec == "%*") {
         m_type  = Sublist;
         m_count = 1;  // sublist callback function pointer
         m_code  = "*";
         m_flag  = "";
-    } else if (m_format == "%1") {
+    } else if (m_argspec == "%1") {
         m_type  = Sublist;
         m_count = 1;  // sublist callback function pointer
         m_code  = "*";
         m_flag  = "";
     } else if (is_separator()) {
+    } else if (m_argspec[0] != '-') {
+        m_type  = Sublist;
+        m_count = 1;  // sublist callback function pointer
+        m_code  = "*";
+        m_flag  = "";
     } else {
         // extract the flag name
-        s = &m_format[0];
+        s = &m_argspec[0];
         assert(*s == '-');
         assert(isalpha(s[1]) || (s[1] == '-' && isalpha(s[2])));
-
         s++;
         if (*s == '-')
             s++;
@@ -188,13 +244,13 @@ ArgOption::initialize()
             s++;
 
         if (!*s) {
-            m_flag  = m_format;
+            m_flag  = m_argspec;
             m_type  = Flag;
             m_count = 1;
             m_code  = "b";
         } else {
-            n = s - (&m_format[0]);
-            m_flag.assign(m_format.begin(), m_format.begin() + n);
+            n = s - (&m_argspec[0]);
+            m_flag.assign(m_argspec.begin(), m_argspec.begin() + n);
 
             // Parse the scanf-like parameters
 
@@ -255,10 +311,35 @@ ArgOption::initialize()
         }
     }
 
+    if (m_argspec[0] == '-')
+        m_name = Strutil::lstrip(m_flag, "-");
+    else
+        m_name = m_argspec;
+    m_dest = m_name;
+
     // Allocate space for the parameter pointers and initialize to NULL
-    m_param.resize(m_count, NULL);
+    m_param.resize(m_count, nullptr);
+    m_paramtypes.resize(m_count, TypeUnknown);
 
     return 0;
+}
+
+
+
+// Allocate space for the parameter pointers and initialize to NULL
+void
+ArgOption::nargs(int n)
+{
+    if (n == m_count)
+        return;
+    m_param.resize(n, nullptr);
+    m_paramtypes.resize(n, TypeUnknown);
+    m_prettyargs.resize(n, Strutil::upper(m_name));
+    compute_prettyformat();
+    for (int i = m_count; i < n; ++i)
+        m_argspec += Strutil::concat(" %s:", m_prettyargs[i]);
+    initialize();
+    m_count = n;
 }
 
 
@@ -270,7 +351,8 @@ void
 ArgOption::add_parameter(int i, void* p)
 {
     assert(i >= 0 && i < m_count);
-    m_param[i] = p;
+    m_param[i]      = p;
+    m_paramtypes[i] = TypeUnknown;
 }
 
 
@@ -309,36 +391,15 @@ ArgOption::set_parameter(int i, const char* argv)
 
 
 
-// Call the sublist callback if any arguments have been parsed
-int
-ArgOption::invoke_callback() const
+ArgParse::ArgParse()
+    : m_impl(new Impl(*this, 0, nullptr))
 {
-    assert(m_count == 1);
-
-    int argc = (int)m_argv.size();
-    if (argc == 0)
-        return 0;
-
-    // Convert the argv's to char*[]
-    const char** myargv = OIIO_ALLOCA(const char*, argc);
-    for (int i = 0; i < argc; ++i)
-        myargv[i] = m_argv[i].c_str();
-    return invoke_callback(argc, myargv);
-}
-
-
-
-// Add an argument to this sublist option
-void
-ArgOption::add_argument(const char* argv)
-{
-    m_argv.emplace_back(argv);
 }
 
 
 
 ArgParse::ArgParse(int argc, const char** argv)
-    : m_impl(new Impl(argc, argv))
+    : m_impl(new Impl(*this, argc, argv))
 {
 }
 
@@ -356,17 +417,38 @@ ArgParse::~ArgParse() {}
 // function returns early.  If there is a match, all the arguments for
 // that option are parsed and the associated variables are set.
 int
-ArgParse::parse(int xargc, const char** xargv)
+ArgParse::parse_args(int xargc, const char** xargv)
 {
-    return m_impl->parse(xargc, xargv);
+    int r = m_impl->parse_args(xargc, xargv);
+    if (r < 0 && m_impl->m_exit_on_error) {
+        Sysutil::Term term(std::cerr);
+        std::cerr << term.ansi("red") << prog_name() << " error: " << geterror()
+                  << term.ansi("default") << std::endl;
+        print_help();
+        exit(EXIT_FAILURE);
+    }
+    return r;
 }
 
 
+
 int
-ArgParse::Impl::parse(int xargc, const char** xargv)
+ArgParse::Impl::parse_args(int xargc, const char** xargv)
 {
     m_argc = xargc;
     m_argv = xargv;
+
+    // Add help option if requested
+    if (m_add_help && !find_option("--help")) {
+        m_option.emplace(m_option.begin(), new ArgOption(m_argparse, "--help"));
+        // m_option[0]->m_type = ArgOption::Flag;
+        m_option[0]->m_help   = "Print help message";
+        m_option[0]->m_action = [&](Arg& arg, cspan<const char*> myarg) {
+            this->m_argparse.print_help();
+            exit(EXIT_SUCCESS);
+        };
+        m_option[0]->initialize();
+    }
 
     bool any_option_encountered = false;
     for (int i = 1; i < m_argc; i++) {
@@ -379,7 +461,7 @@ ArgParse::Impl::parse(int xargc, const char** xargv)
             if (colon != std::string::npos)
                 argname.erase(colon, std::string::npos);
             ArgOption* option = find_option(argname.c_str());
-            if (option == NULL) {
+            if (!option) {
                 errorf("Invalid option \"%s\"", m_argv[i]);
                 return -1;
             }
@@ -387,36 +469,52 @@ ArgParse::Impl::parse(int xargc, const char** xargv)
             option->found_on_command_line();
 
             if (option->is_flag() || option->is_reverse_flag()) {
-                option->set_parameter(0, NULL);
+                option->set_parameter(0, nullptr);
                 if (option->has_callback())
                     option->invoke_callback(1, m_argv + i);
+                if (option->m_action) {
+                    option->m_action(*option, { m_argv + i, 1 });
+                } else {
+                    m_params[option->dest()] = option->is_flag() ? 1 : 0;
+                }
+                // else
             } else {
                 assert(option->is_regular());
-                for (int j = 0; j < option->parameter_count(); j++) {
+                int n = option->nargs();
+                assert(n >= 1);
+                for (int j = 0; j < n; j++) {
                     if (j + i + 1 >= m_argc) {
-                        errorf("Missing parameter %d from option "
-                               "\"%s\"",
-                               j + 1, option->name());
+                        errorf("Missing parameter %d from option \"%s\"", j + 1,
+                               option->flag());
                         return -1;
                     }
                     option->set_parameter(j, m_argv[i + j + 1]);
                 }
                 if (option->has_callback())
-                    option->invoke_callback(1 + option->parameter_count(),
-                                            m_argv + i);
-                i += option->parameter_count();
+                    option->invoke_callback(1 + n, m_argv + i);
+                if (option->m_action) {
+                    option->m_action(*option, { m_argv + i, n + 1 });
+                } else {
+                    m_params[option->dest()] = m_argv[i + 1];
+                }
+                i += n;
             }
         } else {
             // not an option nor an option parameter, glob onto global list,
             // or the preoption list if a preoption callback was given and
             // we haven't encountered any options yet.
             if (m_preoption && !any_option_encountered)
-                m_preoption->invoke_callback(1, m_argv + i);
-            else if (m_global)
-                m_global->invoke_callback(1, m_argv + i);
-            else {
-                errorf("Argument \"%s\" does not have an associated "
-                       "option",
+                if (m_preoption->m_action)
+                    m_preoption->m_action(*m_preoption, { m_argv + i, 1 });
+                else
+                    m_preoption->invoke_callback(1, m_argv + i);
+            else if (m_global) {
+                if (m_global->m_action)
+                    m_global->m_action(*m_global, { m_argv + i, 1 });
+                else
+                    m_global->invoke_callback(1, m_argv + i);
+            } else {
+                errorf("Argument \"%s\" does not have an associated option",
                        m_argv[i]);
                 return -1;
             }
@@ -442,7 +540,7 @@ ArgParse::options(const char* intro, ...)
     va_list ap;
     va_start(ap, intro);
 
-    m_impl->m_intro += intro;
+    m_impl->m_description += intro;
     for (const char* cur = va_arg(ap, char*); cur; cur = va_arg(ap, char*)) {
         if (m_impl->find_option(cur) && strcmp(cur, "<SEPARATOR>")) {
             m_impl->errorf("Option \"%s\" is multiply defined", cur);
@@ -450,7 +548,7 @@ ArgParse::options(const char* intro, ...)
         }
 
         // Build a new option and then parse the values
-        std::unique_ptr<ArgOption> option(new ArgOption(cur));
+        std::unique_ptr<ArgOption> option(new ArgOption(*this, cur));
         if (option->initialize() < 0) {
             return -1;
         }
@@ -470,7 +568,7 @@ ArgParse::options(const char* intro, ...)
             option->set_callback((ArgOption::callback_t)va_arg(ap, void*));
 
         // Grab any parameters and store them with this option
-        for (int i = 0; i < option->parameter_count(); i++) {
+        for (int i = 0; i < option->nargs(); i++) {
             void* p = va_arg(ap, void*);
             option->add_parameter(i, p);
             if (option.get() == m_impl->m_global
@@ -479,7 +577,9 @@ ArgParse::options(const char* intro, ...)
         }
 
         // Last argument is description
-        option->description((const char*)va_arg(ap, const char*));
+        option->help((const char*)va_arg(ap, const char*));
+        if (option->help().empty())
+            option->hidden();
         m_impl->m_option.emplace_back(std::move(option));
     }
 
@@ -489,12 +589,210 @@ ArgParse::options(const char* intro, ...)
 
 
 
+string_view
+ArgParse::Arg::name() const
+{
+    return static_cast<const ArgOption*>(this)->name();
+}
+
+
+
+string_view
+ArgParse::Arg::dest() const
+{
+    return static_cast<const ArgOption*>(this)->dest();
+}
+
+
+
+ParamValueList&
+ArgParse::params()
+{
+    return m_impl->m_params;
+}
+
+
+
+const ParamValueList&
+ArgParse::cparams() const
+{
+    return m_impl->m_params;
+}
+
+
+
+ArgParse::Arg&
+ArgParse::add_argument(const char* argname)
+{
+    // Build a new option and then parse the values
+    auto option = new ArgOption(*this, argname);
+    m_impl->m_option.emplace_back(option);
+    option->m_param.resize(option->nargs(), nullptr);
+    option->m_paramtypes.resize(option->nargs(), TypeUnknown);
+
+    if (option->initialize() < 0) {
+        option->had_error(true);
+        return *static_cast<Arg*>(m_impl->m_option.back().get());
+    }
+
+    if (argname[0] == '\0'
+        || (argname[0] == '%' && argname[1] == '*' && argname[2] == '\0')) {
+        // set default global option
+        m_impl->m_global = option;
+    } else if (argname[0] == '%' && argname[1] == '1' && argname[2] == '\0') {
+        // set default pre-switch option
+        m_impl->m_preoption = option;
+    } else if (argname[0] != '-' && argname[0] != '<') {
+        // set default global option
+        m_impl->m_global = option;
+    }
+
+    return *static_cast<Arg*>(m_impl->m_option.back().get());
+}
+
+
+
+ArgParse::Arg&
+ArgParse::argx(const char* argname, ...)
+{
+    va_list ap;
+    va_start(ap, argname);
+
+    // Build a new option and then parse the values
+    std::unique_ptr<ArgOption> option(new ArgOption(*this, argname));
+    if (option->initialize() < 0) {
+        option->had_error(true);
+        m_impl->m_option.emplace_back(std::move(option));
+        va_end(ap);
+        return *static_cast<Arg*>(m_impl->m_option.back().get());
+    }
+
+    if (argname[0] == '\0'
+        || (argname[0] == '%' && argname[1] == '*' && argname[2] == '\0')) {
+        // set default global option
+        m_impl->m_global = option.get();
+    }
+
+    if (argname[0] == '%' && argname[1] == '1' && argname[2] == '\0') {
+        // set default pre-switch option
+        m_impl->m_preoption = option.get();
+    }
+
+    if (option->has_callback())
+        option->set_callback((ArgOption::callback_t)va_arg(ap, void*));
+
+    // Grab any parameters and store them with this option
+    for (int i = 0; i < option->nargs(); i++) {
+        void* p = va_arg(ap, void*);
+        option->add_parameter(i, p);
+        if (option.get() == m_impl->m_global
+            || option.get() == m_impl->m_preoption)
+            option->set_callback((ArgOption::callback_t)p);
+    }
+
+    m_impl->m_option.emplace_back(std::move(option));
+    va_end(ap);
+    return *static_cast<Arg*>(m_impl->m_option.back().get());
+}
+
+
+
+ArgParse::Arg&
+ArgParse::separator(string_view text)
+{
+    return arg("<SEPARATOR>").help(text);
+}
+
+
+
+ArgParse::Arg&
+ArgParse::Arg::help(string_view help)
+{
+    static_cast<ArgOption*>(this)->help(help);
+    return *this;
+}
+
+
+
+ArgParse::Arg&
+ArgParse::Arg::nargs(int n)
+{
+    static_cast<ArgOption*>(this)->nargs(n);
+    return *this;
+}
+
+
+
+ArgParse::Arg&
+ArgParse::Arg::metavar(string_view name)
+{
+    static_cast<ArgOption*>(this)->metavar(name);
+    return *this;
+}
+
+
+
+ArgParse::Arg&
+ArgParse::Arg::action(ArgAction&& action)
+{
+    static_cast<ArgOption*>(this)->m_action = std::move(action);
+    return *this;
+}
+
+
+
+ArgParse::Arg&
+ArgParse::Arg::dest(string_view dest)
+{
+    static_cast<ArgOption*>(this)->m_dest = dest;
+    return *this;
+}
+
+
+
+ArgParse::Arg&
+ArgParse::Arg::hidden()
+{
+    static_cast<ArgOption*>(this)->m_hidden = true;
+    return *this;
+}
+
+
+
+ArgParse::Action
+ArgParse::do_nothing()
+{
+    return [](cspan<const char*> myarg) { return true; };
+}
+
+
+
+ArgParse::ArgAction
+ArgParse::store_true()
+{
+    return [](Arg& arg, cspan<const char*> myarg) {
+        arg.argparse().params()[arg.dest()] = 1;
+    };
+}
+
+
+
+ArgParse::ArgAction
+ArgParse::store_false()
+{
+    return [](Arg& arg, cspan<const char*> myarg) {
+        arg.argparse().params()[arg.dest()] = 0;
+    };
+}
+
+
+
 // Find an option by name in the option vector
 ArgOption*
 ArgParse::Impl::find_option(const char* name)
 {
     for (auto&& opt : m_option) {
-        const char* optname = opt->name().c_str();
+        const char* optname = opt->flag().c_str();
         if (!strcmp(name, optname))
             return opt.get();
         // Match even if the user mixes up one dash or two
@@ -508,7 +806,79 @@ ArgParse::Impl::find_option(const char* name)
                 return opt.get();
     }
 
-    return NULL;
+    return nullptr;
+}
+
+
+
+ArgParse&
+ArgParse::intro(string_view str)
+{
+    m_impl->m_intro = str;
+    return *this;
+}
+
+
+
+ArgParse&
+ArgParse::usage(string_view str)
+{
+    m_impl->m_usage = str;
+    return *this;
+}
+
+
+
+ArgParse&
+ArgParse::description(string_view str)
+{
+    m_impl->m_description = str;
+    return *this;
+}
+
+
+
+ArgParse&
+ArgParse::epilog(string_view str)
+{
+    m_impl->m_epilog = str;
+    return *this;
+}
+
+
+
+ArgParse&
+ArgParse::prog(string_view str)
+{
+    m_impl->m_prog = str;
+    return *this;
+}
+
+
+
+ArgParse&
+ArgParse::print_defaults(bool print)
+{
+    m_impl->m_print_defaults = print;
+    return *this;
+}
+
+
+
+ArgParse&
+ArgParse::add_help(bool add_help)
+{
+    m_impl->m_add_help = add_help;
+    return *this;
+}
+
+
+
+ArgParse&
+ArgParse::exit_on_error(bool exit_on_error)
+{
+    m_impl->m_exit_on_error = exit_on_error;
+    return *this;
 }
 
 
@@ -532,11 +902,40 @@ ArgParse::geterror() const
 
 
 
+static void
+println(std::ostream& out, string_view str, int blanklines = 1)
+{
+    if (str.size()) {
+        out << str;
+        if (str.back() != '\n')
+            out << '\n';
+        while (blanklines-- > 0)
+            out << '\n';
+    }
+}
+
+
+
+std::string
+ArgParse::prog_name() const
+{
+    return m_impl->m_prog;
+}
+
+
+
 void
-ArgParse::usage() const
+ArgParse::print_help() const
 {
     const size_t longline = 35;
-    std::cout << m_impl->m_intro << '\n';
+
+    println(std::cout, m_impl->m_intro);
+    if (m_impl->m_usage.size()) {
+        std::cout << "Usage: ";
+        println(std::cout, m_impl->m_usage);
+    }
+    println(std::cout, m_impl->m_description);
+
     m_impl->m_preoption_help(*this, std::cout);
     size_t maxlen = 0;
 
@@ -551,11 +950,10 @@ ArgParse::usage() const
     int columns = Sysutil::terminal_columns();
 
     for (auto&& opt : m_impl->m_option) {
-        if (opt->description().length()) {
+        if (!opt->hidden() /*opt->help().length()*/) {
             size_t fmtlen = opt->prettyformat().length();
             if (opt->is_separator()) {
-                std::cout << Strutil::wordwrap(opt->description(), columns - 2,
-                                               0)
+                std::cout << Strutil::wordwrap(opt->help(), columns - 2, 0)
                           << '\n';
             } else {
                 std::cout << "    " << opt->prettyformat();
@@ -563,13 +961,18 @@ ArgParse::usage() const
                     std::cout << std::string(maxlen + 2 - fmtlen, ' ');
                 else
                     std::cout << "\n    " << std::string(maxlen + 2, ' ');
-                std::cout << Strutil::wordwrap(opt->description(), columns - 2,
-                                               (int)maxlen + 2 + 4 + 2)
-                          << '\n';
+                std::string h = opt->help();
+                if (m_impl->m_print_defaults && cparams().contains(opt->dest()))
+                    h += Strutil::sprintf(" (default: %s)",
+                                          cparams()[opt->dest()].get());
+                std::cout << Strutil::wordwrap(h, columns - 2,
+                                               (int)maxlen + 2 + 4 + 2);
+                std::cout << '\n';
             }
         }
     }
     m_impl->m_postoption_help(*this, std::cout);
+    println(std::cout, m_impl->m_epilog, 0);
 }
 
 
@@ -577,24 +980,28 @@ ArgParse::usage() const
 void
 ArgParse::briefusage() const
 {
-    std::cout << m_impl->m_intro << '\n';
+    println(std::cout, m_impl->m_intro);
+    if (m_impl->m_usage.size()) {
+        std::cout << "Usage: ";
+        println(std::cout, m_impl->m_usage);
+    }
+
     // Try to figure out how wide the terminal is, so we can word wrap.
     int columns = Sysutil::terminal_columns();
 
     std::string pending;
     for (auto&& opt : m_impl->m_option) {
-        if (opt->description().length()) {
+        if (!opt->hidden() /*opt->help().length()*/) {
             if (opt->is_separator()) {
                 if (pending.size())
                     std::cout << "    "
                               << Strutil::wordwrap(pending, columns - 2, 4)
                               << '\n';
                 pending.clear();
-                std::cout << Strutil::wordwrap(opt->description(), columns - 2,
-                                               0)
+                std::cout << Strutil::wordwrap(opt->help(), columns - 2, 0)
                           << '\n';
             } else {
-                pending += opt->name() + " ";
+                pending += opt->flag() + " ";
             }
         }
     }

--- a/src/libutil/argparse_test.cpp
+++ b/src/libutil/argparse_test.cpp
@@ -4,6 +4,8 @@
 
 #include <vector>
 
+#include <OpenEXR/ImathColor.h>
+
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/unittest.h>
@@ -63,15 +65,17 @@ callback(int argc, const char* argv[])
 
 
 static void
-test_basic()
+test_old()
 {
     auto args   = split_commands("basic alpha --flag --unflag --intarg 42 "
                                "--floatarg 3.5 --stringarg foo "
                                "--append xxx --append yyy "
+                               "--hidden "
                                "--callback who "
                                "bravo charlie");
     bool flag   = false;
     bool unflag = true;
+    bool hidden = false;
     int i       = 0;
     float f     = 0;
     std::string s;
@@ -88,6 +92,7 @@ test_basic()
         "%*", parse_postarg, "",
         "--flag", &flag, "Set flag",
         "--unflag %!", &unflag, "Unset flag",
+        "--hidden", &hidden, "",  // no help means hidden
         "--intarg %d", &i, "int",
         "--floatarg %f", &f, "float",
         "--stringarg %s", &s, "string",
@@ -100,6 +105,7 @@ test_basic()
     ap.parse(int(args.size()), args.data());
     OIIO_CHECK_EQUAL(flag, true);
     OIIO_CHECK_EQUAL(unflag, false);
+    OIIO_CHECK_EQUAL(hidden, true);
     OIIO_CHECK_EQUAL(i, 42);
     OIIO_CHECK_EQUAL(f, 3.5f);
     OIIO_CHECK_EQUAL(s, "foo");
@@ -126,10 +132,133 @@ test_basic()
 
 
 
+static void
+test_new()
+{
+    std::cout << "\nTesting new style:\n";
+    auto args = split_commands("basic -f -u --ci --cs --cf --istore 15 "
+                               "--fstore 12.5 --sstore hi "
+                               "--color 0.25 0.5 0.75 "
+                               "--app 14 --app 22 "
+                               "--sapp hello --sapp world "
+                               "--fbi a b c "
+                               "bravo charlie");
+
+    // clang-format off
+    ArgParse ap;
+    ap.intro("new style!")
+      .usage("here is my usage")
+      .description("description")
+      .epilog("epilog");
+
+    ap.arg("filename")
+      .action(ArgParse::append())
+      .hidden();
+    ap.arg("-f")
+      .help("Simple flag argument")
+      .action(ArgParse::store_true());
+    ap.arg("--f2")
+      .help("Simple flag argument (unused)")
+      .store_true();
+    ap.arg("-u")
+      .help("Simple flag argument - store false if set")
+      .store_false();
+    ap.arg("--u2")
+      .help("Simple flag argument - store false if set (unused)")
+      .store_false();
+    ap.arg("--ci")
+      .help("Store constant int")
+      .action(ArgParse::store_const(42));
+    ap.arg("--cf")
+      .help("Store constant float")
+      .action(ArgParse::store_const(3.14159f));
+    ap.arg("--cfdef")
+      .help("Store constant float")
+      .defaultval(42.0f)
+      .action(ArgParse::store_const(3.14159f));
+    ap.arg("--cs")
+      .help("Store constant string")
+      .action(ArgParse::store_const("hey hey"));
+
+    ap.separator("Storing values:");
+    ap.arg("--istore")
+      .help("store an int value")
+      .metavar("INT")
+      .action(ArgParse::store<int>());
+    ap.arg("--fstore")
+      .help("store a float value")
+      .metavar("FLOAT")
+      .action(ArgParse::store<float>());
+    ap.arg("--sstore")
+      .help("store a string value")
+      .metavar("STRING")
+      .action(ArgParse::store());
+#if 0
+    ap.arg("--color %f:R %f:G %f:B")
+      .help("store 3 floats into a color")
+      .action(ArgParse::store<float>());
+#else
+    ap.arg("--color R G B")
+      // .metavar("R G B")
+      .help("store 3 floats into a color")
+      .defaultval(Imath::Color3f(0.0f, 0.0f, 0.0f))
+      .action(ArgParse::store<float>());
+#endif
+    ap.arg("--unsettriple")
+      .help("store 3 floats into a triple")
+      .metavar("R G B")
+      .defaultval(Imath::Color3f(1.0f, 2.0f, 4.0f))
+      .action(ArgParse::store<float>());
+    ap.arg("--app")
+      .help("store an int, will append to a list")
+      .metavar("VAL")
+      .action(ArgParse::append<int>());
+    ap.arg("--sapp")
+      .help("store a string, will append to a list")
+      .metavar("STR")
+      .action(ArgParse::append());
+    ap.arg("--fbi")
+      .help("Call the FBI")
+      .nargs(3);
+    ap.add_help(true);
+    // clang-format on
+
+    ap.parse(int(args.size()), args.data());
+    ap.print_help();
+
+    OIIO_CHECK_EQUAL(ap["f"].get<int>(), true);
+    OIIO_CHECK_EQUAL(ap["f2"].get<int>(), false);
+    OIIO_CHECK_EQUAL(ap["u"].get<int>(), false);
+    OIIO_CHECK_EQUAL(ap["u2"].get<int>(), true);
+    OIIO_CHECK_EQUAL(ap["ci"].get<int>(), 42);
+    OIIO_CHECK_EQUAL(ap["cf"].get<float>(), 3.14159f);
+    OIIO_CHECK_EQUAL(ap["cfdef"].get<float>(), 42.0f);
+    OIIO_CHECK_EQUAL(ap["cs"].get<std::string>(), "hey hey");
+    OIIO_CHECK_EQUAL(ap["istore"].get<int>(), 15);
+    OIIO_CHECK_EQUAL(ap["fstore"].get<float>(), 12.5f);
+    OIIO_CHECK_EQUAL(ap["sstore"].get<std::string>(), "hi");
+    OIIO_CHECK_EQUAL(ap["color"].get<Imath::Color3f>(),
+                     Imath::Color3f(0.25f, 0.5f, 0.75f));
+    OIIO_CHECK_EQUAL(ap["unsettriple"].get<Imath::Color3f>(),
+                     Imath::Color3f(1.0f, 2.0f, 4.0f));
+    OIIO_CHECK_EQUAL(ap["filename"].type(), TypeDesc("string[2]"));
+    std::cout << "\nAll args:\n";
+    for (auto& a : ap.params())
+        Strutil::printf("  %s = %s   [%s]\n", a.name(), a.get_string(),
+                        a.type());
+    std::cout << "Extracting filenames:\n";
+    auto fn = ap["filename"].as_vec<std::string>();
+    for (auto& f : fn)
+        Strutil::printf("  \"%s\"\n", f);
+}
+
+
+
 int
 main(int /*argc*/, char* /*argv*/[])
 {
-    test_basic();
+    test_old();
+    test_new();
 
     return unit_test_failures != 0;
 }

--- a/src/libutil/atomic_test.cpp
+++ b/src/libutil/atomic_test.cpp
@@ -177,31 +177,24 @@ do_double_math(int iterations)
 static void
 getargs(int argc, char* argv[])
 {
-    bool help = false;
     ArgParse ap;
     // clang-format off
-    ap.options(
-        "atomic_test\n" OIIO_INTRO_STRING "\n"
-        "Usage:  atomic_test [options]",
-        // "%*", parse_files, "",
-        "--help", &help, "Print help message",
-        "-v", &verbose, "Verbose mode",
-        "--threads %d", &numthreads,
-            ustring::sprintf("Number of threads (default: %d)", numthreads).c_str(),
-        "--iters %d", &iterations,
-            ustring::sprintf("Number of iterations (default: %d)", iterations).c_str(),
-        "--trials %d", &ntrials, "Number of trials", "--wedge", &wedge, "Do a wedge test",
-        nullptr);
+    ap.intro("atomic_test\n" OIIO_INTRO_STRING)
+      .usage("atomic_test [options]");
+
+    ap.arg("-v", &verbose)
+      .help("Verbose mode");
+    ap.arg("--threads %d", &numthreads)
+      .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+    ap.arg("--iters %d", &iterations)
+      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+    ap.arg("--trials %d", &ntrials)
+      .help("Number of trials");
+    ap.arg("--wedge", &wedge)
+      .help("Do a wedge test");
     // clang-format on
-    if (ap.parse(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-    if (help) {
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
+
+    ap.parse(argc, (const char**)argv);
 }
 
 

--- a/src/libutil/filter_test.cpp
+++ b/src/libutil/filter_test.cpp
@@ -30,32 +30,24 @@ static float graphunit = 200;
 static void
 getargs(int argc, char* argv[])
 {
-    bool help = false;
-    ArgParse ap;
     // clang-format off
-    ap.options(
-        "filter_test\n" OIIO_INTRO_STRING "\n"
-        "Usage:  filter_test [options]",
-        // "%*", parse_files, "",
-        "--help", &help, "Print help message",
-        "-v", &verbose, "Verbose mode",
-        // "--threads %d", &numthreads,
-        //     ustring::sprintf("Number of threads (default: %d)", numthreads).c_str(),
-        "--iterations %d", &iterations,
-            ustring::sprintf("Number of iterations (default: %d)", iterations).c_str(),
-        "--trials %d", &ntrials, "Number of trials",
-        "--normalize", &normalize, "Normalize/rescale all filters to peak at 1",
-        nullptr);
+    ArgParse ap;
+    ap.intro("filter_test\n" OIIO_INTRO_STRING)
+      .usage("filter_test [options]");
+
+    ap.arg("-v", &verbose)
+      .help("Verbose mode");
+    // ap.arg("--threads %d", &numthreads)
+    //   .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+    ap.arg("--iters %d", &iterations)
+      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+    ap.arg("--trials %d", &ntrials)
+      .help("Number of trials");
+    ap.arg("--normalize", &normalize)
+      .help("Normalize/rescale all filters to peak at 1");
     // clang-format on
-    if (ap.parse(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-    if (help) {
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
+
+    ap.parse(argc, (const char**)argv);
 }
 
 

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -31,31 +31,20 @@ static bool verbose   = false;
 static void
 getargs(int argc, char* argv[])
 {
-    bool help = false;
     ArgParse ap;
     // clang-format off
-    ap.options(
-        "fmath_test\n" OIIO_INTRO_STRING "\n"
-        "Usage:  fmath_test [options]",
-        // "%*", parse_files, "",
-        "--help", &help, "Print help message",
-        "-v", &verbose, "Verbose mode",
-        // "--threads %d", &numthreads,
-        //     ustring::sprintf("Number of threads (default: %d)", numthreads).c_str(),
-        "--iterations %d", &iterations,
-            ustring::sprintf("Number of values to convert for benchmarks (default: %d)", iterations).c_str(),
-        "--trials %d", &ntrials, "Number of trials",
-        nullptr);
+    ap.intro("fmath_test\n" OIIO_INTRO_STRING)
+      .usage("fmath_test [options]");
+
+    ap.arg("-v", &verbose)
+      .help("Verbose mode");
+    ap.arg("--iters %d", &iterations)
+      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+    ap.arg("--trials %d", &ntrials)
+      .help("Number of trials");
     // clang-format on
-    if (ap.parse(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-    if (help) {
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
+
+    ap.parse(argc, (const char**)argv);
 }
 
 

--- a/src/libutil/hash_test.cpp
+++ b/src/libutil/hash_test.cpp
@@ -164,30 +164,23 @@ test_falkhash(int len)
 static void
 getargs(int argc, char* argv[])
 {
-    bool help = false;
     ArgParse ap;
     // clang-format off
-    ap.options(
-        "hash_test\n" OIIO_INTRO_STRING "\n"
-        "Usage:  hash_test [options]",
-        // "%*", parse_files, "",
-        "--help", &help, "Print help message",
-        "-v", &verbose, "Verbose mode",
-        "--iters %d", &iterations,
-            Strutil::sprintf("Number of iterations (default: %d)", iterations).c_str(),
-        "--trials %d", &ntrials, "Number of trials",
-        nullptr);
+    ap.intro("hash_test\n" OIIO_INTRO_STRING)
+      .usage("hash_test [options]");
+
+    ap.arg("-v", &verbose)
+      .help("Verbose mode");
+    ap.arg("--iters %d", &iterations)
+      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+    ap.arg("--trials %d", &ntrials)
+      .help("Number of trials");
     // clang-format on
-    if (ap.parse(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-    if (help) {
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
+
+    ap.parse(argc, (const char**)argv);
 }
+
+
 
 int
 main(int argc, char* argv[])

--- a/src/libutil/parallel_test.cpp
+++ b/src/libutil/parallel_test.cpp
@@ -31,32 +31,24 @@ static int threadcounts[] = { 1,  2,  4,  8,  12,  16,   20,
 static void
 getargs(int argc, char* argv[])
 {
-    bool help = false;
     ArgParse ap;
     // clang-format off
-    ap.options(
-        "parallel_test\n" OIIO_INTRO_STRING "\n"
-        "Usage:  parallel_test [options]",
-        // "%*", parse_files, "",
-        "--help", &help, "Print help message",
-        "-v", &verbose, "Verbose mode",
-        "--threads %d", &numthreads,
-            ustring::sprintf("Number of threads (default: %d)", numthreads).c_str(),
-        "--iters %d", &iterations,
-            ustring::sprintf("Number of iterations (default: %d)", iterations).c_str(),
-        "--trials %d", &ntrials, "Number of trials",
-        "--wedge", &wedge, "Do a wedge test",
-        nullptr);
+    ap.intro("parallel_test\n" OIIO_INTRO_STRING)
+      .usage("parallel_test [options]");
+
+    ap.arg("-v", &verbose)
+      .help("Verbose mode");
+    ap.arg("--threads %d", &numthreads)
+      .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+    ap.arg("--iters %d", &iterations)
+      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+    ap.arg("--trials %d", &ntrials)
+      .help("Number of trials");
+    ap.arg("--wedge", &wedge)
+      .help("Do a wedge test");
     // clang-format on
-    if (ap.parse(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-    if (help) {
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
+
+    ap.parse(argc, (const char**)argv);
 }
 
 

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -31,7 +31,6 @@ using namespace OIIO::simd;
 
 static int iterations = 1000000;
 static int ntrials    = 5;
-static bool verbose   = false;
 static Sysutil::Term term(std::cout);
 OIIO_SIMD16_ALIGN float dummy_float[16];
 OIIO_SIMD16_ALIGN float dummy_float2[16];
@@ -42,26 +41,17 @@ OIIO_SIMD16_ALIGN float dummy_int[16];
 static void
 getargs(int argc, char* argv[])
 {
-    bool help = false;
     ArgParse ap;
-    ap.options("simd_test\n" OIIO_INTRO_STRING "\n"
-        "Usage:  simd_test [options]",
-        // "%*", parse_files, "",
-        "--help", &help, "Print help message",
-        "-v", &verbose, "Verbose mode",
-        "--iterations %d", &iterations,
-            ustring::sprintf("Number of iterations (default: %d)", iterations).c_str(),
-        "--trials %d", &ntrials, "Number of trials",
-        nullptr);
-    if (ap.parse(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-    if (help) {
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
+    ap.intro("simd_test -- unit test and benchmarks for OpenImageIO/simd.h\n"
+             OIIO_INTRO_STRING)
+      .usage("simd_test [options]");
+
+    ap.arg("--iterations %d", &iterations)
+      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+    ap.arg("--trials %d", &ntrials)
+      .help("Number of trials");
+
+    ap.parse_args(argc, (const char**)argv);
 }
 
 

--- a/src/libutil/spin_rw_test.cpp
+++ b/src/libutil/spin_rw_test.cpp
@@ -77,34 +77,26 @@ test_spin_rw(int numthreads, int iterations)
 static void
 getargs(int argc, char* argv[])
 {
-    bool help = false;
     ArgParse ap;
     // clang-format off
-    ap.options(
-        "spin_rw_test\n" OIIO_INTRO_STRING "\n"
-        "Usage:  spin_rw_test [options]",
-        // "%*", parse_files, "",
-        "--help", &help, "Print help message",
-        "-v", &verbose, "Verbose mode",
-        "--threads %d", &numthreads,
-            ustring::sprintf("Number of threads (default: %d)", numthreads).c_str(),
-        "--iters %d", &iterations,
-            ustring::sprintf("Number of iterations (default: %d)", iterations).c_str(),
-        "--trials %d", &ntrials, "Number of trials",
-        "--rwratio %d", &read_write_ratio,
-            ustring::sprintf("Reader::writer ratio (default: %d)", read_write_ratio).c_str(),
-        "--wedge", &wedge, "Do a wedge test",
-        nullptr);
+    ap.intro("spin_rw_test\n" OIIO_INTRO_STRING)
+      .usage("spin_rw_test [options]");
+
+    ap.arg("-v", &verbose)
+      .help("Verbose mode");
+    ap.arg("--threads %d", &numthreads)
+      .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+    ap.arg("--iters %d", &iterations)
+      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+    ap.arg("--trials %d", &ntrials)
+      .help("Number of trials");
+    ap.arg("--rwratio %d", &read_write_ratio)
+       .help(Strutil::sprintf("Reader::writer ratio (default: %d)", read_write_ratio));
+    ap.arg("--wedge", &wedge)
+      .help("Do a wedge test");
     // clang-format on
-    if (ap.parse(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-    if (help) {
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
+
+    ap.parse(argc, (const char**)argv);
 }
 
 

--- a/src/libutil/spinlock_test.cpp
+++ b/src/libutil/spinlock_test.cpp
@@ -87,31 +87,24 @@ do_accum(int iterations)
 static void
 getargs(int argc, char* argv[])
 {
-    bool help = false;
     ArgParse ap;
     // clang-format off
-    ap.options(
-        "spinlock_test\n" OIIO_INTRO_STRING "\n"
-        "Usage:  spinlock_test [options]",
-        // "%*", parse_files, "",
-        "--help", &help, "Print help message",
-        "-v", &verbose, "Verbose mode",
-        "--threads %d", &numthreads,
-                ustring::sprintf("Number of threads (default: %d)", numthreads).c_str(),
-        "--iters %d", &iterations,
-                ustring::sprintf("Number of iterations (default: %d)", iterations).c_str(),
-        "--trials %d", &ntrials, "Number of trials", "--wedge", &wedge, "Do a wedge test",
-        nullptr);
+    ap.intro("spinlock_test\n" OIIO_INTRO_STRING)
+      .usage("spinlock_test [options]");
+
+    ap.arg("-v", &verbose)
+      .help("Verbose mode");
+    ap.arg("--threads %d", &numthreads)
+      .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+    ap.arg("--iters %d", &iterations)
+      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+    ap.arg("--trials %d", &ntrials)
+      .help("Number of trials");
+    ap.arg("--wedge", &wedge)
+      .help("Do a wedge test");
     // clang-format on
-    if (ap.parse(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-    if (help) {
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
+
+    ap.parse(argc, (const char**)argv);
 }
 
 

--- a/src/libutil/thread_test.cpp
+++ b/src/libutil/thread_test.cpp
@@ -30,32 +30,24 @@ static int threadcounts[] = { 1,  2,  4,  8,  12,  16,   20,
 static void
 getargs(int argc, char* argv[])
 {
-    bool help = false;
-    ArgParse ap;
     // clang-format off
-    ap.options(
-        "thread_test\n" OIIO_INTRO_STRING "\n"
-        "Usage:  thread_test [options]",
-        // "%*", parse_files, "",
-        "--help", &help, "Print help message",
-        "-v", &verbose, "Verbose mode",
-        "--threads %d", &numthreads,
-            ustring::sprintf("Number of threads (default: %d)", numthreads).c_str(),
-        "--iters %d", &iterations,
-            ustring::sprintf("Number of iterations (default: %d)", iterations).c_str(),
-        "--trials %d", &ntrials, "Number of trials",
-        "--wedge", &wedge, "Do a wedge test",
-        nullptr);
+    ArgParse ap;
+    ap.intro("thread_test\n" OIIO_INTRO_STRING)
+      .usage("thread_test [options]");
+
+    ap.arg("-v", &verbose)
+      .help("Verbose mode");
+    ap.arg("--threads %d", &numthreads)
+      .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+    ap.arg("--iters %d", &iterations)
+      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+    ap.arg("--trials %d", &ntrials)
+      .help("Number of trials");
+    ap.arg("--wedge", &wedge)
+      .help("Do a wedge test");
     // clang-format on
-    if (ap.parse(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-    if (help) {
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
+
+    ap.parse(argc, (const char**)argv);
 }
 
 

--- a/src/libutil/timer_test.cpp
+++ b/src/libutil/timer_test.cpp
@@ -17,44 +17,16 @@ using namespace OIIO;
 
 
 
-static int
-parse_files(int /*argc*/, const char* /*argv*/[])
-{
-    //    input_filename = ustring(argv[0]);
-    return 0;
-}
-
-
-
-static void
-getargs(int argc, char* argv[])
-{
-    bool help = false;
-    ArgParse ap;
-    // clang-format off
-    ap.options("timer_test\n" OIIO_INTRO_STRING "\n"
-               "Usage:  timer_test [options]",
-               "%*", parse_files, "",
-               "--help", &help, "Print help message",
-               NULL);
-    // clang-format on
-    if (ap.parse(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-    if (help) {
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-}
-
-
-
 int
 main(int argc, char** argv)
 {
-    getargs(argc, argv);
+    ArgParse ap;
+    // clang-format off
+    ap.intro("timer_test\n" OIIO_INTRO_STRING)
+      .usage("timer_test [options]");
+    // clang-format on
+
+    ap.parse(argc, (const char**)argv);
 
     // First, just compute and print how expensive a Timer begin/end is,
     // in cycles per second.

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -51,32 +51,24 @@ create_lotso_ustrings(int iterations)
 static void
 getargs(int argc, char* argv[])
 {
-    bool help = false;
-    ArgParse ap;
     // clang-format off
-    ap.options(
-        "ustring_test\n" OIIO_INTRO_STRING "\n"
-        "Usage:  ustring_test [options]",
-        // "%*", parse_files, "",
-        "--help", &help, "Print help message",
-        "-v", &verbose, "Verbose mode",
-        "--threads %d", &numthreads,
-            ustring::sprintf("Number of threads (default: %d)", numthreads).c_str(),
-        "--iters %d", &iterations,
-            ustring::sprintf("Number of iterations (default: %d)", iterations).c_str(),
-        "--trials %d", &ntrials, "Number of trials",
-        "--wedge", &wedge, "Do a wedge test",
-        nullptr);
+    ArgParse ap;
+    ap.intro("ustring_test\n" OIIO_INTRO_STRING)
+      .usage("ustring_test [options]");
+
+    ap.arg("-v", &verbose)
+      .help("Verbose mode");
+    ap.arg("--threads %d", &numthreads)
+      .help(Strutil::sprintf("Number of threads (default: %d)", numthreads));
+    ap.arg("--iters %d", &iterations)
+      .help(Strutil::sprintf("Number of iterations (default: %d)", iterations));
+    ap.arg("--trials %d", &ntrials)
+      .help("Number of trials");
+    ap.arg("--wedge", &wedge)
+      .help("Do a wedge test");
     // clang-format on
-    if (ap.parse(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-    if (help) {
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
+
+    ap.parse(argc, (const char**)argv);
 }
 
 

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -142,12 +142,16 @@ public:
     // Otherwise (if enough images are on the stack), return false.
     bool postpone_callback(int required_images, CallbackFunction func, int argc,
                            const char* argv[]);
+    bool postpone_callback(int required_images, ArgParse::Action func,
+                           cspan<const char*> argv);
 
     // Process any pending commands.
     void process_pending();
 
     CallbackFunction pending_callback() const { return m_pending_callback; }
     const char* pending_callback_name() const { return m_pending_argv[0]; }
+    ArgParse::Action pending_action() const { return m_pending_action; }
+    const char* pending_action_name() const { return m_pending_argv[0]; }
 
     void push(const ImageRecRef& img)
     {
@@ -240,6 +244,7 @@ public:
 
 private:
     CallbackFunction m_pending_callback;
+    ArgParse::Action m_pending_action;
     int m_pending_argc;
     const char* m_pending_argv[4];
 


### PR DESCRIPTION
I've been thinking about overhauling ArgParse for a couple years, and
did most of the work in December when I was home from work. Then sat
on it except for slow burn weekend tinkering, but finally got a chance
to put the final touches on and write the docs this week.

The bottom line is that this is a major rewrite of the APIs for
ArgParse to make them much richer, more flexible, and more closely
resembling those of python's argparse module.

Rather than trying to explain the syntax here, I simply will refer you
to the extensive inline documentation in argparse.h, as well as the
examples in the code base of where it's used.

It sill respects the old syntax, so this change is hoped to not alter
the behavior of any programs using the deprecated API.

Start by reading argparse.h, it's design review of the API that is the
most important for those inclined to weigh in.
