### PR TITLE
Fix error checking for file descriptor in gifinput on windows

### DIFF
--- a/src/gif.imageio/gifinput.cpp
+++ b/src/gif.imageio/gifinput.cpp
@@ -364,7 +364,7 @@ GIFInput::seek_subimage(int subimage, int miplevel)
         // On Windows, UTF-8 filenames won't work properly with Giflib. Jump
         // through some hoops: get an integer file descriptor for Giflib.
         int fd = Filesystem::open(m_filename, _O_RDONLY | _O_BINARY);
-        if (!fd) {
+        if (fd == -1) {
             errorf("Error trying to open the file.");
             return false;
         }


### PR DESCRIPTION
## Description

Calling ImageInput::open() with a file path that doesn't exist will cause OIIO to attempt to load the missing file with all plugins. When it gets to the gif plugin the file descriptor is not checked correctly (windows only). This causes an assert inside DGifOpenFileHandle() when it calls _setmode().

## Tests

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

