### PR TITLE
fmath.h: Use intrinsics for swap_endian

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -809,6 +809,82 @@ swap_endian (T *f, int len=1)
 }
 
 
+#if (OIIO_GNUC_VERSION || OIIO_CLANG_VERSION || OIIO_APPLE_CLANG_VERSION || OIIO_INTEL_COMPILER_VERSION) && !defined(__CUDACC__)
+// CPU gcc and compatible can use these intrinsics, 8-15x faster
+
+template<> inline void swap_endian(uint16_t* f, int len) {
+    for (int i = 0; i < len; ++i)
+        f[i] = __builtin_bswap16(f[i]);
+}
+
+template<> inline void swap_endian(uint32_t* f, int len) {
+    for (int i = 0; i < len; ++i)
+        f[i] = __builtin_bswap32(f[i]);
+}
+
+template<> inline void swap_endian(uint64_t* f, int len) {
+    for (int i = 0; i < len; ++i)
+        f[i] = __builtin_bswap64(f[i]);
+}
+
+template<> inline void swap_endian(int16_t* f, int len) {
+    for (int i = 0; i < len; ++i)
+        f[i] = __builtin_bswap16(f[i]);
+}
+
+template<> inline void swap_endian(int32_t* f, int len) {
+    for (int i = 0; i < len; ++i)
+        f[i] = __builtin_bswap32(f[i]);
+}
+
+template<> inline void swap_endian(int64_t* f, int len) {
+    for (int i = 0; i < len; ++i)
+        f[i] = __builtin_bswap64(f[i]);
+}
+
+template<> inline void swap_endian(float* f, int len) {
+    swap_endian((uint32_t*)f, len);
+}
+
+template<> inline void swap_endian(double* f, int len) {
+    swap_endian((uint64_t*)f, len);
+}
+
+#elif defined(_MSC_VER) && !defined(__CUDACC__)
+// CPU MSVS can use these intrinsics
+
+template<> inline void swap_endian(uint16_t* f, int len) {
+    for (int i = 0; i < len; ++i)
+        f[i] = _byteswap_ushort(f[i]);
+}
+
+template<> inline void swap_endian(uint32_t* f, int len) {
+    for (int i = 0; i < len; ++i)
+        f[i] = _byteswap_ulong(f[i]);
+}
+
+template<> inline void swap_endian(uint64_t* f, int len) {
+    for (int i = 0; i < len; ++i)
+        f[i] = _byteswap_uint64(f[i]);
+}
+
+template<> inline void swap_endian(int16_t* f, int len) {
+    for (int i = 0; i < len; ++i)
+        f[i] = _byteswap_ushort(f[i]);
+}
+
+template<> inline void swap_endian(int32_t* f, int len) {
+    for (int i = 0; i < len; ++i)
+        f[i] = _byteswap_ulong(f[i]);
+}
+
+template<> inline void swap_endian(int64_t* f, int len) {
+    for (int i = 0; i < len; ++i)
+        f[i] = _byteswap_uint64(f[i]);
+}
+#endif
+
+
 
 // big_enough_float<T>::float_t is a floating-point type big enough to
 // handle the range and precision of a <T>. It's a float, unless T is big.

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -427,7 +427,7 @@ template<size_t S> struct BaseTypeFromC<const char[S]> { static const TypeDesc::
 /// A template mechanism for getting the TypeDesc from a C type.
 /// The default for simple types is just the TypeDesc based on BaseTypeFromC.
 /// But we can specialize more complex types.
-template<typename T> struct TypeDescFromC { static const constexpr TypeDesc value() { return BaseTypeFromC<T>::value; } };
+template<typename T> struct TypeDescFromC { static const constexpr TypeDesc value() { return TypeDesc(BaseTypeFromC<T>::value); } };
 template<> struct TypeDescFromC<int> { static const constexpr TypeDesc value() { return TypeDesc::INT; } };
 template<> struct TypeDescFromC<float> { static const constexpr TypeDesc value() { return TypeDesc::FLOAT; } };
 template<size_t S> struct TypeDescFromC<char[S]> { static const constexpr TypeDesc value() { return TypeDesc::STRING; } };


### PR DESCRIPTION
Use `__builtin_bswap` when available. These seem to be 8-15x faster than
the std::swap-based implementation when multiple data values are
being swapped. (It's not dramatically better when swapping a single
value, either way it's pretty fast.)

Also add correctness unit test and benchmark for swap_endian.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
