### PR TITLE
UDIM speedups by eliminating mutex

### DIFF
--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -111,19 +111,31 @@ struct ImageCacheStatistics {
 
 struct UdimInfo {
     ustring filename;
-    ImageCacheFile* icfile = nullptr;
+    std::atomic<ImageCacheFile*> icfile { nullptr };
     int u, v;
 
-    UdimInfo()
-        : icfile(nullptr)
-    {
-    }
+    UdimInfo() {}
     UdimInfo(ustring filename, ImageCacheFile* icfile, int u, int v)
         : filename(filename)
         , icfile(icfile)
         , u(u)
         , v(v)
     {
+    }
+    UdimInfo(const UdimInfo& other)
+        : filename(other.filename)
+        , icfile(other.icfile.load())
+        , u(other.u)
+        , v(other.v)
+    {
+    }
+    const UdimInfo& operator=(const UdimInfo& other)
+    {
+        filename = other.filename;
+        icfile   = other.icfile.load();
+        u        = other.u;
+        v        = other.v;
+        return *this;
     }
 };
 


### PR DESCRIPTION
The udim_lookup_mutex_pool is not necessary. Just using an atomic
pointer for udiminfo.icfile is enough.

I'm seeing about a 5-8% overall speed improvement in testtex-based
intense udim benchmarks under heavy threading, a ~2% overall
improvement in a real rendered scene that uses a bunch of udim
textures (I think there are bigger bottlenecks elsewhere that I'll
move on to next, but every little bit helps).

Some testtex enhancements coming along for the ride:

* UDIM-oriented tests (automatically decuded if the test textures
  contain `<UDIM>` in their name.

* --maketests will construct random test textures and use them (handy
  if you need lots of textures for a big test, but don't want to store
  them). The tests are based on a file pattern using std::format-like
  replacement with an index. Also, if the pattern contains `<UDIM>` in
  the name, it's understood to be a udim pattern and many individual
  udim piece files will be created.

An example of these two items in action is:

```
testtex --maketests 200 "tmp/foo{:04}_<UDIM>.exr" --threadtimes 8 -iters 100000000 -runstats -v --handle -maxfiles 1000  -trials 5 -wedge
```

