### PR TITLE
Correctly accumulate 'ofs' when the cubemap has mipmap levels.

### DIFF
--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -473,7 +473,10 @@ DDSInput::internal_seek_subimage(int cubeface, int miplevel, unsigned int& w,
             }
             continue;
         }
-        for (int i = 0; i < miplevel; i++) {
+        // On the target cube face seek to the selected mip level.  On previous faces
+        // seek past all levels.
+        int seekLevel = (j == cubeface) ? miplevel : m_dds.mipmaps;
+        for (int i = 0; i < seekLevel; i++) {
             if (m_compression != Compression::None)
                 len = GetStorageRequirements(w, h, m_compression);
             else


### PR DESCRIPTION
## Description

internal_seek_subimage is trying to find the offset into a DDS cubmap file to read a specific mipmap from. The parameters 'cubeface' and 'miplevel' specify which mipmap to read. The code iterates over the cubemap faces, and then the miplevels for each face accumulating the offset to start reading from.

The problem is the nested loop over the mipmap levels only iterates to the _requested_ miplevel. So in a case where we have a DDS with 2 mipmap levels and we request cubeface 1 and miplevel 0 then when we compute the offset to skip the first cube face we ignore the size of miplevel 1!

The solution is to account for all mip levels for the cubemap faces which are fully skipped over.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [X] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project.

