### PR TITLE
Eliminate use of boost::gcd

### DIFF
--- a/src/openexr.imageio/exr_pvt.h
+++ b/src/openexr.imageio/exr_pvt.h
@@ -32,6 +32,22 @@
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
+#if OIIO_CPLUSPLUS_VERSION >= 17 || defined(__cpp_lib_gcd_lcm)
+using std::gcd;
+#else
+template<class M, class N, class T = std::common_type_t<M, N>>
+inline T
+gcd(M a, N b)
+{
+    while (b) {
+        T t = b;
+        b   = a % b;
+        a   = t;
+    }
+    return a;
+}
+#endif
+
 
 // Split a full channel name into layer and suffix.
 inline void

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -16,16 +16,6 @@
 
 #include <boost/version.hpp>
 
-#if OIIO_CPLUSPLUS_VERSION >= 17
-using std::gcd;
-#elif BOOST_VERSION >= 106900
-#    include <boost/integer/common_factor_rt.hpp>
-using boost::integer::gcd;
-#else
-#    include <boost/math/common_factor_rt.hpp>
-using boost::math::gcd;
-#endif
-
 #include <OpenEXR/ImfChannelList.h>
 #include <OpenEXR/ImfEnvmap.h>
 #include <OpenEXR/ImfInputFile.h>

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -16,16 +16,6 @@
 
 #include <boost/version.hpp>
 
-#if OIIO_CPLUSPLUS_VERSION >= 17
-using std::gcd;
-#elif BOOST_VERSION >= 106900
-#    include <boost/integer/common_factor_rt.hpp>
-using boost::integer::gcd;
-#else
-#    include <boost/math/common_factor_rt.hpp>
-using boost::math::gcd;
-#endif
-
 #include "exr_pvt.h"
 
 #include <OpenEXR/openexr.h>


### PR DESCRIPTION
For C++17 and beyond (and maybe earlier in some compilers), we already
used std::gcd. Now for C++14 compilers without std::gcd, we roll our
own simple gcd implementation instead of using boost::gcd. Maybe it's
slightly slower, but this is nowhere near a performance-critical
path. It's worth it to take one more step at eliminating boost.

