### PR TITLE
Various fixes to make more Windows CI tests pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,7 @@ jobs:
           PYTHON_VERSION: 3.7
           CMAKE_GENERATOR: "Visual Studio 16 2019"
           OPENEXR_VERSION: v2.4.1
+          OIIO_CTEST_FLAGS: "--timeout 120 --repeat after-timeout:4"
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-win-installdeps.bash
@@ -348,6 +349,7 @@ jobs:
           PYTHON_VERSION: 3.7
           CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
           OPENEXR_VERSION: v2.4.1
+          OIIO_CTEST_FLAGS: "--timeout 120 --repeat after-timeout:4"
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-win-installdeps.bash

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -172,7 +172,7 @@ main(int argc, char* argv[])
         std::cerr << "idiff: Must have two input filenames.\n";
         std::cout << "> " << Strutil::join(filenames, ", ") << "\n";
         ap.usage();
-        exit(EXIT_FAILURE);
+        return EXIT_FAILURE;
     }
     bool verbose          = ap["v"].get<int>();
     bool quiet            = ap["q"].get<int>();

--- a/testsuite/jpeg-corrupt-header/ref/out.txt
+++ b/testsuite/jpeg-corrupt-header/ref/out.txt
@@ -1,3 +1,3 @@
 oiiotool ERROR: read : JPEG error: Corrupt JPEG data: 2 extraneous bytes before marker 0xdb ("src/corrupt-header.jpg")
 Full command line was:
-> ../../bin/oiiotool --info -v -a --no-metamatch DateTime|Software|OriginatingProgram|ImageHistory --hash src/corrupt-header.jpg
+> oiiotool --info -v -a --no-metamatch DateTime|Software|OriginatingProgram|ImageHistory --hash src/corrupt-header.jpg

--- a/testsuite/missingcolor/ref/out.err.txt
+++ b/testsuite/missingcolor/ref/out.err.txt
@@ -1,3 +1,3 @@
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "src/partial.exr". Tile (0, 0, 0, 0) is missing.
 Full command line was:
-> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/partial.exr -d uint8 -o error.tif
+> oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/partial.exr -d uint8 -o error.tif

--- a/testsuite/oiiotool-copy/run.py
+++ b/testsuite/oiiotool-copy/run.py
@@ -9,20 +9,20 @@
 # Some tests to verify that we are transferring data formats properly.
 #
 command += oiiotool ("-pattern checker 128x128 3 -d uint8 -tile 16 16 -o uint8.tif " +
-                     "-echo '\nexplicit -d uint save result: ' -metamatch \"width|tile\" -i:info=2 uint8.tif")
+                     "-echo \"\nexplicit -d uint save result: \" -metamatch \"width|tile\" -i:info=2 uint8.tif")
 # Un-modified copy should preserve data type and tiling
 command += oiiotool ("uint8.tif -o tmp.tif " +
-                     "-echo '\nunmodified copy result: ' -metamatch \"width|tile\" -i:info=2 tmp.tif")
+                     "-echo \"\nunmodified copy result: \" -metamatch \"width|tile\" -i:info=2 tmp.tif")
 # Copy with explicit data request should change data type
 command += oiiotool ("uint8.tif -d uint16 -o copy_uint16.tif " +
-                     "-echo '\ncopy with explicit -d uint16 result: ' -metamatch \"width|tile\" -i:info=2 copy_uint16.tif")
+                     "-echo \"\ncopy with explicit -d uint16 result: \" -metamatch \"width|tile\" -i:info=2 copy_uint16.tif")
 # Subimage concatenation should preserve data type
 command += oiiotool ("uint8.tif copy_uint16.tif -siappend -o tmp.tif " +
-                     "-echo '\nsiappend result: ' -metamatch \"width|tile\" -i:info=2 tmp.tif")
+                     "-echo \"\nsiappend result: \" -metamatch \"width|tile\" -i:info=2 tmp.tif")
 # Combining two images preserves the format of the first read input, if
 # there are not any other hints:
 command += oiiotool ("-pattern checker 128x128 3 uint8.tif -add -o tmp.tif " +
-                     "-echo '\ncombining images result: ' -metamatch \"width|tile\" -i:info=2 tmp.tif")
+                     "-echo \"\ncombining images result: \" -metamatch \"width|tile\" -i:info=2 tmp.tif")
 
 # test --crop
 command += oiiotool (OIIO_TESTSUITE_IMAGEDIR + "/grid.tif --crop 100x400+50+200 -o crop.tif")

--- a/testsuite/oiiotool-readerror/ref/out.err-alt.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err-alt.txt
@@ -1,3 +1,3 @@
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Unexpected end of file.
 Full command line was:
-> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr
+> oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr

--- a/testsuite/oiiotool-readerror/ref/out.err-alt2.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err-alt2.txt
@@ -1,3 +1,3 @@
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Unexpected data block y coordinate.
 Full command line was:
-> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr
+> oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr

--- a/testsuite/oiiotool-readerror/ref/out.err-debug.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err-debug.txt
@@ -2,4 +2,4 @@ read was not necessary -- using cache
 going to have to read src/incomplete.exr: float vs float
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Scan line 126 is missing.
 Full command line was:
-> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr
+> oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr

--- a/testsuite/oiiotool-readerror/ref/out.err.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err.txt
@@ -1,3 +1,3 @@
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Scan line 126 is missing.
 Full command line was:
-> ../../bin/oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr
+> oiiotool -colorconfig ../../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr

--- a/testsuite/oiiotool-text/run.py
+++ b/testsuite/oiiotool-text/run.py
@@ -7,7 +7,7 @@ oiiotoolsrcdir = os.path.join(OIIO_TESTSUITE_ROOT, "oiiotool", "src")
 
 # test --text
 command += oiiotool ("--create 320x240 3 "
-            "--text:x=25:y=50:font=DroidSerif 'Hello, world' "
+            "--text:x=25:y=50:font=DroidSerif \"Hello, world\" "
             "--text:x=50:y=120:color=1,0,0:size=42 \"Go Big Red!\" "
             "-d uint8 -o text.tif >> out.txt")
 
@@ -17,17 +17,17 @@ command += oiiotool ("--create 320x320 3 "
             "--line 190,100,210,100 --line 200,90,200,110 "
             "--line 90,200,110,200 --line 100,190,100,210 "
             "--line 190,200,210,200 --line 200,190,200,210 "
-            "--text:x=100:y=100:xalign=left:yalign=top:size=20 'Topleft' "
-            "--text:x=200:y=100:xalign=center:yalign=baseline:size=20 'Center' "
-            "--text:x=100:y=200:xalign=right:yalign=bottom:size=20 'Rightbot' "
-            "--text:x=200:y=200:xalign=left:yalign=baseline:size=20 'Default' "
+            "--text:x=100:y=100:xalign=left:yalign=top:size=20 Topleft "
+            "--text:x=200:y=100:xalign=center:yalign=baseline:size=20 Center "
+            "--text:x=100:y=200:xalign=right:yalign=bottom:size=20 Rightbot "
+            "--text:x=200:y=200:xalign=left:yalign=baseline:size=20 Default "
             "-d uint8 -o aligned.tif >> out.txt")
 
 # test shadow
 command += oiiotool (oiiotoolsrcdir + "/tahoe-tiny.tif "
-            "--text:x=64:y=20:xalign=center:size=20:shadow=0 'shadow = 0' "
-            "--text:x=64:y=40:xalign=center:size=20:shadow=1 'shadow = 1' "
-            "--text:x=64:y=60:xalign=center:size=20:shadow=2 'shadow = 2' "
+            "--text:x=64:y=20:xalign=center:size=20:shadow=0 \"shadow = 0\" "
+            "--text:x=64:y=40:xalign=center:size=20:shadow=1 \"shadow = 1\" "
+            "--text:x=64:y=60:xalign=center:size=20:shadow=2 \"shadow = 2\" "
             "-o textshadowed.tif >> out.txt")
 
 # Outputs to check against references

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -222,9 +222,9 @@ command += oiiotool ('-echo "16+5={16+5}" -echo "16-5={16-5}" -echo "16*5={16*5}
 command += oiiotool ('-echo "16/5={16/5}" -echo "16//5={16//5}" -echo "16%5={16%5}"')
 command += oiiotool ("src/tahoe-small.tif --pattern fill:top=0,0,0,0:bottom=0,0,1,1 " +
                      "{TOP.geom} {TOP.nchannels} -d uint8 -o exprgradient.tif")
-command += oiiotool ("src/tahoe-small.tif -cut '{TOP.width-20* 2}x{TOP.height-40+(4*2- 2 ) /6-1}+{TOP.x+100.5-80.5 }+{TOP.y+20}' -d uint8 -o exprcropped.tif")
-command += oiiotool ("src/tahoe-small.tif -o exprstrcat{TOP.compression}.tif")
-command += oiiotool ("src/tahoe-tiny.tif -subc '{TOP.MINCOLOR}' -divc '{TOP.MAXCOLOR}' -o tahoe-contraststretch.tif")
+command += oiiotool ('src/tahoe-small.tif -cut "{TOP.width-20* 2}x{TOP.height-40+(4*2- 2 ) /6-1}+{TOP.x+100.5-80.5 }+{TOP.y+20}" -d uint8 -o exprcropped.tif')
+command += oiiotool ('src/tahoe-small.tif -o exprstrcat{TOP.compression}.tif')
+command += oiiotool ('src/tahoe-tiny.tif -subc "{TOP.MINCOLOR}" -divc "{TOP.MAXCOLOR}" -o tahoe-contraststretch.tif')
 # test use of quotes inside evaluation, {TOP.foo/bar} would ordinarily want
 # to interpret '/' for division, but we want to look up metadata called
 # 'foo/bar'.

--- a/testsuite/texture-overscan/run.py
+++ b/testsuite/texture-overscan/run.py
@@ -10,22 +10,23 @@
 #    surrounded by the red check border, surrounded by black. The grid
 #    itself should be the "middle half" of the image.
 
-command += (oiio_app("oiiotool") + OIIO_TESTSUITE_IMAGEDIR + "/grid.tif"
+command += oiiotool(OIIO_TESTSUITE_IMAGEDIR + "/grid.tif"
             + " -resize 512x512 "
             + " -pattern checker:color1=1,0,0:color2=.25,0,0 640x640 3 "
-            + "-origin -64-64 -paste +0+0 -fullsize 512x512+0+0 -o overscan-src.exr ;\n")
-command += (oiio_app("maketx") + " --filter lanczos3 overscan-src.exr "
-            + " -o grid-overscan.exr ;\n")
-command += testtex_command ("grid-overscan.exr --res 256 256 " +
-                            "--wrap black --nowarp -o out-exact.exr ;\n")
-command += testtex_command ("grid-overscan.exr --res 256 256 " +
-                            "--wrap black --nowarp " +
+            + "-origin -64-64 -paste +0+0 -fullsize 512x512+0+0 -o overscan-src.exr")
+command += maketx_command("overscan-src.exr", "grid-overscan.exr",
+                          "--filter lanczos3", silent=True)
+command += testtex_command ("grid-overscan.exr",
+                            "--res 256 256 --wrap black --nowarp -o out-exact.exr",
+                            silent=True)
+command += testtex_command ("grid-overscan.exr",
+                            "--res 256 256 --wrap black --nowarp " +
                             "--offset -0.5 -0.5 0 --scalest 2 2 " +
-                            "-o out-over.exr ;\n")
-command += testtex_command ("grid-overscan.exr --res 256 256 " +
-                            "--wrap clamp --nowarp " +
+                            "-o out-over.exr", silent=True)
+command += testtex_command ("grid-overscan.exr",
+                            "--res 256 256 --wrap clamp --nowarp " +
                             "--offset -0.5 -0.5 0 --scalest 2 2 " +
-                            "-o out-overclamp.exr ;\n")
+                            "-o out-overclamp.exr", silent=True)
 
 outputs = [ "out-exact.exr", "out-over.exr", "out-overclamp.exr" ]
 


### PR DESCRIPTION
* Try to address the OpenEXR thread pool hanging when we call exit().

    * Strive to remove all exit() calls after any file reads happen,
      in oiiotool, iconvert, and idiff.

    * This does not stop all hanging.

    * Temp workaround: for the Windows CI tests, use ctest commands to
      allow each test to timeout 4 times before giving up. To be clear,
      this does not solve the problem, it only masks it. But it helps
      us "pass" those tests, exposing any other problems occurring with
      them, and we will return later to find the source of any residual
      timeouts.

* Update ref output for several tests where the differ slightly under Windows.

* Make runtest.py convert text output line endings cr-lf -> lf before
  comparing to reference output. (This eliminates unnecessary diffs.)

* Update many tests' run.py file to use double quotes instead of single
  quotes for arguments containing some characters -- looks like the Windows
  shell invoked by Python system() does not handle the single quotes quite
  the same way as Unix shells.

* Helper: ArgParse: add abort() method, lets you stop command line parsing.

* Helper: Filesystem::generic_filepath. Similar to C++17
  std::filesystem::path::generic_string(), but for a filepath sent as
  string_view.

  While I was there, I noticed that a few Filesystem functions that I
  declared as `noexcept` actually call things that can throw, so I put a
  few try/catch in stratgic spots. Nobody had reported a problem with
  this, and maybe it would be fine, but it's the right thing to do.

* oiiotool: when printing the command line after errors, genericize
  identifiable filenames so they render the same on Windows and POSIX,
  and strip directory name from the oiiotool filepath. This makes
  error output comparison more equal between Windows and POSIX, making
  several more tests pass.

In total, this seems to get us down to failing only 7 tests (not counting
spurious timeouts that cause failures).

