### PR TITLE
ustringhash

### DIFF
--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -27,6 +27,10 @@
 
 OIIO_NAMESPACE_BEGIN
 
+class ustringhash;  // forward declaration
+
+
+
 /// A ustring is an alternative to char* or std::string for storing
 /// strings, in which the character sequence is unique (allowing many
 /// speed advantages for assignment, equality testing, and inequality
@@ -49,10 +53,10 @@ OIIO_NAMESPACE_BEGIN
 ///
 /// We try very hard to completely mimic the API of std::string,
 /// including all the constructors, comparisons, iterations, etc.  Of
-/// course, the charaters of a ustring are non-modifiable, so we do not
+/// course, the characters of a ustring are non-modifiable, so we do not
 /// replicate any of the non-const methods of std::string.  But in most
 /// other ways it looks and acts like a std::string and so most templated
-/// algorthms that would work on a "const std::string &" will also work
+/// algorithms that would work on a "const std::string &" will also work
 /// on a ustring.
 ///
 /// Note that like a `char*`, but unlike a `std::string`, a ustring is not
@@ -124,7 +128,7 @@ public:
     typedef std::string::const_reverse_iterator const_reverse_iterator;
 
     /// Default ctr for ustring -- make an empty string.
-    ustring(void) noexcept
+    constexpr ustring(void) noexcept
         : m_chars(nullptr)
     {
     }
@@ -265,11 +269,7 @@ public:
     /// Assign a single char to a ustring.
     const ustring& operator=(char c)
     {
-        char s[2];
-        s[0]  = c;
-        s[1]  = 0;
-        *this = ustring(s);
-        return *this;
+        return *this = ustring(string_view(&c, 1));
     }
 
     /// Return a C string representation of a ustring.
@@ -308,6 +308,9 @@ public:
         const TableRep* rep = ((const TableRep*)m_chars) - 1;
         return rep->hashed;
     }
+
+    /// Return a hashed version of the string
+    ustringhash uhash(void) const noexcept;
 
     /// Return the number of characters in the string.
     size_t size(void) const noexcept { return length(); }
@@ -358,8 +361,6 @@ public:
     {
         return ustring(*this, pos, n);
     }
-
-    // FIXME: implement compare.
 
     size_type find(const ustring& str, size_type pos = 0) const noexcept
     {
@@ -759,6 +760,214 @@ private:
 
 
 
+/// A ustringhash holds the hash of a ustring in a type-safe way.
+///
+/// It has a nearly identical interface to a ustring, and still refers to a
+/// string in the internal ustring table. But whereas the representation of a
+/// ustring is the pointer to the characters, the representation of a
+/// ustringhash is the hash of the string.
+///
+/// For some uses where you don't need access to the characters in any
+/// performance-critical paths, this may be a more convenient representation.
+/// In particular, it's well suited to a GPU that doesn't have access to the
+/// character memory. Another interesting difference is that from run to run,
+/// a ustring may have a different literal value, since there's no reason to
+/// expect that the pointer to a string like "foo" will refer to the same
+/// memory location every time the program executes, but in contrast, the hash
+/// is guaranteed to be identical from run to run.
+///
+class OIIO_UTIL_API ustringhash {
+public:
+    // Default constructor
+    OIIO_HOSTDEVICE constexpr ustringhash(void) noexcept
+        : m_hash(0)
+    {
+    }
+
+    /// ustringhash destructor.
+    ~ustringhash() noexcept = default;
+
+    /// Copy construct a ustringhash from another ustringhash.
+    OIIO_HOSTDEVICE constexpr ustringhash(const ustringhash& str) noexcept
+        : m_hash(str.m_hash)
+    {
+    }
+
+    /// Construct from a ustring
+    ustringhash(const ustring& str) noexcept
+        : m_hash(str.hash())
+    {
+    }
+
+    /// Construct a ustringhash from a null-terminated C string (char *).
+    OIIO_HOSTDEVICE explicit ustringhash(const char* str)
+    {
+#ifdef __CUDA_ARCH__
+        m_hash = Strutil::strhash(str);  // GPU: just compute the hash
+#else
+        m_hash = ustring(str).hash();  // CPU: make ustring, get its hash
+#endif
+    }
+
+    /// Construct a ustringhash from a string_view, which can be
+    /// auto-converted from either a std::string.
+    OIIO_HOSTDEVICE explicit ustringhash(string_view str)
+    {
+#ifdef __CUDA_ARCH__
+        m_hash = Strutil::strhash(str);  // GPU: just compute the hash
+#else
+        m_hash = ustring(str).hash();  // CPU: make ustring, get its hash
+#endif
+    }
+
+    /// Conversion to an OIIO::string_view.
+    operator string_view() const noexcept { return ustring::from_hash(m_hash); }
+
+    /// Conversion to std::string (explicit only!).
+    explicit operator std::string() const noexcept
+    {
+        return ustring::from_hash(m_hash).string();
+    }
+
+    /// Assign from a ustringhash
+    OIIO_HOSTDEVICE constexpr const ustringhash&
+    operator=(const ustringhash& str)
+    {
+        m_hash = str.m_hash;
+        return *this;
+    }
+
+    /// Assign from a ustring
+    const ustringhash& operator=(const ustring& str)
+    {
+        m_hash = str.hash();
+        return *this;
+    }
+
+    /// Reset to an empty string.
+    OIIO_HOSTDEVICE void clear(void) noexcept { m_hash = 0; }
+
+#ifndef __CUDA_ARCH__
+    /// Return a pointer to the characters.
+    const char* c_str() const noexcept
+    {
+        return ustring::from_hash(m_hash).c_str();
+    }
+
+    /// Return a C string representation of a ustring.
+    const char* data() const noexcept { return c_str(); }
+
+    /// Return a C++ std::string representation of a ustring.
+    const std::string& string() const noexcept
+    {
+        return ustring::from_hash(m_hash).string();
+    }
+
+    /// Return the number of characters in the string.
+    size_t length(void) const noexcept
+    {
+        return ustring::from_hash(m_hash).length();
+    }
+#endif
+
+    /// Return a hashed version of the string
+    OIIO_HOSTDEVICE constexpr size_t hash(void) const noexcept
+    {
+        return m_hash;
+    }
+
+#ifndef __CUDA_ARCH__
+    /// Return the number of characters in the string.
+    size_t size(void) const noexcept { return length(); }
+#endif
+
+    /// Is the string empty -- i.e., is it nullptr or does it point to an
+    /// empty string? (Empty strings always have a hash of 0.)
+    OIIO_HOSTDEVICE constexpr bool empty(void) const noexcept
+    {
+        return m_hash == 0;
+    }
+
+    /// Test for equality with another ustringhash.
+    OIIO_HOSTDEVICE constexpr bool
+    operator==(const ustringhash& str) const noexcept
+    {
+        return m_hash == str.m_hash;
+    }
+
+    /// Test for inequality with another ustringhash.
+    OIIO_HOSTDEVICE constexpr bool
+    operator!=(const ustringhash& str) const noexcept
+    {
+        return m_hash != str.m_hash;
+    }
+
+    /// Test for equality with a char*.
+    bool operator==(const char* str) const noexcept
+    {
+        return m_hash == Strutil::strhash(str);
+    }
+
+    /// Test for inequality with a char*.
+    bool operator!=(const char* str) const noexcept
+    {
+        return m_hash != Strutil::strhash(str);
+    }
+
+#ifndef __CUDA_ARCH__
+    /// Test for equality with a ustring.
+    bool operator==(const ustring& str) const noexcept
+    {
+        return m_hash == str.hash();
+    }
+
+    friend bool operator==(const ustring& a, const ustringhash& b) noexcept
+    {
+        return b == a;
+    }
+
+    /// Test for inequality with a ustring.
+    bool operator!=(const ustring& str) const noexcept
+    {
+        return m_hash != str.hash();
+    }
+
+    friend bool operator!=(const ustring& a, const ustringhash& b) noexcept
+    {
+        return b != a;
+    }
+
+    /// Generic stream output of a ustring.
+    friend std::ostream& operator<<(std::ostream& out, const ustringhash& str)
+    {
+        return (out << str.hash());
+    }
+#endif
+
+private:
+    // Individual ustringhash internal representation -- the hash value.
+    size_t m_hash;
+
+    // Construct from a raw hash value. It's protected so that it's only
+    // callable by its friend, ustring.
+    OIIO_HOSTDEVICE ustringhash(size_t hashval)
+        : m_hash(hashval)
+    {
+    }
+
+    friend class ustring;
+};
+
+
+
+inline ustringhash
+ustring::uhash() const noexcept
+{
+    return ustringhash(hash());
+}
+
+
+
 /// Functor class to use as a hasher when you want to make a hash_map or
 /// hash_set using ustring as a key.
 class ustringHash {
@@ -827,6 +1036,13 @@ inline std::string
 to_string(const ustring& value)
 {
     return value.string();
+}
+
+template<>
+inline std::string
+to_string(const ustringhash& value)
+{
+    return ustring(value).string();
 }
 
 }  // end namespace Strutil

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -336,6 +336,7 @@ test_hash()
     OIIO_CHECK_EQUAL(strhash("foo"), 6150913649986995171);
     OIIO_CHECK_EQUAL(strhash(std::string("foo")), 6150913649986995171);
     OIIO_CHECK_EQUAL(strhash(string_view("foo")), 6150913649986995171);
+    OIIO_CHECK_EQUAL(strhash(""), 0);  // empty string hashes to 0
 }
 
 

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -34,23 +34,6 @@ static std::vector<std::array<char, 16>> strings;
 
 
 static void
-create_lotso_ustrings(int iterations)
-{
-    OIIO_DASSERT(size_t(iterations) <= strings.size());
-    if (verbose)
-        Strutil::print("thread {}\n", std::this_thread::get_id());
-    size_t h = 0;
-    for (int i = 0; i < iterations; ++i) {
-        ustring s(strings[i].data());
-        h += s.hash();
-    }
-    if (verbose)
-        Strutil::printf("checksum %08x\n", unsigned(h));
-}
-
-
-
-static void
 getargs(int argc, char* argv[])
 {
     // clang-format off
@@ -73,28 +56,6 @@ getargs(int argc, char* argv[])
     // clang-format on
 
     ap.parse(argc, (const char**)argv);
-}
-
-
-
-int
-main(int argc, char* argv[])
-{
-    getargs(argc, argv);
-
-    OIIO_CHECK_ASSERT(ustring("foo") == ustring("foo"));
-    OIIO_CHECK_ASSERT(ustring("bar") != ustring("foo"));
-    ustring foo("foo");
-    OIIO_CHECK_ASSERT(foo.string() == "foo");
-    ustring bar("bar");
-    OIIO_CHECK_EQUAL(ustring::concat(foo, bar), "foobar");
-    OIIO_CHECK_EQUAL(ustring::concat(foo, "bar"), "foobar");
-    OIIO_CHECK_EQUAL(ustring::concat(foo, ""), "foo");
-    OIIO_CHECK_EQUAL(ustring::concat("", foo), "foo");
-    ustring longstring(Strutil::repeat("01234567890", 100));
-    OIIO_CHECK_EQUAL(ustring::concat(longstring, longstring),
-                     ustring::fmtformat("{}{}", longstring, longstring));
-    OIIO_CHECK_EQUAL(ustring::from_hash(foo.hash()), foo);
 
     const int nhw_threads = Sysutil::hardware_concurrency();
     std::cout << "hw threads = " << nhw_threads << "\n";
@@ -102,7 +63,170 @@ main(int argc, char* argv[])
     // user wants to max out the number of threads
     if (numthreads <= 0)
         numthreads = nhw_threads;
+}
 
+
+void
+test_ustring()
+{
+    ustring foo("foo"), bar("bar"), empty(""), uninit;
+    ustring foobarbaz("foobarbaz");
+
+    // Size of a ustring is just a pointer
+    OIIO_CHECK_EQUAL(sizeof(ustring), sizeof(const char*));
+
+    // Test constructors
+    OIIO_CHECK_ASSERT(uninit.c_str() == nullptr);
+    OIIO_CHECK_EQUAL(foo, ustring(string_view("foo")));
+    OIIO_CHECK_EQUAL(foo, ustring(std::string("foo")));
+    OIIO_CHECK_EQUAL(ustring("hoobarfoo123", 6, 3), ustring("foo"));
+    OIIO_CHECK_EQUAL(ustring("hoobarfoo123", 3), ustring("hoo"));
+    OIIO_CHECK_EQUAL(ustring(3, 'x'), ustring("xxx"));
+    OIIO_CHECK_EQUAL(ustring(foo), foo);
+    OIIO_CHECK_EQUAL(ustring(foo, 2, 1), ustring("o"));
+
+    // Conversion to char*, string_view, string
+    OIIO_CHECK_ASSERT(!strcmp(foo.c_str(), "foo"));
+    OIIO_CHECK_EQUAL(foo.string(), "foo");
+    OIIO_CHECK_EQUAL(string_view(foo), "foo");
+    OIIO_CHECK_EQUAL(std::string(foo), "foo");
+
+    // assignment, clear
+    ustring foo2;
+    foo2 = foo;
+    OIIO_CHECK_EQUAL(foo2, foo);
+    foo2.clear();
+    OIIO_CHECK_EQUAL(foo2, uninit);
+
+    // length/size, empty
+    OIIO_CHECK_EQUAL(foo.length(), 3);
+    OIIO_CHECK_EQUAL(foo.size(), 3);
+    OIIO_CHECK_EQUAL(empty.size(), 0);
+    OIIO_CHECK_EQUAL(uninit.size(), 0);
+    OIIO_CHECK_ASSERT(empty.empty());
+    OIIO_CHECK_ASSERT(uninit.empty());
+    OIIO_CHECK_ASSERT(!foo.empty());
+
+    // Characters
+    OIIO_CHECK_EQUAL(foo[0], 'f');
+    OIIO_CHECK_EQUAL(bar[1], 'a');
+
+    // copy
+    char buf[10];
+    foo.copy(buf, sizeof(buf) - 1);
+    OIIO_CHECK_ASSERT(!strcmp(buf, "foo"));
+    ustring("foobarbaz").copy(buf, 4, 3);
+    OIIO_CHECK_ASSERT(!strcmp(buf, "barb"));
+
+    // substr
+    OIIO_CHECK_ASSERT(foobarbaz.substr(3, 4) == ustring("barb"));
+
+    // find
+    OIIO_CHECK_ASSERT(foobarbaz.find("ba") == 3);
+    OIIO_CHECK_ASSERT(foobarbaz.find("ba", 4) == 6);
+    OIIO_CHECK_ASSERT(foobarbaz.rfind("ba") == 6);
+    OIIO_CHECK_ASSERT(foobarbaz.rfind("ba") == 6);
+    // FIXME: there are lots of find_* permutations to test, but I'm lazy
+
+    // concat
+    OIIO_CHECK_EQUAL(ustring::concat(foo, bar), "foobar");
+    OIIO_CHECK_EQUAL(ustring::concat(foo, "bar"), "foobar");
+    OIIO_CHECK_EQUAL(ustring::concat(foo, ""), "foo");
+    OIIO_CHECK_EQUAL(ustring::concat("", foo), "foo");
+    ustring longstring(Strutil::repeat("01234567890", 100));
+    OIIO_CHECK_EQUAL(ustring::concat(longstring, longstring),
+                     ustring::fmtformat("{}{}", longstring, longstring));
+
+    // from_hash
+    OIIO_CHECK_EQUAL(ustring::from_hash(foo.hash()), foo);
+
+    // make_unique, is_unique, from_unique
+    const char* foostr = foo.c_str();
+    OIIO_CHECK_EQUAL(ustring::make_unique("foo"), foostr);
+    OIIO_CHECK_EQUAL(ustring::is_unique(foostr), true);
+    OIIO_CHECK_EQUAL(ustring::is_unique("foo"), false);
+    OIIO_CHECK_EQUAL(ustring::from_unique(foostr), foo);
+}
+
+
+
+void
+test_ustringhash()
+{
+    // Two ustrings
+    ustring foo("foo"), bar("bar");
+    OIIO_CHECK_EQUAL(sizeof(ustringhash), sizeof(size_t));
+
+    // Make two ustringhash's from strings
+    ustringhash hfoo("foo"), hbar("bar");
+    OIIO_CHECK_EQUAL(hfoo.hash(), foo.hash());
+    OIIO_CHECK_EQUAL(hbar.hash(), bar.hash());
+    OIIO_CHECK_NE(hfoo.hash(), hbar.hash());
+
+    // Check copy construction, assignment, ==, !=
+    ustringhash hfoo_copy(hfoo);
+    OIIO_CHECK_EQUAL(hfoo_copy, hfoo);
+    OIIO_CHECK_NE(hfoo, hbar);
+    ustringhash hfoo_copy2;
+    hfoo_copy2 = hfoo;
+    OIIO_CHECK_EQUAL(hfoo_copy2, hfoo);
+
+    // Assignment from a ustring
+    ustringhash hfoo_from_foo = foo;
+    OIIO_CHECK_EQUAL(hfoo_from_foo, hfoo);
+
+    // Ask a ustring for its ustringhash
+    OIIO_CHECK_EQUAL(hfoo, foo.uhash());
+
+    // string_view and string from ustringhash
+    string_view foo_sv = hfoo;
+    OIIO_CHECK_EQUAL(foo_sv, "foo");
+    OIIO_CHECK_EQUAL(std::string(foo_sv), "foo");
+
+    // clear and empty()
+    OIIO_CHECK_ASSERT(!hfoo_copy2.empty());
+    hfoo_copy2.clear();
+    OIIO_CHECK_ASSERT(hfoo_copy2.empty());
+
+    // Can we get to the characters?
+    OIIO_CHECK_EQUAL(hfoo.c_str(), foo.c_str());
+    OIIO_CHECK_EQUAL(hfoo.length(), foo.length());
+    OIIO_CHECK_EQUAL(hfoo.size(), foo.size());
+
+    // Check ==, != with strings, and with ustring's
+    OIIO_CHECK_EQUAL(hfoo, "foo");
+    OIIO_CHECK_NE(hbar, "foo");
+    // OIIO_CHECK_EQUAL(hfoo, std::string("foo"));
+    // OIIO_CHECK_NE(hbar, std::string("foo"));
+    OIIO_CHECK_EQUAL(hfoo, foo);
+    OIIO_CHECK_NE(hbar, foo);
+
+    // Conversion to string
+    OIIO_CHECK_EQUAL(Strutil::to_string(hfoo), "foo");
+}
+
+
+
+static void
+create_lotso_ustrings(int iterations)
+{
+    OIIO_DASSERT(size_t(iterations) <= strings.size());
+    if (verbose)
+        Strutil::print("thread {}\n", std::this_thread::get_id());
+    size_t h = 0;
+    for (int i = 0; i < iterations; ++i) {
+        ustring s(strings[i].data());
+        h += s.hash();
+    }
+    if (verbose)
+        Strutil::printf("checksum %08x\n", unsigned(h));
+}
+
+
+
+void
+benchmark_threaded_ustring_creation()
+{
     // prepare the strings we will turn into ustrings to avoid
     // including snprintf in the benchmark
     strings.resize(wedge ? iterations : iterations / numthreads);
@@ -119,7 +243,13 @@ main(int argc, char* argv[])
                            numthreads /* just this one thread count */);
     }
     OIIO_CHECK_ASSERT(true);  // If we make it here without crashing, pass
+}
 
+
+
+void
+verify_no_collisions()
+{
     // Try to force a hash collision
     parallel_for(0LL, 1000000LL * int64_t(collide),
                  [](int64_t i) { ustring u = ustring::fmtformat("{:x}", i); });
@@ -132,6 +262,20 @@ main(int argc, char* argv[])
             Strutil::print("    \"{}\" (orig {:08x} rehashed {:08x})\n", c,
                            Strutil::strhash(c), c.hash());
     }
+}
+
+
+
+int
+main(int argc, char* argv[])
+{
+    getargs(argc, argv);
+
+    test_ustring();
+    test_ustringhash();
+    verify_no_collisions();
+    benchmark_threaded_ustring_creation();
+    verify_no_collisions();
 
     if (verbose)
         std::cout << "\n" << ustring::getstats() << "\n";


### PR DESCRIPTION
ustring is a unique string (that lives in an internal hash table) whose
representation is the pointer to the characters that live in the table.

ustring hash is its alter ego -- it also refers to a ustring in the
internal hash table, but the representation is just the hash itself.

It presents an interface that is a subset of that of ustring, and in
many ways they can be used interchangeably.  For ustringhash,
accessing the characters requires using the hash to find the string in
the table -- which is not hard, but more expensive than accessing the
charcters with a ustring, where the representation is the pointer
directly to the characters.

For some uses where you don't need access to the characters in any
performance-critical paths, this may be a more convenient
representation.  In particular, it's well suited to a GPU that doesn't
have access to the character memory. Another interesting difference is
that from run to run, a ustring may have a different literal value,
since there's no reason to expect that the pointer to a string like
"foo" will refer to the same memory location every time the program
executes, but in contrast, the hash is guaranteed to be identical
from run to run.

In the process of adding unit tests for ustringhash, I ended up
overhauling all of ustring_test.cpp, as I saw that the ustring tests
were extremely cursory. Did a tiny bit of (non-breaking) touch-ups
on a few ustring methods as well.
