### PR TITLE
Fix excessive memory usage when saving EXR file with many channels

### DIFF
--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -395,7 +395,7 @@ ImageOutput::to_native_rectangle(int xbegin, int xend, int ybegin, int yend,
     // (cases #3 and #4 above).
     imagesize_t contiguoussize = contiguous
                                      ? 0
-                                     : rectangle_values * input_pixel_bytes;
+                                     : rectangle_pixels * input_pixel_bytes;
     contiguoussize             = (contiguoussize + 3)
                      & (~3);  // Round up to 4-byte boundary
     OIIO_DASSERT((contiguoussize & 3) == 0);


### PR DESCRIPTION
## Description

Scratch memory allocation in `ImageOutput::to_native_rectangle` was accidentally using the number of channels squared.

We encountered a case where saving a 2K EXR file with 107 channels would use more than 50GB.

I don't have a simple isolated repro case. It requires writing tiles with a stride that does not match the stride in the image file. But hopefully the error in the code is clear.

## Tests

I did not add a test, it's not clear there is a good mechanism to verify memory usage like this with a test.

## Checklist:

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [X] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project.

