### PR TITLE
Rewrite Filesystem::searchpath_split to remove boost::tokenizer

### DIFF
--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -53,7 +53,6 @@ time vcpkg install boost-math:x64-windows
 time vcpkg install boost-stacktrace:x64-windows
 time vcpkg install boost-system:x64-windows
 time vcpkg install boost-thread:x64-windows
-time vcpkg install boost-tokenizer:x64-windows
 
 # # vcpkg install zlib:x64-windows
 vcpkg install tiff:x64-windows

--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -87,14 +87,25 @@ OIIO_UTIL_API std::string replace_extension (const std::string &filepath,
 /// Return the filepath in generic format, not any OS-specific conventions.
 OIIO_UTIL_API std::string generic_filepath (string_view filepath) noexcept;
 
-/// Turn a searchpath (multiple directory paths separated by ':' or ';')
-/// into a vector<string> containing each individual directory.  If
-/// validonly is true, only existing and readable directories will end
-/// up in the list.  N.B., the directory names will not have trailing
-/// slashes.
+/// Turn a searchpath (multiple directory paths separated by ':' or ';') into
+/// a vector<string> containing the name of each individual directory.  If
+/// validonly is true, only existing and readable directories will end up in
+/// the list.  N.B., the directory names will not have trailing slashes.
+OIIO_UTIL_API std::vector<std::string>
+searchpath_split(string_view searchpath, bool validonly = false);
+
+#if OIIO_VERSION_GREATER_EQUAL(2, 4, 0)
+inline void searchpath_split (string_view searchpath,
+                              std::vector<std::string> &dirs,
+                              bool validonly = false)
+{
+    dirs = searchpath_split(searchpath, validonly);
+}
+#else
 OIIO_UTIL_API void searchpath_split (const std::string &searchpath,
                                 std::vector<std::string> &dirs,
                                 bool validonly = false);
+#endif
 
 /// Find the first instance of a filename existing in a vector of
 /// directories, returning the full path as a string.  If the file is


### PR DESCRIPTION
One more boost extraction:  tokenizer.

The only place we used it is Filesystem::searchpath_split, which can
easily be rewritten in terms of the Strutil parsing functions.
While I'm at it, add a new version that returns the vector instead
of needing to pass in a ref.
