### PR TITLE
JPEG: better handling of PixelAspectRatio

### DIFF
--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -878,7 +878,7 @@ read_exif_tag(ImageSpec& spec, const TIFFDirEntry* dirp, cspan<uint8_t> buf,
     } else {
         // Everything else -- use our table to handle the general case
         const TagInfo* taginfo = tagmap.find(dir.tdir_tag);
-        if (taginfo) {
+        if (taginfo && !spec.extra_attribs.contains(taginfo->name)) {
             if (taginfo->handler)
                 taginfo->handler(*taginfo, dir, buf, spec, swab,
                                  offset_adjustment);

--- a/testsuite/psd/ref/out.txt
+++ b/testsuite/psd/ref/out.txt
@@ -8,7 +8,7 @@ Reading ../oiio-images/psd_123.psd
     ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CS5.1 Windows"
     thumbnail_height: 78
     thumbnail_nchannels: 3
@@ -41,7 +41,7 @@ Reading ../oiio-images/psd_123.psd
     ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
@@ -72,7 +72,7 @@ Reading ../oiio-images/psd_123.psd
     ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
@@ -103,7 +103,7 @@ Reading ../oiio-images/psd_123.psd
     ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
@@ -136,7 +136,7 @@ Reading ../oiio-images/psd_123_nomaxcompat.psd
     ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CS5.1 Windows"
     thumbnail_height: 78
     thumbnail_nchannels: 3
@@ -170,7 +170,7 @@ Reading ../oiio-images/psd_123_nomaxcompat.psd
     ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
@@ -202,7 +202,7 @@ Reading ../oiio-images/psd_123_nomaxcompat.psd
     ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
@@ -234,7 +234,7 @@ Reading ../oiio-images/psd_123_nomaxcompat.psd
     ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
@@ -270,7 +270,7 @@ Reading ../oiio-images/psd_bitmap.psd
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CS5.1 Windows"
     thumbnail_height: 120
     thumbnail_nchannels: 3
@@ -339,7 +339,7 @@ Reading ../oiio-images/psd_indexed_trans.psd
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CS5.1 Windows"
     thumbnail_height: 120
     thumbnail_nchannels: 3
@@ -410,7 +410,7 @@ Reading ../oiio-images/psd_rgb_8.psd
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CS5.1 Windows"
     thumbnail_height: 120
     thumbnail_nchannels: 3
@@ -481,7 +481,7 @@ Reading ../oiio-images/psd_rgb_16.psd
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CS5.1 Windows"
     thumbnail_height: 120
     thumbnail_nchannels: 3
@@ -552,7 +552,7 @@ Reading ../oiio-images/psd_rgb_32.psd
     Model: "Canon PowerShot A640"
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CS5.1 Windows"
     thumbnail_height: 120
     thumbnail_nchannels: 3
@@ -619,7 +619,7 @@ Reading ../oiio-images/psd_rgba_8.psd
     ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CS5.1 Windows"
     thumbnail_height: 120
     thumbnail_nchannels: 3
@@ -650,7 +650,7 @@ Reading ../oiio-images/psd_rgba_8.psd
     ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CS5.1 Windows"
     XResolution: 72
     YResolution: 72
@@ -682,7 +682,7 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CC 2015.5 (Windows)"
     XResolution: 72
     YResolution: 72
@@ -710,7 +710,7 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CC 2015.5 (Windows)"
     XResolution: 72
     YResolution: 72
@@ -740,7 +740,7 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CC 2015.5 (Windows)"
     XResolution: 72
     YResolution: 72
@@ -770,7 +770,7 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CC 2015.5 (Windows)"
     XResolution: 72
     YResolution: 72
@@ -801,7 +801,7 @@ src/layer-mask.psd   :   10 x   10, 4 channel, uint8 psd
     DateTime: "2017-07-13T10:26:10+09:00"
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CC 2017 (Windows)"
     XResolution: 72
     YResolution: 72
@@ -827,7 +827,7 @@ src/layer-mask.psd   :   10 x   10, 4 channel, uint8 psd
     DateTime: "2017-07-13T10:26:10+09:00"
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CC 2017 (Windows)"
     XResolution: 72
     YResolution: 72
@@ -854,7 +854,7 @@ src/layer-mask.psd   :   10 x   10, 4 channel, uint8 psd
     DateTime: "2017-07-13T10:26:10+09:00"
     Orientation: 1 (normal)
     PixelAspectRatio: 1
-    ResolutionUnit: 2 (inches)
+    ResolutionUnit: "in"
     Software: "Adobe Photoshop CC 2017 (Windows)"
     XResolution: 72
     YResolution: 72


### PR DESCRIPTION
JPEG expresses pixel aspect ratio implicitly as header fields
"xdensity" and "ydensity" (which we call "XResolution" and
"YResolution" in our metadata after the TIFF names). We also have
"PixelAspectRatio", so the three of them, if they are all used, form
an over-constrained system. Plus, they may come both in the JPEG
header and also (not necessarily having the same values) in any Exif
block.

And on top of that, the way Nuke and PhotoShop infer the aspect ratio
is BACKWARDS! (If pixelaspect = width/height of a displayed pixel,
then it's also = ydensity/xdensity. But Nuke is the other way
around. Only for JPEG, it gets it right for TIFF and OpenEXR.)

Anyhoo, there were some edge cases in which we were still getting
confused (specifically, that we were making some files that Nuke was
not properly recognizing as anamorphic). This patch tightens up
these cases.
