### PR TITLE
Name gamma-corrected color spaces "GammaX.Y"

### DIFF
--- a/src/cineon.imageio/cineoninput.cpp
+++ b/src/cineon.imageio/cineoninput.cpp
@@ -184,7 +184,7 @@ CineonInput::open(const std::string& name, ImageSpec& newspec)
         if (!std::isinf(m_cin.header.Gamma()) && m_cin.header.Gamma() != 0.0f)
             // actual gamma value is read later on
             m_spec.attribute("oiio:ColorSpace",
-                             Strutil::sprintf("GammaCorrected%.2g", g));
+                             Strutil::sprintf("Gamma%.2g", g));
         break;
     }
 

--- a/src/doc/stdmetadata.rst
+++ b/src/doc/stdmetadata.rst
@@ -144,7 +144,7 @@ Color information
     - `"ACES"` :  ACES color space encoding.
     - `"AdobeRGB"` :  Adobe RGB color space.
     - `"KodakLog"` :  Kodak logarithmic color space.
-    - `"GammaCorrectedX.Y"` :  Color values have been gamma corrected
+    - `"GammaX.Y"` :  Color values have been gamma corrected
       (raised to the power :math:`1/\gamma`). The `X.Y` is the numeric value
       of the gamma exponent.
     - *arbitrary* :  The name of any color space known to OpenColorIO (if
@@ -152,9 +152,9 @@ Color information
 
 .. option:: "oiio:Gamma" : float
 
-    If the color space is "GammaCorrectedX.Y", this value is the gamma
-    exponent. (Optional/deprecated; if present, it should match the suffix
-    of the color space.)
+    If the color space is "GammaX.Y", this value is the gamma exponent.
+    (Optional/deprecated; if present, it should match the suffix of the color
+    space.)
 
 .. option:: "oiio:BorderColor" : float[nchannels]
 

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -332,7 +332,7 @@ DPXInput::seek_subimage(int subimage, int miplevel)
         if (!std::isnan(m_dpx.header.Gamma()) && m_dpx.header.Gamma() != 0) {
             float g = float(m_dpx.header.Gamma());
             m_spec.attribute("oiio:ColorSpace",
-                             Strutil::sprintf("GammaCorrected%.2g", g));
+                             Strutil::sprintf("Gamma%.2g", g));
             m_spec.attribute("oiio:Gamma", g);
             break;
         }

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -467,7 +467,7 @@ DPXOutput::prep_subimage(int s, bool allocate)
     std::string colorspace = m_spec.get_string_attribute("oiio:ColorSpace", "");
     if (Strutil::iequals(colorspace, "Linear"))
         m_transfer = dpx::kLinear;
-    else if (Strutil::iequals(colorspace, "GammaCorrected"))
+    else if (Strutil::istarts_with(colorspace, "Gamma"))
         m_transfer = dpx::kUserDefined;
     else if (Strutil::iequals(colorspace, "Rec709"))
         m_transfer = dpx::kITUR709;

--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -141,7 +141,7 @@ HdrInput::seek_subimage(int subimage, int miplevel)
             m_spec.attribute("oiio:ColorSpace", "linear");
         else
             m_spec.attribute("oiio:ColorSpace",
-                             Strutil::sprintf("GammaCorrected%.2g", g));
+                             Strutil::sprintf("Gamma%.2g", g));
     } else {
         // Presume linear color space
         m_spec.attribute("oiio:ColorSpace", "linear");

--- a/src/iv/ivimage.cpp
+++ b/src/iv/ivimage.cpp
@@ -44,8 +44,9 @@ IvImage::init_spec_iv(const std::string& filename, int subimage, int miplevel)
         m_file_dataformat = spec().format;
     }
     string_view colorspace = spec().get_string_attribute("oiio:ColorSpace");
-    if (Strutil::istarts_with(colorspace, "GammaCorrected")) {
-        float g = Strutil::from_string<float>(colorspace.c_str() + 14);
+    if (Strutil::istarts_with(colorspace, "Gamma")) {
+        Strutil::parse_word(colorspace);
+        float g = Strutil::from_string<float>(colorspace);
         if (g > 1.0 && g <= 3.0 /*sanity check*/) {
             gamma(gamma() / g);
         }

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1094,18 +1094,18 @@ ColorConfig::createColorProcessor(ustring inputColorSpace,
                     || iequals(inputrole, "linear")
                     || iequals(inputColorSpace, "lnf")
                     || iequals(inputColorSpace, "lnh"))
-                   && istarts_with(outputColorSpace, "GammaCorrected")) {
+                   && istarts_with(outputColorSpace, "Gamma")) {
             string_view gamstr = outputColorSpace;
-            Strutil::parse_prefix(gamstr, "GammaCorrected");
+            Strutil::parse_word(gamstr);
             float g = from_string<float>(gamstr);
             handle  = ColorProcessorHandle(new ColorProcessor_gamma(1.0f / g));
-        } else if (istarts_with(inputColorSpace, "GammaCorrected")
+        } else if (istarts_with(inputColorSpace, "Gamma")
                    && (iequals(outputColorSpace, "linear")
                        || iequals(outputrole, "linear")
                        || iequals(outputColorSpace, "lnf")
                        || iequals(outputColorSpace, "lnh"))) {
             string_view gamstr = inputColorSpace;
-            Strutil::parse_prefix(gamstr, "GammaCorrected");
+            Strutil::parse_word(gamstr);
             float g = from_string<float>(gamstr);
             handle  = ColorProcessorHandle(new ColorProcessor_gamma(g));
         }

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -229,7 +229,7 @@ read_info(png_structp& sp, png_infop& ip, int& bit_depth, int& color_type,
                 spec.attribute("oiio:ColorSpace", "linear");
             else
                 spec.attribute("oiio:ColorSpace",
-                               Strutil::sprintf("GammaCorrected%.2g", g));
+                               Strutil::sprintf("Gamma%.2g", g));
         }
     }
 
@@ -576,11 +576,12 @@ write_info(png_structp& sp, png_infop& ip, int& color_type, ImageSpec& spec,
 
     gamma = spec.get_float_attribute("oiio:Gamma", 1.0);
 
-    std::string colorspace = spec.get_string_attribute("oiio:ColorSpace");
+    string_view colorspace = spec.get_string_attribute("oiio:ColorSpace");
     if (Strutil::iequals(colorspace, "Linear")) {
         png_set_gAMA(sp, ip, 1.0);
-    } else if (Strutil::istarts_with(colorspace, "GammaCorrected")) {
-        float g = Strutil::from_string<float>(colorspace.c_str() + 14);
+    } else if (Strutil::istarts_with(colorspace, "Gamma")) {
+        Strutil::parse_word(colorspace);
+        float g = Strutil::from_string<float>(colorspace);
         if (g >= 0.01f && g <= 10.0f /* sanity check */)
             gamma = g;
         png_set_gAMA(sp, ip, 1.0f / gamma);

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -399,7 +399,7 @@ RLAInput::seek_subimage(int subimage, int miplevel)
             m_spec.attribute("oiio:ColorSpace", "Linear");
         else {
             m_spec.attribute("oiio:ColorSpace",
-                             Strutil::sprintf("GammaCorrected%.2g", gamma));
+                             Strutil::sprintf("Gamma%.2g", gamma));
             m_spec.attribute("oiio:Gamma", gamma);
         }
     }

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -292,12 +292,12 @@ RLAOutput::open(const std::string& name, const ImageSpec& userspec,
     //           << m_rla.NumOfMatteChannels << " z " << m_rla.NumOfAuxChannels << "\n";
     m_rla.Revision = 0xFFFE;
 
-    std::string colorspace = m_spec.get_string_attribute("oiio:ColorSpace",
-                                                         "Unknown");
+    string_view colorspace = m_spec.get_string_attribute("oiio:ColorSpace");
     if (Strutil::iequals(colorspace, "Linear"))
         Strutil::safe_strcpy(m_rla.Gamma, "1.0", sizeof(m_rla.Gamma));
-    else if (Strutil::istarts_with(colorspace, "GammaCorrected")) {
-        float g = Strutil::from_string<float>(colorspace.c_str() + 14);
+    else if (Strutil::istarts_with(colorspace, "Gamma")) {
+        Strutil::parse_word(colorspace);
+        float g = Strutil::from_string<float>(colorspace);
         if (!(g >= 0.01f && g <= 10.0f /* sanity check */))
             g = m_spec.get_float_attribute("oiio:Gamma", 1.f);
         safe_snprintf(m_rla.Gamma, sizeof(m_rla.Gamma), "%.10f", g);

--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -410,8 +410,7 @@ TGAInput::open(const std::string& name, ImageSpec& newspec)
                     m_spec.attribute("oiio:ColorSpace", "linear");
                 } else {
                     m_spec.attribute("oiio:ColorSpace",
-                                     Strutil::sprintf("GammaCorrected%.2g",
-                                                      gamma));
+                                     Strutil::sprintf("Gamma%.2g", gamma));
                     m_spec.attribute("oiio:Gamma", gamma);
                 }
             }

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -413,10 +413,11 @@ TGAOutput::write_tga20_data_fields()
         }
 
         // gamma -- two shorts, giving a ratio
-        std::string colorspace = m_spec.get_string_attribute("oiio:ColorSpace");
-        if (Strutil::istarts_with(colorspace, "GammaCorrected")) {
+        string_view colorspace = m_spec.get_string_attribute("oiio:ColorSpace");
+        if (Strutil::istarts_with(colorspace, "Gamma")) {
             // Extract gamma value from color space, if it's there
-            float g = Strutil::from_string<float>(colorspace.c_str() + 14);
+            Strutil::parse_word(colorspace);
+            float g = Strutil::from_string<float>(colorspace);
             if (g >= 0.01f && g <= 10.0f /* sanity check */)
                 m_gamma = g;
             // FIXME: invent a smarter way to convert to a vulgar fraction?


### PR DESCRIPTION
For some reason, in the early days I got in the habit of having OIIO
input readers call their color space "GammaCorrected2.2" (for example)
when they appeared to be a straight-up gamma. (Generally only used for
certain fairly old formats that date from before sRGB existed.)

But there appears to be a widely used convention of naming OpenColorIO
spaces "GammaX.Y", so I'm switching OIIO to conform that
convention. It's more straightforward and increases the chances that
it will match the names of color spaces that already exist in people's
OCIO configs.
