### PR TITLE
Fix broken read of 16 bit iff files

### DIFF
--- a/src/iff.imageio/iff_pvt.cpp
+++ b/src/iff.imageio/iff_pvt.cpp
@@ -119,8 +119,7 @@ IffFileHeader::read_header(FILE* fd, std::string& err)
                                 pixel_channels++;
 
                             // test pixel bits
-                            if (!bytes)
-                                pixel_bits = bytes ? 16 : 8;
+                            pixel_bits = bytes ? 16 : 8;
                         }
 
                         // Z format.


### PR DESCRIPTION
This used to work, was inadvertently broken in #2398, in Nov 2019, and
no release of OIIO 2.1 ever had it working!  (I guess people don't
come across 16 bit iff files very often?)

Signed-off-by: Larry Gritz <lg@larrygritz.com>

