### PR TITLE
Filesystem::write_text_file()

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -214,6 +214,11 @@ OIIO_API void open (OIIO::ofstream &stream, string_view path,
 /// returning true on success, false on failure.
 OIIO_API bool read_text_file (string_view filename, std::string &str);
 
+/// Write the entire contents of the string `str` to the file, overwriting
+/// any prior contents of the file (if it existed), returning true on
+/// success, false on failure.
+OIIO_API bool write_text_file (string_view filename, string_view str);
+
 /// Read a maximum of n bytes from the named file, starting at position pos
 /// (which defaults to the start of the file), storing results in
 /// buffer[0..n-1]. Return the number of bytes read, which will be n for

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -509,6 +509,19 @@ Filesystem::read_text_file(string_view filename, std::string& str)
 
 
 
+bool
+Filesystem::write_text_file(string_view filename, string_view str)
+{
+    OIIO::ofstream out;
+    Filesystem::open(out, filename);
+    // N.B. for binary write: open(out, filename, std::ios::out|std::ios::binary);
+    if (out)
+        out << str;
+    return out.good();
+}
+
+
+
 /// Read the entire contents of the named file and place it in str,
 /// returning true on success, false on failure.
 size_t

--- a/src/libutil/filesystem_test.cpp
+++ b/src/libutil/filesystem_test.cpp
@@ -117,6 +117,10 @@ test_file_status()
 
     std::cout << "Testing read_text_file\n";
     OIIO_CHECK_EQUAL(my_read_text_file("testfile"), testtext);
+    std::cout << "Testing write_text_file\n";
+    Filesystem::write_text_file("testfile4", testtext);
+    OIIO_CHECK_EQUAL(my_read_text_file("testfile4"), testtext);
+
 
     std::cout << "Testing read_bytes:\n";
     char buf[3];
@@ -153,10 +157,12 @@ test_file_status()
     OIIO_CHECK_EQUAL(my_read_text_file("testfile3"), testtext);
     Filesystem::remove("testfile");
     Filesystem::remove("testfile3");
+    Filesystem::remove("testfile4");
     Filesystem::remove("testdir");
     OIIO_CHECK_ASSERT(!Filesystem::exists("testfile"));
     OIIO_CHECK_ASSERT(!Filesystem::exists("testfile2"));
     OIIO_CHECK_ASSERT(!Filesystem::exists("testfile3"));
+    OIIO_CHECK_ASSERT(!Filesystem::exists("testfile4"));
     OIIO_CHECK_ASSERT(!Filesystem::exists("testdir"));
 }
 
@@ -401,10 +407,9 @@ test_frame_sequences()
 
 
 void
-create_test_file(const string_view& fn)
+create_test_file(string_view fn)
 {
-    std::ofstream f(fn.c_str());
-    f.close();
+    Filesystem::write_text_file(fn, "");
 }
 
 


### PR DESCRIPTION
One-line utility function to open file, write a string, close file,
return if it succeeded. Analogous to the existing read_text_file().

Signed-off-by: Larry Gritz <lg@larrygritz.com>

