### PR TITLE
CI: update "latest" releases we test against, notably OpenEXR 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,7 @@ jobs:
 
   vfxplatform-2021:
     # Test what's anticipated to be VFX Platform 2021 -- mainly, that means
-    # gcc9 and C++17. This test currently uses the latest OpenEXR release
-    # 2.5, though eventually 2021 will feature OpenEXR 3.0 when complete.
+    # gcc9 and C++17.
     name: "Linux VFX Platform 2021: gcc9/C++17 py3.7 boost-1.73 exr-2.5 qt-5.15"
     runs-on: ubuntu-latest
     container:
@@ -313,11 +312,11 @@ jobs:
       USE_SIMD: avx2,f16c
       LIBRAW_VERSION: 0.20.2
       LIBTIFF_VERSION: v4.3.0
-      OPENCOLORIO_VERSION: v2.0.0
-      OPENEXR_VERSION: v3.0.3
+      OPENCOLORIO_VERSION: v2.0.1
+      OPENEXR_VERSION: v3.1.0
       PUGIXML_VERSION: v1.11.4
       PTEX_VERSION: v2.4.0
-      PYBIND11_VERSION: v2.6.2
+      PYBIND11_VERSION: v2.7.0
       PYTHON_VERSION: 3.8
       WEBP_VERSION: v1.1.0
       MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=8.0.0
@@ -372,8 +371,7 @@ jobs:
       OPENEXR_VERSION: master
       PUGIXML_VERSION: master
       PTEX_VERSION: main
-      PYBIND11_VERSION: v2.6.2
-      # PYBIND11_VERSION: master
+      PYBIND11_VERSION: master
       PYTHON_VERSION: 3.8
       WEBP_VERSION: master
       MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=master -DOIIO_USE_EXR_C_API=ON

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
        CMake configuration flag: `-DCMAKE_CXX_STANDARD=17`, etc.
  * Compilers: **gcc 6.1 - 11.1**, **clang 3.4 - 12**, **MSVS 2017 - 2019**,
    **icc 17+**.
- * CMake >= 3.12 (tested through 3.20)
+ * CMake >= 3.12 (tested through 3.21)
  * OpenEXR/Imath >= 2.0 (recommended: 2.2 or higher; tested through 3.1)
  * libTIFF >= 3.9 (recommended: 4.0+; tested through 4.3)
  * Boost >= 1.53 (recommended: at least 1.66; tested through 1.76)
@@ -31,7 +31,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * OpenGL
  * If you are building the Python bindings or running the testsuite:
      * Python >= 2.7 (tested against 2.7, 3.6, 3.7, 3.8, 3.9)
-     * pybind11 >= 2.4.2 (Tested through 2.6.)
+     * pybind11 >= 2.4.2 (Tested through 2.7.)
      * NumPy
  * If you want support for camera "RAW" formats:
      * LibRaw >= 0.15 (tested 0.15 - 0.20; LibRaw >= 0.18 is necessary for


### PR DESCRIPTION
OpenEXR -> 3.1.0
pybind11 -> 2.7.0
OCIO -> 2.0.1
