### PR TITLE
Avoid divide-by-0 error computing chunk size for invalid image sizes

### DIFF
--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -205,6 +205,13 @@ BmpInput::open(const std::string& name, ImageSpec& newspec,
         }
     }
 
+    if (m_spec.width < 1 || m_spec.height < 1 || m_spec.nchannels < 1
+        || m_spec.image_bytes() < 1) {
+        errorfmt("Invalid image size {} x {} ({} chans, {})", m_spec.width,
+                 m_spec.height, m_spec.nchannels, m_spec.format);
+        return false;
+    }
+
     newspec = m_spec;
     return true;
 }

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -277,6 +277,11 @@ ImageInput::read_scanlines(int subimage, int miplevel, int ybegin, int yend,
         if (!spec.tile_width)
             rps = m_spec.get_int_attribute("tiff:RowsPerStrip", 64);
     }
+    if (spec.image_bytes() < 1) {
+        errorfmt("Invalid image size {} x {} ({} chans)", m_spec.width,
+                 m_spec.height, m_spec.nchannels);
+        return false;
+    }
 
     chend                     = clamp(chend, chbegin + 1, spec.nchannels);
     int nchans                = chend - chbegin;
@@ -895,6 +900,11 @@ ImageInput::read_image(int subimage, int miplevel, int chbegin, int chend,
         // For scanline files, we also need one piece of metadata
         if (!spec.tile_width)
             rps = m_spec.get_int_attribute("tiff:RowsPerStrip", 64);
+    }
+    if (spec.image_bytes() < 1) {
+        errorfmt("Invalid image size {} x {} ({} chans)", m_spec.width,
+                 m_spec.height, m_spec.nchannels);
+        return false;
     }
 
     if (chend < 0)


### PR DESCRIPTION
In ImageInput::read_scanlines and read_image, if somehow the image has
a spec with 0 size, it will lead to a divide by zero error. Check this
and fail safely.

For BMP in particular, do some sanity checks to catch corrupted headers.

Fixes #2982
