### PR TITLE
oiiotool --skip-bad-frames

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -135,6 +135,12 @@ Alternately, you can use the `printf` notation, such as::
 
     oiiotool --frames 3,4,10-20x2 blah.%03d.tif
 
+When using frame ranges, keep in mind that by default, any error (such as an
+input file not being found) on any frame will exit oiiotool right away.
+However, the `--skip-bad-frames` command line option causes an error to skip
+the rest of the processing for that frame, but try to continue iteration
+with the next frame.
+
 Two special command line arguments can be used to disable numeric wildcard
 expansion: `--wildcardoff` disables numeric wildcard expansion for
 subsequent command line arguments, until `--wildcardon` re-enables it for
@@ -952,6 +958,13 @@ output each one to a different file, with names `sub0001.tif`,
     Supplies a comma-separated list of view names (substituted for `%V`
     and `%v`). If not supplied, the view list will be `left,right`.
 
+
+.. option:: --skip-bad-frames
+
+    When iterating over a frame range, if this option is used, any errors
+    will cease processing that frame, but continue iterating with the next
+    frame (rather than the default behavior of exiting immediately and not
+    even attempting the other frames in the range).
 
 .. option:: --wildcardoff, --wildcardon
 

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -65,7 +65,8 @@ public:
     int cachesize;
     int autotile;
     int frame_padding;
-    bool eval_enable;  // Enable evaluation of expressions
+    bool eval_enable;              // Enable evaluation of expressions
+    bool skip_bad_frames = false;  // Just skip a bad frame, don't exit
     std::string full_command_line;
     std::string printinfo_metamatch;
     std::string printinfo_nometamatch;


### PR DESCRIPTION
Ordinarily, oiiotool will exit upon encountering an error (such as an
input file not being found). When operating on a frame range or with
frame number wildcards, that means that it will exit without attempting
the rest of the frame range.

The new `--skip-bad-frames` command line argument means that an error
will skip the rest of that iteration, but not exit, instead starting
fresh on the next frame in the sequence. (But if any frame in the
sequence encounters an error, the exit code of the oiiotool command
will still be EXIT_FAILURE.)

