### PR TITLE
Fix build break for older libheif

### DIFF
--- a/src/heif.imageio/heifinput.cpp
+++ b/src/heif.imageio/heifinput.cpp
@@ -29,7 +29,9 @@ public:
     {
         return feature == "exif";
     }
+#if LIBHEIF_HAVE_VERSION(1, 4, 0)
     virtual bool valid_file(const std::string& filename) const override;
+#endif
     virtual bool open(const std::string& name, ImageSpec& newspec) override;
     virtual bool open(const std::string& name, ImageSpec& newspec,
                       const ImageSpec& config) override;
@@ -70,11 +72,15 @@ heif_input_imageio_create()
 }
 
 OIIO_EXPORT const char* heif_input_extensions[] = { "heic", "heif", "heics",
-                                                    "avif", nullptr };
+#if LIBHEIF_HAVE_VERSION(1, 7, 0)
+                                                    "avif",
+#endif
+                                                    nullptr };
 
 OIIO_PLUGIN_EXPORTS_END
 
 
+#if LIBHEIF_HAVE_VERSION(1, 4, 0)
 bool
 HeifInput::valid_file(const std::string& filename) const
 {
@@ -86,6 +92,7 @@ HeifInput::valid_file(const std::string& filename) const
     return filetype_check != heif_filetype_no
            && filetype_check != heif_filetype_yes_unsupported;
 }
+#endif
 
 
 

--- a/src/heif.imageio/heifoutput.cpp
+++ b/src/heif.imageio/heifoutput.cpp
@@ -79,7 +79,10 @@ heif_output_imageio_create()
 }
 
 OIIO_EXPORT const char* heif_output_extensions[] = { "heif", "heic", "heics",
-                                                     "avif", nullptr };
+#if LIBHEIF_HAVE_VERSION(1, 7, 0)
+                                                     "avif",
+#endif
+                                                     nullptr };
 
 OIIO_PLUGIN_EXPORTS_END
 
@@ -131,15 +134,15 @@ HeifOutput::open(const std::string& name, const ImageSpec& newspec,
         m_himage.add_plane(heif_channel_interleaved, newspec.width,
                            newspec.height, 8 * m_spec.nchannels /*bit depth*/);
 
+        m_encoder = heif::Encoder(heif_compression_HEVC);
+#if LIBHEIF_HAVE_VERSION(1, 7, 0)
         auto compqual  = m_spec.decode_compression_metadata("", 75);
         auto extension = Filesystem::extension(m_filename);
         if (compqual.first == "avif"
             || (extension == ".avif" && compqual.first == "")) {
             m_encoder = heif::Encoder(heif_compression_AV1);
-        } else {
-            m_encoder = heif::Encoder(heif_compression_HEVC);
         }
-
+#endif
     } catch (const heif::Error& err) {
         std::string e = err.get_message();
         errorf("%s", e.empty() ? "unknown exception" : e.c_str());


### PR DESCRIPTION
With some recent heic related packages, we lost the ability to build
against some older libheif versions that we purport to support. We may
eventually want to raise the minimum supported libheif, but in the
mean time, this restores the prior build abilities.
