### PR TITLE
Targa read fix for tga files with 0-sized thumbnails

### DIFF
--- a/testsuite/targa-tgautils/ref/out.txt
+++ b/testsuite/targa-tgautils/ref/out.txt
@@ -173,3 +173,11 @@ Reading ../../../../../oiio-images/targa/UTC32.TGA
     targa:ImageID: "Truevision(R) Sample Image"
 Comparing "../../../../../oiio-images/targa/UTC32.TGA" and "UTC32.TGA"
 PASS
+Reading ../../../../../oiio-images/targa/round_grill.tga
+../../../../../oiio-images/targa/round_grill.tga :  256 x  256, 4 channel, uint8 targa
+    SHA-1: D8D11F158BE59F6E56F69F399050417557132685
+    channel list: R, G, B, A
+    Software: "COREL 0.0"
+    oiio:BitsPerSample: 8
+Comparing "../../../../../oiio-images/targa/round_grill.tga" and "round_grill.tga"
+PASS

--- a/testsuite/targa-tgautils/run.py
+++ b/testsuite/targa-tgautils/run.py
@@ -3,6 +3,7 @@
 imagedir = OIIO_TESTSUITE_IMAGEDIR + "/targa"
 
 files = [ "CBW8.TGA", "CCM8.TGA", "CTC16.TGA", "CTC24.TGA", "CTC32.TGA",
-          "UBW8.TGA", "UCM8.TGA", "UTC16.TGA", "UTC24.TGA", "UTC32.TGA" ]
+          "UBW8.TGA", "UCM8.TGA", "UTC16.TGA", "UTC24.TGA", "UTC32.TGA",
+          "round_grill.tga" ]
 for f in files:
     command += rw_command (imagedir, f)


### PR DESCRIPTION
All of our prior tga tests had valid thumbnails. The code skipped the
thumbnail if the "offset to the thumbnail" was 0. But if the offset was
nonzero but the thumbnail record at that spot had a 0x0 size, we just
ran merrily along, and on Windows in debug mode even it an assert.

This patch makes it understand that a 0x0 thumbnail size means no
thumbnail.

I added an image from Doug Rogers, the reporter of the problem, to the
oiio-images repo in the targa directory, and updated the OIIO testsuite
to also check that image. (So testsuite will fail for people who don't
update their oiio-images repo.)

Also changed some stray refs to &vector[0] to vector.data().

Fixes #2900 
