### PR TITLE
DDS: add test, minor adjustments

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -237,6 +237,9 @@ macro (oiio_add_all_tests)
     oiio_add_tests (dpx
                     ENABLEVAR ENABLE_DPX
                     IMAGEDIR oiio-images URL "Recent checkout of oiio-images")
+    oiio_add_tests (dds
+                    ENABLEVAR ENABLE_DDS
+                    IMAGEDIR oiio-images/dds URL "Recent checkout of oiio-images")
     oiio_add_tests (fits
                     ENABLEVAR ENABLE_FITS
                     IMAGEDIR fits-images

--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -454,15 +454,14 @@ DDSInput::seek_subimage(int subimage, int miplevel)
         tempstr += ((char*)&m_dds.fmt.fourCC)[3];
         m_spec.attribute("compression", tempstr);
     }
-    m_spec.attribute("oiio:BitsPerSample", m_dds.fmt.bpp);
+    if (m_dds.fmt.bpp)
+        m_spec.attribute("oiio:BitsPerSample", m_dds.fmt.bpp);
     m_spec.default_channel_names();
 
     // detect texture type
     if (m_dds.caps.flags2 & DDS_CAPS2_VOLUME) {
-        m_spec.attribute("texturetype", "Volume Texture");
         m_spec.attribute("textureformat", "Volume Texture");
     } else if (m_dds.caps.flags2 & DDS_CAPS2_CUBEMAP) {
-        m_spec.attribute("texturetype", "Environment");
         m_spec.attribute("textureformat", "CubeFace Environment");
         // check available cube map sides
         std::string sides = "";
@@ -495,7 +494,6 @@ DDSInput::seek_subimage(int subimage, int miplevel)
         }
         m_spec.attribute("dds:CubeMapSides", sides);
     } else {
-        m_spec.attribute("texturetype", "Plain Texture");
         m_spec.attribute("textureformat", "Plain Texture");
     }
 

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -129,10 +129,6 @@ OpenImageIO currently only supports reading DDS files, not writing them.
      - string
      - Set correctly to one of ``"Plain Texture"``, ``"Volume Texture"``, or
        ``"CubeFace Environment"``.
-   * - ``texturetype``
-     - string
-     - Set correctly to one of ``"Plain Texture"``, ``"Volume Texture"``,
-       or ``"Environment"``.
    * - ``dds:CubeMapSides``
      - string
      - For environment maps, which cube faces are present (e.g., ``"+x -x

--- a/testsuite/dds/ref/out.txt
+++ b/testsuite/dds/ref/out.txt
@@ -1,0 +1,6 @@
+Reading ../oiio-images/dds/sample-DXT1.dds
+../oiio-images/dds/sample-DXT1.dds :  123 x  456, 4 channel, uint8 dds
+    SHA-1: D6525DC91F2020FB05EF4997BA1A3738955F5B76
+    channel list: R, G, B, A
+    compression: "DXT1"
+    textureformat: "Plain Texture"

--- a/testsuite/dds/run.py
+++ b/testsuite/dds/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+files = [ "sample-DXT1.dds" ]
+for f in files:
+    command += info_command (OIIO_TESTSUITE_IMAGEDIR + "/" + f)


### PR DESCRIPTION
* Add a DDS test, apparently we never had one.
* Remove DDS setting of "texturetype", we don't ever use that, it's only
  "textureformat" that we use. Not sure how that crept in there years ago.
