### PR TITLE
externalpackages.cmake: Fix static boost to not overlink

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -146,6 +146,9 @@ option (BUILD_MISSING_DEPS "Try to download and build any missing dependencies" 
 # Boost setup
 if (LINKSTATIC)
     set (Boost_USE_STATIC_LIBS ON)
+    if (MSVC)
+        add_definitions (-DBOOST_ALL_NO_LIB=1)
+    endif ()
 else ()
     if (MSVC)
         add_definitions (-DBOOST_ALL_DYN_LINK=1)


### PR DESCRIPTION
When compiling OIIO against a static version of boost where only a subset of boost libs have been built:
(eg, boost configured with --link=static --with-filesystem --with-system --with-thread --with-headers)
We want to disable the automatic MSVC linking, which will otherwise also try to link against unused and non-existant boost libraries (such as date_time).


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project.

