### PR TITLE
OIIO_ERRORHANDLER_HIDE_PRINTF as aid for fmt conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,9 @@ if (${PROJ_NAME}_NAMESPACE_INCLUDE_PATCH)
 endif ()
 message(STATUS "Setting Namespace to: ${PROJ_NAMESPACE_V}")
 
+# Define OIIO_INTERNAL symbol only when building OIIO itself, will not be
+# defined for downstream projects using OIIO.
+add_definitions (-DOIIO_INTERNAL=1)
 
 list (APPEND CMAKE_MODULE_PATH
       "${PROJECT_SOURCE_DIR}/src/cmake/modules"

--- a/src/doc/Doxyfile
+++ b/src/doc/Doxyfile
@@ -2173,6 +2173,7 @@ PREDEFINED             = DOXYGEN_SHOULD_SKIP_THIS \
                          OIIO_NODISCARD=[[nodiscard]] \
                          OIIO_DEPRECATED:=[[deprecated]] \
                          OIIO_FORMAT_DEPRECATED:= \
+                         OIIO_ERRORHANDLER_PRINTF_DEPRECATED:= \
                          OIIO_FORCEINLINE=inline \
                          IMATH_HALF_H_=1 \
                          INCLUDED_IMATHVEC_H=1 \

--- a/src/include/OpenImageIO/errorhandler.h
+++ b/src/include/OpenImageIO/errorhandler.h
@@ -10,6 +10,19 @@
 #include <OpenImageIO/strutil.h>
 
 
+// If OIIO_ERRORHANDLER_HIDE_PRINTF is defined, mark the old-style printf-like
+// format functions as deprecated. (This is a debugging aid for downstream
+// projects who want to root out any places where they might be using the old
+// one).
+#if defined(OIIO_ERRORHANDLER_HIDE_PRINTF) || defined(OIIO_INTERNAL)
+#    define OIIO_ERRORHANDLER_PRINTF_DEPRECATED \
+        OIIO_DEPRECATED(                        \
+            "old style (printf-like) formatting version of this function is deprecated")
+#else
+#    define OIIO_ERRORHANDLER_PRINTF_DEPRECATED
+#endif
+
+
 OIIO_NAMESPACE_BEGIN
 
 /// ErrorHandler is a simple class that accepts error messages
@@ -145,41 +158,47 @@ public:
     // in some future OIIO release.
     //
     template<typename... Args>
-    void infof(const char* format, const Args&... args)
+    OIIO_ERRORHANDLER_PRINTF_DEPRECATED void infof(const char* format,
+                                                   const Args&... args)
     {
         if (verbosity() >= VERBOSE)
             info(Strutil::sprintf(format, args...));
     }
 
     template<typename... Args>
-    void warningf(const char* format, const Args&... args)
+    OIIO_ERRORHANDLER_PRINTF_DEPRECATED void warningf(const char* format,
+                                                      const Args&... args)
     {
         if (verbosity() >= NORMAL)
             warning(Strutil::sprintf(format, args...));
     }
 
     template<typename... Args>
-    void errorf(const char* format, const Args&... args)
+    OIIO_ERRORHANDLER_PRINTF_DEPRECATED void errorf(const char* format,
+                                                    const Args&... args)
     {
         error(Strutil::sprintf(format, args...));
     }
 
     template<typename... Args>
-    void severef(const char* format, const Args&... args)
+    OIIO_ERRORHANDLER_PRINTF_DEPRECATED void severef(const char* format,
+                                                     const Args&... args)
     {
         severe(Strutil::sprintf(format, args...));
     }
 
     template<typename... Args>
-    void messagef(const char* format, const Args&... args)
+    OIIO_ERRORHANDLER_PRINTF_DEPRECATED void messagef(const char* format,
+                                                      const Args&... args)
     {
         if (verbosity() > QUIET)
             message(Strutil::sprintf(format, args...));
     }
 
     template<typename... Args>
-    void debugf(const char* format OIIO_MAYBE_UNUSED,
-                const Args&... args OIIO_MAYBE_UNUSED)
+    OIIO_ERRORHANDLER_PRINTF_DEPRECATED void
+    debugf(const char* format OIIO_MAYBE_UNUSED,
+           const Args&... args OIIO_MAYBE_UNUSED)
     {
 #ifndef NDEBUG
         debug(Strutil::sprintf(format, args...));


### PR DESCRIPTION
When this symbol is defined, this marks as deprecated the ErrorHandler
class methods that use sprintf formatting notation. It's not enabled
by default, but a downstream project can define the symbol in order to
help root out any uses of the old style formatting functions, to aid
identifying and changing those spots to the new style, long before
they are truly deprecated or removed from OIIO.

This change also sets up an OIIO_INTERNAL symbol that will be present
when OIIO itself is compiling, but not a downstream project using the
OIIO headers.
