### PR TITLE
oiiotool - remove argc/argv and substitute cspan

### DIFF
--- a/src/igrep/igrep.cpp
+++ b/src/igrep/igrep.cpp
@@ -119,13 +119,13 @@ grep_file(const std::string& filename, regex& re,
 
 
 static int
-parse_files(int argc, const char* argv[])
+parse_files(cspan<const char*> argv)
 {
-    for (int i = 0; i < argc; i++) {
+    for (auto a : argv) {
         if (pattern.empty())
-            pattern = argv[i];
+            pattern = a;
         else
-            filenames.emplace_back(argv[i]);
+            filenames.emplace_back(a);
     }
     return 0;
 }

--- a/src/include/OpenImageIO/argparse.h
+++ b/src/include/OpenImageIO/argparse.h
@@ -511,14 +511,6 @@ public:
             return action([=](Arg&, cspan<const char*>) { func(); });
         }
 
-        // Old style action for compatibility
-        Arg& action(int (*func)(int, const char**))
-        {
-            return action([=](Arg&, cspan<const char*> a) {
-                func(int(a.size()), (const char**)a.data());
-            });
-        }
-
         /// Return the name of the argument.
         string_view name() const;
 


### PR DESCRIPTION
This allows us to remove some older-style vestiges of ArgParse, and in
the process -- hopefully -- avoid some ambiguous polymorphism that older
MSVS seems unable to resolve.

Possibly addresses #2611 

Signed-off-by: Larry Gritz <lg@larrygritz.com>

