### PR TITLE
Improve error propagation from ImageCache to higher levels

### DIFF
--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -1323,6 +1323,12 @@ public:
             return m_ib->deep_value_uint(m_x, m_y, m_z, c, s);
         }
 
+        // Did we encounter an error while we iterated?
+        bool has_error() const { return m_readerror; }
+
+        // Clear the error flag
+        void clear_error() { m_readerror = false; }
+
     protected:
         friend class ImageBuf;
         friend class ImageBufImpl;
@@ -1344,6 +1350,7 @@ public:
         stride_t m_pixel_stride;
         char* m_proxydata = nullptr;
         WrapMode m_wrap   = WrapBlack;
+        bool m_readerror  = false;
 
         // Helper called by ctrs -- set up some locally cached values
         // that are copied or derived from the ImageBuf.
@@ -1374,7 +1381,7 @@ public:
                                                       m_tilexbegin,
                                                       m_tileybegin,
                                                       m_tilezbegin, m_tilexend,
-                                                      e, m_wrap);
+                                                      m_readerror, e, m_wrap);
                     m_exists    = e;
                 }
             }
@@ -1556,11 +1563,17 @@ protected:
 
     // Reset the ImageCacheTile* to reserve and point to the correct
     // tile for the given pixel, and return the ptr to the actual pixel
-    // within the tile.
+    // within the tile. If any read errors occur, set haderror=true (but
+    // if there are no errors, do not modify haderror).
     const void* retile(int x, int y, int z, pvt::ImageCacheTile*& tile,
                        int& tilexbegin, int& tileybegin, int& tilezbegin,
-                       int& tilexend, bool exists,
-                       WrapMode wrap = WrapDefault) const;
+                       int& tilexend, bool& haderr, bool exists,
+                       WrapMode wrap) const;
+
+    // DEPRECATED(2.4)
+    const void* retile(int x, int y, int z, pvt::ImageCacheTile*& tile,
+                       int& tilexbegin, int& tileybegin, int& tilezbegin,
+                       int& tilexend, bool exists, WrapMode wrap) const;
 
     const void* blackpixel() const;
 

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -595,9 +595,9 @@ public:
 
     ~ImageCacheTile();
 
-    /// Actually read the pixels.  The caller had better be the thread
-    /// that constructed the tile.
-    void read(ImageCachePerThreadInfo* thread_info);
+    /// Actually read the pixels.  The caller had better be the thread that
+    /// constructed the tile.  Return true for success, false for failure.
+    OIIO_NODISCARD bool read(ImageCachePerThreadInfo* thread_info);
 
     /// Return pointer to the raw pixel data
     const void* data(void) const { return &m_pixels[0]; }
@@ -958,8 +958,8 @@ public:
 
     /// Add the tile to the cache.  This will also enforce cache memory
     /// limits.
-    void add_tile_to_cache(ImageCacheTileRef& tile,
-                           ImageCachePerThreadInfo* thread_info);
+    OIIO_NODISCARD bool add_tile_to_cache(ImageCacheTileRef& tile,
+                                          ImageCachePerThreadInfo* thread_info);
 
     /// Find the tile specified by id.  If found, return true and place
     /// the tile ref in thread_info->tile; if not found, return false.

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -2624,8 +2624,11 @@ TextureSystemImpl::sample_bicubic(
             // Shortcut if all the texels we need are on the same tile
             id.xy(stex[0] - tile_s, ttex[0] - tile_t);
             bool ok = find_tile(id, thread_info, sample == 0);
-            if (!ok)
-                error("{}", m_imagecache->geterror());
+            if (!ok) {
+                if (m_imagecache->has_error())
+                    error("{}", m_imagecache->geterror());
+                return false;
+            }
             TileRef& tile(thread_info->tile);
             if (!tile) {
                 return false;


### PR DESCRIPTION
Errors encountered while reading tiles were getting lost as we used
ImageBuf::Iterator to iterate over an image. Have the iterator keep a
flag for whether it encountered an error, set to true if the
ImageBuf::retile indicates an error occurred during the read.

Also, some ImageCache errors might get lost on the way to
TextureSystem calls, fix that as well.

