### PR TITLE
Clean up src/doc/Makefile -- remove old LaTeX dependencies

### DIFF
--- a/src/doc/Makefile
+++ b/src/doc/Makefile
@@ -11,25 +11,22 @@ ifeq (${OIIOTOOL},)
 endif
 
 
-PDFLATEX := pdflatex -file-line-error --halt-on-error -interaction=errorstopmode
+help:
+	@echo "help"
+	@echo "BUILDDIR=${BUILDDIR}"
+	@echo "Interesting targets:"
+	@echo "  sphinx         Build html docs in BUILDDIR/sphinx"
+	@echo "  sphinxpdf      Build pdf docs in BUILDDIR/sphinx"
+	@echo "  doxygen        Doxygen pre-pass needed before sphinx"
+	@echo "  doxygenclean   Reset doxygen pass"
+	@echo "  figures        Rebuild all figures (DON'T DO THIS!)"
+	@echo "  cleanfigures   Clear all figures (DEFINITELY DON'T DO THIS!)"
+#	@echo "Sphinx targets:"
+#	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(SPHINXBUILDDIR)" $(SPHINXOPTS) $(O)
 
-# by default, just make the document
-all: openimageio.pdf
 
+.PHONY: help Makefile
 
-# document making rule: use pdflatex
-openimageio.pdf: *.tex *.aux figures.turd
-	${PDFLATEX} openimageio.tex
-
-
-# special command 'make index' to regenerate the index
-index: openimageio_index
-
-openimageio_index: figures
-	${PDFLATEX} openimageio.tex
-	${PDFLATEX} openimageio.tex
-	makeindex openimageio
-	${PDFLATEX} openimageio.tex
 
 figures:
 	(cmake -E make_directory figures ; \
@@ -43,13 +40,6 @@ figures.turd: makefigures.bash
 
 cleanfigures:
 	cmake -E remove_directory figures
-
-
-help:
-	@echo "help"
-	@echo "BUILDDIR=${BUILDDIR}"
-	@echo "Sphinx targets:"
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(SPHINXBUILDDIR)" $(SPHINXOPTS) $(O)
 
 
 
@@ -72,10 +62,6 @@ SPHINXBUILD   = sphinx-build
 SOURCEDIR     = .
 SPHINXBUILDDIR      = ../../build/sphinx
 
-# Put it first so that "make" without argument is like "make help".
-#help:
-
-.PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
It was still by default referencing the old latex files that we've
long since removed.

