### PR TITLE
Bump C++ minimum to 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,50 +20,6 @@ on:
 
 
 jobs:
-  linux-gcc48:
-    name: "Linux 2017-ish: gcc4.8/C++11 py2.7 boost-1.66 exr-2.3"
-    runs-on: ubuntu-latest
-    container:
-      image: aswf/ci-osl:2019
-    env:
-      CXX: /usr/bin/g++
-      CC: /usr/bin/gcc
-      CMAKE_CXX_STANDARD: 11
-      MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=6.2.1
-    steps:
-      - uses: actions/checkout@v2
-      - name: Prepare ccache timestamp
-        id: ccache_cache_keys
-        run: |
-          echo "::set-output name=date::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
-      - name: ccache
-        id: ccache
-        uses: actions/cache@v2
-        with:
-          path: /tmp/ccache
-          key: ${{ github.job }}-${{ steps.ccache_cache_keys.outputs.date }}
-          restore-keys: |
-            ${{ github.job }}-
-      - name: Build setup
-        run: |
-            src/build-scripts/ci-startup.bash
-      - name: Dependencies
-        run: |
-            src/build-scripts/gh-installdeps.bash
-      - name: Build
-        run: |
-            src/build-scripts/ci-build.bash
-      - name: Testsuite
-        run: |
-            src/build-scripts/ci-test.bash
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: ${{ github.job }}
-          path: |
-            build/*/testsuite/*/*.*
-            build/*/CMake*.{txt,log}
-
   vfxplatform-2019:
     name: "Linux VFX Platform 2019: gcc6/C++14 py2.7 boost-1.66 exr-2.3"
     runs-on: ubuntu-latest
@@ -343,51 +299,6 @@ jobs:
             build/*/testsuite/*/*.*
             build/*/CMake*.{txt,log}
 
-  linux-gcc10-cpp11:
-    # Test gcc10 but in C++11 mode
-    name: "Linux gcc10 / C++11 avx2"
-    runs-on: ubuntu-20.04
-    env:
-      CXX: g++-10
-      CMAKE_CXX_STANDARD: 11
-      USE_SIMD: avx2,f16c
-      PYTHON_VERSION: 3.8
-      USE_OPENVDB: 0
-      # The old installed OpenVDB has a TLS conflict with Python 3.8
-    steps:
-      - uses: actions/checkout@v2
-      - name: Prepare ccache timestamp
-        id: ccache_cache_keys
-        run: |
-          echo "::set-output name=date::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
-      - name: ccache
-        id: ccache
-        uses: actions/cache@v2
-        with:
-          path: /tmp/ccache
-          key: ${{ github.job }}-${{ steps.ccache_cache_keys.outputs.date }}
-          restore-keys: |
-            ${{ github.job }}-
-      - name: Build setup
-        run: |
-            src/build-scripts/ci-startup.bash
-      - name: Dependencies
-        run: |
-            src/build-scripts/gh-installdeps.bash
-      - name: Build
-        run: |
-            src/build-scripts/ci-build.bash
-      - name: Testsuite
-        run: |
-            src/build-scripts/ci-test.bash
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: ${{ github.job }}
-          path: |
-            build/*/testsuite/*/*.*
-            build/*/CMake*.{txt,log}
-
   linux-latest-releases:
     # Test against latest supported releases of toolchain and dependencies.
     name: "Linux latest releases: gcc10 C++17 avx2 exr3.0 ocio2.0"
@@ -500,14 +411,12 @@ jobs:
   linux-oldest:
     # Oldest versions of the dependencies that we can muster, and various
     # things disabled (no SSE, OCIO, or OpenCV, don't embed plugins).
-    name: "Linux oldest/hobbled: gcc4.8/C++11 py2.7 boost-1.66 exr-2.2 no-sse no-ocio"
+    name: "Linux oldest/hobbled: gcc6.3/C++14 py2.7 boost-1.66 exr-2.2 no-sse no-ocio"
     runs-on: ubuntu-latest
     container:
       image: aswf/ci-osl:2019
     env:
-      CXX: /usr/bin/g++
-      CC: /usr/bin/gcc
-      CMAKE_CXX_STANDARD: 11
+      CMAKE_CXX_STANDARD: 14
       USE_SIMD: 0
       USE_JPEGTURBO: 0
       USE_OPENCOLORIO: 0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,9 @@
 Release 2.3 (??) -- compared to 2.2
 ----------------------------------------------
 New minimum dependencies and compatibility changes:
-* C++ standard: C++20 is now supported. #2891 (2.3.3) The default C++
-  standard mode, if none is explicitly specified, is now C++14. #2918 (2.3.4)
+* C++ standard: **C++14 is now the minimum (gcc 6.1 - 10.2, clang 3.4 - 12,
+  MSVS 2017 - 2019, icc 17+).** #2955 (2.3.5) The default C++ standard mode,
+  if none is explicitly specified, is now C++14. #2918 (2.3.4)
 
 New major features and public API changes:
 * C API:  #2748 (2.3.1.0)
@@ -297,6 +298,7 @@ Build/test system improvements and platform ports:
     - Use modern style cmake targets for PNG and ZLIB dependencies. #2957
       (2.3.4)
 * Dependency version support:
+    - C++20 is now supported. #2891 (2.3.3)
     - Fix deprecation warnings when building with very new PugiXML versions.
       #2733 (2.3.0.1/2.2.8)
     - Fixes to build against OpenColorIO 2.0. #2765 (2.3.0.1/2.2.8) #2817

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,17 +14,12 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
 
 ### Required dependencies -- OIIO will not build at all without these
 
- * C++11 (also builds with C++14, C++17, and C++20)
+ * **C++14** (also builds with C++17, and C++20)
      * The default build mode is C++14. This can be controlled by via the
-       CMake configuration flag: `-DCMAKE_CXX_STANDARD=11`.
-     * The retirement of C++11 support is coming soon!
- * Compilers: gcc 4.8.2 - 10.2, clang 3.3 - 11, MSVS 2015 - 2019, icc 13+.
-     * Note that for C++14 conformance, you need gcc >= 6.1, clang >= 3.4,
-       or MSVS >= 2017. If you require older versions of these compilers,
-       you must use C++11 compilation mode. Support for this will likely be
-       removed before the final release of OIIO 2.3.
+       CMake configuration flag: `-DCMAKE_CXX_STANDARD=17`, etc.
+ * Compilers: **gcc 6.1 - 10.2**, **clang 3.4 - 12**, **MSVS 2017 - 2019**, **icc 17+**.
  * CMake >= 3.12 (tested through 3.20)
- * OpenEXR >= 2.0 (recommended: 2.2 or higher; tested through 3.0)
+ * OpenEXR/Imath >= 2.0 (recommended: 2.2 or higher; tested through 3.0)
  * libTIFF >= 3.9 (recommended: 4.0+; tested through 4.3)
 
 ### Optional dependencies -- features may be disabled if not found

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -28,7 +28,7 @@ message (STATUS "CMAKE_CXX_COMPILER_ID  = ${CMAKE_CXX_COMPILER_ID}")
 # C++ language standard
 #
 set (CMAKE_CXX_STANDARD 14 CACHE STRING
-     "C++ standard to prefer (11, 14, 17, 20, etc.)")
+     "C++ standard to prefer (14, 17, 20, etc.)")
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 set (CMAKE_CXX_EXTENSIONS OFF)
 message (STATUS "Building for C++${CMAKE_CXX_STANDARD}")

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -196,18 +196,6 @@ checked_find_package (OpenVDB
                       VERSION_MIN 5.0
                       DEPS         TBB
                       DEFINITIONS  -DUSE_OPENVDB=1)
-if (OpenVDB_FOUND AND OpenVDB_VERSION VERSION_GREATER_EQUAL 8.0
-        AND CMAKE_CXX_STANDARD VERSION_LESS 14)
-    set (OpenVDB_FOUND OFF)
-    add_definitions (-UUSE_OPENVDB)
-    message (WARNING
-             "${ColorYellow}OpenVDB 8.0+ requires C++14 or higher (was ${CMAKE_CXX_STANDARD}). "
-             "To build against this OpenVDB ${OpenVDB_VERSION}, you need to set "
-             "build option CMAKE_CXX_STANDARD=14 (or higher). The minimum requirements "
-             "for that are gcc >= 5.1, clang >= 3.5, Apple clang >= 7, icc >= 7, MSVS >= 2017. "
-             "If you must use C++11, you need to build against OpenVDB 7 or earlier. ${ColorReset}")
-    message (STATUS "${ColorRed}Not using OpenVDB -- OpenVDB ${OpenVDB_VERSION} requires C++14 or later. ${ColorReset}")
-endif ()
 
 checked_find_package (PTex)
 checked_find_package (WebP)

--- a/src/include/OpenImageIO/dassert.h
+++ b/src/include/OpenImageIO/dassert.h
@@ -122,7 +122,7 @@
 /// with appropriate fallbacks for older C++ standards.
 #if (__cplusplus >= 201700L) /* FIXME - guess the token, fix when C++17 */
 #    define OIIO_STATIC_ASSERT(cond) static_assert(cond)
-#else /* (__cplusplus >= 201103L) */
+#else
 #    define OIIO_STATIC_ASSERT(cond) static_assert(cond, "")
 #endif
 

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -61,7 +61,7 @@
 // Detect which C++ standard we're using, and handy macros.
 // See https://en.cppreference.com/w/cpp/compiler_support
 //
-// OIIO_CPLUSPLUS_VERSION : which C++ standard is compiling (11, 14, ...)
+// OIIO_CPLUSPLUS_VERSION : which C++ standard is compiling (14, 17, ...)
 // OIIO_CONSTEXPR14 :
 // OIIO_CONSTEXPR17 :
 // OIIO_CONSTEXPR20 : constexpr for C++ >= the designated version, otherwise
@@ -70,42 +70,35 @@
 // OIIO_INLINE_CONSTEXPR : inline constexpr variables, added in C++17. For
 //                         older C++, just constexpr.
 //
-// Note: oiioversion.h defines OIIO_BUILD_CPP11, OIIO_BUILD_CPP14,
-// OIIO_BUILD_CPP17, or OIIO_BUILD_CPP20 to be 1 if OIIO itself was *built*
-// using C++11, C++14, C++17, or C++20, respectively. In contrast,
+// Note: oiioversion.h defines OIIO_BUILD_CPP (set to 14, 17, etc.)
+// reflecting what OIIO itself was *built* with.  In contrast,
 // OIIO_CPLUSPLUS_VERSION defined below will be set to the right number for
 // the C++ standard being compiled RIGHT NOW. These two things may be the
 // same when compiling OIIO, but they may not be the same if another
 // package is compiling against OIIO and using these headers (OIIO may be
-// C++11 but the client package may be newer, or vice versa -- use these two
+// C++14 but the client package may be newer, or vice versa -- use these two
 // symbols to differentiate these cases, when important).
 #if (__cplusplus >= 202001L)
 #    define OIIO_CPLUSPLUS_VERSION 20
-#    define OIIO_CONSTEXPR14 constexpr
 #    define OIIO_CONSTEXPR17 constexpr
 #    define OIIO_CONSTEXPR20 constexpr
 #    define OIIO_INLINE_CONSTEXPR inline constexpr
 #elif (__cplusplus >= 201703L)
 #    define OIIO_CPLUSPLUS_VERSION 17
-#    define OIIO_CONSTEXPR14 constexpr
 #    define OIIO_CONSTEXPR17 constexpr
 #    define OIIO_CONSTEXPR20 /* not constexpr before C++20 */
 #    define OIIO_INLINE_CONSTEXPR inline constexpr
 #elif (__cplusplus >= 201402L) || (defined(_MSC_VER) && _MSC_VER >= 1914)
 #    define OIIO_CPLUSPLUS_VERSION 14
-#    define OIIO_CONSTEXPR14 constexpr
-#    define OIIO_CONSTEXPR17 /* not constexpr before C++17 */
-#    define OIIO_CONSTEXPR20 /* not constexpr before C++20 */
-#    define OIIO_INLINE_CONSTEXPR constexpr
-#elif (__cplusplus >= 201103L) || (defined(_MSC_VER) && _MSC_VER >= 1900)
-#    define OIIO_CPLUSPLUS_VERSION 11
-#    define OIIO_CONSTEXPR14 /* not constexpr before C++14 */
 #    define OIIO_CONSTEXPR17 /* not constexpr before C++17 */
 #    define OIIO_CONSTEXPR20 /* not constexpr before C++20 */
 #    define OIIO_INLINE_CONSTEXPR constexpr
 #else
-#    error "This version of OIIO is meant to work only with C++11 and above"
+#    error "This version of OIIO is meant to work only with C++14 and above"
 #endif
+
+// DEPRECATED(2.3): use C++14 constexpr
+#define OIIO_CONSTEXPR14 constexpr
 
 // DEPRECATED(1.8): use C++11 constexpr
 #define OIIO_CONSTEXPR constexpr
@@ -190,15 +183,15 @@
 
 // Tests for MSVS versions, always 0 if not MSVS at all.
 #if defined(_MSC_VER)
-#  if _MSC_VER < 1900
-#    error "This version of OIIO is meant to work only with Visual Studio 2015 or later"
-#  endif
 #  define OIIO_MSVS_AT_LEAST_2013 (_MSC_VER >= 1800)
 #  define OIIO_MSVS_BEFORE_2013   (_MSC_VER <  1800)
 #  define OIIO_MSVS_AT_LEAST_2015 (_MSC_VER >= 1900)
 #  define OIIO_MSVS_BEFORE_2015   (_MSC_VER <  1900)
 #  define OIIO_MSVS_AT_LEAST_2017 (_MSC_VER >= 1910)
 #  define OIIO_MSVS_BEFORE_2017   (_MSC_VER <  1910)
+#  if OIIO_MSVS_BEFORE_2017
+#    error "This version of OIIO is meant to work only with Visual Studio 2017 or later"
+#  endif
 #else
 #  define OIIO_MSVS_AT_LEAST_2013 0
 #  define OIIO_MSVS_BEFORE_2013   0

--- a/testsuite/cmake-consumer/CMakeLists.txt
+++ b/testsuite/cmake-consumer/CMakeLists.txt
@@ -13,7 +13,7 @@ endif ()
 message (STATUS "Building ${PROJECT_NAME} ${PROJECT_VERSION} - ${CMAKE_BUILD_TYPE}")
 
 # Use C++11
-set (CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard to prefer (11, 14, 17, etc.)")
+set (CMAKE_CXX_STANDARD 14 CACHE STRING "C++ standard to prefer (14, 17, etc.)")
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 set (CMAKE_CXX_EXTENSIONS OFF)
 


### PR DESCRIPTION
This also bumps compiler minimums to gcc 6.1, clang 3.4, MSVS 2017,
and icc 17 (all because those are the first versions to fully support
C++14).

This has been coming and has been socialized for a long time, with
nobody voicing serious objection. So here it is.

This WILL NOT be backported to release branches. The new minimums only
affect OIIO 2.3 and later.

When last discussed on the oiio-dev mail list, I said I would aim to
introduce this change on May 1. I will not merge this PR earlier than
that, and I will tag a developer preview release before that happens.

