### PR TITLE
Fix argument order mismatch on IBA::ociolook and ociofiletransform

### DIFF
--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1657,8 +1657,8 @@ ImageBufAlgo::colorconvert(const ImageBuf& src, const ColorProcessor* processor,
 
 bool
 ImageBufAlgo::ociolook(ImageBuf& dst, const ImageBuf& src, string_view looks,
-                       string_view from, string_view to, bool inverse,
-                       bool unpremult, string_view key, string_view value,
+                       string_view from, string_view to, bool unpremult,
+                       bool inverse, string_view key, string_view value,
                        ColorConfig* colorconfig, ROI roi, int nthreads)
 {
     pvt::LoggedTimer logtime("IBA::ociolook");
@@ -1701,12 +1701,12 @@ ImageBufAlgo::ociolook(ImageBuf& dst, const ImageBuf& src, string_view looks,
 
 ImageBuf
 ImageBufAlgo::ociolook(const ImageBuf& src, string_view looks, string_view from,
-                       string_view to, bool inverse, bool unpremult,
+                       string_view to, bool unpremult, bool inverse,
                        string_view key, string_view value,
                        ColorConfig* colorconfig, ROI roi, int nthreads)
 {
     ImageBuf result;
-    bool ok = ociolook(result, src, looks, from, to, inverse, unpremult, key,
+    bool ok = ociolook(result, src, looks, from, to, unpremult, inverse, key,
                        value, colorconfig, roi, nthreads);
     if (!ok && !result.has_error())
         result.errorf("ImageBufAlgo::ociolook() error");
@@ -1775,7 +1775,7 @@ ImageBufAlgo::ociodisplay(const ImageBuf& src, string_view display,
 
 bool
 ImageBufAlgo::ociofiletransform(ImageBuf& dst, const ImageBuf& src,
-                                string_view name, bool inverse, bool unpremult,
+                                string_view name, bool unpremult, bool inverse,
                                 ColorConfig* colorconfig, ROI roi, int nthreads)
 {
     pvt::LoggedTimer logtime("IBA::ociofiletransform");
@@ -1811,11 +1811,11 @@ ImageBufAlgo::ociofiletransform(ImageBuf& dst, const ImageBuf& src,
 
 ImageBuf
 ImageBufAlgo::ociofiletransform(const ImageBuf& src, string_view name,
-                                bool inverse, bool unpremult,
+                                bool unpremult, bool inverse,
                                 ColorConfig* colorconfig, ROI roi, int nthreads)
 {
     ImageBuf result;
-    bool ok = ociofiletransform(result, src, name, inverse, unpremult,
+    bool ok = ociofiletransform(result, src, name, unpremult, inverse,
                                 colorconfig, roi, nthreads);
     if (!ok && !result.has_error())
         result.errorf("ImageBufAlgo::ociofiletransform() error");

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -2164,8 +2164,8 @@ OIIOTOOL_OP(ociofiletransform, 1, [](OiiotoolOp& op, span<ImageBuf*> img) {
     string_view name = op.args(1);
     bool inverse     = op.options().get_int("inverse");
     bool unpremult   = op.options().get_int("unpremult");
-    return ImageBufAlgo::ociofiletransform(*img[0], *img[1], name, inverse,
-                                           unpremult, &ot.colorconfig);
+    return ImageBufAlgo::ociofiletransform(*img[0], *img[1], name, unpremult,
+                                           inverse, &ot.colorconfig);
 });
 
 


### PR DESCRIPTION
Ugh, the argument order of the headers and documentation didn't match
that of the implementation, with the inverse and unpremult args swapped.

Let's declare that the documented version is correct, and fix the implementation
to match.