### PR TITLE
IBA::contrast_remap -- move alloca outside loop

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -961,6 +961,8 @@ contrast_remap_(ImageBuf& dst, const ImageBuf& src, cspan<float> black,
         // First do the linear stretch
         float* r = OIIO_ALLOCA(float, roi.chend);  // temp result
         ImageBuf::ConstIterator<S> s(src, roi);
+        float* y     = OIIO_ALLOCA(float, roi.chend);
+        float* denom = OIIO_ALLOCA(float, roi.chend);
         for (ImageBuf::Iterator<D> d(dst, roi); !d.done(); ++d, ++s) {
             for (int c = roi.chbegin; c < roi.chend; ++c)
                 r[c] = (s[c] - black[c]) * bwdiffinv[c];
@@ -971,8 +973,6 @@ contrast_remap_(ImageBuf& dst, const ImageBuf& src, cspan<float> black,
             if (use_sigmoid) {
                 // Sorry about the lack of clarity, we're working hard to
                 // minimize computation.
-                float* y     = OIIO_ALLOCA(float, roi.chend);
-                float* denom = OIIO_ALLOCA(float, roi.chend);
                 for (int c = roi.chbegin; c < roi.chend; ++c) {
                     y[c]     = 1.0f / (1.0f + expf(scontrast[c] * sthresh[c]));
                     denom[c] = 1.0f


### PR DESCRIPTION
This could stack overflow for large images.

Fixes #2703

Signed-off-by: Larry Gritz <lg@larrygritz.com>

