### PR TITLE
CI: Simplify install_homebrew_deps.bash for modes we don't use

### DIFF
--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -22,42 +22,21 @@ echo ""
 echo "Before my brew installs:"
 brew list --versions
 
-if [[ "$BUILDTARGET" == "clang-format" ]] ; then
-    # If we are running for the sake of clang-format only, just install the
-    # bare minimum packages and return.
-    brew install --display-times ilmbase openexr llvm clang-format libtiff libpng boost ninja giflib
-    brew install --display-times python pybind11 && true
-    brew upgrade --display-times python && true
-    brew link --overwrite python
-    brew upgrade --display-times cmake && true
-else
-    # All cases except for clang-format target, we need the dependencies.
-    brew install --display-times gcc ccache cmake ninja boost && true
-    brew link --overwrite gcc
-    brew install --display-times python && true
-    brew upgrade --display-times python && true
-    brew link --overwrite python
-    brew upgrade --display-times cmake && true
-    brew install --display-times libtiff ilmbase openexr opencolorio
-    brew install --display-times libpng giflib webp jpeg-turbo openjpeg
-    brew install --display-times freetype libraw dcmtk pybind11 numpy && true
-    brew install --display-times ffmpeg libheif libsquish ptex && true
-    brew install --display-times openvdb tbb && true
-    brew install --display-times opencv && true
-    brew install --display-times qt
-    brew install --display-times field3d && true
-fi
-
-if [[ "$LINKSTATIC" == "1" ]] ; then
-    brew install --display-times little-cms2 tinyxml szip
-    brew install --display-times homebrew/dupes/bzip2
-    brew install --display-times yaml-cpp --with-static-lib
-fi
-if [[ "$CLANG_TIDY" != "" ]] ; then
-    # If we are running for the sake of clang-tidy only, we will need
-    # a modern clang version not just the xcode one.
-    brew install --display-times llvm
-fi
+# All cases except for clang-format target, we need the dependencies.
+brew install --display-times gcc ccache cmake ninja boost && true
+brew link --overwrite gcc
+brew install --display-times python && true
+brew upgrade --display-times python && true
+brew link --overwrite python
+brew upgrade --display-times cmake && true
+brew install --display-times libtiff ilmbase openexr opencolorio
+brew install --display-times libpng giflib webp jpeg-turbo openjpeg
+brew install --display-times freetype libraw dcmtk pybind11 numpy && true
+brew install --display-times ffmpeg libheif libsquish ptex && true
+brew install --display-times openvdb tbb && true
+brew install --display-times opencv && true
+brew install --display-times qt
+brew install --display-times field3d && true
 
 echo ""
 echo "After brew installs:"


### PR DESCRIPTION
Now that we use Linux and the ASWF docker containers for the
"clang-format" test, there's no reason to have logic in this setup
script for Mac to choose a more restrictive set of package for that
case.

Same for clang-tidy and static libs tests -- we don't do these tests, and
if we add one, we will surely do it with one of the Linux containers.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
