### PR TITLE
Fix to `oiiotool --invert` : avoid losing the alpha channel values

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -2180,10 +2180,22 @@ current top image.
 
 .. option:: --invert
 
-    Replace the top images with its color inverse. It only inverts the first
-    three channels, in order to preserve alpha.
-    
+    Replace the top image with its color inverse. By default, it only
+    inverts the first three channels in order to preserve alpha, but you
+    can override the channel range of the inversion with optional modifiers
+    `chbegin` and `chend`. Channels outside this range will simply be
+    copied, without inversion.
+
     Optional appended modifiers include:
+
+      `:chbegin=` *int*
+        Override the beginning of the range of channels to be inverted
+        (defaults to 0.)
+
+      `:chend=` *int*
+        Override the end of the range of channels to be inverted (defaults
+        to 3). Remember that this is one more than the index of the last
+        channel to be inverted.
 
       `:subimages=` *indices-or-names*
         Include/exclude subimages (see :ref:`sec-oiiotool-subimage-modifier`).

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -3069,9 +3069,18 @@ OIIOTOOL_OP(mad, 3, [](OiiotoolOp& op, span<ImageBuf*> img) {
 
 // --invert
 OIIOTOOL_OP(invert, 1, [](OiiotoolOp& op, span<ImageBuf*> img) {
-    // invert the first three channels only, spare alpha
-    ROI roi   = img[1]->roi();
-    roi.chend = std::min(3, roi.chend);
+    ROI roi = img[1]->roi();
+    // By default, we only invert channels [0,3), but this can be overridden
+    // by optional modifiers chbegin and chend.
+    int chbegin = op.options().get_int("chbegin", 0);
+    int chend   = op.options().get_int("chend", std::min(3, roi.chend));
+    if (roi.chbegin < chbegin || roi.chend > chend) {
+        // If the image has channels beyond what we're inverting, start by
+        // copying src to dst first, so we dont lose channels along the way.
+        ImageBufAlgo::copy(*img[0], *img[1]);
+    }
+    roi.chbegin = chbegin;
+    roi.chend   = chend;
     return ImageBufAlgo::invert(*img[0], *img[1], roi, 0);
 });
 
@@ -5923,7 +5932,7 @@ getargs(int argc, char* argv[])
       .help("Multiply two images, add a third")
       .action(action_mad);
     ap.arg("--invert")
-      .help("Take the color inverse (subtract from 1)")
+      .help("Take the color inverse (subtract from 1) (options: chbegin=0, chend=3")
       .action(action_invert);
     ap.arg("--abs")
       .help("Take the absolute value of the image pixels")


### PR DESCRIPTION
When I implemented `oiiotool --invert`, I knew that the default should
be to only invert the first three channels (presumably R,G,B) and not
anything beyond, because we wouldn't want to invert the Alpha channel.

But I botched it, and instead what happened is that if given an RGBA
image, it would just leave the A black in the result image.

So this patch has two improvements:

1. If there are more channels in the source image than we are
   inverting, make sure to copy the other channels unmodified, don't
   just leave them blank.

2. Allow optional modifiers chbegin= and chend=, so users can change
   the default if they want a different channel set to be inverted.
