### PR TITLE
Use 'final' liberally

### DIFF
--- a/src/heif.imageio/heifoutput.cpp
+++ b/src/heif.imageio/heifoutput.cpp
@@ -44,7 +44,7 @@ private:
 
 namespace {
 
-class MyHeifWriter : public heif::Context::Writer {
+class MyHeifWriter final : public heif::Context::Writer {
 public:
     MyHeifWriter(Filesystem::IOProxy* ioproxy)
         : m_ioproxy(ioproxy)

--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -54,7 +54,7 @@ class IvGL;
 class ImageViewer;
 
 
-class IvImage : public ImageBuf {
+class IvImage final : public ImageBuf {
 public:
     IvImage(const std::string& filename,
             const ImageSpec* input_config = nullptr);
@@ -134,7 +134,7 @@ private:
 
 
 
-class ImageViewer : public QMainWindow {
+class ImageViewer final : public QMainWindow {
     Q_OBJECT
 
 public:
@@ -404,7 +404,7 @@ private:
 
 
 
-class IvInfoWindow : public QDialog {
+class IvInfoWindow final : public QDialog {
     Q_OBJECT
 public:
     IvInfoWindow(ImageViewer& viewer, bool visible = true);
@@ -424,7 +424,7 @@ private:
 
 
 
-class IvPreferenceWindow : public QDialog {
+class IvPreferenceWindow final : public QDialog {
     Q_OBJECT
 public:
     IvPreferenceWindow(ImageViewer& viewer);

--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -36,7 +36,7 @@ class ImageViewer;
 
 
 
-class IvGL : public QOpenGLWidget, protected QOpenGLFunctions {
+class IvGL final : public QOpenGLWidget, protected QOpenGLFunctions {
     Q_OBJECT
 public:
     IvGL(QWidget* parent, ImageViewer& viewer);

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -652,7 +652,7 @@ ocio_bitdepth(TypeDesc type)
 
 
 // Custom ColorProcessor that wraps an OpenColorIO Processor.
-class ColorProcessor_OCIO : public ColorProcessor {
+class ColorProcessor_OCIO final : public ColorProcessor {
 public:
     ColorProcessor_OCIO(OCIO::ConstProcessorRcPtr p)
         : m_p(p)
@@ -695,7 +695,7 @@ private:
 
 
 // ColorProcessor that hard-codes sRGB-to-linear
-class ColorProcessor_sRGB_to_linear : public ColorProcessor {
+class ColorProcessor_sRGB_to_linear final : public ColorProcessor {
 public:
     ColorProcessor_sRGB_to_linear()
         : ColorProcessor() {};
@@ -732,7 +732,7 @@ public:
 
 
 // ColorProcessor that hard-codes linear-to-sRGB
-class ColorProcessor_linear_to_sRGB : public ColorProcessor {
+class ColorProcessor_linear_to_sRGB final : public ColorProcessor {
 public:
     ColorProcessor_linear_to_sRGB()
         : ColorProcessor() {};
@@ -770,7 +770,7 @@ public:
 
 
 // ColorProcessor that hard-codes Rec709-to-linear
-class ColorProcessor_Rec709_to_linear : public ColorProcessor {
+class ColorProcessor_Rec709_to_linear final : public ColorProcessor {
 public:
     ColorProcessor_Rec709_to_linear()
         : ColorProcessor() {};
@@ -795,7 +795,7 @@ public:
 
 
 // ColorProcessor that hard-codes linear-to-Rec709
-class ColorProcessor_linear_to_Rec709 : public ColorProcessor {
+class ColorProcessor_linear_to_Rec709 final : public ColorProcessor {
 public:
     ColorProcessor_linear_to_Rec709()
         : ColorProcessor() {};
@@ -821,7 +821,7 @@ public:
 
 
 // ColorProcessor that performs gamma correction
-class ColorProcessor_gamma : public ColorProcessor {
+class ColorProcessor_gamma final : public ColorProcessor {
 public:
     ColorProcessor_gamma(float gamma)
         : ColorProcessor()
@@ -863,7 +863,7 @@ private:
 
 
 // ColorProcessor that does nothing (identity transform)
-class ColorProcessor_Ident : public ColorProcessor {
+class ColorProcessor_Ident final : public ColorProcessor {
 public:
     ColorProcessor_Ident()
         : ColorProcessor()
@@ -880,7 +880,7 @@ public:
 
 
 // ColorProcessor that implements a matrix multiply color transformation.
-class ColorProcessor_Matrix : public ColorProcessor {
+class ColorProcessor_Matrix final : public ColorProcessor {
 public:
     ColorProcessor_Matrix(const Imath::M44f& Matrix, bool inverse)
         : ColorProcessor()

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -126,7 +126,7 @@ struct ImageCacheStatistics {
 /// However, a few of them require passing in a pointer to the
 /// thread-specific IC data including microcache and statistics.
 ///
-class OIIO_API ImageCacheFile : public RefCnt {
+class OIIO_API ImageCacheFile final : public RefCnt {
 public:
     ImageCacheFile(ImageCacheImpl& imagecache,
                    ImageCachePerThreadInfo* thread_info, ustring filename,
@@ -557,7 +557,7 @@ private:
 
 /// Record for a single image tile.
 ///
-class ImageCacheTile : public RefCnt {
+class ImageCacheTile final : public RefCnt {
 public:
     /// Construct a new tile, pixels will be read when calling read()
     ImageCacheTile(const TileID& id);
@@ -729,7 +729,7 @@ public:
 /// Some of the methods require a pointer to the thread-specific IC data
 /// including microcache and statistics.
 ///
-class ImageCacheImpl : public ImageCache {
+class ImageCacheImpl final : public ImageCache {
 public:
     ImageCacheImpl();
     virtual ~ImageCacheImpl();

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -33,7 +33,7 @@ class ImageCacheTileRef;
 
 /// Working implementation of the abstract TextureSystem class.
 ///
-class TextureSystemImpl : public TextureSystem {
+class TextureSystemImpl final : public TextureSystem {
 public:
     typedef ImageCacheFile TextureFile;
 

--- a/src/libutil/argparse.cpp
+++ b/src/libutil/argparse.cpp
@@ -23,7 +23,7 @@
 
 OIIO_NAMESPACE_BEGIN
 
-class ArgOption : public ArgParse::Arg {
+class ArgOption final : public ArgParse::Arg {
 public:
     typedef int (*callback_t)(int, const char**);
 

--- a/src/libutil/filter.cpp
+++ b/src/libutil/filter.cpp
@@ -39,7 +39,7 @@ OIIO_NAMESPACE_BEGIN
 //    float operator(float,float)      Evaluate the filter
 //
 
-class FilterBox1D : public Filter1D {
+class FilterBox1D final : public Filter1D {
 public:
     FilterBox1D(float width)
         : Filter1D(width)
@@ -55,7 +55,7 @@ public:
 
 
 
-class FilterBox2D : public Filter2D {
+class FilterBox2D final : public Filter2D {
 public:
     FilterBox2D(float width, float height)
         : Filter2D(width, height)
@@ -74,7 +74,7 @@ public:
 
 
 
-class FilterTriangle1D : public Filter1D {
+class FilterTriangle1D final : public Filter1D {
 public:
     FilterTriangle1D(float width)
         : Filter1D(width)
@@ -97,7 +97,7 @@ private:
 
 
 
-class FilterTriangle2D : public Filter2D {
+class FilterTriangle2D final : public Filter2D {
 public:
     FilterTriangle2D(float width, float height)
         : Filter2D(width, height)
@@ -128,7 +128,7 @@ private:
 
 
 
-class FilterGaussian1D : public Filter1D {
+class FilterGaussian1D final : public Filter1D {
 public:
     FilterGaussian1D(float width)
         : Filter1D(width)
@@ -150,7 +150,7 @@ private:
 
 
 
-class FilterGaussian2D : public Filter2D {
+class FilterGaussian2D final : public Filter2D {
 public:
     FilterGaussian2D(float width, float height)
         : Filter2D(width, height)
@@ -181,7 +181,7 @@ private:
 
 
 
-class FilterSharpGaussian1D : public Filter1D {
+class FilterSharpGaussian1D final : public Filter1D {
 public:
     FilterSharpGaussian1D(float width)
         : Filter1D(width)
@@ -203,7 +203,7 @@ private:
 
 
 
-class FilterSharpGaussian2D : public Filter2D {
+class FilterSharpGaussian2D final : public Filter2D {
 public:
     FilterSharpGaussian2D(float width, float height)
         : Filter2D(width, height)
@@ -234,7 +234,7 @@ private:
 
 
 
-class FilterCatmullRom1D : public Filter1D {
+class FilterCatmullRom1D final : public Filter1D {
 public:
     FilterCatmullRom1D(float width)
         : Filter1D(4.0f)
@@ -261,7 +261,7 @@ private:
 
 
 
-class FilterCatmullRom2D : public Filter2D {
+class FilterCatmullRom2D final : public Filter2D {
 public:
     FilterCatmullRom2D(float width, float height)
         : Filter2D(width, height)
@@ -292,7 +292,7 @@ private:
 
 
 
-class FilterBlackmanHarris1D : public Filter1D {
+class FilterBlackmanHarris1D final : public Filter1D {
 public:
     FilterBlackmanHarris1D(float width)
         : Filter1D(width)
@@ -336,7 +336,7 @@ private:
 
 
 
-class FilterBlackmanHarris2D : public Filter2D {
+class FilterBlackmanHarris2D final : public Filter2D {
 public:
     FilterBlackmanHarris2D(float width, float height)
         : Filter2D(width, height)
@@ -367,7 +367,7 @@ private:
 
 
 
-class FilterSinc1D : public Filter1D {
+class FilterSinc1D final : public Filter1D {
 public:
     FilterSinc1D(float width)
         : Filter1D(width)
@@ -393,7 +393,7 @@ private:
 
 
 
-class FilterSinc2D : public Filter2D {
+class FilterSinc2D final : public Filter2D {
 public:
     FilterSinc2D(float width, float height)
         : Filter2D(width, height)
@@ -418,7 +418,7 @@ private:
 
 
 
-class FilterLanczos3_1D : public Filter1D {
+class FilterLanczos3_1D final : public Filter1D {
 public:
     FilterLanczos3_1D(float width)
         : Filter1D(width)
@@ -467,7 +467,7 @@ private:
 
 
 
-class FilterLanczos3_2D : public Filter2D {
+class FilterLanczos3_2D final : public Filter2D {
 public:
     FilterLanczos3_2D(float width, float height)
         : Filter2D(width, height)
@@ -498,10 +498,12 @@ protected:
 
 
 
-class FilterRadialLanczos3_2D : public FilterLanczos3_2D {
+class FilterRadialLanczos3_2D final : public Filter2D {
 public:
     FilterRadialLanczos3_2D(float width, float height)
-        : FilterLanczos3_2D(width, height)
+        : Filter2D(width, height)
+        , m_wscale(6.0f / width)
+        , m_hscale(6.0f / height)
     {
     }
     float operator()(float x, float y) const
@@ -511,12 +513,23 @@ public:
         return FilterLanczos3_1D::lanczos3(sqrtf(x * x + y * y));
     }
     bool separable(void) const { return false; }
+    float xfilt(float x) const
+    {
+        return FilterLanczos3_1D::lanczos3(x * m_wscale);
+    }
+    float yfilt(float y) const
+    {
+        return FilterLanczos3_1D::lanczos3(y * m_hscale);
+    }
     string_view name(void) const { return "radial-lanczos3"; }
+
+protected:
+    float m_wscale, m_hscale;
 };
 
 
 
-class FilterMitchell1D : public Filter1D {
+class FilterMitchell1D final : public Filter1D {
 public:
     FilterMitchell1D(float width)
         : Filter1D(width)
@@ -555,7 +568,7 @@ private:
 
 
 
-class FilterMitchell2D : public Filter2D {
+class FilterMitchell2D final : public Filter2D {
 public:
     FilterMitchell2D(float width, float height)
         : Filter2D(width, height)
@@ -587,7 +600,7 @@ private:
 
 
 // B-spline filter from Stark et al, JGT 10(1)
-class FilterBSpline1D : public Filter1D {
+class FilterBSpline1D final : public Filter1D {
 public:
     FilterBSpline1D(float width)
         : Filter1D(width)
@@ -620,7 +633,7 @@ private:
 
 
 
-class FilterBSpline2D : public Filter2D {
+class FilterBSpline2D final : public Filter2D {
 public:
     FilterBSpline2D(float width, float height)
         : Filter2D(width, height)
@@ -651,7 +664,7 @@ private:
 
 
 
-class FilterDisk2D : public Filter2D {
+class FilterDisk2D final : public Filter2D {
 public:
     FilterDisk2D(float width, float height)
         : Filter2D(width, height)
@@ -737,7 +750,7 @@ protected:
 
 
 
-class FilterKeys1D : public FilterCubic1D {
+class FilterKeys1D final : public FilterCubic1D {
 public:
     FilterKeys1D(float width)
         : FilterCubic1D(width)
@@ -749,7 +762,7 @@ public:
 };
 
 
-class FilterKeys2D : public FilterCubic2D {
+class FilterKeys2D final : public FilterCubic2D {
 public:
     FilterKeys2D(float width, float height)
         : FilterCubic2D(width, height)
@@ -762,7 +775,7 @@ public:
 
 
 
-class FilterSimon1D : public FilterCubic1D {
+class FilterSimon1D final : public FilterCubic1D {
 public:
     FilterSimon1D(float width)
         : FilterCubic1D(width)
@@ -774,7 +787,7 @@ public:
 };
 
 
-class FilterSimon2D : public FilterCubic2D {
+class FilterSimon2D final : public FilterCubic2D {
 public:
     FilterSimon2D(float width, float height)
         : FilterCubic2D(width, height)
@@ -787,7 +800,7 @@ public:
 
 
 
-class FilterRifman1D : public FilterCubic1D {
+class FilterRifman1D final : public FilterCubic1D {
 public:
     FilterRifman1D(float width)
         : FilterCubic1D(width)
@@ -799,7 +812,7 @@ public:
 };
 
 
-class FilterRifman2D : public FilterCubic2D {
+class FilterRifman2D final : public FilterCubic2D {
 public:
     FilterRifman2D(float width, float height)
         : FilterCubic2D(width, height)

--- a/src/nuke/txReader/txReader.cpp
+++ b/src/nuke/txReader/txReader.cpp
@@ -32,7 +32,7 @@ using namespace OIIO;
 static const char* const EMPTY[] = { NULL };
 
 
-class TxReaderFormat : public ReaderFormat {
+class TxReaderFormat final : public ReaderFormat {
     int mipLevel_;
     int mipEnumIndex_;
     Knob* mipLevelKnob_;
@@ -92,7 +92,7 @@ public:
 };
 
 
-class txReader : public Reader {
+class txReader final : public Reader {
     std::unique_ptr<ImageInput> oiioInput_;
     TxReaderFormat* txFmt_;
 

--- a/src/nuke/txWriter/txWriter.cpp
+++ b/src/nuke/txWriter/txWriter.cpp
@@ -64,7 +64,7 @@ bool gTxFiltersInitialized = false;
 static std::vector<const char*> gFilterNames;
 
 
-class txWriter : public Writer {
+class txWriter final : public Writer {
     int preset_;
     int tileW_, tileH_;
     int planarMode_;

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -2021,7 +2021,7 @@ set_colorspace(int argc, const char* argv[])
 
 
 // --colorconvert
-class OpColorConvert : public OiiotoolOp {
+class OpColorConvert final : public OiiotoolOp {
 public:
     OpColorConvert(Oiiotool& ot, string_view opname, int argc,
                    const char* argv[])
@@ -2212,7 +2212,7 @@ action_unmip(int argc, const char* argv[])
 
 
 // --chnames
-class OpChnames : public OiiotoolOp {
+class OpChnames final : public OiiotoolOp {
 public:
     OpChnames(Oiiotool& ot, string_view opname, int argc, const char* argv[])
         : OiiotoolOp(ot, opname, argc, argv, 1)
@@ -3445,7 +3445,7 @@ action_cut(int argc, const char* argv[])
 
 
 // --resample
-class OpResample : public OiiotoolOp {
+class OpResample final : public OiiotoolOp {
 public:
     OpResample(Oiiotool& ot, string_view opname, int argc, const char* argv[])
         : OiiotoolOp(ot, opname, argc, argv, 1)
@@ -3502,7 +3502,7 @@ OP_CUSTOMCLASS(resample, OpResample, 1);
 
 
 // --resize
-class OpResize : public OiiotoolOp {
+class OpResize final : public OiiotoolOp {
 public:
     OpResize(Oiiotool& ot, string_view opname, int argc, const char* argv[])
         : OiiotoolOp(ot, opname, argc, argv, 1)

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -96,7 +96,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 // Custom file input stream, copying code from the class StdIFStream in OpenEXR,
 // which would have been used if we just provided a filename. The difference is
 // that this can handle UTF-8 file paths on all platforms.
-class OpenEXRInputStream : public Imf::IStream {
+class OpenEXRInputStream final : public Imf::IStream {
 public:
     OpenEXRInputStream(const char* filename, Filesystem::IOProxy* io)
         : Imf::IStream(filename)

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -80,7 +80,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 
 
 // Custom file output stream that uses IOProxy for output.
-class OpenEXROutputStream : public Imf::OStream {
+class OpenEXROutputStream final : public Imf::OStream {
 public:
     OpenEXROutputStream(const char* filename, Filesystem::IOProxy* io)
         : Imf::OStream(filename)

--- a/src/term.imageio/termoutput.cpp
+++ b/src/term.imageio/termoutput.cpp
@@ -16,7 +16,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 namespace term_pvt {
 
 
-class TermOutput : public ImageOutput {
+class TermOutput final : public ImageOutput {
 public:
     TermOutput() { init(); }
     virtual ~TermOutput() { close(); }


### PR DESCRIPTION
This is good for optimization, allowing "de-virtualization" of function
calls in cases when the compiler can be sure that there can be no further
subclassing.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

