### PR TITLE
Fix loading PSB with cinf tag

### DIFF
--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -479,7 +479,7 @@ const PSDInput::ResourceLoader PSDInput::resource_loaders[]
 
 const char* PSDInput::additional_info_psb[]
     = { "LMsk", "Lr16", "Lr32", "Layr", "Mt16", "Mt32", "Mtrn",
-        "Alph", "FMsk", "Ink2", "FEid", "FXid", "PxSD" };
+        "Alph", "FMsk", "Ink2", "FEid", "FXid", "PxSD", "cinf" };
 
 const unsigned int PSDInput::additional_info_psb_count
     = sizeof(additional_info_psb) / sizeof(additional_info_psb[0]);


### PR DESCRIPTION
## Description

Fixes #2846 

I realise that this key isn't specified in the documentation as one with an 8 byte length, but this certainly appears to fix this issue and causes the "remaining" variable in load_global_additional() to drop to exactly zero.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

