### PR TITLE
Build: FindOpenJPEG.cmake improvements

### DIFF
--- a/src/build-scripts/build_OpenJPEG.bash
+++ b/src/build-scripts/build_OpenJPEG.bash
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# Utility script to download and build OpenJPEG
+#
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/OpenImageIO/oiio
+
+# Exit the whole script if any command fails.
+set -ex
+
+# Repo and branch/tag/commit of OpenJPEG to download if we don't have it yet
+OPENJPEG_REPO=${OPENJPEG_REPO:=https://github.com/uclouvain/openjpeg.git}
+OPENJPEG_VERSION=${OPENJPEG_VERSION:=v2.4.0}
+
+# Where to put OpenJPEG repo source (default to the ext area)
+LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}
+OPENJPEG_SRC_DIR=${OPENJPEG_SRC_DIR:=${LOCAL_DEPS_DIR}/OpenJPEG}
+OPENJPEG_BUILD_DIR=${OPENJPEG_BUILD_DIR:=${OPENJPEG_SRC_DIR}/build}
+OPENJPEG_INSTALL_DIR=${OPENJPEG_INSTALL_DIR:=${LOCAL_DEPS_DIR}/dist}
+#OPENJPEG_CONFIG_OPTS=${OPENJPEG_CONFIG_OPTS:=}
+
+pwd
+echo "OpenJPEG install dir will be: ${OPENJPEG_INSTALL_DIR}"
+
+mkdir -p ./ext
+pushd ./ext
+
+# Clone OpenJPEG project from GitHub and build
+if [[ ! -e ${OPENJPEG_SRC_DIR} ]] ; then
+    echo "git clone ${OPENJPEG_REPO} ${OPENJPEG_SRC_DIR}"
+    git clone ${OPENJPEG_REPO} ${OPENJPEG_SRC_DIR}
+fi
+cd ${OPENJPEG_SRC_DIR}
+echo "git checkout ${OPENJPEG_VERSION} --force"
+git checkout ${OPENJPEG_VERSION} --force
+
+mkdir -p ${OPENJPEG_BUILD_DIR} && true
+cd ${OPENJPEG_BUILD_DIR}
+time cmake -DCMAKE_BUILD_TYPE=Release \
+           -DCMAKE_INSTALL_PREFIX=${OPENJPEG_INSTALL_DIR} \
+           -DBUILD_CODEC=OFF \
+           ${OPENJPEG_CONFIG_OPTS} ..
+time cmake --build . --config Release --target install
+
+# ls -R ${OPENJPEG_INSTALL_DIR}
+popd
+
+
+# Set up paths. These will only affect the caller if this script is
+# run with 'source' rather than in a separate shell.
+export OpenJPEG_ROOT=$OPENJPEG_INSTALL_DIR
+

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -190,7 +190,7 @@ checked_find_package (LibRaw
                       RECOMMEND_MIN 0.18
                       RECOMMEND_MIN_REASON "for ACES support and better camera metadata"
                       PRINT LibRaw_r_LIBRARIES )
-checked_find_package (OpenJpeg VERSION_MIN 2.0)
+checked_find_package (OpenJPEG VERSION_MIN 2.0)
 
 checked_find_package (OpenVDB
                       VERSION_MIN 5.0

--- a/src/cmake/modules/FindOpenJPEG.cmake
+++ b/src/cmake/modules/FindOpenJPEG.cmake
@@ -1,7 +1,7 @@
 # Module to find OpenJpeg.
 #
 # This module will first look into the directories defined by the variables:
-#   - OpenJpeg_ROOT
+#   - OpenJPEG_ROOT
 #
 # This module defines the following variables:
 #
@@ -83,21 +83,21 @@ set (OpenJpeg_library_paths
   /sw/lib
   /opt/local/lib)
 
-if (OpenJpeg_ROOT)
+if (OpenJPEG_ROOT)
   set (OpenJpeg_library_paths
-       ${OpenJpeg_ROOT}/lib
-       ${OpenJpeg_ROOT}/lib64
-       ${OpenJpeg_ROOT}/bin
+       ${OpenJPEG_ROOT}/lib
+       ${OpenJPEG_ROOT}/lib64
+       ${OpenJPEG_ROOT}/bin
        ${OpenJpeg_library_paths}
       )
   set (OpenJpeg_include_paths
-       ${OpenJpeg_ROOT}/include/openjpeg-2.4
-       ${OpenJpeg_ROOT}/include/openjpeg-2.3
-       ${OpenJpeg_ROOT}/include/openjpeg-2.2
-       ${OpenJpeg_ROOT}/include/openjpeg-2.1
-       ${OpenJpeg_ROOT}/include/openjpeg-2.0
-       ${OpenJpeg_ROOT}/include/openjpeg
-       ${OpenJpeg_ROOT}/include
+       ${OpenJPEG_ROOT}/include/openjpeg-2.4
+       ${OpenJPEG_ROOT}/include/openjpeg-2.3
+       ${OpenJPEG_ROOT}/include/openjpeg-2.2
+       ${OpenJPEG_ROOT}/include/openjpeg-2.1
+       ${OpenJPEG_ROOT}/include/openjpeg-2.0
+       ${OpenJPEG_ROOT}/include/openjpeg
+       ${OpenJPEG_ROOT}/include
        ${OpenJpeg_include_paths}
       )
 endif()


### PR DESCRIPTION
Rename FindOpenJpeg -> FindOpenJPEG to match the conventions used by
that project, in particular for its exported CMake config files.

(We don't yet rely on their exported configs, I need to do some
homework to see if they exist and are reliable as far back as the
oldest OpenJPEG release that we support.)
