### PR TITLE
tiffoutput: support ioproxy

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1952,6 +1952,10 @@ aspects of the writing itself:
      - int
      - Overrides TIFF scanline rows per strip with a specific request (if
        not supplied, OIIO will choose a reasonable default).
+   * - ``oiio:ioproxy``
+     - ptr
+     - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
+       example by writing to memory rather than the file system.
 
 
 **TIFF compression modes**

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -58,9 +58,14 @@ public:
                              const void* data, stride_t xstride = AutoStride,
                              stride_t ystride = AutoStride,
                              stride_t zstride = AutoStride) override;
-
+    virtual bool set_ioproxy(Filesystem::IOProxy* ioproxy) override
+    {
+        m_io = ioproxy;
+        return true;
+    }
 private:
     TIFF* m_tif;
+    Filesystem::IOProxy* m_io = nullptr;
     std::vector<unsigned char> m_scratch;
     Timer m_checkpointTimer;
     int m_checkpointItems;
@@ -79,7 +84,8 @@ private:
     // Initialize private members to pre-opened state
     void init(void)
     {
-        m_tif                 = NULL;
+        m_tif                 = nullptr;
+        m_io                  = nullptr;
         m_checkpointItems     = 0;
         m_compression         = COMPRESSION_ADOBE_DEFLATE;
         m_predictor           = PREDICTOR_NONE;
@@ -295,6 +301,8 @@ TIFFOutput::supports(string_view feature) const
         return true;
     if (feature == "iptc")
         return true;
+    if (feature == "ioproxy")
+        return true;
     // N.B. TIFF doesn't support arbitrary metadata.
 
     // FIXME: we could support "volumes" and "empty"
@@ -315,6 +323,56 @@ allval(const std::vector<T>& d, T v = T(0))
     return std::all_of(d.begin(), d.end(), [&](const T& a) { return a == v; });
 }
 
+static tsize_t
+readproc(thandle_t, tdata_t, tsize_t)
+{
+    return 0;
+}
+
+static tsize_t
+writeproc(thandle_t handle, tdata_t data, tsize_t size)
+{
+    auto io = static_cast<Filesystem::IOProxy*>(handle);
+    return io->write(data, size);
+}
+
+static toff_t
+seekproc(thandle_t handle, toff_t offset, int origin)
+{
+    auto io = static_cast<Filesystem::IOProxy*>(handle);
+    // Strutil::print("iop seek {} {} ({})\n",
+    //                io->filename(), offset, origin);
+    return (io->seek(offset, origin)) ? toff_t(io->tell()) : toff_t(-1);
+}
+
+static int
+closeproc(thandle_t handle)
+{
+    // auto io = static_cast<Filesystem::IOProxy*>(handle);
+    // if (io && io->opened()) {
+    //     // Strutil::print("iop close {}\n\n",
+    //     //                io->filename());
+    //     // io->seek(0);
+    //     io->close();
+    // }
+    return 0;
+}
+
+static toff_t
+sizeproc(thandle_t handle)
+{
+    auto io = static_cast<Filesystem::IOProxy*>(handle);
+    // Strutil::print("iop size\n");
+    return toff_t(io->size());
+}
+
+static int
+mapproc(thandle_t, tdata_t*, toff_t*)
+{
+    return 0;
+}
+
+static void unmapproc(thandle_t, tdata_t, toff_t) {}
 
 
 bool
@@ -354,14 +412,26 @@ TIFFOutput::open(const std::string& name, const ImageSpec& userspec,
             return false;
         }
     }
-
+    {
+        const ParamValue* param = m_spec.find_attribute("oiio:ioproxy",
+                                                        TypeDesc::PTR);
+        if (param)
+            m_io = param->get<Filesystem::IOProxy*>();
+    }
     // Open the file
+    if (m_io) {
+        m_io->seek(0);
+        m_tif = TIFFClientOpen(name.c_str(), mode == AppendSubimage ? "a" : "w", m_io, readproc,
+                               writeproc, seekproc, closeproc, sizeproc,
+                               mapproc, unmapproc);
+    } else {
 #ifdef _WIN32
-    std::wstring wname = Strutil::utf8_to_utf16(name);
-    m_tif = TIFFOpenW(wname.c_str(), mode == AppendSubimage ? "a" : "w");
+        std::wstring wname = Strutil::utf8_to_utf16(name);
+        m_tif = TIFFOpenW(wname.c_str(), mode == AppendSubimage ? "a" : "w");
 #else
-    m_tif = TIFFOpen(name.c_str(), mode == AppendSubimage ? "a" : "w");
+        m_tif = TIFFOpen(name.c_str(), mode == AppendSubimage ? "a" : "w");
 #endif
+    }
     if (!m_tif) {
         errorf("Could not open \"%s\"", name);
         return false;


### PR DESCRIPTION
## Description

Add support for the IOProxy functionnality to tiffoutput. 
I just did the same pretty much as what was done in tiffinput
Please review or ignore - I don't have much time to make more changes on this

## Tests

DIdn't add a test

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

