### PR TITLE
add flags to control stages of dependency build

### DIFF
--- a/src/build-scripts/build_OpenJPEG.bash
+++ b/src/build-scripts/build_OpenJPEG.bash
@@ -33,10 +33,8 @@ if [[ ! -e ${OPENJPEG_SRC_DIR} ]] ; then
 fi
 cd ${OPENJPEG_SRC_DIR}
 
-if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
-    echo "git checkout ${OPENJPEG_VERSION} --force"
-    git checkout ${OPENJPEG_VERSION} --force
-fi
+echo "git checkout ${OPENJPEG_VERSION} --force"
+git checkout ${OPENJPEG_VERSION} --force
 
 mkdir -p ${OPENJPEG_BUILD_DIR} && true
 cd ${OPENJPEG_BUILD_DIR}

--- a/src/build-scripts/build_OpenJPEG.bash
+++ b/src/build-scripts/build_OpenJPEG.bash
@@ -32,16 +32,22 @@ if [[ ! -e ${OPENJPEG_SRC_DIR} ]] ; then
     git clone ${OPENJPEG_REPO} ${OPENJPEG_SRC_DIR}
 fi
 cd ${OPENJPEG_SRC_DIR}
-echo "git checkout ${OPENJPEG_VERSION} --force"
-git checkout ${OPENJPEG_VERSION} --force
+
+if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
+    echo "git checkout ${OPENJPEG_VERSION} --force"
+    git checkout ${OPENJPEG_VERSION} --force
+fi
 
 mkdir -p ${OPENJPEG_BUILD_DIR} && true
 cd ${OPENJPEG_BUILD_DIR}
-time cmake -DCMAKE_BUILD_TYPE=Release \
-           -DCMAKE_INSTALL_PREFIX=${OPENJPEG_INSTALL_DIR} \
-           -DBUILD_CODEC=OFF \
-           ${OPENJPEG_CONFIG_OPTS} ..
-time cmake --build . --config Release --target install
+
+if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+    time cmake -DCMAKE_BUILD_TYPE=Release \
+               -DCMAKE_INSTALL_PREFIX=${OPENJPEG_INSTALL_DIR} \
+               -DBUILD_CODEC=OFF \
+               ${OPENJPEG_CONFIG_OPTS} ..
+    time cmake --build . --config Release --target install
+fi
 
 # ls -R ${OPENJPEG_INSTALL_DIR}
 popd

--- a/src/build-scripts/build_gif.bash
+++ b/src/build-scripts/build_gif.bash
@@ -23,16 +23,22 @@ mkdir -p ${LOCAL_DEPS_DIR}
 pushd ${LOCAL_DEPS_DIR}
 
 # Clone giflib project and build
-curl --location https://downloads.sourceforge.net/project/giflib/giflib-${GIFLIB_VERSION}.tar.gz -o giflib.tar.gz
-tar xzf giflib.tar.gz
-pushd giflib-${GIFLIB_VERSION}
-cp Makefile Makefile.old
-curl --location https://sourceforge.net/p/giflib/bugs/_discuss/thread/4e811ad29b/c323/attachment/Makefile.patch -o Makefile.patch
-patch -p0 < Makefile.patch
-popd
+if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
+    curl --location https://downloads.sourceforge.net/project/giflib/giflib-${GIFLIB_VERSION}.tar.gz -o giflib.tar.gz
+    tar xzf giflib.tar.gz
+    pushd giflib-${GIFLIB_VERSION}
+    cp Makefile Makefile.old
+    curl --location https://sourceforge.net/p/giflib/bugs/_discuss/thread/4e811ad29b/c323/attachment/Makefile.patch -o Makefile.patch
+    patch -p0 < Makefile.patch
+    popd
+fi 
+
 
 cd giflib-${GIFLIB_VERSION}
-time make PREFIX=${GIFLIB_INSTALL_DIR} CC=${GIFLIB_CC} install
+
+if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+    time make PREFIX=${GIFLIB_INSTALL_DIR} CC=${GIFLIB_CC} install
+fi
 
 popd
 

--- a/src/build-scripts/build_gif.bash
+++ b/src/build-scripts/build_gif.bash
@@ -22,8 +22,9 @@ echo "giflib install dir will be: ${GIFLIB_INSTALL_DIR}"
 mkdir -p ${LOCAL_DEPS_DIR}
 pushd ${LOCAL_DEPS_DIR}
 
+
 # Clone giflib project and build
-if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
+if [[ ! -e giflib-${GIFLIB_VERSION} ]] ; then
     curl --location https://downloads.sourceforge.net/project/giflib/giflib-${GIFLIB_VERSION}.tar.gz -o giflib.tar.gz
     tar xzf giflib.tar.gz
     pushd giflib-${GIFLIB_VERSION}

--- a/src/build-scripts/build_libjpeg-turbo.bash
+++ b/src/build-scripts/build_libjpeg-turbo.bash
@@ -33,15 +33,20 @@ if [[ ! -e ${LIBJPEGTURBO_SRC_DIR} ]] ; then
     git clone ${LIBJPEGTURBO_REPO} ${LIBJPEGTURBO_SRC_DIR}
 fi
 cd ${LIBJPEGTURBO_SRC_DIR}
-echo "git checkout ${LIBJPEGTURBO_VERSION} --force"
-git checkout ${LIBJPEGTURBO_VERSION} --force
+if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
+    echo "git checkout ${LIBJPEGTURBO_VERSION} --force"
+    git checkout ${LIBJPEGTURBO_VERSION} --force
+fi
 
 mkdir -p ${LIBJPEGTURBO_BUILD_DIR}
 cd ${LIBJPEGTURBO_BUILD_DIR}
-time cmake -DCMAKE_BUILD_TYPE=Release \
-           -DCMAKE_INSTALL_PREFIX=${LIBJPEGTURBO_INSTALL_DIR} \
-           ${LIBJPEGTURBO_CONFIG_OPTS} ..
-time cmake --build . --config Release --target install
+
+if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+    time cmake -DCMAKE_BUILD_TYPE=Release \
+               -DCMAKE_INSTALL_PREFIX=${LIBJPEGTURBO_INSTALL_DIR} \
+               ${LIBJPEGTURBO_CONFIG_OPTS} ..
+    time cmake --build . --config Release --target install
+fi
 
 # ls -R ${LIBJPEGTURBO_INSTALL_DIR}
 popd

--- a/src/build-scripts/build_libjpeg-turbo.bash
+++ b/src/build-scripts/build_libjpeg-turbo.bash
@@ -33,10 +33,8 @@ if [[ ! -e ${LIBJPEGTURBO_SRC_DIR} ]] ; then
     git clone ${LIBJPEGTURBO_REPO} ${LIBJPEGTURBO_SRC_DIR}
 fi
 cd ${LIBJPEGTURBO_SRC_DIR}
-if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
-    echo "git checkout ${LIBJPEGTURBO_VERSION} --force"
-    git checkout ${LIBJPEGTURBO_VERSION} --force
-fi
+echo "git checkout ${LIBJPEGTURBO_VERSION} --force"
+git checkout ${LIBJPEGTURBO_VERSION} --force
 
 mkdir -p ${LIBJPEGTURBO_BUILD_DIR}
 cd ${LIBJPEGTURBO_BUILD_DIR}

--- a/src/build-scripts/build_libpng.bash
+++ b/src/build-scripts/build_libpng.bash
@@ -35,10 +35,8 @@ fi
 cd ${LIBPNG_SRC_DIR}
 
 
-if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
-    echo "git checkout ${LIBPNG_VERSION} --force"
-    git checkout ${LIBPNG_VERSION} --force
-fi
+echo "git checkout ${LIBPNG_VERSION} --force"
+git checkout ${LIBPNG_VERSION} --force
 
 mkdir -p ${LIBPNG_BUILD_DIR}
 cd ${LIBPNG_BUILD_DIR}

--- a/src/build-scripts/build_libpng.bash
+++ b/src/build-scripts/build_libpng.bash
@@ -33,17 +33,24 @@ if [[ ! -e ${LIBPNG_SRC_DIR} ]] ; then
     git clone ${LIBPNG_REPO} ${LIBPNG_SRC_DIR}
 fi
 cd ${LIBPNG_SRC_DIR}
-echo "git checkout ${LIBPNG_VERSION} --force"
-git checkout ${LIBPNG_VERSION} --force
+
+
+if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
+    echo "git checkout ${LIBPNG_VERSION} --force"
+    git checkout ${LIBPNG_VERSION} --force
+fi
 
 mkdir -p ${LIBPNG_BUILD_DIR}
 cd ${LIBPNG_BUILD_DIR}
-time cmake -DCMAKE_BUILD_TYPE=Release \
-           -DCMAKE_INSTALL_PREFIX=${LIBPNG_INSTALL_DIR} \
-           -DPNG_EXECUTABLES=OFF \
-           -DPNG_TESTS=OFF \
-           ${LIBPNG_CONFIG_OPTS} ..
-time cmake --build . --config Release --target install
+
+if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+    time cmake -DCMAKE_BUILD_TYPE=Release \
+               -DCMAKE_INSTALL_PREFIX=${LIBPNG_INSTALL_DIR} \
+               -DPNG_EXECUTABLES=OFF \
+               -DPNG_TESTS=OFF \
+               ${LIBPNG_CONFIG_OPTS} ..
+    time cmake --build . --config Release --target install
+fi
 
 # ls -R ${LIBPNG_INSTALL_DIR}
 popd

--- a/src/build-scripts/build_libraw.bash
+++ b/src/build-scripts/build_libraw.bash
@@ -33,12 +33,17 @@ mkdir -p ${LIBRAW_INSTALL_DIR} && true
 mkdir -p ${LIBRAW_BUILD_DIR} && true
 
 pushd ${LIBRAW_SOURCE_DIR}
-git checkout ${LIBRAW_VERSION} --force
 
-aclocal
-autoreconf --install
-./configure --prefix=${LIBRAW_INSTALL_DIR}
-time make -j ${PARALLEL:=4} && make install
+if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
+    git checkout ${LIBRAW_VERSION} --force
+fi
+
+if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+    aclocal
+    autoreconf --install
+    ./configure --prefix=${LIBRAW_INSTALL_DIR}
+    time make -j ${PARALLEL:=4} && make install
+fi
 
 popd
 

--- a/src/build-scripts/build_libraw.bash
+++ b/src/build-scripts/build_libraw.bash
@@ -34,9 +34,7 @@ mkdir -p ${LIBRAW_BUILD_DIR} && true
 
 pushd ${LIBRAW_SOURCE_DIR}
 
-if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
-    git checkout ${LIBRAW_VERSION} --force
-fi
+git checkout ${LIBRAW_VERSION} --force
 
 if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
     aclocal

--- a/src/build-scripts/build_libtiff.bash
+++ b/src/build-scripts/build_libtiff.bash
@@ -28,15 +28,22 @@ if [[ ! -e libtiff ]] ; then
 fi
 cd libtiff
 
-echo "git checkout ${LIBTIFF_VERSION} --force"
-git checkout ${LIBTIFF_VERSION} --force
+if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
+    echo "git checkout ${LIBTIFF_VERSION} --force"
+    git checkout ${LIBTIFF_VERSION} --force
+fi
+
 mkdir -p build
 cd build
-time cmake -DCMAKE_BUILD_TYPE=Release \
-           -DCMAKE_INSTALL_PREFIX=${LIBTIFF_INSTALL_DIR} \
-           -DCMAKE_CXX_FLAGS="${LIBTIFF_CXX_FLAGS}" \
-           ${LIBTIFF_BUILDOPTS} ..
-time cmake --build . --config Release --target install
+
+if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+    time cmake -DCMAKE_BUILD_TYPE=Release \
+               -DCMAKE_INSTALL_PREFIX=${LIBTIFF_INSTALL_DIR} \
+               -DCMAKE_CXX_FLAGS="${LIBTIFF_CXX_FLAGS}" \
+               ${LIBTIFF_BUILDOPTS} ..
+    time cmake --build . --config Release --target install
+fi
+
 popd
 
 # ls -R ${LIBTIFF_INSTALL_DIR}

--- a/src/build-scripts/build_libtiff.bash
+++ b/src/build-scripts/build_libtiff.bash
@@ -28,10 +28,8 @@ if [[ ! -e libtiff ]] ; then
 fi
 cd libtiff
 
-if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
-    echo "git checkout ${LIBTIFF_VERSION} --force"
-    git checkout ${LIBTIFF_VERSION} --force
-fi
+echo "git checkout ${LIBTIFF_VERSION} --force"
+git checkout ${LIBTIFF_VERSION} --force
 
 mkdir -p build
 cd build

--- a/src/build-scripts/build_pugixml.bash
+++ b/src/build-scripts/build_pugixml.bash
@@ -34,17 +34,23 @@ if [[ ! -e ${PUGIXML_SRC_DIR} ]] ; then
     git clone ${PUGIXML_REPO} ${PUGIXML_SRC_DIR}
 fi
 cd ${PUGIXML_SRC_DIR}
-echo "git checkout ${PUGIXML_VERSION} --force"
-git checkout ${PUGIXML_VERSION} --force
+
+if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
+    echo "git checkout ${PUGIXML_VERSION} --force"
+    git checkout ${PUGIXML_VERSION} --force
+fi
 
 mkdir -p ${PUGIXML_BUILD_DIR}
 cd ${PUGIXML_BUILD_DIR}
-time cmake -DCMAKE_BUILD_TYPE=Release \
-           -DCMAKE_INSTALL_PREFIX=${PUGIXML_INSTALL_DIR} \
-           -DBUILD_SHARED_LIBS=ON \
-           -DBUILD_TESTS=OFF \
-           ${PUGIXML_BUILD_OPTS} ..
-time cmake --build . --config Release --target install
+
+if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+    time cmake -DCMAKE_BUILD_TYPE=Release \
+               -DCMAKE_INSTALL_PREFIX=${PUGIXML_INSTALL_DIR} \
+               -DBUILD_SHARED_LIBS=ON \
+               -DBUILD_TESTS=OFF \
+               ${PUGIXML_BUILD_OPTS} ..
+    time cmake --build . --config Release --target install
+fi
 
 # ls -R ${PUGIXML_INSTALL_DIR}
 popd

--- a/src/build-scripts/build_pugixml.bash
+++ b/src/build-scripts/build_pugixml.bash
@@ -35,10 +35,8 @@ if [[ ! -e ${PUGIXML_SRC_DIR} ]] ; then
 fi
 cd ${PUGIXML_SRC_DIR}
 
-if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
-    echo "git checkout ${PUGIXML_VERSION} --force"
-    git checkout ${PUGIXML_VERSION} --force
-fi
+echo "git checkout ${PUGIXML_VERSION} --force"
+git checkout ${PUGIXML_VERSION} --force
 
 mkdir -p ${PUGIXML_BUILD_DIR}
 cd ${PUGIXML_BUILD_DIR}

--- a/src/build-scripts/build_pybind11.bash
+++ b/src/build-scripts/build_pybind11.bash
@@ -35,10 +35,8 @@ if [[ ! -e ${PYBIND11_SRC_DIR} ]] ; then
 fi
 cd ${PYBIND11_SRC_DIR}
 
-if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
-    echo "git checkout ${PYBIND11_VERSION} --force"
-    git checkout ${PYBIND11_VERSION} --force
-fi
+echo "git checkout ${PYBIND11_VERSION} --force"
+git checkout ${PYBIND11_VERSION} --force
 
 mkdir -p ${PYBIND11_BUILD_DIR}
 cd ${PYBIND11_BUILD_DIR}

--- a/src/build-scripts/build_pybind11.bash
+++ b/src/build-scripts/build_pybind11.bash
@@ -34,16 +34,22 @@ if [[ ! -e ${PYBIND11_SRC_DIR} ]] ; then
     git clone ${PYBIND11_REPO} ${PYBIND11_SRC_DIR}
 fi
 cd ${PYBIND11_SRC_DIR}
-echo "git checkout ${PYBIND11_VERSION} --force"
-git checkout ${PYBIND11_VERSION} --force
+
+if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
+    echo "git checkout ${PYBIND11_VERSION} --force"
+    git checkout ${PYBIND11_VERSION} --force
+fi
 
 mkdir -p ${PYBIND11_BUILD_DIR}
 cd ${PYBIND11_BUILD_DIR}
-time cmake -DCMAKE_BUILD_TYPE=Release \
-           -DCMAKE_INSTALL_PREFIX=${PYBIND11_INSTALL_DIR} \
-           -DPYBIND11_TEST=OFF \
-           ${PYBIND11_BUILD_OPTS} ..
-time cmake --build . --config Release --target install
+
+if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+    time cmake -DCMAKE_BUILD_TYPE=Release \
+               -DCMAKE_INSTALL_PREFIX=${PYBIND11_INSTALL_DIR} \
+               -DPYBIND11_TEST=OFF \
+               ${PYBIND11_BUILD_OPTS} ..
+    time cmake --build . --config Release --target install
+fi
 
 # ls -R ${PYBIND11_INSTALL_DIR}
 popd

--- a/src/build-scripts/build_webp.bash
+++ b/src/build-scripts/build_webp.bash
@@ -33,10 +33,8 @@ if [[ ! -e ${WEBP_SRC_DIR} ]] ; then
 fi
 cd ${WEBP_SRC_DIR}
 
-if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
-    echo "git checkout ${WEBP_VERSION} --force"
-    git checkout ${WEBP_VERSION} --force
-fi
+echo "git checkout ${WEBP_VERSION} --force"
+git checkout ${WEBP_VERSION} --force
 
 mkdir -p ${WEBP_BUILD_DIR}
 cd ${WEBP_BUILD_DIR}

--- a/src/build-scripts/build_webp.bash
+++ b/src/build-scripts/build_webp.bash
@@ -32,24 +32,29 @@ if [[ ! -e ${WEBP_SRC_DIR} ]] ; then
     git clone ${WEBP_REPO} ${WEBP_SRC_DIR}
 fi
 cd ${WEBP_SRC_DIR}
-echo "git checkout ${WEBP_VERSION} --force"
-git checkout ${WEBP_VERSION} --force
+
+if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
+    echo "git checkout ${WEBP_VERSION} --force"
+    git checkout ${WEBP_VERSION} --force
+fi
 
 mkdir -p ${WEBP_BUILD_DIR}
 cd ${WEBP_BUILD_DIR}
-time cmake -DCMAKE_BUILD_TYPE=Release \
-           -DCMAKE_INSTALL_PREFIX=${WEBP_INSTALL_DIR} \
-           -DWEBP_BUILD_ANIM_UTILS=OFF \
-           -DWEBP_BUILD_CWEBP=OFF \
-           -DWEBP_BUILD_DWEBP=OFF \
-           -DWEBP_BUILD_VWEBP=OFF \
-           -DWEBP_BUILD_GIF2WEBPx=OFF \
-           -DWEBP_BUILD_IMG2WEBP=OFF \
-           -DWEBP_BUILD_EXTRAS=OFF \
-           -DBUILD_SHARED_LIBS=ON \
-           ${WEBP_CONFIG_OPTS} ..
-time cmake --build . --config Release --target install
 
+if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+    time cmake -DCMAKE_BUILD_TYPE=Release \
+               -DCMAKE_INSTALL_PREFIX=${WEBP_INSTALL_DIR} \
+               -DWEBP_BUILD_ANIM_UTILS=OFF \
+               -DWEBP_BUILD_CWEBP=OFF \
+               -DWEBP_BUILD_DWEBP=OFF \
+               -DWEBP_BUILD_VWEBP=OFF \
+               -DWEBP_BUILD_GIF2WEBPx=OFF \
+               -DWEBP_BUILD_IMG2WEBP=OFF \
+               -DWEBP_BUILD_EXTRAS=OFF \
+               -DBUILD_SHARED_LIBS=ON \
+               ${WEBP_CONFIG_OPTS} ..
+    time cmake --build . --config Release --target install
+fi
 
 
 # ls -R ${WEBP_INSTALL_DIR}

--- a/src/build-scripts/build_zlib.bash
+++ b/src/build-scripts/build_zlib.bash
@@ -33,15 +33,22 @@ if [[ ! -e ${ZLIB_SRC_DIR} ]] ; then
     git clone ${ZLIB_REPO} ${ZLIB_SRC_DIR}
 fi
 cd ${ZLIB_SRC_DIR}
-echo "git checkout ${ZLIB_VERSION} --force"
-git checkout ${ZLIB_VERSION} --force
+
+if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
+    echo "git checkout ${ZLIB_VERSION} --force"
+    git checkout ${ZLIB_VERSION} --force
+fi
 
 mkdir -p ${ZLIB_BUILD_DIR} && true
 cd ${ZLIB_BUILD_DIR}
-time cmake -DCMAKE_BUILD_TYPE=Release \
-           -DCMAKE_INSTALL_PREFIX=${ZLIB_INSTALL_DIR} \
-           ${ZLIB_CONFIG_OPTS} ..
-time cmake --build . --config Release --target install
+
+
+if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+    time cmake -DCMAKE_BUILD_TYPE=Release \
+               -DCMAKE_INSTALL_PREFIX=${ZLIB_INSTALL_DIR} \
+               ${ZLIB_CONFIG_OPTS} ..
+    time cmake --build . --config Release --target install
+fi
 
 # ls -R ${ZLIB_INSTALL_DIR}
 popd

--- a/src/build-scripts/build_zlib.bash
+++ b/src/build-scripts/build_zlib.bash
@@ -34,10 +34,8 @@ if [[ ! -e ${ZLIB_SRC_DIR} ]] ; then
 fi
 cd ${ZLIB_SRC_DIR}
 
-if [[ -z $OIIO_DEP_BUILD_ONLY ]]; then
-    echo "git checkout ${ZLIB_VERSION} --force"
-    git checkout ${ZLIB_VERSION} --force
-fi
+echo "git checkout ${ZLIB_VERSION} --force"
+git checkout ${ZLIB_VERSION} --force
 
 mkdir -p ${ZLIB_BUILD_DIR} && true
 cd ${ZLIB_BUILD_DIR}


### PR DESCRIPTION
## Description

For building the Rust bindings we need to provide crates.io with a complete source tree that does not depend on external downloads. So during the process of generating the bindings we want to download all the dependencies, then when building the crate we do no further network communication and jsut build the already downloaded dependencies.

To do this I've added support for two environment variables to the relevant build scripts: OIIO_DEP_BUILD_ONLY and OIIO_DEP_DOWNLOAD_ONLY that do what you would expect.

## Tests

N/A

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

