### PR TITLE
writeable -> writable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -738,7 +738,7 @@ Build/test system improvements and platform ports:
 * A new unit test has been backported from master, which tries to perform a
   series of read/write tests on every file format. In partcular, this tests
   certain error conditions, like files not existing, or the directory not
-  being writeable, etc. #2181, #2189 (2.0.8/2.1.1)
+  being writable, etc. #2181, #2189 (2.0.8/2.1.1)
 * Support for CI tests on CircleCI. #2194 (2.1.1) Retired in #2389 (2.1.8).
 * New build-time flag `USE_WEBP=0` can be used to disable building WebP
   format support even on platforms where webp libraries are found.
@@ -987,7 +987,7 @@ Release 2.0.8 (3 May, 2019) -- compared to 2.0.7
 * Testing: A new unit test has been backported from master, which tries to
   perform a series of read/write tests on every file format. In partcular,
   this tests certain error conditions, like files not existing, or the
-  directory not being writeable, etc. #2181
+  directory not being writable, etc. #2181
 * Crashes in the command line utilities now attempt to print a stack trace
   to aid in debugging (but only if OIIO is built with Boost >= 1.65, because
   it relies on the Boost stacktrace library). #2229

--- a/src/doc/imagebuf.rst
+++ b/src/doc/imagebuf.rst
@@ -46,12 +46,12 @@ Constructing a readable ImageBuf
 .. doxygenfunction:: OIIO::ImageBuf::reset(string_view, int, int, ImageCache *, const ImageSpec *, Filesystem::IOProxy *)
 
 
-Constructing a writeable ImageBuf
+Constructing a writable ImageBuf
 --------------------------------------------------
 
 .. doxygenfunction:: OIIO::ImageBuf::ImageBuf(const ImageSpec&, InitializePixels)
 .. doxygenfunction:: OIIO::ImageBuf::reset(const ImageSpec&, InitializePixels)
-.. doxygenfunction:: OIIO::ImageBuf::make_writeable
+.. doxygenfunction:: OIIO::ImageBuf::make_writable
 
 
 Constructing an ImageBuf that "wraps" an application buffer

--- a/src/doc/imagebuf.tex
+++ b/src/doc/imagebuf.tex
@@ -58,13 +58,13 @@ constructed \ImageBuf using the default constructor.
 \apiend
 
 
-\subsection*{Constructing and initializing a writeable \ImageBuf}
+\subsection*{Constructing and initializing a writable \ImageBuf}
 
 \apiitem{{\ce ImageBuf} (const ImageSpec \&spec, \\
 \bigspc\bigspc InitializePixels zero = InitializePixels::Yes) \\
 {\ce ImageBuf} (string_view name, const ImageSpec \&spec, \\
 \bigspc\bigspc InitializePixels zero = InitializePixels::Yes) }
-Constructs a writeable \ImageBuf with the given specification (including
+Constructs a writable \ImageBuf with the given specification (including
 resolution, data type, metadata, etc.).
 The {\cf zero} parameter controls whether the pixel values are filled with
 black/empty, or are left uninitialized after being allocated (if set to
@@ -75,7 +75,7 @@ Optionally, you may name the \ImageBuf.
 \apiitem{void {\ce reset} (const ImageSpec \&spec, bool zero = true) \\
 void {\ce reset} (string_view name, const ImageSpec \&spec, bool zero = true)}
 Destroys any previous contents of the \ImageBuf and re-initializes it
-as a writeable all-black \ImageBuf with the given specification (including
+as a writable all-black \ImageBuf with the given specification (including
 resolution, data type, metadata, etc.).
 The {\cf zero} parameter controls whether the pixel values are filled with
 black/empty, or are left uninitialized after being allocated (if set to
@@ -84,8 +84,8 @@ Optionally, you may name the \ImageBuf.
 \ImageBuf.
 \apiend
 
-\apiitem{bool make_writeable (bool keep_cache_type = false)}
-Force the \ImageBuf to be writeable. That means that if it was previously
+\apiitem{bool make_writable (bool keep_cache_type = false)}
+Force the \ImageBuf to be writable. That means that if it was previously
 backed by an \ImageCache (storage was {\cf IMAGECACHE}), it will force a
 full read so that the whole image is in local memory.
 This will invalidate any current iterators on the image. It has
@@ -94,7 +94,7 @@ it works (including if no read was necessary), {\cf false} if something went
 horribly wrong. If {\cf keep_cache_type} is true, it preserves any
 \ImageCache-forced data types (you might want to do this if it is critical
 that the apparent data type doesn't change, for example if you are calling
-make_writeable from within a type-specialized function).
+make_writable from within a type-specialized function).
 \apiend
 
 \subsection*{Constructing a readable \ImageBuf and reading from a file}
@@ -382,7 +382,7 @@ of the pixel data window.
 \apiend
 
 \apiitem{ImageSpec \& {\ce specmod} ()}
-This returns a \emph{writeable} reference to the \ImageSpec describing
+This returns a \emph{writable} reference to the \ImageSpec describing
 the buffer.  It's ok to modify most of the metadata, but if you modify
 the spec's {\cf format}, {\cf width}, {\cf height}, or {\cf depth}
 fields, you get the pain you deserve, as the \ImageBuf will no longer

--- a/src/doc/imagecache.tex
+++ b/src/doc/imagecache.tex
@@ -904,7 +904,7 @@ custom ImageInput and will be called like this:
 Once created, the \ImageCache owns the \ImageInput and is responsible
 for destroying it when done. Custom \ImageInput's allow ``procedural''
 images, among other things.  Also, this is the method you use to set
-up a ``writeable'' \ImageCache images (perhaps with a type of
+up a ``writable'' \ImageCache images (perhaps with a type of
 \ImageInput that's just a stub that does as little as possible).
 
 If {\cf config} is not NULL, it points to an \ImageSpec with configuration

--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -1528,7 +1528,7 @@ awaiting a call to `reset()` or `copy()` before it is useful.
 
 .. py:method:: ImageBuf (imagespec, zero = True)
 
-    Construct a writeable ImageBuf of the dimensions and data format
+    Construct a writable ImageBuf of the dimensions and data format
     specified by an ImageSpec. The pixels will be initialized to black/empty
     values if `zero` is True, otherwise the pixel values will remain
     uninitialized.
@@ -1568,7 +1568,7 @@ awaiting a call to `reset()` or `copy()` before it is useful.
 
 .. py:method:: ImageBuf.reset (imagespec, zero = True)
 
-    Restore the ImageBuf to the newly-constructed state of a writeable
+    Restore the ImageBuf to the newly-constructed state of a writable
     ImageBuf specified by an ImageSpec. The pixels will be iniialized to
     black/empty if `zero` is True, otherwise the pixel values will remain
     uninitialized.
@@ -1641,9 +1641,9 @@ awaiting a call to `reset()` or `copy()` before it is useful.
 
 
 
-.. py:method:: ImageBuf.make_writeable (keep_cache_type = False)
+.. py:method:: ImageBuf.make_writable (keep_cache_type = False)
 
-    Force the ImageBuf to be writeable. That means that if it was previously
+    Force the ImageBuf to be writable. That means that if it was previously
     backed by an ImageCache (storage was `IMAGECACHE`), it will force a full
     read so that the whole image is in local memory.
 
@@ -1692,7 +1692,7 @@ awaiting a call to `reset()` or `copy()` before it is useful.
 
 .. py:method:: ImageBuf.specmod()
 
-    `ImageBuf.specmod()` provides a reference to the writeable ImageSpec
+    `ImageBuf.specmod()` provides a reference to the writable ImageSpec
     inside the ImageBuf.  Be very careful!  It is safe to modify certain
     metadata, but if you change the data format or resolution fields, you
     will get the chaos you deserve.
@@ -1809,7 +1809,7 @@ awaiting a call to `reset()` or `copy()` before it is useful.
 .. py:attribute:: ImageBuf.pixels_valid
 
     Will be `True` if the file has already been read and the pixels are
-    valid. (It is always `True` for writeable ImageBuf's.) There should be
+    valid. (It is always `True` for writable ImageBuf's.) There should be
     few good reasons to access these, since the spec and pixels will be
     automatically be read when they are needed.
 

--- a/src/doc/pythonbindings.tex
+++ b/src/doc/pythonbindings.tex
@@ -1367,7 +1367,7 @@ Optionally, a specific subimage or MIP level may be specified (defaulting to
 
 \apiitem{ImageBuf {\ce ImageBuf} (imagespec, zero = True)}
 
-Construct a writeable \ImageBuf of the dimensions and data format specified
+Construct a writable \ImageBuf of the dimensions and data format specified
 by an \ImageSpec. The pixels will be initialized to black/empty values if
 {\cf zero} is True, otherwise the pixel values will remain uninitialized.
 
@@ -1399,7 +1399,7 @@ a ``configuration'' \ImageSpec).
 \apiend
 
 \apiitem{ImageBuf.{\ce reset} (imagespec, zero = True)}
-Restore the \ImageBuf to the newly-constructed state of a writeable
+Restore the \ImageBuf to the newly-constructed state of a writable
 \ImageBuf specified by an \ImageSpec.
 The pixels will be iniialized to black/empty if {\cf zero} is True,
 otherwise the pixel values will remain uninitialized.
@@ -1464,8 +1464,8 @@ name).
 \end{code}
 \apiend
 
-\apiitem{bool ImageBuf.{\ce make_writeable} (keep_cache_type = false)}
-Force the \ImageBuf to be writeable. That means that if it was previously
+\apiitem{bool ImageBuf.{\ce make_writable} (keep_cache_type = false)}
+Force the \ImageBuf to be writable. That means that if it was previously
 backed by an \ImageCache (storage was {\cf IMAGECACHE}), it will force a
 full read so that the whole image is in local memory.
 \apiend
@@ -1508,7 +1508,7 @@ describes the original file it came from.
 \apiend
 
 \apiitem{ImageSpec ImageBuf.{\ce specmod}()}
-{\cf ImageBuf.specmod()} provides writeable access to the \ImageSpec that
+{\cf ImageBuf.specmod()} provides writable access to the \ImageSpec that
 describes the contents of the \ImageBuf.  Be very careful!  It is safe
 to modify certain metadata, but if you change the data format or resolution
 fields, you will get the chaos you deserve.
@@ -1606,7 +1606,7 @@ Changes the ``full'' (a.k.a. ``display'') window to the specified ROI.
 
 \apiitem{bool ImageBuf.{\ce pixels_valid}}
 Will be {\cf True} if the file has already been read and the pixels are
-valid. (It is always {\cf True} for writeable \ImageBuf's.)
+valid. (It is always {\cf True} for writable \ImageBuf's.)
 There should be few good reasons to access these, since the spec and pixels
 will be automatically be read when they are needed. 
 \apiend

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -249,11 +249,15 @@ public:
     ///             If true, preserve any ImageCache-forced data types (you
     ///             might want to do this if it is critical that the
     ///             apparent data type doesn't change, for example if you
-    ///             are calling `make_writeable()` from within a
+    ///             are calling `make_writable()` from within a
     ///             type-specialized function).
     /// @returns
     ///             Return `true` if it works (including if no read was
     ///             necessary), `false` if something went horribly wrong.
+    bool make_writable(bool keep_cache_type = false);
+
+    // DEPRECATED(2.2): This is an alternate, and less common, spelling.
+    // Let's standardize on "writable". We will eventuall remove this.
     bool make_writeable(bool keep_cache_type = false);
 
     /// @}
@@ -1377,10 +1381,10 @@ public:
         }
 
         // Make sure it's writable. Use with caution!
-        void make_writeable()
+        void make_writable()
         {
             if (!m_localpixels) {
-                const_cast<ImageBuf*>(m_ib)->make_writeable(true);
+                const_cast<ImageBuf*>(m_ib)->make_writable(true);
                 OIIO_DASSERT(m_ib->storage() != IMAGECACHE);
                 m_tile      = nullptr;
                 m_proxydata = nullptr;
@@ -1415,7 +1419,7 @@ public:
         Iterator(ImageBuf& ib, WrapMode wrap = WrapDefault)
             : IteratorBase(ib, wrap)
         {
-            make_writeable();
+            make_writable();
             pos(m_rng_xbegin, m_rng_ybegin, m_rng_zbegin);
             if (m_rng_xbegin == m_rng_xend || m_rng_ybegin == m_rng_yend
                 || m_rng_zbegin == m_rng_zend)
@@ -1427,14 +1431,14 @@ public:
                  WrapMode wrap = WrapDefault)
             : IteratorBase(ib, wrap)
         {
-            make_writeable();
+            make_writable();
             pos(x, y, z);
         }
         /// Construct read-write iteration region from ImageBuf and ROI.
         Iterator(ImageBuf& ib, const ROI& roi, WrapMode wrap = WrapDefault)
             : IteratorBase(ib, roi, wrap)
         {
-            make_writeable();
+            make_writable();
             pos(m_rng_xbegin, m_rng_ybegin, m_rng_zbegin);
             if (m_rng_xbegin == m_rng_xend || m_rng_ybegin == m_rng_yend
                 || m_rng_zbegin == m_rng_zend)
@@ -1446,7 +1450,7 @@ public:
                  int zbegin = 0, int zend = 1, WrapMode wrap = WrapDefault)
             : IteratorBase(ib, xbegin, xend, ybegin, yend, zbegin, zend, wrap)
         {
-            make_writeable();
+            make_writable();
             pos(m_rng_xbegin, m_rng_ybegin, m_rng_zbegin);
             if (m_rng_xbegin == m_rng_xend || m_rng_ybegin == m_rng_yend
                 || m_rng_zbegin == m_rng_zend)
@@ -1457,7 +1461,7 @@ public:
         Iterator(Iterator& i)
             : IteratorBase(i.m_ib, i.m_wrap)
         {
-            make_writeable();
+            make_writable();
             pos(i.m_x, i.m_y, i.m_z);
         }
 

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -898,8 +898,8 @@ public:
     /// Once created, the ImageCache owns the ImageInput and is responsible
     /// for destroying it when done. Custom ImageInputs allow "procedural"
     /// images, among other things.  Also, this is the method you use to set
-    /// up a "writeable" ImageCache images (perhaps with a type of
-    /// ImageInput that's just a stub that does as little as possible).
+    /// up a "writable" ImageCache images (perhaps with a type of ImageInput
+    /// that's just a stub that does as little as possible).
     ///
     /// If `config` is not NULL, it points to an ImageSpec with configuration
     /// options/hints that will be passed to the underlying

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1325,13 +1325,21 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
 
 
 bool
-ImageBuf::make_writeable(bool keep_cache_type)
+ImageBuf::make_writable(bool keep_cache_type)
 {
     if (storage() == IMAGECACHE) {
         return read(subimage(), miplevel(), 0, -1, true /*force*/,
                     keep_cache_type ? m_impl->m_cachedpixeltype : TypeDesc());
     }
     return true;
+}
+
+
+
+bool
+ImageBuf::make_writeable(bool keep_cache_type)
+{
+    return make_writable(keep_cache_type);
 }
 
 

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -113,7 +113,7 @@ ImageBufAlgo::IBAprep(ROI& roi, ImageBuf* dst, const ImageBuf* A,
         // If the dst is initialized but is a cached image, we'll need
         // to fully read it into allocated memory so that we're able
         // to write to it subsequently.
-        dst->make_writeable(true);
+        dst->make_writable(true);
 
         // Merge source metadata into destination if requested.
         if (prepflags & IBAprep_MERGE_METADATA) {
@@ -1198,7 +1198,7 @@ ImageBufAlgo::fillholes_pushpull(ImageBuf& dst, const ImageBuf& src, ROI roi,
     // auto-deleted when the function exits.
     std::vector<std::shared_ptr<ImageBuf>> pyramid;
 
-    // First, make a writeable copy of the original image (converting
+    // First, make a writable copy of the original image (converting
     // to float as a convenience) as the top level of the pyramid.
     ImageSpec topspec = src.spec();
     topspec.set_format(TypeDesc::FLOAT);

--- a/src/libOpenImageIO/imagebufalgo_mad.cpp
+++ b/src/libOpenImageIO/imagebufalgo_mad.cpp
@@ -32,7 +32,7 @@ mad_impl(ImageBuf& R, const ImageBuf& A, const ImageBuf& B, const ImageBuf& C,
     ImageBufAlgo::parallel_image(roi, nthreads, [&](ROI roi) {
         if ((is_same<Rtype, float>::value || is_same<Rtype, half>::value)
             && (is_same<ABCtype, float>::value || is_same<ABCtype, half>::value)
-            // && R.localpixels() // has to be, because it's writeable
+            // && R.localpixels() // has to be, because it's writable
             && A.localpixels() && B.localpixels()
             && C.localpixels()
             // && R.contains_roi(roi)  // has to be, because IBAPrep

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -278,7 +278,7 @@ resize_(ImageBuf& dst, const ImageBuf& src, Filter2D* filter, ROI roi,
             = ((is_same<DSTTYPE, float>::value || is_same<DSTTYPE, half>::value)
                && (is_same<SRCTYPE, float>::value
                    || is_same<SRCTYPE, half>::value)
-               // && dst.localpixels() // has to be, because it's writeable
+               // && dst.localpixels() // has to be, because it's writable
                && src.localpixels()
                // && R.contains_roi(roi)  // has to be, because IBAPrep
                && src.contains_roi(roi) && roi.chbegin == 0

--- a/src/libOpenImageIO/imageinout_test.cpp
+++ b/src/libOpenImageIO/imageinout_test.cpp
@@ -206,9 +206,9 @@ test_read_proxy(string_view formatname, string_view extension,
 
 
 // Test writer's ability to detect and recover from errors when asked to
-// write an unwriteable file (such as in a nonexistent directory).
+// write an unwritable file (such as in a nonexistent directory).
 static bool
-test_write_unwriteable(string_view extension, const ImageBuf& buf)
+test_write_unwritable(string_view extension, const ImageBuf& buf)
 {
     bool ok = true;
     Sysutil::Term term(stdout);
@@ -308,11 +308,11 @@ test_all_formats()
             test_read_proxy(formatname, extensions[0], filename, buf);
 
         //
-        // Test what happens when we write to an unwriteable or nonexistent
+        // Test what happens when we write to an unwritable or nonexistent
         // directory. It should not crash! But appropriately return some
         // error.
         //
-        test_write_unwriteable(extensions[0], buf);
+        test_write_unwritable(extensions[0], buf);
 
         Filesystem::remove(filename);
     }

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -44,7 +44,7 @@ int tiff_multithread(1);
 ustring plugin_searchpath(OIIO_DEFAULT_PLUGIN_SEARCHPATH);
 std::string format_list;         // comma-separated list of all formats
 std::string input_format_list;   // comma-separated list of readable formats
-std::string output_format_list;  // comma-separated list of writeable formats
+std::string output_format_list;  // comma-separated list of writable formats
 std::string extension_list;      // list of all extensions for all formats
 std::string library_list;        // list of all libraries for all formats
 static const char* oiio_debug_env = getenv("OPENIMAGEIO_DEBUG");

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1237,7 +1237,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     if (channelnames.size()) {
         std::vector<std::string> newchannelnames;
         Strutil::split(channelnames, newchannelnames, ",");
-        ImageSpec& spec(src->specmod());  // writeable version
+        ImageSpec& spec(src->specmod());  // writable version
         for (int c = 0; c < spec.nchannels; ++c) {
             if (c < (int)newchannelnames.size() && newchannelnames[c].size()) {
                 std::string name     = newchannelnames[c];

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4355,7 +4355,7 @@ action_fill(int argc, const char* argv[])
     ImageRecRef A(ot.pop());
     ot.read(A);
     ot.push(new ImageRec(*A, allsubimages ? -1 : 0, allsubimages ? -1 : 0,
-                         /*writeable=*/true, /*copy_pixels=*/true));
+                         /*writable=*/true, /*copy_pixels=*/true));
 
     int subimages = allsubimages ? A->subimages() : 1;
     for (int s = 0; s < subimages; ++s) {
@@ -4433,7 +4433,7 @@ action_clamp(int argc, const char* argv[])
     ot.read(A);
     int subimages = allsubimages ? A->subimages() : 1;
     ImageRecRef R(new ImageRec(*A, allsubimages ? -1 : 0, allsubimages ? -1 : 0,
-                               true /*writeable*/, false /*copy_pixels*/));
+                               true /*writable*/, false /*copy_pixels*/));
     ot.push(R);
     for (int s = 0; s < subimages; ++s) {
         int nchans      = (*R)(s, 0).nchannels();

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -265,10 +265,18 @@ declare_imagebuf(py::module& m)
             },
             "filename"_a, "dtype"_a = TypeUnknown, "fileformat"_a = "")
         .def(
+            "make_writeble",
+            [](ImageBuf& self, bool keep_cache_type) {
+                py::gil_scoped_release gil;
+                return self.make_writable(keep_cache_type);
+            },
+            "keep_cache_type"_a = false)
+        // DEPRECATED(2.2): nonstandard spelling
+        .def(
             "make_writeable",
             [](ImageBuf& self, bool keep_cache_type) {
                 py::gil_scoped_release gil;
-                return self.make_writeable(keep_cache_type);
+                return self.make_writable(keep_cache_type);
             },
             "keep_cache_type"_a = false)
         .def("set_write_format", &ImageBuf_set_write_format)

--- a/testsuite/python-imagebuf/ref/out-alt-python3.txt
+++ b/testsuite/python-imagebuf/ref/out-alt-python3.txt
@@ -1,4 +1,4 @@
-Constructing to be a writeable 320x240,4 UINT16:
+Constructing to be a writable 320x240,4 UINT16:
   resolution 320x240+0+0
   untiled
   4 channels: ('R', 'G', 'B', 'A')
@@ -6,7 +6,7 @@ Constructing to be a writeable 320x240,4 UINT16:
   alpha channel =  3
   z channel =  -1
   deep =  False
-Resetting to be a writeable 640x480,3 Float:
+Resetting to be a writable 640x480,3 Float:
   resolution 640x480+0+0
   untiled
   3 channels: ('R', 'G', 'B')

--- a/testsuite/python-imagebuf/ref/out-alt.txt
+++ b/testsuite/python-imagebuf/ref/out-alt.txt
@@ -1,4 +1,4 @@
-Constructing to be a writeable 320x240,4 UINT16:
+Constructing to be a writable 320x240,4 UINT16:
   resolution 320x240+0+0
   untiled
   4 channels: ('R', 'G', 'B', 'A')
@@ -6,7 +6,7 @@ Constructing to be a writeable 320x240,4 UINT16:
   alpha channel =  3
   z channel =  -1
   deep =  False
-Resetting to be a writeable 640x480,3 Float:
+Resetting to be a writable 640x480,3 Float:
   resolution 640x480+0+0
   untiled
   3 channels: ('R', 'G', 'B')

--- a/testsuite/python-imagebuf/ref/out-python3.txt
+++ b/testsuite/python-imagebuf/ref/out-python3.txt
@@ -1,4 +1,4 @@
-Constructing to be a writeable 320x240,4 UINT16:
+Constructing to be a writable 320x240,4 UINT16:
   resolution 320x240+0+0
   untiled
   4 channels: ('R', 'G', 'B', 'A')
@@ -6,7 +6,7 @@ Constructing to be a writeable 320x240,4 UINT16:
   alpha channel =  3
   z channel =  -1
   deep =  False
-Resetting to be a writeable 640x480,3 Float:
+Resetting to be a writable 640x480,3 Float:
   resolution 640x480+0+0
   untiled
   3 channels: ('R', 'G', 'B')

--- a/testsuite/python-imagebuf/ref/out.txt
+++ b/testsuite/python-imagebuf/ref/out.txt
@@ -1,4 +1,4 @@
-Constructing to be a writeable 320x240,4 UINT16:
+Constructing to be a writable 320x240,4 UINT16:
   resolution 320x240+0+0
   untiled
   4 channels: ('R', 'G', 'B', 'A')
@@ -6,7 +6,7 @@ Constructing to be a writeable 320x240,4 UINT16:
   alpha channel =  3
   z channel =  -1
   deep =  False
-Resetting to be a writeable 640x480,3 Float:
+Resetting to be a writable 640x480,3 Float:
   resolution 640x480+0+0
   untiled
   3 channels: ('R', 'G', 'B')

--- a/testsuite/python-imagebuf/src/test_imagebuf.py
+++ b/testsuite/python-imagebuf/src/test_imagebuf.py
@@ -60,10 +60,10 @@ def write (image, filename, format=oiio.UNKNOWN) :
 
 try:
 
-    print ("Constructing to be a writeable 320x240,4 UINT16:")
+    print ("Constructing to be a writable 320x240,4 UINT16:")
     b = oiio.ImageBuf (oiio.ImageSpec(320,240,4,oiio.UINT16))
     print_imagespec (b.spec())
-    print ("Resetting to be a writeable 640x480,3 Float:")
+    print ("Resetting to be a writable 640x480,3 Float:")
     b.reset (oiio.ImageSpec(640,480,3,oiio.FLOAT))
     print_imagespec (b.spec())
     print ("")


### PR DESCRIPTION
Nick Black points out that in many places we have used "writeable", which
is (depending on which dictionary you check) is either a less commonly
used variant of "writable", or just an outright misspelling.

Even charitably interpreting it as an alternate spelling, let's standardize
on the more common variant.

There's only one API function where this comes into play, so to preserve
link compatibility, we'll have both ImageBuf::make_writable() and
make_writeable() as a deprecated synonym that will eventually disappear.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
