### PR TITLE
oiiotool: Get rid of long-deprecated, useless --histogram function

### DIFF
--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -134,10 +134,6 @@ Comparing "filled.tif" and "ref/filled.tif"
 PASS
 Comparing "autotrim.tif" and "ref/autotrim.tif"
 PASS
-Comparing "histogram_regular.tif" and "ref/histogram_regular.tif"
-PASS
-Comparing "histogram_cumulative.tif" and "ref/histogram_cumulative.tif"
-PASS
 Comparing "trim.tif" and "ref/trim.tif"
 PASS
 Comparing "trimsubimages.tif" and "ref/trimsubimages.tif"

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -79,12 +79,6 @@ command += oiiotool ("negpos.exr -absdiffc 0.2,0.2,0.2 -d half -o absdiffc.exr")
 command += oiiotool ("src/tahoe-small.tif --chsum:weight=.2126,.7152,.0722 "
             + "-d uint8 -o chsum.tif")
 
-# test histogram generation
-command += oiiotool ("ref/histogram_input.png --histogram 256x256 0 "
-            + "-o histogram_regular.tif")
-command += oiiotool ("ref/histogram_input.png --histogram:cumulative=1 256x256 0 "
-            + "-o histogram_cumulative.tif")
-
 # test --trim
 command += oiiotool ("--create 320x240 3 -fill:color=.1,.5,.1 120x80+50+70 "
                      + " -rotate 30 -trim -origin +0+0 -fullpixels -d uint8 -o trim.tif")
@@ -267,7 +261,6 @@ command += oiiotool ("--missingfile checker box.tif missing.tif --over -o box_ov
 outputs = [
             "filled.tif",
             "autotrim.tif",
-            "histogram_regular.tif", "histogram_cumulative.tif",
             "trim.tif", "trimsubimages.tif",
             "chanshuffle.tif", "ch-rgba.exr", "ch-z.exr",
             "chappend-rgbaz.exr", "chname.exr",


### PR DESCRIPTION
It's never been pretty or useful, we removed it from the docs long ago. Let's finally axe it.
