### PR TITLE
Improvements to BMP

### DIFF
--- a/src/bmp.imageio/bmp_pvt.h
+++ b/src/bmp.imageio/bmp_pvt.h
@@ -47,7 +47,7 @@ public:
     int32_t fsize;   // size of the BMP file
     int16_t res1;    // reserved
     int16_t res2;    // reserved
-    int32_t offset;  //offset of image data
+    int32_t offset;  // offset of image data (pixels)
 private:
     void swap_endian(void);
 };

--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -20,7 +20,9 @@ public:
     virtual ~BmpInput() { close(); }
     virtual const char* format_name(void) const override { return "bmp"; }
     virtual bool valid_file(const std::string& filename) const override;
-    virtual bool open(const std::string& name, ImageSpec& spec) override;
+    virtual bool open(const std::string& name, ImageSpec& newspec) override;
+    virtual bool open(const std::string& name, ImageSpec& newspec,
+                      const ImageSpec& config) override;
     virtual bool close(void) override;
     virtual bool read_native_scanline(int subimage, int miplevel, int y, int z,
                                       void* data) override;
@@ -33,9 +35,10 @@ private:
     bmp_pvt::DibInformationHeader m_dib_header;
     std::string m_filename;
     std::vector<bmp_pvt::color_table> m_colortable;
-    std::vector<unsigned char> fscanline;  // temp space: read from file
-    int64_t m_image_start;
+    std::vector<unsigned char> fscanline;       // temp space: read from file
+    std::vector<unsigned char> m_uncompressed;  // uncompressed palette image
     bool m_allgray;
+
     void init(void)
     {
         m_padded_scanline_size = 0;
@@ -44,10 +47,13 @@ private:
         m_filename.clear();
         m_colortable.clear();
         m_allgray = false;
+        fscanline.shrink_to_fit();
+        m_uncompressed.shrink_to_fit();
     }
 
-    bool read_color_table(void);
-    bool color_table_is_all_gray(void);
+    bool read_color_table();
+    bool color_table_is_all_gray();
+    bool read_rle_image();
 };
 
 
@@ -89,10 +95,27 @@ BmpInput::valid_file(const std::string& filename) const
 
 
 bool
-BmpInput::open(const std::string& name, ImageSpec& spec)
+BmpInput::open(const std::string& name, ImageSpec& newspec)
+{
+    ImageSpec emptyconfig;
+    return open(name, newspec, emptyconfig);
+}
+
+
+
+bool
+BmpInput::open(const std::string& name, ImageSpec& newspec,
+               const ImageSpec& config)
 {
     // saving 'name' for later use
     m_filename = name;
+
+    // BMP cannot be 1-channel, but config hint "bmp:monochrome_detect" is a
+    // hint to try to detect when all palette entries are gray and pretend
+    // that it's a 1-channel image to allow the calling app to save memory
+    // and time. It does this by default, but setting the hint to 0 turns
+    // this behavior off.
+    bool monodetect = config["bmp:monochrome_detect"].get<int>(1);
 
     m_fd = Filesystem::fopen(m_filename, "rb");
     if (!m_fd) {
@@ -144,9 +167,11 @@ BmpInput::open(const std::string& name, ImageSpec& spec)
         m_padded_scanline_size = (m_spec.width + 3) & ~3;
         if (!read_color_table())
             return false;
-        m_allgray = color_table_is_all_gray();
-        if (m_allgray)
+        m_allgray = monodetect && color_table_is_all_gray();
+        if (m_allgray) {
             m_spec.nchannels = 1;  // make it look like a 1-channel image
+            m_spec.default_channel_names();
+        }
         break;
     case 4:
         swidth                 = (m_spec.width + 1) / 2;
@@ -170,20 +195,87 @@ BmpInput::open(const std::string& name, ImageSpec& spec)
     case WINDOWS_V5: m_spec.attribute("bmp:version", 5); break;
     }
 
+    // Bite the bullet and uncompress now, for simplicity
     if (m_dib_header.compression == RLE4_COMPRESSION
         || m_dib_header.compression == RLE8_COMPRESSION) {
-        errorfmt("BMP compression {} is not currently supported",
-                 m_dib_header.compression);
-        close();
-        return false;
+        if (!read_rle_image()) {
+            errorfmt("BMP error reading rle-compressed image");
+            close();
+            return false;
+        }
     }
 
-    // file pointer is set to the beginning of image data
-    // we save this position - it will be helpfull in read_native_scanline
-    m_image_start = Filesystem::ftell(m_fd);
-
-    spec = m_spec;
+    newspec = m_spec;
     return true;
+}
+
+
+
+bool
+BmpInput::read_rle_image()
+{
+    int rletype = m_dib_header.compression == RLE4_COMPRESSION ? 4 : 8;
+    m_spec.attribute("bmp:compression", rletype == 4 ? "rle4" : "rle8");
+    m_uncompressed.clear();
+    m_uncompressed.resize(m_spec.height * m_spec.width);
+    // Note: the clear+resize zeroes out the buffer
+    bool err = false;
+    int y = 0, x = 0;
+    while (!err && !feof(m_fd)) {
+        unsigned char rle_pair[2];
+        if (fread(rle_pair, 1, 2, m_fd) != 2) {
+            err = true;
+            break;
+        }
+        int npixels = rle_pair[0];
+        int value   = rle_pair[1];
+        if (npixels == 0 && value == 0) {
+            // [0,0] is end of line marker
+            x = 0;
+            ++y;
+        } else if (npixels == 0 && value == 1) {
+            // [0,1] is end of bitmap marker
+            break;
+        } else if (npixels == 0 && value == 2) {
+            // [0,2] is a "delta" -- two more bytes reposition the
+            // current pixel position that we're reading.
+            unsigned char offset[2];
+            err |= (fread(offset, 1, 2, m_fd) != 2);
+            x += offset[0];
+            y += offset[1];
+        } else if (npixels == 0) {
+            // [0,n>2] is an "absolute" run of pixel data.
+            // n is the number of pixel indices that follow, but note
+            // that it pads to word size.
+            int npixels = value;
+            int nbytes  = (rletype == 4)
+                              ? round_to_multiple((npixels + 1) / 2, 2)
+                              : round_to_multiple(npixels, 2);
+            unsigned char absolute[256];
+            err |= (fread(absolute, 1, nbytes, m_fd) != size_t(nbytes));
+            for (int i = 0; i < npixels; ++i, ++x) {
+                if (rletype == 4)
+                    value = (i & 1) ? (absolute[i / 2] & 0x0f)
+                                    : (absolute[i / 2] >> 4);
+                else
+                    value = absolute[i];
+                if (x < m_spec.width)
+                    m_uncompressed[y * m_spec.width + x] = value;
+            }
+        } else {
+            // [n>0,p] is a run of n pixels.
+            for (int i = 0; i < npixels; ++i, ++x) {
+                int v;
+                if (rletype == 4)
+                    v = (i & 1) ? (value & 0x0f) : (value >> 4);
+                else
+                    v = value;
+                if (x < m_spec.width)
+                    m_uncompressed[y * m_spec.width + x] = v;
+            }
+        }
+    }
+    return !err;
 }
 
 
@@ -199,13 +291,26 @@ BmpInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
     if (y < 0 || y > m_spec.height)
         return false;
 
+    size_t scanline_bytes = m_spec.scanline_bytes();
+    uint8_t* mscanline    = (uint8_t*)data;
+    if (m_dib_header.compression == RLE4_COMPRESSION
+        || m_dib_header.compression == RLE8_COMPRESSION) {
+        for (int x = 0; x < m_spec.width; ++x) {
+            int p = m_uncompressed[(m_spec.height - 1 - y) * m_spec.width + x];
+            mscanline[3 * x]     = m_colortable[p].r;
+            mscanline[3 * x + 1] = m_colortable[p].g;
+            mscanline[3 * x + 2] = m_colortable[p].b;
+        }
+        return true;
+    }
+
     // if the height is positive scanlines are stored bottom-up
     if (m_dib_header.height >= 0)
         y = m_spec.height - y - 1;
     const int64_t scanline_off = y * m_padded_scanline_size;
 
     fscanline.resize(m_padded_scanline_size);
-    Filesystem::fseek(m_fd, m_image_start + scanline_off, SEEK_SET);
+    Filesystem::fseek(m_fd, m_bmp_header.offset + scanline_off, SEEK_SET);
     size_t n = fread(fscanline.data(), 1, m_padded_scanline_size, m_fd);
     if (n != (size_t)m_padded_scanline_size) {
         if (feof(m_fd))
@@ -226,8 +331,6 @@ BmpInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
         return true;
     }
 
-    size_t scanline_bytes = m_spec.scanline_bytes();
-    uint8_t* mscanline    = (uint8_t*)data;
     if (m_dib_header.bpp == 16) {
         const uint16_t RED   = 0x7C00;
         const uint16_t GREEN = 0x03E0;

--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -91,7 +91,8 @@ BmpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
     m_filename = name;
     m_spec     = spec;
 
-    if (m_spec.nchannels != 3 && m_spec.nchannels != 4) {
+    if (m_spec.nchannels != 1 && m_spec.nchannels != 3
+        && m_spec.nchannels != 4) {
         errorf("%s does not support %d-channel images\n", format_name(),
                m_spec.nchannels);
         return false;
@@ -113,12 +114,13 @@ BmpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
         return false;
     }
 
+    // Scanline size is rounded up to align to 4-byte boundary
+    m_padded_scanline_size = round_to_multiple(m_spec.scanline_bytes(), 4);
+
     create_and_write_file_header();
     create_and_write_bitmap_header();
 
-    // Scanline size is rounded up to align to 4-byte boundary
-    m_padded_scanline_size = ((m_spec.width * m_spec.nchannels) + 3) & ~3;
-    m_image_start          = Filesystem::ftell(m_fd);
+    m_image_start = Filesystem::ftell(m_fd);
 
     // If user asked for tiles -- which this format doesn't support, emulate
     // it by buffering the whole image.
@@ -201,13 +203,13 @@ void
 BmpOutput::create_and_write_file_header(void)
 {
     m_bmp_header.magic = MAGIC_BM;
-    int64_t data_size  = int64_t(m_spec.width) * m_spec.height
-                        * m_spec.nchannels;
-    int64_t file_size   = data_size + BMP_HEADER_SIZE + WINDOWS_V3;
-    m_bmp_header.fsize  = file_size;
-    m_bmp_header.res1   = 0;
-    m_bmp_header.res2   = 0;
-    m_bmp_header.offset = BMP_HEADER_SIZE + WINDOWS_V3;
+    int64_t data_size  = m_padded_scanline_size * m_spec.height;
+    int palettesize    = (m_spec.nchannels == 1) ? 4 * 256 : 0;
+    int64_t file_size  = data_size + BMP_HEADER_SIZE + WINDOWS_V3 + palettesize;
+    m_bmp_header.fsize = file_size;
+    m_bmp_header.res1  = 0;
+    m_bmp_header.res2  = 0;
+    m_bmp_header.offset = BMP_HEADER_SIZE + WINDOWS_V3 + palettesize;
 
     m_bmp_header.write_header(m_fd);
 }
@@ -223,16 +225,22 @@ BmpOutput::create_and_write_bitmap_header(void)
     m_dib_header.cplanes     = 1;
     m_dib_header.compression = NO_COMPRESSION;
 
-    m_dib_header.bpp = m_spec.nchannels << 3;
+    if (m_spec.nchannels == 1) {
+        // Special case -- write a 1-channel image as a gray palette
+        m_dib_header.bpp       = 8;
+        m_dib_header.cpalete   = 256;
+        m_dib_header.important = 256;
+    } else {
+        m_dib_header.bpp       = m_spec.nchannels * 8;
+        m_dib_header.cpalete   = 0;
+        m_dib_header.important = 0;
+    }
 
-    m_dib_header.isize     = m_spec.width * m_spec.height * m_spec.nchannels;
-    m_dib_header.hres      = 0;
-    m_dib_header.vres      = 0;
-    m_dib_header.cpalete   = 0;
-    m_dib_header.important = 0;
+    m_dib_header.isize = int32_t(m_spec.image_pixels());
+    m_dib_header.hres  = 0;
+    m_dib_header.vres  = 0;
 
-    ParamValue* p = NULL;
-    p             = m_spec.find_attribute("ResolutionUnit", TypeDesc::STRING);
+    ParamValue* p = m_spec.find_attribute("ResolutionUnit", TypeDesc::STRING);
     if (p && p->data()) {
         std::string res_units = *(char**)p->data();
         if (Strutil::iequals(res_units, "m")
@@ -248,6 +256,13 @@ BmpOutput::create_and_write_bitmap_header(void)
     }
 
     m_dib_header.write_header(m_fd);
+
+    // Write palette, if there is one. This is only used for grayscale
+    // images, and the palette is just the 256 possible gray values.
+    for (int i = 0; i < m_dib_header.cpalete; ++i) {
+        unsigned char val[4] = { uint8_t(i), uint8_t(i), uint8_t(i), 255 };
+        fwrite(&val, 1, 4, m_fd);
+    }
 }
 
 OIIO_PLUGIN_NAMESPACE_END

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -24,6 +24,28 @@ It only supports unsigned integer 1-, 2-, 4-, and 8- bits per channel; only
 grayscale, RGB, and RGBA; does not support MIPmaps, multiimage, or
 tiles.
 
+**Configuration settings for BMP input**
+
+When opening a BMP ImageInput with a *configuration* (see
+Section :ref:`sec-inputwithconfig`), the following special configuration
+options are supported:
+
+.. list-table::
+   :widths: 30 10 65
+   :header-rows: 1
+
+   * - Input Configuration Attribute
+     - Type
+     - Meaning
+   * - ``bmp:monochrome_detect``
+     - int
+     - If nonzero, try to detect when all palette entries are gray and pretend
+       that it's a 1-channel image to allow the calling app to save memory
+       and time (even though the BMP format does not actually support
+       grayscale images per se. It is 1 by default, but by setting the hint
+       to 0, you can disable this behavior.
+
+**BMP Attributes**
 
 .. list-table::
    :widths: 30 10 65
@@ -50,11 +72,15 @@ tiles.
      - int
      - Version of the BMP file format
 
-**Limitations**
+**BMP Limitations**
 
-* OIIO's current implementation of BMP only supports uncompressed BMP files.
-  RLE compression is not currently supported.
-
+* OIIO's current implementation will only write uncompessed 8bpp (from a
+  1-channel source), 24bpp (if 3 channel), or 32bpp (if 4 channel). Reads,
+  however, can handle RLE compression as well as 1, 4, or 16 bpp input.
+* Only 1, 3, and 4-channel images are supported with BMP due to limitations
+  of the file format itself.
+* BMP only supports uint8 pixel data types. Requests for other pixel data
+  types will automatically be converted to uint8.
 
 |
 

--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -218,6 +218,8 @@ adjust_spec(ImageInput* in, ImageOutput* out, const ImageSpec& inspec,
     }
     if (outspec.format != inspec.format || inspec.channelformats.size())
         nocopy = true;
+    if (outspec.nchannels != inspec.nchannels)
+        nocopy = true;
 
     outspec.attribute("oiio:Gamma", gammaval);
     if (sRGB) {
@@ -433,6 +435,8 @@ convert_file(const std::string& in_filename, const std::string& out_filename)
                 break;
             }
 
+            if (in->spec().nchannels != out->spec().nchannels)
+                nocopy = true;
             if (!nocopy) {
                 ok = out->copy_image(in.get());
                 if (!ok)

--- a/testsuite/bmp/ref/out.txt
+++ b/testsuite/bmp/ref/out.txt
@@ -6,6 +6,30 @@ Reading ../../../../../bmpsuite/g01bg.bmp
     bmp:version: 3
 Comparing "../../../../../bmpsuite/g01bg.bmp" and "g01bg.bmp"
 PASS
+Reading ../../../../../bmpsuite/g01bw.bmp
+../../../../../bmpsuite/g01bw.bmp :  127 x   64, 3 channel, uint8 bmp
+    SHA-1: A988B301642C3233BCE238EE6752C185E563CD45
+    channel list: R, G, B
+    bmp:bitsperpixel: 1
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g01bw.bmp" and "g01bw.bmp"
+PASS
+Reading ../../../../../bmpsuite/g01p1.bmp
+../../../../../bmpsuite/g01p1.bmp :  127 x   64, 3 channel, uint8 bmp
+    SHA-1: 5B4DD48C2AECF83A293C9044E4A9CC2391C9A297
+    channel list: R, G, B
+    bmp:bitsperpixel: 1
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g01p1.bmp" and "g01p1.bmp"
+PASS
+Reading ../../../../../bmpsuite/g01wb.bmp
+../../../../../bmpsuite/g01wb.bmp :  127 x   64, 3 channel, uint8 bmp
+    SHA-1: A988B301642C3233BCE238EE6752C185E563CD45
+    channel list: R, G, B
+    bmp:bitsperpixel: 1
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g01wb.bmp" and "g01wb.bmp"
+PASS
 Reading ../../../../../bmpsuite/g04.bmp
 ../../../../../bmpsuite/g04.bmp :  127 x   64, 3 channel, uint8 bmp
     SHA-1: E92BEC9CBC28315DBEBDB943608FF72F88F0C8F6
@@ -13,6 +37,23 @@ Reading ../../../../../bmpsuite/g04.bmp
     bmp:bitsperpixel: 4
     bmp:version: 3
 Comparing "../../../../../bmpsuite/g04.bmp" and "g04.bmp"
+PASS
+Reading ../../../../../bmpsuite/g04p4.bmp
+../../../../../bmpsuite/g04p4.bmp :  127 x   64, 3 channel, uint8 bmp
+    SHA-1: 61FED47FD83EDF78D515C3D1EDF50B86F884A13C
+    channel list: R, G, B
+    bmp:bitsperpixel: 4
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g04p4.bmp" and "g04p4.bmp"
+PASS
+Reading ../../../../../bmpsuite/g04rle.bmp
+../../../../../bmpsuite/g04rle.bmp :  127 x   64, 3 channel, uint8 bmp
+    SHA-1: E92BEC9CBC28315DBEBDB943608FF72F88F0C8F6
+    channel list: R, G, B
+    bmp:bitsperpixel: 4
+    bmp:compression: "rle4"
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g04rle.bmp" and "g04rle.bmp"
 PASS
 Reading ../../../../../bmpsuite/g08.bmp
 ../../../../../bmpsuite/g08.bmp :  127 x   64, 3 channel, uint8 bmp
@@ -22,14 +63,127 @@ Reading ../../../../../bmpsuite/g08.bmp
     bmp:version: 3
 Comparing "../../../../../bmpsuite/g08.bmp" and "g08.bmp"
 PASS
-Reading ../../../../../bmpsuite/g16bf555.bmp
-../../../../../bmpsuite/g16bf555.bmp :  127 x   64, 3 channel, uint4 bmp
-    SHA-1: 630022A1DFE41AA6AE07F272E3D441205F612240
+Reading ../../../../../bmpsuite/g08os2.bmp
+../../../../../bmpsuite/g08os2.bmp :  127 x   64, 3 channel, uint8 bmp
+    SHA-1: 18C1DA0C611E94F164B5C0758132EF9CE202DD47
     channel list: R, G, B
-    bmp:bitsperpixel: 16
+    bmp:bitsperpixel: 8
+    bmp:version: 1
+Comparing "../../../../../bmpsuite/g08os2.bmp" and "g08os2.bmp"
+PASS
+Reading ../../../../../bmpsuite/g08p64.bmp
+../../../../../bmpsuite/g08p64.bmp :  127 x   64, 1 channel, uint8 bmp
+    SHA-1: D634C6C0C005436D62D03F4976B22C9BF1E0062D
+    channel list: Y
+    bmp:bitsperpixel: 8
     bmp:version: 3
-    oiio:BitsPerSample: 4
-Comparing "../../../../../bmpsuite/g16bf555.bmp" and "g16bf555.bmp"
+Comparing "../../../../../bmpsuite/g08p64.bmp" and "g08p64.bmp"
+PASS
+Reading ../../../../../bmpsuite/g08p256.bmp
+../../../../../bmpsuite/g08p256.bmp :  127 x   64, 3 channel, uint8 bmp
+    SHA-1: 18C1DA0C611E94F164B5C0758132EF9CE202DD47
+    channel list: R, G, B
+    bmp:bitsperpixel: 8
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g08p256.bmp" and "g08p256.bmp"
+PASS
+Reading ../../../../../bmpsuite/g08pi64.bmp
+../../../../../bmpsuite/g08pi64.bmp :  127 x   64, 3 channel, uint8 bmp
+    SHA-1: 18C1DA0C611E94F164B5C0758132EF9CE202DD47
+    channel list: R, G, B
+    bmp:bitsperpixel: 8
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g08pi64.bmp" and "g08pi64.bmp"
+PASS
+Reading ../../../../../bmpsuite/g08pi256.bmp
+../../../../../bmpsuite/g08pi256.bmp :  127 x   64, 3 channel, uint8 bmp
+    SHA-1: 18C1DA0C611E94F164B5C0758132EF9CE202DD47
+    channel list: R, G, B
+    bmp:bitsperpixel: 8
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g08pi256.bmp" and "g08pi256.bmp"
+PASS
+Reading ../../../../../bmpsuite/g08res11.bmp
+../../../../../bmpsuite/g08res11.bmp :  127 x   64, 3 channel, uint8 bmp
+    SHA-1: 18C1DA0C611E94F164B5C0758132EF9CE202DD47
+    channel list: R, G, B
+    ResolutionUnit: "m"
+    XResolution: 3937
+    YResolution: 3937
+    bmp:bitsperpixel: 8
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g08res11.bmp" and "g08res11.bmp"
+PASS
+Reading ../../../../../bmpsuite/g08res21.bmp
+../../../../../bmpsuite/g08res21.bmp :  127 x   64, 3 channel, uint8 bmp
+    SHA-1: 18C1DA0C611E94F164B5C0758132EF9CE202DD47
+    channel list: R, G, B
+    ResolutionUnit: "m"
+    XResolution: 7874
+    YResolution: 3937
+    bmp:bitsperpixel: 8
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g08res21.bmp" and "g08res21.bmp"
+PASS
+Reading ../../../../../bmpsuite/g08res22.bmp
+../../../../../bmpsuite/g08res22.bmp :  127 x   64, 3 channel, uint8 bmp
+    SHA-1: 18C1DA0C611E94F164B5C0758132EF9CE202DD47
+    channel list: R, G, B
+    ResolutionUnit: "m"
+    XResolution: 7874
+    YResolution: 7874
+    bmp:bitsperpixel: 8
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g08res22.bmp" and "g08res22.bmp"
+PASS
+Reading ../../../../../bmpsuite/g08s0.bmp
+../../../../../bmpsuite/g08s0.bmp :  127 x   64, 3 channel, uint8 bmp
+    SHA-1: 18C1DA0C611E94F164B5C0758132EF9CE202DD47
+    channel list: R, G, B
+    bmp:bitsperpixel: 8
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g08s0.bmp" and "g08s0.bmp"
+PASS
+Reading ../../../../../bmpsuite/g08w124.bmp
+../../../../../bmpsuite/g08w124.bmp :  124 x   61, 3 channel, uint8 bmp
+    SHA-1: 3102F2DD2E0643ED4C186AF8FA2F64BB8A803BE8
+    channel list: R, G, B
+    bmp:bitsperpixel: 8
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g08w124.bmp" and "g08w124.bmp"
+PASS
+Reading ../../../../../bmpsuite/g08w125.bmp
+../../../../../bmpsuite/g08w125.bmp :  125 x   62, 3 channel, uint8 bmp
+    SHA-1: 93118449D8F3D738386568E6E35EF7699199CF6B
+    channel list: R, G, B
+    bmp:bitsperpixel: 8
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g08w125.bmp" and "g08w125.bmp"
+PASS
+Reading ../../../../../bmpsuite/g08w126.bmp
+../../../../../bmpsuite/g08w126.bmp :  126 x   63, 3 channel, uint8 bmp
+    SHA-1: 441A492FF712BC5C7A98785926F607615917246F
+    channel list: R, G, B
+    bmp:bitsperpixel: 8
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g08w126.bmp" and "g08w126.bmp"
+PASS
+Reading ../../../../../bmpsuite/g08rle.bmp
+../../../../../bmpsuite/g08rle.bmp :  127 x   64, 3 channel, uint8 bmp
+    SHA-1: 18C1DA0C611E94F164B5C0758132EF9CE202DD47
+    channel list: R, G, B
+    bmp:bitsperpixel: 8
+    bmp:compression: "rle8"
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g08rle.bmp" and "g08rle.bmp"
+PASS
+Reading ../../../../../bmpsuite/g08offs.bmp
+../../../../../bmpsuite/g08offs.bmp :  127 x   64, 3 channel, uint8 bmp
+    SHA-1: 18C1DA0C611E94F164B5C0758132EF9CE202DD47
+    channel list: R, G, B
+    bmp:bitsperpixel: 8
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g08offs.bmp" and "g08offs.bmp"
 PASS
 Reading ../../../../../bmpsuite/g24.bmp
 ../../../../../bmpsuite/g24.bmp :  127 x   64, 3 channel, uint8 bmp
@@ -40,7 +194,21 @@ Comparing "../../../../../bmpsuite/g24.bmp" and "g24.bmp"
 PASS
 Reading ../../../../../bmpsuite/g32bf.bmp
 ../../../../../bmpsuite/g32bf.bmp :  127 x   64, 4 channel, uint8 bmp
-    SHA-1: AB315E7E66DBE94299A2E0F2749C5947D924B48B
+    SHA-1: D8807C680B17C70CB33B43AC072E0A9121C551B4
+    channel list: R, G, B, A
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g32bf.bmp" and "g32bf.bmp"
+PASS
+Reading ../../../../../bmpsuite/g32def.bmp
+../../../../../bmpsuite/g32def.bmp :  127 x   64, 4 channel, uint8 bmp
+    SHA-1: D8807C680B17C70CB33B43AC072E0A9121C551B4
+    channel list: R, G, B, A
+    bmp:version: 3
+Comparing "../../../../../bmpsuite/g32def.bmp" and "g32def.bmp"
+PASS
+Reading ../../../../../bmpsuite/g32bf.bmp
+../../../../../bmpsuite/g32bf.bmp :  127 x   64, 4 channel, uint8 bmp
+    SHA-1: D8807C680B17C70CB33B43AC072E0A9121C551B4
     channel list: R, G, B, A
     bmp:version: 3
 Comparing "../../../../../bmpsuite/g32bf.bmp" and "g32bf.bmp"

--- a/testsuite/bmp/run.py
+++ b/testsuite/bmp/run.py
@@ -4,10 +4,20 @@
 redirect = " >> out.txt 2>&1 "
 failureok = 1
 
-files = [ "g01bg.bmp", "g04.bmp", "g08.bmp",
-          "g16bf555.bmp", "g24.bmp", "g32bf.bmp" ]
+files = [ "g01bg.bmp", "g01bw.bmp", "g01p1.bmp", "g01wb.bmp",
+          "g04.bmp", "g04p4.bmp", "g04rle.bmp",
+          "g08.bmp", "g08os2.bmp", "g08p64.bmp", "g08p256.bmp",
+          "g08pi64.bmp", "g08pi256.bmp",
+          "g08res11.bmp", "g08res21.bmp", "g08res22.bmp",
+          "g08s0.bmp", "g08w124.bmp", "g08w125.bmp", "g08w126.bmp",
+          "g08rle.bmp", "g08offs.bmp",
+          "g24.bmp", "g32bf.bmp", "g32def.bmp", "g32bf.bmp"
+           ]
 for f in files :
     command += rw_command (OIIO_TESTSUITE_IMAGEDIR, f)
+
+# TODO: seems broken: g16bf555.bmp,
+#                     g16bf565.bmp, g16def555.bmp
 
 # Test BMR version 5
 command += rw_command ("src", "g01bg2-v5.bmp")


### PR DESCRIPTION
* Read RLE-compressed images correcty now! Both 4 and 8 bpp varieties.

* Reading: respect a configuration hint "bmp:monochrome_detect" that if
  set to 0, will disable the detection of monochrome palettes and spoofing
  to look like a single-channel image. The default is 1.

* Writing: Write single channel BMP as 8 bit palette images (not 24/32
  bit images). This fixes a problem I discovered related to the recent
  change that reads 8 bit palette images as if they were single channel.
  The lack of symmetry there made problems for round-tripping an image
  and having it end with the same apparent number of channels as it
  started with.

* Beef up the testsuite/bmp tests, now test against a wider set of sample
  BMP images from bmpsuite (including rle compressed images).

Fixes #2969 