### PR TITLE
Use a project-specific var for whether we're running in CI

### DIFF
--- a/src/build-scripts/ci-startup.bash
+++ b/src/build-scripts/ci-startup.bash
@@ -27,7 +27,7 @@ export PYTHONPATH=$OpenImageIO_ROOT/lib/python${PYTHON_VERSION}/site-packages:$P
 export BUILD_MISSING_DEPS=${BUILD_MISSING_DEPS:=1}
 export COMPILER=${COMPILER:=gcc}
 export CXX=${CXX:=g++}
-export CI=true
+export OpenImageIO_CI=true
 export USE_NINJA=${USE_NINJA:=1}
 export CMAKE_GENERATOR=${CMAKE_GENERATOR:=Ninja}
 export CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:=Release}

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -91,7 +91,7 @@ if (NOT MSVC)
     if (EXTRA_WARNINGS)
         add_compile_options ("-Wextra")
     endif ()
-    if (STOP_ON_WARNING OR DEFINED ENV{CI})
+    if (STOP_ON_WARNING OR DEFINED ENV{${PROJECT_NAME}_CI})
         add_compile_options ("-Werror")
         # N.B. Force CI builds to use -Werror, even if STOP_ON_WARNING has
         # been switched off by default, which we may do in release
@@ -537,9 +537,10 @@ endif ()
 
 ###########################################################################
 # Any extra logic to be run only for CI builds goes here.
+# We expect our own CI runs to define env variable ${PROJECT_NAME}_CI
 #
-if (DEFINED ENV{CI} OR DEFINED ENV{GITHUB_ACTIONS})
-    add_definitions ("-D${PROJ_NAME}_CI=1" "-DBUILD_CI=1")
+if (DEFINED ENV{${PROJECT_NAME}_CI})
+    add_definitions (-D${PROJ_NAME}_CI=1 -DBUILD_CI=1)
     if (APPLE)
         # Keep Mono framework from being incorrectly searched for include
         # files on GitHub Actions CI.

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -224,7 +224,7 @@ macro (oiio_add_all_tests)
     oiio_add_tests (oiiotool-color
                     FOUNDVAR OPENCOLORIO_FOUND)
 
-    if (NOT DEFINED ENV{CI} AND NOT DEFINED ENV{GITHUB_ACTIONS})
+    if (NOT DEFINED ENV{${PROJECT_NAME}_CI})
         oiio_add_tests (texture-icwrite)
     endif ()
 
@@ -265,7 +265,7 @@ macro (oiio_add_all_tests)
                     oiiotool-deep
                     IMAGEDIR openexr-images
                     URL http://github.com/AcademySoftwareFoundation/openexr-images)
-    if (NOT DEFINED ENV{CI} AND NOT DEFINED ENV{GITHUB_ACTIONS})
+    if (NOT DEFINED ENV{${PROJECT_NAME}_CI})
         oiio_add_tests (openexr-damaged
                         IMAGEDIR openexr-images
                         URL http://github.com/AcademySoftwareFoundation/openexr-images)


### PR DESCRIPTION
Maybe somebody else is building this as a subproject or has a variable
called "CI"?

* For our CI runs, set an env variable "OpenImageIO_CI" (not just
  generic "CI").

* Make sure STOP_ON_WARNING is true for our CI runs, even for release
  branches -- but now check OpenImageIO_CI, not CI, in case somebody
  else has set that.

