### PR TITLE
CMake: don't download missing test data if BUILD_TESTING is off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,7 +279,7 @@ install (EXPORT OIIO_EXPORTED_TARGETS
         NAMESPACE ${PROJECT_NAME}::)
 
 
-if (PROJECT_IS_TOP_LEVEL)
+if (PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
     oiio_setup_test_data()
     oiio_add_all_tests()
 endif ()

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -333,7 +333,7 @@ function (oiio_get_test_data name)
                               "${CMAKE_BINARY_DIR}/testsuite/${name}"
                               SYMBOLIC COPY_ON_ERROR)
         else ()
-        # Older cmake -- copy
+            # Older cmake -- copy
             message (STATUS "Copying ${name} from ${OIIO_LOCAL_TESTDATA_ROOT}/../${name}")
             file (COPY "${OIIO_LOCAL_TESTDATA_ROOT}/${name}"
                   DESTINATION "${CMAKE_BINARY_DIR}/testsuite")


### PR DESCRIPTION
For that matter, don't set up and copy the tests at all when it's off.
Fixes #3189
