### PR TITLE
Build: Add ENABLE_INSTALL_testtex option

### DIFF
--- a/src/cmake/fancy_add_executable.cmake
+++ b/src/cmake/fancy_add_executable.cmake
@@ -12,6 +12,9 @@
 # The executable may be disabled individually using any of the usual
 # check_is_enabled() conventions (e.g. -DENABLE_<executable>=OFF).
 #
+# If -DENABLE_INSTALL_<executable>=OFF was specified, the target will be built
+# (in the build area) but will not be installed.
+#
 # Usage:
 #
 #   fancy_add_executable ([ NAME targetname ... ]
@@ -48,7 +51,10 @@ macro (fancy_add_executable)
             target_link_libraries (${_target_NAME} PRIVATE ${_target_LINK_LIBRARIES})
         endif ()
         set_target_properties (${_target_NAME} PROPERTIES FOLDER "Tools")
-        install_targets (${_target_NAME})
+        check_is_enabled (INSTALL_${_target_NAME} _target_NAME_INSTALL_enabled)
+        if (_target_NAME_INSTALL_enabled)
+            install_targets (${_target_NAME})
+        endif ()
     else ()
         message (STATUS "${ColorRed}Disabling ${_target_NAME} ${ColorReset}")
     endif ()

--- a/src/testtex/CMakeLists.txt
+++ b/src/testtex/CMakeLists.txt
@@ -2,8 +2,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
 
-set (testtex_srcs testtex.cpp)
-add_executable (testtex ${testtex_srcs})
-target_include_directories (testtex PRIVATE ${ROBINMAP_INCLUDES})
-target_link_libraries (testtex PRIVATE OpenImageIO)
-set_target_properties (testtex PROPERTIES FOLDER "Tools")
+# testtex ordinarily gets built for testing but is not "installed". Setting
+# -DENABLE_INSTALL_testtex=ON will install this test program along with the
+# rest of the command line tools.  (Note: must be in PARENT_SCOPE or it would
+# be local to this directory and not override properly by command line `-D`.)
+set (ENABLE_INSTALL_testtex OFF PARENT_SCOPE)
+
+fancy_add_executable (NAME testtex
+                      INCLUDE_DIRS ${ROBINMAP_INCLUDES}
+                      LINK_LIBRARIES OpenImageIO )


### PR DESCRIPTION
If set to ON, will include the testtex program in the install.
The default is OFF, which builds it for tests, but doesn't install it
with the real command line utilities.
