### PR TITLE
Filesystem::generic_filepath.

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -84,6 +84,9 @@ OIIO_API std::string parent_path (const std::string &filepath) noexcept;
 OIIO_API std::string replace_extension (const std::string &filepath, 
                                         const std::string &new_extension) noexcept;
 
+/// Return the filepath in generic format, not any OS-specific conventions.
+OIIO_API std::string generic_filepath (string_view filepath) noexcept;
+
 /// Turn a searchpath (multiple directory paths separated by ':' or ';')
 /// into a vector<string> containing each individual directory.  If
 /// validonly is true, only existing and readable directories will end

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -99,7 +99,11 @@ Filesystem::filename(const std::string& filepath) noexcept
 {
     // To simplify dealing with platform-specific separators and whatnot,
     // just use the Boost routines:
-    return pathstr(u8path(filepath).filename());
+    try {
+        return pathstr(u8path(filepath).filename());
+    } catch (...) {
+        return filepath;
+    }
 }
 
 
@@ -107,7 +111,11 @@ Filesystem::filename(const std::string& filepath) noexcept
 std::string
 Filesystem::extension(const std::string& filepath, bool include_dot) noexcept
 {
-    std::string s = pathstr(u8path(filepath).extension());
+    std::string s;
+    try {
+        s = pathstr(u8path(filepath).extension());
+    } catch (...) {
+    }
     if (!include_dot && !s.empty() && s[0] == '.')
         s.erase(0, 1);  // erase the first character
     return s;
@@ -118,7 +126,11 @@ Filesystem::extension(const std::string& filepath, bool include_dot) noexcept
 std::string
 Filesystem::parent_path(const std::string& filepath) noexcept
 {
-    return pathstr(u8path(filepath).parent_path());
+    try {
+        return pathstr(u8path(filepath).parent_path());
+    } catch (...) {
+        return filepath;
+    }
 }
 
 
@@ -127,7 +139,23 @@ std::string
 Filesystem::replace_extension(const std::string& filepath,
                               const std::string& new_extension) noexcept
 {
-    return pathstr(u8path(filepath).replace_extension(new_extension));
+    try {
+        return pathstr(u8path(filepath).replace_extension(new_extension));
+    } catch (...) {
+        return filepath;
+    }
+}
+
+
+
+std::string
+Filesystem::generic_filepath(string_view filepath) noexcept
+{
+    try {
+        return pathstr(u8path(filepath).generic_string());
+    } catch (...) {
+        return filepath;
+    }
 }
 
 

--- a/src/libutil/filesystem_test.cpp
+++ b/src/libutil/filesystem_test.cpp
@@ -46,6 +46,12 @@ test_filename_decomposition()
     std::cout << "Testing replace_extension\n";
     OIIO_CHECK_EQUAL(Filesystem::replace_extension(test, "foo"),
                      "/directoryA/directory/filename.foo");
+
+    std::cout << "Testing generic_string\n";
+#if _WIN32
+    OIIO_CHECK_EQUAL(Filesystem::generic_filepath("\\x\\y"), "/x/y");
+    OIIO_CHECK_EQUAL(Filesystem::generic_filepath("c:\\x\\y"), "/c/x/y");
+#endif
 }
 
 
@@ -287,6 +293,8 @@ test_scan_file_seq_with_views(const char* pattern, const char** views_,
     Filesystem::scan_for_matching_filenames(normalized_pattern, views,
                                             frame_numbers, frame_views,
                                             frame_names);
+    for (auto& f : frame_names)
+        f = Filesystem::generic_filepath(f);
     std::string joined = Strutil::join(frame_names, " ");
     std::cout << "  " << pattern;
     std::cout << " -> " << joined << "\n";


### PR DESCRIPTION
Similar to C++17 std::filesystem::path::generic_string(), but for a
filepath sent as string_view.

While I was there, I noticed that a few Filesystem functions that I
declared as `noexcept` actually call things that can throw, so I put a
few try/catch in stratgic spots. Nobody had reported a problem with
this, and maybe it would be fine, but it's the right thing to do.
