### PR TITLE
Updated vcpkg instructions to aid discoverability

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -81,6 +81,7 @@ build options), maybe one of these packages managers will do it for you:
 * vckpg (https://github.com/Microsoft/vcpkg)
     * https://github.com/Microsoft/vcpkg/tree/master/ports/openimageio
     * `.\vcpkg install openimageio [tools]`
+    * For a full list of supported build features: `.\vcpkg search openimageio`
 * homebrew (https://github.com/Homebrew/brew)
     * https://formulae.brew.sh/formula/openimageio
     * `brew install openimageio`


### PR DESCRIPTION
## Description
Added a line for vcpkg users to discover additional opencolorio features they can build with that tool. This will help avoid people trying to build manually to enable features available via that relatively obscure package manager. Looking in the vcpkg repo isn't as helpful for people unfamiliar with that package manager or how it is configured.


## Tests
None. Documentation patch only.


