### PR TITLE
Fix missing boost path on recently broken GHA CI

### DIFF
--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -13,14 +13,8 @@ VCPKG_INSTALLATION_ROOT=/c/vcpkg
 
 export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:=.}
 export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;$DEP_DIR"
-export BOOST_ROOT=${BOOST_ROOT_1_72_0}
-
-BOOST_UNIX_PATH=$(echo "/$BOOST_ROOT" | sed -e 's/\\/\//g' -e 's/://')
-echo "BOOST_UNIX_PATH=$BOOST_UNIX_PATH"
-
-export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;$BOOST_ROOT"
 export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;$VCPKG_INSTALLATION_ROOT/installed/x64-windows"
-export PATH="$PATH:$DEP_DIR/bin:$DEP_DIR/lib:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin:/bin:${BOOST_UNIX_PATH}/lib:${BOOST_UNIX_PATH}/bin:${BOOST_UNIX_PATH}/lib64-msvc-14.2:$PWD/ext/dist/bin:$PWD/ext/dist/lib"
+export PATH="$PATH:$DEP_DIR/bin:$DEP_DIR/lib:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin:/bin:$PWD/ext/dist/bin:$PWD/ext/dist/lib"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DEP_DIR/bin:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DEP_DIR/lib:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/lib"
 
@@ -51,6 +45,17 @@ vcpkg list
 echo "---------------"
 # vcpkg update
 # 
+
+time vcpkg install boost-asio:x64-windows
+time vcpkg install boost-container:x64-windows
+time vcpkg install boost-filesystem:x64-windows
+time vcpkg install boost-math:x64-windows
+time vcpkg install boost-regex:x64-windows
+time vcpkg install boost-stacktrace:x64-windows
+time vcpkg install boost-system:x64-windows
+time vcpkg install boost-thread:x64-windows
+time vcpkg install boost-tokenizer:x64-windows
+
 # # vcpkg install zlib:x64-windows
 vcpkg install tiff:x64-windows
 # vcpkg install libpng:x64-windows

--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -62,7 +62,7 @@ vcpkg install tiff:x64-windows
 # vcpkg install giflib:x64-windows
 vcpkg install freetype:x64-windows
 # # vcpkg install openexr:x64-windows
-# # vcpkg install libjpeg-turbo:x64-windows
+vcpkg install libjpeg-turbo:x64-windows
 # 
 # vcpkg install libraw:x64-windows
 # vcpkg install openjpeg:x64-windows
@@ -95,11 +95,11 @@ vcpkg list
 #
 #
 
-src/build-scripts/build_zlib.bash
-export ZLIB_ROOT=$PWD/ext/dist
+# src/build-scripts/build_zlib.bash
+# export ZLIB_ROOT=$PWD/ext/dist
 
-src/build-scripts/build_libpng.bash
-export PNG_ROOT=$PWD/ext/dist
+# src/build-scripts/build_libpng.bash
+# export PNG_ROOT=$PWD/ext/dist
 
 # We're currently getting libtiff from vcpkg
 #src/build-scripts/build_libtiff.bash

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -112,7 +112,8 @@ endif ()
 # JPEG -- prefer Turbo-JPEG to regular libjpeg
 checked_find_package (JPEGTurbo
                       DEFINITIONS -DUSE_JPEG_TURBO=1
-                      PRINT       JPEG_INCLUDES JPEG_LIBRARIES)
+                      PRINT       JPEG_INCLUDES JPEG_INCLUDE_DIRS
+                                  JPEG_LIBRARIES)
 if (NOT JPEG_FOUND) # Try to find the non-turbo version
     checked_find_package (JPEG REQUIRED)
 endif ()

--- a/src/jpeg.imageio/CMakeLists.txt
+++ b/src/jpeg.imageio/CMakeLists.txt
@@ -3,5 +3,5 @@
 # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
 add_oiio_plugin (jpeginput.cpp jpegoutput.cpp
-                 INCLUDE_DIRS ${JPEG_INCLUDE_DIR}
+                 INCLUDE_DIRS ${JPEG_INCLUDE_DIRS}
                  LINK_LIBRARIES ${JPEG_LIBRARIES})


### PR DESCRIPTION
GitHub Actions in its wisdom has removed pre-installed Boost from the Windows
images, causing our CI to fail early in the cmake configure stage when finding
dependencies, doesn't even get as far as starting to compile any modules.

Instead, this change gets boost from vcpkg, just the pieces we need.

Unfortunately, although this approach finds the headers and completes the build,
several testsuite tests fail.

I need to track down the test failures, but even as it stands, this is still a step forward,
compared to having no idea at all if a PR going through CI breaks the Windows build.
