### PR TITLE
oiiotool: allow expression substitution to include getattribute(name)

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -254,6 +254,13 @@ contents of an expression may be any of:
   * `FRAME_NUMBER_PAD` : like `FRAME_NUMBER`, but 0-padded based
     on the value set on the command line by `--framepadding`.
 
+* Functions
+
+  * `getattribute(name)` : returns the global attribute that would be
+    retrieved by `OIIO::getattribute(name, ...)`. The `name` may be enclosed
+    in single or double quotes or be a single unquoted sequence of characters.
+    (Added in OIIO 2.3.)
+
 
 To illustrate how this works, consider the following command, which trims
 a four-pixel border from all sides and outputs a new image prefixed with

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1164,6 +1164,32 @@ Oiiotool::express_parse_atom(const string_view expr, string_view& s,
             return false;
         }
 
+    } else if (Strutil::parse_identifier_if(s, "getattribute")
+               && Strutil::parse_char(s, '(')) {
+        // "{getattribute(name)}" retrieves global attribute `name`
+        bool ok = true;
+        Strutil::skip_whitespace(s);
+        string_view name;
+        if (s.size() && (s.front() == '\"' || s.front() == '\''))
+            ok = Strutil::parse_string(s, name);
+        else {
+            name = Strutil::parse_until(s, ")");
+        }
+        if (name.size()) {
+            std::string rs;
+            int ri;
+            float rf;
+            if (OIIO::getattribute(name, rs))
+                result = rs;
+            else if (OIIO::getattribute(name, ri))
+                result = Strutil::to_string(ri);
+            else if (OIIO::getattribute(name, rf))
+                result = Strutil::to_string(rf);
+            else
+                ok = false;
+        }
+        return Strutil::parse_char(s, ')') && ok;
+
     } else if (Strutil::starts_with(s, "TOP")
                || Strutil::starts_with(s, "IMG[")) {
         // metadata substitution


### PR DESCRIPTION
This teaches oiiotool's command line expression substitution (`{...}`)
syntax to understand that

    getattribute(name)

should be replaced by the value that OIIO::getattribute(name,...) would
retrieve. The `name` may optionally be single or double quoted, but doesn't
have to be if it's a simple identifier.

Some examples:

    # Which SIMD features does this OIIO use?
    oiiotool --echo "{getattribute('oiio:simd')}"

    # Which dependencies are used for each format?
    oiiotool --echo "{getattribute(library_list)}"

    # Which file extensions are associated with each format?
    oiiotool --echo "{getattribute(extension_list)}"
