### PR TITLE
Fix clang 10 warning:

### DIFF
--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -586,7 +586,7 @@ template <>
 struct formatter<OIIO::TypeDesc> {
     // Parses format specification
     // C++14: constexpr auto parse(format_parse_context& ctx) const {
-    auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) const // c++11
+    auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) // c++11
     {
         // Get the presentation type, if any. Required to be 's'.
         auto it = ctx.begin(), end = ctx.end();


### PR DESCRIPTION
## Description

With clang 10 (haven't tested anything else) I get the following warning with the old code. Apparently `const` isn't needed and removing it fixes the warning.

```
include/OpenImageIO/typedesc.h:620:10: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) const // c++11
```
## Tests

No, it's a compiler warning.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [] I have updated the documentation, if applicable.
- [] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.