### PR TITLE
WIP: add support for lossless attribute ofimage spec for webp

### DIFF
--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -124,8 +124,9 @@ WebpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
         m_webp_config.quality = 100;
     }
 
-    // Lossless encoding (0=lossy(default), 1=lossless).    
-    m_webp_config.lossless = (m_spec.get_string_attribute("compression", "lossy") == "lossless");
+    // Lossless encoding (0=lossy(default), 1=lossless).
+    m_webp_config.lossless
+        = (m_spec.get_string_attribute("compression", "lossy") == "lossless");
 
     // forcing UINT8 format
     m_spec.set_format(TypeDesc::UINT8);

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -124,6 +124,9 @@ WebpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
         m_webp_config.quality = 100;
     }
 
+    // Lossless encoding (0=lossy(default), 1=lossless).
+    m_webp_config.lossless = m_spec.get_int_attribute("lossless", 0);
+
     // forcing UINT8 format
     m_spec.set_format(TypeDesc::UINT8);
     m_dither = m_spec.get_int_attribute("oiio:dither", 0);

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -124,8 +124,8 @@ WebpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
         m_webp_config.quality = 100;
     }
 
-    // Lossless encoding (0=lossy(default), 1=lossless).
-    m_webp_config.lossless = m_spec.get_int_attribute("lossless", 0);
+    // Lossless encoding (0=lossy(default), 1=lossless).    
+    m_webp_config.lossless = (m_spec.get_string_attribute("compression", "lossy") == "lossless");
 
     // forcing UINT8 format
     m_spec.set_format(TypeDesc::UINT8);


### PR DESCRIPTION
## Description
Support a `lossless` spec attribute to be able to output lossless webp images

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->
TODO

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

