### PR TITLE
oiiotool --repremult

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -3047,7 +3047,8 @@ BINARY_IMAGE_COLOR_OP(powc, ImageBufAlgo::pow, 1.0f);       // --powc
 
 UNARY_IMAGE_OP(abs, ImageBufAlgo::abs);  // --abs
 
-UNARY_IMAGE_OP(premult, ImageBufAlgo::premult);  // --premult
+UNARY_IMAGE_OP(premult, ImageBufAlgo::premult);      // --premult
+UNARY_IMAGE_OP(repremult, ImageBufAlgo::repremult);  // --repremult
 
 // --unpremult
 OIIOTOOL_OP(unpremult, 1, [](OiiotoolOp& op, span<ImageBuf*> img) {
@@ -6180,6 +6181,9 @@ getargs(int argc, char* argv[])
     ap.arg("--premult")
       .help("Multiply all color channels of the current image by the alpha")
       .action(action_premult);
+    ap.arg("--repremult")
+      .help("Multiply all color channels of the current image by the alpha, but don't crush alpha=0 pixels to black.")
+      .action(action_repremult);
     // clang-format on
 
     if (ap.parse_args(argc, (const char**)argv) < 0) {


### PR DESCRIPTION
ImageBufAlgo has both premult and repremult (as well as unpremult).
But oiiotool only exposed unpremult and premult, but not repremult.
This little patch rectifies that oversight.

Just to remind everybody of the difference:

`premult` just multipies the color channels by alpha, like it says.
Note that for a pixel that has Alpha = 0 but nonzero color, this will
crush the color to black.

That's fine if you have an *original* image that's unpremultiplied and
you want to do a one-time conversion to premultiplied.

But there's another use case, which is when you start with a
premultiplied image, you need to temporarily unpremultiply it (like
for a color space conversion), and then re-premultiply it. In that
case, you may have those glowing pixels in the original image, the
unpremult will preserve them, and you DO NOT want to crush them to
black with the subsequent premult.  So there is a "repremult"
operation that's like premult, but preserves the color values when
alpha == 0. This is the preferred operation when you are doing the
sequence of "unpremult, do something, re-premult" so that the glowing
pixels make it through the round trip.

