### PR TITLE
ImageBuf: Expose strides to ctr from wrapped buffer

### DIFF
--- a/src/doc/Doxyfile
+++ b/src/doc/Doxyfile
@@ -2155,7 +2155,7 @@ INCLUDE_FILE_PATTERNS  = *.h
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
 PREDEFINED             = DOXYGEN_SHOULD_SKIP_THIS \
-                         OIIO_DOXYGEN_ONLY:=1 \
+                         OIIO_DOXYGEN:=1 \
                          OIIO_NO_SANITIZE_ADDRESS:= \
                          OIIO_API:= \
                          OIIO_UTIL_API:= \

--- a/src/doc/imagebuf.rst
+++ b/src/doc/imagebuf.rst
@@ -57,8 +57,8 @@ Constructing a writable ImageBuf
 Constructing an ImageBuf that "wraps" an application buffer
 -------------------------------------------------------------
 
-.. doxygenfunction:: OIIO::ImageBuf::ImageBuf(const ImageSpec &spec, void *buffer)
-.. doxygenfunction:: OIIO::ImageBuf::reset(const ImageSpec &spec, void *buffer)
+.. doxygenfunction:: OIIO::ImageBuf::ImageBuf(const ImageSpec &spec, void *buffer, stride_t xstride = AutoStride, stride_t ystride = AutoStride, stride_t zstride = AutoStride)
+.. doxygenfunction:: OIIO::ImageBuf::reset(const ImageSpec &spec, void *buffer, stride_t xstride = AutoStride, stride_t ystride = AutoStride, stride_t zstride = AutoStride)
 
 
 

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -98,7 +98,7 @@ void OIIO_UTIL_API sync_output (std::ostream &file, string_view str);
 /// works with any types that understand stream output via '<<'.
 /// The formatting of the string will always use the classic "C" locale
 /// conventions (in particular, '.' as decimal separator for float values).
-#ifdef OIIO_DOXYGEN_ONLY
+#ifdef OIIO_DOXYGEN
 template<typename Str, typename... Args>
 inline std::string sprintf(const Str& fmt, Args&&... args)
 {


### PR DESCRIPTION
Internally, ImageBuf has for some time now supported strided or
non-contiguous buffers (for IBs that reside in memory, rather than in
an ImageCache). It was originally anticipated to accommodate cases
where we would want pixels or scanlines to have particular alignment
or spacing, such as to be even multiples of the SIMD width.

But we never allowed the kind of IB that "wraps" an application's
memory buffer to specify the strides, in case the app buffer was in
some layout that was not contiguous. This patch adds that ability, by
amending that constructor with stride values (which are optional and
default to AutoStride, which indicates that contiguity should be
assumed). This is 100% back compatible for source code.

This lets you do some cool things with in-memory buffers:

* More flexible about the kinds and layouts of buffers that you can wrap
  to look like an IB.

* Can easily make an IB that wraps an interior rectangular subset of
  another buffer (including another ImageBuf).

* To a limited extent, makes it possible to have an IB that is a "view"
  of another IB (if the second IB is in memory), including strided pixels
  or scanlines -- and even if the strides are negative (this lets you make
  an IB view of a buffer where copying the buffer can reverse left/right
  or top/bottom, however you can't use it to change the channel order or
  layout within each pixel).

Some other changes that came along for the ride:

* Added `ImageBuf::contiguous()`, which tells you if the memory layout is
  contiguous (will return false if it's not an in-memory buffer of some
  kind, so ImageCache-backed IBs are NOT considered contiguous).

* Renamed some internal types and fields, in particular, changes like
  `size_t ImageBufImpl::m_pixel_bytes` to `stride_t m_xstride` to make it
  clear that the values are strides and can be negative.
