### PR TITLE
Clarify behavior of color conversion on image with > 4 channels

### DIFF
--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -1596,6 +1596,10 @@ bool OIIO_API erode (ImageBuf &dst, const ImageBuf &src,
 /// a color space transformation. In-place operations (`dst` == `src`) are
 /// supported.
 ///
+/// The first three channels are presumed to be the color to be
+/// transformed, and the fourth channel (if it exists) is presumed to be
+/// alpha. Any additional channels will be simply copied unaltered.
+///
 /// If OIIO was built with OpenColorIO support enabled, then the
 /// transformation may be between any two spaces supported by the active
 /// OCIO configuration, or may be a "look" transformation created by
@@ -1672,6 +1676,10 @@ inline bool colorconvert (float *color, int nchannels,
 /// transform specified by a 4x4 matrix.  In-place operations
 /// (`dst` == `src`) are supported.
 ///
+/// The first three channels are presumed to be the color to be
+/// transformed, and the fourth channel (if it exists) is presumed to be
+/// alpha. Any additional channels will be simply copied unaltered.
+///
 /// @param  M
 ///             A 4x4 matrix. Following Imath conventions, the color is a
 ///             row vector and the matrix has the "translation" part in
@@ -1698,6 +1706,10 @@ bool OIIO_API colormatrixtransform (ImageBuf &dst, const ImageBuf &src,
 /// Return a copy of the pixels of `src` within the ROI, applying an
 /// OpenColorIO "look" transform to the pixel values. In-place operations
 /// (`dst` == `src`) are supported.
+///
+/// The first three channels are presumed to be the color to be
+/// transformed, and the fourth channel (if it exists) is presumed to be
+/// alpha. Any additional channels will be simply copied unaltered.
 ///
 /// @param  looks
 ///             The looks to apply (comma-separated).
@@ -1740,6 +1752,10 @@ bool OIIO_API ociolook (ImageBuf &dst, const ImageBuf &src, string_view looks,
 /// Return the pixels of `src` within the ROI, applying an OpenColorIO
 /// "display" transform to the pixel values. In-place operations
 /// (`dst` == `src`) are supported.
+///
+/// The first three channels are presumed to be the color to be
+/// transformed, and the fourth channel (if it exists) is presumed to be
+/// alpha. Any additional channels will be simply copied unaltered.
 ///
 /// @param  display
 ///             The OCIO "display" to apply. If this is the empty string,
@@ -1793,6 +1809,10 @@ bool OIIO_API ociodisplay (ImageBuf &dst, const ImageBuf &src,
 
 /// Return the pixels of `src` within the ROI, applying an OpenColorIO
 /// "file" transform. In-place operations (`dst` == `src`) are supported.
+///
+/// The first three channels are presumed to be the color to be
+/// transformed, and the fourth channel (if it exists) is presumed to be
+/// alpha. Any additional channels will be simply copied unaltered.
 ///
 /// @param  name
 ///             The name of the file containing the transform information.


### PR DESCRIPTION
The docs were ambiguous about what would happen for many-channel
images, and the behavor in fact was to copy and color transform only up
to the first 4 channels, leaving additional channels in the
destination undefined (though in practice they turned out black).

Clarify now that for colorconvert, colormatrixtransform, ociolook,
ociodisplay, and ociofiletransform, the first 4 channels are assumed
to be RGBA to undergo the transformation, and any additional channels
will be copied unaltered from source to destination (not set to black).
