### PR TITLE
Fix conflict between RESTful and Windows long path notation

### DIFF
--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -280,6 +280,14 @@ test_get_rest_arguments()
     OIIO_CHECK_EQUAL(base, "atext");
     OIIO_CHECK_EQUAL(result["arg1"], "value1");
     OIIO_CHECK_EQUAL(result["arg2"], "somevalue");
+
+    // Test windows long filename syntax
+    result.clear();
+    url = "\\\\?\\UNC\\server\\foo?arg1=value1";
+    ret = Strutil::get_rest_arguments(url, base, result);
+    OIIO_CHECK_EQUAL(ret, true);
+    OIIO_CHECK_EQUAL(base, "\\\\?\\UNC\\server\\foo");
+    OIIO_CHECK_EQUAL(result["arg1"], "value1");
 }
 
 


### PR DESCRIPTION
When trying to break filenames into the base name and any "RESTful"
arguments (such as "/foo/bar.exr?name=value&dog=cat"), we were
just looking for presence of the "?" to determine if it was a RESTful
thingie and using that as the split position.

But this is thrown off by an odd Windows notation where names that
start with (get this) `\\?\` somehow designate long filepaths. See
See: https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation

So the solution is to change Strutil::get_rest_arguments to explicitly
check for this pattern at the start of the string.
