### PR TITLE
Fix crash related to ImageBuf::set_write_format

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1328,15 +1328,25 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
         newspec.channelformats.clear();
     } else if (m_impl->m_write_format.size() != 0) {
         // If set_write_format was called for the ImageBuf, it overrides
-        if (m_impl->m_write_format.size())
-            newspec.set_format(m_impl->write_format());
-        else
-            newspec.set_format(nativespec().format);
+        TypeDesc biggest;  // starts as Unknown
+        // Figure out the "biggest" of the channel formats, make that the
+        // presumed default format.
+        for (auto& f : m_impl->m_write_format)
+            biggest = TypeDesc::basetype_merge(biggest, f);
+        newspec.set_format(biggest);
+        // Copy the channel formats, change any 'unknown' to the default
         newspec.channelformats = m_impl->m_write_format;
         newspec.channelformats.resize(newspec.nchannels, newspec.format);
-        for (auto& f : newspec.channelformats)
+        bool alldefault = true;
+        for (auto& f : newspec.channelformats) {
             if (f == TypeUnknown)
                 f = newspec.format;
+            alldefault &= (f == newspec.format);
+        }
+        // If all channel formats are the same, get rid of them, the default
+        // captures all the info we need.
+        if (alldefault)
+            newspec.channelformats.clear();
     } else {
         // No override on the ImageBuf, nor on this call to write(), so
         // we just use what is known from the imagespec.

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -310,13 +310,10 @@ ImageOutput::to_native_rectangle(int xbegin, int xend, int ybegin, int yend,
     // native_pixel_bytes is the size of a pixel in the FILE, including
     // the per-channel format, if specified when the file was opened.
     stride_t native_pixel_bytes = (stride_t)m_spec.pixel_bytes(true);
-    // perchanfile is true if the file has different per-channel formats
+    // perchanfile is true if the spec has different per-channel data types
+    // and the file format supports that feature.
     bool perchanfile = m_spec.channelformats.size()
                        && supports("channelformats");
-    // It's an error to pass per-channel data formats to a writer that
-    // doesn't support it.
-    if (m_spec.channelformats.size() && !perchanfile)
-        return NULL;
     // native_data is true if the user is passing data in the native format
     bool native_data           = (format == TypeDesc::UNKNOWN
                         || (format == m_spec.format && !perchanfile));


### PR DESCRIPTION
There were some flaws in the logic of IB::set_write_format that could
cause a crash when used in conjunction with a file format that doesn't
support per-channel data types (even if the set_write_format call
specified a single type rather than per-channel types!).

There are basically two problems I fixed here.

First, in ImageBuf::write, where we are dealing with the fact that
set_write_format previously registered a request, be extra careful
that the "default" data format is the "biggest" type out of the
per-channel choices, and also make sure that if all the channels are
identical, we just use the default type and clear the channelformats
vector.

Secondly -- and more importantly to the crash itself -- in
ImageOutput::to_native_rectangle, if the output file format does not
suport per-channel data types, just use the main format.  Do NOT
consider this case a hard error, which previously took an early out by
returning NULL for the location where the native data was copied.  It
was that NULL that, when subsequently copied from (not noticing that
it was NULL indicating an error), actually produced the segfault that
caused the crash.  In other words, don't worry, be happy -- just do
your best by treating the unsatisfiable request as the next best
thing, as if it were the same type for all channels.
