### PR TITLE
JPEG2000: enable multithreading, other fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,7 @@ jobs:
       LIBTIFF_VERSION: v4.3.0
       OPENCOLORIO_VERSION: v2.1.0
       OPENEXR_VERSION: v3.1.3
+      OPENJPEG_VERSION: v2.4.0
       PUGIXML_VERSION: v1.11.4
       PTEX_VERSION: v2.4.0
       PYBIND11_VERSION: v2.8.1
@@ -387,6 +388,7 @@ jobs:
       LIBTIFF_VERSION: master
       OPENCOLORIO_VERSION: main
       OPENEXR_VERSION: master
+      OPENJPEG_VERSION: master
       PUGIXML_VERSION: master
       PTEX_VERSION: main
       PYBIND11_VERSION: master

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,7 +42,8 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you want support for a wide variety of video formats:
      * **ffmpeg >= 3.0** (tested through 4.4)
  * If you want support for jpeg 2000 images:
-     * **OpenJpeg >= 2.0** (tested through 2.4)
+     * **OpenJpeg >= 2.0** (tested through 2.4; we recommend 2.4 or higher
+       for multithreading support)
  * If you want support for OpenVDB files:
      * OpenVDB >= 5.0 (tested through 9) and Intel TBB >= 2018 (tested
        through 2021)

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -114,6 +114,10 @@ if [[ "$LIBRAW_VERSION" != "" ]] ; then
     source src/build-scripts/build_libraw.bash
 fi
 
+if [[ "$OPENJPEG_VERSION" != "" ]] ; then
+    source src/build-scripts/build_OpenJPEG.bash
+fi
+
 if [[ "$PUGIXML_VERSION" != "" ]] ; then
     source src/build-scripts/build_pugixml.bash
     export MY_CMAKE_FLAGS+=" -DUSE_EXTERNAL_PUGIXML=1 "

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -198,7 +198,11 @@ if (LibRaw_FOUND AND LibRaw_VERSION VERSION_LESS 0.20 AND CMAKE_CXX_STANDARD VER
     # set (LIBRAW_FOUND 0)
 endif ()
 
-checked_find_package (OpenJPEG VERSION_MIN 2.0)
+checked_find_package (OpenJPEG VERSION_MIN 2.0
+                      RECOMMEND_MIN 2.2
+                      RECOMMEND_MIN_REASON "for multithreading support")
+# Note: Recent OpenJPEG versions have exported cmake configs, but we don't
+# find them reliable at all, so we stick to our FindOpenJPEG.cmake module.
 
 checked_find_package (OpenVDB
                       VERSION_MIN 5.0

--- a/src/cmake/modules/FindOpenJPEG.cmake
+++ b/src/cmake/modules/FindOpenJPEG.cmake
@@ -17,7 +17,8 @@ macro (PREFIX_FIND_INCLUDE_DIR prefix includefile libpath_var)
   string (TOUPPER ${prefix}_INCLUDE_DIR tmp_varname)
   find_path(${tmp_varname} ${includefile}
     PATHS ${${libpath_var}}
-    NO_DEFAULT_PATH
+    PATH_SUFFIXES openjpeg openjpeg-2.0 openjpeg-2.1 openjpeg-2.2
+                  openjpeg-2.3 openjpeg-2.4 openjpeg-2.5
   )
   if (${tmp_varname})
     mark_as_advanced (${tmp_varname})
@@ -31,12 +32,10 @@ macro (PREFIX_FIND_LIB prefix libname libpath_var liblist_var cachelist_var)
   find_library(${tmp_prefix}_LIBRARY_RELEASE
     NAMES ${libname}
     PATHS ${${libpath_var}}
-    NO_DEFAULT_PATH
   )
   find_library(${tmp_prefix}_LIBRARY_DEBUG
     NAMES ${libname}d ${libname}_d ${libname}debug ${libname}_debug
     PATHS ${${libpath_var}}
-    NO_DEFAULT_PATH
   )
   # Properly define ${tmp_prefix}_LIBRARY (cached) and ${tmp_prefix}_LIBRARIES
   select_library_configurations (${tmp_prefix})
@@ -56,25 +55,9 @@ endmacro ()
 
 # Generic search paths
 set (OpenJpeg_include_paths
-     /usr/local/include/openjpeg-2.4
-     /usr/local/include/openjpeg-2.3
-     /usr/local/include/openjpeg-2.2
-     /usr/local/include/openjpeg-2.1
-     /usr/local/include/openjpeg-2.0
-     /usr/local/include/openjpeg
-     /usr/local/include
-     /usr/include/openjpeg-2.4
-     /usr/include/openjpeg-2.3
-     /usr/include/openjpeg-2.2
-     /usr/include/openjpeg-2.1
-     /usr/include/openjpeg
      /usr/include
      /opt/local/include
-     /opt/local/include/openjpeg-2.4
-     /opt/local/include/openjpeg-2.3
-     /opt/local/include/openjpeg-2.2
-     /opt/local/include/openjpeg-2.1
-     /opt/local/include/openjpeg-2.0)
+    )
 
 set (OpenJpeg_library_paths
   /usr/lib
@@ -83,24 +66,6 @@ set (OpenJpeg_library_paths
   /sw/lib
   /opt/local/lib)
 
-if (OpenJPEG_ROOT)
-  set (OpenJpeg_library_paths
-       ${OpenJPEG_ROOT}/lib
-       ${OpenJPEG_ROOT}/lib64
-       ${OpenJPEG_ROOT}/bin
-       ${OpenJpeg_library_paths}
-      )
-  set (OpenJpeg_include_paths
-       ${OpenJPEG_ROOT}/include/openjpeg-2.4
-       ${OpenJPEG_ROOT}/include/openjpeg-2.3
-       ${OpenJPEG_ROOT}/include/openjpeg-2.2
-       ${OpenJPEG_ROOT}/include/openjpeg-2.1
-       ${OpenJPEG_ROOT}/include/openjpeg-2.0
-       ${OpenJPEG_ROOT}/include/openjpeg
-       ${OpenJPEG_ROOT}/include
-       ${OpenJpeg_include_paths}
-      )
-endif()
 
 
 # Locate the header files


### PR DESCRIPTION
* The main event here is that we're now telling OpenJPEG to use
  threading when compressing/decompressing JPEG-2000 files.  This
  improves the speed of JPEG-2000 reading on my laptop by 2-3x!  The
  threading feature was added to OpenJPEG 2.2 for decode, and 2.4 for
  encode.

* CI: Build OpenJPEG 2.4 for the "latest releases" test, and build
  their master for our "bleeding edge" test.

* Fixes to deal with the in-progress 2.5 deprecating a struct field.

* Generally clean up our detection of what OpenJPEG version we are
  using.

* Some clean-up of the FindOpenJPEG.cmake file, use PATH_SUFFIXES.
