### PR TITLE
Rewrite ColorConfig::reset for clearer logic and better err handling

### DIFF
--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -86,6 +86,9 @@ public:
 
     /// Has an error string occurred?
     /// (This will not affect the error state.)
+    bool has_error() const;
+
+    /// DEPRECATED(2.4), old name for has_error().
     bool error() const;
 
     /// This routine will return the error string (and by default, clear any

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -2058,6 +2058,9 @@ set_colorconfig(int argc, const char* argv[])
 {
     OIIO_DASSERT(argc == 2);
     ot.colorconfig.reset(argv[1]);
+    if (ot.colorconfig.has_error()) {
+        ot.errorfmt("--colorconfig", "{}", ot.colorconfig.geterror());
+    }
     return 0;
 }
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -392,17 +392,18 @@ Oiiotool::process_pending()
 void
 Oiiotool::error(string_view command, string_view explanation) const
 {
-    std::cerr << "oiiotool ERROR";
+    auto& errstream(ot.nostderr ? std::cout : std::cerr);
+    errstream << "oiiotool ERROR";
     if (command.size())
-        std::cerr << ": " << command;
+        errstream << ": " << command;
     if (explanation.size())
-        std::cerr << " : " << explanation;
+        errstream << " : " << explanation;
     else
-        std::cerr << " (unknown error)";
-    std::cerr << "\n";
+        errstream << " (unknown error)";
+    errstream << "\n";
     // Repeat the command line, so if oiiotool is being called from a
     // script, it's easy to debug how the command was mangled.
-    std::cerr << "Full command line was:\n> " << full_command_line << "\n";
+    errstream << "Full command line was:\n> " << full_command_line << "\n";
     ap.abort();  // Cease further processing of the command line
     ot.return_value = EXIT_FAILURE;
 }
@@ -412,14 +413,15 @@ Oiiotool::error(string_view command, string_view explanation) const
 void
 Oiiotool::warning(string_view command, string_view explanation) const
 {
-    std::cerr << "oiiotool WARNING";
+    auto& errstream(ot.nostderr ? std::cout : std::cerr);
+    errstream << "oiiotool WARNING";
     if (command.size())
-        std::cerr << ": " << command;
+        errstream << ": " << command;
     if (explanation.size())
-        std::cerr << " : " << explanation;
+        errstream << " : " << explanation;
     else
-        std::cerr << " (unknown warning)";
-    std::cerr << "\n";
+        errstream << " (unknown warning)";
+    errstream << "\n";
 }
 
 
@@ -5544,6 +5546,9 @@ getargs(int argc, char* argv[])
       .action(set_autotile);
     ap.arg("--metamerge", &ot.metamerge)
       .help("Always merge metadata of all inputs into output");
+    ap.arg("--nostderr", &ot.nostderr)
+      .help("Do not use stderr, output error messages to stdout")
+      .hidden();
     ap.arg("--crash")
       .hidden()
       .action(crash_me);
@@ -6009,11 +6014,12 @@ getargs(int argc, char* argv[])
     // clang-format on
 
     if (ap.parse_args(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
+        auto& errstream(ot.nostderr ? std::cout : std::cerr);
+        errstream << ap.geterror() << std::endl;
         print_help(ap);
         // Repeat the command line, so if oiiotool is being called from a
         // script, it's easy to debug how the command was mangled.
-        std::cerr << "\nFull command line was:\n> " << ot.full_command_line
+        errstream << "\nFull command line was:\n> " << ot.full_command_line
                   << "\n";
         ap.abort();
         ot.return_value = EXIT_FAILURE;

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -90,6 +90,7 @@ public:
     int frame_padding;
     bool eval_enable;              // Enable evaluation of expressions
     bool skip_bad_frames = false;  // Just skip a bad frame, don't exit
+    bool nostderr        = false;  // If true, use stdout for errors
     std::string full_command_line;
     std::string printinfo_metamatch;
     std::string printinfo_nometamatch;

--- a/testsuite/oiiotool-color/ref/out-ocio1.1.0.txt
+++ b/testsuite/oiiotool-color/ref/out-ocio1.1.0.txt
@@ -1,7 +1,9 @@
 oiiotool ERROR: --colorconfig : Requested non-existant OCIO config "missing.ocio"
 Full command line was:
 > oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio --nostderr --colorconfig missing.ocio -echo "Nonexistant config"
-OCIOv2 config Ok
+oiiotool ERROR: --colorconfig : Error reading OCIO config "../common/OpenColorIO/ocio-v2_demo.ocio": Error: Loading the OCIO profile '../common/OpenColorIO/ocio-v2_demo.ocio' failed. View 'ACES 1.1 HDR-video (1000 nits)' does not specify colorspace.
+Full command line was:
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio --nostderr --colorconfig ../common/OpenColorIO/ocio-v2_demo.ocio -echo "OCIOv2 config Ok"
 Comparing "colormap-inferno.tif" and "ref/colormap-inferno.tif"
 PASS
 Comparing "colormap-custom.tif" and "ref/colormap-custom.tif"

--- a/testsuite/oiiotool-color/ref/out-ocio1.1.0b.txt
+++ b/testsuite/oiiotool-color/ref/out-ocio1.1.0b.txt
@@ -1,7 +1,9 @@
 oiiotool ERROR: --colorconfig : Requested non-existant OCIO config "missing.ocio"
 Full command line was:
 > oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio --nostderr --colorconfig missing.ocio -echo "Nonexistant config"
-OCIOv2 config Ok
+oiiotool ERROR: --colorconfig : Error reading OCIO config "../common/OpenColorIO/ocio-v2_demo.ocio": Error: Loading the OCIO profile '../common/OpenColorIO/ocio-v2_demo.ocio' failed. Unsupported transform type !<BuiltinTransform> in OCIO profile. 
+Full command line was:
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio --nostderr --colorconfig ../common/OpenColorIO/ocio-v2_demo.ocio -echo "OCIOv2 config Ok"
 Comparing "colormap-inferno.tif" and "ref/colormap-inferno.tif"
 PASS
 Comparing "colormap-custom.tif" and "ref/colormap-custom.tif"

--- a/testsuite/oiiotool-color/run.py
+++ b/testsuite/oiiotool-color/run.py
@@ -62,10 +62,13 @@ command += oiiotool ("--autocc " + oiiotoolsrcdir+"/tahoe-tiny.tif"+
                      + "--ccmatrix 0.805,0.506,-0.311,0,-0.311,0.805,0.506,0,0.506,-0.311,0.805,0,0,0,0,1 "
                      + "-d uint8 -o tahoe-ccmatrix.tif")
 
-# test what happens when we read an OCIOv2 config. In particular, when
-# building against OCIOv1, we should at worst have an error message, not crash
-# with an uncaught exception.
-command += oiiotool ("--colorconfig ../common/OpenColorIO/ocio-v2_demo.ocio -echo 'OCIOv2 config Ok'")
+# test various behaviors and misbehaviors related to OCIO configs.
+command += oiiotool ("--nostderr --colorconfig missing.ocio -echo 'Nonexistant config'", failureok=True)
+
+#   What happens when we read an OCIOv2 config? In particular, when building
+#   against OCIOv1, we should at worst have an error message, not crash with
+#   an uncaught exception.
+command += oiiotool ("--nostderr --colorconfig ../common/OpenColorIO/ocio-v2_demo.ocio -echo 'OCIOv2 config Ok'", failureok=True)
 
 
 # To add more tests, just append more lines like the above and also add

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -291,12 +291,14 @@ def testtex_command (file, extraargs="", silent=False, concat=True) :
 
 
 # Construct a command that will run oiiotool and append its output to out.txt
-def oiiotool (args, silent=False, concat=True) :
+def oiiotool (args, silent=False, concat=True, failureok=False) :
     cmd = (oiio_app("oiiotool") + " "
            + "-colorconfig " + colorconfig_file + " "
            + args)
     if not silent :
         cmd += redirect
+    if failureok :
+        cmd += " || true "
     if concat:
         cmd += " ;\n"
     return cmd


### PR DESCRIPTION
Add tests to be sure we have reasonable error reporting for at least
two important cases: a specified OCIO config file is not found at all,
and an OCIO config is present but cannot be read (in particular, if
the config is newer than the library). Because the exact error spewage
is different for each OCIO version, and apparently also depending on
the exact version of the yaml library that OCIO used, we have a few
different possible output references.

