### PR TITLE
Switch to using std::this_thread::yield() now that we are C++11

### DIFF
--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -88,17 +88,11 @@ typedef std::lock_guard<recursive_mutex> recursive_lock_guard;
 
 
 /// Yield the processor for the rest of the timeslice.
-///
+/// DEPRECATED(2.4): Use std::this_thread::yield() instead.
 inline void
 yield() noexcept
 {
-#if defined(__GNUC__)
-    sched_yield();
-#elif defined(_MSC_VER)
-    SwitchToThread();
-#else
-#    error No yield on this platform.
-#endif
+    std::this_thread::yield();
 }
 
 
@@ -148,7 +142,7 @@ public:
             pause(m_count);
             m_count *= 2;
         } else {
-            yield();
+            std::this_thread::yield();
         }
     }
 

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -499,7 +499,7 @@ task_set::wait_for_task(size_t taskindex, bool block)
         if (!m_pool->run_one_task(m_submitter_thread)) {
             // We tried to do a task ourselves, but there weren't any
             // left, so just wait for the rest to finish.
-            yield();
+            std::this_thread::yield();
         }
     }
 }
@@ -540,7 +540,7 @@ task_set::wait(bool block)
                 // We tried to do a task ourselves, but there weren't any
                 // left, so just wait for the rest to finish.
 #if 1
-                yield();
+                std::this_thread::yield();
 #else
                 // FIXME -- as currently written, if we see an empty queue
                 // but we're still waiting for the tasks in our set to end,


### PR DESCRIPTION
Fixes #3357, which reported problems with Clang + libc++ + Windows,
where our old code used something pthreads-specific.
