### PR TITLE
Fix webp compile break on 32 bit systems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
           CMAKE_CXX_STANDARD: 14
           PYTHON_VERSION: 3.7
           USE_SIMD: avx
+          WEBP_VERSION: v1.1.0
           MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=7.0.1
         run: |
             source src/build-scripts/ci-startup.bash
@@ -110,6 +111,7 @@ jobs:
           PYTHON_VERSION: 3.7
           USE_SIMD: avx2,f16c
           OPENEXR_VERSION: v2.5.3
+          WEBP_VERSION: v1.1.0
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps-centos.bash
@@ -210,6 +212,7 @@ jobs:
           PYBIND11_VERSION: v2.6.1
           LIBRAW_VERSION: 0.20.2
           PUGIXML_VERSION: v1.11.1
+          WEBP_VERSION: v1.1.0
           MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=7.1.3
         run: |
             source src/build-scripts/ci-startup.bash
@@ -239,6 +242,7 @@ jobs:
           PYBIND11_VERSION: master
           LIBRAW_VERSION: master
           PUGIXML_VERSION: master
+          WEBP_VERSION: master
           MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=master
         run: |
             source src/build-scripts/ci-startup.bash
@@ -271,6 +275,7 @@ jobs:
           EMBEDPLUGINS: 0
           OPENEXR_VERSION: v2.2.1
           PYBIND11_VERSION: v2.4.2
+          WEBP_VERSION: v1.0.0
           MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=6.1.2
         run: |
             sudo rm -rf /usr/local/include/OpenEXR
@@ -294,8 +299,6 @@ jobs:
           PYTHON_VERSION: 3.8
           CMAKE_CXX_STANDARD: 14
           ENABLE_FIELD3D: OFF
-          ENABLE_WEBP: OFF
-          #  ^^ webp seems broken on GH CI Mac. Investigate later.
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/install_homebrew_deps.bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,6 +57,8 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * But... if not found on the system, an embedded version will be used.
  * If you want support for DICOM medical image files:
      * DCMTK >= 3.6.1 (tested through 3.6.5)
+ * If you want support for WebP images:
+     * WebP >= 0.6.1 (tested through 1.1.0)
  * If you want support for OpenColorIO color transformations:
      * OpenColorIO >= 1.1 (also tested against the current master that will
        become OCIO 2.0).

--- a/src/build-scripts/build_webp.bash
+++ b/src/build-scripts/build_webp.bash
@@ -14,11 +14,10 @@ WEBP_REPO=${WEBP_REPO:=https://github.com/webmproject/libwebp.git}
 WEBP_VERSION=${WEBP_VERSION:=v1.1.0}
 
 # Where to put webp repo source (default to the ext area)
-WEBP_SRC_DIR=${WEBP_SRC_DIR:=${PWD}/ext/webp}
-# Temp build area (default to a build/ subdir under source)
+LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}
+WEBP_SRC_DIR=${WEBP_SRC_DIR:=${LOCAL_DEPS_DIR}/webp}
 WEBP_BUILD_DIR=${WEBP_BUILD_DIR:=${WEBP_SRC_DIR}/build}
-# Install area for webp (default to ext/dist)
-WEBP_INSTALL_DIR=${WEBP_INSTALL_DIR:=${PWD}/ext/dist}
+WEBP_INSTALL_DIR=${WEBP_INSTALL_DIR:=${LOCAL_DEPS_DIR}/dist}
 #WEBP_CONFIG_OPTS=${WEBP_CONFIG_OPTS:=}
 
 pwd
@@ -48,6 +47,7 @@ time cmake --config Release \
            -DWEBP_BUILD_GIF2WEBPx=OFF \
            -DWEBP_BUILD_IMG2WEBP=OFF \
            -DWEBP_BUILD_EXTRAS=OFF \
+           -DBUILD_SHARED_LIBS=ON \
            ${WEBP_CONFIG_OPTS} ..
 time cmake --build . --config Release --target install
 
@@ -59,5 +59,5 @@ popd
 
 # Set up paths. These will only affect the caller if this script is
 # run with 'source' rather than in a separate shell.
-export Webp_ROOT=$WEBP_INSTALL_DIR
+export WebP_ROOT=$WEBP_INSTALL_DIR
 

--- a/src/build-scripts/gh-installdeps-centos.bash
+++ b/src/build-scripts/gh-installdeps-centos.bash
@@ -37,6 +37,10 @@ if [[ "$OPENEXR_VERSION" != "" ]] ; then
     source src/build-scripts/build_openexr.bash
 fi
 
+if [[ "$WEBP_VERSION" != "" ]] ; then
+    source src/build-scripts/build_webp.bash
+fi
+
 if [[ "$LIBTIFF_VERSION" != "" ]] ; then
     source src/build-scripts/build_libtiff.bash
 fi

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -83,6 +83,10 @@ if [[ "$OPENEXR_VERSION" != "" ]] ; then
     CXX="ccache $CXX" source src/build-scripts/build_openexr.bash
 fi
 
+if [[ "$WEBP_VERSION" != "" ]] ; then
+    source src/build-scripts/build_webp.bash
+fi
+
 if [[ "$LIBTIFF_VERSION" != "" ]] ; then
     CXX="ccache $CXX" source src/build-scripts/build_libtiff.bash
 fi

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -94,6 +94,9 @@ WebpInput::open(const std::string& name, ImageSpec& spec)
                m_filename);
         return false;
     }
+    if (m_image_size > std::numeric_limits<size_t>::max()) {
+        errorf("Image size (%d) is too big to read", m_image_size);
+    }
 
     FILE* file = Filesystem::fopen(m_filename, "rb");
     if (!file) {
@@ -136,7 +139,7 @@ WebpInput::open(const std::string& name, ImageSpec& spec)
     }
 
     // WebPMuxError err;
-    WebPData bitstream { m_encoded_image.get(), m_image_size };
+    WebPData bitstream { m_encoded_image.get(), size_t(m_image_size) };
     m_demux = WebPDemux(&bitstream);
     if (!m_demux) {
         errorf("Couldn't decode");


### PR DESCRIPTION
The WebPData::size is a size_t, on 32 bit systems it will balk at our
putting a uint64_t in it. Downcast explicitly so the warning doesn't
flag us.

Also some changes to ensure adequate testing of webp in CI. (Even though
we only CI test 64 bit systems, so this was not related to the specific
build break being fixed... but an excuse to make sure we are hitting it
a reasonable amount in CI.)

