### PR TITLE
Document design flaw in Python ParamValue.type

### DIFF
--- a/src/python/py_paramvalue.cpp
+++ b/src/python/py_paramvalue.cpp
@@ -125,6 +125,15 @@ declare_paramvalue(py::module& m)
                                [](const ParamValue& p) {
                                    return PY_STR(p.name().string());
                                })
+        // FIXME: This implementation of `type` is almost certainly a
+        // mistake. This should return p.type(), just a TypeDesc, not a
+        // string. I think this was an error introduced in the Python
+        // binding overhaul of OIIO 2.0.  We can't break back compatibility
+        // by changing it until 3.0. It should really look like this:
+        //   .def_property_readonly("type",
+        //                          [](const ParamValue& p) {
+        //                              return p.type();
+        //                          })
         .def_property_readonly("type",
                                [](const ParamValue& p) {
                                    return PY_STR(p.type().c_str());


### PR DESCRIPTION
Oops, ParamValue.type ought to be a TypeDesc, just like in C++.  In
the Python binding overhaul of 2.0, it seems that I made a mistake and
unintentionally changed it to appear to Python as a string (e.g.,
'int' rather than TypeDesc('int')).

Fixing it to be the way it was originally intended would involve a
breaking change and not appropriate until such things are allowed by a
2.x -> 3.0 transition, so we'll just have to live with it.

Closes #2672 

Signed-off-by: Larry Gritz <lg@larrygritz.com>
