### PR TITLE
Targa improvements: attribs, unassociated alpha handling, and more

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -2082,9 +2082,20 @@ http://www.dca.fee.unicamp.br/~martino/disciplinas/ea978/tgaffs.pdf
      - string
      - values of ``none`` and ``rle`` are supported.  The writer will use
        RLE compression if any unknown compression methods are requested.
+   * - ``targa:alpha_type``
+     - int
+     - Meaning of any alpha channel (0 = none; 1 = undefined, ignore;
+       2 = undefined, preserve; 3 = useful unassociated alpha;
+       4 = useful associated alpha / premultiplied color).
    * - ``targa:ImageID``
      - string
      - Image ID
+   * - ``targa:JobTime``
+     - string
+     - Job time
+   * - ``targa:version``
+     - int
+     - TGA file format version (1 or 2)
    * - ``PixelAspectRatio``
      - float
      - pixel aspect ratio
@@ -2121,6 +2132,12 @@ attributes are supported:
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
        example by reading from memory rather than the file system.
+   * - ``oiio:UnassociatedAlpha``
+     - int
+     - If nonzero, and the file contains unassociated alpha, this will
+       cause the reader to leave alpha unassociated (versus the default of
+       premultiplying color channels by alpha if the alpha channel is
+       unassociated).
 
 **Configuration settings for Targa output**
 

--- a/testsuite/targa/ref/out.txt
+++ b/testsuite/targa/ref/out.txt
@@ -13,6 +13,7 @@ Reading ../oiio-images/targa/CBW8.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 8
     targa:ImageID: "Truevision(R) Sample Image"
+    targa:version: 2
 Comparing "../oiio-images/targa/CBW8.TGA" and "CBW8.TGA"
 PASS
 Reading ../oiio-images/targa/CCM8.TGA
@@ -30,6 +31,7 @@ Reading ../oiio-images/targa/CCM8.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 2
     targa:ImageID: "Truevision(R) Sample Image"
+    targa:version: 2
 Comparing "../oiio-images/targa/CCM8.TGA" and "CCM8.TGA"
 PASS
 Reading ../oiio-images/targa/CTC16.TGA
@@ -46,8 +48,9 @@ Reading ../oiio-images/targa/CTC16.TGA
     thumbnail_nchannels: 3
     thumbnail_width: 64
     oiio:BitsPerSample: 5
+    targa:alpha_type: 2
     targa:ImageID: "Truevision(R) Sample Image"
-    tga:alpha_type: 2
+    targa:version: 2
 Comparing "../oiio-images/targa/CTC16.TGA" and "CTC16.TGA"
 PASS
 Reading ../oiio-images/targa/CTC24.TGA
@@ -65,6 +68,7 @@ Reading ../oiio-images/targa/CTC24.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 8
     targa:ImageID: "Truevision(R) Sample Image"
+    targa:version: 2
 Comparing "../oiio-images/targa/CTC24.TGA" and "CTC24.TGA"
 PASS
 Reading ../oiio-images/targa/CTC32.TGA
@@ -81,8 +85,9 @@ Reading ../oiio-images/targa/CTC32.TGA
     thumbnail_nchannels: 4
     thumbnail_width: 64
     oiio:BitsPerSample: 8
+    targa:alpha_type: 2
     targa:ImageID: "Truevision(R) Sample Image"
-    tga:alpha_type: 2
+    targa:version: 2
 Comparing "../oiio-images/targa/CTC32.TGA" and "CTC32.TGA"
 PASS
 Reading ../oiio-images/targa/UBW8.TGA
@@ -99,6 +104,7 @@ Reading ../oiio-images/targa/UBW8.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 8
     targa:ImageID: "Truevision(R) Sample Image"
+    targa:version: 2
 Comparing "../oiio-images/targa/UBW8.TGA" and "UBW8.TGA"
 PASS
 Reading ../oiio-images/targa/UCM8.TGA
@@ -115,6 +121,7 @@ Reading ../oiio-images/targa/UCM8.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 2
     targa:ImageID: "Truevision(R) Sample Image"
+    targa:version: 2
 Comparing "../oiio-images/targa/UCM8.TGA" and "UCM8.TGA"
 PASS
 Reading ../oiio-images/targa/UTC16.TGA
@@ -130,8 +137,9 @@ Reading ../oiio-images/targa/UTC16.TGA
     thumbnail_nchannels: 3
     thumbnail_width: 64
     oiio:BitsPerSample: 5
+    targa:alpha_type: 2
     targa:ImageID: "Truevision(R) Sample Image"
-    tga:alpha_type: 2
+    targa:version: 2
 Comparing "../oiio-images/targa/UTC16.TGA" and "UTC16.TGA"
 PASS
 Reading ../oiio-images/targa/UTC24.TGA
@@ -148,6 +156,7 @@ Reading ../oiio-images/targa/UTC24.TGA
     thumbnail_width: 64
     oiio:BitsPerSample: 8
     targa:ImageID: "Truevision(R) Sample Image"
+    targa:version: 2
 Comparing "../oiio-images/targa/UTC24.TGA" and "UTC24.TGA"
 PASS
 Reading ../oiio-images/targa/UTC32.TGA
@@ -163,8 +172,9 @@ Reading ../oiio-images/targa/UTC32.TGA
     thumbnail_nchannels: 4
     thumbnail_width: 64
     oiio:BitsPerSample: 8
+    targa:alpha_type: 2
     targa:ImageID: "Truevision(R) Sample Image"
-    tga:alpha_type: 2
+    targa:version: 2
 Comparing "../oiio-images/targa/UTC32.TGA" and "UTC32.TGA"
 PASS
 Reading ../oiio-images/targa/round_grill.tga
@@ -173,6 +183,7 @@ Reading ../oiio-images/targa/round_grill.tga
     channel list: R, G, B, A
     Software: "COREL 0.0"
     oiio:BitsPerSample: 8
+    targa:version: 2
 Comparing "../oiio-images/targa/round_grill.tga" and "round_grill.tga"
 PASS
 Converting src/crash1.tga to crash1.exr


### PR DESCRIPTION
The main event:

* Assume that for a TGA 1.0 file (too old to have the header field
  that says if alpha is associated, unassociated, or meaningless), if
  the alpha is zero everywhere, it means that it's meaningless, not
  unassociated, so in that case we should skip the
  auto-premultiplication. (See issue #3277)

Public-ish stuff:

* Be more consistent with Targa-specific attributes all being called
  "targa:foo" (most were, but one was "tga:alpha_type").
* Document all the targa-specific attributes (a few were not).
* Add "targa:version" to reveal whether the file was a TGA 1.0 or
  2.0 version of the format.

Internal stuff, opportunistic:

* Some more minor conversions of string fomatting to fmt style.
* Convert some std::cerr debugging code (commented out) to the DBG macro
  we use anywhere.
* The `std::unique_ptr<uint8_t> m_buf` should always have been
  `unique_ptr<uint8_t[]>` because it's not a pointer to a single value.

Closes #3277 
