### PR TITLE
Fix docs/behavior with webp "LoopCount"

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -2104,7 +2104,7 @@ part of the format name):
 
 **Custom I/O Overrides**
 
-TIFF input (but, currently, not output) supports the "custom I/O" feature
+TIFF input and output support the "custom I/O" feature
 via the `ImageInput::set_ioproxy()` method and the special
 ``"oiio:ioproxy"`` attributes (see Section :ref:`sec-imageinput-ioproxy`).
 
@@ -2269,7 +2269,7 @@ open standard for lossy-compressed images for use on the web.
    * - ``oiio:LoopCount``
      - int
      - Number of times the animation should be played (0-65535, 0 stands for infinity).
-   * - ``gif:LoopCount``
+   * - ``webp:LoopCount``
      - int
      - Deprecated synonym for ``oiio:LoopCount``.
 

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -165,8 +165,10 @@ WebpInput::open(const std::string& name, ImageSpec& spec)
         m_spec.attribute("oiio:Movie", 1);
         m_frame_count       = (int)WebPDemuxGetI(m_demux, WEBP_FF_FRAME_COUNT);
         uint32_t loop_count = WebPDemuxGetI(m_demux, WEBP_FF_LOOP_COUNT);
-        if (loop_count)
-            m_spec.attribute("webp:LoopCount", (int)loop_count);
+        if (loop_count) {
+            m_spec.attribute("oiio:LoopCount", (int)loop_count);
+            m_spec.attribute("webp:LoopCount", (int)loop_count);  // DEPRECATED
+        }
         // uint32_t bgcolor = WebPDemuxGetI(m_demux, WEBP_FF_BACKGROUND_COLOR    );
         // Strutil::print("  animated {} frames, loop {}, bgcolor={}\n",
         //                frame_count, loop_count, bgcolor);


### PR DESCRIPTION
* Typo in webp section -- said "gif:LoopCount" when we meant
  "webp:LoopCount".

* In the code, did not actually set the "oiio:LoopCount" metadata
  that the docs said would be set.

* Opportunistic fix: TIFF docs said we only suported IOProxy for input,
  but we have supported it for output for a while now.
