### PR TITLE
imagebuf_test: reset the IB before we remove the file it's reading

### DIFF
--- a/src/libOpenImageIO/imagebuf_test.cpp
+++ b/src/libOpenImageIO/imagebuf_test.cpp
@@ -415,6 +415,7 @@ test_write_over()
     ImageBuf A("tmp-green.tif");
     A.getpixel(4, 4, pixel);
     OIIO_CHECK_ASSERT(pixel[0] == 0 && pixel[1] == 1 && pixel[2] == 0);
+    A.reset();  // make sure A isn't held open, we're about to remove it
 
     // Replace the green image with red, under the nose of the ImageBuf.
     Filesystem::remove("tmp-green.tif");
@@ -426,6 +427,7 @@ test_write_over()
     ImageBuf B("tmp-green.tif");
     B.getpixel(4, 4, pixel);
     OIIO_CHECK_ASSERT(pixel[0] == 1 && pixel[1] == 0 && pixel[2] == 0);
+    B.reset();  // make sure B isn't held open, we're about to remove it
 
     Filesystem::remove("tmp-green.tif");
 }


### PR DESCRIPTION
This is a weird thing we're doing in this very artificial test,
removing a file when the IB reading it is still alive. That's safe on
Unix, where a file with an open file handle still be safe to read even
if it's removed.  But it's not kosher on Windows.  Fix by simply making
sure that in this test, we aren't doing the unadvised thing of having
the IB still active on the file we're deleting. This should fix the
unit_imagebuf test that is failing our Windows CI.
