### PR TITLE
Fix rare OpenEXR multithread output crash

### DIFF
--- a/src/doc/imageioapi.rst
+++ b/src/doc/imageioapi.rst
@@ -270,6 +270,10 @@ just exist in the OIIO namespace as general utilities. (See
 
 .. doxygenfunction:: declare_imageio_format
 
+
+.. doxygenfunction:: is_imageio_format_name
+
+
 |
 
 

--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -3617,6 +3617,19 @@ details.
         formats = oiio.get_string_attribute ("format_list")
 
 
+.. py:method:: is_imageio_format_name (name)
+
+    Returns True if `name` is the name of a known and supported file format,
+    `False` if it is not.
+
+    Example:
+
+    .. code-block:: python
+
+        >>> print (oiio.is_imageio_format_name('tiff'))
+        True
+        >>> print (oiio.is_imageio_format_name('Bob'))
+        False
 
 
 .. _sec-pythonrecipes:

--- a/src/field3d.imageio/field3doutput.cpp
+++ b/src/field3d.imageio/field3doutput.cpp
@@ -100,17 +100,6 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 
-namespace {  // anon namespace
-
-// format-specific metadata prefixes
-static std::vector<std::string> format_prefixes;
-static atomic_int format_prefixes_initialized;
-static spin_mutex format_prefixes_mutex;  // guard
-
-}  // namespace
-
-
-
 Field3DOutput::Field3DOutput() { init(); }
 
 
@@ -234,23 +223,13 @@ Field3DOutput::put_parameter(const std::string& name, TypeDesc type,
         || Strutil::istarts_with(name, "oiio:"))
         return false;  // skip these; handled separately or not at all
 
-    // Before handling general named metadata, suppress non-openexr
-    // format-specific metadata.
-    if (const char* colon = strchr(name.c_str(), ':')) {
-        std::string prefix(name.c_str(), colon);
-        if (!Strutil::iequals(prefix, "openexr")) {
-            if (!format_prefixes_initialized) {
-                // Retrieve and split the list, only the first time
-                spin_lock lock(format_prefixes_mutex);
-                std::string format_list;
-                OIIO::getattribute("format_list", format_list);
-                Strutil::split(format_list, format_prefixes, ",");
-                format_prefixes_initialized = true;
-            }
-            for (const auto& f : format_prefixes)
-                if (Strutil::iequals(prefix, f))
-                    return false;
-        }
+    // Before handling general named metadata, suppress format-specific
+    // metadata meant for other formats.
+    if (const char* colon = strchr(xname.c_str(), ':')) {
+        std::string prefix(xname.c_str(), colon);
+        Strutil::to_lower(prefix);
+        if (prefix != format_name() && is_imageio_format_name(prefix))
+            return false;
     }
 
     if (type == TypeString)

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2639,6 +2639,9 @@ OIIO_API void declare_imageio_format (const std::string &format_name,
                                       const char **output_extensions,
                                       const char *lib_version);
 
+/// Is `name` one of the known format names?
+OIIO_API bool is_imageio_format_name(string_view name);
+
 /// Helper function: convert contiguous data between two arbitrary pixel
 /// data types (specified by TypeDesc's). Return true if ok, false if it
 /// didn't know how to do the conversion.  If dst_type is UNKNOWN, it will

--- a/src/libOpenImageIO/imagebuf_test.cpp
+++ b/src/libOpenImageIO/imagebuf_test.cpp
@@ -45,6 +45,19 @@ test_wrapmodes()
 
 
 
+void
+test_is_imageio_format_name()
+{
+    OIIO_CHECK_EQUAL(is_imageio_format_name(""), false);
+    OIIO_CHECK_EQUAL(is_imageio_format_name("openexr"), true);
+    OIIO_CHECK_EQUAL(is_imageio_format_name("OpEnExR"), true);
+    OIIO_CHECK_EQUAL(is_imageio_format_name("tiff"), true);
+    OIIO_CHECK_EQUAL(is_imageio_format_name("tiffx"), false);
+    OIIO_CHECK_EQUAL(is_imageio_format_name("blort"), false);
+}
+
+
+
 // Test iterators
 template<class ITERATOR>
 void
@@ -422,7 +435,10 @@ test_write_over()
 int
 main(int /*argc*/, char* /*argv*/[])
 {
+    // Some miscellaneous things that aren't strictly ImageBuf, but this is
+    // as good a place to verify them as any.
     test_wrapmodes();
+    test_is_imageio_format_name();
     test_roi();
 
     // Lots of tests related to ImageBuf::Iterator

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -50,8 +50,7 @@ inline void errorfmt (const char* fmt, const Args&... args) {
     append_error(Strutil::fmt::format(fmt, args...));
 }
 
-// Make sure all plugins are inventoried.  Should only be called while
-// imageio_mutex is held.  For internal use only.
+// Make sure all plugins are inventoried. For internal use only.
 void catalog_all_plugins (std::string searchpath);
 
 /// Given the format, set the default quantization range.

--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -296,6 +296,12 @@ OIIO_DECLARE_PYMODULE(PYMODULE_NAME)
         },
         py::arg("name"), py::arg("defaultval") = "");
     m.def("getattribute", &oiio_getattribute_typed);
+    m.def(
+        "is_imageio_format_name",
+        [](const std::string& name) {
+            return OIIO::is_imageio_format_name(name);
+        },
+        py::arg("name"));
     m.attr("AutoStride")          = AutoStride;
     m.attr("openimageio_version") = OIIO_VERSION;
     m.attr("VERSION")             = OIIO_VERSION;

--- a/testsuite/python-imageinput/ref/out-alt.txt
+++ b/testsuite/python-imageinput/ref/out-alt.txt
@@ -205,4 +205,6 @@ Testing write and read of TIFF CMYK with auto RGB translation:
  [0.24705884 0.49803925 0.49803925]]
 
 
+is_imageio_format_name('tiff') = True
+is_imageio_format_name('txff') = False
 Done.

--- a/testsuite/python-imageinput/ref/out-alt2.txt
+++ b/testsuite/python-imageinput/ref/out-alt2.txt
@@ -205,4 +205,6 @@ Testing write and read of TIFF CMYK with auto RGB translation:
  [0.24705884 0.49803925 0.49803925]]
 
 
+is_imageio_format_name('tiff') = True
+is_imageio_format_name('txff') = False
 Done.

--- a/testsuite/python-imageinput/ref/out-python3.txt
+++ b/testsuite/python-imageinput/ref/out-python3.txt
@@ -205,4 +205,6 @@ Testing write and read of TIFF CMYK with auto RGB translation:
  [0.24705884 0.49803925 0.49803925]]
 
 
+is_imageio_format_name('tiff') = True
+is_imageio_format_name('txff') = False
 Done.

--- a/testsuite/python-imageinput/ref/out-travis-py2.7-pybind2.3.txt
+++ b/testsuite/python-imageinput/ref/out-travis-py2.7-pybind2.3.txt
@@ -205,4 +205,6 @@ Testing write and read of TIFF CMYK with auto RGB translation:
  [ 0.24705884  0.49803925  0.49803925]]
 
 
+is_imageio_format_name('tiff') = True
+is_imageio_format_name('txff') = False
 Done.

--- a/testsuite/python-imageinput/ref/out-travis.txt
+++ b/testsuite/python-imageinput/ref/out-travis.txt
@@ -205,4 +205,6 @@ Testing write and read of TIFF CMYK with auto RGB translation:
  [ 0.24705884  0.49803925  0.49803925]]
 
 
+is_imageio_format_name('tiff') = True
+is_imageio_format_name('txff') = False
 Done.

--- a/testsuite/python-imageinput/ref/out.txt
+++ b/testsuite/python-imageinput/ref/out.txt
@@ -205,4 +205,6 @@ Testing write and read of TIFF CMYK with auto RGB translation:
  [0.24705884 0.49803925 0.49803925]]
 
 
+is_imageio_format_name('tiff') = True
+is_imageio_format_name('txff') = False
 Done.

--- a/testsuite/python-imageinput/src/test_imageinput.py
+++ b/testsuite/python-imageinput/src/test_imageinput.py
@@ -313,6 +313,10 @@ try:
     test_tiff_remembering_config()
     test_tiff_cmyk()
 
+    # Test is_imageio_format_name
+    print ("is_imageio_format_name('tiff') =", oiio.is_imageio_format_name('tiff'))
+    print ("is_imageio_format_name('txff') =", oiio.is_imageio_format_name('txff'))
+
     print ("Done.")
 except Exception as detail:
     print ("Unknown exception:", detail)


### PR DESCRIPTION
TL;DR: This could crash during openexr output, turned out to be a subtle
race condition.

Long explanation:

Metadata gets prefixed with `<formatname>:` in cases where it's only
meant to be understood by the reader or writer of one format.  Formats
that support arbitrary metadata filter out any items that are prefixed
by the name of a different format (so you don't, for example, when
converting file formats, incorrectly copy a TIFF-specific metadata
hint into an OpenEXR file as literal metadata).

The specific code we used in the OpenEXR writer tried to do this but
got the threading locks wrong, and this could lead to very rare, subtle
crashes. It could have been fixed by a 3-line very local fix, but...

I also noticed that the same code was replicated in Field3D output (and
quite incorrectly -- in the cut and paste from the openexr code, it was
still looking for "openexr:" prefix instead of the correcd field3d one!).

Since this idiom was happening (wrong) in two different places, and
seemed likely to crop up again some time, instead of fixing locally I
added a new API call, `is_imageio_format_name()`, to do this centrally
and correctly.  So most of this patch is implementing that and then
using it instead of the incorrect code elsewhere.
