### PR TITLE
CI: pybind11 version bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       CMAKE_CXX_STANDARD: 14
       USE_SIMD: sse4.2
       PUGIXML_VERSION: v1.9
+      PYBIND11_VERSION: v2.4.2
     steps:
       - uses: actions/checkout@v2
       - name: Prepare ccache timestamp
@@ -78,6 +79,7 @@ jobs:
       CXX: g++
       CC: gcc
       CMAKE_CXX_STANDARD: 14
+      PYBIND11_VERSION: v2.5.0
       PYTHON_VERSION: 3.7
       USE_SIMD: avx
       WEBP_VERSION: v1.1.0
@@ -129,6 +131,7 @@ jobs:
       CXX: g++
       CC: gcc
       CMAKE_CXX_STANDARD: 17
+      PYBIND11_VERSION: v2.7.0
       PYTHON_VERSION: 3.7
       USE_SIMD: avx2,f16c
       WEBP_VERSION: v1.1.0
@@ -179,6 +182,7 @@ jobs:
       CXX: g++
       CC: gcc
       CMAKE_CXX_STANDARD: 17
+      PYBIND11_VERSION: v2.9.0
       PYTHON_VERSION: 3.9
       USE_SIMD: avx2,f16c
     steps:
@@ -228,6 +232,7 @@ jobs:
       CMAKE_CXX_STANDARD: 14
       USE_SIMD: sse4.2
       OPENEXR_VERSION: v2.4.3
+      PYBIND11_VERSION: v2.6.2
       CMAKE_BUILD_TYPE: Debug
     steps:
       - uses: actions/checkout@v2
@@ -330,7 +335,7 @@ jobs:
       OPENJPEG_VERSION: v2.4.0
       PUGIXML_VERSION: v1.11.4
       PTEX_VERSION: v2.4.0
-      PYBIND11_VERSION: v2.8.1
+      PYBIND11_VERSION: v2.9.0
       PYTHON_VERSION: 3.8
       WEBP_VERSION: v1.2.1
       MY_CMAKE_FLAGS: -DBUILD_FMT_VERSION=8.0.1
@@ -732,7 +737,7 @@ jobs:
       CMAKE_CXX_STANDARD: 14
       PYTHON_VERSION: 3.7
       USE_SIMD: avx2,f16c
-      PYBIND11_VERSION: v2.6.1
+      PYBIND11_VERSION: v2.6.2
     steps:
       - uses: actions/checkout@v2
       - name: Prepare ccache timestamp
@@ -780,6 +785,7 @@ jobs:
     env:
       CXX: clang++
       CMAKE_CXX_STANDARD: 17
+      PYBIND11_VERSION: v2.8.1
       PYTHON_VERSION: 3.9
       USE_SIMD: avx2,f16c
     steps:
@@ -829,6 +835,7 @@ jobs:
       CMAKE_CXX_STANDARD: 14
       BUILD_SHARED_LIBS: OFF
       OPENEXR_VERSION: v2.4.3
+      PYBIND11_VERSION: v2.6.2
     steps:
       - uses: actions/checkout@v2
       - name: Prepare ccache timestamp

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,8 +32,8 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * Qt >= 5.6 (tested through 5.15)
      * OpenGL
  * If you are building the Python bindings or running the testsuite:
-     * Python >= 2.7 (tested against 2.7, 3.6, 3.7, 3.8, 3.9)
-     * pybind11 >= 2.4.2 (Tested through 2.8.)
+     * Python >= 2.7 (tested against 2.7, 3.7, 3.8, 3.9)
+     * pybind11 >= 2.4.2 (Tested through 2.9.)
      * NumPy
  * If you want support for camera "RAW" formats:
      * LibRaw >= 0.15 (tested 0.15 - 0.20.2; LibRaw >= 0.18 is necessary for

--- a/src/build-scripts/build_pybind11.bash
+++ b/src/build-scripts/build_pybind11.bash
@@ -7,7 +7,7 @@ set -ex
 
 # Repo and branch/tag/commit of pybind11 to download if we don't have it yet
 PYBIND11_REPO=${PYBIND11_REPO:=https://github.com/pybind/pybind11.git}
-PYBIND11_VERSION=${PYBIND11_VERSION:=v2.6.2}
+PYBIND11_VERSION=${PYBIND11_VERSION:=v2.8.1}
 
 # Where to put pybind11 repo source (default to the ext area)
 PYBIND11_SRC_DIR=${PYBIND11_SRC_DIR:=${PWD}/ext/pybind11}


### PR DESCRIPTION
* Use the new pybind11 v2.9.0 for 2022 and "latest" tests.
* Bump the default version built by build_pybind11.bash to 2.8.1.
* Adjust the pybind11 version used in many of the other CI tests, to
  give an even spread across versions, and to make each of the
  "vfx platform" CI tests use the pybind11 version that was available
  near the start of its repsective year.
