### PR TITLE
Windows CI fix: windows shell treats quotes differently

### DIFF
--- a/testsuite/null/run.py
+++ b/testsuite/null/run.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-command += oiiotool ("-v -info -stats 'foo.null?RES=640x480&CHANNELS=3&TYPE=uint8&PIXEL=0.25,0.5,1'")
+command += oiiotool ('-v -info -stats "foo.null?RES=640x480&CHANNELS=3&TYPE=uint8&PIXEL=0.25,0.5,1"')


### PR DESCRIPTION
This fixes the testsuite/null test on Windows.
