### PR TITLE
New oiiotool commands: --printinfo, --printstats

### DIFF
--- a/testsuite/maketx/run.py
+++ b/testsuite/maketx/run.py
@@ -111,7 +111,7 @@ command += oiiotool (" --pattern constant:color=1,1,1 4x2 3 "
             + " -d half -o " + oiio_relpath("white.exr"))
 command += maketx_command ("white.exr", "whiteenv.exr",
                            "--envlatl")
-command += oiiotool ("--stats whiteenv.exr")
+command += oiiotool ("--stats -a whiteenv.exr")
 
 #Test --bumpslopes to export a 6 channels height map with gradients
 command += oiiotool (" --pattern noise 64x64 1"

--- a/testsuite/oiiotool-maketx/run.py
+++ b/testsuite/oiiotool-maketx/run.py
@@ -138,14 +138,14 @@ command += oiiotool (" --pattern constant:color=1,1,1 4x2 3 "
             + " -d half -o " + oiio_relpath("white.exr"))
 command += omaketx_command ("white.exr", "whiteenv.exr",
                             output_cmd="-oenv", showinfo=False)
-command += oiiotool ("--stats whiteenv.exr")
+command += oiiotool ("--stats -a whiteenv.exr")
 
 command += oiiotool (" --pattern noise 64x64 1"
             + " -d half -o " + oiio_relpath("bump.exr"))
 command += omaketx_command ("bump.exr", "bumpslope.exr",
                             extraargs="-d half",
                             output_cmd="-obump", showinfo=False)
-command += oiiotool ("--stats bumpslope.exr")
+command += oiiotool ("--stats -a bumpslope.exr")
 
 
 outputs = [ "out.txt" ]

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -118,6 +118,28 @@ Stats FiniteCount: 12288 12288 12288
 Constant: No
 Monochrome: No
 
+--printstats:
+ 128 x   96, 3 channel, float tiff
+    Stats Min: 0 0 0 (of 255)
+    Stats Max: 190 255 255 (of 255)
+    Stats Avg: 26.00 55.26 108.45 (of 255)
+    Stats StdDev: 32.31 59.12 95.51 (of 255)
+    Stats NanCount: 0 0 0 
+    Stats InfCount: 0 0 0 
+    Stats FiniteCount: 12288 12288 12288 
+    Constant: No
+    Monochrome: No
+ 128 x   96, 3 channel, float tiff
+    Stats Min: 1 3 9 (of 255)
+    Stats Max: 14 28 67 (of 255)
+    Stats Avg: 6.05 8.30 18.13 (of 255)
+    Stats StdDev: 3.07 4.69 10.19 (of 255)
+    Stats NanCount: 0 0 0 
+    Stats InfCount: 0 0 0 
+    Stats FiniteCount: 100 100 100 
+    Constant: No
+    Monochrome: No
+ 
 Reading black.tif
     oiio:DebugOpenConfig!: 42
 Reading add_rgb_rgba.exr

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -232,6 +232,10 @@ command += oiiotool ("src/tahoe-tiny.tif --echo \"\\nBrief: {TOP.METABRIEF}\"")
 command += oiiotool ("src/tahoe-tiny.tif --echo \"\\nMeta: {TOP.META}\"")
 command += oiiotool ("src/tahoe-tiny.tif --echo \"\\nStats:\\n{TOP.STATS}\\n\"")
 
+# Test --statsnow
+command += oiiotool ("src/tahoe-tiny.tif --echo \"--printstats:\" --printstats")
+command += oiiotool ("src/tahoe-tiny.tif --printstats:window=10x10+50+50 --echo \" \"")
+
 # test --iconfig
 command += oiiotool ("--info -v -metamatch Debug --iconfig oiio:DebugOpenConfig! 1 black.tif")
 


### PR DESCRIPTION
The existing --info and --stats seem a little confusing and
inflexible.  Unlike the majority of oiiotool arguments which are
evaluated in order, these merely set flags which apply to the entire
oiiotool command (specifically, they cause all image inputs to print
the metadata or image statistics at the time that the input are read
from disk).  There isn't a way to make it apply to a single image, nor
to print the metadata or stats of any *computed* image, leading some
people to awkwardly save a computed image and re-read it merely to
print information about it.

So in this patch, we add new commands

* `--printinfo` which is like `-info -v` but is done immediately for
  the "current" image on the top of the stack (even if it's a computed
  image and does not correspond to any disk file).

* `--printstats` which is like `--stats` but is done immediately for
  the current image on top of the stack.

  Furthermore, `--printstats` takes an optional modifier `:window=`
  which can be given a rectangular region in either of the notations
  we use ("WxH+X+Y" or "xmin,xmax,ymin,ymax"), for example:

      oiiotool blah.exr --printstats:window=30x30+1000+500

  prints the statistics of the 30x30 region whose upper left corner
  is pixel (1000,500).

The code to implement this is actually pretty short and straightforward,
but this patch turns out to touch a lot more. I needed to plumb
some of the info-printing internals for this support and did some
refactoring along the way.

Also, upon adding these to the docs, I realized that it would be
better to reorganize a bit to separate descriptions of the "flags"
from the "actions", and so many of the oiiotool arguments got shuffled
between different subsections, and in a few cases the descriptions
themselves got rewritten for clarity.
