### PR TITLE
Fix GIF min dependency

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -151,7 +151,7 @@ checked_find_package (FFmpeg 2.6)
 checked_find_package (Field3D
                    DEPS         HDF5
                    DEFINITIONS  -DUSE_FIELD3D=1)
-checked_find_package (GIF 4.1
+checked_find_package (GIF 4
                       RECOMMEND_MIN 5.0
                       RECOMMEND_MIN_REASON "for stability and thread safety")
 checked_find_package (Libheif 1.3)  # For HEIF/HEIC format


### PR DESCRIPTION
Seems that cmake's FindGIF.cmake isn't good at discerning minor
releases (prior to GIF 5.x including more info in its headers),
so saying "find_package(GIF 4.1)" doesn't work the way
we'd like, and seems to fail to find a legit 4.1 installation.
Go back to find_package(GIF 4).

We seem to have broken this in PR 2681, and I'm worried that people
with gif_lib 4.1 will find themselves mysteriously lacking GIF support
in their OIIO builds. I may do an emergency tweak release of 2.2 just
to address this.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
