### PR TITLE
exr output: Fix dwaa compression default

### DIFF
--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -716,7 +716,7 @@ OpenEXROutput::spec_to_header(ImageSpec& spec, int subimage,
 
     string_view comp;
     int qual;
-    std::tie(comp, qual) = spec.decode_compression_metadata("zip", 4);
+    std::tie(comp, qual) = spec.decode_compression_metadata("zip", -1);
     // It seems that zips is the only compression that can reliably work
     // on deep files (but allow "none" as well)
     if (spec.deep && comp != "none")
@@ -734,8 +734,8 @@ OpenEXROutput::spec_to_header(ImageSpec& spec, int subimage,
     }
     spec.attribute("compression", comp);
 #if OPENEXR_CODED_VERSION >= 30103
-    if (Strutil::istarts_with(comp, "zip") && qual >= 1 && qual <= 9) {
-        header.zipCompressionLevel() = qual;
+    if (Strutil::istarts_with(comp, "zip")) {
+        header.zipCompressionLevel() = (qual >= 1 && qual <= 9) ? qual : 4;
     }
 #endif
 


### PR DESCRIPTION
When outputting OpenEXR files, in a case where the "compression"
request was for "dwaa" (no compression specified in the main name,
like "dwaa:100") we accidentally forced a default quality level of 4,
which is the default we wanted for zip compression. But that's not a
good default for dwaa!
