### PR TITLE
Add CI test to exercise gcc10

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,10 +16,27 @@ on:
       - '**.rst'
   schedule:
     # Full nightly build
-    - cron: "0 0 * * *"
+    - cron: "0 4 * * *"
 
 
 jobs:
+  linux-gcc48:
+    name: "Linux 2017-ish: gcc4.8/C++11 py2.7 boost-1.66 exr-2.3"
+    runs-on: ubuntu-latest
+    container:
+      image: aswf/ci-osl:2019
+    steps:
+      - uses: actions/checkout@v2
+      - name: all
+        env:
+          CXX: /usr/bin/g++
+          CC: /usr/bin/gcc
+          CMAKE_CXX_STANDARD: 11
+        run: |
+            source src/build-scripts/ci-startup.bash
+            source src/build-scripts/gh-installdeps-centos.bash
+            source src/build-scripts/ci-build-and-test.bash
+
   vfxplatform-2019:
     name: "Linux VFX Platform 2019: gcc6/C++14 py2.7 boost-1.66 exr-2.3"
     runs-on: ubuntu-latest
@@ -55,24 +72,8 @@ jobs:
             source src/build-scripts/gh-installdeps-centos.bash
             source src/build-scripts/ci-build-and-test.bash
 
-  linux-gcc48:
-    name: "Linux 2017-ish: gcc4.8/C++11 py2.7 boost-1.66 exr-2.3"
-    runs-on: ubuntu-latest
-    container:
-      image: aswf/ci-osl:2019
-    steps:
-      - uses: actions/checkout@v2
-      - name: all
-        env:
-          CXX: /usr/bin/g++
-          CC: /usr/bin/gcc
-          CMAKE_CXX_STANDARD: 11
-        run: |
-            source src/build-scripts/ci-startup.bash
-            source src/build-scripts/gh-installdeps-centos.bash
-            source src/build-scripts/ci-build-and-test.bash
-
   linux-gcc7-cpp14-debug:
+    # Test against gcc7, and also at the same time, do a Debug build.
     name: "Linux debug gcc7/C++14, sse4.2, exr2.4"
     runs-on: ubuntu-18.04
     steps:
@@ -89,6 +90,8 @@ jobs:
             source src/build-scripts/ci-build-and-test.bash
 
   linux-2021ish-gcc8:
+    # Test as close as we can get to what's anticipated to be VFX Platform
+    # 2021 -- mainly, that means gcc8 and C++17.
     name: "Linux next/VFXP2021: gcc8 C++17 avx exr2.5"
     runs-on: ubuntu-18.04
     steps:
@@ -104,19 +107,55 @@ jobs:
             source src/build-scripts/gh-installdeps.bash
             source src/build-scripts/ci-build-and-test.bash
 
-  linux-bleeding-edge:
-    # Test against development master for relevant dependencies, latest
-    # supported releases of everything else. We don't need to run this on
-    # every push or PR -- only run on on nightly test, or if the branch name
-    # contains "gh" or "release".
-    name: "Linux bleeding edge: gcc9 C++17 avx2 OCIO/libtiff/exr master"
-    if: github.event_name == 'schedule' || contains(github.ref, 'release') || contains(github.ref, 'gh')
+  linux-2021ish-gcc9:
+    # Test against gcc9. This will probably never be a VFX Platform
+    # compiler, but lots of people use it.
+    name: "Linux gcc9"
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: all
         env:
           CXX: g++-9
+          CMAKE_CXX_STANDARD: 17
+          USE_SIMD: avx
+          OPENEXR_BRANCH: v2.5.0
+        run: |
+            source src/build-scripts/ci-startup.bash
+            source src/build-scripts/gh-installdeps.bash
+            source src/build-scripts/ci-build-and-test.bash
+
+  linux-latest-releases:
+    # Test against latest supported releases of toolchain and dependencies.
+    name: "Linux latest releases: gcc10 C++17 avx2 exr2.5"
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: all
+        env:
+          CXX: g++-10
+          CMAKE_CXX_STANDARD: 17
+          USE_SIMD: avx2
+          OPENEXR_BRANCH: v2.5.0
+        run: |
+            source src/build-scripts/ci-startup.bash
+            source src/build-scripts/gh-installdeps.bash
+            source src/build-scripts/ci-build-and-test.bash
+
+  linux-bleeding-edge:
+    # Test against development master for relevant dependencies, latest
+    # supported releases of everything else.
+    # We don't need to run this on every push or PR -- only run on nightly
+    # test, or if the branch name contains certain substring: gh, release,
+    # bleeding.
+    name: "Linux bleeding edge: gcc10 C++17 avx2 OCIO/libtiff/exr master"
+    runs-on: ubuntu-18.04
+    if: github.event_name == 'schedule' || contains(github.ref, 'release') || contains(github.ref, 'gh') || contains(github.ref, 'bleeding')
+    steps:
+      - uses: actions/checkout@v2
+      - name: all
+        env:
+          CXX: g++-10
           CMAKE_CXX_STANDARD: 17
           USE_SIMD: avx2,f16c
           OPENEXR_BRANCH: master
@@ -132,8 +171,12 @@ jobs:
 
   linux-oldest:
     # Oldest versions of the dependencies that we can muster, and various
-    # things disabled (no SSE, OCIO, or OpenCV, don't embed plugins)
+    # things disabled (no SSE, OCIO, or OpenCV, don't embed plugins).
+    # We don't need to run this on every push or PR -- only run on nightly
+    # test, or if the branch name contains certain substrings: gh, release,
+    # old.
     name: "Linux oldest/hobbled: gcc4.8/C++11 py2.7 boost-1.66 exr-2.2 no-sse no-ocio"
+    if: github.event_name == 'schedule' || contains(github.ref, 'release') || contains(github.ref, 'gh')
     runs-on: ubuntu-latest
     container:
       image: aswf/ci-osl:2019
@@ -150,6 +193,7 @@ jobs:
           USE_OPENCV: 0
           EMBEDPLUGINS: 0
           OPENEXR_BRANCH: v2.2.0
+          MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=6.1.2
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps-centos.bash
@@ -194,6 +238,9 @@ jobs:
             source src/build-scripts/ci-build-and-test.bash
 
   sanitizer:
+    # Run sanitizers. These don't need to run on every push. Just PRs, nightly
+    # builds, or if the branch name contains one of several tokens: san,
+    # gh, RB, release, or master.
     name: "Sanitizers"
     runs-on: ubuntu-18.04
     if: github.event_name == 'pull_request' || github.event_name == 'schedule' || contains(github.ref, 'san') || contains(github.ref, 'RB') || contains(github.ref, 'release') || contains(github.ref, 'master') || contains(github.ref, 'gh')
@@ -214,7 +261,8 @@ jobs:
             source src/build-scripts/gh-installdeps-centos.bash
             source src/build-scripts/ci-build-and-test.bash
 
-  linux-clang:
+  linux-clang9:
+    # Test compiling with clang9 on Linux.
     name: "Linux clang: clang9 C++14 avx2 exr2.4"
     runs-on: ubuntu-18.04
     steps:
@@ -234,7 +282,11 @@ jobs:
             source src/build-scripts/ci-build-and-test.bash
 
   linux-static:
+    # Test building static libs.  We don't need to run this on every push --
+    # only run on PRs, nightly test, or if the branch name contains
+    # "gh", "master", "release", or "static".
     name: "Linux static libs: gcc7 C++14 exr2.4"
+    if: github.event_name == 'pull_request' || github.event_name == 'schedule' || contains(github.ref, 'static') || contains(github.ref, 'release') || contains(github.ref, 'master') || contains(github.ref, 'gh')
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,10 +15,10 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
 ### Required dependencies -- OIIO will not build at all without these
 
  * C++11 (also builds with C++14 and C++17)
- * Compilers: gcc 4.8.2 - 9.2, clang 3.3 - 10.0, MSVS 2015 - 2019,
+ * Compilers: gcc 4.8.2 - 10.1, clang 3.3 - 10.0, MSVS 2015 - 2019,
    icc version 13 or higher
- * CMake >= 3.12 (tested up through 3.16)
- * OpenEXR >= 2.0 (recommended: 2.2 or higher; tested through 2.4)
+ * CMake >= 3.12 (tested up through 3.17)
+ * OpenEXR >= 2.0 (recommended: 2.2 or higher; tested through 2.5)
  * libTIFF >= 3.9 (recommended: 4.0+; tested through 4.1.0)
 
 ### Optional dependencies -- features may be disabled if not found
@@ -44,7 +44,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
        through 2020_U1)
  * If you want support for converting to and from OpenCV data structures,
    or for capturing images from a camera:
-     * OpenCV 2.x, 3.x, or 4.x (tested through 4.2)
+     * OpenCV 2.x, 3.x, or 4.x (tested through 4.3)
  * If you want support for GIF images:
      * giflib >= 4.1 (tested through 5.2; 5.0+ is strongly recommended for
        stability and thread safety)

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -57,6 +57,8 @@ elif [[ "$CXX" == "g++-8" ]] ; then
     time sudo apt-get install -y g++-8
 elif [[ "$CXX" == "g++-9" ]] ; then
     time sudo apt-get install -y g++-9
+elif [[ "$CXX" == "g++-10" ]] ; then
+    time sudo apt-get install -y g++-10
 fi
 
 # time sudo apt-get install -y clang


### PR DESCRIPTION
* Turns out no code changes were needed for gcc10!

* Also updated some dependency ranges in INSTALL.md.

* Make a new CI test "latest" -- using the latest supported release of
  the toolchain and dependencies. That includes gcc10 in this case.
  (This is different than the "bleeding edge" test, which tests against
  the development master of many dependencies.)

* Make several test matrix entries (including bleeding edge, static
  libs, and sanitizers) no longer test on every push. That makes
  things take too long. They all still run nightly, and if you're
  pushing a branch with the name "RB", "release", or "master", so they
  will catch problems before releases. Also, all tests run any time
  the branch name is "gh", so if you are preparing a patch
  specifically to make changes to CI, make sure to do that. We will
  probably continue to fine-tune exatly when we run all tests, versus
  the common configurations.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

