### PR TITLE
require boost date_time explicitly in cmake

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -47,7 +47,7 @@ if (BOOST_CUSTOM)
     # N.B. For a custom version, the caller had better set up the variables
     # Boost_VERSION, Boost_INCLUDE_DIRS, Boost_LIBRARY_DIRS, Boost_LIBRARIES.
 else ()
-    set (Boost_COMPONENTS filesystem system thread)
+    set (Boost_COMPONENTS filesystem system thread date_time)
     if (NOT USE_STD_REGEX)
         list (APPEND Boost_COMPONENTS regex)
     endif ()

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -32,11 +32,12 @@ option (BUILD_MISSING_DEPS "Try to download and build any missing dependencies" 
 
 ###########################################################################
 # Boost setup
+if (MSVC)
+    # Disable automatic linking using pragma comment(lib,...) of boost libraries upon including of a header
+    add_definitions (-DBOOST_ALL_NO_LIB=1)
+endif ()
 if (LINKSTATIC)
-    set (Boost_USE_STATIC_LIBS ON)
-    if (MSVC)
-        add_definitions (-DBOOST_ALL_NO_LIB=1)
-    endif ()
+    set (Boost_USE_STATIC_LIBS ON)    
 else ()
     if (MSVC)
         add_definitions (-DBOOST_ALL_DYN_LINK=1)
@@ -47,7 +48,7 @@ if (BOOST_CUSTOM)
     # N.B. For a custom version, the caller had better set up the variables
     # Boost_VERSION, Boost_INCLUDE_DIRS, Boost_LIBRARY_DIRS, Boost_LIBRARIES.
 else ()
-    set (Boost_COMPONENTS filesystem system thread date_time)
+    set (Boost_COMPONENTS filesystem system thread)
     if (NOT USE_STD_REGEX)
         list (APPEND Boost_COMPONENTS regex)
     endif ()


### PR DESCRIPTION
## Description

This PR adds date_time to the required boost components in cmake.

In order to save on CI, I compile/stage only the (shared lib) boost components needed for OIIO (and other deps).
Based on _src/cmake/externalpackages.cmake_, those should have been filesystem, system, thread & regex.
Without this change, cmake setup is completing successfully yet results in linker errors (see below).
With this change, cmake setup fails to detect the correct boost libraries while also documenting what libraries are actually required.

Linker erros without this change
> -- Build files have been written to: snip/oiio-Release-2.2.6.1/cmBuild
Microsoft (R) Build Engine version 16.7.0+b89cb5fde for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.
> LINK : fatal error LNK1181: cannot open input file 'snip\lib\boost_date_time-vc142-mt-x64-1_7
3.lib' [snip\oiio-Release-2.2.6.1\cmBuild\src\libOpenImageIO\OpenImageIO.vcxproj]
> LINK : fatal error LNK1181: cannot open input file 'snip\lib\boost_date_time-vc142-mt-x64-1_7
3.lib' [snip\oiio-Release-2.2.6.1\cmBuild\src\libutil\OpenImageIO_Util.vcxproj]

## Tests

Compiling only the minimum required subset of boost now works.
Tested on Windows 10. Due to limited availability of other setups, relying on CI to verify other platforms

## Checklist:


- [ x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ x] My code follows the prevailing code style of this project.

