### PR TITLE
Fix per-file boilerplate to just link to the github project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 name: CI
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 cmake_minimum_required (VERSION 3.12)
 project (OpenImageIO VERSION 2.4.0.0

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 #
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 #########################################################################
 
 

--- a/src/bmp.imageio/CMakeLists.txt
+++ b/src/bmp.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (bmpinput.cpp bmpoutput.cpp bmp_pvt.cpp)

--- a/src/bmp.imageio/bmp_pvt.cpp
+++ b/src/bmp.imageio/bmp_pvt.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cstdio>

--- a/src/bmp.imageio/bmp_pvt.h
+++ b/src/bmp.imageio/bmp_pvt.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #pragma once
 

--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cstdio>
 

--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cstdio>
 

--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -2,7 +2,7 @@
 
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 # DEP_DIR="$PWD/ext/dist"
 DEP_DIR="$PWD/dist/$PLATFORM"

--- a/src/cineon.imageio/CMakeLists.txt
+++ b/src/cineon.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (cineoninput.cpp
                  libcineon/Cineon.cpp libcineon/OutStream.cpp libcineon/Codec.cpp

--- a/src/cineon.imageio/cineoninput.cpp
+++ b/src/cineon.imageio/cineoninput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 

--- a/src/cmake/check_is_enabled.cmake
+++ b/src/cmake/check_is_enabled.cmake
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 # Is the named package "enabled" via our disabling convention? If either
 # USE_pkgname (or the all-uppercase USE_PKGNAME, or ENABLE_pkgname, or

--- a/src/cmake/checked_find_package.cmake
+++ b/src/cmake/checked_find_package.cmake
@@ -1,6 +1,6 @@
 # Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 
 set (REQUIRED_DEPS "" CACHE STRING

--- a/src/cmake/colors.cmake
+++ b/src/cmake/colors.cmake
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 
 # Define color codes for pretty terminal output

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 ###########################################################################
 #

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 ###########################################################################
 # Find external dependencies

--- a/src/cmake/modules/FindFFmpeg.cmake
+++ b/src/cmake/modules/FindFFmpeg.cmake
@@ -18,7 +18,7 @@
 # Modifications:
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 if (FFMPEG_INCLUDES AND FFMPEG_LIBRARIES)
     set (FFmpeg_FOUND TRUE)

--- a/src/cmake/pythonutils.cmake
+++ b/src/cmake/pythonutils.cmake
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 # Python-related options.
 option (USE_PYTHON "Build the Python bindings" ON)

--- a/src/dds.imageio/CMakeLists.txt
+++ b/src/dds.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 if (Libsquish_FOUND)
     # External libsquish was found -- use it

--- a/src/dds.imageio/dds_pvt.h
+++ b/src/dds.imageio/dds_pvt.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #pragma once
 

--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <cstdio>

--- a/src/dicom.imageio/CMakeLists.txt
+++ b/src/dicom.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 if (DCMTK_FOUND)
     add_oiio_plugin (dicominput.cpp

--- a/src/dicom.imageio/dicominput.cpp
+++ b/src/dicom.imageio/dicominput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imageio.h>

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 project(documentation)
 

--- a/src/doc/copyr.rst
+++ b/src/doc/copyr.rst
@@ -8,7 +8,7 @@
 
 The code that implements OpenImageIO is licensed under the BSD 3-clause
 (also sometimes known as "new BSD" or "modified BSD") license
-(https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md):
+(https://github.com/OpenImageIO/oiio):
 
 |
 

--- a/src/dpx.imageio/CMakeLists.txt
+++ b/src/dpx.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (dpxinput.cpp dpxoutput.cpp
   libdpx/DPX.cpp libdpx/OutStream.cpp libdpx/RunLengthEncoding.cpp

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <iomanip>

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <cstdio>

--- a/src/ffmpeg.imageio/CMakeLists.txt
+++ b/src/ffmpeg.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 if (FFmpeg_FOUND)
     add_oiio_plugin (ffmpeginput.cpp

--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 extern "C" {  // ffmpeg is a C api
 #include <cerrno>

--- a/src/fits.imageio/CMakeLists.txt
+++ b/src/fits.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (fitsinput.cpp fitsoutput.cpp fits_pvt.cpp)

--- a/src/fits.imageio/fits_pvt.cpp
+++ b/src/fits.imageio/fits_pvt.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include "fits_pvt.h"
 #include <OpenImageIO/strutil.h>

--- a/src/fits.imageio/fits_pvt.h
+++ b/src/fits.imageio/fits_pvt.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #pragma once
 

--- a/src/fits.imageio/fitsinput.cpp
+++ b/src/fits.imageio/fitsinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cctype>

--- a/src/fits.imageio/fitsoutput.cpp
+++ b/src/fits.imageio/fitsoutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <OpenImageIO/fmath.h>
 

--- a/src/fonts/CMakeLists.txt
+++ b/src/fonts/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 file (GLOB public_fonts "*/*.ttf")
 

--- a/src/gif.imageio/CMakeLists.txt
+++ b/src/gif.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 if (GIF_FOUND)
     add_oiio_plugin (gifinput.cpp gifoutput.cpp

--- a/src/gif.imageio/gifinput.cpp
+++ b/src/gif.imageio/gifinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <fcntl.h>
 #include <memory>

--- a/src/gif.imageio/gifoutput.cpp
+++ b/src/gif.imageio/gifoutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #define USE_GIFH 1
 

--- a/src/hdr.imageio/CMakeLists.txt
+++ b/src/hdr.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (rgbe.cpp hdrinput.cpp hdroutput.cpp)

--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cassert>

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cassert>

--- a/src/heif.imageio/CMakeLists.txt
+++ b/src/heif.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 if (Libheif_FOUND)
     add_oiio_plugin (heifinput.cpp heifoutput.cpp

--- a/src/heif.imageio/heifinput.cpp
+++ b/src/heif.imageio/heifinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/imageio.h>

--- a/src/heif.imageio/heifoutput.cpp
+++ b/src/heif.imageio/heifoutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <OpenImageIO/filesystem.h>

--- a/src/ico.imageio/CMakeLists.txt
+++ b/src/ico.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 if (TARGET PNG::PNG)
     add_oiio_plugin (icoinput.cpp icooutput.cpp

--- a/src/ico.imageio/ico.h
+++ b/src/ico.imageio/ico.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #pragma once
 

--- a/src/ico.imageio/icoinput.cpp
+++ b/src/ico.imageio/icoinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <cstdio>

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <cstdio>

--- a/src/iconvert/CMakeLists.txt
+++ b/src/iconvert/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 fancy_add_executable (LINK_LIBRARIES OpenImageIO)

--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cmath>

--- a/src/idiff/CMakeLists.txt
+++ b/src/idiff/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 fancy_add_executable (LINK_LIBRARIES OpenImageIO)

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cmath>

--- a/src/iff.imageio/CMakeLists.txt
+++ b/src/iff.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (iffinput.cpp iffoutput.cpp iff_pvt.cpp)

--- a/src/iff.imageio/iff_pvt.cpp
+++ b/src/iff.imageio/iff_pvt.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 #include "iff_pvt.h"
 #include <OpenImageIO/dassert.h>
 

--- a/src/iff.imageio/iff_pvt.h
+++ b/src/iff.imageio/iff_pvt.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #pragma once
 

--- a/src/iff.imageio/iffinput.cpp
+++ b/src/iff.imageio/iffinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 #include "iff_pvt.h"
 
 #include <cmath>

--- a/src/iff.imageio/iffoutput.cpp
+++ b/src/iff.imageio/iffoutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include "iff_pvt.h"
 

--- a/src/igrep/CMakeLists.txt
+++ b/src/igrep/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 fancy_add_executable (LINK_LIBRARIES OpenImageIO
                                      ${Boost_LIBRARIES} # because regex

--- a/src/igrep/igrep.cpp
+++ b/src/igrep/igrep.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cmath>

--- a/src/iinfo/CMakeLists.txt
+++ b/src/iinfo/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 fancy_add_executable (LINK_LIBRARIES OpenImageIO
                                      ${Boost_LIBRARIES} # because regex

--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cmath>

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 file (GLOB public_headers OpenImageIO/*.h)
 

--- a/src/include/OpenImageIO/argparse.h
+++ b/src/include/OpenImageIO/argparse.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #pragma once

--- a/src/include/OpenImageIO/array_view.h
+++ b/src/include/OpenImageIO/array_view.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #pragma once

--- a/src/include/OpenImageIO/atomic.h
+++ b/src/include/OpenImageIO/atomic.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 /////////////////////////////////////////////////////////////////////////

--- a/src/include/OpenImageIO/attrdelegate.h
+++ b/src/include/OpenImageIO/attrdelegate.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #pragma once

--- a/src/include/OpenImageIO/benchmark.h
+++ b/src/include/OpenImageIO/benchmark.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 // clang-format off
 

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #pragma once
 

--- a/src/include/OpenImageIO/dassert.h
+++ b/src/include/OpenImageIO/dassert.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #pragma once

--- a/src/include/OpenImageIO/deepdata.h
+++ b/src/include/OpenImageIO/deepdata.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #pragma once

--- a/src/include/OpenImageIO/errorhandler.h
+++ b/src/include/OpenImageIO/errorhandler.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #pragma once

--- a/src/include/OpenImageIO/export.h
+++ b/src/include/OpenImageIO/export.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #pragma once

--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 // clang-format off
 

--- a/src/include/OpenImageIO/filter.h
+++ b/src/include/OpenImageIO/filter.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #pragma once

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 /*
   A few bits here are based upon code from NVIDIA that was also released

--- a/src/include/OpenImageIO/fstream_mingw.h
+++ b/src/include/OpenImageIO/fstream_mingw.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 /// @file  fstream_mingw.h

--- a/src/include/OpenImageIO/function_view.h
+++ b/src/include/OpenImageIO/function_view.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 // Portions of the code in this file is a derived work based on the
 // FunctionRef class in LLVM:

--- a/src/include/OpenImageIO/hash.h
+++ b/src/include/OpenImageIO/hash.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 // clang-format off
 

--- a/src/include/OpenImageIO/image_view.h
+++ b/src/include/OpenImageIO/image_view.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #pragma once

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #pragma once

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 // clang-format off

--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 // clang-format off
 

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 // clang-format off
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/include/OpenImageIO/missing_math.h
+++ b/src/include/OpenImageIO/missing_math.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 // DEPRECATED(2.0)

--- a/src/include/OpenImageIO/oiioversion.h.in
+++ b/src/include/OpenImageIO/oiioversion.h.in
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #ifndef OPENIMAGEIO_VERSION_H

--- a/src/include/OpenImageIO/optparser.h
+++ b/src/include/OpenImageIO/optparser.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 /////////////////////////////////////////////////////////////////////////

--- a/src/include/OpenImageIO/parallel.h
+++ b/src/include/OpenImageIO/parallel.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 // clang-format off
 

--- a/src/include/OpenImageIO/paramlist.h
+++ b/src/include/OpenImageIO/paramlist.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 /// \file

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 /////////////////////////////////////////////////////////////////////////

--- a/src/include/OpenImageIO/plugin.h
+++ b/src/include/OpenImageIO/plugin.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 /////////////////////////////////////////////////////////////////////////

--- a/src/include/OpenImageIO/refcnt.h
+++ b/src/include/OpenImageIO/refcnt.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 /////////////////////////////////////////////////////////////////////////

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 /// @file  simd.h
 ///

--- a/src/include/OpenImageIO/span.h
+++ b/src/include/OpenImageIO/span.h
@@ -1,7 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-//  https://github.com/OpenImageIO/oiio
-// BSD 3-clause license:
-//  https://github.com/OpenImageIO/oiio/blob/master/LICENSE
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio
 
 // clang-format off
 

--- a/src/include/OpenImageIO/strided_ptr.h
+++ b/src/include/OpenImageIO/strided_ptr.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #pragma once

--- a/src/include/OpenImageIO/string_view.h
+++ b/src/include/OpenImageIO/string_view.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 // clang-format off
 

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 // clang-format off
 

--- a/src/include/OpenImageIO/sysutil.h
+++ b/src/include/OpenImageIO/sysutil.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 /////////////////////////////////////////////////////////////////////////

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 // clang-format off
 

--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 // clang-format off
 

--- a/src/include/OpenImageIO/tiffutils.h
+++ b/src/include/OpenImageIO/tiffutils.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 // clang-format off
 

--- a/src/include/OpenImageIO/timer.h
+++ b/src/include/OpenImageIO/timer.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 /// @file timer.h

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 // clang-format off
 

--- a/src/include/OpenImageIO/unittest.h
+++ b/src/include/OpenImageIO/unittest.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #pragma once
 

--- a/src/include/OpenImageIO/unordered_map_concurrent.h
+++ b/src/include/OpenImageIO/unordered_map_concurrent.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #pragma once

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #pragma once

--- a/src/include/OpenImageIO/varyingref.h
+++ b/src/include/OpenImageIO/varyingref.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #pragma once

--- a/src/iv/CMakeLists.txt
+++ b/src/iv/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 set (CMAKE_AUTOMOC ON)
 if (Qt5_POSITION_INDEPENDENT_CODE)

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <iostream>

--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #ifndef OPENIMAGEIO_IMAGEVIEWER_H

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include "ivgl.h"
 #include "imageviewer.h"

--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #ifndef OPENIMAGEIO_IVGL_H

--- a/src/iv/ivimage.cpp
+++ b/src/iv/ivimage.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <iostream>

--- a/src/iv/ivinfowin.cpp
+++ b/src/iv/ivinfowin.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <iostream>

--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #if defined(_MSC_VER)
 // Ignore warnings about conditional expressions that always evaluate true

--- a/src/iv/ivpref.cpp
+++ b/src/iv/ivpref.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <iostream>

--- a/src/jpeg.imageio/CMakeLists.txt
+++ b/src/jpeg.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (jpeginput.cpp jpegoutput.cpp
                  INCLUDE_DIRS ${JPEG_INCLUDE_DIRS}

--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <algorithm>
 #include <cassert>

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cassert>
 #include <cstdio>

--- a/src/jpeg2000.imageio/CMakeLists.txt
+++ b/src/jpeg2000.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 if (OPENJPEG_FOUND)
     add_oiio_plugin (jpeg2000input.cpp jpeg2000output.cpp

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cstdio>
 #include <vector>

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <vector>
 

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 if (VERBOSE)
    message (STATUS "Create imagio_pvt.h from imageio_pvt.h.in")

--- a/src/libOpenImageIO/bluenoise.cpp
+++ b/src/libOpenImageIO/bluenoise.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 // Bluenoise table. This table is derived using free blue noise textures

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <algorithm>
 #include <cmath>

--- a/src/libOpenImageIO/compute_test.cpp
+++ b/src/libOpenImageIO/compute_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 //

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <algorithm>
 #include <cstdio>

--- a/src/libOpenImageIO/exif-canon.cpp
+++ b/src/libOpenImageIO/exif-canon.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 // clang-format off
 

--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <algorithm>

--- a/src/libOpenImageIO/exif.h
+++ b/src/libOpenImageIO/exif.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 // clang-format off
 

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cstdio>
 #include <cstdlib>

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <iostream>

--- a/src/libOpenImageIO/imagebuf_test.cpp
+++ b/src/libOpenImageIO/imagebuf_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <OpenImageIO/benchmark.h>

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <memory>

--- a/src/libOpenImageIO/imagebufalgo_addsub.cpp
+++ b/src/libOpenImageIO/imagebufalgo_addsub.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 /// \file
 /// Implementation of ImageBufAlgo algorithms that do math on

--- a/src/libOpenImageIO/imagebufalgo_channels.cpp
+++ b/src/libOpenImageIO/imagebufalgo_channels.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 /// \file
 /// Implementation of ImageBufAlgo algorithms that merely move pixels

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 /// \file
 /// Implementation of ImageBufAlgo algorithms that analyze or compare

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <iostream>

--- a/src/libOpenImageIO/imagebufalgo_deep.cpp
+++ b/src/libOpenImageIO/imagebufalgo_deep.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cmath>

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <algorithm>
 #include <cmath>

--- a/src/libOpenImageIO/imagebufalgo_mad.cpp
+++ b/src/libOpenImageIO/imagebufalgo_mad.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <iostream>

--- a/src/libOpenImageIO/imagebufalgo_muldiv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_muldiv.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 /// \file
 /// Implementation of ImageBufAlgo algorithms that do math on

--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 /// \file

--- a/src/libOpenImageIO/imagebufalgo_orient.cpp
+++ b/src/libOpenImageIO/imagebufalgo_orient.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <iostream>

--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 /// \file
 /// Implementation of ImageBufAlgo algorithms that do math on

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cstdio>

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 /// \file
 /// ImageBufAlgo functions for filtered transformations

--- a/src/libOpenImageIO/imagebufalgo_yee.cpp
+++ b/src/libOpenImageIO/imagebufalgo_yee.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 /// \file

--- a/src/libOpenImageIO/imagecache_test.cpp
+++ b/src/libOpenImageIO/imagecache_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imageinout_test.cpp
+++ b/src/libOpenImageIO/imageinout_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 /////////////////////////////////////////////////////////////////////////
 // Tests related to ImageInput and ImageOutput

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <cstdio>

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cstdio>
 #include <cstdlib>

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 /// \file

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cstdio>
 #include <cstdlib>

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <cstdio>

--- a/src/libOpenImageIO/imagespec_test.cpp
+++ b/src/libOpenImageIO/imagespec_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <OpenImageIO/argparse.h>

--- a/src/libOpenImageIO/iptc.cpp
+++ b/src/libOpenImageIO/iptc.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <iostream>

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <cstdio>

--- a/src/libOpenImageIO/xmp.cpp
+++ b/src/libOpenImageIO/xmp.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <iostream>

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cmath>

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cstring>

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 /// \file

--- a/src/libtexture/texoptions.cpp
+++ b/src/libtexture/texoptions.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <string>
 

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cmath>

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 /// \file

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cmath>

--- a/src/libutil/argparse.cpp
+++ b/src/libutil/argparse.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cassert>

--- a/src/libutil/argparse_test.cpp
+++ b/src/libutil/argparse_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <vector>
 

--- a/src/libutil/atomic_test.cpp
+++ b/src/libutil/atomic_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <iostream>

--- a/src/libutil/benchmark.cpp
+++ b/src/libutil/benchmark.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cstdio>
 #include <cstdlib>

--- a/src/libutil/errorhandler.cpp
+++ b/src/libutil/errorhandler.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cstdio>
 #include <iostream>

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <algorithm>
 #include <cerrno>

--- a/src/libutil/filesystem_test.cpp
+++ b/src/libutil/filesystem_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <fstream>
 #include <sstream>

--- a/src/libutil/filter.cpp
+++ b/src/libutil/filter.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 // Filter results comparison

--- a/src/libutil/filter_test.cpp
+++ b/src/libutil/filter_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <vector>
 

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <algorithm>
 #include <array>

--- a/src/libutil/hash_test.cpp
+++ b/src/libutil/hash_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cstdio>

--- a/src/libutil/optparser_test.cpp
+++ b/src/libutil/optparser_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cstdlib>

--- a/src/libutil/parallel_test.cpp
+++ b/src/libutil/parallel_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <algorithm>

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <algorithm>
 #include <cstdio>

--- a/src/libutil/paramlist_test.cpp
+++ b/src/libutil/paramlist_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <limits>

--- a/src/libutil/plugin.cpp
+++ b/src/libutil/plugin.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cstdlib>
 #include <string>

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 // clang-format off
 

--- a/src/libutil/span_test.cpp
+++ b/src/libutil/span_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <array>
 #include <iostream>

--- a/src/libutil/spin_rw_test.cpp
+++ b/src/libutil/spin_rw_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <functional>

--- a/src/libutil/spinlock_test.cpp
+++ b/src/libutil/spinlock_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <functional>

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cmath>

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 // clang-format off
 
 #include <cstdio>

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #if (defined __MINGW32__) || (defined __MINGW64__) && !(defined _POSIX_C_SOURCE)
 #    define _POSIX_C_SOURCE 1  // for localtime_r

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 // This implementation of thread_pool is based on CTPL.

--- a/src/libutil/thread_test.cpp
+++ b/src/libutil/thread_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <algorithm>

--- a/src/libutil/timer.cpp
+++ b/src/libutil/timer.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cstdio>
 #include <cstdlib>

--- a/src/libutil/timer_test.cpp
+++ b/src/libutil/timer_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <OpenImageIO/argparse.h>

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cstdio>

--- a/src/libutil/ustring.cpp
+++ b/src/libutil/ustring.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <string>
 #include <unordered_map>

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cstdio>

--- a/src/maketx/CMakeLists.txt
+++ b/src/maketx/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 fancy_add_executable (LINK_LIBRARIES OpenImageIO)

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <cstdio>

--- a/src/nuke/txWriter/CMakeLists.txt
+++ b/src/nuke/txWriter/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_library (txWriter MODULE txWriter.cpp)
 

--- a/src/null.imageio/CMakeLists.txt
+++ b/src/null.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (nullimageio.cpp)

--- a/src/null.imageio/nullimageio.cpp
+++ b/src/null.imageio/nullimageio.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cstdio>

--- a/src/oiiotool/CMakeLists.txt
+++ b/src/oiiotool/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 fancy_add_executable (LINK_LIBRARIES
                         OpenImageIO

--- a/src/oiiotool/diff.cpp
+++ b/src/oiiotool/diff.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cmath>

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cmath>

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <algorithm>

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #pragma once

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cmath>

--- a/src/openexr.imageio/CMakeLists.txt
+++ b/src/openexr.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 set (openexr_src exrinput.cpp exroutput.cpp)
 

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cerrno>
 #include <cmath>

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -1,6 +1,6 @@
 // Copyright 2021-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cerrno>
 #include <cmath>

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cerrno>
 #include <cmath>

--- a/src/openvdb.imageio/CMakeLists.txt
+++ b/src/openvdb.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 if (OpenVDB_FOUND)
     add_oiio_plugin (openvdbinput.cpp

--- a/src/openvdb.imageio/openvdbinput.cpp
+++ b/src/openvdb.imageio/openvdbinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>

--- a/src/png.imageio/CMakeLists.txt
+++ b/src/png.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 if (TARGET PNG::PNG)
     add_oiio_plugin (pnginput.cpp pngoutput.cpp

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #pragma once
 

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <cstdio>

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <cstdio>

--- a/src/pnm.imageio/CMakeLists.txt
+++ b/src/pnm.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (pnminput.cpp pnmoutput.cpp)

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cstdlib>
 #include <fstream>

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <fstream>
 

--- a/src/psd.imageio/CMakeLists.txt
+++ b/src/psd.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (psdinput.cpp jpeg_memory_src.cpp
                  INCLUDE_DIRS ${JPEG_INCLUDE_DIR}

--- a/src/psd.imageio/jpeg_memory_src.cpp
+++ b/src/psd.imageio/jpeg_memory_src.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cstdio>
 

--- a/src/psd.imageio/jpeg_memory_src.h
+++ b/src/psd.imageio/jpeg_memory_src.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #pragma once
 

--- a/src/psd.imageio/psd_pvt.h
+++ b/src/psd.imageio/psd_pvt.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #pragma once
 

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 //

--- a/src/ptex.imageio/CMakeLists.txt
+++ b/src/ptex.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 if (Ptex_FOUND)
     add_oiio_plugin (ptexinput.cpp

--- a/src/ptex.imageio/ptexinput.cpp
+++ b/src/ptex.imageio/ptexinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <Ptexture.h>
 

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 # from pythonutils.cmake
 checked_find_package (pybind11 REQUIRED

--- a/src/python/py_colorconfig.cpp
+++ b/src/python/py_colorconfig.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include "py_oiio.h"
 #include <OpenImageIO/color.h>

--- a/src/python/py_deepdata.cpp
+++ b/src/python/py_deepdata.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include "py_oiio.h"
 

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include "py_oiio.h"
 

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include "py_oiio.h"
 #include <OpenImageIO/color.h>

--- a/src/python/py_imagecache.cpp
+++ b/src/python/py_imagecache.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include "py_oiio.h"
 

--- a/src/python/py_imageinput.cpp
+++ b/src/python/py_imageinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include "py_oiio.h"
 

--- a/src/python/py_imageoutput.cpp
+++ b/src/python/py_imageoutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 // Avoid a compiler warning from a duplication in tiffconf.h/pyconfig.h
 #undef SIZEOF_LONG

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include "py_oiio.h"
 

--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include "py_oiio.h"
 

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #ifndef PYOPENIMAGEIO_PY_OIIO_H
 #define PYOPENIMAGEIO_PY_OIIO_H

--- a/src/python/py_paramvalue.cpp
+++ b/src/python/py_paramvalue.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include "py_oiio.h"
 

--- a/src/python/py_roi.cpp
+++ b/src/python/py_roi.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include "py_oiio.h"
 

--- a/src/python/py_texturesys.cpp
+++ b/src/python/py_texturesys.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include "py_oiio.h"
 

--- a/src/python/py_typedesc.cpp
+++ b/src/python/py_typedesc.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include "py_oiio.h"
 

--- a/src/r3d.imageio/CMakeLists.txt
+++ b/src/r3d.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 # Require the R3DSDK
 

--- a/src/raw.imageio/CMakeLists.txt
+++ b/src/raw.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 if (LIBRAW_FOUND)
     add_oiio_plugin (rawinput.cpp

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <algorithm>
 #include <ctime> /* time_t, struct tm, gmtime */

--- a/src/rla.imageio/CMakeLists.txt
+++ b/src/rla.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (rlainput.cpp rlaoutput.cpp)

--- a/src/rla.imageio/rla_pvt.h
+++ b/src/rla.imageio/rla_pvt.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #pragma once
 

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cassert>
 #include <cmath>

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <cstdio>

--- a/src/sgi.imageio/CMakeLists.txt
+++ b/src/sgi.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (sgiinput.cpp sgioutput.cpp)

--- a/src/sgi.imageio/sgi_pvt.h
+++ b/src/sgi.imageio/sgi_pvt.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #pragma once
 

--- a/src/sgi.imageio/sgiinput.cpp
+++ b/src/sgi.imageio/sgiinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 #include "sgi_pvt.h"
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/fmath.h>

--- a/src/sgi.imageio/sgioutput.cpp
+++ b/src/sgi.imageio/sgioutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include "sgi_pvt.h"
 

--- a/src/socket.imageio/CMakeLists.txt
+++ b/src/socket.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (socketinput.cpp socketoutput.cpp socket_pvt.cpp
                  DEFINITIONS "-DUSE_BOOST_ASIO=1")

--- a/src/socket.imageio/socket_pvt.cpp
+++ b/src/socket.imageio/socket_pvt.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/socket.imageio/socket_pvt.h
+++ b/src/socket.imageio/socket_pvt.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/socket.imageio/socketinput.cpp
+++ b/src/socket.imageio/socketinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <OpenImageIO/imageio.h>
 

--- a/src/socket.imageio/socketoutput.cpp
+++ b/src/socket.imageio/socketoutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <OpenImageIO/imageio.h>
 

--- a/src/softimage.imageio/CMakeLists.txt
+++ b/src/softimage.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (softimageinput.cpp softimage_pvt.cpp)

--- a/src/softimage.imageio/softimage_pvt.cpp
+++ b/src/softimage.imageio/softimage_pvt.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include "softimage_pvt.h"
 

--- a/src/softimage.imageio/softimage_pvt.h
+++ b/src/softimage.imageio/softimage_pvt.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #pragma once
 

--- a/src/softimage.imageio/softimageinput.cpp
+++ b/src/softimage.imageio/softimageinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include "softimage_pvt.h"
 

--- a/src/targa.imageio/CMakeLists.txt
+++ b/src/targa.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (targainput.cpp targaoutput.cpp)

--- a/src/targa.imageio/targa_pvt.h
+++ b/src/targa.imageio/targa_pvt.h
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #pragma once
 

--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <cstdio>

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <cstdio>

--- a/src/term.imageio/CMakeLists.txt
+++ b/src/term.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (termoutput.cpp)

--- a/src/term.imageio/termoutput.cpp
+++ b/src/term.imageio/termoutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cstdio>
 

--- a/src/testtex/CMakeLists.txt
+++ b/src/testtex/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 # testtex ordinarily gets built for testing but is not "installed". Setting
 # -DENABLE_INSTALL_testtex=ON will install this test program along with the

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cmath>

--- a/src/tiff.imageio/CMakeLists.txt
+++ b/src/tiff.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (tiffinput.cpp tiffoutput.cpp
                  INCLUDE_DIRS ${TIFF_INCLUDE_DIR}

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <algorithm>

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 
 #include <cmath>

--- a/src/webp.imageio/CMakeLists.txt
+++ b/src/webp.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 if (WebP_FOUND)
     add_oiio_plugin (webpinput.cpp webpoutput.cpp

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cstdio>
 

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cstdio>
 

--- a/src/zfile.imageio/CMakeLists.txt
+++ b/src/zfile.imageio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (zfile.cpp
                  LINK_LIBRARIES ZLIB::ZLIB)

--- a/src/zfile.imageio/zfile.cpp
+++ b/src/zfile.imageio/zfile.cpp
@@ -1,6 +1,6 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
-// https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+// https://github.com/OpenImageIO/oiio
 
 #include <cmath>
 #include <cstdio>


### PR DESCRIPTION
Rather than the specific license file. Users can find that. Better to use
the project link. I'd been meaning to do this for a long time.

Plus, it has the advantage that if we ever rename the master branch
(as many projects are doing), we won't be littered with references to URLs
that incorporate the old name.
