### PR TITLE
Changing pybind11 bindings to used SHARED rather than using MODULE

### DIFF
--- a/src/cmake/pythonutils.cmake
+++ b/src/cmake/pythonutils.cmake
@@ -69,7 +69,7 @@ macro (setup_python_module)
         set_property (SOURCE ${lib_SOURCES} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-macro-redefined ")
     endif ()
 
-    pybind11_add_module(${target_name} ${lib_SOURCES})
+    pybind11_add_module(${target_name} SHARED ${lib_SOURCES})
 
 #    # Add the library itself
 #    add_library (${target_name} MODULE ${lib_SOURCES})

--- a/src/cmake/pythonutils.cmake
+++ b/src/cmake/pythonutils.cmake
@@ -8,6 +8,11 @@ set (PYTHON_VERSION "" CACHE STRING "Target version of python to find")
 option (PYLIB_INCLUDE_SONAME "If ON, soname/soversion will be set for Python module library" OFF)
 option (PYLIB_LIB_PREFIX "If ON, prefix the Python module with 'lib'" OFF)
 set (PYMODULE_SUFFIX "" CACHE STRING "Suffix to add to Python module init namespace")
+if (WIN32)
+    set (PYLIB_LIB_TYPE SHARED CACHE STRING "Type of library to build for python module (MODULE or SHARED)")
+else ()
+    set (PYLIB_LIB_TYPE MODULE CACHE STRING "Type of library to build for python module (MODULE or SHARED)")
+endif ()
 
 
 # Find Python. This macro should only be called if python is required. If
@@ -69,7 +74,7 @@ macro (setup_python_module)
         set_property (SOURCE ${lib_SOURCES} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-macro-redefined ")
     endif ()
 
-    pybind11_add_module(${target_name} SHARED ${lib_SOURCES})
+    pybind11_add_module(${target_name} ${PYLIB_LIB_TYPE} ${lib_SOURCES})
 
 #    # Add the library itself
 #    add_library (${target_name} MODULE ${lib_SOURCES})


### PR DESCRIPTION
This subtle change basically allows the python bindings to work correctly on windows.

For some background, I don't think I've ever gotten OIIO python bindings to work on windows, I've always chalked this up to using different versions of MSVC and never thought much of it (and just learned to only use the bindings at work).

All dependencies would have been installed via `vcpkg`.

The sort of error I would typically see was:
```python
>>> import OpenImageIO
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: DLL load failed while importing OpenImageIO: The specified module could not be found.
```

Not terribly informative, but if instead I do:
```python
from ctypes import cdll
cdll.LoadLibrary("./OpenImageIO.cp38-win_amd64.pyd")
```

We get a popup message saying the following symbol couldn't be resolved:
`??9TypeDesc@OpenImageIO_v2_3@@QEBA_NAEBU01@@Z`

Running that through `https://demangler.com/` we get:
`public: BOOL __cdecl OpenImageIO_v2_3::TypeDesc::operator!=(struct OpenImageIO_v2_3::TypeDesc const & __ptr64)const __ptr64`

The actual definition of which is:
```cpp
    constexpr bool operator!= (const TypeDesc &t) const noexcept { return ! (*this == t); }
```

And if we run dumpbin on the python module we can see:
```
    OpenImageIO.dll
             1800D3280 Import Address Table
             1800EDBB8 Import Name Table
                     0 time date stamp
                     0 Index of first forwarder reference

                         14A ??9TypeDesc@OpenImageIO_v2_3@@QEBA_NAEBU01@@Z
                         ...
```

Somehow the python shared object, has a dependency on a constexpr function, which could (and I haven't looked into this) have something to do with declaring `OIIO_API` at the class level.

In any case, changing `pybind11_add_module` to use `SHARED` rather than implicitly `MODULE` fixes this (which is something I've seen using GCC/Linux on in-house codebases).



