### PR TITLE
ImageBufAlgo: Slightly more flexibility in inferring constants

### DIFF
--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -162,6 +162,7 @@ public:
     Image_or_Const (cspan<float> val) : m_type(VAL), m_val(val) {}
     Image_or_Const (const float& val) : m_type(VAL), m_val(val) {}
     Image_or_Const (const std::vector<float>& val) : m_type(VAL), m_val(val) {}
+    Image_or_Const (std::initializer_list<const float> val) : m_type(VAL), m_val(val) {}
     Image_or_Const (const float *v, size_t s) : m_type(VAL), m_val(v,s) {}
     Image_or_Const (const float *v, int s) : m_type(VAL), m_val(v,s) {}
 


### PR DESCRIPTION
This little change makes this work:

    ImageBufAlgo::add (buf, { 0.2f, 0.2f, 0.2f });

instead of the more awkward

    ImageBufAlgo::add (buf, cspan<float>({ 0.2f, 0.2f, 0.2f }));

and for anyplace that has Image_or_Const parameter types.

