### PR TITLE
Mark some long-deprecated things with OIIO_DEPRECATED

### DIFF
--- a/src/doc/imagebufalgo.rst
+++ b/src/doc/imagebufalgo.rst
@@ -1128,8 +1128,9 @@ Image comparison and statistics
   Examples::
 
     ImageBuf A ("a.exr");
-    ImageBufAlgo::PixelStats stats;
-    ImageBufAlgo::computePixelStats (stats, A);
+    auto stats = ImageBufAlgo::computePixelStats(A);
+    if (stats.min.size() == 0)
+        return; // empty vectors means we could not get the stats
     for (int c = 0;  c < A.nchannels();  ++c) {
         std::cout << "Channel " << c << ":\n";
         std::cout << "   min = " << stats.min[c] << "\n";
@@ -1160,8 +1161,7 @@ Image comparison and statistics
 
     ImageBuf A ("a.exr");
     ImageBuf B ("b.exr");
-    ImageBufAlgo::CompareResults comp;
-    ImageBufAlgo::compare (A, B, 1.0f/255.0f, 0.0f, comp);
+    auto comp = ImageBufAlgo::compare(A, B, 1.0f/255.0f, 0.0f);
     if (comp.nwarn == 0 && comp.nfail == 0) {
         std::cout << "Images match within tolerance\n";
     } else {

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -260,8 +260,7 @@ main(int argc, char* argv[])
 
             // Compare the two images.
             //
-            ImageBufAlgo::CompareResults cr;
-            ImageBufAlgo::compare(img0, img1, failthresh, warnthresh, cr);
+            auto cr = ImageBufAlgo::compare(img0, img1, failthresh, warnthresh);
 
             int yee_failures = 0;
             if (perceptual && !img0.deep()) {

--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -168,7 +168,6 @@ static void
 print_stats(const std::string& filename, const ImageSpec& originalspec,
             int subimage = 0, int miplevel = 0, bool indentmip = false)
 {
-    PixelStats stats;
     const char* indent = indentmip ? "      " : "    ";
 
     ImageBuf input;
@@ -177,7 +176,8 @@ print_stats(const std::string& filename, const ImageSpec& originalspec,
         return;
     }
 
-    if (!computePixelStats(stats, input)) {
+    PixelStats stats = computePixelStats(input);
+    if (!stats.min.size()) {
         printf("%sStats: (unable to compute)\n", indent);
         if (input.has_error())
             std::cerr << "Error: " << input.geterror() << "\n";

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -280,6 +280,7 @@ public:
     std::string configname() const;
 
     // DEPRECATED(1.9) -- no longer necessary, because it's a shared ptr
+    OIIO_DEPRECATED("no longer necessary (1.9)")
     static void deleteColorProcessor(const ColorProcessorHandle& /*processor*/)
     {
     }

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -511,6 +511,7 @@ public:
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
     // DEPRECATED(1.9): old version did not have the data type
+    OIIO_DEPRECATED("use other write() that takes the dtype argument (1.9)")
     bool write(string_view filename, string_view fileformat,
                ProgressCallback progress_callback = nullptr,
                void* progress_callback_data       = nullptr) const
@@ -724,9 +725,12 @@ public:
     void interppixel_NDC(float s, float t, float* pixel,
                          WrapMode wrap = WrapBlack) const;
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     // DEPRECATED (1.5) synonym for interppixel_NDC.
+    OIIO_DEPRECATED("use interppixel_NDC (1.5)")
     void interppixel_NDC_full(float s, float t, float* pixel,
                               WrapMode wrap = WrapBlack) const;
+#endif
 
     /// Bicubic interpolation at pixel coordinates (x,y).
     void interppixel_bicubic(float x, float y, float* pixel,

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -190,6 +190,7 @@ private:
 namespace ImageBufAlgo {
 
 // old name (DEPRECATED 1.9)
+OIIO_DEPRECATED("use parallel_options (1.9)")
 typedef parallel_options parallel_image_options;
 
 
@@ -1126,6 +1127,7 @@ PixelStats OIIO_API computePixelStats (const ImageBuf &src,
 // DEPRECATED(1.9): with C++11 move semantics, there's no reason why
 // stats needs to be passed as a parameter instead of returned.
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
+OIIO_DEPRECATED("use version that returns PixelStats (1.9)")
 bool OIIO_API computePixelStats (PixelStats &stats, const ImageBuf &src,
                                  ROI roi={}, int nthreads=0);
 #endif
@@ -1178,6 +1180,7 @@ int OIIO_API compare_Yee (const ImageBuf &A, const ImageBuf &B,
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 // DEPRECATED(1.9): with C++11 move semantics, there's no reason why
 // result needs to be passed as a parameter instead of returned.
+OIIO_DEPRECATED("use version that returns CompareResults (1.9)")
 bool OIIO_API compare (const ImageBuf &A, const ImageBuf &B,
                        float failthresh, float warnthresh,
                        CompareResults &result, ROI roi={}, int nthreads=0);
@@ -1322,12 +1325,14 @@ std::vector<imagesize_t> histogram (const ImageBuf &src, int channel=0,
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 /// DEPRECATED(1.9)
+OIIO_DEPRECATED("use version that returns vector (1.9)")
 bool OIIO_API histogram (const ImageBuf &src, int channel,
                          std::vector<imagesize_t> &histogram, int bins=256,
                          float min=0, float max=1, imagesize_t *submin=nullptr,
                          imagesize_t *supermax=nullptr, ROI roi={});
 
 // DEPRECATED(1.9): never liked this.
+OIIO_DEPRECATED("this useless function is going away (1.9)")
 bool OIIO_API histogram_draw (ImageBuf &dst,
                               const std::vector<imagesize_t> &histogram);
 #endif
@@ -1357,6 +1362,7 @@ ImageBuf OIIO_API make_kernel (string_view name, float width, float height,
                                float depth = 1.0f, bool normalize = true);
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 // DEPRECATED(1.9):
+OIIO_DEPRECATED("use version that returns ImageBuf (1.9)")
 inline bool make_kernel (ImageBuf &dst, string_view name,
                          float width, float height, float depth = 1.0f,
                          bool normalize = true) {
@@ -2137,6 +2143,7 @@ ImageBuf OIIO_API capture_image (int cameranum = 0,
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 // DEPRECATED(1.9):
+OIIO_DEPRECATED("use version that returns ImageBuf (1.9)")
 inline bool capture_image (ImageBuf &dst, int cameranum = 0,
                            TypeDesc convert=TypeUnknown) {
     dst = capture_image (cameranum, convert);
@@ -2155,6 +2162,7 @@ inline bool capture_image (ImageBuf &dst, int cameranum = 0,
 ImageBuf OIIO_API from_IplImage (const IplImage *ipl,
                                  TypeDesc convert=TypeUnknown);
 // DEPRECATED(1.9):
+OIIO_DEPRECATED("use from_OpenCV (1.9)")
 inline bool from_IplImage (ImageBuf &dst, const IplImage *ipl,
                            TypeDesc convert=TypeUnknown) {
     dst = from_IplImage (ipl, convert);
@@ -2163,6 +2171,7 @@ inline bool from_IplImage (ImageBuf &dst, const IplImage *ipl,
 
 // DEPRECATED(2.0). The OpenCV 1.x era IplImage-based functions should be
 // avoided, giving preference to from_OpenCV.
+OIIO_DEPRECATED("use from_OpenCV (2.9)")
 OIIO_API IplImage* to_IplImage (const ImageBuf &src);
 #endif  // DOXYGEN_SHOULD_SKIP_THIS
 

--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -49,7 +49,7 @@ namespace ImageBufAlgo {
 ///     ROI roi = get_roi (R.spec());
 ///     parallel_image (bind(my_image_op,ref(R), cref(A),3.14,_1), roi);
 inline void
-parallel_image (ROI roi, parallel_image_options opt,
+parallel_image (ROI roi, parallel_options opt,
                 std::function<void(ROI)> f)
 {
     opt.resolve ();
@@ -95,18 +95,18 @@ parallel_image (ROI roi, parallel_image_options opt,
 inline void
 parallel_image (ROI roi, std::function<void(ROI)> f)
 {
-    parallel_image (roi, parallel_image_options(), f);
+    parallel_image (roi, parallel_options(), f);
 }
 
 
 
 // DEPRECATED(1.8) -- eventually enable the OIIO_DEPRECATION
 template <class Func>
-// OIIO_DEPRECATED("switch to new parallel_image (1.8)")
+OIIO_DEPRECATED("switch to new parallel_image (1.8)")
 void
 parallel_image (Func f, ROI roi, int nthreads=0, SplitDir splitdir=Split_Y)
 {
-    parallel_image (roi, parallel_image_options (nthreads, splitdir), f);
+    parallel_image (roi, parallel_options(nthreads, splitdir), f);
 }
 
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1211,6 +1211,7 @@ public:
                                  stride_t xstride=AutoStride,
                                  stride_t ystride=AutoStride);
 
+#ifndef OIIO_DOXYGEN
     // DEPRECATED versions of read_scanlines (pre-1.9 OIIO). These will
     // eventually be removed. Try to replace these calls with ones to the
     // new variety of read_scanlines that takes an explicit subimage and
@@ -1224,6 +1225,7 @@ public:
                          TypeDesc format, void *data,
                          stride_t xstride=AutoStride,
                          stride_t ystride=AutoStride);
+#endif
 
     /// Read the tile whose upper-left origin is (x,y,z) into `data[]`,
     /// converting if necessary from the native data format of the file into
@@ -1314,6 +1316,7 @@ public:
                              stride_t xstride=AutoStride, stride_t ystride=AutoStride,
                              stride_t zstride=AutoStride);
 
+#ifndef OIIO_DOXYGEN
     // DEPRECATED versions of read_tiles (pre-1.9 OIIO). These will
     // eventually be removed. Try to replace these calls with ones to the
     // new variety of read_tiles that takes an explicit subimage and
@@ -1326,6 +1329,7 @@ public:
                      int zbegin, int zend, int chbegin, int chend,
                      TypeDesc format, void *data, stride_t xstride=AutoStride,
                      stride_t ystride=AutoStride, stride_t zstride=AutoStride);
+#endif
 
     /// Read the entire image of `spec.width x spec.height x spec.depth`
     /// pixels into a buffer with the given strides and in the desired
@@ -1370,6 +1374,7 @@ public:
                              ProgressCallback progress_callback=NULL,
                              void *progress_callback_data=NULL);
 
+#ifndef OIIO_DOXYGEN
     // DEPRECATED versions of read_image (pre-1.9 OIIO). These will
     // eventually be removed. Try to replace these calls with ones to the
     // new variety of read_image that takes an explicit subimage and
@@ -1390,6 +1395,7 @@ public:
     bool read_image (float *data) {
         return read_image (TypeDesc::FLOAT, data);
     }
+#endif
 
     /// Read deep scanlines containing pixels (*,y,z), for all y in the
     /// range [ybegin,yend) into `deepdata`. This will fail if it is not a
@@ -1449,6 +1455,7 @@ public:
     virtual bool read_native_deep_image (int subimage, int miplevel,
                                          DeepData &deepdata);
 
+#ifndef OIIO_DOXYGEN
     // DEPRECATED(1.9), Now just used for back compatibility:
     bool read_native_deep_scanlines (int ybegin, int yend, int z,
                              int chbegin, int chend, DeepData &deepdata) {
@@ -1467,6 +1474,7 @@ public:
         return read_native_deep_image (current_subimage(), current_miplevel(),
                                        deepdata);
     }
+#endif
 
     /// @}
 
@@ -1668,6 +1676,7 @@ private:
 
     void append_error(string_view message) const; // add to error message
     // Deprecated:
+    OIIO_DEPRECATED("Deprecated")
     static unique_ptr create (const std::string& filename, bool do_open,
                               const std::string& plugin_searchpath);
 };

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -890,7 +890,9 @@ public:
     typedef vbool4 vbool_t;   ///< bool type of the same length
     typedef vfloat4 vfloat_t; ///< float type of the same length
     typedef vint4 vint_t;     ///< int type of the same length
+    OIIO_DEPRECATED("use vbool_t (1.8)")
     typedef vbool4 bool_t;   // old name (deprecated 1.8)
+    OIIO_DEPRECATED("use vfloat_t (1.8)")
     typedef vfloat4 float_t; // old name (deprecated 1.8)
 
     /// Default constructor (contents undefined)
@@ -1033,7 +1035,7 @@ public:
     void gather (const value_t *baseptr, const vint_t& vindex);
     /// Gather elements defined by the mask, leave others unchanged.
     template<int scale=4>
-    void gather_mask (const bool_t& mask, const value_t *baseptr, const vint_t& vindex);
+    void gather_mask (const vbool_t& mask, const value_t *baseptr, const vint_t& vindex);
     template<int scale=4>
     void gather_mask (int mask, const value_t *baseptr, const vint_t& vindex);
 
@@ -1042,7 +1044,7 @@ public:
     void scatter (value_t *baseptr, const vint_t& vindex) const;
     /// Scatter elements defined by the mask
     template<int scale=4>
-    void scatter_mask (const bool_t& mask, value_t *baseptr, const vint_t& vindex) const;
+    void scatter_mask (const vbool_t& mask, value_t *baseptr, const vint_t& vindex) const;
     template<int scale=4>
     void scatter_mask (int mask, value_t *baseptr, const vint_t& vindex) const;
 
@@ -1177,7 +1179,9 @@ public:
     typedef vbool8 vbool_t;   ///< bool type of the same length
     typedef vfloat8 vfloat_t; ///< float type of the same length
     typedef vint8 vint_t;     ///< int type of the same length
+    OIIO_DEPRECATED("use vbool_t (1.8)")
     typedef vbool8 bool_t;   // old name (deprecated 1.8)
+    OIIO_DEPRECATED("use vfloat_t (1.8)")
     typedef vfloat8 float_t; // old name (deprecated 1.8)
 
     /// Default constructor (contents undefined)
@@ -1329,7 +1333,7 @@ public:
     void gather (const value_t *baseptr, const vint_t& vindex);
     /// Gather elements defined by the mask, leave others unchanged.
     template<int scale=4>
-    void gather_mask (const bool_t& mask, const value_t *baseptr, const vint_t& vindex);
+    void gather_mask (const vbool_t& mask, const value_t *baseptr, const vint_t& vindex);
     template<int scale=4>
     void gather_mask (int mask, const value_t *baseptr, const vint_t& vindex);
 
@@ -1338,7 +1342,7 @@ public:
     void scatter (value_t *baseptr, const vint_t& vindex) const;
     /// Scatter elements defined by the mask
     template<int scale=4>
-    void scatter_mask (const bool_t& mask, value_t *baseptr, const vint_t& vindex) const;
+    void scatter_mask (const vbool_t& mask, value_t *baseptr, const vint_t& vindex) const;
     template<int scale=4>
     void scatter_mask (int mask, value_t *baseptr, const vint_t& vindex) const;
 
@@ -1473,7 +1477,9 @@ public:
     typedef vbool16 vbool_t;   ///< bool type of the same length
     typedef vfloat16 vfloat_t; ///< float type of the same length
     typedef vint16 vint_t;     ///< int type of the same length
+    OIIO_DEPRECATED("use vbool_t (1.8)")
     typedef vbool16 bool_t;   // old name (deprecated 1.8)
+    OIIO_DEPRECATED("use vfloat_t (1.8)")
     typedef vfloat16 float_t; // old name (deprecated 1.8)
 
     /// Default constructor (contents undefined)
@@ -1627,7 +1633,7 @@ public:
     void gather (const value_t *baseptr, const vint_t& vindex);
     /// Gather elements defined by the mask, leave others unchanged.
     template<int scale=4>
-    void gather_mask (const bool_t& mask, const value_t *baseptr, const vint_t& vindex);
+    void gather_mask (const vbool_t& mask, const value_t *baseptr, const vint_t& vindex);
     template<int scale=4>
     void gather_mask (int mask, const value_t *baseptr, const vint_t& vindex) {
         gather_mask<scale> (vbool_t(mask), baseptr, vindex);
@@ -1638,7 +1644,7 @@ public:
     void scatter (value_t *baseptr, const vint_t& vindex) const;
     /// Scatter elements defined by the mask
     template<int scale=4>
-    void scatter_mask (const bool_t& mask, value_t *baseptr, const vint_t& vindex) const;
+    void scatter_mask (const vbool_t& mask, value_t *baseptr, const vint_t& vindex) const;
     template<int scale=4>
     void scatter_mask (int mask, value_t *baseptr, const vint_t& vindex) const {
         scatter_mask<scale> (vbool_t(mask), baseptr, vindex);
@@ -1782,7 +1788,9 @@ public:
     typedef vfloat4 vfloat_t; ///< SIMD int type
     typedef vint4 vint_t;     ///< SIMD int type
     typedef vbool4 vbool_t;   ///< SIMD bool type
+    OIIO_DEPRECATED("use vbool_t (1.8)")
     typedef vint4 int_t;      // old name (deprecated 1.8)
+    OIIO_DEPRECATED("use vfloat_t (1.8)")
     typedef vbool4 bool_t;    // old name (deprecated 1.8)
 
     /// Default constructor (contents undefined)
@@ -1943,7 +1951,7 @@ public:
     void gather (const value_t *baseptr, const vint_t& vindex);
     /// Gather elements defined by the mask, leave others unchanged.
     template<int scale=4>
-    void gather_mask (const bool_t& mask, const value_t *baseptr, const vint_t& vindex);
+    void gather_mask (const vbool_t& mask, const value_t *baseptr, const vint_t& vindex);
     template<int scale=4>
     void gather_mask (int mask, const value_t *baseptr, const vint_t& vindex);
 
@@ -1952,7 +1960,7 @@ public:
     void scatter (value_t *baseptr, const vint_t& vindex) const;
     /// Scatter elements defined by the mask
     template<int scale=4>
-    void scatter_mask (const bool_t& mask, value_t *baseptr, const vint_t& vindex) const;
+    void scatter_mask (const vbool_t& mask, value_t *baseptr, const vint_t& vindex) const;
     template<int scale=4>
     void scatter_mask (int mask, value_t *baseptr, const vint_t& vindex) const;
 
@@ -2072,6 +2080,7 @@ vfloat4 sign (const vfloat4& a);   ///< 1.0 when value >= 0, -1 when negative
 vfloat4 ceil (const vfloat4& a);
 vfloat4 floor (const vfloat4& a);
 vint4 ifloor (const vfloat4& a);    ///< (int)floor
+OIIO_DEPRECATED("use ifloor (1.8)")
 inline vint4 floori (const vfloat4& a) { return ifloor(a); }  // DEPRECATED(1.8) alias
 
 /// Per-element round to nearest integer.
@@ -2426,7 +2435,9 @@ public:
     typedef vfloat8 vfloat_t; ///< SIMD int type
     typedef vint8 vint_t;     ///< SIMD int type
     typedef vbool8 vbool_t;   ///< SIMD bool type
+    OIIO_DEPRECATED("use vint_t (1.8)")
     typedef vint8 int_t;      // old name (deprecated 1.8)
+    OIIO_DEPRECATED("use vbool_t (1.8)")
     typedef vbool8 bool_t;    // old name (deprecated 1.8)
 
     /// Default constructor (contents undefined)
@@ -2580,7 +2591,7 @@ public:
     void gather (const value_t *baseptr, const vint_t& vindex);
     template<int scale=4>
     // Fastest way to fill with all 1 bits is to cmp any value to itself.
-    void gather_mask (const bool_t& mask, const value_t *baseptr, const vint_t& vindex);
+    void gather_mask (const vbool_t& mask, const value_t *baseptr, const vint_t& vindex);
     template<int scale=4>
     void gather_mask (int mask, const value_t *baseptr, const vint_t& vindex);
 
@@ -2589,7 +2600,7 @@ public:
     void scatter (value_t *baseptr, const vint_t& vindex) const;
     /// Scatter elements defined by the mask
     template<int scale=4>
-    void scatter_mask (const bool_t& mask, value_t *baseptr, const vint_t& vindex) const;
+    void scatter_mask (const vbool_t& mask, value_t *baseptr, const vint_t& vindex) const;
     template<int scale=4>
     void scatter_mask (int mask, value_t *baseptr, const vint_t& vindex) const;
 
@@ -2744,7 +2755,9 @@ public:
     typedef vfloat16 vfloat_t; ///< SIMD int type
     typedef vint16 vint_t;     ///< SIMD int type
     typedef vbool16 vbool_t;   ///< SIMD bool type
+    OIIO_DEPRECATED("use vint_t (1.8)")
     typedef vint16 int_t;      // old name (deprecated 1.8)
+    OIIO_DEPRECATED("use vbool_t (1.8)")
     typedef vbool16 bool_t;    // old name (deprecated 1.8)
 
     /// Default constructor (contents undefined)
@@ -2905,7 +2918,7 @@ public:
     void gather (const value_t *baseptr, const vint_t& vindex);
     /// Gather elements defined by the mask, leave others unchanged.
     template<int scale=4>
-    void gather_mask (const bool_t& mask, const value_t *baseptr, const vint_t& vindex);
+    void gather_mask (const vbool_t& mask, const value_t *baseptr, const vint_t& vindex);
     template<int scale=4>
     void gather_mask (int mask, const value_t *baseptr, const vint_t& vindex) {
         gather_mask<scale> (vbool_t(mask), baseptr, vindex);
@@ -2916,7 +2929,7 @@ public:
     void scatter (value_t *baseptr, const vint_t& vindex) const;
     /// Scatter elements defined by the mask
     template<int scale=4>
-    void scatter_mask (const bool_t& mask, value_t *baseptr, const vint_t& vindex) const;
+    void scatter_mask (const vbool_t& mask, value_t *baseptr, const vint_t& vindex) const;
     template<int scale=4>
     void scatter_mask (int mask, value_t *baseptr, const vint_t& vindex) const {
         scatter_mask<scale> (vbool_t(mask), baseptr, vindex);
@@ -3015,6 +3028,7 @@ vfloat16 sign (const vfloat16& a);   ///< 1.0 when value >= 0, -1 when negative
 vfloat16 ceil (const vfloat16& a);
 vfloat16 floor (const vfloat16& a);
 vint16 ifloor (const vfloat16& a);    ///< (int)floor
+OIIO_DEPRECATED("use ifloor (1.8)")
 inline vint16 floori (const vfloat16& a) { return ifloor(a); }  // DEPRECATED(1.8) alias
 
 /// Per-element round to nearest integer.
@@ -4253,7 +4267,7 @@ vint4::gather (const value_t *baseptr, const vint_t& vindex)
 
 template<int scale>
 OIIO_FORCEINLINE void
-vint4::gather_mask (const bool_t& mask, const value_t *baseptr, const vint_t& vindex)
+vint4::gather_mask (const vbool_t& mask, const value_t *baseptr, const vint_t& vindex)
 {
 #if OIIO_SIMD_AVX >= 2
     m_simd = _mm_mask_i32gather_epi32 (m_simd, baseptr, vindex, _mm_cvtps_epi32(mask), scale);
@@ -4276,7 +4290,7 @@ vint4::scatter (value_t *baseptr, const vint_t& vindex) const
 
 template<int scale>
 OIIO_FORCEINLINE void
-vint4::scatter_mask (const bool_t& mask, value_t *baseptr,
+vint4::scatter_mask (const vbool_t& mask, value_t *baseptr,
                      const vint_t& vindex) const
 {
 #if 0 && OIIO_SIMD_AVX >= 512 && OIIO_AVX512VL_ENABLED
@@ -4695,6 +4709,7 @@ OIIO_FORCEINLINE vint4 bitcast_to_int (const vbool4& x)
 }
 
 // Old names: (DEPRECATED 1.8)
+OIIO_DEPRECATED("use bitcast_to_int() (1.8)")
 inline vint4 bitcast_to_int4 (const vbool4& x) { return bitcast_to_int(x); }
 
 
@@ -5109,7 +5124,7 @@ vint8::gather (const value_t *baseptr, const vint_t& vindex)
 
 template<int scale>
 OIIO_FORCEINLINE void
-vint8::gather_mask (const bool_t& mask, const value_t *baseptr, const vint_t& vindex)
+vint8::gather_mask (const vbool_t& mask, const value_t *baseptr, const vint_t& vindex)
 {
 #if OIIO_SIMD_AVX >= 2
     m_simd = _mm256_mask_i32gather_epi32 (m_simd, baseptr, vindex, _mm256_cvtps_epi32(mask), scale);
@@ -5131,7 +5146,7 @@ vint8::scatter (value_t *baseptr, const vint_t& vindex) const
 
 template<int scale>
 OIIO_FORCEINLINE void
-vint8::scatter_mask (const bool_t& mask, value_t *baseptr,
+vint8::scatter_mask (const vbool_t& mask, value_t *baseptr,
                      const vint_t& vindex) const
 {
 #if OIIO_SIMD_AVX >= 512 && OIIO_AVX512VL_ENABLED
@@ -5879,7 +5894,7 @@ vint16::gather (const value_t *baseptr, const vint_t& vindex) {
 
 template<int scale>
 OIIO_FORCEINLINE void
-vint16::gather_mask (const bool_t& mask, const value_t *baseptr, const vint_t& vindex) {
+vint16::gather_mask (const vbool_t& mask, const value_t *baseptr, const vint_t& vindex) {
 #if OIIO_SIMD_AVX >= 512
     m_simd = _mm512_mask_i32gather_epi32 (m_simd, mask, vindex, baseptr, scale);
 #else
@@ -5901,7 +5916,7 @@ vint16::scatter (value_t *baseptr, const vint_t& vindex) const {
 
 template<int scale>
 OIIO_FORCEINLINE void
-vint16::scatter_mask (const bool_t& mask, value_t *baseptr,
+vint16::scatter_mask (const vbool_t& mask, value_t *baseptr,
                       const vint_t& vindex) const {
 #if OIIO_SIMD_AVX >= 512
     _mm512_mask_i32scatter_epi32 (baseptr, mask, vindex, m_simd, scale);
@@ -6853,7 +6868,7 @@ vfloat4::gather (const value_t *baseptr, const vint_t& vindex)
 
 template<int scale>
 OIIO_FORCEINLINE void
-vfloat4::gather_mask (const bool_t& mask, const value_t *baseptr, const vint_t& vindex)
+vfloat4::gather_mask (const vbool_t& mask, const value_t *baseptr, const vint_t& vindex)
 {
 #if OIIO_SIMD_AVX >= 2
     m_simd = _mm_mask_i32gather_ps (m_simd, baseptr, vindex, mask, scale);
@@ -6876,7 +6891,7 @@ vfloat4::scatter (value_t *baseptr, const vint_t& vindex) const
 
 template<int scale>
 OIIO_FORCEINLINE void
-vfloat4::scatter_mask (const bool_t& mask, value_t *baseptr,
+vfloat4::scatter_mask (const vbool_t& mask, value_t *baseptr,
                        const vint_t& vindex) const
 {
 #if 0 && OIIO_SIMD_AVX >= 512 && OIIO_AVX512VL_ENABLED
@@ -8712,7 +8727,7 @@ vfloat8::gather (const value_t *baseptr, const vint_t& vindex)
 
 template<int scale>
 OIIO_FORCEINLINE void
-vfloat8::gather_mask (const bool_t& mask, const value_t *baseptr, const vint_t& vindex)
+vfloat8::gather_mask (const vbool_t& mask, const value_t *baseptr, const vint_t& vindex)
 {
 #if OIIO_SIMD_AVX >= 2
     m_simd = _mm256_mask_i32gather_ps (m_simd, baseptr, vindex, mask, scale);
@@ -8734,7 +8749,7 @@ vfloat8::scatter (value_t *baseptr, const vint_t& vindex) const
 
 template<int scale>
 OIIO_FORCEINLINE void
-vfloat8::scatter_mask (const bool_t& mask, value_t *baseptr,
+vfloat8::scatter_mask (const vbool_t& mask, value_t *baseptr,
                        const vint_t& vindex) const
 {
 #if OIIO_SIMD_AVX >= 512 && OIIO_AVX512VL_ENABLED
@@ -9567,7 +9582,7 @@ vfloat16::gather (const value_t *baseptr, const vint_t& vindex)
 
 template<int scale>
 OIIO_FORCEINLINE void
-vfloat16::gather_mask (const bool_t& mask, const value_t *baseptr, const vint_t& vindex)
+vfloat16::gather_mask (const vbool_t& mask, const value_t *baseptr, const vint_t& vindex)
 {
 #if OIIO_SIMD_AVX >= 512
     m_simd = _mm512_mask_i32gather_ps (m_simd, mask, vindex, baseptr, scale);
@@ -9591,7 +9606,7 @@ vfloat16::scatter (value_t *baseptr, const vint_t& vindex) const
 
 template<int scale>
 OIIO_FORCEINLINE void
-vfloat16::scatter_mask (const bool_t& mask, value_t *baseptr,
+vfloat16::scatter_mask (const vbool_t& mask, value_t *baseptr,
                         const vint_t& vindex) const
 {
 #if OIIO_SIMD_AVX >= 512

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -316,13 +316,13 @@ private:
 
 
 
-/// DEPRECATED(1.8)
-/// Encapsulate all the options needed for texture lookups.  Making
-/// these options all separate parameters to the texture API routines is
-/// very ugly and also a big pain whenever we think of new options to
-/// add.  So instead we collect all those little options into one
-/// structure that can just be passed by reference to the texture API
-/// routines.
+// DEPRECATED(1.8)
+// Encapsulate all the options needed for texture lookups.  Making
+// these options all separate parameters to the texture API routines is
+// very ugly and also a big pain whenever we think of new options to
+// add.  So instead we collect all those little options into one
+// structure that can just be passed by reference to the texture API
+// routines.
 class OIIO_API TextureOptions {
 public:
     /// Wrap mode describes what happens when texture coordinates describe
@@ -1113,8 +1113,10 @@ public:
                           float *dresultds=nullptr,
                           float *dresultdt=nullptr) = 0;
 
+#ifndef OIIO_DOXYGEN
     // Old multi-point API call.
     // DEPRECATED (1.8)
+    OIIO_DEPRECATED("no longer support this multi-point call (1.8)")
     virtual bool texture (ustring filename, TextureOptions &options,
                           Runflag *runflags, int beginactive, int endactive,
                           VaryingRef<float> s, VaryingRef<float> t,
@@ -1122,6 +1124,7 @@ public:
                           VaryingRef<float> dsdy, VaryingRef<float> dtdy,
                           int nchannels, float *result,
                           float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
+    OIIO_DEPRECATED("no longer support this multi-point call (1.8)")
     virtual bool texture (TextureHandle *texture_handle,
                           Perthread *thread_info, TextureOptions &options,
                           Runflag *runflags, int beginactive, int endactive,
@@ -1130,6 +1133,7 @@ public:
                           VaryingRef<float> dsdy, VaryingRef<float> dtdy,
                           int nchannels, float *result,
                           float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
+#endif
 
     /// Perform filtered 3D volumetric texture lookups on a batch of
     /// positions from the same texture, all at once. The "point-like"
@@ -1197,8 +1201,10 @@ public:
                             float *dresultds=nullptr, float *dresultdt=nullptr,
                             float *dresultdr=nullptr) = 0;
 
+#ifndef OIIO_DOXYGEN
     // Retrieve a 3D texture lookup at many points at once.
     // DEPRECATED(1.8)
+    OIIO_DEPRECATED("no longer support this multi-point call (1.8)")
     virtual bool texture3d (ustring filename, TextureOptions &options,
                             Runflag *runflags, int beginactive, int endactive,
                             VaryingRef<Imath::V3f> P,
@@ -1208,6 +1214,7 @@ public:
                             int nchannels, float *result,
                             float *dresultds=nullptr, float *dresultdt=nullptr,
                             float *dresultdr=nullptr) = 0;
+    OIIO_DEPRECATED("no longer support this multi-point call (1.8)")
     virtual bool texture3d (TextureHandle *texture_handle,
                             Perthread *thread_info, TextureOptions &options,
                             Runflag *runflags, int beginactive, int endactive,
@@ -1218,6 +1225,7 @@ public:
                             int nchannels, float *result,
                             float *dresultds=nullptr, float *dresultdt=nullptr,
                             float *dresultdr=nullptr) = 0;
+#endif
 
     /// Perform filtered directional environment map lookups on a batch of
     /// directions from the same texture, all at once. The "point-like"
@@ -1280,9 +1288,11 @@ public:
                               int nchannels, float *result,
                               float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
 
+#ifndef OIIO_DOXYGEN
     // Retrieve an environment map lookup for direction R, for many
     // points at once.
     // DEPRECATED(1.8)
+    OIIO_DEPRECATED("no longer support this multi-point call (1.8)")
     virtual bool environment (ustring filename, TextureOptions &options,
                               Runflag *runflags, int beginactive, int endactive,
                               VaryingRef<Imath::V3f> R,
@@ -1290,6 +1300,7 @@ public:
                               VaryingRef<Imath::V3f> dRdy,
                               int nchannels, float *result,
                               float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
+    OIIO_DEPRECATED("no longer support this multi-point call (1.8)")
     virtual bool environment (TextureHandle *texture_handle,
                               Perthread *thread_info, TextureOptions &options,
                               Runflag *runflags, int beginactive, int endactive,
@@ -1298,6 +1309,7 @@ public:
                               VaryingRef<Imath::V3f> dRdy,
                               int nchannels, float *result,
                               float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
+#endif
 
     // Batched shadow lookups
     virtual bool shadow (ustring filename,
@@ -1309,8 +1321,10 @@ public:
                          const float *P, const float *dPdx, const float *dPdy,
                          float *result, float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
 
+#ifndef OIIO_DOXYGEN
     // Retrieve a shadow lookup for position P at many points at once.
     // DEPRECATED(1.8)
+    OIIO_DEPRECATED("no longer support this multi-point call (1.8)")
     virtual bool shadow (ustring filename, TextureOptions &options,
                          Runflag *runflags, int beginactive, int endactive,
                          VaryingRef<Imath::V3f> P,
@@ -1318,6 +1332,7 @@ public:
                          VaryingRef<Imath::V3f> dPdy,
                          float *result,
                          float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
+    OIIO_DEPRECATED("no longer support this multi-point call (1.8)")
     virtual bool shadow (TextureHandle *texture_handle, Perthread *thread_info,
                          TextureOptions &options,
                          Runflag *runflags, int beginactive, int endactive,
@@ -1326,6 +1341,7 @@ public:
                          VaryingRef<Imath::V3f> dPdy,
                          float *result,
                          float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
+#endif
 
     /// @}
 

--- a/src/include/OpenImageIO/tiffutils.h
+++ b/src/include/OpenImageIO/tiffutils.h
@@ -161,6 +161,8 @@ tiff_dir_data (const TIFFDirEntry &td, cspan<uint8_t> data);
 /// start with a TIFF directory header.
 OIIO_API bool decode_exif (cspan<uint8_t> exif, ImageSpec &spec);
 OIIO_API bool decode_exif (string_view exif, ImageSpec &spec);
+
+OIIO_DEPRECATED("use version that takes a cspan<> (1.8)")
 OIIO_API bool decode_exif (const void *exif, int length, ImageSpec &spec); // DEPRECATED (1.8)
 
 /// Construct an Exif data block from the ImageSpec, appending the Exif

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -345,6 +345,7 @@ struct OIIO_UTIL_API TypeDesc {
     // that incurred some performance penalty and inability to optimize.
     // Please instead use the out-of-class constexpr versions below.  We
     // will eventually remove these.
+#ifndef OIIO_DOXYGEN
     static const TypeDesc TypeFloat;
     static const TypeDesc TypeColor;
     static const TypeDesc TypeString;
@@ -360,6 +361,7 @@ struct OIIO_UTIL_API TypeDesc {
     static const TypeDesc TypeKeyCode;
     static const TypeDesc TypeFloat4;
     static const TypeDesc TypeRational;
+#endif
 };
 
 

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -817,7 +817,8 @@ ImageViewer::saveAs()
                                         tr(s_file_filters));
     if (name.isEmpty())
         return;
-    bool ok = img->write(name.toStdString(), "", image_progress_callback, this);
+    bool ok = img->write(name.toStdString(), TypeUnknown, "",
+                         image_progress_callback, this);
     if (!ok) {
         std::cerr << "Save failed: " << img->geterror() << "\n";
     }
@@ -836,7 +837,8 @@ ImageViewer::saveWindowAs()
                                         QString(img->name().c_str()));
     if (name.isEmpty())
         return;
-    img->write(name.toStdString(), "", image_progress_callback, this);  // FIXME
+    img->write(name.toStdString(), TypeUnknown, "", image_progress_callback,
+               this);
 }
 
 
@@ -852,7 +854,8 @@ ImageViewer::saveSelectionAs()
                                         QString(img->name().c_str()));
     if (name.isEmpty())
         return;
-    img->write(name.toStdString(), "", image_progress_callback, this);  // FIXME
+    img->write(name.toStdString(), TypeUnknown, "", image_progress_callback,
+               this);
 }
 
 

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1527,7 +1527,7 @@ colorconvert_impl(ImageBuf& R, const ImageBuf& A,
         unpremult = false;
     // clang-format off
     parallel_image(
-        roi, parallel_image_options(nthreads),
+        roi, parallel_options(nthreads),
         [&, unpremult, channelsToCopy, processor](ROI roi) {
             int width = roi.width();
             // Temporary space to hold one RGBA scanline
@@ -1613,7 +1613,7 @@ colorconvert_impl_float_rgba(ImageBuf& R, const ImageBuf& A,
     OIIO_ASSERT(R.localpixels() && A.localpixels()
                 && R.spec().format == TypeFloat && A.spec().format == TypeFloat
                 && R.nchannels() == 4 && A.nchannels() == 4);
-    parallel_image(roi, parallel_image_options(nthreads), [&](ROI roi) {
+    parallel_image(roi, parallel_options(nthreads), [&](ROI roi) {
         int width = roi.width();
         // Temporary space to hold one RGBA scanline
         vfloat4* scanline;

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -549,8 +549,8 @@ ImageBufAlgo::unsharp_mask(ImageBuf& dst, const ImageBuf& src,
     if (kernel == "median") {
         median_filter(Blurry, src, ceilf(width), 0, roi, nthreads);
     } else {
-        ImageBuf K;
-        if (!make_kernel(K, kernel, width, width)) {
+        ImageBuf K = make_kernel(kernel, width, width);
+        if (K.has_error()) {
             dst.errorfmt("{}", K.geterror());
             return false;
         }
@@ -609,8 +609,8 @@ ImageBufAlgo::laplacian(ImageBuf& dst, const ImageBuf& src, ROI roi,
                  IBAprep_REQUIRE_SAME_NCHANNELS | IBAprep_NO_SUPPORT_VOLUME))
         return false;
 
-    ImageBuf K;
-    if (!make_kernel(K, "laplacian", 3, 3)) {
+    ImageBuf K = make_kernel("laplacian", 3, 3);
+    if (K.has_error()) {
         dst.errorfmt("{}", K.geterror());
         return false;
     }

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -916,7 +916,7 @@ ImageBufAlgo::histogram(const ImageBuf& src, int channel, int bins, float min,
                         float max, bool ignore_empty, ROI roi, int nthreads)
 {
     pvt::LoggedTimer logtimer("IBA::histogram");
-    std::vector<imagesize_t> h(bins);
+    std::vector<imagesize_t> h;
 
     // Sanity checks
     if (src.nchannels() == 0) {
@@ -941,6 +941,7 @@ ImageBufAlgo::histogram(const ImageBuf& src, int channel, int bins, float min,
     if (!roi.defined())
         roi = get_roi(src.spec());
 
+    h.resize(bins);
     bool ok = true;
     OIIO_DISPATCH_TYPES(ok, "histogram", histogram_impl, src.spec().format, src,
                         channel, h, bins, min, max, ignore_empty, roi,

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -384,8 +384,7 @@ test_add()
     // Test addition of image and constant color
     ImageBuf D(spec);
     ImageBufAlgo::add(D, A, Bval);
-    ImageBufAlgo::CompareResults comp;
-    ImageBufAlgo::compare(R, D, 1e-6f, 1e-6f, comp);
+    auto comp = ImageBufAlgo::compare(R, D, 1e-6f, 1e-6f);
     OIIO_CHECK_EQUAL(comp.maxerror, 0.0f);
 }
 
@@ -418,8 +417,7 @@ test_sub()
     // Test subtraction of image and constant color
     ImageBuf D(spec);
     ImageBufAlgo::sub(D, A, Bval);
-    ImageBufAlgo::CompareResults comp;
-    ImageBufAlgo::compare(R, D, 1e-6f, 1e-6f, comp);
+    auto comp = ImageBufAlgo::compare(R, D, 1e-6f, 1e-6f);
     OIIO_CHECK_EQUAL(comp.maxerror, 0.0f);
 }
 
@@ -452,8 +450,7 @@ test_mul()
     // Test multiplication of image and constant color
     ImageBuf D(spec);
     ImageBufAlgo::mul(D, A, Bval);
-    ImageBufAlgo::CompareResults comp;
-    ImageBufAlgo::compare(R, D, 1e-6f, 1e-6f, comp);
+    auto comp = ImageBufAlgo::compare(R, D, 1e-6f, 1e-6f);
     OIIO_CHECK_EQUAL(comp.maxerror, 0.0f);
 }
 
@@ -490,8 +487,7 @@ test_mad()
     // Test multiplication of image and constant color
     ImageBuf D(spec);
     ImageBufAlgo::mad(D, A, Bval, Cval);
-    ImageBufAlgo::CompareResults comp;
-    ImageBufAlgo::compare(R, D, 1e-6f, 1e-6f, comp);
+    auto comp = ImageBufAlgo::compare(R, D, 1e-6f, 1e-6f);
     OIIO_CHECK_EQUAL(comp.maxerror, 0.0f);
 }
 
@@ -571,8 +567,7 @@ test_compare()
     // 0.06, 0.07, 0.08, 0.09, 0, 0, ...}.
     const float failthresh = 0.05;
     const float warnthresh = 0.025;
-    ImageBufAlgo::CompareResults comp;
-    ImageBufAlgo::compare(A, B, failthresh, warnthresh, comp);
+    auto comp = ImageBufAlgo::compare(A, B, failthresh, warnthresh);
     // We expect 5 pixels to exceed the fail threshold, 7 pixels to
     // exceed the warn threshold, the maximum difference to be 0.09,
     // and the maximally different pixel to be (9,0).
@@ -699,8 +694,7 @@ test_computePixelStats()
     img.setpixel(1, 0, white);
     img.setpixel(0, 1, black);
     img.setpixel(1, 1, white);
-    ImageBufAlgo::PixelStats stats;
-    ImageBufAlgo::computePixelStats(stats, img);
+    auto stats = ImageBufAlgo::computePixelStats(img);
     for (int c = 0; c < 3; ++c) {
         OIIO_CHECK_EQUAL(stats.min[c], 0.0f);
         OIIO_CHECK_EQUAL(stats.max[c], 1.0f);
@@ -785,8 +779,7 @@ test_maketx_from_imagebuf()
     // Read it back and compare it
     ImageBuf B(pgname);
     B.read();
-    ImageBufAlgo::CompareResults comparison;
-    ImageBufAlgo::compare(A, B, 0, 0, comparison);
+    auto comparison = ImageBufAlgo::compare(A, B, 0, 0);
     OIIO_CHECK_EQUAL(comparison.nwarn, 0);
     OIIO_CHECK_EQUAL(comparison.nfail, 0);
     remove(pgname);  // clean up

--- a/src/libOpenImageIO/imagebufalgo_yee.cpp
+++ b/src/libOpenImageIO/imagebufalgo_yee.cpp
@@ -39,8 +39,7 @@ public:
     GaussianPyramid(ImageBuf& image)
     {
         level[0].swap(image);  // swallow the source as the top level
-        ImageBuf kernel;
-        ImageBufAlgo::make_kernel(kernel, "gaussian", 5, 5);
+        ImageBuf kernel = ImageBufAlgo::make_kernel("gaussian", 5, 5);
         for (int i = 1; i < PYRAMID_MAX_LEVELS; ++i)
             ImageBufAlgo::convolve(level[i], level[i - 1], kernel);
     }

--- a/src/libOpenImageIO/imageinout_test.cpp
+++ b/src/libOpenImageIO/imageinout_test.cpp
@@ -104,7 +104,8 @@ checked_read(ImageInput* in, string_view filename,
     }
     data.resize(in->spec().image_pixels() * in->spec().nchannels
                 * sizeof(float));
-    CHECKED(in, read_image(TypeFloat, data.data()));
+    CHECKED(in,
+            read_image(0, 0, 0, in->spec().nchannels, TypeFloat, data.data()));
     CHECKED(in, close());
     return true;
 }
@@ -358,7 +359,7 @@ test_read_tricky_sizes()
     // Read in, make sure it's right, several different ways
     {
         auto imgin = ImageInput::open(srcfilename);
-        imgin->read_image(TypeUInt8, buf, 4 /* xstride */);
+        imgin->read_image(0, 0, 0, 4, TypeUInt8, buf, 4 /* xstride */);
         OIIO_CHECK_EQUAL(int(buf[0][0][0]), 128);
         OIIO_CHECK_EQUAL(int(buf[0][0][1]), 0);
         OIIO_CHECK_EQUAL(int(buf[0][0][2]), 0);
@@ -390,7 +391,7 @@ test_read_tricky_sizes()
     {
         memset(buf, 0, 4 * 4 * 4);
         auto imgin = ImageInput::open(srcfilename);
-        imgin->read_image(TypeUInt8, buf, 4 /* xstride */);
+        imgin->read_image(0, 0, 0, 4, TypeUInt8, buf, 4 /* xstride */);
         OIIO_CHECK_EQUAL(int(buf[0][0][0]), 128);
         OIIO_CHECK_EQUAL(int(buf[0][0][1]), 0);
         OIIO_CHECK_EQUAL(int(buf[0][0][2]), 0);

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -574,7 +574,8 @@ ImageOutput::copy_image(ImageInput* in)
     bool native = supports("channelformats") && inspec.channelformats.size();
     TypeDesc format = native ? TypeDesc::UNKNOWN : inspec.format;
     std::unique_ptr<char[]> pixels(new char[inspec.image_bytes(native)]);
-    bool ok = in->read_image(format, &pixels[0]);
+    bool ok = in->read_image(in->current_subimage(), in->current_miplevel(), 0,
+                             inspec.nchannels, format, &pixels[0]);
     if (ok)
         ok = write_image(format, &pixels[0]);
     else

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -85,7 +85,7 @@ time_read_image()
     for (ustring filename : input_filename) {
         auto in = ImageInput::open(filename.c_str());
         OIIO_ASSERT(in);
-        in->read_image(conversion, &buffer[0]);
+        in->read_image(0, 0, 0, in->spec().nchannels, conversion, &buffer[0]);
         in->close();
     }
 }
@@ -125,7 +125,7 @@ time_read_64_scanlines_at_a_time()
             pixelsize = spec.pixel_bytes(true);  // UNKNOWN -> native
         imagesize_t scanlinesize = spec.width * pixelsize;
         for (int y = 0; y < spec.height; y += 64) {
-            in->read_scanlines(y + spec.y,
+            in->read_scanlines(0, 0, y + spec.y,
                                std::min(y + spec.y + 64, spec.y + spec.height),
                                0, conversion, &buffer[scanlinesize * y]);
         }

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -222,7 +222,7 @@ resize_block_(ImageBuf& dst, const ImageBuf& src, ROI roi, bool envlatlmode)
         for (int x = x0; x < x1; ++x, ++d) {
             float s = (x + 0.5f) * xscale + xoffset;
             if (src_is_crop)
-                src.interppixel_NDC_full(s, t, pel);
+                src.interppixel_NDC(s, t, pel);
             else
                 interppixel_NDC_clamped<SRCTYPE>(src, s, t, pel, envlatlmode);
             for (int c = 0; c < nchannels; ++c)
@@ -1197,7 +1197,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     bool compute_stats = (constant_color_detect || opaque_detect
                           || compute_average_color);
     if (compute_stats) {
-        ImageBufAlgo::computePixelStats(pixel_stats, *src);
+        pixel_stats = ImageBufAlgo::computePixelStats(*src);
     }
     double stat_pixelstatstime = alltime.lap();
     STATUS("pixelstats", stat_pixelstatstime);

--- a/src/oiiotool/diff.cpp
+++ b/src/oiiotool/diff.cpp
@@ -106,8 +106,8 @@ OiioTool::do_action_diff(ImageRec& ir0, ImageRec& ir1, Oiiotool& ot,
                 yee_failures = ImageBufAlgo::compare_Yee(img0, img1, cr);
                 break;
             default:
-                ImageBufAlgo::compare(img0, img1, ot.diff_failthresh,
-                                      ot.diff_warnthresh, cr);
+                cr = ImageBufAlgo::compare(img0, img1, ot.diff_failthresh,
+                                           ot.diff_warnthresh);
                 break;
             }
 

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -34,14 +34,14 @@ using namespace ImageBufAlgo;
 
 
 static std::string
-compute_sha1(Oiiotool& ot, ImageInput* input)
+compute_sha1(Oiiotool& ot, ImageInput* input, int subimage)
 {
     SHA1 sha;
     const ImageSpec& spec(input->spec());
     if (spec.deep) {
         // Special handling of deep data
         DeepData dd;
-        if (!input->read_native_deep_image(dd)) {
+        if (!input->read_native_deep_image(subimage, 0, dd)) {
             std::string err = input->geterror();
             if (err.empty())
                 err = "could not read image";
@@ -576,7 +576,7 @@ print_info_subimage(std::ostream& out, Oiiotool& ot, int current_subimage,
         && (opt.metamatch.empty() || std::regex_search("sha-1", field_re))) {
         // Before sha-1, be sure to point back to the highest-res MIP level
         ImageSpec tmpspec;
-        std::string sha = compute_sha1(ot, input);
+        std::string sha = compute_sha1(ot, input, current_subimage);
         if (serformat == ImageSpec::SerialText)
             lines.insert(lines.begin() + 1, format("    SHA-1: {}", sha));
         else if (serformat == ImageSpec::SerialText)

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -1401,7 +1401,8 @@ IBA_computePixelStats(const ImageBuf& src, ImageBufAlgo::PixelStats& stats,
                       ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::computePixelStats(stats, src, roi, nthreads);
+    stats = ImageBufAlgo::computePixelStats(src, roi, nthreads);
+    return stats.min.size() != 0;
 }
 
 
@@ -1421,8 +1422,8 @@ IBA_compare(const ImageBuf& A, const ImageBuf& B, float failthresh,
             int nthreads)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::compare(A, B, failthresh, warnthresh, result, roi,
-                                 nthreads);
+    result = ImageBufAlgo::compare(A, B, failthresh, warnthresh, roi, nthreads);
+    return result.error;
 }
 
 
@@ -1620,8 +1621,8 @@ IBA_make_kernel(ImageBuf& dst, const std::string& name, float width,
                 float height, float depth, bool normalize)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::make_kernel(dst, name, width, height, depth,
-                                     normalize);
+    dst = ImageBufAlgo::make_kernel(name, width, height, depth, normalize);
+    return !dst.has_error();
 }
 
 ImageBuf
@@ -2323,7 +2324,8 @@ IBA_capture_image(ImageBuf& dst, int cameranum,
                   TypeDesc::BASETYPE convert = TypeDesc::UNKNOWN)
 {
     py::gil_scoped_release gil;
-    return ImageBufAlgo::capture_image(dst, cameranum, convert);
+    dst = ImageBufAlgo::capture_image(cameranum, convert);
+    return !dst.has_error();
 }
 
 ImageBuf
@@ -2982,7 +2984,6 @@ declare_imagebufalgo(py::module& m)
                     "bins"_a = 256, "min"_a = 0.0f, "max"_a = 1.0f,
                     "ignore_empty"_a = false, "roi"_a = ROI::All(),
                     "nthreads"_a = 0)
-        // histogram_draw,
 
         .def_static("make_texture", &IBA_make_texture_filename, "mode"_a,
                     "filename"_a, "outputfilename"_a, "config"_a = ImageSpec())


### PR DESCRIPTION
And make sure to switch all of our internal uses of those to the
preferred new equivalents!

Also, hide some deprecated things from the documentation system so that
new people won't be tempted to use them.

These are all things that have been deprecated starting with OIIO 2.0
(or in some cases, even earlier). Multiple releases (2.0, 2.1, 2.2)
have gone by with them commented or documented as deprecated, but
without our adding the warnings. It's about time. We're still not
taking them away entirely, I usually don't do that until we've had at
least one release where it's been marked as OIIO_DEPRECATED, and also
only do true removals of API at major releases. But we're laying the
groundwork for being able to totally remove these when we eventually
have a 3.0 release.

