### PR TITLE
BMP files - read additional varieties

### DIFF
--- a/src/bmp.imageio/bmp_pvt.cpp
+++ b/src/bmp.imageio/bmp_pvt.cpp
@@ -92,7 +92,8 @@ DibInformationHeader::read_header(Filesystem::IOProxy* fd)
     if (!fread(fd, &size))
         return false;
 
-    if (size == WINDOWS_V3 || size == WINDOWS_V4 || size == WINDOWS_V5) {
+    if (size == WINDOWS_V3 || size == WINDOWS_V4 || size == WINDOWS_V5
+        || size == UNDOCHEADER52 || size == UNDOCHEADER56) {
         if (!fread(fd, &width) || !fread(fd, &height) || !fread(fd, &cplanes)
             || !fread(fd, &bpp) || !fread(fd, &compression)
             || !fread(fd, &isize) || !fread(fd, &hres) || !fread(fd, &vres)
@@ -100,16 +101,24 @@ DibInformationHeader::read_header(Filesystem::IOProxy* fd)
             return false;
         }
 
+        if (size == WINDOWS_V4 || size == WINDOWS_V5 || size == UNDOCHEADER52
+            || size == UNDOCHEADER56) {
+            if (!fread(fd, &red_mask) || !fread(fd, &green_mask)
+                || !fread(fd, &blue_mask)) {
+                return false;
+            }
+            if (size != UNDOCHEADER52 && !fread(fd, &alpha_mask)) {
+                return false;
+            }
+        }
+
         if (size == WINDOWS_V4 || size == WINDOWS_V5) {
-            if (!fread(fd, &red_mask) || !fread(fd, &blue_mask)
-                || !fread(fd, &green_mask) || !fread(fd, &alpha_mask)
-                || !fread(fd, &cs_type) || !fread(fd, &red_x)
-                || !fread(fd, &red_y) || !fread(fd, &red_z)
-                || !fread(fd, &green_x) || !fread(fd, &green_y)
-                || !fread(fd, &green_z) || !fread(fd, &blue_x)
-                || !fread(fd, &blue_y) || !fread(fd, &blue_z)
-                || !fread(fd, &gamma_x) || !fread(fd, &gamma_y)
-                || !fread(fd, &gamma_z)) {
+            if (!fread(fd, &cs_type) || !fread(fd, &red_x) || !fread(fd, &red_y)
+                || !fread(fd, &red_z) || !fread(fd, &green_x)
+                || !fread(fd, &green_y) || !fread(fd, &green_z)
+                || !fread(fd, &blue_x) || !fread(fd, &blue_y)
+                || !fread(fd, &blue_z) || !fread(fd, &gamma_x)
+                || !fread(fd, &gamma_y) || !fread(fd, &gamma_z)) {
                 return false;
             }
         }

--- a/src/bmp.imageio/bmp_pvt.h
+++ b/src/bmp.imageio/bmp_pvt.h
@@ -7,16 +7,23 @@
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
 
+// Docs reminders:
+// https://en.wikipedia.org/wiki/BMP_file_format
+// https://web.archive.org/web/20150127132443/https://forums.adobe.com/message/3272950
+
+
 namespace bmp_pvt {
 
 // size of the BMP file header (the first header that occur in BMP file)
 const int BMP_HEADER_SIZE = 14;
 
 // sizes of various DIB haders
-const int OS2_V1     = 12;
-const int WINDOWS_V3 = 40;
-const int WINDOWS_V4 = 108;
-const int WINDOWS_V5 = 124;
+const int OS2_V1        = 12;
+const int WINDOWS_V3    = 40;
+const int UNDOCHEADER52 = 52;  // 0x34
+const int UNDOCHEADER56 = 56;  // 0x38
+const int WINDOWS_V4    = 108;
+const int WINDOWS_V5    = 124;
 
 // bmp magic numbers
 const int16_t MAGIC_BM = 0x4D42;

--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -134,11 +134,20 @@ BmpInput::open(const std::string& name, ImageSpec& newspec,
         close();
         return false;
     }
+    // Strutil::print(
+    //     "Header: magic={:x} {}{} fsize={} res1={} res2={} offset={}\n",
+    //     m_bmp_header.magic, char(m_bmp_header.magic & 0xff),
+    //     char(m_bmp_header.magic >> 8), m_bmp_header.fsize, m_bmp_header.res1,
+    //     m_bmp_header.res2, m_bmp_header.offset);
     if (!m_dib_header.read_header(ioproxy())) {
         errorfmt("\"{}\": wrong bitmap header size", name);
         close();
         return false;
     }
+    // Strutil::print(
+    //     "Header: size={}(0x{:02x}) width={} height={} cplanes={} bpp={}\n",
+    //     m_dib_header.size, m_dib_header.size, m_dib_header.width,
+    //     m_dib_header.height, m_dib_header.cplanes, m_dib_header.bpp);
 
     const int nchannels = (m_dib_header.bpp == 32) ? 4 : 3;
     const int height    = (m_dib_header.height >= 0) ? m_dib_header.height

--- a/testsuite/bmp/ref/out.txt
+++ b/testsuite/bmp/ref/out.txt
@@ -231,6 +231,15 @@ src/PRINTER.BMP      :  160 x  120, 3 channel, uint8 bmp
     bmp:version: 1
 Comparing "src/PRINTER.BMP" and "PRINTER.BMP"
 PASS
+Reading ../oiio-images/bmp/gracehopper.bmp
+../oiio-images/bmp/gracehopper.bmp :  256 x  256, 4 channel, uint8 bmp
+    SHA-1: D4C5C625347E8B963DD04AFCE1C25D6EFEDF7CFF
+    channel list: R, G, B, A
+    ResolutionUnit: "m"
+    XResolution: 2835
+    YResolution: 2835
+Comparing "../oiio-images/bmp/gracehopper.bmp" and "gracehopper.bmp"
+PASS
 oiiotool ERROR: read : "src/decodecolormap-corrupt.bmp": Possible corrupted header, invalid palette size
 Full command line was:
 > oiiotool --info -v -a --hash src/decodecolormap-corrupt.bmp

--- a/testsuite/bmp/run.py
+++ b/testsuite/bmp/run.py
@@ -26,5 +26,8 @@ command += rw_command ("src", "g01bg2-v5.bmp")
 # See https://github.com/OpenImageIO/oiio/issues/2898
 command += rw_command ("src", "PRINTER.BMP")
 
+# Test BMP of the 56-byte DIB header variety
+command += rw_command ("../oiio-images/bmp", "gracehopper.bmp")
+
 # See if we handle this corrupt file with a useful error message
 command += info_command ("src/decodecolormap-corrupt.bmp")


### PR DESCRIPTION
There are two undocumented varieties of BMP files only written by
certain Adobe apps that we did not properly handle, identified by the
size value in their header.

This is the only explanation I could find about it:
https://web.archive.org/web/20150127132443/https://forums.adobe.com/message/3272950

Fixes https://github.com/OpenImageIO/oiio/issues/3347