### PR TITLE
Mark a bunch of long-deprecated things as OIIO_DEPRECATED

### DIFF
--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -455,7 +455,8 @@ convert_file(const std::string& in_filename, const std::string& out_filename)
                 // Need to do it by hand for some reason.  Future expansion in which
                 // only a subset of channels are copied, or some such.
                 std::vector<char> pixels((size_t)outspec.image_bytes(true));
-                ok = in->read_image(outspec.format, &pixels[0]);
+                ok = in->read_image(subimage, miplevel, 0, outspec.nchannels,
+                                    outspec.format, &pixels[0]);
                 if (!ok) {
                     std::cerr << "iconvert ERROR reading \"" << in_filename
                               << "\" : " << in->geterror() << "\n";

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -2376,16 +2376,19 @@ bool OIIO_API deep_holdout (ImageBuf &dst, const ImageBuf &src,
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+//OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool fill (ImageBuf &dst, const float *values,
                   ROI roi={}, int nthreads=0) {
     int nc (roi.defined() ? roi.nchannels() : dst.nchannels());
     return fill (dst, {values, nc}, roi, nthreads);
 }
+//OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool fill (ImageBuf &dst, const float *top, const float *bottom,
                   ROI roi={}, int nthreads=0) {
     int nc (roi.defined() ? roi.nchannels() : dst.nchannels());
     return fill (dst, {top, nc}, {bottom, nc}, roi, nthreads);
 }
+//OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool fill (ImageBuf &dst, const float *topleft, const float *topright,
                   const float *bottomleft, const float *bottomright,
                   ROI roi={}, int nthreads=0) {
@@ -2394,6 +2397,7 @@ inline bool fill (ImageBuf &dst, const float *topleft, const float *topright,
                  {bottomright, nc}, roi, nthreads);
 }
 
+//OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool checker (ImageBuf &dst, int width, int height, int depth,
                      const float *color1, const float *color2,
                      int xoffset=0, int yoffset=0, int zoffset=0,
@@ -2403,44 +2407,54 @@ inline bool checker (ImageBuf &dst, int width, int height, int depth,
                     xoffset, yoffset, zoffset, roi, nthreads);
 }
 
+//OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool add (ImageBuf &dst, const ImageBuf &A, const float *B,
                  ROI roi={}, int nthreads=0) {
     return add (dst, A, {B,A.nchannels()}, roi, nthreads);
 }
+//OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool sub (ImageBuf &dst, const ImageBuf &A, const float *B,
                  ROI roi={}, int nthreads=0) {
     return sub (dst, A, {B,A.nchannels()}, roi, nthreads);
 }
+//OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool absdiff (ImageBuf &dst, const ImageBuf &A, const float *B,
                      ROI roi={}, int nthreads=0) {
     return absdiff (dst, A, cspan<float>(B,A.nchannels()), roi, nthreads);
 }
+//OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool mul (ImageBuf &dst, const ImageBuf &A, const float *B,
                  ROI roi={}, int nthreads=0) {
     return mul (dst, A, {B, A.nchannels()}, roi, nthreads);
 }
+//OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool div (ImageBuf &dst, const ImageBuf &A, const float *B,
                  ROI roi={}, int nthreads=0) {
     return div (dst, A, {B, A.nchannels()}, roi, nthreads);
 }
+//OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool mad (ImageBuf &dst, const ImageBuf &A, const float *B,
                  const ImageBuf &C, ROI roi={}, int nthreads=0) {
     return mad (dst, A, {B, A.nchannels()}, C, roi, nthreads);
 }
+//OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool mad (ImageBuf &dst, const ImageBuf &A, const ImageBuf &B,
                  const float *C, ROI roi={}, int nthreads=0) {
     return mad (dst, A, C, B, roi, nthreads);
 }
+//OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool mad (ImageBuf &dst, const ImageBuf &A, const float *B,
                  const float *C, ROI roi={}, int nthreads=0) {
     return mad (dst, A, {B, A.nchannels()}, {C, A.nchannels()}, roi, nthreads);
 }
 
+//OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool pow (ImageBuf &dst, const ImageBuf &A, const float *B,
                  ROI roi={}, int nthreads=0) {
     return pow (dst, A, {B, A.nchannels()}, roi, nthreads);
 }
 
+//OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool channel_sum (ImageBuf &dst, const ImageBuf &src,
                          const float *weights=nullptr, ROI roi={},
                          int nthreads=0) {
@@ -2448,6 +2462,7 @@ inline bool channel_sum (ImageBuf &dst, const ImageBuf &src,
                         roi, nthreads);
 }
 
+//OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool channels (ImageBuf &dst, const ImageBuf &src,
                       int nchannels, const int *channelorder,
                       const float *channelvalues=nullptr,
@@ -2460,6 +2475,7 @@ inline bool channels (ImageBuf &dst, const ImageBuf &src,
                      shuffle_channel_names, nthreads);
 }
 
+//OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool clamp (ImageBuf &dst, const ImageBuf &src,
                    const float *min=nullptr, const float *max=nullptr,
                    bool clampalpha01 = false,
@@ -2469,12 +2485,14 @@ inline bool clamp (ImageBuf &dst, const ImageBuf &src,
                   roi, nthreads);
 }
 
+//OIIO_DEPRECATED("use version that takes span<> instead of raw pointer (2.0)")
 inline bool isConstantColor (const ImageBuf &src, float *color,
                              ROI roi={}, int nthreads=0) {
     int nc = roi.defined() ? std::min(roi.chend,src.nchannels()) : src.nchannels();
     return isConstantColor (src, {color, color ? nc : 0}, roi, nthreads);
 }
 
+//OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool color_count (const ImageBuf &src, imagesize_t *count,
                          int ncolors, const float *color,
                          const float *eps=nullptr,
@@ -2485,6 +2503,7 @@ inline bool color_count (const ImageBuf &src, imagesize_t *count,
                         roi, nthreads);
 }
 
+//OIIO_DEPRECATED("use version that takes span<> instead of raw pointer (2.0)")
 inline bool color_range_check (const ImageBuf &src, imagesize_t *lowcount,
                                imagesize_t *highcount, imagesize_t *inrangecount,
                                const float *low, const float *high,
@@ -2494,6 +2513,7 @@ inline bool color_range_check (const ImageBuf &src, imagesize_t *lowcount,
                               roi, nthreads);
 }
 
+//OIIO_DEPRECATED("use version that takes cspan<> instead of raw pointer (2.0)")
 inline bool render_text (ImageBuf &dst, int x, int y, string_view text,
                          int fontsize, string_view fontname,
                          const float *textcolor) {

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1292,10 +1292,12 @@ public:
     // eventually be removed. Try to replace these calls with ones to the
     // new variety of read_scanlines that takes an explicit subimage and
     // miplevel. These old versions are NOT THREAD-SAFE.
+    OIIO_DEPRECATED("replace with version that takes subimage & miplevel parameters (2.0)")
     bool read_scanlines (int ybegin, int yend, int z,
                          TypeDesc format, void *data,
                          stride_t xstride=AutoStride,
                          stride_t ystride=AutoStride);
+    OIIO_DEPRECATED("replace with version that takes subimage & miplevel parameters (2.0)")
     bool read_scanlines (int ybegin, int yend, int z,
                          int chbegin, int chend,
                          TypeDesc format, void *data,
@@ -1397,10 +1399,12 @@ public:
     // eventually be removed. Try to replace these calls with ones to the
     // new variety of read_tiles that takes an explicit subimage and
     // miplevel. These old versions are NOT THREAD-SAFE.
+    OIIO_DEPRECATED("replace with version that takes subimage & miplevel parameters (2.0)")
     bool read_tiles (int xbegin, int xend, int ybegin, int yend,
                      int zbegin, int zend, TypeDesc format, void *data,
                      stride_t xstride=AutoStride, stride_t ystride=AutoStride,
                      stride_t zstride=AutoStride);
+    OIIO_DEPRECATED("replace with version that takes subimage & miplevel parameters (2.0)")
     bool read_tiles (int xbegin, int xend, int ybegin, int yend,
                      int zbegin, int zend, int chbegin, int chend,
                      TypeDesc format, void *data, stride_t xstride=AutoStride,
@@ -1432,7 +1436,8 @@ public:
     /// @param  miplevel    The MIP level to read (0 is the highest
     ///                     resolution level).
     /// @param  chbegin/chend
-    ///                     The channel range to read.
+    ///                     The channel range to read. If chend is -1, it
+    ///                     will be set to spec.nchannels.
     /// @param  format      A TypeDesc describing the type of `data`.
     /// @param  data        Pointer to the pixel data.
     /// @param  xstride/ystride/zstride
@@ -1455,12 +1460,14 @@ public:
     // eventually be removed. Try to replace these calls with ones to the
     // new variety of read_image that takes an explicit subimage and
     // miplevel. These old versions are NOT THREAD-SAFE.
+    OIIO_DEPRECATED("replace with version that takes subimage & miplevel parameters (2.0)")
     virtual bool read_image (TypeDesc format, void *data,
                              stride_t xstride=AutoStride,
                              stride_t ystride=AutoStride,
                              stride_t zstride=AutoStride,
                              ProgressCallback progress_callback=NULL,
                              void *progress_callback_data=NULL);
+    OIIO_DEPRECATED("replace with version that takes subimage & miplevel parameters (2.0)")
     virtual bool read_image (int chbegin, int chend,
                              TypeDesc format, void *data,
                              stride_t xstride=AutoStride,
@@ -1468,8 +1475,10 @@ public:
                              stride_t zstride=AutoStride,
                              ProgressCallback progress_callback=NULL,
                              void *progress_callback_data=NULL);
+    OIIO_DEPRECATED("replace with version that takes subimage & miplevel parameters (2.0)")
     bool read_image (float *data) {
-        return read_image (TypeDesc::FLOAT, data);
+        return read_image (current_subimage(), current_miplevel(),
+                           0, -1, TypeFloat, data);
     }
 #endif
 
@@ -1533,12 +1542,14 @@ public:
 
 #ifndef OIIO_DOXYGEN
     // DEPRECATED(1.9), Now just used for back compatibility:
+    OIIO_DEPRECATED("replace with version that takes subimage & miplevel parameters (2.0)")
     bool read_native_deep_scanlines (int ybegin, int yend, int z,
                              int chbegin, int chend, DeepData &deepdata) {
         return read_native_deep_scanlines (current_subimage(), current_miplevel(),
                                            ybegin, yend, z,
                                            chbegin, chend, deepdata);
     }
+    OIIO_DEPRECATED("replace with version that takes subimage & miplevel parameters (2.0)")
     bool read_native_deep_tiles (int xbegin, int xend, int ybegin, int yend,
                                  int zbegin, int zend, int chbegin, int chend,
                                  DeepData &deepdata) {
@@ -1546,6 +1557,7 @@ public:
                                        xbegin, xend, ybegin, yend,
                                        zbegin, zend, chbegin, chend, deepdata);
     }
+    OIIO_DEPRECATED("replace with version that takes subimage & miplevel parameters (2.0)")
     bool read_native_deep_image (DeepData &deepdata) {
         return read_native_deep_image (current_subimage(), current_miplevel(),
                                        deepdata);

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1134,20 +1134,12 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
         }
         auto in = ImageInput::open(m_name.string(), m_configspec.get(),
                                    m_rioproxy);
-        bool ok = true;
         if (in) {
             in->threads(threads());  // Pass on our thread policy
-            if (subimage || miplevel) {
-                ImageSpec newspec;
-                ok &= in->seek_subimage(subimage, miplevel, newspec);
-            }
-            if (ok) {
-                ok &= in->read_image(chbegin, chend, m_spec.format,
-                                     m_localpixels, AutoStride, AutoStride,
-                                     AutoStride, progress_callback,
+            bool ok = in->read_image(subimage, miplevel, chbegin, chend,
+                                     m_spec.format, m_localpixels, AutoStride,
+                                     AutoStride, AutoStride, progress_callback,
                                      progress_callback_data);
-            }
-
             in->close();
             if (ok) {
                 m_pixels_valid = true;

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -860,8 +860,9 @@ ImageInput::read_image(TypeDesc format, void* data, stride_t xstride,
                        ProgressCallback progress_callback,
                        void* progress_callback_data)
 {
-    return read_image(0, -1, format, data, xstride, ystride, zstride,
-                      progress_callback, progress_callback_data);
+    return read_image(current_subimage(), current_miplevel(), 0, -1, format,
+                      data, xstride, ystride, zstride, progress_callback,
+                      progress_callback_data);
 }
 
 

--- a/src/python/py_imageinput.cpp
+++ b/src/python/py_imageinput.cpp
@@ -115,24 +115,6 @@ ImageInput_read_tiles(ImageInput& self, int subimage, int miplevel, int xbegin,
 
 
 py::object
-ImageInput_read_native_deep_scanlines_old(ImageInput& self, int ybegin,
-                                          int yend, int z, int chbegin,
-                                          int chend)
-{
-    std::unique_ptr<DeepData> dd;
-    bool ok = true;
-    {
-        py::gil_scoped_release gil;
-        dd.reset(new DeepData);
-        ok = self.read_native_deep_scanlines(ybegin, yend, z, chbegin, chend,
-                                             *dd);
-    }
-    return ok ? py::cast(dd.release()) : py::none();
-}
-
-
-
-py::object
 ImageInput_read_native_deep_scanlines(ImageInput& self, int subimage,
                                       int miplevel, int ybegin, int yend, int z,
                                       int chbegin, int chend)
@@ -342,10 +324,12 @@ declare_imageinput(py::module& m)
             "read_native_deep_scanlines",  // DEPRECATED(1.9), keep for back compatibility
             [](ImageInput& self, int ybegin, int yend, int z, int chbegin,
                int chend) {
-                return ImageInput_read_native_deep_scanlines_old(self, ybegin,
-                                                                 yend, z,
-                                                                 chbegin,
-                                                                 chend);
+                int subimage = self.current_subimage();
+                int miplevel = self.current_miplevel();
+                return ImageInput_read_native_deep_scanlines(self, subimage,
+                                                             miplevel, ybegin,
+                                                             yend, z, chbegin,
+                                                             chend);
             },
             "ybegin"_a, "yend"_a, "z"_a, "chbegin"_a, "chend"_a)
         .def("read_native_deep_tiles", &ImageInput_read_native_deep_tiles,


### PR DESCRIPTION
...and stop using them internally as well.

For some of the IBA functions, we were unable to fully mark them as
OIIO_DEPRECATED (so instead that hint is commentd out) because the
function signatures of the deprecated and new ones can be
ambiguous. We're just going to have to delete those when we are at a
compatibility break point, without going through a period where they
are present but marked as deprecated.
