### PR TITLE
Build scripts: rename OIIO_DEP_DOWNLOAD_ONLY to DEP_DOWNLOAD_ONLY

### DIFF
--- a/src/build-scripts/build_OpenJPEG.bash
+++ b/src/build-scripts/build_OpenJPEG.bash
@@ -39,7 +39,7 @@ git checkout ${OPENJPEG_VERSION} --force
 mkdir -p ${OPENJPEG_BUILD_DIR} && true
 cd ${OPENJPEG_BUILD_DIR}
 
-if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
     time cmake -DCMAKE_BUILD_TYPE=Release \
                -DCMAKE_INSTALL_PREFIX=${OPENJPEG_INSTALL_DIR} \
                -DBUILD_CODEC=OFF \

--- a/src/build-scripts/build_gif.bash
+++ b/src/build-scripts/build_gif.bash
@@ -37,7 +37,7 @@ fi
 
 cd giflib-${GIFLIB_VERSION}
 
-if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
     time make PREFIX=${GIFLIB_INSTALL_DIR} CC=${GIFLIB_CC} install
 fi
 

--- a/src/build-scripts/build_libjpeg-turbo.bash
+++ b/src/build-scripts/build_libjpeg-turbo.bash
@@ -39,7 +39,7 @@ git checkout ${LIBJPEGTURBO_VERSION} --force
 mkdir -p ${LIBJPEGTURBO_BUILD_DIR}
 cd ${LIBJPEGTURBO_BUILD_DIR}
 
-if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
     time cmake -DCMAKE_BUILD_TYPE=Release \
                -DCMAKE_INSTALL_PREFIX=${LIBJPEGTURBO_INSTALL_DIR} \
                ${LIBJPEGTURBO_CONFIG_OPTS} ..

--- a/src/build-scripts/build_libpng.bash
+++ b/src/build-scripts/build_libpng.bash
@@ -41,7 +41,7 @@ git checkout ${LIBPNG_VERSION} --force
 mkdir -p ${LIBPNG_BUILD_DIR}
 cd ${LIBPNG_BUILD_DIR}
 
-if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
     time cmake -DCMAKE_BUILD_TYPE=Release \
                -DCMAKE_INSTALL_PREFIX=${LIBPNG_INSTALL_DIR} \
                -DPNG_EXECUTABLES=OFF \

--- a/src/build-scripts/build_libraw.bash
+++ b/src/build-scripts/build_libraw.bash
@@ -36,7 +36,7 @@ pushd ${LIBRAW_SOURCE_DIR}
 
 git checkout ${LIBRAW_VERSION} --force
 
-if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
     aclocal
     autoreconf --install
     ./configure --prefix=${LIBRAW_INSTALL_DIR}

--- a/src/build-scripts/build_libtiff.bash
+++ b/src/build-scripts/build_libtiff.bash
@@ -34,7 +34,7 @@ git checkout ${LIBTIFF_VERSION} --force
 mkdir -p build
 cd build
 
-if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
     time cmake -DCMAKE_BUILD_TYPE=Release \
                -DCMAKE_INSTALL_PREFIX=${LIBTIFF_INSTALL_DIR} \
                -DCMAKE_CXX_FLAGS="${LIBTIFF_CXX_FLAGS}" \

--- a/src/build-scripts/build_pugixml.bash
+++ b/src/build-scripts/build_pugixml.bash
@@ -41,7 +41,7 @@ git checkout ${PUGIXML_VERSION} --force
 mkdir -p ${PUGIXML_BUILD_DIR}
 cd ${PUGIXML_BUILD_DIR}
 
-if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
     time cmake -DCMAKE_BUILD_TYPE=Release \
                -DCMAKE_INSTALL_PREFIX=${PUGIXML_INSTALL_DIR} \
                -DBUILD_SHARED_LIBS=ON \

--- a/src/build-scripts/build_pybind11.bash
+++ b/src/build-scripts/build_pybind11.bash
@@ -41,7 +41,7 @@ git checkout ${PYBIND11_VERSION} --force
 mkdir -p ${PYBIND11_BUILD_DIR}
 cd ${PYBIND11_BUILD_DIR}
 
-if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
     time cmake -DCMAKE_BUILD_TYPE=Release \
                -DCMAKE_INSTALL_PREFIX=${PYBIND11_INSTALL_DIR} \
                -DPYBIND11_TEST=OFF \

--- a/src/build-scripts/build_webp.bash
+++ b/src/build-scripts/build_webp.bash
@@ -39,7 +39,7 @@ git checkout ${WEBP_VERSION} --force
 mkdir -p ${WEBP_BUILD_DIR}
 cd ${WEBP_BUILD_DIR}
 
-if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
     time cmake -DCMAKE_BUILD_TYPE=Release \
                -DCMAKE_INSTALL_PREFIX=${WEBP_INSTALL_DIR} \
                -DWEBP_BUILD_ANIM_UTILS=OFF \

--- a/src/build-scripts/build_zlib.bash
+++ b/src/build-scripts/build_zlib.bash
@@ -41,7 +41,7 @@ mkdir -p ${ZLIB_BUILD_DIR} && true
 cd ${ZLIB_BUILD_DIR}
 
 
-if [[ -z $OIIO_DEP_DOWNLOAD_ONLY ]]; then
+if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
     time cmake -DCMAKE_BUILD_TYPE=Release \
                -DCMAKE_INSTALL_PREFIX=${ZLIB_INSTALL_DIR} \
                ${ZLIB_CONFIG_OPTS} ..


### PR DESCRIPTION
I realized after #3058 was merged that I often share and copy a lot of
these little dependency build scripts across multiple projects, so I
wanted to remove the OIIO-specific naming.

