### PR TITLE
dds: Add more DDS test images

### DIFF
--- a/testsuite/dds/ref/out.txt
+++ b/testsuite/dds/ref/out.txt
@@ -4,3 +4,91 @@ Reading ../oiio-images/dds/sample-DXT1.dds
     channel list: R, G, B, A
     compression: "DXT1"
     textureformat: "Plain Texture"
+Reading ../oiio-images/dds/dds_bc1.dds
+../oiio-images/dds/dds_bc1.dds :   16 x    8, 4 channel, uint8 dds
+    SHA-1: 4899EDECACC4DE45A499D5D66661AF2B6F944001
+    channel list: R, G, B, A
+    compression: "DXT1"
+    textureformat: "Plain Texture"
+Reading ../oiio-images/dds/dds_bc1_mips.dds
+../oiio-images/dds/dds_bc1_mips.dds :   16 x    8, 4 channel, uint8 dds
+    MIP-map levels: 16x8 8x4 4x2 2x1 1x1
+    SHA-1: 4899EDECACC4DE45A499D5D66661AF2B6F944001
+    channel list: R, G, B, A
+    compression: "DXT1"
+    textureformat: "Plain Texture"
+Reading ../oiio-images/dds/dds_bc2.dds
+../oiio-images/dds/dds_bc2.dds :   16 x    8, 4 channel, uint8 dds
+    SHA-1: E94F2C6888523F9BC3EE6EE540C596235680326F
+    channel list: R, G, B, A
+    compression: "DXT3"
+    textureformat: "Plain Texture"
+Reading ../oiio-images/dds/dds_bc3.dds
+../oiio-images/dds/dds_bc3.dds :   16 x    8, 4 channel, uint8 dds
+    SHA-1: 86AFD16DC1658E4F501198AF6C12217DA892AA38
+    channel list: R, G, B, A
+    compression: "DXT5"
+    textureformat: "Plain Texture"
+Reading ../oiio-images/dds/dds_bgr8.dds
+../oiio-images/dds/dds_bgr8.dds :   16 x    8, 3 channel, uint8 dds
+    SHA-1: 6BF57CCCCF14021926285CE97D25AEC150324476
+    channel list: R, G, B
+    textureformat: "Plain Texture"
+    oiio:BitsPerSample: 24
+Reading ../oiio-images/dds/dds_npot_bc3.dds
+../oiio-images/dds/dds_npot_bc3.dds :   13 x    7, 4 channel, uint8 dds
+    SHA-1: 218E8B934EDE7C203DD4646D8634410DB28D564E
+    channel list: R, G, B, A
+    compression: "DXT5"
+    textureformat: "Plain Texture"
+Reading ../oiio-images/dds/dds_npot_bc3_mips.dds
+../oiio-images/dds/dds_npot_bc3_mips.dds :   13 x    7, 4 channel, uint8 dds
+    MIP-map levels: 13x7 6x3 3x1 1x1
+    SHA-1: 218E8B934EDE7C203DD4646D8634410DB28D564E
+    channel list: R, G, B, A
+    compression: "DXT5"
+    textureformat: "Plain Texture"
+Reading ../oiio-images/dds/dds_npot_rgba8.dds
+../oiio-images/dds/dds_npot_rgba8.dds :   13 x    7, 4 channel, uint8 dds
+    SHA-1: 6CBA3E2782498E2E92F5E4B08376A2E948FE3BAF
+    channel list: R, G, B, A
+    textureformat: "Plain Texture"
+    oiio:BitsPerSample: 32
+Reading ../oiio-images/dds/dds_npot_rgba8_mips.dds
+../oiio-images/dds/dds_npot_rgba8_mips.dds :   13 x    7, 4 channel, uint8 dds
+    MIP-map levels: 13x7 6x3 3x1 1x1
+    SHA-1: 6CBA3E2782498E2E92F5E4B08376A2E948FE3BAF
+    channel list: R, G, B, A
+    textureformat: "Plain Texture"
+    oiio:BitsPerSample: 32
+Reading ../oiio-images/dds/dds_r5g6b5.dds
+../oiio-images/dds/dds_r5g6b5.dds :   16 x    8, 3 channel, uint8 dds
+    SHA-1: 40E37C4CC12C783830F4BAB614E9CD294D614A9D
+    channel list: R, G, B
+    textureformat: "Plain Texture"
+    oiio:BitsPerSample: 16
+Reading ../oiio-images/dds/dds_rgb8.dds
+../oiio-images/dds/dds_rgb8.dds :   16 x    8, 3 channel, uint8 dds
+    SHA-1: 6BF57CCCCF14021926285CE97D25AEC150324476
+    channel list: R, G, B
+    textureformat: "Plain Texture"
+    oiio:BitsPerSample: 24
+Reading ../oiio-images/dds/dds_rgba4.dds
+../oiio-images/dds/dds_rgba4.dds :   16 x    8, 4 channel, uint8 dds
+    SHA-1: 913C5D7FE99BAF1950475406D2BE94ABA5BA010D
+    channel list: R, G, B, A
+    textureformat: "Plain Texture"
+    oiio:BitsPerSample: 16
+Reading ../oiio-images/dds/dds_rgba8.dds
+../oiio-images/dds/dds_rgba8.dds :   16 x    8, 4 channel, uint8 dds
+    SHA-1: 61986C7E2D4F402B4A268AE5187AAFAF1647C0E6
+    channel list: R, G, B, A
+    textureformat: "Plain Texture"
+    oiio:BitsPerSample: 32
+Reading ../oiio-images/dds/dds_rgba8_mips.dds
+../oiio-images/dds/dds_rgba8_mips.dds :   16 x    8, 4 channel, uint8 dds
+    MIP-map levels: 16x8 8x4 4x2 2x1 1x1
+    SHA-1: 61986C7E2D4F402B4A268AE5187AAFAF1647C0E6
+    channel list: R, G, B, A
+    textureformat: "Plain Texture"
+    oiio:BitsPerSample: 32

--- a/testsuite/dds/run.py
+++ b/testsuite/dds/run.py
@@ -1,5 +1,26 @@
 #!/usr/bin/env python
 
-files = [ "sample-DXT1.dds" ]
+files = [
+    "sample-DXT1.dds",
+    "dds_bc1.dds",
+    "dds_bc1_mips.dds",
+    "dds_bc2.dds",
+    "dds_bc3.dds",
+    # BC4..BC7 not supported yet
+    #"dds_bc4.dds",
+    #"dds_bc5.dds",
+    #"dds_bc6hu.dds",
+    #"dds_bc6hu_hdr.dds",
+    #"dds_bc7.dds",
+    "dds_bgr8.dds",
+    "dds_npot_bc3.dds",
+    "dds_npot_bc3_mips.dds",
+    "dds_npot_rgba8.dds",
+    "dds_npot_rgba8_mips.dds",
+    "dds_r5g6b5.dds",
+    "dds_rgb8.dds",
+    "dds_rgba4.dds",
+    "dds_rgba8.dds",
+    "dds_rgba8_mips.dds" ]
 for f in files:
     command += info_command (OIIO_TESTSUITE_IMAGEDIR + "/" + f)


### PR DESCRIPTION
## Description

Somewhat in preparation of addressing #2338, this adds more images into DDS test suite. The actual images are at https://github.com/OpenImageIO/oiio-images/pull/4, this one is just using them in the test python script.

## Tests

Yes, this PR is **only** about the newly added tests. Of course all the `dds` tests are failing on CI without having the new images merged into the oiio-images repository (https://github.com/OpenImageIO/oiio-images/pull/4).

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

