### PR TITLE
oiiotool: Fix bug autocropping to positive area for all-negative data

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4924,6 +4924,9 @@ output_file(int /*argc*/, const char* argv[])
         roi.xbegin         = std::max(0, roi.xbegin);
         roi.ybegin         = std::max(0, roi.ybegin);
         roi.zbegin         = std::max(0, roi.zbegin);
+        roi.xend           = std::max(roi.xbegin + 1, roi.xend);
+        roi.yend           = std::max(roi.ybegin + 1, roi.yend);
+        roi.zend           = std::max(roi.zbegin + 1, roi.zend);
         std::string crop   = (ir->spec(0, 0)->depth == 1)
                                  ? format_resolution(roi.width(), roi.height(),
                                                    roi.xbegin, roi.ybegin)


### PR DESCRIPTION
When outputting to formats that don't support negative pixel origins
(such as JPEG), we crop away the negative areas. But we did not
consider the case where the entire data window was in the negative
region!
