### PR TITLE
Python: be more forgiving in what's passed to attribute()

### DIFF
--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -198,7 +198,7 @@ declare_imagespec(py::module& m)
                 const std::string& val) { spec.attribute(name, val); })
         .def("attribute",
              [](ImageSpec& spec, const std::string& name, TypeDesc type,
-                const py::tuple& obj) {
+                const py::object& obj) {
                  attribute_typed(spec, name, type, obj);
              })
         // .def("attribute", [](ImageSpec &spec, const std::string &name, TypeDesc type, const py::list &obj) {

--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -173,7 +173,7 @@ oiio_bufinfo::oiio_bufinfo(const py::buffer_info& pybuf, int nchans, int width,
 
 bool
 oiio_attribute_typed(const std::string& name, TypeDesc type,
-                     const py::tuple& obj)
+                     const py::object& obj)
 {
     if (type.basetype == TypeDesc::INT) {
         std::vector<int> vals;
@@ -259,7 +259,7 @@ OIIO_DECLARE_PYMODULE(PYMODULE_NAME)
         OIIO::attribute(name, val);
     });
     m.def("attribute",
-          [](const std::string& name, TypeDesc type, const py::tuple& obj) {
+          [](const std::string& name, TypeDesc type, const py::object& obj) {
               oiio_attribute_typed(name, type, obj);
           });
 


### PR DESCRIPTION
We have many classes that have methods

    .attribute(name, intval)
    .attribute(name, floatval)
    .attribute(name, stringval)
    .attribute(name, TypeDesc, anyval)

For ImageSpec.attribute() and OIIO.attribute(), the anyval was
restricted to only accept tuples. Fix these to bring them in line with
many other classes' attribute calls in which the 'anyval' really can
be just about anything -- tuples, lists, numpy arrays or other buffer
objects, or scalar values.

Fixes #2674 

Signed-off-by: Larry Gritz <lg@larrygritz.com>
