### PR TITLE
Unbreak CI on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Nuget.exe
-        uses: warrenbuckley/Setup-Nuget@v1
+        uses: nuget/setup-nuget@v1
       - name: all
         shell: bash
         env:
@@ -337,7 +337,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Nuget.exe
-        uses: warrenbuckley/Setup-Nuget@v1
+        uses: nuget/setup-nuget@v1
       - name: all
         shell: bash
         env:


### PR DESCRIPTION
Some permissions on GH changed due to security concerns, and that broke
the setup-nuget action we were using... which turned out to be obsolete,
anyway, and switching to the new recommended replacement fixes everything.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
