### PR TITLE
use dst.create rather than constructor w/move

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -310,8 +310,8 @@ ImageBufAlgo::to_OpenCV(cv::Mat& dst, const ImageBuf& src, ROI roi,
         OIIO_DASSERT(0 && "Unknown data format in ImageBuf.");
         return false;
     }
-    cv::Mat mat(roi.height(), roi.width(), dstFormat);
-    if (mat.empty()) {
+    dst.create(roi.height(), roi.width(), dstFormat);
+    if (dst.empty()) {
         OIIO_DASSERT(0 && "Unable to create cv::Mat.");
         return false;
     }
@@ -321,7 +321,7 @@ ImageBufAlgo::to_OpenCV(cv::Mat& dst, const ImageBuf& src, ROI roi,
     bool converted   = parallel_convert_image(
         chans, roi.width(), roi.height(), 1,
         src.pixeladdr(roi.xbegin, roi.ybegin, roi.zbegin, roi.chbegin),
-        spec.format, spec.pixel_bytes(), spec.scanline_bytes(), 0, mat.ptr(),
+        spec.format, spec.pixel_bytes(), spec.scanline_bytes(), 0, dst.ptr(),
         dstSpecFormat, pixelsize, linestep, 0, -1, -1, nthreads);
 
     if (!converted) {
@@ -331,12 +331,11 @@ ImageBufAlgo::to_OpenCV(cv::Mat& dst, const ImageBuf& src, ROI roi,
 
     // OpenCV uses BGR ordering
     if (chans == 3) {
-        cv::cvtColor(mat, mat, cv::COLOR_RGB2BGR);
+        cv::cvtColor(dst, dst, cv::COLOR_RGB2BGR);
     } else if (chans == 4) {
-        cv::cvtColor(mat, mat, cv::COLOR_RGBA2BGRA);
+        cv::cvtColor(dst, dst, cv::COLOR_RGBA2BGRA);
     }
 
-    dst = std::move(mat);
     return true;
 #else
     return false;


### PR DESCRIPTION
## Description

Avoid unnecessary allocation in to_OpenCV 
## Tests

No, I did not add documentation or a test. 

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).

This is a minor change that does not warrant a CLA.

- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.


The [cv::Mat::create](https://docs.opencv.org/master/d3/d63/classcv_1_1Mat.html#a55ced2c8d844d683ea9a725c60037ad0) method does the same thing as the constructor but "Allocates new array data if needed." And when not needed, which is my use case when all the images I process are the same size, ``create`` does nothing. This is more efficient than the implementation where a new mat is constructed and then moved to the destination. This is a minor optimization, but it does avoid allocating an image size block of pixels when it is not necessary.

Thanks for your time and consideration!
