### PR TITLE
Change default C++ standard to 14

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,8 +15,14 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
 ### Required dependencies -- OIIO will not build at all without these
 
  * C++11 (also builds with C++14, C++17, and C++20)
- * Compilers: gcc 4.8.2 - 10.2, clang 3.3 - 11, MSVS 2015 - 2019,
-   icc version 13 or higher
+     * The default build mode is C++14. This can be controlled by via the
+       CMake configuration flag: `-DCMAKE_CXX_STANDARD=11`.
+     * The retirement of C++11 support is coming soon!
+ * Compilers: gcc 4.8.2 - 10.2, clang 3.3 - 11, MSVS 2015 - 2019, icc 13+.
+     * Note that for C++14 conformance, you need gcc >= 6.1, clang >= 3.4,
+       or MSVS >= 2017. If you require older versions of these compilers,
+       you must use C++11 compilation mode. Support for this will likely be
+       removed before the final release of OIIO 2.3.
  * CMake >= 3.12 (tested through 3.20)
  * OpenEXR >= 2.0 (recommended: 2.2 or higher; tested through 2.5, also
    tested against the current master that will be OpenEXR 3.0 / Imath 3.0)
@@ -43,6 +49,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you want support for OpenVDB files:
      * OpenVDB >= 5.0 (tested through 8.0) and Intel TBB >= 2018 (tested
        through 2020_U3)
+     * Note that OpenVDB 8.0+ requires C++14 or higher.
  * If you want support for converting to and from OpenCV data structures,
    or for capturing images from a camera:
      * OpenCV 2.x, 3.x, or 4.x (tested through 4.5)

--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,7 @@ help:
 	@echo "      STOP_ON_WARNING=0        Do not stop building if compiler warns"
 	@echo "      OPENIMAGEIO_SITE=xx      Use custom site build mods"
 	@echo "      MYCC=xx MYCXX=yy         Use custom compilers"
-	@echo "      CMAKE_CXX_STANDARD=14    Compile in C++14 mode (default is C++11)"
+	@echo "      CMAKE_CXX_STANDARD=14    Set the C++ standard (default is C++14)"
 	@echo "      USE_LIBCPLUSPLUS=1       For clang, use libc++"
 	@echo "      GLIBCXX_USE_CXX11_ABI=1  For gcc, use the new string ABI"
 	@echo "      EXTRA_CPP_ARGS=          Additional args to the C++ command"

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -27,7 +27,7 @@ message (STATUS "CMAKE_CXX_COMPILER_ID  = ${CMAKE_CXX_COMPILER_ID}")
 ###########################################################################
 # C++ language standard
 #
-set (CMAKE_CXX_STANDARD 11 CACHE STRING
+set (CMAKE_CXX_STANDARD 14 CACHE STRING
      "C++ standard to prefer (11, 14, 17, 20, etc.)")
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 set (CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
This does not (YET) change the minimum to C++14. For now, you can still
build for C++11 -- and with compilers that only support C++11 -- by using
CMAKE_CXX_STANDARD=11.

By changing the default, we hope to more thoroughly test everybody's
ability to compile C++14, ahead of the actual cut-off when we make that
the true miimum.

Also, the latest OpenVDB 8.0 does has C++14 as a minimum, so compiling
in C++11 mode will automatically disable OpenVDB support if OpenVDB >=
8 is what is found. We expect an increasing number of our dependencies
to drop support for C++11, so we want our default compilation mode to
be one that doesn't silently drop format support without
users/builders being aware of it.
