### PR TITLE
ImageCache should not close IOProxy-based files to stay in file limits

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -304,6 +304,11 @@ ImageCacheFile::ImageCacheFile(ImageCacheImpl& imagecache,
                  || m_filename.find("<u>") != m_filename.npos
                  || m_filename.find("<v>") != m_filename.npos)
                 && !Filesystem::exists(m_filename);
+
+    // If the config has an IOProxy, remember that we should never actually
+    // release() it, because the proxy can't be reopened.
+    if (config && config->find_attribute("oiio:ioproxy", TypeDesc::PTR))
+        m_allow_release = false;
 }
 
 
@@ -1060,7 +1065,7 @@ ImageCacheFile::release()
     m_mutex_wait_time += input_mutex_timer();
     if (m_used)
         m_used = false;
-    else
+    else if (m_allow_release)
         close();
 }
 

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -336,6 +336,7 @@ private:
     ustring m_filename;            ///< Filename
     bool m_used;                   ///< Recently used (in the LRU sense)
     bool m_broken;                 ///< has errors; can't be used properly
+    bool m_allow_release = true;   ///< Allow the file to release()?
     std::string m_broken_message;  ///< Error message for why it's broken
     std::shared_ptr<ImageInput> m_input;  ///< Open ImageInput, NULL if closed
         // Note that m_input, the shared pointer itself, is NOT safe to


### PR DESCRIPTION
The thing about IOProxy is, once closed, it can't be reopened. So it's
important that if an IOProxy-based file is in the IC, its ImageInput
should not be reclaimed by closing it (and that might not help the
file handle count anyway, since the main use of an IOProxy under those
circumstances is probably to read an image from memory).

Signed-off-by: Larry Gritz <lg@larrygritz.com>

