### PR TITLE
Build: allow "arm64" arch in make

### DIFF
--- a/src/make/detectplatform.mk
+++ b/src/make/detectplatform.mk
@@ -26,7 +26,9 @@ ifneq (${hw},x86)
     ifneq (${hw},i386)
       ifneq (${hw},i686)
         ifneq (${hw},aarch64)
-          $(error "ERROR: Unknown hardware architecture")
+          ifneq (${hw},arm64)
+            $(error "ERROR: Unknown hardware architecture")
+          endif
         endif
       endif
     endif


### PR DESCRIPTION
## Description

On Apple Silicon, `uname -m` returns `arm64`. The make platform detection script was allowing `aarch64`, so similar to that one, also allow `arm64`.

## Tests

n/a (build code only)

With the change, building OIIO locally on an Apple M1 laptop does get much further into the process than before (was just bailing out immediately).

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

