### PR TITLE
TypeDesc ctr from string: accept "box2f", "box3f"

### DIFF
--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -306,9 +306,9 @@ TypeDesc::fromstring(string_view typestring)
         t = TypeBox2i;
     else if (type == "box3i")
         t = TypeBox3i;
-    else if (type == "box2")
+    else if (type == "box2" || type == "box2f")
         t = TypeBox2;
-    else if (type == "box3")
+    else if (type == "box3" || type == "box3f")
         t = TypeBox3;
     else if (type == "timecode")
         t = TypeTimeCode;

--- a/src/libutil/typedesc_test.cpp
+++ b/src/libutil/typedesc_test.cpp
@@ -142,6 +142,14 @@ main(int /*argc*/, char* /*argv*/[])
                             TypeDesc(TypeDesc::FLOAT, TypeDesc::VEC3,
                                      TypeDesc::BOX, 2),
                             TypeBox3);
+    test_type<Imath::Box2f>("box2f",  // synonym for box2
+                            TypeDesc(TypeDesc::FLOAT, TypeDesc::VEC2,
+                                     TypeDesc::BOX, 2),
+                            TypeBox2);
+    test_type<Imath::Box3f>("box3f",  // synonym for box3
+                            TypeDesc(TypeDesc::FLOAT, TypeDesc::VEC3,
+                                     TypeDesc::BOX, 2),
+                            TypeBox3);
     test_type<Imath::Box2i>("box2i",
                             TypeDesc(TypeDesc::INT, TypeDesc::VEC2,
                                      TypeDesc::BOX, 2),


### PR DESCRIPTION
The official names we use are "box2" and "box3", but users of Imath
know these as box2f/box3f, so accept these as synonyms when
constructing a TypeDesc from a string.

