### PR TITLE
CI enhancements: MacOS 11, other updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,14 +493,62 @@ jobs:
             !build/testsuite/fits-images
             !build/testsuite/j2kp4files_v1_5
 
-  macos-py38:
-    name: "Mac py38"
-    runs-on: macOS-latest
+  macos10-py38:
+    name: "MacOS-10.15 appleclang12/C++14 py38 boost1.76 exr3.1 ocio2.1"
+    runs-on: macos-10.15
     env:
       CXX: clang++
       PYTHON_VERSION: 3.8
       CMAKE_CXX_STANDARD: 14
-      ENABLE_FIELD3D: OFF
+      ENABLE_OPENVDB: OFF
+      # No OpenVDB because on Homebrew, OpenVDB still uses OpenEXR 2.5
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare ccache timestamp
+        id: ccache_cache_keys
+        run: |
+          echo "::set-output name=date::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
+      - name: ccache
+        id: ccache
+        uses: actions/cache@v2
+        with:
+          path: /Users/runner/.ccache
+          key: ${{ github.job }}-${{ steps.ccache_cache_keys.outputs.date }}
+          restore-keys: |
+            ${{ github.job }}-
+      - name: Build setup
+        run: |
+            src/build-scripts/ci-startup.bash
+      - name: Dependencies
+        run: |
+            src/build-scripts/install_homebrew_deps.bash
+            src/build-scripts/install_test_images.bash
+      - name: Build
+        run: |
+            export PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages:$PYTHONPATH
+            src/build-scripts/ci-build.bash
+      - name: Testsuite
+        run: |
+            src/build-scripts/ci-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: |
+            build/CMake*.{txt,log}
+            build/testsuite/*/*.*
+            !build/testsuite/oiio-images
+            !build/testsuite/openexr-images
+            !build/testsuite/fits-images
+            !build/testsuite/j2kp4files_v1_5
+
+  macos11-py38:
+    name: "MacOS-11 appleclang13/C++17 py39 boost1.76 exr3.1 ocio2.1"
+    runs-on: macos-11
+    env:
+      CXX: clang++
+      PYTHON_VERSION: 3.9
+      CMAKE_CXX_STANDARD: 17
       ENABLE_OPENVDB: OFF
       # No OpenVDB because on Homebrew, OpenVDB still uses OpenEXR 2.5
     steps:
@@ -725,20 +773,17 @@ jobs:
             !build/testsuite/fits-images
             !build/testsuite/j2kp4files_v1_5
 
-  linux-clang11-cpp17:
-    # Test compiling with clang  and C++17 on Linux.
-    name: "Linux clang11: clang11 C++17 avx2 exr3.1 ocio2.0"
+  linux-clang13-cpp17:
+    # Test compiling with clang and C++17 on Linux.
+    name: "Linux clang13: clang13 C++17 py39 avx2 exr3.1 ocio2.0"
     runs-on: ubuntu-18.04
     container:
-      image: aswf/ci-osl:2021-clang11
+      image: aswf/ci-osl:2022-clang13
     env:
       CXX: clang++
       CMAKE_CXX_STANDARD: 17
-      PYTHON_VERSION: 3.7
+      PYTHON_VERSION: 3.9
       USE_SIMD: avx2,f16c
-      PYBIND11_VERSION: v2.6.1
-      OPENEXR_VERSION: v3.1.1
-      # Pick an OCIO commit that includes a warning fix we need for clang
     steps:
       - uses: actions/checkout@v2
       - name: Prepare ccache timestamp
@@ -758,8 +803,6 @@ jobs:
             src/build-scripts/ci-startup.bash
       - name: Dependencies
         run: |
-            sudo rm -rf /usr/local/include/OpenEXR
-            sudo rm -rf /usr/local/lib64/cmake/{IlmBase,OpenEXR}
             src/build-scripts/gh-installdeps.bash
       - name: Build
         run: |
@@ -836,10 +879,10 @@ jobs:
     name: "clang-format verification"
     runs-on: ubuntu-18.04
     container:
-      image: aswf/ci-osl:2021-clang11
+      image: aswf/ci-osl:2022-clang12
     env:
       BUILDTARGET: clang-format
-      PYTHON_VERSION: 3.7
+      PYTHON_VERSION: 3.9
     steps:
       - uses: actions/checkout@v2
       - name: Build setup

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
        CMake configuration flag: `-DCMAKE_CXX_STANDARD=17`, etc.
  * Compilers: **gcc 6.1 - 11.2**, **clang 3.4 - 13**, **MSVS 2017 - 2019**,
    **icc 17+**.
- * CMake >= 3.12 (tested through 3.21)
+ * CMake >= 3.12 (tested through 3.22)
  * OpenEXR/Imath >= 2.3 (recommended: 2.4 or higher; tested through 3.1)
  * libTIFF >= 3.9 (recommended: 4.0+; tested through 4.3)
  * libjpeg >= 8, or libjpeg-turbo >= 1.1 (tested through jpeg9d and jpeg-turbo
@@ -44,7 +44,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you want support for jpeg 2000 images:
      * **OpenJpeg >= 2.0** (tested through 2.4)
  * If you want support for OpenVDB files:
-     * OpenVDB >= 5.0 (tested through 8.1) and Intel TBB >= 2018 (tested
+     * OpenVDB >= 5.0 (tested through 9) and Intel TBB >= 2018 (tested
        through 2021)
      * Note that OpenVDB 8.0+ requires C++14 or higher.
  * If you want support for converting to and from OpenCV data structures,
@@ -63,7 +63,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you want support for DICOM medical image files:
      * DCMTK >= 3.6.1 (tested through 3.6.5)
  * If you want support for WebP images:
-     * WebP >= 0.6.1 (tested through 1.1.0)
+     * WebP >= 0.6.1 (tested through 1.2.1)
  * If you want support for OpenColorIO color transformations:
      * OpenColorIO >= 1.1 (tested through 2.1; 2.0+ is recommended)
  * If you want support for Ptex:

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -28,9 +28,11 @@ brew unlink python@2.7 || true
 brew unlink python@3.9 || true
 brew unlink python@3.8 || true
 brew link --overwrite --force python@${PYTHON_VERSION} || true
-brew upgrade --display-times -q cmake || true
-brew install --display-times -q libtiff imath openexr opencolorio
-brew install --display-times -q libpng giflib webp jpeg-turbo openjpeg
+#brew upgrade --display-times -q cmake || true
+#brew install --display-times -q libtiff
+brew install --display-times -q imath openexr opencolorio
+#brew install --display-times -q libpng giflib webp
+brew install --display-times -q jpeg-turbo openjpeg
 brew install --display-times -q freetype libraw dcmtk pybind11 numpy || true
 brew install --display-times -q ffmpeg libheif libsquish ptex || true
 brew install --display-times -q tbb || true
@@ -52,10 +54,10 @@ fi
 
 # Set up paths. These will only affect the caller if this script is
 # run with 'source' rather than in a separate shell.
-export PATH=/usr/local/opt/qt5/bin:$PATH ;
-export PATH=/usr/local/opt/python/libexec/bin:$PATH ;
-export PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages:$PYTHONPATH ;
-export PATH=/usr/local/opt/llvm/bin:$PATH ;
+export PATH=/usr/local/opt/qt5/bin:$PATH
+export PATH=/usr/local/opt/python/libexec/bin:$PATH
+export PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages:$PYTHONPATH
+#export PATH=/usr/local/opt/llvm/bin:$PATH
 
 # Save the env for use by other stages
 src/build-scripts/save-env.bash

--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -431,7 +431,7 @@ DDSInput::seek_subimage(int subimage, int miplevel)
         // create imagespec for the 3x2 cube map layout
 #ifdef DDS_3X2_CUBE_MAP_LAYOUT
         m_spec = ImageSpec(w * 3, h * 2, m_nchans, TypeDesc::UINT8);
-#else  // 1x6 layout
+#else   // 1x6 layout
         m_spec = ImageSpec(w, h * 6, m_nchans, TypeDesc::UINT8);
 #endif  // DDS_3X2_CUBE_MAP_LAYOUT
         m_spec.depth      = d;
@@ -667,7 +667,7 @@ DDSInput::read_native_tile(int subimage, int miplevel, int x, int y, int z,
         internal_seek_subimage(((x / m_spec.tile_width) << 1)
                                    + y / m_spec.tile_height,
                                m_miplevel, w, h, d);
-#else  // 1x6 layout
+#else   // 1x6 layout
         internal_seek_subimage(y / m_spec.tile_height, m_miplevel, w, h, d);
 #endif  // DDS_3X2_CUBE_MAP_LAYOUT
         if (!w && !h && !d)

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -193,7 +193,7 @@ Strutil::vsprintf(const char* fmt, va_list ap)
 #ifdef va_copy
         va_copy(ap, apsave);
 #else
-        ap = apsave;
+        ap     = apsave;
 #endif
     }
 }

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -599,7 +599,7 @@ write_info(png_structp& sp, png_infop& ip, int& color_type, ImageSpec& spec,
         if (icc_profile && length)
             png_set_iCCP(sp, ip, "Embedded Profile", 0, icc_profile, length);
 #else
-        char* icc_profile = (char*)icc_profile_parameter->data();
+        char* icc_profile      = (char*)icc_profile_parameter->data();
         if (icc_profile && length)
             png_set_iCCP(sp, ip, (png_charp) "Embedded Profile", 0, icc_profile,
                          length);


### PR DESCRIPTION
* Add a test for MacOS 11
* Updated supported versions of dependencies
* Move linux clang test to clang13 on vfx2022 container
* Switch clang-format test to use clang12 (and minor adjustments that result)
