### PR TITLE
Custom fmt formatters for vector types

### DIFF
--- a/src/include/OpenImageIO/Imath.h.in
+++ b/src/include/OpenImageIO/Imath.h.in
@@ -5,6 +5,9 @@
 // clang-format off
 
 #pragma once
+
+#include <OpenImageIO/detail/fmt.h>
+
 #ifndef OIIO_IMATH_H_INCLUDED
 #define OIIO_IMATH_H_INCLUDED 1
 
@@ -24,5 +27,25 @@
 #   include <OpenEXR/ImathVec.h>
 #   include <OpenEXR/half.h>
 #endif
+
+
+/// Custom fmtlib formatters for Imath types.
+
+namespace fmt {
+template<> struct formatter<Imath::V2f>
+    : OIIO::pvt::array_formatter<Imath::V2f, float, 2> {};
+template<> struct formatter<Imath::V3f>
+    : OIIO::pvt::array_formatter<Imath::V3f, float, 3> {};
+template<> struct formatter<Imath::V4f>
+    : OIIO::pvt::array_formatter<Imath::V4f, float, 4> {};
+#if OIIO_USING_IMATH >= 3
+template<> struct formatter<Imath::M22f>
+    : OIIO::pvt::array_formatter<Imath::M22f, float, 4> {};
+#endif
+template<> struct formatter<Imath::M33f>
+    : OIIO::pvt::array_formatter<Imath::M33f, float, 9> {};
+template<> struct formatter<Imath::M44f>
+    : OIIO::pvt::array_formatter<Imath::M44f, float, 16> {};
+} // namespace fmt
 
 #endif // !defined(OIIO_IMATH_H_INCLUDED)

--- a/src/include/OpenImageIO/detail/fmt.h
+++ b/src/include/OpenImageIO/detail/fmt.h
@@ -6,6 +6,7 @@
 #define OIIO_FMT_H
 
 #include <OpenImageIO/platform.h>
+#include <OpenImageIO/type_traits.h>
 
 // We want the header-only implemention of fmt
 #ifndef FMT_HEADER_ONLY
@@ -42,3 +43,123 @@ OIIO_PRAGMA_WARNING_PUSH
 #include <OpenImageIO/detail/fmt/printf.h>
 
 OIIO_PRAGMA_WARNING_POP
+
+
+OIIO_NAMESPACE_BEGIN
+namespace pvt {
+
+
+// Custom inheritable parse() method used by fmt formatters. In addition to
+// saving the formatting spec, it also checks for a (nonstandard) optional
+// leading ',' and records it as a separator flag.
+struct format_parser_with_separator {
+    FMT_CONSTEXPR auto parse(fmt::format_parse_context& ctx)
+    {
+        auto beg = ctx.begin(), end = ctx.end();
+        if (beg != end && *beg == ',')
+            sep = *beg++;
+        auto it = beg;  // where's the close brace?
+        for (; it != end && *it != '}'; ++it)
+            ;
+        elem_fmt = fmt::string_view(beg, it - beg);
+        return it;
+    }
+
+protected:
+    fmt::string_view elem_fmt;
+    char sep = 0;
+};
+
+
+
+// fmtlib custom formatter that formats a type `T` that has array-like
+// semantics (must have a valid operator[] and size() method) by printing each
+// element according to the format spec. For example, if the object has 3
+// float elements and the spec is "{.3f}", then the output might be "1.234
+// 2.345 3.456".
+//
+// In addition to the usual formatting spec, we also recognize the following
+// special extension: If the first character of the format spec is ','
+// (comma), then the array elements will be separated by ", " rather than the
+// default " ".
+//
+// For example, `format("[{:,.3f}]")` will format the array as `[1.234, 2.345,
+// 3.456]`.
+//
+// Now then, the way this class is helpful is to inherit from it for a custom
+// formatter. For example, this will make this formatter be used for
+// Imath::V3f:
+//
+//     // in global namespace:
+//     template<> struct fmt::formatter<Imath::V3f>
+//         : OIIO::array_formatter<Imath::V3f, float, 3> {};
+//
+template<typename T,
+         OIIO_ENABLE_IF(has_subscript<T>::value&& has_size_method<T>::value)>
+struct index_formatter : format_parser_with_separator {
+    // inherits parse() from format_parser_with_separator
+    template<typename FormatContext> auto format(const T& v, FormatContext& ctx)
+    {
+        std::string vspec = elem_fmt.size() ? fmt::format("{{:{}}}", elem_fmt)
+                                            : std::string("{}");
+        for (size_t i = 0; i < v.size(); ++i) {
+            if (i)
+                fmt::format_to(ctx.out(), "{}", sep == ',' ? ", " : " ");
+#if FMT_VERSION >= 80000
+            fmt::format_to(ctx.out(), fmt::runtime(vspec), v[i]);
+#else
+            fmt::format_to(ctx.out(), vspec, v[i]);
+#endif
+        }
+        return ctx.out();
+    }
+};
+
+
+
+// fmtlib custom formatter that formats a type `T` as if it were an array
+// `Elem[Size]` (and it must be laid out that way in memory). The formatting
+// spec will apply to each element. For example, if the object has 3 float
+// elements and the spec is "{.3f}", then the output might be "1.234 2.345
+// 3.456".
+//
+// In addition to the usual formatting spec, we also recognize the following
+// special extension: If the first character of the format spec is ','
+// (comma), then the array elements will be separated by ", " rather than the
+// default " ".
+//
+// For example, `format("[{:,.3f}]")` will format the array as `[1.234, 2.345,
+// 3.456]`.
+//
+// Now then, the way this class is helpful is to inherit from it for a custom
+// formatter. For example, this will make this formatter be used for
+// Imath::V3f:
+//
+//     // in global namespace:
+//     template<> struct fmt::formatter<Imath::V3f>
+//         : OIIO::array_formatter<Imath::V3f, float, 3> {};
+//
+template<typename T, typename Elem, int Size>
+struct array_formatter : format_parser_with_separator {
+    // inherits parse() from format_parser_with_separator
+    template<typename FormatContext> auto format(const T& v, FormatContext& ctx)
+    {
+        std::string vspec = elem_fmt.size() ? fmt::format("{{:{}}}", elem_fmt)
+                                            : std::string("{}");
+        for (int i = 0; i < Size; ++i) {
+            if (i)
+                fmt::format_to(ctx.out(), "{}", sep == ',' ? ", " : " ");
+#if FMT_VERSION >= 80000
+            fmt::format_to(ctx.out(), fmt::runtime(vspec),
+                           ((const Elem*)&v)[i]);
+#else
+            fmt::format_to(ctx.out(), vspec, ((const Elem*)&v)[i]);
+#endif
+        }
+        return ctx.out();
+    }
+};
+
+
+}  // namespace pvt
+OIIO_NAMESPACE_END

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -642,7 +642,8 @@ inline void aligned_delete(T* t) {
 // An enable_if helper to be used in template parameters which results in
 // much shorter symbols: https://godbolt.org/z/sWw4vP
 // Borrowed from fmtlib.
-#define OIIO_ENABLE_IF(...) OIIO::enable_if_t<(__VA_ARGS__), int> = 0
-
+#ifndef OIIO_ENABLE_IF
+#   define OIIO_ENABLE_IF(...) OIIO::enable_if_t<(__VA_ARGS__), int> = 0
+#endif
 
 OIIO_NAMESPACE_END

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -37,6 +37,8 @@
 #include <OpenImageIO/platform.h>
 #include <OpenImageIO/vecparam.h>
 
+#include <OpenImageIO/detail/fmt.h>
+
 
 //////////////////////////////////////////////////////////////////////////
 // Sort out which SIMD capabilities we have and set definitions
@@ -368,6 +370,20 @@ template<> struct SimdTypeName<vfloat16>  { static const char *name() { return "
 template<> struct SimdTypeName<vint16>    { static const char *name() { return "vint16"; } };
 template<> struct SimdTypeName<vbool16>   { static const char *name() { return "vbool16"; } };
 
+/// Is a type T one of our SIMD-based types?
+template<typename T> struct is_simd : std::false_type {};
+template<> struct is_simd<vint4>    : std::true_type {};
+template<> struct is_simd<vfloat4>  : std::true_type {};
+template<> struct is_simd<vfloat3>  : std::true_type {};
+template<> struct is_simd<vbool4>   : std::true_type {};
+template<> struct is_simd<vint8>    : std::true_type {};
+template<> struct is_simd<vfloat8>  : std::true_type {};
+template<> struct is_simd<vbool8>   : std::true_type {};
+template<> struct is_simd<vint16>   : std::true_type {};
+template<> struct is_simd<vfloat16> : std::true_type {};
+template<> struct is_simd<vbool16>  : std::true_type {};
+template<> struct is_simd<matrix44> : std::true_type {};
+
 
 //////////////////////////////////////////////////////////////////////////
 // Macros helpful for making static constants in code.
@@ -472,6 +488,7 @@ public:
     enum { paddedelements = 4 }; ///< Number of scalar elements for full pad
     enum { bits = elements*32 }; ///< Total number of bits
     typedef simd_bool_t<4>::type simd_t;  ///< the native SIMD type used
+    static constexpr size_t size() noexcept { return elements; }
 
     /// Default constructor (contents undefined)
     vbool4 () { }
@@ -613,6 +630,7 @@ public:
     enum { paddedelements = 8 }; ///< Number of scalar elements for full pad
     enum { bits = elements*32 }; ///< Total number of bits
     typedef simd_bool_t<8>::type simd_t;  ///< the native SIMD type used
+    static constexpr size_t size() noexcept { return elements; }
 
     /// Default constructor (contents undefined)
     vbool8 () { }
@@ -761,6 +779,7 @@ public:
     enum { paddedelements = 16 }; ///< Number of scalar elements for full pad
     enum { bits = 16 };           ///< Total number of bits
     typedef simd_bool_t<16>::type simd_t;  ///< the native SIMD type used
+    static constexpr size_t size() noexcept { return elements; }
 
     /// Default constructor (contents undefined)
     vbool16 () { }
@@ -912,6 +931,7 @@ public:
     typedef vbool4 bool_t;   // old name (deprecated 1.8)
     OIIO_DEPRECATED("use vfloat_t (1.8)")
     typedef vfloat4 float_t; // old name (deprecated 1.8)
+    static constexpr size_t size() noexcept { return elements; }
 
     /// Default constructor (contents undefined)
     vint4 () { }
@@ -1202,6 +1222,7 @@ public:
     typedef vbool8 bool_t;   // old name (deprecated 1.8)
     OIIO_DEPRECATED("use vfloat_t (1.8)")
     typedef vfloat8 float_t; // old name (deprecated 1.8)
+    static constexpr size_t size() noexcept { return elements; }
 
     /// Default constructor (contents undefined)
     vint8 () { }
@@ -1500,6 +1521,7 @@ public:
     typedef vbool16 bool_t;   // old name (deprecated 1.8)
     OIIO_DEPRECATED("use vfloat_t (1.8)")
     typedef vfloat16 float_t; // old name (deprecated 1.8)
+    static constexpr size_t size() noexcept { return elements; }
 
     /// Default constructor (contents undefined)
     vint16 () { }
@@ -1811,6 +1833,7 @@ public:
     typedef vint4 int_t;      // old name (deprecated 1.8)
     OIIO_DEPRECATED("use vfloat_t (1.8)")
     typedef vbool4 bool_t;    // old name (deprecated 1.8)
+    static constexpr size_t size() noexcept { return elements; }
 
     /// Default constructor (contents undefined)
     vfloat4 () { }
@@ -2164,6 +2187,7 @@ public:
     static const char* type_name() { return "vfloat3"; }
     enum { elements = 3 };    ///< Number of scalar elements
     enum { paddedelements = 4 }; ///< Number of scalar elements for full pad
+    static constexpr size_t size() noexcept { return elements; }
 
     /// Default constructor (contents undefined)
     vfloat3 () { }
@@ -2330,6 +2354,7 @@ public:
     static const char* type_name() { return "matrix44"; }
     typedef float value_t;    ///< Underlying equivalent scalar value type
     enum { rows = 4, cols = 4 };
+    static constexpr int elements = 16;
 
     // Uninitialized
     OIIO_FORCEINLINE matrix44() { }
@@ -2476,6 +2501,7 @@ public:
     typedef vint8 int_t;      // old name (deprecated 1.8)
     OIIO_DEPRECATED("use vbool_t (1.8)")
     typedef vbool8 bool_t;    // old name (deprecated 1.8)
+    static constexpr size_t size() noexcept { return elements; }
 
     /// Default constructor (contents undefined)
     vfloat8 () { }
@@ -2796,6 +2822,7 @@ public:
     typedef vint16 int_t;      // old name (deprecated 1.8)
     OIIO_DEPRECATED("use vbool_t (1.8)")
     typedef vbool16 bool_t;    // old name (deprecated 1.8)
+    static constexpr size_t size() noexcept { return elements; }
 
     /// Default constructor (contents undefined)
     vfloat16 () { }
@@ -10171,6 +10198,27 @@ OIIO_FORCEINLINE vfloat16 nmsub (const simd::vfloat16& a, const simd::vfloat16& 
 
 OIIO_NAMESPACE_END
 
+
+/// Custom fmtlib formatters for our SIMD types.
+
+namespace fmt {
+template<> struct formatter<OIIO::simd::vfloat3>
+    : OIIO::pvt::index_formatter<OIIO::simd::vfloat3> {};
+template<> struct formatter<OIIO::simd::vfloat4>
+    : OIIO::pvt::index_formatter<OIIO::simd::vfloat4> {};
+template<> struct formatter<OIIO::simd::vfloat8>
+    : OIIO::pvt::index_formatter<OIIO::simd::vfloat8> {};
+template<> struct formatter<OIIO::simd::vfloat16>
+    : OIIO::pvt::index_formatter<OIIO::simd::vfloat16> {};
+template<> struct formatter<OIIO::simd::vint4>
+    : OIIO::pvt::index_formatter<OIIO::simd::vint4> {};
+template<> struct formatter<OIIO::simd::vint8>
+    : OIIO::pvt::index_formatter<OIIO::simd::vint8> {};
+template<> struct formatter<OIIO::simd::vint16>
+    : OIIO::pvt::index_formatter<OIIO::simd::vint16> {};
+template<> struct formatter<OIIO::simd::matrix44>
+    : OIIO::pvt::array_formatter<OIIO::simd::matrix44, float, 16> {};
+} // namespace fmt
 
 #undef SIMD_DO
 #undef SIMD_CONSTRUCT

--- a/src/include/OpenImageIO/type_traits.h
+++ b/src/include/OpenImageIO/type_traits.h
@@ -1,0 +1,62 @@
+// Copyright 2008-present Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio
+
+// clang-format off
+
+/////////////////////////////////////////////////////////////////////////
+// \file
+// type_traits.h is where we collect little type traits and related
+// templates.
+/////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <OpenImageIO/oiioversion.h>
+#include <OpenImageIO/platform.h>
+
+OIIO_NAMESPACE_BEGIN
+
+
+// An enable_if helper to be used in template parameters which results in
+// much shorter symbols: https://godbolt.org/z/sWw4vP
+// Borrowed from fmtlib.
+#ifndef OIIO_ENABLE_IF
+#    define OIIO_ENABLE_IF(...) std::enable_if_t<(__VA_ARGS__), int> = 0
+#endif
+
+
+// We use std::void_t as an aid to SFINAE. It's part of C++17, so prior to
+// that we'll have to roll our own.
+#if OIIO_CPLUSPLUS_VERSION >= 17 || defined(__cpp_lib_void_t)
+using std::void_t;
+#else
+namespace pvt {
+template<class... Ts> struct make_void { typedef void type; };
+}
+template<class... Ts> using void_t = typename pvt::make_void<Ts...>::type;
+#endif
+
+
+/// has_size_method<T>::value is true if T has a size() method and it returns
+/// an integral type.
+template<class, class = void> struct has_size_method : std::false_type { };
+
+template<class T>
+struct has_size_method<T, void_t<decltype(std::declval<T&>().size())>>
+    : std::is_integral<typename std::decay_t<decltype(std::declval<T&>().size())>> { };
+// How does this work? This overload is only defined if there is a size()
+// method, and it evaluates to true_type or false_type based on whether size()
+// returns an integral type.
+
+
+/// has_subscript<T>::value is true if T has a subscript operator.
+template<class, class = void> struct has_subscript : std::false_type { };
+
+template<class T>
+struct has_subscript<T, void_t<decltype(std::declval<T&>()[0])>>
+    : std::true_type { };
+
+
+
+OIIO_NAMESPACE_END

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -162,4 +162,10 @@ if (OIIO_BUILD_TESTS)
     set_target_properties (typedesc_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_typedesc ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/typedesc_test)
 
+    add_executable (type_traits_test type_traits_test.cpp)
+    target_link_libraries (type_traits_test PRIVATE OpenImageIO_Util
+                           ${OPENIMAGEIO_OPENEXR_TARGETS})
+    set_target_properties (type_traits_test PROPERTIES FOLDER "Unit Tests")
+    add_test (unit_type_traits ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/type_traits_test)
+
 endif ()

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -7,6 +7,7 @@
 
 #include <OpenImageIO/Imath.h>
 #include <OpenImageIO/benchmark.h>
+#include <OpenImageIO/simd.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/unittest.h>
 #include <OpenImageIO/ustring.h>
@@ -95,6 +96,95 @@ test_format()
     bench ("Strutil::fmt::format(\"{} {} {} {} {} {}\")", [&](){
                DoNotOptimize (Strutil::fmt::format("{} {} {} {} {} {}", 123.45f, 1234, "foobar", 42, "kablooey", 3.14159f));
            });
+}
+
+
+
+void
+test_format_custom()
+{
+    std::cout << "testing format() custom formatters" << std::endl;
+
+    simd::vfloat3 vf3iota = simd::vfloat3::Iota(1.5f);
+    Strutil::print("vfloat3 {{}}  '{}'\n", vf3iota);
+    Strutil::print("vfloat3 {{:.3f}}  '{:.3f}'\n", vf3iota);
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{}|Y", vf3iota),
+                     "X|1.5 2.5 3.5|Y");
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{:.3f}|Y", vf3iota),
+                     "X|1.500 2.500 3.500|Y");
+
+    simd::vfloat4 vf4iota = simd::vfloat4::Iota(1.5f);
+    Strutil::print("vfloat4 {{}}  '{}'\n", vf4iota);
+    Strutil::print("vfloat4 {{:.3f}}  '{:.3f}'\n", vf4iota);
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{}|Y", vf4iota),
+                     "X|1.5 2.5 3.5 4.5|Y");
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{:.3f}|Y", vf4iota),
+                     "X|1.500 2.500 3.500 4.500|Y");
+
+    simd::vfloat8 vf8iota = simd::vfloat8::Iota(1.5f);
+    Strutil::print("vfloat8 {{}}  '{}'\n", vf8iota);
+    Strutil::print("vfloat8 {{:.3f}}  '{:.3f}'\n", vf8iota);
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{}|Y", vf8iota),
+                     "X|1.5 2.5 3.5 4.5 5.5 6.5 7.5 8.5|Y");
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{:.3f}|Y", vf8iota),
+                     "X|1.500 2.500 3.500 4.500 5.500 6.500 7.500 8.500|Y");
+
+    simd::vfloat16 vf16iota = simd::vfloat16::Iota(1.5f);
+    Strutil::print("vfloat16 {{}}  '{}'\n", vf16iota);
+    Strutil::print("vfloat16 {{:.3f}}  '{:.3f}'\n", vf16iota);
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{}|Y", vf16iota),
+                     "X|1.5 2.5 3.5 4.5 5.5 6.5 7.5 8.5 9.5 10.5 11.5 12.5 13.5 14.5 15.5 16.5|Y");
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{:.3f}|Y", vf16iota),
+                     "X|1.500 2.500 3.500 4.500 5.500 6.500 7.500 8.500 9.500 10.500 11.500 12.500 13.500 14.500 15.500 16.500|Y");
+
+
+    simd::vint4 vi4iota = simd::vint4::Iota(1);
+    Strutil::print("vint4 {{}}  '{}'\n", vi4iota);
+    Strutil::print("vint4 {{:03d}}  '{:03d}'\n", vi4iota);
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{}|Y", vi4iota),
+                     "X|1 2 3 4|Y");
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{:03d}|Y", vi4iota),
+                     "X|001 002 003 004|Y");
+
+    simd::vint8 vi8iota = simd::vint8::Iota(1);
+    Strutil::print("vint8 {{}}  '{}'\n", vi8iota);
+    Strutil::print("vint8 {{:03d}}  '{:03d}'\n", vi8iota);
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{}|Y", vi8iota),
+                     "X|1 2 3 4 5 6 7 8|Y");
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{:03d}|Y", vi8iota),
+                     "X|001 002 003 004 005 006 007 008|Y");
+
+    simd::vint16 vi16iota = simd::vint16::Iota(1);
+    Strutil::print("vint16 {{}}  '{}'\n", vi16iota);
+    Strutil::print("vint16 {{:03d}}  '{:03d}'\n", vi16iota);
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{}|Y", vi16iota),
+                     "X|1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16|Y");
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{:03d}|Y", vi16iota),
+                     "X|001 002 003 004 005 006 007 008 009 010 011 012 013 014 015 016|Y");
+
+    simd::matrix44 m44iota(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    Strutil::print("matrix44 {{}}  '{}'\n", m44iota);
+    Strutil::print("matrix44 {{:.3f}}  '{:.3f}'\n", m44iota);
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("{}", m44iota),
+                     Strutil::fmt::format("{} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {}",
+                                          m44iota[0][0], m44iota[0][1], m44iota[0][2], m44iota[0][3],
+                                          m44iota[1][0], m44iota[1][1], m44iota[1][2], m44iota[1][3],
+                                          m44iota[2][0], m44iota[2][1], m44iota[2][2], m44iota[2][3],
+                                          m44iota[3][0], m44iota[3][1], m44iota[3][2], m44iota[3][3]));
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{:.3f}|Y", m44iota),
+                     "X|0.000 1.000 2.000 3.000 4.000 5.000 6.000 7.000 8.000 9.000 10.000 11.000 12.000 13.000 14.000 15.000|Y");
+
+    Imath::V3f ivf3iota(1.5f, 2.5f, 3.5f);
+    Strutil::print("Imath::V3f {{}}  '{}'\n", ivf3iota);
+    Strutil::print("Imath::V3f {{:.3f}}  '{:.3f}'\n", ivf3iota);
+    Strutil::print("Imath::V3f {{:,.3f}}  '{:,.3f}'\n", ivf3iota);
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{}|Y", ivf3iota),
+                     "X|1.5 2.5 3.5|Y");
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{:.3f}|Y", ivf3iota),
+                     "X|1.500 2.500 3.500|Y");
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|({:,.3f})|Y", ivf3iota),
+                     "X|(1.500, 2.500, 3.500)|Y");
+    Strutil::print("\n");
 }
 
 
@@ -1376,6 +1466,7 @@ int
 main(int /*argc*/, char* /*argv*/[])
 {
     test_format();
+    test_format_custom();
     test_memformat();
     test_timeintervalformat();
     test_get_rest_arguments();

--- a/src/libutil/type_traits_test.cpp
+++ b/src/libutil/type_traits_test.cpp
@@ -1,0 +1,50 @@
+// Copyright 2008-present Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio
+
+
+#include <limits>
+#include <type_traits>
+
+#include <OpenImageIO/strutil.h>
+#include <OpenImageIO/type_traits.h>
+#include <OpenImageIO/unittest.h>
+
+
+using namespace OIIO;
+using OIIO::Strutil::print;
+
+
+struct test {
+    std::string size() { return ""; }
+};
+
+
+
+int
+main(int /*argc*/, char* /*argv*/[])
+{
+    print("type_traits test\n");
+
+    // Test has_size_method
+    {
+        // std::string has a size() method
+        OIIO_CHECK_EQUAL(has_size_method<std::string>::value, true);
+        // int does not have a size() method
+        OIIO_CHECK_EQUAL(has_size_method<int>::value, false);
+        // struct test has a size method, but it returns a non-integral type
+        OIIO_CHECK_EQUAL(has_size_method<test>::value, false);
+    }
+
+    // Test has_subscript
+    {
+        // std::string has operator[]
+        OIIO_CHECK_EQUAL(has_subscript<std::string>::value, true);
+        // int does not have operator[]
+        OIIO_CHECK_EQUAL(has_subscript<int>::value, false);
+        // struct test does not have operator[]
+        OIIO_CHECK_EQUAL(has_subscript<test>::value, false);
+    }
+
+    return unit_test_failures;
+}


### PR DESCRIPTION
I'm a total convert to fmt (and/or std::format, std::print) and slowly
converting all prior use of sprintf and iostream to it.

If I print an Imath::V3f or a simd::vfloat3,

    fmt::print ("v = {} {} {}\n", myvec[0], myvec[1], myvec[2]);

That's ok, I guess, but it's clunky and a big pain to put the format
specification for every element separately if it were a vfloat16,
say. I would like to be able to do this:

    fmt::print ("v = {}\n", myvec);

and in fact, it does print all elements (thanks to some nice behavior
by fmt)!  But this does not work as expected:

    fmt::print ("v = {:.3f}\n", myvec);

fmt's tricks will print all elements, but only using the default format
spec, and the spec above applied so the "whole thing", not each element,
if you see the distinction.

So this patch sets up the custom formatter infrastructure to be able
to print array-like things (and in particular, the Imath and
OIIO::simd vector and matrix classes) by specifying the format spec
used for the elements.

The important elements to note:

* detail/fmt.h adds custom formatter helpers for (a) any class
  with operator[] and size() ("index_formatter"); (b) any class that
  lacks these but nonetheless has an array-like memory layout and a
  known length ("array_formatter"). I also added a nonstandard
  extension to the format spec for these, which optionally lets you
  use a comma separator rather than just the space between elements.

* These building blocks are used to specify custom formatters for
  the commonly-used Imath types (in our Imath.h) and our internal
  SIMD vector types (in simd.h).

* simd.h also adds a few other goodies, including an `is_simd<>`
  template, and `size()` constexpr methods to each vector type. These
  make certain template metaprogramming tasks easier for these types.

* A new "type_traits.h" header for collecting a bunch of little utility
  templates, such as `has_subscript<>` and `has_size_method<>`.

