### PR TITLE
Modify hash_test to verify correctness and stability of the hashes

### DIFF
--- a/src/include/OpenImageIO/detail/farmhash.h
+++ b/src/include/OpenImageIO/detail/farmhash.h
@@ -78,7 +78,7 @@
 // Make static inline 'const expr, if possible.  Also, try to make CUDA friendly
 // for device code.
 #undef STATIC_INLINE
-#if  __cplusplus >= 201402L
+#if OIIO_CPLUSPLUS_VERSION >= 14
 #  define HASH_CAN_USE_CONSTEXPR 1
 #endif
 #define STATIC_INLINE OIIO_HOSTDEVICE inline OIIO_CONSTEXPR14

--- a/src/include/OpenImageIO/detail/farmhash.h
+++ b/src/include/OpenImageIO/detail/farmhash.h
@@ -80,14 +80,8 @@
 #undef STATIC_INLINE
 #if  __cplusplus >= 201402L
 #  define HASH_CAN_USE_CONSTEXPR 1
-#  ifdef __CUDA_ARCH__
-#      define STATIC_INLINE __device__ inline constexpr
-#  else
-#      define STATIC_INLINE static inline constexpr
-#  endif
-#else
-#  define STATIC_INLINE static inline
 #endif
+#define STATIC_INLINE OIIO_HOSTDEVICE inline OIIO_CONSTEXPR14
 
 // FARMHASH PORTABILITY LAYER: Runtime error if misconfigured
 
@@ -232,7 +226,7 @@ namespace inlined {
 #if !defined(HASH_CAN_USE_CONSTEXPR) || HASH_CAN_USE_CONSTEXPR == 0
 
 STATIC_INLINE uint64_t Fetch64(const char *p) {
-  uint64_t result;
+  uint64_t result = 0;
   memcpy(&result, p, sizeof(result));
   return uint64_in_expected_order(result);
 }
@@ -511,16 +505,7 @@ template <typename T> STATIC_INLINE T DebugTweak(T x) {
   return x;
 }
 
-#ifdef HASH_CAN_USE_CONSTEXPR
-#  ifdef __CUDA_ARCH__
-#    define CONST_EXPR __device__ constexpr
-#  else
-#    define CONST_EXPR constexpr
-#  endif
-#else
-#define CONST_EXPR
-#endif
-template <> CONST_EXPR uint128_t DebugTweak(uint128_t x) {
+template <> STATIC_INLINE uint128_t DebugTweak(uint128_t x) {
   if (debug_mode) {
     uint64_t y = DebugTweak(Uint128Low64(x));
     uint64_t z = DebugTweak(Uint128High64(x));

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -278,25 +278,25 @@ std::string OIIO_API wordwrap (string_view src, int columns = 80,
                                int prefix = 0, string_view sep = " ",
                                string_view presep = "");
 
-#if defined(HASH_CAN_USE_CONSTEXPR) && HASH_CAN_USE_CONSTEXPR == 1
-static inline constexpr
-size_t strhash (size_t len, const char *s)
-{
-    return OIIO::farmhash::inlined::Hash(s, len);
-}
-#else
-static inline
-size_t strhash (size_t len, const char *s)
-{
-    return OIIO::farmhash::inlined::Hash(s, len);
-}
-#endif
 
-/// Hash a string_view.
-inline size_t
+/// Our favorite "string" hash of a length of bytes. Currently, it is just
+/// a wrapper for an inlined, constexpr (if C++ >= 14), Cuda-safe farmhash.
+inline OIIO_CONSTEXPR14 size_t
+strhash (size_t len, const char *s)
+{
+    return OIIO::farmhash::inlined::Hash(s, len);
+}
+
+
+/// Hash a string_view. This is OIIO's default favorite string hasher.
+/// Currently, it uses farmhash, is constexpr (for C++14), and works in
+/// Cuda. This is rigged, though, so that empty strings hash always hash to
+/// 0 (that isn't would a raw farmhash would give you, but it's a useful
+/// property, especially for trivial initialization).
+inline OIIO_CONSTEXPR14 size_t
 strhash (string_view s)
 {
-    return s.length() ? strhash (s.length(), s.data()) : 0;
+    return s.length() ? strhash(s.length(), s.data()) : 0;
 }
 
 

--- a/src/libutil/hash_test.cpp
+++ b/src/libutil/hash_test.cpp
@@ -265,30 +265,30 @@ main(int argc, char* argv[])
     print("\nTesting correctness\n");
     using hashfn_t = uint64_t(string_view);
     auto hashes    = {
-        std::make_pair<const char*, hashfn_t*>("BJ hash           ",
+        std::make_pair<string_view, hashfn_t*>("BJ hash           ",
                                                [](string_view s) -> uint64_t {
                                                    return bjhash::strhash(s);
                                                }),
-        std::make_pair<const char*, hashfn_t*>("XX hash           ",
+        std::make_pair<string_view, hashfn_t*>("XX hash           ",
                                                [](string_view s) -> uint64_t {
                                                    return xxhash::xxhash(s);
                                                }),
-        std::make_pair<const char*, hashfn_t*>("farmhash          ",
+        std::make_pair<string_view, hashfn_t*>("farmhash          ",
                                                [](string_view s) -> uint64_t {
                                                    return farmhash::Hash(s);
                                                }),
-        std::make_pair<const char*, hashfn_t*>(
+        std::make_pair<string_view, hashfn_t*>(
             "farmhash::inlined ",
             [](string_view s) -> uint64_t {
                 return farmhash::inlined::Hash(s.data(), s.size());
             }),
-        std::make_pair<const char*, hashfn_t*>("fasthash64        ",
+        std::make_pair<string_view, hashfn_t*>("fasthash64        ",
                                                [](string_view s) -> uint64_t {
                                                    return fasthash::fasthash64(
                                                        s.data(), s.size());
                                                }),
 #ifdef __AES__
-        std::make_pair<const char*, hashfn_t*>("falkhash          ",
+        std::make_pair<string_view, hashfn_t*>("falkhash          ",
                                                [](string_view s) -> uint64_t {
                                                    return falkhash(s.data(),
                                                                    s.size());


### PR DESCRIPTION
Do some adjustment/simplification of the macros that set up the right
decorators on the new inline farmhash.

Some additional constexpr's, including Strutil::strhash().

Add to hash_test verification of the actual results of each of the
hashes, so we know that we don't break them over time, that they give
the same result on all platforms, and most immediately, to 100% verify
that the new constexpr inline version of the hash precisely matches
the old procedure call one.

Augment the existing benchmarking of the hashes to include
farmhash::inline.  It tries a variety of string sizes. I was worried
that the constexpr/inline version would be a performance hit because
it can't use any of the SSE intrinsics (which, ugh, aren't declared
constexpr in the headers).  But it turns out that the inline (but
SSE-free0 version is a little faster on some tests, a little slower on
other tests, overall a wash and never differing by more than
10%. Maybe that means that the inlining/constexpr makes up for the
lack of SSE? Maybe it means that the compiler optimization is adding
SSE back in well enough that losing the intrinsics isn't as bad as we
would have thought? In any case, the upshot is that this doesn't
represent a performance it, so I may consider a future change to just
go strictly with the inline constexpr versions and eliminating the
separately compiled version altogether. Will mull that over.
