### PR TITLE
Update LibRaw longitude

### DIFF
--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -653,8 +653,12 @@ RawInput::open_raw(bool unpack, const std::string& name,
 #if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0, 17, 0)
     if (other.parsed_gps.gpsparsed) {
         add("GPS", "Latitude", other.parsed_gps.latitude, false, 0.0f);
+#    if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0, 20, 0)
+        add("GPS", "Longitude", other.parsed_gps.longitude, false, 0.0f);
+#    else
         add("GPS", "Longitude", other.parsed_gps.longtitude, false,
             0.0f);  // N.B. wrong spelling!
+#    endif
         add("GPS", "TimeStamp", other.parsed_gps.gpstimestamp, false, 0.0f);
         add("GPS", "Altitude", other.parsed_gps.altitude, false, 0.0f);
         add("GPS", "LatitudeRef", string_view(&other.parsed_gps.latref, 1),


### PR DESCRIPTION
## Description

LibRaw recently fixed their long lasting spelling error on longitude (https://github.com/LibRaw/LibRaw/pull/304)
This means that any version of LibRaw from 0.20-Beta3 and newer has this fix and it will break oiio which uses the old misspelled parameter name.

This fix adds a LibRaw version check to know if it should use the misspelled parameter or the correct one.
Just keep in mind that this will cause LibRaw 0.20 versions older than Beta3 (i.e.. Beta1 and Beta2) to not work any more.

## Tests
Don't think a test is needed for this small fix.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

