### PR TITLE
Minor ImageInput/ImageOutput IOProxy handling tweaks

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1699,9 +1699,10 @@ protected:
 
     /// Get the IOProxy being used underneath.
     Filesystem::IOProxy* ioproxy();
+    const Filesystem::IOProxy* ioproxy() const;
 
     /// Is this file currenty opened (active proxy)?
-    bool ioproxy_opened();
+    bool ioproxy_opened() const;
 
     /// Clear the proxy ptr, and close/destroy any "local" proxy.
     void ioproxy_clear();
@@ -1730,7 +1731,7 @@ protected:
     bool ioseek(int64_t pos, int origin = SEEK_SET);
 
     /// Helper: retrieve the current position of the proxy, akin to ftell.
-    int64_t iotell();
+    int64_t iotell() const;
 
     /// @}
 
@@ -2455,9 +2456,10 @@ protected:
 
     /// Get the IOProxy being used underneath.
     Filesystem::IOProxy* ioproxy();
+    const Filesystem::IOProxy* ioproxy() const;
 
     /// Is this file currenty opened (active proxy)?
-    bool ioproxy_opened();
+    bool ioproxy_opened() const;
 
     /// Clear the proxy ptr, and close/destroy any "local" proxy.
     void ioproxy_clear();
@@ -2486,7 +2488,7 @@ protected:
     bool ioseek(int64_t pos, int origin = SEEK_SET);
 
     /// Helper: retrieve the current position of the proxy, akin to ftell.
-    int64_t iotell();
+    int64_t iotell() const;
 
     // Write a formatted string to the output proxy. Return true on success,
     // false upon failure and issue an error message.

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -1145,6 +1145,14 @@ ImageInput::ioproxy()
 
 
 
+const Filesystem::IOProxy*
+ImageInput::ioproxy() const
+{
+    return m_impl->m_io;
+}
+
+
+
 bool
 ImageInput::set_ioproxy(Filesystem::IOProxy* ioproxy)
 {
@@ -1155,7 +1163,7 @@ ImageInput::set_ioproxy(Filesystem::IOProxy* ioproxy)
 
 
 bool
-ImageInput::ioproxy_opened()
+ImageInput::ioproxy_opened() const
 {
     Filesystem::IOProxy*& m_io(m_impl->m_io);
     return m_io != nullptr && m_io->mode() == Filesystem::IOProxy::Read;
@@ -1239,7 +1247,7 @@ ImageInput::ioseek(int64_t pos, int origin)
 
 
 int64_t
-ImageInput::iotell()
+ImageInput::iotell() const
 {
     return m_impl->m_io->tell();
 }

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -732,7 +732,7 @@ ImageOutput::set_ioproxy(Filesystem::IOProxy* ioproxy)
 
 
 bool
-ImageOutput::ioproxy_opened()
+ImageOutput::ioproxy_opened() const
 {
     Filesystem::IOProxy*& m_io(m_impl->m_io);
     return m_io != nullptr && m_io->mode() == Filesystem::IOProxy::Write;
@@ -811,7 +811,7 @@ ImageOutput::ioseek(int64_t pos, int origin)
 
 
 int64_t
-ImageOutput::iotell()
+ImageOutput::iotell() const
 {
     return m_impl->m_io->tell();
 }


### PR DESCRIPTION
Helper functions ioproxy_opened() and iotell() should have been const
all along, since they just return back information and should not
change state of the proxy, and also ioproxy() should have both const
and non-const versions.
