### PR TITLE
Strutil::contains_any_char()

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -373,6 +373,9 @@ size_t OIIO_UTIL_API irfind(string_view a, string_view b);
 /// comparison?
 bool OIIO_UTIL_API icontains (string_view a, string_view b);
 
+/// Does 'a' contain any of the characters within `set`?
+bool OIIO_UTIL_API contains_any_char (string_view a, string_view set);
+
 /// Convert to upper case in place, faster than std::toupper because we use
 /// a static locale that doesn't require a mutex lock.
 void OIIO_UTIL_API to_lower (std::string &a);
@@ -872,17 +875,16 @@ string_view OIIO_UTIL_API parse_identifier (string_view &str,
 bool OIIO_UTIL_API parse_identifier_if (string_view &str, string_view id,
                                    bool eat=true) noexcept;
 
-/// Return the characters until any character in sep is found, storing it in
-/// str, and additionally modify str to skip over the parsed section if eat
-/// is also true. Otherwise, if no word is found at the beginning of str,
-/// return an empty string_view and don't modify str.
+/// Return the longest prefix of `str` that does not contain any characters
+/// found in `set` (which defaults to the set of common whitespace
+/// characters). If `eat` is true, then `str` will be modified to trim off
+/// this returned prefix (but not the separator character).
 string_view OIIO_UTIL_API parse_until (string_view &str,
-                                  string_view sep=" \t\r\n", bool eat=true) noexcept;
+                                  string_view set=" \t\r\n", bool eat=true) noexcept;
 
-/// Return the characters at the head of the string that match any in set,
-/// and additionally modify str to skip over the parsed section if eat is
-/// also true. Otherwise, if no `set` characters are found at the beginning
-/// of str, return an empty string_view and don't modify str.
+/// Return the longest prefix of `str` that contain only characters found in
+/// `set`. If `eat` is true, then `str` will be modified to trim off this
+/// returned prefix.
 string_view OIIO_UTIL_API parse_while (string_view &str,
                                   string_view set, bool eat=true) noexcept;
 

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -460,6 +460,22 @@ Strutil::icontains(string_view a, string_view b)
 }
 
 
+
+bool
+Strutil::contains_any_char(string_view a, string_view set)
+{
+    if (a.size() == 0)
+        return false;
+    // Leverage Strutil::parse_until, which trims a string until it hits
+    // any characters in a set.
+    string_view r = parse_until(a, set, false /* don't alter a */);
+    // If r encompasses less than all of a, it must have found one of the
+    // characters in set.
+    return (r.size() < a.size());
+}
+
+
+
 size_t
 Strutil::find(string_view a, string_view b)
 {

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -301,6 +301,14 @@ test_comparisons()
     OIIO_CHECK_EQUAL(Strutil::icontains("", ""), true);
     OIIO_CHECK_EQUAL(Strutil::icontains("", "x"), false);
 
+    OIIO_CHECK_EQUAL(Strutil::contains_any_char("abcde", "xa"), true);
+    OIIO_CHECK_EQUAL(Strutil::contains_any_char("abcde", "xe"), true);
+    OIIO_CHECK_EQUAL(Strutil::contains_any_char("abcde", "xc"), true);
+    OIIO_CHECK_EQUAL(Strutil::contains_any_char("abcde", "xyz"), false);
+    OIIO_CHECK_EQUAL(Strutil::contains_any_char("abcde", "abcde"), true);
+    OIIO_CHECK_EQUAL(Strutil::contains_any_char("", "abc"), false);
+    OIIO_CHECK_EQUAL(Strutil::contains_any_char("abcde", ""), false);
+
     OIIO_CHECK_EQUAL(Strutil::find("abcdeabcde", "bc"), 1);
     OIIO_CHECK_EQUAL(Strutil::find("abcdeabcde", "BC"), std::string::npos);
     OIIO_CHECK_EQUAL(Strutil::find("abcdeabcde", "ac"), std::string::npos);


### PR DESCRIPTION
Added this handy function that figures out if the first string contains
any character present in the second string.

Also rewrite the comments describing parse_until and parse_while for
better clarity and correctness.
