### PR TITLE
Filesystem::filename_to_regex

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -329,6 +329,16 @@ OIIO_UTIL_API bool scan_for_matching_filenames (const std::string &pattern,
                                            std::vector<int> &numbers,
                                            std::vector<std::string> &filenames);
 
+/// Convert a filename into a regex-safe pattern -- any special regex
+/// characters `.`, `(`, `)`, `[`, `]`, `{`, `}` are backslashed. If
+/// `simple_glob` is also true, then replace `?` with `.?` and `*` with
+/// `.*`. This doesn't support full Unix command line glob syntax (no char
+/// sets `[abc]` or string sets `{ab,cd,ef}`), but it does handle simple
+/// globbing of `?` to mean any single character and `*` to mean any
+/// sequence of 0 or more characters.
+OIIO_UTIL_API std::string filename_to_regex(string_view pattern,
+                                            bool simple_glob = true);
+
 
 
 /// Proxy class for I/O. This provides a simplified interface for file I/O

--- a/src/libutil/filesystem_test.cpp
+++ b/src/libutil/filesystem_test.cpp
@@ -47,11 +47,21 @@ test_filename_decomposition()
     OIIO_CHECK_EQUAL(Filesystem::replace_extension(test, "foo"),
                      "/directoryA/directory/filename.foo");
 
-    std::cout << "Testing generic_string\n";
+    std::cout << "Testing generic_filepath\n";
 #if _WIN32
     OIIO_CHECK_EQUAL(Filesystem::generic_filepath("\\x\\y"), "/x/y");
     OIIO_CHECK_EQUAL(Filesystem::generic_filepath("c:\\x\\y"), "c:/x/y");
 #endif
+
+    std::cout << "Testing filename_to_regex\n";
+    OIIO_CHECK_EQUAL(Filesystem::filename_to_regex("/foo/bar/baz.exr"),
+                     "/foo/bar/baz\\.exr");
+    OIIO_CHECK_EQUAL(Filesystem::filename_to_regex("/f(o)o/b[a]r/b{a}z.exr"),
+                     "/f\\(o\\)o/b\\[a\\]r/b\\{a\\}z\\.exr");
+    OIIO_CHECK_EQUAL(Filesystem::filename_to_regex("/foo/bar/baz.*"),
+                     "/foo/bar/baz\\..*");
+    OIIO_CHECK_EQUAL(Filesystem::filename_to_regex("/fo?/b*r/b?z.*"),
+                     "/fo.?/b.*r/b.?z\\..*");
 }
 
 
@@ -436,6 +446,10 @@ test_scan_sequences()
         filenames.push_back(fn);
         create_test_file(fn);
     }
+    // Deliberate file that's not a match! Make sure dots in the filename
+    // aren't regex dots that match any character.
+    filenames.push_back("fooX0000Xexr");
+    create_test_file("fooX0000Xexr");
 
     test_scan_file_seq(
         "foo.#.exr",


### PR DESCRIPTION
Sometimes we use a filename, or pieces of it, as a regex.
But filenames can have characters that are interpreted differently when
part of a regex pattern (like `.`, which in a filename is literal, but
in a regex means to match any character!).

So this handy utility inserts the right backslashes so the filename will
end up as a literal match when part of a regex.
Furthermore, there's an optional parameter `simple_glob`, which when
true, will also substitute `?` with `.?` and `*` with `.*`.

We then use this to fix a latent bug in scan_for_matching_filenames():
it could have incorrectly matched files during the search.
