### PR TITLE
Fix runaway parsing time for pathological XMP metadata

### DIFF
--- a/testsuite/psd/ref/out-alt.txt
+++ b/testsuite/psd/ref/out-alt.txt
@@ -644,7 +644,6 @@ Reading ../../../../../oiio-images/psd_rgba_8.psd
     IPTC:OriginalDocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
     oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: 3, 3
-    photoshop:DocumentAncestors: "E146B3E37A92795EE3EA6577040DE6D5"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
@@ -674,7 +673,6 @@ Reading ../../../../../oiio-images/psd_rgba_8.psd
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "Layer 1"
     photoshop:ColorMode: 3, 3
-    photoshop:DocumentAncestors: "E146B3E37A92795EE3EA6577040DE6D5"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
@@ -706,7 +704,6 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: 3, 3
-    photoshop:DocumentAncestors: "5B7818AD2E5E32040EA56034BBF08A7B; 76E35AB96B86FEC6F025DB20EBC85B75; xmp.did:1aba88a3-5e9a-4126-9fdb-c0bf9e220220; xmp.did:67CCD764092068118083F3748F43AB53; xmp.did:EF61098A6F16E011A133C53B46066329; xmp.did:ddc52283-5cc3-4453-8815-0f97e7e749e6; xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
@@ -736,7 +733,6 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "Layer 0"
     photoshop:ColorMode: 3, 3
-    photoshop:DocumentAncestors: "5B7818AD2E5E32040EA56034BBF08A7B; 76E35AB96B86FEC6F025DB20EBC85B75; xmp.did:1aba88a3-5e9a-4126-9fdb-c0bf9e220220; xmp.did:67CCD764092068118083F3748F43AB53; xmp.did:EF61098A6F16E011A133C53B46066329; xmp.did:ddc52283-5cc3-4453-8815-0f97e7e749e6; xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
@@ -767,7 +763,6 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "line1"
     photoshop:ColorMode: 3, 3
-    photoshop:DocumentAncestors: "5B7818AD2E5E32040EA56034BBF08A7B; 76E35AB96B86FEC6F025DB20EBC85B75; xmp.did:1aba88a3-5e9a-4126-9fdb-c0bf9e220220; xmp.did:67CCD764092068118083F3748F43AB53; xmp.did:EF61098A6F16E011A133C53B46066329; xmp.did:ddc52283-5cc3-4453-8815-0f97e7e749e6; xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
@@ -798,7 +793,6 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "line2"
     photoshop:ColorMode: 3, 3
-    photoshop:DocumentAncestors: "5B7818AD2E5E32040EA56034BBF08A7B; 76E35AB96B86FEC6F025DB20EBC85B75; xmp.did:1aba88a3-5e9a-4126-9fdb-c0bf9e220220; xmp.did:67CCD764092068118083F3748F43AB53; xmp.did:EF61098A6F16E011A133C53B46066329; xmp.did:ddc52283-5cc3-4453-8815-0f97e7e749e6; xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"

--- a/testsuite/psd/ref/out.txt
+++ b/testsuite/psd/ref/out.txt
@@ -644,7 +644,6 @@ Reading ../../../../../oiio-images/psd_rgba_8.psd
     IPTC:OriginalDocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
     oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: 3, 3
-    photoshop:DocumentAncestors: "E146B3E37A92795EE3EA6577040DE6D5"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
@@ -674,7 +673,6 @@ Reading ../../../../../oiio-images/psd_rgba_8.psd
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "Layer 1"
     photoshop:ColorMode: 3, 3
-    photoshop:DocumentAncestors: "E146B3E37A92795EE3EA6577040DE6D5"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
@@ -706,7 +704,6 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     oiio:ColorSpace: "sRGB"
     photoshop:ColorMode: 3, 3
-    photoshop:DocumentAncestors: "5B7818AD2E5E32040EA56034BBF08A7B; 76E35AB96B86FEC6F025DB20EBC85B75; xmp.did:1aba88a3-5e9a-4126-9fdb-c0bf9e220220; xmp.did:67CCD764092068118083F3748F43AB53; xmp.did:EF61098A6F16E011A133C53B46066329; xmp.did:ddc52283-5cc3-4453-8815-0f97e7e749e6; xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
@@ -736,7 +733,6 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "Layer 0"
     photoshop:ColorMode: 3, 3
-    photoshop:DocumentAncestors: "5B7818AD2E5E32040EA56034BBF08A7B; 76E35AB96B86FEC6F025DB20EBC85B75; xmp.did:1aba88a3-5e9a-4126-9fdb-c0bf9e220220; xmp.did:67CCD764092068118083F3748F43AB53; xmp.did:EF61098A6F16E011A133C53B46066329; xmp.did:ddc52283-5cc3-4453-8815-0f97e7e749e6; xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
@@ -767,7 +763,6 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "line1"
     photoshop:ColorMode: 3, 3
-    photoshop:DocumentAncestors: "5B7818AD2E5E32040EA56034BBF08A7B; 76E35AB96B86FEC6F025DB20EBC85B75; xmp.did:1aba88a3-5e9a-4126-9fdb-c0bf9e220220; xmp.did:67CCD764092068118083F3748F43AB53; xmp.did:EF61098A6F16E011A133C53B46066329; xmp.did:ddc52283-5cc3-4453-8815-0f97e7e749e6; xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
@@ -798,7 +793,6 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "line2"
     photoshop:ColorMode: 3, 3
-    photoshop:DocumentAncestors: "5B7818AD2E5E32040EA56034BBF08A7B; 76E35AB96B86FEC6F025DB20EBC85B75; xmp.did:1aba88a3-5e9a-4126-9fdb-c0bf9e220220; xmp.did:67CCD764092068118083F3748F43AB53; xmp.did:EF61098A6F16E011A133C53B46066329; xmp.did:ddc52283-5cc3-4453-8815-0f97e7e749e6; xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"


### PR DESCRIPTION
Found some files that encountered the problem described here:
https://prepression.blogspot.com/2017/06/metadata-bloat-photoshopdocumentancestors.html
https://feedback.photoshop.com/conversations/photoshop/photoshop-corrupt-ancestors-tag-in-xmp-causing-giant-file-sizes/5f5f45f74b561a3d426ba97f

The pathologically long lists of "photoshop:DocumentAncestors" tags (a
4MB PNG of which 3MB consisting of XMP) was tripping us up with an
O(n^2) handling of appending to lists for those attributes.

It seems like this was a widely acknowledged problem that has been fixed
in Photoshop 20.0.2 (January 2019) and later.

Solution:

* Just skip the problem tag; I can discern noreal use for preserving
  it in any OIIO context.

* More generally, be on the lookout for pathological or corrupt XMP by
  keeping track of the length of lists and just cutting them off from
  further appending when they seem senselessly long. I can imagine XMP
  with lots of attributes, but it's hard to imagine that any single
  attribute having thousands of list entries is intentional and useful.

* Fix some places where we were needlessly generating and then tearing
  down std::string's.
