### PR TITLE
Color space adjustment for PPM and PNG files.

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5531,6 +5531,10 @@ output_file(int /*argc*/, const char* argv[])
                 || Strutil::iends_with(filename, ".gif")
                 || Strutil::iends_with(filename, ".webp")))
             outcolorspace = string_view("sRGB");
+        if (outcolorspace.empty()
+            && (Strutil::iends_with(filename, ".ppm")
+                || Strutil::iends_with(filename, ".pnm")))
+            outcolorspace = string_view("Rec709");
         if (outcolorspace.size() && currentspace != outcolorspace) {
             if (ot.debug)
                 std::cout << "  Converting from " << currentspace << " to "

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -323,7 +323,7 @@ PNMInput::read_file_header()
                            TypeDesc::FLOAT);
         m_spec.attribute("pnm:bigendian", m_scaling_factor < 0 ? 0 : 1);
     }
-    m_spec.attribute("oiio:ColorSpace", "Gamma2.2");
+    m_spec.attribute("oiio:ColorSpace", "Rec709");
     return true;
 }
 

--- a/testsuite/ico/ref/out.txt
+++ b/testsuite/ico/ref/out.txt
@@ -29,6 +29,7 @@ Reading ../oiio-images/oiio.ico
     SHA-1: F44C9B94AB7D612F62A4DC29FD9C56FD173F2614
     channel list: R, G, B, A
     oiio:BitsPerSample: 2
+    oiio:ColorSpace: "sRGB"
     oiio:UnassociatedAlpha: 1
  subimage  7:   48 x   48, 4 channel, uint8 ico
     SHA-1: 127700A3DACBF25FCD800642D78F8EE91EDE24B9

--- a/testsuite/pnm/ref/out.txt
+++ b/testsuite/pnm/ref/out.txt
@@ -2,17 +2,17 @@ Reading ../oiio-images/pnm/test-1.pfm
 ../oiio-images/pnm/test-1.pfm :   64 x   64, 3 channel, float pnm
     SHA-1: ACEB5CA4B88F78E3344D79E7C8E16200FF434085
     channel list: R, G, B
-    oiio:ColorSpace: "Gamma2.2"
+    oiio:ColorSpace: "Rec709"
     pnm:bigendian: 0
 Reading ../oiio-images/pnm/test-2.pfm
 ../oiio-images/pnm/test-2.pfm :  240 x  240, 3 channel, float pnm
     SHA-1: 312B084985EF1B9C20D35A9D7A5DC8E8EAEB25A0
     channel list: R, G, B
-    oiio:ColorSpace: "Gamma2.2"
+    oiio:ColorSpace: "Rec709"
     pnm:bigendian: 0
 Reading ../oiio-images/pnm/test-3.pfm
 ../oiio-images/pnm/test-3.pfm :  240 x  240, 3 channel, float pnm
     SHA-1: 613A9639725F51ADC8B6F8F5A38DB5EFF0B3A628
     channel list: R, G, B
-    oiio:ColorSpace: "Gamma2.2"
+    oiio:ColorSpace: "Rec709"
     pnm:bigendian: 1


### PR DESCRIPTION
PPM by specification is Rec709! Make it so.

PNG files were getting marked as sRGB or Gamma if certain header
attributes were found in the file, but if they were absent, we didn't
designate a color space at all. Change so that the default assumes
sRGB, in the absence of any metadata telling us for sure.

Fixes #3084
