### PR TITLE
Fix thread safety in ImageInput error reporting

### DIFF
--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -126,7 +126,7 @@ bool
 BmpInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/cineon.imageio/cineoninput.cpp
+++ b/src/cineon.imageio/cineoninput.cpp
@@ -369,7 +369,7 @@ bool
 CineonInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                   void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -31,12 +31,12 @@ public:
     virtual bool close() override;
     virtual int current_subimage(void) const override
     {
-        lock_guard lock(m_mutex);
+        lock_guard lock(*this);
         return m_subimage;
     }
     virtual int current_miplevel(void) const override
     {
-        lock_guard lock(m_mutex);
+        lock_guard lock(*this);
         return m_miplevel;
     }
     virtual bool seek_subimage(int subimage, int miplevel) override;
@@ -623,7 +623,7 @@ bool
 DDSInput::read_native_scanline(int subimage, int miplevel, int y, int z,
                                void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 
@@ -644,7 +644,7 @@ bool
 DDSInput::read_native_tile(int subimage, int miplevel, int x, int y, int z,
                            void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/dicom.imageio/dicominput.cpp
+++ b/src/dicom.imageio/dicominput.cpp
@@ -326,7 +326,7 @@ bool
 DICOMInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                  void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
     if (y < 0 || y >= m_spec.height)  // out of range scanline

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -607,7 +607,7 @@ bool
 DPXInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
                                 int yend, int /*z*/, void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -128,7 +128,7 @@ public:
     virtual bool close(void) override;
     virtual int current_subimage(void) const override
     {
-        lock_guard lock(m_mutex);
+        lock_guard lock(*this);
         return m_subimage;
     }
     virtual bool seek_subimage(int subimage, int miplevel) override;
@@ -572,7 +572,7 @@ bool
 FFmpegInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                   void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
     if (!m_read_frame) {

--- a/src/field3d.imageio/field3dinput.cpp
+++ b/src/field3d.imageio/field3dinput.cpp
@@ -42,7 +42,7 @@ public:
     virtual bool close() override;
     virtual int current_subimage(void) const override
     {
-        lock_guard lock(m_mutex);
+        lock_guard lock(*this);
         return m_subimage;
     }
     virtual bool seek_subimage(int subimage, int miplevel) override;

--- a/src/fits.imageio/fitsinput.cpp
+++ b/src/fits.imageio/fitsinput.cpp
@@ -96,7 +96,7 @@ bool
 FitsInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                 void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/gif.imageio/gifinput.cpp
+++ b/src/gif.imageio/gifinput.cpp
@@ -43,7 +43,7 @@ public:
 
     virtual int current_subimage(void) const override
     {
-        lock_guard lock(m_mutex);
+        lock_guard lock(*this);
         return m_subimage;
     }
     virtual int current_miplevel(void) const override
@@ -164,7 +164,7 @@ bool
 GIFInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -165,7 +165,7 @@ bool
 HdrInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/heif.imageio/heifinput.cpp
+++ b/src/heif.imageio/heifinput.cpp
@@ -238,7 +238,7 @@ bool
 HeifInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                 void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
     if (y < 0 || y >= m_spec.height)  // out of range scanline

--- a/src/ico.imageio/icoinput.cpp
+++ b/src/ico.imageio/icoinput.cpp
@@ -29,7 +29,7 @@ public:
     virtual bool close() override;
     virtual int current_subimage(void) const override
     {
-        lock_guard lock(m_mutex);
+        lock_guard lock(*this);
         return m_subimage;
     }
     virtual bool seek_subimage(int subimage, int miplevel) override;
@@ -421,7 +421,7 @@ bool
 ICOInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/iff.imageio/iffinput.cpp
+++ b/src/iff.imageio/iffinput.cpp
@@ -141,7 +141,7 @@ bool
 IffInput::read_native_tile(int subimage, int miplevel, int x, int y, int /*z*/,
                            void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/include/OpenImageIO/oiioversion.h.in
+++ b/src/include/OpenImageIO/oiioversion.h.in
@@ -123,8 +123,10 @@ namespace @PROJ_NAME@ = @PROJ_NAMESPACE_V@;
 ///     to return unique_ptr. (OIIO 2.0)
 /// Version 23 added set_ioproxy() methods to ImageInput & ImageOutput
 ///     (OIIO 2.2).
+/// Version 24 Added a PIMPL pointers to ImageInput and ImageOutput and
+///     removed some unnecessary fields that were exposed.
 
-#define OIIO_PLUGIN_VERSION 23
+#define OIIO_PLUGIN_VERSION 24
 
 #define OIIO_PLUGIN_NAMESPACE_BEGIN OIIO_NAMESPACE_BEGIN
 #define OIIO_PLUGIN_NAMESPACE_END OIIO_NAMESPACE_END

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -305,7 +305,7 @@ bool
 Jpeg2000Input::read_native_scanline(int subimage, int miplevel, int y, int z,
                                     void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -538,7 +538,7 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
     if (initialized)
         return ok;
 
-    ImageInput::lock_guard lock(in->m_mutex);
+    ImageInput::lock_guard lock(*in);
     OIIO_DASSERT(header);
     spec = ImageSpec();
 
@@ -1224,7 +1224,7 @@ OpenEXRInput::spec(int subimage, int miplevel)
     if (!part.initialized) {
         // Only if this subimage hasn't yet been inventoried do we need
         // to lock and seek.
-        lock_guard lock(m_mutex);
+        lock_guard lock(*this);
         if (!part.initialized) {
             if (!seek_subimage(subimage, miplevel))
                 return ret;
@@ -1249,7 +1249,7 @@ OpenEXRInput::spec_dimensions(int subimage, int miplevel)
     if (!part.initialized) {
         // Only if this subimage hasn't yet been inventoried do we need
         // to lock and seek.
-        lock_guard lock(m_mutex);
+        lock_guard lock(*this);
         if (!seek_subimage(subimage, miplevel))
             return ret;
     }
@@ -1304,7 +1304,7 @@ OpenEXRInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
                                     int yend, int /*z*/, int chbegin, int chend,
                                     void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
     chend = clamp(chend, chbegin + 1, m_spec.nchannels);
@@ -1362,7 +1362,7 @@ bool
 OpenEXRInput::read_native_tile(int subimage, int miplevel, int x, int y, int z,
                                void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
     return read_native_tiles(subimage, miplevel, x, x + m_spec.tile_width, y,
@@ -1377,7 +1377,7 @@ OpenEXRInput::read_native_tiles(int subimage, int miplevel, int xbegin,
                                 int xend, int ybegin, int yend, int zbegin,
                                 int zend, void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
     return read_native_tiles(subimage, miplevel, xbegin, xend, ybegin, yend,
@@ -1391,7 +1391,7 @@ OpenEXRInput::read_native_tiles(int subimage, int miplevel, int xbegin,
                                 int xend, int ybegin, int yend, int zbegin,
                                 int zend, int chbegin, int chend, void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
     chend = clamp(chend, chbegin + 1, m_spec.nchannels);
@@ -1569,7 +1569,7 @@ OpenEXRInput::read_native_deep_scanlines(int subimage, int miplevel, int ybegin,
                                          int yend, int /*z*/, int chbegin,
                                          int chend, DeepData& deepdata)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
     if (m_deep_scanline_input_part == NULL) {
@@ -1641,7 +1641,7 @@ OpenEXRInput::read_native_deep_tiles(int subimage, int miplevel, int xbegin,
                                      int /*zbegin*/, int /*zend*/, int chbegin,
                                      int chend, DeepData& deepdata)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
     if (m_deep_tiled_input_part == NULL) {

--- a/src/openvdb.imageio/openvdbinput.cpp
+++ b/src/openvdb.imageio/openvdbinput.cpp
@@ -61,7 +61,6 @@ class OpenVDBInput final : public ImageInput {
         m_nsubimages = 0;
     }
 
-    mutex& vdbMutex() { return m_mutex; }
     void readMetaData(const openvdb::GridBase& grid, const layerrecord& layer,
                       ImageSpec& spec);
 
@@ -138,7 +137,7 @@ OpenVDBInput::spec_dimensions(int subimage, int miplevel)
 int
 OpenVDBInput::current_subimage(void) const
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     return m_subimage;
 }
 
@@ -147,7 +146,7 @@ OpenVDBInput::current_subimage(void) const
 bool
 OpenVDBInput::seek_subimage(int subimage, int miplevel)
 {
-    lock_guard lock(vdbMutex());
+    lock_guard lock(*this);
     return seek_subimage_nolock(subimage, miplevel);
 }
 
@@ -559,7 +558,7 @@ bool
 OpenVDBInput::read_native_tile(int subimage, int miplevel, int x, int y, int z,
                                void* data)
 {
-    lock_guard lock(vdbMutex());
+    lock_guard lock(*this);
     if (!seek_subimage_nolock(subimage, miplevel))
         return false;
 

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -29,7 +29,7 @@ public:
     virtual bool close() override;
     virtual int current_subimage(void) const override
     {
-        lock_guard lock(m_mutex);
+        lock_guard lock(*this);
         return m_subimage;
     }
     virtual bool read_native_scanline(int subimage, int miplevel, int y, int z,
@@ -270,7 +270,7 @@ bool
 PNGInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -453,7 +453,7 @@ bool
 PNMInput::read_native_scanline(int subimage, int miplevel, int y, int z,
                                void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -713,7 +713,7 @@ bool
 PSDInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/ptex.imageio/ptexinput.cpp
+++ b/src/ptex.imageio/ptexinput.cpp
@@ -30,12 +30,12 @@ public:
     virtual bool close() override;
     virtual int current_subimage(void) const override
     {
-        lock_guard lock(m_mutex);
+        lock_guard lock(*this);
         return m_subimage;
     }
     virtual int current_miplevel(void) const override
     {
-        lock_guard lock(m_mutex);
+        lock_guard lock(*this);
         return m_miplevel;
     }
     virtual bool seek_subimage(int subimage, int miplevel) override;
@@ -266,7 +266,7 @@ bool
 PtexInput::read_native_tile(int subimage, int miplevel, int x, int y, int /*z*/,
                             void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -1239,7 +1239,7 @@ bool
 RawInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -27,7 +27,7 @@ public:
     virtual bool open(const std::string& name, ImageSpec& newspec) override;
     virtual int current_subimage(void) const override
     {
-        lock_guard lock(m_mutex);
+        lock_guard lock(*this);
         return m_subimage;
     }
     virtual bool seek_subimage(int subimage, int miplevel) override;
@@ -628,7 +628,7 @@ bool
 RLAInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/sgi.imageio/sgiinput.cpp
+++ b/src/sgi.imageio/sgiinput.cpp
@@ -118,7 +118,7 @@ bool
 SgiInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/socket.imageio/socketinput.cpp
+++ b/src/socket.imageio/socketinput.cpp
@@ -91,7 +91,7 @@ bool
 SocketInput::read_native_scanline(int subimage, int miplevel, int /*y*/,
                                   int /*z*/, void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
     try {
@@ -114,7 +114,7 @@ bool
 SocketInput::read_native_tile(int subimage, int miplevel, int /*x*/, int /*y*/,
                               int /*z*/, void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
     try {

--- a/src/softimage.imageio/softimageinput.cpp
+++ b/src/softimage.imageio/softimageinput.cpp
@@ -154,7 +154,7 @@ bool
 SoftimageInput::read_native_scanline(int subimage, int miplevel, int y,
                                      int /*z*/, void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -775,7 +775,7 @@ bool
 TGAInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -1337,7 +1337,7 @@ public:
     virtual bool read_native_tile(int subimage, int miplevel, int xbegin,
                                   int ybegin, int zbegin, void* data) final
     {
-        lock_guard lock(m_mutex);
+        lock_guard lock(*this);
         if (!seek_subimage(subimage, miplevel))
             return false;
         float* tile = (float*)data;

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -86,13 +86,13 @@ public:
     virtual int current_subimage(void) const override
     {
         // If m_emulate_mipmap is true, pretend subimages are mipmap levels
-        lock_guard lock(m_mutex);
+        lock_guard lock(*this);
         return m_emulate_mipmap ? 0 : m_subimage;
     }
     virtual int current_miplevel(void) const override
     {
         // If m_emulate_mipmap is true, pretend subimages are mipmap levels
-        lock_guard lock(m_mutex);
+        lock_guard lock(*this);
         return m_emulate_mipmap ? m_subimage : 0;
     }
     virtual bool seek_subimage(int subimage, int miplevel) override;
@@ -742,7 +742,7 @@ TIFFInput::spec(int subimage, int miplevel)
         s = miplevel;
     }
 
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (s >= 0 && s < int(m_subimage_specs.size())
         && !m_subimage_specs[s].undefined()) {
         // If we've cached this spec, we don't need to seek and read
@@ -774,7 +774,7 @@ TIFFInput::spec_dimensions(int subimage, int miplevel)
         s = miplevel;
     }
 
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (s >= 0 && s < int(m_subimage_specs.size())
         && !m_subimage_specs[s].undefined()) {
         // If we've cached this spec, we don't need to seek and read
@@ -1448,7 +1448,7 @@ bool
 TIFFInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                 void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
     y -= m_spec.y;
@@ -1637,7 +1637,7 @@ TIFFInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
     // parallelize by reading raw (compressed) strips then making calls to
     // zlib ourselves to decompress. Don't bother trying to handle any of
     // the uncommon cases with strips. This covers most real-world cases.
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
     yend        = std::min(yend, spec().y + spec().height);
@@ -1809,7 +1809,7 @@ bool
 TIFFInput::read_native_tile(int subimage, int miplevel, int x, int y, int z,
                             void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
     x -= m_spec.x;
@@ -1908,7 +1908,7 @@ TIFFInput::read_native_tiles(int subimage, int miplevel, int xbegin, int xend,
                              int ybegin, int yend, int zbegin, int zend,
                              void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
     if (!m_spec.valid_tile_range(xbegin, xend, ybegin, yend, zbegin, zend))
@@ -2033,7 +2033,7 @@ TIFFInput::read_scanline(int y, int z, TypeDesc format, void* data,
         // conversions. That's why we do it here, rather than in
         // read_native_blah.
         {
-            lock_guard lock(m_mutex);
+            lock_guard lock(*this);
             if (format
                 == TypeUnknown)  // unknown means retrieve the native type
                 format = m_spec.format;
@@ -2065,7 +2065,7 @@ TIFFInput::read_scanlines(int subimage, int miplevel, int ybegin, int yend,
         // read_native_blah.
         int nchannels, alpha_channel, z_channel, width;
         {
-            lock_guard lock(m_mutex);
+            lock_guard lock(*this);
             seek_subimage(subimage, miplevel);
             nchannels     = m_spec.nchannels;
             alpha_channel = m_spec.alpha_channel;
@@ -2103,7 +2103,7 @@ TIFFInput::read_tile(int x, int y, int z, TypeDesc format, void* data,
         // conversions. That's why we do it here, rather than in
         // read_native_blah.
         {
-            lock_guard lock(m_mutex);
+            lock_guard lock(*this);
             if (format
                 == TypeUnknown)  // unknown means retrieve the native type
                 format = m_spec.format;
@@ -2136,7 +2136,7 @@ TIFFInput::read_tiles(int subimage, int miplevel, int xbegin, int xend,
         // read_native_blah.
         int nchannels, alpha_channel, z_channel;
         {
-            lock_guard lock(m_mutex);
+            lock_guard lock(*this);
             seek_subimage(subimage, miplevel);
             nchannels     = m_spec.nchannels;
             alpha_channel = m_spec.alpha_channel;

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -208,7 +208,7 @@ WebpInput::open(const std::string& name, ImageSpec& spec)
 bool
 WebpInput::seek_subimage(int subimage, int miplevel)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (miplevel != 0 || subimage < 0)
         return false;
 
@@ -339,7 +339,7 @@ bool
 WebpInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                 void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!read_subimage(subimage, true))
         return false;
     if (y < 0 || y >= m_spec.height)  // out of range scanline

--- a/src/zfile.imageio/zfile.cpp
+++ b/src/zfile.imageio/zfile.cpp
@@ -223,7 +223,7 @@ bool
 ZfileInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                  void* data)
 {
-    lock_guard lock(m_mutex);
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
 

--- a/testsuite/python-imagespec/ref/out-python3.txt
+++ b/testsuite/python-imagespec/ref/out-python3.txt
@@ -113,7 +113,7 @@ extra_attribs size is 9
 99.5
 
 seralize(xml):
-<ImageSpec version="23">
+<ImageSpec version="24">
 <x>1</x>
 <y>2</y>
 <z>3</z>

--- a/testsuite/python-imagespec/ref/out.txt
+++ b/testsuite/python-imagespec/ref/out.txt
@@ -113,7 +113,7 @@ extra_attribs size is 9
 99.5
 
 seralize(xml):
-<ImageSpec version="23">
+<ImageSpec version="24">
 <x>1</x>
 <y>2</y>
 <z>3</z>


### PR DESCRIPTION
Although we were careful to make sure that the new versions of
ImageInput `read_scanlines`/`read_tiles`/`read_image` methods were
thread-safe when called concurrently, one thing that slipped through
the cracks was error reporting. A failed read (or other) call would
return an error flag and use error() to set the error message, which
could be retrieved via geterror()/has_error().

Except the flaw was that the error itself was a single std::string in
the class. It was guarded by a mutex, so at least the threads wouldn't
clobber each other over access to the string. But it means that the
following call sequence would do the wrong thing:

    thread 1:   read_tile A  --> fails
    thread 2:   read_tile B  --> fails
    thread 1:   geterror()   --> gets both errors appended, oops!
    thread 2:   geterror()   --> gets an empty error message, oops!

Why hadn't we noticed until now? Because read failures of individual
scanlines or tiles are rare -- usually the failure or discovery of a
missing or corrupt file is in open().  So I guess it's not often that two
concurrent reads would both have just the right timing to have the
error retrieval problem described above.

There is no easy fix, so a bit of a bigger, ABI-breaking, change was
necessary to make this work properly once and for all:

* ImageInput and ImageOutput error messages are now thread-specific. That
  is, geterror() retrieves errors generated by method calls made by the
  same thread.

* ImageInput and ImgageOutput now use a PIMPL idiom to store some data
  behind an opaque pointer. This is good -- it means that the details
  are hidden from the public API, and can use classes we don't wish to
  expose (which we will do here with boost::thread_specific_pointer) as
  well as allow us to change what's behind the pointer without breaking
  the ABI.

* The error message uses a thread_specific_pointer.

* We therefore removed the m_errormessage member that was unfortunately
  in the public class. Also removed the mutex and the m_threads, which
  can now be safely tucked behind the PIMPL.

* With the mutex hidden from view, we now re-jigger references to it
  to use the lock/unlock methods we had already. In fact, instead of
  using lock_guard<mutex>, we can use lock_guard<ImageInput> because
  the presence of lock/unlock methods make ImageInput (and ImageOutput)
  themselves compliant with the BasicLockable concept.

Note that this changes the data layout of ImageInput and ImageOutput,
and therefore is an ABI break. So this is a change meant for master
only (future OIIO 2.3+), and will not be backported to the 2.2 release
branch.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
