### PR TITLE
More exception safety in Filesystem directory iteration

### DIFF
--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -222,11 +222,14 @@ Filesystem::searchpath_find(const std::string& filename_utf8,
 
         if (recursive && filesystem::is_directory(d, ec)) {
             std::vector<std::string> subdirs;
-            for (filesystem::directory_iterator s(d, ec), end_iter;
-                 !ec && s != end_iter; ++s) {
-                if (filesystem::is_directory(s->path(), ec)) {
-                    subdirs.push_back(pathstr(s->path()));
+            try {
+                for (filesystem::directory_iterator s(d, ec), end_iter;
+                     !ec && s != end_iter; s.increment(ec)) {
+                    if (filesystem::is_directory(s->path(), ec)) {
+                        subdirs.push_back(pathstr(s->path()));
+                    }
                 }
+            } catch (...) {
             }
             std::string found = searchpath_find(filename_utf8, subdirs, false,
                                                 true);
@@ -253,26 +256,25 @@ Filesystem::get_directory_entries(const std::string& dirname,
     std::regex re;
     try {
         re = std::regex(filter_regex);
+        if (recursive) {
+            error_code ec;
+            for (filesystem::recursive_directory_iterator s(dirpath, ec), end;
+                 !ec && s != end; s.increment(ec)) {
+                std::string file = pathstr(s->path());
+                if (!filter_regex.size() || std::regex_search(file, re))
+                    filenames.push_back(file);
+            }
+        } else {
+            error_code ec;
+            for (filesystem::directory_iterator s(dirpath, ec), end;
+                 !ec && s != end; s.increment(ec)) {
+                std::string file = pathstr(s->path());
+                if (!filter_regex.size() || std::regex_search(file, re))
+                    filenames.push_back(file);
+            }
+        }
     } catch (...) {
         return false;
-    }
-
-    if (recursive) {
-        error_code ec;
-        for (filesystem::recursive_directory_iterator s(dirpath, ec);
-             !ec && s != filesystem::recursive_directory_iterator(); ++s) {
-            std::string file = pathstr(s->path());
-            if (!filter_regex.size() || std::regex_search(file, re))
-                filenames.push_back(file);
-        }
-    } else {
-        error_code ec;
-        for (filesystem::directory_iterator s(dirpath, ec);
-             !ec && s != filesystem::directory_iterator(); ++s) {
-            std::string file = pathstr(s->path());
-            if (!filter_regex.size() || std::regex_search(file, re))
-                filenames.push_back(file);
-        }
     }
     return true;
 }


### PR DESCRIPTION
When using filesystem::directory_iterator, I was using operator++,
which can throw exceptions for OS errors. I should have used
increment(ec) instead. Throw in a surrounding try/catch just in case,
since even increment is not marked as noexcept.
