### PR TITLE
Fix writing deep exrs when buffer datatype doesn't match the file

### DIFF
--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -857,6 +857,10 @@ Section :ref:`sec-imageinput-deepdata`, is replicated for Python.
 
     Retrieve the packed size (in bytes) of all channels of one sample.
 
+.. py:method:: DeepData.same_channeltypes (other)
+
+    Returns `True` if this DeepData has the same channel types as `other`.
+
 .. py:method:: DeepData.set_samples (pixel, nsamples)
 
     Set the number of samples for a given pixel (specified by integer

--- a/src/include/OpenImageIO/deepdata.h
+++ b/src/include/OpenImageIO/deepdata.h
@@ -30,7 +30,13 @@ public:
     DeepData(const ImageSpec& spec);
 
     /// Copy constructor
-    DeepData(const DeepData& d);
+    DeepData(const DeepData& src);
+
+    /// Copy constructor with change of channel types
+    DeepData(const DeepData& src, cspan<TypeDesc> channeltypes);
+
+    /// Move constructor
+    DeepData(DeepData&& src);
 
     ~DeepData();
 
@@ -92,6 +98,9 @@ public:
     size_t channelsize(int c) const;
     /// Return the size (in bytes) for all channels of one sample.
     size_t samplesize() const;
+
+    /// Does this DeepData have the same channel types as `other`?
+    bool same_channeltypes(const DeepData& other) const;
 
     /// Retrieve the number of samples for the given pixel index.
     int samples(int64_t pixel) const;
@@ -194,9 +203,9 @@ public:
 
 private:
     class Impl;
-    Impl* m_impl;  // holds all the nontrivial stuff
-    int64_t m_npixels;
-    int m_nchannels;
+    Impl* m_impl      = nullptr;  // holds all the nontrivial stuff
+    int64_t m_npixels = 0;
+    int m_nchannels   = 0;
 };
 
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5626,9 +5626,6 @@ output_file(int /*argc*/, const char* argv[])
             adjust_output_options(filename, spec, ir->nativespec(s), ot,
                                   supports_tiles, fileoptions,
                                   (*ir)[s].was_direct_read());
-            // For deep files, must copy the native deep channelformats
-            if (spec.deep)
-                spec.channelformats = (*ir)(s, 0).nativespec().channelformats;
             // If it's not tiled and MIP-mapped, remove any "textureformat"
             if (!spec.tile_pixels() || ir->miplevels(s) <= 1)
                 spec.erase_attribute("textureformat");

--- a/src/python/py_deepdata.cpp
+++ b/src/python/py_deepdata.cpp
@@ -112,6 +112,7 @@ declare_deepdata(py::module& m)
         .def("channeltype", &DeepData::channeltype)
         .def("channelsize",
              [](const DeepData& dd, int c) { return (int)dd.channelsize(c); })
+        .def("same_channeltypes", &DeepData::same_channeltypes)
         .def("samplesize", &DeepData::samplesize)
         .def("deep_value", &DeepData::deep_value, "pixel"_a, "channel"_a,
              "sample"_a)

--- a/testsuite/oiiotool-deep/ref/out-fmt6.txt
+++ b/testsuite/oiiotool-deep/ref/out-fmt6.txt
@@ -41,7 +41,7 @@ allhalf.exr          :  160 x  120, 2 channel, deep half openexr
         8- 15 :     1063 ( 5.5%)
        16- 22 :       91 ( 0.5%)
     Minimum depth was 3.03125 at (159, 56)
-    Maximum depth was 5 at (136, 57)
+    Maximum depth was 5.0 at (136, 57)
 Reading swaptypes.exr
 swaptypes.exr        :  160 x  120, 2 channel, deep float/half openexr
     SHA-1: A26C8B55734B7AE342FA3B37198327B0C00C0BC2
@@ -85,7 +85,7 @@ swaptypes.exr        :  160 x  120, 2 channel, deep float/half openexr
         8- 15 :     1063 ( 5.5%)
        16- 22 :       91 ( 0.5%)
     Minimum depth was 3.03125 at (159, 56)
-    Maximum depth was 5 at (136, 57)
+    Maximum depth was 5.0 at (136, 57)
 Computing diff of "src/deep-nosamples.exr" vs "src/deep-onesample.exr"
   Mean error = 42
   RMS error = 42

--- a/testsuite/oiiotool-deep/run.py
+++ b/testsuite/oiiotool-deep/run.py
@@ -8,6 +8,12 @@ command += oiiotool("src/deepalpha.exr --flatten -o flat.exr")
 # test --ch on deep files (and --chnames)
 command += oiiotool("src/deepalpha.exr --ch =0.0,A,=0.5,A,Z --chnames R,G,B,A,Z --flatten -d half -o ch.exr")
 
+# test -d 
+command += oiiotool("src/deepalpha.exr -d half -o allhalf.exr")
+command += info_command("allhalf.exr", extraargs="--stats", safematch=1)
+command += oiiotool("src/deepalpha.exr -d A=float -d Z=half -o swaptypes.exr")
+command += info_command("swaptypes.exr", extraargs="--stats", safematch=1)
+
 # --deepen
 command += oiiotool("-pattern fill:topleft=0,14:topright=0.5,15:bottomleft=0.5,14:bottomright=1,15 4x4 2 -chnames A,Z -fill:color=0,1e38 2x1+1+2 -o az.exr")
 command += oiiotool("az.exr -deepen -o deepen.exr")


### PR DESCRIPTION
In OpenEXROutput::write_deep_scanlines and write_deep_tiles, don't
just pass the DeepData along -- handle the case of where the DD (the
buffer the caller is presenting) does not match the data types that
you said the file is going to hold. In this case, we need to make a
local temporary DD that holds a copy of the passed-in data, but with
the formats transcoded.

Some changes to DeepData were done to support this.
