### PR TITLE
Replace Imath::clamp with OIIO::clamp

### DIFF
--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -179,8 +179,8 @@ interppixel_NDC_clamped(const ImageBuf& buf, float x, float y, float* pixel,
         // wrong will tend to over-represent the high latitudes in
         // low-res MIP levels.  We fold the area weighting into our
         // linear interpolation by adjusting yfrac.
-        int ynext = Imath::clamp(ytexel + 1, buf.ymin(), buf.ymax());
-        ytexel    = Imath::clamp(ytexel, buf.ymin(), buf.ymax());
+        int ynext = OIIO::clamp(ytexel + 1, buf.ymin(), buf.ymax());
+        ytexel    = OIIO::clamp(ytexel, buf.ymin(), buf.ymax());
         float w0  = (1.0f - yfrac)
                    * sinf((float)M_PI * (ytexel + 0.5f) / (float)fh);
         float w1 = yfrac * sinf((float)M_PI * (ynext + 0.5f) / (float)fh);

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -372,8 +372,8 @@ TextureSystemImpl::environment(TextureHandle* texture_handle_,
     options.twrap = TextureOpt::WrapClamp;
 
     options.envlayout  = LayoutLatLong;
-    int actualchannels = Imath::clamp(spec.nchannels - options.firstchannel, 0,
-                                      nchannels);
+    int actualchannels = OIIO::clamp(spec.nchannels - options.firstchannel, 0,
+                                     nchannels);
 
     // Initialize results to 0.  We'll add from here on as we sample.
     for (int c = 0; c < nchannels; ++c)
@@ -498,8 +498,8 @@ TextureSystemImpl::environment(TextureHandle* texture_handle_,
             if (filtwidth_ras <= 1) {
                 miplevel[0] = m - 1;
                 miplevel[1] = m;
-                levelblend  = Imath::clamp(2.0f * filtwidth_ras - 1.0f, 0.0f,
-                                          1.0f);
+                levelblend  = OIIO::clamp(2.0f * filtwidth_ras - 1.0f, 0.0f,
+                                         1.0f);
                 break;
             }
         }

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -168,8 +168,8 @@ TextureSystemImpl::texture3d(TextureHandle* texture_handle_,
     if (options.rwrap == TextureOpt::WrapPeriodic && ispow2(spec.depth))
         options.rwrap = TextureOpt::WrapPeriodicPow2;
 
-    int actualchannels = Imath::clamp(spec.nchannels - options.firstchannel, 0,
-                                      nchannels);
+    int actualchannels = OIIO::clamp(spec.nchannels - options.firstchannel, 0,
+                                     nchannels);
 
     // Do the volume lookup in local space.
     Imath::V3f Plocal;

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -594,7 +594,7 @@ inline float
 TextureSystemImpl::anisotropic_aspect(float& majorlength, float& minorlength,
                                       TextureOpt& options, float& trueaspect)
 {
-    float aspect = Imath::clamp(majorlength / minorlength, 1.0f, 1.0e6f);
+    float aspect = OIIO::clamp(majorlength / minorlength, 1.0f, 1.0e6f);
     trueaspect   = aspect;
     if (aspect > options.anisotropic) {
         aspect = options.anisotropic;

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -759,7 +759,7 @@ TextureSystemImpl::get_texels(TextureHandle* texture_handle_,
     // doing anything more complicated (not to mention bug-prone) until
     // somebody reports this routine as being a bottleneck.
     int nchannels      = chend - chbegin;
-    int actualchannels = Imath::clamp(spec.nchannels - chbegin, 0, nchannels);
+    int actualchannels = OIIO::clamp(spec.nchannels - chbegin, 0, nchannels);
     int tile_chbegin = 0, tile_chend = spec.nchannels;
     if (spec.nchannels > m_max_tile_channels) {
         // For files with many channels, narrow the range we cache
@@ -1117,8 +1117,8 @@ TextureSystemImpl::texture(TextureHandle* texture_handle_,
         texturefile->subimageinfo(options.subimage));
     const ImageSpec& spec(texturefile->spec(options.subimage, 0));
 
-    int actualchannels = Imath::clamp(spec.nchannels - options.firstchannel, 0,
-                                      nchannels);
+    int actualchannels = OIIO::clamp(spec.nchannels - options.firstchannel, 0,
+                                     nchannels);
 
     // Figure out the wrap functions
     if (options.swrap == TextureOpt::WrapDefault)
@@ -1478,7 +1478,7 @@ compute_miplevels(TextureSystemImpl::TextureFile& texturefile,
         if (filtwidth_ras <= 1.0f) {
             miplevel[0] = m - 1;
             miplevel[1] = m;
-            levelblend  = Imath::clamp(2.0f * filtwidth_ras - 1.0f, 0.0f, 1.0f);
+            levelblend  = OIIO::clamp(2.0f * filtwidth_ras - 1.0f, 0.0f, 1.0f);
             break;
         }
     }
@@ -1502,8 +1502,8 @@ compute_miplevels(TextureSystemImpl::TextureFile& texturefile,
         int r = std::max(subinfo.spec(0).full_width,
                          subinfo.spec(0).full_height);
         if (minorlength * r < 0.5f) {
-            aspect = Imath::clamp(majorlength * r * 2.0f, 1.0f,
-                                  float(options.anisotropic));
+            aspect = OIIO::clamp(majorlength * r * 2.0f, 1.0f,
+                                 float(options.anisotropic));
         }
     }
     if (options.mipmode == TextureOpt::MipModeOneLevel) {
@@ -1976,7 +1976,7 @@ TextureSystemImpl::fade_to_pole(float t, float* accum, float& weight,
                                thread_info->tile, options.subimage, miplevel,
                                1);
     }
-    pole = Imath::clamp(pole, 0.0f, 1.0f);
+    pole = OIIO::clamp(pole, 0.0f, 1.0f);
     pole *= pole;  // squaring makes more pleasing appearance
     polecolor += options.firstchannel;
     for (int c = 0; c < nchannels; ++c)


### PR DESCRIPTION
We had long ago established that the one in fmath was a slightly
faster formulation, as well as having the property of squashing
NaNs. There were a few remaining places where we used a different
clamp so fix them.

