### PR TITLE
Handle NUL (0) characters in ustrings by truncating.

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -319,7 +319,7 @@ strhash (size_t len, const char *s)
 /// Hash a string_view. This is OIIO's default favorite string hasher.
 /// Currently, it uses farmhash, is constexpr (for C++14), and works in
 /// Cuda. This is rigged, though, so that empty strings hash always hash to
-/// 0 (that isn't would a raw farmhash would give you, but it's a useful
+/// 0 (that isn't what a raw farmhash would give you, but it's a useful
 /// property, especially for trivial initialization).
 inline OIIO_CONSTEXPR14 size_t
 strhash (string_view s)

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -55,6 +55,13 @@ OIIO_NAMESPACE_BEGIN
 /// algorthms that would work on a "const std::string &" will also work
 /// on a ustring.
 ///
+/// Note that like a `char*`, but unlike a `std::string`, a ustring is not
+/// allowed to contain any embedded NUL ('\0') characters. When constructing
+/// ustrings from a std::string or a string_view, the contents will be
+/// truncated at the point of any NUL character. This is done to ensure that
+/// ustring::c_str() refers to the same C-style character sequence as the
+/// ustring itself or ustring::string().
+///
 /// Usage guidelines:
 ///
 /// Compared to standard strings, ustrings have several advantages:


### PR DESCRIPTION
It turns out that this can crop up all the time, sometimes from
malformed metadata inside image files. We weren't noticing it because
in many cases, things ended up being turned into ustrings twice, and
the sequence string-with-nuls -> ustring() -> c_str() -> ustring()
will launder it. As I was tracking down and eliminating some of the
double ustring constructions, the metadata strings that were malformed
all along started becoming symptomatic.

Bad paradoxes follow from a ustring contain embedded NUL characters,
including ustring.c_str() and ustring.string() being different
character sequences, as well as ustring.hash() not being equal to
strhash(ustring.c_str()). One should definitely be able to count on
ustring(cstring) == ustring(ustring(cstring).c_str()).

So this patch checks for embedded NUL characters at the appropriate
time of ustring construction, and truncates the character sequence at
the point of any internal NUL character.
