### PR TITLE
Build/CI openvdb tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,8 +500,6 @@ jobs:
       CXX: clang++
       PYTHON_VERSION: 3.8
       CMAKE_CXX_STANDARD: 14
-      ENABLE_OPENVDB: OFF
-      # No OpenVDB because on Homebrew, OpenVDB still uses OpenEXR 2.5
     steps:
       - uses: actions/checkout@v2
       - name: Prepare ccache timestamp
@@ -549,8 +547,6 @@ jobs:
       CXX: clang++
       PYTHON_VERSION: 3.9
       CMAKE_CXX_STANDARD: 17
-      ENABLE_OPENVDB: OFF
-      # No OpenVDB because on Homebrew, OpenVDB still uses OpenEXR 2.5
     steps:
       - uses: actions/checkout@v2
       - name: Prepare ccache timestamp

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -36,8 +36,7 @@ brew install --display-times -q jpeg-turbo openjpeg
 brew install --display-times -q freetype libraw dcmtk pybind11 numpy || true
 brew install --display-times -q ffmpeg libheif libsquish ptex || true
 brew install --display-times -q tbb || true
-# No OpenVDB until it's upgraded to use Imath 3
-# brew install --display-times -q openvdb || true
+brew install --display-times -q openvdb || true
 brew install --display-times -q opencv || true
 brew install --display-times -q qt@5
 

--- a/src/cmake/modules/FindOpenVDB.cmake
+++ b/src/cmake/modules/FindOpenVDB.cmake
@@ -79,11 +79,11 @@ if (OpenVDB_FOUND)
     set(OPENVDB_LIBRARIES ${OPENVDB_LIBRARY})
     set(OPENVDB_INCLUDES ${OPENVDB_INCLUDE_DIR})
 
-    if (NOT TARGET OpenVDB::OpenVDB)
-        add_library(OpenVDB::OpenVDB UNKNOWN IMPORTED)
-        set_target_properties(OpenVDB::OpenVDB PROPERTIES
+    if (NOT TARGET OpenVDB::openvdb)
+        add_library(OpenVDB::openvdb UNKNOWN IMPORTED)
+        set_target_properties(OpenVDB::openvdb PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES "${OPENVDB_INCLUDES}")
-        set_property(TARGET OpenVDB::OpenVDB APPEND PROPERTY
+        set_property(TARGET OpenVDB::openvdb APPEND PROPERTY
             IMPORTED_LOCATION "${OPENVDB_LIBRARIES}")
     endif ()
 endif ()


### PR DESCRIPTION
* On Mac CI, use openvdb from Homebrew now that it's OpenVDB 9, which
  properly supports OpenEXR/Imath 3.1.

* Update our FindOpenVDB.cmake target names to match the names used in
  OpenVDB's own FindOpenVDB.cmake (even though we don't use their module,
  may as well stick to their convention, especially if they eventually have
  a properly exported config file).
