### PR TITLE
Support for libheif 1.8

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,7 +49,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * giflib >= 4.1 (tested through 5.2; 5.0+ is strongly recommended for
        stability and thread safety)
  * If you want support for HEIF/HEIC images:
-     * libheif >= 1.3 (tested through 1.6; older versions may also work, we
+     * libheif >= 1.3 (tested through 1.8; older versions may also work, we
        haven't tested)
  * If you want support for DDS files:
      * libsquish >= 1.13 (tested through 1.15)

--- a/src/libOpenImageIO/imageinout_test.cpp
+++ b/src/libOpenImageIO/imageinout_test.cpp
@@ -27,15 +27,23 @@ make_test_image(string_view formatname)
     auto out = ImageOutput::create(formatname);
     OIIO_DASSERT(out);
     ImageSpec spec(64, 64, 4, TypeFloat);
+    float pval = 1.0f;
+    // Fill with 0 for lossy HEIF
+    if (formatname == "heif")
+        pval = 0.0f;
+
+    // Accommodate limited numbers of channels
     if (formatname == "zfile" || formatname == "fits")
         spec.nchannels = 1;  // these formats are single channel
     else if (!out->supports("alpha"))
-        spec.nchannels = 3;  // this channel doesn't support alpha
+        spec.nchannels = std::min(spec.nchannels, 3);
+
     // Force a fixed datetime metadata so it can't differ between writes
     // and make different file patterns for these tests.
     spec.attribute("DateTime", "01/01/2000 00:00:00");
+
     buf.reset(spec);
-    ImageBufAlgo::fill(buf, { 1.0f, 1.0f, 1.0f, 1.0f });
+    ImageBufAlgo::fill(buf, { pval, pval, pval, 1.0f });
     return buf;
 }
 


### PR DESCRIPTION
HEIF is a lossy format, and it seems libheif 1.8 changed internally
in such a way that the bit-for-bit comparsions of the write-read
cycle we do in imageinout_test started failing. (Bummer on our Mac
CI, where the homebrew version of libheif updated automatically and
then started failing.)

The easy solution is that just for this test, write zeros to the image,
not 1.0 values (which were coming out 254, not the expected 255).

Signed-off-by: Larry Gritz <lg@larrygritz.com>

