### PR TITLE
CMake: don't use --config inappropriately

### DIFF
--- a/src/build-scripts/build_libjpeg-turbo.bash
+++ b/src/build-scripts/build_libjpeg-turbo.bash
@@ -38,8 +38,7 @@ git checkout ${LIBJPEGTURBO_VERSION} --force
 
 mkdir -p ${LIBJPEGTURBO_BUILD_DIR}
 cd ${LIBJPEGTURBO_BUILD_DIR}
-time cmake --config Release \
-           -DCMAKE_BUILD_TYPE=Release \
+time cmake -DCMAKE_BUILD_TYPE=Release \
            -DCMAKE_INSTALL_PREFIX=${LIBJPEGTURBO_INSTALL_DIR} \
            ${LIBJPEGTURBO_CONFIG_OPTS} ..
 time cmake --build . --config Release --target install

--- a/src/build-scripts/build_libpng.bash
+++ b/src/build-scripts/build_libpng.bash
@@ -38,8 +38,7 @@ git checkout ${LIBPNG_VERSION} --force
 
 mkdir -p ${LIBPNG_BUILD_DIR}
 cd ${LIBPNG_BUILD_DIR}
-time cmake --config Release \
-           -DCMAKE_BUILD_TYPE=Release \
+time cmake -DCMAKE_BUILD_TYPE=Release \
            -DCMAKE_INSTALL_PREFIX=${LIBPNG_INSTALL_DIR} \
            -DPNG_EXECUTABLES=OFF \
            -DPNG_TESTS=OFF \

--- a/src/build-scripts/build_libtiff.bash
+++ b/src/build-scripts/build_libtiff.bash
@@ -32,8 +32,7 @@ echo "git checkout ${LIBTIFF_VERSION} --force"
 git checkout ${LIBTIFF_VERSION} --force
 mkdir -p build
 cd build
-time cmake --config Release \
-           -DCMAKE_BUILD_TYPE=Release \
+time cmake -DCMAKE_BUILD_TYPE=Release \
            -DCMAKE_INSTALL_PREFIX=${LIBTIFF_INSTALL_DIR} \
            -DCMAKE_CXX_FLAGS="${LIBTIFF_CXX_FLAGS}" \
            ${LIBTIFF_BUILDOPTS} ..

--- a/src/build-scripts/build_opencolorio.bash
+++ b/src/build-scripts/build_opencolorio.bash
@@ -40,7 +40,10 @@ echo "git checkout ${OPENCOLORIO_VERSION} --force"
 git checkout ${OPENCOLORIO_VERSION} --force
 mkdir -p build
 cd build
-time cmake --config Release -DCMAKE_INSTALL_PREFIX=${OPENCOLORIO_INSTALL_DIR} -DCMAKE_CXX_FLAGS="${OPENCOLORIO_CXX_FLAGS}" ${OPENCOLORIO_BUILDOPTS} ..
+time cmake -DCMAKE_BUILD_TYPE=Release \
+           -DCMAKE_INSTALL_PREFIX=${OPENCOLORIO_INSTALL_DIR} \
+           -DCMAKE_CXX_FLAGS="${OPENCOLORIO_CXX_FLAGS}" \
+           ${OPENCOLORIO_BUILDOPTS} ..
 time cmake --build . --config Release --target install
 popd
 

--- a/src/build-scripts/build_openexr.bash
+++ b/src/build-scripts/build_openexr.bash
@@ -48,14 +48,14 @@ if [[ ${OPENEXR_VERSION} == "v2.2.0" ]] || [[ ${OPENEXR_VERSION} == "v2.2.1" ]] 
     mkdir -p ${OPENEXR_BUILD_DIR}/IlmBase && true
     mkdir -p ${OPENEXR_BUILD_DIR}/OpenEXR && true
     cd ${OPENEXR_BUILD_DIR}/IlmBase
-    cmake --config ${OPENEXR_BUILD_TYPE} ${OPENEXR_GENERATOR_CMD} \
+    cmake -DCMAKE_BUILD_TYPE=${OPENEXR_BUILD_TYPE} ${OPENEXR_GENERATOR_CMD} \
             -DCMAKE_INSTALL_PREFIX="${OPENEXR_INSTALL_DIR}" \
             -DCMAKE_CXX_FLAGS="${OPENEXR_CXX_FLAGS}" \
             -DCMAKE_CXX_STANDARD=11 \
             ${OPENEXR_CMAKE_FLAGS} ${OPENEXR_SOURCE_DIR}/IlmBase
     time cmake --build . --target install --config ${OPENEXR_BUILD_TYPE}
     cd ${OPENEXR_BUILD_DIR}/OpenEXR
-    cmake --config ${OPENEXR_BUILD_TYPE} ${OPENEXR_GENERATOR_CMD} \
+    cmake -DCMAKE_BUILD_TYPE=${OPENEXR_BUILD_TYPE} ${OPENEXR_GENERATOR_CMD} \
             -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}\;${OPENEXR_INSTALL_DIR}" \
             -DCMAKE_INSTALL_PREFIX="${OPENEXR_INSTALL_DIR}" \
             -DILMBASE_PACKAGE_PREFIX="${OPENEXR_INSTALL_DIR}" \
@@ -66,7 +66,7 @@ if [[ ${OPENEXR_VERSION} == "v2.2.0" ]] || [[ ${OPENEXR_VERSION} == "v2.2.1" ]] 
 elif [[ ${OPENEXR_VERSION} == "v2.3.0" ]] ; then
     # Simplified setup for 2.3+
     cd ${OPENEXR_BUILD_DIR}
-    cmake --config ${OPENEXR_BUILD_TYPE} -G "$CMAKE_GENERATOR" \
+    cmake -DCMAKE_BUILD_TYPE=${OPENEXR_BUILD_TYPE} -G "$CMAKE_GENERATOR" \
             -DCMAKE_INSTALL_PREFIX="${OPENEXR_INSTALL_DIR}" \
             -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" \
             -DILMBASE_PACKAGE_PREFIX="${OPENEXR_INSTALL_DIR}" \
@@ -79,7 +79,7 @@ elif [[ ${OPENEXR_VERSION} == "v2.3.0" ]] ; then
 else
     # Simplified setup for 2.4+
     cd ${OPENEXR_BUILD_DIR}
-    cmake --config ${OPENEXR_BUILD_TYPE} -G "$CMAKE_GENERATOR" \
+    cmake -DCMAKE_BUILD_TYPE=${OPENEXR_BUILD_TYPE} -G "$CMAKE_GENERATOR" \
             -DCMAKE_INSTALL_PREFIX="${OPENEXR_INSTALL_DIR}" \
             -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" \
             -DILMBASE_PACKAGE_PREFIX="${OPENEXR_INSTALL_DIR}" \

--- a/src/build-scripts/build_pugixml.bash
+++ b/src/build-scripts/build_pugixml.bash
@@ -39,8 +39,7 @@ git checkout ${PUGIXML_VERSION} --force
 
 mkdir -p ${PUGIXML_BUILD_DIR}
 cd ${PUGIXML_BUILD_DIR}
-time cmake --config Release \
-           -DCMAKE_BUILD_TYPE=Release \
+time cmake -DCMAKE_BUILD_TYPE=Release \
            -DCMAKE_INSTALL_PREFIX=${PUGIXML_INSTALL_DIR} \
            -DBUILD_SHARED_LIBS=ON \
            -DBUILD_TESTS=OFF \

--- a/src/build-scripts/build_pybind11.bash
+++ b/src/build-scripts/build_pybind11.bash
@@ -39,7 +39,7 @@ git checkout ${PYBIND11_VERSION} --force
 
 mkdir -p ${PYBIND11_BUILD_DIR}
 cd ${PYBIND11_BUILD_DIR}
-time cmake --config Release \
+time cmake -DCMAKE_BUILD_TYPE=Release \
            -DCMAKE_INSTALL_PREFIX=${PYBIND11_INSTALL_DIR} \
            -DPYBIND11_TEST=OFF \
            ${PYBIND11_BUILD_OPTS} ..

--- a/src/build-scripts/build_webp.bash
+++ b/src/build-scripts/build_webp.bash
@@ -37,8 +37,7 @@ git checkout ${WEBP_VERSION} --force
 
 mkdir -p ${WEBP_BUILD_DIR}
 cd ${WEBP_BUILD_DIR}
-time cmake --config Release \
-           -DCMAKE_BUILD_TYPE=Release \
+time cmake -DCMAKE_BUILD_TYPE=Release \
            -DCMAKE_INSTALL_PREFIX=${WEBP_INSTALL_DIR} \
            -DWEBP_BUILD_ANIM_UTILS=OFF \
            -DWEBP_BUILD_CWEBP=OFF \

--- a/src/build-scripts/build_zlib.bash
+++ b/src/build-scripts/build_zlib.bash
@@ -38,8 +38,7 @@ git checkout ${ZLIB_VERSION} --force
 
 mkdir -p ${ZLIB_BUILD_DIR} && true
 cd ${ZLIB_BUILD_DIR}
-time cmake --config Release \
-           -DCMAKE_BUILD_TYPE=Release \
+time cmake -DCMAKE_BUILD_TYPE=Release \
            -DCMAKE_INSTALL_PREFIX=${ZLIB_INSTALL_DIR} \
            ${ZLIB_CONFIG_OPTS} ..
 time cmake --build . --config Release --target install

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -71,6 +71,7 @@ else
 
 fi
 
+cmake --version
 
 
 #


### PR DESCRIPTION
It seems that for CMake, --config should only be used in conjunction
with --build. Who knew? Things are breaking right and left now, especially
on GitHub Actions CI. But also on my laptop.

Hypothesis: maybe this was silently ignored in older cmake versions, but
now with CMake 3.20 is a hard error? Yeah, it seems that the GHA machines
now have cmake 3.20 installed, and they did not until a few days ago.

