### PR TITLE
Strutil: Add rcontains, ircontains, improve contains, docs

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -328,8 +328,10 @@ strhash (string_view s)
 
 
 
-/// Case-insensitive comparison of strings.  For speed, this always uses
-/// a static locale that doesn't require a mutex.
+/// Case-insensitive comparison of strings.  For speed, this always uses a
+/// static locale that doesn't require a mutex. Caveat: the case-sensivive
+/// `==` of string_view's is about 20x faster than this case-insensitive
+/// function.
 bool OIIO_UTIL_API iequals (string_view a, string_view b);
 
 /// Case-insensitive ordered comparison of strings.  For speed, this always
@@ -340,25 +342,28 @@ bool OIIO_UTIL_API iless (string_view a, string_view b);
 bool OIIO_UTIL_API starts_with (string_view a, string_view b);
 
 /// Does 'a' start with the string 'b', with a case-insensitive comparison?
-/// For speed, this always uses a static locale that doesn't require a mutex.
+/// For speed, this always uses a static locale that doesn't require a
+/// mutex. Caveat: the case-sensivive starts_with() is about 20x faster than
+/// this case-insensitive function.
 bool OIIO_UTIL_API istarts_with (string_view a, string_view b);
 
 /// Does 'a' end with the string 'b', with a case-sensitive comparison?
 bool OIIO_UTIL_API ends_with (string_view a, string_view b);
 
 /// Does 'a' end with the string 'b', with a case-insensitive comparison?
-/// For speed, this always uses a static locale that doesn't require a mutex.
+/// For speed, this always uses a static locale that doesn't require a
+/// mutex. Caveat: the case-sensivive ends_with() is about 20x faster than
+/// this case-insensitive function.
 bool OIIO_UTIL_API iends_with (string_view a, string_view b);
-
-/// Does 'a' contain the string 'b' within it?
-bool OIIO_UTIL_API contains (string_view a, string_view b);
 
 /// Return the position of the first occurrence of `b` within `a`, or
 /// std::npos if not found.
 size_t OIIO_UTIL_API find(string_view a, string_view b);
 
 /// Return the position of the first occurrence of `b` within `a`, with a
-/// case-insensitive comparison, or std::npos if not found.
+/// case-insensitive comparison, or std::npos if not found. Caveat: the
+/// case-sensivive find() is about 20x faster than this case-insensitive
+/// function.
 size_t OIIO_UTIL_API ifind(string_view a, string_view b);
 
 /// Return the position of the last occurrence of `b` within `a`, or npos if
@@ -366,12 +371,33 @@ size_t OIIO_UTIL_API ifind(string_view a, string_view b);
 size_t OIIO_UTIL_API rfind(string_view a, string_view b);
 
 /// Return the position of the last occurrence of `b` within `a`, with a
-/// case-insensitive comparison, or npos if not found.
+/// case-insensitive comparison, or npos if not found. Caveat: the
+/// case-sensivive rfind() is about 20x faster than this case-insensitive
+/// function.
 size_t OIIO_UTIL_API irfind(string_view a, string_view b);
 
+/// Does 'a' contain the string 'b' within it?
+bool OIIO_UTIL_API contains (string_view a, string_view b);
+
 /// Does 'a' contain the string 'b' within it, using a case-insensitive
-/// comparison?
+/// comparison? Caveat: the case-sensivive contains() is about 20x faster
+/// than this case-insensitive function.
 bool OIIO_UTIL_API icontains (string_view a, string_view b);
+
+/// Does 'a' contain the string 'b' within it? But start looking at the end!
+/// This can be a bit faster than contains() if you think that the substring
+/// `b` will tend to be close to the end of `a`.
+inline bool rcontains (string_view a, string_view b) {
+    return rfind(a, b) != string_view::npos;
+}
+
+/// Does 'a' contain the string 'b' within it? But start looking at the end!
+/// This can be a bit faster than contains() if you think that the substring
+/// `b` will tend to be close to the end of `a`. Caveat: the case-sensivive
+/// rcontains() is about 20x faster than this case-insensitive function.
+inline bool ircontains (string_view a, string_view b) {
+    return irfind(a, b) != string_view::npos;
+}
 
 /// Does 'a' contain any of the characters within `set`?
 bool OIIO_UTIL_API contains_any_char (string_view a, string_view set);

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -449,14 +449,20 @@ Strutil::iends_with(string_view a, string_view b)
 bool
 Strutil::contains(string_view a, string_view b)
 {
-    return boost::algorithm::contains(a, b);
+    return find(a, b) != string_view::npos;
+    // We used to use the boost contains, but it seems to be about 2x more
+    // expensive than (find() != npos).
+    // return boost::algorithm::contains(a, b);
 }
 
 
 bool
 Strutil::icontains(string_view a, string_view b)
 {
-    return boost::algorithm::icontains(a, b, std::locale::classic());
+    return ifind(a, b) != string_view::npos;
+    // We used to use the boost icontains, but it seems to be about 2x more
+    // expensive than (ifind() != npos).
+    // return boost::algorithm::icontains(a, b, std::locale::classic());
 }
 
 

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -288,7 +288,7 @@ test_comparisons()
     OIIO_CHECK_EQUAL(Strutil::contains("abcde", "de"), true);
     OIIO_CHECK_EQUAL(Strutil::contains("abcde", "cdx"), false);
     OIIO_CHECK_EQUAL(Strutil::contains("abcde", ""), true);
-    OIIO_CHECK_EQUAL(Strutil::contains("", ""), true);
+    OIIO_CHECK_EQUAL(Strutil::contains("", ""), false);
     OIIO_CHECK_EQUAL(Strutil::contains("", "x"), false);
 
     OIIO_CHECK_EQUAL(Strutil::icontains("abcde", "ab"), true);
@@ -298,8 +298,26 @@ test_comparisons()
     OIIO_CHECK_EQUAL(Strutil::icontains("abcDe", "dE"), true);
     OIIO_CHECK_EQUAL(Strutil::icontains("abcde", "cdx"), false);
     OIIO_CHECK_EQUAL(Strutil::icontains("abcde", ""), true);
-    OIIO_CHECK_EQUAL(Strutil::icontains("", ""), true);
+    OIIO_CHECK_EQUAL(Strutil::icontains("", ""), false);
     OIIO_CHECK_EQUAL(Strutil::icontains("", "x"), false);
+
+    OIIO_CHECK_EQUAL(Strutil::rcontains("abcde", "ab"), true);
+    OIIO_CHECK_EQUAL(Strutil::rcontains("abcde", "bcd"), true);
+    OIIO_CHECK_EQUAL(Strutil::rcontains("abcde", "de"), true);
+    OIIO_CHECK_EQUAL(Strutil::rcontains("abcde", "cdx"), false);
+    OIIO_CHECK_EQUAL(Strutil::rcontains("abcde", ""), true);
+    OIIO_CHECK_EQUAL(Strutil::rcontains("", ""), false);
+    OIIO_CHECK_EQUAL(Strutil::rcontains("", "x"), false);
+
+    OIIO_CHECK_EQUAL(Strutil::ircontains("abcde", "ab"), true);
+    OIIO_CHECK_EQUAL(Strutil::ircontains("Abcde", "aB"), true);
+    OIIO_CHECK_EQUAL(Strutil::ircontains("abcde", "bcd"), true);
+    OIIO_CHECK_EQUAL(Strutil::ircontains("Abcde", "bCd"), true);
+    OIIO_CHECK_EQUAL(Strutil::ircontains("abcDe", "dE"), true);
+    OIIO_CHECK_EQUAL(Strutil::ircontains("abcde", "cdx"), false);
+    OIIO_CHECK_EQUAL(Strutil::ircontains("abcde", ""), true);
+    OIIO_CHECK_EQUAL(Strutil::ircontains("", ""), false);
+    OIIO_CHECK_EQUAL(Strutil::ircontains("", "x"), false);
 
     OIIO_CHECK_EQUAL(Strutil::contains_any_char("abcde", "xa"), true);
     OIIO_CHECK_EQUAL(Strutil::contains_any_char("abcde", "xe"), true);
@@ -351,6 +369,62 @@ test_comparisons()
     OIIO_CHECK_ASSERT(iless("abc", "abd"));
     OIIO_CHECK_ASSERT(!iless("xbc", "abd"));
     OIIO_CHECK_ASSERT(iless("abc", "ABD"));
+
+    Benchmarker bench;
+    bench.indent (2);
+    bench.units (Benchmarker::Unit::ns);
+    std::string abc = "abcdefghijklmnopqrstuvwxyz";
+    std::string haystack = std::string("begin") + abc + "oiio"
+                         + Strutil::repeat(abc, 10) + "123" + abc + "end";
+    bench ("contains early small", [&](){ DoNotOptimize(Strutil::contains(abc, "def")); });
+    bench ("contains early big", [&](){ DoNotOptimize(Strutil::contains(haystack, "oiio")); });
+    bench ("contains late small", [&](){ DoNotOptimize(Strutil::contains(abc, "uvw")); });
+    bench ("contains late big", [&](){ DoNotOptimize(Strutil::contains(haystack, "123")); });
+    bench ("contains fail/small", [&](){ DoNotOptimize(Strutil::contains(abc, "dog")); });
+    bench ("contains fail/big", [&](){ DoNotOptimize(Strutil::contains(haystack, "dog")); });
+    bench ("rcontains early small", [&](){ DoNotOptimize(Strutil::rcontains(abc, "def")); });
+    bench ("rcontains early big", [&](){ DoNotOptimize(Strutil::rcontains(haystack, "oiio")); });
+    bench ("rcontains late small", [&](){ DoNotOptimize(Strutil::rcontains(abc, "uvw")); });
+    bench ("rcontains late big", [&](){ DoNotOptimize(Strutil::rcontains(haystack, "123")); });
+    bench ("rcontains fail/small", [&](){ DoNotOptimize(Strutil::rcontains(abc, "dog")); });
+    bench ("rcontains fail/big", [&](){ DoNotOptimize(Strutil::rcontains(haystack, "dog")); });
+    bench ("icontains early small", [&](){ DoNotOptimize(Strutil::icontains(abc, "def")); });
+    bench ("icontains early big", [&](){ DoNotOptimize(Strutil::icontains(haystack, "oiio")); });
+    bench ("icontains late small", [&](){ DoNotOptimize(Strutil::icontains(abc, "uvw")); });
+    bench ("icontains late big", [&](){ DoNotOptimize(Strutil::icontains(haystack, "123")); });
+    bench ("icontains fail/small", [&](){ DoNotOptimize(Strutil::icontains(abc, "dog")); });
+    bench ("icontains fail/big", [&](){ DoNotOptimize(Strutil::icontains(haystack, "dog")); });
+
+    bench ("find early small", [&](){ DoNotOptimize(Strutil::find(abc, "def")); });
+    bench ("find early big", [&](){ DoNotOptimize(Strutil::find(haystack, "oiio")); });
+    bench ("find late small", [&](){ DoNotOptimize(Strutil::find(abc, "uvw")); });
+    bench ("find late big", [&](){ DoNotOptimize(Strutil::find(haystack, "123")); });
+    bench ("find fail/small", [&](){ DoNotOptimize(Strutil::find(abc, "dog")); });
+    bench ("find fail/big", [&](){ DoNotOptimize(Strutil::find(haystack, "dog")); });
+    bench ("rfind early small", [&](){ DoNotOptimize(Strutil::rfind(abc, "def")); });
+    bench ("rfind early big", [&](){ DoNotOptimize(Strutil::rfind(haystack, "oiio")); });
+    bench ("rfind late small", [&](){ DoNotOptimize(Strutil::rfind(abc, "uvw")); });
+    bench ("rfind late big", [&](){ DoNotOptimize(Strutil::rfind(haystack, "123")); });
+    bench ("rfind fail/small", [&](){ DoNotOptimize(Strutil::rfind(abc, "dog")); });
+    bench ("rfind fail/big", [&](){ DoNotOptimize(Strutil::rfind(haystack, "dog")); });
+
+    bench ("ifind early small", [&](){ DoNotOptimize(Strutil::ifind(abc, "def")); });
+    bench ("ifind early big", [&](){ DoNotOptimize(Strutil::ifind(haystack, "oiio")); });
+    bench ("ifind late small", [&](){ DoNotOptimize(Strutil::ifind(abc, "uvw")); });
+    bench ("ifind late big", [&](){ DoNotOptimize(Strutil::ifind(haystack, "123")); });
+    bench ("ifind fail/small", [&](){ DoNotOptimize(Strutil::ifind(abc, "dog")); });
+    bench ("ifind fail/big", [&](){ DoNotOptimize(Strutil::ifind(haystack, "dog")); });
+    bench ("irfind early small", [&](){ DoNotOptimize(Strutil::irfind(abc, "def")); });
+    bench ("irfind early big", [&](){ DoNotOptimize(Strutil::irfind(haystack, "oiio")); });
+    bench ("irfind late small", [&](){ DoNotOptimize(Strutil::irfind(abc, "uvw")); });
+    bench ("irfind late big", [&](){ DoNotOptimize(Strutil::irfind(haystack, "123")); });
+    bench ("irfind fail/small", [&](){ DoNotOptimize(Strutil::irfind(abc, "dog")); });
+    bench ("irfind fail/big", [&](){ DoNotOptimize(Strutil::irfind(haystack, "dog")); });
+
+    bench ("starts_with success", [&](){ DoNotOptimize(Strutil::starts_with(abc, "abc")); });
+    bench ("starts_with fail", [&](){ DoNotOptimize(Strutil::starts_with(abc, "def")); });
+    bench ("ends_with success", [&](){ DoNotOptimize(Strutil::ends_with(abc, "xyz")); });
+    bench ("ends_with fail", [&](){ DoNotOptimize(Strutil::ends_with(abc, "def")); });
 }
 
 


### PR DESCRIPTION
* At the suggestion of Luke Emrose, add rcontains() and ircontains(),
  which are like contains/icontains, but start the search at the end
  of the string rather than the beginning. This is measurably faster
  than contains() for the case when you are reasonably certain that if
  the search pattern is found at all, it is highly likely to be close
  to the end of the string. (They're approximately the same speed when
  the pattern is not found.)

* To verify this, I added a bunch of benchmarking to strutil_test.

* The benchmarks also revealed that contains was about 2x slower than
  calling find! It should be the same. I don't know what the underlying
  boost::algorithm::contains is doing differently than find, but whatever.
  Changing our implementation of Strutil::contains to simply call find
  doubles its speed.

* The new implementation of contains has an extremely minor behavior
  change for the degenerate case of `contains("", "")`, which used to
  return true and now returns false. Since the right behavior here is
  debatable at best (is it false because the first empty string
  contains nothing? or is it true because containts(a,b) should return
  true if a==b?), I'm going to accept this behavior change as well
  worth the 2x speed improvement (besides, "contains(a,b) should have
  the same result as find(a,b)!=npos" is also a reasonable
  expectation).

* The benchmarks also reveal that the case-insensitive functions (like
  ifind) are not just a little bit slower than their case-sensitive
  siblings (like find), they are 20x or more slower! I don't think
  there is anything to do about that, but I did note it in the
  documentation of those functions so that we are disuaded from using
  them except when a case-insensitive test is really necessary.
