### PR TITLE
Protect against corrupt headers with image size and channel limits

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2656,6 +2656,23 @@ OIIO_API std::string geterror(bool clear = true);
 ///    When nonzero, use the new "OpenEXR core C library" when available,
 ///    for OpenEXR >= 3.1. This is experimental, and currently defaults to 0.
 ///
+/// - `int limits:channels` (1024)
+///
+///    When nonzero, the maximum number of color channels in an image. Image
+///    files whose headers indicate they have more channels might be assumed
+///    to be corrupted or malicious files.  In situations when more channels
+///    are expected to be encountered, the application should raise this
+///    limit. The default is 1024 channels.
+///
+/// - `int limits:imagesize_MB` (32768)
+///
+///    When nonzero, the maximum size in MB of the uncompressed pixel data of
+///    a single 2D image. Images whose headers indicate that they are larger
+///    than this might be assumed to be corrupted or malicious files. The
+///    default is 32768 (32 GB of uncompressed pixel data -- equivalent to 64k
+///    x 64k x 4 channel x half). In situations when images larger than this
+///    are expected to be encountered, you should raise this limit.
+///
 /// - `int log_times`
 ///
 ///    When the `"log_times"` attribute is nonzero, `ImageBufAlgo` functions

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -41,6 +41,8 @@ atomic_int oiio_try_all_readers(1);
 int openexr_core(0);  // Should we use "Exr core C library"?
 int tiff_half(0);
 int tiff_multithread(1);
+int limit_channels(1024);
+int limit_imagesize_MB(32 * 1024);
 ustring font_searchpath;
 ustring plugin_searchpath(OIIO_DEFAULT_PLUGIN_SEARCHPATH);
 std::string format_list;         // comma-separated list of all formats
@@ -330,6 +332,14 @@ attribute(string_view name, TypeDesc type, const void* val)
     }
     if (name == "tiff:multithread" && type == TypeInt) {
         tiff_multithread = *(const int*)val;
+        return true;
+    }
+    if (name == "limits:channels" && type == TypeInt) {
+        limit_channels = *(const int*)val;
+        return true;
+    }
+    if (name == "limits:imagesize_MB" && type == TypeInt) {
+        limit_imagesize_MB = *(const int*)val;
         return true;
     }
     if (name == "debug" && type == TypeInt) {

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -36,6 +36,8 @@ extern std::string library_list;
 extern int oiio_print_debug;
 extern int oiio_log_times;
 extern int openexr_core;
+extern int limit_channels;
+extern int limit_imagesize_MB;
 
 
 // For internal use - use error() below for a nicer interface.


### PR DESCRIPTION
Add two new global OIIO attributes: "limits:channels" and
"limits:imagesize_MB" which are imposed limits for validating a
reasonable number of channels and total uncompressed image size,
respectively. We presume that an image file header describing an image
that purports to exceed these is most likely corrupted or even
maliciously crafted. The limits, therefore, are designed to avoid
crashes, absurd memory allocations, or other cascading errors that
would result from taking such a claim at face value (for example,
a file that appears to have tens of thousands of color channels).

The limits default currently to a maximum of 1024 color channels, and
a maximum uncompressed data size of a single 2D image to 32GB.  These
seem reasonable today, but if such large sizes become likely to be
seen in the wild in legit files in the future, we may change the
defaults. They may be adjusted now simply by setting the attributes,
of course, as should be done by applications that legitimately expect
to see input that exceeds them. (Applications also may make the
validation limits even smaller if they wish.)

I've modified the TIFF reader to check these limits as a first step.
We'll expand to doing such validation checks on other readers over time,
as we have opportunities to visit them.

