### PR TITLE
Fix some problems with the docs

### DIFF
--- a/src/doc/imagebufalgo.rst
+++ b/src/doc/imagebufalgo.rst
@@ -760,7 +760,7 @@ Image arithmetic
 
 |
 
-.. doxygenfunction:: mul(ImageBuf&, Image_or_Const, Image_or_Const, ROI, int)
+.. doxygenfunction:: mul(Image_or_Const, Image_or_Const, ROI, int)
 ..
 
   Examples::
@@ -782,7 +782,7 @@ Image arithmetic
 
 |
 
-.. doxygenfunction:: div(ImageBuf&, Image_or_Const, Image_or_Const, ROI, int)
+.. doxygenfunction:: div(Image_or_Const, Image_or_Const, ROI, int)
 ..
 
   Examples::
@@ -803,7 +803,7 @@ Image arithmetic
 
 |
 
-.. doxygenfunction:: mad(ImageBuf&, Image_or_Const, Image_or_Const, Image_or_Const, ROI, int)
+.. doxygenfunction:: mad(Image_or_Const, Image_or_Const, Image_or_Const, ROI, int)
 ..
 
   Examples::
@@ -1050,7 +1050,7 @@ Image arithmetic
 
 
 
-.. doxygengroup:: rangecompress-rangeexpand
+.. doxygengroup:: range
 ..
 
   Examples::
@@ -1650,7 +1650,7 @@ Color space conversion
 
 
 |
-.. doxygengroup:: premult-unpremult
+.. doxygengroup:: premult
 ..
 
   Examples::

--- a/src/doc/index.rst
+++ b/src/doc/index.rst
@@ -15,7 +15,7 @@ OpenImageIO |version|
     images in a wide variety of file formats, using a format-agnostic API.
     OIIO emphasizes formats and functionality used in professional,
     large-scale visual effects and feature film animation, and it is used
-    uniquitously by large VFX studios, as well as incorporated into many
+    ubiquitously by large VFX studios, as well as incorporated into many
     commercial products.
 
     Quick Links:

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -981,8 +981,10 @@ OIIO_API bool contrast_remap (ImageBuf &dst, const ImageBuf &src,
                     ROI={}, int nthreads=0);
 
 
-/// @defgroup color_map (color_map: remap value range by spline or name)
+/// @defgroup color_map
 /// @{
+///
+/// Remap value range by spline or name
 ///
 /// Return (or copy into `dst`) pixel values determined by looking up a
 /// color map using values of the source image, using either the channel
@@ -1023,9 +1025,10 @@ bool OIIO_API color_map (ImageBuf &dst, const ImageBuf &src, int srcchannel,
 /// @}
 
 
-/// @defgroup rangecompress-rangeexpand (rangecompress/rangeexpand: nonlinear
-/// range remapping for contrast preservationn)
+/// @defgroup range
 /// @{
+///
+/// Nonlinear range remapping for contrast preservation
 ///
 /// `rangecompress()` returns (or copy into `dst`) all pixels and color
 /// channels of `src` within region `roi` (defaulting to all the defined
@@ -1342,8 +1345,10 @@ bool OIIO_API laplacian (ImageBuf &dst, const ImageBuf &src,
                          ROI roi={}, int nthreads=0);
 
 
-/// @defgroup fft-ifft (fft/ifft -- Fast Fourier Transform and inverse)
+/// @defgroup fft-ifft
 /// @{
+///
+/// Fast Fourier Transform and inverse
 ///
 /// Return (or copy into `dst`) the discrete Fourier transform (DFT), or its
 /// inverse, of the section of `src` denoted by roi,  If roi is not defined,
@@ -1376,8 +1381,10 @@ bool OIIO_API ifft (ImageBuf &dst, const ImageBuf &src, ROI roi={}, int nthreads
 /// @}
 
 
-/// @defgroup complex-polar (Converting complex to polar and back)
+/// @defgroup complex-polar
 /// @{
+///
+/// Converting complex to polar and back
 ///
 /// The `polar_to_complex()` function transforms a 2-channel image whose
 /// channels are interpreted as complex values (real and imaginary
@@ -1536,8 +1543,10 @@ bool OIIO_API erode (ImageBuf &dst, const ImageBuf &src,
 
 
 
-/// @defgroup colorconvert (colorconvert -- convert between color spaces)
+/// @defgroup colorconvert
 /// @{
+///
+/// Convert between color spaces
 ///
 /// Return (or copy into `dst`) the pixels of `src` within the ROI, applying
 /// a color space transformation. In-place operations (`dst` == `src`) are
@@ -1769,8 +1778,10 @@ bool OIIO_API ociofiletransform (ImageBuf &dst, const ImageBuf &src,
                                  ROI roi={}, int nthreads=0);
 
 
-/// @defgroup premult-unpremult (unpremult/premult -- Premultiply or un-premultiply color by alpha)
+/// @defgroup premult
 /// @{
+///
+/// Premultiply or un-premultiply color by alpha
 ///
 /// The `unpremult` operation returns (or copies into `dst`) the pixels of
 /// `src` within the ROI, and in the process divides all color channels


### PR DESCRIPTION
Some IBA functions specified the wrong version of the function, thus
leaving out the explanation from the header that was associated with
the other form of the function.

Some groups had bad identifiers, apparently, and were dropping
pieces of text.

Typo in the intro, oops!
