### PR TITLE
oiiotool --dumpdata:C=name

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -1110,14 +1110,34 @@ These are all non-positional flags that affect how all images are read in the
 
 .. option:: --dumpdata
 
-    Print the numerical values of every pixel, for each input image as it is
-    read.
+    Print to the console the numerical values of every pixel, for each input
+    image as it is read.
 
     Optional appended modifiers include:
+
+    - `C=` *name* : If present, will cause the output of the data to be
+      in the correct syntax of declaring a C array with the given name.
+      (This was added in OpenImageIO v2.3.9.)
 
     - `empty=` *verbose* : If 0, will cause deep images to skip printing of
       information about pixels with no samples.
 
+    Examples::
+
+        $ oiiotool --dumpdata image.exr
+        image.exr       :  256 x  256, 4 channel, float openexr
+            Pixel (0, 0): 0.517036676 0.261921108 0.017822538 0.912108004
+            Pixel (1, 0): 0.653315008 0.527794302 0.359594107 0.277836263
+            ...
+
+        $ oiiotool --dumpdata:C=foo image.exr
+        // image.exr       :  256 x  256, 4 channel, float openexr
+        float foo[256][256][4] =
+        {
+            /* (0, 0): */ { 0.517036676, 0.261921108, 0.017822538, 0.912108004 },
+            /* (1, 0): */ { 0.653315008, 0.527794302, 0.359594107, 0.277836263 },
+            ...
+        };
 
 .. _sec-oiiotool-o:
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -112,6 +112,7 @@ Oiiotool::clear_options()
     printstats         = false;
     dumpdata           = false;
     dumpdata_showempty = true;
+    dumpdata_C         = false;
     hash               = false;
     updatemode         = false;
     autoorient         = false;
@@ -517,6 +518,8 @@ set_dumpdata(cspan<const char*> argv)
     auto options          = ot.extract_options(command);
     ot.dumpdata           = true;
     ot.dumpdata_showempty = options.get_int("empty", 1);
+    ot.dumpdata_C_name    = options.get_string("C");
+    ot.dumpdata_C         = ot.dumpdata_C_name.size();
 }
 
 
@@ -5510,7 +5513,7 @@ getargs(int argc, char* argv[])
     ap.arg("--stats", &ot.printstats)
       .help("Print pixel statistics of all inputs files");
     ap.arg("--dumpdata")
-      .help("Print all pixel data values of input files (options: empty=0)")
+      .help("Print all pixel data values of input files (options: empty=1, C=arrayname)")
       .action(set_dumpdata);
     ap.arg("--hash", &ot.hash)
       .help("Print SHA-1 hash of each input image");

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -51,6 +51,8 @@ struct print_info_options {
     bool compute_stats      = false;
     bool dumpdata           = false;
     bool dumpdata_showempty = true;
+    bool dumpdata_C         = false;
+    std::string dumpdata_C_name;
     std::string metamatch;
     std::string nometamatch;
     std::string infoformat;
@@ -76,6 +78,7 @@ public:
     bool printstats;
     bool dumpdata;
     bool dumpdata_showempty;
+    bool dumpdata_C;
     bool hash;
     bool updatemode;
     bool autoorient;
@@ -91,6 +94,7 @@ public:
     bool eval_enable;              // Enable evaluation of expressions
     bool skip_bad_frames = false;  // Just skip a bad frame, don't exit
     bool nostderr        = false;  // If true, use stdout for errors
+    std::string dumpdata_C_name;
     std::string full_command_line;
     std::string printinfo_metamatch;
     std::string printinfo_nometamatch;
@@ -583,6 +587,8 @@ inline print_info_options::print_info_options(const Oiiotool& ot)
     , compute_stats(ot.printstats)
     , dumpdata(ot.dumpdata)
     , dumpdata_showempty(ot.dumpdata_showempty)
+    , dumpdata_C(ot.dumpdata_C)
+    , dumpdata_C_name(ot.dumpdata_C_name)
     , metamatch(ot.printinfo_metamatch)
     , nometamatch(ot.printinfo_nometamatch)
 {

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -152,6 +152,21 @@ add_rgb_rgba.exr     :   64 x   64, 4 channel, float openexr
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
     oiio:subimages: 1
+dumpdata:
+dump.exr             :    2 x    2, 3 channel, half openexr
+    Pixel (0, 0): 0.000000000 0.000000000 0.000000000
+    Pixel (1, 0): 1.000000000 1.000000000 0.000000000
+    Pixel (0, 1): 0.000000000 0.000000000 0.000000000
+    Pixel (1, 1): 1.000000000 1.000000000 0.000000000
+dumpdata:C
+// dump.exr             :    2 x    2, 3 channel, half openexr
+half data[2][2][3] =
+{
+  { /* (0, 0): */ { 0.000000000, 0.000000000, 0.000000000 },
+    /* (1, 0): */ { 1.000000000, 1.000000000, 0.000000000 } },
+  { /* (0, 1): */ { 0.000000000, 0.000000000, 0.000000000 },
+    /* (1, 1): */ { 1.000000000, 1.000000000, 0.000000000 } },
+};
 Comparing "filled.tif" and "ref/filled.tif"
 PASS
 Comparing "autotrim.tif" and "ref/autotrim.tif"

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -255,6 +255,10 @@ command += oiiotool ("--missingfile black box.tif missing.tif --over -o box_over
 # Test again using --missingfile checker
 command += oiiotool ("--missingfile checker box.tif missing.tif --over -o box_over_missing3.tif || true")
 
+# Test --dumpdata
+command += oiiotool ("--pattern fill:left=0,0,0:right=1,1,0 2x2 3 -d half -o dump.exr")
+command += oiiotool ("-echo dumpdata: --dumpdata dump.exr")
+command += oiiotool ("-echo dumpdata:C --dumpdata:C=data dump.exr")
 
 # To add more tests, just append more lines like the above and also add
 # the new 'feature.tif' (or whatever you call it) to the outputs list,


### PR DESCRIPTION
New ":C=name" modifier for --dumpdata will cause the dumped image data
to be formatted with the syntax of a C array, that can be dropped right
into source code.

    $ oiiotool --dumpdata:C=foo image.exr
    // image.exr       :  256 x  256, 4 channel, float openexr
    float foo[256][256][4] =
    {
      { /* (0, 0): */ { 0.517036676, 0.261921108, 0.017822538, 0.912108004 },
        /* (1, 0): */ { 0.653315008, 0.527794302, 0.359594107, 0.277836263 },
        ...
    };

Without this modifier, --dumpdata will keep the same formatting it
always had.

This works pretty well for ordinary boring flat, single subimage,
non-MIPmap images.  The option should probably not be used (or at
least is very unpolished) for multi-subimage, MIP-mapped, deep, or
other oddball cases (but you probably don't want to shove those into
a single C array anyway).

