### PR TITLE
fix c++11 build

### DIFF
--- a/src/include/OpenImageIO/hash.h
+++ b/src/include/OpenImageIO/hash.h
@@ -331,7 +331,7 @@ OIIO_HOSTDEVICE inline constexpr uint64_t Uint128High64(const uint128_t x) {
     return x.second;
 }
 
-OIIO_HOSTDEVICE inline constexpr uint128_t Uint128(uint64_t lo, uint64_t hi) {
+OIIO_HOSTDEVICE inline OIIO_CONSTEXPR14 uint128_t Uint128(uint64_t lo, uint64_t hi) {
     return uint128_t(lo, hi);
 }
 


### PR DESCRIPTION
## Description

C++11 build of OIIO failed with:
```
[  1%] Building CXX object src/libutil/CMakeFiles/OpenImageIO_Util.dir/argparse.cpp.o
In file included from /Users/devernay/Development/oiio-2.2.13.0/src/libutil/argparse.cpp:16:
In file included from /Users/devernay/Development/oiio-2.2.13.0/src/include/OpenImageIO/argparse.h:20:
In file included from /Users/devernay/Development/oiio-2.2.13.0/src/include/OpenImageIO/paramlist.h:17:
In file included from /Users/devernay/Development/oiio-2.2.13.0/src/include/OpenImageIO/attrdelegate.h:13:
In file included from /Users/devernay/Development/oiio-2.2.13.0/src/include/OpenImageIO/typedesc.h:29:
In file included from /Users/devernay/Development/oiio-2.2.13.0/src/include/OpenImageIO/strutil.h:24:
/Users/devernay/Development/oiio-2.2.13.0/src/include/OpenImageIO/hash.h:334:44: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
OIIO_HOSTDEVICE inline constexpr uint128_t Uint128(uint64_t lo, uint64_t hi) {
                                           ^
/Users/devernay/Development/oiio-2.2.13.0/src/include/OpenImageIO/hash.h:335:12: note: non-constexpr constructor 'pair<unsigned long long &, unsigned long long &, false>' cannot be used in a constant expression
    return uint128_t(lo, hi);
           ^
/usr/local/opt/llvm/bin/../include/c++/v1/utility:444:5: note: declared here
    pair(_U1&& __u1, _U2&& __u2)
    ^
1 error generated.
```

## Tests

Steps to reproduce the behavior:
1. Build and install a C++11 OpenEXR (OpenEXR 2.5 is C++14 by default and must be compiled with `-DOPENEXR_CXX_STANDARD=11`) - if OpenEXR is C++14, then OIIO will also compile in C++14 mode, whatever the `CMAKE_CXX_STANDARD` value is. Maybe OIIO should check for this and trigger an error if `OPENEXR_CXX_STANDARD` > `CMAKE_CXX_STANDARD`?
2. Configure a C++11 oiio
3. Compile with make VERBOSE=1, and check that the c++11 standard is used (`-std=c++11`)


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [X] I have updated the documentation, if applicable.
- [X] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project.

