### PR TITLE
Better error reporting for IOFile, esp. for OpenEXR writes

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -368,22 +368,15 @@ public:
                      (origin == SEEK_END ? offset+int64_t(size()) : 0));
     }
 
-#if OIIO_VERSION >= 20101
     #define OIIO_IOPROXY_HAS_ERROR 1
-    std::string error() const { return m_error; }
-    void error(string_view e) { m_error = e; }
-#else
-    std::string error() const { return ""; }
-    void error(string_view e) { }
-#endif
+    std::string error() const;
+    void error(string_view e);
 
 protected:
     std::string m_filename;
     int64_t m_pos = 0;
     Mode m_mode   = Closed;
-#ifdef OIIO_IOPROXY_HAS_ERROR
     std::string m_error;
-#endif
 };
 
 

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -470,6 +470,15 @@ OpenEXRInput::open(const std::string& name, ImageSpec& newspec,
             m_io = new Filesystem::IOFile(name, Filesystem::IOProxy::Read);
             m_local_io.reset(m_io);
         }
+        OIIO_ASSERT(m_io);
+        if (m_io->mode() != Filesystem::IOProxy::Read) {
+            // If the proxy couldn't be opened in write mode, try to
+            // return an error.
+            std::string e = m_io->error();
+            errorf("Could not open \"%s\" (%s)", name,
+                   e.size() ? e : std::string("unknown error"));
+            return false;
+        }
         m_io->seek(0);
         m_input_stream = new OpenEXRInputStream(name.c_str(), m_io);
     } catch (const std::exception& e) {

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -354,6 +354,15 @@ OpenEXROutput::open(const std::string& name, const ImageSpec& userspec,
                 m_io = new Filesystem::IOFile(name, Filesystem::IOProxy::Write);
                 m_local_io.reset(m_io);
             }
+            OIIO_ASSERT(m_io);
+            if (m_io->mode() != Filesystem::IOProxy::Write) {
+                // If the proxy couldn't be opened in write mode, try to
+                // return an error.
+                std::string e = m_io->error();
+                errorf("Could not open \"%s\" (%s)", name,
+                       e.size() ? e : std::string("unknown error"));
+                return false;
+            }
             m_output_stream.reset(new OpenEXROutputStream(name.c_str(), m_io));
             if (m_spec.tile_width) {
                 m_output_tiled.reset(


### PR DESCRIPTION
Filesystem::IOFile constructor now upon an error opening the file will
set the error message appropriately.

Move IOProxy::error() implementation from inline to be in
filesystem.cpp to hide its details, use a static mutex to make error
set and retrieval be thread-safe (we presume that the rare chance that
multiple threads will be setting or getting IOProxy errors
simultaneously are rare enough that it's not a thread performance
issue, and if the user is getting file I/O errors, a bit of minor
locking is the least of their worries).

Better checking of these errors in OpenEXR input and output open
operations.  Hopefully this means that exr file I/O errors will
percolate up more helpful error messages.
