### PR TITLE
CI test for VP2022, fix revealed python binding bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,7 +320,7 @@ jobs:
       PTEX_VERSION: v2.4.0
       PYBIND11_VERSION: v2.7.1
       PYTHON_VERSION: 3.8
-      WEBP_VERSION: v1.1.0
+      WEBP_VERSION: v1.2.1
       MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=8.0.0
       USE_OPENVDB: 0
       # The old installed OpenVDB has a TLS conflict with Python 3.8
@@ -363,7 +363,7 @@ jobs:
   linux-bleeding-edge:
     # Test against development master for relevant dependencies, latest
     # supported releases of everything else.
-    name: "Linux bleeding edge: gcc11 C++20 py38 avx2 OCIO/libtiff/exr master"
+    name: "Linux bleeding edge: gcc11 C++20 py38 OCIO/libtiff/exr-master boost1.71 avx2"
     runs-on: ubuntu-20.04
     env:
       CXX: g++-11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,10 @@ jobs:
         with:
           name: ${{ github.job }}
           path: |
-            build/testsuite/*/*.*
             build/CMake*.{txt,log}
+            build/testsuite/*/*.*
+            !build/testsuite/{oiio,openexr,fits}-images
+            !build/testsuite/j2kp4files_v1_5
 
   vfxplatform-2020:
     name: "Linux VFX Platform 2020: gcc6/C++14 py3.7 boost1.70 exr2.4 ocio1.1"
@@ -109,12 +111,13 @@ jobs:
         with:
           name: ${{ github.job }}
           path: |
-            build/testsuite/*/*.*
             build/CMake*.{txt,log}
+            build/testsuite/*/*.*
+            !build/testsuite/{oiio,openexr,fits}-images
+            !build/testsuite/j2kp4files_v1_5
 
   vfxplatform-2021:
-    # Test VFX Platform 2021 -- mainly, that means gcc9 and C++17.
-    name: "Linux VFX Platform 2021: gcc9/C++17 py3.7 boost1.73 exr2.5 ocio2.0 qt5.15"
+    name: "Linux VFX Platform 2021: gcc9/C++17 py3.7 boost-1.73 exr-2.5 qt-5.15"
     runs-on: ubuntu-latest
     container:
       image: aswf/ci-osl:2021
@@ -156,20 +159,21 @@ jobs:
         with:
           name: ${{ github.job }}
           path: |
-            build/testsuite/*/*.*
             build/CMake*.{txt,log}
+            build/testsuite/*/*.*
+            !build/testsuite/{oiio,openexr,fits}-images
+            !build/testsuite/j2kp4files_v1_5
 
-  vfxplatform-2021-exr3:
-    # Test VFX Platform 2021, but with OpenEXR/Imath 3.x
-    name: "Linux VFX Platform 2021: gcc9/C++17 py3.7 boost1.73 exr3.1 ocio2.0 qt5.15"
+  vfxplatform-2022:
+    name: "Linux VFX Platform 2022: gcc9/C++17 py3.9 boost-1.73 exr-3.1 qt-5.15"
     runs-on: ubuntu-latest
     container:
-      image: aswf/ci-osl:2021
+      image: aswf/ci-osl:2022-clang11.7
     env:
       CXX: g++
       CC: gcc
       CMAKE_CXX_STANDARD: 17
-      PYTHON_VERSION: 3.7
+      PYTHON_VERSION: 3.9
       USE_SIMD: avx2,f16c
       OPENEXR_VERSION: v3.1.1
     steps:
@@ -191,8 +195,6 @@ jobs:
             src/build-scripts/ci-startup.bash
       - name: Dependencies
         run: |
-            sudo rm -rf /usr/local/include/OpenEXR
-            sudo rm -rf /usr/local/lib64/cmake/{IlmBase,OpenEXR}
             src/build-scripts/gh-installdeps.bash
       - name: Build
         run: |
@@ -205,8 +207,10 @@ jobs:
         with:
           name: ${{ github.job }}
           path: |
-            build/testsuite/*/*.*
             build/CMake*.{txt,log}
+            build/testsuite/*/*.*
+            !build/testsuite/{oiio,openexr,fits}-images
+            !build/testsuite/j2kp4files_v1_5
 
   linux-gcc7-cpp14-debug:
     # Test against gcc7, and also at the same time, do a Debug build.
@@ -249,8 +253,10 @@ jobs:
         with:
           name: ${{ github.job }}
           path: |
-            build/testsuite/*/*.*
             build/CMake*.{txt,log}
+            build/testsuite/*/*.*
+            !build/testsuite/{oiio,openexr,fits}-images
+            !build/testsuite/j2kp4files_v1_5
 
   linux-gcc8:
     # Test against gcc8.
@@ -293,8 +299,10 @@ jobs:
         with:
           name: ${{ github.job }}
           path: |
-            build/testsuite/*/*.*
             build/CMake*.{txt,log}
+            build/testsuite/*/*.*
+            !build/testsuite/{oiio,openexr,fits}-images
+            !build/testsuite/j2kp4files_v1_5
 
   linux-latest-releases:
     # Test against latest supported releases of toolchain and dependencies.
@@ -310,7 +318,7 @@ jobs:
       OPENEXR_VERSION: v3.1.1
       PUGIXML_VERSION: v1.11.4
       PTEX_VERSION: v2.4.0
-      PYBIND11_VERSION: v2.7.0
+      PYBIND11_VERSION: v2.7.1
       PYTHON_VERSION: 3.8
       WEBP_VERSION: v1.1.0
       MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=8.0.0
@@ -347,8 +355,10 @@ jobs:
         with:
           name: ${{ github.job }}
           path: |
-            build/testsuite/*/*.*
             build/CMake*.{txt,log}
+            build/testsuite/*/*.*
+            !build/testsuite/{oiio,openexr,fits}-images
+            !build/testsuite/j2kp4files_v1_5
 
   linux-bleeding-edge:
     # Test against development master for relevant dependencies, latest
@@ -403,8 +413,10 @@ jobs:
         with:
           name: ${{ github.job }}
           path: |
-            build/testsuite/*/*.*
             build/CMake*.{txt,log}
+            build/testsuite/*/*.*
+            !build/testsuite/{oiio,openexr,fits}-images
+            !build/testsuite/j2kp4files_v1_5
 
   linux-oldest:
     # Oldest versions of the dependencies that we can muster, and various
@@ -457,8 +469,10 @@ jobs:
         with:
           name: ${{ github.job }}
           path: |
-            build/testsuite/*/*.*
             build/CMake*.{txt,log}
+            build/testsuite/*/*.*
+            !build/testsuite/{oiio,openexr,fits}-images
+            !build/testsuite/j2kp4files_v1_5
 
   macos-py38:
     name: "Mac py38"
@@ -503,8 +517,10 @@ jobs:
         with:
           name: ${{ github.job }}
           path: |
-            build/testsuite/*/*.*
             build/CMake*.{txt,log}
+            build/testsuite/*/*.*
+            !build/testsuite/{oiio,openexr,fits}-images
+            !build/testsuite/j2kp4files_v1_5
 
   windows-vs2019:
     name: "Windows VS2019"
@@ -539,8 +555,10 @@ jobs:
         with:
           name: ${{ github.job }}
           path: |
-            build/testsuite/*/*.*
             build/CMake*.{txt,log}
+            build/testsuite/*/*.*
+            !build/testsuite/{oiio,openexr,fits}-images
+            !build/testsuite/j2kp4files_v1_5
 
   windows-vs2017:
     name: "Windows VS2017"
@@ -575,8 +593,10 @@ jobs:
         with:
           name: ${{ github.job }}
           path: |
-            build/testsuite/*/*.*
             build/CMake*.{txt,log}
+            build/testsuite/*/*.*
+            !build/testsuite/{oiio,openexr,fits}-images
+            !build/testsuite/j2kp4files_v1_5
 
   sanitizer:
     # Run sanitizers.
@@ -622,8 +642,10 @@ jobs:
         with:
           name: ${{ github.job }}
           path: |
-            build/testsuite/*/*.*
             build/CMake*.{txt,log}
+            build/testsuite/*/*.*
+            !build/testsuite/{oiio,openexr,fits}-images
+            !build/testsuite/j2kp4files_v1_5
 
   linux-clang10-cpp14:
     # Test compiling with clang on Linux.
@@ -668,8 +690,10 @@ jobs:
         with:
           name: ${{ github.job }}
           path: |
-            build/testsuite/*/*.*
             build/CMake*.{txt,log}
+            build/testsuite/*/*.*
+            !build/testsuite/{oiio,openexr,fits}-images
+            !build/testsuite/j2kp4files_v1_5
 
   linux-clang11-cpp17:
     # Test compiling with clang  and C++17 on Linux.
@@ -718,8 +742,10 @@ jobs:
         with:
           name: ${{ github.job }}
           path: |
-            build/testsuite/*/*.*
             build/CMake*.{txt,log}
+            build/testsuite/*/*.*
+            !build/testsuite/{oiio,openexr,fits}-images
+            !build/testsuite/j2kp4files_v1_5
 
   linux-static:
     # Test building static libs.
@@ -760,8 +786,10 @@ jobs:
         with:
           name: ${{ github.job }}
           path: |
-            build/testsuite/*/*.*
             build/CMake*.{txt,log}
+            build/testsuite/*/*.*
+            !build/testsuite/{oiio,openexr,fits}-images
+            !build/testsuite/j2kp4files_v1_5
 
   clang-format:
     # Test formatting. This test entry doesn't do a full build, it just runs

--- a/src/build-scripts/build_pybind11.bash
+++ b/src/build-scripts/build_pybind11.bash
@@ -7,7 +7,7 @@ set -ex
 
 # Repo and branch/tag/commit of pybind11 to download if we don't have it yet
 PYBIND11_REPO=${PYBIND11_REPO:=https://github.com/pybind/pybind11.git}
-PYBIND11_VERSION=${PYBIND11_VERSION:=v2.5.0}
+PYBIND11_VERSION=${PYBIND11_VERSION:=v2.6.2}
 
 # Where to put pybind11 repo source (default to the ext area)
 PYBIND11_SRC_DIR=${PYBIND11_SRC_DIR:=${PWD}/ext/pybind11}

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -18,7 +18,9 @@ if [[ "$ASWF_ORG" != ""  ]] ; then
     sudo yum install -y opencv opencv-devel && true
     sudo yum install -y Field3D Field3D-devel && true
     sudo yum install -y ffmpeg ffmpeg-devel && true
-
+    if [[ "${EXTRA_DEP_PACKAGES}" != "" ]] ; then
+        time sudo yum install -y ${EXTRA_DEP_PACKAGES}
+    fi
 else
     # Using native Ubuntu runner
 
@@ -27,8 +29,7 @@ else
 
     time sudo apt-get -q install -y \
         git cmake ninja-build ccache g++ \
-        libboost-dev libboost-thread-dev \
-        libboost-filesystem-dev libboost-regex-dev \
+        libboost-dev libboost-thread-dev libboost-filesystem-dev \
         libilmbase-dev libopenexr-dev \
         libtbb-dev \
         libtiff-dev libgif-dev libpng-dev libraw-dev libwebp-dev \
@@ -40,8 +41,16 @@ else
         libopencv-dev \
         qt5-default \
         libhdf5-dev
+    if [[ "${EXTRA_DEP_PACKAGES}" != "" ]] ; then
+        time sudo apt-get -q install -y ${EXTRA_DEP_PACKAGES}
+    fi
 
-    if [[ "$PYTHON_VERSION" == "2.7" ]] ; then
+    # Nonstandard python versions
+    if [[ "${PYTHON_VERSION}" == "3.9" ]] ; then
+        time sudo apt-get -q install -y python3.9-dev python3-numpy
+        pip3 --version
+        pip3 install numpy
+    elif [[ "$PYTHON_VERSION" == "2.7" ]] ; then
         time sudo apt-get -q install -y python-dev python-numpy
     else
         pip3 install numpy
@@ -55,9 +64,7 @@ else
 
     export CMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu:$CMAKE_PREFIX_PATH
 
-    if [[ "$CXX" == "g++-4.8" ]] ; then
-        time sudo apt-get install -y g++-4.8
-    elif [[ "$CXX" == "g++-6" ]] ; then
+    if [[ "$CXX" == "g++-6" ]] ; then
         time sudo apt-get install -y g++-6
     elif [[ "$CXX" == "g++-7" ]] ; then
         time sudo apt-get install -y g++-7
@@ -114,8 +121,6 @@ if [[ "$PUGIXML_VERSION" != "" ]] ; then
 fi
 
 if [[ "$OPENCOLORIO_VERSION" != "" ]] ; then
-    # Temporary (?) fix: GH ninja having problems, fall back to make
-    CMAKE_GENERATOR="Unix Makefiles" \
     source src/build-scripts/build_opencolorio.bash
 fi
 


### PR DESCRIPTION
* CI test against ASWF's latest VFXPlatform-2022 docker container,
  including Python 3.9.

* Pesky crash resulted in testsuite/python-imagebufalgo, laboriously
  traced to IBA_color_range_check releasing the GIL too liberally. The
  scoped release cannot contain the tuple construction!

* Audited the rest of py_imagebufalgo.cpp and found the same mistake in
  only one other place: IBA_histogram. Was asymptomatic so far, but fixed
  now.

* Presumably we just got lucky and these bugs were never symptomatic
  until we started building against Python 3.9.

* Noticed that the recent change in build tree layout where we now
  copy the test images into the build/testsuite area, resulted in HUGE
  GHA build artifacts for failed tests. Modify ci.yml use of
  upload-artifact action to exclude those directories.
