### PR TITLE
Extra test for multiplication

### DIFF
--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -972,6 +972,11 @@ void test_arithmetic ()
     { VEC r = a; r *= b; OIIO_CHECK_SIMD_EQUAL (r, mul); }
     { VEC r = a; r /= b; OIIO_CHECK_SIMD_EQUAL (r, div); }
     { VEC r = a; r *= ELEM(2); OIIO_CHECK_SIMD_EQUAL (r, a*ELEM(2)); }
+    // Test to make sure * works for negative 32 bit ints on all SIMD levels,
+    // because it's a different code path for sse2.
+    VEC negA = mkvec<VEC>(-1, 1, -2, 2);
+    VEC negB = mkvec<VEC>(2, 2, -2, -2);
+    OIIO_CHECK_SIMD_EQUAL(negA * negB, mkvec<VEC>(-2, 2, 4, -4));
 
     OIIO_CHECK_EQUAL (reduce_add(b), bsum);
     OIIO_CHECK_SIMD_EQUAL (vreduce_add(b), VEC(bsum));


### PR DESCRIPTION
SSE2 lacks an instruction for 32 bit SIMD int multiply. SSE4 has
it. We simulate it with a trick using unsigned multiply on SSE2. Chris
wondered if this alternate code path was adequately tested for
negative numbers, so I added a test to be sure.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
