### PR TITLE
Add custom UDIM support

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -101,6 +101,7 @@ lg@openimageio.org
 * Lucille Caillaud
 * Lukas Schrangl
 * Lukasz Maliszewski
+* Luke Emrose
 * M Joonas Pihlaja
 * Malcolm Humphreys
 * Manuel Gamito

--- a/src/doc/texturesys.rst
+++ b/src/doc/texturesys.rst
@@ -353,13 +353,15 @@ occur if the texture filename initially passed to `texture()` does not
 exist as a concrete file and contains one or more of the following
 substrings:
 
-======== ========================
-`<UDIM>` 1001 + utile + vtile*10
-`<u>`    utile
-`<v>`    vtile
-`<U>`    utile + 1
-`<V>`    vtile + 1
-======== ========================
+========== ========================
+`<UDIM>`   1001 + utile + vtile*10
+`<u>`      utile
+`<v>`      vtile
+`<U>`      utile + 1
+`<V>`      vtile + 1
+`_u##v##`  utile, vtile
+`%(UDIM)d` 1001 + utile + vtile*10
+========== ========================
 
 where the tile numbers are derived from the input u,v texture
 coordinates as follows::

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -301,7 +301,8 @@ ImageCacheFile::ImageCacheFile(ImageCacheImpl& imagecache,
                  || m_filename.find("<V>") != m_filename.npos
                  || m_filename.find("<u>") != m_filename.npos
                  || m_filename.find("<v>") != m_filename.npos
-                 || m_filename.find("_u##v##") != m_filename.npos)
+                 || m_filename.find("_u##v##") != m_filename.npos
+                 || m_filename.find("%(UDIM)d") != m_filename.npos)
                 && !Filesystem::exists(m_filename);
 
     // If the config has an IOProxy, remember that we should never actually
@@ -3445,6 +3446,8 @@ ImageCacheImpl::resolve_udim(ImageCacheFile* udimfile, Perthread* thread_info,
                                     Strutil::sprintf("v%d", vtile + 1), true);
         realname         = Strutil::replace(realname, "_u##v##",
                                     Strutil::sprintf("_u%02dv%02d", utile, vtile), true);
+        realname         = Strutil::replace(realname, "%(UDIM)d",
+                                    Strutil::sprintf("%04d", udim_tile), true);
         realfile         = find_file(realname, thread_info);
         // Now grab the actual write lock, and double check that it hasn't
         // been added by another thread during the brief time when we

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3444,11 +3444,13 @@ ImageCacheImpl::resolve_udim(ImageCacheFile* udimfile, Perthread* thread_info,
                                     Strutil::sprintf("u%d", utile + 1), true);
         realname         = Strutil::replace(realname, "<V>",
                                     Strutil::sprintf("v%d", vtile + 1), true);
-        realname         = Strutil::replace(realname, "_u##v##",
-                                    Strutil::sprintf("_u%02dv%02d", utile, vtile), true);
-        realname         = Strutil::replace(realname, "%(UDIM)d",
+        realname
+            = Strutil::replace(realname, "_u##v##",
+                               Strutil::sprintf("_u%02dv%02d", utile, vtile),
+                               true);
+        realname = Strutil::replace(realname, "%(UDIM)d",
                                     Strutil::sprintf("%04d", udim_tile), true);
-        realfile         = find_file(realname, thread_info);
+        realfile = find_file(realname, thread_info);
         // Now grab the actual write lock, and double check that it hasn't
         // been added by another thread during the brief time when we
         // weren't holding any lock.

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3443,6 +3443,8 @@ ImageCacheImpl::resolve_udim(ImageCacheFile* udimfile, Perthread* thread_info,
                                     Strutil::sprintf("u%d", utile + 1), true);
         realname         = Strutil::replace(realname, "<V>",
                                     Strutil::sprintf("v%d", vtile + 1), true);
+        realname         = Strutil::replace(realname, "_u##v##",
+                                    Strutil::sprintf("_u%02dv%02d", utile, vtile), true);
         realfile         = find_file(realname, thread_info);
         // Now grab the actual write lock, and double check that it hasn't
         // been added by another thread during the brief time when we

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -300,7 +300,8 @@ ImageCacheFile::ImageCacheFile(ImageCacheImpl& imagecache,
                  || m_filename.find("<U>") != m_filename.npos
                  || m_filename.find("<V>") != m_filename.npos
                  || m_filename.find("<u>") != m_filename.npos
-                 || m_filename.find("<v>") != m_filename.npos)
+                 || m_filename.find("<v>") != m_filename.npos
+                 || m_filename.find("_u##v##") != m_filename.npos)
                 && !Filesystem::exists(m_filename);
 
     // If the config has an IOProxy, remember that we should never actually


### PR DESCRIPTION
For our in-house renderer, we need support for an additional UDIM format of:
/path/to/file/textureName_u##v##.ext

I also added support for the Houdini UDIM naming convention of:
/path/to/file/textureName%(UDIM)d.ext


## Description

Should be clear based on previous discussion I've had with Larry.
But in a nutshell, add missing naming conventions for UDIM files.

## Tests

Not yet but I will.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

