### PR TITLE
Support Qt 5.15

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
 ### Optional dependencies -- features may be disabled if not found
  * If you are building the `iv` viewer (which will be disabled if any of
    these are not found):
-     * Qt >= 5.6 (tested through 5.14)
+     * Qt >= 5.6 (tested through 5.15)
      * OpenGL
  * If you are building the Python bindings or running the testsuite:
      * Python >= 2.7 (tested against 2.7, 3.6, 3.7)

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -1202,14 +1202,15 @@ void
 IvGL::wheelEvent(QWheelEvent* event)
 {
     m_mouse_activation = false;
-    if (event->orientation() == Qt::Vertical) {
-        // TODO: Update this to keep the zoom centered on the event .x, .y
+    QPoint angdelta    = event->angleDelta() / 8;  // div by 8 to get degrees
+    if (abs(angdelta.y()) > abs(angdelta.x())      // predominantly vertical
+        && abs(angdelta.y()) > 2) {                // suppress tiny motions
         float oldzoom = m_viewer.zoom();
-        float newzoom = (event->delta() > 0) ? ceil2f(oldzoom)
-                                             : floor2f(oldzoom);
+        float newzoom = (angdelta.y() > 0) ? ceil2f(oldzoom) : floor2f(oldzoom);
         m_viewer.zoom(newzoom);
         event->accept();
     }
+    // TODO: Update this to keep the zoom centered on the event .x, .y
 }
 
 


### PR DESCRIPTION
Homebrew upgrade to Qt 5.15 made it more urgent to change some
deprecated calls to newer idioms.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

