### PR TITLE
Use std types, not TIFF-defined types

### DIFF
--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -794,7 +794,7 @@ TIFFInput::spec_dimensions(int subimage, int miplevel)
 void
 TIFFInput::readspec(bool read_meta)
 {
-    uint32 width = 0, height = 0, depth = 0;
+    uint32_t width = 0, height = 0, depth = 0;
     TIFFGetField(m_tif, TIFFTAG_IMAGEWIDTH, &width);
     TIFFGetField(m_tif, TIFFTAG_IMAGELENGTH, &height);
     TIFFGetFieldDefaulted(m_tif, TIFFTAG_IMAGEDEPTH, &depth);
@@ -1121,10 +1121,10 @@ TIFFInput::readspec(bool read_meta)
     int iptcsize         = 0;
     const void* iptcdata = NULL;
     if (TIFFGetField(m_tif, TIFFTAG_RICHTIFFIPTC, &iptcsize, &iptcdata)) {
-        std::vector<uint32> iptc((uint32*)iptcdata,
-                                 (uint32*)iptcdata + iptcsize);
+        std::vector<uint32_t> iptc((uint32_t*)iptcdata,
+                                   (uint32_t*)iptcdata + iptcsize);
         if (TIFFIsByteSwapped(m_tif))
-            TIFFSwabArrayOfLong((uint32*)&iptc[0], iptcsize);
+            TIFFSwabArrayOfLong((uint32_t*)&iptc[0], iptcsize);
         decode_iptc_iim(&iptc[0], iptcsize * 4, m_spec);
     }
 #endif

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -634,7 +634,7 @@ TIFFOutput::open(const std::string& name, const ImageSpec& userspec,
     if (icc_profile_parameter != NULL) {
         unsigned char* icc_profile
             = (unsigned char*)icc_profile_parameter->data();
-        uint32 length = icc_profile_parameter->type().size();
+        uint32_t length = icc_profile_parameter->type().size();
         if (icc_profile && length)
             TIFFSetField(m_tif, TIFFTAG_ICCPROFILE, length, icc_profile);
     }
@@ -906,7 +906,11 @@ TIFFOutput::write_exif_data()
     }
 
     // Now write the directory of Exif data
-    uint64 dir_offset = 0;
+#    ifndef TIFF_GCC_DEPRECATED
+    uint64 dir_offset = 0;  // old type
+#    else
+    uint64_t dir_offset = 0;
+#    endif
     if (!TIFFWriteCustomDirectory(m_tif, &dir_offset)) {
         errorf("failed TIFFWriteCustomDirectory() of the Exif data");
         return false;


### PR DESCRIPTION
libtiff trunk is removing these custom types from future
versions. They have been there forever, since long before the std
versions were present.
