### PR TITLE
Revise OpenEXR sorting of channel names into canonical order

### DIFF
--- a/testsuite/openexr-suite/ref/out.txt
+++ b/testsuite/openexr-suite/ref/out.txt
@@ -276,3 +276,21 @@ Reading ../../../../../openexr-images/Tiles/Spirals.exr
     oiio:subimages: 1
 Comparing "../../../../../openexr-images/Tiles/Spirals.exr" and "Spirals.exr"
 PASS
+Reading ../../../../../openexr-images/Beachball/singlepart.0001.exr
+../../../../../openexr-images/Beachball/singlepart.0001.exr :  911 x  876, 20 channel, half openexr
+    SHA-1: C946B18AE0C85563D82394D763541A9F61767C27
+    channel list: R, G, B, A, Z, disparityL.x, disparityL.y, disparityR.x, disparityR.y, forward.left.u, forward.left.v, forward.right.u, forward.right.v, left.R, left.G, left.B, left.A, left.Z, whitebarmask.left.mask, whitebarmask.right.mask
+    pixel data origin: x=654, y=245
+    full/display size: 2048 x 1556
+    full/display origin: 0, 0
+    compression: "zips"
+    multiView: "right", "left"
+    name: "rgba"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimagename: "rgba"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/Beachball/singlepart.0001.exr" and "singlepart.0001.exr"
+PASS

--- a/testsuite/openexr-suite/run.py
+++ b/testsuite/openexr-suite/run.py
@@ -39,3 +39,10 @@ imagedir = OIIO_TESTSUITE_IMAGEDIR + "/Tiles"
 files = [ "GoldenGate.exr", "Ocean.exr", "Spirals.exr" ]
 for f in files:
     command += rw_command (imagedir, f)
+
+
+# Check a complicated channel and layer ordering example
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/Beachball"
+files = [ "singlepart.0001.exr" ]
+for f in files:
+    command += rw_command (imagedir, f)


### PR DESCRIPTION
Brief background: OpenEXR sorts channel names alphabetically. Most
formats dont allow channel naming at all, let alone forcing a
particular order contrary to the order the user tries to write it to
the file. OIIO promises that if there is RGB, they will be first and
in that order, next will be alpha if present, then depth, then
everything else.

So our exr reader will reshuffle channels into this canonical order
before presenting to the calling app. In addition to literal R, G, and
B being first, also obvious synonyms are accepted and understood to be
first ("Red", "Green", "Blue", and also "Y" in case it's just a
1-channel intensity and then maybe alpha).

A user noticed an interesting edge case: what if it's a normal map or
positional info, so the channel names are x, y, z? You want it in that
order (coincidentally alphabetical), duh. But the current heuristic
will reorder it as Y (mistaking for intensity), Z (mistaking for
depth), then X (a non-special name, so goes last). Ick!

The solution is that we need a more sophisticaed heuristic. This patch
changes the logic to first just sort by layer, then within each layer,
look to see if there are channels "x", "y", AND "z", and if all three
are present, then we can conclude that it means something spatial and
that Y isn't really intensity and Z isn't really depth for that
particular layer, so an alternate ordering is used. If all of x,y,z
aren't found in a layer, we continue to use the old heuristic.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

