### PR TITLE
Improvements in opening unknown files

### DIFF
--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -20,9 +20,9 @@ OIIO_NAMESPACE_BEGIN
 
 namespace pvt {
 
-/// Mutex allowing thread safety of ImageOutput internals
-///
+// Mutex allowing thread safety of the ImageIO internals below
 extern recursive_mutex imageio_mutex;
+
 extern atomic_int oiio_threads;
 extern atomic_int oiio_read_chunk;
 extern atomic_int oiio_try_all_readers;


### PR DESCRIPTION
Reminder: When opening a file by name, first it tries to open assuming
that the file's extension indicates the format. If that doesn't work,
it tries all known format readers to see if one will work.

This patch includes several improvements to this process and surrounding
code in imageioplugin.cpp:

* When trying all formats because the extension was wrong, instead of
  traversing the input_formats map in alphabetical order of the list
  of all format names + extensions, try the three most common formats
  we encounter (openexr, tiff, jpeg) FIRST, then try the other formats
  in alphabetical order. We do this by traversing the
  format_list_vector, which contains all format names in the order
  they were declared, and ensure that those common formats are
  declared first. Basically, this means that if the mislabeled file is
  one of those most common formats, the correct reader is found after
  only a couple tries, instead of having to try a dozen or more bad
  guesses of rarely encountered formats.

* Debug mode messages that make it easier to understand which readers
  are being tried for which files.

* Comments clarify that input_formats and output_formats hold not just
  the map from format names to creators, but also map extensions to
  creators. (That confused me while I was debugging this, so I figure
  the clarification is needed.)

* Establish a new extension_to_format_map that lets you get the format
  name if you know the extension.

* Get rid of input_extensions and output_extensions maps, which weren't
  ever used.

* Some other minor refactoring.
