### PR TITLE
Allow oiiotool to print metadata of computed images

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -225,6 +225,12 @@ contents of an expression may be any of:
     comma-separated)
   * `AVGCOLOR` : the average pixel value of the image (channels are
     comma-separated)
+  * `METABRIEF` : a string containing the brief one-line description that
+    would be printed with `oiiotool -info`.
+  * `META` : a multi-line string containing the full metadata that would
+    be printed with `oiiotool -info -v`.
+  * `STATS` : a multi-line string containing the image statistics that would
+    be printed with `oiiotool -stats`.
 
 * *imagename.'metadata'*
 

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -568,14 +568,27 @@ struct print_info_options {
 };
 
 
-// Print info about the named file to stdout, using print_info_options
-// opt for guidance on what to print and how to do it.  The total size
-// of the uncompressed pixels in the file is returned in totalsize.  The
-// return value will be true if everything is ok, or false if there is
-// an error (in which case the error message will be stored in 'error').
+// For either an ImageRec `img`, or a file on disk named by `filename`,
+// print info about the named file to stream `out`, using
+// print_info_options opt for guidance on what to print and how to do it.
+// The total size of the uncompressed pixels in the file is returned in
+// totalsize.  The return value will be true if everything is ok, or false
+// if there is an error(in which case the error message will be stored in
+// `error`).
 bool
-print_info(Oiiotool& ot, const std::string& filename,
+print_info(std::ostream& out, Oiiotool& ot, const std::string& filename,
            const print_info_options& opt, std::string& error);
+bool
+print_info(std::ostream& out, Oiiotool& ot, ImageRec* img,
+           const print_info_options& opt, std::string& error);
+
+// For an ImageBuf or a filename, print the stats into output stream `out`.
+void
+print_stats(std::ostream& out, Oiiotool& ot, const ImageBuf& input,
+            string_view indent = "");
+void
+print_stats(std::ostream& out, Oiiotool& ot, const std::string& filename,
+            int subimage = 0, int miplevel = 0, string_view indent = "");
 
 
 // Set an attribute of the given image.  The type should be one of

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -76,35 +76,30 @@ compute_sha1(Oiiotool& ot, ImageInput* input)
 
 template<typename T>
 static void
-print_nums(int n, const T* val, string_view sep = " ")
+print_nums(std::ostream& out, int n, const T* val, string_view sep = " ")
 {
     if (std::is_floating_point<T>::value || std::is_same<T, half>::value) {
         // Ensure uniform printing of NaN and Inf on all platforms
         for (int i = 0; i < n; ++i) {
             if (i)
-                Strutil::printf("%s", sep);
+                Strutil::print(out, "{}", sep);
             float v = float(val[i]);
             if (isnan(v))
-                Strutil::printf("nan");
+                Strutil::print(out, "nan");
             else if (isinf(v))
-                Strutil::printf("inf");
+                Strutil::print(out, "inf");
             else
-                Strutil::printf("%.9f", v);
+                Strutil::print(out, "{.9f}", v);
         }
     } else {
         // not floating point -- print the int values, then float equivalents
-        for (int i = 0; i < n; ++i) {
-            Strutil::printf(std::is_signed<T>::value ? "%s%d" : "%s%u",
-                            i ? sep : "", val[i]);
-        }
-        Strutil::printf(" (");
-        for (int i = 0; i < n; ++i) {
-            if (i)
-                Strutil::printf("%s", sep);
-            float v = convert_type<T, float>(val[i]);
-            Strutil::printf("%g", v);
-        }
-        Strutil::printf(")");
+        for (int i = 0; i < n; ++i)
+            Strutil::print(out, "{}{}", i ? sep : "", val[i]);
+        Strutil::print(out, " (");
+        for (int i = 0; i < n; ++i)
+            Strutil::print(out, "{}{}", i ? sep : "",
+                           convert_type<T, float>(val[i]));
+        Strutil::print(out, ")");
     }
 }
 
@@ -112,12 +107,13 @@ print_nums(int n, const T* val, string_view sep = " ")
 
 template<typename T>
 static bool
-dump_flat_data(ImageInput* input, const print_info_options& opt)
+dump_flat_data(std::ostream& out, ImageInput* input,
+               const print_info_options& opt)
 {
     const ImageSpec& spec(input->spec());
     std::vector<T> buf(spec.image_pixels() * spec.nchannels);
     if (!input->read_image(BaseTypeFromC<T>::value, &buf[0])) {
-        printf("    dump data: could not read image\n");
+        Strutil::print(out, "    dump data: could not read image\n");
         return false;
     }
     const T* ptr = &buf[0];
@@ -132,13 +128,13 @@ dump_flat_data(ImageInput* input, const print_info_options& opt)
                         continue;
                 }
                 if (spec.depth > 1 || spec.z != 0)
-                    Strutil::printf("    Pixel (%d, %d, %d): ", x + spec.x,
-                                    y + spec.y, z + spec.z);
+                    Strutil::print(out, "    Pixel ({}, {}, {}): ", x + spec.x,
+                                   y + spec.y, z + spec.z);
                 else
-                    Strutil::printf("    Pixel (%d, %d): ", x + spec.x,
-                                    y + spec.y);
-                print_nums(spec.nchannels, ptr);
-                Strutil::printf("\n");
+                    Strutil::print(out, "    Pixel ({}, {}): ", x + spec.x,
+                                   y + spec.y);
+                print_nums(out, spec.nchannels, ptr);
+                Strutil::print(out, "\n");
             }
         }
     }
@@ -165,14 +161,15 @@ dump_flat_data(ImageInput* input, const print_info_options& opt)
 
 
 static void
-dump_data(ImageInput* input, const print_info_options& opt)
+dump_data(std::ostream& out, ImageInput* input, const print_info_options& opt)
 {
+    using Strutil::print;
     const ImageSpec& spec(input->spec());
     if (spec.deep) {
         // Special handling of deep data
         DeepData dd;
         if (!input->read_native_deep_image(dd)) {
-            printf("    dump data: could not read image\n");
+            print(out, "    dump data: could not read image\n");
             return;
         }
         int nc = spec.nchannels;
@@ -182,27 +179,27 @@ dump_data(ImageInput* input, const print_info_options& opt)
                     int nsamples = dd.samples(pixel);
                     if (nsamples == 0 && !opt.dumpdata_showempty)
                         continue;
-                    std::cout << "    Pixel (";
+                    print(out, "    Pixel (");
                     if (spec.depth > 1 || spec.z != 0)
-                        std::cout << Strutil::sprintf("%d, %d, %d", x + spec.x,
-                                                      y + spec.y, z + spec.z);
+                        print(out, "{}, {}, {}", x + spec.x, y + spec.y,
+                              z + spec.z);
                     else
-                        std::cout << Strutil::sprintf("%d, %d", x + spec.x,
-                                                      y + spec.y);
-                    std::cout << "): " << nsamples << " samples"
-                              << (nsamples ? ":" : "");
+                        print(out, "{}, {}", x + spec.x, y + spec.y);
+                    print(out, "): {} samples {}", nsamples,
+                          nsamples ? ":" : "");
                     for (int s = 0; s < nsamples; ++s) {
                         if (s)
-                            std::cout << " / ";
+                            print(out, " / ");
                         for (int c = 0; c < nc; ++c) {
-                            std::cout << " " << spec.channelnames[c] << "=";
+                            print(out, " {}=", spec.channelnames[c]);
                             if (dd.channeltype(c) == TypeDesc::UINT)
-                                std::cout << dd.deep_value_uint(pixel, c, s);
+                                print(out, "{}",
+                                      dd.deep_value_uint(pixel, c, s));
                             else
-                                std::cout << dd.deep_value(pixel, c, s);
+                                print(out, "{}", dd.deep_value(pixel, c, s));
                         }
                     }
-                    std::cout << "\n";
+                    print(out, "\n");
                 }
             }
         }
@@ -210,7 +207,7 @@ dump_data(ImageInput* input, const print_info_options& opt)
     } else {
         OIIO_UNUSED_OK bool ok = true;
         OIIO_DISPATCH_TYPES(ok, "dump_flat_data", dump_flat_data, spec.format,
-                            input, opt);
+                            out, input, opt);
     }
 }
 
@@ -244,25 +241,28 @@ read_input(Oiiotool& ot, const std::string& filename, ImageBuf& img,
 
 
 
-static void
-print_stats_num(float val, int maxval, bool round)
+static std::string
+stats_num(float val, int maxval, bool round)
 {
     // Ensure uniform printing of NaN and Inf on all platforms
+    using Strutil::fmt::format;
+    std::string result;
     if (isnan(val))
-        printf("nan");
+        result = "nan";
     else if (isinf(val))
-        printf("inf");
+        result = "inf";
     else if (maxval == 0) {
-        printf("%f", val);
+        result = format("{:f}", val);
     } else {
         float fval = val * static_cast<float>(maxval);
         if (round) {
-            int v = static_cast<int>(roundf(fval));
-            printf("%d", v);
+            int v  = static_cast<int>(roundf(fval));
+            result = format("{}", v);
         } else {
-            printf("%0.2f", fval);
+            result = format("{:0.2f}", fval);
         }
     }
+    return result;
 }
 
 
@@ -302,89 +302,92 @@ get_intsample_maxval(const ImageSpec& spec)
 }
 
 
-static void
-print_stats_footer(unsigned int maxval)
+static std::string
+stats_footer(unsigned int maxval)
 {
     if (maxval == 0)
-        printf("(float)");
+        return "(float)";
     else
-        printf("(of %u)", maxval);
+        return Strutil::fmt::format("(of {})", maxval);
 }
 
 
-static void
-print_stats(Oiiotool& ot, const std::string& filename,
-            const ImageSpec& originalspec, int subimage = 0, int miplevel = 0,
-            bool indentmip = false)
-{
-    const char* indent = indentmip ? "      " : "    ";
-    ImageBuf input;
 
+void
+OiioTool::print_stats(std::ostream& out, Oiiotool& ot,
+                      const std::string& filename, int subimage, int miplevel,
+                      string_view indent)
+{
+    ImageBuf input;
     if (!read_input(ot, filename, input, subimage, miplevel)) {
         ot.error("stats", input.geterror());
         return;
     }
-    PixelStats stats;
-    if (!computePixelStats(stats, input)) {
+    print_stats(out, ot, input, /*input.nativespec(),*/ indent);
+}
+
+
+
+void
+OiioTool::print_stats(std::ostream& out, Oiiotool& ot, const ImageBuf& input,
+                      /*const ImageSpec& originalspec,*/ string_view indent)
+{
+    using Strutil::print;
+
+    PixelStats stats = computePixelStats(input);
+    if (!stats.min.size()) {
         std::string err = input.geterror();
-        ot.errorf("stats", "unable to compute: %s",
-                  err.empty() ? "unspecified error" : err.c_str());
+        ot.errorfmt("stats", "unable to compute: {}",
+                    err.empty() ? "unspecified error" : err.c_str());
         return;
     }
 
     // The original spec is used, otherwise the bit depth will
     // be reported incorrectly (as FLOAT)
+    const ImageSpec& originalspec(input.nativespec());
     unsigned int maxval = (unsigned int)get_intsample_maxval(originalspec);
 
-    printf("%sStats Min: ", indent);
+    print(out, "{}Stats Min: ", indent);
     for (unsigned int i = 0; i < stats.min.size(); ++i) {
-        print_stats_num(stats.min[i], maxval, true);
-        printf(" ");
+        Strutil::print(out, "{} ", stats_num(stats.min[i], maxval, true));
     }
-    print_stats_footer(maxval);
-    printf("\n");
+    Strutil::print(out, "{}\n", stats_footer(maxval));
 
-    printf("%sStats Max: ", indent);
+    print(out, "{}Stats Max: ", indent);
     for (unsigned int i = 0; i < stats.max.size(); ++i) {
-        print_stats_num(stats.max[i], maxval, true);
-        printf(" ");
+        Strutil::print(out, "{} ", stats_num(stats.max[i], maxval, true));
     }
-    print_stats_footer(maxval);
-    printf("\n");
+    print(out, "{}\n", stats_footer(maxval));
 
-    printf("%sStats Avg: ", indent);
+    print(out, "{}Stats Avg: ", indent);
     for (unsigned int i = 0; i < stats.avg.size(); ++i) {
-        print_stats_num(stats.avg[i], maxval, false);
-        printf(" ");
+        print(out, "{} ", stats_num(stats.avg[i], maxval, false));
     }
-    print_stats_footer(maxval);
-    printf("\n");
+    print(out, "{}\n", stats_footer(maxval));
 
-    printf("%sStats StdDev: ", indent);
+    print(out, "{}Stats StdDev: ", indent);
     for (unsigned int i = 0; i < stats.stddev.size(); ++i) {
-        print_stats_num(stats.stddev[i], maxval, false);
-        printf(" ");
+        print(out, "{} ", stats_num(stats.stddev[i], maxval, false));
     }
-    print_stats_footer(maxval);
-    printf("\n");
+    print(out, "{}\n", stats_footer(maxval));
 
-    printf("%sStats NanCount: ", indent);
+    print(out, "{}Stats NanCount: ", indent);
     for (unsigned int i = 0; i < stats.nancount.size(); ++i) {
-        printf("%llu ", (unsigned long long)stats.nancount[i]);
+        print(out, "{} ", (unsigned long long)stats.nancount[i]);
     }
-    printf("\n");
+    print(out, "\n");
 
-    printf("%sStats InfCount: ", indent);
+    print(out, "{}Stats InfCount: ", indent);
     for (unsigned int i = 0; i < stats.infcount.size(); ++i) {
-        printf("%llu ", (unsigned long long)stats.infcount[i]);
+        print(out, "{} ", (unsigned long long)stats.infcount[i]);
     }
-    printf("\n");
+    print(out, "\n");
 
-    printf("%sStats FiniteCount: ", indent);
+    print(out, "{}Stats FiniteCount: ", indent);
     for (unsigned int i = 0; i < stats.finitecount.size(); ++i) {
-        printf("%llu ", (unsigned long long)stats.finitecount[i]);
+        print(out, "{} ", (unsigned long long)stats.finitecount[i]);
     }
-    printf("\n");
+    print(out, "\n");
 
     if (input.deep()) {
         const DeepData* dd(input.deepdata());
@@ -455,24 +458,22 @@ print_stats(Oiiotool& ot, const std::string& filename,
                 }
             }
         }
-        printf("%sMin deep samples in any pixel : %llu\n", indent,
-               (unsigned long long)minsamples);
-        printf("%sMax deep samples in any pixel : %llu\n", indent,
-               (unsigned long long)maxsamples);
-        printf(
-            "%s%llu pixel%s had the max of %llu samples, including (x=%d, y=%d)\n",
-            indent, (unsigned long long)maxsamples_npixels,
-            maxsamples_npixels > 1 ? "s" : "", (unsigned long long)maxsamples,
-            maxsamples_pixel.x, maxsamples_pixel.y);
-        printf("%sAverage deep samples per pixel: %.2f\n", indent,
-               double(totalsamples) / double(npixels));
-        printf("%sTotal deep samples in all pixels: %llu\n", indent,
-               (unsigned long long)totalsamples);
-        printf("%sPixels with deep samples   : %llu\n", indent,
-               (unsigned long long)(npixels - emptypixels));
-        printf("%sPixels with no deep samples: %llu\n", indent,
-               (unsigned long long)emptypixels);
-        printf("%sSamples/pixel histogram:\n", indent);
+        print(out, "{}Min deep samples in any pixel : {}\n", indent,
+              minsamples);
+        print(out, "{}Max deep samples in any pixel : {}\n", indent,
+              maxsamples);
+        print(out,
+              "{}{} pixel{} had the max of {} samples, including (x={}, y={})\n",
+              indent, maxsamples_npixels, maxsamples_npixels > 1 ? "s" : "",
+              maxsamples, maxsamples_pixel.x, maxsamples_pixel.y);
+        print(out, "{}Average deep samples per pixel: {:.2f}\n", indent,
+              double(totalsamples) / double(npixels));
+        print(out, "{}Total deep samples in all pixels: {}\n", indent,
+              totalsamples);
+        print(out, "{}Pixels with deep samples   : {}\n", indent,
+              (npixels - emptypixels));
+        print(out, "{}Pixels with no deep samples: {}\n", indent, emptypixels);
+        print(out, "{}Samples/pixel histogram:\n", indent);
         size_t grandtotal = 0;
         for (size_t i = 0, e = nsamples_histogram.size(); i < e; ++i)
             grandtotal += nsamples_histogram[i];
@@ -482,25 +483,25 @@ print_stats(Oiiotool& ot, const std::string& filename,
             if (i < 8 || i == (e - 1) || OIIO::ispow2(i + 1)) {
                 // batch by powers of 2, unless it's a small number
                 if (i == binstart)
-                    printf("%s  %3lld    ", indent, (long long)i);
+                    print(out, "{}  {:3}    ", indent, i);
                 else
-                    printf("%s  %3lld-%3lld", indent, (long long)binstart,
-                           (long long)i);
-                printf(" : %8lld (%4.1f%%)\n", (long long)bintotal,
-                       (100.0 * bintotal) / grandtotal);
+                    print(out, "{}  {:3}-{:3}", indent, binstart, i);
+                print(out, " : {:8} ({:4.1f}%)\n", bintotal,
+                      (100.0 * bintotal) / grandtotal);
                 binstart = i + 1;
                 bintotal = 0;
             }
         }
         if (depthchannel >= 0) {
-            printf("%sMinimum depth was %g at (%d, %d)\n", indent, mindepth,
-                   mindepth_pixel.x, mindepth_pixel.y);
-            printf("%sMaximum depth was %g at (%d, %d)\n", indent, maxdepth,
-                   maxdepth_pixel.x, maxdepth_pixel.y);
+            print(out, "{}Minimum depth was {} at ({}, {})\n", indent, mindepth,
+                  mindepth_pixel.x, mindepth_pixel.y);
+            print(out, "{}Maximum depth was {} at ({}, {})\n", indent, maxdepth,
+                  maxdepth_pixel.x, maxdepth_pixel.y);
         }
         if (nonfinites > 0) {
-            printf(
-                "%sNonfinite values: %lld, including (x=%d, y=%d, chan=%s, samp=%d)\n",
+            Strutil::print(
+                out,
+                "{}Nonfinite values: {}, including (x={}, y={}, chan={}, samp={})\n",
                 indent, nonfinites, nonfinite_pixel.x, nonfinite_pixel.y,
                 input.spec().channelnames[nonfinite_pixel_chan].c_str(),
                 nonfinite_pixel_samp);
@@ -508,29 +509,27 @@ print_stats(Oiiotool& ot, const std::string& filename,
     } else {
         std::vector<float> constantValues(input.spec().nchannels);
         if (isConstantColor(input, &constantValues[0])) {
-            printf("%sConstant: Yes\n", indent);
-            printf("%sConstant Color: ", indent);
+            print(out, "{}Constant: Yes\n", indent);
+            print(out, "{}Constant Color: ", indent);
             for (unsigned int i = 0; i < constantValues.size(); ++i) {
-                print_stats_num(constantValues[i], maxval, false);
-                printf(" ");
+                print(out, "{} ", stats_num(constantValues[i], maxval, false));
             }
-            print_stats_footer(maxval);
-            printf("\n");
+            print(out, "{}\n", stats_footer(maxval));
         } else {
-            printf("%sConstant: No\n", indent);
+            print(out, "{}Constant: No\n", indent);
         }
 
         if (isMonochrome(input)) {
-            printf("%sMonochrome: Yes\n", indent);
+            print(out, "{}Monochrome: Yes\n", indent);
         } else {
-            printf("%sMonochrome: No\n", indent);
+            print(out, "{}Monochrome: No\n", indent);
         }
     }
 }
 
 
 
-static const char*
+static std::string
 brief_format_name(TypeDesc type, int bits = 0)
 {
     if (!bits)
@@ -540,11 +539,11 @@ brief_format_name(TypeDesc type, int bits = 0)
             return "f";
         if (type.basetype == TypeDesc::HALF)
             return "h";
-        return ustring::sprintf("f%d", bits).c_str();
+        return Strutil::fmt::format("f{}", bits);
     } else if (type.is_signed()) {
-        return ustring::sprintf("i%d", bits).c_str();
+        return Strutil::fmt::format("i{}", bits);
     } else {
-        return ustring::sprintf("u%d", bits).c_str();
+        return Strutil::fmt::format("u{}", bits);
     }
     return type.c_str();  // use the name implied by type
 }
@@ -552,14 +551,15 @@ brief_format_name(TypeDesc type, int bits = 0)
 
 
 static void
-print_info_subimage(Oiiotool& ot, int current_subimage, int num_of_subimages,
-                    int nmip, const ImageSpec& spec, ImageInput* input,
+print_info_subimage(std::ostream& out, Oiiotool& ot, int current_subimage,
+                    int num_of_subimages, int nmip, const ImageSpec& spec,
+                    ImageRec* img, ImageInput* input,
                     const std::string& filename, const print_info_options& opt,
                     std::regex& field_re, std::regex& field_exclude_re,
                     ImageSpec::SerialFormat serformat,
                     ImageSpec::SerialVerbose verbose)
 {
-    using Strutil::sprintf;
+    using Strutil::fmt::format;
 
     int padlen = std::max(0, (int)opt.namefieldlength - (int)filename.length());
     std::string padding(padlen, ' ');
@@ -572,24 +572,32 @@ print_info_subimage(Oiiotool& ot, int current_subimage, int num_of_subimages,
     std::vector<std::string> lines;
     Strutil::split(spec.serialize(serformat, verbose), lines, "\n");
 
-    if (opt.compute_sha1
+    if (input && opt.compute_sha1
         && (opt.metamatch.empty() || std::regex_search("sha-1", field_re))) {
         // Before sha-1, be sure to point back to the highest-res MIP level
         ImageSpec tmpspec;
         std::string sha = compute_sha1(ot, input);
         if (serformat == ImageSpec::SerialText)
-            lines.insert(lines.begin() + 1, sprintf("    SHA-1: %s", sha));
+            lines.insert(lines.begin() + 1, format("    SHA-1: {}", sha));
         else if (serformat == ImageSpec::SerialText)
-            lines.insert(lines.begin() + 1, sprintf("<SHA1>%s</SHA1>", sha));
+            lines.insert(lines.begin() + 1, format("<SHA1>{}</SHA1>", sha));
     }
 
     // Count MIP levels
     if (printres && nmip > 1) {
-        ImageSpec mipspec;
-        std::string mipdesc = sprintf("    MIP-map levels: %dx%d", spec.width,
-                                      spec.height);
-        for (int m = 1; input->seek_subimage(current_subimage, m, mipspec); ++m)
-            mipdesc += sprintf(" %dx%d", mipspec.width, mipspec.height);
+        std::string mipdesc = format("    MIP-map levels: {}x{}", spec.width,
+                                     spec.height);
+        if (img) {
+            for (int m = 1; m < nmip; ++m) {
+                ImageSpec* mipspec = img->spec(current_subimage, m);
+                mipdesc += format(" {}x{}", mipspec->width, mipspec->height);
+            }
+        } else if (input) {
+            ImageSpec mipspec;
+            for (int m = 1; input->seek_subimage(current_subimage, m, mipspec);
+                 ++m)
+                mipdesc += format(" {}x{}", mipspec.width, mipspec.height);
+        }
         lines.insert(lines.begin() + 1, mipdesc);
     }
 
@@ -599,61 +607,69 @@ print_info_subimage(Oiiotool& ot, int current_subimage, int num_of_subimages,
             || std::regex_search("resolution, width, height, depth, channels",
                                  field_re)) {
             std::string orig_line0 = lines[0];
-            if (current_subimage == 0)
-                lines[0] = Strutil::sprintf("%s%s : ", filename, padding)
-                           + lines[0];
-            else
-                lines[0] = Strutil::sprintf(" subimage %2d: ", current_subimage)
-                           + lines[0];
+            if (current_subimage == 0) {
+                if (filename.size())
+                    lines[0] = format("{}{} : {}", filename, padding, lines[0]);
+            } else
+                lines[0] = format(" subimage {:2}: {}", current_subimage,
+                                  lines[0]);
             if (opt.sum) {
                 imagesize_t imagebytes = spec.image_bytes(true);
                 // totalsize += imagebytes;
-                lines[0] += sprintf(" (%.2f MB)",
-                                    (float)imagebytes / (1024.0 * 1024.0));
+                lines[0] += format(" ({.2f} MB)",
+                                   (float)imagebytes / (1024.0 * 1024.0));
             }
-            lines[0] += sprintf(" %s", input->format_name());
+            std::string file_format_name;
+            if (img)
+                file_format_name = (*img)(current_subimage).file_format_name();
+            else if (input)
+                file_format_name = input->format_name();
+            lines[0] += format(" {}", file_format_name);
             // we print info about how many subimages are stored in file
             // only when we have more then one subimage
             if (!opt.verbose && num_of_subimages != 1)
-                lines[0] += sprintf(" (%d subimages%s)", num_of_subimages,
-                                    (nmip > 1) ? " +mipmap)" : "");
+                lines[0] += format(" ({} subimages{})", num_of_subimages,
+                                   (nmip > 1) ? " +mipmap)" : "");
             if (!opt.verbose && num_of_subimages == 1 && (nmip > 1))
                 lines[0] += " (+mipmap)";
             if (num_of_subimages > 1 && current_subimage == 0 && opt.subimages)
                 lines.insert(lines.begin() + 1,
-                             sprintf(" subimage  0: %s %s", orig_line0,
-                                     input->format_name()));
+                             format(" subimage  0: {} {}", orig_line0,
+                                    file_format_name));
         } else {
             lines.erase(lines.begin());
         }
     } else if (serformat == ImageSpec::SerialXML) {
         if (nmip > 1)
             lines.insert(lines.begin() + 1,
-                         sprintf("<miplevels>%d</miplevels>", nmip));
+                         format("<miplevels>{}</miplevels>", nmip));
         if (num_of_subimages > 1)
-            lines.insert(lines.begin() + 1, sprintf("<subimages>%d</subimages>",
-                                                    num_of_subimages));
+            lines.insert(lines.begin() + 1,
+                         format("<subimages>{}</subimages>", num_of_subimages));
     }
 
     if (current_subimage == 0 && opt.verbose && num_of_subimages != 1
         && serformat == ImageSpec::SerialText) {
         // info about num of subimages and their resolutions
         int movie     = spec.get_int_attribute("oiio:Movie");
-        std::string s = sprintf("    %d subimages: ", num_of_subimages);
+        std::string s = format("    {} subimages: ", num_of_subimages);
         for (int i = 0; i < num_of_subimages; ++i) {
             ImageSpec spec;
-            input->seek_subimage(i, 0, spec);
+            if (img)
+                spec = *img->nativespec(i);
+            if (input)
+                input->seek_subimage(i, 0, spec);
             int bits = spec.get_int_attribute("oiio:BitsPerSample",
                                               spec.format.size() * 8);
             if (i)
                 s += ", ";
             if (spec.depth > 1)
-                s += sprintf("%dx%dx%d ", spec.width, spec.height, spec.depth);
+                s += format("{}x{}x{} ", spec.width, spec.height, spec.depth);
             else
-                s += sprintf("%dx%d ", spec.width, spec.height);
+                s += format("{}x{} ", spec.width, spec.height);
             for (int c = 0; c < spec.nchannels; ++c)
-                s += sprintf("%c%s", c ? ',' : '[',
-                             brief_format_name(spec.channelformat(c), bits));
+                s += format("{}{}", c ? ',' : '[',
+                            brief_format_name(spec.channelformat(c), bits));
             s += "]";
             if (movie)
                 break;
@@ -687,26 +703,27 @@ print_info_subimage(Oiiotool& ot, int current_subimage, int num_of_subimages,
     std::string ser = Strutil::join(lines, "\n");
     if (ser[ser.size() - 1] != '\n')
         ser += '\n';
-    std::cout << ser;
+    out << ser;
 
-    if (opt.dumpdata) {
+    if (input && opt.dumpdata) {
         ImageSpec tmp;
         input->seek_subimage(current_subimage, 0, tmp);
-        dump_data(input, opt);
+        dump_data(out, input, opt);
     }
 
-    if (opt.compute_stats
+    if (input && opt.compute_stats
         && (opt.metamatch.empty() || std::regex_search("stats", field_re))) {
         for (int m = 0; m < nmip; ++m) {
             ImageSpec mipspec;
             input->seek_subimage(current_subimage, m, mipspec);
             if (opt.filenameprefix)
-                std::cout << sprintf("%s : ", filename);
+                Strutil::print(out, "{} : ", filename);
             if (nmip > 1) {
-                std::cout << sprintf("    MIP %d of %d (%d x %d):\n", m, nmip,
-                                     mipspec.width, mipspec.height);
+                Strutil::print(out, "    MIP {} of {} ({} x {}):\n", m, nmip,
+                               mipspec.width, mipspec.height);
             }
-            print_stats(ot, filename, spec, current_subimage, m, nmip > 1);
+            print_stats(out, ot, filename, /*spec,*/ current_subimage, m,
+                        nmip > 1 ? "      " : "    ");
         }
     }
 }
@@ -714,15 +731,13 @@ print_info_subimage(Oiiotool& ot, int current_subimage, int num_of_subimages,
 
 
 bool
-OiioTool::print_info(Oiiotool& ot, const std::string& filename,
+OiioTool::print_info(std::ostream& out, Oiiotool& ot, ImageRec* img,
                      const print_info_options& opt, std::string& error)
 {
+    using Strutil::fmt::format;
     error.clear();
-    auto input = ImageInput::open(filename, &ot.input_config);
-    if (!input) {
-        error = geterror();
-        if (error.empty())
-            error = Strutil::sprintf("Could not open \"%s\"", filename);
+    if (!img) {
+        error = "No image";
         return false;
     }
 
@@ -740,9 +755,8 @@ OiioTool::print_info(Oiiotool& ot, const std::string& filename,
             field_re.assign(opt.metamatch, std::regex_constants::extended
                                                | std::regex_constants::icase);
         } catch (const std::exception& e) {
-            error
-                = Strutil::sprintf("Regex error '%s' on metamatch regex \"%s\"",
-                                   e.what(), opt.metamatch);
+            error = format("Regex error '{}' on metamatch regex \"{}\"",
+                           e.what(), opt.metamatch);
             return false;
         }
     }
@@ -752,9 +766,70 @@ OiioTool::print_info(Oiiotool& ot, const std::string& filename,
                                     std::regex_constants::extended
                                         | std::regex_constants::icase);
         } catch (const std::exception& e) {
-            error
-                = Strutil::sprintf("Regex error '%s' on metamatch regex \"%s\"",
-                                   e.what(), opt.nometamatch);
+            error = format("Regex error '{}' on metamatch regex \"{}\"",
+                           e.what(), opt.nometamatch);
+            return false;
+        }
+    }
+
+    // checking how many subimages and mipmap levels are stored in the file
+    for (int s = 0, nsubimages = img->subimages(); s < nsubimages; ++s) {
+        print_info_subimage(out, ot, s, nsubimages, img->miplevels(s),
+                            *img->spec(s), img, nullptr, "", opt, field_re,
+                            field_exclude_re, serformat, verbose);
+        // If opt.subimages is not set, we print info about first subimage
+        // only.
+        if (!opt.subimages)
+            break;
+    }
+
+    return true;
+}
+
+
+
+bool
+OiioTool::print_info(std::ostream& out, Oiiotool& ot,
+                     const std::string& filename, const print_info_options& opt,
+                     std::string& error)
+{
+    using Strutil::fmt::format;
+    error.clear();
+    auto input = ImageInput::open(filename, &ot.input_config);
+    if (!input) {
+        error = geterror();
+        if (error.empty())
+            error = format("Could not open \"{}\"", filename);
+        return false;
+    }
+
+    ImageSpec::SerialFormat serformat = ImageSpec::SerialText;
+    if (Strutil::iequals(opt.infoformat, "xml"))
+        serformat = ImageSpec::SerialXML;
+    ImageSpec::SerialVerbose verbose = opt.verbose
+                                           ? ImageSpec::SerialDetailedHuman
+                                           : ImageSpec::SerialBrief;
+
+    std::regex field_re;
+    std::regex field_exclude_re;
+    if (!opt.metamatch.empty()) {
+        try {
+            field_re.assign(opt.metamatch, std::regex_constants::extended
+                                               | std::regex_constants::icase);
+        } catch (const std::exception& e) {
+            error = format("Regex error '{}' on metamatch regex \"{}\"",
+                           e.what(), opt.metamatch);
+            return false;
+        }
+    }
+    if (!opt.nometamatch.empty()) {
+        try {
+            field_exclude_re.assign(opt.nometamatch,
+                                    std::regex_constants::extended
+                                        | std::regex_constants::icase);
+        } catch (const std::exception& e) {
+            error = format("Regex error '{}' on metamatch regex \"{}\"",
+                           e.what(), opt.nometamatch);
             return false;
         }
     }
@@ -774,9 +849,9 @@ OiioTool::print_info(Oiiotool& ot, const std::string& filename,
          ++current_subimage) {
         if (!input->seek_subimage(current_subimage, 0))
             break;
-        print_info_subimage(ot, current_subimage, num_of_subimages,
+        print_info_subimage(out, ot, current_subimage, num_of_subimages,
                             num_of_miplevels[current_subimage], input->spec(),
-                            input.get(), filename, opt, field_re,
+                            nullptr, input.get(), filename, opt, field_re,
                             field_exclude_re, serformat, verbose);
         // if the '-a' flag is not set we print info
         // about first subimage only

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -87,6 +87,37 @@ timecode is 01:02:03:04
 2
 {3+4}
 4
+
+Brief:  128 x   96, 3 channel, float tiff
+
+Meta:  128 x   96, 3 channel, float tiff
+    channel list: R, G, B
+    compression: "lzw"
+    DateTime: "2013:04:16 10:20:35"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "OpenImageIO 1.6.4dev : oiiotool testsuite/oiiotool/tahoe-small.tif -resize 128x96 -o testsuite/oiiotool/tahoe-tiny.tif"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:Compression: 5
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 32
+
+Stats:
+Stats Min: 0 0 0 (of 255)
+Stats Max: 190 255 255 (of 255)
+Stats Avg: 26.00 55.26 108.45 (of 255)
+Stats StdDev: 32.31 59.12 95.51 (of 255)
+Stats NanCount: 0 0 0 
+Stats InfCount: 0 0 0 
+Stats FiniteCount: 12288 12288 12288 
+Constant: No
+Monochrome: No
+
 Reading black.tif
     oiio:DebugOpenConfig!: 42
 Reading add_rgb_rgba.exr

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -234,9 +234,9 @@ command += oiiotool ("-create 16x16 3 -attrib smpte:TimeCode \"01:02:03:04\" -ec
 command += oiiotool ("-echo \"{1+1}\" --evaloff -echo \"{3+4}\" --evalon -echo \"{2*2}\"")
 
 # Test stats and metadata expression substitution
-command += oiiotool ('src/tahoe-tiny.tif --echo "\nBrief: {TOP.METABRIEF}"')
-command += oiiotool ('src/tahoe-tiny.tif --echo "\nMeta: {TOP.META}"')
-command += oiiotool ('src/tahoe-tiny.tif --echo "\nStats:\n{TOP.STATS}\n"')
+command += oiiotool ("src/tahoe-tiny.tif --echo \"\\nBrief: {TOP.METABRIEF}\"")
+command += oiiotool ("src/tahoe-tiny.tif --echo \"\\nMeta: {TOP.META}\"")
+command += oiiotool ("src/tahoe-tiny.tif --echo \"\\nStats:\\n{TOP.STATS}\\n\"")
 
 # test --iconfig
 command += oiiotool ("--info -v -metamatch Debug --iconfig oiio:DebugOpenConfig! 1 black.tif")

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -233,6 +233,11 @@ command += oiiotool ("-create 16x16 3 -attrib smpte:TimeCode \"01:02:03:04\" -ec
 # Ensure that --evaloff/--evalon work
 command += oiiotool ("-echo \"{1+1}\" --evaloff -echo \"{3+4}\" --evalon -echo \"{2*2}\"")
 
+# Test stats and metadata expression substitution
+command += oiiotool ('src/tahoe-tiny.tif --echo "\nBrief: {TOP.METABRIEF}"')
+command += oiiotool ('src/tahoe-tiny.tif --echo "\nMeta: {TOP.META}"')
+command += oiiotool ('src/tahoe-tiny.tif --echo "\nStats:\n{TOP.STATS}\n"')
+
 # test --iconfig
 command += oiiotool ("--info -v -metamatch Debug --iconfig oiio:DebugOpenConfig! 1 black.tif")
 

--- a/testsuite/openexr-v2/ref/out.txt
+++ b/testsuite/openexr-v2/ref/out.txt
@@ -140,8 +140,8 @@ Reading ../../../../../openexr-images/v2/Stereo/Balls.exr
         0     :   677019 (62.2%)
         1     :   252006 (23.1%)
         2     :   159966 (14.7%)
-    Minimum depth was 127.873 at (999, 1030)
-    Maximum depth was 738.561 at (930, 413)
+    Minimum depth was 127.87268 at (999, 1030)
+    Maximum depth was 738.56067 at (930, 413)
 Comparing "../../../../../openexr-images/v2/Stereo/Balls.exr" and "Balls.exr"
 PASS
 Reading ../../../../../openexr-images/v2/Stereo/Leaves.exr
@@ -197,7 +197,7 @@ Reading ../../../../../openexr-images/v2/Stereo/Leaves.exr
         1     :   773945 (37.3%)
         2     :   125696 ( 6.1%)
     Minimum depth was 72.4937 at (0, 1079)
-    Maximum depth was 954.393 at (716, 324)
+    Maximum depth was 954.3927 at (716, 324)
 Comparing "../../../../../openexr-images/v2/Stereo/Leaves.exr" and "Leaves.exr"
 PASS
 Reading ../../../../../openexr-images/Beachball/multipart.0001.exr


### PR DESCRIPTION
The existing semantics of `oiiotool -info`, `-info -v` and `-stats`
are that these options set flags so that each time a file is opened
for the first time, it will print the metadata and/or stats. But these
do not allow you to create new images and print their metadata or stats
(at least, not without writing to disk and reading those files).

This patch extends the expression substition syntax to recognize the
following new metadata notations:

* `METABRIEF` : a string containing the brief one-line description that
  would be printed with `oiiotool -info`.
* `META` : a multi-line string containing the full metadata that would
  be printed with `oiiotool -info -v`.
* `STATS` : a multi-line string containing the image statistics that would
  be printed with `oiiotool -stats`.

Some interesting use cases are illustrated with these examples:

    # Roughly the same behavior as `oiiotool -info img.exr`:
    oiiotool img.exr -echo "{TOP.filename} : {TOP.METABRIEF}"

    # Perform computations on an image and print statistics about
    # the computed image (not the original):
    oiiotool img.exr -blur 3x3 -echo "blurred stats: {TOP.STATS}"

    # Print statistics on intermediate results... and keep going with
    # more operations:
    oiiotool fg.exr bg.exr -over -echo "{TOP.STATS}" -o comp.exr

    # Write metdata as "burn-in" on an image:
    oiiotool in.exr -text:x=10:y=20 "{TOP.META}" -o burned.exr

The implementation in the business logic of oiiotool.cpp was very
simple.  The more extensive change behind the scenes to make this
possible was a massive refactoring of printinfo.cpp, which previously
just wrote everything to stdout in a totally undisciplined fashion,
and transforming it to very carefully write to output streams instead,
which could be passed a stringstream to render the metadata listing or
stats output as a string. Also needed some refactoring to allow it to
take either the name of a file to read anew (as it did before), or an
existing ImageBuf/ImageRec (to support the new feature).
