### PR TITLE
make_texture()/maketx fix to channel name with monochrome_detect

### DIFF
--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -405,9 +405,11 @@ ROI OIIO_API text_size (string_view text, int fontsize=16,
 ///             `channelvalues[i]` rather than copy any channel from `src`.
 ///             If `channelorder` itself is empty, the implied channel order
 ///             will be `{0, 1, ..., nchannels-1}`, meaning that it's only
-///             renaming channels, not reordering them.
+///             renaming, truncating, or extending channels, not reordering
+///             the channels that are already present.
 /// @param  channelvalues Fill values for color channels in which
-///             `channelorder[i]` < 0.
+///             `channelorder[i]` < 0. This can be empty if no channels are
+///             to be filled with constant values.
 /// @param  newchannelnames
 ///             An array of new channel names. Channels for which this
 ///             specifies an empty string will have their name taken from

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1345,6 +1345,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
                 << "  Monochrome image detected. Converting to single channel texture.\n";
         std::shared_ptr<ImageBuf> newsrc(new ImageBuf(src->spec()));
         ImageBufAlgo::channels(*newsrc, *src, 1, NULL, NULL, NULL, true);
+        newsrc->specmod().default_channel_names();
         std::swap(src, newsrc);
     }
 


### PR DESCRIPTION
When the make_texture option monochrome_detect is used to collapse 3
identical channels to 1, it was leaving the first channel name in
place (for example, "R"). That was confusing, because at this point,
we're not trying to represent a red image, we're trying to represent a
grayscale image. A strategic call to `default_channel_names()` clears
it up, imposing the standard "Y" we use for a single channel luminance
image.

Also amended the documentation of IBA::channels(). It turned out not
to be the way I called channels() that was the problem here, but by
the time I figured that out, I had already seen that its docs could be
improved.

Fixes #3204
