### PR TITLE
ImageCache: add a variety of invalidate() that takes an ImageHandle*

### DIFF
--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -821,6 +821,10 @@ public:
     /// since it was first opened by the ImageCache.
     virtual void invalidate(ustring filename, bool force = true) = 0;
 
+    /// A more efficient variety of `invalidate()` for cases where you
+    /// already have an `ImageHandle*` for the file you want to invalidate.
+    virtual void invalidate(ImageHandle* file, bool force = true) = 0;
+
     /// Invalidate all loaded tiles and close open file handles.  This is
     /// safe to do even if other procedures are currently holding
     /// reference-counted tile pointers from the named image, but those

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3246,11 +3246,21 @@ ImageCacheImpl::invalidate(ustring filename, bool force)
             return;  // no such file
     }
 
+    invalidate(file.get(), force);
+}
+
+
+
+void
+ImageCacheImpl::invalidate(ImageHandle* handle, bool force)
+{
+    ImageCacheFileRef file(handle);
+
     if (!force) {
         // If not in force mode, we don't do anything if the modification
         // time of the file has not changed since we opened it.
         recursive_lock_guard guard(file->m_input_mutex);
-        if (file->mod_time() == Filesystem::last_write_time(filename)
+        if (file->mod_time() == Filesystem::last_write_time(file->filename())
             && !file->broken())
             return;
     }

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -972,6 +972,7 @@ public:
     virtual std::string getstats(int level = 1) const;
     virtual void reset_stats();
     virtual void invalidate(ustring filename, bool force);
+    virtual void invalidate(ImageHandle* file, bool force);
     virtual void invalidate_all(bool force = false);
     virtual void close(ustring filename);
     virtual void close_all();


### PR DESCRIPTION
Most of the rest of the IC methods that take a filename, also have
a version that takes a handle.

Closes #3034