### PR TITLE
CI: bump OpenEXR version used for 'latest'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
       LIBRAW_VERSION: 0.20.2
       LIBTIFF_VERSION: v4.3.0
       OPENCOLORIO_VERSION: v2.1.1
-      OPENEXR_VERSION: v3.1.3
+      OPENEXR_VERSION: v3.1.4
       OPENJPEG_VERSION: v2.4.0
       PUGIXML_VERSION: v1.11.4
       PTEX_VERSION: v2.4.0
@@ -403,7 +403,7 @@ jobs:
       LIBRAW_VERSION: master
       LIBTIFF_VERSION: master
       OPENCOLORIO_VERSION: main
-      OPENEXR_VERSION: master
+      OPENEXR_VERSION: main
       OPENJPEG_VERSION: master
       PUGIXML_VERSION: master
       PTEX_VERSION: main


### PR DESCRIPTION
Also, for the bleeding edge test, OpenEXR's "master" has been renamed
to "main".
