### PR TITLE
CI: adjust to upgrading Intel Clang compiler to 2022.1.0

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -68,9 +68,9 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER MATCHES "[Cc]lan
         endif ()
     elseif (CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
         set (CMAKE_COMPILER_IS_INTELCLANG 1)
-        string (REGEX REPLACE ".* version ([0-9]+\\.[0-9]+).*" "\\1" CLANG_VERSION_STRING ${clang_full_version_string})
+        string (REGEX MATCH "[0-9]+(\\.[0-9]+)+" INTELCLANG_VERSION_STRING ${clang_full_version_string})
         if (VERBOSE)
-            message (STATUS "The compiler is Intel Clang: ${CMAKE_CXX_COMPILER_ID} version ${CLANG_VERSION_STRING}")
+            message (STATUS "The compiler is Intel Clang: ${CMAKE_CXX_COMPILER_ID} version ${INTELCLANG_VERSION_STRING}")
         endif ()
     else ()
         string (REGEX REPLACE ".* version ([0-9]+\\.[0-9]+).*" "\\1" CLANG_VERSION_STRING ${clang_full_version_string})
@@ -178,6 +178,11 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
     # Ensure this macro is set for stdint.h
     add_definitions ("-D__STDC_LIMIT_MACROS")
     add_definitions ("-D__STDC_CONSTANT_MACROS")
+endif ()
+
+if (INTELCLANG_VERSION_STRING VERSION_GREATER_EQUAL 2022.1.0)
+    # New versions of icx warn about changing certain floating point options
+    add_compile_options ("-Wno-overriding-t-option")
 endif ()
 
 if (MSVC)

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -857,7 +857,7 @@ swap_endian (T *f, int len=1)
 }
 
 
-#if (OIIO_GNUC_VERSION || OIIO_CLANG_VERSION || OIIO_APPLE_CLANG_VERSION || OIIO_INTEL_COMPILER_VERSION) && !defined(__CUDACC__)
+#if (OIIO_GNUC_VERSION || OIIO_ANY_CLANG || OIIO_INTEL_CLASSIC_COMPILER_VERSION) && !defined(__CUDACC__)
 // CPU gcc and compatible can use these intrinsics, 8-15x faster
 
 template<> inline void swap_endian(uint16_t* f, int len) {

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -176,12 +176,12 @@
 #  define OIIO_APPLE_CLANG_VERSION 0
 #endif
 
-// Define OIIO_INTEL_COMPILER_VERSION to hold an encoded Intel compiler
-// version (e.g. 1900), or 0 if not an Intel compiler.
+// Define OIIO_INTEL_CLASSIC_COMPILER_VERSION to hold an encoded Intel
+// compiler version (e.g. 1900), or 0 if not an Intel compiler.
 #if defined(__INTEL_COMPILER)
-#  define OIIO_INTEL_COMPILER_VERSION __INTEL_COMPILER
+#  define OIIO_INTEL_CLASSIC_COMPILER_VERSION __INTEL_COMPILER
 #else
-#  define OIIO_INTEL_COMPILER_VERSION 0
+#  define OIIO_INTEL_CLASSIC_COMPILER_VERSION 0
 #endif
 
 // DEPRECATED(2.4) phase out OIIO_NON_INTEL_CLANG for OIIO_INTEL_LLVM_COMPILER.
@@ -215,24 +215,24 @@
 
 // Tests for MSVS versions, always 0 if not MSVS at all.
 #if defined(_MSC_VER)
+#  define OIIO_MSVS_VERSION       _MSC_VER
 #  define OIIO_MSVS_AT_LEAST_2013 (_MSC_VER >= 1800)
 #  define OIIO_MSVS_BEFORE_2013   (_MSC_VER <  1800)
 #  define OIIO_MSVS_AT_LEAST_2015 (_MSC_VER >= 1900)
 #  define OIIO_MSVS_BEFORE_2015   (_MSC_VER <  1900)
 #  define OIIO_MSVS_AT_LEAST_2017 (_MSC_VER >= 1910)
 #  define OIIO_MSVS_BEFORE_2017   (_MSC_VER <  1910)
-#  define OIIO_MSVS_VERSION       _MSC_VER
 #  if OIIO_MSVS_BEFORE_2017
 #    error "This version of OIIO is meant to work only with Visual Studio 2017 or later"
 #  endif
 #else
+#  define OIIO_MSVS_VERSION       0
 #  define OIIO_MSVS_AT_LEAST_2013 0
 #  define OIIO_MSVS_BEFORE_2013   0
 #  define OIIO_MSVS_AT_LEAST_2015 0
 #  define OIIO_MSVS_BEFORE_2015   0
 #  define OIIO_MSVS_AT_LEAST_2017 0
 #  define OIIO_MSVS_BEFORE_2017   0
-#  define OIIO_MSVS_VERSION       0
 #endif
 
 

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -155,7 +155,7 @@
 // Define OIIO_CLANG_VERSION to hold an encoded generic Clang version (e.g.
 // 30402 for clang 3.4.2), or 0 if not a generic Clang release.
 // N.B. This will be 0 for the clang Apple distributes (which has different
-// version numbers entirely).
+// version numbers entirely) and for the Intel clang-based compiler.
 #if defined(__clang__) && !defined(__apple_build_version__) && !defined(__INTEL_LLVM_COMPILER)
 #  define OIIO_CLANG_VERSION (10000*__clang_major__ + 100*__clang_minor__ + __clang_patchlevel__)
 #else
@@ -221,6 +221,7 @@
 #  define OIIO_MSVS_BEFORE_2015   (_MSC_VER <  1900)
 #  define OIIO_MSVS_AT_LEAST_2017 (_MSC_VER >= 1910)
 #  define OIIO_MSVS_BEFORE_2017   (_MSC_VER <  1910)
+#  define OIIO_MSVS_VERSION       _MSC_VER
 #  if OIIO_MSVS_BEFORE_2017
 #    error "This version of OIIO is meant to work only with Visual Studio 2017 or later"
 #  endif
@@ -231,6 +232,7 @@
 #  define OIIO_MSVS_BEFORE_2015   0
 #  define OIIO_MSVS_AT_LEAST_2017 0
 #  define OIIO_MSVS_BEFORE_2017   0
+#  define OIIO_MSVS_VERSION       0
 #endif
 
 

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -2248,7 +2248,7 @@ TextureSystemImpl::sample_bilinear(
         else
             tile_st %= tilewh;
         OIIO_PRAGMA_WARNING_PUSH
-#if OIIO_CLANG_VERSION >= 140000
+#if OIIO_CLANG_VERSION >= 140000 || OIIO_INTEL_CLANG_VERSION >= 140000
         OIIO_CLANG_PRAGMA(GCC diagnostic ignored "-Wbitwise-instead-of-logical")
 #endif
         bool s_onetile = (tile_st[S0] != tilewhmask[S0])

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -85,10 +85,23 @@ colorconfig_file = make_relpath(colorconfig_file)
 
 command = ""
 outputs = [ "out.txt" ]    # default
+
+# The image comparison thresholds are tricky to remember. Here's the key:
+# A test fails if more than `failpercent` of pixel values differ by more
+# than `failthresh`, or if even one pixel differs by more than `hardfail`.
+failthresh = 0.004         # "Failure" threshold for any pixel value
+failpercent = 0.02         # Ok fo this percentage of pixels to "fail"
+hardfail = 0.012           # Even one pixel this wrong => hard failure
+
+# Some tests are designed for the app running to "fail" (in the sense of
+# terminating with an error return code), for example, a test that is designed
+# to present an error condition to check that it issues the right error. That
+# "failure" is a success of the test! For those cases, set `failureok = 1` to
+# indicate that the app having an error is fine, and the full test will pass
+# or fail based on comparing the output files.
 failureok = 0
-failthresh = 0.004
-hardfail = 0.012
-failpercent = 0.02
+
+
 anymatch = False
 cleanup_on_success = False
 if int(os.getenv('TESTSUITE_CLEANUP_ON_SUCCESS', '0')) :

--- a/testsuite/texture-interp-closest/run.py
+++ b/testsuite/texture-interp-closest/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Adjust error thresholds a tad to account for platform-to-platform variation
+# in some math precision.
+hardfail = 0.032
+failpercent = 0.002
+
 command = testtex_command ("../common/textures/grid.tx",
                            extraargs = "-interpmode 0  -d uint8 -o out.tif")
 outputs = [ "out.tif" ]

--- a/testsuite/texture-mip-stochasticaniso/run.py
+++ b/testsuite/texture-mip-stochasticaniso/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Adjust error thresholds a tad to account for platform-to-platform variation
+# in some math precision.
+hardfail = 0.16
+failpercent = 0.001
+
 command = testtex_command ("../common/textures/grid.tx",
                            extraargs = "-mipmode 6 -d uint8 -o out.tif")
 outputs = [ "out.tif" ]


### PR DESCRIPTION
The Intel OneAPI LLVM-based C++ compiler, as we download it from Intel
for our CI, bumped from 2022.0.0 to 2022.1.0.

New warning popped up -- newest Intel LLVM-based compiler warns about
overriding certain floating point math flags.

Also had to adjust thresholds on a couple texture tests that have a
few pixels change slightly due to numerical differences.
