### PR TITLE
Eliminate the last few std::cerr outputs

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2480,20 +2480,18 @@ OIIO_API std::string geterror(bool clear = true);
 ///    When the `"log_times"` attribute is nonzero, `ImageBufAlgo` functions
 ///    are instrumented to record the number of times they were called and
 ///    the total amount of time spent executing them. It can be overridden
-///    by environment variable `OPENIMAGEIO_LOG_TIMES`. If the value of
-///    `log_times` is 2 or more when the application terminates, the timing
-///    report will be printed to `stdout` upon exit.
+///    by environment variable `OPENIMAGEIO_LOG_TIMES`. The totals will be
+///    recorded and can be retrieved as a string by using
+///    `OIIO::getattribute("timing_report", ...)`. Additionally, if the
+///    value is 2 or more, the timing report will be printed to `stdout`
+///    upon application exit (not advised in contexts where it isn't ok to
+///    print to the terminal via stdout, such as GUI apps or libraries).
 ///
 ///    When enabled, there is a slight runtime performance cost due to
 ///    checking the time at the start and end of each of those function
 ///    calls, and the locking and recording of the data structure that holds
 ///    the log information. When the `log_times` attribute is disabled,
 ///    there is no additional performance cost.
-///
-///    The report of totals can be retrieved as the value of the
-///    `"timing_report"` attribute, using `OIIO:get_attribute()` call.
-///
-///
 ///
 OIIO_API bool attribute(string_view name, TypeDesc type, const void* val);
 

--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -728,7 +728,7 @@ add_exif_item_to_spec(ImageSpec& spec, const char* name,
     }
 #endif
 
-#if !defined(NDEBUG) || DEBUG_EXIF_UNHANDLED
+#if DEBUG_EXIF_UNHANDLED
     std::cerr << "add_exif_item_to_spec: didn't know how to process " << name
               << ", type " << dirp->tdir_type << " x " << dirp->tdir_count
               << "\n";

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -340,9 +340,9 @@ check_nan_block(const ImageBuf& src, ROI roi, int& found_nonfinite)
             for (int c = 0; c < spec.nchannels; ++c) {
                 if (!isfinite(pel[c])) {
                     spin_lock lock(maketx_mutex);
-                    if (found_nonfinite < 3)
-                        std::cerr << "maketx ERROR: Found " << pel[c]
-                                  << " at (x=" << x << ", y=" << y << ")\n";
+                    // if (found_nonfinite < 3)
+                    //     std::cerr << "maketx ERROR: Found " << pel[c]
+                    //               << " at (x=" << x << ", y=" << y << ")\n";
                     ++found_nonfinite;
                     break;  // skip other channels, there's no point
                 }

--- a/src/libOpenImageIO/xmp.cpp
+++ b/src/libOpenImageIO/xmp.cpp
@@ -391,7 +391,7 @@ add_attrib(ImageSpec& spec, string_view xmlname, string_view xmlvalue,
         spec.attribute(oiioname, t, vals.data());
         return;
     }
-#if (!defined(NDEBUG) || DEBUG_XMP_READ)
+#if DEBUG_XMP_READ
     else {
         std::cerr << "iptc xml add_attrib unknown type " << xmlname << ' '
                   << oiiotype.c_str() << "\n";

--- a/src/nuke/txWriter/txWriter.cpp
+++ b/src/nuke/txWriter/txWriter.cpp
@@ -1,3 +1,4 @@
+#include <sstream>
 #include <vector>
 
 #include "DDImage/Row.h"
@@ -331,10 +332,11 @@ public:
         OIIO::attribute("threads", (int)Thread::numCPUs);
 
         iop->progressMessage("Writing %s", filename());
+        std::stringstream errmsg;
         if (!ImageBufAlgo::make_texture(oiiotxMode[txMode_], srcBuffer,
-                                        filename(), destSpec, &std::cout))
-            iop->error("ImageBufAlgo::make_texture failed to write file %s",
-                       filename());
+                                        filename(), destSpec, &errmsg))
+            iop->error("ImageBufAlgo::make_texture failed to write file %s (%s)",
+                       filename(), errmsg.str());
     }
 
     const char* help() { return "Tiled, mipmapped texture format"; }


### PR DESCRIPTION
In many cases, this informative debugging code was left over from when
parts of this code was strictly a command line utility. It's not
appropriate for a library call, especially on Windows.

Make sure every last output to std::cerr is guarded by some
preprocessor symbol that would only be enabled when one of the
developers is trying to do some "printf debugging".

Closes #2922 
