### PR TITLE
iv shouldn't open with config unless it really means it

### DIFF
--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -773,10 +773,14 @@ ImageViewer::add_image(const std::string& filename)
 {
     if (filename.empty())
         return;
-    ImageSpec config;
-    if (rawcolor())
+    IvImage* newimage = nullptr;
+    if (rawcolor()) {
+        ImageSpec config;
         config.attribute("oiio:RawColor", 1);
-    IvImage* newimage = new IvImage(filename, &config);
+        newimage = new IvImage(filename, &config);
+    } else {
+        newimage = new IvImage(filename);
+    }
     newimage->gamma(m_default_gamma);
     m_images.push_back(newimage);
     addRecentFile(filename);


### PR DESCRIPTION
This can cause cache re-reads unnecessarily because it thinks you're
asking for potentially different configuration hints every time you
set the ImageBuf to a different subimage.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

