### PR TITLE
V3fParam

### DIFF
--- a/THIRD-PARTY.md
+++ b/THIRD-PARTY.md
@@ -34,6 +34,11 @@ SPDX-License-Identifier: BSD-3-Clause
   The sample OpenColorIO configurations in our testsuite are borrowed from
   this ASWF project, also BSD-3-Clause licensed.
 
+* OpenEXR/Imath (c) Copyright contributors to the OpenEXR Project.
+  https://github.com/AcademySoftwareFoundation/Imath
+
+  Some templates in vecparam.h were first developed for Imath.
+
 * DPX reader/writer (c) Copyright 2009 Patrick A. Palmer.
   https://github.com/patrickpalmer/dpx
 

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -19,6 +19,7 @@
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/parallel.h>
 #include <OpenImageIO/span.h>
+#include <OpenImageIO/vecparam.h>
 
 #include <limits>
 
@@ -767,31 +768,25 @@ bool OIIO_API fit (ImageBuf &dst, const ImageBuf &src, Filter2D *filter,
 /// filter is used to weight the `src` pixels falling underneath it for each
 /// `dst` pixel; the filter's size is expressed in pixel units of the `dst`
 /// image.
-///
-/// Note: C++ users must include `ImathMatrix.h` (or `OpenImageIO/Imath.h`)
-/// prior to including `imagebufalgo.h` to see define the Imath::M33f class,
-/// or else the `warp()` function declaration will not be visible.
 
-#ifdef INCLUDED_IMATHMATRIX_H
-ImageBuf OIIO_API warp (const ImageBuf &src, const Imath::M33f &M,
+ImageBuf OIIO_API warp (const ImageBuf &src, M33fParam M,
                         string_view filtername = string_view(),
                         float filterwidth = 0.0f, bool recompute_roi = false,
                         ImageBuf::WrapMode wrap = ImageBuf::WrapDefault,
                         ROI roi={}, int nthreads=0);
-ImageBuf OIIO_API warp (const ImageBuf &src, const Imath::M33f &M,
+ImageBuf OIIO_API warp (const ImageBuf &src, M33fParam M,
                         const Filter2D *filter, bool recompute_roi = false,
                         ImageBuf::WrapMode wrap = ImageBuf::WrapDefault,
                         ROI roi = {}, int nthreads=0);
-bool OIIO_API warp (ImageBuf &dst, const ImageBuf &src, const Imath::M33f &M,
+bool OIIO_API warp (ImageBuf &dst, const ImageBuf &src, M33fParam M,
                     string_view filtername = string_view(),
                     float filterwidth = 0.0f, bool recompute_roi = false,
                     ImageBuf::WrapMode wrap = ImageBuf::WrapDefault,
                     ROI roi={}, int nthreads=0);
-bool OIIO_API warp (ImageBuf &dst, const ImageBuf &src, const Imath::M33f &M,
+bool OIIO_API warp (ImageBuf &dst, const ImageBuf &src, M33fParam M,
                     const Filter2D *filter, bool recompute_roi = false,
                     ImageBuf::WrapMode wrap = ImageBuf::WrapDefault,
                     ROI roi = {}, int nthreads=0);
-#endif
 /// @}
 
 
@@ -1803,20 +1798,13 @@ inline bool colorconvert (float *color, int nchannels,
 ///
 /// @version 2.1+
 ///
-/// Note: C++ users must include `ImathMatrix.h` (or `OpenImageIO/Imath.h`)
-/// prior to including `imagebufalgo.h` to see define the Imath::M44f class,
-/// or else the `colormatrixtransform()` function declaration will not be
-/// visible.
-
-#ifdef INCLUDED_IMATHMATRIX_H
 ImageBuf OIIO_API colormatrixtransform (const ImageBuf &src,
-                                    const Imath::M44f& M, bool unpremult=true,
-                                    ROI roi={}, int nthreads=0);
+                                        M44fParam M, bool unpremult=true,
+                                        ROI roi={}, int nthreads=0);
 /// Write to an existing image `dst` (allocating if it is uninitialized).
 bool OIIO_API colormatrixtransform (ImageBuf &dst, const ImageBuf &src,
-                                    const Imath::M44f& M, bool unpremult=true,
+                                    M44fParam M, bool unpremult=true,
                                     ROI roi={}, int nthreads=0);
-#endif
 
 
 /// Return a copy of the pixels of `src` within the ROI, applying an

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -277,9 +277,9 @@ typedef vfloat8 float8;
 } // namespace simd
 
 
-// Force has_subscript to understand that our simd::vfloat3 counts as a
+// Force has_subscript_N to understand that our simd::vfloat3 counts as a
 // 3-vector, even though its padding to 4 values makes it look the wrong size.
-template<> struct has_subscript<simd::vfloat3, float, 3> : public std::true_type { };
+template<> struct has_subscript_N<simd::vfloat3, float, 3> : public std::true_type { };
 
 
 
@@ -2185,7 +2185,7 @@ public:
 
     /// Construct from something that looks like a generic 3-vector class,
     /// having an operator[] that returns a float and is the size of 3 floats.
-    template<typename V, OIIO_ENABLE_IF(has_subscript<V, float, 3>::value
+    template<typename V, OIIO_ENABLE_IF(has_subscript_N<V, float, 3>::value
                                         && !has_xyz<V, float>::value)>
     vfloat3(const V& v) : vfloat3(v[0], v[1], v[2]) { }
 

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -10,11 +10,11 @@
 
 #pragma once
 
-#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/simd.h>
 #include <OpenImageIO/ustring.h>
 #include <OpenImageIO/varyingref.h>
+#include <OpenImageIO/vecparam.h>
 
 
 // Define symbols that let client applications determine if newly added
@@ -22,6 +22,15 @@
 #define OIIO_TEXTURESYSTEM_SUPPORTS_CLOSE 1
 
 #define OIIO_TEXTURESYSTEM_SUPPORTS_STOCHASTIC 1
+
+#ifndef INCLUDED_IMATHVEC_H
+// Placeholder declaration for Imath::V3f if no Imath headers have been
+// included.
+namespace Imath {
+template <class T> class Vec3;
+using V3f = Vec3<float>;
+}
+#endif
 
 
 OIIO_NAMESPACE_BEGIN
@@ -963,8 +972,8 @@ public:
     ///             plugin.
     ///
     virtual bool texture3d (ustring filename, TextureOpt &options,
-                            const Imath::V3f &P, const Imath::V3f &dPdx,
-                            const Imath::V3f &dPdy, const Imath::V3f &dPdz,
+                            V3fParam P, V3fParam dPdx,
+                            V3fParam dPdy, V3fParam dPdz,
                             int nchannels, float *result,
                             float *dresultds=nullptr, float *dresultdt=nullptr,
                             float *dresultdr=nullptr) = 0;
@@ -973,8 +982,8 @@ public:
     /// a texture handle and per-thread info.
     virtual bool texture3d (TextureHandle *texture_handle,
                             Perthread *thread_info, TextureOpt &options,
-                            const Imath::V3f &P, const Imath::V3f &dPdx,
-                            const Imath::V3f &dPdy, const Imath::V3f &dPdz,
+                            V3fParam P, V3fParam dPdx,
+                            V3fParam dPdy, V3fParam dPdz,
                             int nchannels, float *result,
                             float *dresultds=nullptr, float *dresultdt=nullptr,
                             float *dresultdr=nullptr) = 0;
@@ -985,16 +994,16 @@ public:
     // Return true if the file is found and could be opened by an
     // available ImageIO plugin, otherwise return false.
     virtual bool shadow (ustring filename, TextureOpt &options,
-                         const Imath::V3f &P, const Imath::V3f &dPdx,
-                         const Imath::V3f &dPdy, float *result,
+                         V3fParam P, V3fParam dPdx,
+                         V3fParam dPdy, float *result,
                          float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
 
     // Slightly faster version of texture3d() lookup if the app already
     // has a texture handle and per-thread info.
     virtual bool shadow (TextureHandle *texture_handle, Perthread *thread_info,
                          TextureOpt &options,
-                         const Imath::V3f &P, const Imath::V3f &dPdx,
-                         const Imath::V3f &dPdy, float *result,
+                         V3fParam P, V3fParam dPdx,
+                         V3fParam dPdy, float *result,
                          float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
 
     /// Perform a filtered directional environment map lookup in the
@@ -1054,16 +1063,16 @@ public:
     ///             found or could not be opened by any available ImageIO
     ///             plugin.
     virtual bool environment (ustring filename, TextureOpt &options,
-                              const Imath::V3f &R, const Imath::V3f &dRdx,
-                              const Imath::V3f &dRdy, int nchannels, float *result,
+                              V3fParam R, V3fParam dRdx,
+                              V3fParam dRdy, int nchannels, float *result,
                               float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
 
     /// Slightly faster version of environment() if the app already has a
     /// texture handle and per-thread info.
     virtual bool environment (TextureHandle *texture_handle,
                               Perthread *thread_info, TextureOpt &options,
-                              const Imath::V3f &R, const Imath::V3f &dRdx,
-                              const Imath::V3f &dRdy, int nchannels, float *result,
+                              V3fParam R, V3fParam dRdx,
+                              V3fParam dRdy, int nchannels, float *result,
                               float *dresultds=nullptr, float *dresultdt=nullptr) = 0;
 
     /// @}

--- a/src/include/OpenImageIO/vecparam.h
+++ b/src/include/OpenImageIO/vecparam.h
@@ -31,7 +31,7 @@ OIIO_NAMESPACE_BEGIN
 /// `Base` and seems to be the right size to hold exactly those members and
 /// nothing more.
 ///
-/// `has_subscript<T,Base,Nelem>` detects if class `T` can perform `T[int]`
+/// `has_subscript_N<T,Base,Nelem>` detects if class `T` can perform `T[int]`
 /// to yield a `Base`, and that it seems to be exactly the right size to
 /// hold `Nelem` of those elements.
 ///
@@ -139,10 +139,10 @@ public:
 
 
 
-/// `has_subscript<T,Base,Nelem>::value` will be true if type `T` has
+/// `has_subscript_N<T,Base,Nelem>::value` will be true if type `T` has
 /// subscripting syntax, a `T[int]` returns a `Base`, and the size of a `T`
 /// is exactly big enough to hold `Nelem` `Base` values.
-template<typename T, typename Base, int Nelem> struct has_subscript {
+template<typename T, typename Base, int Nelem> struct has_subscript_N {
 private:
     typedef char Yes[1];
     typedef char No[2];
@@ -166,18 +166,18 @@ public:
 
 
 
-/// C arrays of just the right length also are qualified for has_subscript.
+/// C arrays of just the right length also are qualified for has_subscript_N.
 template<typename Base, int Nelem>
-struct has_subscript<Base[Nelem], Base, Nelem> : public std::true_type {
+struct has_subscript_N<Base[Nelem], Base, Nelem> : public std::true_type {
 };
 
 
 
-/// `has_double_subscript<T,Base,Rows,Cols>::value` will be true if type `T`
+/// `has_double_subscript_RC<T,Base,Rows,Cols>::value` will be true if type `T`
 /// has 2-level subscripting syntax, a `T[int][int]` returns a `Base`, and
 /// the size of a `T` is exactly big enough to hold `R*C` `Base` values.
 template<typename T, typename Base, int Rows, int Cols>
-struct has_double_subscript {
+struct has_double_subscript_RC {
 private:
     typedef char Yes[1];
     typedef char No[2];
@@ -200,9 +200,9 @@ public:
 };
 
 
-/// C arrays of just the right length also are qualified for has_double_subscript.
+/// C arrays of just the right length also are qualified for has_double_subscript_RC.
 template<typename Base, int Rows, int Cols>
-struct has_double_subscript<Base[Rows][Cols], Base, Rows, Cols>
+struct has_double_subscript_RC<Base[Rows][Cols], Base, Rows, Cols>
     : public std::true_type {
 };
 
@@ -249,7 +249,7 @@ public:
     /// Construct from anything that looks like a 3-vector, having `[]`
     /// component access returning a `T`, and has exactly the size of a
     /// `T[3]`.
-    template<typename V, OIIO_ENABLE_IF(has_subscript<V, T, 3>::value
+    template<typename V, OIIO_ENABLE_IF(has_subscript_N<V, T, 3>::value
                                         && !has_xyz<V, T>::value)>
     OIIO_HOSTDEVICE constexpr Vec3Param(const V& v) noexcept
         : x(v[0])
@@ -310,7 +310,7 @@ public:
     /// We can construct a MatrixParam out of anything that has the size
     /// of a `T[S][S]` and presents a `[][]` subscript operator.
     template<typename M,
-             OIIO_ENABLE_IF(has_double_subscript<M, T, Size, Size>::value)>
+             OIIO_ENABLE_IF(has_double_subscript_RC<M, T, Size, Size>::value)>
     OIIO_HOSTDEVICE constexpr MatrixParam(const M& m) noexcept
         : m_ptr((const T*)&m)
     {

--- a/src/include/OpenImageIO/vecparam.h
+++ b/src/include/OpenImageIO/vecparam.h
@@ -1,0 +1,377 @@
+// Copyright 2008-present Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio
+
+#pragma once
+#define OIIO_VECPROXY_H 1
+
+#include <algorithm>
+#include <cstring>
+
+#include <OpenImageIO/platform.h>
+
+
+OIIO_NAMESPACE_BEGIN
+
+// NOTE: These interoperable type templates were copied from the
+// [Imath project](http://github.com/AcademySoftwareFoundation/imath),
+// licensed under the same BSD-3-clause license as OpenImageIO.
+
+
+/// @{
+/// @name Detecting interoperable linear algebra types.
+///
+/// In order to construct or assign from external "compatible" types without
+/// prior knowledge of their definitions, we have a few helper type traits.
+/// The intent of these is to allow custom linear algebra types in an
+/// application that have seamless conversion to and from similar types.
+///
+/// `has_xy<T,Base>`, `has_xyz<T,Base>`, `has_xyzw<T,Base>` detect if class
+/// `T` has the right set of elements `.x`, `.y`, `.z`, `.w`, all of type
+/// `Base` and seems to be the right size to hold exactly those members and
+/// nothing more.
+///
+/// `has_subscript<T,Base,Nelem>` detects if class `T` can perform `T[int]`
+/// to yield a `Base`, and that it seems to be exactly the right size to
+/// hold `Nelem` of those elements.
+///
+/// This is not exact. It's possible that for a particular user-defined
+/// type, this may yield a false negative or false positive. For example:
+///   * A class for a 3-vector that contains an extra element of padding
+///     so that it will have the right size and alignment to use 4-wide
+///     SIMD math ops will appear to be the wrong size.
+///   * A `std::vector<T>` is subscriptable and might have N elements at
+///     runtime, but the size is dynamic and so would fail this test.
+///   * A foreign type may have .x, .y, .z that are not matching our base
+///     type but we still want it to work (with appropriate conversions).
+///
+/// In these cases, user code may declare an exception -- for example,
+/// stating that `mytype` should be considered a subscriptable 3-vector:
+///
+///     template<>
+///     struct OIIO::has_subscript<mytype, float, 3> : public std::true_type { };
+///
+/// And similarly, user code may correct a potential false positive (that
+/// is, a `mytype` looks like it should be a 3-vector, but we don't want any
+/// implicit conversions to happen):
+///
+///     template<typename B, int N>
+///     struct OIIO::has_subscript<mytype, B, N> : public std::false_type { };
+///
+
+
+/// `has_xy<T,Base>::value` will be true if type `T` has member variables
+/// `.x` and `.y`, all of type `Base`, and the size of a `T` is exactly big
+/// enough to hold 2 Base values.
+template<typename T, typename Base> struct has_xy {
+private:
+    typedef char Yes[1];
+    typedef char No[2];
+
+    // Valid only if .x, .y exist and are the right type: return a Yes.
+    template<typename C,
+             OIIO_ENABLE_IF(std::is_same<decltype(C().x), Base>::value),
+             OIIO_ENABLE_IF(std::is_same<decltype(C().y), Base>::value)>
+    static Yes& test(int);
+
+    // Fallback, default to returning a No.
+    template<typename C> static No& test(...);
+
+public:
+    enum {
+        value = (sizeof(test<T>(0)) == sizeof(Yes)
+                 && sizeof(T) == 2 * sizeof(Base))
+    };
+};
+
+
+/// `has_xyz<T,Base>::value` will be true if type `T` has member variables
+/// `.x`, `.y`, and `.z`, all of type `Base`, and the size of a `T` is
+/// exactly big enough to hold 3 Base values.
+template<typename T, typename Base> struct has_xyz {
+private:
+    typedef char Yes[1];
+    typedef char No[2];
+
+    // Valid only if .x, .y, .z exist and are the right type: return a Yes.
+    template<typename C,
+             OIIO_ENABLE_IF(std::is_same<decltype(C().x), Base>::value),
+             OIIO_ENABLE_IF(std::is_same<decltype(C().y), Base>::value),
+             OIIO_ENABLE_IF(std::is_same<decltype(C().z), Base>::value)>
+    static Yes& test(int);
+
+    // Fallback, default to returning a No.
+    template<typename C> static No& test(...);
+
+public:
+    enum {
+        value = (sizeof(test<T>(0)) == sizeof(Yes)
+                 && sizeof(T) == 3 * sizeof(Base))
+    };
+};
+
+
+/// `has_xyzw<T,Base>::value` will be true if type `T` has member variables
+/// `.x`, `.y`, `.z`, and `.w`, all of type `Base`, and the size of a `T` is
+/// exactly big enough to hold 4 Base values.
+template<typename T, typename Base> struct has_xyzw {
+private:
+    typedef char Yes[1];
+    typedef char No[2];
+
+    // Valid only if .x, .y, .z, .w exist and are the right type: return a Yes.
+    template<typename C,
+             OIIO_ENABLE_IF(std::is_same<decltype(C().x), Base>::value),
+             OIIO_ENABLE_IF(std::is_same<decltype(C().y), Base>::value),
+             OIIO_ENABLE_IF(std::is_same<decltype(C().z), Base>::value),
+             OIIO_ENABLE_IF(std::is_same<decltype(C().w), Base>::value)>
+    static Yes& test(int);
+
+    // Fallback, default to returning a No.
+    template<typename C> static No& test(...);
+
+public:
+    enum {
+        value = (sizeof(test<T>(0)) == sizeof(Yes)
+                 && sizeof(T) == 4 * sizeof(Base))
+    };
+};
+
+
+
+/// `has_subscript<T,Base,Nelem>::value` will be true if type `T` has
+/// subscripting syntax, a `T[int]` returns a `Base`, and the size of a `T`
+/// is exactly big enough to hold `Nelem` `Base` values.
+template<typename T, typename Base, int Nelem> struct has_subscript {
+private:
+    typedef char Yes[1];
+    typedef char No[2];
+
+    // Valid only if T[] is possible and is the right type: return a Yes.
+    template<
+        typename C,
+        OIIO_ENABLE_IF(std::is_same<typename std::decay<decltype(C()[0])>::type,
+                                    Base>::value)>
+    static Yes& test(int);
+
+    // Fallback, default to returning a No.
+    template<typename C> static No& test(...);
+
+public:
+    enum {
+        value = (sizeof(test<T>(0)) == sizeof(Yes)
+                 && sizeof(T) == Nelem * sizeof(Base))
+    };
+};
+
+
+
+/// C arrays of just the right length also are qualified for has_subscript.
+template<typename Base, int Nelem>
+struct has_subscript<Base[Nelem], Base, Nelem> : public std::true_type {
+};
+
+
+
+/// `has_double_subscript<T,Base,Rows,Cols>::value` will be true if type `T`
+/// has 2-level subscripting syntax, a `T[int][int]` returns a `Base`, and
+/// the size of a `T` is exactly big enough to hold `R*C` `Base` values.
+template<typename T, typename Base, int Rows, int Cols>
+struct has_double_subscript {
+private:
+    typedef char Yes[1];
+    typedef char No[2];
+
+    // Valid only if T[][] is possible and is the right type: return a Yes.
+    template<typename C,
+             OIIO_ENABLE_IF(
+                 std::is_same<typename std::decay<decltype(C()[0][0])>::type,
+                              Base>::value)>
+    static Yes& test(int);
+
+    // Fallback, default to returning a No.
+    template<typename C> static No& test(...);
+
+public:
+    enum {
+        value = (sizeof(test<T>(0)) == sizeof(Yes)
+                 && sizeof(T) == (Rows * Cols) * sizeof(Base))
+    };
+};
+
+
+/// C arrays of just the right length also are qualified for has_double_subscript.
+template<typename Base, int Rows, int Cols>
+struct has_double_subscript<Base[Rows][Cols], Base, Rows, Cols>
+    : public std::true_type {
+};
+
+/// @}
+
+
+
+/// Vec3Param<T> is a helper class that lets us create an interface that takes
+/// a proxy for a `T[3]` analogue for use as a public API function parameter
+/// type, in order to not expose the underlying vector type.
+///
+/// For example, suppose we have a public function like this:
+///
+///     void foo(Vec3Param<float> v);
+///
+/// Then any of the following calls will work:
+///
+///     float array[3];
+///     foo(array);
+///
+///     foo(Imath::V3f(1,2,3));
+///
+template<typename T> class Vec3Param {
+public:
+    /// Construct directly from 3 floats.
+    OIIO_HOSTDEVICE constexpr Vec3Param(T x, T y, T z) noexcept
+        : x(x)
+        , y(y)
+        , z(z)
+    {
+    }
+
+    /// Construct from anything that looks like a 3-vector, having .x, .y, and
+    /// .z members of type T (and has exactly the size of a `T[3]`). This will
+    /// implicitly convert from an Imath::Vector3<T>, among other things.
+    template<typename V, OIIO_ENABLE_IF(has_xyz<V, T>::value)>
+    OIIO_HOSTDEVICE constexpr Vec3Param(const V& v) noexcept
+        : x(v.x)
+        , y(v.y)
+        , z(v.z)
+    {
+    }
+
+    /// Construct from anything that looks like a 3-vector, having `[]`
+    /// component access returning a `T`, and has exactly the size of a
+    /// `T[3]`.
+    template<typename V, OIIO_ENABLE_IF(has_subscript<V, T, 3>::value
+                                        && !has_xyz<V, T>::value)>
+    OIIO_HOSTDEVICE constexpr Vec3Param(const V& v) noexcept
+        : x(v[0])
+        , y(v[1])
+        , z(v[2])
+    {
+    }
+
+#ifdef INCLUDED_IMATHVEC_H
+    /// Only if ImathVec.h has been included, we can construct a Vec3Param<T>
+    /// out of an Imath::Vec3<T>.
+    OIIO_HOSTDEVICE constexpr operator const Imath::Vec3<T>&() const noexcept
+    {
+        return *(const Imath::Vec3<T>*)this;
+    }
+
+    /// Only if ImathVec.h has been included, we can implicitly convert a
+    /// `Vec3Param<T>` to a `Imath::Vec3<T>`.
+    OIIO_HOSTDEVICE constexpr const Imath::Vec3<T>& operator()() const noexcept
+    {
+        return *(const Imath::Vec3<T>*)this;
+    }
+#endif
+
+private:
+    // The internal representation is just the 3 values.
+    T x, y, z;
+};
+
+
+/// V3fParam is an alias for Vec3Param<float>
+using V3fParam = Vec3Param<float>;
+
+
+
+/// MatrixParam is a helper template that lets us create an interface that
+/// takes a proxy for a `T[S][S]` analogue for use as a public API function
+/// parameter type to pass a square matrix, in order to not expose the
+/// underlying matrix types. The common cases are given handy aliases:
+/// M33fParam and M33fParam for 3x3 and 4x4 float matrices, respectively
+/// (`MatrixParam<float,3>` and `MatrixParam<float,4>` are the long names).
+///
+/// For example, suppose we have a public function like this:
+///
+///     void foo(M33fParam v);
+///
+/// Then any of the following calls will work:
+///
+///     float array[3][3];
+///     foo(array);
+///
+///     foo(Imath::M33f(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1));
+///
+template<typename T, int S> class MatrixParam {
+public:
+    static constexpr int Size = S;
+
+    /// We can construct a MatrixParam out of anything that has the size
+    /// of a `T[S][S]` and presents a `[][]` subscript operator.
+    template<typename M,
+             OIIO_ENABLE_IF(has_double_subscript<M, T, Size, Size>::value)>
+    OIIO_HOSTDEVICE constexpr MatrixParam(const M& m) noexcept
+        : m_ptr((const T*)&m)
+    {
+    }
+
+#ifdef INCLUDED_IMATHMATRIX_H
+    /// Only if ImathMatrix.h has been included, we can construct a
+    /// MatrixParam<T,3> out of an Imath::Matrix33<T>.
+    template<typename ThisType = MatrixParam,
+             typename std::enable_if<ThisType::Size == 3, int>::type = 0>
+    OIIO_HOSTDEVICE constexpr
+    operator const Imath::Matrix33<T>&() const noexcept
+    {
+        return *(const Imath::Matrix33<T>*)(m_ptr);
+    }
+
+    /// Only if ImathMatrix.h has been included, we can implicitly convert a
+    /// MatrixParam<T,3> into an Imath::Matrix33<T>.
+    template<typename ThisType = MatrixParam,
+             typename std::enable_if<ThisType::Size == 3, int>::type = 0>
+    OIIO_HOSTDEVICE constexpr const Imath::Matrix33<T>&
+    operator()() const noexcept
+    {
+        return *(const Imath::Matrix33<T>*)(m_ptr);
+    }
+
+    /// Only if ImathMatrix.h has been included, we can construct a
+    /// MatrixParam<T,4> out of an Imath::Matrix44<T>.
+    template<typename ThisType = MatrixParam,
+             typename std::enable_if<ThisType::Size == 4, int>::type = 0>
+    OIIO_HOSTDEVICE constexpr
+    operator const Imath::Matrix44<T>&() const noexcept
+    {
+        return *(const Imath::Matrix44<T>*)(m_ptr);
+    }
+
+    /// Only if ImathMatrix.h has been included, we can implicitly convert a
+    /// MatrixParam<T,4> into an Imath::Matrix44<T>.
+    template<typename ThisType = MatrixParam,
+             typename std::enable_if<ThisType::Size == 4, int>::type = 0>
+    OIIO_HOSTDEVICE constexpr const Imath::Matrix44<T>&
+    operator()() const noexcept
+    {
+        return *(const Imath::Matrix44<T>*)(m_ptr);
+    }
+#endif
+
+    /// Return a pointer to the contiguous values comprising the matrix.
+    const T* data() const noexcept { return m_ptr; }
+
+private:
+    /// Underlying representation is just a pointer.
+    const T* m_ptr;
+};
+
+
+/// M33fParam is an alias for MatrixParam<float, 3>
+using M33fParam = MatrixParam<float, 3>;
+
+/// M44fParam is an alias for MatrixParam<float, 4>
+using M44fParam = MatrixParam<float, 4>;
+
+
+OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1532,8 +1532,8 @@ ImageBufAlgo::colorconvert(const ImageBuf& src, string_view from,
 
 bool
 ImageBufAlgo::colormatrixtransform(ImageBuf& dst, const ImageBuf& src,
-                                   const Imath::M44f& M, bool unpremult,
-                                   ROI roi, int nthreads)
+                                   M44fParam M, bool unpremult, ROI roi,
+                                   int nthreads)
 {
     pvt::LoggedTimer logtime("IBA::colormatrixtransform");
     ColorProcessorHandle processor;
@@ -1553,7 +1553,7 @@ ImageBufAlgo::colormatrixtransform(ImageBuf& dst, const ImageBuf& src,
 
 
 ImageBuf
-ImageBufAlgo::colormatrixtransform(const ImageBuf& src, const Imath::M44f& M,
+ImageBufAlgo::colormatrixtransform(const ImageBuf& src, M44fParam M,
                                    bool unpremult, ROI roi, int nthreads)
 {
     ImageBuf result;

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <memory>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/fmath.h>

--- a/src/libOpenImageIO/imagebufalgo_addsub.cpp
+++ b/src/libOpenImageIO/imagebufalgo_addsub.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <limits>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagebufalgo_channels.cpp
+++ b/src/libOpenImageIO/imagebufalgo_channels.cpp
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <iostream>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <iostream>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>

--- a/src/libOpenImageIO/imagebufalgo_deep.cpp
+++ b/src/libOpenImageIO/imagebufalgo_deep.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <stdexcept>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <limits>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/filter.h>

--- a/src/libOpenImageIO/imagebufalgo_mad.cpp
+++ b/src/libOpenImageIO/imagebufalgo_mad.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <limits>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>

--- a/src/libOpenImageIO/imagebufalgo_minmaxchan.cpp
+++ b/src/libOpenImageIO/imagebufalgo_minmaxchan.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <limits>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagebufalgo_muldiv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_muldiv.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <limits>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -36,6 +36,7 @@
 #include <map>
 #include <vector>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>

--- a/src/libOpenImageIO/imagebufalgo_orient.cpp
+++ b/src/libOpenImageIO/imagebufalgo_orient.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <iostream>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -9,8 +9,9 @@
 #include <cmath>
 #include <memory>
 
-#include "imageio_pvt.h"
 #include <OpenImageIO/Imath.h>
+
+#include "imageio_pvt.h"
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filter.h>
 #include <OpenImageIO/imagebuf.h>
@@ -274,7 +275,7 @@ warp_impl(ImageBuf& dst, const ImageBuf& src, const Imath::M33f& M,
 
 
 bool
-ImageBufAlgo::warp(ImageBuf& dst, const ImageBuf& src, const Imath::M33f& M,
+ImageBufAlgo::warp(ImageBuf& dst, const ImageBuf& src, M33fParam M,
                    const Filter2D* filter, bool recompute_roi,
                    ImageBuf::WrapMode wrap, ROI roi, int nthreads)
 {
@@ -285,7 +286,7 @@ ImageBufAlgo::warp(ImageBuf& dst, const ImageBuf& src, const Imath::M33f& M,
 
 
 bool
-ImageBufAlgo::warp(ImageBuf& dst, const ImageBuf& src, const Imath::M33f& M,
+ImageBufAlgo::warp(ImageBuf& dst, const ImageBuf& src, M33fParam M,
                    string_view filtername_, float filterwidth,
                    bool recompute_roi, ImageBuf::WrapMode wrap, ROI roi,
                    int nthreads)
@@ -315,9 +316,9 @@ ImageBufAlgo::warp(ImageBuf& dst, const ImageBuf& src, const Imath::M33f& M,
 
 
 ImageBuf
-ImageBufAlgo::warp(const ImageBuf& src, const Imath::M33f& M,
-                   const Filter2D* filter, bool recompute_roi,
-                   ImageBuf::WrapMode wrap, ROI roi, int nthreads)
+ImageBufAlgo::warp(const ImageBuf& src, M33fParam M, const Filter2D* filter,
+                   bool recompute_roi, ImageBuf::WrapMode wrap, ROI roi,
+                   int nthreads)
 {
     ImageBuf result;
     bool ok = warp(result, src, M, filter, recompute_roi, wrap, roi, nthreads);
@@ -329,10 +330,9 @@ ImageBufAlgo::warp(const ImageBuf& src, const Imath::M33f& M,
 
 
 ImageBuf
-ImageBufAlgo::warp(const ImageBuf& src, const Imath::M33f& M,
-                   string_view filtername, float filterwidth,
-                   bool recompute_roi, ImageBuf::WrapMode wrap, ROI roi,
-                   int nthreads)
+ImageBufAlgo::warp(const ImageBuf& src, M33fParam M, string_view filtername,
+                   float filterwidth, bool recompute_roi,
+                   ImageBuf::WrapMode wrap, ROI roi, int nthreads)
 {
     ImageBuf result;
     bool ok = warp(result, src, M, filtername, filterwidth, recompute_roi, wrap,

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -8,6 +8,8 @@
 #include <sstream>
 #include <string>
 
+#include <OpenImageIO/Imath.h>
+
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filter.h>
 #include <OpenImageIO/fmath.h>
@@ -288,9 +290,8 @@ vector_to_latlong(const Imath::V3f& R, bool y_is_up, float& s, float& t)
 
 bool
 TextureSystemImpl::environment(ustring filename, TextureOpt& options,
-                               const Imath::V3f& R, const Imath::V3f& dRdx,
-                               const Imath::V3f& dRdy, int nchannels,
-                               float* result, float* dresultds,
+                               V3fParam R, V3fParam dRdx, V3fParam dRdy,
+                               int nchannels, float* result, float* dresultds,
                                float* dresultdt)
 {
     PerThreadInfo* thread_info = m_imagecache->get_perthread_info();
@@ -305,9 +306,8 @@ TextureSystemImpl::environment(ustring filename, TextureOpt& options,
 bool
 TextureSystemImpl::environment(TextureHandle* texture_handle_,
                                Perthread* thread_info_, TextureOpt& options,
-                               const Imath::V3f& _R, const Imath::V3f& _dRdx,
-                               const Imath::V3f& _dRdy, int nchannels,
-                               float* result, float* dresultds,
+                               V3fParam _R, V3fParam _dRdx, V3fParam _dRdy,
+                               int nchannels, float* result, float* dresultds,
                                float* dresultdt)
 {
     // Handle >4 channel lookups by recursion.
@@ -394,9 +394,9 @@ TextureSystemImpl::environment(TextureHandle* texture_handle_,
     // These define the ellipse we're filtering over.
     Imath::V3f R = _R;
     R.normalize();  // center
-    Imath::V3f Rx = _R + _dRdx;
+    Imath::V3f Rx = Imath::V3f(_R) + Imath::V3f(_dRdx);
     Rx.normalize();  // x axis of the ellipse
-    Imath::V3f Ry = _R + _dRdy;
+    Imath::V3f Ry = Imath::V3f(_R) + Imath::V3f(_dRdy);
     Ry.normalize();  // y axis of the ellipse
     // angles formed by the ellipse axes.
     float xfilt_noblur = std::max(safe_acos(R.dot(Rx)), 1e-8f);

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -15,6 +15,7 @@
 #include <boost/container/flat_map.hpp>
 #include <boost/thread/tss.hpp>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/export.h>
 #include <OpenImageIO/hash.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -8,6 +8,8 @@
 #include <sstream>
 #include <string>
 
+#include <OpenImageIO/Imath.h>
+
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imagecache.h>
@@ -52,9 +54,8 @@ namespace pvt {  // namespace pvt
 
 
 bool
-TextureSystemImpl::texture3d(ustring filename, TextureOpt& options,
-                             const Imath::V3f& P, const Imath::V3f& dPdx,
-                             const Imath::V3f& dPdy, const Imath::V3f& dPdz,
+TextureSystemImpl::texture3d(ustring filename, TextureOpt& options, V3fParam P,
+                             V3fParam dPdx, V3fParam dPdy, V3fParam dPdz,
                              int nchannels, float* result, float* dresultds,
                              float* dresultdt, float* dresultdr)
 {
@@ -70,10 +71,10 @@ TextureSystemImpl::texture3d(ustring filename, TextureOpt& options,
 bool
 TextureSystemImpl::texture3d(TextureHandle* texture_handle_,
                              Perthread* thread_info_, TextureOpt& options,
-                             const Imath::V3f& P, const Imath::V3f& dPdx,
-                             const Imath::V3f& dPdy, const Imath::V3f& dPdz,
-                             int nchannels, float* result, float* dresultds,
-                             float* dresultdt, float* dresultdr)
+                             V3fParam P, V3fParam dPdx, V3fParam dPdy,
+                             V3fParam dPdz, int nchannels, float* result,
+                             float* dresultds, float* dresultdt,
+                             float* dresultdr)
 {
     // Handle >4 channel lookups by recursion.
     if (nchannels > 4) {
@@ -174,7 +175,7 @@ TextureSystemImpl::texture3d(TextureHandle* texture_handle_,
     if (si.Mlocal) {
         // See if there is a world-to-local transform stored in the cache
         // entry. If so, use it to transform the input point.
-        si.Mlocal->multVecMatrix(P, Plocal);
+        si.Mlocal->multVecMatrix(Imath::V3f(P), Plocal);
     } else {
         // If no world-to-local matrix could be discerned, just use the
         // input point directly.

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -168,17 +168,15 @@ public:
                          VaryingRef<float> dtdy, int nchannels, float* result,
                          float* dresultds = NULL, float* dresultdt = NULL);
 
-    virtual bool texture3d(ustring filename, TextureOpt& options,
-                           const Imath::V3f& P, const Imath::V3f& dPdx,
-                           const Imath::V3f& dPdy, const Imath::V3f& dPdz,
+    virtual bool texture3d(ustring filename, TextureOpt& options, V3fParam P,
+                           V3fParam dPdx, V3fParam dPdy, V3fParam dPdz,
                            int nchannels, float* result,
                            float* dresultds = NULL, float* dresultdt = NULL,
                            float* dresultdr = NULL);
     virtual bool texture3d(TextureHandle* texture_handle,
                            Perthread* thread_info, TextureOpt& options,
-                           const Imath::V3f& P, const Imath::V3f& dPdx,
-                           const Imath::V3f& dPdy, const Imath::V3f& dPdz,
-                           int nchannels, float* result,
+                           V3fParam P, V3fParam dPdx, V3fParam dPdy,
+                           V3fParam dPdz, int nchannels, float* result,
                            float* dresultds = NULL, float* dresultdt = NULL,
                            float* dresultdr = NULL);
     virtual bool texture3d(ustring filename, TextureOptBatch& options,
@@ -213,17 +211,17 @@ public:
                            float* dresultdt = NULL, float* dresultdr = NULL);
 
     virtual bool shadow(ustring /*filename*/, TextureOpt& /*options*/,
-                        const Imath::V3f& /*P*/, const Imath::V3f& /*dPdx*/,
-                        const Imath::V3f& /*dPdy*/, float* /*result*/,
-                        float* /*dresultds*/, float* /*dresultdt*/)
+                        V3fParam /*P*/, V3fParam /*dPdx*/, V3fParam /*dPdy*/,
+                        float* /*result*/, float* /*dresultds*/,
+                        float* /*dresultdt*/)
     {
         return false;
     }
     virtual bool shadow(TextureHandle* /*texture_handle*/,
                         Perthread* /*thread_info*/, TextureOpt& /*options*/,
-                        const Imath::V3f& /*P*/, const Imath::V3f& /*dPdx*/,
-                        const Imath::V3f& /*dPdy*/, float* /*result*/,
-                        float* /*dresultds*/, float* /*dresultdt*/)
+                        V3fParam /*P*/, V3fParam /*dPdx*/, V3fParam /*dPdy*/,
+                        float* /*result*/, float* /*dresultds*/,
+                        float* /*dresultdt*/)
     {
         return false;
     }
@@ -265,17 +263,15 @@ public:
     }
 
 
-    virtual bool environment(ustring filename, TextureOpt& options,
-                             const Imath::V3f& R, const Imath::V3f& dRdx,
-                             const Imath::V3f& dRdy, int nchannels,
+    virtual bool environment(ustring filename, TextureOpt& options, V3fParam R,
+                             V3fParam dRdx, V3fParam dRdy, int nchannels,
                              float* result, float* dresultds = NULL,
                              float* dresultdt = NULL);
     virtual bool environment(TextureHandle* texture_handle,
                              Perthread* thread_info, TextureOpt& options,
-                             const Imath::V3f& R, const Imath::V3f& dRdx,
-                             const Imath::V3f& dRdy, int nchannels,
-                             float* result, float* dresultds = NULL,
-                             float* dresultdt = NULL);
+                             V3fParam R, V3fParam dRdx, V3fParam dRdy,
+                             int nchannels, float* result,
+                             float* dresultds = NULL, float* dresultdt = NULL);
     virtual bool environment(ustring filename, TextureOptBatch& options,
                              Tex::RunMask mask, const float* R,
                              const float* dRdx, const float* dRdy,

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -17,6 +17,7 @@
 #include <OpenImageIO/timer.h>
 #include <OpenImageIO/typedesc.h>
 #include <OpenImageIO/unittest.h>
+#include <OpenImageIO/vecparam.h>
 
 
 using namespace OIIO;
@@ -584,6 +585,102 @@ test_swap_endian()
 
 
 
+// Minimal vector class having x, y, z struct members.
+struct XYZVector {
+    float x, y, z;
+    XYZVector() {}
+    XYZVector(float x, float y, float z)
+        : x(x)
+        , y(y)
+        , z(z)
+    {
+    }
+};
+
+// Minimal vector class enclosing an array[3].
+struct Arr3Vector {
+    float xyz[3];
+    Arr3Vector() {}
+    Arr3Vector(float x, float y, float z)
+    {
+        xyz[0] = x;
+        xyz[1] = y;
+        xyz[2] = z;
+    }
+    float operator[](int i) const { return xyz[i]; }
+};
+
+
+
+// Function that takes a V3fParam, and must implicitly convert it to an
+// Imath::V3f.
+Imath::V3f
+v3ffunc(V3fParam p)
+{
+    return p;
+}
+
+
+// Function that takes a M33Param, and must implicitly convert it to an
+// Imath::M33f.
+Imath::M33f
+M33func(M33fParam p)
+{
+    return p;
+}
+
+
+// Function that takes a M44Param, and must implicitly convert it to an
+// Imath::M44f.
+Imath::M44f
+m44func(M44fParam p)
+{
+    return p;
+}
+
+
+static void
+test_vecparam()
+{
+    Strutil::print("Testing vec proxy passing\n");
+
+    // Can we pass an Imath::V3f as a V3fParam?
+    Imath::V3f iv3f(1.0f, 2.0f, 3.0f);
+    OIIO_CHECK_EQUAL(v3ffunc(iv3f), iv3f);
+
+    // Can we pass a raw float[3] array as a V3fParam?
+    float arr[3] = { 1.0, 2.0, 3.0 };
+    OIIO_CHECK_EQUAL(v3ffunc(arr), iv3f);
+
+    // Can we pass a std::array<float,3> as a V3fParam?
+    std::array<float, 3> stdarr { 1.0, 2.0, 3.0 };
+    OIIO_CHECK_EQUAL(v3ffunc(stdarr), iv3f);
+
+    // Can we pass an initializer list as a V3fParam?
+    OIIO_CHECK_EQUAL(v3ffunc({ 1.0f, 2.0f, 3.0f }), iv3f);
+
+    // Can we pass a custom vector class with xyz components as a V3fParam?
+    XYZVector xyzv(1.0f, 2.0f, 3.0f);
+    OIIO_CHECK_EQUAL(v3ffunc(xyzv), iv3f);
+
+    // Can we pass a custom vector class with array components as a V3fParam?
+    Arr3Vector av(1.0f, 2.0f, 3.0f);
+    OIIO_CHECK_EQUAL(v3ffunc(av), iv3f);
+
+    // Can we pass our simd::vfloat3 as a V3fParam?
+    simd::vfloat3 vf3(1.0f, 2.0f, 3.0f);
+    OIIO_CHECK_EQUAL(v3ffunc(vf3), iv3f);
+
+    OIIO_CHECK_ASSERT((has_xyz<XYZVector, float>::value));
+    OIIO_CHECK_ASSERT((has_subscript<Arr3Vector, float, 3>::value));
+    OIIO_CHECK_ASSERT((has_subscript<simd::vfloat3, float, 3>::value));
+
+    Imath::M44f m44f(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
+    OIIO_CHECK_EQUAL(m44func(m44f), m44f);
+}
+
+
+
 int
 main(int argc, char* argv[])
 {
@@ -656,6 +753,8 @@ main(int argc, char* argv[])
     test_swap_endian();
 
     test_interpolate_linear();
+
+    test_vecparam();
 
     return unit_test_failures != 0;
 }

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -672,8 +672,8 @@ test_vecparam()
     OIIO_CHECK_EQUAL(v3ffunc(vf3), iv3f);
 
     OIIO_CHECK_ASSERT((has_xyz<XYZVector, float>::value));
-    OIIO_CHECK_ASSERT((has_subscript<Arr3Vector, float, 3>::value));
-    OIIO_CHECK_ASSERT((has_subscript<simd::vfloat3, float, 3>::value));
+    OIIO_CHECK_ASSERT((has_subscript_N<Arr3Vector, float, 3>::value));
+    OIIO_CHECK_ASSERT((has_subscript_N<simd::vfloat3, float, 3>::value));
 
     Imath::M44f m44f(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
     OIIO_CHECK_EQUAL(m44func(m44f), m44f);

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <numeric>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/platform.h>
 
 #include <boost/version.hpp>

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <iterator>
 
+#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/benchmark.h>
 #include <OpenImageIO/filesystem.h>


### PR DESCRIPTION
Speculative work -- create a small shim class template called
Vec3Param (and its specialization, V3fParam) that does nothing but
implicitly convert from and to things that looks like 3-vectors
(thanks to some template magic I developed a while back for the Imath
project). And similar for template MatrixParam (and specializations
M33fParam and M44fParam) to pass a square matrix.

Basically the idea is that we can replace the public API function
parameters where we take an Imath::V3f and instead use a
V3fParam. User code that passes an Imath::V3f still works because
V3fParam accepts and converts it.  Implementation code can implicitly
convert the V3fParam to an Imath::V3f, so it doesn't need to be
changed, either. Only the function declaration itself. (Same basic
situation for MatrixParam and Imath::M33f/M44f.)

So in the process, now we have laundered our public API so that it
doesn't reference the Imath types and headers any longer. This confers
two big advantages:

1. It allows OIIO itself and any downstream client code calling OIIO
   to use *different* versions of Imath if they want.

2. It allows client code to not need Imath at all, for example if they
   have their own proprietary vector type that they prefer to use
   internally.

I'm not necessarily 100% sold on this approach, but I think it's got
promise and am seeking feedback. It seems to work, and I was able
to compile OSL against this altered OIIO with *no changes*.
