### PR TITLE
Typo fix -- got 'ImageBuf.writable' name wrong

### DIFF
--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -272,7 +272,7 @@ declare_imagebuf(py::module& m)
             },
             "out"_a)
         .def(
-            "make_writeble",
+            "make_writable",
             [](ImageBuf& self, bool keep_cache_type) {
                 py::gil_scoped_release gil;
                 return self.make_writable(keep_cache_type);


### PR DESCRIPTION
Signed-off-by: Larry Gritz <lg@larrygritz.com>

