### PR TITLE
`oiiotool --pattern checker` tweak and documentation fix

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -1955,8 +1955,11 @@ current top image.
       color can be set with the optional `:color=r,g,b,...` arguments giving
       a numerical value for each channel.
     * `checker` : A black and white checkerboard pattern.  The optional
-      argument `:width=` sets with width of the checkers (defaulting to 8
-      pixels).
+      modifier `:width=` sets the width of the checkers (defaulting to 8
+      pixels), `:height=` sets the height of the checkers (defaulting to equal
+      height and width). Optional modifiers `:color1=r,g,b,...` and
+      `:color2=r,g,b,...` set the colors of the alternating squares
+      (defaulting to black and white, respectively).
     * `fill`  : A constant color or gradient, depending on the optional
       colors. Argument `:color=r,g,b,...` results in a constant color.
       Argument `:top=r,g,b,...:bottom=...` results in a top-to-bottom

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -3436,8 +3436,8 @@ action_pattern(int argc, const char* argv[])
     } else if (Strutil::istarts_with(pattern, "checker")) {
         auto options = ot.extract_options(pattern);
         int width    = options.get_int("width", 8);
-        int height   = options.get_int("height", 8);
-        int depth    = options.get_int("depth", 8);
+        int height   = options.get_int("height", width);
+        int depth    = options.get_int("depth", width);
         std::vector<float> color1(nchans, 0.0f);
         std::vector<float> color2(nchans, 1.0f);
         Strutil::extract_from_list_string(color1, options.get_string("color1"));


### PR DESCRIPTION
* Docs: we previously only documented the "width=" optional modifier.
  Add height, color1, color2.

* Change behavior ever so slightly so that if the "height=" modifier is
  not supplied, the height defaults to the "width".

