### PR TITLE
Filesystem::searchpath_split handle empty paths

### DIFF
--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -190,6 +190,8 @@ Filesystem::searchpath_split(string_view searchpath, bool validonly)
         size_t len = path.size();
         while (len > 1 && (path.back() == '/' || path.back() == '\\'))
             path.erase(--len);
+        if (path.empty())
+            continue;
         // If it's a valid directory, or if validonly is false, add it
         // to the list
         if (!validonly || Filesystem::is_directory(path))

--- a/src/libutil/filesystem_test.cpp
+++ b/src/libutil/filesystem_test.cpp
@@ -80,6 +80,25 @@ test_filename_searchpath_find()
 
     std::cout << "Testing searchpath_split\n";
     std::vector<std::string> dirs;
+
+    // Split of empty string should make an empty path vector
+    dirs.clear();
+    Filesystem::searchpath_split("", dirs, false);
+    OIIO_CHECK_EQUAL(dirs.size(), 0);
+
+    // Test that empty paths don't show up in the result vector
+    dirs.clear();
+    Filesystem::searchpath_split(":", dirs, false);
+    OIIO_CHECK_EQUAL(dirs.size(), 0);
+    Filesystem::searchpath_split("::", dirs, false);
+    OIIO_CHECK_EQUAL(dirs.size(), 0);
+    dirs.clear();
+    Filesystem::searchpath_split(":abc::def:", dirs, false);
+    OIIO_CHECK_EQUAL(dirs.size(), 2);
+    OIIO_CHECK_EQUAL(dirs[0], "abc");
+    OIIO_CHECK_EQUAL(dirs[1], "def");
+
+    dirs.clear();
     Filesystem::searchpath_split(pathlist, dirs);
     OIIO_CHECK_EQUAL(dirs.size(), 3);
     OIIO_CHECK_EQUAL(dirs[0], ".." DIRSEP "..");


### PR DESCRIPTION
Fixes #3274
