### PR TITLE
Use `inline constexpr` for C++17

### DIFF
--- a/src/doc/Doxyfile
+++ b/src/doc/Doxyfile
@@ -2166,6 +2166,7 @@ PREDEFINED             = DOXYGEN_SHOULD_SKIP_THIS \
                          OIIO_CONSTEXPR14=constexpr \
                          OIIO_CONSTEXPR17=constexpr \
                          OIIO_CONSTEXPR20=constexpr \
+                         OIIO_INLINE_CONSTEXPR="inline constexpr" \
                          OIIO_PURE_FUNC= \
                          OIIO_CONST_FUNC= \
                          OIIO_MAYBE_UNUSED= \

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -68,7 +68,7 @@
 //                    nothing (this is useful for things that can only be
 //                    constexpr for particular versions or greater).
 // OIIO_INLINE_CONSTEXPR : inline constexpr variables, added in C++17. For
-//                         older C++, just constexpr.
+//                         older C++, static constexpr.
 //
 // Note: oiioversion.h defines OIIO_BUILD_CPP (set to 14, 17, etc.)
 // reflecting what OIIO itself was *built* with.  In contrast,
@@ -92,7 +92,7 @@
 #    define OIIO_CPLUSPLUS_VERSION 14
 #    define OIIO_CONSTEXPR17 /* not constexpr before C++17 */
 #    define OIIO_CONSTEXPR20 /* not constexpr before C++20 */
-#    define OIIO_INLINE_CONSTEXPR constexpr
+#    define OIIO_INLINE_CONSTEXPR static constexpr
 #else
 #    error "This version of OIIO is meant to work only with C++14 and above"
 #endif

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -115,8 +115,8 @@ enum class InterpMode {
 /// The SIMD width for batched texturing operations. This is fixed within
 /// any release of OpenImageIO, but may change from release to release and
 /// also may be overridden at build time. A typical batch size is 16.
-static constexpr int BatchWidth = OIIO_TEXTURE_SIMD_BATCH_WIDTH;
-static constexpr int BatchAlign = BatchWidth * sizeof(float);
+OIIO_INLINE_CONSTEXPR int BatchWidth = OIIO_TEXTURE_SIMD_BATCH_WIDTH;
+OIIO_INLINE_CONSTEXPR int BatchAlign = BatchWidth * sizeof(float);
 
 /// A type alias for a SIMD vector of floats with the batch width.
 typedef simd::VecType<float, OIIO_TEXTURE_SIMD_BATCH_WIDTH>::type FloatWide;
@@ -135,15 +135,15 @@ typedef uint64_t RunMask;
 // The defined constant `RunMaskOn` contains the value with all bits
 // `0..BatchWidth-1` set to 1.
 #if OIIO_TEXTURE_SIMD_BATCH_WIDTH == 4
-static constexpr RunMask RunMaskOn = 0xf;
+OIIO_INLINE_CONSTEXPR RunMask RunMaskOn = 0xf;
 #elif OIIO_TEXTURE_SIMD_BATCH_WIDTH == 8
-static constexpr RunMask RunMaskOn = 0xff;
+OIIO_INLINE_CONSTEXPR RunMask RunMaskOn = 0xff;
 #elif OIIO_TEXTURE_SIMD_BATCH_WIDTH == 16
-static constexpr RunMask RunMaskOn = 0xffff;
+OIIO_INLINE_CONSTEXPR RunMask RunMaskOn = 0xffff;
 #elif OIIO_TEXTURE_SIMD_BATCH_WIDTH == 32
-static constexpr RunMask RunMaskOn = 0xffffffff;
+OIIO_INLINE_CONSTEXPR RunMask RunMaskOn = 0xffffffff;
 #elif OIIO_TEXTURE_SIMD_BATCH_WIDTH == 64
-static constexpr RunMask RunMaskOn = 0xffffffffffffffffULL;
+OIIO_INLINE_CONSTEXPR RunMask RunMaskOn = 0xffffffffffffffffULL;
 #else
 #    error "Not a valid OIIO_TEXTURE_SIMD_BATCH_WIDTH choice"
 #endif

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -370,40 +370,40 @@ struct OIIO_UTIL_API TypeDesc {
 // Static values for commonly used types. Because these are constexpr,
 // they should incur no runtime construction cost and should optimize nicely
 // in various ways.
-static constexpr TypeDesc TypeUnknown (TypeDesc::UNKNOWN);
-static constexpr TypeDesc TypeFloat (TypeDesc::FLOAT);
-static constexpr TypeDesc TypeColor (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::COLOR);
-static constexpr TypeDesc TypePoint (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::POINT);
-static constexpr TypeDesc TypeVector (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::VECTOR);
-static constexpr TypeDesc TypeNormal (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::NORMAL);
-static constexpr TypeDesc TypeMatrix33 (TypeDesc::FLOAT, TypeDesc::MATRIX33);
-static constexpr TypeDesc TypeMatrix44 (TypeDesc::FLOAT, TypeDesc::MATRIX44);
-static constexpr TypeDesc TypeMatrix = TypeMatrix44;
-static constexpr TypeDesc TypeFloat2 (TypeDesc::FLOAT, TypeDesc::VEC2);
-static constexpr TypeDesc TypeVector2 (TypeDesc::FLOAT, TypeDesc::VEC2, TypeDesc::VECTOR);
-static constexpr TypeDesc TypeFloat4 (TypeDesc::FLOAT, TypeDesc::VEC4);
-static constexpr TypeDesc TypeVector4 = TypeFloat4;
-static constexpr TypeDesc TypeString (TypeDesc::STRING);
-static constexpr TypeDesc TypeInt (TypeDesc::INT);
-static constexpr TypeDesc TypeUInt (TypeDesc::UINT);
-static constexpr TypeDesc TypeInt32 (TypeDesc::INT);
-static constexpr TypeDesc TypeUInt32 (TypeDesc::UINT);
-static constexpr TypeDesc TypeInt16 (TypeDesc::INT16);
-static constexpr TypeDesc TypeUInt16 (TypeDesc::UINT16);
-static constexpr TypeDesc TypeInt8 (TypeDesc::INT8);
-static constexpr TypeDesc TypeUInt8 (TypeDesc::UINT8);
-static constexpr TypeDesc TypeInt64 (TypeDesc::INT64);
-static constexpr TypeDesc TypeUInt64 (TypeDesc::UINT64);
-static constexpr TypeDesc TypeVector2i(TypeDesc::INT, TypeDesc::VEC2);
-static constexpr TypeDesc TypeBox2(TypeDesc::FLOAT, TypeDesc::VEC2, TypeDesc::BOX, 2);
-static constexpr TypeDesc TypeBox3(TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::BOX, 2);
-static constexpr TypeDesc TypeBox2i(TypeDesc::INT, TypeDesc::VEC2, TypeDesc::BOX, 2);
-static constexpr TypeDesc TypeBox3i(TypeDesc::INT, TypeDesc::VEC3, TypeDesc::BOX, 2);
-static constexpr TypeDesc TypeHalf (TypeDesc::HALF);
-static constexpr TypeDesc TypeTimeCode (TypeDesc::UINT, TypeDesc::SCALAR, TypeDesc::TIMECODE, 2);
-static constexpr TypeDesc TypeKeyCode (TypeDesc::INT, TypeDesc::SCALAR, TypeDesc::KEYCODE, 7);
-static constexpr TypeDesc TypeRational(TypeDesc::INT, TypeDesc::VEC2, TypeDesc::RATIONAL);
-static constexpr TypeDesc TypePointer(TypeDesc::PTR);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeUnknown (TypeDesc::UNKNOWN);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeFloat (TypeDesc::FLOAT);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeColor (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::COLOR);
+OIIO_INLINE_CONSTEXPR TypeDesc TypePoint (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::POINT);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeVector (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::VECTOR);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeNormal (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::NORMAL);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeMatrix33 (TypeDesc::FLOAT, TypeDesc::MATRIX33);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeMatrix44 (TypeDesc::FLOAT, TypeDesc::MATRIX44);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeMatrix = TypeMatrix44;
+OIIO_INLINE_CONSTEXPR TypeDesc TypeFloat2 (TypeDesc::FLOAT, TypeDesc::VEC2);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeVector2 (TypeDesc::FLOAT, TypeDesc::VEC2, TypeDesc::VECTOR);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeFloat4 (TypeDesc::FLOAT, TypeDesc::VEC4);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeVector4 = TypeFloat4;
+OIIO_INLINE_CONSTEXPR TypeDesc TypeString (TypeDesc::STRING);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeInt (TypeDesc::INT);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeUInt (TypeDesc::UINT);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeInt32 (TypeDesc::INT);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeUInt32 (TypeDesc::UINT);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeInt16 (TypeDesc::INT16);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeUInt16 (TypeDesc::UINT16);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeInt8 (TypeDesc::INT8);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeUInt8 (TypeDesc::UINT8);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeInt64 (TypeDesc::INT64);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeUInt64 (TypeDesc::UINT64);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeVector2i(TypeDesc::INT, TypeDesc::VEC2);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeBox2(TypeDesc::FLOAT, TypeDesc::VEC2, TypeDesc::BOX, 2);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeBox3(TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::BOX, 2);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeBox2i(TypeDesc::INT, TypeDesc::VEC2, TypeDesc::BOX, 2);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeBox3i(TypeDesc::INT, TypeDesc::VEC3, TypeDesc::BOX, 2);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeHalf (TypeDesc::HALF);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeTimeCode (TypeDesc::UINT, TypeDesc::SCALAR, TypeDesc::TIMECODE, 2);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeKeyCode (TypeDesc::INT, TypeDesc::SCALAR, TypeDesc::KEYCODE, 7);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeRational(TypeDesc::INT, TypeDesc::VEC2, TypeDesc::RATIONAL);
+OIIO_INLINE_CONSTEXPR TypeDesc TypePointer(TypeDesc::PTR);
 
 
 

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -447,8 +447,8 @@ ImageSpec::find_attribute(string_view name, ParamValue& tmpparam,
         tmpparam.init("full_geom", TypeString, 1, &s);
         return &tmpparam;
     }
-    static constexpr TypeDesc TypeInt_4(TypeDesc::INT, 4);
-    static constexpr TypeDesc TypeInt_6(TypeDesc::INT, 6);
+    constexpr TypeDesc TypeInt_4(TypeDesc::INT, 4);
+    constexpr TypeDesc TypeInt_6(TypeDesc::INT, 6);
     if (MATCH("datawindow", TypeInt_4)) {
         int val[] = { x, y, x + width - 1, y + height - 1 };
         tmpparam.init(name, TypeInt_4, 1, &val);


### PR DESCRIPTION
Owing to our C++11 focus in previous years, we had a number of places
were constants were declared as `static constexpr`. When done in
headers, this potentially causes separate copies of those constants to
be instantiated in each module that includes the header. It's not
really harmful the way we're using it for small constand objects, but
it's wasteful to potentially have dozens of copies of each those
constants by having it repeated in each module.

C++17 has a new idiom, `inline constexpr` that is more like we want --
makes it a true compiler constant that doesn't get instantiated in the
memory of each module.

We still have to cater to C++14, and in platform.h we already had a
C++-standard-dependent definition of OIIO_INLINE_CONSTEXPR that was
almost correct. Fix it (it wasn't previously used, but I must have
seen this coming at some point) so that it expands to
`inline constexpr` for C++17 and beyond, but stays as
`static constexpr` for C++14, and then use it for these constants.

Fixes #3117

