### PR TITLE
Add texture creation metadata: "handed"

### DIFF
--- a/src/doc/maketx.rst
+++ b/src/doc/maketx.rst
@@ -490,6 +490,14 @@ Command-line arguments are:
 
    These options were first added in OpenImageIO 2.3.10.
 
+.. option:: --handed <value>
+
+   Adds a "handed" metadata to the resulting texture, which reveals the
+   handedness of vector displacement maps or normal maps, when expressed in
+   tangent space. Possible values are `left` or `right`.
+
+   This option was first added in OpenImageIO 2.4.0.2.
+
 
 .. sec-oiiotooltex:
 

--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -1469,6 +1469,10 @@ Writing images
       `:cdfbits=` *int*
         In conjunction with `cdf=1`, specifies the number of bits to use for
         the size of the CDF table (default: 8, meaning 256 bins).
+      `:handed=` *string*
+        Specifies the handedness of a vector displacement map or normal map
+        when using tangent space coordinates. Valid values are "left" or
+        "right" (default: none).
 
     Examples::
 

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -2037,6 +2037,8 @@ enum MakeTextureMode {
 ///    - `worldtoscreen` (matrix) : World-to-screen space matrix of the view.
 ///    - `worldtoNDC` (matrix) :    World-to-NDC space matrix of the view.
 ///    - `wrapmodes` (string) :     Default: "black,black"
+///    - `handed` (string) :        "left" or "right" reveals the handedness of
+///                                 the coordinates for normal maps. ("")
 ///    - `maketx:verbose` (int) :   How much detail should go to outstream (0).
 ///    - `maketx:runstats` (int) :  If nonzero, print run stats to outstream (0).
 ///    - `maketx:resize` (int) :    If nonzero, resize to power of 2. (0)

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1827,6 +1827,19 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
             outstream << "  AverageColor: " << avgstr << std::endl;
     }
 
+    string_view handed = configspec.get_string_attribute("handed");
+    if (handed == "right" || handed == "left") {
+        if (out->supports("arbitrary_metadata")) {
+            dstspec.attribute("handed", handed);
+        } else {
+            desc += Strutil::fmt::format("{}oiio:handed={}",
+                                         desc.length() ? " " : "", handed);
+            updatedDesc = true;
+        }
+        if (verbose)
+            outstream << "  Handed: " << handed << std::endl;
+    }
+
     if (updatedDesc) {
         dstspec.attribute("ImageDescription", desc);
     }

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -186,6 +186,7 @@ getargs(int argc, char* argv[], ImageSpec& configspec)
     std::string colorconfigname;
     std::string channelnames;
     std::string bumpformat = "auto";
+    std::string handed;
     std::vector<std::string> string_attrib_names, string_attrib_values;
     std::vector<std::string> any_attrib_names, any_attrib_values;
     filenames.clear();
@@ -311,6 +312,8 @@ getargs(int argc, char* argv[], ImageSpec& configspec)
     ap.arg("--bumpformat %s:NAME", &bumpformat)
       .help("Specify the interpretation of a 3-channel input image for --bumpslopes: \"height\", \"normal\" or \"auto\" (default).");
 //                  "--envcube", &envcubemode, "Create cubic env map (file order: px, nx, py, ny, pz, nz) (UNIMP)",
+    ap.arg("--handed %s:STRING", &handed)
+      .help("Specify the handedness of a vector or normal map: \"left\", \"right\", or \"\" (default).");
 
     ap.separator(colortitle_help_string());
     ap.arg("--colorconfig %s:FILENAME", &colorconfigname)
@@ -437,6 +440,8 @@ getargs(int argc, char* argv[], ImageSpec& configspec)
         configspec.attribute("maketx:mipimages", Strutil::join(mipimages, ";"));
     if (bumpslopesmode)
         configspec.attribute("maketx:bumpformat", bumpformat);
+    if (handed.size())
+        configspec.attribute("handed", handed);
     configspec.attribute("maketx:cdf", cdf);
     configspec.attribute("maketx:cdfsigma", cdfsigma);
     configspec.attribute("maketx:cdfbits", cdfbits);

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5314,6 +5314,8 @@ prep_texture_config(ImageSpec& configspec, ParamValueList& fileoptions)
                          fileoptions.get_string("bumpformat", "auto"));
     configspec.attribute("maketx:uvslopes_scale",
                          fileoptions.get_float("uvslopes_scale", 0.0f));
+    if (fileoptions.contains("handed"))
+        configspec.attribute("handed", fileoptions.get_string("handed"));
 
     // The default values here should match the initialized values
     // in src/maketx/maketx.cpp

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1288,6 +1288,12 @@ TIFFInput::readspec(bool read_meta)
         m_spec.attribute("oiio:SHA-1", sha);
         updatedDesc = true;
     }
+    std::string handed = Strutil::excise_string_after_head(desc,
+                                                           "oiio:handed=");
+    if (handed.size() && (handed == "left" || handed == "right")) {
+        m_spec.attribute("handed", handed);
+        updatedDesc = true;
+    }
 
     if (updatedDesc) {
         string_view d(desc);


### PR DESCRIPTION
For vector displacement maps or normal maps that are in tangent space,
it is heplful to be able to record whether the data are intended to use
a local left-handed or right-handed coordinate system, and for that to
be querably from the shader accessing the map.

The `maketx --handed` option, or `oiiotool -attrib -otex:handed=...`,
or adding "handed" metadata to the configuration ImageSpec being
passed to `IBA::make_texture()` does this. It's easy for texture
formats like openexr that allow arbitrary metadata. For TIFF textures,
we embed it in the ImageDescription tag (as we do for several other
texture-specific hints).

