### PR TITLE
Clarify that our BMP implementation does not support RLE files.

### DIFF
--- a/src/bmp.imageio/bmp_pvt.h
+++ b/src/bmp.imageio/bmp_pvt.h
@@ -30,7 +30,11 @@ const int16_t MAGIC_CI = 0x4943;
 const int16_t MAGIC_CP = 0x5043;
 const int16_t MAGIC_PT = 0x5450;
 
-//const int32_t RLE4_COMPRESSION = 2;
+const int32_t NO_COMPRESSION   = 0;  // BI_RGB
+const int32_t RLE8_COMPRESSION = 1;  // BI_RLE8
+const int32_t RLE4_COMPRESSION = 2;  // BI_RLE4
+
+
 
 // store informations about BMP file
 class BmpFileHeader {

--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -125,6 +125,14 @@ BmpInput::open(const std::string& name, ImageSpec& spec)
     case WINDOWS_V5: m_spec.attribute("bmp:version", 5); break;
     }
 
+    if (m_dib_header.compression == RLE4_COMPRESSION
+        || m_dib_header.compression == RLE8_COMPRESSION) {
+        errorfmt("BMP compression {} is not currently supported",
+                 m_dib_header.compression);
+        close();
+        return false;
+    }
+
     // file pointer is set to the beginning of image data
     // we save this position - it will be helpfull in read_native_scanline
     m_image_start = Filesystem::ftell(m_fd);

--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -176,7 +176,7 @@ BmpOutput::create_and_write_bitmap_header(void)
     m_dib_header.width       = m_spec.width;
     m_dib_header.height      = m_spec.height;
     m_dib_header.cplanes     = 1;
-    m_dib_header.compression = 0;
+    m_dib_header.compression = NO_COMPRESSION;
 
     m_dib_header.bpp = m_spec.nchannels << 3;
 

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -50,6 +50,12 @@ tiles.
      - int
      - Version of the BMP file format
 
+**Limitations**
+
+* OIIO's current implementation of BMP only supports uncompressed BMP files.
+  RLE compression is not currently supported.
+
+
 |
 
 .. _sec-bundledplugins-cineon:


### PR DESCRIPTION
We would welcome a patch that adds this capability.

