### PR TITLE
Beef up thread safety of ImageBuf init_spec() and read().

### DIFF
--- a/src/libutil/spinlock_test.cpp
+++ b/src/libutil/spinlock_test.cpp
@@ -44,6 +44,7 @@ time_lock_cycle()
     std::cout << "Cost of lock/unlock cycle under no contention:\n";
     spin_mutex sm;
     std::mutex m;
+    std::recursive_mutex rm;
     bench("spin_mutex", [&]() {
         sm.lock();
         sm.unlock();
@@ -51,6 +52,10 @@ time_lock_cycle()
     bench("std::mutex", [&]() {
         m.lock();
         m.unlock();
+    });
+    bench("std::recursive_mutex", [&]() {
+        rm.lock();
+        rm.unlock();
     });
 }
 


### PR DESCRIPTION
I don't think issues have been reported, so maybe this wasn't a
problem in practice for reasons I've long forgotten about, but doing
some other work in ImageBuf, I noticed what I think was a thread
safety problem.

ImageBuf reads are done lazily, a lot of operations call
validate_spec() or validate_pixels() which can trigger a call to
init_spec() or read() if they have not yet been done, and those had a
spin mutex protecting them from being called at the same time. But the
underlying read() and init_spec() themselves did not have any lock,
which made me worried about what would happen if one user thread was
explicitly calling read() while another was calling it implicitly
through validate.

Also, spin_lock is probably inappropriate for something that could
trigger an entire image read from disk -- it's meant specifically for
situtions where the lock only will be held for a few instructions.

So, this patch:

* Renames ImageBufImpl::m_valid_mutex to m_mutex, reflecting that it's
  not merely guarding access to `m_spec_valid` and `m_pixels_valid`,
  but to potentially anything internal to the ImageBufImpl that needs
  thread safety.

* Changes that mutex from a spin_mutex to a std::recursive_mutex, to
  reflect that it *may* block longer than a few cycles, so blocked
  threads should yield rather than spin. And recursive to simplify the
  hand-off logic between validate_spec, validate_pixels, init_spec,
  and read, the former two may call the latter two.

* Add locks to read() and init_spec(), which previously lacked them (I
  think in error), in addition to the existing ones in the validate
  methods.

* For some locking ImageBufImpl methods, add a param that lets the
  caller (which will always be internal code) specify that the lock is
  already held.

* Add a timing test of recursive_mutex to spinlock_test, just to verify
  that I'm not doing anything to totally botch performance. On my Intel
  Mac laptop, an uncontested lock acquisition/release is 6.4ns for a
  spin_mutex, 16ns for a std::mutex, and 27ns for std::recursive_mutex.
  So this is definitely a more expensive lock, but 27ns is still very
  reasonable, and *most* operations don't need to acquire the lock at
  all (first it checks the m_spec_valid or m_pixels_valid, once they are
  set there is no more locking).

* Improve ImageBuf docs, adding more explanation including some guideines
  about which methods are considered thread-safe.

