### PR TITLE
Make oiiotool unity-ready

### DIFF
--- a/src/oiiotool/diff.cpp
+++ b/src/oiiotool/diff.cpp
@@ -13,13 +13,13 @@
 #include <string>
 #include <vector>
 
+#include "oiiotool.h"
+
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/filter.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/imageio.h>
-
-#include "oiiotool.h"
 
 using namespace OIIO;
 using namespace OiioTool;

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -12,6 +12,8 @@
 #include <utility>
 #include <vector>
 
+#include "oiiotool.h"
+
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/filter.h>
@@ -20,8 +22,6 @@
 #include <OpenImageIO/imagecache.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/thread.h>
-
-#include "oiiotool.h"
 
 using namespace OIIO;
 using namespace OiioTool;

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -17,6 +17,8 @@
 #include <utility>
 #include <vector>
 
+#include "oiiotool.h"
+
 #include <OpenEXR/ImfTimeCode.h>
 #include <OpenImageIO/Imath.h>
 
@@ -33,8 +35,6 @@
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/timer.h>
-
-#include "oiiotool.h"
 
 using namespace OIIO;
 using namespace OiioTool;

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -11,6 +11,9 @@
 
 #include <boost/container/flat_set.hpp>
 
+#include <OpenImageIO/Imath.h>
+
+#include <OpenImageIO/argparse.h>
 #include <OpenImageIO/color.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagecache.h>

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -15,6 +15,8 @@
 #    include <io.h>
 #endif
 
+#include "oiiotool.h"
+
 #include <OpenImageIO/Imath.h>
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/deepdata.h>
@@ -25,8 +27,6 @@
 #include <OpenImageIO/span.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/sysutil.h>
-
-#include "oiiotool.h"
 
 using namespace OIIO;
 using namespace OiioTool;


### PR DESCRIPTION
This is the first tiny step to fixing all the little things that break
in a unity build. This one is pretty small fry -- the oiiotool set of
modules only needed some minor rearrangement of header file include
order.
