### PR TITLE
ImageSpec: New constructors to accept string for data type

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -314,6 +314,11 @@ public:
     /// something reasonable.
     ImageSpec (TypeDesc format = TypeDesc::UNKNOWN) noexcept;
 
+    /// Constructor: given just the data format (as any type name recognized
+    /// by the `TypeDesc` constructor), set all other fields to something
+    /// reasonable.
+    ImageSpec (string_view format) noexcept : ImageSpec(TypeDesc(format)) {}
+
     /// Constructs an `ImageSpec` with the given x and y resolution, number
     /// of channels, and pixel data format.
     ///
@@ -325,14 +330,30 @@ public:
     /// channel (if it exists) is assumed to be alpha.
     ImageSpec (int xres, int yres, int nchans, TypeDesc fmt = TypeUInt8) noexcept;
 
+    /// Construct an `ImageSpec` with the given x and y resolution, number
+    /// of channels, and pixel data format name (as any type name recognized
+    /// by the `TypeDesc` constructor).
+    ImageSpec (int xres, int yres, int nchans, string_view fmt) noexcept
+        : ImageSpec(xres, yres, nchans, TypeDesc(fmt)) {}
+
     /// Construct an `ImageSpec` whose dimensions (both data and "full") and
     /// number of channels are given by the `ROI`, pixel data type by `fmt`,
     /// and other fields are set to their default values.
     explicit ImageSpec (const ROI &roi, TypeDesc fmt = TypeUInt8) noexcept;
 
+    /// Construct an `ImageSpec` from an ROI giving dimensions, and the name
+    /// of a data type that will be recognized by the `TypeDesc` constructor.
+    explicit ImageSpec (const ROI &roi, string_view fmt) noexcept
+        : ImageSpec(roi, TypeDesc(fmt)) {}
+
     /// Set the data format, and clear any per-channel format information
     /// in `channelformats`.
     void set_format (TypeDesc fmt) noexcept;
+
+    /// Set the data format, and clear any per-channel format information
+    /// in `channelformats`. The `fmt` may be a string such as `"uint8"`,
+    /// or any other type name recognized by the TypeDesc constructor.
+    void set_format (string_view fmt) noexcept { set_format(TypeDesc(fmt)); }
 
     /// Sets the `channelnames` to reasonable defaults for the number of
     /// channels.  Specifically, channel names are set to "R", "G", "B,"

--- a/src/libOpenImageIO/imagespec_test.cpp
+++ b/src/libOpenImageIO/imagespec_test.cpp
@@ -296,7 +296,7 @@ static void
 test_imagespec_from_ROI()
 {
     ROI roi(0, 640, 0, 480, 0, 1, 0, 3);
-    ImageSpec spec(roi, TypeDesc::FLOAT);
+    ImageSpec spec(roi, "float");
     OIIO_CHECK_EQUAL(spec.nchannels, 3);
     OIIO_CHECK_EQUAL(spec.width, 640);
     OIIO_CHECK_EQUAL(spec.height, 480);
@@ -304,6 +304,7 @@ test_imagespec_from_ROI()
     OIIO_CHECK_EQUAL(spec.full_width, 640);
     OIIO_CHECK_EQUAL(spec.full_height, 480);
     OIIO_CHECK_EQUAL(spec.full_depth, 1);
+    OIIO_CHECK_EQUAL(spec.format, TypeFloat);
 }
 
 static void
@@ -320,6 +321,7 @@ test_imagespec_from_xml()
     OIIO_CHECK_EQUAL(spec.full_width, 1920);
     OIIO_CHECK_EQUAL(spec.full_height, 1080);
     OIIO_CHECK_EQUAL(spec.full_depth, 1);
+    OIIO_CHECK_EQUAL(spec.format, TypeFloat);
     OIIO_CHECK_EQUAL(spec.get_string_attribute("oiio:ColorSpace"), "Linear");
 }
 

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -120,7 +120,8 @@ declare_imagespec(py::module& m)
         .def(
             "copy", [](const ImageSpec& self) { return ImageSpec(self); },
             py::return_value_policy::reference_internal)
-        .def("set_format", &ImageSpec::set_format)
+        .def("set_format",
+             [](ImageSpec& self, TypeDesc t) { self.set_format(t); })
         .def("default_channel_names", &ImageSpec::default_channel_names)
         .def("channel_bytes",
              [](const ImageSpec& spec) { return spec.channel_bytes(); })


### PR DESCRIPTION
For each ImageSpec ctr that takes a TypeDesc, add another one
that's the same but takes a string_view (which is just a simple
pass-through of the TypeDesc-from-string_view).
