### PR TITLE
tiff output: switch to "bigtiff" for really big images

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -2117,6 +2117,10 @@ aspects of the writing itself:
      - int
      - Overrides TIFF scanline rows per strip with a specific request (if
        not supplied, OIIO will choose a reasonable default).
+   * - ``tiff:bigtiff``
+     - int
+     - If nonzero, forces use of "bigtiff," a nonstandard extension that
+       allows files to be more than 4 GB (default: 0).
    * - ``oiio:ioproxy``
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for


### PR DESCRIPTION
TIFF has an absolute limit of 4GB file size due to use of uint32
offsets within the file. If you try to write a big enough TIFF image,
it will fail. This is not a software problem, it's a limitation of the
original TIFF file specification itself.

The underlying libtiff supports a nonstandard "bigtiff" extension that
uses 64 bit offsets. This patch switches to this automatically for
images whose uncompressed size would get too close to (or exceed) the
4GB limit.  Any such files can be read by OIIO-based software, as well
as anything else using a relatively modern version of libtiff, but may
not be readable by independent TIFF reading implementations.

This is a mixed bag, though. On one hand, this at least lets us write
files that would have been an error before.  But note that some files
that would have worked as classic TIFF before -- because their
*compressed* size was still under the 4GB limit, even if their
uncompressed pixel size was not -- will now be written as bigtiff
because we have to commit at the time we open the file, before we've
seen the pixels and know the final compressed size.  We just can't
know for sure, for an image with > 4GB of pixels, if the file will get
lucky and be below the limit by the time the scanlines or tiles are
compressed.  So for those files, not all apps will be able to read
them (though anything using libtiff >= 4.0 or OIIO will be fine).

Fixes #3156
