### PR TITLE
TIFF output: Honor zip quality request when we do our own compression

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1944,10 +1944,10 @@ aspects of the writing itself:
        ``ITULAB``.
    * - ``tiff:zipquality``
      - int
-     - A time-vs-quality knob for ``zip`` compression, ranging from 1-9
+     - A time-vs-space knob for ``zip`` compression, ranging from 1-9
        (default is 6). Higher means compress to less space, but taking
-       longer to do so. It is strictly a time vs space tradeoff, the quality
-       is identical (lossless) no matter what the setting.
+       longer to do so. It is strictly a time vs space tradeoff, the visual
+       image quality is identical (lossless) no matter what the setting.
    * - ``tiff:RowsPerStrip``
      - int
      - Overrides TIFF scanline rows per strip with a specific request (if


### PR DESCRIPTION
We were already passing this on to libtiff when it handles the
compression.  But for the case where we were calling zlib ourselves
(to facilitate multi-thread compression, which libtiff doesn't do),
we were just using the default compression.

This is inspired by a great [blog post](https://aras-p.info/blog/2021/08/05/EXR-Zip-compression-levels/)
by Aras Pranckevičius in which he made a similar change to OpenEXR
and benchmarked the results. He reported approximately a slightly more
than 2x write speed increase, while getting files that were only around
2% larger.

I tried replicating his experiment for TIFF, and while I don't quite
get results as good as he did, it still is really interesting.  I
tested with 100 images randomly selected from the [Animal Logic Lab
USD scene](https://animallogic.com/usd-alab/) (they are almost all
4k^2, a mix of 1- and 3-channel images), converted from half exr to
uint16 TIFF images. I ran the tests for both scanline and tiled
images.

Compared to the default zip level 6, using level 4 resulted in 3%
bigger files, and around 40% faster write times. That seems like it
is a potentially very helpful tradeoff.

I tested the same set of images also with zip levels 8 and 2. For
level 8, the files were only another 2% smaller than the default level
6, but the write speed was 45-50% slower, so there is little value to
asking it to work harder on compression -- it just burns up time. For
level 2, it went somewhat faster (maybe another 10% faster than level
4) but the files started getting bigger, level 2 was 12% bigger than
level 6, that's definitely getting into territory where people might
mind the larger files.

So I want to add the control now, though I'm deferring a decision on
changing the default value until I can do some more extensive
tests. In particular, I would like to assess how it behaves with 8 bit
files (I was testing uint16, specifically), how well it works with
rendered images and with natural/photographic images (I was testing a
set of textures, which may not have the same characteristics), and
perhaps also see if results are better or worse for lower resolution
images.
