### PR TITLE
Minor build and compile fixes

### DIFF
--- a/src/build-scripts/build_opencolorio.bash
+++ b/src/build-scripts/build_opencolorio.bash
@@ -11,7 +11,7 @@ OPENCOLORIO_VERSION=${OPENCOLORIO_VERSION:=v2.0.1}
 
 # Where to install the final results
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}
-OPENCOLORIO_SOURCE_DIR=${OPENCOLORIO_BUILD_DIR:=${LOCAL_DEPS_DIR}/OpenColorIO}
+OPENCOLORIO_SOURCE_DIR=${OPENCOLORIO_SOURCE_DIR:=${LOCAL_DEPS_DIR}/OpenColorIO}
 OPENCOLORIO_BUILD_DIR=${OPENCOLORIO_BUILD_DIR:=${LOCAL_DEPS_DIR}/OpenColorIO-build}
 OPENCOLORIO_INSTALL_DIR=${OPENCOLORIO_INSTALL_DIR:=${LOCAL_DEPS_DIR}/dist}
 OPENCOLORIO_CXX_FLAGS=${OPENCOLORIO_CXX_FLAGS:="-Wno-unused-function -Wno-deprecated-declarations -Wno-cast-qual -Wno-write-strings"}
@@ -21,7 +21,7 @@ OPENCOLORIO_BUILDOPTS="-DOCIO_BUILD_APPS=OFF -DOCIO_BUILD_NUKE=OFF \
                        -DOCIO_BUILD_GPU_TESTS=OFF \
                        -DOCIO_BUILD_PYTHON=OFF -DOCIO_BUILD_PYGLUE=OFF \
                        -DOCIO_BUILD_JAVA=OFF \
-                       -DOCIO_BUILD_STATIC=${OCIO_BUILD_STATIC:=OFF}"
+                       -DBUILD_SHARED_LIBS=${OPENCOLORIO_BUILD_SHARED_LIBS:=ON}"
 BASEDIR=`pwd`
 pwd
 echo "OpenColorIO install dir will be: ${OPENCOLORIO_INSTALL_DIR}"
@@ -30,20 +30,20 @@ mkdir -p ${LOCAL_DEPS_DIR}
 pushd ${LOCAL_DEPS_DIR}
 
 # Clone OpenColorIO project from GitHub and build
-if [[ ! -e OpenColorIO ]] ; then
-    echo "git clone ${OPENCOLORIO_REPO} OpenColorIO"
-    git clone ${OPENCOLORIO_REPO} OpenColorIO
+if [[ ! -e ${OPENCOLORIO_SOURCE_DIR} ]] ; then
+    echo "git clone ${OPENCOLORIO_REPO} ${OPENCOLORIO_SOURCE_DIR}"
+    git clone ${OPENCOLORIO_REPO} ${OPENCOLORIO_SOURCE_DIR}
 fi
-cd OpenColorIO
+cd ${OPENCOLORIO_SOURCE_DIR}
 
 echo "git checkout ${OPENCOLORIO_VERSION} --force"
 git checkout ${OPENCOLORIO_VERSION} --force
-mkdir -p build
-cd build
+mkdir -p ${OPENCOLORIO_BUILD_DIR}
+cd ${OPENCOLORIO_BUILD_DIR}
 time cmake -DCMAKE_BUILD_TYPE=Release \
            -DCMAKE_INSTALL_PREFIX=${OPENCOLORIO_INSTALL_DIR} \
            -DCMAKE_CXX_FLAGS="${OPENCOLORIO_CXX_FLAGS}" \
-           ${OPENCOLORIO_BUILDOPTS} ..
+           ${OPENCOLORIO_BUILDOPTS} ${OPENCOLORIO_SOURCE_DIR}
 time cmake --build . --config Release --target install
 popd
 

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -115,7 +115,7 @@ set (CXX_VISIBILITY_PRESET "hidden" CACHE STRING "Symbol visibility (hidden or d
 option (VISIBILITY_INLINES_HIDDEN "Hide symbol visibility of inline functions" ON)
 set (VISIBILITY_MAP_FILE "${PROJECT_SOURCE_DIR}/src/build-scripts/hidesymbols.map" CACHE FILEPATH "Visibility map file")
 set (C_VISIBILITY_PRESET ${CXX_VISIBILITY_PRESET})
-if (${CXX_VISIBILITY_PRESET} STREQUAL "hidden" AND
+if (${CXX_VISIBILITY_PRESET} STREQUAL "hidden" AND VISIBILITY_MAP_FILE AND
     (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG) AND
     (CMAKE_SYSTEM_NAME MATCHES "Linux|kFreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "GNU"))
     # Linux/FreeBSD/Hurd: also hide all the symbols of dependent libraries

--- a/src/cmake/modules/FindOpenColorIO.cmake
+++ b/src/cmake/modules/FindOpenColorIO.cmake
@@ -14,10 +14,31 @@
 # OPENCOLORIO_LIBRARIES   - list of libraries to link against when using OpenColorIO
 # OPENCOLORIO_DEFINITIONS - Definitions needed when using OpenColorIO
 #
+# Hints and overrides:
+#
+#   - OPENCOLORIO_INTERFACE_LINK_LIBRARIES - override for interface link
+#     libraries on the OpenColorIO::OpenColorIO target.
+#   - OPENCOLORIO_NO_CONFIG - if ON, this module will be used even if an
+#     OCIO >= 2.1 cmake config is found. If OFF (the default), a config file
+#     will be perferred if found.
+#
 # OpenColorIO 2.1 exports proper cmake config files on its own.
 # Once OCIO 2.1 is our new minimum, this FindOpenColorIO.cmake will
 # eventually be deprecated and disappear.
 #
+
+if (NOT OPENCOLORIO_NO_CONFIG)
+    find_package(OpenColorIO CONFIG)
+endif ()
+
+if (TARGET OpenColorIO::OpenColorIO)
+    if (OPENCOLORIO_INTERFACE_LINK_LIBRARIES)
+        set_target_properties(OpenColorIO::OpenColorIO PROPERTIES
+            INTERFACE_LINK_LIBRARIES "${OPENCOLORIO_INTERFACE_LINK_LIBRARIES}")
+    endif ()
+
+else ()
+# vvvv the rest is if no OCIO exported config file is found
 
 include (FindPackageHandleStandardArgs)
 include (FindPackageMessage)
@@ -76,6 +97,10 @@ if (OpenColorIO_FOUND)
 
         set_property(TARGET OpenColorIO::OpenColorIO APPEND PROPERTY
             IMPORTED_LOCATION "${OPENCOLORIO_LIBRARIES}")
+        if (OPENCOLORIO_INTERFACE_LINK_LIBRARIES)
+            set_target_properties(OpenColorIO::OpenColorIO PROPERTIES
+                INTERFACE_LINK_LIBRARIES "${OPENCOLORIO_INTERFACE_LINK_LIBRARIES}")
+        endif ()
         if (LINKSTATIC)
             target_compile_definitions(OpenColorIO::OpenColorIO
                 INTERFACE "-DOpenColorIO_STATIC")
@@ -105,3 +130,4 @@ if (OpenColorIO_FOUND AND LINKSTATIC)
     endif ()
 endif ()
 
+endif()

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -188,26 +188,13 @@ set_target_properties(OpenImageIO
                          OUTPUT_NAME OpenImageIO${OIIO_LIBNAME_SUFFIX}
                          POSITION_INDEPENDENT_CODE ON
                      )
-if (VISIBILITY_MAP_COMMAND)
-    set_property (TARGET OpenImageIO
-                  APPEND PROPERTY LINK_FLAGS ${VISIBILITY_MAP_COMMAND})
-endif ()
 
-# For consistency with the linux SpComp2s, create Mac OS X SpComp2s
-# with a .so suffix instead of a .dylib suffix.
-if (DEFINED OVERRIDE_SHARED_LIBRARY_SUFFIX)
-  if (VERBOSE)
-      message(STATUS "Setting SUFFIX to: ${OVERRIDE_SHARED_LIBRARY_SUFFIX}")
-  endif ()
-  set_target_properties(OpenImageIO
-                           PROPERTIES
-                           SUFFIX ${OVERRIDE_SHARED_LIBRARY_SUFFIX}
-                       )
+set (OpenImageIO_LINK_FLAGS "${VISIBILITY_MAP_COMMAND} ${EXTRA_DSO_LINK_ARGS}")
+if (UNIX AND NOT APPLE)
+    # Hide symbols from any static dependent libraries embedded here.
+    set (OpenImageIO_LINK_FLAGS "${OpenImageIO_LINK_FLAGS} -Wl,--exclude-libs,ALL")
 endif ()
-
-if (EXTRA_DSO_LINK_ARGS)
-    set_target_properties (OpenImageIO PROPERTIES LINK_FLAGS ${EXTRA_DSO_LINK_ARGS})
-endif()
+set_target_properties (OpenImageIO PROPERTIES LINK_FLAGS ${OpenImageIO_LINK_FLAGS})
 
 install_targets (OpenImageIO)
 

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -55,11 +55,12 @@ if (CMAKE_COMPILER_IS_GNUCC AND NOT ${GCC_VERSION} VERSION_LESS 9.0)
                   APPEND PROPERTY COMPILE_OPTIONS -Wno-stringop-truncation)
 endif ()
 
-# For consistency with the linux SpComp2s, create Mac OS X SpComp2s
-# with a .so suffix instead of a .dylib suffix.
-if (DEFINED OVERRIDE_SHARED_LIBRARY_SUFFIX)
-    set_target_properties (OpenImageIO_Util PROPERTIES SUFFIX ${OVERRIDE_SHARED_LIBRARY_SUFFIX})
+set (OpenImageIO_Util_LINK_FLAGS "${VISIBILITY_MAP_COMMAND} ${EXTRA_DSO_LINK_ARGS}")
+if (UNIX AND NOT APPLE)
+    # Hide symbols from any static dependent libraries embedded here.
+    set (OpenImageIO_Util_LINK_FLAGS "${OpenImageIO_Util_LINK_FLAGS} -Wl,--exclude-libs,ALL")
 endif ()
+set_target_properties (OpenImageIO_Util PROPERTIES LINK_FLAGS ${OpenImageIO_Util_LINK_FLAGS})
 
 install_targets (OpenImageIO_Util)
 


### PR DESCRIPTION
* Bugs fixed in build_opencolorio.bash, it botched some of the directory
  choices when customizing where to place and build it. Also, switch to
  the more standard BUILD_SHARED_LIBS cmake variable to control whether
  to build dynamic or static libraries.

* Correctly handle the cmake variable VISIBILITY_MAP_FILE being set to
  "" on the command line as a way to disable using the visibility map file
  entirely.

* FindOpenColorIO.cmake changes:
    - Prefer and use an exported cmake config for OCIO if found (is should
      be present for OCIO 2.1+), unless caller set OPENCOLORIO_NO_CONFIG=ON.
    - New hint OPENCOLORIO_INTERFACE_LINK_LIBRARIES lets caller force a
      list of interface link libraries. This is helpful when purposely using
      a static OCIO library, which itself has static dependencies, and you
      need to name those specific library filepaths.

* Simplify some of the logic for setting extra link flag arguments for the
  two main libraries.

* On Linux, also set link flags `--exclude-libs ALL` to hide symbols from
  any embedded static library dependencies, to prevent clashes with other
  versions of those libraries that may be compiled into a DCC app.
