### PR TITLE
TIFF: honor caller request for single threaded

### DIFF
--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -2063,6 +2063,8 @@ TIFFInput::read_native_tiles(int subimage, int miplevel, int xbegin, int xend,
         // only if we're threading and don't enter the thread pool recursively!
         && pool->size() > 1
         && !pool->is_worker()
+        // only if this ImageInput wasn't asked to be single-threaded
+        && this->threads() != 1
         // and not if the feature is turned off
         && m_spec.get_int_attribute("tiff:multithread",
                                     OIIO::get_int_attribute("tiff:multithread"));

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -1127,6 +1127,8 @@ TIFFOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
         // only if we're threading and don't enter the thread pool recursively!
         && pool->size() > 1
         && !pool->is_worker()
+        // only if this ImageInput wasn't asked to be single-threaded
+        && this->threads() != 1
         // and not if the feature is turned off
         && m_spec.get_int_attribute("tiff:multithread",
                                     OIIO::get_int_attribute("tiff:multithread"));


### PR DESCRIPTION
ImageInput and ImageOutput have ways for the caller to say that there
should be no "fan-out" in the internals of what the reader or writer
needs to do. But TIFF wasn't honoring this.

