### PR TITLE
Streamline determination of whether file type is procedural.

### DIFF
--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -53,6 +53,10 @@ inline void errorfmt (const char* fmt, const Args&... args) {
 // Make sure all plugins are inventoried. For internal use only.
 void catalog_all_plugins (std::string searchpath);
 
+// Inexpensive check if a file extension or format name corresponds to a
+// procedural input plugin.
+bool is_procedural_plugin(const std::string& name);
+
 /// Given the format, set the default quantization range.
 void get_default_quantize (TypeDesc format, long long &quant_min,
                            long long &quant_max) noexcept;

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -2492,14 +2492,14 @@ ImageCacheImpl::resolve_filename(const std::string& filename) const
 {
     // Ask if the format can generate imagery procedurally. If so, don't
     // go looking for a file.
-    auto input      = ImageInput::create(filename);
-    bool procedural = input ? input->supports("procedural") : false;
-    if (procedural)
+    if (pvt::is_procedural_plugin(filename)
+        || pvt::is_procedural_plugin(Filesystem::extension(filename, false)))
         return filename;
-    // don't bother with the searchpath_find call since it will do an existence
-    // check that we don't need
-    if (m_searchdirs.empty())
+    if (m_searchdirs.empty() || Filesystem::path_is_absolute(filename, true)) {
+        // Don't bother with the searchpath_find call since it will do an
+        // existence check that we don't need.
         return filename;
+    }
     std::string s = Filesystem::searchpath_find(filename, m_searchdirs, true);
     return s.empty() ? filename : s;
 }


### PR DESCRIPTION
Imagecache repeatedly has to determine whether a filename is a type
of file that's "procedural" and does it expensively -- every time, it
creates the type of ImageInput in question just to ask it if it
supports("procedural").

We can ask this of each plugin type once, when we first register it.
Then just look it up when we need it.

This is strictly internal, has nothing to do with public APIs.
