### PR TITLE
cmake: checked_find_package enhancements

### DIFF
--- a/src/cmake/checked_find_package.cmake
+++ b/src/cmake/checked_find_package.cmake
@@ -37,8 +37,11 @@ endfunction ()
 #     turned off explicitly from one of these sources.
 #   * Print a message if the package is enabled but not found. This is based
 #     on ${Pkgname}_FOUND or $PKGNAME_FOUND.
-#   * Optional DEFINITIONS <string> are passed to add_definitions if the
+#   * Optional DEFINITIONS <string>... are passed to add_definitions if the
 #     package is found.
+#   * Optional SETVARIABLES <id>... is a list of CMake variables to set to
+#     TRUE if the package is found (they will not be set or changed if the
+#     package is not found).
 #   * Optional PRINT <list> is a list of variables that will be printed
 #     if the package is found, if VERBOSE is on.
 #   * Optional DEPS <list> is a list of hard dependencies; for each one, if
@@ -74,7 +77,7 @@ macro (checked_find_package pkgname)
         # singleValueKeywords:
         "ENABLE;ISDEPOF;VERSION_MIN;VERSION_MAX;RECOMMEND_MIN;RECOMMEND_MIN_REASON"
         # multiValueKeywords:
-        "DEFINITIONS;PRINT;DEPS"
+        "DEFINITIONS;PRINT;DEPS;SETVARIABLES"
         # argsToParse:
         ${ARGN})
     string (TOLOWER ${pkgname} pkgname_lower)
@@ -143,23 +146,10 @@ macro (checked_find_package pkgname)
                 endif ()
             endforeach ()
             message (STATUS "${ColorGreen}Found ${pkgname} ${${pkgname}_VERSION} ${_config_status}${ColorReset}")
-            if (_pkg_VERBOSE)
-                if (_pkg_DEBUG)
-                    dump_matching_variables (${pkgname})
-                endif ()
-                set (_vars_to_print ${pkgname}_INCLUDES ${pkgname_upper}_INCLUDES
-                                    ${pkgname}_INCLUDE_DIR ${pkgname_upper}_INCLUDE_DIR
-                                    ${pkgname}_INCLUDE_DIRS ${pkgname_upper}_INCLUDE_DIRS
-                                    ${pkgname}_LIBRARIES ${pkgname_upper}_LIBRARIES
-                                    ${_pkg_PRINT})
-                list (REMOVE_DUPLICATES _vars_to_print)
-                foreach (_v IN LISTS _vars_to_print)
-                    if (NOT "${${_v}}" STREQUAL "")
-                        message (STATUS "    ${_v} = ${${_v}}")
-                    endif ()
-                endforeach ()
-            endif ()
             add_definitions (${_pkg_DEFINITIONS})
+            foreach (_v IN LISTS _pkg_SETVARIABLES)
+                set (${_v} TRUE)
+            endforeach ()
             if (_pkg_RECOMMEND_MIN)
                 if (${${pkgname}_VERSION} VERSION_LESS ${_pkg_RECOMMEND_MIN})
                     message (STATUS "${ColorYellow}Recommend ${pkgname} >= ${_pkg_RECOMMEND_MIN} ${_pkg_RECOMMEND_MIN_REASON} ${ColorReset}")
@@ -187,6 +177,22 @@ macro (checked_find_package pkgname)
                 message (FATAL_ERROR "${ColorRed}${pkgname} is required, aborting.${ColorReset}")
             endif ()
         endif()
+        if (_pkg_VERBOSE AND (${pkgname}_FOUND OR ${pkgname_upper}_FOUND OR _pkg_DEBUG))
+            if (_pkg_DEBUG)
+                dump_matching_variables (${pkgname})
+            endif ()
+            set (_vars_to_print ${pkgname}_INCLUDES ${pkgname_upper}_INCLUDES
+                                ${pkgname}_INCLUDE_DIR ${pkgname_upper}_INCLUDE_DIR
+                                ${pkgname}_INCLUDE_DIRS ${pkgname_upper}_INCLUDE_DIRS
+                                ${pkgname}_LIBRARIES ${pkgname_upper}_LIBRARIES
+                                ${_pkg_PRINT})
+            list (REMOVE_DUPLICATES _vars_to_print)
+            foreach (_v IN LISTS _vars_to_print)
+                if (NOT "${${_v}}" STREQUAL "")
+                    message (STATUS "    ${_v} = ${${_v}}")
+                endif ()
+            endforeach ()
+        endif ()
     else ()
         if (NOT _quietskip)
             message (STATUS "${ColorRed}Not using ${pkgname} -- disabled ${_disablereason} ${ColorReset}")


### PR DESCRIPTION
* New SETVARIABLES option sets named cmake variabes to true if the
  package is found.
* DEBUG should print variables even if not found. Duh, failing to find
  the package is the most important debugging situation.
