### PR TITLE
Augment PR 3037 to make it not break ABI compat

### DIFF
--- a/src/include/OpenImageIO/sysutil.h
+++ b/src/include/OpenImageIO/sysutil.h
@@ -67,7 +67,11 @@ this_program_path();
 /// the environment, return `defaultval`, which in turn defaults to the
 /// empty string.
 OIIO_API string_view
-getenv(string_view name, string_view defaultval = "");
+getenv(string_view name, string_view defaultval);
+
+// Legacy for link compatibility. DEPRECATED(2.3)
+OIIO_API string_view
+getenv(string_view name);
 
 /// Sleep for the given number of microseconds.
 ///

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -282,6 +282,15 @@ Sysutil::getenv(string_view name, string_view defaultval)
 
 
 
+string_view
+Sysutil::getenv(string_view name)
+{
+    const char* env = ::getenv(std::string(name).c_str());
+    return string_view(env ? env : "");
+}
+
+
+
 void
 Sysutil::usleep(unsigned long useconds)
 {


### PR DESCRIPTION
I realized that 3037 breaks ABI compat, so restore the 1-argument
version of Sysutil::getenv. This makes it backportable.
