### PR TITLE
Fix minor issue with fmath's OIIO::clamp

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -326,7 +326,7 @@ clamp (const T& a, const T& low, const T& high)
     // should result in just a max and min instruction, thats it.
     // This implementation is courtesy of Alex Wells, Intel, via OSL.
     T val = a;
-    if (!(low < val))  // Forces clamp(NaN,low,high) to return low
+    if (!(low <= val))  // Forces clamp(NaN,low,high) to return low
         val = low;
     if (val > high)
         val = high;


### PR DESCRIPTION
OIIO::clamp had the property that if `val <= low`, it sets `low`.
But actually, when `val == low`, we want to use `val`, not `low`.

This may seem like the same thing, and it is for ordinary types.  But
OSL uses this clamp template for "dual" types (implementing automatic
differentiation), and it causes a case where `val == low` but `val`
carries derivatives that we want preserved, not written over by the
0-derivatives of the fixed `low` value.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

