### PR TITLE
Make texture system 64-bit safe for tile access

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1469,6 +1469,7 @@ ImageCacheTile::ImageCacheTile(const TileID& id, const void* pels,
     const ImageSpec& spec(file.spec(id.subimage(), id.miplevel()));
     m_channelsize = file.datatype(id.subimage()).size();
     m_pixelsize   = id.nchannels() * m_channelsize;
+    m_tile_width  = spec.tile_width;
     if (copy) {
         size_t size = memsize_needed();
         OIIO_ASSERT_MSG(size > 0 && memsize() == 0,
@@ -1536,9 +1537,10 @@ ImageCacheTile::read(ImageCachePerThreadInfo* thread_info)
                              &m_pixels[0]);
     m_id.file().imagecache().incr_mem(size);
     if (m_valid) {
-        // Figure out if
         ImageCacheFile::LevelInfo& lev(
             file.levelinfo(m_id.subimage(), m_id.miplevel()));
+        m_tile_width = lev.spec.tile_width;
+        OIIO_DASSERT(m_tile_width > 0);
         int whichtile = ((m_id.x() - lev.spec.x) / lev.spec.tile_width)
                         + ((m_id.y() - lev.spec.y) / lev.spec.tile_height)
                               * lev.nxtiles

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -671,12 +671,26 @@ public:
     int channelsize() const { return m_channelsize; }
     int pixelsize() const { return m_pixelsize; }
 
+    // 1D index of the 2D tile coordinate. 64 bit safe.
+    imagesize_t pixel_index(int tile_s, int tile_t) const
+    {
+        return imagesize_t(tile_t) * m_tile_width + tile_s;
+    }
+
+    // Offset in bytes into the tile memory of the given 2D tile pixel
+    // coordinates.  64 bit safe.
+    imagesize_t pixel_offset(int tile_s, int tile_t) const
+    {
+        return m_pixelsize * pixel_index(tile_s, tile_t);
+    }
+
 private:
     TileID m_id;                       ///< ID of this tile
     std::unique_ptr<char[]> m_pixels;  ///< The pixel data
     size_t m_pixels_size { 0 };        ///< How much m_pixels has allocated
     int m_channelsize { 0 };           ///< How big is each channel (bytes)
     int m_pixelsize { 0 };             ///< How big is each pixel (bytes)
+    int m_tile_width { 0 };            ///< Tile width
     bool m_valid { false };            ///< Valid pixels
     bool m_nofree { false };  ///< We do NOT own the pixels, do not free!
     volatile bool m_pixels_ready {

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -2081,9 +2081,9 @@ TextureSystemImpl::sample_closest(
             allok = false;
             continue;
         }
-        int offset = id.nchannels() * (tile_t * spec.tile_width + tile_s)
-                     + (firstchannel - id.chbegin());
-        OIIO_DASSERT((size_t)offset < spec.nchannels * spec.tile_pixels());
+        size_t offset = id.nchannels() * tile->pixel_index(tile_s, tile_t)
+                        + (firstchannel - id.chbegin());
+        OIIO_DASSERT(offset < spec.nchannels * spec.tile_pixels());
         simd::vfloat4 texel_simd;
         if (pixeltype == TypeDesc::UINT8) {
             // special case for 8-bit tiles
@@ -2264,9 +2264,8 @@ TextureSystemImpl::sample_bilinear(
             TileRef& tile(thread_info->tile);
             if (!tile->valid())
                 return false;
-            int pixelsize = tile->pixelsize();
-            int offset    = pixelsize
-                         * (tile_st[T0] * spec.tile_width + tile_st[S0]);
+            int pixelsize      = tile->pixelsize();
+            imagesize_t offset = tile->pixel_offset(tile_st[S0], tile_st[T0]);
             const unsigned char* p = tile->bytedata() + offset
                                      + channelsize
                                            * (firstchannel - id.chbegin());
@@ -2328,12 +2327,9 @@ TextureSystemImpl::sample_bilinear(
                         OIIO_DASSERT(thread_info->tile->id() == id);
                     }
                     TileRef& tile(thread_info->tile);
-                    int pixelsize = tile->pixelsize();
-                    int offset    = pixelsize
-                                 * (tile_t * spec.tile_width + tile_s);
+                    imagesize_t offset = tile->pixel_offset(tile_s, tile_t);
                     offset += (firstchannel - id.chbegin()) * channelsize;
-                    OIIO_DASSERT(offset < spec.tile_width * spec.tile_height
-                                              * spec.tile_depth * pixelsize);
+                    OIIO_DASSERT(offset < spec.tile_bytes());
                     if (pixeltype == TypeDesc::UINT8)
                         texel_simd[j][i] = uchar2float4(
                             (const unsigned char*)(tile->bytedata() + offset));
@@ -2543,9 +2539,9 @@ TextureSystemImpl::sample_bicubic(
     }
     TileID id(texturefile, options.subimage, miplevel, 0, 0, 0, tile_chbegin,
               tile_chend);
-    size_t pixelsize                 = channelsize * id.nchannels();
-    size_t firstchannel_offset_bytes = channelsize
-                                       * (firstchannel - id.chbegin());
+    int pixelsize                         = channelsize * id.nchannels();
+    imagesize_t firstchannel_offset_bytes = channelsize
+                                            * (firstchannel - id.chbegin());
     vfloat4 accum, daccumds, daccumdt;
     accum.clear();
     if (daccumds_) {
@@ -2632,7 +2628,7 @@ TextureSystemImpl::sample_bicubic(
             }
             // N.B. thread_info->tile will keep holding a ref-counted pointer
             // to the tile for the duration that we're using the tile data.
-            int offset = pixelsize * (tile_t * spec.tile_width + tile_s);
+            imagesize_t offset        = tile->pixel_offset(tile_s, tile_t);
             const unsigned char* base = tile->bytedata() + offset
                                         + firstchannel_offset_bytes;
             OIIO_DASSERT(tile->data());
@@ -2679,8 +2675,8 @@ TextureSystemImpl::sample_bicubic(
                         texel_simd[j][i].clear();
                     continue;
                 }
-                int row_offset_bytes = tile_t[j]
-                                       * (spec.tile_width * pixelsize);
+                imagesize_t row_offset_bytes
+                    = tile_t[j] * imagesize_t(spec.tile_width * pixelsize);
                 for (int i = 0; i < 4; ++i) {
                     if (!svalid[i]) {
                         texel_simd[j][i].clear();
@@ -2702,7 +2698,8 @@ TextureSystemImpl::sample_bicubic(
                     }
                     TileRef& tile(thread_info->tile);
                     OIIO_DASSERT(tile->data());
-                    int offset = row_offset_bytes + column_offset_bytes[i];
+                    imagesize_t offset = row_offset_bytes
+                                         + column_offset_bytes[i];
                     // const unsigned char *pixelptr = tile->bytedata() + offset[i];
                     if (pixeltype == TypeDesc::UINT8)
                         texel_simd[j][i] = uchar2float4(tile->bytedata()


### PR DESCRIPTION
TextureSystem is designed primarily for tiled images (typically 64x64
pixels each), but to handle untiled images, it just treats the whole
image as one big tile. That means for very large untiled images, you
might end up with one VERY large tile, and if the image is large
enough, the size and/or offset computations therein may overflow a
32 bit int.

This patch attempts to make all the offset computations in the texture
system be 64-bit safe.
