### PR TITLE
DDS: speed up reading of uncompressed images

### DIFF
--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -662,13 +662,15 @@ DDSInput::internal_readimg(unsigned char* dst, int w, int h, int d)
             return ioread(dst, w * m_Bpp, h);
         }
 
-        int k, pixel = 0;
+        std::vector<uint8_t> tmp(w * m_Bpp);
         for (int z = 0; z < d; z++) {
             for (int y = 0; y < h; y++) {
-                for (int x = 0; x < w; x++) {
-                    if (!ioread(&pixel, 1, m_Bpp))
-                        return false;
-                    k          = (z * h * w + y * w + x) * m_spec.nchannels;
+                if (!ioread(tmp.data(), w, m_Bpp))
+                    return false;
+                size_t k = (z * h * w + y * w) * m_spec.nchannels;
+                for (int x = 0; x < w; x++, k += m_spec.nchannels) {
+                    uint32_t pixel;
+                    memcpy(&pixel, tmp.data() + x * m_Bpp, 4);
                     dst[k + 0] = ((pixel & m_dds.fmt.rmask) >> m_redR)
                                  << m_redL;
                     dst[k + 1] = ((pixel & m_dds.fmt.gmask) >> m_greenR)


### PR DESCRIPTION
## Description

Previous code was doing ioread one pixel at a time. Change it to read one scanline at a time, similar to e.g. how BMP reader does it.

On a 8192x8192 rgba8 image (256MB), on Apple M1 Max `iinfo --hash` time goes from 2.19s down to 0.65s, and is now similar to the time it takes on an uncompressed TIF (0.52s) or BMP (0.71s) image.

## Tests

No need for new tests, existing DDS test coverage should be fine.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

