### PR TITLE
Avoid OCIO 2 exception by setting strides correctly

### DIFF
--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -34,7 +34,8 @@ public:
     // Convert a single 3-color
     void apply(float* data)
     {
-        apply((float*)data, 1, 1, 3, sizeof(float), 0, 0);
+        apply((float*)data, 1, 1, 3, sizeof(float), 3 * sizeof(float),
+              3 * sizeof(float));
     }
 };
 


### PR DESCRIPTION
For the case of applying a color transformation to just one color, we
were sloppy and set the strides to 0 (just one color means we are not
iterating from point to point using the strides).

OpenColorIO 1.x didn't care, but OpenColorIO 2.0 throws an exception if
the strides don't look valid.

Thanks to Thomas Metais for the fix suggestion.
