### PR TITLE
idiff: add --allowfailures and convert output

### DIFF
--- a/testsuite/png/ref/out.txt
+++ b/testsuite/png/ref/out.txt
@@ -27,9 +27,9 @@ iconvert ERROR copying "../oiio-images/png/broken/invalid_gray_alpha_sbit.png" t
 	Read error: hit end of file
 PNG read error: IDAT: Read error: hit end of file
 libpng error: No IDATs written into file
-libpng error: tEXt: Read error: hit end of file
-libpng error: tEXt: Read error: hit end of file
 Comparing "../oiio-images/png/broken/invalid_gray_alpha_sbit.png" and "invalid_gray_alpha_sbit.png"
+libpng error: tEXt: Read error: hit end of file
+libpng error: tEXt: Read error: hit end of file
 idiff ERROR: Could not read invalid_gray_alpha_sbit.png:
 	Invalid image file "invalid_gray_alpha_sbit.png": Read error: hit end of file
 PNG read error: tEXt: Read error: hit end of file

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -92,6 +92,7 @@ outputs = [ "out.txt" ]    # default
 failthresh = 0.004         # "Failure" threshold for any pixel value
 failpercent = 0.02         # Ok fo this percentage of pixels to "fail"
 hardfail = 0.012           # Even one pixel this wrong => hard failure
+allowfailures = 0          # Freebie failures
 
 # Some tests are designed for the app running to "fail" (in the sense of
 # terminating with an error return code), for example, a test that is designed
@@ -231,6 +232,7 @@ def diff_command (fileA, fileB, extraargs="", silent=False, concat=True) :
                + " -fail " + str(failthresh)
                + " -failpercent " + str(failpercent)
                + " -hardfail " + str(hardfail)
+               + " -allowfailures " + str(allowfailures)
                + " -warn " + str(2*failthresh)
                + " -warnpercent " + str(failpercent)
                + " " + extraargs + " " + make_relpath(fileA,tmpdir)
@@ -288,6 +290,7 @@ def rw_command (dir, filename, testwrite=True, use_oiiotool=False, extraargs="",
                + " -fail " + str(failthresh)
                + " -failpercent " + str(failpercent)
                + " -hardfail " + str(hardfail)
+               + " -allowfailures " + str(allowfailures)
                + " -warn " + str(2*failthresh)
                + " " + idiffextraargs + " " + output_filename + redirect + ";\n")
     return cmd


### PR DESCRIPTION
* --allowfailures is a big hammer to allow a certain number of pixel
  mismatches by any amount.
* Convert diff to modern std::format based output.
