### PR TITLE
allow loading of dlls from PATH on Windows Python 3.8+

### DIFF
--- a/src/cmake/pythonutils.cmake
+++ b/src/cmake/pythonutils.cmake
@@ -50,7 +50,7 @@ macro (find_python)
     set (PythonInterp_FIND_VERSION_MAJOR ${Python_VERSION_MAJOR})
 
     if (NOT DEFINED PYTHON_SITE_DIR)
-        set (PYTHON_SITE_DIR "${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_FOUND}/site-packages")
+        set (PYTHON_SITE_DIR "${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_FOUND}/site-packages/OpenImageIO")
     endif ()
     if (VERBOSE)
         message (STATUS "    Python site packages dir ${PYTHON_SITE_DIR}")
@@ -139,6 +139,8 @@ macro (setup_python_module)
     install (TARGETS ${target_name}
              RUNTIME DESTINATION ${PYTHON_SITE_DIR} COMPONENT user
              LIBRARY DESTINATION ${PYTHON_SITE_DIR} COMPONENT user)
+
+    install(FILES __init__.py DESTINATION ${PYTHON_SITE_DIR})
 
 endmacro ()
 

--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -1,10 +1,10 @@
 import os, sys, platform
 
-# This works around python 3.8 change to stop loading DLLs from PATH on Windows.
+# This works around the python 3.8 change to stop loading DLLs from PATH on Windows.
 # We reproduce the old behaviour by manually tokenizing PATH, checking that the directories exist and are not ".",
 # then add them to the DLL load path.
-# This behviour is only enabled if the environment variable "OIIO_LOAD_DLLS_FROM_PATH" is set to "1" so it is opt-in.
-if sys.version_info >= (3, 8) and platform.system() == "Windows" and os.getenv("OIIO_LOAD_DLLS_FROM_PATH", "0") == "1":
+# This behviour can be disablef by setting the environment variable "OIIO_LOAD_DLLS_FROM_PATH" to "0" 
+if sys.version_info >= (3, 8) and platform.system() == "Windows" and os.getenv("OIIO_LOAD_DLLS_FROM_PATH", "1") == "1":
     for path in os.getenv("PATH", "").split(os.pathsep):
         if os.path.exists(path) and path != ".":
             os.add_dll_directory(path)

--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -1,0 +1,9 @@
+import os, sys, platform
+
+if sys.version_info >= (3, 8) and platform.system() == "Windows" and os.getenv("OIIO_LOAD_DLLS_FROM_PATH", "0") == "1":
+    for path in os.getenv("PATH", "").split(os.pathsep):
+        if os.path.exists(path) and path != ".":
+            os.add_dll_directory(path)
+
+from .OpenImageIO import *
+

--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -1,5 +1,9 @@
 import os, sys, platform
 
+# This works around python 3.8 change to stop loading DLLs from PATH on Windows.
+# We reproduce the old behaviour by manually tokenizing PATH, checking that the directories exist and are not ".",
+# then add them to the DLL load path.
+# This behviour is only enabled if the environment variable "OIIO_LOAD_DLLS_FROM_PATH" is set to "1" so it is opt-in.
 if sys.version_info >= (3, 8) and platform.system() == "Windows" and os.getenv("OIIO_LOAD_DLLS_FROM_PATH", "0") == "1":
     for path in os.getenv("PATH", "").split(os.pathsep):
         if os.path.exists(path) and path != ".":


### PR DESCRIPTION
## Description

Python 3.8 stopped loading DLLs from PATH on Windows, meaning anything that relied on that environment for shared library resolution breaks. This PR works around that behviour by manually adding PATH back to DLL resolution using `os.add_dll_directory()` in a new `__init__.py` which just re-exports everything in the current .pyd.

The new behaviour is only enabled if the environment variable `OIIO_LOAD_DLLS_FROM_PATH` is equal to "1".

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

