### PR TITLE
fix typo for REQUIRED_USE

### DIFF
--- a/src/cmake/checked_find_package.cmake
+++ b/src/cmake/checked_find_package.cmake
@@ -3,7 +3,7 @@
 # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
 
-set (REQUIED_DEPS "" CACHE STRING
+set (REQUIRED_DEPS "" CACHE STRING
      "Additional dependencies to consider required (semicolon-separated list, or ALL)")
 set (OPTIONAL_DEPS "" CACHE STRING
      "Additional dependencies to consider optional (semicolon-separated list, or ALL)")


### PR DESCRIPTION
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>


## Description

I think, there's a typo when setting REQUIRED_DEPS. This patch fixes it.

## Tests

no

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

