### PR TITLE
PR: Minor Windows Build Fixes

### DIFF
--- a/src/cmake/modules/FindOpenCV.cmake
+++ b/src/cmake/modules/FindOpenCV.cmake
@@ -36,8 +36,10 @@ if (EXISTS "${_ocv_version_file}")
     string (REGEX MATCHALL "[0-9]+" CV_VERSION_REVISION ${TMP})
     if (CV_VERSION_EPOCH)
         set (OpenCV_VERSION "${CV_VERSION_EPOCH}.${CV_VERSION_MAJOR}.${CV_VERSION_MINOR}")
+        string(REPLACE "." "" OpenCV_VERSION_SUFFIX "${OpenCV_VERSION}")
     else ()
         set (OpenCV_VERSION "${CV_VERSION_MAJOR}.${CV_VERSION_MINOR}.${CV_VERSION_REVISION}")
+        string(REPLACE "." "" OpenCV_VERSION_SUFFIX "${OpenCV_VERSION}")
     endif ()
 endif ()
 
@@ -49,7 +51,7 @@ set (libdirs "${PROJECT_SOURCE_DIR}/lib"
              /usr/local/opt/opencv3/lib
              )
 
-set (opencv_components opencv_core opencv_imgproc opencv_videoio)
+set (opencv_components opencv_core opencv_imgproc opencv_videoio opencv_core${OpenCV_VERSION_SUFFIX} opencv_imgproc${OpenCV_VERSION_SUFFIX} opencv_videoio${OpenCV_VERSION_SUFFIX})
 foreach (component ${opencv_components})
     find_library (${component}_lib
                   NAMES ${component}

--- a/src/cmake/modules/FindTBB.cmake
+++ b/src/cmake/modules/FindTBB.cmake
@@ -74,7 +74,7 @@
 #                           tbbmalloc, tbbmalloc_debug, tbb_preview, or 
 #                           tbb_preview_debug.
 #
-# The following varibles should be used to build and link with TBB:
+# The following variables should be used to build and link with TBB:
 #
 # * TBB_INCLUDE_DIRS - The include directory for TBB.
 # * TBB_LIBRARIES    - The libraries to link against to use TBB.

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -353,7 +353,7 @@ function (oiio_setup_test_data)
     oiio_get_test_data (oiio-images
                         REPO https://github.com/OpenImageIO/oiio-images.git)
     oiio_get_test_data (openexr-images
-                        REPO https://github.com/AcademySoftwareFoudation/openexr-images.git)
+                        REPO https://github.com/AcademySoftwareFoundation/openexr-images.git)
     oiio_get_test_data (fits-images)
     oiio_get_test_data (j2kp4files_v1_5)
 endfunction ()


### PR DESCRIPTION
## Description

This PR implements minor build fixes for Windows:

- *OpenCV* when built on Windows produces libraries with versions, e.g. `opencv_core453.lib`. This addresses #1707.
![image](https://user-images.githubusercontent.com/99779/129993874-8715a4cf-49a1-4365-8aec-9a1542f6d08d.png)
- Pulling [openexr-images](https://github.com/AcademySoftwareFoudation/openexr-images) does not work because of a typo in the URL.

I have experienced quite some troubles building with various dependencies that I ended up deactivating. I will open a separate issue for that.

## Tests

N/A

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

