### PR TITLE
Clang + C++17 + LibRaw < 0.20 don't mutually get along

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,7 +34,8 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * NumPy
  * If you want support for camera "RAW" formats:
      * LibRaw >= 0.15 (tested 0.15 - 0.20; LibRaw >= 0.18 is necessary for
-       ACES support and much better recognition of camera metadata)
+       ACES support and much better recognition of camera metadata; if
+       building with C++17 or higher, LibRaw >= 0.20 is necessary)
  * If you want support for a wide variety of video formats:
      * ffmpeg >= 2.6 (tested through 4.4)
  * If you want support for jpeg 2000 images:

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -186,7 +186,16 @@ endif ()
 checked_find_package (LibRaw
                       RECOMMEND_MIN 0.18
                       RECOMMEND_MIN_REASON "for ACES support and better camera metadata"
-                      PRINT LibRaw_r_LIBRARIES )
+                      PRINT LibRaw_r_LIBRARIES)
+if (LibRaw_FOUND AND LibRaw_VERSION VERSION_LESS 0.20 AND CMAKE_CXX_STANDARD VERSION_GREATER_EQUAL 17)
+    message (STATUS "${ColorYellow}WARNING When building for C++17, LibRaw should be 0.20 or higher (found ${LibRaw_VERSION}). You may get errors, depending on the compiler.${ColorReset}")
+    # Currently, we issue the above warning and let them take their chances.
+    # If we wish to disable the LibRaw<0.20/C++17 combination that may fail,
+    # just uncomment the following two lines.
+    # set (LibRaw_FOUND 0)
+    # set (LIBRAW_FOUND 0)
+endif ()
+
 checked_find_package (OpenJPEG VERSION_MIN 2.0)
 
 checked_find_package (OpenVDB

--- a/src/cmake/modules/FindLibRaw.cmake
+++ b/src/cmake/modules/FindLibRaw.cmake
@@ -86,10 +86,6 @@ MARK_AS_ADVANCED(LibRaw_VERSION_STRING
 
 if (LINKSTATIC)
     # Necessary?
-    find_package (Jasper)
-    if (JASPER_FOUND)
-        set (LibRaw_r_LIBRARIES ${LibRaw_r_LIBRARIES} ${JASPER_LIBRARIES})
-    endif()
     find_library (LCMS2_LIBRARIES NAMES lcms2)
     if (LCMS2_LIBRARIES)
         set (LibRaw_r_LIBRARIES ${LibRaw_r_LIBRARIES} ${LCMS2_LIBRARIES})

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -19,8 +19,9 @@
 #    pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-#if OIIO_CPLUSPLUS_VERSION >= 17 \
-    && (OIIO_CLANG_VERSION || OIIO_APPLE_CLANG_VERSION)
+#if OIIO_CPLUSPLUS_VERSION >= 17                            \
+    && ((OIIO_CLANG_VERSION && OIIO_CLANG_VERSION < 110000) \
+        || OIIO_APPLE_CLANG_VERSION)
 // libraw uses auto_ptr, which is not in C++17 at all for clang, though
 // it does seem to be for gcc. So for clang, alias it to unique_ptr.
 namespace std {


### PR DESCRIPTION
LibRaw 0.19 and earlier use auto_ptr in public headers, which was
deprecated in C++11 and removed in C++17. 

When this combo is detected, issue a warning message from CMake.
