### PR TITLE
Strutil::edit_distance()

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -1036,6 +1036,19 @@ void OIIO_UTIL_API utf8_to_unicode (string_view str, std::vector<uint32_t> &uvec
 /// https://en.wikipedia.org/wiki/Base64
 std::string OIIO_UTIL_API base64_encode (string_view str);
 
+
+enum class EditDistMetric { Levenshtein };
+
+/// Compute an edit distance metric between strings `a` and `b`, roughly
+/// speaking, the number of changes that would be made to transform one string
+/// into the other. Identical strings have a distance of 0. The `method`
+/// selects among possible algorithms, which may have different distance
+/// metrics or allow different types of edits. (Currently, the only method
+/// supported is Levenshtein; this parameter is for future expansion.)
+OIIO_UTIL_API size_t
+edit_distance(string_view a, string_view b,
+              EditDistMetric metric = EditDistMetric::Levenshtein);
+
 }  // namespace Strutil
 
 OIIO_NAMESPACE_END

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -1326,6 +1326,23 @@ test_datetime()
 
 
 
+void
+test_edit_distance()
+{
+    using namespace Strutil;
+    print("test_edit_distance\n");
+    OIIO_CHECK_EQUAL(edit_distance("", ""), 0);
+    OIIO_CHECK_EQUAL(edit_distance("", "abc"), 3);
+    OIIO_CHECK_EQUAL(edit_distance("abcd", ""), 4);
+    OIIO_CHECK_EQUAL(edit_distance("abc", "abc"), 0);
+    OIIO_CHECK_EQUAL(edit_distance("abc", "ab"), 1);
+    OIIO_CHECK_EQUAL(edit_distance("abc", "abcde"), 2);
+    OIIO_CHECK_EQUAL(edit_distance("abc", "abd"), 1);
+    OIIO_CHECK_EQUAL(edit_distance("sitting", "kitten"), 3);
+}
+
+
+
 int
 main(int /*argc*/, char* /*argv*/[])
 {
@@ -1356,6 +1373,7 @@ main(int /*argc*/, char* /*argv*/[])
     // test_float_formatting ();
     test_string_compare_function();
     test_datetime();
+    test_edit_distance();
 
     return unit_test_failures;
 }


### PR DESCRIPTION
This string utility computes the "edit distance" between two strings.
Currently it only uses the Levenshtein metric, but it has room for
future expansion by taking a parameter that can specify which metric
to use. Levenshtein is an algorithm for computing how many single
character insertions or deletions are necessary to turn one string
into the other.

I have a few ideas for where this can be useful, but as one
demonstration, I also modify the ArgParse class internals so that if a
command is not found, it will print a suggestion naming the valid
command option that has the closest edit distance (but only if one
choice is <= 2 edits away, and only if it's not a single-character
option, in order to reduce the number of useless suggestions). Here's
its behavior in action:

    $ iinfo --stat foo.exr
    iinfo error: Invalid option "--stat" (did you mean --stats?)
    ...

