### PR TITLE
More fmt transition aids

### DIFF
--- a/src/doc/Doxyfile
+++ b/src/doc/Doxyfile
@@ -2170,6 +2170,8 @@ PREDEFINED             = DOXYGEN_SHOULD_SKIP_THIS \
                          OIIO_CONST_FUNC= \
                          OIIO_MAYBE_UNUSED= \
                          OIIO_NODISCARD=[[nodiscard]] \
+                         OIIO_DEPRECATED:=[[deprecated]] \
+                         OIIO_FORMAT_DEPRECATED:= \
                          OIIO_FORCEINLINE=inline
 
 

--- a/src/include/OpenImageIO/errorhandler.h
+++ b/src/include/OpenImageIO/errorhandler.h
@@ -81,13 +81,11 @@ public:
     void debug(const std::string&) {}
 #endif
 
-    //
     // Formatted output with the same notation as Strutil::format.
     /// Use with caution! Some day this will change to be fmt-like rather
     /// than printf-like.
-    //
     template<typename... Args>
-    void info(const char* format, const Args&... args)
+    OIIO_FORMAT_DEPRECATED void info(const char* format, const Args&... args)
     {
         if (verbosity() >= VERBOSE)
             info(Strutil::format(format, args...));
@@ -97,7 +95,7 @@ public:
     /// Will not print unless verbosity >= NORMAL (i.e. will suppress
     /// for QUIET).
     template<typename... Args>
-    void warning(const char* format, const Args&... args)
+    OIIO_FORMAT_DEPRECATED void warning(const char* format, const Args&... args)
     {
         if (verbosity() >= NORMAL)
             warning(Strutil::format(format, args...));
@@ -106,7 +104,7 @@ public:
     /// Error message with printf-like formatted error message.
     /// Will print regardless of verbosity.
     template<typename... Args>
-    void error(const char* format, const Args&... args)
+    OIIO_FORMAT_DEPRECATED void error(const char* format, const Args&... args)
     {
         error(Strutil::format(format, args...));
     }
@@ -114,7 +112,7 @@ public:
     /// Severe error message with printf-like formatted error message.
     /// Will print regardless of verbosity.
     template<typename... Args>
-    void severe(const char* format, const Args&... args)
+    OIIO_FORMAT_DEPRECATED void severe(const char* format, const Args&... args)
     {
         severe(Strutil::format(format, args...));
     }
@@ -123,7 +121,7 @@ public:
     /// Will not print if verbosity is QUIET.  Also note that unlike
     /// the other routines, message() will NOT append a newline.
     template<typename... Args>
-    void message(const char* format, const Args&... args)
+    OIIO_FORMAT_DEPRECATED void message(const char* format, const Args&... args)
     {
         if (verbosity() > QUIET)
             message(Strutil::format(format, args...));
@@ -133,8 +131,8 @@ public:
     /// This will not produce any output if not in DEBUG mode, or
     /// if verbosity is QUIET.
     template<typename... Args>
-    void debug(const char* format OIIO_MAYBE_UNUSED,
-               const Args&... args OIIO_MAYBE_UNUSED)
+    OIIO_FORMAT_DEPRECATED void debug(const char* format OIIO_MAYBE_UNUSED,
+                                      const Args&... args OIIO_MAYBE_UNUSED)
     {
 #ifndef NDEBUG
         debug(Strutil::format(format, args...));

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -974,10 +974,11 @@ public:
 
     /// Error reporting for ImageBuf: call this with Strutil::format
     /// formatting conventions.  It is not necessary to have the error
-    /// message contain a trailing newline.Beware, this is in transition, is
-    /// currently printf-like but will someday change to python-like!
+    /// message contain a trailing newline. Beware, this is in transition,
+    /// is currently printf-like but will someday change to python-like!
     template<typename... Args>
-    void error(const char* fmt, const Args&... args) const
+    OIIO_FORMAT_DEPRECATED void error(const char* fmt,
+                                      const Args&... args) const
     {
         error(Strutil::format(fmt, args...));
     }

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1586,6 +1586,7 @@ public:
     /// Use with caution! Some day this will change to be fmt-like rather
     /// than printf-like.
     template<typename... Args>
+    OIIO_FORMAT_DEPRECATED
     void error(const char* fmt, const Args&... args) const {
         append_error(Strutil::format (fmt, args...));
     }
@@ -2227,6 +2228,7 @@ public:
     /// Use with caution! Some day this will change to be fmt-like rather
     /// than printf-like.
     template<typename... Args>
+    OIIO_FORMAT_DEPRECATED
     void error(const char* fmt, const Args&... args) const {
         append_error(Strutil::format (fmt, args...));
     }
@@ -2821,6 +2823,7 @@ void debugf (const char* fmt, const T1& v1, const Args&... args)
 /// debug output with the same conventions as Strutil::format. Beware, this
 /// will change one day!
 template<typename T1, typename... Args>
+OIIO_FORMAT_DEPRECATED
 void debug (const char* fmt, const T1& v1, const Args&... args)
 {
     debug (Strutil::format(fmt, v1, args...));

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -660,7 +660,8 @@ public:
     /// fmt::format (or future std::format) but for now, it is back
     /// compatible and equivalent to sprintf.
     template<typename... Args>
-    static ustring format(const char* fmt, const Args&... args)
+    OIIO_FORMAT_DEPRECATED static ustring format(const char* fmt,
+                                                 const Args&... args)
     {
         return ustring(Strutil::format(fmt, args...));
     }

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -38,8 +38,10 @@ test_format()
     OIIO_CHECK_EQUAL(Strutil::sprintf("%d", int64_t(0xffffffffffffffff)), "-1");
     OIIO_CHECK_EQUAL(Strutil::sprintf("%u", uint64_t(0xffffffffffffffff)), "18446744073709551615");
 
+#ifndef OIIO_HIDE_FORMAT
     // spot check that Strutil::old::format() is sprintf:
     OIIO_CHECK_EQUAL(Strutil::old::format("%d",1), "1");
+#endif
 
     // Test formatting with Strutil::fmt::format(), which uses the
     // Python conventions:
@@ -61,9 +63,14 @@ test_format()
     OIIO_CHECK_EQUAL(Strutil::fmt::format("{} {:f} {:g}", int(3), 3.14f, 3.14f),
                      "3 3.140000 3.14");
 
-    // Check that Strutil::format is currently aliased to old::format:
-    OIIO_CHECK_EQUAL(Strutil::format("%d",1), "1");
-
+#ifndef OIIO_HIDE_FORMAT
+    // Check that Strutil::format is aliased the right way
+#    if OIIO_FORMAT_IS_FMT
+    OIIO_CHECK_EQUAL(Strutil::format("{}", 1), "1");
+#    else
+    OIIO_CHECK_EQUAL(Strutil::format("%d", 1), "1");
+#    endif
+#endif
 
     Benchmarker bench;
     bench.indent (2);


### PR DESCRIPTION
* strutil.h already had a symbol called OIIO_FORMAT_IS_FMT defined to
  0 or 1 that reveals (to clients of OIIO) whether Strutil::format()
  behaves like printf (the old and current way) or like std::format
  (the future way). Now we adjust so that the caller may pre-set the
  value to force one implementation or the other, at least for the
  "inline" functions of the headers.

* As an aid to downstream packages trying to ensure that they aren't
  using the function slated for eventual deprecation or behavior
  change, you can now define OIIO_HIDE_FORMAT to cause a deprecation
  warning now on those functions that will eventually change or be
  deprecated. This can help to identify any places where you call the
  future-deprecated functions and change them to a "safe" variety.
