### PR TITLE
Try to decrease spurious CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,7 +513,7 @@ jobs:
       PYTHON_VERSION: 3.7
       CMAKE_GENERATOR: "Visual Studio 16 2019"
       OPENEXR_VERSION: v2.5.6
-      CTEST_ARGS: "--timeout 120 --repeat after-timeout:5"
+      CTEST_ARGS: "--timeout 120 --repeat after-timeout:6"
     steps:
       - uses: actions/checkout@v2
       - name: Setup Nuget.exe
@@ -549,7 +549,7 @@ jobs:
       PYTHON_VERSION: 3.7
       CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
       OPENEXR_VERSION: v2.5.6
-      CTEST_ARGS: "--timeout 120 --repeat after-timeout:5"
+      CTEST_ARGS: "--timeout 120 --repeat after-timeout:6"
     steps:
       - uses: actions/checkout@v2
       - name: Setup Nuget.exe

--- a/src/libutil/timer_test.cpp
+++ b/src/libutil/timer_test.cpp
@@ -66,11 +66,13 @@ main(int argc, char** argv)
     // But you want better power use, so instead we just increase the timing
     // tolereance on Apple to make this test pass.
 #    if defined(OIIO_CI) || defined(OIIO_CODE_COVERAGE)
-    // It seems especially bad on Travis, give extra time slop.
-    // Got even worse in Nov 2017 on Travis. Make the slop enormous.
-    // Got worse again Nov 2018. (What does Travis do every November?)
+    // It seems especially bad on CI runs, so give extra time slop.
     eps = 1.0;
 #    endif
+#elif defined(OIIO_CI)
+    // Also on GitHub Actions CI, timing seems a little imprecise. Give it
+    // some extra room to avoid spurious CI failures on this test.
+    eps = 0.02;
 #endif
 
     // Verify that Timer(false) doesn't start


### PR DESCRIPTION
* On Windows, increase number of tries for tests that timeout.
* On all CI runs, allow timer_test to be less accurate.
