### PR TITLE
runtest.py: Rename oiio_relpath to make_relpath

### DIFF
--- a/testsuite/maketx/run.py
+++ b/testsuite/maketx/run.py
@@ -5,7 +5,7 @@ oiio_images = OIIO_TESTSUITE_IMAGEDIR
 
 # Just for simplicity, make a checkerboard with a solid alpha
 command += oiiotool (" --pattern checker 128x128 4 --ch R,G,B,=1.0"
-            + " -d uint8 -o " + oiio_relpath("checker.tif") )
+            + " -d uint8 -o " + make_relpath("checker.tif") )
 
 # Basic test - recreate the grid texture
 command += maketx_command (oiio_images + "/grid.tif", "grid.tx", showinfo=True)
@@ -53,13 +53,13 @@ command += maketx_command ("checker.tif", "checker-opaque.tx",
 
 # Test --monochrome-detect (first create a monochrome image)
 command += oiiotool (" --pattern constant:color=.25,.25,.25 256x256 3 "
-                    + " -d uint8 -o " + oiio_relpath("gray.tif"))
+                    + " -d uint8 -o " + make_relpath("gray.tif"))
 command += maketx_command ("gray.tif", "gray-mono.tx",
                            "--monochrome-detect", showinfo=True)
 
 # Test --monochrome-detect on something that is NOT monochrome
 command += oiiotool (" --pattern constant:color=.25,.2,.15 256x256 3 "
-                    + " -d uint8 -o " + oiio_relpath("pink.tif"))
+                    + " -d uint8 -o " + make_relpath("pink.tif"))
 command += maketx_command ("pink.tif", "pink-mono.tx",
                            "--monochrome-detect", showinfo=True)
 
@@ -85,7 +85,7 @@ command += maketx_command ("checker.tif", "checker-exr.pdq",
 # hint in the ImageDescription of the input file.
 command += oiiotool (" --pattern constant:color=1,0,0 64x64 3 "
             + " --caption \"foo SHA-1=1234abcd ConstantColor=[0.0,0,-0.0] bar\""
-            + " -d uint8 -o " + oiio_relpath("small.tif") )
+            + " -d uint8 -o " + make_relpath("small.tif") )
 command += info_command ("small.tif", safematch=1);
 command += maketx_command ("small.tif", "small.tx",
                            "--oiio --constant-color-detect", showinfo=True)
@@ -108,14 +108,14 @@ command += info_command ("grid-lanczos3-hicomp.tx",
 # all-white image, turning it into an env map, and calculating its
 # statistics (should be 1.0 everywhere).
 command += oiiotool (" --pattern constant:color=1,1,1 4x2 3 "
-            + " -d half -o " + oiio_relpath("white.exr"))
+            + " -d half -o " + make_relpath("white.exr"))
 command += maketx_command ("white.exr", "whiteenv.exr",
                            "--envlatl")
 command += oiiotool ("--stats -a whiteenv.exr")
 
 #Test --bumpslopes to export a 6 channels height map with gradients
 command += oiiotool (" --pattern noise 64x64 1"
-           + " -d half -o " + oiio_relpath("bump.exr"))
+           + " -d half -o " + make_relpath("bump.exr"))
 command += maketx_command ("bump.exr", "bumpslope.exr",
                            "--bumpslopes -d half", showinfo=True)
 

--- a/testsuite/oiiotool-maketx/run.py
+++ b/testsuite/oiiotool-maketx/run.py
@@ -7,9 +7,9 @@ def omaketx_command (infile, outfile, extraargs="",
                      showinfo=True, showinfo_extra="",
                      silent=False, concat=True) :
     command = (oiio_app("oiiotool") 
-               + " " + oiio_relpath(infile,tmpdir) 
+               + " " + make_relpath(infile,tmpdir) 
                + " " + extraargs
-               + " " + output_cmd + options + " " + oiio_relpath(outfile,tmpdir) )
+               + " " + output_cmd + options + " " + make_relpath(outfile,tmpdir) )
     if not silent :
         command += " >> out.txt"
     if concat:
@@ -25,7 +25,7 @@ oiio_images = OIIO_TESTSUITE_IMAGEDIR
 
 # Just for simplicity, make a checkerboard with a solid alpha
 command += oiiotool (" --pattern checker 128x128 4 --ch R,G,B,=1.0"
-                     + " -d uint8 -o " + oiio_relpath("checker.tif") )
+                     + " -d uint8 -o " + make_relpath("checker.tif") )
 
 # Basic test - recreate the grid texture
 command += omaketx_command (oiio_images + "/grid.tif", "grid.tx")
@@ -73,13 +73,13 @@ command += omaketx_command ("checker.tif", "checker-opaque.tx",
 
 # Test --monochrome-detect (first create a monochrome image)
 command += oiiotool (" --pattern constant:color=.25,.25,.25 256x256 3 "
-                    + " -d uint8 -o " + oiio_relpath("gray.tif"))
+                    + " -d uint8 -o " + make_relpath("gray.tif"))
 command += omaketx_command ("gray.tif", "gray-mono.tx",
                             options=":monochrome_detect=1")
 
 # Test --monochrome-detect on something that is NOT monochrome
 command += oiiotool (" --pattern constant:color=.25,.2,.15 256x256 3 "
-                    + " -d uint8 -o " + oiio_relpath("pink.tif"))
+                    + " -d uint8 -o " + make_relpath("pink.tif"))
 command += omaketx_command ("pink.tif", "pink-mono.tx",
                             options=":monochrome_detect=1")
 
@@ -125,7 +125,7 @@ command += info_command ("grid-lanczos3-hicomp.tx",
 # hint in the ImageDescription of the input file.
 command += oiiotool (" --pattern constant:color=1,0,0 64x64 3 "
             + " --caption \"foo SHA-1=1234abcd ConstantColor=[0.0,0,-0.0] bar\""
-            + " -d uint8 -o " + oiio_relpath("small.tif") )
+            + " -d uint8 -o " + make_relpath("small.tif") )
 command += info_command ("small.tif", safematch=1);
 command += omaketx_command ("small.tif", "small.tx",
                             options=":oiio=1:constant_color_detect=1")
@@ -135,13 +135,13 @@ command += omaketx_command ("small.tif", "small.tx",
 # all-white image, turning it into an env map, and calculating its
 # statistics (should be 1.0 everywhere).
 command += oiiotool (" --pattern constant:color=1,1,1 4x2 3 "
-            + " -d half -o " + oiio_relpath("white.exr"))
+            + " -d half -o " + make_relpath("white.exr"))
 command += omaketx_command ("white.exr", "whiteenv.exr",
                             output_cmd="-oenv", showinfo=False)
 command += oiiotool ("--stats -a whiteenv.exr")
 
 command += oiiotool (" --pattern noise 64x64 1"
-            + " -d half -o " + oiio_relpath("bump.exr"))
+            + " -d half -o " + make_relpath("bump.exr"))
 command += omaketx_command ("bump.exr", "bumpslope.exr",
                             extraargs="-d half",
                             output_cmd="-obump", showinfo=False)

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -45,7 +45,7 @@ tmpdir = "."
 tmpdir = os.path.abspath (tmpdir)
 redirect = " >> out.txt "
 
-def oiio_relpath (path, start=os.curdir):
+def make_relpath (path, start=os.curdir):
     "Wrapper around os.path.relpath which always uses '/' as the separator."
     p = os.path.relpath (path, start)
     return p if platform.system() != 'Windows' else p.replace ('\\', '/')
@@ -60,14 +60,14 @@ if OIIO_TESTSUITE_ROOT == '' :
         OIIO_TESTSUITE_ROOT = '../../../testsuite'
     elif os.path.exists('../../../../testsuite') :
         OIIO_TESTSUITE_ROOT = '../../../../testsuite'
-OIIO_TESTSUITE_ROOT = oiio_relpath(OIIO_TESTSUITE_ROOT)
-OIIO_PROJECT_ROOT = oiio_relpath(OIIO_TESTSUITE_ROOT + "/..")
+OIIO_TESTSUITE_ROOT = make_relpath(OIIO_TESTSUITE_ROOT)
+OIIO_PROJECT_ROOT = make_relpath(OIIO_TESTSUITE_ROOT + "/..")
 
 OIIO_TESTSUITE_IMAGEDIR = os.getenv('OIIO_TESTSUITE_IMAGEDIR', '')
 if OIIO_TESTSUITE_IMAGEDIR == '' :
     if os.path.exists('../oiio-images'):
         OIIO_TESTSUITE_IMAGEDIR = '../oiio-images'
-OIIO_TESTSUITE_IMAGEDIR = oiio_relpath(OIIO_TESTSUITE_IMAGEDIR)
+OIIO_TESTSUITE_IMAGEDIR = make_relpath(OIIO_TESTSUITE_IMAGEDIR)
 # Set it back so tests can use it (python-imagebufalgo)
 os.putenv('OIIO_TESTSUITE_IMAGEDIR', OIIO_TESTSUITE_IMAGEDIR)
 
@@ -80,7 +80,7 @@ test_source_dir = os.getenv('OIIO_TESTSUITE_SRC',
                             os.path.join(OIIO_TESTSUITE_ROOT, mytest))
 colorconfig_file = os.getenv('OIIO_TESTSUITE_OCIOCONFIG',
                              '../common/OpenColorIO/nuke-default/config.ocio')
-colorconfig_file = oiio_relpath(colorconfig_file)
+colorconfig_file = make_relpath(colorconfig_file)
 
 
 command = ""
@@ -206,7 +206,7 @@ def info_command (file, extraargs="", safematch=False, hash=True,
     if hash :
         args += " --hash"
     return (oiio_app("oiiotool") + args + " " + extraargs
-            + " " + oiio_relpath(file,tmpdir) + redirect + ";\n")
+            + " " + make_relpath(file,tmpdir) + redirect + ";\n")
 
 
 # Construct a command that will compare two images, appending output to
@@ -220,8 +220,8 @@ def diff_command (fileA, fileB, extraargs="", silent=False, concat=True) :
                + " -hardfail " + str(hardfail)
                + " -warn " + str(2*failthresh)
                + " -warnpercent " + str(failpercent)
-               + " " + extraargs + " " + oiio_relpath(fileA,tmpdir) 
-               + " " + oiio_relpath(fileB,tmpdir))
+               + " " + extraargs + " " + make_relpath(fileA,tmpdir)
+               + " " + make_relpath(fileB,tmpdir))
     if not silent :
         command += redirect
     if concat:
@@ -234,10 +234,10 @@ def diff_command (fileA, fileB, extraargs="", silent=False, concat=True) :
 def maketx_command (infile, outfile, extraargs="",
                     showinfo=False, showinfo_extra="",
                     silent=False, concat=True) :
-    command = (oiio_app("maketx") 
-               + " " + oiio_relpath(infile,tmpdir) 
+    command = (oiio_app("maketx")
+               + " " + make_relpath(infile,tmpdir)
                + " " + extraargs
-               + " -o " + oiio_relpath(outfile,tmpdir) )
+               + " -o " + make_relpath(outfile,tmpdir))
     if not silent :
         command += redirect
     if concat:
@@ -257,7 +257,7 @@ def maketx_command (infile, outfile, extraargs="",
 def rw_command (dir, filename, testwrite=True, use_oiiotool=False, extraargs="",
                 preargs="", idiffextraargs="", output_filename="",
                 safematch=False, printinfo=True) :
-    fn = oiio_relpath (dir + "/" + filename, tmpdir)
+    fn = make_relpath (dir + "/" + filename, tmpdir)
     if printinfo :
         cmd = info_command (fn, safematch=safematch)
     else :


### PR DESCRIPTION
Just reconciling some differences between this file and the analogous
one in OSL.
