### PR TITLE
Changes to make it easier to hide the Imath dependency

### DIFF
--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -3,16 +3,18 @@
 include(CMakeFindDependencyMacro)
 
 # add here all the find_dependency() whenever switching to config based dependencies
-if (@OpenEXR_VERSION@ VERSION_GREATER_EQUAL 3.0)
-    find_dependency(Imath @Imath_VERSION@
-                    HINTS @Imath_DIR@)
-elseif (@OpenEXR_VERSION@ VERSION_GREATER_EQUAL 2.4 AND @FOUND_OPENEXR_WITH_CONFIG@)
-    find_dependency(IlmBase @OpenEXR_VERSION@
-                    HINTS @IlmBase_DIR@ @OpenEXR_DIR@)
-    find_dependency(OpenEXR @OpenEXR_VERSION@
-                    HINTS @OpenEXR_DIR@)
-    find_dependency(ZLIB @ZLIB_VERSION@)  # Because OpenEXR doesn't do it
-    find_dependency(Threads)  # Because OpenEXR doesn't do it
+if (NOT OPENIMAGEIO_CONFIG_DO_NOT_FIND_IMATH)
+    if (@OpenEXR_VERSION@ VERSION_GREATER_EQUAL 3.0)
+        find_dependency(Imath @Imath_VERSION@
+                        HINTS @Imath_DIR@)
+    elseif (@OpenEXR_VERSION@ VERSION_GREATER_EQUAL 2.4 AND @FOUND_OPENEXR_WITH_CONFIG@)
+        find_dependency(IlmBase @OpenEXR_VERSION@
+                        HINTS @IlmBase_DIR@ @OpenEXR_DIR@)
+        find_dependency(OpenEXR @OpenEXR_VERSION@
+                        HINTS @OpenEXR_DIR@)
+        find_dependency(ZLIB @ZLIB_VERSION@)  # Because OpenEXR doesn't do it
+        find_dependency(Threads)  # Because OpenEXR doesn't do it
+    endif ()
 endif ()
 
 # Compute the installation prefix relative to this file

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -29,6 +29,8 @@ include (ExternalProject)
 
 option (BUILD_MISSING_DEPS "Try to download and build any missing dependencies" OFF)
 
+include (FindThreads)
+
 
 ###########################################################################
 # Boost setup
@@ -106,13 +108,32 @@ include_directories(BEFORE ${IMATH_INCLUDES} ${OPENEXR_INCLUDES})
 if (MSVC AND NOT LINKSTATIC)
     add_definitions (-DOPENEXR_DLL) # Is this needed for new versions?
 endif ()
-
 if (OPENEXR_VERSION VERSION_GREATER_EQUAL 3.0)
     set (OIIO_USING_IMATH 3)
 else ()
     set (OIIO_USING_IMATH 2)
 endif ()
-
+set (OPENIMAGEIO_IMATH_TARGETS
+            # For OpenEXR/Imath 3.x:
+            $<TARGET_NAME_IF_EXISTS:Imath::Imath>
+            $<TARGET_NAME_IF_EXISTS:Imath::Half>
+            # For OpenEXR >= 2.4/2.5 with reliable exported targets
+            $<TARGET_NAME_IF_EXISTS:IlmBase::Imath>
+            $<TARGET_NAME_IF_EXISTS:IlmBase::Half>
+            $<TARGET_NAME_IF_EXISTS:IlmBase::Iex>
+            # For OpenEXR <= 2.3:
+            ${ILMBASE_LIBRARIES} )
+set (OPENIMAGEIO_OPENEXR_TARGETS
+            # For OpenEXR/Imath 3.x:
+            $<TARGET_NAME_IF_EXISTS:OpenEXR::OpenEXR>
+            # For OpenEXR >= 2.4/2.5 with reliable exported targets
+            $<TARGET_NAME_IF_EXISTS:OpenEXR::IlmImf>
+            $<TARGET_NAME_IF_EXISTS:IlmBase::IlmThread>
+            $<TARGET_NAME_IF_EXISTS:IlmBase::Iex>
+            # For OpenEXR <= 2.3:
+            ${OPENEXR_LIBRARIES} )
+set (OPENIMAGEIO_IMATH_DEPENDENCY_VISIBILITY "PUBLIC" CACHE STRING
+     "Should we expose Imath library dependency as PUBLIC or PRIVATE")
 
 # JPEG -- prefer Turbo-JPEG to regular libjpeg
 checked_find_package (JPEGTurbo

--- a/src/include/OpenImageIO/Imath.h.in
+++ b/src/include/OpenImageIO/Imath.h.in
@@ -5,7 +5,8 @@
 // clang-format off
 
 #pragma once
-
+#ifndef OIIO_IMATH_H_INCLUDED
+#define OIIO_IMATH_H_INCLUDED 1
 
 // Determine which Imath we're dealing with and include the appropriate
 // headers.
@@ -23,3 +24,5 @@
 #   include <OpenEXR/ImathVec.h>
 #   include <OpenEXR/half.h>
 #endif
+
+#endif // !defined(OIIO_IMATH_H_INCLUDED)

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -126,24 +126,10 @@ target_compile_features (OpenImageIO
 target_link_libraries (OpenImageIO
         PUBLIC
             OpenImageIO_Util
-            # For OpenEXR/Imath 3.x:
-            $<TARGET_NAME_IF_EXISTS:Imath::Imath>
-            $<TARGET_NAME_IF_EXISTS:Imath::Half>
-            # For OpenEXR >= 2.4/2.5 with reliable exported targets
-            $<TARGET_NAME_IF_EXISTS:IlmBase::Imath>
-            $<TARGET_NAME_IF_EXISTS:IlmBase::Half>
-            # For OpenEXR <= 2.3:
-            ${ILMBASE_LIBRARIES}
-            ${GCC_ATOMIC_LIBRARIES}
+        ${OPENIMAGEIO_IMATH_DEPENDENCY_VISIBILITY}
+            ${OPENIMAGEIO_IMATH_TARGETS}
         PRIVATE
-            # For OpenEXR/Imath 3.x:
-            $<TARGET_NAME_IF_EXISTS:OpenEXR::OpenEXR>
-            # For OpenEXR >= 2.4/2.5 with reliable exported targets
-            $<TARGET_NAME_IF_EXISTS:OpenEXR::IlmImf>
-            $<TARGET_NAME_IF_EXISTS:IlmBase::IlmThread>
-            $<TARGET_NAME_IF_EXISTS:IlmBase::Iex>
-            # For OpenEXR <= 2.3:
-            ${OPENEXR_LIBRARIES}
+            ${OPENIMAGEIO_OPENEXR_TARGETS}
             ${OpenCV_LIBRARIES}
             ${SANITIZE_LIBRARIES}
             ${format_plugin_libs} # Add all the target link libraries from the plugins

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -12,17 +12,10 @@ target_include_directories (OpenImageIO_Util
         )
 target_link_libraries (OpenImageIO_Util
         PUBLIC
-            # For OpenEXR/Imath 3.x:
-            $<TARGET_NAME_IF_EXISTS:Imath::Imath>
-            $<TARGET_NAME_IF_EXISTS:Imath::Half>
-            # For OpenEXR >= 2.4/2.5 with reliable exported targets
-            $<TARGET_NAME_IF_EXISTS:IlmBase::Imath>
-            $<TARGET_NAME_IF_EXISTS:IlmBase::Half>
-            $<TARGET_NAME_IF_EXISTS:IlmBase::IlmThread>
-            $<TARGET_NAME_IF_EXISTS:IlmBase::Iex>
-            # For OpenEXR <= 2.3:
-            ${ILMBASE_LIBRARIES}
+            $<TARGET_NAME_IF_EXISTS:Threads::Threads>
             ${GCC_ATOMIC_LIBRARIES}
+        ${OPENIMAGEIO_IMATH_DEPENDENCY_VISIBILITY}
+            ${OPENIMAGEIO_IMATH_TARGETS}
         PRIVATE
             Boost::filesystem
             Boost::system
@@ -106,7 +99,8 @@ if (OIIO_BUILD_TESTS)
     add_test (unit_strutil ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/strutil_test)
 
     add_executable (fmath_test fmath_test.cpp)
-    target_link_libraries (fmath_test PRIVATE OpenImageIO_Util)
+    target_link_libraries (fmath_test PRIVATE OpenImageIO_Util
+                                              ${OPENIMAGEIO_IMATH_TARGETS})
     set_target_properties (fmath_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_fmath ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/fmath_test)
 
@@ -141,7 +135,8 @@ if (OIIO_BUILD_TESTS)
     add_test (unit_thread ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/thread_test)
 
     add_executable (simd_test simd_test.cpp)
-    target_link_libraries (simd_test PRIVATE OpenImageIO)
+    target_link_libraries (simd_test PRIVATE OpenImageIO
+                                             ${OPENIMAGEIO_IMATH_TARGETS})
     set_target_properties (simd_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_simd ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/simd_test)
 
@@ -151,7 +146,8 @@ if (OIIO_BUILD_TESTS)
     add_test (unit_filter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/filter_test)
 
     add_executable (paramlist_test paramlist_test.cpp)
-    target_link_libraries (paramlist_test PRIVATE OpenImageIO)
+    target_link_libraries (paramlist_test PRIVATE OpenImageIO
+                                                  ${OPENIMAGEIO_IMATH_TARGETS})
     set_target_properties (paramlist_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_paramlist ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/paramlist_test)
 
@@ -162,12 +158,7 @@ if (OIIO_BUILD_TESTS)
 
     add_executable (typedesc_test typedesc_test.cpp)
     target_link_libraries (typedesc_test PRIVATE OpenImageIO_Util
-                           # For OpenEXR/Imath 3.x:
-                           $<TARGET_NAME_IF_EXISTS:OpenEXR::OpenEXR>
-                           # For OpenEXR >= 2.4/2.5 with reliable exported targets
-                           $<TARGET_NAME_IF_EXISTS:OpenEXR::IlmImf>
-                           # For OpenEXR <= 2.3:
-                           ${OPENEXR_LIBRARIES})
+                           ${OPENIMAGEIO_OPENEXR_TARGETS})
     set_target_properties (typedesc_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_typedesc ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/typedesc_test)
 


### PR DESCRIPTION
* `OPENIMAGEIO_IMATH_DEPENDENCY_VISIBILITY` is a new CMake cache
  variable at OIIO build time that controls whether the Imath library
  dependencies will be declared as PUBLIC (default) or PRIVATE target
  dependencies of libOpenImageIO and libOpenImageIO_Util.

* For *downstream projects* that consume OIIO's exported cmake config
  files, setting CMake variable `OPENIMAGEIO_CONFIG_DO_NOT_FIND_IMATH`
  to true will skip the find_depencency() calls for Imath and OpenEXR.
  To clarify, this is not a variable that has any effect when building
  OIIO, it's something set in the downstream project itself.

* Add a `OIIO_IMATH_H_INCLUDED` header guard in OpenImageIO/Imath.h,
  which allows something downstream to pre-define it to prevent OIIO
  headers it needs to read from using the contents of that header.

Most builders of OIIO won't care and shouldn't change the defaults or
use any of these.  But here's the specific case it addresses: If you
are building OIIO against static libraries of Imath & OpenEXR, but the
libOpenImageIO will be consumed by a downstream project that wants to
use a different Imath version, this can help you avoid some build-time
conflicts in the downstream project.
