### PR TITLE
Rejigger the build dir's detail area to be in the same spot as dist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ include_directories (
     "${CMAKE_SOURCE_DIR}/src/include"
     "${CMAKE_BINARY_DIR}/src/include"
     "${CMAKE_BINARY_DIR}/include"
+    "${CMAKE_BINARY_DIR}/include/OpenImageIO"
   )
 
 # Tell CMake to process the sub-directories

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -51,7 +51,7 @@ set (fmt_headers
         ${FMT_INCLUDES}/fmt/ostream.h
         ${FMT_INCLUDES}/fmt/printf.h )
 file (COPY ${fmt_headers}
-      DESTINATION ${CMAKE_BINARY_DIR}/include/detail/fmt)
+      DESTINATION ${CMAKE_BINARY_DIR}/include/OpenImageIO/detail/fmt)
 install (FILES ${fmt_headers}
          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/detail/fmt
          COMPONENT developer)
@@ -62,7 +62,7 @@ if (NOT USE_EXTERNAL_PUGIXML)
           OpenImageIO/detail/pugixml/pugiconfig.hpp
           OpenImageIO/detail/pugixml/pugixml.cpp)
     file (COPY ${pugixml_headers}
-          DESTINATION ${CMAKE_BINARY_DIR}/include/detail/pugixml)
+          DESTINATION ${CMAKE_BINARY_DIR}/include/OpenImageIO/detail/pugixml)
     install (FILES ${pugixml_headers}
              DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/detail/pugixml
              COMPONENT developer)


### PR DESCRIPTION
This just makes the build area's directory layout more closely resemble the source and install areas. The 'detail' directory, just in the temp build area, was one level below where we put it in src and install.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

