### PR TITLE
Fix bmp row order

### DIFF
--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -134,7 +134,7 @@ BmpInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
         return false;
 
     // if the height is positive scanlines are stored bottom-up
-    if (m_dib_header.width >= 0)
+    if (m_dib_header.height >= 0)
         y = m_spec.height - y - 1;
     const int64_t scanline_off = y * m_padded_scanline_size;
 


### PR DESCRIPTION
## Description

Negative heights indicate the file is stored with the y-axis inverted from normal. Interestingly the comment above was correct, but the code was checking the width instead of the height.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

