### PR TITLE
Avoid unsafe isspace()

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -812,6 +812,14 @@ std::string OIIO_UTIL_API utf16_to_utf8(const std::wstring& utf16str) noexcept;
 OIIO_UTIL_API char * safe_strcpy (char *dst, string_view src, size_t size) noexcept;
 
 
+/// Is the character a whitespace character (space, linefeed, tab, carrage
+/// return)? Note: this is safer than C isspace(), which has undefined
+/// behavior for negative char values. Also note that it differs from C
+/// isspace by not detecting form feed or vertical tab, because who cares.
+inline bool isspace(char c) {
+    return c == ' ' || c == '\n' || c == '\t' || c == '\r';
+}
+
 /// Modify str to trim any leading whitespace (space, tab, linefeed, cr)
 /// from the front.
 void OIIO_UTIL_API skip_whitespace (string_view &str) noexcept;

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -598,16 +598,16 @@ split_whitespace(string_view str, std::vector<string_view>& result,
     // Implementation inspired by Pystring
     string_view::size_type i, j, len = str.size();
     for (i = j = 0; i < len;) {
-        while (i < len && ::isspace(str[i]))
+        while (i < len && Strutil::isspace(str[i]))
             i++;
         j = i;
-        while (i < len && !::isspace(str[i]))
+        while (i < len && !Strutil::isspace(str[i]))
             i++;
         if (j < i) {
             if (--maxsplit <= 0)
                 break;
             result.push_back(str.substr(j, i - j));
-            while (i < len && ::isspace(str[i]))
+            while (i < len && Strutil::isspace(str[i]))
                 i++;
             j = i;
         }
@@ -823,7 +823,7 @@ Strutil::safe_strcpy(char* dst, string_view src, size_t size) noexcept
 void
 Strutil::skip_whitespace(string_view& str) noexcept
 {
-    while (str.size() && isspace(str.front()))
+    while (str.size() && Strutil::isspace(str.front()))
         str.remove_prefix(1);
 }
 
@@ -832,7 +832,7 @@ Strutil::skip_whitespace(string_view& str) noexcept
 void
 Strutil::remove_trailing_whitespace(string_view& str) noexcept
 {
-    while (str.size() && isspace(str.back()))
+    while (str.size() && Strutil::isspace(str.back()))
         str.remove_suffix(1);
 }
 
@@ -937,7 +937,7 @@ Strutil::parse_string(string_view& str, string_view& val, bool eat,
     const char *begin = p.begin(), *end = p.begin();
     bool escaped = false;  // was the prior character a backslash
     while (end != p.end()) {
-        if (isspace(*end) && !quoted)
+        if (Strutil::isspace(*end) && !quoted)
             break;  // not quoted and we hit whitespace: we're done
         if (quoted && *end == lead_char && !escaped)
             break;  // closing quote -- we're done (beware embedded quote)

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -295,7 +295,7 @@ PNMInput::read_file_header()
             m_max_val = 1;
 
         //Space before content
-        if (!(m_remaining.size() && isspace(m_remaining.front())))
+        if (!(m_remaining.size() && Strutil::isspace(m_remaining.front())))
             return false;
         m_remaining.remove_prefix(1);
         m_after_header = m_remaining;
@@ -314,7 +314,7 @@ PNMInput::read_file_header()
             return false;
 
         //Space before content
-        if (!(m_remaining.size() && isspace(m_remaining.front())))
+        if (!(m_remaining.size() && Strutil::isspace(m_remaining.front())))
             return false;
         m_remaining.remove_prefix(1);
         m_after_header = m_remaining;


### PR DESCRIPTION
C isspace() takes an int, but on Windows when building in debug mode,
the implementation of isspace() can hit an assert if the value is < 0,
which of course it can be if you're looking at a character in a string
whose high bit is set (because char is signed).

Easiest solution is to make our own Strutil::isspace that does exactly
what we want and is safe.

Fixes #3300
