### PR TITLE
Udim improvements

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1170,7 +1170,7 @@ ImageCacheImpl::find_file_no_add(ustring filename,
     // expensive lock on the shared file cache.
     ImageCacheFile* tf = thread_info->find_file(filename);
 
-    // Check the man file cache. For this part, we need to lock the file cache.
+    // Check the main file cache. For this part, we need to lock the file cache.
     if (!tf) {  // was not found in microcache
 #if IMAGECACHE_TIME_STATS
         Timer timer;

--- a/testsuite/texture-udim/ref/out-batched.txt
+++ b/testsuite/texture-udim/ref/out-batched.txt
@@ -1,0 +1,18 @@
+Created texture system
+Result of get_texture_info resolution = 1 256x256
+Result of get_texture_info channels = 1 3
+Result of get_texture_info channels = 1 3
+Result of get_texture_info data format = 1 uint8
+Result of get_texture_info datetime = 0 
+Result of get_texture_info averagecolor = no
+Result of get_texture_info averagealpha = no
+Result of get_texture_info constantcolor = no
+Texture type is 1 Plain Texture
+
+Testing BATCHED 2d texture file.<UDIM>.tx, output = out.tif
+Created texture system
+Image "file.<UDIM>.tx" attrib "Make" = "pet"
+Created texture system
+Image "file.<UDIM>.tx" attrib "Model" -> not found
+Comparing "out.tif" and "ref/out-freetype2.7.tif"
+PASS

--- a/testsuite/texture-udim/ref/out.txt
+++ b/testsuite/texture-udim/ref/out.txt
@@ -1,0 +1,18 @@
+Created texture system
+Result of get_texture_info resolution = 1 256x256
+Result of get_texture_info channels = 1 3
+Result of get_texture_info channels = 1 3
+Result of get_texture_info data format = 1 uint8
+Result of get_texture_info datetime = 0 
+Result of get_texture_info averagecolor = no
+Result of get_texture_info averagealpha = no
+Result of get_texture_info constantcolor = no
+Texture type is 1 Plain Texture
+
+Testing 2d texture file.<UDIM>.tx, output = out.tif
+Created texture system
+Image "file.<UDIM>.tx" attrib "Make" = "pet"
+Created texture system
+Image "file.<UDIM>.tx" attrib "Model" -> not found
+Comparing "out.tif" and "ref/out-freetype2.7.tif"
+PASS

--- a/testsuite/texture-udim/run.py
+++ b/testsuite/texture-udim/run.py
@@ -1,13 +1,20 @@
 #!/usr/bin/env python
 
-
-command += oiiotool ("-pattern constant:color=.5,.1,.1 256x256 3 -text:size=50:x=75:y=140 1001 -d uint8 -otex file.1001.tx")
-command += oiiotool ("-pattern constant:color=.1,.5,.1 256x256 3 -text:size=50:x=75:y=140 1002 -d uint8 -otex file.1002.tx")
-command += oiiotool ("-pattern constant:color=.1,.1,.5 256x256 3 -text:size=50:x=75:y=140 1011 -d uint8 -otex file.1011.tx")
-command += oiiotool ("-pattern constant:color=.1,.5,.5 256x256 3 -text:size=50:x=75:y=140 1012 -d uint8 -otex file.1012.tx")
+command += oiiotool ("-pattern constant:color=.5,.1,.1 256x256 3 -text:size=50:x=75:y=140 1001 --attrib Make pet --attrib Model dog -d uint8 -otex file.1001.tx")
+command += oiiotool ("-pattern constant:color=.1,.5,.1 256x256 3 -text:size=50:x=75:y=140 1002 --attrib Make pet --attrib Model dog -d uint8 -otex file.1002.tx")
+# force DateTime to differ in these files
+command += "sleep 1 ; "
+command += oiiotool ("-pattern constant:color=.1,.1,.5 256x256 3 -text:size=50:x=75:y=140 1011 --attrib Make pet --attrib Model cat -d uint8 -otex file.1011.tx")
+command += oiiotool ("-pattern constant:color=.1,.5,.5 256x256 3 -text:size=50:x=75:y=140 1012 --attrib Make pet --attrib Model dog -d uint8 -otex file.1012.tx")
+command += oiiotool ("-pattern constant:color=.1,.5,.5 256x256 3 -text:size=50:x=75:y=140 1012 --attrib Make pet --attrib Model dog -d uint8 -otex file.1032.tx")
 
 command += testtex_command ("\"file.<UDIM>.tx\"",
-                            "-nowarp -scalest 2 2 --iters 100 -res 128 128 -d uint8 -o out.tif")
+                            "-nowarp -scalest 2 2 -res 128 128 -d uint8 -o out.tif")
 #command += diff_command ("out.tif", "ref/out.tif", "--fail 0.0005 --warn 0.0005")
 
-outputs = [ "out.tif" ]
+# Test get_texture_info on one thing that should be identical across all
+# the tiles, and one thing that should not be.
+command += testtex_command ("\"file.<UDIM>.tx\" --gettextureinfo Make --iters 0")
+command += testtex_command ("\"file.<UDIM>.tx\" --gettextureinfo Model --iters 0")
+
+outputs = [ "out.tif", "out.txt" ]


### PR DESCRIPTION
The primary issue being addressed here was that get_texture_info() on a
udim pattern filename (like `"foo_<UDIM>.exr"`) was unable to retrieve
info, except for an extremely narrow range of queries, because of course,
different UDIM "tiles" might have different attributes or be missing.

So in consultation with Lee Kerley, we decided that get_texture_info should
work as follows:

* If the attribute exists and has the same value for all of the
  matching UDIM file files, then succeed and return the value.

* If any of the tile files does not contain the attribute, or if the
  attribute doesn't have the same value in all found files, then it's
  a failure and the value cannot be retrieved.

This necessitated a more rebust accounting of all the tile files
comprising a UDIM pattern, by doing a full inventory the first time
the UDIM pattern is encountered, rather than (ick) iterating through
all possible tile files every time we retrieve an attribute, as we
were apparently doing before. And so the following improvements were
also made:

* get_texture_info now works for more queries -- in fact, any query
  that would be possible to ask about on an individual file, without
  restriction.  (Though, as I said, the query will fail if the value
  isn't identical across all the found tile files.)

* The info queries (even the few that were previously supported) will
  be MUCH FASTER than before, because we are doing the tile file
  inventory once per udim pattern, rather than on every query.

* That inventory will also pre-build the association between u,v tiles
  and the concrete filename (and texture handle!), so that each
  individual texture call does a simple map lookup to get all the way
  to the texture handle, without any string manipulation to first
  construct a concrete filename, then look that new filename up in the
  cache to get a handle, etc. I'm expecting this to reduce some of the
  overhead of using UDIM files with the TextureSystem.

Note: I added an ImageCacheImpl::find_file_no_add at some point in
this work, eventually not needing it by the time I got to the final
version of my implementation of this PR, but I'm going to keep it
because I can forsee its usefulness and I don't want to delete it only
to write it again some day.
