### PR TITLE
Document and minor changes to uvslopes_scale argument to bumpslopes

### DIFF
--- a/src/doc/maketx.rst
+++ b/src/doc/maketx.rst
@@ -452,6 +452,15 @@ Command-line arguments are:
     if and only if the R, G, B channel values are identical in all pixels,
     otherwise it will be interpreted as a 3-channel normal map.
 
+.. option:: --uvslopes_scale <scalefactor>
+
+   Used in conjunction with `--bumpslopes`, this computes derivatives for
+   the bumpslopes data in UV space rather than in texel space, and divides
+   them by a scale factor. If the value is 0 (default), this is disabled.
+   For a nonzero value, it will be the scale factor. If you use this feature,
+   a suggested value is 256.
+
+   (This option was added for OpenImageIO 2.3.)
 
 
 

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -2034,6 +2034,14 @@ enum MakeTextureMode {
 ///                           ("height"), a normal map ("normal"), or
 ///                           automatically determine it from the number
 ///                           of channels ("auto", the default).
+///    - `maketx:uvslopes_scale` (float) :
+///                           If nonzero, when used in MakeTxBumpWithSlopes
+///                           mode, this computes derivatives for the
+///                           bumpslopes data in UV space rather than in
+///                           texel space, and divides them by this scale
+///                           factor. The default is 0, disabling the
+///                           feature. If you use this feature, a suggested
+///                           value is 256.
 ///
 /// @param  mode
 ///    Describes what type of texture file we are creating and may

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -494,7 +494,9 @@ bump_to_bumpslopes(ImageBuf& dst, const ImageBuf& src,
         return false;
     }
 
-    int uv_scale = configspec.get_int_attribute("uvslopes_scale");
+    float uv_scale = configspec.get_float_attribute(
+        "maketx:uvslopes_scale",
+        configspec.get_float_attribute("uvslopes_scale"));
 
     // If the input is an height map, does the derivatives needs to be UV normalized and scaled?
     if (bump_filter == &sobel_gradient<SRCTYPE> && uv_scale != 0) {
@@ -607,6 +609,11 @@ maketx_merge_spec(ImageSpec& dstspec, const ImageSpec& srcspec)
             dstspec.attribute(name.string(), p.type(), p.data());
         }
     }
+    // Special case: we want "maketx:uvslopes_scale" to turn
+    // into "uvslopes_scale"
+    if (srcspec.extra_attribs.contains("maketx:uvslopes_scale"))
+        dstspec.attribute("uvslopes_scale",
+                          srcspec.get_float_attribute("maketx:uvslopes_scale"));
 }
 
 

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -175,7 +175,7 @@ getargs(int argc, char* argv[], ImageSpec& configspec)
     bool unpremult             = false;
     bool sansattrib            = false;
     float sharpen              = 0.0f;
-    int uvslopes_scale         = 0;
+    float uvslopes_scale       = 0.0f;
     std::string incolorspace;
     std::string outcolorspace;
     std::string colorconfigname;
@@ -294,7 +294,7 @@ getargs(int argc, char* argv[], ImageSpec& configspec)
       .help("Create lat/long environment map from a light probe");
     ap.arg("--bumpslopes", &bumpslopesmode)
       .help("Create a 6 channels bump-map with height, derivatives and square derivatives from an height or a normal map");
-    ap.arg("--uvslopes_scale %d:VALUE", &uvslopes_scale)
+    ap.arg("--uvslopes_scale %f:VALUE", &uvslopes_scale)
       .help("If specified, compute derivatives for --bumpslopes in UV space rather than in texel space and divide them by a scale factor. 0=disable by default, only valid for height maps.");
     ap.arg("--bumpformat %s:NAME", &bumpformat)
       .help("Specify the interpretation of a 3-channel input image for --bumpslopes: \"height\", \"normal\" or \"auto\" (default).");
@@ -470,9 +470,7 @@ getargs(int argc, char* argv[], ImageSpec& configspec)
     }
 
     if (bumpslopesmode)
-        configspec.attribute(
-            "uvslopes_scale",
-            uvslopes_scale);  // we want to write this attribute in the output file
+        configspec.attribute("maketx:uvslopes_scale", uvslopes_scale);
 }
 
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4749,8 +4749,8 @@ prep_texture_config(ImageSpec& configspec, ParamValueList& fileoptions)
                              "prman_options", fileoptions.get_string("prman")));
     configspec.attribute("maketx:bumpformat",
                          fileoptions.get_string("bumpformat", "auto"));
-    configspec.attribute("uvslopes_scale",
-                         fileoptions.get_int("uvslopes_scale", 0));
+    configspec.attribute("maketx:uvslopes_scale",
+                         fileoptions.get_float("uvslopes_scale", 0.0f));
     // if (mipimages.size())
     //     configspec.attribute ("maketx:mipimages", Strutil::join(mipimages,";"));
 


### PR DESCRIPTION
Slightly amends PR 3012

* Add docs for this recently-added feature.

* Change the make_texture configuration hint to "maketx:uvslopes_scale"
  for symmetry with all the other texture conversion configuration names.
  Everything works as before, including setting "uvslopes_scale"
  metadata in the file.  (But still accept the name without the
  prefix as a synonym.)

* Change it to a float for a bit more flexibility.
