### PR TITLE
Always have OpenEXRCore C library on tap -- with option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,8 @@ jobs:
       PYBIND11_VERSION: master
       PYTHON_VERSION: 3.8
       WEBP_VERSION: master
-      MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=master -DOIIO_USE_EXR_C_API=ON
+      MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=master
+      OPENIMAGEIO_OPTIONS: "openexr:core=1"
       USE_OPENVDB: 0
       # The old installed OpenVDB has a TLS conflict with Python 3.8
     steps:

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2543,6 +2543,11 @@ OIIO_API std::string geterror(bool clear = true);
 ///    may not read these correctly, but OIIO will. That's why the default
 ///    is not to support it.
 ///
+/// - `int openexr:core`
+///
+///    When nonzero, use the new "OpenEXR core C library" when available,
+///    for OpenEXR >= 3.1. This is experimental, and currently defaults to 0.
+///
 /// - `int log_times`
 ///
 ///    When the `"log_times"` attribute is nonzero, `ImageBufAlgo` functions

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -37,6 +37,7 @@ recursive_mutex imageio_mutex;
 atomic_int oiio_threads(threads_default());
 atomic_int oiio_exr_threads(threads_default());
 atomic_int oiio_read_chunk(256);
+int openexr_core(0);  // Should we use "Exr core C library"?
 int tiff_half(0);
 int tiff_multithread(1);
 ustring font_searchpath;
@@ -318,6 +319,10 @@ attribute(string_view name, TypeDesc type, const void* val)
         oiio_exr_threads = OIIO::clamp(*(const int*)val, -1, maxthreads);
         return true;
     }
+    if (name == "openexr:core" && type == TypeInt) {
+        openexr_core = *(const int*)val;
+        return true;
+    }
     if (name == "tiff:half" && type == TypeInt) {
         tiff_half = *(const int*)val;
         return true;
@@ -407,6 +412,10 @@ getattribute(string_view name, TypeDesc type, void* val)
     }
     if (name == "exr_threads" && type == TypeInt) {
         *(int*)val = oiio_exr_threads;
+        return true;
+    }
+    if (name == "openexr:core" && type == TypeInt) {
+        *(int*)val = openexr_core;
         return true;
     }
     if (name == "tiff:half" && type == TypeInt) {

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -34,6 +34,7 @@ extern std::string extension_list;
 extern std::string library_list;
 extern int oiio_print_debug;
 extern int oiio_log_times;
+extern int openexr_core;
 
 
 // For internal use - use error() below for a nicer interface.

--- a/src/openexr.imageio/CMakeLists.txt
+++ b/src/openexr.imageio/CMakeLists.txt
@@ -2,17 +2,17 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
-option (OIIO_USE_EXR_C_API "Use the new 3.1 C API for exr I/O" OFF)
-if (OIIO_USE_EXR_C_API)
-  if (NOT TARGET OpenEXR::OpenEXRCore)
-    message(FATAL_ERROR "OpenEXR find did not find the new C library")
-  endif()
-  add_oiio_plugin (exrinput_c.cpp exroutput.cpp
-    INCLUDE_DIRS ${OPENEXR_INCLUDES} ${IMATH_INCLUDE_DIR}/OpenEXR
-    LINK_LIBRARIES OpenEXR::OpenEXRCore)
-else()
-  add_oiio_plugin (exrinput.cpp exroutput.cpp
-    INCLUDE_DIRS ${OPENEXR_INCLUDES} ${IMATH_INCLUDE_DIR}/OpenEXR
-    LINK_LIBRARIES ${OPENEXR_LIBRARIES})
+set (openexr_src exrinput.cpp exroutput.cpp)
+
+option (OIIO_USE_EXR_C_API "Allow use of the new exr 3.1 C API if available" ON)
+if (OIIO_USE_EXR_C_API AND TARGET OpenEXR::OpenEXRCore)
+    set (openexr_defs OIIO_USE_EXR_C_API=1)
+    list (APPEND openexr_src exrinput_c.cpp)
 endif()
 
+add_oiio_plugin (${openexr_src}
+    INCLUDE_DIRS ${OPENEXR_INCLUDES} ${IMATH_INCLUDE_DIR}/OpenEXR
+    LINK_LIBRARIES ${OPENEXR_LIBRARIES}
+                   $<TARGET_NAME_IF_EXISTS:OpenEXR::OpenEXRCore>
+    DEFINITIONS ${openexr_defs}
+    )

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -83,6 +83,10 @@ OIIO_PRAGMA_VISIBILITY_POP
 
 #include <OpenEXR/ImfCRgbaFile.h>
 
+#if OPENEXR_CODED_VERSION >= 30100 && defined(OIIO_USE_EXR_C_API)
+#    define USE_OPENEXR_CORE
+#endif
+
 #include "imageio_pvt.h"
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
@@ -287,6 +291,13 @@ OIIO_PLUGIN_EXPORTS_BEGIN
 OIIO_EXPORT ImageInput*
 openexr_input_imageio_create()
 {
+#ifdef USE_OPENEXR_CORE
+    if (pvt::openexr_core) {
+        // Strutil::print("selecting core\n");
+        extern ImageInput* openexrcore_input_imageio_create();
+        return openexrcore_input_imageio_create();
+    }
+#endif
     return new OpenEXRInput;
 }
 


### PR DESCRIPTION
Instead of a build-time option for enabling (and always using) the
experimental OpenEXR "core" library...

* Build support for it by default any time we're using a new enough
  OpenEXR version (>= 3.1). You can still hard-disable it being compiled
  in at all with `-DOIIO_USE_EXR_C_API=OFF`.

* Select whether it's actually used with the global OIIO attribute
  "openexr:core" (default to 0, disabled, for now).

This easily lets an app select support at runtime, and also may be
selected by user with environment variable
`OPENIMAGEIO_OPTIONS="openexr:core=1".

This all is intended to make it easier to benchmark use of this new
feature, switching back and forth without a rebuild.
