### PR TITLE
New bitcast is closer to std::bit_cast

### DIFF
--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -137,7 +137,11 @@
 //   __INTEL_LLVM_COMPILER is defined only for icx
 //   _MSC_VER is defined for MSVS compiler (not gcc/clang/icc even on Windows)
 //   _WIN32 is defined on Windows regardless of compiler
-//   __CUDACC__ is defined for nvcc and clang during Cuda compilation.
+//   __CUDACC__   is defined any time we are compiling a module for Cuda
+//                (both for the host pass and the device pass). "Do this
+//                when using nvcc or clang with ptx target."
+//   __CUDA_ARCH__  is only defined when doing the device pass. "Do this only
+//                for code that will actually run on the GPU."
 
 
 // Define OIIO_GNUC_VERSION to hold an encoded gcc version (e.g. 40802 for

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -511,7 +511,7 @@ test_half_convert_accuracy()
     const int nhalfs = 1 << 16;
     std::vector<half> H(nhalfs, 0.0f);
     for (auto i = 0; i < nhalfs; ++i)
-        H[i] = bit_cast<unsigned short, half>((unsigned short)i);
+        H[i] = bitcast<half, uint16_t>((uint16_t)i);
 
     // Convert the whole array to float equivalents in one shot (which will
     // use SIMD ops if available).
@@ -529,9 +529,8 @@ test_half_convert_accuracy()
         float f = H[i];  // single assignment uses table from Imath
         half h  = (half)f;
         if ((f != F[i] || f != H2[i] || f != h || H[i] != H2[i]
-             || bit_cast<half, unsigned short>(h)
-                    != bit_cast<half, unsigned short>(H[i])
-             || bit_cast<half, unsigned short>(h) != i)
+             || bitcast<uint16_t, half>(h) != bitcast<uint16_t, half>(H[i])
+             || bitcast<uint16_t, half>(h) != i)
             && Imath::finitef(H[i])) {
             ++nwrong;
             Strutil::printf("wrong %d 0b%s  h=%g, f=%g %s\n", i, bin16(i), H[i],
@@ -545,6 +544,22 @@ test_half_convert_accuracy()
     std::cout << "test_half_convert_accuracy: " << nwrong << " mismatches\n";
     std::cout << term.ansi("default");
     OIIO_CHECK_ASSERT(nwrong == 0);
+}
+
+
+
+static void
+test_bitcast()
+{
+    OIIO_CHECK_EQUAL((bitcast<uint16_t, half>(half(0.0f))), 0);
+    OIIO_CHECK_EQUAL((bitcast<uint32_t, float>(0.0f)), 0);
+    OIIO_CHECK_EQUAL((bitcast<int32_t, float>(0.0f)), 0);
+    OIIO_CHECK_EQUAL((bitcast<float, uint32_t>(0)), 0.0f);
+    OIIO_CHECK_EQUAL((bitcast<float, int32_t>(0)), 0.0f);
+    OIIO_CHECK_EQUAL((bitcast<uint64_t, double>(0.0)), 0);
+    OIIO_CHECK_EQUAL((bitcast<int64_t, double>(0.0)), 0);
+    OIIO_CHECK_EQUAL((bitcast<double, uint64_t>(0)), 0.0);
+    OIIO_CHECK_EQUAL((bitcast<double, int64_t>(0)), 0.0);
 }
 
 
@@ -750,6 +765,7 @@ main(int argc, char* argv[])
 
     test_bit_range_convert();
     test_packbits();
+    test_bitcast();
     test_swap_endian();
 
     test_interpolate_linear();


### PR DESCRIPTION
We have a template OIIO::bit_cast which has served us for a while, but
it turns out that C++20 has std::bit_cast which operates ALMOST the
same -- unfortunately, the tempalte arguments are reversed from the
way we did it!

So here we:

* Set up a new `bitcast<>` that works exactly like C++20 std::bit_cast.
* Implement our old bit_cast in terms of the new one, for now.
* Set up `#if` trick so that the confusing OIIO::bit_cast will be
  marked as deprecated beginning with OIIO 2.5, and will be removed
  entirely from OIIO 3.0. (Farther out than that, we may choose to
  re-introduce bit_cast as truly being identical semantics to
  std::bit_cast. But before that is possible, we need to completely
  ween downstream users off the old one.)
* Took the opportunity to expand the set of compilers for which
  certain bitcast overloads use Intel intrinsics. Previously, we only
  did this for the Intel compiler, but it seems to work for modern
  versions of clang and gcc as well. Do a little bitcast testing in
  fmath_test.cpp to verify that the use of these intrinsics doesn't
  break for any of the compilers we use for CI.
