### PR TITLE
Test Filesystem::searchpath_split behavior on an empty string

### DIFF
--- a/src/libutil/filesystem_test.cpp
+++ b/src/libutil/filesystem_test.cpp
@@ -80,6 +80,11 @@ test_filename_searchpath_find()
 
     std::cout << "Testing searchpath_split\n";
     std::vector<std::string> dirs;
+
+    Filesystem::searchpath_split("", dirs, false);
+    OIIO_CHECK_EQUAL(dirs.size(), 0);
+
+    dirs.clear();
     Filesystem::searchpath_split(pathlist, dirs);
     OIIO_CHECK_EQUAL(dirs.size(), 3);
     OIIO_CHECK_EQUAL(dirs[0], ".." DIRSEP "..");


### PR DESCRIPTION
It should make a vector with no entries, not a vector with one entry
that is an empty string. Verify.
