### PR TITLE
Timer::add_seconds, add_ticks

### DIFF
--- a/src/include/OpenImageIO/timer.h
+++ b/src/include/OpenImageIO/timer.h
@@ -173,6 +173,20 @@ public:
     /// Is the timer currently ticking?
     bool ticking() const { return m_ticking; }
 
+    /// Force an offset to the total, in ticks. This value may be negative to
+    /// subtract from the total. To avoid disrupting the timer in progress,
+    /// this is added to the total elapsed time but not to the current lap, so
+    /// it will be reflected in ticks() or seconds(), but will NOT be
+    /// reflected in ticks_since_start() or time_since_start().
+    void add_ticks(ticks_t delta) { m_elapsed_ticks += delta; }
+
+    /// Force an offset to the total, in seconds. This value may be negative
+    /// to subtract from the total. To avoid disrupting the timer in progress,
+    /// this is added to the total elapsed time but not to the current lap, so
+    /// it will be reflected in ticks() or seconds(), but will NOT be
+    /// reflected in ticks_since_start() or time_since_start().
+    void add_seconds(double t) { add_ticks(ticks_t(t * ticks_per_second)); }
+
 private:
     bool m_ticking;           ///< Are we currently ticking?
     bool m_printdtr;          ///< Print upon destruction?
@@ -211,6 +225,7 @@ private:
     }
 
     static double seconds_per_tick;
+    static ticks_t ticks_per_second;
     friend class TimerSetupOnce;
 };
 

--- a/src/libutil/timer_test.cpp
+++ b/src/libutil/timer_test.cpp
@@ -117,6 +117,18 @@ main(int argc, char** argv)
     std::cout << "Checkpoint2: All " << all() << " selective " << selective()
               << "\n";
 
+    // Test add_ticks/add_seconds
+    {
+        Timer t(false);
+        Sysutil::usleep(100000);
+        OIIO_CHECK_EQUAL(t.ticking(), false);
+        t.add_ticks(100);
+        OIIO_CHECK_EQUAL(t.ticks(), 100);
+        t.add_ticks(100);
+        t.reset();
+        t.add_seconds(1.0);
+        OIIO_CHECK_EQUAL_THRESH(t(), 1.0, 1.0e-6);
+    }
 
     // Test Benchmarker
     Benchmarker bench;


### PR DESCRIPTION
Add methods to the Timer class that allows you to add (or subtract, if
negtive) to the total elapsed value of a timer.

