### PR TITLE
Terminal I/O of images

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1654,6 +1654,64 @@ is the total number of channel samples in the thumbnail).
 
 |
 
+.. _sec-bundledplugins-term:
+
+Term (Terminal)
+===============================================
+
+This *experimental* output-only "format" is actually a procedural output
+that writes a low-res representation of the image to the console output. It
+requires a terminal application that supports Unicode and 24 bit color
+extensions.
+
+The `term` ImageOutput supports the following special metadata tokens to
+control aspects of the writing itself:
+
+.. list-table::
+   :widths: 30 10 65
+   :header-rows: 1
+
+   * - Output Configuration Attribute
+     - Type
+     - Meaning
+   * - ``term:method``
+     - string
+     - May be one of `iterm2`, `24bit` (default), `24bit-space`, `256color`,
+       or `dither`.
+   * - ``term:fit``
+     - int
+     - If 1 (the default), the image will be resized to fit on the console
+       window.
+
+
+
+The `iterm2` mode is the best quality and is the default mode when actually
+running on a Mac and launching using iTerm2 as the terminal. This mode uses
+iTerm2's nonstandard extension to directly output an pixel array to be
+visible in the terminal.
+
+The default in other circumstances is the `24bit` mode, which displays two
+approximately square pixels vertically in each character cell, by outputting
+the Unicode "upper half block" glyph (`\u2508`) with the foreground color
+set to the top pixel's color and the background color set to the bottom
+pixel's color.
+
+If this doesn't look right, or your terminal doesn't support Unicode,
+the `24bit-space` is an alternate mode that displays one elongated pixel
+in each character cell, writing a space character with the correct color.
+
+There's also a `256color` method that just uses the 6x6x6 color space in the
+256 color palette -- which looks horrible -- and an experimental `dither`
+which does a half-assed Floyd-Steinberg dithering, horizontally only, and
+frankly is not an improvement unless you squint really hard. These may
+change or be eliminted in the future.
+
+In all cases, the image will automatically be resized to fit in the terminal
+and keep approximately the correct aspect ratio, as well as converted to
+sRGB so it looks kinda ok.
+
+|
+
 .. _sec-bundledplugins-tiff:
 
 TIFF

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1820,6 +1820,10 @@ public:
     ///  - `"ioproxy"`
     ///         Does the image file format support writing to an `IOProxy`?
     ///
+    /// - `"procedural"` :
+    ///       Is this a purely procedural output that doesn't write an
+    ///       actual file?
+    ///
     /// This list of queries may be extended in future releases. Since this
     /// can be done simply by recognizing new query strings, and does not
     /// require any new API entry points, addition of support for new

--- a/src/libOpenImageIO/imageinout_test.cpp
+++ b/src/libOpenImageIO/imageinout_test.cpp
@@ -245,7 +245,8 @@ test_all_formats()
         auto fmtexts           = Strutil::splitsv(e, ":");
         string_view formatname = fmtexts[0];
         // Skip "formats" that aren't amenable to this kind of testing
-        if (formatname == "null" || formatname == "socket")
+        if (formatname == "null" || formatname == "socket"
+            || formatname == "term")
             continue;
         // Field3d very finicky. Skip for now. FIXME?
         if (formatname == "field3d")

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -206,6 +206,10 @@ catalog_plugin(const std::string& format_name,
         ImageInput* name##_input_imageio_create();                             \
         extern const char* name##_input_extensions[];                          \
         extern const char* name##_imageio_library_version();
+#    define PLUGENTRY_WO(name)                                                 \
+        ImageOutput* name##_output_imageio_create();                           \
+        extern const char* name##_output_extensions[];                         \
+        extern const char* name##_imageio_library_version();
 
 PLUGENTRY(bmp);
 PLUGENTRY(cineon);
@@ -234,6 +238,7 @@ PLUGENTRY(rla);
 PLUGENTRY(sgi);
 PLUGENTRY(socket);
 PLUGENTRY_RO(softimage);
+PLUGENTRY_WO(term);
 PLUGENTRY(tiff);
 PLUGENTRY(targa);
 PLUGENTRY(webp);
@@ -265,6 +270,12 @@ catalog_builtin_plugins()
         declare_imageio_format(                                          \
             #name, (ImageInput::Creator)name##_input_imageio_create,     \
             name##_input_extensions, nullptr, nullptr,                   \
+            name##_imageio_library_version())
+#define DECLAREPLUG_WO(name)                                             \
+        declare_imageio_format(                                          \
+            #name, nullptr, nullptr,                                     \
+            (ImageOutput::Creator)name##_output_imageio_create,          \
+            name##_output_extensions,                                    \
             name##_imageio_library_version())
 
 #if !defined(DISABLE_BMP)
@@ -373,6 +384,9 @@ catalog_builtin_plugins()
 #endif
 #if !defined(DISABLE_TARGA)
     DECLAREPLUG (targa);
+#endif
+#if !defined(DISABLE_TERM)
+    DECLAREPLUG_WO (term);
 #endif
 #ifdef USE_WEBP
 #if !defined(DISABLE_WEBP)

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4618,6 +4618,7 @@ output_file(int /*argc*/, const char* argv[])
     bool supports_displaywindow  = out->supports("displaywindow");
     bool supports_negativeorigin = out->supports("negativeorigin");
     bool supports_tiles = out->supports("tiles") || ot.output_force_tiles;
+    bool procedural     = out->supports("procedural");
     ot.read();
     ImageRecRef saveimg = ot.curimg;
     ImageRecRef ir(ot.curimg);
@@ -4890,7 +4891,7 @@ output_file(int /*argc*/, const char* argv[])
 
         // We wrote to a temporary file, so now atomically move it to the
         // original desired location.
-        if (ok) {
+        if (ok && !procedural) {
             std::string err;
             ok = Filesystem::rename(tmpfilename, filename, err);
             if (!ok)

--- a/src/term.imageio/CMakeLists.txt
+++ b/src/term.imageio/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright 2008-present Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+
+add_oiio_plugin (termoutput.cpp)

--- a/src/term.imageio/termoutput.cpp
+++ b/src/term.imageio/termoutput.cpp
@@ -1,0 +1,304 @@
+// Copyright 2008-present Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+
+#include <cstdio>
+
+#include <OpenImageIO/filesystem.h>
+#include <OpenImageIO/imagebuf.h>
+#include <OpenImageIO/imagebufalgo.h>
+#include <OpenImageIO/imageio.h>
+#include <OpenImageIO/simd.h>
+#include <OpenImageIO/sysutil.h>
+
+OIIO_PLUGIN_NAMESPACE_BEGIN
+
+namespace term_pvt {
+
+
+class TermOutput : public ImageOutput {
+public:
+    TermOutput() { init(); }
+    virtual ~TermOutput() { close(); }
+    virtual const char* format_name() const { return "term"; }
+    virtual bool open(const std::string& name, const ImageSpec& spec,
+                      OpenMode mode = Create);
+    virtual int supports(string_view feature) const;
+    virtual bool write_scanline(int y, int z, TypeDesc format, const void* data,
+                                stride_t xstride);
+    virtual bool write_tile(int x, int y, int z, TypeDesc format,
+                            const void* data, stride_t xstride,
+                            stride_t ystride, stride_t zstride);
+    virtual bool close();
+
+private:
+    ImageBuf m_buf;
+    std::string m_method;
+    bool m_fit = true;  // automatically fit to window size
+
+    void init() { m_buf.clear(); }
+
+    // Actually output the stored buffer to the console
+    bool output();
+};
+
+
+
+int
+TermOutput::supports(string_view feature) const
+{
+    return feature == "tiles" || feature == "alpha"
+           || feature == "random_access" || feature == "rewrite"
+           || feature == "procedural";
+}
+
+
+
+bool
+TermOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
+{
+    if (mode != Create) {
+        error("%s does not support subimages or MIP levels", format_name());
+        return false;
+    }
+
+    if (spec.nchannels != 3 && spec.nchannels != 4) {
+        error("%s does not support %d-channel images\n", format_name(),
+              m_spec.nchannels);
+        return false;
+    }
+
+    m_spec = spec;
+
+    // Retrieve config hints giving special instructions
+    m_method = Strutil::lower(m_spec["term:method"].get());
+    m_fit    = m_spec["term:fit"].get<int>(1);
+
+    // Store temp buffer in HALF format
+    ImageSpec spec2 = m_spec;
+    spec2.set_format(TypeDesc::HALF);
+    m_buf.reset(spec2);
+    ImageBufAlgo::zero(m_buf);
+
+    return true;
+}
+
+
+
+bool
+TermOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
+                           stride_t xstride)
+{
+    if (y > m_spec.height) {
+        error("Attempt to write too many scanlines to terminal");
+        close();
+        return false;
+    }
+    ROI roi(m_spec.x, m_spec.x + m_spec.width, y, y + 1, z, z + 1, 0,
+            m_spec.nchannels);
+    return m_buf.set_pixels(roi, format, data, xstride);
+}
+
+
+
+bool
+TermOutput::write_tile(int x, int y, int z, TypeDesc format, const void* data,
+                       stride_t xstride, stride_t ystride, stride_t zstride)
+{
+    ROI roi(x, std::min(x + m_spec.tile_width, m_spec.x + m_spec.width), y,
+            std::min(y + m_spec.tile_height, m_spec.y + m_spec.height), z,
+            std::min(z + m_spec.tile_depth, m_spec.z + m_spec.depth), 0,
+            m_spec.nchannels);
+    return m_buf.set_pixels(roi, format, data, xstride, ystride, zstride);
+}
+
+
+
+bool
+TermOutput::close()
+{
+    if (!m_buf.initialized())
+        return true;  // already closed
+
+    output();
+
+    init();  // clear everything
+    return true;
+}
+
+
+bool
+TermOutput::output()
+{
+    // Color convert in place to sRGB, or it won't look right
+    std::string cspace = m_buf.spec()["oiio:colorspace"].get();
+    ImageBufAlgo::colorconvert(m_buf, m_buf, cspace, "sRGB");
+
+    string_view TERM(Sysutil::getenv("TERM"));
+    string_view TERM_PROGRAM(Sysutil::getenv("TERM_PROGRAM"));
+    string_view TERM_PROGRAM_VERSION(Sysutil::getenv("TERM_PROGRAM_VERSION"));
+    Sysutil::Term term;
+
+    string_view method(m_method);
+    if (method.empty()) {
+        if (TERM_PROGRAM == "iTerm.app"
+            && Strutil::from_string<float>(TERM_PROGRAM_VERSION) >= 2.9) {
+            method = "iterm2";
+        } else if (TERM == "xterm" || TERM == "xterm-256color") {
+            method = "24bit";
+        } else {
+            method = "256color";
+        }
+    }
+
+    // Try to figure out how big an image we can display
+    int w = m_buf.spec().width;
+    int h = m_buf.spec().height;
+    // iTerm2 is special, see bellow
+    int maxw = (method == "iterm2") ? Sysutil::terminal_columns() * 16
+                                    : Sysutil::terminal_columns();
+    float yscale = (method == "iterm2" || method == "24bit") ? 1.0f : 0.5f;
+    // Resize the image as needed
+    if (w > maxw && m_fit) {
+        ROI newsize(0, maxw, 0, int(std::round(yscale * float(maxw) / w * h)));
+        m_buf = ImageBufAlgo::resize(m_buf, /*filter=*/nullptr, newsize);
+        w     = newsize.width();
+        h     = newsize.height();
+    }
+
+    if (method == "iterm2") {
+        // iTerm2.app can display entire images in the window, if you use a
+        // special escape sequence that lets you transmit a base64-encoded
+        // image file, so we convert to just a simple PPM and do so.
+        std::ostringstream s;
+        s << "P3\n" << m_buf.spec().width << ' ' << m_buf.spec().height << "\n";
+        s << "255\n";
+        for (int y = m_buf.ybegin(), ye = m_buf.yend(); y < ye; y += 1) {
+            for (int x = m_buf.xbegin(), xe = m_buf.xend(); x < xe; ++x) {
+                unsigned char rgb[3];
+                m_buf.get_pixels(ROI(x, x + 1, y, y + 1, 0, 1, 0, 3),
+                                 TypeDesc::UINT8, &rgb);
+                s << int(rgb[0]) << ' ' << int(rgb[1]) << ' ' << int(rgb[2])
+                  << '\n';
+            }
+        }
+        std::cout << "\033]"
+                  << "1337;"
+                  << "File=inline=1"
+                  << ";width=auto"
+                  << ":" << Strutil::base64_encode(s.str()) << '\007'
+                  << std::endl;
+        return true;
+    }
+
+    if (method == "24bit") {
+        // Print two vertical pixels per character cell using the Unicode
+        // "upper half block" glyph U+2580, with fg color set to the 24 bit
+        // RGB value of the upper pixel, and bg color set to the 24-bit RGB
+        // value the lower pixel.
+        int z = m_buf.spec().z;
+        for (int y = m_buf.ybegin(), ye = m_buf.yend(); y < ye; y += 2) {
+            for (int x = m_buf.xbegin(), xe = m_buf.xend(); x < xe; ++x) {
+                unsigned char rgb[2][3];
+                m_buf.get_pixels(ROI(x, x + 1, y, y + 2, z, z + 1, 0, 3),
+                                 TypeDesc::UINT8, &rgb);
+                std::cout << term.ansi_fgcolor(rgb[0][0], rgb[0][1], rgb[0][2]);
+                std::cout << term.ansi_bgcolor(rgb[1][0], rgb[1][1], rgb[1][2])
+                          << "\u2580";
+            }
+            std::cout << term.ansi("default") << "\n";
+        }
+        return true;
+    }
+
+    if (method == "24bit-space") {
+        // Print as space, with bg color set to the 24-bit RGB value of each
+        // pixel.
+        int z = m_buf.spec().z;
+        for (int y = m_buf.ybegin(), ye = m_buf.yend(); y < ye; ++y) {
+            for (int x = m_buf.xbegin(), xe = m_buf.xend(); x < xe; ++x) {
+                unsigned char rgb[3];
+                m_buf.get_pixels(ROI(x, x + 1, y, y + 1, z, z + 1, 0, 3),
+                                 TypeDesc::UINT8, &rgb);
+                std::cout << term.ansi_bgcolor(rgb[0], rgb[1], rgb[2]) << " ";
+            }
+            std::cout << term.ansi("default") << "\n";
+        }
+        return true;
+    }
+
+    if (method == "dither") {
+        // Print as space, with bg color set to the 6x6x6 RGB value of each
+        // pixels. Try to make it better with horizontal dithering. But...
+        // it still looks bad. Room for future improvement?
+        int z = m_buf.spec().z;
+        for (int y = m_buf.ybegin(), ye = m_buf.yend(); y < ye; ++y) {
+            simd::vfloat4 leftover(0.0f);
+            for (int x = m_buf.xbegin(), xe = m_buf.xend(); x < xe; ++x) {
+                simd::vfloat4 rgborig;
+                m_buf.get_pixels(ROI(x, x + 1, y, y + 1, z, z + 1, 0, 3),
+                                 TypeDesc::FLOAT, &rgborig);
+                rgborig += leftover;
+                simd::vfloat4 rgb = 5.0f * rgborig;
+                simd::vint4 rgbi;
+                OIIO_MAYBE_UNUSED simd::vfloat4 frac = floorfrac(rgb, &rgbi);
+                leftover = rgborig - 0.2f * simd::vfloat4(rgbi);
+                rgbi     = clamp(rgbi, simd::vint4(0), simd::vint4(5));
+                std::cout << "\033[48;5;"
+                          << (0x10 + 36 * rgbi[0] + 6 * rgbi[1] + rgbi[2])
+                          << "m ";
+            }
+            std::cout << term.ansi("default") << "\n";
+        }
+        return true;
+    }
+    {
+        // Print as space, with bg color set to the 6x6x6 RGB value of each
+        // pixels. This looks awful!
+        int z = m_buf.spec().z;
+        for (int y = m_buf.ybegin(), ye = m_buf.yend(); y < ye; ++y) {
+            for (int x = m_buf.xbegin(), xe = m_buf.xend(); x < xe; ++x) {
+                simd::vfloat4 rgborig;
+                m_buf.get_pixels(ROI(x, x + 1, y, y + 1, z, z + 1, 0, 3),
+                                 TypeDesc::FLOAT, &rgborig);
+                simd::vfloat4 rgb = 5.0f * rgborig;
+                simd::vint4 rgbi;
+                OIIO_MAYBE_UNUSED simd::vfloat4 frac = floorfrac(rgb, &rgbi);
+                rgbi = clamp(rgbi, simd::vint4(0), simd::vint4(5));
+                std::cout << "\033[48;5;"
+                          << (0x10 + 36 * rgbi[0] + 6 * rgbi[1] + rgbi[2])
+                          << "m ";
+            }
+            std::cout << term.ansi("default") << "\n";
+        }
+        return true;
+    }
+
+    return false;
+}
+
+
+}  // namespace term_pvt
+
+
+OIIO_PLUGIN_EXPORTS_BEGIN
+
+OIIO_EXPORT ImageOutput*
+term_output_imageio_create()
+{
+    return new term_pvt::TermOutput;
+}
+
+OIIO_EXPORT int term_imageio_version = OIIO_PLUGIN_VERSION;
+
+OIIO_EXPORT const char*
+term_imageio_library_version()
+{
+    return nullptr;
+}
+
+OIIO_EXPORT const char* term_output_extensions[] = { "term", nullptr };
+
+OIIO_PLUGIN_EXPORTS_END
+
+OIIO_PLUGIN_NAMESPACE_END


### PR DESCRIPTION
This is a little kooky maybe, but it was something I was playing a couple
years ago, finally inspired by Chris to clean it up and PR it.

This patch adds a "term" format which, instead of writing files,
outputs a preview image to a true color text terminal window.

Is any of this useful? I have no idea. But it's kinda fun.

The quick demo of this is:

    oiiotool myfile.exr -o out.term

It will only do something useful if on a color terminal emulator with
24 bit color capability and Unicode. (I've tested it on the
gnome-terminal on Linux, and iTerm2 on Mac.)

The best quality results are on Mac if you are using iTerm2, it can
additionally do an actual pixel output (iTerm2 has as a nonstandard
feature the ability to send inline images to the terminal). This is
the "iterm2" method, but it's only expected to work on Mac with
iTerm2. It will automatically use this method as the default if you
are running iTerm2.

Next best is (thanks, Chris) is to display two pixels (vertically) in
each character cell, by outputting the Unicode "upper half block"
glyph (\u2508) with the foreground color set to the top pixel's color
and the background color set to the bottom pixel's color. This is the
default if you're not on a Mac running iTerm2. To demo (if you're on
have iTerm2 but want to see this method):

    oiiotool myfile.exr -attrib term:method 24bit -o out.term

But some terminals and fonts don't support unicode, or don't display
this character, or display it with an ugly border. So you can also use
an alternate method:

    oiiotool myfile.exr -attrib term:method 24bit-space -o out.term

where doesn't use the unicode trick but instead outputs a space (' ')
for each 2 vertical pixels, simply setting the background color to the
average of those two pixels.

There's also a "256color" method that just uses the 6x6x6 color space
in the 256 color palette -- which looks horrible -- and an
experimental "dither" which does a half-assed Floyd-Steinberg
dithering, horizontally only, and frankly is not an improvement unless
you squint really hard.

In all cases, the image will automatically be resized to fit in the
terminal, as well as converted to sRGB so it looks kinda ok.

Along the way, I added a new ImageOutput::supports("procedural")
query.  If the existing input supports("procedural") query says
whether the input image is being generated procedurally and doesn't
correspond to an existing file on disk being ead, then the output
supports("procedural") is the opposite -- is the output doing
something procedural that does not correspond to a file being written.
(The specific use is to use this to avoid oiiotool attempting to
rename the file to move it into its final position.)

Signed-off-by: Larry Gritz <lg@larrygritz.com>
