### PR TITLE
Relocatable cmake package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,7 @@ write_basic_package_version_file (
 export (EXPORT OIIO_EXPORTED_TARGETS FILE "${CMAKE_BINARY_DIR}/${OIIO_TARGETS_EXPORT_NAME}")
 
 # generate the config file from the template in the binary dir
+include(GNUInstallDirs) # Needed to populate the package config with CMAKE_INSTALL_INCLUDEDIR, CMAKE_INSTALL_LIBDIR
 configure_package_config_file ("${PROJECT_SOURCE_DIR}/src/cmake/Config.cmake.in"
         "${OIIO_PROJECT_CONFIG}"
         INSTALL_DESTINATION "${OIIO_CONFIG_INSTALL_DIR}")

--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -18,9 +18,13 @@ endif ()
 # Compute the installation prefix relative to this file
 get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
 
-set_and_check (@PROJECT_NAME@_INCLUDE_DIR "${_IMPORT_PREFIX}/include")
-set_and_check (@PROJECT_NAME@_INCLUDES    "${_IMPORT_PREFIX}/include")
-set_and_check (@PROJECT_NAME@_LIB_DIR     "${_IMPORT_PREFIX}/lib")
+# There's no guarantee that CMAKE_INSTALL_XXXDIR is a relative path so we extract the final component to handle asbolute paths
+get_filename_component(_INCLUDE_DIR_NAME "@CMAKE_INSTALL_INCLUDEDIR@" NAME)
+get_filename_component(_LIB_DIR_NAME "@CMAKE_INSTALL_LIBDIR@" NAME)
+
+set_and_check (@PROJECT_NAME@_INCLUDE_DIR "${_IMPORT_PREFIX}/${_INCLUDE_DIR_NAME}")
+set_and_check (@PROJECT_NAME@_INCLUDES    "${_IMPORT_PREFIX}/${_INCLUDE_DIR_NAME}")
+set_and_check (@PROJECT_NAME@_LIB_DIR     "${_IMPORT_PREFIX}/${_LIB_DIR_NAME}")
 set (@PROJECT_NAME@_PLUGIN_SEARCH_PATH    "@PLUGIN_SEARCH_PATH_NATIVE@")
 
 if (NOT @FOUND_OPENEXR_WITH_CONFIG@)

--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -15,9 +15,12 @@ elseif (@OpenEXR_VERSION@ VERSION_GREATER_EQUAL 2.4 AND @FOUND_OPENEXR_WITH_CONF
     find_dependency(Threads)  # Because OpenEXR doesn't do it
 endif ()
 
-set_and_check (@PROJECT_NAME@_INCLUDE_DIR "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
-set_and_check (@PROJECT_NAME@_INCLUDES    "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
-set_and_check (@PROJECT_NAME@_LIB_DIR     "@CMAKE_INSTALL_FULL_LIBDIR@")
+# Compute the installation prefix relative to this file
+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
+
+set_and_check (@PROJECT_NAME@_INCLUDE_DIR "${_IMPORT_PREFIX}/include")
+set_and_check (@PROJECT_NAME@_INCLUDES    "${_IMPORT_PREFIX}/include")
+set_and_check (@PROJECT_NAME@_LIB_DIR     "${_IMPORT_PREFIX}/lib")
 set (@PROJECT_NAME@_PLUGIN_SEARCH_PATH    "@PLUGIN_SEARCH_PATH_NATIVE@")
 
 if (NOT @FOUND_OPENEXR_WITH_CONFIG@)

--- a/src/cmake/modules/FindJPEGTurbo.cmake
+++ b/src/cmake/modules/FindJPEGTurbo.cmake
@@ -43,6 +43,12 @@ FIND_PACKAGE_HANDLE_STANDARD_ARGS(JPEG DEFAULT_MSG JPEG_LIBRARIES JPEG_INCLUDE_D
 
 if (JPEG_FOUND)
     set (JPEGTURBO_FOUND true)
+
+    # Use an intermediary target named "JPEG::JPEG" to match libjpeg's export
+    if(NOT TARGET JPEG::JPEG)
+      add_library(JPEG::JPEG INTERFACE IMPORTED)
+      target_link_libraries(JPEG::JPEG INTERFACE ${JPEG_LIBRARY})
+    endif()
 endif ()
 
 mark_as_advanced(JPEG_LIBRARIES JPEG_INCLUDE_DIRS )

--- a/src/igrep/CMakeLists.txt
+++ b/src/igrep/CMakeLists.txt
@@ -2,6 +2,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio
 
-fancy_add_executable (LINK_LIBRARIES OpenImageIO
-                                     ${Boost_LIBRARIES} # because regex
-                      )
+fancy_add_executable (LINK_LIBRARIES OpenImageIO)

--- a/src/iinfo/CMakeLists.txt
+++ b/src/iinfo/CMakeLists.txt
@@ -2,6 +2,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio
 
-fancy_add_executable (LINK_LIBRARIES OpenImageIO
-                                     ${Boost_LIBRARIES} # because regex
-                      )
+fancy_add_executable (LINK_LIBRARIES OpenImageIO)

--- a/src/jpeg.imageio/CMakeLists.txt
+++ b/src/jpeg.imageio/CMakeLists.txt
@@ -4,4 +4,4 @@
 
 add_oiio_plugin (jpeginput.cpp jpegoutput.cpp
                  INCLUDE_DIRS ${JPEG_INCLUDE_DIRS}
-                 LINK_LIBRARIES ${JPEG_LIBRARIES})
+                 LINK_LIBRARIES JPEG::JPEG)

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -108,6 +108,7 @@ source_group ("libtexture" REGULAR_EXPRESSION ".+/libtexture/.+")
 target_include_directories (OpenImageIO
                             PUBLIC
                                 $<INSTALL_INTERFACE:include>
+                                ${OPENEXR_INCLUDES}
                             PRIVATE
                                 ${ROBINMAP_INCLUDES}
                                 ${FREETYPE_INCLUDE_DIRS}

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -107,8 +107,7 @@ source_group ("libtexture" REGULAR_EXPRESSION ".+/libtexture/.+")
 
 target_include_directories (OpenImageIO
                             PUBLIC
-                                ${CMAKE_INSTALL_FULL_INCLUDEDIR}
-                                ${IMATH_INCLUDES} ${OPENEXR_INCLUDES}
+                                $<INSTALL_INTERFACE:include>
                             PRIVATE
                                 ${ROBINMAP_INCLUDES}
                                 ${FREETYPE_INCLUDE_DIRS}

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -151,7 +151,9 @@ target_link_libraries (OpenImageIO
             $<TARGET_NAME_IF_EXISTS:pugixml::pugixml>
             ${BZIP2_LIBRARIES}
             ZLIB::ZLIB
-            ${Boost_LIBRARIES}
+            Boost::filesystem
+            Boost::system
+            Boost::thread
             ${CMAKE_DL_LIBS}
         )
 

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -8,8 +8,7 @@ set (libOpenImageIO_Util_srcs argparse.cpp benchmark.cpp
 add_library (OpenImageIO_Util ${libOpenImageIO_Util_srcs})
 target_include_directories (OpenImageIO_Util
         PUBLIC
-            ${CMAKE_INSTALL_FULL_INCLUDEDIR}
-            ${IMATH_INCLUDES} ${OPENEXR_INCLUDES}
+            $<INSTALL_INTERFACE:include>
         )
 target_link_libraries (OpenImageIO_Util
         PUBLIC

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -24,8 +24,10 @@ target_link_libraries (OpenImageIO_Util
             ${ILMBASE_LIBRARIES}
             ${GCC_ATOMIC_LIBRARIES}
         PRIVATE
+            Boost::filesystem
+            Boost::system
+            Boost::thread
             ${SANITIZE_LIBRARIES}
-            ${Boost_LIBRARIES}
             ${CMAKE_DL_LIBS}
         )
 

--- a/src/oiiotool/CMakeLists.txt
+++ b/src/oiiotool/CMakeLists.txt
@@ -4,8 +4,7 @@
 
 fancy_add_executable (LINK_LIBRARIES
                         OpenImageIO
-                        ${Boost_LIBRARIES} # because regex
                         $<TARGET_NAME_IF_EXISTS:OpenEXR::OpenEXR>
                         $<TARGET_NAME_IF_EXISTS:OpenEXR::IlmImf>
                         ${OPENEXR_LIBRARIES}
-                      )
+                     )

--- a/src/openexr.imageio/CMakeLists.txt
+++ b/src/openexr.imageio/CMakeLists.txt
@@ -12,7 +12,8 @@ endif()
 
 add_oiio_plugin (${openexr_src}
     INCLUDE_DIRS ${OPENEXR_INCLUDES} ${IMATH_INCLUDE_DIR}/OpenEXR
-    LINK_LIBRARIES ${OPENEXR_LIBRARIES}
-                   $<TARGET_NAME_IF_EXISTS:OpenEXR::OpenEXRCore>
+    LINK_LIBRARIES
+        $<TARGET_NAME_IF_EXISTS:OpenEXR::OpenEXR>
+        $<TARGET_NAME_IF_EXISTS:OpenEXR::OpenEXRCore>
     DEFINITIONS ${openexr_defs}
     )

--- a/src/openvdb.imageio/CMakeLists.txt
+++ b/src/openvdb.imageio/CMakeLists.txt
@@ -8,5 +8,5 @@ if (OpenVDB_FOUND)
                      LINK_LIBRARIES ${OPENVDB_LIBRARIES}
                                     ${TBB_tbb_LIBRARY}
                                     $<TARGET_NAME_IF_EXISTS:TBB::tbb>
-                                    ${BOOST_LIBRARIES})
+    )
 endif()

--- a/src/psd.imageio/CMakeLists.txt
+++ b/src/psd.imageio/CMakeLists.txt
@@ -4,5 +4,5 @@
 
 add_oiio_plugin (psdinput.cpp jpeg_memory_src.cpp
                  INCLUDE_DIRS ${JPEG_INCLUDE_DIR}
-                 LINK_LIBRARIES ${JPEG_LIBRARIES})
+                 LINK_LIBRARIES JPEG::JPEG)
 

--- a/src/tiff.imageio/CMakeLists.txt
+++ b/src/tiff.imageio/CMakeLists.txt
@@ -4,5 +4,4 @@
 
 add_oiio_plugin (tiffinput.cpp tiffoutput.cpp
                  INCLUDE_DIRS ${TIFF_INCLUDE_DIR}
-                 LINK_LIBRARIES ${TIFF_LIBRARIES} ${JPEG_LIBRARIES}
-                                ZLIB::ZLIB)
+                 LINK_LIBRARIES TIFF::TIFF JPEG::JPEG ZLIB::ZLIB)

--- a/src/tiff.imageio/CMakeLists.txt
+++ b/src/tiff.imageio/CMakeLists.txt
@@ -3,5 +3,4 @@
 # https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (tiffinput.cpp tiffoutput.cpp
-                 INCLUDE_DIRS ${TIFF_INCLUDE_DIR}
                  LINK_LIBRARIES TIFF::TIFF JPEG::JPEG ZLIB::ZLIB)


### PR DESCRIPTION
Those changes fix the produced CMake package not being relocatable, as reported in Issue https://github.com/OpenImageIO/oiio/issues/2559.

There are 3 main changes:

- Replace the absolute paths in the cmake export template with relative paths.
- Replace the absolute include path `CMAKE_INSTALL_FULL_INCLUDEDIR` with the `$<INSTALL_INTERFACE:include>` generator expression.
- Use explicit target names to link dependencies instead of the XXX_LIBRARIES variables. Using the old-style XXX_LIBRARIES injected absolute paths in the import script. With explicit targets, CMake references their names instead, and it's the responsibility of the consumer to provide proper paths/call find_package.
  - This particular change forces us to spell out the exact components of some dependencies (eg. `boost::filesystem boost::system boost::thread` instead of just `${Boost_Libraries}`)
  - The FindJPEGTurbo script that comes with OIIO doesn't match the FindJPEG script bundled with CMake as it doesn't create a JPEG::JPEG target, so I had to add it to use jpeg and jpeg-turbo interchangeably.
  - I fixed the paths for libjpeg, libtiff, openexr and boost. Some other dependencies might still use the old-style XXX_LIBRARIES but our environment doesn't use those so I prefer to avoid breaking stuff that I cannot test. This means that CMake packages might still not be relocatable for consumers using those other dependencies.


