### PR TITLE
PNG: beef up error detection and propagation

### DIFF
--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -1068,9 +1068,11 @@ ImageInput::append_error(string_view message) const
     OIIO_DASSERT(
         errptr->size() < 1024 * 1024 * 16
         && "Accumulated error messages > 16MB. Try checking return codes!");
-    if (errptr->size() && errptr->back() != '\n')
-        *errptr += '\n';
-    *errptr += message;
+    if (errptr->size() < 1024 * 1024 * 16) {
+        if (errptr->size() && errptr->back() != '\n')
+            *errptr += '\n';
+        *errptr += message;
+    }
 }
 
 
@@ -1217,8 +1219,7 @@ ImageInput::ioread(void* buf, size_t itemsize, size_t nitems)
     size_t n    = m_io->read(buf, size);
     if (n != size) {
         if (size_t(m_io->tell()) >= m_io->size())
-            ImageInput::errorfmt("Read error on \"{}\": hit end of file",
-                                 m_io->filename());
+            ImageInput::errorfmt("Read error: hit end of file");
         else
             ImageInput::errorfmt(
                 "Read error at position {}, could only read {}/{} bytes {}",

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -182,8 +182,12 @@ read_info(png_structp& sp, png_infop& ip, int& bit_depth, int& color_type,
           bool keep_unassociated_alpha)
 {
     // Must call this setjmp in every function that does PNG reads
-    if (setjmp(png_jmpbuf(sp)))  // NOLINT(cert-err52-cpp)
+    if (setjmp(png_jmpbuf(sp))) {  // NOLINT(cert-err52-cpp)
+        ImageInput* pnginput = (ImageInput*)png_get_io_ptr(sp);
+        if (!pnginput->has_error())
+            pnginput->errorfmt("Could not read info from file");
         return false;
+    }
 
     bool ok = true;
     png_read_info(sp, ip);

--- a/testsuite/png/ref/out.txt
+++ b/testsuite/png/ref/out.txt
@@ -22,3 +22,14 @@ Reading ../oiio-images/oiio-logo-with-alpha.png
     oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/oiio-logo-with-alpha.png" and "oiio-logo-with-alpha.png"
 PASS
+libpng error: IDAT: Read error: hit end of file
+iconvert ERROR copying "../oiio-images/png/broken/invalid_gray_alpha_sbit.png" to "invalid_gray_alpha_sbit.png" :
+	Read error: hit end of file
+PNG read error: IDAT: Read error: hit end of file
+libpng error: No IDATs written into file
+libpng error: tEXt: Read error: hit end of file
+libpng error: tEXt: Read error: hit end of file
+Comparing "../oiio-images/png/broken/invalid_gray_alpha_sbit.png" and "invalid_gray_alpha_sbit.png"
+idiff ERROR: Could not read invalid_gray_alpha_sbit.png:
+	Invalid image file "invalid_gray_alpha_sbit.png": Read error: hit end of file
+PNG read error: tEXt: Read error: hit end of file

--- a/testsuite/png/run.py
+++ b/testsuite/png/run.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python
 
+# save the error output
+redirect = " >> out.txt 2>&1 "
+failureok = 1
+
 files = [ "oiio-logo-no-alpha.png",  "oiio-logo-with-alpha.png" ]
 for f in files:
         command += rw_command (OIIO_TESTSUITE_IMAGEDIR,  f)
+
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR + "/png/broken",
+                       "invalid_gray_alpha_sbit.png",
+                       printinfo=False)

--- a/testsuite/targa/ref/out.err.txt
+++ b/testsuite/targa/ref/out.err.txt
@@ -1,5 +1,5 @@
 iconvert ERROR copying "src/crash1.tga" to "crash1.exr" :
-	Read error on "src/crash1.tga": hit end of file
+	Read error: hit end of file
 oiiotool ERROR: read : "src/crash2.tga": Palette image with no palette
 Full command line was:
 > oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio --oiioattrib try_all_readers 0 src/crash2.tga -o crash2.exr


### PR DESCRIPTION
Especially for corrupt/broken files. Mostly consists of more care in
bubbling up error conditions so they can be properly handled at a
high level.

Fixes #3437 

