### PR TITLE
Add support for saving progressive jpegs

### DIFF
--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -186,8 +186,7 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
         DBG std::cout << "out open: set_colorspace\n";
 
         // Save as a progressive jpeg if requested by the user
-        ParamValue* progressive = m_spec.find_attribute("jpeg:progressive", TypeDesc::INT);
-        if (progressive && *(int*)progressive->data() != 0) {
+        if (m_spec.get_int_attribute("jpeg:progressive")) {
             jpeg_simple_progression(&m_cinfo);
         }
 

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -185,6 +185,12 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
         }
         DBG std::cout << "out open: set_colorspace\n";
 
+        // Save as a progressive jpeg if requested by the user
+        ParamValue* progressive = m_spec.find_attribute("jpeg:progressive", TypeDesc::INT);
+        if (progressive && *(int*)progressive->data() != 0) {
+            jpeg_simple_progression(&m_cinfo);
+        }
+
         jpeg_start_compress(&m_cinfo, TRUE);  // start working
         DBG std::cout << "out open: start_compress\n";
     }


### PR DESCRIPTION
## Description

Allows saving progressive jpegs by adding the attribute "jpeg:progressive", an int which if non-zero will tell libjpeg to create a progressive file. 

## Tests

TODO


## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

