### PR TITLE
Adjust openexr includes

### DIFF
--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -122,7 +122,7 @@ source_group ("libtexture" REGULAR_EXPRESSION ".+/libtexture/.+")
 target_include_directories (OpenImageIO
                             PUBLIC
                                 ${CMAKE_INSTALL_FULL_INCLUDEDIR}
-                                ${IMATH_INCLUDES}
+                                ${IMATH_INCLUDES} ${OPENEXR_INCLUDES}
                                 ${OpenCV_INCLUDES}
                             PRIVATE
                                 ${ROBINMAP_INCLUDES}
@@ -140,7 +140,9 @@ target_link_libraries (OpenImageIO
             $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
             $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
             # For OpenEXR >= 2.4/2.5 with reliable exported targets
+            $<$<TARGET_EXISTS:OpenEXR::IlmImfConfig>:OpenEXR::IlmImfConfig>
             $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
+            $<$<TARGET_EXISTS:IlmBase::IlmBaseConfig>:IlmBase::IlmBaseConfig>
             $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
             $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
             $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library (OpenImageIO_Util ${libOpenImageIO_Util_srcs})
 target_include_directories (OpenImageIO_Util
         PUBLIC
             ${CMAKE_INSTALL_FULL_INCLUDEDIR}
-            ${IMATH_INCLUDES}
+            ${IMATH_INCLUDES} ${OPENEXR_INCLUDES}
         )
 target_link_libraries (OpenImageIO_Util
         PUBLIC
@@ -17,6 +17,8 @@ target_link_libraries (OpenImageIO_Util
             $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
             $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
             # For OpenEXR >= 2.4/2.5 with reliable exported targets
+            $<$<TARGET_EXISTS:OpenEXR::IlmImfConfig>:OpenEXR::IlmImfConfig>
+            $<$<TARGET_EXISTS:IlmBase::IlmBaseConfig>:IlmBase::IlmBaseConfig>
             $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
             $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
             $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>


### PR DESCRIPTION
We broke things subtly for older OpenEXR when we added the 3.x
support.  Without this fix, our export CMake config files weren't
properly exporting the OpenEXR include path as the interface includes
for OIIO libraries. This doesn't affect the OIIO build itself, but it
can affect downstream libraries that use OIIO as a dependency and
rely on our exported cmake config files.

You might think that we wouldn't need this since we don't use any
OpenEXR classes in our APIs (though we do use Imath ones). Well, turns
out that our Imath.h file includes OpenEXR/OpenEXRConfigh in order to
find out which version it's using, so it can include the Imath headers
from the right place (which differs for Imath/OpenEXR 3.x versus 2.x).
In other words, we do leak an interface need for OpenEXR headers, even
though we don't use any interface need for OpenEXR classes.
