### PR TITLE
Rename TITLE to NAME in help2manpages.py script

### DIFF
--- a/src/doc/help2man_preformat.py
+++ b/src/doc/help2man_preformat.py
@@ -10,7 +10,7 @@ import sys
 
 lines = [l.rstrip().replace('\t', ' '*8) for l in sys.stdin.readlines()]
 
-print('TITLE')
+print('NAME')
 print(lines[0])
 print()
 


### PR DESCRIPTION
----

## Description

This PR aims to fix a bunch of warnings in Debian Lintian tool about
the usage of the wrong field to define the name of the manual page.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.