### PR TITLE
oiiotool --ch : reduce expense for no-op

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -1765,13 +1765,19 @@ current top image.
       it,
     * `=` *float*, which will set the channel to a constant value, or
     * *newname* `=` *float*, which sets the channel to a constant value as
-      well as names the new channel. Examples include:  `R,G,B`,
-      `R=0.0,G,B,A=1.0`, `R=B,G,B=R`, `4,5,6,A`.
+      well as names the new channel.
+
+    Example channel lists include: `R,G,B`, `R=0.0,G,B,A=1.0`, `R=B,G,B=R`,
+    `4,5,6,A`.
 
     Channel numbers outside the valid range of input channels, or unknown
     names, will be replaced by black channels. If the *channellist* is
     shorter than the number of channels in the source image, unspecified
     channels will be omitted.
+
+    If the channel list does not specify any changes (neither order, nor
+    name, nor value), then this will just leave the images as-is, without
+    any unnecessary expense or pointless copying of images in memory.
 
 .. option:: --chappend
 

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -26,7 +26,7 @@ class ImageRec;
 typedef std::shared_ptr<ImageRec> ImageRecRef;
 
 
-/// Polycy hints for reading images
+/// Policy hints for reading images
 enum ReadPolicy {
     ReadDefault = 0,        //< Default: use cache, maybe convert to float.
                             //<   For "small" files, may bypass cache.


### PR DESCRIPTION
Before doing all the work of copying the image, first see if the
`--ch` is actually specifying any change versus the image as it
stands. If not, skip all the copying and just stick to the image we
have.

The main benefit here is if you have a --ch primarily for "conformance",
e.g. you want to reduce to a known subset of channels and remove any
extra that may be unanticipated in the input, but it's possible that
the input will come to you already with only the desired channels. As
an example,

    oiiotool in.exr --ch R,G,B ...more ops... -o out.exr

Previously, if in.exr aleady had channels R,G,B (and no other), there
would be some unneceessary expense of creating (in memory) a new image
for the output of --ch copying data to fill it in. With this patch,
the --ch would very nearly turn into a no-op. In both cases, if
in.exr's channels were something other than R,G,B, channel copies
would need to be done identically in both old and new code.

