### PR TITLE
Add the raw:flip attribute

### DIFF
--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -601,7 +601,9 @@ RawInput::open_raw(bool unpack, const std::string& name,
     // The "flip" field gives the information about this rotation.
     // This rotation is dependent on the camera orientation sensor.
     // This information may be important for the user.
-    m_spec.attribute("raw:flip", sizes.flip);
+    if (sizes.flip != 0) {
+        m_spec.attribute("raw:flip", sizes.flip);
+    }
 
     // FIXME: sizes. top_margin, left_margin, raw_pitch, mask?
 

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -596,6 +596,13 @@ RawInput::open_raw(bool unpack, const std::string& name,
 
     const libraw_image_sizes_t& sizes(m_processor->imgdata.sizes);
     m_spec.attribute("PixelAspectRatio", (float)sizes.pixel_aspect);
+    
+    // Libraw rotate the pixels automatically. 
+    // The "flip" field gives the information about this rotation.
+    // This rotation is dependent on the camera orientation sensor.
+    // This information may be important for the user.
+    m_spec.attribute("raw:flip", sizes.flip);
+
     // FIXME: sizes. top_margin, left_margin, raw_pitch, mask?
 
     const libraw_iparams_t& idata(m_processor->imgdata.idata);


### PR DESCRIPTION
## Description

Adding the "raw:flip" attribute. 

This field is set by LibRaw when the image has been rotated internally. 
From my understanding, this is an equivalent to the exif:orientation (Don't know why it is not in this exif).

## Tests

I don't think a test is needed as it is only an export of a known LibRaw structure's field.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ X My code follows the prevailing code style of this project.

