### PR TITLE
imagebuf.h: remove inclusion of imagecache.h

### DIFF
--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -14,7 +14,6 @@
 
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/fmath.h>
-#include <OpenImageIO/imagecache.h>
 #include <OpenImageIO/imageio.h>
 
 #include <limits>
@@ -25,6 +24,11 @@ OIIO_NAMESPACE_BEGIN
 
 class ImageBuf;
 class ImageBufImpl;  // Opaque type for the unique_ptr.
+class ImageCache;
+
+namespace pvt {
+class ImageCacheTile;
+};  // namespace pvt
 
 
 
@@ -1219,7 +1223,7 @@ public:
         ~IteratorBase()
         {
             if (m_tile)
-                m_ib->imagecache()->release_tile(m_tile);
+                release_tile();
         }
 
         /// Assign one IteratorBase to another
@@ -1227,7 +1231,7 @@ public:
         const IteratorBase& assign_base(const IteratorBase& i)
         {
             if (m_tile)
-                m_ib->imagecache()->release_tile(m_tile);
+                release_tile();
             m_tile      = nullptr;
             m_proxydata = i.m_proxydata;
             m_ib        = i.m_ib;
@@ -1409,7 +1413,7 @@ public:
         int m_rng_xbegin, m_rng_xend, m_rng_ybegin, m_rng_yend, m_rng_zbegin,
             m_rng_zend;
         int m_x, m_y, m_z;
-        ImageCache::Tile* m_tile = nullptr;
+        pvt::ImageCacheTile* m_tile = nullptr;
         int m_tilexbegin, m_tileybegin, m_tilezbegin;
         int m_tilexend;
         int m_nchannels;
@@ -1510,6 +1514,11 @@ public:
                 init_ib(m_wrap);
             }
         }
+
+        // Helper to release the IC tile held by m_tile. This is implemented
+        // elsewhere to prevent imagebuf.h needing to know anything more
+        // about ImageCache.
+        void OIIO_API release_tile();
     };
 
     /// Templated class for referring to an individual pixel in an
@@ -1754,10 +1763,10 @@ protected:
     static void impl_deleter(ImageBufImpl*);
     std::unique_ptr<ImageBufImpl, decltype(&impl_deleter)> m_impl;
 
-    // Reset the ImageCache::Tile * to reserve and point to the correct
+    // Reset the ImageCacheTile* to reserve and point to the correct
     // tile for the given pixel, and return the ptr to the actual pixel
     // within the tile.
-    const void* retile(int x, int y, int z, ImageCache::Tile*& tile,
+    const void* retile(int x, int y, int z, pvt::ImageCacheTile*& tile,
                        int& tilexbegin, int& tileybegin, int& tilezbegin,
                        int& tilexend, bool exists,
                        WrapMode wrap = WrapDefault) const;

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -29,6 +29,7 @@ namespace pvt {
 // Forward declaration
 class ImageCacheImpl;
 class ImageCacheFile;
+class ImageCacheTile;
 class ImageCachePerThreadInfo;
 };  // namespace pvt
 
@@ -845,7 +846,7 @@ public:
 
     /// An opaque data type that allows us to have a pointer to a tile but
     /// without exposing any internals.
-    class Tile;
+    typedef pvt::ImageCacheTile Tile;
 
     /// Find the tile specified by an image filename, subimage & miplevel,
     /// the coordinates of a pixel, and optionally a channel range.   An

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -30,6 +30,7 @@
 
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filesystem.h>
+#include <OpenImageIO/imagecache.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/timer.h>

--- a/src/iv/ivimage.cpp
+++ b/src/iv/ivimage.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 
 #include "imageviewer.h"
+#include <OpenImageIO/imagecache.h>
 #include <OpenImageIO/strutil.h>
 
 

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -2670,6 +2670,14 @@ ImageBuf::WrapMode_from_string(string_view name)
 
 
 
+void
+ImageBuf::IteratorBase::release_tile()
+{
+    m_ib->imagecache()->release_tile(m_tile);
+}
+
+
+
 const void*
 ImageBufImpl::retile(int x, int y, int z, ImageCache::Tile*& tile,
                      int& tilexbegin, int& tileybegin, int& tilezbegin,

--- a/src/libOpenImageIO/imagebuf_test.cpp
+++ b/src/libOpenImageIO/imagebuf_test.cpp
@@ -7,6 +7,7 @@
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
+#include <OpenImageIO/imagecache.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/unittest.h>
 

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -7,6 +7,7 @@
 #include <OpenImageIO/benchmark.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
+#include <OpenImageIO/imagecache.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/timer.h>

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -17,6 +17,7 @@
 #include <OpenImageIO/filter.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
+#include <OpenImageIO/imagecache.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/sysutil.h>

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -17,6 +17,7 @@
 #include <OpenImageIO/filter.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
+#include <OpenImageIO/imagecache.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/thread.h>
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -26,6 +26,7 @@
 #include <OpenImageIO/filter.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
+#include <OpenImageIO/imagecache.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/simd.h>
 #include <OpenImageIO/strutil.h>

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -17,6 +17,7 @@
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/imagebufalgo_util.h>
+#include <OpenImageIO/imagecache.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/sysutil.h>


### PR DESCRIPTION
I noticed when working on an ImageCache thing that even the smallest
change to imagecache.h was causing a substantial amount of the
codebase to needlessly recompile even though very few places really
need to use the IC APIs directly.

It took a little bit of juggling of some declarations, but this patch
allows imagebuf.h to be able to treat ImageCache and ImageCacheTile as
opaque, forward-declared types, without the need for every file that
needs imagebuf.h to also have to parse imagecache.h and everything it
might pull in.

This speeds up my development cycle substantially in many cases, and
it also speeds up compilation of user code (by a small amount) by
avoiding parsing of imagecache.h in circumstances where the user code
only needed to know about ImageBuf but not ImageCache.

There's a downside to this -- it's possible that user code that truly
needs both imagebuf.h and imagecache.h only includes the former
(inadvertently relying on the fact that the latter was transitively
included). These apps may need `#include <OpenImageIO/imagecache.h>`
to be added after upgrading to OIIO 2.3. Is that really really bad?

