### PR TITLE
CI: Use Qt5 as a temporary measure

### DIFF
--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -35,7 +35,7 @@ brew install --display-times -q freetype libraw dcmtk pybind11 numpy || true
 brew install --display-times -q ffmpeg libheif libsquish ptex || true
 brew install --display-times -q openvdb tbb || true
 brew install --display-times -q opencv || true
-brew install --display-times -q qt
+brew install --display-times -q qt@5
 brew install --display-times -q field3d || true
 
 echo ""


### PR DESCRIPTION
Homebrew just upgraded to Qt6, and that breaks us. Peg to Qt5 as a
temporary measure to let our CI pass, until somebody figures out what
needs to be fixed for full Qt6 compatibility.
