### PR TITLE
Fix crash parsing OpenEXR header.

### DIFF
--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -825,8 +825,7 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
                 r[0] = n;
                 r[1] = static_cast<int>(d);
                 spec.attribute(oname, TypeRational, r);
-            }
-            else {
+            } else {
                 int f = static_cast<int>(gcd<long long>(n, d));
                 if (f > 1) {
                     int r[2];

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -825,18 +825,20 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
                 r[0] = n;
                 r[1] = static_cast<int>(d);
                 spec.attribute(oname, TypeRational, r);
-            } else if (int f = static_cast<int>(
-                                   gcd<long int>(rational[0], rational[1]))
-                               > 1) {
-                int r[2];
-                r[0] = n / f;
-                r[1] = static_cast<int>(d / f);
-                spec.attribute(oname, TypeRational, r);
-            } else {
-                // TODO: find a way to allow the client to accept "close" rational values
-                OIIO::debugf(
-                    "Don't know what to do with OpenEXR Rational attribute %s with value %d / %u that we cannot represent exactly",
-                    oname, n, d);
+            }
+            else {
+                int f = static_cast<int>(gcd<long long>(n, d));
+                if (f > 1) {
+                    int r[2];
+                    r[0] = n / f;
+                    r[1] = static_cast<int>(d / f);
+                    spec.attribute(oname, TypeRational, r);
+                } else {
+                    // TODO: find a way to allow the client to accept "close" rational values
+                    OIIO::debugf(
+                        "Don't know what to do with OpenEXR Rational attribute %s with value %d / %u that we cannot represent exactly",
+                        oname, n, d);
+                }
             }
         } else {
 #if 0


### PR DESCRIPTION
## Description

Fix for a few issues parsing rational values with large denominator in OpenEXR header.

Incorrect use of array index can cause divide by zero crash (observed consistently on Windows with repro image).

Conditional comparison was assigning 1 or 0 to int f declaration instead of the actual gcd value.

Changed gcd type parameter to long long to avoid uint->long int overflow on windows (long int is only 4-bytes on MSVC).

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

