### PR TITLE
Error policy overhaul to clear up inconsistencies

### DIFF
--- a/src/doc/imageioapi.rst
+++ b/src/doc/imageioapi.rst
@@ -252,14 +252,19 @@ just exist in the OIIO namespace as general utilities. (See
 .. doxygenfunction:: openimageio_version
 
 
-.. cpp:function:: std::string OIIO::geterror ()
+.. cpp:function:: bool OIIO::has_error ()
+
+    Is there a pending global error message waiting to be retrieved?
+
+.. cpp:function:: std::string OIIO::geterror (bool clear = true)
 
     Returns any error string describing what went wrong if
     `ImageInput::create()` or `ImageOutput::create()` failed (since in such
-    cases, the `ImageInput` or `ImageOutput` itself does not exist to have
-    its own `geterror()` function called). This function returns the last
-    error for this particular thread; separate threads will not clobber each
-    other's global error messages.
+    cases, the ImageInput or ImageOutput itself does not exist to have its
+    own `geterror()` function called). This function returns the last error
+    for this particular thread, and clear the pending error message unless
+    `clear` is false; separate threads will not clobber each other's global
+    error messages.
 
 
 

--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -1147,7 +1147,7 @@ the Python versions allocate and return an array holding the pixel values
     explicit subimage/miplevel.
 
 
-.. py:method:: ImageInput.geterror ()
+.. py:method:: ImageInput.geterror (clear = True)
 
     Retrieves the error message from the latest failed operation on an
     ImageInput.
@@ -1454,7 +1454,7 @@ ImageOutput class APIs. The Python APIs are very similar.
         input.close ()
 
 
-.. py:method:: ImageOuput.geterror ()
+.. py:method:: ImageOuput.geterror (clear = True)
 
     Retrieves the error message from the latest failed operation on an open
     file.
@@ -2053,7 +2053,7 @@ awaiting a call to `reset()` or `copy()` before it is useful.
 
     This field will be `True` if an error has occurred in the ImageBuf.
 
-.. py:method::  ImageBuf.geterror ()
+.. py:method::  ImageBuf.geterror (clear = True)
 
     Retrieve the error message (and clear the `has_error` flag).
 
@@ -3568,7 +3568,7 @@ details.
     OpenImageIO 1.2.3 would return a value of 10203.
 
 
-.. py:method:: geterror()
+.. py:method:: geterror(clear = True)
 
     Retrieves the latest global error, as a string.
 

--- a/src/include/OpenImageIO/argparse.h
+++ b/src/include/OpenImageIO/argparse.h
@@ -257,10 +257,14 @@ public:
     /// ok, -1 if it's a malformed command line.
     int parse_args(int argc, const char** argv);
 
+    /// Is there a pending error message waiting to be retrieved?
+    bool has_error() const;
+
     /// Return any error messages generated during the course of parse()
-    /// (and clear any error flags).  If no error has occurred since the
-    /// last time geterror() was called, it will return an empty string.
-    std::string geterror() const;
+    /// (and by default, clear any error flags).  If no error has occurred
+    /// since the last time geterror() was called, it will return an empty
+    /// string.
+    std::string geterror(bool clear = true) const;
 
     /// Return the name of the program. This will be either derived from the
     /// original command line that launched this application, or else

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -89,10 +89,10 @@ public:
     /// (This will not affect the error state.)
     bool error() const;
 
-    /// This routine will return the error string (and clear any error
-    /// flags).  If no error has occurred since the last time geterror()
-    /// was called, it will return an empty string.
-    std::string geterror();
+    /// This routine will return the error string (and by default, clear any
+    /// error flags).  If no error has occurred since the last time
+    /// geterror() was called, it will return an empty string.
+    std::string geterror(bool clear = true);
 
     /// Get the number of ColorSpace(s) defined in this configuration
     int getNumColorSpaces() const;

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -937,11 +937,13 @@ public:
     /// @{
     /// @name Error handling
 
-    /// Add simple string to the error message list for this IB.
-    void error(const std::string& message) const;
+    /// Add simple string to the error message list for this IB. It is not
+    /// necessary to have the error message contain a trailing newline.
+    void error(string_view message) const;
 
-    /// Error reporting for ImageBuf: call this with Python / {fmt} /
-    /// std::format style formatting specification.
+    /// Error reporting for ImageBuf: call this with std::format style
+    /// formatting specification. It is not necessary to have the error
+    /// message contain a trailing newline.
     template<typename... Args>
     void errorfmt(const char* fmt, const Args&... args) const
     {
@@ -949,7 +951,8 @@ public:
     }
 
     /// Error reporting for ImageBuf: call this with printf-like arguments
-    /// to report an error.
+    /// to report an error. It is not necessary to have the error message
+    /// contain a trailing newline.
     template<typename... Args>
     void errorf(const char* fmt, const Args&... args) const
     {
@@ -957,8 +960,9 @@ public:
     }
 
     /// Error reporting for ImageBuf: call this with Strutil::format
-    /// formatting conventions. Beware, this is in transition, is currently
-    /// printf-like but will someday change to python-like!
+    /// formatting conventions.  It is not necessary to have the error
+    /// message contain a trailing newline.Beware, this is in transition, is
+    /// currently printf-like but will someday change to python-like!
     template<typename... Args>
     void error(const char* fmt, const Args&... args) const
     {
@@ -978,10 +982,11 @@ public:
     /// message ready to retrieve via `geterror()`.
     bool has_error(void) const;
 
-    /// Return the text of all error messages issued since `geterror()` was
-    /// called (or an empty string if no errors are pending).  This also
-    /// clears the error message for next time.
-    std::string geterror(void) const;
+    /// Return the text of all pending error messages issued against this
+    /// ImageBuf, and clear the pending error message unless `clear` is
+    /// false. If no error message is pending, it will return an empty
+    /// string.
+    std::string geterror(bool clear = true) const;
 
     /// @}
 

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -944,11 +944,14 @@ public:
     /// @{
     /// @name Errors and statistics
 
-    /// If any of the API routines returned `false` indicating an error,
-    /// this routine will return the error string (and clear any error
-    /// flags).  If no error has occurred since the last time `geterror()`
-    /// was called, it will return an empty string.
-    virtual std::string geterror() const = 0;
+    /// Is there a pending error message waiting to be retrieved?
+    virtual bool has_error() const = 0;
+
+    /// Return the text of all pending error messages issued against this
+    /// ImageCache, and clear the pending error message unless `clear` is
+    /// false. If no error message is pending, it will return an empty
+    /// string.
+    virtual std::string geterror(bool clear = true) const = 0;
 
     /// Returns a big string containing useful statistics about the
     /// ImageCache operations, suitable for saving to a file or outputting

--- a/src/include/OpenImageIO/plugin.h
+++ b/src/include/OpenImageIO/plugin.h
@@ -66,13 +66,9 @@ getsym(Handle plugin_handle, const std::string& symbol_name,
 }
 
 /// Return any error messages associated with the last call to any of
-/// open, close, or getsym.  Note that in a multithreaded environment,
-/// it's up to the caller to properly mutex to ensure that no other
-/// thread has called open, close, or getsym (all of which clear or
-/// overwrite the error message) between the error-generating call and
-/// geterror.
+/// open, close, or getsym from the same thread.
 OIIO_API std::string
-geterror(void);
+geterror(bool clear = true);
 
 
 

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -1675,12 +1675,15 @@ public:
 
     /// @{
     /// @name Errors and statistics
-    
-    /// If any of the API routines returned false indicating an error,
-    /// this routine will return the error string (and clear any error
-    /// flags).  If no error has occurred since the last time geterror()
-    /// was called, it will return an empty string.
-    virtual std::string geterror () const = 0;
+
+    /// Is there a pending error message waiting to be retrieved?
+    virtual bool has_error() const = 0;
+
+    /// Return the text of all pending error messages issued against this
+    /// TextureSystem, and clear the pending error message unless `clear` is
+    /// false. If no error message is pending, it will return an empty
+    /// string.
+    virtual std::string geterror(bool clear = true) const = 0;
 
     /// Returns a big string containing useful statistics about the
     /// TextureSystem operations, suitable for saving to a file or

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -343,9 +343,9 @@ ColorConfig::error() const
 
 
 std::string
-ColorConfig::geterror()
+ColorConfig::geterror(bool clear)
 {
-    return getImpl()->geterror(true /*clear*/);
+    return getImpl()->geterror(clear);
 }
 
 

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -1003,13 +1003,15 @@ ImageInput::send_to_client(const char* /*format*/, ...)
 
 
 void
-ImageInput::append_error(const std::string& message) const
+ImageInput::append_error(string_view message) const
 {
+    if (message.size() && message.back() == '\n')
+        message.remove_suffix(1);
     lock_guard lock(m_mutex);
     OIIO_DASSERT(
         m_errmessage.size() < 1024 * 1024 * 16
         && "Accumulated error messages > 16MB. Try checking return codes!");
-    if (m_errmessage.size())
+    if (m_errmessage.size() && m_errmessage.back() != '\n')
         m_errmessage += '\n';
     m_errmessage += message;
 }

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -36,13 +36,18 @@ extern int oiio_log_times;
 
 
 // For internal use - use error() below for a nicer interface.
-void seterror (string_view message);
+void append_error(string_view message);
 
-/// Use error() privately only.  Prototype is conceptually printf-like, but
-/// also fully typesafe:
+/// Use errorf() privately only. Formatting is printf notation, but typesafe.
 template<typename... Args>
 inline void errorf (const char* fmt, const Args&... args) {
-    seterror(Strutil::sprintf (fmt, args...));
+    append_error(Strutil::sprintf (fmt, args...));
+}
+
+/// Use errorfmt() privately only. Formatting notation is like std::format.
+template<typename... Args>
+inline void errorfmt (const char* fmt, const Args&... args) {
+    append_error(Strutil::fmt::format(fmt, args...));
 }
 
 // Make sure all plugins are inventoried.  Should only be called while

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -227,12 +227,14 @@ ImageOutput::send_to_client(const char* /*format*/, ...)
 
 
 void
-ImageOutput::append_error(const std::string& message) const
+ImageOutput::append_error(string_view message) const
 {
+    if (message.size() && message.back() == '\n')
+        message.remove_suffix(1);
     OIIO_ASSERT(
         m_errmessage.size() < 1024 * 1024 * 16
         && "Accumulated error messages > 16MB. Try checking return codes!");
-    if (m_errmessage.size())
+    if (m_errmessage.size() && m_errmessage.back() != '\n')
         m_errmessage += '\n';
     m_errmessage += message;
 }

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3557,14 +3557,24 @@ ImageCacheImpl::purge_perthread_microcaches()
 
 
 
+bool
+ImageCacheImpl::has_error() const
+{
+    std::string* errptr = m_errormessage.get();
+    return (errptr && errptr->size());
+}
+
+
+
 std::string
-ImageCacheImpl::geterror() const
+ImageCacheImpl::geterror(bool clear) const
 {
     std::string e;
     std::string* errptr = m_errormessage.get();
     if (errptr) {
         e = *errptr;
-        errptr->clear();
+        if (clear)
+            errptr->clear();
     }
     return e;
 }
@@ -3572,8 +3582,10 @@ ImageCacheImpl::geterror() const
 
 
 void
-ImageCacheImpl::append_error(const std::string& message) const
+ImageCacheImpl::append_error(string_view message) const
 {
+    if (message.size() && message.back() == '\n')
+        message.remove_suffix(1);
     std::string* errptr = m_errormessage.get();
     if (!errptr) {
         errptr = new std::string;
@@ -3583,7 +3595,7 @@ ImageCacheImpl::append_error(const std::string& message) const
     OIIO_DASSERT(
         errptr->size() < 1024 * 1024 * 16
         && "Accumulated error messages > 16MB. Try checking return codes!");
-    if (errptr->size())
+    if (errptr->size() && errptr->back() != '\n')
         *errptr += '\n';
     *errptr += message;
 }

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -968,7 +968,8 @@ public:
     /// subimage matches its name.
     int subimage_from_name(ImageCacheFile* file, ustring subimagename);
 
-    virtual std::string geterror() const;
+    virtual bool has_error() const;
+    virtual std::string geterror(bool clear = true) const;
     virtual std::string getstats(int level = 1) const;
     virtual void reset_stats();
     virtual void invalidate(ustring filename, bool force);
@@ -1031,7 +1032,7 @@ public:
     void error(const char* msg) const { append_error(msg); }
 
     /// Append a string to the current error message
-    void append_error(const std::string& message) const;
+    void append_error(string_view message) const;
 
     virtual Perthread* get_perthread_info(Perthread* thread_info = NULL);
     virtual Perthread* create_thread_info();

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -328,7 +328,8 @@ public:
                             int yend, int zbegin, int zend, int chbegin,
                             int chend, TypeDesc format, void* result);
 
-    virtual std::string geterror() const;
+    virtual bool has_error() const;
+    virtual std::string geterror(bool clear = true) const;
     virtual std::string getstats(int level = 1, bool icstats = true) const;
     virtual void reset_stats();
 
@@ -550,7 +551,7 @@ private:
     }
 
     /// Append a string to the current error message
-    void append_error(const std::string& message) const;
+    void append_error(string_view message) const;
 
     void printstats() const;
 

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -761,14 +761,24 @@ TextureSystemImpl::get_texels(TextureHandle* texture_handle_,
 
 
 
+bool
+TextureSystemImpl::has_error() const
+{
+    std::string* errptr = m_errormessage.get();
+    return (errptr && errptr->size());
+}
+
+
+
 std::string
-TextureSystemImpl::geterror() const
+TextureSystemImpl::geterror(bool clear) const
 {
     std::string e;
     std::string* errptr = m_errormessage.get();
     if (errptr) {
         e = *errptr;
-        errptr->clear();
+        if (clear)
+            errptr->clear();
     }
     return e;
 }
@@ -776,8 +786,10 @@ TextureSystemImpl::geterror() const
 
 
 void
-TextureSystemImpl::append_error(const std::string& message) const
+TextureSystemImpl::append_error(string_view message) const
 {
+    if (message.size() && message.back() == '\n')
+        message.remove_suffix(1);
     std::string* errptr = m_errormessage.get();
     if (!errptr) {
         errptr = new std::string;
@@ -786,7 +798,7 @@ TextureSystemImpl::append_error(const std::string& message) const
     OIIO_DASSERT(
         errptr->size() < 1024 * 1024 * 16
         && "Accumulated error messages > 16MB. Try checking return codes!");
-    if (errptr->size())
+    if (errptr->size() && errptr->back() != '\n')
         *errptr += '\n';
     *errptr += message;
 }

--- a/src/libutil/argparse.cpp
+++ b/src/libutil/argparse.cpp
@@ -892,11 +892,20 @@ ArgParse::Impl::found(const char* option_name)
 
 
 
+bool
+ArgParse::has_error() const
+{
+    return !m_impl->m_errmessage.empty();
+}
+
+
+
 std::string
-ArgParse::geterror() const
+ArgParse::geterror(bool clear) const
 {
     std::string e = m_impl->m_errmessage;
-    m_impl->m_errmessage.clear();
+    if (clear)
+        m_impl->m_errmessage.clear();
     return e;
 }
 

--- a/src/libutil/plugin.cpp
+++ b/src/libutil/plugin.cpp
@@ -23,7 +23,7 @@ using namespace Plugin;
 namespace {
 
 static mutex plugin_mutex;
-static std::string last_error;
+static thread_local std::string last_error;
 
 }  // namespace
 
@@ -130,11 +130,11 @@ Plugin::getsym(Handle plugin_handle, const char* symbol_name, bool report_error)
 
 
 std::string
-Plugin::geterror(void)
+Plugin::geterror(bool clear)
 {
-    lock_guard guard(plugin_mutex);
     std::string e = last_error;
-    last_error.clear();
+    if (clear)
+        last_error.clear();
     return e;
 }
 

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -340,8 +340,12 @@ declare_imagebuf(py::module& m)
         .def_property_readonly("pixels_valid", &ImageBuf::pixels_valid)
         .def_property_readonly("pixeltype", &ImageBuf::pixeltype)
         .def_property_readonly("has_error", &ImageBuf::has_error)
-        .def("geterror",
-             [](const ImageBuf& self) { return PY_STR(self.geterror()); })
+        .def(
+            "geterror",
+            [](const ImageBuf& self, bool clear) {
+                return PY_STR(self.geterror(clear));
+            },
+            "clear"_a = true)
 
         .def("pixelindex", &ImageBuf::pixelindex, "x"_a, "y"_a, "z"_a,
              "check_range"_a = false)

--- a/src/python/py_imagecache.cpp
+++ b/src/python/py_imagecache.cpp
@@ -119,8 +119,16 @@ declare_imagecache(py::module& m)
         // .def("release_tile", &ImageCacheWrap::release_tile)
         // .def("tile_pixels", &ImageCacheWrap::tile_pixels)
 
-        .def("geterror",
-             [](ImageCacheWrap& ic) { return PY_STR(ic.m_cache->geterror()); })
+        .def_property_readonly("has_error",
+                               [](ImageCacheWrap& self) {
+                                   return self.m_cache->has_error();
+                               })
+        .def(
+            "geterror",
+            [](ImageCacheWrap& self, bool clear) {
+                return PY_STR(self.m_cache->geterror(clear));
+            },
+            "clear"_a = true)
         .def(
             "getstats",
             [](ImageCacheWrap& ic, int level) {

--- a/src/python/py_imageinput.cpp
+++ b/src/python/py_imageinput.cpp
@@ -361,8 +361,13 @@ declare_imageinput(py::module& m)
             "chbegin"_a, "chend"_a)
         .def("read_native_deep_image", &ImageInput_read_native_deep_image,
              "subimage"_a = 0, "miplevel"_a = 0)
-        .def("geterror",
-             [](ImageInput& self) { return PY_STR(self.geterror()); });
+        .def_property_readonly("has_error", &ImageInput::has_error)
+        .def(
+            "geterror",
+            [](ImageInput& self, bool clear) {
+                return PY_STR(self.geterror(clear));
+            },
+            "clear"_a = true);
 }
 
 }  // namespace PyOpenImageIO

--- a/src/python/py_imageoutput.cpp
+++ b/src/python/py_imageoutput.cpp
@@ -248,8 +248,13 @@ declare_imageoutput(py::module& m)
         .def("write_deep_image", &ImageOutput_write_deep_image)
         .def("copy_image", [](ImageOutput& self,
                               ImageInput& in) { return self.copy_image(&in); })
-        .def("geterror",
-             [](ImageOutput& self) { return PY_STR(self.geterror()); });
+        .def_property_readonly("has_error", &ImageOutput::has_error)
+        .def(
+            "geterror",
+            [](ImageOutput& self, bool clear) {
+                return PY_STR(self.geterror(clear));
+            },
+            "clear"_a = true);
 }
 
 }  // namespace PyOpenImageIO

--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -244,6 +244,8 @@ oiio_getattribute_typed(const std::string& name, TypeDesc type = TypeUnknown)
 
 OIIO_DECLARE_PYMODULE(PYMODULE_NAME)
 {
+    using namespace pybind11::literals;
+
     // Basic helper classes
     declare_typedesc(m);
     declare_paramvalue(m);
@@ -261,7 +263,7 @@ OIIO_DECLARE_PYMODULE(PYMODULE_NAME)
     declare_imagebufalgo(m);
 
     // Global (OpenImageIO scope) functions and symbols
-    m.def("geterror", &OIIO::geterror);
+    m.def("geterror", &OIIO::geterror, "clear"_a = true);
     m.def("attribute", [](const std::string& name, float val) {
         OIIO::attribute(name, val);
     });

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -469,7 +469,7 @@ OIIO_PLUGIN_EXPORTS_END
 
 // Someplace to store an error message from the TIFF error handler
 // To avoid thread oddities, we have the storage area buffering error
-// messages for seterror()/geterror() be thread-specific.
+// messages be thread-specific.
 static thread_local std::string thread_error_msg;
 static atomic_int handler_set;
 static spin_mutex handler_mutex;

--- a/testsuite/openexr-damaged/ref/out-exr2.2-alt.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.2-alt.txt
@@ -297,7 +297,6 @@ Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
-
 Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr2.2-travis.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.2-travis.txt
@@ -297,7 +297,6 @@ Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
-
 Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr2.2.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.2.txt
@@ -293,7 +293,6 @@ Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
-
 Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr2.3.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.3.txt
@@ -293,7 +293,6 @@ Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
-
 Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr2.4-clang-noptex.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.4-clang-noptex.txt
@@ -301,7 +301,6 @@ Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
-
 Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr2.4-clang-ptex.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.4-clang-ptex.txt
@@ -303,7 +303,6 @@ Full command line was:
 
 PtexReader error: read failed (EOF) PtexFile: tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
-
 Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr2.4-noptex-spi.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.4-noptex-spi.txt
@@ -291,7 +291,6 @@ Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
-
 Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr2.4-noptex.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.4-noptex.txt
@@ -293,7 +293,6 @@ Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
-
 Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr2.5-clang-ptex.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.5-clang-ptex.txt
@@ -303,7 +303,6 @@ Full command line was:
 
 PtexReader error: read failed (EOF) PtexFile: tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
-
 Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr2.5.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.5.txt
@@ -301,7 +301,6 @@ Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
-
 Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr3.0.txt
+++ b/testsuite/openexr-damaged/ref/out-exr3.0.txt
@@ -301,7 +301,6 @@ Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
-
 Full command line was:
 > ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 


### PR DESCRIPTION
Different classes and modules had minor inconsistencies on how errors
were reported and retrieved. Let's fix these up.

* geterror() should always take a `clear` parameter that allows the
  caller to control whether or not retrieving the error clears the
  internal error message (default is true, clear it after retrieving).

* Any class with a geterror() should also have a has_error() that merely
  reports whether there is an error message pending retrieval.

* geterror() will always *append* to an existing error message that
  has not yet been retrieved, with a newline separating error
  messages. Previously, some of our geterror implementations appended
  and others replaced.

* geterror() will trim a single trailing newline from the message it
  is passed, thus storing error messages that are not
  newline-terminated and making it so that callers of geterror() don't
  need to wonder whether or not they should terminate their error
  messages with a newline or what happens if you make the wrong
  choice.

* Usage guidance is therefore that individual errorf/errorfmt() calls
  not include a trailing newline (though if one is present, it will
  be harmlessly stripped), and that whoever retrieves with geterror()
  should, after outputting it, add a newline (which they seem to
  invariably do already).

Signed-off-by: Larry Gritz <lg@larrygritz.com>
