### PR TITLE
Break infinite loop in FFMpeg::read_frame()

### DIFF
--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -612,6 +612,9 @@ FFmpegInput::read_frame(int frame)
     int ret      = 0;
     while ((ret = av_read_frame(m_format_context, &pkt)) == 0
            || m_codec_cap_delay) {
+        if (ret == AVERROR_EOF) {
+            break;
+        }
         if (pkt.stream_index == m_video_stream) {
             if (ret < 0 && m_codec_cap_delay) {
                 pkt.data = NULL;


### PR DESCRIPTION
## Description

Codecs which set the CODEC_CAP_DELAY capability led to infinite
loops during reading (see #2571). Once AVERROR_EOF is returned,
no more packets are going to be received, regardless of internal
buffering. break out of the loop in that case.

I've verified that this resolves the livelock following decoding
of the first packet in the Notcurses AVI test case which
illustrated this problem. I've also verified that said AVI
advertises the CODEC_CAP_DELAY attribute, matching the proposed
fix. In addition, I verified that OIIO continues to decode all
my other test cases without trouble. I hand-inspected the media,
and verified that the frame counts were precisely correct.

It is legal to pass NULL/0 into the decoder regardless of
CODEC_CAP_DELAY, and thus this whole conditional can really
be eliminated (I have no mention of it in my FFmpeg wrappers).
I haven't bothered to do that here, but it's a thought for the
future. Closes #2571.

## Tests

I haven't added any, but you're welcome to test with

https://github.com/dankamongmen/notcurses/blob/master/data/samoa.avi

This failed with `oiiotool -a --dumpdata` before, but does not now. Instead, we get all expected frames, followed by successful termination.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

This transitively resolves https://github.com/dankamongmen/notcurses/issues/547.