### PR TITLE
Bump minimum OpenCV supported to >= 3.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * Note that OpenVDB 8.0+ requires C++14 or higher.
  * If you want support for converting to and from OpenCV data structures,
    or for capturing images from a camera:
-     * OpenCV 2.x, 3.x, or 4.x (tested through 4.5)
+     * OpenCV 3.x, or 4.x (tested through 4.5)
  * If you want support for GIF images:
      * giflib >= 4.1 (tested through 5.2; 5.0+ is strongly recommended for
        stability and thread safety)

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -155,7 +155,7 @@ checked_find_package (HDF5
                    ISDEPOF      Field3D)
 checked_find_package (OpenColorIO
                    DEFINITIONS  -DUSE_OCIO=1 -DUSE_OPENCOLORIO=1)
-checked_find_package (OpenCV
+checked_find_package (OpenCV 3.0
                    DEFINITIONS  -DUSE_OPENCV=1)
 
 # Intel TBB

--- a/src/cmake/modules/FindOpenCV.cmake
+++ b/src/cmake/modules/FindOpenCV.cmake
@@ -49,13 +49,7 @@ set (libdirs "${PROJECT_SOURCE_DIR}/lib"
              /usr/local/opt/opencv3/lib
              )
 
-if (NOT ${OpenCV_VERSION} VERSION_LESS 4.0.0)
-    set (opencv_components opencv_core opencv_imgproc opencv_videoio)
-elseif (NOT ${OpenCV_VERSION} VERSION_LESS 3.0.0)
-    set (opencv_components opencv_videoio opencv_imgproc opencv_core)
-else (NOT ${OpenCV_VERSION} VERSION_LESS 2.0.0)
-    set (opencv_components opencv_highgui opencv_imgproc opencv_core)
-endif ()
+set (opencv_components opencv_core opencv_imgproc opencv_videoio)
 foreach (component ${opencv_components})
     find_library (${component}_lib
                   NAMES ${component}
@@ -73,6 +67,9 @@ FIND_PACKAGE_HANDLE_STANDARD_ARGS (OpenCV
 if (OPENCV_FOUND)
     set (OpenCV_INCLUDES ${OpenCV_INCLUDE_DIR})
     set (OpenCV_LIBRARIES ${OpenCV_LIBS})
+    foreach (component ${opencv_components})
+        list (APPEND OpenCV_${component}_LIBRARIES ${${component}_lib})
+    endforeach ()
 endif ()
 
 MARK_AS_ADVANCED (OpenCV_INCLUDE_DIR OpenCV_LIBS)


### PR DESCRIPTION
Only for master+, will not be backported to release branches.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
