### PR TITLE
More principled approach to alloca to avoid stack overflows

### DIFF
--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1457,8 +1457,10 @@ colorconvert_impl(ImageBuf& R, const ImageBuf& A,
         [&, unpremult, channelsToCopy, processor](ROI roi) {
             int width = roi.width();
             // Temporary space to hold one RGBA scanline
-            vfloat4* scanline  = OIIO_ALLOCA(vfloat4, width);
-            float* alpha       = OIIO_ALLOCA(float, width);
+            vfloat4* scanline;
+            OIIO_ALLOCATE_STACK_OR_HEAP(scanline, vfloat4, width);
+            float* alpha;
+            OIIO_ALLOCATE_STACK_OR_HEAP(alpha, float, width);
             const float fltmin = std::numeric_limits<float>::min();
             ImageBuf::ConstIterator<Atype> a(A, roi);
             ImageBuf::Iterator<Rtype> r(R, roi);
@@ -1531,8 +1533,10 @@ colorconvert_impl_float_rgba(ImageBuf& R, const ImageBuf& A,
     parallel_image(roi, parallel_image_options(nthreads), [&](ROI roi) {
         int width = roi.width();
         // Temporary space to hold one RGBA scanline
-        vfloat4* scanline  = OIIO_ALLOCA(vfloat4, width);
-        float* alpha       = OIIO_ALLOCA(float, width);
+        vfloat4* scanline;
+        OIIO_ALLOCATE_STACK_OR_HEAP(scanline, vfloat4, width);
+        float* alpha;
+        OIIO_ALLOCATE_STACK_OR_HEAP(alpha, float, width);
         const float fltmin = std::numeric_limits<float>::min();
         for (int k = roi.zbegin; k < roi.zend; ++k) {
             for (int j = roi.ybegin; j < roi.yend; ++j) {

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -170,8 +170,11 @@ ImageInput::read_scanline(int y, int z, TypeDesc format, void* data,
 
     // Complex case -- either changing data type or stride
     int scanline_values = m_spec.width * m_spec.nchannels;
-    unsigned char* buf  = OIIO_ALLOCA(unsigned char,
-                                     m_spec.scanline_bytes(true));
+
+    unsigned char* buf;
+    OIIO_ALLOCATE_STACK_OR_HEAP(buf, unsigned char,
+                                m_spec.scanline_bytes(true));
+
     bool ok = read_native_scanline(current_subimage(), current_miplevel(), y, z,
                                    buf);
     if (!ok)


### PR DESCRIPTION
A bug (issue #2713) revealed that an alloca in IBA::colorconvert could
cause a stack overflow on an image that had an unusually wide number of
columns per scanline.

This patch takes a number of measures to help root out these problems
in the future:

* The OIIO_ALLOCA macro is amended to assert (in DEBUG builds only)
  upon any attempt to alloca more than 1MB, which is surely a sign that
  we have used alloca in an inappropriate place.

* A new OIIO_ALLOCATE_STACK_OR_HEAP macro is used to encapsulate an
  idiom I have used before, to alloca small things but new[] big things,
  and ensure in both cases that the memory is freed when the function
  exists scope. I choose arbitrarily for "big thing" to mean <= 64 KB,
  which is big enough for one 64x64 tile or one scanline of a 4k image
  if it has 4 float channels, that means most of the time we'll safely
  allocate on the stack, but for anything larger, it will use heap.

* Use OIIO_ALLOCATE_STACK_OR_HEAP in those problematic spots of
  colorconvert.

* Use OIIO_ALLOCATE_STACK_OR_HEAP in a few other places that seem
  prudent.

* Grepped through the code for all instances of OIIO_ALLOCA and I think
  that all the potentially "big" ones are now using the safe idiom.

Fixes #2713

Signed-off-by: Larry Gritz <lg@larrygritz.com>

