### PR TITLE
CI improvements -- don't overwrite cmake caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,8 +182,7 @@ jobs:
         with:
           name: oiio-${{github.job}}-${{matrix.nametag}}
           path: |
-            build/*.cmake
-            build/CMake*
+            build/cmake-save
             build/testsuite/*/*.*
             !build/testsuite/oiio-images
             !build/testsuite/openexr-images
@@ -323,8 +322,7 @@ jobs:
         with:
           name: oiio-${{github.job}}-${{matrix.nametag}}
           path: |
-            build/*.cmake
-            build/CMake*
+            build/cmake-save
             build/testsuite/*/*.*
             !build/testsuite/oiio-images
             !build/testsuite/openexr-images
@@ -385,8 +383,7 @@ jobs:
         with:
           name: oiio-${{github.job}}
           path: |
-            build/*.cmake
-            build/CMake*
+            build/cmake-save
             build/testsuite/*/*.*
             !build/testsuite/oiio-images
             !build/testsuite/openexr-images
@@ -445,8 +442,7 @@ jobs:
         with:
           name: oiio-${{github.job}}-VS${{matrix.vsver}}
           path: |
-            build/*.cmake
-            build/CMake*
+            build/cmake-save
             build/testsuite/*/*.*
             !build/testsuite/oiio-images
             !build/testsuite/openexr-images

--- a/src/build-scripts/ci-build.bash
+++ b/src/build-scripts/ci-build.bash
@@ -26,6 +26,11 @@ cmake .. -G "$CMAKE_GENERATOR" \
         -DCMAKE_INSTALL_LIBDIR="$OpenImageIO_ROOT/lib" \
         -DCMAKE_CXX_STANDARD="$CMAKE_CXX_STANDARD" \
         $MY_CMAKE_FLAGS -DVERBOSE=1
+
+# Save a copy of the generated files for debugging broken CI builds.
+mkdir cmake-save || /bin/true
+cp -r CMake* *.cmake cmake-save
+
 if [[ "$BUILDTARGET" != "none" ]] ; then
     echo "Parallel build " ${CMAKE_BUILD_PARALLEL_LEVEL}
     time cmake --build . --target ${BUILDTARGET:=install} --config ${CMAKE_BUILD_TYPE}


### PR DESCRIPTION
For failed CI builds, save the cmake caches in a safe place, don't zip
them up in situ, because then when I unpack them in my build area
locally, they overwrite my working cache.
