### PR TITLE
argparse -- try to resolve overload ambiguity

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -275,8 +275,8 @@ jobs:
           name: ${{ github.job }}
           path: build/*/testsuite/*/*.*
 
-  windows:
-    name: "Windows"
+  windows-vs2019:
+    name: "Windows VS2019"
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
@@ -289,6 +289,32 @@ jobs:
           CMAKE_GENERATOR: "Visual Studio 16 2019"
           OPENEXR_BRANCH: v2.4.1
           SKIP_TESTS: 1
+        run: |
+            source src/build-scripts/ci-startup.bash
+            source src/build-scripts/gh-win-installdeps.bash
+            source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: build/*/testsuite/*/*.*
+
+  windows-vs2017:
+    name: "Windows VS2017"
+    runs-on: windows-2016
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Nuget.exe
+        uses: warrenbuckley/Setup-Nuget@v1
+      - name: all
+        shell: bash
+        env:
+          PYTHON_VERSION: 3.6
+          CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
+          OPENEXR_BRANCH: v2.4.1
+          SKIP_TESTS: 1
+          #MY_CMAKE_FLAGS: -DUSE_PYTHON=0
+          USE_NINJA: 0
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-win-installdeps.bash

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,9 @@ environment:
       tbs_arch: "x64"
       tbs_tools: "msvc14"
       tbs_static_runtime: 0
+      MY_CMAKE_FLAGS: -DUSE_PYTHON=0
+      USE_PYTHON: 0
+
 
 cache:
   - C:\tools\vcpkg\installed
@@ -60,6 +63,7 @@ install:
   - vcpkg install openjpeg:"%platform%"-windows
   - vcpkg install ptex:"%platform%"-windows
   - vcpkg install libraw:x64-windows
+  - vcpkg install pybind11:x64-windows
 
   # Qt
   - set CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;C:\Qt\5.12
@@ -100,6 +104,7 @@ build_script:
   - cd build\windows64
   - cmake -G "%CMAKE_PLATFORM%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake \
       -DCMAKE_INSTALL_PREFIX=C:\projects\oiio\dist\windows64 \
+      -DUSE_PYTHON=0 -DUSE_PTEX=0 \
       -DPYTHON_INCLUDE_DIR:PATH=%PYTHON_DIR%/include -DPYTHON_LIBRARY:FILEPATH=%PYTHON_DIR%/libs/python27.lib -DPYTHON_EXECUTABLE:FILEPATH=%PYTHON_DIR%/python.exe -DCMAKE_LIBRARY_PATH=%CMAKE_LIBRARY_PATH% -DCMAKE_INCLUDE_PATH=%CMAKE_INCLUDE_PATH%  -DCMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH% -DOPENEXR_ROOT_DIR=C:\projects\oiio\ext -DVERBOSE=1 -DBUILD_MISSING_DEPS=1 ../..
   - dir c:\projects\oiio
   - dir c:\projects\oiio\build

--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -29,7 +29,8 @@ export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DEP_DIR/lib:$VCPKG_INSTALLATION_ROOT/i
 # export MY_CMAKE_FLAGS="$MY_CMAKE_FLAGS -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 # export OPENEXR_CMAKE_FLAGS="$OPENEXR_CMAKE_FLAGS -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 
-ls -l "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC"
+ls -l "C:/Program Files (x86)/Microsoft Visual Studio/*/Enterprise/VC/Tools/MSVC" && true
+ls -l "C:/Program Files (x86)/Microsoft Visual Studio" && true
 
 vcpkg list
 vcpkg update

--- a/src/include/OpenImageIO/argparse.h
+++ b/src/include/OpenImageIO/argparse.h
@@ -494,7 +494,7 @@ public:
             return *this;
         }
 
-        /// Add an arbitrary action:   `func(Act&, cspan<const char*>)`
+        /// Add an arbitrary action:   `func(Arg&, cspan<const char*>)`
         Arg& action(ArgAction&& func);
 
         /// Add an arbitrary action:   `func(cspan<const char*>)`
@@ -504,9 +504,15 @@ public:
             // it into func(Arg&,cspan<const char*>).
             return action([=](Arg&, cspan<const char*> a) { func(a); });
         }
+#if OIIO_MSVS_BEFORE_2017
+        // MSVS 2015 seems to need this, fixed in later versions.
+        Arg& action(void(*func)(cspan<const char*> myargs)) {
+            return action([=](Arg&, cspan<const char*> a) { func(a); });
+        }
+#endif
 
         /// Add an arbitrary action:  `func()`
-        Arg& action(std::function<void()>&& func)
+        Arg& action(void(*func)())
         {
             return action([=](Arg&, cspan<const char*>) { func(); });
         }
@@ -588,6 +594,13 @@ public:
     {
         return [&, value](Arg& arg, cspan<const char*> myarg) {
             arg.argparse().params()[arg.dest()] = value;
+        };
+    }
+
+    static ArgAction store_const(const char* value)
+    {
+        return [&, value](Arg& arg, cspan<const char*> myarg) {
+            arg.argparse().params()[arg.dest()] = string_view(value);
         };
     }
 

--- a/src/libutil/argparse_test.cpp
+++ b/src/libutil/argparse_test.cpp
@@ -226,10 +226,10 @@ test_new()
     ap.parse(int(args.size()), args.data());
     ap.print_help();
 
-    OIIO_CHECK_EQUAL(ap["f"].get<int>(), true);
-    OIIO_CHECK_EQUAL(ap["f2"].get<int>(), false);
-    OIIO_CHECK_EQUAL(ap["u"].get<int>(), false);
-    OIIO_CHECK_EQUAL(ap["u2"].get<int>(), true);
+    OIIO_CHECK_EQUAL(ap["f"].get<int>(), 1);
+    OIIO_CHECK_EQUAL(ap["f2"].get<int>(), 0);
+    OIIO_CHECK_EQUAL(ap["u"].get<int>(), 0);
+    OIIO_CHECK_EQUAL(ap["u2"].get<int>(), 1);
     OIIO_CHECK_EQUAL(ap["ci"].get<int>(), 42);
     OIIO_CHECK_EQUAL(ap["cf"].get<float>(), 3.14159f);
     OIIO_CHECK_EQUAL(ap["cfdef"].get<float>(), 42.0f);

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -153,7 +153,7 @@ public:
 
     CallbackFunction pending_callback() const { return m_pending_callback; }
     const char* pending_callback_name() const { return m_pending_argv[0]; }
-    ArgParse::Action pending_action() const { return m_pending_action; }
+    const ArgParse::Action& pending_action() const { return m_pending_action; }
     const char* pending_action_name() const { return m_pending_argv[0]; }
 
     void push(const ImageRecRef& img)


### PR DESCRIPTION
To help track down build issues with MSVS 2015, re-enable appveyor.
Also split GHA CI to test windows for both MSVS 2019 and 2017.

Also address some warnings on windows.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
