### PR TITLE
Strutil::safe_strcat

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -836,6 +836,14 @@ std::string OIIO_UTIL_API utf16_to_utf8(const std::wstring& utf16str) noexcept;
 OIIO_UTIL_API char * safe_strcpy (char *dst, string_view src, size_t size) noexcept;
 
 
+/// Append `src` to the end of the C-string buffer dst, plus a terminating
+/// null, assuming that dst can hold at most `size` characters (including
+/// terminating 0 character). Returns dst. Note that this behavior is similar
+/// to strcat, but guarantees that the resulting string fits into `size` bytes
+/// and is null-terminated.
+OIIO_UTIL_API char* safe_strcat(char *dst, string_view src, size_t size) noexcept;
+
+
 /// Is the character a whitespace character (space, linefeed, tab, carrage
 /// return)? Note: this is safer than C isspace(), which has undefined
 /// behavior for negative char values. Also note that it differs from C

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -878,6 +878,21 @@ Strutil::safe_strcpy(char* dst, string_view src, size_t size) noexcept
 
 
 
+char*
+Strutil::safe_strcat(char* dst, string_view src, size_t size) noexcept
+{
+    if (src.size()) {
+        size_t dstsize = strlen(dst);
+        size_t end     = std::min(size - dstsize - 1, src.size());
+        for (size_t i = 0; i < end; ++i)
+            dst[dstsize + i] = src[i];
+        dst[dstsize + end] = 0;
+    }
+    return dst;
+}
+
+
+
 void
 Strutil::skip_whitespace(string_view& str) noexcept
 {

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -1062,6 +1062,56 @@ test_safe_strcpy()
 
 
 
+void
+test_safe_strcat()
+{
+    std::cout << "Testing safe_strcat\n";
+    const size_t len = 8;
+    {  // test in-bounds copy
+        char result[len + 1] = { 100, 101, 102, 103, 104, 105, 106, 107, 108 };
+        Strutil::safe_strcpy(result, "123", len);
+        Strutil::safe_strcat(result, "ABC", len);
+        OIIO_CHECK_EQUAL(std::string(result), "123ABC");
+        OIIO_CHECK_EQUAL(result[6], 0);
+        OIIO_CHECK_EQUAL(result[7], 0);
+        OIIO_CHECK_EQUAL(result[8], 108);
+    }
+    {  // test over-bounds copy
+        char result[len + 1] = { 100, 101, 102, 103, 104, 105, 106, 107, 108 };
+        Strutil::safe_strcpy(result, "123", len);
+        Strutil::safe_strcat(result, "ABCDEF", len);
+        OIIO_CHECK_EQUAL(std::string(result), "123ABCD");
+        OIIO_CHECK_EQUAL(result[7], 0);
+        OIIO_CHECK_EQUAL(result[8], 108);
+    }
+    {  // test empty string copy
+        char result[len + 1] = { 100, 101, 102, 103, 104, 105, 106, 107, 108 };
+        Strutil::safe_strcpy(result, "123", len);
+        Strutil::safe_strcat(result, "", len);
+        OIIO_CHECK_EQUAL(std::string(result), "123");
+        OIIO_CHECK_EQUAL(result[3], 0);
+        OIIO_CHECK_EQUAL(result[4], 0);
+        OIIO_CHECK_EQUAL(result[5], 0);
+        OIIO_CHECK_EQUAL(result[6], 0);
+        OIIO_CHECK_EQUAL(result[7], 0);
+        OIIO_CHECK_EQUAL(result[8], 108);
+    }
+    {  // test NULL case
+        char result[len + 1] = { 100, 101, 102, 103, 104, 105, 106, 107, 108 };
+        Strutil::safe_strcpy(result, "123", len);
+        Strutil::safe_strcat(result, nullptr, len);
+        OIIO_CHECK_EQUAL(std::string(result), "123");
+        OIIO_CHECK_EQUAL(result[3], 0);
+        OIIO_CHECK_EQUAL(result[4], 0);
+        OIIO_CHECK_EQUAL(result[5], 0);
+        OIIO_CHECK_EQUAL(result[6], 0);
+        OIIO_CHECK_EQUAL(result[7], 0);
+        OIIO_CHECK_EQUAL(result[8], 108);
+    }
+}
+
+
+
 // test some of the trickier methods in string_view.
 void
 test_string_view()
@@ -1514,6 +1564,7 @@ main(int /*argc*/, char* /*argv*/[])
     test_to_string();
     test_extract();
     test_safe_strcpy();
+    test_safe_strcat();
     test_string_view();
     test_parse();
     test_locale();


### PR DESCRIPTION
Will be needed in a subsequent PR to fix some safety issues revealed by clang-tidy.