### PR TITLE
ustring::from_hash()

### DIFF
--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -725,6 +725,12 @@ public:
         return u;
     }
 
+    /// Return the ustring corresponding to the given hash, or the empty
+    /// ustring() if there is no registered ustring with that hash. Note that
+    /// if there are multiple ustrings with the same hash, this will return
+    /// the first one it finds in the table.
+    OIIO_NODISCARD static ustring from_hash(size_t hash);
+
 private:
     // Individual ustring internal representation -- the unique characters.
     //

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -94,6 +94,7 @@ main(int argc, char* argv[])
     ustring longstring(Strutil::repeat("01234567890", 100));
     OIIO_CHECK_EQUAL(ustring::concat(longstring, longstring),
                      ustring::sprintf("%s%s", longstring, longstring));
+    OIIO_CHECK_EQUAL(ustring::from_hash(foo.hash()), foo);
 
     const int nhw_threads = Sysutil::hardware_concurrency();
     std::cout << "hw threads = " << nhw_threads << "\n";


### PR DESCRIPTION
If you know the hash of a ustring, this tells you the ustring.
(Caveat: in the very unlikely chance of two ustrings having the same
hash, this will return the first one it finds in the table.)
