### PR TITLE
More Imath hiding controls

### DIFF
--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -3,7 +3,7 @@
 include(CMakeFindDependencyMacro)
 
 # add here all the find_dependency() whenever switching to config based dependencies
-if (NOT OPENIMAGEIO_CONFIG_DO_NOT_FIND_IMATH)
+if (NOT @OPENIMAGEIO_CONFIG_DO_NOT_FIND_IMATH@ AND NOT OPENIMAGEIO_CONFIG_DO_NOT_FIND_IMATH)
     if (@OpenEXR_VERSION@ VERSION_GREATER_EQUAL 3.0)
         find_dependency(Imath @Imath_VERSION@
                         HINTS @Imath_DIR@)

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -134,6 +134,8 @@ set (OPENIMAGEIO_OPENEXR_TARGETS
             ${OPENEXR_LIBRARIES} )
 set (OPENIMAGEIO_IMATH_DEPENDENCY_VISIBILITY "PUBLIC" CACHE STRING
      "Should we expose Imath library dependency as PUBLIC or PRIVATE")
+set (OPENIMAGEIO_CONFIG_DO_NOT_FIND_IMATH OFF CACHE BOOL
+     "Exclude find_dependency(Imath) from the exported OpenImageIOConfig.cmake")
 
 # JPEG -- prefer Turbo-JPEG to regular libjpeg
 checked_find_package (JPEGTurbo


### PR DESCRIPTION
Add an OIIO build-time option for forcing our exported
OpenImageIOConfig.cmake to skip the find_dependency of Imath and
OpenEXR.

This is helpful if you're at a site that is trying to build OIIO
against statically compiled Imath/OpenEXR, and want to be super sure
the downstream projects are definitely not going to encounter that
find_dependency(Imath) when the read the OIIO config files.
(They could do their own `-DOPENIMAGEIO_CONFIG_DO_NOT_FIND_IMATH`,
but I want even that to be unnecessary.)
