### PR TITLE
JPEG & PNG: Fix loss of config info upon close and reopen

### DIFF
--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -92,6 +92,7 @@ private:
     std::vector<unsigned char> m_cmyk_buf;  // For CMYK translation
     Filesystem::IOProxy* m_io = nullptr;
     std::unique_ptr<Filesystem::IOProxy> m_local_io;
+    std::unique_ptr<ImageSpec> m_config;  // Saved copy of configuration spec
 
     void init()
     {
@@ -104,6 +105,7 @@ private:
         m_jerr.jpginput = this;
         m_io            = nullptr;
         m_local_io.reset();
+        m_config.reset();
     }
 
     // Rummage through the JPEG "APP1" marker pointed to by buf, decoding

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -171,6 +171,7 @@ JpgInput::open(const std::string& name, ImageSpec& newspec,
     p      = config.find_attribute("oiio:ioproxy", TypeDesc::PTR);
     if (p)
         m_io = p->get<Filesystem::IOProxy*>();
+    m_config.reset(new ImageSpec(config));  // save config spec
     return open(name, newspec);
 }
 
@@ -441,9 +442,13 @@ JpgInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
     if (m_next_scanline > y) {
         // User is trying to read an earlier scanline than the one we're
         // up to.  Easy fix: close the file and re-open.
+        // Don't forget to save and restore any configuration settings.
+        ImageSpec configsave;
+        if (m_config)
+            configsave = *m_config;
         ImageSpec dummyspec;
         int subimage = current_subimage();
-        if (!close() || !open(m_filename, dummyspec)
+        if (!close() || !open(m_filename, dummyspec, configsave)
             || !seek_subimage(subimage, 0))
             return false;  // Somehow, the re-open failed
         OIIO_DASSERT(m_next_scanline == 0 && current_subimage() == subimage);

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -53,6 +53,7 @@ private:
     int m_next_scanline;
     bool m_keep_unassociated_alpha;  ///< Do not convert unassociated alpha
     std::unique_ptr<Filesystem::IOProxy> m_io_local;
+    std::unique_ptr<ImageSpec> m_config;  // Saved copy of configuration spec
     Filesystem::IOProxy* m_io = nullptr;
     int64_t m_io_offset       = 0;
     bool m_err                = false;
@@ -69,6 +70,7 @@ private:
         m_next_scanline           = 0;
         m_keep_unassociated_alpha = false;
         m_err                     = false;
+        m_config.reset();
     }
 
     /// Helper function: read the image.
@@ -194,6 +196,7 @@ PNGInput::open(const std::string& name, ImageSpec& newspec,
     auto ioparam = config.find_attribute("oiio:ioproxy", TypeDesc::PTR);
     if (ioparam)
         m_io = ioparam->get<Filesystem::IOProxy*>();
+    m_config.reset(new ImageSpec(config));  // save config spec
     return open(name, newspec);
 }
 
@@ -286,9 +289,13 @@ PNGInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
         if (m_next_scanline > y) {
             // User is trying to read an earlier scanline than the one we're
             // up to.  Easy fix: close the file and re-open.
+            // Don't forget to save and restore any configuration settings.
+            ImageSpec configsave;
+            if (m_config)
+                configsave = *m_config;
             ImageSpec dummyspec;
             int subimage = current_subimage();
-            if (!close() || !open(m_filename, dummyspec)
+            if (!close() || !open(m_filename, dummyspec, configsave)
                 || !seek_subimage(subimage, miplevel))
                 return false;  // Somehow, the re-open failed
             assert(m_next_scanline == 0 && current_subimage() == subimage);


### PR DESCRIPTION
Both the JPEG and PNG readers, because the can only read scanlines in
strictly ascending order, have a section where if they need to backtrack,
they do so by closing the file and re-opening.

But in this close/open, any 'config' settings they were passed when they
opened the first time would get lost. And this could include the IOProxy
they were supposed to be using.

The config info needs to be remembered and applied again if the file
is closed and reopened internal to the reader's operations.
