### PR TITLE
Add a scaled slopes UV normalization options for --bumpslopes.

### DIFF
--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -469,7 +469,7 @@ bump_to_bumpslopes(ImageBuf& dst, const ImageBuf& src,
     float res_x = 1.0f;
     float res_y = 1.0f;
 
-    const std::string& bumpformat = configspec.get_string_attribute(
+    string_view bumpformat = configspec.get_string_attribute(
         "maketx:bumpformat");
 
     if (Strutil::iequals(bumpformat, "height"))

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -453,7 +453,7 @@ normal_gradient(const ImageBuf& src, const ImageBuf::Iterator<float>& dstpix,
 template<class SRCTYPE>
 static bool
 bump_to_bumpslopes(ImageBuf& dst, const ImageBuf& src,
-                   const std::string& bumpformat, std::ostream& outstream,
+                   const ImageSpec& configspec, std::ostream& outstream,
                    ROI roi = ROI::All(), int nthreads = 0)
 {
     if (!dst.initialized() || dst.nchannels() != 6
@@ -465,6 +465,12 @@ bump_to_bumpslopes(ImageBuf& dst, const ImageBuf& src,
                         float*, float*, float*);
 
     bump_filter = &sobel_gradient<SRCTYPE>;
+
+    float res_x = 1.0f;
+    float res_y = 1.0f;
+
+    const std::string& bumpformat = configspec.get_string_attribute(
+        "maketx:bumpformat");
 
     if (Strutil::iequals(bumpformat, "height"))
         bump_filter = &sobel_gradient<
@@ -488,6 +494,21 @@ bump_to_bumpslopes(ImageBuf& dst, const ImageBuf& src,
         return false;
     }
 
+    int uv_scale = configspec.get_int_attribute("uvslopes_scale");
+
+    // If the input is an height map, does the derivatives needs to be UV normalized and scaled?
+    if (bump_filter == &sobel_gradient<SRCTYPE> && uv_scale != 0) {
+        if (uv_scale < 0) {
+            outstream
+                << "maketx ERROR: Invalid uvslopes_scale value. The value must be >=0.\n";
+            return false;
+        }
+        // Note: the scale factor is used to prevent overflow if the half float format is used as destination.
+        //       A scale factor of 256 is recommended to prevent overflowing for texture sizes up to 32k.
+        res_x = (float)src.spec().width / uv_scale;
+        res_y = (float)src.spec().height / uv_scale;
+    }
+
     ImageBufAlgo::parallel_image(roi, nthreads, [&](ROI roi) {
         // iterate on destination image
         for (ImageBuf::Iterator<float> d(dst, roi); !d.done(); ++d) {
@@ -498,12 +519,12 @@ bump_to_bumpslopes(ImageBuf& dst, const ImageBuf& src,
             // h = height or h = -1.0f if a normal map
             d[0] = h;
             // first moments
-            d[1] = dhds;
-            d[2] = dhdt;
+            d[1] = dhds * res_x;
+            d[2] = dhdt * res_y;
             // second moments
-            d[3] = dhds * dhds;
-            d[4] = dhdt * dhdt;
-            d[5] = dhds * dhdt;
+            d[3] = dhds * dhds * res_x * res_x;
+            d[4] = dhdt * dhdt * res_y * res_y;
+            d[5] = dhds * dhdt * res_x * res_y;
         }
     });
     return true;
@@ -1151,9 +1172,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
         bool ok;
         OIIO_DISPATCH_COMMON_TYPES(ok, "bump_to_bumpslopes", bump_to_bumpslopes,
                                    src->spec().format, *bumpslopes, *src,
-                                   configspec.get_string_attribute(
-                                       "maketx:bumpformat"),
-                                   outstream);
+                                   configspec, outstream);
         // bump_to_bumpslopes(*bumpslopes, *src);
         mode = ImageBufAlgo::MakeTxTexture;
         src  = bumpslopes;

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -175,6 +175,7 @@ getargs(int argc, char* argv[], ImageSpec& configspec)
     bool unpremult             = false;
     bool sansattrib            = false;
     float sharpen              = 0.0f;
+    int uvslopes_scale         = 0;
     std::string incolorspace;
     std::string outcolorspace;
     std::string colorconfigname;
@@ -293,6 +294,8 @@ getargs(int argc, char* argv[], ImageSpec& configspec)
       .help("Create lat/long environment map from a light probe");
     ap.arg("--bumpslopes", &bumpslopesmode)
       .help("Create a 6 channels bump-map with height, derivatives and square derivatives from an height or a normal map");
+    ap.arg("--uvslopes_scale %d:VALUE", &uvslopes_scale)
+      .help("If specified, compute derivatives for --bumpslopes in UV space rather than in texel space and divide them by a scale factor. 0=disable by default, only valid for height maps.");
     ap.arg("--bumpformat %s:NAME", &bumpformat)
       .help("Specify the interpretation of a 3-channel input image for --bumpslopes: \"height\", \"normal\" or \"auto\" (default).");
 //                  "--envcube", &envcubemode, "Create cubic env map (file order: px, nx, py, ny, pz, nz) (UNIMP)",
@@ -465,6 +468,11 @@ getargs(int argc, char* argv[], ImageSpec& configspec)
         ImageCache* ic = ImageCache::create();  // get the shared one
         ic->attribute("unassociatedalpha", (int)ignore_unassoc);
     }
+
+    if (bumpslopesmode)
+        configspec.attribute(
+            "uvslopes_scale",
+            uvslopes_scale);  // we want to write this attribute in the output file
 }
 
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4705,6 +4705,8 @@ prep_texture_config(ImageSpec& configspec, ParamValueList& fileoptions)
                              "prman_options", fileoptions.get_string("prman")));
     configspec.attribute("maketx:bumpformat",
                          fileoptions.get_string("bumpformat", "auto"));
+    configspec.attribute("uvslopes_scale",
+                         fileoptions.get_int("uvslopes_scale", 0));
     // if (mipimages.size())
     //     configspec.attribute ("maketx:mipimages", Strutil::join(mipimages,";"));
 
@@ -5564,7 +5566,7 @@ getargs(int argc, char* argv[])
       .help("Output the current image as a latlong env map")
       .action(output_file);
     ap.arg("-obump %s:FILENAME")
-      .help("Output the current bump texture map as a 6 channels texture including the first and second moment of the bump slopes (options: bumpformat=height|normal|auto)")
+      .help("Output the current bump texture map as a 6 channels texture including the first and second moment of the bump slopes (options: bumpformat=height|normal|auto, uvslopes_scale=val>=0)")
       .action(output_file);
     ap.separator("Options that affect subsequent image output:");
     ap.arg("-d %s:TYPE")

--- a/testsuite/maketx/ref/out.txt
+++ b/testsuite/maketx/ref/out.txt
@@ -393,6 +393,7 @@ bumpslope.exr        :   64 x   64, 6 channel, half openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
+    uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
     oiio:ColorSpace: "Linear"

--- a/testsuite/oiiotool-maketx/ref/out-rhel7.txt
+++ b/testsuite/oiiotool-maketx/ref/out-rhel7.txt
@@ -274,6 +274,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
+    uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
     oiio:ColorSpace: "Linear"
@@ -301,6 +302,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
+    uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
     oiio:ColorSpace: "Linear"

--- a/testsuite/oiiotool-maketx/ref/out-win.txt
+++ b/testsuite/oiiotool-maketx/ref/out-win.txt
@@ -274,6 +274,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
+    uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
     oiio:ColorSpace: "Linear"
@@ -302,6 +303,7 @@ bigval.exr           :    2 x    2, 3 channel, half openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
+    uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "1e+06,1e+06,1e+06"
     oiio:ColorSpace: "Linear"
@@ -344,6 +346,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
+    uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
     oiio:ColorSpace: "Linear"

--- a/testsuite/oiiotool-maketx/ref/out.txt
+++ b/testsuite/oiiotool-maketx/ref/out.txt
@@ -274,6 +274,7 @@ nan.exr              :   64 x   64, 3 channel, half openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
+    uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5"
     oiio:ColorSpace: "Linear"
@@ -302,6 +303,7 @@ bigval.exr           :    2 x    2, 3 channel, half openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
+    uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "1e+06,1e+06,1e+06"
     oiio:ColorSpace: "Linear"
@@ -344,6 +346,7 @@ checker-exr.pdq      :  128 x  128, 4 channel, half openexr
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
     textureformat: "Plain Texture"
+    uvslopes_scale: 0
     wrapmodes: "black,black"
     oiio:AverageColor: "0.5,0.5,0.5,1"
     oiio:ColorSpace: "Linear"


### PR DESCRIPTION
## Description

This patch provides an optional parameter `--uvslopes_scale` for the `--bumpslopes` exporter to output the derivatives in the normalized UV space and scale them by a user defined constant. 

Originally, we decided to store the derivatives in texel space rather than the UV space to prevent floating point overflow when using the half float format (67c863d). However, expressing the derivatives in UV space is interesting because it is resolution independent and convenient when the resolution is not accessible. We restore this ability thanks to this optional parameter and a scale factor to prevent the overflow when using the half format. A typical value of 256 is recommended to prevent half floating point overflow with texture resolutions up to 32k. The value is stored as an extra attribute in the output file to revert the scaling on slopes when the texture is used. Note that this options is only meaningful with height map inputs.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

