### PR TITLE
Wean ourselves off of string_view::c_str()

### DIFF
--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -881,6 +881,9 @@ public:
     /// read from disk).
     string_view name(void) const;
 
+    /// Return the name of the buffer as a ustring.
+    ustring uname(void) const;
+
     /// Return the name of the image file format of the file this ImageBuf
     /// refers to (for example `"openexr"`).  Returns an empty string for an
     /// ImageBuf that was not constructed as a direct reference to a file.

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2789,7 +2789,8 @@ inline bool attribute (string_view name, float val) {
 }
 /// Shortcut attribute() for setting a single string.
 inline bool attribute (string_view name, string_view val) {
-    const char *s = val.c_str();
+    std::string valstr = val;
+    const char *s = valstr.c_str();
     return attribute (name, TypeString, &s);
 }
 

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -814,7 +814,7 @@ ImageViewer::saveAs()
         return;
     QString name;
     name = QFileDialog::getSaveFileName(this, tr("Save Image"),
-                                        QString(img->name().c_str()),
+                                        QString(img->uname().c_str()),
                                         tr(s_file_filters));
     if (name.isEmpty())
         return;
@@ -835,7 +835,7 @@ ImageViewer::saveWindowAs()
         return;
     QString name;
     name = QFileDialog::getSaveFileName(this, tr("Save Window"),
-                                        QString(img->name().c_str()));
+                                        QString(img->uname().c_str()));
     if (name.isEmpty())
         return;
     img->write(name.toStdString(), TypeUnknown, "", image_progress_callback,
@@ -852,7 +852,7 @@ ImageViewer::saveSelectionAs()
         return;
     QString name;
     name = QFileDialog::getSaveFileName(this, tr("Save Selection"),
-                                        QString(img->name().c_str()));
+                                        QString(img->uname().c_str()));
     if (name.isEmpty())
         return;
     img->write(name.toStdString(), TypeUnknown, "", image_progress_callback,
@@ -953,7 +953,7 @@ ImageViewer::loadCurrentImage(int subimage, int miplevel)
         // opengl's capabilities.
         if (!img->init_spec(img->name(), subimage, miplevel)) {
             statusImgInfo->setText(
-                tr("Could not display image: %1.").arg(img->name().c_str()));
+                tr("Could not display image: %1.").arg(img->uname().c_str()));
             statusViewInfo->setText(tr(""));
             return false;
         }
@@ -1021,7 +1021,7 @@ ImageViewer::loadCurrentImage(int subimage, int miplevel)
             return true;
         } else {
             statusImgInfo->setText(
-                tr("Could not display image: %1.").arg(img->name().c_str()));
+                tr("Could not display image: %1.").arg(img->uname().c_str()));
             statusViewInfo->setText(tr(""));
             return false;
         }
@@ -1086,7 +1086,7 @@ ImageViewer::deleteCurrentImage()
 {
     IvImage* img = cur();
     if (img) {
-        const char* filename = img->name().c_str();
+        const char* filename = img->uname().c_str();
         QString message("Are you sure you want to remove <b>");
         message = message + QString(filename) + QString("</b> file from disk?");
         QMessageBox::StandardButton button;

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -343,7 +343,8 @@ ColorConfig::reset(string_view filename)
     } else {
         // Either filename passed, or taken from $OCIO, and it seems to exist
         try {
-            getImpl()->config_ = OCIO::Config::CreateFromFile(filename.c_str());
+            getImpl()->config_ = OCIO::Config::CreateFromFile(
+                filename.str().c_str());
             getImpl()->configname(filename);
         } catch (OCIO::Exception& e) {
             getImpl()->error("Error reading OCIO config \"{}\": {}", filename,
@@ -409,7 +410,7 @@ ColorConfig::getColorSpaceFamilyByName(string_view name) const
 #ifdef USE_OCIO
     if (getImpl()->config_) {
         OCIO::ConstColorSpaceRcPtr c = getImpl()->config_->getColorSpace(
-            name.c_str());
+            name.str().c_str());
         if (c)
             return c->getFamily();
     }
@@ -502,7 +503,7 @@ ColorConfig::getColorSpaceNameByRole(string_view role) const
 #ifdef USE_OCIO
     if (getImpl()->config_) {
         OCIO::ConstColorSpaceRcPtr c = getImpl()->config_->getColorSpace(
-            role.c_str());
+            role.str().c_str());
         // Catch special case of obvious name synonyms
         if (!c
             && (Strutil::iequals(role, "RGB")
@@ -532,7 +533,7 @@ ColorConfig::getColorSpaceDataType(string_view name, int* bits) const
 {
 #ifdef USE_OCIO
     OCIO::ConstColorSpaceRcPtr c = getImpl()->config_->getColorSpace(
-        name.c_str());
+        name.str().c_str());
     if (c) {
         OCIO::BitDepth b = c->getBitDepth();
         switch (b) {
@@ -595,7 +596,7 @@ ColorConfig::getNumViews(string_view display) const
     if (display.empty())
         display = getDefaultDisplayName();
     if (getImpl()->config_)
-        return getImpl()->config_->getNumViews(display.c_str());
+        return getImpl()->config_->getNumViews(display.str().c_str());
 #endif
     return 0;
 }
@@ -609,7 +610,7 @@ ColorConfig::getViewNameByIndex(string_view display, int index) const
     if (display.empty())
         display = getDefaultDisplayName();
     if (getImpl()->config_)
-        return getImpl()->config_->getView(display.c_str(), index);
+        return getImpl()->config_->getView(display.str().c_str(), index);
 #endif
     return NULL;
 }
@@ -646,7 +647,7 @@ ColorConfig::getDefaultViewName(string_view display) const
 {
 #ifdef USE_OCIO
     if (getImpl()->config_)
-        return getImpl()->config_->getDefaultView(display.c_str());
+        return getImpl()->config_->getDefaultView(display.str().c_str());
 #endif
     return NULL;
 }
@@ -1404,9 +1405,10 @@ ColorConfig::getColorSpaceFromFilepath(string_view str) const
 {
 #if defined(USE_OCIO) && (OCIO_VERSION_HEX >= MAKE_OCIO_VERSION_HEX(2, 1, 0))
     if (getImpl() && getImpl()->config_) {
+        std::string s(str);
         string_view r = getImpl()->config_->getColorSpaceFromFilepath(
-            str.c_str());
-        if (!getImpl()->config_->filepathOnlyMatchesDefaultRule(str.c_str()))
+            s.c_str());
+        if (!getImpl()->config_->filepathOnlyMatchesDefaultRule(s.c_str()))
             return r;
     }
 #endif

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -861,7 +861,7 @@ static xml_node
 add_node(xml_node& node, string_view node_name, const char* val)
 {
     xml_node newnode = node.append_child();
-    newnode.set_name(node_name.c_str());
+    newnode.set_name(node_name.str().c_str());
     newnode.append_child(node_pcdata).set_value(val);
     return newnode;
 }

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1339,7 +1339,7 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
                 ProgressCallback progress_callback,
                 void* progress_callback_data) const
 {
-    string_view filename   = _filename.size() ? _filename : name();
+    string_view filename   = _filename.size() ? _filename : string_view(name());
     string_view fileformat = _fileformat.size() ? _fileformat : filename;
     if (filename.size() == 0) {
         errorfmt("ImageBuf::write() called with no filename");
@@ -1612,6 +1612,13 @@ ImageBuf::get_thumbnail() const
 
 string_view
 ImageBuf::name(void) const
+{
+    return m_impl->m_name;
+}
+
+
+ustring
+ImageBuf::uname(void) const
 {
     return m_impl->m_name;
 }

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -789,7 +789,8 @@ public:
     }
     virtual bool attribute(string_view name, string_view val)
     {
-        const char* s = val.c_str();
+        std::string valstr(val);
+        const char* s = valstr.c_str();
         return attribute(name, TypeDesc::STRING, &s);
     }
 

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -56,7 +56,8 @@ public:
     }
     virtual bool attribute(string_view name, string_view val)
     {
-        const char* s = val.c_str();
+        std::string valstr(val);
+        const char* s = valstr.c_str();
         return attribute(name, TypeDesc::STRING, &s);
     }
 

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -453,7 +453,7 @@ Filesystem::fopen(string_view path, string_view mode)
     return ::_wfopen(wpath.c_str(), wmode.c_str());
 #else
     // on Unix platforms passing in UTF-8 works
-    return ::fopen(path.c_str(), mode.c_str());
+    return ::fopen(path.str().c_str(), mode.str().c_str());
 #endif
 }
 
@@ -526,7 +526,7 @@ Filesystem::open(string_view path, int flags)
     return ::_wopen(wpath.c_str(), flags);
 #else
     // on Unix platforms passing in UTF-8 works
-    return ::open(path.c_str(), flags);
+    return ::open(path.str().c_str(), flags);
 #endif
 }
 


### PR DESCRIPTION
c_str() was cute, but it's a little dicey and it's not present in
the C++20 std::string_view. We didn't use it in a ton of places,
so replace with other idioms so that in the future we are better
able to interchange with std::string_view or replace our own entirely
once we have flying cars and C++20 minimum.
