### PR TITLE
Fully hide IplImage references when no OpenCV headers are included

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -109,7 +109,7 @@ jobs:
 
   linux-oldest:
     # Oldest versions of the dependencies that we can muster, and various
-    # things disabled (no SSE, no OCIO available, don't embed plugins)
+    # things disabled (no SSE, OCIO, or OpenCV, don't embed plugins)
     name: "Linux oldest/hobbled: gcc4.8/C++11 py2.7 boost-1.66 exr-2.2 no-sse no-ocio"
     runs-on: ubuntu-latest
     container:
@@ -125,6 +125,7 @@ jobs:
           USE_SIMD: 0
           USE_JPEGTURBO: 0
           USE_OPENCOLORIO: 0
+          USE_OPENCV: 0
           EMBEDPLUGINS: 0
           OPENEXR_BRANCH: v2.2.0
         run: |

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -2053,6 +2053,12 @@ inline bool capture_image (ImageBuf &dst, int cameranum = 0,
     return !dst.has_error();
 }
 
+
+
+#if defined(__OPENCV_CORE_TYPES_H__) || defined(OPENCV_CORE_TYPES_H)
+// These declarations are only visible if the OpenCV headers have already
+// been encountered.
+
 // DEPRECATED(2.0). The OpenCV 1.x era IplImage-based functions should be
 // avoided, giving preference to from_OpenCV.
 ImageBuf OIIO_API from_IplImage (const IplImage *ipl,
@@ -2068,6 +2074,7 @@ inline bool from_IplImage (ImageBuf &dst, const IplImage *ipl,
 // avoided, giving preference to from_OpenCV.
 OIIO_API IplImage* to_IplImage (const ImageBuf &src);
 
+#endif
 
 
 

--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -46,10 +46,11 @@
 OIIO_NAMESPACE_BEGIN
 
 
+namespace ImageBufAlgo {
 
 // Note: DEPRECATED(2.0)
 ImageBuf
-ImageBufAlgo::from_IplImage(const IplImage* ipl, TypeDesc convert)
+from_IplImage(const IplImage* ipl, TypeDesc convert)
 {
     pvt::LoggedTimer logtime("IBA::from_IplImage");
     ImageBuf dst;
@@ -123,7 +124,7 @@ ImageBufAlgo::from_IplImage(const IplImage* ipl, TypeDesc convert)
 
 // Note: DEPRECATED(2.0)
 IplImage*
-ImageBufAlgo::to_IplImage(const ImageBuf& src)
+to_IplImage(const ImageBuf& src)
 {
     pvt::LoggedTimer logtime("IBA::to_IplImage");
 #ifdef USE_OPENCV
@@ -219,6 +220,7 @@ RBswap(ImageBuf& R, ROI roi, int nthreads)
     return true;
 }
 
+}  // end namespace ImageBufAlgo
 
 
 ImageBuf


### PR DESCRIPTION
Closes #2566

Signed-off-by: Larry Gritz <lg@larrygritz.com>
