### PR TITLE
CI: first stab at CI builds for Intel compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -845,6 +845,61 @@ jobs:
             !build/testsuite/fits-images
             !build/testsuite/j2kp4files_v1_5
 
+  linux-icc:
+    name: "Linux icc VFX2022: icc/C++17 py3.9 boost1.76 exr3.1 ocio2.1 qt5.15"
+    runs-on: ubuntu-latest
+    container:
+      image: aswf/ci-osl:2022-clang11
+    env:
+      USE_ICC: icc
+      CXX: g++
+      CC: gcc
+      CMAKE_CXX_STANDARD: 17
+      FMT_VERSION: 7.1.3
+      # icc MUST use this older FMT version
+      PYBIND11_VERSION: v2.9.0
+      PYTHON_VERSION: 3.9
+      # USE_SIMD: avx2,f16c
+      USE_OPENVDB: 0
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare ccache timestamp
+        id: ccache_cache_keys
+        run: |
+          echo "::set-output name=date::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
+      - name: ccache
+        id: ccache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/ccache
+          key: ${{ github.job }}-${{ steps.ccache_cache_keys.outputs.date }}
+          restore-keys: |
+            ${{ github.job }}-
+      - name: Build setup
+        run: |
+            src/build-scripts/ci-startup.bash
+      - name: Dependencies
+        run: |
+            src/build-scripts/gh-installdeps.bash
+      - name: Build
+        run: |
+            src/build-scripts/ci-build.bash
+      - name: Testsuite
+        run: |
+            src/build-scripts/ci-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: |
+            build/*.cmake
+            build/CMake*
+            build/testsuite/*/*.*
+            !build/testsuite/oiio-images
+            !build/testsuite/openexr-images
+            !build/testsuite/fits-images
+            !build/testsuite/j2kp4files_v1_5
+
   linux-static:
     # Test building static libs.
     name: "Linux static libs: gcc7 C++14 exr2.4"

--- a/src/build-scripts/oneAPI.repo
+++ b/src/build-scripts/oneAPI.repo
@@ -1,0 +1,7 @@
+[oneAPI]
+name=Intel® oneAPI repository
+baseurl=https://yum.repos.intel.com/oneapi
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB

--- a/src/cmake/pythonutils.cmake
+++ b/src/cmake/pythonutils.cmake
@@ -69,7 +69,7 @@ macro (setup_python_module)
 
     set (target_name ${lib_TARGET})
 
-    if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND NOT ${CMAKE_COMPILER_ID} STREQUAL "Intel")
         # Seems to be a problem on some systems, with pybind11 and python headers
         set_property (SOURCE ${lib_SOURCES} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-macro-redefined ")
     endif ()

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -1921,7 +1921,7 @@ OIIO_FORCEINLINE OIIO_HOSTDEVICE float fast_atan2 (float y, float x) {
 template<typename T>
 OIIO_FORCEINLINE OIIO_HOSTDEVICE T fast_log2 (const T& xval) {
     using namespace simd;
-    typedef typename T::int_t intN;
+    typedef typename T::vint_t intN;
     // See float fast_log2 for explanations
     T x = clamp (xval, T(std::numeric_limits<float>::min()), T(std::numeric_limits<float>::max()));
     intN bits = bitcast_to_int(x);
@@ -2029,7 +2029,7 @@ OIIO_FORCEINLINE OIIO_HOSTDEVICE float fast_log1p (float x) {
 template<typename T>
 OIIO_FORCEINLINE OIIO_HOSTDEVICE T fast_exp2 (const T& xval) {
     using namespace simd;
-    typedef typename T::int_t intN;
+    typedef typename T::vint_t intN;
 #if OIIO_SIMD_SSE
     // See float specialization for explanations
     T x = clamp (xval, T(-126.0f), T(126.0f));

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -38,6 +38,8 @@ template<class T>
 inline void
 get_default_quantize_(long long& quant_min, long long& quant_max) noexcept
 {
+    OIIO_PRAGMA_WARNING_PUSH
+    OIIO_INTEL_PRAGMA(warning disable 173)
     if (std::numeric_limits<T>::is_integer) {
         quant_min = (long long)std::numeric_limits<T>::min();
         quant_max = (long long)std::numeric_limits<T>::max();
@@ -45,6 +47,7 @@ get_default_quantize_(long long& quant_min, long long& quant_max) noexcept
         quant_min = 0;
         quant_max = 0;
     }
+    OIIO_PRAGMA_WARNING_POP
 }
 
 

--- a/src/libOpenImageIO/imagebufalgo_yee.cpp
+++ b/src/libOpenImageIO/imagebufalgo_yee.cpp
@@ -55,6 +55,7 @@ public:
             return level[lev].getchannel(x, y, 0, 1);
     }
 
+#if 0 /* unused */
     ImageBuf& operator[](int lev)
     {
         OIIO_DASSERT(lev < PYRAMID_MAX_LEVELS);
@@ -66,6 +67,7 @@ public:
         OIIO_DASSERT(lev < PYRAMID_MAX_LEVELS);
         return level[lev].getchannel(x, y, 0, 1);
     }
+#endif
 
 private:
     ImageBuf level[PYRAMID_MAX_LEVELS];

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -595,6 +595,15 @@ main(int argc, char* argv[])
     ntrials = 1;
 #endif
 
+#if OIIO_SIMD_SSE && !OIIO_F16C_ENABLED
+    // Some rogue libraries (and icc runtime libs?) will turn on the cpu mode
+    // that causes floating point denormals get crushed to 0.0 in certain ops,
+    // and leave it that way! This can give us the wrong results for the
+    // particular sequence of SSE intrinsics we use to convert half->float for
+    // exr files containing pixels with denorm values.
+    simd::set_denorms_zero_mode(false);
+#endif
+
     getargs(argc, argv);
 
     test_int_helpers();

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -969,6 +969,7 @@ void test_arithmetic ()
     typedef typename VEC::value_t ELEM;
     test_heading ("arithmetic ", VEC::type_name());
 
+    ELEM eps = static_cast<ELEM>(1.0e-6);
     VEC a = VEC::Iota (1, 3);
     VEC b = VEC::Iota (1, 1);
     VEC add(ELEM(0)), sub(ELEM(0)), mul(ELEM(0)), div(ELEM(0));
@@ -983,13 +984,13 @@ void test_arithmetic ()
     OIIO_CHECK_SIMD_EQUAL (a+b, add);
     OIIO_CHECK_SIMD_EQUAL (a-b, sub);
     OIIO_CHECK_SIMD_EQUAL (a*b, mul);
-    OIIO_CHECK_SIMD_EQUAL (a/b, div);
+    OIIO_CHECK_SIMD_EQUAL_THRESH (a/b, div, eps);
     OIIO_CHECK_SIMD_EQUAL (a*ELEM(2), a*VEC(ELEM(2)));
     OIIO_CHECK_SIMD_EQUAL (ELEM(2)*a, a*VEC(ELEM(2)));
     { VEC r = a; r += b; OIIO_CHECK_SIMD_EQUAL (r, add); }
     { VEC r = a; r -= b; OIIO_CHECK_SIMD_EQUAL (r, sub); }
     { VEC r = a; r *= b; OIIO_CHECK_SIMD_EQUAL (r, mul); }
-    { VEC r = a; r /= b; OIIO_CHECK_SIMD_EQUAL (r, div); }
+    { VEC r = a; r /= b; OIIO_CHECK_SIMD_EQUAL_THRESH (r, div, eps); }
     { VEC r = a; r *= ELEM(2); OIIO_CHECK_SIMD_EQUAL (r, a*ELEM(2)); }
     // Test to make sure * works for negative 32 bit ints on all SIMD levels,
     // because it's a different code path for sse2.
@@ -1591,15 +1592,15 @@ void test_mathfuncs ()
     OIIO_CHECK_SIMD_EQUAL_THRESH (log(expA), A, 1e-6f);
     OIIO_CHECK_SIMD_EQUAL (fast_exp(A),
                 mkvec<VEC>(fast_exp(A[0]), fast_exp(A[1]), fast_exp(A[2]), fast_exp(A[3])));
-    OIIO_CHECK_SIMD_EQUAL (fast_log(expA),
-                mkvec<VEC>(fast_log(expA[0]), fast_log(expA[1]), fast_log(expA[2]), fast_log(expA[3])));
+    OIIO_CHECK_SIMD_EQUAL_THRESH (fast_log(expA),
+                mkvec<VEC>(fast_log(expA[0]), fast_log(expA[1]), fast_log(expA[2]), fast_log(expA[3])), 0.00001f);
     OIIO_CHECK_SIMD_EQUAL_THRESH (fast_pow_pos(VEC(2.0f), A),
                            mkvec<VEC>(0.5f, 1.0f, 2.0f, 22.62741699796952f), 0.0001f);
 
     OIIO_CHECK_SIMD_EQUAL (safe_div(mkvec<VEC>(1.0f,2.0f,3.0f,4.0f), mkvec<VEC>(2.0f,0.0f,2.0f,0.0f)),
                            mkvec<VEC>(0.5f,0.0f,1.5f,0.0f));
-    OIIO_CHECK_SIMD_EQUAL (sqrt(mkvec<VEC>(1.0f,4.0f,9.0f,16.0f)), mkvec<VEC>(1.0f,2.0f,3.0f,4.0f));
-    OIIO_CHECK_SIMD_EQUAL (rsqrt(mkvec<VEC>(1.0f,4.0f,9.0f,16.0f)), VEC(1.0f)/mkvec<VEC>(1.0f,2.0f,3.0f,4.0f));
+    OIIO_CHECK_SIMD_EQUAL_THRESH (sqrt(mkvec<VEC>(1.0f,4.0f,9.0f,16.0f)), mkvec<VEC>(1.0f,2.0f,3.0f,4.0f), 0.00001);
+    OIIO_CHECK_SIMD_EQUAL_THRESH (rsqrt(mkvec<VEC>(1.0f,4.0f,9.0f,16.0f)), VEC(1.0f)/mkvec<VEC>(1.0f,2.0f,3.0f,4.0f), 0.00001);
     OIIO_CHECK_SIMD_EQUAL_THRESH (rsqrt_fast(mkvec<VEC>(1.0f,4.0f,9.0f,16.0f)),
                                   VEC(1.0f)/mkvec<VEC>(1.0f,2.0f,3.0f,4.0f), 0.0005f);
     OIIO_CHECK_SIMD_EQUAL_THRESH (rcp_fast(VEC::Iota(1.0f)),

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -78,6 +78,8 @@
 #    include <boost/thread.hpp>
 #endif
 
+OIIO_INTEL_PRAGMA(warning disable 2196)
+
 
 OIIO_NAMESPACE_BEGIN
 

--- a/src/openvdb.imageio/openvdbinput.cpp
+++ b/src/openvdb.imageio/openvdbinput.cpp
@@ -281,7 +281,6 @@ public:
     }
     openvdb::io::File* operator->() { return m_file.get(); };
     operator bool() const { return m_file.get() != nullptr; }
-    void reset() { m_file.reset(); }
 };
 
 

--- a/testsuite/python-imagebuf/ref/out-alt-python3.txt
+++ b/testsuite/python-imagebuf/ref/out-alt-python3.txt
@@ -110,8 +110,8 @@ Pixel 1,0 is (0.0, 1.0, 0.0)
 Pixel 0,1 is (0.0, 0.0, 1.0)
 Interpolating 1,0.5 -> (0.5, 0.5, 0.0)
 Interpolating NDC 0.25,0.5 -> (0.5, 0.0, 0.5)
-Interpolating bicubic 0.25,0.5 -> (0.31944447755813599, 0.31944447755813599, 0.079861126840114594)
-Interpolating NDC bicubic 0.25,0.5 -> (0.31944447755813599, 0.079861126840114594, 0.31944447755813599)
+Interpolating bicubic 0.25,0.5 -> (0.31944, 0.31944, 0.079861)
+Interpolating NDC bicubic 0.25,0.5 -> (0.31944, 0.079861, 0.31944)
 The whole image is:  [[[1. 0. 0.]
   [0. 1. 0.]]
 

--- a/testsuite/python-imagebuf/ref/out-alt.txt
+++ b/testsuite/python-imagebuf/ref/out-alt.txt
@@ -110,8 +110,8 @@ Pixel 1,0 is (0.0, 1.0, 0.0)
 Pixel 0,1 is (0.0, 0.0, 1.0)
 Interpolating 1,0.5 -> (0.5, 0.5, 0.0)
 Interpolating NDC 0.25,0.5 -> (0.5, 0.0, 0.5)
-Interpolating bicubic 0.25,0.5 -> (0.31944447755813599, 0.31944447755813599, 0.079861126840114594)
-Interpolating NDC bicubic 0.25,0.5 -> (0.31944447755813599, 0.079861126840114594, 0.31944447755813599)
+Interpolating bicubic 0.25,0.5 -> (0.31944, 0.31944, 0.079861)
+Interpolating NDC bicubic 0.25,0.5 -> (0.31944, 0.079861, 0.31944)
 The whole image is:  [[[ 1.  0.  0.]
   [ 0.  1.  0.]]
 

--- a/testsuite/python-imagebuf/ref/out-python3.txt
+++ b/testsuite/python-imagebuf/ref/out-python3.txt
@@ -110,8 +110,8 @@ Pixel 1,0 is (0.0, 1.0, 0.0)
 Pixel 0,1 is (0.0, 0.0, 1.0)
 Interpolating 1,0.5 -> (0.5, 0.5, 0.0)
 Interpolating NDC 0.25,0.5 -> (0.5, 0.0, 0.5)
-Interpolating bicubic 0.25,0.5 -> (0.319444477558136, 0.319444477558136, 0.0798611268401146)
-Interpolating NDC bicubic 0.25,0.5 -> (0.319444477558136, 0.0798611268401146, 0.319444477558136)
+Interpolating bicubic 0.25,0.5 -> (0.31944, 0.31944, 0.079861)
+Interpolating NDC bicubic 0.25,0.5 -> (0.31944, 0.079861, 0.31944)
 The whole image is:  [[[1. 0. 0.]
   [0. 1. 0.]]
 

--- a/testsuite/python-imagebuf/ref/out.txt
+++ b/testsuite/python-imagebuf/ref/out.txt
@@ -110,8 +110,8 @@ Pixel 1,0 is (0.0, 1.0, 0.0)
 Pixel 0,1 is (0.0, 0.0, 1.0)
 Interpolating 1,0.5 -> (0.5, 0.5, 0.0)
 Interpolating NDC 0.25,0.5 -> (0.5, 0.0, 0.5)
-Interpolating bicubic 0.25,0.5 -> (0.319444477558136, 0.319444477558136, 0.0798611268401146)
-Interpolating NDC bicubic 0.25,0.5 -> (0.319444477558136, 0.0798611268401146, 0.319444477558136)
+Interpolating bicubic 0.25,0.5 -> (0.31944, 0.31944, 0.079861)
+Interpolating NDC bicubic 0.25,0.5 -> (0.31944, 0.079861, 0.31944)
 The whole image is:  [[[ 1.  0.  0.]
   [ 0.  1.  0.]]
 

--- a/testsuite/python-imagebuf/src/test_imagebuf.py
+++ b/testsuite/python-imagebuf/src/test_imagebuf.py
@@ -132,6 +132,11 @@ def test_multiimage () :
         return
     out.close ()
 
+# Print floating point tuple contents with slightly less than full precision
+# in order to mask LSB differences between platforms.
+def ftupstr(tup) :
+    return "(" + ", ".join(["{:.5}".format(x) for x in tup]) + ")"
+
 
 
 ######################################################################
@@ -197,10 +202,10 @@ try:
     print ("Pixel 0,0 is", b.getpixel(0,0,0))
     print ("Pixel 1,0 is", b.getpixel(1,0))   # test 2D lookup
     print ("Pixel 0,1 is", b.getpixel(0,1))
-    print ("Interpolating 1,0.5 ->", b.interppixel(1,0.5))
-    print ("Interpolating NDC 0.25,0.5 ->", b.interppixel_NDC(0.25,0.5))
-    print ("Interpolating bicubic 0.25,0.5 ->", b.interppixel_bicubic(1.0,0.5))
-    print ("Interpolating NDC bicubic 0.25,0.5 ->", b.interppixel_bicubic_NDC(0.25,0.5))
+    print ("Interpolating 1,0.5 ->", ftupstr(b.interppixel(1,0.5)))
+    print ("Interpolating NDC 0.25,0.5 ->", ftupstr(b.interppixel_NDC(0.25,0.5)))
+    print ("Interpolating bicubic 0.25,0.5 ->", ftupstr(b.interppixel_bicubic(1.0,0.5)))
+    print ("Interpolating NDC bicubic 0.25,0.5 ->", ftupstr(b.interppixel_bicubic_NDC(0.25,0.5)))
     print ("The whole image is: ", b.get_pixels(oiio.TypeDesc.TypeFloat))
     print ("")
     print ("Saving file...")

--- a/testsuite/tiff-depths/ref/out-icc.txt
+++ b/testsuite/tiff-depths/ref/out-icc.txt
@@ -1,0 +1,876 @@
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-02.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-02.tif :   73 x   43, 1 channel, uint2 tiff
+    SHA-1: F6BD9D10FB0DD8E9AC62DEBBB743A78FC48D3C9B
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-02.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 2
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 431
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-02.tif" and "flower-minisblack-02.tif"
+PASS
+flower-minisblack-02.tif :   73 x   43, 1 channel, uint2 tiff
+    SHA-1: F6BD9D10FB0DD8E9AC62DEBBB743A78FC48D3C9B
+../oiio-images/libtiffpic/depth/flower-minisblack-02.tif :   73 x   43, 1 channel, uint2 tiff
+    SHA-1: F6BD9D10FB0DD8E9AC62DEBBB743A78FC48D3C9B
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-04.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-04.tif :   73 x   43, 1 channel, uint4 tiff
+    SHA-1: 8C0CF14B3B585F4B1F249C681BEDEA4CB63E3EDD
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-04.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 4
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 221
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-04.tif" and "flower-minisblack-04.tif"
+PASS
+flower-minisblack-04.tif :   73 x   43, 1 channel, uint4 tiff
+    SHA-1: 8C0CF14B3B585F4B1F249C681BEDEA4CB63E3EDD
+../oiio-images/libtiffpic/depth/flower-minisblack-04.tif :   73 x   43, 1 channel, uint4 tiff
+    SHA-1: 8C0CF14B3B585F4B1F249C681BEDEA4CB63E3EDD
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-06.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-06.tif :   73 x   43, 1 channel, uint6 tiff
+    SHA-1: AE809BFEF36E3E0047343655231200A916D83492
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-06.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 6
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 148
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-06.tif" and "flower-minisblack-06.tif"
+PASS
+flower-minisblack-06.tif :   73 x   43, 1 channel, uint6 tiff
+    SHA-1: AE809BFEF36E3E0047343655231200A916D83492
+../oiio-images/libtiffpic/depth/flower-minisblack-06.tif :   73 x   43, 1 channel, uint6 tiff
+    SHA-1: AE809BFEF36E3E0047343655231200A916D83492
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-08.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-08.tif :   73 x   43, 1 channel, uint8 tiff
+    SHA-1: 1A909C8E70CC479D8A35BAA9BFEDDCBF4BF46FDC
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-08.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 112
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-08.tif" and "flower-minisblack-08.tif"
+PASS
+flower-minisblack-08.tif :   73 x   43, 1 channel, uint8 tiff
+    SHA-1: 1A909C8E70CC479D8A35BAA9BFEDDCBF4BF46FDC
+../oiio-images/libtiffpic/depth/flower-minisblack-08.tif :   73 x   43, 1 channel, uint8 tiff
+    SHA-1: 1A909C8E70CC479D8A35BAA9BFEDDCBF4BF46FDC
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-10.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-10.tif :   73 x   43, 1 channel, uint10 tiff
+    SHA-1: E9240FEF19CC8EF5EBBF2EE4A10EDF25E51C67B4
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-10.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 10
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 89
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-10.tif" and "flower-minisblack-10.tif"
+PASS
+flower-minisblack-10.tif :   73 x   43, 1 channel, uint10 tiff
+    SHA-1: E9240FEF19CC8EF5EBBF2EE4A10EDF25E51C67B4
+../oiio-images/libtiffpic/depth/flower-minisblack-10.tif :   73 x   43, 1 channel, uint10 tiff
+    SHA-1: E9240FEF19CC8EF5EBBF2EE4A10EDF25E51C67B4
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-12.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-12.tif :   73 x   43, 1 channel, uint12 tiff
+    SHA-1: AAE977957ED6AAC647967192A74E4AD55FF75811
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-12.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 12
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 74
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-12.tif" and "flower-minisblack-12.tif"
+PASS
+flower-minisblack-12.tif :   73 x   43, 1 channel, uint12 tiff
+    SHA-1: AAE977957ED6AAC647967192A74E4AD55FF75811
+../oiio-images/libtiffpic/depth/flower-minisblack-12.tif :   73 x   43, 1 channel, uint12 tiff
+    SHA-1: AAE977957ED6AAC647967192A74E4AD55FF75811
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-14.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-14.tif :   73 x   43, 1 channel, uint14 tiff
+    SHA-1: C1B9CA21C227EF11626EF0C58BD49769EEF48363
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-14.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 14
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 64
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-14.tif" and "flower-minisblack-14.tif"
+PASS
+flower-minisblack-14.tif :   73 x   43, 1 channel, uint14 tiff
+    SHA-1: C1B9CA21C227EF11626EF0C58BD49769EEF48363
+../oiio-images/libtiffpic/depth/flower-minisblack-14.tif :   73 x   43, 1 channel, uint14 tiff
+    SHA-1: C1B9CA21C227EF11626EF0C58BD49769EEF48363
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-16.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-16.tif :   73 x   43, 1 channel, uint16 tiff
+    SHA-1: 7EBB74E46C869CA0D6D091183732214B6A75173A
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-16.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 16
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 56
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-16.tif" and "flower-minisblack-16.tif"
+PASS
+flower-minisblack-16.tif :   73 x   43, 1 channel, uint16 tiff
+    SHA-1: 7EBB74E46C869CA0D6D091183732214B6A75173A
+../oiio-images/libtiffpic/depth/flower-minisblack-16.tif :   73 x   43, 1 channel, uint16 tiff
+    SHA-1: 7EBB74E46C869CA0D6D091183732214B6A75173A
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-24.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-24.tif :   73 x   43, 1 channel, uint24 tiff
+    SHA-1: BBFA6633ECF3FF686DB36F6DD00F8A359D2B1DAF
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-24.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q8 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 24
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 37
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-24.tif" and "flower-minisblack-24.tif"
+PASS
+flower-minisblack-24.tif :   73 x   43, 1 channel, uint24 tiff
+    SHA-1: BBFA6633ECF3FF686DB36F6DD00F8A359D2B1DAF
+../oiio-images/libtiffpic/depth/flower-minisblack-24.tif :   73 x   43, 1 channel, uint24 tiff
+    SHA-1: BBFA6633ECF3FF686DB36F6DD00F8A359D2B1DAF
+Reading ../oiio-images/libtiffpic/depth/flower-minisblack-32.tif
+../oiio-images/libtiffpic/depth/flower-minisblack-32.tif :   73 x   43, 1 channel, uint tiff
+    SHA-1: C98FB1125C7210E380E3F86DFCAEFF49A16742E0
+    channel list: Y
+    compression: "none"
+    DocumentName: "flower-minisblack-32.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 32
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 1
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 28
+Comparing "../oiio-images/libtiffpic/depth/flower-minisblack-32.tif" and "flower-minisblack-32.tif"
+PASS
+flower-minisblack-32.tif :   73 x   43, 1 channel, uint tiff
+    SHA-1: C98FB1125C7210E380E3F86DFCAEFF49A16742E0
+../oiio-images/libtiffpic/depth/flower-minisblack-32.tif :   73 x   43, 1 channel, uint tiff
+    SHA-1: C98FB1125C7210E380E3F86DFCAEFF49A16742E0
+Reading ../oiio-images/libtiffpic/depth/flower-palette-02.tif
+../oiio-images/libtiffpic/depth/flower-palette-02.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 52B3033465AA01129BAE149FF96CBB49877DAB7C
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-palette-02.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:BitsPerSample: 2
+    tiff:ColorSpace: "palette"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 3
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 431
+Comparing "../oiio-images/libtiffpic/depth/flower-palette-02.tif" and "flower-palette-02.tif"
+PASS
+flower-palette-02.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 52B3033465AA01129BAE149FF96CBB49877DAB7C
+../oiio-images/libtiffpic/depth/flower-palette-02.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 52B3033465AA01129BAE149FF96CBB49877DAB7C
+Reading ../oiio-images/libtiffpic/depth/flower-palette-04.tif
+../oiio-images/libtiffpic/depth/flower-palette-04.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: C6E40A3D134F1A29E153FE15459D8DE657CB7F9C
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-palette-04.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:BitsPerSample: 4
+    tiff:ColorSpace: "palette"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 3
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 221
+Comparing "../oiio-images/libtiffpic/depth/flower-palette-04.tif" and "flower-palette-04.tif"
+PASS
+flower-palette-04.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: C6E40A3D134F1A29E153FE15459D8DE657CB7F9C
+../oiio-images/libtiffpic/depth/flower-palette-04.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: C6E40A3D134F1A29E153FE15459D8DE657CB7F9C
+Reading ../oiio-images/libtiffpic/depth/flower-palette-08.tif
+../oiio-images/libtiffpic/depth/flower-palette-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 0ADA355BABFE9866F3D88AF7CA3AAC69D7DC036D
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-palette-08.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:ColorSpace: "palette"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 3
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 112
+Comparing "../oiio-images/libtiffpic/depth/flower-palette-08.tif" and "flower-palette-08.tif"
+PASS
+flower-palette-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 0ADA355BABFE9866F3D88AF7CA3AAC69D7DC036D
+../oiio-images/libtiffpic/depth/flower-palette-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 0ADA355BABFE9866F3D88AF7CA3AAC69D7DC036D
+Reading ../oiio-images/libtiffpic/depth/flower-palette-16.tif
+../oiio-images/libtiffpic/depth/flower-palette-16.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 543285C6812105A1DA3B8ADA691D5DA3AE89B10D
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-palette-16.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 16
+    tiff:ColorSpace: "palette"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 3
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 56
+Comparing "../oiio-images/libtiffpic/depth/flower-palette-16.tif" and "flower-palette-16.tif"
+PASS
+flower-palette-16.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 543285C6812105A1DA3B8ADA691D5DA3AE89B10D
+../oiio-images/libtiffpic/depth/flower-palette-16.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 543285C6812105A1DA3B8ADA691D5DA3AE89B10D
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-02.tif
+../oiio-images/libtiffpic/depth/flower-rgb-contig-02.tif :   73 x   43, 3 channel, uint2 tiff
+    SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-02.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 2
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 148
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-contig-02.tif" and "flower-rgb-contig-02.tif"
+PASS
+flower-rgb-contig-02.tif :   73 x   43, 3 channel, uint2 tiff
+    SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
+../oiio-images/libtiffpic/depth/flower-rgb-contig-02.tif :   73 x   43, 3 channel, uint2 tiff
+    SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-04.tif
+../oiio-images/libtiffpic/depth/flower-rgb-contig-04.tif :   73 x   43, 3 channel, uint4 tiff
+    SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-04.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 4
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 74
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-contig-04.tif" and "flower-rgb-contig-04.tif"
+PASS
+flower-rgb-contig-04.tif :   73 x   43, 3 channel, uint4 tiff
+    SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
+../oiio-images/libtiffpic/depth/flower-rgb-contig-04.tif :   73 x   43, 3 channel, uint4 tiff
+    SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-08.tif
+../oiio-images/libtiffpic/depth/flower-rgb-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-08.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 37
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-contig-08.tif" and "flower-rgb-contig-08.tif"
+PASS
+flower-rgb-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
+../oiio-images/libtiffpic/depth/flower-rgb-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-10.tif
+../oiio-images/libtiffpic/depth/flower-rgb-contig-10.tif :   73 x   43, 3 channel, uint10 tiff
+    SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-10.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 10
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 29
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-contig-10.tif" and "flower-rgb-contig-10.tif"
+PASS
+flower-rgb-contig-10.tif :   73 x   43, 3 channel, uint10 tiff
+    SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
+../oiio-images/libtiffpic/depth/flower-rgb-contig-10.tif :   73 x   43, 3 channel, uint10 tiff
+    SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-12.tif
+../oiio-images/libtiffpic/depth/flower-rgb-contig-12.tif :   73 x   43, 3 channel, uint12 tiff
+    SHA-1: E61083B50548C7D304A45735452FD05C1814677B
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-12.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 12
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 24
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-contig-12.tif" and "flower-rgb-contig-12.tif"
+PASS
+flower-rgb-contig-12.tif :   73 x   43, 3 channel, uint12 tiff
+    SHA-1: E61083B50548C7D304A45735452FD05C1814677B
+../oiio-images/libtiffpic/depth/flower-rgb-contig-12.tif :   73 x   43, 3 channel, uint12 tiff
+    SHA-1: E61083B50548C7D304A45735452FD05C1814677B
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-14.tif
+../oiio-images/libtiffpic/depth/flower-rgb-contig-14.tif :   73 x   43, 3 channel, uint14 tiff
+    SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-14.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 14
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 21
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-contig-14.tif" and "flower-rgb-contig-14.tif"
+PASS
+flower-rgb-contig-14.tif :   73 x   43, 3 channel, uint14 tiff
+    SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
+../oiio-images/libtiffpic/depth/flower-rgb-contig-14.tif :   73 x   43, 3 channel, uint14 tiff
+    SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-16.tif
+../oiio-images/libtiffpic/depth/flower-rgb-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-16.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 16
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 18
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-contig-16.tif" and "flower-rgb-contig-16.tif"
+PASS
+flower-rgb-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
+../oiio-images/libtiffpic/depth/flower-rgb-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-24.tif
+../oiio-images/libtiffpic/depth/flower-rgb-contig-24.tif :   73 x   43, 3 channel, uint24 tiff
+    SHA-1: 6234B3CE28DFDF0FE6B1BCC29F62393696AF79A5
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-24.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q8 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 24
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 12
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-contig-24.tif" and "flower-rgb-contig-24.tif"
+PASS
+flower-rgb-contig-24.tif :   73 x   43, 3 channel, uint24 tiff
+    SHA-1: 6234B3CE28DFDF0FE6B1BCC29F62393696AF79A5
+../oiio-images/libtiffpic/depth/flower-rgb-contig-24.tif :   73 x   43, 3 channel, uint24 tiff
+    SHA-1: 6234B3CE28DFDF0FE6B1BCC29F62393696AF79A5
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-contig-32.tif
+../oiio-images/libtiffpic/depth/flower-rgb-contig-32.tif :   73 x   43, 3 channel, uint tiff
+    SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-contig-32.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 32
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 9
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-contig-32.tif" and "flower-rgb-contig-32.tif"
+PASS
+flower-rgb-contig-32.tif :   73 x   43, 3 channel, uint tiff
+    SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
+../oiio-images/libtiffpic/depth/flower-rgb-contig-32.tif :   73 x   43, 3 channel, uint tiff
+    SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-02.tif
+../oiio-images/libtiffpic/depth/flower-rgb-planar-02.tif :   73 x   43, 3 channel, uint2 tiff
+    SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-02.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 2
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 431
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-planar-02.tif" and "flower-rgb-planar-02.tif"
+PASS
+flower-rgb-planar-02.tif :   73 x   43, 3 channel, uint2 tiff
+    SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
+../oiio-images/libtiffpic/depth/flower-rgb-planar-02.tif :   73 x   43, 3 channel, uint2 tiff
+    SHA-1: D68490C8E508DEBECEE4DF3A9E5DA0523CD5C302
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-04.tif
+../oiio-images/libtiffpic/depth/flower-rgb-planar-04.tif :   73 x   43, 3 channel, uint4 tiff
+    SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-04.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 4
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 221
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-planar-04.tif" and "flower-rgb-planar-04.tif"
+PASS
+flower-rgb-planar-04.tif :   73 x   43, 3 channel, uint4 tiff
+    SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
+../oiio-images/libtiffpic/depth/flower-rgb-planar-04.tif :   73 x   43, 3 channel, uint4 tiff
+    SHA-1: A5920C9D08B9E25C96D55FDF72F46F589AE7643D
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-08.tif
+../oiio-images/libtiffpic/depth/flower-rgb-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-08.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 112
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-planar-08.tif" and "flower-rgb-planar-08.tif"
+PASS
+flower-rgb-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
+../oiio-images/libtiffpic/depth/flower-rgb-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: 35D01526DE5F904B7978B8EA16192A28389E276F
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-10.tif
+../oiio-images/libtiffpic/depth/flower-rgb-planar-10.tif :   73 x   43, 3 channel, uint10 tiff
+    SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-10.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 10
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 89
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-planar-10.tif" and "flower-rgb-planar-10.tif"
+PASS
+flower-rgb-planar-10.tif :   73 x   43, 3 channel, uint10 tiff
+    SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
+../oiio-images/libtiffpic/depth/flower-rgb-planar-10.tif :   73 x   43, 3 channel, uint10 tiff
+    SHA-1: 0C41DF861699CF536C581721EF17B01D1EFB5D86
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-12.tif
+../oiio-images/libtiffpic/depth/flower-rgb-planar-12.tif :   73 x   43, 3 channel, uint12 tiff
+    SHA-1: E61083B50548C7D304A45735452FD05C1814677B
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-12.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 12
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 74
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-planar-12.tif" and "flower-rgb-planar-12.tif"
+PASS
+flower-rgb-planar-12.tif :   73 x   43, 3 channel, uint12 tiff
+    SHA-1: E61083B50548C7D304A45735452FD05C1814677B
+../oiio-images/libtiffpic/depth/flower-rgb-planar-12.tif :   73 x   43, 3 channel, uint12 tiff
+    SHA-1: E61083B50548C7D304A45735452FD05C1814677B
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-14.tif
+../oiio-images/libtiffpic/depth/flower-rgb-planar-14.tif :   73 x   43, 3 channel, uint14 tiff
+    SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-14.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 14
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 64
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-planar-14.tif" and "flower-rgb-planar-14.tif"
+PASS
+flower-rgb-planar-14.tif :   73 x   43, 3 channel, uint14 tiff
+    SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
+../oiio-images/libtiffpic/depth/flower-rgb-planar-14.tif :   73 x   43, 3 channel, uint14 tiff
+    SHA-1: DD060DA62BB8F5903C5087796B2D05A682BE8ADA
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-16.tif
+../oiio-images/libtiffpic/depth/flower-rgb-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-16.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 16
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 56
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-planar-16.tif" and "flower-rgb-planar-16.tif"
+PASS
+flower-rgb-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
+../oiio-images/libtiffpic/depth/flower-rgb-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: 19F69706D5C52FC9510A3C20F9A43361FEF2AC9D
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-24.tif
+../oiio-images/libtiffpic/depth/flower-rgb-planar-24.tif :   73 x   43, 3 channel, uint24 tiff
+    SHA-1: 6234B3CE28DFDF0FE6B1BCC29F62393696AF79A5
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-24.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q8 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 24
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 37
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-planar-24.tif" and "flower-rgb-planar-24.tif"
+PASS
+flower-rgb-planar-24.tif :   73 x   43, 3 channel, uint24 tiff
+    SHA-1: 6234B3CE28DFDF0FE6B1BCC29F62393696AF79A5
+../oiio-images/libtiffpic/depth/flower-rgb-planar-24.tif :   73 x   43, 3 channel, uint24 tiff
+    SHA-1: 6234B3CE28DFDF0FE6B1BCC29F62393696AF79A5
+Reading ../oiio-images/libtiffpic/depth/flower-rgb-planar-32.tif
+../oiio-images/libtiffpic/depth/flower-rgb-planar-32.tif :   73 x   43, 3 channel, uint tiff
+    SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-rgb-planar-32.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 32
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 28
+Comparing "../oiio-images/libtiffpic/depth/flower-rgb-planar-32.tif" and "flower-rgb-planar-32.tif"
+PASS
+flower-rgb-planar-32.tif :   73 x   43, 3 channel, uint tiff
+    SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
+../oiio-images/libtiffpic/depth/flower-rgb-planar-32.tif :   73 x   43, 3 channel, uint tiff
+    SHA-1: 04DAF56E34180687DB7FA12E7EE8EC3A3E40DAB8
+Reading ../oiio-images/libtiffpic/depth/flower-separated-contig-08.tif
+../oiio-images/libtiffpic/depth/flower-separated-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-separated-contig-08.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:ColorSpace: "CMYK"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 5
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 28
+Comparing "../oiio-images/libtiffpic/depth/flower-separated-contig-08.tif" and "flower-separated-contig-08.tif"
+PASS
+flower-separated-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
+../oiio-images/libtiffpic/depth/flower-separated-contig-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
+Reading ../oiio-images/libtiffpic/depth/flower-separated-contig-16.tif
+../oiio-images/libtiffpic/depth/flower-separated-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: BBAA06ABCADF65F9323FDA979421A54F5B2E53D0
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-separated-contig-16.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "contig"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 16
+    tiff:ColorSpace: "CMYK"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 5
+    tiff:PlanarConfiguration: 1
+    tiff:RowsPerStrip: 14
+Comparing "../oiio-images/libtiffpic/depth/flower-separated-contig-16.tif" and "flower-separated-contig-16.tif"
+PASS
+flower-separated-contig-16.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: E55335D12E9A20EFB0A5EAE80F1801DF5A9BEE12
+../oiio-images/libtiffpic/depth/flower-separated-contig-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: BBAA06ABCADF65F9323FDA979421A54F5B2E53D0
+Reading ../oiio-images/libtiffpic/depth/flower-separated-planar-08.tif
+../oiio-images/libtiffpic/depth/flower-separated-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-separated-planar-08.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 8
+    tiff:ColorSpace: "CMYK"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 5
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 112
+Comparing "../oiio-images/libtiffpic/depth/flower-separated-planar-08.tif" and "flower-separated-planar-08.tif"
+PASS
+flower-separated-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
+../oiio-images/libtiffpic/depth/flower-separated-planar-08.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: F739D368D37AB99D237FA1358A2EECE913245226
+Reading ../oiio-images/libtiffpic/depth/flower-separated-planar-16.tif
+../oiio-images/libtiffpic/depth/flower-separated-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: BBAA06ABCADF65F9323FDA979421A54F5B2E53D0
+    channel list: R, G, B
+    compression: "none"
+    DocumentName: "flower-separated-planar-16.tif"
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    planarconfig: "separate"
+    ResolutionUnit: "in"
+    Software: "GraphicsMagick 1.2 unreleased Q32 http://www.GraphicsMagick.org/"
+    XResolution: 72
+    YResolution: 72
+    oiio:BitsPerSample: 16
+    tiff:ColorSpace: "CMYK"
+    tiff:Compression: 1
+    tiff:PhotometricInterpretation: 5
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 56
+Comparing "../oiio-images/libtiffpic/depth/flower-separated-planar-16.tif" and "flower-separated-planar-16.tif"
+PASS
+flower-separated-planar-16.tif :   73 x   43, 3 channel, uint8 tiff
+    SHA-1: E55335D12E9A20EFB0A5EAE80F1801DF5A9BEE12
+../oiio-images/libtiffpic/depth/flower-separated-planar-16.tif :   73 x   43, 3 channel, uint16 tiff
+    SHA-1: BBAA06ABCADF65F9323FDA979421A54F5B2E53D0
+Comparing "cmyk_as_cmyk.tif" and "ref/cmyk_as_cmyk.tif"
+PASS


### PR DESCRIPTION
* New CI test downloads the Intel icc compiler and builds with it.
* A variety of minor fixes to address warnings from icc that were
  not apparent from the other compilers.
* Some minor changes to just a few tests and reference output where
  the icc-built compiler produces slightly different (usually LSB)
  results.
