### PR TITLE
Turn off STOP_ON_WARNING default for release branches

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -80,7 +80,11 @@ endif ()
 ###########################################################################
 # Turn on more detailed warnings and optionally consider warnings as errors
 #
-option (STOP_ON_WARNING "Stop building if there are any compiler warnings" ON)
+if (${PROJECT_NAME}_SUPPORTED_RELEASE)
+    option (STOP_ON_WARNING "Stop building if there are any compiler warnings" OFF)
+else ()
+    option (STOP_ON_WARNING "Stop building if there are any compiler warnings" ON)
+endif()
 option (EXTRA_WARNINGS "Enable lots of extra pedantic warnings" OFF)
 if (NOT MSVC)
     add_compile_options ("-Wall")


### PR DESCRIPTION
I thought I did this a long time ago, but I keep forgetting after release branches to turn off the warnings.

Our CI tests will still turn warnings into errors so we catch them during development, but for *release* branches, ordinary users will have builds that are more tolerant of warnings.
