### PR TITLE
CI: Remove the windows-2016 that will be imminently removed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,7 @@ jobs:
             os: ubuntu-18.04
             cxx_compiler: g++-8
             cxx_std: 17
-            openexr_ver: v2.5.6
+            openexr_ver: v2.5.8
             pybind11_ver: v2.5.0
             simd: avx
           - desc: static libs gcc7 C++14 exr2.4
@@ -376,19 +376,22 @@ jobs:
   windows:
     name: "${{matrix.os}} VS${{matrix.vsver}}"
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - os: windows-2016
-            vsver: 2017
-            generator: "Visual Studio 15 2017 Win64"
-            openexr_ver: v2.5.6
-            python_ver: 3.7
           - os: windows-2019
             vsver: 2019
             generator: "Visual Studio 16 2019"
-            openexr_ver: v2.5.6
+            openexr_ver: v2.5.8
             python_ver: 3.7
             simd: sse4.2
+          # - os: windows-2022
+          #   vsver: 2022
+          #   generator: "Visual Studio 17 2022"
+          #   openexr_ver: main
+          #   # v3.1.4
+          #   python_ver: 3.7
+          #   simd: sse4.2
     runs-on: ${{ matrix.os }}
     env:
       PYTHON_VERSION: ${{matrix.python_ver}}

--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -27,9 +27,13 @@ export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DEP_DIR/lib:$VCPKG_INSTALLATION_ROOT/i
 
 if [[ "$PYTHON_VERSION" == "3.6" ]] ; then
     export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;/c/hostedtoolcache/windows/Python/3.6.8/x64"
-else
+elif [[ "$PYTHON_VERSION" == "3.7" ]] ; then
     export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;/c/hostedtoolcache/windows/Python/3.7.9/x64"
     export Python_EXECUTABLE="/c/hostedtoolcache/windows/Python/3.7.9/x64/python.exe"
+    export PYTHONPATH=$OpenImageIO_ROOT/lib/python${PYTHON_VERSION}/site-packages
+elif [[ "$PYTHON_VERSION" == "3.9" ]] ; then
+    export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;/c/hostedtoolcache/windows/Python/3.9.10/x64"
+    export Python_EXECUTABLE="/c/hostedtoolcache/windows/Python/3.9.10/x64/python3.exe"
     export PYTHONPATH=$OpenImageIO_ROOT/lib/python${PYTHON_VERSION}/site-packages
 fi
 pip install numpy


### PR DESCRIPTION
GHA is retiring the windows-2016 image, we won't be able to use it soon.

Also bump openexr versions in a couple places.

There's some in-progress work on a VS2022 test, but ignore that for now,
it's commented out.
