### PR TITLE
Raise giflib minimum to 5.0 and spruce up

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,8 +48,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
    or for capturing images from a camera:
      * OpenCV 2.x, 3.x, or 4.x (tested through 4.5)
  * If you want support for GIF images:
-     * giflib >= 4.1 (tested through 5.2; 5.0+ is strongly recommended for
-       stability and thread safety)
+     * **giflib >= 5.0** (tested through 5.2)
  * If you want support for HEIF/HEIC or AVIF images:
      * libheif >= 1.3 (1.7 required for AVIF support, tested through 1.11)
      * libheif must be built with an AV1 encoder/decoder for AVIF support.

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -170,9 +170,7 @@ checked_find_package (Field3D
                    DEPS         HDF5
                    DEFINITIONS  -DUSE_FIELD3D=1)
 checked_find_package (GIF
-                      VERSION_MIN 4
-                      RECOMMEND_MIN 5.0
-                      RECOMMEND_MIN_REASON "for stability and thread safety")
+                      VERSION_MIN 5)
 
 # For HEIF/HEIC/AVIF formats
 checked_find_package (Libheif VERSION_MIN 1.3

--- a/src/gif.imageio/CMakeLists.txt
+++ b/src/gif.imageio/CMakeLists.txt
@@ -4,8 +4,7 @@
 
 if (GIF_FOUND)
     add_oiio_plugin (gifinput.cpp gifoutput.cpp
-                     INCLUDE_DIRS ${GIF_INCLUDE_DIRS}
-                     LINK_LIBRARIES ${GIF_LIBRARIES}
+                     LINK_LIBRARIES GIF::GIF
                      DEFINITIONS "-DUSE_GIF")
 else()
     message (WARNING "GIF plugin will not be built")

--- a/src/gif.imageio/gifoutput.cpp
+++ b/src/gif.imageio/gifoutput.cpp
@@ -74,7 +74,7 @@ gif_output_imageio_create()
     return new GIFOutput;
 }
 
-OIIO_EXPORT const char* gif_output_extensions[] = { "gif", NULL };
+OIIO_EXPORT const char* gif_output_extensions[] = { "gif", nullptr };
 
 OIIO_PLUGIN_EXPORTS_END
 
@@ -89,7 +89,7 @@ GIFOutput::open(const std::string& name, const ImageSpec& newspec,
     }
 
     if (mode == AppendMIPLevel) {
-        errorf("%s does not support MIP levels", format_name());
+        errorfmt("{} does not support MIP levels", format_name());
         return false;
     }
 
@@ -111,7 +111,7 @@ bool
 GIFOutput::open(const std::string& name, int subimages, const ImageSpec* specs)
 {
     if (subimages < 1) {
-        errorf("%s does not support %d subimages.", format_name(), subimages);
+        errorfmt("{} does not support {} subimages.", format_name(), subimages);
         return false;
     }
 
@@ -145,19 +145,20 @@ GIFOutput::start_subimage()
 {
     // Check for things this format doesn't support
     if (m_spec.width < 1 || m_spec.height < 1) {
-        errorf("Image resolution must be at least 1x1, you asked for %d x %d",
-               m_spec.width, m_spec.height);
+        errorfmt("Image resolution must be at least 1x1, you asked for {} x {}",
+                 m_spec.width, m_spec.height);
         return false;
     }
     if (m_spec.depth < 1)
         m_spec.depth = 1;
     if (m_spec.depth > 1) {
-        errorf("%s does not support volume images (depth > 1)", format_name());
+        errorfmt("{} does not support volume images (depth > 1)",
+                 format_name());
         return false;
     }
     if (m_spec.nchannels != 3 && m_spec.nchannels != 4) {
-        errorf("%s does not support %d-channel images", format_name(),
-               m_spec.nchannels);
+        errorfmt("{} does not support {}-channel images", format_name(),
+                 m_spec.nchannels);
         return false;
     }
 
@@ -168,7 +169,7 @@ GIFOutput::start_subimage()
                            m_spec.height, m_delay, 8 /*bit depth*/,
                            true /*dither*/);
         if (!ok) {
-            errorf("Could not open \"%s\"", m_filename);
+            errorfmt("Could not open \"{}\"", m_filename);
             return false;
         }
     }


### PR DESCRIPTION
* Raise minimum GIFLib to 5.0. That was back in 2012, so there's really no
  reason for us to support 4.x any longer.
* Remove cruft no longer necessary.
* While I was in there, update error calls to the new format convention,
  and change some old NULL to nullptr.

This will only go into master / 2.3, it will not change the minimum
dependency of released branches.

