### PR TITLE
py_imagespec: added get_bytes_attribute to bypass decoding as utf-8

### DIFF
--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -587,10 +587,15 @@ Section :ref:`sec-ImageSpec`, is replicated for Python.
 .. py:method:: ImageSpec.get_int_attribute (name, defaultval=0)
                   ImageSpec.get_float_attribute (name, defaultval=0.0)
                   ImageSpec.get_string_attribute (name, defaultval="")
+                  ImageSpec.get_bytes_attribute (name, defaultval="")
 
     Retrieves a named metadata value from `extra_attribs`, if it is
     found and is of the given type; returns the default value (or a passed
     value) if not found.
+
+    For an attribute of type STRING, get_bytes_attribute in Python3 skips
+    decoding the underlying C string as UTF-8 and returns a `bytes` object
+    containing the raw byte string.
 
     Example:
 
@@ -3816,6 +3821,7 @@ details.
                get_int_attribute (name, defaultval=0)
                get_float_attribute (name, defaultval=0.0)
                get_string_attribute (name, defaultval="")
+               get_bytes_attribute (name, defaultval="")
 
     Retrieves an attribute value from the named set of global OIIO options.
     (See Section :ref:`sec-globalattribs`.) The `getattribute()` function
@@ -3823,6 +3829,10 @@ details.
     not exist.  The typed variety will only succeed if the attribute is
     actually of that type specified. Type varity with the type in the name
     also takes a default value.
+
+    For an attribute of type STRING, get_bytes_attribute in Python3 skips
+    decoding the underlying C string as UTF-8 and returns a `bytes` object
+    containing the raw byte string.
 
     Example:
 

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -223,6 +223,14 @@ declare_imagespec(py::module& m)
                     std::string(spec.get_string_attribute(name, def)));
             },
             "name"_a, "defaultval"_a = "")
+        .def(
+            "get_bytes_attribute",
+            [](const ImageSpec& spec, const std::string& name,
+               const std::string& def) {
+                return py::bytes(
+                    std::string(spec.get_string_attribute(name, def)));
+            },
+            "name"_a, "defaultval"_a = "")
         .def("getattribute", &ImageSpec_getattribute_typed, "name"_a,
              "type"_a = TypeUnknown)
         .def(

--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -307,6 +307,12 @@ OIIO_DECLARE_PYMODULE(PYMODULE_NAME)
             return PY_STR(std::string(OIIO::get_string_attribute(name, def)));
         },
         py::arg("name"), py::arg("defaultval") = "");
+    m.def(
+        "get_bytes_attribute",
+        [](const std::string& name, const std::string& def) {
+            return py::bytes(std::string(OIIO::get_string_attribute(name, def)));
+        },
+        py::arg("name"), py::arg("defaultval") = "");
     m.def("getattribute", &oiio_getattribute_typed);
     m.def(
         "is_imageio_format_name",

--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -310,7 +310,8 @@ OIIO_DECLARE_PYMODULE(PYMODULE_NAME)
     m.def(
         "get_bytes_attribute",
         [](const std::string& name, const std::string& def) {
-            return py::bytes(std::string(OIIO::get_string_attribute(name, def)));
+            return py::bytes(
+                std::string(OIIO::get_string_attribute(name, def)));
         },
         py::arg("name"), py::arg("defaultval") = "");
     m.def("getattribute", &oiio_getattribute_typed);


### PR DESCRIPTION
py_imagespec: added get_bytes_attribute to bypass decoding as utf-8 and instead returning as a Python3 bytes object

Fixes #3395