### PR TITLE
exr read: don't rename "version" attribute to "openexr:version"

### DIFF
--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -326,7 +326,6 @@ private:
         m_map["wrapmodes"] = "wrapmodes";
         m_map["aperture"]  = "FNumber";
         // Ones to prefix with openexr:
-        m_map["version"]             = "openexr:version";
         m_map["chunkCount"]          = "openexr:chunkCount";
         m_map["maxSamplesPerPixel"]  = "openexr:maxSamplesPerPixel";
         m_map["dwaCompressionLevel"] = "openexr:dwaCompressionLevel";

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -298,7 +298,6 @@ private:
         m_map["wrapmodes"] = "wrapmodes";
         m_map["aperture"]  = "FNumber";
         // Ones to prefix with openexr:
-        m_map["version"]             = "openexr:version";
         m_map["chunkCount"]          = "openexr:chunkCount";
         m_map["maxSamplesPerPixel"]  = "openexr:maxSamplesPerPixel";
         m_map["dwaCompressionLevel"] = "openexr:dwaCompressionLevel";

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -870,8 +870,8 @@ static ExrMeta exr_meta_translation[] = {
     // don't want to mess it up by inadvertently copying it wrong from the
     // user or from a file we read.
     ExrMeta("YResolution"), ExrMeta("planarconfig"), ExrMeta("type"),
-    ExrMeta("tiles"), ExrMeta("version"), ExrMeta("chunkCount"),
-    ExrMeta("maxSamplesPerPixel"), ExrMeta("openexr:roundingmode")
+    ExrMeta("tiles"), ExrMeta("chunkCount"), ExrMeta("maxSamplesPerPixel"),
+    ExrMeta("openexr:roundingmode")
 };
 
 

--- a/testsuite/openexr-v2/ref/out.txt
+++ b/testsuite/openexr-v2/ref/out.txt
@@ -97,12 +97,12 @@ Reading ../../../../../openexr-images/v2/Stereo/Balls.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    version: 1
     view: "left"
     oiio:ColorSpace: "Linear"
     oiio:subimagename: "rgba.left"
     oiio:subimages: 2
     openexr:chunkCount: 761
-    openexr:version: 1
  subimage  1: 1452 x  761, 5 channel, deep half/half/half/half/float openexr
     SHA-1: 23D591E3BE032257729B30F078D62F6A16D40377
     channel list: R (half), G (half), B (half), A (half), Z (float)
@@ -115,12 +115,12 @@ Reading ../../../../../openexr-images/v2/Stereo/Balls.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    version: 1
     view: "right"
     oiio:ColorSpace: "Linear"
     oiio:subimagename: "rgba.right"
     oiio:subimages: 2
     openexr:chunkCount: 761
-    openexr:version: 1
 ../../../../../openexr-images/v2/Stereo/Balls.exr : 1431 x  761, 5 channel, deep half/half/half/half/float openexr (2 subimages)
     Stats Min: 0.000169 0.000083 0.000092 0.015625 127.872681 (float)
     Stats Max: 0.622070 0.265625 0.267822 1.000000 738.560669 (float)
@@ -156,12 +156,12 @@ Reading ../../../../../openexr-images/v2/Stereo/Leaves.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    version: 1
     view: "left"
     oiio:ColorSpace: "Linear"
     oiio:subimagename: "rgba.left"
     oiio:subimages: 2
     openexr:chunkCount: 1080
-    openexr:version: 1
  subimage  1: 1920 x 1080, 5 channel, deep half/half/half/half/float openexr
     SHA-1: B0B52A15E0E25796832E4C25BD835C3F3B970BC0
     channel list: R (half), G (half), B (half), A (half), Z (float)
@@ -171,12 +171,12 @@ Reading ../../../../../openexr-images/v2/Stereo/Leaves.exr
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
     screenWindowWidth: 1
+    version: 1
     view: "right"
     oiio:ColorSpace: "Linear"
     oiio:subimagename: "rgba.right"
     oiio:subimages: 2
     openexr:chunkCount: 1080
-    openexr:version: 1
 ../../../../../openexr-images/v2/Stereo/Leaves.exr : 1920 x 1080, 5 channel, deep half/half/half/half/float openexr (2 subimages)
     Stats Min: 0.000099 0.000341 0.000152 0.015625 72.493698 (float)
     Stats Max: 0.403564 0.593262 0.345215 1.000000 954.392700 (float)


### PR DESCRIPTION
Some of the OpenEXR sample files had an attribute "version".
All along, I assumed this was telling me the version of the OpenEXR file
itself, so I was passing it along and also renaming "openexr:version".

Turns out I was wrong! This is just arbitrary metadata. Who knows why
it's in some of these files? Maybe nobody. But it's not meant to indicate
the file format version, and indeed it does not correctly reflect it.

In fact, there is no simple API call in the OpenEXR API that tells you
the file format version, you have to infer it from the features
present (multi-part or deep or long attribute name indicate changes
that came along with OpenEXR 2.x, but there is no version number in
the file per se).

So I'm just going to stop doing this rename, let "version" be "version",
it's just some user's metadata, I guess.

Fixes #3041 
