### PR TITLE
StrongParam helper for disambiguating parameters

### DIFF
--- a/src/include/OpenImageIO/strongparam.h
+++ b/src/include/OpenImageIO/strongparam.h
@@ -1,0 +1,116 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio
+
+
+#pragma once
+
+#include <type_traits>
+
+#include <OpenImageIO/oiioversion.h>
+
+OIIO_NAMESPACE_BEGIN
+
+
+/// StrongParam is used to construct an implementation of a derived type
+/// that lets you pass strongly typed parameters. It implicitly converts TO
+/// the basetype, but requires explicit conversion FROM the basetype.
+///
+/// The problem this is meant to address is that you may have a function
+/// that has multiple bool, int, or float paramters, particularly if they
+/// are adjacent in the call signature. This is extremely error prone. For
+/// example, suppose you have
+///
+///     void func (bool verbose, bool crazy, int apples, int oranges);
+///
+/// and then it is called:
+///
+///     func(true, false, 3, 8);
+///
+/// Is this correct, or does it harbor a bug? Your guess is as good as mine.
+/// In comparison, Python has a syntax that lets you name parameters, which
+/// looks like this:
+///
+///     func(verbose=true, crazy=false, apples=3, oranges=8);
+///
+/// But, unfortunately, no such syntax exists in C++. Maybe someday it will,
+/// but for now, we want something we can use to make the function call
+/// similarly clear. Like this:
+///
+///     func(Verbose(true), Crazy(false), Apples(3), Oranges(8));
+///
+/// and simultaneously for the following to be considered errors:
+///
+///     // Not allowed: bare bools and ints
+///     func(true, false, 3, 8);
+///
+///     // Not allowed: getting the order wrong
+///     func(Crazy(false), Verbose(true), Oranges(8), Apples(3));
+///
+/// Our solution is inspired by
+/// https://lists.llvm.org/pipermail/llvm-dev/2019-August/134302.html
+/// though we have simplified it quite a bit for our needs.
+///
+/// Example use 1: Use StrongParam to disambiguate parameters.
+///
+///     // Use macro to generate the new types
+///     OIIO_STRONG_PARAM_TYPE(Verbose, bool);
+///     OIIO_STRONG_PARAM_TYPE(Crazy, bool);
+///
+///     bool
+///     compute (Verbose a, Crazy b)
+///     {
+///         return a | b;
+///     }
+///
+///
+/// Example 2: Use StrongParam to disambiguate two floats, a poor person's
+/// implementation of units:
+///
+/// Error prone: speed(float,float)  // which is first, meters or seconds?
+/// Unambigious: speed(Meters,Seconds)
+///
+///     OIIO_STRONG_PARAM_TYPE(Meters, float);
+///     OIIO_STRONG_PARAM_TYPE(Seconds, float);
+///
+///     float
+///     speed (Meters a, Seconds b)
+///     {
+///         return a / b;
+///     }
+///
+/// Note that the fancy strong type is for declaration purposes. Any time
+/// you use it in the function, it implicitly converts to the underlying
+/// base type.
+///
+
+template<typename Tag, typename Basetype> struct StrongParam {
+    // Construct a StrongParam from a Basetype.
+    explicit StrongParam(const Basetype& val)
+        : m_val(val)
+    {
+    }
+
+    // Allow default simple copy construction
+    StrongParam(const StrongParam<Tag, Basetype>& val) = default;
+
+    // Allow implicit conversion back to Basetype.
+    operator const Basetype&() const noexcept { return m_val; }
+
+private:
+    Basetype m_val;
+    static_assert(std::is_trivial<Basetype>::value, "Need trivial type");
+};
+
+
+
+/// Convenience macro for making strong parameter type Name that is Basetype
+/// underneath. What it actually does is make a new type that is derived
+/// from StrongParam<Name,Basetype>.
+#define OIIO_STRONG_PARAM_TYPE(Name, Basetype)         \
+    struct Name : public StrongParam<Name, Basetype> { \
+        using StrongParam::StrongParam;                \
+    }
+
+
+OIIO_NAMESPACE_END

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -140,4 +140,9 @@ if (OIIO_BUILD_TESTS)
     set_target_properties (paramlist_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_paramlist ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/paramlist_test)
 
+    add_executable (strongparam_test strongparam_test.cpp)
+    target_link_libraries (strongparam_test PRIVATE OpenImageIO)
+    set_target_properties (strongparam_test PROPERTIES FOLDER "Unit Tests")
+    add_test (unit_strongparam ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/strongparam_test)
+
 endif ()

--- a/src/libutil/strongparam_test.cpp
+++ b/src/libutil/strongparam_test.cpp
@@ -1,0 +1,31 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio
+
+
+#include <OpenImageIO/strongparam.h>
+#include <OpenImageIO/unittest.h>
+
+using namespace OIIO;
+
+
+OIIO_STRONG_PARAM_TYPE(Meters, float);
+OIIO_STRONG_PARAM_TYPE(Seconds, float);
+
+
+float
+speed(Meters a, Seconds b)
+{
+    return a / b;
+}
+
+
+
+int
+main(int /*argc*/, char* /*argv*/[])
+{
+    float s = speed(Meters(8.0f), Seconds(2.0f));
+    OIIO_CHECK_EQUAL(s, 4.0f);
+
+    return unit_test_failures;
+}


### PR DESCRIPTION
Consider this a design review. The point is all explained in depth in the comments, I won't restate it here.

This is an idea I've been contemplating for a long time. I want people to think about whether using this idiom -- sparingly, in   the kinds of places where we may have used an enum to bring more clarity than a bare bool or int -- would help improve code readability and reduce parameter passing errors. If so, I'd like to start using it. But if people think it's a needless  flourish that detracts from code readability, then I can be persuaded to abandon it.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
