### PR TITLE
WebpInput: Fixed mismatched new[] and delete

### DIFF
--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -36,7 +36,7 @@ public:
 private:
     std::string m_filename;
     std::unique_ptr<uint8_t[]> m_encoded_image;
-    std::unique_ptr<uint8_t> m_decoded_image;
+    std::unique_ptr<uint8_t[]> m_decoded_image;
     uint64_t m_image_size    = 0;
     long int m_scanline_size = 0;
     uint32_t m_demux_flags   = 0;


### PR DESCRIPTION
## Description
This request changes the type of `WebpInput::m_decoded_image` from `std::unique_ptr<uint8_t>` to `std::unique_ptr<uint8_t[]>` which ensures `operator delete[]` is called as the variable is initialized with a `operator new uint8_t[]` expression in `WebpInput::open()`.. This mismatched new/delete pair was causing errors when compiling programs with ASAN enabled.

## Tests

When ASAN was enabled the webp portion of imageinout_test was triggering the sanitizer. After this change the test completes successfully.



## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

