### PR TITLE
Fix variable usage example in docs

### DIFF
--- a/src/doc/imageoutput.rst
+++ b/src/doc/imageoutput.rst
@@ -1665,7 +1665,7 @@ libraries on Mac OS X (with the ``.dylib`` extension).
 OpenImageIO will look for matching plugins according to *search paths*,
 which are strings giving a list of directories to search, with each
 directory separated by a colon ``:``.  Within a search path, any substrings
-of the form ``{$FOO}`` will be replaced by the value of environment variable
+of the form ``${FOO}`` will be replaced by the value of environment variable
 ``FOO``.  For example, the searchpath ``"${HOME}/plugins:/shared/plugins"``
 will first check the directory :file:`/home/tom/plugins` (assuming the
 user's home directory is :file:`/home/tom`), and if not found there, will


### PR DESCRIPTION
I found this while reading through the image output section and it seems wrong given the following examples.


## Description

Fixes the docs regarding environmental variable usage to match the examples used.

## Tests

Didn't add tests


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

