### PR TITLE
Hide Imath headers and types from most of the public API

### DIFF
--- a/src/doc/Doxyfile
+++ b/src/doc/Doxyfile
@@ -2173,7 +2173,10 @@ PREDEFINED             = DOXYGEN_SHOULD_SKIP_THIS \
                          OIIO_NODISCARD=[[nodiscard]] \
                          OIIO_DEPRECATED:=[[deprecated]] \
                          OIIO_FORMAT_DEPRECATED:= \
-                         OIIO_FORCEINLINE=inline
+                         OIIO_FORCEINLINE=inline \
+                         IMATH_HALF_H_=1 \
+                         INCLUDED_IMATHVEC_H=1 \
+                         INCLUDED_IMATHMATRIX_H=1 \
 
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -265,8 +265,10 @@ public:
     ///
     /// Created ColorProcessors are cached, so asking for the same color
     /// space transformation multiple times shouldn't be very expensive.
+#ifdef INCLUDED_IMATHMATRIX_H
     ColorProcessorHandle createMatrixTransform(const Imath::M44f& M,
                                                bool inverse = false) const;
+#endif
 
     /// Given a filepath, ask OCIO what color space it thinks the file
     /// should be, based on how the name matches file naming rules in the

--- a/src/include/OpenImageIO/hash.h
+++ b/src/include/OpenImageIO/hash.h
@@ -20,7 +20,6 @@
 #include <utility>
 #include <vector>
 
-#include <OpenImageIO/span.h>
 #include <OpenImageIO/export.h>
 #include <OpenImageIO/oiioversion.h>
 #include <OpenImageIO/string_view.h>
@@ -31,6 +30,7 @@
 #    include <OpenImageIO/fmath.h>
 #endif
 
+#include <OpenImageIO/span.h>
 
 
 OIIO_NAMESPACE_BEGIN

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -767,7 +767,12 @@ bool OIIO_API fit (ImageBuf &dst, const ImageBuf &src, Filter2D *filter,
 /// filter is used to weight the `src` pixels falling underneath it for each
 /// `dst` pixel; the filter's size is expressed in pixel units of the `dst`
 /// image.
+///
+/// Note: C++ users must include `ImathMatrix.h` (or `OpenImageIO/Imath.h`)
+/// prior to including `imagebufalgo.h` to see define the Imath::M33f class,
+/// or else the `warp()` function declaration will not be visible.
 
+#ifdef INCLUDED_IMATHMATRIX_H
 ImageBuf OIIO_API warp (const ImageBuf &src, const Imath::M33f &M,
                         string_view filtername = string_view(),
                         float filterwidth = 0.0f, bool recompute_roi = false,
@@ -786,6 +791,7 @@ bool OIIO_API warp (ImageBuf &dst, const ImageBuf &src, const Imath::M33f &M,
                     const Filter2D *filter, bool recompute_roi = false,
                     ImageBuf::WrapMode wrap = ImageBuf::WrapDefault,
                     ROI roi = {}, int nthreads=0);
+#endif
 /// @}
 
 
@@ -1796,6 +1802,13 @@ inline bool colorconvert (float *color, int nchannels,
 ///             "not pre-multiplied colors").
 ///
 /// @version 2.1+
+///
+/// Note: C++ users must include `ImathMatrix.h` (or `OpenImageIO/Imath.h`)
+/// prior to including `imagebufalgo.h` to see define the Imath::M44f class,
+/// or else the `colormatrixtransform()` function declaration will not be
+/// visible.
+
+#ifdef INCLUDED_IMATHMATRIX_H
 ImageBuf OIIO_API colormatrixtransform (const ImageBuf &src,
                                     const Imath::M44f& M, bool unpremult=true,
                                     ROI roi={}, int nthreads=0);
@@ -1803,6 +1816,7 @@ ImageBuf OIIO_API colormatrixtransform (const ImageBuf &src,
 bool OIIO_API colormatrixtransform (ImageBuf &dst, const ImageBuf &src,
                                     const Imath::M44f& M, bool unpremult=true,
                                     ROI roi={}, int nthreads=0);
+#endif
 
 
 /// Return a copy of the pixels of `src` within the ROI, applying an

--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -8,6 +8,7 @@
 
 #include <functional>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/parallel.h>
 #include <OpenImageIO/imagebufalgo.h>
 

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/simd.h>
 #include <OpenImageIO/ustring.h>

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -10,6 +10,8 @@
 
 #include <boost/container/flat_map.hpp>
 
+#include <OpenImageIO/Imath.h>
+
 #include <OpenImageIO/color.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/imagebufalgo.h>

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <numeric>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/fmath.h>

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -7,6 +7,7 @@
 #include <regex>
 #include <sstream>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <memory>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filter.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <limits>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/hash.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <limits>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -10,6 +10,7 @@
 #include <memory>
 
 #include "imageio_pvt.h"
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filter.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagebufalgo_yee.cpp
+++ b/src/libOpenImageIO/imagebufalgo_yee.cpp
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <iostream>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -5,6 +5,7 @@
 #include <cstdio>
 #include <cstdlib>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/hash.h>

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <sstream>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/color.h>
 #include <OpenImageIO/dassert.h>

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/fmath.h>

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -10,6 +10,8 @@
 #include <sstream>
 #include <string>
 
+#include <OpenImageIO/Imath.h>
+
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filter.h>
 #include <OpenImageIO/fmath.h>

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -1,6 +1,6 @@
 set (libOpenImageIO_Util_srcs argparse.cpp benchmark.cpp
-                  errorhandler.cpp filesystem.cpp
-                  farmhash.cpp filter.cpp hashes.cpp paramlist.cpp
+                  errorhandler.cpp farmhash.cpp filesystem.cpp
+                  fmath.cpp filter.cpp hashes.cpp paramlist.cpp
                   plugin.cpp SHA1.cpp
                   strutil.cpp sysutil.cpp thread.cpp timer.cpp
                   typedesc.cpp ustring.cpp xxhash.cpp)

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -14,7 +14,7 @@
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/platform.h>
-#include <OpenImageIO/refcnt.h>
+// #include <OpenImageIO/refcnt.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/ustring.h>
 

--- a/src/libutil/fmath.cpp
+++ b/src/libutil/fmath.cpp
@@ -1,0 +1,11 @@
+// Copyright 2008-present Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio
+
+#include <OpenImageIO/Imath.h>
+
+// Force the full implementation of all fmath functions, which will compile
+// some callable versions here.
+#define OIIO_FMATH_HEADER_ONLY 1
+
+#include <OpenImageIO/fmath.h>

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <vector>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/benchmark.h>
 #include <OpenImageIO/fmath.h>
@@ -17,11 +18,6 @@
 #include <OpenImageIO/typedesc.h>
 #include <OpenImageIO/unittest.h>
 
-#if OIIO_USING_IMATH >= 3
-#    include <Imath/ImathFun.h>
-#else
-#    include <OpenEXR/ImathFun.h>
-#endif
 
 using namespace OIIO;
 

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -7,11 +7,12 @@
 #include <sstream>
 #include <type_traits>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/benchmark.h>
+#include <OpenImageIO/simd.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imageio.h>
-#include <OpenImageIO/simd.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/timer.h>
 #include <OpenImageIO/typedesc.h>

--- a/src/libutil/timer.cpp
+++ b/src/libutil/timer.cpp
@@ -5,8 +5,6 @@
 #include <cstdio>
 #include <cstdlib>
 
-#include <OpenImageIO/strutil.h>
-#include <OpenImageIO/thread.h>
 #include <OpenImageIO/timer.h>
 
 

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -10,6 +10,7 @@
 #include <limits>
 #include <sstream>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/color.h>
 #include <OpenImageIO/dassert.h>

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include <OpenEXR/ImfTimeCode.h>
+#include <OpenImageIO/Imath.h>
 
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/color.h>

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -15,6 +15,7 @@
 #    include <io.h>
 #endif
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/hash.h>

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <numeric>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/platform.h>
 
 #include <boost/version.hpp>

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -11,6 +11,7 @@
 #include <map>
 #include <memory>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/platform.h>
 
 #include <OpenEXR/ImfChannelList.h>

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -7,6 +7,7 @@
 #include <png.h>
 #include <zlib.h>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/fmath.h>

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -29,6 +29,7 @@
 #    undef copysign
 #endif
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagecache.h>

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <memory>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/platform.h>


### PR DESCRIPTION
This patch sets out to minimize the extent to which Imath is a
necessary source dependency for using OIIO C++ header files and
APIs. The major changes are:

* Remove the unconditional `#include <OpenImageIO/Imath.h>` from
  fmath.h and simd.h. Those forced Imath headers on nearly all all
  code that uses OIIO's public APIs, whether or not they needed the
  very few calls where Imath types are used as parameters.

* Make sure all public OIIO non-virtual methods and freestanding
  functions that have Imath types as parameters are enclosed in header
  guards like `#ifdef INCLUDE_IMATHVECTOR_H`. Downstream client code
  needs to include Imath headers before including OIIO headers, if
  they want to call those few particular functions.

This means that client applications who don't need those particular
functions, but call other parts of the OIIO APIs, don't need to
`#include` any Imath headers (or pay the extra compilation time for
doing so), and don't need any knowledge of which specific version of
Imath is used by the OIIO they are using.

The small number of public API calls that will no longer be visible
downstream unless the client code also include Imath headers (before
the OIIO headers) are:

  - color.h: ColorConfig::createMatrixTransform (needs ImathColor.h)

  - fmath.h: type conversions involving `half` (needs half.h).

  - imagebufalgo.h: warp(), colormatrixtransform() (needs ImathMatrix.h)

  - simd.h: conversions between our SIMD types and Imath types (Vec3,
    Matrix33, Matrix44) and vtransform() calls involving those types
    (requires ImathVec.h and ImathMatrix.h), and SIMD load/store
    involving `half` data (requires half.h).

These changes necessitated adding including of Imath.h in a number of
internal .cpp files, the ones where those types are actually used.

The following header files do still unconditionally reference Imath
types or headers:

  - texture.h: Some virtual methods of TextureSystem use Imath types
    as parameters.
  - imagebufalgo_util.h: For `half` support. We use this a lot
    internally, but presume most client code never uses this header.
  - simd.h, ONLY IF USE_SIMD=0 (which is generally only used for
    development debugging and if porting to obscure platforms that are
    neither x86 nor ARM).

The bottom line is that the vast majority of downstream callers of OIIO
APIs who need ImageInput/ImageOutput, ImageBuf, ImageBufAlgo, and
generally everything in the OpenImageIO_Util library, do not need to
use Imath types, include Imath headers, or even be aware of which Imath
release OIIO is using.

Why would we do all this?

Because this paves the way for optionally building OIIO to link against
static libraries for OpenEXR and Imath, essentially embedding and
completely hiding an OpenEXR/Imath inside libOpenImageIO.

That allows libOpenImageIO to use the very latest Imath (3.1, say,
with the new faster core API), even though that libOpenImageIO is
being consumed by an application that for whatever reason is forced to
use an entirely different (older) OpenEXR or Imath library.  In other
words, it lets OIIO use OpenEXR/Imath fully embedded without
transitively passing that OpenEXR version as a downstream dependency
(except for the few use cases that need to call the tiny number of
OIIO API methods that require Imath types.

There is a small chance that client code that use Imath types and
SHOULD have been includeing Imath headers themselves actually omitted
those includes and dependd on the fact that certain OIIO headers
included them.  Now that they don't, it may require the client-side
code to add those includes. I'm going to claim that this is a "bug" in
the client code (they didn't include a header that defined a type they
used), and not a breaking incompatibility in OIIO's public calls
themselves. Thus, I feel comfortable with these changes being in OIIO
2.4 (today's master) and not necessitating a 3.0 release (in which
arbitrary loss of backward compatibility would be allowed). So watch
out for the occasional need for OIIO-calling code to need to add an
`#include` for Imath types the code was always using, but neglected
to explicitly include.
