### PR TITLE
Fix CI break

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,24 +363,25 @@ jobs:
           name: ${{ github.job }}
           path: build/*/testsuite/*/*.*
 
-  linux-clang9:
-    # Test compiling with clang9 on Linux.
-    name: "Linux clang: clang9 C++14 avx2 exr2.4"
+  linux-clang:
+    # Test compiling with clang on Linux.
+    name: "Linux clang10: clang10 C++14 avx2 exr2.4"
     runs-on: ubuntu-18.04
+    container:
+      image: aswf/ci-osl:2021
     steps:
       - uses: actions/checkout@v2
       - name: all
         env:
           CXX: clang++
-          LLVM_VERSION: 9.0.0
           CMAKE_CXX_STANDARD: 14
+          PYTHON_VERSION: 3.7
           USE_SIMD: avx2,f16c
-          OPENEXR_VERSION: v2.4.1
           OPENCOLORIO_VERSION: 1c624651b7
           # Pick an OCIO commit that includes a warning fix we need for clang
         run: |
             source src/build-scripts/ci-startup.bash
-            source src/build-scripts/gh-installdeps.bash
+            source src/build-scripts/gh-installdeps-centos.bash
             source src/build-scripts/ci-build-and-test.bash
       - uses: actions/upload-artifact@v2
         if: failure()

--- a/src/build-scripts/gh-installdeps-centos.bash
+++ b/src/build-scripts/gh-installdeps-centos.bash
@@ -24,9 +24,9 @@ sudo yum install -y ffmpeg ffmpeg-devel && true
 
 
 
-if [[ "$CXX" == "clang++" ]] ; then
-    source src/build-scripts/build_llvm.bash
-fi
+# if [[ "$CXX" == "clang++" ]] ; then
+#     source src/build-scripts/build_llvm.bash
+# fi
 
 
 src/build-scripts/install_test_images.bash


### PR DESCRIPTION
One of our CI matrix entries -- building with clang -- has
mysteriously broken with compile errors complaining about reallocarray
being inconsistently declared in stdlib.h and gif_lib.h. It just broke
a few days ago, unrelated to any changes on our part. I have no idea
if it was the compiler or gif library that got updated and then broke.
Whatever. Insulate ourselves from random changes on GHCI by converting
this test to use one of the ASWF containers that we can count on to
have stable dependencies installed.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
