### PR TITLE
More testsuite cleanup for arbitrary build directory

### DIFF
--- a/testsuite/missingcolor/ref/out.err-openexrcore.txt
+++ b/testsuite/missingcolor/ref/out.err-openexrcore.txt
@@ -1,4 +1,4 @@
 oiiotool ERROR: read : EXR Error (src/partial.exr): EXR_ERR_BAD_CHUNK_LEADER Preparing to read tile (0, 0), level (0, 0) (chunk 0), found corrupt leader: found tile x 20000630, expect 0
 EXR Error (src/partial.exr): EXR_ERR_BAD_CHUNK_LEADER Preparing to read tile (1, 0), level (0, 0) (chunk 1), found corrupt leader: found tile x 20000630, expect 1
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/partial.exr -d uint8 -o error.tif
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio src/partial.exr -d uint8 -o error.tif

--- a/testsuite/missingcolor/ref/out.err.txt
+++ b/testsuite/missingcolor/ref/out.err.txt
@@ -1,3 +1,3 @@
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "src/partial.exr". Tile (0, 0, 0, 0) is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/partial.exr -d uint8 -o error.tif
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio src/partial.exr -d uint8 -o error.tif

--- a/testsuite/oiiotool-readerror/ref/out.err-alt.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err-alt.txt
@@ -1,3 +1,3 @@
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr

--- a/testsuite/oiiotool-readerror/ref/out.err-alt2.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err-alt2.txt
@@ -1,3 +1,3 @@
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr

--- a/testsuite/oiiotool-readerror/ref/out.err-debug.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err-debug.txt
@@ -2,4 +2,4 @@ read was not necessary -- using cache
 going to have to read src/incomplete.exr: float vs float
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Scan line 126 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr

--- a/testsuite/oiiotool-readerror/ref/out.err-openexrcore.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err-openexrcore.txt
@@ -1,3 +1,3 @@
 oiiotool ERROR: read : EXR Error (src/incomplete.exr): EXR_ERR_BAD_CHUNK_LEADER Preparing to read scanline 0 (chunk 0), found corrupt leader: scanline says 20000630, expected 0
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr

--- a/testsuite/oiiotool-readerror/ref/out.err.txt
+++ b/testsuite/oiiotool-readerror/ref/out.err.txt
@@ -1,3 +1,3 @@
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "src/incomplete.exr". Scan line 126 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio src/incomplete.exr -o out.exr

--- a/testsuite/openexr-damaged/ref/out-exr2.2-alt.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.2-alt.txt
@@ -2,133 +2,133 @@ tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr :   64 
 oiiotool ERROR: read : Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
 Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr". The x subsampling factor for the "H" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr : 12688 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr :   64 x   64, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr". Error in Huffman-encoded data (invalid code table size).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr": Subsampled channels are not supported (channel "" has sampling 32,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr". The x subsampling factor for the "" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
 
 oiiotool: IlmThreadMutexPosix.cpp:63: virtual IlmThread_2_2::Mutex::~Mutex(): Assertion `error == 0' failed.
 Aborted (core dumped)
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr :  517 x  517, 3 channel, half openexr (+mipmap)
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr". Data decoding (rle) failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr :    1 x  257, 3 channel, half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr :  636 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr". Invalid tile size in image header.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
 
 oiiotool: IlmThreadMutexPosix.cpp:63: virtual IlmThread_2_2::Mutex::~Mutex(): Assertion `error == 0' failed.
 Aborted (core dumped)
@@ -139,189 +139,189 @@ Aborted (core dumped)
 tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr". The x subsampling factor for the "B" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr :    3 x  257, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr.exr : 30608 x  300, 3 channel, half openexr
 
 tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr". The x subsampling factor for the "B" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr :   64 x   64, 2 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr :  480 x  480, 4 channel, half/half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr": Subsampled channels are not supported (channel "" has sampling 16,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr :  400 x  300, 3 channel, float/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr". Huffman decode error (Overrun).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
 
 tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
 
 oiiotool: IlmThreadMutexPosix.cpp:63: virtual IlmThread_2_2::Mutex::~Mutex(): Assertion `error == 0' failed.
 Aborted (core dumped)
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
 Subsampled channels are not supported (channel "RY" has sampling 2,2).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
 
 tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr :  874 x  493, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr". Unexpected tile x coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
 
 tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr :   64 x   64, 5 channel, half/half/half/float/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr". File input failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr": OpenEXR exception: std::bad_alloc
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
 Subsampled channels are not supported (channel "RY" has sampling 2,2).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr". Data window [ (0, 0) - (8388607, 8388607) ] offset / size will overflow pointer calculations
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr". unsupported header type to get chunk offset table size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr2.2-travis.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.2-travis.txt
@@ -2,133 +2,133 @@ tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr :   64 
 oiiotool ERROR: read : Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
 Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr". The x subsampling factor for the "H" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr : 12688 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr :   64 x   64, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr". Error in Huffman-encoded data (invalid code table size).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr": Subsampled channels are not supported (channel "" has sampling 32,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr". The x subsampling factor for the "" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
 
 oiiotool: IlmThreadMutexPosix.cpp:63: virtual IlmThread_2_2::Mutex::~Mutex(): Assertion `error == 0' failed.
 Aborted (core dumped)
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr :  517 x  517, 3 channel, half openexr (+mipmap)
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr". Data decoding (rle) failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr :    1 x  257, 3 channel, half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr :  636 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr". Invalid tile size in image header.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
 
 oiiotool: IlmThreadMutexPosix.cpp:63: virtual IlmThread_2_2::Mutex::~Mutex(): Assertion `error == 0' failed.
 Aborted (core dumped)
@@ -139,189 +139,189 @@ Aborted (core dumped)
 tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr". The x subsampling factor for the "B" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr :    3 x  257, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr.exr : 30608 x  300, 3 channel, half openexr
 
 tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr". The x subsampling factor for the "B" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr :   64 x   64, 2 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr :  480 x  480, 4 channel, half/half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr": Subsampled channels are not supported (channel "" has sampling 16,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr :  400 x  300, 3 channel, float/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr". Huffman decode error (Overrun).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
 
 tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
 
 oiiotool: IlmThreadMutexPosix.cpp:63: virtual IlmThread_2_2::Mutex::~Mutex(): Assertion `error == 0' failed.
 Aborted (core dumped)
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
 Subsampled channels are not supported (channel "RY" has sampling 2,2).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
 
 tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr :  874 x  493, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr". Unexpected tile x coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
 
 tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr :   64 x   64, 5 channel, half/half/half/float/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr". Scan line 0 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr": OpenEXR exception: std::bad_alloc
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
 Subsampled channels are not supported (channel "RY" has sampling 2,2).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr". Data window [ (0, 0) - (8388607, 8388607) ] offset / size will overflow pointer calculations
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr". unsupported header type to get chunk offset table size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr2.2.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.2.txt
@@ -2,130 +2,130 @@ tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr :   64 
 oiiotool ERROR: read : Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Deep scanline sampleCount data corrupt at chunk 0 (negative sample count detected)
 Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Deep scanline sampleCount data corrupt at chunk 0 (negative sample count detected)
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr": Subsampled channels are not supported (channel "H" has sampling 192,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr : 12688 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr :   64 x   64, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr". Error in Huffman-encoded data (invalid code table size).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr": Subsampled channels are not supported (channel "" has sampling 32,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr": Subsampled channels are not supported (channel "R" has sampling 1,2).
 Subsampled channels are not supported (channel "" has sampling 4,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr : 536910914 x    2, 3 channel, uint/half/half openexr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr :  517 x  517, 3 channel, half openexr (+mipmap)
 
 tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr :    1 x  257, 3 channel, half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr :  636 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr : 536871041 x    1, 3 channel, uint/half/half openexr
 
@@ -134,190 +134,190 @@ tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr :
 tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr": Subsampled channels are not supported (channel "B" has sampling 128,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr :    3 x  257, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr.exr : 30608 x  300, 3 channel, half openexr
 
 tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr": Subsampled channels are not supported (channel "B" has sampling 128,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr :   64 x   64, 2 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr :  480 x  480, 4 channel, half/half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr": Subsampled channels are not supported (channel "" has sampling 16,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr :  400 x  300, 3 channel, float/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr". Huffman decode error (Overrun).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
 
 tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr": OpenEXR exception: std::bad_alloc
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
 Subsampled channels are not supported (channel "RY" has sampling 2,2).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
 
 tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr :  874 x  493, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr". Unexpected tile x coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
 
 tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr :   64 x   64, 5 channel, half/half/half/float/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr". Scan line 0 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr": OpenEXR exception: std::bad_alloc
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
 Subsampled channels are not supported (channel "RY" has sampling 2,2).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr": OpenEXR exception: vector::_M_fill_insert
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr". unsupported header type to get chunk offset table size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr2.3.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.3.txt
@@ -2,130 +2,130 @@ tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr :   64 
 oiiotool ERROR: read : Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Deep scanline sampleCount data corrupt at chunk 0 (negative sample count detected)
 Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Deep scanline sampleCount data corrupt at chunk 0 (negative sample count detected)
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr": Subsampled channels are not supported (channel "H" has sampling 192,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr : 12688 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr :   64 x   64, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr". Error in Huffman-encoded data (invalid code table size).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr": Subsampled channels are not supported (channel "" has sampling 32,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr": Subsampled channels are not supported (channel "R" has sampling 1,2).
 Subsampled channels are not supported (channel "" has sampling 4,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr : 536910914 x    2, 3 channel, uint/half/half openexr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr :  517 x  517, 3 channel, half openexr (+mipmap)
 
 tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr :    1 x  257, 3 channel, half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr :  636 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr : 536871041 x    1, 3 channel, uint/half/half openexr
 
@@ -134,190 +134,190 @@ tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr :
 tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr": Subsampled channels are not supported (channel "B" has sampling 128,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr :    3 x  257, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr.exr : 30608 x  300, 3 channel, half openexr
 
 tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr": Subsampled channels are not supported (channel "B" has sampling 128,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr :   64 x   64, 2 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr :  480 x  480, 4 channel, half/half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr": Subsampled channels are not supported (channel "" has sampling 16,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr :  400 x  300, 3 channel, float/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr". Huffman decode error (Overrun).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
 
 tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr": OpenEXR exception: std::bad_alloc
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
 Subsampled channels are not supported (channel "RY" has sampling 2,2).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
 
 tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr :  874 x  493, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr". Unexpected tile x coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
 
 tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr :   64 x   64, 5 channel, half/half/half/float/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr". Invalid scan line 0 requested or missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr": OpenEXR exception: std::bad_alloc
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
 Subsampled channels are not supported (channel "RY" has sampling 2,2).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr": OpenEXR exception: vector::_M_default_append
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr". unsupported header type to get chunk offset table size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr2.4-clang-noptex.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.4-clang-noptex.txt
@@ -2,329 +2,329 @@ tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr :   64 
 oiiotool ERROR: read : Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
 Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr". The x subsampling factor for the "H" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr : 12688 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr". Unexpected data block length.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr :   64 x   64, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr". Error in Huffman-encoded data (invalid code table size).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr": Subsampled channels are not supported (channel "" has sampling 32,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr". Unexpected data block length.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr". The x subsampling factor for the "" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr :  517 x  517, 3 channel, half openexr (+mipmap)
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr". Data decoding (rle) failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr :    1 x  257, 3 channel, half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr :  636 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr". Invalid tile size in image header.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr". The x subsampling factor for the "B" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr :    3 x  257, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr.exr : 30608 x  300, 3 channel, half openexr
 
 tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr". The x subsampling factor for the "B" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr :   64 x   64, 2 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr :  480 x  480, 4 channel, half/half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr": Subsampled channels are not supported (channel "" has sampling 16,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr :  400 x  300, 3 channel, float/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr". Huffman decode error (Overrun).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
 
 tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr". Maximum number of tiles exceeded
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
 Subsampled channels are not supported (channel "RY" has sampling 2,2).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
 
 tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr :  874 x  493, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr". Unexpected tile x coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
 
 tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr :   64 x   64, 5 channel, half/half/half/float/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr". Invalid scan line 0 requested or missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr". Maximum number of tiles exceeded
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr". unsupported header type to get chunk offset table size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr2.4-clang-ptex.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.4-clang-ptex.txt
@@ -2,331 +2,331 @@ tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr :   64 
 oiiotool ERROR: read : Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
 Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr". The x subsampling factor for the "H" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr : 12688 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr". Unexpected data block length.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr :   64 x   64, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr". Error in Huffman-encoded data (invalid code table size).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr": Subsampled channels are not supported (channel "" has sampling 32,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr". Unexpected data block length.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr". The x subsampling factor for the "" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr :  517 x  517, 3 channel, half openexr (+mipmap)
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr". Data decoding (rle) failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr :    1 x  257, 3 channel, half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr :  636 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr". Invalid tile size in image header.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr". The x subsampling factor for the "B" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr :    3 x  257, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr.exr : 30608 x  300, 3 channel, half openexr
 
 tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr". The x subsampling factor for the "B" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr :   64 x   64, 2 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr :  480 x  480, 4 channel, half/half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr": Subsampled channels are not supported (channel "" has sampling 16,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr :  400 x  300, 3 channel, float/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr". Huffman decode error (Overrun).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
 
 tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr". Maximum number of tiles exceeded
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
 Subsampled channels are not supported (channel "RY" has sampling 2,2).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
 
 tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr :  874 x  493, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr". Unexpected tile x coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
 
 tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr :   64 x   64, 5 channel, half/half/half/float/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr". Invalid scan line 0 requested or missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
 
 PtexReader error: read failed (EOF) PtexFile: tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 PtexReader error: read failed (EOF) PtexFile: tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr". Maximum number of tiles exceeded
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr". unsupported header type to get chunk offset table size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr2.4-noptex-spi.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.4-noptex-spi.txt
@@ -2,130 +2,130 @@ tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr :   64 
 oiiotool ERROR: read : Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Deep scanline sampleCount data corrupt at chunk 0 (negative sample count detected)
 Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Deep scanline sampleCount data corrupt at chunk 0 (negative sample count detected)
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr": Subsampled channels are not supported (channel "H" has sampling 192,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr : 12688 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr". Unexpected data block length.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr :   64 x   64, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr". Error in Huffman-encoded data (invalid code table size).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr": Subsampled channels are not supported (channel "" has sampling 32,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr". Unexpected data block length.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr": Subsampled channels are not supported (channel "R" has sampling 1,2).
 Subsampled channels are not supported (channel "" has sampling 4,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr : 536910914 x    2, 3 channel, uint/half/half openexr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr :  517 x  517, 3 channel, half openexr (+mipmap)
 
 tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr :    1 x  257, 3 channel, half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr :  636 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr : 536871041 x    1, 3 channel, uint/half/half openexr
 
@@ -134,187 +134,187 @@ tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr :
 tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr": Subsampled channels are not supported (channel "B" has sampling 128,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr :    3 x  257, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr.exr : 30608 x  300, 3 channel, half openexr
 
 tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr": Subsampled channels are not supported (channel "B" has sampling 128,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr :   64 x   64, 2 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr :  480 x  480, 4 channel, half/half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr": Subsampled channels are not supported (channel "" has sampling 16,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr :  400 x  300, 3 channel, float/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr". Huffman decode error (Overrun).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
 
 tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
 
 tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr : 1001259009 x    1, 3 channel, half openexr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr". Maximum number of tiles exceeded
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
 Subsampled channels are not supported (channel "RY" has sampling 2,2).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
 
 tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr :  874 x  493, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr". Unexpected tile x coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
 
 tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr :   64 x   64, 5 channel, half/half/half/float/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr". Invalid scan line 0 requested or missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr". Maximum number of tiles exceeded
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr". unsupported header type to get chunk offset table size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr2.4-noptex.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.4-noptex.txt
@@ -2,130 +2,130 @@ tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr :   64 
 oiiotool ERROR: read : Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Deep scanline sampleCount data corrupt at chunk 0 (negative sample count detected)
 Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Deep scanline sampleCount data corrupt at chunk 0 (negative sample count detected)
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr": Subsampled channels are not supported (channel "H" has sampling 192,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr : 12688 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr". Unexpected data block length.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr :   64 x   64, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr". Error in Huffman-encoded data (invalid code table size).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr": Subsampled channels are not supported (channel "" has sampling 32,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr". Unexpected data block length.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr": Subsampled channels are not supported (channel "R" has sampling 1,2).
 Subsampled channels are not supported (channel "" has sampling 4,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr : 536910914 x    2, 3 channel, uint/half/half openexr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr :  517 x  517, 3 channel, half openexr (+mipmap)
 
 tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr :    1 x  257, 3 channel, half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr :  636 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr : 536871041 x    1, 3 channel, uint/half/half openexr
 
@@ -134,189 +134,189 @@ tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr :
 tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr": Subsampled channels are not supported (channel "B" has sampling 128,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr :    3 x  257, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr.exr : 30608 x  300, 3 channel, half openexr
 
 tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr": Subsampled channels are not supported (channel "B" has sampling 128,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr :   64 x   64, 2 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr :  480 x  480, 4 channel, half/half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr": Subsampled channels are not supported (channel "" has sampling 16,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr :  400 x  300, 3 channel, float/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr". Huffman decode error (Overrun).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
 
 tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr": OpenEXR exception: std::bad_alloc
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr". Maximum number of tiles exceeded
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
 Subsampled channels are not supported (channel "RY" has sampling 2,2).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
 
 tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr :  874 x  493, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr". Unexpected tile x coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
 
 tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr :   64 x   64, 5 channel, half/half/half/float/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr". Invalid scan line 0 requested or missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr". Maximum number of tiles exceeded
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr". unsupported header type to get chunk offset table size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr2.5-clang-ptex.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.5-clang-ptex.txt
@@ -2,331 +2,331 @@ tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr :   64 
 oiiotool ERROR: read : Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
 Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr". The x subsampling factor for the "H" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr : 12688 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr". Unexpected data block length.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr :   64 x   64, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr". Error in Huffman-encoded data (invalid code table size).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr": Subsampled channels are not supported (channel "" has sampling 32,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr". Unexpected data block length.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr". The x subsampling factor for the "" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr :  517 x  517, 3 channel, half openexr (+mipmap)
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr". Data decoding (rle) failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr :    1 x  257, 3 channel, half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr :  636 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr". Invalid tile size in image header.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr". The x subsampling factor for the "B" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr :    3 x  257, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr.exr : 30608 x  300, 3 channel, half openexr
 
 tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr". The x subsampling factor for the "B" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr :   64 x   64, 2 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr :  480 x  480, 4 channel, half/half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr": Subsampled channels are not supported (channel "" has sampling 16,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr :  400 x  300, 3 channel, float/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr". Huffman decode error (Overrun).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
 
 tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr". Invalid size.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
 Subsampled channels are not supported (channel "RY" has sampling 2,2).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
 
 tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr :  874 x  493, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr". Unexpected tile x coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
 
 tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr :   64 x   64, 5 channel, half/half/half/float/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
 
 PtexReader error: read failed (EOF) PtexFile: tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 PtexReader error: read failed (EOF) PtexFile: tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr". Maximum number of tiles exceeded
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr". unsupported header type to get chunk offset table size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr2.5.txt
+++ b/testsuite/openexr-damaged/ref/out-exr2.5.txt
@@ -2,329 +2,329 @@ tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr :   64 
 oiiotool ERROR: read : Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
 Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr". The x subsampling factor for the "H" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr : 12688 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr". Unexpected data block length.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr :   64 x   64, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr". Error in Huffman-encoded data (invalid code table size).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr": Subsampled channels are not supported (channel "" has sampling 32,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr". Unexpected data block length.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr". The x subsampling factor for the "" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr :  517 x  517, 3 channel, half openexr (+mipmap)
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr". Data decoding (rle) failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr :    1 x  257, 3 channel, half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr :  636 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr". Invalid tile size in image header.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr". The x subsampling factor for the "B" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr :    3 x  257, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr.exr : 30608 x  300, 3 channel, half openexr
 
 tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr". The x subsampling factor for the "B" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr :   64 x   64, 2 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr :  480 x  480, 4 channel, half/half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr": Subsampled channels are not supported (channel "" has sampling 16,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr :  400 x  300, 3 channel, float/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr". Huffman decode error (Overrun).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
 
 tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr". Invalid size.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
 Subsampled channels are not supported (channel "RY" has sampling 2,2).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
 
 tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr :  874 x  493, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr". Unexpected tile x coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
 
 tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr :   64 x   64, 5 channel, half/half/half/float/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr". File input failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr". Maximum number of tiles exceeded
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr". unsupported header type to get chunk offset table size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr3.0-clang-ptex.txt
+++ b/testsuite/openexr-damaged/ref/out-exr3.0-clang-ptex.txt
@@ -2,331 +2,331 @@ tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr :   64 
 oiiotool ERROR: read : Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
 Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr". Missing or empty channel list in header
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr". The x subsampling factor for the "H" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr : 12688 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr". Unexpected data block length.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr :   64 x   64, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr". Error in Huffman-encoded data (invalid code table size).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr": Subsampled channels are not supported (channel "" has sampling 32,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr". Unexpected data block length.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr". The x subsampling factor for the "" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr :  517 x  517, 3 channel, half openexr (+mipmap)
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr". Data decoding (rle) failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr :    1 x  257, 3 channel, half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr :  636 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr". Invalid tile size in image header.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr". The x subsampling factor for the "B" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr :    3 x  257, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr.exr : 30608 x  300, 3 channel, half openexr
 
 tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr". The x subsampling factor for the "B" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr :   64 x   64, 2 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr :  480 x  480, 4 channel, half/half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr": Subsampled channels are not supported (channel "" has sampling 16,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr :  400 x  300, 3 channel, float/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr". Error in Huffman-encoded data (decoded data are shorter than expected).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
 
 tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr". Missing or empty channel list in header
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr". Missing or empty channel list in header
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
 Subsampled channels are not supported (channel "RY" has sampling 2,2).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
 
 tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr :  874 x  493, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr". Unexpected tile x coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
 
 tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr :   64 x   64, 5 channel, half/half/half/float/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr". Missing or empty channel list in header
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
 
 PtexReader error: read failed (EOF) PtexFile: tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr". Missing or empty channel list in header
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 PtexReader error: read failed (EOF) PtexFile: tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Files must contain at least one header
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr". Missing or empty channel list in header
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr". Missing or empty channel list in header
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr". Maximum number of tiles exceeded
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr". unsupported header type to get chunk offset table size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
 

--- a/testsuite/openexr-damaged/ref/out-exr3.0.txt
+++ b/testsuite/openexr-damaged/ref/out-exr3.0.txt
@@ -2,329 +2,329 @@ tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr :   64 
 oiiotool ERROR: read : Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
 Failed OpenEXR read: Error reading sample count data from image file "tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr". Data decoding (rle) failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_4cb169_255_cc7ac9cde4b8634b31cb41c8fe89b92d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_504235_131_78b0e15388401193e1ee2ce20fb7f3b0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd58fcbf3d_356_668b128c27c62e0d8314c503831fde88_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr". The x subsampling factor for the "H" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7efd9bd346a5_639_9e0b30ed499cdf9e8802dd64e16a9508_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f09128c0ec1_358_ecaca7fb3f230d9d842074e1dd88f29b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr : 12688 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f0faa6bb393_900_7d9ed0a6eaa68f8308a042d725119ad2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr". Unexpected data block length.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11c0330393_935_240e7cacd61711daf4285366fea95e0c_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr :   64 x   64, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f11ece681f1_785_a570a0a25ada4752dabb554ad6b1eb6b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr". Error in Huffman-encoded data (invalid code table size).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f171b7ab3a2_937_b4e2415c399c2ab39548de911223769d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr": Subsampled channels are not supported (channel "" has sampling 32,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f178ac80539_109_519f88e9ededfff61f535d6c9eb25a85_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr". Unexpected data block length.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f1fd65113ac_935_8fd55930e544dc3fb88659a6a8509c14_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f35311a1426_780_4871d40882e0fe7fae1427a82319e144_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr". The x subsampling factor for the "" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f479f9536bd_391_5953693841a7931caf3d4592f8b9c90b_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4aaebde389_918_a40f029a8121e5e26fe338b1fb91846e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4d5072b39d_561_5f5e4ef49a581edaf7bf0858fbfcfdd1_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f4f5558d00e_414_ec6445a8638a21c93ce8feb5a2e71981_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f54ed80df53_321_19490ab1841d3854eec557f3c23d0db0_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5860f8d1f4_188_2e62008f8ecb3bb2ed67c09fa0939da7_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f58e8d75e8b_186_4bb7b1de93e9e44ea921c301b29a8026_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr :  517 x  517, 3 channel, half openexr (+mipmap)
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr". Data decoding (rle) failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5a5030cdca_702_045a76649e773c9c18b706c9853f18d9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5c18182f27_369_1fb4dae7654c77cd79646d3aa049d5dd_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f5cd523238e_878_03c277ec5021331fb301c7c1caa7dfd8_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f5cdab9a3a7_415_c33b838f08aafc976d3c24139936e122_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6798416389_229_18bd946a4fde157b9974d16a51a4851d_exr.exr : 1023 x 49409, 1 channel, uint openexr
 
 tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr :    1 x  257, 3 channel, half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6a78657cbf_916_10cc35387b54fdc7744f91b5bb424009_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6e5e983398_203_ff7c0c73c79483db1fee001d77463c37_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr :  636 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6efa7c53a7_991_4f9bd6fda4f5ae991775244b4945a7fb_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr :  480 x  480, 4 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f6f881fa398_561_20ecb7f5a431d03a1502c28cab1214ad_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr". Invalid tile size in image header.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f730474b07c_543_fb506af38c88894d92ba0d433cf41abc_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f76b2c2cefb_196_ea4f8db8b4f2c11e02428c08e9bbbbb8_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f7a75f9abf5_577_a2b8668cc6069643543cb80fedca3ee4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8170c1abfa_115_8c6e33969541bf432ef7e68cc369728c_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8a69d8339d_829_381ccc69dc6bd21c43a1deb0965bf5ab_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8dd48421cd_321_7bae35650e908b12dbee1cf01e3d357f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f8ed39ceed3_955_c6bb655a1bbfab9c5b511bd2b767e023_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9acb068ee5_177_ec645ad270202d39ba5e80c826bbf13d_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr". The x subsampling factor for the "B" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7f9cc08a96a5_942_e708072e479264a7808c055094a0fed9_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr :    3 x  257, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fa0e1f48cbf_760_be9901248390240a24449d4e8a97f6f2_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fa34eacd389_820_476a8109ebb3f7d02252e773b7bca45d_exr.exr : 30608 x  300, 3 channel, half openexr
 
 tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr :  400 x  300, 3 channel, uint/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7faf9aba03ac_414_75af58c21b9b9e994747f9d6a5fc46d4_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr". The x subsampling factor for the "B" channel is not 1.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb3a7c6fc99_871_52d1f03c515bc91cc894515beea56a4f_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fb97d097381_293_78e73b6494a955e87faabcb16b35faa0_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fbe2d8e838e_932_9e9d2b0a870c0ad516189d274c2f98e4_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fc6b05f1eaf_255_e967badfa747d1bb0eda71a1883b419e_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr :   64 x   64, 2 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fca10855564_529_6d418eae3e33a819185a8b09c40fd123_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fcdcb0a9f65_100_70d0d5b98567a5174d512dba7a603377_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fce901e7498_737_927b67c9a1ecd5f997d3a2620fdbf639_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd328d0d206_535_9cc3d65c368fb138cb6a4bdd4da8070f_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr :   64 x   64, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr". Scan line 32 is missing.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fd921b41f11_369_da245dc772c0a5a60ce7b759b2132c51_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr :  480 x  480, 4 channel, half/half/uint/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fdb9de0b38e_829_636ff2831c664e14a73282a3299781dd_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr": Subsampled channels are not supported (channel "" has sampling 16,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe4c4caa975_277_153f78ec07237d01e8902143da28c7ec_exr.exr -o out.exr
 
 tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr :  400 x  300, 3 channel, float/half/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr". Error decoding Huffman table (Run beyond end of table).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe667eb33a2_999_31f64961e47968656f00573f7db5c67d_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7fe814d1ce9d_617_e00af1c4c76b988122b68d43b073dd47_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr": Subsampled channels are not supported (channel "" has sampling 64,1).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_heap-oob_7ff4b88b21df_560_e119e0ba5bf9345e7daa85cc2fff6684_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_157_4c56ecca982bc10e976527cd314bbcfa_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_436_bb29e6f88ad5f5b2f5f9b68a3655b1d8_exr.exr -o out.exr
 
 tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr :   64 x   64, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/asan_stack-oob_433d4f_510_f8d3ef49bd6e5f7ca4fb7e0f9c0af139_exr.exr -o out.exr
 
 tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr :  400 x  300, 3 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr". Unexpected data block y coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_heap_buffer_overflow_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_1_exr.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr": OpenEXR exception: maximum bytes per scanline exceeds maximum permissible size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/openexr_2.2.0_memory_allocation_error_3_exr.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr". Invalid size.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-099125d15685ef30feae813ddae15406b3f539d7cc4aa399176a50dcfe9be95c.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-2b68475a090117f033df54c2de31546f7a1927ecadd9d0aa9b6bb8daad8ea971_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-3e54bd90fc0e2a0b348ecd80d96738ed8324de388b3e88fd6c5fc666c2f01d83_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr": Subsampled channels are not supported (channel "BY" has sampling 2,2).
 Subsampled channels are not supported (channel "RY" has sampling 2,2).
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-4d912f49ddc13ff49f95543880d47c85a8918e563fb723c340264f1719057613.mini.exr -o out.exr
 
 tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr :  874 x  493, 1 channel, half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr". Unexpected tile x coordinate.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-66e4d1f68a3112b9aaa93831afbf8e283fd39be5e4591708bad917e6886c0ebb.mini.exr -o out.exr
 
 tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr :   64 x   64, 5 channel, half/half/half/float/half openexr
 oiiotool ERROR: read : Failed OpenEXR read: Error reading pixel data from image file "tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr". File input failed.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-89f7735a7cc9dcee59bfce4da70ad12e35a8809945b01b975d1a52ec15dbeccc.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-9651abd6ee953b9f669db5927f8832f1b1eab028fa6ae7b4176a701aeea0ec90.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-a905d63836959293bed720ab7d242bd07b7b7ec81ee3ee1e14e89853344dafbf_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-af451a11e18ad9ca6ddc098bfd8b42f803bec2be8fafa6e648b8a7adcfdd0c06_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenImageIO could not find a format reader for "tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr". Is it a file format that OpenImageIO doesn't know about?
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-bd9579c640a6ee867d140c2a4d3bbd6f0452d4726f3f25ed53bf666f558ed245_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr". Invalid size field in header attribute
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-c9457552c1c04ea0f98154bc433a5f5d0421a7e705e6f396aba4339568473435_min.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-cbc6ff03d6bc31f0c61476525641852b0220278e6576a651029c50e86f7f0c77.exr -o out.exr
 
 oiiotool ERROR: read : "tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr": No channels found
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-d545cd0db4595a1c05504ab53d83cc8c6fce02387545aa49e979ee087c1ddf8f_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr". Maximum number of tiles exceeded
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-df1fefc5fb459cb12183eae34dc696cd0e77b0b8deb4cd1ef3dc25279b7a6bde_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr". Unexpected end of file.
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-e2106eebb303e685cee66860c931fe1a4eb9af1a7f5bef5b3b95f90c3e8ae0e0_min.exr -o out.exr
 
 oiiotool ERROR: read : OpenEXR exception: Cannot read image file "tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr". unsupported header type to get chunk offset table size
 Full command line was:
-> oiiotool -colorconfig ../../../testsuite/common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -n -info tmpsrc/poc-fb9238840f4d9d93ab3ac989b70000f9795ab6ad399bff00093b944e6a893403_min.exr -o out.exr
 

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -78,9 +78,9 @@ if str(mytest).endswith('.batch') :
     mytest = mytest.split('.')[0]
 test_source_dir = os.getenv('OIIO_TESTSUITE_SRC',
                             os.path.join(OIIO_TESTSUITE_ROOT, mytest))
-colorconfig_file = os.path.join(OIIO_TESTSUITE_ROOT,
-                                "common", "OpenColorIO", "nuke-default", "config.ocio")
-
+colorconfig_file = os.getenv('OIIO_TESTSUITE_OCIOCONFIG',
+                             '../common/OpenColorIO/nuke-default/config.ocio')
+colorconfig_file = oiio_relpath(colorconfig_file)
 
 
 command = ""


### PR DESCRIPTION
To help make testsuite pass even with nonstandard relative path to the
build area, slightly change how we reference the OCIO config that is
in the testsuite.
