### PR TITLE
Fix GH CI Mac for python

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -115,7 +115,9 @@ jobs:
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/install_homebrew_deps.bash
+            pip3.7 install numpy
             src/build-scripts/install_test_images.bash
+            export PYTHONPATH=/usr/local/lib/python3.7/site-packages:$PYTHONPATH
             source src/build-scripts/ci-build-and-test.bash
 
   windows:


### PR DESCRIPTION
Ugh, homebrew just updated some packages (including numpy!) to be
python 3.8-based, but the 'python' homebrew package is still 3.7.
Need to jump through some hoops to make it work.

