### PR TITLE
Separate C++ that we build with from what we demand downstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,7 @@ help:
 	@echo "      STOP_ON_WARNING=0        Do not stop building if compiler warns"
 	@echo "      OPENIMAGEIO_SITE=xx      Use custom site build mods"
 	@echo "      MYCC=xx MYCXX=yy         Use custom compilers"
-	@echo "      CMAKE_CXX_STANDARD=14    Set the C++ standard (default is C++14)"
+	@echo "      CMAKE_CXX_STANDARD=14    C++ standard to build with (default is 14)"
 	@echo "      USE_LIBCPLUSPLUS=1       For clang, use libc++"
 	@echo "      GLIBCXX_USE_CXX11_ABI=1  For gcc, use the new string ABI"
 	@echo "      EXTRA_CPP_ARGS=          Additional args to the C++ command"

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -28,10 +28,12 @@ message (STATUS "CMAKE_CXX_COMPILER_ID  = ${CMAKE_CXX_COMPILER_ID}")
 # C++ language standard
 #
 set (CMAKE_CXX_STANDARD 14 CACHE STRING
-     "C++ standard to prefer (14, 17, 20, etc.)")
+     "C++ standard to build with (14, 17, 20, etc.)")
+set (DOWNSTREAM_CXX_STANDARD 14 CACHE STRING
+     "C++ minimum standard to impose on downstream clients")
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 set (CMAKE_CXX_EXTENSIONS OFF)
-message (STATUS "Building for C++${CMAKE_CXX_STANDARD}")
+message (STATUS "Building with C++${CMAKE_CXX_STANDARD}, downstream minimum C++${DOWNSTREAM_CXX_STANDARD}")
 
 
 ###########################################################################

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -120,7 +120,8 @@ if (NOT BUILD_SHARED_LIBS)
 endif ()
 
 # Propagate C++ minimum to downstream
-target_compile_features (OpenImageIO PUBLIC cxx_std_14)
+target_compile_features (OpenImageIO
+                         INTERFACE cxx_std_${DOWNSTREAM_CXX_STANDARD})
 
 target_link_libraries (OpenImageIO
         PUBLIC

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -40,7 +40,8 @@ if (NOT BUILD_SHARED_LIBS)
 endif ()
 
 # Propagate C++ minimum to downstream consumers
-target_compile_features (OpenImageIO_Util PUBLIC cxx_std_14)
+target_compile_features (OpenImageIO_Util
+                         INTERFACE cxx_std_${DOWNSTREAM_CXX_STANDARD})
 
 set_target_properties(OpenImageIO_Util
                       PROPERTIES


### PR DESCRIPTION
We were passing along, in the exported cmake config files, a demand
for downstream clients to use a C++ standard version equal to that
which we used to build OpenImageIO itself. But that's not
necessary. We may choose to build with C++17 (for example), but all of
our public APIs are safe to use for C++14.

Split the build-time options to CMAKE_CXX_STANDARD for the standard we
build this project with, and DOWNSTREAM_CXX_STANDARD for the standard
we are declaring is the minimum to *use* the library.
