### PR TITLE
Improved propagation of png write errors and fix sRGB profile check

### DIFF
--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -153,7 +153,7 @@ PNGOutput::open(const std::string& name, const ImageSpec& userspec,
     }
 
     std::string s = PNG_pvt::create_write_struct(m_png, m_info, m_color_type,
-                                                 m_spec);
+                                                 m_spec, this);
     if (s.length()) {
         close();
         errorf("%s", s);
@@ -201,6 +201,17 @@ PNGOutput::open(const std::string& name, const ImageSpec& userspec,
     // finding a filter choice that for "ordinary" images consistently
     // performed better than the default on both time and resulting file
     // size. So for now, we are keeping the default 0 (PNG_NO_FILTERS).
+
+#if defined(PNG_SKIP_sRGB_CHECK_PROFILE) && defined(PNG_SET_OPTION_SUPPORTED)
+    // libpng by default checks ICC profiles and are very strict, treating
+    // it as a serious error if it doesn't match th profile it thinks is
+    // right for sRGB. This call disables that behavior, which tends to have
+    // many false positives. Some references to discussion about this:
+    //    https://github.com/kornelski/pngquant/issues/190
+    //    https://sourceforge.net/p/png-mng/mailman/message/32003609/
+    //    https://bugzilla.gnome.org/show_bug.cgi?id=721135
+    png_set_option(m_png, PNG_SKIP_sRGB_CHECK_PROFILE, PNG_OPTION_ON);
+#endif
 
     PNG_pvt::write_info(m_png, m_info, m_color_type, m_spec, m_pngtext,
                         m_convert_alpha, m_gamma);


### PR DESCRIPTION
We weren't setting up the proper handler callbacks for libpng internal
errors to bubble up to the caller.

Tell libpng to turn off sRGB color profile check. There are many
false positives where embedded ICC profiles that don't match its
expectations (but that other people and apps consider fine) trigger
errors in libpng.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
