### PR TITLE
make_texture now detects and rejects deep images

### DIFF
--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1004,6 +1004,11 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     }
     OIIO_DASSERT(src.get());
 
+    if (src->deep()) {
+        errorfmt("Deep images cannot be turned into textures.");
+        return false;
+    }
+
     if (!outputfilename.length()) {
         std::string fn = src->name();
         if (fn.length()) {


### PR DESCRIPTION
It's meaningless to try to use make_texture on input images that are
"deep".  We never even thought to check for this, which led to a
cascade of problems resulting in a segfault.

Fixes #2950
