### PR TITLE
Fix reading tiff files when size is not multiple of tile size

### DIFF
--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1843,10 +1843,10 @@ TIFFInput::read_native_tile(int subimage, int miplevel, int x, int y, int z,
         int vert_offset = m_spec.tile_height - th;
 
         copy_image(m_spec.nchannels, tw, th, 1,
-                   &m_rgbadata[vert_offset * m_spec.tile_width + (th - 1) * m_spec.tile_width], m_spec.nchannels,
-                   4, -m_spec.tile_width * 4, AutoStride, data,
-                   m_spec.nchannels, m_spec.nchannels * m_spec.tile_width,
-                   AutoStride);
+                   &m_rgbadata[vert_offset * m_spec.tile_width
+                               + (th - 1) * m_spec.tile_width],
+                   m_spec.nchannels, 4, -m_spec.tile_width * 4, AutoStride,
+                   data, m_spec.nchannels, m_spec.nchannels * m_spec.tile_width,
         return true;
     }
 

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1833,13 +1833,15 @@ TIFFInput::read_native_tile(int subimage, int miplevel, int x, int y, int z,
             errorf("Unknown error trying to read TIFF as RGBA");
             return false;
         }
-        // Copy, and use stride magic to reverse top-to-bottom
+        // Copy, and use stride magic to reverse top-to-bottom, because
+        // TIFFReadRGBATile always returns data in bottom-to-top order.
         int tw = std::min(m_spec.tile_width, m_spec.width - x);
         int th = std::min(m_spec.tile_height, m_spec.height - y);
 
         // When the vertical read size is smaller that the tile size
         // the actual data is in the bottom end of the tile
-        // so copy_image should start from tile_height - read_height
+        // so copy_image should start from tile_height - read_height.
+        // (Again, because TIFFReadRGBATile reverses the scanline order.)
         int vert_offset = m_spec.tile_height - th;
 
         copy_image(m_spec.nchannels, tw, th, 1,

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1836,8 +1836,14 @@ TIFFInput::read_native_tile(int subimage, int miplevel, int x, int y, int z,
         // Copy, and use stride magic to reverse top-to-bottom
         int tw = std::min(m_spec.tile_width, m_spec.width - x);
         int th = std::min(m_spec.tile_height, m_spec.height - y);
+
+        // When the vertical read size is smaller that the tile size
+        // the actual data is in the bottom end of the tile
+        // so copy_image should start from tile_height - read_height
+        int vert_offset = m_spec.tile_height - th;
+
         copy_image(m_spec.nchannels, tw, th, 1,
-                   &m_rgbadata[(th - 1) * m_spec.tile_width], m_spec.nchannels,
+                   &m_rgbadata[vert_offset * m_spec.tile_width + (th - 1) * m_spec.tile_width], m_spec.nchannels,
                    4, -m_spec.tile_width * 4, AutoStride, data,
                    m_spec.nchannels, m_spec.nchannels * m_spec.tile_width,
                    AutoStride);

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1847,6 +1847,7 @@ TIFFInput::read_native_tile(int subimage, int miplevel, int x, int y, int z,
                                + (th - 1) * m_spec.tile_width],
                    m_spec.nchannels, 4, -m_spec.tile_width * 4, AutoStride,
                    data, m_spec.nchannels, m_spec.nchannels * m_spec.tile_width,
+                   AutoStride);
         return true;
     }
 

--- a/testsuite/tiff-suite/ref/out-alt.txt
+++ b/testsuite/tiff-suite/ref/out-alt.txt
@@ -341,7 +341,7 @@ Reading ../../../../../libtiffpic/smallliz.tif
     tiff:subfiletype: 0
 Reading ../../../../../libtiffpic/zackthecat.tif
 ../../../../../libtiffpic/zackthecat.tif :  234 x  213, 3 channel, uint8 tiff
-    SHA-1: 061497BA196953824E24E5E6EF765D00BE85702C
+    SHA-1: 7FAA5E402AB1A5307154B3EEF4A62F251472BF3F
     channel list: R, G, B
     tile size: 240 x 224
     compression: "ojpeg"

--- a/testsuite/tiff-suite/ref/out-alt2.txt
+++ b/testsuite/tiff-suite/ref/out-alt2.txt
@@ -341,7 +341,7 @@ Reading ../../../../../libtiffpic/smallliz.tif
     tiff:subfiletype: 0
 Reading ../../../../../libtiffpic/zackthecat.tif
 ../../../../../libtiffpic/zackthecat.tif :  234 x  213, 3 channel, uint8 tiff
-    SHA-1: 061497BA196953824E24E5E6EF765D00BE85702C
+    SHA-1: 7FAA5E402AB1A5307154B3EEF4A62F251472BF3F
     channel list: R, G, B
     tile size: 240 x 224
     compression: "ojpeg"

--- a/testsuite/tiff-suite/ref/out-jpeg9b.txt
+++ b/testsuite/tiff-suite/ref/out-jpeg9b.txt
@@ -341,7 +341,7 @@ Reading ../../../../../libtiffpic/smallliz.tif
     tiff:subfiletype: 0
 Reading ../../../../../libtiffpic/zackthecat.tif
 ../../../../../libtiffpic/zackthecat.tif :  234 x  213, 3 channel, uint8 tiff
-    SHA-1: 061497BA196953824E24E5E6EF765D00BE85702C
+    SHA-1: 7FAA5E402AB1A5307154B3EEF4A62F251472BF3F
     channel list: R, G, B
     tile size: 240 x 224
     compression: "ojpeg"

--- a/testsuite/tiff-suite/ref/out.txt
+++ b/testsuite/tiff-suite/ref/out.txt
@@ -341,7 +341,7 @@ Reading ../../../../../libtiffpic/smallliz.tif
     tiff:subfiletype: 0
 Reading ../../../../../libtiffpic/zackthecat.tif
 ../../../../../libtiffpic/zackthecat.tif :  234 x  213, 3 channel, uint8 tiff
-    SHA-1: 061497BA196953824E24E5E6EF765D00BE85702C
+    SHA-1: 7FAA5E402AB1A5307154B3EEF4A62F251472BF3F
     channel list: R, G, B
     tile size: 240 x 224
     compression: "ojpeg"


### PR DESCRIPTION
## Description

The problem occurs when a tiff file has vertical size which is not multiple of the tile size.
For example tile size 64x64 and size 1240x1240. In this case, when `libtiff` reads the tiles on the last row, it moves the data to the bottom of the tile (vertically), but oiio starts reading from the top of the tile.

## Tests

I have a pre-existing .tx file which is not loaded correctly.

This is the result without the fix:
![problem](https://user-images.githubusercontent.com/325479/111279542-7774b480-8643-11eb-8537-9f2038633ff8.jpg)

And this is with the fix:
![fixed](https://user-images.githubusercontent.com/325479/111279548-780d4b00-8643-11eb-81d3-40a7f223c224.jpg)

I also tested with `zackthecat.tif` from the tiff test suite. In this case the whole image is shifted because the tile is bigger than the image: resolution 234x213 with tile size 240x224

with 2.2.11.1
![image](https://user-images.githubusercontent.com/325479/111338508-ad378e80-867f-11eb-94c1-b2505d54b1e0.png)
vs with the fix
![image](https://user-images.githubusercontent.com/325479/111338275-795c6900-867f-11eb-96be-9c42e8b9990c.png)

I have not run the tests locally - not sure how yet, but I suppose the fix works and test cases need to be updated

command used:
```
./oiiotool -i zackthecat.tif -o zackthecat.jpg
```

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

