### PR TITLE
Work toward eliminating string_view::c_str()

### DIFF
--- a/src/include/OpenImageIO/hash.h
+++ b/src/include/OpenImageIO/hash.h
@@ -576,6 +576,11 @@ public:
     /// Append more data
     void append (const void *data, size_t size);
 
+    /// Append more data from a string_view
+    void append (string_view s) {
+        append(s.data(), s.size());
+    }
+
     /// Append more data from a span, without thinking about sizes.
     template<class T> void append (span<T> v) {
         append (v.data(), v.size()*sizeof(T));

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -162,7 +162,7 @@ template<typename... Args>
 OIIO_FORMAT_DEPRECATED
 inline std::string format (string_view fmt, const Args&... args)
 {
-    return format (fmt.c_str(), args...);
+    return format ({ fmt.data(), fmt.size() }, args...);
 }
 } // namespace old
 

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -870,7 +870,7 @@ ImageViewer::updateTitle()
         return;
     }
     std::string message;
-    message = Strutil::sprintf("%s - iv Image Viewer", img->name().c_str());
+    message = Strutil::sprintf("%s - iv Image Viewer", img->name());
     setWindowTitle(QString::fromLocal8Bit(message.c_str()));
 }
 

--- a/src/iv/ivinfowin.cpp
+++ b/src/iv/ivinfowin.cpp
@@ -56,10 +56,10 @@ IvInfoWindow::update(IvImage* img)
 {
     std::string newtitle;
     if (img) {
-        newtitle = Strutil::sprintf("%s - iv Info", img->name().c_str());
+        newtitle = Strutil::sprintf("%s - iv Info", img->name());
         infoLabel->setText(img->longinfo().c_str());
     } else {
-        newtitle = Strutil::sprintf("iv Info");
+        newtitle = "iv Info";
         infoLabel->setText(tr("No image loaded."));
     }
     setWindowTitle(newtitle.c_str());

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1021,11 +1021,10 @@ ColorConfig::createColorProcessor(ustring inputColorSpace,
             outputColorSpace = name;
         }
 
-        OCIO::ConstConfigRcPtr config   = getImpl()->config_;
-        OCIO::ConstContextRcPtr context = config->getCurrentContext();
-        std::vector<string_view> keys, values;
-        Strutil::split(context_key, keys, ",");
-        Strutil::split(context_value, values, ",");
+        auto config  = getImpl()->config_;
+        auto context = config->getCurrentContext();
+        auto keys    = Strutil::splits(context_key, ",");
+        auto values  = Strutil::splits(context_value, ",");
         if (keys.size() && values.size() && keys.size() == values.size()) {
             OCIO::ContextRcPtr ctx = context->createEditableCopy();
             for (size_t i = 0; i < keys.size(); ++i)
@@ -1177,10 +1176,9 @@ ColorConfig::createLookTransform(ustring looks, ustring inputColorSpace,
             transform->setDst(outputColorSpace.c_str());
             dir = OCIO::TRANSFORM_DIR_FORWARD;
         }
-        OCIO::ConstContextRcPtr context = config->getCurrentContext();
-        std::vector<string_view> keys, values;
-        Strutil::split(context_key, keys, ",");
-        Strutil::split(context_value, values, ",");
+        auto context = config->getCurrentContext();
+        auto keys    = Strutil::splits(context_key, ",");
+        auto values  = Strutil::splits(context_value, ",");
         if (keys.size() && values.size() && keys.size() == values.size()) {
             OCIO::ContextRcPtr ctx = context->createEditableCopy();
             for (size_t i = 0; i < keys.size(); ++i)

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1439,7 +1439,7 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
         }
     }
 
-    if (!out->open(filename.c_str(), newspec)) {
+    if (!out->open(filename, newspec)) {
         error(out->geterror());
         return false;
     }

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -860,8 +860,8 @@ ImageBufAlgo::computePixelHashSHA1(const ImageBuf& src, string_view extrainfo,
     // blocks computed doesn't matter.)
     SHA1 sha;
     for (int b = 0; b < nblocks; ++b)
-        sha.append(results[b].c_str(), results[b].size());
-    sha.append(extrainfo.c_str(), extrainfo.size());
+        sha.append(results[b]);
+    sha.append(extrainfo);
     return sha.digest();
 }
 

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -494,7 +494,7 @@ Filesystem::open(OIIO::ifstream& stream, string_view path,
     stream.open(wpath.c_str(), mode);
     stream.seekg(0, std::ios_base::beg);  // force seek, otherwise broken
 #else
-    stream.open(path.c_str(), mode);
+    stream.open(path, mode);
 #endif
 }
 
@@ -510,7 +510,7 @@ Filesystem::open(OIIO::ofstream& stream, string_view path,
     std::wstring wpath = Strutil::utf8_to_utf16(path);
     stream.open(wpath.c_str(), mode);
 #else
-    stream.open(path.c_str(), mode);
+    stream.open(path, mode);
 #endif
 }
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -2451,7 +2451,7 @@ set_origin(int argc, const char* argv[])
         ImageSpec& spec(*A->spec(s));
         int x = spec.x, y = spec.y, z = spec.z;
         int w = spec.width, h = spec.height, d = spec.depth;
-        ot.adjust_geometry(command, w, h, x, y, origin.c_str());
+        ot.adjust_geometry(command, w, h, x, y, origin);
         if (spec.width != w || spec.height != h || spec.depth != d)
             ot.warning(command,
                        "can't be used to change the size, only the origin");
@@ -2498,7 +2498,7 @@ offset_origin(int argc, const char* argv[])
         ImageSpec& spec(*A->spec(s));
         int x = 0, y = 0, z = 0;  // OFFSETS, not set values
         int w = spec.width, h = spec.height;
-        ot.adjust_geometry(command, w, h, x, y, origin.c_str(), false, false);
+        ot.adjust_geometry(command, w, h, x, y, origin, false, false);
         if (x != 0 || y != 0) {
             ImageBuf& ib = (*A)(s);
             if (ib.storage() == ImageBuf::IMAGECACHE) {
@@ -2542,7 +2542,7 @@ set_fullsize(int argc, const char* argv[])
         ImageSpec& spec(*A->spec(s));
         int x = spec.full_x, y = spec.full_y;
         int w = spec.full_width, h = spec.full_height;
-        ot.adjust_geometry(argv[0], w, h, x, y, size.c_str());
+        ot.adjust_geometry(argv[0], w, h, x, y, size);
         if (spec.full_x != x || spec.full_y != y || spec.full_width != w
             || spec.full_height != h) {
             spec.full_x      = x;
@@ -3740,8 +3740,7 @@ action_create(int argc, const char* argv[])
     }
     ImageSpec spec(64, 64, nchans,
                    TypeDesc(options["type"].as_string("float")));
-    ot.adjust_geometry(argv[0], spec.width, spec.height, spec.x, spec.y,
-                       size.c_str());
+    ot.adjust_geometry(argv[0], spec.width, spec.height, spec.x, spec.y, size);
     spec.full_x      = spec.x;
     spec.full_y      = spec.y;
     spec.full_z      = spec.z;
@@ -3777,8 +3776,7 @@ action_pattern(int argc, const char* argv[])
     }
     ImageSpec spec(64, 64, nchans,
                    TypeDesc(options["type"].as_string("float")));
-    ot.adjust_geometry(argv[0], spec.width, spec.height, spec.x, spec.y,
-                       size.c_str());
+    ot.adjust_geometry(argv[0], spec.width, spec.height, spec.x, spec.y, size);
     spec.full_x      = spec.x;
     spec.full_y      = spec.y;
     spec.full_z      = spec.z;
@@ -3929,7 +3927,7 @@ action_crop(int argc, const char* argv[])
         ImageSpec& spec(*A->spec(s, 0));
         int w = spec.width, h = spec.height, d = spec.depth;
         int x = spec.x, y = spec.y, z = spec.z;
-        ot.adjust_geometry(argv[0], w, h, x, y, size.c_str());
+        ot.adjust_geometry(argv[0], w, h, x, y, size);
         crops_needed |= (w != spec.width || h != spec.height || d != spec.depth
                          || x != spec.x || y != spec.y || z != spec.z);
     }
@@ -3942,7 +3940,7 @@ action_crop(int argc, const char* argv[])
             ImageSpec& spec(*A->spec(s, 0));
             int w = spec.width, h = spec.height, d = spec.depth;
             int x = spec.x, y = spec.y, z = spec.z;
-            ot.adjust_geometry(argv[0], w, h, x, y, size.c_str());
+            ot.adjust_geometry(argv[0], w, h, x, y, size);
             const ImageBuf& Aib((*A)(s, 0));
             ImageBuf& Rib((*R)(s, 0));
             ROI roi = Aib.roi();
@@ -4098,7 +4096,7 @@ action_cut(int argc, const char* argv[])
         ImageSpec& newspec(newspecs[s]);
         newspec = *A->spec(s, 0);
         ot.adjust_geometry(argv[0], newspec.width, newspec.height, newspec.x,
-                           newspec.y, size.c_str());
+                           newspec.y, size);
     }
 
     // Make a new ImageRec sized according to the new set of specs
@@ -4140,8 +4138,8 @@ public:
             ImageSpec& newspec(newspecs[s]);
             newspec = Aspec;
             ot.adjust_geometry(args(0), newspec.full_width, newspec.full_height,
-                               newspec.full_x, newspec.full_y,
-                               args(1).c_str() /*size*/, true);
+                               newspec.full_x, newspec.full_y, args(1) /*size*/,
+                               true);
             if (newspec.full_width == Aspec.full_width
                 && newspec.full_height == Aspec.full_height) {
                 continue;
@@ -4197,8 +4195,8 @@ public:
             ImageSpec& newspec(newspecs[s]);
             newspec = Aspec;
             ot.adjust_geometry(args(0), newspec.full_width, newspec.full_height,
-                               newspec.full_x, newspec.full_y,
-                               args(1).c_str() /*size*/, true);
+                               newspec.full_x, newspec.full_y, args(1) /*size*/,
+                               true);
             if (newspec.full_width == Aspec.full_width
                 && newspec.full_height == Aspec.full_height) {
                 continue;
@@ -4285,7 +4283,7 @@ action_fit(cspan<const char*> argv)
     int fit_full_x      = Aspec->full_x;
     int fit_full_y      = Aspec->full_y;
     ot.adjust_geometry(argv[0], fit_full_width, fit_full_height, fit_full_x,
-                       fit_full_y, size.c_str(), false);
+                       fit_full_y, size, false);
 
     auto options           = ot.extract_options(command);
     bool allsubimages      = options.get_int("allsubimages", ot.allsubimages);
@@ -4833,7 +4831,7 @@ action_fill(int argc, const char* argv[])
         const ImageSpec& Rspec = Rib.spec();
         int w = Rib.spec().width, h = Rib.spec().height;
         int x = Rib.spec().x, y = Rib.spec().y;
-        if (!ot.adjust_geometry(argv[0], w, h, x, y, size.c_str(), true))
+        if (!ot.adjust_geometry(argv[0], w, h, x, y, size, true))
             continue;
         std::vector<float> topleft(Rspec.nchannels, 1.0f);
         std::vector<float> topright(Rspec.nchannels, 1.0f);
@@ -5214,7 +5212,7 @@ input_file(int argc, const char* argv[])
 
         if (autocc) {
             // Try to deduce the color space it's in
-            string_view colorspace(
+            std::string colorspace(
                 ot.colorconfig.getColorSpaceFromFilepath(filename));
             if (colorspace.size() && ot.debug)
                 std::cout << "  From " << filename
@@ -5229,7 +5227,7 @@ input_file(int argc, const char* argv[])
                               << " indicates color space \"" << colorspace
                               << "\"\n";
             }
-            string_view linearspace = ot.colorconfig.getColorSpaceNameByRole(
+            std::string linearspace = ot.colorconfig.getColorSpaceNameByRole(
                 "linear");
             if (linearspace.empty())
                 linearspace = string_view("Linear");
@@ -5353,7 +5351,7 @@ output_file(int /*argc*/, const char* argv[])
 {
     ot.total_writetime.start();
     string_view command  = ot.express(argv[0]);
-    string_view filename = ot.express(argv[1]);
+    std::string filename = ot.express(argv[1]);
     OTScopedTimer timer(ot, command);
 
     auto fileoptions = ot.extract_options(command);
@@ -5440,12 +5438,12 @@ output_file(int /*argc*/, const char* argv[])
     if ((ir->spec()->nchannels > 4 && !out->supports("nchannels"))
         || (ir->spec()->nchannels > 3 && !out->supports("alpha"))) {
         bool alpha = (ir->spec()->nchannels > 3 && out->supports("alpha"));
-        string_view chanlist = alpha ? "R,G,B,A" : "R,G,B";
+        const char* chanlist = alpha ? "R,G,B,A" : "R,G,B";
         std::vector<int> channels;
         bool found = parse_channels(*ir->spec(), chanlist, channels);
         if (!found)
             chanlist = alpha ? "0,1,2,3" : "0,1,2";
-        const char* argv[] = { "channels:allsubimages=1", chanlist.c_str() };
+        const char* argv[] = { "channels:allsubimages=1", chanlist };
         int action_channels(int argc, const char* argv[]);  // forward decl
         action_channels(2, argv);
         ot.warningfmt(command, "Can't save {} channels to {}... saving only {}",
@@ -5495,7 +5493,7 @@ output_file(int /*argc*/, const char* argv[])
     // automatically set -d based on the name if --autocc is used.
     bool autocc          = fileoptions.get_int("autocc", ot.autocc);
     bool autoccunpremult = fileoptions.get_int("unpremult", ot.autoccunpremult);
-    string_view outcolorspace = ot.colorconfig.getColorSpaceFromFilepath(
+    std::string outcolorspace = ot.colorconfig.getColorSpaceFromFilepath(
         filename);
     if (autocc && outcolorspace.size()) {
         TypeDesc type;
@@ -5522,7 +5520,7 @@ output_file(int /*argc*/, const char* argv[])
             "linear");
         if (linearspace.empty())
             linearspace = string_view("Linear");
-        string_view currentspace
+        std::string currentspace
             = ir->spec()->get_string_attribute("oiio:ColorSpace", linearspace);
         // Special cases where we know formats should be particular color
         // spaces


### PR DESCRIPTION
We wrote our string_view before C++17 std::string_view was finalized,
and the std one doesn't have a c_str() method. For conformance with the
standard, I want to remove this over time from ours.

Part 1: There were some places we did not need to call c_str() at all,
and some places where it was much more appropriate to just use a
std::string.

This is the lowest-hanging fruit. I will have later follow-ups.
