### PR TITLE
ustring hash collision instrumentation

### DIFF
--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -685,6 +685,14 @@ public:
     /// Return the amount of memory consumed by the ustring table.
     static size_t memory();
 
+    /// Return the total number of ustrings in the internal table.
+    static size_t total_ustrings();
+
+    /// Return the total number ustrings that have the exact hash as another
+    /// ustring. If `collisions` is passed, store all the colliding ustrings
+    /// in the vector.
+    static size_t hash_collisions(std::vector<ustring>* collisions = nullptr);
+
     /// Given a string_view, return a pointer to the unique
     /// version kept in the internal table (creating a new table entry
     /// if we haven't seen this sequence of characters before).


### PR DESCRIPTION
OSL has some concerns about how ustring hash collisions could impact its
strategy for strings on GPU.

This patch adds some instrumentation to ustring to detect hash
collisions.  Added static ustring methods total_ustrings() and
hash_collisions(). The latter tells you the number of collision pairs,
including optionally enumerating them into a vector of ustrings. Also,
`getstats(verbose=true)`, in Debug builds only, will print all of the
colliding pairs.  These are both somewhat expensive if there are lots
of strings (my laptop takes about 4 seconds to find and print all
collisions for 10M ustrings). So if you are concerned about
performance in debug builds, call getstats(false) instead if you have
a truly enormous ustring table.
