### PR TITLE
Build and CI and support for the icx compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,15 @@ jobs:
             # icc MUST use this older FMT version
             pybind11_ver: v2.9.0
             setenvs: export USE_ICC=1 USE_OPENVDB=0
+          - desc: icx/C++17 py3.9 boost1.76 exr3.1 ocio2.1 qt5.15
+            nametag: linux-vfx2022-icx
+            os: ubuntu-latest
+            vfxyear: 2022
+            cxxstd: 17
+            python_ver: 3.9
+            simd: "avx2,f16c"
+            pybind11_ver: v2.9.0
+            setenvs: export CC=icx CXX=icpx USE_ICX=1 USE_OPENVDB=0
           - desc: sanitizers
             nametag: sanitizer
             os: ubuntu-latest

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -21,12 +21,10 @@ if [[ "$ASWF_ORG" != ""  ]] ; then
         time sudo yum install -y ${EXTRA_DEP_PACKAGES}
     fi
 
-    if [[ "$CXX" == "icpc" || "$CC" == "icc" || "$USE_ICC" != "" ]] ; then
+    if [[ "$CXX" == "icpc" || "$CC" == "icc" || "$USE_ICC" != "" || "$CXX" == "icpx" || "$CC" == "icx" || "$USE_ICX" != "" ]] ; then
         sudo cp src/build-scripts/oneAPI.repo /etc/yum.repos.d
-        # sudo yum install -y intel-hpckit
-        time sudo yum install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+        sudo yum install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        icpc --version
     fi
 
 else
@@ -86,14 +84,13 @@ else
         time sudo apt-get install -y g++-11
     fi
 
-    if [[ "$CXX" == "icpc" || "$CC" == "icc" || "$USE_ICC" != "" ]] ; then
+    if [[ "$CXX" == "icpc" || "$CC" == "icc" || "$USE_ICC" != "" || "$USE_ICX" != "" ]] ; then
         wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         time sudo apt-get update
         time sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        icpc --version
     fi
 
 fi
@@ -153,7 +150,7 @@ fi
 src/build-scripts/install_test_images.bash
 
 if [[ "$USE_ICC" != "" ]] ; then
-    # We used gcc for the prior dependency builds, but use icc for OSL itself
+    # We used gcc for the prior dependency builds, but use icc for OIIO itself
     echo "which icpc:" $(which icpc)
     export CXX=icpc
     export CC=icc

--- a/src/include/OpenImageIO/benchmark.h
+++ b/src/include/OpenImageIO/benchmark.h
@@ -392,7 +392,8 @@ void OIIO_UTIL_API use_char_ptr (char const volatile *);
 }
 
 
-#if ((OIIO_GNUC_VERSION && NDEBUG) || OIIO_CLANG_VERSION >= 30500 || OIIO_APPLE_CLANG_VERSION >= 70000 || defined(__INTEL_COMPILER)) && (defined(__x86_64__) || defined(__i386__))
+#if ((OIIO_GNUC_VERSION && NDEBUG) || OIIO_CLANG_VERSION >= 30500 || OIIO_APPLE_CLANG_VERSION >= 70000 || defined(__INTEL_COMPILER)  || defined(__INTEL_LLVM_COMPILER)) \
+     && (defined(__x86_64__) || defined(__i386__))
 
 // Major non-MS compilers on x86/x86_64: use asm trick to indicate that
 // the value is needed.

--- a/src/include/OpenImageIO/detail/fmt.h
+++ b/src/include/OpenImageIO/detail/fmt.h
@@ -29,15 +29,16 @@
 #    define FMT_DEPRECATED_OSTREAM 1
 #endif
 
+OIIO_PRAGMA_WARNING_PUSH
 #if OIIO_GNUC_VERSION >= 70000
-#    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+#if OIIO_INTEL_LLVM_COMPILER
+#    pragma GCC diagnostic ignored "-Wtautological-constant-compare"
 #endif
 
 #include <OpenImageIO/detail/fmt/format.h>
 #include <OpenImageIO/detail/fmt/ostream.h>
 #include <OpenImageIO/detail/fmt/printf.h>
 
-#if OIIO_GNUC_VERSION >= 70000
-#    pragma GCC diagnostic pop
-#endif
+OIIO_PRAGMA_WARNING_POP

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -2061,7 +2061,7 @@ OIIO_FORCEINLINE OIIO_HOSTDEVICE T fast_exp2 (const T& xval) {
 
 template<>
 OIIO_FORCEINLINE OIIO_HOSTDEVICE float fast_exp2 (const float& xval) {
-#if OIIO_NON_INTEL_CLANG && OIIO_FMATH_SIMD_FRIENDLY
+#if OIIO_ANY_CLANG && !OIIO_INTEL_LLVM_COMPILER && OIIO_FMATH_SIMD_FRIENDLY
     // Clang was unhappy using the bitcast/memcpy/reinter_cast/union inside
     // an explicit SIMD loop, so revert to calling the standard version.
     return std::exp2(xval);

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -791,7 +791,6 @@ void
 test_component_access<vbool4>()
 {
     typedef vbool4 VEC;
-    typedef VEC::value_t ELEM;
     test_heading("component_access ", VEC::type_name());
 
     for (int bit = 0; bit < VEC::elements; ++bit) {
@@ -829,7 +828,6 @@ void
 test_component_access<vbool8>()
 {
     typedef vbool8 VEC;
-    typedef VEC::value_t ELEM;
     test_heading("component_access ", VEC::type_name());
 
     for (int bit = 0; bit < VEC::elements; ++bit) {
@@ -880,7 +878,6 @@ void
 test_component_access<vbool16>()
 {
     typedef vbool16 VEC;
-    typedef VEC::value_t ELEM;
     test_heading("component_access ", VEC::type_name());
 
     for (int bit = 0; bit < VEC::elements; ++bit) {


### PR DESCRIPTION
icx is the *new* Intel LLVM-based compiler, and it behaves a lot like
clang (versus icc, which is the "classic" Intel compiler).

* An additional CI test in ci.yml for icx.

* Tweaks in compiler.cmake and platform.h to detect and set options for
  this compiler.

* A variety of warning fixes encountered for this compiler.

* Add a new cmake build-time option `ENABLE_FAST_MATH` (default: OFF)
  for enabling fast-math optimizations that trade IEEE compliance for
  speed. The Intel compiler enables it by default (!), so this build
  option makes icx behave like the other compilers (not fast math
  unless explicitly asked for), which makes the CI tests and other
  behavior more consisent across compilers and platforms.

* Note: The bug that prevents some versions of fmtlib from working
  with icc does not appear to be a problem for icx.
