### PR TITLE
Strutil::print vs sync::print

### DIFF
--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -99,7 +99,7 @@ string_view::c_str() const
     if (m_len == 0)  // empty string
         return "";
 
-    // This clause attempts to find out if there's a string-teriminating
+    // This clause attempts to find out if there's a string-terminating
     // '\0' character just beyond the boundary of the string_view, in which
     // case, simply returning m_chars (with no ustring creation) is a valid
     // C string.
@@ -131,24 +131,26 @@ string_view::c_str() const
 
 
 void
-Strutil::sync_output(FILE* file, string_view str)
+Strutil::sync_output(FILE* file, string_view str, bool flush)
 {
     if (str.size() && file) {
         std::unique_lock<std::mutex> lock(output_mutex);
         fwrite(str.data(), 1, str.size(), file);
-        fflush(file);
+        if (flush)
+            fflush(file);
     }
 }
 
 
 
 void
-Strutil::sync_output(std::ostream& file, string_view str)
+Strutil::sync_output(std::ostream& file, string_view str, bool flush)
 {
     if (str.size()) {
         std::unique_lock<std::mutex> lock(output_mutex);
         file << str;
-        file.flush();
+        if (flush)
+            file.flush();
     }
 }
 


### PR DESCRIPTION
Strutil::print wraps fmt::format to render the formatted output into a
std::string, then sends the string to Strutil::sync_output(), which
ensures that every string printed (or sent to a FILE or stream) is
done so atomically, using an internal mutex, and with a stream flush
after each string. But this makes it a lot more expensive than it
needs to be, when you don't need such care -- either because buffered
output is ok, or because you don't need the thread safety.

This patch:

* Adds an optional `flush` parameter to sync_output(), defaulting to
  true, which controls whether sync_output flushes or not.

* Introduces Strutil::sync::print, which is the same fully
  synchronous, thread-safe, non-buffering behavior that Strutil::print
  has traditionally had. Use this when you need those features.

* Redefines Strutil::print to be an alias for fmt::print, which means

  - There is one fewer layer of template expansion and generated code,
    and possibly fewer internal string copies, so that should make for
    both faster compilation and faster runtime performance.
  - Results are buffered, no sync after every output, so much faster
    when you don't need that.
  - No internal mutex.

On the platforms we use -- and with the current implementation of
fmtlib -- fmtlib's underlying use of stream and FILE output appears to
be adequately thread-safe. But we can't 100% guarantee this on all
platforms or all future versions of fmtlib, so users who need the
stronger guarantees (and are willing to sacrifice performance) can
simply use sync::print.

