### PR TITLE
Updates to handling OpenColorIO library naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   vfxplatform-2019:
-    name: "Linux VFX Platform 2019: gcc6/C++14 py2.7 boost-1.66 exr-2.3"
+    name: "Linux VFX Platform 2019: gcc6/C++14 py2.7 boost1.66 exr2.3 ocio1.1"
     runs-on: ubuntu-latest
     container:
       image: aswf/ci-osl:2019
@@ -30,7 +30,6 @@ jobs:
       CC: gcc
       CMAKE_CXX_STANDARD: 14
       USE_SIMD: sse4.2
-      OPENCOLORIO_VERSION: v1.1.1
       PUGIXML_VERSION: v1.9
     steps:
       - uses: actions/checkout@v2
@@ -67,7 +66,7 @@ jobs:
             build/*/CMake*.{txt,log}
 
   vfxplatform-2020:
-    name: "Linux VFX Platform 2020: gcc6/C++14 py3.7 boost-1.70 exr-2.4"
+    name: "Linux VFX Platform 2020: gcc6/C++14 py3.7 boost1.70 exr2.4 ocio1.1"
     runs-on: ubuntu-latest
     container:
       image: aswf/ci-osl:2020
@@ -77,7 +76,6 @@ jobs:
       CMAKE_CXX_STANDARD: 14
       PYTHON_VERSION: 3.7
       USE_SIMD: avx
-      OPENCOLORIO_VERSION: v1.1.1
       WEBP_VERSION: v1.1.0
       MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=7.0.1
     steps:
@@ -115,9 +113,8 @@ jobs:
             build/*/CMake*.{txt,log}
 
   vfxplatform-2021:
-    # Test what's anticipated to be VFX Platform 2021 -- mainly, that means
-    # gcc9 and C++17.
-    name: "Linux VFX Platform 2021: gcc9/C++17 py3.7 boost-1.73 exr-2.5 qt-5.15"
+    # Test VFX Platform 2021 -- mainly, that means gcc9 and C++17.
+    name: "Linux VFX Platform 2021: gcc9/C++17 py3.7 boost1.73 exr2.5 ocio2.0 qt5.15"
     runs-on: ubuntu-latest
     container:
       image: aswf/ci-osl:2021
@@ -127,7 +124,6 @@ jobs:
       CMAKE_CXX_STANDARD: 17
       PYTHON_VERSION: 3.7
       USE_SIMD: avx2,f16c
-      OPENCOLORIO_VERSION: v2.0.0
       WEBP_VERSION: v1.1.0
     steps:
       - uses: actions/checkout@v2
@@ -164,9 +160,8 @@ jobs:
             build/*/CMake*.{txt,log}
 
   vfxplatform-2021-exr3:
-    # Test what's anticipated to be VFX Platform 2021 -- mainly, that means
-    # gcc9 and C++17, and also OpenEXR/Imath 3.0.
-    name: "Linux VFX Platform 2021: gcc9/C++17 py3.7 boost-1.73 exr-3.0 qt-5.15"
+    # Test VFX Platform 2021, but with OpenEXR/Imath 3.x
+    name: "Linux VFX Platform 2021: gcc9/C++17 py3.7 boost1.73 exr3.1 ocio2.0 qt5.15"
     runs-on: ubuntu-latest
     container:
       image: aswf/ci-osl:2021
@@ -176,8 +171,7 @@ jobs:
       CMAKE_CXX_STANDARD: 17
       PYTHON_VERSION: 3.7
       USE_SIMD: avx2,f16c
-      OPENCOLORIO_VERSION: v2.0.0
-      OPENEXR_VERSION: v3.0.3
+      OPENEXR_VERSION: v3.1.1
     steps:
       - uses: actions/checkout@v2
       - name: Prepare ccache timestamp
@@ -304,7 +298,7 @@ jobs:
 
   linux-latest-releases:
     # Test against latest supported releases of toolchain and dependencies.
-    name: "Linux latest releases: gcc10 C++17 avx2 exr3.0 ocio2.0"
+    name: "Linux latest releases: gcc10 C++17 avx2 exr3.1 ocio2.0"
     runs-on: ubuntu-20.04
     env:
       CXX: g++-10
@@ -313,7 +307,7 @@ jobs:
       LIBRAW_VERSION: 0.20.2
       LIBTIFF_VERSION: v4.3.0
       OPENCOLORIO_VERSION: v2.0.1
-      OPENEXR_VERSION: v3.1.0
+      OPENEXR_VERSION: v3.1.1
       PUGIXML_VERSION: v1.11.4
       PTEX_VERSION: v2.4.0
       PYBIND11_VERSION: v2.7.0
@@ -633,7 +627,7 @@ jobs:
 
   linux-clang10-cpp14:
     # Test compiling with clang on Linux.
-    name: "Linux clang10: clang10 C++14 avx2 exr2.5"
+    name: "Linux clang10: clang10 C++14 avx2 exr2.5 ocio2.0"
     runs-on: ubuntu-18.04
     container:
       image: aswf/ci-osl:2021-clang10
@@ -643,8 +637,6 @@ jobs:
       PYTHON_VERSION: 3.7
       USE_SIMD: avx2,f16c
       PYBIND11_VERSION: v2.6.1
-      OPENCOLORIO_VERSION: 1c624651b7
-      # Pick an OCIO commit that includes a warning fix we need for clang
     steps:
       - uses: actions/checkout@v2
       - name: Prepare ccache timestamp
@@ -681,7 +673,7 @@ jobs:
 
   linux-clang11-cpp17:
     # Test compiling with clang  and C++17 on Linux.
-    name: "Linux clang11: clang11 C++17 avx2 exr3.0"
+    name: "Linux clang11: clang11 C++17 avx2 exr3.1 ocio2.0"
     runs-on: ubuntu-18.04
     container:
       image: aswf/ci-osl:2021-clang11
@@ -691,8 +683,7 @@ jobs:
       PYTHON_VERSION: 3.7
       USE_SIMD: avx2,f16c
       PYBIND11_VERSION: v2.6.1
-      OPENCOLORIO_VERSION: v2.0.1
-      OPENEXR_VERSION: v3.0.4
+      OPENEXR_VERSION: v3.1.1
       # Pick an OCIO commit that includes a warning fix we need for clang
     steps:
       - uses: actions/checkout@v2

--- a/src/build-scripts/build_opencolorio.bash
+++ b/src/build-scripts/build_opencolorio.bash
@@ -7,7 +7,7 @@ set -ex
 
 # Which OCIO to retrieve, how to build it
 OPENCOLORIO_REPO=${OPENCOLORIO_REPO:=https://github.com/AcademySoftwareFoundation/OpenColorIO.git}
-OPENCOLORIO_VERSION=${OPENCOLORIO_VERSION:=v2.0.0}
+OPENCOLORIO_VERSION=${OPENCOLORIO_VERSION:=v2.0.1}
 
 # Where to install the final results
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -161,7 +161,9 @@ checked_find_package (Freetype
 checked_find_package (HDF5
                    ISDEPOF      Field3D)
 checked_find_package (OpenColorIO
-                   DEFINITIONS  -DUSE_OCIO=1 -DUSE_OPENCOLORIO=1)
+                      DEFINITIONS  -DUSE_OCIO=1 -DUSE_OPENCOLORIO=1
+                      # PREFER_CONFIG
+                      )
 checked_find_package (OpenCV 3.0
                    DEFINITIONS  -DUSE_OPENCV=1)
 

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -143,7 +143,8 @@ target_link_libraries (OpenImageIO
             ${OpenCV_LIBRARIES}
             ${SANITIZE_LIBRARIES}
             ${format_plugin_libs} # Add all the target link libraries from the plugins
-            $<$<BOOL:${OpenColorIO_FOUND}>:OpenColorIO::OpenColorIO>
+            $<$<TARGET_EXISTS:OpenColorIO::OpenColorIO>:OpenColorIO::OpenColorIO>
+            $<$<TARGET_EXISTS:OpenColorIO::OpenColorIOHeaders>:OpenColorIO::OpenColorIOHeaders>
             $<$<BOOL:${pugixml_FOUND}>:pugixml::pugixml>
             ${BZIP2_LIBRARIES}
             ZLIB::ZLIB


### PR DESCRIPTION
For the upcoming OCIO 2.1, the library names will incorporate the
major/minor version numbers, so our Find module needs to take that into
consideration.

Work towards eventually using OCIO exported configs (though still not
100% working now, may need fixes on their end).

Change CI to use the OCIO's that come in the aswf containers instead
of building from scratch in many cases.

Fixes #3048 