### PR TITLE
Python: implement ROI.copy()

### DIFF
--- a/src/doc/imagebufalgo.rst
+++ b/src/doc/imagebufalgo.rst
@@ -213,7 +213,7 @@ zero() -- create a black image
           ImageBufAlgo.zero (A, ROI (0, 100, 0, 100))
           
           # Zero out just the green channel, leave everything else the same
-          roi = A.roi ()
+          roi = A.roi
           roi.chbegin = 1 # green
           roi.chend = 2   # one past the end of the channel region
           ImageBufAlgo.zero (A, roi)

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -117,9 +117,7 @@ declare_imagespec(py::module& m)
         .def(py::init<const ROI&, TypeDesc>())
         .def(py::init<TypeDesc>())
         .def(py::init<const ImageSpec&>())
-        .def(
-            "copy", [](const ImageSpec& self) { return ImageSpec(self); },
-            py::return_value_policy::reference_internal)
+        .def("copy", [](const ImageSpec& self) { return ImageSpec(self); })
         .def("set_format",
              [](ImageSpec& self, TypeDesc t) { self.set_format(t); })
         .def("default_channel_names", &ImageSpec::default_channel_names)

--- a/src/python/py_roi.cpp
+++ b/src/python/py_roi.cpp
@@ -64,6 +64,9 @@ declare_roi(py::module& m)
         .def("__str__",
              [](const ROI& roi) { return PY_STR(Strutil::sprintf("%s", roi)); })
 
+        // Copy
+        .def("copy", [](const ROI& self) -> ROI { return self; })
+
         // roi_union, roi_intersection, get_roi(spec), get_roi_full(spec)
         // set_roi(spec,newroi), set_roi_full(newroi)
 

--- a/testsuite/python-roi/ref/out.txt
+++ b/testsuite/python-roi/ref/out.txt
@@ -36,5 +36,7 @@ ROI.intersection(A,B) = 5 10 0 8 0 1 0 4
 Spec's roi is 0 640 0 480 0 1 0 3
 After set, roi is 3 5 7 9 0 1 0 3
 After set, roi_full is 13 15 17 19 0 1 0 3
+r1 = 0 640 0 480 0 1 0 4
+r2 = 42 640 0 480 0 1 0 4
 
 Done.

--- a/testsuite/python-roi/src/test_roi.py
+++ b/testsuite/python-roi/src/test_roi.py
@@ -65,6 +65,12 @@ try:
     print ("After set, roi is", oiio.get_roi(spec))
     print ("After set, roi_full is", oiio.get_roi_full(spec))
 
+    r1 = oiio.ROI(0, 640, 0, 480, 0, 1, 0, 4)
+    r2 = r1.copy()
+    r2.xbegin = 42
+    print ("r1 =", r1)
+    print ("r2 =", r2)
+
     print ("")
 
     print ("Done.")


### PR DESCRIPTION
Somehow we never implemented a copy() method for ROI, which of course is
super useful if you want to make an actual copy of an ROI and modify
the copy.

I also realized that ImageSpec.copy() unnecessarily/incorrectly set
return_value_policy to reference_internal, but actually it should be a
real copy, which it has to be anyway because the implementation
creates a separate copy.

