### PR TITLE
Fix ImageBuf::read bug for images of mixed per-channel data types

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1142,9 +1142,10 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
                 ok &= in->seek_subimage(subimage, miplevel, newspec);
             }
             if (ok) {
-                ok &= in->read_image(chbegin, chend, convert, m_localpixels,
-                                     AutoStride, AutoStride, AutoStride,
-                                     progress_callback, progress_callback_data);
+                ok &= in->read_image(chbegin, chend, m_spec.format,
+                                     m_localpixels, AutoStride, AutoStride,
+                                     AutoStride, progress_callback,
+                                     progress_callback_data);
             }
 
             in->close();


### PR DESCRIPTION
When it comes time to read_image() into the ImageBuf's internal
memory, we should have said to convert to `m_spec.format`, which
describes the buffer we allocated. Instead, we asked for `convert`,
which is the user request, which at that time can still be UNKNOWN,
which indicates to preserve the file's data format, which in fact does
not necessarily match the internal buffer.

This becomes especially troublesome for images with mixed per-channel
data types, which will obviously never match the internal buffer since
ImageBuf only internally stores one data format for all channels.

Fixes #2691