### PR TITLE
adding host/device attributes to make TypeDesc methods GPU device-fri…

### DIFF
--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -129,7 +129,7 @@ struct OIIO_UTIL_API TypeDesc {
 
     /// Construct from a BASETYPE and optional aggregateness, semantics,
     /// and arrayness.
-    constexpr TypeDesc (BASETYPE btype=UNKNOWN, AGGREGATE agg=SCALAR,
+    OIIO_HOSTDEVICE constexpr TypeDesc (BASETYPE btype=UNKNOWN, AGGREGATE agg=SCALAR,
                         VECSEMANTICS semantics=NOSEMANTICS,
                         int arraylen=0) noexcept
         : basetype(static_cast<unsigned char>(btype)),
@@ -139,12 +139,12 @@ struct OIIO_UTIL_API TypeDesc {
           { }
 
     /// Construct an array of a non-aggregate BASETYPE.
-    constexpr TypeDesc (BASETYPE btype, int arraylen) noexcept
+    OIIO_HOSTDEVICE constexpr TypeDesc (BASETYPE btype, int arraylen) noexcept
         : TypeDesc(btype, SCALAR, NOSEMANTICS, arraylen) {}
 
     /// Construct an array from BASETYPE, AGGREGATE, and array length,
     /// with unspecified (or moot) semantic hints.
-    constexpr TypeDesc (BASETYPE btype, AGGREGATE agg, int arraylen) noexcept
+    OIIO_HOSTDEVICE constexpr TypeDesc (BASETYPE btype, AGGREGATE agg, int arraylen) noexcept
         : TypeDesc(btype, agg, NOSEMANTICS, arraylen) {}
 
     /// Construct from a string (e.g., "float[3]").  If no valid
@@ -163,7 +163,7 @@ struct OIIO_UTIL_API TypeDesc {
     TypeDesc (string_view typestring);
 
     /// Copy constructor.
-    constexpr TypeDesc (const TypeDesc &t) noexcept
+    OIIO_HOSTDEVICE constexpr TypeDesc (const TypeDesc &t) noexcept
         : basetype(t.basetype), aggregate(t.aggregate),
           vecsemantics(t.vecsemantics), reserved(0), arraylen(t.arraylen)
           { }
@@ -179,7 +179,7 @@ struct OIIO_UTIL_API TypeDesc {
 
     /// Return the number of elements: 1 if not an array, or the array
     /// length. Invalid to call this for arrays of undetermined size.
-    OIIO_CONSTEXPR14 size_t numelements () const noexcept {
+    OIIO_HOSTDEVICE OIIO_CONSTEXPR14 size_t numelements () const noexcept {
         OIIO_DASSERT_MSG (arraylen >= 0, "Called numelements() on TypeDesc "
                           "of array with unspecified length (%d)", arraylen);
         return (arraylen >= 1 ? arraylen : 1);
@@ -188,23 +188,23 @@ struct OIIO_UTIL_API TypeDesc {
     /// Return the number of basetype values: the aggregate count multiplied
     /// by the array length (or 1 if not an array). Invalid to call this
     /// for arrays of undetermined size.
-    OIIO_CONSTEXPR14 size_t basevalues () const noexcept {
+    OIIO_HOSTDEVICE OIIO_CONSTEXPR14 size_t basevalues () const noexcept {
         return numelements() * aggregate;
     }
 
     /// Does this TypeDesc describe an array?
-    constexpr bool is_array () const noexcept { return (arraylen != 0); }
+    OIIO_HOSTDEVICE constexpr bool is_array () const noexcept { return (arraylen != 0); }
 
     /// Does this TypeDesc describe an array, but whose length is not
     /// specified?
-    constexpr bool is_unsized_array () const noexcept { return (arraylen < 0); }
+    OIIO_HOSTDEVICE constexpr bool is_unsized_array () const noexcept { return (arraylen < 0); }
 
     /// Does this TypeDesc describe an array, whose length is specified?
-    constexpr bool is_sized_array () const noexcept { return (arraylen > 0); }
+    OIIO_HOSTDEVICE constexpr bool is_sized_array () const noexcept { return (arraylen > 0); }
 
     /// Return the size, in bytes, of this type.
     ///
-    size_t size () const noexcept {
+    OIIO_HOSTDEVICE size_t size () const noexcept {
         OIIO_DASSERT_MSG (arraylen >= 0, "Called size() on TypeDesc "
                           "of array with unspecified length (%d)", arraylen);
         size_t a = (size_t) (arraylen > 0 ? arraylen : 1);
@@ -221,17 +221,17 @@ struct OIIO_UTIL_API TypeDesc {
 
     /// Return the type of one element, i.e., strip out the array-ness.
     ///
-    OIIO_CONSTEXPR14 TypeDesc elementtype () const noexcept {
+    OIIO_HOSTDEVICE OIIO_CONSTEXPR14 TypeDesc elementtype () const noexcept {
         TypeDesc t (*this);  t.arraylen = 0;  return t;
     }
 
     /// Return the size, in bytes, of one element of this type (that is,
     /// ignoring whether it's an array).
-    size_t elementsize () const noexcept { return aggregate * basesize(); }
+    OIIO_HOSTDEVICE size_t elementsize () const noexcept { return aggregate * basesize(); }
 
     /// Return just the underlying C scalar type, i.e., strip out the
     /// array-ness and the aggregateness.
-    constexpr TypeDesc scalartype() const { return TypeDesc(BASETYPE(basetype)); }
+    OIIO_HOSTDEVICE constexpr TypeDesc scalartype() const { return TypeDesc(BASETYPE(basetype)); }
 
     /// Return the base type size, i.e., stripped of both array-ness
     /// and aggregateness.
@@ -245,10 +245,10 @@ struct OIIO_UTIL_API TypeDesc {
     bool is_signed () const noexcept;
 
     /// Shortcut: is it UNKNOWN?
-    constexpr bool is_unknown () const noexcept { return (basetype == UNKNOWN); }
+    OIIO_HOSTDEVICE constexpr bool is_unknown () const noexcept { return (basetype == UNKNOWN); }
 
     /// if (typedesc) is the same as asking whether it's not UNKNOWN.
-    constexpr operator bool () const noexcept { return (basetype != UNKNOWN); }
+    OIIO_HOSTDEVICE constexpr operator bool () const noexcept { return (basetype != UNKNOWN); }
 
     /// Set *this to the type described in the string.  Return the
     /// length of the part of the string that describes the type.  If
@@ -258,77 +258,77 @@ struct OIIO_UTIL_API TypeDesc {
 
     /// Compare two TypeDesc values for equality.
     ///
-    constexpr bool operator== (const TypeDesc &t) const noexcept {
+    OIIO_HOSTDEVICE constexpr bool operator== (const TypeDesc &t) const noexcept {
         return basetype == t.basetype && aggregate == t.aggregate &&
             vecsemantics == t.vecsemantics && arraylen == t.arraylen;
     }
 
     /// Compare two TypeDesc values for inequality.
     ///
-    constexpr bool operator!= (const TypeDesc &t) const noexcept { return ! (*this == t); }
+    OIIO_HOSTDEVICE constexpr bool operator!= (const TypeDesc &t) const noexcept { return ! (*this == t); }
 
     /// Compare a TypeDesc to a basetype (it's the same if it has the
     /// same base type and is not an aggregate or an array).
-    friend constexpr bool operator== (const TypeDesc &t, BASETYPE b) noexcept {
+    OIIO_HOSTDEVICE friend constexpr bool operator== (const TypeDesc &t, BASETYPE b) noexcept {
         return (BASETYPE)t.basetype == b && (AGGREGATE)t.aggregate == SCALAR && !t.is_array();
     }
-    friend constexpr bool operator== (BASETYPE b, const TypeDesc &t) noexcept {
+    OIIO_HOSTDEVICE friend constexpr bool operator== (BASETYPE b, const TypeDesc &t) noexcept {
         return (BASETYPE)t.basetype == b && (AGGREGATE)t.aggregate == SCALAR && !t.is_array();
     }
 
     /// Compare a TypeDesc to a basetype (it's the same if it has the
     /// same base type and is not an aggregate or an array).
-    friend constexpr bool operator!= (const TypeDesc &t, BASETYPE b) noexcept {
+    OIIO_HOSTDEVICE friend constexpr bool operator!= (const TypeDesc &t, BASETYPE b) noexcept {
         return (BASETYPE)t.basetype != b || (AGGREGATE)t.aggregate != SCALAR || t.is_array();
     }
-    friend constexpr bool operator!= (BASETYPE b, const TypeDesc &t) noexcept {
+    OIIO_HOSTDEVICE friend constexpr bool operator!= (BASETYPE b, const TypeDesc &t) noexcept {
         return (BASETYPE)t.basetype != b || (AGGREGATE)t.aggregate != SCALAR || t.is_array();
     }
 
     /// TypeDesc's are equivalent if they are equal, or if their only
     /// inequality is differing vector semantics.
-    friend constexpr bool equivalent (const TypeDesc &a, const TypeDesc &b) noexcept {
+    OIIO_HOSTDEVICE friend constexpr bool equivalent (const TypeDesc &a, const TypeDesc &b) noexcept {
         return a.basetype == b.basetype && a.aggregate == b.aggregate &&
                (a.arraylen == b.arraylen || (a.is_unsized_array() && b.is_sized_array())
                                          || (a.is_sized_array()   && b.is_unsized_array()));
     }
     /// Member version of equivalent
-    constexpr bool equivalent (const TypeDesc &b) const noexcept {
+    OIIO_HOSTDEVICE constexpr bool equivalent (const TypeDesc &b) const noexcept {
         return this->basetype == b.basetype && this->aggregate == b.aggregate &&
                (this->arraylen == b.arraylen || (this->is_unsized_array() && b.is_sized_array())
                                              || (this->is_sized_array()   && b.is_unsized_array()));
     }
 
     /// Is this a 2-vector aggregate (of the given type, float by default)?
-    constexpr bool is_vec2 (BASETYPE b=FLOAT) const noexcept {
+    OIIO_HOSTDEVICE constexpr bool is_vec2 (BASETYPE b=FLOAT) const noexcept {
         return this->aggregate == VEC2 && this->basetype == b && !is_array();
     }
 
     /// Is this a 3-vector aggregate (of the given type, float by default)?
-    constexpr bool is_vec3 (BASETYPE b=FLOAT) const noexcept {
+    OIIO_HOSTDEVICE constexpr bool is_vec3 (BASETYPE b=FLOAT) const noexcept {
         return this->aggregate == VEC3 && this->basetype == b && !is_array();
     }
 
     /// Is this a 4-vector aggregate (of the given type, float by default)?
-    constexpr bool is_vec4 (BASETYPE b=FLOAT) const noexcept {
+    OIIO_HOSTDEVICE constexpr bool is_vec4 (BASETYPE b=FLOAT) const noexcept {
         return this->aggregate == VEC4 && this->basetype == b && !is_array();
     }
 
     /// Is this an array of aggregates that represents a 2D bounding box?
-    constexpr bool is_box2 (BASETYPE b=FLOAT) const noexcept {
+    OIIO_HOSTDEVICE constexpr bool is_box2 (BASETYPE b=FLOAT) const noexcept {
         return this->aggregate == VEC2 && this->basetype == b && arraylen == 2
                 && this->vecsemantics == BOX;
     }
 
     /// Is this an array of aggregates that represents a 3D bounding box?
-    constexpr bool is_box3 (BASETYPE b=FLOAT) const noexcept {
+    OIIO_HOSTDEVICE constexpr bool is_box3 (BASETYPE b=FLOAT) const noexcept {
         return this->aggregate == VEC3 && this->basetype == b && arraylen == 2
                 && this->vecsemantics == BOX;
     }
 
     /// Demote the type to a non-array
     ///
-    void unarray (void) noexcept { arraylen = 0; }
+    OIIO_HOSTDEVICE void unarray (void) noexcept { arraylen = 0; }
 
     /// Test for lexicographic 'less', comes in handy for lots of STL
     /// containers and algorithms.


### PR DESCRIPTION


## Description

adds some `__host__`/`__device__` attributes so we can use some `TypeDesc` methods on the GPU.

## Tests


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

