### PR TITLE
libraw: add new color space names

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1493,8 +1493,11 @@ options are supported:
        is not equal to 0.
    * - ``raw:ColorSpace``
      - string
-     - Which color primaries to use: ``raw``, ``sRGB``, ``Adobe``, ``Wide``,
-       ``ProPhoto``, ``ACES``, ``XYZ``. (Default: ``sRGB``)
+     - Which color primaries to use for the returned pixel values: ``raw``,
+       ``sRGB``, ``sRGB-linear`` (sRGB primaries, but a linear transfer
+       function), ``Adobe``, ``Wide``, ``ProPhoto``, ``XYZ``, ``ACES`` (only
+       supported by LibRaw >= 0.18), ``DCI-P3`` (LibRaw >= 0.21), ``Rec2020``
+       (LibRaw >= 0.2). (Default: ``sRGB``)
    * - ``raw:Exposure``
      - float
      - Amount of exposure before de-mosaicing, from 0.25 (2 stop darken) to

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -520,7 +520,7 @@ RawInput::open_raw(bool unpack, const std::string& name,
     // naively reads a raw image and slaps it into a framebuffer for
     // display, it will work just like a jpeg. More sophisticated users
     // might request a particular color space, like "ACES". Note that a
-    // request for "linear" will give you sRGB primaries with a linear
+    // request for "sRGB-linear" will give you sRGB primaries with a linear
     // response.
     std::string cs = config.get_string_attribute("raw:ColorSpace", "sRGB");
     if (Strutil::iequals(cs, "raw")) {
@@ -559,12 +559,34 @@ RawInput::open_raw(bool unpack, const std::string& name,
         m_processor->imgdata.params.gamm[0]      = 1.0;
         m_processor->imgdata.params.gamm[1]      = 1.0;
 #else
-        errorf(
-            "raw:ColorSpace value of \"ACES\" is not supported by libRaw %d.%d.%d",
-            LIBRAW_MAJOR_VERSION, LIBRAW_MINOR_VERSION, LIBRAW_PATCH_VERSION);
+        errorfmt("raw:ColorSpace value of \"{}\" is not supported by libRaw {}",
+                 cs, LIBRAW_VERSION_STR);
         return false;
 #endif
-    } else if (Strutil::iequals(cs, "linear")) {
+    } else if (Strutil::iequals(cs, "DCI-P3")) {
+#if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0, 21, 0)
+        // ACES linear
+        m_processor->imgdata.params.output_color = 7;
+        m_processor->imgdata.params.gamm[0]      = 1.0;
+        m_processor->imgdata.params.gamm[1]      = 1.0;
+#else
+        errorfmt("raw:ColorSpace value of \"{}\" is not supported by libRaw {}",
+                 cs, LIBRAW_VERSION_STR);
+        return false;
+#endif
+    } else if (Strutil::iequals(cs, "Rec2020")) {
+#if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0, 21, 0)
+        // ACES linear
+        m_processor->imgdata.params.output_color = 8;
+        m_processor->imgdata.params.gamm[0]      = 1.0;
+        m_processor->imgdata.params.gamm[1]      = 1.0;
+#else
+        errorfmt("raw:ColorSpace value of \"{}\" is not supported by libRaw {}",
+                 cs, LIBRAW_VERSION_STR);
+        return false;
+#endif
+    } else if (Strutil::iequals(cs, "sRGB-linear")
+               || Strutil::iequals(cs, "linear") /* DEPRECATED */) {
         // Request "sRGB" primaries, linear reponse
         m_processor->imgdata.params.output_color = 1;
         m_processor->imgdata.params.gamm[0]      = 1.0;


### PR DESCRIPTION
The DSLR raw format reader has the ability to pass hints to the
underlying LibRaw requesting that the pixel data be returned to us in
particular color spaces.

* Add new supported color spaces "DCI-P3" and "Rec2020" when using a
  LibRaw new enough to understand them -- which means the upcoming 0.21.

* A new name to request the data be returned using sRGB color
  primaries but a linear response curve: "sRGB-linear".

* The old name we used for sRGB-linear, "linear", is now considered
  deprecated since it's ambiguous -- since its first use, new color
  spaces "ACES", "DCI-P3", and "Rec2020" have been added, all of which
  are also linear response.
