### PR TITLE
Allow quotes in oiiotool command modifiers

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -69,7 +69,7 @@ The exceptions to this are non-positional flags, which affect the entire
 :program:`oiiotool` command regardless of where they appear on the command
 line.
 
-Optional arguments
+Optional modifiers
 -----------------------
 
 Some arguments stand completely on their own (like `--flip`), others take one
@@ -94,6 +94,9 @@ with colon separators. As an example:
     optional modifiers ---------+-----+--------+
     (separated by ':')
 
+The *value* itself may be a single- or double-quoted string, and this is how
+you would make a value that itself contains a `:` character (which would
+otherwise denote the beginning of the next modifier).
 
 Frame sequences
 -----------------------
@@ -3426,7 +3429,7 @@ current top image.
         font size (height, in pixels)
       `font=` *name*
         font name, full path to the font file on disk (use double quotes
-        `"name"` if the path name includes spaces)
+        `"name"` if the path name includes spaces or a colon)
       `color=` *r,g,b,...*
         specify the color of the text
       `xalign=` *val*

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -257,10 +257,11 @@ public:
     //     spec, such as "width", "ImageDescription", etc.
     string_view express(string_view str);
 
-    // Given a command with perhaps optional modifiers (for example,
-    // "--cmd:a=1:pi=3.14"), extract the options and insert them into a
-    // ParamValueList. For example, having attribute "a" with value "1"
-    // and attribute "pi" with value "3.14".
+    // Given a command with perhaps optional modifiers (a colon separated list
+    // of name=value options, for example, "--cmd:a=1:pi=3.14:foo='a b c'"),
+    // extract the options and insert them into a ParamValueList. For example,
+    // having attribute "a" with value "1" and attribute "pi" with value
+    // "3.14".
     static ParamValueList extract_options(string_view command);
 
     // Error base case -- single unformatted string.


### PR DESCRIPTION
Oiiotool::extract_options was kind of fishy and brittle before --
splitting the string at ':' characters, then split each piece (which
should form a `name=value` pattern) at the first '=' character. There
are probably many malformed option strings that would have had weird
results with the prior naive parsing method. And it has been noted
that it can't handle a value that is intended to be a Windows filename
(like "C:/foo"), nor a searchpath (like "/usr/bin:/usr/local/bin").

Rewrite to parse it more carefully as name=value pairs delimited by
':'. In the process, we now have the ability to have the value be
enclosed by a single or double quoted string, in which case the
contents of the quote may themselves contain a colon, for example, the
following command and modifier is now no longer a problem:
`--foo:filename='C:/blah':count=3`
