### PR TITLE
Build against more recent versions of {fmt}

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -32,6 +32,7 @@ jobs:
           CXX: /usr/bin/g++
           CC: /usr/bin/gcc
           CMAKE_CXX_STANDARD: 11
+          MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=6.2.1
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps-centos.bash
@@ -173,6 +174,7 @@ jobs:
           USE_SIMD: avx2,f16c
           OPENEXR_BRANCH: v2.5.0
           PYBIND11_VERSION: 2.5.0
+          MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=7.0.1
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps.bash

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -171,7 +171,7 @@ struct OIIO_API TypeDesc {
     /// "float", "int[5]", "normal"
     const char *c_str() const;
 
-    friend std::ostream& operator<< (std::ostream& o, TypeDesc t) {
+    friend std::ostream& operator<< (std::ostream& o, const TypeDesc& t) {
         o << t.c_str();  return o;
     }
 
@@ -529,3 +529,34 @@ convert_type(TypeDesc srctype, const void* src,
 
 
 OIIO_NAMESPACE_END
+
+
+
+#if OIIO_USE_FMT
+// Supply a fmtlib compatible custom formatter for TypeDesc.
+FMT_BEGIN_NAMESPACE
+template <>
+struct formatter<OIIO::TypeDesc> {
+    // Parses format specification
+    // C++14: constexpr auto parse(format_parse_context& ctx) {
+    auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) // c++11
+    {
+        // Get the presentation type, if any. Required to be 's'.
+        auto it = ctx.begin(), end = ctx.end();
+        if (it != end && (*it == 's')) ++it;
+        // Check if reached the end of the range:
+        if (it != end && *it != '}')
+            throw format_error("invalid format");
+        // Return an iterator past the end of the parsed range:
+        return it;
+    }
+
+    template <typename FormatContext>
+    auto format(const OIIO::TypeDesc& t, FormatContext& ctx) -> decltype(ctx.out()){
+        // C++14:   auto format(const point& p, FormatContext& ctx) {
+        // ctx.out() is an output iterator to write to.
+        return format_to(ctx.out(), "{}", t.c_str());
+    }
+};
+FMT_END_NAMESPACE
+#endif

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -1037,7 +1037,7 @@ ImageSpec::serialize(SerialFormat fmt, SerialVerbose verbose) const
                    depth > 1 ? "volume " : "");
     if (channelformats.size()) {
         for (size_t c = 0; c < channelformats.size(); ++c)
-            out << sprintf("%s%s", c ? "/" : "", channelformats[c]);
+            out << sprintf("%s%s", c ? "/" : "", channelformats[c].c_str());
     } else {
         int bits = get_int_attribute("oiio:BitsPerSample", 0);
         out << extended_format_name(this->format, bits);
@@ -1052,7 +1052,7 @@ ImageSpec::serialize(SerialFormat fmt, SerialVerbose verbose) const
             else
                 out << "unknown";
             if (i < (int)channelformats.size())
-                out << sprintf(" (%s)", channelformats[i]);
+                out << " (" << channelformats[i] << ")";
             if (i < nchannels - 1)
                 out << ", ";
         }

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -293,8 +293,9 @@ ParamValue::get_string(int maxsize) const
                                              "",   ", ", true,     "%u" };
     std::string out                      = tostring(t, data(), fmt);
     if (n < nfull)
-        out += Strutil::sprintf(", ... [%d x %s]", nfull,
-                                TypeDesc(TypeDesc::BASETYPE(type().basetype)));
+        out += Strutil::sprintf(
+            ", ... [%d x %s]", nfull,
+            TypeDesc(TypeDesc::BASETYPE(type().basetype)).c_str());
     return out;
 }
 


### PR DESCRIPTION
fmt is supposed to (if you include fmt/ostream.h) automatically
support any user type that defines an `operator<<()`. And so it did
through version 6.1.2.

Starting with 6.2.x, the presence of `operator bool()` throws it off,
particularly for our TypeDesc, which started rendering as "true" rather
than "uint8" or whatever. It seems that the fact that it can convert
to bool takes precedence, it formats as a bool, rather than notice that
there's a stream ouput option.

In this patch, we add a custom formatter for TypeDesc, which solves
the problem for `format("{}", typedesc)`, but unfortunately not for
`sprintf("%s", typedesc)`. I've filed an issue, but in any case, the
workaround to avoid incorrect formatting when using sprintf is to be
sure to use typedesc.c_str().

Signed-off-by: Larry Gritz <lg@larrygritz.com>

