### PR TITLE
oiiotool --pixelaspect : fix setting of attributes

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4395,6 +4395,7 @@ action_pixelaspect(int argc, const char* argv[])
     bool highlightcomp     = options.get_int("highlightcomp");
 
     if (ot.debug) {
+        std::cout << "Performing '" << command << "'\n";
         std::cout << "  Scaling "
                   << format_resolution(Aspec->full_width, Aspec->full_height,
                                        Aspec->full_x, Aspec->full_y)
@@ -4419,11 +4420,12 @@ action_pixelaspect(int argc, const char* argv[])
             = scale_full_width;
         A->spec(0, 0)->full_height = (*A)(0, 0).specmod().full_height
             = scale_full_height;
-        A->spec(0, 0)->attribute("PixelAspectRatio", new_paspect);
+        (*A)(0, 0).specmod().attribute("PixelAspectRatio", new_paspect);
         if (xres)
-            A->spec(0, 0)->attribute("XResolution", scale_xres);
+            (*A)(0, 0).specmod().attribute("XResolution", scale_xres);
         if (yres)
-            A->spec(0, 0)->attribute("YResolution", scale_yres);
+            (*A)(0, 0).specmod().attribute("YResolution", scale_yres);
+        A->update_spec_from_imagebuf(0, 0);
         // Now A,Aspec are for the NEW resized top of stack
     }
 


### PR DESCRIPTION
We weren't doing quite the right calls to set the attributes correctly
after performing the scale.
