### PR TITLE
clean up spelling in image{buf,io}.h

### DIFF
--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -77,7 +77,7 @@ public:
             /// the ImageBuf is destroyed.
         IMAGECACHE
             ///< The ImageBuf is "backed" by an ImageCache, which will
-            /// automatically be used to retreive pixels when requested, but
+            /// automatically be used to retrieve pixels when requested, but
             /// the ImageBuf will not allocate separate storage for it. 
             /// This brings all the advantages of the ImageCache, but can
             /// only be used for read-only ImageBuf's that reference a
@@ -134,7 +134,7 @@ public:
     // Deprecated synonym for `ImageBuf(name, 0, 0, imagecache, nullptr)`.
     ImageBuf(string_view name, ImageCache* imagecache);
 
-    /// Construct a writeable ImageBuf with the given specification
+    /// Construct a writable ImageBuf with the given specification
     /// (including resolution, data type, metadata, etc.). The ImageBuf will
     /// allocate and own its own pixel memory and will free that memory
     /// automatically upon destruction, clear(), or reset(). Upon successful
@@ -148,7 +148,7 @@ public:
     ///             state and will have no local pixel storage.
     /// @param zero
     ///             After a successful allocation of the local pixel
-    ///             storage, this parameteter controls whether the pixels
+    ///             storage, this parameter controls whether the pixels
     ///             will be initialized to hold zero (black) values
     ///             (`InitializePixels::Yes`) or if the pixel memory will
     ///             remain uninitialized (`InitializePixels::No`) and thus
@@ -165,7 +165,7 @@ public:
     ImageBuf(string_view name, const ImageSpec& spec,
              InitializePixels zero = InitializePixels::Yes);
 
-    /// Construct a writeable ImageBuf that "wraps" existing pixel memory
+    /// Construct a writable ImageBuf that "wraps" existing pixel memory
     /// owned by the calling application. The ImageBuf does not own the
     /// pixel storage and will will not free/delete that memory, even when
     /// the ImageBuf is destroyed. Upon successful initialization, the
@@ -204,7 +204,7 @@ public:
     /// `IBStorage::UNINITIALIZED`).
     void reset() { clear(); }
 
-    // Deprecated/useless synonym for `reset(name, 0, 0, imageache, nullptr)`
+    // Deprecated/useless synonym for `reset(name, 0, 0, imagecache, nullptr)`
     void reset(string_view name, ImageCache* imagecache = nullptr);
 
     /// Destroy any previous contents of the ImageBuf and re-initialize it
@@ -239,7 +239,7 @@ public:
     /// pixel memory owned by the calling application.
     void reset(const ImageSpec& spec, void* buffer);
 
-    /// Make the ImageBuf be writeable. That means that if it was previously
+    /// Make the ImageBuf be writable. That means that if it was previously
     /// backed by an ImageCache (storage was `IMAGECACHE`), it will force a
     /// full read so that the whole image is in local memory. This will
     /// invalidate any current iterators on the image. It has no effect if
@@ -472,7 +472,7 @@ public:
     /// be a scanline-oriented file.
     ///
     /// This lets you write a tiled file from an ImageBuf that may have been
-    /// read orginally from a scanline file, or change the dimensions of a
+    /// read originally from a scanline file, or change the dimensions of a
     /// tiled file, or to force the file written to be scanline even if it
     /// was originally read from a tiled file.
     ///
@@ -639,8 +639,8 @@ public:
     /// the upper left corner of the display window, (1,1) the lower
     /// right corner of the display window.
     ///
-    /// @note `interppixel()` uses pixel coordiantes (ranging 0..resolution)
-    /// whereas `interppixel_NDC()` uses NDC coordiantes (ranging 0..1).
+    /// @note `interppixel()` uses pixel coordinates (ranging 0..resolution)
+    /// whereas `interppixel_NDC()` uses NDC coordinates (ranging 0..1).
     void interppixel_NDC(float s, float t, float* pixel,
                          WrapMode wrap = WrapBlack) const;
 
@@ -652,7 +652,7 @@ public:
     void interppixel_bicubic(float x, float y, float* pixel,
                              WrapMode wrap = WrapBlack) const;
 
-    /// Bicubic interpolattion at NDC space coordinates (s,t), where (0,0)
+    /// Bicubic interpolation at NDC space coordinates (s,t), where (0,0)
     /// is the upper left corner of the display (a.k.a. "full") window,
     /// (1,1) the lower right corner of the display window.
     void interppixel_bicubic_NDC(float s, float t, float* pixel,
@@ -1376,7 +1376,7 @@ public:
             m_z     = m_rng_zend;
         }
 
-        // Make sure it's writeable. Use with caution!
+        // Make sure it's writable. Use with caution!
         void make_writeable()
         {
             if (!m_localpixels) {

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -137,7 +137,7 @@ struct ROI {
     }
 
     /// All() is an alias for the default constructor, which indicates that
-    /// it means "all" of the image, or no region restruction.  For example,
+    /// it means "all" of the image, or no region restriction.  For example,
     ///     float myfunc (ImageBuf &buf, ROI roi = ROI::All());
     /// Note that this is equivalent to:
     ///     float myfunc (ImageBuf &buf, ROI roi = {});
@@ -293,7 +293,7 @@ public:
         ///< channel is present, or if it is not known which channel
         ///< represents alpha.
     int z_channel;
-        ///< The index of the channel that respresents *z* or *depth* (from
+        ///< The index of the channel that represents *z* or *depth* (from
         ///< the camera).  It defaults to -1 if no depth channel is present,
         ///< or if it is not know which channel represents depth.
     bool deep;                ///< True if the image contains deep data.
@@ -505,7 +505,7 @@ public:
     /// `ParamValue` record, or NULL if not found.  This variety of
     /// `find_attribute(}` can retrieve items such as "width", which are
     /// data members of the `ImageSpec`, but not in `extra_attribs`. The
-    /// 1tmpparam` is a storage area owned by the caller, which is used as
+    /// `tmpparam` is a storage area owned by the caller, which is used as
     /// temporary buffer in cases where the information does not correspond
     /// to an actual `extra_attribs` (in this case, the return value will be
     /// `&tmpparam`). The extra names it understands are:
@@ -841,7 +841,7 @@ public:
     /// @returns
     ///         A `unique_ptr` that will close and free the ImageInput when
     ///         it exits scope or is reset. The pointer will be empty if the
-    ///         requiresd writer was not able to be created.
+    ///         required writer was not able to be created.
     static unique_ptr open (const std::string& filename,
                             const ImageSpec *config = nullptr,
                             Filesystem::IOProxy* ioproxy = nullptr);
@@ -900,7 +900,7 @@ public:
     /// @returns
     ///         A `unique_ptr` that will close and free the ImageInput when
     ///         it exits scope or is reset. The pointer will be empty if the
-    ///         requiresd writer was not able to be created.
+    ///         required writer was not able to be created.
     static unique_ptr create (string_view filename, bool do_open=false,
                               const ImageSpec *config=nullptr,
                               Filesystem::IOProxy* ioproxy = nullptr,
@@ -975,7 +975,7 @@ public:
     /// otherwise corrupted.
     ///
     /// @returns
-    ///         `true` upon success, or `false` upen failure.
+    ///         `true` upon success, or `false` upon failure.
     virtual bool valid_file (const std::string& filename) const;
 
     /// Opens the file with given name and seek to the first subimage in the
@@ -1055,7 +1055,7 @@ public:
     /// still open.
     ///
     /// @returns
-    ///         `true` upon success, or `false` upen failure.
+    ///         `true` upon success, or `false` upon failure.
     virtual bool close () = 0;
 
     /// Returns the index of the subimage that is currently being read.
@@ -1078,7 +1078,7 @@ public:
     /// sequentially read through prior subimages and levels.
     ///
     /// @returns
-    ///         `true` upon success, or `false` upen failure. A failure may
+    ///         `true` upon success, or `false` upon failure. A failure may
     ///         indicate that no such subimage or MIP level exists in the
     ///         file.
     virtual bool seek_subimage (int subimage, int miplevel) {
@@ -1165,7 +1165,7 @@ public:
     /// @param  data        Pointer to the pixel data buffer.
     /// @param  xstride     The distance in bytes between successive
     ///                     pixels in `data` (or `AutoStride`).
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     virtual bool read_scanline (int y, int z, TypeDesc format, void *data,
                                 stride_t xstride=AutoStride);
 
@@ -1200,7 +1200,7 @@ public:
     /// @param  xstride/ystride
     ///                     The distance in bytes between successive pixels
     ///                     and scanlines (or `AutoStride`).
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     ///
     /// @note This call was changed for OpenImageIO 2.0 to include the
     ///     explicit subimage and miplevel parameters. The previous
@@ -1251,7 +1251,7 @@ public:
     ///                     The distance in bytes between successive pixels,
     ///                     scanlines, and image planes (or `AutoStride` to
     ///                     indicate a "contiguous" single tile).
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     ///
     /// @note This call will fail if the image is not tiled, or if (x,y,z)
     /// is not the upper left corner coordinates of a tile.
@@ -1306,7 +1306,7 @@ public:
     /// @param  xstride/ystride/zstride
     ///                     The distance in bytes between successive pixels,
     ///                     scanlines, and image planes (or `AutoStride`).
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     ///
     /// @note The call will fail if the image is not tiled, or if the pixel
     /// ranges do not fall along tile (or image) boundaries, or if it is not
@@ -1337,7 +1337,7 @@ public:
     /// Depending on the spec, this will read either all tiles or all
     /// scanlines. Assume that data points to a layout in row-major order.
     ///
-    /// This version of read_imgage, because it passes explicit subimage and
+    /// This version of read_image, because it passes explicit subimage and
     /// miplevel, does not require a separate call to seek_subimage, and is
     /// guaranteed to be thread-safe against other concurrent calls to any
     /// of the read_* methods that take an explicit subimage/miplevel (but
@@ -1363,7 +1363,7 @@ public:
     ///                     scanlines, and image planes (or `AutoStride`).
     /// @param  progress_callback/progress_callback_data
     ///                     Optional progress callback.
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     virtual bool read_image (int subimage, int miplevel,
                              int chbegin, int chend,
                              TypeDesc format, void *data,
@@ -1407,7 +1407,7 @@ public:
     /// @param  z           The z coordinate of the scanline.
     /// @param  deepdata    A `DeepData` object into which the data for
     ///                     these scanlines will be placed.
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     virtual bool read_native_deep_scanlines (int subimage, int miplevel,
                                              int ybegin, int yend, int z,
                                              int chbegin, int chend,
@@ -1428,7 +1428,7 @@ public:
     ///                     The channel range to read.
     /// @param  deepdata    A `DeepData` object into which the data for
     ///                     these tiles will be placed.
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     ///
     /// @note The call will fail if the image is not tiled, or if the pixel
     /// ranges do not fall along tile (or image) boundaries, or if it is not
@@ -1448,7 +1448,7 @@ public:
     ///                     resolution level).
     /// @param  deepdata    A `DeepData` object into which the data for
     ///                     the image will be placed.
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     virtual bool read_native_deep_image (int subimage, int miplevel,
                                          DeepData &deepdata);
 
@@ -1689,7 +1689,7 @@ public:
     /// @returns
     ///         A `unique_ptr` that will close and free the ImageOutput when
     ///         it exits scope or is reset. The pointer will be empty if the
-    ///         requiresd writer was not able to be created.
+    ///         required writer was not able to be created.
     static unique_ptr create (string_view filename,
                               Filesystem::IOProxy* ioproxy = nullptr,
                               string_view plugin_searchpath = "");
@@ -1847,7 +1847,7 @@ public:
     ///                     to create/truncate the file (default: `Create`),
     ///                     append another subimage (`AppendSubimage`), or
     ///                     append another MIP level (`AppendMIPLevel`).
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     virtual bool open (const std::string &name, const ImageSpec &newspec,
                        OpenMode mode=Create) = 0;
 
@@ -1872,7 +1872,7 @@ public:
     /// @param  specs[]
     ///                      Pointer to an array of `ImageSpec` objects
     ///                      describing each of the expected subimages.
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     virtual bool open (const std::string &name,
                        int subimages OIIO_MAYBE_UNUSED,
                        const ImageSpec *specs) {
@@ -1944,7 +1944,7 @@ public:
     /// @param  data        Pointer to the pixel data.
     /// @param  xstride     The distance in bytes between successive
     ///                     pixels in `data` (or `AutoStride`).
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     virtual bool write_scanline (int y, int z, TypeDesc format,
                                  const void *data, stride_t xstride=AutoStride);
 
@@ -1962,7 +1962,7 @@ public:
     /// @param  xstride/ystride
     ///                     The distance in bytes between successive pixels
     ///                     and scanlines (or `AutoStride`).
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     virtual bool write_scanlines (int ybegin, int yend, int z,
                                   TypeDesc format, const void *data,
                                   stride_t xstride=AutoStride,
@@ -1985,7 +1985,7 @@ public:
     ///                     The distance in bytes between successive pixels,
     ///                     scanlines, and image planes (or `AutoStride` to
     ///                     indicate a "contiguous" single tile).
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     ///
     /// @note This call will fail if the image is not tiled, or if (x,y,z)
     /// is not the upper left corner coordinates of a tile.
@@ -2023,7 +2023,7 @@ public:
     /// @param  xstride/ystride/zstride
     ///                     The distance in bytes between successive pixels,
     ///                     scanlines, and image planes (or `AutoStride`).
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     ///
     /// @note The call will fail if the image is not tiled, or if the pixel
     /// ranges do not fall along tile (or image) boundaries, or if it is not
@@ -2056,7 +2056,7 @@ public:
     /// @param  xstride/ystride/zstride
     ///                     The distance in bytes between successive pixels,
     ///                     scanlines, and image planes (or `AutoStride`).
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     ///
     /// @note The call will fail for a format plugin that does not return
     /// true for `supports("rectangles")`.
@@ -2088,7 +2088,7 @@ public:
     ///                     scanlines, and image planes (or `AutoStride`).
     /// @param  progress_callback/progress_callback_data
     ///                     Optional progress callback.
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     virtual bool write_image (TypeDesc format, const void *data,
                               stride_t xstride=AutoStride,
                               stride_t ystride=AutoStride,
@@ -2104,7 +2104,7 @@ public:
     /// @param  z           The z coordinate of the scanline.
     /// @param  deepdata    A `DeepData` object with the data for these
     ///                     scanlines.
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     virtual bool write_deep_scanlines (int ybegin, int yend, int z,
                                        const DeepData &deepdata);
 
@@ -2123,7 +2123,7 @@ public:
     /// @param  zbegin/zend The z range of the pixels covered by the tiles
     ///                     (for a 2D image, zbegin=0 and zend=1).
     /// @param  deepdata    A `DeepData` object with the data for the tiles.
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     ///
     /// @note The call will fail if the image is not tiled, or if the pixel
     /// ranges do not fall along tile (or image) boundaries, or if it is not
@@ -2136,7 +2136,7 @@ public:
     /// the spec, this will write either all tiles or all scanlines.
     ///
     /// @param  deepdata    A `DeepData` object with the data for the image.
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     virtual bool write_deep_image (const DeepData &deepdata);
 
     /// @}
@@ -2158,7 +2158,7 @@ public:
     /// alterations, especially for formats that use lossy compression.
     ///
     /// @param  in          A pointer to the open `ImageInput` to read from.
-    /// @returns            `true` upon success, or `false` upen failure.
+    /// @returns            `true` upon success, or `false` upon failure.
     virtual bool copy_image (ImageInput *in);
 
     // General message passing between client and image output server. This


### PR DESCRIPTION
## Description

Correct some spelling issues in these two headers. One change I did **not** make was
`make_writeable()` -> `make_writable()`, for obvious reasons.

## Tests

It still compiles.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

