### PR TITLE
Avoid internal use of OIIO::string_view::str()

### DIFF
--- a/src/include/OpenImageIO/string_view.h
+++ b/src/include/OpenImageIO/string_view.h
@@ -128,12 +128,10 @@ public:
         : m_chars(sv.data()), m_len(sv.size()) { }
 #endif
 
-    /// Convert a string_view to a `std::string`.
-    std::string str() const
-    {
-        return (m_chars ? std::string(m_chars, m_len) : std::string());
-        // N.B. std::string ctr from chars+len is constexpr in C++20.
-    }
+    /// Convert a string_view to a `std::string`.  NOTE: this is not a feature
+    /// of std::string_view. Avoid this method if you want 100%
+    /// interchangeability with std::string_view.
+    std::string str() const { return *this; }
 
     /// Explicitly request a 0-terminated string. USUALLY, this turns out to
     /// be just data(), with no significant added expense (because most uses
@@ -159,7 +157,9 @@ public:
     OIIO_CONSTEXPR14 string_view& operator=(const string_view& copy) noexcept = default;
 
     /// Convert a string_view to a `std::string`.
-    operator std::string() const { return str(); }
+    operator std::string() const {
+        return (m_chars ? std::string(m_chars, m_len) : std::string());
+    }
 
 #if defined(OIIO_STD_STRING_VIEW_AVAILABLE) || defined(OIIO_DOXYGEN)
     // Convert an OIIO::string_view to a std::string_view.

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -344,7 +344,7 @@ ColorConfig::reset(string_view filename)
         // Either filename passed, or taken from $OCIO, and it seems to exist
         try {
             getImpl()->config_ = OCIO::Config::CreateFromFile(
-                filename.str().c_str());
+                std::string(filename).c_str());
             getImpl()->configname(filename);
         } catch (OCIO::Exception& e) {
             getImpl()->error("Error reading OCIO config \"{}\": {}", filename,
@@ -410,7 +410,7 @@ ColorConfig::getColorSpaceFamilyByName(string_view name) const
 #ifdef USE_OCIO
     if (getImpl()->config_) {
         OCIO::ConstColorSpaceRcPtr c = getImpl()->config_->getColorSpace(
-            name.str().c_str());
+            std::string(name).c_str());
         if (c)
             return c->getFamily();
     }
@@ -503,7 +503,7 @@ ColorConfig::getColorSpaceNameByRole(string_view role) const
 #ifdef USE_OCIO
     if (getImpl()->config_) {
         OCIO::ConstColorSpaceRcPtr c = getImpl()->config_->getColorSpace(
-            role.str().c_str());
+            std::string(role).c_str());
         // Catch special case of obvious name synonyms
         if (!c
             && (Strutil::iequals(role, "RGB")
@@ -533,7 +533,7 @@ ColorConfig::getColorSpaceDataType(string_view name, int* bits) const
 {
 #ifdef USE_OCIO
     OCIO::ConstColorSpaceRcPtr c = getImpl()->config_->getColorSpace(
-        name.str().c_str());
+        std::string(name).c_str());
     if (c) {
         OCIO::BitDepth b = c->getBitDepth();
         switch (b) {
@@ -596,7 +596,7 @@ ColorConfig::getNumViews(string_view display) const
     if (display.empty())
         display = getDefaultDisplayName();
     if (getImpl()->config_)
-        return getImpl()->config_->getNumViews(display.str().c_str());
+        return getImpl()->config_->getNumViews(std::string(display).c_str());
 #endif
     return 0;
 }
@@ -610,7 +610,7 @@ ColorConfig::getViewNameByIndex(string_view display, int index) const
     if (display.empty())
         display = getDefaultDisplayName();
     if (getImpl()->config_)
-        return getImpl()->config_->getView(display.str().c_str(), index);
+        return getImpl()->config_->getView(std::string(display).c_str(), index);
 #endif
     return NULL;
 }
@@ -647,7 +647,7 @@ ColorConfig::getDefaultViewName(string_view display) const
 {
 #ifdef USE_OCIO
     if (getImpl()->config_)
-        return getImpl()->config_->getDefaultView(display.str().c_str());
+        return getImpl()->config_->getDefaultView(std::string(display).c_str());
 #endif
     return NULL;
 }

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -387,7 +387,7 @@ ImageSpec::erase_attribute(string_view name, TypeDesc searchtype,
             = std::regex_constants::basic;
         if (!casesensitive)
             flag |= std::regex_constants::icase;
-        std::regex re(name.str(), flag);
+        std::regex re(std::string(name), flag);
         auto matcher = [&](const ParamValue& p) {
             return std::regex_match(p.name().string(), re)
                    && (searchtype == TypeUnknown || searchtype == p.type());
@@ -893,7 +893,7 @@ static xml_node
 add_node(xml_node& node, string_view node_name, const char* val)
 {
     xml_node newnode = node.append_child();
-    newnode.set_name(node_name.str().c_str());
+    newnode.set_name(std::string(node_name).c_str());
     newnode.append_child(node_pcdata).set_value(val);
     return newnode;
 }

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -453,7 +453,7 @@ Filesystem::fopen(string_view path, string_view mode)
     return ::_wfopen(wpath.c_str(), wmode.c_str());
 #else
     // on Unix platforms passing in UTF-8 works
-    return ::fopen(path.str().c_str(), mode.str().c_str());
+    return ::fopen(std::string(path).c_str(), std::string(mode).c_str());
 #endif
 }
 
@@ -526,7 +526,7 @@ Filesystem::open(string_view path, int flags)
     return ::_wopen(wpath.c_str(), flags);
 #else
     // on Unix platforms passing in UTF-8 works
-    return ::open(path.str().c_str(), flags);
+    return ::open(std::string(path).c_str(), flags);
 #endif
 }
 


### PR DESCRIPTION
Seemed like a good idea when we wrote it, but subsequently,
std::string_view was accepted into C++17 without a str() method. So
for the sake of future full interchangeability with std::string_view,
stop using this method.  We will eventually deprecate it.
