### PR TITLE
oiiotool internals: convert all error and warning to fmt style

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -137,6 +137,7 @@ using ::fmt::sprintf;
 
 namespace fmt {
 template<typename Str, typename... Args>
+OIIO_NODISCARD
 inline std::string format(const Str& fmt, Args&&... args)
 {
 #if FMT_VERSION >= 70000

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -639,7 +639,7 @@ public:
     /// The formatting of the string will always use the classic "C" locale
     /// conventions (in particular, '.' as decimal separator for float values).
     template<typename... Args>
-    static ustring sprintf(const char* fmt, const Args&... args)
+    OIIO_NODISCARD static ustring sprintf(const char* fmt, const Args&... args)
     {
         return ustring(Strutil::sprintf(fmt, args...));
     }
@@ -651,7 +651,8 @@ public:
     /// The formatting of the string will always use the classic "C" locale
     /// conventions (in particular, '.' as decimal separator for float values).
     template<typename... Args>
-    static ustring fmtformat(const char* fmt, const Args&... args)
+    OIIO_NODISCARD static ustring fmtformat(const char* fmt,
+                                            const Args&... args)
     {
         return ustring(Strutil::fmt::format(fmt, args...));
     }

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -206,7 +206,7 @@ ImageRec::read_nativespec()
     ustring uname(name());
     if (!m_imagecache->get_image_info(uname, 0, 0, u_subimages, TypeInt,
                                       &subimages)) {
-        errorf("file not found: \"%s\"", name());
+        errorfmt("file not found: \"{}\"", name());
         return false;  // Image not found
     }
     m_subimages.resize(subimages);
@@ -223,7 +223,7 @@ ImageRec::read_nativespec()
                 new ImageBuf(name(), s, m, m_imagecache, m_configspec.get()));
             bool ok = ib->init_spec(name(), s, m);
             if (!ok)
-                errorf("%s", ib->geterror());
+                errorfmt("{}", ib->geterror());
             allok &= ok;
             m_subimages[s].m_miplevels[m] = ib;
             m_subimages[s].m_specs[m]     = ib->spec();
@@ -245,7 +245,7 @@ ImageRec::read(ReadPolicy readpolicy, string_view channel_set)
     ustring uname(name());
     if (!m_imagecache->get_image_info(uname, 0, 0, u_subimages, TypeInt,
                                       &subimages)) {
-        errorf("file not found: \"%s\"", name());
+        errorfmt("file not found: \"{}\"", name());
         return false;  // Image not found
     }
     m_subimages.resize(subimages);
@@ -335,7 +335,7 @@ ImageRec::read(ReadPolicy readpolicy, string_view channel_set)
                                             &newchannelnames[0], false);
             }
             if (!ok)
-                errorf("%s", ib->geterror());
+                errorfmt("{}", ib->geterror());
 
             allok &= ok;
             // Remove any existing SHA-1 hash from the spec.

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -907,9 +907,9 @@ adjust_output_options(string_view filename, ImageSpec& spec,
             spec.attribute("Exif:ImageHistory", history);
         }
 
-        std::string software = Strutil::sprintf("OpenImageIO %s : %s",
-                                                OIIO_VERSION_STRING,
-                                                ot.full_command_line);
+        std::string software = Strutil::fmt::format("OpenImageIO {} : {}",
+                                                    OIIO_VERSION_STRING,
+                                                    ot.full_command_line);
         spec.attribute("Software", software);
     }
 
@@ -1013,7 +1013,7 @@ set_dataformat(int argc, const char* argv[])
         string_to_dataformat(chans[0], ot.output_dataformat,
                              ot.output_bitspersample);
         if (ot.output_dataformat == TypeDesc::UNKNOWN)
-            ot.errorf(command, "Unknown data format \"%s\"", chans[0]);
+            ot.errorfmt(command, "Unknown data format \"{}\"", chans[0]);
         ot.output_channelformats.clear();
         return 0;  // we're done
     }
@@ -1026,7 +1026,7 @@ set_dataformat(int argc, const char* argv[])
             std::string channame(chan, 0, eq - chan.c_str());
             ot.output_channelformats[channame] = std::string(eq + 1);
         } else {
-            ot.errorf(command, "Malformed format designator \"%s\"", chan);
+            ot.errorfmt(command, "Malformed format designator \"{}\"", chan);
         }
     }
 
@@ -1189,7 +1189,7 @@ Oiiotool::get_position(string_view command, string_view geom, int& x, int& y)
     bool ok = Strutil::parse_int(geom, x) && Strutil::parse_char(geom, ',')
               && Strutil::parse_int(geom, y);
     if (!ok)
-        errorf(command, "Unrecognized position \"%s\"", orig_geom);
+        errorfmt(command, "Unrecognized position \"{}\"", orig_geom);
     return ok;
 }
 
@@ -1268,10 +1268,10 @@ Oiiotool::adjust_geometry(string_view command, int& w, int& h, int& x, int& y,
         w = (int)(w * scaleX + 0.5f);
         h = (int)(h * scaleX + 0.5f);
     } else {
-        errorf(command, "Unrecognized geometry \"%s\"", geom);
+        errorfmt(command, "Unrecognized geometry \"{}\"", geom);
         return false;
     }
-    // printf ("geom %dx%d, %+d%+d\n", w, h, x, y);
+    // Strutil::print("geom {}x{}, {}d{}d\n", w, h, x, y);
     return true;
 }
 
@@ -1282,7 +1282,7 @@ Oiiotool::express_error(const string_view expr, const string_view s,
                         string_view explanation)
 {
     int offset = expr.rfind(s) + 1;
-    errorf("expression", "%s at char %d of `%s'", explanation, offset, expr);
+    errorfmt("expression", "{} at char {} of '{}'", explanation, offset, expr);
 }
 
 
@@ -1458,18 +1458,18 @@ Oiiotool::express_parse_atom(const string_view expr, string_view& s,
                     result.pop_back();
             } else {
                 express_error(expr, s,
-                              Strutil::sprintf("unknown attribute name `%s'",
-                                               metadata));
+                              Strutil::fmt::format("unknown attribute name '{}'",
+                                                   metadata));
                 result = orig;
                 return false;
             }
         }
     } else if (Strutil::parse_float(s, floatval)) {
-        result = Strutil::sprintf("%g", floatval);
+        result = Strutil::fmt::format("{:g}", floatval);
     }
     // Test some special identifiers
     else if (Strutil::parse_identifier_if(s, "FRAME_NUMBER")) {
-        result = Strutil::sprintf("%d", ot.frame_number);
+        result = Strutil::to_string(ot.frame_number);
     } else if (Strutil::parse_identifier_if(s, "FRAME_NUMBER_PAD")) {
         std::string fmt = ot.frame_padding == 0
                               ? std::string("%d")
@@ -1537,9 +1537,9 @@ Oiiotool::express_parse_factors(const string_view expr, string_view& s,
             }
 
             if (!Strutil::string_is<float>(atom)) {
-                express_error(expr, s,
-                              Strutil::sprintf("expected number but got `%s'",
-                                               atom));
+                express_error(
+                    expr, s,
+                    Strutil::fmt::format("expected number but got '{}'", atom));
                 result = orig;
                 return false;
             }
@@ -1559,7 +1559,7 @@ Oiiotool::express_parse_factors(const string_view expr, string_view& s,
             }
         }
 
-        result = Strutil::sprintf("%g", lval);
+        result = Strutil::fmt::format("{:g}", lval);
 
     } else {
         // atom is not a number, so we're done
@@ -1614,7 +1614,8 @@ Oiiotool::express_parse_summands(const string_view expr, string_view& s,
 
             if (!Strutil::string_is<float>(atom)) {
                 express_error(expr, s,
-                              Strutil::sprintf("`%s' is not a number", atom));
+                              Strutil::fmt::format("'{}' is not a number",
+                                                   atom));
                 result = orig;
                 return false;
             }
@@ -1627,7 +1628,7 @@ Oiiotool::express_parse_summands(const string_view expr, string_view& s,
                 lval -= rval;
         }
 
-        result = Strutil::sprintf("%g", lval);
+        result = Strutil::fmt::format("{:g}", lval);
 
     } else {
         // atom is not a number, so we're done
@@ -1679,8 +1680,8 @@ Oiiotool::express(string_view str)
     expr.remove_prefix(1);
     expr.remove_suffix(1);
     // eg. expr="cde"
-    ustring result = ustring::sprintf("%s%s%s", prefix, express_impl(expr),
-                                      express(s));
+    ustring result = ustring::fmtformat("{}{}{}", prefix, express_impl(expr),
+                                        express(s));
     if (ot.debug)
         std::cout << "Expanding expression \"" << str << "\" -> \"" << result
                   << "\"\n";
@@ -2565,7 +2566,7 @@ OiioTool::decode_channel_set(const ImageSpec& spec, string_view chanlist,
             if (c <= 4)
                 newname = std::string(RGBAZ[c]);
             else
-                newname = Strutil::sprintf("channel%d", c);
+                newname = Strutil::fmt::format("channel{}", c);
         }
 
         // std::cout << "  Chan " << c << ": " << newname << ' ' << chan << ' ' << val << "\n";
@@ -2614,8 +2615,8 @@ action_channels(int argc, const char* argv[])
         bool ok = decode_channel_set(*A->spec(s, 0), chanlist, newchannelnames,
                                      channels, values);
         if (!ok) {
-            ot.errorf(command, "Invalid or unknown channel selection \"%s\"",
-                      chanlist);
+            ot.errorfmt(command, "Invalid or unknown channel selection \"{}\"",
+                        chanlist);
             ot.push(A);
             return 0;
         }
@@ -2770,9 +2771,9 @@ action_select_subimage(int argc, const char* argv[])
     if (Strutil::parse_int(w, subimage) && w.empty()) {
         // Subimage specification was an integer: treat as an index
         if (subimage < 0 || subimage >= ot.curimg->subimages()) {
-            ot.errorf(command, "Invalid -subimage (%d): %s has %d subimage%s",
-                      subimage, ot.curimg->name(), ot.curimg->subimages(),
-                      ot.curimg->subimages() == 1 ? "" : "s");
+            ot.errorfmt(command, "Invalid -subimage ({}): {} has {} subimage{}",
+                        subimage, ot.curimg->name(), ot.curimg->subimages(),
+                        ot.curimg->subimages() == 1 ? "" : "s");
             return 0;
         }
     } else {
@@ -2787,9 +2788,9 @@ action_select_subimage(int argc, const char* argv[])
             }
         }
         if (subimage < 0) {
-            ot.errorf(command,
-                      "Invalid -subimage (%s): named subimage not found",
-                      whichsubimage);
+            ot.errorfmt(command,
+                        "Invalid -subimage ({}): named subimage not found",
+                        whichsubimage);
             return 0;
         }
     }
@@ -2953,7 +2954,7 @@ action_colorcount(cspan<const char*> argv)
                                         &colorvalues[0], &eps[0]);
     if (ok) {
         for (int col = 0; col < ncolors; ++col)
-            Strutil::printf("%8d  %s\n", count[col], colorstrings[col]);
+            Strutil::print("{:8}  {}\n", count[col], colorstrings[col]);
     } else {
         ot.error(command, (*ot.curimg)(0, 0).geterror());
     }
@@ -2987,9 +2988,9 @@ action_rangecheck(cspan<const char*> argv)
                                               &highcount, &inrangecount,
                                               &low[0], &high[0]);
     if (ok) {
-        Strutil::printf("%8d  < %s\n", lowcount, lowarg);
-        Strutil::printf("%8d  > %s\n", highcount, higharg);
-        Strutil::printf("%8d  within range\n", inrangecount);
+        Strutil::print("{:8}  < {}\n", lowcount, lowarg);
+        Strutil::print("{:8}  > {}\n", highcount, higharg);
+        Strutil::print("{:8}  within range\n", inrangecount);
     } else {
         ot.error(command, (*ot.curimg)(0, 0).geterror());
     }
@@ -3011,7 +3012,7 @@ action_diff(int argc, const char* argv[])
         ot.return_value = EXIT_FAILURE;
 
     if (ret != DiffErrOK && ret != DiffErrWarn && ret != DiffErrFail)
-        ot.errorf(command, "Diff failed");
+        ot.error(command, "Diff failed");
 
     ot.printed_info = true;  // because taking the diff has output
     return 0;
@@ -3033,7 +3034,7 @@ action_pdiff(int argc, const char* argv[])
         ot.return_value = EXIT_FAILURE;
 
     if (ret != DiffErrOK && ret != DiffErrWarn && ret != DiffErrFail)
-        ot.errorf(command, "Diff failed");
+        ot.error(command, "Diff failed");
 
     return 0;
 }
@@ -3112,7 +3113,7 @@ OIIOTOOL_OP(noise, 1, [](OiiotoolOp& op, span<ImageBuf*> img) {
         A = op.options().get_float("value", 0.0f);
         B = op.options().get_float("portion", 0.01f);
     } else {
-        ot.errorf(op.opname(), "Unknown noise type \"%s\"", type);
+        ot.errorfmt(op.opname(), "Unknown noise type \"{}\"", type);
         return false;
     }
     bool mono     = op.options().get_int("mono");
@@ -3250,7 +3251,7 @@ OIIOTOOL_OP(cshift, 1, [](OiiotoolOp& op, span<ImageBuf*> img) {
     int xyz[3] = { 0, 0, 0 };
     if (!(Strutil::scan_values(op.args(1), "", span<int>(xyz, 3))
           || Strutil::scan_values(op.args(1), "", span<int>(xyz, 2)))) {
-        ot.errorf(op.opname(), "Invalid shift offset '%s'", op.args(1));
+        ot.errorfmt(op.opname(), "Invalid shift offset '{}'", op.args(1));
         return false;
     }
     return ImageBufAlgo::circular_shift(*img[0], *img[1], xyz[0], xyz[1],
@@ -3287,7 +3288,7 @@ action_swap(int argc, const char* argv[])
     OIIO_DASSERT(argc == 1);
     string_view command = ot.express(argv[0]);
     if (ot.image_stack.size() < 1) {
-        ot.errorf(command, "requires at least two loaded images");
+        ot.error(command, "requires at least two loaded images");
         return 0;
     }
     ImageRecRef B(ot.pop());
@@ -3309,7 +3310,7 @@ action_create(int argc, const char* argv[])
     string_view size = ot.express(argv[1]);
     int nchans       = Strutil::from_string<int>(ot.express(argv[2]));
     if (nchans < 1 || nchans > 1024) {
-        ot.warningf(argv[0], "Invalid number of channels: %d", nchans);
+        ot.warningfmt(argv[0], "Invalid number of channels: {}", nchans);
         nchans = 3;
     }
     ImageSpec spec(64, 64, nchans,
@@ -3346,7 +3347,7 @@ action_pattern(int argc, const char* argv[])
     std::string size    = ot.express(argv[2]);
     int nchans          = Strutil::from_string<int>(ot.express(argv[3]));
     if (nchans < 1 || nchans > 1024) {
-        ot.warningf(argv[0], "Invalid number of channels: %d", nchans);
+        ot.warningfmt(argv[0], "Invalid number of channels: {}", nchans);
         nchans = 3;
     }
     ImageSpec spec(64, 64, nchans,
@@ -3426,7 +3427,7 @@ action_pattern(int argc, const char* argv[])
             A = options.get_float("value", 0.01f);
             B = options.get_float("portion", 0.0f);
         } else {
-            ot.errorf(command, "Unknown noise type \"%s\"", type);
+            ot.errorfmt(command, "Unknown noise type \"{}\"", type);
             ok = false;
         }
         bool mono = options.get_int("mono");
@@ -3436,7 +3437,7 @@ action_pattern(int argc, const char* argv[])
             ok = ImageBufAlgo::noise(ib, type, A, B, mono, seed);
     } else {
         ok = ImageBufAlgo::zero(ib);
-        ot.warningf(command, "Unknown pattern \"%s\"", pattern);
+        ot.warningfmt(command, "Unknown pattern \"{}\"", pattern);
     }
     if (!ok)
         ot.error(command, ib.geterror());
@@ -3452,7 +3453,7 @@ OIIOTOOL_OP(kernel, 0, [](OiiotoolOp& op, span<ImageBuf*> img) {
     float w = 1.0f;
     float h = 1.0f;
     if (!scan_resolution(kernelsize, w, h))
-        ot.errorf(op.opname(), "Unknown size %s", kernelsize);
+        ot.errorfmt(op.opname(), "Unknown size {}", kernelsize);
     *img[0] = ImageBufAlgo::make_kernel(kernelname, w, h);
     return !img[0]->has_error();
 });
@@ -3899,7 +3900,7 @@ action_pixelaspect(int argc, const char* argv[])
 
     float new_paspect = Strutil::from_string<float>(ot.express(argv[1]));
     if (new_paspect <= 0.0f) {
-        ot.errorf(command, "Invalid pixel aspect ratio '%g'", new_paspect);
+        ot.errorfmt(command, "Invalid pixel aspect ratio '{:g}'", new_paspect);
         return 0;
     }
 
@@ -3911,8 +3912,8 @@ action_pixelaspect(int argc, const char* argv[])
     // Get the current pixel aspect ratio
     float paspect = Aspec->get_float_attribute("PixelAspectRatio", 1.0);
     if (paspect <= 0.0f) {
-        ot.errorf(command, "Invalid pixel aspect ratio '%g' in source",
-                  paspect);
+        ot.errorfmt(command, "Invalid pixel aspect ratio '{:g}' in source",
+                    paspect);
         return 0;
     }
 
@@ -3954,7 +3955,7 @@ action_pixelaspect(int argc, const char* argv[])
                                                scale_full_height, 0, 0);
         std::string command = "resize";
         if (filtername.size())
-            command += Strutil::sprintf(":filter=%s", filtername);
+            command += Strutil::fmt::format(":filter={}", filtername);
         const char* newargv[2] = { command.c_str(), resize.c_str() };
         action_resize(2, newargv);
         A                         = ot.top();
@@ -3987,7 +3988,7 @@ OIIOTOOL_OP(blur, 1, [](OiiotoolOp& op, span<ImageBuf*> img) {
     float w             = 1.0f;
     float h             = 1.0f;
     if (!scan_resolution(op.args(1), w, h))
-        ot.errorf(op.opname(), "Unknown size %s", op.args(1));
+        ot.errorfmt(op.opname(), "Unknown size {}", op.args(1));
     ImageBuf Kernel = ImageBufAlgo::make_kernel(kernopt, w, h);
     if (Kernel.has_error()) {
         ot.error(op.opname(), Kernel.geterror());
@@ -4004,7 +4005,7 @@ OIIOTOOL_OP(median, 1, [](OiiotoolOp& op, span<ImageBuf*> img) {
     int w = 3;
     int h = 3;
     if (!scan_resolution(size, w, h))
-        ot.errorf(op.opname(), "Unknown size %s", size);
+        ot.errorfmt(op.opname(), "Unknown size {}", size);
     return ImageBufAlgo::median_filter(*img[0], *img[1], w, h);
 });
 
@@ -4016,7 +4017,7 @@ OIIOTOOL_OP(dilate, 1, [](OiiotoolOp& op, span<ImageBuf*> img) {
     int w = 3;
     int h = 3;
     if (!scan_resolution(size, w, h))
-        ot.errorf(op.opname(), "Unknown size %s", size);
+        ot.errorfmt(op.opname(), "Unknown size {}", size);
     return ImageBufAlgo::dilate(*img[0], *img[1], w, h);
 });
 
@@ -4028,7 +4029,7 @@ OIIOTOOL_OP(erode, 1, [](OiiotoolOp& op, span<ImageBuf*> img) {
     int w = 3;
     int h = 3;
     if (!scan_resolution(size, w, h))
-        ot.errorf(op.opname(), "Unknown size %s", size);
+        ot.errorfmt(op.opname(), "Unknown size {}", size);
     return ImageBufAlgo::erode(*img[0], *img[1], w, h);
 });
 
@@ -4075,9 +4076,9 @@ action_fixnan(int argc, const char* argv[])
     else if (modename == "error")
         mode = NONFINITE_ERROR;
     else {
-        ot.warningf(argv[0],
-                    "\"%s\" not recognized. Valid choices: black, box3, error",
-                    modename);
+        ot.warningfmt(argv[0],
+                      "\"{}\" not recognized. Valid choices: black, box3, error",
+                      modename);
     }
     ot.read();
     ImageRecRef A = ot.pop();
@@ -4154,9 +4155,9 @@ action_paste(int argc, const char* argv[])
     ROI roi_all, roi_full_all;
     for (int i = 0; i < ninputs; ++i) {
         if (ot.debug && ninputs > 4)
-            Strutil::printf("    paste/1 %d (total time %s, mem %s)\n", i,
-                            Strutil::timeintervalformat(ot.total_runtime(), 2),
-                            Strutil::memformat(Sysutil::memory_used()));
+            Strutil::print("    paste/1 {} (total time {}, mem {})\n", i,
+                           Strutil::timeintervalformat(ot.total_runtime(), 2),
+                           Strutil::memformat(Sysutil::memory_used()));
         ot.read(inputs[i]);
         roi_all      = roi_union(roi_all, inputs[i]->spec()->roi());
         roi_full_all = roi_union(roi_full_all, inputs[i]->spec()->roi_full());
@@ -4173,7 +4174,7 @@ action_paste(int argc, const char* argv[])
     if (position == "-" || position == "auto") {
         // Come back to this
     } else if (!scan_offset(position, x, y)) {
-        ot.errorf(command, "Invalid offset '%s'", position);
+        ot.errorfmt(command, "Invalid offset '{}'", position);
         return 0;
     }
 
@@ -4182,10 +4183,10 @@ action_paste(int argc, const char* argv[])
         // to pre-allocate the fully merged set of samples.
         for (int i = 0; i < ninputs; ++i) {
             if (ot.debug && ninputs > 4)
-                Strutil::printf("    paste/2 %d (total time %s, mem %s)\n", i,
-                                Strutil::timeintervalformat(ot.total_runtime(),
-                                                            2),
-                                Strutil::memformat(Sysutil::memory_used()));
+                Strutil::print("    paste/2 {} (total time {}, mem {})\n", i,
+                               Strutil::timeintervalformat(ot.total_runtime(),
+                                                           2),
+                               Strutil::memformat(Sysutil::memory_used()));
             ImageRecRef FG = inputs[i];
             if (!FG->spec()->deep)
                 break;
@@ -4213,9 +4214,9 @@ action_paste(int argc, const char* argv[])
     // Now paste the other images, back to front
     for (int i = 1; i < ninputs && ok; ++i) {
         if (ot.debug && ninputs > 4)
-            Strutil::printf("    paste/3 %d (total time %s, mem %s)\n", i,
-                            Strutil::timeintervalformat(ot.total_runtime(), 2),
-                            Strutil::memformat(Sysutil::memory_used()));
+            Strutil::print("    paste/3 {} (total time {}, mem {})\n", i,
+                           Strutil::timeintervalformat(ot.total_runtime(), 2),
+                           Strutil::memformat(Sysutil::memory_used()));
         ImageRecRef FG = inputs[i];
         ok             = ImageBufAlgo::paste(*Rbuf, x, y, 0, 0, (*FG)());
         if (!ok)
@@ -4250,7 +4251,7 @@ action_mosaic(int /*argc*/, const char* argv[])
     int ximages = 0, yimages = 0;
     if (!scan_resolution(size, ximages, yimages) || ximages < 1
         || yimages < 1) {
-        ot.errorf(command, "Invalid size '%s'", size);
+        ot.errorfmt(command, "Invalid size '{}'", size);
         return 0;
     }
     int nimages = ximages * yimages;
@@ -4656,7 +4657,7 @@ input_file(int argc, const char* argv[])
         if (!exists) {
             // Try to get a more precise error message to report
             if (!Filesystem::exists(filename))
-                ot.errorf("read", "File does not exist: \"%s\"", filename);
+                ot.errorfmt("read", "File does not exist: \"{}\"", filename);
             else {
                 auto in         = ImageInput::open(filename);
                 std::string err = in ? in->geterror() : OIIO::geterror();
@@ -4793,7 +4794,8 @@ prep_texture_config(ImageSpec& configspec, ParamValueList& fileoptions)
     std::string wrap       = fileoptions.get_string("wrap", "black");
     std::string swrap      = fileoptions.get_string("swrap", wrap);
     std::string twrap      = fileoptions.get_string("twrap", wrap);
-    configspec.attribute("wrapmodes", Strutil::sprintf("%s,%s", swrap, twrap));
+    configspec.attribute("wrapmodes",
+                         Strutil::fmt::format("{},{}", swrap, twrap));
     configspec.attribute("maketx:verbose", ot.verbose);
     configspec.attribute("maketx:runstats", ot.runstats);
     configspec.attribute("maketx:resize", fileoptions.get_int("resize"));
@@ -4894,8 +4896,8 @@ output_file(int /*argc*/, const char* argv[])
     if (ot.debug)
         std::cout << "Output: " << filename << "\n";
     if (!ot.curimg.get()) {
-        ot.warningf(command, "%s did not have any current image to output.",
-                    filename);
+        ot.warningfmt(command, "{} did not have any current image to output.",
+                      filename);
         return 0;
     }
 
@@ -4935,7 +4937,7 @@ output_file(int /*argc*/, const char* argv[])
     }
 
     if (ot.noclobber && Filesystem::exists(filename)) {
-        ot.warningf(command, "%s already exists, not overwriting.", filename);
+        ot.warningfmt(command, "{} already exists, not overwriting.", filename);
         return 0;
     }
     std::string formatname = fileoptions.get_string("fileformatname", filename);
@@ -4972,8 +4974,8 @@ output_file(int /*argc*/, const char* argv[])
         const char* argv[] = { "channels:allsubimages=1", chanlist.c_str() };
         int action_channels(int argc, const char* argv[]);  // forward decl
         action_channels(2, argv);
-        ot.warningf(command, "Can't save %d channels to %s... saving only %s",
-                    ir->spec()->nchannels, out->format_name(), chanlist);
+        ot.warningfmt(command, "Can't save {} channels to {}... saving only {}",
+                      ir->spec()->nchannels, out->format_name(), chanlist);
         ir = ot.curimg;
     }
 
@@ -5032,9 +5034,9 @@ output_file(int /*argc*/, const char* argv[])
             if ((ot.output_dataformat && ot.output_dataformat != type)
                 || (bits && ot.output_bitspersample
                     && ot.output_bitspersample != bits)) {
-                ot.warningf(
+                ot.warningfmt(
                     command,
-                    "Output filename (%s) colorspace \"%s\" implies %s (%d bits), overriding prior request for %s.",
+                    "Output filename ({}) colorspace \"{}\" implies {} ({} bits), overriding prior request for {}.",
                     filename, outcolorspace, type, bits, ot.output_dataformat);
             }
             ot.output_dataformat    = type;
@@ -5205,18 +5207,18 @@ output_file(int /*argc*/, const char* argv[])
                     } else if (out->supports("multiimage")) {
                         mode = ImageOutput::AppendSubimage;
                     } else {
-                        ot.warningf(command,
-                                    "%s does not support MIP-maps for %s",
-                                    out->format_name(), filename);
+                        ot.warningfmt(command,
+                                      "{} does not support MIP-maps for {}",
+                                      out->format_name(), filename);
                         break;
                     }
                 }
             }
             mode = ImageOutput::AppendSubimage;  // for next subimage
             if (send > 1 && !out->supports("multiimage")) {
-                ot.warningf(command,
-                            "%s does not support multiple subimages for %s",
-                            out->format_name(), filename);
+                ot.warningfmt(command,
+                              "{} does not support multiple subimages for {}",
+                              out->format_name(), filename);
                 break;
             }
         }
@@ -5233,9 +5235,9 @@ output_file(int /*argc*/, const char* argv[])
             std::string err;
             ok = Filesystem::rename(tmpfilename, filename, err);
             if (!ok)
-                ot.errorf(
+                ot.errorfmt(
                     command,
-                    "oiiotool ERROR: could not move temp file %s to %s: %s",
+                    "oiiotool ERROR: could not move temp file {} to {}: {}",
                     tmpfilename, filename, err);
         }
         if (!ok)
@@ -5265,10 +5267,10 @@ output_file(int /*argc*/, const char* argv[])
     ot.num_outputs += 1;
 
     if (ot.debug)
-        Strutil::printf("    output took %s  (total time %s, mem %s)\n",
-                        Strutil::timeintervalformat(optime, 2),
-                        Strutil::timeintervalformat(ot.total_runtime(), 2),
-                        Strutil::memformat(Sysutil::memory_used()));
+        Strutil::print("    output took {}  (total time {}, mem {})\n",
+                       Strutil::timeintervalformat(optime, 2),
+                       Strutil::timeintervalformat(ot.total_runtime(), 2),
+                       Strutil::memformat(Sysutil::memory_used()));
     return 0;
 }
 
@@ -5590,14 +5592,16 @@ print_help_end(std::ostream& out)
     std::string buildsimd = OIIO::get_string_attribute("oiio:simd");
     if (!buildsimd.size())
         buildsimd = "no SIMD";
-    auto buildinfo
-        = Strutil::sprintf("OIIO %s built for C++%d/%d %s", OIIO_VERSION_STRING,
-                           OIIO_CPLUSPLUS_VERSION, __cplusplus, buildsimd);
+    auto buildinfo = Strutil::fmt::format("OIIO {} built for C++{}/{} {}",
+                                          OIIO_VERSION_STRING,
+                                          OIIO_CPLUSPLUS_VERSION, __cplusplus,
+                                          buildsimd);
     out << Strutil::wordwrap(buildinfo, columns, 4) << std::endl;
-    auto hwinfo = Strutil::sprintf("Running on %d cores %.1fGB %s",
-                                   Sysutil::hardware_concurrency(),
-                                   Sysutil::physical_memory() / float(1 << 30),
-                                   OIIO::get_string_attribute("hw:simd"));
+    auto hwinfo = Strutil::fmt::format("Running on {} cores {:.1f}GB {}",
+                                       Sysutil::hardware_concurrency(),
+                                       Sysutil::physical_memory()
+                                           / float(1 << 30),
+                                       OIIO::get_string_attribute("hw:simd"));
     out << Strutil::wordwrap(hwinfo, columns, 4) << std::endl;
 
     // Print the path to the docs. If found, use the one installed in the
@@ -6345,7 +6349,7 @@ handle_sequence(int argc, const char** argv)
                                            normalized_pattern,
                                            sequence_framespec);
         if (!result) {
-            ot.errorf("", "Could not parse pattern: %s", argv[a]);
+            ot.errorfmt("", "Could not parse pattern: {}", argv[a]);
             return true;
         }
 
@@ -6370,9 +6374,9 @@ handle_sequence(int argc, const char** argv)
                                                              frame_views[a],
                                                              filenames[a]);
             if (!result) {
-                ot.errorf(
+                ot.errorfmt(
                     "",
-                    "No filenames found matching pattern: \"%s\" (did you intend to use --wildcardoff?)",
+                    "No filenames found matching pattern: \"{}\" (did you intend to use --wildcardoff?)",
                     argv[a]);
                 return true;
             }
@@ -6381,9 +6385,9 @@ handle_sequence(int argc, const char** argv)
         if (i == 0) {
             nfilenames = filenames[a].size();
         } else if (nfilenames != filenames[a].size()) {
-            ot.errorf(
+            ot.errorfmt(
                 "",
-                "Not all sequence specifications matched: %s (%d frames) vs. %s (%d frames)",
+                "Not all sequence specifications matched: {} ({} frames) vs. {} ({} frames)",
                 argv[sequence_args[0]], nfilenames, argv[a],
                 filenames[a].size());
             return true;
@@ -6475,10 +6479,10 @@ main(int argc, char* argv[])
         const half* h              = (half*)bad;
         simd::vfloat4 vf(h);
         if (vf[0] == 0.0f || *h != vf[0])
-            Strutil::fprintf(stderr,
-                             "Bad half conversion, code %d %f -> %f "
-                             "(suspect badly set DENORMS_ZERO_MODE)\n",
-                             bad[0], h[0], vf[0]);
+            Strutil::print(stderr,
+                           "Bad half conversion, code {} {} -> {} "
+                           "(suspect badly set DENORMS_ZERO_MODE)\n",
+                           bad[0], h[0], vf[0]);
     }
 
     // Helpful for debugging to make sure that any crashes dump a stack

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -272,20 +272,6 @@ public:
     void error(string_view command, string_view message = "") const;
     void warning(string_view command, string_view message = "") const;
 
-    // Formatted errors with printf-like notation
-    template<typename... Args>
-    void errorf(string_view command, const char* fmt, const Args&... args) const
-    {
-        error(command, Strutil::sprintf(fmt, args...));
-    }
-
-    template<typename... Args>
-    void warningf(string_view command, const char* fmt,
-                  const Args&... args) const
-    {
-        warning(command, Strutil::sprintf(fmt, args...));
-    }
-
     // Formatted errors with std::format-like notation
     template<typename... Args>
     void errorfmt(string_view command, const char* fmt,
@@ -547,9 +533,18 @@ public:
     /// Error reporting for ImageRec: call this with printf-like arguments.
     /// Note however that this is fully typesafe!
     template<typename... Args>
+    OIIO_DEPRECATED("Use errorfmt instead")
     void errorf(const char* fmt, const Args&... args) const
     {
         append_error(Strutil::sprintf(fmt, args...));
+    }
+
+    /// Error reporting for ImageRec: call this with printf-like arguments.
+    /// Note however that this is fully typesafe!
+    template<typename... Args>
+    void errorfmt(const char* fmt, const Args&... args) const
+    {
+        append_error(Strutil::fmt::format(fmt, args...));
     }
 
     /// Return true if the IR has had an error and has an error message
@@ -867,7 +862,7 @@ public:
                     // Call the impl kernel for this subimage
                     bool ok = impl(m_img);
                     if (!ok)
-                        ot.errorf(opname(), "%s", m_img[0]->geterror());
+                        ot.errorfmt(opname(), "{}", m_img[0]->geterror());
 
                     // Merge metadata if called for
                     if (ot.metamerge)
@@ -885,7 +880,7 @@ public:
             // Make sure to forward any errors missed by the impl
             for (auto& im : m_img)
                 if (im->has_error())
-                    ot.errorf(opname(), "%s", im->geterror());
+                    ot.errorfmt(opname(), "{}", im->geterror());
         }
     }
 

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -45,7 +45,7 @@ compute_sha1(Oiiotool& ot, ImageInput* input, int subimage)
             std::string err = input->geterror();
             if (err.empty())
                 err = "could not read image";
-            ot.errorf("-info", "SHA-1: %s", err);
+            ot.errorfmt("-info", "SHA-1: {}", err);
             return std::string();
         }
         // Hash both the sample counts and the data block
@@ -54,7 +54,7 @@ compute_sha1(Oiiotool& ot, ImageInput* input, int subimage)
     } else {
         imagesize_t size = input->spec().image_bytes(true /*native*/);
         if (size >= std::numeric_limits<size_t>::max()) {
-            ot.errorf("-info", "SHA-1: unable to compute, image is too big");
+            ot.error("-info", "SHA-1: unable to compute, image is too big");
             return std::string();
         } else if (size != 0) {
             std::unique_ptr<char[]> buf(new char[size]);
@@ -62,7 +62,7 @@ compute_sha1(Oiiotool& ot, ImageInput* input, int subimage)
                 std::string err = input->geterror();
                 if (err.empty())
                     err = "could not read image";
-                ot.errorf("-info", "SHA-1: %s", err);
+                ot.errorfmt("-info", "SHA-1: {}", err);
                 return std::string();
             }
             sha.append(&buf[0], size);


### PR DESCRIPTION
Also tagged Strutil and ustring::fmtformat as 'nodiscard', to produce
warnings if people call it and ignore the results. (As was the case in
my own bug that I tracked down in the course of this patch.)
