### PR TITLE
Stop running the "openexr-damaged" test for CI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,10 +399,15 @@ oiio_add_tests (jpeg2000
                 IMAGEDIR j2kp4files_v1_5
                 URL http://www.itu.int/net/ITU-T/sigdb/speimage/ImageForm-s.aspx?val=10100803)
 oiio_add_tests (openexr-suite openexr-multires openexr-chroma
-                openexr-v2 openexr-window openexr-damaged perchannel
+                openexr-v2 openexr-window perchannel
                 oiiotool-deep
                 IMAGEDIR openexr-images
                 URL http://www.openexr.com/downloads.html)
+if (NOT DEFINED ENV{TRAVIS} AND NOT DEFINED ENV{CIRCLECI} AND NOT DEFINED ENV{GITHUB_ACTIONS})
+    oiio_add_tests (openexr-damaged
+                    IMAGEDIR openexr-images
+                    URL http://www.openexr.com/downloads.html)
+endif ()
 oiio_add_tests (openvdb
                 FOUNDVAR OpenVDB_FOUND ENABLEVAR ENABLE_OpenVDB)
 oiio_add_tests (png


### PR DESCRIPTION
It's been endless trouble, because the nature of the test is malformed
images that fail in inconsistent ways. I can never seem to make a
stable set of reference output for it, especially for OpenEXR
development master, which is always adding new fixes or tinkering with
exceptions and error messages.

So just don't run that test in the automated CI.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

