### PR TITLE
TypeDesc improvements

### DIFF
--- a/src/doc/imageioapi.rst
+++ b/src/doc/imageioapi.rst
@@ -41,9 +41,11 @@ in the outer OpenImageIO scope:
 
     TypeUnknown TypeFloat TypeColor TypePoint TypeVector TypeNormal
     TypeMatrix33 TypeMatrix44 TypeMatrix TypeHalf
-    TypeInt TypeUInt TypeInt16 TypeUInt16 TypeInt8 TypeUInt8
-    TypeFloat2 TypeVector2 TypeFloat4 TypeVector2i
+    TypeInt TypeUInt TypeInt32 TypeUInt32 TypeInt64 TypeUInt64
+    TypeInt16 TypeUInt16 TypeInt8 TypeUInt8
+    TypeFloat2 TypeVector2 TypeVector2i TypeFloat4
     TypeString TypeTimeCode TypeKeyCode
+    TypeBox2 TypeBox2i TypeBox3 TypeBox3i
     TypeRational TypePointer
 
 The only types commonly used to store *pixel values* in image files

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -117,7 +117,8 @@ struct OIIO_UTIL_API TypeDesc {
                           ///<   4-byte encoding of an SMPTE timecode.
         KEYCODE,          ///< indicates an `int[7]` representing the standard
                           ///<   28-byte encoding of an SMPTE keycode.
-        RATIONAL          ///< A VEC2 representing a rational number `val[0] / val[1]`
+        RATIONAL,         ///< A VEC2 representing a rational number `val[0] / val[1]`
+        BOX,              ///< A VEC2[2] or VEC3[2] that represents a 2D or 3D bounds (min/max)
     };
 
     unsigned char basetype;      ///< C data type at the heart of our type
@@ -313,6 +314,18 @@ struct OIIO_UTIL_API TypeDesc {
         return this->aggregate == VEC4 && this->basetype == b && !is_array();
     }
 
+    /// Is this an array of aggregates that represents a 2D bounding box?
+    constexpr bool is_box2 (BASETYPE b=FLOAT) const noexcept {
+        return this->aggregate == VEC2 && this->basetype == b && arraylen == 2
+                && this->vecsemantics == BOX;
+    }
+
+    /// Is this an array of aggregates that represents a 3D bounding box?
+    constexpr bool is_box3 (BASETYPE b=FLOAT) const noexcept {
+        return this->aggregate == VEC3 && this->basetype == b && arraylen == 2
+                && this->vecsemantics == BOX;
+    }
+
     /// Demote the type to a non-array
     ///
     void unarray (void) noexcept { arraylen = 0; }
@@ -377,7 +390,13 @@ static constexpr TypeDesc TypeInt16 (TypeDesc::INT16);
 static constexpr TypeDesc TypeUInt16 (TypeDesc::UINT16);
 static constexpr TypeDesc TypeInt8 (TypeDesc::INT8);
 static constexpr TypeDesc TypeUInt8 (TypeDesc::UINT8);
+static constexpr TypeDesc TypeInt64 (TypeDesc::INT64);
+static constexpr TypeDesc TypeUInt64 (TypeDesc::UINT64);
 static constexpr TypeDesc TypeVector2i(TypeDesc::INT, TypeDesc::VEC2);
+static constexpr TypeDesc TypeBox2(TypeDesc::FLOAT, TypeDesc::VEC2, TypeDesc::BOX, 2);
+static constexpr TypeDesc TypeBox3(TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::BOX, 2);
+static constexpr TypeDesc TypeBox2i(TypeDesc::INT, TypeDesc::VEC2, TypeDesc::BOX, 2);
+static constexpr TypeDesc TypeBox3i(TypeDesc::INT, TypeDesc::VEC3, TypeDesc::BOX, 2);
 static constexpr TypeDesc TypeHalf (TypeDesc::HALF);
 static constexpr TypeDesc TypeTimeCode (TypeDesc::UINT, TypeDesc::SCALAR, TypeDesc::TIMECODE, 2);
 static constexpr TypeDesc TypeKeyCode (TypeDesc::INT, TypeDesc::SCALAR, TypeDesc::KEYCODE, 7);
@@ -446,6 +465,12 @@ template<> struct TypeDescFromC<Imath::M33f> { static const constexpr TypeDesc v
 template<> struct TypeDescFromC<Imath::M44f> { static const constexpr TypeDesc value() { return TypeMatrix44; } };
 template<> struct TypeDescFromC<Imath::M33d> { static const constexpr TypeDesc value() { return TypeDesc(TypeDesc::DOUBLE, TypeDesc::MATRIX33); } };
 template<> struct TypeDescFromC<Imath::M44d> { static const constexpr TypeDesc value() { return TypeDesc(TypeDesc::DOUBLE, TypeDesc::MATRIX44); } };
+#endif
+#ifdef INCLUDED_IMATHBOX_H
+template<> struct TypeDescFromC<Imath::Box2f> { static const constexpr TypeDesc value() { return TypeBox2; } };
+template<> struct TypeDescFromC<Imath::Box2i> { static const constexpr TypeDesc value() { return TypeBox2i; } };
+template<> struct TypeDescFromC<Imath::Box3f> { static const constexpr TypeDesc value() { return TypeBox3; } };
+template<> struct TypeDescFromC<Imath::Box3i> { static const constexpr TypeDesc value() { return TypeBox3i; } };
 #endif
 
 

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -157,4 +157,15 @@ if (OIIO_BUILD_TESTS)
     set_target_properties (strongparam_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_strongparam ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/strongparam_test)
 
+    add_executable (typedesc_test typedesc_test.cpp)
+    target_link_libraries (typedesc_test PRIVATE OpenImageIO_Util
+                           # For OpenEXR/Imath 3.x:
+                           $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
+                           # For OpenEXR >= 2.4/2.5 with reliable exported targets
+                           $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
+                           # For OpenEXR <= 2.3:
+                           ${OPENEXR_LIBRARIES})
+    set_target_properties (typedesc_test PROPERTIES FOLDER "Unit Tests")
+    add_test (unit_typedesc ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/typedesc_test)
+
 endif ()

--- a/src/libutil/typedesc_test.cpp
+++ b/src/libutil/typedesc_test.cpp
@@ -1,0 +1,167 @@
+// Copyright 2008-present Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio
+
+
+#include <limits>
+#include <type_traits>
+
+#include <OpenImageIO/Imath.h>
+
+#if OIIO_USING_IMATH >= 3
+#    include <Imath/ImathBox.h>
+#else
+#    include <OpenEXR/ImathBox.h>
+#endif
+#include <OpenEXR/ImfKeyCode.h>
+#include <OpenEXR/ImfTimeCode.h>
+
+#include <OpenImageIO/typedesc.h>
+#include <OpenImageIO/unittest.h>
+
+
+using namespace OIIO;
+
+
+struct notype {
+};
+
+
+
+// Several tests for a TypeDesc type. The template parameter `Ctype` is how
+// we store the data in C++. `textrep` is the textual representation,
+// like "float". `constructed` is the TypeDesc we are testing, constructed
+// (like `TypeDesc(TypeDesc::FLOAT)`). `named` is the pre-constructed alias,
+// if there is one (like `TypeFloat`). `value` is data in C++ holding that
+// type, and `valuerep` is what `value` is expected to look like when
+// rendered as a string.
+template<typename CType>
+void
+test_type(string_view textrep, TypeDesc constructed,
+          TypeDesc named = TypeUnknown, const CType& value = CType(),
+          string_view valuerep = "")
+{
+    static tostring_formatting fm;
+    fm.aggregate_sep = ", ";
+    fm.array_sep     = ", ";
+
+    Strutil::print("Testing {}\n", textrep);
+
+    // Make sure constructing by name from string matches the TypeDesc where
+    // it was constructed in C++.
+    OIIO_CHECK_EQUAL(constructed, TypeDesc(textrep));
+
+    // Make sure that the pre-constructed alias (if passed) matches the
+    // fully constructed type.
+    if (named != TypeUnknown)
+        OIIO_CHECK_EQUAL(constructed, named);
+
+    // Make sure the size() matches the size of the equivalent C++ data.
+    OIIO_CHECK_EQUAL(constructed.size(), sizeof(value));
+
+    // Verify that rendering the sample data `value` as a string matches
+    // what we expect.
+    std::string s = tostring(constructed, &value, fm);
+    if (valuerep.size()) {
+        OIIO_CHECK_EQUAL(s, valuerep);
+        Strutil::print("  {}\n", s);
+    }
+}
+
+
+
+int
+main(int /*argc*/, char* /*argv*/[])
+{
+    std::cout << "TypeDesc size = " << sizeof(TypeDesc) << "\n";
+    // We expect a TypeDesc to be the same size as a 64 bit int
+    OIIO_CHECK_EQUAL(sizeof(TypeDesc), sizeof(uint64_t));
+
+    test_type<float>("float", TypeDesc(TypeDesc::FLOAT), TypeFloat, 1.5f,
+                     "1.5");
+    test_type<half>("half", TypeDesc(TypeDesc::HALF), TypeHalf, half(1.5f),
+                    "1.5");
+    test_type<double>("double", TypeDesc(TypeDesc::DOUBLE), TypeUnknown, 1.5,
+                      "1.5");
+    test_type<int>("int", TypeDesc(TypeDesc::INT), TypeInt, 1, "1");
+    test_type<unsigned int>("uint", TypeDesc(TypeDesc::UINT), TypeUInt, 1, "1");
+    test_type<int32_t>("int", TypeDesc(TypeDesc::INT), TypeInt, 1, "1");
+    test_type<uint32_t>("uint", TypeDesc(TypeDesc::UINT), TypeUInt, 1, "1");
+    test_type<int64_t>("int64", TypeDesc(TypeDesc::INT64), TypeInt64, 1, "1");
+    test_type<uint64_t>("uint64", TypeDesc(TypeDesc::UINT64), TypeUInt64, 1,
+                        "1");
+    test_type<int16_t>("int16", TypeDesc(TypeDesc::INT16), TypeInt16, 1, "1");
+    test_type<uint16_t>("uint16", TypeDesc(TypeDesc::UINT16), TypeUInt16, 1,
+                        "1");
+    test_type<int8_t>("int8", TypeDesc(TypeDesc::INT8), TypeInt8, 1, "1");
+    test_type<uint8_t>("uint8", TypeDesc(TypeDesc::UINT8), TypeUInt8, 1, "1");
+
+    // test_type<>("", TypeDesc(TypeDesc::UNKNOWN));
+    test_type<Imath::Color3f>("color",
+                              TypeDesc(TypeDesc::FLOAT, TypeDesc::VEC3,
+                                       TypeDesc::COLOR),
+                              TypeColor, Imath::Color3f(0.0f), "(0, 0, 0)");
+    test_type<Imath::V3f>("point",
+                          TypeDesc(TypeDesc::FLOAT, TypeDesc::VEC3,
+                                   TypeDesc::POINT),
+                          TypePoint, Imath::V3f(0.0f), "(0, 0, 0)");
+    test_type<Imath::V3f>("vector",
+                          TypeDesc(TypeDesc::FLOAT, TypeDesc::VEC3,
+                                   TypeDesc::VECTOR),
+                          TypeVector, Imath::V3f(0.0f), "(0, 0, 0)");
+    test_type<Imath::V3f>("normal",
+                          TypeDesc(TypeDesc::FLOAT, TypeDesc::VEC3,
+                                   TypeDesc::NORMAL),
+                          TypeNormal, Imath::V3f(0.0f), "(0, 0, 0)");
+    test_type<Imath::M33f>("matrix33",
+                           TypeDesc(TypeDesc::FLOAT, TypeDesc::MATRIX33),
+                           TypeMatrix33, {});
+    test_type<Imath::M44f>("matrix",
+                           TypeDesc(TypeDesc::FLOAT, TypeDesc::MATRIX44),
+                           TypeMatrix44, {});
+    test_type<Imath::V2f>("float2", TypeDesc(TypeDesc::FLOAT, TypeDesc::VEC2),
+                          TypeFloat2, {});
+    test_type<Imath::V2f>("vector2",
+                          TypeDesc(TypeDesc::FLOAT, TypeDesc::VEC2,
+                                   TypeDesc::VECTOR),
+                          TypeVector2, {});
+    test_type<Imath::V4f>("float4", TypeDesc(TypeDesc::FLOAT, TypeDesc::VEC4),
+                          TypeFloat4, {});
+    test_type<const char*>("string", TypeDesc(TypeDesc::STRING), TypeString,
+                           "hello", "hello");
+    int i2[2] = { 1, 2 };
+    test_type<int[2]>("rational",
+                      TypeDesc(TypeDesc::INT, TypeDesc::VEC2,
+                               TypeDesc::RATIONAL),
+                      TypeRational, i2, "1/2");
+    test_type<Imath::Box2f>("box2",
+                            TypeDesc(TypeDesc::FLOAT, TypeDesc::VEC2,
+                                     TypeDesc::BOX, 2),
+                            TypeBox2);
+    test_type<Imath::Box3f>("box3",
+                            TypeDesc(TypeDesc::FLOAT, TypeDesc::VEC3,
+                                     TypeDesc::BOX, 2),
+                            TypeBox3);
+    test_type<Imath::Box2i>("box2i",
+                            TypeDesc(TypeDesc::INT, TypeDesc::VEC2,
+                                     TypeDesc::BOX, 2),
+                            TypeBox2i);
+    test_type<Imath::Box3i>("box3i",
+                            TypeDesc(TypeDesc::INT, TypeDesc::VEC3,
+                                     TypeDesc::BOX, 2),
+                            TypeBox3i);
+    Imf::TimeCode tc;
+    test_type<Imf::TimeCode>("timecode",
+                             TypeDesc(TypeDesc::UINT, TypeDesc::SCALAR,
+                                      TypeDesc::TIMECODE, 2),
+                             TypeTimeCode, tc);
+    Imf::KeyCode kc;
+    test_type<Imf::KeyCode>("keycode",
+                            TypeDesc(TypeDesc::INT, TypeDesc::SCALAR,
+                                     TypeDesc::KEYCODE, 7),
+                            TypeKeyCode, kc);
+    test_type<void*>("pointer", TypeDesc(TypeDesc::PTR), TypePointer,
+                     (void*)(1), "0x1");
+
+    return unit_test_failures;
+}

--- a/src/python/py_typedesc.cpp
+++ b/src/python/py_typedesc.cpp
@@ -58,6 +58,7 @@ declare_typedesc(py::module& m)
         .value("TIMECODE", TypeDesc::TIMECODE)
         .value("KEYCODE", TypeDesc::KEYCODE)
         .value("RATIONAL", TypeDesc::RATIONAL)
+        .value("BOX", TypeDesc::BOX)
         .export_values();
 
     py::class_<TypeDesc>(m, "TypeDesc")
@@ -116,6 +117,8 @@ declare_typedesc(py::module& m)
         .def("is_vec2", &TypeDesc::is_vec2)
         .def("is_vec3", &TypeDesc::is_vec3)
         .def("is_vec4", &TypeDesc::is_vec4)
+        .def("is_box2", &TypeDesc::is_box2)
+        .def("is_box3", &TypeDesc::is_box3)
 
         // overloaded operators
         .def(py::self == py::self)  // operator==
@@ -170,6 +173,8 @@ declare_typedesc(py::module& m)
     m.attr("TypeString")   = TypeString;
     m.attr("TypeInt")      = TypeInt;
     m.attr("TypeUInt")     = TypeUInt;
+    m.attr("TypeInt64")    = TypeInt64;
+    m.attr("TypeUInt64")   = TypeUInt64;
     m.attr("TypeInt32")    = TypeInt32;
     m.attr("TypeUInt32")   = TypeUInt32;
     m.attr("TypeInt16")    = TypeInt16;
@@ -187,6 +192,10 @@ declare_typedesc(py::module& m)
     m.attr("TypeFloat4")   = TypeFloat4;
     m.attr("TypeVector4")  = TypeVector4;
     m.attr("TypeVector2i") = TypeVector2i;
+    m.attr("TypeBox2")     = TypeBox2;
+    m.attr("TypeBox3")     = TypeBox3;
+    m.attr("TypeBox2i")    = TypeBox2i;
+    m.attr("TypeBox3i")    = TypeBox3i;
     m.attr("TypeRational") = TypeRational;
     m.attr("TypePointer")  = TypePointer;
 }

--- a/testsuite/python-typedesc/ref/out-python2.txt
+++ b/testsuite/python-typedesc/ref/out-python2.txt
@@ -69,7 +69,7 @@ type 'FLOAT, VEC3, POINT, array of 2'
     basesize = 4
 type 'INT, VEC2, BOX, array of 2'
     c_str "box2i"
-    basetype BASETYPE.INT
+    basetype BASETYPE.INT32
     aggregate AGGREGATE.VEC2
     vecsemantics VECSEMANTICS.BOX
     arraylen 2

--- a/testsuite/python-typedesc/src/test_typedesc.py
+++ b/testsuite/python-typedesc/src/test_typedesc.py
@@ -63,6 +63,7 @@ def vecsemantics_enum_test():
         oiio.TIMECODE
         oiio.KEYCODE
         oiio.RATIONAL
+        oiio.BOX
         print ("Passed VECSEMANTICS")
     except:
         print ("Failed VECSEMANTICS")
@@ -106,12 +107,17 @@ try:
                     "FLOAT, SCALAR, NOXFORM, array of 6")
     breakdown_test (oiio.TypeDesc(oiio.FLOAT, oiio.VEC3, oiio.POINT, 2),
                     "FLOAT, VEC3, POINT, array of 2")
+    breakdown_test (oiio.TypeDesc(oiio.INT, oiio.VEC2, oiio.BOX, 2),
+                    "INT, VEC2, BOX, array of 2")
+    breakdown_test (oiio.TypeDesc(oiio.FLOAT, oiio.VEC3, oiio.BOX, 2),
+                    "FLOAT, VEC3, BOX, array of 2")
     print ("")
 
     # Test construction from a string descriptor
     breakdown_test (oiio.TypeDesc("float[2]"), "float[2]")
     breakdown_test (oiio.TypeDesc("normal"), "normal")
     breakdown_test (oiio.TypeDesc("uint16"), "uint16")
+    breakdown_test (oiio.TypeDesc("box3"), "box3")
     print ("")
 
     # Test equality, inequality, and equivalent
@@ -159,6 +165,8 @@ try:
     breakdown_test (oiio.TypeString,   "TypeString",   verbose=False)
     breakdown_test (oiio.TypeInt,      "TypeInt",      verbose=False)
     breakdown_test (oiio.TypeUInt,     "TypeUInt",     verbose=False)
+    breakdown_test (oiio.TypeInt64,    "TypeInt64",    verbose=False)
+    breakdown_test (oiio.TypeUInt64,   "TypeUInt64",   verbose=False)
     breakdown_test (oiio.TypeInt32,    "TypeInt32",    verbose=False)
     breakdown_test (oiio.TypeUInt32,   "TypeUInt32",   verbose=False)
     breakdown_test (oiio.TypeInt16,    "TypeInt16",    verbose=False)


### PR DESCRIPTION
* Add TypeDesc support for metadata that is a 2D or 3D bounding box,
  represented as an array of 2 VEC2 aggregates (for 2d) or VEC3
  aggregates (for 3d), having the BOX semantic. The basetype
  determines whether it's an integer-based (generally for pixel
  ranges) or float-based (generally for 3D spatial) bounds. The new
  text representations are "box2" and "box3" (for float-based), and
  "box2i" and "box3i" (for int-based).

* Somehow we never had a C++ test thoroughly exercising all the corners
  of TypeDesc. Now we do: typedesc_test.cpp

* The test revealed a number of edge cases we don't handle well, now
  shored up.

