### PR TITLE
Correction to recent wstring changes: un-virtualize one method

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1042,7 +1042,7 @@ public:
     virtual bool open (const std::string& name, ImageSpec &newspec) = 0;
 
     /// Open the ImageInput using a UTF-16 encoded wstring filename.
-    virtual bool open (const std::wstring& name, ImageSpec &newspec) {
+    bool open (const std::wstring& name, ImageSpec &newspec) {
         return open(Strutil::utf16_to_utf8(name), newspec);
     }
 


### PR DESCRIPTION
One new method that should have been inline and non-virtual (so that
this whole set of changes does not change ABI by shifting the vtable
around) was accidentally marked virtual -- cut and paste error. This
patch fixes it to restore ABI compatibility.

This fixes a problem with #3312 