### PR TITLE
CI: test C++20 on the Linux bleeding edge test.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
     # gcc9 and C++17. This test currently uses the latest OpenEXR release
     # 2.5, though eventually 2021 will feature OpenEXR 3.0 when complete.
     name: "Linux VFX Platform 2021: gcc9/C++17 py3.7 boost-1.73 exr-2.5 qt-5.15"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container:
       image: aswf/ci-osl:2021
     env:
@@ -209,7 +209,7 @@ jobs:
     # Test what's anticipated to be VFX Platform 2021 -- mainly, that means
     # gcc9 and C++17, and also the in-progress openexr/imath 3.0.
     name: "Linux VFX Platform 2021: gcc9/C++17 py3.7 boost-1.73 exr-3.0 qt-5.15"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container:
       image: aswf/ci-osl:2021
     env:
@@ -346,7 +346,7 @@ jobs:
   linux-latest-releases:
     # Test against latest supported releases of toolchain and dependencies.
     name: "Linux latest releases: gcc10 C++17 avx2 exr2.5 ocio2.0"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       CXX: g++-10
       CMAKE_CXX_STANDARD: 17
@@ -357,8 +357,11 @@ jobs:
       OPENEXR_VERSION: v2.5.3
       PUGIXML_VERSION: v1.11.4
       PYBIND11_VERSION: v2.6.2
+      PYTHON_VERSION: 3.8
       WEBP_VERSION: v1.1.0
       MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=7.1.3
+      USE_OPENVDB: 0
+      # The old installed OpenVDB has a TLS conflict with Python 3.8
     steps:
       - uses: actions/checkout@v2
       - name: Prepare ccache timestamp
@@ -396,11 +399,11 @@ jobs:
   linux-bleeding-edge:
     # Test against development master for relevant dependencies, latest
     # supported releases of everything else.
-    name: "Linux bleeding edge: gcc10 C++17 avx2 OCIO/libtiff/exr master"
-    runs-on: ubuntu-18.04
+    name: "Linux bleeding edge: gcc10 C++20 py38 avx2 OCIO/libtiff/exr master"
+    runs-on: ubuntu-20.04
     env:
       CXX: g++-10
-      CMAKE_CXX_STANDARD: 17
+      CMAKE_CXX_STANDARD: 20
       USE_SIMD: avx2,f16c
       LIBRAW_VERSION: master
       LIBTIFF_VERSION: master
@@ -409,8 +412,11 @@ jobs:
       PUGIXML_VERSION: master
       PYBIND11_VERSION: v2.6.2
       # PYBIND11_VERSION: master
+      PYTHON_VERSION: 3.8
       WEBP_VERSION: master
       MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=master
+      USE_OPENVDB: 0
+      # The old installed OpenVDB has a TLS conflict with Python 3.8
     steps:
       - uses: actions/checkout@v2
       - name: Prepare ccache timestamp
@@ -419,6 +425,7 @@ jobs:
           echo "::set-output name=date::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
       - name: CCache
         id: ccache
+        if: always()
         uses: actions/cache@v2
         with:
           path: /tmp/ccache

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
 
 ### Required dependencies -- OIIO will not build at all without these
 
- * C++11 (also builds with C++14 and C++17)
+ * C++11 (also builds with C++14, C++17, and C++20)
  * Compilers: gcc 4.8.2 - 10.2, clang 3.3 - 11, MSVS 2015 - 2019,
    icc version 13 or higher
  * CMake >= 3.12 (tested through 3.19)

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -30,7 +30,6 @@ else
         libboost-dev libboost-thread-dev \
         libboost-filesystem-dev libboost-regex-dev \
         libilmbase-dev libopenexr-dev \
-        python-dev python-numpy \
         libtbb-dev \
         libtiff-dev libgif-dev libpng-dev libraw-dev libwebp-dev \
         libavcodec-dev libavformat-dev libswscale-dev libavutil-dev \
@@ -41,6 +40,12 @@ else
         libopencv-dev \
         qt5-default \
         libhdf5-dev
+
+    if [[ "$PYTHON_VERSION" == "2.7" ]] ; then
+        time sudo apt-get -q install -y python-dev python-numpy
+    else
+        pip3 install numpy
+    fi
 
     if [[ "$USE_LIBHEIF" != "0" ]] ; then
        sudo add-apt-repository ppa:strukturag/libde265

--- a/src/libutil/spin_rw_test.cpp
+++ b/src/libutil/spin_rw_test.cpp
@@ -31,7 +31,7 @@ static int ntrials          = 1;
 static bool verbose         = false;
 static bool wedge           = false;
 
-volatile long long accum = 0;
+long long accum = 0;
 spin_rw_mutex mymutex;
 
 

--- a/src/libutil/spinlock_test.cpp
+++ b/src/libutil/spinlock_test.cpp
@@ -30,8 +30,8 @@ static bool verbose   = false;
 static bool wedge     = false;
 
 static spin_mutex print_mutex;  // make the prints not clobber each other
-volatile long long accum = 0;
-float faccum             = 0;
+long long accum = 0;
+float faccum    = 0;
 spin_mutex mymutex;
 
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5305,12 +5305,14 @@ print_help_end(std::ostream& out)
     std::string buildsimd = OIIO::get_string_attribute("oiio:simd");
     if (!buildsimd.size())
         buildsimd = "no SIMD";
-    auto hwinfo
-        = Strutil::sprintf("OIIO %s built %s, running on %d cores %.1fGB %s",
-                           OIIO_VERSION_STRING, buildsimd,
-                           Sysutil::hardware_concurrency(),
-                           Sysutil::physical_memory() / float(1 << 30),
-                           OIIO::get_string_attribute("hw:simd"));
+    auto buildinfo
+        = Strutil::sprintf("OIIO %s built for C++%d/%d %s", OIIO_VERSION_STRING,
+                           OIIO_CPLUSPLUS_VERSION, __cplusplus, buildsimd);
+    out << Strutil::wordwrap(buildinfo, columns, 4) << std::endl;
+    auto hwinfo = Strutil::sprintf("Running on %d cores %.1fGB %s",
+                                   Sysutil::hardware_concurrency(),
+                                   Sysutil::physical_memory() / float(1 << 30),
+                                   OIIO::get_string_attribute("hw:simd"));
     out << Strutil::wordwrap(hwinfo, columns, 4) << std::endl;
 
     // Print the path to the docs. If found, use the one installed in the

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -1172,12 +1172,13 @@ TIFFOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
     for (size_t stripidx = 0; y + m_rowsperstrip <= yend;
          y += m_rowsperstrip, ++stripidx) {
         char* cbuf = compressed_scratch.get() + stripidx * cbound;
+        auto out   = this;
         tasks.push(pool->push([=, &ok](int /*id*/) {
             memcpy((void*)data, origdata, strip_bytes);
-            this->compress_one_strip((void*)data, strip_bytes, cbuf, cbound,
-                                     this->m_spec.nchannels, this->m_spec.width,
-                                     m_rowsperstrip, compressed_len + stripidx,
-                                     &ok);
+            out->compress_one_strip((void*)data, strip_bytes, cbuf, cbound,
+                                    out->m_spec.nchannels, out->m_spec.width,
+                                    out->m_rowsperstrip,
+                                    compressed_len + stripidx, &ok);
         }));
         data     = (char*)data + strip_bytes;
         origdata = (char*)origdata + strip_bytes;


### PR DESCRIPTION
Fix minor warnings and deprecations of C++20.

Bump to more modern ubuntu images for recent-year tests and make some
related adjustments. Also make sure that the "latest" and "bleeding edge"
tests are using python3, they were inadvertently still using python2.
