### PR TITLE
oiiotool: Fix --eraseattrib not applying to all subimages

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -911,9 +911,12 @@ erase_attribute(int argc, const char* argv[])
         ot.warning(argv[0], "no current image available to modify");
         return 0;
     }
+    string_view command = ot.express(argv[0]);
+    auto options        = ot.extract_options(command);
+    bool allsubimages   = options.get_int("allsubimages", ot.allsubimages);
     string_view pattern = ot.express(argv[1]);
     return apply_spec_mod(*ot.curimg, do_erase_attribute, pattern,
-                          ot.allsubimages);
+                          allsubimages);
 }
 
 

--- a/testsuite/oiiotool-attribs/ref/out.txt
+++ b/testsuite/oiiotool-attribs/ref/out.txt
@@ -53,3 +53,59 @@ noattribs.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     Exif:FlashPixVersion: "0100"
     jpeg:subsampling: "4:2:0"
     oiio:ColorSpace: "sRGB"
+Reading attrib2.exr
+attrib2.exr          :   64 x   64, 3 channel, half openexr
+    2 subimages: 64x64 [h,h,h], 64x64 [h,h,h]
+ subimage  0:   64 x   64, 3 channel, half openexr
+    SHA-1: EBDD38B69CD5B9F2D00D273C981E16960FBBB4F7
+    channel list: R, G, B
+    compression: "zip"
+    foo: "bar"
+    name: "subimage00"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimagename: "subimage00"
+    oiio:subimages: 2
+    openexr:chunkCount: 4
+ subimage  1:   64 x   64, 3 channel, half openexr
+    SHA-1: EBDD38B69CD5B9F2D00D273C981E16960FBBB4F7
+    channel list: R, G, B
+    compression: "zip"
+    foo: "bar"
+    name: "subimage01"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimagename: "subimage01"
+    oiio:subimages: 2
+    openexr:chunkCount: 4
+Reading attrib0.exr
+attrib0.exr          :   64 x   64, 3 channel, half openexr
+    2 subimages: 64x64 [h,h,h], 64x64 [h,h,h]
+ subimage  0:   64 x   64, 3 channel, half openexr
+    SHA-1: EBDD38B69CD5B9F2D00D273C981E16960FBBB4F7
+    channel list: R, G, B
+    compression: "zip"
+    name: "subimage00"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimagename: "subimage00"
+    oiio:subimages: 2
+    openexr:chunkCount: 4
+ subimage  1:   64 x   64, 3 channel, half openexr
+    SHA-1: EBDD38B69CD5B9F2D00D273C981E16960FBBB4F7
+    channel list: R, G, B
+    compression: "zip"
+    name: "subimage01"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "Linear"
+    oiio:subimagename: "subimage01"
+    oiio:subimages: 2
+    openexr:chunkCount: 4

--- a/testsuite/oiiotool-attribs/run.py
+++ b/testsuite/oiiotool-attribs/run.py
@@ -18,4 +18,10 @@ command += info_command ("nogps.jpg", safematch=True)
 command += oiiotool (OIIO_TESTSUITE_IMAGEDIR+"/tahoe-gps.jpg --eraseattrib \".*\" -o noattribs.jpg")
 command += info_command ("noattribs.jpg", safematch=True)
 
-
+# Test adding and erasing attribs to multiple subimages
+command += oiiotool ("--create 64x64 3 -dup --siappend " +
+                     "--attrib:allsubimages=1 foo bar -d half -o attrib2.exr")
+command += info_command ("attrib2.exr", safematch=True)
+command += oiiotool ("attrib2.exr " +
+                     "--eraseattrib:allsubimages=1 foo -d half -o attrib0.exr")
+command += info_command ("attrib0.exr", safematch=True)


### PR DESCRIPTION
Either -a or optional modifier :allsubimages=1 ought to have erased
an attribute from all subimages, but it was erased from only the first.

Add a test to verify that --attrib and --eraseattrib both apply
correctly to all subimages when requested.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
