### PR TITLE
Fixed ARM NEON code path in simd.h, all tests in simd_test are passing

### DIFF
--- a/src/include/OpenImageIO/benchmark.h
+++ b/src/include/OpenImageIO/benchmark.h
@@ -26,7 +26,9 @@ OIIO_NAMESPACE_BEGIN
 /// * Google Benchmark https://github.com/google/benchmark/blob/master/include/benchmark/benchmark_api.h
 
 template <class T>
-OIIO_FORCEINLINE T const& DoNotOptimize (T const &val);
+//Do not use always_inline with optnone attribute
+//OIIO_FORCEINLINE T const& DoNotOptimize (T const &val);
+T const& DoNotOptimize (T const &val);
 
 
 /// clobber_all_memory() is a helper function for timing benchmarks that

--- a/src/include/OpenImageIO/benchmark.h
+++ b/src/include/OpenImageIO/benchmark.h
@@ -26,8 +26,6 @@ OIIO_NAMESPACE_BEGIN
 /// * Google Benchmark https://github.com/google/benchmark/blob/master/include/benchmark/benchmark_api.h
 
 template <class T>
-//Do not use always_inline with optnone attribute
-//OIIO_FORCEINLINE T const& DoNotOptimize (T const &val);
 T const& DoNotOptimize (T const &val);
 
 

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -4759,7 +4759,6 @@ OIIO_FORCEINLINE vint4 blend (const vint4& a, const vint4& b, const vbool4& mask
     return _mm_or_si128 (_mm_and_si128(_mm_castps_si128(mask.simd()), b.simd()),
                          _mm_andnot_si128(_mm_castps_si128(mask.simd()), a.simd()));
 #elif OIIO_SIMD_NEON
-    //return vbslq_s32 (mask.simd(), a.simd(), b.simd());
     return vbslq_s32 (mask.simd(), b.simd(), a.simd());
 #else
     SIMD_RETURN (vint4, mask[i] ? b[i] : a[i]);
@@ -6619,7 +6618,6 @@ OIIO_FORCEINLINE void vfloat4::load (const float *values, int n) {
     }
 #elif OIIO_SIMD_NEON
     switch (n) {
-    //case 1: load (values[0], 0.0f, 0.0f, 0.0f);		break;
     case 1: m_simd = vdupq_n_f32(0); m_simd[0] = values[0]; break;
     case 2: load (values[0], values[1], 0.0f, 0.0f);      break;
     case 3: load (values[0], values[1], values[2], 0.0f); break;


### PR DESCRIPTION
## Description

Fixed ARM NEON code path in src/include/OpenImageIO/simd.h, and a single-line change for a compile error in src/include/OpenImageIO/benchmark.h

## Tests

All tests in simd_test binary are passing


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [x ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x ] My code follows the prevailing code style of this project.

