### PR TITLE
Beef up the test of Filesystem::extension

### DIFF
--- a/src/libutil/filesystem_test.cpp
+++ b/src/libutil/filesystem_test.cpp
@@ -31,6 +31,8 @@ test_filename_decomposition()
     std::cout << "Testing filename, extension, parent_path\n";
     OIIO_CHECK_EQUAL(Filesystem::filename(test), "filename.ext");
     OIIO_CHECK_EQUAL(Filesystem::extension(test), ".ext");
+    OIIO_CHECK_EQUAL(Filesystem::extension("./foo.dir/../blah/./bar/file.ext"),
+                     ".ext");
     OIIO_CHECK_EQUAL(Filesystem::extension("/directory/filename"), "");
     OIIO_CHECK_EQUAL(Filesystem::extension("/directory/filename."), ".");
     OIIO_CHECK_EQUAL(Filesystem::parent_path(test), "/directoryA/directory");


### PR DESCRIPTION
I suspected that extra dots within a filename was confusing `extension()`.
It's behaving correctly, it turns out. But this is a good test to add.

