### PR TITLE
[jpeg] remove debugging cruft

### DIFF
--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -299,9 +299,6 @@ JpgInput::open(const std::string& name, ImageSpec& newspec)
         } else if (m->marker == (JPEG_APP0 + 1)
                    && !strcmp((const char*)m->data,
                               "http://ns.adobe.com/xap/1.0/")) {
-#ifndef NDEBUG
-            std::cerr << "Found APP1 XMP! length " << m->data_length << "\n";
-#endif
             std::string xml((const char*)m->data, m->data_length);
             decode_xmp(xml, m_spec);
         } else if (m->marker == (JPEG_APP0 + 13)


### PR DESCRIPTION
## Description

I'm unsure whether this diagnostic was meant to go out, but there are very few other ones like it, and it would seem at least the Debian version of OIIO is built with `NDEBUG` defined, because I'm finding this message printed to the screen when I open JPEGs, and it is most unwelcome.

## Tests

Trivial patch.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project.

