### PR TITLE
More changes to hide Imath: new half.h, improve vecparam.h

### DIFF
--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -39,6 +39,14 @@ endif ()
 configure_file (${PROJECT_NAME}/${versionfile}.in "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${versionfile}" @ONLY)
 list (APPEND public_headers "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${versionfile}")
 
+# Generate half.h
+if (VERBOSE)
+    message(STATUS "Create half.h from half.h.in")
+endif ()
+configure_file (${PROJECT_NAME}/half.h.in "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/half.h" @ONLY)
+list (APPEND public_headers "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/half.h")
+
+
 # Generate Imath.h
 if (VERBOSE)
     message(STATUS "Create Imath.h from Imath.h.in")

--- a/src/include/OpenImageIO/Imath.h.in
+++ b/src/include/OpenImageIO/Imath.h.in
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <OpenImageIO/half.h>
 #include <OpenImageIO/detail/fmt.h>
 
 #ifndef OIIO_IMATH_H_INCLUDED
@@ -20,12 +21,10 @@
 #   include <Imath/ImathColor.h>
 #   include <Imath/ImathMatrix.h>
 #   include <Imath/ImathVec.h>
-#   include <Imath/half.h>
 #else
 #   include <OpenEXR/ImathColor.h>
 #   include <OpenEXR/ImathMatrix.h>
 #   include <OpenEXR/ImathVec.h>
-#   include <OpenEXR/half.h>
 #endif
 
 

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -276,10 +276,8 @@ public:
     ///
     /// Created ColorProcessors are cached, so asking for the same color
     /// space transformation multiple times shouldn't be very expensive.
-#ifdef INCLUDED_IMATHMATRIX_H
-    ColorProcessorHandle createMatrixTransform(const Imath::M44f& M,
+    ColorProcessorHandle createMatrixTransform(M44fParam M,
                                                bool inverse = false) const;
-#endif
 
     /// Given a filepath, ask OCIO what color space it thinks the file
     /// should be, based on how the name matches file naming rules in the

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -47,7 +47,7 @@
 OIIO_NAMESPACE_BEGIN
 
 /// If the caller defines OIIO_FMATH_HEADER_ONLY to nonzero, then 100% of the
-/// implementation of fmath functions will be defined direcly in this header
+/// implementation of fmath functions will be defined directly in this header
 /// file.  If it is not defined, or set to 0, then there are a few functions
 /// for which this header will only provide the definition.
 #ifndef OIIO_FMATH_HEADER_ONLY

--- a/src/include/OpenImageIO/half.h.in
+++ b/src/include/OpenImageIO/half.h.in
@@ -1,0 +1,17 @@
+// Copyright 2008-present Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio/
+
+
+#pragma once
+
+// Determine which Imath we're dealing with and include the appropriate path
+// to half.h.
+
+#if defined(__has_include) && __has_include(<Imath/half.h>)
+#    include <Imath/half.h>
+#elif @OIIO_USING_IMATH@ >= 3
+#    include <Imath/half.h>
+#else
+#    include <OpenEXR/half.h>
+#endif

--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -8,7 +8,7 @@
 
 #include <functional>
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
 #include <OpenImageIO/parallel.h>
 #include <OpenImageIO/imagebufalgo.h>
 

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1393,9 +1393,10 @@ ColorConfig::createFileTransform(ustring name, bool inverse) const
 
 
 ColorProcessorHandle
-ColorConfig::createMatrixTransform(const Imath::M44f& M, bool inverse) const
+ColorConfig::createMatrixTransform(M44fParam M, bool inverse) const
 {
-    return ColorProcessorHandle(new ColorProcessor_Matrix(M, inverse));
+    return ColorProcessorHandle(
+        new ColorProcessor_Matrix(*(const Imath::M44f*)M.data(), inverse));
 }
 
 

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -7,7 +7,8 @@
 #include <cstdlib>
 #include <numeric>
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
+
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/fmath.h>

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -7,7 +7,8 @@
 #include <regex>
 #include <sstream>
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
+
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -6,7 +6,8 @@
 #include <iostream>
 #include <memory>
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
+
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/fmath.h>

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -5,7 +5,8 @@
 #include <cmath>
 #include <memory>
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
+
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filter.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagebufalgo_addsub.cpp
+++ b/src/libOpenImageIO/imagebufalgo_addsub.cpp
@@ -10,7 +10,8 @@
 #include <iostream>
 #include <limits>
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
+
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagebufalgo_channels.cpp
+++ b/src/libOpenImageIO/imagebufalgo_channels.cpp
@@ -10,7 +10,8 @@
 #include <cmath>
 #include <iostream>
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
+
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -10,7 +10,8 @@
 #include <iostream>
 #include <limits>
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
+
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/hash.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -5,7 +5,8 @@
 #include <cmath>
 #include <iostream>
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
+
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>

--- a/src/libOpenImageIO/imagebufalgo_deep.cpp
+++ b/src/libOpenImageIO/imagebufalgo_deep.cpp
@@ -7,7 +7,8 @@
 #include <iostream>
 #include <stdexcept>
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
+
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -6,7 +6,8 @@
 #include <cmath>
 #include <limits>
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
+
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/filter.h>

--- a/src/libOpenImageIO/imagebufalgo_mad.cpp
+++ b/src/libOpenImageIO/imagebufalgo_mad.cpp
@@ -6,8 +6,8 @@
 #include <iostream>
 #include <limits>
 
-#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
+#include <OpenImageIO/half.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/imagebufalgo_util.h>

--- a/src/libOpenImageIO/imagebufalgo_minmaxchan.cpp
+++ b/src/libOpenImageIO/imagebufalgo_minmaxchan.cpp
@@ -6,7 +6,8 @@
 #include <iostream>
 #include <limits>
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
+
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagebufalgo_muldiv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_muldiv.cpp
@@ -10,7 +10,8 @@
 #include <iostream>
 #include <limits>
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
+
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -36,8 +36,8 @@
 #include <map>
 #include <vector>
 
-#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
+#include <OpenImageIO/half.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/imagebufalgo_util.h>

--- a/src/libOpenImageIO/imagebufalgo_orient.cpp
+++ b/src/libOpenImageIO/imagebufalgo_orient.cpp
@@ -5,7 +5,8 @@
 #include <cmath>
 #include <iostream>
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
+
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>

--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -10,7 +10,8 @@
 #include <iostream>
 #include <limits>
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
+
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/deepdata.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -5,7 +5,8 @@
 #include <cstdio>
 #include <cstdlib>
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
+
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/hash.h>

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -385,11 +385,11 @@ TextureSystemImpl::environment(TextureHandle* texture_handle_,
 
     // Calculate unit-length vectors in the direction of R, R+dRdx, R+dRdy.
     // These define the ellipse we're filtering over.
-    Imath::V3f R = _R;
+    Imath::V3f R = _R.cast<Imath::V3f>();
     R.normalize();  // center
-    Imath::V3f Rx = Imath::V3f(_R) + Imath::V3f(_dRdx);
+    Imath::V3f Rx = _R.cast<Imath::V3f>() + _dRdx.cast<Imath::V3f>();
     Rx.normalize();  // x axis of the ellipse
-    Imath::V3f Ry = Imath::V3f(_R) + Imath::V3f(_dRdy);
+    Imath::V3f Ry = _R.cast<Imath::V3f>() + _dRdy.cast<Imath::V3f>();
     Ry.normalize();  // y axis of the ellipse
     // angles formed by the ellipse axes.
     float xfilt_noblur = std::max(safe_acos(R.dot(Rx)), 1e-8f);

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -162,11 +162,11 @@ TextureSystemImpl::texture3d(TextureHandle* texture_handle_,
     if (si.Mlocal) {
         // See if there is a world-to-local transform stored in the cache
         // entry. If so, use it to transform the input point.
-        si.Mlocal->multVecMatrix(Imath::V3f(P), Plocal);
+        si.Mlocal->multVecMatrix(P.cast<Imath::V3f>(), Plocal);
     } else {
         // If no world-to-local matrix could be discerned, just use the
         // input point directly.
-        Plocal = P;
+        Plocal = P.cast<Imath::V3f>();
     }
 
     // FIXME: we don't bother with this for dPdx, dPdy, and dPdz only

--- a/src/libutil/filesystem_test.cpp
+++ b/src/libutil/filesystem_test.cpp
@@ -5,7 +5,6 @@
 #include <fstream>
 #include <sstream>
 
-#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/platform.h>

--- a/src/libutil/fmath.cpp
+++ b/src/libutil/fmath.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
 
 // Force the full implementation of all fmath functions, which will compile
 // some callable versions here.

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -6,8 +6,8 @@
 #include <cstdio>
 #include <cstdlib>
 
-#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
+#include <OpenImageIO/half.h>
 #include <OpenImageIO/paramlist.h>
 #include <OpenImageIO/ustring.h>
 

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -7,8 +7,8 @@
 #include <cstdlib>
 #include <string>
 
-#include <OpenImageIO/Imath.h>
 #include <OpenImageIO/dassert.h>
+#include <OpenImageIO/half.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/typedesc.h>
 #include <OpenImageIO/ustring.h>

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -11,7 +11,7 @@
 
 #include <boost/container/flat_set.hpp>
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
 
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/color.h>

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -7,7 +7,8 @@
 #include <iostream>
 #include <memory>
 
-#include <OpenImageIO/Imath.h>
+#include <OpenImageIO/half.h>
+
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/platform.h>


### PR DESCRIPTION
Another round to hide Imath externally to OIIO public headers as well
as speed up our own builds.

* Remove the external reference to Imath::M44f from color.h, and instead
  use M44fParam.

* The `<OpenImageIO/Imath.h>` includes the most commonly used Imath
  headers including half.h. But this is unnecessarily expensive (and
  presumptuous about wanting other Imath types as well as fmt.h) if
  you just need to know about `half`.  So we create a new
  `<OpenImageIO/half.h>` that only includes what you need for `half`
  (as before, with logic to handle the changing location of the half.h
  header depending on whether you're using Imath 3.x or OpenEXR 2.x).

* Several files that included Imath.h, but in reality only needed half
  all along, change to including OpenImageIO/half.h.

* simd.h leans more on vecparam.h and other template trickery to
  reduce exposure of methods that only work in the presence of Imath
  headers, and make fewer use cases that would care whether the Imath
  headers are included before or after simd.h (which is less
  controllable for unity builds).

* Vec3Param gains a `cast<V>()` templated method that allows easy
  casting to foreign vector types even if Imath headers are not
  included prior to vecparam.h being included (which is less
  controllable for unity builds).
