### PR TITLE
Fix ImageBuf vs ImageCache out-of-date image problem

### DIFF
--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -117,7 +117,10 @@ public:
     ///             first subimage of the file, highest-res MIP level).
     /// @param imagecache
     ///             Optionally, a particular ImageCache to use. If nullptr,
-    ///             the default global/shared image cache will be used.
+    ///             the default global/shared image cache will be used. If
+    ///             a custom ImageCache (not the global/shared one), it is
+    ///             important that the IC should not be destroyed while the
+    ///             ImageBuf is still alive.
     /// @param config
     ///             Optionally, a pointer to an ImageSpec whose metadata
     ///             contains configuration hints that set options related

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -233,6 +233,17 @@ public:
         return (z * m_spec.height + y) * m_spec.width + x;
     }
 
+    // Invalidate the file in our imagecache and the shared one
+    void invalidate(ustring filename, bool force)
+    {
+        ImageCache* shared_imagecache = ImageCache::create(true);
+        OIIO_DASSERT(shared_imagecache);
+        if (m_imagecache)
+            m_imagecache->invalidate(filename, force);  // *our* IC
+        if (m_imagecache != shared_imagecache)
+            shared_imagecache->invalidate(filename, force);  // the shared IC
+    }
+
 private:
     ImageBuf::IBStorage m_storage;  ///< Pixel storage class
     ustring m_name;                 ///< Filename of the image
@@ -347,6 +358,9 @@ ImageBufImpl::ImageBufImpl(string_view filename, int subimage, int miplevel,
         m_spec_valid = true;
     } else if (filename.length() > 0) {
         OIIO_DASSERT(buffer == nullptr);
+        // Invalidate the image in cache. Do so unconditionally if there's
+        // a chance that configuration hints may have changed.
+        invalidate(m_name, config || m_configspec);
         // If a filename was given, read the spec and set it up as an
         // ImageCache-backed image.  Reallocate later if an explicit read()
         // is called to force read into a local buffer.
@@ -424,7 +438,7 @@ ImageBufImpl::~ImageBufImpl()
     // externally and passed to the ImageBuf ctr or reset() method, or
     // else init_spec requested the system-wide shared cache, which
     // does not need to be destroyed.
-    free_pixels();
+    clear();
 }
 
 
@@ -560,13 +574,17 @@ ImageBufImpl::new_pixels(size_t size, const void* data)
 void
 ImageBufImpl::free_pixels()
 {
-    IB_local_mem_current -= m_allocated_size;
+    if (m_allocated_size) {
+        if (pvt::oiio_print_debug > 1)
+            OIIO::debug("IB freed %d MB, global IB memory now %d MB\n",
+                        m_allocated_size >> 20, IB_local_mem_current >> 20);
+        IB_local_mem_current -= m_allocated_size;
+        m_allocated_size = 0;
+    }
     m_pixels.reset();
-    if (m_allocated_size && pvt::oiio_print_debug > 1)
-        OIIO::debugf("IB freed %d MB, global IB memory now %d MB\n",
-                     m_allocated_size >> 20, IB_local_mem_current >> 20);
-    m_allocated_size = 0;
-    m_storage        = ImageBuf::UNINITIALIZED;
+    m_deepdata.free();
+    m_storage = ImageBuf::UNINITIALIZED;
+    m_blackpixel.clear();
 }
 
 
@@ -627,7 +645,11 @@ ImageBuf::storage() const
 void
 ImageBufImpl::clear()
 {
-    m_storage = ImageBuf::UNINITIALIZED;
+    if (storage() == ImageBuf::IMAGECACHE && m_imagecache && !m_name.empty()) {
+        m_imagecache->close(m_name);
+        invalidate(m_name, false);
+    }
+    free_pixels();
     m_name.clear();
     m_fileformat.clear();
     m_nsubimages       = 0;
@@ -636,7 +658,7 @@ ImageBufImpl::clear()
     m_spec             = ImageSpec();
     m_nativespec       = ImageSpec();
     m_pixels.reset();
-    m_localpixels    = NULL;
+    m_localpixels    = nullptr;
     m_spec_valid     = false;
     m_pixels_valid   = false;
     m_badfile        = false;
@@ -645,7 +667,7 @@ ImageBufImpl::clear()
     m_scanline_bytes = 0;
     m_plane_bytes    = 0;
     m_channel_bytes  = 0;
-    m_imagecache     = NULL;
+    m_imagecache     = nullptr;
     m_deepdata.free();
     m_blackpixel.clear();
     m_write_format.clear();
@@ -673,7 +695,8 @@ ImageBufImpl::reset(string_view filename, int subimage, int miplevel,
                     Filesystem::IOProxy* ioproxy)
 {
     clear();
-    m_name             = ustring(filename);
+    m_name = ustring(filename);
+    invalidate(m_name, false);
     m_current_subimage = subimage;
     m_current_miplevel = miplevel;
     if (imagecache)
@@ -825,12 +848,15 @@ ImageBufImpl::init_spec(string_view filename, int subimage, int miplevel)
         && m_current_subimage == subimage && m_current_miplevel == miplevel)
         return true;  // Already done
 
-    if (!m_imagecache) {
+    m_name = filename;
+
+    // Make sure we have access to an imagecache. Also invalidate any cache
+    // info for the file just in case it has changed on disk.
+    if (!m_imagecache)
         m_imagecache = ImageCache::create(true /* shared cache */);
-    }
+    invalidate(m_name, false);
 
     m_pixels_valid = false;
-    m_name         = filename;
     m_nsubimages   = 0;
     m_nmiplevels   = 0;
     static ustring s_subimages("subimages"), s_miplevels("miplevels");
@@ -1060,6 +1086,7 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
                                  m_spec.y + m_spec.height, m_spec.z,
                                  m_spec.z + m_spec.depth, chbegin, chend,
                                  m_spec.format, m_localpixels)) {
+        m_imagecache->close(m_name);
         m_pixels_valid = true;
     } else {
         m_pixels_valid = false;
@@ -1255,11 +1282,7 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
     // pixels in the cache will then be likely wrong; (b) on Windows, if the
     // cache holds an open file handle for reading, we will not be able to
     // open the same file for writing.
-    ImageCache* shared_imagecache = ImageCache::create(true);
-    ustring ufilename(filename);
-    shared_imagecache->invalidate(ufilename);  // the shared IC
-    if (imagecache() && imagecache() != shared_imagecache)
-        imagecache()->invalidate(ufilename);  // *our* IC
+    m_impl->invalidate(ustring(filename), true);
 
     auto out = ImageOutput::create(fileformat);
     if (!out) {

--- a/src/libOpenImageIO/imagebuf_test.cpp
+++ b/src/libOpenImageIO/imagebuf_test.cpp
@@ -222,6 +222,9 @@ test_open_with_config()
     ImageBuf A("A_imagebuf_test.tif", 0, 0, ic, &config);
     OIIO_CHECK_EQUAL(A.spec().get_int_attribute("oiio:DebugOpenConfig!", 0),
                      42);
+    // Clear A because it would be unwise to let the ImageBuf outlive the
+    // custom ImageCache we passed it to use.
+    A.clear();
     ic->destroy(ic);
 }
 
@@ -379,6 +382,43 @@ test_roi()
 
 
 
+// Test what happens when we read, replace the image on disk, then read
+// again.
+void
+test_write_over()
+{
+    // Write two images
+    {
+        ImageBuf img(ImageSpec(16, 16, 3, TypeUInt8));
+        ImageBufAlgo::fill(img, { 0.0f, 1.0f, 0.0f });
+        img.write("tmp-green.tif");
+        Sysutil::usleep(1000000);  // make sure times are different
+        ImageBufAlgo::fill(img, { 1.0f, 0.0f, 0.0f });
+        img.write("tmp-red.tif");
+    }
+
+    // Read the image
+    float pixel[3];
+    ImageBuf A("tmp-green.tif");
+    A.getpixel(4, 4, pixel);
+    OIIO_CHECK_ASSERT(pixel[0] == 0 && pixel[1] == 1 && pixel[2] == 0);
+
+    // Replace the green image with red, under the nose of the ImageBuf.
+    Filesystem::remove("tmp-green.tif");
+    Filesystem::copy("tmp-red.tif", "tmp-green.tif");
+
+    // Read the image again -- different ImageBuf.
+    // We expect it to have the new color, not have the underlying
+    // ImageCache misremember the old color!
+    ImageBuf B("tmp-green.tif");
+    B.getpixel(4, 4, pixel);
+    OIIO_CHECK_ASSERT(pixel[0] == 1 && pixel[1] == 0 && pixel[2] == 0);
+
+    Filesystem::remove("tmp-green.tif");
+}
+
+
+
 int
 main(int /*argc*/, char* /*argv*/[])
 {
@@ -405,6 +445,8 @@ main(int /*argc*/, char* /*argv*/[])
 
     test_set_get_pixels();
     time_get_pixels();
+
+    test_write_over();
 
     Filesystem::remove("A_imagebuf_test.tif");
     return unit_test_failures;


### PR DESCRIPTION
ImageBuf uses ImageCache underneath. But this can lead to the following
unexpected behavior if you don't understand this:

1. Make an ImageBuf for an image, read it (even just header info).
2. Done with it, destroy the ImageBuf.
3. Some other part of the program, or even a different process, changes
   that file on disk.
4. Make another ImageBuf with the same filename, thinking you're getting
   the updated image, but in fact it's relying on the cached representation
   which doesn't contain the changes made in step 3.

So these tiny changes try to make this much harder to shoot yourself in the
foot:

* New ImageBufs automatically call cache->invalidate on the filename
  before they start reading, to ensure that if the file has changed on
  disk, anything in the cache is invalidated.
* When you destroy or clear an ImageBuf, it calls cache->close() on the
  file, to release the handle (especially helpful on Windows, where an
  open file handle can lock the file to other processes).

There is a chance that some image operations will have degraded
performance, if you are mixing direct ImageCache use (including
TextureSystem) and ImageBuf reads of the same files -- since creating
and destroying the IB's will flush tiles from the cache and close cached
file handles. But I think that this should not be a problem in practice,
since most apps that are heavy users of ImageBuf (like oiiotool) aren't
heavey users of IC/TS, and vice versa. And eliminating this confusing
behavior is probably more important than occasional over-eager
invalidation of the cache.

Also clarify in the docs (and imagebuf_test) that if you use the
variety of ImageBuf ctr where you give it a custom ImageCache, it's
important that the ImageBuf outlives the ImageCache, as it is a
non-owning reference.

Fixes #1987

Signed-off-by: Larry Gritz <lg@larrygritz.com>

