### PR TITLE
Fix broken clang-format test

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -404,21 +404,27 @@ jobs:
           path: build/*/testsuite/*/*.*
 
   clang-format:
+    # Test formatting. This test entry doesn't do a full build, it just runs
+    # clang-format on everything, and passes if nothing is misformatted.
+    # Upon failure, the build artifact will be the full source code with the
+    # formatting fixed (diffs will also appear in the console output).
     name: "clang-format verification"
     runs-on: ubuntu-18.04
+    container:
+      image: aswf/ci-osl:2021
     steps:
       - uses: actions/checkout@v2
       - name: all
         env:
-          CXX: clang++
-          LLVM_VERSION: 9.0.0
           BUILDTARGET: clang-format
+          PYTHON_VERSION: 3.7
           SKIP_TESTS: 1
-          BUILD_MISSING_DEPS: 0
-          CMAKE_CXX_STANDARD: 14
-          OCIO_BRANCH: 1c624651b7
-          # Pick an OCIO commit that includes a warning fix we need for clang
         run: |
             source src/build-scripts/ci-startup.bash
-            source src/build-scripts/gh-installdeps.bash
+            source src/build-scripts/gh-installdeps-centos.bash
             source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: src/*/*.{cpp,h}

--- a/src/build-scripts/ci-build-and-test.bash
+++ b/src/build-scripts/ci-build-and-test.bash
@@ -35,7 +35,7 @@ cmake ../.. -G "$CMAKE_GENERATOR" \
         -DCMAKE_INSTALL_LIBDIR="$OpenImageIO_ROOT/lib" \
         -DCMAKE_CXX_STANDARD="$CMAKE_CXX_STANDARD" \
         $MY_CMAKE_FLAGS -DVERBOSE=1
-time cmake --build . --target install --config ${CMAKE_BUILD_TYPE}
+time cmake --build . --target ${BUILDTARGET:=install} --config ${CMAKE_BUILD_TYPE}
 popd
 #make $MAKEFLAGS VERBOSE=1 $BUILD_FLAGS config
 #make $MAKEFLAGS $PAR_MAKEFLAGS $BUILD_FLAGS $BUILDTARGET

--- a/src/build-scripts/gh-installdeps-centos.bash
+++ b/src/build-scripts/gh-installdeps-centos.bash
@@ -33,15 +33,15 @@ src/build-scripts/install_test_images.bash
 
 source src/build-scripts/build_pybind11.bash
 
-if [[ "$OPENEXR_BRANCH" != "" || "$OPENEXR_VERSION" != "" ]] ; then
+if [[ "$OPENEXR_BRANCH" || "$OPENEXR_VERSION" ]] ; then
     source src/build-scripts/build_openexr.bash
 fi
 
-if [[ "$LIBTIFF_BRANCH" != ""  || "$LIBTIFF_VERSION" != "" ]] ; then
+if [[ "$LIBTIFF_BRANCH" || "$LIBTIFF_VERSION" ]] ; then
     source src/build-scripts/build_libtiff.bash
 fi
 
-if [[ "$OCIO_BRANCH" != ""  || "$OCIO_VERSION" != "" ]] ; then
+if [[ "$OCIO_BRANCH" || "$OCIO_VERSION" ]] ; then
     # Temporary (?) fix: GH ninja having problems, fall back to make
     CMAKE_GENERATOR="Unix Makefiles" \
     source src/build-scripts/build_ocio.bash

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -26,7 +26,7 @@ time sudo apt-get -q install -y \
     libfreetype6-dev \
     libavcodec-dev libavformat-dev libswscale-dev libavutil-dev \
     locales \
-    opencolorio-tools \
+    libopencolorio-dev \
     wget \
     libtbb-dev \
     libopenvdb-dev \
@@ -80,14 +80,16 @@ src/build-scripts/install_test_images.bash
 CXX="ccache $CXX" source src/build-scripts/build_pybind11.bash
 CXX="ccache $CXX" source src/build-scripts/build_openexr.bash
 
-if [[ "$LIBTIFF_BRANCH" != ""  || "$LIBTIFF_VERSION" != "" ]] ; then
+if [[ "$LIBTIFF_BRANCH" || "$LIBTIFF_VERSION" ]] ; then
     CXX="ccache $CXX" source src/build-scripts/build_libtiff.bash
 fi
 
-if [[ "$LIBRAW_BRANCH" != "" || "$LIBRAW_VERSION" != "" ]] ; then
+if [[ "$LIBRAW_BRANCH" || "$LIBRAW_VERSION" ]] ; then
     CXX="ccache $CXX" source src/build-scripts/build_libraw.bash
 fi
 
-# Temporary (?) fix: GH ninja having problems, fall back to make
-CMAKE_GENERATOR="Unix Makefiles" \
-CXX="ccache $CXX" source src/build-scripts/build_ocio.bash
+if [[ "$OCIO_BRANCH" || "$OCIO_VERSION" ]] ; then
+    # Temporary (?) fix: GH ninja having problems, fall back to make
+    CMAKE_GENERATOR="Unix Makefiles" \
+    source src/build-scripts/build_ocio.bash
+fi

--- a/src/include/OpenImageIO/argparse.h
+++ b/src/include/OpenImageIO/argparse.h
@@ -506,13 +506,14 @@ public:
         }
 #if OIIO_MSVS_BEFORE_2017
         // MSVS 2015 seems to need this, fixed in later versions.
-        Arg& action(void(*func)(cspan<const char*> myargs)) {
+        Arg& action(void (*func)(cspan<const char*> myargs))
+        {
             return action([=](Arg&, cspan<const char*> a) { func(a); });
         }
 #endif
 
         /// Add an arbitrary action:  `func()`
-        Arg& action(void(*func)())
+        Arg& action(void (*func)())
         {
             return action([=](Arg&, cspan<const char*>) { func(); });
         }

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -923,10 +923,9 @@ struct ChanNameHolder {
     void compute_special_index_xyz()
     {
         static const char* special[]
-            = { "R",    "Red",  "G",  "Green", "B", "Blue", /* "Y", */
-                "X",  "Y",  "Z", "real", "imag",
-                "A",  "Alpha", "AR", "RA", "AG",
-                "GA",   "AB",   "BA", "Depth", "Zback", nullptr };
+            = { "R",  "Red", "G",  "Green", "B",    "Blue", /* "Y", */
+                "X",  "Y",   "Z",  "real",  "imag", "A",     "Alpha", "AR",
+                "RA", "AG",  "GA", "AB",    "BA",   "Depth", "Zback", nullptr };
         for (int i = 0; special[i]; ++i)
             if (Strutil::iequals(suffix, special[i])) {
                 special_index = i;
@@ -986,7 +985,7 @@ OpenEXRInput::PartInfo::query_channels(OpenEXRInput* in,
     for (auto ci = channels.begin(); ci != channels.end(); ++c, ++ci)
         cnh.emplace_back(ci.name(), c, ci.channel());
     spec.nchannels = int(cnh.size());
-    if (! spec.nchannels) {
+    if (!spec.nchannels) {
         in->errorf("No channels found");
         return false;
     }
@@ -1006,8 +1005,8 @@ OpenEXRInput::PartInfo::query_channels(OpenEXRInput* in,
         // Strutil::printf("layerspan:\n");
         // for (auto& c : layerspan)
         //     Strutil::printf("  %s = %s . %s\n", c.fullname, c.layer, c.suffix);
-        if (suffixfound("X", layerspan) && (suffixfound("Y", layerspan)
-                                            || suffixfound("Z", layerspan))) {
+        if (suffixfound("X", layerspan)
+            && (suffixfound("Y", layerspan) || suffixfound("Z", layerspan))) {
             // If "X", and at least one of "Y" and "Z", are found among the
             // channel names of this layer, it must encode some kind of
             // position or normal. The usual sort order will give a weird

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -2157,12 +2157,12 @@ IBA_color_range_check(ImageBuf& src, const py::object& low,
                       const py::object& high, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    std::vector<int64_t> counts { 0, 0, 0};
+    std::vector<int64_t> counts { 0, 0, 0 };
     imagesize_t lowcount = 0, highcount = 0, inrangecount = 0;
     std::vector<float> lowvec, highvec;
     py_to_stdvector(lowvec, low);
     py_to_stdvector(highvec, high);
-    bool ok = ImageBufAlgo::color_range_check(src, &lowcount, &highcount,
+    bool ok   = ImageBufAlgo::color_range_check(src, &lowcount, &highcount,
                                               &inrangecount, lowvec, highvec,
                                               roi, nthreads);
     counts[0] = lowcount;
@@ -2779,9 +2779,8 @@ declare_imagebufalgo(py::module& m)
 
         // color_count
 
-        .def_static("color_range_check", &IBA_color_range_check,
-                    "src"_a, "low"_a, "high"_a,
-                     "roi"_a = ROI::All(), "nthreads"_a = 0)
+        .def_static("color_range_check", &IBA_color_range_check, "src"_a,
+                    "low"_a, "high"_a, "roi"_a = ROI::All(), "nthreads"_a = 0)
 
         .def_static("nonzero_region", &IBA_nonzero_region, "src"_a,
                     "roi"_a = ROI::All(), "nthreads"_a = 0)

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -327,7 +327,7 @@ py_to_stdvector(std::vector<T>& vals, const py::object& obj)
     }
     // Apparently a str can masquerade as a buffer object, so make sure to
     // exclude that from teh buffer case.
-    if (py::isinstance<py::buffer>(obj) && ! py::isinstance<py::str>(obj)) {
+    if (py::isinstance<py::buffer>(obj) && !py::isinstance<py::str>(obj)) {
         return py_buffer_to_stdvector(vals, obj.cast<py::buffer>());
     }
 


### PR DESCRIPTION
A few weeks back, I rearranged a bit of ci-build-and-test.bash to invoke
cmake directly instead of the makefile wrapper. But in the process, I
accidentally caused it to always build `--target install` instead of
using the optional target `$BUILDTARGET` which is how clang-format runs
were supposed to have been triggered.

The result was the 'clang-format' test did a full *build* instead of
running clang-format. This was both much more expensive, and also
pointless: we weren't testing clang-format during CI at all.  Oops.
Thus, some recent checkouts weren't properly formatted. We also amend
the minor fixes that bring us into format compliance.

I also noticed that I can use apt-get to install OCIO on the Ubuntu
instances used by GH CI, so modify to only build OCIO from source if a
specific version is requested. This speeds up some of our CI test
cases.

Signed-off-by: Larry Gritz <lg@larrygritz.com>