### PR TITLE
#2720 - Adding 1 bits per sample support to tiffs.

### DIFF
--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -403,8 +403,8 @@ TIFFOutput::open(const std::string& name, const ImageSpec& userspec,
         sampformat      = SAMPLEFORMAT_INT;
         break;
     case TypeDesc::UINT8:
-        if (m_bitspersample != 2 && m_bitspersample != 4
-            && m_bitspersample != 6)
+        if (m_bitspersample != 2 && m_bitspersample != 4 && m_bitspersample != 6
+            && m_bitspersample != 1)
             m_bitspersample = 8;
         sampformat = SAMPLEFORMAT_UINT;
         break;
@@ -1561,6 +1561,11 @@ TIFFOutput::fix_bitdepth(void* data, int nvals)
         for (int i = 0; i < nvals; ++i)
             v[i] = bit_range_convert<8, 6>(v[i]);
         bit_pack(cspan<unsigned char>(v, v + nvals), v, 6);
+    } else if (spec().format == TypeDesc::UINT8 && m_bitspersample == 1) {
+        unsigned char* v = (unsigned char*)data;
+        for (int i = 0; i < nvals; ++i)
+            v[i] = bit_range_convert<8, 1>(v[i]);
+        bit_pack(cspan<unsigned char>(v, v + nvals), v, 1);
     } else if (spec().format == TypeDesc::UINT32 && m_bitspersample == 24) {
         unsigned int* v = (unsigned int*)data;
         for (int i = 0; i < nvals; ++i)


### PR DESCRIPTION
## Description

Added 1 bits per sample support when writing tiffs (#2720).


## Tests

```c++
#include <iostream>


#include <OpenImageIO/imagebuf.h>
#include <OpenImageIO/imagebufalgo.h>
#include <OpenImageIO/imageio.h>

using namespace OIIO;


int main(void) {


    std::cerr << "Loading\n";
    OIIO::ImageBuf buf("this_is_a_image.png");


    buf.specmod().attribute("compression", "zip");

    std::cerr << "Writing 3x2bpp\n";
    buf.specmod().attribute("oiio:BitsPerSample", 2);
    buf.write("this_is_a_3x2bit.tiff");


    std::cerr << "Writing 3x1bpp\n";
    buf.specmod().attribute("oiio:BitsPerSample", 1);
    buf.write("this_is_a_3x1bit.tiff");


    auto spec = buf.spec();
    spec.nchannels = 1;
    OIIO::ImageBuf buf2(spec);
    OIIO::ImageBufAlgo::paste(buf2, 0, 0, 0, 0, buf);

    std::cerr << "Writing 1x2bpp\n";
    buf2.specmod().attribute("oiio:BitsPerSample", 2);
    buf2.write("this_is_a_2bit.tiff");


    std::cerr << "Writing 1x1bpp\n";
    buf2.specmod().attribute("oiio:BitsPerSample", 1);
    buf2.write("this_is_a_1bit.tiff");

}
```


Source image: 
![this_is_a_image](https://user-images.githubusercontent.com/30833607/94200015-a2aaf200-feb1-11ea-9de5-90cbad5d0853.png)


Output images (github doesn't support tiff attachments):
[written-images.zip](https://github.com/OpenImageIO/oiio/files/5279176/written-images.zip)

(You'll notice the grand whopping 20 byte reduction in file size between the 2bpp and 1bpp).

