### PR TITLE
Raise ImageCache default tile cache size to 1GB

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1628,7 +1628,7 @@ void
 ImageCacheImpl::init()
 {
     set_max_open_files(100);
-    m_max_memory_bytes     = 256 * 1024 * 1024;  // 256 MB default cache size
+    m_max_memory_bytes     = 1024LL * 1024 * 1024;  // 1 GB default cache size
     m_autotile             = 0;
     m_autoscanline         = false;
     m_automip              = false;


### PR DESCRIPTION
In the early days of OIIO, it was 100MB. Ten years ago, we bumped it
to 256MB. I've heard a rumor that computer memories have grown in the
last 10 years, and so have the size of images some people deal
with. So it seems reasonable to raise it to 1GB.
