### PR TITLE
fix const declaration on threads(int)

### DIFF
--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -1019,7 +1019,7 @@ public:
     /// new threads. That is probably the desired behavior in situations
     /// where the calling application has already spawned multiple worker
     /// threads.
-    void threads(int n) const;
+    void threads(int n);
 
     /// Retrieve the current thread-spawning policy of this ImageBuf.
     int threads() const;

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -216,7 +216,7 @@ public:
         return m_spec;
     }
 
-    void threads(int n) const { m_threads = n; }
+    void threads(int n) { m_threads = n; }
     int threads() const { return m_threads; }
 
     // Allocate m_configspec if not already done


### PR DESCRIPTION
## Description

ImageBuf::threads(int n) was declared const even though it mutates internal state. This PR removes the spurious const.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->
No

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

