### PR TITLE
Fix build break due to pybind11 master recent change

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -172,6 +172,7 @@ jobs:
           CMAKE_CXX_STANDARD: 17
           USE_SIMD: avx2,f16c
           OPENEXR_BRANCH: v2.5.0
+          PYBIND11_VERSION: 2.5.0
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps.bash

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -368,7 +368,7 @@ C_to_tuple<TypeDesc>(cspan<TypeDesc> vals)
     size_t size = vals.size();
     py::tuple result(size);
     for (size_t i = 0; i < size; ++i)
-        result[i] = py::cast<TypeDesc>(vals[i]);
+        result[i] = py::cast(vals[i]);
     return result;
 }
 


### PR DESCRIPTION
By using the explicit `cast<TypeDesc>()` instead of allowing the
template system to figure it out, we were losing the `const` detection
and making it fail to match templates. It used to work, but a recently
added change in pybind11's master branch caused this to finally fail.

Also change the "latest releases" to use pybind11 2.5. (Only semi-related,
2.5 was fine, it was post-2.5 where we broke.)

Signed-off-by: Larry Gritz <lg@larrygritz.com>
