### PR TITLE
Timer: use clock_gettime rather than gettimeofday

### DIFF
--- a/src/include/OpenImageIO/timer.h
+++ b/src/include/OpenImageIO/timer.h
@@ -28,6 +28,8 @@
 #    include <sys/time.h>
 #endif
 
+#define OIIO_TIMER_LINUX_USE_clock_gettime 1
+
 
 OIIO_NAMESPACE_BEGIN
 
@@ -60,7 +62,7 @@ OIIO_NAMESPACE_BEGIN
 ///
 class OIIO_UTIL_API Timer {
 public:
-    typedef long long ticks_t;
+    typedef int64_t ticks_t;
     enum StartNowVal { DontStartNow, StartNow };
     enum PrintDtrVal { DontPrintDtr, PrintDtr };
 
@@ -204,10 +206,14 @@ private:
         return n.QuadPart;
 #elif defined(__APPLE__)
         return mach_absolute_time();
+#elif OIIO_TIMER_LINUX_USE_clock_gettime
+        struct timespec t;
+        clock_gettime(CLOCK_MONOTONIC, &t);
+        return int64_t(t.tv_sec) * int64_t(1000000000) + t.tv_nsec;
 #else
         struct timeval t;
         gettimeofday(&t, NULL);
-        return (long long)t.tv_sec * 1000000ll + t.tv_usec;
+        return int64_t(t.tv_sec) * int64_t(1000000) + t.tv_usec;
 #endif
     }
 

--- a/src/libutil/timer.cpp
+++ b/src/libutil/timer.cpp
@@ -10,9 +10,9 @@
 
 OIIO_NAMESPACE_BEGIN
 
-// Defaults based on a microsecond resolution timer: gettimeofday()
-double Timer::seconds_per_tick         = 1.0e-6;
-Timer::ticks_t Timer::ticks_per_second = 1000000;
+double Timer::seconds_per_tick;
+Timer::ticks_t Timer::ticks_per_second;
+
 
 
 class TimerSetupOnce {
@@ -38,6 +38,14 @@ public:
                                   / static_cast<double>(time_info.denom);
         Timer::ticks_per_second = Timer::ticks_t(1.0f
                                                  / Timer::seconds_per_tick);
+#elif OIIO_TIMER_LINUX_USE_clock_gettime
+        // Defaults based on a nanosecond resolution timer: clock_gettime()
+        Timer::seconds_per_tick = 1.0e-9;
+        Timer::ticks_per_second = 1000000000;
+#else
+        // Defaults based on a microsecond resolution timer: gettimeofday()
+        Timer::seconds_per_tick = 1.0e-6;
+        Timer::ticks_per_second = 1000000;
 #endif
         // Note: For anything but Windows and Mac, we rely on gettimeofday,
         // which is microsecond timing, so there's nothing to set up.


### PR DESCRIPTION
On Linux, we'd been using gettimeofday, which gives results with usec
resolution. Switch to clock_gettime, which has nsec results.

In practice, the round trip time of a pair of "get time" system calls
is about 30-50ns in either case. But the new call at least nominally
returns ns resolution values. Another way of saying that is: the
answers we get should be more accurate with this call, but the call
itself is the same expense as before, so we should still be just as
cautious about not inserting timers around events that are so brief
that the timers themselves are going to be a significant addition to
the cost.

This only effects Linux (and maybe BSD?). On MacOS, we use
mach_absolute_time(), and on Windows we use QueryPeformanceCounter(),
so neither of those platforms is affected by this patch.
