### PR TITLE
oiiotool: Improve guessing about output format based on inputs

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -1261,19 +1261,25 @@ Writing images
 
 .. option:: -d <datatype>
             -d <channelname>=<datatype>
+            -d <subimagename>.*=<datatype>
+            -d <subimagename>.<channelname>=<datatype>
 
     Attempts to set the pixel data type of all subsequent outputs.  If no
-    channel is named, sets *all* channels to be the specified data type.  If
-    a specific channel is named, then the data type will be overridden for
-    just that channel (multiple `-d` commands may be used).
+    channel or subimage name is given, sets *all* channels to be the
+    specified data type.  If a specific channel is named, then the data type
+    will be overridden for just that channel (multiple `-d` commands may be
+    used). If both a subimage name and channel name are specified, the hint
+    is only for the named channel when encountered in a named subimage. And
+    if the specification is of the form `subimagename.*=type`, then all
+    channels of that subimage will be output with the given type.
     
-    Valid types are: `UINT8`, `sint8`, `uint16`, `sint16`, `half`, `float`,
+    Valid types are: `uint8`, `sint8`, `uint16`, `sint16`, `half`, `float`,
     `double`. The types `uint10` and `uint12` may be used to request 10- or
     12-bit unsigned integers.  If the output file format does not support
     them, `uint16` will be substituted.
     
-    If the `-d` option is not supplied, the output data type will be the
-    same as the data format of the input files, if possible.
+    If the `-d` option is not supplied, the output data type will be
+    deduced from the data format of the input files, if possible.
     
     In any case, if the output file type does not support the requested data
     type, it will instead use whichever supported data type results in the

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -144,32 +144,32 @@ Oiiotool::clear_options()
     clear_input_config();
     output_dataformat = TypeDesc::UNKNOWN;
     output_channelformats.clear();
-    output_bitspersample        = 0;
-    output_scanline             = false;
-    output_tilewidth            = 0;
-    output_tileheight           = 0;
-    output_compression          = "";
-    output_quality              = -1;
-    output_planarconfig         = "default";
-    output_adjust_time          = false;
-    output_autocrop             = true;
-    output_autotrim             = false;
-    output_dither               = false;
-    output_force_tiles          = false;
-    metadata_nosoftwareattrib   = false;
-    diff_warnthresh             = 1.0e-6f;
-    diff_warnpercent            = 0;
-    diff_hardwarn               = std::numeric_limits<float>::max();
-    diff_failthresh             = 1.0e-6f;
-    diff_failpercent            = 0;
-    diff_hardfail               = std::numeric_limits<float>::max();
-    m_pending_callback          = NULL;
-    m_pending_argc              = 0;
-    frame_number                = 0;
-    frame_padding               = 0;
-    first_input_dataformat      = TypeUnknown;
-    first_input_dataformat_bits = 0;
-    first_input_channelformats.clear();
+    output_bitspersample      = 0;
+    output_scanline           = false;
+    output_tilewidth          = 0;
+    output_tileheight         = 0;
+    output_compression        = "";
+    output_quality            = -1;
+    output_planarconfig       = "default";
+    output_adjust_time        = false;
+    output_autocrop           = true;
+    output_autotrim           = false;
+    output_dither             = false;
+    output_force_tiles        = false;
+    metadata_nosoftwareattrib = false;
+    diff_warnthresh           = 1.0e-6f;
+    diff_warnpercent          = 0;
+    diff_hardwarn             = std::numeric_limits<float>::max();
+    diff_failthresh           = 1.0e-6f;
+    diff_failpercent          = 0;
+    diff_hardfail             = std::numeric_limits<float>::max();
+    m_pending_callback        = NULL;
+    m_pending_argc            = 0;
+    frame_number              = 0;
+    frame_padding             = 0;
+    input_dataformat          = TypeUnknown;
+    input_bitspersample       = 0;
+    input_channelformats.clear();
 }
 
 
@@ -228,7 +228,7 @@ remove_modifier(string_view str, string_view name)
 
 
 bool
-Oiiotool::read(ImageRecRef img, ReadPolicy readpolicy)
+Oiiotool::read(ImageRecRef img, ReadPolicy readpolicy, string_view channel_set)
 {
     // If the image is already elaborated, take an early out, both to
     // save time, but also because we only want to do the format and
@@ -243,7 +243,7 @@ Oiiotool::read(ImageRecRef img, ReadPolicy readpolicy)
     total_readtime.start();
     if (ot.nativeread)
         readpolicy = ReadPolicy(readpolicy | ReadNative);
-    bool ok = img->read(readpolicy);
+    bool ok = img->read(readpolicy, channel_set);
     total_readtime.stop();
     imagecache->getattribute("stat:fileio_time", post_ic_time);
     total_imagecache_readtime += post_ic_time - pre_ic_time;
@@ -257,18 +257,7 @@ Oiiotool::read(ImageRecRef img, ReadPolicy readpolicy)
         output_tileheight = nspec.tile_height;
     }
     // Remember the first input format we encountered.
-    if (first_input_dataformat == TypeUnknown) {
-        first_input_dataformat      = nspec.format;
-        first_input_dataformat_bits = nspec.get_int_attribute(
-            "oiio:BitsPerSample");
-        if (nspec.channelformats.size()) {
-            for (int c = 0; c < nspec.nchannels; ++c) {
-                std::string chname                 = nspec.channelnames[c];
-                first_input_channelformats[chname] = std::string(
-                    nspec.channelformat(c).c_str());
-            }
-        }
-    }
+    remember_input_channelformats(img);
 
     if (!ok)
         error("read", format_read_error(img->name(), img->geterror()));
@@ -299,6 +288,52 @@ Oiiotool::read_nativespec(ImageRecRef img)
     if (!ok)
         error("read", format_read_error(img->name(), img->geterror()));
     return ok;
+}
+
+
+
+void
+Oiiotool::remember_input_channelformats(ImageRecRef img)
+{
+    for (int s = 0, subimages = img->subimages(); s < subimages; ++s) {
+        const ImageSpec& nspec((*img)(s, 0).nativespec());
+        // Overall default format is the merged type of all subimages
+        // of the first input image.
+        input_dataformat         = TypeDesc::basetype_merge(input_dataformat,
+                                                    nspec.format);
+        std::string subimagename = nspec.get_string_attribute(
+            "oiio:subimagename");
+        if (subimagename.size()) {
+            // Record a best guess for this subimage, if not already set.
+            auto key = Strutil::fmt::format("{}.*", subimagename);
+            if (input_channelformats[key] == "")
+                input_channelformats[key] = nspec.format.c_str();
+        }
+        if (!input_bitspersample)
+            input_bitspersample = nspec.get_int_attribute("oiio:BitsPerSample");
+        for (int c = 0; c < nspec.nchannels; ++c) {
+            // For each channel, if we don't already have a type recorded
+            // for its name, record it. Both the bare channel name, and also
+            // "subimagename.channelname", so that we can remember the same
+            // name differently for different subimages.
+            std::string chname     = nspec.channel_name(c);
+            std::string chtypename = nspec.channelformat(c).c_str();
+            if (subimagename.size()) {
+                std::string subchname
+                    = Strutil::fmt::format("{}.{}", subimagename, chname);
+                if (input_channelformats[subchname] == "")
+                    input_channelformats[subchname] = chtypename;
+            } else {
+                if (input_channelformats[chname] != "")
+                    input_channelformats[chname] = chtypename;
+            }
+        }
+    }
+#if 0
+    std::cout << "Input channel type map:\n";
+    for (auto& x : input_channelformats)
+        std::cout << "   " << x.first << " -> " << x.second << "\n";
+#endif
 }
 
 
@@ -592,23 +627,39 @@ get_value_override(string_view localoption, string_view defaultval)
 // and bit depth, modify the existing spec.
 static void
 set_output_dataformat(ImageSpec& spec, TypeDesc format,
-                      const std::map<std::string, std::string>& channelformats,
+                      std::map<std::string, std::string>& channelformats,
                       int bitdepth)
 {
+    // Account for default requested format
     if (format != TypeUnknown)
         spec.format = format;
     if (bitdepth)
         spec.attribute("oiio:BitsPerSample", bitdepth);
     else
         spec.erase_attribute("oiio:BitsPerSample");
+
+    // See if there's a recommended format for this subimage
+    std::string subimagename = spec["oiio:subimagename"];
+    if (format == TypeUnknown && subimagename.size()) {
+        auto key = Strutil::fmt::format("{}.*", subimagename);
+        if (channelformats[key] != "")
+            spec.format = TypeDesc(channelformats[key]);
+    }
+
+    // Honor any per-channel requests
     if (channelformats.size()) {
         spec.channelformats.clear();
         spec.channelformats.resize(spec.nchannels, spec.format);
-        for (auto& cr : channelformats) {
-            int c = spec.channelindex(cr.first);
-            TypeDesc t(cr.second);
-            if (c >= 0 && c < spec.nchannels && t != TypeUnknown)
-                spec.channelformats[c] = t;
+        for (int c = 0; c < spec.nchannels; ++c) {
+            std::string chname = spec.channel_name(c);
+            auto subchname     = Strutil::fmt::format("{}.{}", subimagename,
+                                                  chname);
+            if (channelformats[subchname] != "" && subimagename.size())
+                spec.channelformats[c] = TypeDesc(channelformats[subchname]);
+            else if (channelformats[chname] != "")
+                spec.channelformats[c] = TypeDesc(channelformats[chname]);
+            else
+                spec.channelformats[c] = spec.format;
         }
     } else {
         spec.channelformats.clear();
@@ -673,14 +724,13 @@ adjust_output_options(string_view filename, ImageSpec& spec,
         spec.channelformats = nativespec->channelformats;
         set_output_dataformat(spec, nativespec->format,
                               requested_output_channelformats,
-                              nativespec->get_int_attribute(
-                                  "oiio:BitsPerSample"));
-    } else if (ot.first_input_dataformat != TypeUnknown) {
-        auto mergedlist = ot.first_input_channelformats;
+                              (*nativespec)["oiio:BitsPerSample"].get<int>());
+    } else if (ot.input_dataformat != TypeUnknown) {
+        auto mergedlist = ot.input_channelformats;
         for (auto& c : requested_output_channelformats)
             mergedlist[c.first] = c.second;
-        set_output_dataformat(spec, ot.first_input_dataformat, mergedlist,
-                              ot.first_input_dataformat_bits);
+        set_output_dataformat(spec, ot.input_dataformat, mergedlist,
+                              ot.input_bitspersample);
     }
 
     // Tiling strategy:
@@ -4428,22 +4478,9 @@ input_file(int argc, const char* argv[])
         ot.curimg->input_dataformat(input_dataformat);
         if (readnow) {
             ot.curimg->read(ReadNoCache, channel_set);
-            // If we do not yet have an expected output format, set it based on
-            // this image (presumably the first one read.
-            if (ot.output_dataformat == TypeDesc::UNKNOWN) {
-                const ImageSpec& nspec((*ot.curimg)(0, 0).nativespec());
-                ot.output_dataformat = nspec.format;
-                if (!ot.output_bitspersample)
-                    ot.output_bitspersample = nspec.get_int_attribute(
-                        "oiio:BitsPerSample");
-                if (nspec.channelformats.size()) {
-                    for (int c = 0; c < nspec.nchannels; ++c) {
-                        std::string chname = nspec.channelnames[c];
-                        ot.output_channelformats[chname] = std::string(
-                            nspec.channelformat(c).c_str());
-                    }
-                }
-            }
+            // If we do not yet have an expected output format, set it based
+            // on this image (presumably the first one read.
+            ot.remember_input_channelformats(ot.curimg);
         }
         if (printinfo || ot.printstats || ot.dumpdata || ot.hash) {
             OiioTool::print_info_options pio;

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -116,9 +116,9 @@ public:
     bool input_config_set       = false;
     bool printed_info           = false;  // printed info at some point
     // Remember the first input dataformats we encountered
-    TypeDesc first_input_dataformat;
-    int first_input_dataformat_bits = 0;
-    std::map<std::string, std::string> first_input_channelformats;
+    TypeDesc input_dataformat;
+    int input_bitspersample = 0;
+    std::map<std::string, std::string> input_channelformats;
 
     Oiiotool();
 
@@ -128,18 +128,23 @@ public:
     /// Force img to be read at this point.  Use this wrapper, don't directly
     /// call img->read(), because there's extra work done here specific to
     /// oiiotool.
-    bool read(ImageRecRef img, ReadPolicy readpolicy = ReadDefault);
+    bool read(ImageRecRef img, ReadPolicy readpolicy = ReadDefault,
+              string_view channel_set = "");
     // Read the current image
-    bool read(ReadPolicy readpolicy = ReadDefault)
+    bool read(ReadPolicy readpolicy = ReadDefault, string_view channel_set = "")
     {
         if (curimg)
-            return read(curimg, readpolicy);
+            return read(curimg, readpolicy, channel_set);
         return true;
     }
 
     /// Force partial read of image (if it hasn't been yet), just enough
     /// that the nativespec can be examined.
     bool read_nativespec(ImageRecRef img);
+
+    // If this is the first input image, remember the various formats used
+    // so we can use them as the default for later outputs.
+    void remember_input_channelformats(ImageRecRef img);
 
     // If required_images are not yet on the stack, then postpone this
     // call by putting it on the 'pending' list and return true.
@@ -324,8 +329,8 @@ public:
 private:
     std::vector<ImageBufRef> m_miplevels;
     std::vector<ImageSpec> m_specs;
-    bool m_was_direct_read
-        = false;  ///< Guaranteed pixel data type unmodified since read
+    bool m_was_direct_read = false;
+    // ^^ Guaranteed pixel data type unmodified since read
     friend class ImageRec;
 };
 


### PR DESCRIPTION
What data format does oiiotool write for its outputs? The ones
specified by -d, if supplied, but otherwise it will make a guess based
on the types of inputs it has seen.

This patches makes several improvements:

* Multi-subimage files were getting very confused because different
  subimages may want different data formats, and it was at best
  remembering data formats overall and by channel name, but not taking
  subimages into consideration. Make this much more specific by
  remembering both raw channel names (for all subimages), as well as
  specific channels of named subimages.

* The way the input data formats were remembered had repeaded (and
  non-matching) code depending on whether the input was read
  immediately or lazily.  That is now cleared up, with the logic
  refactored and expressed only once.

* The -d directive can specify a type (for all channels), a type for a
  particular channel name (`channel=type`), and -- this part is new --
  a type for all channels of a named subimage (specified as
  `subimage.*=type`) or just one channel of a specific subimage
  (`subimage.channel=type`).

Fixes #2710 

Signed-off-by: Larry Gritz <lg@larrygritz.com>

