### PR TITLE
Re-enable travis and include an arm64 (aka aarch64) build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ addons:
    sources: &add-sources
       - ubuntu-toolchain-r-test
    packages: &common-packages
+      - libilmbase-dev
+      - libopenexr-dev
+      - libopencolorio-dev
       - libgif-dev
       - libopenjpeg-dev
       - libwebp-dev
@@ -60,11 +63,11 @@ before_install:
     - if [ "$CXX" == "g++" ]; then export CXX="g++-${WHICHGCC}" ; fi
 
 install:
-    - if [ $TRAVIS_OS_NAME == osx ] ; then source src/build-scripts/install_homebrew_deps.bash ; fi
-    - if [ "$BUILD_CMAKE" == "1" ] ; then source src/build-scripts/build_cmake.bash ; fi
-    - if [ $TRAVIS_OS_NAME == linux ] ; then CXX="ccache $CXX" source src/build-scripts/build_openexr.bash ; fi
-    - if [ $TRAVIS_OS_NAME == linux ] ; then CXX="ccache $CXX" source src/build-scripts/build_ocio.bash ; fi
-    - if [ $TRAVIS_OS_NAME == linux ] ; then source src/build-scripts/build_pybind11.bash ; fi
+    - if [[ $TRAVIS_OS_NAME == osx ]] ; then source src/build-scripts/install_homebrew_deps.bash ; fi
+    - if [[ "$BUILD_CMAKE" == "1" ]] ; then source src/build-scripts/build_cmake.bash ; fi
+    - if [[ "$OPENEXR_VERSION" || "$OPENEXR_BRANCH" ]] ; then CXX="ccache $CXX" source src/build-scripts/build_openexr.bash ; fi
+    - if [[ "$OCIO_VERSION" || "$OCIO_BRANCH" ]] ; then CXX="ccache $CXX" source src/build-scripts/build_ocio.bash ; fi
+    - if [[ $TRAVIS_OS_NAME == linux ]] ; then source src/build-scripts/build_pybind11.bash ; fi
     - src/build-scripts/install_test_images.bash
 
 # before_script:
@@ -82,34 +85,36 @@ branches:
     - /RB-/
     - /lg-/
 
-matrix:
+jobs:
     fast_finish: true
+    allow_failures:
+      - name: "Linux ARM64"
     include:
     # test default compile: C++11, optimized, default compilers, SSE2
-      - name: "VFX Platform 2017 (gcc48, py27, exr2.2)"
-        os: linux
-        dist: trusty
-        compiler: gcc
-        env: WHICHGCC=4.8 OPENEXR_BRANCH=v2.2.0 BUILD_CMAKE=1
-        addons:
-          apt:
-            sources: *add-sources
-            packages:
-              - *common-packages
-              - *old-boost-packages
-              - g++-4.8
+      # - name: "VFX Platform 2017 (gcc48, py27, exr2.2)"
+      #   os: linux
+      #   dist: trusty
+      #   compiler: gcc
+      #   env: WHICHGCC=4.8 OPENEXR_BRANCH=v2.2.0 BUILD_CMAKE=1
+      #   addons:
+      #     apt:
+      #       sources: *add-sources
+      #       packages:
+      #         - *common-packages
+      #         - *old-boost-packages
+      #         - g++-4.8
 
-      - name: "Mac (latest clang, py37)"
-        os: osx
-        compiler: clang
-        env: PYTHON_VERSION=3.7
+      # - name: "Mac (latest clang, py37)"
+      #   os: osx
+      #   compiler: clang
+      #   env: PYTHON_VERSION=3.7
     # Make sure Python 2.7 still works on OSX, but only for PRs, master/RB
     # pushes, or if the branch name includes "python".
-      - name: "Mac py27 (latest clang)"
-        os: osx
-        compiler: clang
-        env: PYTHON_VERSION=2.7
-        # if: branch =~ /(master|RB|travis|python)/ OR type = pull_request
+      # - name: "Mac py27 (latest clang)"
+      #   os: osx
+      #   compiler: clang
+      #   env: PYTHON_VERSION=2.7
+      #   # if: branch =~ /(master|RB|travis|python)/ OR type = pull_request
 
     # One more, just for the heck of it, turn all SIMD off, and also make
     # sure we're falling back on libjpeg, not jpeg-turbo, no OCIO support,
@@ -119,19 +124,56 @@ matrix:
     # Only build this case for PRs, direct pushes to master or RB branches,
     # or if the branch name includes "simd". Other ordinary work branch
     # pushes don't need to run this.
-      - name: "Oldest everything: gcc4.8, boost 1.55, no simd, no jpegturbo, no OCIO, dso plugins, exr2.2"
+      # - name: "Oldest everything: gcc4.8, boost 1.55, no simd, no jpegturbo, no OCIO, dso plugins, exr2.2"
+      #   os: linux
+      #   dist: trusty
+      #   compiler: gcc
+      #   env: WHICHGCC=4.8 USE_SIMD=0 USE_JPEGTURBO=0 USE_OPENCOLORIO=0 EMBEDPLUGINS=0 OPENEXR_BRANCH=v2.2.0 BUILD_CMAKE=1
+      #   # if: branch =~ /(master|RB|travis|simd)/ OR type = pull_request
+      #   addons:
+      #     apt:
+      #       sources: *add-sources
+      #       packages:
+      #         - *common-packages
+      #         - *old-boost-packages
+      #         - g++-4.8
+
+    # test ARM64 architecture
+      - name: "Linux ARM64"
         os: linux
-        dist: trusty
+        arch: arm64
+        dist: bionic
         compiler: gcc
-        env: WHICHGCC=4.8 USE_SIMD=0 USE_JPEGTURBO=0 USE_OPENCOLORIO=0 EMBEDPLUGINS=0 OPENEXR_BRANCH=v2.2.0 BUILD_CMAKE=1
-        # if: branch =~ /(master|RB|travis|simd)/ OR type = pull_request
+        env: WHICHGCC=7 BUILD_CMAKE=1
         addons:
           apt:
-            sources: *add-sources
+            #sources: *add-sources
             packages:
-              - *common-packages
-              - *old-boost-packages
-              - g++-4.8
+              - libuv1
+              - rhash
+              - libstdc++6
+              - libboost-all-dev
+              - libtiff-dev
+              - libilmbase-dev
+              - libopenexr-dev
+              - libjpeg-turbo8-dev
+              - libgif-dev
+              - libopencolorio-dev
+              #- libopenjpeg-dev
+              - libwebp-dev
+              - libheif-dev
+              #- libfreetype6-dev
+              #- libjpeg-turbo8-dev
+              - libdcmtk-dev
+              #- locales
+              #- python-numpy
+              - libraw-dev
+              - ninja-build
+              - python3
+              - libpython3-dev
+              - libopenvdb-dev
+              - libsquish-dev
+              - qt5-default
 
     # Static analysis: build with clang-tidy.
     # Disabled -- this takes so long to run, it can't complete in Travis's

--- a/src/build-scripts/build_cmake.bash
+++ b/src/build-scripts/build_cmake.bash
@@ -12,10 +12,25 @@ CMAKE_VERSION=${CMAKE_VERSION:=3.12.4}
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}
 CMAKE_INSTALL_DIR=${CMAKE_INSTALL_DIR:=${LOCAL_DEPS_DIR}/cmake}
 
-if [[ `uname` == "Linux" ]] ; then
-    mkdir -p ${CMAKE_INSTALL_DIR} && true
+if [[ `uname` == "Linux" && `uname -m` == "x86_64" ]] ; then
+    mkdir -p ${CMAKE_INSTALL_DIR} || true
     curl --location "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh" -o "cmake.sh"
     sh cmake.sh --skip-license --prefix=${CMAKE_INSTALL_DIR}
     export PATH=${CMAKE_INSTALL_DIR}/bin:$PATH
 fi
 
+if [[ `uname` == "Linux" && `uname -m` == "aarch64" ]] ; then
+    mkdir -p ${CMAKE_INSTALL_DIR} || true
+    curl --location https://anaconda.org/conda-forge/cmake/3.17.0/download/linux-aarch64/cmake-3.17.0-h28c56e5_0.tar.bz2 -o cmake-3.17.0-h28c56e5_0.tar.bz2
+    tar -xjvf cmake-3.17.0-h28c56e5_0.tar.bz2 -C ${CMAKE_INSTALL_DIR}
+    export PATH=${CMAKE_INSTALL_DIR}/bin:$PATH
+
+    # In case we ever need to build from scratch:
+    # curl --location "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz" -o cmake.tar.gz
+    # tar xzf cmake.tar.gz
+    # pushd cmake-${CMAKE_VERSION}
+    # CXX="ccache $CXX" ./bootstrap --parallel=${PARALLEL:=4} --enable-ccache
+    # CXX="ccache $CXX" timeout 2100 time make ${PAR_MAKEFAGS} || true
+    # export PATH=${CMAKE_INSTALL_DIR}/bin:$PWD/bin:$PATH
+    # popd
+fi

--- a/src/build-scripts/ci-build-and-test.bash
+++ b/src/build-scripts/ci-build-and-test.bash
@@ -35,7 +35,10 @@ cmake ../.. -G "$CMAKE_GENERATOR" \
         -DCMAKE_INSTALL_LIBDIR="$OpenImageIO_ROOT/lib" \
         -DCMAKE_CXX_STANDARD="$CMAKE_CXX_STANDARD" \
         $MY_CMAKE_FLAGS -DVERBOSE=1
-time cmake --build . --target ${BUILDTARGET:=install} --config ${CMAKE_BUILD_TYPE}
+if [[ "$BUILDTARGET" != "none" ]] ; then
+    echo "Parallel build " ${CMAKE_BUILD_PARALLEL_LEVEL}
+    time cmake --build . --target ${BUILDTARGET:=install} --config ${CMAKE_BUILD_TYPE}
+fi
 popd
 #make $MAKEFLAGS VERBOSE=1 $BUILD_FLAGS config
 #make $MAKEFLAGS $PAR_MAKEFLAGS $BUILD_FLAGS $BUILDTARGET
@@ -43,9 +46,10 @@ popd
 #echo "OpenImageIO_ROOT $OpenImageIO_ROOT"
 #ls -R -l "$OpenImageIO_ROOT"
 
-if [[ "$SKIP_TESTS" == "" ]] ; then
-    $OpenImageIO_ROOT/bin/oiiotool --help
+if [[ "${SKIP_TESTS:=0}" == "0" ]] ; then
+    $OpenImageIO_ROOT/bin/oiiotool --help || true
     TESTSUITE_CLEANUP_ON_SUCCESS=1
+    echo "Parallel test " ${CTEST_PARALLEL_LEVEL}
     make $BUILD_FLAGS test
 fi
 

--- a/src/build-scripts/ci-startup.bash
+++ b/src/build-scripts/ci-startup.bash
@@ -7,12 +7,14 @@
 # Figure out the platform
 if [[ $TRAVIS_OS_NAME == osx || $RUNNER_OS == macOS ]] ; then
       export ARCH=macosx
-fi
-if [[ $TRAVIS_OS_NAME == linux || $RUNNER_OS == Linux || $CIRCLECI == true ]] ; then
+elif [[ `uname -m` == aarch64 ]] ; then
+    export ARCH=aarch64
+elif [[ $TRAVIS_OS_NAME == linux || $RUNNER_OS == Linux || $CIRCLECI == true ]] ; then
       export ARCH=linux64
-fi
-if [[ $RUNNER_OS == Windows ]] ; then
+elif [[ $RUNNER_OS == Windows ]] ; then
       export ARCH=windows64
+else
+    export ARCH=unknown
 fi
 export PLATFORM=$ARCH
 
@@ -45,7 +47,9 @@ export CMAKE_GENERATOR=${CMAKE_GENERATOR:=Ninja}
 export CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:=Release}
 export CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD:=11}
 
-if [[ $TRAVIS == true ]] ; then
+if [[ $TRAVIS == true && "$ARCH" == aarch64 ]] ; then
+    export PARALLEL=4
+elif [[ $TRAVIS == true ]] ; then
     export PARALLEL=2
 elif [[ $CIRCLECI == true ]] ; then
     export PARALLEL=4
@@ -54,21 +58,23 @@ elif [[ $GITHUB_ACTIONS == true ]] ; then
 fi
 export PARALLEL=${PARALLEL:=4}
 export PAR_MAKEFLAGS=-j${PARALLEL}
-export CMAKE_BUILD_PARALLEL_LEVEL=${PARALLEL}
-export CTEST_PARALLEL_LEVEL=${PARALLEL}
+export CMAKE_BUILD_PARALLEL_LEVEL=${CMAKE_BUILD_PARALLEL_LEVEL:=${PARALLEL}}
+export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:=${PARALLEL}}
 
 export LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=$HOME/ext}
 export PATH=${LOCAL_DEPS_DIR}/bin:$PATH
 export LD_LIBRARY_PATH=${LOCAL_DEPS_DIR}/lib:$LD_LIBRARY_PATH
 export DYLD_LIBRARY_PATH=${LOCAL_DEPS_DIR}/lib:$DYLD_LIBRARY_PATH
 
-uname -a
-uname -n
+echo "uname -a: " `uname -a`
+echo "uname -m: " `uname -m`
+echo "uname -s: " `uname -s`
+echo "uname -n: " `uname -n`
 pwd
 ls
 env | sort
 
-if [[ $ARCH == linux64 ]] ; then
+if [[ `uname -s` == "Linux" ]] ; then
     head -40 /proc/cpuinfo
 elif [[ $ARCH == macosx ]] ; then
     sysctl machdep.cpu.features

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -78,7 +78,10 @@ fi
 src/build-scripts/install_test_images.bash
 
 CXX="ccache $CXX" source src/build-scripts/build_pybind11.bash
-CXX="ccache $CXX" source src/build-scripts/build_openexr.bash
+
+if [[ "$OPENEXR_BRANCH" || "$OPENEXR_VERSION" ]] ; then
+    CXX="ccache $CXX" source src/build-scripts/build_openexr.bash
+fi
 
 if [[ "$LIBTIFF_BRANCH" || "$LIBTIFF_VERSION" ]] ; then
     CXX="ccache $CXX" source src/build-scripts/build_libtiff.bash

--- a/src/make/detectplatform.mk
+++ b/src/make/detectplatform.mk
@@ -25,7 +25,9 @@ ifneq (${hw},x86)
   ifneq (${hw},x86_64)
     ifneq (${hw},i386)
       ifneq (${hw},i686)
-        $(error "ERROR: Unknown hardware architecture")
+        ifneq (${hw},aarch64)
+          $(error "ERROR: Unknown hardware architecture")
+        endif
       endif
     endif
   endif
@@ -43,6 +45,9 @@ ifeq (${platform},unknown)
     platform := linux
     ifeq (${hw},x86_64)
       platform := linux64
+    endif
+    ifeq (${hw},aarch64)
+      platform := aarch64
     endif
   endif
 


### PR DESCRIPTION
This is a step toward making sure we are habitually testing on ARM64.

It is incomplete at the moment, several individual tests fail and need
to be tracked down, so the test is marked as "allow_failures" so it
will never appear to fail.

Signed-off-by: Larry Gritz <lg@larrygritz.com>