### PR TITLE
gcc 11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,10 +359,10 @@ jobs:
   linux-bleeding-edge:
     # Test against development master for relevant dependencies, latest
     # supported releases of everything else.
-    name: "Linux bleeding edge: gcc10 C++20 py38 avx2 OCIO/libtiff/exr master"
+    name: "Linux bleeding edge: gcc11 C++20 py38 avx2 OCIO/libtiff/exr master"
     runs-on: ubuntu-20.04
     env:
-      CXX: g++-10
+      CXX: g++-11
       CMAKE_CXX_STANDARD: 20
       USE_SIMD: avx2,f16c
       LIBRAW_VERSION: master

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * **C++14** (also builds with C++17, and C++20)
      * The default build mode is C++14. This can be controlled by via the
        CMake configuration flag: `-DCMAKE_CXX_STANDARD=17`, etc.
- * Compilers: **gcc 6.1 - 10.2**, **clang 3.4 - 12**, **MSVS 2017 - 2019**, **icc 17+**.
+ * Compilers: **gcc 6.1 - 11.1**, **clang 3.4 - 12**, **MSVS 2017 - 2019**, **icc 17+**.
  * CMake >= 3.12 (tested through 3.20)
  * OpenEXR/Imath >= 2.0 (recommended: 2.2 or higher; tested through 3.0)
  * libTIFF >= 3.9 (recommended: 4.0+; tested through 4.3)
@@ -28,7 +28,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * Qt >= 5.6 (tested through 5.15)
      * OpenGL
  * If you are building the Python bindings or running the testsuite:
-     * Python >= 2.7 (tested against 2.7, 3.6, 3.7, 3.8)
+     * Python >= 2.7 (tested against 2.7, 3.6, 3.7, 3.8, 3.9)
      * pybind11 >= 2.4.2 (Tested through 2.6.)
      * NumPy
  * If you want support for camera "RAW" formats:

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -67,6 +67,8 @@ else
         time sudo apt-get install -y g++-9
     elif [[ "$CXX" == "g++-10" ]] ; then
         time sudo apt-get install -y g++-10
+    elif [[ "$CXX" == "g++-11" ]] ; then
+        time sudo apt-get install -y g++-11
     fi
 
 fi

--- a/src/include/OpenImageIO/string_view.h
+++ b/src/include/OpenImageIO/string_view.h
@@ -99,12 +99,12 @@ public:
     /// Construct from std::string. Remember that a string_view doesn't have
     /// its own copy of the characters, so don't use the `string_view` after
     /// the original string has been destroyed or altered.
-    OIIO_CONSTEXPR20 string_view(const std::string& str) noexcept
+    string_view(const std::string& str) noexcept
         : m_chars(str.data()), m_len(str.size()) { }
     // N.B. std::string::size() is constexpr starting with C++20.
 
     /// Convert a string_view to a `std::string`.
-    OIIO_CONSTEXPR20 std::string str() const
+    std::string str() const
     {
         return (m_chars ? std::string(m_chars, m_len) : std::string());
         // N.B. std::string ctr from chars+len is constexpr in C++20.
@@ -134,7 +134,7 @@ public:
     OIIO_CONSTEXPR14 string_view& operator=(const string_view& copy) noexcept = default;
 
     /// Convert a string_view to a `std::string`.
-    OIIO_CONSTEXPR20 operator std::string() const { return str(); }
+    operator std::string() const { return str(); }
 
     // iterators
     constexpr iterator begin() const noexcept { return m_chars; }

--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -7,6 +7,8 @@
 /// Implementation of ImageBufAlgo algorithms related to OpenCV.
 /// These are nonfunctional if OpenCV is not found at build time.
 
+#include <OpenImageIO/platform.h>
+
 #ifdef USE_OPENCV
 #    include <opencv2/core/version.hpp>
 #    ifdef CV_VERSION_EPOCH
@@ -17,6 +19,10 @@
 #        define OIIO_OPENCV_VERSION                            \
             (10000 * CV_VERSION_MAJOR + 100 * CV_VERSION_MINOR \
              + CV_VERSION_REVISION)
+#    endif
+#    if OIIO_GNUC_VERSION >= 110000 && OIIO_CPLUSPLUS_VERSION >= 20
+// Suppress gcc 11 / C++20 errors about opencv 4 headers
+#        pragma GCC diagnostic ignored "-Wdeprecated-enum-enum-conversion"
 #    endif
 #    include <opencv2/opencv.hpp>
 #    if OIIO_OPENCV_VERSION >= 40000

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -8,7 +8,13 @@
 #include <iostream>
 #include <string>
 
+#include <OpenImageIO/platform.h>
+
 #if USE_OPENCV
+// Suppress gcc 11 / C++20 errors about opencv 4 headers
+#    if OIIO_GNUC_VERSION >= 110000 && OIIO_CPLUSPLUS_VERSION >= 20
+#        pragma GCC diagnostic ignored "-Wdeprecated-enum-enum-conversion"
+#    endif
 #    include <opencv2/opencv.hpp>
 #endif
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5152,7 +5152,12 @@ crash_me()
 {
     size_t a   = 37;
     char* addr = (char*)a;
-    *addr      = 0;  // This should crash
+    OIIO_PRAGMA_WARNING_PUSH
+#if OIIO_GNUC_VERSION >= 110000 && OIIO_CPLUSPLUS_VERSION >= 20
+    OIIO_GCC_ONLY_PRAGMA(GCC diagnostic ignored "-Wstringop-overflow")
+#endif
+    *addr = 0;  // This should crash
+    OIIO_PRAGMA_WARNING_POP
 }
 
 


### PR DESCRIPTION
* Use g++11 on the bleeding edge CI test
* Remove OIIO_CONSTEXPR20 decls from string_view -- gcc 11, even in
  C++20 mode, doesn't have std::string fully constexpr plumbed, it's
  not ready for this.
* Suppress gcc11 warnings about arithmetic with enums that occur in the
  OpenCV headers.
* Suppress gcc11 warning (correct) in the spot where we were trying to
  force a crash for testing purposes.
