### PR TITLE
More work to enable unity/jumbo builds

### DIFF
--- a/src/cineon.imageio/libcineon/CineonHeader.cpp
+++ b/src/cineon.imageio/libcineon/CineonHeader.cpp
@@ -82,7 +82,7 @@ cineon::GenericHeader::GenericHeader()
 void cineon::GenericHeader::Reset()
 {
 	// File Information
-	this->magicNumber = MAGIC_COOKIE;
+	this->magicNumber = CINEON_MAGIC_COOKIE;
 	this->imageOffset = ~0;
 	EmptyString(this->version);
 	OIIO::Strutil::safe_strcpy(this->version, SPEC_VERSION, sizeof(this->version));
@@ -254,7 +254,7 @@ bool cineon::Header::WriteOffsetData(OutStream *io)
 	//const long IMAGE_STRUCTURE = 72;	// sizeof the image data structure
 
 	/*int i;
-	for (i = 0; i < MAX_ELEMENTS; i++)
+	for (i = 0; i < CINEON_MAX_ELEMENTS; i++)
 	{
 			// only write if there is a defined image description
 			if (this->chan[i].descriptor == kUndefinedDescriptor)
@@ -276,7 +276,7 @@ bool cineon::Header::WriteOffsetData(OutStream *io)
 
 bool cineon::Header::ValidMagicCookie(const U32 magic)
 {
-	U32 mc = MAGIC_COOKIE;
+	U32 mc = CINEON_MAGIC_COOKIE;
 
 	if (magic == mc)
 		return true;
@@ -289,7 +289,7 @@ bool cineon::Header::ValidMagicCookie(const U32 magic)
 
 bool cineon::Header::DetermineByteSwap(const U32 magic) const
 {
-	U32 mc = MAGIC_COOKIE;
+	U32 mc = CINEON_MAGIC_COOKIE;
 
 	bool byteSwap = false;
 
@@ -317,7 +317,7 @@ bool cineon::Header::Validate()
 		SwapBytes(this->fileSize);
 
 		// Image information
-		for (int i = 0; i < MAX_ELEMENTS; i++)
+		for (int i = 0; i < CINEON_MAX_ELEMENTS; i++)
 		{
 			SwapBytes(this->chan[i].pixelsPerLine);
 			SwapBytes(this->chan[i].linesPerElement);
@@ -372,7 +372,7 @@ int cineon::GenericHeader::ImageElementCount() const
 {
 	int i = 0;
 
-	while (i < MAX_ELEMENTS )
+	while (i < CINEON_MAX_ELEMENTS )
 	{
 		if (this->ImageDescriptor(i) == kUndefinedDescriptor)
 			break;
@@ -398,7 +398,7 @@ void cineon::Header::CalculateOffsets()
 {
 	int i;
 
-	for (i = 0; i < MAX_ELEMENTS; i++)
+	for (i = 0; i < CINEON_MAX_ELEMENTS; i++)
 	{
 		// only write if there is a defined image description
 		if (this->chan[i].designator[1] == kUndefinedDescriptor)
@@ -411,7 +411,7 @@ void cineon::Header::CalculateOffsets()
 
 cineon::DataSize cineon::GenericHeader::ComponentDataSize(const int element) const
 {
-	if (element < 0 || element >= MAX_ELEMENTS)
+	if (element < 0 || element >= CINEON_MAX_ELEMENTS)
 		return kByte;
 
 	cineon::DataSize ret;
@@ -444,7 +444,7 @@ cineon::DataSize cineon::GenericHeader::ComponentDataSize(const int element) con
 
 int cineon::GenericHeader::ComponentByteCount(const int element) const
 {
-	if (element < 0 || element >= MAX_ELEMENTS)
+	if (element < 0 || element >= CINEON_MAX_ELEMENTS)
 		return kByte;
 
 	int ret;

--- a/src/cineon.imageio/libcineon/CineonHeader.h
+++ b/src/cineon.imageio/libcineon/CineonHeader.h
@@ -64,24 +64,17 @@
  */
 #define SPEC_VERSION		"V4.5"
 
-/*!
- * \def MAX_ELEMENTS
+   /*!
+ * \def CINEON_MAX_ELEMENTS
  * \brief Maximum number of image elements
  */
-#define MAX_ELEMENTS		8
+#define CINEON_MAX_ELEMENTS 8
 
-/*!
- * \def MAX_COMPONENTS
- * \brief Maximum number of components per image element
- */
-#define MAX_COMPONENTS		8
-
-
-/*!
- * \def MAGIC_COOKIE
+   /*!
+ * \def CINEON_MAGIC_COOKIE
  * \brief HEX value of 0x802A5FD7
  */
-#define MAGIC_COOKIE		0x802A5FD7
+#define CINEON_MAGIC_COOKIE		0x802A5FD7
 
 
 
@@ -275,8 +268,8 @@ namespace cineon
 		U8					imageOrientation;			//!< Image orientation \see Orientation
 		U8					numberOfElements;			//!< Number of elements (1-8)
 		U8					unused1[2];					//!< Unused (word alignment)
-		ImageElement		chan[MAX_ELEMENTS];			//!< Image element data structures
-		R32					whitePoint[2];				//!< White point (x, y pair)
+        ImageElement        chan[CINEON_MAX_ELEMENTS];  //!< Image element data structures
+        R32					whitePoint[2];				//!< White point (x, y pair)
 		R32					redPrimary[2];				//!< Red primary chromaticity (x, y pair)
 		R32					greenPrimary[2];			//!< Green primary chromaticity (x, y pair)
 		R32					bluePrimary[2];				//!< Blue primary chromaticity (x, y pair)
@@ -1242,30 +1235,30 @@ namespace cineon
 
 	inline U32 GenericHeader::PixelsPerLine(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return 0xffffffff;
-		return this->chan[i].pixelsPerLine;
+        if (i < 0 || i >= CINEON_MAX_ELEMENTS)
+            return 0xffffffff;
+        return this->chan[i].pixelsPerLine;
 	}
 
 	inline void GenericHeader::SetPixelsPerLine(const int i, const U32 ppl)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].pixelsPerLine = ppl;
+        if (i < 0 || i >= CINEON_MAX_ELEMENTS)
+            return;
+        this->chan[i].pixelsPerLine = ppl;
 	}
 
 	inline U32 GenericHeader::LinesPerElement(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return 0xffffffff;
-		return this->chan[i].linesPerElement;
+        if (i < 0 || i >= CINEON_MAX_ELEMENTS)
+            return 0xffffffff;
+        return this->chan[i].linesPerElement;
 	}
 
 	inline void GenericHeader::SetLinesPerElement(const int i, const U32 lpe)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].linesPerElement = lpe;
+        if (i < 0 || i >= CINEON_MAX_ELEMENTS)
+            return;
+        this->chan[i].linesPerElement = lpe;
 	}
 
 	inline U8 GenericHeader::DataSign() const
@@ -1280,100 +1273,100 @@ namespace cineon
 
 	inline R32 GenericHeader::LowData(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return std::numeric_limits<R32>::infinity();
-		return this->chan[i].lowData;
+        if (i < 0 || i >= CINEON_MAX_ELEMENTS)
+            return std::numeric_limits<R32>::infinity();
+        return this->chan[i].lowData;
 	}
 
 	inline void GenericHeader::SetLowData(const int i, const R32 data)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].lowData = data;
+        if (i < 0 || i >= CINEON_MAX_ELEMENTS)
+            return;
+        this->chan[i].lowData = data;
 	}
 
 	inline R32 GenericHeader::LowQuantity(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return std::numeric_limits<R32>::max();
-		return this->chan[i].lowQuantity;
+        if (i < 0 || i >= CINEON_MAX_ELEMENTS)
+            return std::numeric_limits<R32>::max();
+        return this->chan[i].lowQuantity;
 	}
 
 	inline void GenericHeader::SetLowQuantity(const int i, const R32 quant)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].lowQuantity = quant;
+        if (i < 0 || i >= CINEON_MAX_ELEMENTS)
+            return;
+        this->chan[i].lowQuantity = quant;
 	}
 
 	inline R32 GenericHeader::HighData(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return std::numeric_limits<R32>::max();
-		return this->chan[i].highData;
+        if (i < 0 || i >= CINEON_MAX_ELEMENTS)
+            return std::numeric_limits<R32>::max();
+        return this->chan[i].highData;
 	}
 
 	inline void GenericHeader::SetHighData(const int i, const R32 data)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].highData = data;
+        if (i < 0 || i >= CINEON_MAX_ELEMENTS)
+            return;
+        this->chan[i].highData = data;
 	}
 
 	inline R32 GenericHeader::HighQuantity(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return std::numeric_limits<R32>::max();
-		return this->chan[i].highQuantity;
+        if (i < 0 || i >= CINEON_MAX_ELEMENTS)
+            return std::numeric_limits<R32>::max();
+        return this->chan[i].highQuantity;
 	}
 
 	inline void GenericHeader::SetHighQuantity(const int i, const R32 quant)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].highQuantity = quant;
+        if (i < 0 || i >= CINEON_MAX_ELEMENTS)
+            return;
+        this->chan[i].highQuantity = quant;
 	}
 
 	inline U8 GenericHeader::Metric(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return 0xff;
-		return this->chan[i].designator[0];
+        if (i < 0 || i >= CINEON_MAX_ELEMENTS)
+            return 0xff;
+        return this->chan[i].designator[0];
 	}
 
 	inline void GenericHeader::SetMetric(const int i, const U8 m)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].designator[0] = m;
+        if (i < 0 || i >= CINEON_MAX_ELEMENTS)
+            return;
+        this->chan[i].designator[0] = m;
 	}
 
 	inline Descriptor GenericHeader::ImageDescriptor(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return Descriptor(0xff);
-		return Descriptor(this->chan[i].designator[1]);
+        if (i < 0 || i >= CINEON_MAX_ELEMENTS)
+            return Descriptor(0xff);
+        return Descriptor(this->chan[i].designator[1]);
 	}
 
 	inline void GenericHeader::SetImageDescriptor(const int i, const Descriptor desc)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].designator[1] = (U8)desc;
+        if (i < 0 || i >= CINEON_MAX_ELEMENTS)
+            return;
+        this->chan[i].designator[1] = (U8)desc;
 	}
 
 	inline U8 GenericHeader::BitDepth(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return 0xff;
-		return this->chan[i].bitDepth;
+        if (i < 0 || i >= CINEON_MAX_ELEMENTS)
+            return 0xff;
+        return this->chan[i].bitDepth;
 	}
 
 	inline void GenericHeader::SetBitDepth(const int i, const U8 depth)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].bitDepth = depth;
+        if (i < 0 || i >= CINEON_MAX_ELEMENTS)
+            return;
+        this->chan[i].bitDepth = depth;
 	}
 
 	inline Interleave GenericHeader::ImageInterleave() const

--- a/src/cineon.imageio/libcineon/Writer.cpp
+++ b/src/cineon.imageio/libcineon/Writer.cpp
@@ -82,12 +82,12 @@ void cineon::Writer::SetImageInfo(const U32 width, const U32 height)
 }
 
 
-// returns next available or MAX_ELEMENTS if full
+// returns next available or CINEON_MAX_ELEMENTS if full
 int cineon::Writer::NextAvailElement() const
 {
 	unsigned int i;
 
-	for (i = 0; i < MAX_ELEMENTS; i++)
+	for (i = 0; i < CINEON_MAX_ELEMENTS; i++)
 	{
 		if (this->header.ImageDescriptor(i) == kUndefinedDescriptor)
 			break;
@@ -139,7 +139,7 @@ void cineon::Writer::SetElement(const int num, const Descriptor desc, const U8 b
 			const R32 highData, const R32 highQuantity)
 {
 	// make sure the range is good
-	if (num < 0 || num >= MAX_ELEMENTS)
+	if (num < 0 || num >= CINEON_MAX_ELEMENTS)
 		return;
 
 	// set values
@@ -160,7 +160,7 @@ void cineon::Writer::SetElement(const int num, const Descriptor desc, const U8 b
 bool cineon::Writer::WriteElement(const int element, void *data, const long count)
 {
 	// make sure the range is good
-	if (element < 0 || element >= MAX_ELEMENTS)
+	if (element < 0 || element >= CINEON_MAX_ELEMENTS)
 		return false;
 
 	// make sure the entry is valid
@@ -180,7 +180,7 @@ bool cineon::Writer::WriteElement(const int element, void *data, const long coun
 bool cineon::Writer::WriteElement(const int element, void *data)
 {
 	// make sure the range is good
-	if (element < 0 || element >= MAX_ELEMENTS)
+	if (element < 0 || element >= CINEON_MAX_ELEMENTS)
 		return false;
 
 	// make sure the entry is valid
@@ -197,7 +197,7 @@ bool cineon::Writer::WriteElement(const int element, void *data, const DataSize 
 	bool status = true;
 
 	// make sure the range is good
-	if (element < 0 || element >= MAX_ELEMENTS)
+	if (element < 0 || element >= CINEON_MAX_ELEMENTS)
 		return false;
 
 	// make sure the entry is valid

--- a/src/dds.imageio/squish/alpha.cpp
+++ b/src/dds.imageio/squish/alpha.cpp
@@ -24,25 +24,11 @@
    -------------------------------------------------------------------------- */
    
 #include "alpha.h"
+#include "maths.h"
 #include <climits>
 #include <algorithm>
 
 namespace squish {
-
-static int FloatToInt( float a, int limit )
-{
-	// use ANSI round-to-zero behaviour to get round-to-nearest
-	int i = ( int )( a + 0.5f );
-
-	// clamp to the limit
-	if( i < 0 )
-		i = 0;
-	else if( i > limit )
-		i = limit; 
-
-	// done
-	return i;
-}
 
 void CompressAlphaDxt3( u8 const* rgba, int mask, void* block )
 {

--- a/src/dds.imageio/squish/colourblock.cpp
+++ b/src/dds.imageio/squish/colourblock.cpp
@@ -27,21 +27,6 @@
 
 namespace squish {
 
-static int FloatToInt( float a, int limit )
-{
-	// use ANSI round-to-zero behaviour to get round-to-nearest
-	int i = ( int )( a + 0.5f );
-
-	// clamp to the limit
-	if( i < 0 )
-		i = 0;
-	else if( i > limit )
-		i = limit; 
-
-	// done
-	return i;
-}
-
 static int FloatTo565( Vec3::Arg colour )
 {
 	// get the components in the correct range

--- a/src/dds.imageio/squish/maths.h
+++ b/src/dds.imageio/squish/maths.h
@@ -228,6 +228,23 @@ private:
 Sym3x3 ComputeWeightedCovariance( int n, Vec3 const* points, float const* weights );
 Vec3 ComputePrincipleComponent( Sym3x3 const& matrix );
 
+inline int
+FloatToInt(float a, int limit)
+{
+    // use ANSI round-to-zero behaviour to get round-to-nearest
+    int i = (int)(a + 0.5f);
+
+    // clamp to the limit
+    if (i < 0)
+        i = 0;
+    else if (i > limit)
+        i = limit;
+
+    // done
+    return i;
+}
+
+
 } // namespace squish
 
 #endif // ndef SQUISH_MATHS_H

--- a/src/dds.imageio/squish/singlecolourfit.cpp
+++ b/src/dds.imageio/squish/singlecolourfit.cpp
@@ -43,21 +43,6 @@ struct SingleColourLookup
 
 #include "singlecolourlookup.inl"
 
-static int FloatToInt( float a, int limit )
-{
-	// use ANSI round-to-zero behaviour to get round-to-nearest
-	int i = ( int )( a + 0.5f );
-
-	// clamp to the limit
-	if( i < 0 )
-		i = 0;
-	else if( i > limit )
-		i = limit; 
-
-	// done
-	return i;
-}
-
 SingleColourFit::SingleColourFit( ColourSet const* colours, int flags )
   : ColourFit( colours, flags )
 {

--- a/src/dpx.imageio/libdpx/DPX.cpp
+++ b/src/dpx.imageio/libdpx/DPX.cpp
@@ -42,9 +42,9 @@
 // determine byte order for current system
 // Intel processors are Little Endian
 // Power PC, MIPS and Ultra Sparc are Big Endian
-static unsigned long lValue = 0x12345678;
-static unsigned long *lPtr = &lValue;
-dpx::Endian dpx::systemByteOrder = (*(unsigned char*)lPtr == 0x78 ? dpx::kLittleEndian : dpx::kBigEndian);
+static unsigned long dpx_lValue = 0x12345678;
+static unsigned long *dpx_lPtr = &dpx_lValue;
+dpx::Endian dpx::systemByteOrder = (*(unsigned char*)dpx_lPtr == 0x78 ? dpx::kLittleEndian : dpx::kBigEndian);
 
 		
 		

--- a/src/dpx.imageio/libdpx/DPX.h
+++ b/src/dpx.imageio/libdpx/DPX.h
@@ -33,7 +33,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-
+#pragma once
 #ifndef _DPX_H
 #define _DPX_H 1
 
@@ -250,14 +250,10 @@ namespace dpx
 	protected:			
 		InStream *fd;
 		
-		Codec *codex[MAX_ELEMENTS];
+		Codec *codex[DPX_MAX_ELEMENTS];
 		ElementReadStream *rio;
 	};
 	
-	
-	
-	
-
 
 
 

--- a/src/dpx.imageio/libdpx/DPXHeader.cpp
+++ b/src/dpx.imageio/libdpx/DPXHeader.cpp
@@ -78,7 +78,7 @@ dpx::GenericHeader::GenericHeader()
 void dpx::GenericHeader::Reset()
 {
 	// File Information
-	this->magicNumber = MAGIC_COOKIE;
+	this->magicNumber = DPX_MAGIC_COOKIE;
 	this->imageOffset = ~0;
 	EmptyString(this->version, sizeof(this->version));
 	OIIO::Strutil::safe_strcpy(this->version, SMPTE_VERSION, sizeof(this->version));
@@ -285,7 +285,7 @@ bool dpx::Header::WriteOffsetData(OutStream *io)
 	const long IMAGE_STRUCTURE = 72;	// sizeof the image data structure
 	
 	int i;
-	for (i = 0; i < MAX_ELEMENTS; i++)
+	for (i = 0; i < DPX_MAX_ELEMENTS; i++)
 	{
 			// only write if there is a defined image description
 			if (this->chan[i].descriptor == kUndefinedDescriptor)
@@ -311,7 +311,7 @@ bool dpx::Header::WriteOffsetData(OutStream *io)
 
 bool dpx::Header::ValidMagicCookie(const U32 magic)
 {
-	U32 mc = MAGIC_COOKIE;
+	U32 mc = DPX_MAGIC_COOKIE;
 	
 	if (magic == mc)
 		return true;
@@ -324,7 +324,7 @@ bool dpx::Header::ValidMagicCookie(const U32 magic)
 
 bool dpx::Header::DetermineByteSwap(const U32 magic) const
 {
-	U32 mc = MAGIC_COOKIE;
+	U32 mc = DPX_MAGIC_COOKIE;
 	
 	bool byteSwap = false;
 	
@@ -358,7 +358,7 @@ bool dpx::Header::Validate()
 		SwapBytes(this->numberOfElements);
 		SwapBytes(this->pixelsPerLine);
 		SwapBytes(this->linesPerElement);
-		for (int i = 0; i < MAX_ELEMENTS; i++) 
+		for (int i = 0; i < DPX_MAX_ELEMENTS; i++) 
 		{
 			SwapBytes(this->chan[i].dataSign);
 			SwapBytes(this->chan[i].lowData);
@@ -498,7 +498,7 @@ int dpx::GenericHeader::ImageElementComponentCount(const int element) const
 
 int dpx::GenericHeader::ImageElementCount() const
 {
-	if(this->numberOfElements>0 && this->numberOfElements<=MAX_ELEMENTS)
+	if(this->numberOfElements>0 && this->numberOfElements<=DPX_MAX_ELEMENTS)
 		return this->numberOfElements;
 	
 	// If the image header does not list a valid number of elements,
@@ -506,7 +506,7 @@ int dpx::GenericHeader::ImageElementCount() const
 	
 	int i = 0;
 	
-	while (i < MAX_ELEMENTS )
+	while (i < DPX_MAX_ELEMENTS )
 	{
 		if (this->ImageDescriptor(i) == kUndefinedDescriptor)
 			break;
@@ -533,7 +533,7 @@ void dpx::Header::CalculateOffsets()
 {
 	int i;
 
-	for (i = 0; i < MAX_ELEMENTS; i++)
+	for (i = 0; i < DPX_MAX_ELEMENTS; i++)
 	{
 		// only write if there is a defined image description
 		if (this->chan[i].descriptor == kUndefinedDescriptor)
@@ -546,7 +546,7 @@ void dpx::Header::CalculateOffsets()
 
 dpx::DataSize dpx::GenericHeader::ComponentDataSize(const int element) const
 {
-	if (element < 0 || element >= MAX_ELEMENTS)
+	if (element < 0 || element >= DPX_MAX_ELEMENTS)
 		return kByte;
 		
 	dpx::DataSize ret;
@@ -579,7 +579,7 @@ dpx::DataSize dpx::GenericHeader::ComponentDataSize(const int element) const
 
 int dpx::GenericHeader::ComponentByteCount(const int element) const
 {
-	if (element < 0 || element >= MAX_ELEMENTS)
+	if (element < 0 || element >= DPX_MAX_ELEMENTS)
 		return kByte;
 		
 	int ret;

--- a/src/dpx.imageio/libdpx/DPXHeader.h
+++ b/src/dpx.imageio/libdpx/DPXHeader.h
@@ -37,7 +37,7 @@
  
 // SMPTE DPX graphic file format v2.0
 
-
+#pragma once
 #ifndef _DPX_DPXHEADER_H
 #define _DPX_DPXHEADER_H 1
 
@@ -54,23 +54,16 @@
 #define SMPTE_VERSION		"V2.0"
 
 /*!
- * \def MAX_ELEMENTS
+ * \def DPX_MAX_ELEMENTS
  * \brief Maximum number of image elements
  */
-#define MAX_ELEMENTS		8
+#    define DPX_MAX_ELEMENTS 8
 
 /*!
- * \def MAX_COMPONENTS
- * \brief Maximum number of components per image element
- */
-#define MAX_COMPONENTS		8
-
-
-/*!
- * \def MAGIC_COOKIE
+ * \def DPX_MAGIC_COOKIE
  * \brief HEX value of "SDPX"
  */
-#define MAGIC_COOKIE		0x53445058
+#define DPX_MAGIC_COOKIE		0x53445058
 
 
 
@@ -325,8 +318,8 @@ namespace dpx
 		U16					numberOfElements;			//!< Number of elements (1-8)
 		U32					pixelsPerLine;				//!< Pixels per line
 		U32					linesPerElement;			//!< Lines per element
-		ImageElement		chan[MAX_ELEMENTS];			//!< Image element data structures
-		ASCII				reserved2[52];				//!< Reserved
+        ImageElement        chan[DPX_MAX_ELEMENTS];     //!< Image element data structures
+        ASCII				reserved2[52];				//!< Reserved
 		/* end of group */
 		//@}
 		
@@ -1685,150 +1678,150 @@ namespace dpx
 	
 	inline U32 GenericHeader::DataSign(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return 0xffffffff;
-		return this->chan[i].dataSign;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return 0xffffffff;
+        return this->chan[i].dataSign;
 	}
 
 	inline void GenericHeader::SetDataSign(const int i, const U32 sign)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].dataSign = sign;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return;
+        this->chan[i].dataSign = sign;
 	}
 
 	inline U32 GenericHeader::LowData(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return 0xffffffff;
-		return this->chan[i].lowData;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return 0xffffffff;
+        return this->chan[i].lowData;
 	}
 
 	inline void GenericHeader::SetLowData(const int i, const U32 data)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].lowData = data;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return;
+        this->chan[i].lowData = data;
 	}
 
 	inline R32 GenericHeader::LowQuantity(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return R32(0xffffffff);
-		return this->chan[i].lowQuantity;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return R32(0xffffffff);
+        return this->chan[i].lowQuantity;
 	}
 
 	inline void GenericHeader::SetLowQuantity(const int i, const R32 quant)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].lowQuantity = quant;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return;
+        this->chan[i].lowQuantity = quant;
 	}
 
 	inline U32 GenericHeader::HighData(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return 0xffffffff;
-		return this->chan[i].highData;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return 0xffffffff;
+        return this->chan[i].highData;
 	}
 
 	inline void GenericHeader::SetHighData(const int i, const U32 data)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].highData = data;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return;
+        this->chan[i].highData = data;
 	}
 
 	inline R32 GenericHeader::HighQuantity(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return R32(0xffffffff);
-		return this->chan[i].highQuantity;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return R32(0xffffffff);
+        return this->chan[i].highQuantity;
 	}
 
 	inline void GenericHeader::SetHighQuantity(const int i, const R32 quant)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].highQuantity = quant;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return;
+        this->chan[i].highQuantity = quant;
 	}
 
 	inline Descriptor GenericHeader::ImageDescriptor(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return Descriptor(0xff);
-		return Descriptor(this->chan[i].descriptor);
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return Descriptor(0xff);
+        return Descriptor(this->chan[i].descriptor);
 	}
 
 	inline void GenericHeader::SetImageDescriptor(const int i, const Descriptor desc)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].descriptor = desc;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return;
+        this->chan[i].descriptor = desc;
 	}
 
 	inline Characteristic GenericHeader::Transfer(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return Characteristic(0xff);
-		return Characteristic(this->chan[i].transfer);
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return Characteristic(0xff);
+        return Characteristic(this->chan[i].transfer);
 	}
 
 	inline void GenericHeader::SetTransfer(const int i, const Characteristic ch)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].transfer = ch;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return;
+        this->chan[i].transfer = ch;
 	}
 
 	inline Characteristic GenericHeader::Colorimetric(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return Characteristic(0xff);
-		return Characteristic(this->chan[i].colorimetric);
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return Characteristic(0xff);
+        return Characteristic(this->chan[i].colorimetric);
 	}
 
 	inline void GenericHeader::SetColorimetric(const int i, const Characteristic c)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].colorimetric = c;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return;
+        this->chan[i].colorimetric = c;
 	}
 
 	inline U8 GenericHeader::BitDepth(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return 0xff;
-		return this->chan[i].bitDepth;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return 0xff;
+        return this->chan[i].bitDepth;
 	}
 
 	inline void GenericHeader::SetBitDepth(const int i, const U8 depth)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].bitDepth = depth;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return;
+        this->chan[i].bitDepth = depth;
 	}
 
 	inline Packing GenericHeader::ImagePacking(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return Packing(0xff);
-		return Packing(this->chan[i].packing);
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return Packing(0xff);
+        return Packing(this->chan[i].packing);
 	}
 
 	inline void GenericHeader::SetImagePacking(const int i, const Packing pack)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].packing = pack;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return;
+        this->chan[i].packing = pack;
 	}
 
 	inline Encoding GenericHeader::ImageEncoding(const int i) const
 	{
 		Encoding e = kNone;
-		
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return kNone;
+
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return kNone;
 	
 		if (this->chan[i].encoding == 1)
 			e = kRLE;
@@ -1838,70 +1831,70 @@ namespace dpx
 
 	inline void GenericHeader::SetImageEncoding(const int i, const Encoding enc)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-	
-		this->chan[i].encoding = (enc == kNone ? 0 : 1);
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return;
+
+        this->chan[i].encoding = (enc == kNone ? 0 : 1);
 	}
 
 	inline U32 GenericHeader::DataOffset(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return 0xffffffff;
-		return this->chan[i].dataOffset;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return 0xffffffff;
+        return this->chan[i].dataOffset;
 	}
 
 	inline void GenericHeader::SetDataOffset(const int i, const U32 offset)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].dataOffset = offset;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return;
+        this->chan[i].dataOffset = offset;
 	}
 
 	inline U32 GenericHeader::EndOfLinePadding(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return 0xffffffff;
-		if (this->chan[i].endOfLinePadding == 0xffffffff)
-				return 0;
-		return this->chan[i].endOfLinePadding;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return 0xffffffff;
+        if (this->chan[i].endOfLinePadding == 0xffffffff)
+            return 0;
+        return this->chan[i].endOfLinePadding;
 	}
 
 	inline void GenericHeader::SetEndOfLinePadding(const int i, const U32 eolp)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].endOfLinePadding = eolp;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return;
+        this->chan[i].endOfLinePadding = eolp;
 	}
 
 	inline U32 GenericHeader::EndOfImagePadding(const int i) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return 0xffffffff;
-		if (this->chan[i].endOfImagePadding == 0xffffffff)
-			return 0;	
-		return this->chan[i].endOfImagePadding;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return 0xffffffff;
+        if (this->chan[i].endOfImagePadding == 0xffffffff)
+            return 0;
+        return this->chan[i].endOfImagePadding;
 	}
 
 	inline void GenericHeader::SetEndOfImagePadding(const int i, const U32 eoip)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		this->chan[i].endOfImagePadding = eoip;
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return;
+        this->chan[i].endOfImagePadding = eoip;
 	}
 
 	inline void GenericHeader::Description(const int i, char *desc) const
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		OIIO::Strutil::safe_strcpy(desc, this->chan[i].description, 32);
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return;
+        OIIO::Strutil::safe_strcpy(desc, this->chan[i].description, 32);
 	}
 
 	inline void GenericHeader::SetDescription(const int i, const char *desc)
 	{
-		if (i < 0 || i >= MAX_ELEMENTS)
-			return;
-		OIIO::Strutil::safe_strcpy(this->chan[i].description, desc, 32);
+        if (i < 0 || i >= DPX_MAX_ELEMENTS)
+            return;
+        OIIO::Strutil::safe_strcpy(this->chan[i].description, desc, 32);
 	}
 	
 	

--- a/src/dpx.imageio/libdpx/Reader.cpp
+++ b/src/dpx.imageio/libdpx/Reader.cpp
@@ -48,7 +48,7 @@
 dpx::Reader::Reader() : fd(0), rio(0)
 {
 	// initialize all of the Codec* to NULL
-	for (int i = 0; i < MAX_ELEMENTS; i++)
+	for (int i = 0; i < DPX_MAX_ELEMENTS; i++)
 		this->codex[i] = 0;
 }
 
@@ -63,7 +63,7 @@ dpx::Reader::~Reader()
 void dpx::Reader::Reset()
 {
 	// delete all of the Codec * entries	
-	for (int i = 0; i < MAX_ELEMENTS; i++)
+	for (int i = 0; i < DPX_MAX_ELEMENTS; i++)
 		if (this->codex[i])
 		{
 			delete codex[i];
@@ -114,7 +114,7 @@ bool dpx::Reader::ReadImage(const int element, void *data)
 bool dpx::Reader::ReadBlock(const int element, unsigned char *data, Block &block)
 {
 	// make sure the range is good
-	if (element < 0 || element >= MAX_ELEMENTS)
+	if (element < 0 || element >= DPX_MAX_ELEMENTS)
 		return false;
 
 	// make sure the entry is valid

--- a/src/dpx.imageio/libdpx/RunLengthEncoding.cpp
+++ b/src/dpx.imageio/libdpx/RunLengthEncoding.cpp
@@ -113,7 +113,7 @@ bool dpx::RunLengthEncoding::Read(const Header &dpxHeader, ElementReadStream *fd
 		U32 endOffset = 0xffffffff;
 		U32 currentOffset = startOffset;
 		
-		for (i = 0; i < MAX_ELEMENTS; i++)
+		for (i = 0; i < DPX_MAX_ELEMENTS; i++)
 		{
 			if (i == element)
 				continue;

--- a/src/dpx.imageio/libdpx/Writer.cpp
+++ b/src/dpx.imageio/libdpx/Writer.cpp
@@ -99,12 +99,12 @@ void dpx::Writer::SetImageInfo(const U32 width, const U32 height)
 }
 
 		
-// returns next available or MAX_ELEMENTS if full
+// returns next available or DPX_MAX_ELEMENTS if full
 int dpx::Writer::NextAvailElement() const
 {
 	unsigned int i;
 	
-	for (i = 0; i < MAX_ELEMENTS; i++)
+	for (i = 0; i < DPX_MAX_ELEMENTS; i++)
 	{
 		if (this->header.ImageDescriptor(i) == kUndefinedDescriptor)
 			break;
@@ -160,7 +160,7 @@ void dpx::Writer::SetElement(const int num, const Descriptor desc, const U8 bitD
 			const U32 eolnPadding, const U32 eoimPadding)
 {
 	// make sure the range is good
-	if (num < 0 || num >= MAX_ELEMENTS)
+	if (num < 0 || num >= DPX_MAX_ELEMENTS)
 		return;
 
 	// set values
@@ -201,7 +201,7 @@ dpx::Writer::WritePadData(const int alignment)
 bool dpx::Writer::WriteElement(const int element, void *data, const long count)
 {
 	// make sure the range is good
-	if (element < 0 || element >= MAX_ELEMENTS)
+	if (element < 0 || element >= DPX_MAX_ELEMENTS)
 		return false;
 
 	// make sure the entry is valid
@@ -225,7 +225,7 @@ bool dpx::Writer::WriteElement(const int element, void *data, const long count)
 bool dpx::Writer::WriteElement(const int element, void *data)
 {
 	// make sure the range is good
-	if (element < 0 || element >= MAX_ELEMENTS)
+	if (element < 0 || element >= DPX_MAX_ELEMENTS)
 		return false;
 
 	// make sure the entry is valid
@@ -240,7 +240,7 @@ bool dpx::Writer::WriteElement(const int element, void *data, const DataSize siz
 	bool status = true;	
 	
 	// make sure the range is good
-	if (element < 0 || element >= MAX_ELEMENTS)
+	if (element < 0 || element >= DPX_MAX_ELEMENTS)
 		return false;
 
 	// make sure the entry is valid


### PR DESCRIPTION
Here we tackle the code that implements dpx, cineon, jpeg2000, and dds.

Most of the work is in finding violations of the "one definition rule" -- using
the same name in static scope in more than one file, but to mean different things.
For example, the dpx and cineon code both internally defined a `MAX_ELEMENTS`
macro. This is made safe by prefixing it differently for each. The other necessary
changes fall mostly similar issues.
