### PR TITLE
EXR: Stop translating "worldToNDC" to "worldtoscreen".

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -910,6 +910,9 @@ The official OpenEXR site is http://www.openexr.com/.
      - worldToCamera
    * - ``worldtoscreen``
      - matrix
+     - worldToScreen
+   * - ``worldtoNDC``
+     - matrix
      - worldToNDC
    * - ``ImageDescription``
      - string

--- a/src/doc/stdmetadata.rst
+++ b/src/doc/stdmetadata.rst
@@ -318,6 +318,13 @@ to be used as textures (especially for OpenImageIO's TextureSystem).
     projection of the 3D view onto a :math:`[-1...1] \times [-1...1]` 2D
     domain.
 
+.. option:: "worldtoNDC" : matrix44
+
+    For shadow maps or rendered images this item (of type
+    `TypeDesc::PT_MATRIX`) is the world-to-NDC matrix describing the full
+    projection of the 3D view onto a :math:`[0...1] \times [0...1]` 2D
+    domain.
+
 .. option:: "oiio:updirection" : string
 
     For environment maps, indicates which direction is "up" (valid values

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -1849,6 +1849,7 @@ enum OIIO_API MakeTextureMode {
 ///    - `planarconfig` (string) :  Default: "separate"
 ///    - `worldtocamera` (matrix) : World-to-camera matrix of the view.
 ///    - `worldtoscreen` (matrix) : World-to-screen space matrix of the view.
+///    - `worldtoNDC` (matrix) :    World-to-NDC space matrix of the view.
 ///    - `wrapmodes` (string) :     Default: "black,black"
 ///    - `maketx:verbose` (int) :   How much detail should go to outstream (0).
 ///    - `maketx:runstats` (int) :  If nonzero, print run stats to outstream (0).

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -551,6 +551,12 @@ public:
     ///   coordinate system where $x$ and $y$ range from -1 to +1.
     ///   Generally, only rendered images will have this.
     ///
+    /// - `"worldtoNDC"` : The projection matrix, which is a 4x4 matrix
+    ///   (an `Imath::M44f`, described as `TypeDesc(FLOAT,MATRIX)`), giving
+    ///   the matrix that projected points from world space into a 2D NDC
+    ///   coordinate system where $x$ and $y$ range from 0 to +1. Generally,
+    ///   only rendered images will have this.
+    ///
     /// - `"averagecolor"` : If available in the metadata (generally only
     ///   for files that have been processed by `maketx`), this will return
     ///   the average color of the texture (into an array of `float`).

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -1425,8 +1425,15 @@ public:
     ///         The projection matrix, which is a 4x4 matrix (an
     ///         `Imath::M44f`, described as `TypeMatrix44`) giving the
     ///         matrix that projected points from world space into a 2D
-    ///         screen coordinate system where *x* and *y* range from $-1$
-    ///         to $+1$.  Generally, only rendered images will have this.
+    ///         screen coordinate system where *x* and *y* range from -1 to
+    ///         +1.  Generally, only rendered images will have this.
+    ///
+    ///   - `worldtoNDC` (matrix) :
+    ///         The projection matrix, which is a 4x4 matrix (an
+    ///         `Imath::M44f`, described as `TypeMatrix44`) giving the
+    ///         matrix that projected points from world space into a 2D
+    ///         screen coordinate system where *x* and *y* range from 0 to
+    ///         +1.  Generally, only rendered images will have this.
     ///
     ///   - `averagecolor` (float[nchannels]) :
     ///         If available in the metadata (generally only for files that

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -438,6 +438,8 @@ template<> struct TypeDescFromC<Imath::Color3f> { static const constexpr TypeDes
 #ifdef INCLUDED_IMATHMATRIX_H
 template<> struct TypeDescFromC<Imath::M33f> { static const constexpr TypeDesc value() { return TypeMatrix33; } };
 template<> struct TypeDescFromC<Imath::M44f> { static const constexpr TypeDesc value() { return TypeMatrix44; } };
+template<> struct TypeDescFromC<Imath::M33d> { static const constexpr TypeDesc value() { return TypeDesc(TypeDesc::DOUBLE, TypeDesc::MATRIX33); } };
+template<> struct TypeDescFromC<Imath::M44d> { static const constexpr TypeDesc value() { return TypeDesc(TypeDesc::DOUBLE, TypeDesc::MATRIX44); } };
 #endif
 
 

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -163,7 +163,7 @@ getargs(int argc, char* argv[], ImageSpec& configspec)
     std::string swrap;
     std::string twrap;
     bool doresize = false;
-    Imath::M44f Mcam(0.0f), Mscr(0.0f);  // Initialize to 0
+    Imath::M44f Mcam(0.0f), Mscr(0.0f), MNDC(0.0f);  // Initialize to 0
     bool separate              = false;
     bool nomipmap              = false;
     bool prman_metadata        = false;
@@ -256,6 +256,12 @@ getargs(int argc, char* argv[], ImageSpec& configspec)
                           &Mscr[2][0], &Mscr[2][1], &Mscr[2][2], &Mscr[2][3],
                           &Mscr[3][0], &Mscr[3][1], &Mscr[3][2], &Mscr[3][3])
       .help("Set the screen matrix");
+    ap.arg("--MNDC %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f",
+                          &MNDC[0][0], &MNDC[0][1], &MNDC[0][2], &MNDC[0][3],
+                          &MNDC[1][0], &MNDC[1][1], &MNDC[1][2], &MNDC[1][3],
+                          &MNDC[2][0], &MNDC[2][1], &MNDC[2][2], &MNDC[2][3],
+                          &MNDC[3][0], &MNDC[3][1], &MNDC[3][2], &MNDC[3][3])
+      .help("Set the NDC matrix");
     ap.arg("--prman-metadata", &prman_metadata)
       .help("Add prman specific metadata");
     ap.arg("--attrib %L:NAME %L:VALUE", &any_attrib_names, &any_attrib_values)
@@ -381,6 +387,8 @@ getargs(int argc, char* argv[], ImageSpec& configspec)
         configspec.attribute("worldtocamera", TypeMatrix, &Mcam);
     if (Mscr != Imath::M44f(0.0f))
         configspec.attribute("worldtoscreen", TypeMatrix, &Mscr);
+    if (MNDC != Imath::M44f(0.0f))
+        configspec.attribute("worldtoNDC", TypeMatrix, &MNDC);
     std::string wrapmodes = (swrap.size() ? swrap : wrap) + ','
                             + (twrap.size() ? twrap : wrap);
     configspec.attribute("wrapmodes", wrapmodes);

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -311,8 +311,6 @@ private:
     {
         // Ones whose name we change to our convention
         m_map["cameraTransform"]  = "worldtocamera";
-        m_map["worldToCamera"]    = "worldtocamera";
-        m_map["worldToNDC"]       = "worldtoscreen";
         m_map["capDate"]          = "DateTime";
         m_map["comments"]         = "ImageDescription";
         m_map["owner"]            = "Copyright";

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -818,7 +818,8 @@ struct ExrMeta {
 static ExrMeta exr_meta_translation[] = {
     // Translate OIIO standard metadata names to OpenEXR standard names
     ExrMeta("worldtocamera", "worldToCamera", TypeMatrix),
-    ExrMeta("worldtoscreen", "worldToNDC", TypeMatrix),
+    ExrMeta("worldtoNDC", "worldToNDC", TypeMatrix),
+    ExrMeta("worldtoscreen", "worldToScreen", TypeMatrix),
     ExrMeta("DateTime", "capDate", TypeString),
     ExrMeta("ImageDescription", "comments", TypeString),
     ExrMeta("description", "comments", TypeString),


### PR DESCRIPTION
This seems wrong. EXR standard metadata "worldToNDC" is exactly what it
says, not screen space. I'm not sure how we ended up with the historical
accident of reading "worldToNDC" from exr headers and auto-translating
it to "worldtoscreen".

The hope is that nearly no one is affected by any of this, since the
use case for these matrices was shadow maps, which were never
fully implemented in OIIO's TextureSystem anyway (they were last on
the list, and the VFX world switched to ray tracing before anybody got
angry enough at my procrastination to force me to implement it).

Signed-off-by: Larry Gritz <lg@larrygritz.com>
