### PR TITLE
Targa: fix alpha handling

### DIFF
--- a/testsuite/targa-tgautils/ref/out.txt
+++ b/testsuite/targa-tgautils/ref/out.txt
@@ -50,6 +50,7 @@ Reading ../../../../../oiio-images/targa/CTC16.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 5
     targa:ImageID: "Truevision(R) Sample Image"
+    tga:alpha_type: 2
 Comparing "../../../../../oiio-images/targa/CTC16.TGA" and "CTC16.TGA"
 PASS
 Reading ../../../../../oiio-images/targa/CTC24.TGA
@@ -86,6 +87,7 @@ Reading ../../../../../oiio-images/targa/CTC32.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 8
     targa:ImageID: "Truevision(R) Sample Image"
+    tga:alpha_type: 2
 Comparing "../../../../../oiio-images/targa/CTC32.TGA" and "CTC32.TGA"
 PASS
 Reading ../../../../../oiio-images/targa/UBW8.TGA
@@ -137,6 +139,7 @@ Reading ../../../../../oiio-images/targa/UTC16.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 5
     targa:ImageID: "Truevision(R) Sample Image"
+    tga:alpha_type: 2
 Comparing "../../../../../oiio-images/targa/UTC16.TGA" and "UTC16.TGA"
 PASS
 Reading ../../../../../oiio-images/targa/UTC24.TGA
@@ -171,6 +174,7 @@ Reading ../../../../../oiio-images/targa/UTC32.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 8
     targa:ImageID: "Truevision(R) Sample Image"
+    tga:alpha_type: 2
 Comparing "../../../../../oiio-images/targa/UTC32.TGA" and "UTC32.TGA"
 PASS
 Reading ../../../../../oiio-images/targa/round_grill.tga


### PR DESCRIPTION
There are several alpha choices. We were assuming that color values
were unassociated (need to be premultiplied) unless it was marked as
premultiplied alpha. But it seems that, actually, we should only
premultiply if it's "useful alpha". [Indeed, their terminology is
the worst.]

Rename the m_alpha member to m_alpha_type to clarifywhat it holds.
Also add the alpha type to the metadata as "tga:alpha_type" to make it
easier to inspect the value in tga files.
