### PR TITLE
RAW plugin improvements

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1508,6 +1508,27 @@ options are supported:
      - int
      - Set libraw highlight mode processing: 0 = clip, 1 = unclip, 2 =
        blend, 3+ = rebuild. (Default: 0.)
+   * - ``raw:balance_clamped``
+     - int
+     - If nonzero, balance any clamped highlight values in the image. Resolves issues
+       where highlights take on an undesired hue shift due to incongruous channel
+       sensor saturation.
+       Enabling this option will change the output datatype to HALF.
+       (Default: 0)
+   * - ``raw:apply_scene_linear_scale``
+     - int
+     - If nonzero, applies an additional multiplication to the pixel values returned
+       by libraw. See ``raw:camera_to_scene_linear_scale`` for more details.
+       Enabling this option will change the output datatype to HALF.
+       (Default: 0)
+   * - ``raw:camera_to_scene_linear_scale``
+     - float
+     - Whilst the libraw pixel values are linear, they are normalized based on
+       the whitepoint / sensor / ISO and shooting conditions. An additional multiplication
+       is needed to bring exposure levels up so that a correctly photographed 18% grey card
+       has pixel values at 0.18. Setting this metadata key implies ``raw:apply_scene_linear_scale``.
+       Enabling this option will change the output datatype to HALF.
+       (Default: 2.2222222222222223 (1.0/0.45))
    * - ``raw:user_flip``
      - int
      - Set libraw user flip value : -1 ignored, other values are between [0; 8] with the same 

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -742,12 +742,12 @@ RawInput::open_raw(bool unpack, const std::string& name,
             ret = m_processor->raw2image_ex(/*subtract_black=*/true);
             if (ret != LIBRAW_SUCCESS) {
                 errorf("HighlightMode adjustment detection read failed");
-                errorf(libraw_strerror(ret));
+                errorf("%s", libraw_strerror(ret));
                 return false;
             }
             if (m_processor->adjust_maximum() != LIBRAW_SUCCESS) {
                 errorf("HighlightMode minimum adjustment failed");
-                errorf(libraw_strerror(ret));
+                errorf("%s", libraw_strerror(ret));
                 return false;
             }
             float unadjusted = m_processor->imgdata.color.maximum;
@@ -759,7 +759,7 @@ RawInput::open_raw(bool unpack, const std::string& name,
             // Get new max value
             if (m_processor->adjust_maximum() != LIBRAW_SUCCESS) {
                 errorf("HighlightMode maximum adjustment failed");
-                errorf(libraw_strerror(ret));
+                errorf("%s", libraw_strerror(ret));
                 return false;
             }
             float adjusted = m_processor->imgdata.color.maximum;

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -410,6 +410,7 @@ RawInput::open_raw(bool unpack, const std::string& name,
                    libraw_strerror(ret));
             return false;
         }
+        m_unpacked = true;
     }
 
     m_processor->adjust_sizes_info_only();

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -66,10 +66,11 @@ private:
     bool m_unpacked = false;
     std::unique_ptr<LibRaw> m_processor;
     libraw_processed_image_t* m_image = nullptr;
-    bool m_do_scene_linear_scale = false;
-    float m_camera_to_scene_linear_scale = (1.0f / 0.45f); // see open_raw for details
+    bool m_do_scene_linear_scale      = false;
+    float m_camera_to_scene_linear_scale
+        = (1.0f / 0.45f);  // see open_raw for details
     bool m_do_balance_clamped = false;
-    float m_balanced_max = 1.0;
+    float m_balanced_max      = 1.0;
     std::string m_filename;
     ImageSpec m_config;  // save config requests
     std::string m_make;
@@ -236,28 +237,30 @@ OIIO_EXPORT const char* raw_input_extensions[]
 OIIO_PLUGIN_EXPORTS_END
 
 namespace {
-    const char* libraw_filter_to_str(unsigned int filters){
-        // Convert the libraw filter pattern description
-        // into a slightly more human readable string
-        // LibRaw/internal/defines.h:166
-        switch(filters){
-            // CYGM
-            case 0xe1e4e1e4: return "GMYC";
-            case 0x1b4e4b1e: return "CYGM";
-            case 0x1e4b4e1b: return "YCGM";
-            case 0xb4b4b4b4: return "GMCY";
-            case 0x1e4e1e4e: return "CYMG";
+const char*
+libraw_filter_to_str(unsigned int filters)
+{
+    // Convert the libraw filter pattern description
+    // into a slightly more human readable string
+    // LibRaw/internal/defines.h:166
+    switch (filters) {
+    // CYGM
+    case 0xe1e4e1e4: return "GMYC";
+    case 0x1b4e4b1e: return "CYGM";
+    case 0x1e4b4e1b: return "YCGM";
+    case 0xb4b4b4b4: return "GMCY";
+    case 0x1e4e1e4e: return "CYMG";
 
-            // RGB
-            case 0x16161616: return "BGRG";
-            case 0x61616161: return "GRGB";
-            case 0x49494949: return "GBGR";
-            case 0x94949494: return "RGBG";
-            default: break;
-        }
-        return "";
+    // RGB
+    case 0x16161616: return "BGRG";
+    case 0x61616161: return "GRGB";
+    case 0x49494949: return "GBGR";
+    case 0x94949494: return "RGBG";
+    default: break;
     }
+    return "";
 }
+}  // namespace
 
 bool
 RawInput::open(const std::string& name, ImageSpec& newspec)
@@ -460,19 +463,19 @@ RawInput::open_raw(bool unpack, const std::string& name,
     // other modes from working. Instead, we can put the camera white
     // balance values into the user mults if desired
     m_processor->imgdata.params.use_camera_wb = 0;
-    if (config.get_int_attribute("raw:use_camera_wb", 1) == 1){
-        auto& color = m_processor->imgdata.color;
+    if (config.get_int_attribute("raw:use_camera_wb", 1) == 1) {
+        auto& color  = m_processor->imgdata.color;
         auto& params = m_processor->imgdata.params;
-        auto& idata = m_processor->imgdata.idata;
+        auto& idata  = m_processor->imgdata.idata;
 
-        auto is_rgbg_or_bgrg = [&](unsigned int filters){
+        auto is_rgbg_or_bgrg = [&](unsigned int filters) {
             std::string filter(libraw_filter_to_str(filters));
             return filter == "RGBG" || filter == "BGRG";
         };
-        float norm[4] = {color.cam_mul[0], color.cam_mul[1],
-                         color.cam_mul[2], color.cam_mul[3]};
+        float norm[4] = { color.cam_mul[0], color.cam_mul[1], color.cam_mul[2],
+                          color.cam_mul[3] };
 
-        if (is_rgbg_or_bgrg(idata.filters)){
+        if (is_rgbg_or_bgrg(idata.filters)) {
             // normalize white balance around green
             norm[0] /= norm[1];
             norm[1] /= norm[1];
@@ -639,8 +642,9 @@ RawInput::open_raw(bool unpack, const std::string& name,
             m_spec.channelnames.emplace_back("Y");
 
             // Put the details about the filter pattern into the metadata
-            std::string filter(libraw_filter_to_str(m_processor->imgdata.idata.filters));
-            if (filter.empty()){
+            std::string filter(
+                libraw_filter_to_str(m_processor->imgdata.idata.filters));
+            if (filter.empty()) {
                 filter = "unknown";
             }
             m_spec.attribute("raw:FilterPattern", filter);
@@ -683,13 +687,15 @@ RawInput::open_raw(bool unpack, const std::string& name,
     // The default value of (1.0f / 0.45f) was solved in this way from a Canon 7D
     if (config.find_attribute("raw:camera_to_scene_linear_scale") ||
         // Add a simple on/off to apply the default scaling
-        config.find_attribute("raw:apply_scene_linear_scale")     ){
-        m_camera_to_scene_linear_scale =
-            config.get_float_attribute("raw:camera_to_scene_linear_scale", (1.0f / 0.45f));
+        config.find_attribute("raw:apply_scene_linear_scale")) {
+        m_camera_to_scene_linear_scale
+            = config.get_float_attribute("raw:camera_to_scene_linear_scale",
+                                         (1.0f / 0.45f));
         m_do_scene_linear_scale = true;
         // Store scene linear values in HALF datatype rather than UINT16
         m_spec.set_format(TypeDesc::HALF);
-        m_spec.attribute("raw:camera_to_scene_linear_scale", m_camera_to_scene_linear_scale);
+        m_spec.attribute("raw:camera_to_scene_linear_scale",
+                         m_camera_to_scene_linear_scale);
     }
 
     // Highlight adjustment
@@ -711,19 +717,22 @@ RawInput::open_raw(bool unpack, const std::string& name,
     // The balance_clamped option checks to see what the highest accepted value should be
     // and then hard clamps all channels to this value.
     // Enabling "balance_clamped" will change the return buffer type to HALF
-    int balance_clamped = config.get_int_attribute("raw:balance_clamped", 0); // default OFF
-    if (highlight_mode != 0/*Clip*/){
+    int balance_clamped = config.get_int_attribute("raw:balance_clamped",
+                                                   0);  // default OFF
+    if (highlight_mode != 0 /*Clip*/) {
         // FIXME: promote this debug message to a runtme warning
-        OIIO::debugf("%s", "raw:balance_clamped will have no effect as raw:HighlightMode is not 0\n");
+        OIIO::debugf(
+            "%s",
+            "raw:balance_clamped will have no effect as raw:HighlightMode is not 0\n");
     }
-    if (m_process && balance_clamped != 0 && highlight_mode == 0 /*Clip*/){
+    if (m_process && balance_clamped != 0 && highlight_mode == 0 /*Clip*/) {
         m_spec.set_format(TypeDesc::HALF);
         m_spec.attribute("raw:balance_clamped", balance_clamped);
 
         // The following code can only run once the libraw processor is unpacked.
         // As these values only have effect on the debayered images, it is ok
         // to leave them unset the first time.
-        if (m_unpacked){
+        if (m_unpacked) {
             float old_max_thr = m_processor->imgdata.params.adjust_maximum_thr;
 
             // Disable max threshold for highlight adjustment
@@ -731,12 +740,12 @@ RawInput::open_raw(bool unpack, const std::string& name,
 
             // Get unadjusted max value (need to force a read first)
             ret = m_processor->raw2image_ex(/*subtract_black=*/true);
-            if (ret != LIBRAW_SUCCESS){
+            if (ret != LIBRAW_SUCCESS) {
                 errorf("HighlightMode adjustment detection read failed");
                 errorf(libraw_strerror(ret));
                 return false;
             }
-            if (m_processor->adjust_maximum() != LIBRAW_SUCCESS){
+            if (m_processor->adjust_maximum() != LIBRAW_SUCCESS) {
                 errorf("HighlightMode minimum adjustment failed");
                 errorf(libraw_strerror(ret));
                 return false;
@@ -744,11 +753,11 @@ RawInput::open_raw(bool unpack, const std::string& name,
             float unadjusted = m_processor->imgdata.color.maximum;
 
             // Set the max threshold to either the default 1.0, or user requested max
-            m_processor->imgdata.params.adjust_maximum_thr =
-                (old_max_thr == 0.0f) ? 1.0 : old_max_thr;
+            m_processor->imgdata.params.adjust_maximum_thr
+                = (old_max_thr == 0.0f) ? 1.0 : old_max_thr;
 
             // Get new max value
-            if (m_processor->adjust_maximum() != LIBRAW_SUCCESS){
+            if (m_processor->adjust_maximum() != LIBRAW_SUCCESS) {
                 errorf("HighlightMode maximum adjustment failed");
                 errorf(libraw_strerror(ret));
                 return false;
@@ -758,11 +767,11 @@ RawInput::open_raw(bool unpack, const std::string& name,
             // Restore old max threshold
             m_processor->imgdata.params.adjust_maximum_thr = old_max_thr;
 
-            if (unadjusted <= 0.0f){
+            if (unadjusted <= 0.0f) {
                 // invalid data
             } else {
                 m_do_balance_clamped = true;
-                m_balanced_max = adjusted / unadjusted;
+                m_balanced_max       = adjusted / unadjusted;
             }
         }
     }
@@ -1427,34 +1436,43 @@ RawInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
 
         // The raw_image buffer might contain junk pixels that are usually trimmed off
         // we must index into the raw buffer, taking these into account
-        auto& sizes = m_processor->imgdata.sizes;
-        int offset = sizes.raw_width * sizes.top_margin;
+        auto& sizes        = m_processor->imgdata.sizes;
+        int offset         = sizes.raw_width * sizes.top_margin;
         int scanline_start = sizes.raw_width * y + sizes.left_margin;
 
         // The raw_image will not have been rotated, so we must factor that into our
         // array access
         // For none or 180 degree rotation, the scanlines are still contiguous in memory
-        if (sizes.flip == 0 /*no rotation*/ || sizes.flip == 3 /*180 degrees*/){
-            if (sizes.flip == 3){
-                scanline_start = sizes.raw_width * (m_spec.height - y) + sizes.left_margin;
+        if (sizes.flip == 0 /*no rotation*/ || sizes.flip == 3 /*180 degrees*/) {
+            if (sizes.flip == 3) {
+                scanline_start = sizes.raw_width * (m_spec.height - y)
+                                 + sizes.left_margin;
             }
-            unsigned short* scanline = &(
-                (m_processor->imgdata.rawdata.raw_image + offset)[scanline_start]);
-            convert_pixel_values(TypeDesc::UINT16, scanline, m_spec.format, data, m_spec.width);
+            unsigned short* scanline = &((m_processor->imgdata.rawdata.raw_image
+                                          + offset)[scanline_start]);
+            convert_pixel_values(TypeDesc::UINT16, scanline, m_spec.format,
+                                 data, m_spec.width);
         }
         // For 90 degrees ClockWise or CounterClockWise, our desired scanlines now run perpendicular
         // to the array direction so we must copy the pixels into a temporary contiguous buffer
-        else if (sizes.flip == 5 /*90 degrees CCW*/ || sizes.flip == 6 /*90 degrees CW*/) {
+        else if (sizes.flip == 5 /*90 degrees CCW*/
+                 || sizes.flip == 6 /*90 degrees CW*/) {
             scanline_start = m_spec.height - y + sizes.left_margin;
-            if (sizes.flip == 6){
+            if (sizes.flip == 6) {
                 scanline_start = y + sizes.left_margin;
             }
             auto buffer = std::make_unique<uint16_t[]>(m_spec.width);
-            for (size_t i=0; i<static_cast<size_t>(m_spec.width); ++i){
-                size_t index = (sizes.flip == 5) ? i : m_spec.width - i; //flip the index if rotating 90 degrees CW
-                buffer[index] = (m_processor->imgdata.rawdata.raw_image + offset)[sizes.raw_width * i + scanline_start];
+            for (size_t i = 0; i < static_cast<size_t>(m_spec.width); ++i) {
+                size_t index
+                    = (sizes.flip == 5)
+                          ? i
+                          : m_spec.width
+                                - i;  //flip the index if rotating 90 degrees CW
+                buffer[index] = (m_processor->imgdata.rawdata.raw_image
+                                 + offset)[sizes.raw_width * i + scanline_start];
             }
-            convert_pixel_values(TypeDesc::UINT16, buffer.get(), m_spec.format, data, m_spec.width);
+            convert_pixel_values(TypeDesc::UINT16, buffer.get(), m_spec.format,
+                                 data, m_spec.width);
         }
         return true;
     }
@@ -1473,11 +1491,12 @@ RawInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
     unsigned short* scanline = &(((unsigned short*)m_image->data)[length * y]);
 
     // Copy or convert pixels from libraw to oiio
-    convert_pixel_values(TypeDesc::UINT16, scanline, m_spec.format, data, length);
+    convert_pixel_values(TypeDesc::UINT16, scanline, m_spec.format, data,
+                         length);
 
     // Check if we need to balance any clamped values (implies HALF output)
-    if (m_do_balance_clamped){
-        half* dst = static_cast<half*>(data);
+    if (m_do_balance_clamped) {
+        half* dst         = static_cast<half*>(data);
         auto balance_func = [&](half& f) -> half {
             return std::min((float)f, m_balanced_max);
         };
@@ -1485,19 +1504,19 @@ RawInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
     }
 
     // Perform any scene linear scaling (implies HALF output)
-    if (m_do_scene_linear_scale){
+    if (m_do_scene_linear_scale) {
         float scale_value = m_camera_to_scene_linear_scale;
 
         // In any mode other than Clip highlights, LibRAW refuses
         // to multiply the image values to the correct level.
         // Perform that conversion here as the user requested
         // scene linear values directly.
-        if (m_processor->imgdata.params.highlight != 0/*Clip*/){
+        if (m_processor->imgdata.params.highlight != 0 /*Clip*/) {
             //TODO: Find this number
             scale_value *= 2.5f;
         }
 
-        half* dst = static_cast<half*>(data);
+        half* dst       = static_cast<half*>(data);
         auto scale_func = [&](half& f) -> half {
             return (float)f * scale_value;
         };

--- a/testsuite/raw/ref/out-libraw-0.20.2-gh.txt
+++ b/testsuite/raw/ref/out-libraw-0.20.2-gh.txt
@@ -78,6 +78,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -164,6 +165,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_FUJI_F700.RAF : 2035 x 1533, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2007-01-06 14:20:22"
@@ -232,6 +234,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -318,6 +321,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_OLYMPUS_E3.ORF : 3720 x 2800, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-12-19 12:29:40"
@@ -385,6 +389,7 @@
     Olympus:MinFocal: 50
     Olympus:SensorCalibration: 0, 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_PENTAX_K200D.PEF : 2616 x 3896, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-08-02 16:46:42"
@@ -445,6 +450,7 @@
     Pentax:MinFocusDistance: 16
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_SONY_A300.ARW : 3880 x 2608, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-08-10 23:16:11"
@@ -487,6 +493,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
     Sony:AFMicroAdjOn: 0
     Sony:AFMicroAdjValue: 0
     Sony:AFPoint: -1

--- a/testsuite/raw/ref/out-libraw-0.20.2.txt
+++ b/testsuite/raw/ref/out-libraw-0.20.2.txt
@@ -78,6 +78,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -164,6 +165,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_FUJI_F700.RAF : 2035 x 1533, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2007-01-06 14:20:22"
@@ -232,6 +234,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -318,6 +321,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_OLYMPUS_E3.ORF : 3720 x 2800, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-12-19 12:29:40"
@@ -385,6 +389,7 @@
     Olympus:MinFocal: 50
     Olympus:SensorCalibration: 0, 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_PANASONIC_G1.RW2 : 4016 x 3016, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-12-10 15:06:33"
@@ -418,6 +423,7 @@
     Panasonic:LensID: 18446744073709551615
     Panasonic:LensMount: 41
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_PENTAX_K200D.PEF : 2616 x 3896, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-08-02 16:46:42"
@@ -478,6 +484,7 @@
     Pentax:MinFocusDistance: 16
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_SONY_A300.ARW : 3880 x 2608, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-08-10 23:16:11"
@@ -520,6 +527,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
     Sony:AFMicroAdjOn: 0
     Sony:AFMicroAdjValue: 0
     Sony:AFPoint: -1

--- a/testsuite/raw/ref/out-libraw0.18.11.txt
+++ b/testsuite/raw/ref/out-libraw0.18.11.txt
@@ -151,6 +151,7 @@
     Exif:WhiteBalance: 0 (auto)
     oiio:ColorSpace: "linear"
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -219,6 +220,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
     raw:Orientation: 8
 ../../../../../oiio-images/raw/RAW_FUJI_F700.RAF : 2035 x 1533, 3 channel, uint16 raw
     channel list: R, G, B
@@ -291,6 +293,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -359,6 +362,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
     raw:Orientation: 8
 ../../../../../oiio-images/raw/RAW_OLYMPUS_E3.ORF : 3720 x 2800, 3 channel, uint16 raw
     channel list: R, G, B
@@ -513,6 +517,7 @@
     Pentax:MinAp4MinFocal: 32
     Pentax:MinFocusDistance: 16
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
     raw:Orientation: 8
 ../../../../../oiio-images/raw/RAW_SONY_A300.ARW : 3880 x 2608, 3 channel, uint16 raw
     channel list: R, G, B
@@ -559,6 +564,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
     Sony:AFPoint: -1
     Sony:CameraFormat: 1
     Sony:CameraMount: 1

--- a/testsuite/raw/ref/out-libraw0.18.8-gh.txt
+++ b/testsuite/raw/ref/out-libraw0.18.8-gh.txt
@@ -151,6 +151,7 @@
     Exif:WhiteBalance: 0 (auto)
     oiio:ColorSpace: "linear"
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -220,6 +221,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
     raw:Orientation: 8
 ../../../../../oiio-images/raw/RAW_FUJI_F700.RAF : 2035 x 1533, 3 channel, uint16 raw
     channel list: R, G, B
@@ -292,6 +294,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -361,6 +364,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
     raw:Orientation: 8
 ../../../../../oiio-images/raw/RAW_OLYMPUS_E3.ORF : 3720 x 2800, 3 channel, uint16 raw
     channel list: R, G, B
@@ -430,6 +434,7 @@
     Olympus:OlympusFrame: 0, 0, 0, 0
     Olympus:OlympusSensorCalibration: 0, 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_PENTAX_K200D.PEF : 2616 x 3896, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-08-02 16:46:42"
@@ -487,6 +492,7 @@
     Pentax:MinFocusDistance: 16
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
     raw:Orientation: 8
 ../../../../../oiio-images/raw/RAW_SONY_A300.ARW : 3880 x 2608, 3 channel, uint16 raw
     channel list: R, G, B
@@ -533,6 +539,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
     Sony:AFPoint: -1
     Sony:CameraFormat: 1
     Sony:CameraMount: 1

--- a/testsuite/raw/ref/out-libraw0.18.8-gh2.txt
+++ b/testsuite/raw/ref/out-libraw0.18.8-gh2.txt
@@ -151,6 +151,7 @@
     Exif:WhiteBalance: 0 (auto)
     oiio:ColorSpace: "linear"
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -220,6 +221,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
     raw:Orientation: 8
 ../../../../../oiio-images/raw/RAW_FUJI_F700.RAF : 2035 x 1533, 3 channel, uint16 raw
     channel list: R, G, B
@@ -292,6 +294,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -361,6 +364,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
     raw:Orientation: 8
 ../../../../../oiio-images/raw/RAW_OLYMPUS_E3.ORF : 3720 x 2800, 3 channel, uint16 raw
     channel list: R, G, B
@@ -430,6 +434,7 @@
     Olympus:OlympusFrame: 0, 0, 0, 0
     Olympus:OlympusSensorCalibration: 0, 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_PENTAX_K200D.PEF : 2616 x 3896, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-08-02 16:46:42"
@@ -487,6 +492,7 @@
     Pentax:MinFocusDistance: 16
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
     raw:Orientation: 8
 ../../../../../oiio-images/raw/RAW_SONY_A300.ARW : 3880 x 2608, 3 channel, uint16 raw
     channel list: R, G, B
@@ -533,6 +539,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
     Sony:AFPoint: -1
     Sony:CameraFormat: 1
     Sony:CameraMount: 1

--- a/testsuite/raw/ref/out-libraw0.19.5-gh.txt
+++ b/testsuite/raw/ref/out-libraw0.19.5-gh.txt
@@ -77,6 +77,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -163,6 +164,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_FUJI_F700.RAF : 2035 x 1533, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2007-01-06 14:20:22"
@@ -229,6 +231,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -315,6 +318,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_OLYMPUS_E3.ORF : 3720 x 2800, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-12-19 12:29:40"
@@ -381,6 +385,7 @@
     Olympus:OlympusFrame: 0, 0, 0, 0
     Olympus:OlympusSensorCalibration: 0, 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_PENTAX_K200D.PEF : 2616 x 3896, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-08-02 16:46:42"
@@ -441,6 +446,7 @@
     Pentax:MinFocusDistance: 16
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_SONY_A300.ARW : 3880 x 2608, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-08-10 23:16:11"
@@ -483,6 +489,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
     Sony:AFMicroAdjOn: 0
     Sony:AFMicroAdjValue: 0
     Sony:AFPoint: -1

--- a/testsuite/raw/ref/out-libraw0.20.0-gh.txt
+++ b/testsuite/raw/ref/out-libraw0.20.0-gh.txt
@@ -78,6 +78,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -164,6 +165,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_FUJI_F700.RAF : 2035 x 1533, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2007-01-06 14:20:22"
@@ -232,6 +234,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -318,6 +321,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_OLYMPUS_E3.ORF : 3720 x 2800, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-12-19 12:29:40"
@@ -385,6 +389,7 @@
     Olympus:MinFocal: 50
     Olympus:SensorCalibration: 0, 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_PENTAX_K200D.PEF : 2616 x 3896, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-08-02 16:46:42"
@@ -445,6 +450,7 @@
     Pentax:MinFocusDistance: 16
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_SONY_A300.ARW : 3880 x 2608, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-08-10 23:16:11"
@@ -487,6 +493,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
     Sony:AFMicroAdjOn: 0
     Sony:AFMicroAdjValue: 0
     Sony:AFPoint: -1

--- a/testsuite/raw/ref/out-libraw0.20.0.txt
+++ b/testsuite/raw/ref/out-libraw0.20.0.txt
@@ -78,6 +78,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -164,6 +165,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_FUJI_F700.RAF : 2035 x 1533, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2007-01-06 14:20:22"
@@ -232,6 +234,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -318,6 +321,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_OLYMPUS_E3.ORF : 3720 x 2800, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-12-19 12:29:40"
@@ -385,6 +389,7 @@
     Olympus:MinFocal: 50
     Olympus:SensorCalibration: 0, 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_PANASONIC_G1.RW2 : 4016 x 3016, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-12-10 15:06:33"
@@ -418,6 +423,7 @@
     Panasonic:LensID: 18446744073709551615
     Panasonic:LensMount: 41
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_PENTAX_K200D.PEF : 2616 x 3896, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-08-02 16:46:42"
@@ -478,6 +484,7 @@
     Pentax:MinFocusDistance: 16
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_SONY_A300.ARW : 3880 x 2608, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-08-10 23:16:11"
@@ -520,6 +527,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
     Sony:AFMicroAdjOn: 0
     Sony:AFMicroAdjValue: 0
     Sony:AFPoint: -1

--- a/testsuite/raw/ref/out-libraw0.21.0-gh.txt
+++ b/testsuite/raw/ref/out-libraw0.21.0-gh.txt
@@ -75,6 +75,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -158,6 +159,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_FUJI_F700.RAF : 2035 x 1533, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2007-01-06 14:20:22"
@@ -224,6 +226,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -307,6 +310,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_OLYMPUS_E3.ORF : 3720 x 2800, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-12-19 12:29:40"
@@ -375,6 +379,7 @@
     Olympus:MinFocal: 50
     Olympus:SensorCalibration: 0, 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_PENTAX_K200D.PEF : 2616 x 3896, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-08-02 16:46:42"
@@ -435,6 +440,7 @@
     Pentax:MinFocusDistance: 16
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_SONY_A300.ARW : 3880 x 2608, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-08-10 23:16:11"
@@ -477,6 +483,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
     Sony:AFMicroAdjOn: -1
     Sony:AFMicroAdjRegisteredLenses: 255
     Sony:AFMicroAdjValue: 127

--- a/testsuite/raw/ref/out-libraw0.21.0-mac.txt
+++ b/testsuite/raw/ref/out-libraw0.21.0-mac.txt
@@ -75,6 +75,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -158,6 +159,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_FUJI_F700.RAF : 2035 x 1533, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2007-01-06 14:20:22"
@@ -224,6 +226,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -307,6 +310,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_OLYMPUS_E3.ORF : 3720 x 2800, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-12-19 12:29:40"
@@ -375,6 +379,7 @@
     Olympus:MinFocal: 50
     Olympus:SensorCalibration: 0, 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_PANASONIC_G1.RW2 : 4016 x 3016, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-12-10 15:06:33"
@@ -408,6 +413,7 @@
     Panasonic:LensID: 18446744073709551615
     Panasonic:LensMount: 44
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_PENTAX_K200D.PEF : 2616 x 3896, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-08-02 16:46:42"
@@ -468,6 +474,7 @@
     Pentax:MinFocusDistance: 16
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_SONY_A300.ARW : 3880 x 2608, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-08-10 23:16:11"
@@ -510,6 +517,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
     Sony:AFMicroAdjOn: -1
     Sony:AFMicroAdjRegisteredLenses: 255
     Sony:AFMicroAdjValue: 127

--- a/testsuite/raw/ref/out.txt
+++ b/testsuite/raw/ref/out.txt
@@ -77,6 +77,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -163,6 +164,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_FUJI_F700.RAF : 2035 x 1533, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2007-01-06 14:20:22"
@@ -229,6 +231,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_NIKON_D3X.NEF : 4044 x 6080, 3 channel, uint16 raw
     channel list: R, G, B
     Artist: "                                    "
@@ -315,6 +318,7 @@
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_OLYMPUS_E3.ORF : 3720 x 2800, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-12-19 12:29:40"
@@ -381,6 +385,7 @@
     Olympus:OlympusFrame: 0, 0, 0, 0
     Olympus:OlympusSensorCalibration: 0, 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_PANASONIC_G1.RW2 : 4016 x 3016, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-12-10 15:06:33"
@@ -411,6 +416,7 @@
     Panasonic:ImageStabilization: -1
     Panasonic:LensID: 18446744073709551615
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_PENTAX_K200D.PEF : 2616 x 3896, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-08-02 16:46:42"
@@ -471,6 +477,7 @@
     Pentax:MinFocusDistance: 16
     raw:Demosaic: "AHD"
     raw:flip: 5
+    raw:HighlightMode: 0
 ../../../../../oiio-images/raw/RAW_SONY_A300.ARW : 3880 x 2608, 3 channel, uint16 raw
     channel list: R, G, B
     DateTime: "2008-08-10 23:16:11"
@@ -513,6 +520,7 @@
     oiio:ColorSpace: "linear"
     oiio:MakerNoteOffset: 0
     raw:Demosaic: "AHD"
+    raw:HighlightMode: 0
     Sony:AFMicroAdjOn: 0
     Sony:AFMicroAdjValue: 0
     Sony:AFPoint: -1


### PR DESCRIPTION
## Description

This PR introduces a number of fixes/updates for the RAW plugin.

1. It fixes the output when raw:Demosaic is set to "none". Previously pixel output was indexed incorrectly into the raw buffer and did not take into account rotation or possible "junk" pixels.
2. Implements raw:balance_clamped mode that will apply a per-channel clamp on all pixel values that are over the saturation level of the sensor. This eliminates issues where clipped highlights take on an unwanted hue shift. This is especially useful when stacking HDRI exposures.
3. Implements raw:apply_scene_linear_scale and raw:camera_to_scene_linear_scale, which allows users to scale libraw output to expected levels. The default scale factors are currently hard coded, but experimentally these settings have proven "good enough" over many years of use.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

