### PR TITLE
Fix recently-symptomatic python2 vs clang warnings

### DIFF
--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -36,6 +36,10 @@
 #include <OpenImageIO/span.h>
 #include <OpenImageIO/typedesc.h>
 
+#if PY_MAJOR_VERSION < 3
+OIIO_CLANG_PRAGMA(GCC diagnostic ignored "-Wunused-value")
+#endif
+
 #include <pybind11/numpy.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>


### PR DESCRIPTION
This did not seem to warn before a recent patch were I switched to using a pybind11 configuration macro.
