### PR TITLE
Changes for recent OpenColorIO v2

### DIFF
--- a/src/build-scripts/build_opencolorio.bash
+++ b/src/build-scripts/build_opencolorio.bash
@@ -18,6 +18,7 @@ OPENCOLORIO_CXX_FLAGS=${OPENCOLORIO_CXX_FLAGS:="-Wno-unused-function -Wno-deprec
 # Just need libs:
 OPENCOLORIO_BUILDOPTS="-DOCIO_BUILD_APPS=OFF -DOCIO_BUILD_NUKE=OFF \
                        -DOCIO_BUILD_DOCS=OFF -DOCIO_BUILD_TESTS=OFF \
+                       -DOCIO_BUILD_GPU_TESTS=OFF \
                        -DOCIO_BUILD_PYTHON=OFF -DOCIO_BUILD_PYGLUE=OFF \
                        -DOCIO_BUILD_JAVA=OFF \
                        -DOCIO_BUILD_STATIC=${OCIO_BUILD_STATIC:=OFF}"

--- a/src/cmake/modules/FindOpenColorIO.cmake
+++ b/src/cmake/modules/FindOpenColorIO.cmake
@@ -36,8 +36,13 @@ find_library (OPENCOLORIO_LIBRARY
     DOC "The OCIO library")
 
 if (EXISTS "${OPENCOLORIO_INCLUDE_DIR}/OpenColorIO/OpenColorABI.h")
+    # Search twice, because this symbol changed between OCIO 1.x and 2.x
     file(STRINGS "${OPENCOLORIO_INCLUDE_DIR}/OpenColorIO/OpenColorABI.h" TMP
-         REGEX "^#define OCIO_VERSION[ \t].*$")
+         REGEX "^#define OCIO_VERSION_STR[ \t].*$")
+    if (NOT TMP)
+        file(STRINGS "${OPENCOLORIO_INCLUDE_DIR}/OpenColorIO/OpenColorABI.h" TMP
+             REGEX "^#define OCIO_VERSION[ \t].*$")
+    endif ()
     string (REGEX MATCHALL "[0-9]+[.0-9]+" OPENCOLORIO_VERSION ${TMP})
 endif ()
 


### PR DESCRIPTION
OCIO master recently renamed the symbol in its headers that we used to
detect its version, breaking OIIO's build against the current OCIO
top of tree master.

This change makes our FindOpenColorIO.cmake work with both old and new
OCIO.

Also, cut out other useless OCIO building (for our purposes) by having
our build_opencolorio.cmake disable buildig of GPU tests (which,
recently, became controlled by a different option than is used to
disable building all the other tests).

Signed-off-by: Larry Gritz <lg@larrygritz.com>

