### PR TITLE
Make a unit test for color.h contents

### DIFF
--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -212,6 +212,11 @@ install_targets (OpenImageIO)
 
 if (OIIO_BUILD_TESTS)
 
+    add_executable (color_test color_test.cpp)
+    target_link_libraries (color_test PRIVATE OpenImageIO)
+    set_target_properties (color_test PROPERTIES FOLDER "Unit Tests")
+    add_test (unit_imagebuf ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/color_test)
+
     add_executable (imagebuf_test imagebuf_test.cpp)
     target_link_libraries (imagebuf_test PRIVATE OpenImageIO)
     set_target_properties (imagebuf_test PROPERTIES FOLDER "Unit Tests")

--- a/src/libOpenImageIO/color_test.cpp
+++ b/src/libOpenImageIO/color_test.cpp
@@ -1,0 +1,140 @@
+// Copyright 2008-present Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+#include <OpenImageIO/argparse.h>
+#include <OpenImageIO/benchmark.h>
+#include <OpenImageIO/color.h>
+#include <OpenImageIO/simd.h>
+#include <OpenImageIO/strutil.h>
+#include <OpenImageIO/timer.h>
+#include <OpenImageIO/typedesc.h>
+#include <OpenImageIO/unittest.h>
+
+
+using namespace OIIO;
+using namespace simd;
+
+
+// Aid for things that are too short to benchmark accurately
+#define REP10(x) x, x, x, x, x, x, x, x, x, x
+
+static int iterations = 1000000;
+static int ntrials    = 5;
+static bool verbose   = false;
+
+
+
+static void
+getargs(int argc, char* argv[])
+{
+    ArgParse ap;
+    // clang-format off
+    ap.intro("color_test\n" OIIO_INTRO_STRING)
+      .usage("color_test [options]");
+
+    ap.arg("-v", &verbose)
+      .help("Verbose mode");
+    ap.arg("--iters %d", &iterations)
+      .help(Strutil::fmt::format("Number of iterations (default: {})", iterations));
+    ap.arg("--trials %d", &ntrials)
+      .help("Number of trials");
+    // clang-format on
+
+    ap.parse(argc, (const char**)argv);
+}
+
+
+
+static void
+test_sRGB_conversion()
+{
+    Benchmarker bench;
+
+    OIIO_CHECK_EQUAL_THRESH(linear_to_sRGB(0.0f), 0.0f, 1.0e-6);
+    OIIO_CHECK_EQUAL_THRESH(linear_to_sRGB(1.0f), 1.0f, 1.0e-6);
+    OIIO_CHECK_EQUAL_THRESH(linear_to_sRGB(0.5f), 0.735356983052449f, 1.0e-6);
+
+    OIIO_CHECK_EQUAL_THRESH(sRGB_to_linear(0.0f), 0.0f, 1.0e-6);
+    OIIO_CHECK_EQUAL_THRESH(sRGB_to_linear(1.0f), 1.0f, 1.0e-6);
+    OIIO_CHECK_EQUAL_THRESH(sRGB_to_linear(0.5f), 0.214041140482232f, 1.0e-6);
+
+    // Check the SIMD versions, too
+    OIIO_CHECK_SIMD_EQUAL_THRESH(linear_to_sRGB(vfloat4(0.0f)), vfloat4(0.0f),
+                                 1.0e-5);
+    OIIO_CHECK_SIMD_EQUAL_THRESH(linear_to_sRGB(vfloat4(1.0f)), vfloat4(1.0f),
+                                 1.0e-5);
+    OIIO_CHECK_SIMD_EQUAL_THRESH(linear_to_sRGB(vfloat4(0.5f)),
+                                 vfloat4(0.735356983052449f), 1.0e-5);
+
+    OIIO_CHECK_SIMD_EQUAL_THRESH(sRGB_to_linear(vfloat4(0.0f)), vfloat4(0.0f),
+                                 1.0e-5);
+    OIIO_CHECK_SIMD_EQUAL_THRESH(sRGB_to_linear(vfloat4(1.0f)), vfloat4(1.0f),
+                                 1.0e-5);
+    OIIO_CHECK_SIMD_EQUAL_THRESH(sRGB_to_linear(vfloat4(0.5f)),
+                                 vfloat4(0.214041140482232f), 1.0e-5);
+
+    float fval = 0.5f;
+    clobber(fval);
+    vfloat4 vfval(fval);
+    clobber(vfval);
+    bench("sRGB_to_linear",
+          [&]() { return DoNotOptimize(sRGB_to_linear(fval)); });
+    bench("linear_to_sRGB",
+          [&]() { return DoNotOptimize(sRGB_to_linear(fval)); });
+    bench.work(4);
+    bench("sRGB_to_linear simd",
+          [&]() { return DoNotOptimize(sRGB_to_linear(vfval)); });
+    bench("linear_to_sRGB simd",
+          [&]() { return DoNotOptimize(sRGB_to_linear(vfval)); });
+}
+
+
+
+static void
+test_Rec709_conversion()
+{
+    Benchmarker bench;
+
+    OIIO_CHECK_EQUAL_THRESH(linear_to_Rec709(0.0f), 0.0f, 1.0e-6);
+    OIIO_CHECK_EQUAL_THRESH(linear_to_Rec709(1.0f), 1.0f, 1.0e-6);
+    OIIO_CHECK_EQUAL_THRESH(linear_to_Rec709(0.5f), 0.705515089922121f, 1.0e-6);
+
+    OIIO_CHECK_EQUAL_THRESH(Rec709_to_linear(0.0f), 0.0f, 1.0e-6);
+    OIIO_CHECK_EQUAL_THRESH(Rec709_to_linear(1.0f), 1.0f, 1.0e-6);
+    OIIO_CHECK_EQUAL_THRESH(Rec709_to_linear(0.5f), 0.259589400506286f, 1.0e-6);
+
+    float fval = 0.5f;
+    clobber(fval);
+    bench("Rec709_to_linear",
+          [&]() { return DoNotOptimize(Rec709_to_linear(fval)); });
+    bench("linear_to_Rec709",
+          [&]() { return DoNotOptimize(Rec709_to_linear(fval)); });
+}
+
+
+
+int
+main(int argc, char* argv[])
+{
+#if !defined(NDEBUG) || defined(OIIO_CI) || defined(OIIO_CODE_COVERAGE)
+    // For the sake of test time, reduce the default iterations for DEBUG,
+    // CI, and code coverage builds. Explicit use of --iters or --trials
+    // will override this, since it comes before the getargs() call.
+    iterations /= 10;
+    ntrials = 1;
+#endif
+
+    getargs(argc, argv);
+
+    test_sRGB_conversion();
+    test_Rec709_conversion();
+
+    return unit_test_failures != 0;
+}


### PR DESCRIPTION
Currently, it only tests the linear <-> sRGB and linear <-> Rec709
transformations.

This was meant to uncover the issue in #2929, but it passes CI tests
on Windows, so maybe it was a MSVS compiler bug that has since 
been fixed?
