### PR TITLE
OpenColorIO v2 miscellany

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
 
   linux-latest-releases:
     # Test against latest supported releases of toolchain and dependencies.
-    name: "Linux latest releases: gcc10 C++17 avx2 exr2.5"
+    name: "Linux latest releases: gcc10 C++17 avx2 exr2.5 ocio2.0"
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -210,10 +210,10 @@ jobs:
           USE_SIMD: avx2,f16c
           LIBRAW_VERSION: 0.20.2
           LIBTIFF_VERSION: v4.2.0
-          OPENCOLOR_VERSION: v2.0.0-rc1
+          OPENCOLORIO_VERSION: v2.0.0
           OPENEXR_VERSION: v2.5.3
           PUGIXML_VERSION: v1.11.4
-          PYBIND11_VERSION: v2.6.1
+          PYBIND11_VERSION: v2.6.2
           WEBP_VERSION: v1.1.0
           MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=7.1.3
         run: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * C++11 (also builds with C++14 and C++17)
  * Compilers: gcc 4.8.2 - 10.2, clang 3.3 - 11, MSVS 2015 - 2019,
    icc version 13 or higher
- * CMake >= 3.12 (tested through 3.18)
+ * CMake >= 3.12 (tested through 3.19)
  * OpenEXR >= 2.0 (recommended: 2.2 or higher; tested through 2.5, also
    tested against the current master that will be OpenEXR 3.0 / Imath 3.0)
  * libTIFF >= 3.9 (recommended: 4.0+; tested through 4.2.0)
@@ -37,12 +37,12 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you want support for a wide variety of video formats:
      * ffmpeg >= 2.6 (tested through 4.3)
  * If you want support for jpeg 2000 images:
-     * **OpenJpeg >= 2.0** (tested through 2.3)
+     * **OpenJpeg >= 2.0** (tested through 2.4)
  * If you want support for Field3D files:
      * Field3D (tested through 1.7.3)
  * If you want support for OpenVDB files:
-     * OpenVDB >= 5.0 (tested through 7.0) and Intel TBB >= 2018 (tested
-       through 2020_U1)
+     * OpenVDB >= 5.0 (tested through 8.0) and Intel TBB >= 2018 (tested
+       through 2020_U3)
  * If you want support for converting to and from OpenCV data structures,
    or for capturing images from a camera:
      * OpenCV 2.x, 3.x, or 4.x (tested through 4.5)
@@ -60,8 +60,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you want support for WebP images:
      * WebP >= 0.6.1 (tested through 1.1.0)
  * If you want support for OpenColorIO color transformations:
-     * OpenColorIO >= 1.1 (also tested against the current master that will
-       become OCIO 2.0).
+     * OpenColorIO 1.1 or 2.0
  * We use PugiXML for XML parsing. There is a version embedded in the OIIO
    tree, but if you want to use an external, system-installed version (as
    may be required by some software distrbutions with policies against

--- a/src/build-scripts/ci-build-and-test.bash
+++ b/src/build-scripts/ci-build-and-test.bash
@@ -50,6 +50,7 @@ if [[ "${DEBUG_CI:=0}" != "0" ]] ; then
 fi
 
 if [[ "${SKIP_TESTS:=0}" == "0" ]] ; then
+    export OCIO="$PWD/testsuite/common/OpenColorIO/nuke-default/config.ocio"
     $OpenImageIO_ROOT/bin/oiiotool --help || true
     TESTSUITE_CLEANUP_ON_SUCCESS=${TESTSUITE_CLEANUP_ON_SUCCESS:=1}
     echo "Parallel test " ${CTEST_PARALLEL_LEVEL}

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -281,6 +281,10 @@ public:
     /// Return if OpenImageIO was built with OCIO support
     static bool supportsOpenColorIO();
 
+    /// Return the hex OCIO version (maj<<24 + min<<16 + patch), or 0 if no
+    /// OCIO support is available.
+    static int OpenColorIO_version_hex();
+
 private:
     ColorConfig(const ColorConfig&) = delete;
     ColorConfig& operator=(const ColorConfig&) = delete;

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -149,6 +149,18 @@ ColorConfig::supportsOpenColorIO()
 
 
 
+int
+ColorConfig::OpenColorIO_version_hex()
+{
+#ifdef USE_OCIO
+    return OCIO_VERSION_HEX;
+#else
+    return 0;
+#endif
+}
+
+
+
 // Hidden implementation of ColorConfig
 class ColorConfig::Impl {
 public:

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5212,7 +5212,13 @@ print_help_end(std::ostream& out)
     out << formatted_format_list("Output", "output_format_list") << "\n";
 
     // debugging color space names
-    out << "Color configuration: " << ot.colorconfig.configname() << "\n";
+    int ociover = ot.colorconfig.OpenColorIO_version_hex();
+    if (ociover)
+        out << "OpenColorIO " << (ociover >> 24) << '.'
+            << ((ociover >> 16) & 0xff) << '.' << ((ociover >> 8) & 0xff);
+    else
+        out << "No OpenColorIO";
+    out << ", color config: " << ot.colorconfig.configname() << "\n";
     std::stringstream s;
     s << "Known color spaces: ";
     const char* linear = ot.colorconfig.getColorSpaceNameByRole("linear");

--- a/src/python/py_colorconfig.cpp
+++ b/src/python/py_colorconfig.cpp
@@ -88,7 +88,8 @@ declare_colorconfig(py::module& m)
              })
         .def("configname", &ColorConfig::configname);
 
-    m.attr("supportsOpenColorIO") = ColorConfig::supportsOpenColorIO();
+    m.attr("supportsOpenColorIO")     = ColorConfig::supportsOpenColorIO();
+    m.attr("OpenColorIO_version_hex") = ColorConfig::OpenColorIO_version_hex();
 }
 
 }  // namespace PyOpenImageIO


### PR DESCRIPTION
Oops, we used the wrong name for the env variable, and that CI test
wasn't getting the OCIOv2 RC all along!

Add OIIO::ColorConfig::OpenColorIO_version_hex().

Have oiiotool --help print the OCIO version.

Also Bump the pybind11 version for the "latest" test, and update
INSTALL.md a bit to document the latest versions known to work of
several dependencies.