### PR TITLE
CMake modernization and warning suppression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,11 +407,11 @@ oiio_add_tests (fits
     URL http://www.cv.nrao.edu/fits/data/tests/)
 
 oiio_add_tests (heif
-    FOUNDVAR LIBHEIF_FOUND
+    FOUNDVAR Libheif_FOUND
     URL https://github.com/nokiatech/heif/tree/gh-pages/content)
 
 oiio_add_tests (webp
-    FOUNDVAR WEBP_FOUND
+    FOUNDVAR Webp_FOUND
     IMAGEDIR oiio-images/webp
     URL "Recent checkout of oiio-images")
 
@@ -419,11 +419,11 @@ oiio_add_tests (ptex
     FOUNDVAR PTEX_FOUND)
 
 oiio_add_tests (texture-field3d field3d
-    FOUNDVAR FIELD3D_FOUND)
+    FOUNDVAR Field3D_FOUND)
 
 
 oiio_add_tests (openvdb
-    FOUNDVAR OPENVDB_FOUND)
+    FOUNDVAR OpenVDB_FOUND)
 
 if (SPI_TESTS)
   oiio_add_tests (oiiotool-spi

--- a/src/cmake/modules/FindFFmpeg.cmake
+++ b/src/cmake/modules/FindFFmpeg.cmake
@@ -1,7 +1,7 @@
 # - Try to find ffmpeg libraries (libavcodec, libavformat and libavutil)
 # Once done this will define
 #
-#  FFMPEG_FOUND - system has ffmpeg or libav
+#  FFmpeg_FOUND - system has ffmpeg or libav
 #  FFMPEG_INCLUDE_DIR - the ffmpeg include directory
 #  FFMPEG_LIBRARIES - Link these to use ffmpeg
 #  FFMPEG_LIBAVCODEC
@@ -21,63 +21,54 @@
 # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
 
-if (FFMPEG_LIBRARIES AND FFMPEG_INCLUDE_DIR)
-  # in cache already
-  set(FFMPEG_FOUND TRUE)
-else ()
-  # use pkg-config to get the directories and then use these values
-  # in the FIND_PATH() and FIND_LIBRARY() calls
-  find_package(PkgConfig)
-  if (PKG_CONFIG_FOUND)
+# use pkg-config to get the directories and then use these values
+# in the FIND_PATH() and FIND_LIBRARY() calls
+find_package(PkgConfig)
+if (PKG_CONFIG_FOUND)
     pkg_check_modules(_FFMPEG_AVCODEC QUIET libavcodec)
     pkg_check_modules(_FFMPEG_AVFORMAT QUIET libavformat)
     pkg_check_modules(_FFMPEG_AVUTIL QUIET libavutil)
     pkg_check_modules(_FFMPEG_SWSCALE QUIET libswscale)
-  endif (PKG_CONFIG_FOUND)
+endif (PKG_CONFIG_FOUND)
 
-  find_path(FFMPEG_AVCODEC_INCLUDE_DIR
+find_path(FFMPEG_AVCODEC_INCLUDE_DIR
     NAMES libavcodec/version.h
     HINTS ${_FFMPEG_AVCODEC_INCLUDE_DIRS}
     PATH_SUFFIXES ffmpeg libav
   )
 
-  find_library(FFMPEG_LIBAVCODEC
+find_library(FFMPEG_LIBAVCODEC
     NAMES avcodec
     HINTS ${_FFMPEG_AVCODEC_LIBRARY_DIRS} )
 
-  find_library(FFMPEG_LIBAVFORMAT
+find_library(FFMPEG_LIBAVFORMAT
     NAMES avformat
     HINTS ${_FFMPEG_AVFORMAT_LIBRARY_DIRS} )
 
-  find_library(FFMPEG_LIBAVUTIL
+find_library(FFMPEG_LIBAVUTIL
     NAMES avutil
     HINTS ${_FFMPEG_AVUTIL_LIBRARY_DIRS} )
 
-  find_library(FFMPEG_LIBSWSCALE
+find_library(FFMPEG_LIBSWSCALE
     NAMES swscale
     HINTS ${_FFMPEG_SWSCALE_LIBRARY_DIRS} )
 
-  if (FFMPEG_LIBAVCODEC AND FFMPEG_LIBAVFORMAT AND FFMPEG_AVCODEC_INCLUDE_DIR)
-    set(FFMPEG_FOUND TRUE)
-  endif()
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (FFmpeg
+    REQUIRED_VARS   FFMPEG_LIBAVCODEC
+                    FFMPEG_LIBAVFORMAT
+                    FFMPEG_AVCODEC_INCLUDE_DIR
+    )
 
-  if (FFMPEG_FOUND)
+if (FFmpeg_FOUND)
     set(FFMPEG_INCLUDE_DIR ${FFMPEG_AVCODEC_INCLUDE_DIR})
-
     set(FFMPEG_LIBRARIES
       ${FFMPEG_LIBAVCODEC}
       ${FFMPEG_LIBAVFORMAT}
       ${FFMPEG_LIBAVUTIL}
       ${FFMPEG_LIBSWSCALE}
     )
-  endif ()
 endif ()
-
-include (FindPackageHandleStandardArgs)
-find_package_handle_standard_args (FFMPEG
-    REQUIRED_VARS   FFMPEG_INCLUDE_DIR
-                    FFMPEG_LIBRARIES
-    )
 
 mark_as_advanced (
     FFMPEG_INCLUDES FFMPEG_LIBRARIES

--- a/src/cmake/modules/FindField3D.cmake
+++ b/src/cmake/modules/FindField3D.cmake
@@ -5,7 +5,7 @@
 #
 # This module defines the following variables:
 #
-# FIELD3D_FOUND            True if Field3D was found.
+# Field3D_FOUND            True if Field3D was found.
 # FIELD3D_INCLUDES         Where to find Field3D headers
 # FIELD3D_LIBRARIES        List of libraries to link against when using Field3D
 # FIELD3D_VERSION          Version of Field3D (e.g., 3.6.2)
@@ -24,13 +24,21 @@ find_library (FIELD3D_LIBRARY Field3D
                   ENV FIELD3D_LIBRARY_PATH
               DOC "The Field3D libraries")
 
-find_package_handle_standard_args (FIELD3D
+find_package_handle_standard_args (Field3D
     REQUIRED_VARS   FIELD3D_INCLUDE_DIR FIELD3D_LIBRARY
     )
 
-if (FIELD3D_FOUND)
+if (Field3D_FOUND)
     set (FIELD3D_INCLUDES ${FIELD3D_INCLUDE_DIR})
     set (FIELD3D_LIBRARIES ${FIELD3D_LIBRARY})
+
+    if (NOT TARGET Field3D::Field3D)
+        add_library(Field3D::Field3D UNKNOWN IMPORTED)
+        set_target_properties(Field3D::Field3D PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${FIELD3D_INCLUDES}")
+        set_property(TARGET Field3D::Field3D APPEND PROPERTY
+            IMPORTED_LOCATION "${FIELD3D_LIBRARIES}")
+    endif ()
 endif ()
 
 mark_as_advanced (

--- a/src/cmake/modules/FindLibheif.cmake
+++ b/src/cmake/modules/FindLibheif.cmake
@@ -5,7 +5,7 @@
 #
 # This module defines the following variables:
 #
-# LIBHEIF_FOUND            True if LIBHEIF was found.
+# Libheif_FOUND            True if LIBHEIF was found.
 # LIBHEIF_INCLUDES         Where to find LIBHEIF headers
 # LIBHEIF_LIBRARIES        List of libraries to link against when using LIBHEIF
 # LIBHEIF_VERSION          Version of LIBHEIF (e.g., 3.6.2)
@@ -30,17 +30,24 @@ if (LIBHEIF_INCLUDE_DIR)
     string(REGEX MATCHALL "[0-9.]+" LIBHEIF_VERSION ${TMP})
 endif ()
 
-if (LIBHEIF_INCLUDE_DIR AND LIBHEIF_LIBRARY)
-    set(LIBHEIF_INCLUDES "${LIBHEIF_INCLUDE_DIR}" CACHE PATH "Libheif include path")
-    set(LIBHEIF_LIBRARIES "${LIBHEIF_LIBRARY}" CACHE STRING "Libheif libraries")
-endif()
-
 include (FindPackageHandleStandardArgs)
-find_package_handle_standard_args (LIBHEIF
-    REQUIRED_VARS   LIBHEIF_INCLUDES
-                    LIBHEIF_LIBRARIES
-    VERSION_VAR     LIBHEIF_VERSION
+find_package_handle_standard_args (Libheif
+    REQUIRED_VARS   LIBHEIF_INCLUDE_DIR
+                    LIBHEIF_LIBRARY
     )
+
+if (Libheif_FOUND)
+    set(LIBHEIF_INCLUDES "${LIBHEIF_INCLUDE_DIR}")
+    set(LIBHEIF_LIBRARIES "${LIBHEIF_LIBRARY}")
+
+    if (NOT TARGET Libheif::Libheif)
+        add_library(Libheif::Libheif UNKNOWN IMPORTED)
+        set_target_properties(Libheif::Libheif PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${LIBHEIF_INCLUDES}")
+        set_property(TARGET Libheif::Libheif APPEND PROPERTY
+            IMPORTED_LOCATION "${LIBHEIF_LIBRARIES}")
+    endif ()
+endif()
 
 mark_as_advanced (
     LIBHEIF_INCLUDES

--- a/src/cmake/modules/FindLibsquish.cmake
+++ b/src/cmake/modules/FindLibsquish.cmake
@@ -5,7 +5,7 @@
 #
 # This module defines the following variables:
 #
-# LIBSQUISH_FOUND            True if Libsquish was found.
+# Libsquish_FOUND            True if Libsquish was found.
 # LIBSQUISH_INCLUDES         Where to find Libsquish headers
 # LIBSQUISH_LIBRARIES        List of libraries to link against when using Libsquish
 # LIBSQUISH_VERSION          Version of Libsquish (e.g., 3.6.2)
@@ -24,13 +24,13 @@ find_library (LIBSQUISH_LIBRARY squish
                   ENV LIBSQUISH_LIBRARY_PATH
               DOC "The Libsquish libraries")
 
-find_package_handle_standard_args (LIBSQUISH
+find_package_handle_standard_args (Libsquish
     REQUIRED_VARS
         LIBSQUISH_INCLUDE_DIR
         LIBSQUISH_LIBRARY
     )
 
-if (LIBSQUISH_FOUND)
+if (Libsquish_FOUND)
     set (LIBSQUISH_INCLUDES ${LIBSQUISH_INCLUDE_DIR})
     set (LIBSQUISH_LIBRARIES ${LIBSQUISH_LIBRARY})
 

--- a/src/cmake/modules/FindOpenVDB.cmake
+++ b/src/cmake/modules/FindOpenVDB.cmake
@@ -6,7 +6,7 @@
 #  OPENVDB_LIBRARIES, libraries to link against to use OPENVDB.
 #  OpenVDB_ROOT, The base directory to search for OPENVDB.
 #                        This can also be an environment variable.
-#  OPENVDB_FOUND, If false, do not try to use OPENVDB.
+#  OpenVDB_FOUND, If false, do not try to use OPENVDB.
 #
 # also defined, but not for general use are
 #  OPENVDB_LIBRARY, where to find the OPENVDB library.
@@ -67,18 +67,26 @@ find_library(OPENVDB_LIBRARY
     ${oiio_vdblib_search}
 )
 
-# handle the QUIETLY and REQUIRED arguments and set OPENVDB_FOUND to TRUE if
+# handle the QUIETLY and REQUIRED arguments and set OpenVDB_FOUND to TRUE if
 # all listed variables are TRUE
 INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(OPENVDB
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(OpenVDB
     REQUIRED_VARS OPENVDB_LIBRARY OPENVDB_INCLUDE_DIR
     VERSION_VAR  OPENVDB_VERSION
     )
 
-IF(OPENVDB_FOUND)
-  SET(OPENVDB_LIBRARIES ${OPENVDB_LIBRARY})
-  SET(OPENVDB_INCLUDE_DIRS ${OPENVDB_INCLUDE_DIR})
-ENDIF(OPENVDB_FOUND)
+if (OpenVDB_FOUND)
+    set(OPENVDB_LIBRARIES ${OPENVDB_LIBRARY})
+    set(OPENVDB_INCLUDE_DIRS ${OPENVDB_INCLUDE_DIR})
+
+    if (NOT TARGET OpenVDB::OpenVDB)
+        add_library(OpenVDB::OpenVDB UNKNOWN IMPORTED)
+        set_target_properties(OpenVDB::OpenVDB PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${OPENVDB_INCLUDES}")
+        set_property(TARGET OpenVDB::OpenVDB APPEND PROPERTY
+            IMPORTED_LOCATION "${OPENVDB_LIBRARIES}")
+    endif ()
+endif ()
 
 MARK_AS_ADVANCED(
   OPENVDB_INCLUDE_DIR

--- a/src/cmake/modules/FindWebp.cmake
+++ b/src/cmake/modules/FindWebp.cmake
@@ -5,7 +5,7 @@
 #
 # This module defines the following variables:
 #
-# WEBP_FOUND            True if Webp was found.
+# Webp_FOUND            True if Webp was found.
 # WEBP_INCLUDES         Where to find Webp headers
 # WEBP_LIBRARIES        List of libraries to link against when using Webp
 # WEBP_VERSION          Version of Webp (e.g., 3.6.2)
@@ -25,14 +25,22 @@ find_library (WEBP_LIBRARY webp
               DOC "The directory where Webp libraries reside")
 
 include (FindPackageHandleStandardArgs)
-find_package_handle_standard_args (WEBP
+find_package_handle_standard_args (Webp
     REQUIRED_VARS   WEBP_INCLUDE_DIR
                     WEBP_LIBRARY
     )
 
-if (WEBP_FOUND)
+if (Webp_FOUND)
     set (WEBP_INCLUDES "${WEBP_INCLUDE_DIR}")
     set (WEBP_LIBRARIES "${WEBP_LIBRARY}")
+
+    if (NOT TARGET Webp::Webp)
+        add_library(Webp::Webp UNKNOWN IMPORTED)
+        set_target_properties(Webp::Webp PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${WEBP_INCLUDES}")
+        set_property(TARGET Webp::Webp APPEND PROPERTY
+            IMPORTED_LOCATION "${WEBP_LIBRARIES}")
+    endif ()
 endif ()
 
 mark_as_advanced (

--- a/src/dds.imageio/CMakeLists.txt
+++ b/src/dds.imageio/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
-if (LIBSQUISH_FOUND)
+if (Libsquish_FOUND)
     # External libsquish was found -- use it
     add_oiio_plugin (ddsinput.cpp
                      LINK_LIBRARIES Libsquish::Libsquish

--- a/src/ffmpeg.imageio/CMakeLists.txt
+++ b/src/ffmpeg.imageio/CMakeLists.txt
@@ -11,10 +11,11 @@ if (NOT MSVC)
                              PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations")
 endif()
 
-if (FFMPEG_FOUND)
+if (FFmpeg_FOUND)
     add_oiio_plugin (ffmpeginput.cpp
                      INCLUDE_DIRS ${FFMPEG_INCLUDE_DIR}
-                     LINK_LIBRARIES ${FFMPEG_LIBRARIES} ${BZIP2_LIBRARIES}
+                     LINK_LIBRARIES ${FFMPEG_LIBRARIES}
+                                    ${BZIP2_LIBRARIES}
                      DEFINITIONS "-DUSE_FFMPEG")
 else()
     message (STATUS "FFmpeg not found: ffmpeg plugin will not be built")

--- a/src/field3d.imageio/CMakeLists.txt
+++ b/src/field3d.imageio/CMakeLists.txt
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
-if (FIELD3D_FOUND)
+if (Field3D_FOUND)
     find_library (SZIP_LIBRARY NAMES sz)
     if (NOT SZIP_LIBRARY)
         set (SZIP_LIBRARY "")
     endif ()
     add_oiio_plugin (field3dinput.cpp field3doutput.cpp
                      INCLUDE_DIRS ${FIELD3D_INCLUDES}
-                     LINK_LIBRARIES ${FIELD3D_LIBRARY} ${HDF5_LIBRARIES}
+                     LINK_LIBRARIES Field3D::Field3D
+                                    # ${HDF5_LIBRARIES}
                                     ${SZIP_LIBRARY})
 endif()

--- a/src/heif.imageio/CMakeLists.txt
+++ b/src/heif.imageio/CMakeLists.txt
@@ -2,10 +2,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
-if (LIBHEIF_FOUND)
+if (Libheif_FOUND)
     add_oiio_plugin (heifinput.cpp heifoutput.cpp
-                     INCLUDE_DIRS ${LIBHEIF_INCLUDES}
-                     LINK_LIBRARIES ${LIBHEIF_LIBRARIES}
+                     LINK_LIBRARIES Libheif::Libheif
                      DEFINITIONS "-DUSE_HEIF=1")
 else ()
     message (WARNING "heif plugin will not be built")

--- a/src/openvdb.imageio/CMakeLists.txt
+++ b/src/openvdb.imageio/CMakeLists.txt
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
-if (OPENVDB_FOUND)
+if (OpenVDB_FOUND)
     add_oiio_plugin (openvdbinput.cpp
-                     INCLUDE_DIRS ${OPENVDB_INCLUDE_DIRS} ${TBB_INCLUDE_DIRS}
-                     LINK_LIBRARIES ${OPENVDB_LIBRARIES} ${TBB_tbb_LIBRARY} ${BOOST_LIBRARIES})
+                     INCLUDE_DIRS ${TBB_INCLUDE_DIRS}
+                     LINK_LIBRARIES OpenVDB::OpenVDB ${TBB_tbb_LIBRARY} ${BOOST_LIBRARIES})
 endif()

--- a/src/webp.imageio/CMakeLists.txt
+++ b/src/webp.imageio/CMakeLists.txt
@@ -2,10 +2,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
-if (WEBP_FOUND)
+if (Webp_FOUND)
     add_oiio_plugin (webpinput.cpp webpoutput.cpp
-                     INCLUDE_DIRS ${WEBP_INCLUDE_DIR}
-                     LINK_LIBRARIES ${WEBP_LIBRARY}
+                     LINK_LIBRARIES Webp::Webp
                      DEFINITIONS "-DUSE_WEBP=1")
 else ()
     message (STATUS "WebP plugin will not be built")


### PR DESCRIPTION
We were getting warnings from newer cmake versions in cases where we
had modules named FindFoo.cmake, but the "found" variable was FOO_FOUND
(instead of matching the module/package name with Foo_FOUND).

Clean that up, as well as imposing a few more namespaced imports to
change to a more modern notation.

