### PR TITLE
CI: fix Windows python tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,10 +322,9 @@ jobs:
       - name: all
         shell: bash
         env:
-          PYTHON_VERSION: 3.6
+          PYTHON_VERSION: 3.7
           CMAKE_GENERATOR: "Visual Studio 16 2019"
           OPENEXR_VERSION: v2.4.1
-          #SKIP_TESTS: 1
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-win-installdeps.bash
@@ -346,12 +345,9 @@ jobs:
       - name: all
         shell: bash
         env:
-          PYTHON_VERSION: 3.6
+          PYTHON_VERSION: 3.7
           CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
           OPENEXR_VERSION: v2.4.1
-          #SKIP_TESTS: 1
-          #MY_CMAKE_FLAGS: -DUSE_PYTHON=0
-          USE_NINJA: 0
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-win-installdeps.bash

--- a/src/build-scripts/build_libjpeg-turbo.bash
+++ b/src/build-scripts/build_libjpeg-turbo.bash
@@ -44,7 +44,7 @@ time cmake --config Release \
            ${LIBJPEGTURBO_CONFIG_OPTS} ..
 time cmake --build . --config Release --target install
 
-ls -R ${LIBJPEGTURBO_INSTALL_DIR}
+# ls -R ${LIBJPEGTURBO_INSTALL_DIR}
 popd
 
 

--- a/src/build-scripts/build_libtiff.bash
+++ b/src/build-scripts/build_libtiff.bash
@@ -40,7 +40,7 @@ time cmake --config Release \
 time cmake --build . --config Release --target install
 popd
 
-ls -R ${LIBTIFF_INSTALL_DIR}
+# ls -R ${LIBTIFF_INSTALL_DIR}
 
 #echo "listing .."
 #ls ..

--- a/src/build-scripts/ci-build-and-test.bash
+++ b/src/build-scripts/ci-build-and-test.bash
@@ -51,11 +51,11 @@ fi
 
 if [[ "${SKIP_TESTS:=0}" == "0" ]] ; then
     $OpenImageIO_ROOT/bin/oiiotool --help || true
-    TESTSUITE_CLEANUP_ON_SUCCESS=1
+    TESTSUITE_CLEANUP_ON_SUCCESS=${TESTSUITE_CLEANUP_ON_SUCCESS:=1}
     echo "Parallel test " ${CTEST_PARALLEL_LEVEL}
     # make $BUILD_FLAGS test
     pushd build/$PLATFORM
-    ctest -C ${CMAKE_BUILD_TYPE} -E broken --force-new-ctest-process --output-on-failure --timeout 180
+    ctest -C ${CMAKE_BUILD_TYPE} -E broken --force-new-ctest-process --output-on-failure --timeout 180 ${OIIO_CTEST_FLAGS}
     popd
 fi
 

--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -34,8 +34,18 @@ export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DEP_DIR/lib:$VCPKG_INSTALLATION_ROOT/i
 # export MY_CMAKE_FLAGS="$MY_CMAKE_FLAGS -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 # export OPENEXR_CMAKE_FLAGS="$OPENEXR_CMAKE_FLAGS -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 
-ls -l "C:/Program Files (x86)/Microsoft Visual Studio/*/Enterprise/VC/Tools/MSVC" && true
-ls -l "C:/Program Files (x86)/Microsoft Visual Studio" && true
+#ls -l "C:/Program Files (x86)/Microsoft Visual Studio/*/Enterprise/VC/Tools/MSVC" && true
+#ls -l "C:/Program Files (x86)/Microsoft Visual Studio" && true
+
+
+if [[ "$PYTHON_VERSION" == "3.6" ]] ; then
+    export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;/c/hostedtoolcache/windows/Python/3.6.8/x64"
+else
+    export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;/c/hostedtoolcache/windows/Python/3.7.9/x64"
+    export Python_EXECUTABLE="/c/hostedtoolcache/windows/Python/3.7.9/x64/python.exe"
+    export PYTHONPATH=$OpenImageIO_ROOT/lib/python${PYTHON_VERSION}/site-packages
+fi
+pip install numpy
 
 
 ########################################################################
@@ -129,19 +139,8 @@ ls -R -l "$DEP_DIR"
 
 src/build-scripts/install_test_images.bash
 
-if [[ -e /c/hostedtoolcache/windows/Python ]] ; then
-	ls /c/hostedtoolcache/windows/Python
-	echo "/c/hostedtoolcache/windows/Python/3.6.8/x64"
-	ls /c/hostedtoolcache/windows/Python/3.6.8/x64
-fi
-
-
 
 # source src/build-scripts/build_openexr.bash
 # export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;$ILMBASE_ROOT;$OPENEXR_ROOT"
 # source src/build-scripts/build_opencolorio.bash
 
-
-if [[ "$PYTHON_VERSION" == "3.6" ]] ; then
-    export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;/c/hostedtoolcache/windows/Python/3.6.8/x64"
-fi

--- a/testsuite/python-imageinput/ref/out-python3-win.txt
+++ b/testsuite/python-imageinput/ref/out-python3-win.txt
@@ -1,0 +1,210 @@
+Could not open "badname.tif"
+	Error:  Could not open file: S: Cannot open
+Opened "D:/a/oiio/oiio/../oiio-images/tahoe-gps.jpg" as a jpeg
+  resolution 2048x1536+0+0
+  untiled
+  3 channels: ('R', 'G', 'B')
+  format =  uint8
+  alpha channel =  -1
+  z channel =  -1
+  deep =  False
+  oiio:ColorSpace = "sRGB"
+  jpeg:subsampling = "4:2:0"
+  Make = "HTC"
+  Model = "T-Mobile G1"
+  Orientation = 1
+  XResolution = 72.0
+  YResolution = 72.0
+  ResolutionUnit = "none"
+  Software = "title;va"
+  Exif:YCbCrPositioning = 1
+  Exif:ExifVersion = "0220"
+  Exif:DateTimeOriginal = "2009:02:21 08:32:04"
+  Exif:DateTimeDigitized = "2009:02:21 08:32:04"
+  Exif:FlashPixVersion = "0100"
+  Exif:ColorSpace = 1
+  Exif:PixelXDimension = 2048
+  Exif:PixelYDimension = 1536
+  Exif:WhiteBalance = 0
+  GPS:VersionID = None
+  GPS:LatitudeRef = "N"
+  GPS:Latitude = (39.0, 18.0, 24.399999618530273)
+  GPS:LongitudeRef = "W"
+  GPS:Longitude = (120.0, 20.0, 6.25)
+  GPS:AltitudeRef = 0
+  GPS:Altitude = 0.0
+  GPS:TimeStamp = (17.0, 56.0, 33.0)
+  GPS:MapDatum = "WGS-84"
+  GPS:DateStamp = "1915:08:08"
+
+Opened "grid.tx" as a tiff
+  resolution 1024x1024+0+0
+  tile size  64x64x1
+  4 channels: ('R', 'G', 'B', 'A')
+  format =  uint8
+  alpha channel =  3
+  z channel =  -1
+  deep =  False
+  oiio:BitsPerSample = 8
+  Orientation = 1
+  XResolution = 72.0
+  YResolution = 72.0
+  ResolutionUnit = "in"
+  Software = "OpenImageIO 1.5.7dev : maketx -filter lanczos3 --resize grid.tif -o grid.tx"
+  DateTime = "2014:11:29 23:20:23"
+  DocumentName = "g.tif"
+  textureformat = "Plain Texture"
+  wrapmodes = "black,black"
+  fovcot = 1.0
+  tiff:PhotometricInterpretation = 2
+  tiff:PlanarConfiguration = 1
+  planarconfig = "contig"
+  tiff:Compression = 8
+  compression = "zip"
+  PixelAspectRatio = 1.0
+  oiio:AverageColor = "0.608983,0.608434,0.608728,1"
+  oiio:SHA-1 = "233A1D3412A54A5F49814AB7BFFD04F56F46D3D7"
+Subimage 0 MIP level 1 :
+  resolution 512x512+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 2 :
+  resolution 256x256+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 3 :
+  resolution 128x128+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 4 :
+  resolution 64x64+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 5 :
+  resolution 32x32+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 6 :
+  resolution 16x16+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 7 :
+  resolution 8x8+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 8 :
+  resolution 4x4+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 9 :
+  resolution 2x2+0+0
+  tile size  64x64x1
+Subimage 0 MIP level 10 :
+  resolution 1x1+0+0
+  tile size  64x64x1
+
+Testing read_image:
+Opened "D:/a/oiio/oiio/../oiio-images/tahoe-gps.jpg" as a jpeg
+@ (0, 0) = [40 35 57]
+@ (2047, 1535) = [37 56 89]
+@ (1024, 768) = [137 183 233]
+
+Opened "D:/a/oiio/oiio/../oiio-images/tahoe-gps.jpg" as a jpeg
+@ (0, 0) = [0.15686275 0.13725491 0.22352943]
+@ (2047, 1535) = [0.14509805 0.21960786 0.34901962]
+@ (1024, 768) = [0.5372549  0.7176471  0.91372555]
+
+Opened "D:/a/oiio/oiio/../oiio-images/tahoe-gps.jpg" as a jpeg
+@ (0, 0) = [40]
+@ (2047, 1535) = [37]
+@ (1024, 768) = [137]
+
+Testing read_scanline:
+Opened "D:/a/oiio/oiio/../oiio-images/tahoe-gps.jpg" as a jpeg
+@ (0, 0) = [40 35 57]
+@ (0, 1535) = [ 82  94 136]
+
+Testing read_tile:
+Opened "grid.tx" as a tiff
+@ (32, 32) = [  1   1   1 255]
+@ (32, 32) = [255 127 127 255]
+
+Testing read_scanlines:
+Opened "D:/a/oiio/oiio/../oiio-images/tahoe-gps.jpg" as a jpeg
+@ (0, 0) = [40 35 57]
+@ (2047, 1535) = [37 56 89]
+@ (1024, 768) = [137 183 233]
+
+Testing read_tiles:
+Opened "grid.tx" as a tiff
+@ (0, 0) = [  0   0   0 255]
+@ (1023, 1023) = [  0   0   0 255]
+@ (512, 512) = [  0   0   0 255]
+
+Test read_image native u16:
+Opened "testu16.tif" as a tiff
+Read array typecode uint16  [ 12288 ]
+
+Test read_scanlines native u16:
+Opened "testu16.tif" as a tiff
+Read array typecode uint16  [ 12288 ]
+
+Test read_tiles native half:
+Opened "testf16.exr" as a openexr
+Read array typecode float16  [ 12288 ]
+
+Test read_image into half:
+Opened "testu16.tif" as a tiff
+Read array typecode float16  [ 12288 ]
+
+Test read_image into FLOAT:
+Opened "testu16.tif" as a tiff
+Read array typecode float32  [ 12288 ]
+
+Testing write and read of unassociated:
+  writing:  [[[0.5 0.5 0.5 0.5]
+  [0.5 0.5 0.5 0.5]]
+
+ [[0.5 0.5 0.5 0.5]
+  [0.5 0.5 0.5 0.5]]]
+
+  default reading as IB:  [[[0.25 0.25 0.25 0.5 ]
+  [0.25 0.25 0.25 0.5 ]]
+
+ [[0.25 0.25 0.25 0.5 ]
+  [0.25 0.25 0.25 0.5 ]]]
+
+  reading as IB with unassoc hint:  [[[0.5 0.5 0.5 0.5]
+  [0.5 0.5 0.5 0.5]]
+
+ [[0.5 0.5 0.5 0.5]
+  [0.5 0.5 0.5 0.5]]]
+
+  reading as II with hint, read scanlines backward: 
+    [1] =  [[0.5 0.5 0.5 0.5]
+ [0.5 0.5 0.5 0.5]]
+    [0] =  [[0.5 0.5 0.5 0.5]
+ [0.5 0.5 0.5 0.5]]
+
+
+Testing write and read of TIFF CMYK with auto RGB translation:
+  writing:  [[[0.5019608 0.        0.        0.5019608]
+  [0.5019608 0.        0.        0.5019608]]
+
+ [[0.5019608 0.        0.        0.5019608]
+  [0.5019608 0.        0.        0.5019608]]]
+
+  default reading as IB:  [[[0.24705884 0.49803925 0.49803925]
+  [0.24705884 0.49803925 0.49803925]]
+
+ [[0.24705884 0.49803925 0.49803925]
+  [0.24705884 0.49803925 0.49803925]]]
+
+  reading as IB with rawcolor=1:  [[[0.5019608 0.        0.        0.5019608]
+  [0.5019608 0.        0.        0.5019608]]
+
+ [[0.5019608 0.        0.        0.5019608]
+  [0.5019608 0.        0.        0.5019608]]]
+
+  reading as II with rawcolor=0, read scanlines backward: 
+    [1] =  [[0.24705884 0.49803925 0.49803925]
+ [0.24705884 0.49803925 0.49803925]]
+    [0] =  [[0.24705884 0.49803925 0.49803925]
+ [0.24705884 0.49803925 0.49803925]]
+
+
+is_imageio_format_name('tiff') = True
+is_imageio_format_name('txff') = False
+Done.

--- a/testsuite/python-imageoutput/run.py
+++ b/testsuite/python-imageoutput/run.py
@@ -13,7 +13,7 @@ files = [ "grid-image.tif", "grid-scanline.tif", "grid-scanlines.tif",
           "grid-timage.tif", "grid-tile.tif", "grid-tiles.tif", "grid-half.exr" ]
 for f in files :
     command += (oiio_app("idiff") + " -fail 0.001 -warn 0.001 "
-                + f + " " + imagedir + "/grid.tif >> out.txt;")
+                + f + " " + imagedir + "/grid.tif >> out.txt ;")
 
 outputs = [ "multipart.exr", "out.txt" ]
 

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -47,7 +47,7 @@ redirect = " >> out.txt "
 def oiio_relpath (path, start=os.curdir):
     "Wrapper around os.path.relpath which always uses '/' as the separator."
     p = os.path.relpath (path, start)
-    return p if sys.platform != "win32" else p.replace ('\\', '/')
+    return p if platform.system() != 'Windows' else p.replace ('\\', '/')
 
 # Try to figure out where some key things are. Go by env variables set by
 # the cmake tests, but if those aren't set, assume somebody is running
@@ -101,7 +101,7 @@ failpercent = 0.02
 anymatch = False
 cleanup_on_success = False
 if int(os.getenv('TESTSUITE_CLEANUP_ON_SUCCESS', '0')) :
-    cleanup_on_success = True;
+    cleanup_on_success = True
 
 image_extensions = [ ".tif", ".tx", ".exr", ".jpg", ".png", ".rla",
                      ".dpx", ".iff", ".psd", ".bmp", ".fits", ".ico",
@@ -144,9 +144,12 @@ if (os.getenv("TRAVIS") and (os.getenv("SANITIZE") in ["leak","address"])
     and os.path.exists(os.path.join (test_source_dir,"TRAVIS_SKIP_LSAN"))) :
     sys.exit (0)
 
-pythonbin = 'python'
-if os.getenv("PYTHON_VERSION") :
-    pythonbin += os.getenv("PYTHON_VERSION")
+if os.getenv("Python_EXECUTABLE") :
+    pythonbin = os.getenv("Python_EXECUTABLE")
+else :
+    pythonbin = 'python'
+    if os.getenv("PYTHON_VERSION") :
+        pythonbin += os.getenv("PYTHON_VERSION")
 #print ("pythonbin = ", pythonbin)
 
 
@@ -395,10 +398,13 @@ def runtest (command, outputs, failureok=0) :
         if ok :
             if extension in image_extensions :
                 # If we got a match for an image, save the idiff results
-                os.system (diff_command (out, testfile, silent=False))
+                os.system (diff_command (out, testfile, silent=False, concat=False))
             print ("PASS: " + out + " matches " + testfile)
         else :
             err = 1
+            if platform.system() == 'Windows' :
+                os.rename (out, "crlf.txt")
+                os.system ("tr -d '\\r' < crlf.txt > " + out)
             print ("NO MATCH for " + out)
             print ("FAIL " + out)
             if extension == ".txt" :
@@ -414,7 +420,7 @@ def runtest (command, outputs, failureok=0) :
             if extension in image_extensions :
                 # If we failed to get a match for an image, send the idiff
                 # results to the console
-                os.system (diff_command (out, testfile, silent=False))
+                os.system (diff_command (out, testfile, silent=False, concat=False))
             if os.path.isfile("debug.log") and os.path.getsize("debug.log") :
                 print ("---   DEBUG LOG   ---\n")
                 #flog = open("debug.log", "r")


### PR DESCRIPTION
* Change to finding a consistent Python version (3.7)

* Install numpy

* On Windows, convert crlf to lf before diffing reference output, so we
  don't get mismatches just because of LF vs CRLF.

* Update ref output on testsuite/python-imageinput

* Fix windows detection in runtest.py oiio_relpath

* Fix some semicolon problems that were making bash command lines conused

Along for the ride:

* Have ci-build-and-test.bash send OIIO_CTEST_FLAGS as extra args to ctest

* Remove some needless verbosity from the dependency building scripts.

