### PR TITLE
Use GH CI to upload test output for any job that fails tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -40,7 +40,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/out.txt
+          path: build/*/testsuite/*/*.*
 
   vfxplatform-2019:
     name: "Linux VFX Platform 2019: gcc6/C++14 py2.7 boost-1.66 exr-2.3"
@@ -63,7 +63,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/out.txt
+          path: build/*/testsuite/*/*.*
 
   vfxplatform-2020:
     name: "Linux VFX Platform 2020: gcc6/C++14 py3.7 boost-1.70 exr-2.4"
@@ -87,7 +87,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/out.txt
+          path: build/*/testsuite/*/*.*
 
   vfxplatform-2021:
     # Test what's anticipated to be VFX Platform 2021 -- mainly, that means
@@ -114,7 +114,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/out.txt
+          path: build/*/testsuite/*/*.*
 
   linux-gcc7-cpp14-debug:
     # Test against gcc7, and also at the same time, do a Debug build.
@@ -136,7 +136,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/out.txt
+          path: build/*/testsuite/*/*.*
 
   linux-gcc8:
     # Test against gcc8.
@@ -158,7 +158,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/out.txt
+          path: build/*/testsuite/*/*.*
 
   linux-latest-releases:
     # Test against latest supported releases of toolchain and dependencies.
@@ -180,7 +180,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/out.txt
+          path: build/*/testsuite/*/*.*
 
   linux-bleeding-edge:
     # Test against development master for relevant dependencies, latest
@@ -212,7 +212,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/out.txt
+          path: build/*/testsuite/*/*.*
 
   linux-oldest:
     # Oldest versions of the dependencies that we can muster, and various
@@ -247,7 +247,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/out.txt
+          path: build/*/testsuite/*/*.*
 
   macos-py37:
     name: "Mac py37"
@@ -273,7 +273,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/out.txt
+          path: build/*/testsuite/*/*.*
 
   windows:
     name: "Windows"
@@ -297,7 +297,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/out.txt
+          path: build/*/testsuite/*/*.*
 
   sanitizer:
     # Run sanitizers. These don't need to run on every push. Just PRs, nightly
@@ -326,7 +326,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/out.txt
+          path: build/*/testsuite/*/*.*
 
   linux-clang9:
     # Test compiling with clang9 on Linux.
@@ -351,7 +351,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/out.txt
+          path: build/*/testsuite/*/*.*
 
   linux-static:
     # Test building static libs.  We don't need to run this on every push --
@@ -375,7 +375,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/out.txt
+          path: build/*/testsuite/*/*.*
 
   clang-format:
     name: "clang-format verification"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -36,6 +36,11 @@ jobs:
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps-centos.bash
             source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: build/*/testsuite/*/out.txt
 
   vfxplatform-2019:
     name: "Linux VFX Platform 2019: gcc6/C++14 py2.7 boost-1.66 exr-2.3"
@@ -54,6 +59,11 @@ jobs:
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps-centos.bash
             source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: build/*/testsuite/*/out.txt
 
   vfxplatform-2020:
     name: "Linux VFX Platform 2020: gcc6/C++14 py3.7 boost-1.70 exr-2.4"
@@ -73,6 +83,11 @@ jobs:
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps-centos.bash
             source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: build/*/testsuite/*/out.txt
 
   vfxplatform-2021:
     # Test what's anticipated to be VFX Platform 2021 -- mainly, that means
@@ -95,6 +110,11 @@ jobs:
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps-centos.bash
             source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: build/*/testsuite/*/out.txt
 
   linux-gcc7-cpp14-debug:
     # Test against gcc7, and also at the same time, do a Debug build.
@@ -112,6 +132,11 @@ jobs:
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps.bash
             source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: build/*/testsuite/*/out.txt
 
   linux-gcc8:
     # Test against gcc8.
@@ -129,6 +154,11 @@ jobs:
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps.bash
             source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: build/*/testsuite/*/out.txt
 
   linux-latest-releases:
     # Test against latest supported releases of toolchain and dependencies.
@@ -146,6 +176,11 @@ jobs:
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps.bash
             source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: build/*/testsuite/*/out.txt
 
   linux-bleeding-edge:
     # Test against development master for relevant dependencies, latest
@@ -173,6 +208,11 @@ jobs:
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps.bash
             source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: build/*/testsuite/*/out.txt
 
   linux-oldest:
     # Oldest versions of the dependencies that we can muster, and various
@@ -203,6 +243,11 @@ jobs:
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps-centos.bash
             source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: build/*/testsuite/*/out.txt
 
   macos-py37:
     name: "Mac py37"
@@ -224,6 +269,11 @@ jobs:
             src/build-scripts/install_test_images.bash
             export PYTHONPATH=/usr/local/lib/python3.7/site-packages:$PYTHONPATH
             source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: build/*/testsuite/*/out.txt
 
   windows:
     name: "Windows"
@@ -243,6 +293,11 @@ jobs:
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-win-installdeps.bash
             source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: build/*/testsuite/*/out.txt
 
   sanitizer:
     # Run sanitizers. These don't need to run on every push. Just PRs, nightly
@@ -267,6 +322,11 @@ jobs:
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps-centos.bash
             source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: build/*/testsuite/*/out.txt
 
   linux-clang9:
     # Test compiling with clang9 on Linux.
@@ -287,6 +347,11 @@ jobs:
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps.bash
             source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: build/*/testsuite/*/out.txt
 
   linux-static:
     # Test building static libs.  We don't need to run this on every push --
@@ -306,6 +371,11 @@ jobs:
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps.bash
             source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: build/*/testsuite/*/out.txt
 
   clang-format:
     name: "clang-format verification"

--- a/src/build-scripts/ci-build-and-test.bash
+++ b/src/build-scripts/ci-build-and-test.bash
@@ -45,6 +45,7 @@ popd
 
 if [[ "$SKIP_TESTS" == "" ]] ; then
     $OpenImageIO_ROOT/bin/oiiotool --help
+    TESTSUITE_CLEANUP_ON_SUCCESS=1
     make $BUILD_FLAGS test
 fi
 

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -99,9 +99,13 @@ failthresh = 0.004
 hardfail = 0.012
 failpercent = 0.02
 anymatch = False
+cleanup_on_success = False
+if int(os.getenv('TESTSUITE_CLEANUP_ON_SUCCESS', '0')) :
+    cleanup_on_success = True;
 
 image_extensions = [ ".tif", ".tx", ".exr", ".jpg", ".png", ".rla",
-                     ".dpx", ".iff", ".psd" ]
+                     ".dpx", ".iff", ".psd", ".bmp", ".fits", ".ico",
+                     ".jp2", ".sgi", ".tga", ".TGA" ]
 
 # print ("srcdir = " + srcdir)
 # print ("tmpdir = " + tmpdir)
@@ -439,4 +443,11 @@ if (os.getenv('TRAVIS') or os.getenv('APPVEYOR') or os.getenv('DEBUG')) :
 
 # Run the test and check the outputs
 ret = runtest (command, outputs, failureok=failureok)
+
+if ret == 0 and cleanup_on_success :
+    for ext in image_extensions + [ ".txt", ".diff" ] :
+        for f in glob.iglob (srcdir + '/*' + ext) :
+            os.remove(f)
+            #print('REMOVED ', f)
+
 sys.exit (ret)


### PR DESCRIPTION
This will make it much easier to investigate failures or update ref
output when failures only happen on CI -- any test that fail tests
will produce a downloadable "artifact" consisting of all tests'
captured console output.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
