### PR TITLE
Add more exr compliance tests and improve error messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,7 +384,8 @@ oiio_add_tests (tiff-suite tiff-depths tiff-misc
     IMAGEDIR libtiffpic
     URL http://www.simplesystems.org/libtiff/images.html)
 
-oiio_add_tests (openexr-suite openexr-multires openexr-chroma openexr-v2 perchannel
+oiio_add_tests (openexr-suite openexr-multires openexr-chroma
+                openexr-v2 openexr-window openexr-damaged perchannel
     IMAGEDIR openexr-images
     URL http://www.openexr.com/downloads.html)
 

--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -333,7 +333,7 @@ convert_file(const std::string& in_filename, const std::string& out_filename)
     if (!out) {
         std::cerr
             << "iconvert ERROR: Could not find an ImageIO plugin to write \""
-            << out_filename << "\" :" << geterror() << "\n";
+            << out_filename << "\" : " << geterror() << "\n";
         return false;
     }
 

--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -52,13 +52,17 @@ static bool compute_stats = false;
 static void
 print_sha1(ImageInput* input)
 {
+    using Strutil::printf;
     SHA1 sha;
     const ImageSpec& spec(input->spec());
     if (spec.deep) {
         // Special handling of deep data
         DeepData dd;
         if (!input->read_native_deep_image(dd)) {
-            printf("    SHA-1: unable to compute, could not read image\n");
+            std::string err = input->geterror();
+            if (err.empty())
+                err = "could not read image";
+            printf("    SHA-1: %s\n", err);
             return;
         }
         // Hash both the sample counds and the data block
@@ -72,7 +76,10 @@ print_sha1(ImageInput* input)
         }
         std::unique_ptr<char[]> buf(new char[size]);
         if (!input->read_image(TypeDesc::UNKNOWN /*native*/, &buf[0])) {
-            printf("    SHA-1: unable to compute, could not read image\n");
+            std::string err = input->geterror();
+            if (err.empty())
+                err = "could not read image";
+            printf("    SHA-1: %s\n", err);
             return;
         }
         sha.append(&buf[0], size);

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -245,6 +245,15 @@ public:
         return mem;
     }
 
+    static std::string format_read_error(string_view filename, std::string err)
+    {
+        if (!err.size())
+            err = "unknown error";
+        if (!Strutil::contains(err, filename))
+            err = Strutil::sprintf("\"%s\": %s", filename, err);
+        return err;
+    }
+
 private:
     CallbackFunction m_pending_callback;
     ArgParse::Action m_pending_action;

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -56,7 +56,10 @@ compute_sha1(Oiiotool& ot, ImageInput* input)
         // Special handling of deep data
         DeepData dd;
         if (!input->read_native_deep_image(dd)) {
-            ot.error("-info", "SHA-1: unable to compute, could not read image");
+            std::string err = input->geterror();
+            if (err.empty())
+                err = "could not read image";
+            ot.errorf("-info", "SHA-1: %s", err);
             return std::string();
         }
         // Hash both the sample counts and the data block
@@ -65,13 +68,15 @@ compute_sha1(Oiiotool& ot, ImageInput* input)
     } else {
         imagesize_t size = input->spec().image_bytes(true /*native*/);
         if (size >= std::numeric_limits<size_t>::max()) {
-            ot.error("-info", "SHA-1: unable to compute, image is too big");
+            ot.errorf("-info", "SHA-1: unable to compute, image is too big");
             return std::string();
         } else if (size != 0) {
             std::unique_ptr<char[]> buf(new char[size]);
             if (!input->read_image(TypeDesc::UNKNOWN /*native*/, &buf[0])) {
-                ot.error("-info",
-                         "SHA-1: unable to compute, could not read image");
+                std::string err = input->geterror();
+                if (err.empty())
+                    err = "could not read image";
+                ot.errorf("-info", "SHA-1: %s", err);
                 return std::string();
             }
             sha.append(&buf[0], size);

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -988,6 +988,10 @@ OpenEXRInput::PartInfo::query_channels(OpenEXRInput* in,
     for (auto ci = channels.begin(); ci != channels.end(); ++c, ++ci)
         cnh.emplace_back(ci.name(), c, ci.channel());
     spec.nchannels = int(cnh.size());
+    if (! spec.nchannels) {
+        in->errorf("No channels found");
+        return false;
+    }
 
     // First, do a partial sort by layername. EXR should already be in that
     // order, but take no chances.

--- a/testsuite/missingcolor/ref/out.err.txt
+++ b/testsuite/missingcolor/ref/out.err.txt
@@ -1,3 +1,3 @@
-oiiotool ERROR: read src/partial.exr : Failed OpenEXR read: Error reading pixel data from image file "src/partial.exr". Tile (0, 0, 0, 0) is missing.
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "src/partial.exr". Tile (0, 0, 0, 0) is missing.
 Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/partial.exr -d uint8 -o error.tif

--- a/testsuite/oiiotool-readerror/ref/out.err-alt.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err-alt.txt
@@ -1,3 +1,3 @@
-oiiotool ERROR: read src/incomplete.exr : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Unexpected end of file.
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Unexpected end of file.
 Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr

--- a/testsuite/oiiotool-readerror/ref/out.err-alt2.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err-alt2.txt
@@ -1,3 +1,3 @@
-oiiotool ERROR: read src/incomplete.exr : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Unexpected data block y coordinate.
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Unexpected data block y coordinate.
 Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr

--- a/testsuite/oiiotool-readerror/ref/out.err-debug.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err-debug.txt
@@ -1,5 +1,5 @@
 read was not necessary -- using cache
 going to have to read src/incomplete.exr: float vs float
-oiiotool ERROR: read src/incomplete.exr : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Scan line 126 is missing.
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Scan line 126 is missing.
 Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr

--- a/testsuite/oiiotool-readerror/ref/out.err.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err.txt
@@ -1,3 +1,3 @@
-oiiotool ERROR: read src/incomplete.exr : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Scan line 126 is missing.
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Scan line 126 is missing.
 Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr

--- a/testsuite/openexr-chroma/ref/out.txt
+++ b/testsuite/openexr-chroma/ref/out.txt
@@ -1,3 +1,30 @@
+Reading ../../../../../openexr-images/Chromaticities/Rec709.exr
+../../../../../openexr-images/Chromaticities/Rec709.exr :  610 x  406, 3 channel, half openexr
+    SHA-1: 8C8D4705DB92D12D9B70F7514BF7AB6B6C783E84
+    channel list: R, G, B
+    compression: "piz"
+    Copyright: "Copyright 2006 Industrial Light & Magic"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/Chromaticities/Rec709.exr" and "Rec709.exr"
+PASS
+Reading ../../../../../openexr-images/Chromaticities/XYZ.exr
+../../../../../openexr-images/Chromaticities/XYZ.exr :  610 x  406, 3 channel, half openexr
+    SHA-1: AEF6776DB3557A4A3A4B09BEB583C48B56AA82BE
+    channel list: R, G, B
+    chromaticities: 1, 0, 0, 1, 0, 0, 0.333333, 0.333333
+    compression: "piz"
+    Copyright: "Copyright 2006 Industrial Light & Magic"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/Chromaticities/XYZ.exr" and "XYZ.exr"
+PASS
 Reading ../../../../../openexr-images/LuminanceChroma/Garden.exr
 ../../../../../openexr-images/LuminanceChroma/Garden.exr :  874 x  493, 1 channel, half openexr
     SHA-1: FDC1BE9592AD4B1FE4EF2FF431783BAC83E619DE

--- a/testsuite/openexr-chroma/run.py
+++ b/testsuite/openexr-chroma/run.py
@@ -2,8 +2,13 @@
 
 # ../openexr-images/Chromaticities:
 # README         Rec709.exr     Rec709_YC.exr  XYZ.exr        XYZ_YC.exr
-imagedir = OIIO_TESTSUITE_IMAGEDIR + "/Chromaciticies"
-# FIXME - we don't currently understand chromaticities
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/Chromaticities"
+files = [
+    "Rec709.exr", "XYZ.exr"
+]
+for f in files:
+    command += rw_command (imagedir, f)
+# FIXME - we don't currently subsampled images (Rec709_YC.exr and XYZ_YC.exr)
 
 # ../openexr-images/LuminanceChroma:
 # CrissyField.exr  Garden.exr       StarField.exr

--- a/testsuite/openexr-damaged/ref/out-exr2.3.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.3.txt
@@ -1,0 +1,324 @@
+tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr :   64 x   64, 2 channel, deep half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Deep scanline sampleCount data corrupt at chunk 0 (negative sample count detected)
+Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Deep scanline sampleCount data corrupt at chunk 0 (negative sample count detected)
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr": Subsampled channels are not supported (channel "H" has sampling 192,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr : 12688 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr :   64 x   64, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr". Error in Huffman-encoded data (invalid code table size).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr": Subsampled channels are not supported (channel "" has sampling 32,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr :   64 x   64, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr": Subsampled channels are not supported (channel "R" has sampling 1,2).
+Subsampled channels are not supported (channel "" has sampling 4,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr :  480 x  480, 4 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr : 536910914 x    2, 3 channel, uint/half/half openexr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr :  517 x  517, 3 channel, half openexr (+mipmap)
+
+tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr :   64 x   64, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr.exr : 1023 x 49409, 1 channel, uint openexr
+
+tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr.exr : 1023 x 49409, 1 channel, uint openexr
+
+tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr :    1 x  257, 3 channel, half/uint/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr :  636 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr :  480 x  480, 4 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr : 536871041 x    1, 3 channel, uint/half/half openexr
+
+tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr : 788520991 x    1, 2 channel, half/float openexr
+
+tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr": Subsampled channels are not supported (channel "B" has sampling 128,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr :    3 x  257, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr.exr : 30608 x  300, 3 channel, half openexr
+
+tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr": Subsampled channels are not supported (channel "B" has sampling 128,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr :   64 x   64, 2 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr :   64 x   64, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr :  480 x  480, 4 channel, half/half/uint/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr": Subsampled channels are not supported (channel "" has sampling 16,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr :  400 x  300, 3 channel, float/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr". Huffman decode error (Overrun).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
+
+tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr :   64 x   64, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
+
+tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
+
+tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr :   64 x   64, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
+
+tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr": OpenEXR exception: std::bad_alloc
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
+Subsampled channels are not supported (channel "RY" has sampling 2,2).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
+
+tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr :  874 x  493, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr". Unexpected tile x coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
+
+tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr :   64 x   64, 5 channel, half/half/half/float/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr". Invalid scan line 0 requested or missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr": OpenEXR exception: std::bad_alloc
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
+
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
+Subsampled channels are not supported (channel "RY" has sampling 2,2).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr": OpenEXR exception: vector::_M_default_append
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr". unsupported header type to get chunk offset table size
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
+

--- a/testsuite/openexr-damaged/ref/out-exr2.4-clang-noptex.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.4-clang-noptex.txt
@@ -1,0 +1,331 @@
+tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr :   64 x   64, 2 channel, deep half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
+Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr". The x subsampling factor for the "H" channel is not 1.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr : 12688 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr". Unexpected data block length.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr :   64 x   64, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr". Error in Huffman-encoded data (invalid code table size).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr": Subsampled channels are not supported (channel "" has sampling 32,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr". Unexpected data block length.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr :   64 x   64, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr". The x subsampling factor for the "" channel is not 1.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr :  480 x  480, 4 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr :  517 x  517, 3 channel, half openexr (+mipmap)
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr". Data decoding (rle) failed.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr :   64 x   64, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr.exr : 1023 x 49409, 1 channel, uint openexr
+
+tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr.exr : 1023 x 49409, 1 channel, uint openexr
+
+tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr :    1 x  257, 3 channel, half/uint/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr :  636 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr :  480 x  480, 4 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr". Invalid tile size in image header.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr". The x subsampling factor for the "B" channel is not 1.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr :    3 x  257, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr.exr : 30608 x  300, 3 channel, half openexr
+
+tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr". The x subsampling factor for the "B" channel is not 1.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr :   64 x   64, 2 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr :   64 x   64, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr :  480 x  480, 4 channel, half/half/uint/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr": Subsampled channels are not supported (channel "" has sampling 16,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr :  400 x  300, 3 channel, float/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr". Huffman decode error (Overrun).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
+
+tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr :   64 x   64, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
+
+tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
+
+tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr :   64 x   64, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
+
+tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr". Maximum number of tiles exceeded
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
+Subsampled channels are not supported (channel "RY" has sampling 2,2).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
+
+tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr :  874 x  493, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr". Unexpected tile x coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
+
+tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr :   64 x   64, 5 channel, half/half/half/float/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr". Invalid scan line 0 requested or missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
+
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr". Maximum number of tiles exceeded
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr". unsupported header type to get chunk offset table size
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
+

--- a/testsuite/openexr-damaged/ref/out-exr2.4-noptex-spi.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.4-noptex-spi.txt
@@ -1,0 +1,321 @@
+tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr :   64 x   64, 2 channel, deep half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Deep scanline sampleCount data corrupt at chunk 0 (negative sample count detected)
+Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Deep scanline sampleCount data corrupt at chunk 0 (negative sample count detected)
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr": Subsampled channels are not supported (channel "H" has sampling 192,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr : 12688 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr". Unexpected data block length.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr :   64 x   64, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr". Error in Huffman-encoded data (invalid code table size).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr": Subsampled channels are not supported (channel "" has sampling 32,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr". Unexpected data block length.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr :   64 x   64, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr": Subsampled channels are not supported (channel "R" has sampling 1,2).
+Subsampled channels are not supported (channel "" has sampling 4,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr :  480 x  480, 4 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr : 536910914 x    2, 3 channel, uint/half/half openexr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr :  517 x  517, 3 channel, half openexr (+mipmap)
+
+tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr :   64 x   64, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr.exr : 1023 x 49409, 1 channel, uint openexr
+
+tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr.exr : 1023 x 49409, 1 channel, uint openexr
+
+tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr :    1 x  257, 3 channel, half/uint/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr :  636 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr :  480 x  480, 4 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr : 536871041 x    1, 3 channel, uint/half/half openexr
+
+tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr : 788520991 x    1, 2 channel, half/float openexr
+
+tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr": Subsampled channels are not supported (channel "B" has sampling 128,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr :    3 x  257, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr.exr : 30608 x  300, 3 channel, half openexr
+
+tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr": Subsampled channels are not supported (channel "B" has sampling 128,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr :   64 x   64, 2 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr :   64 x   64, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr :  480 x  480, 4 channel, half/half/uint/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr": Subsampled channels are not supported (channel "" has sampling 16,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr :  400 x  300, 3 channel, float/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr". Huffman decode error (Overrun).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
+
+tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr :   64 x   64, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
+
+tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
+
+tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr :   64 x   64, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
+
+tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
+
+tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr : 1001259009 x    1, 3 channel, half openexr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr". Maximum number of tiles exceeded
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
+Subsampled channels are not supported (channel "RY" has sampling 2,2).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
+
+tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr :  874 x  493, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr". Unexpected tile x coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
+
+tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr :   64 x   64, 5 channel, half/half/half/float/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr". Invalid scan line 0 requested or missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
+
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr". Maximum number of tiles exceeded
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr". unsupported header type to get chunk offset table size
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
+

--- a/testsuite/openexr-damaged/ref/out-exr2.4-noptex.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.4-noptex.txt
@@ -1,0 +1,323 @@
+tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr :   64 x   64, 2 channel, deep half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Deep scanline sampleCount data corrupt at chunk 0 (negative sample count detected)
+Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Deep scanline sampleCount data corrupt at chunk 0 (negative sample count detected)
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr": Subsampled channels are not supported (channel "H" has sampling 192,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr : 12688 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr". Unexpected data block length.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr :   64 x   64, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr". Error in Huffman-encoded data (invalid code table size).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr": Subsampled channels are not supported (channel "" has sampling 32,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr". Unexpected data block length.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr :   64 x   64, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr": Subsampled channels are not supported (channel "R" has sampling 1,2).
+Subsampled channels are not supported (channel "" has sampling 4,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr :  480 x  480, 4 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr : 536910914 x    2, 3 channel, uint/half/half openexr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr :  517 x  517, 3 channel, half openexr (+mipmap)
+
+tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr :   64 x   64, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr.exr : 1023 x 49409, 1 channel, uint openexr
+
+tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr.exr : 1023 x 49409, 1 channel, uint openexr
+
+tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr :    1 x  257, 3 channel, half/uint/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr :  636 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr :  480 x  480, 4 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr : 536871041 x    1, 3 channel, uint/half/half openexr
+
+tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr : 788520991 x    1, 2 channel, half/float openexr
+
+tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr": Subsampled channels are not supported (channel "B" has sampling 128,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr :    3 x  257, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr.exr : 30608 x  300, 3 channel, half openexr
+
+tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr": Subsampled channels are not supported (channel "B" has sampling 128,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr :   64 x   64, 2 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr :   64 x   64, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr :  480 x  480, 4 channel, half/half/uint/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr": Subsampled channels are not supported (channel "" has sampling 16,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr :  400 x  300, 3 channel, float/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr". Huffman decode error (Overrun).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
+
+tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr :   64 x   64, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
+
+tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
+
+tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr :   64 x   64, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
+
+tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr": OpenEXR exception: std::bad_alloc
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr". Maximum number of tiles exceeded
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
+Subsampled channels are not supported (channel "RY" has sampling 2,2).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
+
+tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr :  874 x  493, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr". Unexpected tile x coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
+
+tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr :   64 x   64, 5 channel, half/half/half/float/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr". Invalid scan line 0 requested or missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
+
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr". Maximum number of tiles exceeded
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr". unsupported header type to get chunk offset table size
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
+

--- a/testsuite/openexr-damaged/ref/out-exr2.5.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.5.txt
@@ -1,0 +1,333 @@
+tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr :   64 x   64, 2 channel, deep half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
+Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr". The x subsampling factor for the "H" channel is not 1.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr : 12688 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr". Unexpected data block length.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr :   64 x   64, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr". Error in Huffman-encoded data (invalid code table size).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr": Subsampled channels are not supported (channel "" has sampling 32,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr". Unexpected data block length.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr :   64 x   64, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr". The x subsampling factor for the "" channel is not 1.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr :  480 x  480, 4 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr :  517 x  517, 3 channel, half openexr (+mipmap)
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr". Data decoding (rle) failed.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr :   64 x   64, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr.exr : 1023 x 49409, 1 channel, uint openexr
+
+tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr.exr : 1023 x 49409, 1 channel, uint openexr
+
+tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr :    1 x  257, 3 channel, half/uint/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr :  636 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr :  480 x  480, 4 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr". Invalid tile size in image header.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr". The x subsampling factor for the "B" channel is not 1.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr :    3 x  257, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr.exr : 30608 x  300, 3 channel, half openexr
+
+tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr". The x subsampling factor for the "B" channel is not 1.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr :   64 x   64, 2 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr :   64 x   64, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr :  480 x  480, 4 channel, half/half/uint/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr": Subsampled channels are not supported (channel "" has sampling 16,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr :  400 x  300, 3 channel, float/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr". Huffman decode error (Overrun).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
+
+tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr :   64 x   64, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
+
+tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
+
+tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr :   64 x   64, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
+
+tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr". Maximum number of tiles exceeded
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
+Subsampled channels are not supported (channel "RY" has sampling 2,2).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
+
+tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr :  874 x  493, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr". Unexpected tile x coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
+
+tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr :   64 x   64, 5 channel, half/half/half/float/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr". Invalid scan line 0 requested or missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
+
+PtexReader error: read failed (EOF) PtexFile: tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
+
+PtexReader error: read failed (EOF) PtexFile: tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr
+oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
+
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr". Maximum number of tiles exceeded
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr". unsupported header type to get chunk offset table size
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
+

--- a/testsuite/openexr-damaged/run.py
+++ b/testsuite/openexr-damaged/run.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+
+import os
+import shutil
+import OpenImageIO as oiio
+
+# Test OpenEXR's collection of damaged and broken images, to be sure
+# we detect the damage and issue errors (not crash, etc).
+
+failureok = True
+
+# Save error output, too, and skip lines to make readable
+redirect = ' >> out.txt 2>&1 '
+
+# Figure out the version of openexr
+openexr_version = 0
+liblist = oiio.get_string_attribute("library_list").split(';')
+for lib in liblist :
+    lib_ver = lib.split(':')
+    if lib_ver[0] == 'openexr' :
+        ver = lib_ver[1].split(' ')[-1].split('.')
+        openexr_version = int(ver[0]) * 10000 + int(ver[1]) * 100 + int(ver[2])
+        print (openexr_version)
+
+
+# ../openexr-images/Damaged:
+# README   t03.exr  t06.exr  t09.exr  t12.exr  t15.exr
+# t01.exr  t04.exr  t07.exr  t10.exr  t13.exr  t16.exr
+# t02.exr  t05.exr  t08.exr  t11.exr  t14.exr
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/Damaged"
+files = [
+"asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr",
+"asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr",
+"asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr",
+"asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr",
+"asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr",
+"asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr",
+"asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr",
+"asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr",
+"asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr",
+"asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr",
+"asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr",
+"asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr",
+"asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr",
+"asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr",
+"asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr",
+"asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr",
+"asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr",
+"asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr",
+"asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr",
+"asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr",
+"asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr",
+"asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr",
+"asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr",
+"asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr",
+"asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr",
+"asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr",
+"asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr",
+"asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr",
+"asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr",
+"asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr",
+"asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr",
+"asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr",
+"asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr",
+"asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr",
+"asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr",
+"asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr",
+"asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr",
+"asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr",
+"asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr",
+"asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr",
+"asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr",
+"asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr",
+"asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr",
+"asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr",
+"asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr",
+"asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr",
+"asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr",
+"asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr",
+"asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr",
+"asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr",
+"asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr",
+"asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr",
+"asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr",
+"asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr",
+"asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr",
+"asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr",
+"asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr",
+"openexr_2.2.0_heap_buffer_overflow_exr",
+"openexr_2.2.0_memory_allocation_error_1_exr",
+# "openexr_2.2.0_memory_allocation_error_2_exr",
+"openexr_2.2.0_memory_allocation_error_3_exr",
+"poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c",
+"poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min",
+"poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min",
+"poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini",
+"poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini",
+"poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc",
+"poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90",
+"poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min",
+"poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min",
+"poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min",
+"poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min",
+"poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77",
+"poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min",
+"poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min",
+"poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min",
+"poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min",
+]
+
+if openexr_version >= 20600 :
+    files += [
+        "signal_sigsegv_7ffff7b21e8a_389_bf048bf41ca71b4e00d2b0edd0a39e27_exr",
+    ]
+
+
+# Need to copy the files to a temp location to add a true .exr suffix
+if not os.path.exists('tmpsrc'):
+    os.mkdir('tmpsrc')
+
+
+
+for f in files:
+    # First, do a simple read/write loop to test ordinary ImageInput
+    shutil.copyfile(os.path.join(imagedir, f),
+                    os.path.join('tmpsrc', f+'.exr'))
+    command += oiiotool ('-n -info tmpsrc/'+f+'.exr -o out.exr')
+    command += '; echo >> out.txt \n'

--- a/testsuite/openexr-multires/ref/out.txt
+++ b/testsuite/openexr-multires/ref/out.txt
@@ -241,3 +241,98 @@ Reading ../../../../../openexr-images/MultiResolution/WavyLinesSphere.exr
     oiio:subimages: 1
 Comparing "../../../../../openexr-images/MultiResolution/WavyLinesSphere.exr" and "WavyLinesSphere.exr"
 PASS
+Reading ../../../../../openexr-images/MultiView/Adjuster.exr
+../../../../../openexr-images/MultiView/Adjuster.exr :  775 x  678, 9 channel, half openexr
+    SHA-1: 3528BD22E1C079B85E694685D80FBBFB7D1B3B9F
+    channel list: R, G, B, left.R, left.G, left.B, right.R, right.G, right.B
+    compression: "b44a"
+    ImageDescription: "Plane blade adjustment mechanism"
+    multiView: "center", "left", "right"
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    XResolution: 100
+    YResolution: 100
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/MultiView/Adjuster.exr" and "Adjuster.exr"
+PASS
+Reading ../../../../../openexr-images/MultiView/Balls.exr
+../../../../../openexr-images/MultiView/Balls.exr : 1000 x  784, 6 channel, half openexr
+    SHA-1: A9E6D430F81F0407D7530B5DBD2379036F227377
+    channel list: R, G, B, right.R, right.G, right.B
+    compression: "piz"
+    multiView: "left", "right"
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    XResolution: 100
+    YResolution: 100
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/MultiView/Balls.exr" and "Balls.exr"
+PASS
+Reading ../../../../../openexr-images/MultiView/Fog.exr
+../../../../../openexr-images/MultiView/Fog.exr : 1000 x  672, 2 channel, half openexr
+    SHA-1: 558BF1D0FD1934388AC24AF7B7ABF1DBA2618119
+    channel list: Y, right.Y
+    compression: "piz"
+    ilut: "log"
+    ImageDescription: "Fog in the Presidio of San Francisco"
+    latitude: 37.7973
+    longitude: -122.476
+    multiView: "left", "right"
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    XResolution: 100
+    YResolution: 100
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/MultiView/Fog.exr" and "Fog.exr"
+PASS
+Reading ../../../../../openexr-images/MultiView/Impact.exr
+../../../../../openexr-images/MultiView/Impact.exr :  554 x  699, 6 channel, half openexr
+    MIP-map levels: 554x699 277x349 138x174 69x87 34x43 17x21 8x10 4x5 2x2 1x1
+    SHA-1: A878ABDBB1C4F1F9DC17C6D31938E9EBFF76930B
+    channel list: R, G, B, right.R, right.G, right.B
+    tile size: 64 x 64
+    compression: "zip"
+    ilut: "log"
+    ImageDescription: "Steel ball breaking a wine glass"
+    multiView: "left", "right"
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    textureformat: "Plain Texture"
+    wrapmodes: "clamp,clamp"
+    XResolution: 100
+    YResolution: 100
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+    openexr:roundingmode: 0
+Comparing "../../../../../openexr-images/MultiView/Impact.exr" and "Impact.exr"
+PASS
+Reading ../../../../../openexr-images/MultiView/LosPadres.exr
+../../../../../openexr-images/MultiView/LosPadres.exr :  689 x 1000, 6 channel, half openexr
+    SHA-1: 489178A1FBE480DCA649EE24B3FAA408351E4EE3
+    channel list: R, G, B, left.R, left.G, left.B
+    compression: "piz"
+    ImageDescription: "Los Padres National Forest from above"
+    latitude: 34.53
+    longitude: -119.05
+    multiView: "right", "left"
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    XResolution: 100
+    YResolution: 100
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/MultiView/LosPadres.exr" and "LosPadres.exr"
+PASS

--- a/testsuite/openexr-multires/run.py
+++ b/testsuite/openexr-multires/run.py
@@ -13,6 +13,13 @@ files = [ "Bonita.exr", "ColorCodedLevels.exr",
           "OrientationCube.exr", "OrientationLatLong.exr",
           "PeriodicPattern.exr", "StageEnvCube.exr", "StageEnvLatLong.exr",
           "WavyLinesCube.exr", "WavyLinesLatLong.exr", "WavyLinesSphere.exr" ]
+for f in files:
+    command += rw_command (imagedir, f)
 
+
+# ../openexr-images/MultiView
+# Adjuster.exr  Balls.exr  Fog.exr  Impact.exr  LosPadres.exr
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/MultiView"
+files = [ "Adjuster.exr", "Balls.exr", "Fog.exr", "Impact.exr", "LosPadres.exr" ]
 for f in files:
     command += rw_command (imagedir, f)

--- a/testsuite/openexr-suite/ref/out.txt
+++ b/testsuite/openexr-suite/ref/out.txt
@@ -1,3 +1,53 @@
+Reading ../../../../../openexr-images/ScanLines/Blobbies.exr
+../../../../../openexr-images/ScanLines/Blobbies.exr : 1040 x 1040, 5 channel, half/half/half/half/float openexr
+    SHA-1: 7228F3D22D0317764870CC00CC697E3E5EEDBA68
+    channel list: R (half), G (half), B (half), A (half), Z (float)
+    pixel data origin: x=-20, y=-20
+    full/display size: 1000 x 1000
+    full/display origin: 0, 0
+    chromaticities: 0.62955, 0.341, 0.2867, 0.6108, 0.1489, 0.07125, 0.3155, 0.33165
+    compression: "zip"
+    Copyright: "Copyright 2004 Industrial Light & Magic"
+    DateTime: "2004:01:19 12:55:33"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    utcOffset: 28800
+    whiteLuminance: 50
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/ScanLines/Blobbies.exr" and "Blobbies.exr"
+PASS
+Reading ../../../../../openexr-images/ScanLines/CandleGlass.exr
+../../../../../openexr-images/ScanLines/CandleGlass.exr : 1000 x  810, 4 channel, half openexr
+    SHA-1: CAB7A1AB50DF281F5F544C5EFDCCD9FFDEBB5D49
+    channel list: R, G, B, A
+    compression: "piz"
+    Copyright: "Copyright 2009 Industial Light & Magic"
+    DateTime: "2009:02:09 12:01:17"
+    ExposureTime: 30
+    FNumber: 32
+    ImageDescription: "Premultiplied alpha with A == 0 and RGB != 0"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/ScanLines/CandleGlass.exr" and "CandleGlass.exr"
+PASS
+Reading ../../../../../openexr-images/ScanLines/Cannon.exr
+../../../../../openexr-images/ScanLines/Cannon.exr :  780 x  566, 3 channel, half openexr
+    SHA-1: 8855671D158731258798358D78E90B2A62CF206D
+    channel list: R, G, B
+    compression: "b44"
+    Copyright: "Copyright 2006 Industrial Light & Magic"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/ScanLines/Cannon.exr" and "Cannon.exr"
+PASS
 Reading ../../../../../openexr-images/ScanLines/Desk.exr
 ../../../../../openexr-images/ScanLines/Desk.exr :  644 x  874, 4 channel, half openexr
     SHA-1: CBFEA416A3CA23DF2B1599A0495EECE6FB009E5D
@@ -29,18 +79,22 @@ Reading ../../../../../openexr-images/ScanLines/MtTamWest.exr
     oiio:subimages: 1
 Comparing "../../../../../openexr-images/ScanLines/MtTamWest.exr" and "MtTamWest.exr"
 PASS
-Reading ../../../../../openexr-images/ScanLines/Cannon.exr
-../../../../../openexr-images/ScanLines/Cannon.exr :  780 x  566, 3 channel, half openexr
-    SHA-1: 8855671D158731258798358D78E90B2A62CF206D
-    channel list: R, G, B
-    compression: "b44"
-    Copyright: "Copyright 2006 Industrial Light & Magic"
+Reading ../../../../../openexr-images/ScanLines/PrismsLenses.exr
+../../../../../openexr-images/ScanLines/PrismsLenses.exr : 1200 x  865, 4 channel, half openexr
+    SHA-1: 82748A5D996848985D4306747BCA5AAEFAF45887
+    channel list: R, G, B, A
+    compression: "piz"
+    Copyright: "Copyright 2009 Industial Light & Magic"
+    DateTime: "2009:02:09 11:55:19"
+    ExposureTime: 30
+    FNumber: 11
+    ImageDescription: "Premultiplied alpha with A == 0 and RGB != 0"
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
     oiio:subimages: 1
-Comparing "../../../../../openexr-images/ScanLines/Cannon.exr" and "Cannon.exr"
+Comparing "../../../../../openexr-images/ScanLines/PrismsLenses.exr" and "PrismsLenses.exr"
 PASS
 Reading ../../../../../openexr-images/ScanLines/StillLife.exr
 ../../../../../openexr-images/ScanLines/StillLife.exr : 1240 x  846, 4 channel, half openexr
@@ -74,26 +128,6 @@ Reading ../../../../../openexr-images/ScanLines/Tree.exr
     oiio:ColorSpace: "Linear"
     oiio:subimages: 1
 Comparing "../../../../../openexr-images/ScanLines/Tree.exr" and "Tree.exr"
-PASS
-Reading ../../../../../openexr-images/ScanLines/Blobbies.exr
-../../../../../openexr-images/ScanLines/Blobbies.exr : 1040 x 1040, 5 channel, half/half/half/half/float openexr
-    SHA-1: 7228F3D22D0317764870CC00CC697E3E5EEDBA68
-    channel list: R (half), G (half), B (half), A (half), Z (float)
-    pixel data origin: x=-20, y=-20
-    full/display size: 1000 x 1000
-    full/display origin: 0, 0
-    chromaticities: 0.62955, 0.341, 0.2867, 0.6108, 0.1489, 0.07125, 0.3155, 0.33165
-    compression: "zip"
-    Copyright: "Copyright 2004 Industrial Light & Magic"
-    DateTime: "2004:01:19 12:55:33"
-    PixelAspectRatio: 1
-    screenWindowCenter: 0, 0
-    screenWindowWidth: 1
-    utcOffset: 28800
-    whiteLuminance: 50
-    oiio:ColorSpace: "Linear"
-    oiio:subimages: 1
-Comparing "../../../../../openexr-images/ScanLines/Blobbies.exr" and "Blobbies.exr"
 PASS
 Reading ../../../../../openexr-images/TestImages/AllHalfValues.exr
 ../../../../../openexr-images/TestImages/AllHalfValues.exr :  256 x  256, 3 channel, half openexr

--- a/testsuite/openexr-suite/run.py
+++ b/testsuite/openexr-suite/run.py
@@ -1,24 +1,17 @@
 #!/usr/bin/env python
 
-# ../openexr-images/DisplayWindow:
-# README   t03.exr  t06.exr  t09.exr  t12.exr  t15.exr
-# t01.exr  t04.exr  t07.exr  t10.exr  t13.exr  t16.exr
-# t02.exr  t05.exr  t08.exr  t11.exr  t14.exr
-imagedir = OIIO_TESTSUITE_IMAGEDIR + "/DisplayWindow"
-
 # ../openexr-images/ScanLines:
-# Blobbies.exr   Desk.exr       StillLife.exr
-# Cannon.exr     MtTamWest.exr  Tree.exr
+# Blobbies.exr     Cannon.exr  MtTamWest.exr     StillLife.exr
+# CandleGlass.exr  Desk.exr    PrismsLenses.exr  Tree.exr
 imagedir = OIIO_TESTSUITE_IMAGEDIR + "/ScanLines"
 files = [ "Desk.exr", "MtTamWest.exr" ]
+files = [
+    "Blobbies.exr", "CandleGlass.exr", "Cannon.exr", "Desk.exr",
+    "MtTamWest.exr", "PrismsLenses.exr", "StillLife.exr", "Tree.exr"
+]
 for f in files:
     command += rw_command (imagedir, f)
-command = command + rw_command (imagedir, "Cannon.exr", extraargs="--compression zip")
-files = [ "StillLife.exr", "Tree.exr", "Blobbies.exr" ]
-for f in files:
-    command += rw_command (imagedir, f)
-# Cannon must be instructed to use lossless compression
-# FIXME - on all: screenWindowCenter, preview?
+
 
 # ../openexr-images/TestImages:
 # AllHalfValues.exr        GrayRampsDiagonal.exr    SquaresSwirls.exr
@@ -32,6 +25,7 @@ files = [ "AllHalfValues.exr", "BrightRings.exr", "BrightRingsNanInf.exr",
           "SquaresSwirls.exr", "WideColorGamut.exr", "WideFloatRange.exr" ]
 for f in files:
     command += rw_command (imagedir, f)
+
 
 # ../openexr-images/Tiles:
 # GoldenGate.exr  Ocean.exr       Spirals.exr

--- a/testsuite/openexr-v2/ref/out.txt
+++ b/testsuite/openexr-v2/ref/out.txt
@@ -200,3 +200,166 @@ Reading ../../../../../openexr-images/v2/Stereo/Leaves.exr
     Maximum depth was 954.393 at (716, 324)
 Comparing "../../../../../openexr-images/v2/Stereo/Leaves.exr" and "Leaves.exr"
 PASS
+Reading ../../../../../openexr-images/Beachball/multipart.0001.exr
+../../../../../openexr-images/Beachball/multipart.0001.exr :  877 x  876, 4 channel, half openexr
+    10 subimages: 877x876 [h,h,h,h], 877x876 [h], 877x876 [h,h], 385x769 [h], 877x876 [h,h,h,h], 877x876 [h], 877x876 [h,h], 911x876 [h,h], 911x876 [h,h], 386x769 [h]
+ subimage  0:  877 x  876, 4 channel, half openexr
+    SHA-1: C0E144BF97015C7019B09F07B7B15793FADD212E
+    channel list: R, G, B, A
+    pixel data origin: x=654, y=245
+    full/display size: 2048 x 1556
+    full/display origin: 0, 0
+    compression: "zips"
+    name: "rgba_right"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    view: "right"
+    oiio:ColorSpace: "Linear"
+    oiio:subimagename: "rgba_right"
+    oiio:subimages: 10
+    openexr:chunkCount: 876
+ subimage  1:  877 x  876, 1 channel, half openexr
+    SHA-1: 464AC3E30615481DB6F60B0D90E46B44868EF541
+    channel list: Z
+    pixel data origin: x=688, y=245
+    full/display size: 2048 x 1556
+    full/display origin: 0, 0
+    compression: "zips"
+    name: "depth_left"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    view: "left"
+    oiio:ColorSpace: "Linear"
+    oiio:subimagename: "depth_left"
+    oiio:subimages: 10
+    openexr:chunkCount: 876
+ subimage  2:  877 x  876, 2 channel, half openexr
+    SHA-1: 3F41E3E55E1549C689E41624DDF76FDD387E6C06
+    channel list: forward.u, forward.v
+    pixel data origin: x=688, y=245
+    full/display size: 2048 x 1556
+    full/display origin: 0, 0
+    compression: "zips"
+    name: "forward_left"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    view: "left"
+    oiio:ColorSpace: "Linear"
+    oiio:subimagename: "forward_left"
+    oiio:subimages: 10
+    openexr:chunkCount: 876
+ subimage  3:  385 x  769, 1 channel, half openexr
+    SHA-1: 07435B6A85DCB4DBC15B8D3CC7B15496A29F7B65
+    channel list: whitebarmask.mask
+    pixel data origin: x=1106, y=245
+    full/display size: 2048 x 1556
+    full/display origin: 0, 0
+    compression: "zips"
+    name: "whitebarmask_left"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    view: "left"
+    oiio:ColorSpace: "Linear"
+    oiio:subimagename: "whitebarmask_left"
+    oiio:subimages: 10
+    openexr:chunkCount: 769
+ subimage  4:  877 x  876, 4 channel, half openexr
+    SHA-1: D7866F11339F2EB9C8D9DB432D0EC6AA22872DD1
+    channel list: R, G, B, A
+    pixel data origin: x=688, y=245
+    full/display size: 2048 x 1556
+    full/display origin: 0, 0
+    compression: "zips"
+    name: "rgba_left"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    view: "left"
+    oiio:ColorSpace: "Linear"
+    oiio:subimagename: "rgba_left"
+    oiio:subimages: 10
+    openexr:chunkCount: 876
+ subimage  5:  877 x  876, 1 channel, half openexr
+    SHA-1: E8A3A031B7043016F0BDFD450E684587536E5571
+    channel list: Z
+    pixel data origin: x=654, y=245
+    full/display size: 2048 x 1556
+    full/display origin: 0, 0
+    compression: "zips"
+    name: "depth_right"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    view: "right"
+    oiio:ColorSpace: "Linear"
+    oiio:subimagename: "depth_right"
+    oiio:subimages: 10
+    openexr:chunkCount: 876
+ subimage  6:  877 x  876, 2 channel, half openexr
+    SHA-1: AF0F404B734D696163E2B175AD423AF637394DE6
+    channel list: forward.u, forward.v
+    pixel data origin: x=654, y=245
+    full/display size: 2048 x 1556
+    full/display origin: 0, 0
+    compression: "zips"
+    name: "forward_right"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    view: "right"
+    oiio:ColorSpace: "Linear"
+    oiio:subimagename: "forward_right"
+    oiio:subimages: 10
+    openexr:chunkCount: 876
+ subimage  7:  911 x  876, 2 channel, half openexr
+    SHA-1: 246B79EF99645956E5315E8C7726431FA82A5BC4
+    channel list: disparityL.x, disparityL.y
+    pixel data origin: x=654, y=245
+    full/display size: 2048 x 1556
+    full/display origin: 0, 0
+    compression: "zips"
+    name: "disparityL"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimagename: "disparityL"
+    oiio:subimages: 10
+    openexr:chunkCount: 876
+ subimage  8:  911 x  876, 2 channel, half openexr
+    SHA-1: 538EEB9BDE9ABD3672892052B67773BBF1BCA31B
+    channel list: disparityR.x, disparityR.y
+    pixel data origin: x=654, y=245
+    full/display size: 2048 x 1556
+    full/display origin: 0, 0
+    compression: "zips"
+    name: "disparityR"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimagename: "disparityR"
+    oiio:subimages: 10
+    openexr:chunkCount: 876
+ subimage  9:  386 x  769, 1 channel, half openexr
+    SHA-1: 110206AA3541F5FF372F9A0A0940F2572C81DCEB
+    channel list: whitebarmask.mask
+    pixel data origin: x=1070, y=245
+    full/display size: 2048 x 1556
+    full/display origin: 0, 0
+    compression: "zips"
+    name: "whitebarmask_right"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    view: "right"
+    oiio:ColorSpace: "Linear"
+    oiio:subimagename: "whitebarmask_right"
+    oiio:subimages: 10
+    openexr:chunkCount: 769
+Comparing "../../../../../openexr-images/Beachball/multipart.0001.exr" and "multipart.0001.exr"
+PASS

--- a/testsuite/openexr-v2/run.py
+++ b/testsuite/openexr-v2/run.py
@@ -13,3 +13,9 @@ command += rw_command (imagedir, "Balls.exr", use_oiiotool=1,
 # Convert from scanline to tiled
 command += rw_command (imagedir, "Leaves.exr", use_oiiotool=1,
                        extraargs="--tile 64 64 ", preargs="--stats")
+
+# Check a complicated multipart example
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/Beachball"
+files = [ "multipart.0001.exr" ]
+for f in files:
+    command += rw_command (imagedir, f, use_oiiotool=1, extraargs="-a")

--- a/testsuite/openexr-window/ref/out.txt
+++ b/testsuite/openexr-window/ref/out.txt
@@ -1,0 +1,223 @@
+Reading ../../../../../openexr-images/DisplayWindow/t01.exr
+../../../../../openexr-images/DisplayWindow/t01.exr :  400 x  300, 3 channel, half openexr
+    SHA-1: 829439C4520AA6F19D88FE1630B2E90A52A522D3
+    channel list: R, G, B
+    compression: "piz"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/DisplayWindow/t01.exr" and "t01.exr"
+PASS
+Reading ../../../../../openexr-images/DisplayWindow/t02.exr
+../../../../../openexr-images/DisplayWindow/t02.exr :  400 x  300, 3 channel, half openexr
+    SHA-1: 829439C4520AA6F19D88FE1630B2E90A52A522D3
+    channel list: R, G, B
+    full/display size: 400 x 300
+    full/display origin: 1, 1
+    compression: "piz"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/DisplayWindow/t02.exr" and "t02.exr"
+PASS
+Reading ../../../../../openexr-images/DisplayWindow/t03.exr
+../../../../../openexr-images/DisplayWindow/t03.exr :  400 x  300, 3 channel, half openexr
+    SHA-1: 829439C4520AA6F19D88FE1630B2E90A52A522D3
+    channel list: R, G, B
+    full/display size: 370 x 280
+    full/display origin: 30, 20
+    compression: "piz"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/DisplayWindow/t03.exr" and "t03.exr"
+PASS
+Reading ../../../../../openexr-images/DisplayWindow/t04.exr
+../../../../../openexr-images/DisplayWindow/t04.exr :  400 x  300, 3 channel, half openexr
+    SHA-1: 829439C4520AA6F19D88FE1630B2E90A52A522D3
+    channel list: R, G, B
+    full/display size: 370 x 280
+    full/display origin: 0, 0
+    compression: "piz"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/DisplayWindow/t04.exr" and "t04.exr"
+PASS
+Reading ../../../../../openexr-images/DisplayWindow/t05.exr
+../../../../../openexr-images/DisplayWindow/t05.exr :  400 x  300, 3 channel, half openexr
+    SHA-1: 829439C4520AA6F19D88FE1630B2E90A52A522D3
+    channel list: R, G, B
+    full/display size: 340 x 260
+    full/display origin: 30, 20
+    compression: "piz"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/DisplayWindow/t05.exr" and "t05.exr"
+PASS
+Reading ../../../../../openexr-images/DisplayWindow/t06.exr
+../../../../../openexr-images/DisplayWindow/t06.exr :  400 x  300, 3 channel, half openexr
+    SHA-1: 829439C4520AA6F19D88FE1630B2E90A52A522D3
+    channel list: R, G, B
+    full/display size: 402 x 302
+    full/display origin: -1, -1
+    compression: "piz"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/DisplayWindow/t06.exr" and "t06.exr"
+PASS
+Reading ../../../../../openexr-images/DisplayWindow/t07.exr
+../../../../../openexr-images/DisplayWindow/t07.exr :  400 x  300, 3 channel, half openexr
+    SHA-1: 829439C4520AA6F19D88FE1630B2E90A52A522D3
+    channel list: R, G, B
+    full/display size: 481 x 371
+    full/display origin: -40, -40
+    compression: "piz"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/DisplayWindow/t07.exr" and "t07.exr"
+PASS
+Reading ../../../../../openexr-images/DisplayWindow/t08.exr
+../../../../../openexr-images/DisplayWindow/t08.exr :  400 x  300, 3 channel, half openexr
+    SHA-1: 829439C4520AA6F19D88FE1630B2E90A52A522D3
+    channel list: R, G, B
+    pixel data origin: x=30, y=40
+    full/display size: 501 x 401
+    full/display origin: 0, 0
+    compression: "piz"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/DisplayWindow/t08.exr" and "t08.exr"
+PASS
+Reading ../../../../../openexr-images/DisplayWindow/t09.exr
+../../../../../openexr-images/DisplayWindow/t09.exr :  400 x  300, 3 channel, half openexr
+    SHA-1: 829439C4520AA6F19D88FE1630B2E90A52A522D3
+    channel list: R, G, B
+    full/display size: 200 x 300
+    full/display origin: 400, 0
+    compression: "piz"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/DisplayWindow/t09.exr" and "t09.exr"
+PASS
+Reading ../../../../../openexr-images/DisplayWindow/t10.exr
+../../../../../openexr-images/DisplayWindow/t10.exr :  400 x  300, 3 channel, half openexr
+    SHA-1: 829439C4520AA6F19D88FE1630B2E90A52A522D3
+    channel list: R, G, B
+    full/display size: 100 x 300
+    full/display origin: -100, 0
+    compression: "piz"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/DisplayWindow/t10.exr" and "t10.exr"
+PASS
+Reading ../../../../../openexr-images/DisplayWindow/t11.exr
+../../../../../openexr-images/DisplayWindow/t11.exr :  400 x  300, 3 channel, half openexr
+    SHA-1: 829439C4520AA6F19D88FE1630B2E90A52A522D3
+    channel list: R, G, B
+    full/display size: 400 x 200
+    full/display origin: 0, 300
+    compression: "piz"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/DisplayWindow/t11.exr" and "t11.exr"
+PASS
+Reading ../../../../../openexr-images/DisplayWindow/t12.exr
+../../../../../openexr-images/DisplayWindow/t12.exr :  400 x  300, 3 channel, half openexr
+    SHA-1: 829439C4520AA6F19D88FE1630B2E90A52A522D3
+    channel list: R, G, B
+    full/display size: 400 x 100
+    full/display origin: 0, -100
+    compression: "piz"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/DisplayWindow/t12.exr" and "t12.exr"
+PASS
+Reading ../../../../../openexr-images/DisplayWindow/t13.exr
+../../../../../openexr-images/DisplayWindow/t13.exr :  400 x  300, 3 channel, half openexr
+    SHA-1: 829439C4520AA6F19D88FE1630B2E90A52A522D3
+    channel list: R, G, B
+    full/display size: 101 x 101
+    full/display origin: 399, 299
+    compression: "piz"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/DisplayWindow/t13.exr" and "t13.exr"
+PASS
+Reading ../../../../../openexr-images/DisplayWindow/t14.exr
+../../../../../openexr-images/DisplayWindow/t14.exr :  400 x  300, 3 channel, half openexr
+    SHA-1: 829439C4520AA6F19D88FE1630B2E90A52A522D3
+    channel list: R, G, B
+    full/display size: 101 x 101
+    full/display origin: -100, -100
+    compression: "piz"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/DisplayWindow/t14.exr" and "t14.exr"
+PASS
+Reading ../../../../../openexr-images/DisplayWindow/t15.exr
+../../../../../openexr-images/DisplayWindow/t15.exr :  400 x  300, 3 channel, half openexr
+    SHA-1: 829439C4520AA6F19D88FE1630B2E90A52A522D3
+    channel list: R, G, B
+    full/display size: 481 x 371
+    full/display origin: -40, -40
+    compression: "piz"
+    PixelAspectRatio: 1.5
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/DisplayWindow/t15.exr" and "t15.exr"
+PASS
+Reading ../../../../../openexr-images/DisplayWindow/t16.exr
+../../../../../openexr-images/DisplayWindow/t16.exr :  400 x  300, 3 channel, half openexr
+    SHA-1: 829439C4520AA6F19D88FE1630B2E90A52A522D3
+    channel list: R, G, B
+    full/display size: 481 x 371
+    full/display origin: -40, -40
+    compression: "piz"
+    PixelAspectRatio: 0.666667
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimages: 1
+Comparing "../../../../../openexr-images/DisplayWindow/t16.exr" and "t16.exr"
+PASS

--- a/testsuite/openexr-window/run.py
+++ b/testsuite/openexr-window/run.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+# Make sure we can do a read-write-read round trip of all the OpenEXR
+# test images that exercise different display and pixel windows.
+
+
+# ../openexr-images/DisplayWindow:
+# README   t03.exr  t06.exr  t09.exr  t12.exr  t15.exr
+# t01.exr  t04.exr  t07.exr  t10.exr  t13.exr  t16.exr
+# t02.exr  t05.exr  t08.exr  t11.exr  t14.exr
+imagedir = OIIO_TESTSUITE_IMAGEDIR + "/DisplayWindow"
+files = [
+    "t01.exr", "t02.exr", "t03.exr", "t04.exr", "t05.exr", "t06.exr",
+    "t07.exr", "t08.exr", "t09.exr", "t10.exr", "t11.exr", "t12.exr",
+    "t13.exr", "t14.exr", "t15.exr", "t16.exr"
+]
+for f in files:
+    command += rw_command (imagedir, f)
+


### PR DESCRIPTION
Test more images that have been part of the openexr-images suite for
a while. Three cases:

  * New images that weren't in the suite when I first set up these tests.

  * Images that were "broken" because of (originally) missing features
    in our exr support, that over the years are now supported.

  * Images I was unaware of or somehow fell through the cracks.

In the process, improve and uniformize a number of error messages in
oiiotool, iinfo, openexr reading.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
