### PR TITLE
oiiotool: don't warn for --colorcount or --rangecheck

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -3346,6 +3346,7 @@ action_colorcount(cspan<const char*> argv)
         ot.error(command, (*ot.curimg)(0, 0).geterror());
     }
 
+    ot.printed_info = true;
     return;
 }
 
@@ -3381,6 +3382,7 @@ action_rangecheck(cspan<const char*> argv)
     } else {
         ot.error(command, (*ot.curimg)(0, 0).geterror());
     }
+    ot.printed_info = true;
 }
 
 


### PR DESCRIPTION
We had forgotten to mark --colorcount and --rangecheck as commands
that intentionally output to the console. This omission meant that an
oiiotool command consisting only of those would warn about no
output.  But we didn't really want it to warn in this case.

