### PR TITLE
Auto conversion from among different string_view types

### DIFF
--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -187,11 +187,8 @@ public:
     /// ustring destructor.
     ~ustring() noexcept {}
 
-    /// Conversion to string_view
-    operator string_view() const noexcept
-    {
-        return string_view(c_str(), length());
-    }
+    /// Conversion to an OIIO::string_view.
+    operator string_view() const noexcept { return { c_str(), length() }; }
 
     /// Conversion to std::string (explicit only!).
     explicit operator std::string() const noexcept { return string(); }

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -959,6 +959,24 @@ test_string_view()
     OIIO_CHECK_EQUAL(string_view(s), cstr);  // test ctr from std::string
     OIIO_CHECK_EQUAL(sr, cstr);  // These better be the same
 
+#ifdef OIIO_STD_STRING_VIEW_AVAILABLE
+    {
+        std::cout << "  Testing OIIO::string_view <-> std::string_view\n";
+        std::string_view ssv = sr;
+        OIIO::string_view osv = ssv;
+        OIIO_CHECK_EQUAL(osv, sr);
+    }
+#endif
+
+#ifdef OIIO_EXPERIMENTAL_STRING_VIEW_AVAILABLE
+    {
+        std::cout << "  Testing OIIO::string_view <-> std::experimental::string_view\n";
+        std::experimental::string_view ssv = sr;
+        OIIO::string_view osv = ssv;
+        OIIO_CHECK_EQUAL(osv, sr);
+    }
+#endif
+
     OIIO_CHECK_EQUAL(sr.substr(0), sr); // whole string
     OIIO_CHECK_EQUAL(sr.substr(2), "23401234"); // nonzero pos, default n
     OIIO_CHECK_EQUAL(sr.substr(2, 3), "234"); // true substrng


### PR DESCRIPTION
* Allow ustring and OIIO::string_view to auto-cast to fmt::string_view
  (helps some fmt formattting of types without custom formatters).

* When std::string_view (C++17) and/or std::experimental::string_view
  (some compilers pre-C++17) are available, add OIIO::string_view
  auto-construction from and auto-casting to those types.
