### PR TITLE
Fix bad alignment and simd assumptions in fill_gray_channels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,6 +550,7 @@ jobs:
       PYTHON_VERSION: 3.7
       CMAKE_GENERATOR: "Visual Studio 16 2019"
       OPENEXR_VERSION: v2.5.6
+      USE_SIMD: sse4.2
       CTEST_ARGS: "--timeout 120 --repeat after-timeout:6"
     steps:
       - uses: actions/checkout@v2

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -940,30 +940,41 @@ TextureSystemImpl::fill_gray_channels(const ImageSpec& spec, int nchannels,
     if (specchans == 1 && nchannels >= 3) {
         // Asked for RGB or RGBA, texture was just R...
         // copy the one channel to G and B
-        *(simd::vfloat4*)result = simd::shuffle<0, 0, 0, 3>(
-            *(simd::vfloat4*)result);
+        result[1] = result[0];
+        result[2] = result[0];
         if (dresultds) {
-            *(simd::vfloat4*)dresultds = simd::shuffle<0, 0, 0, 3>(
-                *(simd::vfloat4*)dresultds);
-            *(simd::vfloat4*)dresultdt = simd::shuffle<0, 0, 0, 3>(
-                *(simd::vfloat4*)dresultdt);
-            if (dresultdr)
-                *(simd::vfloat4*)dresultdr = simd::shuffle<0, 0, 0, 3>(
-                    *(simd::vfloat4*)dresultdr);
+            dresultds[1] = dresultds[0];
+            dresultds[2] = dresultds[0];
+            dresultdt[1] = dresultdt[0];
+            dresultdt[2] = dresultdt[0];
+            if (dresultdr) {
+                dresultdr[1] = dresultdr[0];
+                dresultdr[2] = dresultdr[0];
+            }
         }
     } else if (specchans == 2 && nchannels == 4 && spec.alpha_channel == 1) {
         // Asked for RGBA, texture was RA
         // Shuffle into RRRA
-        *(simd::vfloat4*)result = simd::shuffle<0, 0, 0, 1>(
-            *(simd::vfloat4*)result);
+        float a;
+        a         = result[1];
+        result[1] = result[0];
+        result[2] = result[0];
+        result[3] = a;
         if (dresultds) {
-            *(simd::vfloat4*)dresultds = simd::shuffle<0, 0, 0, 1>(
-                *(simd::vfloat4*)dresultds);
-            *(simd::vfloat4*)dresultdt = simd::shuffle<0, 0, 0, 1>(
-                *(simd::vfloat4*)dresultdt);
-            if (dresultdr)
-                *(simd::vfloat4*)dresultdr = simd::shuffle<0, 0, 0, 1>(
-                    *(simd::vfloat4*)dresultdr);
+            a            = dresultds[1];
+            dresultds[1] = dresultds[0];
+            dresultds[2] = dresultds[0];
+            dresultds[3] = a;
+            a            = dresultdt[1];
+            dresultdt[1] = dresultdt[0];
+            dresultdt[2] = dresultdt[0];
+            dresultdt[3] = a;
+            if (dresultdr) {
+                a            = dresultdr[1];
+                dresultdr[1] = dresultdr[0];
+                dresultdr[2] = dresultdr[0];
+                dresultdr[3] = a;
+            }
         }
     }
 }


### PR DESCRIPTION
Thiago Ize points out that TextureSystemImpl::fill_gray_channels
assumes that the `float*` addresses it is passed are big enough for
a vfloat4, and also properly aligned as such. Not true.

This is an edge case anyway, only called in particular cases where
we are doing 3/4 channel lookups on 1/2 channel files with the option
turned on to expand single channel gray to RGB gray, and also doesn't
do enough SIMD to have a perf impact. So just recode as scalar and
have no more alignment mismatches to worry about.

Also make sure at least one of the Windows CI tests is explicitly
turning SSE on.

Fixes #3128

