### PR TITLE
Better IOProxy support for image format implementations

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -205,6 +205,7 @@ OIIO_UTIL_API std::string unique_path (string_view model="%%%%-%%%%-%%%%-%%%%");
 OIIO_UTIL_API FILE *fopen (string_view path, string_view mode);
 
 /// Version of fseek that works with 64 bit offsets on all systems.
+/// Like std::fseek, returns zero on success, nonzero on failure.
 OIIO_UTIL_API int fseek (FILE *file, int64_t offset, int whence);
 
 /// Version of ftell that works with 64 bit offsets on all systems.
@@ -382,13 +383,21 @@ public:
     virtual void close () { }
     virtual bool opened () const { return mode() != Closed; }
     virtual int64_t tell () { return m_pos; }
+    // Seek to the position, returning true on success, false on failure.
+    // Note the difference between this and std::fseek() which returns 0 on
+    // success, and -1 on failure.
     virtual bool seek (int64_t offset) { m_pos = offset; return true; }
+    // Read `size` bytes at the current position into `buf[]`, returning the
+    // number of bytes successfully read.
     virtual size_t read (void *buf, size_t size);
+    // Write `size` bytes from `buf[]` at the current position, returning the
+    // number of bytes successfully written.
     virtual size_t write (const void *buf, size_t size);
     // pread(), pwrite() are stateless, do not alter the current file
     // position, and are thread-safe (against each other).
     virtual size_t pread (void *buf, size_t size, int64_t offset);
     virtual size_t pwrite (const void *buf, size_t size, int64_t offset);
+    // Return the total size of the proxy data, in bytes.
     virtual size_t size () const { return 0; }
     virtual void flush () const { }
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1590,9 +1590,7 @@ public:
     /// (`supports("ioproxy")`). The caller retains ownership of the proxy.
     ///
     /// @returns `true` for success, `false` for failure.
-    virtual bool set_ioproxy (Filesystem::IOProxy* ioproxy) {
-        return (ioproxy == nullptr);
-    }
+    virtual bool set_ioproxy (Filesystem::IOProxy* ioproxy);
 
     /// Is there a pending error message waiting to be retrieved, that
     /// resulted from an ImageInput API call made by the this thread?
@@ -1689,7 +1687,6 @@ public:
 protected:
     ImageSpec m_spec;  // format spec of the current open subimage/MIPlevel
                        // BEWARE using m_spec directly -- not thread-safe
-    Filesystem::IOProxy* m_io = nullptr;  // pointer to the IOProxy object
 
     /// @{
     /// @name IOProxy aids for ImageInput implementations.
@@ -2308,9 +2305,7 @@ public:
     /// (`supports("ioproxy")`). The caller retains ownership of the proxy.
     ///
     /// @returns `true` for success, `false` for failure.
-    virtual bool set_ioproxy (Filesystem::IOProxy* ioproxy) {
-        return (ioproxy == nullptr);
-    }
+    virtual bool set_ioproxy (Filesystem::IOProxy* ioproxy);
 
     /// Is there a pending error message waiting to be retrieved, that
     /// resulted from an ImageOutput API call made by the this thread?
@@ -2506,7 +2501,6 @@ protected:
 
 protected:
     ImageSpec m_spec;           // format spec of the currently open image
-    Filesystem::IOProxy* m_io = nullptr;  // pointer to the IOProxy object
 
 private:
     // PIMPL idiom -- this lets us hide details of the internals of the

--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -72,11 +72,7 @@ public:
     virtual bool read_native_scanline(int subimage, int miplevel, int y, int z,
                                       void* data) override;
     virtual bool close() override;
-    virtual bool set_ioproxy(Filesystem::IOProxy* ioproxy) override
-    {
-        m_io = ioproxy;
-        return true;
-    }
+
     const std::string& filename() const { return m_filename; }
     void* coeffs() const { return m_coeffs; }
     struct my_error_mgr {
@@ -101,9 +97,7 @@ private:
     my_error_mgr m_jerr;
     jvirt_barray_ptr* m_coeffs;
     std::vector<unsigned char> m_cmyk_buf;  // For CMYK translation
-    Filesystem::IOProxy* m_io = nullptr;
-    std::unique_ptr<Filesystem::IOProxy> m_local_io;
-    std::unique_ptr<ImageSpec> m_config;  // Saved copy of configuration spec
+    std::unique_ptr<ImageSpec> m_config;    // Saved copy of configuration spec
 
     void init()
     {
@@ -114,8 +108,7 @@ private:
         m_decomp_create = false;
         m_coeffs        = NULL;
         m_jerr.jpginput = this;
-        m_io            = nullptr;
-        m_local_io.reset();
+        ioproxy_clear();
         m_config.reset();
     }
 
@@ -130,11 +123,7 @@ private:
 
     bool valid_file(const std::string& filename, Filesystem::IOProxy* io) const;
 
-    void close_file()
-    {
-        m_local_io.reset();
-        init();
-    }
+    void close_file() { init(); }
 
     friend class JpgOutput;
 };

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -150,7 +150,7 @@ JpgInput::valid_file(const std::string& filename, Filesystem::IOProxy* io) const
         FILE* fd = Filesystem::fopen(filename, "rb");
         if (!fd)
             return false;
-        ok = (fread(magic, sizeof(magic), 1, fd) == 1);
+        ok = (::fread(magic, sizeof(magic), 1, fd) == 1);
         fclose(fd);
     }
 
@@ -168,9 +168,7 @@ JpgInput::open(const std::string& name, ImageSpec& newspec,
 {
     auto p = config.find_attribute("_jpeg:raw", TypeInt);
     m_raw  = p && *(int*)p->data();
-    p      = config.find_attribute("oiio:ioproxy", TypeDesc::PTR);
-    if (p)
-        m_io = p->get<Filesystem::IOProxy*>();
+    ioproxy_retrieve_from_config(config);
     m_config.reset(new ImageSpec(config));  // save config spec
     return open(name, newspec);
 }
@@ -182,21 +180,14 @@ JpgInput::open(const std::string& name, ImageSpec& newspec)
 {
     m_filename = name;
 
-    if (m_io) {
-        // If an IOProxy was passed, it had better be a File or a
-        // MemReader, that's all we know how to use with jpeg.
-        std::string proxytype = m_io->proxytype();
-        if (proxytype != "file" && proxytype != "memreader") {
-            errorf("JPEG reader can't handle proxy type %s", proxytype);
-            return false;
-        }
-    } else {
-        // If no proxy was supplied, create a file reader
-        m_io = new Filesystem::IOFile(name, Filesystem::IOProxy::Mode::Read);
-        m_local_io.reset(m_io);
-    }
-    if (!m_io || m_io->mode() != Filesystem::IOProxy::Mode::Read) {
-        errorf("Could not open file \"%s\"", name);
+    if (!ioproxy_use_or_open(name))
+        return false;
+    // If an IOProxy was passed, it had better be a File or a
+    // MemReader, that's all we know how to use with jpeg.
+    Filesystem::IOProxy* m_io = ioproxy();
+    std::string proxytype     = m_io->proxytype();
+    if (proxytype != "file" && proxytype != "memreader") {
+        errorfmt("JPEG reader can't handle proxy type {}", proxytype);
         return false;
     }
 
@@ -233,7 +224,7 @@ JpgInput::open(const std::string& name, ImageSpec& newspec)
     jpeg_create_decompress(&m_cinfo);
     m_decomp_create = true;
     // specify the data source
-    if (!strcmp(m_io->proxytype(), "file")) {
+    if (proxytype == "file") {
         auto fd = reinterpret_cast<Filesystem::IOFile*>(m_io)->handle();
         jpeg_stdio_src(&m_cinfo, fd);
     } else {
@@ -487,7 +478,7 @@ JpgInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
 bool
 JpgInput::close()
 {
-    if (m_io) {
+    if (ioproxy_opened()) {
         // unnecessary?  jpeg_abort_decompress (&m_cinfo);
         if (m_decomp_create)
             jpeg_destroy_decompress(&m_cinfo);

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -59,7 +59,8 @@ set (libOpenImageIO_srcs
                           deepdata.cpp exif.cpp exif-canon.cpp
                           formatspec.cpp imagebuf.cpp
                           imageinput.cpp imageio.cpp imageioplugin.cpp
-                          imageoutput.cpp iptc.cpp xmp.cpp
+                          imageoutput.cpp
+                          iptc.cpp xmp.cpp
                           color_ocio.cpp
                           maketexture.cpp
                           bluenoise.cpp


### PR DESCRIPTION
As we move toward fully equipping all image format implementations
with full IOProxy support, it's clear that a lot of repeated code is
error-prone. I first tried to collect this in a mixin class, but then
re-implemented after realizing that we can use the existing PIMPL
ImageInput::Impl and ImageInput::Impl classes, without changing any
ABI or making new headers.

This patch add a couple data members to the Impl data -- an
`IOProxy*`, (the current proxy, used for both passed-in and created
proxies) and also a `unique_ptr<IOProxy>` used when we have to create
our own and want to make sure it's destroyed with the ImageInput or
ImageOutput.

Then we add a number of protected member functions to ImageInput and
ImageOutput, not meant to be ever called by "users" of the OIIO APIs,
but used internally by II's and IO's to encapsulate several common
tasks related to managing IOProxy's.  This coalesces redundant code
that would need to appear separately in most of the plugins that
support IOProxy, helps to reduce cut-and-paste errors from having to
make these changes separately in many places, and centralizes the
logic so that as our ideas of how to implement IOProxy evolve, we can
easily change it in just one place and have it apply to all plugins.

Use the new methods for the existing JPEG and GIF support for
IOProxy.
