### PR TITLE
Build: be robust to certain OpenEXR 2.x config files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
 
   vfxplatform-2021-exr3:
     # Test what's anticipated to be VFX Platform 2021 -- mainly, that means
-    # gcc9 and C++17, and also the in-progress openexr/imath 3.0.
+    # gcc9 and C++17, and also OpenEXR/Imath 3.0.
     name: "Linux VFX Platform 2021: gcc9/C++17 py3.7 boost-1.73 exr-3.0 qt-5.15"
     runs-on: ubuntu-latest
     container:
@@ -218,7 +218,7 @@ jobs:
       CMAKE_CXX_STANDARD: 17
       PYTHON_VERSION: 3.7
       USE_SIMD: avx2,f16c
-      OPENEXR_VERSION: RB-3.0
+      OPENEXR_VERSION: v3.0.1
     steps:
       - uses: actions/checkout@v2
       - name: Prepare ccache timestamp
@@ -263,7 +263,7 @@ jobs:
       CXX: g++-7
       CMAKE_CXX_STANDARD: 14
       USE_SIMD: sse4.2
-      OPENEXR_VERSION: v2.4.0
+      OPENEXR_VERSION: v2.4.2
       CMAKE_BUILD_TYPE: Debug
     steps:
       - uses: actions/checkout@v2
@@ -307,7 +307,7 @@ jobs:
       CXX: g++-8
       CMAKE_CXX_STANDARD: 17
       USE_SIMD: avx
-      OPENEXR_VERSION: v2.5.3
+      OPENEXR_VERSION: v2.5.5
       PYBIND11_VERSION: v2.5.0
     steps:
       - uses: actions/checkout@v2
@@ -399,7 +399,7 @@ jobs:
       LIBRAW_VERSION: 0.20.2
       LIBTIFF_VERSION: v4.2.0
       OPENCOLORIO_VERSION: v2.0.0
-      OPENEXR_VERSION: v3.0.0-beta
+      OPENEXR_VERSION: v3.0.1
       PUGIXML_VERSION: v1.11.4
       PYBIND11_VERSION: v2.6.2
       PYTHON_VERSION: 3.8
@@ -717,7 +717,7 @@ jobs:
 
   linux-clang:
     # Test compiling with clang on Linux.
-    name: "Linux clang10: clang10 C++14 avx2 exr2.4"
+    name: "Linux clang10: clang10 C++14 avx2 exr2.5"
     runs-on: ubuntu-18.04
     container:
       image: aswf/ci-osl:2021
@@ -765,7 +765,7 @@ jobs:
 
   linux-static:
     # Test building static libs.
-    name: "Linux static libs: gcc7 C++14 exr2.4"
+    name: "Linux static libs: gcc7 C++14 exr2.2"
     runs-on: ubuntu-18.04
     env:
       CXX: g++-7

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -93,13 +93,13 @@ checked_find_package (OpenEXR REQUIRED
                       VERSION_MIN 2.0
                       RECOMMEND_MIN 2.2
                       RECOMMEND_MIN_REASON "for DWA compression"
-                      PRINT IMATH_INCLUDES)
+                      PRINT IMATH_INCLUDES OPENEXR_INCLUDES)
 # Force Imath includes to be before everything else to ensure that we have
 # the right Imath/OpenEXR version, not some older version in the system
 # library. This shoudn't be necessary, except for the common case of people
 # building against Imath/OpenEXR 3.x when there is still a system-level
 # install version of 2.x.
-include_directories(BEFORE ${IMATH_INCLUDES})
+include_directories(BEFORE ${IMATH_INCLUDES} ${OPENEXR_INCLUDES})
 if (CMAKE_COMPILER_IS_CLANG AND OPENEXR_VERSION VERSION_LESS 2.3)
     # clang C++ >= 11 doesn't like 'register' keyword in old exr headers
     add_compile_options (-Wno-deprecated-register)

--- a/src/cmake/modules/FindOpenEXR.cmake
+++ b/src/cmake/modules/FindOpenEXR.cmake
@@ -70,7 +70,8 @@ if (TARGET OpenEXR::OpenEXR AND TARGET Imath::Imath)
         list (APPEND ILMBASE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
     endif ()
 
-elseif (TARGET OpenEXR::IlmImf AND TARGET IlmBase::Imath AND OPENEXR_VERSION VERSION_GREATER_EQUAL 2.4)
+elseif (TARGET OpenEXR::IlmImf AND TARGET IlmBase::Imath AND
+        (OPENEXR_VERSION VERSION_GREATER_EQUAL 2.4 OR OpenEXR_VERSION VERSION_GREATER_EQUAL 2.4))
     # OpenEXR 2.4 or 2.5 with exported config
     if (NOT OpenEXR_FIND_QUIETLY)
         message (STATUS "Found CONFIG for OpenEXR 2 (OPENEXR_VERSION=${OpenEXR_VERSION})")
@@ -97,6 +98,12 @@ elseif (TARGET OpenEXR::IlmImf AND TARGET IlmBase::Imath AND OPENEXR_VERSION VER
     if (CMAKE_USE_PTHREADS_INIT)
         list (APPEND ILMBASE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
     endif ()
+
+    # Correct for how old OpenEXR config exports set the directory one
+    # level lower than we prefer it.
+    string(REGEX REPLACE "include/OpenEXR$" "include" ILMBASE_INCLUDES "${ILMBASE_INCLUDES}")
+    string(REGEX REPLACE "include/OpenEXR$" "include" IMATH_INCLUDES "${IMATH_INCLUDES}")
+    string(REGEX REPLACE "include/OpenEXR$" "include" OPENEXR_INCLUDES "${OPENEXR_INCLUDES}")
 
 else ()
     # OpenEXR 2.x older versions without a config or whose configs we don't


### PR DESCRIPTION
Ever since adding OpenEXR 3.0 support, we had some cases where
installations that built the 2.x IlmBase and OpenEXR portions
separately and installing to separate areas, were not being found
correctly.

Also make some minor changes to ci.yml to make sure we are documenting
the right openexr versions used for each test.

Fixes #2928 
