### PR TITLE
Adjust logic of getting OCIO config

### DIFF
--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -30,3 +30,6 @@ endif ()
 include ("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 
 check_required_components ("@PROJECT_NAME@")
+
+# Set a CMake variable that says if this OpenImageIO build has OCIO support
+set (@PROJECT_NAME@_HAS_OpenColorIO @OPENCOLORIO_FOUND@)

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -164,6 +164,9 @@ checked_find_package (OpenColorIO
                       DEFINITIONS  -DUSE_OCIO=1 -DUSE_OPENCOLORIO=1
                       # PREFER_CONFIG
                       )
+if (NOT OPENCOLORIO_FOUND)
+    set (OPENCOLORIO_FOUND 0)
+endif ()
 checked_find_package (OpenCV 3.0
                    DEFINITIONS  -DUSE_OPENCV=1)
 

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -348,20 +348,6 @@ ColorConfig::reset(string_view filename)
         }
     }
 
-    if (!getImpl()->config_) {
-        if (!ocio_current_config) {
-            try {
-                ocio_current_config = OCIO::GetCurrentConfig();
-            } catch (OCIO::Exception& e) {
-                getImpl()->error("Error getting OCIO default config: {}",
-                                 e.what());
-            } catch (...) {
-                getImpl()->error("Error getting OCIO default config");
-            }
-        }
-        getImpl()->config_ = ocio_current_config;
-    }
-
     ok = getImpl()->config_.get() != nullptr;
 #endif
 


### PR DESCRIPTION
When $OCIO was not set at all, the call to OCIO::GetCurrentConfig()
was checking it again and writing the info message that none was found
to stdout, which we really don't want.  And as Patrick pointed out
recently, asking for the "current" config is suspect, since who knows
exatly what the app has done.

So we're making the following executive decision: At least from OIIO's
viewpoint, if you want an OCIO color config, you either have to name it
expliticly, or have it determined by the `$OCIO` env variable. That makes
cleaner logic, and also rids us of the info messages.

I also now have the exported cmake config set
`OpenImageIO_HAS_OpenColorIO`. This makes it easier for downstream
consumers of our exported OpenImageIOConfig.cmake to know if the OIIO
build they have found has build-in support of OpenColorIO.

