### PR TITLE
heif: Handle unassociated alpha

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -54,7 +54,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * giflib >= 4.1 (tested through 5.2; 5.0+ is strongly recommended for
        stability and thread safety)
  * If you want support for HEIF/HEIC or AVIF images:
-     * libheif >= 1.3 (1.7 required for AVIF support, tested through 1.11)
+     * libheif >= 1.3 (1.7 required for AVIF support, tested through 1.12)
      * libheif must be built with an AV1 encoder/decoder for AVIF support.
      * Avoid libheif 1.10 on Mac, it is very broken. Libheif 1.11 is fine.
  * If you want support for DDS files:

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -639,11 +639,30 @@ currently supported for reading, but not yet writing. All pixel data is
 uint8, though we hope to add support for HDR (more than 8 bits) in the
 future.
 
+**Configuration settings for HEIF input**
+
+When opening an HEIF ImageInput with a *configuration* (see
+Section :ref:`sec-inputwithconfig`), the following special configuration
+attributes are supported:
+
+.. list-table::
+   :widths: 30 10 65
+   :header-rows: 1
+
+   * - Input Configuration Attribute
+     - Type
+     - Meaning
+   * - ``oiio:UnassociatedAlpha``
+     - int
+     - If nonzero, and the file contains unassociated alpha, this will
+       cause the reader to leave alpha unassociated (versus the default of
+       premultiplying color channels by alpha if the alpha channel is
+       unassociated).
+
 **Configuration settings for HEIF output**
 
 When opening an HEIF ImageOutput, the following special metadata tokens
 control aspects of the writing itself:
-
 
 .. list-table::
    :widths: 30 10 65
@@ -1896,7 +1915,8 @@ options are supported:
      - Meaning
    * - ``oiio:UnassociatedAlpha``
      - int
-     - If nonzero, will leave alpha unassociated (versus the default of
+     - If nonzero, and the file contains unassociated alpha, this will
+       cause the reader to leave alpha unassociated (versus the default of
        premultiplying color channels by alpha if the alpha channel is
        unassociated).
    * - ``oiio:RawColor``
@@ -2128,10 +2148,12 @@ aware of:
      - The actual bits per sample in the file (may differ from `ImageSpec::format`).
    * - ``oiio:UnassociatedAlpha``
      - int
-     - Nonzero if the alpha channel contained "unassociated" alpha.
-
-
-
+     - Nonzero if the data returned by OIIO will have "unassociated" alpha.
+   * - ``tiff:UnassociatedAlpha``
+     - int
+     - Nonzero if the data in the file had "unassociated" alpha (even if using
+       the usual convention of returning associated alpha from the read
+       methods).
 
 
 


### PR DESCRIPTION
Turns out that heif files that contain alpha can have either
associated or unassociated alpha. We had been assuming
associated. With LibHeif 1.12 and beyond, you can ask, so now we
do. Thanks Frédéric Devernay for pointing this out.

Similar to other formats that optionally have unassociated alpha:

* The default behavior is to associate/premultiply automatically when
  reading, but set metadata "heif:UnassociatedAlpha" to indicate that
  it was unassociated in the file.

* Open configuration hint "oiio:UnassociatedAlpha", when nonzero,
  means to please keep the data unassociated and not premultiply. In
  that case, metadata "oiio:UnassociatedAlpha" will be set in the
  ImageSpec to indicate that the returned image (not just the file)
  consists of unassociated values.

I did a couple other minor docs touch-ups while I was at it.

Fixes #3129
