### PR TITLE
wstring (almost) all the things

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -29,6 +29,7 @@
 #include <OpenImageIO/export.h>
 #include <OpenImageIO/oiioversion.h>
 #include <OpenImageIO/span.h>
+#include <OpenImageIO/strutil.h>
 #include <OpenImageIO/string_view.h>
 
 #if defined(_WIN32) && defined(__GLIBCXX__)
@@ -65,32 +66,34 @@ typedef std::ofstream ofstream;
 namespace Filesystem {
 
 /// Return the filename (excluding any directories, but including the
-/// file extension, if any) of a filepath.
+/// file extension, if any) of a UTF-8 encoded filepath.
 OIIO_UTIL_API std::string filename (string_view filepath) noexcept;
 
 /// Return the file extension (including the last '.' if
-/// include_dot=true) of a filename or filepath.
+/// include_dot=true) of a UTF-8 encoded filename or filepath.
 OIIO_UTIL_API std::string extension (string_view filepath,
                                 bool include_dot=true) noexcept;
 
-/// Return all but the last part of the path, for example,
+/// Return all but the last part of the UTF-8 encoded path, for example,
 /// parent_path("foo/bar") returns "foo", and parent_path("foo")
 /// returns "".
 OIIO_UTIL_API std::string parent_path (string_view filepath) noexcept;
 
-/// Replace the file extension of a filename or filepath. Does not alter
-/// filepath, just returns a new string.  Note that the new_extension
-/// should contain a leading '.' dot.
+/// Replace the file extension of a UTF-8 encoded filename or filepath. Does
+/// not alter filepath, just returns a new string.  Note that the
+/// new_extension should contain a leading '.' dot.
 OIIO_UTIL_API std::string replace_extension (const std::string &filepath, 
                                         const std::string &new_extension) noexcept;
 
 /// Return the filepath in generic format, not any OS-specific conventions.
+/// Input and output are both UTF-8 encoded.
 OIIO_UTIL_API std::string generic_filepath (string_view filepath) noexcept;
 
-/// Turn a searchpath (multiple directory paths separated by ':' or ';') into
-/// a vector<string> containing the name of each individual directory.  If
-/// validonly is true, only existing and readable directories will end up in
-/// the list.  N.B., the directory names will not have trailing slashes.
+/// Turn a searchpath (multiple UTF-8 encoded directory paths separated by ':'
+/// or ';') into a vector<string> containing the name of each individual
+/// directory.  If validonly is true, only existing and readable directories
+/// will end up in the list.  N.B., the directory names will not have trailing
+/// slashes.
 OIIO_UTIL_API std::vector<std::string>
 searchpath_split(string_view searchpath, bool validonly = false);
 
@@ -115,7 +118,8 @@ OIIO_UTIL_API void searchpath_split (const std::string &searchpath,
 /// otherwise, "." will only be tested if it's explicitly in dirs.  If
 /// recursive is true, the directories will be searched recursively,
 /// finding a matching file in any subdirectory of the directories
-/// listed in dirs; otherwise.
+/// listed in dirs; otherwise. All file and directory names are presumed
+/// to be UTF-8 encoded.
 OIIO_UTIL_API std::string searchpath_find (const std::string &filename,
                                       const std::vector<std::string> &dirs,
                                       bool testcwd = true,
@@ -126,32 +130,33 @@ OIIO_UTIL_API std::string searchpath_find (const std::string &filename,
 /// the directory (even in subdirectories). If filter_regex is supplied and
 /// non-empty, only filenames matching the regular expression will be
 /// returned.  Return true if ok, false if there was an error (such as
-/// dirname not being found or not actually being a directory).
+/// dirname not being found or not actually being a directory). All file
+/// and directory names are presumed to be UTF-8 encoded.
 OIIO_UTIL_API bool get_directory_entries (const std::string &dirname,
                                std::vector<std::string> &filenames,
                                bool recursive = false,
                                const std::string &filter_regex=std::string());
 
-/// Return true if the path is an "absolute" (not relative) path.
-/// If 'dot_is_absolute' is true, consider "./foo" absolute.
+/// Return true if the UTF-8 encoded path is an "absolute" (not relative)
+/// path. If 'dot_is_absolute' is true, consider "./foo" absolute.
 OIIO_UTIL_API bool path_is_absolute (string_view path,
-                                bool dot_is_absolute=false);
+                                     bool dot_is_absolute=false);
 
-/// Return true if the file exists.
+/// Return true if the UTF-8 encoded path exists.
 ///
 OIIO_UTIL_API bool exists (string_view path) noexcept;
 
 
-/// Return true if the file exists and is a directory.
+/// Return true if the UTF-8 encoded path exists and is a directory.
 ///
 OIIO_UTIL_API bool is_directory (string_view path) noexcept;
 
-/// Return true if the file exists and is a regular file.
+/// Return true if the UTF-8 encoded path exists and is a regular file.
 ///
 OIIO_UTIL_API bool is_regular (string_view path) noexcept;
 
-/// Create the directory. Return true for success, false for failure and
-/// place an error message in err.
+/// Create the directory, whose name is UTF-8 encoded. Return true for
+/// success, false for failure and place an error message in err.
 OIIO_UTIL_API bool create_directory (string_view path, std::string &err);
 inline bool create_directory (string_view path) {
     std::string err;
@@ -159,49 +164,49 @@ inline bool create_directory (string_view path) {
 }
 
 /// Copy a file, directory, or link. It is an error if 'to' already exists.
-/// Return true upon success, false upon failure and place an error message
-/// in err.
+/// The file names are all UTF-8 encoded. Return true upon success, false upon
+/// failure and place an error message in err.
 OIIO_UTIL_API bool copy (string_view from, string_view to, std::string &err);
 inline bool copy (string_view from, string_view to) {
     std::string err;
     return copy (from, to, err);
 }
 
-/// Rename (or move) a file, directory, or link.  Return true upon success,
-/// false upon failure and place an error message in err.
+/// Rename (or move) a file, directory, or link. The file names are all UTF-8
+/// encoded. Return true upon success, false upon failure and place an error
+/// message in err.
 OIIO_UTIL_API bool rename (string_view from, string_view to, std::string &err);
 inline bool rename (string_view from, string_view to) {
     std::string err;
     return rename (from, to, err);
 }
 
-/// Remove the file or directory. Return true for success, false for
-/// failure and place an error message in err.
+/// Remove the file or directory. The file names are all UTF-8 encoded. Return
+/// true for success, false for failure and place an error message in err.
 OIIO_UTIL_API bool remove (string_view path, std::string &err);
 inline bool remove (string_view path) {
     std::string err;
     return remove (path, err);
 }
 
-/// Remove the file or directory, including any children (recursively).
-/// Return the number of files removed.  Place an error message (if
-/// applicable in err.
+/// Remove the file or directory, including any children (recursively). The
+/// file names are all UTF-8 encoded. Return the number of files removed.
+/// Place an error message (if applicable in err.
 OIIO_UTIL_API unsigned long long remove_all (string_view path, std::string &err);
 inline unsigned long long remove_all (string_view path) {
     std::string err;
     return remove_all (path, err);
 }
 
-/// Return a directory path where temporary files can be made.
+/// Return a directory path (UTF-8 encoded) where temporary files can be made.
 ///
 OIIO_UTIL_API std::string temp_directory_path ();
 
 /// Return a unique filename suitable for making a temporary file or
-/// directory.
+/// directory.  The file names are all UTF-8 encoded.
 OIIO_UTIL_API std::string unique_path (string_view model="%%%%-%%%%-%%%%-%%%%");
 
-/// Version of fopen that can handle UTF-8 paths even on Windows
-///
+/// Version of fopen that can handle UTF-8 paths even on Windows.
 OIIO_UTIL_API FILE *fopen (string_view path, string_view mode);
 
 /// Version of fseek that works with 64 bit offsets on all systems.
@@ -233,18 +238,19 @@ OIIO_UTIL_API void open (OIIO::ofstream &stream, string_view path,
 /// `#include <fcntl.h>` in order to get the definitions of the flags.)
 OIIO_UTIL_API int open (string_view path, int flags);
 
-/// Read the entire contents of the named text file and place it in str,
-/// returning true on success, false on failure.
+/// Read the entire contents of the named text file (as a UTF-8 encoded
+/// filename) and place it in str, returning true on success, false on
+/// failure.
 OIIO_UTIL_API bool read_text_file (string_view filename, std::string &str);
 
-/// Write the entire contents of the string `str` to the file, overwriting
-/// any prior contents of the file (if it existed), returning true on
-/// success, false on failure.
+/// Write the entire contents of the string `str` to the named file (UTF-8
+/// encoded), overwriting any prior contents of the file (if it existed),
+/// returning true on success, false on failure.
 OIIO_UTIL_API bool write_text_file (string_view filename, string_view str);
 
-/// Write the entire contents of the span `data` to the file as a binary blob,
-/// overwriting any prior contents of the file (if it existed), returning true
-/// on success, false on failure.
+/// Write the entire contents of the span `data` to the file (UTF-8 encoded)
+/// as a binary blob, overwriting any prior contents of the file (if it
+/// existed), returning true on success, false on failure.
 template<typename T>
 bool write_binary_file (string_view filename, cspan<T> data)
 {
@@ -266,22 +272,21 @@ bool write_binary_file (string_view filename, const std::vector<T>& data)
 /// full success, less than n if the file was fewer than n+pos bytes long,
 /// or 0 if the file did not exist or could not be read.
 OIIO_UTIL_API size_t read_bytes (string_view path, void *buffer, size_t n,
-                            size_t pos=0);
+                                 size_t pos=0);
 
-/// Get last modified time of file
+/// Get last modified time of the file named by `path` (UTF-8 encoded).
 ///
 OIIO_UTIL_API std::time_t last_write_time (string_view path) noexcept;
 
-/// Set last modified time on file
+/// Set last modified time on the file named by `path` (UTF-8 encoded).
 ///
 OIIO_UTIL_API void last_write_time (string_view path, std::time_t time) noexcept;
 
 /// Return the size of the file (in bytes), or uint64_t(-1) if there is any
-/// error.
+/// error. The file name is UTF-8 encoded.
 OIIO_UTIL_API uint64_t file_size (string_view path) noexcept;
 
-/// Ensure command line arguments are UTF-8 everywhere
-///
+/// Ensure command line arguments are UTF-8 everywhere.
 OIIO_UTIL_API void convert_native_arguments (int argc, const char *argv[]);
 
 /// Turn a sequence description string into a vector of integers.
@@ -298,7 +303,7 @@ OIIO_UTIL_API void convert_native_arguments (int argc, const char *argv[]);
 /// Return true upon success, false if the description was too malformed
 /// to generate a sequence.
 OIIO_UTIL_API bool enumerate_sequence (string_view desc,
-                                  std::vector<int> &numbers);
+                                       std::vector<int> &numbers);
 
 /// Given a pattern (such as "foo.#.tif" or "bar.1-10#.exr"), return a
 /// normalized pattern in printf format (such as "foo.%04d.tif") and a
@@ -310,13 +315,14 @@ OIIO_UTIL_API bool enumerate_sequence (string_view desc,
 /// Return true upon success, false if the description was too malformed
 /// to generate a sequence.
 OIIO_UTIL_API bool parse_pattern (const char *pattern,
-                             int framepadding_override,
-                             std::string &normalized_pattern,
-                             std::string &framespec);
+                                  int framepadding_override,
+                                  std::string &normalized_pattern,
+                                  std::string &framespec);
 
 
 /// Given a normalized pattern (such as "foo.%04d.tif") and a list of frame
-/// numbers, generate a list of filenames.
+/// numbers, generate a list of filenames. All the filename strings will be
+/// presumed to be UTF-8 encoded.
 ///
 /// Return true upon success, false if the description was too malformed
 /// to generate a sequence.
@@ -325,21 +331,23 @@ OIIO_UTIL_API bool enumerate_file_sequence (const std::string &pattern,
                                        std::vector<std::string> &filenames);
 
 /// Given a normalized pattern (such as "foo_%V.%04d.tif") and a list of frame
-/// numbers, generate a list of filenames. "views" is list of per-frame
-/// views, or empty. In each frame filename, "%V" is replaced with the view,
-/// and "%v" is replaced with the first character of the view.
+/// numbers, generate a list of filenames. "views" is list of per-frame views,
+/// or empty. In each frame filename, "%V" is replaced with the view, and "%v"
+/// is replaced with the first character of the view. All the filename strings
+/// will be presumed to be UTF-8 encoded.
 ///
-/// Return true upon success, false if the description was too malformed
-/// to generate a sequence.
+/// Return true upon success, false if the description was too malformed to
+/// generate a sequence.
 OIIO_UTIL_API bool enumerate_file_sequence (const std::string &pattern,
                                        const std::vector<int> &numbers,
                                        const std::vector<string_view> &views,
                                        std::vector<std::string> &filenames);
 
 /// Given a normalized pattern (such as "/path/to/foo.%04d.tif") scan the
-/// containing directory (/path/to) for matching frame numbers, views and files.
-/// "%V" in the pattern matches views, while "%v" matches the first character
-/// of each entry in views.
+/// containing directory (/path/to) for matching frame numbers, views and
+/// files. "%V" in the pattern matches views, while "%v" matches the first
+/// character of each entry in views. All the filename strings will be
+/// presumed to be UTF-8 encoded.
 ///
 /// Return true upon success, false if the directory doesn't exist or the
 /// pattern can't be parsed.
@@ -350,7 +358,8 @@ OIIO_UTIL_API bool scan_for_matching_filenames (const std::string &pattern,
                                            std::vector<std::string> &filenames);
 
 /// Given a normalized pattern (such as "/path/to/foo.%04d.tif") scan the
-/// containing directory (/path/to) for matching frame numbers and files.
+/// containing directory (/path/to) for matching frame numbers and files. All
+/// the filename strings will be presumed to be UTF-8 encoded.
 ///
 /// Return true upon success, false if the directory doesn't exist or the
 /// pattern can't be parsed.
@@ -358,26 +367,29 @@ OIIO_UTIL_API bool scan_for_matching_filenames (const std::string &pattern,
                                            std::vector<int> &numbers,
                                            std::vector<std::string> &filenames);
 
-/// Convert a filename into a regex-safe pattern -- any special regex
-/// characters `.`, `(`, `)`, `[`, `]`, `{`, `}` are backslashed. If
-/// `simple_glob` is also true, then replace `?` with `.?` and `*` with
-/// `.*`. This doesn't support full Unix command line glob syntax (no char
-/// sets `[abc]` or string sets `{ab,cd,ef}`), but it does handle simple
-/// globbing of `?` to mean any single character and `*` to mean any
-/// sequence of 0 or more characters.
+/// Convert a UTF-8 encoded filename into a regex-safe pattern -- any special
+/// regex characters `.`, `(`, `)`, `[`, `]`, `{`, `}` are backslashed. If
+/// `simple_glob` is also true, then replace `?` with `.?` and `*` with `.*`.
+/// This doesn't support full Unix command line glob syntax (no char sets
+/// `[abc]` or string sets `{ab,cd,ef}`), but it does handle simple globbing
+/// of `?` to mean any single character and `*` to mean any sequence of 0 or
+/// more characters.
 OIIO_UTIL_API std::string filename_to_regex(string_view pattern,
                                             bool simple_glob = true);
 
 
 
 /// Proxy class for I/O. This provides a simplified interface for file I/O
-/// that can have custom overrides.
+/// that can have custom overrides. All char-based filenames are assumed to be
+/// UTF-8 encoded.
 class OIIO_UTIL_API IOProxy {
 public:
     enum Mode { Closed = 0, Read = 'r', Write = 'w' };
     IOProxy () {}
     IOProxy (string_view filename, Mode mode)
         : m_filename(filename), m_mode(mode) {}
+    IOProxy(const std::wstring& filename, Mode mode)
+        : IOProxy(Strutil::utf16_to_utf8(filename), mode) {}
     virtual ~IOProxy () { }
     virtual const char* proxytype () const = 0;
     virtual void close () { }
@@ -436,6 +448,8 @@ class OIIO_UTIL_API IOFile : public IOProxy {
 public:
     // Construct from a filename, open, own the FILE*.
     IOFile(string_view filename, Mode mode);
+    IOFile(const std::wstring& filename, Mode mode)
+        : IOFile(Strutil::utf16_to_utf8(filename), mode) {}
     // Construct from an already-open FILE* that is owned by the caller.
     // Caller is responsible for closing the FILE* after the proxy is gone.
     IOFile(FILE* file, Mode mode);

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -760,19 +760,25 @@ public:
     /// any internals.
     class TextureHandle;
 
-    /// Retrieve an opaque handle for fast texture lookups.  The opaque
-    /// pointer `thread_info` is thread-specific information returned by
-    /// `get_perthread_info()`.  Return nullptr if something has gone
-    /// horribly wrong.
-    virtual TextureHandle * get_texture_handle (ustring filename,
+    /// Retrieve an opaque handle for fast texture lookups.  The filename is
+    /// presumed to be UTF-8 encoded. The opaque pointer `thread_info` is
+    /// thread-specific information returned by `get_perthread_info()`.
+    /// Return nullptr if something has gone horribly wrong.
+    virtual TextureHandle* get_texture_handle (ustring filename,
                                             Perthread *thread_info=nullptr) = 0;
+    /// Get a TextureHandle using a UTF-16 encoded wstring filename.
+    TextureHandle* get_texture_handle (const std::wstring& filename,
+                                       Perthread *thread_info=nullptr) {
+        return get_texture_handle (ustring(Strutil::utf16_to_utf8(filename)),
+                                   thread_info);
+    }
 
     /// Return true if the texture handle (previously returned by
     /// `get_image_handle()`) is a valid texture that can be subsequently
     /// read.
     virtual bool good(TextureHandle* texture_handle) = 0;
 
-    /// Given a handle, return the filename for that texture.
+    /// Given a handle, return the UTF-8 encoded filename for that texture.
     ///
     /// This method was added in OpenImageIO 2.3.
     virtual ustring filename_from_handle(TextureHandle* handle) = 0;
@@ -801,7 +807,7 @@ public:
     /// receive an antialiased texture lookup.
     ///
     /// @param  filename
-    ///             The name of the texture.
+    ///             The name of the texture, as a UTF-8 encoded ustring.
     /// @param  options
     ///     Fields within `options` that are honored for 2D texture lookups
     ///     include the following:
@@ -889,7 +895,7 @@ public:
     /// the volume file itself.
     ///
     /// @param  filename
-    ///             The name of the texture.
+    ///             The name of the texture, as a UTF-8 encoded ustring.
     /// @param  options
     ///     Fields within `options` that are honored for 3D texture lookups
     ///     include the following:
@@ -996,7 +1002,7 @@ public:
     /// stored in `result[]`.
     ///
     /// @param  filename
-    ///             The name of the texture.
+    ///             The name of the texture, as a UTF-8 encode ustring.
     /// @param  options
     ///     Fields within `options` that are honored for environment lookups
     ///     include the following:
@@ -1078,7 +1084,7 @@ public:
     /// required).
     ///
     /// @param  filename
-    ///             The name of the texture.
+    ///             The name of the texture, as a UTF-8 encode ustring.
     /// @param  options
     ///             A TextureOptBatch containing texture lookup options.
     ///             This is conceptually the same as a TextureOpt, but the
@@ -1166,7 +1172,7 @@ public:
     /// batch values for channel 1, etc.
     ///
     /// @param  filename
-    ///             The name of the texture.
+    ///             The name of the texture, as a UTF-8 encode ustring.
     /// @param  options
     ///             A TextureOptBatch containing texture lookup options.
     ///             This is conceptually the same as a TextureOpt, but the
@@ -1258,7 +1264,7 @@ public:
     /// batch values for channel 1, etc.
     ///
     /// @param  filename
-    ///             The name of the texture.
+    ///             The name of the texture, as a UTF-8 encode ustring.
     /// @param  options
     ///             A TextureOptBatch containing texture lookup options.
     ///             This is conceptually the same as a TextureOpt, but the
@@ -1366,8 +1372,8 @@ public:
     /// @name   Texture metadata and raw texels
     ///
 
-    /// Given possibly-relative 'filename', resolve it using the search
-    /// path rules and return the full resolved filename.
+    /// Given possibly-relative 'filename' (UTF-8 encoded), resolve it using
+    /// the search path rules and return the full resolved filename.
     virtual std::string resolve_filename (const std::string &filename) const=0;
 
     /// Get information or metadata about the named texture and store it in
@@ -1531,7 +1537,7 @@ public:
     ///
     ///
     /// @param  filename
-    ///             The name of the texture.
+    ///             The name of the texture, as a UTF-8 encode ustring.
     /// @param  subimage
     ///             The subimage to query. (The metadata retrieved is for
     ///             the highest-resolution MIP level of that subimage.)
@@ -1567,7 +1573,7 @@ public:
     /// subimage by default, or as set by `subimage`).
     ///
     /// @param  filename
-    ///             The name of the image.
+    ///             The name of the texture, as a UTF-8 encode ustring.
     /// @param  subimage
     ///             The subimage to query. (The spec retrieved is for the
     ///             highest-resolution MIP level of that subimage.)
@@ -1601,7 +1607,7 @@ public:
     /// underlying ImageCache.
     ///
     /// @param  filename
-    ///             The name of the image.
+    ///             The name of the texture, as a UTF-8 encode ustring.
     /// @param  subimage
     ///             The subimage to query.  (The spec retrieved is for the
     ///             highest-resolution MIP level of that subimage.)
@@ -1629,7 +1635,7 @@ public:
     /// `options.fill` value.
     ///
     /// @param  filename
-    ///             The name of the image.
+    ///             The name of the texture, as a UTF-8 encode ustring.
     /// @param  options
     ///             A TextureOpt describing access options, including wrap
     ///             modes, fill value, and subimage, that will be used when
@@ -1679,7 +1685,7 @@ public:
     /// @name Methods for UDIM patterns
     ///
 
-    /// Is the filename a UDIM pattern?
+    /// Is the UTF-8 encoded filename a UDIM pattern?
     ///
     /// This method was added in OpenImageIO 2.3.
     virtual bool is_udim(ustring filename) = 0;
@@ -1689,10 +1695,10 @@ public:
     /// This method was added in OpenImageIO 2.3.
     virtual bool is_udim(TextureHandle* udimfile) = 0;
 
-    /// For a UDIM filename pattern and texture coordinates, return the
-    /// TextureHandle pointer for the concrete tile file it refers to, or
-    /// nullptr if there is no corresponding tile (udim sets are allowed to
-    /// be sparse).
+    /// For a UDIM filename pattern (UTF-8 encoded) and texture coordinates,
+    /// return the TextureHandle pointer for the concrete tile file it refers
+    /// to, or nullptr if there is no corresponding tile (udim sets are
+    /// allowed to be sparse).
     ///
     /// This method was added in OpenImageIO 2.3.
     virtual TextureHandle* resolve_udim(ustring udimpattern,
@@ -1708,13 +1714,14 @@ public:
                                         float s, float t) = 0;
 
     /// Produce a full inventory of the set of concrete files comprising the
-    /// UDIM set specified by `udimpattern`.  The apparent number of texture
-    /// atlas tiles in the u and v directions will be written to `nutiles`
-    /// and `nvtiles`, respectively. The vector `filenames` will be sized
-    /// to `ntiles * nvtiles` and filled with the the names of the concrete
-    /// files comprising the atlas, with an empty ustring corresponding to
-    /// any unpopulated tiles (the UDIM set is allowed to be sparse). The
-    /// filename list is indexed as `utile + vtile * nvtiles`.
+    /// UDIM set specified by UTF-8 encoded `udimpattern`.  The apparent
+    /// number of texture atlas tiles in the u and v directions will be
+    /// written to `nutiles` and `nvtiles`, respectively. The vector
+    /// `filenames` will be sized to `ntiles * nvtiles` and filled with the
+    /// the names of the concrete files comprising the atlas, with an empty
+    /// ustring corresponding to any unpopulated tiles (the UDIM set is
+    /// allowed to be sparse). The filename list is indexed as `utile + vtile
+    /// * nvtiles`.
     ///
     /// This method was added in OpenImageIO 2.3.
     virtual void inventory_udim(ustring udimpattern,
@@ -1736,23 +1743,22 @@ public:
     /// @name Controlling the cache
     ///
 
-    /// Invalidate any cached information about the named file, including
-    /// loaded texture tiles from that texture, and close any open file
-    /// handle associated with the file. This calls
-    /// `ImageCache::invalidate(filename,force)` on the underlying
-    /// ImageCache.
+    /// Invalidate any cached information about the named file (UTF-8
+    /// encoded), including loaded texture tiles from that texture, and close
+    /// any open file handle associated with the file. This calls
+    /// `ImageCache::invalidate(filename,force)` on the underlying ImageCache.
     virtual void invalidate (ustring filename, bool force = true) = 0;
 
     /// Invalidate all cached data for all textures.  This calls
     /// `ImageCache::invalidate_all(force)` on the underlying ImageCache.
     virtual void invalidate_all (bool force=false) = 0;
 
-    /// Close any open file handles associated with a named file, but do not
-    /// invalidate any image spec information or pixels associated with the
-    /// files.  A client might do this in order to release OS file handle
-    /// resources, or to make it safe for other processes to modify textures
-    /// on disk.  This calls `ImageCache::close(force)` on the underlying
-    /// ImageCache.
+    /// Close any open file handles associated with a UTF-8 encoded filename,
+    /// but do not invalidate any image spec information or pixels associated
+    /// with the files.  A client might do this in order to release OS file
+    /// handle resources, or to make it safe for other processes to modify
+    /// textures on disk.  This calls `ImageCache::close(force)` on the
+    /// underlying ImageCache.
     virtual void close (ustring filename) = 0;
 
     /// `close()` all files known to the cache.

--- a/src/python/py_imageinput.cpp
+++ b/src/python/py_imageinput.cpp
@@ -214,7 +214,10 @@ declare_imageinput(py::module& m)
             },
             "filename"_a, "config"_a)
         .def("format_name", &ImageInput::format_name)
-        .def("valid_file", &ImageInput::valid_file)
+        .def("valid_file",
+             [](ImageInput& self, const std::string& filename) {
+                 return self.valid_file(filename);
+             })
         .def("spec", [](ImageInput& self) { return self.spec(); })
         .def(
             "spec",


### PR DESCRIPTION
As Doug Rogers points out in Issue #3304, it is customary for Windows
applications to use wstring extensively for Unicode support. But it's
especially critical for unicode filenames, because unlike Unix-like
OS's where fopen() and similar functions support UTF-8, on Windows
those functions are strictly ASCII, and Windows users are used to
calling _wfopen() and other nonstandard functions that expect
filenames to be std::wstring if they want to support Unicode.

This patch:

* More clearly documents through all of our classes when parameters that
  represent filenames or searchpaths are assumed to support UTF-8.

* Augments ImageInput, ImageOutput, and ImageBuf so that their methods
  that take file names or path lists have additional flavors that take
  wstring (always implemented as an inline shim that translates the
  UTF-16 wstring to a std::string with UTF-8 encoding to pass on to the
  usual method).

* Augments ImageCache and TextureSystem in just a couple places, the
  functions where a filename is turned into a handle. All the many
  other functions that take ustring for function names were left alone,
  because they are called very frequently and are performance-sensitive,
  so we don't want any translation from wstring to string happening on
  every call.

We do not attempt to add wstring-based versions of functions that take
strings for other purposes -- that is, that are not intended to
represent filenames.

Fixes #3304 
