### PR TITLE
Speed up case insensitive string comparisons

### DIFF
--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -346,6 +346,11 @@ test_comparisons()
     OIIO_CHECK_EQUAL(Strutil::iequals("abc", "abc"), true);
     OIIO_CHECK_EQUAL(Strutil::iequals("Abc", "aBc"), true);
     OIIO_CHECK_EQUAL(Strutil::iequals("abc", "adc"), false);
+    OIIO_CHECK_EQUAL(Strutil::iequals("abc", "abcd"), false);
+    OIIO_CHECK_EQUAL(Strutil::iequals("abcd", "abc"), false);
+    OIIO_CHECK_EQUAL(Strutil::iequals("", "abc"), false);
+    OIIO_CHECK_EQUAL(Strutil::iequals("abc", ""), false);
+    OIIO_CHECK_EQUAL(Strutil::iequals("", ""), true);
 
     OIIO_CHECK_EQUAL(Strutil::starts_with("abcd", "ab"), true);
     OIIO_CHECK_EQUAL(Strutil::starts_with("aBcd", "Ab"), false);
@@ -472,8 +477,17 @@ test_comparisons()
     bench.indent (2);
     bench.units (Benchmarker::Unit::ns);
     std::string abc = "abcdefghijklmnopqrstuvwxyz";
+    std::string abcmore = "abcdefghijklmnopqrstuvwxyz1";
+    std::string abcnope = "1abcdefghijklmnopqrstuvwxyz";
     std::string haystack = std::string("begin") + abc + "oiio"
                          + Strutil::repeat(abc, 10) + "123" + abc + "end";
+    bench ("string== success", [&](){ DoNotOptimize(abc == abc); });
+    bench ("string== failure", [&](){ DoNotOptimize(abc == abcmore); });
+    bench ("iequals success", [&](){ DoNotOptimize(Strutil::iequals(abc, abc)); });
+    bench ("iless easy", [&](){ DoNotOptimize(Strutil::iless(abc, abcnope)); });
+    bench ("iless hard", [&](){ DoNotOptimize(Strutil::iless(abc, abc)); });
+    bench ("StringILess easy", [&](){ DoNotOptimize(iless(abc, abcnope)); });
+    bench ("StringILess hard", [&](){ DoNotOptimize(iless(abc, abc)); });
     bench ("contains early small", [&](){ DoNotOptimize(Strutil::contains(abc, "def")); });
     bench ("contains early big", [&](){ DoNotOptimize(Strutil::contains(haystack, "oiio")); });
     bench ("contains late small", [&](){ DoNotOptimize(Strutil::contains(abc, "uvw")); });
@@ -521,8 +535,12 @@ test_comparisons()
 
     bench ("starts_with success", [&](){ DoNotOptimize(Strutil::starts_with(abc, "abc")); });
     bench ("starts_with fail", [&](){ DoNotOptimize(Strutil::starts_with(abc, "def")); });
+    bench ("istarts_with success", [&](){ DoNotOptimize(Strutil::istarts_with(abc, "abc")); });
+    bench ("istarts_with fail", [&](){ DoNotOptimize(Strutil::istarts_with(abc, "def")); });
     bench ("ends_with success", [&](){ DoNotOptimize(Strutil::ends_with(abc, "xyz")); });
     bench ("ends_with fail", [&](){ DoNotOptimize(Strutil::ends_with(abc, "def")); });
+    bench ("iends_with success", [&](){ DoNotOptimize(Strutil::iends_with(abc, "xyz")); });
+    bench ("iends_with fail", [&](){ DoNotOptimize(Strutil::iends_with(abc, "def")); });
 }
 
 


### PR DESCRIPTION
Oh boy, never leave anything unbenchmarked.

Turns out the boost::algorithm functions we were relying on underneath
many Strutil "case-insensitive" comparisons were ridiculously slow.
We thought they were good enough because they allowed specification of
locale, so we could just pass the static classic locale, and so they
would be inexpensive because they didn't have to query the current
locale.  But this is wrong, they were still ghastly.

So here I rewrite Strutil::iequals, iless, starts_with, istarts_with,
ends_with, iends_with in terms of a new (internal) Strutil::strcasecmp
and strncasecmp (which underneath handle differences in platform, and
use the locale-independent versions). The net result is that most of
those case-independent comparisons speed up by a factor of
50-100x. Wow.

I still need to tackle the family of 'ifind' related functions. They
are a bit trickier. But I'll leave them for another time, because I
need to roll this present fix out right away to fix a real production
bottleneck.

(Worth noting: iequals is instrumental when you're searching a
ParamValueList for a particular name, which is what happens when you
look up attributes from an ImageSpec, which is what happens when you
call get_texture_info(), which is what underlies OSL gettextureinfo()
calls in the cases that they cannot be constant-folded during runtime
optimization. So this came to my attention when analyzing a slow scene
whose shaders had a pathological explosion of gettextureinfo calls that
couldn't be optimized away.)

