### PR TITLE
Improvements to docs and breathe setup

### DIFF
--- a/src/doc/imagebuf.rst
+++ b/src/doc/imagebuf.rst
@@ -42,37 +42,37 @@ Making an empty or uninitialized ImageBuf
 Constructing a readable ImageBuf
 --------------------------------
 
-.. doxygenfunction:: OIIO::ImageBuf::ImageBuf(string_view, int, int, ImageCache*, const ImageSpec*, Filesystem::IOProxy*)
-.. doxygenfunction:: OIIO::ImageBuf::reset(string_view, int, int, ImageCache*, const ImageSpec*, Filesystem::IOProxy*)
+.. doxygenfunction:: OIIO::ImageBuf::ImageBuf(string_view name, int subimage = 0, int miplevel = 0, ImageCache *imagecache = nullptr, const ImageSpec *config = nullptr, Filesystem::IOProxy *ioproxy = nullptr)
+.. doxygenfunction:: OIIO::ImageBuf::reset(string_view name, int subimage = 0, int miplevel = 0, ImageCache *imagecache = nullptr, const ImageSpec *config = nullptr, Filesystem::IOProxy *ioproxy = nullptr)
 
 
 Constructing a writable ImageBuf
 --------------------------------------------------
 
-.. doxygenfunction:: OIIO::ImageBuf::ImageBuf(const ImageSpec&, InitializePixels)
-.. doxygenfunction:: OIIO::ImageBuf::reset(const ImageSpec&, InitializePixels)
+.. doxygenfunction:: OIIO::ImageBuf::ImageBuf(const ImageSpec &spec, InitializePixels zero = InitializePixels::Yes)
+.. doxygenfunction:: OIIO::ImageBuf::reset(const ImageSpec &spec, InitializePixels zero = InitializePixels::Yes)
 .. doxygenfunction:: OIIO::ImageBuf::make_writable
 
 
 Constructing an ImageBuf that "wraps" an application buffer
 -------------------------------------------------------------
 
-.. doxygenfunction:: OIIO::ImageBuf::ImageBuf(const ImageSpec&, void*)
-.. doxygenfunction:: OIIO::ImageBuf::reset(const ImageSpec&, void*)
+.. doxygenfunction:: OIIO::ImageBuf::ImageBuf(const ImageSpec &spec, void *buffer)
+.. doxygenfunction:: OIIO::ImageBuf::reset(const ImageSpec &spec, void *buffer)
 
 
 
 Reading and Writing disk images
 -------------------------------
 
-.. doxygenfunction:: OIIO::ImageBuf::read(int, int, bool, TypeDesc, ProgressCallback, void*)
-.. doxygenfunction:: OIIO::ImageBuf::read(int, int, int, int, bool, TypeDesc, ProgressCallback, void*)
+.. doxygenfunction:: OIIO::ImageBuf::read(int subimage = 0, int miplevel = 0, bool force = false, TypeDesc convert = TypeDesc::UNKNOWN, ProgressCallback progress_callback = nullptr, void *progress_callback_data = nullptr)
+.. doxygenfunction:: OIIO::ImageBuf::read(int subimage, int miplevel, int chbegin, int chend, bool force, TypeDesc convert, ProgressCallback progress_callback = nullptr, void *progress_callback_data = nullptr)
 .. doxygenfunction:: OIIO::ImageBuf::init_spec
 
-.. doxygenfunction:: OIIO::ImageBuf::write(string_view, TypeDesc, string_view, ProgressCallback, void*) const
-.. doxygenfunction:: OIIO::ImageBuf::write(ImageOutput*, ProgressCallback, void*) const
-.. doxygenfunction:: OIIO::ImageBuf::set_write_format(TypeDesc)
-.. doxygenfunction:: OIIO::ImageBuf::set_write_format(cspan<TypeDesc>)
+.. doxygenfunction:: OIIO::ImageBuf::write(string_view filename, TypeDesc dtype = TypeUnknown, string_view fileformat = string_view(), ProgressCallback progress_callback = nullptr, void *progress_callback_data = nullptr) const
+.. doxygenfunction:: OIIO::ImageBuf::write(ImageOutput *out, ProgressCallback progress_callback = nullptr, void *progress_callback_data = nullptr) const
+.. doxygenfunction:: OIIO::ImageBuf::set_write_format(TypeDesc format)
+.. doxygenfunction:: OIIO::ImageBuf::set_write_format(cspan<TypeDesc> format)
 .. doxygenfunction:: OIIO::ImageBuf::set_write_tiles
 .. doxygenfunction:: OIIO::ImageBuf::set_write_ioproxy
 
@@ -133,17 +133,17 @@ Getting and setting information about an ImageBuf
 .. doxygenfunction:: OIIO::ImageBuf::contains_roi
 .. doxygenfunction:: OIIO::ImageBuf::pixeltype
 .. doxygenfunction:: OIIO::ImageBuf::threads() const
-.. doxygenfunction:: OIIO::ImageBuf::threads(int) const
+.. doxygenfunction:: OIIO::ImageBuf::threads(int n) const
 
 
 
 Copying ImageBuf's and blocks of pixels
 ========================================
 
-.. doxygenfunction:: OIIO::ImageBuf::operator=(const ImageBuf&)
-.. doxygenfunction:: OIIO::ImageBuf::operator=(ImageBuf&&)
-.. doxygenfunction:: OIIO::ImageBuf::copy(const ImageBuf&, TypeDesc)
-.. doxygenfunction:: OIIO::ImageBuf::copy(TypeDesc) const
+.. doxygenfunction:: OIIO::ImageBuf::operator=(const ImageBuf &src)
+.. doxygenfunction:: OIIO::ImageBuf::operator=(ImageBuf &&src)
+.. doxygenfunction:: OIIO::ImageBuf::copy(const ImageBuf &src, TypeDesc format = TypeUnknown)
+.. doxygenfunction:: OIIO::ImageBuf::copy(TypeDesc format) const
 .. doxygenfunction:: OIIO::ImageBuf::copy_metadata
 .. doxygenfunction:: OIIO::ImageBuf::copy_pixels
 .. doxygenfunction:: OIIO::ImageBuf::swap
@@ -156,15 +156,15 @@ Getting and setting pixel values
 **Getting and setting individual pixels -- slow**
 
 .. doxygenfunction:: OIIO::ImageBuf::getchannel
-.. doxygenfunction:: OIIO::ImageBuf::getpixel(int, int, int, float*, int, WrapMode) const
+.. doxygenfunction:: OIIO::ImageBuf::getpixel(int x, int y, int z, float *pixel, int maxchannels = 1000, WrapMode wrap = WrapBlack) const
 
 .. doxygenfunction:: OIIO::ImageBuf::interppixel
 .. doxygenfunction:: OIIO::ImageBuf::interppixel_bicubic
 .. doxygenfunction:: OIIO::ImageBuf::interppixel_NDC
 .. doxygenfunction:: OIIO::ImageBuf::interppixel_bicubic_NDC
 
-.. doxygenfunction:: OIIO::ImageBuf::setpixel(int, int, int, const float*, int)
-.. doxygenfunction:: OIIO::ImageBuf::setpixel(int, const float*, int)
+.. doxygenfunction:: OIIO::ImageBuf::setpixel(int x, int y, int z, cspan<float> pixel)
+.. doxygenfunction:: OIIO::ImageBuf::setpixel(int i, cspan<float> pixel)
 
 |
 
@@ -183,10 +183,10 @@ Deep data in an ImageBuf
 .. doxygenfunction:: OIIO::ImageBuf::set_deep_samples
 .. doxygenfunction:: OIIO::ImageBuf::deep_insert_samples
 .. doxygenfunction:: OIIO::ImageBuf::deep_erase_samples
-.. doxygenfunction:: OIIO::ImageBuf::deep_value(int, int, int, int, int) const
-.. doxygenfunction:: OIIO::ImageBuf::deep_value_uint(int, int, int, int, int) const
-.. doxygenfunction:: OIIO::ImageBuf::set_deep_value(int, int, int, int, int, float)
-.. doxygenfunction:: OIIO::ImageBuf::set_deep_value(int, int, int, int, int, uint32_t)
+.. doxygenfunction:: OIIO::ImageBuf::deep_value(int x, int y, int z, int c, int s) const
+.. doxygenfunction:: OIIO::ImageBuf::deep_value_uint(int x, int y, int z, int c, int s) const
+.. doxygenfunction:: OIIO::ImageBuf::set_deep_value(int x, int y, int z, int c, int s, float value)
+.. doxygenfunction:: OIIO::ImageBuf::set_deep_value(int x, int y, int z, int c, int s, uint32_t value)
 .. doxygenfunction:: OIIO::ImageBuf::deep_pixel_ptr
 
 .. cpp:function:: DeepData& OIIO::ImageBuf::deepdata()

--- a/src/doc/imagebufalgo.rst
+++ b/src/doc/imagebufalgo.rst
@@ -151,7 +151,7 @@ pre-allocated `dst` nor a non-default ROI.
 zero() -- create a black image
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. doxygenfunction:: zero(ROI, int)
+.. doxygenfunction:: zero(ROI roi, int nthreads = 0)
 
 ..
 
@@ -176,7 +176,7 @@ zero() -- create a black image
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: zero(ImageBuf&, ROI, int)
+    .. doxygenfunction:: zero(ImageBuf &dst, ROI roi = {}, int nthreads = 0)
 
 
 |
@@ -207,7 +207,7 @@ fill() -- fill a region with a solid color or gradient
 checker() -- make a checker pattern
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. doxygenfunction:: checker(int, int, int, cspan<float>, cspan<float>, int, int, int, ROI, int)
+.. doxygenfunction:: checker(int width, int height, int depth, cspan<float> color1, cspan<float> color2, int xoffset, int yoffset, int zoffset, ROI roi, int nthreads = 0)
 ..
 
   Examples::
@@ -225,7 +225,7 @@ checker() -- make a checker pattern
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: checker(ImageBuf&, int, int, int, cspan<float>, cspan<float>, int, int, int, ROI, int)
+    .. doxygenfunction:: checker(ImageBuf &dst, int width, int height, int depth, cspan<float> color1, cspan<float> color2, int xoffset = 0, int yoffset = 0, int zoffset = 0, ROI roi = {}, int nthreads = 0)
 
 
 |
@@ -234,7 +234,7 @@ checker() -- make a checker pattern
 noise() -- make a noise pattern
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. doxygenfunction:: noise(string_view, float, float, bool, int, ROI, int)
+.. doxygenfunction:: noise(string_view noisetype, float A = 0.0f, float B = 0.1f, bool mono = false, int seed = 0, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -272,7 +272,7 @@ noise() -- make a noise pattern
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: noise(ImageBuf&, string_view, float, float, bool, int, ROI, int)
+    .. doxygenfunction:: noise(ImageBuf &dst, string_view noisetype, float A = 0.0f, float B = 0.1f, bool mono = false, int seed = 0, ROI roi = {}, int nthreads = 0)
 
 |
 
@@ -329,7 +329,7 @@ Drawing shapes: points, lines, boxes
 Drawing text
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. doxygenfunction:: render_text(ImageBuf&, int, int, string_view, int, string_view, cspan<float>, TextAlignX, TextAlignY, int, ROI, int)
+.. doxygenfunction:: render_text(ImageBuf &dst, int x, int y, string_view text, int fontsize = 16, string_view fontname = "", cspan<float> textcolor = 1.0f, TextAlignX alignx = TextAlignX::Left, TextAlignY aligny = TextAlignY::Baseline, int shadow = 0, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -386,7 +386,7 @@ Image transformations and data movement
 Shuffling channels
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. doxygenfunction:: channels(const ImageBuf&, int, cspan<int>, cspan<float>, cspan<std::string>, bool, int)
+.. doxygenfunction:: channels(const ImageBuf &src, int nchannels, cspan<int> channelorder, cspan<float> channelvalues = {}, cspan<std::string> newchannelnames = {}, bool shuffle_channel_names = false, int nthreads = 0)
 ..
 
   Examples::
@@ -419,12 +419,12 @@ Shuffling channels
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: channels(ImageBuf&, const ImageBuf&, int, cspan<int>, cspan<float>, cspan<std::string>, bool, int)
+    .. doxygenfunction:: channels(ImageBuf &dst, const ImageBuf &src, int nchannels, cspan<int> channelorder, cspan<float> channelvalues = {}, cspan<std::string> newchannelnames = {}, bool shuffle_channel_names = false, int nthreads = 0)
 
 |
 
 
-.. doxygenfunction:: channel_append(const ImageBuf&, const ImageBuf&, ROI, int)
+.. doxygenfunction:: channel_append(const ImageBuf &A, const ImageBuf &B, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -435,12 +435,12 @@ Shuffling channels
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: channel_append(ImageBuf&, const ImageBuf&, const ImageBuf&, ROI, int)
+    .. doxygenfunction:: channel_append(ImageBuf &dst, const ImageBuf &A, const ImageBuf &B, ROI roi = {}, int nthreads = 0)
 
 |
 
 
-.. doxygenfunction:: copy(const ImageBuf&, TypeDesc, ROI, int)
+.. doxygenfunction:: copy(const ImageBuf &src, TypeDesc convert = TypeUnknown, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -451,12 +451,12 @@ Shuffling channels
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: copy(ImageBuf&, const ImageBuf&, TypeDesc, ROI, int)
+    .. doxygenfunction:: copy(ImageBuf &dst, const ImageBuf &src, TypeDesc convert = TypeUnknown, ROI roi = {}, int nthreads = 0)
 
 |
 
 
-.. doxygenfunction:: crop(const ImageBuf&, ROI, int)
+.. doxygenfunction:: crop(const ImageBuf &src, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -467,12 +467,12 @@ Shuffling channels
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: crop(ImageBuf&, const ImageBuf&, ROI, int)
+    .. doxygenfunction:: crop(ImageBuf &dst, const ImageBuf &src, ROI roi = {}, int nthreads = 0)
 
 |
 
 
-.. doxygenfunction:: cut(const ImageBuf&, ROI, int)
+.. doxygenfunction:: cut(const ImageBuf &src, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -484,7 +484,7 @@ Shuffling channels
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: cut(ImageBuf&, const ImageBuf&, ROI, int)
+    .. doxygenfunction:: cut(ImageBuf &dst, const ImageBuf &src, ROI roi = {}, int nthreads = 0)
 
 |
 
@@ -558,7 +558,7 @@ Shuffling channels
 
 
 
-.. doxygenfunction:: reorient(const ImageBuf&, int)
+.. doxygenfunction:: reorient(const ImageBuf &src, int nthreads = 0)
 ..
 
   Examples::
@@ -568,13 +568,13 @@ Shuffling channels
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: reorient(ImageBuf&, const ImageBuf&, int)
+    .. doxygenfunction:: reorient(ImageBuf &dst, const ImageBuf &src, int nthreads = 0)
 
 |
 
 
 
-.. doxygenfunction:: circular_shift(const ImageBuf&, int, int, int, ROI, int)
+.. doxygenfunction:: circular_shift(const ImageBuf &src, int xshift, int yshift, int zshift = 0, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -594,7 +594,7 @@ Shuffling channels
 
   Result-as-parameter version:
 
-  .. doxygenfunction:: circular_shift(ImageBuf&, const ImageBuf&, int, int, int, ROI, int)
+  .. doxygenfunction:: circular_shift(ImageBuf &dst, const ImageBuf &src, int xshift, int yshift, int zshift = 0, ROI roi = {}, int nthreads = 0)
   ..
 
 |
@@ -634,7 +634,7 @@ Shuffling channels
 |
 
 
-.. doxygenfunction:: resample(const ImageBuf&, bool, ROI, int)
+.. doxygenfunction:: resample(const ImageBuf &src, bool interpolate = true, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -646,7 +646,7 @@ Shuffling channels
 
   Result-as-parameter version:
 
-  .. doxygenfunction:: resample(ImageBuf&, const ImageBuf&, bool, ROI, int)
+  .. doxygenfunction:: resample(ImageBuf &dst, const ImageBuf &src, bool interpolate = true, ROI roi = {}, int nthreads = 0)
   ..
 
 |
@@ -687,7 +687,7 @@ Shuffling channels
 Image arithmetic
 ================
 
-.. doxygenfunction:: add(Image_or_Const, Image_or_Const, ROI, int)
+.. doxygenfunction:: add(Image_or_Const A, Image_or_Const B, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -705,14 +705,14 @@ Image arithmetic
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: add(ImageBuf&, Image_or_Const, Image_or_Const, ROI, int)
+    .. doxygenfunction:: add(ImageBuf &dst, Image_or_Const A, Image_or_Const B, ROI roi = {}, int nthreads = 0)
 
 
 
 
 |
 
-.. doxygenfunction:: sub(Image_or_Const, Image_or_Const, ROI, int)
+.. doxygenfunction:: sub(Image_or_Const A, Image_or_Const B, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -723,13 +723,13 @@ Image arithmetic
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: sub(ImageBuf&, Image_or_Const, Image_or_Const, ROI, int)
+    .. doxygenfunction:: sub(ImageBuf &dst, Image_or_Const A, Image_or_Const B, ROI roi = {}, int nthreads = 0)
 
 
 
 |
 
-.. doxygenfunction:: absdiff(Image_or_Const, Image_or_Const, ROI, int)
+.. doxygenfunction:: absdiff(Image_or_Const A, Image_or_Const B, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -740,12 +740,12 @@ Image arithmetic
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: absdiff(ImageBuf&, Image_or_Const, Image_or_Const, ROI, int)
+    .. doxygenfunction:: absdiff(ImageBuf &dst, Image_or_Const A, Image_or_Const B, ROI roi = {}, int nthreads = 0)
 
 
 |
 
-.. doxygenfunction:: abs(const ImageBuf&, ROI, int)
+.. doxygenfunction:: abs(const ImageBuf &A, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -755,13 +755,13 @@ Image arithmetic
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: abs(ImageBuf&, const ImageBuf&, ROI, int)
+    .. doxygenfunction:: abs(ImageBuf &dst, const ImageBuf &A, ROI roi = {}, int nthreads = 0)
 
 
 
 |
 
-.. doxygenfunction:: mul(Image_or_Const, Image_or_Const, ROI, int)
+.. doxygenfunction:: mul(Image_or_Const A, Image_or_Const B, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -777,13 +777,13 @@ Image arithmetic
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: mul(ImageBuf&, Image_or_Const, Image_or_Const, ROI, int)
+    .. doxygenfunction:: mul(ImageBuf &dst, Image_or_Const A, Image_or_Const B, ROI roi = {}, int nthreads = 0)
 
 
 
 |
 
-.. doxygenfunction:: div(Image_or_Const, Image_or_Const, ROI, int)
+.. doxygenfunction:: div(Image_or_Const A, Image_or_Const B, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -799,12 +799,12 @@ Image arithmetic
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: div(ImageBuf&, Image_or_Const, Image_or_Const, ROI, int)
+    .. doxygenfunction:: div(ImageBuf &dst, Image_or_Const A, Image_or_Const B, ROI roi = {}, int nthreads = 0)
 
 
 |
 
-.. doxygenfunction:: mad(Image_or_Const, Image_or_Const, Image_or_Const, ROI, int)
+.. doxygenfunction:: mad(Image_or_Const A, Image_or_Const B, Image_or_Const C, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -823,12 +823,12 @@ Image arithmetic
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: mad(ImageBuf&, Image_or_Const, Image_or_Const, Image_or_Const, ROI, int)
+    .. doxygenfunction:: mad(ImageBuf &dst, Image_or_Const A, Image_or_Const B, Image_or_Const C, ROI roi = {}, int nthreads = 0)
 
 
 |
 
-.. doxygenfunction:: over(const ImageBuf&, const ImageBuf&, ROI, int)
+.. doxygenfunction:: over(const ImageBuf &A, const ImageBuf &B, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -839,12 +839,12 @@ Image arithmetic
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: over(ImageBuf&, const ImageBuf&, const ImageBuf&, ROI, int)
+    .. doxygenfunction:: over(ImageBuf &dst, const ImageBuf &A, const ImageBuf &B, ROI roi = {}, int nthreads = 0)
 
 
 |
 
-.. doxygenfunction:: zover(const ImageBuf&, const ImageBuf&, bool, ROI, int)
+.. doxygenfunction:: zover(const ImageBuf &A, const ImageBuf &B, bool z_zeroisinf = false, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -855,12 +855,12 @@ Image arithmetic
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: zover(ImageBuf&, const ImageBuf&, const ImageBuf&, bool, ROI, int)
+    .. doxygenfunction:: zover(ImageBuf &dst, const ImageBuf &A, const ImageBuf &B, bool z_zeroisinf = false, ROI roi = {}, int nthreads = 0)
 
 
 |
 
-.. doxygenfunction:: invert(const ImageBuf&, ROI, int)
+.. doxygenfunction:: invert(const ImageBuf &A, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -889,12 +889,12 @@ Image arithmetic
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: invert(ImageBuf&, const ImageBuf&, ROI, int)
+    .. doxygenfunction:: invert(ImageBuf &dst, const ImageBuf &A, ROI roi = {}, int nthreads = 0)
 
 
 |
 
-.. doxygenfunction:: pow(const ImageBuf&, cspan<float>, ROI, int)
+.. doxygenfunction:: pow(const ImageBuf &A, cspan<float> B, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -906,12 +906,12 @@ Image arithmetic
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: pow(ImageBuf&, const ImageBuf&, cspan<float>, ROI, int)
+    .. doxygenfunction:: pow(ImageBuf &dst, const ImageBuf &A, cspan<float> B, ROI roi = {}, int nthreads = 0)
 
 
 |
 
-.. doxygenfunction:: channel_sum(const ImageBuf&, cspan<float>, ROI, int)
+.. doxygenfunction:: channel_sum(const ImageBuf &src, cspan<float> weights = 1.0f, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -924,13 +924,13 @@ Image arithmetic
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: channel_sum(ImageBuf&, const ImageBuf&, cspan<float>, ROI, int)
+    .. doxygenfunction:: channel_sum(ImageBuf &dst, const ImageBuf &src, cspan<float> weights = 1.0f, ROI roi = {}, int nthreads = 0)
 
 
 |
 
-.. doxygenfunction:: max(Image_or_Const, Image_or_Const, ROI, int)
-.. doxygenfunction:: min(Image_or_Const, Image_or_Const, ROI, int)
+.. doxygenfunction:: max(Image_or_Const A, Image_or_Const B, ROI roi = {}, int nthreads = 0)
+.. doxygenfunction:: min(Image_or_Const A, Image_or_Const B, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -948,13 +948,13 @@ Image arithmetic
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: max(ImageBuf&, Image_or_Const, Image_or_Const, ROI, int)
-    .. doxygenfunction:: min(ImageBuf&, Image_or_Const, Image_or_Const, ROI, int)
+    .. doxygenfunction:: max(ImageBuf &dst, Image_or_Const A, Image_or_Const B, ROI roi = {}, int nthreads = 0)
+    .. doxygenfunction:: min(ImageBuf &dst, Image_or_Const A, Image_or_Const B, ROI roi = {}, int nthreads = 0)
 
 
 |
 
-.. doxygenfunction:: clamp(const ImageBuf&, cspan<float>, cspan<float>, bool, ROI, int)
+.. doxygenfunction:: clamp(const ImageBuf &src, cspan<float> min = -std::numeric_limits<float>::max(), cspan<float> max = std::numeric_limits<float>::max(), bool clampalpha01 = false, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -975,12 +975,12 @@ Image arithmetic
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: clamp(ImageBuf&, const ImageBuf&, cspan<float>, cspan<float>, bool, ROI, int)
+    .. doxygenfunction:: clamp(ImageBuf &dst, const ImageBuf &src, cspan<float> min = -std::numeric_limits<float>::max(), cspan<float> max = std::numeric_limits<float>::max(), bool clampalpha01 = false, ROI roi = {}, int nthreads = 0)
 
 
 |
 
-.. doxygenfunction:: contrast_remap(const ImageBuf&, cspan<float>, cspan<float>, cspan<float>, cspan<float>, cspan<float>, cspan<float>, ROI, int)
+.. doxygenfunction:: contrast_remap(const ImageBuf &src, cspan<float> black = 0.0f, cspan<float> white = 1.0f, cspan<float> min = 0.0f, cspan<float> max = 1.0f, cspan<float> scontrast = 1.0f, cspan<float> sthresh = 0.5f, ROI = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -1018,7 +1018,7 @@ Image arithmetic
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: contrast_remap(ImageBuf&, const ImageBuf&, cspan<float>, cspan<float>, cspan<float>, cspan<float>, cspan<float>, cspan<float>, ROI, int)
+    .. doxygenfunction:: contrast_remap(ImageBuf &dst, const ImageBuf &src, cspan<float> black = 0.0f, cspan<float> white = 1.0f, cspan<float> min = 0.0f, cspan<float> max = 1.0f, cspan<float> scontrast = 1.0f, cspan<float> sthresh = 0.5f, ROI = {}, int nthreads = 0)
 
 
 |
@@ -1089,7 +1089,7 @@ Image arithmetic
 Image comparison and statistics
 ===============================
 
-.. doxygenfunction:: computePixelStats(const ImageBuf&, ROI, int)
+.. doxygenfunction:: computePixelStats
 ..
 
   The PixelStats structure is defined as follows::
@@ -1123,7 +1123,7 @@ Image comparison and statistics
 
 |
 
-.. doxygenfunction:: compare(const ImageBuf&, const ImageBuf&, float, float, ROI, int)
+.. doxygenfunction:: compare(const ImageBuf &A, const ImageBuf &B, float failthresh, float warnthresh, ROI roi = {}, int nthreads = 0)
 ..
 
   The CompareResults structure is defined as follows::
@@ -1157,13 +1157,13 @@ Image comparison and statistics
 
 |
 
-.. doxygenfunction:: compare_Yee(const ImageBuf&, const ImageBuf&, CompareResults&, float, float, ROI, int)
+.. doxygenfunction:: compare_Yee
 ..
 
 
 |
 
-.. doxygenfunction:: isConstantColor(const ImageBuf&, float, span<float>, ROI, int)
+.. doxygenfunction:: isConstantColor
 ..
 
   Examples::
@@ -1182,7 +1182,7 @@ Image comparison and statistics
 
 |
 
-.. doxygenfunction:: isConstantChannel(const ImageBuf&, int, float, float, ROI, int)
+.. doxygenfunction:: isConstantChannel
 ..
 
   Examples::
@@ -1199,7 +1199,7 @@ Image comparison and statistics
 
 |
 
-.. doxygenfunction:: isMonochrome(const ImageBuf&, float, ROI, int)
+.. doxygenfunction:: isMonochrome
 ..
 
   Examples::
@@ -1213,7 +1213,7 @@ Image comparison and statistics
 
 |
 
-.. doxygenfunction:: color_count(const ImageBuf&, imagesize_t*, int, cspan<float>, cspan<float>, ROI, int)
+.. doxygenfunction:: color_count
 ..
 
   Examples::
@@ -1235,7 +1235,7 @@ Image comparison and statistics
 
 |
 
-.. doxygenfunction:: color_range_check(const ImageBuf&, imagesize_t*, imagesize_t*, imagesize_t*, cspan<float>, cspan<float>, ROI, int)
+.. doxygenfunction:: color_range_check
 ..
 
   Examples::
@@ -1285,7 +1285,7 @@ Image comparison and statistics
 
 |
 
-.. doxygenfunction:: histogram(const ImageBuf&, int, int, float, float, bool, ROI, int)
+.. doxygenfunction:: histogram
 ..
 
   Examples::
@@ -1310,7 +1310,7 @@ Image comparison and statistics
 Convolutions and frequency-space algorithms
 ===========================================
 
-.. doxygenfunction:: make_kernel(string_view, float, float, float, bool)
+.. doxygenfunction:: make_kernel
 ..
 
   Examples::
@@ -1320,7 +1320,7 @@ Convolutions and frequency-space algorithms
 
 |
 
-.. doxygenfunction:: convolve(const ImageBuf&, const ImageBuf&, bool, ROI, int)
+.. doxygenfunction:: convolve(const ImageBuf &src, const ImageBuf &kernel, bool normalize = true, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -1344,13 +1344,13 @@ Convolutions and frequency-space algorithms
 
   Result-as-parameter version:
 
-    .. doxygenfunction:: convolve(ImageBuf&, const ImageBuf&, const ImageBuf&, bool, ROI, int)
+    .. doxygenfunction:: convolve(ImageBuf &dst, const ImageBuf &src, const ImageBuf &kernel, bool normalize = true, ROI roi = {}, int nthreads = 0)
 
 
 
 |
 
-.. doxygenfunction:: laplacian(const ImageBuf&, ROI, int)
+.. doxygenfunction:: laplacian(const ImageBuf &src, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -1370,7 +1370,7 @@ Convolutions and frequency-space algorithms
   | original        | Laplacian image |
   +-----------------+-----------------+
 
-  .. doxygenfunction:: laplacian(ImageBuf&, const ImageBuf&, ROI, int)
+  .. doxygenfunction:: laplacian(ImageBuf &dst, const ImageBuf &src, ROI roi = {}, int nthreads = 0)
 
 
 |
@@ -1416,7 +1416,7 @@ Convolutions and frequency-space algorithms
 Image Enhancement / Restoration
 ===============================
 
-.. doxygenfunction:: fixNonFinite(const ImageBuf&, NonFiniteFixMode, int*, ROI, int)
+.. doxygenfunction:: fixNonFinite(const ImageBuf &src, NonFiniteFixMode mode = NONFINITE_BOX3, int *pixelsFixed = nullptr, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -1428,12 +1428,12 @@ Image Enhancement / Restoration
     std::cout << "Repaired " << pixelsFixed << " non-finite pixels\n";
 
   Result-as-parameter version:
-    .. doxygenfunction:: fixNonFinite(ImageBuf&, const ImageBuf&, NonFiniteFixMode, int*, ROI, int)
+    .. doxygenfunction:: fixNonFinite(ImageBuf &dst, const ImageBuf &src, NonFiniteFixMode mode = NONFINITE_BOX3, int *pixelsFixed = nullptr, ROI roi = {}, int nthreads = 0)
 
 
 |
 
-.. doxygenfunction:: fillholes_pushpull(const ImageBuf&, ROI, int)
+.. doxygenfunction:: fillholes_pushpull(const ImageBuf &src, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -1442,12 +1442,12 @@ Image Enhancement / Restoration
     ImageBuf Filled = ImageBufAlgo::fillholes_pushpull (Src);
 
   Result-as-parameter version:
-    .. doxygenfunction:: fillholes_pushpull(ImageBuf&, const ImageBuf&, ROI, int)
+    .. doxygenfunction:: fillholes_pushpull(ImageBuf &dst, const ImageBuf &src, ROI roi = {}, int nthreads = 0)
 
 
 |
 
-.. doxygenfunction:: median_filter(ImageBuf&, const ImageBuf&, int, int, ROI, int)
+.. doxygenfunction:: median_filter(const ImageBuf &src, int width = 3, int height = -1, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -1472,12 +1472,12 @@ Image Enhancement / Restoration
   +-----------------+-----------------+-----------------+
 
   Result-as-parameter version:
-    .. doxygenfunction:: median_filter(ImageBuf&, const ImageBuf&, int, int, ROI, int)
+    .. doxygenfunction:: median_filter(ImageBuf &dst, const ImageBuf &src, int width = 3, int height = -1, ROI roi = {}, int nthreads = 0)
 
 
 |
 
-.. doxygenfunction:: unsharp_mask(const ImageBuf&, string_view, float, float, float, ROI, int)
+.. doxygenfunction:: unsharp_mask(const ImageBuf &src, string_view kernel = "gaussian", float width = 3.0f, float contrast = 1.0f, float threshold = 0.0f, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -1486,7 +1486,7 @@ Image Enhancement / Restoration
     ImageBuf Sharp = ImageBufAlgo::unsharp_mask (Blurry, "gaussian", 5.0f);
 
   Result-as-parameter version:
-    .. doxygenfunction:: unsharp_mask(ImageBuf&, const ImageBuf&, string_view, float, float, float, ROI, int)
+    .. doxygenfunction:: unsharp_mask(ImageBuf &dst, const ImageBuf &src, string_view kernel = "gaussian", float width = 3.0f, float contrast = 1.0f, float threshold = 0.0f, ROI roi = {}, int nthreads = 0)
 
 |
 
@@ -1494,20 +1494,20 @@ Image Enhancement / Restoration
 Morphological filters
 =====================
 
-.. doxygenfunction:: dilate(const ImageBuf&, int, int, ROI, int)
+.. doxygenfunction:: dilate(const ImageBuf &src, int width = 3, int height = -1, ROI roi = {}, int nthreads = 0)
 ..
 
   Result-as-parameter version:
-    .. doxygenfunction:: dilate(ImageBuf&, const ImageBuf&, int, int, ROI, int)
+    .. doxygenfunction:: dilate(ImageBuf &dst, const ImageBuf &src, int width = 3, int height = -1, ROI roi = {}, int nthreads = 0)
 
 
 |
 
-.. doxygenfunction:: erode(const ImageBuf&, int, int, ROI, int)
+.. doxygenfunction:: erode(const ImageBuf &src, int width = 3, int height = -1, ROI roi = {}, int nthreads = 0)
 ..
 
   Result-as-parameter version:
-    .. doxygenfunction:: erode(ImageBuf&, const ImageBuf&, int, int, ROI, int)
+    .. doxygenfunction:: erode(ImageBuf &dst, const ImageBuf &src, int width = 3, int height = -1, ROI roi = {}, int nthreads = 0)
 
 |
 
@@ -1605,7 +1605,7 @@ Color space conversion
 
 |
 
-.. doxygenfunction:: colormatrixtransform(const ImageBuf&, const Imath::M44f&, bool, ROI, int)
+.. doxygenfunction:: colormatrixtransform(const ImageBuf &src, const Imath::M44f &M, bool unpremult = true, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -1631,12 +1631,12 @@ Color space conversion
   +-----------------+-----------------+
 
   Result-as-parameter version:
-    .. doxygenfunction:: colormatrixtransform(ImageBuf&, const ImageBuf&, const Imath::M44f&, bool, ROI, int)
+    .. doxygenfunction:: colormatrixtransform(ImageBuf &dst, const ImageBuf &src, const Imath::M44f &M, bool unpremult = true, ROI roi = {}, int nthreads = 0)
 
 
 |
 
-.. doxygenfunction:: ociolook(const ImageBuf&, string_view, string_view, string_view, bool, bool, string_view, string_view, ColorConfig*, ROI, int)
+.. doxygenfunction:: ociolook(const ImageBuf &src, string_view looks, string_view fromspace, string_view tospace, bool unpremult = true, bool inverse = false, string_view context_key = "", string_view context_value = "", ColorConfig *colorconfig = nullptr, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -1646,11 +1646,11 @@ Color space conversion
                                            true, false, "SHOT", "pe0012");
 
   Result-as-parameter version:
-    .. doxygenfunction:: ociolook(ImageBuf&, const ImageBuf&, string_view, string_view, string_view, bool, bool, string_view, string_view, ColorConfig*, ROI, int)
+    .. doxygenfunction:: ociolook(ImageBuf &dst, const ImageBuf &src, string_view looks, string_view fromspace, string_view tospace, bool unpremult = true, bool inverse = false, string_view context_key = "", string_view context_value = "", ColorConfig *colorconfig = nullptr, ROI roi = {}, int nthreads = 0)
 
 |
 
-.. doxygenfunction:: ociodisplay(const ImageBuf&, string_view, string_view, string_view, string_view, bool, string_view, string_view, ColorConfig*, ROI, int)
+.. doxygenfunction:: ociodisplay(const ImageBuf &src, string_view display, string_view view, string_view fromspace = "", string_view looks = "", bool unpremult = true, string_view context_key = "", string_view context_value = "", ColorConfig *colorconfig = nullptr, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -1660,12 +1660,12 @@ Color space conversion
                                               "", true, "SHOT", "pe0012");
 
   Result-as-parameter version:
-    .. doxygenfunction:: ociodisplay(ImageBuf&, const ImageBuf&, string_view, string_view, string_view, string_view, bool, string_view, string_view, ColorConfig*, ROI, int)
+    .. doxygenfunction:: ociodisplay(ImageBuf &dst, const ImageBuf &src, string_view display, string_view view, string_view fromspace = "", string_view looks = "", bool unpremult = true, string_view context_key = "", string_view context_value = "", ColorConfig *colorconfig = nullptr, ROI roi = {}, int nthreads = 0)
 
 
 |
 
-.. doxygenfunction:: ociofiletransform(const ImageBuf&, string_view, bool, bool, ColorConfig*, ROI, int)
+.. doxygenfunction:: ociofiletransform(const ImageBuf &src, string_view name, bool unpremult = true, bool inverse = false, ColorConfig *colorconfig = nullptr, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -1675,7 +1675,7 @@ Color space conversion
 
 
   Result-as-parameter version:
-    .. doxygenfunction:: ociofiletransform(ImageBuf&, const ImageBuf&, string_view, bool, bool, ColorConfig*, ROI, int)
+    .. doxygenfunction:: ociofiletransform(ImageBuf &dst, const ImageBuf &src, string_view name, bool unpremult = true, bool inverse = false, ColorConfig *colorconfig = nullptr, ROI roi = {}, int nthreads = 0)
 
 
 |
@@ -1761,7 +1761,7 @@ Functions specific to deep images
 
 |
 
-.. doxygenfunction:: deepen(const ImageBuf&, float, ROI, int)
+.. doxygenfunction:: deepen(const ImageBuf &src, float zvalue = 1.0f, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -1770,12 +1770,12 @@ Functions specific to deep images
     ImageBuf Deep = ImageBufAlgo::deepen (Flat);
 
   Result-as-parameter version:
-    .. doxygenfunction:: deepen(ImageBuf&, const ImageBuf&, float, ROI, int)
+    .. doxygenfunction:: deepen(ImageBuf &dst, const ImageBuf &src, float zvalue = 1.0f, ROI roi = {}, int nthreads = 0)
 
 
 |
 
-.. doxygenfunction:: flatten(const ImageBuf&, ROI, int)
+.. doxygenfunction:: flatten(const ImageBuf &src, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -1784,12 +1784,12 @@ Functions specific to deep images
     ImageBuf Flat = ImageBufAlgo::flatten (Deep);
 
   Result-as-parameter version:
-    .. doxygenfunction:: flatten(ImageBuf&, const ImageBuf&, ROI, int)
+    .. doxygenfunction:: flatten(ImageBuf &dst, const ImageBuf &src, ROI roi = {}, int nthreads = 0)
 
 
 |
 
-.. doxygenfunction:: deep_merge(const ImageBuf&, const ImageBuf&, bool, ROI, int)
+.. doxygenfunction:: deep_merge(const ImageBuf &A, const ImageBuf &B, bool occlusion_cull = true, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -1799,13 +1799,13 @@ Functions specific to deep images
     ImageBuf Merged = ImageBufAlgo::deep_merge (DeepA, DeepB);
 
   Result-as-parameter version:
-    .. doxygenfunction:: deep_merge(ImageBuf&, const ImageBuf&, const ImageBuf&, bool, ROI, int)
+    .. doxygenfunction:: deep_merge(ImageBuf &dst, const ImageBuf &A, const ImageBuf &B, bool occlusion_cull = true, ROI roi = {}, int nthreads = 0)
 
 
 
 |
 
-.. doxygenfunction:: deep_holdout(const ImageBuf&, const ImageBuf&, ROI, int)
+.. doxygenfunction:: deep_holdout(const ImageBuf &src, const ImageBuf &holdout, ROI roi = {}, int nthreads = 0)
 ..
 
   Examples::
@@ -1815,7 +1815,7 @@ Functions specific to deep images
     ImageBuf Merged = ImageBufAlgo::deep_holdout (Src, Holdout);
 
   Result-as-parameter version:
-    .. doxygenfunction:: deep_holdout(ImageBuf&, const ImageBuf&, const ImageBuf&, ROI, int)
+    .. doxygenfunction:: deep_holdout(ImageBuf &dst, const ImageBuf &src, const ImageBuf &holdout, ROI roi = {}, int nthreads = 0)
 
 |
 

--- a/src/doc/requirements.txt
+++ b/src/doc/requirements.txt
@@ -1,2 +1,2 @@
-breathe == 4.16.0
 sphinx >= 3.0
+breathe == 4.23.0

--- a/src/doc/texturesys.rst
+++ b/src/doc/texturesys.rst
@@ -130,16 +130,50 @@ structure:
   will return `false`. Note: When not NULL, the data must point to
   `nchannels` contiguous floats.
 
-- `float bias` :
+..
+  - `float bias` :
   For shadow map lookups only, this gives the "shadow bias" amount.
 
-- `int samples` :
+..
+  - `int samples` :
   For shadow map lookups only, the number of samples to use for the lookup.
 
 - `Wrap rwrap, float rblur, rwidth` :
   Specifies wrap, blur, and width for the third component of 3D volume
   texture lookups.  These are not used for 2D texture or environment
   lookups.
+
+- `MipMode mipmode` :
+  Determines if/how MIP-maps are used:
+
+    - `MipModeDefault`   : The default high-quality lookup (same as Aniso).
+
+    - `MipModeNoMIP`     : Just use highest-res image, no MIP mapping
+
+    - `MipModeOneLevel`  : Use just one mipmap level
+
+    - `MipModeTrilinear` : Use two MIPmap levels (trilinear)
+
+    - `MipModeAniso`     : Use two MIPmap levels w/ anisotropic
+
+- `InterpMode interpmode` :
+  Determines how we sample within a mipmap level:
+
+    - `InterpClosest`      : Force closest texel.
+
+    - `InterpBilinear`     : Force bilinear lookup within a mip level.
+
+    - `InterpBicubic`      : Force cubic lookup within a mip level.
+
+    - `InterpSmartBicubic` : Bicubic when maxifying, else bilinear (default).
+
+- `int anisotropic` :
+  Maximum anisotropic ratio (default: 32).
+
+- `bool conservative_filter` :
+  When true (the default), filters conservatively in a way that chooses to
+  sometimes over-blur rather than alias.
+
 
 
 
@@ -195,19 +229,18 @@ batch of lookups from the same texture at once. The members of
 TextureOptBatch correspond to the similarly named members of the
 single-point TextureOpt, so we refer you to Section :ref:`sec-textureopt`
 for detailed explanations, and this section will only explain the
-differences between batched and single-point options.
+differences between batched and single-point options. Members include:
 
 
-.. cpp:member:: int firstchannel
-                int subimage
-                ustring subimagename
-                Tex::Wrap swrap, twrap, rwrap
-                Tex::MipMode mipmode
-                Tex::InterpMode interpmode
-                int anisotropic
-                bool conservative_filter
-                float fill
-                const float *missingcolor
+- `int firstchannel` :
+- `int subimage, ustring subimagename` :
+- `Wrap swrap, twrap, rwrap` :
+- `float fill` :
+- `const float* missingcolor` :
+- `MipMode mipmode` :
+- `InterpMode interpmode` :
+- `int anisotropic` :
+- `bool conservative_filter` :
 
     These fields are all scalars --- a single value for each TextureOptBatch
     --- which means that the value of these options must be the same for
@@ -216,17 +249,17 @@ differences between batched and single-point options.
     example) differing wrap modes or subimages from point to point, then you
     must split them into separate batch calls.
 
-.. cpp:member:: float sblur[Tex::BatchWidth]
-                float tblur[Tex::BatchWidth]
-                float rblur[Tex::BatchWidth]
+- `float sblur[Tex::BatchWidth]` :
+- `float tblur[Tex::BatchWidth]` :
+- `float rblur[Tex::BatchWidth]` :
 
     These arrays hold the `s`, and `t` blur amounts, for each sample in the
     batch, respectively. (And the `r` blur amount, used only for volumetric
     `texture3d()` lookups.)
 
-.. cpp:member:: float swidth[Tex::BatchWidth]
-                float twidth[Tex::BatchWidth]
-                float rwidth[Tex::BatchWidth]
+- `float swidth[Tex::BatchWidth]` :
+- `float twidth[Tex::BatchWidth]` :
+- `float rwidth[Tex::BatchWidth]` :
 
     These arrays hold the `s`, and `t` filtering width multiplier for
     derivatives, for each sample in the batch, respectively. (And the `r`

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -208,12 +208,12 @@ public:
     void reset() { clear(); }
 
     // Deprecated/useless synonym for `reset(name, 0, 0, imagecache, nullptr)`
-    void reset(string_view name, ImageCache* imagecache = nullptr);
+    void reset(string_view name, ImageCache* imagecache);
 
     /// Destroy any previous contents of the ImageBuf and re-initialize it
     /// as if newly constructed with the same arguments, as a read-only
     /// representation of an existing image file.
-    void reset(string_view name, int subimage, int miplevel,
+    void reset(string_view name, int subimage = 0, int miplevel = 0,
                ImageCache* imagecache       = nullptr,
                const ImageSpec* config      = nullptr,
                Filesystem::IOProxy* ioproxy = nullptr);
@@ -443,6 +443,7 @@ public:
                ProgressCallback progress_callback = nullptr,
                void* progress_callback_data       = nullptr) const;
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     // DEPRECATED(1.9): old version did not have the data type
     bool write(string_view filename, string_view fileformat,
                ProgressCallback progress_callback = nullptr,
@@ -451,6 +452,7 @@ public:
         return write(filename, TypeUnknown, fileformat, progress_callback,
                      progress_callback_data);
     }
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
     /// Set the pixel data format that will be used for subsequent `write()`
     /// calls that do not themselves request a specific data type request.

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -1093,8 +1093,10 @@ PixelStats OIIO_API computePixelStats (const ImageBuf &src,
 
 // DEPRECATED(1.9): with C++11 move semantics, there's no reason why
 // stats needs to be passed as a parameter instead of returned.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 bool OIIO_API computePixelStats (PixelStats &stats, const ImageBuf &src,
                                  ROI roi={}, int nthreads=0);
+#endif
 
 
 // Struct holding all the results computed by ImageBufAlgo::compare().
@@ -1141,12 +1143,13 @@ int OIIO_API compare_Yee (const ImageBuf &A, const ImageBuf &B,
                           float luminance = 100, float fov = 45,
                           ROI roi={}, int nthreads=0);
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 // DEPRECATED(1.9): with C++11 move semantics, there's no reason why
 // result needs to be passed as a parameter instead of returned.
 bool OIIO_API compare (const ImageBuf &A, const ImageBuf &B,
                        float failthresh, float warnthresh,
                        CompareResults &result, ROI roi={}, int nthreads=0);
-
+#endif
 
 
 /// Do all pixels within the ROI have the same values for channels
@@ -1158,10 +1161,12 @@ bool OIIO_API compare (const ImageBuf &A, const ImageBuf &B,
 OIIO_API bool isConstantColor (const ImageBuf &src, float threshold=0.0f,
                                span<float> color = {},
                                ROI roi={}, int nthreads=0);
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 inline bool isConstantColor (const ImageBuf &src, span<float> color,
                              ROI roi={}, int nthreads=0) {
     return isConstantColor (src, 0.0f, color, roi, nthreads);
 }
+#endif
 
 
 /// Does the requested channel have a given value (within a tolerance of +/-
@@ -1172,10 +1177,12 @@ inline bool isConstantColor (const ImageBuf &src, span<float> color,
 OIIO_API bool isConstantChannel (const ImageBuf &src, int channel,
                                  float val, float threshold=0.0f,
                                  ROI roi={}, int nthreads=0);
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 inline bool isConstantChannel (const ImageBuf &src, int channel, float val,
                                ROI roi, int nthreads=0) {
     return isConstantChannel (src, channel, val, 0.0f, roi, nthreads);
 }
+#endif
 
 
 /// Is the image monochrome within the ROI, i.e., for every pixel within the
@@ -1185,9 +1192,11 @@ inline bool isConstantChannel (const ImageBuf &src, int channel, float val,
 /// channels of source.
 OIIO_API bool isMonochrome (const ImageBuf &src, float threshold=0.0f,
                             ROI roi={}, int nthreads=0);
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 inline bool isMonochrome (const ImageBuf &src, ROI roi, int nthreads=0) {
     return isMonochrome (src, 0.0f, roi, nthreads);
 }
+#endif
 
 
 /// Count how many pixels in the ROI match a list of colors. The colors to
@@ -1276,6 +1285,7 @@ std::vector<imagesize_t> histogram (const ImageBuf &src, int channel=0,
                                     ROI roi={}, int nthreads=0);
 
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 /// DEPRECATED(1.9)
 bool OIIO_API histogram (const ImageBuf &src, int channel,
                          std::vector<imagesize_t> &histogram, int bins=256,
@@ -1285,6 +1295,7 @@ bool OIIO_API histogram (const ImageBuf &src, int channel,
 // DEPRECATED(1.9): never liked this.
 bool OIIO_API histogram_draw (ImageBuf &dst,
                               const std::vector<imagesize_t> &histogram);
+#endif
 
 
 
@@ -1306,6 +1317,7 @@ bool OIIO_API histogram_draw (ImageBuf &dst,
 ///
 ImageBuf OIIO_API make_kernel (string_view name, float width, float height,
                                float depth = 1.0f, bool normalize = true);
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 // DEPRECATED(1.9):
 inline bool make_kernel (ImageBuf &dst, string_view name,
                          float width, float height, float depth = 1.0f,
@@ -1313,6 +1325,7 @@ inline bool make_kernel (ImageBuf &dst, string_view name,
     dst = make_kernel (name, width, height, depth, normalize);
     return ! dst.has_error();
 }
+#endif
 
 
 /// Return the convolution of `src` and a `kernel`. If `roi` is not defined,
@@ -2056,19 +2069,21 @@ ImageBuf OIIO_API capture_image (int cameranum = 0,
                                  TypeDesc convert=TypeUnknown);
 
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 // DEPRECATED(1.9):
 inline bool capture_image (ImageBuf &dst, int cameranum = 0,
                            TypeDesc convert=TypeUnknown) {
     dst = capture_image (cameranum, convert);
     return !dst.has_error();
 }
-
+#endif  // DOXYGEN_SHOULD_SKIP_THIS
 
 
 #if defined(__OPENCV_CORE_TYPES_H__) || defined(OPENCV_CORE_TYPES_H)
 // These declarations are only visible if the OpenCV headers have already
 // been encountered.
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 // DEPRECATED(2.0). The OpenCV 1.x era IplImage-based functions should be
 // avoided, giving preference to from_OpenCV.
 ImageBuf OIIO_API from_IplImage (const IplImage *ipl,
@@ -2083,6 +2098,7 @@ inline bool from_IplImage (ImageBuf &dst, const IplImage *ipl,
 // DEPRECATED(2.0). The OpenCV 1.x era IplImage-based functions should be
 // avoided, giving preference to from_OpenCV.
 OIIO_API IplImage* to_IplImage (const ImageBuf &src);
+#endif  // DOXYGEN_SHOULD_SKIP_THIS
 
 #endif
 
@@ -2158,6 +2174,8 @@ bool OIIO_API deep_holdout (ImageBuf &dst, const ImageBuf &src,
 // DEPRECATED(1.9): These are all functions that take raw pointers,
 // which we are deprecating as of 1.9, replaced by new versions that
 // take span<> for length safety.
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 inline bool fill (ImageBuf &dst, const float *values,
                   ROI roi={}, int nthreads=0) {
@@ -2283,6 +2301,8 @@ inline bool render_text (ImageBuf &dst, int x, int y, string_view text,
     return render_text (dst, x, y, text, fontsize, fontname,
                         {textcolor, textcolor?dst.nchannels():0});
 }
+
+#endif  // DOXYGEN_SHOULD_SKIP_THIS
 
 ///////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
* Bump breathe release to the latest (we'e been holding back because of
  errors that we fix in the other elements of this patch, below)

* Changing declaration formatting, particularly in the ImageBuf and
  ImageBufAlgo chapters, eliminates function ambiguity warnings and even
  python exceptions we were getting in Breathe before.

* Document missing texture option fields and improve formatting.

* Instruct Doxygen to not catalog deprecated ImageBufAlgo functions.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
