### PR TITLE
Fix botched build from PR 3381, command line utils not installed

### DIFF
--- a/src/build-scripts/ci-test.bash
+++ b/src/build-scripts/ci-test.bash
@@ -4,7 +4,7 @@
 # any command in it fails. This is crucial for CI tests.
 set -ex
 
-$OpenImageIO_ROOT/bin/oiiotool --help || true
+$OpenImageIO_ROOT/bin/oiiotool --help
 
 echo "Parallel test " ${CTEST_PARALLEL_LEVEL}
 pushd build

--- a/src/cmake/fancy_add_executable.cmake
+++ b/src/cmake/fancy_add_executable.cmake
@@ -51,6 +51,7 @@ macro (fancy_add_executable)
             target_link_libraries (${_target_NAME} PRIVATE ${_target_LINK_LIBRARIES})
         endif ()
         set_target_properties (${_target_NAME} PROPERTIES FOLDER "Tools")
+        check_is_enabled (INSTALL_${_target_NAME} _target_NAME_INSTALL_enabled)
         if (CMAKE_UNITY_BUILD)
             set_source_files_properties(${_target_SRC} PROPERTIES
                                         UNITY_GROUP ${_target_NAME})


### PR DESCRIPTION
Cut/paste error inadvertently deleted a critical cmake line that I
wasn't intending to alter or remove, that resulted in the command line
utilities not being tagged for part of the install step. Oops!
