### PR TITLE
ffmpeg reader: avoid potential crash when frame can't be read

### DIFF
--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -578,8 +578,14 @@ FFmpegInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
     if (!m_read_frame) {
         read_frame(m_subimage);
     }
-    memcpy(data, m_rgb_frame->data[0] + y * m_rgb_frame->linesize[0], m_stride);
-    return true;
+    if (m_rgb_frame->data[0]) {
+        memcpy(data, m_rgb_frame->data[0] + y * m_rgb_frame->linesize[0],
+               m_stride);
+        return true;
+    } else {
+        errorf("Error reading frame");
+        return false;
+    }
 }
 
 


### PR DESCRIPTION
Don't copy from the data pointer if it's null, that indicates an error.

Related to issue #2688, but doesn't fully solve it.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
