### PR TITLE
TIFF: gracefully handle missing ExtraSamples tag

### DIFF
--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1095,8 +1095,7 @@ TIFFInput::readspec(bool read_meta)
 
     unsigned short* sampleinfo  = NULL;
     unsigned short extrasamples = 0;
-    TIFFGetFieldDefaulted(m_tif, TIFFTAG_EXTRASAMPLES, &extrasamples,
-                          &sampleinfo);
+    TIFFGetField(m_tif, TIFFTAG_EXTRASAMPLES, &extrasamples, &sampleinfo);
     // std::cerr << "Extra samples = " << extrasamples << "\n";
     bool alpha_is_unassociated = false;  // basic assumption
     if (extrasamples) {


### PR DESCRIPTION
Some rogue app out there is writing 4-channel TIFF files without the
ExtraSamples tag in the header that explains that the data is a valid
alpha channel.

We were using TIFFGetFieldDefaulted to retrieve this tag, and guess what?
The defaulted behavior changed between libtiff 4.0 and 4.3!

Changing to TIFFGetField actually turns out to fall back to the right
logic on our side, which boils down to assuming a 4th channel is alpha
if there's no other information. That seams reasonable -- RGB + mystery
channel is almost certainly RGBA.
