### PR TITLE
Improvements to ParamList and ImageSpec to reduce ustring construction

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -486,17 +486,16 @@ public:
     }
 
     /// Add a string attribute to `extra_attribs`.
-    void attribute (string_view name, string_view value) {
-        std::string str(value);
-        const char *s = str.c_str();
-        attribute (name, TypeDesc::STRING, &s);
-    }
+    void attribute (string_view name, string_view value);
+
+    /// Add a string attribute (passed as a ustring) to `extra_attribs`.
+    void attribute (string_view name, ustring value);
 
     /// Parse a string containing a textual representation of a value of
     /// the given `type`, and add that as an attribute to `extra_attribs`.
     /// Example:
     ///
-    ///     spec.attribute ("temperature", TypeString, "-273.15");
+    ///     spec.attribute ("temperature", TypeFloat, "-273.15");
     ///
     void attribute (string_view name, TypeDesc type, string_view value);
 

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -345,6 +345,38 @@ ImageSpec::attribute(string_view name, TypeDesc type, string_view value)
 
 
 void
+ImageSpec::attribute(string_view name, string_view value)
+{
+    if (name.empty())  // Guard against bogus empty names
+        return;
+    // Don't allow duplicates
+    ParamValue* f = find_attribute(name);
+    if (f) {
+        *f = ParamValue(name, value);
+    } else {
+        extra_attribs.emplace_back(name, value);
+    }
+}
+
+
+
+void
+ImageSpec::attribute(string_view name, ustring value)
+{
+    if (name.empty())  // Guard against bogus empty names
+        return;
+    // Don't allow duplicates
+    ParamValue* f = find_attribute(name);
+    if (f) {
+        *f = ParamValue(name, value);
+    } else {
+        extra_attribs.emplace_back(name, value);
+    }
+}
+
+
+
+void
 ImageSpec::erase_attribute(string_view name, TypeDesc searchtype,
                            bool casesensitive)
 {


### PR DESCRIPTION
Special case some methods of ParamValue, ParamList, and
ImageSpec::attribute for ustring and string_view data, to reduce some
redundant copies and/or ustring conversions.

The internal method init_noclear() is augmented with a flag that allows
the caller to specify that any string data it might point to is already
ustrings, and thus does avoid the costly default behavior of converting
strings in the data block to ustrings. (This is not publicly exposed, so
users can't screw it up.)

So the new ParamValue constructor directly from a ustring can use this
flag to avoid passing the already-ustring through the string-to-ustring
conversion a needless second time. But also, the copy constructor, move
constructor, and assignment can use the flag and avoid the extra
conversion, since by definition they are copying from the contents of an
existing ParamValue which is guaranteed to be already ustring-ified.
