### PR TITLE
Targa: Fix parsing of TGA 2.0 extension area.

### DIFF
--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -342,20 +342,16 @@ TGAInput::open(const std::string& name, ImageSpec& newspec)
             // software
             if (!ioread(buf.c, 41, 1))
                 return false;
+            uint16_t n;
+            char l;
+            if (!read(n) || !read(l))
+                return false;
             if (buf.c[0]) {
                 // tack on the version number and letter
-                uint16_t n;
-                char l;
-                if (!read(n) || !read(l))
-                    return false;
                 sprintf((char*)&buf.c[strlen((char*)buf.c)], " %u.%u%c",
                         n / 100, n % 100, l != ' ' ? l : 0);
                 m_spec.attribute("Software", (char*)buf.c);
             }
-
-            // software version
-            if (!ioread(buf.c, 3, 1))
-                return false;
 
             // background (key) colour
             if (!ioread(buf.c, 4, 1))

--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -353,6 +353,10 @@ TGAInput::open(const std::string& name, ImageSpec& newspec)
                 m_spec.attribute("Software", (char*)buf.c);
             }
 
+            // software version
+            if (!ioread(buf.c, 3, 1))
+                return false;
+
             // background (key) colour
             if (!ioread(buf.c, 4, 1))
                 return false;


### PR DESCRIPTION
Skip 3 bytes between "software" and "background (key) colour" for the "software
version" (was simply missing). Avoids that m_alpha_type is overwritten with
wrong values.

## Tests

Did not create a new test case. Existing targa test fails for me (probably unrelated) with:

```131/161 Testing: targa
131/161 Test: targa
Command: "/usr/bin/python3.9" "/some_prefix/src/testsuite/runtest.py" "/some_prefix/src/build-debug/testsuite/targa"
Directory: /some_prefix/src/build-debug
"targa" start time: Feb 04 09:19 CET
Output:
----------------------------------------------------------
Traceback (most recent call last):
  File "/some_prefix/src/testsuite/runtest.py", line 452, in <module>
    exec (code)
  File "run.py", line 3, in <module>
ModuleNotFoundError: No module named 'OpenImageIO'
<end of output>
Test time =   0.04 sec
----------------------------------------------------------
Test Failed.
"targa" end time: Feb 04 09:19 CET
"targa" time elapsed: 00:00:00
----------------------------------------------------------
```

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

