### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -41,7 +41,6 @@ jobs:
     name: "Linux VFX Platform 2020: gcc6/C++14 py3.7 boost-1.70 exr-2.4"
     runs-on: ubuntu-latest
     container:
-      #image: aswf/ci-base:2020
       image: aswf/ci-osl:2020
     steps:
       - uses: actions/checkout@v2
@@ -120,6 +119,7 @@ jobs:
           LIBTIFF_BRANCH: master
           PYBIND11_BRANCH: master
           LIBRAW_BRANCH: master
+          MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=master
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps.bash
@@ -181,7 +181,7 @@ jobs:
         env:
           PYTHON_VERSION: 3.6
           CMAKE_GENERATOR: "Visual Studio 16 2019"
-          OPENEXR_BRANCH: v2.4.0
+          OPENEXR_BRANCH: v2.4.1
           SKIP_TESTS: 1
         run: |
             source src/build-scripts/ci-startup.bash
@@ -191,16 +191,19 @@ jobs:
   sanitizer:
     name: "Sanitizers"
     runs-on: ubuntu-18.04
-    if: github.event_name == 'pull_request' || contains(github.ref, 'san') || contains(github.ref, 'RB') || contains(github.ref, 'release') || contains(github.ref, 'master') || contains(github.ref, 'gh')
+    if: github.event_name == 'pull_request' || github.event_name == 'schedule' || contains(github.ref, 'san') || contains(github.ref, 'RB') || contains(github.ref, 'release') || contains(github.ref, 'master') || contains(github.ref, 'gh')
+    container:
+      image: aswf/ci-osl:2020
     steps:
       - uses: actions/checkout@v2
-      #- uses: docker://aswfstaging/ci-base:2019
       - name: all
         env:
-          CXX: g++-7
+          CXX: g++
+          CC: gcc
           CMAKE_CXX_STANDARD: 14
-          SANITIZE: address
+          PYTHON_VERSION: 3.7
           USE_PYTHON: 0
+          SANITIZE: address
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps.bash
@@ -217,7 +220,7 @@ jobs:
           LLVM_VERSION: 9.0.0
           CMAKE_CXX_STANDARD: 14
           USE_SIMD: avx2,f16c
-          OPENEXR_BRANCH: v2.4.0
+          OPENEXR_BRANCH: v2.4.1
           OCIO_BRANCH: 1c624651b7
           # Pick an OCIO commit that includes a warning fix we need for clang
         run: |
@@ -230,7 +233,6 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      #- uses: docker://aswfstaging/ci-base:2019
       - name: all
         env:
           CXX: g++-7

--- a/src/build-scripts/ci-build-and-test.bash
+++ b/src/build-scripts/ci-build-and-test.bash
@@ -19,30 +19,29 @@ if [[ ! -e dist/$PLATFORM ]] ; then
     mkdir -p dist/$PLATFORM
 fi
 
-if [[ "$ARCH" == "windows64" ]] ; then
-    pushd build/$PLATFORM
-    cmake ../.. -G "$CMAKE_GENERATOR" \
-        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+if [[ "$USE_SIMD" != "" ]] ; then
+    MY_CMAKE_FLAGS="$MY_CMAKE_FLAGS -DUSE_SIMD=$USE_SIMD"
+fi
+if [[ "$DEBUG" == "1" ]] ; then
+    export CMAKE_BUILD_TYPE=Debug
+fi
+
+pushd build/$PLATFORM
+cmake ../.. -G "$CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
         -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
         -DCMAKE_INSTALL_PREFIX="$OpenImageIO_ROOT" \
         -DPYTHON_VERSION="$PYTHON_VERSION" \
+        -DCMAKE_INSTALL_LIBDIR="$OpenImageIO_ROOT/lib" \
+        -DCMAKE_CXX_STANDARD="$CMAKE_CXX_STANDARD" \
         $MY_CMAKE_FLAGS -DVERBOSE=1
-    echo "Parallel build $CMAKE_BUILD_PARALLEL_LEVEL"
-    # export VERBOSE=1
-    time cmake --build . --target install --config ${CMAKE_BUILD_TYPE}
-    popd
-else
-    make $MAKEFLAGS VERBOSE=1 $BUILD_FLAGS config
-    make $MAKEFLAGS $PAR_MAKEFLAGS $BUILD_FLAGS $BUILDTARGET
-fi
+time cmake --build . --target install --config ${CMAKE_BUILD_TYPE}
+popd
+#make $MAKEFLAGS VERBOSE=1 $BUILD_FLAGS config
+#make $MAKEFLAGS $PAR_MAKEFLAGS $BUILD_FLAGS $BUILDTARGET
 
-echo "OpenImageIO_ROOT $OpenImageIO_ROOT"
-ls -R -l "$OpenImageIO_ROOT"
-
-if [[ -e ./build/$PLATFORM/src/include/export.h ]] ; then
-    echo "export.h is:"
-    cat ./build/$PLATFORM/src/include/export.h
-fi
+#echo "OpenImageIO_ROOT $OpenImageIO_ROOT"
+#ls -R -l "$OpenImageIO_ROOT"
 
 if [[ "$SKIP_TESTS" == "" ]] ; then
     $OpenImageIO_ROOT/bin/oiiotool --help

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -304,7 +304,7 @@ endif ()
 # Check if we need libatomic on this platform.  We shouldn't on mainstream
 # x86/x86_64, but might on some other platforms.
 #
-if (NOT MSVC)
+if (NOT MSVC AND NOT APPLE)
     cmake_push_check_state ()
     check_cxx_source_runs(
        "#include <atomic>


### PR DESCRIPTION
* Build "bleeding edge" against fmt master

* Tests that build against OpenEXR 2.4.0, bump to 2.4.1.

* The "sanitizer" test, use ane aswf/ci-osl:2020 container.  This is a
  slow test, so may as well speed it up by using the container with
  pre-installed dependencies.

* Modify ci-build-and-test.bash to use straight cmake build and install,
  not the makefile wrapper.

* No need for atomic lib check on Apple

Signed-off-by: Larry Gritz <lg@larrygritz.com>

