### PR TITLE
oiiotool continued refactor

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -1542,6 +1542,12 @@ current top image.
     will rename channel 3 to be "A" and channel 4 to be
     "Z", but will leave channels 0--3 with their old names.
 
+    Optional appended modifiers include:
+
+      `:subimages=` *indices-or-names*
+        Include/exclude subimages (see :ref:`sec-oiiotool-subimage-modifier`).
+        Only included subimages will have their channels renamed.
+
 
 .. _sec-oiiotool-shuffle-channels-or-subimages:
 
@@ -1613,6 +1619,12 @@ current top image.
 
     Replaces the top two images on the stack with a new image comprised of
     the channels of both images appended together.
+
+    Optional appended modifiers include:
+
+      `:subimages=` *indices-or-names*
+        Include/exclude subimages (see :ref:`sec-oiiotool-subimage-modifier`).
+
 
 
 :program:`oiiotool` commands that adjust the image stack
@@ -2044,11 +2056,17 @@ current top image.
     whose value at each pixel is the sum of all channels of the original
     image.  Using the optional weight allows you to customize the
     weight of each channel in the sum.
-    
-    - `weight=` *r,g,...* : Specify the weight of each channel (default: 1).
-    
+
+    Optional appended modifiers include:
+
+      `weight=` *r,g,...*
+        Specify the weight of each channel (default: 1).
+
+      `:subimages=` *indices-or-names*
+        Include/exclude subimages (see :ref:`sec-oiiotool-subimage-modifier`).
+
     Example::
-    
+
         oiiotool RGB.tif --chsum:weight=.2126,.7152,.0722 -o luma.tif
 
     ..

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -29,21 +29,21 @@ using namespace ImageBufAlgo;
 
 
 ImageRec::ImageRec(const std::string& name, int nsubimages,
-                   const int* miplevels, const ImageSpec* specs)
+                   cspan<int> miplevels, cspan<ImageSpec> specs)
     : m_name(name)
     , m_elaborated(true)
 {
     int specnum = 0;
     m_subimages.resize(nsubimages);
     for (int s = 0; s < nsubimages; ++s) {
-        int nmips = miplevels ? miplevels[s] : 1;
+        int nmips = miplevels.size() ? miplevels[s] : 1;
         m_subimages[s].m_miplevels.resize(nmips);
         m_subimages[s].m_specs.resize(nmips);
         for (int m = 0; m < nmips; ++m) {
-            ImageBuf* ib = specs ? new ImageBuf(specs[specnum])
-                                 : new ImageBuf();
+            ImageBuf* ib = specs.size() ? new ImageBuf(specs[specnum])
+                                        : new ImageBuf();
             m_subimages[s].m_miplevels[m].reset(ib);
-            if (specs)
+            if (specs.size())
                 m_subimages[s].m_specs[m] = specs[specnum];
             ++specnum;
         }


### PR DESCRIPTION
* Make sure the opname is always canonicalized

* Refactor to allow setup() to call skip_impl() to skip the impl and
  copy instead.

* --ummip : make OiiotoolOp subclass (but note, it doesn't honor the
  `:subimages=` modifier).

* --chnames : now OiiotoolOp and honors the `:subimages=` modifier.

* --chsum : now OiiotoolOp and honors the `:subimages=` modifier.

* --chappend : now OiiotoolOp and honors the `:subimages=` modifier.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

