### PR TITLE
fixed a crash in ImageCacheFile::read_unmipped

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -934,7 +934,7 @@ ImageCacheFile::read_unmipped(ImageCachePerThreadInfo* thread_info,
     }
 
     // Now convert and copy those values out to the caller's buffer
-    lores.get_pixels(ROI(0, tw, 0, th, 0, 1, chbegin, chend), format, data);
+    lores.get_pixels(ROI(0, tw, 0, th, 0, 1, 0, nchans), format, data);
 
     // Restore the microcache to the way it was before.
     thread_info->tile     = oldtile;


### PR DESCRIPTION
Fixed a crash in ImageCacheFile::read_unmipped when sampling a channel index greater than the number of channels we're sampling (see Description below)

## Description

This is a proposed fix for issue #2959 
To give a bit more information: `ImageCacheFile::read_unmipped` crashes when trying to read from a generated mipmap, when its called with a `chbegin` greater than the number of channels we're sampling.
This is because that method creates a temp image buffer with `chend - chbegin` channels only, and then at the end of the method, it will get its pixels by calling its `get_pixels` methods, and by providing a ROI with unchanged `chbegin` and `chend`.
And in the beginning of `ImageBuf::get_pixels` this line result in a crash in our case: `roi.chend = std::min(roi.chend, nchannels());`
Let's say we were sampling channel 10 to 13, we're creating an image buffer with only 3 channels, and when we get the pixels, that line will set `roi.chend` to `3`.. which leads to negative values in strides and crashes.

Anyway this pull request fixes this by changing the ROI instance passed to `ImageBuf::get_pixels` in order to match how that image buf was created.

## Tests

The only test I did for now was to test the fix of the crash through the sample attached to the issue, and also check that mipmaps are correct through our software.

I'm going to let the CI run on this PR and update this once the results are available.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

