### PR TITLE
More gradual fmt conversion

### DIFF
--- a/src/include/OpenImageIO/errorhandler.h
+++ b/src/include/OpenImageIO/errorhandler.h
@@ -144,7 +144,7 @@ public:
     //
     // Formatted output with printf notation. Use these if you specifically
     // want printf-notation, even after format() changes to python notation
-    // for OIIO 2.1.
+    // in some future OIIO release.
     //
     template<typename... Args>
     void infof(const char* format, const Args&... args)
@@ -185,6 +185,52 @@ public:
     {
 #ifndef NDEBUG
         debug(Strutil::sprintf(format, args...));
+#endif
+    }
+
+    //
+    // Formatted output with std::format notation. Use these if you
+    // specifically want std::format-notation, even before format() changes
+    // to the new notation in some future OIIO release.
+    //
+    template<typename... Args>
+    void infofmt(const char* format, const Args&... args)
+    {
+        if (verbosity() >= VERBOSE)
+            info(Strutil::fmt::format(format, args...));
+    }
+
+    template<typename... Args>
+    void warningfmt(const char* format, const Args&... args)
+    {
+        if (verbosity() >= NORMAL)
+            warning(Strutil::fmt::format(format, args...));
+    }
+
+    template<typename... Args>
+    void errorfmt(const char* format, const Args&... args)
+    {
+        error(Strutil::fmt::format(format, args...));
+    }
+
+    template<typename... Args>
+    void severefmt(const char* format, const Args&... args)
+    {
+        severe(Strutil::fmt::format(format, args...));
+    }
+
+    template<typename... Args>
+    void messagefmt(const char* format, const Args&... args)
+    {
+        if (verbosity() > QUIET)
+            message(Strutil::fmt::format(format, args...));
+    }
+
+    template<typename... Args>
+    void debugfmt(const char* format, const Args&... args)
+    {
+#ifndef NDEBUG
+        debug(Strutil::fmt::format(format, args...));
 #endif
     }
 

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -940,7 +940,7 @@ public:
     /// Error reporting for ImageBuf: call this with Python / {fmt} /
     /// std::format style formatting specification.
     template<typename... Args>
-    void fmterror(const char* fmt, const Args&... args) const
+    void errorfmt(const char* fmt, const Args&... args) const
     {
         error(Strutil::fmt::format(fmt, args...));
     }
@@ -960,6 +960,15 @@ public:
     void error(const char* fmt, const Args&... args) const
     {
         error(Strutil::format(fmt, args...));
+    }
+
+    // Error reporting for ImageBuf: call this with Python / {fmt} /
+    // std::format style formatting specification.
+    template<typename... Args>
+    OIIO_DEPRECATED("use `errorfmt` instead")
+    void fmterror(const char* fmt, const Args&... args) const
+    {
+        error(Strutil::fmt::format(fmt, args...));
     }
 
     /// Returns `true` if the ImageBuf has had an error and has an error

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1595,6 +1595,14 @@ public:
     /// Error reporting for the plugin implementation: call this with
     /// fmt::format-like arguments.
     template<typename... Args>
+    void errorfmt(const char* fmt, const Args&... args) const {
+        append_error(Strutil::fmt::format (fmt, args...));
+    }
+
+    // Error reporting for the plugin implementation: call this with
+    // fmt::format-like arguments.
+    template<typename... Args>
+    OIIO_DEPRECATED("use `errorfmt` instead")
     void fmterror(const char* fmt, const Args&... args) const {
         append_error(Strutil::fmt::format (fmt, args...));
     }
@@ -2208,6 +2216,14 @@ public:
     /// Error reporting for the plugin implementation: call this with
     /// fmt::format-like arguments.
     template<typename... Args>
+    void errorfmt(const char* fmt, const Args&... args) const {
+        append_error(Strutil::fmt::format (fmt, args...));
+    }
+
+    // Error reporting for the plugin implementation: call this with
+    // fmt::format-like arguments.
+    template<typename... Args>
+    OIIO_DEPRECATED("use `errorfmt` instead")
     void fmterror(const char* fmt, const Args&... args) const {
         append_error(Strutil::fmt::format (fmt, args...));
     }
@@ -2722,8 +2738,16 @@ typedef bool (*wrap_impl) (int &coord, int origin, int width);
 /// output to stderr for debugging statements.
 OIIO_API void debug (string_view str);
 
-/// debug output with `fmt`/`std::format` conventions.
+/// debug output with `std::format` conventions.
 template<typename T1, typename... Args>
+void debugfmt (const char* fmt, const T1& v1, const Args&... args)
+{
+    debug (Strutil::fmt::format(fmt, v1, args...));
+}
+
+// (Unfortunate old synonym)
+template<typename T1, typename... Args>
+OIIO_DEPRECATED("use `debugfmt` instead")
 void fmtdebug (const char* fmt, const T1& v1, const Args&... args)
 {
     debug (Strutil::fmt::format(fmt, v1, args...));

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -236,6 +236,7 @@ std::string OIIO_API vsprintf (const char *fmt, va_list ap)
 /// Return a std::string formatted like Strutil::format, but passed
 /// already as a va_list.  This is not guaranteed type-safe and is not
 /// extensible like format(). Use with caution!
+OIIO_DEPRECATED("use `vsprintf` instead")
 std::string OIIO_API vformat (const char *fmt, va_list ap)
                                          OPENIMAGEIO_PRINTF_ARGS(1,0);
 

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -489,6 +489,9 @@ struct tostring_formatting {
     const char *uint_fmt = "%u";
     const char *reserved2 = "";
     const char *reserved3 = "";
+    bool use_sprintf = true;
+
+    enum Notation { STDFORMAT };
 
     tostring_formatting() = default;
     tostring_formatting(const char *int_fmt, const char *float_fmt = "%g",
@@ -498,12 +501,24 @@ struct tostring_formatting {
         const char *array_end = "}", const char *array_sep = ",",
         int flags = escape_strings,
         const char *uint_fmt = "%u");
+
+    // Alternative ctr for std::format notation. You must pass STDFORMAT
+    // as the first argument.
+    tostring_formatting(Notation notation,
+        const char *int_fmt = "{}", const char *uint_fmt = "{}",
+        const char *float_fmt = "{}",
+        const char *string_fmt = "\"{}\"", const char *ptr_fmt = "{}",
+        const char *aggregate_begin = "(", const char *aggregate_end = ")",
+        const char *aggregate_sep = ",", const char *array_begin = "{",
+        const char *array_end = "}", const char *array_sep = ",",
+        int flags = escape_strings);
 };
 
 
 
 /// Return a string containing the data values formatted according
-/// to the type and the optional formatting control arguments.
+/// to the type and the optional formatting control arguments. Will be
+/// deprecated someday as printf formatting falls out of favor.
 OIIO_API std::string
 tostring(TypeDesc type, const void* data, const tostring_formatting& fmt = {});
 

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -108,7 +108,7 @@ public:
     template<typename... Args>
     void error(const char* fmt, const Args&... args) const
     {
-        error(Strutil::sprintf(fmt, args...));
+        error(Strutil::fmt::format(fmt, args...));
     }
 
     template<typename... Args>
@@ -932,12 +932,12 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
         auto input = ImageInput::open(m_name.string(), m_configspec.get(),
                                       m_rioproxy);
         if (!input) {
-            errorf("%s", OIIO::geterror());
+            error("{}", OIIO::geterror());
             return false;
         }
         input->threads(threads());  // Pass on our thread policy
         if (!input->read_native_deep_image(subimage, miplevel, m_deepdata)) {
-            errorf("%s", input->geterror());
+            error("{}", input->geterror());
             return false;
         }
         m_spec         = m_nativespec;  // Deep images always use native data
@@ -1044,11 +1044,11 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
                 m_pixels_valid = true;
             } else {
                 m_pixels_valid = false;
-                errorf("%s", in->geterror());
+                error("{}", in->geterror());
             }
         } else {
             m_pixels_valid = false;
-            errorf("%s", OIIO::geterror());
+            error("{}", OIIO::geterror());
         }
         return m_pixels_valid;
     }
@@ -1063,7 +1063,7 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
         m_pixels_valid = true;
     } else {
         m_pixels_valid = false;
-        errorf("%s", m_imagecache->geterror());
+        error("{}", m_imagecache->geterror());
     }
 
     return m_pixels_valid;
@@ -1218,7 +1218,7 @@ ImageBuf::write(ImageOutput* out, ProgressCallback progress_callback,
         }
     }
     if (!ok)
-        errorf("%s", out->geterror());
+        error("{}", out->geterror());
     return ok;
 }
 
@@ -1263,7 +1263,7 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
 
     auto out = ImageOutput::create(fileformat);
     if (!out) {
-        errorf("%s", geterror());
+        error("{}", geterror());
         return false;
     }
     out->threads(threads());  // Pass on our thread policy
@@ -1315,7 +1315,7 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
     }
 
     if (!out->open(filename.c_str(), newspec)) {
-        errorf("%s", out->geterror());
+        error("{}", out->geterror());
         return false;
     }
     if (!write(out.get(), progress_callback, progress_callback_data))

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -351,8 +351,8 @@ TextureSystemImpl::environment(TextureHandle* texture_handle_,
         int s = m_imagecache->subimage_from_name(texturefile,
                                                  options.subimagename);
         if (s < 0) {
-            errorf("Unknown subimage \"%s\" in texture \"%s\"",
-                   options.subimagename, texturefile->filename());
+            error("Unknown subimage \"{}\" in texture \"{}\"",
+                  options.subimagename, texturefile->filename());
             return missing_texture(options, nchannels, result, dresultds,
                                    dresultdt);
         }
@@ -360,8 +360,8 @@ TextureSystemImpl::environment(TextureHandle* texture_handle_,
         options.subimagename.clear();
     }
     if (options.subimage < 0 || options.subimage >= texturefile->subimages()) {
-        errorf("Unknown subimage \"%s\" in texture \"%s\"",
-               options.subimagename, texturefile->filename());
+        error("Unknown subimage \"{}\" in texture \"{}\"", options.subimagename,
+              texturefile->filename());
         return missing_texture(options, nchannels, result, dresultds,
                                dresultdt);
     }

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -1021,6 +1021,12 @@ public:
     {
         append_error(Strutil::sprintf(fmt, args...));
     }
+    /// Internal error reporting routine, with std::format-like arguments.
+    template<typename... Args>
+    void error(const char* fmt, const Args&... args) const
+    {
+        append_error(Strutil::fmt::format(fmt, args...));
+    }
     void error(const char* msg) const { append_error(msg); }
 
     /// Append a string to the current error message

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -139,8 +139,8 @@ TextureSystemImpl::texture3d(TextureHandle* texture_handle_,
         int s = m_imagecache->subimage_from_name(texturefile,
                                                  options.subimagename);
         if (s < 0) {
-            errorf("Unknown subimage \"%s\" in texture \"%s\"",
-                   options.subimagename, texturefile->filename());
+            error("Unknown subimage \"{}\" in texture \"{}\"",
+                  options.subimagename, texturefile->filename());
             return missing_texture(options, nchannels, result, dresultds,
                                    dresultdt, dresultdr);
         }
@@ -148,8 +148,8 @@ TextureSystemImpl::texture3d(TextureHandle* texture_handle_,
         options.subimagename.clear();
     }
     if (options.subimage < 0 || options.subimage >= texturefile->subimages()) {
-        errorf("Unknown subimage \"%s\" in texture \"%s\"",
-               options.subimagename, texturefile->filename());
+        error("Unknown subimage \"{}\" in texture \"{}\"", options.subimagename,
+              texturefile->filename());
         return missing_texture(options, nchannels, result, dresultds, dresultdt,
                                dresultdr);
     }
@@ -370,7 +370,7 @@ TextureSystemImpl::accum3d_sample_closest(
               ttex - tile_t, rtex - tile_r, tile_chbegin, tile_chend);
     bool ok = find_tile(id, thread_info, true);
     if (!ok)
-        errorf("%s", m_imagecache->geterror());
+        error("{}", m_imagecache->geterror());
     TileRef& tile(thread_info->tile);
     if (!tile || !ok)
         return false;
@@ -518,7 +518,7 @@ TextureSystemImpl::accum3d_sample_bilinear(
         id.xyz(stex[0] - tile_s, ttex[0] - tile_t, rtex[0] - tile_r);
         bool ok = find_tile(id, thread_info, true);
         if (!ok)
-            errorf("%s", m_imagecache->geterror());
+            error("{}", m_imagecache->geterror());
         TileRef& tile(thread_info->tile);
         if (!tile->valid())
             return false;
@@ -555,7 +555,7 @@ TextureSystemImpl::accum3d_sample_bilinear(
                            rtex[k] - tile_r);
                     bool ok = find_tile(id, thread_info, firstsample);
                     if (!ok)
-                        errorf("%s", m_imagecache->geterror());
+                        error("{}", m_imagecache->geterror());
                     firstsample = false;
                     TileRef& tile(thread_info->tile);
                     if (!tile->valid())

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -542,6 +542,12 @@ private:
     {
         append_error(Strutil::sprintf(fmt, args...));
     }
+    /// Internal error reporting routine, with std::format-like arguments.
+    template<typename... Args>
+    void error(const char* fmt, const Args&... args) const
+    {
+        append_error(Strutil::fmt::format(fmt, args...));
+    }
 
     /// Append a string to the current error message
     void append_error(const std::string& message) const;

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -545,7 +545,7 @@ TextureSystemImpl::get_texture_info(ustring filename, int subimage,
     if (!ok) {
         std::string err = m_imagecache->geterror();
         if (!err.empty())
-            errorf("%s", err);
+            error("{}", err);
     }
     return ok;
 }
@@ -565,7 +565,7 @@ TextureSystemImpl::get_texture_info(TextureHandle* texture_handle,
     if (!ok) {
         std::string err = m_imagecache->geterror();
         if (!err.empty())
-            errorf("%s", err);
+            error("{}", err);
     }
     return ok;
 }
@@ -580,7 +580,7 @@ TextureSystemImpl::get_imagespec(ustring filename, int subimage,
     if (!ok) {
         std::string err = m_imagecache->geterror();
         if (!err.empty())
-            errorf("%s", err);
+            error("{}", err);
     }
     return ok;
 }
@@ -599,7 +599,7 @@ TextureSystemImpl::get_imagespec(TextureHandle* texture_handle,
     if (!ok) {
         std::string err = m_imagecache->geterror();
         if (!err.empty())
-            errorf("%s", err);
+            error("{}", err);
     }
     return ok;
 }
@@ -611,7 +611,7 @@ TextureSystemImpl::imagespec(ustring filename, int subimage)
 {
     const ImageSpec* spec = m_imagecache->imagespec(filename, subimage);
     if (!spec)
-        errorf("%s", m_imagecache->geterror());
+        error("{}", m_imagecache->geterror());
     return spec;
 }
 
@@ -628,7 +628,7 @@ TextureSystemImpl::imagespec(TextureHandle* texture_handle,
     if (!spec) {
         std::string err = m_imagecache->geterror();
         if (!err.empty())
-            errorf("%s", err);
+            error("{}", err);
     }
     return spec;
 }
@@ -644,7 +644,7 @@ TextureSystemImpl::get_texels(ustring filename, TextureOpt& options,
     PerThreadInfo* thread_info = m_imagecache->get_perthread_info();
     TextureFile* texfile       = find_texturefile(filename, thread_info);
     if (!texfile) {
-        errorf("Texture file \"%s\" not found", filename);
+        error("Texture file \"{}\" not found", filename);
         return false;
     }
     return get_texels((TextureHandle*)texfile, (Perthread*)thread_info, options,
@@ -666,25 +666,25 @@ TextureSystemImpl::get_texels(TextureHandle* texture_handle_,
     TextureFile* texfile = verify_texturefile((TextureFile*)texture_handle_,
                                               thread_info);
     if (!texfile) {
-        errorf("Invalid texture handle NULL");
+        error("Invalid texture handle NULL");
         return false;
     }
 
     if (texfile->broken()) {
         if (texfile->errors_should_issue())
-            errorf("Invalid texture file \"%s\"", texfile->filename());
+            error("Invalid texture file \"{}\"", texfile->filename());
         return false;
     }
     int subimage = options.subimage;
     if (subimage < 0 || subimage >= texfile->subimages()) {
-        errorf("get_texel asked for nonexistent subimage %d of \"%s\"",
-               subimage, texfile->filename());
+        error("get_texel asked for nonexistent subimage {} of \"{}\"", subimage,
+              texfile->filename());
         return false;
     }
     if (miplevel < 0 || miplevel >= texfile->miplevels(subimage)) {
         if (texfile->errors_should_issue())
-            errorf("get_texel asked for nonexistent MIP level %d of \"%s\"",
-                   miplevel, texfile->filename());
+            error("get_texel asked for nonexistent MIP level {} of \"{}\"",
+                  miplevel, texfile->filename());
         return false;
     }
     const ImageSpec& spec(texfile->spec(subimage, miplevel));
@@ -754,7 +754,7 @@ TextureSystemImpl::get_texels(TextureHandle* texture_handle_,
     if (!ok) {
         std::string err = m_imagecache->geterror();
         if (!err.empty())
-            errorf("%s", err);
+            error("{}", err);
     }
     return ok;
 }
@@ -1024,8 +1024,8 @@ TextureSystemImpl::texture(TextureHandle* texture_handle_,
         int s = m_imagecache->subimage_from_name(texturefile,
                                                  options.subimagename);
         if (s < 0) {
-            errorf("Unknown subimage \"%s\" in texture \"%s\"",
-                   options.subimagename, texturefile->filename());
+            error("Unknown subimage \"{}\" in texture \"{}\"",
+                  options.subimagename, texturefile->filename());
             return missing_texture(options, nchannels, result, dresultds,
                                    dresultdt);
         }
@@ -1965,7 +1965,7 @@ TextureSystemImpl::sample_closest(
         id.xy(stex - tile_s, ttex - tile_t);
         bool ok = find_tile(id, thread_info, sample == 0);
         if (!ok)
-            errorf("%s", m_imagecache->geterror());
+            error("{}", m_imagecache->geterror());
         TileRef& tile(thread_info->tile);
         if (!tile || !ok) {
             allok = false;
@@ -2150,7 +2150,7 @@ TextureSystemImpl::sample_bilinear(
             id.xy(sttex[S0] - tile_st[S0], sttex[T0] - tile_st[T0]);
             bool ok = find_tile(id, thread_info, sample == 0);
             if (!ok)
-                errorf("%s", m_imagecache->geterror());
+                error("{}", m_imagecache->geterror());
             TileRef& tile(thread_info->tile);
             if (!tile->valid())
                 return false;
@@ -2211,7 +2211,7 @@ TextureSystemImpl::sample_bilinear(
                         id.xy(tile_edge[S0 + i], tile_edge[T0 + j]);
                         bool ok = find_tile(id, thread_info, sample == 0);
                         if (!ok)
-                            errorf("%s", m_imagecache->geterror());
+                            error("{}", m_imagecache->geterror());
                         if (!thread_info->tile->valid()) {
                             return false;
                         }
@@ -2515,7 +2515,7 @@ TextureSystemImpl::sample_bicubic(
             id.xy(stex[0] - tile_s, ttex[0] - tile_t);
             bool ok = find_tile(id, thread_info, sample == 0);
             if (!ok)
-                errorf("%s", m_imagecache->geterror());
+                error("{}", m_imagecache->geterror());
             TileRef& tile(thread_info->tile);
             if (!tile) {
                 return false;
@@ -2585,8 +2585,8 @@ TextureSystemImpl::sample_bicubic(
                         id.xy(tile_s_edge[i], tile_t_edge[j]);
                         bool ok = find_tile(id, thread_info, sample == 0);
                         if (!ok)
-                            errorf("%s", m_imagecache->geterror());
-                        OIIO_DASSERT(thread_info->tile->id() == id);
+                            error("{}", m_imagecache->geterror());
+                        DASSERT(thread_info->tile->id() == id);
                         if (!thread_info->tile->valid())
                             return false;
                     }

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -343,9 +343,9 @@ tostring_formatting::tostring_formatting(
 
 
 template<class T>
-inline std::string
-sprintt(TypeDesc type, const char* format, const tostring_formatting& fmt,
-        const T* v)
+static std::string
+sprint_type(TypeDesc type, const char* format, const tostring_formatting& fmt,
+            const T* v)
 {
     std::string val;
     if (type.arraylen)
@@ -371,9 +371,9 @@ sprintt(TypeDesc type, const char* format, const tostring_formatting& fmt,
 
 
 
-inline std::string
-sprintt(TypeDesc type, const char* format, const tostring_formatting& fmt,
-        const char** v)
+static std::string
+sprint_type(TypeDesc type, const char* format, const tostring_formatting& fmt,
+            const char** v)
 {
     std::string val;
     if (type.arraylen)
@@ -404,9 +404,9 @@ sprintt(TypeDesc type, const char* format, const tostring_formatting& fmt,
 
 
 template<class T>
-inline std::string
-formatt(TypeDesc type, const char* format, const tostring_formatting& fmt,
-        const T* v)
+static std::string
+format_type(TypeDesc type, const char* format, const tostring_formatting& fmt,
+            const T* v)
 {
     std::string val;
     if (type.arraylen)
@@ -432,9 +432,9 @@ formatt(TypeDesc type, const char* format, const tostring_formatting& fmt,
 
 
 
-inline std::string
-formatt(TypeDesc type, const char* format, const tostring_formatting& fmt,
-        const char** v)
+static std::string
+format_type(TypeDesc type, const char* format, const tostring_formatting& fmt,
+            const char** v)
 {
     std::string val;
     if (type.arraylen)
@@ -490,29 +490,32 @@ tostring(TypeDesc type, const void* data, const tostring_formatting& fmt)
     // Perhaps there is a way to use CType<> with a dynamic argument?
     switch (type.basetype) {
     case TypeDesc::UNKNOWN:
-        return fmt.use_sprintf ? sprintt(type, fmt.ptr_fmt, fmt, (void**)data)
-                               : formatt(type, fmt.ptr_fmt, fmt, (void**)data);
+        return fmt.use_sprintf
+                   ? sprint_type(type, fmt.ptr_fmt, fmt, (void**)data)
+                   : format_type(type, fmt.ptr_fmt, fmt, (void**)data);
     case TypeDesc::NONE:
-        return fmt.use_sprintf ? sprintt(type, "None", fmt, (void**)data)
-                               : formatt(type, "None", fmt, (void**)data);
+        return fmt.use_sprintf ? sprint_type(type, "None", fmt, (void**)data)
+                               : format_type(type, "None", fmt, (void**)data);
     case TypeDesc::UCHAR:
         return fmt.use_sprintf
-                   ? sprintt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
-                             (unsigned char*)data)
-                   : formatt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
-                             (unsigned char*)data);
+                   ? sprint_type(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
+                                 (unsigned char*)data)
+                   : format_type(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
+                                 (unsigned char*)data);
     case TypeDesc::CHAR:
-        return fmt.use_sprintf ? sprintt(type, fmt.int_fmt, fmt, (char*)data)
-                               : formatt(type, fmt.int_fmt, fmt, (char*)data);
+        return fmt.use_sprintf
+                   ? sprint_type(type, fmt.int_fmt, fmt, (char*)data)
+                   : format_type(type, fmt.int_fmt, fmt, (char*)data);
     case TypeDesc::USHORT:
         return fmt.use_sprintf
-                   ? sprintt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
-                             (uint16_t*)data)
-                   : formatt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
-                             (uint16_t*)data);
+                   ? sprint_type(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
+                                 (uint16_t*)data)
+                   : format_type(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
+                                 (uint16_t*)data);
     case TypeDesc::SHORT:
-        return fmt.use_sprintf ? sprintt(type, fmt.int_fmt, fmt, (short*)data)
-                               : formatt(type, fmt.int_fmt, fmt, (short*)data);
+        return fmt.use_sprintf
+                   ? sprint_type(type, fmt.int_fmt, fmt, (short*)data)
+                   : format_type(type, fmt.int_fmt, fmt, (short*)data);
     case TypeDesc::UINT:
         if (type.vecsemantics == TypeDesc::RATIONAL
             && type.aggregate == TypeDesc::VEC2) {
@@ -536,10 +539,10 @@ tostring(TypeDesc type, const void* data, const tostring_formatting& fmt)
                                     seconds, frame);
         }
         return fmt.use_sprintf
-                   ? sprintt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
-                             (unsigned int*)data)
-                   : formatt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
-                             (unsigned int*)data);
+                   ? sprint_type(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
+                                 (unsigned int*)data)
+                   : format_type(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
+                                 (unsigned int*)data);
     case TypeDesc::INT:
         if (type.elementtype() == TypeRational) {
             std::string out;
@@ -551,40 +554,42 @@ tostring(TypeDesc type, const void* data, const tostring_formatting& fmt)
             }
             return out;
         }
-        return fmt.use_sprintf ? sprintt(type, fmt.int_fmt, fmt, (int*)data)
-                               : formatt(type, fmt.int_fmt, fmt, (int*)data);
+        return fmt.use_sprintf
+                   ? sprint_type(type, fmt.int_fmt, fmt, (int*)data)
+                   : format_type(type, fmt.int_fmt, fmt, (int*)data);
     case TypeDesc::UINT64:
         return fmt.use_sprintf
-                   ? sprintt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
-                             (const uint64_t*)data)
-                   : formatt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
-                             (const uint64_t*)data);
+                   ? sprint_type(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
+                                 (const uint64_t*)data)
+                   : format_type(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
+                                 (const uint64_t*)data);
     case TypeDesc::INT64:
         return fmt.use_sprintf
-                   ? sprintt(type, fmt.int_fmt, fmt, (const int64_t*)data)
-                   : formatt(type, fmt.int_fmt, fmt, (const int64_t*)data);
+                   ? sprint_type(type, fmt.int_fmt, fmt, (const int64_t*)data)
+                   : format_type(type, fmt.int_fmt, fmt, (const int64_t*)data);
     case TypeDesc::HALF:
         return fmt.use_sprintf
-                   ? sprintt(type, fmt.float_fmt, fmt, (const half*)data)
-                   : formatt(type, fmt.float_fmt, fmt, (const half*)data);
+                   ? sprint_type(type, fmt.float_fmt, fmt, (const half*)data)
+                   : format_type(type, fmt.float_fmt, fmt, (const half*)data);
     case TypeDesc::FLOAT:
         return fmt.use_sprintf
-                   ? sprintt(type, fmt.float_fmt, fmt, (const float*)data)
-                   : formatt(type, fmt.float_fmt, fmt, (const float*)data);
+                   ? sprint_type(type, fmt.float_fmt, fmt, (const float*)data)
+                   : format_type(type, fmt.float_fmt, fmt, (const float*)data);
     case TypeDesc::DOUBLE:
         return fmt.use_sprintf
-                   ? sprintt(type, fmt.float_fmt, fmt, (const double*)data)
-                   : formatt(type, fmt.float_fmt, fmt, (const double*)data);
+                   ? sprint_type(type, fmt.float_fmt, fmt, (const double*)data)
+                   : format_type(type, fmt.float_fmt, fmt, (const double*)data);
     case TypeDesc::STRING:
         if (!type.is_array()
             && !(fmt.flags & tostring_formatting::quote_single_string))
             return *(const char**)data;
         return fmt.use_sprintf
-                   ? sprintt(type, fmt.string_fmt, fmt, (const char**)data)
-                   : formatt(type, fmt.string_fmt, fmt, (const char**)data);
+                   ? sprint_type(type, fmt.string_fmt, fmt, (const char**)data)
+                   : format_type(type, fmt.string_fmt, fmt, (const char**)data);
     case TypeDesc::PTR:
-        return fmt.use_sprintf ? sprintt(type, fmt.ptr_fmt, fmt, (void**)data)
-                               : formatt(type, fmt.ptr_fmt, fmt, (void**)data);
+        return fmt.use_sprintf
+                   ? sprint_type(type, fmt.ptr_fmt, fmt, (void**)data)
+                   : format_type(type, fmt.ptr_fmt, fmt, (void**)data);
     default:
 #ifndef NDEBUG
         return Strutil::sprintf("<unknown data type> (base %d, agg %d vec %d)",

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -327,6 +327,21 @@ tostring_formatting::tostring_formatting(
 
 
 
+tostring_formatting::tostring_formatting(
+    Notation notation, const char* int_fmt, const char* uint_fmt,
+    const char* float_fmt, const char* string_fmt, const char* ptr_fmt,
+    const char* aggregate_begin, const char* aggregate_end,
+    const char* aggregate_sep, const char* array_begin, const char* array_end,
+    const char* array_sep, int flags)
+    : tostring_formatting(int_fmt, float_fmt, string_fmt, ptr_fmt,
+                          aggregate_begin, aggregate_end, aggregate_sep,
+                          array_begin, array_end, array_sep, flags, uint_fmt)
+{
+    use_sprintf = false;
+}
+
+
+
 template<class T>
 inline std::string
 sprintt(TypeDesc type, const char* format, const tostring_formatting& fmt,
@@ -388,6 +403,68 @@ sprintt(TypeDesc type, const char* format, const tostring_formatting& fmt,
 
 
 
+template<class T>
+inline std::string
+formatt(TypeDesc type, const char* format, const tostring_formatting& fmt,
+        const T* v)
+{
+    std::string val;
+    if (type.arraylen)
+        val += fmt.array_begin;
+    const size_t n = type.arraylen ? type.arraylen : 1;
+    for (size_t i = 0; i < n; ++i) {
+        if (type.aggregate > 1)
+            val += fmt.aggregate_begin;
+        for (int j = 0; j < (int)type.aggregate; ++j, ++v) {
+            val += Strutil::fmt::format(format, *v);
+            if (type.aggregate > 1 && j < type.aggregate - 1)
+                val += fmt.aggregate_sep;
+        }
+        if (type.aggregate > 1)
+            val += fmt.aggregate_end;
+        if (i < n - 1)
+            val += fmt.array_sep;
+    }
+    if (type.arraylen)
+        val += fmt.array_end;
+    return val;
+}
+
+
+
+inline std::string
+formatt(TypeDesc type, const char* format, const tostring_formatting& fmt,
+        const char** v)
+{
+    std::string val;
+    if (type.arraylen)
+        val += fmt.array_begin;
+    const size_t n = type.arraylen ? type.arraylen : 1;
+    for (size_t i = 0; i < n; ++i) {
+        if (type.aggregate > 1)
+            val += fmt.aggregate_begin;
+        for (int j = 0; j < (int)type.aggregate; ++j, ++v) {
+            if (fmt.flags & tostring_formatting::escape_strings)
+                val += Strutil::fmt::format(format,
+                                            *v ? Strutil::escape_chars(*v)
+                                               : std::string());
+            else
+                val += Strutil::fmt::format(format, *v ? *v : "");
+            if (type.aggregate > 1 && j < type.aggregate - 1)
+                val += fmt.aggregate_sep;
+        }
+        if (type.aggregate > 1)
+            val += fmt.aggregate_end;
+        if (i < n - 1)
+            val += fmt.array_sep;
+    }
+    if (type.arraylen)
+        val += fmt.array_end;
+    return val;
+}
+
+
+
 // From OpenEXR
 inline unsigned int
 bitField(unsigned int value, int minBit, int maxBit)
@@ -413,16 +490,29 @@ tostring(TypeDesc type, const void* data, const tostring_formatting& fmt)
     // Perhaps there is a way to use CType<> with a dynamic argument?
     switch (type.basetype) {
     case TypeDesc::UNKNOWN:
-        return sprintt(type, fmt.ptr_fmt, fmt, (void**)data);
-    case TypeDesc::NONE: return sprintt(type, "None", fmt, (void**)data);
+        return fmt.use_sprintf ? sprintt(type, fmt.ptr_fmt, fmt, (void**)data)
+                               : formatt(type, fmt.ptr_fmt, fmt, (void**)data);
+    case TypeDesc::NONE:
+        return fmt.use_sprintf ? sprintt(type, "None", fmt, (void**)data)
+                               : formatt(type, "None", fmt, (void**)data);
     case TypeDesc::UCHAR:
-        return sprintt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
-                       (unsigned char*)data);
-    case TypeDesc::CHAR: return sprintt(type, fmt.int_fmt, fmt, (char*)data);
+        return fmt.use_sprintf
+                   ? sprintt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
+                             (unsigned char*)data)
+                   : formatt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
+                             (unsigned char*)data);
+    case TypeDesc::CHAR:
+        return fmt.use_sprintf ? sprintt(type, fmt.int_fmt, fmt, (char*)data)
+                               : formatt(type, fmt.int_fmt, fmt, (char*)data);
     case TypeDesc::USHORT:
-        return sprintt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
-                       (uint16_t*)data);
-    case TypeDesc::SHORT: return sprintt(type, fmt.int_fmt, fmt, (short*)data);
+        return fmt.use_sprintf
+                   ? sprintt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
+                             (uint16_t*)data)
+                   : formatt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
+                             (uint16_t*)data);
+    case TypeDesc::SHORT:
+        return fmt.use_sprintf ? sprintt(type, fmt.int_fmt, fmt, (short*)data)
+                               : formatt(type, fmt.int_fmt, fmt, (short*)data);
     case TypeDesc::UINT:
         if (type.vecsemantics == TypeDesc::RATIONAL
             && type.aggregate == TypeDesc::VEC2) {
@@ -445,8 +535,11 @@ tostring(TypeDesc type, const void* data, const tostring_formatting& fmt)
             return Strutil::sprintf("%02d:%02d:%02d:%02d", hours, minutes,
                                     seconds, frame);
         }
-        return sprintt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
-                       (unsigned int*)data);
+        return fmt.use_sprintf
+                   ? sprintt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
+                             (unsigned int*)data)
+                   : formatt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
+                             (unsigned int*)data);
     case TypeDesc::INT:
         if (type.elementtype() == TypeRational) {
             std::string out;
@@ -458,24 +551,40 @@ tostring(TypeDesc type, const void* data, const tostring_formatting& fmt)
             }
             return out;
         }
-        return sprintt(type, fmt.int_fmt, fmt, (int*)data);
+        return fmt.use_sprintf ? sprintt(type, fmt.int_fmt, fmt, (int*)data)
+                               : formatt(type, fmt.int_fmt, fmt, (int*)data);
     case TypeDesc::UINT64:
-        return sprintt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
-                       (const uint64_t*)data);
+        return fmt.use_sprintf
+                   ? sprintt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
+                             (const uint64_t*)data)
+                   : formatt(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,
+                             (const uint64_t*)data);
     case TypeDesc::INT64:
-        return sprintt(type, fmt.int_fmt, fmt, (const int64_t*)data);
+        return fmt.use_sprintf
+                   ? sprintt(type, fmt.int_fmt, fmt, (const int64_t*)data)
+                   : formatt(type, fmt.int_fmt, fmt, (const int64_t*)data);
     case TypeDesc::HALF:
-        return sprintt(type, fmt.float_fmt, fmt, (const half*)data);
+        return fmt.use_sprintf
+                   ? sprintt(type, fmt.float_fmt, fmt, (const half*)data)
+                   : formatt(type, fmt.float_fmt, fmt, (const half*)data);
     case TypeDesc::FLOAT:
-        return sprintt(type, fmt.float_fmt, fmt, (const float*)data);
+        return fmt.use_sprintf
+                   ? sprintt(type, fmt.float_fmt, fmt, (const float*)data)
+                   : formatt(type, fmt.float_fmt, fmt, (const float*)data);
     case TypeDesc::DOUBLE:
-        return sprintt(type, fmt.float_fmt, fmt, (const double*)data);
+        return fmt.use_sprintf
+                   ? sprintt(type, fmt.float_fmt, fmt, (const double*)data)
+                   : formatt(type, fmt.float_fmt, fmt, (const double*)data);
     case TypeDesc::STRING:
         if (!type.is_array()
             && !(fmt.flags & tostring_formatting::quote_single_string))
             return *(const char**)data;
-        return sprintt(type, fmt.string_fmt, fmt, (const char**)data);
-    case TypeDesc::PTR: return sprintt(type, fmt.ptr_fmt, fmt, (void**)data);
+        return fmt.use_sprintf
+                   ? sprintt(type, fmt.string_fmt, fmt, (const char**)data)
+                   : formatt(type, fmt.string_fmt, fmt, (const char**)data);
+    case TypeDesc::PTR:
+        return fmt.use_sprintf ? sprintt(type, fmt.ptr_fmt, fmt, (void**)data)
+                               : formatt(type, fmt.ptr_fmt, fmt, (void**)data);
     default:
 #ifndef NDEBUG
         return Strutil::sprintf("<unknown data type> (base %d, agg %d vec %d)",

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -487,7 +487,7 @@ oiio_tiff_last_error()
 static void
 my_error_handler(const char* /*str*/, const char* format, va_list ap)
 {
-    oiio_tiff_last_error() = Strutil::vformat(format, ap);
+    oiio_tiff_last_error() = Strutil::vsprintf(format, ap);
 }
 
 


### PR DESCRIPTION
Another step toward switching to std::format notation.

The basic strategy is to make sure that all the classes that have
errorf (etc) methods using printf notation will also have errorfmt
(etc) methods using std::format notation. These will coexist for a
while to let people switch, before the printf ones will be marked
deprecated and then eventually removed.

In some cases where the methods aren't really part of the public
API, but only are used by interns, we are already skipping to the
deprecation marking or just changing them completely.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
