### PR TITLE
Move type_merge functionality from IBA to TypeDesc

### DIFF
--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -160,23 +160,18 @@ enum IBAprep_flags {
 
 
 
-/// Given data types a and b, return a type that is a best guess for one
-/// that can handle both without any loss of range or precision.
+// DEPRECATED(2.3): Prefer TypeDesc::basetype_merge().
 TypeDesc::BASETYPE OIIO_API type_merge (TypeDesc::BASETYPE a, TypeDesc::BASETYPE b);
 
-inline TypeDesc::BASETYPE
-type_merge (TypeDesc::BASETYPE a, TypeDesc::BASETYPE b, TypeDesc::BASETYPE c)
-{
-    return type_merge (type_merge(a,b), c);
-}
-
+// DEPRECATED(2.3): Prefer TypeDesc::basetype_merge().
 inline TypeDesc type_merge (TypeDesc a, TypeDesc b) {
-    return type_merge (TypeDesc::BASETYPE(a.basetype), TypeDesc::BASETYPE(b.basetype));
+    return TypeDesc::basetype_merge(a, b);
 }
 
+// DEPRECATED(2.3): Prefer TypeDesc::basetype_merge().
 inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
 {
-    return type_merge (type_merge(a,b), c);
+    return TypeDesc::basetype_merge(TypeDesc::basetype_merge(a,b), c);
 }
 
 

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -321,6 +321,11 @@ struct OIIO_API TypeDesc {
     /// containers and algorithms.
     bool operator< (const TypeDesc &x) const noexcept;
 
+    /// Given base data types of a and b, return a basetype that is a best
+    /// guess for one that can handle both without any loss of range or
+    /// precision.
+    static BASETYPE basetype_merge(TypeDesc a, TypeDesc b);
+
     // DEPRECATED(1.8): These static const member functions were mildly
     // problematic because they required external linkage (and possibly
     // even static initialization order fiasco) and were a memory reference

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -341,40 +341,11 @@ ImageBufAlgo::IBAprep(ROI& roi, ImageBuf* dst, const ImageBuf* A,
 
 
 
-/// Given data types a and b, return a type that is a best guess for one
-/// that can handle both without any loss of range or precision.
+// DEPRECATED(2.3): Replaced by TypeDesc::type_merge(BASETYPE,BASETYPE)
 TypeDesc::BASETYPE
 ImageBufAlgo::type_merge(TypeDesc::BASETYPE a, TypeDesc::BASETYPE b)
 {
-    // Same type already? done.
-    if (a == b)
-        return a;
-    if (a == TypeDesc::UNKNOWN)
-        return b;
-    if (b == TypeDesc::UNKNOWN)
-        return a;
-    // Canonicalize so a's size (in bytes) is >= b's size in bytes. This
-    // unclutters remaining cases.
-    if (TypeDesc(a).size() < TypeDesc(b).size())
-        std::swap(a, b);
-    // Double or float trump anything else
-    if (a == TypeDesc::DOUBLE || a == TypeDesc::FLOAT)
-        return a;
-    if (a == TypeDesc::UINT32
-        && (b == TypeDesc::UINT16 || b == TypeDesc::UINT8))
-        return a;
-    if (a == TypeDesc::INT32
-        && (b == TypeDesc::INT16 || b == TypeDesc::UINT16 || b == TypeDesc::INT8
-            || b == TypeDesc::UINT8))
-        return a;
-    if ((a == TypeDesc::UINT16 || a == TypeDesc::HALF) && b == TypeDesc::UINT8)
-        return a;
-    if ((a == TypeDesc::INT16 || a == TypeDesc::HALF)
-        && (b == TypeDesc::INT8 || b == TypeDesc::UINT8))
-        return a;
-    // Out of common cases. For all remaining edge cases, punt and say that
-    // we prefer float.
-    return TypeDesc::FLOAT;
+    return TypeDesc::basetype_merge(a, b);
 }
 
 

--- a/src/libOpenImageIO/imagebufalgo_channels.cpp
+++ b/src/libOpenImageIO/imagebufalgo_channels.cpp
@@ -236,7 +236,8 @@ ImageBufAlgo::channel_append(ImageBuf& dst, const ImageBuf& A,
     // make it a type that can hold both A's and B's type.
     if (!dst.pixels_valid()) {
         ImageSpec dstspec = A.spec();
-        dstspec.set_format(type_merge(A.spec().format, B.spec().format));
+        dstspec.set_format(
+            TypeDesc::basetype_merge(A.spec().format, B.spec().format));
         // Append the channel descriptions
         dstspec.nchannels = A.spec().nchannels + B.spec().nchannels;
         for (int c = 0; c < B.spec().nchannels; ++c) {

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -62,26 +62,27 @@ void
 test_type_merge()
 {
     std::cout << "test type_merge\n";
-    using namespace OIIO::ImageBufAlgo;
-    OIIO_CHECK_EQUAL(type_merge(TypeDesc::UINT8, TypeDesc::UINT8),
+    OIIO_CHECK_EQUAL(TypeDesc::basetype_merge(TypeDesc::UINT8, TypeDesc::UINT8),
                      TypeDesc::UINT8);
-    OIIO_CHECK_EQUAL(type_merge(TypeDesc::UINT8, TypeDesc::FLOAT),
+    OIIO_CHECK_EQUAL(TypeDesc::basetype_merge(TypeDesc::UINT8, TypeDesc::FLOAT),
                      TypeDesc::FLOAT);
-    OIIO_CHECK_EQUAL(type_merge(TypeDesc::FLOAT, TypeDesc::UINT8),
+    OIIO_CHECK_EQUAL(TypeDesc::basetype_merge(TypeDesc::FLOAT, TypeDesc::UINT8),
                      TypeDesc::FLOAT);
-    OIIO_CHECK_EQUAL(type_merge(TypeDesc::UINT8, TypeDesc::UINT16),
+    OIIO_CHECK_EQUAL(TypeDesc::basetype_merge(TypeDesc::UINT8, TypeDesc::UINT16),
                      TypeDesc::UINT16);
-    OIIO_CHECK_EQUAL(type_merge(TypeDesc::UINT16, TypeDesc::FLOAT),
+    OIIO_CHECK_EQUAL(TypeDesc::basetype_merge(TypeDesc::UINT16, TypeDesc::FLOAT),
                      TypeDesc::FLOAT);
-    OIIO_CHECK_EQUAL(type_merge(TypeDesc::HALF, TypeDesc::FLOAT),
+    OIIO_CHECK_EQUAL(TypeDesc::basetype_merge(TypeDesc::HALF, TypeDesc::FLOAT),
                      TypeDesc::FLOAT);
-    OIIO_CHECK_EQUAL(type_merge(TypeDesc::HALF, TypeDesc::UINT8),
+    OIIO_CHECK_EQUAL(TypeDesc::basetype_merge(TypeDesc::HALF, TypeDesc::UINT8),
                      TypeDesc::HALF);
-    OIIO_CHECK_EQUAL(type_merge(TypeDesc::HALF, TypeDesc::UNKNOWN),
+    OIIO_CHECK_EQUAL(TypeDesc::basetype_merge(TypeDesc::HALF, TypeDesc::UNKNOWN),
                      TypeDesc::HALF);
-    OIIO_CHECK_EQUAL(type_merge(TypeDesc::FLOAT, TypeDesc::UNKNOWN),
+    OIIO_CHECK_EQUAL(TypeDesc::basetype_merge(TypeDesc::FLOAT,
+                                              TypeDesc::UNKNOWN),
                      TypeDesc::FLOAT);
-    OIIO_CHECK_EQUAL(type_merge(TypeDesc::UINT8, TypeDesc::UNKNOWN),
+    OIIO_CHECK_EQUAL(TypeDesc::basetype_merge(TypeDesc::UINT8,
+                                              TypeDesc::UNKNOWN),
                      TypeDesc::UINT8);
 }
 

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -820,6 +820,41 @@ TypeDesc::operator<(const TypeDesc& x) const noexcept
 
 
 
+TypeDesc::BASETYPE
+TypeDesc::basetype_merge(TypeDesc at, TypeDesc bt)
+{
+    BASETYPE a = (BASETYPE)at.basetype;
+    BASETYPE b = (BASETYPE)bt.basetype;
+
+    // Same type already? done.
+    if (a == b)
+        return a;
+    if (a == UNKNOWN)
+        return b;
+    if (b == UNKNOWN)
+        return a;
+    // Canonicalize so a's size (in bytes) is >= b's size in bytes. This
+    // unclutters remaining cases.
+    if (TypeDesc(a).size() < TypeDesc(b).size())
+        std::swap(a, b);
+    // Double or float trump anything else
+    if (a == DOUBLE || a == FLOAT)
+        return a;
+    if (a == UINT32 && (b == UINT16 || b == UINT8))
+        return a;
+    if (a == INT32 && (b == INT16 || b == UINT16 || b == INT8 || b == UINT8))
+        return a;
+    if ((a == UINT16 || a == HALF) && b == UINT8)
+        return a;
+    if ((a == INT16 || a == HALF) && (b == INT8 || b == UINT8))
+        return a;
+    // Out of common cases. For all remaining edge cases, punt and say that
+    // we prefer float.
+    return FLOAT;
+}
+
+
+
 const TypeDesc TypeDesc::TypeFloat(TypeDesc::FLOAT);
 const TypeDesc TypeDesc::TypeColor(TypeDesc::FLOAT, TypeDesc::VEC3,
                                    TypeDesc::COLOR);

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -1044,9 +1044,7 @@ OpenEXRInput::PartInfo::query_channels(OpenEXRInput* in,
     for (int c = 0; c < spec.nchannels; ++c) {
         spec.channelnames.push_back(cnh[c].fullname);
         spec.channelformats.push_back(cnh[c].datatype);
-        spec.format = TypeDesc(ImageBufAlgo::type_merge(
-            TypeDesc::BASETYPE(spec.format.basetype),
-            TypeDesc::BASETYPE(cnh[c].datatype.basetype)));
+        spec.format = TypeDesc::basetype_merge(spec.format, cnh[c].datatype);
         pixeltype.push_back(cnh[c].exr_data_type);
         chanbytes.push_back(cnh[c].datatype.size());
         all_one_format &= (cnh[c].datatype == cnh[0].datatype);


### PR DESCRIPTION
I wanted to use this elsewhere, decided it was general enough to be in
typedesc.h, not specific to ImageBufAlgo.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

