### PR TITLE
Don't use the version of libheif that's known to be broken on Mac

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -163,10 +163,16 @@ checked_find_package (GIF
                       VERSION_MIN 4
                       RECOMMEND_MIN 5.0
                       RECOMMEND_MIN_REASON "for stability and thread safety")
+
 # For HEIF/HEIC/AVIF formats
 checked_find_package (Libheif VERSION_MIN 1.3
                       RECOMMEND_MIN 1.7
                       RECOMMEND_MIN_REASON "for AVIF support")
+if (APPLE AND LIBHEIF_VERSION VERSION_GREATER_EQUAL 1.10 AND LIBHEIF_VERSION VERSION_LESS 1.11)
+    message (WARNING "Libheif 1.10 on Apple is known to be broken, disabling libheif support")
+    set (Libheif_FOUND 0)
+endif ()
+
 checked_find_package (LibRaw
                       RECOMMEND_MIN 0.18
                       RECOMMEND_MIN_REASON "for ACES support and better camera metadata"


### PR DESCRIPTION
This was causing failed CI tests and probably confused users.
libheif 1.10 is very broken on MacOS. The author says that 1.11 will come soon.
