### PR TITLE
TIFF: Special hint to suppress output of EXTRASAMPLES tag

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -2349,6 +2349,10 @@ aspects of the writing itself:
      - int
      - If nonzero, forces use of "bigtiff," a nonstandard extension that
        allows files to be more than 4 GB (default: 0).
+   * - ``tiff:write_extrasamples``
+     - int
+     - If zero, do NOT write the "EXTRASAMPLES" tag to the TIFF header.
+       (The default is 1, which means write the tag.)
 
 
 **TIFF compression modes**

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -671,7 +671,8 @@ TIFFOutput::open(const std::string& name, const ImageSpec& userspec,
 
     // ExtraSamples tag
     if ((m_spec.alpha_channel >= 0 || m_spec.nchannels > 3)
-        && m_photometric != PHOTOMETRIC_SEPARATED) {
+        && m_photometric != PHOTOMETRIC_SEPARATED
+        && m_spec.get_int_attribute("tiff:write_extrasamples", 1)) {
         bool unass = m_spec.get_int_attribute("oiio:UnassociatedAlpha", 0);
         int defaultchans = m_spec.nchannels >= 3 ? 3 : 1;
         short e          = m_spec.nchannels - defaultchans;


### PR DESCRIPTION
Ugh, there's a situation where PhotoShop is misinterpreting an alpha
channel for certain OIIO-written TIFF files, but it's fine with some that
came from elsewhere, and the only thing that appears to be different is
that the non-OIIO one entirely lacks the EXTRASAMPLES TIFF tag.

So I'm adding an option (use with extreme caution) allowing you to
tell the TIFF output to not output this tag, even though clearly it
should be.
