### PR TITLE
Implement Python version of IBA color_range_check

### DIFF
--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -3023,6 +3023,25 @@ Image comparison and statistics
 
 
 
+.. py:method:: bool ImageBufAlgo.color_range_check (src, low, high, roi=ROI.All, nthreads=0)
+
+    Count how many pixels in the `src` image (within the `roi`) are outside
+    the value range described by `low` and `hi` (which each may be either
+    one value or a tuple with per-channel values for each of `roi.chbegin
+    ... roi.chend`. The result returned is a tuple containing three values:
+    the number of values less than `low`, the number of values greater then
+    `hi`, and the number of values within the range.
+
+    Example:
+
+    .. code-block:: python
+
+        A = ImageBuf ("a.exr")
+        counts = ImageBufAlgo.color_range_check (A, 0.5, 0.75)
+        print ('{} values < 0.5, {} values > 0.75'.format(counts[0], counts[1])
+
+
+
 .. py:method:: ROI ImageBufAlgo.nonzero_region (src, roi=ROI.All, nthreads=0)
 
     Returns an ROI that tightly encloses the minimal region within `roi`

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -90,6 +90,7 @@ template<> struct PyTypeForCType<int> { typedef py::int_ type; };
 template<> struct PyTypeForCType<unsigned int> { typedef py::int_ type; };
 template<> struct PyTypeForCType<short> { typedef py::int_ type; };
 template<> struct PyTypeForCType<unsigned short> { typedef py::int_ type; };
+template<> struct PyTypeForCType<int64_t> { typedef py::int_ type; };
 template<> struct PyTypeForCType<float> { typedef py::float_ type; };
 template<> struct PyTypeForCType<half> { typedef py::float_ type; };
 template<> struct PyTypeForCType<double> { typedef py::float_ type; };

--- a/testsuite/python-imagebufalgo/ref/out-freetype2.4.11-py2.7-pybind2.3.txt
+++ b/testsuite/python-imagebufalgo/ref/out-freetype2.4.11-py2.7-pybind2.3.txt
@@ -27,6 +27,7 @@ isConstantColor on pink image is (1 0.50196 0.50196)
 isConstantColor on checker is  None
 Is cmul1.exr monochrome?  True
 Is cmul2.exr monochrome?  False
+color range counts =  (4L, 8L, 4L)
 Nonzero region is:  100 180 100 180 0 1 0 3
 SHA-1 of bsplinekernel.exr is: D5826B66A5313F9A32D42C5CF49C90EC4E7F84BF
 R hist:  (10000L, 0L, 0L, 0L)

--- a/testsuite/python-imagebufalgo/ref/out-freetype2.4.11.txt
+++ b/testsuite/python-imagebufalgo/ref/out-freetype2.4.11.txt
@@ -27,6 +27,7 @@ isConstantColor on pink image is (1 0.50196 0.50196)
 isConstantColor on checker is  None
 Is cmul1.exr monochrome?  True
 Is cmul2.exr monochrome?  False
+color range counts =  (4L, 8L, 4L)
 Nonzero region is:  100 180 100 180 0 1 0 3
 SHA-1 of bsplinekernel.exr is: D5826B66A5313F9A32D42C5CF49C90EC4E7F84BF
 R hist:  (10000L, 0L, 0L, 0L)

--- a/testsuite/python-imagebufalgo/ref/out-python2-alt.txt
+++ b/testsuite/python-imagebufalgo/ref/out-python2-alt.txt
@@ -27,6 +27,7 @@ isConstantColor on pink image is (1 0.50196 0.50196)
 isConstantColor on checker is  None
 Is cmul1.exr monochrome?  True
 Is cmul2.exr monochrome?  False
+color range counts =  (4L, 8L, 4L)
 Nonzero region is:  100 180 100 180 0 1 0 3
 SHA-1 of bsplinekernel.exr is: D5826B66A5313F9A32D42C5CF49C90EC4E7F84BF
 R hist:  (10000L, 0L, 0L, 0L)

--- a/testsuite/python-imagebufalgo/ref/out-python3-freetype2.4.11.txt
+++ b/testsuite/python-imagebufalgo/ref/out-python3-freetype2.4.11.txt
@@ -27,6 +27,7 @@ isConstantColor on pink image is (1 0.50196 0.50196)
 isConstantColor on checker is  None
 Is cmul1.exr monochrome?  True
 Is cmul2.exr monochrome?  False
+color range counts =  (4, 8, 4)
 Nonzero region is:  100 180 100 180 0 1 0 3
 SHA-1 of bsplinekernel.exr is: D5826B66A5313F9A32D42C5CF49C90EC4E7F84BF
 R hist:  (10000, 0, 0, 0)

--- a/testsuite/python-imagebufalgo/ref/out-python3.txt
+++ b/testsuite/python-imagebufalgo/ref/out-python3.txt
@@ -27,6 +27,7 @@ isConstantColor on pink image is (1 0.50196 0.50196)
 isConstantColor on checker is  None
 Is cmul1.exr monochrome?  True
 Is cmul2.exr monochrome?  False
+color range counts =  (4, 8, 4)
 Nonzero region is:  100 180 100 180 0 1 0 3
 SHA-1 of bsplinekernel.exr is: D5826B66A5313F9A32D42C5CF49C90EC4E7F84BF
 R hist:  (10000, 0, 0, 0)

--- a/testsuite/python-imagebufalgo/ref/out.txt
+++ b/testsuite/python-imagebufalgo/ref/out.txt
@@ -27,6 +27,7 @@ isConstantColor on pink image is (1 0.50196 0.50196)
 isConstantColor on checker is  None
 Is cmul1.exr monochrome?  True
 Is cmul2.exr monochrome?  False
+color range counts =  (4L, 8L, 4L)
 Nonzero region is:  100 180 100 180 0 1 0 3
 SHA-1 of bsplinekernel.exr is: D5826B66A5313F9A32D42C5CF49C90EC4E7F84BF
 R hist:  (10000L, 0L, 0L, 0L)

--- a/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
+++ b/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
@@ -314,7 +314,11 @@ try:
     print ("Is", b.name, "monochrome? ", ImageBufAlgo.isMonochrome(b))
 
 
-    # color_count, color_range_check
+    # color_count
+
+    b = ImageBufAlgo.fill (top=(0,0,0), bottom=(1,1,1), roi=ROI(0,4,0,4,0,1,0,3))
+    counts = ImageBufAlgo.color_range_check (b, low=0.25, high=(0.5,0.5,0.5))
+    print ('color range counts = ', counts)
 
     # nonzero_region
     b = make_constimage (256,256,3,oiio.UINT8,(0,0,0))


### PR DESCRIPTION
Was in C++, but seems it never quite got implemented in the python bindings.
