### PR TITLE
Fix potential tls errors

### DIFF
--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -215,13 +215,21 @@ openimageio_version()
 
 // To avoid thread oddities, we have the storage area buffering error
 // messages for seterror()/geterror() be thread-specific.
-static thread_local std::string error_msg;
+
+static std::string&
+error_msg()
+{
+    static thread_local std::unique_ptr<std::string> thread_error_msg;
+    if (!thread_error_msg)
+        thread_error_msg.reset(new std::string);
+    return *thread_error_msg;
+}
 
 
 void
 pvt::seterror(string_view message)
 {
-    error_msg = message;
+    error_msg() = message;
 }
 
 
@@ -229,8 +237,8 @@ pvt::seterror(string_view message)
 std::string
 geterror()
 {
-    std::string e = error_msg;
-    error_msg.clear();
+    std::string e = error_msg();
+    error_msg().clear();
     return e;
 }
 

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -470,7 +470,6 @@ OIIO_PLUGIN_EXPORTS_END
 // Someplace to store an error message from the TIFF error handler
 // To avoid thread oddities, we have the storage area buffering error
 // messages for seterror()/geterror() be thread-specific.
-static thread_local std::string thread_error_msg;
 static atomic_int handler_set;
 static spin_mutex handler_mutex;
 
@@ -479,7 +478,10 @@ static spin_mutex handler_mutex;
 std::string&
 oiio_tiff_last_error()
 {
-    return thread_error_msg;
+    static thread_local std::unique_ptr<std::string> thread_error_msg;
+    if (!thread_error_msg)
+        thread_error_msg.reset(new std::string);
+    return *thread_error_msg;
 }
 
 


### PR DESCRIPTION
It came to my attention that thread_local variables are not allowed to
have initializers that are not constant. But we had two instances of
thread_local std::string, whose default ctr is not constexpr (until
C++20), so that seems suspicious, right?

Replace with unique_ptr<string>, and hide inside a static function so
that we have better control over when it initializes.

