### PR TITLE
Adjustment for OpenColorIO 2.1 (in dev) deprecating method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       CC: gcc
       CMAKE_CXX_STANDARD: 14
       USE_SIMD: sse4.2
+      OPENCOLORIO_VERSION: v1.1.1
       PUGIXML_VERSION: v1.9
     steps:
       - uses: actions/checkout@v2
@@ -76,6 +77,7 @@ jobs:
       CMAKE_CXX_STANDARD: 14
       PYTHON_VERSION: 3.7
       USE_SIMD: avx
+      OPENCOLORIO_VERSION: v1.1.1
       WEBP_VERSION: v1.1.0
       MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=7.0.1
     steps:
@@ -126,6 +128,7 @@ jobs:
       CMAKE_CXX_STANDARD: 17
       PYTHON_VERSION: 3.7
       USE_SIMD: avx2,f16c
+      OPENCOLORIO_VERSION: v2.0.0
       WEBP_VERSION: v1.1.0
     steps:
       - uses: actions/checkout@v2
@@ -174,6 +177,7 @@ jobs:
       CMAKE_CXX_STANDARD: 17
       PYTHON_VERSION: 3.7
       USE_SIMD: avx2,f16c
+      OPENCOLORIO_VERSION: v2.0.0
       OPENEXR_VERSION: v3.0.1
     steps:
       - uses: actions/checkout@v2

--- a/src/build-scripts/build_opencolorio.bash
+++ b/src/build-scripts/build_opencolorio.bash
@@ -7,7 +7,7 @@ set -ex
 
 # Which OCIO to retrieve, how to build it
 OPENCOLORIO_REPO=${OPENCOLORIO_REPO:=https://github.com/AcademySoftwareFoundation/OpenColorIO.git}
-OPENCOLORIO_VERSION=${OPENCOLORIO_VERSION:=v1.1.1}
+OPENCOLORIO_VERSION=${OPENCOLORIO_VERSION:=v2.0.0}
 
 # Where to install the final results
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -265,10 +265,15 @@ public:
     ColorProcessorHandle createMatrixTransform(const Imath::M44f& M,
                                                bool inverse = false) const;
 
+    /// Given a filepath, ask OCIO what color space it thinks the file
+    /// should be, based on how the name matches file naming rules in the
+    /// OCIO config.  (This is mostly a wrapper around OCIO's
+    /// ColorConfig::getColorSpaceFromSFilepath.)
+    string_view getColorSpaceFromFilepath(string_view str) const;
+
     /// Given a string (like a filename), look for the longest, right-most
     /// colorspace substring that appears. Returns "" if no such color space
-    /// is found. (This is just a wrapper around OCIO's
-    /// ColorConfig::parseColorSpaceFromString.)
+    /// is found.
     string_view parseColorSpaceFromString(string_view str) const;
 
     /// Return a filename or other identifier for the config we're using.

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4620,7 +4620,7 @@ input_file(int argc, const char* argv[])
         if (autocc) {
             // Try to deduce the color space it's in
             string_view colorspace(
-                ot.colorconfig.parseColorSpaceFromString(filename));
+                ot.colorconfig.getColorSpaceFromFilepath(filename));
             if (colorspace.size() && ot.debug)
                 std::cout << "  From " << filename
                           << ", we deduce color space \"" << colorspace
@@ -4886,7 +4886,7 @@ output_file(int /*argc*/, const char* argv[])
     // automatically set -d based on the name if --autocc is used.
     bool autocc          = fileoptions.get_int("autocc", ot.autocc);
     bool autoccunpremult = fileoptions.get_int("unpremult", ot.autoccunpremult);
-    string_view outcolorspace = ot.colorconfig.parseColorSpaceFromString(
+    string_view outcolorspace = ot.colorconfig.getColorSpaceFromFilepath(
         filename);
     if (autocc && outcolorspace.size()) {
         TypeDesc type;
@@ -4901,8 +4901,8 @@ output_file(int /*argc*/, const char* argv[])
                     && ot.output_bitspersample != bits)) {
                 ot.warningf(
                     command,
-                    "Output filename colorspace \"%s\" implies %s (%d bits), overriding prior request for %s.",
-                    outcolorspace, type, bits, ot.output_dataformat);
+                    "Output filename (%s) colorspace \"%s\" implies %s (%d bits), overriding prior request for %s.",
+                    filename, outcolorspace, type, bits, ot.output_dataformat);
             }
             ot.output_dataformat    = type;
             ot.output_bitspersample = bits;

--- a/src/python/py_colorconfig.cpp
+++ b/src/python/py_colorconfig.cpp
@@ -82,6 +82,10 @@ declare_colorconfig(py::module& m)
                 return self.getDefaultViewName(display);
             },
             "display"_a = "")
+        .def("getColorSpaceFromFilepath",
+             [](const ColorConfig& self, const std::string& str) {
+                 return std::string(self.getColorSpaceFromFilepath(str));
+             })
         .def("parseColorSpaceFromString",
              [](const ColorConfig& self, const std::string& str) {
                  return std::string(self.parseColorSpaceFromString(str));


### PR DESCRIPTION
This started out as just trying to fix our CI on the "bleeding edge"
building against OCIO master and complaining about a recently committed
OCIO deprecation of Config::parseColorSpaceFromString.

But it turned out that the new OCIO v2 method, getColorSpaceFromFilepath,
didn't work quite the same way and broke our tests. So I ended up having
to implement a bit more of a complicated set of functionality:

* Config::parseColorSpaceFromString now wraps the OCIO version if it's
  available, but implements the equivalent logic if OCIO is new enough
  that the function is deprecated.

* As a bonus, our pCSFS now works (didn't before) in cases where lack of
  OCIO support or missing config meant the OCIO functionality wasn't
  available. That is, it works on our meager set of default color spaces
  that are present even without OCIO.

* New Config::getColorSpaceFromFilepath wraps the OCIO version if OCIO
  is new enough, but if it isn't, or if there's no OCIO, or if OCIO ends
  up not figuring it out and returning the default rule, we fall back
  to Config::parseColorSpaceFromString.

* Add OCIO to VFX Platform CI builds -- because it's not in the aswf-osl
  docker images, we weren't testing OCIO in as many versions as we had
  previously thought.

* Bump default OCIO version built by build-scripts/build_opencolorio.bash
  to 2.0 (from 1.1.1).

