### PR TITLE
Docs: Set up to try sphinx_tabs extension

### DIFF
--- a/src/doc/conf.py
+++ b/src/doc/conf.py
@@ -70,6 +70,7 @@ sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(__file__)), '../
 
 extensions = [
               'breathe',
+              'sphinx_tabs.tabs'
  ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/src/doc/imagebufalgo.rst
+++ b/src/doc/imagebufalgo.rst
@@ -33,15 +33,25 @@ Most ImageBufAlgo functions that produce image data come in two forms:
    error, the result image returned can have any error conditions checked with
    `has_error()` and `geterror()`.
    
-   .. code-block:: cpp
+   .. tabs::
    
-       // Method 1: Return an image result
-       ImageBuf fg ("fg.exr"), bg ("bg.exr");
-       ImageBuf dst = ImageBufAlgo::over (fg, bg);
-       if (dst.has_error())
-           std::cout << "error: " << dst.geterror() << "\n";
+      .. code-tab:: c++
    
+          // Method 1: Return an image result
+          ImageBuf dst = ImageBufAlgo::over (fg, bg);
+          if (dst.has_error())
+              std::cout << "error: " << dst.geterror() << "\n";
+
+      .. code-tab:: py
    
+          # Method 1: Return an image result
+          fg = ImageBuf("fg.exr")
+          bg = ImageBuf("bg.exr")
+          dst = ImageBufAlgo.over (fg, bg)
+          if dst.has_error() :
+              print("error:", dst.geterror())
+
+
 2. Pass a destination ImageBuf reference as the first parameter.
    
    The function is passed a *destination* ImageBuf where the results will
@@ -50,15 +60,26 @@ Most ImageBufAlgo functions that produce image data come in two forms:
    destination ImageBuf (the one that is being altered) will have an error
    message set.
    
-   .. code-block:: cpp
+   .. tabs::
    
-       // Method 2: Write into an existing image
-       ImageBuf fg ("fg.exr"), bg ("bg.exr");
-       ImageBuf dst;   // will be the output image
-       bool ok = ImageBufAlgo::over (dst, fg, bg);
-       if (! ok)
-           std::cout << "error: " << dst.geterror() << "\n";
-   
+      .. code-tab:: c++
+      
+          // Method 2: Write into an existing image
+          ImageBuf fg ("fg.exr"), bg ("bg.exr");
+          ImageBuf dst;   // will be the output image
+          bool ok = ImageBufAlgo::over (dst, fg, bg);
+          if (! ok)
+              std::cout << "error: " << dst.geterror() << "\n";
+
+      .. code-tab:: py
+          
+          # Method 2: Write into an existing image
+          fg = ImageBuf("fg.exr")
+          bg = ImageBuf("bg.exr")
+          dst = ImageBuf()  # will be the output image
+          ok = ImageBufAlgo.over (dst, fg, bg)
+          if not ok :
+              print("error:", dst.geterror())
 
 
 The first option (return an ImageBuf directly) is a more compact and

--- a/src/doc/index.rst
+++ b/src/doc/index.rst
@@ -90,4 +90,7 @@ OpenImageIO |version|
         https://breathe.readthedocs.io/en/latest/directives.html
     RST:
 
+    sphinx-tabs plugin for Sphinx:
+        https://pypi.org/project/sphinx-tabs/
+        https://sphinx-tabs.readthedocs.io/en/latest/#
 

--- a/src/doc/requirements.txt
+++ b/src/doc/requirements.txt
@@ -1,2 +1,3 @@
 sphinx >= 3.0
 breathe == 4.23.0
+sphinx-tabs


### PR DESCRIPTION
Inspired by OpenColorIO's beautiful docs, I'm adding the "sphinx_tabs"
extension to our docs, and testing them out in one little spot in
ImageBufAlgo to see if we like the effect.

Please look at https://openimageio.readthedocs.io/en/rtd/imagebufalgo.html
look at the first couple screenfuls to see the example of how the
tabs look. Opinions are welcome. Should we do this kind of thing more
extensively?

Signed-off-by: Larry Gritz <lg@larrygritz.com>
