### PR TITLE
Fix ssize_t build issue on Windows

### DIFF
--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -74,7 +74,7 @@ oiio_bufinfo::oiio_bufinfo(const py::buffer_info& pybuf)
         xstride = format.size();
         size    = 1;
         for (int i = pybuf.ndim - 1; i >= 0; --i) {
-            if (pybuf.strides[i] != ssize_t(size * xstride)) {
+            if (pybuf.strides[i] != py::ssize_t(size * xstride)) {
                 // Just can't handle non-contiguous strides
                 format = TypeUnknown;
                 size   = 0;


### PR DESCRIPTION
While working on OCIO unit tests for Windows I noticed a familiar error with the use of raw `ssize_t` type, which appear to not always be guaranteed to exists on MSVC. This just use the actual `py::ssize_t` type defined in pybind11. Note for now, I'll just disable python bindings on our CI builds as we don't really use them anyway.

Error here: https://github.com/remia/OpenColorIO/runs/4090745925?check_suite_focus=true#step:6:3531