### PR TITLE
oiiotool: fix some multi-subimage bugs when outputting images

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -3222,7 +3222,7 @@ action_croptofull(int argc, const char* argv[])
 
     if (crops_needed) {
         ot.pop();
-        ImageRecRef R(new ImageRec(A->name(), A->subimages()));
+        ImageRecRef R(new ImageRec(A->name(), subimages));
         ot.push(R);
         for (int s = 0; s < subimages; ++s) {
             const ImageBuf& Aib((*A)(s, 0));
@@ -4643,7 +4643,7 @@ output_file(int /*argc*/, const char* argv[])
         bool found = parse_channels(*ir->spec(), chanlist, channels);
         if (!found)
             chanlist = alpha ? "0,1,2,3" : "0,1,2";
-        const char* argv[] = { "channels", chanlist.c_str() };
+        const char* argv[] = { "channels:allsubimages=1", chanlist.c_str() };
         int action_channels(int argc, const char* argv[]);  // forward decl
         action_channels(2, argv);
         ot.warningf(command, "Can't save %d channels to %s... saving only %s",
@@ -4666,7 +4666,7 @@ output_file(int /*argc*/, const char* argv[])
                       : format_resolution(roi.width(), roi.height(),
                                           roi.depth(), roi.xbegin, roi.ybegin,
                                           roi.zbegin);
-            const char* argv[] = { "crop", crop.c_str() };
+            const char* argv[] = { "crop:allsubimages=1", crop.c_str() };
             int action_crop(int argc, const char* argv[]);  // forward decl
             action_crop(2, argv);
             ir = ot.curimg;
@@ -4681,7 +4681,7 @@ output_file(int /*argc*/, const char* argv[])
             || ir->spec()->y != ir->spec()->full_y
             || ir->spec()->width != ir->spec()->full_width
             || ir->spec()->height != ir->spec()->full_height)) {
-        const char* argv[] = { "croptofull" };
+        const char* argv[] = { "croptofull:allsubimages=1" };
         int action_croptofull(int argc, const char* argv[]);  // forward decl
         action_croptofull(1, argv);
         ir = ot.curimg;
@@ -4734,7 +4734,7 @@ output_file(int /*argc*/, const char* argv[])
                 std::cout << "  Converting from " << currentspace << " to "
                           << outcolorspace << " for output to " << filename
                           << "\n";
-            const char* argv[] = { "colorconvert:strict=0",
+            const char* argv[] = { "colorconvert:strict=0:allsubimages=1",
                                    currentspace.c_str(),
                                    outcolorspace.c_str() };
             action_colorconvert(3, argv);
@@ -4756,7 +4756,7 @@ output_file(int /*argc*/, const char* argv[])
                                : format_resolution(roi.width(), roi.height(),
                                                    roi.depth(), roi.xbegin,
                                                    roi.ybegin, roi.zbegin);
-        const char* argv[] = { "crop", crop.c_str() };
+        const char* argv[] = { "crop:allsubimages=1", crop.c_str() };
         int action_crop(int argc, const char* argv[]);  // forward decl
         action_crop(2, argv);
         ir = ot.curimg;


### PR DESCRIPTION
Plain old bug in all cases:

--croptofull botched the subimage count by reserving space for results
based on the subimages in the input image, but then only producing
results for the first one if -a (or :allsubimages=1) was not used.

Output specific bugs:

There are some operations that happen ephemerally upon output, mostly
to account for output file formats that don't support some feature of
the top image (like action_croptofull if the output format doesn't
support differing display and data windows, or action_channels if
there are more channels than are supported by the format, or
action_colorconvert when --autocc is used).

In these cases, we were forgetting that those operations may tend to
drop all but the first subimages, if no -a or :allsubimages=1 is not
used.  But that's NOT the behavior we want in this case, because for
output specifically, we never want to drop subimages. This is because
we want a simple format conversion like

    oiiotool in.xyz -o out.pdq

to faithfully copy, not "narrow" to one subimage, even if some other
operations on their own will tend to drop all but the first subimage if
not instructed to preserve them all.

So the solution is that we need to add ":allsubimages=1" modifier to
these ephemerally called adjustments.
