### PR TITLE
Enabled AVIF encoding with libheif (#2811)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -51,6 +51,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
        stability and thread safety)
  * If you want support for HEIF/HEIC or AVIF images:
      * libheif >= 1.3 (1.7 required for AVIF support, tested through 1.10)
+     * libheif must be built with an AV1 encoder/decoder for AVIF
  * If you want support for DDS files:
      * libsquish >= 1.13 (tested through 1.15)
      * But... if not found on the system, an embedded version will be used.

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -600,9 +600,9 @@ control aspects of the writing itself:
      - HEIF header data or explanation
    * - ``Compression``
      - string
-     - If supplied, must be ``"heic"``, but may optionally have a quality
-       value appended, like ``"heic:90"``. Quality can be 1-100, with 100
-       meaning lossless. The default is 75.
+     - If supplied, can be ``"heic"`` or ``"avif"``, but may optionally have a
+       quality value appended, like ``"heic:90"``. Quality can be 1-100, with
+       100 meaning lossless. The default is 75.
 
 
 


### PR DESCRIPTION
## Description

Requires libheif built with libaom or dav1d/rav1e. I have tested this, but really not very extensively. It shouldn't cause any regressions though.

## Tests

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

