### PR TITLE
Python: improve ParamValueList and ImageSpec dict interface

### DIFF
--- a/src/doc/imageinput.rst
+++ b/src/doc/imageinput.rst
@@ -576,10 +576,15 @@ as an associative array or dictionary:
 
     .. code-tab:: py
 
-        # spec["key"] returns the attribute, or None
+        # spec["key"] returns the attribute if present, or raises KeyError
+        # if not found.
         i = spec["Orientation"]
         f = spec["PixelAspectRatio"]
         s = spec["ImageDescription"]
+
+        # spec.get("key", default=None) returns the attribute if present,
+        # or the default value if not found.
+        val = spec.get("Orientation", 1)
 
 Note that when retrieving with this "dictionary" syntax, the C++ and
 Python behaviors are different: C++ requires a `get<TYPE>()` call to
@@ -594,8 +599,7 @@ This can be accomplished using the technique of the following example:
 
     .. code-tab:: c++
 
-        for (size_t i = 0;  i < spec.extra_attribs.size();  ++i) {
-            const ParamValue &p (spec.extra_attribs[i]);
+        for (const auto &p : spec.extra_attribs) {
             printf ("    %s: %s\n", p.name().c_str(), p.get_string().c_str());
         }
 

--- a/src/doc/imageoutput.rst
+++ b/src/doc/imageoutput.rst
@@ -847,6 +847,29 @@ values.  For example,
       neutral = (0.3127, 0.329)
       spec.attribute ("adoptedNeutral", "float[2]", neutral)
 
+Additionally, the `["key"]` notation may be used to set metadata in the
+spec as if it were an associative array or dictionary:
+
+.. tabs::
+
+    .. code-tab:: c++
+
+        // spec["key"] = value  sets the value of the metadata, using
+        // the type of value as a guide for the type of the metadata.
+        spec["Orientation"] = 1;   // int
+        spec["PixelAspectRatio"] = 1.0f;   // float
+        spec["ImageDescription"] = "selfie";  // string
+        spec["worldtocamera"] = Imath::M44f(...)  // matrix
+
+    .. code-tab:: py
+
+        // spec["key"] = value  sets the value of the metadata, just
+        // like a Python dict.
+        spec["Orientation"] = 1
+        spec["PixelAspectRatio"] = 1.0
+        spec["ImageDescription"] = "selfie"
+        spec["worldtocamera"] = (1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)
+
 In general, most image file formats (and therefore most ``ImageOutput``
 implementations) are aware of only a small number of name/value pairs
 that they predefine and will recognize.  Some file formats (OpenEXR,

--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -606,22 +606,49 @@ Section :ref:`sec-ImageSpec`, is replicated for Python.
 
 .. py:attribute:: ImageSpec[key]
 
-    *NEW in 2.1*
-
-    Retrieve or set metadata using a dictionary-like syntax, rather than
-    `attribute()` and `getattribute()`. When retrieving a key that is
-    not found, a `KeyError` exception will be thrown.
+    ImageSpec provides a Python `dict`-like interface for metadata,
+    in addition to `attribute()` and `getattribute()`. 
     
-    Example:
+    The `ImageSpec["key"] = value` notation can be used to set an
+    attribute (just like calling `ImageSpec.attribute("key", value)`).
+    Also, `ImageSpec["key"]` can retrieve an attribute if it is present,
+    or raise a `KeyError` exception if not found.
+
+    Like dictionaries, `'key' in spec` is True if the attribute is present,
+    and `del spec['key']` will remove the attribute.
+    
+    Examples:
 
     .. code-block:: python
 
-        comp = spec["Compression"]
-        # Same as:  comp = spec.getattribute("Compression")
-
-        spec["Compression"] = comp
         # Same as: spec.attribute("Compression", comp)
+        spec["Compression"] = comp
 
+        # Same as:  comp = spec.getattribute("Compression")
+        # if it succeeds, or raises a KeyError if not found.
+        comp = spec["Compression"]
+
+        # Failed spec["key"] will raise a KeyError
+        try:
+            r = spec["unknown"]
+        except:
+            print("'unknown' key was not found")
+
+        # "key" in spec is True if the key is present
+        if "Compression" in spec:
+            print("'Compression' metadata is present")
+
+        # del spec["key"] removes the key
+        del key["Compression"]
+
+        # ImageSpec.get("key") returns the value, or None if not found
+        comp = spec.get("Compression")
+        # and optionally, a default value may be passed
+        comp = spec.get("Compression", "none")
+
+    The basic `["key"]` setting and retrieval was added in OpenImageIO in 2.1.
+    The `"key" in` and `del` operators, and the `get()` method, were added in
+    OpenImageIO 2.4.
 
 
 .. py:method:: ImageSpec.metadata_val (paramval, human=False)

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -584,7 +584,8 @@ make_numpy_array(TypeDesc format, void* data, int dims, size_t chans,
 
 
 inline py::object
-ParamValue_getitem(const ParamValue& self, bool allitems = false)
+ParamValue_getitem(const ParamValue& self, bool allitems = false,
+                   py::object defaultvalue = py::none())
 {
     TypeDesc t = self.type();
     int nvals  = allitems ? self.nvalues() : 1;
@@ -608,7 +609,7 @@ case TypeDesc::TYPE:                                                       \
         ParamValue_convert_dispatch(DOUBLE);
     case TypeDesc::STRING:
         return C_to_val_or_tuple((const char**)self.data(), t, nvals);
-    default: return py::none();
+    default: return defaultvalue;
     }
 
 #undef ParamValue_convert_dispatch

--- a/testsuite/python-imagespec/ref/out-python3.txt
+++ b/testsuite/python-imagespec/ref/out-python3.txt
@@ -88,9 +88,16 @@ getattribute('foo_vector') retrieves (1.0, 0.0, 11.0)
 getattribute('foo_matrix') retrieves (1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0, 1.0)
 getattribute('foo_no') retrieves None
 getattribute('smpte:TimeCode') retrieves (18356486, 4294967295)
+getattribute('unknown') retrieves None
+s.get('foo_int') = 14
+s.get('unknown') = None
+s.get('unknown', 123) = None
 s['delfoo_float'] = 99.5
 s['delfoo_int'] = 29
 s['delfoo_str'] = egg
+s['unknown'] raised a KeyError (as expected)
+'foo_int' in s = True
+'unknown' in s = False
 
 extra_attribs size is 9
 0 foo_str string blah

--- a/testsuite/python-imagespec/ref/out.txt
+++ b/testsuite/python-imagespec/ref/out.txt
@@ -88,9 +88,16 @@ getattribute('foo_vector') retrieves (1.0, 0.0, 11.0)
 getattribute('foo_matrix') retrieves (1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0, 1.0)
 getattribute('foo_no') retrieves None
 getattribute('smpte:TimeCode') retrieves (18356486L, 4294967295L)
+getattribute('unknown') retrieves None
+s.get('foo_int') = 14
+s.get('unknown') = None
+s.get('unknown', 123) = None
 s['delfoo_float'] = 99.5
 s['delfoo_int'] = 29
 s['delfoo_str'] = egg
+s['unknown'] raised a KeyError (as expected)
+'foo_int' in s = True
+'unknown' in s = False
 
 extra_attribs size is 9
 0 foo_str string blah

--- a/testsuite/python-imagespec/src/test_imagespec.py
+++ b/testsuite/python-imagespec/src/test_imagespec.py
@@ -111,9 +111,23 @@ try:
     print ("getattribute('foo_matrix') retrieves", s.getattribute("foo_matrix"))
     print ("getattribute('foo_no') retrieves", s.getattribute("foo_no"))
     print ("getattribute('smpte:TimeCode') retrieves", s.getattribute("smpte:TimeCode"))
+    print ("getattribute('unknown') retrieves", s.getattribute("unknown"))
+    print ("s.get('foo_int') =", s.get('foo_int'))
+    print ("s.get('unknown') =", s.get('unknown'))
+    print ("s.get('unknown', 123) =", s.get('unknown'))
     print ("s['delfoo_float'] =", s['delfoo_float'])
     print ("s['delfoo_int'] =", s['delfoo_int'])
     print ("s['delfoo_str'] =", s['delfoo_str'])
+    try :
+        print ("s['unknown'] =", s['unknown'])
+    except KeyError :
+        print ("s['unknown'] raised a KeyError (as expected)")
+    except :
+        print ("s['unknown'] threw an unknown exception (oh no!)")
+    print("'foo_int' in s =", "foo_int" in s)
+    print("'unknown' in s =", "unknown" in s)
+    s["extra"] = 1  # add 'extra', then delete it
+    del s["extra"]  # it should not appear in the serialization below
     print ()
 
     print ("extra_attribs size is", len(s.extra_attribs))

--- a/testsuite/python-paramlist/ref/out.txt
+++ b/testsuite/python-paramlist/ref/out.txt
@@ -23,7 +23,11 @@ pl[1] = s string Bob
 pl['e'] = 2.71828
 pl['pi'] = 3.14159
 pl['foo'] = bar
+'e' in pl = True
 after removing 'e', len= 7 pl.contains('e')= False
+after adding 'x', then 'x' in pl = True
+after removing 'x', then 'x' in pl = False
+pl['unknown'] raised a KeyError (as expected)
 pl2 =
   item a string aval
   item m int 1

--- a/testsuite/python-paramlist/src/test_paramlist.py
+++ b/testsuite/python-paramlist/src/test_paramlist.py
@@ -66,9 +66,22 @@ try:
     print ("pl['e'] = {:.6}".format(pl['e']))
     print ("pl['pi'] = {:.6}".format(pl['pi']))
     print ("pl['foo'] =", pl['foo'])
+    print ("'e' in pl =", 'e' in pl)
 
     pl.remove('e')
     print ("after removing 'e', len=", len(pl), "pl.contains('e')=", pl.contains('e'))
+
+    pl['x'] = 123
+    print ("after adding 'x', then 'x' in pl =", 'x' in pl)
+    del pl['x']
+    print ("after removing 'x', then 'x' in pl =", 'x' in pl)
+
+    try :
+        print ("pl['unknown'] =", pl['unknown'])
+    except KeyError :
+        print ("pl['unknown'] raised a KeyError (as expected)")
+    except :
+        print ("pl['unknown'] threw an unknown exception (oh no!)")
 
     pl2 = oiio.ParamValueList()
     pl2.attribute ("a", "aval")


### PR DESCRIPTION
The Python bindings for ParamValueList and ImageSpec allow a "dict"
style (associative array) interface:

    imagespec["key"] = value
    val = imagespec["key"]

This patch makes some minor improvements:

* Clarify in the docs that like a regular Python dict, the associative
  retrieval will raise a KeyError if the key is not found.

* Add `__contains__` python method as a synonym for contains(), thus
  implementing `key in dict`.

* Add `__delitem__` python method as a synonym for erase(), thus
  implementing `del dict[key]`.

* Add an `ImageSpec.get()` method that is a synonym for getattribute
  (which retrieves the item or returns None or a default if not
  found), mirroring the behavior of Python's `dict.get()`.
