### PR TITLE
Fix ustring crash on M1 (ARM) based Mac.

### DIFF
--- a/src/libutil/ustring.cpp
+++ b/src/libutil/ustring.cpp
@@ -376,7 +376,11 @@ ustring::TableRep::TableRep(string_view strref, size_t hash)
     OIIO_DASSERT(str.c_str() == c_str() && str.size() == length);
     return;
 
-#elif defined(_LIBCPP_VERSION)
+#elif defined(_LIBCPP_VERSION) && !defined(__aarch64__)
+    // FIXME -- we seem to do the wrong thing with libcpp on Mac M1. Disable
+    // when on aarch64 for now. Come back and fix then when I have easier
+    // access to an M1 Mac.
+    //
     // libc++ uses a different std::string representation than gcc.  For
     // long char sequences, it's two size_t's (capacity & length) followed
     // by the pointer to allocated characters. (Gory detail: see the


### PR DESCRIPTION
There's something wrong with the behind the scenes tricks we're using
to doctor the internal string representation. Is it because of big
endian?  The "alternate" string rep? Something else different on
Apple's libc++ on M1?

Fix for now by just disabling that clause. The only harm is that
ustring internals will take more memory on that platform. That's
better than crashing!

When I have more hands-on access to an M1 (or when GitHub Actions
supports running CI tests on M1), I'll return to this for a proper
fix.

Fixes #2858