### PR TITLE
SPI Specific: default to LLVM 12.0.1

### DIFF
--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -30,7 +30,7 @@ ifeq (${SP_OS}, rhel7)
     ifeq (${SPI_COMPILER_PLATFORM},gcc-6.3)
         SPCOMP2_COMPILER ?= gcc63
         CMAKE_CXX_STANDARD ?= 14
-        LLVM_VERSION ?= 11.0.1
+        LLVM_VERSION ?= 12.0.1
     endif
     SP_PLATFORM ?= linux
 else ifeq (${platform}, macosx)


### PR DESCRIPTION
## Description
Running make at SPI currently complains about not finding llvm 11.0.1 (we don't have it; the closest one is 11.0.0) - is it ok to move up to 12.0.1 (which we do have installed)?

## Tests
make now builds without complaining about not finding llvm 11.0.1

## Checklist:

- [X] I have read the contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project.

