### PR TITLE
Docs: illustrate reading image data into separate per-channel buffers

### DIFF
--- a/src/doc/imageinput.rst
+++ b/src/doc/imageinput.rst
@@ -299,6 +299,37 @@ Please consult Section :ref:`ImageInput Class Reference` for detailed
 descriptions of the stride parameters to each ``read`` function.
 
 
+Reading channels to separate buffers
+------------------------------------
+
+While specifying data strides allows writing entire pixels to buffers with
+arbitrary layouts, it is not possible to separate those pixels into multiple
+buffers (i.e. to write image data to a separate or planar memory layout:
+RRRRGGGGBBBB instead of the interleaved RGBRGBRGBRGB).
+
+A workaround for this is to call ``read_scanlines``, ``read_tiles`` or
+``read_image`` repeatedly with arguments ``chbegin`` and ``chend`` of
+``0 <= chbegin < spec.nchannels`` and ``chend == chbegin + 1``::
+
+    // one buffer for all three channels
+    unsigned char pixels[spec.width * spec.height * spec.nchannels];
+
+    for (int channel = 0; channel < spec.nchannels; ++channel) {
+        file->read_image(
+            // reading one channel at a time
+            channel, channel + 1,
+            TypeDesc::UINT8,
+            // writing the data to offsets spaced `spec.width * spec.height`
+            // apart
+            &pixels[spec.width * spec.height * channel]);
+    }
+
+For many formats, this is nearly as fast as reading the image with
+interleaved pixel data if the format stores the pixels in an interleaved
+layout and even slightly faster if the pixels are stored in separate planes
+in the file.
+
+
 Reading metadata
 --------------------------------
 

--- a/src/doc/imageinput.tex
+++ b/src/doc/imageinput.tex
@@ -318,6 +318,39 @@ Please consult Section~\ref{sec:imageinput:reference} for detailed
 descriptions of the stride parameters to each {\cf read} function.
 
 
+\subsection{Reading channels to separate buffers}
+\label{sec:imageinput:separate}
+
+While specifying data strides allows writing entire pixels to buffers with
+arbitrary layouts, it is not possible to separate those pixels into multiple
+buffers (i.e. to write image data to a separate or planar memory layout:
+RRRRGGGGBBBB instead of the interleaved RGBRGBRGBRGB).
+
+A workaround for this is to call {\cf read_scanlines}, {\cf read_tiles} or
+{\cf read_image} repeatedly with arguments {\cf chbegin} and {\cf chend} of
+{\cf 0 <= chbegin < spec.nchannels} and {\cf chend == chbegin + 1}:
+
+\begin{code}
+  // one buffer for all three channels
+  unsigned char pixels[spec.width * spec.height * spec.nchannels];
+
+  for (int channel = 0; channel < spec.nchannels; ++channel) {
+      file->read_image(
+          // reading one channel at a time
+          channel, channel + 1,
+          TypeDesc::UINT8,
+          // writing the data to offsets spaced `spec.width * spec.height`
+          // apart
+          &pixels[spec.width * spec.height * channel]);
+  }
+\end{code}
+
+For many formats, this is nearly as fast as reading the image with
+interleaved pixel data if the format stores the pixels in an interleaved
+layout and even slightly faster if the pixels are stored in separate planes
+in the file.
+
+
 \subsection{Reading metadata}
 \label{sec:imageinput:metadata}
 


### PR DESCRIPTION
Related to #2744


## Description

The discussion around #2744 came to the conclusion that the status quo already allows relatively efficient reading of data into separate per-channel buffers. This PR adds a section to the docs to make this approach more discoverable.

## Tests

I didn't add a test, but since adding this to the docs makes this kind of use of the API "official" I maybe should...?

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

