### PR TITLE
More format modernization

### DIFF
--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -198,7 +198,7 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
     case TypeDesc::DOUBLE:                                              \
         ret = func<double> (R, __VA_ARGS__); break;                     \
     default:                                                            \
-        (R).errorf("%s: Unsupported pixel data format '%s'", name, type); \
+        (R).errorfmt("{}: Unsupported pixel data format '{}'", name, type); \
         ret = false;                                                    \
     }
 
@@ -224,7 +224,7 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
     case TypeDesc::DOUBLE :                                             \
         ret = func<Rtype,double> (R, __VA_ARGS__); break;               \
     default:                                                            \
-        (R).errorf("%s: Unsupported pixel data format '%s'", name, Atype); \
+        (R).errorfmt("{}: Unsupported pixel data format '{}'", name, Atype); \
         ret = false;                                                    \
     }
 
@@ -259,7 +259,7 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
         OIIO_DISPATCH_TYPES2_HELP(ret,name,func,double,Atype,R,__VA_ARGS__);\
         break;                                                          \
     default:                                                            \
-        (R).errorf("%s: Unsupported pixel data format '%s'", name, Rtype); \
+        (R).errorfmt("{}: Unsupported pixel data format '{}'", name, Rtype); \
         ret = false;                                                    \
     }
 
@@ -285,7 +285,7 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
         if (ret)                                                        \
             (R).copy (Rtmp);                                            \
         else                                                            \
-            (R).errorf("%s", Rtmp.geterror());                          \
+            (R).errorfmt("{}", Rtmp.geterror());                        \
         }                                                               \
     }
 
@@ -334,7 +334,7 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
         case TypeDesc::DOUBLE :                                         \
             ret = func<double,double> (R, A, __VA_ARGS__); break;       \
         default:                                                        \
-            (R).errorf("%s: Unsupported pixel data format '%s'", name, Atype); \
+            (R).errorfmt("{}: Unsupported pixel data format '{}'", name, Atype); \
             ret = false;                                                \
         }                                                               \
     } else {                                                            \
@@ -361,7 +361,7 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
             if (ret)                                                    \
                 (R).copy (Rtmp);                                        \
             else                                                        \
-                (R).errorf("%s", Rtmp.geterror());                      \
+                (R).errorfmt("{}", Rtmp.geterror());                    \
             }                                                           \
         }                                                               \
     }
@@ -413,7 +413,7 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
         if (ret)                                                        \
             (R).copy (Rtmp);                                            \
         else                                                            \
-            (R).errorf("%s", Rtmp.geterror());                          \
+            (R).errorfmt("{}", Rtmp.geterror());                        \
         }                                                               \
     }
 
@@ -466,7 +466,7 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
         case TypeDesc::DOUBLE :                                         \
             ret = func<double,double,double> (R, A, B, __VA_ARGS__); break; \
         default:                                                        \
-            (R).errorf("%s: Unsupported pixel data format '%s'", name, Atype); \
+            (R).errorfmt("{}: Unsupported pixel data format '{}'", name, Atype); \
             ret = false;                                                \
         }                                                               \
     } else {                                                            \

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -149,9 +149,9 @@ using old::format;
 
 
 
-/// Strutil::print (fmt, ...)
-/// Strutil::fprint (FILE*, fmt, ...)
-/// Strutil::fprint (ostream& fmt, ...)
+/// Strutil::printf (fmt, ...)
+/// Strutil::fprintf (FILE*, fmt, ...)
+/// Strutil::fprintf (ostream& fmt, ...)
 ///
 /// Output formatted strings to stdout, a FILE*, or a stream, respectively.
 /// All use printf-like formatting rules, are type-safe, are thread-safe

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1375,7 +1375,7 @@ ImageBufAlgo::colorconvert(ImageBuf& dst, const ImageBuf& src, string_view from,
         from = src.spec().get_string_attribute("oiio:Colorspace", "Linear");
     }
     if (from.empty() || to.empty()) {
-        dst.errorf("Unknown color space name");
+        dst.errorfmt("Unknown color space name");
         return false;
     }
     ColorProcessorHandle processor;
@@ -1389,10 +1389,10 @@ ImageBufAlgo::colorconvert(ImageBuf& dst, const ImageBuf& src, string_view from,
                                                       context_value);
         if (!processor) {
             if (colorconfig->error())
-                dst.errorf("%s", colorconfig->geterror());
+                dst.errorfmt("{}", colorconfig->geterror());
             else
-                dst.errorf("Could not construct the color transform %s -> %s",
-                           from, to);
+                dst.errorfmt("Could not construct the color transform {} -> {}",
+                             from, to);
             return false;
         }
     }
@@ -1416,7 +1416,7 @@ ImageBufAlgo::colorconvert(const ImageBuf& src, string_view from,
     bool ok = colorconvert(result, src, from, to, unpremult, context_key,
                            context_value, colorconfig, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::colorconvert() error");
+        result.errorfmt("ImageBufAlgo::colorconvert() error");
     return result;
 }
 
@@ -1451,7 +1451,7 @@ ImageBufAlgo::colormatrixtransform(const ImageBuf& src, const Imath::M44f& M,
     ImageBuf result;
     bool ok = colormatrixtransform(result, src, M, unpremult, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::colormatrixtransform() error");
+        result.errorfmt("ImageBufAlgo::colormatrixtransform() error");
     return result;
 }
 
@@ -1610,7 +1610,7 @@ ImageBufAlgo::colorconvert(ImageBuf& dst, const ImageBuf& src,
     pvt::LoggedTimer logtime("IBA::colorconvert");
     // If the processor is NULL, return false (error)
     if (!processor) {
-        dst.error(
+        dst.errorfmt(
             "Passed NULL ColorProcessor to colorconvert() [probable application bug]");
         return false;
     }
@@ -1661,7 +1661,7 @@ ImageBufAlgo::colorconvert(const ImageBuf& src, const ColorProcessor* processor,
     ImageBuf result;
     bool ok = colorconvert(result, src, processor, unpremult, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::colorconvert() error");
+        result.errorfmt("ImageBufAlgo::colorconvert() error");
     return result;
 }
 
@@ -1681,7 +1681,7 @@ ImageBufAlgo::ociolook(ImageBuf& dst, const ImageBuf& src, string_view looks,
         to = src.spec().get_string_attribute("oiio:Colorspace", "Linear");
     }
     if (from.empty() || to.empty()) {
-        dst.errorf("Unknown color space name");
+        dst.errorfmt("Unknown color space name");
         return false;
     }
     ColorProcessorHandle processor;
@@ -1695,9 +1695,9 @@ ImageBufAlgo::ociolook(ImageBuf& dst, const ImageBuf& src, string_view looks,
                                                      key, value);
         if (!processor) {
             if (colorconfig->error())
-                dst.errorf("%s", colorconfig->geterror());
+                dst.errorfmt("{}", colorconfig->geterror());
             else
-                dst.errorf("Could not construct the color transform");
+                dst.errorfmt("Could not construct the color transform");
             return false;
         }
     }
@@ -1721,7 +1721,7 @@ ImageBufAlgo::ociolook(const ImageBuf& src, string_view looks, string_view from,
     bool ok = ociolook(result, src, looks, from, to, unpremult, inverse, key,
                        value, colorconfig, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::ociolook() error");
+        result.errorfmt("ImageBufAlgo::ociolook() error");
     return result;
 }
 
@@ -1748,16 +1748,16 @@ ImageBufAlgo::ociodisplay(ImageBuf& dst, const ImageBuf& src,
                                                    linearspace);
         }
         if (from.empty()) {
-            dst.errorf("Unknown color space name");
+            dst.errorfmt("Unknown color space name");
             return false;
         }
         processor = colorconfig->createDisplayTransform(display, view, from,
                                                         looks, key, value);
         if (!processor) {
             if (colorconfig->error())
-                dst.errorf("%s", colorconfig->geterror());
+                dst.errorfmt("{}", colorconfig->geterror());
             else
-                dst.errorf("Could not construct the color transform");
+                dst.errorfmt("Could not construct the color transform");
             return false;
         }
     }
@@ -1779,7 +1779,7 @@ ImageBufAlgo::ociodisplay(const ImageBuf& src, string_view display,
     bool ok = ociodisplay(result, src, display, view, from, looks, unpremult,
                           key, value, colorconfig, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::ociodisplay() error");
+        result.errorfmt("ImageBufAlgo::ociodisplay() error");
     return result;
 }
 
@@ -1792,7 +1792,7 @@ ImageBufAlgo::ociofiletransform(ImageBuf& dst, const ImageBuf& src,
 {
     pvt::LoggedTimer logtime("IBA::ociofiletransform");
     if (name.empty()) {
-        dst.errorf("Unknown filetransform name");
+        dst.errorfmt("Unknown filetransform name");
         return false;
     }
     ColorProcessorHandle processor;
@@ -1805,9 +1805,9 @@ ImageBufAlgo::ociofiletransform(ImageBuf& dst, const ImageBuf& src,
         processor = colorconfig->createFileTransform(name, inverse);
         if (!processor) {
             if (colorconfig->error())
-                dst.errorf("%s", colorconfig->geterror());
+                dst.errorfmt("{}", colorconfig->geterror());
             else
-                dst.errorf("Could not construct the color transform");
+                dst.errorfmt("Could not construct the color transform");
             return false;
         }
     }
@@ -1830,7 +1830,7 @@ ImageBufAlgo::ociofiletransform(const ImageBuf& src, string_view name,
     bool ok = ociofiletransform(result, src, name, unpremult, inverse,
                                 colorconfig, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::ociofiletransform() error");
+        result.errorfmt("ImageBufAlgo::ociofiletransform() error");
     return result;
 }
 

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -102,16 +102,11 @@ public:
               void* progress_callback_data       = nullptr);
     void copy_metadata(const ImageBufImpl& src);
 
+    // Note: Uses std::format syntax
     template<typename... Args>
-    void errorfmt(const char* fmt, const Args&... args) const
+    void error(const char* fmt, const Args&... args) const
     {
         error(Strutil::fmt::format(fmt, args...));
-    }
-
-    template<typename... Args>
-    void errorf(const char* fmt, const Args&... args) const
-    {
-        error(Strutil::sprintf(fmt, args...));
     }
 
     void error(string_view message) const;
@@ -563,9 +558,9 @@ ImageBufImpl::new_pixels(size_t size, const void* data)
         // consider this an uninitialized ImageBuf, issue an error, and hope
         // it's handled well downstream.
         m_pixels.reset();
-        OIIO::debugf("ImageBuf unable to allocate %d bytes (%s)\n", size,
-                     e.what());
-        errorf("ImageBuf unable to allocate %d bytes (%s)\n", size, e.what());
+        OIIO::debugfmt("ImageBuf unable to allocate {} bytes ({})\n", size,
+                       e.what());
+        error("ImageBuf unable to allocate {} bytes ({})\n", size, e.what());
         size = 0;
     }
     m_allocated_size = size;
@@ -575,8 +570,8 @@ ImageBufImpl::new_pixels(size_t size, const void* data)
     m_localpixels = m_pixels.get();
     m_storage     = size ? ImageBuf::LOCALBUFFER : ImageBuf::UNINITIALIZED;
     if (pvt::oiio_print_debug > 1)
-        OIIO::debugf("IB allocated %d MB, global IB memory now %d MB\n",
-                     size >> 20, IB_local_mem_current >> 20);
+        OIIO::debugfmt("IB allocated {} MB, global IB memory now {} MB\n",
+                       size >> 20, IB_local_mem_current >> 20);
     return m_localpixels;
 }
 
@@ -586,8 +581,8 @@ ImageBufImpl::free_pixels()
 {
     if (m_allocated_size) {
         if (pvt::oiio_print_debug > 1)
-            OIIO::debug("IB freed %d MB, global IB memory now %d MB\n",
-                        m_allocated_size >> 20, IB_local_mem_current >> 20);
+            OIIO::debugfmt("IB freed {} MB, global IB memory now {} MB\n",
+                           m_allocated_size >> 20, IB_local_mem_current >> 20);
         IB_local_mem_current -= m_allocated_size;
         m_allocated_size = 0;
     }
@@ -1176,7 +1171,7 @@ ImageBuf::write(ImageOutput* out, ProgressCallback progress_callback,
                 void* progress_callback_data) const
 {
     if (!out) {
-        error("Empty ImageOutput passed to ImageBuf::write()");
+        errorfmt("Empty ImageOutput passed to ImageBuf::write()");
         return false;
     }
     stride_t as = AutoStride;
@@ -1275,7 +1270,7 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
     string_view filename   = _filename.size() ? _filename : name();
     string_view fileformat = _fileformat.size() ? _fileformat : filename;
     if (filename.size() == 0) {
-        errorf("ImageBuf::write() called with no filename");
+        errorfmt("ImageBuf::write() called with no filename");
         return false;
     }
     m_impl->validate_pixels();
@@ -1289,7 +1284,8 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
         m_impl->read(subimage(), miplevel(), 0, -1, true /*force*/,
                      spec().format, nullptr, nullptr);
         if (storage() != LOCALBUFFER) {
-            errorf("ImageBuf overwriting %s but could not force read", name());
+            errorfmt("ImageBuf overwriting {} but could not force read",
+                     name());
             return false;
         }
     }
@@ -1357,8 +1353,8 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
     if (m_impl->m_wioproxy) {
         if (!out->supports("ioproxy")
             || !out->set_ioproxy(m_impl->m_wioproxy)) {
-            errorf("Format %s does not support writing via IOProxy",
-                   out->format_name());
+            errorfmt("Format {} does not support writing via IOProxy",
+                     out->format_name());
             return false;
         }
     }
@@ -2117,7 +2113,7 @@ ImageBuf::set_pixels(ROI roi, TypeDesc format, const void* data,
                      stride_t xstride, stride_t ystride, stride_t zstride)
 {
     if (!initialized()) {
-        errorf("Cannot set_pixels() on an uninitialized ImageBuf");
+        errorfmt("Cannot set_pixels() on an uninitialized ImageBuf");
         return false;
     }
     bool ok;
@@ -2653,7 +2649,7 @@ ImageBufImpl::retile(int x, int y, int z, ImageCache::Tile*& tile,
         if (!tile) {
             // Even though tile is NULL, ensure valid black pixel data
             std::string e = m_imagecache->geterror();
-            errorf("%s", e.size() ? e : "unspecified ImageCache error");
+            error("{}", e.size() ? e : "unspecified ImageCache error");
             return &m_blackpixel[0];
         }
     }

--- a/src/libOpenImageIO/imagebufalgo_addsub.cpp
+++ b/src/libOpenImageIO/imagebufalgo_addsub.cpp
@@ -133,7 +133,7 @@ ImageBufAlgo::add(ImageBuf& dst, Image_or_Const A_, Image_or_Const B_, ROI roi,
         return ok;
     }
     // Remaining cases: error
-    dst.errorf("ImageBufAlgo::add(): at least one argument must be an image");
+    dst.errorfmt("ImageBufAlgo::add(): at least one argument must be an image");
     return false;
 }
 
@@ -145,7 +145,7 @@ ImageBufAlgo::add(Image_or_Const A, Image_or_Const B, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = add(result, A, B, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::add() error");
+        result.errorfmt("ImageBufAlgo::add() error");
     return result;
 }
 
@@ -226,7 +226,7 @@ ImageBufAlgo::sub(ImageBuf& dst, Image_or_Const A_, Image_or_Const B_, ROI roi,
         return ok;
     }
     // Remaining cases: error
-    dst.errorf("ImageBufAlgo::sub(): at least one argument must be an image");
+    dst.errorfmt("ImageBufAlgo::sub(): at least one argument must be an image");
     return false;
 }
 
@@ -238,7 +238,7 @@ ImageBufAlgo::sub(Image_or_Const A, Image_or_Const B, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = sub(result, A, B, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::sub() error");
+        result.errorfmt("ImageBufAlgo::sub() error");
     return result;
 }
 

--- a/src/libOpenImageIO/imagebufalgo_channels.cpp
+++ b/src/libOpenImageIO/imagebufalgo_channels.cpp
@@ -62,13 +62,13 @@ ImageBufAlgo::channels(ImageBuf& dst, const ImageBuf& src, int nchannels,
     pvt::LoggedTimer logtime("IBA::channels");
     // Not intended to create 0-channel images.
     if (nchannels <= 0) {
-        dst.errorf("%d-channel images not supported", nchannels);
+        dst.errorfmt("{}-channel images not supported", nchannels);
         return false;
     }
     // If we dont have a single source channel,
     // hard to know how big to make the additional channels
     if (src.spec().nchannels == 0) {
-        dst.errorf("%d-channel images not supported", src.spec().nchannels);
+        dst.errorfmt("{}-channel images not supported", src.spec().nchannels);
         return false;
     }
 
@@ -190,7 +190,7 @@ ImageBufAlgo::channels(const ImageBuf& src, int nchannels,
     bool ok = channels(result, src, nchannels, channelorder, channelvalues,
                        newchannelnames, shuffle_channel_names, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::channels() error");
+        result.errorfmt("ImageBufAlgo::channels() error");
     return result;
 }
 
@@ -257,7 +257,8 @@ ImageBufAlgo::channel_append(ImageBuf& dst, const ImageBuf& A,
                 != dstspec.channelnames.end()) {
                 // If it's still a duplicate, fall back on a totally
                 // artificial name that contains the channel number.
-                name = Strutil::sprintf("channel%d", A.spec().nchannels + c);
+                name = Strutil::fmt::format("channel{}",
+                                            A.spec().nchannels + c);
             }
             dstspec.channelnames.push_back(name);
         }
@@ -284,7 +285,7 @@ ImageBufAlgo::channel_append(const ImageBuf& A, const ImageBuf& B, ROI roi,
     ImageBuf result;
     bool ok = channel_append(result, A, B, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("channel_append error");
+        result.errorfmt("channel_append error");
     return result;
 }
 

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -193,7 +193,7 @@ ImageBufAlgo::computePixelStats(const ImageBuf& src, ROI roi, int nthreads)
         roi.chend = std::min(roi.chend, src.nchannels());
     int nchannels = src.spec().nchannels;
     if (nchannels == 0) {
-        src.errorf("%d-channel images not supported", nchannels);
+        src.errorfmt("{}-channel images not supported", nchannels);
         return stats;
     }
 
@@ -348,7 +348,7 @@ ImageBufAlgo::compare(const ImageBuf& A, const ImageBuf& B, float failthresh,
 
     // Deep and non-deep images cannot be compared
     if (B.deep() != A.deep()) {
-        A.errorf("deep and non-deep images cannot be compared");
+        A.errorfmt("deep and non-deep images cannot be compared");
         return result;
     }
 
@@ -613,7 +613,7 @@ ImageBufAlgo::color_count(const ImageBuf& src, imagesize_t* count, int ncolors,
     roi.chend = std::min(roi.chend, src.nchannels());
 
     if (color.size() < ncolors * src.nchannels()) {
-        src.errorf(
+        src.errorfmt(
             "ImageBufAlgo::color_count: not enough room in 'color' array");
         return false;
     }
@@ -875,7 +875,7 @@ histogram_impl(const ImageBuf& src, int channel, std::vector<imagesize_t>& hist,
 {
     // Double check A's type.
     if (src.spec().format != BaseTypeFromC<Atype>::value) {
-        src.errorf("Unsupported pixel data format '%s'", src.spec().format);
+        src.errorfmt("Unsupported pixel data format '{}'", src.spec().format);
         return false;
     }
 
@@ -920,20 +920,20 @@ ImageBufAlgo::histogram(const ImageBuf& src, int channel, int bins, float min,
 
     // Sanity checks
     if (src.nchannels() == 0) {
-        src.errorf("Input image must have at least 1 channel");
+        src.errorfmt("Input image must have at least 1 channel");
         return h;
     }
     if (channel < 0 || channel >= src.nchannels()) {
-        src.errorf("Invalid channel %d for input image with channels 0 to %d",
-                   channel, src.nchannels() - 1);
+        src.errorfmt("Invalid channel {} for input image with channels 0 to {}",
+                     channel, src.nchannels() - 1);
         return h;
     }
     if (bins < 1) {
-        src.errorf("The number of bins must be at least 1");
+        src.errorfmt("The number of bins must be at least 1");
         return h;
     }
     if (max <= min) {
-        src.errorf("Invalid range, min must be strictly smaller than max");
+        src.errorfmt("Invalid range, min must be strictly smaller than max");
         return h;
     }
 
@@ -972,7 +972,7 @@ histogram_impl_old(const ImageBuf& A, int channel,
 {
     // Double check A's type.
     if (A.spec().format != BaseTypeFromC<Atype>::value) {
-        A.errorf("Unsupported pixel data format '%s'", A.spec().format);
+        A.errorfmt("Unsupported pixel data format '{}'", A.spec().format);
         return false;
     }
 
@@ -1016,28 +1016,28 @@ ImageBufAlgo::histogram(const ImageBuf& A, int channel,
 {
     pvt::LoggedTimer logtimer("IBA::histogram");
     if (A.spec().format != TypeFloat) {
-        A.errorf("Unsupported pixel data format '%s'", A.spec().format);
+        A.errorfmt("Unsupported pixel data format '{}'", A.spec().format);
         return false;
     }
 
     if (A.nchannels() == 0) {
-        A.errorf("Input image must have at least 1 channel");
+        A.errorfmt("Input image must have at least 1 channel");
         return false;
     }
 
     if (channel < 0 || channel >= A.nchannels()) {
-        A.errorf("Invalid channel %d for input image with channels 0 to %d",
-                 channel, A.nchannels() - 1);
+        A.errorfmt("Invalid channel {} for input image with channels 0 to {}",
+                   channel, A.nchannels() - 1);
         return false;
     }
 
     if (bins < 1) {
-        A.errorf("The number of bins must be at least 1");
+        A.errorfmt("The number of bins must be at least 1");
         return false;
     }
 
     if (max <= min) {
-        A.errorf("Invalid range, min must be strictly smaller than max");
+        A.errorfmt("Invalid range, min must be strictly smaller than max");
         return false;
     }
 
@@ -1061,7 +1061,7 @@ ImageBufAlgo::histogram_draw(ImageBuf& R,
     // Fail if there are no bins to draw.
     int bins = histogram.size();
     if (bins == 0) {
-        R.errorf("There are no bins to draw, the histogram is empty");
+        R.errorfmt("There are no bins to draw, the histogram is empty");
         return false;
     }
 

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -242,7 +242,7 @@ ImageBufAlgo::copy(const ImageBuf& src, TypeDesc convert, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = copy(result, src, convert, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::copy() error");
+        result.errorfmt("ImageBufAlgo::copy() error");
     return result;
 }
 
@@ -296,7 +296,7 @@ ImageBufAlgo::crop(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = crop(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::crop() error");
+        result.errorfmt("ImageBufAlgo::crop() error");
     return result;
 }
 
@@ -327,7 +327,7 @@ ImageBufAlgo::cut(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = cut(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::cut() error");
+        result.errorfmt("ImageBufAlgo::cut() error");
     return result;
 }
 
@@ -386,7 +386,7 @@ ImageBufAlgo::circular_shift(const ImageBuf& src, int xshift, int yshift,
     bool ok = circular_shift(result, src, xshift, yshift, zshift, roi,
                              nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::circular_shift() error");
+        result.errorfmt("ImageBufAlgo::circular_shift() error");
     return result;
 }
 

--- a/src/libOpenImageIO/imagebufalgo_deep.cpp
+++ b/src/libOpenImageIO/imagebufalgo_deep.cpp
@@ -102,13 +102,13 @@ ImageBufAlgo::flatten(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
                  IBAprep_SUPPORT_DEEP | IBAprep_DEEP_MIXED))
         return false;
     if (dst.spec().deep) {
-        dst.errorf("Cannot flatten to a deep image");
+        dst.errorfmt("Cannot flatten to a deep image");
         return false;
     }
 
     const DeepData* dd = src.deepdata();
     if (dd->AR_channel() < 0 || dd->AG_channel() < 0 || dd->AB_channel() < 0) {
-        dst.errorf("No alpha channel could be identified");
+        dst.errorfmt("No alpha channel could be identified");
         return false;
     }
 
@@ -126,7 +126,7 @@ ImageBufAlgo::flatten(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = flatten(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::flatten error");
+        result.errorfmt("ImageBufAlgo::flatten error");
     return result;
 }
 
@@ -171,7 +171,7 @@ ImageBufAlgo::deepen(ImageBuf& dst, const ImageBuf& src, float zvalue, ROI roi,
                  IBAprep_SUPPORT_DEEP | IBAprep_DEEP_MIXED))
         return false;
     if (!dst.deep()) {
-        dst.errorf("Cannot deepen to a flat image");
+        dst.errorfmt("Cannot deepen to a flat image");
         return false;
     }
 
@@ -230,7 +230,7 @@ ImageBufAlgo::deepen(const ImageBuf& src, float zvalue, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = deepen(result, src, zvalue, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::deepen error");
+        result.errorfmt("ImageBufAlgo::deepen error");
     return result;
 }
 
@@ -243,14 +243,14 @@ ImageBufAlgo::deep_merge(ImageBuf& dst, const ImageBuf& A, const ImageBuf& B,
     pvt::LoggedTimer logtime("IBA::deep_merge");
     if (!A.deep() || !B.deep()) {
         // For some reason, we were asked to merge a flat image.
-        dst.errorf("deep_merge can only be performed on deep images");
+        dst.errorfmt("deep_merge can only be performed on deep images");
         return false;
     }
     if (!IBAprep(roi, &dst, &A, &B, NULL,
                  IBAprep_SUPPORT_DEEP | IBAprep_REQUIRE_MATCHING_CHANNELS))
         return false;
     if (!dst.deep()) {
-        dst.errorf("Cannot deep_merge to a flat image");
+        dst.errorfmt("Cannot deep_merge to a flat image");
         return false;
     }
 
@@ -354,7 +354,7 @@ ImageBufAlgo::deep_merge(const ImageBuf& A, const ImageBuf& B,
     ImageBuf result;
     bool ok = deep_merge(result, A, B, occlusion_cull, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::deep_merge error");
+        result.errorfmt("ImageBufAlgo::deep_merge error");
     return result;
 }
 
@@ -366,13 +366,13 @@ ImageBufAlgo::deep_holdout(ImageBuf& dst, const ImageBuf& src,
 {
     pvt::LoggedTimer logtime("IBA::deep_holdout");
     if (!src.deep() || !thresh.deep()) {
-        dst.errorf("deep_holdout can only be performed on deep images");
+        dst.errorfmt("deep_holdout can only be performed on deep images");
         return false;
     }
     if (!IBAprep(roi, &dst, &src, &thresh, NULL, IBAprep_SUPPORT_DEEP))
         return false;
     if (!dst.deep()) {
-        dst.errorf("Cannot deep_holdout into a flat image");
+        dst.errorfmt("Cannot deep_holdout into a flat image");
         return false;
     }
 
@@ -437,7 +437,7 @@ ImageBufAlgo::deep_holdout(const ImageBuf& src, const ImageBuf& thresh, ROI roi,
     ImageBuf result;
     bool ok = deep_holdout(result, src, thresh, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::deep_holdout error");
+        result.errorfmt("ImageBufAlgo::deep_holdout error");
     return result;
 }
 

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -147,7 +147,7 @@ ImageBufAlgo::fill(cspan<float> pixel, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = fill(result, pixel, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("fill error");
+        result.errorfmt("fill error");
     return result;
 }
 
@@ -158,7 +158,7 @@ ImageBufAlgo::fill(cspan<float> top, cspan<float> bottom, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = fill(result, top, bottom, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("fill error");
+        result.errorfmt("fill error");
     return result;
 }
 
@@ -172,7 +172,7 @@ ImageBufAlgo::fill(cspan<float> topleft, cspan<float> topright,
     bool ok = fill(result, topleft, topright, bottomleft, bottomright, roi,
                    nthreads);
     if (!ok && !result.has_error())
-        result.errorf("fill error");
+        result.errorfmt("fill error");
     return result;
 }
 
@@ -199,7 +199,7 @@ ImageBufAlgo::zero(ROI roi, int nthreads)
     ImageBuf result;
     bool ok = zero(result, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("zero error");
+        result.errorfmt("zero error");
     return result;
 }
 
@@ -507,7 +507,7 @@ ImageBufAlgo::checker(int width, int height, int depth, cspan<float> color1,
     bool ok = checker(result, width, height, depth, color1, color2, xoffset,
                       yoffset, zoffset, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("checker error");
+        result.errorfmt("checker error");
     return result;
 }
 
@@ -632,7 +632,7 @@ ImageBufAlgo::noise(ImageBuf& dst, string_view noisetype, float A, float B,
                                    roi, nthreads);
     } else {
         ok = false;
-        dst.errorf("noise", "unknown noise type \"%s\"", noisetype);
+        dst.errorfmt("unknown noise type \"{}\"", noisetype);
     }
     return ok;
 }
@@ -647,7 +647,7 @@ ImageBufAlgo::noise(string_view noisetype, float A, float B, bool mono,
     bool ok         = true;
     ok              = noise(result, noisetype, A, B, mono, seed, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("noise error");
+        result.errorfmt("noise error");
     return result;
 }
 
@@ -883,7 +883,7 @@ ImageBufAlgo::render_text(ImageBuf& R, int x, int y, string_view text,
 {
     pvt::LoggedTimer logtime("IBA::render_text");
     if (R.spec().depth > 1) {
-        R.errorf("ImageBufAlgo::render_text does not support volume images");
+        R.errorfmt("ImageBufAlgo::render_text does not support volume images");
         return false;
     }
 
@@ -895,7 +895,7 @@ ImageBufAlgo::render_text(ImageBuf& R, int x, int y, string_view text,
     bool ok = resolve_font(font_, font);
     if (!ok) {
         std::string err = font.size() ? font : "Font error";
-        R.errorf("%s", err);
+        R.errorfmt("{}", err);
         return false;
     }
 
@@ -903,7 +903,7 @@ ImageBufAlgo::render_text(ImageBuf& R, int x, int y, string_view text,
     FT_Face face;  // handle to face object
     error = FT_New_Face(ft_library, font.c_str(), 0 /* face index */, &face);
     if (error) {
-        R.errorf("Could not set font face to \"%s\"", font);
+        R.errorfmt("Could not set font face to \"{}\"", font);
         return false;  // couldn't open the face
     }
 
@@ -911,7 +911,7 @@ ImageBufAlgo::render_text(ImageBuf& R, int x, int y, string_view text,
                                fontsize /*height*/);
     if (error) {
         FT_Done_Face(face);
-        R.errorf("Could not set font size to %d", fontsize);
+        R.errorfmt("Could not set font size to {}", fontsize);
         return false;  // couldn't set the character size
     }
 
@@ -1005,7 +1005,7 @@ ImageBufAlgo::render_text(ImageBuf& R, int x, int y, string_view text,
     return true;
 
 #else
-    R.errorf("OpenImageIO was not compiled with FreeType for font rendering");
+    R.errorfmt("OpenImageIO was not compiled with FreeType for font rendering");
     return false;  // Font rendering not supported
 #endif
 }

--- a/src/libOpenImageIO/imagebufalgo_mad.cpp
+++ b/src/libOpenImageIO/imagebufalgo_mad.cpp
@@ -147,14 +147,14 @@ ImageBufAlgo::mad(ImageBuf& dst, Image_or_Const A_, Image_or_Const B_,
     // Get pointers to any image. At least one of A or B must be an image.
     const ImageBuf *A = A_.imgptr(), *B = B_.imgptr(), *C = C_.imgptr();
     if (!A && !B) {
-        dst.errorf(
+        dst.errorfmt(
             "ImageBufAlgo::mad(): at least one of the first two arguments must be an image");
         return false;
     }
     // All of the arguments that are images need to be initialized
     if ((A && !A->initialized()) || (B && !B->initialized())
         || (C && !C->initialized())) {
-        dst.errorf("Uninitialized input image");
+        dst.errorfmt("Uninitialized input image");
         return false;
     }
 
@@ -222,7 +222,7 @@ ImageBufAlgo::mad(Image_or_Const A, Image_or_Const B, Image_or_Const C, ROI roi,
     ImageBuf result;
     bool ok = mad(result, A, B, C, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::mad() error");
+        result.errorfmt("ImageBufAlgo::mad() error");
     return result;
 }
 
@@ -242,7 +242,7 @@ ImageBufAlgo::invert(const ImageBuf& A, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = invert(result, A, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("invert error");
+        result.errorfmt("invert error");
     return result;
 }
 

--- a/src/libOpenImageIO/imagebufalgo_muldiv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_muldiv.cpp
@@ -117,7 +117,7 @@ ImageBufAlgo::mul(ImageBuf& dst, Image_or_Const A_, Image_or_Const B_, ROI roi,
         return ok;
     }
     // Remaining cases: error
-    dst.errorf("ImageBufAlgo::mul(): at least one argument must be an image");
+    dst.errorfmt("ImageBufAlgo::mul(): at least one argument must be an image");
     return false;
 }
 
@@ -129,7 +129,7 @@ ImageBufAlgo::mul(Image_or_Const A, Image_or_Const B, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = mul(result, A, B, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::mul() error");
+        result.errorfmt("ImageBufAlgo::mul() error");
     return result;
 }
 
@@ -197,7 +197,7 @@ ImageBufAlgo::div(ImageBuf& dst, Image_or_Const A_, Image_or_Const B_, ROI roi,
         return ok;
     }
     // Remaining cases: error
-    dst.errorf("ImageBufAlgo::div(): at least one argument must be an image");
+    dst.errorfmt("ImageBufAlgo::div(): at least one argument must be an image");
     return false;
 }
 
@@ -209,7 +209,7 @@ ImageBufAlgo::div(Image_or_Const A, Image_or_Const B, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = div(result, A, B, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::div() error");
+        result.errorfmt("ImageBufAlgo::div() error");
     return result;
 }
 

--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -53,7 +53,7 @@ from_IplImage(const IplImage* ipl, TypeDesc convert)
     pvt::LoggedTimer logtime("IBA::from_IplImage");
     ImageBuf dst;
     if (!ipl) {
-        dst.errorf("Passed NULL source IplImage");
+        dst.errorfmt("Passed NULL source IplImage");
         return dst;
     }
 #ifdef USE_OPENCV
@@ -66,7 +66,7 @@ from_IplImage(const IplImage* ipl, TypeDesc convert)
     case int(IPL_DEPTH_32F): srcformat = TypeDesc::FLOAT; break;
     case int(IPL_DEPTH_64F): srcformat = TypeDesc::DOUBLE; break;
     default:
-        dst.errorf("Unsupported IplImage depth %d", (int)ipl->depth);
+        dst.errorfmt("Unsupported IplImage depth {}", (int)ipl->depth);
         return dst;
     }
 
@@ -77,7 +77,7 @@ from_IplImage(const IplImage* ipl, TypeDesc convert)
 
     if (ipl->dataOrder != IPL_DATA_ORDER_PIXEL) {
         // We don't handle separate color channels, and OpenCV doesn't either
-        dst.errorf("Unsupported IplImage data order %d", (int)ipl->dataOrder);
+        dst.errorfmt("Unsupported IplImage data order {}", (int)ipl->dataOrder);
         return dst;
     }
 
@@ -111,7 +111,7 @@ from_IplImage(const IplImage* ipl, TypeDesc convert)
     // probably templated by type.
 
 #else
-    dst.errorf(
+    dst.errorfmt(
         "fromIplImage not supported -- no OpenCV support at compile time");
 #endif
 
@@ -237,7 +237,7 @@ ImageBufAlgo::from_OpenCV(const cv::Mat& mat, TypeDesc convert, ROI roi,
     case CV_32F: srcformat = TypeDesc::FLOAT; break;
     case CV_64F: srcformat = TypeDesc::DOUBLE; break;
     default:
-        dst.errorf("Unsupported OpenCV data type, depth=%d", mat.depth());
+        dst.errorfmt("Unsupported OpenCV data type, depth={}", mat.depth());
         return dst;
     }
 
@@ -263,7 +263,7 @@ ImageBufAlgo::from_OpenCV(const cv::Mat& mat, TypeDesc convert, ROI roi,
     }
 
 #else
-    dst.errorf(
+    dst.errorfmt(
         "from_OpenCV() not supported -- no OpenCV support at compile time");
 #endif
 
@@ -389,12 +389,12 @@ ImageBufAlgo::capture_image(int cameranum, TypeDesc convert)
         lock_guard lock(opencv_mutex);
         auto cvcam = cameras[cameranum];
         if (!cvcam) {
-            dst.errorf("Could not create a capture camera (OpenCV error)");
+            dst.errorfmt("Could not create a capture camera (OpenCV error)");
             return dst;  // failed somehow
         }
         (*cvcam) >> frame;
         if (frame.empty()) {
-            dst.errorf("Could not cvQueryFrame (OpenCV error)");
+            dst.errorfmt("Could not cvQueryFrame (OpenCV error)");
             return dst;  // failed somehow
         }
     }
@@ -415,7 +415,7 @@ ImageBufAlgo::capture_image(int cameranum, TypeDesc convert)
         dst.specmod().attribute("DateTime", datetime);
     }
 #else
-    dst.errorf(
+    dst.errorfmt(
         "capture_image not supported -- no OpenCV support at compile time");
 #endif
     return dst;

--- a/src/libOpenImageIO/imagebufalgo_orient.cpp
+++ b/src/libOpenImageIO/imagebufalgo_orient.cpp
@@ -121,7 +121,7 @@ ImageBufAlgo::flip(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = flip(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::flip() error");
+        result.errorfmt("ImageBufAlgo::flip() error");
     return result;
 }
 
@@ -133,7 +133,7 @@ ImageBufAlgo::flop(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = flop(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::flop() error");
+        result.errorfmt("ImageBufAlgo::flop() error");
     return result;
 }
 
@@ -319,7 +319,7 @@ ImageBufAlgo::rotate90(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = rotate90(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::rotate90() error");
+        result.errorfmt("ImageBufAlgo::rotate90() error");
     return result;
 }
 
@@ -331,7 +331,7 @@ ImageBufAlgo::rotate180(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = rotate180(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::rotate180() error");
+        result.errorfmt("ImageBufAlgo::rotate180() error");
     return result;
 }
 
@@ -343,7 +343,7 @@ ImageBufAlgo::rotate270(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = rotate270(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::rotate270() error");
+        result.errorfmt("ImageBufAlgo::rotate270() error");
     return result;
 }
 
@@ -364,7 +364,7 @@ ImageBufAlgo::reorient(ImageBuf& dst, const ImageBuf& src, int nthreads)
         if (ok)
             ok = ImageBufAlgo::flop(dst, tmp, ROI(), nthreads);
         else
-            dst.errorf("%s", tmp.geterror());
+            dst.errorfmt("{}", tmp.geterror());
         break;
     case 6: ok = ImageBufAlgo::rotate90(dst, src, ROI(), nthreads); break;
     case 7:
@@ -372,7 +372,7 @@ ImageBufAlgo::reorient(ImageBuf& dst, const ImageBuf& src, int nthreads)
         if (ok)
             ok = ImageBufAlgo::rotate90(dst, tmp, ROI(), nthreads);
         else
-            dst.errorf("%s", tmp.geterror());
+            dst.errorfmt("{}", tmp.geterror());
         break;
     case 8: ok = ImageBufAlgo::rotate270(dst, src, ROI(), nthreads); break;
     }
@@ -388,7 +388,7 @@ ImageBufAlgo::reorient(const ImageBuf& src, int nthreads)
     ImageBuf result;
     bool ok = reorient(result, src, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::reorient() error");
+        result.errorfmt("ImageBufAlgo::reorient() error");
     return result;
 }
 
@@ -452,7 +452,7 @@ ImageBufAlgo::transpose(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = transpose(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::transpose() error");
+        result.errorfmt("ImageBufAlgo::transpose() error");
     return result;
 }
 

--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -102,7 +102,7 @@ ImageBufAlgo::min(ImageBuf& dst, Image_or_Const A_, Image_or_Const B_, ROI roi,
         return ok;
     }
     // Remaining cases: error
-    dst.errorf("ImageBufAlgo::min(): at least one argument must be an image");
+    dst.errorfmt("ImageBufAlgo::min(): at least one argument must be an image");
     return false;
 }
 
@@ -114,7 +114,7 @@ ImageBufAlgo::min(Image_or_Const A, Image_or_Const B, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = min(result, A, B, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::min() error");
+        result.errorfmt("ImageBufAlgo::min() error");
     return result;
 }
 
@@ -199,7 +199,7 @@ ImageBufAlgo::max(ImageBuf& dst, Image_or_Const A_, Image_or_Const B_, ROI roi,
         return ok;
     }
     // Remaining cases: error
-    dst.errorf("ImageBufAlgo::max(): at least one argument must be an image");
+    dst.errorfmt("ImageBufAlgo::max(): at least one argument must be an image");
     return false;
 }
 
@@ -211,7 +211,7 @@ ImageBufAlgo::max(Image_or_Const A, Image_or_Const B, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = max(result, A, B, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::max() error");
+        result.errorfmt("ImageBufAlgo::max() error");
     return result;
 }
 
@@ -267,7 +267,7 @@ ImageBufAlgo::clamp(const ImageBuf& src, cspan<float> min, cspan<float> max,
     ImageBuf result;
     bool ok = clamp(result, src, min, max, clampalpha01, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::clamp error");
+        result.errorfmt("ImageBufAlgo::clamp error");
     return result;
 }
 
@@ -352,7 +352,7 @@ ImageBufAlgo::absdiff(ImageBuf& dst, Image_or_Const A_, Image_or_Const B_,
         return ok;
     }
     // Remaining cases: error
-    dst.errorf(
+    dst.errorfmt(
         "ImageBufAlgo::absdiff(): at least one argument must be an image");
     return false;
 }
@@ -365,7 +365,7 @@ ImageBufAlgo::absdiff(Image_or_Const A, Image_or_Const B, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = absdiff(result, A, B, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::absdiff() error");
+        result.errorfmt("ImageBufAlgo::absdiff() error");
     return result;
 }
 
@@ -386,7 +386,7 @@ ImageBufAlgo::abs(const ImageBuf& A, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = abs(result, A, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("abs error");
+        result.errorfmt("abs error");
     return result;
 }
 
@@ -427,7 +427,7 @@ ImageBufAlgo::pow(const ImageBuf& A, cspan<float> b, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = pow(result, A, b, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("pow error");
+        result.errorfmt("pow error");
     return result;
 }
 
@@ -484,7 +484,7 @@ ImageBufAlgo::channel_sum(const ImageBuf& src, cspan<float> weights, ROI roi,
     ImageBuf result;
     bool ok = channel_sum(result, src, weights, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("channel_sum error");
+        result.errorfmt("channel_sum error");
     return result;
 }
 
@@ -710,7 +710,7 @@ ImageBufAlgo::rangecompress(const ImageBuf& src, bool useluma, ROI roi,
     ImageBuf result;
     bool ok = rangecompress(result, src, useluma, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::rangecompress() error");
+        result.errorfmt("ImageBufAlgo::rangecompress() error");
     return result;
 }
 
@@ -723,7 +723,7 @@ ImageBufAlgo::rangeexpand(const ImageBuf& src, bool useluma, ROI roi,
     ImageBuf result;
     bool ok = rangeexpand(result, src, useluma, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::rangeexpand() error");
+        result.errorfmt("ImageBufAlgo::rangeexpand() error");
     return result;
 }
 
@@ -800,7 +800,7 @@ ImageBufAlgo::unpremult(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = unpremult(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::unpremult() error");
+        result.errorfmt("ImageBufAlgo::unpremult() error");
     return result;
 }
 
@@ -876,7 +876,7 @@ ImageBufAlgo::premult(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = premult(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::premult() error");
+        result.errorfmt("ImageBufAlgo::premult() error");
     return result;
 }
 
@@ -912,7 +912,7 @@ ImageBufAlgo::repremult(const ImageBuf& src, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = repremult(result, src, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::repremult() error");
+        result.errorfmt("ImageBufAlgo::repremult() error");
     return result;
 }
 
@@ -1040,7 +1040,7 @@ ImageBufAlgo::contrast_remap(const ImageBuf& src, cspan<float> black,
     bool ok = contrast_remap(result, src, black, white, min, max, scontrast,
                              sthresh, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::contrast_remap error");
+        result.errorfmt("ImageBufAlgo::contrast_remap error");
     return result;
 }
 
@@ -1079,11 +1079,11 @@ ImageBufAlgo::color_map(ImageBuf& dst, const ImageBuf& src, int srcchannel,
 {
     pvt::LoggedTimer logtime("IBA::color_map");
     if (srcchannel >= src.nchannels()) {
-        dst.errorf("invalid source channel selected");
+        dst.errorfmt("invalid source channel selected");
         return false;
     }
     if (nknots < 2 || knots.size() < (nknots * channels)) {
-        dst.errorf("not enough knot values supplied");
+        dst.errorfmt("not enough knot values supplied");
         return false;
     }
     if (!roi.defined())
@@ -1113,7 +1113,7 @@ ImageBufAlgo::color_map(const ImageBuf& src, int srcchannel, int nknots,
     bool ok = color_map(result, src, srcchannel, nknots, channels, knots, roi,
                         nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::color_map() error");
+        result.errorfmt("ImageBufAlgo::color_map() error");
     return result;
 }
 
@@ -1207,7 +1207,7 @@ ImageBufAlgo::color_map(ImageBuf& dst, const ImageBuf& src, int srcchannel,
 {
     pvt::LoggedTimer logtime("IBA::color_map");
     if (srcchannel >= src.nchannels()) {
-        dst.errorf("invalid source channel selected");
+        dst.errorfmt("invalid source channel selected");
         return false;
     }
     cspan<float> knots;
@@ -1236,7 +1236,7 @@ ImageBufAlgo::color_map(ImageBuf& dst, const ImageBuf& src, int srcchannel,
                                    0.75f, 0.0f,  1.0f, 1.0f,  1.0f };
         knots                  = cspan<float>(k);
     } else {
-        dst.errorf("Unknown map name \"%s\"", mapname);
+        dst.errorfmt("Unknown map name \"{}\"", mapname);
         return false;
     }
     return color_map(dst, src, srcchannel, int(knots.size() / 3), 3, knots, roi,
@@ -1251,7 +1251,7 @@ ImageBufAlgo::color_map(const ImageBuf& src, int srcchannel,
     ImageBuf result;
     bool ok = color_map(result, src, srcchannel, mapname, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::color_map() error");
+        result.errorfmt("ImageBufAlgo::color_map() error");
     return result;
 }
 
@@ -1418,7 +1418,7 @@ ImageBufAlgo::fixNonFinite(ImageBuf& dst, const ImageBuf& src,
         && mode != ImageBufAlgo::NONFINITE_BOX3
         && mode != ImageBufAlgo::NONFINITE_ERROR) {
         // Something went wrong
-        dst.errorf("fixNonFinite: unknown repair mode");
+        dst.errorfmt("fixNonFinite: unknown repair mode");
         return false;
     }
 
@@ -1448,7 +1448,7 @@ ImageBufAlgo::fixNonFinite(ImageBuf& dst, const ImageBuf& src,
     // pixel values, so the copy was enough.
 
     if (mode == ImageBufAlgo::NONFINITE_ERROR && *pixelsFixed) {
-        dst.errorf("Nonfinite pixel values found");
+        dst.errorfmt("Nonfinite pixel values found");
         ok = false;
     }
     return ok;
@@ -1463,7 +1463,7 @@ ImageBufAlgo::fixNonFinite(const ImageBuf& src, NonFiniteFixMode mode,
     ImageBuf result;
     bool ok = fixNonFinite(result, src, mode, pixelsFixed, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::fixNonFinite() error");
+        result.errorfmt("ImageBufAlgo::fixNonFinite() error");
     return result;
 }
 
@@ -1630,7 +1630,7 @@ ImageBufAlgo::over(const ImageBuf& A, const ImageBuf& B, ROI roi, int nthreads)
     ImageBuf result;
     bool ok = over(result, A, B, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::over() error");
+        result.errorfmt("ImageBufAlgo::over() error");
     return result;
 }
 
@@ -1661,7 +1661,7 @@ ImageBufAlgo::zover(const ImageBuf& A, const ImageBuf& B, bool z_zeroisinf,
     ImageBuf result;
     bool ok = zover(result, A, B, z_zeroisinf, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::zover() error");
+        result.errorfmt("ImageBufAlgo::zover() error");
     return result;
 }
 

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -304,7 +304,7 @@ ImageBufAlgo::warp(ImageBuf& dst, const ImageBuf& src, const Imath::M33f& M,
         }
     }
     if (!filter) {
-        dst.errorf("Filter \"%s\" not recognized", filtername);
+        dst.errorfmt("Filter \"{}\" not recognized", filtername);
         return false;
     }
 
@@ -321,7 +321,7 @@ ImageBufAlgo::warp(const ImageBuf& src, const Imath::M33f& M,
     ImageBuf result;
     bool ok = warp(result, src, M, filter, recompute_roi, wrap, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::warp() error");
+        result.errorfmt("ImageBufAlgo::warp() error");
     return result;
 }
 
@@ -337,7 +337,7 @@ ImageBufAlgo::warp(const ImageBuf& src, const Imath::M33f& M,
     bool ok = warp(result, src, M, filtername, filterwidth, recompute_roi, wrap,
                    roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::warp() error");
+        result.errorfmt("ImageBufAlgo::warp() error");
     return result;
 }
 
@@ -620,7 +620,7 @@ get_resize_filter(string_view filtername, float fwidth, ImageBuf& dst,
         }
     }
     if (!filter) {
-        dst.errorf("Filter \"%s\" not recognized", filtername);
+        dst.errorfmt("Filter \"{}\" not recognized", filtername);
     }
     return filter;
 }
@@ -694,7 +694,7 @@ ImageBufAlgo::resize(const ImageBuf& src, Filter2D* filter, ROI roi,
     ImageBuf result;
     bool ok = resize(result, src, filter, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::resize() error");
+        result.errorfmt("ImageBufAlgo::resize() error");
     return result;
 }
 
@@ -706,7 +706,7 @@ ImageBufAlgo::resize(const ImageBuf& src, string_view filtername,
     ImageBuf result;
     bool ok = resize(result, src, filtername, filterwidth, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::resize() error");
+        result.errorfmt("ImageBufAlgo::resize() error");
     return result;
 }
 
@@ -858,7 +858,7 @@ ImageBufAlgo::fit(const ImageBuf& src, Filter2D* filter, string_view fillmode,
     ImageBuf result;
     bool ok = fit(result, src, filter, fillmode, exact, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::fit() error");
+        result.errorfmt("ImageBufAlgo::fit() error");
     return result;
 }
 
@@ -872,7 +872,7 @@ ImageBufAlgo::fit(const ImageBuf& src, string_view filtername,
     bool ok = fit(result, src, filtername, filterwidth, fillmode, exact, roi,
                   nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::fit() error");
+        result.errorfmt("ImageBufAlgo::fit() error");
     return result;
 }
 
@@ -1034,7 +1034,7 @@ ImageBufAlgo::resample(const ImageBuf& src, bool interpolate, ROI roi,
     ImageBuf result;
     bool ok = resample(result, src, interpolate, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::resample() error");
+        result.errorfmt("ImageBufAlgo::resample() error");
     return result;
 }
 
@@ -1095,7 +1095,7 @@ ImageBufAlgo::rotate(const ImageBuf& src, float angle, float center_x,
     bool ok = rotate(result, src, angle, center_x, center_y, filter,
                      recompute_roi, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::rotate() error");
+        result.errorfmt("ImageBufAlgo::rotate() error");
     return result;
 }
 
@@ -1110,7 +1110,7 @@ ImageBufAlgo::rotate(const ImageBuf& src, float angle, float center_x,
     bool ok = rotate(result, src, angle, center_x, center_y, filtername,
                      filterwidth, recompute_roi, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::rotate() error");
+        result.errorfmt("ImageBufAlgo::rotate() error");
     return result;
 }
 
@@ -1123,7 +1123,7 @@ ImageBufAlgo::rotate(const ImageBuf& src, float angle, Filter2D* filter,
     ImageBuf result;
     bool ok = rotate(result, src, angle, filter, recompute_roi, roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::rotate() error");
+        result.errorfmt("ImageBufAlgo::rotate() error");
     return result;
 }
 
@@ -1138,7 +1138,7 @@ ImageBufAlgo::rotate(const ImageBuf& src, float angle, string_view filtername,
     bool ok = rotate(result, src, angle, filtername, filterwidth, recompute_roi,
                      roi, nthreads);
     if (!ok && !result.has_error())
-        result.errorf("ImageBufAlgo::rotate() error");
+        result.errorfmt("ImageBufAlgo::rotate() error");
     return result;
 }
 

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -115,7 +115,7 @@ ImageInput::open(const std::string& filename, const ImageSpec* config,
         // error, delete the ImageInput we allocated, and return NULL.
         std::string err = in->geterror();
         if (err.size())
-            OIIO::pvt::errorf("%s", err);
+            OIIO::pvt::errorfmt("{}", err);
         in.reset();
     }
 

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -490,7 +490,7 @@ ImageOutput::create(string_view filename, Filesystem::IOProxy* ioproxy,
 {
     std::unique_ptr<ImageOutput> out;
     if (filename.empty()) {  // Can't even guess if no filename given
-        OIIO::pvt::errorf("ImageOutput::create() called with no filename");
+        OIIO::pvt::errorfmt("ImageOutput::create() called with no filename");
         return out;
     }
 
@@ -523,11 +523,11 @@ ImageOutput::create(string_view filename, Filesystem::IOProxy* ioproxy,
                 // case the app is too dumb to do so.
                 const char* msg
                     = "ImageOutput::create() could not find any ImageOutput plugins!  Perhaps you need to set OIIO_LIBRARY_PATH.\n";
-                fprintf(stderr, "%s", msg);
-                OIIO::pvt::errorf("%s", msg);
+                Strutil::print(stderr, "{}", msg);
+                OIIO::pvt::errorfmt("{}", msg);
             } else
-                OIIO::pvt::errorf(
-                    "OpenImageIO could not find a format writer for \"%s\". "
+                OIIO::pvt::errorfmt(
+                    "OpenImageIO could not find a format writer for \"{}\". "
                     "Is it a file format that OpenImageIO doesn't know about?\n",
                     filename);
             return out;
@@ -544,8 +544,8 @@ ImageOutput::create(string_view filename, Filesystem::IOProxy* ioproxy,
     if (out && ioproxy) {
         if (!out->supports("ioproxy")) {
             out.reset();
-            OIIO::pvt::errorf(
-                "ImageOutput::create called with IOProxy, but format %s does not support IOProxy",
+            OIIO::pvt::errorfmt(
+                "ImageOutput::create called with IOProxy, but format {} does not support IOProxy",
                 out->format_name());
         } else {
             out->set_ioproxy(ioproxy);
@@ -615,7 +615,7 @@ ImageInput::create(string_view filename, bool do_open, const ImageSpec* config,
     std::map<std::string, std::string> args;
     std::string filename_stripped;
     if (!Strutil::get_rest_arguments(filename, filename_stripped, args)) {
-        OIIO::pvt::errorf(
+        OIIO::pvt::errorfmt(
             "ImageInput::create() called with malformed filename");
         return in;
     }
@@ -624,7 +624,7 @@ ImageInput::create(string_view filename, bool do_open, const ImageSpec* config,
         filename_stripped = filename;
 
     if (filename_stripped.empty()) {  // Can't even guess if no filename given
-        OIIO::pvt::errorf("ImageInput::create() called with no filename");
+        OIIO::pvt::errorfmt("ImageInput::create() called with no filename");
         return in;
     }
 
@@ -751,20 +751,20 @@ ImageInput::create(string_view filename, bool do_open, const ImageSpec* config,
             const char* msg
                 = "ImageInput::create() could not find any ImageInput plugins!\n"
                   "    Perhaps you need to set OIIO_LIBRARY_PATH.\n";
-            fprintf(stderr, "%s", msg);
-            OIIO::pvt::errorf("%s", msg);
+            Strutil::print(stderr, "{}", msg);
+            OIIO::pvt::errorfmt("{}", msg);
         } else if (!specific_error.empty()) {
             // Pass along any specific error message we got from our
             // best guess of the format.
-            OIIO::pvt::errorf("%s", specific_error);
+            OIIO::pvt::errorfmt("{}", specific_error);
         } else if (Filesystem::exists(filename))
-            pvt::errorf(
-                "OpenImageIO could not find a format reader for \"%s\". "
+            pvt::errorfmt(
+                "OpenImageIO could not find a format reader for \"{}\". "
                 "Is it a file format that OpenImageIO doesn't know about?\n",
                 filename);
         else
-            OIIO::pvt::errorf(
-                "Image \"%s\" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.\n",
+            OIIO::pvt::errorfmt(
+                "Image \"{}\" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.\n",
                 filename);
         OIIO_DASSERT(!in);
         return in;

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -1016,12 +1016,6 @@ public:
         OIIO_DASSERT(m_mem_used >= 0);
     }
 
-    /// Internal error reporting routine, with printf-like arguments.
-    template<typename... Args>
-    void errorf(const char* fmt, const Args&... args) const
-    {
-        append_error(Strutil::sprintf(fmt, args...));
-    }
     /// Internal error reporting routine, with std::format-like arguments.
     template<typename... Args>
     void error(const char* fmt, const Args&... args) const

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -184,7 +184,7 @@ TextureSystemImpl::texture3d(TextureHandle* texture_handle_,
         auto input                   = texturefile->open(thread_info);
         Field3DInput_Interface* f3di = (Field3DInput_Interface*)input.get();
         if (!f3di) {
-            errorf("Unable to open texture \"%s\"", texturefile->filename());
+            error("Unable to open texture \"{}\"", texturefile->filename());
             return false;
         }
         f3di->worldToLocal(P, Plocal, options.time);

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -365,7 +365,7 @@ private:
         if (!texturefile || texturefile->broken()) {
             std::string err = m_imagecache->geterror();
             if (err.size())
-                errorf("%s", err);
+                error("{}", err);
 #if 0
             // If the file is "broken", at least one verbose error message
             // has already been issued about it, so don't belabor the point.
@@ -537,12 +537,6 @@ private:
     /// Perform short unit tests.
     void unit_test_texture();
 
-    /// Internal error reporting routine, with printf-like arguments.
-    template<typename... Args>
-    void errorf(const char* fmt, const Args&... args) const
-    {
-        append_error(Strutil::sprintf(fmt, args...));
-    }
     /// Internal error reporting routine, with std::format-like arguments.
     template<typename... Args>
     void error(const char* fmt, const Args&... args) const

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -223,12 +223,12 @@ Strutil::memformat(long long bytes, int digits)
         d     = (double)bytes / MB;
     } else if (bytes >= KB) {
         // Just KB, don't bother with decimalization
-        return format("%lld KB", (long long)bytes / KB);
+        return fmt::format("{} KB", bytes / KB);
     } else {
         // Just bytes, don't bother with decimalization
-        return format("%lld B", (long long)bytes);
+        return fmt::format("{} B", bytes);
     }
-    return format("%1.*f %s", digits, d, units);
+    return Strutil::sprintf("%1.*f %s", digits, d, units);
 }
 
 
@@ -248,13 +248,13 @@ Strutil::timeintervalformat(double secs, int digits)
     int m = (int)floor(secs / mins);
     secs  = fmod(secs, mins);
     if (d)
-        out += format("%dd %dh ", d, h);
+        out += fmt::format("{}d {}h ", d, h);
     else if (h)
-        out += format("%dh ", h);
+        out += fmt::format("{}h ", h);
     if (m || h || d)
-        out += format("%dm %1.*fs", m, digits, secs);
+        out += Strutil::sprintf("%dm %1.*fs", m, digits, secs);
     else
-        out += format("%1.*fs", digits, secs);
+        out += Strutil::sprintf("%1.*fs", digits, secs);
     return out;
 }
 

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -155,13 +155,13 @@ ImageBuf_set_pixels_buffer(ImageBuf& self, ROI roi, py::buffer& buffer)
     oiio_bufinfo buf(buffer.request(), roi.nchannels(), roi.width(),
                      roi.height(), roi.depth(), self.spec().depth > 1 ? 3 : 2);
     if (!buf.data || buf.error.size()) {
-        self.errorf("set_pixels error: %s",
-                    buf.error.size() ? buf.error.c_str() : "unspecified");
+        self.errorfmt("set_pixels error: {}",
+                      buf.error.size() ? buf.error.c_str() : "unspecified");
         return false;  // failed sanity checks
     }
     if (!buf.data || buf.size != size) {
-        self.error(
-            "ImageBuf.set_pixels: array size (%d) did not match ROI size w=%d h=%d d=%d ch=%d (total %d)",
+        self.errorfmt(
+            "ImageBuf.set_pixels: array size ({}) did not match ROI size w={} h={} d={} ch={} (total {})",
             buf.size, roi.width(), roi.height(), roi.depth(), roi.nchannels(),
             size);
         return false;

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -198,7 +198,7 @@ IBA_channels(ImageBuf& dst, const ImageBuf& src, py::tuple channelorder_,
 {
     size_t nchannels = (size_t)len(channelorder_);
     if (nchannels < 1) {
-        dst.error("No channels selected");
+        dst.errorfmt("No channels selected");
         return false;
     }
     std::vector<int> channelorder(nchannels, -1);
@@ -220,7 +220,7 @@ IBA_channels(ImageBuf& dst, const ImageBuf& src, py::tuple channelorder_,
     std::vector<std::string> newchannelnames;
     py_to_stdvector(newchannelnames, newchannelnames_);
     if (newchannelnames.size() != 0 && newchannelnames.size() != nchannels) {
-        dst.error("Inconsistent number of channel arguments");
+        dst.errorfmt("Inconsistent number of channel arguments");
         return false;
     }
     py::gil_scoped_release gil;
@@ -1146,7 +1146,7 @@ IBA_channel_sum_weight(ImageBuf& dst, const ImageBuf& src,
     std::vector<float> weight;
     py_to_stdvector(weight, weight_tuple);
     if (!src.initialized()) {
-        dst.error("Uninitialized source image for channel_sum");
+        dst.errorfmt("Uninitialized source image for channel_sum");
         return false;
     }
     if (weight.size() == 0)
@@ -1175,7 +1175,7 @@ IBA_channel_sum_weight_ret(const ImageBuf& src, py::object weight_tuple,
     std::vector<float> weight;
     py_to_stdvector(weight, weight_tuple);
     if (!src.initialized()) {
-        result.error("Uninitialized source image for channel_sum");
+        result.errorfmt("Uninitialized source image for channel_sum");
         return result;
     }
     if (weight.size() == 0)
@@ -1204,11 +1204,11 @@ IBA_color_map_values(ImageBuf& dst, const ImageBuf& src, int srcchannel,
     std::vector<float> knots;
     py_to_stdvector(knots, knots_tuple);
     if (!src.initialized()) {
-        dst.error("Uninitialized source image for color_map");
+        dst.errorfmt("Uninitialized source image for color_map");
         return false;
     }
     if (!knots.size()) {
-        dst.error("No knot values supplied");
+        dst.errorfmt("No knot values supplied");
         return false;
     }
     py::gil_scoped_release gil;
@@ -1223,7 +1223,7 @@ IBA_color_map_name(ImageBuf& dst, const ImageBuf& src, int srcchannel,
                    int nthreads = 0)
 {
     if (!src.initialized()) {
-        dst.error("Uninitialized source image for color_map");
+        dst.errorfmt("Uninitialized source image for color_map");
         return false;
     }
     py::gil_scoped_release gil;
@@ -1924,7 +1924,7 @@ IBA_colormatrixtransform(ImageBuf& dst, const ImageBuf& src,
     std::vector<float> Mvals;
     bool ok = py_to_stdvector(Mvals, Mobj);
     if (!ok || Mvals.size() != 16) {
-        dst.errorf(
+        dst.errorfmt(
             "colormatrixtransform did not receive 16 elements to make a 4x4 matrix");
         return false;
     }

--- a/src/python/py_imageoutput.cpp
+++ b/src/python/py_imageoutput.cpp
@@ -34,18 +34,18 @@ ImageOutput_write_scanline(ImageOutput& self, int y, int z, py::buffer& buffer)
 {
     const ImageSpec& spec(self.spec());
     if (spec.tile_width != 0) {
-        self.errorf("Cannot write scanlines to a filed file.");
+        self.errorfmt("Cannot write scanlines to a filed file.");
         return false;
     }
     oiio_bufinfo buf(buffer.request(), spec.nchannels, spec.width, 1, 1, 1);
     if (!buf.data || buf.error.size()) {
-        self.errorf("Pixel data array error: %s",
-                    buf.error.size() ? buf.error.c_str() : "unspecified");
+        self.errorfmt("Pixel data array error: {}",
+                      buf.error.size() ? buf.error.c_str() : "unspecified");
         return false;  // failed sanity checks
     }
     if (static_cast<int>(buf.size)
         < self.spec().width * self.spec().nchannels) {
-        self.error("write_scanlines was not passed a long enough array");
+        self.errorfmt("write_scanlines was not passed a long enough array");
         return false;
     }
     py::gil_scoped_release gil;
@@ -60,19 +60,19 @@ ImageOutput_write_scanlines(ImageOutput& self, int ybegin, int yend, int z,
 {
     const ImageSpec& spec(self.spec());
     if (spec.tile_width != 0) {
-        self.errorf("Cannot write scanlines to a filed file.");
+        self.errorfmt("Cannot write scanlines to a filed file.");
         return false;
     }
     oiio_bufinfo buf(buffer.request(), spec.nchannels, spec.width,
                      yend - ybegin, 1, 2);
     if (!buf.data || buf.error.size()) {
-        self.errorf("Pixel data array error: %s",
-                    buf.error.size() ? buf.error.c_str() : "unspecified");
+        self.errorfmt("Pixel data array error: {}",
+                      buf.error.size() ? buf.error.c_str() : "unspecified");
         return false;  // failed sanity checks
     }
     if (static_cast<int>(buf.size)
         < self.spec().width * self.spec().nchannels * (yend - ybegin)) {
-        self.error("write_scanlines was not passed a long enough array");
+        self.errorfmt("write_scanlines was not passed a long enough array");
         return false;
     }
     py::gil_scoped_release gil;
@@ -100,7 +100,7 @@ ImageOutput_write_tile(ImageOutput& self, int x, int y, int z,
         return false;  // failed sanity checks
     }
     if (buf.size < self.spec().tile_pixels() * self.spec().nchannels) {
-        self.error("write_tile was not passed a long enough array");
+        self.errorfmt("write_tile was not passed a long enough array");
         return false;
     }
     py::gil_scoped_release gil;
@@ -129,7 +129,7 @@ ImageOutput_write_tiles(ImageOutput& self, int xbegin, int xend, int ybegin,
     if (static_cast<int>(buf.size) < (xend - xbegin) * (yend - ybegin)
                                          * (zend - zbegin)
                                          * self.spec().nchannels) {
-        self.error("write_tiles was not passed a long enough array");
+        self.errorfmt("write_tiles was not passed a long enough array");
         return false;
     }
     py::gil_scoped_release gil;

--- a/src/term.imageio/termoutput.cpp
+++ b/src/term.imageio/termoutput.cpp
@@ -58,13 +58,13 @@ bool
 TermOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
 {
     if (mode != Create) {
-        error("%s does not support subimages or MIP levels", format_name());
+        errorfmt("{} does not support subimages or MIP levels", format_name());
         return false;
     }
 
     if (spec.nchannels != 3 && spec.nchannels != 4) {
-        error("%s does not support %d-channel images\n", format_name(),
-              m_spec.nchannels);
+        errorfmt("{} does not support {}-channel images\n", format_name(),
+                 m_spec.nchannels);
         return false;
     }
 
@@ -90,7 +90,7 @@ TermOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
                            stride_t xstride)
 {
     if (y > m_spec.height) {
-        error("Attempt to write too many scanlines to terminal");
+        errorfmt("Attempt to write too many scanlines to terminal");
         close();
         return false;
     }


### PR DESCRIPTION
Update old calls to Strutil::format to new fmt conventions, convert
some sprintf-like calls to std::format like calls.

This is not meant to be comprehensive; there is more work to do.
It's just an opportunistic bite at getting some of it done.

