### PR TITLE
CI tests use unity builds for speed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,15 +317,17 @@ jobs:
 
 
   macos:
-    name: "${{matrix.os}} appleclang${{matrix.aclang}}/C++${{matrix.cxx_std}} py${{matrix.python_ver}} boost1.76 exr3.1 ocio2.1"
+    name: "${{matrix.os}} appleclang${{matrix.aclang}}/C++${{matrix.cxx_std}} py${{matrix.python_ver}} ${{matrix.desc}} boost1.76 exr3.1 ocio2.1"
     strategy:
       matrix:
         include:
-          - os: macos-10.15
+          - desc: MacOS-10.15
+            os: macos-10.15
             cxx_std: 14
             python_ver: 3.8
             aclang: 12
-          - os: macos-11
+          - desc: MacOS-11
+            os: macos-11
             cxx_std: 17
             python_ver: 3.9
             aclang: 13
@@ -348,11 +350,14 @@ jobs:
           key: ${{github.job}}-${{matrix.os}}-${{steps.ccache_cache_keys.outputs.date}}
           restore-keys: ${{github.job}}-
       - name: Build setup
-        run: src/build-scripts/ci-startup.bash
+        run: |
+            ${{matrix.setenvs}}
+            src/build-scripts/ci-startup.bash
       - name: Dependencies
         run: |
             src/build-scripts/install_homebrew_deps.bash
             src/build-scripts/install_test_images.bash
+            ${{matrix.depcmds}}
       - name: Build
         run: |
             export PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages:$PYTHONPATH
@@ -374,18 +379,20 @@ jobs:
 
 
   windows:
-    name: "${{matrix.os}} VS${{matrix.vsver}}"
+    name: "${{matrix.desc}} VS${{matrix.vsver}}"
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2019
+          - desc: windows-2019
+            os: windows-2019
             vsver: 2019
             generator: "Visual Studio 16 2019"
             openexr_ver: v2.5.8
             python_ver: 3.7
             simd: sse4.2
-          # - os: windows-2022
+          # - desc: windows-2022
+          #   os: windows-2022
           #   vsver: 2022
           #   generator: "Visual Studio 17 2022"
           #   openexr_ver: main
@@ -405,7 +412,9 @@ jobs:
         uses: nuget/setup-nuget@v1
       - name: Build setup
         shell: bash
-        run: src/build-scripts/ci-startup.bash
+        run: |
+            ${{matrix.setenvs}}
+            src/build-scripts/ci-startup.bash
       - name: Dependencies
         shell: bash
         run: src/build-scripts/gh-win-installdeps.bash

--- a/src/build-scripts/ci-build.bash
+++ b/src/build-scripts/ci-build.bash
@@ -12,6 +12,11 @@ if [[ -n "$FMT_VERSION" ]] ; then
     MY_CMAKE_FLAGS="$MY_CMAKE_FLAGS -DBUILD_FMT_VERSION=$FMT_VERSION"
 fi
 
+# On GHA, we can reduce build time with "unity" builds.
+if [[ ${GITHUB_ACTIONS} == true ]] ; then
+    MY_CMAKE_FLAGS+=" -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_MODE=BATCH"
+fi
+
 pushd build
 cmake .. -G "$CMAKE_GENERATOR" \
         -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \


### PR DESCRIPTION
Over the span of several individual PRs, we've made the code base safe
for "unity" (a.k.a. "jumbo") builds -- a feature of CMake that
automatically combines multiple .cpp files into a single compilation
unit (basically making temporary .cpp that `#include`s each original
cpp) in order to, allegedly, speed up compilation by not re-parsing
headers multiple times, and other sources of per-module overhead.

We discovered early on that on a modern computer where modules are
built in parallel (another automatic feature of CMake), jumbo builds
are simply not an overall performance improvement for OIIO. Basically,
the efficiency gain from removing redundant parsing is mostly offset
by the loss of parallel efficiency -- fewer and larger modules means
there are periods where all cores are not able to find work to
do. (Reductive example to illustrate the basic problem: If you have 8
independent modules to compile, and each takes 1 second, 8 cores can
compile the entire collection in parallel in 1 second. But a unity
build that batches those files in groups of 4 and achieves a 2x
speedup, thus compiling each set of 4 modules in 2 seconds instead of
4, only can do two of these compilations in parallel, so it takes 2
seconds. We've cut the total work in half, and yet it takes twice as
long in real time to complete, and 6/8 of your cores are idle.

OK, but that's when you have several cores. If you had only one core
(or maybe two) so you weren't using much parallelism in the first
place, then the unity build would look like a win, since you'd really
see the improvement from the amortized overhead of the combined
modules.

Most of us don't have single core machines on our desks, or laps, or
even in our pockets (or on our wrists?).

But we do have single core machines (or close to it) in our CI runners!
We get 1.5-2 cores, roughly, in the slice of VMs we get to run CI on
GitHub Actions. So maybe this is the one place where a unity build would
be of benefit.

That's the theory anyway. Does it pan out? I tested it, and the answer
is basically yes. I can speed up the "build" step of our CI by
somewhere in the vacinity of 30% (varies a LOT from run to run). I
tried a whole bunch of different approaches, summarized in the table
below. I picked the best basic strategies revealed by those tests and
set up the CI to use them. (I didn't preserve all the other
permutations.)

| Name                    | try 1 build | try 2                | try 3          | try 4    |
|:----------------------- | ----------- | -------------------- | -------------- | -------- |
| **linux gcc9 BASELINE** | 14:19       | 11:46                | 11:56          | 13:32    |
| linux gcc9 group        | 9:39        | 8:06                 | 9:58           | **7:58** |
| linux gcc9 batch 8      | 8:06        | **7:17**             | **8:02**       | **7:59** |
| linux gcc9 batch 16     | 8:29        | 7:32                 | **7:56**       | 9:35     |
| linux gcc9 batch 4      | 8:39        | 8:38                 | 8:52           | 10:31    |
| linux gcc9 batch 2      | 13:34       | 12:43                | 11:22          | 9:32     |
| linux gcc9 batch mix 4  | 7:22        | 9:14                 | 9:01           | 9:39     |
| linux gcc9 batch mix 2  | 9:11        | 7:45                 | 10:55          | 9:36     |
| **linux icx BASELINE**  |             | 14:39                | 15:07          | 15:06    |
| linux icx group         |             | 11:59                | **10:36**      | 10:26    |
| linux icx batch 8       |             | **9:40**             | 11:31          | **9:14**     |
| linux icx batch mix 4   |             | 10:06                | 11:58          | 11:16    |
| **macos11 BASELINE**    | 25:41       | 27:53                | 26:30          | 28:32    |
| macos11 group           | 10:56       | 20:24                | 19:28          | 19:24    |
| macos11 batch 8         | 16:43       | 17:38                | **18:34**      | **17:42**         |
| macos11 batch mix 4     |             | **9:22**             | 19:12          | 18:26         |
| **windows BASELINE**    | 20:17       | 23:27                | 28:43          | 19:13         |
| windows group           | 23:05       | 15:57 (tests broken) | 21:57 (broken) | 15:33         |
| windows batch 8         | 21:16       | 15:57                | **17:38**      | **15:08**         |
| windows batch mix 4     |             | **15:30**            | 23:19          | 15:16         |

Notes:

* Timings vary wildly from run to run. You never know which VMs you'll
  get or how overloaded they are. But over 3 trials, the trends were
  clear.
* I rigged it to clear the ccache, so these are FULL uncached builds.
* This is only "build" time. The CI run also includes time to set up the
  VM, download docker images, build or install dependencies, and of course
  run the testsuite. So the overall speedup of the entire CI run will not
  be as improved overall as these numbers indicate for the build step.
  But still, saving several minutes per job means the CI tests turn
  around faster, and that's what we want.
