### PR TITLE
Restore code that finds Jasper when using static libraw

### DIFF
--- a/src/cmake/modules/FindLibRaw.cmake
+++ b/src/cmake/modules/FindLibRaw.cmake
@@ -86,6 +86,10 @@ MARK_AS_ADVANCED(LibRaw_VERSION_STRING
 
 if (LINKSTATIC)
     # Necessary?
+    find_package (Jasper)
+    if (JASPER_FOUND)
+        set (LibRaw_r_LIBRARIES ${LibRaw_r_LIBRARIES} ${JASPER_LIBRARIES})
+    endif()
     find_library (LCMS2_LIBRARIES NAMES lcms2)
     if (LCMS2_LIBRARIES)
         set (LibRaw_r_LIBRARIES ${LibRaw_r_LIBRARIES} ${LCMS2_LIBRARIES})


### PR DESCRIPTION
This was deleted a few months back, but I think I did not realize
it still served a purpose. We don't use JasPer directly, but LibRaw
does, so if we are using static LibRaw, we still need it here.

Fixes #3209
