### PR TITLE
simd.h: add abs,sign,ceil,floor,round for float3

### DIFF
--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -226,8 +226,10 @@
 #    define OIIO_GCC_PRAGMA(UnQuotedPragma) OIIO_PRAGMA(UnQuotedPragma)
 #    if defined(__clang__)
 #        define OIIO_CLANG_PRAGMA(UnQuotedPragma) OIIO_PRAGMA(UnQuotedPragma)
+#        define OIIO_GCC_ONLY_PRAGMA(UnQuotedPragma)
 #    else
 #        define OIIO_CLANG_PRAGMA(UnQuotedPragma)
+#        define OIIO_GCC_ONLY_PRAGMA(UnQuotedPragma) OIIO_PRAGMA(UnQuotedPragma)
 #    endif
 #    define OIIO_MSVS_PRAGMA(UnQuotedPragma)
 #elif defined(_MSC_VER)
@@ -236,6 +238,7 @@
 #    define OIIO_PRAGMA_VISIBILITY_PUSH /* N/A on MSVS */
 #    define OIIO_PRAGMA_VISIBILITY_POP  /* N/A on MSVS */
 #    define OIIO_GCC_PRAGMA(UnQuotedPragma)
+#    define OIIO_GCC_ONLY_PRAGMA(UnQuotedPragma)
 #    define OIIO_CLANG_PRAGMA(UnQuotedPragma)
 #    define OIIO_MSVS_PRAGMA(UnQuotedPragma) OIIO_PRAGMA(UnQuotedPragma)
 #else
@@ -244,6 +247,7 @@
 #    define OIIO_PRAGMA_VISIBILITY_PUSH
 #    define OIIO_PRAGMA_VISIBILITY_POP
 #    define OIIO_GCC_PRAGMA(UnQuotedPragma)
+#    define OIIO_GCC_ONLY_PRAGMA(UnQuotedPragma)
 #    define OIIO_CLANG_PRAGMA(UnQuotedPragma)
 #    define OIIO_MSVS_PRAGMA(UnQuotedPragma)
 #endif


### PR DESCRIPTION
They already existed for float{4,8,16}, but were never implemented for
float3.

Add to simd_test.cpp both unit sanity checks and benchmarks for these
functions (including for the other classes where it already existed,
they were nonetheless not unit tested).

Also beef up simd_test by testing and benchmarking load/construcution
from scalar. Rename some test functions for clarity.

Along the way I realized a difference between scalar std::round and
our vector simd::round() in how they handle exact middle values
i+0.5. Because our round is more efficient (one instruction, whereas
std::round cannot be done in one op on x64, because "round midpoint
away from zero" is not a native hw rounding mode), put a big fat
comment warning about the difference.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
