### PR TITLE
Windows CI: build dependencies ourselves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           CMAKE_CXX_STANDARD: 17
           PYTHON_VERSION: 3.7
           USE_SIMD: avx2,f16c
-          OPENEXR_BRANCH: v2.5.0
+          OPENEXR_VERSION: v2.5.0
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps-centos.bash
@@ -150,7 +150,7 @@ jobs:
           CXX: g++-8
           CMAKE_CXX_STANDARD: 17
           USE_SIMD: avx
-          OPENEXR_BRANCH: v2.5.0
+          OPENEXR_VERSION: v2.5.0
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps.bash
@@ -172,8 +172,8 @@ jobs:
           CXX: g++-10
           CMAKE_CXX_STANDARD: 17
           USE_SIMD: avx2,f16c
-          OPENEXR_BRANCH: v2.5.0
-          PYBIND11_VERSION: 2.5.0
+          OPENEXR_VERSION: v2.5.0
+          PYBIND11_VERSION: v2.5.0
           LIBRAW_BRANCH: 0.20.0
           MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=7.0.1
         run: |
@@ -202,7 +202,7 @@ jobs:
           CXX: g++-10
           CMAKE_CXX_STANDARD: 17
           USE_SIMD: avx2,f16c
-          OPENEXR_BRANCH: master
+          OPENEXR_VERSION: master
           OCIO_BRANCH: master
           LIBTIFF_BRANCH: master
           PYBIND11_BRANCH: master
@@ -241,7 +241,7 @@ jobs:
           USE_OPENCOLORIO: 0
           USE_OPENCV: 0
           EMBEDPLUGINS: 0
-          OPENEXR_BRANCH: v2.2.0
+          OPENEXR_VERSION: v2.2.0
           MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=6.1.2
         run: |
             source src/build-scripts/ci-startup.bash
@@ -291,7 +291,7 @@ jobs:
         env:
           PYTHON_VERSION: 3.6
           CMAKE_GENERATOR: "Visual Studio 16 2019"
-          OPENEXR_BRANCH: v2.4.1
+          OPENEXR_VERSION: v2.4.1
           SKIP_TESTS: 1
         run: |
             source src/build-scripts/ci-startup.bash
@@ -315,7 +315,7 @@ jobs:
         env:
           PYTHON_VERSION: 3.6
           CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
-          OPENEXR_BRANCH: v2.4.1
+          OPENEXR_VERSION: v2.4.1
           SKIP_TESTS: 1
           #MY_CMAKE_FLAGS: -DUSE_PYTHON=0
           USE_NINJA: 0
@@ -370,7 +370,7 @@ jobs:
           LLVM_VERSION: 9.0.0
           CMAKE_CXX_STANDARD: 14
           USE_SIMD: avx2,f16c
-          OPENEXR_BRANCH: v2.4.1
+          OPENEXR_VERSION: v2.4.1
           OCIO_BRANCH: 1c624651b7
           # Pick an OCIO commit that includes a warning fix we need for clang
         run: |

--- a/src/build-scripts/build_libjpeg-turbo.bash
+++ b/src/build-scripts/build_libjpeg-turbo.bash
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Utility script to download and build libjpeg-turbo
+#
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/OpenImageIO/oiio
+
+# Exit the whole script if any command fails.
+set -ex
+
+# Repo and branch/tag/commit of libjpeg-turbo to download if we don't have it yet
+LIBJPEGTURBO_REPO=${LIBJPEGTURBO_REPO:=https://github.com/libjpeg-turbo/libjpeg-turbo.git}
+LIBJPEGTURBO_VERSION=${LIBJPEGTURBO_VERSION:=2.0.5}
+
+# Where to put libjpeg-turbo repo source (default to the ext area)
+LIBJPEGTURBO_SRC_DIR=${LIBJPEGTURBO_SRC_DIR:=${PWD}/ext/libjpeg-turbo}
+# Temp build area (default to a build/ subdir under source)
+LIBJPEGTURBO_BUILD_DIR=${LIBJPEGTURBO_BUILD_DIR:=${LIBJPEGTURBO_SRC_DIR}/build}
+# Install area for libjpeg-turbo (default to ext/dist)
+LIBJPEGTURBO_INSTALL_DIR=${LIBJPEGTURBO_INSTALL_DIR:=${PWD}/ext/dist}
+#LIBJPEGTURBO_CONFIG_OPTS=${LIBJPEGTURBO_CONFIG_OPTS:=}
+
+pwd
+echo "libjpeg-turbo install dir will be: ${LIBJPEGTURBO_INSTALL_DIR}"
+
+mkdir -p ./ext
+pushd ./ext
+
+# Clone libjpeg-turbo project from GitHub and build
+if [[ ! -e ${LIBJPEGTURBO_SRC_DIR} ]] ; then
+    echo "git clone ${LIBJPEGTURBO_REPO} ${LIBJPEGTURBO_SRC_DIR}"
+    git clone ${LIBJPEGTURBO_REPO} ${LIBJPEGTURBO_SRC_DIR}
+fi
+cd ${LIBJPEGTURBO_SRC_DIR}
+echo "git checkout ${LIBJPEGTURBO_VERSION} --force"
+git checkout ${LIBJPEGTURBO_VERSION} --force
+
+mkdir -p ${LIBJPEGTURBO_BUILD_DIR}
+cd ${LIBJPEGTURBO_BUILD_DIR}
+time cmake --config Release \
+           -DCMAKE_BUILD_TYPE=Release \
+           -DCMAKE_INSTALL_PREFIX=${LIBJPEGTURBO_INSTALL_DIR} \
+           ${LIBJPEGTURBO_CONFIG_OPTS} ..
+time cmake --build . --config Release --target install
+
+ls -R ${LIBJPEGTURBO_INSTALL_DIR}
+popd
+
+
+# Set up paths. These will only affect the caller if this script is
+# run with 'source' rather than in a separate shell.
+export JPEGTurbo_ROOT=$LIBJPEGTURBO_INSTALL_DIR
+

--- a/src/build-scripts/build_libpng.bash
+++ b/src/build-scripts/build_libpng.bash
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Utility script to download and build libpng
+#
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/OpenImageIO/oiio
+
+# Exit the whole script if any command fails.
+set -ex
+
+# Repo and branch/tag/commit of libpng to download if we don't have it yet
+LIBPNG_REPO=${LIBPNG_REPO:=https://github.com/glennrp/libpng.git}
+LIBPNG_VERSION=${LIBPNG_VERSION:=v1.6.35}
+
+# Where to put libpng repo source (default to the ext area)
+LIBPNG_SRC_DIR=${LIBPNG_SRC_DIR:=${PWD}/ext/libpng}
+# Temp build area (default to a build/ subdir under source)
+LIBPNG_BUILD_DIR=${LIBPNG_BUILD_DIR:=${LIBPNG_SRC_DIR}/build}
+# Install area for libpng (default to ext/dist)
+LIBPNG_INSTALL_DIR=${LIBPNG_INSTALL_DIR:=${PWD}/ext/dist}
+#LIBPNG_CONFIG_OPTS=${LIBPNG_CONFIG_OPTS:=}
+
+pwd
+echo "libpng install dir will be: ${LIBPNG_INSTALL_DIR}"
+
+mkdir -p ./ext
+pushd ./ext
+
+# Clone libpng project from GitHub and build
+if [[ ! -e ${LIBPNG_SRC_DIR} ]] ; then
+    echo "git clone ${LIBPNG_REPO} ${LIBPNG_SRC_DIR}"
+    git clone ${LIBPNG_REPO} ${LIBPNG_SRC_DIR}
+fi
+cd ${LIBPNG_SRC_DIR}
+echo "git checkout ${LIBPNG_VERSION} --force"
+git checkout ${LIBPNG_VERSION} --force
+
+mkdir -p ${LIBPNG_BUILD_DIR}
+cd ${LIBPNG_BUILD_DIR}
+time cmake --config Release \
+           -DCMAKE_BUILD_TYPE=Release \
+           -DCMAKE_INSTALL_PREFIX=${LIBPNG_INSTALL_DIR} \
+           -DPNG_EXECUTABLES=OFF \
+           -DPNG_TESTS=OFF \
+           ${LIBPNG_CONFIG_OPTS} ..
+time cmake --build . --config Release --target install
+
+ls -R ${LIBPNG_INSTALL_DIR}
+popd
+
+
+# Set up paths. These will only affect the caller if this script is
+# run with 'source' rather than in a separate shell.
+export PNG_ROOT=$LIBPNG_INSTALL_DIR
+

--- a/src/build-scripts/build_libtiff.bash
+++ b/src/build-scripts/build_libtiff.bash
@@ -8,10 +8,11 @@ set -ex
 LIBTIFF_REPO=${LIBTIFF_REPO:=https://gitlab.com/libtiff/libtiff.git}
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}
 LIBTIFF_BUILD_DIR=${LIBTIFF_BUILD_DIR:=${LOCAL_DEPS_DIR}/libtiff}
-LIBTIFF_INSTALL_DIR=${LIBTIFF_INSTALL_DIR:=${LOCAL_DEPS_DIR}/libtiff/dist}
-LIBTIFF_VERSION=${LIBTIFF_VERSION:=4.1.0}
-LIBTIFF_BRANCH=${LIBTIFF_BRANCH:=v${LIBTIFF_VERSION}}
-LIBTIFF_CXX_FLAGS=${LIBTIFF_CXX_FLAGS:="-Wno-unused-function -Wno-deprecated-declarations -Wno-cast-qual -Wno-write-strings"}
+LIBTIFF_INSTALL_DIR=${LIBTIFF_INSTALL_DIR:=${PWD}/ext/dist}
+LIBTIFF_VERSION=${LIBTIFF_VERSION:=v4.1.0}
+if [[ `uname` == `Linux` ]] ; then
+    LIBTIFF_CXX_FLAGS=${LIBTIFF_CXX_FLAGS:="-O3 -Wno-unused-function -Wno-deprecated-declarations -Wno-cast-qual -Wno-write-strings"}
+fi
 LIBTIFF_BUILDOPTS="${LIBTIFF_BUILDOPTS}"
 BASEDIR=`pwd`
 pwd
@@ -27,11 +28,15 @@ if [[ ! -e libtiff ]] ; then
 fi
 cd libtiff
 
-echo "git checkout ${LIBTIFF_BRANCH} --force"
-git checkout ${LIBTIFF_BRANCH} --force
+echo "git checkout ${LIBTIFF_VERSION} --force"
+git checkout ${LIBTIFF_VERSION} --force
 mkdir -p build
 cd build
-time cmake --config Release -DCMAKE_INSTALL_PREFIX=${LIBTIFF_INSTALL_DIR} -DCMAKE_CXX_FLAGS="${LIBTIFF_CXX_FLAGS}" ${LIBTIFF_BUILDOPTS} ..
+time cmake --config Release \
+           -DCMAKE_BUILD_TYPE=Release \
+           -DCMAKE_INSTALL_PREFIX=${LIBTIFF_INSTALL_DIR} \
+           -DCMAKE_CXX_FLAGS="${LIBTIFF_CXX_FLAGS}" \
+           ${LIBTIFF_BUILDOPTS} ..
 time cmake --build . --config Release --target install
 popd
 

--- a/src/build-scripts/build_openexr.bash
+++ b/src/build-scripts/build_openexr.bash
@@ -7,14 +7,13 @@ set -ex
 
 # Which OpenEXR to retrieve, how to build it
 OPENEXR_REPO=${OPENEXR_REPO:=https://github.com/openexr/openexr.git}
-OPENEXR_VERSION=${OPENEXR_VERSION:=2.4.1}
-OPENEXR_BRANCH=${OPENEXR_BRANCH:=v${OPENEXR_VERSION}}
+OPENEXR_VERSION=${OPENEXR_VERSION:=v2.4.1}
 
 # Where to install the final results
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}
 OPENEXR_SOURCE_DIR=${OPENEXR_SOURCE_DIR:=${LOCAL_DEPS_DIR}/openexr}
 OPENEXR_BUILD_DIR=${OPENEXR_BUILD_DIR:=${LOCAL_DEPS_DIR}/openexr-build}
-OPENEXR_INSTALL_DIR=${OPENEXR_INSTALL_DIR:=${LOCAL_DEPS_DIR}/openexr-install}
+OPENEXR_INSTALL_DIR=${OPENEXR_INSTALL_DIR:=${LOCAL_DEPS_DIR}/dist}
 OPENEXR_BUILD_TYPE=${OPENEXR_BUILD_TYPE:=Release}
 CMAKE_GENERATOR=${CMAKE_GENERATOR:="Unix Makefiles"}
 OPENEXR_CMAKE_FLAGS=${OPENEXR_CMAKE_FLAGS:=""}
@@ -22,7 +21,7 @@ OPENEXR_CXX_FLAGS=${OPENEXR_CXX_FLAGS:=""}
 BASEDIR=$PWD
 
 pwd
-echo "Building OpenEXR ${OPENEXR_BRANCH}"
+echo "Building OpenEXR ${OPENEXR_VERSION}"
 echo "EXR build dir will be: ${OPENEXR_BUILD_DIR}"
 echo "EXR install dir will be: ${OPENEXR_INSTALL_DIR}"
 echo "CMAKE_PREFIX_PATH is ${CMAKE_PREFIX_PATH}"
@@ -42,9 +41,9 @@ mkdir -p ${OPENEXR_INSTALL_DIR} && true
 mkdir -p ${OPENEXR_BUILD_DIR} && true
 
 pushd ${OPENEXR_SOURCE_DIR}
-git checkout ${OPENEXR_BRANCH} --force
+git checkout ${OPENEXR_VERSION} --force
 
-if [[ ${OPENEXR_BRANCH} == "v2.2.0" ]] || [[ ${OPENEXR_BRANCH} == "v2.2.1" ]] ; then
+if [[ ${OPENEXR_VERSION} == "v2.2.0" ]] || [[ ${OPENEXR_VERSION} == "v2.2.1" ]] ; then
     mkdir -p ${OPENEXR_BUILD_DIR}/IlmBase && true
     mkdir -p ${OPENEXR_BUILD_DIR}/OpenEXR && true
     cd ${OPENEXR_BUILD_DIR}/IlmBase
@@ -62,7 +61,7 @@ if [[ ${OPENEXR_BRANCH} == "v2.2.0" ]] || [[ ${OPENEXR_BRANCH} == "v2.2.1" ]] ; 
             -DCMAKE_CXX_FLAGS="${OPENEXR_CXX_FLAGS}" \
             ${OPENEXR_CMAKE_FLAGS} ${OPENEXR_SOURCE_DIR}/OpenEXR
     time cmake --build . --target install --config ${OPENEXR_BUILD_TYPE}
-elif [[ ${OPENEXR_BRANCH} == "v2.3.0" ]] ; then
+elif [[ ${OPENEXR_VERSION} == "v2.3.0" ]] ; then
     # Simplified setup for 2.3+
     cd ${OPENEXR_BUILD_DIR}
     cmake --config ${OPENEXR_BUILD_TYPE} -G "$CMAKE_GENERATOR" \

--- a/src/build-scripts/build_pugixml.bash
+++ b/src/build-scripts/build_pugixml.bash
@@ -4,7 +4,7 @@
 #
 # Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/imageworks/OpenShadingLanguage
+# https://github.com/OpenImageIO/oiio
 
 # Exit the whole script if any command fails.
 set -ex

--- a/src/build-scripts/build_pybind11.bash
+++ b/src/build-scripts/build_pybind11.bash
@@ -7,8 +7,7 @@ set -ex
 
 # Repo and branch/tag/commit of pybind11 to download if we don't have it yet
 PYBIND11_REPO=${PYBIND11_REPO:=https://github.com/pybind/pybind11.git}
-PYBIND11_VERSION=${PYBIND11_VERSION:=2.4.3}
-PYBIND11_BRANCH=${PYBIND11_BRANCH:=v${PYBIND11_VERSION}}
+PYBIND11_VERSION=${PYBIND11_VERSION:=v2.4.3}
 
 # Where to put pybind11 repo source (default to the ext area)
 PYBIND11_SRC_DIR=${PYBIND11_SRC_DIR:=${PWD}/ext/pybind11}
@@ -35,8 +34,8 @@ if [[ ! -e ${PYBIND11_SRC_DIR} ]] ; then
     git clone ${PYBIND11_REPO} ${PYBIND11_SRC_DIR}
 fi
 cd ${PYBIND11_SRC_DIR}
-echo "git checkout ${PYBIND11_BRANCH} --force"
-git checkout ${PYBIND11_BRANCH} --force
+echo "git checkout ${PYBIND11_VERSION} --force"
+git checkout ${PYBIND11_VERSION} --force
 
 mkdir -p ${PYBIND11_BUILD_DIR}
 cd ${PYBIND11_BUILD_DIR}

--- a/src/build-scripts/build_zlib.bash
+++ b/src/build-scripts/build_zlib.bash
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Utility script to download and build zlib
+#
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/OpenImageIO/oiio
+
+# Exit the whole script if any command fails.
+set -ex
+
+# Repo and branch/tag/commit of zlib to download if we don't have it yet
+ZLIB_REPO=${ZLIB_REPO:=https://github.com/madler/zlib.git}
+ZLIB_VERSION=${ZLIB_VERSION:=v1.2.11}
+
+# Where to put zlib repo source (default to the ext area)
+ZLIB_SRC_DIR=${ZLIB_SRC_DIR:=${PWD}/ext/zlib}
+# Temp build area (default to a build/ subdir under source)
+ZLIB_BUILD_DIR=${ZLIB_BUILD_DIR:=${ZLIB_SRC_DIR}/build}
+# Install area for zlib (default to ext/dist)
+ZLIB_INSTALL_DIR=${ZLIB_INSTALL_DIR:=${PWD}/ext/dist}
+#ZLIB_CONFIG_OPTS=${ZLIB_CONFIG_OPTS:=}
+
+pwd
+echo "zlib install dir will be: ${ZLIB_INSTALL_DIR}"
+
+mkdir -p ./ext
+pushd ./ext
+
+# Clone zlib project from GitHub and build
+if [[ ! -e ${ZLIB_SRC_DIR} ]] ; then
+    echo "git clone ${ZLIB_REPO} ${ZLIB_SRC_DIR}"
+    git clone ${ZLIB_REPO} ${ZLIB_SRC_DIR}
+fi
+cd ${ZLIB_SRC_DIR}
+echo "git checkout ${ZLIB_VERSION} --force"
+git checkout ${ZLIB_VERSION} --force
+
+mkdir -p ${ZLIB_BUILD_DIR} && true
+cd ${ZLIB_BUILD_DIR}
+time cmake --config Release \
+           -DCMAKE_BUILD_TYPE=Release \
+           -DCMAKE_INSTALL_PREFIX=${ZLIB_INSTALL_DIR} \
+           ${ZLIB_CONFIG_OPTS} ..
+time cmake --build . --config Release --target install
+
+ls -R ${ZLIB_INSTALL_DIR}
+popd
+
+
+# Set up paths. These will only affect the caller if this script is
+# run with 'source' rather than in a separate shell.
+export ZLIB_ROOT=$ZLIB_INSTALL_DIR
+

--- a/src/build-scripts/ci-build-and-test.bash
+++ b/src/build-scripts/ci-build-and-test.bash
@@ -40,17 +40,16 @@ if [[ "$BUILDTARGET" != "none" ]] ; then
     time cmake --build . --target ${BUILDTARGET:=install} --config ${CMAKE_BUILD_TYPE}
 fi
 popd
-#make $MAKEFLAGS VERBOSE=1 $BUILD_FLAGS config
-#make $MAKEFLAGS $PAR_MAKEFLAGS $BUILD_FLAGS $BUILDTARGET
 
-#echo "OpenImageIO_ROOT $OpenImageIO_ROOT"
-#ls -R -l "$OpenImageIO_ROOT"
 
 if [[ "${SKIP_TESTS:=0}" == "0" ]] ; then
     $OpenImageIO_ROOT/bin/oiiotool --help || true
     TESTSUITE_CLEANUP_ON_SUCCESS=1
     echo "Parallel test " ${CTEST_PARALLEL_LEVEL}
-    make $BUILD_FLAGS test
+    # make $BUILD_FLAGS test
+    pushd build/$PLATFORM
+    ctest -C ${CMAKE_BUILD_TYPE} -E broken --force-new-ctest-process --output-on-failure
+    popd
 fi
 
 if [[ "$BUILDTARGET" == clang-format ]] ; then

--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -14,6 +14,7 @@ fi
 # DEP_DIR="$PWD/ext/dist"
 DEP_DIR="$PWD/dist/$PLATFORM"
 mkdir -p "$DEP_DIR"
+mkdir -p ext && true
 INT_DIR="build/$PLATFORM"
 VCPKG_INSTALLATION_ROOT=/c/vcpkg
 
@@ -32,60 +33,77 @@ export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DEP_DIR/lib:$VCPKG_INSTALLATION_ROOT/i
 ls -l "C:/Program Files (x86)/Microsoft Visual Studio/*/Enterprise/VC/Tools/MSVC" && true
 ls -l "C:/Program Files (x86)/Microsoft Visual Studio" && true
 
-vcpkg list
-vcpkg update
 
-# vcpkg install zlib:x64-windows
-vcpkg install tiff:x64-windows
-vcpkg install libpng:x64-windows
-vcpkg install giflib:x64-windows
-vcpkg install freetype:x64-windows
-# vcpkg install openexr:x64-windows
-# vcpkg install libjpeg-turbo:x64-windows
+########################################################################
+# Dependency method #1: Use vcpkg (disabled)
+#
+# Currently we are not using this, but here it is for reference:
+#
+# vcpkg list
+# vcpkg update
+# 
+# # vcpkg install zlib:x64-windows
+# vcpkg install tiff:x64-windows
+# vcpkg install libpng:x64-windows
+# vcpkg install giflib:x64-windows
+# vcpkg install freetype:x64-windows
+# # vcpkg install openexr:x64-windows
+# # vcpkg install libjpeg-turbo:x64-windows
+# 
+# vcpkg install libraw:x64-windows
+# vcpkg install openjpeg:x64-windows
+# vcpkg install libsquish:x64-windows
+# # vcpkg install ffmpeg:x64-windows   # takes FOREVER!
+# # vcpkg install webp:x64-windows  # No such vcpkg package?a
+# 
+# #echo "$VCPKG_INSTALLATION_ROOT"
+# #ls "$VCPKG_INSTALLATION_ROOT"
+# #echo "$VCPKG_INSTALLATION_ROOT/installed/x64-windows"
+# #ls "$VCPKG_INSTALLATION_ROOT/installed/x64-windows"
+# #echo "$VCPKG_INSTALLATION_ROOT/installed/x64-windows/lib"
+# #ls "$VCPKG_INSTALLATION_ROOT/installed/x64-windows/lib"
+# #echo "$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin"
+# #ls "$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin"
+# 
+# # export PATH="$PATH:$DEP_DIR/bin:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin"
+# export PATH="$DEP_DIR/lib:$DEP_DIR/bin:$PATH:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/lib"
+# export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/lib:$DEP_DIR/lib:$DEP_DIR/bin"
+# 
+# echo "All VCPkg installs:"
+# vcpkg list
+#
+########################################################################
 
-vcpkg install libraw:x64-windows
-vcpkg install openjpeg:x64-windows
-vcpkg install libsquish:x64-windows
-# vcpkg install ffmpeg:x64-windows   # takes FOREVER!
-# vcpkg install webp:x64-windows  # No such vcpkg package?a
 
-echo "$VCPKG_INSTALLATION_ROOT"
-ls "$VCPKG_INSTALLATION_ROOT"
-echo "$VCPKG_INSTALLATION_ROOT/installed/x64-windows"
-ls "$VCPKG_INSTALLATION_ROOT/installed/x64-windows"
-echo "$VCPKG_INSTALLATION_ROOT/installed/x64-windows/lib"
-ls "$VCPKG_INSTALLATION_ROOT/installed/x64-windows/lib"
-echo "$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin"
-ls "$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin"
+########################################################################
+# Dependency method #2: Build from source ourselves
+#
+#
 
-echo "All VCPkg installs:"
-vcpkg list
+src/build-scripts/build_zlib.bash
+export ZLIB_ROOT=$PWD/ext/dist
 
-# curl --location https://ffmpeg.zeranoe.com/builds/win64/shared/ffmpeg-4.2.1-win64-shared.zip -o ffmpeg-libs.zip
-# unzip ffmpeg-libs.zip
+src/build-scripts/build_libpng.bash
+export PNG_ROOT=$PWD/ext/dist
+
+src/build-scripts/build_libtiff.bash
+export TIFF_ROOT=$PWD/ext/dist
+
+LIBJPEGTURBO_CONFIG_OPTS=-DWITH_SIMD=OFF
+# ^^ because we're too lazy to build nasm
+src/build-scripts/build_libjpeg-turbo.bash
+export JPEGTurbo_ROOT=$PWD/ext/dist
+
+source src/build-scripts/build_pybind11.bash
+#export pybind11_ROOT=$PWD/ext/dist
+
+
 curl --location https://ffmpeg.zeranoe.com/builds/win64/dev/ffmpeg-4.2.1-win64-dev.zip -o ffmpeg-dev.zip
 unzip ffmpeg-dev.zip
-ls
-ls -R *ffmpeg*
 FFmpeg_ROOT=$PWD/ffmpeg-4.2.1-win64-dev
 
 echo "CMAKE_PREFIX_PATH = $CMAKE_PREFIX_PATH"
 
-mkdir ext
-
-# ZLib
-pushd ext
-git clone -b v1.2.11 https://github.com/madler/zlib.git
-cd zlib
-mkdir -p $INT_DIR
-cd $INT_DIR
-cmake ../.. -G "$CMAKE_GENERATOR" -DCMAKE_CONFIGURATION_TYPES="$CMAKE_BUILD_TYPE" -DCMAKE_PREFIX_PATH="$DEP_DIR" -DCMAKE_INSTALL_PREFIX="$DEP_DIR"
-cmake --build . --config $CMAKE_BUILD_TYPE --target install
-popd
-export MY_CMAKE_FLAGS="$MY_CMAKE_FLAGS -DZLIB_LIBRARY=$DEP_DIR/lib/zlib.lib"
-export OPENEXR_CMAKE_FLAGS="$OPENEXR_CMAKE_FLAGS -DZLIB_LIBRARY=$DEP_DIR/lib/zlib.lib"
-
-source src/build-scripts/build_pybind11.bash
 
 OPENEXR_CXX_FLAGS=" /W1 /EHsc /DWIN32=1 "
 #OPENEXR_BUILD_TYPE=$CMAKE_BUILD_TYPE
@@ -101,10 +119,6 @@ cp $DEP_DIR/bin/*.dll $DEP_DIR/lib
 echo "DEP_DIR $DEP_DIR :"
 ls -R -l "$DEP_DIR"
 
-
-# export PATH="$PATH:$DEP_DIR/bin:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin"
-export PATH="$DEP_DIR/lib:$DEP_DIR/bin:$PATH:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/lib"
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/lib:$DEP_DIR/lib:$DEP_DIR/bin"
 
 src/build-scripts/install_test_images.bash
 


### PR DESCRIPTION
Last week, Vcpkg apparently had some flaw that recently caused it to
fail when building/installing libpng (among other things). It's been
fixed in the vcpkg main branch, but that hasn't propagated to the
vcpkg that's installed on the GitHub Actions CI runners, and that's
causing our Windows CI tests to fail.

Rather than wait out the fix, I'm just taking it into my own hands by
building all our dependencies from source on Windows. This means adding
bash scripts to download and build zlib, libpng, and libjpeg-turbo (and
maybe those will be helpful to others as well).

**Late breaking news** They beat me to it, vcpkg has been updated and
the GitHub CI Windows tests are passing again.

But I had already done this work! So I still would like to switch to
this methodology because:

* Sometimes it's faster to build ourselves rather than have vcpkg
  build, since vcpkg always builds both release and debug, but we only
  need the release builds of the dependencies.

* This makes it easier to customize the specific version of a
  dependency, or particular build options, which are hard or
  impossible to change for a vcpkg build.

* These same dependency-building scripts could be useful for people who
  are not on Windows or not interested in using vcpkg.

Also some minor changes to the build_libtiff and build_openexr scripts
to synchronize some of the idioms I use in these scripts.

Rename workflow.yml to ci.yml to adhere to convention and also make it
so we can have multiple workflows in the future.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
