### PR TITLE
TIFF: support IOProxy for input

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -170,6 +170,10 @@ options are supported:
      - If nonzero, reading images with non-RGB color models (such as YCbCr)
        will return unaltered pixel values (versus the default OIIO behavior
        of automatically converting to RGB).
+   * - ``oiio:ioproxy``
+     - ptr
+     - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
+       example by reading from memory rather than the file system.
 
 
 **Configuration settings for DPX output**
@@ -190,6 +194,12 @@ control aspects of the writing itself:
        will keep unaltered pixel values (versus the default OIIO behavior
        of automatically converting from RGB to the designated color space
        as the pixels are written).
+
+**Custom I/O Overrides**
+
+DPX input (but, currently, not output) supports the "custom I/O" feature
+via the `ImageInput::set_ioproxy()` method and the special
+``"oiio:ioproxy"`` attributes (see Section :ref:`sec-imageinput-ioproxy`).
 
 **DPX Attributes**
 
@@ -756,10 +766,20 @@ control aspects of the writing itself:
      - int
      - If nonzero and outputting UINT8 values in the file, will add a small
        amount of random dither to combat the appearance of banding.
+   * - ``oiio:ioproxy``
+     - ptr
+     - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
+       example by reading from memory rather than the file system.
    * - ``jpeg:progressive``
      - int
      - If nonzero, will write a progressive JPEG file.
 
+
+**Custom I/O Overrides**
+
+JPEG input (but, currently, not output) supports the "custom I/O" feature
+via the `ImageInput::set_ioproxy()` method and the special
+``"oiio:ioproxy"`` attributes (see Section :ref:`sec-imageinput-ioproxy`).
 
 **Limitations**
 
@@ -1063,8 +1083,9 @@ control aspects of the writing itself:
 **Custom I/O Overrides**
 
 OpenEXR input and output both support the "custom I/O" feature via the
-special ``"oiio:ioproxy"`` attributes (see
-Sections :ref:`sec-imageoutput-ioproxy` and :ref:`sec-imageinput-ioproxy`).
+special ``"oiio:ioproxy"`` attributes (see Sections
+:ref:`sec-imageoutput-ioproxy` and :ref:`sec-imageinput-ioproxy`) as well as
+the `set_ioproxy()` methods.
 
 **A note on channel names**
 
@@ -1237,8 +1258,11 @@ control aspects of the writing itself:
 
 **Custom I/O Overrides**
 
-PNG output supports the "custom I/O" feature via the special
-``"oiio:ioproxy"`` attributes (see Section :ref:`sec-imageoutput-ioproxy`).
+PNG input and output both support the "custom I/O" feature via the special
+``"oiio:ioproxy"`` attributes (see Sections :ref:`sec-imageoutput-ioproxy`
+and :ref:`sec-imageinput-ioproxy`) as well as the `set_ioproxy()` methods.
+
+
 
 **Limitations**
 
@@ -1819,6 +1843,10 @@ options are supported:
      - If nonzero, reading images with non-RGB color models (such as YCbCr)
        will return unaltered pixel values (versus the default OIIO behavior
        of automatically converting to RGB).
+   * - ``oiio:ioproxy``
+     - ptr
+     - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
+       example by reading from memory rather than the file system.
 
 **Configuration settings for TIFF output**
 
@@ -1902,6 +1930,12 @@ part of the format name):
     ``T43``
     ``T85``
     ``thunderscan``
+
+**Custom I/O Overrides**
+
+TIFF input (but, currently, not output) supports the "custom I/O" feature
+via the `ImageInput::set_ioproxy()` method and the special
+``"oiio:ioproxy"`` attributes (see Section :ref:`sec-imageinput-ioproxy`).
 
 **Limitations**
 

--- a/src/libOpenImageIO/imageinout_test.cpp
+++ b/src/libOpenImageIO/imageinout_test.cpp
@@ -194,8 +194,11 @@ test_read_proxy(string_view formatname, string_view extension,
     Filesystem::IOMemReader inproxybuf(readbuf);
     ImageBuf inbuf(memname, 0, 0, nullptr, nullptr, &inproxybuf);
     bool ok2 = inbuf.read(0, 0, /*force*/ true, TypeFloat);
-    if (!ok2)
+    if (!ok2) {
         std::cout << "Read failed: " << inbuf.geterror() << "\n";
+        OIIO_CHECK_ASSERT(ok2);
+        return false;
+    }
     OIIO_ASSERT(inbuf.localpixels());
     OIIO_ASSERT(buf.localpixels());
     OIIO_CHECK_EQUAL(buf.spec().format, inbuf.spec().format);


### PR DESCRIPTION
Also beef up docs, which had neglected to mention that proxy was
supported for a few other formats.

Closes #2920 