### PR TITLE
Fix exported cmake config, it confused imath and openexr versions

### DIFF
--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -4,7 +4,7 @@ include(CMakeFindDependencyMacro)
 
 # add here all the find_dependency() whenever switching to config based dependencies
 if (@OpenEXR_VERSION@ VERSION_GREATER_EQUAL 3.0)
-    find_dependency(Imath @OpenEXR_VERSION@
+    find_dependency(Imath @Imath_VERSION@
                     HINTS @Imath_DIR@)
 elseif (@OpenEXR_VERSION@ VERSION_GREATER_EQUAL 2.4 AND @FOUND_OPENEXR_WITH_CONFIG@)
     find_dependency(IlmBase @OpenEXR_VERSION@


### PR DESCRIPTION
OpenImageIO's exported config has a dependency on Imath/OpenEXR.  For
Imath 3, I accidentally used OpenEXR_VERSION when I should have said
Imath_VERSION. Makes no differece if they're in sync. But should
somebody downstream have a separately compiled Imath and OpenEXR that
just might be different patch versions, it could break builds by
rejecting if the Imath version appears to be behind the OpenEXR
version. There's no guarantee that Imath and OpenEXR will always be
released exactly in sync.
