### PR TITLE
ustring: add OIIO_USTRING_HAS_USTRINGHASH symbol

### DIFF
--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -27,6 +27,10 @@
 
 OIIO_NAMESPACE_BEGIN
 
+// Feature tests
+#define OIIO_USTRING_HAS_USTRINGHASH 1
+
+
 class ustringhash;  // forward declaration
 
 


### PR DESCRIPTION
This makes it easier for downstream users to test if ustringhash is
available in a particular version of OIIO.

