### PR TITLE
New global OIIO attribute: "try_all_readers"

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2439,7 +2439,7 @@ OIIO_API bool has_error();
 /// error messages.
 OIIO_API std::string geterror(bool clear = true);
 
-/// `OIIO::attribute()` sets an global attribute (i.e., a property or
+/// `OIIO::attribute()` sets a global attribute (i.e., a property or
 /// option) of OpenImageIO. The `name` designates the name of the attribute,
 /// `type` describes the type of data, and `val` is a pointer to memory
 /// containing the new value for the attribute.
@@ -2480,7 +2480,7 @@ OIIO_API std::string geterror(bool clear = true);
 ///    application level, each of which is expected to be making separate
 ///    OIIO calls simultaneously, should set this to 1, thus having each
 ///    calling thread do its own work inside of OIIO rather than spawning
-///    new threads with a high overall "fan out.""
+///    new threads with a high overall "fan out."
 ///
 /// - `int exr_threads`
 ///
@@ -2497,6 +2497,15 @@ OIIO_API std::string geterror(bool clear = true);
 ///
 ///    Colon-separated (or semicolon-separated) list of directories to search
 ///    for dynamically-loaded format plugins.
+///
+/// - `int try_all_readers`
+///
+///    When nonzero (the default), a call to `ImageInput::create()` or
+///    `ImageInput::open()` that does not succeed in opening the file with the
+///    format reader implied by the file extension will try all available
+///    format readers to see if one of them can open the file. If this is
+///    zero, the only reader that will be tried is the one implied by the file
+///    extension.
 ///
 /// - `int read_chunk`
 ///

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -37,6 +37,7 @@ recursive_mutex imageio_mutex;
 atomic_int oiio_threads(threads_default());
 atomic_int oiio_exr_threads(threads_default());
 atomic_int oiio_read_chunk(256);
+atomic_int oiio_try_all_readers(1);
 int openexr_core(0);  // Should we use "Exr core C library"?
 int tiff_half(0);
 int tiff_multithread(1);
@@ -354,6 +355,10 @@ attribute(string_view name, TypeDesc type, const void* val)
             *(const char**)val);
         return true;
     }
+    if (name == "try_all_readers" && type == TypeInt) {
+        oiio_try_all_readers = *(const int*)val;
+        return true;
+    }
 
     return false;
 }
@@ -464,6 +469,10 @@ getattribute(string_view name, TypeDesc type, void* val)
     if (name == "missingcolor" && type == TypeString) {
         // missingcolor as string
         *(ustring*)val = ustring(Strutil::join(oiio_missingcolor, ","));
+        return true;
+    }
+    if (name == "try_all_readers" && type == TypeInt) {
+        *(int*)val = oiio_try_all_readers;
         return true;
     }
     return false;

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -25,6 +25,7 @@ namespace pvt {
 extern recursive_mutex imageio_mutex;
 extern atomic_int oiio_threads;
 extern atomic_int oiio_read_chunk;
+extern atomic_int oiio_try_all_readers;
 extern ustring font_searchpath;
 extern ustring plugin_searchpath;
 extern std::string format_list;

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -711,7 +711,7 @@ ImageInput::create(string_view filename, bool do_open, const ImageSpec* config,
         in.reset();
     }
 
-    if (!create_function) {
+    if (!create_function && pvt::oiio_try_all_readers) {
         // If a plugin can't be found that was explicitly designated for
         // this extension, then just try every one we find and see if
         // any will open the file.  Add a configuration request that


### PR DESCRIPTION
When ImageInput::create() or open() is called, it first uses the
extension of the filename to guess which reader plugin to try (for
example, "foo.jpg" will try the jpeg reader). If that fails, however,
the default behavior is to then try EVERY reader to see if any will
open the file, in case it guessed wrong, or the extension is used by
more than one format, or the file was simply given the wrong
name. Thus, ultimately, OIIO will never fail to open a valid image
file in a known format, even if the file is wildly misnamed. However,
it's a lot faster to open a correctly named file, because it will try
that one first, before trying a long succession of readers in the hope
that eventually one will work.

There are three cases where this is not the desired behavior:

1. You are confident that files are named with the correct extensions,
and you want a corrupt or invalid file to fail QUICKLY, without trying
every format reader.

2. If the file is corrupt, rather than see a generic "Could not find
any format reader that will open the file" because they all failed,
you want to see the more specific error message for why the (presumed)
correct reader could not succeed.

3. When doing regression tests to make sure that sample corrupted
files are correctly reporting the right errors, we really do want to
see error messages from that one reader we are testing.

This PR exposes a global OIIO attribute, "try_all_readers", which
defaults to 1, but when set to 0, changes the behavior so that ONLY
the one format implied by the file extension is tried, and OIIO does
not subsequently try every known reader.
