### PR TITLE
Start staging span and string_view size and ssize changes

### DIFF
--- a/src/include/OpenImageIO/span.h
+++ b/src/include/OpenImageIO/span.h
@@ -21,8 +21,25 @@
 
 OIIO_NAMESPACE_BEGIN
 
+// By default, our span::size() is a signed value, because we wrote this at
+// a time that the draft of std::span said it should be signed. The final
+// C++20 std::span ended up with an unsigned size, like all the other STL
+// classes. We will eventually conform by switching, but not until we are at
+// OIIO 3.0, allowing source code API-breaking incompatibilities. In the
+// mean time, we allow a back door to experiment with standard conformance
+// by pre-defining OIIO_SPAN_SIZE_IS_UNSIGNED=1.
+#if OIIO_VERSION_GREATER_EQUAL(3,0,0)
+#    define OIIO_SPAN_SIZE_IS_UNSIGNED
+#endif
 
-constexpr ptrdiff_t dynamic_extent = -1;
+#ifdef OIIO_SPAN_SIZE_IS_UNSIGNED
+using oiio_span_size_type = size_t;
+#else
+using oiio_span_size_type = ptrdiff_t;
+#endif
+
+OIIO_INLINE_CONSTEXPR oiio_span_size_type dynamic_extent = -1;
+
 
 
 /// span<T> is a non-owning, non-copying, non-allocating reference to a
@@ -53,35 +70,37 @@ constexpr ptrdiff_t dynamic_extent = -1;
 /// structure (unless you are really sure you know what you're doing).
 ///
 
-template <typename T, ptrdiff_t Extent = dynamic_extent>
+template <typename T, oiio_span_size_type Extent = dynamic_extent>
 class span {
     static_assert (std::is_array<T>::value == false, "can't have span of an array");
 public:
     using element_type = T;
     using value_type = typename std::remove_cv<T>::type;
-    using index_type = ptrdiff_t;
+    using size_type = oiio_span_size_type;
     using difference_type = ptrdiff_t;
-    using size_type = ptrdiff_t;
+#if OIIO_VERSION < OIIO_MAKE_VERSION(3,0,0)
+    using index_type = size_type;  // DEPRECATED(3.0)
+#endif
     using pointer = element_type*;
     using reference = element_type&;
     using iterator = element_type*;
     using const_iterator = const element_type*;
     using reverse_iterator = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-    static constexpr index_type extent = Extent;
+    static constexpr size_type extent = Extent;
 
     /// Default constructor -- the span points to nothing.
     constexpr span () noexcept { }
 
     /// Copy constructor (copies the span pointer and length, NOT the data).
-    template<class U, ptrdiff_t N>
+    template<class U, oiio_span_size_type N>
     constexpr span (const span<U,N> &copy) noexcept
         : m_data(copy.data()), m_size(copy.size()) { }
     /// Copy constructor (copies the span pointer and length, NOT the data).
     constexpr span (const span &copy) noexcept = default;
 
     /// Construct from T* and length.
-    constexpr span (pointer data, index_type size) noexcept
+    constexpr span (pointer data, size_type size) noexcept
         : m_data(data), m_size(size) { }
 
     /// Construct from begin and end pointers.
@@ -131,43 +150,48 @@ public:
     }
 
     /// Subview containing the first Count elements of the span.
-    template<index_type Count>
+    template<size_type Count>
     constexpr span<element_type, Count> first () const {
         return { m_data, Count };
     }
     /// Subview containing the last Count elements of the span.
-    template<index_type Count>
+    template<size_type Count>
     constexpr span<element_type, Count> last () const {
         return { m_data + m_size - Count, Count };
     }
 
-    template<index_type Offset, index_type Count = dynamic_extent>
+    template<size_type Offset, size_type Count = dynamic_extent>
     constexpr span<element_type, Count> subspan () const {
         return { m_data + Offset, Count != dynamic_extent ? Count : (Extent != dynamic_extent ? Extent - Offset : m_size - Offset) };
     }
 
-    constexpr span<element_type, dynamic_extent> first (index_type count) const {
+    constexpr span<element_type, dynamic_extent> first (size_type count) const {
         return { m_data, count };
     }
 
-    constexpr span<element_type, dynamic_extent> last (index_type count) const {
+    constexpr span<element_type, dynamic_extent> last (size_type count) const {
         return { m_data + ( m_size - count ), count };
     }
 
     constexpr span<element_type, dynamic_extent>
-    subspan (index_type offset, index_type count = dynamic_extent) const {
+    subspan (size_type offset, size_type count = dynamic_extent) const {
         return { m_data + offset, count == dynamic_extent ? m_size - offset : count };
     }
 
-    constexpr index_type size() const noexcept { return m_size; }
-    constexpr index_type size_bytes() const noexcept { return m_size*sizeof(T); }
+    // Note: size() currently returns a signed value. But eventually, we
+    // will conform to std::span<>::size() which returns size_t. In the mean
+    // time, apps may choose to avoid the size() method and instead use
+    // std::size(myspan) and std::ssize(myspan), which already conform to
+    // std's practice of returning size_t and ptrdiff_t, respectively.
+    constexpr size_type size() const noexcept { return m_size; }
+    constexpr size_type size_bytes() const noexcept { return size()*sizeof(T); }
     constexpr bool empty() const noexcept { return m_size == 0; }
 
     constexpr pointer data() const noexcept { return m_data; }
 
-    constexpr reference operator[] (index_type idx) const { return m_data[idx]; }
-    constexpr reference operator() (index_type idx) const { return m_data[idx]; }
-    reference at (index_type idx) const {
+    constexpr reference operator[] (size_type idx) const { return m_data[idx]; }
+    constexpr reference operator() (size_type idx) const { return m_data[idx]; }
+    reference at (size_type idx) const {
         if (idx >= size())
             throw (std::out_of_range ("OpenImageIO::span::at"));
         return m_data[idx];
@@ -190,7 +214,7 @@ public:
 
 private:
     pointer     m_data = nullptr;
-    index_type  m_size = 0;
+    size_type   m_size = 0;
 };
 
 
@@ -202,7 +226,7 @@ using cspan = span<const T>;
 
 
 /// Compare all elements of two spans for equality
-template <class T, ptrdiff_t X, class U, ptrdiff_t Y>
+template <class T, oiio_span_size_type X, class U, oiio_span_size_type Y>
 OIIO_CONSTEXPR14 bool operator== (span<T,X> l, span<U,Y> r) {
 #if OIIO_CPLUSPLUS_VERSION >= 20
     return std::equal (l.begin(), l.end(), r.begin(), r.end());
@@ -216,7 +240,7 @@ OIIO_CONSTEXPR14 bool operator== (span<T,X> l, span<U,Y> r) {
 }
 
 /// Compare all elements of two spans for inequality
-template <class T, ptrdiff_t X, class U, ptrdiff_t Y>
+template <class T, oiio_span_size_type X, class U, oiio_span_size_type Y>
 OIIO_CONSTEXPR14 bool operator!= (span<T,X> l, span<U,Y> r) {
     return !(l == r);
 }
@@ -227,15 +251,18 @@ OIIO_CONSTEXPR14 bool operator!= (span<T,X> l, span<U,Y> r) {
 /// array with known length and optionally non-default strides through the
 /// data.  An span_strided<T> is mutable (the values in the array may
 /// be modified), whereas an span_strided<const T> is not mutable.
-template <typename T, ptrdiff_t Extent = dynamic_extent>
+template <typename T, oiio_span_size_type Extent = dynamic_extent>
 class span_strided {
     static_assert (std::is_array<T>::value == false,
                    "can't have span_strided of an array");
 public:
     using element_type = T;
     using value_type = typename std::remove_cv<T>::type;
-    using index_type = ptrdiff_t;
+    using size_type  = oiio_span_size_type;
     using difference_type = ptrdiff_t;
+#if OIIO_VERSION < OIIO_MAKE_VERSION(3,0,0)
+    using index_type = size_type;  // DEPRECATED(3.0)
+#endif
     using stride_type = ptrdiff_t;
     using pointer = element_type*;
     using reference = element_type&;
@@ -243,7 +270,7 @@ public:
     using const_iterator = const element_type*;
     using reverse_iterator = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-    static constexpr index_type extent = Extent;
+    static constexpr size_type extent = Extent;
 
     /// Default ctr -- points to nothing
     constexpr span_strided () noexcept {}
@@ -253,7 +280,7 @@ public:
         : m_data(copy.data()), m_size(copy.size()), m_stride(copy.stride()) {}
 
     /// Construct from T* and size, and optionally stride.
-    constexpr span_strided (pointer data, index_type size, stride_type stride=1)
+    constexpr span_strided (pointer data, size_type size, stride_type stride=1)
         : m_data(data), m_size(size), m_stride(stride) { }
 
     /// Construct from a single T&.
@@ -292,16 +319,16 @@ public:
         return *this;
     }
 
-    constexpr index_type size() const noexcept { return m_size; }
+    constexpr size_type size() const noexcept { return m_size; }
     constexpr stride_type stride() const noexcept { return m_stride; }
 
-    constexpr reference operator[] (index_type idx) const {
+    constexpr reference operator[] (size_type idx) const {
         return m_data[m_stride*idx];
     }
-    constexpr reference operator() (index_type idx) const {
+    constexpr reference operator() (size_type idx) const {
         return m_data[m_stride*idx];
     }
-    reference at (index_type idx) const {
+    reference at (size_type idx) const {
         if (idx >= size())
             throw (std::out_of_range ("OpenImageIO::span_strided::at"));
         return m_data[m_stride*idx];
@@ -312,7 +339,7 @@ public:
 
 private:
     pointer       m_data   = nullptr;
-    index_type    m_size   = 0;
+    size_type     m_size   = 0;
     stride_type   m_stride = 1;
 };
 
@@ -325,7 +352,7 @@ using cspan_strided = span_strided<const T>;
 
 
 /// Compare all elements of two spans for equality
-template <class T, ptrdiff_t X, class U, ptrdiff_t Y>
+template <class T, oiio_span_size_type X, class U, oiio_span_size_type Y>
 OIIO_CONSTEXPR14 bool operator== (span_strided<T,X> l, span_strided<U,Y> r) {
     auto lsize = l.size();
     if (lsize != r.size())
@@ -337,10 +364,45 @@ OIIO_CONSTEXPR14 bool operator== (span_strided<T,X> l, span_strided<U,Y> r) {
 }
 
 /// Compare all elements of two spans for inequality
-template <class T, ptrdiff_t X, class U, ptrdiff_t Y>
+template <class T, oiio_span_size_type X, class U, oiio_span_size_type Y>
 OIIO_CONSTEXPR14 bool operator!= (span_strided<T,X> l, span_strided<U,Y> r) {
     return !(l == r);
 }
 
 
 OIIO_NAMESPACE_END
+
+
+
+// Declare std::size and std::ssize for our span.
+namespace std {
+
+template<class T, OIIO::oiio_span_size_type E = OIIO::dynamic_extent>
+constexpr size_t size(const OIIO::span<T, E>& c) {
+    return static_cast<size_t>(c.size());
+}
+
+template<class T, OIIO::oiio_span_size_type E = OIIO::dynamic_extent>
+constexpr size_t size(const OIIO::span_strided<T, E>& c) {
+    return static_cast<size_t>(c.size());
+}
+
+
+#if OIIO_CPLUSPLUS_VERSION < 20
+// C++20 and beyond already have these declared.
+template<class T, OIIO::oiio_span_size_type E = OIIO::dynamic_extent>
+constexpr ptrdiff_t ssize(const OIIO::span<T, E>& c) {
+    return static_cast<ptrdiff_t>(c.size());
+}
+
+template<class T, OIIO::oiio_span_size_type E = OIIO::dynamic_extent>
+constexpr ptrdiff_t ssize(const OIIO::span_strided<T, E>& c) {
+    return static_cast<ptrdiff_t>(c.size());
+}
+#endif
+
+// Allow client software to easily know if the std::size/ssize was added for
+// our span templates.
+#define OIIO_SPAN_HAS_STD_SIZE 1
+
+} // namespace std

--- a/src/include/OpenImageIO/string_view.h
+++ b/src/include/OpenImageIO/string_view.h
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstring>
+#include <limits>
 #include <ostream>
 #include <stdexcept>
 #include <string>
@@ -77,7 +78,7 @@ public:
     static const size_type npos = ~size_type(0);
 
     /// Default ctr
-    string_view() noexcept { init(nullptr, 0); }
+    constexpr string_view() noexcept : m_chars(nullptr), m_len(0) { }
     /// Copy ctr
     string_view(const string_view& copy) noexcept { init(copy.m_chars, copy.m_len); }
     /// Construct from char* and length.
@@ -136,11 +137,13 @@ public:
     const_reverse_iterator crend() const noexcept { return const_reverse_iterator (begin()); }
 
     // capacity
-    size_type size() const noexcept { return m_len; }
-    size_type length() const noexcept { return m_len; }
-    size_type max_size() const noexcept { return m_len; }
+    constexpr size_type size() const noexcept { return m_len; }
+    constexpr size_type length() const noexcept { return m_len; }
+    constexpr size_type max_size() const noexcept {
+        return std::numeric_limits<size_type>::max();
+    }
     /// Is the string_view empty, containing no characters?
-    bool empty() const noexcept { return m_len == 0; }
+    constexpr bool empty() const noexcept { return m_len == 0; }
 
     /// Element access of an individual character (beware: no bounds
     /// checking!).
@@ -382,3 +385,25 @@ typedef string_view string_ref;
 
 
 OIIO_NAMESPACE_END
+
+
+
+// Declare std::size and std::ssize for our string_view.
+namespace std {
+
+#if OIIO_CPLUSPLUS_VERSION < 17
+constexpr size_t size(const OIIO::string_view& c) { return c.size(); }
+#endif
+
+#if OIIO_CPLUSPLUS_VERSION < 20
+constexpr ptrdiff_t ssize(const OIIO::string_view& c) {
+    return static_cast<ptrdiff_t>(c.size());
+}
+#endif
+
+// Allow client software to easily know if the std::size/ssize was added for
+// our string_view.
+#define OIIO_STRING_VIEW_HAS_STD_SIZE 1
+
+
+} // namespace std

--- a/src/libutil/span_test.cpp
+++ b/src/libutil/span_test.cpp
@@ -22,6 +22,8 @@ test_span()
     static float A[] = { 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 0 };
     cspan<float> a(A);
     OIIO_CHECK_EQUAL(a.size(), 12);
+    OIIO_CHECK_EQUAL(std::size(a), size_t(12));
+    OIIO_CHECK_EQUAL(std::ssize(a), int(12));
     OIIO_CHECK_EQUAL(a[0], 0.0f);
     OIIO_CHECK_EQUAL(a[1], 1.0f);
     OIIO_CHECK_EQUAL(a[2], 0.0f);
@@ -59,6 +61,8 @@ test_span_mutable()
     float A[] = { 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 0 };
     span<float> a(A);
     OIIO_CHECK_EQUAL(a.size(), 12);
+    OIIO_CHECK_EQUAL(std::size(a), size_t(12));
+    OIIO_CHECK_EQUAL(std::ssize(a), int(12));
     OIIO_CHECK_EQUAL(a[0], 0.0f);
     OIIO_CHECK_EQUAL(a[1], 1.0f);
     OIIO_CHECK_EQUAL(a[2], 0.0f);

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1120,7 +1120,6 @@ Oiiotool::express_parse_atom(const string_view expr, string_view& s,
     // std::cout << " Entering express_parse_atom, s='" << s << "'\n";
 
     string_view orig = s;
-    string_view stringval;
     float floatval;
 
     Strutil::skip_whitespace(s);


### PR DESCRIPTION
When we wrote our `span<>`, we based it off the draft for std::span,
which at that time specified span::size() as ptrdiff_t, which is
signed. By the time std::span got finalized in C++20, it was changed
to size_t, which is unsigned. Ick. Switching to size_t will be an API
break, so we can't do that until we're at a version where it's ok to
make breaking changes.

But we can stage a few changes that will make that future transition
easier.

* Add std::size() and std::ssize() wrappers for both span and
  string_view.  This gives downstream apps the opportunity to avoid
  span::size(), instead using std::size(the_span), which is guaranteed
  to be unsigned, and std::ssize(the_span), which is guaranteed to be
  signed, and both of these will work now as well as after we make the
  other breaking changes.

* Doing this properly required adding a couple 'constexpr' in places
  where they should have been all along.

* Define macros OIIO_SPAN_HAS_STD_SIZE and OIIO_STRING_VIEW_HAS_STD_SIZE
  making it easy to know if std::size and std::ssize are defined for
  span and string_view

* OIIO_SPAN_SIZE_IS_UNSIGNED will be defined when OIIO::span switches
  to having an unsigned size like std::span (making it easy for client
  software to know if span::size is signed or unsigned).

  Turn this on automatically for OIIO >= 3.0 so we don't forget.

  If client code predefines OIIO_SPAN_SIZE_IS_UNSIGNED before
  including span.h, that forces span::size to unsigned now (good for
  experimentation and compatibility testing, but I don't recommend
  anybody ship software in that state unless they really know what
  they are doing and don't mind potential incompatibility with the
  out-of-the-box OIIO).

These SHOULD NOT break any existing code or ABIs that uses our
existing span and string_view classes or their size() methods. It only
adds options that will help bridge compatibility.