### PR TITLE
Overhaul ustring hash collision handling

### DIFF
--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -126,9 +126,10 @@ main(int argc, char* argv[])
     size_t ncollisions = ustring::hash_collisions(&collisions);
     OIIO_CHECK_ASSERT(ncollisions == 0);
     if (ncollisions) {
-        std::cout << "  Hash collisions: " << ncollisions << "\n";
+        Strutil::print("  Hash collisions: {}\n", ncollisions);
         for (auto c : collisions)
-            std::cout << Strutil::fmt::format("    {} \"{}\"\n", c.hash(), c);
+            Strutil::print("    \"{}\" (orig {:08x} rehashed {:08x})\n", c,
+                           Strutil::strhash(c), c.hash());
     }
 
     if (verbose)


### PR DESCRIPTION
This patch ensures that two ustrings will never have the same hash value.
The basic strategy is that the usual 64 bit hash of the characters provides
an initial guess. If no other string has already used that hash (as is
almost always the case), we use it. However, if a different string already
took that hash value, we rehash, and repeat until we find an unused hash.

We maintain a "reverse hash map" that relates hashes to ustrings to
help figure this out efficiently. (Note: This adds at least another 16
bytes per unique ustring to maintain the reverse map. Do we care?
Probably few applications are in the business of creating more than a
few million distinct strings.)

Because we are recording the collisions as they happen, this also
greatly simplifies (and reduces to trivially low cost) the
recently-added ustring::hash_collisions() function, because there is
no complicated search when it is called.
