### PR TITLE
Strutil::splits, splitsv should return NO pieces for empty string

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -368,7 +368,8 @@ string_view OIIO_API rstrip (string_view str, string_view chars=string_view());
 
 /// Fills the "result" list with the words in the string, using sep as
 /// the delimiter string.  If maxsplit is > -1, at most maxsplit splits
-/// are done. If sep is "", any whitespace string is a separator.
+/// are done. If sep is "", any whitespace string is a separator.  If the
+/// source `str` is empty, there will be zero pieces.
 void OIIO_API split (string_view str, std::vector<string_view> &result,
                      string_view sep = string_view(), int maxsplit = -1);
 void OIIO_API split (string_view str, std::vector<std::string> &result,
@@ -379,7 +380,8 @@ void OIIO_API split (string_view str, std::vector<std::string> &result,
 /// at most `maxsplit` split fragments will be produced (for example,
 /// maxsplit=2 will split at only the first separator, yielding at most two
 /// fragments). The result is returned as a vector of std::string (for
-/// `splits()`) or a vector of string_view (for `splitsv()`).
+/// `splits()`) or a vector of string_view (for `splitsv()`). If the source
+/// `str` is empty, there will be zero pieces.
 OIIO_API std::vector<std::string>
 splits (string_view str, string_view sep = "", int maxsplit = -1);
 OIIO_API std::vector<string_view>

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -560,8 +560,8 @@ Strutil::splits(string_view str, string_view sep, int maxsplit)
     auto sr_result = splitsv(str, sep, maxsplit);
     std::vector<std::string> result;
     result.reserve(sr_result.size());
-    for (size_t i = 0, e = sr_result.size(); i != e; ++i)
-        result.push_back(sr_result[i]);
+    for (auto& s : sr_result)
+        result.push_back(s);
     return result;
 }
 
@@ -580,6 +580,8 @@ std::vector<string_view>
 Strutil::splitsv(string_view str, string_view sep, int maxsplit)
 {
     std::vector<string_view> result;
+    if (str.size() == 0)
+        return result;  // No source string --> no pieces
 
     // Implementation inspired by Pystring
     if (maxsplit < 0)

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -359,41 +359,109 @@ test_strip()
 
 
 void
-test_split()
+test_splits()
 {
     std::string s("Now\nis the  time!");
-    std::vector<string_view> splits;
+    {   // test default -- split at whitespace
+        auto pieces = Strutil::splits(s);
+        OIIO_CHECK_EQUAL(pieces.size(), 4);
+        OIIO_CHECK_EQUAL(pieces[0], "Now");
+        OIIO_CHECK_EQUAL(pieces[1], "is");
+        OIIO_CHECK_EQUAL(pieces[2], "the");
+        OIIO_CHECK_EQUAL(pieces[3], "time!");
+    }
+    {   // test custom split string
+        auto pieces = Strutil::splits(s, " t");
+        OIIO_CHECK_EQUAL(pieces.size(), 3);
+        OIIO_CHECK_EQUAL(pieces[0], "Now\nis");
+        OIIO_CHECK_EQUAL(pieces[1], "he ");
+        OIIO_CHECK_EQUAL(pieces[2], "ime!");
+    }
+    {   // test maxsplit
+        auto pieces = Strutil::splits(s, "", 2);
+        OIIO_CHECK_EQUAL(pieces.size(), 2);
+        OIIO_CHECK_EQUAL(pieces[0], "Now");
+        OIIO_CHECK_EQUAL(pieces[1], "is the  time!");
+    }
+    {   // test maxsplit with non-default sep
+        auto pieces = Strutil::splits(s, " ", 2);
+        OIIO_CHECK_EQUAL(pieces.size(), 2);
+        OIIO_CHECK_EQUAL(pieces[0], "Now\nis");
+        OIIO_CHECK_EQUAL(pieces[1], "the  time!");
+    }
+    {   // test split against a substring that is not present
+        auto pieces = Strutil::splits("blah", "!");
+        OIIO_CHECK_EQUAL(pieces.size(), 1);
+        OIIO_CHECK_EQUAL(pieces[0], "blah");
+    }
+    {   // test splitting empty string
+        auto pieces = Strutil::splits("", ",");
+        OIIO_CHECK_EQUAL(pieces.size(), 0);
+    }
+    {   // test splitting with empty pieces
+        auto pieces = Strutil::splits(",foo,,,bar,", ",");
+        OIIO_CHECK_EQUAL(pieces.size(), 6);
+        OIIO_CHECK_EQUAL(pieces[0], "");
+        OIIO_CHECK_EQUAL(pieces[1], "foo");
+        OIIO_CHECK_EQUAL(pieces[2], "");
+        OIIO_CHECK_EQUAL(pieces[3], "");
+        OIIO_CHECK_EQUAL(pieces[4], "bar");
+        OIIO_CHECK_EQUAL(pieces[5], "");
+    }
+}
 
-    // test default -- split at whitespace
-    Strutil::split(s, splits);
-    OIIO_CHECK_EQUAL(splits.size(), 4);
-    OIIO_CHECK_EQUAL(splits[0], "Now");
-    OIIO_CHECK_EQUAL(splits[1], "is");
-    OIIO_CHECK_EQUAL(splits[2], "the");
-    OIIO_CHECK_EQUAL(splits[3], "time!");
 
-    // test custom split string
-    Strutil::split(s, splits, " t");
-    OIIO_CHECK_EQUAL(splits.size(), 3);
-    OIIO_CHECK_EQUAL(splits[0], "Now\nis");
-    OIIO_CHECK_EQUAL(splits[1], "he ");
-    OIIO_CHECK_EQUAL(splits[2], "ime!");
 
-    // test maxsplit
-    Strutil::split(s, splits, "", 2);
-    OIIO_CHECK_EQUAL(splits.size(), 2);
-    OIIO_CHECK_EQUAL(splits[0], "Now");
-    OIIO_CHECK_EQUAL(splits[1], "is the  time!");
-
-    // test maxsplit with non-default sep
-    Strutil::split(s, splits, " ", 2);
-    OIIO_CHECK_EQUAL(splits.size(), 2);
-    OIIO_CHECK_EQUAL(splits[0], "Now\nis");
-    OIIO_CHECK_EQUAL(splits[1], "the  time!");
-
-    Strutil::split("blah", splits, "!");
-    OIIO_CHECK_EQUAL(splits.size(), 1);
-    OIIO_CHECK_EQUAL(splits[0], "blah");
+void
+test_splitsv()
+{
+    std::string s("Now\nis the  time!");
+    {   // test default -- split at whitespace
+        auto pieces = Strutil::splitsv(s);
+        OIIO_CHECK_EQUAL(pieces.size(), 4);
+        OIIO_CHECK_EQUAL(pieces[0], "Now");
+        OIIO_CHECK_EQUAL(pieces[1], "is");
+        OIIO_CHECK_EQUAL(pieces[2], "the");
+        OIIO_CHECK_EQUAL(pieces[3], "time!");
+    }
+    {   // test custom split string
+        auto pieces = Strutil::splitsv(s, " t");
+        OIIO_CHECK_EQUAL(pieces.size(), 3);
+        OIIO_CHECK_EQUAL(pieces[0], "Now\nis");
+        OIIO_CHECK_EQUAL(pieces[1], "he ");
+        OIIO_CHECK_EQUAL(pieces[2], "ime!");
+    }
+    {   // test maxsplit
+        auto pieces = Strutil::splitsv(s, "", 2);
+        OIIO_CHECK_EQUAL(pieces.size(), 2);
+        OIIO_CHECK_EQUAL(pieces[0], "Now");
+        OIIO_CHECK_EQUAL(pieces[1], "is the  time!");
+    }
+    {   // test maxsplit with non-default sep
+        auto pieces = Strutil::splitsv(s, " ", 2);
+        OIIO_CHECK_EQUAL(pieces.size(), 2);
+        OIIO_CHECK_EQUAL(pieces[0], "Now\nis");
+        OIIO_CHECK_EQUAL(pieces[1], "the  time!");
+    }
+    {   // test split against a substring that is not present
+        auto pieces = Strutil::splitsv("blah", "!");
+        OIIO_CHECK_EQUAL(pieces.size(), 1);
+        OIIO_CHECK_EQUAL(pieces[0], "blah");
+    }
+    {   // test splitting empty string
+        auto pieces = Strutil::splitsv("", ",");
+        OIIO_CHECK_EQUAL(pieces.size(), 0);
+    }
+    {   // test splitting with empty pieces
+        auto pieces = Strutil::splitsv(",foo,,,bar,", ",");
+        OIIO_CHECK_EQUAL(pieces.size(), 6);
+        OIIO_CHECK_EQUAL(pieces[0], "");
+        OIIO_CHECK_EQUAL(pieces[1], "foo");
+        OIIO_CHECK_EQUAL(pieces[2], "");
+        OIIO_CHECK_EQUAL(pieces[3], "");
+        OIIO_CHECK_EQUAL(pieces[4], "bar");
+        OIIO_CHECK_EQUAL(pieces[5], "");
+    }
 }
 
 
@@ -1067,7 +1135,8 @@ main(int /*argc*/, char* /*argv*/[])
     test_comparisons();
     test_case();
     test_strip();
-    test_split();
+    test_splits();
+    test_splitsv();
     test_join();
     test_concat();
     test_repeat();


### PR DESCRIPTION
Fix cause of a subtle bug: splitting an empty string returned one
string piece (also empty) instead of 0 pieces.

Beef up the Strutil unit tests in this area.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

