### PR TITLE
Fix propagation of errors from make_texture

### DIFF
--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -3429,6 +3429,10 @@ Import / export
     of supported configuration options is given in
     Section :ref:`sec-iba-importexport`.
 
+    The return value is True for success, False if errors occurred, in which
+    case the error message will be retrievable from the global
+    `oiio.geterror()`.
+
     Example:
 
     .. code-block:: python
@@ -3436,15 +3440,19 @@ Import / export
         # This command line:
         #    maketx in.exr --hicomp --filter lanczos3 --opaque-detect \
         #             -o texture.exr
-        # is equivalent to:
-    
-        Input = ImageBuf ("in.exr")
-        config = ImageSpec()
+        # performs the same operations as:
+
+        import OpenImageIO as oiio
+
+        Input = oiio.ImageBuf ("in.exr")
+        config = oiio.ImageSpec()
         config.attribute ("maketx:highlightcomp", 1)
         config.attribute ("maketx:filtername", "lanczos3")
         config.attribute ("maketx:opaque_detect", 1)
-        ImageBufAlgo.make_texture (oiio.MakeTxTexture, Input,
-                                   "texture.exr", config)
+        ok = oiio.ImageBufAlgo.make_texture (oiio.MakeTxTexture, Input,
+                                        "texture.exr", config)
+        if not ok :
+            print("error:", oiio.geterror())
 
 
 

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -1837,6 +1837,11 @@ enum MakeTextureMode {
 /// The `make_texture()` function turns an image into a tiled, MIP-mapped,
 /// texture file and write it to disk (outputfilename).
 ///
+/// The return value is `true` for success, `false` if an error occurred. If
+/// there was an error, any error message will be retrievable via the global
+/// `OIIO::geterror()` call (since there is no destination `ImageBuf` in
+/// which to store it).
+///
 /// Named fields in config:
 ///
 ///    - format : Data format of the texture file (default: UNKNOWN = same
@@ -1991,8 +1996,9 @@ enum MakeTextureMode {
 /// @param  outstream
 ///     If not `nullptr`, it should point to a stream (for example,
 ///     `&std::out`, or a pointer to a local `std::stringstream` to capture
-///     output), which is where console output and error messages will be
-///     deposited.
+///     output), which is where console output and errors will be
+///     deposited. Note that error messages will also be retrievable from
+///     OIIO::geterror().
 ///
 ///
 

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -601,6 +601,7 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
              std::ostream& outstream, double& stat_writetime,
              double& stat_miptime, size_t& peak_mem)
 {
+    using OIIO::pvt::errorfmt;
     bool envlatlmode       = (mode == ImageBufAlgo::MakeTxEnvLatl);
     bool orig_was_overscan = (img->spec().x || img->spec().y || img->spec().z
                               || img->spec().full_x || img->spec().full_y
@@ -610,8 +611,8 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
     outspec.set_format(outputdatatype);
 
     if (mipmap && !out->supports("multiimage") && !out->supports("mipmap")) {
-        outstream << "maketx ERROR: \"" << outputfilename
-                  << "\" format does not support multires images\n";
+        errorfmt("\"{} \" format does not support multires images",
+                 outputfilename);
         return false;
     }
 
@@ -664,8 +665,7 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
 
     Timer writetimer;
     if (!out->open(outputfilename.c_str(), outspec)) {
-        outstream << "maketx ERROR: Could not open \"" << outputfilename
-                  << "\" : " << out->geterror() << "\n";
+        errorfmt("Could not open \"{}\" : {}", outputfilename, out->geterror());
         return false;
     }
 
@@ -679,8 +679,7 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
     if (!img->write(out)) {
         // ImageBuf::write transfers any errors from the ImageOutput to
         // the ImageBuf.
-        outstream << "maketx ERROR: Write failed \" : " << img->geterror()
-                  << "\n";
+        errorfmt("Write failed: {}", img->geterror());
         out->close();
         return false;
     }
@@ -765,8 +764,7 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
                     Filter2D* filter = setup_filter(small->spec(), img->spec(),
                                                     filtername);
                     if (!filter) {
-                        outstream << "maketx ERROR: could not make filter \""
-                                  << filtername << "\"\n";
+                        errorfmt("Could not make filter \"{}\"", filtername);
                         return false;
                     }
                     if (verbose) {
@@ -789,8 +787,7 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
                                                               sharpenfilt, 3.0,
                                                               sharpen, 0.0f);
                         if (!uok)
-                            outstream << "maketx ERROR: " << sharp->geterror()
-                                      << "\n";
+                            errorfmt("{}", sharp->geterror());
                         std::swap(img, sharp);
                     }
                     ImageBufAlgo::resize(*small, *img, filter);
@@ -800,8 +797,7 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
                                                               sharpenfilt, 3.0,
                                                               sharpen, 0.0f);
                         if (!uok)
-                            outstream << "maketx ERROR: " << sharp->geterror()
-                                      << "\n";
+                            errorfmt("{}", sharp->geterror());
                         std::swap(small, sharp);
                     }
                     if (do_highlight_compensation) {
@@ -827,16 +823,15 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
                                              ? ImageOutput::AppendMIPLevel
                                              : ImageOutput::AppendSubimage;
             if (!out->open(outputfilename.c_str(), outspec, mode)) {
-                outstream << "maketx ERROR: Could not append \""
-                          << outputfilename << "\" : " << out->geterror()
-                          << "\n";
+                errorfmt("Could not append \"{}\" : {}", outputfilename,
+                         out->geterror());
                 return false;
             }
             if (!small->write(out)) {
                 // ImageBuf::write transfers any errors from the
                 // ImageOutput to the ImageBuf.
-                outstream << "maketx ERROR writing \"" << outputfilename
-                          << "\" : " << small->geterror() << "\n";
+                errorfmt("Error writing \"{}\" : {}", outputfilename,
+                         small->geterror());
                 out->close();
                 return false;
             }
@@ -859,8 +854,7 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
     writetimer.reset();
     writetimer.start();
     if (!out->close()) {
-        outstream << "maketx ERROR writing \"" << outputfilename
-                  << "\" : " << out->geterror() << "\n";
+        errorfmt("Error writing \"{}\" : {}", outputfilename, out->geterror());
         return false;
     }
     stat_writetime += writetimer();
@@ -942,6 +936,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
                   std::string filename, std::string outputfilename,
                   const ImageSpec& _configspec, std::ostream* outstream_ptr)
 {
+    using OIIO::pvt::errorfmt;
     OIIO_ASSERT(mode >= 0 && mode < ImageBufAlgo::_MakeTxLast);
     double stat_readtime         = 0;
     double stat_writetime        = 0;
@@ -978,7 +973,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     bool from_filename = (input == NULL);
 
     if (from_filename && !Filesystem::exists(filename)) {
-        outstream << "maketx ERROR: \"" << filename << "\" does not exist\n";
+        errorfmt("\"{}\" does not exist", filename);
         return false;
     }
 
@@ -1006,7 +1001,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
             else
                 outputfilename = outputfilename + ".tx";
         } else {
-            outstream << "maketx: no output filename supplied\n";
+            errorfmt("no output filename supplied");
             return false;
         }
     }
@@ -1063,13 +1058,12 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
                                           outputfilename);
     auto out = ImageOutput::create(outformat.c_str());
     if (!out) {
-        outstream << "maketx ERROR: Could not find an ImageIO plugin to write "
-                  << outformat << " files:" << geterror() << "\n";
+        errorfmt("Could not find an ImageIO plugin to write {} files: {}",
+                 outformat, geterror());
         return false;
     }
     if (!out->supports("tiles")) {
-        outstream << "maketx ERROR: \"" << outputfilename
-                  << "\" format does not support tiled images\n";
+        errorfmt("\"{}\" format does not support tiled images", outputfilename);
         return false;
     }
 
@@ -1102,8 +1096,8 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
         if (verbose)
             outstream << "Reading file: " << src->name() << std::endl;
         if (!src->read(0, 0, read_local)) {
-            outstream << "maketx ERROR: Could not read \"" << src->name()
-                      << "\" : " << src->geterror() << "\n";
+            errorfmt("Could not read \"{}\" : {}", src->name(),
+                     src->geterror());
             return false;
         }
     }
@@ -1269,9 +1263,9 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     if (shadowmode) {
         // Some special checks for shadow maps
         if (src->spec().nchannels != 1) {
-            outstream << "maketx ERROR: shadow maps require 1-channel images,\n"
-                      << "\t\"" << src->name() << "\" is "
-                      << src->spec().nchannels << " channels\n";
+            errorfmt(
+                "shadow maps require 1-channel images, \"{}\" is {} channels",
+                src->name(), src->spec().nchannels);
             return false;
         }
         // Shadow maps only make sense for floating-point data.
@@ -1413,8 +1407,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     } else if (fixnan == "box3") {
         fixmode = ImageBufAlgo::NONFINITE_BOX3;
     } else {
-        outstream << "maketx ERROR: Unknown --fixnan mode "
-                  << " fixnan\n";
+        errorfmt("Unknown fixnan mode \"{}\"", fixnan);
         return false;
     }
     int pixelsFixed = 0;
@@ -1423,7 +1416,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
             || srcspec.format.basetype == TypeDesc::HALF
             || srcspec.format.basetype == TypeDesc::DOUBLE)
         && !ImageBufAlgo::fixNonFinite(*src, *src, fixmode, &pixelsFixed)) {
-        outstream << "maketx ERROR: Error fixing nans/infs.\n";
+        errorfmt("Error fixing nans/infs.");
         return false;
     }
     if (verbose && pixelsFixed)
@@ -1440,9 +1433,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
                                      std::bind(check_nan_block, std::ref(*src),
                                                _1, std::ref(found_nonfinite)));
         if (found_nonfinite) {
-            if (found_nonfinite > 3)
-                outstream << "maketx ERROR: ...and Nan/Inf at "
-                          << (found_nonfinite - 3) << " other pixels\n";
+            errorfmt("maketx ERROR: Nan/Inf at {} pixels", found_nonfinite);
             return false;
         }
     }
@@ -1480,16 +1471,15 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
 
         ColorConfig colorconfig(colorconfigname);
         if (colorconfig.error()) {
-            outstream << "Error Creating ColorConfig\n";
-            outstream << colorconfig.geterror() << std::endl;
+            errorfmt("Error Creating ColorConfig: {}", colorconfig.geterror());
             return false;
         }
 
         ColorProcessorHandle processor
             = colorconfig.createColorProcessor(incolorspace, outcolorspace);
         if (!processor || colorconfig.error()) {
-            outstream << "Error Creating Color Processor." << std::endl;
-            outstream << colorconfig.geterror() << std::endl;
+            errorfmt("Error Creating Color Processor: {}",
+                     colorconfig.geterror());
             return false;
         }
 
@@ -1499,7 +1489,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
 
         if (!ImageBufAlgo::colorconvert(*ccSrc, *src, processor.get(),
                                         unpremult)) {
-            outstream << "Error applying color conversion to image.\n";
+            errorfmt("Error applying color conversion to image.");
             return false;
         }
 
@@ -1509,8 +1499,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
             if (!ImageBufAlgo::colorconvert(
                     &constantColor[0], static_cast<int>(constantColor.size()),
                     processor.get(), unpremult)) {
-                outstream
-                    << "Error applying color conversion to constant color.\n";
+                errorfmt("Error applying color conversion to constant color.");
                 return false;
             }
         }
@@ -1522,8 +1511,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
                                             static_cast<int>(
                                                 pixel_stats.avg.size()),
                                             processor.get(), unpremult)) {
-                outstream
-                    << "Error applying color conversion to average color.\n";
+                errorfmt("Error applying color conversion to average color.");
                 return false;
             }
         }
@@ -1567,10 +1555,10 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
         do_resize = true;
 
     if (orig_was_overscan && out && !out->supports("displaywindow")) {
-        outstream << Strutil::sprintf(
-            "maketx ERROR: format \"%s\" does not support separate display "
+        errorfmt(
+            "Format \"{}\" does not support separate display "
             "windows, which is necessary for textures with overscan. OpenEXR "
-            " is a format that allows overscan textures.\n",
+            "is a format that allows overscan textures.",
             out->format_name());
         return false;
     }
@@ -1608,8 +1596,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
             Filter2D* filter = setup_filter(toplevel->spec(), src->spec(),
                                             resize_filter);
             if (!filter) {
-                outstream << "maketx ERROR: could not make filter \""
-                          << resize_filter << "\"\n";
+                errorfmt("Could not make filter \"{}\"", resize_filter);
                 return false;
             }
             ImageBufAlgo::resize(*toplevel, *src, filter);
@@ -1742,7 +1729,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
         std::string err;
         ok = Filesystem::rename(tmpfilename, outputfilename, err);
         if (!ok)
-            outstream << "maketx ERROR: could not rename file: " << err << "\n";
+            errorfmt("Could not rename file: {}", err);
     }
     if (!ok)
         Filesystem::remove(tmpfilename);
@@ -1786,8 +1773,13 @@ ImageBufAlgo::make_texture(ImageBufAlgo::MakeTextureMode mode,
                            const ImageSpec& configspec, std::ostream* outstream)
 {
     pvt::LoggedTimer logtime("IBA::make_texture");
-    return make_texture_impl(mode, NULL, filename, outputfilename, configspec,
-                             outstream);
+    bool ok = make_texture_impl(mode, NULL, filename, outputfilename,
+                                configspec, outstream);
+    if (!ok && outstream && OIIO::has_error()) {
+        // also send errors to the stream
+        *outstream << "make_texture ERROR: " << OIIO::geterror(false) << "\n";
+    }
+    return ok;
 }
 
 
@@ -1796,12 +1788,16 @@ bool
 ImageBufAlgo::make_texture(ImageBufAlgo::MakeTextureMode mode,
                            const std::vector<std::string>& filenames,
                            string_view outputfilename,
-                           const ImageSpec& configspec,
-                           std::ostream* outstream_ptr)
+                           const ImageSpec& configspec, std::ostream* outstream)
 {
     pvt::LoggedTimer logtime("IBA::make_texture");
-    return make_texture_impl(mode, NULL, filenames[0], outputfilename,
-                             configspec, outstream_ptr);
+    bool ok = make_texture_impl(mode, NULL, filenames[0], outputfilename,
+                                configspec, outstream);
+    if (!ok && outstream && OIIO::has_error()) {
+        // also send errors to the stream
+        *outstream << "make_texture ERROR: " << OIIO::geterror(false) << "\n";
+    }
+    return ok;
 }
 
 
@@ -1812,6 +1808,11 @@ ImageBufAlgo::make_texture(ImageBufAlgo::MakeTextureMode mode,
                            const ImageSpec& configspec, std::ostream* outstream)
 {
     pvt::LoggedTimer logtime("IBA::make_texture");
-    return make_texture_impl(mode, &input, "", outputfilename, configspec,
-                             outstream);
+    bool ok = make_texture_impl(mode, &input, "", outputfilename, configspec,
+                                outstream);
+    if (!ok && outstream && OIIO::has_error()) {
+        // also send errors to the stream
+        *outstream << "make_texture ERROR: " << OIIO::geterror(false) << "\n";
+    }
+    return ok;
 }

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -507,6 +507,8 @@ main(int argc, char* argv[])
 
     bool ok = ImageBufAlgo::make_texture(mode, filenames[0], outputfilename,
                                          configspec, &std::cout);
+    if (!ok)
+        std::cout << OIIO::geterror() << "\n";
     if (runstats)
         std::cout << "\n" << ic->getstats();
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4874,7 +4874,8 @@ output_file(int /*argc*/, const char* argv[])
         ok = ImageBufAlgo::make_texture(mode, (*ir)(0, 0), filename, configspec,
                                         &std::cout);
         if (!ok)
-            ot.errorf(command, "Could not make texture");
+            ot.errorfmt(command, "Could not make texture: {}",
+                        OIIO::geterror());
         // N.B. make_texture already internally writes to a temp file and
         // then atomically moves it to the final destination, so we don't
         // need to explicitly do that here.


### PR DESCRIPTION
There was no formal error setting! Errors were echoed to the optional
output stream, if supplied. But that's not good enough.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
