### PR TITLE
Adjust string formatters after change in fmt master

### DIFF
--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -832,3 +832,19 @@ to_string(const ustring& value)
 }  // end namespace Strutil
 
 OIIO_NAMESPACE_END
+
+
+// Supply a fmtlib compatible custom formatter for ustring.
+FMT_BEGIN_NAMESPACE
+
+template<> struct formatter<OIIO::ustring> : formatter<fmt::string_view, char> {
+    template<typename FormatContext>
+    auto format(const OIIO::ustring& t, FormatContext& ctx)
+        -> decltype(ctx.out()) const
+    {
+        return formatter<fmt::string_view, char>::format({ t.data(), t.size() },
+                                                         ctx);
+    }
+};
+
+FMT_END_NAMESPACE

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -1110,7 +1110,7 @@ ImageSpec::serialize(SerialFormat fmt, SerialVerbose verbose) const
         attribs.sort(false /* sort case-insensitively */);
 
         for (auto&& p : attribs) {
-            out << sprintf("    %s: ", p.name());
+            Strutil::print(out, "    {}: ", p.name());
             std::string s = metadata_val(p, verbose == SerialDetailedHuman);
             if (s == "1.#INF")
                 s = "inf";

--- a/src/libutil/argparse_test.cpp
+++ b/src/libutil/argparse_test.cpp
@@ -243,12 +243,12 @@ test_new()
     OIIO_CHECK_EQUAL(ap["filename"].type(), TypeDesc("string[2]"));
     std::cout << "\nAll args:\n";
     for (auto& a : ap.params())
-        Strutil::printf("  %s = %s   [%s]\n", a.name(), a.get_string(),
-                        a.type());
+        Strutil::print("  {} = {}   [{}]\n", a.name(), a.get_string(),
+                       a.type());
     std::cout << "Extracting filenames:\n";
     auto fn = ap["filename"].as_vec<std::string>();
     for (auto& f : fn)
-        Strutil::printf("  \"%s\"\n", f);
+        Strutil::print("  \"{}\"\n", f);
 }
 
 

--- a/src/libutil/paramlist_test.cpp
+++ b/src/libutil/paramlist_test.cpp
@@ -359,10 +359,10 @@ test_delegates()
     string_view sv = pl["foo"].get();
     OIIO_CHECK_EQUAL(sv, "42");
 
-    Strutil::printf("Delegate-loaded array is\n");
+    Strutil::print("Delegate-loaded array is\n");
     for (auto&& p : pl)
-        Strutil::printf(" %16s : %s\n", p.name(), p.get_string());
-    Strutil::printf("\n");
+        Strutil::print(" {:16} : {}\n", p.name(), p.get_string());
+    Strutil::print("\n");
 }
 
 

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -97,7 +97,7 @@ benchmark(string_view funcname, FUNC func, T x, size_t work = 0)
         r = func(x); DoNotOptimize (r); clobber_all_memory();
     };
     float time = time_trial(repeat_func, ntrials, iterations / 8);
-    Strutil::printf("  %s: %7.1f Mvals/sec, (%.1f Mcalls/sec)\n",
+    Strutil::print("  {}: {:7.1f} Mvals/sec, ({:.1f} Mcalls/sec)\n",
                                  funcname, ((iterations * work) / 1.0e6) / time,
                                  (iterations / 1.0e6) / time);
 }
@@ -121,7 +121,7 @@ benchmark2(string_view funcname, FUNC func, T x, U y, size_t work = 0)
         r = func(x, y); DoNotOptimize (r); clobber_all_memory();
     };
     float time = time_trial(repeat_func, ntrials, iterations / 8);
-    Strutil::printf("  %s: %7.1f Mvals/sec, (%.1f Mcalls/sec)\n",
+    Strutil::print("  {}: {:7.1f} Mvals/sec, ({:.1f} Mcalls/sec)\n",
                                  funcname, ((iterations * work) / 1.0e6) / time,
                                  (iterations / 1.0e6) / time);
 }
@@ -1364,11 +1364,11 @@ test_shift()
         VEC vhard(hard);
         OIIO_CHECK_SIMD_EQUAL (vhard >> 1, VEC(hard>>1));
         OIIO_CHECK_SIMD_EQUAL (srl(vhard,1), VEC(unsigned(hard)>>1));
-        Strutil::printf("  [%x] >>  1 == [%x]\n", vhard, vhard>>1);
-        Strutil::printf("  [%x] srl 1 == [%x]\n", vhard, srl(vhard,1));
+        Strutil::print("  [{:x}] >>  1 == [{:x}]\n", vhard, vhard>>1);
+        Strutil::print("  [{:x}] srl 1 == [{:x}]\n", vhard, srl(vhard,1));
         OIIO_CHECK_SIMD_EQUAL (srl(vhard,4), VEC(unsigned(hard)>>4));
-        Strutil::printf("  [%x] >>  4 == [%x]\n", vhard, vhard>>4);
-        Strutil::printf("  [%x] srl 4 == [%x]\n", vhard, srl(vhard,4));
+        Strutil::print("  [{:x}] >>  4 == [{:x}]\n", vhard, vhard>>4);
+        Strutil::print("  [{:x}] srl 4 == [{:x}]\n", vhard, srl(vhard,4));
     }
 
     // Test <<= and >>=

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -38,7 +38,7 @@ create_lotso_ustrings(int iterations)
 {
     OIIO_DASSERT(size_t(iterations) <= strings.size());
     if (verbose)
-        Strutil::printf("thread %d\n", std::this_thread::get_id());
+        Strutil::print("thread {}\n", std::this_thread::get_id());
     size_t h = 0;
     for (int i = 0; i < iterations; ++i) {
         ustring s(strings[i].data());
@@ -93,7 +93,7 @@ main(int argc, char* argv[])
     OIIO_CHECK_EQUAL(ustring::concat("", foo), "foo");
     ustring longstring(Strutil::repeat("01234567890", 100));
     OIIO_CHECK_EQUAL(ustring::concat(longstring, longstring),
-                     ustring::sprintf("%s%s", longstring, longstring));
+                     ustring::fmtformat("{}{}", longstring, longstring));
     OIIO_CHECK_EQUAL(ustring::from_hash(foo.hash()), foo);
 
     const int nhw_threads = Sysutil::hardware_concurrency();

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -1672,8 +1672,8 @@ main(int argc, const char* argv[])
             texsys->get_texture_info(all_filenames[i], 0,
                                      ustring("stat:file_size"), TypeDesc::INT64,
                                      &file_size);
-            std::cout << Strutil::sprintf(
-                "  %d: %s  opens=%d, read=%s, time=%s, data=%s, file=%s\n", i,
+            Strutil::print(
+                "  {}: {}  opens={}, read={}, time={}, data={}, file={}\n", i,
                 all_filenames[i], timesopened, Strutil::memformat(bytesread),
                 Strutil::timeintervalformat(iotime, 2),
                 Strutil::memformat(data_size), Strutil::memformat(file_size));


### PR DESCRIPTION
fmt master seems to have just deprecated the ability for
fmt::sprintf("%s") to default to printing anything that allows stream
output. This breaks use of Strutil::sprintf formatting ustrings.

This isn't yet in any tagged release of fmtlib, but I'm trying to get
ahead of it.

The quick fix is to just change those handful of places to use
std::format style calls, which we are slowly converting to anyway.

Also throw in a fmt::formater for ustrings for good measure.

