### PR TITLE
Convert dpx output to be ioproxy enabled

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -226,12 +226,17 @@ control aspects of the writing itself:
        will keep unaltered pixel values (versus the default OIIO behavior
        of automatically converting from RGB to the designated color space
        as the pixels are written).
+   * - ``oiio:ioproxy``
+     - ptr
+     - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
+       example by writing to memory rather than the file system.
 
 **Custom I/O Overrides**
 
-DPX input (but, currently, not output) supports the "custom I/O" feature
-via the `ImageInput::set_ioproxy()` method and the special
-``"oiio:ioproxy"`` attributes (see Section :ref:`sec-imageinput-ioproxy`).
+DPX input and output both support the "custom I/O" feature via the
+special ``"oiio:ioproxy"`` attributes (see Sections
+:ref:`sec-imageoutput-ioproxy` and :ref:`sec-imageinput-ioproxy`) as well as
+the `set_ioproxy()` methods.
 
 **DPX Attributes**
 

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -91,7 +91,7 @@ private:
         m_subimage_specs.clear();
         m_write_pending = false;
         m_io_local.reset();
-        m_io       = nullptr;
+        m_io = nullptr;
     }
 
     // Is the output file currently opened?
@@ -134,10 +134,7 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 
-DPXOutput::DPXOutput()
-{
-    init();
-}
+DPXOutput::DPXOutput() { init(); }
 
 
 

--- a/src/dpx.imageio/libdpx/DPXStream.h
+++ b/src/dpx.imageio/libdpx/DPXStream.h
@@ -155,19 +155,12 @@ class OutStream
 	/*!
 	 * \brief Constructor
 	 */
-	OutStream();
-		
+	OutStream(OIIO::Filesystem::IOProxy* io) : m_io(io) { }
+
 	/*!
 	 * \brief Destructor 
 	 */
 	virtual ~OutStream();
-		
-	/*!
-	 * \brief Open file
-	 * \param fn File name
-	 * \return success true/false
-	 */
-	virtual bool Open(const char *fn);
 		
 	/*!
 	 * \brief Close file
@@ -208,7 +201,11 @@ class OutStream
 		
 		
   protected:
-	FILE *fp;
+	/*!
+	* This is a weak pointer, so opening and closing is done by the caller. Therefore, be
+	* carefull to delete this object after `m_io` is deleted externally
+	*/
+	OIIO::Filesystem::IOProxy* m_io;
 };
 
 

--- a/src/dpx.imageio/libdpx/OutStream.cpp
+++ b/src/dpx.imageio/libdpx/OutStream.cpp
@@ -30,7 +30,7 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
  * POSSIBILITY OF SUCH DAMAGE.
- */ 
+ */
 
 #include <cstdio>
 
@@ -39,60 +39,49 @@
 #include "DPXStream.h"
 
 
-OutStream::~OutStream()
+OutStream::~OutStream() {}
+
+
+void
+OutStream::Close()
 {
+    if (this->m_io) {
+        this->m_io = nullptr;
+    }
 }
 
 
-void OutStream::Close()
+size_t
+OutStream::Write(void* buf, const size_t size)
 {
-	if (this->m_io)
-	{
-		this->m_io = 0;
-	}
-}
-
-
-size_t OutStream::Write(void *buf, const size_t size)
-{
-	if (this->m_io == 0)
-		return 0;
+    if (this->m_io == 0)
+        return 0;
     return this->m_io->write(buf, size);
 }
 
 
-bool OutStream::Seek(long offset, Origin origin)
+bool
+OutStream::Seek(long offset, Origin origin)
 {
-	int64_t npos = 0;
-	if (! this->m_io)
-		return false;
+    int64_t npos = 0;
+    if (!this->m_io)
+        return false;
 
-	switch (origin)
-	{
-	case kCurrent:
-		npos = static_cast<int64_t>(this->m_io->tell()) + offset;
-		break;
-	case kEnd:
-		npos = static_cast<int64_t>(this->m_io->size()) + offset;
-		break;
-	case kStart:
-		npos = offset;
-		break;
-	}
-	
-	return this->m_io->seek(npos);
+    switch (origin) {
+    case kCurrent:
+        npos = static_cast<int64_t>(this->m_io->tell()) + offset;
+        break;
+    case kEnd: npos = static_cast<int64_t>(this->m_io->size()) + offset; break;
+    case kStart: npos = offset; break;
+    }
+
+    return this->m_io->seek(npos);
 }
 
 
-void OutStream::Flush()
+void
+OutStream::Flush()
 {
-	if (this->m_io)
-		this->m_io->flush();
+    if (this->m_io)
+        this->m_io->flush();
 }
-
-
-
-
-
-
-

--- a/src/dpx.imageio/libdpx/OutStream.cpp
+++ b/src/dpx.imageio/libdpx/OutStream.cpp
@@ -63,7 +63,7 @@ size_t OutStream::Write(void *buf, const size_t size)
 
 bool OutStream::Seek(long offset, Origin origin)
 {
-	int o;
+	int o = SEEK_SET;
 	if (! this->m_io)
 		return false;
 

--- a/src/dpx.imageio/libdpx/OutStream.cpp
+++ b/src/dpx.imageio/libdpx/OutStream.cpp
@@ -30,7 +30,7 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
  * POSSIBILITY OF SUCH DAMAGE.
- */
+ */ 
 
 #include <cstdio>
 
@@ -39,49 +39,60 @@
 #include "DPXStream.h"
 
 
-OutStream::~OutStream() {}
-
-
-void
-OutStream::Close()
+OutStream::~OutStream()
 {
-    if (this->m_io) {
-        this->m_io = nullptr;
-    }
 }
 
 
-size_t
-OutStream::Write(void* buf, const size_t size)
+void OutStream::Close()
 {
-    if (this->m_io == 0)
-        return 0;
+	if (this->m_io)
+	{
+		this->m_io = 0;
+	}
+}
+
+
+size_t OutStream::Write(void *buf, const size_t size)
+{
+	if (this->m_io == 0)
+		return 0;
     return this->m_io->write(buf, size);
 }
 
 
-bool
-OutStream::Seek(long offset, Origin origin)
+bool OutStream::Seek(long offset, Origin origin)
 {
-    int64_t npos = 0;
-    if (!this->m_io)
-        return false;
+	int64_t npos = 0;
+	if (! this->m_io)
+		return false;
 
-    switch (origin) {
-    case kCurrent:
-        npos = static_cast<int64_t>(this->m_io->tell()) + offset;
-        break;
-    case kEnd: npos = static_cast<int64_t>(this->m_io->size()) + offset; break;
-    case kStart: npos = offset; break;
-    }
-
-    return this->m_io->seek(npos);
+	switch (origin)
+	{
+	case kCurrent:
+		npos = static_cast<int64_t>(this->m_io->tell()) + offset;
+		break;
+	case kEnd:
+		npos = static_cast<int64_t>(this->m_io->size()) + offset;
+		break;
+	case kStart:
+		npos = offset;
+		break;
+	}
+	
+	return this->m_io->seek(npos);
 }
 
 
-void
-OutStream::Flush()
+void OutStream::Flush()
 {
-    if (this->m_io)
-        this->m_io->flush();
+	if (this->m_io)
+		this->m_io->flush();
 }
+
+
+
+
+
+
+

--- a/src/dpx.imageio/libdpx/OutStream.cpp
+++ b/src/dpx.imageio/libdpx/OutStream.cpp
@@ -63,24 +63,24 @@ size_t OutStream::Write(void *buf, const size_t size)
 
 bool OutStream::Seek(long offset, Origin origin)
 {
-	int64_t npos = 0;
+	int o;
 	if (! this->m_io)
 		return false;
 
 	switch (origin)
 	{
 	case kCurrent:
-		npos = static_cast<int64_t>(this->m_io->tell()) + offset;
+		o = SEEK_CUR;
 		break;
 	case kEnd:
-		npos = static_cast<int64_t>(this->m_io->size()) + offset;
+		o = SEEK_END;
 		break;
 	case kStart:
-		npos = offset;
+		o = SEEK_SET;
 		break;
 	}
-	
-	return this->m_io->seek(npos);
+
+	return this->m_io->seek(offset, o);
 }
 
 

--- a/src/libOpenImageIO/imageinout_test.cpp
+++ b/src/libOpenImageIO/imageinout_test.cpp
@@ -124,14 +124,16 @@ test_write_proxy(string_view formatname, string_view extension,
 
     // Use ImageOutput interface with a proxy
     Filesystem::IOVecOutput outproxy;
-    std::string memname = Strutil::sprintf("mem.%s", extension);
-    ok = checked_write(nullptr, memname, buf.spec(), buf.spec().format,
+    // some formats store the filename in the header (i.e. dpx)
+    //std::string memname = Strutil::sprintf("mem.%s", extension);
+    ok = checked_write(nullptr, disk_filename, buf.spec(), buf.spec().format,
                        buf.localpixels(), true, nullptr, &outproxy);
 
     // Use ImageBuf write interface with a proxy
     Filesystem::IOVecOutput outproxybuf;
     buf.set_write_ioproxy(&outproxybuf);
-    buf.write(memname);
+    //buf.write(memname);
+    buf.write(disk_filename);
 
     // The in-memory vectors we wrote should match, byte-for-byte,
     // the version we wrote to disk earlier.


### PR DESCRIPTION
Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>


## Description

Converts dpx output (input is already) to use the IO proxy layer (I recently
had a reason to write dpx, but couldn't make a memory stream).

## Tests

just tested with dpx image tests

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

