### PR TITLE
CI: Bump some dependency versions that we test against

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,8 +210,9 @@ jobs:
           USE_SIMD: avx2,f16c
           LIBRAW_VERSION: 0.20.2
           LIBTIFF_VERSION: v4.2.0
+          OPENCOLOR_VERSION: v2.0.0-rc1
           OPENEXR_VERSION: v2.5.3
-          PUGIXML_VERSION: v1.11.1
+          PUGIXML_VERSION: v1.11.4
           PYBIND11_VERSION: v2.6.1
           WEBP_VERSION: v1.1.0
           MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=7.1.3

--- a/src/build-scripts/build_pugixml.bash
+++ b/src/build-scripts/build_pugixml.bash
@@ -11,7 +11,7 @@ set -ex
 
 # Repo and branch/tag/commit of pugixml to download if we don't have it yet
 PUGIXML_REPO=${PUGIXML_REPO:=https://github.com/zeux/pugixml.git}
-PUGIXML_VERSION=${PUGIXML_VERSION:=v1.10}
+PUGIXML_VERSION=${PUGIXML_VERSION:=v1.11.4}
 
 # Where to put pugixml repo source (default to the ext area)
 PUGIXML_SRC_DIR=${PUGIXML_SRC_DIR:=${PWD}/ext/pugixml}

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -257,7 +257,7 @@ endif ()
 
 option (BUILD_FMT_FORCE "Force local download/build of fmt even if installed" OFF)
 option (BUILD_MISSING_FMT "Local download/build of fmt if not installed" ON)
-set (BUILD_FMT_VERSION "7.0.1" CACHE STRING "Preferred fmtlib/fmt version, when downloading/building our own")
+set (BUILD_FMT_VERSION "7.1.3" CACHE STRING "Preferred fmtlib/fmt version, when downloading/building our own")
 
 macro (find_or_download_fmt)
     # If we weren't told to force our own download/build of fmt, look

--- a/src/cmake/modules/Findpugixml.cmake
+++ b/src/cmake/modules/Findpugixml.cmake
@@ -16,7 +16,9 @@ find_package (pugixml CONFIG)
 if (TARGET pugixml::pugixml)
     # New pugixml (>= 1.11) has nice config files we can rely on and makes a
     # pugixml::pugixml target.
-    message (STATUS "Found CONFIG for pugixml (>=1.11)")
+    if (VERBOSE)
+        message (STATUS "Found CONFIG for pugixml (>=1.11)")
+    endif ()
 
     set (PUGIXML_FOUND true)
     set (pugixml_FOUND true)


### PR DESCRIPTION
* CI use latest PugiXML release

* Have the 'latest' test use OCIO v2 RC1

* Bump which version of fmt we download by default
