### PR TITLE
Work around broken OpenEXR definition of OPENEXR_PACKAGE_STRING

### DIFF
--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -224,8 +224,8 @@ OIIO_EXPORT int openexr_imageio_version = OIIO_PLUGIN_VERSION;
 OIIO_EXPORT const char*
 openexr_imageio_library_version()
 {
-#ifdef OPENEXR_PACKAGE_STRING
-    return OPENEXR_PACKAGE_STRING;
+#ifdef OPENEXR_VERSION_STRING
+    return "OpenEXR " OPENEXR_VERSION_STRING;
 #else
     return "OpenEXR 1.x";
 #endif


### PR DESCRIPTION
In at least OpenEXR 2.4 and 2.5, is it quite broken!
But OPENEXR_VERSION_STRING seems ok, so use that.
Issue filed against OpenEXR, but I don't have time to fix it myself tonight.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

