### PR TITLE
Update the CI clang-format to use llvm 11 (from 10)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,7 +5,10 @@ SpaceBeforeParens: ControlStatements
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: true
+#AlignConsecutiveAssignments: Consecutive
+#AlignConsecutiveBitFields: Consecutive
 AlignConsecutiveDeclarations: false
+#AlignConsecutiveDeclarations: None
 AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: true
@@ -75,6 +78,7 @@ IncludeCategories:
     Priority:        1
 IncludeIsMainRegex: '(Test)?$'
 IndentCaseLabels: false
+IndentExternBlock: NoIndent
 IndentPPDirectives: AfterHash
 IndentWidth:     4
 IndentWrappedFunctionNames: false
@@ -118,7 +122,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
+Standard:        c++14
 StatementMacros: 
   - Q_UNUSED
   - QT_REQUIRE_VERSION

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -726,7 +726,7 @@ jobs:
     name: "clang-format verification"
     runs-on: ubuntu-18.04
     container:
-      image: aswf/ci-osl:2021-clang10
+      image: aswf/ci-osl:2021-clang11
     env:
       BUILDTARGET: clang-format
       PYTHON_VERSION: 3.7

--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -75,7 +75,7 @@ BmpInput::open(const std::string& name, ImageSpec& spec)
 
     const int nchannels = (m_dib_header.bpp == 32) ? 4 : 3;
     const int height    = (m_dib_header.height >= 0) ? m_dib_header.height
-                                                  : -m_dib_header.height;
+                                                     : -m_dib_header.height;
     m_spec = ImageSpec(m_dib_header.width, height, nchannels, TypeDesc::UINT8);
     if (m_dib_header.hres > 0 && m_dib_header.vres > 0) {
         m_spec.attribute("XResolution", (int)m_dib_header.hres);
@@ -260,7 +260,7 @@ BmpInput::read_color_table(void)
     }
     const int32_t colors = (m_dib_header.cpalete) ? m_dib_header.cpalete
                                                   : 1 << m_dib_header.bpp;
-    size_t entry_size = 4;
+    size_t entry_size    = 4;
     // if the file is OS V2 bitmap color table entry has only 3 bytes, not four
     if (m_dib_header.size == OS2_V1)
         entry_size = 3;

--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -431,7 +431,7 @@ DDSInput::seek_subimage(int subimage, int miplevel)
         // create imagespec for the 3x2 cube map layout
 #ifdef DDS_3X2_CUBE_MAP_LAYOUT
         m_spec = ImageSpec(w * 3, h * 2, m_nchans, TypeDesc::UINT8);
-#else   // 1x6 layout
+#else  // 1x6 layout
         m_spec = ImageSpec(w, h * 6, m_nchans, TypeDesc::UINT8);
 #endif  // DDS_3X2_CUBE_MAP_LAYOUT
         m_spec.depth      = d;
@@ -667,7 +667,7 @@ DDSInput::read_native_tile(int subimage, int miplevel, int x, int y, int z,
         internal_seek_subimage(((x / m_spec.tile_width) << 1)
                                    + y / m_spec.tile_height,
                                m_miplevel, w, h, d);
-#else   // 1x6 layout
+#else  // 1x6 layout
         internal_seek_subimage(y / m_spec.tile_height, m_miplevel, w, h, d);
 #endif  // DDS_3X2_CUBE_MAP_LAYOUT
         if (!w && !h && !d)

--- a/src/heif.imageio/heifinput.cpp
+++ b/src/heif.imageio/heifinput.cpp
@@ -182,7 +182,7 @@ HeifInput::seek_subimage(int subimage, int miplevel)
         m_has_alpha = m_ihandle.has_alpha_channel();
         auto chroma = m_has_alpha ? heif_chroma_interleaved_RGBA
                                   : heif_chroma_interleaved_RGB;
-        m_himage = m_ihandle.decode_image(heif_colorspace_RGB, chroma);
+        m_himage    = m_ihandle.decode_image(heif_colorspace_RGB, chroma);
 
     } catch (const heif::Error& err) {
         std::string e = err.get_message();

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -180,10 +180,10 @@ ICOOutput::open(const std::string& name, const ImageSpec& userspec,
             return false;
         }
 
-        m_bpp = (m_color_type == PNG_COLOR_TYPE_GRAY_ALPHA
+        m_bpp     = (m_color_type == PNG_COLOR_TYPE_GRAY_ALPHA
                  || m_color_type == PNG_COLOR_TYPE_RGB_ALPHA)
-                    ? 32
-                    : 24;
+                        ? 32
+                        : 24;
         m_xor_slb = (m_spec.width * m_bpp + 7) / 8  // real data bytes
                     + (4 - ((m_spec.width * m_bpp + 7) / 8) % 4)
                           % 4;              // padding

--- a/src/include/OpenImageIO/image_view.h
+++ b/src/include/OpenImageIO/image_view.h
@@ -123,9 +123,9 @@ private:
         m_depth      = depth;
         m_chanstride = chanstride != AutoStride ? chanstride : sizeof(T);
         m_xstride    = xstride != AutoStride ? xstride
-                                          : m_nchannels * m_chanstride;
-        m_ystride = ystride != AutoStride ? ystride : m_width * m_xstride;
-        m_zstride = zstride != AutoStride ? zstride : m_height * m_ystride;
+                                             : m_nchannels * m_chanstride;
+        m_ystride    = ystride != AutoStride ? ystride : m_width * m_xstride;
+        m_zstride    = zstride != AutoStride ? zstride : m_height * m_ystride;
     }
 
     inline T* getptr(int c, int x, int y, int z = 0) const

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -157,9 +157,9 @@ Jpeg2000Output::open(const std::string& name, const ImageSpec& spec,
     if (m_spec.format != TypeDesc::UINT8 && m_spec.format != TypeDesc::UINT16)
         m_spec.set_format(TypeDesc::UINT8);
 
-    m_dither = (m_spec.format == TypeDesc::UINT8)
-                   ? m_spec.get_int_attribute("oiio:dither", 0)
-                   : 0;
+    m_dither        = (m_spec.format == TypeDesc::UINT8)
+                          ? m_spec.get_int_attribute("oiio:dither", 0)
+                          : 0;
     m_convert_alpha = m_spec.alpha_channel != -1
                       && !m_spec.get_int_attribute("oiio:UnassociatedAlpha", 0);
 

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1316,8 +1316,8 @@ ColorConfig::createFileTransform(ustring name, bool inverse) const
         OCIO::FileTransformRcPtr transform = OCIO::FileTransform::Create();
         transform->setSrc(name.c_str());
         transform->setInterpolation(OCIO::INTERP_BEST);
-        OCIO::TransformDirection dir = inverse ? OCIO::TRANSFORM_DIR_INVERSE
-                                               : OCIO::TRANSFORM_DIR_FORWARD;
+        OCIO::TransformDirection dir    = inverse ? OCIO::TRANSFORM_DIR_INVERSE
+                                                  : OCIO::TRANSFORM_DIR_FORWARD;
         OCIO::ConstContextRcPtr context = config->getCurrentContext();
         OCIO::ConstProcessorRcPtr p;
         try {

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -243,9 +243,9 @@ warp_impl(ImageBuf& dst, const ImageBuf& src, const Imath::M33f& M,
         dst_roi      = roi.defined() ? roi : dst.roi();
         dst_roi_full = dst.roi_full();
     } else {
-        dst_roi = roi.defined()
-                      ? roi
-                      : (recompute_roi ? transform(M, src.roi()) : src.roi());
+        dst_roi      = roi.defined()
+                           ? roi
+                           : (recompute_roi ? transform(M, src.roi()) : src.roi());
         dst_roi_full = src_roi_full;
     }
     dst_roi.chend      = std::min(dst_roi.chend, src.nchannels());

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -292,11 +292,11 @@ ImageInput::read_scanlines(int subimage, int miplevel, int ybegin, int yend,
     stride_t zstride = AutoStride;
     spec.auto_stride(xstride, ystride, zstride, format, nchans, spec.width,
                      spec.height);
-    stride_t buffer_pixel_bytes = native ? native_pixel_bytes
-                                         : format.size() * nchans;
+    stride_t buffer_pixel_bytes    = native ? native_pixel_bytes
+                                            : format.size() * nchans;
     stride_t buffer_scanline_bytes = native ? native_scanline_bytes
                                             : buffer_pixel_bytes * spec.width;
-    bool contiguous = (xstride == (stride_t)buffer_pixel_bytes
+    bool contiguous                = (xstride == (stride_t)buffer_pixel_bytes
                        && ystride == (stride_t)buffer_scanline_bytes);
 
     if (native && contiguous) {
@@ -614,19 +614,19 @@ ImageInput::read_tiles(int subimage, int miplevel, int xbegin, int xend,
     }
 
     // No such luck.  Just punt and read tiles individually.
-    bool ok            = true;
-    stride_t pixelsize = native_data ? native_pixel_bytes
-                                     : (format.size() * nchans);
-    stride_t native_pixelsize = spec.pixel_bytes(true);
-    stride_t full_pixelsize   = native_data ? native_pixelsize
-                                          : (format.size() * spec.nchannels);
+    bool ok                        = true;
+    stride_t pixelsize             = native_data ? native_pixel_bytes
+                                                 : (format.size() * nchans);
+    stride_t native_pixelsize      = spec.pixel_bytes(true);
+    stride_t full_pixelsize        = native_data ? native_pixelsize
+                                                 : (format.size() * spec.nchannels);
     stride_t full_tilewidthbytes   = full_pixelsize * spec.tile_width;
     stride_t full_tilewhbytes      = full_tilewidthbytes * spec.tile_height;
     stride_t full_tilebytes        = full_tilewhbytes * spec.tile_depth;
     stride_t full_native_tilebytes = spec.tile_bytes(true);
     size_t prefix_bytes = native_data ? spec.pixel_bytes(0, chbegin, true)
                                       : format.size() * chbegin;
-    bool allchans = (chbegin == 0 && chend == spec.nchannels);
+    bool allchans       = (chbegin == 0 && chend == spec.nchannels);
     std::vector<char> buf;
     for (int z = zbegin; z < zend; z += std::max(1, spec.tile_depth)) {
         int zd      = std::min(zend - z, spec.tile_depth);

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -396,7 +396,7 @@ ImageOutput::to_native_rectangle(int xbegin, int xend, int ybegin, int yend,
     imagesize_t contiguoussize = contiguous
                                      ? 0
                                      : rectangle_values * input_pixel_bytes;
-    contiguoussize = (contiguoussize + 3)
+    contiguoussize             = (contiguoussize + 3)
                      & (~3);  // Round up to 4-byte boundary
     OIIO_DASSERT((contiguoussize & 3) == 0);
     imagesize_t floatsize = rectangle_values * sizeof(float);

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -463,7 +463,8 @@ TextureSystemImpl::accum3d_sample_bilinear(
     OIIO_DASSERT(sizeof(valid_storage) == 8);
     const unsigned long long none_valid = 0;
     const unsigned long long all_valid  = littleendian() ? 0x010101010101LL
-                                                        : 0x01010101010100LL;
+                                                         : 0x01010101010100LL;
+
     bool* svalid = valid_storage.bvalid;
     bool* tvalid = valid_storage.bvalid + 2;
     bool* rvalid = valid_storage.bvalid + 4;

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -1468,7 +1468,7 @@ TextureSystemImpl::texture_lookup_trilinear_mipmap(
     float sfilt          = std::max(fabsf(dsdx), fabsf(dsdy));
     float tfilt          = std::max(fabsf(dtdx), fabsf(dtdy));
     float filtwidth      = options.conservative_filter ? std::max(sfilt, tfilt)
-                                                  : std::min(sfilt, tfilt);
+                                                       : std::min(sfilt, tfilt);
     // account for blur
     filtwidth += std::max(options.sblur, options.tblur);
     float aspect = 1.0f;
@@ -2064,8 +2064,8 @@ TextureSystemImpl::sample_bilinear(
     wrap_impl swrap_func         = wrap_functions[(int)options.swrap];
     wrap_impl twrap_func         = wrap_functions[(int)options.twrap];
     wrap_impl_simd wrap_func     = (swrap_func == twrap_func)
-                                   ? wrap_functions_simd[(int)options.swrap]
-                                   : NULL;
+                                       ? wrap_functions_simd[(int)options.swrap]
+                                       : NULL;
     simd::vint4 xy(spec.x, spec.y);
     simd::vint4 widthheight(spec.width, spec.height);
     simd::vint4 tilewh(spec.tile_width, spec.tile_height);

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -192,7 +192,7 @@ Strutil::vsprintf(const char* fmt, va_list ap)
 #ifdef va_copy
         va_copy(ap, apsave);
 #else
-        ap     = apsave;
+        ap = apsave;
 #endif
     }
 }
@@ -1147,8 +1147,8 @@ decode(uint32_t* state, uint32_t* codep, uint32_t byte)
 {
     uint32_t type = utf8d[byte];
     *codep        = (*state != UTF8_ACCEPT) ? (byte & 0x3fu) | (*codep << 6)
-                                     : (0xff >> type) & (byte);
-    *state = utf8d[256 + *state + type];
+                                            : (0xff >> type) & (byte);
+    *state        = utf8d[256 + *state + type];
     return *state;
 }
 

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -102,9 +102,9 @@ ImageRec::ImageRec(ImageRec& A, ImageRec& B, int subimage_to_copy,
 {
     A.read();
     B.read();
-    int subimages = (subimage_to_copy < 0)
-                        ? std::min(A.subimages(), B.subimages())
-                        : 1;
+    int subimages      = (subimage_to_copy < 0)
+                             ? std::min(A.subimages(), B.subimages())
+                             : 1;
     int first_subimage = clamp(subimage_to_copy, 0, subimages - 1);
     m_subimages.resize(subimages);
     for (int s = 0; s < subimages; ++s) {

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -774,7 +774,7 @@ adjust_output_options(string_view filename, ImageSpec& spec,
         spec.tile_width  = requested_tilewidth;
         spec.tile_height = requested_tileheight ? requested_tileheight
                                                 : requested_tilewidth;
-        spec.tile_depth = 1;  // FIXME if we ever want volume support
+        spec.tile_depth  = 1;  // FIXME if we ever want volume support
     } else if (was_direct_read && nativespec && nativespec->tile_width > 0
                && nativespec->tile_height > 0 && !requested_scanline
                && format_supports_tiles) {
@@ -1295,7 +1295,7 @@ Oiiotool::express_parse_atom(const string_view expr, string_view& s,
                               ? std::string("%d")
                               : Strutil::sprintf("\"%%0%dd\"",
                                                  ot.frame_padding);
-        result = Strutil::sprintf(fmt.c_str(), ot.frame_number);
+        result          = Strutil::sprintf(fmt.c_str(), ot.frame_number);
     } else {
         express_error(expr, s, "syntax error");
         result = orig;
@@ -4942,14 +4942,14 @@ output_file(int /*argc*/, const char* argv[])
     // that doesn't support negative origins.
     if (!supports_negativeorigin && autocrop
         && (ir->spec()->x < 0 || ir->spec()->y < 0 || ir->spec()->z < 0)) {
-        ROI roi          = get_roi(*ir->spec(0, 0));
-        roi.xbegin       = std::max(0, roi.xbegin);
-        roi.ybegin       = std::max(0, roi.ybegin);
-        roi.zbegin       = std::max(0, roi.zbegin);
-        std::string crop = (ir->spec(0, 0)->depth == 1)
-                               ? format_resolution(roi.width(), roi.height(),
+        ROI roi            = get_roi(*ir->spec(0, 0));
+        roi.xbegin         = std::max(0, roi.xbegin);
+        roi.ybegin         = std::max(0, roi.ybegin);
+        roi.zbegin         = std::max(0, roi.zbegin);
+        std::string crop   = (ir->spec(0, 0)->depth == 1)
+                                 ? format_resolution(roi.width(), roi.height(),
                                                    roi.xbegin, roi.ybegin)
-                               : format_resolution(roi.width(), roi.height(),
+                                 : format_resolution(roi.width(), roi.height(),
                                                    roi.depth(), roi.xbegin,
                                                    roi.ybegin, roi.zbegin);
         const char* argv[] = { "crop:allsubimages=1", crop.c_str() };

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -600,7 +600,7 @@ write_info(png_structp& sp, png_infop& ip, int& color_type, ImageSpec& spec,
         if (icc_profile && length)
             png_set_iCCP(sp, ip, "Embedded Profile", 0, icc_profile, length);
 #else
-        char* icc_profile      = (char*)icc_profile_parameter->data();
+        char* icc_profile = (char*)icc_profile_parameter->data();
         if (icc_profile && length)
             png_set_iCCP(sp, ip, (png_charp) "Embedded Profile", 0, icc_profile,
                          length);

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -140,8 +140,8 @@ PNMOutput::open(const std::string& name, const ImageSpec& userspec,
     m_spec.set_format(TypeDesc::UINT8);  // Force 8 bit output
     int bits_per_sample = m_spec.get_int_attribute("oiio:BitsPerSample", 8);
     m_dither            = (m_spec.format == TypeDesc::UINT8)
-                   ? m_spec.get_int_attribute("oiio:dither", 0)
-                   : 0;
+                              ? m_spec.get_int_attribute("oiio:dither", 0)
+                              : 0;
 
     if (m_spec.nchannels != 1 && m_spec.nchannels != 3) {
         errorf("%s does not support %d-channel images\n", format_name(),

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -1799,8 +1799,8 @@ PSDInput::setup()
     for (Layer& layer : m_layers) {
         spec_channel_count = m_WantRaw ? mode_channel_count[m_header.color_mode]
                                        : 3;
-        raw_channel_count = mode_channel_count[m_header.color_mode];
-        bool transparency = (bool)layer.channel_id_map.count(
+        raw_channel_count  = mode_channel_count[m_header.color_mode];
+        bool transparency  = (bool)layer.channel_id_map.count(
             ChannelID_Transparency);
         if (transparency) {
             spec_channel_count++;

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -274,7 +274,7 @@ RLAInput::seek_subimage(int subimage, int miplevel)
                             ? get_channel_typedesc(m_rla.AuxChannelType,
                                                    m_rla.NumOfAuxBits)
                             : TypeUnknown;
-    TypeDesc maxtype = ImageBufAlgo::type_merge(col_type, mat_type, aux_type);
+    TypeDesc maxtype  = ImageBufAlgo::type_merge(col_type, mat_type, aux_type);
     if (maxtype == TypeUnknown) {
         errorf("Failed channel bytes sanity check");
         return false;  // failed sanity check

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -562,11 +562,10 @@ RLAOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
         TypeDesc chantype = m_spec.channelformats.size()
                                 ? m_spec.channelformats[c]
                                 : m_spec.format;
-        int bits = (c < m_rla.NumOfColorChannels)
-                       ? m_rla.NumOfChannelBits
-                       : (c < (m_rla.NumOfColorChannels + m_rla.NumOfMatteBits))
-                             ? m_rla.NumOfMatteBits
-                             : m_rla.NumOfAuxBits;
+        int bits = (c < m_rla.NumOfColorChannels) ? m_rla.NumOfChannelBits
+                   : (c < (m_rla.NumOfColorChannels + m_rla.NumOfMatteBits))
+                       ? m_rla.NumOfMatteBits
+                       : m_rla.NumOfAuxBits;
         if (!encode_channel((unsigned char*)data + offset, pixelsize, chantype,
                             bits))
             return false;

--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -418,7 +418,7 @@ TGAInput::open(const std::string& name, ImageSpec& newspec)
                 int palbytespp = (m_tga.cmap_size == 15)
                                      ? 2
                                      : (m_tga.cmap_size / 8);
-                int alphabits = m_tga.attr & 0x0F;
+                int alphabits  = m_tga.attr & 0x0F;
                 if (alphabits == 0 && m_tga.bpp == 32)
                     alphabits = 8;
                 // read palette, if there is any

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -213,8 +213,8 @@ TGAOutput::open(const std::string& name, const ImageSpec& userspec,
     // prepare and write Targa header
     tga_header tga;
     memset(&tga, 0, sizeof(tga));
-    tga.type = m_spec.nchannels <= 2 ? TYPE_GRAY
-                                     : (m_want_rle ? TYPE_RGB_RLE : TYPE_RGB);
+    tga.type   = m_spec.nchannels <= 2 ? TYPE_GRAY
+                                       : (m_want_rle ? TYPE_RGB_RLE : TYPE_RGB);
     tga.bpp    = m_spec.nchannels * 8;
     tga.width  = m_spec.width;
     tga.height = m_spec.height;

--- a/src/term.imageio/termoutput.cpp
+++ b/src/term.imageio/termoutput.cpp
@@ -155,8 +155,8 @@ TermOutput::output()
     int w = m_buf.spec().width;
     int h = m_buf.spec().height;
     // iTerm2 is special, see bellow
-    int maxw = (method == "iterm2") ? Sysutil::terminal_columns() * 16
-                                    : Sysutil::terminal_columns();
+    int maxw     = (method == "iterm2") ? Sysutil::terminal_columns() * 16
+                                        : Sysutil::terminal_columns();
     float yscale = (method == "iterm2" || method == "24bit") ? 1.0f : 0.5f;
     // Resize the image as needed
     if (w > maxw && m_fit) {

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -966,6 +966,7 @@ rgb_to_cmyk(int n, const T* rgb, size_t rgb_stride, T* cmyk, size_t cmyk_stride)
         float one_minus_K     = std::max(R, std::max(G, B));
         float one_minus_K_inv = (one_minus_K <= 1e-6) ? 0.0f
                                                       : 1.0f / one_minus_K;
+
         float C = (one_minus_K - R) * one_minus_K_inv;
         float M = (one_minus_K - G) * one_minus_K_inv;
         float Y = (one_minus_K - B) * one_minus_K_inv;


### PR DESCRIPTION
This makes several minor formatting changes, mostly related to how
clang-format 11 has improved ability to track the alignment of `=` in
successive statements, even when one of those statements is split
across two lines.
