### PR TITLE
Use discovered python executable

### DIFF
--- a/src/cmake/oiio_macros.cmake
+++ b/src/cmake/oiio_macros.cmake
@@ -197,7 +197,7 @@ macro (oiio_add_tests)
                 set (_testname "${_testname}-broken")
             endif ()
 
-            set (_runtest python "${CMAKE_SOURCE_DIR}/testsuite/runtest.py" ${_testdir})
+            set (_runtest ${PYTHON_EXECUTABLE} "${CMAKE_SOURCE_DIR}/testsuite/runtest.py" ${_testdir})
             if (MSVC_IDE)
                 set (_runtest ${_runtest} --devenv-config $<CONFIGURATION>
                                           --solution-path "${CMAKE_BINARY_DIR}" )
@@ -215,7 +215,7 @@ macro (oiio_add_tests)
             if (_testname MATCHES "texture")
                 set (_testname ${_testname}.batch)
                 set (_testdir ${_testdir}.batch)
-                set (_runtest python "${CMAKE_SOURCE_DIR}/testsuite/runtest.py" ${_testdir})
+                set (_runtest ${PYTHON_EXECUTABLE} "${CMAKE_SOURCE_DIR}/testsuite/runtest.py" ${_testdir})
                 if (MSVC_IDE)
                     set (_runtest ${_runtest} --devenv-config $<CONFIGURATION>
                                           --solution-path "${CMAKE_BINARY_DIR}" )


### PR DESCRIPTION
## Description

On Fedora, Python must be run using version specific binaries, python2 or python3. Since we go to the trouble of finding python for the main library, we might as well use the discovered binary name and path.

## Tests

This should fix errors for python not being found while running 'make test'

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

