### PR TITLE
Build: fix over-eager use of targets

### DIFF
--- a/src/build-scripts/build_webp.bash
+++ b/src/build-scripts/build_webp.bash
@@ -18,6 +18,7 @@ LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}
 WEBP_SRC_DIR=${WEBP_SRC_DIR:=${LOCAL_DEPS_DIR}/webp}
 WEBP_BUILD_DIR=${WEBP_BUILD_DIR:=${WEBP_SRC_DIR}/build}
 WEBP_INSTALL_DIR=${WEBP_INSTALL_DIR:=${LOCAL_DEPS_DIR}/dist}
+WEBP_BUILD_TYPE=${WEBP_BUILD_TYPE:=${CMAKE_BUILD_TYPE:-Release}}
 #WEBP_CONFIG_OPTS=${WEBP_CONFIG_OPTS:=}
 
 pwd
@@ -40,7 +41,7 @@ mkdir -p ${WEBP_BUILD_DIR}
 cd ${WEBP_BUILD_DIR}
 
 if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
-    time cmake -DCMAKE_BUILD_TYPE=Release \
+    time cmake -DCMAKE_BUILD_TYPE=${WEBP_BUILD_TYPE} \
                -DCMAKE_INSTALL_PREFIX=${WEBP_INSTALL_DIR} \
                -DWEBP_BUILD_ANIM_UTILS=OFF \
                -DWEBP_BUILD_CWEBP=OFF \
@@ -51,7 +52,7 @@ if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
                -DWEBP_BUILD_EXTRAS=OFF \
                -DBUILD_SHARED_LIBS=ON \
                ${WEBP_CONFIG_OPTS} ..
-    time cmake --build . --config Release --target install
+    time cmake --build . --target install
 fi
 
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -158,8 +158,6 @@ endif ()
 checked_find_package (Freetype
                    DEFINITIONS  -DUSE_FREETYPE=1 )
 
-checked_find_package (HDF5
-                   ISDEPOF      Field3D)
 checked_find_package (OpenColorIO
                       DEFINITIONS  -DUSE_OCIO=1 -DUSE_OPENCOLORIO=1
                       # PREFER_CONFIG
@@ -179,8 +177,7 @@ checked_find_package (TBB 2017
 checked_find_package (DCMTK VERSION_MIN 3.6.1)  # For DICOM images
 checked_find_package (FFmpeg VERSION_MIN 3.0)
 checked_find_package (Field3D
-                   DEPS         HDF5
-                   DEFINITIONS  -DUSE_FIELD3D=1)
+                      DEFINITIONS  -DUSE_FIELD3D=1)
 checked_find_package (GIF
                       VERSION_MIN 4
                       RECOMMEND_MIN 5.0

--- a/src/cmake/modules/FindLibsquish.cmake
+++ b/src/cmake/modules/FindLibsquish.cmake
@@ -11,6 +11,7 @@
 # LIBSQUISH_VERSION          Version of Libsquish (e.g., 3.6.2)
 
 include (FindPackageHandleStandardArgs)
+include (SelectLibraryConfigurations)
 
 find_path (LIBSQUISH_INCLUDE_DIR squish.h
            HINTS
@@ -18,11 +19,11 @@ find_path (LIBSQUISH_INCLUDE_DIR squish.h
                ENV LIBSQUISH_INCLUDE_PATH
            DOC "The directory where Libsquish headers reside")
 
-find_library (LIBSQUISH_LIBRARY squish
-              HINTS
-                  ${LIBSQUISH_LIBRARY_PATH}
-                  ENV LIBSQUISH_LIBRARY_PATH
-              DOC "The Libsquish libraries")
+find_library (LIBSQUISH_LIBRARY_RELEASE squish
+              HINTS ${LIBSQUISH_LIBRARY_PATH} ENV LIBSQUISH_LIBRARY_PATH)
+find_library (LIBSQUISH_LIBRARY_DEBUG squishd
+              HINTS ${LIBSQUISH_LIBRARY_PATH} ENV LIBSQUISH_LIBRARY_PATH)
+select_library_configurations(LIBSQUISH)
 
 find_package_handle_standard_args (Libsquish
     REQUIRED_VARS
@@ -32,15 +33,33 @@ find_package_handle_standard_args (Libsquish
 
 if (Libsquish_FOUND)
     set (LIBSQUISH_INCLUDES ${LIBSQUISH_INCLUDE_DIR})
-    set (LIBSQUISH_LIBRARIES ${LIBSQUISH_LIBRARY})
+    if (NOT LIBSQUISH_LIBRARIES)
+        set (LIBSQUISH_LIBRARIES ${LIBSQUISH_LIBRARY})
+    endif ()
 
     if (NOT TARGET Libsquish::Libsquish)
         add_library(Libsquish::Libsquish UNKNOWN IMPORTED)
         set_target_properties(Libsquish::Libsquish PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES "${LIBSQUISH_INCLUDES}")
 
-        set_property(TARGET Libsquish::Libsquish APPEND PROPERTY
-            IMPORTED_LOCATION "${LIBSQUISH_LIBRARIES}")
+        if (LIBSQUISH_LIBRARY_RELEASE)
+            set_property(TARGET Libsquish::Libsquish APPEND PROPERTY
+              IMPORTED_CONFIGURATIONS RELEASE)
+            set_target_properties(Libsquish::Libsquish PROPERTIES
+              IMPORTED_LOCATION_RELEASE "${LIBSQUISH_LIBRARY_RELEASE}")
+        endif ()
+
+        if (LIBSQUISH_LIBRARY_DEBUG)
+            set_property(TARGET Libsquish::Libsquish APPEND PROPERTY
+              IMPORTED_CONFIGURATIONS DEBUG)
+            set_target_properties(Libsquish::Libsquish PROPERTIES
+              IMPORTED_LOCATION_DEBUG "${LIBSQUISH_LIBRARY_DEBUG}")
+        endif ()
+
+        if (NOT LIBSQUISH_LIBRARY_RELEASE AND NOT LIBSQUISH_LIBRARY_DEBUG)
+            set_property(TARGET Libsquish::Libsquish APPEND PROPERTY
+              IMPORTED_LOCATION "${LIBSQUISH_LIBRARY}")
+        endif ()
     endif ()
 endif ()
 

--- a/src/dds.imageio/CMakeLists.txt
+++ b/src/dds.imageio/CMakeLists.txt
@@ -5,7 +5,8 @@
 if (Libsquish_FOUND)
     # External libsquish was found -- use it
     add_oiio_plugin (ddsinput.cpp
-                     LINK_LIBRARIES Libsquish::Libsquish
+                     INCLUDE_DIRS ${LIBSQUISH_INCLUDES}
+                     LINK_LIBRARIES ${LIBSQUISH_LIBRARIES}
                      )
 else ()
     # No external libsquish was found -- use the embedded version.

--- a/src/field3d.imageio/CMakeLists.txt
+++ b/src/field3d.imageio/CMakeLists.txt
@@ -3,13 +3,14 @@
 # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
 if (Field3D_FOUND)
+    # checked_find_package (HDF5)
     find_library (SZIP_LIBRARY NAMES sz)
     if (NOT SZIP_LIBRARY)
         set (SZIP_LIBRARY "")
     endif ()
     add_oiio_plugin (field3dinput.cpp field3doutput.cpp
                      INCLUDE_DIRS ${FIELD3D_INCLUDES}
-                     LINK_LIBRARIES Field3D::Field3D
+                     LINK_LIBRARIES ${FIELD3D_LIBRARIES}
                                     # ${HDF5_LIBRARIES}
                                     ${SZIP_LIBRARY})
 endif()

--- a/src/heif.imageio/CMakeLists.txt
+++ b/src/heif.imageio/CMakeLists.txt
@@ -4,7 +4,8 @@
 
 if (Libheif_FOUND)
     add_oiio_plugin (heifinput.cpp heifoutput.cpp
-                     LINK_LIBRARIES Libheif::Libheif
+                     INCLUDE_DIRS ${LIBHEIF_INCLUDES}
+                     LINK_LIBRARIES ${LIBHEIF_LIBRARIES}
                      DEFINITIONS "-DUSE_HEIF=1")
 else ()
     message (WARNING "heif plugin will not be built")

--- a/src/openvdb.imageio/CMakeLists.txt
+++ b/src/openvdb.imageio/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 if (OpenVDB_FOUND)
     add_oiio_plugin (openvdbinput.cpp
-                     INCLUDE_DIRS ${TBB_INCLUDE_DIRS}
-                     LINK_LIBRARIES OpenVDB::OpenVDB ${TBB_tbb_LIBRARY} ${BOOST_LIBRARIES})
+                     INCLUDE_DIRS ${OPENVDB_INCLUDES} ${TBB_INCLUDE_DIRS}
+                     LINK_LIBRARIES ${OPENVDB_LIBRARIES}
+                                    ${TBB_tbb_LIBRARY} ${BOOST_LIBRARIES})
 endif()

--- a/src/webp.imageio/CMakeLists.txt
+++ b/src/webp.imageio/CMakeLists.txt
@@ -4,7 +4,8 @@
 
 if (WebP_FOUND)
     add_oiio_plugin (webpinput.cpp webpoutput.cpp
-                     LINK_LIBRARIES WebP::WebP WebP::WebPDemux
+                     INCLUDE_DIRS ${WEBP_INCLUDES}
+                     LINK_LIBRARIES ${WEBP_LIBRARIES}
                      DEFINITIONS "-DUSE_WEBP=1")
 else ()
     message (STATUS "WebP plugin will not be built")


### PR DESCRIPTION
Background: Old style CMake was to use FindFoo.cmake modules, which
set FOO_INCLUDES and FOO_LIBRARIES variables. Best new cmake practices
are for the upstream packages themselves to export a FooConfig.cmake
and friends, which set up cmake targets. Of course, many packages don't
provide exported configs, so we use the old Find modules for many of
our dependencies.

I've slowly been migrating our Find modules to set up targets in addition
to the variables, and favoring use of the targets over the variables.

But I was wrong about this. It's more than just a choice of style.
When targets are used, use of transitive linkage (especially for static
library versions of dependencies) make the dependency targets show up in
our own exported OpenImageIOConfig.cmake. But to a downstream package,
now our config talks about a target like Libsquish::Libsquish, but it
doesn't know what that is, and it doesn't have the FindLibsquish.cmake
module that we used (internally) when we found that dependency.

This was causing particular problems for Libsquish on Windows with
vcpkg, but I see now that this could be a problem elsewhere as well:
field3d, libheif, openvdb, and webp.

So this patch:

* Reverts from the ill-advised targets back to the old style
  variables, for the dependencies where we use *custom* Find modules.
  (We presume that a dependency's exported configs, as well as any
  Find modules that are distributed as part of CMake itself and define
  targets, are done correctly, and will be available to downstream
  packages, and so we continue to use targets in those cases.)

* Beefs up our FindLibsquish.cmake module to correctly find debug
  versions of the library, to use in debug builds.

* Alters build_webp.bash to allow WEBP_BUILD_TYPE to override the build
  type, which had previously been hard-coded to Release.

* Removes search for HDF5, which as far as I can tell was unused
  directly by OIIO.

