### PR TITLE
exr output: Support new OpenEXR zip compression level choices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,13 +326,13 @@ jobs:
       LIBRAW_VERSION: 0.20.2
       LIBTIFF_VERSION: v4.3.0
       OPENCOLORIO_VERSION: v2.1.0
-      OPENEXR_VERSION: v3.1.2
+      OPENEXR_VERSION: v3.1.3
       PUGIXML_VERSION: v1.11.4
       PTEX_VERSION: v2.4.0
-      PYBIND11_VERSION: v2.8.0
+      PYBIND11_VERSION: v2.8.1
       PYTHON_VERSION: 3.8
       WEBP_VERSION: v1.2.1
-      MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=8.0.0
+      MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=8.0.1
       OPENIMAGEIO_OPTIONS: "openexr:core=1"
       USE_OPENVDB: 0
       # The old installed OpenVDB has a TLS conflict with Python 3.8

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1109,7 +1109,10 @@ The official OpenEXR site is http://www.openexr.com/.
        system, it will use ``"zip"`` by default. For ``"dwaa"`` and
        ``"dwab"``, the dwaCompressionLevel may be optionally appended to the
        compression name after a colon, like this: ``"dwaa:200"``. (The
-       default DWA compression value is 45.)
+       default DWA compression value is 45.) For ``"zip"`` and ``"zips"``
+       compression, a level from 1 to 9 may be appended (the default is
+       ``"zip:4"``), but note that this is only honored when building
+       against OpenEXR 3.1.3 or later.
    * - ``textureformat``
      - string
      - ``"Plain Texture"`` for MIP-mapped OpenEXR files, ``"CubeFace

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -636,10 +636,7 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
         case Imf::B44_COMPRESSION: comp = "b44"; break;
         case Imf::B44A_COMPRESSION: comp = "b44a"; break;
 #endif
-#if defined(OPENEXR_VERSION_MAJOR)                                  \
-    && (OPENEXR_VERSION_MAJOR * 10000 + OPENEXR_VERSION_MINOR * 100 \
-        + OPENEXR_VERSION_PATCH)                                    \
-           >= 20200
+#if OPENEXR_CODED_VERSION >= 20200
         case Imf::DWAA_COMPRESSION: comp = "dwaa"; break;
         case Imf::DWAB_COMPRESSION: comp = "dwab"; break;
 #endif


### PR DESCRIPTION
When building against OpenEXR >= 3.1.3, exr output now allows zip/zips
compression to take a quality metric (such as compression
"zip:4"). The range is from 1-9, 4 is the default, and it's a control
over speed of compression vs compression ratio (higher number is more
expensive but may result in smaller files). This only affects
compressed output -- it's lossless and will be read to the same pixel
values upon input.

This is also incentive to upgrade to OpenEXR >= 3.1.3, because its new
default (and ours) is 4, versus the old (implied, not directly
controlled) 6. This change was made because compared to 6, it's
significantly faster to write exr files with zip compression 4 (tens
of % faster), while only increasing file size by 1-2%, so that seemed
like the right tradeoff. Lower numbers make much larger files for
little speed gain, and larger numbers than 6 make for much slower
writes of exr files for very tiny compression improvements. But YMMV
and you may want to experiment to find the right trade-off for your
use cases.
