### PR TITLE
Minor formatting changes in ustring with new clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,26 +2,30 @@ Language:        Cpp
 BasedOnStyle:  WebKit
 SpaceBeforeParens: ControlStatements
 
-#AccessModifierOffset: -4
+AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: true
-#AlignConsecutiveDeclarations: false
-#AlignEscapedNewlines: Right
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
 AlignOperands:   true
 AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: true
-#AllowShortFunctionsOnASingleLine: All
-#AllowShortIfStatementsOnASingleLine: false
-#AllowShortLoopsOnASingleLine: false
-#AlwaysBreakAfterDefinitionReturnType: None
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: TopLevel
-#AlwaysBreakBeforeMultilineStrings: false
-#AlwaysBreakTemplateDeclarations: MultiLine
-#BinPackArguments: true
-#BinPackParameters: true
-BraceWrapping:
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterCaseLabel:  false
   AfterClass:      false
   AfterControlStatement: false
   AfterEnum:       false
@@ -37,83 +41,88 @@ BraceWrapping:
   SplitEmptyFunction: false
   SplitEmptyRecord: false
   SplitEmptyNamespace: false
-#BreakBeforeBinaryOperators: All
-#BreakBeforeBraces: WebKit
-#BreakBeforeInheritanceComma: false
-#BreakInheritanceList: BeforeColon
-#BreakBeforeTernaryOperators: true
-#BreakConstructorInitializersBeforeComma: false
-#BreakConstructorInitializers: BeforeComma
-#BreakAfterJavaFieldAnnotations: false
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: WebKit
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: false
 ColumnLimit:     80
-#CommentPragmas:  '^ IWYU pragma:'
-#CompactNamespaces: false
-#ConstructorInitializerAllOnOneLineOrOnePerLine: false
-#ConstructorInitializerIndentWidth: 4
-#ContinuationIndentWidth: 4
-#Cpp11BracedListStyle: false
-#DerivePointerAlignment: true
-#DisableFormat:   false
-#ExperimentalAutoDetectBinPacking: false
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
-#ForEachMacros:   
-#  - foreach
-#  - Q_FOREACH
-#  - BOOST_FOREACH
-#IncludeBlocks:   Preserve
-#IncludeCategories: 
-#  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
-#    Priority:        2
-#  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
-#    Priority:        3
-#  - Regex:           '.*'
-#    Priority:        1
-#IncludeIsMainRegex: '(Test)?$'
-#IndentCaseLabels: false
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
 IndentPPDirectives: AfterHash
-#IndentWidth:     4
-#IndentWrappedFunctionNames: false
-#JavaScriptQuotes: Leave
-#JavaScriptWrapImports: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
-#MacroBlockBegin: ''
-#MacroBlockEnd:   ''
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 3
-#NamespaceIndentation: Inner
-#ObjCBinPackProtocolList: Auto
-#ObjCBlockIndentWidth: 4
-#ObjCSpaceAfterProperty: true
-#ObjCSpaceBeforeProtocolList: true
+NamespaceIndentation: Inner
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
 PenaltyBreakAssignment: 40
 PenaltyBreakBeforeFirstCallParameter: 100
-#PenaltyBreakComment: 300
-#PenaltyBreakFirstLessLess: 120
-#PenaltyBreakString: 1000
-#PenaltyBreakTemplateDeclaration: 10
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 75
 PenaltyReturnTypeOnItsOwnLine: 50
-#PointerAlignment: Left
+PointerAlignment: Left
 ReflowComments:  false
-#SortIncludes:    true
-#SortUsingDeclarations: true
-#SpaceAfterCStyleCast: false
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: false
-#SpaceBeforeAssignmentOperators: true
-#SpaceBeforeCpp11BracedList: true
-#SpaceBeforeCtorInitializerColon: true
-#SpaceBeforeInheritanceColon: true
-#SpaceBeforeParens: ControlStatements
-#SpaceBeforeRangeBasedForLoopColon: true
-#SpaceInEmptyParentheses: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
-#SpacesInAngles:  false
-#SpacesInContainerLiterals: true
-#SpacesInCStyleCastParentheses: false
-#SpacesInParentheses: false
-#SpacesInSquareBrackets: false
-#Standard:        Cpp11
-#TabWidth:        8
-#UseTab:          Never
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+StatementMacros: 
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never
 #...
 

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -407,14 +407,14 @@ public:
         return string().rfind(c, pos);
     }
 
-    size_type find_first_of(const ustring& str, size_type pos = 0) const
-        noexcept
+    size_type find_first_of(const ustring& str,
+                            size_type pos = 0) const noexcept
     {
         return string().find_first_of(str.string(), pos);
     }
 
-    size_type find_first_of(const std::string& str, size_type pos = 0) const
-        noexcept
+    size_type find_first_of(const std::string& str,
+                            size_type pos = 0) const noexcept
     {
         return string().find_first_of(str, pos);
     }
@@ -434,14 +434,14 @@ public:
         return string().find_first_of(c, pos);
     }
 
-    size_type find_last_of(const ustring& str, size_type pos = npos) const
-        noexcept
+    size_type find_last_of(const ustring& str,
+                           size_type pos = npos) const noexcept
     {
         return string().find_last_of(str.string(), pos);
     }
 
-    size_type find_last_of(const std::string& str, size_type pos = npos) const
-        noexcept
+    size_type find_last_of(const std::string& str,
+                           size_type pos = npos) const noexcept
     {
         return string().find_last_of(str, pos);
     }
@@ -461,14 +461,14 @@ public:
         return string().find_last_of(c, pos);
     }
 
-    size_type find_first_not_of(const ustring& str, size_type pos = 0) const
-        noexcept
+    size_type find_first_not_of(const ustring& str,
+                                size_type pos = 0) const noexcept
     {
         return string().find_first_not_of(str.string(), pos);
     }
 
-    size_type find_first_not_of(const std::string& str, size_type pos = 0) const
-        noexcept
+    size_type find_first_not_of(const std::string& str,
+                                size_type pos = 0) const noexcept
     {
         return string().find_first_not_of(str, pos);
     }
@@ -488,8 +488,8 @@ public:
         return string().find_first_not_of(c, pos);
     }
 
-    size_type find_last_not_of(const ustring& str, size_type pos = npos) const
-        noexcept
+    size_type find_last_not_of(const ustring& str,
+                               size_type pos = npos) const noexcept
     {
         return string().find_last_not_of(str.string(), pos);
     }


### PR DESCRIPTION
From here on, clang-format 10 will be our official reference formatter.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

