### PR TITLE
Avoid unexplained build break with VS2015 -- presumed compiler bug

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5307,8 +5307,8 @@ getargs(int argc, char* argv[])
     ap.arg("--metamerge", &ot.metamerge)
       .help("Always merge metadata of all inputs into output");
     ap.arg("--crash")
-      .action(crash_me)
-      .hidden();
+      .hidden()
+      .action(crash_me);
     ap.separator("Commands that read images:");
     ap.arg("-i %s:FILENAME")
       .help("Input file (options: now=, printinfo=, autocc=, type=, ch=)")


### PR DESCRIPTION
Doesn't trigger an error on other compilers, or on newer MSVS. But this
minor rearrangement makes VS2015 happy, so let's just go with it and
not look under that rug.

Closes #2611

Signed-off-by: Larry Gritz <lg@larrygritz.com>
