### PR TITLE
Make finding Boost more flexible.

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -36,13 +36,20 @@ if (MSVC)
     # Disable automatic linking using pragma comment(lib,...) of boost libraries upon including of a header
     add_definitions (-DBOOST_ALL_NO_LIB=1)
 endif ()
-if (LINKSTATIC)
-    set (Boost_USE_STATIC_LIBS ON)
-else ()
-    if (MSVC)
+
+# If the build system hasn't been specifically told how to link Boost, link it the same way as other
+# OIIO dependencies:
+if (NOT DEFINED Boost_USE_STATIC_LIBS)
+    set (Boost_USE_STATIC_LIBS "${LINKSTATIC}")
+endif ()
+
+if (MSVC)
+    # Not linking Boost as static libraries: either an explicit setting or LINKSTATIC is FALSE:
+    if (NOT Boost_USE_STATIC_LIBS)
         add_definitions (-DBOOST_ALL_DYN_LINK=1)
     endif ()
 endif ()
+
 if (BOOST_CUSTOM)
     set (Boost_FOUND true)
     # N.B. For a custom version, the caller had better set up the variables


### PR DESCRIPTION
## Description

Addresses #2956. Apologies for the long radio silence on this, I've been quite busy lately...

This patch modifies the build system to make it possible to control
whether OIIO should link Boost in the form of static or dynamic
libraries, independently from the LINKSTATIC setting, without
having to use the fully custom route (BOOST_CUSTOM).

This is done by preserving the value of the Boost_USE_STATIC_LIBS
variable, if it has been defined by the user. If the value
of Boost_USE_STATIC_LIBS has NOT been explicitly defined, it is
set to match the value of the LINKSTATIC variable, which should
result in Boost being linked in the same way as other dependencies.

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

The existing CI workflows should (hopefully) be able to detect any anomalies in the common build scenarios.
To test this specific scenario a new CI workflow would be needed, but it seems such a niche use case, that I don't really expect it to be included in the standard test suite.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

