### PR TITLE
Split fmt setup into detail/fmt.h, fix fmt ostream problem

### DIFF
--- a/src/include/OpenImageIO/detail/fmt.h
+++ b/src/include/OpenImageIO/detail/fmt.h
@@ -1,0 +1,43 @@
+// Copyright 2008-present Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio
+
+#pragma once
+#define OIIO_FMT_H
+
+#include <OpenImageIO/platform.h>
+
+// We want the header-only implemention of fmt
+#ifndef FMT_HEADER_ONLY
+#    define FMT_HEADER_ONLY
+#endif
+
+// Disable fmt exceptions
+#ifndef FMT_EXCEPTIONS
+#    define FMT_EXCEPTIONS 0
+#endif
+
+// Use the grisu fast floating point formatting for old fmt versions
+// (irrelevant for >= 7.1).
+#ifndef FMT_USE_GRISU
+#    define FMT_USE_GRISU 1
+#endif
+
+// fmt 8.1 stopped automatically enabling formatting of anything that supports
+// ostream output. This breaks a lot! Re-enable this old behavior.
+#ifndef FMT_DEPRECATED_OSTREAM
+#    define FMT_DEPRECATED_OSTREAM 1
+#endif
+
+#if OIIO_GNUC_VERSION >= 70000
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
+#include <OpenImageIO/detail/fmt/format.h>
+#include <OpenImageIO/detail/fmt/ostream.h>
+#include <OpenImageIO/detail/fmt/printf.h>
+
+#if OIIO_GNUC_VERSION >= 70000
+#    pragma GCC diagnostic pop
+#endif

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -26,29 +26,10 @@
 #include <OpenImageIO/platform.h>
 #include <OpenImageIO/string_view.h>
 
+#include <OpenImageIO/detail/fmt.h>
 #include <OpenImageIO/detail/farmhash.h>
 
-#if OIIO_GNUC_VERSION >= 70000
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-#ifndef FMT_HEADER_ONLY
-#    define FMT_HEADER_ONLY
-#endif
-#ifndef FMT_EXCEPTIONS
-#    define FMT_EXCEPTIONS 0
-#endif
-#ifndef FMT_USE_GRISU
-#    define FMT_USE_GRISU 1
-#endif
-#include "detail/fmt/ostream.h"
-#include "detail/fmt/format.h"
-#include "detail/fmt/printf.h"
-#if OIIO_GNUC_VERSION >= 70000
-#    pragma GCC diagnostic pop
-#endif
-
-// Allow client software to know if this version of OIIO as Strutil::sprintf
+// Allow client software to know if this version of OIIO has Strutil::sprintf
 #define OIIO_HAS_SPRINTF 1
 
 // Allow client software to know (and to determine, by setting this value


### PR DESCRIPTION
The very latest fmt master changes a behavior: fmt functions no longer
automatically know how to format any type that can output to an
ostream, and instead need custom formtter objects. This breaks A LOT.
Fix by defining the preprocessor symbol `FMT_DEPRECATED_OSTREAM`,
which restores the old behavior (for now, at least).

While I was at it, I moved the fmt inclusion logic out of strutil.h
and into a new separate header, detail/fmt.h. This is in turn included
from strutil.h, so nothing in user code needs to change.

