### PR TITLE
Python: Direct support for 'half' using numpy.float16 type

### DIFF
--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -11,15 +11,15 @@ const char*
 python_array_code(TypeDesc format)
 {
     switch (format.basetype) {
-    case TypeDesc::UINT8: return "B";
-    case TypeDesc::INT8: return "b";
-    case TypeDesc::UINT16: return "H";
-    case TypeDesc::INT16: return "h";
-    case TypeDesc::UINT32: return "I";
-    case TypeDesc::INT32: return "i";
-    case TypeDesc::FLOAT: return "f";
-    case TypeDesc::DOUBLE: return "d";
-    case TypeDesc::HALF: return "e";
+    case TypeDesc::UINT8: return "uint8";
+    case TypeDesc::INT8: return "int8";
+    case TypeDesc::UINT16: return "uint16";
+    case TypeDesc::INT16: return "int16";
+    case TypeDesc::UINT32: return "uint32";
+    case TypeDesc::INT32: return "int32";
+    case TypeDesc::FLOAT: return "float";
+    case TypeDesc::DOUBLE: return "double";
+    case TypeDesc::HALF: return "half";
     default:
         // For any other type, including UNKNOWN, pack it into an
         // unsigned byte array.
@@ -30,22 +30,34 @@ python_array_code(TypeDesc format)
 
 
 TypeDesc
-typedesc_from_python_array_code(char code)
+typedesc_from_python_array_code(string_view code)
 {
-    switch (code) {
-    case 'b':
-    case 'c': return TypeDesc::INT8;
-    case 'B': return TypeDesc::UINT8;
-    case 'h': return TypeDesc::INT16;
-    case 'H': return TypeDesc::UINT16;
-    case 'i': return TypeDesc::INT;
-    case 'I': return TypeDesc::UINT;
-    case 'l': return TypeDesc::INT64;
-    case 'L': return TypeDesc::UINT64;
-    case 'f': return TypeDesc::FLOAT;
-    case 'd': return TypeDesc::DOUBLE;
-    case 'e': return TypeDesc::HALF;
-    }
+    TypeDesc t(code);
+    if (!t.is_unknown())
+        return t;
+
+    if (code == "b" || code == "c")
+        return TypeDesc::INT8;
+    if (code == "B")
+        return TypeDesc::UINT8;
+    if (code == "h")
+        return TypeDesc::INT16;
+    if (code == "H")
+        return TypeDesc::UINT16;
+    if (code == "i")
+        return TypeDesc::INT;
+    if (code == "I")
+        return TypeDesc::UINT;
+    if (code == "l")
+        return TypeDesc::INT64;
+    if (code == "L")
+        return TypeDesc::UINT64;
+    if (code == "f")
+        return TypeDesc::FLOAT;
+    if (code == "d")
+        return TypeDesc::DOUBLE;
+    if (code == "float16" || code == "e")
+        return TypeDesc::HALF;
     return TypeDesc::UNKNOWN;
 }
 
@@ -54,7 +66,7 @@ typedesc_from_python_array_code(char code)
 oiio_bufinfo::oiio_bufinfo(const py::buffer_info& pybuf)
 {
     if (pybuf.format.size())
-        format = typedesc_from_python_array_code(pybuf.format[0]);
+        format = typedesc_from_python_array_code(pybuf.format);
     if (format != TypeUnknown) {
         data    = pybuf.ptr;
         xstride = format.size();
@@ -77,7 +89,7 @@ oiio_bufinfo::oiio_bufinfo(const py::buffer_info& pybuf, int nchans, int width,
                            int height, int depth, int pixeldims)
 {
     if (pybuf.format.size())
-        format = typedesc_from_python_array_code(pybuf.format[0]);
+        format = typedesc_from_python_array_code(pybuf.format);
     if (size_t(pybuf.itemsize) != format.size()
         || pybuf.size
                != int64_t(width) * int64_t(height) * int64_t(depth * nchans)) {

--- a/testsuite/python-imageinput/ref/out-alt.txt
+++ b/testsuite/python-imageinput/ref/out-alt.txt
@@ -143,11 +143,11 @@ Read array typecode uint16  [ 12288 ]
 
 Test read_tiles native half:
 Opened "testf16.exr" as a openexr
-Read array typecode uint16  [ 12288 ]
+Read array typecode float16  [ 12288 ]
 
 Test read_image into half:
 Opened "testu16.tif" as a tiff
-Read array typecode uint16  [ 12288 ]
+Read array typecode float16  [ 12288 ]
 
 Test read_image into FLOAT:
 Opened "testu16.tif" as a tiff

--- a/testsuite/python-imageinput/ref/out-alt2.txt
+++ b/testsuite/python-imageinput/ref/out-alt2.txt
@@ -143,11 +143,11 @@ Read array typecode uint16  [ 12288 ]
 
 Test read_tiles native half:
 Opened "testf16.exr" as a openexr
-Read array typecode uint16  [ 12288 ]
+Read array typecode float16  [ 12288 ]
 
 Test read_image into half:
 Opened "testu16.tif" as a tiff
-Read array typecode uint16  [ 12288 ]
+Read array typecode float16  [ 12288 ]
 
 Test read_image into FLOAT:
 Opened "testu16.tif" as a tiff

--- a/testsuite/python-imageinput/ref/out-python3.txt
+++ b/testsuite/python-imageinput/ref/out-python3.txt
@@ -143,11 +143,11 @@ Read array typecode uint16  [ 12288 ]
 
 Test read_tiles native half:
 Opened "testf16.exr" as a openexr
-Read array typecode uint16  [ 12288 ]
+Read array typecode float16  [ 12288 ]
 
 Test read_image into half:
 Opened "testu16.tif" as a tiff
-Read array typecode uint16  [ 12288 ]
+Read array typecode float16  [ 12288 ]
 
 Test read_image into FLOAT:
 Opened "testu16.tif" as a tiff

--- a/testsuite/python-imageinput/ref/out-travis-py2.7-pybind2.3.txt
+++ b/testsuite/python-imageinput/ref/out-travis-py2.7-pybind2.3.txt
@@ -143,11 +143,11 @@ Read array typecode uint16  [ 12288 ]
 
 Test read_tiles native half:
 Opened "testf16.exr" as a openexr
-Read array typecode uint16  [ 12288 ]
+Read array typecode float16  [ 12288 ]
 
 Test read_image into half:
 Opened "testu16.tif" as a tiff
-Read array typecode uint16  [ 12288 ]
+Read array typecode float16  [ 12288 ]
 
 Test read_image into FLOAT:
 Opened "testu16.tif" as a tiff

--- a/testsuite/python-imageinput/ref/out-travis.txt
+++ b/testsuite/python-imageinput/ref/out-travis.txt
@@ -143,11 +143,11 @@ Read array typecode uint16  [ 12288 ]
 
 Test read_tiles native half:
 Opened "testf16.exr" as a openexr
-Read array typecode uint16  [ 12288 ]
+Read array typecode float16  [ 12288 ]
 
 Test read_image into half:
 Opened "testu16.tif" as a tiff
-Read array typecode uint16  [ 12288 ]
+Read array typecode float16  [ 12288 ]
 
 Test read_image into FLOAT:
 Opened "testu16.tif" as a tiff

--- a/testsuite/python-imageinput/ref/out.txt
+++ b/testsuite/python-imageinput/ref/out.txt
@@ -143,11 +143,11 @@ Read array typecode uint16  [ 12288 ]
 
 Test read_tiles native half:
 Opened "testf16.exr" as a openexr
-Read array typecode uint16  [ 12288 ]
+Read array typecode float16  [ 12288 ]
 
 Test read_image into half:
 Opened "testu16.tif" as a tiff
-Read array typecode uint16  [ 12288 ]
+Read array typecode float16  [ 12288 ]
 
 Test read_image into FLOAT:
 Opened "testu16.tif" as a tiff

--- a/testsuite/python-imageoutput/ref/out.txt
+++ b/testsuite/python-imageoutput/ref/out.txt
@@ -1,10 +1,11 @@
-Copied scanline.tif to grid-image.tif as image
-Copied scanline.tif to grid-scanline.tif as scanline
-Copied scanline.tif to grid-scanlines.tif as scanlines
-Copied tiled.tif to grid-timage.tif as image
-Copied tiled.tif to grid-tile.tif as tile
-Copied tiled.tif to grid-tiles.tif as tiles
-Copied scanline.tif to grid-image.tif as image
+Copied scanline.tif to grid-image.tif as image (memformat float outformat unknown )
+Copied scanline.tif to grid-scanline.tif as scanline (memformat float outformat unknown )
+Copied scanline.tif to grid-scanlines.tif as scanlines (memformat float outformat unknown )
+Copied tiled.tif to grid-timage.tif as image (memformat float outformat unknown )
+Copied tiled.tif to grid-tile.tif as tile (memformat float outformat unknown )
+Copied tiled.tif to grid-tiles.tif as tiles (memformat float outformat unknown )
+Copied scanline.tif to grid-image.tif as image (memformat uint8 outformat uint16 )
+Copied scanline.tif to grid-half.exr as image (memformat half outformat half )
 Done.
 Comparing "grid-image.tif" and "../../../../../oiio-images/grid.tif"
 PASS
@@ -17,6 +18,8 @@ PASS
 Comparing "grid-tile.tif" and "../../../../../oiio-images/grid.tif"
 PASS
 Comparing "grid-tiles.tif" and "../../../../../oiio-images/grid.tif"
+PASS
+Comparing "grid-half.exr" and "../../../../../oiio-images/grid.tif"
 PASS
 Comparing "multipart.exr" and "ref/multipart.exr"
 PASS

--- a/testsuite/python-imageoutput/run.py
+++ b/testsuite/python-imageoutput/run.py
@@ -10,9 +10,10 @@ command += pythonbin + " src/test_imageoutput.py > out.txt ;"
 
 # compare the outputs -- these are custom because they compare to grid.tif
 files = [ "grid-image.tif", "grid-scanline.tif", "grid-scanlines.tif",
-          "grid-timage.tif", "grid-tile.tif", "grid-tiles.tif" ]
+          "grid-timage.tif", "grid-tile.tif", "grid-tiles.tif", "grid-half.exr" ]
 for f in files :
-    command += oiio_app("idiff") + f + " " + imagedir + "/grid.tif >> out.txt;"
+    command += (oiio_app("idiff") + " -fail 0.001 -warn 0.001 "
+                + f + " " + imagedir + "/grid.tif >> out.txt;")
 
 outputs = [ "multipart.exr", "out.txt" ]
 

--- a/testsuite/python-imageoutput/src/test_imageoutput.py
+++ b/testsuite/python-imageoutput/src/test_imageoutput.py
@@ -84,7 +84,8 @@ def copy_image (in_filename, out_filename, method="image",
     input.close ()
     output.close ()
     if ok :
-        print ("Copied", in_filename, "to", out_filename, "as", method)
+        print ("Copied", in_filename, "to", out_filename, "as", method,
+               "(memformat", memformat, "outformat", outformat, ")")
 
 
 def test_subimages (out_filename="multipart.exr") :
@@ -114,6 +115,10 @@ try:
     # Regression test for crash when changing formats
     copy_image ("scanline.tif", "grid-image.tif",
                 memformat=oiio.TypeUInt8, outformat=oiio.TypeUInt16)
+
+    # Exercise 'half'
+    copy_image ("scanline.tif", "grid-half.exr",
+                memformat='half', outformat='half')
 
     # Ensure we can write multiple subimages
     test_subimages ()


### PR DESCRIPTION
When transferring blocks of pixels (for example, by ImageInput.read_image
or ImageOutput.write_image), "half" pixels ended up mangled into uint16,
the only type of the right bit width.

But NumPy has a numpy.float16 type! A little bit of extra hinting to
pybind11 makes this work as users probably expect.

Fixes #2689  

Signed-off-by: Larry Gritz <lg@larrygritz.com>
