### PR TITLE
make_texture was not correctly setting tile sizes

### DIFF
--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -963,6 +963,15 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     }
 
     ImageSpec configspec = _configspec;
+
+    // Set default tile size if no specific one was requested via config
+    if (!configspec.tile_width)
+        configspec.tile_width = 64;
+    if (!configspec.tile_height)
+        configspec.tile_height = 64;
+    if (!configspec.tile_depth)
+        configspec.tile_depth = 1;
+
     std::stringstream localstream;  // catch output when user doesn't want it
     std::ostream& outstream(outstream_ptr ? *outstream_ptr : localstream);
 


### PR DESCRIPTION
It was setting it, but later, too late for the particular case where
constant_color_detect was used and found a constant color and
also the config spec came in without any tile preference (still 0's).
So move the default initialization up to the top.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

