### PR TITLE
Minor fixes to ImageBuf error reporting

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -106,7 +106,7 @@ public:
     void copy_metadata(const ImageBufImpl& src);
 
     template<typename... Args>
-    void error(const char* fmt, const Args&... args) const
+    void errorfmt(const char* fmt, const Args&... args) const
     {
         error(Strutil::fmt::format(fmt, args...));
     }
@@ -932,12 +932,12 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
         auto input = ImageInput::open(m_name.string(), m_configspec.get(),
                                       m_rioproxy);
         if (!input) {
-            error("{}", OIIO::geterror());
+            error(OIIO::geterror());
             return false;
         }
         input->threads(threads());  // Pass on our thread policy
         if (!input->read_native_deep_image(subimage, miplevel, m_deepdata)) {
-            error("{}", input->geterror());
+            error(input->geterror());
             return false;
         }
         m_spec         = m_nativespec;  // Deep images always use native data
@@ -1044,11 +1044,11 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
                 m_pixels_valid = true;
             } else {
                 m_pixels_valid = false;
-                error("{}", in->geterror());
+                error(in->geterror());
             }
         } else {
             m_pixels_valid = false;
-            error("{}", OIIO::geterror());
+            error(OIIO::geterror());
         }
         return m_pixels_valid;
     }
@@ -1063,7 +1063,7 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
         m_pixels_valid = true;
     } else {
         m_pixels_valid = false;
-        error("{}", m_imagecache->geterror());
+        error(m_imagecache->geterror());
     }
 
     return m_pixels_valid;
@@ -1218,7 +1218,7 @@ ImageBuf::write(ImageOutput* out, ProgressCallback progress_callback,
         }
     }
     if (!ok)
-        error("{}", out->geterror());
+        error(out->geterror());
     return ok;
 }
 
@@ -1263,7 +1263,7 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
 
     auto out = ImageOutput::create(fileformat);
     if (!out) {
-        error("{}", geterror());
+        error(geterror());
         return false;
     }
     out->threads(threads());  // Pass on our thread policy
@@ -1315,7 +1315,7 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
     }
 
     if (!out->open(filename.c_str(), newspec)) {
-        error("{}", out->geterror());
+        error(out->geterror());
         return false;
     }
     if (!write(out.get(), progress_callback, progress_callback_data))

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -347,6 +347,8 @@ Oiiotool::error(string_view command, string_view explanation) const
         std::cerr << ": " << command;
     if (explanation.size())
         std::cerr << " : " << explanation;
+    else
+        std::cerr << " (unknown error)";
     std::cerr << "\n";
     // Repeat the command line, so if oiiotool is being called from a
     // script, it's easy to debug how the command was mangled.
@@ -364,6 +366,8 @@ Oiiotool::warning(string_view command, string_view explanation) const
         std::cerr << ": " << command;
     if (explanation.size())
         std::cerr << " : " << explanation;
+    else
+        std::cerr << " (unknown warning)";
     std::cerr << "\n";
 }
 
@@ -1988,7 +1992,7 @@ public:
             // The color transform failed, but we were told not to be
             // strict, so ignore the error and just copy destination to
             // source.
-            ot.warningf(opname(), "%s", img[0]->geterror());
+            ot.warning(opname(), img[0]->geterror());
             // ok = ImageBufAlgo::copy (*img[0], *img[1], TypeDesc);
             ok = img[0]->copy(*img[1]);
         }
@@ -4830,14 +4834,12 @@ output_file(int /*argc*/, const char* argv[])
         ImageOutput::OpenMode mode = ImageOutput::Create;
         if (ir->subimages() > 1 && out->supports("multiimage")) {
             if (!out->open(tmpfilename, ir->subimages(), &subimagespecs[0])) {
-                std::string err = out->geterror();
-                ot.error(command, err.size() ? err.c_str() : "unknown error");
+                ot.error(command, out->geterror());
                 return 0;
             }
         } else {
             if (!out->open(tmpfilename, subimagespecs[0], mode)) {
-                std::string err = out->geterror();
-                ot.error(command, err.size() ? err.c_str() : "unknown error");
+                ot.error(command, out->geterror());
                 return 0;
             }
         }
@@ -4851,9 +4853,7 @@ output_file(int /*argc*/, const char* argv[])
                                       (*ir)[s].was_direct_read());
                 if (s > 0 || m > 0) {  // already opened first subimage/level
                     if (!out->open(tmpfilename, spec, mode)) {
-                        std::string err = out->geterror();
-                        ot.error(command,
-                                 err.size() ? err.c_str() : "unknown error");
+                        ot.error(command, out->geterror());
                         ok = false;
                         break;
                     }

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -239,6 +239,21 @@ public:
         warning(command, Strutil::sprintf(fmt, args...));
     }
 
+    // Formatted errors with std::format-like notation
+    template<typename... Args>
+    void errorfmt(string_view command, const char* fmt,
+                  const Args&... args) const
+    {
+        error(command, Strutil::fmt::format(fmt, args...));
+    }
+
+    template<typename... Args>
+    void warningfmt(string_view command, const char* fmt,
+                    const Args&... args) const
+    {
+        warning(command, Strutil::fmt::format(fmt, args...));
+    }
+
     size_t check_peak_memory()
     {
         size_t mem  = Sysutil::memory_used();


### PR DESCRIPTION
* Fix some incorrect error calls in ImageBuf internals.
* Make sure that if no message bubbles up, we say "unknown error".

Signed-off-by: Larry Gritz <lg@larrygritz.com>
