### PR TITLE
[exif] memory leak in exif parse

### DIFF
--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -841,6 +841,16 @@ read_exif_tag(ImageSpec& spec, const TIFFDirEntry* dirp, cspan<uint8_t> buf,
         unsigned int offset = dirp->tdir_offset;  // int stored in offset itself
         if (swab)
             swap_endian(&offset);
+        if (offset >= size_t(buf.size())) {
+#if DEBUG_EXIF_READ
+            unsigned int off2 = offset;
+            swap_endian(&off2);
+            std::cerr << "Bad Exif block? ExifIFD has offset " << offset
+                      << " inexplicably greater than exif buffer length "
+                      << buf.size() << " (byte swapped = " << off2 << ")\n";
+#endif
+            return;
+        }
         // Don't recurse if we've already visited this IFD
         if (ifd_offsets_seen.find(offset) != ifd_offsets_seen.end())
             return;


### PR DESCRIPTION
I had a crash on reading a JPEG image coming from a Canon EOS1200D.

After investigation, it appears that an IFD offset was larger than the buffer size. This is tested for various Exif IFD but not for the one spotted in this commit (INTEROP).

I am not sure why I have this problem in the first place (Bad header ? or memory leak ?)  but I assume this check won't hurt.