### PR TITLE
PR template: fix links to work in actual PR page

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,12 +14,12 @@
 
 <!-- Put an 'x' in the boxes as you complete the checklist items -->
 
-- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
+- [ ] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
 - [ ] If this is more extensive than a small change to existing code, I
   have previously submitted a Contributor License Agreement
-  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
+  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
   employers might think my programming belongs to them, then also
-  [corporate](../src/doc/CLA-CORPORATE)).
+  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
 - [ ] I have updated the documentation, if applicable.
 - [ ] I have ensured that the change is tested somewhere in the testsuite
   (adding new test cases if necessary).


### PR DESCRIPTION
## Description

When viewing this .md file in Github UI, everything seems to work. But when creating an actual PR, the links to CONTRIBUTING and CLAs point to nothing that would exist. Looks like they try to be relative links from the "create a new PR" page. Workaround seems to be to use absolute links instead.

## Tests

N/A


## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](../src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](../src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

