### PR TITLE
Fix redundant error message for maketx and oiiotool -otex

### DIFF
--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -504,9 +504,9 @@ main(int argc, char* argv[])
         mode = ImageBufAlgo::MakeTxBumpWithSlopes;
 
     bool ok = ImageBufAlgo::make_texture(mode, filenames[0], outputfilename,
-                                         configspec, &std::cout);
+                                         configspec);
     if (!ok)
-        std::cout << OIIO::geterror() << "\n";
+        std::cout << "make_texture ERROR: " << OIIO::geterror() << "\n";
     if (runstats)
         std::cout << "\n" << ic->getstats();
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4975,8 +4975,8 @@ output_file(int /*argc*/, const char* argv[])
             mode = ImageBufAlgo::MakeTxBumpWithSlopes;
         // if (lightprobemode)
         //     mode = ImageBufAlgo::MakeTxEnvLatlFromLightProbe;
-        ok = ImageBufAlgo::make_texture(mode, (*ir)(0, 0), filename, configspec,
-                                        &std::cout);
+        ok = ImageBufAlgo::make_texture(mode, (*ir)(0, 0), filename,
+                                        configspec);
         if (!ok) {
             ot.errorfmt(command, "Could not make texture: {}",
                         OIIO::geterror());


### PR DESCRIPTION
We were double-printing error messages. If maketx/oiiotool is itself
printing errors returned by IBA::make_texture, it is not necessary to
pass std::cout to make_texture so that it can echo the message to the
console itself.
