### PR TITLE
Python: support uint8 attributes in and out

### DIFF
--- a/testsuite/python-imageinput/ref/out-alt.txt
+++ b/testsuite/python-imageinput/ref/out-alt.txt
@@ -26,7 +26,7 @@ Opened "../oiio-images/tahoe-gps.jpg" as a jpeg
   Exif:PixelXDimension = 2048
   Exif:PixelYDimension = 1536
   Exif:WhiteBalance = 0
-  GPS:VersionID = None
+  GPS:VersionID = (2, 2, 0, 0)
   GPS:LatitudeRef = "N"
   GPS:Latitude = (39.0, 18.0, 24.399999618530273)
   GPS:LongitudeRef = "W"

--- a/testsuite/python-imageinput/ref/out-alt2.txt
+++ b/testsuite/python-imageinput/ref/out-alt2.txt
@@ -26,7 +26,7 @@ Opened "../oiio-images/tahoe-gps.jpg" as a jpeg
   Exif:PixelXDimension = 2048
   Exif:PixelYDimension = 1536
   Exif:WhiteBalance = 0
-  GPS:VersionID = None
+  GPS:VersionID = (2, 2, 0, 0)
   GPS:LatitudeRef = "N"
   GPS:Latitude = (39.0, 18.0, 24.399999618530273)
   GPS:LongitudeRef = "W"

--- a/testsuite/python-imageinput/ref/out-py37-jpeg9d.txt
+++ b/testsuite/python-imageinput/ref/out-py37-jpeg9d.txt
@@ -26,7 +26,7 @@ Opened "../oiio-images/tahoe-gps.jpg" as a jpeg
   Exif:PixelXDimension = 2048
   Exif:PixelYDimension = 1536
   Exif:WhiteBalance = 0
-  GPS:VersionID = None
+  GPS:VersionID = (2, 2, 0, 0)
   GPS:LatitudeRef = "N"
   GPS:Latitude = (39.0, 18.0, 24.399999618530273)
   GPS:LongitudeRef = "W"

--- a/testsuite/python-imageinput/ref/out-python3-win.txt
+++ b/testsuite/python-imageinput/ref/out-python3-win.txt
@@ -26,7 +26,7 @@ Opened "D:/a/oiio/oiio/build/testsuite/oiio-images/tahoe-gps.jpg" as a jpeg
   Exif:PixelXDimension = 2048
   Exif:PixelYDimension = 1536
   Exif:WhiteBalance = 0
-  GPS:VersionID = None
+  GPS:VersionID = (2, 2, 0, 0)
   GPS:LatitudeRef = "N"
   GPS:Latitude = (39.0, 18.0, 24.399999618530273)
   GPS:LongitudeRef = "W"

--- a/testsuite/python-imageinput/ref/out-python3.txt
+++ b/testsuite/python-imageinput/ref/out-python3.txt
@@ -26,7 +26,7 @@ Opened "../oiio-images/tahoe-gps.jpg" as a jpeg
   Exif:PixelXDimension = 2048
   Exif:PixelYDimension = 1536
   Exif:WhiteBalance = 0
-  GPS:VersionID = None
+  GPS:VersionID = (2, 2, 0, 0)
   GPS:LatitudeRef = "N"
   GPS:Latitude = (39.0, 18.0, 24.399999618530273)
   GPS:LongitudeRef = "W"

--- a/testsuite/python-imageinput/ref/out-travis-py2.7-pybind2.3.txt
+++ b/testsuite/python-imageinput/ref/out-travis-py2.7-pybind2.3.txt
@@ -26,7 +26,7 @@ Opened "../oiio-images/tahoe-gps.jpg" as a jpeg
   Exif:PixelXDimension = 2048
   Exif:PixelYDimension = 1536
   Exif:WhiteBalance = 0
-  GPS:VersionID = None
+  GPS:VersionID = (2, 2, 0, 0)
   GPS:LatitudeRef = "N"
   GPS:Latitude = (39.0, 18.0, 24.399999618530273)
   GPS:LongitudeRef = "W"

--- a/testsuite/python-imageinput/ref/out-travis.txt
+++ b/testsuite/python-imageinput/ref/out-travis.txt
@@ -26,7 +26,7 @@ Opened "../oiio-images/tahoe-gps.jpg" as a jpeg
   Exif:PixelXDimension = 2048
   Exif:PixelYDimension = 1536
   Exif:WhiteBalance = 0
-  GPS:VersionID = None
+  GPS:VersionID = (2, 2, 0, 0)
   GPS:LatitudeRef = "N"
   GPS:Latitude = (39.0, 18.0, 24.399999618530273)
   GPS:LongitudeRef = "W"

--- a/testsuite/python-imageinput/ref/out.txt
+++ b/testsuite/python-imageinput/ref/out.txt
@@ -26,7 +26,7 @@ Opened "../oiio-images/tahoe-gps.jpg" as a jpeg
   Exif:PixelXDimension = 2048
   Exif:PixelYDimension = 1536
   Exif:WhiteBalance = 0
-  GPS:VersionID = None
+  GPS:VersionID = (2, 2, 0, 0)
   GPS:LatitudeRef = "N"
   GPS:Latitude = (39.0, 18.0, 24.399999618530273)
   GPS:LongitudeRef = "W"


### PR DESCRIPTION
This is necessary for dealing correctly with ICCProfile ImageSpec
attributes, which are simply arrays of uint8's.
