### PR TITLE
clang-format: Adjust alignment of line continuation backslashes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,7 +6,7 @@ AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: false
-AlignEscapedNewlines: Right
+AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true

--- a/src/cineon.imageio/cineoninput.cpp
+++ b/src/cineon.imageio/cineoninput.cpp
@@ -223,40 +223,40 @@ CineonInput::open(const std::string& name, ImageSpec& newspec)
 // per-file attribs
 #define CINEON_SET_ATTRIB_S(x, n, s) m_spec.attribute(s, m_cin.header.x(n))
 #define CINEON_SET_ATTRIB(x, n) CINEON_SET_ATTRIB_S(x, n, "cineon:" #x)
-#define CINEON_SET_ATTRIB_BYTE(x)                                              \
-    if (m_cin.header.x() != 0xFF)                                              \
+#define CINEON_SET_ATTRIB_BYTE(x) \
+    if (m_cin.header.x() != 0xFF) \
     CINEON_SET_ATTRIB(x, )
-#define CINEON_SET_ATTRIB_INT(x)                                               \
-    if (static_cast<unsigned int>(m_cin.header.x()) != 0xFFFFFFFF)             \
+#define CINEON_SET_ATTRIB_INT(x)                                   \
+    if (static_cast<unsigned int>(m_cin.header.x()) != 0xFFFFFFFF) \
     CINEON_SET_ATTRIB(x, )
-#define CINEON_SET_ATTRIB_FLOAT(x)                                             \
-    if (!std::isinf(m_cin.header.x()))                                         \
+#define CINEON_SET_ATTRIB_FLOAT(x)     \
+    if (!std::isinf(m_cin.header.x())) \
     CINEON_SET_ATTRIB(x, )
-#define CINEON_SET_ATTRIB_COORDS(x)                                            \
-    m_cin.header.x(floats);                                                    \
-    if (!std::isinf(floats[0]) && !std::isinf(floats[1])                       \
-        && !(floats[0] == 0. && floats[1] == 0.))                              \
+#define CINEON_SET_ATTRIB_COORDS(x)                      \
+    m_cin.header.x(floats);                              \
+    if (!std::isinf(floats[0]) && !std::isinf(floats[1]) \
+        && !(floats[0] == 0. && floats[1] == 0.))        \
     m_spec.attribute("cineon:" #x, TypeDesc(TypeDesc::FLOAT, 2), &floats[0])
-#define CINEON_SET_ATTRIB_STR(X, x)                                            \
-    if (m_cin.header.x[0] && m_cin.header.x[0] != char(-1))                    \
+#define CINEON_SET_ATTRIB_STR(X, x)                         \
+    if (m_cin.header.x[0] && m_cin.header.x[0] != char(-1)) \
     m_spec.attribute("cineon:" #X, m_cin.header.x)
 
 // per-element attribs
-#define CINEON_SET_ATTRIB_N(x, a, t, c)                                        \
-    for (int i = 0; i < m_cin.header.NumberOfElements(); i++) {                \
-        c(x) a[i] = m_cin.header.x(i);                                         \
-    }                                                                          \
-    m_spec.attribute("cineon:" #x,                                             \
-                     TypeDesc(TypeDesc::t, m_cin.header.NumberOfElements()),   \
+#define CINEON_SET_ATTRIB_N(x, a, t, c)                                      \
+    for (int i = 0; i < m_cin.header.NumberOfElements(); i++) {              \
+        c(x) a[i] = m_cin.header.x(i);                                       \
+    }                                                                        \
+    m_spec.attribute("cineon:" #x,                                           \
+                     TypeDesc(TypeDesc::t, m_cin.header.NumberOfElements()), \
                      &a)
 #define CINEON_CHECK_ATTRIB_FLOAT(x) if (!std::isinf(m_cin.header.x(i)))
-#define CINEON_SET_ATTRIB_FLOAT_N(x)                                           \
+#define CINEON_SET_ATTRIB_FLOAT_N(x) \
     CINEON_SET_ATTRIB_N(x, floats, FLOAT, CINEON_CHECK_ATTRIB_FLOAT)
 #define CINEON_CHECK_ATTRIB_INT(x) if (m_cin.header.x(i) != 0xFFFFFFFF)
-#define CINEON_SET_ATTRIB_INT_N(x)                                             \
+#define CINEON_SET_ATTRIB_INT_N(x) \
     CINEON_SET_ATTRIB_N(x, ints, UINT32, CINEON_CHECK_ATTRIB_INT)
 #define CINEON_CHECK_ATTRIB_BYTE(x) if (m_cin.header.x(i) != 0xFF)
-#define CINEON_SET_ATTRIB_BYTE_N(x)                                            \
+#define CINEON_SET_ATTRIB_BYTE_N(x) \
     CINEON_SET_ATTRIB_N(x, ints, UINT32, CINEON_CHECK_ATTRIB_BYTE)
 
     CINEON_SET_ATTRIB_STR(Version, version);

--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -141,8 +141,8 @@ DDSInput::open(const std::string& name, ImageSpec& newspec)
 // due to struct packing, we may get a corrupt header if we just load the
 // struct from file; to adress that, read every member individually
 // save some typing
-#define RH(memb)                                                               \
-    if (!fread(&m_dds.memb, sizeof(m_dds.memb), 1))                            \
+#define RH(memb)                                    \
+    if (!fread(&m_dds.memb, sizeof(m_dds.memb), 1)) \
     return false
 
     RH(fourCC);

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -371,24 +371,24 @@ DPXInput::seek_subimage(int subimage, int miplevel)
     // set without checking for bogus attributes
 #define DPX_SET_ATTRIB_N(x) DPX_SET_ATTRIB(x, subimage)
     // set with checking for bogus attributes
-#define DPX_SET_ATTRIB_BYTE(x)                                                 \
-    if (m_dpx.header.x() != 0xFF)                                              \
+#define DPX_SET_ATTRIB_BYTE(x)    \
+    if (m_dpx.header.x() != 0xFF) \
     DPX_SET_ATTRIB(x, )
-#define DPX_SET_ATTRIB_INT_N(x)                                                \
-    if (m_dpx.header.x(subimage) != 0xFFFFFFFF)                                \
+#define DPX_SET_ATTRIB_INT_N(x)                 \
+    if (m_dpx.header.x(subimage) != 0xFFFFFFFF) \
     DPX_SET_ATTRIB(x, subimage)
-#define DPX_SET_ATTRIB_INT(x)                                                  \
-    if (m_dpx.header.x() != 0xFFFFFFFF)                                        \
+#define DPX_SET_ATTRIB_INT(x)           \
+    if (m_dpx.header.x() != 0xFFFFFFFF) \
     DPX_SET_ATTRIB(x, )
-#define DPX_SET_ATTRIB_FLOAT_N(x)                                              \
-    if (!std::isnan(m_dpx.header.x(subimage)))                                 \
+#define DPX_SET_ATTRIB_FLOAT_N(x)              \
+    if (!std::isnan(m_dpx.header.x(subimage))) \
     DPX_SET_ATTRIB(x, subimage)
-#define DPX_SET_ATTRIB_FLOAT(x)                                                \
-    if (!std::isnan(m_dpx.header.x()))                                         \
+#define DPX_SET_ATTRIB_FLOAT(x)        \
+    if (!std::isnan(m_dpx.header.x())) \
     DPX_SET_ATTRIB(x, )
     // see comment above Copyright, Software and DocumentName
-#define DPX_SET_ATTRIB_STR(X, x)                                               \
-    if (m_dpx.header.x[0] && m_dpx.header.x[0] != char(-1))                    \
+#define DPX_SET_ATTRIB_STR(X, x)                            \
+    if (m_dpx.header.x[0] && m_dpx.header.x[0] != char(-1)) \
     m_spec.attribute("dpx:" #X, m_dpx.header.x)
 
     DPX_SET_ATTRIB_INT(EncryptKey);

--- a/src/include/OpenImageIO/dassert.h
+++ b/src/include/OpenImageIO/dassert.h
@@ -29,11 +29,11 @@
 ///
 /// OIIO_ASSERT_MSG(condition,msg,...) lets you add formatted output (a la
 /// printf) to the failure message.
-#define OIIO_ASSERT(x)                                                         \
-    (OIIO_LIKELY(x)                                                            \
-         ? ((void)0)                                                           \
-         : (std::fprintf(stderr, "%s:%u: %s: Assertion '%s' failed.\n",        \
-                         __FILE__, __LINE__, OIIO_PRETTY_FUNCTION, #x),        \
+#define OIIO_ASSERT(x)                                                  \
+    (OIIO_LIKELY(x)                                                     \
+         ? ((void)0)                                                    \
+         : (std::fprintf(stderr, "%s:%u: %s: Assertion '%s' failed.\n", \
+                         __FILE__, __LINE__, OIIO_PRETTY_FUNCTION, #x), \
             OIIO_ABORT_IF_DEBUG))
 #define OIIO_ASSERT_MSG(x, msg, ...)                                            \
     (OIIO_LIKELY(x)                                                             \
@@ -70,22 +70,22 @@
 /// DASSERT and DASSERT_MSG also are considered deprecated for the namespace
 /// reasons.
 #ifndef ASSERT
-#    define ASSERT(x)                                                          \
-        (OIIO_LIKELY(x)                                                        \
-             ? ((void)0)                                                       \
-             : (std::fprintf(stderr, "%s:%u: %s: Assertion '%s' failed.\n",    \
-                             __FILE__, __LINE__, OIIO_PRETTY_FUNCTION, #x),    \
+#    define ASSERT(x)                                                       \
+        (OIIO_LIKELY(x)                                                     \
+             ? ((void)0)                                                    \
+             : (std::fprintf(stderr, "%s:%u: %s: Assertion '%s' failed.\n", \
+                             __FILE__, __LINE__, OIIO_PRETTY_FUNCTION, #x), \
                 abort()))
 #endif
 
 #ifndef ASSERT_MSG
-#    define ASSERT_MSG(x, msg, ...)                                            \
-        (OIIO_LIKELY(x)                                                        \
-             ? ((void)0)                                                       \
-             : (std::fprintf(stderr,                                           \
-                             "%s:%u: %s: Assertion '%s' failed: " msg "\n",    \
-                             __FILE__, __LINE__, OIIO_PRETTY_FUNCTION, #x,     \
-                             __VA_ARGS__),                                     \
+#    define ASSERT_MSG(x, msg, ...)                                         \
+        (OIIO_LIKELY(x)                                                     \
+             ? ((void)0)                                                    \
+             : (std::fprintf(stderr,                                        \
+                             "%s:%u: %s: Assertion '%s' failed: " msg "\n", \
+                             __FILE__, __LINE__, OIIO_PRETTY_FUNCTION, #x,  \
+                             __VA_ARGS__),                                  \
                 abort()))
 #endif
 

--- a/src/include/OpenImageIO/unittest.h
+++ b/src/include/OpenImageIO/unittest.h
@@ -96,135 +96,135 @@ static OIIO::pvt::UnitTestFailureCounter unit_test_failures;
 /// prints an error message indicating the module and line where the
 /// error occurred, but does NOT abort.  This is helpful for unit tests
 /// where we do not want one failure.
-#define OIIO_CHECK_ASSERT(x)                                                   \
-    ((x) ? ((void)0)                                                           \
-         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")      \
-                       << __FILE__ << ":" << __LINE__ << ":\n"                 \
-                       << "FAILED: "                                           \
-                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x  \
-                       << "\n"),                                               \
+#define OIIO_CHECK_ASSERT(x)                                                  \
+    ((x) ? ((void)0)                                                          \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")     \
+                       << __FILE__ << ":" << __LINE__ << ":\n"                \
+                       << "FAILED: "                                          \
+                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x \
+                       << "\n"),                                              \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_EQUAL(x, y)                                                 \
-    (((x) == (y))                                                              \
-         ? ((void)0)                                                           \
-         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")      \
-                       << __FILE__ << ":" << __LINE__ << ":\n"                 \
-                       << "FAILED: "                                           \
-                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x  \
-                       << " == " << #y << "\n"                                 \
-                       << "\tvalues were '" << (x) << "' and '" << (y)         \
-                       << "'\n"),                                              \
+#define OIIO_CHECK_EQUAL(x, y)                                                \
+    (((x) == (y))                                                             \
+         ? ((void)0)                                                          \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")     \
+                       << __FILE__ << ":" << __LINE__ << ":\n"                \
+                       << "FAILED: "                                          \
+                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x \
+                       << " == " << #y << "\n"                                \
+                       << "\tvalues were '" << (x) << "' and '" << (y)        \
+                       << "'\n"),                                             \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_EQUAL_THRESH(x, y, eps)                                     \
-    ((std::abs((x) - (y)) <= eps)                                              \
-         ? ((void)0)                                                           \
-         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")      \
-                       << __FILE__ << ":" << __LINE__ << ":\n"                 \
-                       << "FAILED: "                                           \
-                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x  \
-                       << " == " << #y << "\n"                                 \
-                       << "\tvalues were '" << (x) << "' and '" << (y) << "'"  \
-                       << ", diff was " << std::abs((x) - (y)) << "\n"),       \
+#define OIIO_CHECK_EQUAL_THRESH(x, y, eps)                                    \
+    ((std::abs((x) - (y)) <= eps)                                             \
+         ? ((void)0)                                                          \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")     \
+                       << __FILE__ << ":" << __LINE__ << ":\n"                \
+                       << "FAILED: "                                          \
+                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x \
+                       << " == " << #y << "\n"                                \
+                       << "\tvalues were '" << (x) << "' and '" << (y) << "'" \
+                       << ", diff was " << std::abs((x) - (y)) << "\n"),      \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_EQUAL_APPROX(x, y)                                          \
-    (OIIO::pvt::equal_approx(x, y)                                             \
-         ? ((void)0)                                                           \
-         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")      \
-                       << __FILE__ << ":" << __LINE__ << ":\n"                 \
-                       << "FAILED: "                                           \
-                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x  \
-                       << " == " << #y << "\n"                                 \
-                       << "\tvalues were '" << (x) << "' and '" << (y) << "'"  \
-                       << ", diff was " << ((x) - (y)) << "\n"),               \
+#define OIIO_CHECK_EQUAL_APPROX(x, y)                                         \
+    (OIIO::pvt::equal_approx(x, y)                                            \
+         ? ((void)0)                                                          \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")     \
+                       << __FILE__ << ":" << __LINE__ << ":\n"                \
+                       << "FAILED: "                                          \
+                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x \
+                       << " == " << #y << "\n"                                \
+                       << "\tvalues were '" << (x) << "' and '" << (y) << "'" \
+                       << ", diff was " << ((x) - (y)) << "\n"),              \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_NE(x, y)                                                    \
-    (((x) != (y))                                                              \
-         ? ((void)0)                                                           \
-         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")      \
-                       << __FILE__ << ":" << __LINE__ << ":\n"                 \
-                       << "FAILED: "                                           \
-                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x  \
-                       << " != " << #y << "\n"                                 \
-                       << "\tvalues were '" << (x) << "' and '" << (y)         \
-                       << "'\n"),                                              \
+#define OIIO_CHECK_NE(x, y)                                                   \
+    (((x) != (y))                                                             \
+         ? ((void)0)                                                          \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")     \
+                       << __FILE__ << ":" << __LINE__ << ":\n"                \
+                       << "FAILED: "                                          \
+                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x \
+                       << " != " << #y << "\n"                                \
+                       << "\tvalues were '" << (x) << "' and '" << (y)        \
+                       << "'\n"),                                             \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_LT(x, y)                                                    \
-    (((x) < (y))                                                               \
-         ? ((void)0)                                                           \
-         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")      \
-                       << __FILE__ << ":" << __LINE__ << ":\n"                 \
-                       << "FAILED: "                                           \
-                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x  \
-                       << " < " << #y << "\n"                                  \
-                       << "\tvalues were '" << (x) << "' and '" << (y)         \
-                       << "'\n"),                                              \
+#define OIIO_CHECK_LT(x, y)                                                   \
+    (((x) < (y))                                                              \
+         ? ((void)0)                                                          \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")     \
+                       << __FILE__ << ":" << __LINE__ << ":\n"                \
+                       << "FAILED: "                                          \
+                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x \
+                       << " < " << #y << "\n"                                 \
+                       << "\tvalues were '" << (x) << "' and '" << (y)        \
+                       << "'\n"),                                             \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_GT(x, y)                                                    \
-    (((x) > (y))                                                               \
-         ? ((void)0)                                                           \
-         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")      \
-                       << __FILE__ << ":" << __LINE__ << ":\n"                 \
-                       << "FAILED: "                                           \
-                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x  \
-                       << " > " << #y << "\n"                                  \
-                       << "\tvalues were '" << (x) << "' and '" << (y)         \
-                       << "'\n"),                                              \
+#define OIIO_CHECK_GT(x, y)                                                   \
+    (((x) > (y))                                                              \
+         ? ((void)0)                                                          \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")     \
+                       << __FILE__ << ":" << __LINE__ << ":\n"                \
+                       << "FAILED: "                                          \
+                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x \
+                       << " > " << #y << "\n"                                 \
+                       << "\tvalues were '" << (x) << "' and '" << (y)        \
+                       << "'\n"),                                             \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_LE(x, y)                                                    \
-    (((x) <= (y))                                                              \
-         ? ((void)0)                                                           \
-         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")      \
-                       << __FILE__ << ":" << __LINE__ << ":\n"                 \
-                       << "FAILED: "                                           \
-                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x  \
-                       << " <= " << #y << "\n"                                 \
-                       << "\tvalues were '" << (x) << "' and '" << (y)         \
-                       << "'\n"),                                              \
+#define OIIO_CHECK_LE(x, y)                                                   \
+    (((x) <= (y))                                                             \
+         ? ((void)0)                                                          \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")     \
+                       << __FILE__ << ":" << __LINE__ << ":\n"                \
+                       << "FAILED: "                                          \
+                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x \
+                       << " <= " << #y << "\n"                                \
+                       << "\tvalues were '" << (x) << "' and '" << (y)        \
+                       << "'\n"),                                             \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_GE(x, y)                                                    \
-    (((x) >= (y))                                                              \
-         ? ((void)0)                                                           \
-         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")      \
-                       << __FILE__ << ":" << __LINE__ << ":\n"                 \
-                       << "FAILED: "                                           \
-                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x  \
-                       << " >= " << #y << "\n"                                 \
-                       << "\tvalues were '" << (x) << "' and '" << (y)         \
-                       << "'\n"),                                              \
+#define OIIO_CHECK_GE(x, y)                                                   \
+    (((x) >= (y))                                                             \
+         ? ((void)0)                                                          \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")     \
+                       << __FILE__ << ":" << __LINE__ << ":\n"                \
+                       << "FAILED: "                                          \
+                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x \
+                       << " >= " << #y << "\n"                                \
+                       << "\tvalues were '" << (x) << "' and '" << (y)        \
+                       << "'\n"),                                             \
             (void)++unit_test_failures))
 
 
 // Special SIMD related equality checks that use all()
-#define OIIO_CHECK_SIMD_EQUAL(x, y)                                            \
-    (all((x) == (y))                                                           \
-         ? ((void)0)                                                           \
-         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")      \
-                       << __FILE__ << ":" << __LINE__ << ":\n"                 \
-                       << "FAILED: "                                           \
-                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x  \
-                       << " == " << #y << "\n"                                 \
-                       << "\tvalues were '" << (x) << "' and '" << (y)         \
-                       << "'\n"),                                              \
+#define OIIO_CHECK_SIMD_EQUAL(x, y)                                           \
+    (all((x) == (y))                                                          \
+         ? ((void)0)                                                          \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")     \
+                       << __FILE__ << ":" << __LINE__ << ":\n"                \
+                       << "FAILED: "                                          \
+                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x \
+                       << " == " << #y << "\n"                                \
+                       << "\tvalues were '" << (x) << "' and '" << (y)        \
+                       << "'\n"),                                             \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_SIMD_EQUAL_THRESH(x, y, eps)                                \
-    (all(abs((x) - (y)) < (eps))                                               \
-         ? ((void)0)                                                           \
-         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")      \
-                       << __FILE__ << ":" << __LINE__ << ":\n"                 \
-                       << "FAILED: "                                           \
-                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x  \
-                       << " == " << #y << "\n"                                 \
-                       << "\tvalues were '" << (x) << "' and '" << (y)         \
-                       << "'\n"),                                              \
+#define OIIO_CHECK_SIMD_EQUAL_THRESH(x, y, eps)                               \
+    (all(abs((x) - (y)) < (eps))                                              \
+         ? ((void)0)                                                          \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")     \
+                       << __FILE__ << ":" << __LINE__ << ":\n"                \
+                       << "FAILED: "                                          \
+                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x \
+                       << " == " << #y << "\n"                                \
+                       << "\tvalues were '" << (x) << "' and '" << (y)        \
+                       << "'\n"),                                             \
             (void)++unit_test_failures))
 
 
@@ -236,12 +236,12 @@ static OIIO::pvt::UnitTestFailureCounter unit_test_failures;
 //    OIIO_CHECK_IMAGEBUF_STATUS(buf,
 //        ImageBufAlgo::Func (buf, ...)
 //    );
-#define OIIO_CHECK_IMAGEBUF_STATUS(buf, x)                                     \
-    ((x && !buf.has_error())                                                   \
-         ? ((void)0)                                                           \
-         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")      \
-                       << __FILE__ << ":" << __LINE__ << ":\n"                 \
-                       << "FAILED: "                                           \
-                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x  \
-                       << ": " << buf.geterror() << "\n"),                     \
+#define OIIO_CHECK_IMAGEBUF_STATUS(buf, x)                                    \
+    ((x && !buf.has_error())                                                  \
+         ? ((void)0)                                                          \
+         : ((std::cout << OIIO::Sysutil::Term(std::cout).ansi("red,bold")     \
+                       << __FILE__ << ":" << __LINE__ << ":\n"                \
+                       << "FAILED: "                                          \
+                       << OIIO::Sysutil::Term(std::cout).ansi("normal") << #x \
+                       << ": " << buf.geterror() << "\n"),                    \
             (void)++unit_test_failures))

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -36,9 +36,9 @@ gl_err_to_string(GLenum err)
 }
 
 
-#define GLERRPRINT(msg)                                                        \
-    for (GLenum err = glGetError(); err != GL_NO_ERROR; err = glGetError())    \
-        std::cerr << "GL error " << msg << " " << (int)err << " - "            \
+#define GLERRPRINT(msg)                                                     \
+    for (GLenum err = glGetError(); err != GL_NO_ERROR; err = glGetError()) \
+        std::cerr << "GL error " << msg << " " << (int)err << " - "         \
                   << gl_err_to_string(err) << "\n";
 
 

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -19,7 +19,7 @@
 
 #include "imageio_pvt.h"
 
-#define MAKE_OCIO_VERSION_HEX(maj, min, patch)                                 \
+#define MAKE_OCIO_VERSION_HEX(maj, min, patch) \
     (((maj) << 24) | ((min) << 16) | (patch))
 
 #ifdef USE_OCIO

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -418,14 +418,14 @@ ImageSpec::find_attribute(string_view name, ParamValue& tmpparam,
     if (iter != extra_attribs.end())
         return &(*iter);
         // Check named items in the ImageSpec structs, not in extra_attrubs
-#define MATCH(n, t)                                                            \
-    (((!casesensitive && Strutil::iequals(name, n))                            \
-      || (casesensitive && name == n))                                         \
+#define MATCH(n, t)                                 \
+    (((!casesensitive && Strutil::iequals(name, n)) \
+      || (casesensitive && name == n))              \
      && (searchtype == TypeDesc::UNKNOWN || searchtype == t))
-#define GETINT(n)                                                              \
-    if (MATCH(#n, TypeInt)) {                                                  \
-        tmpparam.init(#n, TypeInt, 1, &this->n);                               \
-        return &tmpparam;                                                      \
+#define GETINT(n)                                \
+    if (MATCH(#n, TypeInt)) {                    \
+        tmpparam.init(#n, TypeInt, 1, &this->n); \
+        return &tmpparam;                        \
     }
     GETINT(nchannels);
     GETINT(width);

--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -10,12 +10,12 @@
 #ifdef USE_OPENCV
 #    include <opencv2/core/version.hpp>
 #    ifdef CV_VERSION_EPOCH
-#        define OIIO_OPENCV_VERSION                                            \
-            (10000 * CV_VERSION_EPOCH + 100 * CV_VERSION_MAJOR                 \
+#        define OIIO_OPENCV_VERSION                            \
+            (10000 * CV_VERSION_EPOCH + 100 * CV_VERSION_MAJOR \
              + CV_VERSION_MINOR)
 #    else
-#        define OIIO_OPENCV_VERSION                                            \
-            (10000 * CV_VERSION_MAJOR + 100 * CV_VERSION_MINOR                 \
+#        define OIIO_OPENCV_VERSION                            \
+            (10000 * CV_VERSION_MAJOR + 100 * CV_VERSION_MINOR \
              + CV_VERSION_REVISION)
 #    endif
 #    include <opencv2/opencv.hpp>

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -796,17 +796,17 @@ test_IBAprep()
     ImageBuf rgb(ImageSpec(256, 256, 3));   // Basic RGB uint8 image
     ImageBuf rgba(ImageSpec(256, 256, 4));  // Basic RGBA uint8 image
 
-#define CHECK(...)                                                             \
-    {                                                                          \
-        ImageBuf dst;                                                          \
-        ROI roi;                                                               \
-        OIIO_CHECK_ASSERT(IBAprep(__VA_ARGS__));                               \
+#define CHECK(...)                               \
+    {                                            \
+        ImageBuf dst;                            \
+        ROI roi;                                 \
+        OIIO_CHECK_ASSERT(IBAprep(__VA_ARGS__)); \
     }
-#define CHECK0(...)                                                            \
-    {                                                                          \
-        ImageBuf dst;                                                          \
-        ROI roi;                                                               \
-        OIIO_CHECK_ASSERT(!IBAprep(__VA_ARGS__));                              \
+#define CHECK0(...)                               \
+    {                                             \
+        ImageBuf dst;                             \
+        ROI roi;                                  \
+        OIIO_CHECK_ASSERT(!IBAprep(__VA_ARGS__)); \
     }
 
     // Test REQUIRE_ALPHA

--- a/src/libOpenImageIO/imageinout_test.cpp
+++ b/src/libOpenImageIO/imageinout_test.cpp
@@ -41,15 +41,15 @@ make_test_image(string_view formatname)
 
 
 
-#define CHECKED(obj, call)                                                     \
-    if (!obj->call) {                                                          \
-        if (do_asserts)                                                        \
-            OIIO_CHECK_ASSERT(false && #call);                                 \
-        if (errmsg)                                                            \
-            *errmsg = obj->geterror();                                         \
-        else                                                                   \
-            std::cout << "      " << obj->geterror() << "\n";                  \
-        return false;                                                          \
+#define CHECKED(obj, call)                                    \
+    if (!obj->call) {                                         \
+        if (do_asserts)                                       \
+            OIIO_CHECK_ASSERT(false && #call);                \
+        if (errmsg)                                           \
+            *errmsg = obj->geterror();                        \
+        else                                                  \
+            std::cout << "      " << obj->geterror() << "\n"; \
+        return false;                                         \
     }
 
 

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -196,19 +196,19 @@ catalog_plugin(const std::string& format_name,
 // list of file extensions, for the standard plugins that come with OIIO.
 // These won't be used unless EMBED_PLUGINS is defined.  Use the PLUGENTRY
 // macro to make the declaration compact and easy to read.
-#    define PLUGENTRY(name)                                                    \
-        ImageInput* name##_input_imageio_create();                             \
-        ImageOutput* name##_output_imageio_create();                           \
-        extern const char* name##_output_extensions[];                         \
-        extern const char* name##_input_extensions[];                          \
+#    define PLUGENTRY(name)                            \
+        ImageInput* name##_input_imageio_create();     \
+        ImageOutput* name##_output_imageio_create();   \
+        extern const char* name##_output_extensions[]; \
+        extern const char* name##_input_extensions[];  \
         extern const char* name##_imageio_library_version();
-#    define PLUGENTRY_RO(name)                                                 \
-        ImageInput* name##_input_imageio_create();                             \
-        extern const char* name##_input_extensions[];                          \
+#    define PLUGENTRY_RO(name)                        \
+        ImageInput* name##_input_imageio_create();    \
+        extern const char* name##_input_extensions[]; \
         extern const char* name##_imageio_library_version();
-#    define PLUGENTRY_WO(name)                                                 \
-        ImageOutput* name##_output_imageio_create();                           \
-        extern const char* name##_output_extensions[];                         \
+#    define PLUGENTRY_WO(name)                         \
+        ImageOutput* name##_output_imageio_create();   \
+        extern const char* name##_output_extensions[]; \
         extern const char* name##_imageio_library_version();
 
 PLUGENTRY(bmp);

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -951,15 +951,15 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     size_t peak_mem              = 0;
     Timer alltime;
 
-#define STATUS(task, timer)                                                    \
-    {                                                                          \
-        size_t mem = Sysutil::memory_used(true);                               \
-        peak_mem   = std::max(peak_mem, mem);                                  \
-        if (verbose)                                                           \
-            outstream << Strutil::sprintf("  %-25s %s   (%s)\n", task,         \
-                                          Strutil::timeintervalformat(timer,   \
-                                                                      2),      \
-                                          Strutil::memformat(mem));            \
+#define STATUS(task, timer)                                                  \
+    {                                                                        \
+        size_t mem = Sysutil::memory_used(true);                             \
+        peak_mem   = std::max(peak_mem, mem);                                \
+        if (verbose)                                                         \
+            outstream << Strutil::sprintf("  %-25s %s   (%s)\n", task,       \
+                                          Strutil::timeintervalformat(timer, \
+                                                                      2),    \
+                                          Strutil::memformat(mem));          \
     }
 
     ImageSpec configspec = _configspec;

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1788,12 +1788,12 @@ ImageCacheImpl::getstats(int level) const
         out << ") ver " << OIIO_VERSION_STRING << "\n";
 
         std::string opt;
-#define BOOLOPT(name)                                                          \
-    if (m_##name)                                                              \
+#define BOOLOPT(name) \
+    if (m_##name)     \
     opt += #name " "
 #define INTOPT(name) opt += Strutil::sprintf(#name "=%d ", m_##name)
-#define STROPT(name)                                                           \
-    if (m_##name.size())                                                       \
+#define STROPT(name)     \
+    if (m_##name.size()) \
     opt += Strutil::sprintf(#name "=\"%s\" ", m_##name)
         opt += Strutil::sprintf("max_memory_MB=%0.1f ",
                                 m_max_memory_bytes / (1024.0 * 1024.0));
@@ -2189,10 +2189,10 @@ ImageCacheImpl::attribute(string_view name, TypeDesc type, const void* val)
 bool
 ImageCacheImpl::getattribute(string_view name, TypeDesc type, void* val) const
 {
-#define ATTR_DECODE(_name, _ctype, _src)                                       \
-    if (name == _name && type == BaseTypeFromC<_ctype>::value) {               \
-        *(_ctype*)(val) = (_ctype)(_src);                                      \
-        return true;                                                           \
+#define ATTR_DECODE(_name, _ctype, _src)                         \
+    if (name == _name && type == BaseTypeFromC<_ctype>::value) { \
+        *(_ctype*)(val) = (_ctype)(_src);                        \
+        return true;                                             \
     }
 
     ATTR_DECODE("max_open_files", int, m_max_open_files);
@@ -2517,10 +2517,10 @@ ImageCacheImpl::get_image_info(ImageCacheFile* file,
                                int subimage, int miplevel, ustring dataname,
                                TypeDesc datatype, void* data)
 {
-#define ATTR_DECODE(_name, _ctype, _src)                                       \
-    if (dataname == _name && datatype == BaseTypeFromC<_ctype>::value) {       \
-        *(_ctype*)(data) = (_ctype)(_src);                                     \
-        return true;                                                           \
+#define ATTR_DECODE(_name, _ctype, _src)                                 \
+    if (dataname == _name && datatype == BaseTypeFromC<_ctype>::value) { \
+        *(_ctype*)(data) = (_ctype)(_src);                               \
+        return true;                                                     \
     }
 
     if (!thread_info)

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -376,12 +376,12 @@ TextureSystemImpl::getstats(int level, bool icstats) const
         out << "OpenImageIO Texture statistics\n";
 
         std::string opt;
-#define BOOLOPT(name)                                                          \
-    if (m_##name)                                                              \
+#define BOOLOPT(name) \
+    if (m_##name)     \
     opt += #name " "
 #define INTOPT(name) opt += Strutil::sprintf(#name "=%d ", m_##name)
-#define STROPT(name)                                                           \
-    if (m_##name.size())                                                       \
+#define STROPT(name)     \
+    if (m_##name.size()) \
     opt += Strutil::sprintf(#name "=\"%s\" ", m_##name)
         INTOPT(gray_to_rgb);
         INTOPT(flip_t);

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -658,8 +658,8 @@ Filesystem::parse_pattern(const char* pattern_, int framepadding_override,
     // string (e.g. "%04d").
 #define ONERANGE_SPEC "[0-9]+(-[0-9]+((x|y)-?[0-9]+)?)?"
 #define MANYRANGE_SPEC ONERANGE_SPEC "(," ONERANGE_SPEC ")*"
-#define SEQUENCE_SPEC                                                          \
-    "(" MANYRANGE_SPEC ")?"                                                    \
+#define SEQUENCE_SPEC       \
+    "(" MANYRANGE_SPEC ")?" \
     "((#|@)+|(%[0-9]*d))"
     static regex sequence_re(SEQUENCE_SPEC);
     // std::cout << "pattern >" << (SEQUENCE_SPEC) << "<\n";

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -51,7 +51,7 @@ namespace {
 static std::mutex output_mutex;
 
 // On systems that support it, get a location independent locale.
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)           \
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) \
     || defined(__FreeBSD_kernel__) || defined(__GLIBC__)
 static locale_t c_loc = newlocale(LC_ALL_MASK, "C", nullptr);
 #elif defined(_WIN32)
@@ -1279,7 +1279,7 @@ Strutil::strtof(const char* nptr, char** endptr) noexcept
 #ifdef __APPLE__
     // On OSX, strtod_l is for some reason drastically faster than strtof_l.
     return static_cast<float>(strtod_l(nptr, endptr, c_loc));
-#elif defined(__linux__) || defined(__FreeBSD__)                               \
+#elif defined(__linux__) || defined(__FreeBSD__) \
     || defined(__FreeBSD_kernel__) || defined(__GLIBC__)
     return strtof_l(nptr, endptr, c_loc);
 #elif defined(_WIN32)
@@ -1314,7 +1314,7 @@ double
 Strutil::strtod(const char* nptr, char** endptr) noexcept
 {
     // Can use strtod_l on platforms that support it
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)           \
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) \
     || defined(__FreeBSD_kernel__) || defined(__GLIBC__)
     // static initialization inside function is thread-safe by C++11 rules!
     return strtod_l(nptr, endptr, c_loc);

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -295,7 +295,7 @@ Sysutil::terminal_columns()
 {
     int columns = 80;  // a decent guess, if we have nothing more to go on
 
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)           \
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) \
     || defined(__FreeBSD_kernel__) || defined(__GNU__)
     struct winsize w;
     ioctl(0, TIOCGWINSZ, &w);
@@ -319,7 +319,7 @@ Sysutil::terminal_rows()
 {
     int rows = 24;  // a decent guess, if we have nothing more to go on
 
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)           \
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) \
     || defined(__FreeBSD_kernel__) || defined(__GNU__)
     struct winsize w;
     ioctl(0, TIOCGWINSZ, &w);

--- a/src/libutil/ustring.cpp
+++ b/src/libutil/ustring.cpp
@@ -337,7 +337,7 @@ ustring::TableRep::TableRep(string_view strref, size_t hash)
     // the std::string to make it point to our chars!  In such a case, the
     // destructor will be careful not to allow a deallocation.
 
-#if defined(__GNUC__) && !defined(_LIBCPP_VERSION)                             \
+#if defined(__GNUC__) && !defined(_LIBCPP_VERSION) \
     && defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI
     // NEW gcc ABI
     // FIXME -- do something smart with this.

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -59,48 +59,48 @@ static Oiiotool ot;
 // a lambda for each subimage. Beware, the macro expansion rules may require
 // you may need to enclose the lambda itself in parenthesis () if there it
 // contains commas that are not inside other parentheses.
-#define OIIOTOOL_OP(name, ninputs, ...)                                        \
-    static int action_##name(int argc, const char* argv[])                     \
-    {                                                                          \
-        if (ot.postpone_callback(ninputs, action_##name, argc, argv))          \
-            return 0;                                                          \
-        OiiotoolOp op(ot, #name, argc, argv, ninputs, __VA_ARGS__);            \
-        return op();                                                           \
+#define OIIOTOOL_OP(name, ninputs, ...)                               \
+    static int action_##name(int argc, const char* argv[])            \
+    {                                                                 \
+        if (ot.postpone_callback(ninputs, action_##name, argc, argv)) \
+            return 0;                                                 \
+        OiiotoolOp op(ot, #name, argc, argv, ninputs, __VA_ARGS__);   \
+        return op();                                                  \
     }
 
 // Canned setup for an op that uses one image on the stack.
-#define UNARY_IMAGE_OP(name, impl)                                             \
-    OIIOTOOL_OP(name, 1, [](OiiotoolOp& op, span<ImageBuf*> img) {             \
-        return impl(*img[0], *img[1]);                                         \
+#define UNARY_IMAGE_OP(name, impl)                                 \
+    OIIOTOOL_OP(name, 1, [](OiiotoolOp& op, span<ImageBuf*> img) { \
+        return impl(*img[0], *img[1]);                             \
     })
 
 // Canned setup for an op that uses two images on the stack.
-#define BINARY_IMAGE_OP(name, impl)                                            \
-    OIIOTOOL_OP(name, 2, [](OiiotoolOp& op, span<ImageBuf*> img) {             \
-        return impl(*img[0], *img[1], *img[2]);                                \
+#define BINARY_IMAGE_OP(name, impl)                                \
+    OIIOTOOL_OP(name, 2, [](OiiotoolOp& op, span<ImageBuf*> img) { \
+        return impl(*img[0], *img[1], *img[2]);                    \
     })
 
 // Canned setup for an op that uses one image on the stack and one color
 // on the command line.
-#define BINARY_IMAGE_COLOR_OP(name, impl, defaultval)                          \
-    OIIOTOOL_OP(name, 1, [](OiiotoolOp& op, span<ImageBuf*> img) {             \
-        int nchans = img[1]->spec().nchannels;                                 \
-        std::vector<float> val(nchans, defaultval);                            \
-        int nvals = Strutil::extract_from_list_string(val, op.args(1));        \
-        val.resize(nvals);                                                     \
-        val.resize(nchans, val.size() == 1 ? val.back() : defaultval);         \
-        return impl(*img[0], *img[1], val, ROI(), 0);                          \
+#define BINARY_IMAGE_COLOR_OP(name, impl, defaultval)                   \
+    OIIOTOOL_OP(name, 1, [](OiiotoolOp& op, span<ImageBuf*> img) {      \
+        int nchans = img[1]->spec().nchannels;                          \
+        std::vector<float> val(nchans, defaultval);                     \
+        int nvals = Strutil::extract_from_list_string(val, op.args(1)); \
+        val.resize(nvals);                                              \
+        val.resize(nchans, val.size() == 1 ? val.back() : defaultval);  \
+        return impl(*img[0], *img[1], val, ROI(), 0);                   \
     })
 
 // Macro to fully set up the "action" function that straightforwardly
 // calls a custom OiiotoolOp class.
-#define OP_CUSTOMCLASS(name, opclass, ninputs)                                 \
-    static int action_##name(int argc, const char* argv[])                     \
-    {                                                                          \
-        if (ot.postpone_callback(ninputs, action_##name, argc, argv))          \
-            return 0;                                                          \
-        opclass op(ot, #name, argc, argv);                                     \
-        return op();                                                           \
+#define OP_CUSTOMCLASS(name, opclass, ninputs)                        \
+    static int action_##name(int argc, const char* argv[])            \
+    {                                                                 \
+        if (ot.postpone_callback(ninputs, action_##name, argc, argv)) \
+            return 0;                                                 \
+        opclass op(ot, #name, argc, argv);                            \
+        return op();                                                  \
     }
 
 
@@ -5779,10 +5779,10 @@ handle_sequence(int argc, const char** argv)
 #define ONERANGE_SPEC "-?[0-9]+(--?[0-9]+((x|y)-?[0-9]+)?)?"
 #define MANYRANGE_SPEC ONERANGE_SPEC "(," ONERANGE_SPEC ")*"
 #define VIEW_SPEC "%[Vv]"
-#define SEQUENCE_SPEC                                                          \
-    "((" MANYRANGE_SPEC ")?"                                                   \
-    "((#|@)+|(%[0-9]*d)))"                                                     \
-    "|"                                                                        \
+#define SEQUENCE_SPEC        \
+    "((" MANYRANGE_SPEC ")?" \
+    "((#|@)+|(%[0-9]*d)))"   \
+    "|"                      \
     "(" VIEW_SPEC ")"
     static regex sequence_re(SEQUENCE_SPEC);
     std::string framespec = "";

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -161,18 +161,18 @@ dump_flat_data(ImageInput* input, const print_info_options& opt)
 
 
 // Macro to call a type-specialzed version func<type>(R,...)
-#define OIIO_DISPATCH_TYPES(ret, name, func, type, R, ...)                     \
-    switch (type.basetype) {                                                   \
-    case TypeDesc::FLOAT: ret = func<float>(R, __VA_ARGS__); break;            \
-    case TypeDesc::UINT8: ret = func<unsigned char>(R, __VA_ARGS__); break;    \
-    case TypeDesc::HALF: ret = func<half>(R, __VA_ARGS__); break;              \
-    case TypeDesc::UINT16: ret = func<unsigned short>(R, __VA_ARGS__); break;  \
-    case TypeDesc::INT8: ret = func<char>(R, __VA_ARGS__); break;              \
-    case TypeDesc::INT16: ret = func<short>(R, __VA_ARGS__); break;            \
-    case TypeDesc::UINT: ret = func<unsigned int>(R, __VA_ARGS__); break;      \
-    case TypeDesc::INT: ret = func<int>(R, __VA_ARGS__); break;                \
-    case TypeDesc::DOUBLE: ret = func<double>(R, __VA_ARGS__); break;          \
-    default: ret = false;                                                      \
+#define OIIO_DISPATCH_TYPES(ret, name, func, type, R, ...)                    \
+    switch (type.basetype) {                                                  \
+    case TypeDesc::FLOAT: ret = func<float>(R, __VA_ARGS__); break;           \
+    case TypeDesc::UINT8: ret = func<unsigned char>(R, __VA_ARGS__); break;   \
+    case TypeDesc::HALF: ret = func<half>(R, __VA_ARGS__); break;             \
+    case TypeDesc::UINT16: ret = func<unsigned short>(R, __VA_ARGS__); break; \
+    case TypeDesc::INT8: ret = func<char>(R, __VA_ARGS__); break;             \
+    case TypeDesc::INT16: ret = func<short>(R, __VA_ARGS__); break;           \
+    case TypeDesc::UINT: ret = func<unsigned int>(R, __VA_ARGS__); break;     \
+    case TypeDesc::INT: ret = func<int>(R, __VA_ARGS__); break;               \
+    case TypeDesc::DOUBLE: ret = func<double>(R, __VA_ARGS__); break;         \
+    default: ret = false;                                                     \
     }
 
 

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -29,14 +29,14 @@ using boost::math::gcd;
 #include <OpenEXR/ImfTiledInputFile.h>
 
 #ifdef OPENEXR_VERSION_MAJOR
-#    define OPENEXR_CODED_VERSION                                              \
-        (OPENEXR_VERSION_MAJOR * 10000 + OPENEXR_VERSION_MINOR * 100           \
+#    define OPENEXR_CODED_VERSION                                    \
+        (OPENEXR_VERSION_MAJOR * 10000 + OPENEXR_VERSION_MINOR * 100 \
          + OPENEXR_VERSION_PATCH)
 #else
 #    define OPENEXR_CODED_VERSION 20000
 #endif
 
-#if OPENEXR_CODED_VERSION >= 20400                                             \
+#if OPENEXR_CODED_VERSION >= 20400 \
     || __has_include(<OpenEXR/ImfFloatVectorAttribute.h>)
 #    define OPENEXR_HAS_FLOATVECTOR 1
 #else
@@ -614,9 +614,9 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
         case Imf::B44_COMPRESSION: comp = "b44"; break;
         case Imf::B44A_COMPRESSION: comp = "b44a"; break;
 #endif
-#if defined(OPENEXR_VERSION_MAJOR)                                             \
-    && (OPENEXR_VERSION_MAJOR * 10000 + OPENEXR_VERSION_MINOR * 100            \
-        + OPENEXR_VERSION_PATCH)                                               \
+#if defined(OPENEXR_VERSION_MAJOR)                                  \
+    && (OPENEXR_VERSION_MAJOR * 10000 + OPENEXR_VERSION_MINOR * 100 \
+        + OPENEXR_VERSION_PATCH)                                    \
            >= 20200
         case Imf::DWAA_COMPRESSION: comp = "dwaa"; break;
         case Imf::DWAB_COMPRESSION: comp = "dwab"; break;

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -19,14 +19,14 @@
 #include <OpenEXR/ImfTiledOutputFile.h>
 
 #ifdef OPENEXR_VERSION_MAJOR
-#    define OPENEXR_CODED_VERSION                                              \
-        (OPENEXR_VERSION_MAJOR * 10000 + OPENEXR_VERSION_MINOR * 100           \
+#    define OPENEXR_CODED_VERSION                                    \
+        (OPENEXR_VERSION_MAJOR * 10000 + OPENEXR_VERSION_MINOR * 100 \
          + OPENEXR_VERSION_PATCH)
 #else
 #    define OPENEXR_CODED_VERSION 20000
 #endif
 
-#if OPENEXR_CODED_VERSION >= 20400                                             \
+#if OPENEXR_CODED_VERSION >= 20400 \
     || __has_include(<OpenEXR/ImfFloatVectorAttribute.h>)
 #    define OPENEXR_HAS_FLOATVECTOR 1
 #else
@@ -891,9 +891,9 @@ OpenEXROutput::put_parameter(const std::string& name, TypeDesc type,
             else if (Strutil::iequals(str, "b44a"))
                 header.compression() = Imf::B44A_COMPRESSION;
 #endif
-#if defined(OPENEXR_VERSION_MAJOR)                                             \
-    && (OPENEXR_VERSION_MAJOR * 10000 + OPENEXR_VERSION_MINOR * 100            \
-        + OPENEXR_VERSION_PATCH)                                               \
+#if defined(OPENEXR_VERSION_MAJOR)                                  \
+    && (OPENEXR_VERSION_MAJOR * 10000 + OPENEXR_VERSION_MINOR * 100 \
+        + OPENEXR_VERSION_PATCH)                                    \
            >= 20200
             else if (Strutil::iequals(str, "dwaa"))
                 header.compression() = Imf::DWAA_COMPRESSION;

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -19,8 +19,8 @@
 #include <OpenImageIO/typedesc.h>
 
 
-#define OIIO_LIBPNG_VERSION                                                    \
-    (PNG_LIBPNG_VER_MAJOR * 10000 + PNG_LIBPNG_VER_MINOR * 100                 \
+#define OIIO_LIBPNG_VERSION                                    \
+    (PNG_LIBPNG_VER_MAJOR * 10000 + PNG_LIBPNG_VER_MINOR * 100 \
      + PNG_LIBPNG_VER_RELEASE)
 
 

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -462,10 +462,10 @@ private:
 // 1) Add ADD_LOADER(<ResourceID>) below
 // 2) Add a method in PSDInput:
 //    bool load_resource_<ResourceID> (uint32_t length);
-#define ADD_LOADER(id)                                                         \
-    {                                                                          \
-        id, std::bind(&PSDInput::load_resource_##id, std::placeholders::_1,    \
-                      std::placeholders::_2)                                   \
+#define ADD_LOADER(id)                                                      \
+    {                                                                       \
+        id, std::bind(&PSDInput::load_resource_##id, std::placeholders::_1, \
+                      std::placeholders::_2)                                \
     }
 const PSDInput::ResourceLoader PSDInput::resource_loaders[]
     = { ADD_LOADER(1005), ADD_LOADER(1006), ADD_LOADER(1010), ADD_LOADER(1033),

--- a/src/ptex.imageio/ptexinput.cpp
+++ b/src/ptex.imageio/ptexinput.cpp
@@ -190,13 +190,13 @@ PtexInput::seek_subimage(int subimage, int miplevel)
         wrapmode += "periodic";
     m_spec.attribute("wrapmode", wrapmode);
 
-#define GETMETA(pmeta, key, ptype, basetype, typedesc, value)                  \
-    {                                                                          \
-        const ptype* v;                                                        \
-        int count;                                                             \
-        pmeta->getValue(key, v, count);                                        \
-        typedesc = TypeDesc(basetype, count);                                  \
-        value    = (const void*)v;                                             \
+#define GETMETA(pmeta, key, ptype, basetype, typedesc, value) \
+    {                                                         \
+        const ptype* v;                                       \
+        int count;                                            \
+        pmeta->getValue(key, v, count);                       \
+        typedesc = TypeDesc(basetype, count);                 \
+        value    = (const void*)v;                            \
     }
 
     PtexMetaData* pmeta = m_ptex->getMetaData();

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -548,9 +548,9 @@ ParamValue_getitem(const ParamValue& self, bool allitems = false)
     TypeDesc t = self.type();
     int nvals  = allitems ? self.nvalues() : 1;
 
-#define ParamValue_convert_dispatch(TYPE)                                      \
-case TypeDesc::TYPE:                                                           \
-    return C_to_val_or_tuple((CType<TypeDesc::TYPE>::type*)self.data(), t,     \
+#define ParamValue_convert_dispatch(TYPE)                                  \
+case TypeDesc::TYPE:                                                       \
+    return C_to_val_or_tuple((CType<TypeDesc::TYPE>::type*)self.data(), t, \
                              nvals)
 
     switch (t.basetype) {

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -19,7 +19,7 @@
 #    pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-#if OIIO_CPLUSPLUS_VERSION >= 17                                               \
+#if OIIO_CPLUSPLUS_VERSION >= 17 \
     && (OIIO_CLANG_VERSION || OIIO_APPLE_CLANG_VERSION)
 // libraw uses auto_ptr, which is not in C++17 at all for clang, though
 // it does seem to be for gcc. So for clang, alias it to unique_ptr.

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -363,11 +363,11 @@ RLAInput::seek_subimage(int subimage, int miplevel)
     }
 
     // save some typing by using macros
-#define FIELD(x, name)                                                         \
-    if (m_rla.x > 0)                                                           \
+#define FIELD(x, name) \
+    if (m_rla.x > 0)   \
     m_spec.attribute(name, m_rla.x)
-#define STRING_FIELD(x, name)                                                  \
-    if (m_rla.x[0])                                                            \
+#define STRING_FIELD(x, name) \
+    if (m_rla.x[0])           \
     m_spec.attribute(name, m_rla.x)
 
     STRING_FIELD(Description, "ImageDescription");

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -317,15 +317,15 @@ RLAOutput::open(const std::string& name, const ImageSpec& userspec,
     set_chromaticity(p, m_rla.WhitePoint, sizeof(m_rla.WhitePoint),
                      "0.31 0.316");
 
-#define STRING_FIELD(rlafield, name)                                           \
-    {                                                                          \
-        std::string s = m_spec.get_string_attribute(name);                     \
-        if (s.length()) {                                                      \
-            strncpy(m_rla.rlafield, s.c_str(), sizeof(m_rla.rlafield));        \
-            m_rla.rlafield[sizeof(m_rla.rlafield) - 1] = 0;                    \
-        } else {                                                               \
-            m_rla.rlafield[0] = 0;                                             \
-        }                                                                      \
+#define STRING_FIELD(rlafield, name)                                    \
+    {                                                                   \
+        std::string s = m_spec.get_string_attribute(name);              \
+        if (s.length()) {                                               \
+            strncpy(m_rla.rlafield, s.c_str(), sizeof(m_rla.rlafield)); \
+            m_rla.rlafield[sizeof(m_rla.rlafield) - 1] = 0;             \
+        } else {                                                        \
+            m_rla.rlafield[0] = 0;                                      \
+        }                                                               \
     }
 
     m_rla.JobNumber = m_spec.get_int_attribute("rla:JobNumber", 0);

--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -112,8 +112,8 @@ TGAInput::open(const std::string& name, ImageSpec& newspec)
     // due to struct packing, we may get a corrupt header if we just load the
     // struct from file; to adress that, read every member individually
     // save some typing
-#define RH(memb)                                                               \
-    if (!fread(&m_tga.memb, sizeof(m_tga.memb), 1))                            \
+#define RH(memb)                                    \
+    if (!fread(&m_tga.memb, sizeof(m_tga.memb), 1)) \
     return false
 
     RH(idlen);


### PR DESCRIPTION
I just like this better than the prior habit of putting it one PAST
the column width, which made the backslashes go in column 81, ick.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
