### PR TITLE
Change localtime() calls to Sysutil::get_local_time

### DIFF
--- a/src/cineon.imageio/libcineon/CineonHeader.cpp
+++ b/src/cineon.imageio/libcineon/CineonHeader.cpp
@@ -41,6 +41,7 @@
 #include <limits>
 
 #include <OpenImageIO/strutil.h>
+#include <OpenImageIO/sysutil.h>
 
 #include "CineonHeader.h"
 #include "EndianSwap.h"
@@ -540,7 +541,6 @@ void cineon::IndustryHeader::SetFilmEdgeCode(const char *edge)
 
 void cineon::GenericHeader::SetCreationTimeDate(const long sec)
 {
-	struct tm *tm_time;
 	char str[32];
 
 #ifdef _WIN32
@@ -548,8 +548,9 @@ void cineon::GenericHeader::SetCreationTimeDate(const long sec)
 #endif
 
 	const time_t t = time_t(sec);
-	tm_time = ::localtime(&t);
-	::strftime(str, 32, "%Y:%m:%d:%H:%M:%S%Z", tm_time);
+    struct tm localtm;
+    OIIO::Sysutil::get_local_time(&t, &localtm);
+    ::strftime(str, 32, "%Y:%m:%d:%H:%M:%S%Z", &localtm);
 	OIIO::Strutil::safe_strcpy(this->creationDate, str, 11);
 	OIIO::Strutil::safe_strcpy(this->creationTime, str + 11, 12);
 }
@@ -557,7 +558,6 @@ void cineon::GenericHeader::SetCreationTimeDate(const long sec)
 
 void cineon::GenericHeader::SetSourceTimeDate(const long sec)
 {
-	struct tm *tm_time;
 	char str[32];
 
 #ifdef _WIN32
@@ -565,8 +565,9 @@ void cineon::GenericHeader::SetSourceTimeDate(const long sec)
 #endif
 
 	const time_t t = time_t(sec);
-	tm_time = ::localtime(&t);
-	::strftime(str, 32, "%Y:%m:%d:%H:%M:%S%Z", tm_time);
+    struct tm localtm;
+    OIIO::Sysutil::get_local_time(&t, &localtm);
+    ::strftime(str, 32, "%Y:%m:%d:%H:%M:%S%Z", &localtm);
 	OIIO::Strutil::safe_strcpy(this->sourceDate, str, 11);
 	OIIO::Strutil::safe_strcpy(this->sourceTime, str + 11, 12);
 }

--- a/src/dpx.imageio/libdpx/DPXHeader.cpp
+++ b/src/dpx.imageio/libdpx/DPXHeader.cpp
@@ -40,6 +40,7 @@
 #include <ctime>
 #include <limits>
 
+#include <OpenImageIO/sysutil.h>
 
 #include "DPXHeader.h"
 #include "EndianSwap.h"
@@ -764,32 +765,32 @@ static void EmptyString(char *str, const int len)
 
 void dpx::GenericHeader::SetCreationTimeDate(const long sec)
 {
-	struct tm *tm_time;
-	char str[32];
-	
+    char str[32];
+
 #ifdef _WIN32
 	_tzset();
 #endif
 
-	const time_t t = time_t(sec);
-	tm_time = ::localtime(&t);
-	::strftime(str, 32, "%Y:%m:%d:%H:%M:%S%Z", tm_time);
+    const time_t t = time_t(sec);
+    struct tm localtm;
+    OIIO::Sysutil::get_local_time(&t, &localtm);
+    ::strftime(str, 32, "%Y:%m:%d:%H:%M:%S%Z", &localtm);
 	OIIO::Strutil::safe_strcpy(this->creationTimeDate, str, 24);
 }
 
 
 void dpx::GenericHeader::SetSourceTimeDate(const long sec)
 {
-	struct tm *tm_time;
-	char str[32];
-	
+    char str[32];
+
 #ifdef _WIN32
 	_tzset();
 #endif
 
-	const time_t t = time_t(sec);
-	tm_time = ::localtime(&t);
-	::strftime(str, 32, "%Y:%m:%d:%H:%M:%S%Z", tm_time);
+    const time_t t = time_t(sec);
+    struct tm localtm;
+    OIIO::Sysutil::get_local_time(&t, &localtm);
+    ::strftime(str, 32, "%Y:%m:%d:%H:%M:%S%Z", &localtm);
 	OIIO::Strutil::safe_strcpy(this->sourceTimeDate, str, 24);
 }
 

--- a/src/include/OpenImageIO/sysutil.h
+++ b/src/include/OpenImageIO/sysutil.h
@@ -53,7 +53,8 @@ OIIO_API size_t
 physical_memory();
 
 /// Convert calendar time pointed by 'time' into local time and save it in
-/// 'converted_time' variable
+/// 'converted_time' variable. This is a fully reentrant/thread-safe
+/// alternative to the non-reentrant C localtime() call.
 OIIO_API void
 get_local_time(const time_t* time, struct tm* converted_time);
 

--- a/src/rla.imageio/rla_pvt.h
+++ b/src/rla.imageio/rla_pvt.h
@@ -49,6 +49,9 @@
   * RLA files are "big endian" for all 16 and 32 bit data: header fields,
     offsets, and pixel data.
 
+  * References:
+      - https://www.fileformat.info/format/wavefrontrla/egff.htm
+
  */
 
 

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -337,16 +337,10 @@ RLAOutput::open(const std::string& name, const ImageSpec& userspec,
 
     // the month number will be replaced with the 3-letter abbreviation
     time_t t = time(NULL);
-    strftime(m_rla.DateCreated, sizeof(m_rla.DateCreated), "%m  %d %H:%M %Y",
-             localtime(&t));
-    // nice little trick - stoi() will convert the month number to integer,
-    // which we then use to index this array of constants, and copy the
-    // abbreviation back into the date string
-    int m = clamp(Strutil::stoi(m_rla.DateCreated), 1, 12);
-    static const char months[12][4] = { "JAN", "FEB", "MAR", "APR",
-                                        "MAY", "JUN", "JUL", "AUG",
-                                        "SEP", "OCT", "NOV", "DEC" };
-    memcpy(m_rla.DateCreated, months[m - 1], 3);
+    struct tm localtm;
+    Sysutil::get_local_time(&t, &localtm);
+    strftime(m_rla.DateCreated, sizeof(m_rla.DateCreated), "%b %d %H:%M %Y",
+             &localtm);
 
     // FIXME: it appears that Wavefront have defined a set of aspect names;
     // I think it's safe not to care until someone complains


### PR DESCRIPTION
We still had a few stray localtime() calls (which is not reentrant,
because it depends on a global buffer), even though all along we had a
"safe" wrapper in Sysutil::get_local_time, which internally calls safe
versions localtime_r or localtime_s (depending on the OS).
