### PR TITLE
IOProxyMixin helper class

### DIFF
--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -10,6 +10,7 @@
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imageio.h>
+#include <OpenImageIO/ioproxymixin.h>
 #include <OpenImageIO/typedesc.h>
 
 #include "dds_pvt.h"
@@ -22,12 +23,15 @@ using namespace DDS_pvt;
 // uncomment the following define to enable 3x2 cube map layout
 //#define DDS_3X2_CUBE_MAP_LAYOUT
 
-class DDSInput final : public ImageInput {
+class DDSInput final : public IOProxyMixin<ImageInput> {
 public:
     DDSInput() { init(); }
     virtual ~DDSInput() { close(); }
     virtual const char* format_name(void) const override { return "dds"; }
+    // supports() and set_ioproxy are inherited from IOProxyMixin
     virtual bool open(const std::string& name, ImageSpec& newspec) override;
+    virtual bool open(const std::string& name, ImageSpec& spec,
+                      const ImageSpec& config) override;
     virtual bool close() override;
     virtual int current_subimage(void) const override
     {
@@ -47,7 +51,6 @@ public:
 
 private:
     std::string m_filename;            ///< Stash the filename
-    FILE* m_file;                      ///< Open image handle
     std::vector<unsigned char> m_buf;  ///< Buffer the image pixels
     int m_subimage;
     int m_miplevel;
@@ -58,17 +61,17 @@ private:
     int m_greenL, m_greenR;  ///< Bit shifts to extract green channel
     int m_blueL, m_blueR;    ///< Bit shifts to extract blue channel
     int m_alphaL, m_alphaR;  ///< Bit shifts to extract alpha channel
-
-    dds_header m_dds;  ///< DDS header
+    dds_header m_dds;        ///< DDS header
+    // Don't forget we inherit m_io from IOProxyMixin
 
     /// Reset everything to initial state
     ///
     void init()
     {
-        m_file     = NULL;
         m_subimage = -1;
         m_miplevel = -1;
         m_buf.clear();
+        ioproxy_clear();
     }
 
     /// Helper function: read the image as scanlines (all but cubemaps).
@@ -90,16 +93,6 @@ private:
 
     /// Helper function: performs the actual pixel decoding.
     bool internal_readimg(unsigned char* dst, int w, int h, int d);
-
-    /// Helper: read, with error detection
-    ///
-    bool fread(void* buf, size_t itemsize, size_t nitems)
-    {
-        size_t n = ::fread(buf, itemsize, nitems, m_file);
-        if (n != nitems)
-            errorf("Read error");
-        return n == nitems;
-    }
 };
 
 
@@ -128,15 +121,22 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 bool
+DDSInput::open(const std::string& name, ImageSpec& newspec,
+               const ImageSpec& config)
+{
+    ioproxy_retrieve_from_config(config);
+    return open(name, newspec);
+}
+
+
+
+bool
 DDSInput::open(const std::string& name, ImageSpec& newspec)
 {
     m_filename = name;
 
-    m_file = Filesystem::fopen(name, "rb");
-    if (!m_file) {
-        errorf("Could not open file \"%s\"", name);
+    if (!ioproxy_use_or_open_for_reading(name))
         return false;
-    }
 
 // due to struct packing, we may get a corrupt header if we just load the
 // struct from file; to address that, read every member individually
@@ -155,7 +155,7 @@ DDSInput::open(const std::string& name, ImageSpec& newspec)
     RH(mipmaps);
 
     // advance the file pointer by 44 bytes (reserved fields)
-    fseek(m_file, 44, SEEK_CUR);
+    fseek(44, SEEK_CUR);
 
     // pixel format struct
     RH(fmt.size);
@@ -172,7 +172,7 @@ DDSInput::open(const std::string& name, ImageSpec& newspec)
     RH(caps.flags2);
 
     // advance the file pointer by 8 bytes (reserved fields)
-    fseek(m_file, 8, SEEK_CUR);
+    fseek(8, SEEK_CUR);
 #undef RH
     if (bigendian()) {
         // DDS files are little-endian
@@ -384,7 +384,7 @@ DDSInput::internal_seek_subimage(int cubeface, int miplevel, unsigned int& w,
         }
     }
     // seek to the offset we've found
-    fseek(m_file, ofs, SEEK_SET);
+    fseek(ofs, SEEK_SET);
 }
 
 
@@ -582,7 +582,7 @@ DDSInput::internal_readimg(unsigned char* dst, int w, int h, int d)
 bool
 DDSInput::readimg_scanlines()
 {
-    //std::cerr << "[dds] readimg: " << ftell (m_file) << "\n";
+    //std::cerr << "[dds] readimg: " << ftell() << "\n";
     // resize destination buffer
     m_buf.resize(m_spec.scanline_bytes() * m_spec.height * m_spec.depth
                  /*/ (1 << m_miplevel)*/);
@@ -608,11 +608,6 @@ DDSInput::readimg_tiles()
 bool
 DDSInput::close()
 {
-    if (m_file) {
-        fclose(m_file);
-        m_file = NULL;
-    }
-
     init();  // Reset to initial state
     return true;
 }

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -139,6 +139,47 @@ OpenImageIO currently only supports reading DDS files, not writing them.
        +y -y"`` if *x* & *y* faces are present, but not *z*).
 
 
+**Configuration settings for DDS input**
+
+When opening an DDS ImageInput with a *configuration* (see
+Section :ref:`sec-inputwithconfig`), the following special configuration
+attributes are supported:
+
+.. list-table::
+   :widths: 30 10 65
+   :header-rows: 1
+
+   * - Input Configuration Attribute
+     - Type
+     - Meaning
+   * - ``oiio:ioproxy``
+     - ptr
+     - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
+       example by reading from memory rather than the file system.
+
+**Configuration settings for DDS output**
+
+When opening an DDS ImageOutput, the following special metadata tokens
+control aspects of the writing itself:
+
+.. list-table::
+   :widths: 30 10 65
+   :header-rows: 1
+
+   * - Output Configuration Attribute
+     - Type
+     - Meaning
+   * - ``oiio:ioproxy``
+     - ptr
+     - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
+       example by writing to a memory buffer.
+
+**Custom I/O Overrides**
+
+DDS supports the "custom I/O" feature via the
+special ``"oiio:ioproxy"`` attributes (see Sections
+:ref:`sec-imageoutput-ioproxy` and :ref:`sec-imageinput-ioproxy`) as well as
+the `set_ioproxy()` methods.
 
 
 |

--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -205,6 +205,7 @@ OIIO_UTIL_API std::string unique_path (string_view model="%%%%-%%%%-%%%%-%%%%");
 OIIO_UTIL_API FILE *fopen (string_view path, string_view mode);
 
 /// Version of fseek that works with 64 bit offsets on all systems.
+/// Like std::fseek, returns zero on success, nonzero on failure.
 OIIO_UTIL_API int fseek (FILE *file, int64_t offset, int whence);
 
 /// Version of ftell that works with 64 bit offsets on all systems.
@@ -364,13 +365,21 @@ public:
     virtual void close () { }
     virtual bool opened () const { return mode() != Closed; }
     virtual int64_t tell () { return m_pos; }
+    // Seek to the position, returning true on success, false on failure.
+    // Note the difference between this and std::fseek() which returns 0 on
+    // success, and -1 on failure.
     virtual bool seek (int64_t offset) { m_pos = offset; return true; }
+    // Read `size` bytes at the current position into `buf[]`, returning the
+    // number of bytes successfully read.
     virtual size_t read (void *buf, size_t size);
+    // Write `size` bytes from `buf[]` at the current position, returning the
+    // number of bytes successfully written.
     virtual size_t write (const void *buf, size_t size);
     // pread(), pwrite() are stateless, do not alter the current file
     // position, and are thread-safe (against each other).
     virtual size_t pread (void *buf, size_t size, int64_t offset);
     virtual size_t pwrite (const void *buf, size_t size, int64_t offset);
+    // Return the total size of the proxy data, in bytes.
     virtual size_t size () const { return 0; }
     virtual void flush () const { }
 

--- a/src/include/OpenImageIO/ioproxymixin.h
+++ b/src/include/OpenImageIO/ioproxymixin.h
@@ -1,0 +1,118 @@
+// Copyright 2008-present Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio
+
+#pragma once
+#define OPENIMAGEIO_IOPROXYMIXIN_H
+
+
+#include <OpenImageIO/filesystem.h>
+#include <OpenImageIO/imageio.h>
+
+OIIO_NAMESPACE_BEGIN
+
+
+/// Convenience template class that can be an ImageInput or ImageOutput that
+/// has extra utilities to fully support IOProxy. The way you use this is, if
+/// you want to make ImageInput and ImageOutput implementations for your
+/// format FMT that are IOProxy-aware, instead of inheriting directly from
+/// ImageInput or ImageOutput, you can do this:
+///
+///      class FMTInput : public IOProxyMixin<ImageInput>
+///      { ... };
+///
+///      class FMTOutput : public IOProxyMixin<ImageOutput>
+///      { ... };
+///
+/// and then within those implementation classes, you can use any of the
+/// IOProxyMixin utility functions.
+template<class T> class IOProxyMixin : public T {
+public:
+    IOProxyMixin() {}
+    ~IOProxyMixin() {}
+
+    virtual int supports(string_view feature) const override
+    {
+        return feature == "ioproxy" || T::supports(feature);
+    }
+
+    virtual bool set_ioproxy(Filesystem::IOProxy* ioproxy) override
+    {
+        m_io = ioproxy;
+        return true;
+    }
+
+protected:
+    // The IOProxy object we will use for all I/O operations.
+    Filesystem::IOProxy* m_io = nullptr;
+    // The "local" proxy that we will create to use if the user didn't
+    // supply a proxy for us to use.
+    std::unique_ptr<Filesystem::IOProxy> m_io_local;
+
+    // Is this file currenty opened (active proxy)?
+    bool ioproxy_opened() { return m_io != nullptr; }
+
+    // Clear the proxy ptr, and close/destroy any "local" proxy.
+    void ioproxy_clear()
+    {
+        m_io = nullptr;
+        m_io_local.reset();
+    }
+
+    // Retrieve any ioproxy request from the configuration hint spec, and make
+    // `m_io` point to it. But if no IOProxy is found in the config, don't
+    // overwrite one we already have.
+    void ioproxy_retrieve_from_config(const ImageSpec& config)
+    {
+        if (auto p = config.find_attribute("oiio:ioproxy", TypeDesc::PTR))
+            m_io = p->get<Filesystem::IOProxy*>();
+    }
+
+    // Presuming that `ioproxy_retrieve_from_config` has already been called,
+    // if `m_io` is still not set (i.e., wasn't found in the config), open a
+    // IOFile local proxy with the given read/write `mode`. Return true if a
+    // proxy is set up. If it can't be done (i.e., no proxy passed, file
+    // couldn't be opened), issue an error and return false.
+    bool ioproxy_use_or_open(string_view name, Filesystem::IOProxy::Mode mode);
+
+    bool ioproxy_use_or_open_for_reading(string_view name)
+    {
+        return ioproxy_use_or_open(name, Filesystem::IOProxy::Mode::Read);
+    }
+
+    bool ioproxy_use_or_open_for_writing(string_view name)
+    {
+        return ioproxy_use_or_open(name, Filesystem::IOProxy::Mode::Write);
+    }
+
+    // Helper: read from the proxy akin to fread(). Return true on success,
+    // false upon failure and issue a helpful error message. NOTE: this is
+    // not the same return value as std::fread, which returns the number of
+    // items read.
+    bool fread(void* buf, size_t itemsize, size_t nitems = 1);
+
+    // Helper: write to the proxy akin to fwrite(). Return true on success,
+    // false upon failure and issue a helpful error message. NOTE: this is
+    // not the same return value as std::fwrite, which returns the number of
+    // items written.
+    bool fwrite(const void* buf, size_t itemsize, size_t nitems = 1);
+
+    // Helper: seek the proxy, akin to fseek. Return true on success, false
+    // upon failure and issue an error message. (NOTE: this is not the same
+    // return value as std::fseek, which returns 0 on success.)
+    bool fseek(int64_t pos, int origin = SEEK_SET);
+
+    // Helper: retrieve the current position of the proxy, akin to ftell.
+    int64_t ftell() { return m_io->tell(); }
+
+    // Write a formatted string to the output proxy. Return true on success,
+    // false upon failure and issue an error message.
+    template<typename Str, typename... Args>
+    inline bool writefmt(const Str& fmt, Args&&... args)
+    {
+        std::string s = Strutil::fmt::format(fmt, args...);
+        return fwrite(s.data(), s.size());
+    }
+};
+
+OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -58,7 +58,8 @@ set (libOpenImageIO_srcs
                           deepdata.cpp exif.cpp exif-canon.cpp
                           formatspec.cpp imagebuf.cpp
                           imageinput.cpp imageio.cpp imageioplugin.cpp
-                          imageoutput.cpp iptc.cpp xmp.cpp
+                          imageoutput.cpp ioproxymixin.cpp
+                          iptc.cpp xmp.cpp
                           color_ocio.cpp
                           maketexture.cpp
                           bluenoise.cpp

--- a/src/libOpenImageIO/ioproxymixin.cpp
+++ b/src/libOpenImageIO/ioproxymixin.cpp
@@ -1,0 +1,109 @@
+// Copyright 2008-present Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+#include <OpenImageIO/imageio.h>
+#include <OpenImageIO/ioproxymixin.h>
+
+#include "imageio_pvt.h"
+
+
+OIIO_NAMESPACE_BEGIN
+using namespace pvt;
+
+
+
+template<class T>
+bool
+IOProxyMixin<T>::ioproxy_use_or_open(string_view name,
+                                     Filesystem::IOProxy::Mode mode)
+{
+    if (!m_io) {
+        // If no proxy was supplied, create an IOFile
+        m_io = new Filesystem::IOFile(name, mode);
+        m_io_local.reset(m_io);
+    }
+    if (!m_io || m_io->mode() != mode) {
+        T::errorfmt("Could not open file \"{}\"", name);
+        ioproxy_clear();
+        return false;
+    }
+    return true;
+}
+
+// Explicit instantiations
+template bool
+IOProxyMixin<ImageInput>::ioproxy_use_or_open(string_view name,
+                                              Filesystem::IOProxy::Mode mode);
+template bool
+IOProxyMixin<ImageOutput>::ioproxy_use_or_open(string_view name,
+                                               Filesystem::IOProxy::Mode mode);
+
+
+
+template<class T>
+bool
+IOProxyMixin<T>::fseek(int64_t pos, int origin)
+{
+    if (!m_io->seek(pos, origin)) {
+        T::errorfmt(
+            "Seek error, could not seek from {} to {} (total size {}) {}",
+            m_io->tell(),
+            origin == SEEK_SET ? pos
+                               : (origin == SEEK_CUR ? pos + m_io->tell()
+                                                     : pos + m_io->size()),
+            m_io->size(), m_io->error());
+        return false;
+    }
+    return true;
+}
+
+template bool
+IOProxyMixin<ImageInput>::fseek(int64_t pos, int origin);
+template bool
+IOProxyMixin<ImageOutput>::fseek(int64_t pos, int origin);
+
+
+
+template<>
+bool
+IOProxyMixin<ImageInput>::fread(void* buf, size_t itemsize, size_t nitems)
+{
+    size_t size = itemsize * nitems;
+    size_t n    = m_io->read(buf, size);
+    if (n != size) {
+        if (size_t(m_io->tell()) >= m_io->size())
+            ImageInput::errorfmt("Read error on \"{}\": hit end of file",
+                                 m_io->filename());
+        else
+            ImageInput::errorfmt(
+                "Read error at position {}, could only read {}/{} bytes {}",
+                m_io->tell() - n, n, size, m_io->error());
+    }
+    return n == size;
+}
+
+
+
+template<>
+bool
+IOProxyMixin<ImageOutput>::fwrite(const void* buf, size_t itemsize,
+                                  size_t nitems)
+{
+    size_t size = itemsize * nitems;
+    size_t n    = m_io->write(buf, size);
+    if (n != size)
+        ImageOutput::errorfmt(
+            "Write error at position {}, could only write {}/{} bytes {}",
+            m_io->tell() - n, n, size, m_io->error());
+    return n == size;
+}
+
+
+OIIO_NAMESPACE_END


### PR DESCRIPTION
IOProxyMixin helper class
    
When implementing a format-specialized derived class of ImageInput or
ImageOutput, now you can inherit from `IOProxyMixin<ImageInput>` or
`IOProxyMixin<ImageOutput>` that gives you the data members and many
convenience functions you'll need for using the IOProxy, without
needing to repeat it in every format plugin that supports proxies.

This coalesces some redundant code that would need to appear
separately in most of the plugins that support IOProxy, helps to
reduce cut-and-paste errors from having to make these changes
separately in many places, and centralizes the logic so that as our
ideas of how to implement IOProxy evolve, we can easily change it in
just one place and have it apply to all plugins.

Revise the JPEG and GIF IOProxy handling to use this new mixin class,
so you can see how it works, and the bits of redundant code that it
eliminates.

Also add IOProxy support to DDS input using the new mixin.
