### PR TITLE
Fix function name ambiguity in farmhash.h for C++11 and certain compilers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,51 @@ jobs:
             build/*/testsuite/*/*.*
             build/*/CMake*.{txt,log}
 
+  linux-gcc10-cpp11:
+    # Test gcc10 but in C++11 mode
+    name: "Linux gcc10 / C++11 avx2"
+    runs-on: ubuntu-20.04
+    env:
+      CXX: g++-10
+      CMAKE_CXX_STANDARD: 11
+      USE_SIMD: avx2,f16c
+      PYTHON_VERSION: 3.8
+      USE_OPENVDB: 0
+      # The old installed OpenVDB has a TLS conflict with Python 3.8
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare ccache timestamp
+        id: ccache_cache_keys
+        run: |
+          echo "::set-output name=date::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
+      - name: ccache
+        id: ccache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/ccache
+          key: ${{ github.job }}-${{ steps.ccache_cache_keys.outputs.date }}
+          restore-keys: |
+            ${{ github.job }}-
+      - name: Build setup
+        run: |
+            src/build-scripts/ci-startup.bash
+      - name: Dependencies
+        run: |
+            src/build-scripts/gh-installdeps.bash
+      - name: Build
+        run: |
+            src/build-scripts/ci-build.bash
+      - name: Testsuite
+        run: |
+            src/build-scripts/ci-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: |
+            build/*/testsuite/*/*.*
+            build/*/CMake*.{txt,log}
+
   linux-latest-releases:
     # Test against latest supported releases of toolchain and dependencies.
     name: "Linux latest releases: gcc10 C++17 avx2 exr3.0 ocio2.0"

--- a/src/include/OpenImageIO/detail/farmhash.h
+++ b/src/include/OpenImageIO/detail/farmhash.h
@@ -1302,7 +1302,7 @@ STATIC_INLINE uint32_t Hash32(const char *s, size_t len) {
     b += Fetch(s + len - 20);
     c += Fetch(s + len - 16);
     uint32_t d = a;
-    a = NAMESPACE_FOR_HASH_FUNCTIONS::Rotate32(a, 21);
+    a = inlined::Rotate32(a, 21);
     a = inlined::Mur(a, inlined::Mur(b, _mm_crc32_u32(c, d)));
     a += Fetch(s + len - 12);
     b += Fetch(s + len - 8);

--- a/src/include/OpenImageIO/detail/farmhash.h
+++ b/src/include/OpenImageIO/detail/farmhash.h
@@ -1496,12 +1496,12 @@ STATIC_INLINE __m128i Xor(__m128i x, __m128i y) { return _mm_xor_si128(x, y); }
 STATIC_INLINE __m128i Or(__m128i x, __m128i y) { return _mm_or_si128(x, y); }
 STATIC_INLINE __m128i Mul(__m128i x, __m128i y) { return _mm_mullo_epi32(x, y); }
 STATIC_INLINE __m128i Mul5(__m128i x) { return Add(x, _mm_slli_epi32(x, 2)); }
-STATIC_INLINE __m128i Rotate(__m128i x, int c) {
+STATIC_INLINE __m128i Rotatesse(__m128i x, int c) {
   return Or(_mm_slli_epi32(x, c),
             _mm_srli_epi32(x, 32 - c));
 }
-STATIC_INLINE __m128i Rot17(__m128i x) { return Rotate(x, 17); }
-STATIC_INLINE __m128i Rot19(__m128i x) { return Rotate(x, 19); }
+STATIC_INLINE __m128i Rot17(__m128i x) { return Rotatesse(x, 17); }
+STATIC_INLINE __m128i Rot19(__m128i x) { return Rotatesse(x, 19); }
 STATIC_INLINE __m128i Shuffle0321(__m128i x) {
   return _mm_shuffle_epi32(x, (0 << 6) + (3 << 4) + (2 << 2) + (1 << 0));
 }
@@ -1522,7 +1522,7 @@ STATIC_INLINE uint32_t Hash32(const char *s, size_t len) {
     b += Fetch(s + len - 20);
     c += Fetch(s + len - 16);
     uint32_t d = a;
-    a = NAMESPACE_FOR_HASH_FUNCTIONS::Rotate32(a, 21);
+    a = inlined::Rotate32(a, 21);
     a = inlined::Mur(a, inlined::Mur(b, inlined::Mur(c, d)));
     a += Fetch(s + len - 12);
     b += Fetch(s + len - 8);


### PR DESCRIPTION
Apparently all the recent farmhash changes are fine with C++14 mode,
and fine with C++11 mode on gcc 4.8, but gets some errors when
used in newer compilers (gcc6+) using C++11 mode.

Add a CI test with gcc10 but with C++11 compatibility to verify this fix.
We will remove this test once we retire C++11 compatibility.

Fixes #2909