### PR TITLE
Fix Windows long paths when opening files

### DIFF
--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -265,7 +265,7 @@ Strutil::get_rest_arguments(const std::string& str, std::string& base,
                             std::map<std::string, std::string>& result)
 {
     // Disregard the Windows long path question style prefix "\\?\"
-    const char longPathQPrefix[]    = "\\\\?\\";
+    const char longPathQPrefix[] = "\\\\?\\";
     const size_t longPathQPrefixLen
         = sizeof(longPathQPrefix) / sizeof(longPathQPrefix[0]) - 1;
     std::string::size_type find_start_pos

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -265,13 +265,10 @@ Strutil::get_rest_arguments(const std::string& str, std::string& base,
                             std::map<std::string, std::string>& result)
 {
     // Disregard the Windows long path question style prefix "\\?\"
-    const char longPathQPrefix[] = "\\\\?\\";
-    const size_t longPathQPrefixLen
-        = sizeof(longPathQPrefix) / sizeof(longPathQPrefix[0]) - 1;
-    std::string::size_type find_start_pos
-        = (str.compare(0, longPathQPrefixLen, longPathQPrefix) == 0)
-              ? longPathQPrefixLen
-              : 0;
+    static const std::string longPathQPrefix("\\\\?\\");
+    auto find_start_pos = starts_with(str, longPathQPrefix)
+                              ? longPathQPrefix.size()
+                              : size_t(0);
 
     std::string::size_type mark_pos = str.find_first_of("?", find_start_pos);
     if (mark_pos == std::string::npos) {

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -264,7 +264,16 @@ bool
 Strutil::get_rest_arguments(const std::string& str, std::string& base,
                             std::map<std::string, std::string>& result)
 {
-    std::string::size_type mark_pos = str.find_first_of("?");
+    // Disregard the Windows long path question style prefix "\\?\"
+    const char longPathQPrefix[]    = "\\\\?\\";
+    const size_t longPathQPrefixLen
+        = sizeof(longPathQPrefix) / sizeof(longPathQPrefix[0]) - 1;
+    std::string::size_type find_start_pos
+        = (str.compare(0, longPathQPrefixLen, longPathQPrefix) == 0)
+              ? longPathQPrefixLen
+              : 0;
+
+    std::string::size_type mark_pos = str.find_first_of("?", find_start_pos);
     if (mark_pos == std::string::npos) {
         base = str;
         return true;

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -161,6 +161,30 @@ test_get_rest_arguments()
     OIIO_CHECK_EQUAL(base, "atext");
     OIIO_CHECK_EQUAL(result["arg1"], "value1");
     OIIO_CHECK_EQUAL(result["arg2"], "somevalue");
+
+    result.clear();
+    url            = "\\\\?\\C:\\WindowsLongPathNoRestArgs";
+    ret            = Strutil::get_rest_arguments(url, base, result);
+    OIIO_CHECK_EQUAL(ret, true);
+    OIIO_CHECK_EQUAL(base, "\\\\?\\C:\\WindowsLongPathNoRestArgs");
+    OIIO_CHECK_EQUAL(result["arg1"], "");
+
+    result.clear();
+    url            = "\\\\?\\C:\\WindowsLongPathWithGoodRestArgs?arg1=value1&arg2=value2";
+    ret            = Strutil::get_rest_arguments(url, base, result);
+    OIIO_CHECK_EQUAL(ret, true);
+    OIIO_CHECK_EQUAL(base, "\\\\?\\C:\\WindowsLongPathWithGoodRestArgs");
+    OIIO_CHECK_EQUAL(result["arg1"], "value1");
+    OIIO_CHECK_EQUAL(result["arg2"], "value2");
+
+    result.clear();
+    url            = "\\\\?\\C:\\WindowsLongPathWithBadRestArgs?arg1=value1&arg2value2";
+    result["arg2"] = "somevalue";
+    ret            = Strutil::get_rest_arguments(url, base, result);
+    OIIO_CHECK_EQUAL(ret, false);
+    OIIO_CHECK_EQUAL(base, "\\\\?\\C:\\WindowsLongPathWithBadRestArgs");
+    OIIO_CHECK_EQUAL(result["arg1"], "value1");
+    OIIO_CHECK_EQUAL(result["arg2"], "somevalue");
 }
 
 


### PR DESCRIPTION
## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

In order to support Windows extended-length / long paths ("\\?\" style), I've added code to disregard the long path prefix when getting the REST arguments, for opening files.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->

Added 3 test cases in `test_get_rest_arguments()` of "strutil_test.cpp".

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

