### PR TITLE
fmt related fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,8 +320,7 @@ jobs:
       PYBIND11_VERSION: v2.6.2
       PYTHON_VERSION: 3.8
       WEBP_VERSION: v1.1.0
-      MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=master
-      # MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=7.1.3
+      MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=8.0.0
       USE_OPENVDB: 0
       # The old installed OpenVDB has a TLS conflict with Python 3.8
     steps:
@@ -377,7 +376,7 @@ jobs:
       # PYBIND11_VERSION: master
       PYTHON_VERSION: 3.8
       WEBP_VERSION: master
-      MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=7.1.3
+      MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=master
       USE_OPENVDB: 0
       # The old installed OpenVDB has a TLS conflict with Python 3.8
     steps:

--- a/src/doc/Doxyfile
+++ b/src/doc/Doxyfile
@@ -2155,6 +2155,7 @@ INCLUDE_FILE_PATTERNS  = *.h
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
 PREDEFINED             = DOXYGEN_SHOULD_SKIP_THIS \
+                         OIIO_DOXYGEN_ONLY:=1 \
                          OIIO_NO_SANITIZE_ADDRESS:= \
                          OIIO_API:= \
                          OIIO_UTIL_API:= \

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -86,11 +86,15 @@ void OIIO_UTIL_API sync_output (std::ostream &file, string_view str);
 /// works with any types that understand stream output via '<<'.
 /// The formatting of the string will always use the classic "C" locale
 /// conventions (in particular, '.' as decimal separator for float values).
-template<typename... Args>
-inline std::string sprintf (const char* fmt, const Args&... args)
+#ifdef OIIO_DOXYGEN_ONLY
+template<typename Str, typename... Args>
+inline std::string sprintf(const Str& fmt, Args&&... args)
 {
-    return ::fmt::sprintf (fmt, args...);
+    return ::fmt::sprintf(fmt, args...);
 }
+#else
+using ::fmt::sprintf;
+#endif
 
 
 
@@ -120,10 +124,14 @@ inline std::string sprintf (const char* fmt, const Args&... args)
 ///
 
 namespace fmt {
-template<typename... Args>
-inline std::string format (const char* fmt, const Args&... args)
+template<typename Str, typename... Args>
+inline std::string format(const Str& fmt, Args&&... args)
 {
-    return ::fmt::format (fmt, args...);
+#if FMT_VERSION >= 70000
+    return ::fmt::vformat(fmt, ::fmt::make_format_args(args...));
+#else
+    return ::fmt::format(fmt, args...);
+#endif
 }
 } // namespace fmt
 

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -558,8 +558,8 @@ FMT_BEGIN_NAMESPACE
 template <>
 struct formatter<OIIO::TypeDesc> {
     // Parses format specification
-    // C++14: constexpr auto parse(format_parse_context& ctx) {
-    auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) // c++11
+    // C++14: constexpr auto parse(format_parse_context& ctx) const {
+    auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) const // c++11
     {
         // Get the presentation type, if any. Required to be 's'.
         auto it = ctx.begin(), end = ctx.end();
@@ -572,8 +572,8 @@ struct formatter<OIIO::TypeDesc> {
     }
 
     template <typename FormatContext>
-    auto format(const OIIO::TypeDesc& t, FormatContext& ctx) -> decltype(ctx.out()){
-        // C++14:   auto format(const point& p, FormatContext& ctx) {
+    auto format(const OIIO::TypeDesc& t, FormatContext& ctx) -> decltype(ctx.out()) const {
+        // C++14:   auto format(const OIIO::TypeDesc& p, FormatContext& ctx) const {
         // ctx.out() is an output iterator to write to.
         return format_to(ctx.out(), "{}", t.c_str());
     }


### PR DESCRIPTION
* New fmt 8.0.0 is out -- make sure we test against both that and their
  current master.

* Starting with fmt 8.0, we need to wrap non-constexpr format spec
  strings passed to fmt::format() in a fmt::runtime. A format string
  that started out as a string literal nonetheless looks like a
  non-constant by the time it gets to std::format via our wrapper
  functions. This only triggers the error with gcc11 and -std=c++20,
  so it was a little tricky to understand at first.

* Update the idioms we use for Strutil::format and sprintf to use
  "perfect forwarding". (Dunno if that makes a practical difference,
  but it covers all our bases.)

* For Strutil::sprintf, just `using ::fmt::sprintf` and eliminate the
  wrapper entirely. (Though we express the wrapper inside
  `#ifdef OIIO_OXYGEN_ONLY` so that it fully appears in any docs we
  generate.)

