### PR TITLE
TIFF: Mitigate IPTC corruptions

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -2370,6 +2370,10 @@ aspects of the writing itself:
      - int
      - If zero, do NOT write the "EXTRASAMPLES" tag to the TIFF header.
        (The default is 1, which means write the tag.)
+   * - ``tiff:write_iptc``
+     - int
+     - If nonzero, write an IPTC data block to the TIFF file.
+       (The default is 0, which means not to write an IPTC block.)
 
 
 **TIFF compression modes**

--- a/src/libOpenImageIO/iptc.cpp
+++ b/src/libOpenImageIO/iptc.cpp
@@ -142,7 +142,8 @@ decode_iptc_iim(const void* iptc, int length, ImageSpec& spec)
                     } else {
                         spec.attribute(iimtag[i].name, s);
                     }
-                    if (iimtag[i].anothername)
+                    if (iimtag[i].anothername
+                        && !spec.extra_attribs.contains(iimtag[i].anothername))
                         spec.attribute(iimtag[i].anothername, s);
                     break;
                 }

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -783,11 +783,18 @@ TIFFOutput::open(const std::string& name, const ImageSpec& userspec,
                       m_spec.extra_attribs[p].type(),
                       m_spec.extra_attribs[p].data());
 
-    std::vector<char> iptc;
-    encode_iptc_iim(m_spec, iptc);
-    if (iptc.size()) {
-        iptc.resize((iptc.size() + 3) & (0xffff - 3));  // round up
-        TIFFSetField(m_tif, TIFFTAG_RICHTIFFIPTC, iptc.size() / 4, &iptc[0]);
+    if (m_spec.get_int_attribute("tiff:write_iptc")) {
+        // Disable this by default. It seems buggy, and I don't know why. Our
+        // code? Something in libtiff? Since nobody is depending on it and
+        // none of our testsuite appears to fail when disabled, only write the
+        // IPTC block if the user explicitly asks for it.
+        std::vector<char> iptc;
+        encode_iptc_iim(m_spec, iptc);
+        if (iptc.size()) {
+            iptc.resize((iptc.size() + 3) & (0xffff - 3));  // round up
+            TIFFSetField(m_tif, TIFFTAG_RICHTIFFIPTC, iptc.size() / 4,
+                         &iptc[0]);
+        }
     }
 
     std::string xmp = encode_xmp(m_spec, true);


### PR DESCRIPTION
IPTC data blocks seems buggy, and I don't know why. Our code?
Something in libtiff?  Since nobody is depending on it and none of our
testsuite appears to fail when disabled, only write the IPTC block if
the user explicitly asks for it.  Also, when reading them, don't
overwrite other metadata of the same name.
