### PR TITLE
Let CUE_THREADS help determine default number of threads for OIIO

### DIFF
--- a/src/doc/imageioapi.rst
+++ b/src/doc/imageioapi.rst
@@ -316,7 +316,7 @@ inside the source code.
         imagecache->attribute ("options", value);
 
 
-``OPENIMAGEIO_TEXTURESYSTEM_OPTIONS``
+``OPENIMAGEIO_TEXTURE_OPTIONS``
 
     Allows you to seed the options for any TextureSystem created.
 
@@ -328,3 +328,10 @@ inside the source code.
     will be passed to a call to::
 
         texturesys->attribute ("options", value);
+
+``OPENIMAGEIO_THREADS``, ``CUE_THREADS``
+
+    Either of these sets the default number of threads that OpenImageIO will
+    use for its thread pool. If both are set, ``OPENIMAGEIO_THREADS`` will
+    take precedence. If neither is set, the default will be 0, which means
+    to use as many threads as there are physical cores on the machine.

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -24,7 +24,8 @@ OIIO_NAMESPACE_BEGIN
 static int
 threads_default()
 {
-    int n = Strutil::from_string<int>(Sysutil::getenv("OPENIMAGEIO_THREADS"));
+    int n = Strutil::from_string<int>(
+        Sysutil::getenv("OPENIMAGEIO_THREADS", Sysutil::getenv("CUE_THREADS")));
     if (n < 1)
         n = Sysutil::hardware_concurrency();
     return n;

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -88,7 +88,8 @@ OIIO_NAMESPACE_BEGIN
 static int
 threads_default()
 {
-    int n = Strutil::from_string<int>(Sysutil::getenv("OPENIMAGEIO_THREADS"));
+    int n = Strutil::from_string<int>(
+        Sysutil::getenv("OPENIMAGEIO_THREADS", Sysutil::getenv("CUE_THREADS")));
     if (n < 1)
         n = Sysutil::hardware_concurrency();
     return n;


### PR DESCRIPTION
OpenCue-launched apps are encouraged to honor the setting of
CUE_THREADS to limit the number of threads they use. This change makes
oiiotool a better citizen when run as part of an OpenCue job.

CUE_THREADS has lower precedence than the more OIIO-specific
`OPENIMAGEIO_THREADS`.

For ordinary command line usage, this should not change behavior, since
you wouldn't expect CUE_THREADS to be set.

(Also fix docs which incorrectly named `OPENIMAGEIO_TEXTURE_OPTIONS`.)

