### PR TITLE
Fix crash in oiiotool --resize with multi-subimages

### DIFF
--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -846,6 +846,8 @@ public:
             Strutil::trim_whitespace(s);
             bool exclude       = Strutil::parse_char(s, '-');
             int named_subimage = -1;
+            if (s.size() == 0)
+                continue;
             if (Strutil::string_is_int(s)) {
                 int si = Strutil::from_string<int>(s);
                 if (exclude)


### PR DESCRIPTION
This was subtle. Empty subimage include/exclude specifications would
confuse compute_subimages(), which in turn would MUCH later do a
mis-allocation and lead to a situation in --resize where it would
iterate over subimages that had not been allocated.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

