### PR TITLE
Build against OpenEXR 3.0 + Imath 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
       - '**.rst'
   schedule:
     # Full nightly build
-    - cron: "0 4 * * *"
+    - cron: "0 8 * * *"
 
 
 jobs:
@@ -93,7 +93,8 @@ jobs:
 
   vfxplatform-2021:
     # Test what's anticipated to be VFX Platform 2021 -- mainly, that means
-    # gcc9 and C++17.
+    # gcc9 and C++17. This test currently uses the latest OpenEXR release
+    # 2.5, though eventually 2021 will feature OpenEXR 3.0 when complete.
     name: "Linux VFX Platform 2021: gcc9/C++17 py3.7 boost-1.70 exr-2.5"
     runs-on: ubuntu-18.04
     container:
@@ -118,6 +119,35 @@ jobs:
           name: ${{ github.job }}
           path: build/*/testsuite/*/*.*
 
+  vfxplatform-2021-exrmaster:
+    # Test what's anticipated to be VFX Platform 2021 -- mainly, that means
+    # gcc9 and C++17, and also the in-progress openexr/imath 3.0.
+    name: "Linux VFX Platform 2021: gcc9/C++17 py3.7 boost-1.70 exr-3.0"
+    runs-on: ubuntu-18.04
+    container:
+      image: aswf/ci-osl:2021
+    steps:
+      - uses: actions/checkout@v2
+      - name: all
+        env:
+          CXX: g++
+          CC: gcc
+          CMAKE_CXX_STANDARD: 17
+          PYTHON_VERSION: 3.7
+          USE_SIMD: avx2,f16c
+          OPENEXR_VERSION: master
+        run: |
+            sudo rm -rf /usr/local/include/OpenEXR
+            sudo rm -rf /usr/local/lib64/cmake/{IlmBase,OpenEXR}
+            source src/build-scripts/ci-startup.bash
+            source src/build-scripts/gh-installdeps-centos.bash
+            source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: build/*/testsuite/*/*.*
+
   linux-gcc7-cpp14-debug:
     # Test against gcc7, and also at the same time, do a Debug build.
     name: "Linux debug gcc7/C++14, sse4.2, exr2.4"
@@ -129,6 +159,7 @@ jobs:
           CXX: g++-7
           CMAKE_CXX_STANDARD: 14
           USE_SIMD: sse4.2
+          OPENEXR_VERSION: v2.4.0
           DEBUG: 1
         run: |
             source src/build-scripts/ci-startup.bash

--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -3,13 +3,16 @@
 include(CMakeFindDependencyMacro)
 
 # add here all the find_dependency() whenever switching to config based dependencies
-# e.g. if switching to Boost::Boost instead of using ${Boost_LIBRARY_DIRS} the add:
-# find_dependency(Boost @Boost_VERSION@)
+if (@OpenEXR_VERSION@ VERSION_GREATER_EQUAL 2.5)
+    find_dependency(OpenEXR @OpenEXR_VERSION@)
+    # N.B. Only do this for OpenEXR >= 2.5, difficult to rely on their
+    # exported configs before that.
+endif ()
 
 set_and_check (@PROJECT_NAME@_INCLUDE_DIR "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
 set_and_check (@PROJECT_NAME@_INCLUDES    "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
 set_and_check (@PROJECT_NAME@_LIB_DIR     "@CMAKE_INSTALL_FULL_LIBDIR@")
-set (@PROJECT_NAME@_PLUGIN_SEARCH_PATH         "@PLUGIN_SEARCH_PATH_NATIVE@")
+set (@PROJECT_NAME@_PLUGIN_SEARCH_PATH    "@PLUGIN_SEARCH_PATH_NATIVE@")
 
 #...logic to determine installedPrefix from the own location...
 #set (@PROJECT_NAME@_CONFIG_DIR  "${installedPrefix}/@CONFIG_INSTALL_DIR@")

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -88,10 +88,8 @@ checked_find_package (TIFF 3.9 REQUIRED
 # IlmBase & OpenEXR
 checked_find_package (OpenEXR 2.0 REQUIRED
                       RECOMMEND_MIN 2.2
-                      RECOMMEND_MIN_REASON "for DWA compression")
-# We use Imath so commonly, may as well include it everywhere.
-include_directories ("${OPENEXR_INCLUDES}" "${ILMBASE_INCLUDES}"
-                     "${ILMBASE_INCLUDES}/OpenEXR")
+                      RECOMMEND_MIN_REASON "for DWA compression"
+                      PRINT IMATH_INCLUDES)
 if (CMAKE_COMPILER_IS_CLANG AND OPENEXR_VERSION VERSION_LESS 2.3)
     # clang C++ >= 11 doesn't like 'register' keyword in old exr headers
     add_compile_options (-Wno-deprecated-register)

--- a/src/cmake/modules/FindOpenEXR.cmake
+++ b/src/cmake/modules/FindOpenEXR.cmake
@@ -1,14 +1,106 @@
-# Module to find OpenEXR.
+# Module to find OpenEXR and Imath.
 #
-# This module will set
+# I'm afraid this is a mess, due to needing to support a wide range of
+# OpenEXR versions.
+#
+# For OpenEXR & Imath 3.0, this will establish the following imported
+# targets:
+#
+#    Imath::Imath
+#    Imath::Half
+#    OpenEXR::OpenEXR
+#    OpenEXR::Iex
+#    OpenEXR::IlmThread
+#
+# For OpenEXR 2.4 & 2.5, it will establish the following imported targets:
+#
+#    IlmBase::Imath
+#    IlmBase::Half
+#    IlmBase::Iex
+#    IlmBase::IlmThread
+#    OpenEXR::IlmImf
+#
+# For all versions -- but for OpenEXR < 2.4 the only thing this sets --
+# are the following CMake variables:
+#
 #   OPENEXR_FOUND          true, if found
-#   OPENEXR_INCLUDES       directory where headers are found
+#   OPENEXR_INCLUDES       directory where OpenEXR headers are found
 #   OPENEXR_LIBRARIES      libraries for OpenEXR + IlmBase
-#   ILMBASE_LIBRARIES      libraries just IlmBase
 #   OPENEXR_VERSION        OpenEXR version (accurate for >= 2.0.0,
 #                              otherwise will just guess 1.6.1)
+#   IMATH_INCLUDES         directory where Imath headers are found
+#   ILMBASE_INCLUDES       directory where IlmBase headers are found
+#   ILMBASE_LIBRARIES      libraries just IlmBase
 #
 #
+
+# First, try to fine just the right config files
+find_package(Imath CONFIG)
+if (NOT TARGET Imath::Imath)
+    # Couldn't find Imath::Imath, maybe it's older and has IlmBase?
+    find_package(IlmBase CONFIG)
+endif ()
+find_package(OpenEXR CONFIG)
+
+if (TARGET OpenEXR::OpenEXR AND TARGET Imath::Imath)
+    # OpenEXR 3.x if both of these targets are found
+    if (NOT OpenEXR_FIND_QUIETLY)
+        message (STATUS "Found CONFIG for OpenEXR 3 (OPENEXR_VERSION=${OpenEXR_VERSION})")
+    endif ()
+
+    # Mimic old style variables
+    set (OPENEXR_VERSION ${OpenEXR_VERSION})
+    get_target_property(IMATH_INCLUDES Imath::Imath INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(ILMBASE_INCLUDES Imath::Imath INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(ILMBASE_IMATH_LIBRARY Imath::Imath INTERFACE_LINK_LIBRARIES)
+    get_target_property(IMATH_LIBRARY Imath::Imath INTERFACE_LINK_LIBRARIES)
+    get_target_property(OPENEXR_IEX_LIBRARY OpenEXR::Iex INTERFACE_LINK_LIBRARIES)
+    get_target_property(OPENEXR_ILMTHREAD_LIBRARY OpenEXR::IlmThread INTERFACE_LINK_LIBRARIES)
+    set (ILMBASE_LIBRARIES ${ILMBASE_IMATH_LIBRARY})
+    set (ILMBASE_FOUND true)
+
+    get_target_property(OPENEXR_INCLUDES OpenEXR::OpenEXR INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(OPENEXR_ILMIMF_LIBRARY OpenEXR::OpenEXR INTERFACE_LINK_LIBRARIES)
+    set (OPENEXR_LIBRARIES ${OPENEXR_ILMIMF_LIBRARY} ${OPENEXR_IEX_LIBRARY} ${OPENEXR_ILMTHREAD_LIBRARY} ${ILMBASE_LIBRARIES})
+    set (OPENEXR_FOUND true)
+
+    # Link with pthreads if required
+    find_package (Threads)
+    if (CMAKE_USE_PTHREADS_INIT)
+        list (APPEND ILMBASE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+    endif ()
+
+elseif (TARGET OpenEXR::IlmImf AND TARGET IlmBase::Imath AND OPENEXR_VERSION VERSION_GREATER_EQUAL 2.4)
+    # OpenEXR 2.4 or 2.5 with exported config
+    if (NOT OpenEXR_FIND_QUIETLY)
+        message (STATUS "Found CONFIG for OpenEXR 2 (OPENEXR_VERSION=${OpenEXR_VERSION})")
+    endif ()
+
+    # Mimic old style variables
+    get_target_property(ILMBASE_INCLUDES IlmBase::IlmBaseConfig INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(IMATH_INCLUDES IlmBase::IlmBaseConfig INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(ILMBASE_Imath_LIBRARY IlmBase::Imath INTERFACE_LINK_LIBRARIES)
+    get_target_property(ILMBASE_IMATH_LIBRARY IlmBase::Imath INTERFACE_LINK_LIBRARIES)
+    get_target_property(ILMBASE_HALF_LIBRARY IlmBase::Half INTERFACE_LINK_LIBRARIES)
+    get_target_property(OPENEXR_IEX_LIBRARY IlmBase::Iex INTERFACE_LINK_LIBRARIES)
+    get_target_property(OPENEXR_ILMTHREAD_LIBRARY IlmBase::IlmThread INTERFACE_LINK_LIBRARIES)
+    set (ILMBASE_LIBRARIES ${ILMBASE_IMATH_LIBRARY} ${ILMBASE_HALF_LIBRARY} ${OPENEXR_IEX_LIBRARY} ${OPENEXR_ILMTHREAD_LIBRARY})
+    set (ILMBASE_FOUND true)
+
+    get_target_property(OPENEXR_INCLUDES OpenEXR::IlmImfConfig INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(OPENEXR_ILMIMF_LIBRARY OpenEXR::IlmImf INTERFACE_LINK_LIBRARIES)
+    set (OPENEXR_LIBRARIES ${OPENEXR_ILMIMF_LIBRARY} ${ILMBASE_LIBRARIES})
+    set (OPENEXR_FOUND true)
+
+    # Link with pthreads if required
+    find_package (Threads)
+    if (CMAKE_USE_PTHREADS_INIT)
+        list (APPEND ILMBASE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+    endif ()
+
+else ()
+    # OpenEXR 2.x older versions without a config or whose configs we don't
+    # trust.
 
 # Other standard issue macros
 include (FindPackageHandleStandardArgs)
@@ -131,17 +223,20 @@ find_package_handle_standard_args (OpenEXR
     REQUIRED_VARS ILMBASE_INCLUDE_PATH OPENEXR_INCLUDE_PATH
                   OPENEXR_IMATH_LIBRARY OPENEXR_ILMIMF_LIBRARY
                   OPENEXR_IEX_LIBRARY OPENEXR_HALF_LIBRARY
-    VERSION_VAR   OPENEXR_VERSION
     )
 
 if (OPENEXR_FOUND)
+    set (OpenEXR_VERSION ${OPENEXR_VERSION})
     set (ILMBASE_FOUND TRUE)
     set (ILMBASE_INCLUDES ${ILMBASE_INCLUDE_PATH})
+    set (IMATH_INCLUDES ${ILMBASE_INCLUDE_PATH})
     set (OPENEXR_INCLUDES ${OPENEXR_INCLUDE_PATH})
     set (ILMBASE_INCLUDE_DIR ${ILMBASE_INCLUDE_PATH})
+    set (IMATH_INCLUDE_DIR ${ILMBASE_INCLUDE_PATH})
     set (OPENEXR_INCLUDE_DIR ${OPENEXR_INCLUDE_PATH})
     set (ILMBASE_LIBRARIES ${OPENEXR_IMATH_LIBRARY} ${OPENEXR_IEX_LIBRARY} ${OPENEXR_HALF_LIBRARY} ${OPENEXR_ILMTHREAD_LIBRARY} ${ILMBASE_PTHREADS} CACHE STRING "The libraries needed to use IlmBase")
     set (OPENEXR_LIBRARIES ${OPENEXR_ILMIMF_LIBRARY} ${ILMBASE_LIBRARIES} ${ZLIB_LIBRARIES} CACHE STRING "The libraries needed to use OpenEXR")
+    set (FINDOPENEXR_FALLBACK TRUE)
 endif ()
 
 mark_as_advanced(
@@ -153,3 +248,5 @@ mark_as_advanced(
 
 # Restore the original CMAKE_FIND_LIBRARY_SUFFIXES
 set (CMAKE_FIND_LIBRARY_SUFFIXES ${_openexr_orig_suffixes})
+
+endif ()

--- a/src/dpx.imageio/CMakeLists.txt
+++ b/src/dpx.imageio/CMakeLists.txt
@@ -6,4 +6,4 @@ add_oiio_plugin (dpxinput.cpp dpxoutput.cpp
   libdpx/DPX.cpp libdpx/OutStream.cpp libdpx/RunLengthEncoding.cpp
   libdpx/Codec.cpp libdpx/Reader.cpp libdpx/Writer.cpp libdpx/DPXHeader.cpp
   libdpx/ElementReadStream.cpp libdpx/InStream.cpp libdpx/DPXColorConverter.cpp
-  LINK_LIBRARIES ${OPENEXR_LIBRARIES})
+  )

--- a/src/field3d.imageio/field3d_pvt.h
+++ b/src/field3d.imageio/field3d_pvt.h
@@ -5,8 +5,13 @@
 
 #pragma once
 
-#include <OpenEXR/ImathBox.h>
-#include <OpenEXR/ImathVec.h>
+#include <OpenImageIO/Imath.h>
+
+#if OIIO_USING_IMATH >= 3
+#    include <Imath/ImathBox.h>
+#else
+#    include <OpenEXR/ImathBox.h>
+#endif
 
 #include <Field3D/DenseField.h>
 #include <Field3D/Field3DFile.h>

--- a/src/field3d.imageio/field3dinput.cpp
+++ b/src/field3d.imageio/field3dinput.cpp
@@ -11,8 +11,6 @@
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/thread.h>
 
-#include <OpenEXR/ImathVec.h>
-
 #include "field3d_pvt.h"
 using namespace OIIO_NAMESPACE::f3dpvt;
 

--- a/src/include/OpenImageIO/Imath.h
+++ b/src/include/OpenImageIO/Imath.h
@@ -1,0 +1,30 @@
+// Copyright 2008-present Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio/
+
+// clang-format off
+
+#pragma once
+
+
+// Determine which Imath we're dealing with and include the appropriate
+// headers.
+
+#include <OpenEXR/OpenEXRConfig.h>
+#define OIIO_OPENEXR_VERSION ((10000*OPENEXR_VERSION_MAJOR) + \
+                              (100*OPENEXR_VERSION_MINOR) + \
+                              OPENEXR_VERSION_PATCH)
+
+#if OIIO_OPENEXR_VERSION >= 20599 /* 2.5.99: pre-3.0 */
+#   define OIIO_USING_IMATH 3
+#   include <Imath/ImathColor.h>
+#   include <Imath/ImathMatrix.h>
+#   include <Imath/ImathVec.h>
+#   include <Imath/half.h>
+#else
+#   define OIIO_USING_IMATH 2
+#   include <OpenEXR/ImathColor.h>
+#   include <OpenEXR/ImathMatrix.h>
+#   include <OpenEXR/ImathVec.h>
+#   include <OpenEXR/half.h>
+#endif

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -12,8 +12,6 @@
 #include <OpenImageIO/typedesc.h>
 #include <OpenImageIO/ustring.h>
 
-#include <OpenEXR/ImathMatrix.h> /* because we need M44f */
-
 
 OIIO_NAMESPACE_BEGIN
 

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -37,6 +37,7 @@
 #include <typeinfo>
 #include <type_traits>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/span.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/oiioversion.h>

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -20,8 +20,6 @@
 #include <OpenImageIO/parallel.h>
 #include <OpenImageIO/span.h>
 
-#include <OpenEXR/ImathMatrix.h>       /* because we need M33f */
-
 #include <limits>
 
 #if !defined(__OPENCV_CORE_TYPES_H__) && !defined(OPENCV_CORE_TYPES_H)

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -31,9 +31,7 @@
 #include <algorithm>
 #include <cstring>
 
-#include <OpenEXR/ImathVec.h>
-#include <OpenEXR/ImathMatrix.h>
-
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/platform.h>
 

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -15,8 +15,6 @@
 #include <OpenImageIO/ustring.h>
 #include <OpenImageIO/varyingref.h>
 
-#include <OpenEXR/ImathVec.h> /* because we need V3f */
-
 
 // Define symbols that let client applications determine if newly added
 // features are supported.

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -28,8 +28,6 @@
 #include <QStatusBar>
 #include <QTimer>
 
-#include <OpenEXR/ImathFun.h>
-
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/strutil.h>
@@ -1825,10 +1823,10 @@ ImageViewer::zoomIn()
     float xoffset      = xc - xm;
     float yoffset      = yc - ym;
     float maxzoomratio = std::max(oldzoom / newzoom, newzoom / oldzoom);
-    int nsteps = (int)Imath::clamp(20 * (maxzoomratio - 1), 2.0f, 10.0f);
+    int nsteps         = (int)OIIO::clamp(20 * (maxzoomratio - 1), 2.0f, 10.0f);
     for (int i = 1; i <= nsteps; ++i) {
         float a         = (float)i / (float)nsteps;  // Interpolation amount
-        float z         = Imath::lerp(oldzoom, newzoom, a);
+        float z         = OIIO::lerp(oldzoom, newzoom, a);
         float zoomratio = z / oldzoom;
         view(xm + xoffset / zoomratio, ym + yoffset / zoomratio, z, false);
         if (i != nsteps) {
@@ -1860,10 +1858,10 @@ ImageViewer::zoomOut()
     float xoffset      = xcpel - xmpel;
     float yoffset      = ycpel - ympel;
     float maxzoomratio = std::max(oldzoom / newzoom, newzoom / oldzoom);
-    int nsteps = (int)Imath::clamp(20 * (maxzoomratio - 1), 2.0f, 10.0f);
+    int nsteps         = (int)OIIO::clamp(20 * (maxzoomratio - 1), 2.0f, 10.0f);
     for (int i = 1; i <= nsteps; ++i) {
         float a         = (float)i / (float)nsteps;  // Interpolation amount
-        float z         = Imath::lerp(oldzoom, newzoom, a);
+        float z         = OIIO::lerp(oldzoom, newzoom, a);
         float zoomratio = z / oldzoom;
         view(xmpel + xoffset / zoomratio, ympel + yoffset / zoomratio, z,
              false);
@@ -2055,7 +2053,7 @@ static inline void
 calc_subimage_from_zoom(const IvImage* img, int& subimage, float& zoom,
                         float& xcenter, float& ycenter)
 {
-    int rel_subimage = Imath::trunc(std::log2(1.0f / zoom));
+    int rel_subimage = std::trunc(std::log2(1.0f / zoom));
     subimage         = clamp<int>(img->subimage() + rel_subimage, 0,
                           img->nsubimages() - 1);
     if (!(img->subimage() == 0 && zoom > 1)
@@ -2081,14 +2079,14 @@ ImageViewer::view(float xcenter, float ycenter, float newzoom, bool smooth,
     float oldxcenter, oldycenter;
     glwin->get_center(oldxcenter, oldycenter);
     float zoomratio = std::max(oldzoom / newzoom, newzoom / oldzoom);
-    int nsteps      = (int)Imath::clamp(20 * (zoomratio - 1), 2.0f, 10.0f);
+    int nsteps      = (int)OIIO::clamp(20 * (zoomratio - 1), 2.0f, 10.0f);
     if (!smooth || !redraw)
         nsteps = 1;
     for (int i = 1; i <= nsteps; ++i) {
         float a  = (float)i / (float)nsteps;  // Interpolation amount
-        float xc = Imath::lerp(oldxcenter, xcenter, a);
-        float yc = Imath::lerp(oldycenter, ycenter, a);
-        m_zoom   = Imath::lerp(oldzoom, newzoom, a);
+        float xc = OIIO::lerp(oldxcenter, xcenter, a);
+        float yc = OIIO::lerp(oldycenter, ycenter, a);
+        m_zoom   = OIIO::lerp(oldzoom, newzoom, a);
 
         glwin->view(xc, yc, m_zoom, redraw);  // Triggers redraw automatically
         if (i != nsteps) {

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -7,9 +7,6 @@
 
 #include <iostream>
 
-#include <OpenEXR/ImathFun.h>
-#include <OpenEXR/half.h>
-
 #include <QComboBox>
 #include <QLabel>
 #include <QMouseEvent>
@@ -1075,15 +1072,15 @@ IvGL::clamp_view_to_window()
 
     // Don't let us scroll off the edges
     if (zoomedwidth >= w) {
-        m_centerx = Imath::clamp(m_centerx, xmin + 0.5f * w / m_zoom,
-                                 xmax - 0.5f * w / m_zoom);
+        m_centerx = OIIO::clamp(m_centerx, xmin + 0.5f * w / m_zoom,
+                                xmax - 0.5f * w / m_zoom);
     } else {
         m_centerx = img->oriented_full_x() + img->oriented_full_width() / 2;
     }
 
     if (zoomedheight >= h) {
-        m_centery = Imath::clamp(m_centery, ymin + 0.5f * h / m_zoom,
-                                 ymax - 0.5f * h / m_zoom);
+        m_centery = OIIO::clamp(m_centery, ymin + 0.5f * h / m_zoom,
+                                ymax - 0.5f * h / m_zoom);
     } else {
         m_centery = img->oriented_full_y() + img->oriented_full_height() / 2;
     }
@@ -1180,7 +1177,7 @@ IvGL::mouseMoveEvent(QMouseEvent* event)
         float dx = (pos.x() - m_mousex);
         float dy = (pos.y() - m_mousey);
         float z  = m_viewer.zoom() * (1.0 + 0.005 * (dx + dy));
-        z        = Imath::clamp(z, 0.01f, 256.0f);
+        z        = OIIO::clamp(z, 0.01f, 256.0f);
         m_viewer.zoom(z);
         m_viewer.fitImageToWindowAct->setChecked(false);
     } else if (do_wipe) {
@@ -1248,8 +1245,8 @@ IvGL::get_focus_image_pixel(int& x, int& y)
     float normx = (float)(m_mousex + 0.5f) / w;
     float normy = (float)(m_mousey + 0.5f) / h;
     // imgx,imgy are the position of the mouse, in pixel coordinates
-    float imgx = Imath::lerp(left, right, normx);
-    float imgy = Imath::lerp(top, bottom, normy);
+    float imgx = OIIO::lerp(left, right, normx);
+    float imgy = OIIO::lerp(top, bottom, normy);
     // So finally x,y are the coordinates of the image pixel (on [0,res-1])
     // underneath the mouse cursor.
     //FIXME: Shouldn't this take image rotation into account?

--- a/src/iv/ivimage.cpp
+++ b/src/iv/ivimage.cpp
@@ -5,8 +5,6 @@
 
 #include <iostream>
 
-#include <OpenEXR/half.h>
-
 #include "imageviewer.h"
 #include <OpenImageIO/strutil.h>
 

--- a/src/libOpenImageIO-C/CMakeLists.txt
+++ b/src/libOpenImageIO-C/CMakeLists.txt
@@ -19,7 +19,10 @@ add_library(OpenImageIO-C SHARED
     ${COIIO_HEADERS}
 )
 
-target_link_libraries(OpenImageIO-C PUBLIC OpenImageIO)
+target_link_libraries(OpenImageIO-C
+                      PRIVATE OpenImageIO)
+target_include_directories (OpenImageIO-C
+                            PUBLIC ${CMAKE_INSTALL_FULL_INCLUDEDIR})
 set_target_properties(OpenImageIO-C
     PROPERTIES
         VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -135,8 +135,18 @@ endif ()
 
 target_link_libraries (OpenImageIO
         PUBLIC
-            ${ILMBASE_LIBRARIES}
-            ${OPENEXR_LIBRARIES}
+            # For OpenEXR/Imath 3.x:
+            $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
+            $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
+            $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
+            # For OpenEXR >= 2.4/2.5 with reliable exported targets
+            $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
+            $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
+            $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
+            $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
+            $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
+            # These two are for OpenEXR <= 2.3:
+            ${OPENEXR_LIBRARIES} ${ILMBASE_LIBRARIES}
             ${OpenCV_LIBRARIES}
             ${GCC_ATOMIC_LIBRARIES}
         PRIVATE

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -9,8 +9,6 @@
 
 #include <boost/container/flat_map.hpp>
 
-#include <OpenEXR/half.h>
-
 #include <OpenImageIO/color.h>
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/imagebufalgo_util.h>

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -7,8 +7,6 @@
 #include <cstdlib>
 #include <numeric>
 
-#include <OpenEXR/half.h>
-
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/fmath.h>

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -6,8 +6,6 @@
 #include <cstdlib>
 #include <sstream>
 
-#include <OpenEXR/half.h>
-
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -6,9 +6,6 @@
 #include <iostream>
 #include <memory>
 
-#include <OpenEXR/ImathFun.h>
-#include <OpenEXR/half.h>
-
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/fmath.h>

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -5,8 +5,6 @@
 #include <cmath>
 #include <memory>
 
-#include <OpenEXR/half.h>
-
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filter.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagebufalgo_addsub.cpp
+++ b/src/libOpenImageIO/imagebufalgo_addsub.cpp
@@ -6,8 +6,6 @@
 /// Implementation of ImageBufAlgo algorithms that do math on
 /// single pixels at a time.
 
-#include <OpenEXR/half.h>
-
 #include <cmath>
 #include <iostream>
 #include <limits>

--- a/src/libOpenImageIO/imagebufalgo_channels.cpp
+++ b/src/libOpenImageIO/imagebufalgo_channels.cpp
@@ -7,8 +7,6 @@
 /// or channels between images without altering their values.
 
 
-#include <OpenEXR/half.h>
-
 #include <cmath>
 #include <iostream>
 

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -6,8 +6,6 @@
 /// Implementation of ImageBufAlgo algorithms that analyze or compare
 /// images.
 
-#include <OpenEXR/half.h>
-
 #include <cmath>
 #include <iostream>
 #include <limits>

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -2,13 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
-/// \file
-/// Implementation of ImageBufAlgo algorithms that merely move pixels
-/// or channels between images without altering their values.
-
-
-#include <OpenEXR/half.h>
-
 #include <cmath>
 #include <iostream>
 

--- a/src/libOpenImageIO/imagebufalgo_deep.cpp
+++ b/src/libOpenImageIO/imagebufalgo_deep.cpp
@@ -3,8 +3,6 @@
 // https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
 
-#include <OpenEXR/half.h>
-
 #include <cmath>
 #include <iostream>
 #include <stdexcept>

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
-#include <OpenEXR/half.h>
-
 #include <algorithm>
 #include <cmath>
 #include <limits>

--- a/src/libOpenImageIO/imagebufalgo_mad.cpp
+++ b/src/libOpenImageIO/imagebufalgo_mad.cpp
@@ -2,12 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
-/// \file
-/// Implementation of ImageBufAlgo algorithms that do math on
-/// single pixels at a time.
-
-#include <OpenEXR/half.h>
-
 #include <cmath>
 #include <iostream>
 #include <limits>

--- a/src/libOpenImageIO/imagebufalgo_muldiv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_muldiv.cpp
@@ -6,8 +6,6 @@
 /// Implementation of ImageBufAlgo algorithms that do math on
 /// single pixels at a time.
 
-#include <OpenEXR/half.h>
-
 #include <cmath>
 #include <iostream>
 #include <limits>

--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -30,8 +30,6 @@
 #include <map>
 #include <vector>
 
-#include <OpenEXR/half.h>
-
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>

--- a/src/libOpenImageIO/imagebufalgo_orient.cpp
+++ b/src/libOpenImageIO/imagebufalgo_orient.cpp
@@ -2,13 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
-/// \file
-/// Implementation of ImageBufAlgo algorithms that merely move pixels
-/// or channels between images without altering their values.
-
-
-#include <OpenEXR/half.h>
-
 #include <cmath>
 #include <iostream>
 

--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -6,8 +6,6 @@
 /// Implementation of ImageBufAlgo algorithms that do math on
 /// single pixels at a time.
 
-#include <OpenEXR/half.h>
-
 #include <cmath>
 #include <iostream>
 #include <limits>

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -6,10 +6,6 @@
 /// ImageBufAlgo functions for filtered transformations
 
 
-#include <OpenEXR/ImathBox.h>
-#include <OpenEXR/ImathMatrix.h>
-#include <OpenEXR/half.h>
-
 #include <cmath>
 #include <memory>
 
@@ -20,6 +16,12 @@
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/imagebufalgo_util.h>
 #include <OpenImageIO/thread.h>
+
+#if OIIO_USING_IMATH >= 3
+#    include <Imath/ImathBox.h>
+#else
+#    include <OpenEXR/ImathBox.h>
+#endif
 
 OIIO_NAMESPACE_BEGIN
 

--- a/src/libOpenImageIO/imagebufalgo_yee.cpp
+++ b/src/libOpenImageIO/imagebufalgo_yee.cpp
@@ -9,15 +9,13 @@
 #include <cmath>
 #include <iostream>
 
-#include <OpenEXR/ImathColor.h>
-#include <OpenEXR/ImathFun.h>
-using Imath::Color3f;
-
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/imagebufalgo_util.h>
+using Imath::Color3f;
+
 
 
 template<class T>
@@ -297,7 +295,7 @@ ImageBufAlgo::compare_Yee(const ImageBuf& img0, const ImageBuf& img1,
             float factor = 0;
             for (int i = 0; i < PYRAMID_MAX_LEVELS - 2; i++)
                 factor += contrast[i] * F_freq[i] * F_mask[i] / sum_contrast;
-            factor      = Imath::clamp(factor, 1.0f, 10.0f);
+            factor      = OIIO::clamp(factor, 1.0f, 10.0f);
             float delta = fabsf(la.value(x, y, 0) - lb.value(x, y, 0));
             bool pass   = true;
             // pure luminance test

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -5,9 +5,6 @@
 #include <cstdio>
 #include <cstdlib>
 
-#include <OpenEXR/ImathFun.h>
-#include <OpenEXR/half.h>
-
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/hash.h>
@@ -295,7 +292,7 @@ attribute(string_view name, TypeDesc type, const void* val)
         return optparser(gos, *(const char**)val);
     }
     if (name == "threads" && type == TypeInt) {
-        int ot = Imath::clamp(*(const int*)val, 0, maxthreads);
+        int ot = OIIO::clamp(*(const int*)val, 0, maxthreads);
         if (ot == 0)
             ot = threads_default();
         oiio_threads = ot;
@@ -312,7 +309,7 @@ attribute(string_view name, TypeDesc type, const void* val)
         return true;
     }
     if (name == "exr_threads" && type == TypeInt) {
-        oiio_exr_threads = Imath::clamp(*(const int*)val, -1, maxthreads);
+        oiio_exr_threads = OIIO::clamp(*(const int*)val, -1, maxthreads);
         return true;
     }
     if (name == "tiff:half" && type == TypeInt) {
@@ -458,7 +455,7 @@ inline long long
 quantize(float value, long long quant_min, long long quant_max)
 {
     value = value * quant_max;
-    return Imath::clamp((long long)(value + 0.5f), quant_min, quant_max);
+    return OIIO::clamp((long long)(value + 0.5f), quant_min, quant_max);
 }
 
 namespace {

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -11,9 +11,6 @@
 #include <memory>
 #include <sstream>
 
-#include <OpenEXR/ImathMatrix.h>
-#include <OpenEXR/half.h>
-
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/color.h>
 #include <OpenImageIO/dassert.h>

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -8,8 +8,6 @@
 #include <sstream>
 #include <string>
 
-#include <OpenEXR/ImathMatrix.h>
-
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filter.h>
 #include <OpenImageIO/fmath.h>

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -9,8 +9,6 @@
 #include <string>
 #include <vector>
 
-#include <OpenEXR/ImathMatrix.h>
-
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/fmath.h>

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -15,8 +15,6 @@
 #include <boost/container/flat_map.hpp>
 #include <boost/thread/tss.hpp>
 
-#include <OpenEXR/half.h>
-
 #include <OpenImageIO/export.h>
 #include <OpenImageIO/hash.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -8,8 +8,6 @@
 #include <sstream>
 #include <string>
 
-#include <OpenEXR/ImathMatrix.h>
-
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imagecache.h>

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -11,9 +11,6 @@
 
 #include <boost/random.hpp>
 
-#include <OpenEXR/ImathMatrix.h>
-#include <OpenEXR/half.h>
-
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filter.h>
 #include <OpenImageIO/fmath.h>

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -13,6 +13,15 @@ target_include_directories (OpenImageIO_Util
         )
 target_link_libraries (OpenImageIO_Util
         PUBLIC
+            # For OpenEXR/Imath 3.x:
+            $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
+            $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
+            # For OpenEXR >= 2.4/2.5 with reliable exported targets
+            $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
+            $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
+            $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
+            $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
+            # For OpenEXR <= 2.3:
             ${ILMBASE_LIBRARIES}
             ${GCC_ATOMIC_LIBRARIES}
         PRIVATE

--- a/src/libutil/argparse_test.cpp
+++ b/src/libutil/argparse_test.cpp
@@ -4,8 +4,7 @@
 
 #include <vector>
 
-#include <OpenEXR/ImathColor.h>
-
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/unittest.h>

--- a/src/libutil/filesystem_test.cpp
+++ b/src/libutil/filesystem_test.cpp
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <sstream>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/platform.h>

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -4,11 +4,9 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <iostream>
 #include <vector>
-
-#include <OpenEXR/ImathFun.h>
-#include <OpenEXR/half.h>
 
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/benchmark.h>
@@ -18,6 +16,12 @@
 #include <OpenImageIO/timer.h>
 #include <OpenImageIO/typedesc.h>
 #include <OpenImageIO/unittest.h>
+
+#if OIIO_USING_IMATH >= 3
+#    include <Imath/ImathFun.h>
+#else
+#    include <OpenEXR/ImathFun.h>
+#endif
 
 using namespace OIIO;
 

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -6,8 +6,7 @@
 #include <cstdio>
 #include <cstdlib>
 
-#include <OpenEXR/half.h>
-
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/paramlist.h>
 #include <OpenImageIO/ustring.h>

--- a/src/libutil/paramlist_test.cpp
+++ b/src/libutil/paramlist_test.cpp
@@ -5,10 +5,7 @@
 
 #include <limits>
 
-#include <OpenEXR/ImathColor.h>
-#include <OpenEXR/ImathMatrix.h>
-#include <OpenEXR/ImathVec.h>
-
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/paramlist.h>
 #include <OpenImageIO/unittest.h>
 

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -7,10 +7,6 @@
 #include <sstream>
 #include <type_traits>
 
-#include <OpenEXR/ImathMatrix.h>
-#include <OpenEXR/ImathVec.h>
-#include <OpenEXR/half.h>
-
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/benchmark.h>
 #include <OpenImageIO/fmath.h>

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -5,6 +5,7 @@
 
 #include <cstdio>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/benchmark.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/unittest.h>

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -7,8 +7,7 @@
 #include <cstdlib>
 #include <string>
 
-#include <OpenEXR/half.h>
-
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/typedesc.h>

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -10,8 +10,6 @@
 #include <limits>
 #include <sstream>
 
-#include <OpenEXR/ImathMatrix.h>
-
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/color.h>
 #include <OpenImageIO/dassert.h>

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -17,7 +17,6 @@
 #include <vector>
 
 #include <OpenEXR/ImfTimeCode.h>
-#include <OpenEXR/half.h>
 
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/color.h>

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -14,9 +14,6 @@
 #    include <io.h>
 #endif
 
-#include <OpenEXR/ImathVec.h>
-#include <OpenEXR/half.h>
-
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/hash.h>

--- a/src/openexr.imageio/CMakeLists.txt
+++ b/src/openexr.imageio/CMakeLists.txt
@@ -3,5 +3,6 @@
 # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
 add_oiio_plugin (exrinput.cpp exroutput.cpp
+                 INCLUDE_DIRS ${OPENEXR_INCLUDES} ${IMATH_INCLUDE_DIR}/OpenEXR
                  LINK_LIBRARIES ${OPENEXR_LIBRARIES})
 

--- a/src/openvdb.imageio/openvdbinput.cpp
+++ b/src/openvdb.imageio/openvdbinput.cpp
@@ -2,11 +2,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/imageio.h>
-
-#include <OpenEXR/ImathMatrix.h>
 
 #if OIIO_GNUC_VERSION >= 60000
 #    pragma GCC diagnostic ignored "-Wstrict-overflow"

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -7,8 +7,6 @@
 #include <png.h>
 #include <zlib.h>
 
-#include <OpenEXR/ImathColor.h>
-
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/fmath.h>

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -6,8 +6,6 @@
 #include <cstdio>
 #include <cstdlib>
 
-#include <OpenEXR/ImathColor.h>
-
 #include "png_pvt.h"
 
 OIIO_PLUGIN_NAMESPACE_BEGIN

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -24,8 +24,6 @@
 // Avoid a compiler warning from a duplication in tiffconf.h/pyconfig.h
 #undef SIZEOF_LONG
 
-#include <OpenEXR/half.h>
-
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagecache.h>

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -11,10 +11,6 @@
 #include <iostream>
 #include <iterator>
 
-#include <OpenEXR/ImathMatrix.h>
-#include <OpenEXR/ImathVec.h>
-#include <OpenEXR/half.h>
-
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/benchmark.h>
 #include <OpenImageIO/filesystem.h>

--- a/testsuite/openexr-damaged/ref/out-exr3.0-clang-ptex.txt
+++ b/testsuite/openexr-damaged/ref/out-exr3.0-clang-ptex.txt
@@ -1,0 +1,332 @@
+tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr :   64 x   64, 2 channel, deep half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
+Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr". The x subsampling factor for the "H" channel is not 1.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr : 12688 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr". Unexpected data block length.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr :   64 x   64, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr". Error in Huffman-encoded data (invalid code table size).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr": Subsampled channels are not supported (channel "" has sampling 32,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr". Unexpected data block length.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr :   64 x   64, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr". The x subsampling factor for the "" channel is not 1.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr :  480 x  480, 4 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr :  517 x  517, 3 channel, half openexr (+mipmap)
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr". Data decoding (rle) failed.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr :   64 x   64, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr.exr : 1023 x 49409, 1 channel, uint openexr
+
+tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr.exr : 1023 x 49409, 1 channel, uint openexr
+
+tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr :    1 x  257, 3 channel, half/uint/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr :  636 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr :  480 x  480, 4 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr". Invalid tile size in image header.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr". The x subsampling factor for the "B" channel is not 1.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr :    3 x  257, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr.exr : 30608 x  300, 3 channel, half openexr
+
+tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr". The x subsampling factor for the "B" channel is not 1.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr :   64 x   64, 2 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr :   64 x   64, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr". Scan line 32 is missing.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr :  480 x  480, 4 channel, half/half/uint/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr": Subsampled channels are not supported (channel "" has sampling 16,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
+
+tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr :  400 x  300, 3 channel, float/half/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr". Error decoding Huffman table (Run beyond end of table).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
+
+tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr :   64 x   64, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
+
+tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
+
+tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr :   64 x   64, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
+
+tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr :  400 x  300, 3 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr". Unexpected data block y coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
+Subsampled channels are not supported (channel "RY" has sampling 2,2).
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
+
+tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr :  874 x  493, 1 channel, half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr". Unexpected tile x coordinate.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
+
+tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr :   64 x   64, 5 channel, half/half/half/float/half openexr
+oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
+
+PtexReader error: read failed (EOF) PtexFile: tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
+
+PtexReader error: read failed (EOF) PtexFile: tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Files must contain at least one header
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr". Invalid size field in header attribute
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
+
+oiiotool ERROR: read : "tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr": No channels found
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr". Maximum number of tiles exceeded
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr". Unexpected end of file.
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
+
+oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr". unsupported header type to get chunk offset table size
+Full command line was:
+> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
+


### PR DESCRIPTION
As OpenEXR works toward their 3.0 release, which includes splitting
Imath (the vector, matrix, math, and 'half' stuff) out into a separate
repo, their top of tree master finally breaks our "bleeding edge"
build.

This is a little tricky, because now our support of this dependency is
attempting to span 3 eras: 3.0 with the full split of openexr from
imath, recent openexr+ilmbase 2.x that supplies reliable exported
cmake configs, and older 2.x that predates cmake configs. Eventually
we'll phase out older versions and clean up.

Fixes in this patch generally include:

* Add a new CI test of VFX2021 + openexr/imath master. (This will go away
  when 3.0 is released and that's what we use for the main 2021 case.)

* For new enough versions of OpenEXR, use the exported config file and
  targets, rather than the old style OPENEXR_LIBRARIES style variables.
  We have kind of a mixed idiom use because we're still supporting older
  versions that predate use of the config files.

* Deal with the fact that the Imath headers now live inside
  `<Imath/ImathBlah.h>` rather than `<OpenEXR/ImathBlah.h>`. But of
  course, you need to start including things just to find out the
  version. It's tricky.  The logic is to look at
  `<OpenEXR/OpenEXRConfig.h>` to determine the version we're dealing
  with, then include Imath stuff from one or the other depending on
  what we found. I rearranged quite a few includes to ensure that all
  this logic only happens in a couple spots and the rest gets included
  transitively. As it turns out, quite a few of our `#include`s of
  Imath headers were redundant.

* OpenImageIO-C depended on OpenImageIO publicly, but actually it
  should depend on OpenImageIO privately, but export its include
  needs.

* OIIO's exported config needs to look for OpenEXR.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
