### PR TITLE
Adjust openexr includes

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -108,6 +108,12 @@ if (MSVC AND NOT LINKSTATIC)
     add_definitions (-DOPENEXR_DLL) # Is this needed for new versions?
 endif ()
 
+if (OPENEXR_VERSION VERSION_GREATER_EQUAL 2.5.99)
+    set (OIIO_USING_IMATH 3)
+else ()
+    set (OIIO_USING_IMATH 2)
+endif ()
+
 
 # JPEG -- prefer Turbo-JPEG to regular libjpeg
 checked_find_package (JPEGTurbo

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -39,6 +39,13 @@ endif ()
 configure_file (${PROJECT_NAME}/${versionfile}.in "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${versionfile}" @ONLY)
 list (APPEND public_headers "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${versionfile}")
 
+# Generate Imath.h
+if (VERBOSE)
+    message(STATUS "Create Imath.h from Imath.h.in")
+endif ()
+configure_file (${PROJECT_NAME}/Imath.h.in "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/Imath.h" @ONLY)
+list (APPEND public_headers "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/Imath.h")
+
 
 install (FILES ${public_headers}
          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}

--- a/src/include/OpenImageIO/Imath.h.in
+++ b/src/include/OpenImageIO/Imath.h.in
@@ -10,19 +10,14 @@
 // Determine which Imath we're dealing with and include the appropriate
 // headers.
 
-#include <OpenEXR/OpenEXRConfig.h>
-#define OIIO_OPENEXR_VERSION ((10000*OPENEXR_VERSION_MAJOR) + \
-                              (100*OPENEXR_VERSION_MINOR) + \
-                              OPENEXR_VERSION_PATCH)
+#define OIIO_USING_IMATH @OIIO_USING_IMATH@
 
-#if OIIO_OPENEXR_VERSION >= 20599 /* 2.5.99: pre-3.0 */
-#   define OIIO_USING_IMATH 3
+#if OIIO_USING_IMATH >= 3
 #   include <Imath/ImathColor.h>
 #   include <Imath/ImathMatrix.h>
 #   include <Imath/ImathVec.h>
 #   include <Imath/half.h>
 #else
-#   define OIIO_USING_IMATH 2
 #   include <OpenEXR/ImathColor.h>
 #   include <OpenEXR/ImathMatrix.h>
 #   include <OpenEXR/ImathVec.h>

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -122,7 +122,7 @@ source_group ("libtexture" REGULAR_EXPRESSION ".+/libtexture/.+")
 target_include_directories (OpenImageIO
                             PUBLIC
                                 ${CMAKE_INSTALL_FULL_INCLUDEDIR}
-                                ${IMATH_INCLUDES}
+                                ${IMATH_INCLUDES} ${OPENEXR_INCLUDES}
                                 ${OpenCV_INCLUDES}
                             PRIVATE
                                 ${ROBINMAP_INCLUDES}

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library (OpenImageIO_Util ${libOpenImageIO_Util_srcs})
 target_include_directories (OpenImageIO_Util
         PUBLIC
             ${CMAKE_INSTALL_FULL_INCLUDEDIR}
-            ${IMATH_INCLUDES}
+            ${IMATH_INCLUDES} ${OPENEXR_INCLUDES}
         )
 target_link_libraries (OpenImageIO_Util
         PUBLIC


### PR DESCRIPTION
We broke things subtly for older OpenEXR when we added the 3.x
support.  Without this fix, our exported CMake config files weren't
properly exporting the OpenEXR include path as the interface includes
for OIIO libraries. This doesn't affect the OIIO build itself, but it
can affect downstream libraries that use OIIO as a dependency and
rely on our exported cmake config files.

We also remove the need for OpenEXR/OpenEXRConfig.h entirely through
header configuration.
